### PR TITLE
fix(desktop): restore worktree directory consolidation

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1321,6 +1321,7 @@ describe("DesktopBackendRegistry", () => {
     const projectA = "/Users/huntharo/projects/ProjectA";
     const worktree1 = "/Users/huntharo/.codex/worktrees/wt1/ProjectA";
     const worktree2 = "/Users/huntharo/.codex/worktrees/wt2/ProjectA";
+    const nestedWorktreeCwd = `${worktree2}/apps`;
     const cheapThreads: AppServerThreadSummary[] = [
       {
         id: "project-a-local",
@@ -1361,14 +1362,14 @@ describe("DesktopBackendRegistry", () => {
         title: "ProjectA worktree 2",
         titleSource: "explicit",
         source: "codex",
-        projectKey: worktree2,
+        projectKey: nestedWorktreeCwd,
         createdAt: 1_000,
         updatedAt: 1_000,
         linkedDirectories: [
           {
-            id: worktree2,
+            id: nestedWorktreeCwd,
             label: "ProjectA",
-            path: worktree2,
+            path: nestedWorktreeCwd,
             kind: "local",
           },
         ],
@@ -1386,7 +1387,10 @@ describe("DesktopBackendRegistry", () => {
                   id: projectA,
                   label: "ProjectA",
                   path: projectA,
-                  worktreePath: thread.projectKey,
+                  worktreePath:
+                    thread.id === "project-a-worktree-2"
+                      ? worktree2
+                      : thread.projectKey,
                   kind: "worktree" as const,
                 },
               ],
@@ -1449,6 +1453,14 @@ describe("DesktopBackendRegistry", () => {
     });
 
     expect(enrichThreadDirectories).toHaveBeenCalledTimes(1);
+    expect(
+      overlaysByThreadId["project-a-worktree-2"]?.extraLinkedDirectories[0],
+    ).toMatchObject({
+      id: nestedWorktreeCwd,
+      path: projectA,
+      worktreePath: worktree2,
+      kind: "worktree",
+    });
     expect(snapshot.directories).toEqual([
       expect.objectContaining({
         key: `directory:${projectA}`,
@@ -1461,6 +1473,14 @@ describe("DesktopBackendRegistry", () => {
         ],
       }),
     ]);
+
+    await registry.listThreads({
+      backend: "codex",
+      callerReason: "startup-prewarm",
+      filter: "force-new-cache-key",
+    });
+
+    expect(enrichThreadDirectories).toHaveBeenCalledTimes(1);
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -21,6 +21,7 @@ import type {
   WorktreeSnapshotSummary,
 } from "@pwragent/shared";
 import type { MessagingBindingRecord } from "@pwragent/messaging-interface";
+import { buildNavigationSnapshot } from "@pwragent/agent-core";
 import { DesktopBackendRegistry } from "../app-server/backend-registry";
 import type { WorktreeArchiveService } from "../app-server/worktree-archive-service";
 
@@ -331,6 +332,34 @@ function createOverlayStoreMock(params?: {
         gitBranch: gitBranch ?? current.gitBranch,
         observedGitBranch: gitBranch ?? current.observedGitBranch,
         extraLinkedDirectories: [directory],
+      } as ThreadOverlayState;
+      overlays.set(key, next);
+      return next;
+    },
+    addLinkedDirectory: async ({
+      backend,
+      threadId,
+      directory,
+    }: {
+      backend: "codex" | "grok";
+      threadId: string;
+      directory: ThreadOverlayState["extraLinkedDirectories"][number];
+    }) => {
+      const key = `${backend}:${threadId}`;
+      const current = overlays.get(key) ?? {
+        backend,
+        threadId,
+        executionMode: "default",
+        extraLinkedDirectories: [],
+      };
+      const next = {
+        ...current,
+        extraLinkedDirectories: [
+          ...current.extraLinkedDirectories.filter(
+            (candidate) => candidate.id !== directory.id,
+          ),
+          directory,
+        ],
       } as ThreadOverlayState;
       overlays.set(key, next);
       return next;
@@ -1284,6 +1313,150 @@ describe("DesktopBackendRegistry", () => {
     expect(codexClient.lastListThreadsParams).toMatchObject({
       enrichDirectories: true,
     });
+
+    await registry.close();
+  });
+
+  it("backfills Codex worktree parent directories so directory view shows one project", async () => {
+    const projectA = "/Users/huntharo/projects/ProjectA";
+    const worktree1 = "/Users/huntharo/.codex/worktrees/wt1/ProjectA";
+    const worktree2 = "/Users/huntharo/.codex/worktrees/wt2/ProjectA";
+    const cheapThreads: AppServerThreadSummary[] = [
+      {
+        id: "project-a-local",
+        title: "ProjectA local",
+        titleSource: "explicit",
+        source: "codex",
+        projectKey: projectA,
+        createdAt: 3_000,
+        updatedAt: 3_000,
+        linkedDirectories: [
+          {
+            id: projectA,
+            label: "ProjectA",
+            path: projectA,
+            kind: "local",
+          },
+        ],
+      },
+      {
+        id: "project-a-worktree-1",
+        title: "ProjectA worktree 1",
+        titleSource: "explicit",
+        source: "codex",
+        projectKey: worktree1,
+        createdAt: 2_000,
+        updatedAt: 2_000,
+        linkedDirectories: [
+          {
+            id: worktree1,
+            label: "ProjectA",
+            path: worktree1,
+            kind: "local",
+          },
+        ],
+      },
+      {
+        id: "project-a-worktree-2",
+        title: "ProjectA worktree 2",
+        titleSource: "explicit",
+        source: "codex",
+        projectKey: worktree2,
+        createdAt: 1_000,
+        updatedAt: 1_000,
+        linkedDirectories: [
+          {
+            id: worktree2,
+            label: "ProjectA",
+            path: worktree2,
+            kind: "local",
+          },
+        ],
+      },
+    ];
+    const enrichedByThreadId = new Map<string, AppServerThreadSummary>(
+      cheapThreads.map((thread) => [
+        thread.id,
+        thread.projectKey === projectA
+          ? thread
+          : {
+              ...thread,
+              linkedDirectories: [
+                {
+                  id: projectA,
+                  label: "ProjectA",
+                  path: projectA,
+                  worktreePath: thread.projectKey,
+                  kind: "worktree" as const,
+                },
+              ],
+            },
+      ]),
+    );
+    const codexClient = new MockBackendClient({
+      threads: cheapThreads,
+    });
+    const enrichThreadDirectories = vi.fn(
+      async (threads: AppServerThreadSummary[]) =>
+        threads.map((thread) => enrichedByThreadId.get(thread.id) ?? thread),
+    );
+    Object.assign(codexClient, { enrichThreadDirectories });
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({}),
+      overlayStore,
+    });
+
+    await registry.listThreads({
+      backend: "codex",
+      callerReason: "startup-prewarm",
+    });
+
+    await expectEventually(
+      async () => {
+        const overlays = await overlayStore.getThreadOverlayStates({
+          backend: "codex",
+          threadIds: ["project-a-worktree-1"],
+        });
+        return overlays["project-a-worktree-1"]?.extraLinkedDirectories[0]?.path;
+      },
+      projectA,
+    );
+
+    const overlaysByThreadId = await overlayStore.getThreadOverlayStates({
+      backend: "codex",
+      threadIds: cheapThreads.map((thread) => thread.id),
+    });
+    const overlayByThreadKey = Object.fromEntries(
+      Object.entries(overlaysByThreadId).map(([threadId, overlay]) => [
+        `codex:${threadId}`,
+        overlay,
+      ]),
+    );
+    const snapshot = buildNavigationSnapshot({
+      backend: "codex",
+      fetchedAt: 4_000,
+      firstSnapshot: false,
+      overlayByThreadKey,
+      previousKnownThreadKeys: [],
+      threads: cheapThreads,
+      unchanged: false,
+    });
+
+    expect(enrichThreadDirectories).toHaveBeenCalledTimes(1);
+    expect(snapshot.directories).toEqual([
+      expect.objectContaining({
+        key: `directory:${projectA}`,
+        label: "ProjectA",
+        path: projectA,
+        threadKeys: [
+          "codex:project-a-local",
+          "codex:project-a-worktree-1",
+          "codex:project-a-worktree-2",
+        ],
+      }),
+    ]);
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1396,9 +1396,14 @@ describe("DesktopBackendRegistry", () => {
     const codexClient = new MockBackendClient({
       threads: cheapThreads,
     });
+    const enrichmentStarted = createDeferred<void>();
+    const enrichmentRelease = createDeferred<void>();
     const enrichThreadDirectories = vi.fn(
-      async (threads: AppServerThreadSummary[]) =>
-        threads.map((thread) => enrichedByThreadId.get(thread.id) ?? thread),
+      async (threads: AppServerThreadSummary[]) => {
+        enrichmentStarted.resolve();
+        await enrichmentRelease.promise;
+        return threads.map((thread) => enrichedByThreadId.get(thread.id) ?? thread);
+      },
     );
     Object.assign(codexClient, { enrichThreadDirectories });
     const overlayStore = createOverlayStoreMock();
@@ -1408,21 +1413,20 @@ describe("DesktopBackendRegistry", () => {
       overlayStore,
     });
 
-    await registry.listThreads({
+    let listResolved = false;
+    const listPromise = registry.listThreads({
       backend: "codex",
       callerReason: "startup-prewarm",
     });
+    void listPromise.then(() => {
+      listResolved = true;
+    });
 
-    await expectEventually(
-      async () => {
-        const overlays = await overlayStore.getThreadOverlayStates({
-          backend: "codex",
-          threadIds: ["project-a-worktree-1"],
-        });
-        return overlays["project-a-worktree-1"]?.extraLinkedDirectories[0]?.path;
-      },
-      projectA,
-    );
+    await enrichmentStarted.promise;
+    await flushAsync();
+    expect(listResolved).toBe(false);
+    enrichmentRelease.resolve();
+    await listPromise;
 
     const overlaysByThreadId = await overlayStore.getThreadOverlayStates({
       backend: "codex",

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AppServerThreadSummary } from "@pwragent/shared";
 import type { JsonRpcTransport } from "../codex-app-server/json-rpc";
 
 const codexClientLogError = vi.hoisted(() => vi.fn());
@@ -1023,6 +1024,57 @@ describe("CodexAppServerClient", () => {
       ],
       source: "codex",
     });
+
+    await client.close();
+  });
+
+  it("preserves thread order while enriching directories concurrently", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const threadDirectoryEnricher = vi.fn(async (projectKey?: string) => {
+      if (projectKey?.includes("slow")) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+
+      return {
+        linkedDirectories: [
+          {
+            id: projectKey ?? "missing",
+            label: path.basename(projectKey ?? "missing"),
+            path: projectKey ?? "missing",
+            kind: "local" as const,
+          },
+        ],
+      };
+    });
+    const client = new CodexAppServerClient({
+      command: "codex",
+      threadDirectoryEnricher,
+    });
+    const threads: AppServerThreadSummary[] = [
+      {
+        id: "slow-thread",
+        title: "Slow thread",
+        titleSource: "explicit",
+        source: "codex",
+        projectKey: "/repo/slow",
+        linkedDirectories: [],
+      },
+      {
+        id: "fast-thread",
+        title: "Fast thread",
+        titleSource: "explicit",
+        source: "codex",
+        projectKey: "/repo/fast",
+        linkedDirectories: [],
+      },
+    ];
+
+    const enriched = await client.enrichThreadDirectories(threads);
+
+    expect(enriched.map((thread) => thread.id)).toEqual([
+      "slow-thread",
+      "fast-thread",
+    ]);
 
     await client.close();
   });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -198,6 +198,9 @@ type BackendClient = {
     params?: { archived?: boolean; enrichDirectories?: boolean; filter?: string },
     diagnostics?: { callerReason?: string; ownerId?: string },
   ): Promise<AppServerThreadSummary[]>;
+  enrichThreadDirectories?(
+    threads: AppServerThreadSummary[],
+  ): Promise<AppServerThreadSummary[]>;
   archiveThread?(params: { threadId: string }): Promise<{ threadId: string }>;
   restoreThread?(params: { threadId: string }): Promise<{ threadId: string }>;
   renameThread?(params: { threadId: string; name: string }): Promise<{ threadId: string }>;
@@ -363,6 +366,66 @@ function buildWorktreeLinkedDirectory(params: {
       worktreePath,
     },
   ];
+}
+
+function isLikelyToolManagedWorktreePath(projectKey: string | undefined): boolean {
+  const normalized = projectKey?.trim();
+  if (!normalized) {
+    return false;
+  }
+
+  return /[\\/](?:\.codex[\\/]worktrees|\.pwrag(?:ent|nt)[\\/]worktrees|\.worktrees)[\\/]/.test(
+    normalized,
+  );
+}
+
+function hasCachedWorktreeDirectory(
+  overlay: ThreadOverlayState | undefined,
+  projectPath: string,
+): boolean {
+  return Boolean(
+    overlay?.extraLinkedDirectories.some((directory) => {
+      if (directory.id !== projectPath) {
+        return false;
+      }
+      return Boolean(directory.worktreePath?.trim());
+    }),
+  );
+}
+
+function buildCachedWorktreeDirectory(
+  thread: AppServerThreadSummary,
+): LinkedDirectorySummary | undefined {
+  const projectKey = thread.projectKey?.trim();
+  if (!projectKey) {
+    return undefined;
+  }
+
+  const projectPath = path.resolve(projectKey);
+  const directory = thread.linkedDirectories.find((candidate) => {
+    const worktreePath = candidate.worktreePath?.trim();
+    if (!worktreePath) {
+      return false;
+    }
+    return path.resolve(worktreePath) === projectPath;
+  });
+  if (!directory) {
+    return undefined;
+  }
+
+  const repositoryPath = path.resolve(directory.path);
+  if (repositoryPath === projectPath) {
+    return undefined;
+  }
+
+  return {
+    ...directory,
+    id: projectPath,
+    kind: "worktree",
+    label: directory.label || path.basename(repositoryPath) || repositoryPath,
+    path: repositoryPath,
+    worktreePath: projectPath,
+  };
 }
 
 function normalizeLinkedDirectoryKind(
@@ -1314,6 +1377,7 @@ export class DesktopBackendRegistry {
   private readonly codexEnvironmentCommandEnv?: NodeJS.ProcessEnv;
   private readonly threadListCacheOwnerId = `backend-thread-list-cache-${++threadListCacheSequence}`;
   private readonly threadListCache = new Map<string, ThreadListCacheState>();
+  private readonly codexDirectoryBackfillProjectKeys = new Set<string>();
   private readonly activeThreadIdsByBackend = new Map<AppServerBackendKind, Set<string>>();
   private readonly pendingStartedThreads = new Map<string, AppServerThreadSummary>();
   private readonly captureStores: ProtocolCaptureStore[] = [];
@@ -4198,6 +4262,13 @@ export class DesktopBackendRegistry {
       backend: "codex",
       threadIds: threadsWithPending.map((thread) => thread.id),
     });
+    if (!params.archived && params.enrichDirectories === false) {
+      this.scheduleCodexDirectoryBackfill({
+        diagnostics,
+        overlaysByThreadId,
+        threads: threadsWithPending,
+      });
+    }
 
     const enrichedThreads = await Promise.all(
       threadsWithPending.map(async (thread) => {
@@ -4220,6 +4291,106 @@ export class DesktopBackendRegistry {
     return enrichedThreads.sort(
       (left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0),
     );
+  }
+
+  private scheduleCodexDirectoryBackfill(params: {
+    diagnostics?: {
+      callerReason?: string;
+      ownerId?: string;
+    };
+    overlaysByThreadId: Record<string, ThreadOverlayState | undefined>;
+    threads: AppServerThreadSummary[];
+  }): void {
+    if (!this.codexClient.enrichThreadDirectories) {
+      return;
+    }
+
+    const candidates = params.threads.filter((thread) => {
+      const projectKey = thread.projectKey?.trim();
+      if (!isLikelyToolManagedWorktreePath(projectKey)) {
+        return false;
+      }
+
+      const projectPath = path.resolve(projectKey!);
+      if (hasCachedWorktreeDirectory(params.overlaysByThreadId[thread.id], projectPath)) {
+        return false;
+      }
+      if (this.codexDirectoryBackfillProjectKeys.has(projectPath)) {
+        return false;
+      }
+
+      return true;
+    });
+    if (candidates.length === 0) {
+      return;
+    }
+
+    for (const thread of candidates) {
+      this.codexDirectoryBackfillProjectKeys.add(path.resolve(thread.projectKey!.trim()));
+    }
+
+    void this.backfillCodexDirectoryRelationships({
+      candidates,
+      diagnostics: params.diagnostics,
+    });
+  }
+
+  private async backfillCodexDirectoryRelationships(params: {
+    candidates: AppServerThreadSummary[];
+    diagnostics?: {
+      callerReason?: string;
+      ownerId?: string;
+    };
+  }): Promise<void> {
+    try {
+      const enrichedThreads = await this.codexClient.enrichThreadDirectories!(
+        params.candidates,
+      );
+      let updatedThreadCount = 0;
+
+      for (const thread of enrichedThreads) {
+        const directory = buildCachedWorktreeDirectory(thread);
+        if (!directory) {
+          continue;
+        }
+
+        await this.overlayStore.addLinkedDirectory({
+          backend: "codex",
+          threadId: thread.id,
+          directory,
+        });
+        updatedThreadCount += 1;
+      }
+
+      if (updatedThreadCount > 0) {
+        await this.emit({
+          backend: "codex",
+          notification: {
+            method: "navigation/threadDirectories/updated",
+            params: {
+              updatedThreadCount,
+            },
+          } as unknown as AppServerNotification,
+        });
+      }
+
+      logDebug("codexDirectoryBackfill:completed", {
+        callerReason: params.diagnostics?.callerReason ?? null,
+        candidateCount: params.candidates.length,
+        updatedThreadCount,
+      });
+    } catch (error) {
+      for (const thread of params.candidates) {
+        const projectKey = thread.projectKey?.trim();
+        if (projectKey) {
+          this.codexDirectoryBackfillProjectKeys.delete(path.resolve(projectKey));
+        }
+      }
+      backendRegistryLog.warn("Codex directory relationship backfill failed", {
+        callerReason: params.diagnostics?.callerReason ?? null,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   private withPendingStartedThreads(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -393,6 +393,14 @@ function hasCachedWorktreeDirectory(
   );
 }
 
+function pathContainsOrEquals(parentPath: string, childPath: string): boolean {
+  const relativePath = path.relative(parentPath, childPath);
+  return (
+    relativePath === "" ||
+    (!relativePath.startsWith("..") && !path.isAbsolute(relativePath))
+  );
+}
+
 function buildCachedWorktreeDirectory(
   thread: AppServerThreadSummary,
 ): LinkedDirectorySummary | undefined {
@@ -407,13 +415,14 @@ function buildCachedWorktreeDirectory(
     if (!worktreePath) {
       return false;
     }
-    return path.resolve(worktreePath) === projectPath;
+    return pathContainsOrEquals(path.resolve(worktreePath), projectPath);
   });
   if (!directory) {
     return undefined;
   }
 
   const repositoryPath = path.resolve(directory.path);
+  const worktreePath = path.resolve(directory.worktreePath!);
   if (repositoryPath === projectPath) {
     return undefined;
   }
@@ -424,7 +433,7 @@ function buildCachedWorktreeDirectory(
     kind: "worktree",
     label: directory.label || path.basename(repositoryPath) || repositoryPath,
     path: repositoryPath,
-    worktreePath: projectPath,
+    worktreePath,
   };
 }
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1377,7 +1377,6 @@ export class DesktopBackendRegistry {
   private readonly codexEnvironmentCommandEnv?: NodeJS.ProcessEnv;
   private readonly threadListCacheOwnerId = `backend-thread-list-cache-${++threadListCacheSequence}`;
   private readonly threadListCache = new Map<string, ThreadListCacheState>();
-  private readonly codexDirectoryBackfillProjectKeys = new Set<string>();
   private readonly activeThreadIdsByBackend = new Map<AppServerBackendKind, Set<string>>();
   private readonly pendingStartedThreads = new Map<string, AppServerThreadSummary>();
   private readonly captureStores: ProtocolCaptureStore[] = [];
@@ -4263,11 +4262,13 @@ export class DesktopBackendRegistry {
       threadIds: threadsWithPending.map((thread) => thread.id),
     });
     if (!params.archived && params.enrichDirectories === false) {
-      this.scheduleCodexDirectoryBackfill({
-        diagnostics,
-        overlaysByThreadId,
-        threads: threadsWithPending,
-      });
+      const updatedOverlaysByThreadId =
+        await this.backfillMissingCodexDirectoryRelationships({
+          diagnostics,
+          overlaysByThreadId,
+          threads: threadsWithPending,
+        });
+      Object.assign(overlaysByThreadId, updatedOverlaysByThreadId);
     }
 
     const enrichedThreads = await Promise.all(
@@ -4293,16 +4294,16 @@ export class DesktopBackendRegistry {
     );
   }
 
-  private scheduleCodexDirectoryBackfill(params: {
+  private async backfillMissingCodexDirectoryRelationships(params: {
     diagnostics?: {
       callerReason?: string;
       ownerId?: string;
     };
     overlaysByThreadId: Record<string, ThreadOverlayState | undefined>;
     threads: AppServerThreadSummary[];
-  }): void {
+  }): Promise<Record<string, ThreadOverlayState | undefined>> {
     if (!this.codexClient.enrichThreadDirectories) {
-      return;
+      return {};
     }
 
     const candidates = params.threads.filter((thread) => {
@@ -4312,41 +4313,21 @@ export class DesktopBackendRegistry {
       }
 
       const projectPath = path.resolve(projectKey!);
-      if (hasCachedWorktreeDirectory(params.overlaysByThreadId[thread.id], projectPath)) {
-        return false;
-      }
-      if (this.codexDirectoryBackfillProjectKeys.has(projectPath)) {
-        return false;
-      }
-
-      return true;
+      return !hasCachedWorktreeDirectory(
+        params.overlaysByThreadId[thread.id],
+        projectPath,
+      );
     });
     if (candidates.length === 0) {
-      return;
+      return {};
     }
 
-    for (const thread of candidates) {
-      this.codexDirectoryBackfillProjectKeys.add(path.resolve(thread.projectKey!.trim()));
-    }
-
-    void this.backfillCodexDirectoryRelationships({
-      candidates,
-      diagnostics: params.diagnostics,
-    });
-  }
-
-  private async backfillCodexDirectoryRelationships(params: {
-    candidates: AppServerThreadSummary[];
-    diagnostics?: {
-      callerReason?: string;
-      ownerId?: string;
-    };
-  }): Promise<void> {
     try {
-      const enrichedThreads = await this.codexClient.enrichThreadDirectories!(
-        params.candidates,
-      );
-      let updatedThreadCount = 0;
+      const enrichedThreads = await this.codexClient.enrichThreadDirectories(candidates);
+      const updatedOverlaysByThreadId: Record<
+        string,
+        ThreadOverlayState | undefined
+      > = {};
 
       for (const thread of enrichedThreads) {
         const directory = buildCachedWorktreeDirectory(thread);
@@ -4354,42 +4335,27 @@ export class DesktopBackendRegistry {
           continue;
         }
 
-        await this.overlayStore.addLinkedDirectory({
-          backend: "codex",
-          threadId: thread.id,
-          directory,
-        });
-        updatedThreadCount += 1;
-      }
-
-      if (updatedThreadCount > 0) {
-        await this.emit({
-          backend: "codex",
-          notification: {
-            method: "navigation/threadDirectories/updated",
-            params: {
-              updatedThreadCount,
-            },
-          } as unknown as AppServerNotification,
-        });
+        updatedOverlaysByThreadId[thread.id] =
+          await this.overlayStore.addLinkedDirectory({
+            backend: "codex",
+            threadId: thread.id,
+            directory,
+          });
       }
 
       logDebug("codexDirectoryBackfill:completed", {
         callerReason: params.diagnostics?.callerReason ?? null,
-        candidateCount: params.candidates.length,
-        updatedThreadCount,
+        candidateCount: candidates.length,
+        updatedThreadCount: Object.keys(updatedOverlaysByThreadId).length,
       });
+
+      return updatedOverlaysByThreadId;
     } catch (error) {
-      for (const thread of params.candidates) {
-        const projectKey = thread.projectKey?.trim();
-        if (projectKey) {
-          this.codexDirectoryBackfillProjectKeys.delete(path.resolve(projectKey));
-        }
-      }
       backendRegistryLog.warn("Codex directory relationship backfill failed", {
         callerReason: params.diagnostics?.callerReason ?? null,
         error: error instanceof Error ? error.message : String(error),
       });
+      return {};
     }
   }
 

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -4073,20 +4073,26 @@ export class CodexAppServerClient {
   private async enrichRawThreadDirectories(
     threads: RawCodexThreadSummary[],
   ): Promise<EnrichedCodexThread[]> {
-    const enrichedThreads: EnrichedCodexThread[] = [];
+    const enrichedThreads: Array<EnrichedCodexThread | undefined> = [];
 
     for await (const enrichedThread of new IterableMapper(
-      threads,
-      async (thread): Promise<EnrichedCodexThread> => {
+      threads.map((thread, index) => ({ index, thread })),
+      async ({ index, thread }): Promise<{
+        index: number;
+        thread: EnrichedCodexThread;
+      }> => {
         const projectKey = await resolveThreadProjectKey(thread);
         const enrichment = await this.threadDirectoryEnricher(projectKey);
         return {
-          ...thread,
-          projectKey,
-          gitBranch: thread.gitBranch,
-          linkedDirectories: enrichment.linkedDirectories,
-          observedGitBranch: enrichment.observedGitBranch,
-          source: "codex" as const,
+          index,
+          thread: {
+            ...thread,
+            projectKey,
+            gitBranch: thread.gitBranch,
+            linkedDirectories: enrichment.linkedDirectories,
+            observedGitBranch: enrichment.observedGitBranch,
+            source: "codex" as const,
+          },
         };
       },
       {
@@ -4094,10 +4100,12 @@ export class CodexAppServerClient {
         maxUnread: THREAD_DIRECTORY_ENRICHMENT_MAX_UNREAD,
       },
     )) {
-      enrichedThreads.push(enrichedThread);
+      enrichedThreads[enrichedThread.index] = enrichedThread.thread;
     }
 
-    return enrichedThreads;
+    return enrichedThreads.filter(
+      (thread): thread is EnrichedCodexThread => Boolean(thread),
+    );
   }
 
   async listSkills(params?: {

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -59,6 +59,7 @@ import type {
   TurnSteerParams as CodexTurnSteerParams,
   UserInput as CodexUserInput,
 } from "@pwragent/codex-app-server-protocol/v2";
+import { IterableMapper } from "@shutterstock/p-map-iterable";
 import {
   JsonRpcConnection,
   type JsonRpcId,
@@ -3115,6 +3116,9 @@ type EnrichedCodexThread = AppServerThreadSummary & {
   gitOriginUrl?: string;
 };
 
+const THREAD_DIRECTORY_ENRICHMENT_CONCURRENCY = 8;
+const THREAD_DIRECTORY_ENRICHMENT_MAX_UNREAD = 16;
+
 function hydrateMissingLinkedDirectoriesFromSiblingRepos(
   threads: EnrichedCodexThread[]
 ): EnrichedCodexThread[] {
@@ -4052,8 +4056,28 @@ export class CodexAppServerClient {
       });
     }
 
-    const enrichedThreads = await Promise.all(
-      threads.map(async (thread) => {
+    const enrichedThreads = await this.enrichRawThreadDirectories(threads);
+
+    return hydrateMissingLinkedDirectoriesFromSiblingRepos(enrichedThreads);
+  }
+
+  async enrichThreadDirectories(
+    threads: AppServerThreadSummary[],
+  ): Promise<AppServerThreadSummary[]> {
+    const enrichedThreads = await this.enrichRawThreadDirectories(
+      threads as RawCodexThreadSummary[],
+    );
+    return hydrateMissingLinkedDirectoriesFromSiblingRepos(enrichedThreads);
+  }
+
+  private async enrichRawThreadDirectories(
+    threads: RawCodexThreadSummary[],
+  ): Promise<EnrichedCodexThread[]> {
+    const enrichedThreads: EnrichedCodexThread[] = [];
+
+    for await (const enrichedThread of new IterableMapper(
+      threads,
+      async (thread): Promise<EnrichedCodexThread> => {
         const projectKey = await resolveThreadProjectKey(thread);
         const enrichment = await this.threadDirectoryEnricher(projectKey);
         return {
@@ -4062,12 +4086,18 @@ export class CodexAppServerClient {
           gitBranch: thread.gitBranch,
           linkedDirectories: enrichment.linkedDirectories,
           observedGitBranch: enrichment.observedGitBranch,
-          source: "codex" as const
+          source: "codex" as const,
         };
-      })
-    );
+      },
+      {
+        concurrency: THREAD_DIRECTORY_ENRICHMENT_CONCURRENCY,
+        maxUnread: THREAD_DIRECTORY_ENRICHMENT_MAX_UNREAD,
+      },
+    )) {
+      enrichedThreads.push(enrichedThread);
+    }
 
-    return hydrateMissingLinkedDirectoriesFromSiblingRepos(enrichedThreads);
+    return enrichedThreads;
   }
 
   async listSkills(params?: {

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -1565,11 +1565,6 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
         return;
       }
 
-      if (method === "navigation/threadDirectories/updated") {
-        scheduleRefresh();
-        return;
-      }
-
       if (method === "thread/name/updated") {
         const { threadId, threadName } = event.notification.params as {
           threadId: string;

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -1565,6 +1565,11 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
         return;
       }
 
+      if (method === "navigation/threadDirectories/updated") {
+        scheduleRefresh();
+        return;
+      }
+
       if (method === "thread/name/updated") {
         const { threadId, threadName } = event.notification.params as {
           threadId: string;


### PR DESCRIPTION
## Summary

- I restored Codex worktree directory consolidation while keeping the already-populated sqlite path fast.
- Cheap Codex thread lists now synchronously backfill only missing tool-managed worktree parent relationships; once the enriched parent repo/worktree relationship exists in the thread overlay sqlite payload, later navigation snapshots do not wait on git.
- Directory enrichment still uses `@shutterstock/p-map-iterable` with bounded concurrency, and the client now preserves the original thread order after concurrent enrichment.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/main/__tests__/codex-client.test.ts packages/agent-core/src/__tests__/directory-navigation.test.ts`
- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm --filter @pwragent/agent-core typecheck`
- `pnpm lint:boundaries`

## Notes

- Regression coverage now asserts that ProjectA local plus two Codex worktrees render as one ProjectA directory row with all three thread children, not three distinct ProjectA folders.
