### PR TITLE
docs(docs-site): render triple-backticks as code in Markdown composer pitch

### DIFF
--- a/docs-site/_layouts/default.html
+++ b/docs-site/_layouts/default.html
@@ -28,7 +28,7 @@
           <ul id="nav-desktop" class="site-nav__dropdown" aria-label="Desktop sections">
             <li><a href="{{ '/desktop/#sidebar-lenses' | relative_url }}">Sidebar lenses (Updated / Created / Directories)</a></li>
             <li><a href="{{ '/desktop/#thread-workspaces-local-and-worktree' | relative_url }}">Workspaces — Local &amp; Worktree</a></li>
-            <li><a href="{{ '/desktop/#codex-environments' | relative_url }}">Codex environments (setup hooks, command gating)</a></li>
+            <li><a href="{{ '/desktop/#codex-environments' | relative_url }}">Codex environments (worktree setup, quick commands)</a></li>
             <li><a href="{{ '/desktop/#per-thread-settings' | relative_url }}">Per-thread model / access / fast / reasoning</a></li>
             <li><a href="{{ '/desktop/#markdown-composer' | relative_url }}">Markdown composer (Codex Desktop doesn't have this)</a></li>
             <li><a href="{{ '/desktop/#access-modes' | relative_url }}">Access modes &amp; approval mirroring</a></li>

--- a/docs-site/_layouts/default.html
+++ b/docs-site/_layouts/default.html
@@ -26,11 +26,13 @@
             <button class="site-nav__toggle" type="button" aria-expanded="false" aria-controls="nav-desktop" aria-label="Toggle Desktop submenu"></button>
           </div>
           <ul id="nav-desktop" class="site-nav__dropdown" aria-label="Desktop sections">
-            <li><a href="{{ '/desktop/#sidebar-lenses' | relative_url }}">Sidebar lenses</a></li>
-            <li><a href="{{ '/desktop/#thread-workspaces-local-and-worktree' | relative_url }}">Workspaces &amp; worktrees</a></li>
-            <li><a href="{{ '/desktop/#codex-environments' | relative_url }}">Codex environments</a></li>
-            <li><a href="{{ '/desktop/#per-thread-settings' | relative_url }}">Per-thread settings</a></li>
-            <li><a href="{{ '/desktop/#multiple-profiles' | relative_url }}">Multiple profiles</a></li>
+            <li><a href="{{ '/desktop/#sidebar-lenses' | relative_url }}">Sidebar lenses (Updated / Created / Directories)</a></li>
+            <li><a href="{{ '/desktop/#thread-workspaces-local-and-worktree' | relative_url }}">Workspaces — Local &amp; Worktree</a></li>
+            <li><a href="{{ '/desktop/#codex-environments' | relative_url }}">Codex environments (setup hooks, command gating)</a></li>
+            <li><a href="{{ '/desktop/#per-thread-settings' | relative_url }}">Per-thread model / access / fast / reasoning</a></li>
+            <li><a href="{{ '/desktop/#markdown-composer' | relative_url }}">Markdown composer (Codex Desktop doesn't have this)</a></li>
+            <li><a href="{{ '/desktop/#access-modes' | relative_url }}">Access modes &amp; approval mirroring</a></li>
+            <li><a href="{{ '/desktop/#multiple-profiles' | relative_url }}">Multiple Codex profiles + isolated PwrAgent state</a></li>
             <li><a href="{{ '/desktop/#not-yet' | relative_url }}">Not yet / Coming soon</a></li>
           </ul>
         </div>

--- a/docs-site/assets/css/site.css
+++ b/docs-site/assets/css/site.css
@@ -244,9 +244,9 @@ body {
 @media (hover: hover) and (pointer: fine) {
   .site-nav__top::after {
     content: "▾";
-    margin-left: 4px;
-    font-size: 9px;
-    color: var(--text-muted);
+    margin-left: 5px;
+    font-size: 12px;
+    color: var(--text-secondary);
     transform: translateY(-1px);
     transition: color 120ms ease;
   }

--- a/docs-site/desktop.md
+++ b/docs-site/desktop.md
@@ -28,9 +28,9 @@ What makes the PwrAgent side worth running:
   worktree, PwrAgent can run the environment's setup hook (install
   deps, warm caches, run codegen) and stream the output into the
   transcript before the agent takes its first turn.
-- **In-place Markdown composer** — triple-backticks open a code
-  block, `>` opens a blockquote, bullet and numbered lists
-  auto-continue. Codex Desktop doesn't have this yet.
+- **In-place Markdown composer** — ```` ``` ```` opens a code block,
+  `>` opens a blockquote, bullet and numbered lists auto-continue.
+  Codex Desktop doesn't have this yet.
 - **Profile isolation** — two layered profile mechanisms (PwrAgent
   + Codex) compose into anything from "one install, one identity"
   to "N installs running side-by-side with isolated auth and
@@ -182,7 +182,7 @@ conversation.
 
 The composer parses Markdown as you type:
 
-- Triple backticks + space opens a code block.
+- ```` ``` ```` + space opens a code block.
 - `>` + space opens a blockquote.
 - `-` or `*` + space starts a bulleted list; press Enter on an empty
   bullet to exit.


### PR DESCRIPTION
## Summary

Tiny consistency fix flagged on a re-read of the live site. The Markdown composer section listed every other trigger as a code-styled token (\`>\`, \`-\`, \`*\`, \`1.\`, \`**bold**\`, etc.) but spelled out "triple backticks" / "Triple backticks" as prose in two spots — visually broke the pattern.

Now renders as a code-styled \`\`\`\`\`\` in both places (the Desktop page intro bullet at desktop.md:31 and the detailed Markdown composer section at desktop.md:185).

The kramdown trick: a four-backtick fence around three literal backticks (\`\`\`\` \`\`\` \`\`\`\`) — the longer fence is required because the content itself contains backticks.

## Verification

Built locally; HTML output for both spots renders as \`<code>\`\`\`</code>\` matching the surrounding code-styled tokens. Captured a screenshot of the Markdown composer section at 1440×900 to confirm visual consistency before pushing.

## Post-Deploy Monitoring & Validation

- **What to monitor:** Pages workflow (\`Deploy docs.pwragent.ai\`) fires on merge since \`docs-site/**\` changed.
- **Cache:** Cloudflare cache will need a manual purge after deploy for the change to be visible.
- **Validation:** \`curl -s https://docs.pwragent.ai/desktop/ | grep -c "<code class=\\"language-plaintext highlighter-rouge\\">\\\`\\\`\\\`</code>"\` returns 2.
- **Failure / rollback:** Revert the commit on \`main\`; workflow redeploys + CF purge.
- **Validation window:** 5 min post-merge + CF purge.
- **Owner:** @huntharo

🤖 Generated with Claude Opus 4.7 via [Claude Code](https://claude.com/claude-code)