### PR TITLE
fix(desktop): persist composer draft recovery history

### DIFF
--- a/apps/desktop/e2e/composer-draft-persistence-regression.spec.ts
+++ b/apps/desktop/e2e/composer-draft-persistence-regression.spec.ts
@@ -471,3 +471,42 @@ test("restores an already-open Tiptap WYSIWYG reply as rendered markdown after s
     await fixture.cleanup();
   }
 });
+
+test("recovers an accidentally deleted Tiptap reply draft from another blank composer", async () => {
+  const fixture = await createComposerDraftPersistenceFixture();
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    await openExistingThread(app);
+
+    const deletedDraft =
+      "This is a long unsent reply draft typed into the real Tiptap editor. " +
+      "It should be recoverable with ArrowUp after an accidental select-all delete " +
+      "instead of disappearing when the composer becomes empty.";
+    const tiptapInput = app.window.getByTestId("composer-tiptap-input");
+    const textbox = app.window.getByRole("textbox", { name: "Reply" });
+
+    await textbox.focus();
+    await app.window.keyboard.type(deletedDraft);
+    await expect(tiptapInput).toHaveAttribute("data-value", deletedDraft);
+
+    await app.window.keyboard.press(
+      process.platform === "darwin" ? "Meta+A" : "Control+A",
+    );
+    await app.window.keyboard.press("Backspace");
+    await expect(tiptapInput).toHaveAttribute("data-value", "");
+
+    await openDirectoryLaunchpad(app);
+    const launchpadInput = app.window.getByTestId("composer-tiptap-input");
+    await app.window.getByRole("textbox", { name: "New thread" }).focus();
+    await expect(launchpadInput).toHaveAttribute("data-value", "");
+
+    await app.window.keyboard.press("ArrowUp");
+    await expect(launchpadInput).toHaveAttribute("data-value", deletedDraft);
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});

--- a/apps/desktop/e2e/new-thread-transcript-sync.spec.ts
+++ b/apps/desktop/e2e/new-thread-transcript-sync.spec.ts
@@ -461,7 +461,7 @@ test("top-level new thread rereads the created thread until the assistant reply 
   }
 });
 
-test("top-level new thread recovers an accidentally deleted no-project draft with ArrowUp", async () => {
+test("top-level new thread cycles deleted no-project drafts only from the recovery caret", async () => {
   const fixture = await createNewThreadTranscriptFixture();
   const app = await launchElectronApp({
     fixturePath: fixture.fixturePath,
@@ -491,8 +491,27 @@ test("top-level new thread recovers an accidentally deleted no-project draft wit
       "- This is",
       "- Not exactly a tool",
     ].join("\n");
+    const earlierDraft = [
+      "Earlier coherent draft",
+      "",
+      "This one should be the second recovery candidate after the newest deleted draft is restored.",
+      "",
+      "It is intentionally long enough to qualify as a complete abandoned draft rather than a tiny intermediate edit.",
+    ].join("\n");
     const tiptapInput = app.window.getByTestId("composer-tiptap-input");
     const textbox = app.window.getByRole("textbox", { name: "New thread" });
+
+    await textbox.fill(earlierDraft);
+    await expect(tiptapInput).toHaveAttribute("data-value", /Earlier coherent draft/);
+    const storedEarlierDraft = await tiptapInput.getAttribute("data-value");
+    expect(storedEarlierDraft).toContain(
+      "This one should be the second recovery candidate after the newest deleted draft is restored.",
+    );
+    await app.window.keyboard.press(
+      process.platform === "darwin" ? "Meta+A" : "Control+A",
+    );
+    await app.window.keyboard.press("Backspace");
+    await expect(tiptapInput).toHaveAttribute("data-value", "");
 
     await textbox.fill(deletedDraft);
     await expect(tiptapInput).toHaveAttribute("data-value", /Somebody once told me/);
@@ -508,6 +527,41 @@ test("top-level new thread recovers an accidentally deleted no-project draft wit
 
     await app.window.keyboard.press("ArrowUp");
     await expect(tiptapInput).toHaveAttribute("data-value", storedDraft ?? "");
+    await expect
+      .poll(async () =>
+        await textbox.evaluate(
+          (node) =>
+            (node as HTMLElement & { selectionStart: number }).selectionStart,
+        )
+      )
+      .toBe(0);
+
+    await app.window.keyboard.press("ArrowUp");
+    await expect(tiptapInput).toHaveAttribute("data-value", storedEarlierDraft ?? "");
+    await expect
+      .poll(async () =>
+        await textbox.evaluate(
+          (node) =>
+            (node as HTMLElement & { selectionStart: number }).selectionStart,
+        )
+      )
+      .toBe(0);
+
+    await textbox.evaluate((node, selectionIndex) => {
+      (node as HTMLElement & {
+        setSelectionRange: (start: number, end: number) => void;
+      }).setSelectionRange(selectionIndex, selectionIndex);
+    }, storedEarlierDraft?.length ?? earlierDraft.length);
+    await expect
+      .poll(async () =>
+        await textbox.evaluate(
+          (node) =>
+            (node as HTMLElement & { selectionStart: number }).selectionStart,
+        )
+      )
+      .toBe(storedEarlierDraft?.length ?? earlierDraft.length);
+    await app.window.keyboard.press("ArrowUp");
+    await expect(tiptapInput).toHaveAttribute("data-value", storedEarlierDraft ?? "");
   } finally {
     await app.close();
     await fixture.cleanup();

--- a/apps/desktop/e2e/new-thread-transcript-sync.spec.ts
+++ b/apps/desktop/e2e/new-thread-transcript-sync.spec.ts
@@ -461,6 +461,60 @@ test("top-level new thread rereads the created thread until the assistant reply 
   }
 });
 
+test("top-level new thread recovers an accidentally deleted no-project draft with ArrowUp", async () => {
+  const fixture = await createNewThreadTranscriptFixture();
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    await app.window.getByRole("button", { name: "New thread" }).click();
+    await expect(
+      app.window.getByRole("heading", { level: 2, name: "New thread" }),
+    ).toBeVisible();
+
+    const deletedDraft = [
+      "Somebody once told me",
+      "",
+      "",
+      "The world is gonna roll me",
+      "",
+      "",
+      "I ain't the sharpest tool in the shed",
+      "",
+      "",
+      "```",
+      "// This is a tool",
+      "```",
+      "",
+      "",
+      "- This is",
+      "- Not exactly a tool",
+    ].join("\n");
+    const tiptapInput = app.window.getByTestId("composer-tiptap-input");
+    const textbox = app.window.getByRole("textbox", { name: "New thread" });
+
+    await textbox.fill(deletedDraft);
+    await expect(tiptapInput).toHaveAttribute("data-value", /Somebody once told me/);
+    const storedDraft = await tiptapInput.getAttribute("data-value");
+    expect(storedDraft).toContain("The world is gonna roll me");
+    expect(storedDraft).toContain("// This is a tool");
+    expect(storedDraft).toContain("- Not exactly a tool");
+
+    await app.window.keyboard.press(
+      process.platform === "darwin" ? "Meta+A" : "Control+A",
+    );
+    await app.window.keyboard.press("Backspace");
+    await expect(tiptapInput).toHaveAttribute("data-value", "");
+
+    await app.window.keyboard.press("ArrowUp");
+    await expect(tiptapInput).toHaveAttribute("data-value", storedDraft ?? "");
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
 test("does not move focus back to a new thread after the user selects another thread", async () => {
   const fixture = await createNewThreadFocusFixture();
   const app = await launchElectronApp({

--- a/apps/desktop/e2e/new-thread-transcript-sync.spec.ts
+++ b/apps/desktop/e2e/new-thread-transcript-sync.spec.ts
@@ -505,7 +505,6 @@ test("top-level new thread recovers an accidentally deleted no-project draft wit
       process.platform === "darwin" ? "Meta+A" : "Control+A",
     );
     await app.window.keyboard.press("Backspace");
-    await expect(tiptapInput).toHaveAttribute("data-value", "");
 
     await app.window.keyboard.press("ArrowUp");
     await expect(tiptapInput).toHaveAttribute("data-value", storedDraft ?? "");

--- a/apps/desktop/e2e/new-thread-transcript-sync.spec.ts
+++ b/apps/desktop/e2e/new-thread-transcript-sync.spec.ts
@@ -547,11 +547,8 @@ test("top-level new thread cycles deleted no-project drafts only from the recove
       )
       .toBe(0);
 
-    await textbox.evaluate((node, selectionIndex) => {
-      (node as HTMLElement & {
-        setSelectionRange: (start: number, end: number) => void;
-      }).setSelectionRange(selectionIndex, selectionIndex);
-    }, storedEarlierDraft?.length ?? earlierDraft.length);
+    await app.window.keyboard.press("ArrowDown");
+    await expect(tiptapInput).toHaveAttribute("data-value", storedDraft ?? "");
     await expect
       .poll(async () =>
         await textbox.evaluate(
@@ -559,8 +556,13 @@ test("top-level new thread cycles deleted no-project drafts only from the recove
             (node as HTMLElement & { selectionStart: number }).selectionStart,
         )
       )
-      .toBe(storedEarlierDraft?.length ?? earlierDraft.length);
+      .toBe(0);
+
     await app.window.keyboard.press("ArrowUp");
+    await expect(tiptapInput).toHaveAttribute("data-value", storedEarlierDraft ?? "");
+
+    await app.window.keyboard.press("ArrowRight");
+    await app.window.keyboard.press("ArrowDown");
     await expect(tiptapInput).toHaveAttribute("data-value", storedEarlierDraft ?? "");
   } finally {
     await app.close();

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -58,6 +58,7 @@
     "electron-log": "^5.4.3",
     "electron-updater": "^6.8.3",
     "node-fetch": "2.7.0",
+    "prosemirror-history": "^1.5.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-markdown": "^10.1.0",

--- a/apps/desktop/src/main/__tests__/composer-draft-recovery-store.test.ts
+++ b/apps/desktop/src/main/__tests__/composer-draft-recovery-store.test.ts
@@ -96,6 +96,77 @@ describe("ComposerDraftRecoveryStore", () => {
       }),
     ).toEqual([]);
   });
+
+  it("does not return same-id thread drafts from a different backend", () => {
+    store.recordHistory(
+      buildDraft({
+        backend: "grok",
+        scopeKey: "thread:grok:thread-1",
+        status: "sent",
+        text: "Grok backend draft with the same local thread id.",
+      }),
+    );
+    store.recordHistory(
+      buildDraft({
+        backend: "codex",
+        scopeKey: "thread:codex:thread-1",
+        status: "sent",
+        text: "Codex backend draft with the same local thread id.",
+      }),
+    );
+
+    expect(
+      store.listCandidates({
+        backend: "codex",
+        includeSent: true,
+        threadId: "thread-1",
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        backend: "codex",
+        text: "Codex backend draft with the same local thread id.",
+      }),
+    ]);
+  });
+
+  it("queries scoped journal rows before applying the global cap", () => {
+    store.recordHistory(
+      buildDraft({
+        contentHash: "target",
+        scopeKey: "thread:codex:older-thread",
+        status: "sent",
+        text: "Older scoped draft that should still be recoverable.",
+        threadId: "older-thread",
+        updatedAt: 1,
+      }),
+    );
+    for (let index = 0; index < 100; index += 1) {
+      store.recordHistory(
+        buildDraft({
+          contentHash: `other-${index}`,
+          scopeKey: `thread:codex:newer-thread-${index}`,
+          status: "sent",
+          text: `Newer draft in another thread ${index}.`,
+          threadId: `newer-thread-${index}`,
+          updatedAt: 100 + index,
+        }),
+      );
+    }
+
+    expect(
+      store.listCandidates({
+        backend: "codex",
+        includeSent: true,
+        scopeKey: "thread:codex:older-thread",
+        threadId: "older-thread",
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        scopeKey: "thread:codex:older-thread",
+        text: "Older scoped draft that should still be recoverable.",
+      }),
+    ]);
+  });
 });
 
 function buildDraft(

--- a/apps/desktop/src/main/__tests__/composer-draft-recovery-store.test.ts
+++ b/apps/desktop/src/main/__tests__/composer-draft-recovery-store.test.ts
@@ -1,0 +1,120 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { ComposerDraftSnapshotRecord } from "@pwragent/shared";
+import { ComposerDraftRecoveryStore } from "../state/composer-draft-recovery-store";
+import { StateDb } from "../state/state-db";
+
+let stateDb: StateDb;
+let store: ComposerDraftRecoveryStore;
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-composer-drafts-"));
+  stateDb = StateDb.open(path.join(tempDir, "state.db"));
+  store = new ComposerDraftRecoveryStore(stateDb);
+});
+
+afterEach(() => {
+  stateDb.close();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("ComposerDraftRecoveryStore", () => {
+  it("creates the durable draft schema at the current state DB version", () => {
+    expect(stateDb.raw.pragma("user_version", { simple: true })).toBe(6);
+    expect(
+      stateDb.raw
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?",
+        )
+        .get("composer_draft_latest"),
+    ).toBeDefined();
+    expect(
+      stateDb.raw
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?",
+        )
+        .get("composer_draft_journal"),
+    ).toBeDefined();
+  });
+
+  it("saves the latest unsent draft and ranks it for the current scope", () => {
+    store.save({
+      draft: buildDraft({
+        scopeKey: "thread:codex:thread-1",
+        text: "A durable draft that should survive a restart.",
+      }),
+      recordHistory: true,
+    });
+
+    expect(store.listLatest()).toEqual([
+      expect.objectContaining({
+        scopeKey: "thread:codex:thread-1",
+        text: "A durable draft that should survive a restart.",
+      }),
+    ]);
+    expect(
+      store.listCandidates({
+        includeSent: true,
+        scopeKey: "thread:codex:thread-1",
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        scopeKey: "thread:codex:thread-1",
+        status: "unsent",
+      }),
+    ]);
+  });
+
+  it("clears latest drafts while keeping recent sent history recoverable", () => {
+    const draft = buildDraft({
+      scopeKey: "thread:codex:thread-1",
+      status: "sent",
+      text: "Recently sent text that can be recalled from a blank composer.",
+    });
+
+    store.recordHistory(draft);
+    store.clear("thread:codex:thread-1");
+
+    expect(store.listLatest()).toEqual([]);
+    expect(
+      store.listCandidates({
+        includeSent: true,
+        scopeKey: "thread:codex:thread-1",
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        status: "sent",
+        text: "Recently sent text that can be recalled from a blank composer.",
+      }),
+    ]);
+    expect(
+      store.listCandidates({
+        scopeKey: "thread:codex:thread-1",
+      }),
+    ).toEqual([]);
+  });
+});
+
+function buildDraft(
+  patch: Partial<ComposerDraftSnapshotRecord>,
+): ComposerDraftSnapshotRecord {
+  const text = patch.text ?? "Example draft";
+  return {
+    scopeKey: "thread:codex:thread-1",
+    scopeKind: "thread",
+    backend: "codex",
+    threadId: "thread-1",
+    text,
+    skillTokens: [],
+    imageAttachments: [],
+    status: "unsent",
+    createdAt: 1,
+    updatedAt: 2,
+    contentHash: `hash-${text.length}-${patch.status ?? "unsent"}`,
+    charCount: text.length,
+    ...patch,
+  };
+}

--- a/apps/desktop/src/main/__tests__/composer-draft-recovery-store.test.ts
+++ b/apps/desktop/src/main/__tests__/composer-draft-recovery-store.test.ts
@@ -167,6 +167,73 @@ describe("ComposerDraftRecoveryStore", () => {
       }),
     ]);
   });
