### PR TITLE
feat(desktop): surface pin reorder shortcuts in context menus + docs

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -13,6 +13,14 @@ import type {
   NavigationThreadSummary,
   ThreadExecutionMode,
 } from "@pwragent/shared";
+import {
+  comparePinnedDirectories,
+  comparePinnedThreads,
+  isPinnedDirectory,
+  isPinnedThread,
+  moveDirectoryKey,
+  moveThreadKey,
+} from "@pwragent/shared";
 import type { RuntimeIdentity } from "../../../../shared/runtime-identity";
 import { copyText } from "../../lib/copy-text";
 import { BranchIcon, FolderIcon } from "../../icons";
@@ -404,6 +412,82 @@ export function Sidebar(props: SidebarProps) {
     void props.onSetDirectoryPin?.(directory, !directory.pinnedRank);
   };
 
+  /**
+   * Pinned-thread order, grouped by backend. The thread reorder
+   * IPC is per-backend (mirrors per-backend pin ranks), so the
+   * "Move Up / Move Down" menu items have to compute per-backend
+   * adjacency to figure out whether the target row is at the top
+   * or bottom of its backend's pinned section.
+   */
+  const pinnedThreadIdsByBackend = useMemo(() => {
+    const byBackend = new Map<AppServerBackendKind, string[]>();
+    for (const thread of [...props.threads]
+      .filter(isPinnedThread)
+      .sort(comparePinnedThreads)) {
+      const list = byBackend.get(thread.source) ?? [];
+      list.push(thread.id);
+      byBackend.set(thread.source, list);
+    }
+    return byBackend;
+  }, [props.threads]);
+
+  /**
+   * Pinned-directory keys in stable user-curated order. Directory
+   * pinning is global (backend-agnostic, see plan 2026-05-09-002),
+   * so a single sorted array is enough to compute Move Up / Move
+   * Down adjacency for the directory context menu.
+   */
+  const pinnedDirectoryKeysInOrder = useMemo(
+    () =>
+      [...props.directories]
+        .filter(isPinnedDirectory)
+        .sort(comparePinnedDirectories)
+        .map((directory) => directory.key),
+    [props.directories],
+  );
+
+  const moveThreadFromContextMenu = (
+    thread: NavigationThreadSummary,
+    direction: "up" | "down",
+  ): void => {
+    const ordered = pinnedThreadIdsByBackend.get(thread.source) ?? [];
+    const currentIndex = ordered.indexOf(thread.id);
+    if (currentIndex === -1) return;
+    const targetIndex =
+      direction === "up" ? currentIndex - 1 : currentIndex + 1;
+    if (targetIndex < 0 || targetIndex >= ordered.length) return;
+    const targetId = ordered[targetIndex]!;
+    const nextIds = moveThreadKey(
+      ordered,
+      thread.id,
+      targetId,
+      direction === "up" ? "before" : "after",
+    );
+    setContextMenu(undefined);
+    void props.onReorderThreadPins?.(thread.source, nextIds);
+  };
+
+  const moveDirectoryFromContextMenu = (
+    directory: NavigationDirectorySummary,
+    direction: "up" | "down",
+  ): void => {
+    const ordered = pinnedDirectoryKeysInOrder;
+    const currentIndex = ordered.indexOf(directory.key);
+    if (currentIndex === -1) return;
+    const targetIndex =
+      direction === "up" ? currentIndex - 1 : currentIndex + 1;
+    if (targetIndex < 0 || targetIndex >= ordered.length) return;
+    const targetKey = ordered[targetIndex]!;
+    const nextKeys = moveDirectoryKey(
+      ordered,
+      directory.key,
+      targetKey,
+      direction === "up" ? "before" : "after",
+    );
+    setDirectoryContextMenu(undefined);
+    void props.onReorderDirectoryPins?.(nextKeys);
+  };
+
   const copyFromContextMenu = (value: string): void => {
     setContextMenu(undefined);
     void copyText(value);
@@ -442,8 +526,53 @@ export function Sidebar(props: SidebarProps) {
     contextMenuWorktreePath?.worktreePath ?? contextMenuWorktreePath?.path;
   const contextMenuBranchName = contextMenu?.thread.gitBranch;
   const contextMenuCanPin = Boolean(contextMenu && props.onSetThreadPin);
+  /**
+   * Move Up / Move Down show as menu items only when the target
+   * thread is pinned (reorder only applies inside the pinned
+   * section) AND the reorder IPC is wired. Each item is then
+   * disabled when the thread is at the top / bottom of its
+   * backend's pinned slice. We render the items even when disabled
+   * so the menu layout doesn't jump as the user walks the list.
+   */
+  const contextMenuShowMoveItems = Boolean(
+    contextMenu?.thread.pinnedRank && props.onReorderThreadPins,
+  );
+  const contextMenuPinnedThreadIndex = contextMenu
+    ? (pinnedThreadIdsByBackend.get(contextMenu.thread.source) ?? []).indexOf(
+        contextMenu.thread.id,
+      )
+    : -1;
+  const contextMenuPinnedThreadCount = contextMenu
+    ? (pinnedThreadIdsByBackend.get(contextMenu.thread.source) ?? []).length
+    : 0;
+  const contextMenuCanMoveUp =
+    contextMenuShowMoveItems && contextMenuPinnedThreadIndex > 0;
+  const contextMenuCanMoveDown =
+    contextMenuShowMoveItems &&
+    contextMenuPinnedThreadIndex >= 0 &&
+    contextMenuPinnedThreadIndex < contextMenuPinnedThreadCount - 1;
   const contextMenuHasTopActions =
-    contextMenuCanPin || contextMenuCanRename || contextMenuCanArchive;
+    contextMenuCanPin ||
+    contextMenuShowMoveItems ||
+    contextMenuCanRename ||
+    contextMenuCanArchive;
+
+  // Same shape as the thread context menu's "Move" items, applied
+  // to the directory context menu. Directory pinning is global so
+  // a single sorted array drives both adjacency checks.
+  const directoryMenuShowMoveItems = Boolean(
+    directoryContextMenu?.directory.pinnedRank &&
+      props.onReorderDirectoryPins,
+  );
+  const directoryMenuPinnedIndex = directoryContextMenu
+    ? pinnedDirectoryKeysInOrder.indexOf(directoryContextMenu.directory.key)
+    : -1;
+  const directoryMenuCanMoveUp =
+    directoryMenuShowMoveItems && directoryMenuPinnedIndex > 0;
+  const directoryMenuCanMoveDown =
+    directoryMenuShowMoveItems &&
+    directoryMenuPinnedIndex >= 0 &&
+    directoryMenuPinnedIndex < pinnedDirectoryKeysInOrder.length - 1;
 
   return (
     <aside className="sidebar" aria-label="Threads">
@@ -658,6 +787,42 @@ export function Sidebar(props: SidebarProps) {
                   {contextMenu.thread.pinnedRank ? "Unpin Thread" : "Pin Thread"}
                 </button>
               ) : null}
+              {contextMenuShowMoveItems ? (
+                <>
+                  <button
+                    role="menuitem"
+                    type="button"
+                    disabled={!contextMenuCanMoveUp}
+                    onClick={() =>
+                      moveThreadFromContextMenu(contextMenu.thread, "up")
+                    }
+                  >
+                    <span>Move Up</span>
+                    <span
+                      className="thread-context-menu__shortcut"
+                      aria-hidden="true"
+                    >
+                      {"⌘↑"}
+                    </span>
+                  </button>
+                  <button
+                    role="menuitem"
+                    type="button"
+                    disabled={!contextMenuCanMoveDown}
+                    onClick={() =>
+                      moveThreadFromContextMenu(contextMenu.thread, "down")
+                    }
+                  >
+                    <span>Move Down</span>
+                    <span
+                      className="thread-context-menu__shortcut"
+                      aria-hidden="true"
+                    >
+                      {"⌘↓"}
+                    </span>
+                  </button>
+                </>
+              ) : null}
               {contextMenuCanRename ? (
                 <button
                   role="menuitem"
@@ -773,6 +938,48 @@ export function Sidebar(props: SidebarProps) {
                 ? "Unpin Directory"
                 : "Pin Directory"}
             </button>
+            {directoryMenuShowMoveItems ? (
+              <>
+                <button
+                  role="menuitem"
+                  type="button"
+                  disabled={!directoryMenuCanMoveUp}
+                  onClick={() =>
+                    moveDirectoryFromContextMenu(
+                      directoryContextMenu.directory,
+                      "up",
+                    )
+                  }
+                >
+                  <span>Move Up</span>
+                  <span
+                    className="thread-context-menu__shortcut"
+                    aria-hidden="true"
+                  >
+                    {"⌘⇧↑"}
+                  </span>
+                </button>
+                <button
+                  role="menuitem"
+                  type="button"
+                  disabled={!directoryMenuCanMoveDown}
+                  onClick={() =>
+                    moveDirectoryFromContextMenu(
+                      directoryContextMenu.directory,
+                      "down",
+                    )
+                  }
+                >
+                  <span>Move Down</span>
+                  <span
+                    className="thread-context-menu__shortcut"
+                    aria-hidden="true"
+                  >
+                    {"⌘⇧↓"}
+                  </span>
+                </button>
+              </>
+            ) : null}
           </div>
         </div>
       ) : null}

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -463,7 +463,14 @@ export function Sidebar(props: SidebarProps) {
       targetId,
       direction === "up" ? "before" : "after",
     );
-    setContextMenu(undefined);
+    // Intentionally do NOT dismiss the menu after a Move — the
+    // user often wants several reorder taps in a row, and
+    // re-right-clicking between every one is a UX downgrade vs
+    // the keyboard shortcut. The menu re-renders with fresh
+    // `pinnedThreadIdsByBackend` on the snapshot reconciliation
+    // tick, so subsequent Move clicks see updated adjacency.
+    // Pin / Unpin / Rename / Archive are terminal actions and
+    // still dismiss the menu.
     void props.onReorderThreadPins?.(thread.source, nextIds);
   };
 
@@ -484,7 +491,8 @@ export function Sidebar(props: SidebarProps) {
       targetKey,
       direction === "up" ? "before" : "after",
     );
-    setDirectoryContextMenu(undefined);
+    // See `moveThreadFromContextMenu` for why we don't dismiss
+    // the menu here.
     void props.onReorderDirectoryPins?.(nextKeys);
   };
 
