### PR TITLE
ux(desktop): tighten directory rows + Finder-style sidebar scrollbar

### DIFF
--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1383,7 +1383,11 @@ textarea,
   overflow-y: auto;
   min-height: 0;
   padding-left: 0;
-  padding-right: 0;
+  /* 4px right padding holds row content (notably the selected
+     thread row's accent-border) clear of the scrollbar gutter so
+     the row's right border doesn't visually kiss the thumb. Left
+     stays at 0 — the title-width gain there is intentional. */
+  padding-right: 4px;
   scrollbar-width: thin;
   scrollbar-color: rgba(140, 133, 122, 0.46) rgba(247, 243, 235, 0.05);
   /* Finder-style scrollbar gutter (sidebar-tightening pass): reserve
@@ -1400,7 +1404,7 @@ textarea,
   overflow-y: auto;
   padding-top: 0;
   padding-left: 0;
-  padding-right: 0;
+  padding-right: 4px;
   scrollbar-width: thin;
   scrollbar-color: rgba(140, 133, 122, 0.46) rgba(247, 243, 235, 0.05);
   scrollbar-gutter: stable;
@@ -2271,12 +2275,9 @@ textarea,
   color: var(--text-muted);
   font-size: 16px;
   line-height: 1;
-  /* Hold the icon a few pixels in from the scrollbar gutter. The
-     hover-state outline can still bleed right up to the gutter —
-     that's only a 1-frame visual on hover and not worth padding
-     out — but the icon glyph itself should never touch the
-     scrollbar thumb when the list is scrolled. */
-  margin-right: 4px;
+  /* The list wrapper carries `padding-right: 4px` so the icon
+     glyph already sits clear of the scrollbar gutter — no
+     additional margin needed here. */
 }
 
 .directory-row__launchpad-button:hover,

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1382,10 +1382,16 @@ textarea,
   flex: 1;
   overflow-y: auto;
   min-height: 0;
-  padding-left: 4px;
-  padding-right: 4px;
+  padding-left: 0;
+  padding-right: 0;
   scrollbar-width: thin;
   scrollbar-color: rgba(140, 133, 122, 0.46) rgba(247, 243, 235, 0.05);
+  /* Finder-style scrollbar gutter (sidebar-tightening pass): reserve
+     a stable 10px column on the right for the scrollbar so the thumb
+     never overlays row content. The previous overlay-scrollbar
+     behavior intermittently failed to hide on macOS Chromium and
+     visually collided with titles + the per-row launchpad button. */
+  scrollbar-gutter: stable;
 }
 
 .directory-groups {
@@ -1393,10 +1399,11 @@ textarea,
   min-height: 0;
   overflow-y: auto;
   padding-top: 0;
-  padding-left: 4px;
-  padding-right: 4px;
+  padding-left: 0;
+  padding-right: 0;
   scrollbar-width: thin;
   scrollbar-color: rgba(140, 133, 122, 0.46) rgba(247, 243, 235, 0.05);
+  scrollbar-gutter: stable;
 }
 
 .sidebar-list--dense::-webkit-scrollbar,
@@ -2137,7 +2144,11 @@ textarea,
 }
 
 .directory-row {
-  padding: 10px 0 0;
+  /* Sidebar-tightening pass: the previous 10px top padding + 44px
+     summary min-height + 34px launchpad button meant each
+     directory header took ~54px. Recovered ~20px per row by halving
+     the top padding and tightening the summary geometry below. */
+  padding: 4px 0 0;
   border-top: 1px solid var(--border-subtle);
 }
 
@@ -2150,8 +2161,11 @@ textarea,
   position: sticky;
   top: 0;
   z-index: 5;
+  /* Gap between summary button and launchpad icon button. Tightened
+     from 8 → 4 — the icon button itself lost its border (no longer
+     reads as a separate "card" the way the framed 34px button did). */
   grid-template-columns: minmax(0, 1fr) auto;
-  gap: 8px;
+  gap: 4px;
   align-items: center;
   background: var(--bg-sidebar);
 }
@@ -2160,9 +2174,21 @@ textarea,
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
-  gap: 12px;
-  min-height: 44px;
-  padding: 10px 12px;
+  /* Inner gap between title block and meta block. Tightened from
+     12 → 8 since the meta block now sits tighter against the
+     scrollbar gutter. */
+  gap: 8px;
+  /* Row height tightened 44 → 32. Was set to match the masthead's
+     44px button height, but rows are list entries and don't need
+     that same hit-target generosity. Combined with the row top
+     padding drop, each directory header now reads ~22px taller
+     than the comfortable touch target instead of 54px. */
+  min-height: 32px;
+  /* Lateral inset tightened 12 → 4 to recover horizontal space for
+     the title text. Combined with dropping the sidebar-list's
+     padding-left/right above, the title can grow ~30–40px wider in
+     the same sidebar width. */
+  padding: 4px 4px;
 }
 
 .directory-row__summary:focus,
