### PR TITLE
chore: tag all image / icon / packaging assets as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,21 @@
-# Captured README demo artifacts. Tag as binary so git doesn't try to
-# diff them on every recapture (each `pnpm --filter @pwragent/desktop
-# screenshot:readme` run regenerates these PNGs and the GIF, and the
-# diffs are noise).
-docs/assets/screenshots/*.png binary
-docs/assets/screenshots/*.gif binary
+# Binary asset handling.
+#
+# Tag image / icon / packaging artifacts as binary so git doesn't
+# try to text-diff them on every regeneration (README and docs-site
+# captures, vendor brand-kit refreshes, packaging builds) and
+# doesn't apply EOL conversion on Windows checkouts.
+
+**/*.png binary
+**/*.gif binary
+**/*.jpg binary
+**/*.jpeg binary
+**/*.ico binary
+**/*.icns binary
+**/*.webp binary
+
+# Vendor brand-kit SVGs — verbatim files from each vendor's brand
+# kit, refreshed via the procedure documented in each vendor's
+# `README.md` and never hand-edited (see
+# `apps/desktop/CLAUDE.md` → "Third-Party Brand Assets" for the rule).
+# Treat as binary so vendor refreshes don't show noisy XML diffs.
+apps/desktop/src/renderer/src/assets/**/*.svg binary


### PR DESCRIPTION
## Summary

Expand `.gitattributes` so every binary asset in the repo is explicitly marked binary, not just the README screenshots.

## Before vs after

| Path | Before | After |
|---|---|---|
| `docs/assets/screenshots/*.png` | `binary: set` | `binary: set` |
| `docs-site/assets/screenshots/*.png` | `binary: unspecified` | `binary: set` |
| `docs-site/assets/favicon-*.png` | `binary: unspecified` | `binary: set` |
| `apps/desktop/build/icon.icns` | `binary: unspecified` | `binary: set` |
| `apps/desktop/build/dmg-background.png` | `binary: unspecified` | `binary: set` |
| `apps/desktop/src/renderer/src/assets/**/*.png` | `binary: unspecified` | `binary: set` |
| `apps/desktop/src/renderer/src/assets/**/*.svg` | `binary: unspecified` | `binary: set` |
| `apps/desktop/e2e/fixtures/**/*.png` | `binary: unspecified` | `binary: set` |
| `docs/design/pwragent-v2/**/*.svg` (design source) | `binary: unspecified` | `binary: unspecified` *(intentional)* |

## What gets binary marking

Recursive `**/*.<ext>` patterns covering **png, gif, jpg, jpeg, ico, icns, webp** at any depth. Plus an explicit rule for vendor brand-kit SVGs under `apps/desktop/src/renderer/src/assets/**/*.svg` — these are verbatim files per the [apps/desktop/CLAUDE.md "Third-Party Brand Assets"](https://github.com/pwrdrvr/PwrAgent/blob/main/apps/desktop/CLAUDE.md) rule and never hand-edited, so XML text-diffs would just be noise on vendor refreshes.

## What stays text

The `docs/design/pwragent-v2/` design-source SVGs are intentionally NOT tagged binary — they're hand-readable design references, not vendor brand-kit artifacts.

## Why this matters

`binary: unspecified` means git falls back to content-detection — which usually works for PNGs in practice, but you lose explicit guarantees against:
- EOL conversion on Windows checkouts (LF/CRLF mangling of binary content)
- Tools attempting text diffs (terminals can dump KB of binary garbage)
- Weird merge behavior if two branches touch the same image

Explicit tagging is cheap and removes those edge cases.

## Verification

Ran `git check-attr binary <paths>` against a representative sample of each category before and after. The before/after table above is the output.

## Operational notes

- **No file content changes** — this is metadata only. Existing checkouts pick up the new behavior on next `git checkout` / `git pull`.
- **No CI impact** — the `.gitattributes` change matches the docs-site `paths-ignore` exception (it's at repo root, not under `docs-site/`), so CI WILL run on this PR. That's fine; it's a one-line metadata change.

🤖 Generated with Claude Opus 4.7 via [Claude Code](https://claude.com/claude-code)