### PR TITLE
fix(desktop): point release help links at PwrAgent

### DIFF
--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -16,6 +16,7 @@ const disposeAppUpdateIpcHandlersMock = vi.fn();
 const initAutoUpdaterMock = vi.fn();
 const showAppLogWindowMock = vi.fn();
 const showChangelogWindowMock = vi.fn();
+const showThirdPartyNoticesWindowMock = vi.fn();
 const registerImageNormalizationIpcHandlersMock = vi.fn();
 const disposeImageNormalizationIpcHandlersMock = vi.fn();
 const registerPreloadLogIpcHandlersMock = vi.fn();
@@ -48,7 +49,11 @@ const disposeDesktopMessagingRuntimeMock = vi.fn();
 const registerMessagingStatusIpcHandlersMock = vi.fn();
 const disposeMessagingStatusIpcHandlersMock = vi.fn();
 const setApplicationMenuMock = vi.fn();
-const buildFromTemplateMock = vi.fn(() => ({ kind: "menu" }));
+const buildFromTemplateMock = vi.fn((template: unknown) => ({
+  kind: "menu",
+  template,
+}));
+const shellOpenExternalMock = vi.fn(async () => undefined);
 const setNameMock = vi.fn();
 const setAboutPanelOptionsMock = vi.fn();
 const getAppPathMock = vi.fn(() => "/test/app");
