### PR TITLE
docs(agents): don't-rewrite-historical-plans rule + .rgignore for plans/brainstorms/solutions

### DIFF
--- a/.rgignore
+++ b/.rgignore
@@ -1,0 +1,16 @@
+# ripgrep auto-picks this up from the repo root. Lists paths to
+# exclude from default `rg` searches because they are large
+# historical-artifact directories that drown out current-truth
+# signal when grepping the live codebase.
+#
+# Override per-search with: `rg --no-ignore <pattern>` or `rg -u`.
+
+# Decision-artifact directories. See `docs/plans/AGENTS.md` for the
+# don't-edit-historical-plans rule that motivates this exclusion.
+docs/plans/
+docs/brainstorms/
+docs/solutions/
+
+# Captured E2E protocol snippets — relevant only when debugging a
+# specific replay fixture. Mirrors the rule in the root AGENTS.md.
+apps/desktop/.local/protocol-captures/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@
 
 - Treat plan documents as decision artifacts, not implementation scripts.
 - Keep changes aligned with the current active plan unless the user explicitly changes scope.
-- Do not delete or "clean up" files in `docs/brainstorms/`, `docs/plans/`, or future `docs/solutions/` directories.
+- Do not delete or "clean up" files in `docs/brainstorms/`, `docs/plans/`, or future `docs/solutions/` directories. **Don't rewrite plan / brainstorm / solution files that weren't created on your current branch either** — they are point-in-time decision artifacts, a historical record of what was decided when. The one exception: the plan file your current branch is executing is fair game for in-flight updates (progress checkboxes, deferred-to-implementation answers resolved as you work). The root [`.rgignore`](.rgignore) skips all three directories from default `rg` searches; override per-search with `rg --no-ignore` (or `rg -u`) when you actually want to grep them. Full rules in [`docs/plans/AGENTS.md`](docs/plans/AGENTS.md).
 - GitHub Actions labels that intentionally trigger workflow behavior are
   documented in [.github/workflows/README.md](.github/workflows/README.md).
   Check that list before adding or using a CI-triggering PR label.

--- a/docs/plans/AGENTS.md
+++ b/docs/plans/AGENTS.md
@@ -1,0 +1,75 @@
+# docs/plans/ — Agent Guidance
+
+This directory holds **implementation plan files** — point-in-time
+decision artifacts produced by `/ce:plan` (and earlier planning
+workflows). Each one documents what was decided at the time, in
+service of executing a specific implementation.
+
+The rules below apply equally to `docs/brainstorms/` (pre-plan
+requirements docs from `/ce:brainstorm`) and to `docs/solutions/`
+(post-implementation learnings from `/ce:compound`) once that
+directory exists. The repo's [`.rgignore`](../../.rgignore) lists
+all three.
+
+## Don't edit historical plan files
+
+**You MUST NOT rewrite plan files that were not created on your
+current branch.** They are a historical record of what was decided
+and when. Editing them after the fact:
+
+- Destroys the chronology that makes the record useful.
+- Wastes tokens on a file nobody will read again unless they're
+  doing archaeology.
+- Reads as scope creep on any PR that touches them.
+- Confuses the next agent looking at git blame for "why did we
+  choose X over Y?" — the trail leads to a rewrite, not the
+  original decision.
+
+The **one exception** is the plan file your current branch is
+itself executing — that one is fair game to update with checkbox
+progress, dependency notes, deferred-to-implementation answers
+resolved during the work, etc. as you go.
+
+If you find a plan file that's factually wrong about something
+that matters today (rare), open an issue or a Slack-channel-style
+note in the PR you're working on — don't silently rewrite the plan.
+
+## Read plans, but selectively
+
+You CAN read these files. Read them when:
+
+- You're investigating "why was this built this way" and the git
+  blame trail points to a specific plan.
+- The plan you're executing references a prior plan by name.
+- A non-obvious architectural choice has you stuck and you suspect
+  the decision rationale is captured in a plan.
+
+Don't read them when:
+
+- You're doing a routine implementation that doesn't need
+  historical context.
+- You're searching for code patterns or current API shape (the
+  live codebase, [ARCHITECTURE.md](../../ARCHITECTURE.md), and
+  package-level `AGENTS.md` files are faster, more accurate
+  sources of truth).
+- You'd be reading "just in case" — the cost is real (token
+  budget, distraction from the actual task).
+
+## Skip from ripgrep by default
+
+The repo ships a [`.rgignore`](../../.rgignore) at the root that
+excludes `docs/plans/`, `docs/brainstorms/`, and `docs/solutions/`
+from default `rg` searches. Ripgrep picks it up automatically — no
+flag required.
+
+To search across plans intentionally (the rare case):
+
+```bash
+rg --no-ignore '<term>' docs/plans/
+# or the short form
+rg -u '<term>' docs/plans/
+```
+
+For everything else, the default `rg` invocation now returns the
+signal you want: matches in the live codebase, not in years of
+plan files describing decisions that already shipped.

