### PR TITLE
fix(desktop): run env setup in interactive shell

### DIFF
--- a/apps/desktop/e2e/codex-environment-setup.spec.ts
+++ b/apps/desktop/e2e/codex-environment-setup.spec.ts
@@ -6,6 +6,7 @@ import { expect, test } from "@playwright/test";
 import { launchElectronApp } from "./fixtures/electron-app";
 
 async function createCodexEnvironmentSetupFixture(params?: {
+  includeExistingRunningSteps?: boolean;
   includeExistingThread?: boolean;
 }): Promise<{
   cleanup: () => Promise<void>;
@@ -67,6 +68,40 @@ script = "printf setup-output && sleep 2"
             updatedAt: 1_000,
           },
         ];
+  const existingRunningSteps = params?.includeExistingRunningSteps
+    ? [
+        {
+          id: "existing-thread-status-active",
+          kind: "notification" as const,
+          notification: {
+            method: "thread/status/changed" as const,
+            params: {
+              threadId: "thread-existing",
+              status: {
+                type: "active" as const,
+                activeFlags: [],
+              },
+            },
+          },
+        },
+        {
+          id: "existing-thread-turn-started",
+          kind: "notification" as const,
+          notification: {
+            method: "turn/started" as const,
+            params: {
+              threadId: "thread-existing",
+              turnId: "turn-existing-1",
+              turn: {
+                id: "turn-existing-1",
+                status: "in_progress" as const,
+                startedAt: 1_500,
+              },
+            },
+          },
+        },
+      ]
+    : [];
   await writeFile(
     fixturePath,
     JSON.stringify(
@@ -108,6 +143,7 @@ script = "printf setup-output && sleep 2"
               },
             },
           },
