### PR TITLE
ci(docs): gate pages.yml on pa11y-ci WCAG2 AA audit

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -86,6 +86,13 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: "22"
+          # We install pa11y-ci + http-server globally as a one-shot;
+          # no project package.json in docs-site. Disable the auto-
+          # detected pnpm cache (the repo root has a pnpm-lock.yaml
+          # that setup-node would otherwise try to honor, but pnpm
+          # isn't pre-installed on the runner so the cache step
+          # fails with "Unable to locate executable file: pnpm").
+          package-manager-cache: false
 
       - name: Build Jekyll site for a11y audit
         # Re-build with no base path so the URLs in .pa11yci.json

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -83,15 +83,21 @@ jobs:
           bundler-cache: true
           working-directory: docs-site
 
+      # Note: every other workflow in this repo uses
+      # `pwrdrvr/configure-nodejs@v1`, which detects the package
+      # manager from a lockfile and runs a full project install.
+      # This job doesn't have (or want) a `docs-site/package.json`
+      # — pa11y-ci and http-server are installed globally as a
+      # one-shot. `actions/setup-node@v5` is the right shape for
+      # "give me Node, that's it."
+      #
+      # `package-manager-cache: false` because setup-node otherwise
+      # auto-detects the repo root's `pnpm-lock.yaml`, tries to
+      # enable the pnpm cache, and fails (pnpm isn't pre-installed
+      # on the runner).
       - uses: actions/setup-node@v5
         with:
           node-version: "22"
-          # We install pa11y-ci + http-server globally as a one-shot;
-          # no project package.json in docs-site. Disable the auto-
-          # detected pnpm cache (the repo root has a pnpm-lock.yaml
-          # that setup-node would otherwise try to honor, but pnpm
-          # isn't pre-installed on the runner so the cache step
-          # fails with "Unable to locate executable file: pnpm").
           package-manager-cache: false
 
       - name: Build Jekyll site for a11y audit

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -60,10 +60,65 @@ jobs:
         with:
           path: docs-site/_site
 
-  deploy:
-    # PR runs only validate the build; deploys are gated to main.
-    if: github.event_name != 'pull_request'
+  a11y:
+    # Accessibility gate. Spins up the freshly-built _site under a
+    # local static server and runs pa11y-ci (axe + HTML CodeSniffer)
+    # against every important URL. Any WCAG2 AA violation fails the
+    # job, which prevents the deploy gate from advancing on main and
+    # surfaces as a failed status check on PRs.
+    #
+    # The audit goal lives in docs-site/AGENTS.md "Accessibility";
+    # URL list + config live in docs-site/.pa11yci.json.
     needs: build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: docs-site
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2"
+          bundler-cache: true
+          working-directory: docs-site
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+
+      - name: Build Jekyll site for a11y audit
+        # Re-build with no base path so the URLs in .pa11yci.json
+        # resolve at the site root (the production build uses
+        # configure-pages' base_path, which would break the localhost
+        # URL list).
+        env:
+          JEKYLL_ENV: production
+        run: bundle exec jekyll build
+
+      - name: Install pa11y-ci + http-server
+        run: npm install -g pa11y-ci@4 http-server@14
+
+      - name: Serve _site on 4001
+        run: |
+          http-server _site -p 4001 -s &
+          for i in $(seq 1 30); do
+            if curl -sf http://127.0.0.1:4001/ > /dev/null; then
+              exit 0
+            fi
+            sleep 0.5
+          done
+          echo "::error::http-server did not come up on port 4001"
+          exit 1
+
+      - name: Run pa11y-ci (WCAG2 AA)
+        run: pa11y-ci --config .pa11yci.json
+
+  deploy:
+    # PR runs only validate the build + a11y gate; deploys are gated
+    # to main pushes (and to a11y passing).
+    if: github.event_name != 'pull_request'
+    needs: [build, a11y]
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/docs-site/.pa11yci.json
+++ b/docs-site/.pa11yci.json
@@ -1,0 +1,36 @@
+{
+  "defaults": {
+    "standard": "WCAG2AA",
+    "runners": ["axe", "htmlcs"],
+    "includeWarnings": false,
+    "includeNotices": false,
+    "timeout": 30000,
+    "wait": 250,
+    "chromeLaunchConfig": {
+      "args": ["--no-sandbox", "--disable-dev-shm-usage"]
+    },
+    "viewport": {
+      "width": 1440,
+      "height": 900
+    },
+    "hideElements": "kbd"
+  },
+  "urls": [
+    "http://127.0.0.1:4001/",
+    "http://127.0.0.1:4001/desktop/",
+    "http://127.0.0.1:4001/messaging/",
+    "http://127.0.0.1:4001/using-codex/",
+    "http://127.0.0.1:4001/messaging/pairing/",
+    "http://127.0.0.1:4001/settings/",
+    "http://127.0.0.1:4001/streaming/",
+    "http://127.0.0.1:4001/webhook-dangers/",
+    "http://127.0.0.1:4001/rate-limits/",
+    "http://127.0.0.1:4001/providers/",
+    "http://127.0.0.1:4001/providers/telegram/",
+    "http://127.0.0.1:4001/providers/discord/",
+    "http://127.0.0.1:4001/providers/slack/",
+    "http://127.0.0.1:4001/providers/mattermost/",
+    "http://127.0.0.1:4001/providers/feishu/",
+    "http://127.0.0.1:4001/providers/line/"
+  ]
+}

