### PR TITLE
chore(deps): override axios >=1.16.0 to clear 15 Dependabot alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,5 +35,10 @@
     "jsdom": "^29.0.2",
     "typescript": "^6.0.2",
     "vitest": "^4.1.4"
+  },
+  "pnpm": {
+    "overrides": {
+      "axios": "^1.16.0"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  axios: ^1.16.0
+
 pnpmfileChecksum: sha256-qhUjtdsDx+KID8QibUkWT/nJBDVb/TMK08fsoGdLy78=
 
 importers:
@@ -1688,9 +1691,6 @@ packages:
     resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
     engines: {node: '>= 4.0.0'}
 
-  axios@1.13.6:
-    resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
-
   axios@1.16.0:
     resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
 
@@ -3075,9 +3075,6 @@ packages:
     resolution: {integrity: sha512-NGnrxS/nLKUo5nkbVQxlC71sB4hdfImdYIbFeSCidxtwATx0AHRPcANSLd0q5Bb2BkoSWo2iisQhGg5/r+ihbA==}
     engines: {node: '>=12.0.0'}
 
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
-
   proxy-from-env@2.1.0:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
     engines: {node: '>=10'}
@@ -4375,7 +4372,7 @@ snapshots:
 
   '@larksuiteoapi/node-sdk@1.63.1':
     dependencies:
-      axios: 1.13.6
+      axios: 1.16.0
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -5161,14 +5158,6 @@ snapshots:
   asynckit@0.4.0: {}
 
   at-least-node@1.0.0: {}
-
-  axios@1.13.6:
-    dependencies:
-      follow-redirects: 1.16.0
-      form-data: 4.0.5
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
 
   axios@1.16.0:
     dependencies:
@@ -6913,8 +6902,6 @@ snapshots:
       '@protobufjs/utf8': 1.1.1
       '@types/node': 25.6.0
       long: 5.3.2
-
-  proxy-from-env@1.1.0: {}
 
   proxy-from-env@2.1.0: {}
 


### PR DESCRIPTION
## Summary
- Adds a `pnpm.overrides` entry forcing `axios` to `^1.16.0` across the workspace.
- Clears all 15 axios advisories surfaced by [Dependabot](https://github.com/pwrdrvr/PwrAgent/security/dependabot) (4 high / 10 moderate / 1 low — prototype pollution, NO_PROXY SSRF, CRLF injection, etc.).
- No first-party `axios` usage — all paths are transitive via the Slack and Feishu messaging provider SDKs.

## Background
- `@larksuiteoapi/node-sdk@1.63.1` (Feishu provider) pinned `axios: ~1.13.3` → resolved to **1.13.6**, the source of every alert. The latest SDK (`1.64.0`) still pins `~1.13.3`, so bumping the SDK does not help.
- `@slack/web-api@7.15.2` (Slack provider) requested `axios: ^1.16.0` → resolved to **1.16.0**, already patched. No alerts here.
- Override collapses both onto a single patched copy.

## Version choice
- Used `^1.16.0` rather than `^1.16.1` because the repo's `minimumReleaseAge: 10080` (7 days) in `pnpm-workspace.yaml` blocks 1.16.1 (published 4 days ago). It will pick up automatically once it ages past the gate.

## Verification
- `pnpm audit` → "No known vulnerabilities found"
- Lockfile now shows a single `axios@1.16.0` entry consumed by both Slack and Feishu
- `pnpm lint` (sql + licenses + typecheck + boundaries) → clean
- Slack + Feishu provider tests (66 tests across 9 files) → all pass

## Why not migrate off axios entirely?
Both Slack and Feishu speak axios through their official SDKs. Replacing them with `fetch` would mean forking or reimplementing each provider against the raw REST APIs — out of scope for an alert clearance. Worth tracking as a separate consideration if we ever want to drop the dependency entirely.

## Test plan
- [x] `pnpm install` succeeds with override applied
- [x] `pnpm audit` reports no vulnerabilities
- [x] `pnpm lint` passes
- [x] Slack + Feishu provider tests pass
- [ ] CI green on this PR
- [ ] Dependabot alerts close after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)