### PR TITLE
feat(desktop): add archived thread settings

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -409,6 +409,11 @@ describe("app server ipc", () => {
         expect.objectContaining({ source: "codex", id: "thread-1" }),
         expect.objectContaining({ source: "grok", id: "thread-1" }),
       ],
+      workspaceRoots: [
+        path.join(os.homedir(), ".pwragent", "profiles", "default", "projects"),
+        path.join(os.homedir(), ".pwragent", "projects"),
+        path.join(os.homedir(), ".pwragnt", "projects"),
+      ],
     });
   });
 
@@ -463,6 +468,11 @@ describe("app server ipc", () => {
             }),
           ],
         }),
+      ],
+      workspaceRoots: [
+        path.join(os.homedir(), ".pwragent", "profiles", "default", "projects"),
+        path.join(os.homedir(), ".pwragent", "projects"),
+        path.join(os.homedir(), ".pwragnt", "projects"),
       ],
     });
   });

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -214,6 +214,7 @@ const markThreadSeen = vi.fn(async (request: MarkThreadSeenRequest) => ({
   seenUpdatedAt: request.seenUpdatedAt,
 }));
 const getThreadOverlayState = vi.fn();
+const getThreadOverlayStates = vi.fn(async () => ({}));
 const setThreadPullRequests = vi.fn(async (request: {
   backend: "codex" | "grok";
   threadId: string;
@@ -256,6 +257,7 @@ vi.mock("../app-server/desktop-overlay-store", () => ({
     reconcileNavigationSnapshot,
     markThreadSeen,
     getThreadOverlayState,
+    getThreadOverlayStates,
     setThreadPullRequests,
     readDirectoryGitStatusCache,
     writeDirectoryGitStatusCacheEntry,
@@ -316,6 +318,8 @@ describe("app server ipc", () => {
     markThreadSeen.mockClear();
     getThreadOverlayState.mockReset();
     getThreadOverlayState.mockResolvedValue(undefined);
+    getThreadOverlayStates.mockReset();
+    getThreadOverlayStates.mockResolvedValue({});
     setThreadPullRequests.mockClear();
     isGhAvailable.mockClear();
     isGhAvailable.mockResolvedValue(true);
@@ -404,6 +408,61 @@ describe("app server ipc", () => {
       threads: [
         expect.objectContaining({ source: "codex", id: "thread-1" }),
         expect.objectContaining({ source: "grok", id: "thread-1" }),
+      ],
+    });
+  });
+
+  it("hydrates retained worktree snapshots when listing archived threads", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { APP_SERVER_LIST_THREADS_CHANNEL } = await import("../../shared/ipc");
+    getThreadOverlayStates.mockResolvedValue({
+      "thread-archived": {
+        backend: "codex",
+        threadId: "thread-archived",
+        executionMode: "default",
+        extraLinkedDirectories: [],
+        worktreeSnapshots: [
+          {
+            id: "snapshot-1",
+            backend: "codex",
+            threadId: "thread-archived",
+            worktreePath: "/Users/test/.codex/worktrees/mp7efuda/PwrSnap",
+            repositoryPath: "/Users/test/github/PwrSnap",
+            snapshotRef: "refs/codex/snapshots/snapshot-1",
+            snapshotCommit: "abc123",
+            createdAt: 1000,
+            archivedAt: 3000,
+            state: "archived",
+            ignoredFilesExcluded: true,
+          },
+        ],
+      },
+    });
+
+    registerAppServerIpcHandlers();
+
+    const response = await handlers.get(APP_SERVER_LIST_THREADS_CHANNEL)?.(
+      {},
+      { archived: true } satisfies AppServerListThreadsRequest,
+    );
+
+    expect(getThreadOverlayStates).toHaveBeenCalledWith({
+      backend: "codex",
+      threadIds: ["thread-archived"],
+    });
+    expect(response).toEqual({
+      backend: "all",
+      fetchedAt: expect.any(Number),
+      threads: [
+        expect.objectContaining({
+          id: "thread-archived",
+          worktreeSnapshots: [
+            expect.objectContaining({
+              repositoryPath: "/Users/test/github/PwrSnap",
+              worktreePath: "/Users/test/.codex/worktrees/mp7efuda/PwrSnap",
+            }),
+          ],
+        }),
       ],
     });
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -4830,6 +4830,87 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("restores deleted archived thread worktrees from retained metadata when no snapshot exists", async () => {
+    const archivedThread: AppServerThreadSummary = {
+      id: "thread-1",
+      title: "Archived worktree",
+      titleSource: "explicit",
+      linkedDirectories: [
+        {
+          id: "directory:/repo/PwrSnap",
+          label: "PwrSnap",
+          path: "/repo/PwrSnap",
+          kind: "worktree",
+          worktreePath: "/Users/test/.codex/worktrees/mp32wplq/PwrSnap",
+        },
+      ],
+      source: "codex",
+      gitBranch: "fix/float-over-hitbox",
+      updatedAt: 2,
+    };
+    const restoredSnapshot: WorktreeSnapshotSummary = {
+      id: "snapshot-1",
+      backend: "codex",
+      threadId: "thread-1",
+      worktreePath: "/Users/test/.codex/worktrees/mp32wplq/PwrSnap",
+      repositoryPath: "/repo/PwrSnap",
+      snapshotRef: "fix/float-over-hitbox",
+      snapshotCommit: "ecce5f83",
+      sourceBranch: "fix/float-over-hitbox",
+      createdAt: 2000,
+      restoredAt: 2000,
+      state: "restored",
+      ignoredFilesExcluded: true,
+      unavailableReason:
+        "Restored detached worktree from repository state because no archived snapshot was available.",
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/unarchive"] },
+      archivedThreads: [archivedThread],
+    });
+    const restoreDetached = vi.fn(async () => restoredSnapshot);
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      worktreeArchiveService: {
+        restoreDetached,
+      } as unknown as WorktreeArchiveService,
+    });
+
+    const response = await registry.restoreThread({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    expect(codexClient.lastListThreadsParams).toMatchObject({
+      archived: true,
+    });
+    expect(restoreDetached).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      worktreePath: "/Users/test/.codex/worktrees/mp32wplq/PwrSnap",
+      repositoryPath: "/repo/PwrSnap",
+      restoreRef: "fix/float-over-hitbox",
+    });
+    expect(response).toMatchObject({
+      backend: "codex",
+      threadId: "thread-1",
+      worktrees: [
+        {
+          worktreePath: "/Users/test/.codex/worktrees/mp32wplq/PwrSnap",
+          repositoryPath: "/repo/PwrSnap",
+          snapshotRef: "fix/float-over-hitbox",
+          restored: true,
+        },
+      ],
+    });
+
+    await registry.close();
+  });
+
   it("reports failed cleanup when a worktree directory remains after archive", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-registry-sentinel-"));
     const repoPath = path.join(root, "PwrAgnt");

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -548,6 +548,17 @@ class MockBackendClient {
     enrichDirectories?: boolean;
     filter?: string;
   };
+  listThreadsCalls: Array<{
+    diagnostics?: {
+      callerReason?: string;
+      ownerId?: string;
+    };
+    params?: {
+      archived?: boolean;
+      enrichDirectories?: boolean;
+      filter?: string;
+    };
+  }> = [];
 
   constructor(
     private readonly options: {
@@ -601,6 +612,7 @@ class MockBackendClient {
     this.listThreadsCallCount += 1;
     this.lastListThreadsDiagnostics = diagnostics;
     this.lastListThreadsParams = params;
+    this.listThreadsCalls.push({ diagnostics, params });
     if (this.options.listThreadsError) {
       throw this.options.listThreadsError;
     }
@@ -4885,7 +4897,7 @@ command = "pnpm dev"
       threadId: "thread-1",
     });
 
-    expect(codexClient.lastListThreadsParams).toMatchObject({
+    expect(codexClient.listThreadsCalls[0]?.params).toMatchObject({
       archived: true,
     });
     expect(restoreDetached).toHaveBeenCalledWith({
@@ -5292,6 +5304,48 @@ command = "pnpm dev"
     expect(messagingStore.revokedBindingIds).toEqual(["binding-telegram"]);
     expect(messagingStore.deletedPendingThreads).toEqual([
       { backend: "codex", threadId: "thread-1" },
+    ]);
+
+    await registry.close();
+  });
+
+  it("hides archived records for threads that are active again", async () => {
+    const restoredThread: AppServerThreadSummary = {
+      id: "thread-restored",
+      title: "Restored elsewhere",
+      titleSource: "explicit",
+      linkedDirectories: [],
+      source: "codex",
+      updatedAt: 2,
+    };
+    const stillArchivedThread: AppServerThreadSummary = {
+      id: "thread-archived",
+      title: "Still archived",
+      titleSource: "explicit",
+      linkedDirectories: [],
+      source: "codex",
+      updatedAt: 1,
+    };
+    const codexClient = new MockBackendClient({
+      archivedThreads: [restoredThread, stillArchivedThread],
+      initializeResult: { methods: ["thread/list", "thread/archive"] },
+      threads: [restoredThread],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await expect(
+      registry.listThreads({ backend: "codex", archived: true }),
+    ).resolves.toEqual([expect.objectContaining({ id: "thread-archived" })]);
+
+    expect(codexClient.listThreadsCalls.map((call) => call.params)).toEqual([
+      { archived: true, enrichDirectories: true },
+      { archived: false, enrichDirectories: false },
     ]);
 
     await registry.close();

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -4752,6 +4752,84 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("restores archived thread worktrees from retained snapshots", async () => {
+    const snapshot: WorktreeSnapshotSummary = {
+      id: "snapshot-1",
+      backend: "codex",
+      threadId: "thread-1",
+      worktreePath: "/repo/.worktrees/archive-me",
+      repositoryPath: "/repo/app",
+      snapshotRef: "refs/codex/snapshots/snapshot-1",
+      snapshotCommit: "abc123",
+      sourceBranch: "codex/archive-me",
+      sourceHead: "def456",
+      createdAt: 1000,
+      archivedAt: 1000,
+      state: "archived",
+      ignoredFilesExcluded: true,
+    };
+    const restoredSnapshot: WorktreeSnapshotSummary = {
+      ...snapshot,
+      restoredAt: 2000,
+      state: "restored",
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/unarchive"] },
+    });
+    const restoreWorktree = vi.fn(async () => restoredSnapshot);
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock({
+        overlays: {
+          "codex:thread-1": {
+            backend: "codex",
+            threadId: "thread-1",
+            executionMode: "default",
+            extraLinkedDirectories: [],
+            worktreeSnapshots: [snapshot],
+          },
+        },
+      }),
+      worktreeArchiveService: {
+        restore: restoreWorktree,
+      } as unknown as WorktreeArchiveService,
+    });
+
+    const response = await registry.restoreThread({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    expect(restoreWorktree).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      worktreePath: "/repo/.worktrees/archive-me",
+      repositoryPath: "/repo/app",
+      snapshotRef: "refs/codex/snapshots/snapshot-1",
+      snapshotCommit: "abc123",
+      snapshot,
+      allowDetachedFallback: true,
+    });
+    expect(response).toMatchObject({
+      backend: "codex",
+      threadId: "thread-1",
+      worktrees: [
+        {
+          worktreePath: "/repo/.worktrees/archive-me",
+          repositoryPath: "/repo/app",
+          snapshotRef: "refs/codex/snapshots/snapshot-1",
+          restored: true,
+          snapshot: restoredSnapshot,
+        },
+      ],
+    });
+
+    await registry.close();
+  });
+
   it("reports failed cleanup when a worktree directory remains after archive", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-registry-sentinel-"));
     const repoPath = path.join(root, "PwrAgnt");
@@ -6120,6 +6198,7 @@ command = "pnpm dev"
       backend: "codex",
       threadId: "thread-1",
       restoredAt: expect.any(Number),
+      worktrees: [],
     });
 
     await expect(
@@ -6131,6 +6210,7 @@ command = "pnpm dev"
       backend: "grok",
       threadId: "thread-2",
       restoredAt: expect.any(Number),
+      worktrees: [],
     });
 
     expect(codexClient.lastRestoreThreadParams).toEqual({ threadId: "thread-1" });

--- a/apps/desktop/src/main/__tests__/grok-app-server-client.test.ts
+++ b/apps/desktop/src/main/__tests__/grok-app-server-client.test.ts
@@ -974,6 +974,54 @@ describe("GrokAppServerClient", () => {
     await client.close();
   });
 
+  it("parses Grok archived timestamps from archived thread summaries", async () => {
+    const server = {
+      request: async (method: string): Promise<unknown> => {
+        if (method === "initialize") {
+          return {
+            serverInfo: { name: "@pwragent/grok-app-server", version: "1.0.0" },
+            methods: ["thread/list"],
+          };
+        }
+        if (method === "thread/list") {
+          return {
+            threads: [
+              {
+                id: "thread-snake",
+                title: "Snake timestamp",
+                archived_at: "2026-05-16T23:00:00.000Z",
+                updatedAt: 1000,
+              },
+              {
+                threadId: "thread-camel",
+                title: "Camel timestamp",
+                archivedAt: 2000,
+                updatedAt: 500,
+              },
+            ],
+          };
+        }
+        throw new Error(`Unexpected request ${method}`);
+      },
+      notify: async () => undefined,
+      onNotification: () => () => undefined,
+    };
+    const client = new GrokAppServerClient({ server });
+
+    await expect(client.listThreads({ archived: true })).resolves.toMatchObject([
+      {
+        id: "thread-snake",
+        archivedAt: Date.parse("2026-05-16T23:00:00.000Z"),
+      },
+      {
+        id: "thread-camel",
+        archivedAt: 2000,
+      },
+    ]);
+
+    await client.close();
+  });
+
   it("renames Grok threads through the app-server contract", async () => {
     const server = new CodexAppServer({
       provider: new FakeProvider(),

--- a/apps/desktop/src/main/__tests__/worktree-archive-service.test.ts
+++ b/apps/desktop/src/main/__tests__/worktree-archive-service.test.ts
@@ -163,4 +163,39 @@ describe("WorktreeArchiveService", () => {
     );
     expect(await git(worktreePath, ["rev-parse", "--abbrev-ref", "HEAD"])).toBe("HEAD");
   });
+
+  it("restores a detached worktree from an existing branch when no archive snapshot exists", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-worktree-archive-"));
+    const repoPath = path.join(root, "repo");
+    const worktreePath = path.join(root, "restored-worktree");
+    await mkdir(repoPath);
+    await git(repoPath, ["init", "-b", "main"]);
+    await git(repoPath, ["config", "user.email", "test@example.com"]);
+    await git(repoPath, ["config", "user.name", "Test User"]);
+    await writeFile(path.join(repoPath, "README.md"), "base\n", "utf8");
+    await git(repoPath, ["add", "."]);
+    await git(repoPath, ["commit", "-m", "initial"]);
+    await git(repoPath, ["switch", "-c", "fix/float-over-hitbox"]);
+    await writeFile(path.join(repoPath, "README.md"), "branch work\n", "utf8");
+    await git(repoPath, ["commit", "-am", "branch work"]);
+    const branchCommit = await git(repoPath, ["rev-parse", "fix/float-over-hitbox"]);
+
+    const service = new WorktreeArchiveService();
+    const restored = await service.restoreDetached({
+      backend: "codex",
+      threadId: "thread-1",
+      worktreePath,
+      repositoryPath: repoPath,
+      restoreRef: "fix/float-over-hitbox",
+      now: 2000,
+    });
+
+    expect(restored.state).toBe("restored");
+    expect(restored.snapshotRef).toBe("fix/float-over-hitbox");
+    expect(restored.snapshotCommit).toBe(branchCommit);
+    await expect(readFile(path.join(worktreePath, "README.md"), "utf8")).resolves.toBe(
+      "branch work\n",
+    );
+    expect(await git(worktreePath, ["rev-parse", "--abbrev-ref", "HEAD"])).toBe("HEAD");
+  });
 });

--- a/apps/desktop/src/main/__tests__/worktree-archive-service.test.ts
+++ b/apps/desktop/src/main/__tests__/worktree-archive-service.test.ts
@@ -118,4 +118,49 @@ describe("WorktreeArchiveService", () => {
     expect(snapshot.repositoryPath).toBe(await realpath(repoPath));
     expect(await pathExists(worktreePath)).toBe(false);
   });
+
+  it("restores a detached worktree from the retained snapshot commit when the snapshot ref is missing", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-worktree-archive-"));
+    const repoPath = path.join(root, "repo");
+    const worktreePath = path.join(root, "repo-feature");
+    await mkdir(repoPath);
+    await git(repoPath, ["init", "-b", "main"]);
+    await git(repoPath, ["config", "user.email", "test@example.com"]);
+    await git(repoPath, ["config", "user.name", "Test User"]);
+    await writeFile(path.join(repoPath, "README.md"), "base\n", "utf8");
+    await git(repoPath, ["add", "."]);
+    await git(repoPath, ["commit", "-m", "initial"]);
+    await git(repoPath, ["worktree", "add", "-b", "feature/archive", worktreePath, "main"]);
+    await writeFile(path.join(worktreePath, "README.md"), "snapshot contents\n", "utf8");
+
+    const service = new WorktreeArchiveService();
+    const snapshot = await service.archive({
+      backend: "codex",
+      threadId: "thread-1",
+      worktreePath,
+      repositoryPath: repoPath,
+      now: 1000,
+    });
+    await git(repoPath, ["update-ref", "-d", snapshot.snapshotRef]);
+
+    const restored = await service.restore({
+      backend: "codex",
+      threadId: "thread-1",
+      worktreePath,
+      repositoryPath: repoPath,
+      snapshotRef: snapshot.snapshotRef,
+      snapshotCommit: snapshot.snapshotCommit,
+      snapshot,
+      allowDetachedFallback: true,
+      now: 2000,
+    });
+
+    expect(restored.state).toBe("restored");
+    expect(restored.snapshotCommit).toBe(snapshot.snapshotCommit);
+    expect(restored.unavailableReason).toContain("retained snapshot commit");
+    await expect(readFile(path.join(worktreePath, "README.md"), "utf8")).resolves.toBe(
+      "snapshot contents\n",
+    );
+    expect(await git(worktreePath, ["rev-parse", "--abbrev-ref", "HEAD"])).toBe("HEAD");
+  });
 });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -61,6 +61,7 @@ import {
   type RestoreWorktreeResponse,
   type RestoreThreadRequest,
   type RestoreThreadResponse,
+  type RestoreThreadWorktreeResult,
   type SetThreadExecutionModeRequest,
   type SetThreadExecutionModeResponse,
   type SetThreadModelSettingsRequest,
@@ -1956,11 +1957,16 @@ export class DesktopBackendRegistry {
       backend,
       threadId: result.threadId,
     });
+    const worktrees = await this.restoreThreadWorktrees({
+      backend,
+      threadId: result.threadId,
+    });
 
     return {
       backend,
       threadId: result.threadId,
       restoredAt: Date.now(),
+      worktrees,
     };
   }
 
@@ -5305,6 +5311,90 @@ export class DesktopBackendRegistry {
           };
         }
       }),
