### PR TITLE
docs(docs-site): give Settings → General a proper sub-heading + framing

### DIFF
--- a/docs-site/settings.md
+++ b/docs-site/settings.md
@@ -26,10 +26,23 @@ The left-nav layout is roughly:
 
 ## General
 
-Desktop-wide defaults that don't fit anywhere more specific. The
-load-bearing setting today is the **pasted image patch budget**,
-which caps how aggressively PwrAgent resizes large images you paste
-into the composer before they're forwarded to the model.
+Desktop-wide defaults that don't fit anywhere more specific. Only
+one section lives here today (image patch budget); more land here
+as the desktop grows surfaces that don't belong in any other panel.
+
+### Pasted images — patch budget
+
+When you paste a large image into the composer (a screenshot, a
+diagram, a photo from your clipboard), PwrAgent resizes it before
+forwarding to the model so it costs a predictable amount of context.
+Images are converted into model-token-friendly **32×32 pixel patches**;
+this setting caps the patch count before per-model multipliers apply.
+
+Pick the budget based on the typical fidelity you need. Most
+screenshots read fine at the default; bump it up when the model
+needs to read small text (UI labels, code snippets in screenshots,
+tiny CLI output). Drop it down if you regularly paste enormous
+images and want to keep the per-turn token cost low.
 
 | Option | What it means |
 |---|---|


### PR DESCRIPTION
## Summary

Landing on \`/settings/#general\` showed the H2 "General" + a single-line intro that name-checked "pasted image patch budget" in prose + a bare table of options — no sub-heading, no description of what the setting actually does, no framing for the table. It read like the page was broken.

Now reads as a proper editorial unit:

- **H2 "General"** + a one-line section frame (one setting today; more land here as the desktop grows surfaces that don't belong elsewhere)
- **H3 "Pasted images — patch budget"** matching the desktop UI's "Pasted images" section header + "Image patch budget" row label
- **What-it-does paragraph** — model-token-friendly 32×32 patches, capped before per-model multipliers
- **How-to-choose paragraph** — default fine for most screenshots; bump up for small text; drop down for huge pastes
- The options table (unchanged)
- The pointer to the messaging-side equivalent
- Screenshot

## Anchor IDs

\`#general\` (H2) unchanged — Settings dropdown still resolves correctly. The new H3 picks up its own kramdown anchor (\`#pasted-images--patch-budget\`) which we could deep-link to from the dropdown later if useful.

## Verification

Captured at 1440×900 against the local Docker build with cache-bust to bypass CF/CDN caching. The new structure reads cleanly above the fold: heading → context → setting heading → what + how → table.

## Post-Deploy Monitoring

- Pages workflow fires on merge; CI skips (docs-site-only).
- Manual CF cache purge of \`/settings/\` after deploy.
- Validation: \`curl -s https://docs.pwragent.ai/settings/ | grep -c "pasted-images--patch-budget"\` returns 1.

🤖 Generated with Claude Opus 4.7 via [Claude Code](https://claude.com/claude-code)