--- a/docs-site/assets/css/site.css
+++ b/docs-site/assets/css/site.css
@@ -647,6 +647,25 @@ code {
   border: 1px solid var(--border-subtle);
 }
 
+/* Keyboard key glyphs (<kbd>↑</kbd>, <kbd>Cmd+Z</kbd>). Slightly
+ * heavier border and softer background than <code> so a key reads
+ * as a key, not as code. Inherits text-primary so contrast against
+ * the page background stays at ≈19:1. */
+kbd {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  font-weight: 600;
+  color: var(--text-primary);
+  background: var(--bg-panel-elevated);
+  padding: 0.1em 0.45em;
+  border-radius: 4px;
+  border: 1px solid var(--border-strong);
+  box-shadow: 0 1px 0 var(--border-strong);
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
 pre {
   background: var(--bg-panel);
   border: 1px solid var(--border-subtle);

--- a/docs-site/desktop.md
+++ b/docs-site/desktop.md
@@ -31,10 +31,10 @@ What makes the PwrAgent side worth running:
   `>` opens a blockquote, bullet and numbered lists auto-continue.
   Codex Desktop doesn't have this yet.
 - **Persistent draft history** — every keystroke autosaves to a
-  per-profile store. Press **↑** in an empty composer to recover
-  and cycle through the last 20 drafts (unsent *and* sent). Drafts
-  survive thread switches, sidebar refreshes, settings overlays,
-  and full app restarts.
+  per-profile store. Press <kbd>↑</kbd> in an empty composer to
+  recover and cycle through the last 20 drafts (unsent *and* sent).
+  Drafts survive thread switches, sidebar refreshes, settings
+  overlays, and full app restarts.
 - **Profile isolation** — two layered profile mechanisms (PwrAgent
   + Codex) compose into anything from "one install, one identity"
   to "N installs running side-by-side with isolated auth and
@@ -199,21 +199,21 @@ Codex Desktop doesn't have this yet.
 
 ### Undo / redo (per-thread)
 
-While a thread is focused, **Cmd+Z** undoes the most recent change
-to that thread's composer, and **Cmd+Shift+Z** (or **Cmd+Y**)
-redoes. Each thread carries its own independent undo stack —
-switching threads doesn't merge the histories, and undo never
-crosses thread boundaries.
+While a thread is focused, <kbd>Cmd+Z</kbd> undoes the most recent
+change to that thread's composer, and <kbd>Cmd+Shift+Z</kbd> (or
+<kbd>Cmd+Y</kbd>) redoes. Each thread carries its own independent
+undo stack — switching threads doesn't merge the histories, and
+undo never crosses thread boundaries.
 
 Undo also restores a `$skill` chip you just removed with
-**Backspace**, recovering both the chip and its position in the
-surrounding text — so an accidental delete doesn't cost you the
+<kbd>Backspace</kbd>, recovering both the chip and its position in
+the surrounding text — so an accidental delete doesn't cost you the
 chip you spent time picking.
 
 For recovery **across** threads or app restarts, see
 [Composer draft history](#composer-draft-history--recovers-your-last-message)
-below — the **↑** mechanic there reaches further back than the
-per-thread undo stack does.
+below — the <kbd>↑</kbd> mechanic there reaches further back than
+the per-thread undo stack does.
 
 ### Composer draft history (↑ recovers your last message)
 
@@ -230,10 +230,10 @@ that historically lost them in other agent UIs:
 - Closing a thread without sending
 
 To recover a previous draft, focus an **empty** composer and press
-**↑ (ArrowUp)**. The composer fills with the most recent
-candidate. Keep pressing **↑** to cycle further back through up to
-**20 recent candidates** (per-profile); **↓ (ArrowDown)** cycles
-forward through the same list.
+<kbd>↑</kbd> (ArrowUp). The composer fills with the most recent
+candidate. Keep pressing <kbd>↑</kbd> to cycle further back through
+up to **20 recent candidates** (per-profile); <kbd>↓</kbd>
+(ArrowDown) cycles forward through the same list.
 
 Candidates include:
 
@@ -247,7 +247,7 @@ Candidates include:
 
 The recovery cycle is anchored on the *blank composer* state.
 Start typing once you've found the draft you want and the cycle
-ends — the next **↑** will move the cursor in the usual way.
+ends — the next <kbd>↑</kbd> will move the cursor in the usual way.
 
 Draft history is **per PwrAgent profile** — switching profiles via
 `--profile <name>` gives that profile its own independent history.


### PR DESCRIPTION
## Summary

Adds an accessibility check between Jekyll build and Pages deploy. **Any WCAG2 AA violation fails the job → the deploy doesn't advance on `main`, and PRs surface the failure as a separate status check.**

Runs against 16 representative URLs (home, all top-level sections, every per-provider page). ~30s added to the workflow.

## Three pieces

### `docs-site/.pa11yci.json` (new)

pa11y-ci config — WCAG2 AA standard, axe + HTML CodeSniffer runners, 1440×900 viewport, the 16 URL list. `hideElements: "kbd"` suppresses one specific class of false positives (see below).

### `.github/workflows/pages.yml` (updated)

New `a11y` job between `build` and `deploy`:

```
build:  Jekyll build → upload-pages-artifact
a11y:   rebuild for localhost (no base path)
        → install Node + pa11y-ci + http-server
        → serve _site on :4001
        → pa11y-ci --config .pa11yci.json
deploy: needs both build AND a11y → upload-pages → live
```

The a11y job re-runs Jekyll without `--baseurl` so localhost URLs in `.pa11yci.json` resolve correctly (the production build uses `configure-pages`' base path, which would break the URL list).

### `docs-site/desktop.md` + `docs-site/assets/css/site.css` (the swap)

Replace bolded-key glyphs (`**↑**`, `**Cmd+Z**`, `**Cmd+Shift+Z**`, `**Cmd+Y**`, `**Backspace**`) with `<kbd>` elements. `<kbd>` is the semantically-correct HTML element for keyboard input — readers/screen readers identify the content as keystrokes, not generic emphasis.

Small `kbd { ... }` rule in site.css so keys read as little keycaps (monospace, subtle border + shadow on `--bg-panel-elevated`) instead of generic bold text. Inherits `--text-primary` so contrast is 17:1 (AAA).

## The `hideElements: "kbd"` decision

axe-core's color-contrast algorithm **can't measure single-character glyphs reliably** (the `<kbd>↑</kbd>` and `<kbd>↓</kbd>` keys throughout the composer docs). Manual measurement: `#f7f3eb` on `#101010` = ~17:1, well above WCAG AAA's 7:1 floor. But axe returns "incomplete" on these, and pa11y-ci treats "incomplete" as fail.

Two ways to handle that:

| Option | Trade-off |
|---|---|
| **`hideElements: "kbd"`** *(chosen)* | Suppress axe checks on `<kbd>` only. We keep contrast checking everywhere else; we lose it on `<kbd>` where we manually verified contrast is fine. |
| `ignore: ["color-contrast"]` | Disable contrast checking site-wide. Too broad — we'd miss real future violations. |

Inline-color workaround (adding `style="color:…; background:…"` to every `<kbd>`) didn't help — axe's single-character heuristic still trips even with explicit styles.

## Verification

Ran the exact same pa11y-ci config against the local Docker build:

```
$ pa11y-ci --config /tmp/pa11y-local.json
…
 > http://127.0.0.1:4000/providers/line/ - 0 errors

✔ 16/16 URLs passed
```

The first attempt (before the `<kbd>` swap + `hideElements`) failed 1/16 on the bolded-arrow glyphs. After the swap → 16/16 clean.

## Relationship to PR #477

Both branched off main; both touch CSS but at different points:
- **#477** adds `.skip-link` rules right after `::selection`
- **This PR** adds `kbd` rules right after `code`

Neither touches the other's lines in `default.html`. They'll merge in either order with no conflict.

#477 added the `docs-site/AGENTS.md` "Accessibility" section with the goal statement and the local audit recipe. After both land, a small follow-up should add a "CI gate" line to AGENTS.md noting that violations now block the deploy.

## Post-Deploy Monitoring

- Pages workflow fires on merge. The `a11y` job is now visible in every Pages run (PR + main). Expected runtime: ~30-45s for the audit step.
- If a future PR introduces a violation, the PR's a11y check fails with the URL list + specific axe rule + specific element. Reviewer fixes the violation or adjusts the audit config.
- If pa11y-ci itself becomes flaky (network blips downloading axe-core, http-server race), revisit. Initial bet: stable.

🤖 Generated with Claude Opus 4.7 via [Claude Code](https://claude.com/claude-code)