### PR TITLE
fix(desktop): keep selected refreshed threads read

### DIFF
--- a/apps/desktop/e2e/thread-unread-regression.spec.ts
+++ b/apps/desktop/e2e/thread-unread-regression.spec.ts
@@ -1,0 +1,186 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import { launchElectronApp } from "./fixtures/electron-app";
+
+async function createUnreadRegressionFixture(): Promise<{
+  cleanup: () => Promise<void>;
+  fixturePath: string;
+}> {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-thread-unread-"));
+  const fixturePath = path.join(rootDir, "thread-unread-regression.fixture.json");
+
+  await writeFile(
+    fixturePath,
+    JSON.stringify(
+      {
+        metadata: {
+          backend: "codex",
+          scenario: "thread-unread-regression",
+          threadId: "thread-read",
+        },
+        steps: [
+          {
+            id: "initialize-1",
+            kind: "response",
+            method: "initialize",
+            result: {
+              serverInfo: {
+                name: "Replay Codex",
+                version: "1.0.0",
+              },
+              methods: ["thread/list", "thread/read"],
+            },
+          },
+          {
+            id: "thread-list-1",
+            kind: "response",
+            method: "thread/list",
+            result: [
+              {
+                id: "thread-read",
+                title: "Read thread",
+                titleSource: "explicit",
+                summary: "A thread that has already been read",
+                source: "codex",
+                executionMode: "default",
+                linkedDirectories: [],
+                createdAt: 1_000,
+                updatedAt: 1_000,
+              },
+              {
+                id: "thread-other",
+                title: "Other thread",
+                titleSource: "explicit",
+                summary: "A separate thread",
+                source: "codex",
+                executionMode: "default",
+                linkedDirectories: [],
+                createdAt: 900,
+                updatedAt: 900,
+              },
+            ],
+          },
+          {
+            id: "thread-read-1",
+            kind: "response",
+            method: "thread/read",
+            result: {
+              entries: [
+                {
+                  type: "message",
+                  id: "read-message-1",
+                  role: "assistant",
+                  text: "There is nothing new to read here.",
+                },
+              ],
+              messages: [
+                {
+                  id: "read-message-1",
+                  role: "assistant",
+                  text: "There is nothing new to read here.",
+                },
+              ],
+              lastAssistantMessage: "There is nothing new to read here.",
+              pagination: {
+                supportsPagination: false,
+                hasPreviousPage: false,
+              },
+            },
+          },
+          {
+            id: "unrelated-turn-completed",
+            kind: "notification",
+            notification: {
+              method: "turn/completed",
+              params: {
+                threadId: "thread-other",
+                turnId: "turn-other-1",
+                turn: {
+                  id: "turn-other-1",
+                  status: "completed",
+                  output: [],
+                },
+              },
+            },
+          },
+          {
+            id: "thread-list-2",
+            kind: "response",
+            method: "thread/list",
+            result: [
+              {
+                id: "thread-read",
+                title: "Read thread",
+                titleSource: "explicit",
+                summary: "A thread that has already been read",
+                source: "codex",
+                executionMode: "default",
+                linkedDirectories: [],
+                createdAt: 1_000,
+                updatedAt: 2_000,
+              },
+              {
+                id: "thread-other",
+                title: "Other thread refreshed",
+                titleSource: "explicit",
+                summary: "A separate thread changed elsewhere",
+                source: "codex",
+                executionMode: "default",
+                linkedDirectories: [],
+                createdAt: 900,
+                updatedAt: 1_100,
+              },
+            ],
+          },
+        ],
+      },
+      null,
+      2
+    )
+  );
+
+  return {
+    cleanup: async () => {
+      await rm(rootDir, { force: true, recursive: true });
+    },
+    fixturePath,
+  };
+}
+
+test("does not make the selected read thread unread after a metadata-only refresh", async () => {
+  const fixture = await createUnreadRegressionFixture();
+  const app = await launchElectronApp({ fixturePath: fixture.fixturePath });
+
+  try {
+    const browseSection = app.window.locator(".sidebar__section--fill");
+    const readRow = browseSection.getByRole("button", {
+      name: /Read thread/i,
+    });
+
+    await expect(readRow).toBeVisible();
+    await readRow.click();
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "Read thread",
+      })
+    ).toBeVisible();
+    await expect(readRow.locator('[data-thread-status="unread"]')).toHaveCount(0);
+
+    await app.advance({ stepId: "unrelated-turn-completed" });
+    await expect(
+      browseSection.getByRole("button", { name: /Other thread refreshed/i })
+    ).toBeVisible();
+    await expect(readRow.locator('[data-thread-status="unread"]')).toHaveCount(0);
+
+    await browseSection
+      .getByRole("button", { name: /Other thread refreshed/i })
+      .click();
+    await expect(readRow.locator('[data-thread-status="unread"]')).toHaveCount(0);
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -82,7 +82,9 @@ function DesktopAppShell(props: {
   const settings = props.settings;
   const profiles = usePwrAgentProfiles(desktopApi);
   const runtimeIdentity = useRuntimeIdentity(desktopApi);
-  const navigation = useThreadNavigation(desktopApi);
+  const navigation = useThreadNavigation(desktopApi, {
+    threadViewVisible: mainView === "thread",
+  });
   const backendSummaries = useBackendSummaries(desktopApi);
   const pullRequests = usePullRequestRefresh({
     desktopApi,

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -7,10 +7,15 @@ import type {
   NavigationSnapshot,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../desktop-api";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useThreadNavigation } from "../useThreadNavigation";
 
 describe("useThreadNavigation", () => {
+  beforeEach(() => {
+    vi.spyOn(document, "hasFocus").mockReturnValue(true);
+    vi.spyOn(document, "visibilityState", "get").mockReturnValue("visible");
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -258,6 +263,370 @@ describe("useThreadNavigation", () => {
 
     await waitFor(() => {
       expect(result.current.threads[0]?.inbox.inInbox).toBe(false);
+    });
+  });
+
+  it("marks the selected thread seen again when a refresh advances it", async () => {
+    const listeners = new Set<(event: any) => void>();
+    const markThreadSeen = vi.fn(
+      async (
+        request: Parameters<NonNullable<DesktopApi["markThreadSeen"]>>[0]
+      ) => ({
+        backend: request.backend,
+        threadId: request.threadId,
+        seenAt: Date.now(),
+        seenUpdatedAt: request.seenUpdatedAt,
+      })
+    );
+    let refreshed = false;
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: refreshed ? ["codex:thread-read"] : [],
+      threads: [
+        {
+          id: "thread-read",
+          title: "Read thread",
+          titleSource: "explicit" as const,
+          summary: "Read thread summary",
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: refreshed
+            ? {
+                inInbox: true,
+                reason: "updated-since-seen" as const,
+                lastSeenUpdatedAt: 1_000,
+              }
+            : {
+                inInbox: false,
+                lastSeenUpdatedAt: 1_000,
+              },
+          updatedAt: refreshed ? 2_000 : 1_000,
+        },
+        {
+          id: "thread-other",
+          title: "Other thread",
+          titleSource: "explicit" as const,
+          summary: "Other thread summary",
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: {
+            inInbox: false,
+          },
+          updatedAt: 900,
+        },
+      ],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      markThreadSeen,
+      onAgentEvent: (callback) => {
+        listeners.add(callback);
+        return () => {
+          listeners.delete(callback);
+        };
+      },
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.id).toBe("thread-read");
+    });
+
+    act(() => {
+      result.current.selectThread(result.current.threads[0]!);
+    });
+
+    await waitFor(() => {
+      expect(markThreadSeen).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-read",
+        seenUpdatedAt: 1_000,
+      });
+    });
+
+    refreshed = true;
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "turn/completed",
+            params: {
+              threadId: "thread-other",
+              turnId: "turn-other",
+            },
+          },
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(markThreadSeen).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-read",
+        seenUpdatedAt: 2_000,
+      });
+      expect(result.current.threads[0]?.inbox.inInbox).toBe(false);
+    });
+  });
+
+  it("keeps selected refreshes unread while the window is backgrounded", async () => {
+    const listeners = new Set<(event: any) => void>();
+    const markThreadSeen = vi.fn(
+      async (
+        request: Parameters<NonNullable<DesktopApi["markThreadSeen"]>>[0]
+      ) => ({
+        backend: request.backend,
+        threadId: request.threadId,
+        seenAt: Date.now(),
+        seenUpdatedAt: request.seenUpdatedAt,
+      })
+    );
+    let refreshed = false;
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: refreshed ? ["codex:thread-read"] : [],
+      threads: [
+        {
+          id: "thread-read",
+          title: "Read thread",
+          titleSource: "explicit" as const,
+          summary: "Read thread summary",
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: refreshed
+            ? {
+                inInbox: true,
+                reason: "updated-since-seen" as const,
+                lastSeenUpdatedAt: 1_000,
+              }
+            : {
+                inInbox: false,
+                lastSeenUpdatedAt: 1_000,
+              },
+          updatedAt: refreshed ? 2_000 : 1_000,
+        },
+        {
+          id: "thread-other",
+          title: "Other thread",
+          titleSource: "explicit" as const,
+          summary: "Other thread summary",
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: {
+            inInbox: false,
+          },
+          updatedAt: 900,
+        },
+      ],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      markThreadSeen,
+      onAgentEvent: (callback) => {
+        listeners.add(callback);
+        return () => {
+          listeners.delete(callback);
+        };
+      },
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.id).toBe("thread-read");
+    });
+
+    act(() => {
+      result.current.selectThread(result.current.threads[0]!);
+    });
+
+    await waitFor(() => {
+      expect(markThreadSeen).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-read",
+        seenUpdatedAt: 1_000,
+      });
+    });
+
+    vi.mocked(document.hasFocus).mockReturnValue(false);
+    act(() => {
+      window.dispatchEvent(new Event("blur"));
+    });
+
+    refreshed = true;
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "turn/completed",
+            params: {
+              threadId: "thread-other",
+              turnId: "turn-other",
+            },
+          },
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(result.current.threads[0]?.inbox.inInbox).toBe(true);
+    });
+    expect(markThreadSeen).not.toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-read",
+      seenUpdatedAt: 2_000,
+    });
+  });
+
+  it("keeps selected refreshes unread while the thread view is hidden", async () => {
+    const listeners = new Set<(event: any) => void>();
+    const markThreadSeen = vi.fn(
+      async (
+        request: Parameters<NonNullable<DesktopApi["markThreadSeen"]>>[0]
+      ) => ({
+        backend: request.backend,
+        threadId: request.threadId,
+        seenAt: Date.now(),
+        seenUpdatedAt: request.seenUpdatedAt,
+      })
+    );
+    let refreshed = false;
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: refreshed ? ["codex:thread-read"] : [],
+      threads: [
+        {
+          id: "thread-read",
+          title: "Read thread",
+          titleSource: "explicit" as const,
+          summary: "Read thread summary",
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: refreshed
+            ? {
+                inInbox: true,
+                reason: "updated-since-seen" as const,
+                lastSeenUpdatedAt: 1_000,
+              }
+            : {
+                inInbox: false,
+                lastSeenUpdatedAt: 1_000,
+              },
+          updatedAt: refreshed ? 2_000 : 1_000,
+        },
+        {
+          id: "thread-other",
+          title: "Other thread",
+          titleSource: "explicit" as const,
+          summary: "Other thread summary",
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: {
+            inInbox: false,
+          },
+          updatedAt: 900,
+        },
+      ],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      markThreadSeen,
+      onAgentEvent: (callback) => {
+        listeners.add(callback);
+        return () => {
+          listeners.delete(callback);
+        };
+      },
+    };
+
+    const { rerender, result } = renderHook(
+      ({ threadViewVisible }: { threadViewVisible: boolean }) =>
+        useThreadNavigation(desktopApi, { threadViewVisible }),
+      {
+        initialProps: {
+          threadViewVisible: true,
+        },
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.id).toBe("thread-read");
+    });
+
+    act(() => {
+      result.current.selectThread(result.current.threads[0]!);
+    });
+
+    await waitFor(() => {
+      expect(markThreadSeen).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-read",
+        seenUpdatedAt: 1_000,
+      });
+    });
+
+    rerender({ threadViewVisible: false });
+
+    refreshed = true;
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "turn/completed",
+            params: {
+              threadId: "thread-other",
+              turnId: "turn-other",
+            },
+          },
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(result.current.threads[0]?.inbox.inInbox).toBe(true);
+    });
+    expect(markThreadSeen).not.toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-read",
+      seenUpdatedAt: 2_000,
+    });
+
+    rerender({ threadViewVisible: true });
+
+    await waitFor(() => {
+      expect(markThreadSeen).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-read",
+        seenUpdatedAt: 2_000,
+      });
     });
   });
 

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -32,6 +32,18 @@ const ROOT_NEW_THREAD_WORKSPACE_LAUNCHPAD_KEY = "workspace:new-thread";
 const ROOT_NEW_THREAD_WORKSPACE_LABEL = "Workspaces";
 const NAVIGATION_BACKGROUND_REFRESH_INTERVAL_MS = 30_000;
 
