### PR TITLE
fix(release): ship universal mac dmg

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,12 @@
+# GitHub Actions Labels
+
+Some PR labels intentionally trigger workflow behavior. Keep label names
+namespaced with `ci:` when they start, skip, or narrow CI work.
+
+| Label | Workflow | Effect |
+|---|---|---|
+| `ci:build-preview` | `preview-build.yml` | Builds an unsigned macOS preview DMG and uploads it as a workflow artifact. Use for PRs that change release packaging, installer assets, or desktop distribution behavior. |
+| `ci:live-agent-core` | `ci.yml` | Runs the live agent-core smoke test even when the changed-file detector would otherwise skip it. |
+
+If you add another label-triggered workflow path, document it here in the same
+change as the workflow update.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
         run: xvfb-run --auto-servernum pnpm run test:desktop-e2e
 
       - name: Upload desktop Playwright artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         if: ${{ !cancelled() }}
         timeout-minutes: 10
         with:

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -1,4 +1,4 @@
-name: Preview Build (macOS arm64)
+name: Preview Build (macOS universal)
 
 on:
   pull_request:

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -45,7 +45,7 @@ jobs:
         run: pnpm --filter @pwragent/desktop package:dryrun
 
       - name: Upload DMG artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: PwrAgent-${{ steps.version.outputs.version }}-preview
           path: apps/desktop/release-stage/dist/*.dmg

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   preview:
     name: Build preview DMG
-    if: github.event.label.name == 'build-preview'
+    if: github.event.label.name == 'ci:build-preview'
     runs-on: macos-15
     timeout-minutes: 30
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release Desktop (macOS arm64)
+name: Release Desktop (macOS universal)
 
 on:
   push:
@@ -62,6 +62,20 @@ jobs:
           # docs/desktop-distribution-phase-2-runbook.md.
           GH_TOKEN: ${{ secrets.RELEASES_PAT || secrets.GITHUB_TOKEN }}
         run: pnpm --filter @pwragent/desktop release
+
+      - name: Publish stable-name DMG alias
+        env:
+          GH_TOKEN: ${{ secrets.RELEASES_PAT || secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          cd apps/desktop/release-stage/dist
+          versioned=$(ls PwrAgent-*-universal.dmg | head -n 1)
+          cp "$versioned" PwrAgent.dmg
+          gh release upload "$RELEASE_TAG" \
+            PwrAgent.dmg \
+            --repo pwrdrvr/PwrAgent \
+            --clobber
 
       - name: Upload release artifacts (debug retention)
         uses: actions/upload-artifact@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
             --clobber
 
       - name: Upload release artifacts (debug retention)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         if: ${{ !cancelled() }}
         with:
           name: desktop-release-artifacts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,9 @@
 - Treat plan documents as decision artifacts, not implementation scripts.
 - Keep changes aligned with the current active plan unless the user explicitly changes scope.
 - Do not delete or "clean up" files in `docs/brainstorms/`, `docs/plans/`, or future `docs/solutions/` directories.
+- GitHub Actions labels that intentionally trigger workflow behavior are
+  documented in [.github/workflows/README.md](.github/workflows/README.md).
+  Check that list before adding or using a CI-triggering PR label.
 - Exclude `apps/desktop/.local/protocol-captures/` from broad searches by default. Only search it when the task is specifically about captured E2E protocol snippets.
 - Use the project-local [desktop E2E fixture seeding skill](.agents/skills/desktop-e2e-fixture-seeding/SKILL.md) when seeding or refreshing desktop replay fixtures from live captured sessions.
 - For reliable desktop E2E runs, prefer `pnpm test:desktop-e2e` from the repo root. The package-level `pnpm --filter @pwragent/desktop test:e2e` path is also safe now because it builds `apps/desktop/out/` before launching Playwright.

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -98,9 +98,9 @@ mac:
     LSApplicationCategoryType: public.app-category.developer-tools
   target:
     - target: dmg
-      arch: [arm64]
+      arch: [universal]
     - target: zip
-      arch: [arm64]
+      arch: [universal]
 
 dmg:
   background: build/dmg-background.png

--- a/apps/desktop/scripts/release.mjs
+++ b/apps/desktop/scripts/release.mjs
@@ -117,9 +117,9 @@ for (const file of ["LICENSE", "THIRD_PARTY_LICENSES", "CHANGELOG.md"]) {
 }
 
 // 5. electron-builder.
-step(`electron-builder --mac --arm64 (${publish ? "publish" : "no publish"}, ${dryrun ? "ad-hoc signed" : "signed"})`);
+step(`electron-builder --mac --universal (${publish ? "publish" : "no publish"}, ${dryrun ? "ad-hoc signed" : "signed"})`);
 maybeDecodeAppleApiKey();
-const builderArgs = ["electron-builder", "--mac", "--arm64"];
+const builderArgs = ["electron-builder", "--mac", "--universal"];
 if (dryrun) {
   // Use ad-hoc signing (identity=-) instead of no signing (identity=null).
   // electron-builder modifies the Electron binary to set fuses, which
@@ -137,8 +137,33 @@ runChecked("npx", cleanedArgs, { cwd: stageDir });
 //    tests, third-party docs, design docs, screenshots, etc.) leaked into the
 //    bundle. Exclusions are configured in electron-builder.yml; this script
 //    is a belt-and-braces guard against accidental edits to that YAML.
+const builtApp = join(stageDir, "dist", "mac-universal", "PwrAgent.app");
+
+step("verify universal binary slices");
+runChecked("lipo", [
+  join(builtApp, "Contents", "MacOS", "PwrAgent"),
+  "-verify_arch",
+  "x86_64",
+  "arm64",
+]);
+runChecked("lipo", [
+  join(
+    builtApp,
+    "Contents",
+    "Resources",
+    "app.asar.unpacked",
+    "node_modules",
+    "better-sqlite3",
+    "build",
+    "Release",
+    "better_sqlite3.node",
+  ),
+  "-verify_arch",
+  "x86_64",
+  "arm64",
+]);
+
 step("verify packaged asar contents");
-const builtApp = join(stageDir, "dist", "mac-arm64", "PwrAgent.app");
 runChecked("node", [join(desktopRoot, "scripts", "verify-asar-contents.mjs"), builtApp]);
 
 step("done");

--- a/apps/desktop/scripts/verify-asar-contents.mjs
+++ b/apps/desktop/scripts/verify-asar-contents.mjs
@@ -10,7 +10,7 @@ import { resolve } from "node:path";
 
 const args = process.argv.slice(2);
 const appPath = args[0]
-  ?? resolve("release-stage/dist/mac-arm64/PwrAgent.app");
+  ?? resolve("release-stage/dist/mac-universal/PwrAgent.app");
 
 const asarPath = resolve(appPath, "Contents/Resources/app.asar");
 if (!existsSync(asarPath)) {

--- a/docs/desktop-release-runbook.md
+++ b/docs/desktop-release-runbook.md
@@ -4,9 +4,10 @@
 >
 > Origin: [docs/plans/2026-05-02-004-feat-desktop-release-packaging-plan.md](plans/2026-05-02-004-feat-desktop-release-packaging-plan.md)
 
-This runbook covers cutting v1.x desktop releases. Apple Silicon (arm64) only;
-distribution is outside the Mac App Store via signed/notarized DMG with auto-
-update through `electron-updater` against the private `pwrdrvr/PwrAgent` repo.
+This runbook covers cutting v1.x desktop releases. macOS releases ship as
+universal Apple Silicon + Intel binaries; distribution is outside the Mac App
+Store via signed/notarized DMG with auto-update through `electron-updater`
+against the private `pwrdrvr/PwrAgent` repo.
 
 ---
 
@@ -68,7 +69,7 @@ git tag -s v1.0.0-alpha.7 -m "v1.0.0-alpha.7"
 git push origin v1.0.0-alpha.7
 ```
 
-The `Release Desktop (macOS arm64)` workflow on `macos-15` triggers, runs
+The `Release Desktop (macOS universal)` workflow on `macos-15` triggers, runs
 typecheck + tests, and then `apps/desktop/scripts/release.mjs` which:
 
 1. Verifies `THIRD_PARTY_LICENSES` matches a fresh deterministic generation.
@@ -78,11 +79,13 @@ typecheck + tests, and then `apps/desktop/scripts/release.mjs` which:
 4. Seeds the stage with `out/`, `build/`, `electron-builder.yml`, `LICENSE`,
    and `THIRD_PARTY_LICENSES`.
 5. Decodes `APPLE_API_KEY_BASE64` from the env to a temp `.p8` file.
-6. Runs `electron-builder --mac --arm64 --publish always` which signs every
+6. Runs `electron-builder --mac --universal --publish always` which signs every
    helper bundle individually, signs the main `.app`, submits to Apple's
    notarization service via `notarytool`, staples the ticket, builds the DMG
-   and ZIP, generates `latest-mac.yml`, and uploads everything to a GitHub
-   Release on `pwrdrvr/PwrAgent`.
+   and universal updater ZIP, generates `latest-mac.yml`, and uploads
+   everything to a GitHub Release on `pwrdrvr/PwrAgent`.
+7. Uploads the stable-name `PwrAgent.dmg` alias for landing-page download
+   links.
 
 Cycle time target: ≤ 12 minutes.
 
@@ -95,6 +98,22 @@ the generated/empty notes with the matching `CHANGELOG.md` content.
 If direct push to `main` is rejected, use the repo-local release skill fallback:
 open a short-lived release PR, wait for checks, squash merge it, then tag the
 merged `main` commit.
+
+Stable landing-page URL:
+
+```text
+https://github.com/pwrdrvr/PwrAgent/releases/latest/download/PwrAgent.dmg
+```
+
+For the current arm64-only beta, backfill the stable alias:
+
+```bash
+tmpdir=$(mktemp -d)
+cd "$tmpdir"
+gh release download v1.0.0-beta.4 --repo pwrdrvr/PwrAgent --pattern "*arm64.dmg"
+mv PwrAgent-*-arm64.dmg PwrAgent.dmg
+gh release upload v1.0.0-beta.4 PwrAgent.dmg --repo pwrdrvr/PwrAgent --clobber
+```
 
 ---
 
@@ -128,10 +147,14 @@ dependencies changed, run `pnpm licenses:generate`, review the
 Verify the produced `.app`:
 
 ```bash
-APP=apps/desktop/release-stage/dist/mac-arm64/PwrAgent.app
+APP=apps/desktop/release-stage/dist/mac-universal/PwrAgent.app
 
 # Identity must be PwrDrvr LLC
 codesign -dv --verbose=4 "$APP"
+
+# Main executable and native addon must contain both Apple Silicon and Intel slices
+lipo -archs "$APP/Contents/MacOS/PwrAgent"
+lipo -archs "$APP/Contents/Resources/app.asar.unpacked/node_modules/better-sqlite3/build/Release/better_sqlite3.node"
 
 # Gatekeeper-approved (Notarized Developer ID)
 spctl -a -vv "$APP"


### PR DESCRIPTION
## Summary

macOS releases now ship a universal installer and updater ZIP, so one published build supports both Apple Silicon and Intel Macs. The release workflow also publishes a stable `PwrAgent.dmg` alias that the landing site can link to without tracking versioned Electron Builder filenames.

The release script verifies the packaged app and `better-sqlite3` native addon both contain `x86_64` and `arm64` slices before it accepts the artifact. Label-triggered CI paths are now documented under `.github/workflows/README.md`, preview builds use the namespaced `ci:build-preview` label, and artifact uploads use `actions/upload-artifact@v6` for Node 24 compatibility.

## Verification

- `pnpm --filter @pwragent/desktop package:dryrun`
- `pnpm typecheck`
- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
- `git diff --check`
- Parsed all `.github/workflows/*.yml` as YAML
- GitHub CI passed on the previous head after rerunning the initially flaky `Test` job
- `ci:build-preview` successfully produced a preview DMG artifact on the previous head

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
