### PR TITLE
fix(desktop): headline env-command exit errors with combined stdout+stderr tail

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
@@ -311,6 +311,52 @@ describe("codex environment runtime", () => {
     }
   });
 
+  it("includes the tail of stdout in the exit error when the failing command writes its diagnostic to stdout", async () => {
+    // Reproduces the pnpm/vite/npm pattern: an earlier command in the
+    // script left a benign message on stderr (here mimicked with `echo
+    // ... >&2`), then the final command writes its actual error to stdout
+    // and exits non-zero. The exit error suffix must surface the stdout
+    // diagnostic, not the unrelated stderr chatter, so the failure dialog
+    // and main.log line point at the real cause.
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-env-stdout-error-"));
+    try {
+      let error: unknown;
+      try {
+        await applyLocalCodexEnvironmentSelection({
+          cwd: root,
+          env: {
+            ...process.env,
+            SHELL: "/bin/sh",
+          },
+          selection: {
+            environment: {
+              id: "env",
+              name: "Env",
+              sourcePath: path.join(root, "environment.toml"),
+              setupScript: [
+                "echo 'unrelated benign chatter' 1>&2",
+                "echo 'ERR_PNPM_IGNORED_BUILDS the actual reason for exit 1'",
+                "exit 1",
+              ].join("\n"),
+              actions: [],
+            },
+            executionTarget: "local",
+            setupEnabled: true,
+          },
+        });
+      } catch (caught) {
+        error = caught;
+      }
+
+      expect(error).toBeDefined();
+      expect((error as { message?: string }).message).toContain(
+        "ERR_PNPM_IGNORED_BUILDS the actual reason for exit 1",
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("times out setup commands that do not finish", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-env-timeout-"));
 

--- a/apps/desktop/src/main/app-server/codex-environment-runtime.ts
+++ b/apps/desktop/src/main/app-server/codex-environment-runtime.ts
@@ -8,12 +8,41 @@ import { getMainLogger } from "../log";
 const environmentRuntimeLog = getMainLogger("pwragent:codex-environment-runtime");
 
 const MAX_OUTPUT_PREVIEW_CHARS = 4_000;
+const EXIT_ERROR_SUFFIX_LINES = 8;
 
 function truncateForLog(value: string | undefined): string | undefined {
   if (!value) return value;
   const trimmed = value.trim();
   if (trimmed.length <= MAX_OUTPUT_PREVIEW_CHARS) return trimmed;
   return `${trimmed.slice(0, MAX_OUTPUT_PREVIEW_CHARS)}…[truncated ${trimmed.length - MAX_OUTPUT_PREVIEW_CHARS} chars]`;
+}
+
+/**
+ * Build the suffix attached to `Codex environment command exited with N`.
+ *
+ * Modern CLIs (pnpm, vite, npm, corepack) commonly print fatal errors on
+ * stdout, not stderr — so the previous "stderr.trim() only" suffix would
+ * misleadingly headline an exit failure with whatever stale chatter the
+ * earlier command in a multi-line setup script happened to leave in the
+ * stderr buffer (e.g. nvm's "v24.14.1 is already installed" trailing a
+ * pnpm install that exited 1 with ERR_PNPM_IGNORED_BUILDS on stdout).
+ *
+ * The fix: include the tail of the combined stdout+stderr buffer, the way
+ * a user running the script in a terminal would have seen it. The full
+ * output is still preserved on `CodexEnvironmentCommandError.output` for
+ * the dialog's collapsible details — this is just the headline.
+ */
+function buildExitErrorSuffix(stdout: string, stderr: string): string {
+  const combined = [stdout.trimEnd(), stderr.trimEnd()]
+    .filter(Boolean)
+    .join("\n");
+  if (!combined) return "";
+  const lines = combined.split("\n");
+  const tail =
+    lines.length <= EXIT_ERROR_SUFFIX_LINES
+      ? combined
+      : lines.slice(-EXIT_ERROR_SUFFIX_LINES).join("\n");
+  return `: ${tail}`;
 }
 
 export const DEFAULT_CODEX_ENVIRONMENT_SETUP_TIMEOUT_MS = 10 * 60 * 1_000;
@@ -570,7 +599,7 @@ function runShellCommand(
         cwd: params.cwd,
         output: truncateForLog(combinedOutput),
       });
-      const suffix = stderr.trim() ? `: ${stderr.trim()}` : "";
+      const suffix = buildExitErrorSuffix(stdout, stderr);
       settle(() => {
         reject(
           new CodexEnvironmentCommandError(


### PR DESCRIPTION
## Summary

Stacked on top of #505.

When an env-setup command exits non-zero, the headline attached to `CodexEnvironmentCommandError` (and to the failure dialog the user reads) used to be `: <stderr.trim()>` only. Modern CLIs — pnpm, vite, npm, corepack — commonly print their fatal errors on stdout instead of stderr, so the stderr buffer at exit time is often either empty or full of stale chatter from an earlier command in a multi-line setup script.

The motivating case (uncovered the moment #505 landed locally):

- PwrSnap's setup script is `nvm install` + `corepack enable` + `pnpm install`
- `pnpm install` exits 1 with `ERR_PNPM_IGNORED_BUILDS` printed to stdout
- stderr at exit time still contains `nvm install`'s benign trailing line `v24.14.1 is already installed.`
- so the dialog headline read `Codex environment command exited with 1: v24.14.1 is already installed.` and pointed at the wrong command

The fix uses the tail of the combined stdout+stderr buffer (the way a user running the script in a terminal would have seen it), capped at the last 8 lines. The full output stays on `CodexEnvironmentCommandError.output` and feeds the dialog's collapsible details block introduced in #505 — this PR only changes the *headline*.

## What's in the change

- `codex-environment-runtime.ts` — extracts a small `buildExitErrorSuffix(stdout, stderr)` helper that joins the two stream buffers (stdout first, then stderr) and surfaces their combined last ~8 lines. Replaces the inline `stderr.trim() ? ... : ""` suffix in the non-zero-exit `close` handler.
- `codex-environment-runtime.test.ts` — new test reproduces the pnpm pattern: an earlier `echo ... >&2` (benign stderr) followed by a real `echo 'ERR_...' ; exit 1` whose diagnostic only ever hits stdout. The test asserts that the thrown error's `message` contains the stdout diagnostic.

## Test plan

- [x] `pnpm test apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts` — 9/9 pass (1 new + 8 unchanged)
- [x] `pnpm --filter @pwragent/desktop typecheck` — clean
- [ ] Follow-up smoke test once #505 lands and the user re-runs the PwrSnap worktree-create: the dialog headline should now read `… exited with 1: <pnpm error tail>` instead of pointing at nvm chatter.

## Stacking note

Base is `optimistic-engelbart-32f30c` (PR #505). After #505 merges, GitHub will retarget this PR's base to `main` automatically. Reviewers can merge in order, or review this PR's diff in isolation against #505's tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)