+function isRendererViewForeground(): boolean {
+  if (typeof document === "undefined") {
+    return true;
+  }
+
+  if (document.visibilityState !== "visible") {
+    return false;
+  }
+
+  return typeof document.hasFocus !== "function" ? true : document.hasFocus();
+}
+
 type NavigationState = {
   loading: boolean;
   refreshing: boolean;
@@ -1192,7 +1204,14 @@ function buildOptimisticUserMessage(
   };
 }
 
-export function useThreadNavigation(desktopApi?: DesktopApi): {
+type UseThreadNavigationOptions = {
+  threadViewVisible?: boolean;
+};
+
+export function useThreadNavigation(
+  desktopApi?: DesktopApi,
+  options: UseThreadNavigationOptions = {}
+): {
   browseMode: BrowseMode;
   createThread: (
     backend?: AppServerBackendKind,
@@ -1304,6 +1323,7 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
   const cancelThreadExecutionModeQueueRequest =
     desktopApi?.cancelThreadExecutionModeQueue;
   const setThreadModelSettings = desktopApi?.setThreadModelSettings;
+  const threadViewVisible = options.threadViewVisible ?? true;
   const [browseMode, setBrowseMode] = useState<BrowseMode>("inbox");
   const [selectedItemKey, setSelectedItemKey] = useState<string>();
   const [pendingSeenThreadKey, setPendingSeenThreadKey] = useState<string>();
@@ -1336,9 +1356,12 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
     loading: true,
     refreshing: false,
   });
+  const [viewForeground, setViewForeground] = useState(isRendererViewForeground);
 
   const optimisticThreadRef = useRef<NavigationThreadSummary | undefined>(undefined);
   const retainedUnreadThreadRef = useRef<NavigationThreadSummary | undefined>(undefined);
+  const manuallySelectedThreadKeysRef = useRef(new Set<string>());
+  const submittedSeenUpdatedAtByThreadKeyRef = useRef(new Map<string, number | undefined>());
   const refreshInFlightRef = useRef(false);
   const queuedRefreshRef = useRef<
     | {
@@ -1560,6 +1583,27 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
       if (scheduledRefreshTimerRef.current !== undefined) {
         clearTimeout(scheduledRefreshTimerRef.current);
       }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof document === "undefined") {
+      return;
+    }
+
+    const updateForegroundState = () => {
+      setViewForeground(isRendererViewForeground());
+    };
+
+    updateForegroundState();
+    window.addEventListener("focus", updateForegroundState);
+    window.addEventListener("blur", updateForegroundState);
+    document.addEventListener("visibilitychange", updateForegroundState);
+
+    return () => {
+      window.removeEventListener("focus", updateForegroundState);
+      window.removeEventListener("blur", updateForegroundState);
+      document.removeEventListener("visibilitychange", updateForegroundState);
     };
   }, []);
 
