### PR TITLE
feat(desktop): add profiles menu

### DIFF
--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -27,6 +27,8 @@ const registerPreloadLogIpcHandlersMock = vi.fn();
 const disposePreloadLogIpcHandlersMock = vi.fn();
 const registerProfilesIpcHandlersMock = vi.fn();
 const disposeProfilesIpcHandlersMock = vi.fn();
+const listDesktopPwrAgentProfilesMock = vi.fn();
+const openDesktopPwrAgentProfileMock = vi.fn();
 const registerRendererErrorIpcHandlersMock = vi.fn();
 const registerRuntimeIdentityIpcHandlersMock = vi.fn();
 const disposeRuntimeIdentityIpcHandlersMock = vi.fn();
@@ -35,6 +37,7 @@ const disposeSettingsIpcHandlersMock = vi.fn();
 const registerWindowPointerIpcHandlersMock = vi.fn();
 const disposeWindowPointerIpcHandlersMock = vi.fn();
 const initializeMainLoggerMock = vi.fn();
+const requestOpenSettingsMock = vi.fn();
 const mainLogInfoMock = vi.fn();
 const mainLogWarnMock = vi.fn();
 const mainLogErrorMock = vi.fn();
@@ -61,6 +64,7 @@ const shellOpenExternalMock = vi.fn(async () => undefined);
 const setNameMock = vi.fn();
 const setAboutPanelOptionsMock = vi.fn();
 const showAboutPanelMock = vi.fn();
+const appFocusMock = vi.fn();
 const getAppPathMock = vi.fn(() => "/test/app");
 const getVersionMock = vi.fn(() => "1.0.0-alpha.0");
 const whenReadyMock = vi.fn(() => Promise.resolve());
@@ -82,6 +86,11 @@ const resolveDeveloperModeMock = vi.fn(() => true);
 const getDesktopSettingsServiceMock = vi.fn(() => ({
   resolveDeveloperMode: resolveDeveloperModeMock,
 }));