+    );
+  }
+
+  private async restoreThreadWorktrees(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): Promise<RestoreThreadWorktreeResult[]> {
+    const overlay = await this.overlayStore.getThreadOverlayState({
+      backend: params.backend,
+      threadId: params.threadId,
+    });
+    const snapshots = [...(overlay?.worktreeSnapshots ?? [])]
+      .filter((snapshot) => snapshot.state !== "present")
+      .sort(
+        (left, right) =>
+          (right.archivedAt ?? right.restoredAt ?? right.createdAt) -
+          (left.archivedAt ?? left.restoredAt ?? left.createdAt),
+      );
+    const seenWorktreePaths = new Set<string>();
+    const uniqueSnapshots = snapshots.filter((snapshot) => {
+      const resolvedPath = path.resolve(snapshot.worktreePath);
+      if (seenWorktreePaths.has(resolvedPath)) {
+        return false;
+      }
+      seenWorktreePaths.add(resolvedPath);
+      return true;
+    });
+
+    return await Promise.all(
+      uniqueSnapshots.map(
+        async (snapshot): Promise<RestoreThreadWorktreeResult> => {
+          try {
+            if (await pathExists(snapshot.worktreePath)) {
+              return {
+                worktreePath: snapshot.worktreePath,
+                repositoryPath: snapshot.repositoryPath,
+                snapshotRef: snapshot.snapshotRef,
+                restored: false,
+                skippedReason: "Worktree path already exists.",
+              };
+            }
+
+            const restoredSnapshot = await this.worktreeArchiveService.restore({
+              backend: params.backend,
+              threadId: params.threadId,
+              worktreePath: snapshot.worktreePath,
+              repositoryPath: snapshot.repositoryPath,
+              snapshotRef: snapshot.snapshotRef,
+              snapshotCommit: snapshot.snapshotCommit,
+              snapshot,
+              allowDetachedFallback: true,
+            });
+            await this.overlayStore.upsertWorktreeSnapshot({
+              backend: params.backend,
+              threadId: params.threadId,
+              snapshot: restoredSnapshot,
+            });
+
+            return {
+              worktreePath: restoredSnapshot.worktreePath,
+              repositoryPath: restoredSnapshot.repositoryPath,
+              snapshotRef: restoredSnapshot.snapshotRef,
+              restored: true,
+              snapshot: restoredSnapshot,
+            };
+          } catch (error) {
+            backendRegistryLog.warn("restore thread worktree restore failed", {
+              backend: params.backend,
+              threadId: params.threadId,
+              repositoryPath: snapshot.repositoryPath,
+              worktreePath: snapshot.worktreePath,
+              snapshotRef: snapshot.snapshotRef,
+              error: error instanceof Error ? error.message : String(error),
+            });
+            return {
+              worktreePath: snapshot.worktreePath,
+              repositoryPath: snapshot.repositoryPath,
+              snapshotRef: snapshot.snapshotRef,
+              restored: false,
+              error: error instanceof Error ? error.message : String(error),
+            };
+          }
+        },
+      ),
     );
   }
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1804,11 +1804,17 @@ export class DesktopBackendRegistry {
       ownerId: this.threadListCacheOwnerId,
     };
     if (params.backend === "codex") {
-      const threads = await this.listCodexThreads({
+      const threads = await this.filterArchivedThreadsPresentInActiveList({
         archived: params.archived,
-        enrichDirectories: params.enrichDirectories,
+        backend: "codex",
+        diagnostics,
         filter: params.filter,
-      }, diagnostics);
+        threads: await this.listCodexThreads({
+          archived: params.archived,
+          enrichDirectories: params.enrichDirectories,
+          filter: params.filter,
+        }, diagnostics),
+      });
       this.scheduleThreadListArchiveStateCleanup({
         backend: "codex",
         filter: params.filter,
@@ -1819,14 +1825,20 @@ export class DesktopBackendRegistry {
     }
 
     if (params.backend === "grok") {
-      const threads = this.withPendingStartedThreads(
-        "grok",
-        await this.grokClient.listThreads({
-          archived: params.archived,
-          filter: params.filter,
-        }, diagnostics),
-        params,
-      );
+      const threads = await this.filterArchivedThreadsPresentInActiveList({
+        archived: params.archived,
+        backend: "grok",
+        diagnostics,
+        filter: params.filter,
+        threads: this.withPendingStartedThreads(
+          "grok",
+          await this.grokClient.listThreads({
+            archived: params.archived,
+            filter: params.filter,
+          }, diagnostics),
+          params,
+        ),
+      });
       this.scheduleThreadListArchiveStateCleanup({
         backend: "grok",
         filter: params.filter,
@@ -1856,6 +1868,67 @@ export class DesktopBackendRegistry {
     return threadLists
       .flat()
       .sort((left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0));
+  }
+
+  private async filterArchivedThreadsPresentInActiveList(params: {
+    archived?: boolean;
+    backend: AppServerBackendKind;
+    diagnostics: {
+      callerReason: ThreadListCallerReason;
+      ownerId: string;
+    };
+    filter?: string;
+    threads: AppServerThreadSummary[];
+  }): Promise<AppServerThreadSummary[]> {
+    if (params.archived !== true || params.threads.length === 0) {
+      return params.threads;
+    }
+
+    try {
+      const activeThreads =
+        params.backend === "codex"
+          ? await this.listCodexThreads({
+              archived: false,
+              enrichDirectories: false,
+              filter: params.filter,
+            }, {
+              ...params.diagnostics,
+              callerReason: `${params.diagnostics.callerReason}:active-archive-filter`,
+            })
+          : this.withPendingStartedThreads(
+              "grok",
+              await this.grokClient.listThreads({
+                archived: false,
+                filter: params.filter,
+              }, {
+                ...params.diagnostics,
+                callerReason: `${params.diagnostics.callerReason}:active-archive-filter`,
+              }),
+              { archived: false, filter: params.filter },
+            );
+      const activeThreadIds = new Set(activeThreads.map((thread) => thread.id));
+      const filteredThreads = params.threads.filter(
+        (thread) => !activeThreadIds.has(thread.id),
+      );
+      const filteredCount = params.threads.length - filteredThreads.length;
+      if (filteredCount > 0) {
+        backendRegistryLog.info("archived thread list filtered active duplicates", {
+          backend: params.backend,
+          filteredCount,
+          threadIds: params.threads
+            .filter((thread) => activeThreadIds.has(thread.id))
+            .slice(0, 10)
+            .map((thread) => thread.id),
+        });
+      }
+      return filteredThreads;
+    } catch (error) {
+      backendRegistryLog.warn("archived thread active-state filter failed", {
+        backend: params.backend,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return params.threads;
+    }
   }
 
   async listSkills(params: {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -82,6 +82,7 @@ import {
   type SubmitServerRequestResponse,
   type ThreadExecutionMode,
   type ThreadOverlayState,
+  type WorktreeSnapshotSummary,
   type UpdateDirectoryLaunchpadRequest,
   type UpdateDirectoryLaunchpadResponse,
   type UpdateThreadExpectedBranchRequest,
@@ -637,6 +638,13 @@ type ThreadTitleGenerationLogStatus =
 
 type WorktreeArchiveCandidate = {
   repositoryPath: string;
+  worktreePath: string;
+};
+
+type WorktreeRestoreCandidate = {
+  branch?: string;
+  repositoryPath?: string;
+  snapshot?: WorktreeSnapshotSummary;
   worktreePath: string;
 };
 
@@ -1946,6 +1954,10 @@ export class DesktopBackendRegistry {
     request: RestoreThreadRequest,
   ): Promise<RestoreThreadResponse> {
     const backend = request.backend ?? "codex";
+    const archivedThread = await this.findThreadForRestoreWorktrees({
+      backend,
+      threadId: request.threadId,
+    });
     const result =
       backend === "codex"
         ? await this.withCodexThreadClient(request.threadId, async (client) =>
@@ -1960,6 +1972,7 @@ export class DesktopBackendRegistry {
     const worktrees = await this.restoreThreadWorktrees({
       backend,
       threadId: result.threadId,
+      thread: archivedThread,
     });
 
     return {
@@ -5077,6 +5090,26 @@ export class DesktopBackendRegistry {
     throw new Error("Thread metadata was not found.");
   }
 
+  private async findThreadForRestoreWorktrees(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): Promise<AppServerThreadSummary | undefined> {
+    return await this.listThreads({
+      backend: params.backend,
+      archived: true,
+      callerReason: "thread-restore-worktrees",
+    })
+      .then((threads) => threads.find((thread) => thread.id === params.threadId))
+      .catch((error) => {
+        backendRegistryLog.warn("restore thread worktree metadata lookup failed", {
+          backend: params.backend,
+          threadId: params.threadId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return undefined;
+      });
+  }
+
   private async findThreadForWorkspaceHandoff(params: {
     backend: AppServerBackendKind;
     callerReason?: ThreadListCallerReason;
@@ -5317,52 +5350,59 @@ export class DesktopBackendRegistry {
   private async restoreThreadWorktrees(params: {
     backend: AppServerBackendKind;
     threadId: string;
+    thread?: AppServerThreadSummary;
   }): Promise<RestoreThreadWorktreeResult[]> {
     const overlay = await this.overlayStore.getThreadOverlayState({
       backend: params.backend,
       threadId: params.threadId,
     });
-    const snapshots = [...(overlay?.worktreeSnapshots ?? [])]
-      .filter((snapshot) => snapshot.state !== "present")
-      .sort(
-        (left, right) =>
-          (right.archivedAt ?? right.restoredAt ?? right.createdAt) -
-          (left.archivedAt ?? left.restoredAt ?? left.createdAt),
-      );
-    const seenWorktreePaths = new Set<string>();
-    const uniqueSnapshots = snapshots.filter((snapshot) => {
-      const resolvedPath = path.resolve(snapshot.worktreePath);
-      if (seenWorktreePaths.has(resolvedPath)) {
-        return false;
-      }
-      seenWorktreePaths.add(resolvedPath);
-      return true;
+    const candidates = this.buildRestoreThreadWorktreeCandidates({
+      overlay,
+      thread: params.thread,
     });
 
     return await Promise.all(
-      uniqueSnapshots.map(
-        async (snapshot): Promise<RestoreThreadWorktreeResult> => {
+      candidates.map(
+        async (candidate): Promise<RestoreThreadWorktreeResult> => {
           try {
-            if (await pathExists(snapshot.worktreePath)) {
+            if (await pathExists(candidate.worktreePath)) {
               return {
-                worktreePath: snapshot.worktreePath,
-                repositoryPath: snapshot.repositoryPath,
-                snapshotRef: snapshot.snapshotRef,
+                worktreePath: candidate.worktreePath,
+                repositoryPath: candidate.repositoryPath,
+                snapshotRef: candidate.snapshot?.snapshotRef,
                 restored: false,
                 skippedReason: "Worktree path already exists.",
               };
             }
 
-            const restoredSnapshot = await this.worktreeArchiveService.restore({
-              backend: params.backend,
-              threadId: params.threadId,
-              worktreePath: snapshot.worktreePath,
-              repositoryPath: snapshot.repositoryPath,
-              snapshotRef: snapshot.snapshotRef,
-              snapshotCommit: snapshot.snapshotCommit,
-              snapshot,
-              allowDetachedFallback: true,
-            });
+            if (!candidate.repositoryPath) {
+              return {
+                worktreePath: candidate.worktreePath,
+                snapshotRef: candidate.snapshot?.snapshotRef,
+                restored: false,
+                skippedReason:
+                  "Repository path is unavailable for this archived worktree.",
+              };
+            }
+
+            const restoredSnapshot = candidate.snapshot
+              ? await this.worktreeArchiveService.restore({
+                  backend: params.backend,
+                  threadId: params.threadId,
+                  worktreePath: candidate.worktreePath,
+                  repositoryPath: candidate.repositoryPath,
+                  snapshotRef: candidate.snapshot.snapshotRef,
+                  snapshotCommit: candidate.snapshot.snapshotCommit,
+                  snapshot: candidate.snapshot,
+                  allowDetachedFallback: true,
+                })
+              : await this.worktreeArchiveService.restoreDetached({
+                  backend: params.backend,
+                  threadId: params.threadId,
+                  worktreePath: candidate.worktreePath,
+                  repositoryPath: candidate.repositoryPath,
+                  restoreRef: candidate.branch,
+                });
             await this.overlayStore.upsertWorktreeSnapshot({
               backend: params.backend,
               threadId: params.threadId,
@@ -5380,15 +5420,15 @@ export class DesktopBackendRegistry {
             backendRegistryLog.warn("restore thread worktree restore failed", {
               backend: params.backend,
               threadId: params.threadId,
-              repositoryPath: snapshot.repositoryPath,
-              worktreePath: snapshot.worktreePath,
-              snapshotRef: snapshot.snapshotRef,
+              repositoryPath: candidate.repositoryPath,
+              worktreePath: candidate.worktreePath,
+              snapshotRef: candidate.snapshot?.snapshotRef,
               error: error instanceof Error ? error.message : String(error),
             });
             return {
-              worktreePath: snapshot.worktreePath,
-              repositoryPath: snapshot.repositoryPath,
-              snapshotRef: snapshot.snapshotRef,
+              worktreePath: candidate.worktreePath,
+              repositoryPath: candidate.repositoryPath,
+              snapshotRef: candidate.snapshot?.snapshotRef,
               restored: false,
               error: error instanceof Error ? error.message : String(error),
             };
@@ -5396,6 +5436,76 @@ export class DesktopBackendRegistry {
         },
       ),
     );
+  }
+
+  private buildRestoreThreadWorktreeCandidates(params: {
+    overlay?: ThreadOverlayState;
+    thread?: AppServerThreadSummary;
+  }): WorktreeRestoreCandidate[] {
+    const snapshotCandidates: WorktreeRestoreCandidate[] = [
+      ...(params.overlay?.worktreeSnapshots ?? []),
+    ]
+      .filter((snapshot) => snapshot.state !== "present")
+      .sort(
+        (left, right) =>
+          (right.archivedAt ?? right.restoredAt ?? right.createdAt) -
+          (left.archivedAt ?? left.restoredAt ?? left.createdAt),
+      )
+      .map((snapshot) => ({
+        repositoryPath: snapshot.repositoryPath,
+        snapshot,
+        worktreePath: snapshot.worktreePath,
+      }));
+    const metadataCandidates = this.buildRestoreThreadMetadataCandidates(
+      params.thread,
+      snapshotCandidates,
+    );
+    const seenWorktreePaths = new Set<string>();
+    return [...snapshotCandidates, ...metadataCandidates].filter((candidate) => {
+      const resolvedPath = path.resolve(candidate.worktreePath);
+      if (seenWorktreePaths.has(resolvedPath)) {
+        return false;
+      }
+      seenWorktreePaths.add(resolvedPath);
+      return true;
+    });
+  }
+
+  private buildRestoreThreadMetadataCandidates(
+    thread: AppServerThreadSummary | undefined,
+    snapshotCandidates: WorktreeRestoreCandidate[],
+  ): WorktreeRestoreCandidate[] {
+    if (!thread) {
+      return [];
+    }
+
+    const fallbackRepositoryPath = snapshotCandidates.find(
+      (candidate) => candidate.repositoryPath?.trim(),
+    )?.repositoryPath;
+    const branch = thread.observedGitBranch ?? thread.gitBranch;
+
+    return thread.linkedDirectories.flatMap((directory): WorktreeRestoreCandidate[] => {
+      const worktreePath =
+        directory.worktreePath ?? (directory.kind === "worktree" ? directory.path : undefined);
+      if (!worktreePath?.trim()) {
+        return [];
+      }
+
+      const repositoryPath =
+        directory.path.trim() &&
+        !isToolManagedWorktreePath(directory.path) &&
+        path.resolve(directory.path) !== path.resolve(worktreePath)
+          ? directory.path
+          : fallbackRepositoryPath;
+
+      return [
+        {
+          branch,
+          repositoryPath,
+          worktreePath,
+        },
+      ];
+    });
   }
 
   private async restoreWithClient(

--- a/apps/desktop/src/main/app-server/worktree-archive-service.ts
+++ b/apps/desktop/src/main/app-server/worktree-archive-service.ts
@@ -43,6 +43,15 @@ type RestoreWorktreeParams = {
   now?: number;
 };
 
+type RestoreDetachedWorktreeParams = {
+  backend: AppServerBackendKind;
+  threadId: string;
+  worktreePath: string;
+  repositoryPath: string;
+  restoreRef?: string;
+  now?: number;
+};
+
 type WorktreeArchiveServiceOptions = {
   gitEnv?: NodeJS.ProcessEnv;
 };
@@ -230,6 +239,45 @@ export class WorktreeArchiveService {
       restoredAt,
       state: "restored",
       unavailableReason: fallbackReason,
+    };
+  }
+
+  async restoreDetached(
+    params: RestoreDetachedWorktreeParams,
+  ): Promise<WorktreeSnapshotSummary> {
+    const worktreePath = path.resolve(params.worktreePath);
+    const repositoryPath = path.resolve(params.repositoryPath);
+    const restoreRef = params.restoreRef?.trim() || "HEAD";
+    const snapshotCommit = trimGitOutput(
+      (await this.runGit(repositoryPath, ["rev-parse", `${restoreRef}^{commit}`]))
+        .stdout,
+    );
+
+    await mkdir(path.dirname(worktreePath), { recursive: true });
+    await this.runGit(repositoryPath, [
+      "worktree",
+      "add",
+      "--detach",
+      worktreePath,
+      snapshotCommit,
+    ]);
+
+    const restoredAt = params.now ?? Date.now();
+    return {
+      id: snapshotIdForPath(worktreePath),
+      backend: params.backend,
+      threadId: params.threadId,
+      worktreePath,
+      repositoryPath,
+      snapshotRef: restoreRef,
+      snapshotCommit,
+      sourceBranch: restoreRef === "HEAD" ? undefined : restoreRef,
+      createdAt: restoredAt,
+      restoredAt,
+      state: "restored",
+      ignoredFilesExcluded: true,
+      unavailableReason:
+        "Restored detached worktree from repository state because no archived snapshot was available.",
     };
   }
 

--- a/apps/desktop/src/main/app-server/worktree-archive-service.ts
+++ b/apps/desktop/src/main/app-server/worktree-archive-service.ts
@@ -39,6 +39,7 @@ type RestoreWorktreeParams = {
   snapshotRef: string;
   snapshotCommit: string;
   snapshot?: WorktreeSnapshotSummary;
+  allowDetachedFallback?: boolean;
   now?: number;
 };
 
@@ -195,19 +196,8 @@ export class WorktreeArchiveService {
   async restore(params: RestoreWorktreeParams): Promise<WorktreeSnapshotSummary> {
     const worktreePath = path.resolve(params.worktreePath);
     const repositoryPath = path.resolve(params.repositoryPath);
-    const snapshotCommit = trimGitOutput(
-      (await this.runGit(repositoryPath, [
-        "rev-parse",
-        `${params.snapshotRef}^{commit}`,
-      ]))
-        .stdout,
-    );
-
-    if (snapshotCommit !== params.snapshotCommit) {
-      throw new Error(
-        `Snapshot ref ${params.snapshotRef} points at ${snapshotCommit}, expected ${params.snapshotCommit}.`,
-      );
-    }
+    const { commit: restoreCommit, fallbackReason } =
+      await this.resolveRestoreCommit(params);
 
     await mkdir(path.dirname(worktreePath), { recursive: true });
     await this.runGit(repositoryPath, [
@@ -215,7 +205,7 @@ export class WorktreeArchiveService {
       "add",
       "--detach",
       worktreePath,
-      snapshotCommit,
+      restoreCommit,
     ]);
 
     const restoredAt = params.now ?? Date.now();
@@ -227,7 +217,7 @@ export class WorktreeArchiveService {
         worktreePath,
         repositoryPath,
         snapshotRef: params.snapshotRef,
-        snapshotCommit,
+        snapshotCommit: restoreCommit,
         createdAt: restoredAt,
         ignoredFilesExcluded: true,
       }),
@@ -236,11 +226,84 @@ export class WorktreeArchiveService {
       worktreePath,
       repositoryPath,
       snapshotRef: params.snapshotRef,
-      snapshotCommit,
+      snapshotCommit: restoreCommit,
       restoredAt,
       state: "restored",
-      unavailableReason: undefined,
+      unavailableReason: fallbackReason,
     };
+  }
+
+  private async resolveRestoreCommit(
+    params: RestoreWorktreeParams,
+  ): Promise<{ commit: string; fallbackReason?: string }> {
+    try {
+      const snapshotCommit = trimGitOutput(
+        (await this.runGit(params.repositoryPath, [
+          "rev-parse",
+          `${params.snapshotRef}^{commit}`,
+        ]))
+          .stdout,
+      );
+
+      if (snapshotCommit === params.snapshotCommit) {
+        return { commit: snapshotCommit };
+      }
+
+      const mismatch = `Snapshot ref ${params.snapshotRef} points at ${snapshotCommit}, expected ${params.snapshotCommit}.`;
+      if (!params.allowDetachedFallback) {
+        throw new Error(mismatch);
+      }
+      return await this.resolveDetachedFallbackCommit(params, mismatch);
+    } catch (error) {
+      if (!params.allowDetachedFallback) {
+        throw error;
+      }
+      const reason = error instanceof Error ? error.message : String(error);
+      return await this.resolveDetachedFallbackCommit(params, reason);
+    }
+  }
+
+  private async resolveDetachedFallbackCommit(
+    params: RestoreWorktreeParams,
+    reason: string,
+  ): Promise<{ commit: string; fallbackReason: string }> {
+    const fallbackCandidates = [
+      {
+        label: "retained snapshot commit",
+        value: params.snapshotCommit,
+      },
+      {
+        label: "source HEAD",
+        value: params.snapshot?.sourceHead,
+      },
+      {
+        label: "repository HEAD",
+        value: "HEAD",
+      },
+    ];
+
+    for (const candidate of fallbackCandidates) {
+      if (!candidate.value) {
+        continue;
+      }
+
+      try {
+        const commit = trimGitOutput(
+          (await this.runGit(params.repositoryPath, [
+            "rev-parse",
+            `${candidate.value}^{commit}`,
+          ])).stdout,
+        );
+        return {
+          commit,
+          fallbackReason: `${reason} Restored detached worktree from ${candidate.label}.`,
+        };
+      } catch {
+        // Try the next retained identity before giving up.
+      }
+    }
+
+    throw new Error(`${reason} No detached fallback commit is available.`);
   }
 
   private async createSnapshotCommit(params: {

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -2979,6 +2979,10 @@ function extractThreadsFromValue(value: unknown): RawCodexThreadSummary[] {
         pickNumber(record, ["updatedAt", "updated_at", "lastActivityAt", "createdAt"]) ??
           pickNumber(sessionRecord ?? {}, ["updatedAt", "updated_at", "lastActivityAt"])
       ),
+      archivedAt: normalizeEpochTimestamp(
+        pickNumber(record, ["archivedAt", "archived_at"]) ??
+          pickNumber(sessionRecord ?? {}, ["archivedAt", "archived_at"])
+      ),
       gitBranch:
         pickString(gitInfoRecord ?? {}, ["branch"]) ??
         pickString(asRecord(sessionRecord?.gitInfo) ?? {}, ["branch"]) ??

--- a/apps/desktop/src/main/grok-app-server/client.ts
+++ b/apps/desktop/src/main/grok-app-server/client.ts
@@ -152,6 +152,25 @@ function readString(
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
+function readTimestamp(
+  record: Record<string, unknown>,
+  ...keys: string[]
+): number | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+    if (typeof value === "string" && value.trim()) {
+      const parsed = Date.parse(value);
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+  }
+  return undefined;
+}
+
 function normalizeThreadStatus(value: string | undefined): AppServerThreadStatus | undefined {
   const normalized = value?.trim().replace(/[-_\s]/g, "").toLowerCase();
   if (normalized === "active") {
@@ -257,6 +276,7 @@ function extractThreadSummaryList(value: unknown): RawThreadSummary[] {
             typeof record.createdAt === "number" ? record.createdAt : undefined,
           updatedAt:
             typeof record.updatedAt === "number" ? record.updatedAt : undefined,
+          archivedAt: readTimestamp(record, "archivedAt", "archived_at"),
         },
       ];
     })

--- a/apps/desktop/src/main/grok-app-server/client.ts
+++ b/apps/desktop/src/main/grok-app-server/client.ts
@@ -92,6 +92,7 @@ type RawThreadSummary = {
   fastMode?: boolean;
   createdAt?: number;
   updatedAt?: number;
+  archivedAt?: number;
 };
 
 type SkillCatalogEntry = {
@@ -831,6 +832,7 @@ export class GrokAppServerClient {
           ...(thread.projectKey ? { projectKey: thread.projectKey } : {}),
           createdAt: thread.createdAt,
           updatedAt: thread.updatedAt,
+          archivedAt: thread.archivedAt,
           model: thread.model,
           serviceTier: thread.serviceTier,
           reasoningEffort: thread.reasoningEffort,

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -8,6 +8,7 @@ import type {
   AgentEvent,
   AppServerBackendKind,
   AppServerBackendScope,
+  AppServerThreadSummary,
   ArchiveWorktreeRequest,
   ArchiveWorktreeResponse,
   ArchiveThreadRequest,
@@ -57,6 +58,7 @@ import type {
   RestoreWorktreeResponse,
   RestoreThreadRequest,
   RestoreThreadResponse,
+  ThreadOverlayState,
   UpdateDirectoryLaunchpadRequest,
   UpdateDirectoryLaunchpadResponse,
 } from "@pwragent/shared";
@@ -144,6 +146,53 @@ function logDebug(event: string, payload: Record<string, unknown>): void {
   }
 
   appServerLog.info(event, payload);
+}
+
+async function hydrateRetainedThreadOverlayData(
+  overlayStore: OverlayStoreLike,
+  threads: AppServerThreadSummary[],
+): Promise<AppServerThreadSummary[]> {
+  if (threads.length === 0) {
+    return threads;
+  }
+
+  const threadIdsByBackend = new Map<AppServerBackendKind, Set<string>>();
+  for (const thread of threads) {
+    const threadIds = threadIdsByBackend.get(thread.source) ?? new Set<string>();
+    threadIds.add(thread.id);
+    threadIdsByBackend.set(thread.source, threadIds);
+  }
+
+  const overlayEntries: Array<
+    readonly [AppServerBackendKind, Record<string, ThreadOverlayState | undefined>]
+  > = await Promise.all(
+    [...threadIdsByBackend.entries()].map(
+      async ([backend, threadIds]): Promise<
+        readonly [
+          AppServerBackendKind,
+          Record<string, ThreadOverlayState | undefined>,
+        ]
+      > => [
+        backend,
+        await overlayStore.getThreadOverlayStates({
+          backend,
+          threadIds: [...threadIds],
+        }),
+      ],
+    ),
+  );
+  const overlaysByBackend = new Map(overlayEntries);
+
+  return threads.map((thread) => {
+    const overlay = overlaysByBackend.get(thread.source)?.[thread.id];
+    if (!overlay?.worktreeSnapshots?.length) {
+      return thread;
+    }
+    return {
+      ...thread,
+      worktreeSnapshots: overlay.worktreeSnapshots,
+    };
+  });
 }
 
 function directoryStatusesEqual(
@@ -276,17 +325,21 @@ class DesktopAppServerService {
       callerReason: "ipc-list-threads",
       filter: request.filter,
     });
+    const hydratedThreads = await hydrateRetainedThreadOverlayData(
+      this.getOverlayStore(),
+      threads,
+    );
 
     logDebug("listThreads", {
       backend: backend ?? "all",
-      count: threads.length,
-      threadIds: threads.slice(0, 5).map((thread) => thread.id),
+      count: hydratedThreads.length,
+      threadIds: hydratedThreads.slice(0, 5).map((thread) => thread.id),
     });
 
     return {
       backend: backend ?? "all",
       fetchedAt: Date.now(),
-      threads,
+      threads: hydratedThreads,
     };
   }
 

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -340,6 +340,7 @@ class DesktopAppServerService {
       backend: backend ?? "all",
       fetchedAt: Date.now(),
       threads: hydratedThreads,
+      workspaceRoots: resolveScratchProjectsRoots(),
     };
   }
 

--- a/apps/desktop/src/renderer/src/features/settings/ArchivedThreadsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ArchivedThreadsSettings.tsx
@@ -1,5 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { AppServerThreadSummary } from "@pwragent/shared";
+import {
+  isToolManagedWorktreePath,
+  type AppServerThreadSummary,
+} from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 import {
   SettingsPanelHead,
@@ -330,15 +333,37 @@ function groupArchivedThreadsByProject(
 function resolveArchivedProject(
   thread: AppServerThreadSummary,
 ): ArchivedProjectIdentity {
-  const directory =
-    thread.linkedDirectories.find((candidate) => candidate.kind === "local") ??
-    thread.linkedDirectories[0];
-  if (directory) {
+  const repositoryDirectory = resolveRepositoryLinkedDirectory(thread);
+  if (repositoryDirectory) {
     return {
-      key: directory.path || directory.id || directory.label,
-      label: directory.label || pathBaseName(directory.path) || "Project",
+      key:
+        repositoryDirectory.path ||
+        repositoryDirectory.id ||
+        repositoryDirectory.label,
+      label:
+        repositoryDirectory.label ||
+        pathBaseName(repositoryDirectory.path) ||
+        "Project",
       latestArchiveTimestamp: resolveArchiveSortTimestamp(thread),
-      path: directory.path,
+      path: repositoryDirectory.path,
+    };
+  }
+
+  const snapshotRepositoryPath = resolveSnapshotRepositoryPath(thread);
+  if (snapshotRepositoryPath) {
+    return {
+      key: snapshotRepositoryPath,
+      label: pathBaseName(snapshotRepositoryPath) || snapshotRepositoryPath,
+      latestArchiveTimestamp: resolveArchiveSortTimestamp(thread),
+      path: snapshotRepositoryPath,
+    };
+  }
+
+  const managedWorktreeProject = resolveManagedWorktreeProject(thread);
+  if (managedWorktreeProject) {
+    return {
+      ...managedWorktreeProject,
+      latestArchiveTimestamp: resolveArchiveSortTimestamp(thread),
     };
   }
 
@@ -355,6 +380,84 @@ function resolveArchivedProject(
   return {
     key: "__no-project__",
     label: "No project",
+    latestArchiveTimestamp: resolveArchiveSortTimestamp(thread),
+  };
+}
+
+function resolveRepositoryLinkedDirectory(
+  thread: AppServerThreadSummary,
+): AppServerThreadSummary["linkedDirectories"][number] | undefined {
+  const localDirectory = thread.linkedDirectories.find(
+    (candidate) =>
+      candidate.kind === "local" &&
+      candidate.path.trim() &&
+      !isManagedWorktreePath(candidate.path),
+  );
+  if (localDirectory) {
+    return localDirectory;
+  }
+
+  return thread.linkedDirectories.find((candidate) => {
+    if (candidate.kind !== "worktree") {
+      return false;
+    }
+
+    const directoryPath = candidate.path.trim();
+    if (!directoryPath || isManagedWorktreePath(directoryPath)) {
+      return false;
+    }
+
+    const worktreePath = candidate.worktreePath?.trim();
+    return (
+      !worktreePath ||
+      normalizePath(directoryPath) !== normalizePath(worktreePath)
+    );
+  });
+}
+
+function resolveSnapshotRepositoryPath(
+  thread: AppServerThreadSummary,
+): string | undefined {
+  return [...(thread.worktreeSnapshots ?? [])]
+    .sort(
+      (left, right) =>
+        (right.archivedAt ?? right.createdAt) -
+        (left.archivedAt ?? left.createdAt),
+    )
+    .map((snapshot) => snapshot.repositoryPath.trim())
+    .find((repositoryPath) => {
+      if (!repositoryPath || isManagedWorktreePath(repositoryPath)) {
+        return false;
+      }
+      return !(thread.worktreeSnapshots ?? []).some(
+        (snapshot) =>
+          normalizePath(snapshot.worktreePath) === normalizePath(repositoryPath),
+      );
+    });
+}
+
+function resolveManagedWorktreeProject(
+  thread: AppServerThreadSummary,
+): ArchivedProjectIdentity | undefined {
+  const managedPath =
+    thread.linkedDirectories
+      .flatMap((directory) => [directory.worktreePath, directory.path])
+      .find((candidate) => candidate && isManagedWorktreePath(candidate)) ??
+    (isManagedWorktreePath(thread.projectKey) ? thread.projectKey : undefined);
+  if (!managedPath) {
+    return undefined;
+  }
+
+  const label =
+    thread.linkedDirectories
+      .find((directory) => directory.label.trim())
+      ?.label.trim() ||
+    pathBaseName(managedPath) ||
+    "Project";
+  return {
+    key: `managed-worktree:${label}`,
+    label,
+    path: `Recovered from managed worktrees named ${label}`,
     latestArchiveTimestamp: resolveArchiveSortTimestamp(thread),
   };
 }
@@ -399,4 +502,12 @@ function formatTimestamp(timestamp: number): string {
 
 function pathBaseName(pathname: string): string {
   return pathname.split(/[\\/]/).filter(Boolean).at(-1) ?? pathname;
+}
+
+function isManagedWorktreePath(pathname: string | undefined): boolean {
+  return isToolManagedWorktreePath(normalizePath(pathname));
+}
+
+function normalizePath(pathname: string | undefined): string {
+  return pathname?.trim().replace(/\\/g, "/").replace(/\/+$/, "") ?? "";
 }

--- a/apps/desktop/src/renderer/src/features/settings/ArchivedThreadsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ArchivedThreadsSettings.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { AppServerThreadSummary } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 import {
@@ -30,6 +30,7 @@ export function ArchivedThreadsSettings(props: {
   });
   const [restoringThreadKey, setRestoringThreadKey] = useState<string>();
   const [restoreMessage, setRestoreMessage] = useState<string>();
+  const restoredThreadKeysRef = useRef(new Set<string>());
 
   const loadArchivedThreads = useCallback(async () => {
     const listThreads = props.desktopApi?.listThreads;
@@ -48,7 +49,12 @@ export function ArchivedThreadsSettings(props: {
       setState({
         fetchedAt: response.fetchedAt,
         loading: false,
-        threads: sortArchivedThreads(response.threads),
+        threads: sortArchivedThreads(
+          response.threads.filter(
+            (thread) =>
+              !restoredThreadKeysRef.current.has(buildArchivedThreadKey(thread)),
+          ),
+        ),
       });
     } catch (error) {
       setState((current) => ({
@@ -86,6 +92,7 @@ export function ArchivedThreadsSettings(props: {
         backend: thread.source,
         threadId: thread.id,
       });
+      restoredThreadKeysRef.current.add(threadKey);
       setState((current) => ({
         ...current,
         threads: current.threads.filter(

--- a/apps/desktop/src/renderer/src/features/settings/ArchivedThreadsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ArchivedThreadsSettings.tsx
@@ -14,6 +14,15 @@ type ArchivedThreadsState = {
   threads: AppServerThreadSummary[];
 };
 
+type ArchivedProjectGroup = {
+  key: string;
+  label: string;
+  path?: string;
+  threads: AppServerThreadSummary[];
+};
+
+type ArchivedProjectIdentity = Omit<ArchivedProjectGroup, "threads">;
+
 const dateFormatter = new Intl.DateTimeFormat(undefined, {
   month: "short",
   day: "numeric",
@@ -69,8 +78,14 @@ export function ArchivedThreadsSettings(props: {
     void loadArchivedThreads();
   }, [loadArchivedThreads]);
 
+  const projectGroups = useMemo(() => {
+    return groupArchivedThreadsByProject(state.threads);
+  }, [state.threads]);
+
   const fetchedAtLabel = useMemo(() => {
-    return state.fetchedAt ? `Updated ${formatTimestamp(state.fetchedAt)}` : "Archive";
+    return state.fetchedAt
+      ? `Updated ${formatTimestamp(state.fetchedAt)}`
+      : "Archived Threads";
   }, [state.fetchedAt]);
 
   const restoreThread = async (thread: AppServerThreadSummary) => {
@@ -111,11 +126,11 @@ export function ArchivedThreadsSettings(props: {
   };
 
   return (
-    <SettingsSectionStack paneId="archived" aria-label="Archived thread settings">
+    <SettingsSectionStack paneId="archived" aria-label="Archived Threads settings">
       <SettingsPanelHead
-        eyebrow="Archive"
+        eyebrow="Archived Threads"
         title="Archived threads"
-        help="Archived threads stay out of Inbox, Recents, and Directories. Restore one here to make it visible again."
+        help="Archived threads stay out of Inbox, Recents, and Directories. Restore one from its project group to make it visible again."
         action={
           <button
             className="button button--secondary"
@@ -131,9 +146,9 @@ export function ArchivedThreadsSettings(props: {
       />
 
       <SettingsSection
-        eyebrow="Threads"
-        title="Archive"
-        description="Review archived work and restore threads that should return to the main thread lists."
+        eyebrow="Archived Threads"
+        title="By project"
+        description="Review archived work by project and restore threads that should return to the main thread lists."
         chip={state.loading ? "loading" : fetchedAtLabel}
         chipKind="muted"
       >
@@ -141,21 +156,44 @@ export function ArchivedThreadsSettings(props: {
           <p className="settings-empty settings-archive-empty">
             Loading archived threads...
           </p>
-        ) : state.threads.length ? (
+        ) : projectGroups.length ? (
           <div className="settings-archive-list">
-            {state.threads.map((thread) => {
-              const threadKey = buildArchivedThreadKey(thread);
-              return (
-                <ArchivedThreadRow
-                  key={threadKey}
-                  restoring={restoringThreadKey === threadKey}
-                  thread={thread}
-                  onRestore={() => {
-                    void restoreThread(thread);
-                  }}
-                />
-              );
-            })}
+            {projectGroups.map((group) => (
+              <section className="settings-archive-project" key={group.key}>
+                <header className="settings-archive-project__header">
+                  <div className="settings-archive-project__body">
+                    <h3 className="settings-archive-project__title">
+                      {group.label}
+                    </h3>
+                    {group.path ? (
+                      <p className="settings-archive-project__path">
+                        {group.path}
+                      </p>
+                    ) : null}
+                  </div>
+                  <span className="settings-pathrow__chip">
+                    {group.threads.length === 1
+                      ? "1 thread"
+                      : `${group.threads.length} threads`}
+                  </span>
+                </header>
+                <div className="settings-archive-project__threads">
+                  {group.threads.map((thread) => {
+                    const threadKey = buildArchivedThreadKey(thread);
+                    return (
+                      <ArchivedThreadRow
+                        key={threadKey}
+                        restoring={restoringThreadKey === threadKey}
+                        thread={thread}
+                        onRestore={() => {
+                          void restoreThread(thread);
+                        }}
+                      />
+                    );
+                  })}
+                </div>
+              </section>
+            ))}
           </div>
         ) : (
           <p className="settings-empty settings-archive-empty">
@@ -237,10 +275,67 @@ function sortArchivedThreads(
   });
 }
 
+function groupArchivedThreadsByProject(
+  threads: AppServerThreadSummary[],
+): ArchivedProjectGroup[] {
+  const groups = new Map<string, ArchivedProjectGroup>();
+  for (const thread of threads) {
+    const project = resolveArchivedProject(thread);
+    const existing = groups.get(project.key);
+    if (existing) {
+      existing.threads.push(thread);
+      continue;
+    }
+    groups.set(project.key, {
+      ...project,
+      threads: [thread],
+    });
+  }
+
+  return [...groups.values()].sort((left, right) => {
+    if (left.key === "__no-project__") return 1;
+    if (right.key === "__no-project__") return -1;
+    return left.label.localeCompare(right.label);
+  });
+}
+
+function resolveArchivedProject(
+  thread: AppServerThreadSummary,
+): ArchivedProjectIdentity {
+  const directory =
+    thread.linkedDirectories.find((candidate) => candidate.kind === "local") ??
+    thread.linkedDirectories[0];
+  if (directory) {
+    return {
+      key: directory.path || directory.id || directory.label,
+      label: directory.label || pathBaseName(directory.path) || "Project",
+      path: directory.path,
+    };
+  }
+
+  const projectKey = thread.projectKey?.trim();
+  if (projectKey) {
+    return {
+      key: projectKey,
+      label: pathBaseName(projectKey) || projectKey,
+      path: projectKey,
+    };
+  }
+
+  return {
+    key: "__no-project__",
+    label: "No project",
+  };
+}
+
 function buildArchivedThreadKey(thread: AppServerThreadSummary): string {
   return `${thread.source}:${thread.id}`;
 }
 
 function formatTimestamp(timestamp: number): string {
   return dateFormatter.format(timestamp);
+}
+
+function pathBaseName(pathname: string): string {
+  return pathname.split(/[\\/]/).filter(Boolean).at(-1) ?? pathname;
 }

--- a/apps/desktop/src/renderer/src/features/settings/ArchivedThreadsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ArchivedThreadsSettings.tsx
@@ -17,11 +17,14 @@ type ArchivedThreadsState = {
 type ArchivedProjectGroup = {
   key: string;
   label: string;
+  latestArchiveTimestamp: number;
   path?: string;
   threads: AppServerThreadSummary[];
 };
 
 type ArchivedProjectIdentity = Omit<ArchivedProjectGroup, "threads">;
+
+const ARCHIVED_THREADS_PER_PROJECT_LIMIT = 20;
 
 const dateFormatter = new Intl.DateTimeFormat(undefined, {
   month: "short",
@@ -145,72 +148,86 @@ export function ArchivedThreadsSettings(props: {
         }
       />
 
-      <SettingsSection
-        eyebrow="Archived Threads"
-        title="By project"
-        description="Review archived work by project and restore threads that should return to the main thread lists."
-        chip={state.loading ? "loading" : fetchedAtLabel}
-        chipKind="muted"
-      >
-        {state.loading && state.threads.length === 0 ? (
-          <p className="settings-empty settings-archive-empty">
-            Loading archived threads...
-          </p>
-        ) : projectGroups.length ? (
-          <div className="settings-archive-list">
-            {projectGroups.map((group) => (
-              <section className="settings-archive-project" key={group.key}>
-                <header className="settings-archive-project__header">
-                  <div className="settings-archive-project__body">
-                    <h3 className="settings-archive-project__title">
-                      {group.label}
-                    </h3>
-                    {group.path ? (
-                      <p className="settings-archive-project__path">
-                        {group.path}
-                      </p>
-                    ) : null}
-                  </div>
-                  <span className="settings-pathrow__chip">
-                    {group.threads.length === 1
-                      ? "1 thread"
-                      : `${group.threads.length} threads`}
-                  </span>
-                </header>
-                <div className="settings-archive-project__threads">
-                  {group.threads.map((thread) => {
-                    const threadKey = buildArchivedThreadKey(thread);
-                    return (
-                      <ArchivedThreadRow
-                        key={threadKey}
-                        restoring={restoringThreadKey === threadKey}
-                        thread={thread}
-                        onRestore={() => {
-                          void restoreThread(thread);
-                        }}
-                      />
-                    );
-                  })}
-                </div>
-              </section>
-            ))}
-          </div>
-        ) : (
-          <p className="settings-empty settings-archive-empty">
-            No archived threads.
-          </p>
-        )}
-        {restoreMessage ? (
-          <p className="settings-archive-status" role="status">
-            {restoreMessage}
-          </p>
-        ) : null}
-        {state.error ? (
-          <p className="settings-row__error settings-archive-status" role="alert">
-            {state.error}
-          </p>
-        ) : null}
-      </SettingsSection>
+      {(state.loading && state.threads.length === 0) ||
+      (!state.loading && projectGroups.length === 0) ||
+      restoreMessage ||
+      state.error ? (
+        <SettingsSection
+          eyebrow="Archived Threads"
+          title="Project folders"
+          description="Review archived work by project and restore threads that should return to the main thread lists."
+          chip={state.loading ? "loading" : fetchedAtLabel}
+          chipKind="muted"
+        >
+          {state.loading && state.threads.length === 0 ? (
+            <p className="settings-empty settings-archive-empty">
+              Loading archived threads...
+            </p>
+          ) : null}
+          {!state.loading && projectGroups.length === 0 ? (
+            <p className="settings-empty settings-archive-empty">
+              No archived threads.
+            </p>
+          ) : null}
+          {restoreMessage ? (
+            <p className="settings-archive-status" role="status">
+              {restoreMessage}
+            </p>
+          ) : null}
+          {state.error ? (
+            <p
+              className="settings-row__error settings-archive-status"
+              role="alert"
+            >
+              {state.error}
+            </p>
+          ) : null}
+        </SettingsSection>
+      ) : null}
+
+      {projectGroups.map((group) => {
+        const visibleThreads = group.threads.slice(
+          0,
+          ARCHIVED_THREADS_PER_PROJECT_LIMIT,
+        );
+        const hiddenThreadCount = group.threads.length - visibleThreads.length;
+        return (
+          <SettingsSection
+            key={group.key}
+            eyebrow="Project folder"
+            title={group.label}
+            description={group.path}
+            chip={
+              group.threads.length === 1
+                ? "1 thread"
+                : `${group.threads.length} threads`
+            }
+            chipKind="muted"
+          >
+            <div className="settings-archive-project__threads">
+              {visibleThreads.map((thread) => {
+                const threadKey = buildArchivedThreadKey(thread);
+                return (
+                  <ArchivedThreadRow
+                    key={threadKey}
+                    restoring={restoringThreadKey === threadKey}
+                    thread={thread}
+                    onRestore={() => {
+                      void restoreThread(thread);
+                    }}
+                  />
+                );
+              })}
+              {hiddenThreadCount > 0 ? (
+                <p className="settings-archive-status">
+                  Showing {ARCHIVED_THREADS_PER_PROJECT_LIMIT} of{" "}
+                  {group.threads.length} most recent archived threads.
+                </p>
+              ) : null}
+            </div>
+          </SettingsSection>
+        );
+      })}
     </SettingsSectionStack>
   );
 }
@@ -224,7 +241,10 @@ function ArchivedThreadRow(props: {
   const directories = thread.linkedDirectories
     .map((directory) => directory.label || directory.path)
     .filter(Boolean);
-  const activityLabel = thread.updatedAt
+  const archivedAt = resolveArchiveTimestamp(thread);
+  const activityLabel = archivedAt
+    ? `Archived ${formatTimestamp(archivedAt)}`
+    : thread.updatedAt
     ? `Updated ${formatTimestamp(thread.updatedAt)}`
     : thread.createdAt
       ? `Created ${formatTimestamp(thread.createdAt)}`
@@ -266,8 +286,8 @@ function sortArchivedThreads(
   threads: AppServerThreadSummary[],
 ): AppServerThreadSummary[] {
   return [...threads].sort((left, right) => {
-    const rightTimestamp = right.updatedAt ?? right.createdAt ?? 0;
-    const leftTimestamp = left.updatedAt ?? left.createdAt ?? 0;
+    const rightTimestamp = resolveArchiveSortTimestamp(right);
+    const leftTimestamp = resolveArchiveSortTimestamp(left);
     const timestampDelta = rightTimestamp - leftTimestamp;
     return timestampDelta !== 0
       ? timestampDelta
@@ -284,6 +304,10 @@ function groupArchivedThreadsByProject(
     const existing = groups.get(project.key);
     if (existing) {
       existing.threads.push(thread);
+      existing.latestArchiveTimestamp = Math.max(
+        existing.latestArchiveTimestamp,
+        project.latestArchiveTimestamp,
+      );
       continue;
     }
     groups.set(project.key, {
@@ -295,7 +319,11 @@ function groupArchivedThreadsByProject(
   return [...groups.values()].sort((left, right) => {
     if (left.key === "__no-project__") return 1;
     if (right.key === "__no-project__") return -1;
-    return left.label.localeCompare(right.label);
+    const timestampDelta =
+      right.latestArchiveTimestamp - left.latestArchiveTimestamp;
+    return timestampDelta !== 0
+      ? timestampDelta
+      : left.label.localeCompare(right.label);
   });
 }
 
@@ -309,6 +337,7 @@ function resolveArchivedProject(
     return {
       key: directory.path || directory.id || directory.label,
       label: directory.label || pathBaseName(directory.path) || "Project",
+      latestArchiveTimestamp: resolveArchiveSortTimestamp(thread),
       path: directory.path,
     };
   }
@@ -318,6 +347,7 @@ function resolveArchivedProject(
     return {
       key: projectKey,
       label: pathBaseName(projectKey) || projectKey,
+      latestArchiveTimestamp: resolveArchiveSortTimestamp(thread),
       path: projectKey,
     };
   }
@@ -325,7 +355,38 @@ function resolveArchivedProject(
   return {
     key: "__no-project__",
     label: "No project",
+    latestArchiveTimestamp: resolveArchiveSortTimestamp(thread),
   };
+}
+
+function resolveArchiveSortTimestamp(thread: AppServerThreadSummary): number {
+  return (
+    resolveArchiveTimestamp(thread) ??
+    thread.updatedAt ??
+    thread.createdAt ??
+    0
+  );
+}
+
+function resolveArchiveTimestamp(
+  thread: AppServerThreadSummary,
+): number | undefined {
+  const explicitArchivedAt = thread.archivedAt;
+  if (explicitArchivedAt) {
+    return explicitArchivedAt;
+  }
+
+  return (thread.worktreeSnapshots ?? []).reduce<number | undefined>(
+    (latest, snapshot) => {
+      if (!snapshot.archivedAt) {
+        return latest;
+      }
+      return latest === undefined
+        ? snapshot.archivedAt
+        : Math.max(latest, snapshot.archivedAt);
+    },
+    undefined,
+  );
 }
 
 function buildArchivedThreadKey(thread: AppServerThreadSummary): string {

--- a/apps/desktop/src/renderer/src/features/settings/ArchivedThreadsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ArchivedThreadsSettings.tsx
@@ -1,0 +1,239 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { AppServerThreadSummary } from "@pwragent/shared";
+import type { DesktopApi } from "../../lib/desktop-api";
+import {
+  SettingsPanelHead,
+  SettingsSection,
+  SettingsSectionStack,
+} from "./SettingsLayout";
+
+type ArchivedThreadsState = {
+  error?: string;
+  fetchedAt?: number;
+  loading: boolean;
+  threads: AppServerThreadSummary[];
+};
+
+const dateFormatter = new Intl.DateTimeFormat(undefined, {
+  month: "short",
+  day: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+});
+
+export function ArchivedThreadsSettings(props: {
+  desktopApi?: DesktopApi;
+}) {
+  const [state, setState] = useState<ArchivedThreadsState>({
+    loading: true,
+    threads: [],
+  });
+  const [restoringThreadKey, setRestoringThreadKey] = useState<string>();
+  const [restoreMessage, setRestoreMessage] = useState<string>();
+
+  const loadArchivedThreads = useCallback(async () => {
+    const listThreads = props.desktopApi?.listThreads;
+    if (!listThreads) {
+      setState({
+        error: "Desktop bridge is missing listThreads().",
+        loading: false,
+        threads: [],
+      });
+      return;
+    }
+
+    setState((current) => ({ ...current, error: undefined, loading: true }));
+    try {
+      const response = await listThreads({ archived: true });
+      setState({
+        fetchedAt: response.fetchedAt,
+        loading: false,
+        threads: sortArchivedThreads(response.threads),
+      });
+    } catch (error) {
+      setState((current) => ({
+        ...current,
+        error: error instanceof Error ? error.message : String(error),
+        loading: false,
+      }));
+    }
+  }, [props.desktopApi]);
+
+  useEffect(() => {
+    void loadArchivedThreads();
+  }, [loadArchivedThreads]);
+
+  const fetchedAtLabel = useMemo(() => {
+    return state.fetchedAt ? `Updated ${formatTimestamp(state.fetchedAt)}` : "Archive";
+  }, [state.fetchedAt]);
+
+  const restoreThread = async (thread: AppServerThreadSummary) => {
+    const restoreThreadRequest = props.desktopApi?.restoreThread;
+    if (!restoreThreadRequest) {
+      setState((current) => ({
+        ...current,
+        error: "Desktop bridge is missing restoreThread().",
+      }));
+      return;
+    }
+
+    const threadKey = buildArchivedThreadKey(thread);
+    setRestoreMessage(undefined);
+    setState((current) => ({ ...current, error: undefined }));
+    setRestoringThreadKey(threadKey);
+    try {
+      await restoreThreadRequest({
+        backend: thread.source,
+        threadId: thread.id,
+      });
+      setState((current) => ({
+        ...current,
+        threads: current.threads.filter(
+          (candidate) => buildArchivedThreadKey(candidate) !== threadKey,
+        ),
+      }));
+      setRestoreMessage(`Restored ${thread.title}.`);
+    } catch (error) {
+      setState((current) => ({
+        ...current,
+        error: error instanceof Error ? error.message : String(error),
+      }));
+    } finally {
+      setRestoringThreadKey(undefined);
+    }
+  };
+
+  return (
+    <SettingsSectionStack paneId="archived" aria-label="Archived thread settings">
+      <SettingsPanelHead
+        eyebrow="Archive"
+        title="Archived threads"
+        help="Archived threads stay out of Inbox, Recents, and Directories. Restore one here to make it visible again."
+        action={
+          <button
+            className="button button--secondary"
+            disabled={state.loading}
+            type="button"
+            onClick={() => {
+              void loadArchivedThreads();
+            }}
+          >
+            Refresh
+          </button>
+        }
+      />
+
+      <SettingsSection
+        eyebrow="Threads"
+        title="Archive"
+        description="Review archived work and restore threads that should return to the main thread lists."
+        chip={state.loading ? "loading" : fetchedAtLabel}
+        chipKind="muted"
+      >
+        {state.loading && state.threads.length === 0 ? (
+          <p className="settings-empty settings-archive-empty">
+            Loading archived threads...
+          </p>
+        ) : state.threads.length ? (
+          <div className="settings-archive-list">
+            {state.threads.map((thread) => {
+              const threadKey = buildArchivedThreadKey(thread);
+              return (
+                <ArchivedThreadRow
+                  key={threadKey}
+                  restoring={restoringThreadKey === threadKey}
+                  thread={thread}
+                  onRestore={() => {
+                    void restoreThread(thread);
+                  }}
+                />
+              );
+            })}
+          </div>
+        ) : (
+          <p className="settings-empty settings-archive-empty">
+            No archived threads.
+          </p>
+        )}
+        {restoreMessage ? (
+          <p className="settings-archive-status" role="status">
+            {restoreMessage}
+          </p>
+        ) : null}
+        {state.error ? (
+          <p className="settings-row__error settings-archive-status" role="alert">
+            {state.error}
+          </p>
+        ) : null}
+      </SettingsSection>
+    </SettingsSectionStack>
+  );
+}
+
+function ArchivedThreadRow(props: {
+  restoring: boolean;
+  thread: AppServerThreadSummary;
+  onRestore: () => void;
+}) {
+  const thread = props.thread;
+  const directories = thread.linkedDirectories
+    .map((directory) => directory.label || directory.path)
+    .filter(Boolean);
+  const activityLabel = thread.updatedAt
+    ? `Updated ${formatTimestamp(thread.updatedAt)}`
+    : thread.createdAt
+      ? `Created ${formatTimestamp(thread.createdAt)}`
+      : "No timestamp";
+
+  return (
+    <article className="settings-archive-row">
+      <div className="settings-archive-row__body">
+        <h3 className="settings-archive-row__title">{thread.title}</h3>
+        {thread.summary ? (
+          <p className="settings-archive-row__summary">{thread.summary}</p>
+        ) : null}
+        <p className="settings-archive-row__meta">
+          <span>{activityLabel}</span>
+          {directories.length ? <span>{directories.join(", ")}</span> : null}
+        </p>
+      </div>
+      <div className="settings-archive-row__side">
+        <div className="settings-pathrow__chips">
+          <span className="settings-pathrow__chip">{thread.source}</span>
+          {thread.gitBranch ? (
+            <span className="settings-pathrow__chip">{thread.gitBranch}</span>
+          ) : null}
+        </div>
+        <button
+          className="button button--secondary settings-archive-row__button"
+          disabled={props.restoring}
+          type="button"
+          onClick={props.onRestore}
+        >
+          {props.restoring ? "Restoring..." : "Restore"}
+        </button>
+      </div>
+    </article>
+  );
+}
+
+function sortArchivedThreads(
+  threads: AppServerThreadSummary[],
+): AppServerThreadSummary[] {
+  return [...threads].sort((left, right) => {
+    const rightTimestamp = right.updatedAt ?? right.createdAt ?? 0;
+    const leftTimestamp = left.updatedAt ?? left.createdAt ?? 0;
+    const timestampDelta = rightTimestamp - leftTimestamp;
+    return timestampDelta !== 0
+      ? timestampDelta
+      : left.title.localeCompare(right.title);
+  });
+}
+
+function buildArchivedThreadKey(thread: AppServerThreadSummary): string {
+  return `${thread.source}:${thread.id}`;
+}
+
+function formatTimestamp(timestamp: number): string {
+  return dateFormatter.format(timestamp);
+}

--- a/apps/desktop/src/renderer/src/features/settings/ArchivedThreadsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ArchivedThreadsSettings.tsx
@@ -15,6 +15,7 @@ type ArchivedThreadsState = {
   fetchedAt?: number;
   loading: boolean;
   threads: AppServerThreadSummary[];
+  workspaceRoots: string[];
 };
 
 type ArchivedProjectGroup = {
@@ -42,6 +43,7 @@ export function ArchivedThreadsSettings(props: {
   const [state, setState] = useState<ArchivedThreadsState>({
     loading: true,
     threads: [],
+    workspaceRoots: [],
   });
   const [restoringThreadKey, setRestoringThreadKey] = useState<string>();
   const [restoreMessage, setRestoreMessage] = useState<string>();
@@ -54,6 +56,7 @@ export function ArchivedThreadsSettings(props: {
         error: "Desktop bridge is missing listThreads().",
         loading: false,
         threads: [],
+        workspaceRoots: [],
       });
       return;
     }
@@ -70,6 +73,7 @@ export function ArchivedThreadsSettings(props: {
               !restoredThreadKeysRef.current.has(buildArchivedThreadKey(thread)),
           ),
         ),
+        workspaceRoots: response.workspaceRoots ?? [],
       });
     } catch (error) {
       setState((current) => ({
@@ -85,8 +89,8 @@ export function ArchivedThreadsSettings(props: {
   }, [loadArchivedThreads]);
 
   const projectGroups = useMemo(() => {
-    return groupArchivedThreadsByProject(state.threads);
-  }, [state.threads]);
+    return groupArchivedThreadsByProject(state.threads, state.workspaceRoots);
+  }, [state.threads, state.workspaceRoots]);
 
   const fetchedAtLabel = useMemo(() => {
     return state.fetchedAt
@@ -300,10 +304,14 @@ function sortArchivedThreads(
 
 function groupArchivedThreadsByProject(
   threads: AppServerThreadSummary[],
+  workspaceRoots: string[] = [],
 ): ArchivedProjectGroup[] {
   const groups = new Map<string, ArchivedProjectGroup>();
   for (const thread of threads) {
-    const project = resolveArchivedProject(thread);
+    const project = resolveArchivedProject(thread, workspaceRoots);
+    if (!project) {
+      continue;
+    }
     const existing = groups.get(project.key);
     if (existing) {
       existing.threads.push(thread);
@@ -332,7 +340,13 @@ function groupArchivedThreadsByProject(
 
 function resolveArchivedProject(
   thread: AppServerThreadSummary,
-): ArchivedProjectIdentity {
+  workspaceRoots: string[] = [],
+): ArchivedProjectIdentity | null | undefined {
+  const workspaceProject = resolveWorkspaceProject(thread, workspaceRoots);
+  if (workspaceProject !== undefined) {
+    return workspaceProject;
+  }
+
   const repositoryDirectory = resolveRepositoryLinkedDirectory(thread);
   if (repositoryDirectory) {
     return {
@@ -382,6 +396,69 @@ function resolveArchivedProject(
     label: "No project",
     latestArchiveTimestamp: resolveArchiveSortTimestamp(thread),
   };
+}
+
+function resolveWorkspaceProject(
+  thread: AppServerThreadSummary,
+  workspaceRoots: string[],
+): ArchivedProjectIdentity | null | undefined {
+  const workspaceRoot = threadWorkspaceRoot(thread);
+  if (!workspaceRoot) {
+    return undefined;
+  }
+
+  const activeRoot = activeWorkspaceRoot(workspaceRoot, workspaceRoots);
+  if (!activeRoot) {
+    return null;
+  }
+
+  return {
+    key: `workspace:${activeRoot}`,
+    label: "Workspaces",
+    latestArchiveTimestamp: resolveArchiveSortTimestamp(thread),
+    path: activeRoot,
+  };
+}
+
+function threadWorkspaceRoot(
+  thread: AppServerThreadSummary,
+): string | undefined {
+  return [
+    thread.projectKey,
+    ...thread.linkedDirectories.flatMap((directory) => [
+      directory.path,
+      directory.worktreePath,
+    ]),
+  ]
+    .map(matchScratchProjectsRoot)
+    .find((root): root is string => Boolean(root));
+}
+
+function activeWorkspaceRoot(
+  candidateRoot: string,
+  workspaceRoots: string[],
+): string | undefined {
+  if (workspaceRoots.length === 0) {
+    return candidateRoot;
+  }
+
+  const normalizedCandidate = normalizeComparablePath(candidateRoot);
+  return workspaceRoots.find(
+    (workspaceRoot) =>
+      normalizeComparablePath(workspaceRoot) === normalizedCandidate,
+  );
+}
+
+function matchScratchProjectsRoot(pathname: string | undefined): string | undefined {
+  const normalized = normalizePath(pathname);
+  if (!normalized) {
+    return undefined;
+  }
+
+  const match = normalized.match(
+    /^(.*\/\.pwrag(?:ent|nt)(?:\/profiles\/[^/]+)?\/projects)(?:\/.*)?$/,
+  );
+  return match?.[1];
 }
 
 function resolveRepositoryLinkedDirectory(
@@ -510,4 +587,8 @@ function isManagedWorktreePath(pathname: string | undefined): boolean {
 
 function normalizePath(pathname: string | undefined): string {
   return pathname?.trim().replace(/\\/g, "/").replace(/\/+$/, "") ?? "";
+}
+
+function normalizeComparablePath(pathname: string | undefined): string {
+  return normalizePath(pathname).replace(/\/+$/, "");
 }

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -44,7 +44,7 @@ const SECTIONS: Array<{ id: SettingsSection; label: string }> = [
   { id: "applications", label: "Applications" },
   { id: "profiles", label: "Profiles" },
   { id: "worktrees", label: "Worktrees" },
-  { id: "archived", label: "Archived" },
+  { id: "archived", label: "Archived Threads" },
   { id: "messaging", label: "Messaging" },
   { id: "models", label: "Models" },
   { id: "experimental", label: "Experimental" },

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -15,6 +15,7 @@ import { MessagingSettings } from "./MessagingSettings";
 import { ModelsSettings } from "./ModelsSettings";
 import { ProfilesSettings } from "./ProfilesSettings";
 import { ApplicationsSettings } from "./ApplicationsSettings";
+import { ArchivedThreadsSettings } from "./ArchivedThreadsSettings";
 import { MessagingStatusBar } from "../messaging-status/MessagingStatusBar";
 import { WorktreesSettings } from "./WorktreesSettings";
 import {
@@ -35,6 +36,7 @@ export type SettingsSection =
   | "profiles"
   | "applications"
   | "worktrees"
+  | "archived"
   | "about";
 
 const SECTIONS: Array<{ id: SettingsSection; label: string }> = [
@@ -42,6 +44,7 @@ const SECTIONS: Array<{ id: SettingsSection; label: string }> = [
   { id: "applications", label: "Applications" },
   { id: "profiles", label: "Profiles" },
   { id: "worktrees", label: "Worktrees" },
+  { id: "archived", label: "Archived" },
   { id: "messaging", label: "Messaging" },
   { id: "models", label: "Models" },
   { id: "experimental", label: "Experimental" },
@@ -402,6 +405,10 @@ function SettingsSectionBody(props: {
         }}
       />
     );
+  }
+
+  if (props.section === "archived") {
+    return <ArchivedThreadsSettings desktopApi={props.desktopApi} />;
   }
 
   if (props.section === "applications") {

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -26,7 +26,7 @@ import {
   buildSlackPatchDelta,
   buildTelegramPatchDelta,
 } from "./settings-patch-delta";
-import { useCallback, useEffect, useState } from "react";
+import { Fragment, useCallback, useEffect, useState } from "react";
 
 export type SettingsSection =
   | "general"
@@ -43,13 +43,40 @@ const SECTIONS: Array<{ id: SettingsSection; label: string }> = [
   { id: "general", label: "General" },
   { id: "applications", label: "Applications" },
   { id: "profiles", label: "Profiles" },
+  { id: "models", label: "Models" },
+  { id: "messaging", label: "Messaging" },
   { id: "worktrees", label: "Worktrees" },
   { id: "archived", label: "Archived Threads" },
-  { id: "messaging", label: "Messaging" },
-  { id: "models", label: "Models" },
   { id: "experimental", label: "Experimental" },
   { id: "about", label: "About" },
 ];
+
+const PRIMARY_SECTIONS: SettingsSection[] = [
+  "general",
+  "applications",
+  "profiles",
+  "models",
+  "messaging",
+];
+
+const SETTINGS_NAV_DIVIDER_AFTER: SettingsSection = "messaging";
+
+const SECTION_LABELS = new Map(
+  SECTIONS.map((section) => [section.id, section.label] as const),
+);
+
+const ORDERED_SECTION_IDS: SettingsSection[] = [
+  ...PRIMARY_SECTIONS,
+  "worktrees",
+  "archived",
+  "experimental",
+  "about",
+];
+
+const ORDERED_SECTIONS = ORDERED_SECTION_IDS.map((id) => ({
+  id,
+  label: SECTION_LABELS.get(id) ?? id,
+}));
 
 export function SettingsScreen(props: {
   /** Live theme + density controller from the App root. Threaded down to
@@ -121,16 +148,20 @@ export function SettingsScreen(props: {
         {/* Group label between Exit and the section list. */}
         <p className="settings-nav__group-label">General</p>
 
-        {SECTIONS.map((item) => (
-          <button
-            key={item.id}
-            aria-current={section === item.id ? "page" : undefined}
-            className={`settings-nav__button${section === item.id ? " is-active" : ""}`}
-            type="button"
-            onClick={() => setSection(item.id)}
-          >
-            {item.label}
-          </button>
+        {ORDERED_SECTIONS.map((item) => (
+          <Fragment key={item.id}>
+            <button
+              aria-current={section === item.id ? "page" : undefined}
+              className={`settings-nav__button${section === item.id ? " is-active" : ""}`}
+              type="button"
+              onClick={() => setSection(item.id)}
+            >
+              {item.label}
+            </button>
+            {item.id === SETTINGS_NAV_DIVIDER_AFTER ? (
+              <hr className="settings-nav__divider" />
+            ) : null}
+          </Fragment>
         ))}
       </nav>
 

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -2364,6 +2364,35 @@ describe("SettingsScreen", () => {
     expect(label?.textContent?.toLowerCase()).toBe("general");
   });
 
+  it("orders settings nav sections with worktree settings separated", () => {
+    render(
+      <SettingsScreen
+        settings={createSettingsState()}
+        onClose={() => undefined}
+      />,
+    );
+
+    const nav = screen.getByRole("navigation", { name: "Settings sections" });
+    const buttons = within(nav)
+      .getAllByRole("button")
+      .map((button) => button.textContent);
+    expect(buttons).toEqual([
+      "← Exit Settings",
+      "General",
+      "Applications",
+      "Profiles",
+      "Models",
+      "Messaging",
+      "Worktrees",
+      "Archived Threads",
+      "Experimental",
+      "About",
+    ]);
+    expect(within(nav).getByRole("separator")).toHaveClass(
+      "settings-nav__divider",
+    );
+  });
+
   it("shows when messaging is disabled by a runtime override", () => {
     render(
       <SettingsScreen

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -11,6 +11,7 @@ import {
 import { useState } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
+  AppServerThreadSummary,
   DesktopSettingsSnapshot,
   MessagingPairingEntry,
 } from "@pwragent/shared";
@@ -517,11 +518,72 @@ describe("SettingsScreen", () => {
       });
     });
 
+    fireEvent.click(within(sections).getByRole("button", { name: "Archived" }));
+    expect(screen.getByRole("heading", { name: "Archived threads" })).toBeInTheDocument();
+
     fireEvent.click(within(sections).getByRole("button", { name: "General" }));
     expect(within(sections).getByRole("button", { name: "Experimental" })).not.toHaveAttribute(
       "aria-current",
       "page",
     );
+  });
+
+  it("lists archived threads and restores one", async () => {
+    const archivedThread: AppServerThreadSummary = {
+      id: "thread-archived",
+      title: "Archived code review",
+      titleSource: "explicit",
+      summary: "Needs to come back to the active thread list.",
+      createdAt: 1_000,
+      updatedAt: 2_000,
+      linkedDirectories: [
+        {
+          id: "directory-1",
+          label: "PwrAgnt",
+          path: "/repo/PwrAgnt",
+          kind: "local",
+        },
+      ],
+      gitBranch: "feature/archive-settings",
+      source: "codex",
+    };
+    const listThreads = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: 3_000,
+      threads: [archivedThread],
+    }));
+    const restoreThread = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-archived",
+      restoredAt: 4_000,
+    }));
+
+    render(
+      <SettingsScreen
+        desktopApi={{ listThreads, restoreThread }}
+        settings={createSettingsState()}
+        initialSection="archived"
+        onClose={() => undefined}
+      />,
+    );
+
+    expect(await screen.findByText("Archived code review")).toBeInTheDocument();
+    expect(screen.getByText("Needs to come back to the active thread list.")).toBeInTheDocument();
+    expect(screen.getByText("PwrAgnt")).toBeInTheDocument();
+    expect(listThreads).toHaveBeenCalledWith({ archived: true });
+
+    fireEvent.click(screen.getByRole("button", { name: "Restore" }));
+
+    await waitFor(() => {
+      expect(restoreThread).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-archived",
+      });
+    });
+    await waitFor(() => {
+      expect(screen.queryByText("Archived code review")).not.toBeInTheDocument();
+    });
+    expect(screen.getByText("Restored Archived code review.")).toBeInTheDocument();
   });
 
   it("can restart login for an existing Codex auth profile", async () => {

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -781,6 +781,86 @@ describe("SettingsScreen", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("groups active-profile scratch projects as Workspaces and hides inactive profile roots", async () => {
+    const activeWorkspaceRoot = "/Users/huntharo/.pwragent/profiles/dev/projects";
+    const listThreads = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: 3_000,
+      workspaceRoots: [activeWorkspaceRoot],
+      threads: [
+        {
+          id: "thread-dev-workspace-1",
+          title: "lions roar",
+          titleSource: "explicit" as const,
+          createdAt: 1_000,
+          updatedAt: 5_000,
+          linkedDirectories: [
+            {
+              id: `${activeWorkspaceRoot}/2026-05-10-844f31`,
+              label: "2026-05-10-844f31",
+              path: `${activeWorkspaceRoot}/2026-05-10-844f31`,
+              kind: "local" as const,
+            },
+          ],
+          source: "codex" as const,
+        },
+        {
+          id: "thread-dev-workspace-2",
+          title: "what's up",
+          titleSource: "explicit" as const,
+          createdAt: 1_000,
+          updatedAt: 4_000,
+          projectKey: `${activeWorkspaceRoot}/2026-05-10-883761`,
+          linkedDirectories: [],
+          source: "codex" as const,
+        },
+        {
+          id: "thread-legacy-workspace",
+          title: "Key Lime Pie yum",
+          titleSource: "explicit" as const,
+          createdAt: 1_000,
+          updatedAt: 3_000,
+          linkedDirectories: [
+            {
+              id: "/Users/huntharo/.pwragnt/projects",
+              label: "projects",
+              path: "/Users/huntharo/.pwragnt/projects",
+              kind: "local" as const,
+            },
+          ],
+          source: "codex" as const,
+        },
+      ],
+    }));
+
+    render(
+      <SettingsScreen
+        desktopApi={{ listThreads }}
+        settings={createSettingsState()}
+        initialSection="archived"
+        onClose={() => undefined}
+      />,
+    );
+
+    const workspacesGroup = (await screen.findByRole("heading", {
+      name: "Workspaces",
+    })).closest("section")!;
+    expect(within(workspacesGroup).getByText("2 threads")).toBeInTheDocument();
+    expect(within(workspacesGroup).getByText("lions roar")).toBeInTheDocument();
+    expect(within(workspacesGroup).getByText("what's up")).toBeInTheDocument();
+    expect(within(workspacesGroup).getByText(activeWorkspaceRoot)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "2026-05-10-844f31" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "2026-05-10-883761" }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Key Lime Pie yum")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "projects" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("limits each archived project to the 20 most recent archive timestamps", async () => {
     const listThreads = vi.fn(async () => ({
       backend: "all" as const,

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -519,7 +519,9 @@ describe("SettingsScreen", () => {
       });
     });
 
-    fireEvent.click(within(sections).getByRole("button", { name: "Archived" }));
+    fireEvent.click(
+      within(sections).getByRole("button", { name: "Archived Threads" }),
+    );
     expect(screen.getByRole("heading", { name: "Archived threads" })).toBeInTheDocument();
 
     fireEvent.click(within(sections).getByRole("button", { name: "General" }));
@@ -570,7 +572,8 @@ describe("SettingsScreen", () => {
 
     expect(await screen.findByText("Archived code review")).toBeInTheDocument();
     expect(screen.getByText("Needs to come back to the active thread list.")).toBeInTheDocument();
-    expect(screen.getByText("PwrAgnt")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "PwrAgnt" })).toBeInTheDocument();
+    expect(screen.getByText("/repo/PwrAgnt")).toBeInTheDocument();
     expect(listThreads).toHaveBeenCalledWith({ archived: true });
 
     fireEvent.click(screen.getByRole("button", { name: "Restore" }));
@@ -585,6 +588,89 @@ describe("SettingsScreen", () => {
       expect(screen.queryByText("Archived code review")).not.toBeInTheDocument();
     });
     expect(screen.getByText("Restored Archived code review.")).toBeInTheDocument();
+  });
+
+  it("groups archived threads by project before restoration", async () => {
+    const listThreads = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: 3_000,
+      threads: [
+        {
+          id: "thread-pwragent-2",
+          title: "Second PwrAgent thread",
+          titleSource: "explicit" as const,
+          createdAt: 1_000,
+          updatedAt: 4_000,
+          linkedDirectories: [
+            {
+              id: "directory-1",
+              label: "PwrAgnt",
+              path: "/repo/PwrAgnt",
+              kind: "local" as const,
+            },
+          ],
+          source: "codex" as const,
+        },
+        {
+          id: "thread-other",
+          title: "Other project thread",
+          titleSource: "explicit" as const,
+          createdAt: 1_000,
+          updatedAt: 3_000,
+          linkedDirectories: [
+            {
+              id: "directory-2",
+              label: "OtherProject",
+              path: "/repo/OtherProject",
+              kind: "local" as const,
+            },
+          ],
+          source: "codex" as const,
+        },
+        {
+          id: "thread-pwragent-1",
+          title: "First PwrAgent thread",
+          titleSource: "explicit" as const,
+          createdAt: 1_000,
+          updatedAt: 2_000,
+          linkedDirectories: [
+            {
+              id: "directory-1",
+              label: "PwrAgnt",
+              path: "/repo/PwrAgnt",
+              kind: "local" as const,
+            },
+          ],
+          source: "codex" as const,
+        },
+      ],
+    }));
+
+    render(
+      <SettingsScreen
+        desktopApi={{ listThreads }}
+        settings={createSettingsState()}
+        initialSection="archived"
+        onClose={() => undefined}
+      />,
+    );
+
+    const pwrAgentGroup = (await screen.findByRole("heading", {
+      name: "PwrAgnt",
+    })).closest("section")!;
+    expect(within(pwrAgentGroup).getByText("2 threads")).toBeInTheDocument();
+    expect(
+      within(pwrAgentGroup).getByText("Second PwrAgent thread"),
+    ).toBeInTheDocument();
+    expect(
+      within(pwrAgentGroup).getByText("First PwrAgent thread"),
+    ).toBeInTheDocument();
+
+    const otherGroup = screen.getByRole("heading", {
+      name: "OtherProject",
+    }).closest("section")!;
+    expect(within(otherGroup).getByText("1 thread")).toBeInTheDocument();
+    expect(within(otherGroup).getByText("Other project thread")).toBeInTheDocument();
   });
 
   it("does not re-add a restored thread when a stale archive refresh resolves", async () => {

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -708,6 +708,79 @@ describe("SettingsScreen", () => {
     ).toBeInTheDocument();
   });
 
+  it("groups corrupted managed-worktree paths by project folder name", async () => {
+    const listThreads = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: 3_000,
+      threads: [
+        {
+          id: "thread-pwrsnap-1",
+          title: "Testing env setup",
+          titleSource: "explicit" as const,
+          archivedAt: 5_000,
+          createdAt: 1_000,
+          updatedAt: 2_000,
+          linkedDirectories: [
+            {
+              id: "/Users/huntharo/.codex/worktrees/mp7efuda/PwrSnap",
+              label: "PwrSnap",
+              path: "/Users/huntharo/.codex/worktrees/mp7efuda/PwrSnap",
+              worktreePath:
+                "/Users/huntharo/.codex/worktrees/mp7efuda/PwrSnap",
+              kind: "worktree" as const,
+            },
+          ],
+          source: "codex" as const,
+        },
+        {
+          id: "thread-pwrsnap-2",
+          title: "Popover window too tall",
+          titleSource: "explicit" as const,
+          archivedAt: 4_000,
+          createdAt: 1_000,
+          updatedAt: 2_000,
+          linkedDirectories: [
+            {
+              id: "/Users/huntharo/.codex/worktrees/mp32wplq/PwrSnap",
+              label: "PwrSnap",
+              path: "/Users/huntharo/.codex/worktrees/mp32wplq/PwrSnap",
+              worktreePath:
+                "/Users/huntharo/.codex/worktrees/mp32wplq/PwrSnap",
+              kind: "worktree" as const,
+            },
+          ],
+          source: "codex" as const,
+        },
+      ],
+    }));
+
+    render(
+      <SettingsScreen
+        desktopApi={{ listThreads }}
+        settings={createSettingsState()}
+        initialSection="archived"
+        onClose={() => undefined}
+      />,
+    );
+
+    const pwrSnapGroup = (await screen.findByRole("heading", {
+      name: "PwrSnap",
+    })).closest("section")!;
+    expect(within(pwrSnapGroup).getByText("2 threads")).toBeInTheDocument();
+    expect(
+      within(pwrSnapGroup).getByText("Testing env setup"),
+    ).toBeInTheDocument();
+    expect(
+      within(pwrSnapGroup).getByText("Popover window too tall"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: /mp7efuda/ }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: /mp32wplq/ }),
+    ).not.toBeInTheDocument();
+  });
+
   it("limits each archived project to the 20 most recent archive timestamps", async () => {
     const listThreads = vi.fn(async () => ({
       backend: "all" as const,

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -11,6 +11,7 @@ import {
 import { useState } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
+  AppServerListThreadsResponse,
   AppServerThreadSummary,
   DesktopSettingsSnapshot,
   MessagingPairingEntry,
@@ -580,6 +581,73 @@ describe("SettingsScreen", () => {
         threadId: "thread-archived",
       });
     });
+    await waitFor(() => {
+      expect(screen.queryByText("Archived code review")).not.toBeInTheDocument();
+    });
+    expect(screen.getByText("Restored Archived code review.")).toBeInTheDocument();
+  });
+
+  it("does not re-add a restored thread when a stale archive refresh resolves", async () => {
+    const archivedThread: AppServerThreadSummary = {
+      id: "thread-archived",
+      title: "Archived code review",
+      titleSource: "explicit",
+      createdAt: 1_000,
+      updatedAt: 2_000,
+      linkedDirectories: [],
+      source: "codex",
+    };
+    let resolveStaleRefresh:
+      | ((response: AppServerListThreadsResponse) => void)
+      | undefined;
+    const listThreads = vi
+      .fn()
+      .mockResolvedValueOnce({
+        backend: "all" as const,
+        fetchedAt: 3_000,
+        threads: [archivedThread],
+      })
+      .mockImplementationOnce(
+        () =>
+          new Promise<AppServerListThreadsResponse>((resolve) => {
+            resolveStaleRefresh = resolve;
+          }),
+      );
+    const restoreThread = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-archived",
+      restoredAt: 4_000,
+    }));
+
+    render(
+      <SettingsScreen
+        desktopApi={{ listThreads, restoreThread }}
+        settings={createSettingsState()}
+        initialSection="archived"
+        onClose={() => undefined}
+      />,
+    );
+
+    expect(await screen.findByText("Archived code review")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+    await waitFor(() => {
+      expect(listThreads).toHaveBeenCalledTimes(2);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Restore" }));
+    await waitFor(() => {
+      expect(screen.queryByText("Archived code review")).not.toBeInTheDocument();
+    });
+
+    await act(async () => {
+      resolveStaleRefresh?.({
+        backend: "all",
+        fetchedAt: 5_000,
+        threads: [archivedThread],
+      });
+    });
+
     await waitFor(() => {
       expect(screen.queryByText("Archived code review")).not.toBeInTheDocument();
     });

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -15,6 +15,7 @@ import type {
   AppServerThreadSummary,
   DesktopSettingsSnapshot,
   MessagingPairingEntry,
+  WorktreeSnapshotSummary,
 } from "@pwragent/shared";
 import { SettingsScreen } from "../SettingsScreen";
 import type { DesktopSettingsState } from "../useDesktopSettings";
@@ -298,6 +299,25 @@ function createSettingsState(
   };
 }
 
+function createArchivedSnapshot(
+  threadId: string,
+  archivedAt: number,
+): WorktreeSnapshotSummary {
+  return {
+    id: `snapshot-${threadId}-${archivedAt}`,
+    backend: "codex",
+    threadId,
+    worktreePath: `/worktrees/${threadId}`,
+    repositoryPath: "/repo/PwrAgnt",
+    snapshotRef: `refs/archive/${threadId}`,
+    snapshotCommit: "abc123",
+    createdAt: archivedAt,
+    archivedAt,
+    state: "archived",
+    ignoredFilesExcluded: true,
+  };
+}
+
 describe("SettingsScreen", () => {
   it("switches sections and saves settings", async () => {
     const settings = createSettingsState();
@@ -571,7 +591,9 @@ describe("SettingsScreen", () => {
     );
 
     expect(await screen.findByText("Archived code review")).toBeInTheDocument();
-    expect(screen.getByText("Needs to come back to the active thread list.")).toBeInTheDocument();
+    expect(
+      screen.getByText("Needs to come back to the active thread list."),
+    ).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "PwrAgnt" })).toBeInTheDocument();
     expect(screen.getByText("/repo/PwrAgnt")).toBeInTheDocument();
     expect(listThreads).toHaveBeenCalledWith({ archived: true });
@@ -601,6 +623,9 @@ describe("SettingsScreen", () => {
           titleSource: "explicit" as const,
           createdAt: 1_000,
           updatedAt: 4_000,
+          worktreeSnapshots: [
+            createArchivedSnapshot("thread-pwragent-2", 2_000),
+          ],
           linkedDirectories: [
             {
               id: "directory-1",
@@ -617,6 +642,7 @@ describe("SettingsScreen", () => {
           titleSource: "explicit" as const,
           createdAt: 1_000,
           updatedAt: 3_000,
+          worktreeSnapshots: [createArchivedSnapshot("thread-other", 3_000)],
           linkedDirectories: [
             {
               id: "directory-2",
@@ -633,6 +659,9 @@ describe("SettingsScreen", () => {
           titleSource: "explicit" as const,
           createdAt: 1_000,
           updatedAt: 2_000,
+          worktreeSnapshots: [
+            createArchivedSnapshot("thread-pwragent-1", 5_000),
+          ],
           linkedDirectories: [
             {
               id: "directory-1",
@@ -659,18 +688,79 @@ describe("SettingsScreen", () => {
       name: "PwrAgnt",
     })).closest("section")!;
     expect(within(pwrAgentGroup).getByText("2 threads")).toBeInTheDocument();
+    const firstPwrAgentThread = within(pwrAgentGroup).getByText(
+      "First PwrAgent thread",
+    );
+    const secondPwrAgentThread = within(pwrAgentGroup).getByText(
+      "Second PwrAgent thread",
+    );
     expect(
-      within(pwrAgentGroup).getByText("Second PwrAgent thread"),
-    ).toBeInTheDocument();
-    expect(
-      within(pwrAgentGroup).getByText("First PwrAgent thread"),
-    ).toBeInTheDocument();
+      firstPwrAgentThread.compareDocumentPosition(secondPwrAgentThread) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
 
     const otherGroup = screen.getByRole("heading", {
       name: "OtherProject",
     }).closest("section")!;
     expect(within(otherGroup).getByText("1 thread")).toBeInTheDocument();
-    expect(within(otherGroup).getByText("Other project thread")).toBeInTheDocument();
+    expect(
+      within(otherGroup).getByText("Other project thread"),
+    ).toBeInTheDocument();
+  });
+
+  it("limits each archived project to the 20 most recent archive timestamps", async () => {
+    const listThreads = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: 3_000,
+      threads: Array.from({ length: 25 }, (_, index): AppServerThreadSummary => {
+        const threadNumber = index + 1;
+        const threadId = `thread-${threadNumber}`;
+        return {
+          id: threadId,
+          title: `Archived thread ${String(threadNumber).padStart(2, "0")}`,
+          titleSource: "explicit",
+          createdAt: 1_000,
+          updatedAt: 1_000 + threadNumber,
+          worktreeSnapshots: [createArchivedSnapshot(threadId, threadNumber)],
+          linkedDirectories: [
+            {
+              id: "directory-1",
+              label: "PwrAgnt",
+              path: "/repo/PwrAgnt",
+              kind: "local",
+            },
+          ],
+          source: "codex",
+        };
+      }),
+    }));
+
+    render(
+      <SettingsScreen
+        desktopApi={{ listThreads }}
+        settings={createSettingsState()}
+        initialSection="archived"
+        onClose={() => undefined}
+      />,
+    );
+
+    const pwrAgentGroup = (await screen.findByRole("heading", {
+      name: "PwrAgnt",
+    })).closest("section")!;
+    expect(
+      within(pwrAgentGroup).getByText("Archived thread 25"),
+    ).toBeInTheDocument();
+    expect(
+      within(pwrAgentGroup).getByText("Archived thread 06"),
+    ).toBeInTheDocument();
+    expect(
+      within(pwrAgentGroup).queryByText("Archived thread 05"),
+    ).not.toBeInTheDocument();
+    expect(
+      within(pwrAgentGroup).getByText(
+        "Showing 20 of 25 most recent archived threads.",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("does not re-add a restored thread when a stale archive refresh resolves", async () => {

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -426,6 +426,16 @@ describe("Tangerine Terminal theme contract", () => {
     }
   });
 
+  it("lets SettingsSection own the archive section header divider", () => {
+    // Archive rows live directly inside a SettingsSection body. Adding
+    // a second top border to the thread container stacks with the
+    // SettingsSection header divider and makes the pane visibly heavier
+    // than neighboring settings panes.
+    expect(css).not.toMatch(
+      /\.settings-archive-project__threads\s*\{[\s\S]*?border-top:/,
+    );
+  });
+
   it("keeps Activity and Settings titlebar breadcrumbs visually identical", () => {
     // The Activity window's titlebar mirrors the Settings overlay's
     // right-pane titlebar — same eyebrow color, same separator

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -4327,6 +4327,53 @@ textarea,
   flex-direction: column;
 }
 
+.settings-archive-project {
+  border-top: 1px solid var(--border-subtle);
+}
+
+.settings-archive-project:first-child {
+  border-top: 0;
+}
+
+.settings-archive-project__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 18px;
+  background: var(--bg-panel-elevated);
+}
+
+.settings-archive-project__body {
+  min-width: 0;
+}
+
+.settings-archive-project__title {
+  margin: 0;
+  overflow: hidden;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.settings-archive-project__path {
+  margin: 3px 0 0;
+  overflow: hidden;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.settings-archive-project__threads {
+  border-top: 1px solid var(--border-subtle);
+}
+
 .settings-archive-row {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
@@ -4496,6 +4543,11 @@ textarea,
 }
 
 @media (max-width: 760px) {
+  .settings-archive-project__header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
   .settings-archive-row {
     grid-template-columns: 1fr;
   }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -4322,54 +4322,6 @@ textarea,
   padding: 14px 18px;
 }
 
-.settings-archive-list {
-  display: flex;
-  flex-direction: column;
-}
-
-.settings-archive-project {
-  border-top: 1px solid var(--border-subtle);
-}
-
-.settings-archive-project:first-child {
-  border-top: 0;
-}
-
-.settings-archive-project__header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 12px 18px;
-  background: var(--bg-panel-elevated);
-}
-
-.settings-archive-project__body {
-  min-width: 0;
-}
-
-.settings-archive-project__title {
-  margin: 0;
-  overflow: hidden;
-  color: var(--text-primary);
-  font-size: 13px;
-  font-weight: 700;
-  line-height: 1.25;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.settings-archive-project__path {
-  margin: 3px 0 0;
-  overflow: hidden;
-  color: var(--text-muted);
-  font-family: var(--font-mono);
-  font-size: 11px;
-  line-height: 1.35;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 .settings-archive-project__threads {
   border-top: 1px solid var(--border-subtle);
 }
@@ -4543,11 +4495,6 @@ textarea,
 }
 
 @media (max-width: 760px) {
-  .settings-archive-project__header {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
   .settings-archive-row {
     grid-template-columns: 1fr;
   }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3236,6 +3236,14 @@ textarea,
   outline: none;
 }
 
+.settings-nav__divider {
+  width: calc(100% - 24px);
+  height: 1px;
+  margin: 8px 12px;
+  border: 0;
+  background: var(--border-subtle);
+}
+
 .settings-content {
   min-height: 0;
   overflow: auto;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -4330,10 +4330,6 @@ textarea,
   padding: 14px 18px;
 }
 
-.settings-archive-project__threads {
-  border-top: 1px solid var(--border-subtle);
-}
-
 .settings-archive-row {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -4317,6 +4317,78 @@ textarea,
   background: var(--danger-soft);
 }
 
+.settings-archive-empty,
+.settings-archive-status {
+  padding: 14px 18px;
+}
+
+.settings-archive-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.settings-archive-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: start;
+  padding: 14px 18px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.settings-archive-row:first-child {
+  border-top: 0;
+}
+
+.settings-archive-row__body {
+  min-width: 0;
+}
+
+.settings-archive-row__title {
+  margin: 0;
+  overflow: hidden;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 650;
+  line-height: 1.3;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.settings-archive-row__summary {
+  display: -webkit-box;
+  overflow: hidden;
+  margin: 4px 0 0;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.settings-archive-row__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 10px;
+  margin: 6px 0 0;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.settings-archive-row__side {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.settings-archive-row__button {
+  min-height: 30px;
+  padding: 0 10px;
+  white-space: nowrap;
+}
+
 .settings-confirm-modal {
   position: fixed;
   z-index: 120;
@@ -4424,6 +4496,14 @@ textarea,
 }
 
 @media (max-width: 760px) {
+  .settings-archive-row {
+    grid-template-columns: 1fr;
+  }
+
+  .settings-archive-row__side {
+    justify-content: space-between;
+  }
+
   .settings-profile-row,
   .settings-profile-row__actions,
   .settings-codex-profile-details {

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -372,10 +372,21 @@ export type RestoreThreadRequest = {
   threadId: ThreadIdentifier;
 };
 
+export type RestoreThreadWorktreeResult = {
+  worktreePath: string;
+  repositoryPath?: string;
+  snapshotRef?: string;
+  restored: boolean;
+  snapshot?: WorktreeSnapshotSummary;
+  skippedReason?: string;
+  error?: string;
+};
+
 export type RestoreThreadResponse = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;
   restoredAt: number;
+  worktrees?: RestoreThreadWorktreeResult[];
 };
 
 export type ArchiveWorktreeRequest = {

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -162,6 +162,7 @@ export type AppServerThreadSummary = {
   projectKey?: string;
   createdAt?: number;
   updatedAt?: number;
+  archivedAt?: number;
   linkedDirectories: LinkedDirectorySummary[];
   gitBranch?: string;
   observedGitBranch?: string;

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -344,6 +344,7 @@ export type AppServerListThreadsResponse = {
   backend: AppServerBackendScope;
   fetchedAt: number;
   threads: AppServerThreadSummary[];
+  workspaceRoots?: string[];
 };
 
 export type ArchiveThreadCleanupResult = {


### PR DESCRIPTION
## Summary

- I added an Archived Threads settings tab that lists archived threads for restoration.
- I grouped archived threads by project folder, sorted projects and rows by the most recent archive timestamp, and capped each project preview at 20 threads.
- I made the grouping resilient to older corrupted managed-worktree rows so paths like `~/.codex/worktrees/<id>/PwrSnap` collapse back under the `PwrSnap` project instead of one section per worktree id.
- I rebased on `origin/main`, including the active-profile workspace-root filtering change, so default/dev/other profile project roots stay isolated according to the new standard.

## Verification

- I verified the archived settings regression suite with `pnpm test apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx`.
- I verified dependency boundaries with `pnpm lint:boundaries`.
- I checked commit signing on the latest checkpoint commit.

## Notes

- `pnpm --filter @pwragent/desktop typecheck` is blocked by an existing unrelated missing dependency/type resolution error for `prosemirror-history` in `src/renderer/src/features/composer/ComposerTiptapInput.tsx`.
