### PR TITLE
fix(desktop): bound Codex environment setup

### DIFF
--- a/apps/desktop/e2e/codex-environment-setup.spec.ts
+++ b/apps/desktop/e2e/codex-environment-setup.spec.ts
@@ -378,9 +378,13 @@ test("selected Codex environments run setup and show transcript output", async (
       .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
       .click();
 
-    await app.window.getByRole("button", { name: "Codex environment" }).click();
+    await expect(app.window.getByRole("textbox", { name: "New thread" })).toBeVisible();
+    const launchpadTools = app.window.getByLabel("Composer tools");
+    await launchpadTools.getByRole("button", { name: "Codex environment" }).click();
     await app.window.getByRole("option", { name: "Fixture Env" }).click();
-    await expect(app.window.getByLabel("Run setup")).toBeChecked();
+    await expect(
+      launchpadTools.locator("label", { hasText: "Run setup" }).locator("input"),
+    ).toBeChecked();
 
     await app.window.getByRole("textbox", { name: "New thread" }).fill("hello env");
     await app.window.getByRole("button", { name: "Start thread" }).click();

--- a/apps/desktop/e2e/fixtures/electron-app.ts
+++ b/apps/desktop/e2e/fixtures/electron-app.ts
@@ -70,6 +70,7 @@ export async function launchElectronApp(params: {
   Object.assign(env, {
     HOME: homeRoot,
     NODE_ENV: "production",
+    PWRAGENT_CODEX_ENVIRONMENT_SETUP_TIMEOUT_MS: "15000",
     PWRAGENT_REPLAY_FIXTURE_PATH: params.fixturePath,
   });
   delete env.ELECTRON_RENDERER_URL;

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -23,6 +23,10 @@ import type {
 import type { MessagingBindingRecord } from "@pwragent/messaging-interface";
 import { buildNavigationSnapshot } from "@pwragent/agent-core";
 import { DesktopBackendRegistry } from "../app-server/backend-registry";
+import {
+  CodexEnvironmentCommandError,
+  type CodexEnvironmentCommandRunner,
+} from "../app-server/codex-environment-runtime";
 import type { WorktreeArchiveService } from "../app-server/worktree-archive-service";
 
 const execFileAsync = promisify(execFileCallback);
@@ -3172,11 +3176,29 @@ script = "printf setup-output"
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/start"] },
     });
+    const commandRunner: CodexEnvironmentCommandRunner = vi.fn(async (params) => {
+      expect(params).toMatchObject({
+        cwd: root,
+        command: "printf setup-output",
+        mode: "wait",
+      });
+      params.onProgress?.({
+        phase: "stdout",
+        chunk: "setup-output",
+        at: Date.now(),
+      });
+      return {
+        durationMs: 4,
+        exitCode: 0,
+        output: "setup-output",
+      };
+    });
     const registry = new DesktopBackendRegistry({
       codexClient,
       grokClient: new MockBackendClient({
         initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
       }),
+      codexEnvironmentCommandRunner: commandRunner,
       overlayStore,
     });
 
@@ -3218,6 +3240,7 @@ script = "printf setup-output"
           },
         ],
       });
+      expect(commandRunner).toHaveBeenCalledTimes(1);
     } finally {
       await registry.close();
       await rm(root, { recursive: true, force: true });
@@ -3357,11 +3380,27 @@ script = "printf setup-failed && exit 42"
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/start", "turn/start"] },
     });
