### PR TITLE
fix(docs-site): offset anchor jumps so headings clear the sticky header

### DIFF
--- a/docs-site/assets/css/site.css
+++ b/docs-site/assets/css/site.css
@@ -488,6 +488,17 @@ h1, h2, h3, h4, h5, h6 {
   margin: 2em 0 0.6em;
 }
 
+/* Sticky-header offset for anchor-jumps. The header is
+   position: sticky on desktop (~50px tall + border), so anchor
+   targets need a top margin or they land underneath the header.
+   Mobile drops sticky (`.site-header { position: static }` in the
+   mobile media query below), so this only fires on desktop. */
+@media (min-width: 721px) {
+  .page :is(h1, h2, h3, h4, h5, h6) {
+    scroll-margin-top: 72px;
+  }
+}
+
 h1 {
   font-size: 30px;
   font-weight: 700;


### PR DESCRIPTION
## Summary

Anchor links in the top-nav dropdowns (e.g. Desktop → Codex environments → \`/desktop/#codex-environments\`) scrolled the target heading **underneath the sticky top header**. The heading landed at viewport y=0, but the header is ~59px tall, so the heading was completely hidden — readers landed mid-paragraph with no visual cue they'd arrived at the right place.

## Fix

\`scroll-margin-top: 72px\` on every heading inside \`.page\`, scoped to viewports >720px:

\`\`\`css
@media (min-width: 721px) {
  .page :is(h1, h2, h3, h4, h5, h6) {
    scroll-margin-top: 72px;
  }
}
\`\`\`

The browser honors this on both anchor-driven scroll and \`:target\` highlighting, so jumps land the heading ~13px below the header's bottom edge instead of behind it.

Scoped to the desktop media query because mobile already drops sticky (\`.site-header { position: static }\` in the existing \`max-width: 720px\` block) — on mobile the header scrolls away normally and a top margin would just add awkward spacing.

## Verification

Local Docker build, agent-browser at 1440×900:

| Metric | Before | After |
|---|---|---|
| \`#codex-environments\` \`getBoundingClientRect().top\` after anchor jump | 0px (behind 59px header) | 72px (13px below header bottom) |
| \`getComputedStyle(heading).scrollMarginTop\` | "0px" | "72px" |

Captured a screenshot post-jump — "Codex environments" heading now sits cleanly at the top of the content area below the sticky nav.

## Post-Deploy Monitoring & Validation

- **What to monitor:** Pages workflow fires on merge (\`docs-site/**\` change); CI skips per #436.
- **Cache:** Manual CF purge of \`/assets/css/site.css\` after deploy or wait ~4h.
- **Validation:** Open <https://docs.pwragent.ai/> on desktop, hover Desktop → click "Codex environments" — the heading should appear ~10-15px below the nav bar, not hidden behind it.
- **Failure / rollback:** Revert; redeploys ~30s + CF purge.
- **Owner:** @huntharo

🤖 Generated with Claude Opus 4.7 via [Claude Code](https://claude.com/claude-code)