### PR TITLE
fix(desktop): keep pasted text inside active blocks

### DIFF
--- a/apps/desktop/e2e/composer-draft-persistence-regression.spec.ts
+++ b/apps/desktop/e2e/composer-draft-persistence-regression.spec.ts
@@ -245,6 +245,34 @@ async function pasteDelayedImage(page: Page, params: {
   }, params);
 }
 
+async function pastePlainText(page: Page, params: {
+  accessibleName: "New thread" | "Reply";
+  html?: string;
+  text: string;
+}): Promise<void> {
+  await page.evaluate(({ accessibleName, html, text }) => {
+    const textbox = Array.from(
+      document.querySelectorAll<HTMLElement>('[role="textbox"]'),
+    ).find((element) => element.getAttribute("aria-label") === accessibleName);
+    if (!textbox) {
+      throw new Error(`${accessibleName} Tiptap textbox not found`);
+    }
+
+    const dataTransfer = new DataTransfer();
+    dataTransfer.setData("text/plain", text);
+    if (html) {
+      dataTransfer.setData("text/html", html);
+    }
+    textbox.dispatchEvent(
+      new ClipboardEvent("paste", {
+        bubbles: true,
+        cancelable: true,
+        clipboardData: dataTransfer,
+      }),
+    );
+  }, params);
+}
+
 test("keeps Tiptap launchpad and reply drafts with pasted images across switching and refresh", async () => {
   const fixture = await createComposerDraftPersistenceFixture();
   const app = await launchElectronApp({
@@ -289,6 +317,110 @@ test("keeps Tiptap launchpad and reply drafts with pasted images across switchin
     await expect(tiptapInput).toHaveAttribute("data-value", replyDraft);
     await expect(app.window.getByLabel("Pasted images")).toHaveCount(1);
     await expect(app.window.getByAltText("reply-draft.png")).toBeVisible();
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
+test("keeps every pasted line inside the active Tiptap code block", async () => {
+  const fixture = await createComposerDraftPersistenceFixture();
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    await openExistingThread(app);
+
+    const tiptapInput = app.window.getByTestId("composer-tiptap-input");
+    const textbox = app.window.getByRole("textbox", { name: "Reply" });
+    await textbox.focus();
+    await app.window.keyboard.type("```");
+    await app.window.keyboard.press("Space");
+
+    const pastedText = [
+      " 1) e2e/library-source-filter.spec.ts:74:1 › source-app filters load captures outside the initial virtualized page ",
+      "",
+      "",
+      "Test timeout of 180000ms exceeded.",
+      "",
+      "",
+      "    Error Context: test-results/library-source-filter-sour-7c26e-he-initial-virtualized-page/error-context.md",
+    ].join("\n");
+
+    await pastePlainText(app.window, {
+      accessibleName: "Reply",
+      html: [
+        "<div> 1) e2e/library-source-filter.spec.ts:74:1 › source-app filters load captures outside the initial virtualized page </div>",
+        "<div><br></div>",
+        "<div><br></div>",
+        "<div>Test timeout of 180000ms exceeded.</div>",
+        "<div><br></div>",
+        "<div><br></div>",
+        "<div>&nbsp;&nbsp;&nbsp;&nbsp;Error Context: test-results/library-source-filter-sour-7c26e-he-initial-virtualized-page/error-context.md</div>",
+      ].join(""),
+      text: pastedText,
+    });
+
+    await expect(tiptapInput.locator("pre")).toHaveCount(1);
+    await expect(tiptapInput.locator("pre")).toContainText(
+      "Test timeout of 180000ms exceeded.",
+    );
+    await expect(
+      tiptapInput.locator("p", {
+        hasText: /Test timeout|Error Context|source-app/,
+      }),
+    ).toHaveCount(0);
+    await expect(tiptapInput).toHaveAttribute(
+      "data-value",
+      `\`\`\`\n${pastedText}\n\`\`\``,
+    );
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
+test("keeps every pasted line inside the active Tiptap block quote", async () => {
+  const fixture = await createComposerDraftPersistenceFixture();
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+  });
+
+  try {
+    await openExistingThread(app);
+
+    const tiptapInput = app.window.getByTestId("composer-tiptap-input");
+    const textbox = app.window.getByRole("textbox", { name: "Reply" });
+    await textbox.focus();
+    await app.window.keyboard.type("> ");
+
+    const pastedText = [
+      "first quoted line",
+      "",
+      "second quoted line after a blank",
+      "third quoted line",
+    ].join("\n");
+
+    await pastePlainText(app.window, {
+      accessibleName: "Reply",
+      text: pastedText,
+    });
+
+    await expect(tiptapInput.locator("blockquote")).toHaveCount(1);
+    await expect(tiptapInput.locator("blockquote")).toContainText(
+      "second quoted line after a blank",
+    );
+    await expect(tiptapInput.locator("> p")).toHaveCount(0);
+    await expect(tiptapInput).toHaveAttribute(
+      "data-value",
+      [
+        "> first quoted line",
+        "> ",
+        "> second quoted line after a blank",
+        "> third quoted line",
+      ].join("\n"),
+    );
   } finally {
     await app.close();
     await fixture.cleanup();

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -628,6 +628,53 @@ function insertWysiwygSoftBreak(editor: TiptapEditor): boolean {
   return editor.commands.setHardBreak();
 }
 
+function getPlainTextFromPaste(event: ClipboardEvent<HTMLDivElement>): string {
+  return event.clipboardData?.getData("text/plain").replace(/\r\n?/g, "\n") ?? "";
+}
+
+function selectionIsInsideNode(editor: TiptapEditor, nodeTypeName: string): boolean {
+  const { $from, $to } = editor.state.selection;
+  const isInside = ($pos: typeof $from): boolean => {
+    for (let depth = $pos.depth; depth >= 0; depth -= 1) {
+      if ($pos.node(depth).type.name === nodeTypeName) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  return isInside($from) && isInside($to);
+}
+
+function pastePlainTextIntoActiveBlock(
+  editor: TiptapEditor,
+  event: ClipboardEvent<HTMLDivElement>,
+): boolean {
+  const text = getPlainTextFromPaste(event);
+  if (!text) {
+    return false;
+  }
+
+  if (
+    editor.state.selection.$from.parent.type.name === "codeBlock" &&
+    editor.state.selection.$to.parent.type.name === "codeBlock"
+  ) {
+    event.preventDefault();
+    const { from, to } = editor.state.selection;
+    editor.view.dispatch(editor.state.tr.insertText(text, from, to).scrollIntoView());
+    return true;
+  }
+
+  if (selectionIsInsideNode(editor, "blockquote")) {
+    event.preventDefault();
+    return editor.commands.insertContent(splitTextContent(text), {
+      updateSelection: true,
+    });
+  }
+
+  return false;
+}
+
 function getCodeBlockMarkdownParts(node: ProseMirrorNode): {
   contentLength: number;
   prefixLength: number;
@@ -1114,7 +1161,17 @@ export const ComposerTiptapInput = forwardRef<
         },
         paste: (_view, event) => {
           propsRef.current.onPaste?.(event as unknown as ClipboardEvent<HTMLDivElement>);
-          return event.defaultPrevented;
+          if (event.defaultPrevented) {
+            return true;
+          }
+          const currentEditor = editorRef.current;
+          if (!currentEditor || !propsRef.current.markdownConversion) {
+            return false;
+          }
+          return pastePlainTextIntoActiveBlock(
+            currentEditor,
+            event as unknown as ClipboardEvent<HTMLDivElement>,
+          );
         },
       },
     },


### PR DESCRIPTION
## Summary
Pasting multi-line plain text while the Tiptap cursor is inside a code block or block quote now keeps the entire paste inside that active block. The composer gives pasted images first chance to consume paste events, then handles plain text in active block contexts directly instead of letting Tiptap's default paste parser reshape it.

This fixes the regression where pasted error logs could leave only the first line in a code block and spill the rest into plain text.

## Test Plan
- `pnpm --filter @pwragent/desktop test:e2e e2e/composer-draft-persistence-regression.spec.ts`
- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
