### PR TITLE
ci: run lint:sql + lint:colors in the Lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,14 @@ jobs:
         timeout-minutes: 10
         run: pnpm licenses:check
 
+      - name: SQL template safety
+        timeout-minutes: 10
+        run: pnpm lint:sql
+
+      - name: Renderer color literals
+        timeout-minutes: 10
+        run: pnpm lint:colors
+
       - name: Type check
         timeout-minutes: 10
         run: pnpm typecheck


### PR DESCRIPTION
## Summary

The Lint workflow runs individual steps (`licenses:check`, `typecheck`, `depcruise`) rather than chaining through `pnpm lint`, so the `lint:sql` template-string scan AND the new `lint:colors` renderer color-literal scan were defined as package.json scripts but **never actually enforced by CI**.

Adds both as explicit steps in the Lint job, ordered after `licenses:check` and before `typecheck`.

## What was missing

| Script | What it catches | Was running in CI? |
|---|---|---|
| `pnpm lint:sql` | Interpolated SQL template strings in messaging / state persistence (security guard from `apps/desktop/CLAUDE.md`'s SQLite rules) | ❌ defined but unenforced |
| `pnpm lint:colors` | Raw hex / rgb / hsl literals outside `:root` / `:root[data-theme="..."]` in `app.css` (theming regression-prevention from #472 / #476) | ❌ added in PR #509 with the same gap |

Both were defined as `package.json` scripts and chained into `pnpm lint`. Locally `pnpm lint` runs everything; CI ran a subset.

## What's in the diff

Just adds two `run:` steps to `.github/workflows/ci.yml` in the `lint` job:

```yaml
- name: SQL template safety
  timeout-minutes: 10
  run: pnpm lint:sql

- name: Renderer color literals
  timeout-minutes: 10
  run: pnpm lint:colors
```

## Verification

Both pass on `main`:

```
$ pnpm lint:sql      → sql template lint passed
$ pnpm lint:colors   → renderer color lint passed
```

If either ever fails on a future PR, CI will block the merge rather than silently letting the regression land.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this is CI tooling, not production code. The next PR opened against this repo will exercise both new steps in its Lint job.

Refs #472, #476, #508

---

🤖 Generated with Claude Sonnet 4.5 (200K context) via [Claude Code](https://claude.com/claude-code)