### PR TITLE
fix(desktop): recover Codex worktree repository links

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1487,7 +1487,7 @@ describe("DesktopBackendRegistry", () => {
 
   it("does not let non-backfilling cheap list cache suppress navigation backfill", async () => {
     const projectA = "/Users/huntharo/projects/ProjectA";
-    const worktreePath = "/Users/huntharo/.codex/worktrees/wt1/ProjectA";
+    const worktreePath = "/Users/huntharo/.codex/profiles/sstk/worktrees/wt1/ProjectA";
     const cheapThread: AppServerThreadSummary = {
       id: "thread-1",
       title: "ProjectA worktree",
@@ -1555,6 +1555,277 @@ describe("DesktopBackendRegistry", () => {
           kind: "worktree",
         }),
       ],
+    });
+
+    await registry.close();
+  });
+
+  it("lets fresh Codex local metadata replace stale overlay worktree relationships", async () => {
+    const projectA = "/Users/huntharo/projects/ProjectA";
+    const staleWorktreePath =
+      "/Users/huntharo/.codex/profiles/sstk/worktrees/wt1/ProjectA";
+    const localThread: AppServerThreadSummary = {
+      id: "thread-1",
+      title: "ProjectA local",
+      titleSource: "explicit",
+      source: "codex",
+      projectKey: projectA,
+      createdAt: 1_000,
+      updatedAt: 1_000,
+      linkedDirectories: [
+        {
+          id: projectA,
+          label: "ProjectA",
+          path: projectA,
+          kind: "local",
+        },
+      ],
+    };
+    const codexClient = new MockBackendClient({
+      threads: [localThread],
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [
+            {
+              id: staleWorktreePath,
+              label: "ProjectA",
+              path: projectA,
+              worktreePath: staleWorktreePath,
+              kind: "worktree",
+            },
+          ],
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({}),
+      overlayStore,
+    });
+
+    await registry.listThreads({
+      backend: "codex",
+      callerReason: "startup-prewarm",
+    });
+
+    await expect(
+      overlayStore.getThreadOverlayState({ backend: "codex", threadId: "thread-1" }),
+    ).resolves.toMatchObject({
+      extraLinkedDirectories: [
+        {
+          id: projectA,
+          label: "ProjectA",
+          path: projectA,
+          kind: "local",
+        },
+      ],
+    });
+
+    await registry.close();
+  });
+
+  it("does not let Codex source metadata replace active handoff workspace overlays", async () => {
+    const projectA = "/Users/huntharo/projects/ProjectA";
+    const handoffWorktreePath = "/Users/huntharo/projects/ProjectA/.worktrees/thread-1";
+    const localThread: AppServerThreadSummary = {
+      id: "thread-1",
+      title: "ProjectA local",
+      titleSource: "explicit",
+      source: "codex",
+      projectKey: projectA,
+      createdAt: 1_000,
+      updatedAt: 1_000,
+      linkedDirectories: [
+        {
+          id: projectA,
+          label: "ProjectA",
+          path: projectA,
+          kind: "local",
+        },
+      ],
+    };
+    const codexClient = new MockBackendClient({
+      threads: [localThread],
+    });
+    const handoffDirectory: ThreadOverlayState["extraLinkedDirectories"][number] = {
+      id: "pwragent-handoff:codex:thread-1",
+      label: "ProjectA",
+      path: projectA,
+      worktreePath: handoffWorktreePath,
+      kind: "worktree",
+    };
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [handoffDirectory],
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({}),
+      overlayStore,
+    });
+
+    await registry.listThreads({
+      backend: "codex",
+      callerReason: "startup-prewarm",
+    });
+
+    await expect(
+      overlayStore.getThreadOverlayState({ backend: "codex", threadId: "thread-1" }),
+    ).resolves.toMatchObject({
+      extraLinkedDirectories: [handoffDirectory],
+    });
+
+    await registry.close();
+  });
+
+  it("does not let Codex source worktree metadata replace active handoff workspace overlays", async () => {
+    const projectA = "/Users/huntharo/projects/ProjectA";
+    const codexWorktreePath =
+      "/Users/huntharo/.codex/profiles/sstk/worktrees/original/ProjectA";
+    const handoffWorktreePath = "/Users/huntharo/projects/ProjectA/.worktrees/thread-1";
+    const worktreeThread: AppServerThreadSummary = {
+      id: "thread-1",
+      title: "ProjectA worktree",
+      titleSource: "explicit",
+      source: "codex",
+      projectKey: codexWorktreePath,
+      createdAt: 1_000,
+      updatedAt: 1_000,
+      linkedDirectories: [
+        {
+          id: projectA,
+          label: "ProjectA",
+          path: projectA,
+          worktreePath: codexWorktreePath,
+          kind: "worktree",
+        },
+      ],
+    };
+    const codexClient = new MockBackendClient({
+      threads: [worktreeThread],
+    });
+    const handoffDirectory: ThreadOverlayState["extraLinkedDirectories"][number] = {
+      id: "pwragent-handoff:codex:thread-1",
+      label: "ProjectA",
+      path: projectA,
+      worktreePath: handoffWorktreePath,
+      kind: "worktree",
+    };
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [handoffDirectory],
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({}),
+      overlayStore,
+    });
+
+    await registry.listThreads({
+      backend: "codex",
+      callerReason: "startup-prewarm",
+    });
+
+    await expect(
+      overlayStore.getThreadOverlayState({ backend: "codex", threadId: "thread-1" }),
+    ).resolves.toMatchObject({
+      extraLinkedDirectories: [handoffDirectory],
+    });
+
+    await registry.close();
+  });
+
+  it("does not backfill Codex worktree metadata over active handoff workspace overlays", async () => {
+    const projectA = "/Users/huntharo/projects/ProjectA";
+    const codexWorktreePath =
+      "/Users/huntharo/.codex/profiles/sstk/worktrees/original/ProjectA";
+    const handoffWorktreePath = "/Users/huntharo/projects/ProjectA/.worktrees/thread-1";
+    const cheapThread: AppServerThreadSummary = {
+      id: "thread-1",
+      title: "ProjectA worktree",
+      titleSource: "explicit",
+      source: "codex",
+      projectKey: codexWorktreePath,
+      createdAt: 1_000,
+      updatedAt: 1_000,
+      linkedDirectories: [
+        {
+          id: codexWorktreePath,
+          label: "ProjectA",
+          path: codexWorktreePath,
+          kind: "local",
+        },
+      ],
+    };
+    const codexClient = new MockBackendClient({
+      threads: [cheapThread],
+    });
+    const enrichThreadDirectories = vi.fn(
+      async (threads: AppServerThreadSummary[]) =>
+        threads.map((thread) => ({
+          ...thread,
+          linkedDirectories: [
+            {
+              id: projectA,
+              label: "ProjectA",
+              path: projectA,
+              worktreePath: codexWorktreePath,
+              kind: "worktree" as const,
+            },
+          ],
+        })),
+    );
+    Object.assign(codexClient, { enrichThreadDirectories });
+    const handoffDirectory: ThreadOverlayState["extraLinkedDirectories"][number] = {
+      id: "pwragent-handoff:codex:thread-1",
+      label: "ProjectA",
+      path: projectA,
+      worktreePath: handoffWorktreePath,
+      kind: "worktree",
+    };
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [handoffDirectory],
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({}),
+      overlayStore,
+    });
+
+    await registry.listThreads({
+      backend: "codex",
+      callerReason: "startup-prewarm",
+    });
+
+    expect(enrichThreadDirectories).not.toHaveBeenCalled();
+    await expect(
+      overlayStore.getThreadOverlayState({ backend: "codex", threadId: "thread-1" }),
+    ).resolves.toMatchObject({
+      extraLinkedDirectories: [handoffDirectory],
     });
 
     await registry.close();

