### PR TITLE
feat(desktop): tighten release-mode menu

### DIFF
--- a/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
@@ -2,6 +2,24 @@ import { describe, expect, it } from "vitest";
 import { desktopSettingsPatchToEdits } from "../settings/desktop-config";
 import { parseTomlTables } from "../settings/toml-editor";
 
+describe("desktopSettingsPatchToEdits — general", () => {
+  it("writes developer mode", () => {
+    const edits = desktopSettingsPatchToEdits({
+      general: {
+        developerMode: true,
+      },
+    });
+
+    expect(edits).toEqual([
+      {
+        op: "set",
+        path: ["general", "developer_mode"],
+        value: true,
+      },
+    ]);
+  });
+});
+
 describe("desktopSettingsPatchToEdits — experimental", () => {
   it("writes the Full Access risk warning dismissal flag", () => {
     const edits = desktopSettingsPatchToEdits({

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -29,6 +29,9 @@ describe("DesktopSettingsService", () => {
         "[experimental]",
         'chat_reply_composer = "tiptap-chips"',
         "",
+        "[general]",
+        "developer_mode = true",
+        "",
         "[messaging]",
         "allow_full_access_thread_resume = false",
         "allow_full_access_escalation = false",
@@ -85,6 +88,10 @@ describe("DesktopSettingsService", () => {
     expect(snapshot.experimental.chatReplyComposer).toEqual({
       value: "tiptap-wysiwyg-markdown-chips",
       source: "default",
+    });
+    expect(snapshot.general.developerMode).toEqual({
+      value: true,
+      source: "config",
     });
     expect(snapshot.messaging.toolUpdateMode).toEqual({
       value: "show_more",
@@ -216,6 +223,39 @@ describe("DesktopSettingsService", () => {
       value: "latest",
       source: "default",
     });
+  });
+
+  it("defaults developer mode from the app packaging mode and persists overrides", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    const service = new DesktopSettingsService({
+      configPath,
+      defaultDeveloperMode: false,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    const initial = await service.readSettings();
+    expect(initial.general.developerMode).toEqual({
+      value: false,
+      source: "default",
+    });
+    expect(service.resolveDeveloperMode()).toBe(false);
+
+    await service.writeConfigPatch({
+      general: {
+        developerMode: true,
+      },
+    });
+
+    const saved = fs.readFileSync(configPath, "utf8");
+    expect(saved).toContain("[general]");
+    expect(saved).toContain("developer_mode = true");
+    expect((await service.readSettings()).general.developerMode).toEqual({
+      value: true,
+      source: "config",
+    });
+    expect(service.resolveDeveloperMode()).toBe(true);
   });
 
   it("defaults the image upload profile and only persists non-default values", async () => {

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -17,6 +17,7 @@ const initAutoUpdaterMock = vi.fn();
 const checkForAppUpdatesNowMock = vi.fn();
 const showAppLogWindowMock = vi.fn();
 const showChangelogWindowMock = vi.fn();
+const showLicenseWindowMock = vi.fn();
 const showThirdPartyNoticesWindowMock = vi.fn();
 const registerImageNormalizationIpcHandlersMock = vi.fn();
 const disposeImageNormalizationIpcHandlersMock = vi.fn();
@@ -59,6 +60,7 @@ const buildFromTemplateMock = vi.fn((template: unknown) => ({
 const shellOpenExternalMock = vi.fn(async () => undefined);
 const setNameMock = vi.fn();
 const setAboutPanelOptionsMock = vi.fn();
+const showAboutPanelMock = vi.fn();
 const getAppPathMock = vi.fn(() => "/test/app");
 const getVersionMock = vi.fn(() => "1.0.0-alpha.0");
 const whenReadyMock = vi.fn(() => Promise.resolve());
@@ -76,14 +78,19 @@ const startupProfilerInstance = {
 const StartupCpuProfilerMock = vi.fn(function StartupCpuProfiler() {
   return startupProfilerInstance;
 });
+const resolveDeveloperModeMock = vi.fn(() => true);
+const getDesktopSettingsServiceMock = vi.fn(() => ({
+  resolveDeveloperMode: resolveDeveloperModeMock,
+}));
 
 vi.mock("electron", () => ({
   app: {
     setName: setNameMock,
     setAboutPanelOptions: setAboutPanelOptionsMock,
+    isPackaged: false,
     getAppPath: getAppPathMock,
     getVersion: getVersionMock,
-    showAboutPanel: vi.fn(),
+    showAboutPanel: showAboutPanelMock,
     whenReady: whenReadyMock,
     dock: {
       setIcon: dockSetIconMock,
@@ -148,6 +155,7 @@ vi.mock("../changelog-window", () => ({
 }));
 
 vi.mock("../license-document-window", () => ({
+  showLicenseWindow: showLicenseWindowMock,
   showThirdPartyNoticesWindow: showThirdPartyNoticesWindowMock,
 }));
 
@@ -221,6 +229,10 @@ vi.mock("../state/app-state", () => ({
   isAppStateInitialized: isAppStateInitializedMock,
 }));
 
+vi.mock("../settings/desktop-settings-singleton", () => ({
+  getDesktopSettingsService: getDesktopSettingsServiceMock,
+}));
+
 const runtimeMessagingLeaseCoordinatorMock = {
   start: messagingLeaseStartMock,
   shutdownSync: messagingLeaseShutdownSyncMock,
@@ -271,6 +283,7 @@ describe("bootstrapApp", () => {
     checkForAppUpdatesNowMock.mockReset();
     showAppLogWindowMock.mockReset();
     showChangelogWindowMock.mockReset();
+    showLicenseWindowMock.mockReset();
     showThirdPartyNoticesWindowMock.mockReset();
     registerImageNormalizationIpcHandlersMock.mockReset();
     disposeImageNormalizationIpcHandlersMock.mockReset();
@@ -320,8 +333,12 @@ describe("bootstrapApp", () => {
     buildFromTemplateMock.mockClear();
     setNameMock.mockReset();
     setAboutPanelOptionsMock.mockReset();
+    showAboutPanelMock.mockReset();
     getAppPathMock.mockClear();
     getVersionMock.mockClear();
+    resolveDeveloperModeMock.mockReset();
+    resolveDeveloperModeMock.mockReturnValue(true);
+    getDesktopSettingsServiceMock.mockClear();
     dockSetIconMock.mockClear();
     nativeImageMock.isEmpty.mockReset();
     nativeImageMock.isEmpty.mockReturnValue(false);
@@ -462,12 +479,20 @@ describe("bootstrapApp", () => {
     item("Third-Party Notices")?.click?.();
     expect(showThirdPartyNoticesWindowMock).toHaveBeenCalledOnce();
 
+    item("View License")?.click?.();
+    expect(showLicenseWindowMock).toHaveBeenCalledOnce();
+
     await item("PwrAgent Website")?.click?.();
     expect(shellOpenExternalMock).toHaveBeenCalledWith("https://pwragent.ai");
 
     await item("Documentation")?.click?.();
     expect(shellOpenExternalMock).toHaveBeenCalledWith(
       "https://docs.pwragent.ai",
+    );
+
+    await item("Report an Issue")?.click?.();
+    expect(shellOpenExternalMock).toHaveBeenCalledWith(
+      "https://github.com/pwrdrvr/PwrAgent/issues/new",
     );
 
     expect(item(["Visit", "Website"].join(" "))).toBeUndefined();

--- a/apps/desktop/src/main/__tests__/menu.test.ts
+++ b/apps/desktop/src/main/__tests__/menu.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+import type { MenuItemConstructorOptions } from "electron";
+import { buildApplicationMenuTemplate } from "../menu";
+
+function buildTemplate(developerMode: boolean): MenuItemConstructorOptions[] {
+  return buildApplicationMenuTemplate({
+    appName: "PwrAgent",
+    developerMode,
+    isMac: true,
+    actions: {
+      checkForUpdates: vi.fn(),
+      openDocumentation: vi.fn(),
+      openIssueReporter: vi.fn(),
+      openWebsite: vi.fn(),
+      showAboutPanel: vi.fn(),
+      showChangelogWindow: vi.fn(),
+      showLicenseWindow: vi.fn(),
+      showLogsWindow: vi.fn(),
+      showThirdPartyNoticesWindow: vi.fn(),
+    },
+  });
+}
+
+function submenuRoles(
+  template: MenuItemConstructorOptions[],
+  label: string,
+): Array<string | undefined> {
+  const menu = template.find((item) => item.label === label);
+  const submenu = Array.isArray(menu?.submenu) ? menu.submenu : [];
+  return submenu.map((item) => item.role);
+}
+
+describe("buildApplicationMenuTemplate", () => {
+  it("hides developer-only View items when Developer Mode is off", () => {
+    const roles = submenuRoles(buildTemplate(false), "View");
+
+    expect(roles).not.toContain("reload");
+    expect(roles).not.toContain("forceReload");
+    expect(roles).not.toContain("toggleDevTools");
+    expect(roles.filter((role) => role === "togglefullscreen")).toHaveLength(1);
+  });
+
+  it("includes developer-only View items when Developer Mode is on", () => {
+    const roles = submenuRoles(buildTemplate(true), "View");
+
+    expect(roles).toContain("reload");
+    expect(roles).toContain("forceReload");
+    expect(roles).toContain("toggleDevTools");
+    expect(roles.filter((role) => role === "togglefullscreen")).toHaveLength(1);
+  });
+});

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -14,7 +14,10 @@ import {
 } from "./auto-updater";
 import { showAppLogWindow } from "./app-log-window";
 import { showChangelogWindow } from "./changelog-window";
-import { showThirdPartyNoticesWindow } from "./license-document-window";
+import {
+  showLicenseWindow,
+  showThirdPartyNoticesWindow,
+} from "./license-document-window";
 import {
   PWRAGENT_DOCUMENTATION_URL,
   PWRAGENT_HOMEPAGE_URL,
@@ -76,9 +79,12 @@ import {
   isAppStateInitialized,
 } from "./state/app-state";
 import { createMainWindow } from "./window";
+import { buildApplicationMenuTemplate } from "./menu";
 
 const APP_NAME = "PwrAgent";
 const APP_COPYRIGHT = "Copyright © 2026 PwrDrvr LLC.";
+const PWRAGENT_ISSUE_REPORTER_URL =
+  "https://github.com/pwrdrvr/PwrAgent/issues/new";
 const isMac = process.platform === "darwin";
 const isDevelopment = process.env.NODE_ENV !== "production";
 const mainLog = getMainLogger("pwragent:main");
@@ -167,60 +173,33 @@ function installDevelopmentDockIcon(): void {
 }
 
 function installApplicationMenu(): void {
-  const template: Electron.MenuItemConstructorOptions[] = [
-    ...(isMac ? [{ role: "appMenu" as const }] : []),
-    { role: "fileMenu" },
-    { role: "editMenu" },
-    { role: "viewMenu" },
-    { role: "windowMenu" },
-    {
-      role: "help",
-      submenu: [
-        {
-          label: `About ${APP_NAME}`,
-          click: () => {
-            app.showAboutPanel();
-          },
-        },
-        {
-          label: "Check for Updates",
-          click: () => {
-            void checkForAppUpdatesNow("menu");
-          },
-        },
-        {
-          label: "Changelog",
-          click: () => {
-            showChangelogWindow();
-          },
-        },
-        {
-          label: "Third-Party Notices",
-          click: () => {
-            showThirdPartyNoticesWindow();
-          },
-        },
-        {
-          label: "Logs",
-          click: () => {
-            showAppLogWindow();
-          },
-        },
-        {
-          label: "PwrAgent Website",
-          click: async () => {
-            await shell.openExternal(PWRAGENT_HOMEPAGE_URL);
-          },
-        },
-        {
-          label: "Documentation",
-          click: async () => {
-            await shell.openExternal(PWRAGENT_DOCUMENTATION_URL);
-          },
-        },
-      ],
+  const developerMode = getDesktopSettingsService().resolveDeveloperMode();
+  const template = buildApplicationMenuTemplate({
+    appName: APP_NAME,
+    developerMode,
+    isMac,
+    actions: {
+      checkForUpdates: () => {
+        void checkForAppUpdatesNow("menu");
+      },
+      openDocumentation: async () => {
+        await shell.openExternal(PWRAGENT_DOCUMENTATION_URL);
+      },
+      openIssueReporter: async () => {
+        await shell.openExternal(PWRAGENT_ISSUE_REPORTER_URL);
+      },
+      openWebsite: async () => {
+        await shell.openExternal(PWRAGENT_HOMEPAGE_URL);
+      },
+      showAboutPanel: () => {
+        app.showAboutPanel();
+      },
+      showChangelogWindow,
+      showLicenseWindow,
+      showLogsWindow: showAppLogWindow,
+      showThirdPartyNoticesWindow,
     },
-  ];
+  });
 
   Menu.setApplicationMenu(Menu.buildFromTemplate(template));
 }
@@ -251,7 +230,13 @@ export function bootstrapApp(): void {
     registerPreloadLogIpcHandlers();
     registerProfilesIpcHandlers();
     registerRendererErrorIpcHandlers();
-    registerSettingsIpcHandlers();
+    registerSettingsIpcHandlers(undefined, {
+      onConfigPatchWritten: async (patch) => {
+        if (patch.general?.developerMode !== undefined) {
+          installApplicationMenu();
+        }
+      },
+    });
     registerWindowPointerIpcHandlers();
     if (isDevelopment) {
       registerRuntimeIdentityIpcHandlers();

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -545,6 +545,12 @@ function disposeCredentialTester(): void {
 
 export function registerSettingsIpcHandlers(
   service?: DesktopSettingsService,
+  options?: {
+    onConfigPatchWritten?: (
+      patch: DesktopSettingsConfigPatch,
+      snapshot: DesktopSettingsSnapshot,
+    ) => void | Promise<void>;
+  },
 ): void {
   ipcMain.removeHandler(SETTINGS_READ_CHANNEL);
   ipcMain.handle(
@@ -568,6 +574,7 @@ export function registerSettingsIpcHandlers(
     ): Promise<DesktopSettingsWriteResponse> => {
       const activeService = getService(service);
       const snapshot = await activeService.writeConfigPatch(request.patch);
+      await options?.onConfigPatchWritten?.(request.patch, snapshot);
       await refreshModelBackendsIfNeeded({ patch: request.patch });
       if (messagingPatchTouchesRuntime(request.patch)) {
         await applyLatestMessagingRuntimeConfig(activeService);

--- a/apps/desktop/src/main/license-document-window.ts
+++ b/apps/desktop/src/main/license-document-window.ts
@@ -11,17 +11,47 @@ import {
 } from "./window-channels";
 
 const log = getMainLogger("pwragent:license-document-window");
+const LICENSE_HASH = "license";
 const THIRD_PARTY_NOTICES_HASH = "third-party-notices";
 
+let licenseWindow: BrowserWindow | undefined;
 let thirdPartyNoticesWindow: BrowserWindow | undefined;
 
+export function showLicenseWindow(): void {
+  showLicenseDocumentWindow({
+    hash: LICENSE_HASH,
+    title: "MIT License - PwrAgent",
+    windowRef: () => licenseWindow,
+    setWindowRef: (window) => {
+      licenseWindow = window;
+    },
+  });
+}
+
 export function showThirdPartyNoticesWindow(): void {
-  if (thirdPartyNoticesWindow && !thirdPartyNoticesWindow.isDestroyed()) {
-    if (thirdPartyNoticesWindow.isMinimized()) {
-      thirdPartyNoticesWindow.restore();
+  showLicenseDocumentWindow({
+    hash: THIRD_PARTY_NOTICES_HASH,
+    title: "Third-Party Notices - PwrAgent",
+    windowRef: () => thirdPartyNoticesWindow,
+    setWindowRef: (window) => {
+      thirdPartyNoticesWindow = window;
+    },
+  });
+}
+
+function showLicenseDocumentWindow(options: {
+  hash: string;
+  title: string;
+  windowRef: () => BrowserWindow | undefined;
+  setWindowRef: (window: BrowserWindow | undefined) => void;
+}): void {
+  const existingWindow = options.windowRef();
+  if (existingWindow && !existingWindow.isDestroyed()) {
+    if (existingWindow.isMinimized()) {
+      existingWindow.restore();
     }
-    thirdPartyNoticesWindow.show();
-    thirdPartyNoticesWindow.focus();
+    existingWindow.show();
+    existingWindow.focus();
     return;
   }
 
@@ -31,7 +61,7 @@ export function showThirdPartyNoticesWindow(): void {
     minWidth: 640,
     minHeight: 480,
     show: false,
-    title: "Third-Party Notices - PwrAgent",
+    title: options.title,
     titleBarStyle: "hiddenInset",
     trafficLightPosition: { x: 20, y: 18 },
     backgroundColor: "#000000",
@@ -48,9 +78,9 @@ export function showThirdPartyNoticesWindow(): void {
 
   const rendererEntry = getRendererEntry();
   if (rendererEntry.kind === "url") {
-    void window.loadURL(`${rendererEntry.value}#${THIRD_PARTY_NOTICES_HASH}`);
+    void window.loadURL(`${rendererEntry.value}#${options.hash}`);
   } else {
-    void window.loadFile(rendererEntry.value, { hash: THIRD_PARTY_NOTICES_HASH });
+    void window.loadFile(rendererEntry.value, { hash: options.hash });
   }
 
   window.once("ready-to-show", () => {
@@ -58,10 +88,10 @@ export function showThirdPartyNoticesWindow(): void {
   });
 
   window.on("closed", () => {
-    thirdPartyNoticesWindow = undefined;
-    log.debug("third-party notices window closed");
+    options.setWindowRef(undefined);
+    log.debug("license document window closed", { hash: options.hash });
   });
 
-  thirdPartyNoticesWindow = window;
-  log.debug("third-party notices window created");
+  options.setWindowRef(window);
+  log.debug("license document window created", { hash: options.hash });
 }

--- a/apps/desktop/src/main/menu.ts
+++ b/apps/desktop/src/main/menu.ts
@@ -1,0 +1,139 @@
+import type { MenuItemConstructorOptions } from "electron";
+
+export type ApplicationMenuActions = {
+  checkForUpdates: () => void;
+  openDocumentation: () => void | Promise<void>;
+  openIssueReporter: () => void | Promise<void>;
+  openWebsite: () => void | Promise<void>;
+  showAboutPanel: () => void;
+  showChangelogWindow: () => void;
+  showLicenseWindow: () => void;
+  showLogsWindow: () => void;
+  showThirdPartyNoticesWindow: () => void;
+};
+
+export type ApplicationMenuOptions = {
+  appName: string;
+  developerMode: boolean;
+  isMac: boolean;
+  actions: ApplicationMenuActions;
+};
+
+export function buildApplicationMenuTemplate(
+  options: ApplicationMenuOptions,
+): MenuItemConstructorOptions[] {
+  return [
+    ...(options.isMac ? [buildMacAppMenu(options)] : []),
+    buildFileMenu(options),
+    { role: "editMenu" },
+    buildViewMenu(options.developerMode),
+    { role: "windowMenu" },
+    buildHelpMenu(options),
+  ];
+}
+
+function buildMacAppMenu(
+  options: ApplicationMenuOptions,
+): MenuItemConstructorOptions {
+  return {
+    label: options.appName,
+    submenu: [
+      {
+        label: `About ${options.appName}`,
+        click: options.actions.showAboutPanel,
+      },
+      { type: "separator" },
+      { role: "services" },
+      { type: "separator" },
+      { role: "hide" },
+      { role: "hideOthers" },
+      { role: "unhide" },
+      { type: "separator" },
+      { role: "quit" },
+    ],
+  };
+}
+
+function buildFileMenu(options: ApplicationMenuOptions): MenuItemConstructorOptions {
+  return {
+    label: "File",
+    submenu: [
+      { role: "close" },
+      ...(options.isMac
+        ? []
+        : [{ type: "separator" as const }, { role: "quit" as const }]),
+    ],
+  };
+}
+
+function buildViewMenu(developerMode: boolean): MenuItemConstructorOptions {
+  return {
+    label: "View",
+    submenu: [
+      ...(developerMode
+        ? [
+            { role: "reload" as const },
+            { role: "forceReload" as const },
+            { role: "toggleDevTools" as const },
+            { type: "separator" as const },
+          ]
+        : []),
+      { role: "resetZoom" },
+      { role: "zoomIn" },
+      { role: "zoomOut" },
+      { type: "separator" },
+      { role: "togglefullscreen" },
+    ],
+  };
+}
+
+function buildHelpMenu(options: ApplicationMenuOptions): MenuItemConstructorOptions {
+  return {
+    role: "help",
+    submenu: [
+      ...(!options.isMac
+        ? [
+            {
+              label: `About ${options.appName}`,
+              click: options.actions.showAboutPanel,
+            },
+            { type: "separator" as const },
+          ]
+        : []),
+      {
+        label: "Check for Updates",
+        click: options.actions.checkForUpdates,
+      },
+      {
+        label: "Changelog",
+        click: options.actions.showChangelogWindow,
+      },
+      { type: "separator" },
+      {
+        label: "Documentation",
+        click: options.actions.openDocumentation,
+      },
+      {
+        label: "Report an Issue",
+        click: options.actions.openIssueReporter,
+      },
+      {
+        label: "PwrAgent Website",
+        click: options.actions.openWebsite,
+      },
+      { type: "separator" },
+      {
+        label: "View License",
+        click: options.actions.showLicenseWindow,
+      },
+      {
+        label: "Third-Party Notices",
+        click: options.actions.showThirdPartyNoticesWindow,
+      },
+      {
+        label: "Logs",
+        click: options.actions.showLogsWindow,
+      },
+    ],
+  };
+}

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -46,6 +46,9 @@ type StoredChatReplyComposer =
   | LegacyChatReplyComposer;
 
 export type DesktopSettingsConfig = {
+  general?: {
+    developerMode?: boolean;
+  };
   experimental?: {
     chatReplyComposer?: StoredChatReplyComposer;
     fullAccessRiskWarningDismissed?: boolean;
@@ -305,6 +308,10 @@ export function desktopSettingsPatchToEdits(
   // `chat_reply_composer` is obsolete and intentionally ignored by current
   // clients. Preserve existing values for downgrade compatibility, but do not
   // write new values.
+  if (patch.general?.developerMode !== undefined) {
+    set(["general", "developer_mode"], patch.general.developerMode);
+  }
+
   if (patch.experimental?.diffCondensation?.enabled !== undefined) {
     set(
       ["experimental", "diff_condensation", "enabled"],
@@ -676,6 +683,7 @@ function normalizeDesktopConfig(
   tables: Record<string, Record<string, TomlScalar>>,
 ): DesktopSettingsConfig {
   const experimental = tables["experimental"];
+  const general = tables["general"];
   const diffCondensation = tables["experimental.diff_condensation"];
   const imageUploads = tables["image_uploads"];
   const updates = tables["updates"];
@@ -694,6 +702,9 @@ function normalizeDesktopConfig(
   const worktrees = tables["worktrees"];
 
   return pruneEmptyConfig({
+    general: {
+      developerMode: readBoolean(general?.developer_mode),
+    },
     experimental: {
       chatReplyComposer: readComposer(experimental?.chat_reply_composer),
       fullAccessRiskWarningDismissed: readBoolean(
@@ -871,6 +882,10 @@ function pruneEmptyConfig(config: DesktopSettingsConfig): DesktopSettingsConfig 
 
   if (config.experimental && hasDefinedValue(config.experimental)) {
     pruned.experimental = config.experimental;
+  }
+
+  if (config.general && hasDefinedValue(config.general)) {
+    pruned.general = config.general;
   }
 
   if (config.imageUploads && hasDefinedValue(config.imageUploads)) {

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -114,6 +114,7 @@ import { mergeLoginShellEnvIntoEnv } from "../shell-environment";
 
 type DesktopSettingsServiceOptions = {
   configPath?: string;
+  defaultDeveloperMode?: boolean;
   env?: NodeJS.ProcessEnv;
   argv?: readonly string[];
   secretStore: DesktopSecretStore;
@@ -280,6 +281,12 @@ export class DesktopSettingsService {
         },
       },
       secretStorage,
+      general: {
+        developerMode: this.resolveConfigBoolean(
+          config.general?.developerMode,
+          this.defaultDeveloperMode(),
+        ),
+      },
       experimental: {
         chatReplyComposer: this.resolveComposer(
           config.experimental?.chatReplyComposer,
@@ -599,6 +606,13 @@ export class DesktopSettingsService {
       .value;
   }
 
+  resolveDeveloperMode(): boolean {
+    return this.resolveConfigBoolean(
+      this.readConfig().config.general?.developerMode,
+      this.defaultDeveloperMode(),
+    ).value;
+  }
+
   async writeConfigPatch(
     patch: DesktopSettingsConfigPatch,
   ): Promise<DesktopSettingsSnapshot> {
@@ -760,6 +774,10 @@ export class DesktopSettingsService {
         error: error instanceof Error ? error.message : String(error),
       };
     }
+  }
+
+  private defaultDeveloperMode(): boolean {
+    return this.options.defaultDeveloperMode ?? this.env.NODE_ENV !== "production";
   }
 
   private resolveComposer(

--- a/apps/desktop/src/main/settings/desktop-settings-singleton.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-singleton.ts
@@ -1,4 +1,4 @@
-import { safeStorage } from "electron";
+import { app, safeStorage } from "electron";
 import { DesktopSettingsService } from "./desktop-settings-service";
 import { DbBackedSafeStorageSecretStore } from "../state/secret-store-sqlite";
 import { getAppStateDb } from "../state/app-state";
@@ -7,6 +7,7 @@ let desktopSettingsService: DesktopSettingsService | undefined;
 
 export function getDesktopSettingsService(): DesktopSettingsService {
   desktopSettingsService ??= new DesktopSettingsService({
+    defaultDeveloperMode: app.isPackaged === true ? false : true,
     secretStore: new DbBackedSafeStorageSecretStore(safeStorage, getAppStateDb()),
   });
   return desktopSettingsService;

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -170,6 +170,12 @@ describe("App", () => {
         backend: "memory",
         encrypted: false,
       },
+      general: {
+        developerMode: {
+          value: false,
+          source: "default",
+        },
+      },
       experimental: {
         chatReplyComposer: {
           value: "tiptap-wysiwyg-markdown-chips",

--- a/apps/desktop/src/renderer/src/features/license/LicenseDocumentWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/license/LicenseDocumentWindow.tsx
@@ -1,17 +1,29 @@
 import { useEffect, useState } from "react";
-import type { AppLicenseDocument } from "../../../../shared/app-metadata";
+import type {
+  AppLicenseDocument,
+  AppLicenseDocumentKind,
+} from "../../../../shared/app-metadata";
 import { useDesktopApi } from "../../lib/desktop-api";
+
+function currentDocumentKind(): AppLicenseDocumentKind {
+  return window.location.hash.replace(/^#/, "") === "license"
+    ? "license"
+    : "third-party-licenses";
+}
 
 export function LicenseDocumentWindow() {
   const desktopApi = useDesktopApi();
+  const documentKind = currentDocumentKind();
+  const fallbackTitle =
+    documentKind === "license" ? "MIT License" : "Third-Party Notices";
   const [licenseDocument, setLicenseDocument] = useState<
     AppLicenseDocument | undefined
   >();
   const [error, setError] = useState<string | undefined>();
 
   useEffect(() => {
-    document.title = "Third-Party Notices";
-  }, []);
+    document.title = fallbackTitle;
+  }, [fallbackTitle]);
 
   useEffect(() => {
     let cancelled = false;
@@ -20,7 +32,7 @@ export function LicenseDocumentWindow() {
       return;
     }
 
-    reader("third-party-licenses")
+    reader(documentKind)
       .then((value) => {
         if (!cancelled) {
           setLicenseDocument(value);
@@ -36,11 +48,13 @@ export function LicenseDocumentWindow() {
     return () => {
       cancelled = true;
     };
-  }, [desktopApi]);
+  }, [desktopApi, documentKind]);
+
+  const title = licenseDocument?.title ?? fallbackTitle;
 
   return (
     <div className="document-window">
-      <section aria-label="PwrAgent third-party notices" className="activity-screen">
+      <section aria-label={`PwrAgent ${title}`} className="activity-screen">
         <header className="activity-titlebar">
           <p className="activity-titlebar__brand">
             Pwr<span className="activity-titlebar__brand-accent">Agent</span>
@@ -50,7 +64,7 @@ export function LicenseDocumentWindow() {
             <span aria-hidden="true" className="activity-titlebar__separator">
               ›
             </span>
-            <span className="activity-titlebar__current">Third-Party Notices</span>
+            <span className="activity-titlebar__current">{title}</span>
           </div>
           <div className="activity-titlebar__spacer" />
         </header>
@@ -58,7 +72,7 @@ export function LicenseDocumentWindow() {
           <article className="document-window__body">
             {error ? (
               <p className="document-window__error" role="alert">
-                Could not load third-party notices: {error}
+                Could not load {title.toLowerCase()}: {error}
               </p>
             ) : licenseDocument ? (
               <pre className="document-window__pre">{licenseDocument.content}</pre>

--- a/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
@@ -15,6 +15,7 @@ import {
   SettingsSectionStack,
 } from "./SettingsLayout";
 import { sourceBadge } from "./settings-fields";
+import { SettingsSwitch } from "./SettingsSwitch";
 
 const PASTED_IMAGE_PATCH_OPTIONS: Array<{
   description: string;
@@ -71,6 +72,7 @@ export function GeneralSettings(props: {
   desktopApi?: DesktopApi;
   saving: boolean;
   snapshot: DesktopSettingsSnapshot;
+  onDeveloperModeChange: (value: boolean) => Promise<void>;
   onPastedImageMaxPatchesChange: (value: number) => Promise<void>;
   onUpdateChannelChange: (value: DesktopUpdateChannel) => Promise<void>;
 }) {
@@ -79,6 +81,7 @@ export function GeneralSettings(props: {
   >();
   const pastedImageMaxPatches =
     props.snapshot.imageUploads.pastedImageMaxPatches;
+  const developerMode = props.snapshot.general.developerMode;
   const updateChannel = props.snapshot.updates.channel;
   const activeOption = PASTED_IMAGE_PATCH_OPTIONS.find(
     (option) => option.value === pastedImageMaxPatches.value,
@@ -103,6 +106,30 @@ export function GeneralSettings(props: {
         title="General settings"
         help="Defaults that apply across PwrAgent surfaces."
       />
+
+      <SettingsSection
+        eyebrow="General"
+        title="Developer mode"
+        chip={sourceBadge(developerMode)}
+      >
+        <div className="settings-fields">
+          <SettingsField
+            label="Developer Mode"
+            sub="Expose Reload, Force Reload, and Developer Tools menu shortcuts."
+            source={sourceBadge(developerMode)}
+            control={
+              <SettingsSwitch
+                checked={developerMode.value}
+                disabled={props.saving}
+                label="Developer Mode"
+                onChange={(next) => {
+                  void props.onDeveloperModeChange(next);
+                }}
+              />
+            }
+          />
+        </div>
+      </SettingsSection>
 
       <SettingsSection
         eyebrow="General"

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -225,6 +225,11 @@ function SettingsSectionBody(props: {
         desktopApi={props.desktopApi}
         saving={props.settings.saving}
         snapshot={props.snapshot}
+        onDeveloperModeChange={async (developerMode: boolean) => {
+          await props.settings.writeConfig({
+            general: { developerMode },
+          });
+        }}
         onUpdateChannelChange={async (channel: DesktopUpdateChannel) => {
           await props.settings.writeConfig({
             updates: { channel },

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -46,6 +46,12 @@ function createSnapshot(
       backend: "memory",
       encrypted: false,
     },
+    general: {
+      developerMode: {
+        value: false,
+        source: "default",
+      },
+    },
     experimental: {
       chatReplyComposer: {
         value: "tiptap-wysiwyg-markdown-chips",
@@ -311,6 +317,19 @@ describe("SettingsScreen", () => {
       "aria-checked",
       "true",
     );
+    expect(screen.getByRole("switch", { name: "Developer Mode" })).toHaveAttribute(
+      "aria-checked",
+      "false",
+    );
+    fireEvent.click(screen.getByRole("switch", { name: "Developer Mode" }));
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        general: {
+          developerMode: true,
+        },
+      });
+    });
+
     expect(await screen.findByText("v1.0.0-beta.7")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("radio", { name: /Prerelease/ }));
     await waitFor(() => {

--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -47,7 +47,7 @@ const routes: Array<{
     render: () => <ChangelogWindow />,
   },
   {
-    match: (hash) => hash === "third-party-notices",
+    match: (hash) => hash === "license" || hash === "third-party-notices",
     render: () => <LicenseDocumentWindow />,
   },
   {

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -18,6 +18,12 @@ describe("desktop settings contracts", () => {
         backend: "safeStorage",
         encrypted: true,
       },
+      general: {
+        developerMode: {
+          value: false,
+          source: "default",
+        },
+      },
       experimental: {
         chatReplyComposer: {
           value: "tiptap-wysiwyg-markdown-chips",

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -146,6 +146,10 @@ export type DesktopUpdateSettingsSnapshot = {
   channel: DesktopSettingsValue<DesktopUpdateChannel>;
 };
 
+export type DesktopGeneralSettingsSnapshot = {
+  developerMode: DesktopSettingsValue<boolean>;
+};
+
 export type DesktopCodexCandidateSource =
   | "env"
   | "config"
@@ -295,6 +299,7 @@ export type DesktopSettingsSnapshot = {
     };
   };
   secretStorage: DesktopSettingsSecretStorageState;
+  general: DesktopGeneralSettingsSnapshot;
   experimental: {
     chatReplyComposer: DesktopSettingsValue<DesktopChatReplyComposer>;
     fullAccessRiskWarningDismissed: DesktopSettingsValue<boolean>;
@@ -414,6 +419,9 @@ export type DesktopSettingsSnapshot = {
 };
 
 export type DesktopSettingsConfigPatch = {
+  general?: {
+    developerMode?: boolean;
+  };
   experimental?: {
     fullAccessRiskWarningDismissed?: boolean;
     diffCondensation?: {


### PR DESCRIPTION
## Summary

- I replaced the stock Electron View menu with a curated application menu that hides Reload, Force Reload, and Toggle Developer Tools unless Developer Mode is enabled.
- I added a persisted Settings -> General -> Developer Mode toggle under `general.developer_mode`, defaulting on for dev builds and off for packaged release builds.
- I wired menu rebuilds when the toggle changes, kept only one Toggle Full Screen item, and added Help menu entries for docs, issue reporting, MIT license, and third-party notices.

Closes #468

## Verification

- I ran `pnpm test apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx apps/desktop/src/main/__tests__/menu.test.ts apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts apps/desktop/src/main/__tests__/desktop-settings-service.test.ts apps/desktop/src/main/__tests__/index.test.ts apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx apps/desktop/src/renderer/src/features/license/__tests__/license-document-window.test.tsx packages/shared/src/contracts/__tests__/settings.test.ts`.
- I ran `pnpm --filter @pwragent/desktop typecheck`.
- I ran `git diff --check`.

## Notes

- I confirmed the existing renderer context menu path is custom and only exposes Copy Link, so it does not surface Electron Inspect or Reload items.
