### PR TITLE
fix(desktop): avoid duplicate about version

### DIFF
--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -313,7 +313,9 @@ describe("bootstrapApp", () => {
     shellOpenExternalMock.mockReset();
     buildFromTemplateMock.mockClear();
     setNameMock.mockReset();
+    setAboutPanelOptionsMock.mockReset();
     getAppPathMock.mockClear();
+    getVersionMock.mockClear();
     dockSetIconMock.mockClear();
     nativeImageMock.isEmpty.mockReset();
     nativeImageMock.isEmpty.mockReturnValue(false);
@@ -370,6 +372,19 @@ describe("bootstrapApp", () => {
     expect(registerWindowPointerIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(registerRuntimeIdentityIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(setApplicationMenuMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("sets the About panel version without duplicating it as a build value", async () => {
+    startupProfilerInstance.start.mockResolvedValue();
+
+    await import("../index");
+    await flushMicrotasks();
+
+    expect(setAboutPanelOptionsMock).toHaveBeenCalledWith({
+      applicationName: "PwrAgent",
+      applicationVersion: "1.0.0-alpha.0",
+      copyright: "Copyright © 2026 PwrDrvr LLC.",
+    });
   });
 
   it("uses the PwrAgent icon for the development Dock icon on macOS", async () => {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -223,7 +223,6 @@ export function bootstrapApp(): void {
   app.setAboutPanelOptions({
     applicationName: APP_NAME,
     applicationVersion: app.getVersion(),
-    version: app.getVersion(),
     copyright: APP_COPYRIGHT,
   });
   initializeMainLogger();


### PR DESCRIPTION
## Summary

I fixed the macOS About panel so it only shows the app version once.

Electron renders `applicationVersion` plus the optional `version` build value as `Version x (y)`. We were passing `app.getVersion()` for both fields, which produced `Version 1.0.0-beta.6 (1.0.0-beta.6)`. This PR removes the duplicate build value and leaves `applicationVersion` as the single displayed version.

## Verification

I verified this with:

- `pnpm test apps/desktop/src/main/__tests__/index.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
