### PR TITLE
fix(desktop): open source links at target lines

### DIFF
--- a/apps/desktop/e2e/fixtures/source-link-editor-open/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/source-link-editor-open/replay.fixture.json
@@ -1,0 +1,93 @@
+{
+  "metadata": {
+    "backend": "codex",
+    "scenario": "source-link-editor-open",
+    "threadId": "thread-source-link-editor-open"
+  },
+  "steps": [
+    {
+      "id": "initialize-1",
+      "kind": "response",
+      "method": "initialize",
+      "result": {
+        "serverInfo": {
+          "name": "Replay Codex",
+          "version": "1.0.0"
+        },
+        "methods": [
+          "thread/list",
+          "thread/read",
+          "skills/list"
+        ]
+      }
+    },
+    {
+      "id": "thread-list-1",
+      "kind": "response",
+      "method": "thread/list",
+      "result": [
+        {
+          "id": "thread-source-link-editor-open",
+          "title": "Source link editor open",
+          "titleSource": "explicit",
+          "summary": "Verify transcript source links open editor line targets.",
+          "source": "codex",
+          "executionMode": "default",
+          "linkedDirectories": [],
+          "inbox": {
+            "inInbox": true,
+            "reason": "new-thread"
+          },
+          "updatedAt": 1760000000000
+        }
+      ]
+    },
+    {
+      "id": "thread-read-1",
+      "kind": "response",
+      "method": "thread/read",
+      "result": {
+        "entries": [
+          {
+            "type": "review",
+            "id": "review-1",
+            "displayText": "Code review",
+            "review": "Source link line target regression.",
+            "output": {
+              "findings": [
+                {
+                  "title": "Open this source link",
+                  "body": "Clicking the source link should preserve the target line.",
+                  "confidence_score": 0.95,
+                  "priority": 2,
+                  "code_location": {
+                    "absolute_file_path": "/tmp/pwragent-source-link-e2e/source.ts",
+                    "line_range": {
+                      "start": 12,
+                      "end": 12
+                    }
+                  }
+                }
+              ],
+              "overall_correctness": "patch is incorrect",
+              "overall_explanation": "Source link line target regression.",
+              "overall_confidence_score": 0.95
+            }
+          }
+        ],
+        "messages": [
+          {
+            "id": "message-1",
+            "role": "assistant",
+            "text": "Source link line target regression."
+          }
+        ],
+        "lastAssistantMessage": "Source link line target regression.",
+        "pagination": {
+          "supportsPagination": false,
+          "hasPreviousPage": false
+        }
+      }
+    }
+  ]
+}