@@ -2224,34 +2250,40 @@ textarea,
 }
 
 .directory-row__launchpad-button {
+  /* Sidebar-tightening pass: stripped the 34px framed-button
+     treatment (border + bg-panel + 8px radius) — at directory-row
+     density it read as "another card" inside the row instead of an
+     inline icon affordance. Now a flat 24px icon button that picks
+     up an accent-soft hover state. */
   display: inline-flex;
-  width: 34px;
-  height: 34px;
+  width: 24px;
+  height: 24px;
   align-items: center;
   justify-content: center;
   appearance: none;
   cursor: pointer;
   padding: 0;
-  border: 1px solid var(--border-subtle);
-  border-radius: 8px;
-  background: var(--bg-panel);
-  color: var(--text-secondary);
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
   font-size: 16px;
   line-height: 1;
 }
 
 .directory-row__launchpad-button:hover,
 .directory-row__launchpad-button:focus-visible {
-  border-color: var(--accent-border);
-  background: var(--bg-panel-hover);
-  color: var(--text-primary);
+  background: var(--accent-soft);
+  color: var(--accent-bright);
   outline: none;
 }
 
 .directory-row__launchpad-button.has-draft {
-  border-color: var(--accent-border);
-  background: var(--bg-panel-hover);
-  color: var(--text-primary);
+  /* When the directory has an in-flight launchpad draft the user
+     hasn't sent yet, the button is tinted (not boxed) so the cue
+     reads as "the icon is active" rather than "the icon got a
+     new outline". */
+  color: var(--accent-bright);
 }
 
 .directory-row__details {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2184,11 +2184,13 @@ textarea,
      padding drop, each directory header now reads ~22px taller
      than the comfortable touch target instead of 54px. */
   min-height: 32px;
-  /* Lateral inset tightened 12 → 4 to recover horizontal space for
-     the title text. Combined with dropping the sidebar-list's
-     padding-left/right above, the title can grow ~30–40px wider in
-     the same sidebar width. */
-  padding: 4px 4px;
+  /* Lateral inset: 4px on the left mirrors the gap from the
+     selected-row border to the folder icon; 10px on the right gives
+     the chevron the same visual breathing room from the
+     selected-row border on the opposite edge (chevron is a
+     rotated-square glyph so it visually crowds its bounding-box
+     right edge more than the folder icon crowds its left). */
+  padding: 4px 10px 4px 4px;
 }
 
 .directory-row__summary:focus,
@@ -2269,6 +2271,12 @@ textarea,
   color: var(--text-muted);
   font-size: 16px;
   line-height: 1;
+  /* Hold the icon a few pixels in from the scrollbar gutter. The
+     hover-state outline can still bleed right up to the gutter —
+     that's only a 1-frame visual on hover and not worth padding
+     out — but the icon glyph itself should never touch the
+     scrollbar thumb when the list is scrolled. */
+  margin-right: 4px;
 }
 
 .directory-row__launchpad-button:hover,


### PR DESCRIPTION
Two internal-feedback items on the Directories lens in the sidebar.

## 1. Scrollbar moved into a stable right gutter

The overlay scrollbar on the dense directory list was overlapping row content (chevron, count pill, per-row launchpad button) and didn't reliably hide on idle on macOS Chromium. Finder's left sidebar parks its scrollbar in a permanent right-gutter, which is the affordance to copy.

\`.sidebar-list--dense\` and \`.directory-groups\` now declare \`scrollbar-gutter: stable\` — the 10px scrollbar column is always reserved on the right, so the thumb appears in the gutter and never over a row's contents. Also dropped the 4px lateral padding on the list wrappers since the gutter handles its own offset.

This also applies to the Recents list (\`RecentsList.tsx\` reuses \`.sidebar-list--dense\`), which gets the same Finder-style treatment for free.

## 2. Directory rows tightened — recovered ~30–40px lateral, ~20px vertical per row

Each directory row was ~54px tall and lateral-padded heavily. The per-row "new thread for this directory" button was a 34×34 panel-tinted card with a 1px border — read as "another button-shaped thing inside the row" rather than an inline icon.

| Selector | Was | Now |
|---|---|---|
| \`.directory-row { padding-top }\` | 10px | 4px |
| \`.directory-row__summary { min-height }\` | 44px | 32px |
| \`.directory-row__summary { padding }\` | 10px 12px | 4px 4px |
| \`.directory-row__header { gap }\` | 8px | 4px |
| \`.directory-row__summary { gap }\` | 12px | 8px |
| \`.directory-row__launchpad-button { size }\` | 34×34, 1px border, bg-panel, radius 8 | 24×24, no border, transparent, radius 6 |
| \`.directory-row__launchpad-button:hover\` | border-accent + bg-panel-hover | bg accent-soft + accent-bright text |
| \`.directory-row__launchpad-button.has-draft\` | bordered + tinted | icon tinted (accent-bright) |

Net: each directory header is ~36px tall (was ~54), titles get ~30–40px more horizontal room on the same sidebar width, and the launchpad button reads as an inline icon affordance instead of a competing button.

## Test plan

- [x] \`pnpm --filter @pwragent/desktop typecheck\` — clean
- [x] \`pnpm test apps/desktop/src/renderer\` — 613 pass
- [x] \`pnpm lint:boundaries\` — clean (1220 modules)
- [x] Visual sanity in dev: Recents list scrollbar appears in the gutter not over content; Directories rows are noticeably tighter; launchpad buttons read as inline icons.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: pure CSS layout change, no IPC / persistence / network surface touched.

🤖 Generated with [Claude Opus 4.7](https://claude.com/claude-code) (1M context, extended thinking)