@@ -792,6 +800,7 @@ export function Sidebar(props: SidebarProps) {
                   <button
                     role="menuitem"
                     type="button"
+                    aria-keyshortcuts="Meta+Shift+ArrowUp"
                     disabled={!contextMenuCanMoveUp}
                     onClick={() =>
                       moveThreadFromContextMenu(contextMenu.thread, "up")
@@ -802,12 +811,13 @@ export function Sidebar(props: SidebarProps) {
                       className="thread-context-menu__shortcut"
                       aria-hidden="true"
                     >
-                      {"⌘↑"}
+                      {"⌘⇧↑"}
                     </span>
                   </button>
                   <button
                     role="menuitem"
                     type="button"
+                    aria-keyshortcuts="Meta+Shift+ArrowDown"
                     disabled={!contextMenuCanMoveDown}
                     onClick={() =>
                       moveThreadFromContextMenu(contextMenu.thread, "down")
@@ -818,7 +828,7 @@ export function Sidebar(props: SidebarProps) {
                       className="thread-context-menu__shortcut"
                       aria-hidden="true"
                     >
-                      {"⌘↓"}
+                      {"⌘⇧↓"}
                     </span>
                   </button>
                 </>
@@ -943,6 +953,7 @@ export function Sidebar(props: SidebarProps) {
                 <button
                   role="menuitem"
                   type="button"
+                  aria-keyshortcuts="Meta+Shift+ArrowUp"
                   disabled={!directoryMenuCanMoveUp}
                   onClick={() =>
                     moveDirectoryFromContextMenu(
@@ -962,6 +973,7 @@ export function Sidebar(props: SidebarProps) {
                 <button
                   role="menuitem"
                   type="button"
+                  aria-keyshortcuts="Meta+Shift+ArrowDown"
                   disabled={!directoryMenuCanMoveDown}
                   onClick={() =>
                     moveDirectoryFromContextMenu(

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -164,13 +164,19 @@ export function ThreadRow(props: ThreadRowProps) {
         }`}
         type="button"
         onKeyDown={(event) => {
+          // Reorder a pinned thread within its backend's pinned
+          // slice. Unified with the directory-pin shortcut
+          // (Cmd+Shift+Arrow) so users learn one keybind. Plain
+          // Cmd+Arrow used to drive this — that collided with
+          // macOS Finder's "go to parent folder" mental model and
+          // diverged from the directory shortcut.
           if (
             props.onMovePinnedThread &&
             props.thread.pinnedRank &&
             event.metaKey &&
+            event.shiftKey &&
             !event.altKey &&
             !event.ctrlKey &&
-            !event.shiftKey &&
             (event.key === "ArrowUp" || event.key === "ArrowDown")
           ) {
             event.preventDefault();

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -926,8 +926,16 @@ describe("Sidebar", () => {
     });
     expect(moveUp).toBeDisabled();
     expect(moveDown).not.toBeDisabled();
-    expect(moveUp).toHaveTextContent("⌘↑");
-    expect(moveDown).toHaveTextContent("⌘↓");
+    // Unified shortcut with directory pinning (Cmd+Shift+Arrow).
+    expect(moveUp).toHaveTextContent("⌘⇧↑");
+    expect(moveDown).toHaveTextContent("⌘⇧↓");
+    // aria-keyshortcuts so screen readers can announce the binding
+    // independently of the visual chip (which is aria-hidden).
+    expect(moveUp).toHaveAttribute("aria-keyshortcuts", "Meta+Shift+ArrowUp");
+    expect(moveDown).toHaveAttribute(
+      "aria-keyshortcuts",
+      "Meta+Shift+ArrowDown",
+    );
 
     // Click Move Down on the top thread → swap order.
     await clickElement(moveDown);
@@ -2465,6 +2473,11 @@ describe("Sidebar directory pinning", () => {
     expect(moveDown).not.toBeDisabled();
     expect(moveUp).toHaveTextContent("⌘⇧↑");
     expect(moveDown).toHaveTextContent("⌘⇧↓");
+    expect(moveUp).toHaveAttribute("aria-keyshortcuts", "Meta+Shift+ArrowUp");
+    expect(moveDown).toHaveAttribute(
+      "aria-keyshortcuts",
+      "Meta+Shift+ArrowDown",
+    );
 
     // Click Move Down → the middle directory should move past the
     // bottom one, producing [top, bottom, middle].
@@ -2525,5 +2538,200 @@ describe("Sidebar directory pinning", () => {
     expect(
       screen.queryByRole("menuitem", { name: /Move Down/i }),
     ).not.toBeInTheDocument();
+  });
+
+  it("keeps the directory menu open after a Move click so the user can chain reorders", async () => {
+    // The keyboard shortcut path lets a user mash Cmd+Shift+↓
+    // repeatedly. The menu path should not force a re-right-click
+    // between every Move — that's a UX downgrade. Pin/Unpin
+    // still dismiss because those are terminal actions.
+    const pinnedTop: NavigationDirectorySummary = {
+      ...projectADirectory,
+      pinnedRank: "1024",
+    };
+    const pinnedMiddle: NavigationDirectorySummary = {
+      ...projectBDirectory,
+      pinnedRank: "2048",
+    };
+    const pinnedBottom: NavigationDirectorySummary = {
+      key: "directory:/Users/huntharo/pwrdrvr/ProjectC",
+      kind: "directory",
+      label: "ProjectC",
+      path: "/Users/huntharo/pwrdrvr/ProjectC",
+      threadKeys: [],
+      needsAttentionCount: 0,
+      latestUpdatedAt: 3000,
+      pinnedRank: "3072",
+    };
+
+    renderSidebar([pinnedTop, pinnedMiddle, pinnedBottom], {
+      onSetDirectoryPin: async () => undefined,
+      onReorderDirectoryPins: async () => undefined,
+    });
+
+    fireEvent.contextMenu(getDirectorySummary(/ProjectB/i));
+    const moveDown = await screen.findByRole("menuitem", {
+      name: /Move Down/i,
+    });
+    await clickElement(moveDown);
+
+    // Menu must still be mounted after the Move click — the
+    // Pin / Unpin item is the marker that the same menu is
+    // still open.
+    expect(
+      screen.queryByRole("menuitem", { name: /Unpin Directory/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("dismisses the directory menu after Pin / Unpin (terminal action)", async () => {
+    const pinned: NavigationDirectorySummary = {
+      ...projectADirectory,
+      pinnedRank: "1024",
+    };
+
+    renderSidebar([pinned], {
+      onSetDirectoryPin: async () => undefined,
+      onReorderDirectoryPins: async () => undefined,
+    });
+
+    fireEvent.contextMenu(getDirectorySummary(/ProjectA/i));
+    const unpinItem = await screen.findByRole("menuitem", {
+      name: "Unpin Directory",
+    });
+    await clickElement(unpinItem);
+
+    // Unlike Move, the Unpin item collapses the menu.
+    expect(
+      screen.queryByRole("menuitem", { name: /Unpin Directory/i }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("Sidebar thread pinning Move items", () => {
+  it("disables Move Down on backend A's bottom pinned thread regardless of backend B's pinned count", async () => {
+    // Per-backend pin-rank invariant: reorder IPC is scoped to
+    // (backend, [threadId, threadId, ...]). Move Down on backend
+    // A's bottom thread must NOT promote into backend B's pinned
+    // slice. Lock the boundary so a future refactor that
+    // accidentally globalizes the sort can't slip past review.
+    const codexOnly = {
+      ...sharedThread,
+      id: "codex-pinned-only",
+      title: "Codex sole pin",
+      source: "codex" as const,
+      pinnedRank: "1024",
+    };
+    const grokTop = {
+      ...sharedThread,
+      id: "grok-top",
+      title: "Grok top pin",
+      source: "grok" as const,
+      pinnedRank: "1024",
+    };
+    const grokBottom = {
+      ...sharedThread,
+      id: "grok-bottom",
+      title: "Grok bottom pin",
+      source: "grok" as const,
+      pinnedRank: "2048",
+    };
+
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="recents"
+        createThreadError={undefined}
+        directories={[]}
+        inboxThreads={[]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey={undefined}
+        threads={[codexOnly, grokTop, grokBottom]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onReorderThreadPins={async () => undefined}
+        onSelectThread={() => undefined}
+        onSetThreadPin={async () => undefined}
+      />,
+    );
+
+    // Open menu on codex's sole pin (it's at both top AND bottom
+    // of its backend's slice — but grok has TWO pins below).
+    const codexRow = screen
+      .getByRole("button", { name: /Codex sole pin/i })
+      .closest(".thread-row-shell") as HTMLElement;
+    fireEvent.click(
+      codexRow.querySelector(".thread-row__overflow-button") as HTMLButtonElement,
+    );
+
+    const moveUp = await screen.findByRole("menuitem", { name: /Move Up/i });
+    const moveDown = await screen.findByRole("menuitem", {
+      name: /Move Down/i,
+    });
+    // Per-backend slice has length 1 → both Up and Down disabled
+    // even though the global pin count is 3.
+    expect(moveUp).toBeDisabled();
+    expect(moveDown).toBeDisabled();
+  });
+
+  it("invokes the reorder IPC on Cmd+Shift+ArrowDown on a focused pinned thread row", () => {
+    // Locks the unified shortcut. The thread reorder shortcut
+    // used to be plain Cmd+Arrow; it now matches the directory
+    // reorder shortcut (Cmd+Shift+Arrow). A plain Cmd+Arrow
+    // press should NOT trigger a reorder anymore.
+    const onReorderThreadPins = vi.fn(async () => undefined);
+    const pinnedTop = {
+      ...sharedThread,
+      id: "thread-top",
+      title: "Top pinned",
+      pinnedRank: "1024",
+    };
+    const pinnedBottom = {
+      ...sharedThread,
+      id: "thread-bottom",
+      title: "Bottom pinned",
+      pinnedRank: "2048",
+    };
+
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="recents"
+        createThreadError={undefined}
+        directories={[]}
+        inboxThreads={[]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey={undefined}
+        threads={[pinnedTop, pinnedBottom]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onReorderThreadPins={onReorderThreadPins}
+        onSelectThread={() => undefined}
+        onSetThreadPin={async () => undefined}
+      />,
+    );
+
+    const topButton = screen.getByRole("button", { name: /Top pinned/i });
+
+    // Old shortcut (Cmd alone) → must NOT fire.
+    fireEvent.keyDown(topButton, { key: "ArrowDown", metaKey: true });
+    expect(onReorderThreadPins).not.toHaveBeenCalled();
+
+    // New shortcut (Cmd + Shift) → fires the reorder, swapping
+    // the top thread with the bottom one.
+    fireEvent.keyDown(topButton, {
+      key: "ArrowDown",
+      metaKey: true,
+      shiftKey: true,
+    });
+    expect(onReorderThreadPins).toHaveBeenCalledWith("codex", [
+      pinnedBottom.id,
+      pinnedTop.id,
+    ]);
   });
 });

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -871,6 +871,110 @@ describe("Sidebar", () => {
     expect(onSetThreadPin).toHaveBeenCalledWith(sharedThread, true);
   });
 
+  it("exposes Move Up / Move Down with shortcut hints on a pinned thread's context menu", async () => {
+    // Discoverability: the Cmd+Arrow keyboard shortcut for
+    // reordering pinned threads is invisible without a surfaced
+    // affordance. Mirrors the macOS-native pattern of showing
+    // the shortcut hint inline on the menu item.
+    const onReorderThreadPins = vi.fn(async () => undefined);
+    const pinnedTop = {
+      ...sharedThread,
+      id: "thread-top",
+      title: "Top pinned thread",
+      pinnedRank: "1024",
+    };
+    const pinnedBottom = {
+      ...sharedThread,
+      id: "thread-bottom",
+      title: "Bottom pinned thread",
+      pinnedRank: "2048",
+    };
+
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="recents"
+        createThreadError={undefined}
+        directories={directories}
+        inboxThreads={[]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey={undefined}
+        threads={[pinnedTop, pinnedBottom]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onReorderThreadPins={onReorderThreadPins}
+        onSelectThread={() => undefined}
+        onSetThreadPin={async () => undefined}
+      />,
+    );
+
+    // Open context menu on the TOP pinned thread → Move Up
+    // disabled, Move Down enabled, both shortcut hints visible.
+    const topRow = screen
+      .getByRole("button", { name: /Top pinned thread/i })
+      .closest(".thread-row-shell") as HTMLElement;
+    fireEvent.click(
+      topRow.querySelector(".thread-row__overflow-button") as HTMLButtonElement,
+    );
+
+    const moveUp = await screen.findByRole("menuitem", { name: /Move Up/i });
+    const moveDown = await screen.findByRole("menuitem", {
+      name: /Move Down/i,
+    });
+    expect(moveUp).toBeDisabled();
+    expect(moveDown).not.toBeDisabled();
+    expect(moveUp).toHaveTextContent("⌘↑");
+    expect(moveDown).toHaveTextContent("⌘↓");
+
+    // Click Move Down on the top thread → swap order.
+    await clickElement(moveDown);
+    expect(onReorderThreadPins).toHaveBeenCalledWith("codex", [
+      pinnedBottom.id,
+      pinnedTop.id,
+    ]);
+  });
+
+  it("omits Move Up / Move Down from an unpinned thread's context menu", async () => {
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="recents"
+        createThreadError={undefined}
+        directories={directories}
+        inboxThreads={[]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey={undefined}
+        threads={[sharedThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onReorderThreadPins={async () => undefined}
+        onSelectThread={() => undefined}
+        onSetThreadPin={async () => undefined}
+      />,
+    );
+
+    const row = screen
+      .getByRole("button", { name: /Cross-project cleanup/i })
+      .closest(".thread-row-shell") as HTMLElement;
+    fireEvent.click(
+      row.querySelector(".thread-row__overflow-button") as HTMLButtonElement,
+    );
+
+    await screen.findByRole("menuitem", { name: "Pin Thread" });
+    expect(
+      screen.queryByRole("menuitem", { name: /Move Up/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("menuitem", { name: /Move Down/i }),
+    ).not.toBeInTheDocument();
+  });
+
   it("renders pinned threads above directory threads inside each expanded directory", () => {
     const pinnedThread = {
       ...updatedSinceSeenThread,
@@ -2317,6 +2421,109 @@ describe("Sidebar directory pinning", () => {
     await screen.findByRole("menuitem", { name: "Pin Thread" });
     expect(
       screen.queryByRole("menuitem", { name: "Unpin Directory" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("exposes Move Up / Move Down with shortcut hints on a pinned directory's context menu", async () => {
+    // Discoverability: the Cmd+Shift+Arrow keyboard shortcut for
+    // reordering pinned directories is invisible without a
+    // surfaced affordance. Mirrors the macOS-native pattern of
+    // showing the shortcut hint inline on the menu item.
+    const onReorderDirectoryPins = vi.fn(async () => undefined);
+    const pinnedTop: NavigationDirectorySummary = {
+      ...projectADirectory,
+      pinnedRank: "1024",
+    };
+    const pinnedMiddle: NavigationDirectorySummary = {
+      ...projectBDirectory,
+      pinnedRank: "2048",
+    };
+    const pinnedBottom: NavigationDirectorySummary = {
+      key: "directory:/Users/huntharo/pwrdrvr/ProjectC",
+      kind: "directory",
+      label: "ProjectC",
+      path: "/Users/huntharo/pwrdrvr/ProjectC",
+      threadKeys: [],
+      needsAttentionCount: 0,
+      latestUpdatedAt: 3000,
+      pinnedRank: "3072",
+    };
+
+    renderSidebar([pinnedTop, pinnedMiddle, pinnedBottom], {
+      onSetDirectoryPin: async () => undefined,
+      onReorderDirectoryPins,
+    });
+
+    // Right-click the middle pinned directory — both Move Up and
+    // Move Down should be enabled.
+    fireEvent.contextMenu(getDirectorySummary(/ProjectB/i));
+    const moveUp = await screen.findByRole("menuitem", { name: /Move Up/i });
+    const moveDown = await screen.findByRole("menuitem", {
+      name: /Move Down/i,
+    });
+    expect(moveUp).not.toBeDisabled();
+    expect(moveDown).not.toBeDisabled();
+    expect(moveUp).toHaveTextContent("⌘⇧↑");
+    expect(moveDown).toHaveTextContent("⌘⇧↓");
+
+    // Click Move Down → the middle directory should move past the
+    // bottom one, producing [top, bottom, middle].
+    await clickElement(moveDown);
+    expect(onReorderDirectoryPins).toHaveBeenCalledWith([
+      pinnedTop.key,
+      pinnedBottom.key,
+      pinnedMiddle.key,
+    ]);
+  });
+
+  it("disables Move Up on the top pinned directory and Move Down on the bottom", async () => {
+    const pinnedTop: NavigationDirectorySummary = {
+      ...projectADirectory,
+      pinnedRank: "1024",
+    };
+    const pinnedBottom: NavigationDirectorySummary = {
+      ...projectBDirectory,
+      pinnedRank: "2048",
+    };
+
+    renderSidebar([pinnedTop, pinnedBottom], {
+      onSetDirectoryPin: async () => undefined,
+      onReorderDirectoryPins: async () => undefined,
+    });
+
+    // Top: Move Up disabled, Move Down enabled
+    fireEvent.contextMenu(getDirectorySummary(/ProjectA/i));
+    expect(
+      await screen.findByRole("menuitem", { name: /Move Up/i }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("menuitem", { name: /Move Down/i }),
+    ).not.toBeDisabled();
+
+    // Dismiss + open the bottom row's menu
+    fireEvent.click(document.body);
+    fireEvent.contextMenu(getDirectorySummary(/ProjectB/i));
+    expect(
+      await screen.findByRole("menuitem", { name: /Move Up/i }),
+    ).not.toBeDisabled();
+    expect(
+      screen.getByRole("menuitem", { name: /Move Down/i }),
+    ).toBeDisabled();
+  });
+
+  it("omits Move Up / Move Down entirely from an unpinned directory's context menu", async () => {
+    renderSidebar([projectADirectory], {
+      onSetDirectoryPin: async () => undefined,
+      onReorderDirectoryPins: async () => undefined,
+    });
+
+    fireEvent.contextMenu(getDirectorySummary(/ProjectA/i));
+    await screen.findByRole("menuitem", { name: "Pin Directory" });
+    expect(
+      screen.queryByRole("menuitem", { name: /Move Up/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("menuitem", { name: /Move Down/i }),
     ).not.toBeInTheDocument();
   });
 });

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -312,9 +312,38 @@ describe("Tangerine Terminal theme contract", () => {
     expect(summaryMetaRule).toContain("flex: 0 0 auto;");
   });
 
-  it("keeps thread context menu hover states visible", () => {
+  it("keeps thread context menu hover states visible (skipping disabled rows)", () => {
+    // The `:not(:disabled)` qualifier was added so disabled menu
+    // items (Move Up at top of pinned list / Move Down at bottom)
+    // don't pick up the accent hover treatment — they stay muted
+    // to telegraph that nothing happens on click.
     expect(css).toMatch(
-      /\.thread-context-menu button:hover,\s*\.thread-context-menu button:focus-visible\s*\{[\s\S]*?background:\s*var\(--accent-soft\);[\s\S]*?color:\s*var\(--accent-bright\);[\s\S]*?\}/
+      /\.thread-context-menu button:hover:not\(:disabled\),\s*\.thread-context-menu button:focus-visible:not\(:disabled\)\s*\{[\s\S]*?background:\s*var\(--accent-soft\);[\s\S]*?color:\s*var\(--accent-bright\);[\s\S]*?\}/
+    );
+    // Disabled state uses text-muted so the row reads as
+    // "present but inert" rather than fully hidden — keeps the
+    // menu height stable as the user walks the pinned list.
+    const disabledRule = extractRuleBody(
+      css,
+      ".thread-context-menu button:disabled",
+    );
+    expect(disabledRule).toContain("color: var(--text-muted);");
+  });
+
+  it("right-aligns the keyboard shortcut hint chip on context menu items", () => {
+    // The `__shortcut` chip is the discoverability surface for
+    // the otherwise-invisible Cmd+(Shift+)Arrow reorder shortcut.
+    // Visual contract: muted color by default, tracks the parent
+    // button's accent color on hover so it doesn't drop out of
+    // the highlighted row.
+    const shortcutRule = extractRuleBody(
+      css,
+      ".thread-context-menu__shortcut",
+    );
+    expect(shortcutRule).toContain("margin-left: auto;");
+    expect(shortcutRule).toContain("color: var(--text-muted);");
+    expect(css).toMatch(
+      /\.thread-context-menu button:hover:not\(:disabled\) \.thread-context-menu__shortcut,\s*\.thread-context-menu button:focus-visible:not\(:disabled\) \.thread-context-menu__shortcut\s*\{[\s\S]*?color:\s*var\(--accent-bright\);[\s\S]*?\}/
     );
   });
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2758,11 +2758,43 @@ textarea,
   text-align: left;
 }
 
-.thread-context-menu button:hover,
-.thread-context-menu button:focus-visible {
+.thread-context-menu button:hover:not(:disabled),
+.thread-context-menu button:focus-visible:not(:disabled) {
   background: var(--accent-soft);
   color: var(--accent-bright);
   outline: none;
+}
+
+.thread-context-menu button:disabled {
+  /* Disabled "Move Up" at the top of the pinned list / "Move
+     Down" at the bottom. Keep the row in the menu so the layout
+     doesn't jump as the user moves items — just de-emphasize and
+     suppress hover. */
+  color: var(--text-muted);
+  cursor: default;
+}
+
+/* macOS-native pattern: action label on the left, keyboard
+   shortcut hint chip on the right (margin-left: auto). Used by
+   the pin/move items in the thread + directory context menus so
+   the otherwise-undiscoverable Cmd+(Shift+)Arrow reorder
+   shortcuts have a visible affordance. */
+.thread-context-menu__shortcut {
+  margin-left: auto;
+  padding-left: 16px;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+}
+
+.thread-context-menu button:hover:not(:disabled) .thread-context-menu__shortcut,
+.thread-context-menu button:focus-visible:not(:disabled) .thread-context-menu__shortcut {
+  /* Track the parent button's accent color on hover so the
+     shortcut chip doesn't visually drop out of the highlighted
+     row. */
+  color: var(--accent-bright);
 }
 
 .thread-context-menu__separator {

--- a/docs-site/desktop.md
+++ b/docs-site/desktop.md
@@ -106,11 +106,11 @@ To pin or change pin order:
   pinned section. Drag an unpinned thread or directory above the
   pinned divider to add it; drop it back below to remove it.
 - **Keyboard reorder:** with a pinned row focused (Tab from the
-  sidebar or click it once), press <kbd>⌘↑</kbd> / <kbd>⌘↓</kbd>
-  to move a pinned thread up or down, or <kbd>⌘⇧↑</kbd> /
-  <kbd>⌘⇧↓</kbd> for a pinned directory. The same shortcuts are
-  surfaced inline on the **Move Up** and **Move Down** items in
-  the right-click menu — discover once there, use anywhere.
+  sidebar or click it once), press <kbd>⌘⇧↑</kbd> / <kbd>⌘⇧↓</kbd>
+  to move it up or down. Same shortcut for pinned threads and
+  pinned directories. The chips next to **Move Up** and **Move
+  Down** in the right-click menu surface the same binding —
+  discover once there, use anywhere.
 
 #### Unread marker
 

--- a/docs-site/desktop.md
+++ b/docs-site/desktop.md
@@ -92,6 +92,26 @@ In **Directories**, pins belong to their parent directory rather
 than to the global list, so each directory gets its own statically-
 ordered pin shelf.
 
+The **Directories** lens also lets you pin entire directories
+(and workspaces) above the divider so your active projects stay
+on top regardless of which one most recently woke up. Pinned
+directories carry over across restarts.
+
+To pin or change pin order:
+
+- **Pin or unpin:** right-click a thread or directory row and
+  pick **Pin / Unpin** from the menu. The same menu is reachable
+  from the **⋯** overflow button on thread rows.
+- **Drag to reorder:** drag a pinned row up or down inside the
+  pinned section. Drag an unpinned thread or directory above the
+  pinned divider to add it; drop it back below to remove it.
+- **Keyboard reorder:** with a pinned row focused (Tab from the
+  sidebar or click it once), press **⌘↑ / ⌘↓** to move a pinned
+  thread up or down, or **⌘⇧↑ / ⌘⇧↓** for a pinned directory.
+  The same shortcuts are surfaced inline on the **Move Up** and
+  **Move Down** items in the right-click menu — discover once
+  there, use anywhere.
+
 #### Unread marker
 
 When a thread you haven't actively viewed gets new agent output,

--- a/docs-site/desktop.md
+++ b/docs-site/desktop.md
@@ -101,7 +101,7 @@ To pin or change pin order:
 
 - **Pin or unpin:** right-click a thread or directory row and
   pick **Pin / Unpin** from the menu. The same menu is reachable
-  from the <code>⋯</code> overflow button on thread rows.
+  from the three-dot overflow button on thread rows.
 - **Drag to reorder:** drag a pinned row up or down inside the
   pinned section. Drag an unpinned thread or directory above the
   pinned divider to add it; drop it back below to remove it.

--- a/docs-site/desktop.md
+++ b/docs-site/desktop.md
@@ -101,16 +101,16 @@ To pin or change pin order:
 
 - **Pin or unpin:** right-click a thread or directory row and
   pick **Pin / Unpin** from the menu. The same menu is reachable
-  from the **⋯** overflow button on thread rows.
+  from the <code>⋯</code> overflow button on thread rows.
 - **Drag to reorder:** drag a pinned row up or down inside the
   pinned section. Drag an unpinned thread or directory above the
   pinned divider to add it; drop it back below to remove it.
 - **Keyboard reorder:** with a pinned row focused (Tab from the
-  sidebar or click it once), press **⌘↑ / ⌘↓** to move a pinned
-  thread up or down, or **⌘⇧↑ / ⌘⇧↓** for a pinned directory.
-  The same shortcuts are surfaced inline on the **Move Up** and
-  **Move Down** items in the right-click menu — discover once
-  there, use anywhere.
+  sidebar or click it once), press <kbd>⌘↑</kbd> / <kbd>⌘↓</kbd>
+  to move a pinned thread up or down, or <kbd>⌘⇧↑</kbd> /
+  <kbd>⌘⇧↓</kbd> for a pinned directory. The same shortcuts are
+  surfaced inline on the **Move Up** and **Move Down** items in
+  the right-click menu — discover once there, use anywhere.
 
 #### Unread marker
 


### PR DESCRIPTION
## Summary

Follow-up to #480. The `Cmd+Shift+Arrow` keyboard shortcut for reordering pinned items has shipped for a while but was effectively invisible — no tooltip, no menu hint, no docs. The only discovery path was reading the source. This PR closes the loop on three surfaces, and unifies the shortcut across threads and directories along the way.

### UI — context menu Move items with shortcut hints
macOS-native pattern: action label on the left, keyboard shortcut chip on the right.

| Menu | Items added |
|---|---|
| Thread context menu | **Move Up ⌘⇧↑** / **Move Down ⌘⇧↓** |
| Directory context menu | **Move Up ⌘⇧↑** / **Move Down ⌘⇧↓** |

Behavior:
- Items only render when the target is pinned (reorder doesn't apply to unpinned items)
- Items disable (rather than disappear) at the top / bottom of the pinned section, so menu height stays stable as the user walks the list
- **Menu stays open after a Move click** — reorders chain naturally, parity with mashing the keyboard shortcut. Pin / Unpin / Rename / Archive stay terminal and still dismiss the menu.
- Clicking the item invokes the same reorder IPC the keyboard shortcut already uses — no new behavior on those code paths, just an alternate teaching surface.

### Unified the reorder shortcut

The thread reorder shortcut used to be `Cmd+Arrow`; directories shipped (in #480) as `Cmd+Shift+Arrow`. Once the menu chips made the inconsistency visible to every user, leaving it alone wasn't an option. Both now bind to `Cmd+Shift+Arrow` — the safer choice, since plain `Cmd+Arrow` collides with macOS Finder's "go to parent folder" mental model.

**Behavior change for thread users**: anyone who learned the old `Cmd+Arrow` muscle memory needs to add the Shift modifier. The chip in the menu telegraphs the new binding, and the docs are updated.

### Accessibility — `aria-keyshortcuts`

The visual `⌘⇧↑` / `⌘⇧↓` chips are `aria-hidden="true"` (correct — prevents screen readers from announcing "Move Up Command Shift Up Arrow" twice). The shortcut is exposed to assistive tech via `aria-keyshortcuts="Meta+Shift+ArrowUp"` / `Meta+Shift+ArrowDown` on each menuitem. First use of `aria-keyshortcuts` in the renderer — establishes the pattern for future menu work.

### Docs — `docs-site/desktop.md` Pins section
Extended the existing Pins block to describe all three reorder paths (right-click menu, drag-and-drop, keyboard shortcuts) with the unified shortcut spelled out once. Earlier rounds of this PR also tripped axe-core's color-contrast rule on a `⋯` glyph I'd added inline; ended up describing the overflow button in plain words for robustness.

## Test plan
- [ ] Right-click a pinned thread → Move Up / Move Down items show with `⌘⇧↑` / `⌘⇧↓` chips
- [ ] Right-click a pinned directory → same items, same chips
- [ ] Right-click the **top-most** pinned item → Move Up is disabled (muted, no hover)
- [ ] Right-click the **bottom-most** pinned item → Move Down is disabled
- [ ] Right-click an **unpinned** item → no Move items in the menu
- [ ] Click "Move Down" on a pinned item → it swaps with the next pinned item AND the menu stays open
- [ ] Click "Unpin" → menu dismisses
- [ ] With a pinned thread row focused, press `Cmd+Shift+↓` → reorder fires
- [ ] With a pinned thread row focused, press plain `Cmd+↓` (old shortcut) → nothing happens
- [ ] With a screen reader on, navigate to a Move menuitem → shortcut is announced

## Pre-flight gates
- ✅ `pnpm typecheck` (all 12 workspaces)
- ✅ `pnpm lint:boundaries` (1226 modules / 1852 deps)
- ✅ Sidebar tests: 56 passing
  - Move items render with chips + `aria-keyshortcuts`
  - Top/bottom disable correctly
  - Unpinned omits Move items
  - **Menu stays open** after Move click; dismisses after Pin/Unpin
  - **Cross-backend boundary**: backend-A's only pinned thread keeps Move disabled even when backend-B has more pinned items globally
  - **Keyboard shortcut integration**: `Cmd+Shift+↓` fires reorder; plain `Cmd+↓` does not
- ✅ Theme contract tests: 27 passing
- ✅ Docs-site a11y (pa11y-ci / axe-core): 16/16 URLs pass

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this is a UI affordance + docs change. The underlying reorder IPC and persistence layer is unchanged from #480; the renderer surfaces a new path to invoke it and the keyboard handler in `ThreadRow.tsx` changed its modifier check (`!event.shiftKey` → `event.shiftKey`). Validate post-deploy by:
- Right-click any pinned thread or directory → confirm Move Up / Move Down items appear with `⌘⇧↑` / `⌘⇧↓` chips
- Press `Cmd+Shift+↓` on a focused pinned thread row → reorder happens

If a user reports `Cmd+↓` no longer reordering, that's expected — point them at the new chip / docs.

---

[![Compound Engineering v2.49.0](https://img.shields.io/badge/Compound_Engineering-v2.49.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Sonnet 4.5 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)