### PR TITLE
fix(desktop): auto-close stale context rail

### DIFF
--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -27,6 +27,8 @@ const registerRuntimeIdentityIpcHandlersMock = vi.fn();
 const disposeRuntimeIdentityIpcHandlersMock = vi.fn();
 const registerSettingsIpcHandlersMock = vi.fn();
 const disposeSettingsIpcHandlersMock = vi.fn();
+const registerWindowPointerIpcHandlersMock = vi.fn();
+const disposeWindowPointerIpcHandlersMock = vi.fn();
 const initializeMainLoggerMock = vi.fn();
 const mainLogInfoMock = vi.fn();
 const mainLogWarnMock = vi.fn();
@@ -165,6 +167,11 @@ vi.mock("../ipc/settings", () => ({
   disposeSettingsIpcHandlers: disposeSettingsIpcHandlersMock,
 }));
 
+vi.mock("../ipc/window-pointer", () => ({
+  registerWindowPointerIpcHandlers: registerWindowPointerIpcHandlersMock,
+  disposeWindowPointerIpcHandlers: disposeWindowPointerIpcHandlersMock,
+}));
+
 vi.mock("../log", () => ({
   initializeMainLogger: initializeMainLoggerMock,
   getMainLogger: vi.fn(() => ({
@@ -253,6 +260,8 @@ describe("bootstrapApp", () => {
     disposeRuntimeIdentityIpcHandlersMock.mockReset();
     registerSettingsIpcHandlersMock.mockReset();
     disposeSettingsIpcHandlersMock.mockReset();
+    registerWindowPointerIpcHandlersMock.mockReset();
+    disposeWindowPointerIpcHandlersMock.mockReset();
     initializeMainLoggerMock.mockReset();
     mainLogInfoMock.mockReset();
     mainLogWarnMock.mockReset();
@@ -337,6 +346,7 @@ describe("bootstrapApp", () => {
     expect(registerPreloadLogIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(registerRendererErrorIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(registerSettingsIpcHandlersMock).toHaveBeenCalledTimes(1);
+    expect(registerWindowPointerIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(registerRuntimeIdentityIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(setApplicationMenuMock).toHaveBeenCalledTimes(1);
   });
@@ -455,6 +465,7 @@ describe("bootstrapApp", () => {
     appEventHandlers.get("before-quit")?.();
     expect(disposeApplicationIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(disposeSettingsIpcHandlersMock).toHaveBeenCalledTimes(1);
+    expect(disposeWindowPointerIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(disposeRuntimeIdentityIpcHandlersMock).not.toHaveBeenCalled();
     expect(disposeDesktopMessagingRuntimeMock).toHaveBeenCalledTimes(1);
   });

--- a/apps/desktop/src/main/__tests__/window-pointer-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/window-pointer-ipc.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const handlers = new Map<string, (...args: unknown[]) => Promise<unknown>>();
+const getContentBoundsMock = vi.fn();
+const isFocusedMock = vi.fn();
+const getCursorScreenPointMock = vi.fn();
+const fromWebContentsMock = vi.fn();
+
+vi.mock("electron", () => ({
+  BrowserWindow: {
+    fromWebContents: fromWebContentsMock,
+  },
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => Promise<unknown>) => {
+      handlers.set(channel, handler);
+    }),
+    removeHandler: vi.fn((channel: string) => {
+      handlers.delete(channel);
+    }),
+  },
+  screen: {
+    getCursorScreenPoint: getCursorScreenPointMock,
+  },
+}));
+
+describe("window pointer ipc", () => {
+  beforeEach(() => {
+    handlers.clear();
+    getContentBoundsMock.mockReset();
+    getCursorScreenPointMock.mockReset();
+    isFocusedMock.mockReset();
+    fromWebContentsMock.mockReset();
+  });
+
+  it("returns cursor position and sender content bounds", async () => {
+    const { registerWindowPointerIpcHandlers, disposeWindowPointerIpcHandlers } =
+      await import("../ipc/window-pointer");
+    const { WINDOW_POINTER_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+
+    getContentBoundsMock.mockReturnValue({
+      height: 800,
+      width: 1200,
+      x: 100,
+      y: 80,
+    });
+    getCursorScreenPointMock.mockReturnValue({
+      x: 1180,
+      y: 220,
+    });
+    isFocusedMock.mockReturnValue(false);
+    fromWebContentsMock.mockReturnValue({
+      getContentBounds: getContentBoundsMock,
+      isFocused: isFocusedMock,
+    });
+
+    registerWindowPointerIpcHandlers();
+
+    await expect(
+      handlers.get(WINDOW_POINTER_SNAPSHOT_CHANNEL)?.({
+        sender: { id: 1 },
+      }),
+    ).resolves.toEqual({
+      contentBounds: {
+        height: 800,
+        width: 1200,
+        x: 100,
+        y: 80,
+      },
+      cursor: {
+        x: 1180,
+        y: 220,
+      },
+      windowFocused: false,
+    });
+
+    disposeWindowPointerIpcHandlers();
+    expect(handlers.has(WINDOW_POINTER_SNAPSHOT_CHANNEL)).toBe(false);
+  });
+});

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -43,6 +43,10 @@ import {
   disposeSettingsIpcHandlers,
   registerSettingsIpcHandlers,
 } from "./ipc/settings";
+import {
+  disposeWindowPointerIpcHandlers,
+  registerWindowPointerIpcHandlers,
+} from "./ipc/window-pointer";
 import { getMainLogger, initializeMainLogger } from "./log";
 import { StartupCpuProfiler } from "./diagnostics/startup-cpu-profiler";
 import {
@@ -110,6 +114,7 @@ function disposeMainProcessResourcesSync(): void {
   disposePreloadLogIpcHandlers();
   disposeProfilesIpcHandlers();
   disposeSettingsIpcHandlers();
+  disposeWindowPointerIpcHandlers();
   if (isDevelopment) {
     disposeRuntimeIdentityIpcHandlers();
   }
@@ -219,6 +224,7 @@ export function bootstrapApp(): void {
     registerProfilesIpcHandlers();
     registerRendererErrorIpcHandlers();
     registerSettingsIpcHandlers();
+    registerWindowPointerIpcHandlers();
     if (isDevelopment) {
       registerRuntimeIdentityIpcHandlers();
     }

--- a/apps/desktop/src/main/ipc/window-pointer.ts
+++ b/apps/desktop/src/main/ipc/window-pointer.ts
@@ -1,0 +1,30 @@
+import { BrowserWindow, ipcMain, screen } from "electron";
+import { WINDOW_POINTER_SNAPSHOT_CHANNEL } from "../../shared/ipc";
+import type { WindowPointerSnapshot } from "../../shared/window-pointer";
+
+export function registerWindowPointerIpcHandlers(): void {
+  ipcMain.removeHandler(WINDOW_POINTER_SNAPSHOT_CHANNEL);
+  ipcMain.handle(
+    WINDOW_POINTER_SNAPSHOT_CHANNEL,
+    async (event): Promise<WindowPointerSnapshot> => {
+      const window = BrowserWindow.fromWebContents(event.sender);
+      const contentBounds =
+        window?.getContentBounds() ?? {
+          height: 0,
+          width: 0,
+          x: 0,
+          y: 0,
+        };
+
+      return {
+        contentBounds,
+        cursor: screen.getCursorScreenPoint(),
+        windowFocused: Boolean(window?.isFocused()),
+      };
+    },
+  );
+}
+
+export function disposeWindowPointerIpcHandlers(): void {
+  ipcMain.removeHandler(WINDOW_POINTER_SNAPSHOT_CHANNEL);
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -226,8 +226,10 @@ import {
   SETTINGS_TEST_CREDENTIALS_CHANNEL,
   SETTINGS_WRITE_CONFIG_CHANNEL,
   WINDOW_FOCUS_SYNC_CHANNEL,
+  WINDOW_POINTER_SNAPSHOT_CHANNEL,
 } from "../shared/ipc";
 import type { RuntimeIdentity } from "../shared/runtime-identity";
+import type { WindowPointerSnapshot } from "../shared/window-pointer";
 import type {
   AppChangelogDocument,
   AppLogEntry,
@@ -574,6 +576,8 @@ const desktopApi = Object.freeze({
       ipcRenderer.off(WINDOW_FOCUS_SYNC_CHANNEL, listener);
     };
   },
+  getWindowPointerSnapshot: async (): Promise<WindowPointerSnapshot> =>
+    await ipcRenderer.invoke(WINDOW_POINTER_SNAPSHOT_CHANNEL),
   onAgentEvent: (callback: (event: AgentEvent) => void): (() => void) => {
     const listener = (_event: Electron.IpcRendererEvent, payload: AgentEvent) =>
       callback(payload);

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -17,8 +17,10 @@ import type {
   NavigationThreadSummary,
   WorktreeSnapshotSummary,
 } from "@pwragent/shared";
+import type { WindowPointerSnapshot } from "../../../../shared/window-pointer";
 import { FolderIcon, WorktreeIcon } from "../../icons";
 import { copyText, formatCopyTooltip } from "../../lib/copy-text";
+import type { DesktopApi } from "../../lib/desktop-api";
 import { formatExecutionModeLabel } from "../../lib/execution-mode";
 import {
   formatBackendAccountText,
@@ -26,9 +28,13 @@ import {
   selectVisibleRateLimits,
 } from "../../lib/backend-status-format";
 
+const HOVER_RAIL_POINTER_POLL_MS = 500;
+const HOVER_RAIL_OFF_TARGET_CLOSE_MS = 2_500;
+
 type ThreadContextPanelProps = {
   backendError?: string;
   backends: BackendSummary[];
+  desktopApi?: Pick<DesktopApi, "getWindowPointerSnapshot">;
   onPinnedChange?: (pinned: boolean) => void;
   onResizingChange?: (resizing: boolean) => void;
   onWidthChange?: (width: number) => void;
@@ -61,12 +67,14 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
   const open = pinned || revealed;
   const hideTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const lastMousePositionRef = useRef<{ x: number; y: number } | undefined>(undefined);
+  const outsideRailSinceRef = useRef<number | undefined>(undefined);
 
   const rememberMousePosition = useCallback((event: MouseEvent<HTMLElement>) => {
     lastMousePositionRef.current = {
       x: event.clientX,
       y: event.clientY,
     };
+    outsideRailSinceRef.current = undefined;
   }, []);
 
   const isMouseInsideRail = useCallback((point: { x: number; y: number }) => {
@@ -88,6 +96,26 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
     );
   }, []);
 
+  const isScreenCursorInsideRail = useCallback(
+    (snapshot: WindowPointerSnapshot) => {
+      if (snapshot.contentBounds.width <= 0 || snapshot.contentBounds.height <= 0) {
+        return false;
+      }
+
+      return isMouseInsideRail({
+        x: snapshot.cursor.x - snapshot.contentBounds.x,
+        y: snapshot.cursor.y - snapshot.contentBounds.y,
+      });
+    },
+    [isMouseInsideRail]
+  );
+
+  const hideRailNow = useCallback(() => {
+    clearTimeout(hideTimerRef.current);
+    outsideRailSinceRef.current = undefined;
+    setRevealed(false);
+  }, []);
+
   // Debounced reveal/hide prevents flicker from CSS transform transitions
   // causing spurious mouseenter→mouseleave sequences. The final hit test
   // keeps the rail open when an inactive window reports a transient leave
@@ -95,6 +123,7 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
   // inside the opened rail.
   const revealRail = useCallback(() => {
     clearTimeout(hideTimerRef.current);
+    outsideRailSinceRef.current = undefined;
     setRevealed(true);
   }, []);
 
@@ -107,10 +136,10 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
           return;
         }
 
-        setRevealed(false);
+        hideRailNow();
       }, 300);
     },
-    [isMouseInsideRail]
+    [hideRailNow, isMouseInsideRail]
   );
 
   useEffect(() => {
@@ -118,6 +147,81 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
       clearTimeout(hideTimerRef.current);
     };
   }, []);
+
+  useEffect(() => {
+    if (pinned || !revealed) {
+      return;
+    }
+
+    const handleDocumentMouseMove = (event: globalThis.MouseEvent): void => {
+      const point = {
+        x: event.clientX,
+        y: event.clientY,
+      };
+      lastMousePositionRef.current = point;
+
+      if (isMouseInsideRail(point)) {
+        outsideRailSinceRef.current = undefined;
+        return;
+      }
+
+      hideRail(point);
+    };
+
+    document.addEventListener("mousemove", handleDocumentMouseMove, true);
+    return () => {
+      document.removeEventListener("mousemove", handleDocumentMouseMove, true);
+    };
+  }, [hideRail, isMouseInsideRail, pinned, revealed]);
+
+  useEffect(() => {
+    const readPointerSnapshot = props.desktopApi?.getWindowPointerSnapshot;
+    if (pinned || !revealed || !readPointerSnapshot) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const checkPointer = async (): Promise<void> => {
+      try {
+        const snapshot = await readPointerSnapshot();
+        if (cancelled) {
+          return;
+        }
+
+        if (isScreenCursorInsideRail(snapshot)) {
+          outsideRailSinceRef.current = undefined;
+          return;
+        }
+
+        const now = Date.now();
+        const outsideSince = outsideRailSinceRef.current ?? now;
+        outsideRailSinceRef.current = outsideSince;
+        if (now - outsideSince >= HOVER_RAIL_OFF_TARGET_CLOSE_MS) {
+          hideRailNow();
+        }
+      } catch {
+        // Cursor polling is a best-effort Electron affordance; renderer
+        // mousemove and mouseleave still cover the normal browser path.
+      }
+    };
+
+    void checkPointer();
+    const intervalId = window.setInterval(() => {
+      void checkPointer();
+    }, HOVER_RAIL_POINTER_POLL_MS);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+    };
+  }, [
+    hideRailNow,
+    isScreenCursorInsideRail,
+    pinned,
+    props.desktopApi?.getWindowPointerSnapshot,
+    revealed,
+  ]);
 
   useLayoutEffect(() => {
     if (!tooltip || tooltip.left !== undefined) {

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -29,7 +29,7 @@ import {
 } from "../../lib/backend-status-format";
 
 const HOVER_RAIL_POINTER_POLL_MS = 500;
-const HOVER_RAIL_OFF_TARGET_CLOSE_MS = 2_500;
+const HOVER_RAIL_OFF_TARGET_CLOSE_MS = 1_200;
 
 type ThreadContextPanelProps = {
   backendError?: string;

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1987,6 +1987,7 @@ export function ThreadView(props: ThreadViewProps) {
         <ThreadContextPanel
           backendError={props.backendError}
           backends={props.backends}
+          desktopApi={props.desktopApi}
           onPinnedChange={setContextRailPinned}
           onResizingChange={setContextRailResizing}
           onWidthChange={setContextRailWidth}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -81,6 +81,134 @@ const baseBackend: BackendSummary = {
 };
 
 describe("ThreadContextPanel", () => {
+  it("hides the hover rail when document mouse movement resumes outside the rail", () => {
+    vi.useFakeTimers();
+    render(
+      <ThreadContextPanel backends={[baseBackend]} pinned={false} thread={baseThread} />
+    );
+
+    const rail = screen.getByLabelText("Thread context");
+    vi.spyOn(rail, "getBoundingClientRect").mockReturnValue({
+      bottom: 800,
+      height: 800,
+      left: 620,
+      right: 1000,
+      top: 0,
+      width: 380,
+      x: 620,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    fireEvent.mouseEnter(rail, { clientX: 980, clientY: 120 });
+    expect(screen.getByText("Auto-hide")).toBeInTheDocument();
+
+    fireEvent.mouseMove(document, { clientX: 600, clientY: 120 });
+    act(() => {
+      vi.advanceTimersByTime(301);
+    });
+
+    expect(screen.queryByText("Auto-hide")).not.toBeInTheDocument();
+  });
+
+  it("polls the window pointer and closes when the cursor remains outside the rail", async () => {
+    vi.useFakeTimers();
+    const getWindowPointerSnapshot = vi.fn(async () => ({
+      contentBounds: {
+        height: 800,
+        width: 1000,
+        x: 100,
+        y: 100,
+      },
+      cursor: {
+        x: 700,
+        y: 220,
+      },
+      windowFocused: false,
+    }));
+
+    render(
+      <ThreadContextPanel
+        backends={[baseBackend]}
+        desktopApi={{ getWindowPointerSnapshot }}
+        pinned={false}
+        thread={baseThread}
+      />
+    );
+
+    const rail = screen.getByLabelText("Thread context");
+    vi.spyOn(rail, "getBoundingClientRect").mockReturnValue({
+      bottom: 800,
+      height: 800,
+      left: 620,
+      right: 1000,
+      top: 0,
+      width: 380,
+      x: 620,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    fireEvent.mouseEnter(rail, { clientX: 980, clientY: 120 });
+    expect(screen.getByText("Auto-hide")).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3_001);
+    });
+
+    expect(getWindowPointerSnapshot).toHaveBeenCalled();
+    expect(screen.queryByText("Auto-hide")).not.toBeInTheDocument();
+  });
+
+  it("keeps the hover rail open while the polled cursor remains inside the rail", async () => {
+    vi.useFakeTimers();
+    const getWindowPointerSnapshot = vi.fn(async () => ({
+      contentBounds: {
+        height: 800,
+        width: 1000,
+        x: 100,
+        y: 100,
+      },
+      cursor: {
+        x: 1080,
+        y: 220,
+      },
+      windowFocused: false,
+    }));
+
+    render(
+      <ThreadContextPanel
+        backends={[baseBackend]}
+        desktopApi={{ getWindowPointerSnapshot }}
+        pinned={false}
+        thread={baseThread}
+      />
+    );
+
+    const rail = screen.getByLabelText("Thread context");
+    vi.spyOn(rail, "getBoundingClientRect").mockReturnValue({
+      bottom: 800,
+      height: 800,
+      left: 620,
+      right: 1000,
+      top: 0,
+      width: 380,
+      x: 620,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    fireEvent.mouseEnter(rail, { clientX: 980, clientY: 120 });
+    expect(screen.getByText("Auto-hide")).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4_000);
+    });
+
+    expect(getWindowPointerSnapshot).toHaveBeenCalled();
+    expect(screen.getByText("Auto-hide")).toBeInTheDocument();
+  });
+
   it("keeps the hover rail open when a transient leave is still inside the opened rail", () => {
     vi.useFakeTimers();
     render(

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -153,7 +153,7 @@ describe("ThreadContextPanel", () => {
     expect(screen.getByText("Auto-hide")).toBeInTheDocument();
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(3_001);
+      await vi.advanceTimersByTimeAsync(1_701);
     });
 
     expect(getWindowPointerSnapshot).toHaveBeenCalled();
@@ -202,7 +202,7 @@ describe("ThreadContextPanel", () => {
     expect(screen.getByText("Auto-hide")).toBeInTheDocument();
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(4_000);
+      await vi.advanceTimersByTimeAsync(2_000);
     });
 
     expect(getWindowPointerSnapshot).toHaveBeenCalled();

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -138,6 +138,7 @@ import type {
   WriteDesktopSettingsConfigRequest,
 } from "@pwragent/shared";
 import type { RuntimeIdentity } from "../../../shared/runtime-identity";
+import type { WindowPointerSnapshot } from "../../../shared/window-pointer";
 import type {
   AppChangelogDocument,
   AppLogEntry,
@@ -389,6 +390,7 @@ export type DesktopApi = {
   /** Spawns or focuses the dedicated Messaging Activity window. */
   openMessagingActivityWindow?: () => Promise<void>;
   onWindowFocus?: (callback: () => void) => () => void;
+  getWindowPointerSnapshot?: () => Promise<WindowPointerSnapshot>;
   platform?: string;
   versions?: {
     chrome?: string;

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -132,6 +132,7 @@ export const IMAGE_UPLOAD_NORMALIZATION_LOG_CHANNEL =
   "image-upload:normalization-log";
 export const PRELOAD_LOG_CHANNEL = "preload:log";
 export const WINDOW_FOCUS_SYNC_CHANNEL = "window:focus-sync";
+export const WINDOW_POINTER_SNAPSHOT_CHANNEL = "window:pointer-snapshot";
 export const RUNTIME_IDENTITY_CHANNEL = "runtime:get-identity";
 export const SETTINGS_READ_CHANNEL = "settings:read";
 export const SETTINGS_WRITE_CONFIG_CHANNEL = "settings:write-config";

--- a/apps/desktop/src/shared/window-pointer.ts
+++ b/apps/desktop/src/shared/window-pointer.ts
@@ -1,0 +1,13 @@
+export type WindowPointerSnapshot = {
+  contentBounds: {
+    height: number;
+    width: number;
+    x: number;
+    y: number;
+  };
+  cursor: {
+    x: number;
+    y: number;
+  };
+  windowFocused: boolean;
+};


### PR DESCRIPTION
## Summary

I fixed a follow-up right context rail hover case where the rail could stay stuck open after the cursor moved over another app/window and PwrAgent never received a normal mouseleave.

This builds on #402. The rail still stays open when the cursor is actually over it, including inactive-window hover, but it now closes after a short grace period when Electron's global cursor position shows the cursor is no longer over the rail.

## Changes

- Added a small Electron IPC snapshot for the sender window's content bounds and current global cursor position.
- Poll the cursor while the auto-hide context rail is revealed and close after the cursor remains outside the rail for a few seconds.
- Added a document-level mousemove fallback so the rail closes immediately when mouse movement resumes inside PwrAgent outside the rail.
- Added renderer regression tests for document movement, cursor-poll close, and cursor-poll stay-open behavior.
- Added main-process IPC coverage and boot registration coverage for the new pointer snapshot handler.

## Verification

I verified this with:

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx`
- `pnpm test apps/desktop/src/main/__tests__/window-pointer-ipc.test.ts apps/desktop/src/main/__tests__/index.test.ts`
- `pnpm test apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`
- `pnpm --filter @pwragent/desktop test:e2e e2e/context-rail-linked-directory-tooltips.spec.ts`
