### PR TITLE
fix(desktop): keep skill chips visible in compact density

### DIFF
--- a/apps/desktop/e2e/skill-autocomplete-interactions.spec.ts
+++ b/apps/desktop/e2e/skill-autocomplete-interactions.spec.ts
@@ -327,10 +327,18 @@ test("thread reply Tiptap skill chip stays visible in compact density", async ()
       hasText: "$ce:plan",
     });
     await expect(chip).toBeVisible();
+    // `toBeVisible` alone wouldn't catch the regression: a `display: none`
+    // chip is what produced the original "Tab inserts nothing" bug, but
+    // the same compact-density rule could just as easily collapse the
+    // chip with `width: 0` and still keep `visibility: visible`. Assert
+    // the actual rendered geometry so this test fails the same way
+    // (silently disappeared chip) as the user-visible symptom.
     const box = await chip.boundingBox();
-    expect(box).not.toBeNull();
-    expect(box!.width).toBeGreaterThan(0);
-    expect(box!.height).toBeGreaterThan(0);
+    if (!box) {
+      throw new Error("skill chip is in the DOM but has no rendered layout");
+    }
+    expect(box.width).toBeGreaterThan(0);
+    expect(box.height).toBeGreaterThan(0);
   } finally {
     await app.close();
   }

--- a/apps/desktop/e2e/skill-autocomplete-interactions.spec.ts
+++ b/apps/desktop/e2e/skill-autocomplete-interactions.spec.ts
@@ -295,3 +295,43 @@ test("thread reply Tiptap Tab insertion keeps caret after chip and copy-paste pr
     await app.close();
   }
 });
