### PR TITLE
feat(desktop,docs-site): self-host Geist + Geist Mono for suite typography

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -68,6 +68,8 @@
   },
   "devDependencies": {
     "@electron/asar": "^4.2.0",
+    "@fontsource-variable/geist": "5.2.8",
+    "@fontsource-variable/geist-mono": "5.2.7",
     "@playwright/test": "^1.55.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -3,6 +3,11 @@ import ReactDOM from "react-dom/client";
 import { App } from "./App";
 import { RendererErrorBoundary } from "./features/diagnostics/RendererErrorBoundary";
 import { installGlobalRendererErrorHandlers } from "./lib/renderer-error-reporting";
+// Self-hosted Geist + Geist Mono — bundled into the renderer's dist so the
+// app never falls back to SF Pro Text on machines without Geist installed.
+// Variable-font builds: one .woff2 each, all weights / axes available.
+import "@fontsource-variable/geist";
+import "@fontsource-variable/geist-mono";
 import "./styles/app.css";
 
 installGlobalRendererErrorHandlers();

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1,7 +1,11 @@
 :root {
   color-scheme: dark;
-  font-family: "Geist", "IBM Plex Sans", "SF Pro Text", "Inter", system-ui, sans-serif;
-  --font-mono: "IBM Plex Mono", "SFMono-Regular", "SF Mono", Consolas, monospace;
+  /* Geist + Geist Mono are self-hosted via @fontsource-variable/* (imported
+     in renderer entry main.tsx). System fonts remain as fallbacks during the
+     ~1-frame load window and for any future surface that bypasses the
+     bundled CSS. Geist is the suite-wide PwrDrvr typeface — matches PwrSnap. */
+  font-family: "Geist Variable", "Geist", "SF Pro Text", "Inter", system-ui, sans-serif;
+  --font-mono: "Geist Mono Variable", "Geist Mono", "IBM Plex Mono", "SFMono-Regular", "SF Mono", Consolas, monospace;
   --bg-app: #000000;
   --bg-sidebar: #050505;
   --bg-panel: #0a0a0a;

--- a/apps/desktop/src/renderer/src/vite-env.d.ts
+++ b/apps/desktop/src/renderer/src/vite-env.d.ts
@@ -1,5 +1,12 @@
 declare module "*.css";
 
+// Fontsource CSS-only packages — bare side-effect imports register
+// @font-face declarations and bundle the .woff2 files via Vite's CSS
+// pipeline. There are no runtime exports, so a side-effect-only module
+// shim is the right shape.
+declare module "@fontsource-variable/geist";
+declare module "@fontsource-variable/geist-mono";
+
 declare module "*.svg" {
   const url: string;
   export default url;

--- a/docs-site/_layouts/default.html
+++ b/docs-site/_layouts/default.html
@@ -37,8 +37,9 @@
   <link rel="icon" type="image/png" sizes="32x32" href="{{ '/assets/favicon-32.png' | relative_url }}">
   <link rel="icon" type="image/png" sizes="16x16" href="{{ '/assets/favicon-16.png' | relative_url }}">
   <link rel="apple-touch-icon" sizes="180x180" href="{{ '/assets/apple-touch-icon.png' | relative_url }}">
-  <link rel="preconnect" href="https://rsms.me/">
-  <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700;800;900&family=Geist+Mono:wght@400;500;600;700&display=swap">
   <link rel="stylesheet" href="{{ '/assets/css/site.css' | relative_url }}">
 </head>
 <body>

--- a/docs-site/assets/css/site.css
+++ b/docs-site/assets/css/site.css
@@ -36,17 +36,11 @@
   --status-suspended: #6b6660;
   --status-error: #c45a3a;
 
-  --font-sans: "Inter", "Geist", "IBM Plex Sans", "SF Pro Text", system-ui, sans-serif;
-  --font-mono: "IBM Plex Mono", SFMono-Regular, "SF Mono", Consolas, monospace;
+  --font-sans: "Geist", "SF Pro Text", "Inter", "IBM Plex Sans", system-ui, sans-serif;
+  --font-mono: "Geist Mono", "IBM Plex Mono", SFMono-Regular, "SF Mono", Consolas, monospace;
 
   --content-max: 70ch;
   --shell-max: 104ch;
-}
-
-@supports (font-variation-settings: normal) {
-  :root {
-    --font-sans: "InterVariable", "Inter", "Geist", "IBM Plex Sans", "SF Pro Text", system-ui, sans-serif;
-  }
 }
 
 * {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,12 @@ importers:
       '@electron/asar':
         specifier: ^4.2.0
         version: 4.2.0
+      '@fontsource-variable/geist':
+        specifier: 5.2.8
+        version: 5.2.8
+      '@fontsource-variable/geist-mono':
+        specifier: 5.2.7
+        version: 5.2.7
       '@playwright/test':
         specifier: ^1.55.0
         version: 1.59.1
@@ -854,6 +860,12 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@fontsource-variable/geist-mono@5.2.7':
+    resolution: {integrity: sha512-ZKlZ5sjtalb2TwXKs400mAGDlt/+2ENLNySPx0wTz3bP3mWARCsUW+rpxzZc7e05d2qGch70pItt3K4qttbIYA==}
+
+  '@fontsource-variable/geist@5.2.8':
+    resolution: {integrity: sha512-cJ6m9e+8MQ5dCYJsLylfZrgBh6KkG4bOLckB35Tr9J/EqdkEM6QllH5PxqP1dhTvFup+HtMRPuz9xOjxXJggxw==}
 
   '@grammyjs/types@3.26.0':
     resolution: {integrity: sha512-jlnyfxfev/2o68HlvAGRocAXgdPPX5QabG7jZlbqC2r9DZyWBfzTlg+nu3O3Fy4EhgLWu28hZ/8wr7DsNamP9A==}
@@ -4344,6 +4356,10 @@ snapshots:
 
   '@floating-ui/utils@0.2.11':
     optional: true
+
+  '@fontsource-variable/geist-mono@5.2.7': {}
+
+  '@fontsource-variable/geist@5.2.8': {}
 
   '@grammyjs/types@3.26.0': {}
 


### PR DESCRIPTION
## Summary

Converge PwrAgent on Geist + Geist Mono so the suite (PwrSnap, PwrAgent app, PwrAgent docs) renders in one typeface. Pairs with the matching pwragent.ai marketing-site change (not yet pushed — gated on this PR's review).

## What the audit turned up

PwrAgent's renderer was already declaring `"Geist"` as its primary `font-family` in [apps/desktop/src/renderer/src/styles/app.css](apps/desktop/src/renderer/src/styles/app.css) — **but never loaded the font.** No `@fontsource`, no `<link>`, no `@font-face`. On any machine without Geist system-installed (which is most machines), it silently fell back to SF Pro Text via the third fallback slot. Mono had the same shape — `IBM Plex Mono` was the declared primary but was also never loaded.

The docs site at `docs/_layouts/default.html` was the only PwrAgent surface actually loading Inter (from rsms.me).

So the swap is: **make Geist real in the app**, and **swap docs from Inter to Geist**.

## Changes

**Desktop app**
- Add `@fontsource-variable/geist@5.2.8` + `@fontsource-variable/geist-mono@5.2.7` as devDeps. Pinned to latest *mature* versions — the just-published 5.2.9 / 5.2.8 trip the repo's \`min-release-age=7\` pnpm policy.
- Import both in `main.tsx` before `app.css` so the bundled \`.woff2\` files are registered before first paint.
- Update `app.css` font stacks to lead with `"Geist Variable"` / `"Geist Mono Variable"` (the family name Fontsource registers for the variable build), then `"Geist"` (system-installed), then prior fallbacks.
- Add module shims for the two side-effect imports in `vite-env.d.ts` — TS strict won't accept a side-effect import without a declaration.

**Docs site**
- Drop the `<link rel="stylesheet" href="https://rsms.me/inter/inter.css">` for the matching Geist + Geist Mono pair from Google Fonts.
- Reorder `--font-sans` / `--font-mono` in `assets/css/site.css` to prefer Geist. The `@supports (font-variation-settings: normal)` override block is no longer needed — Geist's Google Fonts delivery handles variable axes natively.

## Verification

- `pnpm --filter @pwragent/desktop build` ✅ — 6 Geist \`.woff2\` files (latin / latin-ext / cyrillic for both sans + mono, ~116 KB total) get fingerprinted into \`out/renderer/assets/\`.
- `pnpm --filter @pwragent/desktop typecheck` ✅.

## Out of scope (follow-up PR)

Screenshot fixtures committed under \`apps/desktop/e2e/fixtures/\` and any rendered images in the docs site were captured against SF Pro Text / Inter. Per the brief, regeneration ships separately — \`pnpm screenshot:readme\` + \`pnpm screenshot:docs-site\` after this lands.

## Test plan

- [ ] \`pnpm --filter @pwragent/desktop dev\` — launch and visually confirm the renderer now uses Geist (cleanest tell: the lowercase \`g\` and digit forms).
- [ ] Confirm mono surfaces (thread IDs, command lines, code blocks in markdown) now render in Geist Mono.
- [ ] Open the docs site locally (\`cd docs-site && bundle exec jekyll serve\`) and visually confirm body copy is Geist.
- [ ] Compare side-by-side against a built PwrSnap renderer — they should now read as the same product family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)