### PR TITLE
fix(desktop): allow text selection in env-setup transcript pane

### DIFF
--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5314,6 +5314,11 @@ textarea,
   min-height: 0;
   padding: 0;
   text-align: left;
+  /* Defensive: the global .app-shell rule disables selection on chrome,
+     but env-setup output (command, path, stdout/stderr) must be copyable
+     while the run is still in progress. */
+  user-select: text;
+  -webkit-user-select: text;
 }
 
 .launchpad-pending__header {


### PR DESCRIPTION
## Summary
- The global `.app-shell` rule sets `user-select: none` across the renderer, and the "Preparing transcript" pane (`.launchpad-pending--setup`, shown while env setup is still running) had no override — so PATH, COMMAND, and OUTPUT text was not selectable or copyable.
- Adds a defensive `user-select: text` (+ `-webkit-` prefix) override on `.launchpad-pending--setup`, mirroring the existing override on `.environment-setup-choice__pre` used by the post-failure dialog.

## Test plan
- [ ] `pnpm dev` (or `pnpm dev:no-messaging`), launch a thread that triggers environment setup
- [ ] While the COMMAND/OUTPUT is still streaming (RUNNING pill visible), drag-select inside the COMMAND block and copy — verify clipboard contents
- [ ] Same for the OUTPUT block (during streaming, before completion)
- [ ] Also verify PATH value at the top of the pane is selectable
- [ ] Confirm no regression: the rest of the renderer chrome (sidebar rows, titlebar) still resists drag-selection as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)