### PR TITLE
[codex] Test pnpm store configure-nodejs branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         timeout-minutes: 10
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@v1
+        uses: pwrdrvr/configure-nodejs@fix/pnpm-store-cache
         timeout-minutes: 10
         with:
           node-version: 24.x
@@ -48,7 +48,7 @@ jobs:
         timeout-minutes: 10
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@v1
+        uses: pwrdrvr/configure-nodejs@fix/pnpm-store-cache
         timeout-minutes: 10
         with:
           node-version: 24.x
@@ -91,7 +91,7 @@ jobs:
         timeout-minutes: 10
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@v1
+        uses: pwrdrvr/configure-nodejs@fix/pnpm-store-cache
         timeout-minutes: 10
         with:
           node-version: 24.x
@@ -111,7 +111,7 @@ jobs:
         timeout-minutes: 10
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@v1
+        uses: pwrdrvr/configure-nodejs@fix/pnpm-store-cache
         timeout-minutes: 10
         with:
           node-version: 24.x
@@ -136,7 +136,7 @@ jobs:
         timeout-minutes: 10
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@v1
+        uses: pwrdrvr/configure-nodejs@fix/pnpm-store-cache
         timeout-minutes: 10
         with:
           node-version: 24.x
@@ -233,7 +233,7 @@ jobs:
 
       - name: Install Node.js and dependencies
         if: steps.changes.outputs.relevant == 'true'
-        uses: pwrdrvr/configure-nodejs@v1
+        uses: pwrdrvr/configure-nodejs@fix/pnpm-store-cache
         timeout-minutes: 10
         with:
           node-version: 24.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ permissions:
   contents: read
 
 jobs:
+  # Validation-only PR: rerun CI against pwrdrvr/configure-nodejs@v1 after v1 moved to v1.1.0.
   install-deps:
     name: Install Dependencies
     if: ${{ github.event_name != 'pull_request' || github.event.action != 'labeled' || github.event.label.name == 'ci:live-agent-core' }}
@@ -31,7 +32,7 @@ jobs:
         timeout-minutes: 10
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@fix/pnpm-store-cache
+        uses: pwrdrvr/configure-nodejs@v1
         timeout-minutes: 10
         with:
           node-version: 24.x
@@ -48,7 +49,7 @@ jobs:
         timeout-minutes: 10
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@fix/pnpm-store-cache
+        uses: pwrdrvr/configure-nodejs@v1
         timeout-minutes: 10
         with:
           node-version: 24.x
@@ -91,7 +92,7 @@ jobs:
         timeout-minutes: 10
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@fix/pnpm-store-cache
+        uses: pwrdrvr/configure-nodejs@v1
         timeout-minutes: 10
         with:
           node-version: 24.x
@@ -111,7 +112,7 @@ jobs:
         timeout-minutes: 10
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@fix/pnpm-store-cache
+        uses: pwrdrvr/configure-nodejs@v1
         timeout-minutes: 10
         with:
           node-version: 24.x
@@ -136,7 +137,7 @@ jobs:
         timeout-minutes: 10
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@fix/pnpm-store-cache
+        uses: pwrdrvr/configure-nodejs@v1
         timeout-minutes: 10
         with:
           node-version: 24.x
@@ -233,7 +234,7 @@ jobs:
 
       - name: Install Node.js and dependencies
         if: steps.changes.outputs.relevant == 'true'
-        uses: pwrdrvr/configure-nodejs@fix/pnpm-store-cache
+        uses: pwrdrvr/configure-nodejs@v1
         timeout-minutes: 10
         with:
           node-version: 24.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ permissions:
   contents: read
 
 jobs:
-  # Validation-only PR: rerun CI against a configure-nodejs pnpm store env fix.
+  # Validation-only PR: rerun CI against pwrdrvr/configure-nodejs@v1 after v1 moved to v1.1.1.
   install-deps:
     name: Install Dependencies
     if: ${{ github.event_name != 'pull_request' || github.event.action != 'labeled' || github.event.label.name == 'ci:live-agent-core' }}
@@ -32,7 +32,7 @@ jobs:
         timeout-minutes: 10
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@fix/pnpm-store-env
+        uses: pwrdrvr/configure-nodejs@v1
         timeout-minutes: 10
         with:
           node-version: 24.x
