### PR TITLE
fix(desktop): keep managed worktrees labeled as worktrees

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -1046,6 +1046,7 @@ describe("CodexAppServerClient", () => {
         ],
       };
     });
+
     const client = new CodexAppServerClient({
       command: "codex",
       threadDirectoryEnricher,
@@ -1074,6 +1075,42 @@ describe("CodexAppServerClient", () => {
     expect(enriched.map((thread) => thread.id)).toEqual([
       "slow-thread",
       "fast-thread",
+    ]);
+
+    await client.close();
+  });
+
+  it("keeps cheap thread summaries from rendering managed worktrees as local", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const threadDirectoryEnricher = vi.fn(async () => ({
+      linkedDirectories: [],
+    }));
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      threadDirectoryEnricher,
+    });
+
+    const threads = await client.listThreads({
+      enrichDirectories: false,
+      filter: "missing-worktree",
+    });
+
+    expect(threadDirectoryEnricher).not.toHaveBeenCalled();
+    expect(threads).toEqual([
+      expect.objectContaining({
+        id: "thread-missing-worktree",
+        projectKey: "/Users/huntharo/.codex/worktrees/0cb4/web-app",
+        linkedDirectories: [
+          {
+            id: "/Users/huntharo/.codex/worktrees/0cb4/web-app",
+            label: "web-app",
+            path: "/Users/huntharo/.codex/worktrees/0cb4/web-app",
+            worktreePath: "/Users/huntharo/.codex/worktrees/0cb4/web-app",
+            kind: "worktree",
+          },
+        ],
+      }),
     ]);
 
     await client.close();

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { promisify } from "node:util";
 import type { OverlayStoreLike } from "../state/overlay-store-sqlite";
 import {
+  isToolManagedWorktreePath,
   shortenDerivedThreadTitle,
   type AgentEvent,
   type ArchiveWorktreeRequest,
@@ -523,10 +524,15 @@ function shouldRepairCachedDirectoryRelationship(params: {
 function normalizeLinkedDirectoryKind(
   directory: LinkedDirectorySummary,
 ): LinkedDirectorySummary {
-  if (directory.kind === "local" && directory.worktreePath?.trim()) {
+  if (
+    directory.kind === "local" &&
+    (directory.worktreePath?.trim() || isToolManagedWorktreePath(directory.path))
+  ) {
+    const worktreePath = directory.worktreePath?.trim() || directory.path;
     return {
       ...directory,
       kind: "worktree",
+      worktreePath,
     };
   }
 

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import {
+  isToolManagedWorktreePath,
   shortenDerivedThreadTitle,
 } from "@pwragent/shared";
 import type {
@@ -947,13 +948,15 @@ function buildProjectKeyLinkedDirectories(
   const resolvedPath = path.isAbsolute(directoryPath)
     ? directoryPath
     : path.resolve(directoryPath);
+  const isWorktree = isToolManagedWorktreePath(resolvedPath);
 
   return [
     {
       id: resolvedPath,
       label: path.basename(resolvedPath) || resolvedPath,
       path: resolvedPath,
-      kind: "local",
+      ...(isWorktree ? { worktreePath: resolvedPath } : {}),
+      kind: isWorktree ? "worktree" : "local",
     },
   ];
 }

--- a/packages/agent-core/src/__tests__/directory-navigation.test.ts
+++ b/packages/agent-core/src/__tests__/directory-navigation.test.ts
@@ -719,4 +719,34 @@ describe("materializeNavigationThreads", () => {
       },
     ]);
   });
+
+  it("normalizes managed worktree paths even when no repository path is known", () => {
+    const [thread] = materializeNavigationThreads({
+      firstSnapshot: false,
+      overlayByThreadKey: {},
+      previousKnownThreadKeys: ["codex:thread-1"],
+      threads: [
+        buildThread({
+          linkedDirectories: [
+            {
+              id: "/Users/huntharo/.codex/worktrees/mp62bt71/PwrAgnt",
+              label: "PwrAgnt",
+              path: "/Users/huntharo/.codex/worktrees/mp62bt71/PwrAgnt",
+              kind: "local",
+            },
+          ],
+        }),
+      ],
+    });
+
+    expect(thread?.linkedDirectories).toEqual([
+      {
+        id: "/Users/huntharo/.codex/worktrees/mp62bt71/PwrAgnt",
+        label: "PwrAgnt",
+        path: "/Users/huntharo/.codex/worktrees/mp62bt71/PwrAgnt",
+        worktreePath: "/Users/huntharo/.codex/worktrees/mp62bt71/PwrAgnt",
+        kind: "worktree",
+      },
+    ]);
+  });
 });

--- a/packages/agent-core/src/domain/directory-navigation.ts
+++ b/packages/agent-core/src/domain/directory-navigation.ts
@@ -8,6 +8,7 @@ import type {
 import {
   buildThreadIdentityKey,
   compareThreadsByCreatedAtDesc,
+  isToolManagedWorktreePath,
 } from "@pwragent/shared";
 
 type DirectoryDescriptor = Pick<
@@ -53,12 +54,6 @@ function pathFromDirectoryKey(directoryKey: string): string | undefined {
       ? directoryKey.slice("workspace:".length)
       : undefined;
   return directoryPath?.trim() || undefined;
-}
-
-function isToolManagedWorktreePath(value: string): boolean {
-  return /[\\/]\.(?:codex|pwrag(?:ent|nt))[\\/]worktrees[\\/][^\\/]+[\\/][^\\/]+(?:[\\/].*)?$/.test(
-    value,
-  );
 }
 
 function matchScratchProjectsRoot(value: string): string | undefined {

--- a/packages/agent-core/src/domain/navigation-state.ts
+++ b/packages/agent-core/src/domain/navigation-state.ts
@@ -11,7 +11,7 @@ import type {
   NavigationLaunchpadDefaults,
   ThreadOverlayState,
 } from "@pwragent/shared";
-import { buildThreadIdentityKey } from "@pwragent/shared";
+import { buildThreadIdentityKey, isToolManagedWorktreePath } from "@pwragent/shared";
 import { deriveInboxState, rankInboxThreadKeys } from "./inbox";
 import { buildDirectorySummaries } from "./directory-navigation";
 
@@ -58,10 +58,15 @@ function dedupeLinkedDirectories(
 function normalizeLinkedDirectoryKind(
   directory: LinkedDirectorySummary,
 ): LinkedDirectorySummary {
-  if (directory.kind === "local" && directory.worktreePath?.trim()) {
+  if (
+    directory.kind === "local" &&
+    (directory.worktreePath?.trim() || isToolManagedWorktreePath(directory.path))
+  ) {
+    const worktreePath = directory.worktreePath?.trim() || directory.path;
     return {
       ...directory,
       kind: "worktree",
+      worktreePath,
     };
   }
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -10,3 +10,4 @@ export * from "./messaging-contact-labels";
 export * from "./messaging-id-validation";
 export * from "./thread-pins";
 export * from "./thread-titles";
+export * from "./worktree-paths";

--- a/packages/shared/src/worktree-paths.ts
+++ b/packages/shared/src/worktree-paths.ts
@@ -1,0 +1,9 @@
+export function isToolManagedWorktreePath(value: string | undefined): boolean {
+  if (!value?.trim()) {
+    return false;
+  }
+
+  return /[\\/]\.(?:codex|pwrag(?:ent|nt))[\\/]worktrees[\\/][^\\/]+[\\/][^\\/]+(?:[\\/].*)?$/.test(
+    value,
+  );
+}


### PR DESCRIPTION
## Summary

- Classify Codex/PwrAgent-managed worktree paths as `worktree` even when navigation uses cheap thread summaries without git directory enrichment.
- Share the managed-worktree path detector across desktop and agent-core navigation logic.
- Add regressions for cheap Codex thread lists and navigation materialization so worktree paths cannot render as `local` chips.

## Root Cause

`navigation-snapshot` intentionally skips expensive directory enrichment. For newly materialized worktree threads, the fallback linked-directory builder only had Codex `projectKey`/`cwd`, so it rebuilt `/Users/.../.codex/worktrees/...` as a `local` linked directory. That made the sidebar display a worktree path with a `local` indicator after the pending-start state expired.

## Validation

- `pnpm test packages/agent-core/src/__tests__/directory-navigation.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/codex-client.test.ts`
- `pnpm lint:boundaries`