--- a/docs/plans/CLAUDE.md
+++ b/docs/plans/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary

Two recurring agent failure modes we've seen across sessions:

1. **Silent rewrites of historical plan files** mid-PR — destroys the chronology that makes the record useful, wastes tokens, reads as scope creep on the PR.
2. **Ripgrep noise** — across-the-repo searches get drowned in plan-doc matches that have nothing to do with the current code-search target.

Both have one fix: make "don't touch historical decision artifacts" a written rule, and make "skip them in default `rg`" a mechanical default.

## Changes

### 1. New: `docs/plans/AGENTS.md` (with `CLAUDE.md` symlink)

Per-directory agent guidance spelling out:

- **Don't rewrite plan files you didn't create on the current branch.** They're a point-in-time record. The one exception is the plan your branch is itself executing (in-flight progress updates fine).
- **Reading plans is fine; be selective.** Read for historical "why was this built this way" context. Don't read "just in case" — the cost is real (token budget, distraction).
- **Default `rg` skips this directory.** Override per-search with `rg --no-ignore` (or `rg -u`).

Same rules apply equally to `docs/brainstorms/` and `docs/solutions/` (when it exists). All three are covered.

### 2. New: `.rgignore` at repo root

```
docs/plans/
docs/brainstorms/
docs/solutions/
apps/desktop/.local/protocol-captures/
```

Ripgrep auto-discovers `.rgignore` — no flag required, no other tool affected. The protocol-captures path was already a "skip by default" recommendation in the root `AGENTS.md`; now it's mechanically enforced too.

### 3. Updated: root `AGENTS.md` "Workflow" bullet

The existing one-line `Do not delete or "clean up"...` expanded into the don't-rewrite rule + the ripgrep escape hatch + a pointer to `docs/plans/AGENTS.md` for the full version.

## Verification

```bash
$ rg -c "Implementation Units"
apps/desktop/e2e/fixtures/codex-todo-list/raw.capture.jsonl:2
# ↑ no hits in docs/plans/ — .rgignore working

$ rg -c "Implementation Units" --no-ignore
docs/plans/2026-05-02-004-fix-messaging-handoff-branch-picker-plan.md:1
docs/plans/2026-05-02-001-fix-messaging-typing-indicator-plan.md:1
docs/plans/2026-05-09-001-feat-messaging-rate-limit-slow-mode-plan.md:1
docs/plans/2026-05-06-001-feat-settings-screens-design-alignment-plan.md:1
docs/plans/2026-05-02-001-feat-messaging-tool-update-verbosity-plan.md:1
# ↑ override flag brings them back when intentional
```

## Out of scope (could be follow-ups)

- **Mirror AGENTS.md to `docs/brainstorms/`.** Same rules apply, but the user only explicitly asked for `docs/plans/`. The root AGENTS.md and the in-file mentions cover brainstorms by reference. Easy follow-up if desired.
- **Pre-commit hook that blocks edits to plan files not created on current branch.** Mechanical enforcement on top of the written rule. Bigger lift; defer until the written rule + .rgignore prove insufficient.

🤖 Generated with Claude Opus 4.7 via [Claude Code](https://claude.com/claude-code)