### PR TITLE
fix(desktop): filter workspace rows by active profile

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -300,10 +300,16 @@ describe("app server ipc", () => {
     expect(reconcileNavigationSnapshot).toHaveBeenCalledWith({
       backend: "all",
       fetchedAt: expect.any(Number),
+      messagingBindingsByThreadKey: undefined,
       queuedExecutionModesByThreadId: {},
       threads: [
         expect.objectContaining({ source: "codex", id: "thread-1" }),
         expect.objectContaining({ source: "grok", id: "thread-1" }),
+      ],
+      workspaceRoots: [
+        path.join(os.homedir(), ".pwragent", "profiles", "default", "projects"),
+        path.join(os.homedir(), ".pwragent", "projects"),
+        path.join(os.homedir(), ".pwragnt", "projects"),
       ],
     });
     expect(response).toEqual({

--- a/apps/desktop/src/main/__tests__/scratch-projects-root.test.ts
+++ b/apps/desktop/src/main/__tests__/scratch-projects-root.test.ts
@@ -34,6 +34,7 @@ describe("resolveScratchProjectsRoot", () => {
       }),
     ).toEqual([
       "/Users/tester/.pwragent/profiles/default/projects",
+      "/Users/tester/.pwragent/projects",
       "/Users/tester/.pwragnt/projects",
     ]);
 

--- a/apps/desktop/src/main/__tests__/scratch-projects-root.test.ts
+++ b/apps/desktop/src/main/__tests__/scratch-projects-root.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { resolveScratchProjectsRoot } from "../app-server/scratch-projects";
-import { PWRAGENT_HOME_ENV } from "../profile";
+import {
+  resolveScratchProjectsRoot,
+  resolveScratchProjectsRoots,
+} from "../app-server/scratch-projects";
+import { PWRAGENT_HOME_ENV, PWRAGENT_PROFILE_ENV } from "../profile";
 
 describe("resolveScratchProjectsRoot", () => {
   it("defaults to the profile path under ~/.pwragent/", () => {
@@ -21,5 +24,26 @@ describe("resolveScratchProjectsRoot", () => {
         homeDir: "/Users/tester",
       }),
     ).toBe("/tmp/pwragent-home/profiles/default/projects");
+  });
+
+  it("allows only the active profile workspace plus legacy scratch root", () => {
+    expect(
+      resolveScratchProjectsRoots({
+        env: {} as NodeJS.ProcessEnv,
+        homeDir: "/Users/tester",
+      }),
+    ).toEqual([
+      "/Users/tester/.pwragent/profiles/default/projects",
+      "/Users/tester/.pwragnt/projects",
+    ]);
+
+    expect(
+      resolveScratchProjectsRoots({
+        env: {
+          [PWRAGENT_PROFILE_ENV]: "dev",
+        } as NodeJS.ProcessEnv,
+        homeDir: "/Users/tester",
+      }),
+    ).toEqual(["/Users/tester/.pwragent/profiles/dev/projects"]);
   });
 });

--- a/apps/desktop/src/main/app-server/scratch-projects.ts
+++ b/apps/desktop/src/main/app-server/scratch-projects.ts
@@ -1,7 +1,11 @@
 import { randomBytes } from "node:crypto";
+import os from "node:os";
 import { promises as fs } from "node:fs";
 import path from "node:path";
-import { resolveActiveProfilePath } from "../profile";
+import {
+  resolveActiveProfileName,
+  resolveActiveProfilePath,
+} from "../profile";
 
 function formatLocalDatePrefix(date: Date): string {
   const year = String(date.getFullYear());
@@ -15,6 +19,17 @@ export function resolveScratchProjectsRoot(options?: {
   homeDir?: string;
 }): string {
   return resolveActiveProfilePath("projects", options);
+}
+
+export function resolveScratchProjectsRoots(options?: {
+  env?: NodeJS.ProcessEnv;
+  homeDir?: string;
+}): string[] {
+  const roots = [resolveScratchProjectsRoot(options)];
+  if (resolveActiveProfileName(options) === "default") {
+    roots.push(path.join(options?.homeDir ?? os.homedir(), ".pwragnt", "projects"));
+  }
+  return roots;
 }
 
 export async function createScratchProjectDirectory(

--- a/apps/desktop/src/main/app-server/scratch-projects.ts
+++ b/apps/desktop/src/main/app-server/scratch-projects.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import {
   resolveActiveProfileName,
   resolveActiveProfilePath,
+  resolvePwragentRoot,
 } from "../profile";
 
 function formatLocalDatePrefix(date: Date): string {
@@ -27,6 +28,7 @@ export function resolveScratchProjectsRoots(options?: {
 }): string[] {
   const roots = [resolveScratchProjectsRoot(options)];
   if (resolveActiveProfileName(options) === "default") {
+    roots.push(path.join(resolvePwragentRoot(options), "projects"));
     roots.push(path.join(options?.homeDir ?? os.homedir(), ".pwragnt", "projects"));
   }
   return roots;

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -94,6 +94,7 @@ import { buildMessagingBindingsByThreadKey } from "../messaging/messaging-bindin
 import { GithubPrFetcher } from "../pr-status/github-pr-fetcher";
 import { detectPullRequestsForThread } from "../pr-status/pr-detection";
 import { getDesktopSettingsService } from "../settings/desktop-settings-singleton";
+import { resolveScratchProjectsRoots } from "../app-server/scratch-projects";
 
 const isDevelopment = process.env.NODE_ENV !== "production";
 const THREAD_PR_REFRESH_MIN_INTERVAL_MS = 60_000;
@@ -453,6 +454,7 @@ class DesktopAppServerService {
       messagingBindingsByThreadKey,
       queuedExecutionModesByThreadId,
       threads,
+      workspaceRoots: resolveScratchProjectsRoots(),
     });
     const overlayDurationMs = Date.now() - overlayStartedAt;
     const directoryStartedAt = Date.now();

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -40,6 +40,7 @@ import type {
 import type { DesktopBackendRegistry } from "../app-server/backend-registry";
 import { getDesktopBackendRegistry } from "../app-server/backend-registry";
 import { getDesktopOverlayStore } from "../app-server/desktop-overlay-store";
+import { resolveScratchProjectsRoots } from "../app-server/scratch-projects";
 import { buildMessagingBindingsByThreadKey } from "./messaging-bindings-snapshot";
 
 export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
@@ -65,6 +66,7 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
       messagingBindingsByThreadKey,
       queuedExecutionModesByThreadId,
       threads,
+      workspaceRoots: resolveScratchProjectsRoots(),
     });
     const directoryStatuses = await this.registry.readDirectoryStatuses(
       snapshot.directories,

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -76,6 +76,7 @@ export class SqliteOverlayStore {
       { mode: ThreadExecutionMode; queuedAt: number } | undefined
     >;
     threads: AppServerThreadSummary[];
+    workspaceRoots?: string[];
   }): Promise<NavigationSnapshot> {
     const backendState = this.getBackend(params.backend);
     const firstSnapshot = !backendState?.lastSnapshotHash;
@@ -154,6 +155,7 @@ export class SqliteOverlayStore {
       previousKnownThreadKeys: backendState?.knownThreadKeys ?? [],
       threads: params.threads,
       unchanged: false,
+      workspaceRoots: params.workspaceRoots,
     });
 
     const nextHash = buildNavigationSnapshotHash({

--- a/packages/agent-core/src/__tests__/directory-navigation.test.ts
+++ b/packages/agent-core/src/__tests__/directory-navigation.test.ts
@@ -376,6 +376,91 @@ describe("buildDirectorySummaries", () => {
     ]);
   });
 
+  it("filters profile-scoped workspace roots outside the active profile", () => {
+    const defaultProjectsRoot = "/Users/huntharo/.pwragent/profiles/default/projects";
+    const devProjectsRoot = "/Users/huntharo/.pwragent/profiles/dev/projects";
+    const legacyProjectsRoot = "/Users/huntharo/.pwragnt/projects";
+    const directories = buildDirectorySummaries({
+      threads: [
+        buildThread({
+          id: "default-thread",
+          linkedDirectories: [
+            {
+              id: `${defaultProjectsRoot}/2026-05-08-9bc2d3`,
+              label: "2026-05-08-9bc2d3",
+              path: `${defaultProjectsRoot}/2026-05-08-9bc2d3`,
+              kind: "local",
+            },
+          ],
+        }),
+        buildThread({
+          id: "dev-thread",
+          linkedDirectories: [
+            {
+              id: `${devProjectsRoot}/2026-05-12-605c84`,
+              label: "2026-05-12-605c84",
+              path: `${devProjectsRoot}/2026-05-12-605c84`,
+              kind: "local",
+            },
+          ],
+        }),
+        buildThread({
+          id: "legacy-thread",
+          linkedDirectories: [
+            {
+              id: `${legacyProjectsRoot}/2026-05-02-bc16ae`,
+              label: "2026-05-02-bc16ae",
+              path: `${legacyProjectsRoot}/2026-05-02-bc16ae`,
+              kind: "local",
+            },
+          ],
+        }),
+      ],
+      launchpadsByKey: {
+        [`workspace:${defaultProjectsRoot}`]: {
+          directoryKey: `workspace:${defaultProjectsRoot}`,
+          directoryKind: "workspace",
+          directoryLabel: "Workspaces",
+          directoryPath: defaultProjectsRoot,
+          backend: "codex",
+          executionMode: "default",
+          prompt: "Default draft",
+          workMode: "local",
+          createdAt: 1_000,
+          updatedAt: 3_000,
+        },
+        [`workspace:${devProjectsRoot}`]: {
+          directoryKey: `workspace:${devProjectsRoot}`,
+          directoryKind: "workspace",
+          directoryLabel: "Workspaces",
+          directoryPath: devProjectsRoot,
+          backend: "codex",
+          executionMode: "default",
+          prompt: "Dev draft",
+          workMode: "local",
+          createdAt: 1_000,
+          updatedAt: 4_000,
+        },
+      },
+      workspaceRoots: [defaultProjectsRoot, legacyProjectsRoot],
+    });
+
+    expect(directories).toEqual([
+      expect.objectContaining({
+        key: `workspace:${defaultProjectsRoot}`,
+        label: "Workspaces",
+        path: defaultProjectsRoot,
+        threadKeys: expect.arrayContaining([
+          "codex:default-thread",
+          "codex:legacy-thread",
+        ]),
+        launchpad: expect.objectContaining({
+          prompt: "Default draft",
+        }),
+      }),
+    ]);
+  });
+
   it("collapses current, legacy, and launchpad-only scratch roots into one Workspaces row", () => {
     const directories = buildDirectorySummaries({
       threads: [

--- a/packages/agent-core/src/__tests__/directory-navigation.test.ts
+++ b/packages/agent-core/src/__tests__/directory-navigation.test.ts
@@ -467,7 +467,7 @@ describe("buildDirectorySummaries", () => {
     ]);
   });
 
-  it("keeps multiple pending workspace drafts selectable instead of collapsing one away", () => {
+  it("collapses multiple pending workspace drafts into one Workspaces row", () => {
     const directories = buildDirectorySummaries({
       threads: [],
       launchpadsByKey: {
@@ -498,25 +498,21 @@ describe("buildDirectorySummaries", () => {
       },
     });
 
-    expect(directories).toHaveLength(2);
-    expect(directories).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          key: "workspace:/Users/huntharo/.pwragnt/projects",
-          launchpad: expect.objectContaining({
-            directoryKey: "workspace:/Users/huntharo/.pwragnt/projects",
-            prompt: "Legacy draft",
-          }),
+    expect(directories).toEqual([
+      expect.objectContaining({
+        key: "workspace:/Users/huntharo/.pwragent/profiles/dev/projects",
+        kind: "workspace",
+        label: "Workspaces",
+        path: "/Users/huntharo/.pwragent/profiles/dev/projects",
+        threadKeys: [],
+        needsAttentionCount: 0,
+        latestUpdatedAt: 4_000,
+        launchpad: expect.objectContaining({
+          directoryKey: "workspace:/Users/huntharo/.pwragent/profiles/dev/projects",
+          prompt: "Profile draft",
         }),
-        expect.objectContaining({
-          key: "workspace:/Users/huntharo/.pwragent/profiles/dev/projects",
-          launchpad: expect.objectContaining({
-            directoryKey: "workspace:/Users/huntharo/.pwragent/profiles/dev/projects",
-            prompt: "Profile draft",
-          }),
-        }),
-      ]),
-    );
+      }),
+    ]);
   });
 
   it("keeps same-named Codex worktrees as separate directory rows", () => {

--- a/packages/agent-core/src/__tests__/directory-navigation.test.ts
+++ b/packages/agent-core/src/__tests__/directory-navigation.test.ts
@@ -378,6 +378,7 @@ describe("buildDirectorySummaries", () => {
 
   it("filters profile-scoped workspace roots outside the active profile", () => {
     const defaultProjectsRoot = "/Users/huntharo/.pwragent/profiles/default/projects";
+    const preProfileProjectsRoot = "/Users/huntharo/.pwragent/projects";
     const devProjectsRoot = "/Users/huntharo/.pwragent/profiles/dev/projects";
     const legacyProjectsRoot = "/Users/huntharo/.pwragnt/projects";
     const directories = buildDirectorySummaries({
@@ -389,6 +390,17 @@ describe("buildDirectorySummaries", () => {
               id: `${defaultProjectsRoot}/2026-05-08-9bc2d3`,
               label: "2026-05-08-9bc2d3",
               path: `${defaultProjectsRoot}/2026-05-08-9bc2d3`,
+              kind: "local",
+            },
+          ],
+        }),
+        buildThread({
+          id: "pre-profile-thread",
+          linkedDirectories: [
+            {
+              id: `${preProfileProjectsRoot}/2026-05-10-c7d8e9`,
+              label: "2026-05-10-c7d8e9",
+              path: `${preProfileProjectsRoot}/2026-05-10-c7d8e9`,
               kind: "local",
             },
           ],
@@ -429,6 +441,18 @@ describe("buildDirectorySummaries", () => {
           createdAt: 1_000,
           updatedAt: 3_000,
         },
+        [`workspace:${preProfileProjectsRoot}`]: {
+          directoryKey: `workspace:${preProfileProjectsRoot}`,
+          directoryKind: "workspace",
+          directoryLabel: "Workspaces",
+          directoryPath: preProfileProjectsRoot,
+          backend: "codex",
+          executionMode: "default",
+          prompt: "Pre-profile draft",
+          workMode: "local",
+          createdAt: 1_000,
+          updatedAt: 5_000,
+        },
         [`workspace:${devProjectsRoot}`]: {
           directoryKey: `workspace:${devProjectsRoot}`,
           directoryKind: "workspace",
@@ -442,7 +466,11 @@ describe("buildDirectorySummaries", () => {
           updatedAt: 4_000,
         },
       },
-      workspaceRoots: [defaultProjectsRoot, legacyProjectsRoot],
+      workspaceRoots: [
+        defaultProjectsRoot,
+        preProfileProjectsRoot,
+        legacyProjectsRoot,
+      ],
     });
 
     expect(directories).toEqual([
@@ -452,6 +480,7 @@ describe("buildDirectorySummaries", () => {
         path: defaultProjectsRoot,
         threadKeys: expect.arrayContaining([
           "codex:default-thread",
+          "codex:pre-profile-thread",
           "codex:legacy-thread",
         ]),
         launchpad: expect.objectContaining({

--- a/packages/agent-core/src/domain/directory-navigation.ts
+++ b/packages/agent-core/src/domain/directory-navigation.ts
@@ -220,14 +220,6 @@ function collapseWorkspaceSummaries(params: {
     return params.summaries;
   }
 
-  const pendingWorkspaces = workspaces.filter(
-    (workspace) =>
-      workspace.launchpad && hasPersistableLaunchpadState(workspace.launchpad),
-  );
-  if (pendingWorkspaces.length > 1) {
-    return params.summaries;
-  }
-
   const preferred = chooseWorkspaceSummary(workspaces);
   const threadOrder = buildThreadCreationOrder(params.threads);
   const inboxByThreadKey = new Map(

--- a/packages/agent-core/src/domain/directory-navigation.ts
+++ b/packages/agent-core/src/domain/directory-navigation.ts
@@ -26,6 +26,11 @@ function pathBaseName(value?: string): string {
   return parts.at(-1) ?? normalized;
 }
 
+function normalizeComparablePath(value?: string): string | undefined {
+  const normalized = value?.trim().replace(/[\\/]+$/, "");
+  return normalized || undefined;
+}
+
 function isInternalDirectoryLabel(value?: string): boolean {
   return Boolean(value?.startsWith("directory:") || value?.startsWith("workspace:"));
 }
@@ -171,6 +176,29 @@ function ensureSummary(
   return created;
 }
 
+function workspaceRootSet(
+  workspaceRoots?: string[],
+): Set<string> | undefined {
+  const roots = new Set(
+    (workspaceRoots ?? [])
+      .map(normalizeComparablePath)
+      .filter((root): root is string => Boolean(root)),
+  );
+  return roots.size > 0 ? roots : undefined;
+}
+
+function isAllowedWorkspaceRoot(
+  descriptor: DirectoryDescriptor,
+  allowedWorkspaceRoots: Set<string> | undefined,
+): boolean {
+  if (descriptor.kind !== "workspace" || !allowedWorkspaceRoots) {
+    return true;
+  }
+
+  const workspacePath = normalizeComparablePath(descriptor.path);
+  return Boolean(workspacePath && allowedWorkspaceRoots.has(workspacePath));
+}
+
 function hasPersistableLaunchpadState(
   launchpad: DirectoryLaunchpadOverlayState,
 ): boolean {
@@ -185,7 +213,21 @@ function hasPersistableLaunchpadState(
 function compareWorkspaceSummaryPreference(
   left: NavigationDirectorySummary,
   right: NavigationDirectorySummary,
+  preferredWorkspaceRoots?: string[],
 ): number {
+  if (preferredWorkspaceRoots && preferredWorkspaceRoots.length > 0) {
+    const rootRank = new Map(
+      preferredWorkspaceRoots.map((root, index) => [root, index]),
+    );
+    const leftRootRank =
+      rootRank.get(normalizeComparablePath(left.path) ?? "") ?? Number.MAX_SAFE_INTEGER;
+    const rightRootRank =
+      rootRank.get(normalizeComparablePath(right.path) ?? "") ?? Number.MAX_SAFE_INTEGER;
+    if (leftRootRank !== rightRootRank) {
+      return leftRootRank - rightRootRank;
+    }
+  }
+
   const leftLaunchpadUpdatedAt = left.launchpad?.updatedAt ?? 0;
   const rightLaunchpadUpdatedAt = right.launchpad?.updatedAt ?? 0;
   const launchpadUpdatedDelta = rightLaunchpadUpdatedAt - leftLaunchpadUpdatedAt;
@@ -199,6 +241,7 @@ function compareWorkspaceSummaryPreference(
 
 function chooseWorkspaceSummary(
   workspaces: NavigationDirectorySummary[],
+  preferredWorkspaceRoots?: string[],
 ): NavigationDirectorySummary {
   const withPendingLaunchpads = workspaces.filter(
     (workspace) =>
@@ -206,12 +249,15 @@ function chooseWorkspaceSummary(
   );
   const candidates =
     withPendingLaunchpads.length > 0 ? withPendingLaunchpads : workspaces;
-  return [...candidates].sort(compareWorkspaceSummaryPreference)[0]!;
+  return [...candidates].sort((left, right) =>
+    compareWorkspaceSummaryPreference(left, right, preferredWorkspaceRoots),
+  )[0]!;
 }
 
 function collapseWorkspaceSummaries(params: {
   summaries: NavigationDirectorySummary[];
   threads: NavigationThreadSummary[];
+  workspaceRoots?: string[];
 }): NavigationDirectorySummary[] {
   const workspaces = params.summaries.filter(
     (summary) => summary.kind === "workspace",
@@ -220,7 +266,7 @@ function collapseWorkspaceSummaries(params: {
     return params.summaries;
   }
 
-  const preferred = chooseWorkspaceSummary(workspaces);
+  const preferred = chooseWorkspaceSummary(workspaces, params.workspaceRoots);
   const threadOrder = buildThreadCreationOrder(params.threads);
   const inboxByThreadKey = new Map(
     params.threads.map((thread) => [
@@ -294,9 +340,11 @@ export function buildDirectorySummaries(params: {
   threads: NavigationThreadSummary[];
   launchpadsByKey?: Record<string, DirectoryLaunchpadOverlayState | undefined>;
   gitStatusByKey?: Record<string, NavigationDirectoryGitStatus | undefined>;
+  workspaceRoots?: string[];
 }): NavigationDirectorySummary[] {
   const summaries = new Map<string, NavigationDirectorySummary>();
   const stablePathByLabel = collectStablePathByLabel(params.threads);
+  const allowedWorkspaceRoots = workspaceRootSet(params.workspaceRoots);
 
   for (const thread of params.threads) {
     const threadKey = buildThreadIdentityKey(thread.source, thread.id);
@@ -339,6 +387,9 @@ export function buildDirectorySummaries(params: {
                 path: stablePath,
               }
             : descriptor;
+      if (!isAllowedWorkspaceRoot(normalizedDescriptor, allowedWorkspaceRoots)) {
+        continue;
+      }
       if (seenDescriptors.has(normalizedDescriptor.key)) {
         continue;
       }
@@ -364,6 +415,19 @@ export function buildDirectorySummaries(params: {
       label: launchpad.directoryLabel,
       path: launchpadPath,
     });
+    if (
+      !isAllowedWorkspaceRoot(
+        {
+          key: directoryKey,
+          kind: launchpad.directoryKind,
+          label: launchpadLabel,
+          path: launchpadPath,
+        },
+        allowedWorkspaceRoots,
+      )
+    ) {
+      continue;
+    }
     const summary = ensureSummary(summaries, {
       key: directoryKey,
       kind: launchpad.directoryKind,
@@ -392,6 +456,9 @@ export function buildDirectorySummaries(params: {
     collapseWorkspaceSummaries({
       summaries: [...summaries.values()],
       threads: params.threads,
+      workspaceRoots: params.workspaceRoots
+        ?.map(normalizeComparablePath)
+        .filter((root): root is string => Boolean(root)),
     }),
     params.threads,
   ).sort((left, right) => left.label.localeCompare(right.label));

--- a/packages/agent-core/src/domain/navigation-state.ts
+++ b/packages/agent-core/src/domain/navigation-state.ts
@@ -196,6 +196,7 @@ export function buildNavigationSnapshot(params: {
   previousKnownThreadKeys: string[];
   threads: AppServerThreadSummaryWithEnvironmentOptions[];
   unchanged: boolean;
+  workspaceRoots?: string[];
 }): NavigationSnapshot {
   const threads = materializeNavigationThreads({
     firstSnapshot: params.firstSnapshot,
@@ -216,6 +217,7 @@ export function buildNavigationSnapshot(params: {
       threads,
       launchpadsByKey: params.launchpadsByKey,
       gitStatusByKey: params.gitStatusByDirectoryKey,
+      workspaceRoots: params.workspaceRoots,
     }),
     launchpadDefaults: params.launchpadDefaults ?? {
       backend: "codex",


### PR DESCRIPTION
## Summary

- I collapsed duplicate Workspaces rows so scratchpad roots render as one directory group instead of repeating the same label.
- I constrained workspace scratchpad grouping to the active PwrAgent profile, so another profile's `projects` directory no longer leaks into the current profile's Directories lens.
- I kept default-profile compatibility for both legacy scratch roots: `~/.pwragent/projects` and `~/.pwragnt/projects`, merging them into the active default Workspaces row instead of hiding old threads.

## Verification

- I ran `pnpm test packages/agent-core/src/__tests__/directory-navigation.test.ts`.
- I ran `pnpm test apps/desktop/src/main/__tests__/scratch-projects-root.test.ts`.
- I ran `pnpm test apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx`.
- I ran `pnpm --filter @pwragent/agent-core typecheck`.
- I ran `pnpm --filter @pwragent/desktop typecheck`.

## Notes

- The visible regression was multiple Workspaces sections in the Directories lens. The underlying cause was that workspace summaries did not know which scratch roots belonged to the active profile.
- The desktop navigation and messaging snapshot paths now pass the active workspace root allowlist into agent-core. Agent-core still collapses compatible workspace roots, but filters out profile-scoped roots outside the active profile.
