### PR TITLE
fix(desktop): LiveWorkRail sticky toggle pins flush with rail body top

### DIFF
--- a/apps/desktop/e2e/fixtures/live-work-rail-sticky-gap/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/live-work-rail-sticky-gap/replay.fixture.json
@@ -1,0 +1,123 @@
+{
+  "metadata": {
+    "backend": "codex",
+    "scenario": "live-work-rail-sticky-gap",
+    "threadId": "thread-live-work-rail-sticky-gap"
+  },
+  "steps": [
+    {
+      "id": "initialize-1",
+      "kind": "response",
+      "method": "initialize",
+      "result": {
+        "serverInfo": {
+          "name": "Replay Codex",
+          "version": "1.0.0"
+        },
+        "methods": [
+          "thread/list",
+          "thread/read",
+          "skills/list",
+          "turn/start"
+        ]
+      }
+    },
+    {
+      "id": "thread-list-1",
+      "kind": "response",
+      "method": "thread/list",
+      "result": [
+        {
+          "id": "thread-live-work-rail-sticky-gap",
+          "title": "LiveWorkRail sticky-gap replay",
+          "titleSource": "explicit",
+          "summary": "Replay seeded with a long single-file diff to force rail-body overflow + sticky scrolling",
+          "source": "codex",
+          "executionMode": "default",
+          "linkedDirectories": [],
+          "inbox": {
+            "inInbox": true,
+            "reason": "new-thread"
+          },
+          "updatedAt": 1776563600000
+        }
+      ]
+    },
+    {
+      "id": "thread-read-1",
+      "kind": "response",
+      "method": "thread/read",
+      "result": {
+        "entries": [
+          {
+            "type": "message",
+            "id": "message-1",
+            "role": "assistant",
+            "text": "Ready for the next rail check."
+          }
+        ],
+        "messages": [
+          {
+            "id": "message-1",
+            "role": "assistant",
+            "text": "Ready for the next rail check."
+          }
+        ],
+        "lastAssistantMessage": "Ready for the next rail check.",
+        "pagination": {
+          "supportsPagination": false,
+          "hasPreviousPage": false
+        }
+      }
+    },
+    {
+      "id": "turn-start-1",
+      "kind": "response",
+      "method": "turn/start",
+      "result": {
+        "threadId": "thread-live-work-rail-sticky-gap",
+        "turnId": "turn-sticky-1"
+      }
+    },
+    {
+      "id": "status-active-1",
+      "kind": "notification",
+      "notification": {
+        "method": "thread/status/changed",
+        "params": {
+          "threadId": "thread-live-work-rail-sticky-gap",
+          "status": {
+            "type": "active",
+            "activeFlags": []
+          }
+        }
+      }
+    },
+    {
+      "id": "turn-started-1",
+      "kind": "notification",
+      "notification": {
+        "method": "turn/started",
+        "params": {
+          "threadId": "thread-live-work-rail-sticky-gap",
+          "turn": {
+            "id": "turn-sticky-1",
+            "status": "inProgress"
+          }
+        }
+      }
+    },
+    {
+      "id": "turn-diff-updated-1",
+      "kind": "notification",
+      "notification": {
+        "method": "turn/diff/updated",
+        "params": {
+          "threadId": "thread-live-work-rail-sticky-gap",
+          "turnId": "turn-sticky-1",
+          "diff": "diff --git a/CHANGELOG.md b/CHANGELOG.md\n--- a/CHANGELOG.md\n+++ b/CHANGELOG.md\n@@ -1,3 +1,53 @@\n # Changelog\n \n+## v1.0.0-beta.3 - 2026-05-18\n+\n+- Added the LiveWorkRail above the composer for live edited-files\n+  tracking, with per-file inline diff expansion and a sticky file\n+  header so scrolling through long diffs keeps the collapse control\n+  reachable.\n+- Cleaned up desktop build noise by silencing Swift recorder warnings,\n+  removing redundant main-process dynamic imports, and allowing the\n+  ffmpeg installer postinstall script needed for release packaging.\n+- Updated the release workflow artifact actions to versions that run\n+  on the Node.js 24 action runtime.\n+- Aligned the rail-level chevron with the [hidden] attribute so\n+  collapsing the rail actually hides its body in real CSS engines\n+  (previously a flex display rule was silently overriding it).\n+- Merged the section-level heading text into the rail title so the\n+  summary count + line stats live on a single chevron-bearing line.\n+- Tightened the rail's width to match the composer's reading column\n+  via --chat-column-max so the edges line up visually across the\n+  primary chat surface.\n+- Dropped redundant aria-labels on inner section elements that\n+  duplicated the rail-level complementary landmark name.\n+- Switched idle file-toggle background to --bg-panel so rows sit\n+  visually inside the rail card instead of merging flush with its\n+  --bg-panel-elevated chrome.\n+- Gated the editedFilesEntry on having at least one diff-bearing\n+  detail so a malformed entry can't claim a title without\n+  rendering anything below it.\n+- Routed the persisted activity diff through deferLiveTranscriptEntry\n+  on turn/completed so the transcript receives a single canonical\n+  copy instead of double-rendering against the rail's pending\n+  snapshot.\n+- Locked in the merged-title shape with new vitest cases covering\n+  the comma-join logic, the empty-fileDiff guard, and the rail's\n+  pinned-to-last-turn snapshot lifecycle.\n+- Added new Playwright e2e cases that exercise the chevron toggle,\n+  per-file expansion, and title rendering inside Electron's real\n+  CSS engine so display:flex vs [hidden] regressions can't sneak in\n+  the way they did the first time.\n+- Replaced the in-transcript Edited N files rows with the rail's\n+  cumulative summary plus per-file expansion so the user no longer\n+  sees the same file in two competing surfaces during an active\n+  turn.\n+- Improved sticky positioning so the file-toggle header pins to\n+  the very top of the rail's scroll viewport with no leftover\n+  padding gap.\n+\n ## v1.0.0-beta.2 - 2026-05-18\n \n - Fixed universal macOS release packaging so the prebuilt window-list helper\n"
+        }
+      }
+    }
+  ]
+}

