### PR TITLE
fix(desktop): pick update-channel versions by semver, not publish order

### DIFF
--- a/apps/desktop/src/main/__tests__/auto-updater.test.ts
+++ b/apps/desktop/src/main/__tests__/auto-updater.test.ts
@@ -126,3 +126,76 @@ describe("auto updater", () => {
     expect(windowSendMock).not.toHaveBeenCalled();
   });
 });
+
+describe("compareSemver", () => {
+  it("orders by major/minor/patch", async () => {
+    const { compareSemver } = await import("../auto-updater");
+    expect(compareSemver("v2.0.0", "v1.9.9")).toBeGreaterThan(0);
+    expect(compareSemver("v1.2.0", "v1.10.0")).toBeLessThan(0);
+    expect(compareSemver("v1.2.3", "v1.2.3")).toBe(0);
+  });
+
+  it("treats stable as higher precedence than prerelease at the same core", async () => {
+    const { compareSemver } = await import("../auto-updater");
+    expect(compareSemver("v1.0.0", "v1.0.0-beta.8")).toBeGreaterThan(0);
+    expect(compareSemver("v1.0.0-beta.8", "v1.0.0")).toBeLessThan(0);
+  });
+
+  it("orders numeric prerelease identifiers numerically, not lexically", async () => {
+    const { compareSemver } = await import("../auto-updater");
+    expect(compareSemver("v1.0.0-beta.9", "v1.0.0-beta.10")).toBeLessThan(0);
+    expect(compareSemver("v1.0.0-beta.2", "v1.0.0-beta.1")).toBeGreaterThan(0);
+  });
+
+  it("sorts unparseable tags below valid versions", async () => {
+    const { compareSemver } = await import("../auto-updater");
+    expect(compareSemver("not-a-version", "v1.0.0-beta.1")).toBeLessThan(0);
+    expect(compareSemver("v0.0.1", "garbage")).toBeGreaterThan(0);
+  });
+});
+
+describe("selectChannelReleases", () => {
+  it("picks the highest-precedence stable for latest and never lets prerelease go backwards", async () => {
+    const { selectChannelReleases } = await import("../auto-updater");
+    // GitHub returns releases newest-first by publish date. Here a newer
+    // stable (beta.8) was promoted after older beta-tagged prereleases were
+    // published — exactly the production scenario behind this bug.
+    const releases = [
+      { tag_name: "v1.0.0-beta.8", prerelease: false, draft: false },
+      { tag_name: "v1.0.0-beta.7", prerelease: true, draft: false },
+      { tag_name: "v1.0.0-beta.2", prerelease: true, draft: false },
+      { tag_name: "v1.0.0-beta.1", prerelease: true, draft: false },
+    ];
+    const { latest, prerelease } = selectChannelReleases(releases);
+    expect(latest?.tag_name).toBe("v1.0.0-beta.8");
+    // The prerelease slot must mirror the latest stable because no published
+    // prerelease has higher precedence than v1.0.0-beta.8.
+    expect(prerelease?.tag_name).toBe("v1.0.0-beta.8");
+  });
+
+  it("prefers a higher prerelease over latest stable when one exists", async () => {
+    const { selectChannelReleases } = await import("../auto-updater");
+    const releases = [
+      { tag_name: "v1.0.0-beta.9", prerelease: true, draft: false },
+      { tag_name: "v1.0.0-beta.8", prerelease: false, draft: false },
+      { tag_name: "v1.0.0-beta.1", prerelease: true, draft: false },
+    ];
+    const { latest, prerelease } = selectChannelReleases(releases);
+    expect(latest?.tag_name).toBe("v1.0.0-beta.8");
+    expect(prerelease?.tag_name).toBe("v1.0.0-beta.9");
+  });
+
+  it("ignores drafts in both channels", async () => {
+    const { selectChannelReleases } = await import("../auto-updater");
+    const releases = [
+      { tag_name: "v2.0.0", prerelease: false, draft: true },
+      { tag_name: "v1.5.0", prerelease: false, draft: false },
+      { tag_name: "v1.6.0-rc.1", prerelease: true, draft: true },
+      { tag_name: "v1.5.1-rc.1", prerelease: true, draft: false },
+    ];
+    const { latest, prerelease } = selectChannelReleases(releases);
+    expect(latest?.tag_name).toBe("v1.5.0");
+    // v1.5.1-rc.1 > v1.5.0 by core, and stable rule doesn't override that.
+    expect(prerelease?.tag_name).toBe("v1.5.1-rc.1");
+  });
+});

--- a/apps/desktop/src/main/auto-updater.ts
+++ b/apps/desktop/src/main/auto-updater.ts
@@ -186,6 +186,82 @@ function releaseInfoFromGitHubRelease(
   };
 }
 
