### PR TITLE
chore(supply-chain): ignore user-level global-pnpmfile in repo

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,9 @@
 ignore-scripts=false
+
+# Force pnpm to ignore any user-level global-pnpmfile when running
+# inside this repo. Same install env on dev + CI; lockfile
+# pnpmfileChecksum is portable; --frozen-lockfile works for every
+# contributor regardless of their personal pnpm config. Our git-block
+# protection lives in .pnpmfile.cjs (project-level), so contributors
+# whose user global did the same thing aren't losing protection.
+global-pnpmfile=


### PR DESCRIPTION
## Summary

Companion change to the existing `.pnpmfile.cjs` git-block hook. Adds `global-pnpmfile=` to `.npmrc` so pnpm IGNORES any user-level global pnpmfile when running inside this repo.

Same fix [PwrSnap landed in pwrdrvr/PwrSnap#44](https://github.com/pwrdrvr/PwrSnap/pull/44).

## Why

pnpm 10 hashes ALL active pnpmfiles (project + global) into `pnpm-lock.yaml`'s `pnpmfileChecksum` field. Without this line:

- A contributor with a user-level `global-pnpmfile` configured (a common supply-chain pattern — same git-block content this repo's `.pnpmfile.cjs` already ships) computes a DIFFERENT checksum than CI
- They run `pnpm install`, the new checksum gets committed
- Next CI run fails with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`

The current lockfile checksum (`qhUjtdsDx+KID8QibUkWT/nJBDVb/TMK08fsoGdLy78=`) already happens to be the per-file value of `.pnpmfile.cjs` alone — whoever last regenerated it had no global pnpmfile bleed. This PR locks in that posture so any future contributor's setup can't break CI.

## Effect

- Same install env on dev + CI regardless of any contributor's personal `~/.pnpm/global_pnpmfile.cjs`
- Lockfile `pnpmfileChecksum` is portable
- `--frozen-lockfile` works for everyone
- The project's `.pnpmfile.cjs` (git-block) is the single source of supply-chain protection in this repo, reviewable in PRs, active in CI

Contributors keep their personal global pnpmfile for OTHER repos that don't bring their own.

## Testing

- `pnpm install --frozen-lockfile` — exit 0 (the `ERR_PNPM_IGNORED_BUILDS` warning about `protobufjs@7.5.7` is pre-existing, doesn't fail the install)
- No lockfile drift — only `.npmrc` changes
- Lockfile checksum already matches; no regeneration needed

## Out of scope

- Doesn't change `.pnpmfile.cjs` — already correct and slightly more thorough than PwrSnap's version (covers `gitHostedTarball` fetcher)
- Doesn't change any package integrity hashes (sha512 entries that protect tarballs)
- Doesn't change CI workflow

---

🤖 Generated with Claude Opus 4.7 via Claude Code + Compound Engineering v2.49.0