### PR TITLE
ci(agent-core): skip live smoke on main pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,7 @@ jobs:
 
   live-agent-core:
     name: Live Agent Core
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     needs: install-deps
     timeout-minutes: 10
@@ -200,7 +201,7 @@ jobs:
 
             while IFS= read -r path; do
               case "$path" in
-                packages/agent-core/src/app-server/*|packages/agent-core/src/config/*|packages/agent-core/src/persistence/*|packages/agent-core/src/providers/*|packages/agent-core/src/testing/*|packages/agent-core/src/tools/*|packages/agent-core/src/__tests__/grok-live.test.ts|packages/agent-core/package.json|packages/shared/src/contracts/normalized-app-server.ts|packages/shared/src/contracts/navigation.ts|packages/shared/src/thread-titles.ts|packages/shared/src/index.ts|package.json|pnpm-lock.yaml|pnpm-workspace.yaml|tsconfig.base.json|vitest.workspace.ts|.nvmrc)
+                packages/agent-core/src/app-server/*|packages/agent-core/src/config/*|packages/agent-core/src/persistence/*|packages/agent-core/src/providers/*|packages/agent-core/src/testing/*|packages/agent-core/src/tools/*|packages/agent-core/src/__tests__/grok-live.test.ts|packages/agent-core/package.json|package.json|pnpm-lock.yaml|pnpm-workspace.yaml|tsconfig.base.json|vitest.workspace.ts|.nvmrc)
                   relevant=true
                   matched_path="$path"
                   break
@@ -220,7 +221,7 @@ jobs:
               echo
               echo "Skipped live agent-core smoke test because no agent-core inputs changed."
               echo
-              echo "Relevant inputs: live app-server/provider/config/tool paths, the live test itself, shared files imported by the live path, root dependency/test config, or the \`ci:live-agent-core\` PR label."
+              echo "Relevant inputs: live app-server/provider/config/tool paths, the live test itself, agent-core package metadata, root dependency/test config, or the \`ci:live-agent-core\` PR label."
             } >> "$GITHUB_STEP_SUMMARY"
           fi
 


### PR DESCRIPTION
## Summary
- Stop the Live Agent Core job from running on `push` events to `main`.
- Remove shared contract files from the automatic live-smoke path allowlist.
- Keep automatic PR live smoke for agent-core runtime/provider/tool inputs and keep the `ci:live-agent-core` PR label override.

## Root Cause
The previous gate still evaluated the Live Agent Core job on `main` push events, so merge commits could pay for live Grok again after PR CI. Run `25942083422` for `fix(desktop): run env setup in interactive shell (#424)` reached `pnpm --filter @pwragent/agent-core test:live` because `packages/shared/src/contracts/normalized-app-server.ts` was still in the allowlist.

## Validation
- `git diff --check`
- Parsed `.github/workflows/ci.yml` with Ruby Psych.
- Simulated detector behavior for the `#424` merge file list, PR #424 file list, PR #422 file list, the manual `ci:live-agent-core` label, `ci.yml` only, shared-contract-only, provider-only, and unit-test-only changes.