### PR TITLE
feat(desktop): intellij idea and warp autodiscovery

### DIFF
--- a/apps/desktop/src/main/__tests__/application-discovery.test.ts
+++ b/apps/desktop/src/main/__tests__/application-discovery.test.ts
@@ -12,6 +12,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildGhosttyAppleScriptArgs,
+  discoverDesktopApplications,
   openDesktopApplication,
   resolveBundledApplicationCliPath,
 } from "../settings/application-discovery";
@@ -101,6 +102,73 @@ describe("application discovery", () => {
     expect(capture.request).toMatchObject({ targetPath, targetLine: 12 });
     expect(capture.invocation.command).toMatch(/code$/);
     expect(capture.invocation.args).toEqual(["--goto", `${targetPath}:12`]);
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("discovers IntelliJ IDEA from the idea launcher on PATH", async () => {
+    const binDir = path.join(tempDir, "bin");
+    const ideaPath = path.join(binDir, "idea");
+    mkdirSync(binDir, { recursive: true });
+    writeFileSync(ideaPath, "#!/bin/sh\nexit 0\n", "utf8");
+    chmodSync(ideaPath, 0o755);
+
+    const snapshot = await discoverDesktopApplications({ env: { PATH: binDir } });
+
+    expect(snapshot.editors).toContainEqual(
+      expect.objectContaining({
+        id: "intellijidea",
+        kind: "editor",
+        name: "IntelliJ IDEA",
+        source: "path",
+        executablePath: ideaPath,
+        canOpenWorkspace: true,
+      })
+    );
+  });
+
+  it("opens IntelliJ IDEA source links with JetBrains line metadata", async () => {
+    const binDir = path.join(tempDir, "bin");
+    const ideaPath = path.join(binDir, "idea");
+    const targetPath = path.join(tempDir, "source.kt");
+    const capturePath = path.join(tempDir, "application-open.json");
+    mkdirSync(binDir, { recursive: true });
+    writeFileSync(ideaPath, "#!/bin/sh\nexit 0\n", "utf8");
+    chmodSync(ideaPath, 0o755);
+    writeFileSync(targetPath, "line 1\nline 2\n", "utf8");
+
+    await openDesktopApplication(
+      {
+        applicationId: "intellijidea",
+        kind: "editor",
+        targetPath,
+        targetLine: 12,
+        targetColumn: 4,
+      },
+      {
+        env: {
+          PATH: binDir,
+          PWRAGENT_E2E_APPLICATION_OPEN_CAPTURE_PATH: capturePath,
+        },
+      }
+    );
+
+    const capture = JSON.parse(readFileSync(capturePath, "utf8")) as {
+      invocation: { args: string[]; command: string };
+      request: { targetColumn?: number; targetLine?: number; targetPath?: string };
+    };
+    expect(capture.request).toMatchObject({
+      targetPath,
+      targetLine: 12,
+      targetColumn: 4,
+    });
+    expect(capture.invocation.command).toBe(ideaPath);
+    expect(capture.invocation.args).toEqual([
+      "--line",
+      "12",
+      "--column",
+      "4",
+      targetPath,
+    ]);
     expect(spawnMock).not.toHaveBeenCalled();
   });
 

--- a/apps/desktop/src/main/__tests__/application-discovery.test.ts
+++ b/apps/desktop/src/main/__tests__/application-discovery.test.ts
@@ -17,9 +17,25 @@ import {
   resolveBundledApplicationCliPath,
 } from "../settings/application-discovery";
 
-const { spawnMock } = vi.hoisted(() => ({
+const { blockedAccessPaths, spawnMock } = vi.hoisted(() => ({
+  blockedAccessPaths: new Set<string>(),
   spawnMock: vi.fn(),
 }));
+
+vi.mock("node:fs/promises", async () => {
+  const actual = await vi.importActual<typeof import("node:fs/promises")>(
+    "node:fs/promises"
+  );
+  return {
+    ...actual,
+    access: vi.fn(async (candidatePath, mode) => {
+      if (blockedAccessPaths.has(String(candidatePath))) {
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      }
+      return actual.access(candidatePath, mode);
+    }),
+  };
+});
 
 vi.mock("node:child_process", async () => {
   const actual = await vi.importActual<typeof import("node:child_process")>(
@@ -36,6 +52,7 @@ describe("application discovery", () => {
 
   beforeEach(() => {
     tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-application-test-"));
+    blockedAccessPaths.clear();
     spawnMock.mockImplementation(() => {
       const child = new EventEmitter() as EventEmitter & { unref: () => void };
       child.unref = vi.fn();
@@ -106,6 +123,7 @@ describe("application discovery", () => {
   });
 
   it("discovers IntelliJ IDEA from the idea launcher on PATH", async () => {
+    blockHostIntelliJDiscoveryPaths();
     const binDir = path.join(tempDir, "bin");
     const ideaPath = path.join(binDir, "idea");
     mkdirSync(binDir, { recursive: true });
@@ -127,6 +145,7 @@ describe("application discovery", () => {
   });
 
   it("opens IntelliJ IDEA source links with JetBrains line metadata", async () => {
+    blockHostIntelliJDiscoveryPaths();
     const binDir = path.join(tempDir, "bin");
     const ideaPath = path.join(binDir, "idea");
     const targetPath = path.join(tempDir, "source.kt");
@@ -191,3 +210,15 @@ describe("application discovery", () => {
     );
   });
 });
+
+function blockHostIntelliJDiscoveryPaths(): void {
+  for (const appName of ["IntelliJ IDEA.app", "IntelliJ IDEA CE.app"]) {
+    for (const appPath of [
+      path.join("/Applications", appName),
+      path.join(os.homedir(), "Applications", appName),
+    ]) {
+      blockedAccessPaths.add(appPath);
+      blockedAccessPaths.add(path.join(appPath, "Contents", "MacOS", "idea"));
+    }
+  }
+}

--- a/apps/desktop/src/main/settings/application-discovery.ts
+++ b/apps/desktop/src/main/settings/application-discovery.ts
@@ -125,7 +125,20 @@ const EDITORS: KnownApplication[] = [
     id: "intellijidea",
     kind: "editor",
     name: "IntelliJ IDEA",
-    appPaths: applicationPaths("IntelliJ IDEA.app"),
+    appPaths: [
+      ...applicationPaths("IntelliJ IDEA.app"),
+      ...applicationPaths("IntelliJ IDEA CE.app"),
+    ],
+    binaryNames: ["idea"],
+    binaryPaths: [
+      ...applicationExecutablePaths("IntelliJ IDEA.app", "Contents", "MacOS", "idea"),
+      ...applicationExecutablePaths(
+        "IntelliJ IDEA CE.app",
+        "Contents",
+        "MacOS",
+        "idea",
+      ),
+    ],
   },
 ];
 
@@ -206,6 +219,10 @@ function homebrewBinaryPaths(binaryName: string): string[] {
     path.join("/opt/homebrew/bin", binaryName),
     path.join("/usr/local/bin", binaryName),
   ];
+}
+
+function applicationExecutablePaths(appName: string, ...segments: string[]): string[] {
+  return applicationPaths(appName).map((appPath) => path.join(appPath, ...segments));
 }
 
 async function pathExists(candidatePath: string): Promise<boolean> {
@@ -402,6 +419,15 @@ function editorCliArgs(
   targetPath: string,
   request: OpenDesktopApplicationRequest,
 ): string[] {
+  if (supportsJetBrainsLineArgs(applicationId) && isPositiveInteger(request.targetLine)) {
+    const args = ["--line", String(request.targetLine)];
+    if (isPositiveInteger(request.targetColumn)) {
+      args.push("--column", String(request.targetColumn));
+    }
+    args.push(targetPath);
+    return args;
+  }
+
   if (!supportsVsCodeGoto(applicationId) || !isPositiveInteger(request.targetLine)) {
     return [targetPath];
   }
@@ -410,6 +436,10 @@ function editorCliArgs(
     ? `${targetPath}:${request.targetLine}:${request.targetColumn}`
     : `${targetPath}:${request.targetLine}`;
   return ["--goto", location];
+}
+
+function supportsJetBrainsLineArgs(applicationId: string): boolean {
+  return applicationId === "intellijidea";
 }
 
 function supportsVsCodeGoto(applicationId: string): boolean {

--- a/apps/desktop/src/main/settings/application-discovery.ts
+++ b/apps/desktop/src/main/settings/application-discovery.ts
@@ -121,6 +121,12 @@ const EDITORS: KnownApplication[] = [
     binaryNames: ["nvim-qt"],
     binaryPaths: homebrewBinaryPaths("nvim-qt"),
   },
+  {
+    id: "intellijidea",
+    kind: "editor",
+    name: "IntelliJ IDEA",
+    appPaths: applicationPaths("IntelliJ IDEA.app"),
+  },
 ];
 
 const TERMINALS: KnownApplication[] = [
@@ -179,6 +185,12 @@ const TERMINALS: KnownApplication[] = [
     binaryNames: ["kitty"],
     binaryPaths: homebrewBinaryPaths("kitty"),
     terminalWorkingDirectoryArg: (targetPath) => ["--directory", targetPath],
+  },
+  {
+    id: "warp",
+    kind: "terminal",
+    name: "Warp",
+    appPaths: applicationPaths("Warp.app"),
   },
 ];
 


### PR DESCRIPTION
## Summary

- Intellij IDEA editor and Warp terminal added to autodiscovery

## Verification
I ran
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:desktop-e2e`


Manual test:
- see apps in autodiscovery settings
- editor opens file from the thread message
- apps open via buttons click
## Notes

-
