### PR TITLE
ci: skip CI on docs-site-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,18 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'docs-site/**'
+      - '.github/workflows/pages.yml'
   pull_request:
     types:
       - opened
       - synchronize
       - reopened
       - labeled
+    paths-ignore:
+      - 'docs-site/**'
+      - '.github/workflows/pages.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

The full CI workflow (Vitest, typecheck, lint, dependency-cruiser, the build matrix) runs on every push and PR. Docs-only changes touching just `docs-site/**` don't change any runtime code, so spinning up CI is pure noise and minutes.

This adds `paths-ignore` on both `push` (to `main`) and `pull_request` triggers covering:

- `docs-site/**` — the operator-facing Jekyll site
- `.github/workflows/pages.yml` — the Pages deploy workflow itself

If a PR touches `docs-site/` **and** any other path (say, a docs change bundled with a real code fix), `paths-ignore` lets CI run — it skips only when **every** changed file matches the ignore set.

The Pages deploy workflow on `pages.yml` continues to fire on the same push because it's a separate workflow with its own trigger.

## Branch protection note

If "CI" is a required status check on `main`, docs-only PRs would have a pending check that never resolves. Two options if that becomes a problem:

1. Mark CI as not-required (loosest, but the PR author / reviewer still sees pass/fail when CI does run on code changes).
2. Add a no-op "CI" placeholder workflow that always passes for docs-only paths (so the required check resolves green).

Not addressing here — defer until it actually blocks a merge. None of the recent docs PRs (#430, #432, etc.) hit this, so likely fine.

## Verification

Locally checked the YAML parses. Once merged, the next docs-site-only PR will demonstrate the skip — no `CI / *` jobs queued, only the Pages deploy.

🤖 Generated with Claude Opus 4.7 via [Claude Code](https://claude.com/claude-code)