### PR TITLE
test(desktop): E2E for cross-window appearance broadcast

### DIFF
--- a/apps/desktop/e2e/appearance-broadcast.spec.ts
+++ b/apps/desktop/e2e/appearance-broadcast.spec.ts
@@ -1,0 +1,144 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test, type Page } from "@playwright/test";
+import { launchElectronApp } from "./fixtures/electron-app";
+
+const specDir = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Cross-window appearance broadcast contract.
+ *
+ * When the user changes theme or density in Settings, the main process
+ * fans an `APPEARANCE_CHANGED_EVENT_CHANNEL` event out to every open
+ * BrowserWindow that subscribed (every window, currently). Each window's
+ * renderer applies the resolved `<html data-theme/data-density>`
+ * attributes from `main.tsx`. The main window also adopts via its
+ * useAppearance hook, but secondary windows have no React layer for
+ * appearance — they rely entirely on the broadcast to flip.
+ *
+ * Pre-existing unit coverage validates the settings-service callback
+ * fires correctly; this spec is the integration test that proves the
+ * IPC channel + per-window subscription + DOM apply work end-to-end
+ * across two BrowserWindow processes.
+ */
+test("broadcasts theme + density changes to a secondary window", async () => {
+  const app = await launchElectronApp({
+    fixturePath: path.resolve(specDir, "fixtures/smoke/replay.fixture.json"),
+  });
+
+  try {
+    // E2E default seeds dark theme + mission-control density (see
+    // `electron-app.ts`). Both windows should start there.
+    await expect.poll(() => readThemeAttribute(app.window)).toBe(null);
+    await expect.poll(() => readDensityAttribute(app.window)).toBe(null);
+
+    // Open the changelog window via the preload bridge. It's the
+    // simplest secondary window — no live messaging or polling deps,
+    // just reads the bundled CHANGELOG markdown. The window registers
+    // APPEARANCE_CHANGED_EVENT_CHANNEL so it should track theme changes
+    // we make in the main window.
+    await app.window.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (window as any).pwragent.openChangelogWindow();
+    });
+
+    const changelogWindow = await waitForWindowByUrlHash(app, "changelog");
+
+    // Both windows bootstrapped from the same TOML (dark default), so
+    // neither has data-theme set (bare :root carries dark in app.css).
+    await expect.poll(() => readThemeAttribute(changelogWindow)).toBe(null);
+    await expect.poll(() => readDensityAttribute(changelogWindow)).toBe(null);
+
+    // Drive a theme change from the main window via writeSettingsConfig.
+    // This is what Settings → General → Appearance does internally.
+    // After the write, the settings service fires onAppearanceChange
+    // which the production wiring routes to broadcastAppearanceChange,
+    // sending APPEARANCE_CHANGED_EVENT_CHANNEL to every subscriber.
+    await app.window.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (window as any).pwragent.writeSettingsConfig({
+        patch: {
+          general: { appearance: { theme: "light", density: "compact" } },
+        },
+      });
+    });
+
+    // Main window: useAppearance hook adopts the snapshot update on
+    // its own React state path. Verify it ends up applied to DOM.
+    await expect.poll(() => readThemeAttribute(app.window)).toBe("light");
+    await expect.poll(() => readDensityAttribute(app.window)).toBe("compact");
+
+    // Changelog window: no useAppearance hook — only path to update
+    // is the broadcast → main.tsx subscription → applyAppearanceAttributes.
+    // This is the assertion the broadcast wiring exists to make true.
+    await expect.poll(() => readThemeAttribute(changelogWindow)).toBe("light");
+    await expect
+      .poll(() => readDensityAttribute(changelogWindow))
+      .toBe("compact");
+
+    // Flip back to dark explicitly — verifies the broadcast handles
+    // both directions (not just one-way light-on). Using `"dark"`
+    // rather than `"system"` keeps the assertion deterministic: the
+    // CI runner's `matchMedia(prefers-color-scheme: light)` resolves
+    // differently across distros / Chromium versions, so `"system"`
+    // could land on either theme and the assertion would flake.
+    await app.window.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (window as any).pwragent.writeSettingsConfig({
+        patch: {
+          general: {
+            appearance: { theme: "dark", density: "mission-control" },
+          },
+        },
+      });
+    });
+
+    // Explicit dark → no data-theme attribute (the bare :root carries
+    // dark). Mission-control density is the bare default too.
+    await expect.poll(() => readThemeAttribute(app.window)).toBe(null);
+    await expect.poll(() => readDensityAttribute(app.window)).toBe(null);
+    await expect.poll(() => readThemeAttribute(changelogWindow)).toBe(null);
+    await expect.poll(() => readDensityAttribute(changelogWindow)).toBe(null);
+  } finally {
+    await app.close();
+  }
+});
+
+async function readThemeAttribute(page: Page): Promise<string | null> {
+  return await page.evaluate(() =>
+    document.documentElement.getAttribute("data-theme"),
+  );
+}
+
+async function readDensityAttribute(page: Page): Promise<string | null> {
+  return await page.evaluate(() =>
+    document.documentElement.getAttribute("data-density"),
+  );
+}
+
+/**
+ * Poll `electronApp.windows()` for a window whose URL contains the
+ * given hash. Mirrors the pattern in `readme-screenshots.inspect.spec.ts`
+ * — BrowserWindow is created with `show: false` so Playwright's
+ * `window` event fires before the URL has loaded; polling sidesteps
+ * the race.
+ */
+async function waitForWindowByUrlHash(
+  app: Awaited<ReturnType<typeof launchElectronApp>>,
+  hash: string,
+): Promise<Page> {
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    for (const candidate of app.electronApp.windows()) {
+      if (candidate.url().includes(`#${hash}`)) {
+        return candidate;
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+  throw new Error(
+    `Window with hash "#${hash}" did not open; current windows: ${app.electronApp
+      .windows()
+      .map((win) => win.url())
+      .join(", ")}`,
+  );
+}


### PR DESCRIPTION
## Summary

Closes the integration-test gap I flagged in my own review of PR #509. Pre-existing unit coverage validates the settings-service `onAppearanceChange` callback fires when a write touches `[general.appearance]`; this Playwright spec proves the **full chain** works end-to-end across two BrowserWindow processes:

```
writeSettingsConfig → TOML write → settings-service.onAppearanceChange
  → broadcastAppearanceChange
  → APPEARANCE_CHANGED_EVENT_CHANNEL fan-out
  → main.tsx subscription (in every window's renderer)
  → applyAppearanceAttributes
  → <html data-theme/data-density> flip
```

The main window also runs the React `useAppearance` hook adopting the snapshot update; the changelog window has **no React appearance layer** and updates purely through the broadcast — that's the assertion the broadcast wiring exists to make true.

## What the spec does

1. **Launch** with the smoke fixture (E2E default seeds dark + mission-control).
2. **Open** the changelog window via `desktopApi.openChangelogWindow()`. Picked changelog over messaging-activity because it has no live polling or messaging deps — just reads the bundled `CHANGELOG.md`.
3. **Confirm baseline** — both windows bootstrap to dark + mission-control (no `<html data-*>` attributes; bare `:root` carries those values in `app.css`).
4. **Write** `{ patch: { general: { appearance: { theme: \"light\", density: \"compact\" } } } }` from the main window's preload bridge.
5. **Assert** both windows poll-update to `<html data-theme=\"light\" data-density=\"compact\">`.
6. **Flip back** to explicit `theme: \"dark\"` (rather than `\"system\"` — `matchMedia(prefers-color-scheme: light)` on a CI runner is non-deterministic across Chromium versions, so using explicit dark keeps the assertion stable). Verify both windows drop the data-* attributes.

## Verification

Local run:

```
$ pnpm exec playwright test e2e/appearance-broadcast.spec.ts
Running 1 test using 1 worker

  ✓  1 e2e/appearance-broadcast.spec.ts:24:1 › broadcasts theme + density changes to a secondary window (2.9s)

  1 passed (3.3s)
```

Typecheck, lint:colors, lint:boundaries all green.

## Why now

Self-review of PR #509 flagged this as a real test-coverage gap. The unit test covers the service callback in isolation; the broadcast IPC + per-window subscription + DOM apply path wasn't exercised by any test until now.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this is test-only code that runs in CI alongside the other Playwright specs.

Refs #472, #476, #509

---

🤖 Generated with Claude Sonnet 4.5 (200K context) via [Claude Code](https://claude.com/claude-code)