### PR TITLE
feat(desktop): show Codex profile account email

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-profiles.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-profiles.test.ts
@@ -56,6 +56,33 @@ describe("Codex auth profile discovery", () => {
     ]);
   });
 
+  it("reads the account email from Codex auth tokens when present", () => {
+    const root = createTempRoot();
+    const codexHome = path.join(root, "codex");
+    const profileHome = path.join(codexHome, "profiles", "work");
+    fs.mkdirSync(profileHome, { recursive: true });
+    fs.writeFileSync(
+      path.join(profileHome, "auth.json"),
+      JSON.stringify({
+        auth_mode: "chatgpt",
+        tokens: {
+          id_token: createUnsignedJwt({ email: "work@example.com" }),
+        },
+      }),
+      "utf8",
+    );
+
+    const discovery = discoverCodexAuthProfiles({
+      configuredProfile: "work",
+      env: { CODEX_HOME: codexHome } as NodeJS.ProcessEnv,
+    });
+
+    expect(discovery.profiles[1]).toMatchObject({
+      name: "work",
+      accountEmail: "work@example.com",
+    });
+  });
+
   it("adds the configured profile even when the directory does not exist yet", () => {
     const root = createTempRoot();
     const codexHome = path.join(root, "codex");
@@ -104,3 +131,19 @@ describe("Codex auth profile discovery", () => {
     ).toBe(false);
   });
 });
+
+function createUnsignedJwt(payload: Record<string, unknown>): string {
+  return [
+    encodeJwtPart({ alg: "none", typ: "JWT" }),
+    encodeJwtPart(payload),
+    "",
+  ].join(".");
+}
+
+function encodeJwtPart(value: Record<string, unknown>): string {
+  return Buffer.from(JSON.stringify(value), "utf8")
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/u, "");
+}

--- a/apps/desktop/src/main/settings/codex-profiles.ts
+++ b/apps/desktop/src/main/settings/codex-profiles.ts
@@ -70,6 +70,7 @@ export function discoverCodexAuthProfiles(options?: {
       exists: fs.existsSync(defaultCodexHome),
       selected: selectedProfile === "",
       hasAuthFile: fileExists(path.join(defaultCodexHome, "auth.json")),
+      accountEmail: readCodexAuthEmail(defaultCodexHome),
       hasConfigFile: fileExists(path.join(defaultCodexHome, "config.toml")),
     },
   ];
@@ -124,6 +125,7 @@ function buildDirectoryProfile(
     exists: fs.existsSync(codexHome),
     selected: selectedProfile === name,
     hasAuthFile: fileExists(path.join(codexHome, "auth.json")),
+    accountEmail: readCodexAuthEmail(codexHome),
     hasConfigFile: fileExists(path.join(codexHome, "config.toml")),
   };
 }
@@ -134,4 +136,54 @@ function fileExists(filePath: string): boolean {
   } catch {
     return false;
   }
+}
+
+function readCodexAuthEmail(codexHome: string): string | undefined {
+  try {
+    const raw = fs.readFileSync(path.join(codexHome, "auth.json"), "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    const idToken = getNestedString(parsed, ["tokens", "id_token"]);
+    if (!idToken) return undefined;
+    return extractEmailFromJwt(idToken);
+  } catch {
+    return undefined;
+  }
+}
+
+function extractEmailFromJwt(token: string): string | undefined {
+  const payload = token.split(".")[1];
+  if (!payload) return undefined;
+
+  try {
+    const decoded = Buffer.from(normalizeBase64Url(payload), "base64").toString("utf8");
+    const claims = JSON.parse(decoded) as unknown;
+    const email = getNestedString(claims, ["email"])?.trim();
+    if (!email || email.length > 320 || !email.includes("@")) return undefined;
+    return email;
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizeBase64Url(value: string): string {
+  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+  const remainder = normalized.length % 4;
+  return remainder === 0
+    ? normalized
+    : `${normalized}${"=".repeat(4 - remainder)}`;
+}
+
+function getNestedString(value: unknown, pathParts: string[]): string | undefined {
+  let current = value;
+  for (const pathPart of pathParts) {
+    if (
+      typeof current !== "object"
+      || current === null
+      || !Object.prototype.hasOwnProperty.call(current, pathPart)
+    ) {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[pathPart];
+  }
+  return typeof current === "string" ? current : undefined;
 }

--- a/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
@@ -315,7 +315,14 @@ function CodexProfileRow(props: {
 
   return (
     <SettingsPathRow
-      title={profile.displayName}
+      title={
+        <span className="settings-pathrow__title-line">
+          <span>{profile.displayName}</span>
+          {profile.accountEmail ? (
+            <span className="settings-pathrow__meta">{profile.accountEmail}</span>
+          ) : null}
+        </span>
+      }
       path={profile.codexHome}
       chips={chips}
       selected={profile.selected}

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -185,6 +185,7 @@ function createSnapshot(
               name: "work",
               displayName: "work",
               codexHome: "/home/example/.codex/profiles/work",
+              accountEmail: "work@example.com",
               source: "directory",
               exists: true,
               selected: false,
@@ -397,6 +398,7 @@ describe("SettingsScreen", () => {
     });
     expect(screen.getAllByText("System default").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("/home/example/.codex/profiles/work")).toBeInTheDocument();
+    expect(screen.getByText("work@example.com")).toBeInTheDocument();
     fireEvent.click(useButtons[1]!);
     await waitFor(() => {
       expect(settings.writeConfig).toHaveBeenCalledWith({

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3645,6 +3645,25 @@ textarea,
   line-height: 1.2;
 }
 
+.settings-pathrow__title-line {
+  display: inline-flex;
+  max-width: 100%;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+}
+
+.settings-pathrow__meta {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .settings-pathrow__path {
   display: block;
   margin-top: 3px;

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -161,6 +161,7 @@ export type DesktopCodexAuthProfileCandidate = {
   name: string;
   displayName: string;
   codexHome: string;
+  accountEmail?: string;
   source: DesktopCodexAuthProfileSource;
   exists: boolean;
   selected: boolean;


### PR DESCRIPTION
## Summary

- Add `accountEmail` to discovered Codex auth profiles in the desktop settings snapshot.
- Read the email claim from the local Codex `auth.json` ID token without exposing tokens.
- Show the email next to each Codex profile name on Settings -> Models.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/codex-profiles.test.ts`
- `pnpm test apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`