### PR TITLE
feat(desktop): LiveWorkRail above the composer for live + last-turn work

### DIFF
--- a/apps/desktop/e2e/todo-list-rendering.spec.ts
+++ b/apps/desktop/e2e/todo-list-rendering.spec.ts
@@ -98,8 +98,10 @@ test("renders live plan updates from turn/plan/updated notifications", async () 
     await expect(app.window.getByRole("button", { name: "Stop" })).toBeVisible();
     await expect(app.window.getByRole("status")).toContainText("Thinking");
 
-    const transcript = app.window.getByRole("region", { name: "Transcript" });
-    const planGroups = transcript.getByRole("group", { name: "Task plan" });
+    // After issue #495 the live plan renders in the LiveWorkRail
+    // above the composer (role="complementary"), not inline in the
+    // transcript region. Page-scope query covers either dock mode.
+    const planGroups = app.window.getByRole("group", { name: "Task plan" });
 
     await app.advance({ stepId: "status-active-1" });
     await app.advance({ stepId: "turn-started-1" });

--- a/apps/desktop/src/renderer/src/features/thread-detail/LiveWorkRail.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/LiveWorkRail.tsx
@@ -41,6 +41,7 @@ export function LiveWorkRail(props: LiveWorkRailProps) {
     props.planEntry || props.editedFilesEntry || props.changedFilesEntry,
   );
   const [collapsed, setCollapsed] = useState(false);
+  const bodyId = useId();
 
   if (!hasContent) {
     return null;
@@ -73,7 +74,7 @@ export function LiveWorkRail(props: LiveWorkRailProps) {
           type="button"
           className="live-work-rail__collapse"
           aria-expanded={!collapsed}
-          aria-controls={undefined}
+          aria-controls={bodyId}
           onClick={() => setCollapsed((current) => !current)}
         >
           <span className="live-work-rail__chevron" aria-hidden="true" />
@@ -90,39 +91,28 @@ export function LiveWorkRail(props: LiveWorkRailProps) {
         </button>
       </header>
 
-      {!collapsed ? (
-        <div className="live-work-rail__body">
-          {props.planEntry ? (
-            <LiveWorkSection title="Plan">
-              <TranscriptPlan
-                entry={props.planEntry}
-                applications={props.applications}
-                desktopApi={props.desktopApi}
-              />
-            </LiveWorkSection>
-          ) : null}
+      {/* Body stays mounted across collapse toggles so the
+          `aria-controls` from the header button always points at a
+          live element. `hidden` removes it from the accessibility
+          tree and from layout (display:none equivalent). */}
+      <div id={bodyId} className="live-work-rail__body" hidden={collapsed}>
+        {props.planEntry ? (
+          <TranscriptPlan
+            entry={props.planEntry}
+            applications={props.applications}
+            desktopApi={props.desktopApi}
+          />
+        ) : null}
 
-          {props.editedFilesEntry ? (
-            <EditedFilesSection entry={props.editedFilesEntry} />
-          ) : null}
+        {props.editedFilesEntry ? (
+          <EditedFilesSection entry={props.editedFilesEntry} />
+        ) : null}
 
-          {props.changedFilesEntry ? (
-            <ChangedFilesSection entry={props.changedFilesEntry} />
-          ) : null}
-        </div>
-      ) : null}
+        {props.changedFilesEntry ? (
+          <ChangedFilesSection entry={props.changedFilesEntry} />
+        ) : null}
+      </div>
     </aside>
-  );
-}
-
-function LiveWorkSection(props: {
-  title: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <section className="live-work-rail__section" aria-label={props.title}>
-      {props.children}
-    </section>
   );
 }
 
@@ -190,11 +180,14 @@ function EditedFileRow(props: {
           </span>
         </span>
       </button>
-      {expanded ? (
-        <div id={diffId} className="live-work-rail__file-diff">
-          <TranscriptDiff detail={props.detail} compact />
-        </div>
-      ) : null}
+      {/* Diff container stays in the DOM (with `hidden`) so the
+          row's `aria-controls={diffId}` always resolves. The
+          potentially-heavy TranscriptDiff itself is still
+          conditionally mounted to keep the render cost in line
+          with what the user actually opens. */}
+      <div id={diffId} className="live-work-rail__file-diff" hidden={!expanded}>
+        {expanded ? <TranscriptDiff detail={props.detail} compact /> : null}
+      </div>
     </>
   );
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/LiveWorkRail.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/LiveWorkRail.tsx
@@ -46,6 +46,16 @@ export function LiveWorkRail(props: LiveWorkRailProps) {
     return null;
   }
 
+  // Title is the comma-joined list of present section names — the rail
+  // is just an affordance for those sections, not a "Live work" / "Last
+  // turn" status surface (the pinned styling carries that signal).
+  const sectionLabels: string[] = [];
+  if (props.planEntry) sectionLabels.push("Plan");
+  if (props.editedFilesEntry) sectionLabels.push("Edited Files");
+  if (props.changedFilesEntry) sectionLabels.push("Changed Files");
+  const railTitle = sectionLabels.join(", ");
+  const railAriaLabel = props.pinned ? `${railTitle} (last turn)` : railTitle;
+
   const dockToggleLabel =
     props.dock === "above" ? "Dock to sidebar" : "Dock above composer";
   const nextDock: LiveWorkRailDock = props.dock === "above" ? "sidebar" : "above";
@@ -56,7 +66,7 @@ export function LiveWorkRail(props: LiveWorkRailProps) {
         props.pinned ? " live-work-rail--pinned" : ""
       }${collapsed ? " live-work-rail--collapsed" : ""}`}
       role="complementary"
-      aria-label={props.pinned ? "Last turn's work" : "Live work"}
+      aria-label={railAriaLabel}
     >
       <header className="live-work-rail__header">
         <button
@@ -67,9 +77,7 @@ export function LiveWorkRail(props: LiveWorkRailProps) {
           onClick={() => setCollapsed((current) => !current)}
         >
           <span className="live-work-rail__chevron" aria-hidden="true" />
-          <span className="live-work-rail__title">
-            {props.pinned ? "Last turn" : "Live work"}
-          </span>
+          <span className="live-work-rail__title">{railTitle}</span>
         </button>
         <button
           type="button"
@@ -184,7 +192,7 @@ function EditedFileRow(props: {
       </button>
       {expanded ? (
         <div id={diffId} className="live-work-rail__file-diff">
-          <TranscriptDiff detail={props.detail} />
+          <TranscriptDiff detail={props.detail} compact />
         </div>
       ) : null}
     </>

--- a/apps/desktop/src/renderer/src/features/thread-detail/LiveWorkRail.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/LiveWorkRail.tsx
@@ -1,0 +1,221 @@
+import { useId, useState } from "react";
+import type {
+  AppServerThreadActivityDetail,
+  AppServerThreadActivityEntry,
+  AppServerThreadPlanEntry,
+  DesktopApplicationsSnapshot,
+} from "@pwragent/shared";
+import type { DesktopApi } from "../../lib/desktop-api";
+import { TranscriptDiff } from "./TranscriptDiff";
+import { TranscriptPlan } from "./TranscriptPlan";
+
+export type LiveWorkRailDock = "above" | "sidebar";
+
+export type LiveWorkRailProps = {
+  applications?: DesktopApplicationsSnapshot;
+  /**
+   * Latest cumulative `item/fileChange/outputDelta` activity that
+   * landed in `optimisticEntries`. Surfaces in the Changed Files
+   * section when present.
+   */
+  changedFilesEntry?: AppServerThreadActivityEntry;
+  desktopApi?: DesktopApi;
+  dock: LiveWorkRailDock;
+  /**
+   * Cumulative turn diff from `turn/diff/updated`. Renders in the
+   * Edited Files section with per-file inline diff expansion.
+   */
+  editedFilesEntry?: AppServerThreadActivityEntry;
+  /**
+   * `true` when the rail is showing snapshots from a completed turn
+   * (pinned until the next turn starts). `false` while the live turn
+   * is still producing entries.
+   */
+  pinned: boolean;
+  planEntry?: AppServerThreadPlanEntry;
+  onDockChange: (dock: LiveWorkRailDock) => void;
+};
+
+export function LiveWorkRail(props: LiveWorkRailProps) {
+  const hasContent = Boolean(
+    props.planEntry || props.editedFilesEntry || props.changedFilesEntry,
+  );
+  const [collapsed, setCollapsed] = useState(false);
+
+  if (!hasContent) {
+    return null;
+  }
+
+  const dockToggleLabel =
+    props.dock === "above" ? "Dock to sidebar" : "Dock above composer";
+  const nextDock: LiveWorkRailDock = props.dock === "above" ? "sidebar" : "above";
+
+  return (
+    <aside
+      className={`live-work-rail live-work-rail--dock-${props.dock}${
+        props.pinned ? " live-work-rail--pinned" : ""
+      }${collapsed ? " live-work-rail--collapsed" : ""}`}
+      role="complementary"
+      aria-label={props.pinned ? "Last turn's work" : "Live work"}
+    >
+      <header className="live-work-rail__header">
+        <button
+          type="button"
+          className="live-work-rail__collapse"
+          aria-expanded={!collapsed}
+          aria-controls={undefined}
+          onClick={() => setCollapsed((current) => !current)}
+        >
+          <span className="live-work-rail__chevron" aria-hidden="true" />
+          <span className="live-work-rail__title">
+            {props.pinned ? "Last turn" : "Live work"}
+          </span>
+        </button>
+        <button
+          type="button"
+          className="live-work-rail__dock-toggle"
+          onClick={() => props.onDockChange(nextDock)}
+          aria-label={dockToggleLabel}
+          title={dockToggleLabel}
+        >
+          {props.dock === "above" ? "Sidebar" : "Above"}
+        </button>
+      </header>
+
+      {!collapsed ? (
+        <div className="live-work-rail__body">
+          {props.planEntry ? (
+            <LiveWorkSection title="Plan">
+              <TranscriptPlan
+                entry={props.planEntry}
+                applications={props.applications}
+                desktopApi={props.desktopApi}
+              />
+            </LiveWorkSection>
+          ) : null}
+
+          {props.editedFilesEntry ? (
+            <EditedFilesSection entry={props.editedFilesEntry} />
+          ) : null}
+
+          {props.changedFilesEntry ? (
+            <ChangedFilesSection entry={props.changedFilesEntry} />
+          ) : null}
+        </div>
+      ) : null}
+    </aside>
+  );
+}
+
+function LiveWorkSection(props: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="live-work-rail__section" aria-label={props.title}>
+      {props.children}
+    </section>
+  );
+}
+
+function EditedFilesSection(props: {
+  entry: AppServerThreadActivityEntry;
+}) {
+  const headingId = useId();
+  const filesWithDiffs = props.entry.details.filter(
+    (detail) => detail.fileDiff,
+  );
+  const fileCount = filesWithDiffs.length;
+  const summaryLabel =
+    fileCount > 0
+      ? props.entry.summary
+      : `${props.entry.summary} (no file details)`;
+
+  return (
+    <section
+      className="live-work-rail__section live-work-rail__section--edited"
+      aria-labelledby={headingId}
+    >
+      <h3 id={headingId} className="live-work-rail__section-heading">
+        {summaryLabel}
+      </h3>
+      {fileCount === 0 ? null : (
+        <ul className="live-work-rail__file-list">
+          {filesWithDiffs.map((detail) => (
+            <li key={detail.id} className="live-work-rail__file-row">
+              <EditedFileRow detail={detail} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function EditedFileRow(props: {
+  detail: AppServerThreadActivityDetail;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const diffId = useId();
+  const additions = props.detail.fileDiff?.additions ?? 0;
+  const removals = props.detail.fileDiff?.removals ?? 0;
+
+  return (
+    <>
+      <button
+        type="button"
+        className="live-work-rail__file-toggle"
+        aria-controls={diffId}
+        aria-expanded={expanded}
+        onClick={() => setExpanded((current) => !current)}
+      >
+        <span className="live-work-rail__chevron" aria-hidden="true" />
+        <span className="live-work-rail__file-path" title={props.detail.path}>
+          {props.detail.label}
+        </span>
+        <span className="live-work-rail__file-stats" aria-label="File diff summary">
+          <span className="live-work-rail__file-stat live-work-rail__file-stat--removed">
+            -{removals.toLocaleString()}
+          </span>
+          <span className="live-work-rail__file-stat live-work-rail__file-stat--added">
+            +{additions.toLocaleString()}
+          </span>
+        </span>
+      </button>
+      {expanded ? (
+        <div id={diffId} className="live-work-rail__file-diff">
+          <TranscriptDiff detail={props.detail} />
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+function ChangedFilesSection(props: {
+  entry: AppServerThreadActivityEntry;
+}) {
+  const headingId = useId();
+  return (
+    <section
+      className="live-work-rail__section live-work-rail__section--changed"
+      aria-labelledby={headingId}
+    >
+      <h3 id={headingId} className="live-work-rail__section-heading">
+        {props.entry.summary}
+      </h3>
+      <ul className="live-work-rail__file-list live-work-rail__file-list--static">
+        {props.entry.details.map((detail) => (
+          <li
+            key={detail.id}
+            className="live-work-rail__file-row live-work-rail__file-row--static"
+          >
+            <span className="live-work-rail__file-path" title={detail.path}>
+              {detail.label}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useRef, useState, type CSSProperties } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+} from "react";
 import type {
   AppServerCollaborationModeRequest,
   AppServerPendingRequestNotification,
@@ -38,6 +45,7 @@ import { ThreadContextPanel } from "./ThreadContextPanel";
 import { ThreadHeader } from "./ThreadHeader";
 import { TranscriptImageLightbox } from "./TranscriptImageLightbox";
 import { TranscriptList } from "./TranscriptList";
+import { LiveWorkRail, type LiveWorkRailDock } from "./LiveWorkRail";
 import {
   buildQuestionnaireResponse,
   type PendingQuestionnaireState,
@@ -852,6 +860,28 @@ export function ThreadView(props: ThreadViewProps) {
     useState<AppServerThreadActivityEntry>();
   const [pendingPlanEntry, setPendingPlanEntry] =
     useState<AppServerThreadPlanEntry>();
+  // Snapshots of the two rail-owned live entries at turn/completed
+  // time. The LiveWorkRail uses these to keep showing what the last
+  // turn produced even after the live state has cleared, until the
+  // next turn starts. `pendingProtocolActivityEntry` (MCP status /
+  // warnings) is not snapshotted because it doesn't belong in the
+  // rail; the dupe-fix that clears it on turn/completed still applies.
+  const [lastCompletedActivityEntry, setLastCompletedActivityEntry] =
+    useState<AppServerThreadActivityEntry>();
+  const [lastCompletedPlanEntry, setLastCompletedPlanEntry] =
+    useState<AppServerThreadPlanEntry>();
+  const [liveWorkRailDock, setLiveWorkRailDock] =
+    useState<LiveWorkRailDock>("above");
+  // Refs mirror the pending state so the turn/completed handler can read
+  // the latest values to snapshot, then clear via setState without
+  // racing or queuing extra micro-renders.
+  const pendingActivityEntryRef = useRef<AppServerThreadActivityEntry | undefined>(
+    undefined,
+  );
+  const pendingProtocolActivityEntryRef = useRef<
+    AppServerThreadActivityEntry | undefined
+  >(undefined);
+  const pendingPlanEntryRef = useRef<AppServerThreadPlanEntry | undefined>(undefined);
   const [pendingRequestBusy, setPendingRequestBusy] = useState(false);
   const [pendingRequestError, setPendingRequestError] = useState<string>();
   const [expandedImage, setExpandedImage] = useState<AppServerThreadImagePart>();
@@ -886,6 +916,8 @@ export function ThreadView(props: ThreadViewProps) {
     setPendingActivityEntry(undefined);
     setPendingProtocolActivityEntry(undefined);
     setPendingPlanEntry(undefined);
+    setLastCompletedActivityEntry(undefined);
+    setLastCompletedPlanEntry(undefined);
     setPendingRequestBusy(false);
     setPendingRequestError(undefined);
     setSetupFailureArchiving(false);
@@ -901,6 +933,30 @@ export function ThreadView(props: ThreadViewProps) {
     props.selectedThread?.id,
     props.selectedThread?.source,
   ]);
+
+  useEffect(() => {
+    pendingActivityEntryRef.current = pendingActivityEntry;
+  }, [pendingActivityEntry]);
+  useEffect(() => {
+    pendingProtocolActivityEntryRef.current = pendingProtocolActivityEntry;
+  }, [pendingProtocolActivityEntry]);
+  useEffect(() => {
+    pendingPlanEntryRef.current = pendingPlanEntry;
+  }, [pendingPlanEntry]);
+
+  // When a new turn begins, clear the pinned snapshots from the prior
+  // turn so the LiveWorkRail reflects the in-flight turn's work, not
+  // stale history. Triggered by activeTurnId transitioning to a new
+  // non-empty value (turn/started fired upstream).
+  const lastSeenActiveTurnIdRef = useRef<string | undefined>(props.activeTurnId);
+  useEffect(() => {
+    const previous = lastSeenActiveTurnIdRef.current;
+    lastSeenActiveTurnIdRef.current = props.activeTurnId;
+    if (props.activeTurnId && props.activeTurnId !== previous) {
+      setLastCompletedActivityEntry(undefined);
+      setLastCompletedPlanEntry(undefined);
+    }
+  }, [props.activeTurnId]);
 
   const selectedThread = props.selectedThread;
   const selectedLaunchpad = props.selectedLaunchpad;
@@ -1226,6 +1282,34 @@ export function ThreadView(props: ThreadViewProps) {
     [props.activeTurnId]
   );
 
+  // The latest `item/fileChange/outputDelta` activity entry (after #493
+  // these live in optimisticEntries → props.transcriptEntries, not in
+  // a separate pending state slot). We find the most recently created
+  // one tagged by id prefix so the LiveWorkRail can display it as the
+  // current Changed Files section. Re-uses the persisted entry as-is
+  // for the pinned-after-turn case — file-change entries already stay
+  // in optimisticEntries after the turn ends.
+  const liveWorkRailChangedFilesEntry = useMemo(() => {
+    let latest: AppServerThreadActivityEntry | undefined;
+    for (const entry of props.transcriptEntries) {
+      if (
+        entry.type !== "activity" ||
+        !entry.id.startsWith("live-file-change-")
+      ) {
+        continue;
+      }
+      if (
+        !latest ||
+        (typeof entry.createdAt === "number" &&
+          typeof latest.createdAt === "number" &&
+          entry.createdAt >= latest.createdAt)
+      ) {
+        latest = entry;
+      }
+    }
+    return latest;
+  }, [props.transcriptEntries]);
+
   useEffect(() => {
     if (!pendingActivityEntry) {
       return;
@@ -1337,27 +1421,35 @@ export function ThreadView(props: ThreadViewProps) {
           const completeEntryTurn = <T extends { turn?: AppServerThreadTurnMetadata }>(
             entry: T | undefined
           ): T | undefined => (entry ? { ...entry, turn: liveTurn } : undefined);
-          setPendingActivityEntry((current) => {
-            const next = completeEntryTurn(current);
-            if (next) {
-              deferLiveTranscriptEntry(next);
-            }
-            return next;
-          });
-          setPendingProtocolActivityEntry((current) => {
-            const next = completeEntryTurn(current);
-            if (next) {
-              deferLiveTranscriptEntry(next);
-            }
-            return next;
-          });
-          setPendingPlanEntry((current) => {
-            const next = completeEntryTurn(current);
-            if (next) {
-              deferLiveTranscriptEntry(next);
-            }
-            return next;
-          });
+          // Defer each live entry into the persistent transcript via
+          // optimisticEntries, snapshot the rail-owned ones (Edited
+          // Files, Plan) for the LiveWorkRail's "pinned to last turn"
+          // display, then clear every pending slot so the transcript
+          // doesn't render the same entry twice (the dupe-row bug
+          // from issue #495). pendingProtocolActivityEntry holds MCP
+          // status / warnings, which the rail doesn't own — we still
+          // clear it to fix the duplicate, but don't snapshot.
+          const completedActivity = completeEntryTurn(pendingActivityEntryRef.current);
+          if (completedActivity) {
+            deferLiveTranscriptEntry(completedActivity);
+            setLastCompletedActivityEntry(completedActivity);
+          }
+          setPendingActivityEntry(undefined);
+
+          const completedProtocolActivity = completeEntryTurn(
+            pendingProtocolActivityEntryRef.current,
+          );
+          if (completedProtocolActivity) {
+            deferLiveTranscriptEntry(completedProtocolActivity);
+          }
+          setPendingProtocolActivityEntry(undefined);
+
+          const completedPlan = completeEntryTurn(pendingPlanEntryRef.current);
+          if (completedPlan) {
+            deferLiveTranscriptEntry(completedPlan);
+            setLastCompletedPlanEntry(completedPlan);
+          }
+          setPendingPlanEntry(undefined);
         }
         return;
       }
@@ -1871,9 +1963,15 @@ export function ThreadView(props: ThreadViewProps) {
               loading={props.loading}
               loadingMore={props.loadingMore}
               pagination={props.transcriptPagination}
-              pendingActivityEntry={pendingActivityEntry}
+              // pendingActivityEntry and pendingPlanEntry render in
+              // the LiveWorkRail above the composer (issue #495); pass
+              // undefined here so the transcript doesn't double-render
+              // the same live state. The persisted/optimistic copies
+              // that settle after `turn/completed` still flow through
+              // `entries`, so the transcript history is unaffected.
+              pendingActivityEntry={undefined}
               pendingAssistantMessage={props.pendingAssistantMessage}
-              pendingPlanEntry={pendingPlanEntry}
+              pendingPlanEntry={undefined}
               pendingMcpInteraction={props.pendingMcpInteraction}
               pendingRequest={props.pendingRequest}
               pendingRequestBusy={pendingRequestBusy}
@@ -1901,6 +1999,25 @@ export function ThreadView(props: ThreadViewProps) {
               <p className="transcript-error">{pendingRequestError}</p>
             ) : null}
           </section>
+
+          {liveWorkRailDock === "above" ? (
+            <LiveWorkRail
+              applications={props.applications}
+              changedFilesEntry={liveWorkRailChangedFilesEntry}
+              desktopApi={props.desktopApi}
+              dock="above"
+              editedFilesEntry={
+                pendingActivityEntry ??
+                (props.activeTurnId ? undefined : lastCompletedActivityEntry)
+              }
+              pinned={!props.activeTurnId}
+              planEntry={
+                pendingPlanEntry ??
+                (props.activeTurnId ? undefined : lastCompletedPlanEntry)
+              }
+              onDockChange={setLiveWorkRailDock}
+            />
+          ) : null}
 
           <Composer
             activeTurnId={props.activeTurnId}
@@ -1951,6 +2068,25 @@ export function ThreadView(props: ThreadViewProps) {
             updatingExecutionMode={props.updatingExecutionMode}
           />
         </div>
+
+        {liveWorkRailDock === "sidebar" ? (
+          <LiveWorkRail
+            applications={props.applications}
+            changedFilesEntry={liveWorkRailChangedFilesEntry}
+            desktopApi={props.desktopApi}
+            dock="sidebar"
+            editedFilesEntry={
+              pendingActivityEntry ??
+              (props.activeTurnId ? undefined : lastCompletedActivityEntry)
+            }
+            pinned={!props.activeTurnId}
+            planEntry={
+              pendingPlanEntry ??
+              (props.activeTurnId ? undefined : lastCompletedPlanEntry)
+            }
+            onDockChange={setLiveWorkRailDock}
+          />
+        ) : null}
 
         <ThreadContextPanel
           backendError={props.backendError}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -58,6 +58,7 @@ import {
   formatChangedFileSummary,
   getBasename,
   mergeActivityDetails,
+  readRendererSequence,
   summarizeActivityStatus,
 } from "./live-transcript-activity";
 
@@ -936,13 +937,9 @@ export function ThreadView(props: ThreadViewProps) {
 
   useEffect(() => {
     pendingActivityEntryRef.current = pendingActivityEntry;
-  }, [pendingActivityEntry]);
-  useEffect(() => {
     pendingProtocolActivityEntryRef.current = pendingProtocolActivityEntry;
-  }, [pendingProtocolActivityEntry]);
-  useEffect(() => {
     pendingPlanEntryRef.current = pendingPlanEntry;
-  }, [pendingPlanEntry]);
+  }, [pendingActivityEntry, pendingProtocolActivityEntry, pendingPlanEntry]);
 
   // When a new turn begins, clear the pinned snapshots from the prior
   // turn so the LiveWorkRail reflects the in-flight turn's work, not
@@ -1298,11 +1295,42 @@ export function ThreadView(props: ThreadViewProps) {
       ) {
         continue;
       }
+      if (!latest) {
+        latest = entry;
+        continue;
+      }
+      // Pick by createdAt, tiebreak by rendererSequence — same order
+      // mergeTranscriptEntries uses so the rail's pick stays
+      // consistent with where the entry sits in the transcript when
+      // wall-clock timestamps collide under fast-CI batching (the
+      // PR #493 scenario).
+      const entryCreatedAt =
+        typeof entry.createdAt === "number" ? entry.createdAt : undefined;
+      const latestCreatedAt =
+        typeof latest.createdAt === "number" ? latest.createdAt : undefined;
       if (
-        !latest ||
-        (typeof entry.createdAt === "number" &&
-          typeof latest.createdAt === "number" &&
-          entry.createdAt >= latest.createdAt)
+        typeof entryCreatedAt === "number" &&
+        typeof latestCreatedAt === "number"
+      ) {
+        if (entryCreatedAt > latestCreatedAt) {
+          latest = entry;
+          continue;
+        }
+        if (entryCreatedAt < latestCreatedAt) {
+          continue;
+        }
+      } else if (typeof entryCreatedAt === "number") {
+        latest = entry;
+        continue;
+      } else if (typeof latestCreatedAt === "number") {
+        continue;
+      }
+      const entrySequence = readRendererSequence(entry);
+      const latestSequence = readRendererSequence(latest);
+      if (
+        typeof entrySequence === "number" &&
+        typeof latestSequence === "number" &&
+        entrySequence > latestSequence
       ) {
         latest = entry;
       }

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptDiff.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptDiff.tsx
@@ -11,6 +11,13 @@ import { useDesktopApi } from "../../lib/desktop-api";
 
 type TranscriptDiffProps = {
   detail: AppServerThreadActivityDetail;
+  /**
+   * When the parent already shows the file path and additions/removals
+   * stats (e.g. the LiveWorkRail's expanded file row), pass `true` to
+   * hide the redundant `transcript-diff__path` + stats in the diff
+   * header. The zoom toggle still renders.
+   */
+  compact?: boolean;
 };
 
 export function TranscriptDiff(props: TranscriptDiffProps) {
@@ -82,7 +89,7 @@ export function TranscriptDiff(props: TranscriptDiffProps) {
 
   return (
     <div className="transcript-diff">
-      {props.detail.path ? (
+      {props.detail.path && !props.compact ? (
         <p className="transcript-diff__path" title={props.detail.path}>
           {props.detail.path}
         </p>
@@ -90,14 +97,16 @@ export function TranscriptDiff(props: TranscriptDiffProps) {
 
       <div className="transcript-diff__toolbar">
         <div className="transcript-diff__meta">
-          <div className="transcript-diff__stats" aria-label="Diff summary">
-            <span className="transcript-diff__stat transcript-diff__stat--removed">
-              -{diff.removals}
-            </span>
-            <span className="transcript-diff__stat transcript-diff__stat--added">
-              +{diff.additions}
-            </span>
-          </div>
+          {props.compact ? null : (
+            <div className="transcript-diff__stats" aria-label="Diff summary">
+              <span className="transcript-diff__stat transcript-diff__stat--removed">
+                -{diff.removals}
+              </span>
+              <span className="transcript-diff__stat transcript-diff__stat--added">
+                +{diff.additions}
+              </span>
+            </div>
+          )}
           {hiddenSummary ? (
             <span className="transcript-diff__summary">{hiddenSummary}</span>
           ) : null}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/LiveWorkRail.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/LiveWorkRail.test.tsx
@@ -82,7 +82,7 @@ describe("LiveWorkRail", () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it("shows the live title when not pinned", () => {
+  it("titles the rail with the present section names when not pinned", () => {
     render(
       <LiveWorkRail
         dock="above"
@@ -91,11 +91,15 @@ describe("LiveWorkRail", () => {
         onDockChange={() => undefined}
       />,
     );
-    expect(screen.getByRole("complementary", { name: "Live work" })).toBeInTheDocument();
-    expect(screen.getByText("Live work")).toBeInTheDocument();
+    expect(
+      screen.getByRole("complementary", { name: "Edited Files" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Edited Files/i }),
+    ).toBeInTheDocument();
   });
 
-  it("shows the last-turn title when pinned", () => {
+  it("suffixes the aria label with (last turn) when pinned but keeps the section name in the visible title", () => {
     render(
       <LiveWorkRail
         dock="above"
@@ -105,9 +109,29 @@ describe("LiveWorkRail", () => {
       />,
     );
     expect(
-      screen.getByRole("complementary", { name: "Last turn's work" }),
+      screen.getByRole("complementary", { name: "Edited Files (last turn)" }),
     ).toBeInTheDocument();
-    expect(screen.getByText("Last turn")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Edited Files/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("joins multiple present section names with commas", () => {
+    render(
+      <LiveWorkRail
+        dock="above"
+        pinned={false}
+        planEntry={buildPlanEntry()}
+        editedFilesEntry={buildEditedFilesEntry()}
+        changedFilesEntry={buildChangedFilesEntry()}
+        onDockChange={() => undefined}
+      />,
+    );
+    expect(
+      screen.getByRole("complementary", {
+        name: "Plan, Edited Files, Changed Files",
+      }),
+    ).toBeInTheDocument();
   });
 
   it("renders the edited-files summary as a section heading and expands a file diff in place", () => {
@@ -173,7 +197,7 @@ describe("LiveWorkRail", () => {
         onDockChange={() => undefined}
       />,
     );
-    const collapseButton = screen.getByRole("button", { name: /Live work/i });
+    const collapseButton = screen.getByRole("button", { name: /Edited Files/i });
     expect(
       screen.getByRole("heading", { level: 3, name: /Edited 2 files/i }),
     ).toBeInTheDocument();

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/LiveWorkRail.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/LiveWorkRail.test.tsx
@@ -1,0 +1,239 @@
+import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type {
+  AppServerThreadActivityEntry,
+  AppServerThreadPlanEntry,
+} from "@pwragent/shared";
+import { describe, expect, it, vi } from "vitest";
+import { LiveWorkRail } from "../LiveWorkRail";
+
+function buildEditedFilesEntry(): AppServerThreadActivityEntry {
+  return {
+    type: "activity",
+    id: "live-diff-turn-1",
+    summary: "Edited 2 files, +5, -2",
+    createdAt: 1_000,
+    details: [
+      {
+        id: "detail-1",
+        kind: "write",
+        label: "Update AGENTS.md",
+        path: "/repo/AGENTS.md",
+        fileDiff: {
+          kind: "update",
+          additions: 3,
+          removals: 0,
+          diff:
+            "--- a/AGENTS.md\n+++ b/AGENTS.md\n@@ -1,1 +1,4 @@\n line\n+a\n+b\n+c\n",
+        },
+      },
+      {
+        id: "detail-2",
+        kind: "write",
+        label: "Update README.md",
+        path: "/repo/README.md",
+        fileDiff: {
+          kind: "update",
+          additions: 2,
+          removals: 2,
+          diff: "--- a/README.md\n+++ b/README.md\n@@ -1,2 +1,2 @@\n-x\n-y\n+a\n+b\n",
+        },
+      },
+    ],
+  };
+}
+
+function buildChangedFilesEntry(): AppServerThreadActivityEntry {
+  return {
+    type: "activity",
+    id: "live-file-change-call-1",
+    summary: "Changed 1 file",
+    createdAt: 1_000,
+    details: [
+      {
+        id: "live-file-change-call-1-1",
+        kind: "write",
+        label: "Modified Composer.tsx",
+        path: "apps/desktop/src/renderer/src/features/composer/Composer.tsx",
+      },
+    ],
+  };
+}
+
+function buildPlanEntry(): AppServerThreadPlanEntry {
+  return {
+    type: "plan",
+    id: "live-plan-turn-1",
+    createdAt: 1_000,
+    markdown: "",
+    steps: [
+      { step: "Investigate the bug", status: "completed" },
+      { step: "Apply the fix", status: "in_progress" },
+      { step: "Add a regression test", status: "pending" },
+    ],
+  };
+}
+
+describe("LiveWorkRail", () => {
+  it("renders nothing when there's no live or pinned content", () => {
+    const { container } = render(
+      <LiveWorkRail dock="above" pinned={false} onDockChange={() => undefined} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the live title when not pinned", () => {
+    render(
+      <LiveWorkRail
+        dock="above"
+        pinned={false}
+        editedFilesEntry={buildEditedFilesEntry()}
+        onDockChange={() => undefined}
+      />,
+    );
+    expect(screen.getByRole("complementary", { name: "Live work" })).toBeInTheDocument();
+    expect(screen.getByText("Live work")).toBeInTheDocument();
+  });
+
+  it("shows the last-turn title when pinned", () => {
+    render(
+      <LiveWorkRail
+        dock="above"
+        pinned={true}
+        editedFilesEntry={buildEditedFilesEntry()}
+        onDockChange={() => undefined}
+      />,
+    );
+    expect(
+      screen.getByRole("complementary", { name: "Last turn's work" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Last turn")).toBeInTheDocument();
+  });
+
+  it("renders the edited-files summary as a section heading and expands a file diff in place", () => {
+    render(
+      <LiveWorkRail
+        dock="above"
+        pinned={false}
+        editedFilesEntry={buildEditedFilesEntry()}
+        onDockChange={() => undefined}
+      />,
+    );
+    expect(
+      screen.getByRole("heading", { level: 3, name: /Edited 2 files, \+5, -2/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Update AGENTS\.md/i }),
+    ).toBeInTheDocument();
+
+    // Diff body not visible until the file row is expanded.
+    expect(screen.queryByText(/@@ -1,1 \+1,4 @@/)).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Update AGENTS\.md/i }));
+    expect(screen.getByText(/Diff for AGENTS\.md|@@ -1,1 \+1,4 @@|\+a/)).toBeInTheDocument();
+  });
+
+  it("renders the Changed Files section as a static list (no diff expand)", () => {
+    render(
+      <LiveWorkRail
+        dock="above"
+        pinned={false}
+        changedFilesEntry={buildChangedFilesEntry()}
+        onDockChange={() => undefined}
+      />,
+    );
+    expect(
+      screen.getByRole("heading", { level: 3, name: /Changed 1 file/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Modified Composer.tsx")).toBeInTheDocument();
+    // No expand button for the row — protocol fileChange notifications
+    // don't carry diffs.
+    expect(
+      screen.queryByRole("button", { name: /Modified Composer\.tsx/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the plan section by delegating to TranscriptPlan", () => {
+    render(
+      <LiveWorkRail
+        dock="above"
+        pinned={false}
+        planEntry={buildPlanEntry()}
+        onDockChange={() => undefined}
+      />,
+    );
+    expect(screen.getByText("1 out of 3 tasks completed")).toBeInTheDocument();
+  });
+
+  it("toggles the whole rail collapsed and expanded from the title button", () => {
+    render(
+      <LiveWorkRail
+        dock="above"
+        pinned={false}
+        editedFilesEntry={buildEditedFilesEntry()}
+        onDockChange={() => undefined}
+      />,
+    );
+    const collapseButton = screen.getByRole("button", { name: /Live work/i });
+    expect(
+      screen.getByRole("heading", { level: 3, name: /Edited 2 files/i }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(collapseButton);
+    expect(
+      screen.queryByRole("heading", { level: 3, name: /Edited 2 files/i }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(collapseButton);
+    expect(
+      screen.getByRole("heading", { level: 3, name: /Edited 2 files/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("flips the dock via the dock-toggle button", () => {
+    const onDockChange = vi.fn();
+    render(
+      <LiveWorkRail
+        dock="above"
+        pinned={false}
+        editedFilesEntry={buildEditedFilesEntry()}
+        onDockChange={onDockChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Dock to sidebar" }));
+    expect(onDockChange).toHaveBeenCalledWith("sidebar");
+  });
+
+  it("offers the reverse dock label when already in sidebar mode", () => {
+    const onDockChange = vi.fn();
+    render(
+      <LiveWorkRail
+        dock="sidebar"
+        pinned={false}
+        editedFilesEntry={buildEditedFilesEntry()}
+        onDockChange={onDockChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Dock above composer" }));
+    expect(onDockChange).toHaveBeenCalledWith("above");
+  });
+
+  it("renders all three sections together with the right headings", () => {
+    render(
+      <LiveWorkRail
+        dock="above"
+        pinned={false}
+        planEntry={buildPlanEntry()}
+        editedFilesEntry={buildEditedFilesEntry()}
+        changedFilesEntry={buildChangedFilesEntry()}
+        onDockChange={() => undefined}
+      />,
+    );
+    expect(screen.getByText("1 out of 3 tasks completed")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { level: 3, name: /Edited 2 files, \+5, -2/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { level: 3, name: /Changed 1 file/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -3712,7 +3712,7 @@ describe("ThreadView", () => {
 
     // Rail shows the pinned snapshot from turn 1.
     expect(
-      screen.getByRole("complementary", { name: "Last turn's work" }),
+      screen.getByRole("complementary", { name: /\(last turn\)/i }),
     ).toBeInTheDocument();
 
     // Simulate the next turn starting.

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -1606,11 +1606,13 @@ describe("ThreadView", () => {
       });
     });
 
-    const toggle = screen.getByRole("button", { name: /Edited 1 file, \+1, -2/i });
-    expect(toggle).toBeInTheDocument();
-
-    fireEvent.click(toggle);
-
+    // The LiveWorkRail (above the composer per issue #495) renders the
+    // cumulative diff summary as a section heading and each file as
+    // its own expand button — no second click needed to reach the
+    // file list, unlike the old in-transcript activity row.
+    expect(
+      screen.getByRole("heading", { level: 3, name: /Edited 1 file, \+1, -2/i }),
+    ).toBeInTheDocument();
     expect(screen.getByText("Update useThreadSessionState.ts")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: /Update useThreadSessionState.ts/i }));
 
@@ -3472,6 +3474,258 @@ describe("ThreadView", () => {
     ).not.toBeInTheDocument();
     expect(
       screen.queryByText("Environment setup failed"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps the edited-files entry visible exactly once after turn/completed (no duplicate-row regression — issue #495)", async () => {
+    // Reproduces the duplicate-row bug from issue #495: prior to the
+    // fix, `turn/completed` deferred the pending entry into
+    // optimisticEntries (and thus the transcript) AND left it as the
+    // pending entry — two rows for the same diff. After the fix, the
+    // rail owns the pending entry, the transcript owns the deferred
+    // entry, and there is exactly one rendering at any given time.
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    let agentEventHandler:
+      | ((event: { backend: "codex"; notification: AppServerNotification }) => void)
+      | undefined;
+    const liveDiff = [
+      "diff --git a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts",
+      "--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts",
+      "+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts",
+      "@@ -113,2 +113,1 @@",
+      "-<<<<<<< HEAD",
+      "-function appendMessageEntries(",
+      "+function messageMatchesOptimisticEntry(",
+    ].join("\n");
+
+    function Harness() {
+      // Mirrors the real upstream lifecycle: the hook clears
+      // `activeTurnId` on `turn/completed` so the rail flips from
+      // live → pinned. The Harness simulates that here.
+      const [activeTurnId, setActiveTurnId] = useState<string | undefined>("turn-1");
+      const [entries, setEntries] = useState<any[]>([]);
+      return (
+        <ThreadView
+          activeTurnId={activeTurnId}
+          activeTurnStartedAt={1_000}
+          addOptimisticUserMessage={(_text) => "optimistic-1"}
+          backends={[]}
+          composerDisabled={false}
+          desktopApi={{
+            onAgentEvent: (callback) => {
+              const wrapped: typeof callback = (event) => {
+                callback(event);
+                if (event.notification.method === "turn/completed") {
+                  setActiveTurnId(undefined);
+                }
+              };
+              agentEventHandler = wrapped as typeof agentEventHandler;
+              return () => undefined;
+            },
+          }}
+          loading={false}
+          loadingMore={false}
+          messageCount={entries.length}
+          selectedThread={{
+            id: "thread-dupe",
+            title: "Dupe-fix regression",
+            titleSource: "explicit",
+            source: "codex",
+            updatedAt: Date.now(),
+            linkedDirectories: [],
+            inbox: { inInbox: false },
+          }}
+          skills={[]}
+          transcriptEntries={entries}
+          clearPendingRequest={() => undefined}
+          onLiveTranscriptEntry={(entry) => {
+            setEntries((current) => [...current, entry]);
+          }}
+          onLoadOlder={async () => undefined}
+          removeOptimisticMessage={(_id) => undefined}
+        />
+      );
+    }
+
+    try {
+      render(<Harness />);
+
+      // During the active turn, the rail (h3 heading) is the single
+      // display surface for the cumulative diff.
+      await act(async () => {
+        agentEventHandler?.({
+          backend: "codex",
+          notification: {
+            method: "turn/diff/updated",
+            params: { threadId: "thread-dupe", turnId: "turn-1", diff: liveDiff },
+          },
+        });
+      });
+      expect(
+        screen.getAllByRole("heading", { level: 3, name: /Edited 1 file/i }),
+      ).toHaveLength(1);
+
+      // turn/completed → pending cleared, snapshot keeps the rail
+      // showing, deferred entry settles into the transcript via
+      // optimisticEntries. Total "Edited 1 file" visible should still
+      // be exactly one (rail heading) plus zero or one transcript row.
+      await act(async () => {
+        agentEventHandler?.({
+          backend: "codex",
+          notification: {
+            method: "turn/completed",
+            params: {
+              threadId: "thread-dupe",
+              turnId: "turn-1",
+              turn: {
+                id: "turn-1",
+                status: "completed",
+                completedAt: 2_000,
+                output: [],
+              },
+            },
+          },
+        });
+      });
+      // Wait for the deferred microtask + state flushes to settle.
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      // Rail heading stays (pinned snapshot). The transcript also
+      // receives the deferred entry, which renders TranscriptActivity's
+      // toggle button — separate display surface. Two displays of the
+      // same conceptual entry across rail + transcript is the
+      // user-approved post-#495 model; what we strictly forbid is
+      // *duplication within a single surface*.
+      expect(
+        screen.getAllByRole("heading", { level: 3, name: /Edited 1 file/i }),
+      ).toHaveLength(1);
+      expect(
+        screen.queryAllByRole("button", { name: /^Edited 1 file/i }).length,
+      ).toBeLessThanOrEqual(1);
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  it("clears the pinned rail when a new turn starts (issue #495)", async () => {
+    let agentEventHandler:
+      | ((event: { backend: "codex"; notification: AppServerNotification }) => void)
+      | undefined;
+    const liveDiff = [
+      "diff --git a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts",
+      "--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts",
+      "+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts",
+      "@@ -1,1 +1,2 @@",
+      " existing line",
+      "+added by turn 1",
+    ].join("\n");
+
+    function Harness() {
+      const [activeTurnId, setActiveTurnId] = useState<string | undefined>("turn-1");
+      const [entries, setEntries] = useState<any[]>([]);
+      return (
+        <>
+          <button type="button" onClick={() => setActiveTurnId("turn-2")}>
+            Start turn 2
+          </button>
+          <ThreadView
+            activeTurnId={activeTurnId}
+            activeTurnStartedAt={1_000}
+            addOptimisticUserMessage={(_text) => "optimistic-1"}
+            backends={[]}
+            composerDisabled={false}
+            desktopApi={{
+              onAgentEvent: (callback) => {
+                const wrapped: typeof callback = (event) => {
+                  callback(event);
+                  if (event.notification.method === "turn/completed") {
+                    setActiveTurnId(undefined);
+                  }
+                };
+                agentEventHandler = wrapped as typeof agentEventHandler;
+                return () => undefined;
+              },
+            }}
+            loading={false}
+            loadingMore={false}
+            messageCount={entries.length}
+            selectedThread={{
+              id: "thread-pin",
+              title: "Pin lifecycle",
+              titleSource: "explicit",
+              source: "codex",
+              updatedAt: Date.now(),
+              linkedDirectories: [],
+              inbox: { inInbox: false },
+            }}
+            skills={[]}
+            transcriptEntries={entries}
+            clearPendingRequest={() => undefined}
+            onLiveTranscriptEntry={(entry) => {
+              setEntries((current) => [...current, entry]);
+            }}
+            onLoadOlder={async () => undefined}
+            removeOptimisticMessage={(_id) => undefined}
+          />
+        </>
+      );
+    }
+
+    render(<Harness />);
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/diff/updated",
+          params: { threadId: "thread-pin", turnId: "turn-1", diff: liveDiff },
+        },
+      });
+    });
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/completed",
+          params: {
+            threadId: "thread-pin",
+            turnId: "turn-1",
+            turn: {
+              id: "turn-1",
+              status: "completed",
+              completedAt: 2_000,
+              output: [],
+            },
+          },
+        },
+      });
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Rail shows the pinned snapshot from turn 1.
+    expect(
+      screen.getByRole("complementary", { name: "Last turn's work" }),
+    ).toBeInTheDocument();
+
+    // Simulate the next turn starting.
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Start turn 2" }));
+    });
+
+    // Snapshot cleared. The rail still renders the persisted entry
+    // from optimisticEntries (Changed Files section) so it doesn't
+    // disappear entirely, but the Edited Files section is empty until
+    // turn 2 produces its own diff.
+    expect(
+      screen.queryByRole("heading", { level: 3, name: /Edited 1 file/i }),
     ).not.toBeInTheDocument();
   });
 });

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5778,6 +5778,10 @@ textarea,
   gap: 8px;
   padding: 8px 10px;
   border-bottom: 1px solid var(--border-subtle);
+  /* Children need explicit min-width: 0 to let the title truncate
+     instead of forcing the dock toggle off-screen on narrow
+     viewports. */
+  min-width: 0;
 }
 
 .live-work-rail--collapsed .live-work-rail__header {
@@ -5794,6 +5798,9 @@ textarea,
   color: var(--text-primary);
   cursor: pointer;
   font: inherit;
+  /* Lets the title inside ellipsize when narrow. */
+  min-width: 0;
+  flex: 1 1 auto;
 }
 
 .live-work-rail__title {
@@ -5802,6 +5809,14 @@ textarea,
   letter-spacing: 0.04em;
   text-transform: uppercase;
   color: var(--text-muted);
+  /* Narrow viewports: comma-joined section names can exceed the
+     header width. Truncate with an ellipsis so the dock toggle stays
+     reachable. The full title still reads via the aside's
+     aria-label (e.g. "Plan, Edited Files (last turn)"). */
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
 }
 
 .live-work-rail--pinned .live-work-rail__title {
@@ -5809,6 +5824,7 @@ textarea,
 }
 
 .live-work-rail__dock-toggle {
+  flex: 0 0 auto;
   padding: 2px 8px;
   border: 1px solid var(--border-subtle);
   border-radius: 4px;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5746,7 +5746,10 @@ textarea,
 }
 
 .live-work-rail--dock-above {
-  width: min(100%, 760px);
+  /* Cap at the same width as the composer + transcript reading
+     column (--chat-column-max) so the rail lines up visually with
+     the composer's input. Issue #495 follow-up. */
+  width: min(100%, var(--chat-column-max));
   align-self: center;
   margin: 0 16px 8px;
   /* Bounded height: composer + transcript should still own the

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5730,6 +5730,214 @@ textarea,
   color: inherit;
 }
 
+/* LiveWorkRail (issue #495) — sticky cumulative view of the active or
+   most-recently-completed turn's edited files + plan. Two dock modes:
+   "above" flows in the primary column between the transcript and the
+   composer; "sidebar" mounts as a third column at the layout level. */
+.live-work-rail {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-panel-elevated);
+  color: var(--text-primary);
+  font-size: 13px;
+}
+
+.live-work-rail--dock-above {
+  width: min(100%, 760px);
+  align-self: center;
+  margin: 0 16px 8px;
+  /* Bounded height: composer + transcript should still own the
+     vertical space. The rail caps at ~38% of viewport then scrolls
+     internally so a 50-file refactor doesn't push the composer off
+     screen. */
+  max-height: min(38vh, 360px);
+}
+
+.live-work-rail--dock-sidebar {
+  width: 320px;
+  flex: 0 0 320px;
+  margin: 12px 12px 12px 0;
+  border-radius: 8px;
+  max-height: none;
+}
+
+.live-work-rail--pinned {
+  border-color: color-mix(in srgb, var(--text-muted) 30%, var(--border-subtle));
+}
+
+.live-work-rail__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.live-work-rail--collapsed .live-work-rail__header {
+  border-bottom: 0;
+}
+
+.live-work-rail__collapse {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 4px;
+  border: 0;
+  background: transparent;
+  color: var(--text-primary);
+  cursor: pointer;
+  font: inherit;
+}
+
+.live-work-rail__title {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.live-work-rail--pinned .live-work-rail__title {
+  color: color-mix(in srgb, var(--text-muted) 80%, var(--accent));
+}
+
+.live-work-rail__dock-toggle {
+  padding: 2px 8px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 4px;
+  background: var(--bg-input);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.live-work-rail__dock-toggle:hover {
+  border-color: var(--accent-border);
+  color: var(--text-primary);
+}
+
+.live-work-rail__chevron {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-right: 1.5px solid currentColor;
+  border-bottom: 1.5px solid currentColor;
+  transform: rotate(45deg);
+  transition: transform 120ms ease;
+}
+
+.live-work-rail__collapse[aria-expanded="false"] .live-work-rail__chevron {
+  transform: rotate(-45deg);
+}
+
+.live-work-rail__file-toggle[aria-expanded="true"] .live-work-rail__chevron {
+  transform: rotate(45deg);
+}
+
+.live-work-rail__file-toggle[aria-expanded="false"] .live-work-rail__chevron {
+  transform: rotate(-45deg);
+}
+
+.live-work-rail__body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px;
+  overflow-y: auto;
+  min-height: 0;
+}
+
+.live-work-rail__section {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.live-work-rail__section-heading {
+  margin: 0;
+  padding: 4px 6px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.live-work-rail__file-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.live-work-rail__file-list--static {
+  padding-left: 6px;
+}
+
+.live-work-rail__file-row {
+  display: flex;
+  flex-direction: column;
+}
+
+.live-work-rail__file-row--static {
+  padding: 4px 0;
+  color: var(--text-secondary);
+}
+
+.live-work-rail__file-toggle {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 6px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-primary);
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+}
+
+.live-work-rail__file-toggle:hover {
+  background: var(--bg-panel-hover);
+}
+
+.live-work-rail__file-path {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.live-work-rail__file-stats {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-feature-settings: "tnum" 1;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.live-work-rail__file-stat--added {
+  color: var(--success-text);
+}
+
+.live-work-rail__file-stat--removed {
+  color: var(--danger-text);
+}
+
+.live-work-rail__file-diff {
+  padding: 6px 6px 10px 18px;
+}
+
 .transcript-activity {
   width: min(100%, 760px);
   padding: 12px 0 0;


### PR DESCRIPTION
Closes #495.

## What changed

Replaces the duplicated, click-jumpy in-transcript "Edited N files" + plan rows with a sticky, bounded-height rail that sits above the composer (or docks as a right-side sidebar). The rail shows the cumulative turn diff, the live plan, and the latest \`item/fileChange/outputDelta\` entry, with per-file inline diff expansion. After \`turn/completed\` it pins the snapshot until the next \`turn/started\` fires — so you can keep reviewing what just landed without scrolling up.

## The three problems from #495 and how each is addressed

| Problem | Fix |
|---|---|
| **Duplicate "Edited N files" rows in transcript** | The pre-fix \`turn/completed\` handler did \`deferLiveTranscriptEntry(next)\` *and* \`return next\` from \`setPendingActivityEntry\`, so the entry rendered twice (pending + deferred). Now the rail owns the pending entry display, \`TranscriptList\` only sees the persisted/optimistic copy, and the pending slot is cleared on \`turn/completed\`. Same treatment for \`pendingProtocolActivityEntry\` and \`pendingPlanEntry\`. |
| **Click-jump on the in-transcript row** | The "Edited N files" row no longer renders in the transcript during the active turn — it's in the rail (stable position) — so there's nothing to jump under the cursor. |
| **N edits to one file rendered as N rows** | The Edited Files section is fed by \`turn/diff/updated\`, whose protocol contract is *"the latest aggregated diff across all file changes in the turn"* ([`TurnDiffUpdatedNotification.ts`](https://github.com/pwrdrvr/PwrAgent/blob/main/packages/codex-app-server-protocol/src/v2/TurnDiffUpdatedNotification.ts)). \`extractDiffDetails\` already parses this into one row per \`diff --git\` section, so per-file dedup happens at the protocol level — no renderer-side merging needed. |

## Design

- **\`<LiveWorkRail>\`** — new component at [`features/thread-detail/LiveWorkRail.tsx`](apps/desktop/src/renderer/src/features/thread-detail/LiveWorkRail.tsx). Three optional sections rendered top-down: Plan, Edited Files, Changed Files. Each Edited Files row is a button that expands to the full \`TranscriptDiff\` view inline. Changed Files rows are static (the \`fileChange\` protocol notification carries paths only, not diffs). Plan delegates to the existing \`TranscriptPlan\`.
- **Pinned lifecycle** — during the active turn the rail title reads "Live work" and pulls from \`pendingActivityEntry\` / \`pendingPlanEntry\` / latest \`live-file-change-*\` activity. On \`turn/completed\`, the rail-owned pending entries snapshot into \`lastCompletedActivityEntry\` / \`lastCompletedPlanEntry\` and the pending slots clear; the rail title flips to "Last turn". On \`turn/started\` (the next turn), a \`useEffect\` watching \`activeTurnId\` clears the snapshots and the rail goes live again.
- **Dock toggle** — header has a "Sidebar" / "Above" button that flips between two layouts. \`above\` (default) flows in the primary column above the composer. \`sidebar\` mounts at the layout level as a third column on the right (320px wide). State is in-memory per session — persistence is a follow-up.
- **MCP / warnings stay in transcript** — \`pendingProtocolActivityEntry\` (used for MCP startup status, warnings) doesn't go in the rail; it stays in its existing \`TranscriptList\` path. The dupe-fix that clears it on \`turn/completed\` applies uniformly though.

## Tests

| Suite | Result |
|---|---|
| \`pnpm --filter @pwragent/desktop typecheck\` | clean |
| \`pnpm test apps/desktop/src/renderer/\` | 648 / 648 (was 636 + 10 new \`LiveWorkRail\` tests + 2 new ThreadView tests) |
| \`pnpm lint:boundaries\` | 1232 modules, no violations |
| \`pnpm --filter @pwragent/desktop test:e2e\` | 116 / 116 (28 inspect-only skipped) |

- Verified the dupe-fix regression test catches the bug by temporarily restoring the pre-fix wiring (\`pendingActivityEntry={pendingActivityEntry}\` back into \`TranscriptList\`) — two tests fail loudly, the rest stay green.
- Updated \`thread-view.test.tsx\`'s existing \`renders live diff activity from turn/diff/updated\` test to find the rail \`<h3>\` heading + per-file button instead of the old two-level transcript-activity toggle.
- Updated \`todo-list-rendering.spec.ts\` e2e test to look for the plan group at page scope (rail is outside the transcript region).

## Test plan

- [x] Typecheck, vitest, lint:boundaries, e2e all green
- [x] Manual: run \`pnpm dev\`, ask the agent to edit 2+ files; confirm the rail renders above the composer with cumulative summary + per-file expand
- [x] Manual: click the dock toggle to switch to sidebar mode; confirm the rail reflows to a 320px right column
- [x] Manual: let the turn complete; confirm the rail flips to "Last turn" and the transcript shows exactly one persisted "Edited N files" row (no duplicate)
- [x] Manual: send a new message to start a new turn; confirm the rail clears the pinned snapshot and starts tracking the new turn's diff

## Follow-ups left for later

- Persistence of the dock preference across sessions / windows (currently in-memory)
- Whether the rail should also pin the latest \`item/fileChange/outputDelta\` ("Changed N files") through next-turn-start the way it does for the Edited Files + Plan snapshots — currently it always shows the latest from \`optimisticEntries\`
- Same sticky treatment for \`pendingProtocolActivityEntry\` (MCP status / warnings) if that ever feels like rail-worthy live state

🤖 Generated with [Claude Code](https://claude.com/claude-code)