### PR TITLE
docs(docs-site): nested Providers submenu + collapsible mobile nav + #416 resume note

### DIFF
--- a/docs-site/_layouts/default.html
+++ b/docs-site/_layouts/default.html
@@ -21,8 +21,11 @@
       </a>
       <nav class="site-nav" aria-label="Top navigation">
         <div class="site-nav__group">
-          <a class="site-nav__top" href="{{ '/desktop/' | relative_url }}" aria-haspopup="true">Desktop</a>
-          <ul class="site-nav__dropdown" aria-label="Desktop sections">
+          <div class="site-nav__head">
+            <a class="site-nav__top" href="{{ '/desktop/' | relative_url }}">Desktop</a>
+            <button class="site-nav__toggle" type="button" aria-expanded="false" aria-controls="nav-desktop" aria-label="Toggle Desktop submenu"></button>
+          </div>
+          <ul id="nav-desktop" class="site-nav__dropdown" aria-label="Desktop sections">
             <li><a href="{{ '/desktop/#sidebar-lenses' | relative_url }}">Sidebar lenses</a></li>
             <li><a href="{{ '/desktop/#thread-workspaces-local-and-worktree' | relative_url }}">Workspaces &amp; worktrees</a></li>
             <li><a href="{{ '/desktop/#codex-environments' | relative_url }}">Codex environments</a></li>
@@ -32,19 +35,38 @@
           </ul>
         </div>
         <div class="site-nav__group">
-          <a class="site-nav__top" href="{{ '/messaging/' | relative_url }}" aria-haspopup="true">Messaging</a>
-          <ul class="site-nav__dropdown" aria-label="Messaging sections">
+          <div class="site-nav__head">
+            <a class="site-nav__top" href="{{ '/messaging/' | relative_url }}">Messaging</a>
+            <button class="site-nav__toggle" type="button" aria-expanded="false" aria-controls="nav-messaging" aria-label="Toggle Messaging submenu"></button>
+          </div>
+          <ul id="nav-messaging" class="site-nav__dropdown" aria-label="Messaging sections">
             <li><a href="{{ '/using-codex/' | relative_url }}">Using Codex via Messaging</a></li>
             <li><a href="{{ '/messaging/pairing/' | relative_url }}">Pairing</a></li>
-            <li><a href="{{ '/providers/' | relative_url }}">Providers (Telegram, Discord, …)</a></li>
+            <li class="site-nav__group--sub">
+              <div class="site-nav__head site-nav__head--sub">
+                <a class="site-nav__top site-nav__top--sub" href="{{ '/providers/' | relative_url }}">Providers</a>
+                <button class="site-nav__toggle site-nav__toggle--sub" type="button" aria-expanded="false" aria-controls="nav-providers" aria-label="Toggle Providers submenu"></button>
+              </div>
+              <ul id="nav-providers" class="site-nav__subdropdown" aria-label="Providers">
+                <li><a href="{{ '/providers/telegram/' | relative_url }}">Telegram</a></li>
+                <li><a href="{{ '/providers/discord/' | relative_url }}">Discord</a></li>
+                <li><a href="{{ '/providers/feishu/' | relative_url }}">Feishu / Lark</a></li>
+                <li><a href="{{ '/providers/slack/' | relative_url }}">Slack</a></li>
+                <li><a href="{{ '/providers/mattermost/' | relative_url }}">Mattermost</a></li>
+                <li><a href="{{ '/providers/line/' | relative_url }}">LINE</a></li>
+              </ul>
+            </li>
             <li><a href="{{ '/streaming/' | relative_url }}">Streaming responses</a></li>
             <li><a href="{{ '/webhook-dangers/' | relative_url }}">Webhooks — a security note</a></li>
             <li><a href="{{ '/rate-limits/' | relative_url }}">Rate limits and budgets</a></li>
           </ul>
         </div>
         <div class="site-nav__group">
