### PR TITLE
fix(desktop): env-setup-failure dialog respects column width and stays selectable

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1984,58 +1984,58 @@ export function ThreadView(props: ThreadViewProps) {
         onOpenMessagingActivity={props.onOpenMessagingActivity}
       />
 
-      {showSetupFailureChoice && selectedThread && selectedThreadKey ? (
-        <EnvironmentSetupFailureChoice
-          archiving={setupFailureArchiving}
-          continuing={setupFailureContinuing}
-          command={
-            selectedThreadEnvironmentFailurePhase === "action"
-              ? selectedThread.codexEnvironmentRuntime?.actionCommand
-              : selectedThread.codexEnvironmentRuntime?.setupCommand ??
-                launchpadSetupProgress?.command
-          }
-          cwd={
-            selectedThread.codexEnvironmentRuntime?.cwd ??
-            launchpadSetupProgress?.cwd
-          }
-          environmentName={
-            selectedThread.codexEnvironmentRuntime?.environmentName ??
-            "Codex environment"
-          }
-          error={props.archiveThreadError ?? setupFailureContinueError}
-          exitCode={
-            selectedThreadEnvironmentFailurePhase === "setup"
-              ? selectedThread.codexEnvironmentRuntime?.setupExitCode ??
-                launchpadSetupProgress?.exitCode
-              : undefined
-          }
-          hasWorktree={Boolean(selectedThreadWorktree)}
-          output={
-            selectedThreadEnvironmentFailurePhase === "setup"
-              ? selectedThread.codexEnvironmentRuntime?.setupOutput ??
-                launchpadSetupProgress?.output
-              : undefined
-          }
-          phase={selectedThreadEnvironmentFailurePhase}
-          onCleanup={() => {
-            if (!props.onArchiveThread) {
-              return;
-            }
-            setSetupFailureArchiving(true);
-            void props.onArchiveThread(selectedThread).finally(() => {
-              setSetupFailureArchiving(false);
-            });
-          }}
-          onContinue={continueAfterSetupFailure}
-        />
-      ) : null}
-
       <div
         className={`thread-view__layout${
           contextRailEffectivePinned ? " has-pinned-context-rail" : ""
         }${contextRailResizing ? " is-resizing-context-rail" : ""}`}
       >
         <div className="thread-view__primary">
+          {showSetupFailureChoice && selectedThread && selectedThreadKey ? (
+            <EnvironmentSetupFailureChoice
+              archiving={setupFailureArchiving}
+              continuing={setupFailureContinuing}
+              command={
+                selectedThreadEnvironmentFailurePhase === "action"
+                  ? selectedThread.codexEnvironmentRuntime?.actionCommand
+                  : selectedThread.codexEnvironmentRuntime?.setupCommand ??
+                    launchpadSetupProgress?.command
+              }
+              cwd={
+                selectedThread.codexEnvironmentRuntime?.cwd ??
+                launchpadSetupProgress?.cwd
+              }
+              environmentName={
+                selectedThread.codexEnvironmentRuntime?.environmentName ??
+                "Codex environment"
+              }
+              error={props.archiveThreadError ?? setupFailureContinueError}
+              exitCode={
+                selectedThreadEnvironmentFailurePhase === "setup"
+                  ? selectedThread.codexEnvironmentRuntime?.setupExitCode ??
+                    launchpadSetupProgress?.exitCode
+                  : undefined
+              }
+              hasWorktree={Boolean(selectedThreadWorktree)}
+              output={
+                selectedThreadEnvironmentFailurePhase === "setup"
+                  ? selectedThread.codexEnvironmentRuntime?.setupOutput ??
+                    launchpadSetupProgress?.output
+                  : undefined
+              }
+              phase={selectedThreadEnvironmentFailurePhase}
+              onCleanup={() => {
+                if (!props.onArchiveThread) {
+                  return;
+                }
+                setSetupFailureArchiving(true);
+                void props.onArchiveThread(selectedThread).finally(() => {
+                  setSetupFailureArchiving(false);
+                });
+              }}
+              onContinue={continueAfterSetupFailure}
+            />
+          ) : null}
+
           <section className="transcript-panel" aria-label="Transcript">
             <TranscriptList
               entries={props.transcriptEntries}

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -4764,11 +4764,15 @@ textarea,
 
 .environment-setup-choice {
   display: flex;
+  flex-wrap: wrap;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 18px;
-  margin: 0 22px 12px;
+  gap: 12px 18px;
+  margin: 12px 22px;
   padding: 14px 16px;
+  /* Stay inside the transcript column even when the context rail is pinned. */
+  max-width: 100%;
+  box-sizing: border-box;
   border: 1px solid var(--danger-border);
   border-radius: 8px;
   background: var(--danger-soft);
@@ -4776,7 +4780,7 @@ textarea,
 }
 
 .environment-setup-choice__body {
-  flex: 1 1 auto;
+  flex: 1 1 360px;
   min-width: 0;
   display: flex;
   flex-direction: column;
@@ -4806,6 +4810,8 @@ textarea,
 
 .environment-setup-choice__details {
   margin: 0;
+  width: 100%;
+  min-width: 0;
   border: 1px solid var(--surface-border);
   border-radius: 6px;
   background: var(--surface-raised);
@@ -4856,13 +4862,16 @@ textarea,
   font-size: 12px;
   line-height: 1.5;
   color: var(--text-primary);
-  white-space: pre-wrap;
-  word-break: break-word;
+  white-space: pre;
   overflow-x: auto;
+  /* Defensive: ensure the user can actually copy build output from the
+     dialog. Some upstream rules globally set user-select: none on chrome. */
+  user-select: text;
+  -webkit-user-select: text;
 }
 
 .environment-setup-choice__pre--output {
-  max-height: 280px;
+  max-height: 320px;
   overflow: auto;
 }
 
@@ -4871,13 +4880,16 @@ textarea,
   font-size: 12px;
   color: var(--text-secondary);
   word-break: break-all;
+  user-select: text;
+  -webkit-user-select: text;
 }
 
 .environment-setup-choice__actions {
   display: flex;
-  flex: 0 0 auto;
+  flex: 1 1 auto;
   flex-wrap: wrap;
   justify-content: flex-end;
+  align-self: flex-start;
   gap: 8px;
 }
 
@@ -7948,6 +7960,8 @@ textarea,
   color: var(--text-secondary);
   overflow-x: auto;
   white-space: nowrap;
+  user-select: text;
+  -webkit-user-select: text;
 }
 
 .composer__queued-env-action-details {
@@ -7973,7 +7987,7 @@ textarea,
 .composer__queued-env-action-output {
   margin: 0;
   padding: 6px 8px;
-  max-height: 260px;
+  max-height: 320px;
   overflow: auto;
   background: var(--surface);
   border: 1px solid var(--surface-border);
@@ -7982,8 +7996,9 @@ textarea,
   font-size: 12px;
   line-height: 1.5;
   color: var(--text-primary);
-  white-space: pre-wrap;
-  word-break: break-word;
+  white-space: pre;
+  user-select: text;
+  -webkit-user-select: text;
 }
 
 .composer__attachments {


### PR DESCRIPTION
## Summary

Stacked on top of #506 (which is stacked on #505). Addresses four UI bugs in the failure dialog #505 introduced, reported on a real reproduction of the PwrSnap pnpm-install failure:

1. **Dives under the right context rail** — the dialog sat as a sibling of `.thread-view__layout`, so it took the full thread-view width and ignored the pinned context rail. Buttons clipped under the rail.
2. **Doesn't stay inside the transcript area** — same root cause; bounded by `.thread-view` instead of `.thread-view__primary`.
3. **Text not selectable** — global chrome rules in some paths set `user-select: none` on the pre, making the build output (the one thing you actually want to copy when something exits 1 with a wall of warnings) impossible to select.
4. **Output area only half the available width** — the inner `<pre>` shrank because the dialog itself was overflowing; long swift/eslint compiler lines broke mid-path because of `pre-wrap` + `word-break: break-word`.

## Changes

- **`ThreadView.tsx`** — move `EnvironmentSetupFailureChoice` inside `.thread-view__primary`, above the transcript panel. Width is now bounded by the same column the transcript and composer live in, including when the context rail is pinned.
- **`app.css` (`.environment-setup-choice`)** — `max-width: 100%` + `box-sizing: border-box` so the dialog never overflows its column; `flex-wrap` lets the heading/output body and the action buttons wrap onto separate rows on narrow widths.
- **`app.css` (`__pre`, `__pre--output`, `__path`, `__details`)** — `white-space: pre` + `overflow-x: auto` (instead of `pre-wrap` + `word-break: break-word`) keeps long compiler/lint lines readable horizontally instead of breaking mid-path. `user-select: text` + `-webkit-user-select: text` defensively wins back text selection. Output `max-height` 280→320 so a typical failing-build tail fits.
- **`app.css` (`.composer__queued-env-action-output` / `__command`)** — same `white-space: pre` + selectable text fix for the sibling primitive in the composer's env-action anchor, since it has the same problem class.

## Test plan

- [x] `pnpm --filter @pwragent/desktop typecheck` — clean
- [x] `pnpm lint:boundaries` — clean
- [x] `pnpm test apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts` — 9/9 pass (unchanged; this PR is CSS + JSX placement only)
- [ ] After #505/#506/#507 land, smoke-test the actual repro again: dialog should stay inside the transcript column with the context rail pinned, output should be horizontally scrollable with full lines visible, and selecting + copying the output should work.

## Stacking

Base is `fix/desktop-env-error-includes-stdout-tail` (#506). After both #505 and #506 merge, GitHub will retarget this PR to `main` automatically. Reviewers should merge #505 → #506 → #507 (or use a merge queue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)