### PR TITLE
feat(desktop): add update channel setting

### DIFF
--- a/apps/desktop/src/main/__tests__/auto-updater.test.ts
+++ b/apps/desktop/src/main/__tests__/auto-updater.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type UpdateEventHandler = (info?: { version?: string }) => void;
+
+const ipcHandlers = new Map<string, (...args: unknown[]) => unknown>();
+const updateEventHandlers = new Map<string, UpdateEventHandler>();
+const windowSendMock = vi.fn();
+const checkForUpdatesMock = vi.fn();
+const resolveUpdateChannelMock = vi.fn();
+const logInfoMock = vi.fn();
+const logWarnMock = vi.fn();
+
+const autoUpdaterMock = {
+  allowPrerelease: false,
+  autoDownload: false,
+  autoInstallOnAppQuit: false,
+  checkForUpdates: checkForUpdatesMock,
+  currentVersion: { version: "1.0.0-beta.7" },
+  logger: undefined as Console | undefined,
+  on: vi.fn((event: string, handler: UpdateEventHandler) => {
+    updateEventHandlers.set(event, handler);
+  }),
+  quitAndInstall: vi.fn(),
+};
+
+vi.mock("electron", () => ({
+  BrowserWindow: {
+    getAllWindows: vi.fn(() => [
+      {
+        isDestroyed: () => false,
+        webContents: {
+          send: windowSendMock,
+        },
+      },
+    ]),
+  },
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      ipcHandlers.set(channel, handler);
+    }),
+    removeHandler: vi.fn((channel: string) => {
+      ipcHandlers.delete(channel);
+    }),
+  },
+}));
+
+vi.mock("electron-updater", () => ({
+  default: {
+    autoUpdater: autoUpdaterMock,
+  },
+}));
+
+vi.mock("../settings/desktop-settings-singleton", () => ({
+  getDesktopSettingsService: vi.fn(() => ({
+    resolveUpdateChannel: resolveUpdateChannelMock,
+  })),
+}));
+
+vi.mock("../log", () => ({
+  getMainLogger: vi.fn(() => ({
+    info: logInfoMock,
+    warn: logWarnMock,
+  })),
+}));
+
+async function importAutoUpdater() {
+  return await import("../auto-updater");
+}
+
+describe("auto updater", () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    process.env.NODE_ENV = "production";
+    ipcHandlers.clear();
+    updateEventHandlers.clear();
+    windowSendMock.mockReset();
+    checkForUpdatesMock.mockReset();
+    checkForUpdatesMock.mockResolvedValue({
+      updateInfo: { version: "1.0.0-beta.8" },
+    });
+    resolveUpdateChannelMock.mockReset();
+    resolveUpdateChannelMock.mockReturnValue("latest");
+    logInfoMock.mockReset();
+    logWarnMock.mockReset();
+    autoUpdaterMock.allowPrerelease = false;
+    autoUpdaterMock.autoDownload = false;
+    autoUpdaterMock.autoInstallOnAppQuit = false;
+    autoUpdaterMock.logger = undefined;
+    autoUpdaterMock.on.mockClear();
+    autoUpdaterMock.quitAndInstall.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  it("checks on startup and then hourly", async () => {
+    const updater = await importAutoUpdater();
+
+    updater.initAutoUpdater();
+    await Promise.resolve();
+
+    expect(checkForUpdatesMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(updater.APP_UPDATE_CHECK_INTERVAL_MS);
+
+    expect(checkForUpdatesMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps a downloaded update visible during follow-up no-update checks", async () => {
+    const updater = await importAutoUpdater();
+
+    updater.initAutoUpdater();
+    updateEventHandlers.get("update-downloaded")?.({ version: "1.0.0-beta.8" });
+    windowSendMock.mockClear();
+
+    updateEventHandlers.get("checking-for-update")?.();
+    updateEventHandlers.get("update-not-available")?.({
+      version: "1.0.0-beta.7",
+    });
+
+    expect(windowSendMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
@@ -53,6 +53,39 @@ describe("desktopSettingsPatchToEdits — image uploads", () => {
   });
 });
 
+describe("desktopSettingsPatchToEdits — updates", () => {
+  it("writes the prerelease update channel", () => {
+    expect(
+      desktopSettingsPatchToEdits({
+        updates: {
+          channel: "prerelease",
+        },
+      }),
+    ).toEqual([
+      {
+        op: "set",
+        path: ["updates", "channel"],
+        value: "prerelease",
+      },
+    ]);
+  });
+
+  it("removes the update channel when saving the default", () => {
+    expect(
+      desktopSettingsPatchToEdits({
+        updates: {
+          channel: "latest",
+        },
+      }),
+    ).toEqual([
+      {
+        op: "delete",
+        path: ["updates", "channel"],
+      },
+    ]);
+  });
+});
+
 describe("desktopSettingsPatchToEdits — messaging attachments", () => {
   it("writes non-default image upload profiles", () => {
     expect(

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -39,6 +39,9 @@ describe("DesktopSettingsService", () => {
         "[image_uploads]",
         "pasted_image_max_patches = 4096",
         "",
+        "[updates]",
+        'channel = "prerelease"',
+        "",
         "[messaging.attachments]",
         'image_profile = "high"',
         "",
@@ -107,6 +110,10 @@ describe("DesktopSettingsService", () => {
       value: 4096,
       source: "config",
     });
+    expect(snapshot.updates.channel).toEqual({
+      value: "prerelease",
+      source: "config",
+    });
     expect(snapshot.messaging.attachments.imageProfile).toEqual({
       value: "high",
       source: "config",
@@ -164,6 +171,51 @@ describe("DesktopSettingsService", () => {
     expect(snapshot.worktrees.effectivePath).toMatch(
       /\.pwragent\/worktrees$/,
     );
+  });
+
+  it("defaults the update channel and only persists prerelease", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    const service = new DesktopSettingsService({
+      configPath,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    const initial = await service.readSettings();
+    expect(initial.updates.channel).toEqual({
+      value: "latest",
+      source: "default",
+    });
+    expect(service.resolveUpdateChannel()).toBe("latest");
+
+    await service.writeConfigPatch({
+      updates: {
+        channel: "prerelease",
+      },
+    });
+
+    const afterPrerelease = fs.readFileSync(configPath, "utf8");
+    expect(afterPrerelease).toContain("[updates]");
+    expect(afterPrerelease).toContain('channel = "prerelease"');
+    expect((await service.readSettings()).updates.channel).toEqual({
+      value: "prerelease",
+      source: "config",
+    });
+    expect(service.resolveUpdateChannel()).toBe("prerelease");
+
+    await service.writeConfigPatch({
+      updates: {
+        channel: "latest",
+      },
+    });
+
+    const afterDefault = fs.readFileSync(configPath, "utf8");
+    expect(afterDefault).not.toContain("channel");
+    expect((await service.readSettings()).updates.channel).toEqual({
+      value: "latest",
+      source: "default",
+    });
   });
 
   it("defaults the image upload profile and only persists non-default values", async () => {

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -14,6 +14,7 @@ const disposeAppMetadataIpcHandlersMock = vi.fn();
 const registerAppUpdateIpcHandlersMock = vi.fn();
 const disposeAppUpdateIpcHandlersMock = vi.fn();
 const initAutoUpdaterMock = vi.fn();
+const checkForAppUpdatesNowMock = vi.fn();
 const showAppLogWindowMock = vi.fn();
 const showChangelogWindowMock = vi.fn();
 const showThirdPartyNoticesWindowMock = vi.fn();
@@ -132,6 +133,7 @@ vi.mock("../ipc/app-metadata", () => ({
 }));
 
 vi.mock("../auto-updater", () => ({
+  checkForAppUpdatesNow: checkForAppUpdatesNowMock,
   registerAppUpdateIpcHandlers: registerAppUpdateIpcHandlersMock,
   disposeAppUpdateIpcHandlers: disposeAppUpdateIpcHandlersMock,
   initAutoUpdater: initAutoUpdaterMock,
@@ -263,6 +265,10 @@ describe("bootstrapApp", () => {
     disposeAgentIpcHandlersMock.mockReset();
     registerApplicationIpcHandlersMock.mockReset();
     disposeApplicationIpcHandlersMock.mockReset();
+    registerAppUpdateIpcHandlersMock.mockReset();
+    disposeAppUpdateIpcHandlersMock.mockReset();
+    initAutoUpdaterMock.mockReset();
+    checkForAppUpdatesNowMock.mockReset();
     showAppLogWindowMock.mockReset();
     showChangelogWindowMock.mockReset();
     showThirdPartyNoticesWindowMock.mockReset();
@@ -449,6 +455,9 @@ describe("bootstrapApp", () => {
     const helpMenu = template?.find((item) => item.role === "help");
     const item = (label: string) =>
       helpMenu?.submenu?.find((menuItem) => menuItem.label === label);
+
+    item("Check for Updates")?.click?.();
+    expect(checkForAppUpdatesNowMock).toHaveBeenCalledWith("menu");
 
     item("Third-Party Notices")?.click?.();
     expect(showThirdPartyNoticesWindowMock).toHaveBeenCalledOnce();

--- a/apps/desktop/src/main/auto-updater.ts
+++ b/apps/desktop/src/main/auto-updater.ts
@@ -22,9 +22,12 @@ const log = getMainLogger("pwragent:updater");
 const GITHUB_RELEASES_URL =
   "https://api.github.com/repos/pwrdrvr/PwrAgent/releases?per_page=30";
 const RELEASE_FETCH_TIMEOUT_MS = 5_000;
+export const APP_UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1_000;
 
 let initialized = false;
 let updateStatus: AppUpdateStatus = { status: "idle" };
+let periodicUpdateCheckTimer: ReturnType<typeof setInterval> | undefined;
+let updateCheckInFlight: Promise<AppUpdateCheckResult> | undefined;
 
 type GitHubRelease = {
   draft?: boolean;
@@ -67,6 +70,105 @@ function configureAutoUpdaterChannel(): void {
     allowPrerelease: autoUpdater.allowPrerelease,
     updateChannel,
   });
+}
+
+function productionUpdatesEnabled(): boolean {
+  return process.env.NODE_ENV === "production";
+}
+
+function developmentUpdateCheckResult(): AppUpdateCheckResult {
+  return {
+    status: "skipped",
+    reason: "auto-update disabled in development",
+  };
+}
+
+function preserveDownloadedStatus(nextStatus: AppUpdateStatus): boolean {
+  if (updateStatus.status !== "downloaded") {
+    return false;
+  }
+  return (
+    nextStatus.status === "checking" ||
+    nextStatus.status === "no-update" ||
+    nextStatus.status === "error"
+  );
+}
+
+function setUpdateStatusUnlessDownloaded(nextStatus: AppUpdateStatus): void {
+  const currentStatus = updateStatus;
+  if (
+    currentStatus.status === "downloaded" &&
+    preserveDownloadedStatus(nextStatus)
+  ) {
+    log.info("keeping downloaded update status during follow-up check", {
+      currentVersion: currentStatus.version,
+      nextStatus: nextStatus.status,
+    });
+    return;
+  }
+  setUpdateStatus(nextStatus);
+}
+
+export async function checkForAppUpdatesNow(
+  trigger: "startup" | "periodic" | "manual" | "menu" = "manual",
+): Promise<AppUpdateCheckResult> {
+  if (!productionUpdatesEnabled()) {
+    const result = developmentUpdateCheckResult();
+    setUpdateStatus(result);
+    return result;
+  }
+
+  if (updateCheckInFlight) {
+    log.info("joining in-flight update check", { trigger });
+    return updateCheckInFlight;
+  }
+
+  updateCheckInFlight = (async () => {
+    try {
+      log.info("checking for app updates", { trigger });
+      configureAutoUpdaterChannel();
+      const result = await autoUpdater.checkForUpdates();
+      if (updateStatus.status === "downloaded") {
+        return { status: "downloaded", version: updateStatus.version };
+      }
+      if (!result || !result.updateInfo) {
+        return {
+          status: "no-update",
+          version: result?.updateInfo?.version ?? "unknown",
+        };
+      }
+      const currentVersion = autoUpdater.currentVersion?.version ?? "unknown";
+      if (result.updateInfo.version === currentVersion) {
+        return { status: "no-update", version: currentVersion };
+      }
+      return { status: "available", version: result.updateInfo.version };
+    } catch (err) {
+      const result = {
+        status: "error",
+        message: err instanceof Error ? err.message : String(err),
+      } as const;
+      setUpdateStatusUnlessDownloaded(result);
+      log.warn("checkForUpdates failed", {
+        message: result.message,
+        trigger,
+      });
+      return result;
+    } finally {
+      updateCheckInFlight = undefined;
+    }
+  })();
+
+  return updateCheckInFlight;
+}
+
+function startPeriodicUpdateChecks(): void {
+  if (periodicUpdateCheckTimer) {
+    return;
+  }
+  periodicUpdateCheckTimer = setInterval(() => {
+    void checkForAppUpdatesNow("periodic");
+  }, APP_UPDATE_CHECK_INTERVAL_MS);
+  periodicUpdateCheckTimer.unref?.();
 }
 
 function releaseInfoFromGitHubRelease(
@@ -146,12 +248,9 @@ export function initAutoUpdater(): void {
   // Skip in development. The dev binary isn't signed and Squirrel.Mac would
   // refuse to apply any update anyway. Skipping cleanly avoids spurious
   // 404s when running `pnpm dev` without a release feed.
-  if (process.env.NODE_ENV !== "production") {
+  if (!productionUpdatesEnabled()) {
     log.info("auto-update disabled in non-production");
-    setUpdateStatus({
-      status: "skipped",
-      reason: "auto-update disabled in development",
-    });
+    setUpdateStatus(developmentUpdateCheckResult());
     return;
   }
 
@@ -167,7 +266,7 @@ export function initAutoUpdater(): void {
 
   autoUpdater.on("checking-for-update", () => {
     log.info("checking-for-update");
-    setUpdateStatus({ status: "checking" });
+    setUpdateStatusUnlessDownloaded({ status: "checking" });
   });
   autoUpdater.on("update-available", (info) => {
     log.info("update-available", { version: info.version });
@@ -175,7 +274,7 @@ export function initAutoUpdater(): void {
   });
   autoUpdater.on("update-not-available", (info) => {
     log.info("update-not-available", { version: info.version });
-    setUpdateStatus({ status: "no-update", version: info.version });
+    setUpdateStatusUnlessDownloaded({ status: "no-update", version: info.version });
   });
   autoUpdater.on("download-progress", (progress) => {
     log.info("download-progress", {
@@ -199,20 +298,11 @@ export function initAutoUpdater(): void {
   });
   autoUpdater.on("error", (err: Error) => {
     log.warn("auto-update error", { message: err.message });
-    setUpdateStatus({ status: "error", message: err.message });
+    setUpdateStatusUnlessDownloaded({ status: "error", message: err.message });
   });
 
-  autoUpdater
-    .checkForUpdates()
-    .catch((err) => {
-      setUpdateStatus({
-        status: "error",
-        message: err instanceof Error ? err.message : String(err),
-      });
-      log.warn("checkForUpdates failed", {
-        message: err instanceof Error ? err.message : String(err),
-      });
-    });
+  startPeriodicUpdateChecks();
+  void checkForAppUpdatesNow("startup");
 }
 
 export function registerAppUpdateIpcHandlers(): void {
@@ -254,34 +344,7 @@ export function registerAppUpdateIpcHandlers(): void {
   ipcMain.handle(
     APP_UPDATE_CHECK_CHANNEL,
     async (): Promise<AppUpdateCheckResult> => {
-      if (process.env.NODE_ENV !== "production") {
-        const result = {
-          status: "skipped",
-          reason: "auto-update disabled in development",
-        } as const;
-        setUpdateStatus(result);
-        return result;
-      }
-      try {
-        configureAutoUpdaterChannel();
-        const result = await autoUpdater.checkForUpdates();
-        if (updateStatus.status === "downloaded") {
-          return { status: "downloaded", version: updateStatus.version };
-        }
-        if (!result || !result.updateInfo) {
-          return { status: "no-update", version: result?.updateInfo?.version ?? "unknown" };
-        }
-        const currentVersion = autoUpdater.currentVersion?.version ?? "unknown";
-        if (result.updateInfo.version === currentVersion) {
-          return { status: "no-update", version: currentVersion };
-        }
-        return { status: "available", version: result.updateInfo.version };
-      } catch (err) {
-        return {
-          status: "error",
-          message: err instanceof Error ? err.message : String(err),
-        };
-      }
+      return await checkForAppUpdatesNow("manual");
     },
   );
 }

--- a/apps/desktop/src/main/auto-updater.ts
+++ b/apps/desktop/src/main/auto-updater.ts
@@ -4,20 +4,36 @@ const { autoUpdater } = electronUpdater;
 import {
   APP_UPDATE_CHECK_CHANNEL,
   APP_UPDATE_INSTALL_CHANNEL,
+  APP_UPDATE_RELEASES_READ_CHANNEL,
   APP_UPDATE_STATUS_EVENT_CHANNEL,
   APP_UPDATE_STATUS_READ_CHANNEL,
 } from "../shared/ipc";
 import type {
   AppUpdateCheckResult,
   AppUpdateInstallResult,
+  AppUpdateReleaseInfo,
+  AppUpdateReleaseVersions,
   AppUpdateStatus,
 } from "../shared/app-metadata";
 import { getMainLogger } from "./log";
+import { getDesktopSettingsService } from "./settings/desktop-settings-singleton";
 
 const log = getMainLogger("pwragent:updater");
+const GITHUB_RELEASES_URL =
+  "https://api.github.com/repos/pwrdrvr/PwrAgent/releases?per_page=30";
+const RELEASE_FETCH_TIMEOUT_MS = 5_000;
 
 let initialized = false;
 let updateStatus: AppUpdateStatus = { status: "idle" };
+
+type GitHubRelease = {
+  draft?: boolean;
+  html_url?: string;
+  name?: string;
+  prerelease?: boolean;
+  published_at?: string;
+  tag_name?: string;
+};
 
 function setUpdateStatus(nextStatus: AppUpdateStatus): void {
   updateStatus = nextStatus;
@@ -31,6 +47,94 @@ function setUpdateStatus(nextStatus: AppUpdateStatus): void {
 
 function downloadedVersion(): string | undefined {
   return updateStatus.status === "downloaded" ? updateStatus.version : undefined;
+}
+
+function currentUpdateChannel(): "latest" | "prerelease" {
+  try {
+    return getDesktopSettingsService().resolveUpdateChannel();
+  } catch (err) {
+    log.warn("failed to read update channel setting", {
+      message: err instanceof Error ? err.message : String(err),
+    });
+    return "latest";
+  }
+}
+
+function configureAutoUpdaterChannel(): void {
+  const updateChannel = currentUpdateChannel();
+  autoUpdater.allowPrerelease = updateChannel === "prerelease";
+  log.info("configured auto-update channel", {
+    allowPrerelease: autoUpdater.allowPrerelease,
+    updateChannel,
+  });
+}
+
+function releaseInfoFromGitHubRelease(
+  release: GitHubRelease | undefined,
+  unavailableReason: string,
+): AppUpdateReleaseInfo {
+  if (!release?.tag_name) {
+    return { unavailableReason };
+  }
+  return {
+    version: release.tag_name,
+    ...(release.name ? { name: release.name } : {}),
+    ...(release.html_url ? { url: release.html_url } : {}),
+    ...(release.published_at ? { publishedAt: release.published_at } : {}),
+  };
+}
+
+function githubReleaseHeaders(): HeadersInit {
+  const token = process.env.GH_TOKEN?.trim() || process.env.GITHUB_TOKEN?.trim();
+  return {
+    Accept: "application/vnd.github+json",
+    "User-Agent": "PwrAgent",
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+}
+
+export async function readAppUpdateReleaseVersions(): Promise<AppUpdateReleaseVersions> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), RELEASE_FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(GITHUB_RELEASES_URL, {
+      headers: githubReleaseHeaders(),
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      throw new Error(`GitHub releases request failed with ${response.status}`);
+    }
+    const payload = await response.json();
+    const releases = Array.isArray(payload)
+      ? payload.filter((release): release is GitHubRelease =>
+          typeof release === "object" && release !== null,
+        )
+      : [];
+    const publicReleases = releases.filter((release) => release.draft !== true);
+    const latest = publicReleases.find(
+      (release) => release.prerelease !== true,
+    );
+    const prerelease = publicReleases.find(
+      (release) => release.prerelease === true,
+    );
+    return {
+      fetchedAt: Date.now(),
+      latest: releaseInfoFromGitHubRelease(latest, "No stable release found."),
+      prerelease: releaseInfoFromGitHubRelease(
+        prerelease,
+        "No prerelease found.",
+      ),
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      fetchedAt: Date.now(),
+      latest: { unavailableReason: message },
+      prerelease: { unavailableReason: message },
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 export function initAutoUpdater(): void {
@@ -59,7 +163,7 @@ export function initAutoUpdater(): void {
   autoUpdater.logger = log as unknown as Console;
   autoUpdater.autoDownload = true;
   autoUpdater.autoInstallOnAppQuit = true;
-  autoUpdater.allowPrerelease = true;
+  configureAutoUpdaterChannel();
 
   autoUpdater.on("checking-for-update", () => {
     log.info("checking-for-update");
@@ -115,9 +219,15 @@ export function registerAppUpdateIpcHandlers(): void {
   ipcMain.removeHandler(APP_UPDATE_CHECK_CHANNEL);
   ipcMain.removeHandler(APP_UPDATE_STATUS_READ_CHANNEL);
   ipcMain.removeHandler(APP_UPDATE_INSTALL_CHANNEL);
+  ipcMain.removeHandler(APP_UPDATE_RELEASES_READ_CHANNEL);
   ipcMain.handle(
     APP_UPDATE_STATUS_READ_CHANNEL,
     async (): Promise<AppUpdateStatus> => updateStatus,
+  );
+  ipcMain.handle(
+    APP_UPDATE_RELEASES_READ_CHANNEL,
+    async (): Promise<AppUpdateReleaseVersions> =>
+      await readAppUpdateReleaseVersions(),
   );
   ipcMain.handle(
     APP_UPDATE_INSTALL_CHANNEL,
@@ -153,6 +263,7 @@ export function registerAppUpdateIpcHandlers(): void {
         return result;
       }
       try {
+        configureAutoUpdaterChannel();
         const result = await autoUpdater.checkForUpdates();
         if (updateStatus.status === "downloaded") {
           return { status: "downloaded", version: updateStatus.version };
@@ -179,4 +290,5 @@ export function disposeAppUpdateIpcHandlers(): void {
   ipcMain.removeHandler(APP_UPDATE_CHECK_CHANNEL);
   ipcMain.removeHandler(APP_UPDATE_STATUS_READ_CHANNEL);
   ipcMain.removeHandler(APP_UPDATE_INSTALL_CHANNEL);
+  ipcMain.removeHandler(APP_UPDATE_RELEASES_READ_CHANNEL);
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -7,6 +7,7 @@ import {
   registerAppMetadataIpcHandlers,
 } from "./ipc/app-metadata";
 import {
+  checkForAppUpdatesNow,
   disposeAppUpdateIpcHandlers,
   initAutoUpdater,
   registerAppUpdateIpcHandlers,
@@ -179,6 +180,12 @@ function installApplicationMenu(): void {
           label: `About ${APP_NAME}`,
           click: () => {
             app.showAboutPanel();
+          },
+        },
+        {
+          label: "Check for Updates",
+          click: () => {
+            void checkForAppUpdatesNow("menu");
           },
         },
         {

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -8,11 +8,14 @@ import type {
   DesktopMessagingFullAccessWarningUserPolicy,
   DesktopMessagingImageProfile,
   DesktopSettingsConfigPatch,
+  DesktopUpdateChannel,
   DesktopWorktreeStorageLocation,
   MessagingToolUpdateMode,
 } from "@pwragent/shared";
 import {
+  DESKTOP_UPDATE_CHANNEL_DEFAULT,
   isDesktopWorktreeStorageLocation,
+  isDesktopUpdateChannel,
   sanitizeMessagingContactLabel,
 } from "@pwragent/shared";
 import { DEFAULT_PASTED_IMAGE_MAX_PATCHES } from "../../shared/image-normalization";
@@ -53,6 +56,9 @@ export type DesktopSettingsConfig = {
   };
   imageUploads?: {
     pastedImageMaxPatches?: number;
+  };
+  updates?: {
+    channel?: DesktopUpdateChannel;
   };
   messaging?: {
     enabled?: boolean;
@@ -330,6 +336,17 @@ export function desktopSettingsPatchToEdits(
         ["image_uploads", "pasted_image_max_patches"],
         pastedImageMaxPatches,
       );
+    }
+  }
+
+  if (patch.updates?.channel !== undefined) {
+    if (patch.updates.channel === DESKTOP_UPDATE_CHANNEL_DEFAULT) {
+      edits.push({
+        op: "delete",
+        path: ["updates", "channel"],
+      });
+    } else {
+      set(["updates", "channel"], patch.updates.channel);
     }
   }
 
@@ -661,6 +678,7 @@ function normalizeDesktopConfig(
   const experimental = tables["experimental"];
   const diffCondensation = tables["experimental.diff_condensation"];
   const imageUploads = tables["image_uploads"];
+  const updates = tables["updates"];
   const messaging = tables["messaging"];
   const attachments = tables["messaging.attachments"];
   const telegram = tables["messaging.telegram"];
@@ -690,6 +708,9 @@ function normalizeDesktopConfig(
       pastedImageMaxPatches: readNumber(
         imageUploads?.pasted_image_max_patches,
       ),
+    },
+    updates: {
+      channel: readUpdateChannel(updates?.channel),
     },
     messaging: {
       enabled: readBoolean(messaging?.enabled),
@@ -856,6 +877,10 @@ function pruneEmptyConfig(config: DesktopSettingsConfig): DesktopSettingsConfig 
     pruned.imageUploads = config.imageUploads;
   }
 
+  if (config.updates && hasDefinedValue(config.updates)) {
+    pruned.updates = config.updates;
+  }
+
   const attachments = config.messaging?.attachments;
   const telegram = config.messaging?.telegram;
   const discord = config.messaging?.discord;
@@ -984,6 +1009,14 @@ function readToolUpdateMode(
   value: TomlScalar | undefined,
 ): MessagingToolUpdateMode | undefined {
   return typeof value === "string" && isMessagingToolUpdateMode(value)
+    ? value
+    : undefined;
+}
+
+function readUpdateChannel(
+  value: TomlScalar | undefined,
+): DesktopUpdateChannel | undefined {
+  return typeof value === "string" && isDesktopUpdateChannel(value)
     ? value
     : undefined;
 }

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -8,11 +8,13 @@ import type {
   DesktopSettingsSecretState,
   DesktopSettingsSnapshot,
   DesktopSettingsValue,
+  DesktopUpdateChannel,
   DesktopWorktreeStorageLocation,
   MessagingToolUpdateMode,
 } from "@pwragent/shared";
 import {
   DESKTOP_CHAT_REPLY_COMPOSER_DEFAULT,
+  DESKTOP_UPDATE_CHANNEL_DEFAULT,
   DESKTOP_WORKTREE_STORAGE_DEFAULT,
 } from "@pwragent/shared";
 import { DEFAULT_PASTED_IMAGE_MAX_PATCHES } from "../../shared/image-normalization";
@@ -299,6 +301,9 @@ export class DesktopSettingsService {
         pastedImageMaxPatches: this.resolvePastedImageMaxPatches(
           config.imageUploads?.pastedImageMaxPatches,
         ),
+      },
+      updates: {
+        channel: this.resolveUpdateChannelValue(config.updates?.channel),
       },
       messaging: {
         enabled: this.resolveConfigBoolean(config.messaging?.enabled, true),
@@ -589,6 +594,11 @@ export class DesktopSettingsService {
       .storage.value;
   }
 
+  resolveUpdateChannel(): DesktopUpdateChannel {
+    return this.resolveUpdateChannelValue(this.readConfig().config.updates?.channel)
+      .value;
+  }
+
   async writeConfigPatch(
     patch: DesktopSettingsConfigPatch,
   ): Promise<DesktopSettingsSnapshot> {
@@ -856,6 +866,15 @@ export class DesktopSettingsService {
     return {
       value: normalized ?? DEFAULT_PASTED_IMAGE_MAX_PATCHES,
       source: normalized === undefined ? "default" : "config",
+    };
+  }
+
+  private resolveUpdateChannelValue(
+    configValue: DesktopUpdateChannel | undefined,
+  ): DesktopSettingsValue<DesktopUpdateChannel> {
+    return {
+      value: configValue ?? DESKTOP_UPDATE_CHANNEL_DEFAULT,
+      source: configValue === undefined ? "default" : "config",
     };
   }
 

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -175,6 +175,7 @@ import {
   APP_THIRD_PARTY_NOTICES_WINDOW_OPEN_CHANNEL,
   APP_UPDATE_CHECK_CHANNEL,
   APP_UPDATE_INSTALL_CHANNEL,
+  APP_UPDATE_RELEASES_READ_CHANNEL,
   APP_UPDATE_STATUS_EVENT_CHANNEL,
   APP_UPDATE_STATUS_READ_CHANNEL,
   APP_SERVER_LIST_SKILLS_CHANNEL,
@@ -257,6 +258,7 @@ import type {
   AppMetadata,
   AppUpdateCheckResult,
   AppUpdateInstallResult,
+  AppUpdateReleaseVersions,
   AppUpdateStatus,
 } from "../shared/app-metadata";
 
@@ -316,6 +318,8 @@ const desktopApi = Object.freeze({
     await ipcRenderer.invoke(APP_UPDATE_CHECK_CHANNEL),
   readAppUpdateStatus: async (): Promise<AppUpdateStatus> =>
     await ipcRenderer.invoke(APP_UPDATE_STATUS_READ_CHANNEL),
+  readAppUpdateReleaseVersions: async (): Promise<AppUpdateReleaseVersions> =>
+    await ipcRenderer.invoke(APP_UPDATE_RELEASES_READ_CHANNEL),
   onAppUpdateStatus: (
     callback: (status: AppUpdateStatus) => void,
   ): (() => void) => {

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -187,6 +187,9 @@ describe("App", () => {
       imageUploads: {
         pastedImageMaxPatches: { value: 1536, source: "default" },
       },
+      updates: {
+        channel: { value: "latest", source: "default" },
+      },
       messaging: {
         enabled: { value: true, source: "default" },
         allowFullAccessEscalation: { value: true, source: "default" },

--- a/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
@@ -1,4 +1,13 @@
-import type { DesktopSettingsSnapshot } from "@pwragent/shared";
+import { useEffect, useState } from "react";
+import type {
+  DesktopSettingsSnapshot,
+  DesktopUpdateChannel,
+} from "@pwragent/shared";
+import type {
+  AppUpdateReleaseInfo,
+  AppUpdateReleaseVersions,
+} from "../../../../shared/app-metadata";
+import type { DesktopApi } from "../../lib/desktop-api";
 import {
   SettingsField,
   SettingsPanelHead,
@@ -37,16 +46,55 @@ const PASTED_IMAGE_PATCH_OPTIONS: Array<{
   },
 ];
 
+const UPDATE_CHANNEL_OPTIONS: Array<{
+  label: string;
+  value: DesktopUpdateChannel;
+}> = [
+  { label: "Latest", value: "latest" },
+  { label: "Prerelease", value: "prerelease" },
+];
+
+function releaseVersionText(release: AppUpdateReleaseInfo | undefined): string {
+  return release?.version ?? "Unavailable";
+}
+
+function releaseHelpText(
+  releases: AppUpdateReleaseVersions | undefined,
+): string {
+  if (!releases) {
+    return "Release versions are loading.";
+  }
+  return `Latest: ${releaseVersionText(releases.latest)}. Prerelease: ${releaseVersionText(releases.prerelease)}.`;
+}
+
 export function GeneralSettings(props: {
+  desktopApi?: DesktopApi;
   saving: boolean;
   snapshot: DesktopSettingsSnapshot;
   onPastedImageMaxPatchesChange: (value: number) => Promise<void>;
+  onUpdateChannelChange: (value: DesktopUpdateChannel) => Promise<void>;
 }) {
+  const [releaseVersions, setReleaseVersions] = useState<
+    AppUpdateReleaseVersions | undefined
+  >();
   const pastedImageMaxPatches =
     props.snapshot.imageUploads.pastedImageMaxPatches;
+  const updateChannel = props.snapshot.updates.channel;
   const activeOption = PASTED_IMAGE_PATCH_OPTIONS.find(
     (option) => option.value === pastedImageMaxPatches.value,
   );
+
+  useEffect(() => {
+    let canceled = false;
+    void props.desktopApi?.readAppUpdateReleaseVersions?.().then((versions) => {
+      if (!canceled) {
+        setReleaseVersions(versions);
+      }
+    });
+    return () => {
+      canceled = true;
+    };
+  }, [props.desktopApi]);
 
   return (
     <SettingsSectionStack paneId="general" aria-label="General settings">
@@ -55,6 +103,50 @@ export function GeneralSettings(props: {
         title="General settings"
         help="Defaults that apply across PwrAgent surfaces."
       />
+
+      <SettingsSection
+        eyebrow="General"
+        title="Updates"
+        chip={sourceBadge(updateChannel)}
+      >
+        <div className="settings-fields">
+          <SettingsField
+            label="Update channel"
+            sub="Choose which GitHub release stream the updater follows."
+            help={releaseHelpText(releaseVersions)}
+            error={updateChannel.error}
+            source={sourceBadge(updateChannel)}
+            control={
+              <div
+                className="settings-segmented"
+                role="radiogroup"
+                aria-label="Update channel"
+              >
+                {UPDATE_CHANNEL_OPTIONS.map((option) => (
+                  <button
+                    key={option.value}
+                    aria-checked={updateChannel.value === option.value}
+                    className={`settings-segmented__button settings-segmented__button--stacked${
+                      updateChannel.value === option.value ? " is-active" : ""
+                    }`}
+                    disabled={props.saving}
+                    role="radio"
+                    type="button"
+                    onClick={() => {
+                      void props.onUpdateChannelChange(option.value);
+                    }}
+                  >
+                    <span>{option.label}</span>
+                    <span className="settings-segmented__meta">
+                      {releaseVersionText(releaseVersions?.[option.value])}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            }
+          />
+        </div>
+      </SettingsSection>
 
       <SettingsSection
         eyebrow="General"

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -1,6 +1,7 @@
 import type {
   DesktopSettingsSnapshot,
   DesktopMessagingImageProfile,
+  DesktopUpdateChannel,
   MessagingChannelKind,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
@@ -221,8 +222,14 @@ function SettingsSectionBody(props: {
   if (props.section === "general") {
     return (
       <GeneralSettings
+        desktopApi={props.desktopApi}
         saving={props.settings.saving}
         snapshot={props.snapshot}
+        onUpdateChannelChange={async (channel: DesktopUpdateChannel) => {
+          await props.settings.writeConfig({
+            updates: { channel },
+          });
+        }}
         onPastedImageMaxPatchesChange={async (pastedImageMaxPatches) => {
           await props.settings.writeConfig({
             imageUploads: {

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -63,6 +63,9 @@ function createSnapshot(
     imageUploads: {
       pastedImageMaxPatches: { value: 1536, source: "default" },
     },
+    updates: {
+      channel: { value: "latest", source: "default" },
+    },
     messaging: {
       enabled: { value: true, source: "default" },
       allowFullAccessEscalation: { value: true, source: "default" },
@@ -282,13 +285,41 @@ function createSettingsState(
 describe("SettingsScreen", () => {
   it("switches sections and saves settings", async () => {
     const settings = createSettingsState();
-    render(<SettingsScreen settings={settings} onClose={() => undefined} />);
+    const desktopApi = {
+      readAppUpdateReleaseVersions: vi.fn(async () => ({
+        fetchedAt: 1,
+        latest: { version: "v1.0.0" },
+        prerelease: { version: "v1.0.0-beta.7" },
+      })),
+    };
+    render(
+      <SettingsScreen
+        desktopApi={desktopApi}
+        settings={settings}
+        onClose={() => undefined}
+      />,
+    );
 
     const sections = screen.getByRole("navigation", { name: "Settings sections" });
     expect(within(sections).getByRole("button", { name: "General" })).toHaveAttribute(
       "aria-current",
       "page",
     );
+
+    expect(screen.getByRole("heading", { name: "Updates" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /Latest/ })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+    expect(await screen.findByText("v1.0.0-beta.7")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("radio", { name: /Prerelease/ }));
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        updates: {
+          channel: "prerelease",
+        },
+      });
+    });
 
     expect(screen.getByRole("heading", { name: "Pasted images" })).toBeInTheDocument();
     expect(screen.getByRole("radio", { name: "1536 patches" })).toHaveAttribute(

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -157,6 +157,7 @@ import type {
   AppMetadata,
   AppUpdateCheckResult,
   AppUpdateInstallResult,
+  AppUpdateReleaseVersions,
   AppUpdateStatus,
 } from "../../../shared/app-metadata";
 
@@ -175,6 +176,7 @@ export type DesktopApi = {
   onAppLogEntry?: (callback: (entry: AppLogEntry) => void) => () => void;
   checkForAppUpdates?: () => Promise<AppUpdateCheckResult>;
   readAppUpdateStatus?: () => Promise<AppUpdateStatus>;
+  readAppUpdateReleaseVersions?: () => Promise<AppUpdateReleaseVersions>;
   onAppUpdateStatus?: (callback: (status: AppUpdateStatus) => void) => () => void;
   installAppUpdate?: () => Promise<AppUpdateInstallResult>;
   listPwrAgentProfiles?: () => Promise<ListDesktopPwrAgentProfilesResponse>;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3483,6 +3483,24 @@ textarea,
   line-height: 1;
 }
 
+.settings-segmented__button--stacked {
+  flex-direction: column;
+  align-items: flex-start;
+  min-width: 112px;
+  line-height: 1.15;
+}
+
+.settings-segmented__meta {
+  max-width: 100%;
+  overflow: hidden;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .settings-segmented__button:hover,
 .settings-segmented__button:focus-visible {
   color: var(--text-primary);

--- a/apps/desktop/src/shared/app-metadata.ts
+++ b/apps/desktop/src/shared/app-metadata.ts
@@ -64,3 +64,17 @@ export type AppUpdateStatus =
 export type AppUpdateInstallResult =
   | { status: "restarting" }
   | { status: "error"; message: string };
+
+export type AppUpdateReleaseInfo = {
+  version?: string;
+  name?: string;
+  url?: string;
+  publishedAt?: string;
+  unavailableReason?: string;
+};
+
+export type AppUpdateReleaseVersions = {
+  latest: AppUpdateReleaseInfo;
+  prerelease: AppUpdateReleaseInfo;
+  fetchedAt: number;
+};

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -169,6 +169,7 @@ export const APP_UPDATE_CHECK_CHANNEL = "app:check-for-updates";
 export const APP_UPDATE_STATUS_READ_CHANNEL = "app:read-update-status";
 export const APP_UPDATE_STATUS_EVENT_CHANNEL = "app:update-status-event";
 export const APP_UPDATE_INSTALL_CHANNEL = "app:install-update";
+export const APP_UPDATE_RELEASES_READ_CHANNEL = "app:read-update-releases";
 export const PROFILES_LIST_CHANNEL = "profiles:list";
 export const PROFILES_OPEN_CHANNEL = "profiles:open";
 export const PROFILES_CREATE_CHANNEL = "profiles:create";

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -35,6 +35,9 @@ describe("desktop settings contracts", () => {
       imageUploads: {
         pastedImageMaxPatches: { value: 1536, source: "default" },
       },
+      updates: {
+        channel: { value: "latest", source: "default" },
+      },
       messaging: {
         enabled: {
           value: true,

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -21,6 +21,12 @@ export type DesktopWorktreeStorageLocation =
 export const DESKTOP_WORKTREE_STORAGE_DEFAULT: DesktopWorktreeStorageLocation =
   "user-home";
 
+export const DESKTOP_UPDATE_CHANNELS = ["latest", "prerelease"] as const;
+
+export type DesktopUpdateChannel = (typeof DESKTOP_UPDATE_CHANNELS)[number];
+
+export const DESKTOP_UPDATE_CHANNEL_DEFAULT: DesktopUpdateChannel = "latest";
+
 export type DesktopSettingsNonSecretSource = "default" | "config" | "env";
 export type DesktopSettingsSecretSource = "unset" | "keychain" | "env";
 export type DesktopSettingsSource =
@@ -134,6 +140,10 @@ export type DesktopMessagingAttachmentSettingsSnapshot = {
 
 export type DesktopImageUploadSettingsSnapshot = {
   pastedImageMaxPatches: DesktopSettingsValue<number>;
+};
+
+export type DesktopUpdateSettingsSnapshot = {
+  channel: DesktopSettingsValue<DesktopUpdateChannel>;
 };
 
 export type DesktopCodexCandidateSource =
@@ -305,6 +315,7 @@ export type DesktopSettingsSnapshot = {
     };
   };
   imageUploads: DesktopImageUploadSettingsSnapshot;
+  updates: DesktopUpdateSettingsSnapshot;
   messaging: {
     enabled: DesktopSettingsValue<boolean>;
     allowFullAccessEscalation: DesktopSettingsValue<boolean>;
@@ -413,6 +424,9 @@ export type DesktopSettingsConfigPatch = {
   };
   imageUploads?: {
     pastedImageMaxPatches?: number;
+  };
+  updates?: {
+    channel?: DesktopUpdateChannel;
   };
   messaging?: {
     enabled?: boolean;
@@ -665,6 +679,12 @@ export function isDesktopWorktreeStorageLocation(
   return DESKTOP_WORKTREE_STORAGE_LOCATIONS.includes(
     value as DesktopWorktreeStorageLocation,
   );
+}
+
+export function isDesktopUpdateChannel(
+  value: string,
+): value is DesktopUpdateChannel {
+  return DESKTOP_UPDATE_CHANNELS.includes(value as DesktopUpdateChannel);
 }
 
 /**


### PR DESCRIPTION
## Summary

- I added a General -> Updates setting that lets users choose whether the updater follows the Latest or Prerelease GitHub Releases stream.
- I wired the setting through the desktop config, settings snapshot, preload/renderer API, and updater startup/check path.
- I added release-version lookup for the settings UI, a Help -> Check for Updates menu item, hourly background update checks, and logic to keep the restart banner current if a newer update downloads while the app is still running.

## Verification

- I ran `pnpm --filter @pwragent/desktop typecheck`.
- I ran focused Vitest coverage for the updater, main menu, settings service, settings UI, and shared settings contract.
- I ran `pnpm lint:boundaries`.

## Notes

- The Latest/Prerelease distinction maps to `electron-updater`'s GitHub Releases behavior via `allowPrerelease`.
- The current beta release process can still publish beta builds as both Latest and Prerelease; the Prerelease option is for testing builds before they become the normal update target.
