### PR TITLE
fix(desktop): contain launchpad setup output

### DIFF
--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -219,6 +219,19 @@ describe("Tangerine Terminal theme contract", () => {
     );
   });
 
+  it("keeps launchpad setup output from shrinking the header summary", () => {
+    const setupComposerRule = extractRuleBody(
+      css,
+      ".thread-view__launchpad-composer:has(.transcript-panel--setup)"
+    );
+
+    expect(css).toMatch(
+      /\.thread-view--launchpad > \.thread-header,\s*\.thread-view--launchpad > \.launchpad-panel\s*\{[\s\S]*?flex:\s*0 0 auto;[\s\S]*?\}/
+    );
+    expect(setupComposerRule).toContain("flex: 1 1 0;");
+    expect(setupComposerRule).toContain("min-height: 0;");
+  });
+
   it("reserves opened context rail width for the thread header status area", () => {
     expect(css).toMatch(
       /\.thread-view:has\(\.context-rail\.is-open\) \.thread-header\s*\{[\s\S]*?padding-right:\s*calc\(min\(var\(--context-rail-width, 380px\), calc\(100% - 32px\)\) \+ 12px\);[\s\S]*?\}/

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -4194,6 +4194,11 @@ textarea,
   padding: 0 24px 16px 24px;
 }
 
+.thread-view--launchpad > .thread-header,
+.thread-view--launchpad > .launchpad-panel {
+  flex: 0 0 auto;
+}
+
 .thread-view__launchpad-composer {
   display: flex;
   flex: 0 0 auto;
@@ -4203,7 +4208,7 @@ textarea,
 }
 
 .thread-view__launchpad-composer:has(.transcript-panel--setup) {
-  flex: 1 1 auto;
+  flex: 1 1 0;
   min-height: 0;
   margin-top: 0;
 }


### PR DESCRIPTION
Launchpad environment setup output now stays inside the setup panel, so noisy install scripts scroll without pushing the directory summary into the thread title. The launchpad header and summary card keep their fixed height while the setup transcript consumes the remaining space.

Tested with:

- `pnpm test apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx`
- `pnpm --filter @pwragent/desktop test:e2e e2e/codex-environment-setup.spec.ts --grep "selected Codex environments run setup"`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