@@ -1995,6 +2039,15 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
     let cancelled = false;
 
     async function markSeen(): Promise<void> {
+      const threadKey = buildThreadIdentityKey(
+        threadToMarkSeen.source,
+        threadToMarkSeen.id
+      );
+      submittedSeenUpdatedAtByThreadKeyRef.current.set(
+        threadKey,
+        threadToMarkSeen.updatedAt
+      );
+
       try {
         await markThreadSeenRequest({
           backend: threadToMarkSeen.source,
@@ -2002,10 +2055,6 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
           seenUpdatedAt: threadToMarkSeen.updatedAt,
         });
         if (!cancelled) {
-          const threadKey = buildThreadIdentityKey(
-            threadToMarkSeen.source,
-            threadToMarkSeen.id
-          );
           if (
             !retainedUnreadThread ||
             buildThreadIdentityKey(retainedUnreadThread.source, retainedUnreadThread.id) !==
@@ -2054,8 +2103,55 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
     [desktopApi?.refreshDirectoryGitStatuses, directories]
   );
 
+  useEffect(() => {
+    if (
+      !selectedThread ||
+      selectedThread.inbox.reason !== "updated-since-seen" ||
+      !viewForeground ||
+      !threadViewVisible
+    ) {
+      return;
+    }
+
+    const threadKey = buildThreadIdentityKey(
+      selectedThread.source,
+      selectedThread.id
+    );
+    if (!manuallySelectedThreadKeysRef.current.has(threadKey)) {
+      return;
+    }
+    const retainedThreadKey = retainedUnreadThread
+      ? buildThreadIdentityKey(retainedUnreadThread.source, retainedUnreadThread.id)
+      : undefined;
+
+    if (
+      retainedThreadKey === threadKey &&
+      retainedUnreadThread?.updatedAt !== selectedThread.updatedAt
+    ) {
+      setRetainedUnreadThread(selectedThread);
+    }
+
+    if (
+      pendingSeenThreadKey === threadKey ||
+      selectedThread.inbox.lastSeenUpdatedAt === selectedThread.updatedAt ||
+      submittedSeenUpdatedAtByThreadKeyRef.current.get(threadKey) ===
+        selectedThread.updatedAt
+    ) {
+      return;
+    }
+
+    setPendingSeenThreadKey(threadKey);
+  }, [
+    pendingSeenThreadKey,
+    retainedUnreadThread,
+    selectedThread,
+    threadViewVisible,
+    viewForeground,
+  ]);
+
   const selectThread = useCallback((thread: NavigationThreadSummary): void => {
     const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+    manuallySelectedThreadKeysRef.current.add(threadKey);
     releaseRetainedUnreadThread(threadKey);
     refreshThreadDirectoryGitStatuses(threadKey);
     setCreateThreadError(undefined);


### PR DESCRIPTION
## Summary

Fixes a desktop unread-state regression where a thread could become unread again after the user had selected it and read it, if a later navigation refresh advanced that selected thread's `updatedAt` while there was no new readable transcript content.

## Root Cause

`useThreadNavigation` only scheduled `markThreadSeen` from the original row click. If a selected thread appeared in a later navigation snapshot as `updated-since-seen`, the selected row could remain unread after the user navigated away because no second seen write was scheduled for the newer `updatedAt`.

## Changes

- Track manually selected thread keys and submitted seen versions in `useThreadNavigation`.
- When a manually selected thread refreshes as `updated-since-seen`, schedule another `markThreadSeen` for the newer `updatedAt`.
- Preserve the existing behavior for initially auto-selected unread rows.
- Add focused hook coverage and a replay-backed Electron E2E for a metadata-only refresh on the selected thread.

## Validation

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx`
- `pnpm --filter @pwragent/desktop test:e2e e2e/thread-unread-regression.spec.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `git diff --check`
