### PR TITLE
ci(release): isolate desktop signing secrets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,21 +13,28 @@ on:
         type: string
 
 permissions:
-  contents: write # publish releases to the same repo
+  contents: read
+  id-token: none
 
 jobs:
-  release:
-    name: Build, sign, notarize, publish
+  prepare:
+    name: Test and prepare signing input
     runs-on: macos-15 # Apple Silicon GH-hosted runner; matches Phase A signing identity
-    timeout-minutes: 60
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      id-token: none
+    outputs:
+      signing-input-sha256: ${{ steps.archive.outputs.sha256 }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
+          persist-credentials: false
 
       - name: Install Node.js and dependencies
-        uses: pwrdrvr/configure-nodejs@v1
+        uses: pwrdrvr/configure-nodejs@7c109865ae9af59c6fcd2f2a0e8cc851f6ded26a # v1
         with:
           node-version: 24.x
 
@@ -42,9 +49,69 @@ jobs:
       - name: Test (unit)
         run: pnpm test
 
-      - name: Build, sign, notarize, publish
+      - name: Prepare release stage
+        run: node apps/desktop/scripts/release.mjs --prepare-only
+
+      - name: Archive signing input
+        id: archive
+        run: |
+          set -euo pipefail
+          tarball="$RUNNER_TEMP/desktop-release-signing-input.tgz"
+          tar -czf "$tarball" \
+            package.json \
+            pnpm-lock.yaml \
+            pnpm-workspace.yaml \
+            apps/desktop/release-stage \
+            apps/desktop/scripts/release.mjs \
+            apps/desktop/scripts/verify-asar-contents.mjs \
+            apps/desktop/node_modules \
+            node_modules
+          sha256="$(shasum -a 256 "$tarball" | awk '{print $1}')"
+          echo "sha256=$sha256" >> "$GITHUB_OUTPUT"
+          printf "%s  desktop-release-signing-input.tgz\n" "$sha256" > "$RUNNER_TEMP/desktop-release-signing-input.tgz.sha256"
+
+      - name: Upload signing input
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: desktop-release-signing-input
+          path: |
+            ${{ runner.temp }}/desktop-release-signing-input.tgz
+            ${{ runner.temp }}/desktop-release-signing-input.tgz.sha256
+          retention-days: 7
+
+  sign:
+    name: Sign, notarize, publish
+    runs-on: macos-15
+    needs: prepare
+    timeout-minutes: 60
+    environment: apple-signing
+    permissions:
+      contents: write # publish releases to the same repo
+      id-token: none
+    steps:
+      - name: Download signing input
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: desktop-release-signing-input
+          path: .release-input
+
+      - name: Verify signing input
+        env:
+          EXPECTED_SHA256: ${{ needs.prepare.outputs.signing-input-sha256 }}
+        run: |
+          set -euo pipefail
+          cd .release-input
+          actual="$(shasum -a 256 desktop-release-signing-input.tgz | awk '{print $1}')"
+          test "$actual" = "$EXPECTED_SHA256"
+          shasum -a 256 --check desktop-release-signing-input.tgz.sha256
+
+      - name: Expand signing input
+        run: tar -xzf .release-input/desktop-release-signing-input.tgz
+
+      - name: Sign, notarize, publish
         env:
           # Code signing (Developer ID Application: PwrDrvr LLC, T44CNHC4UH).
+          # Store these in the apple-signing GitHub Environment, not as repo secrets.
           # CSC_LINK is the .p12 base64-encoded; CSC_KEY_PASSWORD is its password.
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
@@ -60,12 +127,12 @@ jobs:
           # Publish to the existing private pwrdrvr/PwrAgent repo.
           # Phase 1 (solo dogfooding). Phase 2 channel migration is in
           # docs/desktop-distribution-phase-2-runbook.md.
-          GH_TOKEN: ${{ secrets.RELEASES_PAT || secrets.GITHUB_TOKEN }}
-        run: pnpm --filter @pwragent/desktop release
+          GH_TOKEN: ${{ secrets.RELEASES_PAT || github.token }}
+        run: node apps/desktop/scripts/release.mjs --sign-stage-only
 
       - name: Publish stable-name DMG alias
         env:
-          GH_TOKEN: ${{ secrets.RELEASES_PAT || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASES_PAT || github.token }}
           RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
         run: |
           set -euo pipefail
@@ -78,7 +145,7 @@ jobs:
             --clobber
 
       - name: Upload release artifacts (debug retention)
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !cancelled() }}
         with:
           name: desktop-release-artifacts

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -49,6 +49,10 @@ files:
   - "!**/.eslintrc*"
   - "!**/.prettierrc*"
   - "!**/.github/**"
