### PR TITLE
docs(docs-site): figure-with-caption pattern for every screenshot

### DIFF
--- a/docs-site/_includes/figure.html
+++ b/docs-site/_includes/figure.html
@@ -1,0 +1,1 @@
+<figure class="screenshot"><img src="{{ include.src | relative_url }}" alt="{{ include.alt | escape }}" loading="lazy"><figcaption>{{ include.caption }}</figcaption></figure>

--- a/docs-site/assets/css/site.css
+++ b/docs-site/assets/css/site.css
@@ -240,6 +240,49 @@ body {
   line-height: 1.5;
 }
 
+/* ----- In-page screenshot figure -----
+ * Used by `_includes/figure.html` for every body-level screenshot.
+ * Caption sits inside the bordered frame as a strip beneath the
+ * image — the image + caption read as one figure object so a
+ * reader can decode the screenshot without scrolling back to the
+ * surrounding prose. */
+
+.screenshot {
+  margin: 1.6em 0 2em;
+  padding: 0;
+  background: var(--bg-panel);
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
+}
+
+.screenshot img {
+  display: block;
+  width: 100%;
+  height: auto;
+  border: 0;
+  border-radius: 0;
+}
+
+.screenshot figcaption {
+  padding: 10px 14px;
+  font-size: 12.5px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  border-top: 1px solid var(--border-subtle);
+  background: var(--bg-panel);
+}
+
+.screenshot figcaption strong {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.screenshot figcaption code {
+  font-size: 0.92em;
+}
+
 .site-nav {
   display: flex;
   align-items: center;

--- a/docs-site/desktop.md
+++ b/docs-site/desktop.md
@@ -304,7 +304,7 @@ list immediately, and vice versa.
 {% include figure.html
    src="/assets/screenshots/desktop-skills-autocomplete.png"
    alt='Composer mid-message ("Let&#39;s use $ce") with the Skills autocomplete listbox open below it, showing matching skill rows like $ce:plan, $ce:brainstorm, $ce:compound'
-   caption="Typing <code>$ce</code> in the composer opens the Skills listbox. Filtering is incremental — keep typing to narrow (<code>$ce:p</code>) or pick a row to insert it as an inline chip."
+   caption="Typing <code>$</code> in the composer opens the Skills listbox. Subsequent characters filter incrementally — here <code>$ce</code> narrows to skills whose names start with <code>ce</code>. Pick a row to insert it as an inline chip."
 %}
 
 PwrAgent surfaces **Codex skills** (including plugin-exposed

--- a/docs-site/desktop.md
+++ b/docs-site/desktop.md
@@ -58,7 +58,11 @@ desktop **does**, what's not in it yet, and what's on the roadmap.
 
 ### Sidebar lenses
 
-![Sidebar with the Updated lens active, showing pinned threads at the top and recent activity below](assets/screenshots/desktop-recents.png)
+{% include figure.html
+   src="/assets/screenshots/desktop-recents.png"
+   alt="Sidebar with the Updated lens active, showing pinned threads at the top and recent activity below"
+   caption="The <strong>Updated</strong> lens, populated. Pins sit in a statically-ordered shelf at the top; unpinned threads sort by most-recent activity below."
+%}
 
 The left sidebar carries three thread lenses you can switch between
 with the segmented toggle at the top of the list. All three start
@@ -257,7 +261,11 @@ Codex Desktop doesn't have this yet either.
 
 ### Multi-message queueing
 
-![Composer with a turn in flight on the "Convert OAuth flow to PKCE" thread; "Review changes against main" (a queued /review against the base branch) and "now squash and push --force-with-lease" stacked as queued chips above the composer](assets/screenshots/desktop-queued-turns.png)
+{% include figure.html
+   src="/assets/screenshots/desktop-queued-turns.png"
+   alt='Composer with a turn in flight on the "Convert OAuth flow to PKCE" thread; "Review changes against main" (a queued /review against the base branch) and "now squash and push --force-with-lease" stacked as queued chips above the composer'
+   caption="The two <strong>QUEUED</strong> chips above the composer will fire FIFO when the in-flight <em>make a branch and PR</em> turn finishes. The composer's <strong>Send</strong> is replaced by <strong>Stop / Queue</strong> while a turn is active."
+%}
 
 You don't have to wait for the agent to finish a turn before
 queueing the next thing. While a turn is running, the composer's
@@ -293,7 +301,11 @@ list immediately, and vice versa.
 
 ### Skills browser ($ autocomplete and chips)
 
-![Composer mid-message ("Let's use $ce") with the Skills autocomplete listbox open below it, showing matching skill rows like $ce:plan, $ce:brainstorm, $ce:compound](assets/screenshots/desktop-skills-autocomplete.png)
+{% include figure.html
+   src="/assets/screenshots/desktop-skills-autocomplete.png"
+   alt='Composer mid-message ("Let&#39;s use $ce") with the Skills autocomplete listbox open below it, showing matching skill rows like $ce:plan, $ce:brainstorm, $ce:compound'
+   caption="Typing <code>$ce</code> in the composer opens the Skills listbox. Filtering is incremental — keep typing to narrow (<code>$ce:p</code>) or pick a row to insert it as an inline chip."
+%}
 
 PwrAgent surfaces **Codex skills** (including plugin-exposed
 skills) directly in the composer. Type **`$`** and an autocomplete
@@ -411,7 +423,11 @@ Both kinds of profiles are managed from **Settings → Profiles**:
   profile from the same panel triggers the appropriate `codex login`
   flow against the isolated `CODEX_HOME`.
 
-![Settings → Profiles panel listing PwrAgent profiles](assets/screenshots/settings-profiles.png)
+{% include figure.html
+   src="/assets/screenshots/settings-profiles.png"
+   alt="Settings → Profiles panel listing PwrAgent profiles"
+   caption="<strong>Settings → Profiles</strong>. Every PwrAgent profile under <code>~/.pwragent/profiles/</code> is listed; the active one is highlighted. Switching restarts the app under the selected profile."
+%}
 
 ### Launching a profile from the command line
 

--- a/docs-site/messaging/pairing.md
+++ b/docs-site/messaging/pairing.md
@@ -26,7 +26,11 @@ In **Settings → Messaging → \<platform\>**, click the **Generate**
 button on the Pairing field. PwrAgent shows a short one-time code
 that expires after a few minutes.
 
-![Pairing — generated, code visible in the Pairing field](../assets/screenshots/messaging-pairing-frame-1.png)
+{% include figure.html
+   src="/assets/screenshots/messaging-pairing-frame-1.png"
+   alt="Pairing — generated, code visible in the Pairing field"
+   caption="<strong>Step 1: token generated.</strong> The short one-time code appears in the <strong>Pairing</strong> row of Settings → Messaging → &lt;platform&gt;. Send it to the bot from the account you want to authorize."
+%}
 
 ### 2. Send the code to the bot
 
@@ -36,7 +40,11 @@ want to pair when the platform doesn't have DMs. PwrAgent observes
 the bot receiving the code; the actor's resolved name and chat
 appear in the Pairing row, and the row prompts you to **Approve**.
 
-![Pairing — observed, approval prompt visible with the resolved actor](../assets/screenshots/messaging-pairing-frame-2.png)
+{% include figure.html
+   src="/assets/screenshots/messaging-pairing-frame-2.png"
+   alt="Pairing — observed, approval prompt visible with the resolved actor"
+   caption="<strong>Step 2: token observed.</strong> PwrAgent sees the code arrive, resolves the actor's display name from the platform, and shows an <strong>Approve</strong> prompt with the resolved identity inline so you can sanity-check who's about to be authorized."
+%}
 
 ### 3. Approve
 
@@ -45,7 +53,11 @@ user's stable platform ID to the **Authorized User IDs** list
 below, with the resolved display name beside it for your benefit.
 The approval prompt clears.
 
-![Pairing — approved, user in authorized list with resolved name](../assets/screenshots/messaging-pairing-frame-3.png)
+{% include figure.html
+   src="/assets/screenshots/messaging-pairing-frame-3.png"
+   alt="Pairing — approved, user in authorized list with resolved name"
+   caption="<strong>Step 3: approved.</strong> The actor's stable platform ID is now in the <strong>Authorized User IDs</strong> list, with the resolved name beside it for your benefit. The Pairing prompt clears."
+%}
 
 ### Phase 2: pair a shared space
 
@@ -66,7 +78,11 @@ under the **Attention** section so you can see what's stuck and
 copy the peer / actor / channel ID into the allowlist directly if
 the pairing flow doesn't work.
 
-![Messaging Activity panel showing rejected inbound entries with copyable peer IDs](../assets/screenshots/messaging-activity-blocked.png)
+{% include figure.html
+   src="/assets/screenshots/messaging-activity-blocked.png"
+   alt="Messaging Activity panel showing rejected inbound entries with copyable peer IDs"
+   caption="<strong>Settings → Messaging → Activity (Attention).</strong> Inbound messages from non-authorized peers are silently rejected and logged here with copyable peer / actor / channel IDs — useful when the Pairing flow doesn't observe (most often: the bot isn't actually receiving messages on that platform yet)."
+%}
 
 What this surface gives you for each rejected message:
 

--- a/docs-site/providers/discord.md
+++ b/docs-site/providers/discord.md
@@ -52,7 +52,11 @@ flow or discovery-mode logging will surface it after the bot is online.
 11. **Try `/resume`.** Send `/resume` from the DM or any allowlisted
     channel; the bot replies with the thread picker.
 
-![Settings → Messaging → Discord panel](../assets/screenshots/settings-messaging-discord.png)
+{% include figure.html
+   src="/assets/screenshots/settings-messaging-discord.png"
+   alt="Settings → Messaging → Discord panel"
+   caption="<strong>Settings → Messaging → Discord</strong>. <strong>Test</strong> confirms PwrAgent can reach Discord's Gateway; <strong>Authorized User IDs</strong> is populated by the <a href='../../messaging/pairing/'>Pairing</a> flow."
+%}
 
 ## Pairing
 

--- a/docs-site/providers/feishu.md
+++ b/docs-site/providers/feishu.md
@@ -87,7 +87,11 @@ Broad shortcut: `im:message` covers multiple message read/send
 capabilities. Fine for a private internal app; narrower scopes above
 are easier to get approved.
 
-![Settings → Messaging → Feishu / Lark panel](../assets/screenshots/settings-messaging-feishu.png)
+{% include figure.html
+   src="/assets/screenshots/settings-messaging-feishu.png"
+   alt="Settings → Messaging → Feishu / Lark panel"
+   caption="<strong>Settings → Messaging → Feishu / Lark</strong>. <strong>Tenant region</strong> picks the Feishu (China) vs. Lark (international) API endpoint; <strong>Authorized open_ids</strong> is populated by the <a href='../../messaging/pairing/'>Pairing</a> flow."
+%}
 
 ## Pairing
 

--- a/docs-site/providers/line.md
+++ b/docs-site/providers/line.md
@@ -75,7 +75,11 @@ PwrAgent verifies every inbound LINE webhook by checking
 keyed by the channel secret. Requests that don't verify are rejected
 before JSON parsing.
 
-![Settings → Messaging → LINE panel](../assets/screenshots/settings-messaging-line.png)
+{% include figure.html
+   src="/assets/screenshots/settings-messaging-line.png"
+   alt="Settings → Messaging → LINE panel"
+   caption="<strong>Settings → Messaging → LINE</strong>. <strong>Channel Secret</strong> verifies inbound webhook signatures; the <strong>Public Webhook URL</strong> field is the public tunnel hostname you paste into LINE Developers Console."
+%}
 
 ## Pairing
 

--- a/docs-site/providers/mattermost.md
+++ b/docs-site/providers/mattermost.md
@@ -128,7 +128,11 @@ Set `PWRAGENT_MESSAGING_MATTERMOST_CALLBACK_HMAC_SECRET` to that value
 in the environment, or store it in the Settings UI. The HMAC pin is
 **strongly recommended** for any production deployment.
 
-![Settings → Messaging → Mattermost panel](../assets/screenshots/settings-messaging-mattermost.png)
+{% include figure.html
+   src="/assets/screenshots/settings-messaging-mattermost.png"
+   alt="Settings → Messaging → Mattermost panel"
+   caption="<strong>Settings → Messaging → Mattermost</strong>. The <strong>Callback Base URL</strong> field is where the public tunnel hostname goes; <strong>HMAC Secret</strong> pins the callback so only Mattermost can deliver. <strong>Authorized User IDs</strong> is populated by the <a href='../../messaging/pairing/'>Pairing</a> flow."
+%}
 
 ## Pairing
 

--- a/docs-site/providers/slack.md
+++ b/docs-site/providers/slack.md
@@ -79,7 +79,11 @@ below.
   instead of their `U…` ID.
 - `commands` — only if you're registering Slack slash commands.
 
-![Settings → Messaging → Slack panel](../assets/screenshots/settings-messaging-slack.png)
+{% include figure.html
+   src="/assets/screenshots/settings-messaging-slack.png"
+   alt="Settings → Messaging → Slack panel"
+   caption="<strong>Settings → Messaging → Slack</strong>. <strong>Test</strong> confirms PwrAgent can reach the Slack API; <strong>Authorized User IDs</strong> is populated by the <a href='../../messaging/pairing/'>Pairing</a> flow."
+%}
 
 ## Pairing
 

--- a/docs-site/providers/telegram.md
+++ b/docs-site/providers/telegram.md
@@ -54,7 +54,11 @@ discards the unauthorized message and logs your Telegram user ID
 there. Copy the ID into the authorized list. The pairing flow is just
 the friendlier version of that same path.
 
-![Settings → Messaging → Telegram panel](../assets/screenshots/settings-messaging-telegram.png)
+{% include figure.html
+   src="/assets/screenshots/settings-messaging-telegram.png"
+   alt="Settings → Messaging → Telegram panel"
+   caption="<strong>Settings → Messaging → Telegram</strong>. <strong>Test</strong> confirms PwrAgent can reach the Telegram Bot API; <strong>Authorized User IDs</strong> is populated by the <a href='../../messaging/pairing/'>Pairing</a> flow."
+%}
 
 For the captured walkthrough of the pairing flow (generate → send
 code → approve), and for the troubleshooting Activity screen that

--- a/docs-site/settings.md
+++ b/docs-site/settings.md
@@ -51,7 +51,11 @@ images and want to keep the per-turn token cost low.
 | `4096 patches` | Allows roughly a 2048×2048 square image before model-specific multipliers. |
 | `Actual size` | Preserves pasted image dimensions before upload. |
 
-![Settings → General panel showing the pasted image patch budget options](assets/screenshots/settings-general.png)
+{% include figure.html
+   src="/assets/screenshots/settings-general.png"
+   alt="Settings → General panel showing the pasted image patch budget options"
+   caption="<strong>Settings → General → Pasted images</strong>. The <strong>Image patch budget</strong> picker controls how aggressively large pasted images are downscaled before forwarding to the model."
+%}
 
 The same patch budget affects messaging-side image attachments
 similarly. See [Using Codex via Messaging → Image upload profile](../using-codex/#image-upload-profile)
@@ -73,7 +77,11 @@ If the auto-discovery picks the wrong binary or doesn't find one,
 override the path in **Settings → Applications**. Paths are
 per-tool; an explicit value beats the auto-discovered one.
 
-![Settings → Applications panel showing discovered terminal, editor, git, and gh CLI paths](assets/screenshots/settings-applications.png)
+{% include figure.html
+   src="/assets/screenshots/settings-applications.png"
+   alt="Settings → Applications panel showing discovered terminal, editor, git, and gh CLI paths"
+   caption="<strong>Settings → Applications</strong>. PwrAgent auto-discovers your terminal, editor, <code>git</code>, and <code>gh</code> CLI paths. A green status indicator next to each row means the tool was found."
+%}
 
 Codex App Server discovery is its own beast — see
 [Models / Codex App Server](#models--codex-app-server) below.
@@ -92,7 +100,11 @@ delete PwrAgent profiles. Each row shows the on-disk profile dir,
 the Codex auth profile bound to it, and which one's active /
 configured to launch by default.
 
-![Settings → Profiles panel listing PwrAgent profiles with the active one highlighted](assets/screenshots/settings-profiles.png)
+{% include figure.html
+   src="/assets/screenshots/settings-profiles.png"
+   alt="Settings → Profiles panel listing PwrAgent profiles with the active one highlighted"
+   caption="<strong>Settings → Profiles</strong>. Active profile is highlighted; <strong>New profile</strong> creates a fresh <code>~/.pwragent/profiles/&lt;name&gt;/</code> directory and switches to it on next launch."
+%}
 
 Launches via `--profile <name>` (or `PWRAGENT_PROFILE=<name>`)
 still override the startup default — see
@@ -110,7 +122,11 @@ storage location**. Pick a path on the same filesystem as your
 repos — `git worktree` requires that, and putting the storage on a
 different volume will produce surprising errors at handoff.
 
-![Settings → Worktrees panel showing the default storage location](assets/screenshots/settings-worktrees.png)
+{% include figure.html
+   src="/assets/screenshots/settings-worktrees.png"
+   alt="Settings → Worktrees panel showing the default storage location"
+   caption="<strong>Settings → Worktrees</strong>. Default storage location for managed git worktrees (<code>~/.pwragent/worktrees/</code>). Change to any path on disk if you want them somewhere else."
+%}
 
 When PwrAgent creates a worktree for a thread, it lands at
 `<worktree-storage>/<hash>/<project-folder-name>` where `<hash>` is
@@ -134,7 +150,11 @@ your threads. The version currently in use is shown in **Settings →
 Models** — same panel where you'd verify which models are available
 and which one PwrAgent thinks you're logged into.
 
-![Settings → Models panel showing Codex App Server version, source, and model list](assets/screenshots/settings-models.png)
+{% include figure.html
+   src="/assets/screenshots/settings-models.png"
+   alt="Settings → Models panel showing Codex App Server version, source, and model list"
+   caption="<strong>Settings → Models / Codex App Server</strong>. Shows the detected Codex App Server version, the source it was discovered from (Codex Desktop or CLI), the active OpenAI account, and the picker for switching Codex auth profiles."
+%}
 
 ### Keeping the App Server up to date
 
@@ -195,7 +215,11 @@ Opt-in features that are still in flux. Today the panel hosts:
   diff payloads bloat past comfortable model-context sizes; off by
   default.
 
-![Settings → Experimental panel showing the diff condensation toggle](assets/screenshots/settings-experimental.png)
+{% include figure.html
+   src="/assets/screenshots/settings-experimental.png"
+   alt="Settings → Experimental panel showing the diff condensation toggle"
+   caption="<strong>Settings → Experimental</strong>. Opt-in features still in flux. Toggles here don't carry stability guarantees and may change shape between releases."
+%}
 
 Expect this section to grow as features cycle through the
 experimental phase before promotion.


### PR DESCRIPTION
## Summary

Every body-level screenshot on docs.pwragent.ai was a bare \`<img>\` with no caption — readers had to scroll back to the surrounding prose to decode each one ("what am I looking for here?"). Deep-links to a section heading landed on a screenshot with no context whatsoever.

Now every screenshot gets a **figure with caption inside the box** — image and caption read as one figure object so the reader can decode the screenshot without scrolling away from it.

## Three pieces

### \`_includes/figure.html\` (new)

\`\`\`liquid
<figure class="screenshot"><img src="{{ include.src | relative_url }}" alt="{{ include.alt | escape }}" loading="lazy"><figcaption>{{ include.caption }}</figcaption></figure>
\`\`\`

Single-line output (no internal newlines) so kramdown doesn't escape the inner \`<img>\`. The \`| escape\` on alt is load-bearing — embedded \`"\` characters in alt text (like a thread title) would otherwise break HTML attribute parsing and trigger kramdown to escape the whole \`<img>\` tag.

### \`.screenshot\` CSS (new)

Caption sits as a strip **inside** the bordered figure frame, separated by a top border, on \`--bg-panel\` background with \`--text-secondary\` text. Same Tangerine palette as the existing \`.screenshot-hero\` on the landing page; smaller margin/shadow because these run inline with body copy.

### 20 screenshot conversions

| File | Count |
|---|---|
| \`desktop.md\` | 4 |
| \`settings.md\` | 6 |
| \`messaging/pairing.md\` | 4 |
| \`providers/{telegram,discord,slack,mattermost,feishu,line}.md\` | 6 |

Each caption is action-oriented — the reader should know what to notice without having to read the prose:

> "The two **QUEUED** chips above the composer will fire FIFO when the in-flight *make a branch and PR* turn finishes. The composer's **Send** is replaced by **Stop / Queue** while a turn is active."

> "**Step 1: token generated.** The short one-time code appears in the **Pairing** row of Settings → Messaging → \<platform\>. Send it to the bot from the account you want to authorize."

> "**Settings → Models / Codex App Server**. Shows the detected Codex App Server version, the source it was discovered from (Codex Desktop or CLI), the active OpenAI account, and the picker for switching Codex auth profiles."

## Index page hero unchanged

\`.screenshot-hero\` (the centered-caption-below treatment on the landing page) stays as-is. The new \`.screenshot\` is the in-page pattern; the hero is its own thing.

## Two kramdown traps caught

1. **Multi-line include in markdown → escaped inner \`<img>\`.** kramdown treats line-broken HTML inside a \`<figure>\` block as inline markdown content. Fix: collapse the include to a single line.
2. **Unescaped \`"\` in alt text → broken attribute parsing.** Alt text often contains the on-screen thread title (which itself contains \`"\`). Fix: \`{{ include.alt | escape }}\`.

Both surfaced during local verification and were fixed before the PR landed — the working pattern is the one captured in the final include.

## Verification

- Built locally, verified the rendered HTML on \`/desktop/#multi-message-queueing\`: single \`<figure>\` block, properly-quoted \`<img>\`, intact \`<figcaption>\` with inline \`<strong>\` / \`<em>\`. Zero \`&lt;img\` in the page output (was 2 before the escape fix).
- Screenshot at 1440×900 — caption strip renders inside the figure border, separated by the top border line, on muted background. Matches the look the user asked for.

## Interaction with #478 (a11y CI gate)

\`<figure>\` + \`<figcaption>\` + \`<img alt>\` are textbook semantic HTML — adds no new violations. Once #478 lands, the audit will run against this content on every PR.

🤖 Generated with Claude Opus 4.7 via [Claude Code](https://claude.com/claude-code)