--- a/apps/desktop/e2e/source-link-editor-open.spec.ts
+++ b/apps/desktop/e2e/source-link-editor-open.spec.ts
@@ -1,0 +1,80 @@
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "@playwright/test";
+import { launchElectronApp } from "./fixtures/electron-app";
+
+const specDir = path.dirname(fileURLToPath(import.meta.url));
+const sourceRoot = "/tmp/pwragent-source-link-e2e";
+const sourcePath = path.join(sourceRoot, "source.ts");
+
+test("opens transcript source links with VS Code line metadata", async () => {
+  const capturePath = path.join(sourceRoot, "application-open.json");
+  const fakeBinDir = path.join(sourceRoot, "bin");
+
+  await rm(sourceRoot, { recursive: true, force: true });
+  await mkdir(fakeBinDir, { recursive: true });
+  await writeFile(
+    sourcePath,
+    Array.from({ length: 20 }, (_, index) => `line ${index + 1}`).join("\n"),
+    "utf8"
+  );
+  await writeFile(path.join(fakeBinDir, "code"), "#!/bin/sh\nexit 0\n", {
+    encoding: "utf8",
+    mode: 0o755,
+  });
+
+  const app = await launchElectronApp({
+    fixturePath: path.resolve(
+      specDir,
+      "fixtures/source-link-editor-open/replay.fixture.json"
+    ),
+    env: {
+      PATH: `${fakeBinDir}:${process.env.PATH ?? ""}`,
+      PWRAGENT_E2E_APPLICATION_OPEN_CAPTURE_PATH: capturePath,
+    },
+  });
+
+  try {
+    await app.window
+      .getByRole("button", { name: /Source link editor open/i })
+      .first()
+      .click();
+
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "Source link editor open",
+      })
+    ).toBeVisible();
+
+    const reviewCard = app.window.getByRole("group", { name: "Code review" }).last();
+    await expect(reviewCard).toContainText("Open this source link");
+    await expect(reviewCard).toContainText("Line 12");
+
+    await reviewCard.locator("a.transcript-review__location-path").click();
+
+    await expect
+      .poll(async () => {
+        try {
+          return JSON.parse(await readFile(capturePath, "utf8"));
+        } catch {
+          return null;
+        }
+      })
+      .toMatchObject({
+        request: {
+          applicationId: "vscode",
+          kind: "editor",
+          targetPath: sourcePath,
+          targetLine: 12,
+        },
+        invocation: {
+          args: ["--goto", `${sourcePath}:12`],
+        },
+      });
+  } finally {
+    await app.close();
+    await rm(sourceRoot, { recursive: true, force: true });
+  }
+});

--- a/apps/desktop/e2e/source-link-editor-open.spec.ts
+++ b/apps/desktop/e2e/source-link-editor-open.spec.ts
@@ -47,6 +47,25 @@ test("opens transcript source links with VS Code line metadata", async () => {
         name: "Source link editor open",
       })
     ).toBeVisible();
+    await expect
+      .poll(async () =>
+        await app.window.evaluate(async () => {
+          const api = (
+            window as Window & {
+              pwragent?: {
+                readSettings?: (
+                  request: Record<string, never>
+                ) => Promise<{
+                  snapshot: { applications: { editors: Array<{ id: string }> } };
+                }>;
+              };
+            }
+          ).pwragent;
+          const settings = await api?.readSettings?.({});
+          return settings?.snapshot.applications.editors.map((editor) => editor.id) ?? [];
+        })
+      )
+      .toContain("vscode");
 
     const reviewCard = app.window.getByRole("group", { name: "Code review" }).last();
     await expect(reviewCard).toContainText("Open this source link");

--- a/apps/desktop/src/main/__tests__/application-discovery.test.ts
+++ b/apps/desktop/src/main/__tests__/application-discovery.test.ts
@@ -1,11 +1,12 @@
 import { EventEmitter } from "node:events";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildGhosttyAppleScriptArgs,
   openDesktopApplication,