+const profileFocusRequestWatcherStopMock = vi.fn();
+const resolveActiveProfileNameMock = vi.fn(() => "default");
+const startProfileFocusRequestWatcherMock = vi.fn(() => ({
+  stop: profileFocusRequestWatcherStopMock,
+}));
 
 vi.mock("electron", () => ({
   app: {
@@ -91,6 +100,7 @@ vi.mock("electron", () => ({
     getAppPath: getAppPathMock,
     getVersion: getVersionMock,
     showAboutPanel: showAboutPanelMock,
+    focus: appFocusMock,
     whenReady: whenReadyMock,
     dock: {
       setIcon: dockSetIconMock,
@@ -117,6 +127,10 @@ vi.mock("electron", () => ({
 
 vi.mock("../window", () => ({
   createMainWindow: createMainWindowMock,
+}));
+
+vi.mock("../window-open-settings", () => ({
+  requestOpenSettings: requestOpenSettingsMock,
 }));
 
 vi.mock("../ipc/app-server", () => ({
@@ -177,6 +191,8 @@ vi.mock("../ipc/preload-log", () => ({
 vi.mock("../ipc/profiles", () => ({
   registerProfilesIpcHandlers: registerProfilesIpcHandlersMock,
   disposeProfilesIpcHandlers: disposeProfilesIpcHandlersMock,
+  listDesktopPwrAgentProfiles: listDesktopPwrAgentProfilesMock,
+  openDesktopPwrAgentProfile: openDesktopPwrAgentProfileMock,
 }));
 
 vi.mock("../ipc/renderer-error", () => ({
@@ -231,6 +247,11 @@ vi.mock("../state/app-state", () => ({
 
 vi.mock("../settings/desktop-settings-singleton", () => ({
   getDesktopSettingsService: getDesktopSettingsServiceMock,
+}));
+
+vi.mock("../profile", () => ({
+  resolveActiveProfileName: resolveActiveProfileNameMock,
+  startProfileFocusRequestWatcher: startProfileFocusRequestWatcherMock,
 }));
 
 const runtimeMessagingLeaseCoordinatorMock = {
@@ -293,6 +314,36 @@ describe("bootstrapApp", () => {
     disposePreloadLogIpcHandlersMock.mockReset();
     registerProfilesIpcHandlersMock.mockReset();
     disposeProfilesIpcHandlersMock.mockReset();
+    listDesktopPwrAgentProfilesMock.mockReset();
+    listDesktopPwrAgentProfilesMock.mockReturnValue({
+      activeProfile: "default",
+      defaultProfile: "default",
+      profiles: [
+        {
+          active: true,
+          canDelete: false,
+          codexProfile: {
+            codexHome: "/codex/default",
+            displayName: "default",
+            exists: true,
+            hasAuthFile: true,
+            hasConfigFile: true,
+            name: "default",
+            selected: true,
+            source: "default",
+          },
+          default: true,
+          name: "default",
+          profileDir: "/profiles/default",
+        },
+      ],
+    });
+    openDesktopPwrAgentProfileMock.mockReset();
+    openDesktopPwrAgentProfileMock.mockReturnValue({
+      opened: false,
+      profile: "default",
+      reason: "active",
+    });
     registerRendererErrorIpcHandlersMock.mockReset();
     registerRuntimeIdentityIpcHandlersMock.mockReset();
     disposeRuntimeIdentityIpcHandlersMock.mockReset();
@@ -301,6 +352,7 @@ describe("bootstrapApp", () => {
     registerWindowPointerIpcHandlersMock.mockReset();
     disposeWindowPointerIpcHandlersMock.mockReset();
     initializeMainLoggerMock.mockReset();
+    requestOpenSettingsMock.mockReset();
     mainLogInfoMock.mockReset();
     mainLogWarnMock.mockReset();
     mainLogErrorMock.mockReset();
@@ -334,6 +386,7 @@ describe("bootstrapApp", () => {
     setNameMock.mockReset();
     setAboutPanelOptionsMock.mockReset();
     showAboutPanelMock.mockReset();
+    appFocusMock.mockReset();
     getAppPathMock.mockClear();
     getVersionMock.mockClear();
     resolveDeveloperModeMock.mockReset();
@@ -348,6 +401,10 @@ describe("bootstrapApp", () => {
     quitMock.mockReset();
     getAllWindowsMock.mockReset();
     getAllWindowsMock.mockReturnValue([]);
+    profileFocusRequestWatcherStopMock.mockReset();
+    resolveActiveProfileNameMock.mockReset();
+    resolveActiveProfileNameMock.mockReturnValue("default");
+    startProfileFocusRequestWatcherMock.mockClear();
     startupProfilerInstance.start.mockReset();
     startupProfilerInstance.attachWindow.mockReset();
     StartupCpuProfilerMock.mockClear();
@@ -394,6 +451,10 @@ describe("bootstrapApp", () => {
     expect(registerSettingsIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(registerWindowPointerIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(registerRuntimeIdentityIpcHandlersMock).toHaveBeenCalledTimes(1);
+    expect(startProfileFocusRequestWatcherMock).toHaveBeenCalledWith(
+      "default",
+      expect.objectContaining({ onFocus: expect.any(Function) }),
+    );
     expect(setApplicationMenuMock).toHaveBeenCalledTimes(1);
   });
 
@@ -437,6 +498,32 @@ describe("bootstrapApp", () => {
     expect(createMainWindowMock).toHaveBeenCalledWith({
       startupCpuProfiler: startupProfilerInstance,
     });
+  });
+
+  it("creates a main window when a profile focus request arrives without one", async () => {
+    startupProfilerInstance.start.mockResolvedValue();
+
+    await import("../index");
+    await flushMicrotasks();
+
+    const watcherCalls = startProfileFocusRequestWatcherMock.mock.calls as unknown as Array<
+      [string, { onFocus: () => void }]
+    >;
+    const onFocus = watcherCalls[0]?.[1].onFocus;
+    expect(onFocus).toBeTypeOf("function");
+    if (!onFocus) {
+      return;
+    }
+
+    expect(createMainWindowMock).toHaveBeenCalledTimes(1);
+
+    onFocus();
+
+    expect(createMainWindowMock).toHaveBeenCalledTimes(2);
+    expect(createMainWindowMock).toHaveBeenNthCalledWith(2, {
+      startupCpuProfiler: startupProfilerInstance,
+    });
+    expect(appFocusMock).toHaveBeenCalledWith({ steal: true });
   });
 
   it("prewarms the initial thread list after starting the first window", async () => {
@@ -496,6 +583,76 @@ describe("bootstrapApp", () => {
     );
 
     expect(item(["Visit", "Website"].join(" "))).toBeUndefined();
+  });
+
+  it("wires the Profiles menu to profile opening and profile settings", async () => {
+    startupProfilerInstance.start.mockResolvedValue();
+    listDesktopPwrAgentProfilesMock.mockReturnValue({
+      activeProfile: "default",
+      defaultProfile: "default",
+      profiles: [
+        {
+          active: true,
+          canDelete: false,
+          codexProfile: {
+            codexHome: "/codex/default",
+            displayName: "default",
+            exists: true,
+            hasAuthFile: true,
+            hasConfigFile: true,
+            name: "default",
+            selected: true,
+            source: "default",
+          },
+          default: true,
+          name: "default",
+          profileDir: "/profiles/default",
+        },
+        {
+          active: false,
+          canDelete: true,
+          codexProfile: {
+            codexHome: "/codex/work",
+            displayName: "work",
+            exists: true,
+            hasAuthFile: true,
+            hasConfigFile: true,
+            name: "work",
+            selected: true,
+            source: "directory",
+          },
+          default: false,
+          name: "work",
+          profileDir: "/profiles/work",
+        },
+      ],
+    });
+
+    await import("../index");
+    await flushMicrotasks();
+
+    const template = buildFromTemplateMock.mock.calls[0]?.[0] as
+      | Array<{
+          label?: string;
+          submenu?: Array<{
+            label?: string;
+            click?: () => void | Promise<void>;
+          }>;
+        }>
+      | undefined;
+    const profilesMenu = template?.find((item) => item.label === "Profiles");
+    const item = (label: string) =>
+      profilesMenu?.submenu?.find((menuItem) => menuItem.label === label);
+
+    item("work")?.click?.();
+    await flushMicrotasks();
+    expect(openDesktopPwrAgentProfileMock).toHaveBeenCalledWith({
+      profile: "work",
+    });
+    expect(setApplicationMenuMock).toHaveBeenCalledTimes(2);
+
+    item("Manage Profiles…")?.click?.();
+    expect(requestOpenSettingsMock).toHaveBeenCalledWith("profiles");
   });
 
   it("logs startup thread list prewarm failures without blocking startup", async () => {

--- a/apps/desktop/src/main/__tests__/menu.test.ts
+++ b/apps/desktop/src/main/__tests__/menu.test.ts
@@ -1,19 +1,33 @@
 import { describe, expect, it, vi } from "vitest";
 import type { MenuItemConstructorOptions } from "electron";
+import type { DesktopPwrAgentProfileSummary } from "@pwragent/shared";
 import { buildApplicationMenuTemplate } from "../menu";
 
 function buildTemplate(
   developerMode: boolean,
-  options?: { isMac?: boolean; openSettings?: () => void },
+  options?: {
+    isMac?: boolean;
+    openProfile?: (profile: string) => void;
+    openProfilesSettings?: () => void;
+    openSettings?: () => void;
+    profiles?: DesktopPwrAgentProfileSummary[];
+  },
 ): MenuItemConstructorOptions[] {
   return buildApplicationMenuTemplate({
     appName: "PwrAgent",
     developerMode,
     isMac: options?.isMac ?? true,
+    profiles: options?.profiles ?? [
+      profile("work"),
+      profile("default", { active: true, default: true }),
+      profile("personal"),
+    ],
     actions: {
       checkForUpdates: vi.fn(),
       openDocumentation: vi.fn(),
       openIssueReporter: vi.fn(),
+      openProfile: options?.openProfile ?? vi.fn(),
+      openProfilesSettings: options?.openProfilesSettings ?? vi.fn(),
       openSettings: options?.openSettings ?? vi.fn(),
       openWebsite: vi.fn(),
       showAboutPanel: vi.fn(),
@@ -23,6 +37,30 @@ function buildTemplate(
       showThirdPartyNoticesWindow: vi.fn(),
     },
   });
+}
+
+function profile(
+  name: string,
+  options: Partial<DesktopPwrAgentProfileSummary> = {},
+): DesktopPwrAgentProfileSummary {
+  return {
+    active: false,
+    canDelete: name !== "default",
+    codexProfile: {
+      codexHome: `/codex/${name}`,
+      displayName: name || "default",
+      exists: true,
+      hasAuthFile: true,
+      hasConfigFile: true,
+      name: "",
+      selected: false,
+      source: "default",
+    },
+    default: false,
+    name,
+    profileDir: `/profiles/${name}`,
+    ...options,
+  };
 }
 
 function submenuRoles(
@@ -51,6 +89,74 @@ function findSubmenuByRole(
 }
 
 describe("buildApplicationMenuTemplate", () => {
+  it("places Profiles between View and Window", () => {
+    const labels = buildTemplate(false).map((item) => item.label ?? item.role);
+
+    expect(labels).toEqual([
+      "PwrAgent",
+      "File",
+      "editMenu",
+      "View",
+      "Profiles",
+      "windowMenu",
+      "help",
+    ]);
+  });
+
+  it("orders profiles with default pinned, checks the active profile, and assigns first shortcuts", () => {
+    const items = submenuItems(buildTemplate(false), "Profiles");
+    const profileItems = items.slice(0, 3);
+
+    expect(profileItems.map((item) => item.label)).toEqual([
+      "default",
+      "personal",
+      "work",
+    ]);
+    expect(profileItems.map((item) => item.type)).toEqual([
+      "checkbox",
+      "checkbox",
+      "checkbox",
+    ]);
+    expect(profileItems.map((item) => item.checked)).toEqual([
+      true,
+      false,
+      false,
+    ]);
+    expect(profileItems.map((item) => item.accelerator)).toEqual([
+      "CmdOrCtrl+1",
+      "CmdOrCtrl+2",
+      "CmdOrCtrl+3",
+    ]);
+  });
+
+  it("routes profile menu clicks through the shared profile opener", () => {
+    const openProfile = vi.fn();
+    const items = submenuItems(buildTemplate(false, { openProfile }), "Profiles");
+
+    (items.find((item) => item.label === "work")?.click as
+      | (() => void)
+      | undefined)?.();
+
+    expect(openProfile).toHaveBeenCalledWith("work");
+  });
+
+  it("opens the profile settings surface from profile management menu items", () => {
+    const openProfilesSettings = vi.fn();
+    const items = submenuItems(
+      buildTemplate(false, { openProfilesSettings }),
+      "Profiles",
+    );
+
+    (items.find((item) => item.label === "New Profile…")?.click as
+      | (() => void)
+      | undefined)?.();
+    (items.find((item) => item.label === "Manage Profiles…")?.click as
+      | (() => void)
+      | undefined)?.();
+
+    expect(openProfilesSettings).toHaveBeenCalledTimes(2);
+  });
+
   it("hides developer-only View items when Developer Mode is off", () => {
     const roles = submenuRoles(buildTemplate(false), "View");
 

--- a/apps/desktop/src/main/__tests__/profile.test.ts
+++ b/apps/desktop/src/main/__tests__/profile.test.ts
@@ -9,10 +9,12 @@ import {
   ensureNamedProfileExists,
   readProfileArg,
   readProfilesRegistry,
+  requestProfileInstanceFocus,
   resetCachedActiveProfileNameForTests,
   resolveActiveProfileName,
   resolveDefaultProfileName,
   setDefaultProfileName,
+  startProfileFocusRequestWatcher,
   startProfileRuntimeHeartbeat,
 } from "../profile";
 
@@ -140,5 +142,50 @@ describe("PwrAgent profiles", () => {
     expect(readProfilesRegistry({ env }).profiles).not.toContainEqual(
       expect.objectContaining({ name: "scratch" }),
     );
+  });
+
+  it("requests focus only for profiles with a live runtime heartbeat", () => {
+    const { env } = createRoot();
+    ensureNamedProfileExists("scratch", { env });
+
+    expect(requestProfileInstanceFocus("scratch", { env })).toBe(false);
+
+    const heartbeat = startProfileRuntimeHeartbeat("scratch", {
+      env,
+      intervalMs: 60_000,
+      processId: process.pid,
+    });
+    try {
+      expect(requestProfileInstanceFocus("scratch", { env })).toBe(true);
+    } finally {
+      heartbeat.stop();
+    }
+  });
+
+  it("consumes profile focus requests and invokes the focus callback", () => {
+    const { env } = createRoot();
+    ensureNamedProfileExists("scratch", { env });
+    const heartbeat = startProfileRuntimeHeartbeat("scratch", {
+      env,
+      intervalMs: 60_000,
+      processId: process.pid,
+    });
+    const onFocus = vi.fn();
+
+    try {
+      expect(requestProfileInstanceFocus("scratch", { env })).toBe(true);
+      const watcher = startProfileFocusRequestWatcher("scratch", {
+        env,
+        intervalMs: 60_000,
+        onFocus,
+      });
+      try {
+        expect(onFocus).toHaveBeenCalledOnce();
+      } finally {
+        watcher.stop();
+      }
+    } finally {
+      heartbeat.stop();
+    }
   });
 });

--- a/apps/desktop/src/main/__tests__/profiles-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/profiles-ipc.test.ts
@@ -7,7 +7,12 @@ import {
   PWRAGENT_PROFILE_ENV,
   ensureNamedProfileExists,
   setDefaultProfileName,
+  startProfileRuntimeHeartbeat,
 } from "../profile";
+
+const spawnMock = vi.fn(() => ({
+  unref: vi.fn(),
+}));
 
 vi.mock("electron", () => ({
   ipcMain: {
@@ -23,10 +28,15 @@ vi.mock("../app-server/backend-registry", () => ({
   disposeDesktopBackendRegistry: vi.fn(async () => undefined),
 }));
 
+vi.mock("node:child_process", () => ({
+  spawn: spawnMock,
+}));
+
 const roots: string[] = [];
 
 afterEach(() => {
   vi.unstubAllEnvs();
+  spawnMock.mockClear();
   for (const root of roots.splice(0)) {
     fs.rmSync(root, { recursive: true, force: true });
   }
@@ -92,6 +102,35 @@ describe("profile IPC helpers", () => {
     expect(
       replaceProfileLaunchArgs(["/repo/apps/desktop", "--profile=dev"], "work"),
     ).toEqual(["/repo/apps/desktop", "--profile", "work"]);
+  });
+
+  it("focuses an existing profile instance instead of spawning a duplicate", async () => {
+    const root = createRoot();
+    const env = {
+      [PWRAGENT_HOME_ENV]: root,
+      [PWRAGENT_PROFILE_ENV]: "dev",
+    } as NodeJS.ProcessEnv;
+    ensureNamedProfileExists("dev", { env });
+    ensureNamedProfileExists("scratch", { env });
+    const heartbeat = startProfileRuntimeHeartbeat("scratch", {
+      env,
+      intervalMs: 60_000,
+      processId: process.pid,
+    });
+    vi.stubEnv(PWRAGENT_HOME_ENV, root);
+    vi.stubEnv(PWRAGENT_PROFILE_ENV, "dev");
+    const { openDesktopPwrAgentProfile } = await import("../ipc/profiles");
+
+    try {
+      expect(openDesktopPwrAgentProfile({ profile: "scratch" })).toEqual({
+        opened: false,
+        profile: "scratch",
+        reason: "focused",
+      });
+      expect(spawnMock).not.toHaveBeenCalled();
+    } finally {
+      heartbeat.stop();
+    }
   });
 
   it("keeps listing profiles when an inactive profile config is malformed", async () => {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -22,6 +22,7 @@ import {
   PWRAGENT_DOCUMENTATION_URL,
   PWRAGENT_HOMEPAGE_URL,
 } from "../shared/app-metadata";
+import { WINDOW_OPEN_SETTINGS_CHANNEL } from "../shared/ipc";
 import {
   disposeApplicationIpcHandlers,
   registerApplicationIpcHandlers,
@@ -45,6 +46,8 @@ import {
 } from "./ipc/preload-log";
 import {
   disposeProfilesIpcHandlers,
+  listDesktopPwrAgentProfiles,
+  openDesktopPwrAgentProfile,
   registerProfilesIpcHandlers,
 } from "./ipc/profiles";
 import { registerRendererErrorIpcHandlers } from "./ipc/renderer-error";
@@ -79,8 +82,14 @@ import {
   isAppStateInitialized,
 } from "./state/app-state";
 import { createMainWindow } from "./window";
+import { subscribersForChannel } from "./window-channels";
 import { requestOpenSettings } from "./window-open-settings";
 import { buildApplicationMenuTemplate } from "./menu";
+import {
+  resolveActiveProfileName,
+  startProfileFocusRequestWatcher,
+  type ProfileFocusRequestWatcher,
+} from "./profile";
 
 const APP_NAME = "PwrAgent";
 const APP_COPYRIGHT = "Copyright © 2026 PwrDrvr LLC.";
@@ -90,6 +99,10 @@ const isMac = process.platform === "darwin";
 const isDevelopment = process.env.NODE_ENV !== "production";
 const mainLog = getMainLogger("pwragent:main");
 let mainProcessResourcesDisposed = false;
+let profileFocusRequestWatcher: ProfileFocusRequestWatcher | null = null;
+let startupCpuProfilerForNewWindows:
+  | NonNullable<Parameters<typeof createMainWindow>[0]>["startupCpuProfiler"]
+  | undefined;
 
 function prewarmInitialThreadList(): void {
   const startedAt = Date.now();
@@ -122,6 +135,9 @@ function disposeMainProcessResourcesSync(): void {
     return;
   }
   mainProcessResourcesDisposed = true;
+  profileFocusRequestWatcher?.stop();
+  profileFocusRequestWatcher = null;
+  startupCpuProfilerForNewWindows = undefined;
   disposeAgentIpcHandlers();
   disposeApplicationIpcHandlers();
   disposeAppMetadataIpcHandlers();
@@ -173,12 +189,50 @@ function installDevelopmentDockIcon(): void {
   app.dock?.setIcon(icon);
 }
 
+function focusPwrAgentWindows(): void {
+  const windows = subscribersForChannel(WINDOW_OPEN_SETTINGS_CHANNEL)
+    .map((webContents) => BrowserWindow.fromWebContents(webContents))
+    .filter((window): window is BrowserWindow =>
+      Boolean(window && !window.isDestroyed()),
+  );
+  if (windows.length === 0) {
+    createMainWindow(
+      startupCpuProfilerForNewWindows
+        ? { startupCpuProfiler: startupCpuProfilerForNewWindows }
+        : undefined,
+    );
+    app.focus({ steal: true });
+    return;
+  }
+
+  for (const window of windows) {
+    if (window.isMinimized()) {
+      window.restore();
+    }
+    window.show();
+    window.focus();
+  }
+  app.focus({ steal: true });
+}
+
+function installProfileFocusRequestWatcher(): void {
+  profileFocusRequestWatcher?.stop();
+  profileFocusRequestWatcher = startProfileFocusRequestWatcher(
+    resolveActiveProfileName(),
+    {
+      onFocus: focusPwrAgentWindows,
+    },
+  );
+}
+
 function installApplicationMenu(): void {
   const developerMode = getDesktopSettingsService().resolveDeveloperMode();
+  const profiles = listDesktopPwrAgentProfiles().profiles;
   const template = buildApplicationMenuTemplate({
     appName: APP_NAME,
     developerMode,
     isMac,
+    profiles,
     actions: {
       checkForUpdates: () => {
         void checkForAppUpdatesNow("menu");
@@ -188,6 +242,14 @@ function installApplicationMenu(): void {
       },
       openIssueReporter: async () => {
         await shell.openExternal(PWRAGENT_ISSUE_REPORTER_URL);
+      },
+      openProfile: (profile) => {
+        void Promise.resolve(openDesktopPwrAgentProfile({ profile })).finally(
+          installApplicationMenu,
+        );
+      },
+      openProfilesSettings: () => {
+        requestOpenSettings("profiles");
       },
       openSettings: () => {
         requestOpenSettings();
@@ -220,9 +282,11 @@ export function bootstrapApp(): void {
 
   app.whenReady().then(async () => {
     const startupCpuProfiler = new StartupCpuProfiler();
+    startupCpuProfilerForNewWindows = startupCpuProfiler;
     await startupCpuProfiler.start();
     installDevelopmentDockIcon();
     initializeAppState();
+    installProfileFocusRequestWatcher();
     installApplicationMenu();
     registerAppServerIpcHandlers();
     registerAgentIpcHandlers();
@@ -232,7 +296,7 @@ export function bootstrapApp(): void {
     registerComposerDraftIpcHandlers();
     registerImageNormalizationIpcHandlers();
     registerPreloadLogIpcHandlers();
-    registerProfilesIpcHandlers();
+    registerProfilesIpcHandlers({ onProfilesChanged: installApplicationMenu });
     registerRendererErrorIpcHandlers();
     registerSettingsIpcHandlers(undefined, {
       onConfigPatchWritten: async (patch) => {

--- a/apps/desktop/src/main/ipc/profiles.ts
+++ b/apps/desktop/src/main/ipc/profiles.ts
@@ -31,6 +31,7 @@ import {
   forgetDeletedProfile,
   isValidProfileName,
   readProfilesRegistry,
+  requestProfileInstanceFocus,
   resolveActiveProfileName,
   resolveDefaultProfileName,
   resolveProfileDir,
@@ -42,6 +43,10 @@ import {
   resolveDesktopConfigPath,
 } from "../settings/desktop-config";
 import { discoverCodexAuthProfiles } from "../settings/codex-profiles";
+
+type ProfilesIpcHandlerOptions = {
+  onProfilesChanged?: () => void;
+};
 
 export function listDesktopPwrAgentProfiles(): ListDesktopPwrAgentProfilesResponse {
   const activeProfile = resolveActiveProfileName();
@@ -108,6 +113,10 @@ export function openDesktopPwrAgentProfile(
   const activeProfile = resolveActiveProfileName();
   if (profile === activeProfile) {
     return { opened: false, profile, reason: "active" };
+  }
+
+  if (requestProfileInstanceFocus(profile)) {
+    return { opened: false, profile, reason: "focused" };
   }
 
   ensureProfileExists({
@@ -220,7 +229,9 @@ export async function setDesktopPwrAgentProfileCodexProfile(
   return { profile, codexProfile };
 }
 
-export function registerProfilesIpcHandlers(): void {
+export function registerProfilesIpcHandlers(
+  options: ProfilesIpcHandlerOptions = {},
+): void {
   ipcMain.removeHandler(PROFILES_LIST_CHANNEL);
   ipcMain.handle(
     PROFILES_LIST_CHANNEL,
@@ -244,8 +255,11 @@ export function registerProfilesIpcHandlers(): void {
     async (
       _event,
       request: CreateDesktopPwrAgentProfileRequest,
-    ): Promise<CreateDesktopPwrAgentProfileResponse> =>
-      createDesktopPwrAgentProfile(request),
+    ): Promise<CreateDesktopPwrAgentProfileResponse> => {
+      const response = createDesktopPwrAgentProfile(request);
+      options.onProfilesChanged?.();
+      return response;
+    },
   );
 
   ipcMain.removeHandler(PROFILES_SET_DEFAULT_CHANNEL);
@@ -264,8 +278,11 @@ export function registerProfilesIpcHandlers(): void {
     async (
       _event,
       request: DeleteDesktopPwrAgentProfileRequest,
-    ): Promise<DeleteDesktopPwrAgentProfileResponse> =>
-      await deleteDesktopPwrAgentProfile(request),
+    ): Promise<DeleteDesktopPwrAgentProfileResponse> => {
+      const response = await deleteDesktopPwrAgentProfile(request);
+      options.onProfilesChanged?.();
+      return response;
+    },
   );
 
   ipcMain.removeHandler(PROFILES_SET_CODEX_PROFILE_CHANNEL);

--- a/apps/desktop/src/main/menu.ts
+++ b/apps/desktop/src/main/menu.ts
@@ -1,9 +1,12 @@
 import type { MenuItemConstructorOptions } from "electron";
+import type { DesktopPwrAgentProfileSummary } from "@pwragent/shared";
 
 export type ApplicationMenuActions = {
   checkForUpdates: () => void;
   openDocumentation: () => void | Promise<void>;
   openIssueReporter: () => void | Promise<void>;
+  openProfile: (profile: string) => void | Promise<void>;
+  openProfilesSettings: () => void;
   openSettings: () => void;
   openWebsite: () => void | Promise<void>;
   showAboutPanel: () => void;
@@ -17,6 +20,7 @@ export type ApplicationMenuOptions = {
   appName: string;
   developerMode: boolean;
   isMac: boolean;
+  profiles: DesktopPwrAgentProfileSummary[];
   actions: ApplicationMenuActions;
 };
 
@@ -28,6 +32,7 @@ export function buildApplicationMenuTemplate(
     buildFileMenu(options),
     { role: "editMenu" },
     buildViewMenu(options.developerMode),
+    buildProfilesMenu(options),
     { role: "windowMenu" },
     buildHelpMenu(options),
   ];
@@ -99,6 +104,52 @@ function buildViewMenu(developerMode: boolean): MenuItemConstructorOptions {
       { role: "togglefullscreen" },
     ],
   };
+}
+
+function buildProfilesMenu(options: ApplicationMenuOptions): MenuItemConstructorOptions {
+  const profiles = orderProfilesForMenu(options.profiles);
+  const profileItems: MenuItemConstructorOptions[] = profiles.length
+    ? profiles.map((profile, index) => ({
+        label: profile.displayName || profile.name,
+        type: "checkbox",
+        checked: profile.active,
+        accelerator: index < 3 ? `CmdOrCtrl+${index + 1}` : undefined,
+        click: () => {
+          void options.actions.openProfile(profile.name);
+        },
+      }))
+    : [
+        {
+          label: "No Profiles Found",
+          enabled: false,
+        },
+      ];
+
+  return {
+    label: "Profiles",
+    submenu: [
+      ...profileItems,
+      { type: "separator" },
+      {
+        label: "New Profile…",
+        click: options.actions.openProfilesSettings,
+      },
+      {
+        label: "Manage Profiles…",
+        click: options.actions.openProfilesSettings,
+      },
+    ],
+  };
+}
+
+function orderProfilesForMenu(
+  profiles: DesktopPwrAgentProfileSummary[],
+): DesktopPwrAgentProfileSummary[] {
+  return [...profiles].sort((left, right) => {
+    if (left.name === "default") return -1;
+    if (right.name === "default") return 1;
+    return left.name.localeCompare(right.name);
+  });
 }
 
 function buildHelpMenu(options: ApplicationMenuOptions): MenuItemConstructorOptions {

--- a/apps/desktop/src/main/profile.ts
+++ b/apps/desktop/src/main/profile.ts
@@ -27,6 +27,10 @@ export type ProfileRuntimeHeartbeat = {
   stop: () => void;
 };
 
+export type ProfileFocusRequestWatcher = {
+  stop: () => void;
+};
+
 export type ProfileRuntimeMarker = {
   instanceId: string;
   processId: number;
@@ -363,6 +367,83 @@ export function findLiveProfileRuntimeMarkers(
   return markers;
 }
 
+export function requestProfileInstanceFocus(
+  profileName: string,
+  options?: {
+    env?: NodeJS.ProcessEnv;
+    homeDir?: string;
+    now?: number;
+    processId?: number;
+  },
+): boolean {
+  if (findLiveProfileRuntimeMarkers(profileName, options).length === 0) {
+    return false;
+  }
+
+  const requestDir = resolveProfileFocusRequestDir(profileName, options);
+  fs.mkdirSync(requestDir, { recursive: true });
+  const now = options?.now ?? Date.now();
+  const processId = options?.processId ?? process.pid;
+  const requestPath = path.join(
+    requestDir,
+    `${now}-${processId}-${randomUUID()}.json`,
+  );
+  writeJsonAtomic(requestPath, {
+    profileName,
+    processId,
+    requestedAt: now,
+  });
+  return true;
+}
+
+export function startProfileFocusRequestWatcher(
+  profileName = resolveActiveProfileName(),
+  options: {
+    env?: NodeJS.ProcessEnv;
+    homeDir?: string;
+    intervalMs?: number;
+    now?: () => number;
+    onFocus: () => void;
+  },
+): ProfileFocusRequestWatcher {
+  const requestDir = resolveProfileFocusRequestDir(profileName, options);
+  fs.mkdirSync(requestDir, { recursive: true });
+  const seen = new Set<string>();
+  const now = options.now ?? Date.now;
+  const scan = (): void => {
+    let entries: string[];
+    try {
+      entries = fs.readdirSync(requestDir);
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const requestPath = path.join(requestDir, entry);
+      if (seen.has(requestPath)) {
+        continue;
+      }
+      seen.add(requestPath);
+      const request = readProfileFocusRequest(requestPath);
+      fs.rmSync(requestPath, { force: true });
+      if (!request || request.profileName !== profileName) {
+        continue;
+      }
+      if (now() - request.requestedAt > PROFILE_RUNTIME_HEARTBEAT_TTL_MS) {
+        continue;
+      }
+      options.onFocus();
+    }
+  };
+  scan();
+  const interval = setInterval(scan, options.intervalMs ?? 500);
+  if (interval.unref) interval.unref();
+  return {
+    stop: () => {
+      clearInterval(interval);
+    },
+  };
+}
+
 export function updateLastUsed(
   profileName: string,
   options?: { env?: NodeJS.ProcessEnv; homeDir?: string },
@@ -426,6 +507,13 @@ function resolveProfileRuntimeMarkerDir(
   return path.join(resolveProfileDir(profileName, options), "state", "runtime-instances");
 }
 
+function resolveProfileFocusRequestDir(
+  profileName: string,
+  options?: { env?: NodeJS.ProcessEnv; homeDir?: string },
+): string {
+  return path.join(resolveProfileDir(profileName, options), "state", "focus-requests");
+}
+
 function readProfileRuntimeMarker(markerPath: string): ProfileRuntimeMarker | undefined {
   try {
     const parsed = JSON.parse(fs.readFileSync(markerPath, "utf8")) as Partial<ProfileRuntimeMarker>;
@@ -437,6 +525,29 @@ function readProfileRuntimeMarker(markerPath: string): ProfileRuntimeMarker | un
       && typeof parsed.heartbeatAt === "number"
     ) {
       return parsed as ProfileRuntimeMarker;
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+function readProfileFocusRequest(
+  requestPath: string,
+): { profileName: string; requestedAt: number } | undefined {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(requestPath, "utf8")) as Partial<{
+      profileName: string;
+      requestedAt: number;
+    }>;
+    if (
+      typeof parsed.profileName === "string"
+      && typeof parsed.requestedAt === "number"
+    ) {
+      return {
+        profileName: parsed.profileName,
+        requestedAt: parsed.requestedAt,
+      };
     }
   } catch {
     return undefined;

--- a/apps/desktop/src/main/window-open-settings.ts
+++ b/apps/desktop/src/main/window-open-settings.ts
@@ -18,7 +18,7 @@ import { subscribersForChannel } from "./window-channels";
  * the Settings overlay, so we have to dispatch to the actual main
  * window.
  */
-export function requestOpenSettings(): void {
+export function requestOpenSettings(section?: string): void {
   const focused = BrowserWindow.getFocusedWindow();
   const subscribers = subscribersForChannel(WINDOW_OPEN_SETTINGS_CHANNEL);
 
@@ -32,7 +32,7 @@ export function requestOpenSettings(): void {
     if (focusedSubscriber) {
       // Bring the window forward in case it's behind a sibling.
       focused.show();
-      focusedSubscriber.send(WINDOW_OPEN_SETTINGS_CHANNEL);
+      focusedSubscriber.send(WINDOW_OPEN_SETTINGS_CHANNEL, section);
       return;
     }
   }
@@ -45,5 +45,5 @@ export function requestOpenSettings(): void {
   if (fallbackWindow && !fallbackWindow.isDestroyed()) {
     fallbackWindow.show();
   }
-  fallback.send(WINDOW_OPEN_SETTINGS_CHANNEL);
+  fallback.send(WINDOW_OPEN_SETTINGS_CHANNEL, section);
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -655,10 +655,13 @@ const desktopApi = Object.freeze({
       ipcRenderer.off(WINDOW_FOCUS_SYNC_CHANNEL, listener);
     };
   },
-  onOpenSettingsRequested: (callback: () => void): (() => void) => {
+  onOpenSettingsRequested: (
+    callback: (section?: string) => void,
+  ): (() => void) => {
     // Main → renderer push from the PwrAgent → Settings… menu item.
     // App.tsx subscribes and switches `mainView` to "settings".
-    const listener = () => callback();
+    const listener = (_event: Electron.IpcRendererEvent, section?: unknown) =>
+      callback(typeof section === "string" ? section : undefined);
     ipcRenderer.on(WINDOW_OPEN_SETTINGS_CHANNEL, listener);
     return () => {
       ipcRenderer.off(WINDOW_OPEN_SETTINGS_CHANNEL, listener);

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -30,6 +30,17 @@ import { useThreadSkills } from "./lib/useThreadSkills";
 import { useQueuedTurnRelease } from "./lib/useQueuedTurnRelease";
 import { AppUpdateBanner } from "./features/update/AppUpdateBanner";
 
+const SETTINGS_SECTIONS = new Set<SettingsSection>([
+  "general",
+  "applications",
+  "profiles",
+  "worktrees",
+  "messaging",
+  "models",
+  "experimental",
+  "about",
+]);
+
 export function App() {
   const desktopApi = useDesktopApi();
   const settings = useDesktopSettings(desktopApi);
@@ -189,8 +200,10 @@ function DesktopAppShell(props: {
     if (!desktopApi?.onOpenSettingsRequested) {
       return;
     }
-    return desktopApi.onOpenSettingsRequested(() => {
-      setSettingsInitialSection(undefined);
+    return desktopApi.onOpenSettingsRequested((section) => {
+      setSettingsInitialSection(
+        isSettingsSection(section) ? section : undefined,
+      );
       setMainView("settings");
     });
   }, [desktopApi]);
@@ -415,5 +428,13 @@ function DesktopAppShell(props: {
 
       <AppUpdateBanner desktopApi={desktopApi} />
     </div>
+  );
+}
+
+function isSettingsSection(
+  section: string | undefined,
+): section is SettingsSection {
+  return (
+    section !== undefined && SETTINGS_SECTIONS.has(section as SettingsSection)
   );
 }

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -442,7 +442,9 @@ export type DesktopApi = {
    * switches its main view to the Settings overlay. Returns an
    * unsubscribe function.
    */
-  onOpenSettingsRequested?: (callback: () => void) => () => void;
+  onOpenSettingsRequested?: (
+    callback: (section?: string) => void,
+  ) => () => void;
   getWindowPointerSnapshot?: () => Promise<WindowPointerSnapshot>;
   platform?: string;
   versions?: {

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -643,7 +643,7 @@ export type OpenDesktopPwrAgentProfileRequest = {
 export type OpenDesktopPwrAgentProfileResponse = {
   opened: boolean;
   profile: string;
-  reason?: "active";
+  reason?: "active" | "focused";
 };
 
 export type CreateDesktopPwrAgentProfileRequest = {


### PR DESCRIPTION
## Summary

PwrAgent can now switch desktop profiles from a dedicated menu bar entry. The new Profiles menu appears between View and Window, pins the default profile first, checkmarks the active profile, assigns shortcuts to the first three profiles, and routes New Profile / Manage Profiles straight to Settings -> Profiles.

Profile switching now uses the shared desktop profile opener: it focuses an already-running profile instance when one exists, recreates that profile's main window if the macOS process is alive but windowless, and only spawns a new profile process when needed. The menu also refreshes after profile create/delete actions so profile state stays current.

Closes #474.

## Testing

- `pnpm test apps/desktop/src/main/__tests__/menu.test.ts apps/desktop/src/main/__tests__/profiles-ipc.test.ts apps/desktop/src/main/__tests__/profile.test.ts apps/desktop/src/main/__tests__/index.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