+  # Dev-only Electron native prebuilds are single-arch. electron-builder
+  # rebuilds build/Release for each target arch before creating the universal
+  # app, so including electron-native would break universal merge.
+  - "!**/electron-native/**"
   # Our own workspace package metadata is unused at runtime — vite inlines.
   - "!**/node_modules/@pwragent/*/AGENTS.md"
   - "!**/node_modules/@pwragent/*/src/**"

--- a/apps/desktop/scripts/release.mjs
+++ b/apps/desktop/scripts/release.mjs
@@ -13,6 +13,10 @@
  *       --no-publish  : build + package signed/notarized, no publish (local
  *                       end-to-end verification — Phase E5 in the release
  *                       packaging plan)
+ *       --prepare-only: build + prepare release-stage, no package/sign/publish
+ *       --sign-stage-only:
+ *                       sign/notarize/publish an already prepared release-stage
+ *                       without reinstalling dependencies or rerunning tests
  *       (default)     : build + package signed/notarized + publish to the
  *                       channel configured in electron-builder.yml
  *   - In CI, the App Store Connect API key may arrive as a base64-encoded
@@ -23,7 +27,7 @@
  */
 
 import { execSync, spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join, resolve } from "node:path";
 import { tmpdir } from "node:os";
@@ -37,7 +41,14 @@ const stageDir = join(desktopRoot, "release-stage");
 const args = process.argv.slice(2);
 const dryrun = args.includes("--dryrun");
 const noPublish = args.includes("--no-publish");
-const publish = !dryrun && !noPublish;
+const prepareOnly = args.includes("--prepare-only");
+const signStageOnly = args.includes("--sign-stage-only");
+
+if (prepareOnly && signStageOnly) {
+  throw new Error("--prepare-only and --sign-stage-only cannot be combined");
+}
+
+const publish = !dryrun && !noPublish && !prepareOnly;
 
 function step(label) {
   console.log(`\n→ ${label}`);
@@ -60,6 +71,14 @@ function runChecked(file, args, opts = {}) {
   }
 }
 
