### PR TITLE
fix(desktop): stabilize launchpad environment controls

### DIFF
--- a/apps/desktop/e2e/codex-environment-setup.spec.ts
+++ b/apps/desktop/e2e/codex-environment-setup.spec.ts
@@ -192,6 +192,107 @@ script = "printf setup-output && sleep 2"
   };
 }
 
+async function createNoCodexEnvironmentsFixture(): Promise<{
+  cleanup: () => Promise<void>;
+  fixturePath: string;
+}> {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-no-env-"));
+  const repoDir = path.join(rootDir, "NoEnvRepo");
+  await mkdir(repoDir, { recursive: true });
+  await writeFile(path.join(repoDir, ".codex"), "not a directory\n", "utf8");
+
+  execFileSync("git", ["init"], { cwd: repoDir, stdio: "ignore" });
+  execFileSync("git", ["checkout", "-B", "main"], { cwd: repoDir, stdio: "ignore" });
+  execFileSync(
+    "git",
+    [
+      "-c",
+      "user.name=PwrAgent Tests",
+      "-c",
+      "user.email=pwragent-tests@example.invalid",
+      "commit",
+      "--allow-empty",
+      "-m",
+      "Seed no-env fixture repo",
+    ],
+    { cwd: repoDir, stdio: "ignore" },
+  );
+
+  const fixturePath = path.join(rootDir, "codex-no-environments.fixture.json");
+  await writeFile(
+    fixturePath,
+    JSON.stringify(
+      {
+        metadata: {
+          backend: "codex",
+          scenario: "codex-no-environments",
+          threadId: "thread-no-env",
+        },
+        steps: [
+          {
+            id: "initialize-1",
+            kind: "response",
+            method: "initialize",
+            result: {
+              serverInfo: {
+                name: "Replay Codex",
+                version: "1.0.0",
+              },
+              methods: ["thread/list", "thread/read", "skills/list", "thread/start", "turn/start"],
+            },
+          },
+          {
+            id: "thread-list-1",
+            kind: "response",
+            method: "thread/list",
+            result: [
+              {
+                id: "thread-no-env",
+                title: "No environment thread",
+                titleSource: "explicit",
+                source: "codex",
+                executionMode: "default",
+                linkedDirectories: [
+                  {
+                    id: "no-env-repo",
+                    label: "NoEnvRepo",
+                    path: repoDir,
+                    kind: "local",
+                  },
+                ],
+                updatedAt: 1_000,
+              },
+            ],
+          },
+          {
+            id: "thread-read-1",
+            kind: "response",
+            method: "thread/read",
+            result: {
+              entries: [],
+              messages: [],
+              pagination: {
+                supportsPagination: false,
+                hasPreviousPage: false,
+              },
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+
+  return {
+    fixturePath,
+    cleanup: async () => {
+      await rm(rootDir, { recursive: true, force: true });
+    },
+  };
+}
+
 test("selected Codex environments run setup and show transcript output", async () => {
   const fixture = await createCodexEnvironmentSetupFixture();
   const app = await launchElectronApp({
@@ -322,6 +423,32 @@ test("directory launchpad keeps selected Codex environment controls after snapsh
     if (seededHomeRoot) {
       await rm(seededHomeRoot, { recursive: true, force: true });
     }
+    await fixture.cleanup();
+  }
+});
+
+test("directory launchpad opens without an environment picker when no environments are available", async () => {
+  const fixture = await createNoCodexEnvironmentsFixture();
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    await app.window.getByRole("button", { name: "directories" }).click();
+    await app.window
+      .getByRole("button", { name: "Open new thread launchpad for NoEnvRepo" })
+      .click();
+
+    await expect(
+      app.window.getByRole("heading", { level: 2, name: "NoEnvRepo" }),
+    ).toBeVisible();
+    await expect(app.window.getByRole("textbox", { name: "New thread" })).toBeVisible();
+    await expect(app.window.getByLabel("Codex environment")).toHaveCount(0);
+    await expect(
+      app.window.getByText(/Error invoking remote method|ENOTDIR/),
+    ).toHaveCount(0);
+  } finally {
+    await app.close();
     await fixture.cleanup();
   }
 });

--- a/apps/desktop/e2e/codex-environment-setup.spec.ts
+++ b/apps/desktop/e2e/codex-environment-setup.spec.ts
@@ -5,9 +5,12 @@ import path from "node:path";
 import { expect, test } from "@playwright/test";
 import { launchElectronApp } from "./fixtures/electron-app";
 
-async function createCodexEnvironmentSetupFixture(): Promise<{
+async function createCodexEnvironmentSetupFixture(params?: {
+  includeExistingThread?: boolean;
+}): Promise<{
   cleanup: () => Promise<void>;
   fixturePath: string;
+  repoDir: string;
 }> {
   const rootDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-env-setup-"));
   const repoDir = path.join(rootDir, "FixtureRepo");
@@ -43,6 +46,27 @@ script = "printf setup-output && sleep 2"
   );
 
   const fixturePath = path.join(rootDir, "codex-environment-setup.fixture.json");
+  const initialThreads =
+    params?.includeExistingThread === false
+      ? []
+      : [
+          {
+            id: "thread-existing",
+            title: "Existing directory thread",
+            titleSource: "explicit",
+            source: "codex",
+            executionMode: "default",
+            linkedDirectories: [
+              {
+                id: "fixture-repo",
+                label: "FixtureRepo",
+                path: repoDir,
+                kind: "local",
+              },
+            ],
+            updatedAt: 1_000,
+          },
+        ];
   await writeFile(
     fixturePath,
     JSON.stringify(
@@ -69,24 +93,7 @@ script = "printf setup-output && sleep 2"
             id: "thread-list-1",
             kind: "response",
             method: "thread/list",
-            result: [
-              {
-                id: "thread-existing",
-                title: "Existing directory thread",
-                titleSource: "explicit",
-                source: "codex",
-                executionMode: "default",
-                linkedDirectories: [
-                  {
-                    id: "fixture-repo",
-                    label: "FixtureRepo",
-                    path: repoDir,
-                    kind: "local",
-                  },
-                ],
-                updatedAt: 1_000,
-              },
-            ],
+            result: initialThreads,
           },
           {
             id: "thread-read-1",
@@ -177,6 +184,7 @@ script = "printf setup-output && sleep 2"
   );
 
   return {
+    repoDir,
     fixturePath,
     cleanup: async () => {
       await rm(rootDir, { recursive: true, force: true });
@@ -238,6 +246,81 @@ test("selected Codex environments run setup and show transcript output", async (
     ).toBeVisible();
   } finally {
     await app.close();
+    await fixture.cleanup();
+  }
+});
+
+test("directory launchpad keeps selected Codex environment controls after snapshot reload", async () => {
+  const fixture = await createCodexEnvironmentSetupFixture({
+    includeExistingThread: false,
+  });
+  let firstApp: Awaited<ReturnType<typeof launchElectronApp>> | undefined;
+  let secondApp: Awaited<ReturnType<typeof launchElectronApp>> | undefined;
+  let seededHomeRoot: string | undefined;
+
+  try {
+    const directoryKey = `directory:${fixture.repoDir}`;
+    firstApp = await launchElectronApp({
+      fixturePath: fixture.fixturePath,
+    });
+    seededHomeRoot = firstApp.homeRoot;
+
+    await firstApp.window.evaluate(
+      async ({ directoryKey, repoDir }) => {
+        const desktopApi = (window as any).pwragent;
+        await desktopApi.ensureDirectoryLaunchpad({
+          directoryKey,
+          directoryKind: "directory",
+          directoryLabel: "FixtureRepo",
+          directoryPath: repoDir,
+          preferredBackend: "codex",
+          currentBranch: "main",
+        });
+        await desktopApi.updateDirectoryLaunchpad({
+          directoryKey,
+          patch: {
+            codexEnvironmentId: "environment",
+            codexEnvironmentExecutionTarget: "local",
+            codexEnvironmentSetupEnabled: true,
+            workMode: "worktree",
+          },
+          stickySettingsChanged: true,
+        });
+      },
+      { directoryKey, repoDir: fixture.repoDir },
+    );
+
+    await firstApp.electronApp.close();
+    firstApp = undefined;
+
+    secondApp = await launchElectronApp({
+      fixturePath: fixture.fixturePath,
+      homeRoot: seededHomeRoot,
+    });
+    seededHomeRoot = undefined;
+
+    const settings = secondApp.window.getByLabel("New thread settings");
+    await expect(
+      secondApp.window.getByRole("textbox", { name: "New thread" }),
+    ).toBeVisible();
+    await expect(settings.getByLabel("Workspace mode")).toHaveAttribute(
+      "data-value",
+      "worktree",
+    );
+    await expect(settings.getByLabel("Codex environment")).toContainText(
+      "Fixture Env",
+    );
+    await expect(settings.getByLabel("Run setup")).toBeChecked();
+  } finally {
+    if (secondApp) {
+      await secondApp.close();
+    }
+    if (firstApp) {
+      await firstApp.close();
+    }
+    if (seededHomeRoot) {
+      await rm(seededHomeRoot, { recursive: true, force: true });
+    }
     await fixture.cleanup();
   }
 });

--- a/apps/desktop/e2e/codex-environment-setup.spec.ts
+++ b/apps/desktop/e2e/codex-environment-setup.spec.ts
@@ -307,10 +307,11 @@ test("directory launchpad keeps selected Codex environment controls after snapsh
       "data-value",
       "worktree",
     );
-    await expect(settings.getByLabel("Codex environment")).toContainText(
+    const tools = secondApp.window.getByLabel("Composer tools");
+    await expect(tools.getByLabel("Codex environment")).toContainText(
       "Fixture Env",
     );
-    await expect(settings.getByLabel("Run setup")).toBeChecked();
+    await expect(tools.getByLabel("Run setup")).toBeChecked();
   } finally {
     if (secondApp) {
       await secondApp.close();

--- a/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -653,6 +653,41 @@ test("directory launchpad can switch from local checkout to a new worktree", asy
 
     await expect(workspaceMode).toHaveAttribute("data-value", "worktree");
     await expect(settings.getByLabel("Base branch")).toHaveAttribute("data-value", "main");
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
+test("directory launchpad does not show workspace application buttons before a thread exists", async () => {
+  const fixture = await createDirectoryLaunchpadFixture();
+  const fakeBinDir = path.join(path.dirname(fixture.fixturePath), "fake-bin");
+  await mkdir(fakeBinDir, { recursive: true });
+  for (const binaryName of ["code", "ghostty"]) {
+    const binaryPath = path.join(fakeBinDir, binaryName);
+    await writeFile(binaryPath, "#!/bin/sh\nexit 0\n", "utf8");
+    await chmod(binaryPath, 0o755);
+  }
+
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+    env: {
+      PATH: `${fakeBinDir}${path.delimiter}${process.env.PATH ?? ""}`,
+    },
+  });
+
+  try {
+    await app.window.getByRole("button", { name: "directories" }).click();
+    await app.window
+      .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
+      .click();
+
+    await expect(
+      app.window.getByRole("heading", { level: 2, name: "FixtureRepo" }),
+    ).toBeVisible();
+    await expect(app.window.getByRole("textbox", { name: "New thread" })).toBeVisible();
+    await expect(app.window.getByRole("button", { name: "VS Code" })).toHaveCount(0);
+    await expect(app.window.getByRole("button", { name: "Ghostty" })).toHaveCount(0);
   } finally {
     await app.close();
     await fixture.cleanup();

--- a/apps/desktop/e2e/fixtures/electron-app.ts
+++ b/apps/desktop/e2e/fixtures/electron-app.ts
@@ -41,6 +41,7 @@ type LaunchResult = {
 export async function launchElectronApp(params: {
   fixturePath: string;
   env?: Record<string, string | undefined>;
+  homeRoot?: string;
   windowSize?: {
     width: number;
     height: number;
@@ -54,7 +55,9 @@ export async function launchElectronApp(params: {
    */
   preLaunchHook?: (homeRoot: string) => void | Promise<void>;
 }): Promise<LaunchResult> {
-  const homeRoot = await mkdtemp(path.join(os.tmpdir(), "pwragent-desktop-e2e-home-"));
+  const homeRoot =
+    params.homeRoot ??
+    await mkdtemp(path.join(os.tmpdir(), "pwragent-desktop-e2e-home-"));
   if (params.preLaunchHook) {
     await params.preLaunchHook(homeRoot);
   }

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2515,7 +2515,7 @@ script = "printf setup-failed && exit 42"
     }
   });
 
-  it("keeps failed environment action worktree threads registered without starting the turn", async () => {
+  it("ignores legacy launchpad environment actions until the thread exists", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-env-action-failure-"));
     const repoPath = path.join(root, "repo");
     const worktreePath = path.join(root, "missing-worktree");
@@ -2575,22 +2575,21 @@ command = "pnpm dev"
       });
 
       expect(response.threadId).toBe("thread-1");
-      expect(response.turnId).toBeUndefined();
-      expect(response.codexEnvironmentStartupFailure).toEqual({
-        message: expect.any(String),
-        phase: "action",
-        worktreeCleanupAvailable: true,
-      });
+      expect(response.turnId).toBe("turn-1");
+      expect(response.codexEnvironmentStartupFailure).toBeUndefined();
       expect(response.codexEnvironmentRuntime).toMatchObject({
         environmentName: "Broken Action Env",
-        actionStatus: "failed",
-        actionName: "Start dev",
       });
+      expect(response.codexEnvironmentRuntime?.actionId).toBeUndefined();
+      expect(response.codexEnvironmentRuntime?.actionStatus).toBeUndefined();
       expect(recordCodexWorktreeOwnerThread).toHaveBeenCalledWith({
         worktreePath,
         threadId: "thread-1",
       });
-      expect(codexClient.lastStartTurnParams).toBeUndefined();
+      expect(codexClient.lastStartTurnParams).toMatchObject({
+        threadId: "thread-1",
+        input: [{ type: "text", text: "start after setup" }],
+      });
     } finally {
       await registry.close();
       await rm(root, { recursive: true, force: true });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -115,7 +115,10 @@ import {
   BackendModelCatalog,
   type BackendModelCatalogCallerReason,
 } from "./backend-model-catalog";
-import { listCodexEnvironmentOptions } from "./codex-environment-config";
+import {
+  listCodexEnvironmentOptions,
+  withCodexEnvironmentOptions,
+} from "./codex-environment-config";
 import {
   applyLocalCodexEnvironmentSelection,
   CodexEnvironmentStartupError,
@@ -938,42 +941,6 @@ function defaultLaunchpadWorkMode(
   return request.directoryKind === "directory" && request.directoryPath
     ? defaults.workMode ?? "local"
     : "local";
-}
-
-function withCodexEnvironmentOptions(
-  launchpad: NavigationLaunchpadDraft,
-  options: CodexEnvironmentOption[],
-): NavigationLaunchpadDraft {
-  if (launchpad.backend !== "codex") {
-    return {
-      ...launchpad,
-      codexEnvironmentOptions: [],
-    };
-  }
-
-  if (options.length === 0) {
-    return {
-      ...launchpad,
-      codexEnvironmentId: undefined,
-      codexEnvironmentActionId: undefined,
-      codexEnvironmentOptions: [],
-    };
-  }
-
-  const selectedEnvironment = options.find(
-    (environment) => environment.id === launchpad.codexEnvironmentId,
-  );
-  return {
-    ...launchpad,
-    codexEnvironmentId: selectedEnvironment?.id,
-    codexEnvironmentExecutionTarget:
-      launchpad.codexEnvironmentExecutionTarget ?? "local",
-    codexEnvironmentSetupEnabled:
-      launchpad.codexEnvironmentSetupEnabled ??
-      Boolean(selectedEnvironment?.setupScript),
-    codexEnvironmentActionId: undefined,
-    codexEnvironmentOptions: options,
-  };
 }
 
 function resolveCodexEnvironmentSelection(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -963,10 +963,6 @@ function withCodexEnvironmentOptions(
   const selectedEnvironment = options.find(
     (environment) => environment.id === launchpad.codexEnvironmentId,
   );
-  const selectedAction = selectedEnvironment?.actions.find(
-    (action) => action.id === launchpad.codexEnvironmentActionId,
-  );
-
   return {
     ...launchpad,
     codexEnvironmentId: selectedEnvironment?.id,
@@ -975,7 +971,7 @@ function withCodexEnvironmentOptions(
     codexEnvironmentSetupEnabled:
       launchpad.codexEnvironmentSetupEnabled ??
       Boolean(selectedEnvironment?.setupScript),
-    codexEnvironmentActionId: selectedAction?.id,
+    codexEnvironmentActionId: undefined,
     codexEnvironmentOptions: options,
   };
 }
@@ -995,15 +991,10 @@ function resolveCodexEnvironmentSelection(
     return undefined;
   }
 
-  const action = environment.actions.find(
-    (candidate) => candidate.id === launchpad.codexEnvironmentActionId,
-  );
-
   return {
     environment,
     executionTarget: launchpad.codexEnvironmentExecutionTarget ?? "local",
     setupEnabled: Boolean(launchpad.codexEnvironmentSetupEnabled),
-    action,
   };
 }
 
@@ -1041,7 +1032,6 @@ async function resetLaunchpadAfterMaterialize(params: {
       launchpad.codexEnvironmentExecutionTarget ?? "local",
     codexEnvironmentSetupEnabled:
       launchpad.codexEnvironmentSetupEnabled ?? true,
-    codexEnvironmentActionId: launchpad.codexEnvironmentActionId,
     createdAt: now,
     updatedAt: now,
   });

--- a/apps/desktop/src/main/app-server/codex-environment-config.ts
+++ b/apps/desktop/src/main/app-server/codex-environment-config.ts
@@ -1,6 +1,9 @@
 import { readdir, readFile, stat } from "node:fs/promises";
 import path from "node:path";
-import type { CodexEnvironmentOption } from "@pwragent/shared";
+import type {
+  CodexEnvironmentOption,
+  NavigationLaunchpadDraft,
+} from "@pwragent/shared";
 
 type RawAction = {
   name?: string;
@@ -78,6 +81,51 @@ export async function listCodexEnvironmentOptions(
   }
 
   return options;
+}
+
+export function withCodexEnvironmentOptions(
+  launchpad: NavigationLaunchpadDraft,
+  options: CodexEnvironmentOption[],
+): NavigationLaunchpadDraft {
+  if (launchpad.backend !== "codex") {
+    return {
+      ...launchpad,
+      codexEnvironmentOptions: [],
+    };
+  }
+
+  if (options.length === 0) {
+    return {
+      ...launchpad,
+      codexEnvironmentId: undefined,
+      codexEnvironmentActionId: undefined,
+      codexEnvironmentOptions: [],
+    };
+  }
+
+  const selectedEnvironment = options.find(
+    (environment) => environment.id === launchpad.codexEnvironmentId,
+  );
+  return {
+    ...launchpad,
+    codexEnvironmentId: selectedEnvironment?.id,
+    codexEnvironmentExecutionTarget:
+      launchpad.codexEnvironmentExecutionTarget ?? "local",
+    codexEnvironmentSetupEnabled:
+      launchpad.codexEnvironmentSetupEnabled ??
+      Boolean(selectedEnvironment?.setupScript),
+    codexEnvironmentActionId: undefined,
+    codexEnvironmentOptions: options,
+  };
+}
+
+export async function hydrateLaunchpadCodexEnvironmentOptions(
+  launchpad: NavigationLaunchpadDraft,
+): Promise<NavigationLaunchpadDraft> {
+  return withCodexEnvironmentOptions(
+    launchpad,
+    await listCodexEnvironmentOptions(launchpad.directoryPath),
+  );
 }
 
 export function parseCodexEnvironmentToml(

--- a/apps/desktop/src/main/app-server/codex-environment-config.ts
+++ b/apps/desktop/src/main/app-server/codex-environment-config.ts
@@ -48,7 +48,8 @@ export async function listCodexEnvironmentOptions(
     }
     entries = await readdir(environmentsDir);
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+    const errorCode = (error as NodeJS.ErrnoException).code;
+    if (errorCode === "ENOENT" || errorCode === "ENOTDIR") {
       return [];
     }
     throw error;

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -61,6 +61,7 @@ import {
   disposeDesktopBackendRegistry,
   getDesktopBackendRegistry,
 } from "../app-server/backend-registry";
+import { hydrateLaunchpadCodexEnvironmentOptions } from "../app-server/codex-environment-config";
 import { getDesktopOverlayStore } from "../app-server/desktop-overlay-store";
 import {
   APP_SERVER_LIST_SKILLS_CHANNEL,
@@ -145,6 +146,33 @@ function applyDirectoryGitStatus(
     delete next.gitStatus;
   }
   return next;
+}
+
+async function hydrateDirectoryLaunchpads(
+  directories: NavigationSnapshot["directories"],
+): Promise<NavigationSnapshot["directories"]> {
+  return await Promise.all(
+    directories.map(async (directory) => {
+      if (!directory.launchpad) {
+        return directory;
+      }
+
+      try {
+        return {
+          ...directory,
+          launchpad: await hydrateLaunchpadCodexEnvironmentOptions(
+            directory.launchpad,
+          ),
+        };
+      } catch (error) {
+        logDebug("getNavigationSnapshot:launchpad-environments-failed", {
+          directoryKey: directory.key,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return directory;
+      }
+    }),
+  );
 }
 
 function getNavigationSnapshotRequestKey(
@@ -424,13 +452,15 @@ class DesktopAppServerService {
     for (const directory of snapshot.directories) {
       this.lastDirectoriesByKey.set(directory.key, directory);
     }
-    const directories = snapshot.directories.map((directory) => {
-      const cached = this.directoryGitStatusByKey.get(directory.key);
-      if (!cached) {
-        return directory;
-      }
-      return applyDirectoryGitStatus(directory, cached.gitStatus);
-    });
+    const directories = await hydrateDirectoryLaunchpads(
+      snapshot.directories.map((directory) => {
+        const cached = this.directoryGitStatusByKey.get(directory.key);
+        if (!cached) {
+          return directory;
+        }
+        return applyDirectoryGitStatus(directory, cached.gitStatus);
+      }),
+    );
     const directoryDurationMs = Date.now() - directoryStartedAt;
     const previousDirectories = this.previousDirectoriesByBackend.get(backend);
     const directoriesUnchanged = previousDirectories

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -2539,32 +2539,6 @@ export function Composer(props: ComposerProps) {
     }
   };
 
-  const setThreadCodexEnvironment = async (environmentId: string): Promise<void> => {
-    if (
-      !props.thread ||
-      props.thread.source !== "codex" ||
-      !props.desktopApi?.setCodexThreadEnvironment
-    ) {
-      return;
-    }
-
-    setSendError(undefined);
-    props.onPendingStatusChange?.("Updating environment");
-    try {
-      await props.desktopApi.setCodexThreadEnvironment({
-        backend: props.thread.source,
-        threadId: props.thread.id,
-        environmentId: environmentId || undefined,
-      });
-      setSelectedThreadCodexActionId("");
-      await props.onRefreshNavigation?.();
-    } catch (error) {
-      setSendError(error instanceof Error ? error.message : String(error));
-    } finally {
-      props.onPendingStatusChange?.(undefined);
-    }
-  };
-
   const applyExecutionModeSelection = (
     executionMode: ThreadExecutionMode,
   ): void => {
@@ -3787,26 +3761,6 @@ export function Composer(props: ComposerProps) {
             <span className="composer__fixed-value" aria-label="Provider">
               {formatBackendLabel(props.thread.source)}
             </span>
-          ) : null}
-
-          {props.thread && threadCodexEnvironmentOptions.length > 0 ? (
-            <ComposerDropdown
-              ariaLabel="Codex environment"
-              compact
-              disabled={!props.desktopApi?.setCodexThreadEnvironment}
-              icon={FileCodeIcon}
-              value={props.thread.codexEnvironmentRuntime?.environmentId ?? ""}
-              options={[
-                { label: "No environment", value: "" },
-                ...threadCodexEnvironmentOptions.map((environment) => ({
-                  label: environment.name,
-                  value: environment.id,
-                })),
-              ]}
-              onChange={(value) => {
-                void setThreadCodexEnvironment(value);
-              }}
-            />
           ) : null}
 
           {props.thread?.codexEnvironmentRuntime ? (

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -4634,11 +4634,11 @@ function getComposerWorkspaceOpenPath(params: {
   launchpad?: NavigationLaunchpadDraft;
   threadWorkspace?: ThreadWorkspace;
 }): string | undefined {
-  return (
-    params.launchpad?.directoryPath ??
-    params.threadWorkspace?.sourcePath ??
-    params.directory?.path
-  );
+  if (params.launchpad) {
+    return undefined;
+  }
+
+  return params.threadWorkspace?.sourcePath ?? params.directory?.path;
 }
 
 function getThreadWorkspace(thread: NavigationThreadSummary): ThreadWorkspace | undefined {

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -3946,27 +3946,6 @@ export function Composer(props: ComposerProps) {
             </label>
           ) : null}
 
-          {props.launchpad && selectedCodexEnvironment?.actions.length ? (
-            <ComposerDropdown
-              ariaLabel="Environment command"
-              compact
-              disabled={launchpadSubmitting}
-              value={props.launchpad.codexEnvironmentActionId ?? ""}
-              options={[
-                { label: "No command", value: "" },
-                ...selectedCodexEnvironment.actions.map((action) => ({
-                  label: action.name,
-                  value: action.id,
-                })),
-              ]}
-              onChange={(value) => {
-                handleLaunchpadPatch({
-                  codexEnvironmentActionId: value || undefined,
-                });
-              }}
-            />
-          ) : null}
-
           {props.launchpad ? (
             <ComposerDropdown
               ariaLabel="Workspace mode"

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -2539,6 +2539,36 @@ export function Composer(props: ComposerProps) {
     }
   };
 
+  const setThreadCodexEnvironment = async (
+    environmentId?: string,
+  ): Promise<void> => {
+    if (
+      !props.thread ||
+      props.thread.source !== "codex" ||
+      !props.desktopApi?.setCodexThreadEnvironment
+    ) {
+      return;
+    }
+
+    setSendError(undefined);
+    setSelectedThreadCodexActionId("");
+    props.onPendingStatusChange?.(
+      environmentId ? "Selecting Codex environment" : "Clearing Codex environment",
+    );
+    try {
+      await props.desktopApi.setCodexThreadEnvironment({
+        backend: props.thread.source,
+        threadId: props.thread.id,
+        environmentId,
+      });
+      await props.onRefreshNavigation?.();
+    } catch (error) {
+      setSendError(error instanceof Error ? error.message : String(error));
+    } finally {
+      props.onPendingStatusChange?.(undefined);
+    }
+  };
+
   const applyExecutionModeSelection = (
     executionMode: ThreadExecutionMode,
   ): void => {
@@ -3763,44 +3793,6 @@ export function Composer(props: ComposerProps) {
             </span>
           ) : null}
 
-          {props.thread?.codexEnvironmentRuntime ? (
-            <>
-              <ComposerDropdown
-                ariaLabel="Environment command"
-                compact
-                disabled={
-                  threadCodexEnvironmentActions.length === 0 ||
-                  !props.desktopApi?.runCodexEnvironmentAction
-                }
-                value={selectedThreadCodexAction?.id ?? ""}
-                options={
-                  threadCodexEnvironmentActions.length > 0
-                    ? threadCodexEnvironmentActions.map((action) => ({
-                        label: action.name,
-                        value: action.id,
-                      }))
-                    : [{ label: "No commands", value: "" }]
-                }
-                onChange={(value) => {
-                  setSelectedThreadCodexActionId(value);
-                }}
-              />
-              <button
-                className="composer__action-button"
-                disabled={
-                  !selectedThreadCodexAction ||
-                  !props.desktopApi?.runCodexEnvironmentAction
-                }
-                type="button"
-                onClick={() => {
-                  void runThreadCodexEnvironmentAction();
-                }}
-              >
-                Run
-              </button>
-            </>
-          ) : null}
-
           {availableExecutionModes.length > 0 &&
           (props.launchpad || (props.thread?.source === "codex" && props.onSetExecutionMode)) ? (
             <ComposerDropdown
@@ -3850,54 +3842,6 @@ export function Composer(props: ComposerProps) {
                 props.onPickAndRegisterDirectory?.();
               }}
             />
-          ) : null}
-
-          {props.launchpad && launchpadCodexEnvironmentOptions.length > 0 ? (
-            <ComposerDropdown
-              ariaLabel="Codex environment"
-              compact
-              disabled={launchpadSubmitting}
-              icon={FileCodeIcon}
-              value={props.launchpad.codexEnvironmentId ?? ""}
-              options={[
-                { label: "No environment", value: "" },
-                ...launchpadCodexEnvironmentOptions.map((environment) => ({
-                  label: environment.name,
-                  value: environment.id,
-                })),
-              ]}
-              onChange={(value) => {
-                const environment = launchpadCodexEnvironmentOptions.find(
-                  (candidate) => candidate.id === value,
-                );
-                handleLaunchpadPatch({
-                  codexEnvironmentId: environment?.id,
-                  codexEnvironmentExecutionTarget: environment
-                    ? props.launchpad?.codexEnvironmentExecutionTarget ?? "local"
-                    : undefined,
-                  codexEnvironmentSetupEnabled: Boolean(
-                    environment?.setupScript,
-                  ),
-                  codexEnvironmentActionId: undefined,
-                });
-              }}
-            />
-          ) : null}
-
-          {props.launchpad && selectedCodexEnvironment?.setupScript ? (
-            <label className="composer__checkbox">
-              <input
-                checked={Boolean(props.launchpad.codexEnvironmentSetupEnabled)}
-                disabled={launchpadSubmitting}
-                type="checkbox"
-                onChange={(event) => {
-                  handleLaunchpadPatch({
-                    codexEnvironmentSetupEnabled: event.target.checked,
-                  });
-                }}
-              />
-              <span>Run setup</span>
-            </label>
           ) : null}
 
           {props.launchpad ? (
@@ -4163,16 +4107,125 @@ export function Composer(props: ComposerProps) {
       ) : null}
 
       <div className="composer__footer">
-        {workspaceOpenPath && (editorApplication || terminalApplication) ? (
-          <div className="composer__application-actions" aria-label="Open workspace">
-            {editorApplication ? (
+        {launchpadCodexEnvironmentOptions.length > 0 ||
+        threadCodexEnvironmentOptions.length > 0 ||
+        props.thread?.codexEnvironmentRuntime ||
+        (workspaceOpenPath && (editorApplication || terminalApplication)) ? (
+          <div className="composer__application-actions" aria-label="Composer tools">
+            {props.launchpad && launchpadCodexEnvironmentOptions.length > 0 ? (
+              <ComposerDropdown
+                ariaLabel="Codex environment"
+                compact
+                disabled={launchpadSubmitting}
+                icon={FileCodeIcon}
+                value={props.launchpad.codexEnvironmentId ?? ""}
+                options={[
+                  { label: "No environment", value: "" },
+                  ...launchpadCodexEnvironmentOptions.map((environment) => ({
+                    label: environment.name,
+                    value: environment.id,
+                  })),
+                ]}
+                onChange={(value) => {
+                  const environment = launchpadCodexEnvironmentOptions.find(
+                    (candidate) => candidate.id === value,
+                  );
+                  handleLaunchpadPatch({
+                    codexEnvironmentId: environment?.id,
+                    codexEnvironmentExecutionTarget: environment
+                      ? props.launchpad?.codexEnvironmentExecutionTarget ?? "local"
+                      : undefined,
+                    codexEnvironmentSetupEnabled: Boolean(
+                      environment?.setupScript,
+                    ),
+                    codexEnvironmentActionId: undefined,
+                  });
+                }}
+              />
+            ) : null}
+
+            {props.launchpad && selectedCodexEnvironment?.setupScript ? (
+              <label className="composer__checkbox">
+                <input
+                  checked={Boolean(props.launchpad.codexEnvironmentSetupEnabled)}
+                  disabled={launchpadSubmitting}
+                  type="checkbox"
+                  onChange={(event) => {
+                    handleLaunchpadPatch({
+                      codexEnvironmentSetupEnabled: event.target.checked,
+                    });
+                  }}
+                />
+                <span>Run setup</span>
+              </label>
+            ) : null}
+
+            {!props.launchpad && threadCodexEnvironmentOptions.length > 0 ? (
+              <ComposerDropdown
+                ariaLabel="Codex environment"
+                compact
+                disabled={!props.desktopApi?.setCodexThreadEnvironment}
+                icon={FileCodeIcon}
+                value={props.thread?.codexEnvironmentRuntime?.environmentId ?? ""}
+                options={[
+                  { label: "No environment", value: "" },
+                  ...threadCodexEnvironmentOptions.map((environment) => ({
+                    label: environment.name,
+                    value: environment.id,
+                  })),
+                ]}
+                onChange={(value) => {
+                  void setThreadCodexEnvironment(value || undefined);
+                }}
+              />
+            ) : null}
+
+            {props.thread?.codexEnvironmentRuntime ? (
+              <>
+                <ComposerDropdown
+                  ariaLabel="Environment command"
+                  compact
+                  disabled={
+                    threadCodexEnvironmentActions.length === 0 ||
+                    !props.desktopApi?.runCodexEnvironmentAction
+                  }
+                  value={selectedThreadCodexAction?.id ?? ""}
+                  options={
+                    threadCodexEnvironmentActions.length > 0
+                      ? threadCodexEnvironmentActions.map((action) => ({
+                          label: action.name,
+                          value: action.id,
+                        }))
+                      : [{ label: "No commands", value: "" }]
+                  }
+                  onChange={(value) => {
+                    setSelectedThreadCodexActionId(value);
+                  }}
+                />
+                <button
+                  className="composer__action-button"
+                  disabled={
+                    !selectedThreadCodexAction ||
+                    !props.desktopApi?.runCodexEnvironmentAction
+                  }
+                  type="button"
+                  onClick={() => {
+                    void runThreadCodexEnvironmentAction();
+                  }}
+                >
+                  Run
+                </button>
+              </>
+            ) : null}
+
+            {workspaceOpenPath && editorApplication ? (
               <ComposerApplicationButton
                 application={editorApplication}
                 label={editorApplication.name}
                 onOpen={openWorkspaceApplication}
               />
             ) : null}
-            {terminalApplication ? (
+            {workspaceOpenPath && terminalApplication ? (
               <ComposerApplicationButton
                 application={terminalApplication}
                 label={terminalApplication.name}

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -332,6 +332,63 @@ describe("Composer", () => {
     });
   });
 
+  it("does not show workspace application buttons on a launchpad before the thread exists", () => {
+    render(
+      <Composer
+        applications={{
+          editors: [
+            {
+              id: "vscode",
+              kind: "editor",
+              name: "VS Code",
+              source: "application",
+              appPath: "/Applications/Visual Studio Code.app",
+              canOpenWorkspace: true,
+            },
+          ],
+          terminals: [
+            {
+              id: "ghostty",
+              kind: "terminal",
+              name: "Ghostty",
+              source: "application",
+              appPath: "/Applications/Ghostty.app",
+              canOpenWorkspace: true,
+            },
+          ],
+          preferredEditorId: { value: "", source: "default" },
+          preferredTerminalId: { value: "ghostty", source: "config" },
+          gh: {
+            path: { value: "", source: "default" },
+            discovery: { candidates: [] },
+          },
+          git: {
+            discovery: { candidates: [] },
+          },
+        }}
+        backends={[backendSummary("codex")]}
+        disabled={false}
+        launchpad={{
+          directoryKey: "directory:/repo/PwrAgent",
+          directoryKind: "directory",
+          directoryLabel: "PwrAgent",
+          directoryPath: "/repo/PwrAgent",
+          backend: "codex",
+          executionMode: "default",
+          prompt: "",
+          workMode: "worktree",
+          branchName: "main",
+          createdAt: 1,
+          updatedAt: 1,
+        }}
+        skills={[]}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "VS Code" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Ghostty" })).not.toBeInTheDocument();
+  });
+
   it("shows thread environment commands from refreshed environment options", async () => {
     const runCodexEnvironmentAction = vi.fn(async () => ({
       backend: "codex" as const,

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -434,6 +434,58 @@ describe("Composer", () => {
     expect(screen.getByLabelText("Environment command")).toBeDisabled();
   });
 
+  it("does not show environment commands on a launchpad", () => {
+    render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        disabled={false}
+        directory={{
+          key: "directory:/repo/PwrAgent",
+          kind: "directory",
+          label: "PwrAgent",
+          path: "/repo/PwrAgent",
+          threadKeys: [],
+          needsAttentionCount: 0,
+        }}
+        launchpad={{
+          directoryKey: "directory:/repo/PwrAgent",
+          directoryKind: "directory",
+          directoryLabel: "PwrAgent",
+          directoryPath: "/repo/PwrAgent",
+          backend: "codex",
+          executionMode: "default",
+          prompt: "",
+          workMode: "local",
+          codexEnvironmentId: "environment",
+          codexEnvironmentSetupEnabled: true,
+          codexEnvironmentOptions: [
+            {
+              id: "environment",
+              name: "PwrAgnt",
+              sourcePath: "/repo/.codex/environments/environment.toml",
+              setupScript: "pnpm install",
+              actions: [
+                {
+                  id: "dev-messaging",
+                  name: "Dev - Messaging",
+                  command: "pnpm dev:messaging",
+                },
+              ],
+            },
+          ],
+          createdAt: 1,
+          updatedAt: 1,
+        }}
+        skills={[]}
+      />,
+    );
+
+    expect(screen.getByLabelText("Codex environment")).toHaveTextContent("PwrAgnt");
+    expect(screen.getByText("Run setup")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Environment command")).not.toBeInTheDocument();
+    expect(screen.queryByText("No command")).not.toBeInTheDocument();
+  });
+
   it("shows an orange moon for reported context window usage", () => {
     render(
       <Composer

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -342,6 +342,10 @@ describe("Composer", () => {
         executionTarget: "local" as const,
       },
     }));
+    const setCodexThreadEnvironment = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+    }));
     const thread: NavigationThreadSummary = {
       id: "thread-1",
       title: "Environment commands",
@@ -375,23 +379,32 @@ describe("Composer", () => {
     render(
       <Composer
         backends={[backendSummary("codex")]}
-        desktopApi={{ runCodexEnvironmentAction }}
+        desktopApi={{ runCodexEnvironmentAction, setCodexThreadEnvironment }}
         disabled={false}
         skills={[]}
         thread={thread}
       />,
     );
 
+    expect(screen.getByLabelText("Codex environment")).toHaveTextContent("PwrAgnt");
     expect(screen.getByLabelText("Environment command")).toHaveTextContent(
       "Dev - Messaging",
     );
-    expect(screen.queryByLabelText("Codex environment")).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Run" }));
     await waitFor(() => {
       expect(runCodexEnvironmentAction).toHaveBeenCalledWith({
         backend: "codex",
         threadId: "thread-1",
         actionId: "dev-messaging",
+      });
+    });
+
+    chooseDropdownOption("Codex environment", "No environment");
+    await waitFor(() => {
+      expect(setCodexThreadEnvironment).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        environmentId: undefined,
       });
     });
   });
@@ -433,7 +446,47 @@ describe("Composer", () => {
       "No commands",
     );
     expect(screen.getByLabelText("Environment command")).toBeDisabled();
-    expect(screen.queryByLabelText("Codex environment")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Codex environment")).toHaveTextContent("PwrAgnt");
+  });
+
+  it("hides thread environment commands when no environment is selected", () => {
+    render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        desktopApi={{ setCodexThreadEnvironment: vi.fn() }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Environment commands",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+          codexEnvironmentOptions: [
+            {
+              id: "environment",
+              name: "PwrAgnt",
+              sourcePath: "/repo/.codex/environments/environment.toml",
+              actions: [
+                {
+                  id: "dev-messaging",
+                  name: "Dev - Messaging",
+                  command: "pnpm dev:messaging",
+                },
+              ],
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByLabelText("Codex environment")).toHaveTextContent(
+      "No environment",
+    );
+    expect(screen.queryByLabelText("Environment command")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Run" })).not.toBeInTheDocument();
   });
 
   it("does not show environment commands on a launchpad", () => {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -385,6 +385,7 @@ describe("Composer", () => {
     expect(screen.getByLabelText("Environment command")).toHaveTextContent(
       "Dev - Messaging",
     );
+    expect(screen.queryByLabelText("Codex environment")).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Run" }));
     await waitFor(() => {
       expect(runCodexEnvironmentAction).toHaveBeenCalledWith({
@@ -432,6 +433,7 @@ describe("Composer", () => {
       "No commands",
     );
     expect(screen.getByLabelText("Environment command")).toBeDisabled();
+    expect(screen.queryByLabelText("Codex environment")).not.toBeInTheDocument();
   });
 
   it("does not show environment commands on a launchpad", () => {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom/vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { shortenDerivedThreadTitle } from "@pwragent/shared";
-import type { NavigationSnapshot } from "@pwragent/shared";
+import type { NavigationLaunchpadDraft, NavigationSnapshot } from "@pwragent/shared";
 import type { DesktopApi } from "../desktop-api";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useThreadNavigation } from "../useThreadNavigation";
@@ -1304,7 +1304,7 @@ describe("useThreadNavigation", () => {
         executionMode: "default" as const,
       },
     }));
-    const launchpad = {
+    const launchpad: NavigationLaunchpadDraft = {
       directoryKey: "directory:/Users/huntharo/github/PwrAgent",
       directoryKind: "directory" as const,
       directoryLabel: "PwrAgent",
@@ -1362,7 +1362,7 @@ describe("useThreadNavigation", () => {
       backend: "codex" as const,
       executionMode: "default" as const,
     };
-    const launchpad = {
+    const launchpad: NavigationLaunchpadDraft = {
       directoryKey: "directory:/Users/huntharo/github/PwrAgent",
       directoryKind: "directory" as const,
       directoryLabel: "PwrAgent",
@@ -1463,6 +1463,115 @@ describe("useThreadNavigation", () => {
     });
 
     expect(result.current.selectedLaunchpad?.prompt).toBe("newer prompt");
+  });
+
+  it("keeps launchpad environment controls stable after prompt-only update responses", async () => {
+    const defaults = {
+      backend: "codex" as const,
+      executionMode: "default" as const,
+    };
+    const launchpad: NavigationLaunchpadDraft = {
+      directoryKey: "directory:/Users/huntharo/github/PwrAgent",
+      directoryKind: "directory" as const,
+      directoryLabel: "PwrAgent",
+      directoryPath: "/Users/huntharo/github/PwrAgent",
+      backend: "codex" as const,
+      executionMode: "default" as const,
+      prompt: "",
+      workMode: "local" as const,
+      branchName: "main",
+      codexEnvironmentId: "environment",
+      codexEnvironmentExecutionTarget: "local" as const,
+      codexEnvironmentSetupEnabled: true,
+      codexEnvironmentOptions: [
+        {
+          id: "environment",
+          name: "PwrAgnt",
+          sourcePath: "/Users/huntharo/github/PwrAgent/.codex/environments/environment.toml",
+          setupScript: "pnpm install",
+          actions: [
+            {
+              id: "dev",
+              name: "Dev",
+              command: "pnpm dev",
+            },
+          ],
+        },
+      ],
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const promptUpdate = createDeferred<{
+      defaults: typeof defaults;
+      launchpad: typeof launchpad;
+    }>();
+    const updateDirectoryLaunchpad = vi.fn().mockReturnValueOnce(promptUpdate.promise);
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [],
+      directories: [
+        {
+          key: launchpad.directoryKey,
+          kind: "directory" as const,
+          label: "PwrAgent",
+          path: "/Users/huntharo/github/PwrAgent",
+          threadKeys: [],
+          needsAttentionCount: 0,
+          launchpad,
+        },
+      ],
+      launchpadDefaults: defaults,
+    }));
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+      updateDirectoryLaunchpad,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.selectedLaunchpad?.codexEnvironmentId).toBe("environment");
+    });
+
+    let update: Promise<void> | undefined;
+    act(() => {
+      update = result.current.updateDirectoryLaunchpad(launchpad.directoryKey, {
+        prompt: "typing",
+      });
+    });
+
+    await act(async () => {
+      promptUpdate.resolve({
+        defaults,
+        launchpad: {
+          ...launchpad,
+          prompt: "typing",
+          codexEnvironmentId: undefined,
+          codexEnvironmentExecutionTarget: undefined,
+          codexEnvironmentSetupEnabled: undefined,
+          codexEnvironmentOptions: [],
+          updatedAt: 2,
+        },
+      });
+      await update!;
+    });
+
+    expect(result.current.selectedLaunchpad).toMatchObject({
+      prompt: "typing",
+      codexEnvironmentId: "environment",
+      codexEnvironmentExecutionTarget: "local",
+      codexEnvironmentSetupEnabled: true,
+      codexEnvironmentOptions: [
+        expect.objectContaining({
+          id: "environment",
+          name: "PwrAgnt",
+        }),
+      ],
+    });
   });
 
   it("opens masthead new-thread drafts inside the Workspaces directory", async () => {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -1,7 +1,11 @@
 import "@testing-library/jest-dom/vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { shortenDerivedThreadTitle } from "@pwragent/shared";
-import type { NavigationLaunchpadDraft, NavigationSnapshot } from "@pwragent/shared";
+import type {
+  NavigationLaunchpadDefaults,
+  NavigationLaunchpadDraft,
+  NavigationSnapshot,
+} from "@pwragent/shared";
 import type { DesktopApi } from "../desktop-api";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useThreadNavigation } from "../useThreadNavigation";
@@ -1571,6 +1575,100 @@ describe("useThreadNavigation", () => {
           name: "PwrAgnt",
         }),
       ],
+    });
+  });
+
+  it("keeps server-confirmed settingsTouchedAt after sticky launchpad updates", async () => {
+    const defaults: NavigationLaunchpadDefaults = {
+      backend: "codex" as const,
+      executionMode: "default" as const,
+    };
+    const launchpad: NavigationLaunchpadDraft = {
+      directoryKey: "directory:/Users/huntharo/github/PwrAgent",
+      directoryKind: "directory",
+      directoryLabel: "PwrAgent",
+      directoryPath: "/Users/huntharo/github/PwrAgent",
+      backend: "codex",
+      executionMode: "default",
+      prompt: "",
+      workMode: "local",
+      branchName: "main",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const stickyUpdate = createDeferred<{
+      defaults: typeof defaults;
+      launchpad: NavigationLaunchpadDraft;
+    }>();
+    const updateDirectoryLaunchpad = vi.fn().mockReturnValueOnce(stickyUpdate.promise);
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [],
+      directories: [
+        {
+          key: launchpad.directoryKey,
+          kind: "directory" as const,
+          label: "PwrAgent",
+          path: "/Users/huntharo/github/PwrAgent",
+          threadKeys: [],
+          needsAttentionCount: 0,
+          launchpad,
+        },
+      ],
+      launchpadDefaults: defaults,
+    }));
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+      updateDirectoryLaunchpad,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.selectedLaunchpad?.workMode).toBe("local");
+    });
+
+    let update: Promise<void> | undefined;
+    act(() => {
+      update = result.current.updateDirectoryLaunchpad(
+        launchpad.directoryKey,
+        {
+          workMode: "worktree",
+        },
+        { stickySettingsChanged: true },
+      );
+    });
+
+    await act(async () => {
+      stickyUpdate.resolve({
+        defaults: {
+          ...defaults,
+          workMode: "worktree",
+        },
+        launchpad: {
+          ...launchpad,
+          workMode: "worktree",
+          settingsTouchedAt: 123_456,
+          updatedAt: 2,
+        },
+      });
+      await update!;
+    });
+
+    expect(result.current.selectedLaunchpad).toMatchObject({
+      workMode: "worktree",
+      settingsTouchedAt: 123_456,
+    });
+    expect(updateDirectoryLaunchpad).toHaveBeenCalledWith({
+      directoryKey: launchpad.directoryKey,
+      patch: {
+        workMode: "worktree",
+      },
+      stickySettingsChanged: true,
     });
   });
 

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -904,6 +904,50 @@ function applyLaunchpadUpdate(
   };
 }
 
+function mergeLaunchpadUpdateResponse(
+  current: NavigationLaunchpadDraft | undefined,
+  next: NavigationLaunchpadDraft,
+  patch: Parameters<NonNullable<DesktopApi["updateDirectoryLaunchpad"]>>[0]["patch"],
+): NavigationLaunchpadDraft {
+  if (!current || current.directoryKey !== next.directoryKey) {
+    return next;
+  }
+
+  const merged: NavigationLaunchpadDraft = { ...next };
+  const backendChanged = "backend" in patch;
+  const environmentChanged = backendChanged || "codexEnvironmentId" in patch;
+  const preserveSetting = <Key extends keyof NavigationLaunchpadDraft>(
+    key: Key,
+  ): void => {
+    if (!backendChanged && !(key in patch)) {
+      merged[key] = current[key] as NavigationLaunchpadDraft[Key];
+    }
+  };
+  const preserveEnvironment = <Key extends keyof NavigationLaunchpadDraft>(
+    key: Key,
+  ): void => {
+    if (!environmentChanged && !(key in patch)) {
+      merged[key] = current[key] as NavigationLaunchpadDraft[Key];
+    }
+  };
+
+  preserveSetting("executionMode");
+  preserveSetting("model");
+  preserveSetting("reasoningEffort");
+  preserveSetting("serviceTier");
+  preserveSetting("fastMode");
+  preserveSetting("workMode");
+  preserveSetting("branchName");
+  preserveSetting("settingsTouchedAt");
+  preserveEnvironment("codexEnvironmentId");
+  preserveEnvironment("codexEnvironmentExecutionTarget");
+  preserveEnvironment("codexEnvironmentSetupEnabled");
+  preserveEnvironment("codexEnvironmentActionId");
+  preserveEnvironment("codexEnvironmentOptions");
+
+  return merged;
+}
+
 function applyLaunchpadReset(
   snapshot: NavigationSnapshot | undefined,
   directoryKey: string,
@@ -2236,7 +2280,13 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
           ...current,
           response: applyLaunchpadUpdate(
             current.response,
-            response.launchpad,
+            mergeLaunchpadUpdateResponse(
+              current.response?.directories.find(
+                (directory) => directory.key === directoryKey
+              )?.launchpad,
+              response.launchpad,
+              patch,
+            ),
             response.defaults
           ),
         }));

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -938,7 +938,6 @@ function mergeLaunchpadUpdateResponse(
   preserveSetting("fastMode");
   preserveSetting("workMode");
   preserveSetting("branchName");
-  preserveSetting("settingsTouchedAt");
   preserveEnvironment("codexEnvironmentId");
   preserveEnvironment("codexEnvironmentExecutionTarget");
   preserveEnvironment("codexEnvironmentSetupEnabled");


### PR DESCRIPTION
## Summary

- I hid launchpad-only Codex environment selection controls after a thread exists.
- I removed pre-thread environment command selection so commands can only be run after thread creation.
- I stabilized prompt autosave responses so launchpad environment controls do not flicker while typing.

## Verification

- I ran `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx`.
- I ran `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts`.
- I ran `pnpm --filter @pwragent/desktop typecheck`.

## Notes

- The thread composer still shows environment commands only when the thread already has a Codex environment runtime.
