### PR TITLE
fix(desktop): submit launchpad prompt after setup failure

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -1,3 +1,6 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   ArchiveWorktreeRequest,
@@ -687,6 +690,109 @@ describe("app server ipc", () => {
         executionMode: "default",
       },
     });
+  });
+
+  it("marks snapshots changed when hydrated launchpad environment options change", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-nav-env-"));
+    const environmentsDir = path.join(root, ".codex", "environments");
+    await mkdir(environmentsDir, { recursive: true });
+    await writeFile(
+      path.join(environmentsDir, "environment.toml"),
+      'name = "Existing environment"\n',
+      "utf8",
+    );
+
+    const launchpad = {
+      directoryKey: "directory:/repo/app",
+      directoryKind: "directory" as const,
+      directoryLabel: "app",
+      directoryPath: root,
+      backend: "codex" as const,
+      executionMode: "default" as const,
+      prompt: "",
+      workMode: "local" as const,
+      createdAt: 1000,
+      updatedAt: 1000,
+    };
+
+    reconcileNavigationSnapshot
+      .mockResolvedValueOnce({
+        backend: "all",
+        fetchedAt: 1234,
+        unchanged: false,
+        threads: [],
+        inboxThreadKeys: [],
+        directories: [
+          {
+            key: "directory:/repo/app",
+            kind: "directory" as const,
+            label: "app",
+            path: "/repo/app",
+            threadKeys: [],
+            needsAttentionCount: 0,
+            latestUpdatedAt: 2000,
+            launchpad,
+          },
+        ],
+        launchpadDefaults: {
+          backend: "codex" as const,
+          executionMode: "default" as const,
+        },
+      } as unknown as Awaited<ReturnType<typeof reconcileNavigationSnapshot>>)
+      .mockResolvedValueOnce({
+        backend: "all",
+        fetchedAt: 5678,
+        unchanged: true,
+        threads: [],
+        inboxThreadKeys: [],
+        directories: [
+          {
+            key: "directory:/repo/app",
+            kind: "directory" as const,
+            label: "app",
+            path: "/repo/app",
+            threadKeys: [],
+            needsAttentionCount: 0,
+            latestUpdatedAt: 2000,
+            launchpad,
+          },
+        ],
+        launchpadDefaults: {
+          backend: "codex" as const,
+          executionMode: "default" as const,
+        },
+      } as unknown as Awaited<ReturnType<typeof reconcileNavigationSnapshot>>);
+
+    try {
+      registerAppServerIpcHandlers();
+
+      await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
+      await writeFile(
+        path.join(environmentsDir, "new-environment.toml"),
+        'name = "New environment"\n',
+        "utf8",
+      );
+      const response = await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
+
+      expect(response).toMatchObject({
+        unchanged: false,
+        directories: [
+          {
+            launchpad: {
+              codexEnvironmentOptions: [
+                { id: "environment" },
+                { id: "new-environment" },
+              ],
+            },
+          },
+        ],
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 
   it("uses cached directory git status without refreshing unchanged directories", async () => {

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -131,7 +131,15 @@ function directoryStatusesEqual(
 
     const leftStatus = directory.gitStatus;
     const rightStatus = candidate.gitStatus;
-    return JSON.stringify(leftStatus ?? null) === JSON.stringify(rightStatus ?? null);
+    const leftCodexEnvironmentOptions =
+      directory.launchpad?.codexEnvironmentOptions ?? null;
+    const rightCodexEnvironmentOptions =
+      candidate.launchpad?.codexEnvironmentOptions ?? null;
+    return (
+      JSON.stringify(leftStatus ?? null) === JSON.stringify(rightStatus ?? null) &&
+      JSON.stringify(leftCodexEnvironmentOptions) ===
+        JSON.stringify(rightCodexEnvironmentOptions)
+    );
   });
 }
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -195,12 +195,13 @@ function LaunchpadEnvironmentSetupPending(props: {
 
 function EnvironmentSetupFailureChoice(props: {
   archiving: boolean;
+  continuing: boolean;
   error?: string;
   environmentName: string;
   hasWorktree: boolean;
   phase: "setup" | "action";
   onCleanup: () => void;
-  onContinue: () => void;
+  onContinue: () => void | Promise<void>;
 }) {
   const label =
     props.phase === "action" ? "Environment action failed" : "Environment setup failed";
@@ -222,7 +223,7 @@ function EnvironmentSetupFailureChoice(props: {
       <div className="environment-setup-choice__actions">
         <button
           className="composer__action-button composer__action-button--danger"
-          disabled={props.archiving}
+          disabled={props.archiving || props.continuing}
           type="button"
           onClick={props.onCleanup}
         >
@@ -230,15 +231,34 @@ function EnvironmentSetupFailureChoice(props: {
         </button>
         <button
           className="composer__action-button"
-          disabled={props.archiving}
+          disabled={props.archiving || props.continuing}
           type="button"
-          onClick={props.onContinue}
+          onClick={() => {
+            void props.onContinue();
+          }}
         >
-          Continue anyway
+          {props.continuing ? "Continuing..." : "Continue anyway"}
         </button>
       </div>
     </section>
   );
+}
+
+function buildInputFromOptimisticUserMessage(
+  optimisticUserMessage: NavigationThreadSummary["optimisticUserMessage"],
+): AppServerTurnInputItem[] {
+  if (!optimisticUserMessage) {
+    return [];
+  }
+
+  const text = optimisticUserMessage.text.trim();
+  return [
+    ...(text ? [{ type: "text" as const, text }] : []),
+    ...(optimisticUserMessage.imageParts ?? []).map((imagePart) => ({
+      type: "image" as const,
+      url: imagePart.url,
+    })),
+  ];
 }
 
 function arePlanEntriesEquivalent(
@@ -927,6 +947,9 @@ export function ThreadView(props: ThreadViewProps) {
   const [setupFailureDismissedThreadKeys, setSetupFailureDismissedThreadKeys] =
     useState<Set<string>>(() => new Set());
   const [setupFailureArchiving, setSetupFailureArchiving] = useState(false);
+  const [setupFailureContinuing, setSetupFailureContinuing] = useState(false);
+  const [setupFailureContinueError, setSetupFailureContinueError] =
+    useState<string>();
   const [launchpadSetupProgress, setLaunchpadSetupProgress] =
     useState<LaunchpadEnvironmentSetupProgress>();
   // Auto-pin the context rail on wide displays (issue #240). Same
@@ -955,6 +978,8 @@ export function ThreadView(props: ThreadViewProps) {
     setExpandedImage(undefined);
     setLaunchpadMaterializing(false);
     setLaunchpadSetupProgress(undefined);
+    setSetupFailureContinuing(false);
+    setSetupFailureContinueError(undefined);
   }, [
     props.selectedLaunchpad?.directoryKey,
     props.selectedThread?.id,
@@ -1017,6 +1042,56 @@ export function ThreadView(props: ThreadViewProps) {
   const selectedThreadEnvironmentFailurePhase = selectedThreadActionFailed
     ? "action"
     : "setup";
+  const continueAfterSetupFailure = async (): Promise<void> => {
+    if (!selectedThread || !selectedThreadKey) {
+      return;
+    }
+
+    const input = buildInputFromOptimisticUserMessage(
+      selectedThread.optimisticUserMessage,
+    );
+    if (input.length === 0 || !props.desktopApi?.startTurn) {
+      setSetupFailureDismissedThreadKeys((current) => {
+        const next = new Set(current);
+        next.add(selectedThreadKey);
+        return next;
+      });
+      return;
+    }
+
+    setSetupFailureContinueError(undefined);
+    setSetupFailureContinuing(true);
+    props.onPendingStatusChange?.("Thinking");
+    try {
+      const response = await props.desktopApi.startTurn({
+        backend: selectedThread.source,
+        threadId: selectedThread.id,
+        input,
+        executionMode: selectedThread.executionMode,
+        model: selectedThread.model,
+        reasoningEffort: selectedThread.reasoningEffort,
+        serviceTier: selectedThread.serviceTier,
+        fastMode: selectedThread.source === "codex"
+          ? selectedThread.fastMode
+          : undefined,
+      });
+      props.onActiveTurnIdChange?.(response.turnId);
+      setSetupFailureDismissedThreadKeys((current) => {
+        const next = new Set(current);
+        next.add(selectedThreadKey);
+        return next;
+      });
+      await props.onRefreshNavigation?.();
+    } catch (error) {
+      props.onPendingStatusChange?.(undefined);
+      props.onActiveTurnIdChange?.(undefined);
+      setSetupFailureContinueError(
+        error instanceof Error ? error.message : String(error),
+      );
+    } finally {
+      setSetupFailureContinuing(false);
+    }
+  };
 
   useEffect(() => {
     if (!branchDriftDialog) return;
@@ -1855,11 +1930,12 @@ export function ThreadView(props: ThreadViewProps) {
       {showSetupFailureChoice && selectedThread && selectedThreadKey ? (
         <EnvironmentSetupFailureChoice
           archiving={setupFailureArchiving}
+          continuing={setupFailureContinuing}
           environmentName={
             selectedThread.codexEnvironmentRuntime?.environmentName ??
             "Codex environment"
           }
-          error={props.archiveThreadError}
+          error={props.archiveThreadError ?? setupFailureContinueError}
           hasWorktree={Boolean(selectedThreadWorktree)}
           phase={selectedThreadEnvironmentFailurePhase}
           onCleanup={() => {
@@ -1871,13 +1947,7 @@ export function ThreadView(props: ThreadViewProps) {
               setSetupFailureArchiving(false);
             });
           }}
-          onContinue={() => {
-            setSetupFailureDismissedThreadKeys((current) => {
-              const next = new Set(current);
-              next.add(selectedThreadKey);
-              return next;
-            });
-          }}
+          onContinue={continueAfterSetupFailure}
         />
       ) : null}
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1033,9 +1033,15 @@ export function ThreadView(props: ThreadViewProps) {
     (directory) =>
       directory.kind === "worktree" || Boolean(directory.worktreePath?.trim()),
   );
+  const selectedThreadOptimisticLaunchpadInput =
+    buildInputFromOptimisticUserMessage(selectedThread?.optimisticUserMessage);
+  const hasOnlyOptimisticLaunchpadMessage =
+    props.messageCount === 1 && selectedThreadOptimisticLaunchpadInput.length > 0;
   const showSetupFailureChoice = Boolean(
     selectedThread &&
       selectedThreadKey &&
+      (props.messageCount === 0 || hasOnlyOptimisticLaunchpadMessage) &&
+      !props.activeTurnId &&
       (selectedThreadSetupFailed || selectedThreadActionFailed) &&
       !setupFailureDismissedThreadKeys.has(selectedThreadKey),
   );

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -3537,4 +3537,88 @@ describe("ThreadView", () => {
       consoleErrorSpy.mockRestore();
     }
   });
+
+  it("submits the launchpad prompt when continuing after environment setup failure", async () => {
+    const startTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-env-failure",
+      turnId: "turn-1",
+    }));
+    const onActiveTurnIdChange = vi.fn();
+    const onPendingStatusChange = vi.fn();
+
+    render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[]}
+        composerDisabled={false}
+        desktopApi={{ startTurn }}
+        loading={false}
+        loadingMore={false}
+        messageCount={0}
+        selectedThread={{
+          id: "thread-env-failure",
+          title: "Untitled thread",
+          titleSource: "fallback",
+          source: "codex",
+          executionMode: "full-access",
+          model: "gpt-5.5",
+          reasoningEffort: "high",
+          updatedAt: Date.now(),
+          codexEnvironmentRuntime: {
+            environmentId: "environment",
+            environmentName: "PwrAgent",
+            executionTarget: "local",
+            setupEnabled: true,
+            setupStatus: "failed",
+          },
+          linkedDirectories: [
+            {
+              id: "/repo",
+              kind: "worktree",
+              label: "repo",
+              path: "/repo",
+              worktreePath: "/repo/.worktrees/thread-env-failure",
+            },
+          ],
+          optimisticUserMessage: {
+            text: "Fix the failed setup",
+            imageParts: [{ type: "image", url: "data:image/png;base64,abc" }],
+            createdAt: 1_000,
+          },
+          inbox: {
+            inInbox: true,
+            reason: "new-thread",
+          },
+        }}
+        skills={[]}
+        transcriptEntries={[]}
+        clearPendingRequest={() => undefined}
+        onActiveTurnIdChange={onActiveTurnIdChange}
+        onLoadOlder={async () => undefined}
+        onPendingStatusChange={onPendingStatusChange}
+        removeOptimisticMessage={(_id) => undefined}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Continue anyway" }));
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-env-failure",
+        input: [
+          { type: "text", text: "Fix the failed setup" },
+          { type: "image", url: "data:image/png;base64,abc" },
+        ],
+        executionMode: "full-access",
+        model: "gpt-5.5",
+        reasoningEffort: "high",
+        serviceTier: undefined,
+        fastMode: undefined,
+      });
+    });
+    expect(onPendingStatusChange).toHaveBeenCalledWith("Thinking");
+    expect(onActiveTurnIdChange).toHaveBeenCalledWith("turn-1");
+  });
 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -3555,7 +3555,7 @@ describe("ThreadView", () => {
         desktopApi={{ startTurn }}
         loading={false}
         loadingMore={false}
-        messageCount={0}
+        messageCount={1}
         selectedThread={{
           id: "thread-env-failure",
           title: "Untitled thread",
@@ -3620,5 +3620,66 @@ describe("ThreadView", () => {
     });
     expect(onPendingStatusChange).toHaveBeenCalledWith("Thinking");
     expect(onActiveTurnIdChange).toHaveBeenCalledWith("turn-1");
+  });
+
+  it("hides the environment setup failure choice after the thread has messages", () => {
+    render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[]}
+        composerDisabled={false}
+        desktopApi={{}}
+        loading={false}
+        loadingMore={false}
+        messageCount={1}
+        selectedThread={{
+          id: "thread-env-failure",
+          title: "A new problem I ran into really bit me last night",
+          titleSource: "derived",
+          source: "codex",
+          executionMode: "full-access",
+          updatedAt: Date.now(),
+          codexEnvironmentRuntime: {
+            environmentId: "environment",
+            environmentName: "PwrAgent",
+            executionTarget: "local",
+            setupEnabled: true,
+            setupStatus: "failed",
+          },
+          linkedDirectories: [
+            {
+              id: "/repo",
+              kind: "worktree",
+              label: "repo",
+              path: "/repo",
+              worktreePath: "/repo/.worktrees/thread-env-failure",
+            },
+          ],
+          inbox: {
+            inInbox: true,
+            reason: "updated-since-seen",
+          },
+        }}
+        skills={[]}
+        transcriptEntries={[
+          {
+            type: "message",
+            id: "message-1",
+            role: "user",
+            text: "What is the CWD?",
+          },
+        ]}
+        clearPendingRequest={() => undefined}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+      />
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Continue anyway" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Environment setup failed"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -1499,6 +1499,114 @@ describe("useThreadNavigation", () => {
     expect(result.current.selectedThread?.title).not.toBe(threadId);
   });
 
+  it("keeps launchpad input on an environment setup failure thread", async () => {
+    const directoryKey = "directory:/Users/huntharo/github/PwrAgent";
+    const threadId = "thread-env-failure";
+    const input = [{ type: "text" as const, text: "Fix the failed setup" }];
+    const initialSnapshot = {
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [],
+      directories: [
+        {
+          key: directoryKey,
+          kind: "directory" as const,
+          label: "PwrAgent",
+          path: "/Users/huntharo/github/PwrAgent",
+          threadKeys: [],
+          needsAttentionCount: 0,
+          launchpad: {
+            directoryKey,
+            directoryKind: "directory" as const,
+            directoryLabel: "PwrAgent",
+            directoryPath: "/Users/huntharo/github/PwrAgent",
+            backend: "codex" as const,
+            executionMode: "full-access" as const,
+            prompt: "Fix the failed setup",
+            workMode: "worktree" as const,
+            branchName: "main",
+            model: "gpt-5.5",
+            reasoningEffort: "high",
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        },
+      ],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    };
+    const getNavigationSnapshot = vi
+      .fn()
+      .mockResolvedValueOnce(initialSnapshot)
+      .mockResolvedValueOnce({
+        ...initialSnapshot,
+        inboxThreadKeys: [`codex:${threadId}`],
+        threads: [
+          {
+            id: threadId,
+            title: "Untitled thread",
+            titleSource: "fallback" as const,
+            source: "codex" as const,
+            linkedDirectories: [],
+            inbox: { inInbox: true, reason: "new-thread" as const },
+            updatedAt: 2,
+            codexEnvironmentRuntime: {
+              environmentId: "environment",
+              environmentName: "PwrAgent",
+              executionTarget: "local" as const,
+              setupEnabled: true,
+              setupStatus: "failed" as const,
+            },
+          },
+        ],
+        directories: [
+          {
+            ...initialSnapshot.directories[0]!,
+            threadKeys: [`codex:${threadId}`],
+            launchpad: undefined,
+          },
+        ],
+      });
+    const materializeDirectoryLaunchpad = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId,
+      executionMode: "full-access" as const,
+      workMode: "worktree" as const,
+      codexEnvironmentStartupFailure: {
+        message: "setup failed",
+        phase: "setup" as const,
+        worktreeCleanupAvailable: true,
+      },
+    }));
+
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      materializeDirectoryLaunchpad,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.directories[0]?.launchpad?.prompt).toBe(
+        "Fix the failed setup"
+      );
+    });
+
+    await act(async () => {
+      await result.current.materializeDirectoryLaunchpad(directoryKey, input);
+    });
+
+    expect(result.current.selectedThread?.id).toBe(threadId);
+    expect(result.current.selectedThread?.optimisticUserMessage?.text).toBe(
+      "Fix the failed setup"
+    );
+  });
+
   it("does not let a materialized thread refresh override a newer user thread selection", async () => {
     const directoryKey = "directory:/Users/huntharo/github/PwrAgent";
     const refreshedSnapshot = createDeferred<Awaited<ReturnType<NonNullable<DesktopApi["getNavigationSnapshot"]>>>>();

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -2544,9 +2544,7 @@ export function useThreadNavigation(
           executionMode: response.executionMode,
           workMode: response.workMode,
           codexEnvironmentRuntime: response.codexEnvironmentRuntime,
-          optimisticUserMessage: response.codexEnvironmentStartupFailure
-            ? undefined
-            : buildOptimisticUserMessage(input),
+          optimisticUserMessage: buildOptimisticUserMessage(input),
         });
         const nextThreadKey = buildThreadIdentityKey(response.backend, response.threadId);
         setOptimisticThread(optimisticMaterializedThread);


### PR DESCRIPTION
## Summary
- Preserve launchpad input on environment setup failure threads so the original prompt can still be submitted.
- Make the setup failure "Continue anyway" action start a turn with the saved launchpad input and thread model settings.
- Hide the setup failure choice once the failed thread has messages or an active turn so stale banners do not keep resurfacing.
- Include hydrated launchpad Codex environment options in navigation change detection so environment picker updates are not skipped as unchanged snapshots.

## Tests
- pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
- pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
- pnpm test apps/desktop/src/main/__tests__/app-server-ipc.test.ts
- pnpm typecheck