+    const commandRunner: CodexEnvironmentCommandRunner = vi.fn(async (params) => {
+      expect(params).toMatchObject({
+        cwd: worktreePath,
+        command: "printf setup-failed && exit 42",
+        mode: "wait",
+      });
+      throw new CodexEnvironmentCommandError(
+        "Codex environment command exited with 42",
+        {
+          durationMs: 3,
+          exitCode: 42,
+          output: "setup-failed",
+        },
+      );
+    });
     const registry = new DesktopBackendRegistry({
       codexClient,
       grokClient: new MockBackendClient({
         initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
       }),
+      codexEnvironmentCommandRunner: commandRunner,
       overlayStore: createOverlayStoreMock(),
       gitDirectoryService: {
         prepareLaunchpadWorkspace: vi.fn(async () => ({
@@ -3407,6 +3446,7 @@ script = "printf setup-failed && exit 42"
         setupExitCode: 42,
         setupOutput: expect.stringContaining("setup-failed"),
       });
+      expect(commandRunner).toHaveBeenCalledTimes(1);
       expect(recordCodexWorktreeOwnerThread).toHaveBeenCalledWith({
         worktreePath,
         threadId: "thread-1",

--- a/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
@@ -302,6 +302,46 @@ describe("codex environment runtime", () => {
       await rm(root, { recursive: true, force: true });
     }
   });
+
+  it("times out setup commands that do not finish", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-env-timeout-"));
+
+    try {
+      let error: unknown;
+      try {
+        await applyLocalCodexEnvironmentSelection({
+          cwd: root,
+          selection: {
+            environment: {
+              id: "env",
+              name: "Env",
+              sourcePath: path.join(root, "environment.toml"),
+              setupScript: "printf before && sleep 10 && printf after",
+              actions: [],
+            },
+            executionTarget: "local",
+            setupEnabled: true,
+          },
+          setupTimeoutMs: 50,
+        });
+      } catch (caught) {
+        error = caught;
+      }
+
+      expect(error).toMatchObject({
+        message: expect.stringContaining("timed out after 50ms"),
+        phase: "setup",
+        runtime: {
+          setupStatus: "failed",
+        },
+      });
+      expect(
+        ((error as { runtime?: { setupOutput?: string } }).runtime?.setupOutput ?? ""),
+      ).not.toContain("after");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 });
 
 async function expectEventually<T>(

--- a/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
@@ -352,6 +352,60 @@ describe("codex environment runtime", () => {
       await rm(root, { recursive: true, force: true });
     }
   });
+
+  it("waits for timed-out setup commands to exit before reporting failure", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-env-timeout-exit-"));
+    const markerPath = path.join(root, "marker.txt");
+    const markerShellPath = `'${markerPath.replace(/'/g, "'\\''")}'`;
+
+    try {
+      let error: unknown;
+      try {
+        await applyLocalCodexEnvironmentSelection({
+          cwd: root,
+          env: {
+            ...process.env,
+            [CODEX_ENVIRONMENT_SETUP_TIMEOUT_MS_ENV]: "1000",
+          },
+          selection: {
+            environment: {
+              id: "env",
+              name: "Env",
+              sourcePath: path.join(root, "environment.toml"),
+              setupScript: [
+                `printf 'before\\n' > ${markerShellPath}`,
+                [
+                  "trap",
+                  `"printf 'term\\\\n' >> ${markerShellPath}; sleep 0.2; printf 'after-term\\\\n' >> ${markerShellPath}; exit 0"`,
+                  "TERM",
+                ].join(" "),
+                "while true; do sleep 1; done",
+              ].join("\n"),
+              actions: [],
+            },
+            executionTarget: "local",
+            setupEnabled: true,
+          },
+        });
+      } catch (caught) {
+        error = caught;
+      }
+
+      expect(error).toMatchObject({
+        message: expect.stringContaining("timed out after 1000ms"),
+        phase: "setup",
+      });
+      await expect(readFile(markerPath, "utf8")).resolves.toBe(
+        "before\nterm\nafter-term\n",
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 });
 
 async function expectEventually<T>(

--- a/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   applyLocalCodexEnvironmentSelection,
+  CODEX_ENVIRONMENT_SETUP_TIMEOUT_MS_ENV,
   startLocalCodexEnvironmentAction,
 } from "../app-server/codex-environment-runtime";
 
@@ -119,15 +120,22 @@ describe("codex environment runtime", () => {
         actionStatus: "started",
       });
 
-      await expect(expectEventually(async () => await readFile(outputPath, "utf8"))).resolves.toBe(
-        [
-          "renderer=unset",
-          "run_as_node=unset",
-          "vite=unset",
-          "hydrated=hydrated",
-          "",
-        ].join("\n"),
-      );
+      const expectedOutput = [
+        "renderer=unset",
+        "run_as_node=unset",
+        "vite=unset",
+        "hydrated=hydrated",
+        "",
+      ].join("\n");
+      await expect(
+        expectEventually(async () => {
+          const output = await readFile(outputPath, "utf8");
+          if (output !== expectedOutput) {
+            throw new Error(`Output is not complete yet: ${JSON.stringify(output)}`);
+          }
+          return output;
+        }),
+      ).resolves.toBe(expectedOutput);
     } finally {
       await rm(root, { recursive: true, force: true });
     }
@@ -311,6 +319,9 @@ describe("codex environment runtime", () => {
       try {
         await applyLocalCodexEnvironmentSelection({
           cwd: root,
+          env: {
+            [CODEX_ENVIRONMENT_SETUP_TIMEOUT_MS_ENV]: "50",
+          },
           selection: {
             environment: {
               id: "env",
@@ -322,7 +333,6 @@ describe("codex environment runtime", () => {
             executionTarget: "local",
             setupEnabled: true,
           },
-          setupTimeoutMs: 50,
         });
       } catch (caught) {
         error = caught;

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -124,6 +124,7 @@ import {
   applyLocalCodexEnvironmentSelection,
   CodexEnvironmentStartupError,
   startLocalCodexEnvironmentAction,
+  type CodexEnvironmentCommandRunner,
   type CodexEnvironmentSelection,
 } from "./codex-environment-runtime";
 import type { MessagingStoreLike } from "../state/messaging-store-sqlite";
@@ -1469,6 +1470,7 @@ export class DesktopBackendRegistry {
   private readonly threadTitleGenerationService?: ThreadTitleService;
   private readonly modelCatalog: BackendModelCatalog;
   private readonly codexEnvironmentCommandEnv?: NodeJS.ProcessEnv;
+  private readonly codexEnvironmentCommandRunner?: CodexEnvironmentCommandRunner;
   private readonly threadListCacheOwnerId = `backend-thread-list-cache-${++threadListCacheSequence}`;
   private readonly threadListCache = new Map<string, ThreadListCacheState>();
   private readonly activeThreadIdsByBackend = new Map<AppServerBackendKind, Set<string>>();
@@ -1521,6 +1523,7 @@ export class DesktopBackendRegistry {
     messagingStore?: MessagingArchiveCleanupStore | null;
     messagingArchiveCleaner?: MessagingArchiveCleaner | null;
     createScratchProjectDirectory?: () => Promise<string>;
+    codexEnvironmentCommandRunner?: CodexEnvironmentCommandRunner;
     threadTitleGenerationService?: ThreadTitleService | null;
   }) {
     const replayClients = createReplayClientsFromEnv();
@@ -1567,6 +1570,7 @@ export class DesktopBackendRegistry {
         ? settingsService.resolveCodexSpawnEnv()
         : undefined;
     this.codexEnvironmentCommandEnv = codexEnv;
+    this.codexEnvironmentCommandRunner = options?.codexEnvironmentCommandRunner;
     const codexHome = codexEnv?.CODEX_HOME?.trim() || undefined;
     const createsLiveGrokClient = !options?.grokClient && !replayClients?.grokClient;
     const grokApiKey = createsLiveGrokClient
@@ -3559,6 +3563,7 @@ export class DesktopBackendRegistry {
     try {
       nextRuntime = await startLocalCodexEnvironmentAction({
         actionId: request.actionId,
+        commandRunner: this.codexEnvironmentCommandRunner,
         env: this.codexEnvironmentCommandEnv,
         runtime: runtimeForAction,
       });
@@ -3758,6 +3763,7 @@ export class DesktopBackendRegistry {
     if (launchpad.backend === "codex") {
       try {
         codexEnvironmentRuntime = await applyLocalCodexEnvironmentSelection({
+          commandRunner: this.codexEnvironmentCommandRunner,
           cwd: workspace.cwd,
           env: this.codexEnvironmentCommandEnv,
           onSetupProgress: options?.onCodexEnvironmentSetupProgress

--- a/apps/desktop/src/main/app-server/codex-environment-runtime.ts
+++ b/apps/desktop/src/main/app-server/codex-environment-runtime.ts
@@ -287,6 +287,7 @@ function runShellCommand(
     let stderr = "";
     let settled = false;
     let closed = false;
+    let timedOut = false;
     let timeoutHandle: NodeJS.Timeout | undefined;
     let killHandle: NodeJS.Timeout | undefined;
 
@@ -309,10 +310,7 @@ function runShellCommand(
       }
     };
 
-    const settle = (
-      callback: () => void,
-      options?: { keepKillTimer?: boolean },
-    ) => {
+    const settle = (callback: () => void) => {
       if (settled) {
         return;
       }
@@ -321,7 +319,7 @@ function runShellCommand(
         clearTimeout(timeoutHandle);
         timeoutHandle = undefined;
       }
-      if (killHandle && !options?.keepKillTimer) {
+      if (killHandle) {
         clearTimeout(killHandle);
         killHandle = undefined;
       }
@@ -336,28 +334,14 @@ function runShellCommand(
           timeoutMs: params.timeoutMs,
           durationMs,
         });
+        timedOut = true;
+        timeoutHandle = undefined;
         terminateChild("SIGTERM");
         killHandle = setTimeout(() => {
           if (!closed) {
             terminateChild("SIGKILL");
           }
         }, 2_000);
-        settle(
-          () => {
-            reject(
-              new CodexEnvironmentCommandError(
-                `Codex environment command timed out after ${params.timeoutMs}ms`,
-                {
-                  durationMs,
-                  output: [stdout.trimEnd(), stderr.trimEnd()]
-                    .filter(Boolean)
-                    .join("\n"),
-                },
-              ),
-            );
-          },
-          { keepKillTimer: true },
-        );
       }, params.timeoutMs);
     }
 
@@ -411,6 +395,22 @@ function runShellCommand(
         code,
         signal,
       });
+      if (timedOut) {
+        settle(() => {
+          reject(
+            new CodexEnvironmentCommandError(
+              `Codex environment command timed out after ${params.timeoutMs}ms`,
+              {
+                durationMs: Date.now() - startedAt,
+                output: [stdout.trimEnd(), stderr.trimEnd()]
+                  .filter(Boolean)
+                  .join("\n"),
+              },
+            ),
+          );
+        });
+        return;
+      }
       if (code === 0) {
         settle(() => {
           resolve({

--- a/apps/desktop/src/main/app-server/codex-environment-runtime.ts
+++ b/apps/desktop/src/main/app-server/codex-environment-runtime.ts
@@ -8,6 +8,8 @@ import { getMainLogger } from "../log";
 const environmentRuntimeLog = getMainLogger("pwragent:codex-environment-runtime");
 
 export const DEFAULT_CODEX_ENVIRONMENT_SETUP_TIMEOUT_MS = 10 * 60 * 1_000;
+export const CODEX_ENVIRONMENT_SETUP_TIMEOUT_MS_ENV =
+  "PWRAGENT_CODEX_ENVIRONMENT_SETUP_TIMEOUT_MS";
 
 export class CodexEnvironmentCommandError extends Error {
   durationMs?: number;
@@ -142,7 +144,8 @@ export async function applyLocalCodexEnvironmentSelection(params: {
         env: params.env,
         mode: "wait",
         timeoutMs:
-          params.setupTimeoutMs ?? DEFAULT_CODEX_ENVIRONMENT_SETUP_TIMEOUT_MS,
+          params.setupTimeoutMs ??
+          readCodexEnvironmentSetupTimeoutMs(params.env ?? process.env),
         onProgress: (event) => {
           emitSetupProgress(event);
         },
@@ -456,6 +459,24 @@ function isParentElectronRuntimeEnvKey(key: string): boolean {
     key.startsWith("PRELOAD_VITE_") ||
     key.startsWith("RENDERER_VITE_")
   );
+}
+
+function readCodexEnvironmentSetupTimeoutMs(env: NodeJS.ProcessEnv): number {
+  const rawValue = env[CODEX_ENVIRONMENT_SETUP_TIMEOUT_MS_ENV]?.trim();
+  if (!rawValue) {
+    return DEFAULT_CODEX_ENVIRONMENT_SETUP_TIMEOUT_MS;
+  }
+
+  const parsed = Number(rawValue);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    environmentRuntimeLog.warn("codex-environment-setup-timeout-invalid", {
+      env: CODEX_ENVIRONMENT_SETUP_TIMEOUT_MS_ENV,
+      value: rawValue,
+    });
+    return DEFAULT_CODEX_ENVIRONMENT_SETUP_TIMEOUT_MS;
+  }
+
+  return Math.round(parsed);
 }
 
 function wrapShellCommand(shell: string, command: string): string {

--- a/apps/desktop/src/main/app-server/codex-environment-runtime.ts
+++ b/apps/desktop/src/main/app-server/codex-environment-runtime.ts
@@ -7,7 +7,9 @@ import { getMainLogger } from "../log";
 
 const environmentRuntimeLog = getMainLogger("pwragent:codex-environment-runtime");
 
-class ShellCommandError extends Error {
+export const DEFAULT_CODEX_ENVIRONMENT_SETUP_TIMEOUT_MS = 10 * 60 * 1_000;
+
+export class CodexEnvironmentCommandError extends Error {
   durationMs?: number;
   exitCode?: number;
   output?: string;
@@ -18,7 +20,7 @@ class ShellCommandError extends Error {
     output?: string;
   }) {
     super(message);
-    this.name = "ShellCommandError";
+    this.name = "CodexEnvironmentCommandError";
     this.durationMs = details?.durationMs;
     this.exitCode = details?.exitCode;
     this.output = details?.output;
@@ -48,13 +50,37 @@ export type CodexEnvironmentSelection = {
   action?: CodexEnvironmentOption["actions"][number];
 };
 
+export type CodexEnvironmentCommandParams = {
+  cwd?: string;
+  command: string;
+  env?: NodeJS.ProcessEnv;
+  mode: "wait" | "detach";
+  timeoutMs?: number;
+  onProgress?: (
+    event: Pick<CodexEnvironmentSetupProgressEvent, "phase" | "chunk" | "at">,
+  ) => void;
+};
+
+export type CodexEnvironmentCommandResult = {
+  durationMs?: number;
+  exitCode?: number;
+  output?: string;
+  pid?: number;
+};
+
+export type CodexEnvironmentCommandRunner = (
+  params: CodexEnvironmentCommandParams,
+) => Promise<CodexEnvironmentCommandResult>;
+
 export async function applyLocalCodexEnvironmentSelection(params: {
+  commandRunner?: CodexEnvironmentCommandRunner;
   cwd?: string;
   env?: NodeJS.ProcessEnv;
   onSetupProgress?: (
     event: Omit<CodexEnvironmentSetupProgressEvent, "directoryKey">,
   ) => void;
   selection?: CodexEnvironmentSelection;
+  setupTimeoutMs?: number;
 }): Promise<CodexThreadEnvironmentRuntime | undefined> {
   const { cwd, selection } = params;
   if (!selection) {
@@ -110,11 +136,13 @@ export async function applyLocalCodexEnvironmentSelection(params: {
         phase: "started",
         at: Date.now(),
       });
-      const result = await runShellCommand({
+      const result = await (params.commandRunner ?? runShellCommand)({
         cwd,
         command: selection.environment.setupScript,
         env: params.env,
         mode: "wait",
+        timeoutMs:
+          params.setupTimeoutMs ?? DEFAULT_CODEX_ENVIRONMENT_SETUP_TIMEOUT_MS,
         onProgress: (event) => {
           emitSetupProgress(event);
         },
@@ -132,7 +160,7 @@ export async function applyLocalCodexEnvironmentSelection(params: {
       });
     } catch (error) {
       runtime.setupStatus = "failed";
-      if (error instanceof ShellCommandError) {
+      if (error instanceof CodexEnvironmentCommandError) {
         runtime.setupOutput = error.output;
         runtime.setupExitCode = error.exitCode;
         runtime.setupDurationMs = error.durationMs;
@@ -164,7 +192,7 @@ export async function applyLocalCodexEnvironmentSelection(params: {
     runtime.actionName = selection.action.name;
     runtime.actionCommand = selection.action.command;
     try {
-      const result = await runShellCommand({
+      const result = await (params.commandRunner ?? runShellCommand)({
         cwd,
         command: selection.action.command,
         env: params.env,
@@ -187,6 +215,7 @@ export async function applyLocalCodexEnvironmentSelection(params: {
 
 export async function startLocalCodexEnvironmentAction(params: {
   actionId: string;
+  commandRunner?: CodexEnvironmentCommandRunner;
   env?: NodeJS.ProcessEnv;
   runtime: CodexThreadEnvironmentRuntime;
 }): Promise<CodexThreadEnvironmentRuntime> {
@@ -209,7 +238,7 @@ export async function startLocalCodexEnvironmentAction(params: {
   };
 
   try {
-    const result = await runShellCommand({
+    const result = await (params.commandRunner ?? runShellCommand)({
       cwd: params.runtime.cwd,
       command: action.command,
       env: params.env,
@@ -229,20 +258,9 @@ export async function startLocalCodexEnvironmentAction(params: {
   return nextRuntime;
 }
 
-function runShellCommand(params: {
-  cwd?: string;
-  command: string;
-  env?: NodeJS.ProcessEnv;
-  mode: "wait" | "detach";
-  onProgress?: (
-    event: Pick<CodexEnvironmentSetupProgressEvent, "phase" | "chunk" | "at">,
-  ) => void;
-}): Promise<{
-  durationMs?: number;
-  exitCode?: number;
-  output?: string;
-  pid?: number;
-}> {
+function runShellCommand(
+  params: CodexEnvironmentCommandParams,
+): Promise<CodexEnvironmentCommandResult> {
   const commandEnv = sanitizeLocalEnvironmentCommandEnv(params.env ?? process.env);
   const shell = commandEnv.SHELL?.trim() || process.env.SHELL?.trim() || "/bin/sh";
   const processId = `pwragent-env-${randomUUID()}`;
@@ -257,13 +275,89 @@ function runShellCommand(params: {
   return new Promise((resolve, reject) => {
     const child = spawn(shell, ["-lc", wrapShellCommand(shell, params.command)], {
       cwd: params.cwd,
-      detached: params.mode === "detach",
+      detached: params.mode === "detach" || Boolean(params.timeoutMs),
       env: commandEnv,
       stdio: params.mode === "detach" ? "ignore" : "pipe",
     });
 
     let stdout = "";
     let stderr = "";
+    let settled = false;
+    let closed = false;
+    let timeoutHandle: NodeJS.Timeout | undefined;
+    let killHandle: NodeJS.Timeout | undefined;
+
+    const terminateChild = (signal: NodeJS.Signals) => {
+      if (!child.pid) {
+        return;
+      }
+      try {
+        if (process.platform !== "win32") {
+          process.kill(-child.pid, signal);
+        } else {
+          child.kill(signal);
+        }
+      } catch (error) {
+        environmentRuntimeLog.warn("codex-environment-command-kill-failed", {
+          processId,
+          signal,
+          message: error instanceof Error ? error.message : String(error),
+        });
+      }
+    };
+
+    const settle = (
+      callback: () => void,
+      options?: { keepKillTimer?: boolean },
+    ) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+        timeoutHandle = undefined;
+      }
+      if (killHandle && !options?.keepKillTimer) {
+        clearTimeout(killHandle);
+        killHandle = undefined;
+      }
+      callback();
+    };
+
+    if (params.mode === "wait" && params.timeoutMs && params.timeoutMs > 0) {
+      timeoutHandle = setTimeout(() => {
+        const durationMs = Date.now() - startedAt;
+        environmentRuntimeLog.warn("codex-environment-command-timeout", {
+          processId,
+          timeoutMs: params.timeoutMs,
+          durationMs,
+        });
+        terminateChild("SIGTERM");
+        killHandle = setTimeout(() => {
+          if (!closed) {
+            terminateChild("SIGKILL");
+          }
+        }, 2_000);
+        settle(
+          () => {
+            reject(
+              new CodexEnvironmentCommandError(
+                `Codex environment command timed out after ${params.timeoutMs}ms`,
+                {
+                  durationMs,
+                  output: [stdout.trimEnd(), stderr.trimEnd()]
+                    .filter(Boolean)
+                    .join("\n"),
+                },
+              ),
+            );
+          },
+          { keepKillTimer: true },
+        );
+      }, params.timeoutMs);
+    }
+
     child.stdout?.on("data", (chunk: Buffer) => {
       const text = chunk.toString("utf8");
       stdout = `${stdout}${text}`.slice(-32_000);
@@ -288,43 +382,56 @@ function runShellCommand(params: {
         processId,
         message: error.message,
       });
-      reject(error);
+      settle(() => {
+        reject(error);
+      });
     });
 
     if (params.mode === "detach") {
       child.once("spawn", () => {
         child.unref();
-        resolve({ pid: child.pid });
+        settle(() => {
+          resolve({ pid: child.pid });
+        });
       });
       return;
     }
 
     child.once("close", (code, signal) => {
+      closed = true;
+      if (killHandle) {
+        clearTimeout(killHandle);
+        killHandle = undefined;
+      }
       environmentRuntimeLog.info("codex-environment-command-exit", {
         processId,
         code,
         signal,
       });
       if (code === 0) {
-        resolve({
-          durationMs: Date.now() - startedAt,
-          exitCode: code,
-          output: [stdout.trimEnd(), stderr.trimEnd()].filter(Boolean).join("\n"),
-          pid: child.pid,
+        settle(() => {
+          resolve({
+            durationMs: Date.now() - startedAt,
+            exitCode: code,
+            output: [stdout.trimEnd(), stderr.trimEnd()].filter(Boolean).join("\n"),
+            pid: child.pid,
+          });
         });
         return;
       }
       const suffix = stderr.trim() ? `: ${stderr.trim()}` : "";
-      reject(
-        new ShellCommandError(
-          `Codex environment command exited with ${code ?? signal ?? "unknown"}${suffix}`,
-          {
-            durationMs: Date.now() - startedAt,
-            exitCode: typeof code === "number" ? code : undefined,
-            output: [stdout.trimEnd(), stderr.trimEnd()].filter(Boolean).join("\n"),
-          },
-        ),
-      );
+      settle(() => {
+        reject(
+          new CodexEnvironmentCommandError(
+            `Codex environment command exited with ${code ?? signal ?? "unknown"}${suffix}`,
+            {
+              durationMs: Date.now() - startedAt,
+              exitCode: typeof code === "number" ? code : undefined,
+              output: [stdout.trimEnd(), stderr.trimEnd()].filter(Boolean).join("\n"),
+            },
+          ),
+        );
+      });
     });
   });
 }


### PR DESCRIPTION
## Summary

- Fixed the flaky backend-registry unit coverage by adding an injectable Codex environment command runner, then using it in the setup-output and setup-failure tests instead of spawning a real shell.
- Kept the test assertions focused on registry behavior: failed setup still registers the worktree thread, returns a startup failure, and does not start the turn.
- Added a default 10-minute timeout for the real local setup command path so the production code has the same kind of escape hatch Vitest was providing during the flaky failure.
- Added an environment-variable override for setup command timeout and set replay-backed Electron E2Es to 15 seconds.
- Confirmed the Codex environment E2E fixture uses dummy local commands (`printf`, `sleep`, `pwd`) rather than package-manager or network setup.

## Verification

- I verified `pnpm test apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts` passes.
- I verified `pnpm --filter @pwragent/desktop typecheck` passes.
- I verified `pnpm lint:boundaries` passes.
- I verified `pnpm --filter @pwragent/desktop test:e2e e2e/codex-environment-setup.spec.ts` passes.
- I verified `git diff --check` passes.

## Notes

- Fixes the unit-test flake reported in https://github.com/pwrdrvr/PwrAgent/issues/481 and covers the related no-timeout production path called out there.
