### PR TITLE
feat(desktop): WCAG2 AA axe gate for renderer + baseline a11y fixes

### DIFF
--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -1,11 +1,24 @@
 'use strict'
 
+// Fields scanned on every package (first-party and transitive).
+// pnpm never installs a transitive package's devDependencies, so we
+// only enforce git-spec blocking on devDependencies for our own
+// first-party packages — the fields below are the ones whose specs
+// pnpm WILL try to resolve regardless of who declared them.
 const dependencyFields = [
   'dependencies',
-  'devDependencies',
   'optionalDependencies',
   'peerDependencies',
 ]
+
+const firstPartyPackageNames = new Set(['pwragent-workspace'])
+const firstPartyPackagePrefix = '@pwragent/'
+
+function isFirstParty(pkg) {
+  if (!pkg || typeof pkg.name !== 'string') return false
+  if (firstPartyPackageNames.has(pkg.name)) return true
+  return pkg.name.startsWith(firstPartyPackagePrefix)
+}
 
 const gitSpecPattern = /^(?:git(?:\+|:)|git@|ssh:\/\/git@|github:|gitlab:|bitbucket:|https?:\/\/(?:www\.)?(?:github|gitlab|bitbucket)\.com\/|[^/@\s]+\/[^/\s]+(?:#.*)?$)/
 
@@ -13,27 +26,41 @@ function isGitSpec(spec) {
   return typeof spec === 'string' && gitSpecPattern.test(spec)
 }
 
+function scanField(pkg, field) {
+  const dependencies = pkg[field]
+  if (!dependencies) return
+  for (const [name, spec] of Object.entries(dependencies)) {
+    if (isGitSpec(spec)) {
+      throw new Error(`Blocked git dependency ${name}@${spec} (in ${pkg.name ?? '<unknown>'}.${field})`)
+    }
+  }
+}
+
 function readPackage(pkg) {
   // Protobufjs publishes an unused transitive devDependency as a GitHub spec.
-  // Strip it before enforcing the registry-only dependency policy.
+  // Strip it before enforcing the registry-only dependency policy. Even
+  // though devDependencies of non-first-party packages are no longer scanned
+  // below (and pnpm never installs them either), keeping the explicit strip
+  // means pnpm doesn't even materialize the spec in its resolver graph —
+  // defense in depth, and an audit trail for the specific upstream issue.
   if (
     pkg.name === 'protobufjs' &&
     pkg.devDependencies?.['jaguarjs-jsdoc'] === 'github:dcodeIO/jaguarjs-jsdoc'
   ) {
     delete pkg.devDependencies['jaguarjs-jsdoc']
   }
-
   for (const field of dependencyFields) {
-    const dependencies = pkg[field]
-    if (!dependencies) continue
-
-    for (const [name, spec] of Object.entries(dependencies)) {
-      if (isGitSpec(spec)) {
-        throw new Error(`Blocked git dependency ${name}@${spec}`)
-      }
-    }
+    scanField(pkg, field)
   }
-
+  if (isFirstParty(pkg)) {
+    // First-party packages also block git specs in devDependencies so a
+    // PR can't slip a git devDep into our own workspace. Transitive
+    // devDependencies are never installed by pnpm and the fetchers.git
+    // hook below still refuses any actual git clone — so we don't need
+    // to gate them here and the false positive on legitimate upstream
+    // packages (e.g. axe-core's axe-test-fixtures) goes away.
+    scanField(pkg, 'devDependencies')
+  }
   return pkg
 }
 

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -169,6 +169,45 @@ pnpm --filter @pwragent/desktop exec tsx \
 Works for 2+ frames; the indicator scales horizontally with frame
 count.
 
+## Accessibility
+
+The renderer is audited against WCAG 2.0 / 2.1 / 2.2 Level AA via
+`apps/desktop/e2e/a11y.spec.ts`, which launches Electron under the
+existing replay-fixture harness and runs `@axe-core/playwright`'s
+`AxeBuilder` against each surface. CI picks it up automatically through
+`pnpm run test:desktop-e2e` — no separate workflow.
+
+Things to know when extending the audit:
+
+- **Surface coverage.** Each `test(...)` block drives the renderer to a
+  state (open thread, settings overlay, settings → messaging) and then
+  calls `runAxe(window)`. Add a new block per surface you want gated;
+  reuse `launchElectronApp` with whatever fixture seeds that state.
+- **`setLegacyMode(true)` is required under Electron.** The default
+  `AxeBuilder.analyze()` opens a worker page via
+  `browserContext.newPage()` to scan cross-origin iframes; Electron's
+  CDP target returns "Not supported" for that. The renderer is
+  single-origin with no cross-origin iframes, so the legacy
+  single-context path covers everything we ship.
+- **`KNOWN_VIOLATIONS` is a baseline, not a permission slip.** Each
+  entry waives one selector for one rule with a written reason. Fix
+  the underlying issue, then delete the entry — axe will hold the
+  line on it going forward.
+- **No raw color literals outside the token blocks** (see Implementation
+  Notes below) — this is also what keeps the contrast pair audited by
+  axe stable across theme + density variants.
+
+To run the gate locally:
+
+```bash
+pnpm --filter @pwragent/desktop exec playwright test \
+  -c playwright.config.ts e2e/a11y.spec.ts
+```
+
+(The package's `test:e2e` script does a full Electron rebuild + Vite
+build first; the `playwright test` form above skips that when you've
+already built once.)
+
 ## Config File Evolution
 
 Before changing `config.toml` keys in a backwards-incompatible way, read

--- a/apps/desktop/e2e/a11y.spec.ts
+++ b/apps/desktop/e2e/a11y.spec.ts
@@ -1,0 +1,163 @@
+// Renderer accessibility gate. Runs axe-core via @axe-core/playwright
+// against a handful of high-traffic UI surfaces inside a real Electron
+// launch (the same fixture/replay harness every other e2e spec uses),
+// and asserts zero WCAG 2.0/2.1/2.2 AA violations.
+//
+// We intentionally use the actual Electron renderer (not a jsdom render
+// of individual components) so that real styling from app.css — focus
+// rings, contrast, sticky-header layout — gets audited as it actually
+// ships. The cost is one Electron launch per surface; the coverage is
+// what a screen-reader / keyboard-only operator actually encounters.
+//
+// To extend: add another entry to SURFACES below, or a separate
+// `test(...)` block that drives the renderer into a state (open a
+// dialog, switch a tab) and then calls `runAxe(window)`.
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test, type Page } from "@playwright/test";
+import { launchElectronApp } from "./fixtures/electron-app";
+
+const specDir = path.dirname(fileURLToPath(import.meta.url));
+
+const WCAG_AA_TAGS = [
+  "wcag2a",
+  "wcag2aa",
+  "wcag21a",
+  "wcag21aa",
+  "wcag22aa",
+];
+
+// Selectors waived from the axe scan, with a written reason. The
+// baseline is empty — every previously waived violation has been
+// fixed in the renderer. If a new pre-existing violation surfaces
+// (e.g. on a new surface added to the suite below) and is too
+// invasive to fix in the same PR, add an entry here so the gate
+// stays green AND surfaces the debt, then file a follow-up.
+const KNOWN_VIOLATIONS: ReadonlyArray<{
+  selector: string;
+  rule: string;
+  reason: string;
+}> = [];
+
+async function runAxe(window: Page): Promise<void> {
+  // setLegacyMode is required under Electron: the default analyze()
+  // path tries to spawn a worker page via browserContext.newPage() to
+  // audit cross-origin iframes, which Electron's CDP target doesn't
+  // support and fails with "Protocol error (Target.createTarget): Not
+  // supported". The renderer is single-origin (app://) with no
+  // cross-origin iframes, so the legacy single-context path covers
+  // everything we render anyway. See
+  // https://github.com/dequelabs/axe-core-npm/blob/develop/packages/playwright/error-handling.md
+  let builder = new AxeBuilder({ page: window })
+    .withTags(WCAG_AA_TAGS)
+    .setLegacyMode(true);
+  for (const known of KNOWN_VIOLATIONS) {
+    // exclude() removes the node from the scan entirely. Combined with
+    // the .rule mapping in KNOWN_VIOLATIONS above, this gives an
+    // auditable list of waived selectors instead of a global rule
+    // disable that would hide regressions on other surfaces.
+    builder = builder.exclude(known.selector);
+  }
+  const results = await builder.analyze();
+
+  // Surface the human-readable summary on failure so the CI log tells
+  // you which rules + selectors failed without having to download the
+  // Playwright trace artifact.
+  if (results.violations.length > 0) {
+    const summary = results.violations
+      .map((violation) => {
+        const nodes = violation.nodes
+          .map((node) => `    - ${node.target.join(" ")}`)
+          .join("\n");
+        return `  ${violation.id} (${violation.impact ?? "n/a"}): ${violation.help}\n${nodes}\n    ${violation.helpUrl}`;
+      })
+      .join("\n");
+    throw new Error(
+      `axe-core found ${results.violations.length} WCAG2 AA violation(s):\n${summary}`,
+    );
+  }
+}
+
+test.describe("desktop renderer accessibility (WCAG2 AA)", () => {
+  test("sidebar + empty-thread shell has no violations", async () => {
+    const app = await launchElectronApp({
+      fixturePath: path.resolve(specDir, "fixtures/smoke/replay.fixture.json"),
+    });
+    try {
+      // Wait for first paint of the inbox lens — the "Replay smoke
+      // thread" row is the proxy for "renderer has hydrated".
+      await expect(
+        app.window.getByRole("button", { name: /Replay smoke thread/i }).first(),
+      ).toBeVisible();
+      await runAxe(app.window);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test("open thread view has no violations", async () => {
+    const app = await launchElectronApp({
+      fixturePath: path.resolve(specDir, "fixtures/smoke/replay.fixture.json"),
+    });
+    try {
+      await app.window
+        .getByRole("button", { name: /Replay smoke thread/i })
+        .first()
+        .click();
+      await expect(
+        app.window.getByRole("heading", {
+          level: 2,
+          name: "Replay smoke thread",
+        }),
+      ).toBeVisible();
+      await expect(app.window.getByText("The replay harness is live.")).toBeVisible();
+      await runAxe(app.window);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test("settings overlay has no violations", async () => {
+    const app = await launchElectronApp({
+      fixturePath: path.resolve(specDir, "fixtures/smoke/replay.fixture.json"),
+    });
+    try {
+      await expect(
+        app.window.getByRole("button", { name: /Replay smoke thread/i }).first(),
+      ).toBeVisible();
+      await app.window.getByRole("button", { name: "Open settings" }).click();
+      // Settings sections nav is the stable signal that the overlay is
+      // hydrated (the overlay has no level-1 heading; see
+      // composer-draft-settings.spec.ts for the same anchor).
+      await expect(
+        app.window.getByRole("navigation", { name: "Settings sections" }),
+      ).toBeVisible();
+      await runAxe(app.window);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test("settings → messaging has no violations", async () => {
+    const app = await launchElectronApp({
+      fixturePath: path.resolve(specDir, "fixtures/smoke/replay.fixture.json"),
+    });
+    try {
+      await expect(
+        app.window.getByRole("button", { name: /Replay smoke thread/i }).first(),
+      ).toBeVisible();
+      await app.window.getByRole("button", { name: "Open settings" }).click();
+      await expect(
+        app.window.getByRole("navigation", { name: "Settings sections" }),
+      ).toBeVisible();
+      await app.window
+        .getByRole("navigation", { name: "Settings sections" })
+        .getByRole("button", { name: /^Messaging$/ })
+        .click();
+      await runAxe(app.window);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/apps/desktop/e2e/codex-environment-setup.spec.ts
+++ b/apps/desktop/e2e/codex-environment-setup.spec.ts
@@ -373,7 +373,7 @@ test("selected Codex environments run setup and show transcript output", async (
   });
 
   try {
-    await app.window.getByRole("button", { name: "directories" }).click();
+    await app.window.getByRole("tab", { name: "directories" }).click();
     await app.window
       .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
       .click();
@@ -637,7 +637,7 @@ test("directory launchpad opens without an environment picker when no environmen
   });
 
   try {
-    await app.window.getByRole("button", { name: "directories" }).click();
+    await app.window.getByRole("tab", { name: "directories" }).click();
     await app.window
       .getByRole("button", { name: "Open new thread launchpad for NoEnvRepo" })
       .click();

--- a/apps/desktop/e2e/composer-draft-persistence-regression.spec.ts
+++ b/apps/desktop/e2e/composer-draft-persistence-regression.spec.ts
@@ -159,7 +159,7 @@ async function createComposerDraftPersistenceFixture(): Promise<{
 }
 
 async function openDirectoryLaunchpad(app: Awaited<ReturnType<typeof launchElectronApp>>) {
-  await app.window.getByRole("button", { name: "directories" }).click();
+  await app.window.getByRole("tab", { name: "directories" }).click();
   await app.window
     .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
     .click();

--- a/apps/desktop/e2e/directory-launchpad-skills.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-skills.spec.ts
@@ -223,7 +223,7 @@ async function seedPersistedDirectoryLaunchpad(params: {
 }
 
 async function openDirectoryLaunchpad(app: Awaited<ReturnType<typeof launchElectronApp>>) {
-  await app.window.getByRole("button", { name: "directories" }).click();
+  await app.window.getByRole("tab", { name: "directories" }).click();
   await app.window
     .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
     .click();
@@ -315,7 +315,14 @@ test("directory launchpad skill autocomplete supports active keyboard selection"
 
     const listbox = app.window.getByRole("listbox", { name: "Skills" });
     await expect(listbox).toBeVisible();
-    await expect(textbox).toHaveAttribute("aria-expanded", "true");
+    // The composer follows the ARIA 1.2 textbox + autocomplete pattern:
+    // popup state is conveyed via aria-controls toggling (set to the
+    // listbox id when open, removed when closed), NOT aria-expanded —
+    // which the spec disallows on role="textbox". See the rationale
+    // in ComposerTiptapInput.tsx where the attributes are declared.
+    const listboxId = await listbox.getAttribute("id");
+    expect(listboxId).toBeTruthy();
+    await expect(textbox).toHaveAttribute("aria-controls", listboxId ?? "");
 
     const firstActiveOption = listbox.locator('[aria-selected="true"]');
     const firstActiveOptionId = await firstActiveOption.getAttribute("id");

--- a/apps/desktop/e2e/directory-launchpad-transcript-sync.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-transcript-sync.spec.ts
@@ -267,7 +267,7 @@ test("directory launchpad rereads the created thread after completion when the f
   });
 
   try {
-    await app.window.getByRole("button", { name: "directories" }).click();
+    await app.window.getByRole("tab", { name: "directories" }).click();
     await app.window
       .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
       .click();

--- a/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
@@ -653,7 +653,7 @@ test("directory launchpad can switch from local checkout to a new worktree", asy
   });
 
   try {
-    await app.window.getByRole("button", { name: "directories" }).click();
+    await app.window.getByRole("tab", { name: "directories" }).click();
     await app.window
       .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
       .click();
@@ -698,7 +698,7 @@ test("directory launchpad does not show workspace application buttons before a t
   });
 
   try {
-    await app.window.getByRole("button", { name: "directories" }).click();
+    await app.window.getByRole("tab", { name: "directories" }).click();
     await app.window
       .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
       .click();
@@ -804,7 +804,7 @@ test("directory launchpad starts a local thread from an unborn git HEAD", async 
   });
 
   try {
-    await app.window.getByRole("button", { name: "directories" }).click();
+    await app.window.getByRole("tab", { name: "directories" }).click();
     await app.window
       .getByRole("button", { name: "Open new thread launchpad for PwrTester" })
       .click();
@@ -855,7 +855,7 @@ test("opening a directory launchpad persists directory identity for future draft
   });
 
   try {
-    await app.window.getByRole("button", { name: "directories" }).click();
+    await app.window.getByRole("tab", { name: "directories" }).click();
     await app.window
       .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
       .click();
@@ -895,7 +895,7 @@ test("directory launchpad draft save does not leak the directory key into projec
     const repoDir = path.join(rootDir, "FixtureRepo");
     const directoryKey = `directory:${repoDir}`;
 
-    await app.window.getByRole("button", { name: "directories" }).click();
+    await app.window.getByRole("tab", { name: "directories" }).click();
     await app.window
       .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
       .click();
@@ -952,7 +952,7 @@ test("directory launchpad repairs stale drafts that saved the internal directory
       });
     }, directoryKey);
 
-    await app.window.getByRole("button", { name: "directories" }).click();
+    await app.window.getByRole("tab", { name: "directories" }).click();
     await app.window
       .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
       .click();
@@ -987,7 +987,7 @@ test("directory launchpad keeps full access as the sticky default after user cha
   });
 
   try {
-    await app.window.getByRole("button", { name: "directories" }).click();
+    await app.window.getByRole("tab", { name: "directories" }).click();
     await app.window
       .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
       .click();
@@ -1033,7 +1033,7 @@ test("directory launchpad keeps new worktree as the sticky default after startin
   });
 
   try {
-    await app.window.getByRole("button", { name: "directories" }).click();
+    await app.window.getByRole("tab", { name: "directories" }).click();
     await app.window
       .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
       .click();
@@ -1183,7 +1183,7 @@ test("directory launchpad does not duplicate a materialized worktree thread unde
   });
 
   try {
-    await app.window.getByRole("button", { name: "directories" }).click();
+    await app.window.getByRole("tab", { name: "directories" }).click();
     await app.window
       .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
       .click();
@@ -1207,7 +1207,7 @@ test("directory launchpad does not duplicate a materialized worktree thread unde
       }),
     ).toBeVisible();
 
-    await app.window.getByRole("button", { name: "directories" }).click();
+    await app.window.getByRole("tab", { name: "directories" }).click();
     await expect(app.window.locator(".directory-row").filter({
       has: app.window.getByText("FixtureRepo", { exact: true }),
     })).toHaveCount(1);
@@ -1227,7 +1227,7 @@ test("directory launchpad keeps Tiptap Markdown focus and fenced-code formatting
   });
 
   try {
-    await app.window.getByRole("button", { name: "directories" }).click();
+    await app.window.getByRole("tab", { name: "directories" }).click();
     await app.window
       .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
       .click();
@@ -1273,7 +1273,7 @@ test("directory launchpad applies new worktree sticky defaults to stale empty dr
   });
 
   try {
-    await app.window.getByRole("button", { name: "directories" }).click();
+    await app.window.getByRole("tab", { name: "directories" }).click();
 
     await app.window
       .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })

--- a/apps/desktop/e2e/directory-parity.spec.ts
+++ b/apps/desktop/e2e/directory-parity.spec.ts
@@ -16,7 +16,7 @@ test("shows only the Codex Desktop search-product threads in directory browse mo
   try {
     const sidebar = app.window.locator(".sidebar");
 
-    await app.window.getByRole("button", { name: "directories" }).click();
+    await app.window.getByRole("tab", { name: "directories" }).click();
 
     await expect(sidebar.getByText("search-product ProjMgr")).toBeVisible();
     await expect(sidebar.getByText("Plan Slidev theme extraction")).toBeVisible();

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -67,6 +67,7 @@
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.3",
     "@electron/asar": "^4.2.0",
     "@playwright/test": "^1.55.0",
     "@testing-library/jest-dom": "^6.9.1",
@@ -75,6 +76,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.2.0",
+    "axe-core": "^4.11.4",
     "electron": "^41.2.1",
     "electron-builder": "^26.8.1",
     "electron-vite": "^5.0.0",

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -106,6 +106,11 @@ function DesktopAppShell(props: {
   settings: DesktopSettingsState;
 }) {
   const [sidebarWidth, setSidebarWidth] = useState(408);
+  // Hardcoded sidebar resize bounds — mirrored in resizeSidebar() below.
+  // Exposed as constants so both the setter and the aria-valuemin/max
+  // attributes on the resize handle stay in sync.
+  const sidebarMinWidth = 280;
+  const sidebarMaxWidth = 560;
   const [mainView, setMainView] = useState<"thread" | "settings">("thread");
   // Initial section for SettingsScreen — non-undefined when navigation
   // came from a deep-link to a specific section. Resets when the user
@@ -328,7 +333,7 @@ function DesktopAppShell(props: {
   } satisfies ThreadViewProps;
 
   const resizeSidebar = (nextWidth: number): void => {
-    setSidebarWidth(Math.min(560, Math.max(280, nextWidth)));
+    setSidebarWidth(Math.min(sidebarMaxWidth, Math.max(sidebarMinWidth, nextWidth)));
   };
 
   const startSidebarResize = (event: PointerEvent<HTMLElement>): void => {
@@ -406,6 +411,9 @@ function DesktopAppShell(props: {
         }}
         onResizeStart={startSidebarResize}
         onResizeByKeyboard={(delta) => resizeSidebar(sidebarWidth + delta)}
+        sidebarWidth={sidebarWidth}
+        sidebarMinWidth={sidebarMinWidth}
+        sidebarMaxWidth={sidebarMaxWidth}
       />
 
       <main className="app-main">

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -638,9 +638,9 @@ describe("App", () => {
 
     expect(screen.getByRole("complementary", { name: "Threads" })).toBeInTheDocument();
     expect(screen.queryByRole("heading", { level: 1, name: "Threads" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "inbox" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("tab", { name: "inbox" })).not.toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Created" })
+      screen.getByRole("tab", { name: "Created" })
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "New thread" })).toBeInTheDocument();
     expect(

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -1172,9 +1172,23 @@ export const ComposerTiptapInput = forwardRef<
     content: initialContent,
     editorProps: {
       attributes: {
-        "aria-activedescendant": props.ariaActiveDescendant ?? "",
-        "aria-controls": props.ariaControls ?? "",
-        "aria-expanded": String(Boolean(props.ariaExpanded)),
+        // ARIA 1.2 textbox + listbox autocomplete pattern. We
+        // deliberately do NOT set aria-expanded here — that attribute
+        // is invalid on role="textbox" (per the spec, it belongs on
+        // role="combobox"), and axe-core flags it under
+        // aria-allowed-attr. The popup's open/closed state is still
+        // conveyed via aria-controls being present (and pointing at
+        // the visible listbox) when autocomplete is open, and absent
+        // otherwise; the layout effect below mirrors that.
+        // aria-controls / aria-activedescendant are only set when
+        // truthy — an empty IDREF is itself an axe violation.
+        ...(props.ariaActiveDescendant
+          ? { "aria-activedescendant": props.ariaActiveDescendant }
+          : {}),
+        ...(props.ariaControls
+          ? { "aria-controls": props.ariaControls }
+          : {}),
+        "aria-autocomplete": "list",
         "aria-label": props.label,
         class: `composer-tiptap-input__editor${props.disabled ? " is-disabled" : ""}`,
         "data-placeholder": props.placeholder,
@@ -1405,7 +1419,12 @@ export const ComposerTiptapInput = forwardRef<
     editor.setEditable(!props.disabled);
     editor.view.dom.setAttribute("id", props.id);
     editor.view.dom.setAttribute("aria-label", props.label);
-    editor.view.dom.setAttribute("aria-expanded", String(Boolean(props.ariaExpanded)));
+    // aria-expanded is deliberately NOT set on the textbox role — see
+    // the editorProps.attributes block above for the rationale. The
+    // ariaExpanded prop is still consumed via the aria-controls /
+    // aria-activedescendant mirroring below, which is what conveys
+    // popup state to screen readers under the ARIA 1.2 textbox +
+    // autocomplete pattern.
     if (props.ariaActiveDescendant) {
       editor.view.dom.setAttribute("aria-activedescendant", props.ariaActiveDescendant);
     } else {

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -121,6 +121,17 @@ type SidebarProps = {
   ) => Promise<void>;
   onResizeStart?: (event: PointerEvent<HTMLElement>) => void;
   onResizeByKeyboard?: (delta: number) => void;
+  /**
+   * Current sidebar width and clamp range, plumbed in so the resize
+   * handle can expose aria-valuenow / aria-valuemin / aria-valuemax —
+   * required by axe-core for focusable role="separator". All three are
+   * optional so older callers (and unit tests that mount Sidebar in
+   * isolation) keep compiling; the handle silently omits the aria-value*
+   * attributes when they're absent.
+   */
+  sidebarWidth?: number;
+  sidebarMinWidth?: number;
+  sidebarMaxWidth?: number;
 };
 
 const browseModeLabels = {
@@ -587,6 +598,9 @@ export function Sidebar(props: SidebarProps) {
       <div
         aria-label="Resize thread sidebar"
         aria-orientation="vertical"
+        aria-valuenow={props.sidebarWidth}
+        aria-valuemin={props.sidebarMinWidth}
+        aria-valuemax={props.sidebarMaxWidth}
         className="sidebar__resize-handle"
         role="separator"
         tabIndex={0}
@@ -714,7 +728,13 @@ export function Sidebar(props: SidebarProps) {
           {(["inbox", "recents", "directories"] as const).map((mode) => (
             <button
               key={mode}
-              aria-pressed={props.browseMode === mode}
+              // role="tab" + aria-selected is what makes the tablist a
+              // valid ARIA composite. Keyboard nav is unchanged (Tab still
+              // cycles through every button) since browsers don't auto-wire
+              // arrow-key navigation from role alone — adding role here only
+              // changes how screen readers announce the widget.
+              role="tab"
+              aria-selected={props.browseMode === mode}
               className={`lens-switch__button${
                 props.browseMode === mode ? " is-active" : ""
               }`}

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -185,16 +185,16 @@ describe("Sidebar", () => {
     expect(onOpenSettings).toHaveBeenCalledOnce();
     expect(screen.queryByRole("heading", { level: 2, name: "Browse" })).not.toBeInTheDocument();
     expect(screen.getByRole("region", { name: "Thread browser" })).toBeInTheDocument();
-    const lensButtons = within(
+    const lensTabs = within(
       screen.getByRole("tablist", { name: "Thread lenses" })
-    ).getAllByRole("button");
-    expect(lensButtons.map((button) => button.textContent)).toEqual([
+    ).getAllByRole("tab");
+    expect(lensTabs.map((tab) => tab.textContent)).toEqual([
       "Updated",
       "Created",
       "Directories",
     ]);
-    expect(screen.getByRole("button", { name: "Directories" })).toHaveAttribute(
-      "aria-pressed",
+    expect(screen.getByRole("tab", { name: "Directories" })).toHaveAttribute(
+      "aria-selected",
       "true"
     );
     expect(screen.getAllByText("PwrAgent").length).toBeGreaterThan(0);
@@ -730,17 +730,17 @@ describe("Sidebar", () => {
       />
     );
 
-    expect(screen.getByRole("button", { name: "Updated" })).toHaveAttribute(
-      "aria-pressed",
+    expect(screen.getByRole("tab", { name: "Updated" })).toHaveAttribute(
+      "aria-selected",
       "true",
     );
-    expect(screen.getByRole("button", { name: "Created" })).toHaveAttribute(
-      "aria-pressed",
+    expect(screen.getByRole("tab", { name: "Created" })).toHaveAttribute(
+      "aria-selected",
       "false",
     );
     expect(screen.getByRole("button", { name: /Updated thread/i })).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Created" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Created" }));
 
     expect(onBrowseModeChange).toHaveBeenCalledWith("recents");
   });

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -701,12 +701,22 @@ export function TranscriptList(props: TranscriptListProps) {
           syncScrollState({ preserveGlueOnResize: true });
         }}
       >
-        <div ref={scrollContentRef} className="transcript-list__content">
+        {/*
+          role="presentation" on the inner scroll wrapper removes it
+          from the accessibility tree, letting the role="listitem"
+          entries below appear as direct owned children of the
+          role="list" scroll container above — which is what axe's
+          aria-required-children rule looks for. Without this, the
+          inner wrapper sits between the list role and its items in
+          the a11y tree and the rule fails.
+        */}
+        <div ref={scrollContentRef} className="transcript-list__content" role="presentation">
           {transcriptRenderItems.map((item) => {
-            if (item.type === "workPhaseGroup") {
-              return (
+            const entryKey =
+              item.type === "workPhaseGroup" ? item.id : item.entry.id;
+            const body =
+              item.type === "workPhaseGroup" ? (
                 <TranscriptWorkPhaseGroup
-                  key={item.id}
                   applications={props.applications}
                   collapsible={item.collapsible}
                   directoryPaths={props.directoryPaths}
@@ -720,36 +730,34 @@ export function TranscriptList(props: TranscriptListProps) {
                     toggleCommentaryGroup(item.id);
                   }}
                 />
+              ) : item.entry.type === "activity" ? (
+                <TranscriptActivity entry={item.entry} />
+              ) : item.entry.type === "plan" ? (
+                <TranscriptPlan
+                  applications={props.applications}
+                  desktopApi={props.desktopApi}
+                  entry={item.entry}
+                />
+              ) : item.entry.type === "review" ? (
+                <TranscriptReview
+                  applications={props.applications}
+                  directoryPaths={props.directoryPaths}
+                  desktopApi={props.desktopApi}
+                  entry={item.entry}
+                />
+              ) : (
+                <TranscriptMessage
+                  applications={props.applications}
+                  desktopApi={props.desktopApi}
+                  message={item.entry}
+                  skills={skills}
+                  onOpenImage={props.onOpenImage}
+                />
               );
-            }
-
-            const entry = item.entry;
-            return entry.type === "activity" ? (
-              <TranscriptActivity key={entry.id} entry={entry} />
-            ) : entry.type === "plan" ? (
-              <TranscriptPlan
-                key={entry.id}
-                applications={props.applications}
-                desktopApi={props.desktopApi}
-                entry={entry}
-              />
-            ) : entry.type === "review" ? (
-              <TranscriptReview
-                key={entry.id}
-                applications={props.applications}
-                directoryPaths={props.directoryPaths}
-                desktopApi={props.desktopApi}
-                entry={entry}
-              />
-            ) : (
-              <TranscriptMessage
-                key={entry.id}
-                applications={props.applications}
-                desktopApi={props.desktopApi}
-                message={entry}
-                skills={skills}
-                onOpenImage={props.onOpenImage}
-              />
+            return (
+              <div key={entryKey} role="listitem">
+                {body}
+              </div>
             );
           })}
           {props.pendingStatusText ? (

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -755,7 +755,7 @@ export function TranscriptList(props: TranscriptListProps) {
                 />
               );
             return (
-              <div key={entryKey} role="listitem">
+              <div key={entryKey} className="transcript-list__item" role="listitem">
                 {body}
               </div>
             );

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5558,6 +5558,20 @@ textarea,
   margin-right: auto;
 }
 
+/*
+  Wrapper around each transcript entry that exists purely to carry
+  role="listitem" for the role="list" on the scroll container (see
+  TranscriptList.tsx). `display: contents` skips the wrapper for
+  layout, so .transcript-message + friends remain direct flex children
+  of .transcript-list__content and keep their align-self docking
+  (user → right, assistant → left). Modern Chromium preserves the
+  role in the a11y tree under display: contents, so axe's
+  aria-required-children rule is still satisfied.
+*/
+.transcript-list__item {
+  display: contents;
+}
+
 .transcript-list__scroll-bottom {
   position: absolute;
   left: 50%;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1752,8 +1752,8 @@ packages:
   brace-expansion@2.1.0:
     resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   browserslist@4.28.2:
@@ -5232,7 +5232,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -6624,7 +6624,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimatch@3.1.5:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   protobufjs: 7.5.8
   ws: 8.20.1
 
-pnpmfileChecksum: sha256-l+QzxfS11BtK+deH01/WT+xIHHSpNZ4LVvVbmeGnNLU=
+pnpmfileChecksum: sha256-ENVI4WvTe5sygYLw830xNJB8CimBQgr6EM0Oi3TR7os=
 
 importers:
 
@@ -112,6 +112,9 @@ importers:
         specifier: ^4.0.1
         version: 4.0.1
     devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.11.3
+        version: 4.11.3(playwright-core@1.59.1)
       '@electron/asar':
         specifier: ^4.2.0
         version: 4.2.0
@@ -136,6 +139,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^5.2.0
         version: 5.2.0(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+      axe-core:
+        specifier: ^4.11.4
+        version: 4.11.4
       electron:
         specifier: ^41.2.1
         version: 41.2.1
@@ -307,6 +313,11 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@axe-core/playwright@4.11.3':
+    resolution: {integrity: sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -1693,6 +1704,10 @@ packages:
     resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
     engines: {node: '>= 4.0.0'}
 
+  axe-core@4.11.4:
+    resolution: {integrity: sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==}
+    engines: {node: '>=4'}
+
   axios@1.16.0:
     resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
 
@@ -1737,8 +1752,8 @@ packages:
   brace-expansion@2.1.0:
     resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
 
   browserslist@4.28.2:
@@ -3859,6 +3874,11 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
+  '@axe-core/playwright@4.11.3(playwright-core@1.59.1)':
+    dependencies:
+      axe-core: 4.11.4
+      playwright-core: 1.59.1
+
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -5161,6 +5181,8 @@ snapshots:
 
   at-least-node@1.0.0: {}
 
+  axe-core@4.11.4: {}
+
   axios@1.16.0:
     dependencies:
       follow-redirects: 1.16.0
@@ -5210,7 +5232,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
 
@@ -6602,7 +6624,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.5
 
   minimatch@3.1.5:
     dependencies:


### PR DESCRIPTION
## Summary

- New [`apps/desktop/e2e/a11y.spec.ts`](apps/desktop/e2e/a11y.spec.ts) launches Electron under the existing replay-fixture harness and runs `@axe-core/playwright`'s `AxeBuilder` against four high-traffic surfaces with WCAG 2.0 / 2.1 / 2.2 Level AA tags. CI picks it up automatically via the existing `desktop-e2e` job — no workflow changes.
- The initial run surfaced four real pre-existing WCAG2 AA violations; **all four are fixed in this PR** so the gate ships with an empty `KNOWN_VIOLATIONS` baseline.
- Narrowed `.pnpmfile.cjs` to only scan `devDependencies` on first-party packages so `@axe-core/playwright` can resolve. The `fetchers.git` block (the real install-time defense) is unchanged.

## Surfaces audited

1. Sidebar + empty-thread shell
2. Open thread view
3. Settings overlay (default General section)
4. Settings → Messaging

Each one is a separate `test(...)` block that drives the renderer into the state and calls `runAxe(window)`. Adding more is just another block. `setLegacyMode(true)` is required under Electron — the default `AxeBuilder.analyze()` opens a worker page via `browserContext.newPage()` which Electron's CDP target rejects; the renderer is single-origin so the legacy single-context path covers everything we ship. Rationale documented inline + in [apps/desktop/AGENTS.md](apps/desktop/AGENTS.md).

## Renderer fixes (4)

| # | File | Issue | Fix | User-visible behavior change |
|---|---|---|---|---|
| 1 | [`ComposerTiptapInput.tsx`](apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx) | `aria-expanded` on `role="textbox"` is invalid per ARIA spec | Switched to the ARIA 1.2 textbox + autocomplete pattern: dropped `aria-expanded`, added `aria-autocomplete="list"`, made `aria-controls` / `aria-activedescendant` conditional (empty IDREFs are themselves violations) | None for sighted/keyboard users; SR users get correct popup-state announcements via `aria-controls` toggling |
| 2 | [`Sidebar.tsx`](apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx) + [`App.tsx`](apps/desktop/src/renderer/src/App.tsx) | Focusable `role="separator"` missing `aria-valuenow/min/max` | Plumbed `sidebarWidth` / `sidebarMinWidth` / `sidebarMaxWidth` as props on `Sidebar`; resize handle exposes live values | None visually; SR users hear the current width when they tab onto it |
| 3 | [`Sidebar.tsx`](apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx) | `role="tablist"` requires `role="tab"` children | Added `role="tab"` + `aria-selected` to lens-switch buttons (replacing `aria-pressed`). Updated 2 tests to `getByRole("tab", ...)` / `aria-selected` assertions | Keyboard nav unchanged (browsers don't auto-wire arrow nav from role alone); SR users hear "tab, selected" instead of "button, pressed" |
| 4 | [`TranscriptList.tsx`](apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx) | `role="list"` requires `role="listitem"` descendants; the intermediate `.transcript-list__content` wrapper interrupted the a11y tree | Marked the wrapper `role="presentation"` (flattens it in the a11y tree); wrapped each entry render in `<div role="listitem">`. `getByRole("list")` still finds the scroll container, so ~20 transcript tests are unchanged | None visually; SR users get "list with N items" announcements when navigating |

## `.pnpmfile.cjs` change

`@axe-core/playwright` declares `dequelabs/axe-test-fixtures` (a real Deque-maintained cross-SDK test fixtures repo) as its **own** `devDependency`. pnpm never installs transitive devDeps, but the existing `readPackage` hook scans *every* package's `devDependencies` and rejects on any git spec — false positive.

Narrowed `readPackage` to only scan `devDependencies` on first-party packages (`pwragent-workspace` + `@pwragent/*`). Defense-in-depth is preserved:

1. `dependencies` / `peerDependencies` / `optionalDependencies` are still scanned on every package (these are the fields pnpm actually resolves).
2. The `fetchers.git` block still refuses any actual git clone at install time — the real enforcement.
3. The `onlyBuiltDependencies` allowlist in [`pnpm-workspace.yaml`](pnpm-workspace.yaml) only permits `better-sqlite3`, `electron`, and `esbuild` to run install scripts, so even a fork-commit / typosquat of any axe-core package couldn't run code at install time.

## Test plan

- [x] `pnpm --filter @pwragent/desktop exec playwright test -c playwright.config.ts e2e/a11y.spec.ts` → 4/4 passed, zero violations, zero waivers
- [x] `pnpm test` (full workspace vitest suite) → 2281 passed / 3 skipped
- [x] `pnpm --filter @pwragent/desktop typecheck` → clean
- [x] `pnpm lint:boundaries` → clean (1227 modules, 1858 deps)
- [x] Spot-checked E2Es for regressions: `composer-draft-settings`, `skill-autocomplete-interactions`, `smoke` → 6/6 passed
- [ ] CI desktop-e2e job picks up the new spec under xvfb

🤖 Generated with [Claude Code](https://claude.com/claude-code)