--- a/apps/desktop/e2e/live-work-rail-sticky-gap.spec.ts
+++ b/apps/desktop/e2e/live-work-rail-sticky-gap.spec.ts
@@ -1,0 +1,127 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "@playwright/test";
+import { launchElectronApp } from "./fixtures/electron-app";
+
+const specDir = path.dirname(fileURLToPath(import.meta.url));
+
+// Asserts the sticky file-toggle pins flush with the rail body's top
+// edge (no leftover padding gap). Before this fix, `.live-work-rail__body`
+// had `padding: 8px`, so `position: sticky; top: 0` engaged at the
+// content-edge top — 8px below the rail header's border-bottom. Visually
+// that produced a strip of empty rail-card background between the
+// header divider and the sticky toggle when scrolling through a long
+// diff.
+test("LiveWorkRail sticky file-toggle pins flush with the rail body's top edge", async () => {
+  const app = await launchElectronApp({
+    fixturePath: path.resolve(
+      specDir,
+      "fixtures/live-work-rail-sticky-gap/replay.fixture.json"
+    ),
+    // Force a narrow viewport so the long diff overflows the rail
+    // body even on a tall monitor. Rail max-height is min(38vh, 360px)
+    // so this guarantees overflow regardless of host display size.
+    windowSize: { width: 1280, height: 720 },
+  });
+
+  try {
+    await app.window
+      .getByRole("button", { name: /LiveWorkRail sticky-gap replay/i })
+      .first()
+      .click();
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "LiveWorkRail sticky-gap replay",
+      })
+    ).toBeVisible();
+
+    await app.window
+      .getByLabel("Reply")
+      .fill("Drop in a long changelog entry to force rail-body scroll.");
+    await app.window.getByRole("button", { name: "Send" }).click();
+    await app.advance({ stepId: "status-active-1" });
+    await app.advance({ stepId: "turn-started-1" });
+    await app.advance({ stepId: "turn-diff-updated-1" });
+
+    // Expand the file so its diff body becomes the scrollable region.
+    const rail = app.window.getByRole("complementary", { name: /Edited 1 file/i });
+    const fileToggle = rail.getByRole("button", { name: /Update CHANGELOG\.md/i });
+    await fileToggle.click();
+    await expect(fileToggle).toHaveAttribute("aria-expanded", "true");
+
+    // Scroll inside the rail body so the file-toggle engages sticky.
+    const railBody = rail.locator("css=.live-work-rail__body");
+    await railBody.evaluate((el) => {
+      el.scrollTop = 200;
+    });
+
+    // After scrolling, the toggle should pin at the same top
+    // coordinate as the body's content area's top edge (= the body's
+    // border-edge top, since we removed the body's padding-top in
+    // the fix). Before the fix the toggle would pin 8px below.
+    const toggleTop = await fileToggle.evaluate(
+      (el) => el.getBoundingClientRect().top,
+    );
+    const bodyTop = await railBody.evaluate(
+      (el) => el.getBoundingClientRect().top,
+    );
+
+    // Allow 1px slack for sub-pixel rounding.
+    expect(Math.abs(toggleTop - bodyTop)).toBeLessThanOrEqual(1);
+  } finally {
+    await app.close();
+  }
+});
+
+// Inspect-style spec that captures a screenshot for visual review.
+// Gated behind the same PWRAGENT_SCREENSHOT_CAPTURE env var the other
+// inspect specs use; not run in CI.
+test.describe("inspect", () => {
+  test.skip(
+    !process.env.PWRAGENT_RAIL_INSPECT,
+    "Set PWRAGENT_RAIL_INSPECT=1 to capture screenshots locally.",
+  );
+
+  test("screenshot the rail with a long diff scrolled into the middle", async () => {
+    const app = await launchElectronApp({
+      fixturePath: path.resolve(
+        specDir,
+        "fixtures/live-work-rail-sticky-gap/replay.fixture.json"
+      ),
+      windowSize: { width: 1280, height: 720 },
+    });
+
+    try {
+      await app.window
+        .getByRole("button", { name: /LiveWorkRail sticky-gap replay/i })
+        .first()
+        .click();
+      await app.window
+        .getByLabel("Reply")
+        .fill("Drop in a long changelog entry to force rail-body scroll.");
+      await app.window.getByRole("button", { name: "Send" }).click();
+      await app.advance({ stepId: "status-active-1" });
+      await app.advance({ stepId: "turn-started-1" });
+      await app.advance({ stepId: "turn-diff-updated-1" });
+
+      const rail = app.window.getByRole("complementary", {
+        name: /Edited 1 file/i,
+      });
+      await rail.getByRole("button", { name: /Update CHANGELOG\.md/i }).click();
+      const railBody = rail.locator("css=.live-work-rail__body");
+      await railBody.evaluate((el) => {
+        el.scrollTop = 200;
+      });
+
+      await app.window.screenshot({
+        path: path.resolve(
+          specDir,
+          "../test-results/live-work-rail-sticky-gap.png",
+        ),
+      });
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -6128,9 +6128,22 @@ textarea,
   display: flex;
   flex-direction: column;
   gap: 8px;
-  padding: 8px;
+  /* Horizontal + bottom padding only. `position: sticky; top: 0` on
+     the file-toggle pins to the body's content-box top edge, so any
+     padding-top here pushes the stuck toggle that many pixels down
+     the rail card and leaves a band of bg-panel-elevated visible
+     between the rail header divider and the sticky toggle. The 8px
+     of breathing room above the first child is restored via
+     `> *:first-child { margin-block-start: 8px }` below — that
+     margin scrolls with the content, so the non-scrolled state
+     stays inset and the scrolled state pins flush. */
+  padding: 0 8px 8px;
   overflow-y: auto;
   min-height: 0;
+}
+
+.live-work-rail__body > *:first-child {
+  margin-block-start: 8px;
 }
 
 /* The `display: flex` rule above defeats the [hidden] attribute's


### PR DESCRIPTION
Follow-up to #510. User-observed: when scrolling through a long expanded diff, the sticky file-toggle header sat ~8px below the rail header's divider, leaving a visible strip of empty `--bg-panel-elevated` between the rail chrome and the toggle.

Confirmed by capturing the before-state with a Playwright inspect screenshot, then assertion-tested by comparing `getBoundingClientRect()` of the toggle against the rail body — the gap was an exact 8px.

## Root cause

`.live-work-rail__body` had `padding: 8px`. `position: sticky; top: 0` engages at the body's **content-box top edge** — that's *inside* the padding, 8px below the body's border-edge top. The padding-top became visible permanently as a strip of card background between the header divider and the stuck toggle.

## Fix

Drop the body's `padding-top` (keep horizontal + bottom) and restore the visual 8px breathing room above the first child via `margin-block-start`. The margin scrolls with the content, so:

- **Non-scrolled**: first child still sits 8px below the divider, same as before.
- **Scrolled**: the margin scrolls past; sticky toggle pins at `top: 0` of the body's border edge — flush with the divider, no gap.

```diff
 .live-work-rail__body {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  padding: 8px;
+  padding: 0 8px 8px;
   overflow-y: auto;
   min-height: 0;
 }
+
+.live-work-rail__body > *:first-child {
+  margin-block-start: 8px;
+}
```

## Tests

### New regression test (e2e, Electron-only)

`apps/desktop/e2e/live-work-rail-sticky-gap.spec.ts` asserts the toggle's `getBoundingClientRect().top` matches the rail body's within 1px after scrolling. Verified to catch the regression — pre-fix the test reported exactly `Received: 8` at the assertion line. Post-fix passes flush.

### New fixture

`apps/desktop/e2e/fixtures/live-work-rail-sticky-gap/replay.fixture.json` carries a ~46-line single-file CHANGELOG.md diff so the rail body actually overflows and the sticky behavior gets exercised regardless of viewport size.

### Inspect-only screenshot helper

A sibling test gated behind `PWRAGENT_RAIL_INSPECT=1` captures the rail state to `apps/desktop/test-results/live-work-rail-sticky-gap.png` for visual review:

```bash
PWRAGENT_RAIL_INSPECT=1 pnpm --filter @pwragent/desktop test:e2e -- \
  e2e/live-work-rail-sticky-gap.spec.ts -g "screenshot the rail"
```

I used it locally to confirm the visual before + after:

- **Before fix**: 8px band of `--bg-panel-elevated` between the divider and "Update CHANGELOG.md".
- **After fix**: toggle sits directly under the divider — no gap.

## Verification

| Check | Result |
|---|---|
| `pnpm --filter @pwragent/desktop typecheck` | clean |
| `pnpm lint:colors` | clean (no token changes) |
| `pnpm lint:boundaries` | clean (1243 modules) |
| `pnpm test apps/desktop/src/renderer/` | 689 / 689 |
| `pnpm --filter @pwragent/desktop test:e2e` | **121 / 121** (29 inspect-only skipped) |

## Test plan

- [x] Unit + e2e suites green
- [x] Regression test confirmed to catch the gap (8px before fix, ≤1px after)
- [x] Manual: in a thread that produces a long cumulative diff (or use the new replay fixture), expand a file and scroll — confirm the sticky file header sits flush with the rail header's divider with no visible card-background strip between them

🤖 Generated with [Claude Code](https://claude.com/claude-code)