-          <a class="site-nav__top" href="{{ '/settings/' | relative_url }}" aria-haspopup="true">Settings</a>
-          <ul class="site-nav__dropdown" aria-label="Settings sections">
+          <div class="site-nav__head">
+            <a class="site-nav__top" href="{{ '/settings/' | relative_url }}">Settings</a>
+            <button class="site-nav__toggle" type="button" aria-expanded="false" aria-controls="nav-settings" aria-label="Toggle Settings submenu"></button>
+          </div>
+          <ul id="nav-settings" class="site-nav__dropdown" aria-label="Settings sections">
             <li><a href="{{ '/settings/#general' | relative_url }}">General</a></li>
             <li><a href="{{ '/settings/#application-discovery' | relative_url }}">Applications</a></li>
             <li><a href="{{ '/settings/#profiles' | relative_url }}">Profiles</a></li>
@@ -70,5 +92,18 @@
       <span class="site-footer__meta">MIT licensed · operator docs · <a href="https://github.com/pwrdrvr/PwrAgent">github.com/pwrdrvr/PwrAgent</a></span>
     </div>
   </footer>
+
+  <script>
+    // Tap-to-toggle for nav dropdowns on touch / mobile. CSS hides the
+    // dropdown by default on touch + small viewports; flipping aria-expanded
+    // on the closest .site-nav__group(--sub) reveals it. Desktop with a
+    // hover-capable pointer ignores this — CSS shows on :hover/:focus-within.
+    document.addEventListener("click", function (event) {
+      var toggle = event.target.closest(".site-nav__toggle");
+      if (!toggle) return;
+      var expanded = toggle.getAttribute("aria-expanded") === "true";
+      toggle.setAttribute("aria-expanded", expanded ? "false" : "true");
+    });
+  </script>
 </body>
 </html>

--- a/docs-site/assets/css/site.css
+++ b/docs-site/assets/css/site.css
@@ -200,24 +200,84 @@ body {
   align-items: center;
 }
 