--- a/apps/desktop/src/main/__tests__/thread-directory-enricher.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-directory-enricher.test.ts
@@ -6,7 +6,17 @@ describe("createThreadDirectoryEnricher", () => {
   });
 
   it("resolves the home repo, preserves the worktree path, and caches repeated lookups", async () => {
-    const accessMock = vi.fn(async () => undefined);
+    const projectPath = "/Users/huntharo/pwrdrvr/PwrAgent/.worktrees/feature-one/apps";
+    const dotGitPath = "/Users/huntharo/pwrdrvr/PwrAgent/.worktrees/feature-one/.git";
+    const accessMock = vi.fn(async (targetPath: string) => {
+      if (targetPath === projectPath || targetPath === dotGitPath) {
+        return undefined;
+      }
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+    const readFileMock = vi.fn(async () =>
+      "gitdir: /Users/huntharo/pwrdrvr/PwrAgent/.git/worktrees/feature-one\n"
+    );
     const execFileMock = vi.fn(
       (
         _file: string,
@@ -45,6 +55,7 @@ describe("createThreadDirectoryEnricher", () => {
 
     vi.doMock("node:fs/promises", () => ({
       access: accessMock,
+      readFile: readFileMock,
     }));
     vi.doMock("node:child_process", () => ({
       execFile: execFileMock,
@@ -57,8 +68,8 @@ describe("createThreadDirectoryEnricher", () => {
       cacheTtlMs: 60_000,
     });
 
-    const first = await enricher("/Users/huntharo/pwrdrvr/PwrAgent/.worktrees/feature-one/apps");
-    const second = await enricher("/Users/huntharo/pwrdrvr/PwrAgent/.worktrees/feature-one/apps");
+    const first = await enricher(projectPath);
+    const second = await enricher(projectPath);
 
     expect(first).toEqual({
       linkedDirectories: [
@@ -73,8 +84,62 @@ describe("createThreadDirectoryEnricher", () => {
       observedGitBranch: "feature-one",
     });
     expect(second).toEqual(first);
-    expect(accessMock).toHaveBeenCalledTimes(1);
+    expect(accessMock).toHaveBeenCalledTimes(3);
+    expect(readFileMock).toHaveBeenCalledTimes(1);
     expect(execFileMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("recovers the home repo from a worktree .git file when git worktree list fails", async () => {
+    const projectPath = "/Users/huntharo/.codex/profiles/sstk/worktrees/mp75tdnu/PwrAgnt/apps/desktop";
+    const worktreePath = "/Users/huntharo/.codex/profiles/sstk/worktrees/mp75tdnu/PwrAgnt";
+    const dotGitPath = `${worktreePath}/.git`;
+    vi.doMock("node:fs/promises", () => ({
+      access: vi.fn(async (targetPath: string) => {
+        if (targetPath === projectPath || targetPath === dotGitPath) {
+          return undefined;
+        }
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      }),
+      readFile: vi.fn(async () =>
+        "gitdir: /Users/huntharo/pwrdrvr/PwrAgnt/.git/worktrees/PwrAgnt\n"
+      ),
+    }));
+    vi.doMock("node:child_process", () => ({
+      execFile: vi.fn(
+        (
+          _file: string,
+          args: string[],
+          _options: unknown,
+          callback: (error: Error | null, result?: { stdout: string; stderr: string }) => void,
+        ) => {
+          if (args.includes("--porcelain")) {
+            callback(new Error("worktree list failed"));
+            return;
+          }
+          callback(null, {
+            stdout: "/Users/huntharo/.codex/profiles/sstk/worktrees/mp75tdnu/PwrAgnt\n",
+            stderr: "",
+          });
+        },
+      ),
+    }));
+
+    const { createThreadDirectoryEnricher } = await import(
+      "../app-server/thread-directory-enricher"
+    );
+    const enricher = createThreadDirectoryEnricher();
+
+    await expect(enricher(projectPath)).resolves.toEqual({
+      linkedDirectories: [
+        {
+          id: "/Users/huntharo/pwrdrvr/PwrAgnt",
+          path: "/Users/huntharo/pwrdrvr/PwrAgnt",
+          worktreePath,
+          label: "PwrAgnt",
+          kind: "worktree",
+        },
+      ],
+    });
   });
 
   it("returns no linked directories when the anchored path no longer exists", async () => {
@@ -82,6 +147,7 @@ describe("createThreadDirectoryEnricher", () => {
       access: vi.fn(async () => {
         throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
       }),
+      readFile: vi.fn(),
     }));
     vi.doMock("node:child_process", () => ({
       execFile: vi.fn(),

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -324,10 +324,19 @@ function resolveLinkedDirectoryCwd(
 function hasHandoffWorkspace(
   directories: AppServerThreadSummary["linkedDirectories"] = [],
 ): boolean {
-  return directories.some(
-    (directory) =>
-      directory.id.startsWith("pwragent-handoff:") ||
-      directory.id.startsWith("pwragnt-handoff:"),  // legacy prefix from pre-rebrand data
+  return directories.some(isHandoffDirectory);
+}
+
+function overlayHasHandoffWorkspace(
+  overlay: ThreadOverlayState | undefined,
+): boolean {
+  return Boolean(overlay?.extraLinkedDirectories.some(isHandoffDirectory));
+}
+
+function isHandoffDirectory(directory: LinkedDirectorySummary): boolean {
+  return (
+    directory.id.startsWith("pwragent-handoff:") ||
+    directory.id.startsWith("pwragnt-handoff:")  // legacy prefix from pre-rebrand data
   );
 }
 
@@ -378,9 +387,7 @@ function isLikelyToolManagedWorktreePath(projectKey: string | undefined): boolea
     return false;
   }
 
-  return /[\\/](?:\.codex[\\/]worktrees|\.pwrag(?:ent|nt)[\\/]worktrees|\.worktrees)[\\/]/.test(
-    normalized,
-  );
+  return isToolManagedWorktreePath(normalized) || /[\\/]\.worktrees[\\/]/.test(normalized);
 }
 
 function hasCachedWorktreeDirectory(
@@ -481,6 +488,10 @@ function buildCachedDirectoryRelationship(
     return undefined;
   }
 
+  if (isLikelyToolManagedWorktreePath(projectKey)) {
+    return undefined;
+  }
+
   const projectPath = path.resolve(projectKey);
   const localDirectory = thread.linkedDirectories.find((candidate) => {
     if (candidate.worktreePath?.trim()) {
@@ -510,14 +521,25 @@ function shouldRepairCachedDirectoryRelationship(params: {
     return false;
   }
 
+  if (overlayHasHandoffWorkspace(params.overlay)) {
+    return false;
+  }
+
   if (params.directory.kind === "worktree") {
     return true;
   }
 
   return Boolean(
-    params.overlay?.extraLinkedDirectories.some(
-      (candidate) => candidate.id === params.directory.id,
-    ),
+    params.overlay?.extraLinkedDirectories.some((candidate) => {
+      if (candidate.id === params.directory.id) {
+        return true;
+      }
+      if (isHandoffDirectory(candidate)) {
+        return false;
+      }
+
+      return path.resolve(candidate.path) === path.resolve(params.directory.path);
+    }),
   );
 }
 
@@ -1479,6 +1501,7 @@ export class DesktopBackendRegistry {
   private readonly queuedExecutionModeFlushes = new Map<string, Promise<void>>();
   private readonly attemptedTitleGenerations = new Set<string>();
   private readonly repairedDirectoryThreadKeys = new Set<string>();
+  private readonly failedDirectoryRelationshipLogKeys = new Set<string>();
   private fullDirectoryReconcileDispatched = false;
   private titleGenerationSequence = 0;
 
@@ -4047,7 +4070,7 @@ export class DesktopBackendRegistry {
         return;
       }
 
-      await this.overlayStore.addLinkedDirectory({
+      await this.overlayStore.replaceWorkspaceLinkedDirectory({
         backend: "codex",
         threadId: params.threadId,
         directory,
@@ -4498,6 +4521,13 @@ export class DesktopBackendRegistry {
       backend: "codex",
       threadIds: threadsWithPending.map((thread) => thread.id),
     });
+    const reconciledOverlaysByThreadId =
+      await this.reconcileCodexDirectoryRelationshipsFromSource({
+        diagnostics,
+        overlaysByThreadId,
+        threads: threadsWithPending,
+      });
+    Object.assign(overlaysByThreadId, reconciledOverlaysByThreadId);
     if (
       !params.archived &&
       params.enrichDirectories === false &&
@@ -4535,6 +4565,49 @@ export class DesktopBackendRegistry {
     );
   }
 
+  private async reconcileCodexDirectoryRelationshipsFromSource(params: {
+    diagnostics?: {
+      callerReason?: string;
+      ownerId?: string;
+    };
+    overlaysByThreadId: Record<string, ThreadOverlayState | undefined>;
+    threads: AppServerThreadSummary[];
+  }): Promise<Record<string, ThreadOverlayState | undefined>> {
+    const updatedOverlaysByThreadId: Record<
+      string,
+      ThreadOverlayState | undefined
+    > = {};
+
+    for (const thread of params.threads) {
+      const directory = buildCachedDirectoryRelationship(thread);
+      if (!directory) {
+        continue;
+      }
+
+      const overlay = params.overlaysByThreadId[thread.id];
+      if (!shouldRepairCachedDirectoryRelationship({ directory, overlay })) {
+        continue;
+      }
+
+      updatedOverlaysByThreadId[thread.id] =
+        await this.overlayStore.replaceWorkspaceLinkedDirectory({
+          backend: "codex",
+          threadId: thread.id,
+          directory,
+        });
+    }
+
+    const updatedThreadCount = Object.keys(updatedOverlaysByThreadId).length;
+    if (updatedThreadCount > 0) {
+      logDebug("codexDirectorySourceReconcile:completed", {
+        callerReason: params.diagnostics?.callerReason ?? null,
+        updatedThreadCount,
+      });
+    }
+
+    return updatedOverlaysByThreadId;
+  }
+
   private async backfillMissingCodexDirectoryRelationships(params: {
     diagnostics?: {
       callerReason?: string;
@@ -4548,6 +4621,10 @@ export class DesktopBackendRegistry {
     }
 
     const candidates = params.threads.filter((thread) => {
+      if (overlayHasHandoffWorkspace(params.overlaysByThreadId[thread.id])) {
+        return false;
+      }
+
       const projectKey = thread.projectKey?.trim();
       if (!isLikelyToolManagedWorktreePath(projectKey)) {
         return false;
@@ -4563,6 +4640,18 @@ export class DesktopBackendRegistry {
       return {};
     }
 
+    logDebug("codexDirectoryBackfill:candidates", {
+      callerReason: params.diagnostics?.callerReason ?? null,
+      candidateCount: candidates.length,
+      candidates: candidates.slice(0, 10).map((thread) => ({
+        threadId: thread.id,
+        projectKey: thread.projectKey,
+        linkedDirectories: thread.linkedDirectories,
+        overlayExtraLinkedDirectories:
+          params.overlaysByThreadId[thread.id]?.extraLinkedDirectories ?? [],
+      })),
+    });
+
     try {
       const enrichedThreads = await this.codexClient.enrichThreadDirectories(candidates);
       const updatedOverlaysByThreadId: Record<
@@ -4571,13 +4660,32 @@ export class DesktopBackendRegistry {
       > = {};
 
       for (const thread of enrichedThreads) {
+        if (overlayHasHandoffWorkspace(params.overlaysByThreadId[thread.id])) {
+          continue;
+        }
+
         const directory = buildCachedWorktreeDirectory(thread);
         if (!directory) {
+          const warningKey = `${thread.id}:${thread.projectKey ?? ""}`;
+          if (!this.failedDirectoryRelationshipLogKeys.has(warningKey)) {
+            this.failedDirectoryRelationshipLogKeys.add(warningKey);
+            backendRegistryLog.warn(
+              "Codex directory enrichment did not produce a worktree repository relationship",
+              {
+                callerReason: params.diagnostics?.callerReason ?? null,
+                threadId: thread.id,
+                projectKey: thread.projectKey,
+                linkedDirectories: thread.linkedDirectories,
+                overlayExtraLinkedDirectories:
+                  params.overlaysByThreadId[thread.id]?.extraLinkedDirectories ?? [],
+              },
+            );
+          }
           continue;
         }
 
         updatedOverlaysByThreadId[thread.id] =
-          await this.overlayStore.addLinkedDirectory({
+          await this.overlayStore.replaceWorkspaceLinkedDirectory({
             backend: "codex",
             threadId: thread.id,
             directory,

--- a/apps/desktop/src/main/codex-app-server/thread-directory-enricher.ts
+++ b/apps/desktop/src/main/codex-app-server/thread-directory-enricher.ts
@@ -1,10 +1,13 @@
 import { execFile as execFileCallback } from "node:child_process";
-import { access } from "node:fs/promises";
+import { access, readFile } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 import type { LinkedDirectorySummary } from "@pwragent/shared";
+import { isToolManagedWorktreePath } from "@pwragent/shared";
+import { getMainLogger } from "../log";
 
 const execFile = promisify(execFileCallback);
+const threadDirectoryLog = getMainLogger("pwragent:thread-directory-enricher");
 
 export type ThreadDirectoryEnrichment = {
   linkedDirectories: LinkedDirectorySummary[];
@@ -15,6 +18,16 @@ type CachedEnrichment = {
   expiresAt: number;
   inFlight?: Promise<ThreadDirectoryEnrichment>;
   value?: ThreadDirectoryEnrichment;
+};
+
+type GitMetadataEvidence = {
+  dotGitKind: "directory" | "file" | "missing" | "unreadable";
+  dotGitPath?: string;
+  gitdirPath?: string;
+  gitdirParentName?: string;
+  inferredRepositoryPath?: string;
+  inferredWorktreeAdminName?: string;
+  error?: string;
 };
 
 async function runGit(projectKey: string, args: string[]): Promise<string> {
@@ -31,6 +44,101 @@ async function pathExists(targetPath: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+async function findDotGitPath(startPath: string): Promise<string | undefined> {
+  let currentPath = path.resolve(startPath);
+
+  while (true) {
+    const dotGitPath = path.join(currentPath, ".git");
+    if (await pathExists(dotGitPath)) {
+      return dotGitPath;
+    }
+
+    const parentPath = path.dirname(currentPath);
+    if (parentPath === currentPath) {
+      return undefined;
+    }
+    currentPath = parentPath;
+  }
+}
+
+function inferRepositoryFromGitdir(gitdirPath: string): {
+  inferredRepositoryPath?: string;
+  inferredWorktreeAdminName?: string;
+} {
+  const normalized = path.resolve(gitdirPath).replace(/[\\/]+$/, "");
+  const match = normalized.match(/^(.*)[\\/]\.git[\\/]worktrees[\\/]([^\\/]+)$/);
+  if (!match) {
+    return {};
+  }
+
+  return {
+    inferredRepositoryPath: path.resolve(match[1]),
+    inferredWorktreeAdminName: match[2],
+  };
+}
+
+async function readGitMetadataEvidence(
+  currentPath: string,
+): Promise<GitMetadataEvidence> {
+  const dotGitPath = await findDotGitPath(currentPath);
+  if (!dotGitPath) {
+    return { dotGitKind: "missing" };
+  }
+
+  try {
+    const dotGitContent = await readFile(dotGitPath, "utf8");
+    const gitdirMatch = dotGitContent.match(/^gitdir:\s*(.+?)\s*$/m);
+    const gitdirPath = gitdirMatch
+      ? path.resolve(path.dirname(dotGitPath), gitdirMatch[1])
+      : undefined;
+    const inferred = gitdirPath ? inferRepositoryFromGitdir(gitdirPath) : {};
+
+    return {
+      dotGitKind: "file",
+      dotGitPath,
+      gitdirPath,
+      gitdirParentName: gitdirPath ? path.basename(path.dirname(gitdirPath)) : undefined,
+      ...inferred,
+    };
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "EISDIR") {
+      return {
+        dotGitKind: "directory",
+        dotGitPath,
+      };
+    }
+
+    return {
+      dotGitKind: "unreadable",
+      dotGitPath,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+async function buildLinkedDirectoryFromGitMetadata(
+  currentPath: string,
+): Promise<{ evidence: GitMetadataEvidence; directory?: LinkedDirectorySummary }> {
+  const evidence = await readGitMetadataEvidence(currentPath);
+  if (!evidence.inferredRepositoryPath) {
+    return { evidence };
+  }
+
+  const worktreePath = path.dirname(evidence.dotGitPath!);
+  const repositoryPath = evidence.inferredRepositoryPath;
+  return {
+    evidence,
+    directory: {
+      id: repositoryPath,
+      path: repositoryPath,
+      worktreePath,
+      label: path.basename(repositoryPath) || repositoryPath,
+      kind: "worktree",
+    },
+  };
 }
 
 function parseGitWorktrees(output: string): string[] {
@@ -69,31 +177,75 @@ async function loadThreadDirectoryEnrichment(
   }
 
   try {
-    const [repoRoot, worktreeList, observedGitBranch] = await Promise.all([
+    const [repoRoot, worktreeList, observedGitBranch, gitMetadata] = await Promise.all([
       runGit(currentPath, ["rev-parse", "--show-toplevel"]),
       runGit(currentPath, ["worktree", "list", "--porcelain"]),
       runGit(currentPath, ["rev-parse", "--abbrev-ref", "HEAD"]).catch(() => undefined),
+      readGitMetadataEvidence(currentPath),
     ]);
     const worktreePaths = parseGitWorktrees(worktreeList);
     const primaryPath = path.resolve(worktreePaths[0] || repoRoot);
     const currentWorktreePath =
       findContainingWorktree(currentPath, worktreePaths) ?? path.resolve(repoRoot);
-    const isWorktree = currentWorktreePath !== primaryPath;
+    const gitFileRepositoryPath = gitMetadata.inferredRepositoryPath
+      ? path.resolve(gitMetadata.inferredRepositoryPath)
+      : undefined;
+    const isWorktree =
+      currentWorktreePath !== primaryPath ||
+      Boolean(gitFileRepositoryPath && gitFileRepositoryPath !== currentWorktreePath);
+    const repositoryPath = isWorktree && gitFileRepositoryPath
+      ? gitFileRepositoryPath
+      : primaryPath;
+
+    if (isToolManagedWorktreePath(currentPath) && !isWorktree) {
+      threadDirectoryLog.warn("managed worktree path classified as local by git", {
+        projectKey,
+        currentPath,
+        repoRoot,
+        primaryPath,
+        currentWorktreePath,
+        worktreePaths,
+        gitMetadata,
+      });
+    }
 
     return {
       linkedDirectories: [
         {
-          id: primaryPath,
-          path: primaryPath,
+          id: repositoryPath,
+          path: repositoryPath,
           worktreePath: isWorktree ? currentWorktreePath : undefined,
-          label: path.basename(primaryPath) || primaryPath,
+          label: path.basename(repositoryPath) || repositoryPath,
           kind: isWorktree ? "worktree" : "local",
         },
       ],
       observedGitBranch: observedGitBranch?.trim() || undefined,
     };
-  } catch {
+  } catch (error) {
+    const gitMetadataFallback = await buildLinkedDirectoryFromGitMetadata(currentPath);
+    if (gitMetadataFallback.directory) {
+      threadDirectoryLog.warn("recovered worktree directory relationship from .git metadata", {
+        projectKey,
+        currentPath,
+        error: error instanceof Error ? error.message : String(error),
+        gitMetadata: gitMetadataFallback.evidence,
+        linkedDirectory: gitMetadataFallback.directory,
+      });
+      return {
+        linkedDirectories: [gitMetadataFallback.directory],
+      };
+    }
+
     const fallbackPath = path.resolve(currentPath);
+    if (isToolManagedWorktreePath(fallbackPath)) {
+      threadDirectoryLog.warn("managed worktree path fell back to local directory", {
+        projectKey,
+        fallbackPath,
+        error: error instanceof Error ? error.message : String(error),
+        gitMetadata: gitMetadataFallback.evidence,
+      });
+    }
+
     return {
       linkedDirectories: [
         {

--- a/packages/agent-core/src/__tests__/directory-navigation.test.ts
+++ b/packages/agent-core/src/__tests__/directory-navigation.test.ts
@@ -749,4 +749,34 @@ describe("materializeNavigationThreads", () => {
       },
     ]);
   });
+
+  it("normalizes profile-scoped Codex worktree paths even when no repository path is known", () => {
+    const [thread] = materializeNavigationThreads({
+      firstSnapshot: false,
+      overlayByThreadKey: {},
+      previousKnownThreadKeys: ["codex:thread-1"],
+      threads: [
+        buildThread({
+          linkedDirectories: [
+            {
+              id: "/Users/huntharo/.codex/profiles/sstk/worktrees/mp75j7bn/GifGrabber",
+              label: "GifGrabber",
+              path: "/Users/huntharo/.codex/profiles/sstk/worktrees/mp75j7bn/GifGrabber",
+              kind: "local",
+            },
+          ],
+        }),
+      ],
+    });
+
+    expect(thread?.linkedDirectories).toEqual([
+      {
+        id: "/Users/huntharo/.codex/profiles/sstk/worktrees/mp75j7bn/GifGrabber",
+        label: "GifGrabber",
+        path: "/Users/huntharo/.codex/profiles/sstk/worktrees/mp75j7bn/GifGrabber",
+        worktreePath: "/Users/huntharo/.codex/profiles/sstk/worktrees/mp75j7bn/GifGrabber",
+        kind: "worktree",
+      },
+    ]);
+  });
 });

--- a/packages/agent-core/src/domain/directory-navigation.ts
+++ b/packages/agent-core/src/domain/directory-navigation.ts
@@ -97,7 +97,7 @@ function classifyDirectory(directory: LinkedDirectorySummary): DirectoryDescript
   }
 
   const codexWorktreeMatch = directory.path.match(
-    /^[\\/].*[\\/]\.codex[\\/]worktrees[\\/][^\\/]+[\\/]([^\\/]+)(?:[\\/].*)?$/,
+    /^[\\/].*[\\/]\.codex(?:[\\/]profiles[\\/][^\\/]+)?[\\/]worktrees[\\/][^\\/]+[\\/]([^\\/]+)(?:[\\/].*)?$/,
   );
   if (codexWorktreeMatch) {
     const canonicalPath = directory.path.replace(/[\\/]+$/, "");

--- a/packages/shared/src/worktree-paths.ts
+++ b/packages/shared/src/worktree-paths.ts
@@ -3,7 +3,7 @@ export function isToolManagedWorktreePath(value: string | undefined): boolean {
     return false;
   }
 
-  return /[\\/]\.(?:codex|pwrag(?:ent|nt))[\\/]worktrees[\\/][^\\/]+[\\/][^\\/]+(?:[\\/].*)?$/.test(
+  return /[\\/]\.(?:codex|pwrag(?:ent|nt))(?:[\\/]profiles[\\/][^\\/]+)?[\\/]worktrees[\\/][^\\/]+[\\/][^\\/]+(?:[\\/].*)?$/.test(
     value,
   );
 }


### PR DESCRIPTION
## Summary

- Recover Codex worktree parent-repo relationships from the worktree `.git` file when `git worktree list` fails or loses the parent link.
- Recognize profile-scoped Codex worktree paths like `.codex/profiles/sstk/worktrees/...` during cheap metadata classification and directory backfill.
- Treat fresh Codex local directory metadata as authoritative over stale overlay worktree relationships.
- Keep diagnostics focused on failed/conflicting evidence instead of logging every expected cheap worktree summary.
- Cover the `.git` recovery fallback, profile-scoped worktree detection, and Codex-local-overlays-worktree reconciliation with regression tests.

## Root Cause

The startup performance path can use cheap Codex thread metadata before full directory enrichment has recovered the repository/worktree relationship. When the later Git enrichment fails, the fallback preserved the managed worktree path as a local directory. The first diagnostic run also showed the managed-worktree heuristic only matched `.codex/worktrees/...`, so profile-scoped Codex homes such as `.codex/profiles/sstk/worktrees/...` never entered the warning/backfill path. Since overlay state is durable, stale overlay worktree relationships also needed to be replaced when Codex later reports that the thread is local again.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/main/__tests__/codex-client.test.ts packages/agent-core/src/__tests__/directory-navigation.test.ts apps/desktop/src/main/__tests__/thread-directory-enricher.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`
- `git diff --check`