### PR TITLE
chore(desktop): add post-capture noise filter for screenshot pipeline

### DIFF
--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -99,10 +99,16 @@ as its gate. See
 for the shot list and what state each capture needs.
 
 The script builds the desktop app, launches it headed against curated
-replay fixtures + state-seeded sqlite rows, takes the screenshots, and
-exits. macOS Screen Recording permission is required for whichever
-terminal/IDE runs the spec — the first invocation triggers the system
-prompt; subsequent runs are silent.
+replay fixtures + state-seeded sqlite rows, takes the screenshots,
+then runs the **noise filter** (`filter-noise-screenshots.mjs`) to
+revert any PNG whose pixels are identical to the committed version
+— the `screencapture` encoder produces nondeterministic byte streams
+for deterministic input pixels, and PNGs don't delta-compress in
+git's pack format, so committing re-encode noise adds ~900 KB per
+file per regen for zero visual benefit. macOS Screen Recording
+permission is required for whichever terminal/IDE runs the spec —
+the first invocation triggers the system prompt; subsequent runs
+are silent.
 
 Pieces, all under `apps/desktop/`:
 
@@ -114,6 +120,7 @@ Pieces, all under `apps/desktop/`:
 | `e2e/fixtures/readme-state-seeding.ts` | Direct sqlite/config seeders for messaging bindings, activity log entries, pairing tokens, and Telegram-enabled config. |
 | `e2e/fixtures/docs-site-state-seeding.ts` | All-providers-enabled `config.toml` seeder so the per-platform Settings → Messaging captures can scroll directly to each platform's section without driving the Enabled toggle in the UI. |
 | `scripts/capture-window.swift` | Resolves the Electron window's CGWindowID and runs `screencapture -l <wid>`. Optional `--title=<substring>` for multi-window apps. |
+| `scripts/filter-noise-screenshots.mjs` | Post-capture cleanup. Iterates modified PNGs under `docs/assets/screenshots/` and `docs-site/assets/screenshots/`, decodes both HEAD and working-tree versions to TIFF via `sips`, SHA-256 compares. Identical → `git restore --source=HEAD --worktree`. Visually different → kept for review. Net-new PNGs (untracked) are left alone. |
 | `scripts/render-indicator-overlay.swift` | Paints a numbered step-indicator pill onto a single PNG via Core Graphics + Core Text. |
 | `scripts/stitch-demo-gif.ts` | Reusable GIF stitcher. Annotates each frame via the indicator-overlay Swift helper, then encodes via two-pass ffmpeg `palettegen`/`paletteuse`. CLI: `--output`, `--frame-duration-ms`, `--no-indicator`, `--indicator-position top|bottom`. |
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -33,8 +33,8 @@
     "inspect:e2e:branch-drift": "node scripts/rebuild-native-for-electron.mjs && pnpm build && PWRAGENT_E2E_INSPECT=1 playwright test -c playwright.config.ts e2e/thread-branch-drift.inspect.spec.ts --headed --timeout=0",
     "inspect:e2e:workspace-handoff": "node scripts/rebuild-native-for-electron.mjs && pnpm build && PWRAGENT_E2E_INSPECT=1 playwright test -c playwright.config.ts e2e/workspace-handoff-dialog.inspect.spec.ts --headed --timeout=0",
     "inspect:e2e:markdown-table": "node scripts/rebuild-native-for-electron.mjs && pnpm build && PWRAGENT_E2E_INSPECT=1 playwright test -c playwright.config.ts e2e/markdown-findings-table.inspect.spec.ts --headed --timeout=0",
