### PR TITLE
fix(desktop): repair selected worktree directory metadata

### DIFF
--- a/apps/desktop/e2e/thread-archive-worktree-cleanup.spec.ts
+++ b/apps/desktop/e2e/thread-archive-worktree-cleanup.spec.ts
@@ -134,6 +134,12 @@ async function createArchiveWorktreeFixture(): Promise<{
             result: [thread],
           },
           {
+            id: "thread-list-pre-archive-refresh",
+            kind: "response",
+            method: "thread/list",
+            result: [thread],
+          },
+          {
             id: "thread-archive-1",
             kind: "response",
             method: "thread/archive",

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1485,6 +1485,184 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
+  it("repairs a selected Codex worktree thread with a single-thread directory enrichment", async () => {
+    const projectA = "/Users/example/ProjectA";
+    const worktreePath = "/Users/example/.codex/worktrees/worktree-1/ProjectA";
+    const nestedWorktreeCwd = `${worktreePath}/apps/desktop`;
+    const cheapThread: AppServerThreadSummary = {
+      id: "thread-1",
+      title: "ProjectA worktree",
+      titleSource: "explicit",
+      source: "codex",
+      projectKey: nestedWorktreeCwd,
+      createdAt: 1_000,
+      updatedAt: 2_000,
+      linkedDirectories: [
+        {
+          id: nestedWorktreeCwd,
+          label: "desktop",
+          path: nestedWorktreeCwd,
+          kind: "local",
+        },
+      ],
+    };
+    const codexClient = new MockBackendClient({
+      threads: [cheapThread],
+    });
+    const enrichThreadDirectories = vi.fn(
+      async (threads: AppServerThreadSummary[]) =>
+        threads.map((thread) => ({
+          ...thread,
+          linkedDirectories: [
+            {
+              id: projectA,
+              label: "ProjectA",
+              path: projectA,
+              worktreePath,
+              kind: "worktree" as const,
+            },
+          ],
+        })),
+    );
+    Object.assign(codexClient, { enrichThreadDirectories });
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({}),
+      overlayStore,
+    });
+    const events: AgentEvent[] = [];
+    const unsubscribe = registry.onEvent((event) => {
+      events.push(event);
+    });
+
+    await registry.readThread({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    expect(enrichThreadDirectories).toHaveBeenCalledTimes(1);
+    expect(enrichThreadDirectories).toHaveBeenCalledWith([cheapThread]);
+    await expect(
+      overlayStore.getThreadOverlayState({ backend: "codex", threadId: "thread-1" }),
+    ).resolves.toMatchObject({
+      extraLinkedDirectories: [
+        expect.objectContaining({
+          id: nestedWorktreeCwd,
+          path: projectA,
+          worktreePath,
+          kind: "worktree",
+        }),
+      ],
+    });
+    expect(events).toContainEqual({
+      backend: "codex",
+      notification: {
+        method: "navigation/threadDirectories/updated",
+        params: {
+          reason: "selected-thread",
+          threadIds: ["thread-1"],
+        },
+      },
+    });
+
+    unsubscribe();
+    await registry.close();
+  });
+
+  it("runs the full Codex directory reconcile once after three distinct selected-thread repairs", async () => {
+    const projectA = "/Users/example/ProjectA";
+    const makeCheapThread = (index: number): AppServerThreadSummary => {
+      const projectKey = `/Users/example/.codex/worktrees/worktree-${index}/ProjectA`;
+      return {
+        id: `thread-${index}`,
+        title: `ProjectA worktree ${index}`,
+        titleSource: "explicit",
+        source: "codex",
+        projectKey,
+        createdAt: 1_000 + index,
+        updatedAt: 2_000 + index,
+        linkedDirectories: [
+          {
+            id: projectKey,
+            label: `worktree-${index}`,
+            path: projectKey,
+            kind: "local",
+          },
+        ],
+      };
+    };
+    const cheapThreads = [1, 2, 3, 4, 5].map(makeCheapThread);
+    const codexClient = new MockBackendClient({
+      threads: cheapThreads,
+    });
+    const enrichThreadDirectories = vi.fn(
+      async (threads: AppServerThreadSummary[]) =>
+        threads.map((thread) => ({
+          ...thread,
+          linkedDirectories: [
+            {
+              id: projectA,
+              label: "ProjectA",
+              path: projectA,
+              worktreePath: thread.projectKey,
+              kind: "worktree" as const,
+            },
+          ],
+        })),
+    );
+    Object.assign(codexClient, { enrichThreadDirectories });
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({}),
+      overlayStore,
+    });
+    const events: AgentEvent[] = [];
+    const unsubscribe = registry.onEvent((event) => {
+      events.push(event);
+    });
+
+    await registry.readThread({ backend: "codex", threadId: "thread-1" });
+    await registry.readThread({ backend: "codex", threadId: "thread-2" });
+    const fullReconcileCalls = () =>
+      enrichThreadDirectories.mock.calls.filter(([threads]) => threads.length > 1);
+    expect(fullReconcileCalls()).toHaveLength(0);
+    await registry.readThread({ backend: "codex", threadId: "thread-3" });
+
+    await waitForCondition(() =>
+      enrichThreadDirectories.mock.calls.some(
+        ([threads]) =>
+          threads.length === 2 &&
+          threads.map((thread) => thread.id).join(",") === "thread-4,thread-5",
+      ),
+    );
+    expect(fullReconcileCalls()).toHaveLength(1);
+    const hasFullReconcileEvent = () =>
+      events.some(
+        (event) =>
+          event.backend === "codex" &&
+          event.notification.method === "navigation/threadDirectories/updated" &&
+          (event.notification.params as { reason?: string; threadIds?: string[] })
+            .reason === "full-reconcile" &&
+          (event.notification.params as { threadIds?: string[] }).threadIds?.join(
+            ",",
+          ) === "thread-4,thread-5",
+      );
+    await waitForCondition(hasFullReconcileEvent);
+    expect(hasFullReconcileEvent()).toBe(true);
+
+    const lateThread = makeCheapThread(6);
+    codexClient.setThreads([...cheapThreads, lateThread]);
+    await registry.readThread({ backend: "codex", threadId: "thread-6" });
+    await flushAsync();
+
+    expect(fullReconcileCalls()).toHaveLength(1);
+
+    unsubscribe();
+    await registry.close();
+  });
+
   it("uses cheap thread summaries for selected-thread branch drift checks", async () => {
     const codexClient = new MockBackendClient({
       threads: [

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1485,6 +1485,81 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
+  it("does not let non-backfilling cheap list cache suppress navigation backfill", async () => {
+    const projectA = "/Users/huntharo/projects/ProjectA";
+    const worktreePath = "/Users/huntharo/.codex/worktrees/wt1/ProjectA";
+    const cheapThread: AppServerThreadSummary = {
+      id: "thread-1",
+      title: "ProjectA worktree",
+      titleSource: "explicit",
+      source: "codex",
+      projectKey: worktreePath,
+      createdAt: 1_000,
+      updatedAt: 1_000,
+      linkedDirectories: [
+        {
+          id: worktreePath,
+          label: "ProjectA",
+          path: worktreePath,
+          kind: "local",
+        },
+      ],
+    };
+    const codexClient = new MockBackendClient({
+      threads: [cheapThread],
+    });
+    const enrichThreadDirectories = vi.fn(
+      async (threads: AppServerThreadSummary[]) =>
+        threads.map((thread) => ({
+          ...thread,
+          linkedDirectories: [
+            {
+              id: projectA,
+              label: "ProjectA",
+              path: projectA,
+              worktreePath,
+              kind: "worktree" as const,
+            },
+          ],
+        })),
+    );
+    Object.assign(codexClient, { enrichThreadDirectories });
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({}),
+      overlayStore,
+    });
+
+    await registry.listThreads({
+      backend: "codex",
+      callerReason: "branch-drift",
+    });
+    expect(enrichThreadDirectories).not.toHaveBeenCalled();
+
+    await registry.listThreads({
+      backend: "codex",
+      callerReason: "startup-prewarm",
+    });
+
+    expect(codexClient.listThreadsCallCount).toBe(2);
+    expect(enrichThreadDirectories).toHaveBeenCalledTimes(1);
+    await expect(
+      overlayStore.getThreadOverlayState({ backend: "codex", threadId: "thread-1" }),
+    ).resolves.toMatchObject({
+      extraLinkedDirectories: [
+        expect.objectContaining({
+          id: worktreePath,
+          path: projectA,
+          worktreePath,
+          kind: "worktree",
+        }),
+      ],
+    });
+
+    await registry.close();
+  });
+
   it("repairs a selected Codex worktree thread with a single-thread directory enrichment", async () => {
     const projectA = "/Users/example/ProjectA";
     const worktreePath = "/Users/example/.codex/worktrees/worktree-1/ProjectA";

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -3939,12 +3939,21 @@ export class DesktopBackendRegistry {
   private buildThreadListCacheKey(params: {
     archived?: boolean;
     backend?: AppServerBackendKind;
+    callerReason?: ThreadListCallerReason;
     enrichDirectories?: boolean;
     filter?: string;
   }): string {
+    const codexDirectoryBackfill =
+      params.backend === "grok" ||
+      params.archived ||
+      params.enrichDirectories !== false
+        ? undefined
+        : shouldBackfillCodexDirectoryRelationships(params.callerReason);
+
     return JSON.stringify({
       archived: params.archived === true,
       backend: params.backend ?? "all",
+      codexDirectoryBackfill,
       enrichDirectories:
         params.backend === "grok" ? undefined : params.enrichDirectories === true,
       filter: params.filter?.trim() ?? "",

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -396,6 +396,33 @@ function hasCachedWorktreeDirectory(
   );
 }
 
+function hasEquivalentLinkedDirectory(
+  overlay: ThreadOverlayState | undefined,
+  directory: LinkedDirectorySummary,
+): boolean {
+  return Boolean(
+    overlay?.extraLinkedDirectories.some((candidate) => {
+      if (candidate.id !== directory.id || candidate.kind !== directory.kind) {
+        return false;
+      }
+
+      const candidatePath = path.resolve(candidate.path);
+      const directoryPath = path.resolve(directory.path);
+      const candidateWorktreePath = candidate.worktreePath?.trim()
+        ? path.resolve(candidate.worktreePath)
+        : undefined;
+      const directoryWorktreePath = directory.worktreePath?.trim()
+        ? path.resolve(directory.worktreePath)
+        : undefined;
+
+      return (
+        candidatePath === directoryPath &&
+        candidateWorktreePath === directoryWorktreePath
+      );
+    }),
+  );
+}
+
 function pathContainsOrEquals(parentPath: string, childPath: string): boolean {
   const relativePath = path.relative(parentPath, childPath);
   return (
@@ -438,6 +465,59 @@ function buildCachedWorktreeDirectory(
     path: repositoryPath,
     worktreePath,
   };
+}
+
+function buildCachedDirectoryRelationship(
+  thread: AppServerThreadSummary,
+): LinkedDirectorySummary | undefined {
+  const worktreeDirectory = buildCachedWorktreeDirectory(thread);
+  if (worktreeDirectory) {
+    return worktreeDirectory;
+  }
+
+  const projectKey = thread.projectKey?.trim();
+  if (!projectKey) {
+    return undefined;
+  }
+
+  const projectPath = path.resolve(projectKey);
+  const localDirectory = thread.linkedDirectories.find((candidate) => {
+    if (candidate.worktreePath?.trim()) {
+      return false;
+    }
+    return path.resolve(candidate.path) === projectPath;
+  });
+  if (!localDirectory) {
+    return undefined;
+  }
+
+  return {
+    ...localDirectory,
+    id: projectPath,
+    kind: "local",
+    label: localDirectory.label || path.basename(projectPath) || projectPath,
+    path: projectPath,
+    worktreePath: undefined,
+  };
+}
+
+function shouldRepairCachedDirectoryRelationship(params: {
+  directory: LinkedDirectorySummary;
+  overlay: ThreadOverlayState | undefined;
+}): boolean {
+  if (hasEquivalentLinkedDirectory(params.overlay, params.directory)) {
+    return false;
+  }
+
+  if (params.directory.kind === "worktree") {
+    return true;
+  }
+
+  return Boolean(
+    params.overlay?.extraLinkedDirectories.some(
+      (candidate) => candidate.id === params.directory.id,
+    ),
+  );
 }
 
 function normalizeLinkedDirectoryKind(
@@ -973,6 +1053,20 @@ function shouldEnrichThreadDirectories(
   }
 }
 
+function shouldBackfillCodexDirectoryRelationships(
+  callerReason?: ThreadListCallerReason,
+): boolean {
+  switch (callerReason) {
+    case "directory-relationship-reconcile":
+    case "messaging-navigation-snapshot":
+    case "navigation-snapshot":
+    case "startup-prewarm":
+      return true;
+    default:
+      return false;
+  }
+}
+
 type MessagingArchiveCleanupStore = Pick<
   MessagingStoreLike,
   | "deletePendingIntentsForThread"
@@ -1378,6 +1472,8 @@ export class DesktopBackendRegistry {
   >();
   private readonly queuedExecutionModeFlushes = new Map<string, Promise<void>>();
   private readonly attemptedTitleGenerations = new Set<string>();
+  private readonly repairedDirectoryThreadKeys = new Set<string>();
+  private fullDirectoryReconcileDispatched = false;
   private titleGenerationSequence = 0;
 
   constructor(options?: {
@@ -1940,6 +2036,13 @@ export class DesktopBackendRegistry {
             before: request.before,
             limit: request.limit,
           });
+
+    if (backend === "codex" && !request.before) {
+      await this.repairCodexThreadDirectoryRelationship({
+        reason: "selected-thread",
+        threadId: request.threadId,
+      });
+    }
 
     const overlay = await this.overlayStore.getThreadOverlayState({
       backend,
@@ -3861,6 +3964,159 @@ export class DesktopBackendRegistry {
     }
   }
 
+  private findCachedCodexThread(threadId: string): AppServerThreadSummary | undefined {
+    for (const state of this.threadListCache.values()) {
+      const thread = state.threads?.find(
+        (candidate) => candidate.source === "codex" && candidate.id === threadId,
+      );
+      if (thread) {
+        return thread;
+      }
+    }
+    return undefined;
+  }
+
+  private async readCheapCodexThreadForRepair(
+    threadId: string,
+  ): Promise<AppServerThreadSummary | undefined> {
+    const cached = this.findCachedCodexThread(threadId);
+    if (cached) {
+      return cached;
+    }
+
+    const threads = await this.codexClient.listThreads(
+      {
+        archived: false,
+        enrichDirectories: false,
+        filter: threadId,
+      },
+      {
+        callerReason: "selected-thread-directory-repair",
+        ownerId: this.threadListCacheOwnerId,
+      },
+    );
+    return threads.find((thread) => thread.id === threadId);
+  }
+
+  private async repairCodexThreadDirectoryRelationship(params: {
+    reason: "selected-thread";
+    threadId: string;
+  }): Promise<void> {
+    if (!this.codexClient.enrichThreadDirectories) {
+      return;
+    }
+
+    try {
+      const cheapThread = await this.readCheapCodexThreadForRepair(params.threadId);
+      if (!cheapThread) {
+        return;
+      }
+
+      const [enrichedThread] = await this.codexClient.enrichThreadDirectories([
+        cheapThread,
+      ]);
+      if (!enrichedThread) {
+        return;
+      }
+
+      const directory = buildCachedDirectoryRelationship(enrichedThread);
+      if (!directory) {
+        return;
+      }
+
+      const overlay = await this.overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: params.threadId,
+      });
+      if (!shouldRepairCachedDirectoryRelationship({ directory, overlay })) {
+        return;
+      }
+
+      await this.overlayStore.addLinkedDirectory({
+        backend: "codex",
+        threadId: params.threadId,
+        directory,
+      });
+      this.invalidateThreadListCache("codex");
+      await this.emitCodexDirectoryRelationshipsUpdated({
+        reason: params.reason,
+        threadIds: [params.threadId],
+      });
+      this.recordCodexDirectoryRelationshipRepair(params.threadId);
+    } catch (error) {
+      backendRegistryLog.warn("Codex selected thread directory repair failed", {
+        error: error instanceof Error ? error.message : String(error),
+        threadId: params.threadId,
+      });
+    }
+  }
+
+  private recordCodexDirectoryRelationshipRepair(threadId: string): void {
+    this.repairedDirectoryThreadKeys.add(`codex:${threadId}`);
+    if (
+      this.repairedDirectoryThreadKeys.size < 3 ||
+      this.fullDirectoryReconcileDispatched
+    ) {
+      return;
+    }
+
+    this.fullDirectoryReconcileDispatched = true;
+    void this.reconcileAllCodexDirectoryRelationships().catch((error) => {
+      backendRegistryLog.warn("Codex full directory relationship reconcile failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+  }
+
+  private async reconcileAllCodexDirectoryRelationships(): Promise<void> {
+    const threads = await this.codexClient.listThreads(
+      {
+        archived: false,
+        enrichDirectories: false,
+      },
+      {
+        callerReason: "directory-relationship-reconcile",
+        ownerId: this.threadListCacheOwnerId,
+      },
+    );
+    const overlaysByThreadId = await this.overlayStore.getThreadOverlayStates({
+      backend: "codex",
+      threadIds: threads.map((thread) => thread.id),
+    });
+    const updatedOverlaysByThreadId =
+      await this.backfillMissingCodexDirectoryRelationships({
+        diagnostics: {
+          callerReason: "directory-relationship-reconcile",
+          ownerId: this.threadListCacheOwnerId,
+        },
+        overlaysByThreadId,
+        threads,
+      });
+    const threadIds = Object.keys(updatedOverlaysByThreadId);
+    if (threadIds.length === 0) {
+      return;
+    }
+
+    this.invalidateThreadListCache("codex");
+    await this.emitCodexDirectoryRelationshipsUpdated({
+      reason: "full-reconcile",
+      threadIds,
+    });
+  }
+
+  private async emitCodexDirectoryRelationshipsUpdated(params: {
+    reason: "selected-thread" | "full-reconcile";
+    threadIds: string[];
+  }): Promise<void> {
+    await this.emit({
+      backend: "codex",
+      notification: {
+        method: "navigation/threadDirectories/updated",
+        params,
+      },
+    });
+  }
+
   private shouldInvalidateThreadListCacheForNotification(method: string): boolean {
     return (
       method === "thread/archived" ||
@@ -4227,7 +4483,11 @@ export class DesktopBackendRegistry {
       backend: "codex",
       threadIds: threadsWithPending.map((thread) => thread.id),
     });
-    if (!params.archived && params.enrichDirectories === false) {
+    if (
+      !params.archived &&
+      params.enrichDirectories === false &&
+      shouldBackfillCodexDirectoryRelationships(diagnostics?.callerReason)
+    ) {
       const updatedOverlaysByThreadId =
         await this.backfillMissingCodexDirectoryRelationships({
           diagnostics,

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -2231,6 +2231,90 @@ describe("useThreadNavigation", () => {
     expect(getNavigationSnapshot).toHaveBeenCalledTimes(1);
   });
 
+  it("refreshes the snapshot when thread directory metadata is repaired", async () => {
+    const listeners = new Set<(event: any) => void>();
+    let navigationSnapshot: NavigationSnapshot = {
+      backend: "all",
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: ["codex:thread-1"],
+      threads: [
+        {
+          id: "thread-1",
+          title: "First thread",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [
+            {
+              id: "/Users/example/.codex/worktrees/wt1/ProjectA",
+              label: "ProjectA",
+              path: "/Users/example/.codex/worktrees/wt1/ProjectA",
+              kind: "local",
+            },
+          ],
+          inbox: { inInbox: true, reason: "new-thread" },
+          updatedAt: 1_000,
+        },
+      ],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+    };
+    const getNavigationSnapshot = vi.fn(async () => navigationSnapshot);
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: (callback) => {
+        listeners.add(callback);
+        return () => {
+          listeners.delete(callback);
+        };
+      },
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.id).toBe("thread-1");
+    });
+    expect(getNavigationSnapshot).toHaveBeenCalledTimes(1);
+
+    navigationSnapshot = {
+      ...navigationSnapshot,
+      directories: [
+        {
+          key: "directory:/Users/example/ProjectA",
+          kind: "directory",
+          label: "ProjectA",
+          path: "/Users/example/ProjectA",
+          threadKeys: ["codex:thread-1"],
+          needsAttentionCount: 0,
+        },
+      ],
+    };
+
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "navigation/threadDirectories/updated",
+            params: {
+              reason: "selected-thread",
+              threadIds: ["thread-1"],
+            },
+          },
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(getNavigationSnapshot).toHaveBeenCalledTimes(2);
+      expect(result.current.directories[0]?.label).toBe("ProjectA");
+    });
+  });
+
   it("removes a revoked messaging binding from the thread row after onMessagingBindingsChanged fires", async () => {
     const bindingsListeners = new Set<(event: { at: number }) => void>();
     let navigationCallCount = 0;

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -1608,6 +1608,11 @@ export function useThreadNavigation(desktopApi?: DesktopApi): {
         return;
       }
 
+      if (method === "navigation/threadDirectories/updated") {
+        scheduleRefresh();
+        return;
+      }
+
       if (method === "thread/name/updated") {
         const { threadId, threadName } = event.notification.params as {
           threadId: string;

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -854,6 +854,13 @@ export type AppServerNotification =
       };
     }
   | {
+      method: "navigation/threadDirectories/updated";
+      params: {
+        reason: "selected-thread" | "full-reconcile";
+        threadIds: string[];
+      };
+    }
+  | {
       method: "thread/pin/added";
       params: {
         threadId: string;


### PR DESCRIPTION
## Summary

- Repair a selected Codex thread's cached directory relationship with one-thread directory enrichment when the DB metadata is stale or missing.
- Dispatch one full Codex directory reconcile after three distinct selected-thread repairs, guarded so it can only run once per app instance.
- Refresh the renderer navigation snapshot when directory metadata repair changes the thread list grouping.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx -- --runInBand`
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `git diff --check`