+          ...existingRunningSteps,
           {
             id: "thread-start-1",
             kind: "response",
@@ -130,6 +166,7 @@ script = "printf setup-output && sleep 2"
             kind: "response",
             method: "thread/list",
             result: [
+              ...initialThreads,
               {
                 id: "thread-env",
                 title: "hello env",
@@ -345,6 +382,40 @@ test("selected Codex environments run setup and show transcript output", async (
         .getByRole("region", { name: "Transcript" })
         .getByText("setup-output", { exact: true }),
     ).toBeVisible();
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
+test("existing running thread keeps selected Codex environment after pending state clears", async () => {
+  const fixture = await createCodexEnvironmentSetupFixture({
+    includeExistingRunningSteps: true,
+  });
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    await app.window
+      .getByRole("button", { name: /Existing directory thread/ })
+      .click();
+    await expect(
+      app.window.getByRole("heading", { level: 2, name: "Existing directory thread" }),
+    ).toBeVisible();
+
+    await app.advance({ stepId: "existing-thread-status-active" });
+    await app.advance({ stepId: "existing-thread-turn-started" });
+    await expect(app.window.getByRole("button", { name: "Stop" })).toBeVisible();
+
+    const environmentDropdown = app.window.getByLabel("Codex environment");
+    await expect(environmentDropdown).toHaveAttribute("data-value", "");
+    await environmentDropdown.click();
+    await app.window.getByRole("option", { name: "Fixture Env" }).click();
+
+    await expect(app.window.getByRole("status")).toContainText("Thinking");
+    await expect(environmentDropdown).toHaveAttribute("data-value", "environment");
+    await expect(environmentDropdown).toContainText("Fixture Env");
   } finally {
     await app.close();
     await fixture.cleanup();

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2520,6 +2520,10 @@ command = "pnpm dev:messaging"
       }),
       overlayStore,
     });
+    const events: AgentEvent[] = [];
+    registry.onEvent((event) => {
+      events.push(event);
+    });
 
     try {
       await expect(
@@ -2561,6 +2565,25 @@ command = "pnpm dev:messaging"
               name: "Dev - Messaging",
             }),
           ],
+        },
+      });
+
+      expect(
+        events.find(
+          (event) =>
+            event.notification.method === "thread/codexEnvironment/updated",
+        ),
+      ).toMatchObject({
+        backend: "codex",
+        notification: {
+          method: "thread/codexEnvironment/updated",
+          params: {
+            threadId: "thread-1",
+            codexEnvironmentRuntime: {
+              environmentId: "environment",
+              environmentName: "PwrAgnt",
+            },
+          },
         },
       });
     } finally {

--- a/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
@@ -78,6 +78,7 @@ describe("codex environment runtime", () => {
         shellPath,
         [
           "#!/bin/sh",
+          'if [ "$1" != "-ilc" ]; then exit 64; fi',
           `printf shell-used > ${JSON.stringify(markerPath)}`,
           'exec /bin/sh -c "$2"',
           "",
@@ -111,6 +112,116 @@ describe("codex environment runtime", () => {
 
       await expect(readFile(markerPath, "utf8")).resolves.toBe("shell-used");
       await expect(readFile(outputPath, "utf8")).resolves.toBe("setup");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("runs setup commands in an interactive login shell so startup-defined functions are available", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-env-nvm-"));
+    const shellPath = path.join(root, "test-shell.sh");
+    const outputPath = path.join(root, "setup.txt");
+
+    try {
+      await writeFile(
+        shellPath,
+        [
+          "#!/bin/sh",
+          'if [ "$1" != "-ilc" ]; then exit 64; fi',
+          "nvm() {",
+          `  printf 'nvm:%s\\n' "$*" >> ${JSON.stringify(outputPath)}`,
+          "}",
+          'eval "$2"',
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+      await chmod(shellPath, 0o755);
+
+      await expect(
+        applyLocalCodexEnvironmentSelection({
+          cwd: root,
+          env: {
+            ...process.env,
+            SHELL: shellPath,
+          },
+          selection: {
+            environment: {
+              id: "env",
+              name: "Env",
+              sourcePath: path.join(root, "environment.toml"),
+              setupScript: [
+                "nvm use --silent",
+                `printf done >> ${JSON.stringify(outputPath)}`,
+              ].join("\n"),
+              actions: [],
+            },
+            executionTarget: "local",
+            setupEnabled: true,
+          },
+        }),
+      ).resolves.toMatchObject({
+        setupStatus: "completed",
+      });
+
+      await expect(readFile(outputPath, "utf8")).resolves.toBe(
+        "nvm:use --silent\ndone",
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("fails setup immediately when an earlier script command exits non-zero", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-env-strict-"));
+    const shellPath = path.join(root, "test-shell.sh");
+    const outputPath = path.join(root, "setup.txt");
+
+    try {
+      await writeFile(
+        shellPath,
+        [
+          "#!/bin/sh",
+          'if [ "$1" != "-ilc" ]; then exit 64; fi',
+          'exec /bin/sh -c "$2"',
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+      await chmod(shellPath, 0o755);
+
+      await expect(
+        applyLocalCodexEnvironmentSelection({
+          cwd: root,
+          env: {
+            ...process.env,
+            SHELL: shellPath,
+          },
+          selection: {
+            environment: {
+              id: "env",
+              name: "Env",
+              sourcePath: path.join(root, "environment.toml"),
+              setupScript: [
+                `printf before > ${JSON.stringify(outputPath)}`,
+                "false",
+                `printf after >> ${JSON.stringify(outputPath)}`,
+              ].join("\n"),
+              actions: [],
+            },
+            executionTarget: "local",
+            setupEnabled: true,
+          },
+        }),
+      ).rejects.toMatchObject({
+        runtime: {
+          setupStatus: "failed",
+          setupExitCode: 1,
+          setupOutput: "",
+        },
+      });
+
+      await expect(readFile(outputPath, "utf8")).resolves.toBe("before");
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
@@ -67,6 +67,72 @@ describe("codex environment runtime", () => {
     }
   });
 
+  it("strips parent Electron runtime variables from detached actions", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-env-electron-"));
+    const shellPath = path.join(root, "test-shell.sh");
+    const outputPath = path.join(root, "env.txt");
+
+    try {
+      await writeFile(
+        shellPath,
+        [
+          "#!/bin/sh",
+          'if [ "$1" != "-lc" ]; then exit 64; fi',
+          'exec /bin/sh -c "$2"',
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+      await chmod(shellPath, 0o755);
+
+      await expect(
+        startLocalCodexEnvironmentAction({
+          actionId: "start-dev",
+          env: {
+            ...process.env,
+            ELECTRON_RENDERER_URL: "http://127.0.0.1:5173",
+            ELECTRON_RUN_AS_NODE: "1",
+            PWRAGENT_TEST_HYDRATED_ENV: "hydrated",
+            SHELL: shellPath,
+            VITE_DEV_SERVER_URL: "http://127.0.0.1:5174",
+          },
+          runtime: {
+            environmentId: "env",
+            environmentName: "Env",
+            executionTarget: "local",
+            cwd: root,
+            actions: [
+              {
+                id: "start-dev",
+                name: "Start dev",
+                command: [
+                  `printf 'renderer=%s\\n' "\${ELECTRON_RENDERER_URL-unset}" > ${JSON.stringify(outputPath)}`,
+                  `printf 'run_as_node=%s\\n' "\${ELECTRON_RUN_AS_NODE-unset}" >> ${JSON.stringify(outputPath)}`,
+                  `printf 'vite=%s\\n' "\${VITE_DEV_SERVER_URL-unset}" >> ${JSON.stringify(outputPath)}`,
+                  `printf 'hydrated=%s\\n' "$PWRAGENT_TEST_HYDRATED_ENV" >> ${JSON.stringify(outputPath)}`,
+                ].join("\n"),
+              },
+            ],
+          },
+        }),
+      ).resolves.toMatchObject({
+        actionStatus: "started",
+      });
+
+      await expect(expectEventually(async () => await readFile(outputPath, "utf8"))).resolves.toBe(
+        [
+          "renderer=unset",
+          "run_as_node=unset",
+          "vite=unset",
+          "hydrated=hydrated",
+          "",
+        ].join("\n"),
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("chooses the command shell from the provided hydrated environment", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-env-shell-"));
     const shellPath = path.join(root, "test-shell.sh");

--- a/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -78,7 +78,7 @@ describe("codex environment runtime", () => {
         shellPath,
         [
           "#!/bin/sh",
-          'if [ "$1" != "-ilc" ]; then exit 64; fi',
+          'if [ "$1" != "-lc" ]; then exit 64; fi',
           `printf shell-used > ${JSON.stringify(markerPath)}`,
           'exec /bin/sh -c "$2"',
           "",
@@ -120,17 +120,26 @@ describe("codex environment runtime", () => {
   it("runs setup commands in an interactive login shell so startup-defined functions are available", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-env-nvm-"));
     const shellPath = path.join(root, "test-shell.sh");
+    const nvmDir = path.join(root, "nvm");
     const outputPath = path.join(root, "setup.txt");
 
     try {
+      await mkdir(nvmDir, { recursive: true });
+      await writeFile(
+        path.join(nvmDir, "nvm.sh"),
+        [
+          "nvm() {",
+          `  printf 'nvm:%s\\n' "$*" >> ${JSON.stringify(outputPath)}`,
+          "}",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
       await writeFile(
         shellPath,
         [
           "#!/bin/sh",
-          'if [ "$1" != "-ilc" ]; then exit 64; fi',
-          "nvm() {",
-          `  printf 'nvm:%s\\n' "$*" >> ${JSON.stringify(outputPath)}`,
-          "}",
+          'if [ "$1" != "-lc" ]; then exit 64; fi',
           'eval "$2"',
           "",
         ].join("\n"),
@@ -143,6 +152,7 @@ describe("codex environment runtime", () => {
           cwd: root,
           env: {
             ...process.env,
+            NVM_DIR: nvmDir,
             SHELL: shellPath,
           },
           selection: {
@@ -182,7 +192,7 @@ describe("codex environment runtime", () => {
         shellPath,
         [
           "#!/bin/sh",
-          'if [ "$1" != "-ilc" ]; then exit 64; fi',
+          'if [ "$1" != "-lc" ]; then exit 64; fi',
           'exec /bin/sh -c "$2"',
           "",
         ].join("\n"),

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -3541,6 +3541,11 @@ export class DesktopBackendRegistry {
           codexEnvironmentRuntime: error.runtime,
         });
         this.invalidateThreadListCache(request.backend);
+        await this.emitCodexEnvironmentRuntimeUpdated({
+          backend: request.backend,
+          threadId: request.threadId,
+          codexEnvironmentRuntime: error.runtime,
+        });
       }
       throw error;
     }
@@ -3550,6 +3555,11 @@ export class DesktopBackendRegistry {
       codexEnvironmentRuntime: nextRuntime,
     });
     this.invalidateThreadListCache(request.backend);
+    await this.emitCodexEnvironmentRuntimeUpdated({
+      backend: request.backend,
+      threadId: request.threadId,
+      codexEnvironmentRuntime: nextRuntime,
+    });
 
     return {
       backend: request.backend,
@@ -3599,6 +3609,11 @@ export class DesktopBackendRegistry {
         codexEnvironmentRuntime: undefined,
       });
       this.invalidateThreadListCache(request.backend);
+      await this.emitCodexEnvironmentRuntimeUpdated({
+        backend: request.backend,
+        threadId: request.threadId,
+        codexEnvironmentRuntime: undefined,
+      });
       return {
         backend: request.backend,
         threadId: request.threadId,
@@ -3634,12 +3649,34 @@ export class DesktopBackendRegistry {
       codexEnvironmentRuntime,
     });
     this.invalidateThreadListCache(request.backend);
+    await this.emitCodexEnvironmentRuntimeUpdated({
+      backend: request.backend,
+      threadId: request.threadId,
+      codexEnvironmentRuntime,
+    });
 
     return {
       backend: request.backend,
       threadId: request.threadId,
       codexEnvironmentRuntime,
     };
+  }
+
+  private async emitCodexEnvironmentRuntimeUpdated(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
+  }): Promise<void> {
+    await this.emit({
+      backend: params.backend,
+      notification: {
+        method: "thread/codexEnvironment/updated",
+        params: {
+          threadId: params.threadId,
+          codexEnvironmentRuntime: params.codexEnvironmentRuntime,
+        },
+      },
+    });
   }
 
   async materializeDirectoryLaunchpad(

--- a/apps/desktop/src/main/app-server/codex-environment-runtime.ts
+++ b/apps/desktop/src/main/app-server/codex-environment-runtime.ts
@@ -254,7 +254,7 @@ function runShellCommand(params: {
   });
 
   return new Promise((resolve, reject) => {
-    const child = spawn(shell, ["-lc", params.command], {
+    const child = spawn(shell, ["-ilc", wrapShellCommand(params.command)], {
       cwd: params.cwd,
       detached: params.mode === "detach",
       env: params.env ?? process.env,
@@ -326,4 +326,8 @@ function runShellCommand(params: {
       );
     });
   });
+}
+
+function wrapShellCommand(command: string): string {
+  return ["set -e", "set -o pipefail 2>/dev/null || true", command].join("\n");
 }

--- a/apps/desktop/src/main/app-server/codex-environment-runtime.ts
+++ b/apps/desktop/src/main/app-server/codex-environment-runtime.ts
@@ -243,7 +243,8 @@ function runShellCommand(params: {
   output?: string;
   pid?: number;
 }> {
-  const shell = params.env?.SHELL?.trim() || process.env.SHELL?.trim() || "/bin/sh";
+  const commandEnv = sanitizeLocalEnvironmentCommandEnv(params.env ?? process.env);
+  const shell = commandEnv.SHELL?.trim() || process.env.SHELL?.trim() || "/bin/sh";
   const processId = `pwragent-env-${randomUUID()}`;
   const startedAt = Date.now();
   environmentRuntimeLog.info("codex-environment-command-start", {
@@ -257,7 +258,7 @@ function runShellCommand(params: {
     const child = spawn(shell, ["-lc", wrapShellCommand(shell, params.command)], {
       cwd: params.cwd,
       detached: params.mode === "detach",
-      env: params.env ?? process.env,
+      env: commandEnv,
       stdio: params.mode === "detach" ? "ignore" : "pipe",
     });
 
@@ -326,6 +327,28 @@ function runShellCommand(params: {
       );
     });
   });
+}
+
+function sanitizeLocalEnvironmentCommandEnv(
+  env: NodeJS.ProcessEnv,
+): NodeJS.ProcessEnv {
+  const sanitized = { ...env };
+  for (const key of Object.keys(sanitized)) {
+    if (isParentElectronRuntimeEnvKey(key)) {
+      delete sanitized[key];
+    }
+  }
+  return sanitized;
+}
+
+function isParentElectronRuntimeEnvKey(key: string): boolean {
+  return (
+    key.startsWith("ELECTRON_") ||
+    key === "VITE_DEV_SERVER_URL" ||
+    key.startsWith("MAIN_VITE_") ||
+    key.startsWith("PRELOAD_VITE_") ||
+    key.startsWith("RENDERER_VITE_")
+  );
 }
 
 function wrapShellCommand(shell: string, command: string): string {

--- a/apps/desktop/src/main/app-server/codex-environment-runtime.ts
+++ b/apps/desktop/src/main/app-server/codex-environment-runtime.ts
@@ -254,7 +254,7 @@ function runShellCommand(params: {
   });
 
   return new Promise((resolve, reject) => {
-    const child = spawn(shell, ["-ilc", wrapShellCommand(params.command)], {
+    const child = spawn(shell, ["-lc", wrapShellCommand(shell, params.command)], {
       cwd: params.cwd,
       detached: params.mode === "detach",
       env: params.env ?? process.env,
@@ -328,6 +328,23 @@ function runShellCommand(params: {
   });
 }
 
-function wrapShellCommand(command: string): string {
-  return ["set -e", "set -o pipefail 2>/dev/null || true", command].join("\n");
+function wrapShellCommand(shell: string, command: string): string {
+  return [
+    ...shellStartupCommands(shell),
+    '[ -n "${NVM_DIR:-}" ] && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"',
+    '[ -z "${NVM_DIR:-}" ] && [ -s "$HOME/.nvm/nvm.sh" ] && . "$HOME/.nvm/nvm.sh"',
+    "set -e",
+    command,
+  ].join("\n");
+}
+
+function shellStartupCommands(shell: string): string[] {
+  const shellName = shell.split(/[\\/]/).at(-1) ?? "";
+  if (shellName.includes("zsh")) {
+    return ['[ -s "$HOME/.zshrc" ] && . "$HOME/.zshrc"'];
+  }
+  if (shellName.includes("bash")) {
+    return ['[ -s "$HOME/.bashrc" ] && . "$HOME/.bashrc"'];
+  }
+  return [];
 }

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -618,7 +618,8 @@ export class MessagingController {
     }
     if (
       event.notification.method === "thread/executionMode/updated" ||
-      event.notification.method === "thread/modelSettings/updated"
+      event.notification.method === "thread/modelSettings/updated" ||
+      event.notification.method === "thread/codexEnvironment/updated"
     ) {
       await this.refreshStatusSurfacesForThread(
         event.backend,

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -2563,7 +2563,6 @@ export function Composer(props: ComposerProps) {
         threadId: props.thread.id,
         environmentId,
       });
-      await props.onRefreshNavigation?.();
     } catch (error) {
       setSendError(error instanceof Error ? error.message : String(error));
     } finally {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -2708,6 +2708,90 @@ describe("useThreadNavigation", () => {
     expect(getNavigationSnapshot).toHaveBeenCalledTimes(1);
   });
 
+  it("patches the snapshot for thread/codexEnvironment/updated without refetching", async () => {
+    const listeners = new Set<(event: any) => void>();
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: ["codex:thread-1"],
+      threads: [
+        {
+          id: "thread-1",
+          title: "First thread",
+          titleSource: "explicit" as const,
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: { inInbox: true, reason: "new-thread" as const },
+          updatedAt: 1_000,
+        },
+      ],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: (callback) => {
+        listeners.add(callback);
+        return () => {
+          listeners.delete(callback);
+        };
+      },
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.id).toBe("thread-1");
+    });
+    expect(result.current.selectedThread?.codexEnvironmentRuntime).toBeUndefined();
+    expect(getNavigationSnapshot).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "thread/codexEnvironment/updated",
+            params: {
+              threadId: "thread-1",
+              codexEnvironmentRuntime: {
+                environmentId: "environment",
+                environmentName: "Fixture Env",
+                executionTarget: "local",
+                cwd: "/repo/app",
+                setupEnabled: false,
+                setupCommand: "pnpm install",
+                actions: [
+                  {
+                    id: "dev",
+                    name: "Dev",
+                    command: "pnpm dev",
+                  },
+                ],
+              },
+            },
+          },
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(
+        result.current.selectedThread?.codexEnvironmentRuntime?.environmentId,
+      ).toBe("environment");
+      expect(
+        result.current.selectedThread?.codexEnvironmentRuntime?.environmentName,
+      ).toBe("Fixture Env");
+    });
+    // Push-driven patch — no full snapshot re-fetch.
+    expect(getNavigationSnapshot).toHaveBeenCalledTimes(1);
+  });
+
   it("refreshes the snapshot when thread directory metadata is repaired", async () => {
     const listeners = new Set<(event: any) => void>();
     let navigationSnapshot: NavigationSnapshot = {

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -754,6 +754,39 @@ function applyThreadModelSettingsUpdate(
     : snapshot;
 }
 
+function applyThreadCodexEnvironmentUpdate(
+  snapshot: NavigationSnapshot | undefined,
+  params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    codexEnvironmentRuntime?: NavigationThreadSummary["codexEnvironmentRuntime"];
+  }
+): NavigationSnapshot | undefined {
+  if (!snapshot) {
+    return snapshot;
+  }
+
+  let changed = false;
+  const threads = snapshot.threads.map((thread) => {
+    if (thread.source !== params.backend || thread.id !== params.threadId) {
+      return thread;
+    }
+
+    changed = true;
+    return {
+      ...thread,
+      codexEnvironmentRuntime: params.codexEnvironmentRuntime,
+    };
+  });
+
+  return changed
+    ? {
+        ...snapshot,
+        threads,
+      }
+    : snapshot;
+}
+
 function applyThreadExecutionModeUpdate(
   snapshot: NavigationSnapshot | undefined,
   params: {
@@ -1822,6 +1855,28 @@ export function useThreadNavigation(
         // Pull the snapshot so the matching `applied` / `cancelled`
         // transition entry shows up in the transcript.
         scheduleRefresh();
+        return;
+      }
+
+      if (method === "thread/codexEnvironment/updated") {
+        const { threadId, codexEnvironmentRuntime } = event.notification
+          .params as {
+          threadId: string;
+          codexEnvironmentRuntime?: NavigationThreadSummary["codexEnvironmentRuntime"];
+        };
+        setState((current) => ({
+          ...current,
+          response: applyThreadCodexEnvironmentUpdate(current.response, {
+            backend: event.backend,
+            threadId,
+            codexEnvironmentRuntime,
+          }),
+        }));
+        setOptimisticThread((current) =>
+          current?.source === event.backend && current.id === threadId
+            ? { ...current, codexEnvironmentRuntime }
+            : current
+        );
         return;
       }
 

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -854,6 +854,13 @@ export type AppServerNotification =
       };
     }
   | {
+      method: "thread/codexEnvironment/updated";
+      params: {
+        threadId: string;
+        codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
+      };
+    }
+  | {
       method: "navigation/threadDirectories/updated";
       params: {
         reason: "selected-thread" | "full-reconcile";


### PR DESCRIPTION
## Summary

- I changed Codex environment setup/action commands to run through the user shell while explicitly loading shell startup files and nvm when available, so shell-managed commands like `nvm use --silent` work from environment setup.
- I wrapped setup/action scripts with strict shell error handling so an earlier failed command stops the script instead of being hidden by a later successful command.
- I fixed existing running Codex threads so selecting a Codex environment persists through the typed backend event stream instead of flashing pending UI and snapping back to No Environment.
- I stripped inherited parent Electron/Vite runtime variables from local Codex environment commands so a child Electron app launched by Run command does not inherit PwrAgent's renderer URL or Electron control env.
- I added regression coverage for hydrated shell selection, nvm-style shell functions, fail-fast setup behavior, Electron env sanitization, and running-thread environment selection.

## Verification

- I ran `pnpm test apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts`.
- I ran `pnpm test apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts`.
- I ran `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`.
- I ran `pnpm --filter @pwragent/desktop test:e2e e2e/codex-environment-setup.spec.ts`.
- I ran `pnpm --filter @pwragent/desktop typecheck`.

## Notes

- Root cause for `nvm`: the hydrated environment captured PATH and variables from an interactive login shell, but setup execution did not load shell-managed functions like `nvm` and reported only the final command status.
- Root cause for the running-thread dropdown: environment selection persisted in the overlay store, but no navigation-thread update was pushed to the renderer; the composer then cleared its transient pending status and continued rendering the stale selected thread snapshot.
- Root cause for the PwrSnap Run command: PwrAgent is itself an Electron app, so local environment commands inherited parent Electron/Vite variables such as `ELECTRON_RENDERER_URL`; child Electron apps can interpret those as their own dev-server/runtime configuration.
- I adjusted the implementation after CI showed that using an interactive shell in GitHub Actions emits bash job-control noise; the final version avoids interactive shell execution while still loading the startup/nvm context environment scripts need.
