### PR TITLE
fix(desktop): match thread reaction emoji size

### DIFF
--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -250,6 +250,26 @@ describe("Tangerine Terminal theme contract", () => {
     );
   });
 
+  it("keeps thread card reaction emoji the same size as picker emoji", () => {
+    const baseChipIndex = css.indexOf(".thread-row__chip {");
+    const reactionChipIndex = css.indexOf(
+      ".thread-row__chip.thread-row__chip--reaction {"
+    );
+    expect(baseChipIndex).toBeGreaterThanOrEqual(0);
+    expect(reactionChipIndex).toBeGreaterThan(baseChipIndex);
+
+    const threadReactionRule = extractRuleBody(
+      css,
+      ".thread-row__chip.thread-row__chip--reaction"
+    );
+    const pickerReactionRule = extractRuleBody(css, ".reaction-picker__option");
+
+    expect(threadReactionRule).toContain("font-size: 16px;");
+    expect(pickerReactionRule).toContain("font-size: 16px;");
+    expect(threadReactionRule).toContain("font-variant-emoji: emoji;");
+    expect(pickerReactionRule).toContain("font-variant-emoji: emoji;");
+  });
+
   it("keeps focused sticky directory summaries from painting outside the scrollport", () => {
     const headerRule = extractRuleBody(css, ".directory-row__header");
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1594,7 +1594,6 @@ textarea,
      (🅐 🅑 …) take this color, and secondary made them look alpha'd
      down compared to the colored emoji. Picker uses --text-primary too. */
   color: var(--text-primary);
-  font-size: 14px;
   line-height: 1;
   cursor: pointer;
 }
@@ -1901,6 +1900,16 @@ textarea,
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.thread-row__chip.thread-row__chip--reaction {
+  min-width: 24px;
+  justify-content: center;
+  padding: 0 4px;
+  font-size: 16px;
+  /* Match .reaction-picker__option so symbol-block reactions render
+     with the same visual weight in the picker and on the thread card. */
+  font-variant-emoji: emoji;
 }
 
 .thread-row__chip.thread-row__chip--add-reaction {


### PR DESCRIPTION
## Summary

- Make thread card reaction emoji render at the same 16px size as the reaction picker.
- Move the reaction-specific CSS below the base chip rule so the base 12px chip font no longer wins in the cascade.
- Add a theme contract regression test that checks both the sizing and cascade order.

## Root Cause

The reaction chip rule declared the desired size before the shared `.thread-row__chip` rule. The later base chip rule reset reactions back to 12px, so DevTools reported smaller emoji on thread cards than in the picker.

## Validation

- `pnpm test apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx`
- `pnpm test apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx`