### PR TITLE
docs(docs-site): add Open Graph + Twitter Card meta for social unfurls

### DIFF
--- a/docs-site/_layouts/default.html
+++ b/docs-site/_layouts/default.html
@@ -3,8 +3,37 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>{% if page.title and page.url != "/" %}{{ page.title }} — {% endif %}{{ site.title }}</title>
-  <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
+  {%- assign page_title = site.title -%}
+  {%- if page.title and page.url != "/" -%}
+    {%- assign page_title = page.title | append: " — " | append: site.title -%}
+  {%- endif -%}
+  {%- assign page_description = page.description | default: site.description -%}
+  {%- assign og_image_path = page.og_image | default: site.og_image | default: "/assets/screenshots/desktop-hero.png" -%}
+  {%- assign og_image_url = og_image_path | absolute_url -%}
+  {%- assign og_image_alt = page.og_image_alt | default: site.og_image_alt | default: "PwrAgent desktop showing threads grouped by repo, an in-flight thread mid-conversation, four messenger status icons (Telegram, Discord, Slack, Mattermost), and per-thread model / access / worktree controls." -%}
+  <title>{{ page_title }}</title>
+  <meta name="description" content="{{ page_description }}">
+
+  <!-- Open Graph (Facebook, LinkedIn, Slack unfurls, Discord embeds, …). -->
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="{{ site.title }}">
+  <meta property="og:title" content="{{ page_title }}">
+  <meta property="og:description" content="{{ page_description }}">
+  <meta property="og:url" content="{{ page.url | absolute_url }}">
+  <meta property="og:image" content="{{ og_image_url }}">
+  <meta property="og:image:alt" content="{{ og_image_alt }}">
+  <meta property="og:image:width" content="2880">
+  <meta property="og:image:height" content="1920">
+
+  <!-- Twitter / X Card. summary_large_image gives the wide hero
+       treatment instead of the small thumbnail. -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="{{ page_title }}">
+  <meta name="twitter:description" content="{{ page_description }}">
+  <meta name="twitter:image" content="{{ og_image_url }}">
+  <meta name="twitter:image:alt" content="{{ og_image_alt }}">
+
+  <link rel="canonical" href="{{ page.url | absolute_url }}">
   <link rel="icon" type="image/png" sizes="32x32" href="{{ '/assets/favicon-32.png' | relative_url }}">
   <link rel="icon" type="image/png" sizes="16x16" href="{{ '/assets/favicon-16.png' | relative_url }}">
   <link rel="apple-touch-icon" sizes="180x180" href="{{ '/assets/apple-touch-icon.png' | relative_url }}">


### PR DESCRIPTION
## Summary

Pasting \`https://docs.pwragent.ai\` into X / Slack / Discord / LinkedIn / iMessage produced a bare URL — no preview card, no thumbnail, no title. Site was missing every social-meta tag platforms look for.

This adds the full Open Graph + Twitter Card set to the shared layout, generating proper unfurls on every page.

## What gets emitted (every page)

\`\`\`html
<meta property="og:type" content="website">
<meta property="og:site_name" content="PwrAgent">
<meta property="og:title" content="{{ page_title }}">
<meta property="og:description" content="{{ page_description }}">
<meta property="og:url" content="{{ canonical_url }}">
<meta property="og:image" content="…/assets/screenshots/desktop-hero.png">
<meta property="og:image:alt" content="PwrAgent desktop showing threads grouped by repo, …">
<meta property="og:image:width" content="2880">
<meta property="og:image:height" content="1920">

<meta name="twitter:card" content="summary_large_image">
<meta name="twitter:title" content="{{ page_title }}">
<meta name="twitter:description" content="{{ page_description }}">
<meta name="twitter:image" content="…/assets/screenshots/desktop-hero.png">
<meta name="twitter:image:alt" content="…">

<link rel="canonical" href="{{ canonical_url }}">
\`\`\`

## Per-page resolution

Title and description resolve **per-page** using the same fallback chain the existing \`<title>\` and \`<meta name="description">\` already use:

| Page | og:title | og:description |
|---|---|---|
| \`/\` (index) | \`PwrAgent\` | \`Run a coding agent. Drive it from your messenger.\` |
| \`/desktop/\` | \`Desktop — PwrAgent\` | \`Run a coding agent. Drive it from your messenger.\` |
| \`/providers/telegram/\` | \`Telegram — PwrAgent\` | \`Run a coding agent. Drive it from your messenger.\` |

Description falls back to the site default today because no page has frontmatter \`description:\`. Future improvement: add per-page \`description:\` for sharper unfurls; not blocking.

## OG image strategy

Points at the **existing** \`desktop-hero.png\` (2880×1920) — the real product screenshot already opening the landing page. Twitter \`summary_large_image\` cards display at 2:1, Facebook OG at 1.91:1, so the 3:2 source will center-crop. The thread + agent reply (the visually interesting content) is in the middle of the image, so the crop should look fine. If the first share looks off, easy follow-up: generate a dedicated \`og-image.png\` cropped to 1200×630 and override site-wide via \`_config.yml\`.

Per-page override path is already in place: any page can set \`og_image: /assets/screenshots/foo.png\` in frontmatter; site-wide default in \`_config.yml\` as \`og_image:\`.

## Verification

Local Docker build:

\`\`\`bash
$ curl -s http://localhost:4000/desktop/ | grep -E 'og:title|twitter:card|canonical'
<meta property="og:title" content="Desktop — PwrAgent">
<meta name="twitter:card" content="summary_large_image">
<link rel="canonical" href="http://0.0.0.0:4000/desktop/">
\`\`\`

URLs say \`0.0.0.0:4000\` locally because Jekyll's \`serve\` overrides \`site.url\` for dev safety; production builds (\`JEKYLL_ENV=production\` from the Pages workflow) honor the configured \`https://docs.pwragent.ai\` from \`_config.yml\`.

## Post-Deploy Validation

After merge + Pages deploy + CF cache purge, validate the unfurls against the actual platform validators:

- **X / Twitter:** <https://cards-dev.twitter.com/validator> (legacy URL still works), or just paste the URL into a draft tweet to see the preview.
- **Facebook / Meta / WhatsApp:** <https://developers.facebook.com/tools/debug/>
- **LinkedIn:** <https://www.linkedin.com/post-inspector/>
- **Slack:** unfurl in any channel; Slack caches aggressively, so use \`/uncache\` or wait ~24h after a fix.
- **Discord:** paste the URL in any channel.
- **iMessage:** Apple unfurls fresh on each paste.

\`curl -s https://docs.pwragent.ai/ | grep -c "og:image"\` should return 1 after deploy.

Cache invalidation note: every platform that cached the \`no-preview\` state needs to revalidate. Facebook/LinkedIn validators have a "scrape again" button. Slack has \`/remind\` patterns. X/Twitter usually re-fetches on each paste but can occasionally cache too.

🤖 Generated with Claude Opus 4.7 via [Claude Code](https://claude.com/claude-code)