### PR TITLE
feat(desktop): onboarding wizard chrome + first-launch detection + Help replay

### DIFF
--- a/apps/desktop/e2e/fixtures/electron-app.ts
+++ b/apps/desktop/e2e/fixtures/electron-app.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -47,6 +47,7 @@ export async function launchElectronApp(params: {
   fixturePath: string;
   env?: Record<string, string | undefined>;
   homeRoot?: string;
+  onboardingCompleted?: boolean;
   windowSize?: {
     width: number;
     height: number;
@@ -104,6 +105,9 @@ export async function launchElectronApp(params: {
       },
     },
   );
+  if (params.onboardingCompleted !== false) {
+    await seedOnboardingCompleted(seedHomeRoot);
+  }
   const env: Record<string, string> = {};
   for (const [key, value] of Object.entries(process.env)) {
     if (value !== undefined) {
@@ -215,4 +219,27 @@ export async function launchElectronApp(params: {
       await rm(homeRoot, { recursive: true, force: true });
     },
   };
+}
+
+async function seedOnboardingCompleted(homeRoot: string): Promise<void> {
+  const configPath = path.join(
+    homeRoot,
+    ".pwragent/profiles/default/config.toml",
+  );
+  await mkdir(path.dirname(configPath), { recursive: true });
+  let current = "";
+  try {
+    current = await readFile(configPath, "utf8");
+  } catch {
+    current = "";
+  }
+  if (/^\s*\[onboarding\]\s*$/m.test(current)) {
+    return;
+  }
+  const prefix = current.trim().length > 0 ? `${current.trimEnd()}\n\n` : "";
+  await writeFile(
+    configPath,
+    `${prefix}[onboarding]\ncompleted = true\n`,
+    "utf8",
+  );
 }

--- a/apps/desktop/e2e/specs/onboarding-first-launch.spec.ts
+++ b/apps/desktop/e2e/specs/onboarding-first-launch.spec.ts
@@ -1,0 +1,94 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "@playwright/test";
+import { launchElectronApp } from "../fixtures/electron-app";
+
+const specDir = path.dirname(fileURLToPath(import.meta.url));
+const fixturePath = path.resolve(
+  specDir,
+  "../fixtures/smoke/replay.fixture.json",
+);
+
+test("fresh profile opens onboarding once", async () => {
+  const firstApp = await launchElectronApp({
+    fixturePath,
+    onboardingCompleted: false,
+  });
+  const homeRoot = firstApp.homeRoot;
+
+  await expect(
+    firstApp.window.getByRole("dialog", {
+      name: /Thread Presentation/,
+    }),
+  ).toBeVisible();
+  await firstApp.window.getByRole("button", { name: "Skip onboarding" }).click();
+  await expect(
+    firstApp.window.getByRole("dialog", { name: /Thread Presentation/ }),
+  ).toHaveCount(0);
+  await firstApp.electronApp.close();
+
+  const secondApp = await launchElectronApp({ fixturePath, homeRoot });
+  try {
+    await expect(
+      secondApp.window.getByRole("dialog", { name: /Thread Presentation/ }),
+    ).toHaveCount(0);
+  } finally {
+    await secondApp.close();
+  }
+});
+
+test("Help menu can replay onboarding without clearing completion", async () => {
+  const app = await launchElectronApp({
+    fixturePath,
+    preLaunchHook: async (homeRoot) => {
+      const profileDir = path.join(homeRoot, ".pwragent/profiles/default");
+      await mkdir(profileDir, { recursive: true });
+      await writeFile(
+        path.join(profileDir, "config.toml"),
+        "[onboarding]\ncompleted = true\n",
+        "utf8",
+      );
+    },
+  });
+
+  try {
+    await expect(
+      app.window.getByRole("dialog", { name: /Thread Presentation/ }),
+    ).toHaveCount(0);
+    await app.electronApp.evaluate(({ Menu }) => {
+      const item = Menu.getApplicationMenu()?.getMenuItemById(
+        "replay-onboarding-wizard",
+      );
+      if (!item) {
+        throw new Error("Replay onboarding wizard menu item was not registered.");
+      }
+      (item.click as unknown as () => void)();
+    });
+    await expect(
+      app.window.getByRole("dialog", {
+        name: /Thread Presentation/,
+      }),
+    ).toBeVisible();
+    await app.window.getByRole("button", { name: "Skip onboarding" }).click();
+    await expect
+      .poll(async () =>
+        await app.window.evaluate(async () => {
+          const api = (
+            window as Window & {
+              pwragent?: {
+                readSettings?: (request: Record<string, never>) => Promise<{
+                  snapshot: { onboarding: { completed: boolean } };
+                }>;
+              };
+            }
+          ).pwragent;
+          const response = await api?.readSettings?.({});
+          return response?.snapshot.onboarding.completed;
+        }),
+      )
+      .toBe(true);
+  } finally {
+    await app.close();
+  }
+});

--- a/apps/desktop/src/main/__tests__/menu.test.ts
+++ b/apps/desktop/src/main/__tests__/menu.test.ts
@@ -16,6 +16,7 @@ function buildTemplate(
       openIssueReporter: vi.fn(),
       openSettings: options?.openSettings ?? vi.fn(),
       openWebsite: vi.fn(),
+      replayOnboardingWizard: vi.fn(),
       showAboutPanel: vi.fn(),
       showChangelogWindow: vi.fn(),
       showLicenseWindow: vi.fn(),

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -22,6 +22,7 @@ import {
   PWRAGENT_DOCUMENTATION_URL,
   PWRAGENT_HOMEPAGE_URL,
 } from "../shared/app-metadata";
+import { ONBOARDING_REPLAY_CHANNEL } from "../shared/ipc";
 import {
   disposeApplicationIpcHandlers,
   registerApplicationIpcHandlers,
@@ -194,6 +195,11 @@ function installApplicationMenu(): void {
       },
       openWebsite: async () => {
         await shell.openExternal(PWRAGENT_HOMEPAGE_URL);
+      },
+      replayOnboardingWizard: () => {
+        for (const window of BrowserWindow.getAllWindows()) {
+          window.webContents.send(ONBOARDING_REPLAY_CHANNEL);
+        }
       },
       showAboutPanel: () => {
         app.showAboutPanel();

--- a/apps/desktop/src/main/menu.ts
+++ b/apps/desktop/src/main/menu.ts
@@ -6,6 +6,7 @@ export type ApplicationMenuActions = {
   openIssueReporter: () => void | Promise<void>;
   openSettings: () => void;
   openWebsite: () => void | Promise<void>;
+  replayOnboardingWizard: () => void;
   showAboutPanel: () => void;
   showChangelogWindow: () => void;
   showLicenseWindow: () => void;
@@ -156,6 +157,12 @@ function buildHelpMenu(options: ApplicationMenuOptions): MenuItemConstructorOpti
       {
         label: "Logs",
         click: options.actions.showLogsWindow,
+      },
+      { type: "separator" },
+      {
+        id: "replay-onboarding-wizard",
+        label: "Replay onboarding wizard",
+        click: options.actions.replayOnboardingWizard,
       },
     ],
   };

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -6,6 +6,8 @@ import type {
   DesktopAppearanceTheme,
   DesktopChatReplyComposer,
   DesktopAuthorizedContact,
+  DesktopOnboardingCodexProfileModel,
+  DesktopOnboardingThreadPresentation,
   DesktopMessagingFullAccessWarningGlobalPolicy,
   DesktopMessagingFullAccessWarningUserPolicy,
   DesktopMessagingImageProfile,
@@ -22,6 +24,8 @@ import {
   isDesktopAppearanceTheme,
   isDesktopWorktreeStorageLocation,
   isDesktopUpdateChannel,
+  isDesktopOnboardingCodexProfileModel,
+  isDesktopOnboardingThreadPresentation,
   sanitizeMessagingContactLabel,
 } from "@pwragent/shared";
 import { DEFAULT_PASTED_IMAGE_MAX_PATCHES } from "../../shared/image-normalization";
@@ -72,6 +76,15 @@ export type DesktopSettingsConfig = {
   };
   updates?: {
     channel?: DesktopUpdateChannel;
+  };
+  onboarding?: {
+    completed?: boolean;
+    threadPresentation?: DesktopOnboardingThreadPresentation;
+    codexProfileModel?: DesktopOnboardingCodexProfileModel;
+    messaging?: {
+      acknowledgedAt?: string | null;
+      checkedProviders?: string[];
+    };
   };
   messaging?: {
     enabled?: boolean;
@@ -385,6 +398,41 @@ export function desktopSettingsPatchToEdits(
     } else {
       set(["updates", "channel"], patch.updates.channel);
     }
+  }
+
+  if (patch.onboarding?.completed !== undefined) {
+    set(["onboarding", "completed"], patch.onboarding.completed);
+  }
+  if (patch.onboarding?.threadPresentation !== undefined) {
+    set(
+      ["onboarding", "thread_presentation"],
+      patch.onboarding.threadPresentation,
+    );
+  }
+  if (patch.onboarding?.codexProfileModel !== undefined) {
+    set(
+      ["onboarding", "codex_profile_model"],
+      patch.onboarding.codexProfileModel,
+    );
+  }
+  if (patch.onboarding?.messaging?.acknowledgedAt !== undefined) {
+    if (patch.onboarding.messaging.acknowledgedAt === null) {
+      edits.push({
+        op: "delete",
+        path: ["onboarding", "messaging", "acknowledged_at"],
+      });
+    } else {
+      set(
+        ["onboarding", "messaging", "acknowledged_at"],
+        patch.onboarding.messaging.acknowledgedAt,
+      );
+    }
+  }
+  if (patch.onboarding?.messaging?.checkedProviders !== undefined) {
+    set(
+      ["onboarding", "messaging", "checked_providers"],
+      patch.onboarding.messaging.checkedProviders,
+    );
   }
 
   if (patch.messaging?.inputDebounceMs !== undefined) {
@@ -718,6 +766,8 @@ function normalizeDesktopConfig(
   const diffCondensation = tables["experimental.diff_condensation"];
   const imageUploads = tables["image_uploads"];
   const updates = tables["updates"];
+  const onboarding = tables["onboarding"];
+  const onboardingMessaging = tables["onboarding.messaging"];
   const messaging = tables["messaging"];
   const attachments = tables["messaging.attachments"];
   const telegram = tables["messaging.telegram"];
@@ -757,6 +807,19 @@ function normalizeDesktopConfig(
     },
     updates: {
       channel: readUpdateChannel(updates?.channel),
+    },
+    onboarding: {
+      completed: readBoolean(onboarding?.completed),
+      threadPresentation: readOnboardingThreadPresentation(
+        onboarding?.thread_presentation,
+      ),
+      codexProfileModel: readOnboardingCodexProfileModel(
+        onboarding?.codex_profile_model,
+      ),
+      messaging: {
+        acknowledgedAt: readString(onboardingMessaging?.acknowledged_at),
+        checkedProviders: readStringArray(onboardingMessaging?.checked_providers),
+      },
     },
     messaging: {
       enabled: readBoolean(messaging?.enabled),
@@ -938,6 +1001,29 @@ function pruneEmptyConfig(config: DesktopSettingsConfig): DesktopSettingsConfig 
 
   if (config.updates && hasDefinedValue(config.updates)) {
     pruned.updates = config.updates;
+  }
+
+  const onboardingMessaging = config.onboarding?.messaging;
+  const onboarding = config.onboarding;
+  if (
+    onboarding?.completed !== undefined ||
+    onboarding?.threadPresentation !== undefined ||
+    onboarding?.codexProfileModel !== undefined ||
+    (onboardingMessaging && hasDefinedValue(onboardingMessaging))
+  ) {
+    pruned.onboarding = {};
+    if (onboarding?.completed !== undefined) {
+      pruned.onboarding.completed = onboarding.completed;
+    }
+    if (onboarding?.threadPresentation !== undefined) {
+      pruned.onboarding.threadPresentation = onboarding.threadPresentation;
+    }
+    if (onboarding?.codexProfileModel !== undefined) {
+      pruned.onboarding.codexProfileModel = onboarding.codexProfileModel;
+    }
+    if (onboardingMessaging && hasDefinedValue(onboardingMessaging)) {
+      pruned.onboarding.messaging = onboardingMessaging;
+    }
   }
 
   const attachments = config.messaging?.attachments;
@@ -1130,6 +1216,23 @@ function readFullAccessWarningGlobalPolicy(
   value: TomlScalar | undefined,
 ): DesktopMessagingFullAccessWarningGlobalPolicy | undefined {
   return value === "always" || value === "dismissable" || value === "never"
+    ? value
+    : undefined;
+}
+
+function readOnboardingThreadPresentation(
+  value: TomlScalar | undefined,
+): DesktopOnboardingThreadPresentation | undefined {
+  return typeof value === "string" &&
+    isDesktopOnboardingThreadPresentation(value)
+    ? value
+    : undefined;
+}
+
+function readOnboardingCodexProfileModel(
+  value: TomlScalar | undefined,
+): DesktopOnboardingCodexProfileModel | undefined {
+  return typeof value === "string" && isDesktopOnboardingCodexProfileModel(value)
     ? value
     : undefined;
 }

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -324,6 +324,18 @@ export class DesktopSettingsService {
       updates: {
         channel: this.resolveUpdateChannelValue(config.updates?.channel),
       },
+      onboarding: {
+        completed: config.onboarding?.completed ?? false,
+        threadPresentation:
+          config.onboarding?.threadPresentation ?? "mission_control",
+        codexProfileModel: config.onboarding?.codexProfileModel ?? "shared",
+        messaging: {
+          acknowledgedAt:
+            config.onboarding?.messaging?.acknowledgedAt?.trim() || null,
+          checkedProviders:
+            config.onboarding?.messaging?.checkedProviders?.filter(Boolean) ?? [],
+        },
+      },
       messaging: {
         enabled: this.resolveConfigBoolean(config.messaging?.enabled, true),
         allowFullAccessEscalation: this.resolveConfigBoolean(

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -229,6 +229,7 @@ import {
   NAVIGATION_RESET_DIRECTORY_LAUNCHPAD_CHANNEL,
   NAVIGATION_SNAPSHOT_CHANNEL,
   NAVIGATION_UPDATE_DIRECTORY_LAUNCHPAD_CHANNEL,
+  ONBOARDING_REPLAY_CHANNEL,
   PRELOAD_LOG_CHANNEL,
   PROFILES_CREATE_CHANNEL,
   PROFILES_DELETE_CHANNEL,
@@ -662,6 +663,13 @@ const desktopApi = Object.freeze({
     ipcRenderer.on(WINDOW_OPEN_SETTINGS_CHANNEL, listener);
     return () => {
       ipcRenderer.off(WINDOW_OPEN_SETTINGS_CHANNEL, listener);
+    };
+  },
+  onOnboardingReplay: (callback: () => void): (() => void) => {
+    const listener = () => callback();
+    ipcRenderer.on(ONBOARDING_REPLAY_CHANNEL, listener);
+    return () => {
+      ipcRenderer.off(ONBOARDING_REPLAY_CHANNEL, listener);
     };
   },
   getWindowPointerSnapshot: async (): Promise<WindowPointerSnapshot> =>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -12,6 +12,10 @@ import {
   type SettingsSection,
 } from "./features/settings/SettingsScreen";
 import {
+  OnboardingWizard,
+  type OnboardingWizardMode,
+} from "./features/onboarding/OnboardingWizard";
+import {
   useDesktopSettings,
   type DesktopSettingsState,
 } from "./features/settings/useDesktopSettings";
@@ -104,6 +108,7 @@ function DesktopAppShell(props: {
   const [settingsInitialSection, setSettingsInitialSection] = useState<
     SettingsSection | undefined
   >(undefined);
+  const [manualOnboardingOpen, setManualOnboardingOpen] = useState(false);
   const [threadViewReady, setThreadViewReady] = useState(false);
   const [ThreadViewComponent, setThreadViewComponent] =
     useState<ComponentType<ThreadViewProps>>();
@@ -139,6 +144,14 @@ function DesktopAppShell(props: {
     selectedThread: navigation.selectedThread,
     threads: navigation.threads,
   });
+  useEffect(() => {
+    if (!desktopApi?.onOnboardingReplay) {
+      return undefined;
+    }
+    return desktopApi.onOnboardingReplay(() => {
+      setManualOnboardingOpen(true);
+    });
+  }, [desktopApi]);
   useEffect(() => {
     if (threadViewReady || mainView !== "thread" || navigation.loading) {
       return;
@@ -318,6 +331,37 @@ function DesktopAppShell(props: {
     setSidebarWidth(Math.min(560, Math.max(280, nextWidth)));
   };
 
+  const autoOnboardingOpen = settings.snapshot?.onboarding.completed === false;
+  const onboardingMode: OnboardingWizardMode | undefined = manualOnboardingOpen
+    ? "manual"
+    : autoOnboardingOpen
+      ? "auto"
+      : undefined;
+  const completeOnboarding = async (): Promise<void> => {
+    if (onboardingMode === "auto") {
+      const saved = await settings.writeConfig({
+        onboarding: { completed: true },
+      });
+      if (!saved) {
+        throw new Error("Could not save the onboarding preference.");
+      }
+      return;
+    }
+    setManualOnboardingOpen(false);
+  };
+  const skipOnboarding = async (): Promise<void> => {
+    if (onboardingMode === "auto") {
+      const saved = await settings.writeConfig({
+        onboarding: { completed: true },
+      });
+      if (!saved) {
+        throw new Error("Could not save the onboarding preference.");
+      }
+      return;
+    }
+    setManualOnboardingOpen(false);
+  };
+
   const startSidebarResize = (event: PointerEvent<HTMLElement>): void => {
     event.preventDefault();
     const startX = event.clientX;
@@ -411,6 +455,37 @@ function DesktopAppShell(props: {
             onOpenMessagingActivity={openMessagingActivityWindow}
           />
         </div>
+      ) : null}
+
+      {onboardingMode ? (
+        <OnboardingWizard
+          codexProfileModel={
+            settings.snapshot?.onboarding.codexProfileModel ?? "shared"
+          }
+          mode={onboardingMode}
+          saving={settings.saving}
+          threadPresentation={
+            settings.snapshot?.onboarding.threadPresentation ?? "mission_control"
+          }
+          onComplete={completeOnboarding}
+          onCodexProfileModelChange={async (codexProfileModel) => {
+            const saved = await settings.writeConfig({
+              onboarding: { codexProfileModel },
+            });
+            if (!saved) {
+              throw new Error("Could not save the Codex profile model.");
+            }
+          }}
+          onSkip={skipOnboarding}
+          onThreadPresentationChange={async (threadPresentation) => {
+            const saved = await settings.writeConfig({
+              onboarding: { threadPresentation },
+            });
+            if (!saved) {
+              throw new Error("Could not save the thread presentation.");
+            }
+          }}
+        />
       ) : null}
 
       <AppUpdateBanner desktopApi={desktopApi} />

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -200,6 +200,15 @@ describe("App", () => {
       updates: {
         channel: { value: "latest", source: "default" },
       },
+      onboarding: {
+        completed: true,
+        threadPresentation: "mission_control",
+        codexProfileModel: "shared",
+        messaging: {
+          acknowledgedAt: null,
+          checkedProviders: [],
+        },
+      },
       messaging: {
         enabled: { value: true, source: "default" },
         allowFullAccessEscalation: { value: true, source: "default" },

--- a/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
+++ b/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
@@ -1,0 +1,343 @@
+import { useMemo, useRef, useState, type ReactElement } from "react";
+import type {
+  DesktopOnboardingCodexProfileModel,
+  DesktopOnboardingThreadPresentation,
+} from "@pwragent/shared";
+import {
+  ONBOARDING_STEPS,
+  advanceOnboardingStep,
+  createOnboardingMachineState,
+  getCurrentOnboardingStep,
+  getOnboardingStepIndex,
+  skipRestOfOnboarding,
+} from "./onboarding-state";
+
+export type OnboardingWizardMode = "auto" | "manual";
+
+export function OnboardingWizard(props: {
+  mode: OnboardingWizardMode;
+  saving?: boolean;
+  codexProfileModel: DesktopOnboardingCodexProfileModel;
+  threadPresentation: DesktopOnboardingThreadPresentation;
+  onComplete: () => Promise<void>;
+  onCodexProfileModelChange: (
+    value: DesktopOnboardingCodexProfileModel,
+  ) => Promise<void>;
+  onSkip: () => Promise<void>;
+  onThreadPresentationChange: (
+    value: DesktopOnboardingThreadPresentation,
+  ) => Promise<void>;
+}): ReactElement {
+  const [state, setState] = useState(() => createOnboardingMachineState());
+  const [error, setError] = useState<string>();
+  const [actionBusy, setActionBusy] = useState(false);
+  const currentStep = getCurrentOnboardingStep(state);
+  const currentStepIndex = getOnboardingStepIndex(currentStep.id);
+  const totalSteps = ONBOARDING_STEPS.length;
+  const busyRef = useRef(false);
+  const busy = props.saving || actionBusy;
+  const primaryLabel =
+    currentStepIndex === totalSteps - 1 ? "Finish onboarding" : "Continue";
+  const title = useMemo(
+    () => `${currentStep.label} (${currentStepIndex + 1} of ${totalSteps})`,
+    [currentStep.label, currentStepIndex, totalSteps],
+  );
+
+  const runAction = async (action: () => Promise<void>): Promise<void> => {
+    if (busyRef.current) return;
+    busyRef.current = true;
+    setActionBusy(true);
+    setError(undefined);
+    try {
+      await action();
+    } catch (nextError) {
+      setError(
+        nextError instanceof Error ? nextError.message : String(nextError),
+      );
+    } finally {
+      busyRef.current = false;
+      setActionBusy(false);
+    }
+  };
+
+  const advance = async (): Promise<void> => {
+    await runAction(async () => {
+      const next = advanceOnboardingStep(state);
+      if (next.completed) {
+        await props.onComplete();
+        return;
+      }
+      setState(next);
+    });
+  };
+
+  const skip = async (): Promise<void> => {
+    await runAction(async () => {
+      setState((current) => skipRestOfOnboarding(current));
+      await props.onSkip();
+    });
+  };
+
+  const saveThreadPresentation = async (
+    value: DesktopOnboardingThreadPresentation,
+  ): Promise<void> => {
+    await runAction(async () => {
+      await props.onThreadPresentationChange(value);
+    });
+  };
+
+  const saveCodexProfileModel = async (
+    value: DesktopOnboardingCodexProfileModel,
+  ): Promise<void> => {
+    await runAction(async () => {
+      await props.onCodexProfileModelChange(value);
+    });
+  };
+
+  const stepContent = (() => {
+    if (currentStep.id === "thread-presentation") {
+      return (
+        <ThreadPresentationStep
+          disabled={busy}
+          selected={props.threadPresentation}
+          onSelect={(value) => {
+            void saveThreadPresentation(value);
+          }}
+        />
+      );
+    }
+
+    if (currentStep.id === "codex-profile-model") {
+      return (
+        <CodexProfileModelStep
+          disabled={busy}
+          selected={props.codexProfileModel}
+          onSelect={(value) => {
+            void saveCodexProfileModel(value);
+          }}
+        />
+      );
+    }
+
+    return (
+      <p className="onboarding-wizard__placeholder">
+        {currentStep.placeholder}
+      </p>
+    );
+  })();
+
+  return (
+    <div className="onboarding-modal" role="presentation">
+      <section
+        aria-labelledby="onboarding-wizard-title"
+        aria-modal="true"
+        className="onboarding-wizard"
+        role="dialog"
+      >
+        <header className="onboarding-wizard__titlebar">
+          <div className="onboarding-wizard__breadcrumb">
+            <span className="onboarding-wizard__eyebrow">Onboarding</span>
+            <span className="onboarding-wizard__separator" aria-hidden="true">
+              /
+            </span>
+            <span className="onboarding-wizard__current">{title}</span>
+          </div>
+          <button
+            aria-label="Close onboarding wizard"
+            className="onboarding-wizard__close"
+            disabled={busy}
+            type="button"
+            onClick={() => {
+              void skip();
+            }}
+          >
+            x
+          </button>
+        </header>
+
+        <div className="onboarding-wizard__body">
+          <div className="onboarding-wizard__step-kicker">
+            Step {currentStepIndex + 1}
+          </div>
+          <h2 id="onboarding-wizard-title" className="onboarding-wizard__title">
+            {currentStep.label}
+          </h2>
+          {stepContent}
+        </div>
+
+        <footer className="onboarding-wizard__footer">
+          <button
+            className="onboarding-wizard__skip"
+            disabled={busy}
+            type="button"
+            onClick={() => {
+              void skip();
+            }}
+          >
+            Skip onboarding
+          </button>
+          <div className="onboarding-wizard__actions">
+            <div className="onboarding-wizard__progress" aria-hidden="true">
+              {ONBOARDING_STEPS.map((step) => (
+                <span
+                  key={step.id}
+                  className={`onboarding-wizard__dot${
+                    step.id === currentStep.id ? " is-active" : ""
+                  }`}
+                />
+              ))}
+            </div>
+            <button
+              className="button button--primary"
+              disabled={busy}
+              type="button"
+              onClick={() => {
+                void advance();
+              }}
+            >
+              {primaryLabel}
+            </button>
+          </div>
+        </footer>
+
+        {error ? (
+          <p className="onboarding-wizard__error" role="alert">
+            {error}
+          </p>
+        ) : null}
+
+        <span className="sr-only" aria-live="polite">
+          {props.mode === "manual"
+            ? "Replay onboarding wizard"
+            : "First-launch onboarding wizard"}
+        </span>
+      </section>
+    </div>
+  );
+}
+
+const THREAD_PRESENTATION_OPTIONS: Array<{
+  description: string;
+  label: string;
+  value: DesktopOnboardingThreadPresentation;
+}> = [
+  {
+    description:
+      "Tighter rows for scanning more threads and keeping navigation dense.",
+    label: "Compact",
+    value: "compact",
+  },
+  {
+    description:
+      "Roomier rows with more context for work that moves across threads.",
+    label: "Mission Control",
+    value: "mission_control",
+  },
+];
+
+const CODEX_PROFILE_MODEL_OPTIONS: Array<{
+  description: string;
+  label: string;
+  value: DesktopOnboardingCodexProfileModel;
+}> = [
+  {
+    description: "One Codex login for everything.",
+    label: "Shared",
+    value: "shared",
+  },
+  {
+    description: "Per-directory Codex login.",
+    label: "Isolated",
+    value: "isolated",
+  },
+  {
+    description: "Different logins for different threads (advanced).",
+    label: "Multiple",
+    value: "multiple",
+  },
+];
+
+function ThreadPresentationStep(props: {
+  disabled: boolean;
+  selected: DesktopOnboardingThreadPresentation;
+  onSelect: (value: DesktopOnboardingThreadPresentation) => void;
+}): ReactElement {
+  return (
+    <div
+      className="onboarding-choice-grid onboarding-choice-grid--two"
+      role="radiogroup"
+      aria-label="Thread Presentation"
+    >
+      {THREAD_PRESENTATION_OPTIONS.map((option) => (
+        <button
+          key={option.value}
+          aria-checked={props.selected === option.value}
+          className={`onboarding-preview-card${
+            props.selected === option.value ? " is-active" : ""
+          }`}
+          disabled={props.disabled}
+          role="radio"
+          type="button"
+          onClick={() => props.onSelect(option.value)}
+        >
+          <span className="onboarding-preview-card__label">{option.label}</span>
+          <span className="onboarding-preview-card__art" aria-hidden="true">
+            <span className="onboarding-preview-card__rail" />
+            <span className="onboarding-preview-card__threads">
+              {Array.from({ length: option.value === "compact" ? 5 : 3 }).map(
+                (_, index) => (
+                  <span
+                    key={index}
+                    className={`onboarding-preview-card__thread onboarding-preview-card__thread--${option.value}`}
+                  >
+                    <span />
+                    <span />
+                  </span>
+                ),
+              )}
+            </span>
+          </span>
+          <span className="onboarding-preview-card__description">
+            {option.description}
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function CodexProfileModelStep(props: {
+  disabled: boolean;
+  selected: DesktopOnboardingCodexProfileModel;
+  onSelect: (value: DesktopOnboardingCodexProfileModel) => void;
+}): ReactElement {
+  return (
+    <div
+      className="onboarding-choice-grid onboarding-choice-grid--three"
+      role="radiogroup"
+      aria-label="Codex Profile Model"
+    >
+      {CODEX_PROFILE_MODEL_OPTIONS.map((option) => (
+        <button
+          key={option.value}
+          aria-checked={props.selected === option.value}
+          className={`onboarding-radio-card${
+            props.selected === option.value ? " is-active" : ""
+          }`}
+          disabled={props.disabled}
+          role="radio"
+          type="button"
+          onClick={() => props.onSelect(option.value)}
+        >
+          <span className="onboarding-radio-card__marker" aria-hidden="true" />
+          <span className="onboarding-radio-card__content">
+            <span className="onboarding-radio-card__label">{option.label}</span>
+            <span className="onboarding-radio-card__description">
+              {option.description}
+            </span>
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/onboarding/__tests__/OnboardingWizard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/onboarding/__tests__/OnboardingWizard.test.tsx
@@ -1,0 +1,102 @@
+import "@testing-library/jest-dom/vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { useState } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  DesktopOnboardingCodexProfileModel,
+  DesktopOnboardingThreadPresentation,
+} from "@pwragent/shared";
+import { OnboardingWizard } from "../OnboardingWizard";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function renderWizard() {
+  const onComplete = vi.fn(async () => undefined);
+  const onSkip = vi.fn(async () => undefined);
+  const onThreadPresentationChange = vi.fn(
+    async (_value: DesktopOnboardingThreadPresentation) => undefined,
+  );
+  const onCodexProfileModelChange = vi.fn(
+    async (_value: DesktopOnboardingCodexProfileModel) => undefined,
+  );
+
+  function Harness() {
+    const [threadPresentation, setThreadPresentation] =
+      useState<DesktopOnboardingThreadPresentation>("mission_control");
+    const [codexProfileModel, setCodexProfileModel] =
+      useState<DesktopOnboardingCodexProfileModel>("shared");
+
+    return (
+      <OnboardingWizard
+        codexProfileModel={codexProfileModel}
+        mode="auto"
+        threadPresentation={threadPresentation}
+        onCodexProfileModelChange={async (value) => {
+          await onCodexProfileModelChange(value);
+          setCodexProfileModel(value);
+        }}
+        onComplete={onComplete}
+        onSkip={onSkip}
+        onThreadPresentationChange={async (value) => {
+          await onThreadPresentationChange(value);
+          setThreadPresentation(value);
+        }}
+      />
+    );
+  }
+
+  render(<Harness />);
+
+  return {
+    onCodexProfileModelChange,
+    onComplete,
+    onSkip,
+    onThreadPresentationChange,
+  };
+}
+
+describe("OnboardingWizard", () => {
+  it("persists the selected thread presentation", async () => {
+    const callbacks = renderWizard();
+
+    fireEvent.click(screen.getByRole("radio", { name: /Compact/ }));
+
+    await waitFor(() => {
+      expect(callbacks.onThreadPresentationChange).toHaveBeenCalledWith(
+        "compact",
+      );
+    });
+    expect(screen.getByRole("radio", { name: /Compact/ })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+  });
+
+  it("persists the selected Codex profile model", async () => {
+    const callbacks = renderWizard();
+
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+    await screen.findByRole("heading", { name: "Codex Profile Model" });
+
+    fireEvent.click(screen.getByRole("radio", { name: /Isolated/ }));
+
+    await waitFor(() => {
+      expect(callbacks.onCodexProfileModelChange).toHaveBeenCalledWith(
+        "isolated",
+      );
+    });
+    expect(screen.getByRole("radio", { name: /Isolated/ })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+  });
+});

--- a/apps/desktop/src/renderer/src/features/onboarding/__tests__/onboarding-state.test.ts
+++ b/apps/desktop/src/renderer/src/features/onboarding/__tests__/onboarding-state.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "vitest";
+import {
+  advanceOnboardingStep,
+  createOnboardingMachineState,
+  getCurrentOnboardingStep,
+  skipRestOfOnboarding,
+} from "../onboarding-state";
+
+describe("onboarding state machine", () => {
+  test("progresses through the placeholder steps before completing", () => {
+    const first = createOnboardingMachineState();
+    expect(getCurrentOnboardingStep(first).id).toBe("thread-presentation");
+    expect(first.completed).toBe(false);
+
+    const second = advanceOnboardingStep(first);
+    expect(getCurrentOnboardingStep(second).id).toBe("codex-profile-model");
+    expect(second.completed).toBe(false);
+
+    const third = advanceOnboardingStep(second);
+    expect(getCurrentOnboardingStep(third).id).toBe(
+      "messaging-acknowledgment",
+    );
+    expect(third.completed).toBe(false);
+
+    const completed = advanceOnboardingStep(third);
+    expect(getCurrentOnboardingStep(completed).id).toBe(
+      "messaging-acknowledgment",
+    );
+    expect(completed.completed).toBe(true);
+  });
+
+  test("skip rest of wizard completes without advancing the current step", () => {
+    const state = advanceOnboardingStep(createOnboardingMachineState());
+    const skipped = skipRestOfOnboarding(state);
+
+    expect(getCurrentOnboardingStep(skipped).id).toBe("codex-profile-model");
+    expect(skipped.completed).toBe(true);
+    expect(skipped.skipped).toBe(true);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/onboarding/onboarding-state.ts
+++ b/apps/desktop/src/renderer/src/features/onboarding/onboarding-state.ts
@@ -1,0 +1,79 @@
+export const ONBOARDING_STEPS = [
+  {
+    id: "thread-presentation",
+    label: "Thread Presentation",
+    placeholder: "Step 1 — coming in Phase 2",
+  },
+  {
+    id: "codex-profile-model",
+    label: "Codex Profile Model",
+    placeholder: "Step 2 — coming in Phase 3",
+  },
+  {
+    id: "messaging-acknowledgment",
+    label: "Messaging acknowledgment",
+    placeholder: "Step 3 — coming in Phase 4",
+  },
+] as const;
+
+export type OnboardingStep = (typeof ONBOARDING_STEPS)[number];
+export type OnboardingStepId = OnboardingStep["id"];
+
+export type OnboardingMachineState = {
+  completed: boolean;
+  currentStepId: OnboardingStepId;
+  skipped: boolean;
+};
+
+export function createOnboardingMachineState(): OnboardingMachineState {
+  return {
+    completed: false,
+    currentStepId: ONBOARDING_STEPS[0].id,
+    skipped: false,
+  };
+}
+
+export function getCurrentOnboardingStep(
+  state: OnboardingMachineState,
+): OnboardingStep {
+  return (
+    ONBOARDING_STEPS.find((step) => step.id === state.currentStepId) ??
+    ONBOARDING_STEPS[0]
+  );
+}
+
+export function getOnboardingStepIndex(stepId: OnboardingStepId): number {
+  return ONBOARDING_STEPS.findIndex((step) => step.id === stepId);
+}
+
+export function advanceOnboardingStep(
+  state: OnboardingMachineState,
+): OnboardingMachineState {
+  if (state.completed) {
+    return state;
+  }
+
+  const currentIndex = getOnboardingStepIndex(state.currentStepId);
+  const nextStep = ONBOARDING_STEPS[currentIndex + 1];
+  if (!nextStep) {
+    return {
+      ...state,
+      completed: true,
+    };
+  }
+
+  return {
+    ...state,
+    currentStepId: nextStep.id,
+  };
+}
+
+export function skipRestOfOnboarding(
+  state: OnboardingMachineState,
+): OnboardingMachineState {
+  return {
+    ...state,
+    completed: true,
+    skipped: true,
+  };
+}

--- a/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
 import type {
+  DesktopOnboardingCodexProfileModel,
+  DesktopOnboardingThreadPresentation,
   DesktopSettingsSnapshot,
   DesktopUpdateChannel,
 } from "@pwragent/shared";
@@ -95,6 +97,23 @@ function releaseHelpText(
   }
   return `Latest: ${releaseVersionText(releases.latest)}. Prerelease: ${releaseVersionText(releases.prerelease)}.`;
 }
+
+const THREAD_PRESENTATION_LABELS: Record<
+  DesktopOnboardingThreadPresentation,
+  string
+> = {
+  compact: "Compact",
+  mission_control: "Mission Control",
+};
+
+const CODEX_PROFILE_MODEL_LABELS: Record<
+  DesktopOnboardingCodexProfileModel,
+  string
+> = {
+  isolated: "Isolated",
+  multiple: "Multiple",
+  shared: "Shared",
+};
 
 export function GeneralSettings(props: {
   appearanceController?: AppearanceController;
@@ -331,6 +350,114 @@ export function GeneralSettings(props: {
           />
         </div>
       </SettingsSection>
+
+      <SettingsSection
+        eyebrow="Onboarding"
+        title="Thread Presentation"
+        chip="Set during onboarding"
+      >
+        <div className="settings-fields">
+          <SettingsField
+            label="Thread row density"
+            sub={
+              THREAD_PRESENTATION_LABELS[
+                props.snapshot.onboarding.threadPresentation
+              ]
+            }
+            help="The onboarding wizard sets how thread rows are presented in navigation surfaces."
+            control={
+              <PlaceholderSegmented
+                ariaLabel="Thread Presentation"
+                options={["Compact", "Mission Control"]}
+                selected={
+                  THREAD_PRESENTATION_LABELS[
+                    props.snapshot.onboarding.threadPresentation
+                  ]
+                }
+              />
+            }
+          />
+        </div>
+      </SettingsSection>
+
+      <SettingsSection
+        eyebrow="Onboarding"
+        title="Codex Profile Model"
+        chip="Set during onboarding"
+      >
+        <div className="settings-fields">
+          <SettingsField
+            label="Profile isolation"
+            sub={
+              CODEX_PROFILE_MODEL_LABELS[
+                props.snapshot.onboarding.codexProfileModel
+              ]
+            }
+            help="The onboarding wizard sets how future threads map to Codex auth profiles."
+            control={
+              <PlaceholderSegmented
+                ariaLabel="Codex Profile Model"
+                options={["Shared", "Isolated", "Multiple"]}
+                selected={
+                  CODEX_PROFILE_MODEL_LABELS[
+                    props.snapshot.onboarding.codexProfileModel
+                  ]
+                }
+              />
+            }
+          />
+        </div>
+      </SettingsSection>
+
+      <SettingsSection
+        eyebrow="Onboarding"
+        title="Messaging acknowledgment"
+        chip="Set during onboarding"
+      >
+        <div className="settings-fields">
+          <SettingsField
+            label="Safety acknowledgment"
+            sub="Set during onboarding."
+            help="This placeholder becomes editable when the Messaging onboarding step lands."
+            control={
+              <PlaceholderSegmented
+                ariaLabel="Messaging acknowledgment placeholder"
+                options={["Not acknowledged"]}
+                selected="Not acknowledged"
+              />
+            }
+          />
+        </div>
+      </SettingsSection>
     </SettingsSectionStack>
+  );
+}
+
+function PlaceholderSegmented(props: {
+  ariaLabel: string;
+  options: string[];
+  selected: string;
+}) {
+  return (
+    <div
+      className="settings-segmented"
+      role="radiogroup"
+      aria-label={props.ariaLabel}
+    >
+      {props.options.map((option) => (
+        <button
+          key={option}
+          aria-checked={option === props.selected}
+          className={`settings-segmented__button${
+            option === props.selected ? " is-active" : ""
+          }`}
+          disabled
+          role="radio"
+          type="button"
+        >
+          {option}
+        </button>
+      ))}
+    </div>
   );
 }

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -76,6 +76,15 @@ function createSnapshot(
     updates: {
       channel: { value: "latest", source: "default" },
     },
+    onboarding: {
+      completed: true,
+      threadPresentation: "mission_control",
+      codexProfileModel: "shared",
+      messaging: {
+        acknowledgedAt: null,
+        checkedProviders: [],
+      },
+    },
     messaging: {
       enabled: { value: true, source: "default" },
       allowFullAccessEscalation: { value: true, source: "default" },
@@ -349,6 +358,20 @@ describe("SettingsScreen", () => {
       "aria-checked",
       "true",
     );
+    const threadPresentationGroup = screen.getByRole("radiogroup", {
+      name: "Thread Presentation",
+    });
+    expect(
+      within(threadPresentationGroup).getByRole("radio", {
+        name: "Mission Control",
+      }),
+    ).toHaveAttribute("aria-checked", "true");
+    const codexProfileModelGroup = screen.getByRole("radiogroup", {
+      name: "Codex Profile Model",
+    });
+    expect(
+      within(codexProfileModelGroup).getByRole("radio", { name: "Shared" }),
+    ).toHaveAttribute("aria-checked", "true");
     fireEvent.click(screen.getByRole("radio", { name: "4096 patches" }));
     await waitFor(() => {
       expect(settings.writeConfig).toHaveBeenCalledWith({

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -435,6 +435,7 @@ export type DesktopApi = {
   ) => () => void;
   /** Spawns or focuses the dedicated Messaging Activity window. */
   openMessagingActivityWindow?: () => Promise<void>;
+  onOnboardingReplay?: (callback: () => void) => () => void;
   onWindowFocus?: (callback: () => void) => () => void;
   /**
    * Main → renderer push: fires when the user invokes the app's

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -4314,6 +4314,350 @@ textarea,
   margin-top: 16px;
 }
 
+.onboarding-modal {
+  position: fixed;
+  z-index: 130;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 28px;
+  background: rgb(0 0 0 / 68%);
+  isolation: isolate;
+}
+
+.onboarding-wizard {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  width: min(760px, calc(100vw - 56px));
+  min-height: min(520px, calc(100vh - 56px));
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-panel-elevated);
+  box-shadow: var(--shadow-popover);
+}
+
+.onboarding-wizard__titlebar {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.onboarding-wizard__breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.onboarding-wizard__eyebrow,
+.onboarding-wizard__step-kicker {
+  color: var(--accent);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.onboarding-wizard__separator {
+  color: var(--text-muted);
+}
+
+.onboarding-wizard__current {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-primary);
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.onboarding-wizard__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  margin-left: auto;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.onboarding-wizard__close:hover:not(:disabled),
+.onboarding-wizard__close:focus-visible:not(:disabled) {
+  border-color: var(--accent-border);
+  color: var(--text-primary);
+  outline: none;
+}
+
+.onboarding-wizard__body {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  justify-content: center;
+  gap: 12px;
+  padding: 56px;
+}
+
+.onboarding-wizard__title {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 24px;
+  line-height: 1.2;
+}
+
+.onboarding-wizard__placeholder {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 15px;
+  line-height: 1.5;
+}
+
+.onboarding-choice-grid {
+  display: grid;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.onboarding-choice-grid--two {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.onboarding-choice-grid--three {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.onboarding-preview-card,
+.onboarding-radio-card {
+  appearance: none;
+  cursor: pointer;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-panel);
+  color: var(--text-primary);
+  text-align: left;
+}
+
+.onboarding-preview-card:hover:not(:disabled),
+.onboarding-preview-card:focus-visible:not(:disabled),
+.onboarding-radio-card:hover:not(:disabled),
+.onboarding-radio-card:focus-visible:not(:disabled) {
+  border-color: var(--accent-border);
+  outline: none;
+}
+
+.onboarding-preview-card.is-active,
+.onboarding-radio-card.is-active {
+  border-color: var(--accent-border);
+  background: var(--bg-row-active);
+  box-shadow: inset 0 0 0 1px var(--accent-border);
+}
+
+.onboarding-preview-card:disabled,
+.onboarding-radio-card:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.onboarding-preview-card {
+  display: flex;
+  min-height: 260px;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px;
+}
+
+.onboarding-preview-card__label,
+.onboarding-radio-card__label {
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.onboarding-preview-card__art {
+  display: grid;
+  flex: 1 1 auto;
+  grid-template-columns: 30px 1fr;
+  gap: 8px;
+  min-height: 150px;
+  overflow: hidden;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-input);
+  padding: 8px;
+}
+
+.onboarding-preview-card__rail {
+  border-radius: 4px;
+  background: var(--bg-panel-elevated);
+}
+
+.onboarding-preview-card__threads {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  min-width: 0;
+}
+
+.onboarding-preview-card__thread {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 5px;
+  background: var(--bg-panel-elevated);
+  padding: 8px;
+}
+
+.onboarding-preview-card__thread--compact {
+  padding-block: 6px;
+}
+
+.onboarding-preview-card__thread--mission_control {
+  padding-block: 14px;
+}
+
+.onboarding-preview-card__thread span {
+  display: block;
+  height: 6px;
+  border-radius: 3px;
+  background: var(--text-muted);
+  opacity: 0.42;
+}
+
+.onboarding-preview-card__thread span:first-child {
+  width: 72%;
+}
+
+.onboarding-preview-card__thread span:last-child {
+  width: 48%;
+}
+
+.onboarding-preview-card__description,
+.onboarding-radio-card__description {
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.onboarding-radio-card {
+  display: grid;
+  grid-template-columns: 16px 1fr;
+  gap: 10px;
+  min-height: 132px;
+  padding: 14px;
+}
+
+.onboarding-radio-card__marker {
+  width: 14px;
+  height: 14px;
+  margin-top: 1px;
+  border: 1px solid var(--border-strong);
+  border-radius: 999px;
+  background: var(--bg-panel-elevated);
+}
+
+.onboarding-radio-card.is-active .onboarding-radio-card__marker {
+  border-color: var(--accent);
+  background: radial-gradient(
+    circle,
+    var(--accent) 0 38%,
+    var(--bg-panel-elevated) 42%
+  );
+}
+
+.onboarding-radio-card__content {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.onboarding-wizard__footer {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.onboarding-wizard__skip {
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.onboarding-wizard__skip:hover:not(:disabled),
+.onboarding-wizard__skip:focus-visible:not(:disabled) {
+  color: var(--text-primary);
+  outline: none;
+}
+
+.onboarding-wizard__actions,
+.onboarding-wizard__progress {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.onboarding-wizard__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: var(--border-subtle);
+}
+
+.onboarding-wizard__dot.is-active {
+  background: var(--accent);
+}
+
+.onboarding-wizard__error {
+  margin: 0;
+  padding: 0 14px 14px;
+  color: var(--danger-text);
+  font-size: 12px;
+}
+
+@media (max-width: 760px) {
+  .onboarding-choice-grid--two,
+  .onboarding-choice-grid--three {
+    grid-template-columns: 1fr;
+  }
+
+  .onboarding-wizard__body {
+    justify-content: flex-start;
+    padding: 32px;
+  }
+}
+
+.sr-only {
+  position: absolute;
+  overflow: hidden;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  border: 0;
+  margin: -1px;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+}
+
 .settings-codex-profile-select {
   display: grid;
   gap: 6px;

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -162,6 +162,7 @@ export const WINDOW_POINTER_SNAPSHOT_CHANNEL = "window:pointer-snapshot";
  * directly from the main process.
  */
 export const WINDOW_OPEN_SETTINGS_CHANNEL = "window:open-settings";
+export const ONBOARDING_REPLAY_CHANNEL = "onboarding:replay";
 export const RUNTIME_IDENTITY_CHANNEL = "runtime:get-identity";
 export const SETTINGS_READ_CHANNEL = "settings:read";
 export const SETTINGS_WRITE_CONFIG_CHANNEL = "settings:write-config";

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -48,6 +48,15 @@ describe("desktop settings contracts", () => {
       updates: {
         channel: { value: "latest", source: "default" },
       },
+      onboarding: {
+        completed: false,
+        threadPresentation: "mission_control",
+        codexProfileModel: "shared",
+        messaging: {
+          acknowledgedAt: null,
+          checkedProviders: [],
+        },
+      },
       messaging: {
         enabled: {
           value: true,

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -169,6 +169,33 @@ export type DesktopGeneralSettingsSnapshot = {
   appearance: DesktopAppearanceSnapshot;
 };
 
+export const DESKTOP_ONBOARDING_THREAD_PRESENTATIONS = [
+  "compact",
+  "mission_control",
+] as const;
+
+export type DesktopOnboardingThreadPresentation =
+  (typeof DESKTOP_ONBOARDING_THREAD_PRESENTATIONS)[number];
+
+export const DESKTOP_ONBOARDING_CODEX_PROFILE_MODELS = [
+  "shared",
+  "isolated",
+  "multiple",
+] as const;
+
+export type DesktopOnboardingCodexProfileModel =
+  (typeof DESKTOP_ONBOARDING_CODEX_PROFILE_MODELS)[number];
+
+export type DesktopOnboardingSettingsSnapshot = {
+  completed: boolean;
+  threadPresentation: DesktopOnboardingThreadPresentation;
+  codexProfileModel: DesktopOnboardingCodexProfileModel;
+  messaging: {
+    acknowledgedAt: string | null;
+    checkedProviders: string[];
+  };
+};
+
 export type DesktopCodexCandidateSource =
   | "env"
   | "config"
@@ -340,6 +367,7 @@ export type DesktopSettingsSnapshot = {
   };
   imageUploads: DesktopImageUploadSettingsSnapshot;
   updates: DesktopUpdateSettingsSnapshot;
+  onboarding: DesktopOnboardingSettingsSnapshot;
   messaging: {
     enabled: DesktopSettingsValue<boolean>;
     allowFullAccessEscalation: DesktopSettingsValue<boolean>;
@@ -458,6 +486,15 @@ export type DesktopSettingsConfigPatch = {
   };
   updates?: {
     channel?: DesktopUpdateChannel;
+  };
+  onboarding?: {
+    completed?: boolean;
+    threadPresentation?: DesktopOnboardingThreadPresentation;
+    codexProfileModel?: DesktopOnboardingCodexProfileModel;
+    messaging?: {
+      acknowledgedAt?: string | null;
+      checkedProviders?: string[];
+    };
   };
   messaging?: {
     enabled?: boolean;
@@ -729,6 +766,22 @@ export function isDesktopAppearanceDensity(
 ): value is DesktopAppearanceDensity {
   return DESKTOP_APPEARANCE_DENSITIES.includes(
     value as DesktopAppearanceDensity,
+  );
+}
+
+export function isDesktopOnboardingThreadPresentation(
+  value: string,
+): value is DesktopOnboardingThreadPresentation {
+  return DESKTOP_ONBOARDING_THREAD_PRESENTATIONS.includes(
+    value as DesktopOnboardingThreadPresentation,
+  );
+}
+
+export function isDesktopOnboardingCodexProfileModel(
+  value: string,
+): value is DesktopOnboardingCodexProfileModel {
+  return DESKTOP_ONBOARDING_CODEX_PROFILE_MODELS.includes(
+    value as DesktopOnboardingCodexProfileModel,
   );
 }
 


### PR DESCRIPTION
## Summary

Adds the first-launch onboarding wizard chrome described in #467, plus the persistence and Help-menu plumbing the per-step content will land on later. The wizard fires once per fresh PwrAgent profile, is replayable from Help → "Replay onboarding wizard", and surfaces three placeholder Settings → General sections (Thread Presentation, Codex Profile Model, Messaging acknowledgment) that go live in follow-up PRs.

Steps 1-3 inside the wizard render text-only placeholders today ("Step N - coming in Phase X"). They are filled in by separate PRs:

- Phase 2: Thread Presentation (wires into `ThreadRow.tsx`)
- Phase 3: Codex Profile Model (drives the existing surface shipped in #256)
- Phase 4: Messaging safety preamble + provider table
- Phase 5: Per-provider setup flows (Telegram first)

The "Claude Design pass" called out in the issue's first acceptance criterion is still pending. This PR lands the chrome and persistence so the design pass can target real surfaces, and the per-step PRs can fill them in once the design is locked.

## Verification

- `pnpm typecheck` ✅
- `pnpm lint:boundaries` ✅
- `pnpm test apps/desktop/src/renderer/src/features/onboarding` - 2 tests passing
- `pnpm test:desktop-e2e apps/desktop/e2e/specs/onboarding-first-launch.spec.ts` ✅

Existing E2E specs were updated (in `electron-app.ts` fixture) to mark onboarding complete by default so they aren't blocked by the new first-run modal. Existing unit-test fixtures (`app-shell.test.tsx`, `settings-screen.test.tsx`, `contracts/__tests__/settings.test.ts`) got the new `onboarding` field added to their snapshot inputs.

## Notes

- Per-profile `onboarding.completed` flag lives in `config.toml` as an additive field. Backwards-compatible: a missing flag means "first launch, fire the wizard."
- Renderer mounts `<OnboardingWizard>` from `App.tsx` when `settings.onboarding.completed === false` (auto mode) or when receiving the `ONBOARDING_REPLAY_CHANNEL` IPC from the Help menu (manual mode). Manual replay does not flip the `completed` flag, per the issue's R4.
- No new theme tokens are introduced. The wizard chrome reuses `--accent`, `--text-primary`, `--text-muted`, and `--accent-border` per the canonical primitives table in AGENTS.md.
- Dependency boundaries respected. The renderer imports only `@pwragent/shared`; profile creation and config persistence cross IPC via the existing `DesktopApi` wrapper.
- `completeOnboarding` and `skipOnboarding` in `App.tsx` are intentionally identical right now - Phase 1 is chrome-only and has no real choices to diverge them. Phases 2-4 will split them once each step has live state to persist.

Refs #467.

AI was used for assistance.
