### PR TITLE
feat(messaging): repost last reply on resume

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -1766,6 +1766,72 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("inherits envelope timestamps for nested thread/read messages", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.readThreadResultByThreadId.set("thread-envelope-messages", {
+      events: [
+        {
+          type: "response_item",
+          timestamp: "2026-05-15T14:10:43.491Z",
+          payload: {
+            id: "final-response-item",
+            role: "assistant",
+            content: [
+              {
+                type: "output_text",
+                text: "Final answer from the raw session envelope.",
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    const replay = await client.readThread({
+      threadId: "thread-envelope-messages",
+    });
+
+    expect(replay.messages).toEqual([
+      {
+        id: "final-response-item",
+        role: "assistant",
+        text: "Final answer from the raw session envelope.",
+        createdAt: Date.parse("2026-05-15T14:10:43.491Z"),
+        parts: [
+          {
+            type: "text",
+            text: "Final answer from the raw session envelope.",
+          },
+        ],
+      },
+    ]);
+    expect(replay.entries).toEqual([
+      {
+        type: "message",
+        id: "final-response-item",
+        role: "assistant",
+        text: "Final answer from the raw session envelope.",
+        createdAt: Date.parse("2026-05-15T14:10:43.491Z"),
+        parts: [
+          {
+            type: "text",
+            text: "Final answer from the raw session envelope.",
+          },
+        ],
+      },
+    ]);
+    expect(replay.lastAssistantMessage).toBe(
+      "Final answer from the raw session envelope."
+    );
+
+    await client.close();
+  });
+
   it("counts added, removed, and updated FileChange variants from thread/read", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
     MockTransport.readThreadResultByThreadId.set("thread-file-change-counts", {

--- a/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+import type {
+  AppServerReadThreadResponse,
+  AppServerThreadReplay,
+} from "@pwragent/shared";
+import type { DesktopBackendRegistry } from "../app-server/backend-registry";
+import { DesktopMessagingBackendBridge } from "../messaging/desktop-backend-bridge";
+
+describe("DesktopMessagingBackendBridge", () => {
+  it("prefers the latest replay message over older transcript entries", async () => {
+    const bridge = createBridge({
+      entries: [
+        {
+          type: "message",
+          id: "older-entry",
+          role: "assistant",
+          text: "Older transcript entry.",
+          createdAt: 1_000,
+        },
+      ],
+      messages: [
+        {
+          id: "older-message",
+          role: "assistant",
+          text: "Older transcript entry.",
+        },
+        {
+          id: "newer-nested-message",
+          role: "assistant",
+          text: "Newer nested response item.",
+          createdAt: 2_000,
+        },
+      ],
+      lastAssistantMessage: "Newer nested response item.",
+      pagination: {
+        supportsPagination: false,
+        hasPreviousPage: false,
+      },
+    });
+
+    await expect(
+      bridge.readThreadLastAssistantReply({
+        backend: "codex",
+        threadId: "thread-1",
+      }),
+    ).resolves.toEqual({
+      text: "Newer nested response item.",
+      createdAt: 2_000,
+    });
+  });
+
+  it("uses matching transcript entry timestamps when replay messages lack one", async () => {
+    const bridge = createBridge({
+      entries: [
+        {
+          type: "message",
+          id: "entry-final",
+          role: "assistant",
+          text: "Final turn-shaped answer.",
+          createdAt: 3_000,
+        },
+      ],
+      messages: [
+        {
+          id: "message-final",
+          role: "assistant",
+          text: "Final turn-shaped answer.",
+        },
+      ],
+      lastAssistantMessage: "Final turn-shaped answer.",
+      pagination: {
+        supportsPagination: false,
+        hasPreviousPage: false,
+      },
+    });
+
+    await expect(
+      bridge.readThreadLastAssistantReply({
+        backend: "codex",
+        threadId: "thread-1",
+      }),
+    ).resolves.toEqual({
+      text: "Final turn-shaped answer.",
+      createdAt: 3_000,
+    });
+  });
+});
+
+function createBridge(replay: AppServerThreadReplay): DesktopMessagingBackendBridge {
+  const response: AppServerReadThreadResponse = {
+    backend: "codex",
+    fetchedAt: 1,
+    threadId: "thread-1",
+    replay,
+  };
+  const registry = {
+    readThread: vi.fn(async () => response),
+  } as unknown as DesktopBackendRegistry;
+  return new DesktopMessagingBackendBridge(registry);
+}

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -1145,6 +1145,38 @@ describe("MessagingController", () => {
     });
   });
 
+  it("reposts the last assistant response after selecting a thread to resume", async () => {
+    const harness = await createHarness({
+      readThreadLastAssistantMessage: async () => "Last completed answer.",
+    });
+    await harness.controller.handleInboundEvent(buildCommandEvent("/resume"));
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-thread",
+        value: {
+          backend: "codex",
+          threadId: "thread-1",
+        },
+      }),
+    );
+
+    expect(harness.readThreadLastAssistantMessage).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "message",
+      role: "assistant",
+      parts: [
+        {
+          type: "text",
+          text: "Last completed answer.",
+        },
+      ],
+    });
+  });
+
   it("completes binding mutations without throwing when no onBindingChanged listener is configured", async () => {
     // The `onBindingChanged` option is declared optional on
     // `MessagingControllerOptions`. Production wiring always supplies

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -4101,6 +4101,25 @@ describe("MessagingController", () => {
     expect(messagingDeliveryPriority(approvalCleanup)).toBe("routine_status");
   });
 
+  it("treats resume reposts as routine budget traffic", () => {
+    const resumeRepost = {
+      id: "assistant-resume-repost-1",
+      kind: "message",
+      bindingId: "binding-1",
+      createdAt: 1_000,
+      role: "assistant",
+      parts: [{ type: "text", text: "Last Bot Reply\n\nPrevious answer." }],
+    } satisfies MessagingSurfaceIntent;
+
+    const finalAssistant = {
+      ...resumeRepost,
+      id: "assistant-message-1",
+    } satisfies MessagingSurfaceIntent;
+
+    expect(messagingDeliveryPriority(resumeRepost)).toBe("routine_status");
+    expect(messagingDeliveryPriority(finalAssistant)).toBe("final_turn");
+  });
+
   it("does not charge typing activity against the message write budget", () => {
     const activity = {
       id: "activity-1",

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -1147,7 +1147,14 @@ describe("MessagingController", () => {
 
   it("reposts the last assistant response after selecting a thread to resume", async () => {
     const harness = await createHarness({
-      readThreadLastAssistantMessage: async () => "Last completed answer.",
+      readThreadLastAssistantMessage: async function (
+        this: MessagingBackendBridge,
+      ) {
+        if (typeof this.getNavigationSnapshot !== "function") {
+          throw new Error("backend receiver was not preserved");
+        }
+        return "Last completed answer.";
+      },
     });
     await harness.controller.handleInboundEvent(buildCommandEvent("/resume"));
 

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -1146,14 +1146,19 @@ describe("MessagingController", () => {
   });
 
   it("reposts the last assistant response after selecting a thread to resume", async () => {
+    const now = Date.UTC(2026, 4, 15, 13, 30);
     const harness = await createHarness({
-      readThreadLastAssistantMessage: async function (
+      now: () => now,
+      readThreadLastAssistantReply: async function (
         this: MessagingBackendBridge,
       ) {
         if (typeof this.getNavigationSnapshot !== "function") {
           throw new Error("backend receiver was not preserved");
         }
-        return "Last completed answer.";
+        return {
+          createdAt: now - 60 * 60_000,
+          text: "Last completed answer.",
+        };
       },
     });
     await harness.controller.handleInboundEvent(buildCommandEvent("/resume"));
@@ -1168,7 +1173,7 @@ describe("MessagingController", () => {
       }),
     );
 
-    expect(harness.readThreadLastAssistantMessage).toHaveBeenCalledWith({
+    expect(harness.readThreadLastAssistantReply).toHaveBeenCalledWith({
       backend: "codex",
       threadId: "thread-1",
     });
@@ -1178,7 +1183,9 @@ describe("MessagingController", () => {
       parts: [
         {
           type: "text",
-          text: "Last completed answer.",
+          text: expect.stringMatching(
+            /^Last Bot Reply \(1 hour ago, .+\)\n\nLast completed answer\.$/,
+          ),
         },
       ],
     });
@@ -7108,6 +7115,9 @@ async function createHarness(options?: {
   readThreadLastAssistantMessage?: NonNullable<
     MessagingBackendBridge["readThreadLastAssistantMessage"]
   >;
+  readThreadLastAssistantReply?: NonNullable<
+    MessagingBackendBridge["readThreadLastAssistantReply"]
+  >;
   setConversationTitle?: MessagingAdapter["setConversationTitle"];
   startThread?: NonNullable<MessagingBackendBridge["startThread"]>;
   toolUpdateDefaultMode?: MessagingToolUpdateMode;
@@ -7124,6 +7134,7 @@ async function createHarness(options?: {
   materializeDirectoryLaunchpad: ReturnType<typeof vi.fn>;
   onBindingChanged: ReturnType<typeof vi.fn>;
   readThreadLastAssistantMessage: ReturnType<typeof vi.fn>;
+  readThreadLastAssistantReply: ReturnType<typeof vi.fn>;
   readThreadStatus: ReturnType<typeof vi.fn>;
   recordMessagingBindingTransition: ReturnType<typeof vi.fn>;
   setThreadExecutionMode: ReturnType<typeof vi.fn>;
@@ -7330,6 +7341,9 @@ async function createHarness(options?: {
   const readThreadLastAssistantMessage = vi.fn(
     options?.readThreadLastAssistantMessage ?? (async () => undefined),
   );
+  const readThreadLastAssistantReply = vi.fn(
+    options?.readThreadLastAssistantReply ?? (async () => undefined),
+  );
   const readThreadStatus = vi.fn(async () => undefined);
   const recordMessagingBindingTransition = vi.fn(async () => undefined);
   const submitServerRequest = vi.fn(async (request: SubmitServerRequestRequest) => ({
@@ -7347,6 +7361,7 @@ async function createHarness(options?: {
     ...(listSkills ? { listSkills } : {}),
     listBackends,
     materializeDirectoryLaunchpad,
+    readThreadLastAssistantReply,
     readThreadLastAssistantMessage,
     readThreadStatus,
     recordMessagingBindingTransition,
@@ -7401,6 +7416,7 @@ async function createHarness(options?: {
     materializeDirectoryLaunchpad,
     onBindingChanged,
     readThreadLastAssistantMessage,
+    readThreadLastAssistantReply,
     readThreadStatus,
     recordMessagingBindingTransition,
     setThreadExecutionMode,

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -1244,10 +1244,11 @@ function buildMessageContent(record: Record<string, unknown>): {
 function extractConversationMessages(value: unknown): AppServerThreadReplay["messages"] {
   const output: AppServerThreadReplay["messages"] = [];
   const suppressedAssistantTexts = collectReviewSuppressionTexts(value);
+  const timestampKeys = ["createdAt", "created_at", "timestamp", "time"];
 
-  const visit = (node: unknown): void => {
+  const visit = (node: unknown, inheritedCreatedAt?: number): void => {
     if (Array.isArray(node)) {
-      node.forEach((entry) => visit(entry));
+      node.forEach((entry) => visit(entry, inheritedCreatedAt));
       return;
     }
 
@@ -1255,6 +1256,10 @@ function extractConversationMessages(value: unknown): AppServerThreadReplay["mes
     if (!record) {
       return;
     }
+    const recordCreatedAt = normalizeEpochTimestamp(
+      pickNumber(record, timestampKeys)
+    );
+    const createdAt = recordCreatedAt ?? inheritedCreatedAt;
 
     const role = normalizeConversationRole(
       pickString(record, ["role", "author", "speaker", "source", "type"])
@@ -1272,9 +1277,7 @@ function extractConversationMessages(value: unknown): AppServerThreadReplay["mes
         role,
         text: content.text,
         ...(content.parts ? { parts: content.parts } : {}),
-        createdAt: normalizeEpochTimestamp(
-          pickNumber(record, ["createdAt", "created_at", "timestamp", "time"])
-        )
+        createdAt
       });
     }
 
@@ -1288,13 +1291,14 @@ function extractConversationMessages(value: unknown): AppServerThreadReplay["mes
       "results",
       "turns",
       "events",
+      "payload",
       "item",
       "message",
       "thread",
       "response",
       "result"
     ]) {
-      visit(record[key]);
+      visit(record[key], createdAt);
     }
   };
 

--- a/apps/desktop/src/main/messaging/core/messaging-adapter.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-adapter.ts
@@ -67,6 +67,11 @@ export type MessagingConversationTitleUpdateResult = {
   updatedAt: number;
 };
 
+export type MessagingLastAssistantReply = {
+  createdAt?: number;
+  text: string;
+};
+
 export type MessagingAdapter = {
   capabilityProfile: MessagingCapabilityProfile;
   clientRateLimitStrategy?: MessagingClientRateLimitStrategy;
@@ -98,6 +103,10 @@ export type MessagingBackendBridge = {
     backend: AppServerBackendKind;
     threadId: string;
   }): Promise<string | undefined>;
+  readThreadLastAssistantReply?(request: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): Promise<MessagingLastAssistantReply | undefined>;
   handoffThreadWorkspace?(
     request: HandoffThreadWorkspaceRequest,
   ): Promise<HandoffThreadWorkspaceResponse>;

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -2507,7 +2507,7 @@ export class MessagingController {
 
     let text: string | undefined;
     try {
-      text = await readLastAssistantMessage({
+      text = await this.options.backend.readThreadLastAssistantMessage({
         backend: binding.backend,
         threadId: binding.threadId,
       });

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -2507,7 +2507,7 @@ export class MessagingController {
 
     let text: string | undefined;
     try {
-      text = await this.options.backend.readThreadLastAssistantMessage({
+      text = await readLastAssistantMessage.call(this.options.backend, {
         backend: binding.backend,
         threadId: binding.threadId,
       });

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -8071,6 +8071,9 @@ export function messagingDeliveryPriority(
     case "stream_update":
       return intent.stream.isFinal ? "final_turn" : "stream_partial";
     case "message":
+      if (intent.id.startsWith("assistant-resume-repost")) {
+        return "routine_status";
+      }
       if (intent.role === "assistant") {
         return "final_turn";
       }

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -67,7 +67,11 @@ import {
 import { buildMessagingConversationKey } from "./messaging-store.js";
 import type { MessagingStoreLike } from "../../state/messaging-store-sqlite";
 import type { MessagingCapabilityProfile } from "@pwragent/messaging-interface";
-import type { MessagingAdapter, MessagingBackendBridge } from "./messaging-adapter.js";
+import type {
+  MessagingAdapter,
+  MessagingBackendBridge,
+  MessagingLastAssistantReply,
+} from "./messaging-adapter.js";
 import {
   buildActivityIntent,
   buildApprovalIntent,
@@ -2500,17 +2504,26 @@ export class MessagingController {
   private async repostLastAssistantMessageForResume(
     binding: MessagingBindingRecord,
   ): Promise<void> {
+    const readLastAssistantReply = this.options.backend.readThreadLastAssistantReply;
     const readLastAssistantMessage = this.options.backend.readThreadLastAssistantMessage;
-    if (!readLastAssistantMessage) {
+    if (!readLastAssistantReply && !readLastAssistantMessage) {
       return;
     }
 
-    let text: string | undefined;
+    let reply: MessagingLastAssistantReply | undefined;
     try {
-      text = await readLastAssistantMessage.call(this.options.backend, {
-        backend: binding.backend,
-        threadId: binding.threadId,
-      });
+      if (readLastAssistantReply) {
+        reply = await readLastAssistantReply.call(this.options.backend, {
+          backend: binding.backend,
+          threadId: binding.threadId,
+        });
+      } else if (readLastAssistantMessage) {
+        const text = await readLastAssistantMessage.call(this.options.backend, {
+          backend: binding.backend,
+          threadId: binding.threadId,
+        });
+        reply = text ? { text } : undefined;
+      }
     } catch (error) {
       this.logger.debug?.("messaging resume last assistant replay failed", {
         backend: binding.backend,
@@ -2520,7 +2533,7 @@ export class MessagingController {
       return;
     }
 
-    const trimmed = text?.trim();
+    const trimmed = reply?.text.trim();
     if (!trimmed) {
       return;
     }
@@ -2535,7 +2548,11 @@ export class MessagingController {
         parts: [
           {
             type: "text",
-            text: trimmed,
+            text: formatResumeRepostText({
+              createdAt: reply?.createdAt,
+              now: this.now(),
+              text: trimmed,
+            }),
             markdown: "markdown",
           },
         ],
@@ -8586,6 +8603,63 @@ function messagingLaunchpadMaterializationKey(
   session: MessagingBrowseSessionRecord,
 ): string {
   return `messaging:${session.id}`;
+}
+
+function formatResumeRepostText(params: {
+  createdAt?: number;
+  now: number;
+  text: string;
+}): string {
+  return [
+    formatResumeRepostHeading(params.createdAt, params.now),
+    params.text,
+  ].join("\n\n");
+}
+
+function formatResumeRepostHeading(
+  createdAt: number | undefined,
+  now: number,
+): string {
+  if (typeof createdAt !== "number" || !Number.isFinite(createdAt)) {
+    return "Last Bot Reply";
+  }
+  const relativeAge = formatRelativeAge(createdAt, now);
+  const absoluteTime = formatAbsoluteDateTime(createdAt);
+  return `Last Bot Reply (${relativeAge}, ${absoluteTime})`;
+}
+
+function formatRelativeAge(createdAt: number, now: number): string {
+  const elapsedMs = Math.max(0, now - createdAt);
+  const elapsedMinutes = Math.floor(elapsedMs / 60_000);
+  if (elapsedMinutes < 1) {
+    return "just now";
+  }
+  if (elapsedMinutes < 60) {
+    return formatAgeUnit(elapsedMinutes, "minute");
+  }
+
+  const elapsedHours = Math.floor(elapsedMinutes / 60);
+  if (elapsedHours < 48) {
+    return formatAgeUnit(elapsedHours, "hour");
+  }
+
+  const elapsedDays = Math.floor(elapsedHours / 24);
+  if (elapsedDays < 14) {
+    return formatAgeUnit(elapsedDays, "day");
+  }
+
+  return formatAgeUnit(Math.floor(elapsedDays / 7), "week");
+}
+
+function formatAgeUnit(value: number, unit: string): string {
+  return `${value} ${unit}${value === 1 ? "" : "s"} ago`;
+}
+
+function formatAbsoluteDateTime(timestamp: number): string {
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(timestamp));
 }
 
 function parseTextCommand(text: string): string | undefined {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -1833,6 +1833,7 @@ export class MessagingController {
         binding,
       );
       await this.renderBindingStatus(binding);
+      await this.repostLastAssistantMessageForResume(binding);
       return;
     }
 
@@ -2496,6 +2497,53 @@ export class MessagingController {
     );
   }
 
+  private async repostLastAssistantMessageForResume(
+    binding: MessagingBindingRecord,
+  ): Promise<void> {
+    const readLastAssistantMessage = this.options.backend.readThreadLastAssistantMessage;
+    if (!readLastAssistantMessage) {
+      return;
+    }
+
+    let text: string | undefined;
+    try {
+      text = await readLastAssistantMessage({
+        backend: binding.backend,
+        threadId: binding.threadId,
+      });
+    } catch (error) {
+      this.logger.debug?.("messaging resume last assistant replay failed", {
+        backend: binding.backend,
+        error: error instanceof Error ? error.message : String(error),
+        threadId: binding.threadId,
+      });
+      return;
+    }
+
+    const trimmed = text?.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    await this.deliver(
+      {
+        id: this.newIntentId("assistant-resume-repost"),
+        kind: "message",
+        bindingId: binding.id,
+        createdAt: this.now(),
+        role: "assistant",
+        parts: [
+          {
+            type: "text",
+            text: trimmed,
+            markdown: "markdown",
+          },
+        ],
+      },
+      binding,
+    );
+  }
+
   private markAssistantMessageDelivered(
     event: AgentEvent,
     binding: MessagingBindingRecord,
@@ -3070,6 +3118,7 @@ export class MessagingController {
         event,
       );
       await this.renderBindingStatus(updatedBinding, event, navigation);
+      await this.repostLastAssistantMessageForResume(updatedBinding);
       return;
     }
 
@@ -5217,6 +5266,7 @@ export class MessagingController {
         event,
       );
       await this.renderBindingStatus(updatedBinding, event);
+      await this.repostLastAssistantMessageForResume(updatedBinding);
       return;
     }
 

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -1,6 +1,7 @@
 import type {
   AgentEvent,
   AppServerBackendKind,
+  AppServerThreadReplay,
   AppServerListSkillsRequest,
   AppServerListSkillsResponse,
   AppServerThreadStatus,
@@ -106,36 +107,22 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
       limit: 20,
       threadId: request.threadId,
     });
-    for (let index = response.replay.entries.length - 1; index >= 0; index -= 1) {
-      const entry = response.replay.entries[index];
-      if (entry?.type !== "message" || entry.role !== "assistant") {
-        continue;
-      }
-      const text = entry.text.trim();
-      if (!text) {
-        continue;
-      }
-      return {
-        text,
-        ...(entry.createdAt ? { createdAt: entry.createdAt } : {}),
-      };
-    }
-    for (let index = response.replay.messages.length - 1; index >= 0; index -= 1) {
-      const message = response.replay.messages[index];
-      if (message?.role !== "assistant") {
-        continue;
-      }
-      const text = message.text.trim();
-      if (!text) {
-        continue;
-      }
-      return {
-        text,
-        ...(message.createdAt ? { createdAt: message.createdAt } : {}),
-      };
+    const messageReply = findLastAssistantMessageReply(response.replay);
+    if (messageReply) {
+      return messageReply;
     }
     const fallbackText = response.replay.lastAssistantMessage?.trim();
-    return fallbackText ? { text: fallbackText } : undefined;
+    if (fallbackText) {
+      const createdAt = findLastAssistantEntryCreatedAt(
+        response.replay,
+        fallbackText,
+      );
+      return {
+        text: fallbackText,
+        ...(createdAt ? { createdAt } : {}),
+      };
+    }
+    return findLastAssistantEntryReply(response.replay);
   }
 
   async handoffThreadWorkspace(
@@ -215,4 +202,63 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
   onEvent(listener: (event: AgentEvent) => void | Promise<void>): () => void {
     return this.registry.onEvent(listener);
   }
+}
+
+function findLastAssistantMessageReply(
+  replay: AppServerThreadReplay,
+): MessagingLastAssistantReply | undefined {
+  for (let index = replay.messages.length - 1; index >= 0; index -= 1) {
+    const message = replay.messages[index];
+    if (message?.role !== "assistant") {
+      continue;
+    }
+    const text = message.text.trim();
+    if (!text) {
+      continue;
+    }
+    const createdAt =
+      message.createdAt ?? findLastAssistantEntryCreatedAt(replay, text);
+    return {
+      text,
+      ...(createdAt ? { createdAt } : {}),
+    };
+  }
+  return undefined;
+}
+
+function findLastAssistantEntryReply(
+  replay: AppServerThreadReplay,
+): MessagingLastAssistantReply | undefined {
+  for (let index = replay.entries.length - 1; index >= 0; index -= 1) {
+    const entry = replay.entries[index];
+    if (entry?.type !== "message" || entry.role !== "assistant") {
+      continue;
+    }
+    const text = entry.text.trim();
+    if (!text) {
+      continue;
+    }
+    return {
+      text,
+      ...(entry.createdAt ? { createdAt: entry.createdAt } : {}),
+    };
+  }
+  return undefined;
+}
+
+function findLastAssistantEntryCreatedAt(
+  replay: AppServerThreadReplay,
+  text: string,
+): number | undefined {
+  for (let index = replay.entries.length - 1; index >= 0; index -= 1) {
+    const entry = replay.entries[index];
+    if (
+      entry?.type === "message" &&
+      entry.role === "assistant" &&
+      entry.text.trim() === text
+    ) {
+      return entry.createdAt;
+    }
+  }
+  return undefined;
 }

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -32,7 +32,10 @@ import type {
   SubmitServerRequestResponse,
   ThreadMessagingBindingTransition,
 } from "@pwragent/shared";
-import type { MessagingBackendBridge } from "./core/messaging-adapter";
+import type {
+  MessagingBackendBridge,
+  MessagingLastAssistantReply,
+} from "./core/messaging-adapter";
 import type { DesktopBackendRegistry } from "../app-server/backend-registry";
 import { getDesktopBackendRegistry } from "../app-server/backend-registry";
 import { getDesktopOverlayStore } from "../app-server/desktop-overlay-store";
@@ -91,12 +94,34 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
     backend: AppServerBackendKind;
     threadId: string;
   }): Promise<string | undefined> {
+    return (await this.readThreadLastAssistantReply(request))?.text;
+  }
+
+  async readThreadLastAssistantReply(request: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): Promise<MessagingLastAssistantReply | undefined> {
     const response = await this.registry.readThread({
       backend: request.backend,
       limit: 20,
       threadId: request.threadId,
     });
-    return response.replay.lastAssistantMessage;
+    for (let index = response.replay.messages.length - 1; index >= 0; index -= 1) {
+      const message = response.replay.messages[index];
+      if (message?.role !== "assistant") {
+        continue;
+      }
+      const text = message.text.trim();
+      if (!text) {
+        continue;
+      }
+      return {
+        text,
+        ...(message.createdAt ? { createdAt: message.createdAt } : {}),
+      };
+    }
+    const fallbackText = response.replay.lastAssistantMessage?.trim();
+    return fallbackText ? { text: fallbackText } : undefined;
   }
 
   async handoffThreadWorkspace(

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -106,6 +106,20 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
       limit: 20,
       threadId: request.threadId,
     });
+    for (let index = response.replay.entries.length - 1; index >= 0; index -= 1) {
+      const entry = response.replay.entries[index];
+      if (entry?.type !== "message" || entry.role !== "assistant") {
+        continue;
+      }
+      const text = entry.text.trim();
+      if (!text) {
+        continue;
+      }
+      return {
+        text,
+        ...(entry.createdAt ? { createdAt: entry.createdAt } : {}),
+      };
+    }
     for (let index = response.replay.messages.length - 1; index >= 0; index -= 1) {
       const message = response.replay.messages[index];
       if (message?.role !== "assistant") {


### PR DESCRIPTION
## Summary

I added the OpenClaw-Codex-App-Server-style resume behavior for messaging-bound threads:

- after a thread is resumed from messaging, PwrAgent best-effort reads the thread's last assistant reply and reposts it into the bound conversation
- the repost is wired through the normal resume picker path, direct bind path, and Full Access resume escalation path
- the controller ignores missing/failed replay reads so a resume bind still succeeds even if the prior reply cannot be loaded

## Verification

I verified this with:

- `pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts`