+.site-nav__head {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
 .site-nav__top {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
   padding: 6px 0;
 }
 
-.site-nav__top::after {
-  content: "▾";
-  font-size: 9px;
-  color: var(--text-muted);
-  transform: translateY(-1px);
-  transition: color 120ms ease;
+/* Cosmetic caret on hover-capable pointers. Touch + mobile
+   replace this with an explicit .site-nav__toggle button. */
+@media (hover: hover) and (pointer: fine) {
+  .site-nav__top::after {
+    content: "▾";
+    margin-left: 4px;
+    font-size: 9px;
+    color: var(--text-muted);
+    transform: translateY(-1px);
+    transition: color 120ms ease;
+  }
+
+  .site-nav__top--sub::after {
+    content: "▸";
+  }
+
+  .site-nav__group:hover .site-nav__top::after,
+  .site-nav__group:focus-within .site-nav__top::after,
+  .site-nav__group--sub:hover .site-nav__top--sub::after,
+  .site-nav__group--sub:focus-within .site-nav__top--sub::after {
+    color: var(--accent);
+  }
 }
 
-.site-nav__group:hover .site-nav__top::after,
-.site-nav__group:focus-within .site-nav__top::after {
+/* Explicit tap-target shown only when CSS can't rely on hover.
+   Hidden by default on hover-capable desktop pointers. */
+.site-nav__toggle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 0;
+  color: var(--text-muted);
+  padding: 8px 10px;
+  margin: -8px 0 -8px 2px;
+  font: inherit;
+  line-height: 1;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: color 120ms ease, background 120ms ease;
+}
+
+.site-nav__toggle::before {
+  content: "▾";
+  font-size: 11px;
+  display: inline-block;
+  transition: transform 160ms ease;
+}
+
+.site-nav__toggle--sub::before {
+  content: "▸";
+}
+
+.site-nav__toggle[aria-expanded="true"]::before {
+  transform: rotate(180deg);
+}
+
+.site-nav__toggle--sub[aria-expanded="true"]::before {
+  transform: rotate(90deg);
+}
+
+.site-nav__toggle:hover,
+.site-nav__toggle:focus-visible {
   color: var(--accent);
+  background: var(--bg-panel-hover);
+  outline: none;
 }
 
 .site-nav__dropdown {
@@ -239,11 +299,14 @@ body {
   z-index: 20;
 }
 
-.site-nav__group:hover .site-nav__dropdown,
-.site-nav__group:focus-within .site-nav__dropdown {
-  opacity: 1;
-  visibility: visible;
-  transform: translateY(0);
+/* Hover/focus reveal — only when the pointer can hover. */
+@media (hover: hover) and (pointer: fine) {
+  .site-nav__group:hover > .site-nav__dropdown,
+  .site-nav__group:focus-within > .site-nav__dropdown {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+  }
 }
 
 .site-nav__dropdown li {
@@ -262,6 +325,98 @@ body {
 .site-nav__dropdown a:focus-visible {
   background: var(--bg-panel-hover);
   color: var(--accent);
+}
+
+/* Nested Providers submenu — sits inside .site-nav__dropdown as a <li>. */
+.site-nav__group--sub {
+  position: relative;
+}
+
+.site-nav__head--sub {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.site-nav__head--sub .site-nav__top {
+  flex: 1;
+  padding: 7px 16px;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.site-nav__head--sub .site-nav__top:hover,
+.site-nav__head--sub .site-nav__top:focus-visible {
+  background: var(--bg-panel-hover);
+  color: var(--accent);
+}
+
+.site-nav__subdropdown {
+  position: absolute;
+  top: -7px;
+  left: 100%;
+  min-width: 200px;
+  margin: 0 0 0 4px;
+  padding: 6px 0;
+  list-style: none;
+  background: var(--bg-panel-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.55), 0 2px 6px rgba(0, 0, 0, 0.6);
+  opacity: 0;
+  visibility: hidden;
+  transform: translateX(-4px);
+  transition: opacity 120ms ease, transform 120ms ease, visibility 120ms ease;
+  z-index: 21;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .site-nav__group--sub:hover > .site-nav__subdropdown,
+  .site-nav__group--sub:focus-within > .site-nav__subdropdown {
+    opacity: 1;
+    visibility: visible;
+    transform: translateX(0);
+  }
+}
+
+.site-nav__subdropdown li {
+  margin: 0;
+}
+
+.site-nav__subdropdown a {
+  display: block;
+  padding: 7px 16px;
+  font-size: 13px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.site-nav__subdropdown a:hover,
+.site-nav__subdropdown a:focus-visible {
+  background: var(--bg-panel-hover);
+  color: var(--accent);
+}
+
+/* Touch pointers (iPad, phones large enough to fall outside the
+   <=720px mobile media query): hide hover-cosmetic carets, show
+   the real toggle buttons, drive visibility from aria-expanded. */
+@media (hover: none), (pointer: coarse) {
+  .site-nav__top::after { content: none; }
+  .site-nav__toggle { display: inline-flex; }
+
+  .site-nav__dropdown,
+  .site-nav__subdropdown {
+    opacity: 0;
+    visibility: hidden;
+  }
+
+  .site-nav__group:has(> .site-nav__head > .site-nav__toggle[aria-expanded="true"]) > .site-nav__dropdown,
+  .site-nav__group--sub:has(> .site-nav__head > .site-nav__toggle[aria-expanded="true"]) > .site-nav__subdropdown {
+    opacity: 1;
+    visibility: visible;
+    transform: none;
+  }
 }
 
 .site-nav__github {
@@ -556,52 +711,118 @@ img {
 /* ----- Responsive ----- */
 
 @media (max-width: 720px) {
-  .site-header__inner {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 12px;
+  /* Header scrolls away normally on mobile — sticky + always-expanded
+     dropdowns covered most of the viewport. */
+  .site-header {
+    position: static;
+    padding: 10px 18px;
   }
 
+  .site-header__inner {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 10px;
+  }
+
+  .site-brand {
+    align-self: flex-start;
+  }
+
+  /* Stack groups + GitHub link as full-width rows so nothing wraps
+     into someone else's whitespace. */
   .site-nav {
-    flex-wrap: wrap;
-    gap: 12px 16px;
-    font-size: 13px;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 2px;
+    font-size: 14px;
   }
 
   .site-nav__group {
-    flex-direction: column;
-    align-items: flex-start;
+    display: block;
   }
 
-  .site-nav__top::after {
-    display: none;
+  .site-nav__head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
   }
 
-  .site-nav__dropdown {
+  .site-nav__top {
+    flex: 1;
+    padding: 10px 0;
+  }
+
+  .site-nav__top::after { content: none; }
+
+  .site-nav__toggle {
+    display: inline-flex;
+    padding: 10px 14px;
+    margin: 0 -4px 0 0;
+    color: var(--text-secondary);
+  }
+
+  .site-nav__toggle::before {
+    font-size: 14px;
+  }
+
+  .site-nav__dropdown,
+  .site-nav__subdropdown {
     position: static;
     min-width: 0;
-    margin: 4px 0 0 12px;
+    margin: 0 0 6px 12px;
     padding: 0;
     background: transparent;
     border: 0;
     box-shadow: none;
-    opacity: 1;
-    visibility: visible;
+    opacity: 0;
+    visibility: hidden;
+    height: 0;
+    overflow: hidden;
     transform: none;
   }
 
-  .site-nav__dropdown a {
-    padding: 4px 0;
-    font-size: 12.5px;
+  .site-nav__group:has(> .site-nav__head > .site-nav__toggle[aria-expanded="true"]) > .site-nav__dropdown,
+  .site-nav__group--sub:has(> .site-nav__head > .site-nav__toggle[aria-expanded="true"]) > .site-nav__subdropdown {
+    opacity: 1;
+    visibility: visible;
+    height: auto;
+  }
+
+  .site-nav__dropdown a,
+  .site-nav__subdropdown a {
+    padding: 8px 0;
+    font-size: 13.5px;
+    white-space: normal;
   }
 
   .site-nav__dropdown a:hover,
-  .site-nav__dropdown a:focus-visible {
+  .site-nav__subdropdown a:hover,
+  .site-nav__dropdown a:focus-visible,
+  .site-nav__subdropdown a:focus-visible {
     background: transparent;
   }
 
+  .site-nav__head--sub .site-nav__top {
+    padding: 8px 0;
+    font-size: 13.5px;
+  }
+
+  .site-nav__github {
+    padding: 10px 0;
+  }
+
   .site-main {
-    padding: 36px 18px 72px;
+    padding: 24px 18px 60px;
+  }
+
+  /* Wide tables (4-col Settings references on provider pages, etc.)
+     get their own horizontal scroll so they don't push body width. */
+  .page table {
+    display: block;
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
   }
 
   h1 {

--- a/docs-site/using-codex.md
+++ b/docs-site/using-codex.md
@@ -276,6 +276,23 @@ Selecting a thread completes the binding and pins a **status card**
 to the conversation showing the bound thread's current model,
 reasoning, fast mode, and permissions.
 
+### Resume replays the last reply
+
+Once the bind completes, PwrAgent best-effort reposts the bound
+thread's **most recent assistant reply** back into the conversation,
+labeled with how long ago it was originally sent ("from 14 min ago",
+"from 2 days ago"). The replay shows up *before* the status card so
+you immediately see where the agent left off — no scrolling back
+through your own messenger history or jumping to the desktop to
+find the thread.
+
+The replay is best-effort: if the prior reply can't be loaded
+(deleted from the thread, replay store unavailable, very old thread
+without a captured last message), the bind still succeeds — you just
+don't get the recap. The replay runs through all three resume paths:
+picking a row in the Resume browser, a direct `/resume <thread-id>`
+text bind, and the Full Access resume escalation path.
+
 <details markdown="1">
 <summary>Per-provider exceptions</summary>
 


### PR DESCRIPTION
## Summary

Three coupled docs-site changes, plus one resume-flow content paragraph for [#416](https://github.com/pwrdrvr/PwrAgent/pull/416):

### Messaging → Providers becomes a real nested submenu

Before: Messaging dropdown had `Providers (Telegram, Discord, …)` as a flat link.
After:

```
Messaging
  └── Using Codex via Messaging
      Pairing
      Providers       (hover/tap fans the sub-panel below)
        ├── Telegram
        │   Discord
        │   Feishu / Lark
        │   Slack
        │   Mattermost
        │   LINE
      Streaming responses
      Webhooks — a security note
      Rate limits and budgets
```

On hover-capable desktop the nested submenu fans to the **right** of the Messaging panel. On touch / mobile, an explicit caret toggle expands the same six links **inline-indented** under Providers.

### Mobile nav was severely broken

Audit at iPhone 14 Pro (393×852) caught three real problems that didn't show in any desktop viewport:

| Issue | Impact | Fix |
|---|---|---|
| Sticky header + always-expanded dropdowns ate ~60% of viewport, followed users as they scrolled | On `/using-codex/` only ~3 lines of content were above the fold | `.site-header { position: static }` on ≤720px; explicit `<button>` toggles drive dropdown visibility via `aria-expanded` instead of always-showing |
| `GitHub →` flex-wrapped to an awkward spot next to "Profiles" inside the Settings group | Confusing layout | `.site-nav { flex-direction: column }` on mobile; nav items stack as full-width rows |
| The 4-col "Optional Settings reference" tables on provider pages overflowed by ~25px | Document-level horizontal scroll on every provider page | `.page table { display: block; overflow-x: auto }` on ≤720px — tables get their own internal scroll instead of pushing body width |

Also added `@media (hover: none) and (pointer: coarse)` branch so iPads and large touch phones (which fall above the 720px mobile breakpoint) still get tap-to-toggle dropdowns instead of needing hover.

### Resume now replays the last reply

[#416](https://github.com/pwrdrvr/PwrAgent/pull/416) shipped: after resuming a messaging-bound thread, PwrAgent best-effort reposts the thread's most recent assistant reply with an age label (`"from 14 min ago"`). Documented in [`/using-codex/#resume-replays-the-last-reply`](https://docs.pwragent.ai/using-codex/#resume-replays-the-last-reply) as a sub-section of the Resume Thread browser. Notes the best-effort semantics (silent skip if reply can't be loaded) and that it runs through all three resume paths (picker, direct `/resume <id>`, Full Access escalation).

## Verification

Captured against the local Docker container at three viewport widths via `agent-browser`:

- **393×852 (iPhone 14 Pro, DPR 3)** — nav collapses to 4 rows (Desktop / Messaging / Settings / GitHub) with visible chevron toggles; tapping a parent toggle expands its dropdown inline; tapping the nested Providers toggle further-indents the six providers; document does not horizontal-scroll on any page; provider Settings tables scroll internally
- **768×1024 (iPad Mini)** — nav in single row with hover carets (desktop layout); tap-toggle still works via the `(hover: none)` branch on actual touch devices
- **1440×900 (Desktop)** — Messaging dropdown opens on hover/focus; Providers row inside shows `▸`; hovering/focusing it fans the six-platform sub-panel to the right at `top: -7px; left: 100%`

Inline DOM probes confirmed:
- Telegram page at 393px: `docWidth: 393 === viewportWidth: 393` (no document overflow)
- Optional Settings table: `tableWidth: 357 (matches article), tableScrollWidth: 382 (overflows internally)` ✓
- All 15 using-codex tables fit at 393px without internal overflow

## Post-Deploy Monitoring & Validation

- **What to monitor:** GitHub Pages workflow (`Deploy docs.pwragent.ai`) — should fire on merge since `docs-site/**` changes, build in ~17s, deploy in ~10s. Live at <https://docs.pwragent.ai/> within ~30s of merge after CF cache miss.
- **Validation checks:**
  - `curl -sI https://docs.pwragent.ai/` → `HTTP/2 200`, `server: cloudflare`
  - Smoke-check the new submenu: open <https://docs.pwragent.ai/> on a phone, tap Messaging, then Providers — should expand inline-indented; on desktop, hover Messaging then Providers should fan a side panel
  - `curl -s https://docs.pwragent.ai/using-codex/ | grep "resume-replays-the-last-reply"` returns the new `<h3>` anchor
- **Expected healthy behavior:** All existing pages 200; new structure renders; no document-level horizontal scroll on phones.
- **Failure signal / rollback:** If the new submenu HTML doesn't render (Jekyll build error), the GHA workflow fails — investigate logs in Actions tab. To roll back quickly: revert this commit on `main`, the workflow re-deploys.
- **Validation window:** 5 min post-merge.
- **Owner:** @huntharo

🤖 Generated with Claude Opus 4.7 via [Claude Code](https://claude.com/claude-code)