### PR TITLE
feat(desktop): surface env-setup/action failures so they can be diagnosed

### DIFF
--- a/apps/desktop/e2e/codex-environment-setup.spec.ts
+++ b/apps/desktop/e2e/codex-environment-setup.spec.ts
@@ -506,7 +506,11 @@ test("thread environment Run command uses the current cwd after workspace handof
             const thread = snapshot.threads.find(
               (candidate: { id: string }) => candidate.id === "thread-existing",
             );
-            return thread?.codexEnvironmentRuntime?.actionStatus ?? "missing";
+            const runs = thread?.codexEnvironmentRuntime?.actionRuns ?? [];
+            // Take the most recently started run's status, which is the
+            // one the Run-button click just kicked off. (Multi-instance
+            // refactor: see PR #505.)
+            return runs.at(-1)?.status ?? "missing";
           }),
         { timeout: 5_000 },
       )

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2922,8 +2922,13 @@ command = '''printf action-ran > ${outputPath}'''
         }),
       ).resolves.toMatchObject({
         codexEnvironmentRuntime: {
-          actionName: "Dev - Messaging",
-          actionStatus: "started",
+          actionRuns: [
+            expect.objectContaining({
+              actionId: "dev-messaging",
+              actionName: "Dev - Messaging",
+              status: "started",
+            }),
+          ],
         },
       });
       await expectEventually(async () => await readFile(outputPath, "utf8"), "action-ran");
