### PR TITLE
feat(desktop): add transcript copy buttons

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
@@ -9,11 +9,12 @@ import remarkGfm from "remark-gfm";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { SkillChip } from "../composer/SkillChip";
 import { remarkTableProfile } from "./remark-table-profile";
+import { TranscriptCopyButton } from "./TranscriptCopyButton";
 
 type ThreadMarkdownProps = {
   applications?: DesktopApplicationsSnapshot;
   className?: string;
-  desktopApi?: Pick<DesktopApi, "openApplication">;
+  desktopApi?: Pick<DesktopApi, "copyText" | "openApplication">;
   skills?: AppServerSkillSummary[];
   text: string;
   variant?: "message" | "summary";
@@ -108,8 +109,22 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
         );
       },
       blockquote(blockquoteProps) {
+        const copyText = normalizeBlockquoteCopyText(
+          sourceForNode(props.text, blockquoteProps.node) ??
+            extractTextContent(blockquoteProps.children)
+        );
+
         return (
           <blockquote className="transcript-message__blockquote">
+            {copyText ? (
+              <TranscriptCopyButton
+                className="transcript-copy-button--section"
+                copiedLabel="Copied quote"
+                desktopApi={props.desktopApi}
+                label="Copy quote"
+                text={copyText}
+              />
+            ) : null}
             {blockquoteProps.children}
           </blockquote>
         );
@@ -166,7 +181,22 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
         );
       },
       pre(preProps) {
-        return <pre className="transcript-message__pre">{preProps.children}</pre>;
+        const copyText = extractTextContent(preProps.children);
+
+        return (
+          <div className="transcript-message__pre-wrap">
+            {copyText ? (
+              <TranscriptCopyButton
+                className="transcript-copy-button--section"
+                copiedLabel="Copied code"
+                desktopApi={props.desktopApi}
+                label="Copy code"
+                text={copyText}
+              />
+            ) : null}
+            <pre className="transcript-message__pre">{preProps.children}</pre>
+          </div>
+        );
       },
       table(tableProps) {
         return (
@@ -377,6 +407,14 @@ function splitFileLineSuffix(filePath: string): {
     ...(Number.isInteger(line) ? { line } : {}),
     ...(Number.isInteger(column) ? { column } : {}),
   };
+}
+
+function normalizeBlockquoteCopyText(text: string): string {
+  return text
+    .split("\n")
+    .map((line) => line.replace(/^\s{0,3}>\s?/, ""))
+    .join("\n")
+    .trim();
 }
 
 function extractTextContent(node: ReactNode): string {

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptCopyButton.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptCopyButton.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useRef, useState } from "react";
+import { CopyIcon } from "../../icons";
+import { copyText } from "../../lib/copy-text";
+import type { DesktopApi } from "../../lib/desktop-api";
+
+type TranscriptCopyButtonProps = {
+  className?: string;
+  copiedLabel?: string;
+  desktopApi?: Pick<DesktopApi, "copyText">;
+  label: string;
+  text: string;
+};
+
+export function TranscriptCopyButton(props: TranscriptCopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+  const resetTimerRef = useRef<number | undefined>(undefined);
+
+  useEffect(() => {
+    return () => {
+      if (resetTimerRef.current) {
+        window.clearTimeout(resetTimerRef.current);
+      }
+    };
+  }, []);
+
+  return (
+    <button
+      type="button"
+      className={["transcript-copy-button", props.className].filter(Boolean).join(" ")}
+      data-copied={copied ? "true" : undefined}
+      aria-label={copied ? props.copiedLabel ?? "Copied" : props.label}
+      title={copied ? props.copiedLabel ?? "Copied" : props.label}
+      onClick={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        void copyText(props.text, props.desktopApi)
+          .then(() => {
+            if (resetTimerRef.current) {
+              window.clearTimeout(resetTimerRef.current);
+            }
+            setCopied(true);
+            resetTimerRef.current = window.setTimeout(() => {
+              setCopied(false);
+              resetTimerRef.current = undefined;
+            }, 1400);
+          })
+          .catch((error: unknown) => {
+            console.error("Failed to copy transcript text", error);
+          });
+      }}
+    >
+      <CopyIcon size={14} aria-hidden="true" />
+    </button>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -45,7 +45,7 @@ type TranscriptListProps = {
   activeTurnId?: string;
   activeTurnStartedAt?: number;
   applications?: DesktopApplicationsSnapshot;
-  desktopApi?: Pick<DesktopApi, "openApplication">;
+  desktopApi?: Pick<DesktopApi, "copyText" | "openApplication">;
   directoryPaths?: string[];
   entries: AppServerThreadEntry[];
   error?: string;

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
@@ -1,4 +1,4 @@
-import { memo, type ReactNode } from "react";
+import { memo, useMemo, type ReactNode } from "react";
 import type {
   DesktopApplicationsSnapshot,
   AppServerSkillSummary,
@@ -9,10 +9,11 @@ import type {
 import type { DesktopApi } from "../../lib/desktop-api";
 import { TranscriptImage } from "./TranscriptImage";
 import { ThreadMarkdown } from "./ThreadMarkdown";
+import { TranscriptCopyButton } from "./TranscriptCopyButton";
 
 type TranscriptMessageProps = {
   applications?: DesktopApplicationsSnapshot;
-  desktopApi?: Pick<DesktopApi, "openApplication">;
+  desktopApi?: Pick<DesktopApi, "copyText" | "openApplication">;
   message: AppServerThreadMessageEntry;
   skills: AppServerSkillSummary[];
   onOpenImage?: (image: AppServerThreadImagePart) => void;
@@ -25,6 +26,7 @@ export const TranscriptMessage = memo(function TranscriptMessage(props: Transcri
       : props.message.text
         ? [{ type: "text", text: props.message.text } satisfies AppServerThreadMessagePart]
         : [];
+  const messageCopyText = useMemo(() => buildMessageCopyText(contentParts), [contentParts]);
   const messageSegments = groupMessageParts(contentParts).flatMap(splitMarkdownTableSegment);
 
   if (messageSegments.length === 0) {
@@ -32,7 +34,12 @@ export const TranscriptMessage = memo(function TranscriptMessage(props: Transcri
       <article
         className={`transcript-message transcript-message--${props.message.role}`}
       >
-        {renderMessageHeader(props.message, false)}
+        {renderMessageHeader({
+          continuation: false,
+          desktopApi: props.desktopApi,
+          message: props.message,
+          text: messageCopyText,
+        })}
       </article>
     );
   }
@@ -54,7 +61,12 @@ export const TranscriptMessage = memo(function TranscriptMessage(props: Transcri
             .join(" ")}
           key={`${props.message.id}:${index}`}
         >
-          {renderMessageHeader(props.message, index > 0)}
+          {renderMessageHeader({
+            continuation: index > 0,
+            desktopApi: props.desktopApi,
+            message: props.message,
+            text: messageCopyText,
+          })}
           <div className="transcript-message__text">
             {renderMessageSegment({
               segment,
@@ -288,7 +300,7 @@ function appendTextSegment(segments: MessagePartSegment[], text: string): void {
 
 function renderMessageSegment(params: {
   applications?: DesktopApplicationsSnapshot;
-  desktopApi?: Pick<DesktopApi, "openApplication">;
+  desktopApi?: Pick<DesktopApi, "copyText" | "openApplication">;
   segment: MessagePartSegment;
   index: number;
   onOpenImage?: (image: AppServerThreadImagePart) => void;
@@ -333,27 +345,40 @@ function renderMessageSegment(params: {
   );
 }
 
-function renderMessageHeader(
-  message: AppServerThreadMessageEntry,
-  continuation: boolean
-): ReactNode {
-  if (continuation) {
+function renderMessageHeader(params: {
+  continuation: boolean;
+  desktopApi?: Pick<DesktopApi, "copyText">;
+  message: AppServerThreadMessageEntry;
+  text: string;
+}): ReactNode {
+  if (params.continuation) {
     return null;
   }
 
   return (
     <header className="transcript-message__header">
-      <span className="transcript-message__role">{labelForRole(message.role)}</span>
-      {message.createdAt ? (
-        <time className="transcript-message__time">
-          {new Intl.DateTimeFormat(undefined, {
-            month: "short",
-            day: "numeric",
-            hour: "numeric",
-            minute: "2-digit"
-          }).format(message.createdAt)}
-        </time>
-      ) : null}
+      <span className="transcript-message__role">{labelForRole(params.message.role)}</span>
+      <span className="transcript-message__header-actions">
+        {params.text ? (
+          <TranscriptCopyButton
+            className="transcript-copy-button--message"
+            copiedLabel="Copied message"
+            desktopApi={params.desktopApi}
+            label="Copy message"
+            text={params.text}
+          />
+        ) : null}
+        {params.message.createdAt ? (
+          <time className="transcript-message__time">
+            {new Intl.DateTimeFormat(undefined, {
+              month: "short",
+              day: "numeric",
+              hour: "numeric",
+              minute: "2-digit"
+            }).format(params.message.createdAt)}
+          </time>
+        ) : null}
+      </span>
     </header>
   );
 }
@@ -363,4 +388,15 @@ function labelForRole(role: AppServerThreadMessageEntry["role"]): string {
     return "Assistant";
   }
   return "User";
+}
+
+function buildMessageCopyText(parts: AppServerThreadMessagePart[]): string {
+  return parts
+    .filter((part): part is Exclude<AppServerThreadMessagePart, AppServerThreadImagePart> =>
+      part.type !== "image"
+    )
+    .map((part) => part.text)
+    .filter((text) => text.trim() !== "")
+    .join("\n\n")
+    .trim();
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
@@ -26,7 +26,10 @@ export const TranscriptMessage = memo(function TranscriptMessage(props: Transcri
       : props.message.text
         ? [{ type: "text", text: props.message.text } satisfies AppServerThreadMessagePart]
         : [];
-  const messageCopyText = useMemo(() => buildMessageCopyText(contentParts), [contentParts]);
+  const messageCopyText = useMemo(
+    () => buildMessageCopyText(props.message, contentParts),
+    [contentParts, props.message]
+  );
   const messageSegments = groupMessageParts(contentParts).flatMap(splitMarkdownTableSegment);
 
   if (messageSegments.length === 0) {
@@ -390,13 +393,18 @@ function labelForRole(role: AppServerThreadMessageEntry["role"]): string {
   return "User";
 }
 
-function buildMessageCopyText(parts: AppServerThreadMessagePart[]): string {
+function buildMessageCopyText(
+  message: AppServerThreadMessageEntry,
+  parts: AppServerThreadMessagePart[]
+): string {
+  if (typeof message.text === "string" && message.text.length > 0) {
+    return message.text;
+  }
+
   return parts
     .filter((part): part is Exclude<AppServerThreadMessagePart, AppServerThreadImagePart> =>
       part.type !== "image"
     )
     .map((part) => part.text)
-    .filter((text) => text.trim() !== "")
-    .join("\n\n")
-    .trim();
+    .join("\n\n");
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptWorkPhaseGroup.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptWorkPhaseGroup.tsx
@@ -15,7 +15,7 @@ type TranscriptWorkPhaseGroupProps = {
   applications?: DesktopApplicationsSnapshot;
   collapsible: boolean;
   directoryPaths?: string[];
-  desktopApi?: Pick<DesktopApi, "openApplication">;
+  desktopApi?: Pick<DesktopApi, "copyText" | "openApplication">;
   entries: AppServerThreadEntry[];
   expanded: boolean;
   label: string;
@@ -75,7 +75,7 @@ TranscriptWorkPhaseGroup.displayName = "TranscriptWorkPhaseGroup";
 function renderEntry(params: {
   applications?: DesktopApplicationsSnapshot;
   directoryPaths?: string[];
-  desktopApi?: Pick<DesktopApi, "openApplication">;
+  desktopApi?: Pick<DesktopApi, "copyText" | "openApplication">;
   entry: AppServerThreadEntry;
   skills: AppServerSkillSummary[];
   onOpenImage?: (image: AppServerThreadImagePart) => void;

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
@@ -248,6 +248,40 @@ describe("ThreadMarkdown", () => {
     expect(container.querySelector("pre img")).toBeNull();
   });
 
+  it("copies fenced code blocks without markdown fences", async () => {
+    const copyText = vi.fn(async () => undefined);
+
+    render(
+      <ThreadMarkdown
+        desktopApi={{ copyText }}
+        text={"```ts\nconst answer = 42;\n```"}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy code" }));
+
+    await waitFor(() => {
+      expect(copyText).toHaveBeenCalledWith("const answer = 42;\n");
+    });
+  });
+
+  it("copies blockquotes without quote markers", async () => {
+    const copyText = vi.fn(async () => undefined);
+
+    render(
+      <ThreadMarkdown
+        desktopApi={{ copyText }}
+        text={"> Replay this prompt\n> exactly as written"}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy quote" }));
+
+    await waitFor(() => {
+      expect(copyText).toHaveBeenCalledWith("Replay this prompt\nexactly as written");
+    });
+  });
+
   it("renders markdown image syntax as literal text instead of an image", () => {
     const { container } = render(
       <ThreadMarkdown

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -313,6 +313,36 @@ describe("TranscriptList", () => {
     expect(screen.getByText("Follow-up prose should not inherit", { exact: false })).toBeInTheDocument();
   });
 
+  it("copies the full original message when the rendered message is split into segments", async () => {
+    const copyText = vi.fn(async () => undefined);
+    const messageText = `Intro prose should stay in the normal readable assistant bubble.\n\n${wideMarkdownTable}\n\nFollow-up prose should not inherit the table width.`;
+
+    render(
+      <TranscriptList
+        desktopApi={{ copyText }}
+        entries={[
+          {
+            type: "message",
+            id: "message-table",
+            role: "assistant",
+            text: messageText,
+          },
+        ]}
+        loading={false}
+        loadingMore={false}
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(screen.getAllByRole("button", { name: "Copy message" })).toHaveLength(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy message" }));
+
+    await waitFor(() => {
+      expect(copyText).toHaveBeenCalledWith(messageText);
+    });
+  });
+
   it("preserves reference-style links inside split wide markdown tables", () => {
     const { container } = render(
       <TranscriptList

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -343,6 +343,71 @@ describe("TranscriptList", () => {
     });
   });
 
+  it("preserves boundary whitespace when copying a full message", async () => {
+    const copyText = vi.fn(async () => undefined);
+    const messageText = "\n  Replay this prompt exactly.  \n\n";
+
+    render(
+      <TranscriptList
+        desktopApi={{ copyText }}
+        entries={[
+          {
+            type: "message",
+            id: "message-whitespace",
+            role: "user",
+            text: messageText,
+          },
+        ]}
+        loading={false}
+        loadingMore={false}
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy message" }));
+
+    await waitFor(() => {
+      expect(copyText).toHaveBeenCalledWith(messageText);
+    });
+  });
+
+  it("preserves whitespace-only text parts when copying a multipart message", async () => {
+    const copyText = vi.fn(async () => undefined);
+
+    render(
+      <TranscriptList
+        desktopApi={{ copyText }}
+        entries={[
+          {
+            type: "message",
+            id: "message-whitespace-parts",
+            role: "assistant",
+            text: "",
+            parts: [
+              {
+                type: "text",
+                text: "  ",
+              },
+              {
+                type: "text",
+                text: "\nkeep this boundary\n",
+              },
+            ],
+          },
+        ]}
+        loading={false}
+        loadingMore={false}
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy message" }));
+
+    await waitFor(() => {
+      expect(copyText).toHaveBeenCalledWith("  \n\n\nkeep this boundary\n");
+    });
+  });
+
   it("preserves reference-style links inside split wide markdown tables", () => {
     const { container } = render(
       <TranscriptList

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5729,11 +5729,57 @@ textarea,
   gap: 12px;
 }
 
+.transcript-message__header-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .transcript-message__role {
   font-size: 11px;
   font-weight: 600;
   text-transform: uppercase;
   color: var(--text-secondary);
+}
+
+.transcript-copy-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  color: var(--text-muted);
+  background: color-mix(in srgb, var(--bg-panel-elevated) 92%, transparent);
+  opacity: 0;
+  cursor: pointer;
+  transition:
+    background 120ms ease,
+    border-color 120ms ease,
+    color 120ms ease,
+    opacity 120ms ease;
+}
+
+.transcript-copy-button:hover,
+.transcript-copy-button:focus-visible,
+.transcript-copy-button[data-copied="true"] {
+  border-color: var(--accent-border);
+  color: var(--accent-bright);
+  background: var(--accent-soft);
+}
+
+.transcript-copy-button:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+  opacity: 1;
+}
+
+.transcript-message:hover .transcript-copy-button--message,
+.transcript-message:focus-within .transcript-copy-button--message,
+.transcript-copy-button--message[data-copied="true"] {
+  opacity: 1;
 }
 
 .transcript-message__text {
@@ -5831,7 +5877,10 @@ textarea,
 }
 
 .transcript-message__blockquote {
+  position: relative;
   margin: 0;
+  min-height: 28px;
+  padding-right: 38px;
   padding-left: 12px;
   border-left: 2px solid var(--border-subtle);
   color: var(--text-secondary);
@@ -5849,8 +5898,40 @@ textarea,
   overflow-wrap: anywhere;
 }
 
+.transcript-message__pre-wrap {
+  position: relative;
+}
+
+.transcript-message__pre-wrap:hover .transcript-copy-button--section,
+.transcript-message__pre-wrap:focus-within .transcript-copy-button--section,
+.transcript-message__blockquote:hover .transcript-copy-button--section,
+.transcript-message__blockquote:focus-within .transcript-copy-button--section,
+.transcript-copy-button--section[data-copied="true"] {
+  opacity: 1;
+}
+
+.transcript-copy-button--section {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 1;
+  background: color-mix(in srgb, var(--bg-app) 92%, transparent);
+}
+
+.transcript-message__blockquote .transcript-copy-button--section {
+  top: 0;
+  right: 0;
+}
+
+@media (hover: none) {
+  .transcript-copy-button--message,
+  .transcript-copy-button--section {
+    opacity: 1;
+  }
+}
+
 .transcript-message__pre {
-  padding: 12px;
+  padding: 12px 44px 12px 12px;
   border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: var(--bg-app);


### PR DESCRIPTION
## Summary
Transcript content can now be copied without manual text selection. Message headers expose a hover/focus copy affordance for the full user or assistant message, while code blocks and blockquotes expose their own scoped copy controls so replay prompts and command snippets can be lifted cleanly.

The copy path reuses the existing desktop clipboard bridge and falls back to browser clipboard behavior. Wide table splitting still copies the original full message from the first segment, so rendered transcript layout does not change the clipboard value.

## Test Plan
- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx`
- `pnpm lint`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)
