### PR TITLE
fix(deps): pin protobufjs patched release

### DIFF
--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -14,6 +14,15 @@ function isGitSpec(spec) {
 }
 
 function readPackage(pkg) {
+  // Protobufjs publishes an unused transitive devDependency as a GitHub spec.
+  // Strip it before enforcing the registry-only dependency policy.
+  if (
+    pkg.name === 'protobufjs' &&
+    pkg.devDependencies?.['jaguarjs-jsdoc'] === 'github:dcodeIO/jaguarjs-jsdoc'
+  ) {
+    delete pkg.devDependencies['jaguarjs-jsdoc']
+  }
+
   for (const field of dependencyFields) {
     const dependencies = pkg[field]
     if (!dependencies) continue

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "pnpm": {
     "overrides": {
       "axios": "^1.16.0",
+      "protobufjs": "7.5.8",
       "ws": "8.20.1"
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,10 @@ settings:
 
 overrides:
   axios: ^1.16.0
+  protobufjs: 7.5.8
   ws: 8.20.1
 
-pnpmfileChecksum: sha256-qhUjtdsDx+KID8QibUkWT/nJBDVb/TMK08fsoGdLy78=
+pnpmfileChecksum: sha256-l+QzxfS11BtK+deH01/WT+xIHHSpNZ4LVvVbmeGnNLU=
 
 importers:
 
@@ -3072,8 +3073,8 @@ packages:
   prosemirror-view@1.41.8:
     resolution: {integrity: sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==}
 
-  protobufjs@7.5.7:
-    resolution: {integrity: sha512-NGnrxS/nLKUo5nkbVQxlC71sB4hdfImdYIbFeSCidxtwATx0AHRPcANSLd0q5Bb2BkoSWo2iisQhGg5/r+ihbA==}
+  protobufjs@7.5.8:
+    resolution: {integrity: sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==}
     engines: {node: '>=12.0.0'}
 
   proxy-from-env@2.1.0:
@@ -4377,7 +4378,7 @@ snapshots:
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
-      protobufjs: 7.5.7
+      protobufjs: 7.5.8
       qs: 6.15.1
       ws: 8.20.1
     transitivePeerDependencies:
@@ -6889,7 +6890,7 @@ snapshots:
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.12.0
 
-  protobufjs@7.5.7:
+  protobufjs@7.5.8:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2


### PR DESCRIPTION
## Summary

- Pin transitive `protobufjs` resolution to `7.5.8` with a root pnpm override
- Refresh `pnpm-lock.yaml` so the Feishu provider path resolves the patched release
- Strip protobufjs's unused GitHub devDependency from package metadata before enforcing the repo's registry-only pnpmfile policy
- Address Dependabot alert 18 / GHSA-jggg-4jg4-v7c6 / CVE-2026-45740

## Verification

- `pnpm install --lockfile-only`
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm why protobufjs -r`
- `pnpm audit --prod --json`

## Notes

- `pnpm audit --prod --json` reports zero production advisories after this change.