+
+  it("replaces the last unsubmitted prefix draft with the longer version", () => {
+    store.recordHistory(
+      buildDraft({
+        contentHash: "short",
+        status: "abandoned",
+        text: "the quick fox",
+        updatedAt: 10,
+      }),
+    );
+    store.recordHistory(
+      buildDraft({
+        contentHash: "long",
+        status: "abandoned",
+        text: "the quick fox jumped over the lazy dog",
+        updatedAt: 20,
+      }),
+    );
+
+    expect(
+      store.listCandidates({
+        scopeKey: "thread:codex:thread-1",
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        contentHash: "long",
+        text: "the quick fox jumped over the lazy dog",
+      }),
+    ]);
+  });
+
+  it("keeps sent history even when a longer unsent prompt starts with it", () => {
+    store.recordHistory(
+      buildDraft({
+        contentHash: "sent-short",
+        status: "sent",
+        text: "the quick fox",
+        updatedAt: 10,
+      }),
+    );
+    store.recordHistory(
+      buildDraft({
+        contentHash: "unsent-long",
+        status: "abandoned",
+        text: "the quick fox jumped over the lazy dog",
+        updatedAt: 20,
+      }),
+    );
+
+    expect(
+      store.listCandidates({
+        includeSent: true,
+        scopeKey: "thread:codex:thread-1",
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        contentHash: "unsent-long",
+        status: "abandoned",
+        text: "the quick fox jumped over the lazy dog",
+      }),
+      expect.objectContaining({
+        contentHash: "sent-short",
+        status: "sent",
+        text: "the quick fox",
+      }),
+    ]);
+  });
 });
 
 function buildDraft(

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -18,6 +18,8 @@ const showAppLogWindowMock = vi.fn();
 const showChangelogWindowMock = vi.fn();
 const registerImageNormalizationIpcHandlersMock = vi.fn();
 const disposeImageNormalizationIpcHandlersMock = vi.fn();
+const registerComposerDraftIpcHandlersMock = vi.fn();
+const disposeComposerDraftIpcHandlersMock = vi.fn();
 const registerPreloadLogIpcHandlersMock = vi.fn();
 const disposePreloadLogIpcHandlersMock = vi.fn();
 const registerProfilesIpcHandlersMock = vi.fn();
@@ -143,6 +145,11 @@ vi.mock("../ipc/image-normalization", () => ({
   disposeImageNormalizationIpcHandlers: disposeImageNormalizationIpcHandlersMock,
 }));
 
+vi.mock("../ipc/composer-drafts", () => ({
+  registerComposerDraftIpcHandlers: registerComposerDraftIpcHandlersMock,
+  disposeComposerDraftIpcHandlers: disposeComposerDraftIpcHandlersMock,
+}));
+
 vi.mock("../ipc/preload-log", () => ({
   registerPreloadLogIpcHandlers: registerPreloadLogIpcHandlersMock,
   disposePreloadLogIpcHandlers: disposePreloadLogIpcHandlersMock,
@@ -251,6 +258,8 @@ describe("bootstrapApp", () => {
     showChangelogWindowMock.mockReset();
     registerImageNormalizationIpcHandlersMock.mockReset();
     disposeImageNormalizationIpcHandlersMock.mockReset();
+    registerComposerDraftIpcHandlersMock.mockReset();
+    disposeComposerDraftIpcHandlersMock.mockReset();
     registerPreloadLogIpcHandlersMock.mockReset();
     disposePreloadLogIpcHandlersMock.mockReset();
     registerProfilesIpcHandlersMock.mockReset();
@@ -342,6 +351,7 @@ describe("bootstrapApp", () => {
     expect(registerAppServerIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(registerAgentIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(registerApplicationIpcHandlersMock).toHaveBeenCalledTimes(1);
+    expect(registerComposerDraftIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(registerImageNormalizationIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(registerPreloadLogIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(registerRendererErrorIpcHandlersMock).toHaveBeenCalledTimes(1);
@@ -464,6 +474,7 @@ describe("bootstrapApp", () => {
 
     appEventHandlers.get("before-quit")?.();
     expect(disposeApplicationIpcHandlersMock).toHaveBeenCalledTimes(1);
+    expect(disposeComposerDraftIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(disposeSettingsIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(disposeWindowPointerIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(disposeRuntimeIdentityIpcHandlersMock).not.toHaveBeenCalled();

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -23,6 +23,10 @@ import {
   registerImageNormalizationIpcHandlers,
 } from "./ipc/image-normalization";
 import {
+  disposeComposerDraftIpcHandlers,
+  registerComposerDraftIpcHandlers,
+} from "./ipc/composer-drafts";
+import {
   disposeMessagingStatusIpcHandlers,
   registerMessagingStatusIpcHandlers,
 } from "./ipc/messaging-status";
@@ -110,6 +114,7 @@ function disposeMainProcessResourcesSync(): void {
   disposeApplicationIpcHandlers();
   disposeAppMetadataIpcHandlers();
   disposeAppUpdateIpcHandlers();
+  disposeComposerDraftIpcHandlers();
   disposeImageNormalizationIpcHandlers();
   disposePreloadLogIpcHandlers();
   disposeProfilesIpcHandlers();
@@ -219,6 +224,7 @@ export function bootstrapApp(): void {
     registerApplicationIpcHandlers();
     registerAppMetadataIpcHandlers();
     registerAppUpdateIpcHandlers();
+    registerComposerDraftIpcHandlers();
     registerImageNormalizationIpcHandlers();
     registerPreloadLogIpcHandlers();
     registerProfilesIpcHandlers();

--- a/apps/desktop/src/main/ipc/composer-drafts.ts
+++ b/apps/desktop/src/main/ipc/composer-drafts.ts
@@ -1,0 +1,98 @@
+import { ipcMain } from "electron";
+import type {
+  ClearComposerDraftRequest,
+  ClearComposerDraftResponse,
+  ListComposerDraftLatestResponse,
+  ListComposerDraftRecoveryCandidatesRequest,
+  ListComposerDraftRecoveryCandidatesResponse,
+  RecordComposerDraftHistoryRequest,
+  RecordComposerDraftHistoryResponse,
+  SaveComposerDraftRequest,
+  SaveComposerDraftResponse,
+} from "@pwragent/shared";
+import {
+  COMPOSER_DRAFT_CLEAR_CHANNEL,
+  COMPOSER_DRAFT_LIST_CANDIDATES_CHANNEL,
+  COMPOSER_DRAFT_LIST_LATEST_CHANNEL,
+  COMPOSER_DRAFT_RECORD_HISTORY_CHANNEL,
+  COMPOSER_DRAFT_SAVE_CHANNEL,
+} from "../../shared/ipc";
+import { getMainLogger } from "../log";
+import { getAppStateDb } from "../state/app-state";
+import { ComposerDraftRecoveryStore } from "../state/composer-draft-recovery-store";
+
+const log = getMainLogger("pwragent:composer-drafts");
+
+function getStore(): ComposerDraftRecoveryStore {
+  return new ComposerDraftRecoveryStore(getAppStateDb());
+}
+
+export function registerComposerDraftIpcHandlers(): void {
+  ipcMain.removeHandler(COMPOSER_DRAFT_SAVE_CHANNEL);
+  ipcMain.handle(
+    COMPOSER_DRAFT_SAVE_CHANNEL,
+    async (
+      _event,
+      request: SaveComposerDraftRequest,
+    ): Promise<SaveComposerDraftResponse> => {
+      const draft = getStore().save(request);
+      return { draft };
+    },
+  );
+
+  ipcMain.removeHandler(COMPOSER_DRAFT_RECORD_HISTORY_CHANNEL);
+  ipcMain.handle(
+    COMPOSER_DRAFT_RECORD_HISTORY_CHANNEL,
+    async (
+      _event,
+      request: RecordComposerDraftHistoryRequest,
+    ): Promise<RecordComposerDraftHistoryResponse> => {
+      const candidate = getStore().recordHistory(request.draft);
+      return { candidate };
+    },
+  );
+
+  ipcMain.removeHandler(COMPOSER_DRAFT_CLEAR_CHANNEL);
+  ipcMain.handle(
+    COMPOSER_DRAFT_CLEAR_CHANNEL,
+    async (
+      _event,
+      request: ClearComposerDraftRequest,
+    ): Promise<ClearComposerDraftResponse> => {
+      getStore().clear(request.scopeKey);
+      return { scopeKey: request.scopeKey };
+    },
+  );
+
+  ipcMain.removeHandler(COMPOSER_DRAFT_LIST_CANDIDATES_CHANNEL);
+  ipcMain.handle(
+    COMPOSER_DRAFT_LIST_CANDIDATES_CHANNEL,
+    async (
+      _event,
+      request: ListComposerDraftRecoveryCandidatesRequest | undefined,
+    ): Promise<ListComposerDraftRecoveryCandidatesResponse> => {
+      return { candidates: getStore().listCandidates(request) };
+    },
+  );
+
+  ipcMain.removeHandler(COMPOSER_DRAFT_LIST_LATEST_CHANNEL);
+  ipcMain.handle(
+    COMPOSER_DRAFT_LIST_LATEST_CHANNEL,
+    async (): Promise<ListComposerDraftLatestResponse> => {
+      return { drafts: getStore().listLatest() };
+    },
+  );
+}
+
+export function disposeComposerDraftIpcHandlers(): void {
+  for (const channel of [
+    COMPOSER_DRAFT_SAVE_CHANNEL,
+    COMPOSER_DRAFT_RECORD_HISTORY_CHANNEL,
+    COMPOSER_DRAFT_CLEAR_CHANNEL,
+    COMPOSER_DRAFT_LIST_CANDIDATES_CHANNEL,
+    COMPOSER_DRAFT_LIST_LATEST_CHANNEL,
+  ]) {
+    ipcMain.removeHandler(channel);
+  }
+  log.debug("composer draft ipc handlers disposed");
+}

--- a/apps/desktop/src/main/state/composer-draft-recovery-store.ts
+++ b/apps/desktop/src/main/state/composer-draft-recovery-store.ts
@@ -1,0 +1,301 @@
+import type {
+  ComposerDraftLifecycle,
+  ComposerDraftRecoveryCandidate,
+  ComposerDraftSnapshotRecord,
+  ListComposerDraftRecoveryCandidatesRequest,
+  SaveComposerDraftRequest,
+} from "@pwragent/shared";
+import type { StateDb } from "./state-db.js";
+
+type DraftLatestRow = {
+  scope_key: string;
+  scope_kind: string;
+  status: string;
+  updated_at: number;
+  payload: string;
+};
+
+type DraftJournalRow = DraftLatestRow & {
+  id: number;
+  content_hash: string;
+  char_count: number;
+  created_at: number;
+};
+
+const DEFAULT_RECOVERY_LIMIT = 20;
+const MAX_RECOVERY_LIMIT = 50;
+const RECOVERABLE_STATUSES = new Set<ComposerDraftLifecycle>([
+  "unsent",
+  "abandoned",
+]);
+
+export class ComposerDraftRecoveryStore {
+  constructor(private readonly stateDb: StateDb) {}
+
+  save(request: SaveComposerDraftRequest): ComposerDraftSnapshotRecord {
+    const draft = normalizeDraftRecord(request.draft);
+    const db = this.stateDb.raw;
+
+    db.transaction(() => {
+      if (draft.status === "unsent") {
+        db.prepare(
+          `INSERT INTO composer_draft_latest(
+             scope_key, scope_kind, status, updated_at, payload
+           )
+           VALUES (?, ?, ?, ?, ?)
+           ON CONFLICT(scope_key) DO UPDATE SET
+             scope_kind = excluded.scope_kind,
+             status = excluded.status,
+             updated_at = excluded.updated_at,
+             payload = excluded.payload`,
+        ).run(
+          draft.scopeKey,
+          draft.scopeKind,
+          draft.status,
+          draft.updatedAt,
+          JSON.stringify(draft),
+        );
+      } else {
+        db.prepare("DELETE FROM composer_draft_latest WHERE scope_key = ?").run(
+          draft.scopeKey,
+        );
+      }
+
+      if (request.recordHistory) {
+        this.insertJournalDraft(draft);
+      }
+    })();
+
+    return draft;
+  }
+
+  recordHistory(
+    draftRecord: ComposerDraftSnapshotRecord,
+  ): ComposerDraftRecoveryCandidate {
+    const draft = normalizeDraftRecord(draftRecord);
+    return this.insertJournalDraft(draft);
+  }
+
+  clear(scopeKey: string): void {
+    this.stateDb.raw
+      .prepare("DELETE FROM composer_draft_latest WHERE scope_key = ?")
+      .run(scopeKey);
+  }
+
+  listLatest(): ComposerDraftSnapshotRecord[] {
+    const rows = this.stateDb.raw
+      .prepare(
+        `SELECT scope_key, scope_kind, status, updated_at, payload
+         FROM composer_draft_latest
+         ORDER BY updated_at DESC`,
+      )
+      .all() as DraftLatestRow[];
+
+    return rows
+      .map((row) => parseDraftPayload(row.payload))
+      .filter((draft): draft is ComposerDraftSnapshotRecord => Boolean(draft));
+  }
+
+  listCandidates(
+    request: ListComposerDraftRecoveryCandidatesRequest = {},
+  ): ComposerDraftRecoveryCandidate[] {
+    const limit = clampLimit(request.limit);
+    const latestRows = this.stateDb.raw
+      .prepare(
+        `SELECT scope_key, scope_kind, status, updated_at, payload
+         FROM composer_draft_latest
+         ORDER BY updated_at DESC
+         LIMIT ?`,
+      )
+      .all(Math.max(limit * 2, limit)) as DraftLatestRow[];
+    const journalRows = this.stateDb.raw
+      .prepare(
+        `SELECT id, scope_key, scope_kind, status, content_hash, char_count,
+                created_at, updated_at, payload
+         FROM composer_draft_journal
+         ORDER BY updated_at DESC, id DESC
+         LIMIT ?`,
+      )
+      .all(Math.max(limit * 4, limit)) as DraftJournalRow[];
+
+    const candidates: ComposerDraftRecoveryCandidate[] = [];
+    for (const row of latestRows) {
+      const draft = parseDraftPayload(row.payload);
+      if (draft) {
+        candidates.push({ ...draft });
+      }
+    }
+    for (const row of journalRows) {
+      const draft = parseDraftPayload(row.payload);
+      if (draft) {
+        candidates.push({ ...draft, journalId: row.id });
+      }
+    }
+
+    const seen = new Set<string>();
+    return candidates
+      .filter((candidate) => matchesRecoveryRequest(candidate, request))
+      .filter((candidate) => {
+        if (!isRecoverable(candidate, request.includeSent)) {
+          return false;
+        }
+        const key = `${candidate.scopeKey}:${candidate.status}:${candidate.contentHash}`;
+        if (seen.has(key)) {
+          return false;
+        }
+        seen.add(key);
+        return true;
+      })
+      .sort((left, right) => {
+        const leftScore = scoreCandidate(left, request);
+        const rightScore = scoreCandidate(right, request);
+        if (leftScore !== rightScore) {
+          return rightScore - leftScore;
+        }
+        return right.updatedAt - left.updatedAt;
+      })
+      .slice(0, limit);
+  }
+
+  private insertJournalDraft(
+    draft: ComposerDraftSnapshotRecord,
+  ): ComposerDraftRecoveryCandidate {
+    const db = this.stateDb.raw;
+    db.prepare(
+      `INSERT INTO composer_draft_journal(
+         scope_key, scope_kind, status, content_hash, char_count,
+         created_at, updated_at, payload
+       )
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(scope_key, content_hash, status) DO UPDATE SET
+         scope_kind = excluded.scope_kind,
+         char_count = excluded.char_count,
+         updated_at = excluded.updated_at,
+         payload = excluded.payload`,
+    ).run(
+      draft.scopeKey,
+      draft.scopeKind,
+      draft.status,
+      draft.contentHash,
+      draft.charCount,
+      draft.createdAt,
+      draft.updatedAt,
+      JSON.stringify(draft),
+    );
+
+    const row = db
+      .prepare(
+        `SELECT id, payload
+         FROM composer_draft_journal
+         WHERE scope_key = ? AND content_hash = ? AND status = ?`,
+      )
+      .get(draft.scopeKey, draft.contentHash, draft.status) as
+      | { id: number; payload: string }
+      | undefined;
+    const persisted = row ? parseDraftPayload(row.payload) : draft;
+    return { ...(persisted ?? draft), journalId: row?.id };
+  }
+}
+
+function normalizeDraftRecord(
+  draft: ComposerDraftSnapshotRecord,
+): ComposerDraftSnapshotRecord {
+  if (!draft || typeof draft !== "object") {
+    throw new Error("Invalid composer draft record");
+  }
+  const now = Date.now();
+  const text = typeof draft.text === "string" ? draft.text : "";
+  if (!draft.scopeKey || !draft.scopeKind) {
+    throw new Error("Composer draft record requires a scope");
+  }
+  return {
+    ...draft,
+    text,
+    createdAt: Number.isFinite(draft.createdAt) ? draft.createdAt : now,
+    updatedAt: Number.isFinite(draft.updatedAt) ? draft.updatedAt : now,
+    charCount: text.length,
+    contentHash: draft.contentHash || hashDraftContent(draft),
+    imageAttachments: Array.isArray(draft.imageAttachments)
+      ? draft.imageAttachments
+      : [],
+    skillTokens: Array.isArray(draft.skillTokens) ? draft.skillTokens : [],
+  };
+}
+
+function parseDraftPayload(
+  payload: string,
+): ComposerDraftSnapshotRecord | undefined {
+  try {
+    const parsed = JSON.parse(payload) as ComposerDraftSnapshotRecord;
+    return normalizeDraftRecord(parsed);
+  } catch {
+    return undefined;
+  }
+}
+
+function hashDraftContent(draft: Pick<ComposerDraftSnapshotRecord, "text">): string {
+  let hash = 5381;
+  for (let index = 0; index < draft.text.length; index += 1) {
+    hash = (hash * 33) ^ draft.text.charCodeAt(index);
+  }
+  return `h${(hash >>> 0).toString(36)}`;
+}
+
+function clampLimit(limit: number | undefined): number {
+  if (limit === undefined || !Number.isFinite(limit)) {
+    return DEFAULT_RECOVERY_LIMIT;
+  }
+  return Math.max(1, Math.min(MAX_RECOVERY_LIMIT, Math.floor(limit)));
+}
+
+function isRecoverable(
+  candidate: ComposerDraftRecoveryCandidate,
+  includeSent = false,
+): boolean {
+  if (candidate.status === "sent") {
+    return includeSent;
+  }
+  return RECOVERABLE_STATUSES.has(candidate.status);
+}
+
+function matchesRecoveryRequest(
+  candidate: ComposerDraftRecoveryCandidate,
+  request: ListComposerDraftRecoveryCandidatesRequest,
+): boolean {
+  if (request.scopeKey && candidate.scopeKey === request.scopeKey) {
+    return true;
+  }
+  if (request.threadId && candidate.threadId === request.threadId) {
+    return true;
+  }
+  if (request.directoryKey && candidate.directoryKey === request.directoryKey) {
+    return true;
+  }
+  if (request.backend && candidate.backend !== request.backend) {
+    return false;
+  }
+  return !request.scopeKey && !request.threadId && !request.directoryKey;
+}
+
+function scoreCandidate(
+  candidate: ComposerDraftRecoveryCandidate,
+  request: ListComposerDraftRecoveryCandidatesRequest,
+): number {
+  let score = 0;
+  if (request.scopeKey && candidate.scopeKey === request.scopeKey) {
+    score += 100;
+  }
+  if (request.threadId && candidate.threadId === request.threadId) {
+    score += 60;
+  }
+  if (request.directoryKey && candidate.directoryKey === request.directoryKey) {
+    score += 40;
+  }
+  if (candidate.status === "unsent") {
+    score += 20;
+  }
+  if (candidate.status === "sent") {
+    score -= 10;
+  }
+  return score;
+}

--- a/apps/desktop/src/main/state/composer-draft-recovery-store.ts
+++ b/apps/desktop/src/main/state/composer-draft-recovery-store.ts
@@ -100,23 +100,56 @@ export class ComposerDraftRecoveryStore {
     request: ListComposerDraftRecoveryCandidatesRequest = {},
   ): ComposerDraftRecoveryCandidate[] {
     const limit = clampLimit(request.limit);
-    const latestRows = this.stateDb.raw
-      .prepare(
-        `SELECT scope_key, scope_kind, status, updated_at, payload
-         FROM composer_draft_latest
-         ORDER BY updated_at DESC
-         LIMIT ?`,
-      )
-      .all(Math.max(limit * 2, limit)) as DraftLatestRow[];
-    const journalRows = this.stateDb.raw
-      .prepare(
-        `SELECT id, scope_key, scope_kind, status, content_hash, char_count,
-                created_at, updated_at, payload
-         FROM composer_draft_journal
-         ORDER BY updated_at DESC, id DESC
-         LIMIT ?`,
-      )
-      .all(Math.max(limit * 4, limit)) as DraftJournalRow[];
+    const scopeKeys = getRequestedScopeKeys(request);
+    const scopeKeyParams = getScopeKeyParams(scopeKeys);
+    const latestLimit = Math.max(limit * 2, limit);
+    const journalLimit = Math.max(limit * 4, limit);
+    const latestRows =
+      scopeKeys.length > 0
+        ? (this.stateDb.raw
+            .prepare(
+              `SELECT scope_key, scope_kind, status, updated_at, payload
+               FROM composer_draft_latest
+               WHERE
+                 (? IS NOT NULL AND scope_key = ?)
+                 OR (? IS NOT NULL AND scope_key = ?)
+                 OR (? IS NOT NULL AND scope_key = ?)
+               ORDER BY updated_at DESC
+               LIMIT ?`,
+            )
+            .all(...scopeKeyParams, latestLimit) as DraftLatestRow[])
+        : (this.stateDb.raw
+            .prepare(
+              `SELECT scope_key, scope_kind, status, updated_at, payload
+               FROM composer_draft_latest
+               ORDER BY updated_at DESC
+               LIMIT ?`,
+            )
+            .all(latestLimit) as DraftLatestRow[]);
+    const journalRows =
+      scopeKeys.length > 0
+        ? (this.stateDb.raw
+            .prepare(
+              `SELECT id, scope_key, scope_kind, status, content_hash, char_count,
+                      created_at, updated_at, payload
+               FROM composer_draft_journal
+               WHERE
+                 (? IS NOT NULL AND scope_key = ?)
+                 OR (? IS NOT NULL AND scope_key = ?)
+                 OR (? IS NOT NULL AND scope_key = ?)
+               ORDER BY updated_at DESC, id DESC
+               LIMIT ?`,
+            )
+            .all(...scopeKeyParams, journalLimit) as DraftJournalRow[])
+        : (this.stateDb.raw
+            .prepare(
+              `SELECT id, scope_key, scope_kind, status, content_hash, char_count,
+                      created_at, updated_at, payload
+               FROM composer_draft_journal
+               ORDER BY updated_at DESC, id DESC
+               LIMIT ?`,
+            )
+            .all(journalLimit) as DraftJournalRow[]);
 
     const candidates: ComposerDraftRecoveryCandidate[] = [];
     for (const row of latestRows) {
@@ -262,6 +295,9 @@ function matchesRecoveryRequest(
   candidate: ComposerDraftRecoveryCandidate,
   request: ListComposerDraftRecoveryCandidatesRequest,
 ): boolean {
+  if (request.backend && candidate.backend !== request.backend) {
+    return false;
+  }
   if (request.scopeKey && candidate.scopeKey === request.scopeKey) {
     return true;
   }
@@ -271,10 +307,28 @@ function matchesRecoveryRequest(
   if (request.directoryKey && candidate.directoryKey === request.directoryKey) {
     return true;
   }
-  if (request.backend && candidate.backend !== request.backend) {
-    return false;
-  }
   return !request.scopeKey && !request.threadId && !request.directoryKey;
+}
+
+function getRequestedScopeKeys(
+  request: ListComposerDraftRecoveryCandidatesRequest,
+): string[] {
+  const scopeKeys = new Set<string>();
+  if (request.scopeKey) {
+    scopeKeys.add(request.scopeKey);
+  }
+  if (request.backend && request.threadId) {
+    scopeKeys.add(`thread:${request.backend}:${request.threadId}`);
+  }
+  if (request.directoryKey) {
+    scopeKeys.add(`launchpad:${request.directoryKey}`);
+  }
+  return [...scopeKeys];
+}
+
+function getScopeKeyParams(scopeKeys: string[]): Array<string | null> {
+  const [first = null, second = null, third = null] = scopeKeys;
+  return [first, first, second, second, third, third];
 }
 
 function scoreCandidate(

--- a/apps/desktop/src/main/state/composer-draft-recovery-store.ts
+++ b/apps/desktop/src/main/state/composer-draft-recovery-store.ts
@@ -194,6 +194,45 @@ export class ComposerDraftRecoveryStore {
     draft: ComposerDraftSnapshotRecord,
   ): ComposerDraftRecoveryCandidate {
     const db = this.stateDb.raw;
+    const previousRow = db
+      .prepare(
+        `SELECT id, scope_key, scope_kind, status, content_hash, char_count,
+                created_at, updated_at, payload
+         FROM composer_draft_journal
+         WHERE scope_key = ? AND status IN ('unsent', 'abandoned')
+         ORDER BY updated_at DESC, id DESC
+         LIMIT 1`,
+      )
+      .get(draft.scopeKey) as DraftJournalRow | undefined;
+    const previousDraft = previousRow
+      ? parseDraftPayload(previousRow.payload)
+      : undefined;
+    if (shouldReplacePreviousUnsentDraft(previousDraft, draft)) {
+      db.prepare(
+        `DELETE FROM composer_draft_journal
+         WHERE scope_key = ? AND content_hash = ? AND status = ? AND id <> ?`,
+      ).run(draft.scopeKey, draft.contentHash, draft.status, previousRow!.id);
+      db.prepare(
+        `UPDATE composer_draft_journal
+         SET scope_kind = ?,
+             status = ?,
+             content_hash = ?,
+             char_count = ?,
+             updated_at = ?,
+             payload = ?
+         WHERE id = ?`,
+      ).run(
+        draft.scopeKind,
+        draft.status,
+        draft.contentHash,
+        draft.charCount,
+        draft.updatedAt,
+        JSON.stringify(draft),
+        previousRow!.id,
+      );
+      return { ...draft, journalId: previousRow!.id };
+    }
+
     db.prepare(
       `INSERT INTO composer_draft_journal(
          scope_key, scope_kind, status, content_hash, char_count,
@@ -352,4 +391,23 @@ function scoreCandidate(
     score -= 10;
   }
   return score;
+}
+
+function shouldReplacePreviousUnsentDraft(
+  previous: ComposerDraftSnapshotRecord | undefined,
+  next: ComposerDraftSnapshotRecord,
+): boolean {
+  if (!previous || previous.status === "sent" || next.status === "sent") {
+    return false;
+  }
+  if (previous.scopeKey !== next.scopeKey) {
+    return false;
+  }
+  const previousText = previous.text.trimEnd();
+  const nextText = next.text.trimEnd();
+  return (
+    previousText.length > 0 &&
+    nextText.length > previousText.length &&
+    nextText.startsWith(previousText)
+  );
 }

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -197,9 +197,41 @@ CREATE INDEX IF NOT EXISTS idx_directory_git_status_fetched
   ON directory_git_status(fetched_at DESC);
 `;
 
+const COMPOSER_DRAFT_RECOVERY_SCHEMA = `
+CREATE TABLE IF NOT EXISTS composer_draft_latest (
+  scope_key    TEXT PRIMARY KEY,
+  scope_kind   TEXT NOT NULL,
+  status       TEXT NOT NULL,
+  updated_at   INTEGER NOT NULL,
+  payload      TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_composer_draft_latest_updated
+  ON composer_draft_latest(updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS composer_draft_journal (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  scope_key    TEXT NOT NULL,
+  scope_kind   TEXT NOT NULL,
+  status       TEXT NOT NULL,
+  content_hash TEXT NOT NULL,
+  char_count   INTEGER NOT NULL,
+  created_at   INTEGER NOT NULL,
+  updated_at   INTEGER NOT NULL,
+  payload      TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_composer_draft_journal_scope_updated
+  ON composer_draft_journal(scope_key, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_composer_draft_journal_updated
+  ON composer_draft_journal(updated_at DESC);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_composer_draft_journal_scope_hash_status
+  ON composer_draft_journal(scope_key, content_hash, status);
+`;
+
 const DELIVERIES_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 const REVOKED_BINDINGS_RETENTION_MS = 90 * 24 * 60 * 60 * 1000;
 const APP_RUNTIME_INSTANCE_RETENTION_MS = 60 * 60 * 1000;
+const COMPOSER_DRAFT_JOURNAL_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+const COMPOSER_DRAFT_JOURNAL_CAP = 300;
 /**
  * Per-platform cap for the messaging activity log. Older rows are
  * evicted FIFO so the table stays small even on busy platforms. Tuned
@@ -266,6 +298,12 @@ export class StateDb {
     if ((db.pragma("user_version", { simple: true }) as number) < 5) {
       db.transaction(() => {
         db.pragma("user_version = 5");
+      })();
+    }
+    if ((db.pragma("user_version", { simple: true }) as number) < 6) {
+      db.transaction(() => {
+        db.exec(COMPOSER_DRAFT_RECOVERY_SCHEMA);
+        db.pragma("user_version = 6");
       })();
     }
 
@@ -351,6 +389,19 @@ export class StateDb {
            )`,
         )
         .run(MESSAGING_ACTIVITY_LOG_PER_PLATFORM_CAP);
+      this.db
+        .prepare("DELETE FROM composer_draft_journal WHERE updated_at < ?")
+        .run(now - COMPOSER_DRAFT_JOURNAL_RETENTION_MS);
+      this.db
+        .prepare(
+          `DELETE FROM composer_draft_journal
+           WHERE id IN (
+             SELECT id FROM composer_draft_journal
+             ORDER BY updated_at DESC, id DESC
+             LIMIT -1 OFFSET ?
+           )`,
+        )
+        .run(COMPOSER_DRAFT_JOURNAL_CAP);
     });
     cleanup();
     this.db.pragma("incremental_vacuum");
@@ -393,6 +444,7 @@ function ensureCurrentSchema(db: BetterSqlite3.Database): void {
   db.transaction(() => {
     db.exec(SCHEMA_V4);
     db.exec(DIRECTORY_GIT_STATUS_SCHEMA);
+    db.exec(COMPOSER_DRAFT_RECOVERY_SCHEMA);
     if ((db.pragma("user_version", { simple: true }) as number) < 4) {
       db.pragma("user_version = 4");
     }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -99,6 +99,11 @@ import type {
   CheckDesktopCodexAuthProfileStatusRequest,
   CheckDesktopCodexAuthProfileStatusResponse,
   ClearDesktopSettingsSecretRequest,
+  ClearComposerDraftRequest,
+  ClearComposerDraftResponse,
+  ListComposerDraftLatestResponse,
+  ListComposerDraftRecoveryCandidatesRequest,
+  ListComposerDraftRecoveryCandidatesResponse,
   CreateDesktopPwrAgentProfileRequest,
   CreateDesktopPwrAgentProfileResponse,
   CreateDesktopCodexAuthProfileRequest,
@@ -116,6 +121,10 @@ import type {
   ReadDesktopSettingsResponse,
   RefreshDesktopCodexDiscoveryRequest,
   ReplaceDesktopSettingsSecretRequest,
+  RecordComposerDraftHistoryRequest,
+  RecordComposerDraftHistoryResponse,
+  SaveComposerDraftRequest,
+  SaveComposerDraftResponse,
   SettingsCredentialTestKind,
   SettingsCredentialTestRequest,
   SettingsCredentialTestResult,
@@ -176,6 +185,11 @@ import {
   APPLICATION_OPEN_CHANNEL,
   BACKEND_LIST_CHANNEL,
   CODEX_ENVIRONMENT_SETUP_PROGRESS_CHANNEL,
+  COMPOSER_DRAFT_CLEAR_CHANNEL,
+  COMPOSER_DRAFT_LIST_CANDIDATES_CHANNEL,
+  COMPOSER_DRAFT_LIST_LATEST_CHANNEL,
+  COMPOSER_DRAFT_RECORD_HISTORY_CHANNEL,
+  COMPOSER_DRAFT_SAVE_CHANNEL,
   NAVIGATION_ENSURE_DIRECTORY_LAUNCHPAD_CHANNEL,
   FOCUSED_DIFF_ANALYZE_CHANNEL,
   IMAGE_UPLOAD_FALLBACK_CHANNEL,
@@ -543,6 +557,24 @@ const desktopApi = Object.freeze({
     request: ResetDirectoryLaunchpadRequest,
   ): Promise<ResetDirectoryLaunchpadResponse> =>
     await ipcRenderer.invoke(NAVIGATION_RESET_DIRECTORY_LAUNCHPAD_CHANNEL, request),
+  saveComposerDraft: async (
+    request: SaveComposerDraftRequest,
+  ): Promise<SaveComposerDraftResponse> =>
+    await ipcRenderer.invoke(COMPOSER_DRAFT_SAVE_CHANNEL, request),
+  recordComposerDraftHistory: async (
+    request: RecordComposerDraftHistoryRequest,
+  ): Promise<RecordComposerDraftHistoryResponse> =>
+    await ipcRenderer.invoke(COMPOSER_DRAFT_RECORD_HISTORY_CHANNEL, request),
+  clearComposerDraft: async (
+    request: ClearComposerDraftRequest,
+  ): Promise<ClearComposerDraftResponse> =>
+    await ipcRenderer.invoke(COMPOSER_DRAFT_CLEAR_CHANNEL, request),
+  listComposerDraftRecoveryCandidates: async (
+    request: ListComposerDraftRecoveryCandidatesRequest,
+  ): Promise<ListComposerDraftRecoveryCandidatesResponse> =>
+    await ipcRenderer.invoke(COMPOSER_DRAFT_LIST_CANDIDATES_CHANNEL, request),
+  listComposerDraftLatest: async (): Promise<ListComposerDraftLatestResponse> =>
+    await ipcRenderer.invoke(COMPOSER_DRAFT_LIST_LATEST_CHANNEL),
   pickDirectoryFromDisk: async (): Promise<PickDirectoryFromDiskResponse> =>
     await ipcRenderer.invoke(NAVIGATION_PICK_DIRECTORY_FROM_DISK_CHANNEL),
   registerDirectoryFromDisk: async (

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -17,6 +17,7 @@ import {
 } from "./features/settings/useDesktopSettings";
 import type { ThreadViewProps } from "./features/thread-detail/ThreadView";
 import { useComposerDraftStore } from "./features/composer/useComposerDraftStore";
+import { useDurableComposerDraftStore } from "./features/composer/useDurableComposerDraftStore";
 import { useBackendSummaries } from "./lib/useBackendSummaries";
 import { useDesktopApi, type DesktopApi } from "./lib/desktop-api";
 import { useRuntimeIdentity } from "./lib/runtime-identity";
@@ -91,7 +92,11 @@ function DesktopAppShell(props: {
     onRefreshNavigation: navigation.refresh,
     selectedThread: navigation.selectedThread,
   });
-  const composerDraftStore = useComposerDraftStore();
+  const baseComposerDraftStore = useComposerDraftStore();
+  const composerDraftStore = useDurableComposerDraftStore(
+    baseComposerDraftStore,
+    desktopApi,
+  );
   useQueuedTurnRelease({
     backends: backendSummaries.backends,
     composerDraftStore,

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -3198,9 +3198,13 @@ export function Composer(props: ComposerProps) {
     }
 
     if (!hasAutocomplete) {
+      const liveHasComposerContent = Boolean(
+        (inputRef.current?.value ?? draft).trim() ||
+          (inputRef.current?.skillTokenCount ?? skillTokens.length) > 0,
+      );
       if (
         event.key === "ArrowUp" &&
-        (!hasComposerContent ||
+        (!liveHasComposerContent ||
           recoveryCycleRef.current?.scopeKey === composerScopeKey) &&
         imageAttachments.length === 0
       ) {

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1149,7 +1149,7 @@ export function Composer(props: ComposerProps) {
 
     let cycle = recoveryCycleRef.current;
     if (!cycle || cycle.scopeKey !== composerScopeKey) {
-      const response = await draftStore
+      let response = await draftStore
         .listRecoveryCandidates({
           backend: props.thread?.source,
           directoryKey: props.launchpad?.directoryKey ?? props.directory?.key,
@@ -1162,6 +1162,20 @@ export function Composer(props: ComposerProps) {
           console.warn("Failed to list composer draft recovery candidates", error);
           return [];
         });
+      if (response.length === 0) {
+        response = await draftStore
+          .listRecoveryCandidates({
+            includeSent: true,
+            limit: 20,
+          })
+          .catch((error) => {
+            console.warn(
+              "Failed to list global composer draft recovery candidates",
+              error,
+            );
+            return [];
+          });
+      }
       const candidates = response
         .map((candidate) => ({
           draft: candidate.text,

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -909,6 +909,7 @@ export function Composer(props: ComposerProps) {
       : "empty";
   const localDraftStore = useComposerDraftStore();
   const draftStore = props.draftStore ?? localDraftStore;
+  const draftStoreHydrationVersion = draftStore.hydrationVersion ?? 0;
   const savedInitialDraft = draftStore.get(composerScopeKey);
   const savedInitialQueuedTurns = props.thread
     ? draftStore.getQueuedTurns(composerScopeKey)
@@ -1480,6 +1481,29 @@ export function Composer(props: ComposerProps) {
     setActiveOptimisticMessageId(undefined);
     setReviewConfig(undefined);
   }, [composerScopeKey, draft, editorDocument, imageAttachments, skillTokens]);
+
+  useEffect(() => {
+    const saved = draftStore.get(composerScopeKey);
+    if (!saved) {
+      return;
+    }
+    const latest = latestDraftSnapshotRef.current;
+    if (latest.scopeKey !== composerScopeKey) {
+      return;
+    }
+    if (
+      latest.snapshot.draft.trim() ||
+      latest.snapshot.skillTokens.length > 0 ||
+      latest.snapshot.imageAttachments.length > 0
+    ) {
+      return;
+    }
+
+    setDraft(saved.draft);
+    setEditorDocument(saved.editorDocument);
+    setImageAttachments(saved.imageAttachments);
+    setSkillTokens(saved.skillTokens);
+  }, [composerScopeKey, draftStore, draftStoreHydrationVersion]);
 
   useEffect(() => {
     setActiveSkillIndex(0);

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -923,6 +923,12 @@ export function Composer(props: ComposerProps) {
   const activeComposerScopeKeyRef = useRef(composerScopeKey);
   const pasteScopeRef = useRef({ key: composerScopeKey, version: 0 });
   const submittedDraftScopeKeysRef = useRef<Set<string>>(new Set());
+  const recoveryCycleRef = useRef<{
+    candidates: ComposerDraftSnapshot[];
+    index: number;
+    scopeKey: string;
+  } | undefined>(undefined);
+  const recoveringDraftRef = useRef(false);
   const deletedSkillTokenHistoryRef = useRef<DeletedSkillTokenHistoryEntry[]>([]);
   const latestDraftSnapshotRef = useRef<{
     scopeKey: string;
@@ -1058,6 +1064,9 @@ export function Composer(props: ComposerProps) {
     nextDraft: string,
     nextSkillTokens?: ComposerSkillToken[],
   ): void => {
+    if (!recoveringDraftRef.current) {
+      recoveryCycleRef.current = undefined;
+    }
     deletedSkillTokenHistoryRef.current = [];
     setEditorDocument(undefined);
     if (nextSkillTokens) {
@@ -1096,6 +1105,82 @@ export function Composer(props: ComposerProps) {
     if (isDraftStoreScope(scopeKey)) {
       draftStore.delete(scopeKey);
     }
+  };
+  const recordComposerDraftHistory = (
+    scopeKey: string,
+    state: ComposerDraftSnapshot,
+    status: "unsent" | "sent" | "abandoned",
+  ): void => {
+    if (!isDraftStoreScope(scopeKey)) {
+      return;
+    }
+    draftStore.recordHistory?.(scopeKey, state, status);
+  };
+  const applyRecoveredComposerDraft = (
+    snapshot: ComposerDraftSnapshot,
+  ): void => {
+    recoveringDraftRef.current = true;
+    deletedSkillTokenHistoryRef.current = [];
+    setDraft(snapshot.draft);
+    setEditorDocument(snapshot.editorDocument);
+    setImageAttachments(snapshot.imageAttachments);
+    setSkillTokens(snapshot.skillTokens);
+    saveComposerDraftSnapshot(composerScopeKey, snapshot);
+    setSendError(undefined);
+    requestAnimationFrame(() => {
+      recoveringDraftRef.current = false;
+      inputRef.current?.focus();
+    });
+  };
+  const recoverPreviousComposerDraft = async (): Promise<void> => {
+    if (!draftStore.listRecoveryCandidates) {
+      return;
+    }
+
+    let cycle = recoveryCycleRef.current;
+    if (!cycle || cycle.scopeKey !== composerScopeKey) {
+      const response = await draftStore
+        .listRecoveryCandidates({
+          backend: props.thread?.source,
+          directoryKey: props.launchpad?.directoryKey ?? props.directory?.key,
+          includeSent: true,
+          limit: 20,
+          scopeKey: composerScopeKey,
+          threadId: props.thread?.id,
+        })
+        .catch((error) => {
+          console.warn("Failed to list composer draft recovery candidates", error);
+          return [];
+        });
+      const candidates = response
+        .map((candidate) => ({
+          draft: candidate.text,
+          editorDocument: candidate.editorDocument as JSONContent | undefined,
+          imageAttachments: candidate.imageAttachments,
+          skillTokens: candidate.skillTokens as ComposerSkillToken[],
+        }))
+        .filter(
+          (candidate) =>
+            candidate.draft.trim() ||
+            candidate.skillTokens.length > 0 ||
+            candidate.imageAttachments.length > 0,
+        );
+      if (candidates.length === 0) {
+        return;
+      }
+      cycle = {
+        candidates,
+        index: 0,
+        scopeKey: composerScopeKey,
+      };
+    }
+
+    const candidate = cycle.candidates[cycle.index % cycle.candidates.length];
+    recoveryCycleRef.current = {
+      ...cycle,
+      index: cycle.index + 1,
+    };
+    applyRecoveredComposerDraft(candidate);
   };
   const isQueuedTurnStoreScope = (scopeKey: string): boolean =>
     scopeKey.startsWith("thread:");
@@ -1212,6 +1297,10 @@ export function Composer(props: ComposerProps) {
       skillTokens: [],
     };
 
+    const latest = latestDraftSnapshotRef.current;
+    if (latest.scopeKey === scopeKey) {
+      recordComposerDraftHistory(scopeKey, latest.snapshot, "sent");
+    }
     clearComposerDraftSnapshot(scopeKey);
     latestDraftSnapshotRef.current = {
       scopeKey,
@@ -1748,6 +1837,11 @@ export function Composer(props: ComposerProps) {
       if (options?.queued) {
         removeQueuedTurn(options.queued);
       } else {
+        recordComposerDraftHistory(
+          composerScopeKey,
+          latestDraftSnapshotRef.current.snapshot,
+          "sent",
+        );
         clearComposerDraftSnapshot(composerScopeKey);
         clearComposerDraft();
         setReviewConfig(undefined);
@@ -1863,6 +1957,11 @@ export function Composer(props: ComposerProps) {
       if (queued) {
         removeQueuedTurn(queued);
       } else {
+        recordComposerDraftHistory(
+          composerScopeKey,
+          latestDraftSnapshotRef.current.snapshot,
+          "sent",
+        );
         clearComposerDraftSnapshot(composerScopeKey);
         clearComposerDraft();
         setImageAttachments([]);
@@ -1944,6 +2043,11 @@ export function Composer(props: ComposerProps) {
       text: canonicalDraft,
       imageAttachments,
     });
+    recordComposerDraftHistory(
+      composerScopeKey,
+      latestDraftSnapshotRef.current.snapshot,
+      "unsent",
+    );
     clearComposerDraftSnapshot(composerScopeKey);
     clearComposerDraft();
     setImageAttachments([]);
@@ -1961,6 +2065,11 @@ export function Composer(props: ComposerProps) {
       imageAttachments: [],
       reviewCommand,
     });
+    recordComposerDraftHistory(
+      composerScopeKey,
+      latestDraftSnapshotRef.current.snapshot,
+      "unsent",
+    );
     clearComposerDraftSnapshot(composerScopeKey);
     clearComposerDraft();
     setImageAttachments([]);
@@ -2056,6 +2165,11 @@ export function Composer(props: ComposerProps) {
       imageAttachments: pending.imageAttachments,
       status: "pending",
     });
+    recordComposerDraftHistory(
+      composerScopeKey,
+      latestDraftSnapshotRef.current.snapshot,
+      "unsent",
+    );
     clearComposerDraftSnapshot(composerScopeKey);
     clearComposerDraft();
     setImageAttachments([]);
@@ -2967,6 +3081,9 @@ export function Composer(props: ComposerProps) {
     nextSkillTokens?: ComposerSkillToken[],
     metadata?: ComposerInputChangeMetadata,
   ): void => {
+    if (!recoveringDraftRef.current) {
+      recoveryCycleRef.current = undefined;
+    }
     unmarkComposerDraftSubmitted(composerScopeKey);
     const pendingProgrammaticChange =
       pendingProgrammaticComposerChangeRef.current;
@@ -3032,6 +3149,17 @@ export function Composer(props: ComposerProps) {
     }
 
     if (!hasAutocomplete) {
+      if (
+        event.key === "ArrowUp" &&
+        (!hasComposerContent ||
+          recoveryCycleRef.current?.scopeKey === composerScopeKey) &&
+        imageAttachments.length === 0
+      ) {
+        event.preventDefault();
+        void recoverPreviousComposerDraft();
+        return;
+      }
+
       if (event.key === "Enter" && !event.shiftKey) {
         event.preventDefault();
         void submitTurn(event.metaKey ? "steer" : "default");

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1096,6 +1096,15 @@ export function Composer(props: ComposerProps) {
       state.skillTokens.length === 0 &&
       state.imageAttachments.length === 0
     ) {
+      const previous = latestDraftSnapshotRef.current;
+      if (
+        previous.scopeKey === scopeKey &&
+        (previous.snapshot.draft.trim() ||
+          previous.snapshot.skillTokens.length > 0 ||
+          previous.snapshot.imageAttachments.length > 0)
+      ) {
+        recordComposerDraftHistory(scopeKey, previous.snapshot, "abandoned");
+      }
       draftStore.delete(scopeKey);
       return;
     }

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -192,6 +192,12 @@ type DeletedSkillTokenHistoryEntry = {
   skillTokens: ComposerSkillToken[];
 };
 
+type RecoveryLookupRequest = {
+  lookupId: number;
+  scopeKey: string;
+  version: number;
+};
+
 type PendingProgrammaticComposerChange = {
   expectedDraft: string;
   expectedSkillTokensSignature: string;
@@ -929,6 +935,8 @@ export function Composer(props: ComposerProps) {
     candidates: ComposerDraftSnapshot[];
     scopeKey: string;
   } | undefined>(undefined);
+  const recoveryEligibilityVersionRef = useRef(0);
+  const recoveryLookupSequenceRef = useRef(0);
   const recoveringDraftRef = useRef(false);
   const composerSelectionRequestSequenceRef = useRef(0);
   const deletedSkillTokenHistoryRef = useRef<DeletedSkillTokenHistoryEntry[]>([]);
@@ -1067,6 +1075,15 @@ export function Composer(props: ComposerProps) {
     setEditorDocument(undefined);
     setDraft("");
     setSkillTokens([]);
+  };
+  const hasLiveComposerContent = (): boolean => {
+    const latest = latestDraftSnapshotRef.current;
+    return Boolean(
+      (inputRef.current?.value ?? latest.snapshot.draft).trim() ||
+        (inputRef.current?.skillTokenCount ??
+          latest.snapshot.skillTokens.length) > 0 ||
+        latest.snapshot.imageAttachments.length > 0,
+    );
   };
   const updateVisibleDraft = (
     nextDraft: string,
@@ -1217,7 +1234,17 @@ export function Composer(props: ComposerProps) {
       });
     });
   };
-  const getOrCreateRecoveryCycle = async (): Promise<
+  const isRecoveryLookupCurrent = (
+    request: RecoveryLookupRequest,
+  ): boolean =>
+    recoveryLookupSequenceRef.current === request.lookupId &&
+    recoveryEligibilityVersionRef.current === request.version &&
+    activeComposerScopeKeyRef.current === request.scopeKey &&
+    latestDraftSnapshotRef.current.scopeKey === request.scopeKey &&
+    !hasLiveComposerContent();
+  const getOrCreateRecoveryCycle = async (
+    request?: RecoveryLookupRequest,
+  ): Promise<
     NonNullable<typeof recoveryCycleRef.current> | undefined
   > => {
     if (!draftStore.listRecoveryCandidates) {
@@ -1253,6 +1280,9 @@ export function Composer(props: ComposerProps) {
             return [];
           });
       }
+      if (request && !isRecoveryLookupCurrent(request)) {
+        return undefined;
+      }
       const candidates = response
         .map((candidate) => ({
           draft: candidate.text,
@@ -1280,8 +1310,20 @@ export function Composer(props: ComposerProps) {
     return cycle;
   };
   const recoverPreviousComposerDraft = async (): Promise<void> => {
-    const cycle = await getOrCreateRecoveryCycle();
+    const existingCycle = recoveryCycleRef.current;
+    const lookupRequest =
+      !existingCycle || existingCycle.scopeKey !== composerScopeKey
+        ? {
+            lookupId: ++recoveryLookupSequenceRef.current,
+            scopeKey: composerScopeKey,
+            version: recoveryEligibilityVersionRef.current,
+          }
+        : undefined;
+    const cycle = await getOrCreateRecoveryCycle(lookupRequest);
     if (!cycle) {
+      return;
+    }
+    if (lookupRequest && !isRecoveryLookupCurrent(lookupRequest)) {
       return;
     }
 
@@ -1573,6 +1615,8 @@ export function Composer(props: ComposerProps) {
       return;
     }
 
+    recoveryEligibilityVersionRef.current += 1;
+    recoveryLookupSequenceRef.current += 1;
     const previousSnapshot = {
       draft,
       editorDocument,
@@ -3237,6 +3281,7 @@ export function Composer(props: ComposerProps) {
   ): void => {
     if (!recoveringDraftRef.current) {
       recoveryCycleRef.current = undefined;
+      recoveryEligibilityVersionRef.current += 1;
     }
     unmarkComposerDraftSubmitted(composerScopeKey);
     const pendingProgrammaticChange =
@@ -3319,6 +3364,8 @@ export function Composer(props: ComposerProps) {
         (inputRef.current?.value ?? draft).trim() ||
           (inputRef.current?.skillTokenCount ?? skillTokens.length) > 0,
       );
+      const liveHasAnyComposerContent =
+        liveHasComposerContent || imageAttachments.length > 0;
       const recoveryCycle = recoveryCycleRef.current;
       const liveSelectionAtStart =
         (inputRef.current?.selectionStart ?? 0) === 0 &&
@@ -3327,20 +3374,22 @@ export function Composer(props: ComposerProps) {
         recoveryCycle?.scopeKey === composerScopeKey && liveSelectionAtStart;
       if (recoveryCycle && !canCycleActiveRecovery) {
         recoveryCycleRef.current = undefined;
+        recoveryEligibilityVersionRef.current += 1;
       }
       if (
         recoveryCycle &&
         canCycleActiveRecovery &&
-        liveHasComposerContent &&
+        liveHasAnyComposerContent &&
         event.key !== "ArrowUp" &&
         event.key !== "ArrowDown"
       ) {
         recoveryCycleRef.current = undefined;
+        recoveryEligibilityVersionRef.current += 1;
       }
       if (
         event.key === "ArrowUp" &&
         (!liveHasComposerContent || canCycleActiveRecovery) &&
-        imageAttachments.length === 0
+        (imageAttachments.length === 0 || canCycleActiveRecovery)
       ) {
         event.preventDefault();
         void recoverPreviousComposerDraft();
@@ -3348,9 +3397,9 @@ export function Composer(props: ComposerProps) {
       }
       if (
         event.key === "ArrowDown" &&
-        liveHasComposerContent &&
+        liveHasAnyComposerContent &&
         canCycleActiveRecovery &&
-        imageAttachments.length === 0
+        (imageAttachments.length === 0 || canCycleActiveRecovery)
       ) {
         event.preventDefault();
         recoverNextComposerDraft();

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -930,6 +930,7 @@ export function Composer(props: ComposerProps) {
     scopeKey: string;
   } | undefined>(undefined);
   const recoveringDraftRef = useRef(false);
+  const composerSelectionRequestSequenceRef = useRef(0);
   const deletedSkillTokenHistoryRef = useRef<DeletedSkillTokenHistoryEntry[]>([]);
   const latestDraftSnapshotRef = useRef<{
     scopeKey: string;
@@ -1000,6 +1001,10 @@ export function Composer(props: ComposerProps) {
   const [skillTokens, setSkillTokens] = useState<ComposerSkillToken[]>(
     latestDraftSnapshotRef.current.snapshot.skillTokens
   );
+  const [composerSelectionRequest, setComposerSelectionRequest] = useState<{
+    id: string;
+    index: number;
+  }>();
   const [activeSkillIndex, setActiveSkillIndex] = useState(0);
   const [activeSlashIndex, setActiveSlashIndex] = useState(0);
   const [dismissedAutocompleteKey, setDismissedAutocompleteKey] = useState<string>();
@@ -1066,8 +1071,9 @@ export function Composer(props: ComposerProps) {
   const updateVisibleDraft = (
     nextDraft: string,
     nextSkillTokens?: ComposerSkillToken[],
+    options?: { preserveRecoveryCycle?: boolean },
   ): void => {
-    if (!recoveringDraftRef.current) {
+    if (!recoveringDraftRef.current && !options?.preserveRecoveryCycle) {
       recoveryCycleRef.current = undefined;
     }
     deletedSkillTokenHistoryRef.current = [];
@@ -1128,6 +1134,38 @@ export function Composer(props: ComposerProps) {
     }
     draftStore.recordHistory?.(scopeKey, state, status);
   };
+  const getComposerDraftSnapshotSignature = (
+    snapshot: ComposerDraftSnapshot,
+  ): string =>
+    JSON.stringify({
+      draft: snapshot.draft,
+      editorDocument: snapshot.editorDocument,
+      imageAttachments: snapshot.imageAttachments.map((attachment) => ({
+        id: attachment.id,
+        name: attachment.name,
+        size: attachment.size,
+        type: attachment.type,
+        url: attachment.url,
+      })),
+      skillTokens: snapshot.skillTokens.map((token) => ({
+        index: token.index,
+        name: token.name,
+        path: token.path,
+      })),
+    });
+  const dedupeComposerDraftSnapshots = (
+    snapshots: ComposerDraftSnapshot[],
+  ): ComposerDraftSnapshot[] => {
+    const seen = new Set<string>();
+    return snapshots.filter((snapshot) => {
+      const signature = getComposerDraftSnapshotSignature(snapshot);
+      if (seen.has(signature)) {
+        return false;
+      }
+      seen.add(signature);
+      return true;
+    });
+  };
   const applyRecoveredComposerDraft = (
     snapshot: ComposerDraftSnapshot,
   ): void => {
@@ -1137,11 +1175,16 @@ export function Composer(props: ComposerProps) {
     setEditorDocument(snapshot.editorDocument);
     setImageAttachments(snapshot.imageAttachments);
     setSkillTokens(snapshot.skillTokens);
+    setComposerSelectionRequest({
+      id: `recovery:${++composerSelectionRequestSequenceRef.current}`,
+      index: 0,
+    });
     saveComposerDraftSnapshot(composerScopeKey, snapshot);
     setSendError(undefined);
     requestAnimationFrame(() => {
       recoveringDraftRef.current = false;
       inputRef.current?.focus();
+      inputRef.current?.setSelectionRange(0, 0);
     });
   };
   const recoverPreviousComposerDraft = async (): Promise<void> => {
@@ -1191,11 +1234,12 @@ export function Composer(props: ComposerProps) {
             candidate.skillTokens.length > 0 ||
             candidate.imageAttachments.length > 0,
         );
-      if (candidates.length === 0) {
+      const uniqueCandidates = dedupeComposerDraftSnapshots(candidates);
+      if (uniqueCandidates.length === 0) {
         return;
       }
       cycle = {
-        candidates,
+        candidates: uniqueCandidates,
         index: 0,
         scopeKey: composerScopeKey,
       };
@@ -3169,8 +3213,20 @@ export function Composer(props: ComposerProps) {
           })()
         : undefined;
     const storedSkillTokens = nextSkillTokens ?? skillTokens;
+    const preserveRecoveryCycle =
+      !recoveringDraftRef.current &&
+      recoveryCycleRef.current?.candidates.some(
+        (candidate) =>
+          getComposerDraftSnapshotSignature(candidate) ===
+          getComposerDraftSnapshotSignature({
+            draft: nextDraft,
+            editorDocument: metadata?.editorDocument,
+            imageAttachments,
+            skillTokens: storedSkillTokens,
+          }),
+      ) === true;
 
-    updateVisibleDraft(nextDraft, nextSkillTokens);
+    updateVisibleDraft(nextDraft, nextSkillTokens, { preserveRecoveryCycle });
     setEditorDocument(metadata?.editorDocument);
     saveComposerDraftSnapshot(composerScopeKey, {
       draft: nextDraft,
@@ -3202,10 +3258,18 @@ export function Composer(props: ComposerProps) {
         (inputRef.current?.value ?? draft).trim() ||
           (inputRef.current?.skillTokenCount ?? skillTokens.length) > 0,
       );
+      const recoveryCycle = recoveryCycleRef.current;
+      const liveSelectionAtStart =
+        (inputRef.current?.selectionStart ?? 0) === 0 &&
+        (inputRef.current?.selectionEnd ?? 0) === 0;
+      const canCycleActiveRecovery =
+        recoveryCycle?.scopeKey === composerScopeKey && liveSelectionAtStart;
+      if (recoveryCycle && !canCycleActiveRecovery) {
+        recoveryCycleRef.current = undefined;
+      }
       if (
         event.key === "ArrowUp" &&
-        (!liveHasComposerContent ||
-          recoveryCycleRef.current?.scopeKey === composerScopeKey) &&
+        (!liveHasComposerContent || canCycleActiveRecovery) &&
         imageAttachments.length === 0
       ) {
         event.preventDefault();
@@ -3784,6 +3848,7 @@ export function Composer(props: ComposerProps) {
             label={isLaunchpad ? "New thread" : "Reply"}
             markdownConversion
             placeholder={composerPlaceholder}
+            selectionRequest={composerSelectionRequest}
             editorDocument={editorDocument}
             skillTokens={skillTokens}
             value={draft}

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1030,7 +1030,9 @@ export function Composer(props: ComposerProps) {
     draft.length,
   );
   const isDraftStoreScope = (scopeKey: string): boolean =>
-    scopeKey.startsWith("thread:") || scopeKey.startsWith("launchpad:");
+    scopeKey === "empty" ||
+    scopeKey.startsWith("thread:") ||
+    scopeKey.startsWith("launchpad:");
   const canonicalDraft = useMemo(
     () => serializeDraftWithSkillTokens(draft, skillTokens),
     [draft, skillTokens]

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -925,8 +925,8 @@ export function Composer(props: ComposerProps) {
   const pasteScopeRef = useRef({ key: composerScopeKey, version: 0 });
   const submittedDraftScopeKeysRef = useRef<Set<string>>(new Set());
   const recoveryCycleRef = useRef<{
+    activeIndex?: number;
     candidates: ComposerDraftSnapshot[];
-    index: number;
     scopeKey: string;
   } | undefined>(undefined);
   const recoveringDraftRef = useRef(false);
@@ -1171,13 +1171,15 @@ export function Composer(props: ComposerProps) {
   ): void => {
     recoveringDraftRef.current = true;
     deletedSkillTokenHistoryRef.current = [];
-    setDraft(snapshot.draft);
-    setEditorDocument(snapshot.editorDocument);
-    setImageAttachments(snapshot.imageAttachments);
-    setSkillTokens(snapshot.skillTokens);
-    setComposerSelectionRequest({
-      id: `recovery:${++composerSelectionRequestSequenceRef.current}`,
-      index: 0,
+    flushSync(() => {
+      setDraft(snapshot.draft);
+      setEditorDocument(snapshot.editorDocument);
+      setImageAttachments(snapshot.imageAttachments);
+      setSkillTokens(snapshot.skillTokens);
+      setComposerSelectionRequest({
+        id: `recovery:${++composerSelectionRequestSequenceRef.current}`,
+        index: 0,
+      });
     });
     saveComposerDraftSnapshot(composerScopeKey, snapshot);
     setSendError(undefined);
@@ -1185,11 +1187,41 @@ export function Composer(props: ComposerProps) {
       recoveringDraftRef.current = false;
       inputRef.current?.focus();
       inputRef.current?.setSelectionRange(0, 0);
+      requestAnimationFrame(() => {
+        inputRef.current?.setSelectionRange(0, 0);
+      });
     });
   };
-  const recoverPreviousComposerDraft = async (): Promise<void> => {
+  const clearRecoveredComposerDraft = (): void => {
+    recoveryCycleRef.current = undefined;
+    recoveringDraftRef.current = true;
+    deletedSkillTokenHistoryRef.current = [];
+    clearComposerDraftSnapshot(composerScopeKey);
+    flushSync(() => {
+      setDraft("");
+      setEditorDocument(undefined);
+      setImageAttachments([]);
+      setSkillTokens([]);
+      setComposerSelectionRequest({
+        id: `recovery:${++composerSelectionRequestSequenceRef.current}`,
+        index: 0,
+      });
+    });
+    setSendError(undefined);
+    requestAnimationFrame(() => {
+      recoveringDraftRef.current = false;
+      inputRef.current?.focus();
+      inputRef.current?.setSelectionRange(0, 0);
+      requestAnimationFrame(() => {
+        inputRef.current?.setSelectionRange(0, 0);
+      });
+    });
+  };
+  const getOrCreateRecoveryCycle = async (): Promise<
+    NonNullable<typeof recoveryCycleRef.current> | undefined
+  > => {
     if (!draftStore.listRecoveryCandidates) {
-      return;
+      return undefined;
     }
 
     let cycle = recoveryCycleRef.current;
@@ -1239,18 +1271,47 @@ export function Composer(props: ComposerProps) {
         return;
       }
       cycle = {
+        activeIndex: undefined,
         candidates: uniqueCandidates,
-        index: 0,
         scopeKey: composerScopeKey,
       };
     }
 
-    const candidate = cycle.candidates[cycle.index % cycle.candidates.length];
+    return cycle;
+  };
+  const recoverPreviousComposerDraft = async (): Promise<void> => {
+    const cycle = await getOrCreateRecoveryCycle();
+    if (!cycle) {
+      return;
+    }
+
+    const activeIndex = cycle.activeIndex ?? -1;
+    const nextIndex = Math.min(activeIndex + 1, cycle.candidates.length - 1);
+    const candidate = cycle.candidates[nextIndex];
     recoveryCycleRef.current = {
       ...cycle,
-      index: cycle.index + 1,
+      activeIndex: nextIndex,
     };
     applyRecoveredComposerDraft(candidate);
+  };
+  const recoverNextComposerDraft = (): void => {
+    const cycle = recoveryCycleRef.current;
+    if (!cycle || cycle.scopeKey !== composerScopeKey) {
+      return;
+    }
+
+    const activeIndex = cycle.activeIndex ?? 0;
+    const nextIndex = activeIndex - 1;
+    if (nextIndex < 0) {
+      clearRecoveredComposerDraft();
+      return;
+    }
+
+    recoveryCycleRef.current = {
+      ...cycle,
+      activeIndex: nextIndex,
+    };
+    applyRecoveredComposerDraft(cycle.candidates[nextIndex]);
   };
   const isQueuedTurnStoreScope = (scopeKey: string): boolean =>
     scopeKey.startsWith("thread:");
@@ -3268,12 +3329,31 @@ export function Composer(props: ComposerProps) {
         recoveryCycleRef.current = undefined;
       }
       if (
+        recoveryCycle &&
+        canCycleActiveRecovery &&
+        liveHasComposerContent &&
+        event.key !== "ArrowUp" &&
+        event.key !== "ArrowDown"
+      ) {
+        recoveryCycleRef.current = undefined;
+      }
+      if (
         event.key === "ArrowUp" &&
         (!liveHasComposerContent || canCycleActiveRecovery) &&
         imageAttachments.length === 0
       ) {
         event.preventDefault();
         void recoverPreviousComposerDraft();
+        return;
+      }
+      if (
+        event.key === "ArrowDown" &&
+        liveHasComposerContent &&
+        canCycleActiveRecovery &&
+        imageAttachments.length === 0
+      ) {
+        event.preventDefault();
+        recoverNextComposerDraft();
         return;
       }
 

--- a/apps/desktop/src/renderer/src/features/composer/ComposerInputTypes.ts
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerInputTypes.ts
@@ -15,5 +15,7 @@ export type ComposerInputHandle = {
   focus: () => void;
   readonly selectionEnd: number;
   readonly selectionStart: number;
+  readonly skillTokenCount: number;
+  readonly value: string;
   setSelectionRange: (start: number, end: number) => void;
 };

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -13,6 +13,7 @@ import {
 import { flushSync } from "react-dom";
 import Mention from "@tiptap/extension-mention";
 import StarterKit from "@tiptap/starter-kit";
+import { closeHistory } from "prosemirror-history";
 import { EditorContent, useEditor, type JSONContent } from "@tiptap/react";
 import type { AppServerSkillSummary } from "@pwragent/shared";
 import { buildSkillTooltip, findSkillTrigger } from "../../lib/skill-mentions";
@@ -54,6 +55,11 @@ type TiptapReadState = {
 };
 
 type DeletedSingleSkillState = TiptapReadState & {
+  editorDocument: JSONContent;
+  selectionIndex: number;
+};
+
+type ControlledHistoryEntry = TiptapReadState & {
   editorDocument: JSONContent;
   selectionIndex: number;
 };
@@ -133,6 +139,10 @@ const SkillMention = Mention.extend({
 
 const MarkdownStarterKit = StarterKit.configure({
   link: false,
+  undoRedo: {
+    depth: 500,
+    newGroupDelay: 750,
+  },
 });
 
 const PlainTextStarterKit = StarterKit.configure({
@@ -144,6 +154,10 @@ const PlainTextStarterKit = StarterKit.configure({
   link: false,
   listItem: false,
   orderedList: false,
+  undoRedo: {
+    depth: 500,
+    newGroupDelay: 750,
+  },
 });
 
 function splitTextContent(text: string): JSONContent[] {
@@ -942,6 +956,10 @@ function getContentSignature(params: {
   });
 }
 
+function closeEditorHistory(editor: TiptapEditor): void {
+  editor.view.dispatch(closeHistory(editor.state.tr));
+}
+
 function applyExternalSkillInsertion(params: {
   current: TiptapReadState;
   editor: TiptapEditor;
@@ -995,11 +1013,16 @@ function applyExternalSkillInsertion(params: {
     insertedContent.push({ type: "text", text: " " });
   }
 
-  return params.editor.commands.insertContentAt(
+  closeEditorHistory(params.editor);
+  const inserted = params.editor.commands.insertContentAt(
     { from, to },
     insertedContent,
     { updateSelection: true },
   );
+  if (inserted) {
+    closeEditorHistory(params.editor);
+  }
+  return inserted;
 }
 
 export const ComposerTiptapInput = forwardRef<
@@ -1014,6 +1037,10 @@ export const ComposerTiptapInput = forwardRef<
   const deletedSingleSkillRef = useRef<DeletedSingleSkillState | undefined>(
     undefined,
   );
+  const controlledUndoStackRef = useRef<ControlledHistoryEntry[]>([]);
+  const controlledRedoStackRef = useRef<ControlledHistoryEntry[]>([]);
+  const applyingControlledHistoryRef = useRef(false);
+  const controlledChangeInProgressRef = useRef(false);
   const readMode: TiptapReadMode = props.markdownConversion ? "markdown" : "text";
   const propsSignature = getContentSignature({
     value: props.value,
@@ -1028,6 +1055,92 @@ export const ComposerTiptapInput = forwardRef<
   );
 
   propsRef.current = props;
+  const getControlledHistoryEntry = (
+    currentEditor: TiptapEditor,
+  ): ControlledHistoryEntry => ({
+    ...readTiptapContent(currentEditor, readMode),
+    editorDocument: currentEditor.getJSON(),
+    selectionIndex: selectionIndexRef.current,
+  });
+  const pushControlledUndoEntry = (currentEditor: TiptapEditor): void => {
+    if (applyingControlledHistoryRef.current) {
+      return;
+    }
+    const entry = getControlledHistoryEntry(currentEditor);
+    const stack = controlledUndoStackRef.current;
+    const previous = stack.at(-1);
+    if (
+      previous &&
+      getContentSignature(previous) === getContentSignature(entry)
+    ) {
+      return;
+    }
+    stack.push(entry);
+    if (stack.length > 100) {
+      stack.shift();
+    }
+  };
+  const restoreControlledHistoryEntry = (
+    currentEditor: TiptapEditor,
+    entry: ControlledHistoryEntry,
+  ): void => {
+    applyingControlledHistoryRef.current = true;
+    closeEditorHistory(currentEditor);
+    currentEditor.commands.setContent(entry.editorDocument, { emitUpdate: false });
+    closeEditorHistory(currentEditor);
+    selectionIndexRef.current = entry.selectionIndex;
+    flushSync(() => {
+      propsRef.current.onChange(entry.value, entry.skillTokens, {
+        editorDocument: entry.editorDocument,
+      });
+    });
+    applyingControlledHistoryRef.current = false;
+    requestAnimationFrame(() => {
+      currentEditor.commands.focus();
+      try {
+        currentEditor.commands.setTextSelection(
+          getPositionAtDraftIndex(currentEditor, entry.selectionIndex, readMode),
+        );
+      } catch {
+        // jsdom and detached editor states can fail selection mapping.
+      }
+    });
+  };
+  const runUndoOrRedo = (
+    currentEditor: TiptapEditor,
+    direction: "undo" | "redo",
+  ): boolean => {
+    const sourceStack =
+      direction === "undo"
+        ? controlledUndoStackRef.current
+        : controlledRedoStackRef.current;
+    const targetStack =
+      direction === "undo"
+        ? controlledRedoStackRef.current
+        : controlledUndoStackRef.current;
+    const entry = sourceStack.pop();
+    if (entry) {
+      targetStack.push(getControlledHistoryEntry(currentEditor));
+      restoreControlledHistoryEntry(currentEditor, entry);
+      return true;
+    }
+
+    const beforeSignature = getContentSignature(
+      readTiptapContent(currentEditor, readMode),
+    );
+    const handled =
+      direction === "undo"
+        ? currentEditor.commands.undo()
+        : currentEditor.commands.redo();
+    const afterSignature = getContentSignature(
+      readTiptapContent(currentEditor, readMode),
+    );
+    if (handled && beforeSignature !== afterSignature) {
+      return true;
+    }
+
+    return handled;
+  };
   const initialContent = useMemo(
     () =>
       props.editorDocument ??
@@ -1065,8 +1178,37 @@ export const ComposerTiptapInput = forwardRef<
         keydown: (_view, event) => {
           const macPlatform = isMacPlatform();
           if (
+            event.key.toLowerCase() === "y" &&
+            (event.metaKey || event.ctrlKey) &&
+            !event.altKey &&
+            !event.shiftKey
+          ) {
+            const currentEditor = editorRef.current;
+            if (!currentEditor) {
+              return false;
+            }
+            event.preventDefault();
+            return runUndoOrRedo(currentEditor, "redo");
+          }
+
+          if (
             event.key.toLowerCase() === "z" &&
             (event.metaKey || event.ctrlKey) &&
+            !event.altKey &&
+            event.shiftKey
+          ) {
+            const currentEditor = editorRef.current;
+            if (!currentEditor) {
+              return false;
+            }
+            event.preventDefault();
+            return runUndoOrRedo(currentEditor, "redo");
+          }
+
+          if (
+            event.key.toLowerCase() === "z" &&
+            (event.metaKey || event.ctrlKey) &&
+            !event.altKey &&
             !event.shiftKey &&
             deletedSingleSkillRef.current
           ) {
@@ -1077,9 +1219,11 @@ export const ComposerTiptapInput = forwardRef<
             if (!currentEditor) {
               return true;
             }
+            closeEditorHistory(currentEditor);
             currentEditor.commands.setContent(deleted.editorDocument, {
               emitUpdate: false,
             });
+            closeEditorHistory(currentEditor);
             selectionIndexRef.current = deleted.selectionIndex;
             flushSync(() => {
               propsRef.current.onChange(deleted.value, deleted.skillTokens, {
@@ -1131,15 +1275,31 @@ export const ComposerTiptapInput = forwardRef<
               skillTokens: propsRef.current.skillTokens,
               value: propsRef.current.value,
             };
+            closeEditorHistory(currentEditor);
             currentEditor.commands.setContent(buildTiptapContent("", []), {
               emitUpdate: false,
             });
+            closeEditorHistory(currentEditor);
             flushSync(() => {
               propsRef.current.onChange("", [], {
                 editorDocument: currentEditor.getJSON(),
               });
             });
             return true;
+          }
+
+          if (
+            event.key.toLowerCase() === "z" &&
+            (event.metaKey || event.ctrlKey) &&
+            !event.altKey &&
+            !event.shiftKey
+          ) {
+            const currentEditor = editorRef.current;
+            if (!currentEditor) {
+              return false;
+            }
+            event.preventDefault();
+            return runUndoOrRedo(currentEditor, "undo");
           }
 
           if (
@@ -1191,6 +1351,14 @@ export const ComposerTiptapInput = forwardRef<
         return;
       }
       pendingExternalSignatureRef.current = undefined;
+      if (
+        !pendingSignature &&
+        !controlledChangeInProgressRef.current &&
+        !applyingControlledHistoryRef.current
+      ) {
+        controlledUndoStackRef.current = [];
+        controlledRedoStackRef.current = [];
+      }
       selectionIndexRef.current = getDraftIndexAtPosition(
         nextEditor,
         nextEditor.state.selection.from,
@@ -1255,6 +1423,9 @@ export const ComposerTiptapInput = forwardRef<
       get: () => propsRef.current.value,
       set: (nextValue) => {
         const value = String(nextValue ?? "");
+        pushControlledUndoEntry(editor);
+        controlledRedoStackRef.current = [];
+        controlledChangeInProgressRef.current = true;
         selectionIndexRef.current = value.length;
         editor.commands.setContent(
           buildTiptapContent(value, [], {
@@ -1267,6 +1438,7 @@ export const ComposerTiptapInput = forwardRef<
             editorDocument: editor.getJSON(),
           });
         });
+        controlledChangeInProgressRef.current = false;
       },
     });
     Object.defineProperty(editorDom, "selectionStart", {
@@ -1326,12 +1498,18 @@ export const ComposerTiptapInput = forwardRef<
       currentEditorDocumentSignature !== nextEditorDocumentSignature
     ) {
       pendingExternalSignatureRef.current = propsSignature;
+      pushControlledUndoEntry(editor);
+      controlledRedoStackRef.current = [];
+      closeEditorHistory(editor);
       editor.commands.setContent(props.editorDocument!, { emitUpdate: false });
+      closeEditorHistory(editor);
       pendingExternalSignatureRef.current = undefined;
       return;
     }
 
     pendingExternalSignatureRef.current = propsSignature;
+    pushControlledUndoEntry(editor);
+    controlledRedoStackRef.current = [];
     if (
       applyExternalSkillInsertion({
         current,
@@ -1347,12 +1525,14 @@ export const ComposerTiptapInput = forwardRef<
     }
 
     pendingExternalSignatureRef.current = propsSignature;
+    closeEditorHistory(editor);
     editor.commands.setContent(
       buildTiptapContent(props.value, props.skillTokens, {
         markdownConversion: props.markdownConversion,
       }),
       { emitUpdate: false },
     );
+    closeEditorHistory(editor);
     pendingExternalSignatureRef.current = undefined;
 
     if (pendingSelectionIndexRef.current !== undefined) {
@@ -1439,6 +1619,40 @@ export const ComposerTiptapInput = forwardRef<
       data-placeholder={props.placeholder}
       data-testid="composer-tiptap-input"
       data-value={props.value}
+      onKeyDownCapture={(event) => {
+        if (!editor || event.defaultPrevented) {
+          return;
+        }
+        if (
+          event.key.toLowerCase() === "z" &&
+          (event.metaKey || event.ctrlKey) &&
+          !event.altKey &&
+          !event.shiftKey &&
+          deletedSingleSkillRef.current
+        ) {
+          return;
+        }
+        if (
+          event.key.toLowerCase() === "y" &&
+          (event.metaKey || event.ctrlKey) &&
+          !event.altKey &&
+          !event.shiftKey
+        ) {
+          event.preventDefault();
+          event.stopPropagation();
+          runUndoOrRedo(editor, "redo");
+          return;
+        }
+        if (
+          event.key.toLowerCase() === "z" &&
+          (event.metaKey || event.ctrlKey) &&
+          !event.altKey
+        ) {
+          event.preventDefault();
+          event.stopPropagation();
+          runUndoOrRedo(editor, event.shiftKey ? "redo" : "undo");
+        }
+      }}
     >
       <EditorContent editor={editor} />
     </div>

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -43,6 +43,10 @@ type ComposerTiptapInputProps = {
   onKeyDown?: (event: KeyboardEvent<HTMLDivElement>) => void;
   onPaste?: (event: ClipboardEvent<HTMLDivElement>) => void;
   placeholder: string;
+  selectionRequest?: {
+    id: string;
+    index: number;
+  };
   skillTokens: ComposerSkillToken[];
   value: string;
 };
@@ -1034,6 +1038,7 @@ export const ComposerTiptapInput = forwardRef<
   const selectionIndexRef = useRef(props.value.length);
   const pendingExternalSignatureRef = useRef<string | undefined>(undefined);
   const pendingSelectionIndexRef = useRef<number | undefined>(undefined);
+  const appliedSelectionRequestIdRef = useRef<string | undefined>(undefined);
   const deletedSingleSkillRef = useRef<DeletedSingleSkillState | undefined>(
     undefined,
   );
@@ -1553,6 +1558,23 @@ export const ComposerTiptapInput = forwardRef<
   ]);
 
   useEffect(() => {
+    if (
+      !editor ||
+      !props.selectionRequest ||
+      appliedSelectionRequestIdRef.current === props.selectionRequest.id
+    ) {
+      return;
+    }
+
+    appliedSelectionRequestIdRef.current = props.selectionRequest.id;
+    selectionIndexRef.current = props.selectionRequest.index;
+    editor.commands.focus();
+    editor.commands.setTextSelection(
+      getPositionAtDraftIndex(editor, props.selectionRequest.index, readMode),
+    );
+  }, [editor, props.selectionRequest, readMode]);
+
+  useEffect(() => {
     if (!editor) {
       return;
     }
@@ -1629,6 +1651,13 @@ export const ComposerTiptapInput = forwardRef<
       data-value={props.value}
       onKeyDownCapture={(event) => {
         if (!editor || event.defaultPrevented) {
+          return;
+        }
+        if (event.key === "ArrowUp") {
+          propsRef.current.onKeyDown?.(event as unknown as KeyboardEvent<HTMLDivElement>);
+          if (event.defaultPrevented) {
+            event.stopPropagation();
+          }
           return;
         }
         if (

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -1111,6 +1111,20 @@ export const ComposerTiptapInput = forwardRef<
       }
     });
   };
+  const applySelectionRequest = (
+    currentEditor: TiptapEditor,
+    request: ComposerTiptapInputProps["selectionRequest"] | undefined,
+  ): void => {
+    if (!request || appliedSelectionRequestIdRef.current === request.id) {
+      return;
+    }
+    appliedSelectionRequestIdRef.current = request.id;
+    selectionIndexRef.current = request.index;
+    currentEditor.commands.focus();
+    currentEditor.commands.setTextSelection(
+      getPositionAtDraftIndex(currentEditor, request.index, readMode),
+    );
+  };
   const runUndoOrRedo = (
     currentEditor: TiptapEditor,
     direction: "undo" | "redo",
@@ -1508,6 +1522,7 @@ export const ComposerTiptapInput = forwardRef<
       closeEditorHistory(editor);
       editor.commands.setContent(props.editorDocument!, { emitUpdate: false });
       closeEditorHistory(editor);
+      applySelectionRequest(editor, props.selectionRequest);
       pendingExternalSignatureRef.current = undefined;
       return;
     }
@@ -1547,17 +1562,20 @@ export const ComposerTiptapInput = forwardRef<
       editor.commands.setTextSelection(
         getPositionAtDraftIndex(editor, nextSelectionIndex, readMode),
       );
+    } else {
+      applySelectionRequest(editor, props.selectionRequest);
     }
   }, [
     editor,
     props.editorDocument,
+    props.selectionRequest,
     props.skillTokens,
     props.value,
     propsSignature,
     readMode,
   ]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (
       !editor ||
       !props.selectionRequest ||
@@ -1653,7 +1671,7 @@ export const ComposerTiptapInput = forwardRef<
         if (!editor || event.defaultPrevented) {
           return;
         }
-        if (event.key === "ArrowUp") {
+        if (event.key === "ArrowUp" || event.key === "ArrowDown") {
           propsRef.current.onKeyDown?.(event as unknown as KeyboardEvent<HTMLDivElement>);
           if (event.defaultPrevented) {
             event.stopPropagation();

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -1597,6 +1597,14 @@ export const ComposerTiptapInput = forwardRef<
     get selectionStart() {
       return selectionIndexRef.current;
     },
+    get skillTokenCount() {
+      return editor
+        ? readTiptapContent(editor, readMode).skillTokens.length
+        : props.skillTokens.length;
+    },
+    get value() {
+      return editor ? readTiptapContent(editor, readMode).value : props.value;
+    },
     setSelectionRange: (start: number) => {
       if (!editor) {
         return;

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -2,6 +2,7 @@ import "@testing-library/jest-dom/vitest";
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import type {
   BackendSummary,
+  ComposerDraftRecoveryCandidate,
   NavigationThreadSummary,
   NavigationLaunchpadDraft,
   StartReviewRequest,
@@ -4518,6 +4519,132 @@ describe("Composer", () => {
           ],
         }),
       );
+    });
+  });
+
+  it("keeps post-skill long-form text recoverable across undo and redo", async () => {
+    renderComposerWithRegressionSkills();
+
+    const input = screen.getByLabelText("Reply");
+    fireEvent.change(input, {
+      target: { value: `${reportedSkillAutocompleteDraftPrefix}$ce:plan` },
+    });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    const longBody = [
+      "This is the first long paragraph after the inserted skill.",
+      "",
+      "This is the second paragraph with enough text to look like a real note.",
+      "",
+      "This is the final sentence before a small accidental deletion.",
+    ].join("\n");
+    fireEvent.change(input, {
+      target: { value: `${reportedSkillAutocompleteDraftPrefix}${longBody}` },
+    });
+    fireEvent.change(input, {
+      target: {
+        value: `${reportedSkillAutocompleteDraftPrefix}${longBody.replace(
+          "small accidental deletion",
+          "small accidental"
+        )}`,
+      },
+    });
+
+    const richInput = screen.getByTestId("composer-tiptap-input");
+    fireEvent.keyDown(screen.getByRole("textbox", { name: "Reply" }), { key: "z", metaKey: true });
+
+    await waitFor(() => {
+      expect(richInput.getAttribute("data-value")).toContain(
+        "This is the second paragraph with enough text",
+      );
+    });
+    expect(richInput).toHaveTextContent(
+      "This is the second paragraph with enough text"
+    );
+
+    fireEvent.keyDown(screen.getByRole("textbox", { name: "Reply" }), { key: "y", metaKey: true });
+
+    await waitFor(() => {
+      expect(richInput.getAttribute("data-value")).toContain(
+        "This is the second paragraph with enough text",
+      );
+    });
+    expect(richInput).toHaveTextContent(
+      "This is the second paragraph with enough text"
+    );
+  });
+
+  it("cycles durable draft recovery candidates with ArrowUp from a blank composer", async () => {
+    const draftStore = createComposerDraftStore();
+    const recoveryCandidates: ComposerDraftRecoveryCandidate[] = [
+      {
+        scopeKey: "thread:codex:thread-1",
+        scopeKind: "thread",
+        backend: "codex",
+        threadId: "thread-1",
+        text: "Recovered unsent draft",
+        skillTokens: [],
+        imageAttachments: [],
+        status: "unsent",
+        createdAt: 1,
+        updatedAt: 3,
+        contentHash: "h1",
+        charCount: "Recovered unsent draft".length,
+      },
+      {
+        scopeKey: "thread:codex:thread-1",
+        scopeKind: "thread",
+        backend: "codex",
+        threadId: "thread-1",
+        text: "Recovered recently sent draft",
+        skillTokens: [],
+        imageAttachments: [],
+        status: "sent",
+        createdAt: 1,
+        updatedAt: 2,
+        contentHash: "h2",
+        charCount: "Recovered recently sent draft".length,
+      },
+    ];
+    draftStore.listRecoveryCandidates = vi.fn(async () => recoveryCandidates);
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn: vi.fn(),
+        }}
+        disabled={false}
+        draftStore={draftStore}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Build Codex client",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const input = screen.getByLabelText("Reply");
+    fireEvent.keyDown(input, { key: "ArrowUp" });
+
+    await waitFor(() => {
+      expect(input).toHaveValue("Recovered unsent draft");
+    });
+    expect(draftStore.listRecoveryCandidates).toHaveBeenCalledWith(
+      expect.objectContaining({
+        includeSent: true,
+        scopeKey: "thread:codex:thread-1",
+      }),
+    );
+
+    fireEvent.keyDown(input, { key: "ArrowUp" });
+
+    await waitFor(() => {
+      expect(input).toHaveValue("Recovered recently sent draft");
     });
   });
 

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -4648,6 +4648,47 @@ describe("Composer", () => {
     });
   });
 
+  it("hydrates a mounted blank composer when durable drafts load after mount", async () => {
+    const draftStore = createComposerDraftStore();
+    draftStore.hydrationVersion = 0;
+    const thread: NavigationThreadSummary = {
+      id: "thread-1",
+      title: "Build Codex client",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const renderComposer = () => (
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn: vi.fn(),
+        }}
+        disabled={false}
+        draftStore={draftStore}
+        skills={[]}
+        thread={thread}
+      />
+    );
+    const { rerender } = render(renderComposer());
+    const input = screen.getByLabelText("Reply");
+    expect(input).toHaveValue("");
+
+    draftStore.set("thread:codex:thread-1", {
+      draft: "Hydrated durable draft after startup",
+      editorDocument: undefined,
+      imageAttachments: [],
+      skillTokens: [],
+    });
+    draftStore.hydrationVersion = 1;
+    rerender(renderComposer());
+
+    await waitFor(() => {
+      expect(input).toHaveValue("Hydrated durable draft after startup");
+    });
+  });
+
   it("does not collapse pasted GitHub paragraph gaps when deleting a trailing blank line", async () => {
     const heading =
       "feat(navigation): replace Inbox tab with user-curated Pins tab (drag-to-pin, reorderable, with auto-switch on drag)";

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -4576,6 +4576,13 @@ describe("Composer", () => {
 
   it("cycles durable draft recovery candidates like shell history", async () => {
     const draftStore = createComposerDraftStore();
+    const recoveredImageAttachment = {
+      id: "image-1",
+      name: "diagram.png",
+      size: 3,
+      type: "image/png",
+      url: "data:image/png;base64,AQID",
+    };
     const recoveryCandidates: ComposerDraftRecoveryCandidate[] = [
       {
         scopeKey: "thread:codex:thread-1",
@@ -4584,7 +4591,7 @@ describe("Composer", () => {
         threadId: "thread-1",
         text: "Recovered unsent draft",
         skillTokens: [],
-        imageAttachments: [],
+        imageAttachments: [recoveredImageAttachment],
         status: "unsent",
         createdAt: 1,
         updatedAt: 3,
@@ -4661,6 +4668,70 @@ describe("Composer", () => {
     await waitFor(() => {
       expect(input).toHaveValue("");
     });
+  });
+
+  it("does not apply stale async draft recovery after the user types", async () => {
+    const draftStore = createComposerDraftStore();
+    let resolveRecoveryCandidates:
+      | ((candidates: ComposerDraftRecoveryCandidate[]) => void)
+      | undefined;
+    draftStore.listRecoveryCandidates = vi.fn(
+      () =>
+        new Promise<ComposerDraftRecoveryCandidate[]>((resolve) => {
+          resolveRecoveryCandidates = resolve;
+        }),
+    );
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn: vi.fn(),
+        }}
+        disabled={false}
+        draftStore={draftStore}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Build Codex client",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const input = screen.getByLabelText("Reply");
+    fireEvent.keyDown(input, { key: "ArrowUp" });
+    fireEvent.change(input, { target: { value: "New user draft" } });
+
+    await waitFor(() => {
+      expect(input).toHaveValue("New user draft");
+    });
+
+    await act(async () => {
+      resolveRecoveryCandidates?.([
+        {
+          scopeKey: "thread:codex:thread-1",
+          scopeKind: "thread",
+          backend: "codex",
+          threadId: "thread-1",
+          text: "Stale recovered draft",
+          skillTokens: [],
+          imageAttachments: [],
+          status: "unsent",
+          createdAt: 1,
+          updatedAt: 2,
+          contentHash: "stale",
+          charCount: "Stale recovered draft".length,
+        },
+      ]);
+      await Promise.resolve();
+    });
+
+    await flushReactUpdates();
+    expect(input).toHaveValue("New user draft");
   });
 
   it("falls back to global recovery candidates from a blank composer", async () => {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -4648,6 +4648,69 @@ describe("Composer", () => {
     });
   });
 
+  it("falls back to global recovery candidates from a blank composer", async () => {
+    const draftStore = createComposerDraftStore();
+    const globalCandidate: ComposerDraftRecoveryCandidate = {
+      scopeKey: "thread:codex:other-thread",
+      scopeKind: "thread",
+      backend: "codex",
+      threadId: "other-thread",
+      text: "Recovered draft from another composer",
+      skillTokens: [],
+      imageAttachments: [],
+      status: "abandoned",
+      createdAt: 1,
+      updatedAt: 2,
+      contentHash: "h-global",
+      charCount: "Recovered draft from another composer".length,
+    };
+    draftStore.listRecoveryCandidates = vi
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([globalCandidate]);
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn: vi.fn(),
+        }}
+        disabled={false}
+        draftStore={draftStore}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Build Codex client",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const input = screen.getByLabelText("Reply");
+    fireEvent.keyDown(input, { key: "ArrowUp" });
+
+    await waitFor(() => {
+      expect(input).toHaveValue("Recovered draft from another composer");
+    });
+    expect(draftStore.listRecoveryCandidates).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        includeSent: true,
+        scopeKey: "thread:codex:thread-1",
+      }),
+    );
+    expect(draftStore.listRecoveryCandidates).toHaveBeenNthCalledWith(
+      2,
+      {
+        includeSent: true,
+        limit: 20,
+      },
+    );
+  });
+
   it("recovers a meaningful unsent draft after the user deletes it", async () => {
     const draftStore = createComposerDraftStore();
     const recoveryCandidates: ComposerDraftRecoveryCandidate[] = [];

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -4648,6 +4648,76 @@ describe("Composer", () => {
     });
   });
 
+  it("recovers a meaningful unsent draft after the user deletes it", async () => {
+    const draftStore = createComposerDraftStore();
+    const recoveryCandidates: ComposerDraftRecoveryCandidate[] = [];
+    draftStore.recordHistory = vi.fn((scopeKey, snapshot, status) => {
+      recoveryCandidates.unshift({
+        scopeKey,
+        scopeKind: "thread",
+        backend: "codex",
+        threadId: "thread-1",
+        text: snapshot.draft,
+        editorDocument: snapshot.editorDocument,
+        skillTokens: snapshot.skillTokens,
+        imageAttachments: snapshot.imageAttachments,
+        status,
+        createdAt: 1,
+        updatedAt: 2,
+        contentHash: `h${recoveryCandidates.length + 1}`,
+        charCount: snapshot.draft.length,
+      });
+    });
+    draftStore.listRecoveryCandidates = vi.fn(async () => recoveryCandidates);
+    const deletedDraft =
+      "This is a long unsent draft that the user accidentally deleted. " +
+      "It has enough detail to be worth recovering from ArrowUp history " +
+      "instead of disappearing when the composer becomes empty.";
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn: vi.fn(),
+        }}
+        disabled={false}
+        draftStore={draftStore}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Build Codex client",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const input = screen.getByLabelText("Reply");
+    fireEvent.change(input, { target: { value: deletedDraft } });
+    await waitFor(() => {
+      expect(input).toHaveValue(deletedDraft);
+    });
+
+    fireEvent.change(input, { target: { value: "" } });
+    await waitFor(() => {
+      expect(input).toHaveValue("");
+    });
+
+    expect(draftStore.recordHistory).toHaveBeenCalledWith(
+      "thread:codex:thread-1",
+      expect.objectContaining({ draft: deletedDraft }),
+      "abandoned",
+    );
+
+    fireEvent.keyDown(input, { key: "ArrowUp" });
+
+    await waitFor(() => {
+      expect(input).toHaveValue(deletedDraft);
+    });
+  });
+
   it("hydrates a mounted blank composer when durable drafts load after mount", async () => {
     const draftStore = createComposerDraftStore();
     draftStore.hydrationVersion = 0;

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -4574,7 +4574,7 @@ describe("Composer", () => {
     );
   });
 
-  it("cycles durable draft recovery candidates with ArrowUp from a blank composer", async () => {
+  it("cycles durable draft recovery candidates like shell history", async () => {
     const draftStore = createComposerDraftStore();
     const recoveryCandidates: ComposerDraftRecoveryCandidate[] = [
       {
@@ -4633,6 +4633,7 @@ describe("Composer", () => {
 
     await waitFor(() => {
       expect(input).toHaveValue("Recovered unsent draft");
+      expect((input as HTMLTextAreaElement).selectionStart).toBe(0);
     });
     expect(draftStore.listRecoveryCandidates).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -4645,6 +4646,20 @@ describe("Composer", () => {
 
     await waitFor(() => {
       expect(input).toHaveValue("Recovered recently sent draft");
+      expect((input as HTMLTextAreaElement).selectionStart).toBe(0);
+    });
+
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+
+    await waitFor(() => {
+      expect(input).toHaveValue("Recovered unsent draft");
+      expect((input as HTMLTextAreaElement).selectionStart).toBe(0);
+    });
+
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+
+    await waitFor(() => {
+      expect(input).toHaveValue("");
     });
   });
 

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -4781,6 +4781,68 @@ describe("Composer", () => {
     });
   });
 
+  it("recovers an accidentally deleted no-project draft from the empty composer scope", async () => {
+    const draftStore = createComposerDraftStore();
+    const recoveryCandidates: ComposerDraftRecoveryCandidate[] = [];
+    draftStore.recordHistory = vi.fn((scopeKey, snapshot, status) => {
+      recoveryCandidates.unshift({
+        scopeKey,
+        scopeKind: "empty",
+        text: snapshot.draft,
+        editorDocument: snapshot.editorDocument,
+        skillTokens: snapshot.skillTokens,
+        imageAttachments: snapshot.imageAttachments,
+        status,
+        createdAt: 1,
+        updatedAt: 2,
+        contentHash: `h-empty-${recoveryCandidates.length + 1}`,
+        charCount: snapshot.draft.length,
+      });
+    });
+    draftStore.listRecoveryCandidates = vi.fn(async () => recoveryCandidates);
+    const deletedDraft =
+      "Somebody once told me\n\n\n\n" +
+      "The world is gonna roll me\n\n\n\n" +
+      "I ain't the sharpest tool in the shed\n\n\n\n" +
+      "```\n// This is a tool\n```\n\n\n\n" +
+      "- This is\n- Not exactly a tool";
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn: vi.fn(),
+        }}
+        disabled={false}
+        draftStore={draftStore}
+        skills={[]}
+      />
+    );
+
+    const input = screen.getByLabelText("Reply");
+    fireEvent.change(input, { target: { value: deletedDraft } });
+    await waitFor(() => {
+      expect(input).toHaveValue(deletedDraft);
+    });
+
+    fireEvent.change(input, { target: { value: "" } });
+    await waitFor(() => {
+      expect(input).toHaveValue("");
+    });
+
+    expect(draftStore.recordHistory).toHaveBeenCalledWith(
+      "empty",
+      expect.objectContaining({ draft: deletedDraft }),
+      "abandoned",
+    );
+
+    fireEvent.keyDown(input, { key: "ArrowUp" });
+
+    await waitFor(() => {
+      expect(input).toHaveValue(deletedDraft);
+    });
+  });
+
   it("hydrates a mounted blank composer when durable drafts load after mount", async () => {
     const draftStore = createComposerDraftStore();
     draftStore.hydrationVersion = 0;

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/useDurableComposerDraftStore.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/useDurableComposerDraftStore.test.tsx
@@ -75,6 +75,60 @@ describe("useDurableComposerDraftStore", () => {
       }),
     );
   });
+
+  it("returns just-recorded sent prompts before durable history finishes", async () => {
+    type RecordHistoryResponse = Awaited<
+      ReturnType<NonNullable<DesktopApi["recordComposerDraftHistory"]>>
+    >;
+    let resolveRecordHistory:
+      | ((response: RecordHistoryResponse) => void)
+      | undefined;
+    const recordComposerDraftHistory = vi.fn<
+      NonNullable<DesktopApi["recordComposerDraftHistory"]>
+    >(
+      () =>
+        new Promise((resolve) => {
+          resolveRecordHistory = resolve;
+        }),
+    );
+    const listComposerDraftRecoveryCandidates = vi.fn<
+      NonNullable<DesktopApi["listComposerDraftRecoveryCandidates"]>
+    >(async () => ({ candidates: [] }));
+    const desktopApi = {
+      listComposerDraftRecoveryCandidates,
+      recordComposerDraftHistory,
+    } as Partial<DesktopApi> as DesktopApi;
+    const { result } = renderHook(() =>
+      useDurableComposerDraftStore(useComposerDraftStore(), desktopApi),
+    );
+
+    act(() => {
+      result.current.recordHistory?.(
+        "thread:codex:thread-1",
+        buildSnapshot("Short prompt"),
+        "sent",
+      );
+    });
+
+    const candidates = await result.current.listRecoveryCandidates?.({
+      backend: "codex",
+      includeSent: true,
+      scopeKey: "thread:codex:thread-1",
+      threadId: "thread-1",
+    });
+
+    expect(candidates).toEqual([
+      expect.objectContaining({
+        scopeKey: "thread:codex:thread-1",
+        status: "sent",
+        text: "Short prompt",
+      }),
+    ]);
+
+    const draft = recordComposerDraftHistory.mock.calls[0]?.[0].draft;
+    expect(draft).toBeDefined();
+    resolveRecordHistory?.({ candidate: draft! });
+  });
 });
 
 function buildSnapshot(draft: string): ComposerDraftSnapshot {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/useDurableComposerDraftStore.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/useDurableComposerDraftStore.test.tsx
@@ -1,0 +1,87 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { DesktopApi } from "../../../lib/desktop-api";
+import type { ComposerDraftSnapshot } from "../useComposerDraftStore";
+import { useComposerDraftStore } from "../useComposerDraftStore";
+import { useDurableComposerDraftStore } from "../useDurableComposerDraftStore";
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("useDurableComposerDraftStore", () => {
+  it("flushes pending debounced draft saves on teardown", () => {
+    vi.useFakeTimers();
+    const saveComposerDraft = vi.fn<NonNullable<DesktopApi["saveComposerDraft"]>>(
+      async (request) => ({ draft: request.draft }),
+    );
+    const desktopApi = {
+      saveComposerDraft,
+    } as Partial<DesktopApi> as DesktopApi;
+    const { result, unmount } = renderHook(() =>
+      useDurableComposerDraftStore(useComposerDraftStore(), desktopApi),
+    );
+
+    act(() => {
+      result.current.set(
+        "thread:codex:thread-1",
+        buildSnapshot("Keep this draft before teardown."),
+      );
+    });
+
+    expect(saveComposerDraft).not.toHaveBeenCalled();
+    unmount();
+
+    expect(saveComposerDraft).toHaveBeenCalledOnce();
+    expect(saveComposerDraft).toHaveBeenCalledWith(
+      expect.objectContaining({
+        draft: expect.objectContaining({
+          scopeKey: "thread:codex:thread-1",
+          status: "unsent",
+          text: "Keep this draft before teardown.",
+        }),
+      }),
+    );
+  });
+
+  it("records short sent prompts in durable recovery history", () => {
+    const recordComposerDraftHistory = vi.fn<
+      NonNullable<DesktopApi["recordComposerDraftHistory"]>
+    >(async (request) => ({ candidate: request.draft }));
+    const desktopApi = {
+      recordComposerDraftHistory,
+    } as Partial<DesktopApi> as DesktopApi;
+    const { result } = renderHook(() =>
+      useDurableComposerDraftStore(useComposerDraftStore(), desktopApi),
+    );
+
+    act(() => {
+      result.current.recordHistory?.(
+        "thread:codex:thread-1",
+        buildSnapshot("Short prompt"),
+        "sent",
+      );
+    });
+
+    expect(recordComposerDraftHistory).toHaveBeenCalledOnce();
+    expect(recordComposerDraftHistory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        draft: expect.objectContaining({
+          scopeKey: "thread:codex:thread-1",
+          status: "sent",
+          text: "Short prompt",
+        }),
+      }),
+    );
+  });
+});
+
+function buildSnapshot(draft: string): ComposerDraftSnapshot {
+  return {
+    draft,
+    editorDocument: undefined,
+    imageAttachments: [],
+    skillTokens: [],
+  };
+}

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/useDurableComposerDraftStore.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/useDurableComposerDraftStore.test.tsx
@@ -129,6 +129,51 @@ describe("useDurableComposerDraftStore", () => {
     expect(draft).toBeDefined();
     resolveRecordHistory?.({ candidate: draft! });
   });
+
+  it("replaces the optimistic unsubmitted prefix candidate with the longer draft", async () => {
+    const recordComposerDraftHistory = vi.fn<
+      NonNullable<DesktopApi["recordComposerDraftHistory"]>
+    >(async (request) => ({ candidate: request.draft }));
+    const listComposerDraftRecoveryCandidates = vi.fn<
+      NonNullable<DesktopApi["listComposerDraftRecoveryCandidates"]>
+    >(async () => ({ candidates: [] }));
+    const desktopApi = {
+      listComposerDraftRecoveryCandidates,
+      recordComposerDraftHistory,
+    } as Partial<DesktopApi> as DesktopApi;
+    const { result } = renderHook(() =>
+      useDurableComposerDraftStore(useComposerDraftStore(), desktopApi),
+    );
+
+    act(() => {
+      result.current.recordHistory?.(
+        "thread:codex:thread-1",
+        buildSnapshot(
+          "the quick fox typed enough context to be treated as a complete recoverable draft before it grew past the minimum recovery threshold",
+        ),
+        "abandoned",
+      );
+      result.current.recordHistory?.(
+        "thread:codex:thread-1",
+        buildSnapshot(
+          "the quick fox typed enough context to be treated as a complete recoverable draft before it grew past the minimum recovery threshold into a longer coherent prompt",
+        ),
+        "abandoned",
+      );
+    });
+
+    const candidates = await result.current.listRecoveryCandidates?.({
+      backend: "codex",
+      scopeKey: "thread:codex:thread-1",
+      threadId: "thread-1",
+    });
+
+    expect(candidates).toEqual([
+      expect.objectContaining({
+        text: "the quick fox typed enough context to be treated as a complete recoverable draft before it grew past the minimum recovery threshold into a longer coherent prompt",
+      }),
+    ]);
+  });
 });
 
 function buildSnapshot(draft: string): ComposerDraftSnapshot {

--- a/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
+++ b/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
@@ -37,6 +37,7 @@ export type ComposerPendingSteerSnapshot = {
 export type ComposerDraftStore = {
   delete(scopeKey: string): void;
   get(scopeKey: string): ComposerDraftSnapshot | undefined;
+  hydrationVersion?: number;
   deletePendingSteer(scopeKey: string): void;
   deleteQueuedTurn(scopeKey: string): void;
   getPendingSteer(scopeKey: string): ComposerPendingSteerSnapshot | undefined;

--- a/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
+++ b/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
@@ -3,6 +3,9 @@ import type { JSONContent } from "@tiptap/react";
 import type {
   AppServerReviewTarget,
   AppServerTurnInputItem,
+  ComposerDraftLifecycle,
+  ComposerDraftRecoveryCandidate,
+  ListComposerDraftRecoveryCandidatesRequest,
   NavigationLaunchpadImageAttachment,
 } from "@pwragent/shared";
 import type { ComposerSkillToken } from "./ComposerInputTypes";
@@ -42,6 +45,14 @@ export type ComposerDraftStore = {
   removeQueuedTurnAt(scopeKey: string, index: number): ComposerQueuedTurnSnapshot | undefined;
   removeQueuedTurnById(scopeKey: string, id: string): ComposerQueuedTurnSnapshot | undefined;
   shiftQueuedTurn(scopeKey: string): ComposerQueuedTurnSnapshot | undefined;
+  listRecoveryCandidates?(
+    request: ListComposerDraftRecoveryCandidatesRequest,
+  ): Promise<ComposerDraftRecoveryCandidate[]>;
+  recordHistory?(
+    scopeKey: string,
+    snapshot: ComposerDraftSnapshot,
+    status: ComposerDraftLifecycle,
+  ): void;
   setPendingSteer(scopeKey: string, snapshot: ComposerPendingSteerSnapshot): void;
   setQueuedTurn(scopeKey: string, snapshot: ComposerQueuedTurnSnapshot): void;
   setQueuedTurns(scopeKey: string, snapshots: ComposerQueuedTurnSnapshot[]): void;

--- a/apps/desktop/src/renderer/src/features/composer/useDurableComposerDraftStore.ts
+++ b/apps/desktop/src/renderer/src/features/composer/useDurableComposerDraftStore.ts
@@ -33,13 +33,37 @@ type PendingDraftSave = {
   timer: number;
 };
 
+type LocalRecoveryCandidate = ComposerDraftRecoveryCandidate & {
+  localSequence: number;
+};
+
 export function useDurableComposerDraftStore(
   baseStore: ComposerDraftStore,
   desktopApi?: DesktopApi,
 ): ComposerDraftStore {
   const pendingSavesRef = useRef(new Map<string, PendingDraftSave>());
   const createdAtRef = useRef(new Map<string, number>());
+  const localRecoveryCandidatesRef = useRef<LocalRecoveryCandidate[]>([]);
+  const localRecoverySequenceRef = useRef(0);
   const [hydrationVersion, setHydrationVersion] = useState(0);
+
+  const rememberLocalRecoveryCandidate = useCallback(
+    (record: ComposerDraftSnapshotRecord): void => {
+      const nextCandidate = {
+        ...record,
+        localSequence: localRecoverySequenceRef.current,
+      };
+      localRecoverySequenceRef.current += 1;
+      const dedupeKey = getRecoveryCandidateKey(nextCandidate);
+      localRecoveryCandidatesRef.current = [
+        nextCandidate,
+        ...localRecoveryCandidatesRef.current.filter(
+          (candidate) => getRecoveryCandidateKey(candidate) !== dedupeKey,
+        ),
+      ].slice(0, 80);
+    },
+    [],
+  );
 
   const flushPendingSave = useCallback(
     (scopeKey: string, pending: PendingDraftSave): void => {
@@ -51,6 +75,9 @@ export function useDurableComposerDraftStore(
         "unsent",
         createdAtRef,
       );
+      if (shouldRecordHistory(pending.snapshot, "unsent")) {
+        rememberLocalRecoveryCandidate(record);
+      }
       void pending
         .saveComposerDraft({
           draft: record,
@@ -60,7 +87,7 @@ export function useDurableComposerDraftStore(
           console.warn("Failed to save composer draft", error);
         });
     },
-    [],
+    [rememberLocalRecoveryCandidate],
   );
 
   useEffect(() => {
@@ -125,7 +152,14 @@ export function useDurableComposerDraftStore(
         const response = await desktopApi?.listComposerDraftRecoveryCandidates?.(
           request,
         );
-        return response?.candidates ?? [];
+        const localCandidates = localRecoveryCandidatesRef.current
+          .filter((candidate) => matchesLocalRecoveryRequest(candidate, request))
+          .map(({ localSequence: _localSequence, ...candidate }) => candidate);
+        return mergeRecoveryCandidates(
+          localCandidates,
+          response?.candidates ?? [],
+          request,
+        );
       },
       recordHistory: (
         scopeKey: string,
@@ -139,6 +173,7 @@ export function useDurableComposerDraftStore(
           return;
         }
         const record = buildDraftRecord(scopeKey, snapshot, status, createdAtRef);
+        rememberLocalRecoveryCandidate(record);
         void desktopApi.recordComposerDraftHistory({ draft: record }).catch((error) => {
           console.warn("Failed to record composer draft history", error);
         });
@@ -168,7 +203,13 @@ export function useDurableComposerDraftStore(
         });
       },
     }),
-    [baseStore, desktopApi, flushPendingSave, hydrationVersion],
+    [
+      baseStore,
+      desktopApi,
+      flushPendingSave,
+      hydrationVersion,
+      rememberLocalRecoveryCandidate,
+    ],
   );
 }
 
@@ -258,6 +299,94 @@ function shouldRecordHistory(
     return true;
   }
   return snapshot.draft.trim().length >= HISTORY_TEXT_THRESHOLD;
+}
+
+function mergeRecoveryCandidates(
+  localCandidates: ComposerDraftRecoveryCandidate[],
+  durableCandidates: ComposerDraftRecoveryCandidate[],
+  request: ListComposerDraftRecoveryCandidatesRequest,
+): ComposerDraftRecoveryCandidate[] {
+  const seen = new Set<string>();
+  const limit = clampRecoveryLimit(request.limit);
+  return [...localCandidates, ...durableCandidates]
+    .filter((candidate) => {
+      const key = getRecoveryCandidateKey(candidate);
+      if (seen.has(key)) {
+        return false;
+      }
+      seen.add(key);
+      return true;
+    })
+    .sort((left, right) => {
+      const leftScore = scoreRecoveryCandidate(left, request);
+      const rightScore = scoreRecoveryCandidate(right, request);
+      if (leftScore !== rightScore) {
+        return rightScore - leftScore;
+      }
+      return right.updatedAt - left.updatedAt;
+    })
+    .slice(0, limit);
+}
+
+function clampRecoveryLimit(limit: number | undefined): number {
+  if (limit === undefined || !Number.isFinite(limit)) {
+    return 20;
+  }
+  return Math.max(1, Math.min(50, Math.floor(limit)));
+}
+
+function getRecoveryCandidateKey(
+  candidate: Pick<
+    ComposerDraftRecoveryCandidate,
+    "contentHash" | "scopeKey" | "status"
+  >,
+): string {
+  return `${candidate.scopeKey}:${candidate.status}:${candidate.contentHash}`;
+}
+
+function matchesLocalRecoveryRequest(
+  candidate: ComposerDraftRecoveryCandidate,
+  request: ListComposerDraftRecoveryCandidatesRequest,
+): boolean {
+  if (candidate.status === "sent" && !request.includeSent) {
+    return false;
+  }
+  if (request.backend && candidate.backend !== request.backend) {
+    return false;
+  }
+  if (request.scopeKey && candidate.scopeKey === request.scopeKey) {
+    return true;
+  }
+  if (request.threadId && candidate.threadId === request.threadId) {
+    return true;
+  }
+  if (request.directoryKey && candidate.directoryKey === request.directoryKey) {
+    return true;
+  }
+  return !request.scopeKey && !request.threadId && !request.directoryKey;
+}
+
+function scoreRecoveryCandidate(
+  candidate: ComposerDraftRecoveryCandidate,
+  request: ListComposerDraftRecoveryCandidatesRequest,
+): number {
+  let score = 0;
+  if (request.scopeKey && candidate.scopeKey === request.scopeKey) {
+    score += 100;
+  }
+  if (request.threadId && candidate.threadId === request.threadId) {
+    score += 60;
+  }
+  if (request.directoryKey && candidate.directoryKey === request.directoryKey) {
+    score += 40;
+  }
+  if (candidate.status === "unsent") {
+    score += 20;
+  }
+  if (candidate.status === "sent") {
+    score -= 10;
+  }
+  return score;
 }
 
 function hashDraftContent(snapshot: ComposerDraftSnapshot): string {

--- a/apps/desktop/src/renderer/src/features/composer/useDurableComposerDraftStore.ts
+++ b/apps/desktop/src/renderer/src/features/composer/useDurableComposerDraftStore.ts
@@ -1,4 +1,10 @@
-import { useEffect, useMemo, useRef, type MutableRefObject } from "react";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type MutableRefObject,
+} from "react";
 import type { JSONContent } from "@tiptap/react";
 import type {
   AppServerBackendKind,
@@ -24,6 +30,7 @@ export function useDurableComposerDraftStore(
 ): ComposerDraftStore {
   const saveTimersRef = useRef(new Map<string, number>());
   const createdAtRef = useRef(new Map<string, number>());
+  const [hydrationVersion, setHydrationVersion] = useState(0);
 
   useEffect(() => {
     if (!desktopApi?.listComposerDraftLatest) {
@@ -36,11 +43,16 @@ export function useDurableComposerDraftStore(
         if (cancelled) {
           return;
         }
+        let hydratedAny = false;
         for (const draft of response.drafts) {
           if (!baseStore.get(draft.scopeKey)) {
             baseStore.set(draft.scopeKey, snapshotFromDraftRecord(draft));
             createdAtRef.current.set(draft.scopeKey, draft.createdAt);
+            hydratedAny = true;
           }
+        }
+        if (hydratedAny) {
+          setHydrationVersion((current) => current + 1);
         }
       })
       .catch((error) => {
@@ -64,6 +76,7 @@ export function useDurableComposerDraftStore(
   return useMemo(
     () => ({
       ...baseStore,
+      hydrationVersion,
       delete: (scopeKey) => {
         baseStore.delete(scopeKey);
         createdAtRef.current.delete(scopeKey);
@@ -130,7 +143,7 @@ export function useDurableComposerDraftStore(
         saveTimersRef.current.set(scopeKey, timer);
       },
     }),
-    [baseStore, desktopApi],
+    [baseStore, desktopApi, hydrationVersion],
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/composer/useDurableComposerDraftStore.ts
+++ b/apps/desktop/src/renderer/src/features/composer/useDurableComposerDraftStore.ts
@@ -54,6 +54,14 @@ export function useDurableComposerDraftStore(
         localSequence: localRecoverySequenceRef.current,
       };
       localRecoverySequenceRef.current += 1;
+      const [previousCandidate] = localRecoveryCandidatesRef.current;
+      if (shouldReplacePreviousUnsentCandidate(previousCandidate, nextCandidate)) {
+        localRecoveryCandidatesRef.current = [
+          nextCandidate,
+          ...localRecoveryCandidatesRef.current.slice(1),
+        ].slice(0, 80);
+        return;
+      }
       const dedupeKey = getRecoveryCandidateKey(nextCandidate);
       localRecoveryCandidatesRef.current = [
         nextCandidate,
@@ -387,6 +395,25 @@ function scoreRecoveryCandidate(
     score -= 10;
   }
   return score;
+}
+
+function shouldReplacePreviousUnsentCandidate(
+  previous: ComposerDraftRecoveryCandidate | undefined,
+  next: ComposerDraftRecoveryCandidate,
+): boolean {
+  if (!previous || previous.status === "sent" || next.status === "sent") {
+    return false;
+  }
+  if (previous.scopeKey !== next.scopeKey) {
+    return false;
+  }
+  const previousText = previous.text.trimEnd();
+  const nextText = next.text.trimEnd();
+  return (
+    previousText.length > 0 &&
+    nextText.length > previousText.length &&
+    nextText.startsWith(previousText)
+  );
 }
 
 function hashDraftContent(snapshot: ComposerDraftSnapshot): string {

--- a/apps/desktop/src/renderer/src/features/composer/useDurableComposerDraftStore.ts
+++ b/apps/desktop/src/renderer/src/features/composer/useDurableComposerDraftStore.ts
@@ -1,0 +1,237 @@
+import { useEffect, useMemo, useRef, type MutableRefObject } from "react";
+import type { JSONContent } from "@tiptap/react";
+import type {
+  AppServerBackendKind,
+  ComposerDraftJsonValue,
+  ComposerDraftLifecycle,
+  ComposerDraftRecoveryCandidate,
+  ComposerDraftScopeKind,
+  ComposerDraftSnapshotRecord,
+  ListComposerDraftRecoveryCandidatesRequest,
+} from "@pwragent/shared";
+import type { DesktopApi } from "../../lib/desktop-api";
+import type {
+  ComposerDraftSnapshot,
+  ComposerDraftStore,
+} from "./useComposerDraftStore";
+
+const DURABLE_SAVE_DEBOUNCE_MS = 200;
+const HISTORY_TEXT_THRESHOLD = 120;
+
+export function useDurableComposerDraftStore(
+  baseStore: ComposerDraftStore,
+  desktopApi?: DesktopApi,
+): ComposerDraftStore {
+  const saveTimersRef = useRef(new Map<string, number>());
+  const createdAtRef = useRef(new Map<string, number>());
+
+  useEffect(() => {
+    if (!desktopApi?.listComposerDraftLatest) {
+      return;
+    }
+
+    let cancelled = false;
+    void desktopApi.listComposerDraftLatest()
+      .then((response) => {
+        if (cancelled) {
+          return;
+        }
+        for (const draft of response.drafts) {
+          if (!baseStore.get(draft.scopeKey)) {
+            baseStore.set(draft.scopeKey, snapshotFromDraftRecord(draft));
+            createdAtRef.current.set(draft.scopeKey, draft.createdAt);
+          }
+        }
+      })
+      .catch((error) => {
+        console.warn("Failed to hydrate composer drafts", error);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [baseStore, desktopApi]);
+
+  useEffect(() => {
+    return () => {
+      for (const timer of saveTimersRef.current.values()) {
+        window.clearTimeout(timer);
+      }
+      saveTimersRef.current.clear();
+    };
+  }, []);
+
+  return useMemo(
+    () => ({
+      ...baseStore,
+      delete: (scopeKey) => {
+        baseStore.delete(scopeKey);
+        createdAtRef.current.delete(scopeKey);
+        const timer = saveTimersRef.current.get(scopeKey);
+        if (timer) {
+          window.clearTimeout(timer);
+          saveTimersRef.current.delete(scopeKey);
+        }
+        void desktopApi?.clearComposerDraft?.({ scopeKey }).catch((error) => {
+          console.warn("Failed to clear composer draft", error);
+        });
+      },
+      listRecoveryCandidates: async (
+        request: ListComposerDraftRecoveryCandidatesRequest,
+      ): Promise<ComposerDraftRecoveryCandidate[]> => {
+        const response = await desktopApi?.listComposerDraftRecoveryCandidates?.(
+          request,
+        );
+        return response?.candidates ?? [];
+      },
+      recordHistory: (
+        scopeKey: string,
+        snapshot: ComposerDraftSnapshot,
+        status: ComposerDraftLifecycle,
+      ): void => {
+        if (!desktopApi?.recordComposerDraftHistory) {
+          return;
+        }
+        if (!shouldRecordHistory(snapshot, status)) {
+          return;
+        }
+        const record = buildDraftRecord(scopeKey, snapshot, status, createdAtRef);
+        void desktopApi.recordComposerDraftHistory({ draft: record }).catch((error) => {
+          console.warn("Failed to record composer draft history", error);
+        });
+      },
+      set: (scopeKey, snapshot) => {
+        baseStore.set(scopeKey, snapshot);
+        if (!desktopApi?.saveComposerDraft) {
+          return;
+        }
+
+        const existingTimer = saveTimersRef.current.get(scopeKey);
+        if (existingTimer) {
+          window.clearTimeout(existingTimer);
+        }
+
+        const saveComposerDraft = desktopApi.saveComposerDraft;
+        const timer = window.setTimeout(() => {
+          saveTimersRef.current.delete(scopeKey);
+          const record = buildDraftRecord(
+            scopeKey,
+            snapshot,
+            "unsent",
+            createdAtRef,
+          );
+          void saveComposerDraft({
+            draft: record,
+            recordHistory: shouldRecordHistory(snapshot, "unsent"),
+          }).catch((error) => {
+            console.warn("Failed to save composer draft", error);
+          });
+        }, DURABLE_SAVE_DEBOUNCE_MS);
+        saveTimersRef.current.set(scopeKey, timer);
+      },
+    }),
+    [baseStore, desktopApi],
+  );
+}
+
+export function snapshotFromDraftRecord(
+  record: ComposerDraftSnapshotRecord,
+): ComposerDraftSnapshot {
+  return {
+    draft: record.text,
+    editorDocument: record.editorDocument as JSONContent | undefined,
+    imageAttachments: record.imageAttachments,
+    skillTokens: record.skillTokens,
+  };
+}
+
+function buildDraftRecord(
+  scopeKey: string,
+  snapshot: ComposerDraftSnapshot,
+  status: ComposerDraftLifecycle,
+  createdAtRef: MutableRefObject<Map<string, number>>,
+): ComposerDraftSnapshotRecord {
+  const now = Date.now();
+  const createdAt = createdAtRef.current.get(scopeKey) ?? now;
+  createdAtRef.current.set(scopeKey, createdAt);
+  const scope = parseScope(scopeKey);
+  const contentHash = hashDraftContent(snapshot);
+
+  return {
+    scopeKey,
+    scopeKind: scope.scopeKind,
+    backend: scope.backend,
+    threadId: scope.threadId,
+    directoryKey: scope.directoryKey,
+    text: snapshot.draft,
+    editorDocument: snapshot.editorDocument as ComposerDraftJsonValue | undefined,
+    skillTokens: snapshot.skillTokens,
+    imageAttachments: snapshot.imageAttachments,
+    status,
+    createdAt,
+    updatedAt: now,
+    contentHash,
+    charCount: snapshot.draft.length,
+  };
+}
+
+function parseScope(scopeKey: string): {
+  backend?: AppServerBackendKind;
+  directoryKey?: string;
+  scopeKind: ComposerDraftScopeKind;
+  threadId?: string;
+} {
+  if (scopeKey.startsWith("thread:")) {
+    const remainder = scopeKey.slice("thread:".length);
+    const separatorIndex = remainder.indexOf(":");
+    if (separatorIndex === -1) {
+      return { scopeKind: "thread", threadId: remainder };
+    }
+    return {
+      backend: remainder.slice(0, separatorIndex) as AppServerBackendKind,
+      scopeKind: "thread",
+      threadId: remainder.slice(separatorIndex + 1),
+    };
+  }
+  if (scopeKey.startsWith("launchpad:")) {
+    return {
+      directoryKey: scopeKey.slice("launchpad:".length),
+      scopeKind: "launchpad",
+    };
+  }
+  return { scopeKind: "empty" };
+}
+
+function shouldRecordHistory(
+  snapshot: ComposerDraftSnapshot,
+  status: ComposerDraftLifecycle,
+): boolean {
+  if (status === "cleared") {
+    return false;
+  }
+  if (snapshot.imageAttachments.length > 0 || snapshot.skillTokens.length > 0) {
+    return true;
+  }
+  return snapshot.draft.trim().length >= HISTORY_TEXT_THRESHOLD;
+}
+
+function hashDraftContent(snapshot: ComposerDraftSnapshot): string {
+  const content = JSON.stringify({
+    text: snapshot.draft,
+    editorDocument: snapshot.editorDocument,
+    skillTokens: snapshot.skillTokens.map((token) => ({
+      id: token.id,
+      index: token.index,
+      name: token.name,
+      path: token.path,
+    })),
+    imageAttachments: snapshot.imageAttachments.map((attachment) => ({
+      url: attachment.url,
+    })),
+  });
+  let hash = 5381;
+  for (let index = 0; index < content.length; index += 1) {
+    hash = (hash * 33) ^ content.charCodeAt(index);
+  }
+  return `h${(hash >>> 0).toString(36)}`;
+}

--- a/apps/desktop/src/renderer/src/features/composer/useDurableComposerDraftStore.ts
+++ b/apps/desktop/src/renderer/src/features/composer/useDurableComposerDraftStore.ts
@@ -1,4 +1,5 @@
 import {
+  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -24,13 +25,43 @@ import type {
 const DURABLE_SAVE_DEBOUNCE_MS = 200;
 const HISTORY_TEXT_THRESHOLD = 120;
 
+type SaveComposerDraft = NonNullable<DesktopApi["saveComposerDraft"]>;
+
+type PendingDraftSave = {
+  saveComposerDraft: SaveComposerDraft;
+  snapshot: ComposerDraftSnapshot;
+  timer: number;
+};
+
 export function useDurableComposerDraftStore(
   baseStore: ComposerDraftStore,
   desktopApi?: DesktopApi,
 ): ComposerDraftStore {
-  const saveTimersRef = useRef(new Map<string, number>());
+  const pendingSavesRef = useRef(new Map<string, PendingDraftSave>());
   const createdAtRef = useRef(new Map<string, number>());
   const [hydrationVersion, setHydrationVersion] = useState(0);
+
+  const flushPendingSave = useCallback(
+    (scopeKey: string, pending: PendingDraftSave): void => {
+      window.clearTimeout(pending.timer);
+      pendingSavesRef.current.delete(scopeKey);
+      const record = buildDraftRecord(
+        scopeKey,
+        pending.snapshot,
+        "unsent",
+        createdAtRef,
+      );
+      void pending
+        .saveComposerDraft({
+          draft: record,
+          recordHistory: shouldRecordHistory(pending.snapshot, "unsent"),
+        })
+        .catch((error) => {
+          console.warn("Failed to save composer draft", error);
+        });
+    },
+    [],
+  );
 
   useEffect(() => {
     if (!desktopApi?.listComposerDraftLatest) {
@@ -66,12 +97,11 @@ export function useDurableComposerDraftStore(
 
   useEffect(() => {
     return () => {
-      for (const timer of saveTimersRef.current.values()) {
-        window.clearTimeout(timer);
+      for (const [scopeKey, pending] of [...pendingSavesRef.current]) {
+        flushPendingSave(scopeKey, pending);
       }
-      saveTimersRef.current.clear();
     };
-  }, []);
+  }, [flushPendingSave]);
 
   return useMemo(
     () => ({
@@ -80,10 +110,10 @@ export function useDurableComposerDraftStore(
       delete: (scopeKey) => {
         baseStore.delete(scopeKey);
         createdAtRef.current.delete(scopeKey);
-        const timer = saveTimersRef.current.get(scopeKey);
-        if (timer) {
-          window.clearTimeout(timer);
-          saveTimersRef.current.delete(scopeKey);
+        const pending = pendingSavesRef.current.get(scopeKey);
+        if (pending) {
+          window.clearTimeout(pending.timer);
+          pendingSavesRef.current.delete(scopeKey);
         }
         void desktopApi?.clearComposerDraft?.({ scopeKey }).catch((error) => {
           console.warn("Failed to clear composer draft", error);
@@ -119,31 +149,26 @@ export function useDurableComposerDraftStore(
           return;
         }
 
-        const existingTimer = saveTimersRef.current.get(scopeKey);
-        if (existingTimer) {
-          window.clearTimeout(existingTimer);
+        const existingPending = pendingSavesRef.current.get(scopeKey);
+        if (existingPending) {
+          window.clearTimeout(existingPending.timer);
         }
 
         const saveComposerDraft = desktopApi.saveComposerDraft;
         const timer = window.setTimeout(() => {
-          saveTimersRef.current.delete(scopeKey);
-          const record = buildDraftRecord(
-            scopeKey,
-            snapshot,
-            "unsent",
-            createdAtRef,
-          );
-          void saveComposerDraft({
-            draft: record,
-            recordHistory: shouldRecordHistory(snapshot, "unsent"),
-          }).catch((error) => {
-            console.warn("Failed to save composer draft", error);
-          });
+          const pending = pendingSavesRef.current.get(scopeKey);
+          if (pending) {
+            flushPendingSave(scopeKey, pending);
+          }
         }, DURABLE_SAVE_DEBOUNCE_MS);
-        saveTimersRef.current.set(scopeKey, timer);
+        pendingSavesRef.current.set(scopeKey, {
+          saveComposerDraft,
+          snapshot,
+          timer,
+        });
       },
     }),
-    [baseStore, desktopApi, hydrationVersion],
+    [baseStore, desktopApi, flushPendingSave, hydrationVersion],
   );
 }
 
@@ -221,6 +246,13 @@ function shouldRecordHistory(
 ): boolean {
   if (status === "cleared") {
     return false;
+  }
+  const hasRecoverableContent =
+    snapshot.draft.trim().length > 0 ||
+    snapshot.imageAttachments.length > 0 ||
+    snapshot.skillTokens.length > 0;
+  if (status === "sent") {
+    return hasRecoverableContent;
   }
   if (snapshot.imageAttachments.length > 0 || snapshot.skillTokens.length > 0) {
     return true;

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -103,6 +103,11 @@ import type {
   CheckDesktopCodexAuthProfileStatusRequest,
   CheckDesktopCodexAuthProfileStatusResponse,
   ClearDesktopSettingsSecretRequest,
+  ClearComposerDraftRequest,
+  ClearComposerDraftResponse,
+  ListComposerDraftLatestResponse,
+  ListComposerDraftRecoveryCandidatesRequest,
+  ListComposerDraftRecoveryCandidatesResponse,
   CodexEnvironmentSetupProgressEvent,
   CreateDesktopCodexAuthProfileRequest,
   CreateDesktopCodexAuthProfileResponse,
@@ -122,6 +127,10 @@ import type {
   PickGhCommandResponse,
   RefreshDesktopCodexDiscoveryRequest,
   ReplaceDesktopSettingsSecretRequest,
+  RecordComposerDraftHistoryRequest,
+  RecordComposerDraftHistoryResponse,
+  SaveComposerDraftRequest,
+  SaveComposerDraftResponse,
   SettingsCredentialTestKind,
   SettingsCredentialTestRequest,
   SettingsCredentialTestResult,
@@ -324,6 +333,19 @@ export type DesktopApi = {
   resetDirectoryLaunchpad?: (
     request: ResetDirectoryLaunchpadRequest
   ) => Promise<ResetDirectoryLaunchpadResponse>;
+  saveComposerDraft?: (
+    request: SaveComposerDraftRequest,
+  ) => Promise<SaveComposerDraftResponse>;
+  recordComposerDraftHistory?: (
+    request: RecordComposerDraftHistoryRequest,
+  ) => Promise<RecordComposerDraftHistoryResponse>;
+  clearComposerDraft?: (
+    request: ClearComposerDraftRequest,
+  ) => Promise<ClearComposerDraftResponse>;
+  listComposerDraftRecoveryCandidates?: (
+    request: ListComposerDraftRecoveryCandidatesRequest,
+  ) => Promise<ListComposerDraftRecoveryCandidatesResponse>;
+  listComposerDraftLatest?: () => Promise<ListComposerDraftLatestResponse>;
   /**
    * Project-directory picker (issue #223): two-step flow so the renderer
    * can show inline validation errors. `pickDirectoryFromDisk` opens the

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -126,6 +126,13 @@ export const NAVIGATION_PICK_DIRECTORY_FROM_DISK_CHANNEL =
   "navigation:pick-directory-from-disk";
 export const NAVIGATION_REGISTER_DIRECTORY_FROM_DISK_CHANNEL =
   "navigation:register-directory-from-disk";
+export const COMPOSER_DRAFT_SAVE_CHANNEL = "composer-draft:save";
+export const COMPOSER_DRAFT_RECORD_HISTORY_CHANNEL =
+  "composer-draft:record-history";
+export const COMPOSER_DRAFT_CLEAR_CHANNEL = "composer-draft:clear";
+export const COMPOSER_DRAFT_LIST_CANDIDATES_CHANNEL =
+  "composer-draft:list-candidates";
+export const COMPOSER_DRAFT_LIST_LATEST_CHANNEL = "composer-draft:list-latest";
 export const RENDERER_ERROR_REPORT_CHANNEL = "renderer:error-report";
 export const IMAGE_UPLOAD_FALLBACK_CHANNEL = "image-upload:fallback";
 export const IMAGE_UPLOAD_NORMALIZATION_LOG_CHANNEL =

--- a/docs/plans/2026-05-14-001-fix-composer-draft-recovery-history-plan.md
+++ b/docs/plans/2026-05-14-001-fix-composer-draft-recovery-history-plan.md
@@ -1,0 +1,422 @@
+---
+title: fix: Protect composer undo and draft recovery
+type: fix
+status: active
+date: 2026-05-14
+origin: docs/brainstorms/2026-05-02-desktop-composer-draft-persistence-regression-requirements.md
+deepened: 2026-05-14
+---
+
+# fix: Protect composer undo and draft recovery
+
+## Overview
+
+Make long composer drafts recoverable when Tiptap undo history, skill-token insertion, navigation, or remount behavior goes wrong. The live editor should keep an aggressive undo/redo stack for normal editing, while PwrAgent keeps a profile-scoped durable draft journal that can restore complete unsent drafts and recently sent prompts from a blank composer.
+
+## Problem Frame
+
+The reported failure happened in the new-thread launchpad after inserting a skill through autocomplete, typing a lengthy multi-paragraph message, and pressing `Cmd+Z`. Instead of undoing the most recent text operation, the editor deleted everything after the inserted skill. `Cmd+Y` did not recover it, and navigating away/back recreated the entry enough to lose the only possible in-memory recovery path.
+
+This extends the existing draft-persistence concern from the origin document: unsent composer content is user data and must not be treated as disposable UI state. The prior work protects text/images across navigation, but it does not provide a recoverable history of complete drafts or explicitly constrain Tiptap undo/redo semantics around programmatic skill insertion and external document sync. (see origin: `docs/brainstorms/2026-05-02-desktop-composer-draft-persistence-regression-requirements.md`)
+
+## Requirements Trace
+
+- R1. `Cmd/Ctrl+Z` in Tiptap composers undoes the latest user edit or atomic skill-token edit, not the whole post-skill draft.
+- R2. Redo works with `Cmd/Ctrl+Shift+Z`; add `Cmd/Ctrl+Y` as a compatibility redo shortcut when focus is inside the composer.
+- R3. Programmatic composer hydration, scope switching, launchpad autosave echoes, and durable recovery restores do not pollute or collapse the live undo history.
+- R4. Skill autocomplete insertion is one atomic undo step that can be undone/redone without losing later text or leaving broken mention state.
+- R5. PwrAgent stores complete draft snapshots durably enough to survive renderer remounts, navigation away/back, window reloads, and app restart for unsent drafts.
+- R6. PwrAgent stores enough recent sent and abandoned draft snapshots to recover a long message from a blank composer using keyboard cycling.
+- R7. Durable storage is profile-scoped, bounded by retention, and does not introduce dependency-boundary violations from the renderer.
+- R8. Draft recovery covers launchpad and existing-thread reply composers, including text, Tiptap JSON document, skill tokens, image attachments metadata, timestamps, and sent/unsent status.
+- R9. Recovery UX is discoverable but quiet: on ArrowUp in a blank composer, cycle through recoverable drafts for the current scope first, then recent sent prompts where appropriate.
+- R10. Tests reproduce the reported skill autocomplete + long multiline message + undo/redo failure and prove recovery after navigation/restart boundaries.
+
+## Scope Boundaries
+
+- This plan does not redesign the composer UI or transcript.
+- This plan does not attempt to persist ProseMirror's internal undo/redo stack across app restarts.
+- This plan does not store image binary data beyond the attachment metadata/data URLs already used by the composer.
+- This plan does not add cloud sync or cross-profile draft sharing.
+- This plan does not change send payload semantics, launchpad materialization semantics, or the existing one-launchpad-per-directory model.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx` builds the Tiptap editor with `StarterKit`, a custom mention extension, `setContent`-based external sync, and a custom one-off single-skill delete undo workaround.
+- `apps/desktop/src/renderer/src/features/composer/Composer.tsx` owns composer scope keys, skill autocomplete insertion, canonical draft serialization, image attachments, launchpad persistence flushes, and the current draft store integration.
+- `apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts` is an in-memory app-level store for scoped draft snapshots, queued turns, and pending steer state.
+- `apps/desktop/src/renderer/src/App.tsx` creates one `useComposerDraftStore` at the shell level and passes it into `ThreadView`, so it is stable across normal thread view remounts but not app restarts.
+- `apps/desktop/src/main/state/state-db.ts` owns the profile-scoped SQLite database at `~/.pwragent/profiles/<name>/state/state.db`, current migrations, WAL settings, and bounded GC patterns.
+- `apps/desktop/src/main/ipc/agent-ipc.ts`, `apps/desktop/src/preload/index.ts`, `apps/desktop/src/renderer/src/lib/desktop-api.ts`, and `apps/desktop/src/shared/ipc.ts` are the existing renderer-main IPC pattern for typed desktop capabilities.
+- `apps/desktop/e2e/composer-draft-persistence-regression.spec.ts` already exercises Tiptap launchpad/reply draft persistence with pasted images across switching and refresh.
+- `apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx` and `apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx` are the right home for editor behavior and composer integration tests.
+
+### Institutional Learnings
+
+- `docs/solutions/2026-05-07-codex-permission-mode-state-machine.md` is relevant by pattern, not domain: eliminate split-brain state where possible, and prefer structural fixes over drift detection. For this plan, the structural boundary is that Tiptap owns live undo/redo, while PwrAgent owns durable recovery snapshots.
+- `docs/plans/2026-05-02-003-fix-composer-draft-persistence-plan.md` established that draft text, Tiptap JSON, skill tokens, and image attachments should move as one coherent scoped snapshot.
+- `docs/plans/2026-04-30-001-fix-composer-skill-autocomplete-plan.md` established that the canonical draft string remains the send source of truth even when the visual composer renders skill tokens.
+
+### External References
+
+- Tiptap UndoRedo docs: `https://github.com/ueberdosis/tiptap-docs/blob/main/src/content/editor/extensions/functionality/undo-redo.mdx`
+- Tiptap v3 upgrade docs: `https://github.com/ueberdosis/tiptap-docs/blob/main/src/content/guides/upgrade-tiptap-v2.mdx`
+- ProseMirror history reference: `https://prosemirror.net/docs/ref/#history`
+- ProseMirror guide keymap/history example: `https://prosemirror.net/docs/guide/`
+
+Tiptap v3 uses `UndoRedo` through `StarterKit` unless disabled with `undoRedo: false`; the old `history` StarterKit option was renamed. `UndoRedo` exposes `depth` and `newGroupDelay`. ProseMirror history defaults to depth 100 and 500ms grouping, supports `undo`/`redo`, `undoDepth`/`redoDepth`, `closeHistory`, and `addToHistory: false` transaction metadata for changes that should not be user-undoable.
+
+## Key Technical Decisions
+
+- **Keep live undo/redo inside Tiptap/ProseMirror.** The editor history is the right primitive for same-focus editing, cursor-aware undo, and redo. Configure it aggressively, but do not replace it with app-level snapshot replay.
+- **Do not persist ProseMirror history as the recovery format.** The durable layer should store PwrAgent-owned composer snapshots and journal entries. That avoids coupling recovery to ProseMirror plugin internals and lets recovery work after remounts, restarts, or future editor changes.
+- **Persist recovery in profile SQLite, not renderer `localStorage`.** SQLite is already profile-scoped, migratable, testable, included in backup/state semantics, and accessible from the main process without renderer storage quirks. `localStorage` can remain an implementation fallback only if implementation proves IPC latency is a problem, but it should not be the source of truth.
+- **Separate current draft from recovery history.** The current in-memory draft snapshot should keep composer reads synchronous and make reopening a scope immediate. The durable journal should mirror those snapshots asynchronously and retain complete versions of long drafts, recently sent prompts, and abandoned drafts for bounded recovery.
+- **Treat skill insertion and restore operations as explicit history boundaries.** Skill autocomplete insertion should be a normal user history item, external prop sync should use non-history transactions, and recovery restore should start a fresh history group so one undo does not erase the restored document.
+- **Prefer complete snapshots over text diffs.** Drafts are small compared with transcript history, and snapshot storage is simpler, safer, and easier to recover than custom diff chains for Tiptap JSON plus skill/image state.
+- **Expose recovery through existing composer ergonomics first.** ArrowUp on a blank composer is the initial retrieval path because it is already a familiar chat-composer convention and does not add persistent UI chrome.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Where should durable recovery live?** Profile SQLite in the main process. It aligns with existing state storage and avoids renderer-only durability.
+- **Should we persist ProseMirror undo history?** No. Store app-level snapshots and keep ProseMirror history for live in-editor undo/redo only.
+- **Should `Cmd+Y` work on macOS?** Yes as composer-local compatibility. Keep `Cmd/Ctrl+Shift+Z` as the documented redo path, but support `Cmd/Ctrl+Y` while focus is inside the editor because users expect it after a destructive undo.
+- **Should sent messages be recoverable too?** Yes, bounded recent sent prompts should be available from a blank composer after unsent scope-local candidates, because a user often wants to resend or recover the just-sent full text.
+
+### Deferred to Implementation
+
+- Exact retention numbers for max rows and max age may be tuned after measuring snapshot size. Start with conservative caps and make them constants.
+- Exact IPC method grouping may be adjusted if the existing preload API organization suggests a better split.
+- Exact ArrowUp candidate ordering within equal timestamps can be decided while writing tests, as long as scope-local unsent drafts precede global recent sent prompts.
+- Exact completeness thresholds for journal candidates may be tuned during implementation. Start by always keeping latest unsent scope state, and only adding recovery-history rows for non-empty snapshots that cross a modest text length, have skill tokens, have image attachments, are sent, or are flushed on focus/scope loss.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TB
+    User["User edits composer"] --> Tiptap["Tiptap live editor"]
+    Tiptap --> UndoRedo["ProseMirror UndoRedo stack"]
+    Tiptap --> Snapshot["ComposerDraftSnapshot"]
+    Snapshot --> MemoryStore["Renderer draft store"]
+    Snapshot --> JournalBuffer["Debounced recovery writer"]
+    JournalBuffer --> IPC["Typed desktop IPC"]
+    IPC --> SQLite["Profile SQLite draft recovery tables"]
+    SQLite --> Recovery["Blank-composer ArrowUp recovery"]
+    Recovery --> Tiptap
+    Sent["Successful send/materialize"] --> SQLite
+```
+
+The live editor stack and durable recovery store are deliberately different systems. Undo/redo handles immediate editing. The recovery journal handles complete-draft restoration when the editor history is gone, corrupted, or the user navigated away.
+
+## Implementation Units
+
+```mermaid
+flowchart TB
+    U1["Unit 1: Reproduce undo loss"] --> U2["Unit 2: Normalize Tiptap history"]
+    U2 --> U3["Unit 3: Add SQLite recovery store"]
+    U3 --> U4["Unit 4: Bridge renderer draft snapshots"]
+    U4 --> U5["Unit 5: Add blank ArrowUp recovery"]
+    U5 --> U6["Unit 6: E2E recovery coverage"]
+```
+
+- [ ] **Unit 1: Reproduce the skill autocomplete undo failure**
+
+**Goal:** Capture the reported destructive undo/redo behavior before changing editor history semantics.
+
+**Requirements:** R1, R2, R4, R10
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
+- Modify: `apps/desktop/e2e/directory-launchpad-skills.spec.ts` or `apps/desktop/e2e/composer-draft-persistence-regression.spec.ts`
+
+**Approach:**
+- Build a test draft that matches the report: start in a launchpad, insert a skill through autocomplete, type a lengthy multiline body after it, delete a small recent text span, then press undo.
+- Assert undo restores only the recent deleted span, not the entire post-skill body.
+- Assert redo through `Cmd/Ctrl+Shift+Z` and `Cmd/Ctrl+Y` restores the undone state while focus remains in the composer.
+- Include a component-level test for fast feedback and one Electron-level scenario for the real Tiptap keyboard path.
+
+**Execution note:** Characterization-first. The first tests should fail or clearly document the current behavior if implementation has already drifted.
+
+**Patterns to follow:**
+- Current reported multiline skill tests near the end of `apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`.
+- Tiptap `data-value` assertions in `apps/desktop/e2e/composer-draft-persistence-regression.spec.ts`.
+
+**Test scenarios:**
+- Integration: launchpad skill autocomplete insertion -> lengthy multiline text -> small deletion -> `Cmd+Z` restores only the small deletion.
+- Integration: after that undo, `Cmd+Shift+Z` redoes the small deletion without clearing the body.
+- Integration: after that undo, `Cmd+Y` also redoes while composer focus is active.
+- Edge case: undoing the skill insertion itself removes only the skill token and leaves later manually typed text intact according to normal editor selection/history semantics.
+- Regression: navigation away/back after the destructive undo test does not silently clear the durable recovery candidate created before undo.
+
+**Verification:**
+- The test suite fails on the exact destructive-history class: a single undo cannot delete all post-skill long-form text.
+
+- [ ] **Unit 2: Normalize Tiptap undo/redo configuration and transaction boundaries**
+
+**Goal:** Make Tiptap history behavior predictable for skill insertion, external sync, restore, and keyboard redo.
+
+**Requirements:** R1, R2, R3, R4
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/composer/Composer.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/composer/ComposerInputTypes.ts` only if the input handle needs explicit undo/redo diagnostics
+- Test: `apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx`
+- Test: `apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
+
+**Approach:**
+- Configure Tiptap v3 `UndoRedo` through `StarterKit` or an explicit extension with a larger history `depth` and a `newGroupDelay` tuned for prose composition.
+- Audit every `setContent` and external sync path. Hydration from props, launchpad autosave echoes, scope restore, and recovery restore should not append stale synthetic changes to the user's undo stack.
+- Prefer ProseMirror transactions for skill insertion/deletion over React-state-driven full document replacement when the change is a user action.
+- Use history boundaries around skill insertion and recovery restore so undo steps are atomic and legible.
+- Add composer-local key handling for `Cmd/Ctrl+Y` redo, preserving existing `Cmd/Ctrl+Shift+Z`.
+- Remove or subsume the bespoke `deletedSingleSkillRef` workaround if normalized history makes it redundant; keep it only if tests prove the mention extension still needs a narrowly scoped guard.
+
+**Patterns to follow:**
+- Current `pendingExternalSignatureRef` and `props.editorDocument` synchronization in `ComposerTiptapInput.tsx`.
+- Existing `applyExternalSkillInsertion` and mention-node helpers in `ComposerTiptapInput.tsx`.
+
+**Test scenarios:**
+- Happy path: consecutive prose typing groups into sensible undo steps instead of one giant document wipe.
+- Happy path: selecting a skill from autocomplete is one undoable user transaction.
+- Happy path: `Cmd+Y` triggers redo in the Tiptap editor while focus is inside the composer.
+- Edge case: prop hydration for the same saved draft does not create an undo step that clears the whole document.
+- Edge case: restoring a durable draft starts a clean history group; the first undo after restore does not jump back to the pre-restore empty composer.
+- Error path: malformed or missing `editorDocument` falls back to canonical text without crashing and without poisoning the undo stack.
+
+**Verification:**
+- Tiptap-specific tests prove undo/redo depth, grouping, and keyboard handling around skill mentions and external restores.
+
+- [ ] **Unit 3: Add a profile-scoped SQLite draft recovery store**
+
+**Goal:** Persist current draft snapshots and bounded recovery history in the existing profile state database.
+
+**Requirements:** R5, R6, R7, R8
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `apps/desktop/src/main/state/state-db.ts`
+- Create: `apps/desktop/src/main/state/composer-draft-recovery-store.ts`
+- Modify: `apps/desktop/src/main/state/app-state.ts`
+- Create: `packages/shared/src/contracts/composer-drafts.ts`
+- Modify: `packages/shared/src/contracts/index.ts` or the package's existing export surface for shared contracts
+- Test: `apps/desktop/src/main/__tests__/state-migration.test.ts`
+- Test: `apps/desktop/src/main/__tests__/composer-draft-recovery-store.test.ts`
+
+**Approach:**
+- Add SQLite tables for the latest draft per scope and a bounded draft recovery journal. Keep rows profile-local because the DB path is profile-local.
+- Store scope key, scope kind, backend/thread/directory identifiers where known, canonical text, Tiptap JSON document, skill token metadata, image attachment metadata, lifecycle state (`unsent`, `sent`, `abandoned`, `cleared`), timestamps, content hash, and an approximate character count.
+- Define `abandoned` narrowly as a non-empty unsent snapshot superseded by scope change, app shutdown, or explicit blank-composer replacement. Do not mark active current drafts abandoned while they remain the latest state for that scope.
+- Deduplicate journal entries by scope/content hash so continuous typing does not flood the table with identical snapshots.
+- Keep writes transactional and retention bounded. Suggested initial retention: latest per active scope plus a per-profile journal cap and max age, enforced from `StateDb.cleanupExpired`.
+- Avoid storing secrets beyond what the user typed into the draft. Do not encrypt these rows in this phase because existing transcript and launchpad state are not encrypted, but name the privacy implication in PR notes.
+
+**Patterns to follow:**
+- `apps/desktop/src/main/messaging/messaging-activity-log.ts` for bounded append-only activity storage.
+- `apps/desktop/src/main/state/state-db.ts` migration and GC style.
+- `apps/desktop/src/main/state/overlay-store-sqlite.ts` for JSON payload storage over typed contracts.
+
+**Test scenarios:**
+- Happy path: saving a current launchpad draft and reopening the DB restores the same text, editor document, skill tokens, and image metadata.
+- Happy path: appending multiple versions of a long draft keeps ordered recovery candidates.
+- Happy path: marking a draft as sent preserves it as a recent sent recovery candidate but clears it as the latest unsent draft.
+- Edge case: repeated identical snapshots update metadata or no-op without adding duplicate journal rows.
+- Edge case: retention deletes oldest journal rows beyond the cap while preserving the latest current draft per scope.
+- Error path: malformed JSON payload rows are skipped with a logged warning instead of crashing app startup.
+
+**Verification:**
+- Main-process unit tests prove schema migration, persistence across handles, retention, and malformed-row resilience.
+
+- [ ] **Unit 4: Bridge renderer draft snapshots to durable recovery IPC**
+
+**Goal:** Feed the SQLite recovery store from the existing renderer draft snapshot lifecycle without blocking typing or violating renderer boundaries.
+
+**Requirements:** R5, R7, R8
+
+**Dependencies:** Unit 3
+
+**Files:**
+- Modify: `apps/desktop/src/shared/ipc.ts`
+- Modify: `apps/desktop/src/preload/index.ts`
+- Modify: `apps/desktop/src/renderer/src/lib/desktop-api.ts`
+- Create: `apps/desktop/src/main/ipc/composer-drafts.ts`
+- Modify: `apps/desktop/src/main/index.ts`
+- Modify: `apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts`
+- Create: `apps/desktop/src/renderer/src/features/composer/useDurableComposerDraftStore.ts`
+- Modify: `apps/desktop/src/renderer/src/App.tsx`
+- Test: `apps/desktop/src/main/__tests__/composer-drafts-ipc.test.ts`
+- Test: `apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
+
+**Approach:**
+- Add typed IPC for saving current snapshots, recording sent/abandoned snapshots, listing recovery candidates, and clearing specific latest drafts.
+- Keep the existing `ComposerDraftStore` read/write methods synchronous. Add a durable wrapper hook at the app-shell level that writes through to the in-memory store immediately, mirrors changes to IPC asynchronously, and exposes separate async recovery-candidate methods.
+- Prime the in-memory store from durable latest-draft rows during app-shell startup or before first recovery interaction, but do not make every composer render wait on SQLite.
+- Debounce durable writes during typing, but flush immediately on scope switch, unmount, successful send/materialize, and before clearing a submitted draft.
+- Treat IPC failure as recoverable: keep the in-memory draft and surface diagnostic logging, but do not block typing or sending.
+- Keep renderer imports limited to `@pwragent/shared` and local renderer modules; all SQLite access stays in main.
+
+**Patterns to follow:**
+- Existing `desktopApi` optional-method style in `apps/desktop/src/renderer/src/lib/desktop-api.ts`.
+- Existing renderer error/logging IPC patterns for best-effort diagnostics.
+- Current `flushComposerDraftSnapshot` and `markComposerDraftSubmitted` behavior in `Composer.tsx`.
+
+**Test scenarios:**
+- Happy path: typing a long launchpad draft schedules a durable save and scope switch flushes it immediately.
+- Happy path: successful thread reply send records a sent snapshot and clears the latest unsent snapshot for that scope.
+- Happy path: app restart hydration requests latest unsent drafts before rendering a blank composer.
+- Edge case: IPC save rejects -> in-memory draft remains visible and usable.
+- Edge case: two rapid scope switches persist both scopes without overwriting one with the other.
+- Integration: renderer tests prove `Composer.tsx` still uses the draft store abstraction and does not import main-process persistence.
+
+**Verification:**
+- Renderer-main boundary remains clean, and draft persistence failures are non-destructive.
+
+- [ ] **Unit 5: Add blank-composer ArrowUp recovery cycling**
+
+**Goal:** Let users recover recent unsent or sent drafts from a blank composer without opening a separate recovery screen.
+
+**Requirements:** R6, R8, R9
+
+**Dependencies:** Unit 4
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/features/composer/Composer.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts`
+- Modify: `apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx` only if restore needs an explicit input-handle method
+- Test: `apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
+
+**Approach:**
+- When the composer is blank and the caret is at the start, intercept ArrowUp to request recovery candidates.
+- Candidate order should be current-scope unsent drafts first, then current-directory/thread related unsent drafts, then recent sent prompts for the same thread/directory/backend, then broader recent sent prompts if still useful.
+- Restoring a candidate should restore the full snapshot: text, editor document, skill tokens, and image metadata.
+- Provide a small quiet inline status or accessible announcement indicating which candidate was restored and how to cycle, without adding persistent explanatory copy.
+- Do not override ArrowUp when the composer has content, autocomplete is open, or the caret is not at the start.
+- Add a clear path to return to blank after cycling, either by cycling past the last candidate or using normal select/delete behavior.
+
+**Patterns to follow:**
+- Existing autocomplete key handling and active index management in `Composer.tsx`.
+- Existing queued-turn recovery/preview affordances for compact composer state.
+
+**Test scenarios:**
+- Happy path: blank launchpad composer + ArrowUp restores the most recent unsent launchpad draft for that directory.
+- Happy path: blank thread reply composer + ArrowUp restores the most recent unsent reply draft for that thread.
+- Happy path: blank composer + repeated ArrowUp cycles from unsent candidates into recent sent candidates.
+- Edge case: nonblank composer + ArrowUp preserves normal editor navigation and does not replace content.
+- Edge case: autocomplete open + ArrowUp moves autocomplete selection, not recovery.
+- Edge case: restored candidate with skill tokens rehydrates the Tiptap mention nodes and serializes to the same canonical draft on send.
+- Error path: no candidates available leaves the composer blank and does not show an error.
+
+**Verification:**
+- Users can recover a recent long draft from an empty composer using keyboard-only interaction.
+
+- [ ] **Unit 6: Add restart and destructive-undo E2E coverage**
+
+**Goal:** Prove the full protection story at the Electron level: live undo does not destroy long drafts, and durable recovery works after navigation/restart.
+
+**Requirements:** R1, R2, R5, R6, R8, R9, R10
+
+**Dependencies:** Units 1-5
+
+**Files:**
+- Modify: `apps/desktop/e2e/composer-draft-persistence-regression.spec.ts`
+- Create or modify: `apps/desktop/e2e/composer-draft-recovery-history.spec.ts`
+- Modify: `apps/desktop/e2e/fixtures/electron-app.ts` only if app restart with preserved `PWRAGENT_HOME` needs a reusable helper
+
+**Approach:**
+- Extend or add a replay-backed spec that uses a persistent temp `PWRAGENT_HOME`/profile directory across app relaunch.
+- Cover the reported flow with skill autocomplete, long multiline text, undo, redo, navigation away/back, and recovery candidate availability.
+- Cover a sent-message recovery flow: send a long prompt, open a blank composer in the same scope, press ArrowUp, and verify the sent text can be restored as a candidate.
+- Keep assertions semantic: Tiptap `data-value`, visible skill mention/chip, attachment previews, and successful send payload where relevant.
+
+**Patterns to follow:**
+- `apps/desktop/e2e/composer-draft-persistence-regression.spec.ts` for persistent temp root, replay fixture, and Tiptap assertions.
+- `apps/desktop/e2e/directory-launchpad-skills.spec.ts` for skill autocomplete setup.
+
+**Test scenarios:**
+- Integration: destructive-undo reproduction flow -> `Cmd+Z`/redo preserve the long post-skill message.
+- Integration: long unsent launchpad draft -> navigate away -> relaunch app with same profile -> blank composer ArrowUp restores the draft.
+- Integration: long sent thread reply -> clear composer -> ArrowUp restores recent sent text as a candidate.
+- Edge case: recovery candidate with skill mention still sends path-bearing skill markdown.
+- Edge case: recovery retention does not surface a draft explicitly cleared after successful submission as an unsent candidate.
+
+**Verification:**
+- Electron coverage proves the feature across Tiptap, IPC, SQLite, navigation, relaunch, and keyboard recovery.
+
+## System-Wide Impact
+
+```mermaid
+flowchart TB
+    Composer["Composer.tsx"]
+    Input["ComposerTiptapInput.tsx"]
+    Store["useComposerDraftStore"]
+    API["desktopApi/preload IPC"]
+    Main["main IPC handler"]
+    DB["StateDb SQLite"]
+    E2E["Electron E2E"]
+
+    Input --> Composer
+    Composer --> Store
+    Store --> API
+    API --> Main
+    Main --> DB
+    DB --> Main
+    Main --> API
+    API --> Store
+    Store --> Composer
+    Composer --> E2E
+```
+
+- **Interaction graph:** Tiptap handles live edit history; `Composer.tsx` owns scope and send lifecycle; the draft store bridges to durable IPC; the main process owns SQLite persistence.
+- **Error propagation:** Durable-save failures should be logged and should not clear visible in-memory drafts. Recovery-list failures should simply produce no candidates plus diagnostic logging.
+- **State lifecycle risks:** The risky transitions are skill insertion, external `setContent`, scope switch, app relaunch, successful send clearing, explicit clear, delayed image normalization, and recovery restore.
+- **API surface parity:** Add desktop renderer IPC only; no app-server or backend protocol changes are planned.
+- **Integration coverage:** Unit tests cover editor history boundaries and store behavior; E2E covers real keyboard shortcuts, relaunch, and SQLite-backed recovery.
+- **Unchanged invariants:** Composer send payloads, launchpad materialization, image normalization policy, thread navigation ordering, and dependency boundaries remain unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Programmatic `setContent` continues to collapse Tiptap history. | Audit every external sync path and test history behavior around skill insertion, restore, and scope hydration. |
+| Durable writes on every keystroke hurt responsiveness. | Debounce normal typing writes, dedupe by content hash, and flush at lifecycle boundaries. |
+| Recovery store grows without bound. | Add per-profile caps, max-age retention, and GC from `StateDb.cleanupExpired`. |
+| Draft rows contain sensitive user text. | Keep storage profile-local, avoid extra copies beyond retention, document privacy implication in PR notes, and provide explicit clear behavior. |
+| ArrowUp recovery conflicts with editor navigation or autocomplete. | Trigger only when blank, caret is at start, and autocomplete is closed. |
+| Sent-message recovery could surprise users by resurrecting already-sent content. | Scope it behind blank-composer ArrowUp and order unsent drafts before sent candidates. |
+| Persisting image data URLs increases DB size. | Store current attachment metadata as-is initially, measure row size, and cap retention; do not expand binary support in this plan. |
+| Main/renderer contracts drift or violate boundaries. | Put shared request/response types in `@pwragent/shared` and keep SQLite access in main only. |
+
+## Documentation / Operational Notes
+
+- Add PR notes explaining that live undo history is intentionally not persisted; durable recovery uses complete draft snapshots.
+- No user-facing help page is required for the first pass, but release notes should mention ArrowUp draft recovery if the interaction ships.
+- If retention constants are tuned during implementation, record the rationale in code comments near the constants and in the PR summary.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-05-02-desktop-composer-draft-persistence-regression-requirements.md](../brainstorms/2026-05-02-desktop-composer-draft-persistence-regression-requirements.md)
+- Related plan: [docs/plans/2026-05-02-003-fix-composer-draft-persistence-plan.md](2026-05-02-003-fix-composer-draft-persistence-plan.md)
+- Related plan: [docs/plans/2026-04-30-001-fix-composer-skill-autocomplete-plan.md](2026-04-30-001-fix-composer-skill-autocomplete-plan.md)
+- Related learning: [docs/solutions/2026-05-07-codex-permission-mode-state-machine.md](../solutions/2026-05-07-codex-permission-mode-state-machine.md)
+- Related code: `apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx`
+- Related code: `apps/desktop/src/renderer/src/features/composer/Composer.tsx`
+- Related code: `apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts`
+- Related code: `apps/desktop/src/main/state/state-db.ts`
+- Related tests: `apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx`
+- Related tests: `apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
+- Related E2E: `apps/desktop/e2e/composer-draft-persistence-regression.spec.ts`
+- External docs: Tiptap UndoRedo extension, `https://github.com/ueberdosis/tiptap-docs/blob/main/src/content/editor/extensions/functionality/undo-redo.mdx`
+- External docs: Tiptap v3 StarterKit undo/redo rename, `https://github.com/ueberdosis/tiptap-docs/blob/main/src/content/guides/upgrade-tiptap-v2.mdx`
+- External docs: ProseMirror history reference, `https://prosemirror.net/docs/ref/#history`

--- a/docs/plans/2026-05-14-001-fix-composer-draft-recovery-history-plan.md
+++ b/docs/plans/2026-05-14-001-fix-composer-draft-recovery-history-plan.md
@@ -301,6 +301,9 @@ flowchart TB
 - When the composer is blank and the caret is at the start, intercept ArrowUp to request recovery candidates.
 - Candidate order should be current-scope unsent drafts first, then current-directory/thread related unsent drafts, then recent sent prompts for the same thread/directory/backend, then broader recent sent prompts if still useful.
 - Restoring a candidate should restore the full snapshot: text, editor document, skill tokens, and image metadata.
+- Restoring a candidate must place the caret at draft index `0`, not at the end. While the caret remains exactly at `0..0`, repeated ArrowUp continues cycling through recovery candidates.
+- Once the caret leaves `0..0` in a restored draft, the active recovery cycle is over. ArrowUp must return to normal editor navigation and must not cycle drafts again until the composer is fully blank.
+- Recovery-history rows should represent coherent drafts, not every edit step. Record them at explicit boundaries: successful send, queue/steer handoff, lifecycle flush of a complete unsent draft, or whole-composer deletion that transitions from non-empty to empty.
 - Provide a small quiet inline status or accessible announcement indicating which candidate was restored and how to cycle, without adding persistent explanatory copy.
 - Do not override ArrowUp when the composer has content, autocomplete is open, or the caret is not at the start.
 - Add a clear path to return to blank after cycling, either by cycling past the last candidate or using normal select/delete behavior.
@@ -313,6 +316,8 @@ flowchart TB
 - Happy path: blank launchpad composer + ArrowUp restores the most recent unsent launchpad draft for that directory.
 - Happy path: blank thread reply composer + ArrowUp restores the most recent unsent reply draft for that thread.
 - Happy path: blank composer + repeated ArrowUp cycles from unsent candidates into recent sent candidates.
+- Happy path: after ArrowUp restores a candidate, the caret is at the top-left/start position and a second ArrowUp cycles to the next candidate.
+- Edge case: after a restored candidate's caret moves away from the start position, ArrowUp does not cycle recovery candidates again while that draft remains non-empty.
 - Edge case: nonblank composer + ArrowUp preserves normal editor navigation and does not replace content.
 - Edge case: autocomplete open + ArrowUp moves autocomplete selection, not recovery.
 - Edge case: restored candidate with skill tokens rehydrates the Tiptap mention nodes and serializes to the same canonical draft on send.
@@ -393,7 +398,7 @@ flowchart TB
 | Durable writes on every keystroke hurt responsiveness. | Debounce normal typing writes, dedupe by content hash, and flush at lifecycle boundaries. |
 | Recovery store grows without bound. | Add per-profile caps, max-age retention, and GC from `StateDb.cleanupExpired`. |
 | Draft rows contain sensitive user text. | Keep storage profile-local, avoid extra copies beyond retention, document privacy implication in PR notes, and provide explicit clear behavior. |
-| ArrowUp recovery conflicts with editor navigation or autocomplete. | Trigger only when blank, caret is at start, and autocomplete is closed. |
+| ArrowUp recovery conflicts with editor navigation or autocomplete. | Trigger when blank, or while an active recovery cycle has focus at `0..0`; clear the cycle as soon as the caret leaves that position. |
 | Sent-message recovery could surprise users by resurrecting already-sent content. | Scope it behind blank-composer ArrowUp and order unsent drafts before sent candidates. |
 | Persisting image data URLs increases DB size. | Store current attachment metadata as-is initially, measure row size, and cap retention; do not expand binary support in this plan. |
 | Main/renderer contracts drift or violate boundaries. | Put shared request/response types in `@pwragent/shared` and keep SQLite access in main only. |

--- a/docs/plans/2026-05-14-001-fix-composer-draft-recovery-history-plan.md
+++ b/docs/plans/2026-05-14-001-fix-composer-draft-recovery-history-plan.md
@@ -302,8 +302,11 @@ flowchart TB
 - Candidate order should be current-scope unsent drafts first, then current-directory/thread related unsent drafts, then recent sent prompts for the same thread/directory/backend, then broader recent sent prompts if still useful.
 - Restoring a candidate should restore the full snapshot: text, editor document, skill tokens, and image metadata.
 - Restoring a candidate must place the caret at draft index `0`, not at the end. While the caret remains exactly at `0..0`, repeated ArrowUp continues cycling through recovery candidates.
+- While recovery mode is active, the caret remains at `0..0`, and the composer is non-empty, ArrowDown moves back toward the newest/first recovery candidate. ArrowDown from the newest candidate returns the composer to blank and ends the active cycle, matching shell history behavior.
 - Once the caret leaves `0..0` in a restored draft, the active recovery cycle is over. ArrowUp must return to normal editor navigation and must not cycle drafts again until the composer is fully blank.
+- Any key other than ArrowUp/ArrowDown while a restored non-empty draft is active breaks recovery mode. That includes typing, ArrowRight, Ctrl/Command-end movement, mouse movement, or any selection-changing command; after that, ArrowUp/ArrowDown behave as normal editor navigation until the composer is blank again.
 - Recovery-history rows should represent coherent drafts, not every edit step. Record them at explicit boundaries: successful send, queue/steer handoff, lifecycle flush of a complete unsent draft, or whole-composer deletion that transitions from non-empty to empty.
+- The recovery store should collapse near-repeat unsubmitted drafts: if the last unsubmitted history item for the same scope is a prefix of the next unsubmitted item, replace the older item with the longer one. Sent prompts are immutable shell-style history entries and must not be replaced by later longer drafts.
 - Provide a small quiet inline status or accessible announcement indicating which candidate was restored and how to cycle, without adding persistent explanatory copy.
 - Do not override ArrowUp when the composer has content, autocomplete is open, or the caret is not at the start.
 - Add a clear path to return to blank after cycling, either by cycling past the last candidate or using normal select/delete behavior.
@@ -317,7 +320,10 @@ flowchart TB
 - Happy path: blank thread reply composer + ArrowUp restores the most recent unsent reply draft for that thread.
 - Happy path: blank composer + repeated ArrowUp cycles from unsent candidates into recent sent candidates.
 - Happy path: after ArrowUp restores a candidate, the caret is at the top-left/start position and a second ArrowUp cycles to the next candidate.
+- Happy path: after repeated ArrowUp reaches an older candidate, ArrowDown returns toward the newest candidate and ArrowDown from the newest candidate returns to a blank composer.
 - Edge case: after a restored candidate's caret moves away from the start position, ArrowUp does not cycle recovery candidates again while that draft remains non-empty.
+- Edge case: after a restored candidate's caret moves away from the start position, ArrowDown does not cycle or clear recovery candidates while that draft remains non-empty.
+- Edge case: unsubmitted prefix drafts are collapsed in recovery history, while sent prompts remain as separate recoverable entries.
 - Edge case: nonblank composer + ArrowUp preserves normal editor navigation and does not replace content.
 - Edge case: autocomplete open + ArrowUp moves autocomplete selection, not recovery.
 - Edge case: restored candidate with skill tokens rehydrates the Tiptap mention nodes and serializes to the same canonical draft on send.

--- a/packages/shared/src/contracts/composer-drafts.ts
+++ b/packages/shared/src/contracts/composer-drafts.ts
@@ -1,0 +1,89 @@
+import type { AppServerBackendKind, ThreadIdentifier } from "./normalized-app-server";
+import type { NavigationLaunchpadImageAttachment } from "./navigation";
+
+export type ComposerDraftScopeKind = "thread" | "launchpad" | "empty";
+
+export type ComposerDraftLifecycle = "unsent" | "sent" | "abandoned" | "cleared";
+
+export type ComposerDraftJsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | ComposerDraftJsonValue[]
+  | { [key: string]: ComposerDraftJsonValue };
+
+export type ComposerDraftSkillToken = {
+  id: string;
+  index: number;
+  name: string;
+  path?: string;
+  description?: string;
+  shortDescription?: string;
+  source?: string;
+};
+
+export type ComposerDraftSnapshotRecord = {
+  scopeKey: string;
+  scopeKind: ComposerDraftScopeKind;
+  backend?: AppServerBackendKind;
+  threadId?: ThreadIdentifier;
+  directoryKey?: string;
+  directoryPath?: string;
+  text: string;
+  editorDocument?: ComposerDraftJsonValue;
+  skillTokens: ComposerDraftSkillToken[];
+  imageAttachments: NavigationLaunchpadImageAttachment[];
+  status: ComposerDraftLifecycle;
+  createdAt: number;
+  updatedAt: number;
+  contentHash: string;
+  charCount: number;
+};
+
+export type ComposerDraftRecoveryCandidate = ComposerDraftSnapshotRecord & {
+  journalId?: number;
+};
+
+export type SaveComposerDraftRequest = {
+  draft: ComposerDraftSnapshotRecord;
+  recordHistory?: boolean;
+};
+
+export type SaveComposerDraftResponse = {
+  draft: ComposerDraftSnapshotRecord;
+};
+
+export type RecordComposerDraftHistoryRequest = {
+  draft: ComposerDraftSnapshotRecord;
+};
+
+export type RecordComposerDraftHistoryResponse = {
+  candidate: ComposerDraftRecoveryCandidate;
+};
+
+export type ClearComposerDraftRequest = {
+  scopeKey: string;
+  clearedAt?: number;
+};
+
+export type ClearComposerDraftResponse = {
+  scopeKey: string;
+};
+
+export type ListComposerDraftRecoveryCandidatesRequest = {
+  backend?: AppServerBackendKind;
+  directoryKey?: string;
+  includeSent?: boolean;
+  limit?: number;
+  scopeKey?: string;
+  threadId?: ThreadIdentifier;
+};
+
+export type ListComposerDraftRecoveryCandidatesResponse = {
+  candidates: ComposerDraftRecoveryCandidate[];
+};
+
+export type ListComposerDraftLatestResponse = {
+  drafts: ComposerDraftSnapshotRecord[];
+};

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -2,6 +2,7 @@ export * from "./contracts/normalized-app-server";
 export * from "./contracts/backend";
 export * from "./contracts/agent";
 export * from "./contracts/branch-drift";
+export * from "./contracts/composer-drafts";
 export * from "./contracts/diff-focus";
 export * from "./contracts/messaging";
 export * from "./contracts/navigation";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,9 @@ importers:
       node-fetch:
         specifier: 2.7.0
         version: 2.7.0
+      prosemirror-history:
+        specifier: ^1.5.0
+        version: 1.5.0
       react:
         specifier: ^19.2.0
         version: 19.2.5


### PR DESCRIPTION
## Summary

This adds durable recovery for desktop composer drafts so long-form launchpad/thread messages are not lost when Tiptap undo grouping, navigation, or app restarts interact badly.

## What Changed

- Added SQLite-backed composer draft persistence with a latest-draft table and a bounded recovery journal.
- Added typed shared contracts plus main/preload/renderer IPC methods for saving, clearing, listing, and recording draft history.
- Wrapped the renderer composer draft store with durable save/hydrate behavior.
- Added blank-composer `ArrowUp` recovery that cycles through recent unsent and recently sent candidates.
- Tightened Tiptap undo/redo handling around autocomplete skill insertion and controlled editor updates, including `Cmd+Y` / `Cmd+Shift+Z` redo handling.
- Added the implementation plan under `docs/plans/`.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/composer-draft-recovery-store.test.ts apps/desktop/src/main/__tests__/index.test.ts apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `pnpm lint`