### PR TITLE
fix(deps): use supported dependabot cooldown keys

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,9 +48,6 @@ updates:
       include: "scope"
     cooldown:
       default-days: 7
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 7
     groups:
       github-actions-minor-patch:
         patterns:
@@ -97,9 +94,6 @@ updates:
       include: "scope"
     cooldown:
       default-days: 7
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 7
     groups:
       docs-containers-minor-patch:
         patterns:


### PR DESCRIPTION
## Summary

- I removed the unsupported semver-specific cooldown keys from the `github-actions` and `docker` Dependabot update blocks.
- I kept the general `default-days` cooldown for those ecosystems, and left the npm/Bundler semver-specific cooldowns unchanged.

## Verification

- I parsed `.github/dependabot.yml` with Ruby YAML.
- I verified the `github-actions` and `docker` blocks no longer contain `semver-*` cooldown keys.
- I verified the fix commit is signed with the configured SSH signing key.

## Notes

- This addresses the Dependabot parser failure from run `76360657634`.
