### PR TITLE
fix(desktop): require context rail hover intent

### DIFF
--- a/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
@@ -1083,7 +1083,7 @@ test("directory launchpad keeps new worktree as the sticky default after startin
     const contextRail = app.window.getByRole("complementary", {
       name: "Thread context",
     });
-    await contextRail.hover();
+    await contextRail.getByRole("button", { name: "Open context rail" }).click();
     await expect(
       contextRail.getByLabel("Path for worktree FixtureRepo", { exact: true }),
     ).toBeVisible();

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -30,6 +30,7 @@ import {
 
 const HOVER_RAIL_POINTER_POLL_MS = 500;
 const HOVER_RAIL_OFF_TARGET_CLOSE_MS = 1_200;
+const HOVER_RAIL_REVEAL_DELAY_MS = 175;
 
 type ThreadContextPanelProps = {
   backendError?: string;
@@ -66,6 +67,8 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
   const pinned = props.pinned;
   const open = pinned || revealed;
   const hideTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const revealTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const revealIntentRef = useRef(0);
   const lastMousePositionRef = useRef<{ x: number; y: number } | undefined>(undefined);
   const outsideRailSinceRef = useRef<number | undefined>(undefined);
 
@@ -110,11 +113,37 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
     [isMouseInsideRail]
   );
 
+  const clearRevealTimer = useCallback(() => {
+    revealIntentRef.current += 1;
+    clearTimeout(revealTimerRef.current);
+    revealTimerRef.current = undefined;
+  }, []);
+
+  const isHoverStillInsideRail = useCallback(
+    async (point?: { x: number; y: number }): Promise<boolean> => {
+      const readPointerSnapshot = props.desktopApi?.getWindowPointerSnapshot;
+      if (readPointerSnapshot) {
+        try {
+          return isScreenCursorInsideRail(await readPointerSnapshot());
+        } catch {
+          // Cursor polling is a best-effort Electron affordance. Fall back
+          // to the latest renderer mouse position when the bridge is absent
+          // or briefly unavailable.
+        }
+      }
+
+      const latestPoint = lastMousePositionRef.current ?? point;
+      return Boolean(latestPoint && isMouseInsideRail(latestPoint));
+    },
+    [isMouseInsideRail, isScreenCursorInsideRail, props.desktopApi?.getWindowPointerSnapshot]
+  );
+
   const hideRailNow = useCallback(() => {
     clearTimeout(hideTimerRef.current);
+    clearRevealTimer();
     outsideRailSinceRef.current = undefined;
     setRevealed(false);
-  }, []);
+  }, [clearRevealTimer]);
 
   // Debounced reveal/hide prevents flicker from CSS transform transitions
   // causing spurious mouseenter→mouseleave sequences. The final hit test
