### PR TITLE
fix(desktop): hydrate picked directory git status

### DIFF
--- a/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -21,13 +21,16 @@ async function selectComposerOption(params: {
 async function createDirectoryLaunchpadFixture(): Promise<{
   cleanup: () => Promise<void>;
   fixturePath: string;
+  pickedRepoDir: string;
 }> {
   const rootDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-launchpad-e2e-"));
   const repoDir = path.join(rootDir, "FixtureRepo");
   const otherRepoDir = path.join(rootDir, "OtherRepo");
+  const pickedRepoDir = path.join(rootDir, "PickedRepo");
   const worktreeDir = path.join(rootDir, ".pwragent", "worktrees", "mord46hf", "FixtureRepo");
   await mkdir(repoDir, { recursive: true });
   await mkdir(otherRepoDir, { recursive: true });
+  await mkdir(pickedRepoDir, { recursive: true });
 
   execFileSync("git", ["init"], { cwd: repoDir, stdio: "ignore" });
   execFileSync("git", ["checkout", "-B", "main"], { cwd: repoDir, stdio: "ignore" });
@@ -62,6 +65,23 @@ async function createDirectoryLaunchpadFixture(): Promise<{
     ],
     { cwd: otherRepoDir, stdio: "ignore" },
   );
+  execFileSync("git", ["init"], { cwd: pickedRepoDir, stdio: "ignore" });
+  execFileSync("git", ["checkout", "-B", "main"], { cwd: pickedRepoDir, stdio: "ignore" });
+  execFileSync(
+    "git",
+    [
+      "-c",
+      "user.name=PwrAgent Tests",
+      "-c",
+      "user.email=pwragent-tests@example.invalid",
+      "commit",
+      "--allow-empty",
+      "-m",
+      "Seed picked fixture repo",
+    ],
+    { cwd: pickedRepoDir, stdio: "ignore" },
+  );
+  const resolvedPickedRepoDir = await realpath(pickedRepoDir);
 
   const fixturePath = path.join(rootDir, "directory-launchpad-workspace.fixture.json");
   await writeFile(
@@ -272,6 +292,7 @@ async function createDirectoryLaunchpadFixture(): Promise<{
 
   return {
     fixturePath,
+    pickedRepoDir: resolvedPickedRepoDir,
     cleanup: async () => {
       await rm(rootDir, { recursive: true, force: true });
     },
@@ -688,6 +709,88 @@ test("directory launchpad does not show workspace application buttons before a t
     await expect(app.window.getByRole("textbox", { name: "New thread" })).toBeVisible();
     await expect(app.window.getByRole("button", { name: "VS Code" })).toHaveCount(0);
     await expect(app.window.getByRole("button", { name: "Ghostty" })).toHaveCount(0);
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
+test("new-thread picker hydrates git status for a newly added directory", async () => {
+  const fixture = await createDirectoryLaunchpadFixture();
+  const app = await launchElectronApp({
+    env: {
+      PWRAGENT_E2E_PICK_DIRECTORY_PATH: fixture.pickedRepoDir,
+    },
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    const newThreadButton = app.window
+      .locator(".sidebar__masthead-actions")
+      .getByRole("button", { name: "New thread" });
+    await expect(newThreadButton).toBeEnabled();
+    await newThreadButton.click();
+    await expect(app.window.getByRole("textbox", { name: "New thread" })).toBeVisible();
+
+    await app.window.getByRole("button", { name: /^(Project:|Choose a project)/ }).click();
+    await app.window.getByRole("button", { name: /Add directory/ }).click();
+
+    await expect(
+      app.window.getByRole("heading", { level: 2, name: "PickedRepo" }),
+    ).toBeVisible();
+
+    const settings = app.window.getByLabel("New thread settings");
+    const workspaceMode = settings.getByLabel("Workspace mode");
+
+    await expect(workspaceMode).toBeEnabled();
+    await expect(workspaceMode).toContainText("Local (main)");
+    await workspaceMode.click();
+    await expect(app.window.getByRole("option", { name: "New worktree" })).toHaveCount(1);
+    await app.window.getByRole("option", { name: "New worktree" }).click();
+    await expect(settings.getByLabel("Base branch")).toHaveAttribute("data-value", "main");
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
+test("new-thread picker starts a newly added directory in local checkout by default", async () => {
+  const fixture = await createDirectoryLaunchpadFixture();
+  const app = await launchElectronApp({
+    env: {
+      PWRAGENT_E2E_PICK_DIRECTORY_PATH: fixture.pickedRepoDir,
+    },
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    const newThreadButton = app.window
+      .locator(".sidebar__masthead-actions")
+      .getByRole("button", { name: "New thread" });
+    await expect(newThreadButton).toBeEnabled();
+    await newThreadButton.click();
+    await expect(app.window.getByRole("textbox", { name: "New thread" })).toBeVisible();
+
+    await app.window.getByRole("button", { name: /^(Project:|Choose a project)/ }).click();
+    await app.window.getByRole("button", { name: /Add directory/ }).click();
+
+    const settings = app.window.getByLabel("New thread settings");
+    const workspaceMode = settings.getByLabel("Workspace mode");
+    await expect(workspaceMode).toBeEnabled();
+    await expect(workspaceMode).toHaveAttribute("data-value", "local");
+    await expect(workspaceMode).toContainText("Local (main)");
+
+    await app.window
+      .getByRole("textbox", { name: "New thread" })
+      .fill("Start in the picked local checkout");
+    await app.window.getByRole("button", { name: "Start thread" }).click();
+
+    await expect
+      .poll(
+        async () =>
+          ((await app.getLastStartTurn()) as { cwd?: string } | undefined)?.cwd,
+      )
+      .toBe(fixture.pickedRepoDir);
   } finally {
     await app.close();
     await fixture.cleanup();

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -998,6 +998,13 @@ class DesktopAppServerService {
   async pickDirectoryFromDisk(
     parentWindow?: BrowserWindow,
   ): Promise<PickDirectoryFromDiskResponse> {
+    const e2ePickPath = process.env.PWRAGENT_REPLAY_FIXTURE_PATH
+      ? process.env.PWRAGENT_E2E_PICK_DIRECTORY_PATH?.trim()
+      : undefined;
+    if (e2ePickPath) {
+      return { canceled: false, path: e2ePickPath };
+    }
+
     // Anchor the dialog to whichever window dispatched the IPC so it
     // appears as a sheet on macOS (the renderer's expectation) instead
     // of floating free. `dialog.showOpenDialog` accepts an optional
@@ -1025,10 +1032,20 @@ class DesktopAppServerService {
   async registerDirectoryFromDisk(
     request: RegisterDirectoryFromDiskRequest,
   ): Promise<RegisterDirectoryFromDiskResponse> {
-    const registry = getDesktopBackendRegistry();
-    return await registerDirectoryFromDisk(request, {
-      ensureDirectoryLaunchpad: (req) => registry.ensureDirectoryLaunchpad(req),
+    const response = await registerDirectoryFromDisk(request, {
+      ensureDirectoryLaunchpad: (req) => this.ensureDirectoryLaunchpad(req),
     });
+    if (response.ok) {
+      this.lastDirectoriesByKey.set(response.directoryKey, {
+        key: response.directoryKey,
+        kind: "directory",
+        label: response.directoryLabel,
+        path: response.directoryPath,
+        threadKeys: [],
+        needsAttentionCount: 0,
+      });
+    }
+    return response;
   }
 
   async analyzeFocusedDiff(

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -2818,22 +2818,48 @@ describe("useThreadNavigation", () => {
   });
 
   describe("pickAndRegisterDirectory (issue #223)", () => {
+    const launchpadDefaults = {
+      backend: "codex" as const,
+      executionMode: "default" as const,
+    };
+
+    function buildSnapshot(
+      directories: NavigationSnapshot["directories"] = [],
+    ): NavigationSnapshot {
+      return {
+        backend: "all" as const,
+        fetchedAt: Date.now(),
+        unchanged: false,
+        inboxThreadKeys: [],
+        threads: [],
+        directories,
+        launchpadDefaults,
+      };
+    }
+
+    function buildPickedLaunchpad(
+      patch: Partial<NavigationLaunchpadDraft> = {},
+    ): NavigationLaunchpadDraft {
+      return {
+        directoryKey: "directory:/Users/me/repos/PwrAgent",
+        directoryKind: "directory" as const,
+        directoryLabel: "PwrAgent",
+        directoryPath: "/Users/me/repos/PwrAgent",
+        backend: "codex" as const,
+        executionMode: "default" as const,
+        prompt: "",
+        workMode: "local" as const,
+        createdAt: 1,
+        updatedAt: 1,
+        ...patch,
+      };
+    }
+
     function buildBaseDesktopApi(
       overrides: Partial<DesktopApi> = {},
     ): DesktopApi {
       return {
-        getNavigationSnapshot: vi.fn(async () => ({
-          backend: "all" as const,
-          fetchedAt: Date.now(),
-          unchanged: false,
-          inboxThreadKeys: [],
-          threads: [],
-          directories: [],
-          launchpadDefaults: {
-            backend: "codex" as const,
-            executionMode: "default" as const,
-          },
-        })),
+        getNavigationSnapshot: vi.fn(async () => buildSnapshot()),
         onAgentEvent: () => () => undefined,
         ...overrides,
       };
@@ -2970,6 +2996,131 @@ describe("useThreadNavigation", () => {
       expect(result.current.pickingDirectory).toBe(false);
       expect(result.current.selectedItemKey).toBe(
         "launchpad:directory:/Users/me/repos/PwrAgent",
+      );
+    });
+
+    it("force-refreshes git status for a newly picked directory", async () => {
+      const launchpad = buildPickedLaunchpad();
+      const pickDirectoryFromDisk = vi.fn(async () => ({
+        canceled: false as const,
+        path: "/Users/me/repos/PwrAgent",
+      }));
+      const registerDirectoryFromDisk = vi.fn(async () => ({
+        ok: true as const,
+        directoryPath: "/Users/me/repos/PwrAgent",
+        directoryKey: launchpad.directoryKey,
+        directoryLabel: "PwrAgent",
+        currentBranch: "main",
+        launchpad,
+        defaults: launchpadDefaults,
+      }));
+      const getNavigationSnapshot = vi
+        .fn()
+        .mockResolvedValueOnce(buildSnapshot())
+        .mockResolvedValueOnce(
+          buildSnapshot([
+            {
+              key: launchpad.directoryKey,
+              kind: "directory" as const,
+              label: "PwrAgent",
+              path: "/Users/me/repos/PwrAgent",
+              threadKeys: [],
+              needsAttentionCount: 0,
+              launchpad,
+            },
+          ]),
+        );
+      const refreshDirectoryGitStatuses = vi.fn(async () => ({
+        scheduledCount: 1,
+      }));
+      const desktopApi = buildBaseDesktopApi({
+        getNavigationSnapshot,
+        pickDirectoryFromDisk,
+        registerDirectoryFromDisk,
+        refreshDirectoryGitStatuses,
+      });
+
+      const { result } = renderHook(() => useThreadNavigation(desktopApi));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      await act(async () => {
+        await result.current.pickAndRegisterDirectory();
+      });
+
+      expect(refreshDirectoryGitStatuses).toHaveBeenCalledExactlyOnceWith({
+        directoryKeys: [launchpad.directoryKey],
+        force: true,
+      });
+    });
+
+    it("does not overwrite launchpad edits when the picker refresh is stale", async () => {
+      const launchpad = buildPickedLaunchpad();
+      const refreshSnapshot = createDeferred<NavigationSnapshot>();
+      const pickDirectoryFromDisk = vi.fn(async () => ({
+        canceled: false as const,
+        path: "/Users/me/repos/PwrAgent",
+      }));
+      const registerDirectoryFromDisk = vi.fn(async () => ({
+        ok: true as const,
+        directoryPath: "/Users/me/repos/PwrAgent",
+        directoryKey: launchpad.directoryKey,
+        directoryLabel: "PwrAgent",
+        currentBranch: "main",
+        launchpad,
+        defaults: launchpadDefaults,
+      }));
+      const getNavigationSnapshot = vi
+        .fn()
+        .mockResolvedValueOnce(buildSnapshot())
+        .mockReturnValueOnce(refreshSnapshot.promise);
+      const updateDirectoryLaunchpad = vi.fn(async () => ({
+        launchpad: buildPickedLaunchpad({
+          prompt: "Edited before refresh completes",
+          updatedAt: 2,
+        }),
+        defaults: launchpadDefaults,
+      }));
+      const desktopApi = buildBaseDesktopApi({
+        getNavigationSnapshot,
+        pickDirectoryFromDisk,
+        registerDirectoryFromDisk,
+        refreshDirectoryGitStatuses: vi.fn(async () => ({ scheduledCount: 1 })),
+        updateDirectoryLaunchpad,
+      });
+
+      const { result } = renderHook(() => useThreadNavigation(desktopApi));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      let pick!: Promise<void>;
+      act(() => {
+        pick = result.current.pickAndRegisterDirectory();
+      });
+
+      await waitFor(() => {
+        expect(result.current.selectedLaunchpad?.directoryKey).toBe(
+          launchpad.directoryKey,
+        );
+      });
+
+      await act(async () => {
+        await result.current.updateDirectoryLaunchpad(launchpad.directoryKey, {
+          prompt: "Edited before refresh completes",
+        });
+      });
+
+      await waitFor(() => {
+        expect(result.current.selectedLaunchpad?.prompt).toBe(
+          "Edited before refresh completes",
+        );
+      });
+
+      await act(async () => {
+        refreshSnapshot.resolve(buildSnapshot());
+        await pick;
+      });
+
+      expect(result.current.selectedLaunchpad?.prompt).toBe(
+        "Edited before refresh completes",
       );
     });
 

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -916,6 +916,21 @@ function applyLaunchpadUpdate(
   };
 }
 
+function applyLaunchpadUpdateIfMissing(
+  snapshot: NavigationSnapshot | undefined,
+  launchpad: NavigationLaunchpadDraft,
+  defaults: NavigationSnapshot["launchpadDefaults"],
+): NavigationSnapshot | undefined {
+  if (
+    !snapshot ||
+    snapshot.directories.some((directory) => directory.key === launchpad.directoryKey)
+  ) {
+    return snapshot;
+  }
+
+  return applyLaunchpadUpdate(snapshot, launchpad, defaults);
+}
+
 function mergeLaunchpadUpdateResponse(
   current: NavigationLaunchpadDraft | undefined,
   next: NavigationLaunchpadDraft,
@@ -1376,6 +1391,7 @@ export function useThreadNavigation(
     undefined
   );
   const launchpadUpdateRevisionRef = useRef(new Map<string, number>());
+  const pendingPickedLaunchpadRef = useRef(new Map<string, NavigationLaunchpadDraft>());
 
   optimisticThreadRef.current = optimisticThread;
   retainedUnreadThreadRef.current = retainedUnreadThread;
@@ -2290,6 +2306,7 @@ export function useThreadNavigation(
       setPickDirectoryError(undefined);
       setPickingDirectory(true);
 
+      let pendingPickedDirectoryKey: string | undefined;
       try {
         const pick = await desktopApi.pickDirectoryFromDisk();
         if (pick.canceled) {
@@ -2303,6 +2320,8 @@ export function useThreadNavigation(
           setPickDirectoryError(result.message);
           return;
         }
+        pendingPickedDirectoryKey = result.directoryKey;
+        pendingPickedLaunchpadRef.current.set(result.directoryKey, result.launchpad);
         setState((current) => ({
           ...current,
           response: applyLaunchpadUpdate(
@@ -2311,16 +2330,37 @@ export function useThreadNavigation(
             result.defaults,
           ),
         }));
-        setSelectedItemKey(buildLaunchpadSelectionKey(result.directoryKey));
+        const selectionKey = buildLaunchpadSelectionKey(result.directoryKey);
+        setSelectedItemKey(selectionKey);
+        await refresh(selectionKey, undefined, true);
+        const pickedLaunchpad =
+          pendingPickedLaunchpadRef.current.get(result.directoryKey) ??
+          result.launchpad;
+        setState((current) => ({
+          ...current,
+          response: applyLaunchpadUpdateIfMissing(
+            current.response,
+            pickedLaunchpad,
+            result.defaults,
+          ),
+        }));
+        setSelectedItemKey(selectionKey);
+        await desktopApi.refreshDirectoryGitStatuses?.({
+          directoryKeys: [result.directoryKey],
+          force: true,
+        });
       } catch (error) {
         setPickDirectoryError(
           error instanceof Error ? error.message : String(error),
         );
       } finally {
+        if (pendingPickedDirectoryKey) {
+          pendingPickedLaunchpadRef.current.delete(pendingPickedDirectoryKey);
+        }
         setPickingDirectory(false);
       }
     },
-    [desktopApi],
+    [desktopApi, refresh],
   );
 
   const clearPickDirectoryError = useCallback((): void => {
@@ -2366,6 +2406,15 @@ export function useThreadNavigation(
           ),
         };
       });
+      const pendingPickedLaunchpad = pendingPickedLaunchpadRef.current.get(directoryKey);
+      if (pendingPickedLaunchpad) {
+        pendingPickedLaunchpadRef.current.set(directoryKey, {
+          ...pendingPickedLaunchpad,
+          ...patch,
+          directoryKey,
+          updatedAt: Date.now(),
+        });
+      }
 
       try {
         const response = await desktopApi.updateDirectoryLaunchpad({
@@ -2390,6 +2439,18 @@ export function useThreadNavigation(
             response.defaults
           ),
         }));
+        const nextPendingPickedLaunchpad =
+          pendingPickedLaunchpadRef.current.get(directoryKey);
+        if (nextPendingPickedLaunchpad) {
+          pendingPickedLaunchpadRef.current.set(
+            directoryKey,
+            mergeLaunchpadUpdateResponse(
+              nextPendingPickedLaunchpad,
+              response.launchpad,
+              patch,
+            ),
+          );
+        }
       } catch (error) {
         if (launchpadUpdateRevisionRef.current.get(directoryKey) !== revision) {
           return;


### PR DESCRIPTION
## Summary
- Refresh the navigation snapshot immediately after registering a directory from the new-thread project picker so the selected launchpad has hydrated git status without requiring an app focus change.
- Add replay-backed E2E coverage for newly picked git directories showing `Local (main)`, exposing `New worktree`, and preserving Local as the default start cwd.
- Add a replay-only picker path override for deterministic directory-picker E2Es.

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm --filter @pwragent/desktop test:e2e e2e/directory-launchpad-workspace.spec.ts -g "new-thread picker"`