### PR TITLE
chore(release): keep github-actions pins on major-version tags

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,13 +48,15 @@ updates:
       include: "scope"
     cooldown:
       default-days: 7
-    groups:
-      github-actions-minor-patch:
-        patterns:
-          - "*"
+    # We pin actions to major-version tags (e.g. `@v1`). Those tags silently
+    # absorb every minor and patch release upstream, so Dependabot PRs that
+    # rewrite `@v1` to `@v1.0.1` are pure noise. Only surface major bumps,
+    # which actually warrant a human review.
+    ignore:
+      - dependency-name: "*"
         update-types:
-          - "minor"
-          - "patch"
+          - "version-update:semver-patch"
+          - "version-update:semver-minor"
 
   - package-ecosystem: "bundler"
     directory: "/docs-site"


### PR DESCRIPTION
## Summary
- Tell Dependabot to ignore `semver-minor` and `semver-patch` updates for the `github-actions` ecosystem so PRs like [#457](https://github.com/pwrdrvr/PwrAgent/pull/457) that rewrite `pwrdrvr/configure-nodejs@v1` to `@v1.0.1` stop being filed. Our actions are pinned to major-version tags, which silently absorb every minor/patch release upstream — those PRs were pure noise.
- Major bumps still come through (which is when a human actually needs to look).
- Removes the now-dead `github-actions-minor-patch` group, since with minor/patch ignored it can never match anything.

## Test plan
- [ ] Watch next Tuesday's Dependabot run: no minor/patch GHA PRs should appear.
- [ ] Confirm [#457](https://github.com/pwrdrvr/PwrAgent/pull/457) (currently open) gets auto-closed by Dependabot on its next run, or close it manually.
- [ ] When a real `v2` of any pinned action ships, verify Dependabot still files that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)