### PR TITLE
chore(deps): patch brace-expansion advisory

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1735,8 +1735,8 @@ packages:
   brace-expansion@2.1.0:
     resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   browserslist@4.28.2:
@@ -5208,7 +5208,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -6600,7 +6600,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimatch@3.1.5:
     dependencies:


### PR DESCRIPTION
## Summary

- Resolve Dependabot alert 16 by moving the vulnerable `brace-expansion` 5.x lockfile entry from `5.0.5` to patched `5.0.6`
- Keep the change scoped to `pnpm-lock.yaml`; no workspace manifests or license notices changed

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm why brace-expansion --recursive`
- `rg -n "brace-expansion@5\\.0\\.5|brace-expansion: 5\\.0\\.5|brace-expansion@5\\.0\\.6|brace-expansion: 5\\.0\\.6" pnpm-lock.yaml`
- `pnpm licenses:check`

## Notes

- `pnpm audit --prod --audit-level moderate` no longer reports `brace-expansion`, but it still fails on separate `ws` and `protobufjs` advisories.