@@ -123,13 +152,40 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
   // inside the opened rail.
   const revealRail = useCallback(() => {
     clearTimeout(hideTimerRef.current);
+    clearRevealTimer();
     outsideRailSinceRef.current = undefined;
     setRevealed(true);
-  }, []);
+  }, [clearRevealTimer]);
+
+  const revealRailAfterHoverIntent = useCallback(
+    (point: { x: number; y: number }) => {
+      clearTimeout(hideTimerRef.current);
+      clearRevealTimer();
+      outsideRailSinceRef.current = undefined;
+
+      const intent = revealIntentRef.current;
+      revealTimerRef.current = setTimeout(() => {
+        revealTimerRef.current = undefined;
+        void (async () => {
+          if (revealIntentRef.current !== intent) {
+            return;
+          }
+
+          if (await isHoverStillInsideRail(point)) {
+            if (revealIntentRef.current === intent) {
+              revealRail();
+            }
+          }
+        })();
+      }, HOVER_RAIL_REVEAL_DELAY_MS);
+    },
+    [clearRevealTimer, isHoverStillInsideRail, revealRail]
+  );
 
   const hideRail = useCallback(
     (point?: { x: number; y: number }) => {
       clearTimeout(hideTimerRef.current);
+      clearRevealTimer();
       hideTimerRef.current = setTimeout(() => {
         const latestPoint = lastMousePositionRef.current ?? point;
         if (latestPoint && isMouseInsideRail(latestPoint)) {
@@ -139,12 +195,14 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
         hideRailNow();
       }, 300);
     },
-    [hideRailNow, isMouseInsideRail]
+    [clearRevealTimer, hideRailNow, isMouseInsideRail]
   );
 
   useEffect(() => {
     return () => {
       clearTimeout(hideTimerRef.current);
+      clearTimeout(revealTimerRef.current);
+      revealIntentRef.current += 1;
     };
   }, []);
 
@@ -299,7 +357,10 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
       onMouseEnter={(event) => {
         rememberMousePosition(event);
         if (!pinned) {
-          revealRail();
+          revealRailAfterHoverIntent({
+            x: event.clientX,
+            y: event.clientY,
+          });
         }
       }}
       onMouseMove={rememberMousePosition}
@@ -351,6 +412,7 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
             if (pinned) {
               updatePinned(false);
               clearTimeout(hideTimerRef.current);
+              clearRevealTimer();
               setRevealed(false);
               return;
             }

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -30,7 +30,7 @@ import {
 
 const HOVER_RAIL_POINTER_POLL_MS = 500;
 const HOVER_RAIL_OFF_TARGET_CLOSE_MS = 1_200;
-const HOVER_RAIL_REVEAL_DELAY_MS = 175;
+const HOVER_RAIL_REVEAL_DELAY_MS = 250;
 
 type ThreadContextPanelProps = {
   backendError?: string;

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -30,7 +30,7 @@ import {
 
 const HOVER_RAIL_POINTER_POLL_MS = 500;
 const HOVER_RAIL_OFF_TARGET_CLOSE_MS = 1_200;
-const HOVER_RAIL_REVEAL_DELAY_MS = 250;
+const HOVER_RAIL_REVEAL_DELAY_MS = 350;
 
 type ThreadContextPanelProps = {
   backendError?: string;

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { BackendSummary, NavigationThreadSummary } from "@pwragent/shared";
 import { ThreadContextPanel } from "../ThreadContextPanel";
 
-const HOVER_RAIL_REVEAL_DELAY_MS = 175;
+const HOVER_RAIL_REVEAL_DELAY_MS = 250;
 
 afterEach(() => {
   cleanup();
@@ -145,6 +145,23 @@ describe("ThreadContextPanel", () => {
     });
 
     expect(screen.queryByText("Auto-hide")).not.toBeInTheDocument();
+  });
+
+  it("reveals immediately when the collapsed rail is clicked", () => {
+    vi.useFakeTimers();
+    render(
+      <ThreadContextPanel backends={[baseBackend]} pinned={false} thread={baseThread} />
+    );
+
+    const rail = screen.getByLabelText("Thread context");
+    fireEvent.mouseEnter(rail, { clientX: 980, clientY: 120 });
+    act(() => {
+      vi.advanceTimersByTime(HOVER_RAIL_REVEAL_DELAY_MS - 25);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Open context rail" }));
+
+    expect(screen.getByText("Auto-hide")).toBeInTheDocument();
   });
 
   it("hides the hover rail when document mouse movement resumes outside the rail", async () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -4,6 +4,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { BackendSummary, NavigationThreadSummary } from "@pwragent/shared";
 import { ThreadContextPanel } from "../ThreadContextPanel";
 
+const HOVER_RAIL_REVEAL_DELAY_MS = 175;
+
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
@@ -80,8 +82,14 @@ const baseBackend: BackendSummary = {
   ],
 };
 
+const advanceHoverRevealDelay = async (): Promise<void> => {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(HOVER_RAIL_REVEAL_DELAY_MS + 1);
+  });
+};
+
 describe("ThreadContextPanel", () => {
-  it("hides the hover rail when document mouse movement resumes outside the rail", () => {
+  it("waits for hover intent before revealing the rail", async () => {
     vi.useFakeTimers();
     render(
       <ThreadContextPanel backends={[baseBackend]} pinned={false} thread={baseThread} />
@@ -101,6 +109,65 @@ describe("ThreadContextPanel", () => {
     } as DOMRect);
 
     fireEvent.mouseEnter(rail, { clientX: 980, clientY: 120 });
+    expect(screen.queryByText("Auto-hide")).not.toBeInTheDocument();
+
+    await advanceHoverRevealDelay();
+
+    expect(screen.getByText("Auto-hide")).toBeInTheDocument();
+  });
+
+  it("does not reveal the rail after a drive-by hover", () => {
+    vi.useFakeTimers();
+    render(
+      <ThreadContextPanel backends={[baseBackend]} pinned={false} thread={baseThread} />
+    );
+
+    const rail = screen.getByLabelText("Thread context");
+    vi.spyOn(rail, "getBoundingClientRect").mockReturnValue({
+      bottom: 800,
+      height: 800,
+      left: 620,
+      right: 1000,
+      top: 0,
+      width: 380,
+      x: 620,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    fireEvent.mouseEnter(rail, { clientX: 980, clientY: 120 });
+    act(() => {
+      vi.advanceTimersByTime(HOVER_RAIL_REVEAL_DELAY_MS - 25);
+    });
+    fireEvent.mouseLeave(rail, { clientX: 600, clientY: 120 });
+    act(() => {
+      vi.advanceTimersByTime(HOVER_RAIL_REVEAL_DELAY_MS + 1);
+    });
+
+    expect(screen.queryByText("Auto-hide")).not.toBeInTheDocument();
+  });
+
+  it("hides the hover rail when document mouse movement resumes outside the rail", async () => {
+    vi.useFakeTimers();
+    render(
+      <ThreadContextPanel backends={[baseBackend]} pinned={false} thread={baseThread} />
+    );
+
+    const rail = screen.getByLabelText("Thread context");
+    vi.spyOn(rail, "getBoundingClientRect").mockReturnValue({
+      bottom: 800,
+      height: 800,
+      left: 620,
+      right: 1000,
+      top: 0,
+      width: 380,
+      x: 620,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    fireEvent.mouseEnter(rail, { clientX: 980, clientY: 120 });
+    await advanceHoverRevealDelay();
     expect(screen.getByText("Auto-hide")).toBeInTheDocument();
 
     fireEvent.mouseMove(document, { clientX: 600, clientY: 120 });
@@ -113,19 +180,34 @@ describe("ThreadContextPanel", () => {
 
   it("polls the window pointer and closes when the cursor remains outside the rail", async () => {
     vi.useFakeTimers();
-    const getWindowPointerSnapshot = vi.fn(async () => ({
-      contentBounds: {
-        height: 800,
-        width: 1000,
-        x: 100,
-        y: 100,
-      },
-      cursor: {
-        x: 700,
-        y: 220,
-      },
-      windowFocused: false,
-    }));
+    const getWindowPointerSnapshot = vi
+      .fn()
+      .mockResolvedValueOnce({
+        contentBounds: {
+          height: 800,
+          width: 1000,
+          x: 100,
+          y: 100,
+        },
+        cursor: {
+          x: 1080,
+          y: 220,
+        },
+        windowFocused: false,
+      })
+      .mockResolvedValue({
+        contentBounds: {
+          height: 800,
+          width: 1000,
+          x: 100,
+          y: 100,
+        },
+        cursor: {
+          x: 700,
+          y: 220,
+        },
+        windowFocused: false,
+      });
 
     render(
       <ThreadContextPanel
@@ -150,6 +232,7 @@ describe("ThreadContextPanel", () => {
     } as DOMRect);
 
     fireEvent.mouseEnter(rail, { clientX: 980, clientY: 120 });
+    await advanceHoverRevealDelay();
     expect(screen.getByText("Auto-hide")).toBeInTheDocument();
 
     await act(async () => {
@@ -199,6 +282,7 @@ describe("ThreadContextPanel", () => {
     } as DOMRect);
 
     fireEvent.mouseEnter(rail, { clientX: 980, clientY: 120 });
+    await advanceHoverRevealDelay();
     expect(screen.getByText("Auto-hide")).toBeInTheDocument();
 
     await act(async () => {
@@ -209,7 +293,7 @@ describe("ThreadContextPanel", () => {
     expect(screen.getByText("Auto-hide")).toBeInTheDocument();
   });
 
-  it("keeps the hover rail open when a transient leave is still inside the opened rail", () => {
+  it("keeps the hover rail open when a transient leave is still inside the opened rail", async () => {
     vi.useFakeTimers();
     render(
       <ThreadContextPanel backends={[baseBackend]} pinned={false} thread={baseThread} />
@@ -229,6 +313,7 @@ describe("ThreadContextPanel", () => {
     } as DOMRect);
 
     fireEvent.mouseEnter(rail, { clientX: 980, clientY: 120 });
+    await advanceHoverRevealDelay();
     expect(screen.getByText("Auto-hide")).toBeInTheDocument();
 
     fireEvent.mouseLeave(rail, { clientX: 980, clientY: 120 });
@@ -239,7 +324,7 @@ describe("ThreadContextPanel", () => {
     expect(screen.getByText("Auto-hide")).toBeInTheDocument();
   });
 
-  it("hides the hover rail after the mouse leaves the opened rail", () => {
+  it("hides the hover rail after the mouse leaves the opened rail", async () => {
     vi.useFakeTimers();
     render(
       <ThreadContextPanel backends={[baseBackend]} pinned={false} thread={baseThread} />
@@ -259,6 +344,7 @@ describe("ThreadContextPanel", () => {
     } as DOMRect);
 
     fireEvent.mouseEnter(rail, { clientX: 980, clientY: 120 });
+    await advanceHoverRevealDelay();
     expect(screen.getByText("Auto-hide")).toBeInTheDocument();
 
     fireEvent.mouseLeave(rail, { clientX: 600, clientY: 120 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { BackendSummary, NavigationThreadSummary } from "@pwragent/shared";
 import { ThreadContextPanel } from "../ThreadContextPanel";
 
-const HOVER_RAIL_REVEAL_DELAY_MS = 250;
+const HOVER_RAIL_REVEAL_DELAY_MS = 350;
 
 afterEach(() => {
   cleanup();


### PR DESCRIPTION
## Summary

- Added a 175 ms hover-intent delay before the right context rail expands from mouse hover.
- Kept focus and explicit click behavior immediate, while cancelling pending hover reveals when the cursor leaves before the linger time.
- Validated delayed reveal against the Electron cursor snapshot when available, so missed renderer leave events do not have to rely only on stale mouse coordinates.

## Verification

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`
- `pnpm --filter @pwragent/desktop test:e2e e2e/directory-launchpad-workspace.spec.ts --grep "sticky default"`

## Notes

- This is a follow-up to the context rail hover stability and stale-open fixes.