+type ParsedSemver = {
+  core: [number, number, number];
+  pre: Array<string | number>;
+};
+
+function parseSemver(tag: string | undefined): ParsedSemver | undefined {
+  if (!tag) return undefined;
+  const trimmed = tag.trim().replace(/^v/i, "");
+  const match = trimmed.match(
+    /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/,
+  );
+  if (!match) return undefined;
+  const [, maj, min, patch, pre] = match;
+  return {
+    core: [Number(maj), Number(min), Number(patch)],
+    pre: pre
+      ? pre.split(".").map((part) => (/^\d+$/.test(part) ? Number(part) : part))
+      : [],
+  };
+}
+
+// Semver 2.0.0 precedence. Returns positive if a > b, negative if a < b.
+// Unparseable tags sort below any valid version so they cannot win a "highest"
+// selection over a real release.
+export function compareSemver(a: string | undefined, b: string | undefined): number {
+  const pa = parseSemver(a);
+  const pb = parseSemver(b);
+  if (!pa && !pb) return 0;
+  if (!pa) return -1;
+  if (!pb) return 1;
+  for (let i = 0; i < 3; i++) {
+    if (pa.core[i] !== pb.core[i]) return pa.core[i] - pb.core[i];
+  }
+  if (pa.pre.length === 0 && pb.pre.length === 0) return 0;
+  // A version without prerelease identifiers has higher precedence than one
+  // with them (SemVer rule 11).
+  if (pa.pre.length === 0) return 1;
+  if (pb.pre.length === 0) return -1;
+  const len = Math.max(pa.pre.length, pb.pre.length);
+  for (let i = 0; i < len; i++) {
+    const ai = pa.pre[i];
+    const bi = pb.pre[i];
+    if (ai === undefined) return -1;
+    if (bi === undefined) return 1;
+    if (typeof ai === "number" && typeof bi === "number") {
+      if (ai !== bi) return ai - bi;
+    } else if (typeof ai === "number") {
+      return -1;
+    } else if (typeof bi === "number") {
+      return 1;
+    } else if (ai !== bi) {
+      return ai < bi ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+// Resolve channel slots by semver precedence, not GitHub publish order:
+//   - `latest`     → highest-precedence release that is NOT a prerelease
+//   - `prerelease` → highest-precedence release across both pools
+// Reporting `max(stable, prerelease)` for the prerelease slot guarantees the
+// prerelease channel never advertises a version older than `latest`. When no
+// newer prerelease exists, both slots show the same version, which truthfully
+// reflects what the updater would install.
+export function selectChannelReleases(
+  releases: GitHubRelease[],
+): { latest: GitHubRelease | undefined; prerelease: GitHubRelease | undefined } {
+  const publicReleases = releases.filter((release) => release.draft !== true);
+  const byPrecedenceDesc = [...publicReleases].sort((a, b) =>
+    compareSemver(b.tag_name, a.tag_name),
+  );
+  const latest = byPrecedenceDesc.find((release) => release.prerelease !== true);
+  const prerelease = byPrecedenceDesc[0];
+  return { latest, prerelease };
+}
+
 function githubReleaseHeaders(): HeadersInit {
   const token = process.env.GH_TOKEN?.trim() || process.env.GITHUB_TOKEN?.trim();
   return {
@@ -212,13 +288,7 @@ export async function readAppUpdateReleaseVersions(): Promise<AppUpdateReleaseVe
           typeof release === "object" && release !== null,
         )
       : [];
-    const publicReleases = releases.filter((release) => release.draft !== true);
-    const latest = publicReleases.find(
-      (release) => release.prerelease !== true,
-    );
-    const prerelease = publicReleases.find(
-      (release) => release.prerelease === true,
-    );
+    const { latest, prerelease } = selectChannelReleases(releases);
     return {
       fetchedAt: Date.now(),
       latest: releaseInfoFromGitHubRelease(latest, "No stable release found."),


### PR DESCRIPTION
## Summary

- Settings → Updates showed **Prerelease: v1.0.0-beta.1** while **Latest: v1.0.0-beta.8** — the prerelease channel was reporting a version *older* than latest, which violates SemVer precedence.
- Root cause: [`readAppUpdateReleaseVersions`](apps/desktop/src/main/auto-updater.ts) used `Array.find()` against GitHub's date-ordered releases list, so it picked the *oldest* GitHub-prerelease-flagged release instead of the highest by SemVer. Once v1.0.0-beta.8 was promoted to "Latest" on GitHub, betas 1–7 stayed flagged as prerelease and `.find()` returned beta.1.
- Fixed by sorting releases via a small inline SemVer 2.0.0 comparator and selecting:
  - **latest** = highest-precedence release where `prerelease !== true`
  - **prerelease** = highest-precedence release across *both* pools, so the prerelease channel never advertises a version older than latest

When no newer prerelease exists, both slots show the same version — truthful, since that's what either channel would actually install.

## Scope: what this fix does and does not cover

This change only affects the **Settings panel display** — the sole consumer of `readAppUpdateReleaseVersions`. The two other paths that talk to the user about versions were already going through `electron-updater`'s own semver-aware logic:

| Surface | Version source | Affected by this PR? |
|---|---|---|
| Settings → Updates "Latest: X. Prerelease: Y." caption | `readAppUpdateReleaseVersions` (GitHub Releases API) | **Yes — fixed** |
| `AppUpdateBanner` toast / "Update ready" message | `updateStatus.version`, populated from `autoUpdater.on("update-downloaded", info)` — `info.version` is what `electron-updater` actually downloaded | No — already reports the actual install-target version |
| Actual install decision | `autoUpdater.checkForUpdates()` (electron-updater) with `allowPrerelease` flag, reading `latest-mac.yml` published by electron-builder | No — electron-updater has its own well-tested semver logic |

So the user-visible bug from the screenshot is fully addressed; we are not reaching into electron-updater's install pipeline.

## Test plan

- [x] `pnpm test apps/desktop/src/main/__tests__/auto-updater.test.ts` — 9/9 pass (2 existing + 7 new)
- [x] `pnpm --filter @pwragent/desktop typecheck` — clean
- New tests cover: core ordering, stable-vs-prerelease precedence (SemVer rule 11), numeric prerelease identifiers (`beta.9 < beta.10`), unparseable tag fallback, draft filtering, and the exact production scenario (beta.8 stable + older beta.1–7 prereleases → prerelease slot reports beta.8, not beta.1)
- [ ] Manual: open Settings → Updates and confirm Prerelease no longer regresses behind Latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)