@@ -49,7 +49,7 @@ jobs:
         timeout-minutes: 10
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@fix/pnpm-store-env
+        uses: pwrdrvr/configure-nodejs@v1
         timeout-minutes: 10
         with:
           node-version: 24.x
@@ -87,7 +87,7 @@ jobs:
         timeout-minutes: 10
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@fix/pnpm-store-env
+        uses: pwrdrvr/configure-nodejs@v1
         timeout-minutes: 10
         with:
           node-version: 24.x
@@ -107,7 +107,7 @@ jobs:
         timeout-minutes: 10
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@fix/pnpm-store-env
+        uses: pwrdrvr/configure-nodejs@v1
         timeout-minutes: 10
         with:
           node-version: 24.x
@@ -132,7 +132,7 @@ jobs:
         timeout-minutes: 10
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@fix/pnpm-store-env
+        uses: pwrdrvr/configure-nodejs@v1
         timeout-minutes: 10
         with:
           node-version: 24.x
@@ -229,7 +229,7 @@ jobs:
 
       - name: Install Node.js and dependencies
         if: steps.changes.outputs.relevant == 'true'
-        uses: pwrdrvr/configure-nodejs@fix/pnpm-store-env
+        uses: pwrdrvr/configure-nodejs@v1
         timeout-minutes: 10
         with:
           node-version: 24.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ permissions:
   contents: read
 
 jobs:
-  # Validation-only PR: rerun CI against pwrdrvr/configure-nodejs@v1 after v1 moved to v1.1.0.
+  # Validation-only PR: rerun CI against a configure-nodejs pnpm store env fix.
   install-deps:
     name: Install Dependencies
     if: ${{ github.event_name != 'pull_request' || github.event.action != 'labeled' || github.event.label.name == 'ci:live-agent-core' }}
@@ -32,7 +32,7 @@ jobs:
         timeout-minutes: 10
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@v1
+        uses: pwrdrvr/configure-nodejs@fix/pnpm-store-env
         timeout-minutes: 10
         with:
           node-version: 24.x
@@ -49,7 +49,7 @@ jobs:
         timeout-minutes: 10
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@v1
+        uses: pwrdrvr/configure-nodejs@fix/pnpm-store-env
         timeout-minutes: 10
         with:
           node-version: 24.x
@@ -87,7 +87,7 @@ jobs:
         timeout-minutes: 10
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@v1
+        uses: pwrdrvr/configure-nodejs@fix/pnpm-store-env
         timeout-minutes: 10
         with:
           node-version: 24.x
@@ -107,7 +107,7 @@ jobs:
         timeout-minutes: 10
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@v1
+        uses: pwrdrvr/configure-nodejs@fix/pnpm-store-env
         timeout-minutes: 10
         with:
           node-version: 24.x
@@ -132,7 +132,7 @@ jobs:
         timeout-minutes: 10
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@v1
+        uses: pwrdrvr/configure-nodejs@fix/pnpm-store-env
         timeout-minutes: 10
         with:
           node-version: 24.x
@@ -229,7 +229,7 @@ jobs:
 
       - name: Install Node.js and dependencies
         if: steps.changes.outputs.relevant == 'true'
-        uses: pwrdrvr/configure-nodejs@v1
+        uses: pwrdrvr/configure-nodejs@fix/pnpm-store-env
         timeout-minutes: 10
         with:
           node-version: 24.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,12 +56,7 @@ jobs:
 
       - name: License metadata
         timeout-minutes: 10
-        run: |
-          if ! pnpm licenses:check; then
-            echo "License check failed; forcing pnpm to relink dependencies before retrying."
-            pnpm install --frozen-lockfile --force
-            pnpm licenses:check
-          fi
+        run: pnpm licenses:check
 
       - name: Type check
         timeout-minutes: 10


### PR DESCRIPTION
## Summary

- Points the CI workflow at `pwrdrvr/configure-nodejs@fix/pnpm-store-cache` for validation.
- Leaves preview and release workflows on `pwrdrvr/configure-nodejs@v1`.

## Why

This is a non-merge validation PR for the configure-nodejs pnpm cache fix. The goal is to confirm PwrAgent CI restores a pnpm store cache and runs fast materialization installs instead of trying to restore pnpm `node_modules` archives.

## Validation

- CI run on this PR is the validation target.