+function electronBuilderCli() {
+  const cli = join(desktopRoot, "node_modules", "electron-builder", "cli.js");
+  if (!existsSync(cli)) {
+    throw new Error(`electron-builder CLI is missing at ${cli}; signing jobs must use the prepared release artifact`);
+  }
+  return cli;
+}
+
 // 1. Decode CI-provided Apple API key (if present) to a real .p8 file.
 function maybeDecodeAppleApiKey() {
   if (process.env.APPLE_API_KEY && existsSync(process.env.APPLE_API_KEY)) {
@@ -75,51 +94,62 @@ function maybeDecodeAppleApiKey() {
   }
   const target = join(tmpdir(), `AuthKey_${keyId}.p8`);
   writeFileSync(target, Buffer.from(base64, "base64"));
+  chmodSync(target, 0o600);
   process.env.APPLE_API_KEY = target;
-  console.log(`  decoded APPLE_API_KEY_BASE64 -> ${target}`);
+  console.log("  decoded APPLE_API_KEY_BASE64 -> temporary App Store Connect key file");
 }
 
-// 2. Build (electron-vite -> apps/desktop/out/).
-step("license notices check");
-runChecked("pnpm", ["licenses:check"], { cwd: repoRoot });
+if (!signStageOnly) {
+  // 2. Build (electron-vite -> apps/desktop/out/).
+  step("license notices check");
+  runChecked("pnpm", ["licenses:check"], { cwd: repoRoot });
 
-step("electron-vite build");
-runChecked("pnpm", ["--filter", "@pwragent/desktop", "build"], { cwd: repoRoot });
+  step("electron-vite build");
+  runChecked("pnpm", ["--filter", "@pwragent/desktop", "build"], { cwd: repoRoot });
 
-// 3. Materialize a self-contained, flat node_modules under stage.
-step("pnpm deploy --prod -> release-stage");
-if (existsSync(stageDir)) {
-  rmSync(stageDir, { recursive: true, force: true });
-}
-mkdirSync(stageDir, { recursive: true });
-runChecked(
-  "pnpm",
-  ["deploy", "--filter", "@pwragent/desktop", "--prod", "--legacy", stageDir],
-  { cwd: repoRoot },
-);
-
-// 4. Copy the build output, notices, changelog, and electron-builder inputs into the stage so
-//    electron-builder finds them at well-known paths.
-//    pnpm deploy copies the package source tree (including out/ if it exists)
-//    into the stage. Remove stale copies before our controlled cp to avoid
-//    macOS cp -R nesting (cp -R src dst/ creates dst/src/ when dst exists).
-step("seed stage with build output + builder inputs");
-for (const dir of ["out", "build"]) {
-  const target = join(stageDir, dir);
-  if (existsSync(target)) {
-    rmSync(target, { recursive: true, force: true });
+  // 3. Materialize a self-contained, flat node_modules under stage.
+  step("pnpm deploy --prod -> release-stage");
+  if (existsSync(stageDir)) {
+    rmSync(stageDir, { recursive: true, force: true });
   }
-  run(`cp -R ${join(desktopRoot, dir)} ${target}`);
-}
-run(`cp ${join(desktopRoot, "electron-builder.yml")} ${join(stageDir, "electron-builder.yml")}`);
-for (const file of ["LICENSE", "THIRD_PARTY_LICENSES", "CHANGELOG.md"]) {
-  run(`cp ${join(repoRoot, file)} ${join(stageDir, file)}`);
+  mkdirSync(stageDir, { recursive: true });
+  runChecked(
+    "pnpm",
+    ["deploy", "--filter", "@pwragent/desktop", "--prod", "--legacy", stageDir],
+    { cwd: repoRoot },
+  );
+
+  // 4. Copy the build output, notices, changelog, and electron-builder inputs into the stage so
+  //    electron-builder finds them at well-known paths.
+  //    pnpm deploy copies the package source tree (including out/ if it exists)
+  //    into the stage. Remove stale copies before our controlled cp to avoid
+  //    macOS cp -R nesting (cp -R src dst/ creates dst/src/ when dst exists).
+  step("seed stage with build output + builder inputs");
+  for (const dir of ["out", "build"]) {
+    const target = join(stageDir, dir);
+    if (existsSync(target)) {
+      rmSync(target, { recursive: true, force: true });
+    }
+    run(`cp -R ${join(desktopRoot, dir)} ${target}`);
+  }
+  run(`cp ${join(desktopRoot, "electron-builder.yml")} ${join(stageDir, "electron-builder.yml")}`);
+  for (const file of ["LICENSE", "THIRD_PARTY_LICENSES", "CHANGELOG.md"]) {
+    run(`cp ${join(repoRoot, file)} ${join(stageDir, file)}`);
+  }
+
+  if (prepareOnly) {
+    step("prepared release-stage");
+    console.log(`  stage: ${stageDir}`);
+    process.exit(0);
+  }
+} else if (!existsSync(stageDir)) {
+  throw new Error(`release-stage is missing at ${stageDir}`);
 }
 
 // 5. electron-builder.
 step(`electron-builder --mac --universal (${publish ? "publish" : "no publish"}, ${dryrun ? "ad-hoc signed" : "signed"})`);
 maybeDecodeAppleApiKey();
-const builderArgs = ["electron-builder", "--mac", "--universal"];
+const builderArgs = ["--mac", "--universal"];
 if (dryrun) {
   // Use ad-hoc signing (identity=-) instead of no signing (identity=null).
   // electron-builder modifies the Electron binary to set fuses, which
@@ -131,7 +161,7 @@ if (dryrun) {
 }
 builderArgs.push(publish ? "--publish" : "--publish=never", publish ? "always" : "");
 const cleanedArgs = builderArgs.filter((arg) => arg !== "");
-runChecked("npx", cleanedArgs, { cwd: stageDir });
+runChecked("node", [electronBuilderCli(), ...cleanedArgs], { cwd: stageDir });
 
 // 6. Post-build asar contents check — fails if forbidden files (TS sources,
 //    tests, third-party docs, design docs, screenshots, etc.) leaked into the

--- a/docs/desktop-release-runbook.md
+++ b/docs/desktop-release-runbook.md
@@ -32,14 +32,26 @@ packaging plan as Phase A.
      with the **Developer** role (least privilege that can notarize).
    - Downloaded the `.p8` file (one-time).
    - Stored in 1Password alongside the Key ID and Issuer ID.
-4. **GitHub repository secrets** (for the release CI workflow):
-   - `CSC_LINK` — `.p12` base64-encoded
-   - `CSC_KEY_PASSWORD` — the `.p12` password
-   - `APPLE_API_KEY_BASE64` — `.p8` base64-encoded
-   - `APPLE_API_KEY_ID` — the Key ID
-   - `APPLE_API_ISSUER` — the Issuer ID
-   - `RELEASES_PAT` (optional) — fine-grained PAT scoped to `Contents: Read & Write`
-     on `pwrdrvr/PwrAgent`. Falls back to `GITHUB_TOKEN` if absent.
+4. **GitHub `apple-signing` Environment**.
+   - Create the `apple-signing` environment in `pwrdrvr/PwrAgent`.
+   - Add required reviewers and limit approval to **`huntharo`**.
+   - Limit the environment to protected release refs/tags when GitHub's
+     environment controls allow it.
+   - Store the Apple signing/notarization secrets on this environment, not as
+     repository secrets:
+     - `CSC_LINK` — `.p12` base64-encoded
+     - `CSC_KEY_PASSWORD` — the `.p12` password
+     - `APPLE_API_KEY_BASE64` — `.p8` base64-encoded
+     - `APPLE_API_KEY_ID` — the Key ID
+     - `APPLE_API_ISSUER` — the Issuer ID
+   - Optional publish secret, also environment-scoped if used:
+     `RELEASES_PAT` — fine-grained PAT scoped to `Contents: Read & Write` on
+     `pwrdrvr/PwrAgent`. The workflow falls back to `GITHUB_TOKEN` if absent.
+5. **GitHub repository secrets**.
+   - Do **not** keep Apple signing/notarization material as repository secrets
+     after the `apple-signing` environment secrets are configured.
+   - Non-release CI secrets, such as live smoke-test service keys, may remain as
+     repository secrets if their workflows require them.
 
 `APPLE_TEAM_ID` is hardcoded in `.github/workflows/release.yml` to `T44CNHC4UH`
 since it is not a secret.
@@ -69,8 +81,21 @@ git tag -s v1.0.0-alpha.7 -m "v1.0.0-alpha.7"
 git push origin v1.0.0-alpha.7
 ```
 
-The `Release Desktop (macOS universal)` workflow on `macos-15` triggers, runs
-typecheck + tests, and then `apps/desktop/scripts/release.mjs` which:
+The `Release Desktop (macOS universal)` workflow on `macos-15` triggers as two
+separate jobs:
+
+1. `Test and prepare signing input`, with `contents: read`, explicit
+   `id-token: none`, no Apple secrets, and checkout credentials disabled. It
+   installs dependencies, runs release metadata checks, typecheck, tests, and
+   `apps/desktop/scripts/release.mjs --prepare-only`.
+2. `Sign, notarize, publish`, gated by the protected `apple-signing`
+   environment, with `contents: write` and explicit `id-token: none`. It does
+   not check out the repository or run dependency installation/postinstall
+   scripts. It downloads the prepared artifact, verifies its SHA-256 digest,
+   expands it, and runs `apps/desktop/scripts/release.mjs --sign-stage-only`
+   with the environment-scoped Apple secrets.
+
+The no-secret prepare job:
 
 1. Verifies `THIRD_PARTY_LICENSES` matches a fresh deterministic generation.
 2. Builds main/preload/renderer with electron-vite.
@@ -78,22 +103,32 @@ typecheck + tests, and then `apps/desktop/scripts/release.mjs` which:
    `apps/desktop/release-stage/`.
 4. Seeds the stage with `out/`, `build/`, `electron-builder.yml`, `LICENSE`,
    and `THIRD_PARTY_LICENSES`.
-5. Decodes `APPLE_API_KEY_BASE64` from the env to a temp `.p8` file.
-6. Runs `electron-builder --mac --universal --publish always` which signs every
+5. Archives the prepared stage plus the already-resolved `electron-builder`
+   toolchain into the `desktop-release-signing-input` workflow artifact.
+
+The environment-gated signing job:
+
+1. Verifies the prepared artifact SHA-256 from the build job output.
+2. Decodes `APPLE_API_KEY_BASE64` from the env to a temp `.p8` file.
+3. Runs `electron-builder --mac --universal --publish always` from the
+   downloaded artifact, without invoking `pnpm install`, `npx`, or dependency
+   lifecycle scripts. `electron-builder` signs every
    helper bundle individually, signs the main `.app`, submits to Apple's
    notarization service via `notarytool`, staples the ticket, builds the DMG
    and universal updater ZIP, generates `latest-mac.yml`, and uploads
    everything to a GitHub Release on `pwrdrvr/PwrAgent`.
-7. Uploads the stable-name `PwrAgent.dmg` alias for landing-page download
+4. Uploads the stable-name `PwrAgent.dmg` alias for landing-page download
    links.
 
 Cycle time target: ≤ 12 minutes.
 
-Do not create the GitHub Release manually before the build succeeds. A manually
-created release appears before signing/notarization finishes. The current flow
-lets electron-builder create or update the release from the successful CI build;
-afterward, edit the release to mark prerelease tags as prereleases and replace
-the generated/empty notes with the matching `CHANGELOG.md` content.
+Do not approve the `apple-signing` environment unless the tag, commit, and
+metadata are the intended release. Do not create the GitHub Release manually
+before the build succeeds. A manually created release appears before
+signing/notarization finishes. The current flow lets electron-builder create or
+update the release from the successful CI build; afterward, edit the release to
+mark prerelease tags as prereleases and replace the generated/empty notes with
+the matching `CHANGELOG.md` content.
 
 If direct push to `main` is rejected, use the repo-local release skill fallback:
 open a short-lived release PR, wait for checks, squash merge it, then tag the
@@ -134,7 +169,7 @@ export GH_TOKEN=ghp_xxx_fine_grained_PAT_with_Contents_Read_Write_on_pwrdrvr_Pwr
 EOF
 source .envrc.release
 
-# 2. Run the orchestrator. Three modes:
+# 2. Run the orchestrator. Common local modes:
 pnpm --filter @pwragent/desktop package:dryrun  # unsigned, no publish
 pnpm --filter @pwragent/desktop package         # signed + notarized, no publish
 pnpm --filter @pwragent/desktop release         # signed + notarized + publish


### PR DESCRIPTION
## Summary

- I split the desktop release workflow into a no-secret prepare job and an `apple-signing` environment-gated signing job.
- I pinned release workflow actions by commit SHA, set explicit `id-token: none`, disabled checkout credential persistence, and kept `contents: write` only on the signing job.
- I added release script modes for preparing a signing artifact and signing from that artifact without dependency installation or postinstall scripts, and documented the environment-secret workflow.
- I excluded the dev-only `better-sqlite3/electron-native` prebuild from packaged app contents so universal packaging succeeds from the prepared artifact.

## Verification

- I ran `node --check apps/desktop/scripts/release.mjs`.
- I ran `RELEASE_TAG=v1.0.0-beta.5 pnpm release:check`.
- I parsed `.github/workflows/release.yml` with Ruby YAML.
- I ran `node apps/desktop/scripts/release.mjs --prepare-only`.
- I ran `node apps/desktop/scripts/release.mjs --sign-stage-only --dryrun`.
- I validated the release-signing tarball shape by archiving and expanding the same paths the workflow uses, then running the dry-run sign path.
- I ran `pnpm typecheck`.
- I ran `git diff --check`.

## Notes

- I created the `apple-signing` GitHub environment with `huntharo` as required reviewer and a selected `v*` tag policy.
- I verified the `apple-signing` environment now has the expected Apple signing/notarization secrets after they were added and the repo-level copies were removed.
