### PR TITLE
fix(desktop): run worktree git with prepared env

### DIFF
--- a/apps/desktop/src/main/__tests__/git-directory-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-directory-service.test.ts
@@ -284,6 +284,59 @@ describe("GitDirectoryService", () => {
     expect(branchesAfter).toEqual(branchesBefore);
   });
 
+  it("passes the prepared git environment to worktree creation commands", async () => {
+    const repoDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-git-env-"));
+    cleanupPaths.push(repoDir);
+    const preparedEnv = {
+      PATH: "/opt/homebrew/bin:/usr/bin:/bin",
+    } as NodeJS.ProcessEnv;
+    const calls: Array<{
+      args: string[];
+      cwd: string;
+      env?: NodeJS.ProcessEnv;
+    }> = [];
+    const runGit = vi.fn(
+      async (cwd: string, args: string[], env?: NodeJS.ProcessEnv) => {
+        calls.push({ args, cwd, env });
+        if (args.join(" ") === "rev-parse --show-toplevel") {
+          return repoDir;
+        }
+        if (args.join(" ") === "rev-parse --verify main^{commit}") {
+          return "0123456789abcdef0123456789abcdef01234567";
+        }
+        if (args[0] === "worktree" && args[1] === "add") {
+          return "";
+        }
+        throw new Error(`Unexpected git command: ${args.join(" ")}`);
+      },
+    );
+    const service = new GitDirectoryService({
+      gitEnv: preparedEnv,
+      resolveWorktreeStorage: () => "in-repo",
+      runGit,
+    });
+
+    const workspace = await service.prepareLaunchpadWorkspace({
+      directoryKind: "directory",
+      directoryLabel: "FixtureRepo",
+      directoryPath: repoDir,
+      workMode: "worktree",
+      branchName: "main",
+    });
+
+    expect(workspace.workMode).toBe("worktree");
+    expect(calls).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          args: ["worktree", "add", "--detach", workspace.cwd, "main"],
+          cwd: repoDir,
+          env: preparedEnv,
+        }),
+      ]),
+    );
+    expect(calls.every((call) => call.env === preparedEnv)).toBe(true);
+  });
+
   it("creates a worktree under a user-home root when storage is user-home", async () => {
     const repoDir = await createFixtureRepo();
     cleanupPaths.push(repoDir);

--- a/apps/desktop/src/main/__tests__/git-discovery.test.ts
+++ b/apps/desktop/src/main/__tests__/git-discovery.test.ts
@@ -130,6 +130,90 @@ describe("Git discovery", () => {
     await expect(resolveGitExecutable()).resolves.toBe(homeGit);
   });
 
+  it("uses the supplied hydrated PATH when resolving app-server git", async () => {
+    const missingError = new Error("missing") as NodeJS.ErrnoException;
+    missingError.code = "ENOENT";
+    const hydratedEnv = {
+      PATH: "/nix/profile/bin:/usr/bin",
+    } as NodeJS.ProcessEnv;
+    execFileMock.mockImplementation(
+      (
+        command: string,
+        args: string[],
+        options: { env?: NodeJS.ProcessEnv },
+        callback: (
+          error: Error | null,
+          result?: { stdout: string; stderr?: string },
+        ) => void,
+      ) => {
+        if (command === "git" && options.env === hydratedEnv) {
+          callback(null, {
+            stdout: args[0] === "--version" ? "git version 2.49.0\n" : "ok\n",
+          });
+          return;
+        }
+        callback(missingError);
+      },
+    );
+    const { runGitCommand } = await import("../app-server/git-executable");
+
+    await expect(
+      runGitCommand("/repo", ["status", "--short"], { env: hydratedEnv }),
+    ).resolves.toEqual({
+      stdout: "ok",
+      stderr: "",
+    });
+    expect(execFileMock).toHaveBeenCalledWith(
+      "git",
+      ["--version"],
+      expect.objectContaining({ env: hydratedEnv }),
+      expect.any(Function),
+    );
+    expect(execFileMock).toHaveBeenCalledWith(
+      "git",
+      ["-C", "/repo", "status", "--short"],
+      expect.objectContaining({ env: hydratedEnv }),
+      expect.any(Function),
+    );
+  });
+
+  it("does not reuse app-server git resolution across different PATH values", async () => {
+    const missingError = new Error("missing") as NodeJS.ErrnoException;
+    missingError.code = "ENOENT";
+    const finderEnv = { PATH: "/usr/bin:/bin" } as NodeJS.ProcessEnv;
+    const hydratedEnv = {
+      PATH: "/custom/bin:/usr/bin:/bin",
+    } as NodeJS.ProcessEnv;
+    execFileMock.mockImplementation(
+      (
+        command: string,
+        args: string[],
+        options: { env?: NodeJS.ProcessEnv },
+        callback: (
+          error: Error | null,
+          result?: { stdout: string; stderr?: string },
+        ) => void,
+      ) => {
+        if (
+          command === "git" &&
+          args[0] === "--version" &&
+          options.env === hydratedEnv
+        ) {
+          callback(null, { stdout: "git version 2.49.0\n" });
+          return;
+        }
+        callback(missingError);
+      },
+    );
+    const { resolveGitExecutable } = await import("../app-server/git-executable");
+
+    await expect(resolveGitExecutable(finderEnv)).rejects.toThrow(
+      "Git executable unavailable",
+    );
+
+    await expect(resolveGitExecutable(hydratedEnv)).resolves.toBe("git");
+  });
+
   it("retries app-server git resolution after an initial failure", async () => {
     const missingError = new Error("missing") as NodeJS.ErrnoException;
     missingError.code = "ENOENT";

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1601,16 +1601,19 @@ export class DesktopBackendRegistry {
       options?.gitDirectoryService ??
       new GitDirectoryService({
         codexHome,
+        gitEnv: codexEnv,
         resolveWorktreeStorage: () =>
           getDesktopSettingsService().resolveWorktreeStorage(),
       });
     this.worktreeArchiveService =
-      options?.worktreeArchiveService ?? new WorktreeArchiveService();
+      options?.worktreeArchiveService ??
+      new WorktreeArchiveService({ gitEnv: codexEnv });
     this.messagingStore = options?.messagingStore;
     this.messagingArchiveCleaner = options?.messagingArchiveCleaner;
     this.gitWorkspaceHandoffService =
       options?.gitWorkspaceHandoffService ??
       new GitWorkspaceHandoffService({
+        gitEnv: codexEnv,
         worktreeArchiveService: this.worktreeArchiveService,
         resolveWorktreeStorage: () =>
           getDesktopSettingsService().resolveWorktreeStorage(),

--- a/apps/desktop/src/main/app-server/git-directory-service.ts
+++ b/apps/desktop/src/main/app-server/git-directory-service.ts
@@ -16,8 +16,18 @@ import { DESKTOP_WORKTREE_STORAGE_DEFAULT } from "@pwragent/shared";
 import { userHomeWorktreesRoot } from "../settings/desktop-config";
 import { runGitCommand } from "./git-executable";
 
-async function runGit(cwd: string, args: string[]): Promise<string> {
-  return (await runGitCommand(cwd, args)).stdout;
+type GitCommandRunner = (
+  cwd: string,
+  args: string[],
+  env?: NodeJS.ProcessEnv,
+) => Promise<string>;
+
+async function defaultRunGit(
+  cwd: string,
+  args: string[],
+  env?: NodeJS.ProcessEnv,
+): Promise<string> {
+  return (await runGitCommand(cwd, args, { env })).stdout;
 }
 
 function errorText(error: unknown): string {
@@ -33,9 +43,13 @@ function isNotGitRepositoryError(error: unknown): boolean {
   return errorText(error).includes("not a git repository");
 }
 
-async function readGitRoot(cwd: string): Promise<string | undefined> {
+async function readGitRoot(
+  cwd: string,
+  runGit: GitCommandRunner = defaultRunGit,
+  env?: NodeJS.ProcessEnv,
+): Promise<string | undefined> {
   try {
-    return await runGit(cwd, ["rev-parse", "--show-toplevel"]);
+    return await runGit(cwd, ["rev-parse", "--show-toplevel"], env);
   } catch (error) {
     if (isNotGitRepositoryError(error)) {
       return undefined;
@@ -47,6 +61,8 @@ async function readGitRoot(cwd: string): Promise<string | undefined> {
 export async function recordCodexWorktreeOwnerThread(params: {
   worktreePath: string;
   threadId: string;
+  gitEnv?: NodeJS.ProcessEnv;
+  runGit?: GitCommandRunner;
 }): Promise<void> {
   const worktreePath = params.worktreePath.trim();
   const threadId = params.threadId.trim();
@@ -54,11 +70,12 @@ export async function recordCodexWorktreeOwnerThread(params: {
     return;
   }
 
-  const ownerFile = await runGit(worktreePath, [
-    "rev-parse",
-    "--git-path",
-    "codex-thread.json",
-  ]);
+  const runGit = params.runGit ?? defaultRunGit;
+  const ownerFile = await runGit(
+    worktreePath,
+    ["rev-parse", "--git-path", "codex-thread.json"],
+    params.gitEnv,
+  );
   if (!ownerFile) {
     throw new Error(`Unable to resolve Codex worktree owner file for ${worktreePath}`);
   }
@@ -268,28 +285,39 @@ function isProtectedBranch(branch?: string): boolean {
 async function resolveVerifiedWorktreeBaseBranch(params: {
   repoRoot: string;
   requestedBranch?: string;
+  gitEnv?: NodeJS.ProcessEnv;
+  runGit?: GitCommandRunner;
 }): Promise<string | undefined> {
+  const runGit = params.runGit ?? defaultRunGit;
   const requestedBranch = sanitizeBranchName(params.requestedBranch ?? "");
   if (requestedBranch) {
-    const commit = await runGit(params.repoRoot, [
-      "rev-parse",
-      "--verify",
-      `${requestedBranch}^{commit}`,
-    ]).catch(() => "");
+    const commit = await runGit(
+      params.repoRoot,
+      ["rev-parse", "--verify", `${requestedBranch}^{commit}`],
+      params.gitEnv,
+    ).catch(() => "");
     return commit ? requestedBranch : undefined;
   }
 
   const [currentBranch, branchesOutput, remoteHead] = await Promise.all([
-    runGit(params.repoRoot, ["rev-parse", "--abbrev-ref", "HEAD"]).catch(() => ""),
-    runGit(params.repoRoot, [
-      "for-each-ref",
-      "refs/heads",
-      "--sort=-committerdate",
-      "--format=%(refname:short)",
-    ]).catch(() => ""),
-    runGit(params.repoRoot, ["symbolic-ref", "refs/remotes/origin/HEAD", "--short"]).catch(
+    runGit(params.repoRoot, ["rev-parse", "--abbrev-ref", "HEAD"], params.gitEnv).catch(
       () => "",
     ),
+    runGit(
+      params.repoRoot,
+      [
+        "for-each-ref",
+        "refs/heads",
+        "--sort=-committerdate",
+        "--format=%(refname:short)",
+      ],
+      params.gitEnv,
+    ).catch(() => ""),
+    runGit(
+      params.repoRoot,
+      ["symbolic-ref", "refs/remotes/origin/HEAD", "--short"],
+      params.gitEnv,
+    ).catch(() => ""),
   ]);
   const branches = parseGitLines(branchesOutput);
   const defaultBranch = resolveDefaultBranch({ branches, remoteHead });
@@ -300,11 +328,11 @@ async function resolveVerifiedWorktreeBaseBranch(params: {
   ]);
 
   for (const branch of candidates) {
-    const commit = await runGit(params.repoRoot, [
-      "rev-parse",
-      "--verify",
-      `${branch}^{commit}`,
-    ]).catch(() => "");
+    const commit = await runGit(
+      params.repoRoot,
+      ["rev-parse", "--verify", `${branch}^{commit}`],
+      params.gitEnv,
+    ).catch(() => "");
     if (commit) {
       return branch;
     }
@@ -329,6 +357,8 @@ type GitDirectoryServiceOptions = {
   statusConcurrency?: number;
   statusMaxUnread?: number;
   codexHome?: string;
+  gitEnv?: NodeJS.ProcessEnv;
+  runGit?: GitCommandRunner;
   resolveWorktreeStorage?: () =>
     | DesktopWorktreeStorageLocation
     | Promise<DesktopWorktreeStorageLocation>;
@@ -341,6 +371,8 @@ export class GitDirectoryService {
   private readonly statusConcurrency: number;
   private readonly statusMaxUnread: number;
   private readonly codexHome?: string;
+  private readonly gitEnv?: NodeJS.ProcessEnv;
+  private readonly runGitCommand: GitCommandRunner;
   private readonly resolveStorage: () => Promise<DesktopWorktreeStorageLocation>;
   private readonly homeDir: string;
 
@@ -354,6 +386,8 @@ export class GitDirectoryService {
       this.statusConcurrency,
     );
     this.codexHome = normalized.codexHome;
+    this.gitEnv = normalized.gitEnv;
+    this.runGitCommand = normalized.runGit ?? defaultRunGit;
     this.homeDir = normalized.homeDir ?? os.homedir();
     const resolveStorage = normalized.resolveWorktreeStorage;
     this.resolveStorage = async () =>
@@ -445,30 +479,47 @@ export class GitDirectoryService {
   private async loadDirectoryStatus(
     cwd: string,
   ): Promise<NavigationDirectoryGitStatus | undefined> {
-    const repoRoot = await readGitRoot(cwd);
+    const runGit = this.runGitCommand;
+    const gitEnv = this.gitEnv;
+    const repoRoot = await readGitRoot(cwd, runGit, gitEnv);
     if (!repoRoot) {
       return undefined;
     }
 
-    const [currentBranch, branchesOutput, remoteHead, worktreeList] = await Promise.all([
-      runGit(repoRoot, ["rev-parse", "--abbrev-ref", "HEAD"]).catch(() => ""),
-      runGit(repoRoot, [
-        "for-each-ref",
-        "refs/heads",
-        "--sort=-committerdate",
-        "--format=%(refname:short)",
-      ]).catch(() => ""),
-      runGit(repoRoot, ["symbolic-ref", "refs/remotes/origin/HEAD", "--short"]).catch(
-        () => "",
-      ),
-      runGit(repoRoot, ["worktree", "list", "--porcelain"]).catch(() => ""),
-    ]);
-    const upstreamBranch = await runGit(repoRoot, [
-      "rev-parse",
-      "--abbrev-ref",
-      "--symbolic-full-name",
-      "@{upstream}",
-    ]).catch(() => "");
+    const [currentBranch, branchesOutput, remoteHead, worktreeList] =
+      await Promise.all([
+        runGit(repoRoot, ["rev-parse", "--abbrev-ref", "HEAD"], gitEnv).catch(
+          () => "",
+        ),
+        runGit(
+          repoRoot,
+          [
+            "for-each-ref",
+            "refs/heads",
+            "--sort=-committerdate",
+            "--format=%(refname:short)",
+          ],
+          gitEnv,
+        ).catch(() => ""),
+        runGit(
+          repoRoot,
+          ["symbolic-ref", "refs/remotes/origin/HEAD", "--short"],
+          gitEnv,
+        ).catch(() => ""),
+        runGit(repoRoot, ["worktree", "list", "--porcelain"], gitEnv).catch(
+          () => "",
+        ),
+      ]);
+    const upstreamBranch = await runGit(
+      repoRoot,
+      [
+        "rev-parse",
+        "--abbrev-ref",
+        "--symbolic-full-name",
+        "@{upstream}",
+      ],
+      gitEnv,
+    ).catch(() => "");
     const branches = parseGitLines(branchesOutput);
     const defaultBranch = resolveDefaultBranch({ branches, remoteHead });
     if (!currentBranch) {
@@ -497,12 +548,11 @@ export class GitDirectoryService {
       };
     }
 
-    const counts = await runGit(cwd, [
-      "rev-list",
-      "--left-right",
-      "--count",
-      `HEAD...${upstreamBranch}`,
-    ]).catch(() => "");
+    const counts = await runGit(
+      cwd,
+      ["rev-list", "--left-right", "--count", `HEAD...${upstreamBranch}`],
+      gitEnv,
+    ).catch(() => "");
     const [aheadValue, behindValue] = counts
       .split(/\s+/)
       .map((value) => Number.parseInt(value, 10));
@@ -558,7 +608,11 @@ export class GitDirectoryService {
       };
     }
 
-    const repoRoot = await readGitRoot(directoryPath);
+    const repoRoot = await readGitRoot(
+      directoryPath,
+      this.runGitCommand,
+      this.gitEnv,
+    );
     if (!repoRoot) {
       return {
         cwd: directoryPath,
@@ -567,8 +621,10 @@ export class GitDirectoryService {
     }
 
     const baseBranch = await resolveVerifiedWorktreeBaseBranch({
+      gitEnv: this.gitEnv,
       repoRoot,
       requestedBranch: launchpad.branchName,
+      runGit: this.runGitCommand,
     });
     if (!baseBranch) {
       return {
@@ -586,7 +642,11 @@ export class GitDirectoryService {
       homeDir: this.homeDir,
     });
     await mkdir(path.dirname(worktreePath), { recursive: true });
-    await runGit(repoRoot, ["worktree", "add", "--detach", worktreePath, baseBranch]);
+    await this.runGitCommand(
+      repoRoot,
+      ["worktree", "add", "--detach", worktreePath, baseBranch],
+      this.gitEnv,
+    );
 
     return {
       cwd: worktreePath,
@@ -599,7 +659,11 @@ export class GitDirectoryService {
     worktreePath: string;
     threadId: string;
   }): Promise<void> {
-    await recordCodexWorktreeOwnerThread(params);
+    await recordCodexWorktreeOwnerThread({
+      ...params,
+      gitEnv: this.gitEnv,
+      runGit: this.runGitCommand,
+    });
   }
 
   async cleanupThreadWorktrees(
@@ -645,6 +709,8 @@ export class GitDirectoryService {
     },
     thread: Pick<AppServerThreadSummary, "gitBranch" | "observedGitBranch">,
   ): Promise<ArchiveThreadCleanupResult> {
+    const runGit = this.runGitCommand;
+    const gitEnv = this.gitEnv;
     const repoPath = path.resolve(candidate.repoPath);
     const worktreePath = path.resolve(candidate.worktreePath);
     const base: ArchiveThreadCleanupResult = {
@@ -661,8 +727,16 @@ export class GitDirectoryService {
     }
 
     try {
-      const repoRoot = await runGit(repoPath, ["rev-parse", "--show-toplevel"]);
-      const worktreeList = await runGit(repoRoot, ["worktree", "list", "--porcelain"]);
+      const repoRoot = await runGit(
+        repoPath,
+        ["rev-parse", "--show-toplevel"],
+        gitEnv,
+      );
+      const worktreeList = await runGit(
+        repoRoot,
+        ["worktree", "list", "--porcelain"],
+        gitEnv,
+      );
       const entries = parseGitWorktreeEntries(worktreeList);
       const primaryPath = path.resolve(entries[0]?.path || repoRoot);
       const entry = entries.find((item) => path.resolve(item.path) === worktreePath);
@@ -682,7 +756,7 @@ export class GitDirectoryService {
       }
 
       const branch = entry.branch ?? thread.observedGitBranch ?? thread.gitBranch;
-      await runGit(repoRoot, ["worktree", "remove", "--force", worktreePath]);
+      await runGit(repoRoot, ["worktree", "remove", "--force", worktreePath], gitEnv);
       await pruneEmptyWorktreeParents(worktreePath);
 
       const result: ArchiveThreadCleanupResult = {
@@ -705,7 +779,7 @@ export class GitDirectoryService {
         };
       }
 
-      await runGit(repoRoot, ["branch", "-D", branch]);
+      await runGit(repoRoot, ["branch", "-D", branch], gitEnv);
 
       return {
         ...result,

--- a/apps/desktop/src/main/app-server/git-executable.ts
+++ b/apps/desktop/src/main/app-server/git-executable.ts
@@ -4,15 +4,31 @@ import { gitCandidateInputs } from "../settings/git-discovery";
 
 const execFile = promisify(execFileCallback);
 
-let resolvedGitExecutable: string | undefined;
-let resolvingGitExecutable: Promise<string> | undefined;
+const resolvedGitExecutableByEnv = new Map<string, string>();
+const resolvingGitExecutableByEnv = new Map<string, Promise<string>>();
 
-function gitExecutableCandidates(): string[] {
-  const candidates = gitCandidateInputs(process.env).flatMap((candidate) => {
+function gitExecutableCandidates(env: NodeJS.ProcessEnv): string[] {
+  const candidates = gitCandidateInputs(env).flatMap((candidate) => {
     const normalized = candidate.command?.trim();
     return normalized ? [normalized] : [];
   });
   return [...new Set(candidates)];
+}
+
+function readPathEnv(env: NodeJS.ProcessEnv): string | undefined {
+  if (process.platform !== "win32") {
+    return env.PATH;
+  }
+
+  const pathKey = Object.keys(env).find((key) => key.toLowerCase() === "path");
+  return pathKey ? env[pathKey] : undefined;
+}
+
+function gitResolutionCacheKey(env: NodeJS.ProcessEnv): string {
+  return JSON.stringify({
+    candidates: gitExecutableCandidates(env),
+    path: readPathEnv(env),
+  });
 }
 
 function errorText(error: unknown): string {
@@ -26,11 +42,12 @@ function errorText(error: unknown): string {
 
 async function canRunGit(
   candidate: string,
+  env: NodeJS.ProcessEnv,
 ): Promise<{ ok: true } | { ok: false; error: string }> {
   try {
     await execFile(candidate, ["--version"], {
       encoding: "utf8",
-      env: process.env,
+      env,
     });
     return { ok: true };
   } catch (error) {
@@ -38,41 +55,54 @@ async function canRunGit(
   }
 }
 
-export async function resolveGitExecutable(): Promise<string> {
-  if (resolvedGitExecutable) {
-    return resolvedGitExecutable;
+export async function resolveGitExecutable(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<string> {
+  const cacheKey = gitResolutionCacheKey(env);
+  const resolved = resolvedGitExecutableByEnv.get(cacheKey);
+  if (resolved) {
+    return resolved;
   }
 
-  resolvingGitExecutable ??= (async () => {
-    const failures: string[] = [];
-    for (const candidate of gitExecutableCandidates()) {
-      const result = await canRunGit(candidate);
-      if (result.ok) {
-        resolvedGitExecutable = candidate;
-        return candidate;
+  let resolving = resolvingGitExecutableByEnv.get(cacheKey);
+  if (!resolving) {
+    resolving = (async () => {
+      const failures: string[] = [];
+      for (const candidate of gitExecutableCandidates(env)) {
+        const result = await canRunGit(candidate, env);
+        if (result.ok) {
+          resolvedGitExecutableByEnv.set(cacheKey, candidate);
+          return candidate;
+        }
+        failures.push(`${candidate}: ${result.error}`);
       }
-      failures.push(`${candidate}: ${result.error}`);
-    }
 
-    throw new Error(`Git executable unavailable. Tried:\n${failures.join("\n")}`);
-  })().finally(() => {
-    resolvingGitExecutable = undefined;
-  });
+      throw new Error(`Git executable unavailable. Tried:\n${failures.join("\n")}`);
+    })().finally(() => {
+      resolvingGitExecutableByEnv.delete(cacheKey);
+    });
+    resolvingGitExecutableByEnv.set(cacheKey, resolving);
+  }
 
-  return await resolvingGitExecutable;
+  return await resolving;
 }
 
-export async function runGitCommand(cwd: string, args: string[]): Promise<{
+export async function runGitCommand(
+  cwd: string,
+  args: string[],
+  options: { env?: NodeJS.ProcessEnv } = {},
+): Promise<{
   stdout: string;
   stderr: string;
 }> {
-  const git = await resolveGitExecutable();
+  const env = options.env ?? process.env;
+  const git = await resolveGitExecutable(env);
   const { stdout, stderr } = await execFile(git, ["-C", cwd, ...args], {
     encoding: "utf8",
-    env: process.env,
+    env,
   });
   return {
     stdout: stdout.trim(),
-    stderr: stderr.trim(),
+    stderr: (stderr ?? "").trim(),
   };
 }

--- a/apps/desktop/src/main/app-server/git-workspace-handoff-service.ts
+++ b/apps/desktop/src/main/app-server/git-workspace-handoff-service.ts
@@ -57,20 +57,26 @@ type HandoffContext = {
 type StashOptions = {
   message: string;
   path: string;
+  gitEnv?: NodeJS.ProcessEnv;
 };
 
 type WorkspaceHandoffServiceOptions = {
   worktreeArchiveService?: WorktreeArchiveService;
+  gitEnv?: NodeJS.ProcessEnv;
   resolveWorktreeStorage?: () =>
     | DesktopWorktreeStorageLocation
     | Promise<DesktopWorktreeStorageLocation>;
   homeDir?: string;
 };
 
-async function runGit(cwd: string, args: string[]): Promise<GitResult> {
+async function runGit(
+  cwd: string,
+  args: string[],
+  env?: NodeJS.ProcessEnv,
+): Promise<GitResult> {
   return await execFileAsync("git", args, {
     cwd,
-    env: process.env,
+    env: env ?? process.env,
     maxBuffer: 1024 * 1024 * 10,
   });
 }
@@ -159,14 +165,19 @@ function ensureBranchNotCheckedOutElsewhere(params: {
 async function createNamedStashIfDirty(
   options: StashOptions,
 ): Promise<ThreadWorkspaceHandoffStashSummary | undefined> {
-  const status = await getDirtyStatus(options.path);
+  const status = await getDirtyStatus(options.path, options.gitEnv);
   if (!status) {
     return undefined;
   }
 
-  await runGit(options.path, ["stash", "push", "--include-untracked", "-m", options.message]);
+  await runGit(
+    options.path,
+    ["stash", "push", "--include-untracked", "-m", options.message],
+    options.gitEnv,
+  );
   const ref = trim(
-    (await runGit(options.path, ["rev-parse", "--verify", "stash@{0}"])).stdout,
+    (await runGit(options.path, ["rev-parse", "--verify", "stash@{0}"], options.gitEnv))
+      .stdout,
   );
 
   return {
@@ -178,24 +189,38 @@ async function createNamedStashIfDirty(
   };
 }
 
-async function getDirtyStatus(workspacePath: string): Promise<string> {
+async function getDirtyStatus(
+  workspacePath: string,
+  gitEnv?: NodeJS.ProcessEnv,
+): Promise<string> {
   return trim(
-    (await runGit(workspacePath, ["status", "--porcelain", "--untracked-files=normal"]))
+    (await runGit(
+      workspacePath,
+      ["status", "--porcelain", "--untracked-files=normal"],
+      gitEnv,
+    ))
       .stdout,
   );
 }
 
-async function assertLocalCleanForDestinationHandoff(repositoryPath: string): Promise<void> {
-  if (await getDirtyStatus(repositoryPath)) {
+async function assertLocalCleanForDestinationHandoff(
+  repositoryPath: string,
+  gitEnv?: NodeJS.ProcessEnv,
+): Promise<void> {
+  if (await getDirtyStatus(repositoryPath, gitEnv)) {
     throw new Error(
       "Local has dirty tracked or untracked changes. Commit, stash, or discard them before handing a worktree back to Local.",
     );
   }
 }
 
-async function dropStashByCommit(cwd: string, commit: string): Promise<void> {
+async function dropStashByCommit(
+  cwd: string,
+  commit: string,
+  gitEnv?: NodeJS.ProcessEnv,
+): Promise<void> {
   const stashList = (
-    await runGit(cwd, ["stash", "list", "--format=%H%x00%gd"])
+    await runGit(cwd, ["stash", "list", "--format=%H%x00%gd"], gitEnv)
   ).stdout.split("\n");
   const match = stashList.flatMap((line) => {
     const [sha, ref] = line.split("\0");
@@ -206,20 +231,32 @@ async function dropStashByCommit(cwd: string, commit: string): Promise<void> {
     return;
   }
 
-  await runGit(cwd, ["stash", "drop", match]);
+  await runGit(cwd, ["stash", "drop", match], gitEnv);
 }
 
-async function validateBranchName(cwd: string, branch: string): Promise<void> {
+async function validateBranchName(
+  cwd: string,
+  branch: string,
+  gitEnv?: NodeJS.ProcessEnv,
+): Promise<void> {
   try {
-    await runGit(cwd, ["check-ref-format", "--branch", branch]);
+    await runGit(cwd, ["check-ref-format", "--branch", branch], gitEnv);
   } catch {
     throw new Error(`Invalid branch name: ${branch}`);
   }
 }
 
-async function branchExists(cwd: string, branch: string): Promise<boolean> {
+async function branchExists(
+  cwd: string,
+  branch: string,
+  gitEnv?: NodeJS.ProcessEnv,
+): Promise<boolean> {
   try {
-    await runGit(cwd, ["show-ref", "--verify", "--quiet", `refs/heads/${branch}`]);
+    await runGit(
+      cwd,
+      ["show-ref", "--verify", "--quiet", `refs/heads/${branch}`],
+      gitEnv,
+    );
     return true;
   } catch {
     return false;
@@ -229,13 +266,14 @@ async function branchExists(cwd: string, branch: string): Promise<boolean> {
 async function applyVerifyAndDropStash(
   cwd: string,
   stash: ThreadWorkspaceHandoffStashSummary | undefined,
+  gitEnv?: NodeJS.ProcessEnv,
 ): Promise<ThreadWorkspaceHandoffStashSummary | undefined> {
   if (!stash?.ref) {
     return stash;
   }
 
-  await runGit(cwd, ["stash", "apply", stash.ref]);
-  await dropStashByCommit(cwd, stash.ref);
+  await runGit(cwd, ["stash", "apply", stash.ref], gitEnv);
+  await dropStashByCommit(cwd, stash.ref, gitEnv);
 
   return {
     ...stash,
@@ -248,6 +286,7 @@ async function applyVerifyAndDropStash(
 export class GitWorkspaceHandoffService {
   private readonly worktreeArchiveService: WorktreeArchiveService;
   private readonly resolveStorage: () => Promise<DesktopWorktreeStorageLocation>;
+  private readonly gitEnv?: NodeJS.ProcessEnv;
   private readonly homeDir: string | undefined;
 
   constructor(options: WorkspaceHandoffServiceOptions = {}) {
@@ -256,6 +295,7 @@ export class GitWorkspaceHandoffService {
     const resolveStorage = options.resolveWorktreeStorage;
     this.resolveStorage = async () =>
       (await resolveStorage?.()) ?? DESKTOP_WORKTREE_STORAGE_DEFAULT;
+    this.gitEnv = options.gitEnv;
     this.homeDir = options.homeDir;
   }
 
@@ -274,21 +314,38 @@ export class GitWorkspaceHandoffService {
     const repositoryPath = await realpath(
       path.resolve(
         params.repositoryPath ??
-          trim((await runGit(sourcePath, ["rev-parse", "--show-toplevel"])).stdout),
+          trim(
+            (await runGit(
+              sourcePath,
+              ["rev-parse", "--show-toplevel"],
+              this.gitEnv,
+            )).stdout,
+          ),
       ),
     );
     const worktrees = parseWorktreeList(
-      (await runGit(repositoryPath, ["worktree", "list", "--porcelain"])).stdout,
+      (await runGit(repositoryPath, ["worktree", "list", "--porcelain"], this.gitEnv))
+        .stdout,
     );
     const observedBranch = sanitizeBranchName(
-      trim((await runGit(sourcePath, ["rev-parse", "--abbrev-ref", "HEAD"])).stdout),
+      trim(
+        (await runGit(
+          sourcePath,
+          ["rev-parse", "--abbrev-ref", "HEAD"],
+          this.gitEnv,
+        )).stdout,
+      ),
     );
     const branch =
       observedBranch === "HEAD"
         ? "HEAD"
         : sanitizeBranchName(params.sourceBranch ?? "") || observedBranch;
     const headSha = trim(
-      (await runGit(sourcePath, ["rev-parse", "--verify", "HEAD^{commit}"])).stdout,
+      (await runGit(
+        sourcePath,
+        ["rev-parse", "--verify", "HEAD^{commit}"],
+        this.gitEnv,
+      )).stdout,
     );
 
     if (!branch) {
@@ -363,6 +420,7 @@ export class GitWorkspaceHandoffService {
       warnings.push("Local was left on a detached HEAD at the moved branch commit.");
     }
     const sourceStash = await createNamedStashIfDirty({
+      gitEnv: this.gitEnv,
       path: context.sourcePath,
       message: this.buildStashMessage(context, "source"),
     });
@@ -371,11 +429,20 @@ export class GitWorkspaceHandoffService {
       leaveLocalDetached
         ? ["switch", "--detach", context.headSha]
         : ["switch", leaveLocalBranch],
+      this.gitEnv,
     );
 
     await mkdir(path.dirname(targetPath), { recursive: true });
-    await runGit(context.repositoryPath, ["worktree", "add", targetPath, context.branch]);
-    const appliedSourceStash = await applyVerifyAndDropStash(targetPath, sourceStash);
+    await runGit(
+      context.repositoryPath,
+      ["worktree", "add", targetPath, context.branch],
+      this.gitEnv,
+    );
+    const appliedSourceStash = await applyVerifyAndDropStash(
+      targetPath,
+      sourceStash,
+      this.gitEnv,
+    );
 
     const linkedDirectory = this.buildLinkedDirectory({
       context,
@@ -411,8 +478,8 @@ export class GitWorkspaceHandoffService {
     if (newBranchName === context.branch) {
       throw new Error("New branch name must differ from the current branch.");
     }
-    await validateBranchName(context.repositoryPath, newBranchName);
-    if (await branchExists(context.repositoryPath, newBranchName)) {
+    await validateBranchName(context.repositoryPath, newBranchName, this.gitEnv);
+    if (await branchExists(context.repositoryPath, newBranchName, this.gitEnv)) {
       throw new Error(`Branch ${newBranchName} already exists.`);
     }
 
@@ -430,6 +497,7 @@ export class GitWorkspaceHandoffService {
       `The new worktree starts from ${context.branch} at the current commit.`,
     ];
     const sourceStash = await createNamedStashIfDirty({
+      gitEnv: this.gitEnv,
       path: context.sourcePath,
       message: this.buildStashMessage(context, "source"),
     });
@@ -438,15 +506,16 @@ export class GitWorkspaceHandoffService {
     }
 
     await mkdir(path.dirname(targetPath), { recursive: true });
-    await runGit(context.repositoryPath, [
-      "worktree",
-      "add",
-      "-b",
-      newBranchName,
+    await runGit(
+      context.repositoryPath,
+      ["worktree", "add", "-b", newBranchName, targetPath, baseSha],
+      this.gitEnv,
+    );
+    const appliedSourceStash = await applyVerifyAndDropStash(
       targetPath,
-      baseSha,
-    ]);
-    const appliedSourceStash = await applyVerifyAndDropStash(targetPath, sourceStash);
+      sourceStash,
+      this.gitEnv,
+    );
 
     const linkedDirectory = this.buildLinkedDirectory({
       context,
@@ -490,6 +559,7 @@ export class GitWorkspaceHandoffService {
       "The new worktree starts detached at the current branch tip.",
     ];
     const sourceStash = await createNamedStashIfDirty({
+      gitEnv: this.gitEnv,
       path: context.sourcePath,
       message: this.buildStashMessage(context, "source"),
     });
@@ -498,8 +568,16 @@ export class GitWorkspaceHandoffService {
     }
 
     await mkdir(path.dirname(targetPath), { recursive: true });
-    await runGit(context.repositoryPath, ["worktree", "add", "--detach", targetPath, baseSha]);
-    const appliedSourceStash = await applyVerifyAndDropStash(targetPath, sourceStash);
+    await runGit(
+      context.repositoryPath,
+      ["worktree", "add", "--detach", targetPath, baseSha],
+      this.gitEnv,
+    );
+    const appliedSourceStash = await applyVerifyAndDropStash(
+      targetPath,
+      sourceStash,
+      this.gitEnv,
+    );
 
     const linkedDirectory = this.buildLinkedDirectory({
       context,
@@ -542,17 +620,19 @@ export class GitWorkspaceHandoffService {
     });
 
     const warnings = ["Ignored files are not preserved by workspace handoff."];
-    await assertLocalCleanForDestinationHandoff(context.repositoryPath);
+    await assertLocalCleanForDestinationHandoff(context.repositoryPath, this.gitEnv);
     const sourceStash = await createNamedStashIfDirty({
+      gitEnv: this.gitEnv,
       path: context.sourcePath,
       message: this.buildStashMessage(context, "source"),
     });
 
-    await runGit(context.sourcePath, ["switch", "--detach"]);
-    await runGit(context.repositoryPath, ["switch", context.branch]);
+    await runGit(context.sourcePath, ["switch", "--detach"], this.gitEnv);
+    await runGit(context.repositoryPath, ["switch", context.branch], this.gitEnv);
     const appliedSourceStash = await applyVerifyAndDropStash(
       context.repositoryPath,
       sourceStash,
+      this.gitEnv,
     );
     const archivedSourceWorktree = await this.worktreeArchiveService.archive({
       backend: context.backend,
@@ -592,16 +672,22 @@ export class GitWorkspaceHandoffService {
       "Ignored files are not preserved by workspace handoff.",
       "Local will be left on a detached HEAD at the moved worktree commit.",
     ];
-    await assertLocalCleanForDestinationHandoff(context.repositoryPath);
+    await assertLocalCleanForDestinationHandoff(context.repositoryPath, this.gitEnv);
     const sourceStash = await createNamedStashIfDirty({
+      gitEnv: this.gitEnv,
       path: context.sourcePath,
       message: this.buildStashMessage(context, "source"),
     });
 
-    await runGit(context.repositoryPath, ["switch", "--detach", context.headSha]);
+    await runGit(
+      context.repositoryPath,
+      ["switch", "--detach", context.headSha],
+      this.gitEnv,
+    );
     const appliedSourceStash = await applyVerifyAndDropStash(
       context.repositoryPath,
       sourceStash,
+      this.gitEnv,
     );
     const archivedSourceWorktree = await this.worktreeArchiveService.archive({
       backend: context.backend,

--- a/apps/desktop/src/main/app-server/worktree-archive-service.ts
+++ b/apps/desktop/src/main/app-server/worktree-archive-service.ts
@@ -42,6 +42,10 @@ type RestoreWorktreeParams = {
   now?: number;
 };
 
+type WorktreeArchiveServiceOptions = {
+  gitEnv?: NodeJS.ProcessEnv;
+};
+
 async function runGit(
   cwd: string,
   args: string[],
@@ -135,6 +139,12 @@ function findWorktree(
 }
 
 export class WorktreeArchiveService {
+  private readonly gitEnv?: NodeJS.ProcessEnv;
+
+  constructor(options: WorktreeArchiveServiceOptions = {}) {
+    this.gitEnv = options.gitEnv;
+  }
+
   async archive(params: ArchiveWorktreeParams): Promise<WorktreeSnapshotSummary> {
     const worktreePath = await realpath(path.resolve(params.worktreePath));
     const worktreeListPath = params.repositoryPath
@@ -161,8 +171,8 @@ export class WorktreeArchiveService {
       worktreePath,
     });
     const snapshotRef = snapshotRefForBackend(params.backend, worktreePath);
-    await runGit(repositoryPath, ["update-ref", snapshotRef, snapshotCommit]);
-    await runGit(repositoryPath, ["worktree", "remove", "--force", worktreePath]);
+    await this.runGit(repositoryPath, ["update-ref", snapshotRef, snapshotCommit]);
+    await this.runGit(repositoryPath, ["worktree", "remove", "--force", worktreePath]);
 
     const archivedAt = params.now ?? Date.now();
     return {
@@ -186,7 +196,10 @@ export class WorktreeArchiveService {
     const worktreePath = path.resolve(params.worktreePath);
     const repositoryPath = path.resolve(params.repositoryPath);
     const snapshotCommit = trimGitOutput(
-      (await runGit(repositoryPath, ["rev-parse", `${params.snapshotRef}^{commit}`]))
+      (await this.runGit(repositoryPath, [
+        "rev-parse",
+        `${params.snapshotRef}^{commit}`,
+      ]))
         .stdout,
     );
 
@@ -197,7 +210,7 @@ export class WorktreeArchiveService {
     }
 
     await mkdir(path.dirname(worktreePath), { recursive: true });
-    await runGit(repositoryPath, [
+    await this.runGit(repositoryPath, [
       "worktree",
       "add",
       "--detach",
@@ -241,10 +254,10 @@ export class WorktreeArchiveService {
 
     try {
       const env = { GIT_INDEX_FILE: indexPath };
-      await runGit(params.worktreePath, ["read-tree", "HEAD"], { env });
-      await runGit(params.worktreePath, ["add", "-A", "--", "."], { env });
+      await this.runGit(params.worktreePath, ["read-tree", "HEAD"], { env });
+      await this.runGit(params.worktreePath, ["add", "-A", "--", "."], { env });
       const tree = trimGitOutput(
-        (await runGit(params.worktreePath, ["write-tree"], { env })).stdout,
+        (await this.runGit(params.worktreePath, ["write-tree"], { env })).stdout,
       );
       const message = [
         `Snapshot worktree for ${params.backend}:${params.threadId}`,
@@ -266,7 +279,8 @@ export class WorktreeArchiveService {
       };
 
       return trimGitOutput(
-        (await runGit(params.worktreePath, commitArgs, { env: commitEnv })).stdout,
+        (await this.runGit(params.worktreePath, commitArgs, { env: commitEnv }))
+          .stdout,
       );
     } finally {
       await rm(tempDir, { force: true, recursive: true });
@@ -286,8 +300,21 @@ export class WorktreeArchiveService {
   }
 
   private async listWorktrees(repositoryPath: string): Promise<WorktreeInfo[]> {
-    const output = await runGit(repositoryPath, ["worktree", "list", "--porcelain"]);
+    const output = await this.runGit(repositoryPath, ["worktree", "list", "--porcelain"]);
     return parseWorktreeList(output.stdout);
+  }
+
+  private async runGit(
+    cwd: string,
+    args: string[],
+    options: { env?: NodeJS.ProcessEnv } = {},
+  ): Promise<GitResult> {
+    return await runGit(cwd, args, {
+      env: {
+        ...this.gitEnv,
+        ...options.env,
+      },
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
Finder-launched PwrAgent now runs worktree-related Git operations with the same login-shell hydrated environment used for Codex spawns, so Git can find helper programs like Homebrew `git-lfs` while materializing worktrees.

The prepared environment is threaded through launchpad worktree creation, workspace handoff, archive/restore, and cleanup paths instead of only the environment-run command path. A regression test locks the important case: `git worktree add` receives the prepared PATH.

## Tests
- `pnpm test apps/desktop/src/main/__tests__/git-directory-service.test.ts apps/desktop/src/main/__tests__/git-discovery.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
