### PR TITLE
docs(docs-site): mobile nav toggles read as obvious tap targets

### DIFF
--- a/docs-site/assets/css/site.css
+++ b/docs-site/assets/css/site.css
@@ -782,15 +782,32 @@ img {
 
   .site-nav__top::after { content: none; }
 
+  /* Mobile toggle reads as an obvious tap target — outlined chevron
+     pill in the accent color rather than a dim text character. */
   .site-nav__toggle {
     display: inline-flex;
-    padding: 10px 14px;
-    margin: 0 -4px 0 0;
-    color: var(--text-secondary);
+    min-width: 44px;
+    height: 32px;
+    padding: 0 12px;
+    margin: 0;
+    color: var(--accent);
+    background: var(--accent-soft);
+    border: 1px solid var(--accent-border);
+    border-radius: 6px;
   }
 
   .site-nav__toggle::before {
-    font-size: 14px;
+    font-size: 16px;
+    line-height: 1;
+    font-weight: 700;
+  }
+
+  .site-nav__toggle:hover,
+  .site-nav__toggle:focus-visible,
+  .site-nav__toggle[aria-expanded="true"] {
+    color: var(--accent-strong);
+    background: var(--accent-soft);
+    border-color: var(--accent);
   }
 
   .site-nav__dropdown,


### PR DESCRIPTION
## Summary

Follow-up to a real-device iPhone Safari capture: the parent-row toggle chevrons on the mobile nav rendered as dim `--text-secondary` characters against the black canvas. They were hard to find, hard to recognize as interactive, and visually merged with the parent label text next to them.

## Before / After

| Before (real-device iPhone capture) | After (393×852, DPR 3) |
|---|---|
| Dim `▴` / `▾` glyphs next to each parent. Indistinguishable from text. | Outlined accent-tinted pills with bright orange chevrons. Clear 44px tap target. |

## Change

`.site-nav__toggle` on `≤720px` viewports gets:

- **44px min tap target** (Apple HIG floor), 32px tall pill.
- **Accent-tinted background + 1px accent-border** so each toggle reads as a button instead of a glyph.
- **16px bold chevron in `--accent`** for visibility against the black bg.
- **Brighter border when `aria-expanded="true"`** so the open one stands out from the collapsed siblings.
- **Rotation animation preserved** — `▾` → `▴` on expand, sub-toggle `▸` → `▾`.

Desktop dropdown UX is **unchanged** — toggles stay `display: none` on hover-capable pointers; the existing `(hover: none), (pointer: coarse)` branch retains its own minimal styling between mobile and full desktop.

## Verification

Captured locally at 393×852 (iPhone 14 Pro) DPR 3 against the Docker build, both collapsed and expanded states. All three parent toggles + the nested Providers sub-toggle render as outlined pills with visible chevrons; the rotation animation provides clear "I tapped it" feedback.

## Post-Deploy Monitoring & Validation

- **What to monitor:** Pages workflow (`Deploy docs.pwragent.ai`) fires on merge since `docs-site/**` changed. Build ~17s + deploy ~10s.
- **Cache:** Cloudflare cache for `https://docs.pwragent.ai/assets/css/site.css` will need a manual purge after the workflow finishes (or wait ~4h for the natural TTL). Per the user's preference, no fingerprinting added to the link.
- **Validation:** open <https://docs.pwragent.ai/> on a phone after CF purge — each parent row (Desktop / Messaging / Settings) and the nested Providers row should show a visible outlined chevron pill on the right.
- **Failure / rollback:** Revert this commit on `main`; workflow redeploys within ~30s + manual CF purge.
- **Validation window:** 5 min post-merge + CF purge.
- **Owner:** @huntharo

🤖 Generated with Claude Opus 4.7 via [Claude Code](https://claude.com/claude-code)