+
+test("thread reply Tiptap skill chip stays visible in compact density", async () => {
+  // Regression: the SkillMention chip in the composer carries the
+  // `thread-row__chip` class to inherit the pill shape from the thread-list
+  // primitive. The compact-density suppression rule that hides metadata
+  // chips inside the thread list was originally written without a scoping
+  // ancestor, so it also collapsed the skill chip inside the composer to
+  // `display: none` — the chip ended up in the DOM but invisible, which
+  // looked exactly like Tab/Enter not inserting anything.
+  const app = await launchElectronApp({
+    fixturePath,
+    appearance: { density: "compact" },
+    windowSize: {
+      width: 1180,
+      height: 760,
+    },
+  });
+
+  try {
+    await openSkillAutocompleteThread(app);
+
+    const tiptapInput = app.window.getByTestId("composer-tiptap-input");
+    const textbox = app.window.getByRole("textbox", { name: "Reply" });
+    await textbox.focus();
+    await app.window.keyboard.type("$ce:plan");
+    await expect(app.window.getByRole("listbox", { name: "Skills" })).toBeVisible();
+    await app.window.keyboard.press("Tab");
+
+    const chip = tiptapInput.locator(".composer-tiptap-input__mention", {
+      hasText: "$ce:plan",
+    });
+    await expect(chip).toBeVisible();
+    const box = await chip.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.width).toBeGreaterThan(0);
+    expect(box!.height).toBeGreaterThan(0);
+  } finally {
+    await app.close();
+  }
+});

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -108,7 +108,7 @@ const SkillMention = Mention.extend({
 }).configure({
   deleteTriggerWithBackspace: true,
   HTMLAttributes: {
-    class: "thread-row__chip skill-chip composer-tiptap-input__mention",
+    class: "chip skill-chip composer-tiptap-input__mention",
   },
   renderHTML: ({ node }) => {
     const skill = getSkillSummary(node.attrs);
@@ -116,7 +116,7 @@ const SkillMention = Mention.extend({
     return [
       "span",
       {
-        class: "thread-row__chip skill-chip composer-tiptap-input__mention",
+        class: "chip skill-chip composer-tiptap-input__mention",
         "data-type": "mention",
         "data-composer-skill-token-id": String(node.attrs.id ?? ""),
         "data-id": String(node.attrs.id ?? ""),

--- a/apps/desktop/src/renderer/src/features/composer/SkillChip.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/SkillChip.tsx
@@ -12,7 +12,7 @@ export function SkillChip(props: SkillChipProps) {
 
   return (
     <span
-      className={`thread-row__chip skill-chip tooltip-target${props.onRemove ? " skill-chip--removable" : ""}`}
+      className={`chip skill-chip tooltip-target${props.onRemove ? " skill-chip--removable" : ""}`}
       data-tooltip={tooltip || undefined}
       tabIndex={tooltip && !props.onRemove ? 0 : -1}
     >

--- a/apps/desktop/src/renderer/src/features/thread-detail/PendingMcpInteraction.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/PendingMcpInteraction.tsx
@@ -24,7 +24,7 @@ export function PendingMcpInteraction(props: PendingMcpInteractionProps) {
   return (
     <div className="transcript-mcp" role="group" aria-label="Pending MCP interaction">
       <div className="transcript-mcp__header">
-        <span className="thread-row__chip thread-row__chip--mode">
+        <span className="chip chip--mode">
           {props.state.mode === "url" ? "MCP login" : "MCP approval"}
         </span>
         <span className="transcript-message__time">

--- a/apps/desktop/src/renderer/src/features/thread-detail/PendingQuestionnaire.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/PendingQuestionnaire.tsx
@@ -30,7 +30,7 @@ export function PendingQuestionnaire(props: PendingQuestionnaireProps) {
   return (
     <div className="transcript-questionnaire" role="group" aria-label="Pending input">
       <div className="transcript-questionnaire__header">
-        <span className="thread-row__chip thread-row__chip--mode">
+        <span className="chip chip--mode">
           Input needed
         </span>
         <span className="transcript-message__time">

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
@@ -38,10 +38,10 @@ export function ThreadHeader(props: ThreadHeaderProps) {
           <h2 className="thread-header__compact-title" title={props.thread.title}>
             {props.thread.title}
           </h2>
-          <span className="thread-row__chip thread-row__chip--backend">
+          <span className="chip chip--backend">
             {formatBackendLabel(props.thread.source)}
           </span>
-          <span className="thread-row__chip thread-row__chip--mode">
+          <span className="chip chip--mode">
             {formatExecutionModeLabel(props.thread.executionMode)}
           </span>
         </div>

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1669,10 +1669,10 @@ export function ThreadView(props: ThreadViewProps) {
           <div className="thread-header__main thread-header__main--launchpad">
             <div className="thread-header__eyebrow-row">
               <p className="eyebrow">New thread</p>
-              <span className="thread-row__chip thread-row__chip--backend">
+              <span className="chip chip--backend">
                 {formatBackendLabel(selectedLaunchpad.backend)}
               </span>
-              <span className="thread-row__chip thread-row__chip--mode">
+              <span className="chip chip--mode">
                 {formatExecutionModeLabel(selectedLaunchpad.executionMode)}
               </span>
             </div>

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -785,7 +785,7 @@ export function TranscriptList(props: TranscriptListProps) {
           {props.pendingRequest ? (
             <div className="transcript-request" role="group" aria-label="Pending approval">
               <div className="transcript-request__header">
-                <span className="thread-row__chip thread-row__chip--mode">
+                <span className="chip chip--mode">
                   Approval needed
                 </span>
                 <span className="transcript-message__time">

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -237,8 +237,14 @@
    =========================================================================== */
 /* Suppress directory / PR / agent / binding chips in the list. Reaction
    and pin markers stay visible — reactions because they're user-curated
-   signals, pin because the pin marker on its own is information-dense. */
-:root[data-density="compact"] .thread-row__chip:not(.thread-row__chip--reaction):not(.thread-row__chip--pin) {
+   signals, pin because the pin marker on its own is information-dense.
+
+   Scope the rule to `.thread-row__chips` so non-list surfaces that
+   carry a `.thread-row__chip--*` variant (e.g. the questionnaire's mode
+   chip in the transcript) don't get collapsed when compact density is
+   on. The skill chip in the composer and the standalone SkillChip use
+   `.chip` directly and aren't affected by this rule. */
+:root[data-density="compact"] .thread-row__chips .thread-row__chip:not(.thread-row__chip--reaction):not(.thread-row__chip--pin) {
   display: none;
 }
 
@@ -2153,6 +2159,12 @@ textarea,
   outline-offset: 2px;
 }
 
+/* `.chip` is the shared pill primitive. `.thread-row__chip` is the
+   thread-list specialization that the compact-density rule above
+   suppresses; surfaces outside the thread list (composer skill chips,
+   transcript chips) should use `.chip` instead so density rules don't
+   reach across surfaces. */
+.chip,
 .thread-row__chip {
   display: inline-flex;
   min-width: 0;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2205,6 +2205,11 @@ textarea,
   background: var(--bg-row-active);
 }
 
+/* `.chip--backend` is the non-list alias of `.thread-row__chip--backend`,
+   pairing with the `.chip` primitive. Used by the open-thread header and
+   the transcript so they keep their elevated-panel backend pill without
+   the thread-list class chain. */
+.chip--backend,
 .thread-row__chip--backend {
   border: 1px solid var(--border-subtle);
   background: var(--bg-panel-elevated);
@@ -2212,6 +2217,12 @@ textarea,
   font-weight: 600;
 }
 
+/* `.chip--mode` is the non-list alias of `.thread-row__chip--mode`,
+   pairing with the `.chip` primitive. Transcript surfaces use it so
+   they can keep the accent-mode styling without inheriting the
+   thread-list class name (and the density-suppression rule that
+   targets it). */
+.chip--mode,
 .thread-row__chip--mode {
   border: 1px solid var(--accent-border);
   background: var(--accent-soft);


### PR DESCRIPTION
## Summary

- The compact-density CSS rule introduced in #476 (`:root[data-density="compact"] .thread-row__chip:not(--reaction):not(--pin) { display: none; }`) was unscoped, so it hid every element carrying `.thread-row__chip` — not just the ones inside the thread list. The composer's Tiptap skill chip attached that class to inherit the pill shape, so when compact density was on, `Tab` / `Enter` would commit the autocomplete, the chip would land in the DOM with correct attrs, and immediately render as `display: none` (zero-size, invisible). It looked exactly like the autocomplete had silently swallowed the keystroke.
- Split the chip primitive: `.chip` is now the shared pill shape; `.thread-row__chip` keeps the same styles via comma-selector but stays as the thread-list specialization. The composer's `SkillMention` and the standalone `SkillChip` switch to `.chip` and stop pulling in the density-suppression target. The density rule itself is tightened to `:root[data-density="compact"] .thread-row__chips .thread-row__chip:not(--reaction):not(--pin)` so any future `.thread-row__chip--*` variant used outside the list (e.g. the transcript questionnaire's mode chip) doesn't get clipped by the same accident.

## Test plan

- [x] Added `e2e/skill-autocomplete-interactions.spec.ts › thread reply Tiptap skill chip stays visible in compact density` — opens the composer with `appearance: { density: "compact" }`, types `$ce:plan`, presses `Tab`, then asserts the chip is visible with a non-zero bounding box. Verified the test fails on `main` (30 s timeout, chip never visible) and passes with the fix.
- [x] `pnpm test:desktop-e2e -- skill-autocomplete-interactions` — all 5 specs pass.
- [x] `pnpm test apps/desktop/src/renderer/src/features/composer apps/desktop/src/renderer/src/features/navigation` — 182 unit tests pass.
- [x] `pnpm typecheck` — clean.
- [x] Manual smoke: in `Settings → Appearance → Density: Compact`, open a Codex thread and confirm typing `\$ce` + `Tab` inserts a visible orange chip (and the thread-list chips are still suppressed as intended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)