-    "screenshot:readme": "node scripts/rebuild-native-for-electron.mjs && pnpm build && PWRAGENT_SCREENSHOT_CAPTURE=1 playwright test -c playwright.config.ts e2e/readme-screenshots.inspect.spec.ts --headed",
-    "screenshot:docs-site": "node scripts/rebuild-native-for-electron.mjs && pnpm build && PWRAGENT_DOCS_SITE_SCREENSHOT_CAPTURE=1 playwright test -c playwright.config.ts e2e/docs-site-screenshots.inspect.spec.ts --headed",
+    "screenshot:readme": "node scripts/rebuild-native-for-electron.mjs && pnpm build && PWRAGENT_SCREENSHOT_CAPTURE=1 playwright test -c playwright.config.ts e2e/readme-screenshots.inspect.spec.ts --headed && node scripts/filter-noise-screenshots.mjs",
+    "screenshot:docs-site": "node scripts/rebuild-native-for-electron.mjs && pnpm build && PWRAGENT_DOCS_SITE_SCREENSHOT_CAPTURE=1 playwright test -c playwright.config.ts e2e/docs-site-screenshots.inspect.spec.ts --headed && node scripts/filter-noise-screenshots.mjs",
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {

--- a/apps/desktop/scripts/filter-noise-screenshots.mjs
+++ b/apps/desktop/scripts/filter-noise-screenshots.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+//
+// Revert PNGs in the tracked screenshot directories whose pixels
+// are identical to the committed (HEAD) version.
+//
+// Why: macOS `screencapture` re-encodes its output every run, so
+// even a deterministic-input capture can land with a different
+// byte stream than what's in git. PNGs don't delta-compress in
+// git's pack format — every byte-different commit adds ~900 KB
+// per file to .git regardless of whether anything visible
+// changed. Running this script after `screenshot:readme` /
+// `screenshot:docs-site` reverts the no-op re-encodes while
+// keeping any captures whose pixels actually changed.
+//
+// Mechanics: for each modified PNG under the target dirs,
+// extract HEAD's blob, normalize both to TIFF via `sips` (lossless,
+// canonical encoding), SHA-256 the TIFFs, compare. Same SHA →
+// `git restore --source=HEAD --worktree` to drop the working-tree
+// change.
+//
+// Untracked / newly-added PNGs are left alone — they're net-new
+// content, not re-encode noise. Staged changes are left alone too
+// (the restore is worktree-only).
+//
+// macOS-only because the screenshot pipeline is macOS-only (Swift
+// `screencapture` + Screen Recording permission).
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const TARGET_DIRS = [
+  "docs/assets/screenshots/",
+  "docs-site/assets/screenshots/",
+];
+
+function repoRoot() {
+  return execFileSync("git", ["rev-parse", "--show-toplevel"], {
+    encoding: "utf8",
+  }).trim();
+}
+
+function listModifiedPngs(root) {
+  const status = execFileSync("git", ["status", "--porcelain", "--"], {
+    cwd: root,
+    encoding: "utf8",
+  });
+  return status
+    .split("\n")
+    .filter((line) => /^[ MA]M /.test(line) || /^M[ MA] /.test(line))
+    .map((line) => line.slice(3).trim())
+    .filter((p) => p.endsWith(".png"))
+    .filter((p) => TARGET_DIRS.some((dir) => p.startsWith(dir)));
+}
+
+function extractHeadBlob(root, relPath, outPath) {
+  const result = spawnSync("git", ["show", `HEAD:${relPath}`], {
+    cwd: root,
+    maxBuffer: 50 * 1024 * 1024,
+  });
+  if (result.status !== 0) return false;
+  writeFileSync(outPath, result.stdout);
+  return true;
+}
+
+function pixelHashViaSips(pngPath, tmpDir, tag) {
+  const tiffPath = path.join(tmpDir, `${tag}.tiff`);
+  const result = spawnSync(
+    "sips",
+    ["-s", "format", "tiff", pngPath, "--out", tiffPath],
+    { stdio: ["ignore", "ignore", "ignore"] }
+  );
+  if (result.status !== 0) return null;
+  try {
+    return createHash("sha256").update(readFileSync(tiffPath)).digest("hex");
+  } catch {
+    return null;
+  }
+}
+
+function restoreFromHead(root, relPath) {
+  execFileSync("git", ["restore", "--source=HEAD", "--worktree", "--", relPath], {
+    cwd: root,
+    stdio: "ignore",
+  });
+}
+
+function main() {
+  const root = repoRoot();
+  const modified = listModifiedPngs(root);
+
+  if (modified.length === 0) {
+    console.log("filter-noise-screenshots: no modified PNGs under tracked screenshot dirs.");
+    return;
+  }
+
+  const tmpDir = mkdtempSync(path.join(tmpdir(), "filter-noise-"));
+  let reverted = 0;
+  let kept = 0;
+  let skipped = 0;
+
+  try {
+    for (const relPath of modified) {
+      const absWork = path.join(root, relPath);
+      const headPath = path.join(tmpDir, "head.png");
+
+      if (!extractHeadBlob(root, relPath, headPath)) {
+        console.log(`  skip (no HEAD blob): ${relPath}`);
+        skipped += 1;
+        continue;
+      }
+
+      const headHash = pixelHashViaSips(headPath, tmpDir, "head");
+      const workHash = pixelHashViaSips(absWork, tmpDir, "work");
+
+      if (!headHash || !workHash) {
+        console.log(`  skip (sips decode failed): ${relPath}`);
+        skipped += 1;
+        continue;
+      }
+
+      if (headHash === workHash) {
+        restoreFromHead(root, relPath);
+        console.log(`  revert (pixels identical): ${relPath}`);
+        reverted += 1;
+      } else {
+        console.log(`  keep   (visible change):   ${relPath}`);
+        kept += 1;
+      }
+    }
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+
+  const tail = `${reverted} reverted, ${kept} kept${skipped ? `, ${skipped} skipped` : ""}.`;
+  console.log(`filter-noise-screenshots: ${tail}`);
+}
+
+main();


### PR DESCRIPTION
## Summary

macOS \`screencapture\` produces nondeterministic PNG byte streams for deterministic input pixels, and PNGs don't delta-compress in git's pack format. Every \`pnpm screenshot:docs-site\` (or \`screenshot:readme\`) run re-encodes every captured PNG; committing all 17 docs-site PNGs adds ~14 MB to \`.git/objects/pack/\` per run even when nothing visible changed.

Historical data from this repo: heaviest-churn screenshot files already have **5-6 revisions in the pack** (~5 × 900 KB = ~4.5 MB per file). Projected linear growth at 100 future regen cycles is roughly **1.5 GB** of pack bloat for zero visual benefit.

## What this PR adds

\`apps/desktop/scripts/filter-noise-screenshots.mjs\` — a small Node script that runs **after** each screenshot capture and reverts modified PNGs whose pixels are identical to the committed (HEAD) version:

1. \`git status --porcelain\` → list modified PNGs under \`docs/assets/screenshots/\` and \`docs-site/assets/screenshots/\`.
2. For each, extract HEAD blob via \`git show HEAD:<path>\`.
3. Normalize both HEAD and working-tree versions to **TIFF via \`sips -s format tiff\`** (lossless, canonical encoding).
4. **SHA-256 the TIFFs.** Identical → \`git restore --source=HEAD --worktree\` (worktree-only restore, preserves any staged state). Different → keep for the user to review.
5. **Untracked / newly-added PNGs are skipped** — net-new content, not noise.

Wired into both screenshot scripts in \`apps/desktop/package.json\`:

\`\`\`json
"screenshot:readme":    "... && node scripts/filter-noise-screenshots.mjs",
"screenshot:docs-site": "... && node scripts/filter-noise-screenshots.mjs"
\`\`\`

Documentation update in \`apps/desktop/AGENTS.md\` "Capturing README Screenshots" section — the script gets a row in the existing scripts inventory table.

## Why \`sips\` + TIFF round-trip

- \`sips\` is a macOS built-in (the screenshot pipeline is already macOS-only — Swift \`screencapture\` + Screen Recording permission). **No new dependencies.**
- TIFF is lossless and canonical — the same pixels always produce the same TIFF bytes. SHA-256 over the TIFF is a robust pixel-identity check.
- PNG-to-PNG SHA wouldn't work because that's exactly what we're trying to filter (different bytes, same pixels).

## Failure modes

| Scenario | Behavior |
|---|---|
| Playwright tests fail | Filter doesn't run (chained via \`&&\`). User fixes the test and re-runs; the successful pass cleans up. |
| User staged a real PNG change before running screenshot script | \`git restore --worktree\` preserves index state — won't unstage anything. |
| \`sips\` fails to decode (corrupt PNG) | Filter skips the file with \`skip (sips decode failed)\` log; user sees the file as still modified, can investigate. |
| PNG newly added (not in HEAD) | Filter skips (only "M" status, not "??"). New screenshots are kept. |

## Verification

Smoke-tested locally on real files:

| Test | Result |
|---|---|
| Re-encode of an existing PNG (\`sips -s formatOptions normal\`, 972 KB → 915 KB, MD5 changed) | ✅ **reverted** (\`pixels identical\`) |
| Resize of an existing PNG (\`sips --resampleHeightWidth 700 1000\`, 972 KB → 205 KB, real pixel change) | ✅ **kept** (\`visible change\`) |
| Clean working tree | ✅ No-op with informative message |

## What this saves

Looking at the most recent docs-site capture (PR #438), 16 of 18 modified PNGs were 1-byte re-encode differences. With this filter in place that run would have committed **2 files** (the queue + skills PNGs that were the actual point of the capture) instead of 18. Pack-growth-per-regen drops from ~14 MB to ~1-2 MB on average.

🤖 Generated with Claude Opus 4.7 via [Claude Code](https://claude.com/claude-code)