+  resolveBundledApplicationCliPath,
 } from "../settings/application-discovery";
 
 const { spawnMock } = vi.hoisted(() => ({
@@ -64,7 +65,12 @@ describe("application discovery", () => {
   it("opens VS Code source links with --goto line metadata", async () => {
     const targetPath = path.join(tempDir, "source.ts");
     const capturePath = path.join(tempDir, "application-open.json");
+    const fakeBinDir = path.join(tempDir, "bin");
+    const fakeCodePath = path.join(fakeBinDir, "code");
+    mkdirSync(fakeBinDir, { recursive: true });
     writeFileSync(targetPath, "line 1\nline 2\n", "utf8");
+    writeFileSync(fakeCodePath, "#!/bin/sh\nexit 0\n", "utf8");
+    chmodSync(fakeCodePath, 0o755);
 
     await openDesktopApplication(
       {
@@ -75,7 +81,7 @@ describe("application discovery", () => {
       },
       {
         env: {
-          PATH: process.env.PATH,
+          PATH: fakeBinDir,
           PWRAGENT_E2E_APPLICATION_OPEN_CAPTURE_PATH: capturePath,
         },
       }
@@ -89,5 +95,24 @@ describe("application discovery", () => {
     expect(capture.invocation.command).toMatch(/code$/);
     expect(capture.invocation.args).toEqual(["--goto", `${targetPath}:12`]);
     expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("resolves the bundled VS Code CLI from an app-only install", async () => {
+    const appPath = path.join(tempDir, "Visual Studio Code.app");
+    const bundledCodePath = path.join(
+      appPath,
+      "Contents",
+      "Resources",
+      "app",
+      "bin",
+      "code"
+    );
+    mkdirSync(path.dirname(bundledCodePath), { recursive: true });
+    writeFileSync(bundledCodePath, "#!/bin/sh\nexit 0\n", "utf8");
+    chmodSync(bundledCodePath, 0o755);
+
+    await expect(resolveBundledApplicationCliPath(appPath, ["code"])).resolves.toBe(
+      bundledCodePath
+    );
   });
 });

--- a/apps/desktop/src/main/__tests__/application-discovery.test.ts
+++ b/apps/desktop/src/main/__tests__/application-discovery.test.ts
@@ -1,7 +1,47 @@
-import { describe, expect, it } from "vitest";
-import { buildGhosttyAppleScriptArgs } from "../settings/application-discovery";
+import { EventEmitter } from "node:events";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildGhosttyAppleScriptArgs,
+  openDesktopApplication,
+} from "../settings/application-discovery";
+
+const { spawnMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn(),
+}));
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>(
+    "node:child_process"
+  );
+  return {
+    ...actual,
+    spawn: spawnMock,
+  };
+});
 
 describe("application discovery", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-application-test-"));
+    spawnMock.mockImplementation(() => {
+      const child = new EventEmitter() as EventEmitter & { unref: () => void };
+      child.unref = vi.fn();
+      queueMicrotask(() => {
+        child.emit("spawn");
+      });
+      return child;
+    });
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+    spawnMock.mockReset();
+  });
+
   it("builds Ghostty AppleScript with an initial working directory", () => {
     expect(buildGhosttyAppleScriptArgs('/repo/.worktrees/feature "quoted"')).toEqual([
       "-e",
@@ -19,5 +59,35 @@ describe("application discovery", () => {
       "-e",
       "end tell",
     ]);
+  });
+
+  it("opens VS Code source links with --goto line metadata", async () => {
+    const targetPath = path.join(tempDir, "source.ts");
+    const capturePath = path.join(tempDir, "application-open.json");
+    writeFileSync(targetPath, "line 1\nline 2\n", "utf8");
+
+    await openDesktopApplication(
+      {
+        applicationId: "vscode",
+        kind: "editor",
+        targetPath,
+        targetLine: 12,
+      },
+      {
+        env: {
+          PATH: process.env.PATH,
+          PWRAGENT_E2E_APPLICATION_OPEN_CAPTURE_PATH: capturePath,
+        },
+      }
+    );
+
+    const capture = JSON.parse(readFileSync(capturePath, "utf8")) as {
+      invocation: { args: string[]; command: string };
+      request: { targetLine?: number; targetPath?: string };
+    };
+    expect(capture.request).toMatchObject({ targetPath, targetLine: 12 });
+    expect(capture.invocation.command).toMatch(/code$/);
+    expect(capture.invocation.args).toEqual(["--goto", `${targetPath}:12`]);
+    expect(spawnMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/main/settings/application-discovery.ts
+++ b/apps/desktop/src/main/settings/application-discovery.ts
@@ -3,7 +3,7 @@ import {
   spawn as spawnProcess,
 } from "node:child_process";
 import fs from "node:fs";
-import { access } from "node:fs/promises";
+import { access, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -27,6 +27,13 @@ type KnownApplication = {
   canOpenWorkspace?: boolean;
   macOpenStrategy?: "ghostty-applescript";
   terminalWorkingDirectoryArg?: (targetPath: string) => string[];
+};
+
+type ApplicationLaunchInvocation = {
+  command: string;
+  args: string[];
+  cwd?: string;
+  mode: "execFile" | "spawn";
 };
 
 const EDITORS: KnownApplication[] = [
@@ -323,33 +330,99 @@ export async function openDesktopApplication(
     return { opened: true };
   }
 
-  await openEditor(application, targetPath, env);
+  const invocation = buildEditorLaunchInvocation(application, targetPath, request);
+  if (await captureApplicationOpenIfRequested(request, invocation, env)) {
+    return { opened: true };
+  }
+  await runLaunchInvocation(invocation, env);
   return { opened: true };
 }
 
-async function openEditor(
+function buildEditorLaunchInvocation(
   application: DesktopApplicationDiscoveryCandidate,
   targetPath: string,
-  env: NodeJS.ProcessEnv,
-): Promise<void> {
+  request: OpenDesktopApplicationRequest,
+): ApplicationLaunchInvocation {
   if (application.executablePath) {
-    await spawnDetached(application.executablePath, [targetPath], { env });
-    return;
+    return {
+      command: application.executablePath,
+      args: editorCliArgs(application.id, targetPath, request),
+      mode: "spawn",
+    };
   }
 
   if (application.appPath && process.platform === "darwin") {
-    await execFile(
-      "/usr/bin/open",
-      ["-a", macApplicationName(application.appPath), targetPath],
-      {
-        env,
-        timeout: 10_000,
-      },
-    );
-    return;
+    return {
+      command: "/usr/bin/open",
+      args: ["-a", macApplicationName(application.appPath), targetPath],
+      mode: "execFile",
+    };
   }
 
   throw new Error(`${application.name} does not have an executable launcher.`);
+}
+
+function editorCliArgs(
+  applicationId: string,
+  targetPath: string,
+  request: OpenDesktopApplicationRequest,
+): string[] {
+  if (!supportsVsCodeGoto(applicationId) || !isPositiveInteger(request.targetLine)) {
+    return [targetPath];
+  }
+
+  const location = isPositiveInteger(request.targetColumn)
+    ? `${targetPath}:${request.targetLine}:${request.targetColumn}`
+    : `${targetPath}:${request.targetLine}`;
+  return ["--goto", location];
+}
+
+function supportsVsCodeGoto(applicationId: string): boolean {
+  return (
+    applicationId === "vscode" ||
+    applicationId === "cursor" ||
+    applicationId === "windsurf"
+  );
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0;
+}
+
+async function runLaunchInvocation(
+  invocation: ApplicationLaunchInvocation,
+  env: NodeJS.ProcessEnv,
+): Promise<void> {
+  if (invocation.mode === "spawn") {
+    await spawnDetached(invocation.command, invocation.args, {
+      cwd: invocation.cwd,
+      env,
+    });
+    return;
+  }
+
+  await execFile(invocation.command, invocation.args, {
+    env,
+    timeout: 10_000,
+  });
+}
+
+async function captureApplicationOpenIfRequested(
+  request: OpenDesktopApplicationRequest,
+  invocation: ApplicationLaunchInvocation,
+  env: NodeJS.ProcessEnv,
+): Promise<boolean> {
+  const capturePath = env.PWRAGENT_E2E_APPLICATION_OPEN_CAPTURE_PATH;
+  if (!capturePath) {
+    return false;
+  }
+
+  await writeFile(
+    capturePath,
+    `${JSON.stringify({ request, invocation }, null, 2)}\n`,
+    "utf8",
+  );
+  return true;
 }
 
 async function openTerminal(

--- a/apps/desktop/src/main/settings/application-discovery.ts
+++ b/apps/desktop/src/main/settings/application-discovery.ts
@@ -208,6 +208,7 @@ async function pathExists(candidatePath: string): Promise<boolean> {
 async function resolveBinary(
   application: KnownApplication,
   env: NodeJS.ProcessEnv,
+  appPath?: string,
 ): Promise<string | undefined> {
   const explicitPath = application.binaryPaths
     ? await firstExistingPath(application.binaryPaths)
@@ -231,7 +232,29 @@ async function resolveBinary(
     }
   }
 
+  const bundledPath = appPath
+    ? await resolveBundledApplicationCliPath(appPath, application.binaryNames ?? [])
+    : undefined;
+  if (bundledPath) {
+    return bundledPath;
+  }
+
   return undefined;
+}
+
+export async function resolveBundledApplicationCliPath(
+  appPath: string,
+  binaryNames: readonly string[],
+): Promise<string | undefined> {
+  if (binaryNames.length === 0) {
+    return undefined;
+  }
+
+  return await firstExistingPath(
+    binaryNames.map((binaryName) =>
+      path.join(appPath, "Contents", "Resources", "app", "bin", binaryName)
+    )
+  );
 }
 
 async function firstExistingPath(candidates: string[]): Promise<string | undefined> {
@@ -250,7 +273,7 @@ async function discoverApplication(
   const appPath = application.appPaths
     ? await firstExistingPath(application.appPaths)
     : undefined;
-  const executablePath = await resolveBinary(application, env);
+  const executablePath = await resolveBinary(application, env, appPath);
 
   if (!appPath && !executablePath) {
     return undefined;

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
@@ -43,8 +43,8 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
 
   const openLocalFileLink = useCallback(
     (event: MouseEvent<HTMLAnchorElement>, href: string): void => {
-      const targetPath = localFilePathFromHref(href);
-      if (!targetPath || !editorApplication || !props.desktopApi?.openApplication) {
+      const target = localFileTargetFromHref(href);
+      if (!target || !editorApplication || !props.desktopApi?.openApplication) {
         return;
       }
 
@@ -53,7 +53,9 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
         .openApplication({
           applicationId: editorApplication.id,
           kind: "editor",
-          targetPath,
+          targetPath: target.path,
+          targetLine: target.line,
+          targetColumn: target.column,
         })
         .catch((error: unknown) => {
           console.error("Failed to open transcript file link", error);
@@ -332,13 +334,15 @@ function normalizeSkillPath(href: string): string | undefined {
   return undefined;
 }
 
-function localFilePathFromHref(href: string): string | undefined {
+function localFileTargetFromHref(
+  href: string
+): { path: string; line?: number; column?: number } | undefined {
   if (href.startsWith("file://")) {
-    return stripFileLineSuffix(decodeURIComponent(href.replace(/^file:\/\//, "")));
+    return splitFileLineSuffix(decodeURIComponent(href.replace(/^file:\/\//, "")));
   }
 
   if (href.startsWith("/")) {
-    return stripFileLineSuffix(href);
+    return splitFileLineSuffix(href);
   }
 
   return undefined;
@@ -353,7 +357,26 @@ function denormalizeMarkdownUrl(url: string): string {
 }
 
 function stripFileLineSuffix(filePath: string): string {
-  return filePath.replace(/:(\d+)(?::\d+)?$/, "");
+  return splitFileLineSuffix(filePath).path;
+}
+
+function splitFileLineSuffix(filePath: string): {
+  path: string;
+  line?: number;
+  column?: number;
+} {
+  const match = /:(\d+)(?::(\d+))?$/.exec(filePath);
+  if (!match) {
+    return { path: filePath };
+  }
+
+  const line = Number.parseInt(match[1] ?? "", 10);
+  const column = match[2] ? Number.parseInt(match[2], 10) : undefined;
+  return {
+    path: filePath.slice(0, match.index),
+    ...(Number.isInteger(line) ? { line } : {}),
+    ...(Number.isInteger(column) ? { column } : {}),
+  };
 }
 
 function extractTextContent(node: ReactNode): string {

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptReview.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptReview.tsx
@@ -130,7 +130,11 @@ export function TranscriptReview(props: TranscriptReviewProps) {
     [props.applications]
   );
   const openLocalFile = useCallback(
-    (event: MouseEvent<HTMLAnchorElement>, targetPath: string): void => {
+    (
+      event: MouseEvent<HTMLAnchorElement>,
+      targetPath: string,
+      targetLine: number
+    ): void => {
       if (!editorApplication || !props.desktopApi?.openApplication) {
         return;
       }
@@ -141,6 +145,7 @@ export function TranscriptReview(props: TranscriptReviewProps) {
           applicationId: editorApplication.id,
           kind: "editor",
           targetPath,
+          targetLine,
         })
         .catch((error: unknown) => {
           console.error("Failed to open review file link", error);
@@ -247,7 +252,7 @@ export function TranscriptReview(props: TranscriptReviewProps) {
                     className="transcript-review__location-path"
                     href={fileHref(absoluteFilePath, range.start)}
                     onClick={(event) => {
-                      openLocalFile(event, absoluteFilePath);
+                      openLocalFile(event, absoluteFilePath, range.start);
                     }}
                     rel="noopener noreferrer"
                     target="_blank"

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
@@ -73,6 +73,53 @@ describe("ThreadMarkdown", () => {
         applicationId: "zed",
         kind: "editor",
         targetPath: "/repo/PwrAgent/AGENTS.md",
+        targetLine: 17,
+        targetColumn: undefined,
+      });
+    });
+  });
+
+  it("passes local file link line and column metadata to the configured editor", async () => {
+    const openApplication = vi.fn(async () => ({ opened: true as const }));
+
+    render(
+      <ThreadMarkdown
+        applications={{
+          editors: [
+            {
+              id: "vscode",
+              kind: "editor",
+              name: "VS Code",
+              source: "application",
+              appPath: "/Applications/Visual Studio Code.app",
+              canOpenWorkspace: true,
+            },
+          ],
+          terminals: [],
+          preferredEditorId: { value: "vscode", source: "config" },
+          preferredTerminalId: { value: "", source: "default" },
+          gh: {
+            path: { value: "", source: "default" },
+            discovery: { candidates: [] },
+          },
+          git: {
+            discovery: { candidates: [] },
+          },
+        }}
+        desktopApi={{ openApplication }}
+        text={"Open [source](/repo/PwrAgent/src/main.ts:12:4)."}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "source" }));
+
+    await waitFor(() => {
+      expect(openApplication).toHaveBeenCalledWith({
+        applicationId: "vscode",
+        kind: "editor",
+        targetPath: "/repo/PwrAgent/src/main.ts",
+        targetLine: 12,
+        targetColumn: 4,
       });
     });
   });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -501,6 +501,8 @@ describe("TranscriptList", () => {
         applicationId: "zed",
         kind: "editor",
         targetPath: "/repo/PwrAgent/AGENTS.md",
+        targetLine: 17,
+        targetColumn: undefined,
       });
     });
   });

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -643,6 +643,8 @@ export type OpenDesktopApplicationRequest = {
   applicationId: string;
   kind: DesktopApplicationKind;
   targetPath: string;
+  targetLine?: number;
+  targetColumn?: number;
 };
 
 export type OpenDesktopApplicationResponse = {


### PR DESCRIPTION
## Summary

Source links in chat transcripts now open editor targets at the referenced line instead of dropping the `:line` suffix before IPC. Review finding links and markdown file links both carry line metadata through the desktop application-open request, and VS Code-style editors launch with `--goto file:line[:column]`.

This keeps the filesystem existence check pointed at the real file path while still giving editors enough metadata to place the cursor on the referenced line.

## Test Plan

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx apps/desktop/src/main/__tests__/application-discovery.test.ts`
- `pnpm --filter @pwragent/desktop test:e2e -- source-link-editor-open.spec.ts`
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `pnpm lint:sql`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