@@ -93,7 +98,7 @@ vi.mock("electron", () => ({
     buildFromTemplate: buildFromTemplateMock,
   },
   shell: {
-    openExternal: vi.fn(),
+    openExternal: shellOpenExternalMock,
   },
   nativeImage: {
     createFromPath: nativeImageCreateFromPathMock,
@@ -136,6 +141,10 @@ vi.mock("../app-log-window", () => ({
 
 vi.mock("../changelog-window", () => ({
   showChangelogWindow: showChangelogWindowMock,
+}));
+
+vi.mock("../license-document-window", () => ({
+  showThirdPartyNoticesWindow: showThirdPartyNoticesWindowMock,
 }));
 
 vi.mock("../ipc/image-normalization", () => ({
@@ -249,6 +258,7 @@ describe("bootstrapApp", () => {
     disposeApplicationIpcHandlersMock.mockReset();
     showAppLogWindowMock.mockReset();
     showChangelogWindowMock.mockReset();
+    showThirdPartyNoticesWindowMock.mockReset();
     registerImageNormalizationIpcHandlersMock.mockReset();
     disposeImageNormalizationIpcHandlersMock.mockReset();
     registerPreloadLogIpcHandlersMock.mockReset();
@@ -291,6 +301,7 @@ describe("bootstrapApp", () => {
     registerMessagingStatusIpcHandlersMock.mockReset();
     disposeMessagingStatusIpcHandlersMock.mockReset();
     setApplicationMenuMock.mockReset();
+    shellOpenExternalMock.mockReset();
     buildFromTemplateMock.mockClear();
     setNameMock.mockReset();
     getAppPathMock.mockClear();
@@ -393,6 +404,39 @@ describe("bootstrapApp", () => {
     expect(listThreadsMock).toHaveBeenCalledWith({
       callerReason: "startup-prewarm",
     });
+  });
+
+  it("wires release help links to PwrAgent destinations and bundled notices", async () => {
+    startupProfilerInstance.start.mockResolvedValue();
+
+    await import("../index");
+    await flushMicrotasks();
+
+    const template = buildFromTemplateMock.mock.calls[0]?.[0] as
+      | Array<{
+          role?: string;
+          submenu?: Array<{
+            label?: string;
+            click?: () => void | Promise<void>;
+          }>;
+        }>
+      | undefined;
+    const helpMenu = template?.find((item) => item.role === "help");
+    const item = (label: string) =>
+      helpMenu?.submenu?.find((menuItem) => menuItem.label === label);
+
+    item("Third-Party Notices")?.click?.();
+    expect(showThirdPartyNoticesWindowMock).toHaveBeenCalledOnce();
+
+    await item("PwrAgent Website")?.click?.();
+    expect(shellOpenExternalMock).toHaveBeenCalledWith("https://pwragent.ai");
+
+    await item("Documentation")?.click?.();
+    expect(shellOpenExternalMock).toHaveBeenCalledWith(
+      "https://docs.pwragent.ai",
+    );
+
+    expect(item(["Visit", "Website"].join(" "))).toBeUndefined();
   });
 
   it("logs startup thread list prewarm failures without blocking startup", async () => {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -13,6 +13,11 @@ import {
 } from "./auto-updater";
 import { showAppLogWindow } from "./app-log-window";
 import { showChangelogWindow } from "./changelog-window";
+import { showThirdPartyNoticesWindow } from "./license-document-window";
+import {
+  PWRAGENT_DOCUMENTATION_URL,
+  PWRAGENT_HOMEPAGE_URL,
+} from "../shared/app-metadata";
 import {
   disposeApplicationIpcHandlers,
   registerApplicationIpcHandlers,
@@ -69,7 +74,6 @@ import { createMainWindow } from "./window";
 
 const APP_NAME = "PwrAgent";
 const APP_COPYRIGHT = "Copyright © 2026 PwrDrvr LLC.";
-const APP_WEBSITE = "https://pwrdrvr.com";
 const isMac = process.platform === "darwin";
 const isDevelopment = process.env.NODE_ENV !== "production";
 const mainLog = getMainLogger("pwragent:main");
@@ -179,15 +183,27 @@ function installApplicationMenu(): void {
           },
         },
         {
+          label: "Third-Party Notices",
+          click: () => {
+            showThirdPartyNoticesWindow();
+          },
+        },
+        {
           label: "Logs",
           click: () => {
             showAppLogWindow();
           },
         },
         {
-          label: "Visit Website",
+          label: "PwrAgent Website",
           click: async () => {
-            await shell.openExternal(APP_WEBSITE);
+            await shell.openExternal(PWRAGENT_HOMEPAGE_URL);
+          },
+        },
+        {
+          label: "Documentation",
+          click: async () => {
+            await shell.openExternal(PWRAGENT_DOCUMENTATION_URL);
           },
         },
       ],

--- a/apps/desktop/src/main/ipc/app-metadata.ts
+++ b/apps/desktop/src/main/ipc/app-metadata.ts
@@ -10,21 +10,24 @@ import {
   APP_LOG_WINDOW_OPEN_CHANNEL,
   APP_LICENSE_DOCUMENT_READ_CHANNEL,
   APP_METADATA_READ_CHANNEL,
+  APP_THIRD_PARTY_NOTICES_WINDOW_OPEN_CHANNEL,
 } from "../../shared/ipc";
-import type {
-  AppChangelogDocument,
-  AppLogSnapshot,
-  AppLicenseDocument,
-  AppLicenseDocumentKind,
-  AppMetadata,
+import {
+  PWRAGENT_DOCUMENTATION_URL,
+  PWRAGENT_HOMEPAGE_URL,
+  type AppChangelogDocument,
+  type AppLogSnapshot,
+  type AppLicenseDocument,
+  type AppLicenseDocumentKind,
+  type AppMetadata,
 } from "../../shared/app-metadata";
 import { readAppLogSnapshot, subscribeAppLogEntries } from "../app-logs";
 import { showAppLogWindow } from "../app-log-window";
 import { showChangelogWindow } from "../changelog-window";
+import { showThirdPartyNoticesWindow } from "../license-document-window";
 import { subscribersForChannel } from "../window-channels";
 
 const APP_COPYRIGHT = "Copyright © 2026 PwrDrvr LLC.";
-const APP_HOMEPAGE = "https://pwrdrvr.com";
 
 let unsubscribeAppLogEntries: (() => void) | undefined;
 
@@ -33,7 +36,8 @@ export function resolveAppMetadata(): AppMetadata {
     applicationName: app.getName(),
     applicationVersion: app.getVersion(),
     copyright: APP_COPYRIGHT,
-    homepage: APP_HOMEPAGE,
+    homepage: PWRAGENT_HOMEPAGE_URL,
+    documentationUrl: PWRAGENT_DOCUMENTATION_URL,
     electronVersion: process.versions.electron ?? "",
     chromeVersion: process.versions.chrome ?? "",
     nodeVersion: process.versions.node ?? "",
@@ -69,7 +73,7 @@ export async function readAppLicenseDocument(
   const content = await readFile(resolveLicenseDocumentPath(kind), "utf8");
   return {
     kind,
-    title: kind === "license" ? "MIT License" : "Third-Party Licenses",
+    title: kind === "license" ? "MIT License" : "Third-Party Notices",
     content,
   };
 }
@@ -97,6 +101,7 @@ export function registerAppMetadataIpcHandlers(): void {
   ipcMain.removeHandler(APP_LICENSE_DOCUMENT_READ_CHANNEL);
   ipcMain.removeHandler(APP_CHANGELOG_DOCUMENT_READ_CHANNEL);
   ipcMain.removeHandler(APP_CHANGELOG_WINDOW_OPEN_CHANNEL);
+  ipcMain.removeHandler(APP_THIRD_PARTY_NOTICES_WINDOW_OPEN_CHANNEL);
   ipcMain.removeHandler(APP_LOG_SNAPSHOT_READ_CHANNEL);
   ipcMain.removeHandler(APP_LOG_WINDOW_OPEN_CHANNEL);
   ipcMain.handle(APP_METADATA_READ_CHANNEL, async (): Promise<AppMetadata> =>
@@ -117,6 +122,12 @@ export function registerAppMetadataIpcHandlers(): void {
     showChangelogWindow();
   });
   ipcMain.handle(
+    APP_THIRD_PARTY_NOTICES_WINDOW_OPEN_CHANNEL,
+    async (): Promise<void> => {
+      showThirdPartyNoticesWindow();
+    },
+  );
+  ipcMain.handle(
     APP_LOG_SNAPSHOT_READ_CHANNEL,
     async (): Promise<AppLogSnapshot> => readAppLogSnapshot(),
   );
@@ -132,6 +143,7 @@ export function disposeAppMetadataIpcHandlers(): void {
   ipcMain.removeHandler(APP_LICENSE_DOCUMENT_READ_CHANNEL);
   ipcMain.removeHandler(APP_CHANGELOG_DOCUMENT_READ_CHANNEL);
   ipcMain.removeHandler(APP_CHANGELOG_WINDOW_OPEN_CHANNEL);
+  ipcMain.removeHandler(APP_THIRD_PARTY_NOTICES_WINDOW_OPEN_CHANNEL);
   ipcMain.removeHandler(APP_LOG_SNAPSHOT_READ_CHANNEL);
   ipcMain.removeHandler(APP_LOG_WINDOW_OPEN_CHANNEL);
 }

--- a/apps/desktop/src/main/license-document-window.ts
+++ b/apps/desktop/src/main/license-document-window.ts
@@ -1,0 +1,67 @@
+import { BrowserWindow } from "electron";
+import { getMainLogger } from "./log";
+import {
+  applyWindowSecurityHardening,
+  getPreloadPath,
+  getRendererEntry,
+} from "./window";
+import {
+  WINDOW_KIND_LICENSE_DOCUMENT,
+  registerWindowChannels,
+} from "./window-channels";
+
+const log = getMainLogger("pwragent:license-document-window");
+const THIRD_PARTY_NOTICES_HASH = "third-party-notices";
+
+let thirdPartyNoticesWindow: BrowserWindow | undefined;
+
+export function showThirdPartyNoticesWindow(): void {
+  if (thirdPartyNoticesWindow && !thirdPartyNoticesWindow.isDestroyed()) {
+    if (thirdPartyNoticesWindow.isMinimized()) {
+      thirdPartyNoticesWindow.restore();
+    }
+    thirdPartyNoticesWindow.show();
+    thirdPartyNoticesWindow.focus();
+    return;
+  }
+
+  const window = new BrowserWindow({
+    width: 920,
+    height: 760,
+    minWidth: 640,
+    minHeight: 480,
+    show: false,
+    title: "Third-Party Notices - PwrAgent",
+    titleBarStyle: "hiddenInset",
+    trafficLightPosition: { x: 20, y: 18 },
+    backgroundColor: "#000000",
+    webPreferences: {
+      preload: getPreloadPath(),
+      contextIsolation: true,
+      sandbox: true,
+      nodeIntegration: false,
+    },
+  });
+
+  applyWindowSecurityHardening(window);
+  registerWindowChannels(window, WINDOW_KIND_LICENSE_DOCUMENT, []);
+
+  const rendererEntry = getRendererEntry();
+  if (rendererEntry.kind === "url") {
+    void window.loadURL(`${rendererEntry.value}#${THIRD_PARTY_NOTICES_HASH}`);
+  } else {
+    void window.loadFile(rendererEntry.value, { hash: THIRD_PARTY_NOTICES_HASH });
+  }
+
+  window.once("ready-to-show", () => {
+    window.show();
+  });
+
+  window.on("closed", () => {
+    thirdPartyNoticesWindow = undefined;
+    log.debug("third-party notices window closed");
+  });
+
+  thirdPartyNoticesWindow = window;
+  log.debug("third-party notices window created");
+}

--- a/apps/desktop/src/main/window-channels.ts
+++ b/apps/desktop/src/main/window-channels.ts
@@ -34,11 +34,13 @@ import type { BrowserWindow, WebContents } from "electron";
 export const WINDOW_KIND_MAIN = "main" as const;
 export const WINDOW_KIND_MESSAGING_ACTIVITY = "messaging-activity" as const;
 export const WINDOW_KIND_CHANGELOG = "changelog" as const;
+export const WINDOW_KIND_LICENSE_DOCUMENT = "license-document" as const;
 export const WINDOW_KIND_APP_LOGS = "app-logs" as const;
 export type WindowKind =
   | typeof WINDOW_KIND_MAIN
   | typeof WINDOW_KIND_MESSAGING_ACTIVITY
   | typeof WINDOW_KIND_CHANGELOG
+  | typeof WINDOW_KIND_LICENSE_DOCUMENT
   | typeof WINDOW_KIND_APP_LOGS;
 
 interface Entry {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -163,6 +163,7 @@ import {
   APP_LOG_WINDOW_OPEN_CHANNEL,
   APP_LICENSE_DOCUMENT_READ_CHANNEL,
   APP_METADATA_READ_CHANNEL,
+  APP_THIRD_PARTY_NOTICES_WINDOW_OPEN_CHANNEL,
   APP_UPDATE_CHECK_CHANNEL,
   APP_SERVER_LIST_SKILLS_CHANNEL,
   APP_SERVER_LIST_THREADS_CHANNEL,
@@ -275,6 +276,9 @@ const desktopApi = Object.freeze({
     await ipcRenderer.invoke(APP_CHANGELOG_DOCUMENT_READ_CHANNEL),
   openChangelogWindow: async (): Promise<void> => {
     await ipcRenderer.invoke(APP_CHANGELOG_WINDOW_OPEN_CHANNEL);
+  },
+  openThirdPartyNoticesWindow: async (): Promise<void> => {
+    await ipcRenderer.invoke(APP_THIRD_PARTY_NOTICES_WINDOW_OPEN_CHANNEL);
   },
   readAppLogSnapshot: async (): Promise<AppLogSnapshot> =>
     await ipcRenderer.invoke(APP_LOG_SNAPSHOT_READ_CHANNEL),

--- a/apps/desktop/src/renderer/src/features/license/LicenseDocumentWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/license/LicenseDocumentWindow.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from "react";
+import type { AppLicenseDocument } from "../../../../shared/app-metadata";
+import { useDesktopApi } from "../../lib/desktop-api";
+
+export function LicenseDocumentWindow() {
+  const desktopApi = useDesktopApi();
+  const [licenseDocument, setLicenseDocument] = useState<
+    AppLicenseDocument | undefined
+  >();
+  const [error, setError] = useState<string | undefined>();
+
+  useEffect(() => {
+    document.title = "Third-Party Notices";
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const reader = desktopApi?.readLicenseDocument;
+    if (!reader) {
+      return;
+    }
+
+    reader("third-party-licenses")
+      .then((value) => {
+        if (!cancelled) {
+          setLicenseDocument(value);
+          setError(undefined);
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [desktopApi]);
+
+  return (
+    <div className="document-window">
+      <section aria-label="PwrAgent third-party notices" className="activity-screen">
+        <header className="activity-titlebar">
+          <p className="activity-titlebar__brand">
+            Pwr<span className="activity-titlebar__brand-accent">Agent</span>
+          </p>
+          <div className="activity-titlebar__breadcrumb">
+            <span className="activity-titlebar__eyebrow">Help</span>
+            <span aria-hidden="true" className="activity-titlebar__separator">
+              ›
+            </span>
+            <span className="activity-titlebar__current">Third-Party Notices</span>
+          </div>
+          <div className="activity-titlebar__spacer" />
+        </header>
+        <main className="document-window__content">
+          <article className="document-window__body">
+            {error ? (
+              <p className="document-window__error" role="alert">
+                Could not load third-party notices: {error}
+              </p>
+            ) : licenseDocument ? (
+              <pre className="document-window__pre">{licenseDocument.content}</pre>
+            ) : (
+              <p className="document-window__empty">Loading…</p>
+            )}
+          </article>
+        </main>
+      </section>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/license/__tests__/license-document-window.test.tsx
+++ b/apps/desktop/src/renderer/src/features/license/__tests__/license-document-window.test.tsx
@@ -1,0 +1,31 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AppLicenseDocumentKind } from "../../../../../shared/app-metadata";
+import type { DesktopApi } from "../../../lib/desktop-api";
+import { LicenseDocumentWindow } from "../LicenseDocumentWindow";
+
+afterEach(() => {
+  cleanup();
+  delete (window as Window & { pwragent?: unknown }).pwragent;
+});
+
+describe("LicenseDocumentWindow", () => {
+  it("loads bundled third-party notices", async () => {
+    const readLicenseDocument = vi.fn(async (kind: AppLicenseDocumentKind) => ({
+      kind,
+      title: "Third-Party Notices",
+      content: "PwrAgent Third-Party Notices\n\nreact@19.2.5",
+    }));
+    (window as Window & { pwragent?: DesktopApi }).pwragent = {
+      readLicenseDocument,
+    };
+
+    render(<LicenseDocumentWindow />);
+
+    await waitFor(() => {
+      expect(readLicenseDocument).toHaveBeenCalledWith("third-party-licenses");
+    });
+    expect(await screen.findByText(/react@19\.2\.5/)).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/renderer/src/features/settings/AboutSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/AboutSettings.tsx
@@ -73,6 +73,8 @@ export function AboutSettings(props: { desktopApi?: DesktopApi }) {
 
   const readLicenseDocument = props.desktopApi?.readLicenseDocument;
   const openChangelogWindow = props.desktopApi?.openChangelogWindow;
+  const openThirdPartyNoticesWindow =
+    props.desktopApi?.openThirdPartyNoticesWindow;
   const handleReadLicenseDocument = async (kind: AppLicenseDocumentKind) => {
     if (!readLicenseDocument) {
       return;
@@ -159,6 +161,18 @@ export function AboutSettings(props: { desktopApi?: DesktopApi }) {
             </dd>
           </div>
           <div>
+            <dt>Documentation</dt>
+            <dd>
+              <a
+                href={metadata.documentationUrl}
+                target="_blank"
+                rel="noreferrer"
+              >
+                {metadata.documentationUrl}
+              </a>
+            </dd>
+          </div>
+          <div>
             <dt>Electron</dt>
             <dd>{metadata.electronVersion}</dd>
           </div>
@@ -207,22 +221,17 @@ export function AboutSettings(props: { desktopApi?: DesktopApi }) {
                 void handleReadLicenseDocument("license");
               }}
             >
-              {licenseLoading === "license" ? "Loading…" : "View license"}
+              {licenseLoading === "license" ? "Loading…" : "View MIT license"}
             </button>
             <button
               className="button button--secondary"
               type="button"
-              disabled={
-                !readLicenseDocument ||
-                licenseLoading === "third-party-licenses"
-              }
+              disabled={!openThirdPartyNoticesWindow}
               onClick={() => {
-                void handleReadLicenseDocument("third-party-licenses");
+                void openThirdPartyNoticesWindow?.();
               }}
             >
-              {licenseLoading === "third-party-licenses"
-                ? "Loading…"
-                : "Third-party licenses"}
+              Third-party notices
             </button>
           </div>
           {licenseError ? (

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -1721,25 +1721,28 @@ describe("SettingsScreen", () => {
 
   it("renders About license attribution and opens bundled notices", async () => {
     const openChangelogWindow = vi.fn(async () => undefined);
+    const openThirdPartyNoticesWindow = vi.fn(async () => undefined);
     const readLicenseDocument = vi.fn(async (kind: string) => ({
       kind,
-      title: kind === "license" ? "MIT License" : "Third-Party Licenses",
+      title: kind === "license" ? "MIT License" : "Third-Party Notices",
       content:
         kind === "license"
           ? "MIT License\n\nPermission is hereby granted."
-          : "PwrAgent Third-Party Licenses\n\nreact@19.2.5",
+          : "PwrAgent Third-Party Notices\n\nreact@19.2.5",
     }));
     const desktopApi = {
       readAppMetadata: vi.fn(async () => ({
         applicationName: "PwrAgent",
         applicationVersion: "1.0.0-alpha.8",
         copyright: "Copyright © 2026 PwrDrvr LLC.",
-        homepage: "https://pwrdrvr.com",
+        homepage: "https://pwragent.ai",
+        documentationUrl: "https://docs.pwragent.ai",
         electronVersion: "41.2.1",
         chromeVersion: "142.0.0.0",
         nodeVersion: "24.0.0",
       })),
       openChangelogWindow,
+      openThirdPartyNoticesWindow,
       readLicenseDocument,
     } as unknown as Parameters<typeof SettingsScreen>[0]["desktopApi"];
 
@@ -1753,17 +1756,22 @@ describe("SettingsScreen", () => {
     );
 
     expect(await screen.findByText("PwrAgent is licensed under MIT.")).toBeInTheDocument();
+    expect(screen.getByText("https://pwragent.ai")).toBeInTheDocument();
+    expect(screen.getByText("https://docs.pwragent.ai")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Open changelog" }));
     expect(openChangelogWindow).toHaveBeenCalledOnce();
 
-    fireEvent.click(screen.getByRole("button", { name: "Third-party licenses" }));
+    fireEvent.click(screen.getByRole("button", { name: "Third-party notices" }));
+    expect(openThirdPartyNoticesWindow).toHaveBeenCalledOnce();
+
+    fireEvent.click(screen.getByRole("button", { name: "View MIT license" }));
 
     await waitFor(() => {
-      expect(readLicenseDocument).toHaveBeenCalledWith("third-party-licenses");
+      expect(readLicenseDocument).toHaveBeenCalledWith("license");
     });
-    expect(await screen.findByLabelText("Third-Party Licenses")).toHaveTextContent(
-      "react@19.2.5",
+    expect(await screen.findByLabelText("MIT License")).toHaveTextContent(
+      "Permission is hereby granted.",
     );
   });
 

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -158,6 +158,7 @@ export type DesktopApi = {
   ) => Promise<AppLicenseDocument>;
   readChangelogDocument?: () => Promise<AppChangelogDocument>;
   openChangelogWindow?: () => Promise<void>;
+  openThirdPartyNoticesWindow?: () => Promise<void>;
   readAppLogSnapshot?: () => Promise<AppLogSnapshot>;
   openAppLogWindow?: () => Promise<void>;
   onAppLogEntry?: (callback: (entry: AppLogEntry) => void) => () => void;

--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -13,6 +13,10 @@ const ChangelogWindow = lazy(async () => ({
 const LogsWindow = lazy(async () => ({
   default: (await import("./features/logs/LogsWindow")).LogsWindow,
 }));
+const LicenseDocumentWindow = lazy(async () => ({
+  default: (await import("./features/license/LicenseDocumentWindow"))
+    .LicenseDocumentWindow,
+}));
 const MessagingActivityWindow = lazy(async () => ({
   default: (await import("./features/messaging-activity/MessagingActivityWindow"))
     .MessagingActivityWindow,
@@ -41,6 +45,10 @@ const routes: Array<{
   {
     match: (hash) => hash === "changelog",
     render: () => <ChangelogWindow />,
+  },
+  {
+    match: (hash) => hash === "third-party-notices",
+    render: () => <LicenseDocumentWindow />,
   },
   {
     match: (hash) => hash === "logs",

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -607,6 +607,16 @@ textarea,
   margin-top: 8px;
 }
 
+.document-window__pre {
+  margin: 0;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 .document-window--logs {
   color: var(--text-primary);
 }

--- a/apps/desktop/src/shared/app-metadata.ts
+++ b/apps/desktop/src/shared/app-metadata.ts
@@ -1,8 +1,12 @@
+export const PWRAGENT_HOMEPAGE_URL = "https://pwragent.ai";
+export const PWRAGENT_DOCUMENTATION_URL = "https://docs.pwragent.ai";
+
 export type AppMetadata = {
   applicationName: string;
   applicationVersion: string;
   copyright: string;
   homepage: string;
+  documentationUrl: string;
   electronVersion: string;
   chromeVersion: string;
   nodeVersion: string;

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -153,6 +153,8 @@ export const APP_METADATA_READ_CHANNEL = "app:read-metadata";
 export const APP_LICENSE_DOCUMENT_READ_CHANNEL = "app:read-license-document";
 export const APP_CHANGELOG_DOCUMENT_READ_CHANNEL = "app:read-changelog-document";
 export const APP_CHANGELOG_WINDOW_OPEN_CHANNEL = "app:open-changelog-window";
+export const APP_THIRD_PARTY_NOTICES_WINDOW_OPEN_CHANNEL =
+  "app:open-third-party-notices-window";
 export const APP_LOG_SNAPSHOT_READ_CHANNEL = "app:read-log-snapshot";
 export const APP_LOG_ENTRY_EVENT_CHANNEL = "app:log-entry-event";
 export const APP_LOG_WINDOW_OPEN_CHANNEL = "app:open-log-window";


### PR DESCRIPTION
## Summary

I updated the desktop release/help link surface so PwrAgent points at the PwrAgent web properties instead of the old PwrDrvr homepage.

- Changed the Help menu website item to `PwrAgent Website` and pointed it at `https://pwragent.ai`.
- Added a Help menu `Documentation` item for `https://docs.pwragent.ai`.
- Added a Help menu `Third-Party Notices` item that opens a bundled viewer for `THIRD_PARTY_LICENSES`.
- Updated About settings to show the new website and documentation URLs, and to expose third-party notices through the same viewer path.

## Verification

I verified this with:

- `pnpm test apps/desktop/src/main/__tests__/index.test.ts apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx apps/desktop/src/renderer/src/features/license/__tests__/license-document-window.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`
- `pnpm --filter @pwragent/desktop build`
- Electron smoke test confirming the third-party notices window renders the bundled notices