@@ -2994,8 +2999,13 @@ command = '''printf action-ran > ${outputPath}'''
       ).resolves.toMatchObject({
         codexEnvironmentRuntime: {
           cwd: worktreePath,
-          actionName: "Capture CWD",
-          actionStatus: "started",
+          actionRuns: [
+            expect.objectContaining({
+              actionId: "capture-cwd",
+              actionName: "Capture CWD",
+              status: "started",
+            }),
+          ],
         },
       });
       await expectEventually(
@@ -3078,8 +3088,13 @@ command = '''printf action-ran > ${outputPath}'''
       ).resolves.toMatchObject({
         codexEnvironmentRuntime: {
           cwd: localPath,
-          actionName: "Capture CWD",
-          actionStatus: "started",
+          actionRuns: [
+            expect.objectContaining({
+              actionId: "capture-cwd",
+              actionName: "Capture CWD",
+              status: "started",
+            }),
+          ],
         },
       });
       await expectEventually(
@@ -3144,10 +3159,14 @@ command = '''printf action-ran > ${outputPath}'''
         }),
       ).resolves.toMatchObject({
         codexEnvironmentRuntime: {
-          actionId: "dev-messaging",
-          actionName: "Dev - Messaging",
-          actionCommand: "pnpm dev",
-          actionStatus: "failed",
+          actionRuns: [
+            expect.objectContaining({
+              actionId: "dev-messaging",
+              actionName: "Dev - Messaging",
+              command: "pnpm dev",
+              status: "failed",
+            }),
+          ],
         },
       });
     } finally {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -195,6 +195,11 @@ function createOverlayStoreMock(params?: {
       overlays.set(key, next);
       return next;
     },
+    listThreadOverlaysWithCodexEnvironmentRuntime: async () => {
+      return Array.from(overlays.values()).filter(
+        (overlay) => overlay.codexEnvironmentRuntime !== undefined,
+      );
+    },
     setThreadExpectedBranch: async ({
       backend,
       threadId,
@@ -3172,6 +3177,295 @@ command = '''printf action-ran > ${outputPath}'''
     } finally {
       await registry.close();
       await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("attributes output to the right run when two env actions run concurrently on the same thread", async () => {
+    // Multi-instance regression test: Start + Test (or E2E + Unit) workflows
+    // require independent run tracking, otherwise a second concurrent run
+    // would overwrite the first's overlay entry and the first run's output
+    // would disappear.
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-thread-env-parallel-"));
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          codexEnvironmentRuntime: {
+            environmentId: "environment",
+            environmentName: "PwrAgnt",
+            executionTarget: "local",
+            cwd: root,
+            setupEnabled: false,
+            actions: [
+              {
+                // Print a marker to stdout so the captured output (which
+                // gets attributed to the run via onDetachedExit) has a
+                // deterministic value to assert on. A small sleep makes
+                // the two children genuinely overlap in time.
+                id: "action-a",
+                name: "Action A",
+                command: "sleep 0.2 && printf 'A-output-marker'",
+              },
+              {
+                id: "action-b",
+                name: "Action B",
+                command: "sleep 0.2 && printf 'B-output-marker'",
+              },
+            ],
+          },
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/list"] },
+        threads: [],
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+
+    try {
+      // Fire both run requests without awaiting either, so the spawn paths
+      // and their detached children interleave.
+      const [resultA, resultB] = await Promise.all([
+        registry.runCodexEnvironmentAction({
+          backend: "codex",
+          threadId: "thread-1",
+          actionId: "action-a",
+        }),
+        registry.runCodexEnvironmentAction({
+          backend: "codex",
+          threadId: "thread-1",
+          actionId: "action-b",
+        }),
+      ]);
+
+      // Each invocation's return value should carry its own runId.
+      const runIdA = resultA.codexEnvironmentRuntime?.actionRuns?.find(
+        (run) => run.actionId === "action-a",
+      )?.runId;
+      const runIdB = resultB.codexEnvironmentRuntime?.actionRuns?.find(
+        (run) => run.actionId === "action-b",
+      )?.runId;
+      expect(runIdA).toBeTruthy();
+      expect(runIdB).toBeTruthy();
+      expect(runIdA).not.toBe(runIdB);
+
+      // After both detached children exit, the overlay's actionRuns should
+      // contain both entries, each with its own captured output. Poll
+      // until the exit + output handlers have both fired and persisted.
+      const deadline = Date.now() + 10_000;
+      let lastSnapshot: ReadonlyArray<unknown> | undefined;
+      let lastError: string | undefined;
+      while (Date.now() < deadline) {
+        const overlay = await overlayStore.getThreadOverlayState({
+          backend: "codex",
+          threadId: "thread-1",
+        });
+        const runs = overlay?.codexEnvironmentRuntime?.actionRuns ?? [];
+        lastSnapshot = runs;
+        const a = runs.find((run) => run.actionId === "action-a");
+        const b = runs.find((run) => run.actionId === "action-b");
+        if (
+          a?.status === "exited" &&
+          b?.status === "exited" &&
+          a.output === "A-output-marker" &&
+          b.output === "B-output-marker"
+        ) {
+          // Sanity-check the runId attribution: each invocation's return
+          // value's run should match the overlay's persisted entry.
+          expect(a.runId).toBe(runIdA);
+          expect(b.runId).toBe(runIdB);
+          return;
+        }
+        lastError = `a.status=${a?.status} b.status=${b?.status} a.output=${JSON.stringify(a?.output)} b.output=${JSON.stringify(b?.output)}`;
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+      throw new Error(
+        `concurrent runs did not settle in time. last snapshot: ${JSON.stringify(lastSnapshot)} (${lastError ?? "no probe"})`,
+      );
+    } finally {
+      await registry.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  }, 15_000);
+
+  it("cleans up prior-session env-action runs on startup", async () => {
+    // Before the cleanup pass: an overlay row from a previous app launch
+    // carries a "started" run that's effectively a zombie (the child died
+    // when the parent exited) plus completed runs whose ~36KB outputs no
+    // longer matter. After construction, those should be normalised:
+    // zombies become "failed" with output dropped; finished runs keep
+    // status but lose their stored output.
+    const fakeSessionStart = Date.now();
+    const longAgo = fakeSessionStart - 60_000; // 1 minute before this session
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-zombie": {
+          backend: "codex",
+          threadId: "thread-zombie",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          codexEnvironmentRuntime: {
+            environmentId: "environment",
+            environmentName: "PwrAgnt",
+            executionTarget: "local",
+            cwd: "/tmp/x",
+            setupEnabled: false,
+            actions: [],
+            actionRuns: [
+              {
+                runId: "old-zombie",
+                actionId: "dev",
+                actionName: "Dev",
+                command: "pnpm dev",
+                status: "started",
+                startedAt: longAgo,
+                pid: 12345,
+                output: "a lot of stale output bytes that nobody will read",
+              },
+            ],
+          },
+        },
+        "codex:thread-finished": {
+          backend: "codex",
+          threadId: "thread-finished",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          codexEnvironmentRuntime: {
+            environmentId: "environment",
+            environmentName: "PwrAgnt",
+            executionTarget: "local",
+            cwd: "/tmp/y",
+            setupEnabled: false,
+            actions: [],
+            actionRuns: [
+              {
+                runId: "old-exited",
+                actionId: "test",
+                actionName: "Test",
+                command: "pnpm test",
+                status: "exited",
+                startedAt: longAgo,
+                exitedAt: longAgo + 5_000,
+                exitCode: 0,
+                durationMs: 5_000,
+                output: "build done\nready\n…lots more bytes…",
+              },
+            ],
+          },
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/list"] },
+        threads: [],
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+
+    try {
+      // The cleanup runs fire-and-forget in the constructor; poll until
+      // the persisted overlay reflects the post-cleanup shape.
+      const deadline = Date.now() + 5_000;
+      while (Date.now() < deadline) {
+        const zombie = await overlayStore.getThreadOverlayState({
+          backend: "codex",
+          threadId: "thread-zombie",
+        });
+        const finished = await overlayStore.getThreadOverlayState({
+          backend: "codex",
+          threadId: "thread-finished",
+        });
+        const zombieRun = zombie?.codexEnvironmentRuntime?.actionRuns?.[0];
+        const finishedRun = finished?.codexEnvironmentRuntime?.actionRuns?.[0];
+        if (
+          zombieRun?.status === "failed" &&
+          zombieRun.output === undefined &&
+          finishedRun?.status === "exited" &&
+          finishedRun.output === undefined
+        ) {
+          return;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      throw new Error("startup cleanup did not normalise overlays in time");
+    } finally {
+      await registry.close();
+    }
+  });
+
+  it("leaves current-session env-action runs untouched on startup", async () => {
+    // Negative case: a run whose startedAt is >= the registry's session
+    // start (which is captured at construction) must survive the cleanup
+    // pass intact. This guards against the cleanup accidentally clobbering
+    // runs that the auto-action emitted during the same session.
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          codexEnvironmentRuntime: {
+            environmentId: "environment",
+            environmentName: "PwrAgnt",
+            executionTarget: "local",
+            cwd: "/tmp/x",
+            setupEnabled: false,
+            actions: [],
+            // startedAt set well into the future so the cleanup is
+            // guaranteed to see this run as "fresh this session" no
+            // matter when the test executes.
+            actionRuns: [
+              {
+                runId: "fresh-run",
+                actionId: "dev",
+                actionName: "Dev",
+                command: "pnpm dev",
+                status: "started",
+                startedAt: Date.now() + 60_000,
+                pid: 99999,
+                output: "important live output",
+              },
+            ],
+          },
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/list"] },
+        threads: [],
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+
+    try {
+      // Wait long enough for the cleanup pass to run.
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      const overlay = await overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-1",
+      });
+      const run = overlay?.codexEnvironmentRuntime?.actionRuns?.[0];
+      expect(run?.status).toBe("started");
+      expect(run?.output).toBe("important live output");
+    } finally {
+      await registry.close();
     }
   });
 

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -3405,6 +3405,75 @@ command = '''printf action-ran > ${outputPath}'''
     }
   });
 
+  it("converts started env-action runs to failed even when timestamps are 0 or missing (legacy-synthesised data)", async () => {
+    // Reproduces the PwrAgent-killed-by-Computer-Use regression: an
+    // overlay row from a pre-actionStartedAt build (or any data where
+    // synthesis produces startedAt=0) used to slip past the
+    // timestamp-gated cleanup, then slip past the renderer's
+    // session-start filter, leaving the user with a perpetual
+    // "running" anchor and no Dismiss control. The fix is to convert
+    // any "started" run unconditionally — by lifecycle, anything we
+    // didn't start in this process lifetime is a zombie.
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-zombie-legacy": {
+          backend: "codex",
+          threadId: "thread-zombie-legacy",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          codexEnvironmentRuntime: {
+            environmentId: "environment",
+            environmentName: "PwrAgnt",
+            executionTarget: "local",
+            cwd: "/tmp/x",
+            setupEnabled: false,
+            actions: [],
+            actionRuns: [
+              {
+                runId: "legacy:dev:0",
+                actionId: "dev",
+                actionName: "Dev",
+                command: "pnpm dev",
+                status: "started",
+                startedAt: 0, // legacy-synthesised
+                pid: 72685,
+                output: "lots of stale bytes",
+              },
+            ],
+          },
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/list"] },
+        threads: [],
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+
+    try {
+      const deadline = Date.now() + 5_000;
+      while (Date.now() < deadline) {
+        const overlay = await overlayStore.getThreadOverlayState({
+          backend: "codex",
+          threadId: "thread-zombie-legacy",
+        });
+        const run = overlay?.codexEnvironmentRuntime?.actionRuns?.[0];
+        if (run?.status === "failed" && run.output === undefined) {
+          return;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      throw new Error("cleanup did not convert legacy zombie run in time");
+    } finally {
+      await registry.close();
+    }
+  });
+
   it("leaves current-session env-action runs untouched on startup", async () => {
     // Negative case: a run whose startedAt is >= the registry's session
     // start (which is captured at construction) must survive the cleanup

--- a/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   applyLocalCodexEnvironmentSelection,
+  buildExitErrorSuffix,
   CODEX_ENVIRONMENT_SETUP_TIMEOUT_MS_ENV,
   startLocalCodexEnvironmentAction,
 } from "../app-server/codex-environment-runtime";
@@ -453,6 +454,67 @@ describe("codex environment runtime", () => {
       await rm(root, { recursive: true, force: true });
     }
   }, 10_000);
+});
+
+describe("buildExitErrorSuffix", () => {
+  it("returns an empty suffix when both streams are blank", () => {
+    expect(buildExitErrorSuffix("", "")).toBe("");
+    expect(buildExitErrorSuffix("   \n  ", "\n\n")).toBe("");
+  });
+
+  it("returns the stderr line when only stderr has content", () => {
+    expect(buildExitErrorSuffix("", "v24.14.1 is already installed.")).toBe(
+      ": v24.14.1 is already installed.",
+    );
+  });
+
+  it("returns the stdout content when only stdout has content (modern-CLI case)", () => {
+    expect(buildExitErrorSuffix("ERR_PNPM_IGNORED_BUILDS the actual reason for exit 1", "")).toBe(
+      ": ERR_PNPM_IGNORED_BUILDS the actual reason for exit 1",
+    );
+  });
+
+  it("includes both streams concatenated when both have content", () => {
+    expect(buildExitErrorSuffix("first stdout line", "first stderr line")).toBe(
+      ": first stdout line\nfirst stderr line",
+    );
+  });
+
+  it("trims to the last 8 lines of combined output", () => {
+    const stdout = [
+      "line 1",
+      "line 2",
+      "line 3",
+      "line 4",
+      "line 5",
+      "line 6",
+      "line 7",
+      "line 8",
+      "line 9",
+      "line 10",
+    ].join("\n");
+    const suffix = buildExitErrorSuffix(stdout, "");
+    // Last 8 of 10 lines, joined with newlines and prefixed by ": "
+    expect(suffix).toBe(
+      ": line 3\nline 4\nline 5\nline 6\nline 7\nline 8\nline 9\nline 10",
+    );
+  });
+
+  it("preserves nvm-on-stderr alongside pnpm-on-stdout (motivating regression)", () => {
+    // Reproduces the failure mode that motivated the helper: pnpm writes
+    // its real exit-1 diagnostic to stdout, while stderr only contains
+    // unrelated benign chatter from an earlier `nvm install`. Both must
+    // survive into the suffix so the dialog headline isn't misled.
+    const stdout = [
+      "Scope: all 5 workspace projects",
+      "Progress: resolved 463, reused 463, downloaded 0, added 463, done",
+      "ERR_PNPM_IGNORED_BUILDS Ignored build scripts: @ffmpeg-installer/darwin-arm64",
+    ].join("\n");
+    const stderr = "v24.14.1 is already installed.";
+    const suffix = buildExitErrorSuffix(stdout, stderr);
+    expect(suffix).toContain("ERR_PNPM_IGNORED_BUILDS");
+    expect(suffix).toContain("v24.14.1 is already installed.");
+  });
 });
 
 async function expectEventually<T>(

--- a/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
@@ -311,6 +311,52 @@ describe("codex environment runtime", () => {
     }
   });
 
+  it("includes the tail of stdout in the exit error when the failing command writes its diagnostic to stdout", async () => {
+    // Reproduces the pnpm/vite/npm pattern: an earlier command in the
+    // script left a benign message on stderr (here mimicked with `echo
+    // ... >&2`), then the final command writes its actual error to stdout
+    // and exits non-zero. The exit error suffix must surface the stdout
+    // diagnostic, not the unrelated stderr chatter, so the failure dialog
+    // and main.log line point at the real cause.
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-env-stdout-error-"));
+    try {
+      let error: unknown;
+      try {
+        await applyLocalCodexEnvironmentSelection({
+          cwd: root,
+          env: {
+            ...process.env,
+            SHELL: "/bin/sh",
+          },
+          selection: {
+            environment: {
+              id: "env",
+              name: "Env",
+              sourcePath: path.join(root, "environment.toml"),
+              setupScript: [
+                "echo 'unrelated benign chatter' 1>&2",
+                "echo 'ERR_PNPM_IGNORED_BUILDS the actual reason for exit 1'",
+                "exit 1",
+              ].join("\n"),
+              actions: [],
+            },
+            executionTarget: "local",
+            setupEnabled: true,
+          },
+        });
+      } catch (caught) {
+        error = caught;
+      }
+
+      expect(error).toBeDefined();
+      expect((error as { message?: string }).message).toContain(
+        "ERR_PNPM_IGNORED_BUILDS the actual reason for exit 1",
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("times out setup commands that do not finish", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-env-timeout-"));
 

--- a/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
@@ -14,6 +14,7 @@ describe("codex environment runtime", () => {
     await expect(
       startLocalCodexEnvironmentAction({
         actionId: "start-dev",
+        runId: "test-run-1",
         runtime: {
           environmentId: "env",
           environmentName: "Env",
@@ -36,30 +37,34 @@ describe("codex environment runtime", () => {
     const outputPath = path.join(root, "env.txt");
 
     try {
-      await expect(
-        startLocalCodexEnvironmentAction({
-          actionId: "start-dev",
-          env: {
-            ...process.env,
-            PWRAGENT_TEST_HYDRATED_ENV: "hydrated",
-          },
-          runtime: {
-            environmentId: "env",
-            environmentName: "Env",
-            executionTarget: "local",
-            cwd: root,
-            actions: [
-              {
-                id: "start-dev",
-                name: "Start dev",
-                command: `printf "$PWRAGENT_TEST_HYDRATED_ENV" > ${JSON.stringify(outputPath)}`,
-              },
-            ],
-          },
-        }),
-      ).resolves.toMatchObject({
-        actionStatus: "started",
+      const result = await startLocalCodexEnvironmentAction({
+        actionId: "start-dev",
+        runId: "test-run-2",
+        env: {
+          ...process.env,
+          PWRAGENT_TEST_HYDRATED_ENV: "hydrated",
+        },
+        runtime: {
+          environmentId: "env",
+          environmentName: "Env",
+          executionTarget: "local",
+          cwd: root,
+          actions: [
+            {
+              id: "start-dev",
+              name: "Start dev",
+              command: `printf "$PWRAGENT_TEST_HYDRATED_ENV" > ${JSON.stringify(outputPath)}`,
+            },
+          ],
+        },
       });
+      expect(result.actionRuns).toEqual([
+        expect.objectContaining({
+          runId: "test-run-2",
+          actionId: "start-dev",
+          status: "started",
+        }),
+      ]);
 
       await expect(expectEventually(async () => await readFile(outputPath, "utf8"))).resolves.toBe(
         "hydrated",
@@ -87,39 +92,39 @@ describe("codex environment runtime", () => {
       );
       await chmod(shellPath, 0o755);
 
-      await expect(
-        startLocalCodexEnvironmentAction({
-          actionId: "start-dev",
-          env: {
-            ...process.env,
-            ELECTRON_RENDERER_URL: "http://127.0.0.1:5173",
-            ELECTRON_RUN_AS_NODE: "1",
-            PWRAGENT_TEST_HYDRATED_ENV: "hydrated",
-            SHELL: shellPath,
-            VITE_DEV_SERVER_URL: "http://127.0.0.1:5174",
-          },
-          runtime: {
-            environmentId: "env",
-            environmentName: "Env",
-            executionTarget: "local",
-            cwd: root,
-            actions: [
-              {
-                id: "start-dev",
-                name: "Start dev",
-                command: [
-                  `printf 'renderer=%s\\n' "\${ELECTRON_RENDERER_URL-unset}" > ${JSON.stringify(outputPath)}`,
-                  `printf 'run_as_node=%s\\n' "\${ELECTRON_RUN_AS_NODE-unset}" >> ${JSON.stringify(outputPath)}`,
-                  `printf 'vite=%s\\n' "\${VITE_DEV_SERVER_URL-unset}" >> ${JSON.stringify(outputPath)}`,
-                  `printf 'hydrated=%s\\n' "$PWRAGENT_TEST_HYDRATED_ENV" >> ${JSON.stringify(outputPath)}`,
-                ].join("\n"),
-              },
-            ],
-          },
-        }),
-      ).resolves.toMatchObject({
-        actionStatus: "started",
+      const result = await startLocalCodexEnvironmentAction({
+        actionId: "start-dev",
+        runId: "test-run-3",
+        env: {
+          ...process.env,
+          ELECTRON_RENDERER_URL: "http://127.0.0.1:5173",
+          ELECTRON_RUN_AS_NODE: "1",
+          PWRAGENT_TEST_HYDRATED_ENV: "hydrated",
+          SHELL: shellPath,
+          VITE_DEV_SERVER_URL: "http://127.0.0.1:5174",
+        },
+        runtime: {
+          environmentId: "env",
+          environmentName: "Env",
+          executionTarget: "local",
+          cwd: root,
+          actions: [
+            {
+              id: "start-dev",
+              name: "Start dev",
+              command: [
+                `printf 'renderer=%s\\n' "\${ELECTRON_RENDERER_URL-unset}" > ${JSON.stringify(outputPath)}`,
+                `printf 'run_as_node=%s\\n' "\${ELECTRON_RUN_AS_NODE-unset}" >> ${JSON.stringify(outputPath)}`,
+                `printf 'vite=%s\\n' "\${VITE_DEV_SERVER_URL-unset}" >> ${JSON.stringify(outputPath)}`,
+                `printf 'hydrated=%s\\n' "$PWRAGENT_TEST_HYDRATED_ENV" >> ${JSON.stringify(outputPath)}`,
+              ].join("\n"),
+            },
+          ],
+        },
       });
+      expect(result.actionRuns).toEqual([
+        expect.objectContaining({ runId: "test-run-3", status: "started" }),
+      ]);
 
       const expectedOutput = [
         "renderer=unset",

--- a/apps/desktop/src/main/__tests__/per-key-async-lock.test.ts
+++ b/apps/desktop/src/main/__tests__/per-key-async-lock.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+import { PerKeyAsyncLock } from "../util/per-key-async-lock";
+
+/** Promise-based deferred for test scheduling. */
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("PerKeyAsyncLock", () => {
+  it("runs tasks against different keys concurrently", async () => {
+    const lock = new PerKeyAsyncLock();
+    const aGate = deferred<void>();
+    const bGate = deferred<void>();
+    const order: string[] = [];
+
+    const a = lock.run("a", async () => {
+      order.push("a:start");
+      await aGate.promise;
+      order.push("a:end");
+    });
+    const b = lock.run("b", async () => {
+      order.push("b:start");
+      await bGate.promise;
+      order.push("b:end");
+    });
+
+    // Both tasks should have begun before either finishes; this is the
+    // distinguishing behaviour vs a global lock.
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(order).toEqual(["a:start", "b:start"]);
+
+    bGate.resolve();
+    aGate.resolve();
+    await Promise.all([a, b]);
+    expect(order).toEqual(["a:start", "b:start", "b:end", "a:end"]);
+  });
+
+  it("serialises tasks against the same key", async () => {
+    const lock = new PerKeyAsyncLock();
+    const firstGate = deferred<void>();
+    const secondStartedSpy = { called: false };
+    const order: string[] = [];
+
+    const first = lock.run("k", async () => {
+      order.push("1:start");
+      await firstGate.promise;
+      order.push("1:end");
+    });
+    const second = lock.run("k", async () => {
+      secondStartedSpy.called = true;
+      order.push("2:start");
+      order.push("2:end");
+    });
+
+    // The second task must not have started yet — the lock should hold
+    // it until the first task settles.
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(order).toEqual(["1:start"]);
+    expect(secondStartedSpy.called).toBe(false);
+
+    firstGate.resolve();
+    await Promise.all([first, second]);
+    expect(order).toEqual(["1:start", "1:end", "2:start", "2:end"]);
+  });
+
+  it("preserves task return values and propagates rejections to the caller", async () => {
+    const lock = new PerKeyAsyncLock();
+    await expect(lock.run("k", async () => 42)).resolves.toBe(42);
+    await expect(
+      lock.run("k", async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+  });
+
+  it("does not let a failed task poison the chain for subsequent tasks on the same key", async () => {
+    // Regression for the failure-poisoning concern: a single rejected
+    // task in the chain must not cause the next caller's `run()` to
+    // reject before its own task has had a chance to execute. We
+    // deliberately queue both calls before the first resolves so they
+    // sit on the same chain link.
+    const lock = new PerKeyAsyncLock();
+    const failingGate = deferred<void>();
+    const failing = lock.run("k", async () => {
+      await failingGate.promise;
+      throw new Error("planned failure");
+    });
+    const followUp = lock.run("k", async () => "ok");
+    failingGate.resolve();
+
+    await expect(failing).rejects.toThrow("planned failure");
+    await expect(followUp).resolves.toBe("ok");
+  });
+
+  it("releases the key entry after the chain settles with no follow-up queued", async () => {
+    const lock = new PerKeyAsyncLock();
+    await lock.run("k", async () => "done");
+    expect(lock.size()).toBe(0);
+
+    // Same after a rejection.
+    await expect(
+      lock.run("k", async () => {
+        throw new Error("oops");
+      }),
+    ).rejects.toThrow();
+    expect(lock.size()).toBe(0);
+  });
+
+  it("retains the key entry while a follow-up is still queued, and drops it after that settles", async () => {
+    // The lazy cleanup must NOT delete an entry that has a chained
+    // follow-up waiting, otherwise the next concurrent caller would
+    // bypass the chain and race.
+    const lock = new PerKeyAsyncLock();
+    const firstGate = deferred<void>();
+    const secondGate = deferred<void>();
+
+    const first = lock.run("k", async () => {
+      await firstGate.promise;
+    });
+    const second = lock.run("k", async () => {
+      await secondGate.promise;
+    });
+
+    // While the first is still in flight, the map has an entry.
+    expect(lock.size()).toBe(1);
+
+    firstGate.resolve();
+    await first;
+    // After the first settles, the second's chain link is still the
+    // latest, so the map keeps an entry.
+    expect(lock.size()).toBe(1);
+
+    secondGate.resolve();
+    await second;
+    // After the second settles and no further task is queued, the
+    // entry is dropped.
+    expect(lock.size()).toBe(0);
+  });
+
+  it("isolates failure on one key from progress on another", async () => {
+    const lock = new PerKeyAsyncLock();
+    const aFailed = lock.run("a", async () => {
+      throw new Error("a failed");
+    });
+    const bOk = lock.run("b", async () => "b ok");
+
+    await expect(aFailed).rejects.toThrow("a failed");
+    await expect(bOk).resolves.toBe("b ok");
+  });
+
+  it("queues many concurrent tasks against the same key into strict order", async () => {
+    const lock = new PerKeyAsyncLock();
+    const order: number[] = [];
+    const tasks: Array<Promise<void>> = [];
+    for (let i = 0; i < 10; i += 1) {
+      const index = i;
+      tasks.push(
+        lock.run("k", async () => {
+          // Yield once so concurrent enqueuing has a chance to scramble
+          // the order if the lock weren't enforcing it.
+          await Promise.resolve();
+          order.push(index);
+        }),
+      );
+    }
+    await Promise.all(tasks);
+    expect(order).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  });
+});

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1699,46 +1699,81 @@ export class DesktopBackendRegistry {
     let cleanedThreads = 0;
     let bytesShed = 0;
     let zombiesConverted = 0;
-    for (const overlay of overlays) {
-      const runtime = overlay.codexEnvironmentRuntime;
-      if (!runtime) continue;
-      const runs = readCodexEnvironmentActionRuns(runtime);
-      if (runs.length === 0) continue;
-      let changed = false;
-      const nextRuns = runs.map((run) => {
-        const latestAt = Math.max(run.exitedAt ?? 0, run.startedAt ?? 0);
-        if (latestAt === 0 || latestAt >= sessionStartedAt) {
-          return run;
-        }
-        changed = true;
-        bytesShed += run.output?.length ?? 0;
+    for (const overlayHint of overlays) {
+      // Run each thread's clean under the per-thread lock and re-read
+      // overlay state inside it, so a concurrent runCodexEnvironmentAction
+      // can't append a fresh run that we then overwrite with a stale
+      // snapshot. The hint we got from `lister` is point-in-time; the
+      // re-read is the source of truth.
+      await this.withCodexEnvironmentRuntimeLock(
+        overlayHint.backend,
+        overlayHint.threadId,
+        async () => {
+          const overlay = await this.overlayStore.getThreadOverlayState({
+            backend: overlayHint.backend,
+            threadId: overlayHint.threadId,
+          });
+          const runtime = overlay?.codexEnvironmentRuntime;
+          if (!runtime) return;
+          const runs = readCodexEnvironmentActionRuns(runtime);
+          if (runs.length === 0) return;
+          let changed = false;
+          const nextRuns = runs.map((run) => {
+        // For "started" runs, decide ownership by timestamp: anything
+        // started before this registry session is a zombie (detached
+        // children with piped stdio died via SIGPIPE when the prior
+        // process exited). Anything started at or after sessionStartedAt
+        // was kicked off by this session and must be left alone — the
+        // cleanup is fire-and-forget so a fast user Run-click could
+        // land a fresh entry before this iteration commits.
+        //
+        // Legacy-synthesised runs (from overlays written before
+        // actionStartedAt existed) carry startedAt=0, which correctly
+        // falls into the "before this session" bucket and gets
+        // converted — fixing the regression where the renderer would
+        // show a stale, undismissable "running" anchor after a parent
+        // crash.
         if (run.status === "started") {
+          const startedAt = run.startedAt ?? 0;
+          if (startedAt >= sessionStartedAt) {
+            return run;
+          }
+          changed = true;
+          bytesShed += run.output?.length ?? 0;
           zombiesConverted += 1;
           return {
             ...run,
             status: "failed" as const,
             output: undefined,
-            // Without an authoritative exit time, use startedAt so the
-            // duration math doesn't go negative or absurd.
             exitedAt: run.exitedAt ?? run.startedAt ?? sessionStartedAt,
             durationMs:
               run.durationMs ??
-              Math.max(0, (run.exitedAt ?? sessionStartedAt) - (run.startedAt ?? 0)),
+              Math.max(0, (run.exitedAt ?? sessionStartedAt) - startedAt),
           };
         }
-        return { ...run, output: undefined };
+        // Finished runs: shed bytes only if their latest activity
+        // predates this session.
+        const latestAt = Math.max(run.exitedAt ?? 0, run.startedAt ?? 0);
+        if (latestAt > 0 && latestAt < sessionStartedAt && run.output) {
+          changed = true;
+          bytesShed += run.output.length;
+          return { ...run, output: undefined };
+        }
+        return run;
       });
-      if (!changed) continue;
-      cleanedThreads += 1;
-      const nextRuntime: CodexThreadEnvironmentRuntime = {
-        ...runtime,
-        actionRuns: nextRuns,
-      };
-      await this.overlayStore.setThreadCodexEnvironmentRuntime?.({
-        backend: overlay.backend,
-        threadId: overlay.threadId,
-        codexEnvironmentRuntime: nextRuntime,
-      });
+          if (!changed) return;
+          cleanedThreads += 1;
+          const nextRuntime: CodexThreadEnvironmentRuntime = {
+            ...runtime,
+            actionRuns: nextRuns,
+          };
+          await this.overlayStore.setThreadCodexEnvironmentRuntime?.({
+            backend: overlayHint.backend,
+            threadId: overlayHint.threadId,
+            codexEnvironmentRuntime: nextRuntime,
+          });
+        },
+      );
     }
     if (cleanedThreads > 0) {
       backendRegistryLog.info("codex-environment-startup-cleanup", {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1511,6 +1511,18 @@ export class DesktopBackendRegistry {
     }
   >();
   private readonly queuedExecutionModeFlushes = new Map<string, Promise<void>>();
+  /**
+   * Per-thread async chain serialising read-modify-write of
+   * codexEnvironmentRuntime. Concurrent Run-button clicks and
+   * concurrent detached-child exit/output callbacks all funnel through
+   * this so two simultaneous overlay writes can't clobber each other.
+   * Keyed by `${backend}:${threadId}`. Cleared lazily when a chain
+   * settles and no later task has been queued on it.
+   */
+  private readonly codexEnvironmentRuntimeLocks = new Map<
+    string,
+    Promise<unknown>
+  >();
   private readonly attemptedTitleGenerations = new Set<string>();
   private readonly repairedDirectoryThreadKeys = new Set<string>();
   private readonly failedDirectoryRelationshipLogKeys = new Set<string>();
@@ -1652,6 +1664,90 @@ export class DesktopBackendRegistry {
 
     this.subscribeClient("codex", this.codexClient);
     this.subscribeClient("grok", this.grokClient);
+
+    // Kick off a one-shot scan of persisted codexEnvironmentRuntime
+    // entries: zombie "started" runs from a prior session become
+    // "failed", and output bytes get cleared on anything finished
+    // before this session started. Fire-and-forget — the renderer's
+    // session-startedAt filter already hides stale entries from view,
+    // so this is purely about reclaiming sqlite bytes and tidying
+    // persisted state. Errors are swallowed; this can't break startup.
+    void this.cleanupStaleCodexEnvironmentRuntimes().catch((error) => {
+      backendRegistryLog.warn("codex-environment-startup-cleanup-failed", {
+        message: error instanceof Error ? error.message : String(error),
+      });
+    });
+  }
+
+  /**
+   * Captured at registry construction. Action-run entries from before
+   * this moment are treated as historical: their `output` is shed and
+   * any "started" entries are downgraded to "failed", since the child
+   * process didn't survive the parent restart.
+   */
+  private readonly registrySessionStartedAt = Date.now();
+
+  private async cleanupStaleCodexEnvironmentRuntimes(): Promise<void> {
+    const lister = this.overlayStore.listThreadOverlaysWithCodexEnvironmentRuntime;
+    if (!lister) {
+      // Test overlay mocks or older overlay-store implementations may
+      // not expose the bulk reader. Skip cleanup silently.
+      return;
+    }
+    const overlays = await lister.call(this.overlayStore);
+    const sessionStartedAt = this.registrySessionStartedAt;
+    let cleanedThreads = 0;
+    let bytesShed = 0;
+    let zombiesConverted = 0;
+    for (const overlay of overlays) {
+      const runtime = overlay.codexEnvironmentRuntime;
+      if (!runtime) continue;
+      const runs = readCodexEnvironmentActionRuns(runtime);
+      if (runs.length === 0) continue;
+      let changed = false;
+      const nextRuns = runs.map((run) => {
+        const latestAt = Math.max(run.exitedAt ?? 0, run.startedAt ?? 0);
+        if (latestAt === 0 || latestAt >= sessionStartedAt) {
+          return run;
+        }
+        changed = true;
+        bytesShed += run.output?.length ?? 0;
+        if (run.status === "started") {
+          zombiesConverted += 1;
+          return {
+            ...run,
+            status: "failed" as const,
+            output: undefined,
+            // Without an authoritative exit time, use startedAt so the
+            // duration math doesn't go negative or absurd.
+            exitedAt: run.exitedAt ?? run.startedAt ?? sessionStartedAt,
+            durationMs:
+              run.durationMs ??
+              Math.max(0, (run.exitedAt ?? sessionStartedAt) - (run.startedAt ?? 0)),
+          };
+        }
+        return { ...run, output: undefined };
+      });
+      if (!changed) continue;
+      cleanedThreads += 1;
+      const nextRuntime: CodexThreadEnvironmentRuntime = {
+        ...runtime,
+        actionRuns: nextRuns,
+      };
+      await this.overlayStore.setThreadCodexEnvironmentRuntime?.({
+        backend: overlay.backend,
+        threadId: overlay.threadId,
+        codexEnvironmentRuntime: nextRuntime,
+      });
+    }
+    if (cleanedThreads > 0) {
+      backendRegistryLog.info("codex-environment-startup-cleanup", {
+        cleanedThreads,
+        zombiesConverted,
+        bytesShed,
+        sessionStartedAt,
+      });
+    }
   }
 
   onEvent(listener: (event: AgentEvent) => void | Promise<void>): () => void {
@@ -3550,84 +3646,95 @@ export class DesktopBackendRegistry {
       throw new Error("Codex environment actions are only available for Codex threads.");
     }
 
-    const overlay = await this.overlayStore.getThreadOverlayState({
-      backend: request.backend,
-      threadId: request.threadId,
-    });
-    const runtime = overlay?.codexEnvironmentRuntime;
-    if (!runtime) {
-      throw new Error("This thread does not have a selected Codex environment.");
-    }
+    // Serialise the read-modify-write under the per-thread lock so two
+    // concurrent Run-button clicks can't clobber each other's appended
+    // run entry.
+    return this.withCodexEnvironmentRuntimeLock(
+      request.backend,
+      request.threadId,
+      async () => {
+        const overlay = await this.overlayStore.getThreadOverlayState({
+          backend: request.backend,
+          threadId: request.threadId,
+        });
+        const runtime = overlay?.codexEnvironmentRuntime;
+        if (!runtime) {
+          throw new Error(
+            "This thread does not have a selected Codex environment.",
+          );
+        }
 
-    const currentCwd =
-      request.cwd?.trim() ||
-      (await this.resolveCodexThreadTurnCwd(request.threadId, overlay));
-    const runtimeForAction = await this.refreshCodexEnvironmentRuntimeActions(
-      currentCwd?.trim() ? { ...runtime, cwd: currentCwd.trim() } : runtime,
-      request.actionId,
-    );
-    const runId = randomUUID();
-    let nextRuntime: CodexThreadEnvironmentRuntime;
-    try {
-      nextRuntime = await startLocalCodexEnvironmentAction({
-        actionId: request.actionId,
-        runId,
-        commandRunner: this.codexEnvironmentCommandRunner,
-        env: this.codexEnvironmentCommandEnv,
-        runtime: runtimeForAction,
-        onDetachedExit: (event) => {
-          void this.handleCodexEnvironmentActionDetachedExit({
-            backend: request.backend,
-            threadId: request.threadId,
+        const currentCwd =
+          request.cwd?.trim() ||
+          (await this.resolveCodexThreadTurnCwd(request.threadId, overlay));
+        const runtimeForAction = await this.refreshCodexEnvironmentRuntimeActions(
+          currentCwd?.trim() ? { ...runtime, cwd: currentCwd.trim() } : runtime,
+          request.actionId,
+        );
+        const runId = randomUUID();
+        let nextRuntime: CodexThreadEnvironmentRuntime;
+        try {
+          nextRuntime = await startLocalCodexEnvironmentAction({
+            actionId: request.actionId,
             runId,
-            event,
+            commandRunner: this.codexEnvironmentCommandRunner,
+            env: this.codexEnvironmentCommandEnv,
+            runtime: runtimeForAction,
+            onDetachedExit: (event) => {
+              void this.handleCodexEnvironmentActionDetachedExit({
+                backend: request.backend,
+                threadId: request.threadId,
+                runId,
+                event,
+              });
+            },
+            onDetachedOutput: (event) => {
+              void this.handleCodexEnvironmentActionDetachedOutput({
+                backend: request.backend,
+                threadId: request.threadId,
+                runId,
+                event,
+              });
+            },
           });
-        },
-        onDetachedOutput: (event) => {
-          void this.handleCodexEnvironmentActionDetachedOutput({
-            backend: request.backend,
-            threadId: request.threadId,
-            runId,
-            event,
-          });
-        },
-      });
-    } catch (error) {
-      if (
-        error instanceof CodexEnvironmentStartupError &&
-        error.phase === "action"
-      ) {
+        } catch (error) {
+          if (
+            error instanceof CodexEnvironmentStartupError &&
+            error.phase === "action"
+          ) {
+            await this.overlayStore.setThreadCodexEnvironmentRuntime?.({
+              backend: request.backend,
+              threadId: request.threadId,
+              codexEnvironmentRuntime: error.runtime,
+            });
+            this.invalidateThreadListCache(request.backend);
+            await this.emitCodexEnvironmentRuntimeUpdated({
+              backend: request.backend,
+              threadId: request.threadId,
+              codexEnvironmentRuntime: error.runtime,
+            });
+          }
+          throw error;
+        }
         await this.overlayStore.setThreadCodexEnvironmentRuntime?.({
           backend: request.backend,
           threadId: request.threadId,
-          codexEnvironmentRuntime: error.runtime,
+          codexEnvironmentRuntime: nextRuntime,
         });
         this.invalidateThreadListCache(request.backend);
         await this.emitCodexEnvironmentRuntimeUpdated({
           backend: request.backend,
           threadId: request.threadId,
-          codexEnvironmentRuntime: error.runtime,
+          codexEnvironmentRuntime: nextRuntime,
         });
-      }
-      throw error;
-    }
-    await this.overlayStore.setThreadCodexEnvironmentRuntime?.({
-      backend: request.backend,
-      threadId: request.threadId,
-      codexEnvironmentRuntime: nextRuntime,
-    });
-    this.invalidateThreadListCache(request.backend);
-    await this.emitCodexEnvironmentRuntimeUpdated({
-      backend: request.backend,
-      threadId: request.threadId,
-      codexEnvironmentRuntime: nextRuntime,
-    });
 
-    return {
-      backend: request.backend,
-      threadId: request.threadId,
-      codexEnvironmentRuntime: nextRuntime,
-    };
+        return {
+          backend: request.backend,
+          threadId: request.threadId,
+          codexEnvironmentRuntime: nextRuntime,
+        };
+      },
+    );
   }
 
   private async refreshCodexEnvironmentRuntimeActions(
@@ -3742,6 +3849,42 @@ export class DesktopBackendRegistry {
   }
 
   /**
+   * Serialise codexEnvironmentRuntime read-modify-write operations
+   * per-thread. Without this, two concurrent run-button clicks (or two
+   * detached-child exit callbacks firing simultaneously) both read the
+   * same overlay state, each patch their own run, and the second writer
+   * silently overwrites the first.
+   */
+  private async withCodexEnvironmentRuntimeLock<T>(
+    backend: AppServerBackendKind,
+    threadId: string,
+    task: () => Promise<T>,
+  ): Promise<T> {
+    const key = `${backend}:${threadId}`;
+    const previous = this.codexEnvironmentRuntimeLocks.get(key) ?? Promise.resolve();
+    // Chain regardless of whether the previous task settled with success
+    // or failure — a single failed Run shouldn't poison the chain for
+    // subsequent Runs / exit handlers.
+    const next = previous.then(task, task);
+    // Track the swallowed-error form so future chains never reject when
+    // awaiting the previous link.
+    const tracked = next.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.codexEnvironmentRuntimeLocks.set(key, tracked);
+    try {
+      return await next;
+    } finally {
+      // Lazy cleanup: only drop the map entry if no later task got
+      // chained on this same slot while we were running.
+      if (this.codexEnvironmentRuntimeLocks.get(key) === tracked) {
+        this.codexEnvironmentRuntimeLocks.delete(key);
+      }
+    }
+  }
+
+  /**
    * Called when a detached env-action child (e.g., `pnpm dev` for the
    * PwrSnap run button) eventually exits. Patches the matching entry in
    * `codexEnvironmentRuntime.actionRuns` so the renderer's anchored
@@ -3758,60 +3901,71 @@ export class DesktopBackendRegistry {
     runId: string;
     event: CodexEnvironmentDetachedExit;
   }): Promise<void> {
-    try {
-      const overlay = await this.overlayStore.getThreadOverlayState({
-        backend: params.backend,
-        threadId: params.threadId,
-      });
-      const current = overlay?.codexEnvironmentRuntime;
-      if (!current) {
-        return;
-      }
-      const currentRuns = readCodexEnvironmentActionRuns(current);
-      if (!currentRuns.some((run) => run.runId === params.runId)) {
-        // The matching run has been evicted (cap exceeded) or this is a
-        // stale callback from a previous environment selection. Nothing
-        // to patch.
-        return;
-      }
-      const exitedSuccessfully =
-        params.event.exitCode === 0 && !params.event.exitSignal;
-      const nextRuns = applyCodexEnvironmentActionRunUpdate(currentRuns, {
-        kind: "patch",
-        runId: params.runId,
-        patch: {
-          status: exitedSuccessfully ? "exited" : "failed",
-          exitCode:
-            params.event.exitCode === null ? undefined : params.event.exitCode,
-          exitSignal: params.event.exitSignal ?? undefined,
-          durationMs: params.event.durationMs,
-          exitedAt: Date.now(),
-          output: params.event.output,
-        },
-      });
-      const next: CodexThreadEnvironmentRuntime = {
-        ...current,
-        actionRuns: nextRuns,
-      };
-      await this.overlayStore.setThreadCodexEnvironmentRuntime?.({
-        backend: params.backend,
-        threadId: params.threadId,
-        codexEnvironmentRuntime: next,
-      });
-      this.invalidateThreadListCache(params.backend);
-      await this.emitCodexEnvironmentRuntimeUpdated({
-        backend: params.backend,
-        threadId: params.threadId,
-        codexEnvironmentRuntime: next,
-      });
-    } catch (error) {
-      backendRegistryLog.warn("codex-environment-action-exit-overlay-update-failed", {
-        backend: params.backend,
-        threadId: params.threadId,
-        runId: params.runId,
-        message: error instanceof Error ? error.message : String(error),
-      });
-    }
+    await this.withCodexEnvironmentRuntimeLock(
+      params.backend,
+      params.threadId,
+      async () => {
+        try {
+          const overlay = await this.overlayStore.getThreadOverlayState({
+            backend: params.backend,
+            threadId: params.threadId,
+          });
+          const current = overlay?.codexEnvironmentRuntime;
+          if (!current) {
+            return;
+          }
+          const currentRuns = readCodexEnvironmentActionRuns(current);
+          if (!currentRuns.some((run) => run.runId === params.runId)) {
+            // The matching run has been evicted (cap exceeded) or this is
+            // a stale callback from a previous environment selection.
+            // Nothing to patch.
+            return;
+          }
+          const exitedSuccessfully =
+            params.event.exitCode === 0 && !params.event.exitSignal;
+          const nextRuns = applyCodexEnvironmentActionRunUpdate(currentRuns, {
+            kind: "patch",
+            runId: params.runId,
+            patch: {
+              status: exitedSuccessfully ? "exited" : "failed",
+              exitCode:
+                params.event.exitCode === null
+                  ? undefined
+                  : params.event.exitCode,
+              exitSignal: params.event.exitSignal ?? undefined,
+              durationMs: params.event.durationMs,
+              exitedAt: Date.now(),
+              output: params.event.output,
+            },
+          });
+          const next: CodexThreadEnvironmentRuntime = {
+            ...current,
+            actionRuns: nextRuns,
+          };
+          await this.overlayStore.setThreadCodexEnvironmentRuntime?.({
+            backend: params.backend,
+            threadId: params.threadId,
+            codexEnvironmentRuntime: next,
+          });
+          this.invalidateThreadListCache(params.backend);
+          await this.emitCodexEnvironmentRuntimeUpdated({
+            backend: params.backend,
+            threadId: params.threadId,
+            codexEnvironmentRuntime: next,
+          });
+        } catch (error) {
+          backendRegistryLog.warn(
+            "codex-environment-action-exit-overlay-update-failed",
+            {
+              backend: params.backend,
+              threadId: params.threadId,
+              runId: params.runId,
+              message: error instanceof Error ? error.message : String(error),
+            },
+          );
+        }
+      },
+    );
   }
 
   /**
@@ -3827,56 +3981,62 @@ export class DesktopBackendRegistry {
     runId: string;
     event: CodexEnvironmentDetachedOutput;
   }): Promise<void> {
-    try {
-      const overlay = await this.overlayStore.getThreadOverlayState({
-        backend: params.backend,
-        threadId: params.threadId,
-      });
-      const current = overlay?.codexEnvironmentRuntime;
-      if (!current) {
-        return;
-      }
-      const currentRuns = readCodexEnvironmentActionRuns(current);
-      const matching = currentRuns.find((run) => run.runId === params.runId);
-      if (!matching) {
-        return;
-      }
-      // Skip the write+emit if the snapshot hasn't actually changed — keeps
-      // a quiet child from generating empty IPC noise.
-      if (matching.output === params.event.output) {
-        return;
-      }
-      const nextRuns = applyCodexEnvironmentActionRunUpdate(currentRuns, {
-        kind: "patch",
-        runId: params.runId,
-        patch: { output: params.event.output },
-      });
-      const next: CodexThreadEnvironmentRuntime = {
-        ...current,
-        actionRuns: nextRuns,
-      };
-      await this.overlayStore.setThreadCodexEnvironmentRuntime?.({
-        backend: params.backend,
-        threadId: params.threadId,
-        codexEnvironmentRuntime: next,
-      });
-      this.invalidateThreadListCache(params.backend);
-      await this.emitCodexEnvironmentRuntimeUpdated({
-        backend: params.backend,
-        threadId: params.threadId,
-        codexEnvironmentRuntime: next,
-      });
-    } catch (error) {
-      backendRegistryLog.warn(
-        "codex-environment-action-output-overlay-update-failed",
-        {
-          backend: params.backend,
-          threadId: params.threadId,
-          runId: params.runId,
-          message: error instanceof Error ? error.message : String(error),
-        },
-      );
-    }
+    await this.withCodexEnvironmentRuntimeLock(
+      params.backend,
+      params.threadId,
+      async () => {
+        try {
+          const overlay = await this.overlayStore.getThreadOverlayState({
+            backend: params.backend,
+            threadId: params.threadId,
+          });
+          const current = overlay?.codexEnvironmentRuntime;
+          if (!current) {
+            return;
+          }
+          const currentRuns = readCodexEnvironmentActionRuns(current);
+          const matching = currentRuns.find((run) => run.runId === params.runId);
+          if (!matching) {
+            return;
+          }
+          // Skip the write+emit if the snapshot hasn't actually changed —
+          // keeps a quiet child from generating empty IPC noise.
+          if (matching.output === params.event.output) {
+            return;
+          }
+          const nextRuns = applyCodexEnvironmentActionRunUpdate(currentRuns, {
+            kind: "patch",
+            runId: params.runId,
+            patch: { output: params.event.output },
+          });
+          const next: CodexThreadEnvironmentRuntime = {
+            ...current,
+            actionRuns: nextRuns,
+          };
+          await this.overlayStore.setThreadCodexEnvironmentRuntime?.({
+            backend: params.backend,
+            threadId: params.threadId,
+            codexEnvironmentRuntime: next,
+          });
+          this.invalidateThreadListCache(params.backend);
+          await this.emitCodexEnvironmentRuntimeUpdated({
+            backend: params.backend,
+            threadId: params.threadId,
+            codexEnvironmentRuntime: next,
+          });
+        } catch (error) {
+          backendRegistryLog.warn(
+            "codex-environment-action-output-overlay-update-failed",
+            {
+              backend: params.backend,
+              threadId: params.threadId,
+              runId: params.runId,
+              message: error instanceof Error ? error.message : String(error),
+            },
+          );
+        }
+      },
+    );
   }
 
   async materializeDirectoryLaunchpad(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -126,6 +126,7 @@ import {
   startLocalCodexEnvironmentAction,
   type CodexEnvironmentCommandRunner,
   type CodexEnvironmentDetachedExit,
+  type CodexEnvironmentDetachedOutput,
   type CodexEnvironmentSelection,
 } from "./codex-environment-runtime";
 import type { MessagingStoreLike } from "../state/messaging-store-sqlite";
@@ -3578,6 +3579,14 @@ export class DesktopBackendRegistry {
             event,
           });
         },
+        onDetachedOutput: (event) => {
+          void this.handleCodexEnvironmentActionDetachedOutput({
+            backend: request.backend,
+            threadId: request.threadId,
+            actionId: request.actionId,
+            event,
+          });
+        },
       });
     } catch (error) {
       if (
@@ -3790,6 +3799,67 @@ export class DesktopBackendRegistry {
     }
   }
 
+  /**
+   * Called periodically (throttled to ~500ms) while a detached env-action
+   * child is running, with a snapshot of its accumulated stdout+stderr.
+   * Updates `actionOutput` on the overlay so the renderer's anchored UI
+   * shows live output instead of "(no output yet)". Does not change
+   * actionStatus — that stays "started" until the child closes.
+   *
+   * Same actionId guard as the exit handler so a stale snapshot can't
+   * overwrite a fresh action's output.
+   */
+  private async handleCodexEnvironmentActionDetachedOutput(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    actionId: string;
+    event: CodexEnvironmentDetachedOutput;
+  }): Promise<void> {
+    try {
+      const overlay = await this.overlayStore.getThreadOverlayState({
+        backend: params.backend,
+        threadId: params.threadId,
+      });
+      const current = overlay?.codexEnvironmentRuntime;
+      if (!current) {
+        return;
+      }
+      if (current.actionId && current.actionId !== params.actionId) {
+        return;
+      }
+      // Skip the write+emit if the snapshot hasn't actually changed — keeps
+      // a quiet child from generating empty IPC noise.
+      if (current.actionOutput === params.event.output) {
+        return;
+      }
+      const next: CodexThreadEnvironmentRuntime = {
+        ...current,
+        actionOutput: params.event.output,
+      };
+      await this.overlayStore.setThreadCodexEnvironmentRuntime?.({
+        backend: params.backend,
+        threadId: params.threadId,
+        codexEnvironmentRuntime: next,
+      });
+      this.invalidateThreadListCache(params.backend);
+      await this.emitCodexEnvironmentRuntimeUpdated({
+        backend: params.backend,
+        threadId: params.threadId,
+        codexEnvironmentRuntime: next,
+      });
+    } catch (error) {
+      backendRegistryLog.warn(
+        "codex-environment-action-output-overlay-update-failed",
+        {
+          backend: params.backend,
+          threadId: params.threadId,
+          actionId: params.actionId,
+          message: error instanceof Error ? error.message : String(error),
+        },
+      );
+    }
+  }
+
   async materializeDirectoryLaunchpad(
     request: MaterializeDirectoryLaunchpadRequest,
     options?: {
@@ -3839,6 +3909,7 @@ export class DesktopBackendRegistry {
     // thread is started so we can attribute them to the right thread.
     let pendingActionThreadId: string | undefined;
     const queuedActionDetachedExits: CodexEnvironmentDetachedExit[] = [];
+    const queuedActionDetachedOutputs: CodexEnvironmentDetachedOutput[] = [];
     const codexActionBackend: AppServerBackendKind = launchpad.backend;
     const onActionDetachedExit = (event: CodexEnvironmentDetachedExit) => {
       if (pendingActionThreadId && codexEnvironmentSelection?.action?.id) {
@@ -3851,6 +3922,23 @@ export class DesktopBackendRegistry {
         return;
       }
       queuedActionDetachedExits.push(event);
+    };
+    const onActionDetachedOutput = (event: CodexEnvironmentDetachedOutput) => {
+      if (pendingActionThreadId && codexEnvironmentSelection?.action?.id) {
+        void this.handleCodexEnvironmentActionDetachedOutput({
+          backend: codexActionBackend,
+          threadId: pendingActionThreadId,
+          actionId: codexEnvironmentSelection.action.id,
+          event,
+        });
+        return;
+      }
+      // Output snapshots before startThread completes are rare (auto-action
+      // commands usually print after a moment) but worth queueing so the
+      // first post-start render of the anchor has something to show.
+      // Only keep the latest — older snapshots are strict subsets of newer.
+      queuedActionDetachedOutputs.length = 0;
+      queuedActionDetachedOutputs.push(event);
     };
     if (launchpad.backend === "codex") {
       try {
@@ -3867,6 +3955,7 @@ export class DesktopBackendRegistry {
               }
             : undefined,
           onActionDetachedExit,
+          onActionDetachedOutput,
           selection: codexEnvironmentSelection,
         });
       } catch (error) {
@@ -3893,11 +3982,17 @@ export class DesktopBackendRegistry {
       codexEnvironmentRuntime,
     });
     pendingActionThreadId = startThreadResponse.threadId;
-    if (
-      codexEnvironmentSelection?.action?.id &&
-      queuedActionDetachedExits.length > 0
-    ) {
+    if (codexEnvironmentSelection?.action?.id) {
       const actionId = codexEnvironmentSelection.action.id;
+      for (const event of queuedActionDetachedOutputs) {
+        void this.handleCodexEnvironmentActionDetachedOutput({
+          backend: codexActionBackend,
+          threadId: startThreadResponse.threadId,
+          actionId,
+          event,
+        });
+      }
+      queuedActionDetachedOutputs.length = 0;
       for (const event of queuedActionDetachedExits) {
         void this.handleCodexEnvironmentActionDetachedExit({
           backend: codexActionBackend,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -87,6 +87,8 @@ import {
   type UpdateThreadExpectedBranchResponse,
   type EnsureDirectoryLaunchpadRequest,
   type EnsureDirectoryLaunchpadResponse,
+  applyCodexEnvironmentActionRunUpdate,
+  readCodexEnvironmentActionRuns,
 } from "@pwragent/shared";
 import { CodexAppServerClient } from "../codex-app-server/client";
 import { GrokAppServerClient } from "../grok-app-server/client";
@@ -3564,10 +3566,12 @@ export class DesktopBackendRegistry {
       currentCwd?.trim() ? { ...runtime, cwd: currentCwd.trim() } : runtime,
       request.actionId,
     );
+    const runId = randomUUID();
     let nextRuntime: CodexThreadEnvironmentRuntime;
     try {
       nextRuntime = await startLocalCodexEnvironmentAction({
         actionId: request.actionId,
+        runId,
         commandRunner: this.codexEnvironmentCommandRunner,
         env: this.codexEnvironmentCommandEnv,
         runtime: runtimeForAction,
@@ -3575,7 +3579,7 @@ export class DesktopBackendRegistry {
           void this.handleCodexEnvironmentActionDetachedExit({
             backend: request.backend,
             threadId: request.threadId,
-            actionId: request.actionId,
+            runId,
             event,
           });
         },
@@ -3583,7 +3587,7 @@ export class DesktopBackendRegistry {
           void this.handleCodexEnvironmentActionDetachedOutput({
             backend: request.backend,
             threadId: request.threadId,
-            actionId: request.actionId,
+            runId,
             event,
           });
         },
@@ -3739,18 +3743,19 @@ export class DesktopBackendRegistry {
 
   /**
    * Called when a detached env-action child (e.g., `pnpm dev` for the
-   * PwrSnap run button) eventually exits. Updates overlay state so the
-   * renderer's anchored env-action output UI shows exit code + output,
+   * PwrSnap run button) eventually exits. Patches the matching entry in
+   * `codexEnvironmentRuntime.actionRuns` so the renderer's anchored
+   * env-action output UI shows exit code + output for that specific run,
    * and emits `thread/codexEnvironment/updated` so the UI refreshes.
    *
-   * The current overlay runtime is the source of truth — we only patch
-   * the exit-related fields if the recorded action matches (so a stale
-   * exit from a prior run doesn't overwrite a freshly-started one).
+   * Patches by `runId` rather than `actionId` so a second concurrent run
+   * of the same action (e.g. user runs Test, it's still running, user
+   * runs Test again) doesn't have its output collide with the first.
    */
   private async handleCodexEnvironmentActionDetachedExit(params: {
     backend: AppServerBackendKind;
     threadId: string;
-    actionId: string;
+    runId: string;
     event: CodexEnvironmentDetachedExit;
   }): Promise<void> {
     try {
@@ -3762,21 +3767,31 @@ export class DesktopBackendRegistry {
       if (!current) {
         return;
       }
-      if (current.actionId && current.actionId !== params.actionId) {
-        // A different action has since been started; don't clobber.
+      const currentRuns = readCodexEnvironmentActionRuns(current);
+      if (!currentRuns.some((run) => run.runId === params.runId)) {
+        // The matching run has been evicted (cap exceeded) or this is a
+        // stale callback from a previous environment selection. Nothing
+        // to patch.
         return;
       }
       const exitedSuccessfully =
         params.event.exitCode === 0 && !params.event.exitSignal;
+      const nextRuns = applyCodexEnvironmentActionRunUpdate(currentRuns, {
+        kind: "patch",
+        runId: params.runId,
+        patch: {
+          status: exitedSuccessfully ? "exited" : "failed",
+          exitCode:
+            params.event.exitCode === null ? undefined : params.event.exitCode,
+          exitSignal: params.event.exitSignal ?? undefined,
+          durationMs: params.event.durationMs,
+          exitedAt: Date.now(),
+          output: params.event.output,
+        },
+      });
       const next: CodexThreadEnvironmentRuntime = {
         ...current,
-        actionStatus: exitedSuccessfully ? "exited" : "failed",
-        actionExitCode:
-          params.event.exitCode === null ? undefined : params.event.exitCode,
-        actionExitSignal: params.event.exitSignal ?? undefined,
-        actionDurationMs: params.event.durationMs,
-        actionExitedAt: Date.now(),
-        actionOutput: params.event.output,
+        actionRuns: nextRuns,
       };
       await this.overlayStore.setThreadCodexEnvironmentRuntime?.({
         backend: params.backend,
@@ -3793,7 +3808,7 @@ export class DesktopBackendRegistry {
       backendRegistryLog.warn("codex-environment-action-exit-overlay-update-failed", {
         backend: params.backend,
         threadId: params.threadId,
-        actionId: params.actionId,
+        runId: params.runId,
         message: error instanceof Error ? error.message : String(error),
       });
     }
@@ -3802,17 +3817,14 @@ export class DesktopBackendRegistry {
   /**
    * Called periodically (throttled to ~500ms) while a detached env-action
    * child is running, with a snapshot of its accumulated stdout+stderr.
-   * Updates `actionOutput` on the overlay so the renderer's anchored UI
-   * shows live output instead of "(no output yet)". Does not change
-   * actionStatus — that stays "started" until the child closes.
-   *
-   * Same actionId guard as the exit handler so a stale snapshot can't
-   * overwrite a fresh action's output.
+   * Patches the matching run's `output` on the overlay so the renderer's
+   * anchored UI shows live output. Does not change `status` — that stays
+   * "started" until the child closes.
    */
   private async handleCodexEnvironmentActionDetachedOutput(params: {
     backend: AppServerBackendKind;
     threadId: string;
-    actionId: string;
+    runId: string;
     event: CodexEnvironmentDetachedOutput;
   }): Promise<void> {
     try {
@@ -3824,17 +3836,24 @@ export class DesktopBackendRegistry {
       if (!current) {
         return;
       }
-      if (current.actionId && current.actionId !== params.actionId) {
+      const currentRuns = readCodexEnvironmentActionRuns(current);
+      const matching = currentRuns.find((run) => run.runId === params.runId);
+      if (!matching) {
         return;
       }
       // Skip the write+emit if the snapshot hasn't actually changed — keeps
       // a quiet child from generating empty IPC noise.
-      if (current.actionOutput === params.event.output) {
+      if (matching.output === params.event.output) {
         return;
       }
+      const nextRuns = applyCodexEnvironmentActionRunUpdate(currentRuns, {
+        kind: "patch",
+        runId: params.runId,
+        patch: { output: params.event.output },
+      });
       const next: CodexThreadEnvironmentRuntime = {
         ...current,
-        actionOutput: params.event.output,
+        actionRuns: nextRuns,
       };
       await this.overlayStore.setThreadCodexEnvironmentRuntime?.({
         backend: params.backend,
@@ -3853,7 +3872,7 @@ export class DesktopBackendRegistry {
         {
           backend: params.backend,
           threadId: params.threadId,
-          actionId: params.actionId,
+          runId: params.runId,
           message: error instanceof Error ? error.message : String(error),
         },
       );
@@ -3907,6 +3926,10 @@ export class DesktopBackendRegistry {
     // The detached env-action child can exit asynchronously after we've
     // already returned to the caller. Queue any early exits until the
     // thread is started so we can attribute them to the right thread.
+    // Pre-generate the runId for the auto-action so the same id flows
+    // from the runtime helper into the renderer's actionRuns entry and
+    // into the post-startThread output/exit handlers.
+    const autoActionRunId = randomUUID();
     let pendingActionThreadId: string | undefined;
     const queuedActionDetachedExits: CodexEnvironmentDetachedExit[] = [];
     const queuedActionDetachedOutputs: CodexEnvironmentDetachedOutput[] = [];
@@ -3916,7 +3939,7 @@ export class DesktopBackendRegistry {
         void this.handleCodexEnvironmentActionDetachedExit({
           backend: codexActionBackend,
           threadId: pendingActionThreadId,
-          actionId: codexEnvironmentSelection.action.id,
+          runId: autoActionRunId,
           event,
         });
         return;
@@ -3928,7 +3951,7 @@ export class DesktopBackendRegistry {
         void this.handleCodexEnvironmentActionDetachedOutput({
           backend: codexActionBackend,
           threadId: pendingActionThreadId,
-          actionId: codexEnvironmentSelection.action.id,
+          runId: autoActionRunId,
           event,
         });
         return;
@@ -3956,6 +3979,7 @@ export class DesktopBackendRegistry {
             : undefined,
           onActionDetachedExit,
           onActionDetachedOutput,
+          actionRunId: autoActionRunId,
           selection: codexEnvironmentSelection,
         });
       } catch (error) {
@@ -3983,12 +4007,11 @@ export class DesktopBackendRegistry {
     });
     pendingActionThreadId = startThreadResponse.threadId;
     if (codexEnvironmentSelection?.action?.id) {
-      const actionId = codexEnvironmentSelection.action.id;
       for (const event of queuedActionDetachedOutputs) {
         void this.handleCodexEnvironmentActionDetachedOutput({
           backend: codexActionBackend,
           threadId: startThreadResponse.threadId,
-          actionId,
+          runId: autoActionRunId,
           event,
         });
       }
@@ -3997,7 +4020,7 @@ export class DesktopBackendRegistry {
         void this.handleCodexEnvironmentActionDetachedExit({
           backend: codexActionBackend,
           threadId: startThreadResponse.threadId,
-          actionId,
+          runId: autoActionRunId,
           event,
         });
       }

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -5,6 +5,7 @@ import { stat } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 import type { OverlayStoreLike } from "../state/overlay-store-sqlite";
+import { PerKeyAsyncLock } from "../util/per-key-async-lock";
 import {
   isToolManagedWorktreePath,
   shortenDerivedThreadTitle,
@@ -1516,13 +1517,10 @@ export class DesktopBackendRegistry {
    * codexEnvironmentRuntime. Concurrent Run-button clicks and
    * concurrent detached-child exit/output callbacks all funnel through
    * this so two simultaneous overlay writes can't clobber each other.
-   * Keyed by `${backend}:${threadId}`. Cleared lazily when a chain
-   * settles and no later task has been queued on it.
+   * Keyed by `${backend}:${threadId}`. Implementation details and
+   * failure-poisoning semantics live in PerKeyAsyncLock.
    */
-  private readonly codexEnvironmentRuntimeLocks = new Map<
-    string,
-    Promise<unknown>
-  >();
+  private readonly codexEnvironmentRuntimeLocks = new PerKeyAsyncLock();
   private readonly attemptedTitleGenerations = new Set<string>();
   private readonly repairedDirectoryThreadKeys = new Set<string>();
   private readonly failedDirectoryRelationshipLogKeys = new Set<string>();
@@ -3889,38 +3887,20 @@ export class DesktopBackendRegistry {
 
   /**
    * Serialise codexEnvironmentRuntime read-modify-write operations
-   * per-thread. Without this, two concurrent run-button clicks (or two
-   * detached-child exit callbacks firing simultaneously) both read the
-   * same overlay state, each patch their own run, and the second writer
-   * silently overwrites the first.
+   * per-thread via {@link PerKeyAsyncLock}. Two concurrent run-button
+   * clicks, or two detached-child exit callbacks firing at once, would
+   * otherwise both read the same overlay state, each patch their own
+   * run, and the second writer would silently overwrite the first.
    */
-  private async withCodexEnvironmentRuntimeLock<T>(
+  private withCodexEnvironmentRuntimeLock<T>(
     backend: AppServerBackendKind,
     threadId: string,
     task: () => Promise<T>,
   ): Promise<T> {
-    const key = `${backend}:${threadId}`;
-    const previous = this.codexEnvironmentRuntimeLocks.get(key) ?? Promise.resolve();
-    // Chain regardless of whether the previous task settled with success
-    // or failure — a single failed Run shouldn't poison the chain for
-    // subsequent Runs / exit handlers.
-    const next = previous.then(task, task);
-    // Track the swallowed-error form so future chains never reject when
-    // awaiting the previous link.
-    const tracked = next.then(
-      () => undefined,
-      () => undefined,
+    return this.codexEnvironmentRuntimeLocks.run(
+      `${backend}:${threadId}`,
+      task,
     );
-    this.codexEnvironmentRuntimeLocks.set(key, tracked);
-    try {
-      return await next;
-    } finally {
-      // Lazy cleanup: only drop the map entry if no later task got
-      // chained on this same slot while we were running.
-      if (this.codexEnvironmentRuntimeLocks.get(key) === tracked) {
-        this.codexEnvironmentRuntimeLocks.delete(key);
-      }
-    }
   }
 
   /**

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -3774,12 +3774,16 @@ export class DesktopBackendRegistry {
 
   private async refreshCodexEnvironmentRuntimeActions(
     runtime: CodexThreadEnvironmentRuntime,
-    actionId: string,
+    _actionId: string,
   ): Promise<CodexThreadEnvironmentRuntime> {
-    if (runtime.actions?.some((action) => action.id === actionId)) {
-      return runtime;
-    }
-
+    // Always reload action data from disk before running. The cached
+    // runtime.actions was populated when the env was first selected
+    // (materializeDirectoryLaunchpad or setCodexThreadEnvironment);
+    // env.toml edits made afterwards — adding `nvm use --silent`,
+    // `corepack enable`, or otherwise expanding a single-line command
+    // into a multi-line script — wouldn't propagate to subsequent
+    // runs without this reload. Disk read + TOML parse is fast (single
+    // file per environment); correctness wins over a micro-cache.
     const cwd = runtime.cwd?.trim();
     if (!cwd) {
       return runtime;

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -125,6 +125,7 @@ import {
   CodexEnvironmentStartupError,
   startLocalCodexEnvironmentAction,
   type CodexEnvironmentCommandRunner,
+  type CodexEnvironmentDetachedExit,
   type CodexEnvironmentSelection,
 } from "./codex-environment-runtime";
 import type { MessagingStoreLike } from "../state/messaging-store-sqlite";
@@ -3569,6 +3570,14 @@ export class DesktopBackendRegistry {
         commandRunner: this.codexEnvironmentCommandRunner,
         env: this.codexEnvironmentCommandEnv,
         runtime: runtimeForAction,
+        onDetachedExit: (event) => {
+          void this.handleCodexEnvironmentActionDetachedExit({
+            backend: request.backend,
+            threadId: request.threadId,
+            actionId: request.actionId,
+            event,
+          });
+        },
       });
     } catch (error) {
       if (
@@ -3719,6 +3728,68 @@ export class DesktopBackendRegistry {
     });
   }
 
+  /**
+   * Called when a detached env-action child (e.g., `pnpm dev` for the
+   * PwrSnap run button) eventually exits. Updates overlay state so the
+   * renderer's anchored env-action output UI shows exit code + output,
+   * and emits `thread/codexEnvironment/updated` so the UI refreshes.
+   *
+   * The current overlay runtime is the source of truth — we only patch
+   * the exit-related fields if the recorded action matches (so a stale
+   * exit from a prior run doesn't overwrite a freshly-started one).
+   */
+  private async handleCodexEnvironmentActionDetachedExit(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    actionId: string;
+    event: CodexEnvironmentDetachedExit;
+  }): Promise<void> {
+    try {
+      const overlay = await this.overlayStore.getThreadOverlayState({
+        backend: params.backend,
+        threadId: params.threadId,
+      });
+      const current = overlay?.codexEnvironmentRuntime;
+      if (!current) {
+        return;
+      }
+      if (current.actionId && current.actionId !== params.actionId) {
+        // A different action has since been started; don't clobber.
+        return;
+      }
+      const exitedSuccessfully =
+        params.event.exitCode === 0 && !params.event.exitSignal;
+      const next: CodexThreadEnvironmentRuntime = {
+        ...current,
+        actionStatus: exitedSuccessfully ? "exited" : "failed",
+        actionExitCode:
+          params.event.exitCode === null ? undefined : params.event.exitCode,
+        actionExitSignal: params.event.exitSignal ?? undefined,
+        actionDurationMs: params.event.durationMs,
+        actionExitedAt: Date.now(),
+        actionOutput: params.event.output,
+      };
+      await this.overlayStore.setThreadCodexEnvironmentRuntime?.({
+        backend: params.backend,
+        threadId: params.threadId,
+        codexEnvironmentRuntime: next,
+      });
+      this.invalidateThreadListCache(params.backend);
+      await this.emitCodexEnvironmentRuntimeUpdated({
+        backend: params.backend,
+        threadId: params.threadId,
+        codexEnvironmentRuntime: next,
+      });
+    } catch (error) {
+      backendRegistryLog.warn("codex-environment-action-exit-overlay-update-failed", {
+        backend: params.backend,
+        threadId: params.threadId,
+        actionId: params.actionId,
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
   async materializeDirectoryLaunchpad(
     request: MaterializeDirectoryLaunchpadRequest,
     options?: {
@@ -3763,6 +3834,24 @@ export class DesktopBackendRegistry {
     let codexEnvironmentStartupFailure:
       | MaterializeDirectoryLaunchpadResponse["codexEnvironmentStartupFailure"]
       | undefined;
+    // The detached env-action child can exit asynchronously after we've
+    // already returned to the caller. Queue any early exits until the
+    // thread is started so we can attribute them to the right thread.
+    let pendingActionThreadId: string | undefined;
+    const queuedActionDetachedExits: CodexEnvironmentDetachedExit[] = [];
+    const codexActionBackend: AppServerBackendKind = launchpad.backend;
+    const onActionDetachedExit = (event: CodexEnvironmentDetachedExit) => {
+      if (pendingActionThreadId && codexEnvironmentSelection?.action?.id) {
+        void this.handleCodexEnvironmentActionDetachedExit({
+          backend: codexActionBackend,
+          threadId: pendingActionThreadId,
+          actionId: codexEnvironmentSelection.action.id,
+          event,
+        });
+        return;
+      }
+      queuedActionDetachedExits.push(event);
+    };
     if (launchpad.backend === "codex") {
       try {
         codexEnvironmentRuntime = await applyLocalCodexEnvironmentSelection({
@@ -3777,6 +3866,7 @@ export class DesktopBackendRegistry {
                 });
               }
             : undefined,
+          onActionDetachedExit,
           selection: codexEnvironmentSelection,
         });
       } catch (error) {
@@ -3802,6 +3892,22 @@ export class DesktopBackendRegistry {
       fastMode: launchpad.backend === "codex" ? launchpad.fastMode : undefined,
       codexEnvironmentRuntime,
     });
+    pendingActionThreadId = startThreadResponse.threadId;
+    if (
+      codexEnvironmentSelection?.action?.id &&
+      queuedActionDetachedExits.length > 0
+    ) {
+      const actionId = codexEnvironmentSelection.action.id;
+      for (const event of queuedActionDetachedExits) {
+        void this.handleCodexEnvironmentActionDetachedExit({
+          backend: codexActionBackend,
+          threadId: startThreadResponse.threadId,
+          actionId,
+          event,
+        });
+      }
+      queuedActionDetachedExits.length = 0;
+    }
     if (workspace.workMode === "worktree") {
       await this.recordCodexWorktreeOwnerThread({
         backend: launchpad.backend,

--- a/apps/desktop/src/main/app-server/codex-environment-runtime.ts
+++ b/apps/desktop/src/main/app-server/codex-environment-runtime.ts
@@ -32,7 +32,7 @@ function truncateForLog(value: string | undefined): string | undefined {
  * output is still preserved on `CodexEnvironmentCommandError.output` for
  * the dialog's collapsible details — this is just the headline.
  */
-function buildExitErrorSuffix(stdout: string, stderr: string): string {
+export function buildExitErrorSuffix(stdout: string, stderr: string): string {
   const combined = [stdout.trimEnd(), stderr.trimEnd()]
     .filter(Boolean)
     .join("\n");
@@ -479,10 +479,31 @@ function runShellCommand(
 
     if (params.mode === "detach") {
       child.once("spawn", () => {
-        // child.unref() lets the parent exit independently of the child.
-        // Pipes stay attached so we keep getting stdout/stderr until child
-        // exits (or until we close them when shutting down).
+        // Let the parent exit independently of this child. child.unref()
+        // alone doesn't suffice when stdio is "pipe": the libuv pipe
+        // handles on child.stdout/stderr also keep the parent's event
+        // loop alive, so unref those too.
+        //
+        // KNOWN CAVEAT — SIGPIPE on parent exit. With pipes attached, if
+        // the parent process exits while a long-survival detached child
+        // (e.g. `pnpm dev`) is still writing to stdout/stderr, the child's
+        // next write hits a closed pipe and the kernel delivers SIGPIPE,
+        // which typically kills the child. Most users don't notice
+        // because env-action commands are short-lived, but a "restart
+        // PwrAgent while my dev server is running" scenario can lose the
+        // dev server.
+        //
+        // The proper fix is to write detached output to a temp file
+        // (so the child doesn't depend on the parent for stdio) and tail
+        // that file for the anchored UI. Deferred — see the env-action
+        // anchor follow-ups in the original review.
         child.unref();
+        // child.stdout / child.stderr are typed as `Readable` but at
+        // runtime they're socket-backed pipes that expose .unref(). The
+        // cast keeps the call safe-typed and defensive against future
+        // Node versions where the type might tighten.
+        (child.stdout as { unref?: () => void } | null)?.unref?.();
+        (child.stderr as { unref?: () => void } | null)?.unref?.();
         settle(() => {
           resolve({ pid: child.pid });
         });

--- a/apps/desktop/src/main/app-server/codex-environment-runtime.ts
+++ b/apps/desktop/src/main/app-server/codex-environment-runtime.ts
@@ -8,12 +8,41 @@ import { getMainLogger } from "../log";
 const environmentRuntimeLog = getMainLogger("pwragent:codex-environment-runtime");
 
 const MAX_OUTPUT_PREVIEW_CHARS = 4_000;
+const EXIT_ERROR_SUFFIX_LINES = 8;
 
 function truncateForLog(value: string | undefined): string | undefined {
   if (!value) return value;
   const trimmed = value.trim();
   if (trimmed.length <= MAX_OUTPUT_PREVIEW_CHARS) return trimmed;
   return `${trimmed.slice(0, MAX_OUTPUT_PREVIEW_CHARS)}…[truncated ${trimmed.length - MAX_OUTPUT_PREVIEW_CHARS} chars]`;
+}
+
+/**
+ * Build the suffix attached to `Codex environment command exited with N`.
+ *
+ * Modern CLIs (pnpm, vite, npm, corepack) commonly print fatal errors on
+ * stdout, not stderr — so the previous "stderr.trim() only" suffix would
+ * misleadingly headline an exit failure with whatever stale chatter the
+ * earlier command in a multi-line setup script happened to leave in the
+ * stderr buffer (e.g. nvm's "v24.14.1 is already installed" trailing a
+ * pnpm install that exited 1 with ERR_PNPM_IGNORED_BUILDS on stdout).
+ *
+ * The fix: include the tail of the combined stdout+stderr buffer, the way
+ * a user running the script in a terminal would have seen it. The full
+ * output is still preserved on `CodexEnvironmentCommandError.output` for
+ * the dialog's collapsible details — this is just the headline.
+ */
+function buildExitErrorSuffix(stdout: string, stderr: string): string {
+  const combined = [stdout.trimEnd(), stderr.trimEnd()]
+    .filter(Boolean)
+    .join("\n");
+  if (!combined) return "";
+  const lines = combined.split("\n");
+  const tail =
+    lines.length <= EXIT_ERROR_SUFFIX_LINES
+      ? combined
+      : lines.slice(-EXIT_ERROR_SUFFIX_LINES).join("\n");
+  return `: ${tail}`;
 }
 
 export const DEFAULT_CODEX_ENVIRONMENT_SETUP_TIMEOUT_MS = 10 * 60 * 1_000;
@@ -570,7 +599,7 @@ function runShellCommand(
         cwd: params.cwd,
         output: truncateForLog(combinedOutput),
       });
-      const suffix = stderr.trim() ? `: ${stderr.trim()}` : "";
+      const suffix = buildExitErrorSuffix(stdout, stderr);
       settle(() => {
         reject(
           new CodexEnvironmentCommandError(

--- a/apps/desktop/src/main/app-server/codex-environment-runtime.ts
+++ b/apps/desktop/src/main/app-server/codex-environment-runtime.ts
@@ -7,6 +7,15 @@ import { getMainLogger } from "../log";
 
 const environmentRuntimeLog = getMainLogger("pwragent:codex-environment-runtime");
 
+const MAX_OUTPUT_PREVIEW_CHARS = 4_000;
+
+function truncateForLog(value: string | undefined): string | undefined {
+  if (!value) return value;
+  const trimmed = value.trim();
+  if (trimmed.length <= MAX_OUTPUT_PREVIEW_CHARS) return trimmed;
+  return `${trimmed.slice(0, MAX_OUTPUT_PREVIEW_CHARS)}…[truncated ${trimmed.length - MAX_OUTPUT_PREVIEW_CHARS} chars]`;
+}
+
 export const DEFAULT_CODEX_ENVIRONMENT_SETUP_TIMEOUT_MS = 10 * 60 * 1_000;
 export const CODEX_ENVIRONMENT_SETUP_TIMEOUT_MS_ENV =
   "PWRAGENT_CODEX_ENVIRONMENT_SETUP_TIMEOUT_MS";
@@ -61,6 +70,20 @@ export type CodexEnvironmentCommandParams = {
   onProgress?: (
     event: Pick<CodexEnvironmentSetupProgressEvent, "phase" | "chunk" | "at">,
   ) => void;
+  /**
+   * For detach mode only: fired when the detached child eventually exits.
+   * Lets callers update overlay state with the final exit code / output
+   * for the anchored env-action output UI without blocking the initial
+   * resolve(). Not invoked for wait mode (use the resolved value instead).
+   */
+  onDetachedExit?: (event: CodexEnvironmentDetachedExit) => void;
+};
+
+export type CodexEnvironmentDetachedExit = {
+  exitCode: number | null;
+  exitSignal: NodeJS.Signals | null;
+  durationMs: number;
+  output: string;
 };
 
 export type CodexEnvironmentCommandResult = {
@@ -81,6 +104,7 @@ export async function applyLocalCodexEnvironmentSelection(params: {
   onSetupProgress?: (
     event: Omit<CodexEnvironmentSetupProgressEvent, "directoryKey">,
   ) => void;
+  onActionDetachedExit?: (event: CodexEnvironmentDetachedExit) => void;
   selection?: CodexEnvironmentSelection;
   setupTimeoutMs?: number;
 }): Promise<CodexThreadEnvironmentRuntime | undefined> {
@@ -172,6 +196,16 @@ export async function applyLocalCodexEnvironmentSelection(params: {
       } else {
         runtime.setupOutput = String(error);
       }
+      environmentRuntimeLog.error("codex-environment-setup-failed", {
+        environmentId: selection.environment.id,
+        environmentName: selection.environment.name,
+        cwd,
+        command: selection.environment.setupScript,
+        exitCode: runtime.setupExitCode,
+        durationMs: runtime.setupDurationMs,
+        message: error instanceof Error ? error.message : String(error),
+        output: truncateForLog(runtime.setupOutput),
+      });
       emitSetupProgress({
         phase: "failed",
         error: error instanceof Error ? error.message : String(error),
@@ -200,11 +234,23 @@ export async function applyLocalCodexEnvironmentSelection(params: {
         command: selection.action.command,
         env: params.env,
         mode: "detach",
+        onDetachedExit: params.onActionDetachedExit,
       });
       runtime.actionPid = result.pid;
       runtime.actionStatus = "started";
+      runtime.actionStartedAt = Date.now();
     } catch (error) {
       runtime.actionStatus = "failed";
+      environmentRuntimeLog.error("codex-environment-action-failed", {
+        environmentId: selection.environment.id,
+        environmentName: selection.environment.name,
+        actionId: selection.action.id,
+        actionName: selection.action.name,
+        cwd,
+        command: selection.action.command,
+        phase: "during-setup",
+        message: error instanceof Error ? error.message : String(error),
+      });
       throw new CodexEnvironmentStartupError(
         error instanceof Error ? error.message : String(error),
         "action",
@@ -220,6 +266,7 @@ export async function startLocalCodexEnvironmentAction(params: {
   actionId: string;
   commandRunner?: CodexEnvironmentCommandRunner;
   env?: NodeJS.ProcessEnv;
+  onDetachedExit?: (event: CodexEnvironmentDetachedExit) => void;
   runtime: CodexThreadEnvironmentRuntime;
 }): Promise<CodexThreadEnvironmentRuntime> {
   if (params.runtime.executionTarget !== "local") {
@@ -238,6 +285,13 @@ export async function startLocalCodexEnvironmentAction(params: {
     actionId: action.id,
     actionName: action.name,
     actionCommand: action.command,
+    // Clear stale exit fields from a prior run of this (or another) action
+    // so the renderer doesn't display old output while the new run starts.
+    actionExitedAt: undefined,
+    actionExitCode: undefined,
+    actionExitSignal: undefined,
+    actionDurationMs: undefined,
+    actionOutput: undefined,
   };
 
   try {
@@ -246,11 +300,23 @@ export async function startLocalCodexEnvironmentAction(params: {
       command: action.command,
       env: params.env,
       mode: "detach",
+      onDetachedExit: params.onDetachedExit,
     });
     nextRuntime.actionPid = result.pid;
     nextRuntime.actionStatus = "started";
+    nextRuntime.actionStartedAt = Date.now();
   } catch (error) {
     nextRuntime.actionStatus = "failed";
+    environmentRuntimeLog.error("codex-environment-action-failed", {
+      environmentId: params.runtime.environmentId,
+      environmentName: params.runtime.environmentName,
+      actionId: action.id,
+      actionName: action.name,
+      cwd: params.runtime.cwd,
+      command: action.command,
+      phase: "run-button",
+      message: error instanceof Error ? error.message : String(error),
+    });
     throw new CodexEnvironmentStartupError(
       error instanceof Error ? error.message : String(error),
       "action",
@@ -273,6 +339,8 @@ function runShellCommand(
     cwd: params.cwd,
     mode: params.mode,
     command: params.command,
+    shell,
+    pathPreview: truncateForLog(commandEnv.PATH),
   });
 
   return new Promise((resolve, reject) => {
@@ -280,7 +348,11 @@ function runShellCommand(
       cwd: params.cwd,
       detached: params.mode === "detach" || Boolean(params.timeoutMs),
       env: commandEnv,
-      stdio: params.mode === "detach" ? "ignore" : "pipe",
+      // Pipe output even in detach mode so we can drain to a ring buffer,
+      // stream to the renderer's anchored output UI, and log non-zero exits.
+      // Caller still resolves on spawn for detach mode; we keep listening so
+      // long-running children (e.g., `pnpm dev`) report failures.
+      stdio: "pipe",
     });
 
     let stdout = "";
@@ -329,8 +401,10 @@ function runShellCommand(
     if (params.mode === "wait" && params.timeoutMs && params.timeoutMs > 0) {
       timeoutHandle = setTimeout(() => {
         const durationMs = Date.now() - startedAt;
-        environmentRuntimeLog.warn("codex-environment-command-timeout", {
+        environmentRuntimeLog.error("codex-environment-command-timeout", {
           processId,
+          cwd: params.cwd,
+          command: params.command,
           timeoutMs: params.timeoutMs,
           durationMs,
         });
@@ -376,10 +450,62 @@ function runShellCommand(
 
     if (params.mode === "detach") {
       child.once("spawn", () => {
+        // child.unref() lets the parent exit independently of the child.
+        // Pipes stay attached so we keep getting stdout/stderr until child
+        // exits (or until we close them when shutting down).
         child.unref();
         settle(() => {
           resolve({ pid: child.pid });
         });
+      });
+      // Even in detach mode, log non-zero exits so failed `pnpm dev` /
+      // PwrSnap-style launches don't disappear silently, and fire
+      // onDetachedExit so callers can persist the exit details to
+      // overlay state for the anchored env-action output UI.
+      child.once("close", (code, signal) => {
+        const durationMs = Date.now() - startedAt;
+        const combinedOutput = [stdout.trimEnd(), stderr.trimEnd()]
+          .filter(Boolean)
+          .join("\n");
+        if (code === 0) {
+          environmentRuntimeLog.info("codex-environment-detached-exit", {
+            processId,
+            code,
+            signal,
+            durationMs,
+            command: params.command,
+            cwd: params.cwd,
+          });
+        } else {
+          environmentRuntimeLog.error("codex-environment-detached-failed", {
+            processId,
+            code,
+            signal,
+            durationMs,
+            command: params.command,
+            cwd: params.cwd,
+            output: truncateForLog(combinedOutput),
+          });
+        }
+        try {
+          params.onDetachedExit?.({
+            exitCode: typeof code === "number" ? code : null,
+            exitSignal: signal ?? null,
+            durationMs,
+            output: combinedOutput,
+          });
+        } catch (callbackError) {
+          environmentRuntimeLog.warn(
+            "codex-environment-detached-exit-callback-failed",
+            {
+              processId,
+              message:
+                callbackError instanceof Error
+                  ? callbackError.message
+                  : String(callbackError),
+            },
+          );
+        }
       });
       return;
     }
@@ -390,21 +516,28 @@ function runShellCommand(
         clearTimeout(killHandle);
         killHandle = undefined;
       }
-      environmentRuntimeLog.info("codex-environment-command-exit", {
-        processId,
-        code,
-        signal,
-      });
+      const durationMs = Date.now() - startedAt;
+      const combinedOutput = [stdout.trimEnd(), stderr.trimEnd()]
+        .filter(Boolean)
+        .join("\n");
       if (timedOut) {
+        environmentRuntimeLog.error("codex-environment-command-exit", {
+          processId,
+          code,
+          signal,
+          durationMs,
+          timedOut: true,
+          command: params.command,
+          cwd: params.cwd,
+          output: truncateForLog(combinedOutput),
+        });
         settle(() => {
           reject(
             new CodexEnvironmentCommandError(
               `Codex environment command timed out after ${params.timeoutMs}ms`,
               {
-                durationMs: Date.now() - startedAt,
-                output: [stdout.trimEnd(), stderr.trimEnd()]
-                  .filter(Boolean)
-                  .join("\n"),
+                durationMs,
+                output: combinedOutput,
               },
             ),
           );
@@ -412,25 +545,40 @@ function runShellCommand(
         return;
       }
       if (code === 0) {
+        environmentRuntimeLog.info("codex-environment-command-exit", {
+          processId,
+          code,
+          signal,
+          durationMs,
+        });
         settle(() => {
           resolve({
-            durationMs: Date.now() - startedAt,
+            durationMs,
             exitCode: code,
-            output: [stdout.trimEnd(), stderr.trimEnd()].filter(Boolean).join("\n"),
+            output: combinedOutput,
             pid: child.pid,
           });
         });
         return;
       }
+      environmentRuntimeLog.error("codex-environment-command-exit", {
+        processId,
+        code,
+        signal,
+        durationMs,
+        command: params.command,
+        cwd: params.cwd,
+        output: truncateForLog(combinedOutput),
+      });
       const suffix = stderr.trim() ? `: ${stderr.trim()}` : "";
       settle(() => {
         reject(
           new CodexEnvironmentCommandError(
             `Codex environment command exited with ${code ?? signal ?? "unknown"}${suffix}`,
             {
-              durationMs: Date.now() - startedAt,
+              durationMs,
               exitCode: typeof code === "number" ? code : undefined,
-              output: [stdout.trimEnd(), stderr.trimEnd()].filter(Boolean).join("\n"),
+              output: combinedOutput,
             },
           ),
         );

--- a/apps/desktop/src/main/app-server/codex-environment-runtime.ts
+++ b/apps/desktop/src/main/app-server/codex-environment-runtime.ts
@@ -106,6 +106,17 @@ export type CodexEnvironmentCommandParams = {
    * resolve(). Not invoked for wait mode (use the resolved value instead).
    */
   onDetachedExit?: (event: CodexEnvironmentDetachedExit) => void;
+  /**
+   * For detach mode only: fired with a snapshot of the running command's
+   * accumulated stdout+stderr buffers, throttled to at most one call per
+   * `DETACHED_OUTPUT_SNAPSHOT_MS` (default ~500ms) regardless of how
+   * chatty the child is. Lets callers stream live output into the
+   * anchored UI so users can see what a long-running command is doing
+   * before it exits, instead of staring at "(no output yet)" for
+   * minutes. The final pre-exit snapshot is also delivered via
+   * `onDetachedExit.output`, so callers don't need to merge.
+   */
+  onDetachedOutput?: (event: CodexEnvironmentDetachedOutput) => void;
 };
 
 export type CodexEnvironmentDetachedExit = {
@@ -114,6 +125,13 @@ export type CodexEnvironmentDetachedExit = {
   durationMs: number;
   output: string;
 };
+
+export type CodexEnvironmentDetachedOutput = {
+  /** Current combined-stdout+stderr snapshot, capped to runShellCommand's buffers. */
+  output: string;
+};
+
+export const DETACHED_OUTPUT_SNAPSHOT_MS = 500;
 
 export type CodexEnvironmentCommandResult = {
   durationMs?: number;
@@ -134,6 +152,7 @@ export async function applyLocalCodexEnvironmentSelection(params: {
     event: Omit<CodexEnvironmentSetupProgressEvent, "directoryKey">,
   ) => void;
   onActionDetachedExit?: (event: CodexEnvironmentDetachedExit) => void;
+  onActionDetachedOutput?: (event: CodexEnvironmentDetachedOutput) => void;
   selection?: CodexEnvironmentSelection;
   setupTimeoutMs?: number;
 }): Promise<CodexThreadEnvironmentRuntime | undefined> {
@@ -264,6 +283,7 @@ export async function applyLocalCodexEnvironmentSelection(params: {
         env: params.env,
         mode: "detach",
         onDetachedExit: params.onActionDetachedExit,
+        onDetachedOutput: params.onActionDetachedOutput,
       });
       runtime.actionPid = result.pid;
       runtime.actionStatus = "started";
@@ -296,6 +316,7 @@ export async function startLocalCodexEnvironmentAction(params: {
   commandRunner?: CodexEnvironmentCommandRunner;
   env?: NodeJS.ProcessEnv;
   onDetachedExit?: (event: CodexEnvironmentDetachedExit) => void;
+  onDetachedOutput?: (event: CodexEnvironmentDetachedOutput) => void;
   runtime: CodexThreadEnvironmentRuntime;
 }): Promise<CodexThreadEnvironmentRuntime> {
   if (params.runtime.executionTarget !== "local") {
@@ -330,6 +351,7 @@ export async function startLocalCodexEnvironmentAction(params: {
       env: params.env,
       mode: "detach",
       onDetachedExit: params.onDetachedExit,
+      onDetachedOutput: params.onDetachedOutput,
     });
     nextRuntime.actionPid = result.pid;
     nextRuntime.actionStatus = "started";
@@ -448,6 +470,36 @@ function runShellCommand(
       }, params.timeoutMs);
     }
 
+    // Throttled snapshot for detach-mode live output streaming. Coalesces
+    // bursts of data events into at most one onDetachedOutput call per
+    // DETACHED_OUTPUT_SNAPSHOT_MS, regardless of how chatty the child is.
+    let snapshotTimer: NodeJS.Timeout | undefined;
+    const scheduleDetachedOutputSnapshot = () => {
+      if (params.mode !== "detach" || !params.onDetachedOutput || snapshotTimer) {
+        return;
+      }
+      snapshotTimer = setTimeout(() => {
+        snapshotTimer = undefined;
+        const snapshotOutput = [stdout.trimEnd(), stderr.trimEnd()]
+          .filter(Boolean)
+          .join("\n");
+        try {
+          params.onDetachedOutput?.({ output: snapshotOutput });
+        } catch (callbackError) {
+          environmentRuntimeLog.warn(
+            "codex-environment-detached-output-callback-failed",
+            {
+              processId,
+              message:
+                callbackError instanceof Error
+                  ? callbackError.message
+                  : String(callbackError),
+            },
+          );
+        }
+      }, DETACHED_OUTPUT_SNAPSHOT_MS);
+    };
+
     child.stdout?.on("data", (chunk: Buffer) => {
       const text = chunk.toString("utf8");
       stdout = `${stdout}${text}`.slice(-32_000);
@@ -456,6 +508,7 @@ function runShellCommand(
         chunk: text,
         at: Date.now(),
       });
+      scheduleDetachedOutputSnapshot();
     });
     child.stderr?.on("data", (chunk: Buffer) => {
       const text = chunk.toString("utf8");
@@ -465,6 +518,7 @@ function runShellCommand(
         chunk: text,
         at: Date.now(),
       });
+      scheduleDetachedOutputSnapshot();
     });
 
     child.once("error", (error) => {
@@ -513,6 +567,12 @@ function runShellCommand(
       // onDetachedExit so callers can persist the exit details to
       // overlay state for the anchored env-action output UI.
       child.once("close", (code, signal) => {
+        // Cancel any pending throttled snapshot so it doesn't race past
+        // onDetachedExit's final-output write to the overlay.
+        if (snapshotTimer) {
+          clearTimeout(snapshotTimer);
+          snapshotTimer = undefined;
+        }
         const durationMs = Date.now() - startedAt;
         const combinedOutput = [stdout.trimEnd(), stderr.trimEnd()]
           .filter(Boolean)

--- a/apps/desktop/src/main/app-server/codex-environment-runtime.ts
+++ b/apps/desktop/src/main/app-server/codex-environment-runtime.ts
@@ -1,8 +1,15 @@
 import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import type { CodexEnvironmentSetupProgressEvent } from "@pwragent/shared";
-import type { CodexThreadEnvironmentRuntime } from "@pwragent/shared";
-import type { CodexEnvironmentOption } from "@pwragent/shared";
+import type {
+  CodexEnvironmentActionRun,
+  CodexEnvironmentOption,
+  CodexEnvironmentSetupProgressEvent,
+  CodexThreadEnvironmentRuntime,
+} from "@pwragent/shared";
+import {
+  applyCodexEnvironmentActionRunUpdate,
+  readCodexEnvironmentActionRuns,
+} from "@pwragent/shared";
 import { getMainLogger } from "../log";
 
 const environmentRuntimeLog = getMainLogger("pwragent:codex-environment-runtime");
@@ -153,6 +160,8 @@ export async function applyLocalCodexEnvironmentSelection(params: {
   ) => void;
   onActionDetachedExit?: (event: CodexEnvironmentDetachedExit) => void;
   onActionDetachedOutput?: (event: CodexEnvironmentDetachedOutput) => void;
+  /** Optional caller-generated runId for the auto-action; falls back to a fresh UUID. */
+  actionRunId?: string;
   selection?: CodexEnvironmentSelection;
   setupTimeoutMs?: number;
 }): Promise<CodexThreadEnvironmentRuntime | undefined> {
@@ -273,9 +282,16 @@ export async function applyLocalCodexEnvironmentSelection(params: {
   }
 
   if (selection.action) {
-    runtime.actionId = selection.action.id;
-    runtime.actionName = selection.action.name;
-    runtime.actionCommand = selection.action.command;
+    const runId = params.actionRunId ?? randomUUID();
+    const startedAt = Date.now();
+    const run: CodexEnvironmentActionRun = {
+      runId,
+      actionId: selection.action.id,
+      actionName: selection.action.name,
+      command: selection.action.command,
+      status: "started",
+      startedAt,
+    };
     try {
       const result = await (params.commandRunner ?? runShellCommand)({
         cwd,
@@ -285,11 +301,18 @@ export async function applyLocalCodexEnvironmentSelection(params: {
         onDetachedExit: params.onActionDetachedExit,
         onDetachedOutput: params.onActionDetachedOutput,
       });
-      runtime.actionPid = result.pid;
-      runtime.actionStatus = "started";
-      runtime.actionStartedAt = Date.now();
+      run.pid = result.pid;
+      runtime.actionRuns = applyCodexEnvironmentActionRunUpdate(
+        readCodexEnvironmentActionRuns(runtime),
+        { kind: "append", run },
+      );
     } catch (error) {
-      runtime.actionStatus = "failed";
+      run.status = "failed";
+      run.exitedAt = Date.now();
+      runtime.actionRuns = applyCodexEnvironmentActionRunUpdate(
+        readCodexEnvironmentActionRuns(runtime),
+        { kind: "append", run },
+      );
       environmentRuntimeLog.error("codex-environment-action-failed", {
         environmentId: selection.environment.id,
         environmentName: selection.environment.name,
@@ -298,6 +321,7 @@ export async function applyLocalCodexEnvironmentSelection(params: {
         cwd,
         command: selection.action.command,
         phase: "during-setup",
+        runId,
         message: error instanceof Error ? error.message : String(error),
       });
       throw new CodexEnvironmentStartupError(
@@ -313,6 +337,8 @@ export async function applyLocalCodexEnvironmentSelection(params: {
 
 export async function startLocalCodexEnvironmentAction(params: {
   actionId: string;
+  /** Caller-generated runId so output/exit callbacks can be pre-bound to the right run. */
+  runId: string;
   commandRunner?: CodexEnvironmentCommandRunner;
   env?: NodeJS.ProcessEnv;
   onDetachedExit?: (event: CodexEnvironmentDetachedExit) => void;
@@ -330,19 +356,16 @@ export async function startLocalCodexEnvironmentAction(params: {
     throw new Error(`Codex environment action '${params.actionId}' is not available.`);
   }
 
-  const nextRuntime: CodexThreadEnvironmentRuntime = {
-    ...params.runtime,
+  const startedAt = Date.now();
+  const run: CodexEnvironmentActionRun = {
+    runId: params.runId,
     actionId: action.id,
     actionName: action.name,
-    actionCommand: action.command,
-    // Clear stale exit fields from a prior run of this (or another) action
-    // so the renderer doesn't display old output while the new run starts.
-    actionExitedAt: undefined,
-    actionExitCode: undefined,
-    actionExitSignal: undefined,
-    actionDurationMs: undefined,
-    actionOutput: undefined,
+    command: action.command,
+    status: "started",
+    startedAt,
   };
+  const existingRuns = readCodexEnvironmentActionRuns(params.runtime);
 
   try {
     const result = await (params.commandRunner ?? runShellCommand)({
@@ -353,11 +376,24 @@ export async function startLocalCodexEnvironmentAction(params: {
       onDetachedExit: params.onDetachedExit,
       onDetachedOutput: params.onDetachedOutput,
     });
-    nextRuntime.actionPid = result.pid;
-    nextRuntime.actionStatus = "started";
-    nextRuntime.actionStartedAt = Date.now();
+    run.pid = result.pid;
+    return {
+      ...params.runtime,
+      actionRuns: applyCodexEnvironmentActionRunUpdate(existingRuns, {
+        kind: "append",
+        run,
+      }),
+    };
   } catch (error) {
-    nextRuntime.actionStatus = "failed";
+    run.status = "failed";
+    run.exitedAt = Date.now();
+    const nextRuntime: CodexThreadEnvironmentRuntime = {
+      ...params.runtime,
+      actionRuns: applyCodexEnvironmentActionRunUpdate(existingRuns, {
+        kind: "append",
+        run,
+      }),
+    };
     environmentRuntimeLog.error("codex-environment-action-failed", {
       environmentId: params.runtime.environmentId,
       environmentName: params.runtime.environmentName,
@@ -366,6 +402,7 @@ export async function startLocalCodexEnvironmentAction(params: {
       cwd: params.runtime.cwd,
       command: action.command,
       phase: "run-button",
+      runId: params.runId,
       message: error instanceof Error ? error.message : String(error),
     });
     throw new CodexEnvironmentStartupError(
@@ -374,8 +411,6 @@ export async function startLocalCodexEnvironmentAction(params: {
       nextRuntime,
     );
   }
-
-  return nextRuntime;
 }
 
 function runShellCommand(

--- a/apps/desktop/src/main/shell-environment.ts
+++ b/apps/desktop/src/main/shell-environment.ts
@@ -1,6 +1,9 @@
 import { execFileSync } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
+import { getMainLogger } from "./log";
+
+const shellEnvLog = getMainLogger("pwragent:shell-environment");
 
 type ExecFileSyncLike = (
   file: string,
@@ -42,8 +45,25 @@ export function mergeLoginShellEnvIntoEnv(
         platform,
       });
   if (!shellEnv || Object.keys(shellEnv).length === 0) {
+    // Silent hydration failure is a likely root cause when env-setup
+    // commands work from a terminal-launched dev build but fail from a
+    // Finder-launched bundle. Log enough to diagnose without leaking
+    // sensitive env values.
+    shellEnvLog.warn("login-shell-env-merge-empty", {
+      platform,
+      shellCandidates: defaultShellCandidates(env),
+      parentShell: env.SHELL,
+      parentPathLength: env.PATH?.length ?? 0,
+    });
     return env;
   }
+  shellEnvLog.info("login-shell-env-merged", {
+    keys: Object.keys(shellEnv).length,
+    parentPathLength: env.PATH?.length ?? 0,
+    hydratedPathLength: shellEnv.PATH?.length ?? 0,
+    hadNvmDir: Boolean(shellEnv.NVM_DIR),
+    hadHomebrewPrefix: Boolean(shellEnv.HOMEBREW_PREFIX),
+  });
   return {
     ...env,
     ...shellEnv,
@@ -70,6 +90,7 @@ export function resolveInteractiveLoginShellEnv(
     `command printf '${ENV_MARKER_END}\\n'`,
   ].join("; ");
 
+  const failures: Array<{ shell: string; message: string }> = [];
   for (const shell of options.shellCandidates ?? defaultShellCandidates(env)) {
     try {
       const output = exec(shell, ["-ilc", command], {
@@ -82,11 +103,22 @@ export function resolveInteractiveLoginShellEnv(
       if (shellEnv) {
         return shellEnv;
       }
-    } catch {
-      continue;
+      failures.push({ shell, message: "empty-env-output" });
+    } catch (error) {
+      failures.push({
+        shell,
+        message: error instanceof Error ? error.message : String(error),
+      });
     }
   }
 
+  if (failures.length > 0) {
+    shellEnvLog.warn("login-shell-env-resolve-failed", {
+      attempts: failures.length,
+      failures: failures.map((entry) => `${entry.shell}:${entry.message}`).join("; "),
+      timeoutMs: timeout,
+    });
+  }
   return undefined;
 }
 

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -809,6 +809,35 @@ export class SqliteOverlayStore {
     return row ? JSON.parse(row.payload) : undefined;
   }
 
+  /**
+   * Returns every thread overlay whose JSON payload mentions
+   * `codexEnvironmentRuntime`. The substring filter is done in SQL so a
+   * large `threads` table with mostly non-Codex rows doesn't pay the
+   * JSON.parse cost. Used by the startup cleanup pass that normalises
+   * prior-session env-action state.
+   */
+  async listThreadOverlaysWithCodexEnvironmentRuntime(): Promise<
+    ThreadOverlayState[]
+  > {
+    const rows = this.stateDb.raw
+      .prepare(
+        `SELECT payload FROM threads WHERE payload LIKE '%"codexEnvironmentRuntime"%'`,
+      )
+      .all() as Array<{ payload: string }>;
+    const results: ThreadOverlayState[] = [];
+    for (const row of rows) {
+      try {
+        const parsed = JSON.parse(row.payload) as ThreadOverlayState;
+        if (parsed.codexEnvironmentRuntime) {
+          results.push(parsed);
+        }
+      } catch {
+        // Defensive: skip malformed rows rather than abort the whole scan.
+      }
+    }
+    return results;
+  }
+
   private putThread(threadKey: string, state: ThreadOverlayState): void {
     // Queue-only fields are registry-memory state; never persist them.
     // They reset to undefined on app restart by design.
@@ -966,4 +995,5 @@ export type OverlayStoreLike = Pick<
   | "resetDirectoryLaunchpad"
 > & {
   setThreadCodexEnvironmentRuntime?: SqliteOverlayStore["setThreadCodexEnvironmentRuntime"];
+  listThreadOverlaysWithCodexEnvironmentRuntime?: SqliteOverlayStore["listThreadOverlaysWithCodexEnvironmentRuntime"];
 };

--- a/apps/desktop/src/main/util/per-key-async-lock.ts
+++ b/apps/desktop/src/main/util/per-key-async-lock.ts
@@ -1,0 +1,50 @@
+/**
+ * Serialises async operations keyed by an arbitrary string. Each call to
+ * {@link PerKeyAsyncLock.run} chains its `task` after the previous task
+ * registered against the same key; tasks on different keys run in
+ * parallel. This is the right primitive when you have read-modify-write
+ * operations against shared state (e.g. an overlay row) keyed by an
+ * identifier (e.g. a thread id) that need to serialise per-key but
+ * shouldn't block unrelated work.
+ *
+ * Failure semantics: a task that rejects does NOT poison the chain for
+ * subsequent tasks on the same key. The chain is tracked via a
+ * promise that swallows errors so future awaiters never see them; each
+ * caller's `run()` call returns the unfiltered promise so they observe
+ * the rejection themselves.
+ *
+ * Memory: map entries are dropped once the chain settles AND no later
+ * `run()` call has queued on the same key, so a busy-then-quiet key
+ * doesn't grow the map unboundedly.
+ */
+export class PerKeyAsyncLock {
+  private readonly chains = new Map<string, Promise<unknown>>();
+
+  async run<T>(key: string, task: () => Promise<T>): Promise<T> {
+    const previous = this.chains.get(key) ?? Promise.resolve();
+    // Chain regardless of previous settled state — a single failed
+    // task shouldn't poison the chain for subsequent ones.
+    const next = previous.then(task, task);
+    // The map tracks the swallowed-error form so future chains don't
+    // reject when they await the previous link.
+    const tracked = next.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.chains.set(key, tracked);
+    try {
+      return await next;
+    } finally {
+      // Lazy cleanup: only drop the map entry if no later task got
+      // chained on this same slot while we were running.
+      if (this.chains.get(key) === tracked) {
+        this.chains.delete(key);
+      }
+    }
+  }
+
+  /** For tests: how many keys currently have a chained task in flight. */
+  size(): number {
+    return this.chains.size;
+  }
+}

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -479,13 +479,21 @@ function tailLines(text: string, maxLines: number): string {
   ].join("\n");
 }
 
-function formatDurationMs(ms?: number): string {
+// Exported for unit testing; the existing call sites import via the
+// in-file identifier.
+export function formatDurationMs(ms?: number): string {
   if (!ms || !Number.isFinite(ms)) return "";
-  if (ms < 1_000) return `${ms}ms`;
-  const seconds = ms / 1_000;
-  if (seconds < 60) return `${seconds.toFixed(seconds < 10 ? 1 : 0)}s`;
-  const minutes = Math.floor(seconds / 60);
-  const remainder = Math.round(seconds % 60);
+  if (ms < 1_000) return `${Math.round(ms)}ms`;
+  // Always integer seconds — the previous `toFixed(1)` for elapsed < 10s
+  // produced "0.9s" / "1.9s" displays that kept changing the last digit
+  // every render even when the second hadn't actually advanced.
+  const totalSeconds = Math.round(ms / 1_000);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  // Convert via totalSeconds rather than `Math.round(seconds % 60)`,
+  // which would have flipped `seconds=119.5` into `"1m 60s"` because of
+  // half-up rounding at the 60-second boundary.
+  const minutes = Math.floor(totalSeconds / 60);
+  const remainder = totalSeconds % 60;
   return remainder ? `${minutes}m ${remainder}s` : `${minutes}m`;
 }
 

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -511,24 +511,39 @@ function EnvActionAnchorList(props: {
   runtime?: Pick<CodexThreadEnvironmentRuntime, "actionRuns" | "environmentName"> | undefined;
 }): ReactNode {
   const runs = readCodexEnvironmentActionRuns(props.runtime);
-  // Re-render every second while ANY run is started, so the per-run
-  // "running for Xs" meta keeps ticking. Cheaper than one timer per run.
-  // useMemo stabilises the effect dependency so the interval isn't torn
-  // down and re-created on every render (props.runtime is a fresh object
-  // each upstream re-render, so `runs` is a fresh array reference even
-  // when its contents haven't changed).
-  const anyRunning = useMemo(
-    () => runs.some((run) => run.status === "started"),
-    [runs],
-  );
+  // Tiered tick cadence for the per-run "running for Xs" meta. Updating
+  // every second is the right resolution while elapsed is < 1 min; once
+  // we're into "Xm Ys" territory the seconds digit advances on its own
+  // and the user doesn't need the same fidelity:
+  //   < 1 min  → tick every 1s    (seconds digit moves every second)
+  //   < 1 hour → tick every 5s    ("Xm Ys" jumps in 5s increments —
+  //                                still feels live, ~12× less work)
+  //   ≥ 1 hour → tick every 30s   (long-running dev servers shouldn't
+  //                                burn renders to advance "Ys" every
+  //                                second for hours on end)
+  // Single shared timer across all started runs on the thread; the
+  // interval re-arms when the longest-running run crosses a threshold.
+  const tickIntervalMs = useMemo(() => {
+    let maxElapsed = -1;
+    for (const run of runs) {
+      if (run.status !== "started") continue;
+      const startedAt = run.startedAt ?? Date.now();
+      const elapsed = Date.now() - startedAt;
+      if (elapsed > maxElapsed) maxElapsed = elapsed;
+    }
+    if (maxElapsed < 0) return 0; // no running runs → no timer
+    if (maxElapsed < 60_000) return 1_000;
+    if (maxElapsed < 3_600_000) return 5_000;
+    return 30_000;
+  }, [runs]);
   const [, setElapsedTick] = useState(0);
   useEffect(() => {
-    if (!anyRunning) return undefined;
+    if (!tickIntervalMs) return undefined;
     const handle = setInterval(() => {
       setElapsedTick((tick) => tick + 1);
-    }, 1_000);
+    }, tickIntervalMs);
     return () => clearInterval(handle);
-  }, [anyRunning]);
+  }, [tickIntervalMs]);
   // Bumped after dismissal to force a re-render (the dismissed-set lives
   // outside React state).
   const [, setDismissTick] = useState(0);

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -536,8 +536,16 @@ function EnvActionAnchorList(props: {
   const visible = runs.filter((run) => {
     if (dismissedEnvActionAnchorKeys.has(run.runId)) return false;
     const latestActivityAt = Math.max(run.exitedAt ?? 0, run.startedAt ?? 0);
-    if (latestActivityAt > 0 && latestActivityAt < envActionAnchorSessionStartedAt) {
-      // Persisted from a previous session; treat as historical.
+    // Anything not started during this renderer session is treated as
+    // historical / zombie and hidden. Note: the `< envActionAnchorSessionStartedAt`
+    // check catches runs with timestamps that predate this session AND
+    // runs with missing/zero timestamps (legacy overlay rows from before
+    // actionStartedAt existed synthesise startedAt=0 via
+    // readCodexEnvironmentActionRuns). The earlier `latestActivityAt > 0`
+    // guard let those legacy entries slip through, leaving the user with
+    // an undismissable "running" zombie after an app crash — see the
+    // PwrAgent termination repro in PR #505 review.
+    if (latestActivityAt < envActionAnchorSessionStartedAt) {
       return false;
     }
     return true;

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -610,28 +610,56 @@ export function EnvActionAnchorEntry(props: {
         : "composer__queued--env-action-running";
 
   return (
-    <div
+    <details
       className={`composer__queued composer__queued--env-action ${modifier}`}
       aria-label={label}
     >
-      <div className="composer__queued-copy">
-        <span className="composer__queued-label">{label}</span>
-        <span className="composer__queued-text">
-          {run.actionName}
-          {props.environmentName ? ` · ${props.environmentName}` : ""}
-          {meta.length > 0 ? ` · ${meta.join(" · ")}` : ""}
+      <summary className="composer__queued-env-action-summary">
+        <span
+          className="composer__queued-env-action-chevron"
+          aria-hidden="true"
+        />
+        <span className="composer__queued-env-action-summary-text">
+          <span className="composer__queued-label">{label}</span>
+          <span className="composer__queued-text">
+            {run.actionName}
+            {props.environmentName ? ` · ${props.environmentName}` : ""}
+            {meta.length > 0 ? ` · ${meta.join(" · ")}` : ""}
+          </span>
         </span>
+        <button
+          className="composer__secondary-action composer__queued-env-action-dismiss"
+          type="button"
+          onClick={(event) => {
+            // Prevent the click from toggling the surrounding <details>.
+            event.preventDefault();
+            event.stopPropagation();
+            props.onDismiss();
+          }}
+        >
+          Dismiss
+        </button>
+      </summary>
+      <div className="composer__queued-env-action-body">
         {run.command ? (
-          <code className="composer__queued-env-action-command">$ {run.command}</code>
+          <div className="composer__queued-env-action-section">
+            <div className="composer__queued-env-action-section-label">
+              Command
+            </div>
+            <pre className="composer__queued-env-action-command-block">
+              <code>$ {run.command}</code>
+            </pre>
+          </div>
         ) : null}
-        <details className="composer__queued-env-action-details">
-          <summary>
+        <div className="composer__queued-env-action-section">
+          <div className="composer__queued-env-action-section-label">
+            Output
             {truncatedOutput
-              ? `Show output (${truncatedOutput.split("\n").length} line${
+              ? ` · ${truncatedOutput.split("\n").length} line${
                   truncatedOutput.split("\n").length === 1 ? "" : "s"
-                })`
-              : "Show output"}
-          </summary>
+                }`
+              : ""}
+          </div>
           <pre className="composer__queued-env-action-output">
             <code>
               {truncatedOutput ||
@@ -640,20 +668,9 @@ export function EnvActionAnchorEntry(props: {
                   : "(no output captured)")}
             </code>
           </pre>
-        </details>
-      </div>
-      {status !== "started" ? (
-        <div className="composer__queued-actions">
-          <button
-            className="composer__secondary-action"
-            type="button"
-            onClick={props.onDismiss}
-          >
-            Dismiss
-          </button>
         </div>
-      ) : null}
-    </div>
+      </div>
+    </details>
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -604,7 +604,12 @@ function EnvActionAnchor(props: {
               : "Show output"}
           </summary>
           <pre className="composer__queued-env-action-output">
-            <code>{truncatedOutput || "(no output captured)"}</code>
+            <code>
+              {truncatedOutput ||
+                (status === "started"
+                  ? "(no output yet — waiting for the command to print something)"
+                  : "(no output captured)")}
+            </code>
           </pre>
         </details>
       </div>

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -481,7 +481,10 @@ function tailLines(text: string, maxLines: number): string {
 
 // Exported for unit testing; the existing call sites import via the
 // in-file identifier.
-export function formatDurationMs(ms?: number): string {
+export function formatDurationMs(
+  ms?: number,
+  options?: { coarseAfterMinute?: boolean },
+): string {
   if (!ms || !Number.isFinite(ms)) return "";
   if (ms < 1_000) return `${Math.round(ms)}ms`;
   // Always integer seconds — the previous `toFixed(1)` for elapsed < 10s
@@ -493,6 +496,15 @@ export function formatDurationMs(ms?: number): string {
   // which would have flipped `seconds=119.5` into `"1m 60s"` because of
   // half-up rounding at the 60-second boundary.
   const minutes = Math.floor(totalSeconds / 60);
+  // For live counters (e.g., the "running for Xm" anchor meta),
+  // coarseAfterMinute drops the seconds portion entirely past 1m so
+  // the display only changes on minute boundaries — otherwise the
+  // ticking "Xm Ys" with sub-minute updates was a distracting noise
+  // floor for long-running actions like `pnpm dev`. Static one-shot
+  // displays (e.g., "ran 2m 30s" on an already-exited run) leave the
+  // option off and keep full precision since the value never changes
+  // after first paint.
+  if (options?.coarseAfterMinute) return `${minutes}m`;
   const remainder = totalSeconds % 60;
   return remainder ? `${minutes}m ${remainder}s` : `${minutes}m`;
 }
@@ -519,18 +531,19 @@ function EnvActionAnchorList(props: {
   runtime?: Pick<CodexThreadEnvironmentRuntime, "actionRuns" | "environmentName"> | undefined;
 }): ReactNode {
   const runs = readCodexEnvironmentActionRuns(props.runtime);
-  // Tiered tick cadence for the per-run "running for Xs" meta. Updating
-  // every second is the right resolution while elapsed is < 1 min; once
-  // we're into "Xm Ys" territory the seconds digit advances on its own
-  // and the user doesn't need the same fidelity:
-  //   < 1 min  → tick every 1s    (seconds digit moves every second)
-  //   < 1 hour → tick every 5s    ("Xm Ys" jumps in 5s increments —
-  //                                still feels live, ~12× less work)
-  //   ≥ 1 hour → tick every 30s   (long-running dev servers shouldn't
-  //                                burn renders to advance "Ys" every
-  //                                second for hours on end)
+  // Tiered tick cadence for the per-run "running for X" meta:
+  //   < 1 min → tick every 1s   (seconds digit moves every second;
+  //                              format prints "Xs")
+  //   ≥ 1 min → tick every 30s  (display switches to coarse "Xm" with
+  //                              no seconds; we only need the tick to
+  //                              catch each minute boundary within
+  //                              ~30s, which is below user-perceived
+  //                              staleness for a minute-granularity
+  //                              display. Avoids the "distracting
+  //                              every-5s text-change" issue.)
   // Single shared timer across all started runs on the thread; the
-  // interval re-arms when the longest-running run crosses a threshold.
+  // interval re-arms when the longest-running run crosses the 1-min
+  // boundary.
   const tickIntervalMs = useMemo(() => {
     let maxElapsed = -1;
     for (const run of runs) {
@@ -541,7 +554,6 @@ function EnvActionAnchorList(props: {
     }
     if (maxElapsed < 0) return 0; // no running runs → no timer
     if (maxElapsed < 60_000) return 1_000;
-    if (maxElapsed < 3_600_000) return 5_000;
     return 30_000;
   }, [runs]);
   const [, setElapsedTick] = useState(0);
@@ -611,7 +623,9 @@ export function EnvActionAnchorEntry(props: {
   const meta: string[] = [];
   if (run.pid) meta.push(`pid ${run.pid}`);
   if (status === "started" && run.startedAt) {
-    meta.push(`running for ${formatDurationMs(Date.now() - run.startedAt)}`);
+    meta.push(
+      `running for ${formatDurationMs(Date.now() - run.startedAt, { coarseAfterMinute: true })}`,
+    );
   }
   if (status !== "started") {
     if (typeof run.exitCode === "number") {

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -527,7 +527,10 @@ const dismissedEnvActionAnchorKeys = new Set<string>();
  */
 const envActionAnchorSessionStartedAt = Date.now();
 
-function EnvActionAnchorList(props: {
+// Exported solely so the list filter + dismiss machinery can be unit-
+// tested without standing up the full Composer; consumers should still
+// reach the anchor through the Composer.
+export function EnvActionAnchorList(props: {
   runtime?: Pick<CodexThreadEnvironmentRuntime, "actionRuns" | "environmentName"> | undefined;
 }): ReactNode {
   const runs = readCodexEnvironmentActionRuns(props.runtime);

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -513,7 +513,14 @@ function EnvActionAnchorList(props: {
   const runs = readCodexEnvironmentActionRuns(props.runtime);
   // Re-render every second while ANY run is started, so the per-run
   // "running for Xs" meta keeps ticking. Cheaper than one timer per run.
-  const anyRunning = runs.some((run) => run.status === "started");
+  // useMemo stabilises the effect dependency so the interval isn't torn
+  // down and re-created on every render (props.runtime is a fresh object
+  // each upstream re-render, so `runs` is a fresh array reference even
+  // when its contents haven't changed).
+  const anyRunning = useMemo(
+    () => runs.some((run) => run.status === "started"),
+    [runs],
+  );
   const [, setElapsedTick] = useState(0);
   useEffect(() => {
     if (!anyRunning) return undefined;
@@ -554,7 +561,9 @@ function EnvActionAnchorList(props: {
   );
 }
 
-function EnvActionAnchorEntry(props: {
+// Exported solely so the entry can be unit-tested without standing up the
+// full Composer; consumers should still go through EnvActionAnchorList.
+export function EnvActionAnchorEntry(props: {
   run: CodexEnvironmentActionRun;
   environmentName: string | undefined;
   onDismiss: () => void;

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -19,6 +19,7 @@ import type {
   AppServerThreadImagePart,
   AppServerTurnInputItem,
   BackendSummary,
+  CodexThreadEnvironmentRuntime,
   DesktopApplicationDiscoveryCandidate,
   DesktopApplicationsSnapshot,
   DesktopChatReplyComposer,
@@ -486,27 +487,50 @@ function formatDurationMs(ms?: number): string {
   return remainder ? `${minutes}m ${remainder}s` : `${minutes}m`;
 }
 
-type EnvActionAnchorRuntime = {
-  actionName?: string;
-  actionCommand?: string;
-  actionStatus?: "started" | "exited" | "failed";
-  actionPid?: number;
-  actionStartedAt?: number;
-  actionExitedAt?: number;
-  actionExitCode?: number;
-  actionExitSignal?: string;
-  actionDurationMs?: number;
-  actionOutput?: string;
-  environmentName?: string;
-};
+type EnvActionAnchorRuntime = Pick<
+  CodexThreadEnvironmentRuntime,
+  | "actionCommand"
+  | "actionDurationMs"
+  | "actionExitCode"
+  | "actionExitSignal"
+  | "actionExitedAt"
+  | "actionName"
+  | "actionOutput"
+  | "actionPid"
+  | "actionStartedAt"
+  | "actionStatus"
+  | "environmentName"
+>;
+
+/**
+ * Set of run identities the user has explicitly dismissed in this session.
+ * Module-level so it survives Composer remounts (thread switches), but
+ * cleared on page reload — fresh runs always show, since each run gets a
+ * new dismissKey from pid + startedAt + exitedAt.
+ */
+const dismissedEnvActionAnchorKeys = new Set<string>();
 
 function EnvActionAnchor(props: {
   runtime?: EnvActionAnchorRuntime;
 }): ReactNode {
   const runtime = props.runtime;
-  const [dismissedKey, setDismissedKey] = useState<string | undefined>();
-
+  // Re-render version bumped each second while an action is running so the
+  // "running for Xs" elapsed meta keeps ticking — useState(0) on a 1Hz
+  // interval, only when status === "started" so idle/exited anchors don't
+  // burn cycles.
+  const [, setElapsedTick] = useState(0);
   const status = runtime?.actionStatus;
+  useEffect(() => {
+    if (status !== "started") return undefined;
+    const handle = setInterval(() => {
+      setElapsedTick((tick) => tick + 1);
+    }, 1_000);
+    return () => clearInterval(handle);
+  }, [status]);
+  // Force a re-render after dismissal even though the dismissed-set lives
+  // outside React state; bumping any state value will do.
+  const [, setDismissTick] = useState(0);
+
   // Only surface when there's something meaningful to show.
   if (!runtime || (status !== "started" && status !== "exited" && status !== "failed")) {
     return null;
@@ -514,7 +538,7 @@ function EnvActionAnchor(props: {
   const dismissKey = `${runtime.actionPid ?? "?"}:${runtime.actionStartedAt ?? 0}:${
     runtime.actionExitedAt ?? 0
   }`;
-  if (dismissedKey === dismissKey) {
+  if (dismissedEnvActionAnchorKeys.has(dismissKey)) {
     return null;
   }
 
@@ -589,7 +613,10 @@ function EnvActionAnchor(props: {
           <button
             className="composer__secondary-action"
             type="button"
-            onClick={() => setDismissedKey(dismissKey)}
+            onClick={() => {
+              dismissedEnvActionAnchorKeys.add(dismissKey);
+              setDismissTick((tick) => tick + 1);
+            }}
           >
             Dismiss
           </button>

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -510,6 +510,16 @@ type EnvActionAnchorRuntime = Pick<
  */
 const dismissedEnvActionAnchorKeys = new Set<string>();
 
+/**
+ * Approximate moment the renderer started this session. Runtime entries
+ * whose latest activity timestamp predates this are treated as historical
+ * (persisted from a prior app launch) and not surfaced in the anchor —
+ * otherwise the user would have to re-dismiss the same finished run on
+ * every restart. The persisted fields stay on the runtime so logs and
+ * future "show last run" affordances can still inspect them.
+ */
+const envActionAnchorSessionStartedAt = Date.now();
+
 function EnvActionAnchor(props: {
   runtime?: EnvActionAnchorRuntime;
 }): ReactNode {
@@ -533,6 +543,21 @@ function EnvActionAnchor(props: {
 
   // Only surface when there's something meaningful to show.
   if (!runtime || (status !== "started" && status !== "exited" && status !== "failed")) {
+    return null;
+  }
+  // Hide persisted-from-prior-session entries. After app restart, a
+  // runtime with actionStatus "started" is almost certainly a zombie
+  // (parent exited, child died via SIGPIPE on closed stdio), and a
+  // runtime with "exited"/"failed" is a finished run the user has
+  // already seen — no point shouting about it on every launch.
+  const latestActivityAt = Math.max(
+    runtime.actionExitedAt ?? 0,
+    runtime.actionStartedAt ?? 0,
+  );
+  if (
+    latestActivityAt > 0 &&
+    latestActivityAt < envActionAnchorSessionStartedAt
+  ) {
     return null;
   }
   const dismissKey = `${runtime.actionPid ?? "?"}:${runtime.actionStartedAt ?? 0}:${

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -464,6 +464,141 @@ function QueuedImageAttachments(props: {
   );
 }
 
+const ENV_ACTION_OUTPUT_MAX_LINES = 500;
+
+function tailLines(text: string, maxLines: number): string {
+  const lines = text.split("\n");
+  if (lines.length <= maxLines) return text;
+  const dropped = lines.length - maxLines;
+  return [
+    `[…${dropped} earlier lines truncated]`,
+    ...lines.slice(-maxLines),
+  ].join("\n");
+}
+
+function formatDurationMs(ms?: number): string {
+  if (!ms || !Number.isFinite(ms)) return "";
+  if (ms < 1_000) return `${ms}ms`;
+  const seconds = ms / 1_000;
+  if (seconds < 60) return `${seconds.toFixed(seconds < 10 ? 1 : 0)}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remainder = Math.round(seconds % 60);
+  return remainder ? `${minutes}m ${remainder}s` : `${minutes}m`;
+}
+
+type EnvActionAnchorRuntime = {
+  actionName?: string;
+  actionCommand?: string;
+  actionStatus?: "started" | "exited" | "failed";
+  actionPid?: number;
+  actionStartedAt?: number;
+  actionExitedAt?: number;
+  actionExitCode?: number;
+  actionExitSignal?: string;
+  actionDurationMs?: number;
+  actionOutput?: string;
+  environmentName?: string;
+};
+
+function EnvActionAnchor(props: {
+  runtime?: EnvActionAnchorRuntime;
+}): ReactNode {
+  const runtime = props.runtime;
+  const [dismissedKey, setDismissedKey] = useState<string | undefined>();
+
+  const status = runtime?.actionStatus;
+  // Only surface when there's something meaningful to show.
+  if (!runtime || (status !== "started" && status !== "exited" && status !== "failed")) {
+    return null;
+  }
+  const dismissKey = `${runtime.actionPid ?? "?"}:${runtime.actionStartedAt ?? 0}:${
+    runtime.actionExitedAt ?? 0
+  }`;
+  if (dismissedKey === dismissKey) {
+    return null;
+  }
+
+  const label =
+    status === "started"
+      ? "Env action running"
+      : status === "exited"
+        ? "Env action exited"
+        : "Env action failed";
+
+  const meta: string[] = [];
+  if (runtime.actionPid) meta.push(`pid ${runtime.actionPid}`);
+  if (status === "started" && runtime.actionStartedAt) {
+    const elapsed = Date.now() - runtime.actionStartedAt;
+    meta.push(`running for ${formatDurationMs(elapsed)}`);
+  }
+  if (status !== "started") {
+    if (typeof runtime.actionExitCode === "number") {
+      meta.push(`exit ${runtime.actionExitCode}`);
+    } else if (runtime.actionExitSignal) {
+      meta.push(`signal ${runtime.actionExitSignal}`);
+    }
+    if (runtime.actionDurationMs) {
+      meta.push(`ran ${formatDurationMs(runtime.actionDurationMs)}`);
+    }
+  }
+
+  const truncatedOutput = tailLines(
+    (runtime.actionOutput ?? "").trim(),
+    ENV_ACTION_OUTPUT_MAX_LINES,
+  );
+
+  const modifier =
+    status === "failed"
+      ? "composer__queued--env-action-failed"
+      : status === "exited"
+        ? "composer__queued--env-action-exited"
+        : "composer__queued--env-action-running";
+
+  return (
+    <div
+      className={`composer__queued composer__queued--env-action ${modifier}`}
+      aria-label={label}
+    >
+      <div className="composer__queued-copy">
+        <span className="composer__queued-label">{label}</span>
+        <span className="composer__queued-text">
+          {runtime.actionName ?? "Action"}
+          {runtime.environmentName ? ` · ${runtime.environmentName}` : ""}
+          {meta.length > 0 ? ` · ${meta.join(" · ")}` : ""}
+        </span>
+        {runtime.actionCommand ? (
+          <code className="composer__queued-env-action-command">
+            $ {runtime.actionCommand}
+          </code>
+        ) : null}
+        <details className="composer__queued-env-action-details">
+          <summary>
+            {truncatedOutput
+              ? `Show output (${truncatedOutput.split("\n").length} line${
+                  truncatedOutput.split("\n").length === 1 ? "" : "s"
+                })`
+              : "Show output"}
+          </summary>
+          <pre className="composer__queued-env-action-output">
+            <code>{truncatedOutput || "(no output captured)"}</code>
+          </pre>
+        </details>
+      </div>
+      {status !== "started" ? (
+        <div className="composer__queued-actions">
+          <button
+            className="composer__secondary-action"
+            type="button"
+            onClick={() => setDismissedKey(dismissKey)}
+          >
+            Dismiss
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 function collectTextFragments(value: unknown): string[] {
   if (typeof value === "string") {
     return [value];
@@ -3712,6 +3847,8 @@ export function Composer(props: ComposerProps) {
           conveys the action prompt visually. Stacking another header
           above an input that already names itself was redundant
           chrome. */}
+
+      <EnvActionAnchor runtime={props.thread?.codexEnvironmentRuntime} />
 
       {pendingSteer ? (
         <div

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -19,6 +19,7 @@ import type {
   AppServerThreadImagePart,
   AppServerTurnInputItem,
   BackendSummary,
+  CodexEnvironmentActionRun,
   CodexThreadEnvironmentRuntime,
   DesktopApplicationDiscoveryCandidate,
   DesktopApplicationsSnapshot,
@@ -31,6 +32,7 @@ import type {
   ThreadWorkspaceHandoffStrategy,
   ThreadExecutionMode,
 } from "@pwragent/shared";
+import { readCodexEnvironmentActionRuns } from "@pwragent/shared";
 import { EditorIcon, FileCodeIcon, TerminalIcon } from "../../icons";
 import { formatBackendLabel } from "../../lib/backend-label";
 import type { DesktopApi } from "../../lib/desktop-api";
@@ -487,86 +489,78 @@ function formatDurationMs(ms?: number): string {
   return remainder ? `${minutes}m ${remainder}s` : `${minutes}m`;
 }
 
-type EnvActionAnchorRuntime = Pick<
-  CodexThreadEnvironmentRuntime,
-  | "actionCommand"
-  | "actionDurationMs"
-  | "actionExitCode"
-  | "actionExitSignal"
-  | "actionExitedAt"
-  | "actionName"
-  | "actionOutput"
-  | "actionPid"
-  | "actionStartedAt"
-  | "actionStatus"
-  | "environmentName"
->;
-
 /**
  * Set of run identities the user has explicitly dismissed in this session.
  * Module-level so it survives Composer remounts (thread switches), but
  * cleared on page reload — fresh runs always show, since each run gets a
- * new dismissKey from pid + startedAt + exitedAt.
+ * new runId on the server.
  */
 const dismissedEnvActionAnchorKeys = new Set<string>();
 
 /**
- * Approximate moment the renderer started this session. Runtime entries
- * whose latest activity timestamp predates this are treated as historical
- * (persisted from a prior app launch) and not surfaced in the anchor —
- * otherwise the user would have to re-dismiss the same finished run on
- * every restart. The persisted fields stay on the runtime so logs and
- * future "show last run" affordances can still inspect them.
+ * Approximate moment the renderer started this session. Runs whose latest
+ * activity timestamp predates this are treated as historical (persisted
+ * from a prior app launch) and not surfaced — otherwise the user would
+ * have to re-dismiss the same finished run on every restart. The
+ * persisted fields stay on the runtime so logs and a future "show last
+ * run" affordance can still inspect them.
  */
 const envActionAnchorSessionStartedAt = Date.now();
 
-function EnvActionAnchor(props: {
-  runtime?: EnvActionAnchorRuntime;
+function EnvActionAnchorList(props: {
+  runtime?: Pick<CodexThreadEnvironmentRuntime, "actionRuns" | "environmentName"> | undefined;
 }): ReactNode {
-  const runtime = props.runtime;
-  // Re-render version bumped each second while an action is running so the
-  // "running for Xs" elapsed meta keeps ticking — useState(0) on a 1Hz
-  // interval, only when status === "started" so idle/exited anchors don't
-  // burn cycles.
+  const runs = readCodexEnvironmentActionRuns(props.runtime);
+  // Re-render every second while ANY run is started, so the per-run
+  // "running for Xs" meta keeps ticking. Cheaper than one timer per run.
+  const anyRunning = runs.some((run) => run.status === "started");
   const [, setElapsedTick] = useState(0);
-  const status = runtime?.actionStatus;
   useEffect(() => {
-    if (status !== "started") return undefined;
+    if (!anyRunning) return undefined;
     const handle = setInterval(() => {
       setElapsedTick((tick) => tick + 1);
     }, 1_000);
     return () => clearInterval(handle);
-  }, [status]);
-  // Force a re-render after dismissal even though the dismissed-set lives
-  // outside React state; bumping any state value will do.
+  }, [anyRunning]);
+  // Bumped after dismissal to force a re-render (the dismissed-set lives
+  // outside React state).
   const [, setDismissTick] = useState(0);
 
-  // Only surface when there's something meaningful to show.
-  if (!runtime || (status !== "started" && status !== "exited" && status !== "failed")) {
-    return null;
-  }
-  // Hide persisted-from-prior-session entries. After app restart, a
-  // runtime with actionStatus "started" is almost certainly a zombie
-  // (parent exited, child died via SIGPIPE on closed stdio), and a
-  // runtime with "exited"/"failed" is a finished run the user has
-  // already seen — no point shouting about it on every launch.
-  const latestActivityAt = Math.max(
-    runtime.actionExitedAt ?? 0,
-    runtime.actionStartedAt ?? 0,
-  );
-  if (
-    latestActivityAt > 0 &&
-    latestActivityAt < envActionAnchorSessionStartedAt
-  ) {
-    return null;
-  }
-  const dismissKey = `${runtime.actionPid ?? "?"}:${runtime.actionStartedAt ?? 0}:${
-    runtime.actionExitedAt ?? 0
-  }`;
-  if (dismissedEnvActionAnchorKeys.has(dismissKey)) {
-    return null;
-  }
+  const visible = runs.filter((run) => {
+    if (dismissedEnvActionAnchorKeys.has(run.runId)) return false;
+    const latestActivityAt = Math.max(run.exitedAt ?? 0, run.startedAt ?? 0);
+    if (latestActivityAt > 0 && latestActivityAt < envActionAnchorSessionStartedAt) {
+      // Persisted from a previous session; treat as historical.
+      return false;
+    }
+    return true;
+  });
+  if (visible.length === 0) return null;
 
+  return (
+    <>
+      {visible.map((run) => (
+        <EnvActionAnchorEntry
+          key={run.runId}
+          run={run}
+          environmentName={props.runtime?.environmentName}
+          onDismiss={() => {
+            dismissedEnvActionAnchorKeys.add(run.runId);
+            setDismissTick((tick) => tick + 1);
+          }}
+        />
+      ))}
+    </>
+  );
+}
+
+function EnvActionAnchorEntry(props: {
+  run: CodexEnvironmentActionRun;
+  environmentName: string | undefined;
+  onDismiss: () => void;
+}): ReactNode {
+  const { run } = props;
+  const status = run.status;
   const label =
     status === "started"
       ? "Env action running"
@@ -575,27 +569,22 @@ function EnvActionAnchor(props: {
         : "Env action failed";
 
   const meta: string[] = [];
-  if (runtime.actionPid) meta.push(`pid ${runtime.actionPid}`);
-  if (status === "started" && runtime.actionStartedAt) {
-    const elapsed = Date.now() - runtime.actionStartedAt;
-    meta.push(`running for ${formatDurationMs(elapsed)}`);
+  if (run.pid) meta.push(`pid ${run.pid}`);
+  if (status === "started" && run.startedAt) {
+    meta.push(`running for ${formatDurationMs(Date.now() - run.startedAt)}`);
   }
   if (status !== "started") {
-    if (typeof runtime.actionExitCode === "number") {
-      meta.push(`exit ${runtime.actionExitCode}`);
-    } else if (runtime.actionExitSignal) {
-      meta.push(`signal ${runtime.actionExitSignal}`);
+    if (typeof run.exitCode === "number") {
+      meta.push(`exit ${run.exitCode}`);
+    } else if (run.exitSignal) {
+      meta.push(`signal ${run.exitSignal}`);
     }
-    if (runtime.actionDurationMs) {
-      meta.push(`ran ${formatDurationMs(runtime.actionDurationMs)}`);
+    if (run.durationMs) {
+      meta.push(`ran ${formatDurationMs(run.durationMs)}`);
     }
   }
 
-  const truncatedOutput = tailLines(
-    (runtime.actionOutput ?? "").trim(),
-    ENV_ACTION_OUTPUT_MAX_LINES,
-  );
-
+  const truncatedOutput = tailLines((run.output ?? "").trim(), ENV_ACTION_OUTPUT_MAX_LINES);
   const modifier =
     status === "failed"
       ? "composer__queued--env-action-failed"
@@ -611,14 +600,12 @@ function EnvActionAnchor(props: {
       <div className="composer__queued-copy">
         <span className="composer__queued-label">{label}</span>
         <span className="composer__queued-text">
-          {runtime.actionName ?? "Action"}
-          {runtime.environmentName ? ` · ${runtime.environmentName}` : ""}
+          {run.actionName}
+          {props.environmentName ? ` · ${props.environmentName}` : ""}
           {meta.length > 0 ? ` · ${meta.join(" · ")}` : ""}
         </span>
-        {runtime.actionCommand ? (
-          <code className="composer__queued-env-action-command">
-            $ {runtime.actionCommand}
-          </code>
+        {run.command ? (
+          <code className="composer__queued-env-action-command">$ {run.command}</code>
         ) : null}
         <details className="composer__queued-env-action-details">
           <summary>
@@ -643,10 +630,7 @@ function EnvActionAnchor(props: {
           <button
             className="composer__secondary-action"
             type="button"
-            onClick={() => {
-              dismissedEnvActionAnchorKeys.add(dismissKey);
-              setDismissTick((tick) => tick + 1);
-            }}
+            onClick={props.onDismiss}
           >
             Dismiss
           </button>
@@ -3905,7 +3889,7 @@ export function Composer(props: ComposerProps) {
           above an input that already names itself was redundant
           chrome. */}
 
-      <EnvActionAnchor runtime={props.thread?.codexEnvironmentRuntime} />
+      <EnvActionAnchorList runtime={props.thread?.codexEnvironmentRuntime} />
 
       {pendingSteer ? (
         <div

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/EnvActionAnchorEntry.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/EnvActionAnchorEntry.test.tsx
@@ -188,4 +188,32 @@ describe("EnvActionAnchorEntry", () => {
       expect(screen.queryByText(/PwrAgnt/)).toBeNull();
     });
   });
+
+  describe("backend-converted zombie display", () => {
+    // EnvActionAnchorEntry itself doesn't apply the session-start filter
+    // (its parent EnvActionAnchorList does), but we assert the entry
+    // renders correctly for the "converted-by-backend-cleanup" path:
+    // a previously-started run that backend cleanup has flipped to
+    // "failed" must show with a Dismiss button so the user isn't stuck.
+    it("renders a backend-converted zombie run with a Dismiss button", () => {
+      render(
+        <EnvActionAnchorEntry
+          run={buildRun({
+            status: "failed",
+            startedAt: 1, // legacy-synthesised values may be 0/1 here
+            exitedAt: 1_700_000_000_000,
+            output: undefined,
+          })}
+          environmentName="PwrAgnt"
+          onDismiss={() => {}}
+        />,
+      );
+      expect(
+        screen.getByLabelText("Env action failed"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Dismiss" }),
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/EnvActionAnchorEntry.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/EnvActionAnchorEntry.test.tsx
@@ -2,7 +2,7 @@ import "@testing-library/jest-dom/vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { CodexEnvironmentActionRun } from "@pwragent/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { EnvActionAnchorEntry } from "../Composer";
+import { EnvActionAnchorEntry, formatDurationMs } from "../Composer";
 
 afterEach(() => {
   cleanup();
@@ -68,8 +68,8 @@ describe("EnvActionAnchorEntry", () => {
         screen.getByLabelText("Env action exited"),
       ).toBeInTheDocument();
       expect(screen.getByText(/exit 0/)).toBeInTheDocument();
-      // Duration formatter rounds <10s to 1 decimal.
-      expect(screen.getByText(/ran 4\.3s/)).toBeInTheDocument();
+      // Duration formatter rounds to integer seconds (4321ms → 4s).
+      expect(screen.getByText(/ran 4s/)).toBeInTheDocument();
       expect(
         screen.getByRole("button", { name: "Dismiss" }),
       ).toBeInTheDocument();
@@ -246,5 +246,51 @@ describe("EnvActionAnchorEntry", () => {
         screen.getByRole("button", { name: "Dismiss" }),
       ).toBeInTheDocument();
     });
+  });
+});
+
+describe("formatDurationMs", () => {
+  it("returns empty for falsy / non-finite inputs", () => {
+    expect(formatDurationMs(undefined)).toBe("");
+    expect(formatDurationMs(0)).toBe("");
+    expect(formatDurationMs(Number.NaN)).toBe("");
+    expect(formatDurationMs(Number.POSITIVE_INFINITY)).toBe("");
+  });
+
+  it("formats sub-second elapsed in integer milliseconds", () => {
+    expect(formatDurationMs(1)).toBe("1ms");
+    expect(formatDurationMs(750)).toBe("750ms");
+    expect(formatDurationMs(999)).toBe("999ms");
+  });
+
+  it("formats sub-minute elapsed in integer seconds (no decimal)", () => {
+    // Regression: the previous `toFixed(1)` for elapsed < 10s produced
+    // "0.9s" / "1.9s" displays that the user spotted as visual noise.
+    expect(formatDurationMs(1_000)).toBe("1s");
+    expect(formatDurationMs(1_499)).toBe("1s"); // rounds down
+    expect(formatDurationMs(1_500)).toBe("2s"); // rounds up
+    expect(formatDurationMs(9_400)).toBe("9s"); // never "9.4s"
+    expect(formatDurationMs(10_000)).toBe("10s");
+    expect(formatDurationMs(59_000)).toBe("59s");
+  });
+
+  it("crosses the 60-second boundary cleanly without producing 'Xm 60s'", () => {
+    // Regression: with `Math.round(seconds % 60)`, an elapsed of 59.5s
+    // produced "1m 60s" because half-up rounding rolled the remainder
+    // past 60 without bumping the minute.
+    expect(formatDurationMs(59_499)).toBe("59s");
+    expect(formatDurationMs(59_500)).toBe("1m");
+    expect(formatDurationMs(60_000)).toBe("1m");
+    expect(formatDurationMs(60_499)).toBe("1m");
+    expect(formatDurationMs(60_500)).toBe("1m 1s");
+    expect(formatDurationMs(119_499)).toBe("1m 59s");
+    expect(formatDurationMs(119_500)).toBe("2m");
+    expect(formatDurationMs(120_000)).toBe("2m");
+  });
+
+  it("formats hour-plus durations with the minute portion only", () => {
+    expect(formatDurationMs(60 * 60_000)).toBe("60m");
+    expect(formatDurationMs(60 * 60_000 + 5_000)).toBe("60m 5s");
+    expect(formatDurationMs(2 * 60 * 60_000)).toBe("120m");
   });
 });

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/EnvActionAnchorEntry.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/EnvActionAnchorEntry.test.tsx
@@ -293,4 +293,31 @@ describe("formatDurationMs", () => {
     expect(formatDurationMs(60 * 60_000 + 5_000)).toBe("60m 5s");
     expect(formatDurationMs(2 * 60 * 60_000)).toBe("120m");
   });
+
+  describe("coarseAfterMinute", () => {
+    it("drops the seconds portion entirely past 1 minute", () => {
+      // For the live "running for X" anchor meta, we want minute-only
+      // updates past the 1-minute mark to avoid distracting the user
+      // with a ticking sub-minute display.
+      expect(formatDurationMs(60_500, { coarseAfterMinute: true })).toBe("1m");
+      expect(formatDurationMs(118_000, { coarseAfterMinute: true })).toBe("1m");
+      expect(formatDurationMs(119_499, { coarseAfterMinute: true })).toBe("1m");
+      expect(formatDurationMs(119_500, { coarseAfterMinute: true })).toBe("2m");
+      expect(formatDurationMs(6 * 60_000 + 23_000, { coarseAfterMinute: true })).toBe("6m");
+    });
+
+    it("does not affect sub-minute formatting", () => {
+      // Sub-minute uses second-precision in either mode — there's no
+      // distraction problem there since the display does update.
+      expect(formatDurationMs(5_500, { coarseAfterMinute: true })).toBe("6s");
+      expect(formatDurationMs(59_499, { coarseAfterMinute: true })).toBe("59s");
+    });
+
+    it("leaves the default precise behavior unchanged", () => {
+      // The "ran 2m 30s" suffix on completed runs is a static one-shot
+      // display, not a ticker — keep the seconds precision intact.
+      expect(formatDurationMs(60_500)).toBe("1m 1s");
+      expect(formatDurationMs(6 * 60_000 + 23_000)).toBe("6m 23s");
+    });
+  });
 });

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/EnvActionAnchorEntry.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/EnvActionAnchorEntry.test.tsx
@@ -29,7 +29,7 @@ function buildRun(
 
 describe("EnvActionAnchorEntry", () => {
   describe("status branches", () => {
-    it("renders the running label and hides Dismiss while started", () => {
+    it("renders the running label with always-visible Dismiss while started", () => {
       render(
         <EnvActionAnchorEntry
           run={buildRun({ status: "started", pid: 12345 })}
@@ -40,7 +40,12 @@ describe("EnvActionAnchorEntry", () => {
       expect(
         screen.getByLabelText("Env action running"),
       ).toBeInTheDocument();
-      expect(screen.queryByRole("button", { name: "Dismiss" })).toBeNull();
+      // Dismiss is always available now, regardless of status — a
+      // long-running action that the user no longer cares about
+      // should be clearable without having to wait for it to exit.
+      expect(
+        screen.getByRole("button", { name: "Dismiss" }),
+      ).toBeInTheDocument();
       // The pid meta and the command echo land in the same anchor.
       expect(screen.getByText(/pid 12345/)).toBeInTheDocument();
       expect(screen.getByText(/\$ pnpm test/)).toBeInTheDocument();
@@ -186,6 +191,32 @@ describe("EnvActionAnchorEntry", () => {
       // anchor; meta (pid, running-for, exit) still uses the · separator,
       // but the env-name slot specifically is empty.
       expect(screen.queryByText(/PwrAgnt/)).toBeNull();
+    });
+  });
+
+  describe("multi-line command rendering", () => {
+    // Regression: previously rendered with white-space: nowrap, which
+    // flattened a multi-line script (`nvm use --silent\ncorepack
+    // enable\npnpm dev`) onto a single horizontally-scrolling line,
+    // making it look as though only the last line was running.
+    it("preserves newlines in commands so each line is visible", () => {
+      const multiLineCommand = "nvm use --silent\ncorepack enable\npnpm dev";
+      render(
+        <EnvActionAnchorEntry
+          run={buildRun({
+            status: "started",
+            command: multiLineCommand,
+          })}
+          environmentName="PwrSnap"
+          onDismiss={() => {}}
+        />,
+      );
+      // The command body lives inside a <pre><code> with white-space:
+      // pre, so the textContent retains the newlines verbatim.
+      const codeBlock = screen.getByText(/nvm use --silent/);
+      expect(codeBlock.textContent).toContain("nvm use --silent");
+      expect(codeBlock.textContent).toContain("corepack enable");
+      expect(codeBlock.textContent).toContain("pnpm dev");
     });
   });
 

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/EnvActionAnchorEntry.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/EnvActionAnchorEntry.test.tsx
@@ -1,0 +1,191 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { CodexEnvironmentActionRun } from "@pwragent/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EnvActionAnchorEntry } from "../Composer";
+
+afterEach(() => {
+  cleanup();
+});
+
+function buildRun(
+  overrides: Partial<CodexEnvironmentActionRun> = {},
+): CodexEnvironmentActionRun {
+  return {
+    runId: overrides.runId ?? "run-1",
+    actionId: overrides.actionId ?? "test",
+    actionName: overrides.actionName ?? "Test",
+    command: overrides.command ?? "pnpm test",
+    status: overrides.status ?? "started",
+    startedAt: overrides.startedAt ?? 1_700_000_000_000,
+    pid: overrides.pid,
+    exitedAt: overrides.exitedAt,
+    exitCode: overrides.exitCode,
+    exitSignal: overrides.exitSignal,
+    durationMs: overrides.durationMs,
+    output: overrides.output,
+  };
+}
+
+describe("EnvActionAnchorEntry", () => {
+  describe("status branches", () => {
+    it("renders the running label and hides Dismiss while started", () => {
+      render(
+        <EnvActionAnchorEntry
+          run={buildRun({ status: "started", pid: 12345 })}
+          environmentName="PwrAgnt"
+          onDismiss={() => {}}
+        />,
+      );
+      expect(
+        screen.getByLabelText("Env action running"),
+      ).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Dismiss" })).toBeNull();
+      // The pid meta and the command echo land in the same anchor.
+      expect(screen.getByText(/pid 12345/)).toBeInTheDocument();
+      expect(screen.getByText(/\$ pnpm test/)).toBeInTheDocument();
+    });
+
+    it("renders the exited label with exit code + duration meta and shows Dismiss", () => {
+      render(
+        <EnvActionAnchorEntry
+          run={buildRun({
+            status: "exited",
+            exitCode: 0,
+            durationMs: 4_321,
+            output: "build done\nready",
+          })}
+          environmentName={undefined}
+          onDismiss={() => {}}
+        />,
+      );
+      expect(
+        screen.getByLabelText("Env action exited"),
+      ).toBeInTheDocument();
+      expect(screen.getByText(/exit 0/)).toBeInTheDocument();
+      // Duration formatter rounds <10s to 1 decimal.
+      expect(screen.getByText(/ran 4\.3s/)).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Dismiss" }),
+      ).toBeInTheDocument();
+      // Output is rendered inside the collapsible <details>.
+      expect(screen.getByText(/build done/)).toBeInTheDocument();
+    });
+
+    it("renders the failed label and surfaces a non-zero exit code", () => {
+      render(
+        <EnvActionAnchorEntry
+          run={buildRun({
+            status: "failed",
+            exitCode: 1,
+            durationMs: 750,
+            output: "ERR_PNPM_IGNORED_BUILDS",
+          })}
+          environmentName="PwrAgnt"
+          onDismiss={() => {}}
+        />,
+      );
+      expect(
+        screen.getByLabelText("Env action failed"),
+      ).toBeInTheDocument();
+      expect(screen.getByText(/exit 1/)).toBeInTheDocument();
+      expect(
+        screen.getByText(/ERR_PNPM_IGNORED_BUILDS/),
+      ).toBeInTheDocument();
+      // Sub-second durations format in ms.
+      expect(screen.getByText(/ran 750ms/)).toBeInTheDocument();
+    });
+
+    it("falls back to signal meta when exit code is undefined", () => {
+      render(
+        <EnvActionAnchorEntry
+          run={buildRun({
+            status: "failed",
+            exitCode: undefined,
+            exitSignal: "SIGTERM",
+          })}
+          environmentName={undefined}
+          onDismiss={() => {}}
+        />,
+      );
+      expect(screen.getByText(/signal SIGTERM/)).toBeInTheDocument();
+      expect(screen.queryByText(/exit /)).toBeNull();
+    });
+  });
+
+  describe("output placeholders", () => {
+    it("shows the waiting-for-output placeholder while running with no output", () => {
+      render(
+        <EnvActionAnchorEntry
+          run={buildRun({ status: "started", output: undefined })}
+          environmentName={undefined}
+          onDismiss={() => {}}
+        />,
+      );
+      expect(
+        screen.getByText(/no output yet — waiting for the command/),
+      ).toBeInTheDocument();
+    });
+
+    it("shows the captured-empty placeholder after exit with no output", () => {
+      render(
+        <EnvActionAnchorEntry
+          run={buildRun({
+            status: "exited",
+            exitCode: 0,
+            output: undefined,
+          })}
+          environmentName={undefined}
+          onDismiss={() => {}}
+        />,
+      );
+      expect(
+        screen.getByText("(no output captured)"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("dismiss interaction", () => {
+    it("invokes onDismiss when the user clicks Dismiss", () => {
+      const onDismiss = vi.fn();
+      render(
+        <EnvActionAnchorEntry
+          run={buildRun({ status: "failed", exitCode: 1 })}
+          environmentName={undefined}
+          onDismiss={onDismiss}
+        />,
+      );
+      fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+      expect(onDismiss).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("environment-name decoration", () => {
+    it("appends environmentName when provided", () => {
+      render(
+        <EnvActionAnchorEntry
+          run={buildRun({ actionName: "E2E Tests" })}
+          environmentName="PwrAgnt"
+          onDismiss={() => {}}
+        />,
+      );
+      expect(
+        screen.getByText(/E2E Tests · PwrAgnt/),
+      ).toBeInTheDocument();
+    });
+
+    it("omits the env-name when undefined", () => {
+      render(
+        <EnvActionAnchorEntry
+          run={buildRun({ actionName: "E2E Tests" })}
+          environmentName={undefined}
+          onDismiss={() => {}}
+        />,
+      );
+      // The env-name "PwrAgnt" should not appear anywhere in the rendered
+      // anchor; meta (pid, running-for, exit) still uses the · separator,
+      // but the env-name slot specifically is empty.
+      expect(screen.queryByText(/PwrAgnt/)).toBeNull();
+    });
+  });
+});

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/EnvActionAnchorList.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/EnvActionAnchorList.test.tsx
@@ -1,0 +1,252 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type {
+  CodexEnvironmentActionRun,
+  CodexThreadEnvironmentRuntime,
+} from "@pwragent/shared";
+import { afterEach, describe, expect, it } from "vitest";
+import { EnvActionAnchorList } from "../Composer";
+
+afterEach(() => {
+  cleanup();
+});
+
+// Each test uses a unique runId namespace so the module-level
+// dismissed-set in Composer.tsx doesn't leak state between tests.
+// (The set is intentionally module-level to survive Composer remounts
+// during real thread switches; tests just need disjoint identities.)
+let runIdCounter = 0;
+function uniqueRunId(prefix: string): string {
+  runIdCounter += 1;
+  return `${prefix}-${runIdCounter}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function buildRuntime(
+  runs: CodexEnvironmentActionRun[],
+  environmentName = "PwrAgnt",
+): Pick<CodexThreadEnvironmentRuntime, "actionRuns" | "environmentName"> {
+  return { actionRuns: runs, environmentName };
+}
+
+function buildRun(
+  overrides: Partial<CodexEnvironmentActionRun> = {},
+): CodexEnvironmentActionRun {
+  return {
+    runId: overrides.runId ?? uniqueRunId("run"),
+    actionId: overrides.actionId ?? "dev",
+    actionName: overrides.actionName ?? "Dev",
+    command: overrides.command ?? "pnpm dev",
+    status: overrides.status ?? "started",
+    startedAt: overrides.startedAt ?? Date.now(),
+    pid: overrides.pid,
+    exitedAt: overrides.exitedAt,
+    exitCode: overrides.exitCode,
+    exitSignal: overrides.exitSignal,
+    durationMs: overrides.durationMs,
+    output: overrides.output,
+  };
+}
+
+describe("EnvActionAnchorList", () => {
+  it("renders nothing when runtime is undefined", () => {
+    const { container } = render(<EnvActionAnchorList runtime={undefined} />);
+    expect(container.textContent).toBe("");
+  });
+
+  it("renders nothing when there are no action runs", () => {
+    const { container } = render(
+      <EnvActionAnchorList runtime={buildRuntime([])} />,
+    );
+    expect(container.textContent).toBe("");
+  });
+
+  it("renders nothing when the only run is from before this renderer session (zombie)", () => {
+    // A run whose startedAt predates the module's session start is a
+    // zombie (the parent didn't survive long enough to mark it exited).
+    // The list must hide it categorically — otherwise the user is stuck
+    // with an undismissable "running" anchor that they can never clear,
+    // which was the PwrAgent-terminated-by-Computer-Use repro.
+    const { container } = render(
+      <EnvActionAnchorList
+        runtime={buildRuntime([
+          buildRun({ runId: uniqueRunId("zombie"), status: "started", startedAt: 1 }),
+        ])}
+      />,
+    );
+    expect(container.textContent).toBe("");
+  });
+
+  it("renders nothing when a legacy run (startedAt=0) would otherwise look 'started'", () => {
+    // Regression for the original bug where the renderer filter's
+    // `latestActivityAt > 0 && latestActivityAt < sessionStart` guard
+    // let runs with missing timestamps through, since `0 > 0` is false.
+    const { container } = render(
+      <EnvActionAnchorList
+        runtime={buildRuntime([
+          buildRun({
+            runId: uniqueRunId("legacy"),
+            status: "started",
+            startedAt: 0,
+          }),
+        ])}
+      />,
+    );
+    expect(container.textContent).toBe("");
+  });
+
+  it("renders a fresh, current-session run", () => {
+    render(
+      <EnvActionAnchorList
+        runtime={buildRuntime([
+          buildRun({
+            runId: uniqueRunId("fresh"),
+            status: "started",
+            pid: 4242,
+          }),
+        ])}
+      />,
+    );
+    expect(screen.getByLabelText("Env action running")).toBeInTheDocument();
+    expect(screen.getByText(/pid 4242/)).toBeInTheDocument();
+  });
+
+  it("renders one anchor per fresh run when multiple are alive on the same thread", () => {
+    // Multi-instance regression: two concurrent runs (e.g. Start + Test)
+    // should each get their own anchor entry. Before the multi-instance
+    // refactor the second would have overwritten the first.
+    render(
+      <EnvActionAnchorList
+        runtime={buildRuntime([
+          buildRun({
+            runId: uniqueRunId("a"),
+            actionId: "start",
+            actionName: "Start",
+            command: "pnpm start",
+            status: "started",
+            pid: 1001,
+          }),
+          buildRun({
+            runId: uniqueRunId("b"),
+            actionId: "test",
+            actionName: "Test",
+            command: "pnpm test",
+            status: "started",
+            pid: 1002,
+          }),
+        ])}
+      />,
+    );
+    // Two separate anchors with their own running labels.
+    expect(screen.getAllByLabelText("Env action running")).toHaveLength(2);
+    expect(screen.getByText(/pid 1001/)).toBeInTheDocument();
+    expect(screen.getByText(/pid 1002/)).toBeInTheDocument();
+  });
+
+  it("filters out zombies while keeping fresh siblings visible", () => {
+    // Mixed list: one prior-session zombie, one current-session fresh.
+    // The zombie must be hidden; the fresh one must remain.
+    render(
+      <EnvActionAnchorList
+        runtime={buildRuntime([
+          buildRun({
+            runId: uniqueRunId("zombie"),
+            status: "started",
+            startedAt: 1, // pre-session
+            pid: 9999,
+          }),
+          buildRun({
+            runId: uniqueRunId("fresh"),
+            status: "started",
+            pid: 7777,
+          }),
+        ])}
+      />,
+    );
+    expect(screen.getAllByLabelText("Env action running")).toHaveLength(1);
+    expect(screen.queryByText(/pid 9999/)).toBeNull();
+    expect(screen.getByText(/pid 7777/)).toBeInTheDocument();
+  });
+
+  it("hides a run after Dismiss is clicked", () => {
+    const runId = uniqueRunId("dismissable");
+    render(
+      <EnvActionAnchorList
+        runtime={buildRuntime([
+          buildRun({
+            runId,
+            status: "failed",
+            exitCode: 1,
+            startedAt: Date.now(),
+            exitedAt: Date.now(),
+          }),
+        ])}
+      />,
+    );
+    expect(screen.getByLabelText("Env action failed")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+    // After dismiss, the anchor disappears from the rendered tree.
+    expect(screen.queryByLabelText("Env action failed")).toBeNull();
+  });
+
+  it("keeps a dismissed run hidden across re-renders (module-level dismiss set)", () => {
+    // Real-world: Composer remounts on thread switch. The module-level
+    // dismiss set means a re-mount with the same runId continues to
+    // hide it. We simulate the remount by unmounting + re-rendering
+    // with the same runtime.
+    const runId = uniqueRunId("persistent-dismiss");
+    const runtime = buildRuntime([
+      buildRun({
+        runId,
+        status: "exited",
+        exitCode: 0,
+        startedAt: Date.now(),
+        exitedAt: Date.now(),
+      }),
+    ]);
+    const { unmount } = render(<EnvActionAnchorList runtime={runtime} />);
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+    unmount();
+    // Re-render with the SAME runtime; the dismiss should stick.
+    render(<EnvActionAnchorList runtime={runtime} />);
+    expect(screen.queryByLabelText("Env action exited")).toBeNull();
+  });
+
+  it("does not include exited/failed runs from a prior session", () => {
+    // Even if a "finished" run carries timestamps, predating the
+    // session means it's already-seen historical state. The cleanup
+    // pass on the backend should have shed its output bytes, but the
+    // renderer is the last line of defence.
+    const { container } = render(
+      <EnvActionAnchorList
+        runtime={buildRuntime([
+          buildRun({
+            runId: uniqueRunId("historical"),
+            status: "exited",
+            exitCode: 0,
+            startedAt: 1,
+            exitedAt: 2,
+          }),
+        ])}
+      />,
+    );
+    expect(container.textContent).toBe("");
+  });
+
+  it("preserves the env-name decoration on the anchor entry", () => {
+    render(
+      <EnvActionAnchorList
+        runtime={buildRuntime(
+          [
+            buildRun({
+              runId: uniqueRunId("named"),
+              actionName: "E2E Tests",
+              status: "started",
+            }),
+          ],
+          "PwrSnap",
+        )}
+      />,
+    );
+    expect(screen.getByText(/E2E Tests · PwrSnap/)).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -32,7 +32,7 @@ import type {
   NavigationThreadSummary,
   ThreadExecutionMode,
 } from "@pwragent/shared";
-import { isBranchDrifted } from "@pwragent/shared";
+import { isBranchDrifted, readCodexEnvironmentActionRuns } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 import type { ThreadContextWindowState } from "../../lib/useThreadSessionState";
 import { formatBackendLabel } from "../../lib/backend-label";
@@ -1035,8 +1035,17 @@ export function ThreadView(props: ThreadViewProps) {
   }, [props.suppressBranchDriftDialog]);
   const selectedThreadSetupFailed =
     selectedThread?.codexEnvironmentRuntime?.setupStatus === "failed";
-  const selectedThreadActionFailed =
-    selectedThread?.codexEnvironmentRuntime?.actionStatus === "failed";
+  // The setup-failure dialog only surfaces during launchpad materialise
+  // (messageCount === 0), where at most one auto-action runs. Look for
+  // the most recent failed run in actionRuns to drive the action-phase
+  // branch of the dialog.
+  const selectedThreadActionRuns = readCodexEnvironmentActionRuns(
+    selectedThread?.codexEnvironmentRuntime,
+  );
+  const selectedThreadLatestFailedActionRun = [...selectedThreadActionRuns]
+    .reverse()
+    .find((run) => run.status === "failed");
+  const selectedThreadActionFailed = Boolean(selectedThreadLatestFailedActionRun);
   const selectedThreadWorktree = selectedThread?.linkedDirectories.find(
     (directory) =>
       directory.kind === "worktree" || Boolean(directory.worktreePath?.trim()),
@@ -1996,7 +2005,7 @@ export function ThreadView(props: ThreadViewProps) {
               continuing={setupFailureContinuing}
               command={
                 selectedThreadEnvironmentFailurePhase === "action"
-                  ? selectedThread.codexEnvironmentRuntime?.actionCommand
+                  ? selectedThreadLatestFailedActionRun?.command
                   : selectedThread.codexEnvironmentRuntime?.setupCommand ??
                     launchpadSetupProgress?.command
               }

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1984,58 +1984,58 @@ export function ThreadView(props: ThreadViewProps) {
         onOpenMessagingActivity={props.onOpenMessagingActivity}
       />
 
-      {showSetupFailureChoice && selectedThread && selectedThreadKey ? (
-        <EnvironmentSetupFailureChoice
-          archiving={setupFailureArchiving}
-          continuing={setupFailureContinuing}
-          command={
-            selectedThreadEnvironmentFailurePhase === "action"
-              ? selectedThread.codexEnvironmentRuntime?.actionCommand
-              : selectedThread.codexEnvironmentRuntime?.setupCommand ??
-                launchpadSetupProgress?.command
-          }
-          cwd={
-            selectedThread.codexEnvironmentRuntime?.cwd ??
-            launchpadSetupProgress?.cwd
-          }
-          environmentName={
-            selectedThread.codexEnvironmentRuntime?.environmentName ??
-            "Codex environment"
-          }
-          error={props.archiveThreadError ?? setupFailureContinueError}
-          exitCode={
-            selectedThreadEnvironmentFailurePhase === "setup"
-              ? selectedThread.codexEnvironmentRuntime?.setupExitCode ??
-                launchpadSetupProgress?.exitCode
-              : undefined
-          }
-          hasWorktree={Boolean(selectedThreadWorktree)}
-          output={
-            selectedThreadEnvironmentFailurePhase === "setup"
-              ? selectedThread.codexEnvironmentRuntime?.setupOutput ??
-                launchpadSetupProgress?.output
-              : undefined
-          }
-          phase={selectedThreadEnvironmentFailurePhase}
-          onCleanup={() => {
-            if (!props.onArchiveThread) {
-              return;
-            }
-            setSetupFailureArchiving(true);
-            void props.onArchiveThread(selectedThread).finally(() => {
-              setSetupFailureArchiving(false);
-            });
-          }}
-          onContinue={continueAfterSetupFailure}
-        />
-      ) : null}
-
       <div
         className={`thread-view__layout${
           contextRailEffectivePinned ? " has-pinned-context-rail" : ""
         }${contextRailResizing ? " is-resizing-context-rail" : ""}`}
       >
         <div className="thread-view__primary">
+          {showSetupFailureChoice && selectedThread && selectedThreadKey ? (
+            <EnvironmentSetupFailureChoice
+              archiving={setupFailureArchiving}
+              continuing={setupFailureContinuing}
+              command={
+                selectedThreadEnvironmentFailurePhase === "action"
+                  ? selectedThread.codexEnvironmentRuntime?.actionCommand
+                  : selectedThread.codexEnvironmentRuntime?.setupCommand ??
+                    launchpadSetupProgress?.command
+              }
+              cwd={
+                selectedThread.codexEnvironmentRuntime?.cwd ??
+                launchpadSetupProgress?.cwd
+              }
+              environmentName={
+                selectedThread.codexEnvironmentRuntime?.environmentName ??
+                "Codex environment"
+              }
+              error={props.archiveThreadError ?? setupFailureContinueError}
+              exitCode={
+                selectedThreadEnvironmentFailurePhase === "setup"
+                  ? selectedThread.codexEnvironmentRuntime?.setupExitCode ??
+                    launchpadSetupProgress?.exitCode
+                  : undefined
+              }
+              hasWorktree={Boolean(selectedThreadWorktree)}
+              output={
+                selectedThreadEnvironmentFailurePhase === "setup"
+                  ? selectedThread.codexEnvironmentRuntime?.setupOutput ??
+                    launchpadSetupProgress?.output
+                  : undefined
+              }
+              phase={selectedThreadEnvironmentFailurePhase}
+              onCleanup={() => {
+                if (!props.onArchiveThread) {
+                  return;
+                }
+                setSetupFailureArchiving(true);
+                void props.onArchiveThread(selectedThread).finally(() => {
+                  setSetupFailureArchiving(false);
+                });
+              }}
+              onContinue={continueAfterSetupFailure}
+            />
+          ) : null}
+
           <section className="transcript-panel" aria-label="Transcript">
             <TranscriptList
               entries={props.transcriptEntries}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -207,9 +207,13 @@ function LaunchpadEnvironmentSetupPending(props: {
 function EnvironmentSetupFailureChoice(props: {
   archiving: boolean;
   continuing: boolean;
+  command?: string;
+  cwd?: string;
   error?: string;
   environmentName: string;
+  exitCode?: number;
   hasWorktree: boolean;
+  output?: string;
   phase: "setup" | "action";
   onCleanup: () => void;
   onContinue: () => void | Promise<void>;
@@ -217,18 +221,53 @@ function EnvironmentSetupFailureChoice(props: {
   const label =
     props.phase === "action" ? "Environment action failed" : "Environment setup failed";
   const commandLabel = props.phase === "action" ? "action command" : "setup command";
+  const trimmedOutput = props.output?.trim();
+  const hasDetails =
+    Boolean(props.command?.trim()) ||
+    Boolean(trimmedOutput) ||
+    typeof props.exitCode === "number";
   return (
     <section className="environment-setup-choice" aria-label={label}>
-      <div>
-        <p className="eyebrow">{label}</p>
-        <h3>{props.environmentName}</h3>
-        <p>
-          {props.hasWorktree
-            ? `The ${commandLabel} exited with an error. You can delete the new worktree and close this thread, or keep the thread open and fix it yourself or with agent assistance.`
-            : `The ${commandLabel} exited with an error. You can close this thread, or keep it open and fix it yourself or with agent assistance.`}
-        </p>
-        {props.error ? (
-          <p className="environment-setup-choice__error">{props.error}</p>
+      <div className="environment-setup-choice__body">
+        <div className="environment-setup-choice__heading">
+          <p className="eyebrow">{label}</p>
+          <h3>{props.environmentName}</h3>
+          <p>
+            {props.hasWorktree
+              ? `The ${commandLabel} exited with an error. You can delete the new worktree and close this thread, or keep the thread open and fix it yourself or with agent assistance.`
+              : `The ${commandLabel} exited with an error. You can close this thread, or keep it open and fix it yourself or with agent assistance.`}
+          </p>
+          {props.error ? (
+            <p className="environment-setup-choice__error">{props.error}</p>
+          ) : null}
+        </div>
+        {hasDetails ? (
+          <details className="environment-setup-choice__details" open>
+            <summary>
+              Show command output
+              {typeof props.exitCode === "number" ? ` (exit ${props.exitCode})` : ""}
+            </summary>
+            {props.command?.trim() ? (
+              <div className="environment-setup-choice__field">
+                <div className="environment-setup-choice__field-label">Command</div>
+                <pre className="environment-setup-choice__pre">
+                  <code>{`$ ${props.command.trim()}`}</code>
+                </pre>
+              </div>
+            ) : null}
+            {props.cwd?.trim() ? (
+              <div className="environment-setup-choice__field">
+                <div className="environment-setup-choice__field-label">Path</div>
+                <code className="environment-setup-choice__path">{props.cwd}</code>
+              </div>
+            ) : null}
+            <div className="environment-setup-choice__field">
+              <div className="environment-setup-choice__field-label">Output</div>
+              <pre className="environment-setup-choice__pre environment-setup-choice__pre--output">
+                <code>{trimmedOutput || "(no output captured)"}</code>
+              </pre>
+            </div>
+          </details>
         ) : null}
       </div>
       <div className="environment-setup-choice__actions">
@@ -1949,12 +1988,34 @@ export function ThreadView(props: ThreadViewProps) {
         <EnvironmentSetupFailureChoice
           archiving={setupFailureArchiving}
           continuing={setupFailureContinuing}
+          command={
+            selectedThreadEnvironmentFailurePhase === "action"
+              ? selectedThread.codexEnvironmentRuntime?.actionCommand
+              : selectedThread.codexEnvironmentRuntime?.setupCommand ??
+                launchpadSetupProgress?.command
+          }
+          cwd={
+            selectedThread.codexEnvironmentRuntime?.cwd ??
+            launchpadSetupProgress?.cwd
+          }
           environmentName={
             selectedThread.codexEnvironmentRuntime?.environmentName ??
             "Codex environment"
           }
           error={props.archiveThreadError ?? setupFailureContinueError}
+          exitCode={
+            selectedThreadEnvironmentFailurePhase === "setup"
+              ? selectedThread.codexEnvironmentRuntime?.setupExitCode ??
+                launchpadSetupProgress?.exitCode
+              : undefined
+          }
           hasWorktree={Boolean(selectedThreadWorktree)}
+          output={
+            selectedThreadEnvironmentFailurePhase === "setup"
+              ? selectedThread.codexEnvironmentRuntime?.setupOutput ??
+                launchpadSetupProgress?.output
+              : undefined
+          }
           phase={selectedThreadEnvironmentFailurePhase}
           onCleanup={() => {
             if (!props.onArchiveThread) {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -4764,11 +4764,15 @@ textarea,
 
 .environment-setup-choice {
   display: flex;
+  flex-wrap: wrap;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 18px;
-  margin: 0 22px 12px;
+  gap: 12px 18px;
+  margin: 12px 22px;
   padding: 14px 16px;
+  /* Stay inside the transcript column even when the context rail is pinned. */
+  max-width: 100%;
+  box-sizing: border-box;
   border: 1px solid var(--danger-border);
   border-radius: 8px;
   background: var(--danger-soft);
@@ -4776,7 +4780,7 @@ textarea,
 }
 
 .environment-setup-choice__body {
-  flex: 1 1 auto;
+  flex: 1 1 360px;
   min-width: 0;
   display: flex;
   flex-direction: column;
@@ -4806,6 +4810,8 @@ textarea,
 
 .environment-setup-choice__details {
   margin: 0;
+  width: 100%;
+  min-width: 0;
   border: 1px solid var(--surface-border);
   border-radius: 6px;
   background: var(--surface-raised);
@@ -4856,13 +4862,16 @@ textarea,
   font-size: 12px;
   line-height: 1.5;
   color: var(--text-primary);
-  white-space: pre-wrap;
-  word-break: break-word;
+  white-space: pre;
   overflow-x: auto;
+  /* Defensive: ensure the user can actually copy build output from the
+     dialog. Some upstream rules globally set user-select: none on chrome. */
+  user-select: text;
+  -webkit-user-select: text;
 }
 
 .environment-setup-choice__pre--output {
-  max-height: 280px;
+  max-height: 320px;
   overflow: auto;
 }
 
@@ -4871,13 +4880,16 @@ textarea,
   font-size: 12px;
   color: var(--text-secondary);
   word-break: break-all;
+  user-select: text;
+  -webkit-user-select: text;
 }
 
 .environment-setup-choice__actions {
   display: flex;
-  flex: 0 0 auto;
+  flex: 1 1 auto;
   flex-wrap: wrap;
   justify-content: flex-end;
+  align-self: flex-start;
   gap: 8px;
 }
 
@@ -7948,6 +7960,8 @@ textarea,
   color: var(--text-secondary);
   overflow-x: auto;
   white-space: nowrap;
+  user-select: text;
+  -webkit-user-select: text;
 }
 
 .composer__queued-env-action-details {
@@ -7973,7 +7987,7 @@ textarea,
 .composer__queued-env-action-output {
   margin: 0;
   padding: 6px 8px;
-  max-height: 260px;
+  max-height: 320px;
   overflow: auto;
   background: var(--surface);
   border: 1px solid var(--surface-border);
@@ -7982,8 +7996,9 @@ textarea,
   font-size: 12px;
   line-height: 1.5;
   color: var(--text-primary);
-  white-space: pre-wrap;
-  word-break: break-word;
+  white-space: pre;
+  user-select: text;
+  -webkit-user-select: text;
 }
 
 .composer__attachments {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -4815,9 +4815,9 @@ textarea,
   margin: 0;
   width: 100%;
   min-width: 0;
-  border: 1px solid var(--surface-border);
+  border: 1px solid var(--border-subtle);
   border-radius: 6px;
-  background: var(--surface-raised);
+  background: var(--bg-panel-elevated);
   padding: 0;
 }
 
@@ -4835,7 +4835,7 @@ textarea,
 }
 
 .environment-setup-choice__details[open] > summary {
-  border-bottom: 1px solid var(--surface-border);
+  border-bottom: 1px solid var(--border-subtle);
 }
 
 .environment-setup-choice__field {
@@ -4846,7 +4846,7 @@ textarea,
 }
 
 .environment-setup-choice__field + .environment-setup-choice__field {
-  border-top: 1px solid var(--surface-border);
+  border-top: 1px solid var(--border-subtle);
 }
 
 .environment-setup-choice__field-label {
@@ -4859,7 +4859,7 @@ textarea,
 .environment-setup-choice__pre {
   margin: 0;
   padding: 6px 8px;
-  background: var(--surface);
+  background: var(--bg-input);
   border-radius: 4px;
   font-family: var(--font-monospace, ui-monospace, SFMono-Regular, monospace);
   font-size: 12px;
@@ -7959,7 +7959,7 @@ textarea,
   display: block;
   margin-top: 4px;
   padding: 4px 6px;
-  background: var(--surface);
+  background: var(--bg-input);
   border-radius: 4px;
   font-family: var(--font-monospace, ui-monospace, SFMono-Regular, monospace);
   font-size: 12px;
@@ -7995,8 +7995,8 @@ textarea,
   padding: 6px 8px;
   max-height: 320px;
   overflow: auto;
-  background: var(--surface);
-  border: 1px solid var(--surface-border);
+  background: var(--bg-input);
+  border: 1px solid var(--border-subtle);
   border-radius: 4px;
   font-family: var(--font-monospace, ui-monospace, SFMono-Regular, monospace);
   font-size: 12px;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -4775,6 +4775,18 @@ textarea,
   color: var(--text-primary);
 }
 
+.environment-setup-choice__body {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.environment-setup-choice__heading > *:first-child {
+  margin-top: 0;
+}
+
 .environment-setup-choice h3 {
   margin: 0;
   font-size: 16px;
@@ -4790,6 +4802,75 @@ textarea,
 
 .environment-setup-choice__error {
   color: var(--danger-text);
+}
+
+.environment-setup-choice__details {
+  margin: 0;
+  border: 1px solid var(--surface-border);
+  border-radius: 6px;
+  background: var(--surface-raised);
+  padding: 0;
+}
+
+.environment-setup-choice__details > summary {
+  cursor: pointer;
+  list-style: none;
+  padding: 8px 10px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  user-select: none;
+}
+
+.environment-setup-choice__details > summary::-webkit-details-marker {
+  display: none;
+}
+
+.environment-setup-choice__details[open] > summary {
+  border-bottom: 1px solid var(--surface-border);
+}
+
+.environment-setup-choice__field {
+  padding: 8px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.environment-setup-choice__field + .environment-setup-choice__field {
+  border-top: 1px solid var(--surface-border);
+}
+
+.environment-setup-choice__field-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+}
+
+.environment-setup-choice__pre {
+  margin: 0;
+  padding: 6px 8px;
+  background: var(--surface);
+  border-radius: 4px;
+  font-family: var(--font-monospace, ui-monospace, SFMono-Regular, monospace);
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-primary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-x: auto;
+}
+
+.environment-setup-choice__pre--output {
+  max-height: 280px;
+  overflow: auto;
+}
+
+.environment-setup-choice__path {
+  font-family: var(--font-monospace, ui-monospace, SFMono-Regular, monospace);
+  font-size: 12px;
+  color: var(--text-secondary);
+  word-break: break-all;
 }
 
 .environment-setup-choice__actions {
@@ -7831,6 +7912,78 @@ textarea,
   flex-wrap: wrap;
   justify-content: flex-end;
   gap: 6px;
+}
+
+.composer__queued--env-action {
+  align-items: flex-start;
+}
+
+.composer__queued--env-action .composer__queued-text {
+  white-space: normal;
+  overflow: visible;
+  text-overflow: clip;
+}
+
+.composer__queued--env-action-failed {
+  border-color: var(--danger-border);
+  background: color-mix(in srgb, var(--danger-soft) 40%, var(--bg-panel-elevated));
+}
+
+.composer__queued--env-action-failed .composer__queued-label {
+  color: var(--danger-text);
+}
+
+.composer__queued--env-action-exited {
+  border-color: color-mix(in srgb, var(--status-warning) 36%, var(--border-subtle));
+}
+
+.composer__queued-env-action-command {
+  display: block;
+  margin-top: 4px;
+  padding: 4px 6px;
+  background: var(--surface);
+  border-radius: 4px;
+  font-family: var(--font-monospace, ui-monospace, SFMono-Regular, monospace);
+  font-size: 12px;
+  color: var(--text-secondary);
+  overflow-x: auto;
+  white-space: nowrap;
+}
+
+.composer__queued-env-action-details {
+  margin-top: 6px;
+}
+
+.composer__queued-env-action-details > summary {
+  cursor: pointer;
+  list-style: none;
+  font-size: 12px;
+  color: var(--text-secondary);
+  user-select: none;
+}
+
+.composer__queued-env-action-details > summary::-webkit-details-marker {
+  display: none;
+}
+
+.composer__queued-env-action-details[open] > summary {
+  margin-bottom: 4px;
+}
+
+.composer__queued-env-action-output {
+  margin: 0;
+  padding: 6px 8px;
+  max-height: 260px;
+  overflow: auto;
+  background: var(--surface);
+  border: 1px solid var(--surface-border);
+  border-radius: 4px;
+  font-family: var(--font-monospace, ui-monospace, SFMono-Regular, monospace);
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-primary);
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .composer__attachments {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -7932,14 +7932,16 @@ textarea,
   gap: 6px;
 }
 
+/* Env-action anchor: collapsed-by-default <details> with chevron, body
+   hidden until expanded. The base .composer__queued is a grid layout
+   meant for the steer/permissions/queued-turn pattern; for the
+   env-action anchor we override to block so <details>/<summary> can
+   own the layout. */
 .composer__queued--env-action {
-  align-items: flex-start;
-}
-
-.composer__queued--env-action .composer__queued-text {
-  white-space: normal;
-  overflow: visible;
-  text-overflow: clip;
+  display: block;
+  padding: 0;
+  background: var(--bg-panel-elevated);
+  border-color: var(--border-subtle);
 }
 
 .composer__queued--env-action-failed {
@@ -7955,39 +7957,100 @@ textarea,
   border-color: color-mix(in srgb, var(--status-warning) 36%, var(--border-subtle));
 }
 
-.composer__queued-env-action-command {
-  display: block;
-  margin-top: 4px;
-  padding: 4px 6px;
-  background: var(--bg-input);
-  border-radius: 4px;
-  font-family: var(--font-monospace, ui-monospace, SFMono-Regular, monospace);
-  font-size: 12px;
-  color: var(--text-secondary);
-  overflow-x: auto;
-  white-space: nowrap;
-  user-select: text;
-  -webkit-user-select: text;
-}
-
-.composer__queued-env-action-details {
-  margin-top: 6px;
-}
-
-.composer__queued-env-action-details > summary {
+.composer__queued-env-action-summary {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
   cursor: pointer;
   list-style: none;
-  font-size: 12px;
-  color: var(--text-secondary);
   user-select: none;
+  border-radius: 8px;
 }
 
-.composer__queued-env-action-details > summary::-webkit-details-marker {
+.composer__queued-env-action-summary::-webkit-details-marker {
   display: none;
 }
 
-.composer__queued-env-action-details[open] > summary {
-  margin-bottom: 4px;
+.composer__queued-env-action-summary:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.composer__queued-env-action-chevron {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  flex: 0 0 auto;
+  border-right: 1.5px solid var(--text-muted);
+  border-bottom: 1.5px solid var(--text-muted);
+  transform: rotate(-45deg);
+  transition: transform 120ms ease;
+}
+
+.composer__queued--env-action[open] .composer__queued-env-action-chevron {
+  transform: rotate(45deg);
+}
+
+.composer__queued-env-action-summary-text {
+  display: flex;
+  flex: 1 1 auto;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: baseline;
+  column-gap: 8px;
+  row-gap: 2px;
+}
+
+.composer__queued-env-action-summary-text .composer__queued-text {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.composer__queued-env-action-dismiss {
+  flex: 0 0 auto;
+}
+
+.composer__queued-env-action-body {
+  padding: 0 10px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.composer__queued-env-action-section {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.composer__queued-env-action-section-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+}
+
+.composer__queued-env-action-command-block {
+  margin: 0;
+  padding: 6px 8px;
+  background: var(--bg-input);
+  border: 1px solid var(--border-subtle);
+  border-radius: 4px;
+  font-family: var(--font-monospace, ui-monospace, SFMono-Regular, monospace);
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-secondary);
+  /* Critical: preserve newlines so multi-line scripts render as the
+     user wrote them. white-space: nowrap (the previous value) flattened
+     a 3-line script onto a single horizontally-scrolling line. */
+  white-space: pre;
+  overflow-x: auto;
+  user-select: text;
+  -webkit-user-select: text;
 }
 
 .composer__queued-env-action-output {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -4780,7 +4780,10 @@ textarea,
 }
 
 .environment-setup-choice__body {
-  flex: 1 1 360px;
+  /* Take all remaining horizontal space so the output pre fills the
+     dialog. The actions column on the right is flex: 0 0 auto so it
+     only gets its natural width, leaving the rest to the body. */
+  flex: 1 1 auto;
   min-width: 0;
   display: flex;
   flex-direction: column;
@@ -4885,8 +4888,11 @@ textarea,
 }
 
 .environment-setup-choice__actions {
+  /* Natural width only so the body next to it can stretch to fill the
+     dialog. When the dialog wraps onto two rows (narrow widths), this
+     wraps under the body at full width with the buttons right-aligned. */
   display: flex;
-  flex: 1 1 auto;
+  flex: 0 0 auto;
   flex-wrap: wrap;
   justify-content: flex-end;
   align-self: flex-start;

--- a/packages/agent-core/src/domain/navigation-state.ts
+++ b/packages/agent-core/src/domain/navigation-state.ts
@@ -314,6 +314,30 @@ export function buildNavigationSnapshotHash(params: {
             actionCommand: thread.codexEnvironmentRuntime.actionCommand ?? null,
             actionStatus: thread.codexEnvironmentRuntime.actionStatus ?? null,
             actionPid: thread.codexEnvironmentRuntime.actionPid ?? null,
+            // Multi-instance env-action runs (PR #505). Each run's
+            // identity + lifecycle fields contribute to the hash so the
+            // navigation snapshot invalidates when any run starts, gets
+            // a new output snapshot, or exits.
+            actionRuns: (thread.codexEnvironmentRuntime.actionRuns ?? []).map(
+              (run) => ({
+                runId: run.runId,
+                actionId: run.actionId,
+                actionName: run.actionName,
+                command: run.command,
+                status: run.status,
+                pid: run.pid ?? null,
+                startedAt: run.startedAt,
+                exitedAt: run.exitedAt ?? null,
+                exitCode: run.exitCode ?? null,
+                exitSignal: run.exitSignal ?? null,
+                durationMs: run.durationMs ?? null,
+                // Hash the output's length only — the actual bytes can
+                // be megabytes and hashing them on every snapshot would
+                // be wasteful. Length still flips the hash on each new
+                // chunk's overlay write so live-output renders refresh.
+                outputLength: run.output?.length ?? 0,
+              }),
+            ),
             sourcePath: thread.codexEnvironmentRuntime.sourcePath ?? null,
           }
         : null,

--- a/packages/shared/src/__tests__/codex-environment-action-runs.test.ts
+++ b/packages/shared/src/__tests__/codex-environment-action-runs.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyCodexEnvironmentActionRunUpdate,
+  CODEX_ENVIRONMENT_ACTION_RUNS_MAX,
+  type CodexEnvironmentActionRun,
+  type CodexThreadEnvironmentRuntime,
+  readCodexEnvironmentActionRuns,
+} from "../index";
+
+function buildRun(
+  overrides: Partial<CodexEnvironmentActionRun>,
+): CodexEnvironmentActionRun {
+  return {
+    runId: overrides.runId ?? "r1",
+    actionId: overrides.actionId ?? "a1",
+    actionName: overrides.actionName ?? "Action 1",
+    command: overrides.command ?? "echo",
+    status: overrides.status ?? "started",
+    startedAt: overrides.startedAt ?? 1_000,
+    pid: overrides.pid,
+    exitedAt: overrides.exitedAt,
+    exitCode: overrides.exitCode,
+    exitSignal: overrides.exitSignal,
+    durationMs: overrides.durationMs,
+    output: overrides.output,
+  };
+}
+
+describe("readCodexEnvironmentActionRuns", () => {
+  it("returns empty when runtime is undefined", () => {
+    expect(readCodexEnvironmentActionRuns(undefined)).toEqual([]);
+  });
+
+  it("prefers actionRuns when present", () => {
+    const runtime: CodexThreadEnvironmentRuntime = {
+      environmentId: "env",
+      environmentName: "Env",
+      executionTarget: "local",
+      actionRuns: [buildRun({ runId: "fresh" })],
+    };
+    expect(readCodexEnvironmentActionRuns(runtime)).toEqual([
+      expect.objectContaining({ runId: "fresh" }),
+    ]);
+  });
+
+  it("synthesises a single-element array from legacy fields when actionRuns is missing", () => {
+    const runtime: CodexThreadEnvironmentRuntime = {
+      environmentId: "env",
+      environmentName: "Env",
+      executionTarget: "local",
+      actionId: "start-dev",
+      actionName: "Start Dev",
+      actionCommand: "pnpm dev",
+      actionStatus: "started",
+      actionPid: 12345,
+      actionStartedAt: 1_700_000_000_000,
+      actionOutput: "first lines",
+    };
+    expect(readCodexEnvironmentActionRuns(runtime)).toEqual([
+      {
+        runId: "legacy:start-dev:1700000000000",
+        actionId: "start-dev",
+        actionName: "Start Dev",
+        command: "pnpm dev",
+        status: "started",
+        pid: 12345,
+        startedAt: 1_700_000_000_000,
+        exitedAt: undefined,
+        exitCode: undefined,
+        exitSignal: undefined,
+        durationMs: undefined,
+        output: "first lines",
+      },
+    ]);
+  });
+
+  it("returns empty when both actionRuns and legacy fields are missing", () => {
+    const runtime: CodexThreadEnvironmentRuntime = {
+      environmentId: "env",
+      environmentName: "Env",
+      executionTarget: "local",
+    };
+    expect(readCodexEnvironmentActionRuns(runtime)).toEqual([]);
+  });
+});
+
+describe("applyCodexEnvironmentActionRunUpdate", () => {
+  it("appends new runs in order", () => {
+    const first = buildRun({ runId: "a", actionId: "a" });
+    const second = buildRun({ runId: "b", actionId: "b" });
+    const after1 = applyCodexEnvironmentActionRunUpdate([], {
+      kind: "append",
+      run: first,
+    });
+    const after2 = applyCodexEnvironmentActionRunUpdate(after1, {
+      kind: "append",
+      run: second,
+    });
+    expect(after2.map((r) => r.runId)).toEqual(["a", "b"]);
+  });
+
+  it("patches the matching runId leaving others unchanged", () => {
+    const a = buildRun({ runId: "a", output: "old" });
+    const b = buildRun({ runId: "b", output: "old" });
+    const next = applyCodexEnvironmentActionRunUpdate([a, b], {
+      kind: "patch",
+      runId: "b",
+      patch: { output: "fresh" },
+    });
+    expect(next).toEqual([
+      expect.objectContaining({ runId: "a", output: "old" }),
+      expect.objectContaining({ runId: "b", output: "fresh" }),
+    ]);
+  });
+
+  it("returns the input unchanged when the patched runId isn't present", () => {
+    const a = buildRun({ runId: "a" });
+    const result = applyCodexEnvironmentActionRunUpdate([a], {
+      kind: "patch",
+      runId: "missing",
+      patch: { output: "x" },
+    });
+    expect(result).toEqual([a]);
+  });
+
+  it("evicts the oldest non-running entry when the cap is exceeded", () => {
+    const runs: CodexEnvironmentActionRun[] = [];
+    for (let i = 0; i < CODEX_ENVIRONMENT_ACTION_RUNS_MAX; i += 1) {
+      runs.push(buildRun({ runId: `r${i}`, status: i < 3 ? "exited" : "started" }));
+    }
+    const next = applyCodexEnvironmentActionRunUpdate(runs, {
+      kind: "append",
+      run: buildRun({ runId: "new", status: "started" }),
+    });
+    expect(next.length).toBe(CODEX_ENVIRONMENT_ACTION_RUNS_MAX);
+    // Oldest non-running (r0) was evicted; r1, r2 (also non-running) remain.
+    expect(next.map((r) => r.runId)).toEqual([
+      "r1",
+      "r2",
+      "r3",
+      "r4",
+      "r5",
+      "r6",
+      "r7",
+      "r8",
+      "r9",
+      "new",
+    ]);
+  });
+
+  it("does not evict running entries even if the cap is exceeded and all are running", () => {
+    const runs: CodexEnvironmentActionRun[] = [];
+    for (let i = 0; i < CODEX_ENVIRONMENT_ACTION_RUNS_MAX; i += 1) {
+      runs.push(buildRun({ runId: `r${i}`, status: "started" }));
+    }
+    const next = applyCodexEnvironmentActionRunUpdate(runs, {
+      kind: "append",
+      run: buildRun({ runId: "new", status: "started" }),
+    });
+    // All entries are "started"; nothing evictable. List grows past cap.
+    expect(next.length).toBe(CODEX_ENVIRONMENT_ACTION_RUNS_MAX + 1);
+    expect(next.at(-1)?.runId).toBe("new");
+  });
+});

--- a/packages/shared/src/codex-environment-action-runs.ts
+++ b/packages/shared/src/codex-environment-action-runs.ts
@@ -1,0 +1,83 @@
+import {
+  CODEX_ENVIRONMENT_ACTION_RUNS_MAX,
+  type CodexEnvironmentActionRun,
+  type CodexThreadEnvironmentRuntime,
+} from "./contracts/normalized-app-server";
+
+/**
+ * Read the action-run list from a runtime, synthesising a single-element
+ * array from the deprecated singular `actionId/actionStatus/actionOutput`
+ * fields if a runtime persisted before the multi-instance refactor is
+ * encountered. New writers always populate `actionRuns` directly; the
+ * legacy fields will disappear from disk as runtimes are rewritten.
+ */
+export function readCodexEnvironmentActionRuns(
+  runtime:
+    | Pick<
+        CodexThreadEnvironmentRuntime,
+        | "actionRuns"
+        | "actionId"
+        | "actionName"
+        | "actionCommand"
+        | "actionStatus"
+        | "actionPid"
+        | "actionStartedAt"
+        | "actionExitedAt"
+        | "actionExitCode"
+        | "actionExitSignal"
+        | "actionDurationMs"
+        | "actionOutput"
+      >
+    | undefined,
+): CodexEnvironmentActionRun[] {
+  if (!runtime) return [];
+  if (Array.isArray(runtime.actionRuns)) return runtime.actionRuns;
+  if (!runtime.actionId || !runtime.actionStatus) return [];
+  // Synthesise from legacy fields. runId is deterministic so we don't
+  // generate a new one on every read.
+  const startedAt = runtime.actionStartedAt ?? 0;
+  return [
+    {
+      runId: `legacy:${runtime.actionId}:${startedAt}`,
+      actionId: runtime.actionId,
+      actionName: runtime.actionName ?? runtime.actionId,
+      command: runtime.actionCommand ?? "",
+      status: runtime.actionStatus,
+      pid: runtime.actionPid,
+      startedAt,
+      exitedAt: runtime.actionExitedAt,
+      exitCode: runtime.actionExitCode,
+      exitSignal: runtime.actionExitSignal,
+      durationMs: runtime.actionDurationMs,
+      output: runtime.actionOutput,
+    },
+  ];
+}
+
+/**
+ * Apply a single update to the action-runs list, capped at the configured
+ * maximum. When a new run is appended and the cap is exceeded, the oldest
+ * non-running entry is evicted; "started" runs are never evicted so users
+ * never silently lose track of a live action even if they queue many.
+ */
+export function applyCodexEnvironmentActionRunUpdate(
+  current: CodexEnvironmentActionRun[],
+  update:
+    | { kind: "append"; run: CodexEnvironmentActionRun }
+    | { kind: "patch"; runId: string; patch: Partial<CodexEnvironmentActionRun> },
+): CodexEnvironmentActionRun[] {
+  if (update.kind === "append") {
+    const next = [...current, update.run];
+    while (next.length > CODEX_ENVIRONMENT_ACTION_RUNS_MAX) {
+      const evictIndex = next.findIndex((run) => run.status !== "started");
+      if (evictIndex === -1) break;
+      next.splice(evictIndex, 1);
+    }
+    return next;
+  }
+  const idx = current.findIndex((run) => run.runId === update.runId);
+  if (idx === -1) return current;
+  const next = [...current];
+  next[idx] = { ...next[idx], ...update.patch };
+  return next;
+}

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -124,6 +124,30 @@ export type CodexEnvironmentAction = {
   command: string;
 };
 
+/**
+ * A single invocation of a Codex environment action. Multiple runs can be
+ * alive at once on the same thread (e.g. "Start" + "E2E Tests" + "Unit
+ * Tests" running in parallel). Each run has a unique `runId` so output
+ * snapshots and exit events can be attributed to the right invocation
+ * even when the run order interleaves.
+ */
+export type CodexEnvironmentActionRun = {
+  /** Unique per invocation. Generated at action-start time in the backend. */
+  runId: string;
+  /** Which configured action this is a run of (matches CodexEnvironmentAction.id). */
+  actionId: string;
+  actionName: string;
+  command: string;
+  status: "started" | "exited" | "failed";
+  pid?: number;
+  startedAt: number;
+  exitedAt?: number;
+  exitCode?: number;
+  exitSignal?: string;
+  durationMs?: number;
+  output?: string;
+};
+
 export type CodexThreadEnvironmentRuntime = {
   environmentId: string;
   environmentName: string;
@@ -143,19 +167,48 @@ export type CodexThreadEnvironmentRuntime = {
   setupExitCode?: number;
   setupDurationMs?: number;
   actions?: CodexEnvironmentAction[];
-  actionId?: string;
-  actionName?: string;
-  actionCommand?: string;
-  actionStatus?: "started" | "exited" | "failed";
-  actionPid?: number;
-  actionStartedAt?: number;
-  actionExitedAt?: number;
-  actionExitCode?: number;
-  actionExitSignal?: string;
-  actionDurationMs?: number;
-  actionOutput?: string;
+  /**
+   * Live + recently-finished action invocations on this thread, oldest
+   * first. Multiple runs can be present simultaneously when parallel
+   * actions (Start + Test, E2E + Unit, etc.) are kicked off. Capped
+   * server-side; oldest non-running entries are evicted first when the
+   * cap is exceeded.
+   */
+  actionRuns?: CodexEnvironmentActionRun[];
   sourcePath?: string;
+
+  // --- Legacy fields, preserved for read-compatibility with overlay rows
+  // persisted before the multi-instance refactor. NEW code MUST NOT read
+  // these; on read, BackendRegistry normalises them into a synthesised
+  // single-element actionRuns array. They are not written by current
+  // code, so they will eventually disappear from disk as runtimes get
+  // rewritten.
+  /** @deprecated read via `actionRuns` */
+  actionId?: string;
+  /** @deprecated read via `actionRuns` */
+  actionName?: string;
+  /** @deprecated read via `actionRuns` */
+  actionCommand?: string;
+  /** @deprecated read via `actionRuns` */
+  actionStatus?: "started" | "exited" | "failed";
+  /** @deprecated read via `actionRuns` */
+  actionPid?: number;
+  /** @deprecated read via `actionRuns` */
+  actionStartedAt?: number;
+  /** @deprecated read via `actionRuns` */
+  actionExitedAt?: number;
+  /** @deprecated read via `actionRuns` */
+  actionExitCode?: number;
+  /** @deprecated read via `actionRuns` */
+  actionExitSignal?: string;
+  /** @deprecated read via `actionRuns` */
+  actionDurationMs?: number;
+  /** @deprecated read via `actionRuns` */
+  actionOutput?: string;
 };
+
+/** Maximum entries kept in `actionRuns`. Running entries are never evicted. */
+export const CODEX_ENVIRONMENT_ACTION_RUNS_MAX = 10;
 
 export type AppServerThreadTitleSource = "explicit" | "derived" | "fallback";
 export type AppServerThreadStatus = "active" | "idle" | "notLoaded" | "unknown";

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -146,8 +146,14 @@ export type CodexThreadEnvironmentRuntime = {
   actionId?: string;
   actionName?: string;
   actionCommand?: string;
-  actionStatus?: "started" | "failed";
+  actionStatus?: "started" | "exited" | "failed";
   actionPid?: number;
+  actionStartedAt?: number;
+  actionExitedAt?: number;
+  actionExitCode?: number;
+  actionExitSignal?: string;
+  actionDurationMs?: number;
+  actionOutput?: string;
   sourcePath?: string;
 };
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./contracts/normalized-app-server";
+export * from "./codex-environment-action-runs";
 export * from "./contracts/backend";
 export * from "./contracts/agent";
 export * from "./contracts/branch-drift";


### PR DESCRIPTION
## Summary

When the Codex environment setup script fails during worktree creation, or an env-action run-button command (e.g., `pnpm dev` for PwrSnap) fails afterwards, the failure has been effectively invisible:

- the failure dialog dropped the streaming output the moment status flipped to "failed";
- env-action commands ran detached with `stdio: "ignore"`, so detached children that exited non-zero left no trace at all;
- only spawn errors were logged — non-zero exit codes, timeouts, and the catch sites in `applyLocalCodexEnvironmentSelection` / `startLocalCodexEnvironmentAction` were silent at `error` level;
- shell-env hydration (`mergeLoginShellEnvIntoEnv`) silently fell back to the raw Finder env when the interactive login shell couldn't be exec'd, which is a likely root cause of "works from terminal, fails from Finder."

This change makes those failure modes legible, without yet attempting the root-cause fix — once a real failure now hits a built bundle, the new log lines and retained output will tell us _which_ piece is broken.

## What's in the change

- **`codex-environment-runtime.ts`** — log non-zero exits, timeouts, and caught setup/action errors at `error` level with phase + command + cwd + truncated output. Detached children now pipe stdout/stderr so failures can be logged and a new `onDetachedExit` callback fires when the child eventually closes. Adds `actionStatus: "exited"`, `actionStartedAt`, `actionExitedAt`, `actionExitCode`, `actionExitSignal`, `actionDurationMs`, `actionOutput` to `CodexThreadEnvironmentRuntime`.
- **`backend-registry.ts`** — wires `onDetachedExit` from both the worktree-create path (`materializeDirectoryLaunchpad`, with a small queue to absorb exits that fire before `startThread` returns a threadId) and the run-button path (`runCodexEnvironmentAction`). New `handleCodexEnvironmentActionDetachedExit` patches the overlay runtime with exit fields and emits `thread/codexEnvironment/updated` so the renderer refreshes.
- **`shell-environment.ts`** — logs whether interactive-login-shell hydration succeeded (`login-shell-env-merged` with PATH lengths + nvm/Homebrew presence) or failed (`login-shell-env-resolve-failed` with per-candidate failure messages, then `login-shell-env-merge-empty` showing what un-hydrated env was kept).
- **`ThreadView.tsx` + `app.css`** — the "setup failed — continue or delete worktree" dialog now keeps the streaming output visible as a collapsible details block (command, path, exit code, monospace output) instead of dropping everything but the message.
- **`Composer.tsx` + `app.css`** — new `EnvActionAnchor` component above the composer (mirrors the `.composer__queued` primitive). Shows the env-action runtime when status is `started` / `exited` / `failed`: status pill, action name, command, pid + elapsed/exit info, and a collapsible ring-buffered (~500 line) output tray. Persists after exit; dismiss button keyed by run identity so a fresh run replaces it.

## Test plan

- [x] `pnpm test apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts` — 8/8 pass (unchanged semantics for the existing detach/setup/timeout cases)
- [x] `pnpm test apps/desktop/src/main/__tests__/shell-environment.test.ts` — 4/4 pass
- [x] `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts` — passes alongside env-runtime tests (114 combined)
- [x] `pnpm lint:boundaries` — clean
- [x] `pnpm lint:sql` — clean
- [x] `pnpm --filter @pwragent/desktop typecheck` + `pnpm --filter @pwragent/shared typecheck` — clean
- [x] Reproduce the original failure (PwrSnap env setup from a Finder-launched build) on the new build and confirm:
  - `~/Library/Logs/PwrAgent/main.log` shows `codex-environment-setup-failed` (or `codex-environment-detached-failed`) with stderr in the `output` field
  - `login-shell-env-merged` vs `login-shell-env-merge-empty` tells us whether shell hydration is the culprit
  - the setup-failure dialog retains the captured output, collapsible
  - clicking the env-action run button on an existing thread surfaces the live/exit output in the composer anchor
- [x] Follow-up PR: root-cause fix once the new log lines pinpoint where hydration / spawn is going wrong on Finder-launched bundles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)