### PR TITLE
fix(desktop): keep directory header controls visible

### DIFF
--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -281,6 +281,16 @@ describe("Tangerine Terminal theme contract", () => {
     );
   });
 
+  it("keeps long directory names from crowding the count and expand control", () => {
+    const summaryRule = extractRuleBody(css, ".directory-row__summary");
+    const summaryMetaRule = extractRuleBody(css, ".directory-row__summary-meta");
+
+    expect(summaryRule).toContain("display: grid;");
+    expect(summaryRule).toContain("grid-template-columns: minmax(0, 1fr) auto;");
+    expect(summaryRule).toContain("align-items: center;");
+    expect(summaryMetaRule).toContain("flex: 0 0 auto;");
+  });
+
   it("keeps thread context menu hover states visible", () => {
     expect(css).toMatch(
       /\.thread-context-menu button:hover,\s*\.thread-context-menu button:focus-visible\s*\{[\s\S]*?background:\s*var\(--accent-soft\);[\s\S]*?color:\s*var\(--accent-bright\);[\s\S]*?\}/

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2147,6 +2147,10 @@ textarea,
 }
 
 .directory-row__summary {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
   min-height: 44px;
   padding: 10px 12px;
 }
@@ -2169,7 +2173,9 @@ textarea,
 }
 
 .directory-row__summary-meta {
+  flex: 0 0 auto;
   gap: 10px;
+  justify-content: flex-end;
 }
 
 .directory-row__icon {
@@ -2180,6 +2186,7 @@ textarea,
 }
 
 .directory-row__title-wrap {
+  flex: 1 1 auto;
   min-width: 0;
 }
 
@@ -2192,6 +2199,7 @@ textarea,
 
 .directory-row__chevron {
   display: inline-flex;
+  flex: 0 0 auto;
   width: 9px;
   height: 9px;
   border-right: 1.75px solid var(--text-muted);


### PR DESCRIPTION
## Summary

- Keep the directory header label in a shrinkable grid column so long names truncate without moving the controls.
- Reserve the count chip and expand/collapse chevron in a fixed trailing lane.
- Add a CSS contract regression test for long directory names crowding the count and expand control.

## Root Cause

Directory headers used the compact thread-row flex layout, which let a long truncated directory name crowd the trailing metadata lane. That could visually push the chevron into the count chip area.

## Validation

- `pnpm test apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx`
- `pnpm test apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx`