### PR TITLE
fix(desktop): wizard prerequisites — defer Codex spawn, Linux discovery, Step 0 (#467 follow-up)

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-discovery.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-discovery.test.ts
@@ -328,4 +328,112 @@ describe("Codex discovery", () => {
       version: "0.126.0-alpha.8",
     });
   });
+
+  it("discovers Codex at /usr/local/bin on Linux when PATH does not include it", async () => {
+    // Repro of the bug from the field: Electron-spawned process on
+    // Linux gets a stripped PATH that may not include common system
+    // bin dirs, so the PATH lookup misses. The well-known auto-
+    // candidates need to find /usr/local/bin/codex explicitly.
+    const notFoundError = new Error("missing") as NodeJS.ErrnoException;
+    notFoundError.code = "ENOENT";
+    accessMock.mockImplementation(async (candidate: string) => {
+      if (candidate === "/usr/local/bin/codex") return undefined;
+      throw notFoundError;
+    });
+    realpathMock.mockImplementation(async (candidate: string) => candidate);
+    execFileMock.mockImplementation(
+      (
+        command: string,
+        _args: string[],
+        _options: Record<string, unknown>,
+        callback: (error: Error | null, result?: { stdout: string }) => void,
+      ) => {
+        if (command === "/usr/local/bin/codex") {
+          callback(null, { stdout: "codex-cli 0.130.0\n" });
+          return;
+        }
+        const error = new Error("missing") as NodeJS.ErrnoException;
+        error.code = "ENOENT";
+        callback(error);
+      },
+    );
+    const { discoverCodexCommands } = await import("../settings/codex-discovery");
+
+    const snapshot = await discoverCodexCommands({
+      env: { PATH: "" }, // Intentionally empty — must find via well-known paths.
+      platform: "linux",
+    });
+
+    expect(snapshot.selectedCommand).toBe("/usr/local/bin/codex");
+    expect(
+      snapshot.candidates.find((c) => c.command === "/usr/local/bin/codex"),
+    ).toMatchObject({ executable: true, selected: true, version: "0.130.0" });
+  });
+
+  it("discovers Codex at ~/.local/bin/codex (npm/pnpm/bun user install) on Linux", async () => {
+    const homeDir = (await import("node:os")).homedir();
+    const userBinCodex = `${homeDir}/.local/bin/codex`;
+    const notFoundError = new Error("missing") as NodeJS.ErrnoException;
+    notFoundError.code = "ENOENT";
+    accessMock.mockImplementation(async (candidate: string) => {
+      if (candidate === userBinCodex) return undefined;
+      throw notFoundError;
+    });
+    realpathMock.mockImplementation(async (candidate: string) => candidate);
+    execFileMock.mockImplementation(
+      (
+        command: string,
+        _args: string[],
+        _options: Record<string, unknown>,
+        callback: (error: Error | null, result?: { stdout: string }) => void,
+      ) => {
+        if (command === userBinCodex) {
+          callback(null, { stdout: "codex-cli 0.130.0\n" });
+          return;
+        }
+        const error = new Error("missing") as NodeJS.ErrnoException;
+        error.code = "ENOENT";
+        callback(error);
+      },
+    );
+    const { discoverCodexCommands } = await import("../settings/codex-discovery");
+
+    const snapshot = await discoverCodexCommands({
+      env: {},
+      platform: "linux",
+    });
+
+    expect(snapshot.selectedCommand).toBe(userBinCodex);
+  });
+
+  it("resolveCodexCommand throws CodexCliNotInstalledError when nothing is found", async () => {
+    // The transport relies on this to refuse to spawn — previous
+    // behavior of falling back to `codex` (PATH) then letting
+    // `spawn` ENOENT was confusing on Linux without Codex installed.
+    const notFoundError = new Error("missing") as NodeJS.ErrnoException;
+    notFoundError.code = "ENOENT";
+    accessMock.mockRejectedValue(notFoundError);
+    realpathMock.mockResolvedValue("/no/such/path");
+    execFileMock.mockImplementation(
+      (
+        _command: string,
+        _args: string[],
+        _options: Record<string, unknown>,
+        callback: (error: Error | null) => void,
+      ) => {
+        callback(notFoundError);
+      },
+    );
+    const { resolveCodexCommand, CodexCliNotInstalledError } = await import(
+      "../settings/codex-discovery"
+    );
+
+    await expect(
+      resolveCodexCommand({
+        command: "codex",
+        env: { PATH: "/nowhere" },
+        platform: "linux",
+      }),
+    ).rejects.toThrow(CodexCliNotInstalledError);
+  });
 });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1622,6 +1622,16 @@ export class DesktopBackendRegistry {
         connectionObserver: codexObserver,
         env: codexEnv,
         clientVersion,
+        // Fire the gate at the client level too, not just the
+        // listThreads layer. Without this, `describeCodexBackend`
+        // (called by `listBackends` on app startup) would call
+        // `ensureInitialized` → spawn the Codex CLI subprocess —
+        // even on a fresh PwrAgent profile mid-wizard, and on
+        // machines where the operator doesn't have Codex installed
+        // yet. The client throws `CodexBootstrapDeferredError` which
+        // `describeCodexBackend` catches via `Promise.allSettled` and
+        // surfaces as `available: false` with a clean reason.
+        isCodexBootstrapDeferred: () => this.isCodexBootstrapDeferredFn(),
       });
     this.grokClient =
       options?.grokClient ??

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -109,7 +109,33 @@ type CodexClientOptions = {
   connectionObserver?: JsonRpcObserver;
   requestTimeoutMs?: number;
   clientVersion?: string;
+  /**
+   * Gate predicate consulted on every `ensureInitialized` call. When it
+   * returns true, the client refuses to spawn / connect the Codex CLI
+   * subprocess and throws {@link CodexBootstrapDeferredError}. The
+   * BackendRegistry wires this to `DesktopSettingsService
+   * .isCodexBootstrapDeferred()` so a brand-new PwrAgent profile (or
+   * one mid-wizard) doesn't slurp threads from an arbitrary Codex
+   * identity AND, importantly, doesn't even attempt to spawn the
+   * `codex` binary on machines that don't have it installed yet. The
+   * gate is the architectural boundary between "we know what backend
+   * the operator wants" and "fire it up."
+   */
+  isCodexBootstrapDeferred?: () => boolean;
 };
+
+/**
+ * Thrown by `ensureInitialized` when `isCodexBootstrapDeferred` returns
+ * true. Callers catch this to surface a clean "backend deferred" state
+ * (e.g. `describeCodexBackend` reports `available: false` with a
+ * recognizable reason) instead of treating it as a Codex CLI error.
+ */
+export class CodexBootstrapDeferredError extends Error {
+  constructor(message = "codex bootstrap deferred until onboarding completes") {
+    super(message);
+    this.name = "CodexBootstrapDeferredError";
+  }
+}
 
 type InitializeResult = {
   serverInfo?: {
@@ -4688,6 +4714,17 @@ export class CodexAppServerClient {
   private async ensureInitialized(): Promise<void> {
     if (this.initialized) {
       return;
+    }
+
+    // Bootstrap gate: when the deferred predicate is set and active,
+    // refuse to spawn the Codex CLI subprocess at all. This is the
+    // architectural choke point that lets `describeCodexBackend`
+    // return a clean "deferred" placeholder for both (a) a fresh
+    // PwrAgent profile mid-wizard and (b) a machine where the
+    // operator hasn't yet confirmed they have a Codex CLI installed
+    // (e.g. Linux without `codex` on PATH).
+    if (this.options.isCodexBootstrapDeferred?.()) {
+      throw new CodexBootstrapDeferredError();
     }
 
     if (this.initializationPromise) {

--- a/apps/desktop/src/main/settings/codex-discovery.ts
+++ b/apps/desktop/src/main/settings/codex-discovery.ts
@@ -117,11 +117,63 @@ function validateCodexCliVersion(version: string): string | undefined {
     : undefined;
 }
 
-function getCodexAppCandidatePaths(): string[] {
-  return [
-    "/Applications/Codex.app/Contents/Resources/codex",
-    path.join(os.homedir(), "Applications/Codex.app/Contents/Resources/codex"),
-  ];
+/**
+ * Well-known install locations for the Codex CLI, used as auto-candidates
+ * alongside the PATH lookup. Platform-aware: macOS gets `Codex.app`
+ * resource bundles, Linux gets the standard FHS dirs plus the common
+ * user-local Node/Rust/Bun toolchain locations that aren't typically on
+ * an Electron-spawned process's PATH. Returned in priority order
+ * (system-wide first, user-local second) so the discovery prefers the
+ * canonical install when both are present.
+ */
+function getCodexInstallCandidatePaths(platform: NodeJS.Platform): string[] {
+  const homeDir = os.homedir();
+  if (platform === "darwin") {
+    return [
+      "/Applications/Codex.app/Contents/Resources/codex",
+      path.join(homeDir, "Applications/Codex.app/Contents/Resources/codex"),
+    ];
+  }
+  if (platform === "linux") {
+    return [
+      // System-wide installs (the typical "apt install", "rpm install",
+      // or homebrew-on-linux destination).
+      "/usr/bin/codex",
+      "/usr/local/bin/codex",
+      "/opt/codex/bin/codex",
+      // Ubuntu Snap installs land here when installed via `snap install
+      // codex`. The snap-wrapper exec is a shim that delegates to the
+      // real binary under `/snap/codex/current/`, but `/snap/bin/codex`
+      // is what shows up on PATH for a normal shell.
+      "/snap/bin/codex",
+      // User-local installs. Electron's spawned-process PATH on Linux
+      // does NOT typically include `~/.local/bin` or any of the per-
+      // language toolchain bin dirs (npm-global, pnpm, bun, cargo),
+      // so these need explicit auto-candidates to be discoverable
+      // without the operator setting CODEX_COMMAND or `PATH`.
+      path.join(homeDir, ".local/bin/codex"),
+      path.join(homeDir, ".npm-global/bin/codex"),
+      path.join(homeDir, ".local/share/pnpm/codex"),
+      path.join(homeDir, ".bun/bin/codex"),
+      path.join(homeDir, ".cargo/bin/codex"),
+      // Linuxbrew on Linux. Two common prefixes:
+      "/home/linuxbrew/.linuxbrew/bin/codex",
+      path.join(homeDir, ".linuxbrew/bin/codex"),
+    ];
+  }
+  if (platform === "win32") {
+    // Windows isn't a user-reported gap yet, but include the obvious
+    // npm + LOCALAPPDATA installs so the discovery snapshot is
+    // symmetric. The npm-global `.cmd` shim is what gets executed by
+    // `spawn` on win32.
+    return [
+      path.join(homeDir, "AppData/Roaming/npm/codex.cmd"),
+      path.join(homeDir, "AppData/Local/Programs/codex/codex.exe"),
+    ];
+  }
+  // Other Unix flavors (freebsd, openbsd, sunos) — fall back to the FHS
+  // basics, no user-local guesses.
+  return ["/usr/bin/codex", "/usr/local/bin/codex"];
 }
 
 async function inspectCodexCandidateBeforeVersionProbe(params: {
@@ -187,6 +239,7 @@ export async function discoverCodexCommands(params?: {
   const envOverride = env[CODEX_COMMAND_ENV]?.trim();
   const configuredCommand = params?.configuredCommand?.trim();
 
+  const resolvedPlatform = params?.platform ?? process.platform;
   return discoverCommands<DesktopCodexCandidateSource>({
     env,
     platform: params?.platform,
@@ -196,10 +249,12 @@ export async function discoverCodexCommands(params?: {
     ],
     autoCandidates: [
       { command: "codex", source: "path" },
-      ...getCodexAppCandidatePaths().map((candidatePath) => ({
-        command: candidatePath,
-        source: "application" as const,
-      })),
+      ...getCodexInstallCandidatePaths(resolvedPlatform).map(
+        (candidatePath) => ({
+          command: candidatePath,
+          source: "application" as const,
+        }),
+      ),
     ],
     parseVersion: parseCodexVersionOutput,
     compareVersions: compareCodexCliVersions,
@@ -207,6 +262,22 @@ export async function discoverCodexCommands(params?: {
     preflightCandidate: ({ command, platform }) =>
       inspectCodexCandidateBeforeVersionProbe({ command, platform }),
   }) as Promise<DesktopCodexDiscoverySnapshot>;
+}
+
+/**
+ * Thrown by `resolveCodexCommand` when discovery finds no executable
+ * Codex CLI on this machine. Callers catch this to surface a clean
+ * "Codex CLI not installed" state instead of attempting a spawn that
+ * would `ENOENT` (the previous fallback behavior on Linux without
+ * Codex). The wizard's Step 0 backend-requirements check also uses
+ * the discovery output directly and decorates this with install
+ * instructions.
+ */
+export class CodexCliNotInstalledError extends Error {
+  constructor(message = "codex CLI not found on PATH or in known install locations") {
+    super(message);
+    this.name = "CodexCliNotInstalledError";
+  }
 }
 
 export async function resolveCodexCommand(params: {
@@ -242,8 +313,12 @@ export async function resolveCodexCommand(params: {
     );
   }
 
-  return {
-    command: params.command.trim() || "codex",
-    source: "path",
-  };
+  // No selected candidate and no version-rejected candidate — discovery
+  // turned up nothing usable. Throw a typed error so the transport can
+  // refuse to spawn cleanly instead of attempting `spawn("codex")` and
+  // letting it `ENOENT`. Pre-fix behavior was to fall back to `"codex"`
+  // (PATH lookup); discovery already searched PATH plus the
+  // platform-specific install locations, so a fallback would just
+  // repeat the same lookup that already failed.
+  throw new CodexCliNotInstalledError();
 }

--- a/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
+++ b/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
@@ -405,7 +405,7 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
     >
       <div className="onboarding-wizard-overlay__scrim" />
       <div
-        className={`onboarding-wizard${step === "welcome" || step === "done" ? " onboarding-wizard--narrow" : ""}${step === "backend-requirements" ? " onboarding-wizard--medium" : ""}`}
+        className={`onboarding-wizard${step === "welcome" || step === "done" || step === "backend-requirements" ? " onboarding-wizard--narrow" : ""}`}
       >
         <WizardTitlebar
           step={step}

--- a/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
+++ b/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
@@ -43,6 +43,7 @@ export type OnboardingProvider =
   | "line";
 
 type WizardStep =
+  | "backend-requirements"
   | "welcome"
   | "thread-presentation"
   | "codex-profile"
@@ -62,7 +63,10 @@ const RAIL_STEPS: ReadonlyArray<{ label: string }> = [
 ];
 
 function railIndexForStep(step: WizardStep): RailIndex | -1 {
-  if (step === "welcome") return -1;
+  // `backend-requirements` and `welcome` are pre-rail screens —
+  // prerequisite + intro, before the four numbered steps the rail
+  // tracks.
+  if (step === "backend-requirements" || step === "welcome") return -1;
   if (step === "thread-presentation") return 0;
   if (step === "codex-profile" || step === "name-codex-profiles") return 1;
   if (
@@ -104,7 +108,15 @@ export type OnboardingWizardProps = {
 };
 
 export function OnboardingWizard(props: OnboardingWizardProps) {
-  const [step, setStep] = useState<WizardStep>("welcome");
+  // Backend requirements is the first stop. If the operator opens the
+  // wizard with neither Codex CLI nor an xAI key configured, we have to
+  // resolve that before any of the downstream steps make sense. Replays
+  // (Help → Replay Onboarding) skip straight to Welcome since the user
+  // is presumably already past the backend gate — they're re-running to
+  // change settings, not bootstrap.
+  const [step, setStep] = useState<WizardStep>(
+    props.isReplay ? "welcome" : "backend-requirements",
+  );
   const [density, setDensity] = useState<DesktopAppearanceDensity>(
     props.initialDensity,
   );
@@ -137,17 +149,25 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
   );
   const currentProvider = orderedProviders[providerSetupIndex];
 
-  // ESC = dismiss (same as Skip — see onDismiss contract)
+  // ESC = dismiss without persisting onboarding.completed. Previous
+  // behavior wrote completed=true on ESC during first-run, which left
+  // the operator with a profile that *says* it finished onboarding but
+  // has no working backend configured. The user's #467 follow-up
+  // explicitly called this out: "don't write anything to the config
+  // saying we succeeded with the wizard until we really truly did."
+  // Now: ESC + Skip both leave `completed` unchanged (false for fresh
+  // profiles → wizard auto-fires again next launch). Only the Done
+  // step's "Open my workspace" persists completion.
   useEffect(() => {
     const handler = (event: KeyboardEvent): void => {
       if (event.key === "Escape" && !submitting) {
         event.preventDefault();
-        props.onDismiss(!isReplay);
+        props.onDismiss(false);
       }
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [isReplay, props, submitting]);
+  }, [props, submitting]);
 
   // Reset the naming step's defaults when the operator changes Step 2's
   // selection. Isolated → single canonical default "pwragent" (unless
@@ -183,6 +203,8 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
   const nextStep = useCallback(
     (current: WizardStep): WizardStep | null => {
       switch (current) {
+        case "backend-requirements":
+          return "welcome";
         case "welcome":
           return "thread-presentation";
         case "thread-presentation":
@@ -213,7 +235,14 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
   const prevStep = useCallback(
     (current: WizardStep): WizardStep | null => {
       switch (current) {
+        case "backend-requirements":
+          return null;
         case "welcome":
+          // Replay path doesn't include backend-requirements, so back
+          // from welcome goes nowhere. First-run path could go back to
+          // backend-requirements but the operator already satisfied
+          // that to leave it — make Back from welcome a no-op too so
+          // the gate doesn't get re-checked midway.
           return null;
         case "thread-presentation":
           return "welcome";
@@ -357,11 +386,13 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
   );
 
   const handleSkip = useCallback((): void => {
-    // Skip mirrors Finish from a persistence standpoint when the
-    // operator was already on first-run — we still mark completed so
-    // they don't see the wizard auto-launch again. Replays skip persist.
-    props.onDismiss(!isReplay);
-  }, [isReplay, props]);
+    // Skip never persists `onboarding.completed = true`. Anything else
+    // would let the operator end up with a "completed" profile that
+    // doesn't actually have a working backend. The wizard re-fires on
+    // the next launch — see the docs on the ESC keydown handler above
+    // for the full reasoning.
+    props.onDismiss(false);
+  }, [props]);
 
   const currentRailIndex = railIndexForStep(step);
 
@@ -374,7 +405,7 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
     >
       <div className="onboarding-wizard-overlay__scrim" />
       <div
-        className={`onboarding-wizard${step === "welcome" || step === "done" ? " onboarding-wizard--narrow" : ""}`}
+        className={`onboarding-wizard${step === "welcome" || step === "done" ? " onboarding-wizard--narrow" : ""}${step === "backend-requirements" ? " onboarding-wizard--medium" : ""}`}
       >
         <WizardTitlebar
           step={step}
@@ -389,7 +420,7 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
               ? `${providerSetupIndex + 1} of ${orderedProviders.length}`
               : undefined
           }
-          onClose={() => props.onDismiss(!isReplay)}
+          onClose={() => props.onDismiss(false)}
         />
         {step !== "welcome" ? (
           <WizardRail
@@ -399,6 +430,12 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
           />
         ) : null}
         <div className="onboarding-wizard__body">
+          {step === "backend-requirements" ? (
+            <BackendRequirementsStep
+              settings={props.settings}
+              desktopApi={props.desktopApi}
+            />
+          ) : null}
           {step === "welcome" ? <WelcomeStep /> : null}
           {step === "thread-presentation" ? (
             <ThreadPresentationStep
@@ -470,6 +507,9 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
             currentProvider ? providerName(currentProvider) : undefined
           }
           codexProfileNamesValid={validateProfileNames(codexProfileNames)}
+          backendRequirementSatisfied={isBackendRequirementSatisfied(
+            props.settings.snapshot,
+          )}
           density={density}
           codexProfileModel={codexProfileModel}
           onBack={goPrev}
@@ -501,9 +541,15 @@ function WizardTitlebar(props: {
   providerPosition?: string;
   onClose: () => void;
 }) {
-  const eyebrow = props.isReplay ? "Replay" : "Welcome";
+  const eyebrow = props.isReplay
+    ? "Replay"
+    : props.step === "backend-requirements"
+      ? "Prerequisites"
+      : "Welcome";
   const crumb = (() => {
     switch (props.step) {
+      case "backend-requirements":
+        return "Backend requirements";
       case "welcome":
         return "First-run setup";
       case "thread-presentation":
@@ -592,6 +638,7 @@ function WizardFooter(props: {
   providerSetupTotal: number;
   currentProviderName?: string;
   codexProfileNamesValid: boolean;
+  backendRequirementSatisfied: boolean;
   density: DesktopAppearanceDensity;
   codexProfileModel: DesktopCodexProfileModel;
   onBack: () => void;
@@ -635,10 +682,25 @@ function WizardFooter(props: {
         : "No providers selected";
   } else if (props.step === "provider-setup") {
     hint = `Provider ${props.providerSetupIndex + 1} of ${props.providerSetupTotal}`;
+  } else if (props.step === "backend-requirements") {
+    hint = props.backendRequirementSatisfied
+      ? "Ready"
+      : "Install Codex CLI or paste an xAI API key to continue";
   }
 
   let primary: ReactNode = null;
-  if (props.step === "welcome") {
+  if (props.step === "backend-requirements") {
+    primary = (
+      <button
+        type="button"
+        className="onboarding-wizard__btn onboarding-wizard__btn--primary"
+        disabled={!props.backendRequirementSatisfied || props.submitting}
+        onClick={props.onNext}
+      >
+        Continue →
+      </button>
+    );
+  } else if (props.step === "welcome") {
     primary = (
       <button
         type="button"
@@ -750,6 +812,234 @@ function WizardFooter(props: {
 /* ----------------------------------------------------------------
    Step bodies
    ---------------------------------------------------------------- */
+
+/**
+ * Returns true when the live snapshot shows at least one valid backend
+ * — either a discoverable Codex CLI candidate that's executable and at
+ * the minimum supported version, OR an xAI/Grok API key configured in
+ * the keychain. The wizard's Step 0 footer enables Continue based on
+ * this; downstream wizard steps assume this has already been satisfied,
+ * which lets them defer Codex CLI execution until a known-good backend
+ * exists (see `CodexAppServerClient.isCodexBootstrapDeferred`).
+ */
+function isBackendRequirementSatisfied(
+  snapshot: DesktopSettingsSnapshot | undefined,
+): boolean {
+  if (!snapshot) return false;
+  const codexSelected = snapshot.models.codex.discovery.candidates.some(
+    (candidate) => candidate.selected && candidate.executable,
+  );
+  const grokConfigured = snapshot.models.grok.apiKey.configured;
+  return codexSelected || grokConfigured;
+}
+
+function BackendRequirementsStep(props: {
+  settings: DesktopSettingsState;
+  desktopApi?: DesktopApi;
+}) {
+  const snapshot = props.settings.snapshot;
+  const discovery = snapshot?.models.codex.discovery;
+  const grokKey = snapshot?.models.grok.apiKey;
+  const codexCandidate = discovery?.candidates.find(
+    (candidate) => candidate.selected && candidate.executable,
+  );
+  const codexOk = Boolean(codexCandidate);
+  const grokOk = Boolean(grokKey?.configured);
+
+  const [refreshing, setRefreshing] = useState(false);
+  const [grokKeyInput, setGrokKeyInput] = useState("");
+  const [savingGrok, setSavingGrok] = useState(false);
+  const [grokError, setGrokError] = useState<string | undefined>(undefined);
+
+  const refresh = async (): Promise<void> => {
+    if (!props.desktopApi?.refreshCodexDiscovery || refreshing) return;
+    setRefreshing(true);
+    try {
+      await props.desktopApi.refreshCodexDiscovery({});
+    } catch (caught) {
+      // eslint-disable-next-line no-console
+      console.warn("Onboarding: refreshCodexDiscovery failed", caught);
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  const saveGrokKey = async (): Promise<void> => {
+    const value = grokKeyInput.trim();
+    if (!value || savingGrok) return;
+    setSavingGrok(true);
+    setGrokError(undefined);
+    const ok = await props.settings.replaceSecret("grokApiKey", value);
+    if (ok) {
+      setGrokKeyInput("");
+    } else {
+      setGrokError(
+        props.settings.error ??
+          "Could not save the API key. Check the Settings → Models error log.",
+      );
+    }
+    setSavingGrok(false);
+  };
+
+  return (
+    <div className="onboarding-wizard__prereqs">
+      <header className="onboarding-wizard__head">
+        <h1 className="onboarding-wizard__title">
+          Pick at least one backend to continue
+        </h1>
+        <p className="onboarding-wizard__sub">
+          PwrAgent runs on top of one or both of these backends. You only
+          need one to get started — the rest of the wizard configures
+          profiles and messaging on top.
+        </p>
+      </header>
+
+      <div className="onboarding-wizard__prereq-card">
+        <div className="onboarding-wizard__prereq-head">
+          <div>
+            <div className="onboarding-wizard__prereq-title">Codex CLI</div>
+            <div className="onboarding-wizard__prereq-sub">
+              Required for the Codex backend. PwrAgent shells out to the
+              installed binary; we don&rsquo;t bundle it.
+            </div>
+          </div>
+          <span
+            className={`onboarding-wizard__prereq-status ${
+              codexOk
+                ? "onboarding-wizard__prereq-status--ok"
+                : "onboarding-wizard__prereq-status--missing"
+            }`}
+          >
+            {codexOk ? (
+              <>
+                ✓ Found{codexCandidate?.version ? ` v${codexCandidate.version}` : ""}
+              </>
+            ) : (
+              "Not found"
+            )}
+          </span>
+        </div>
+        {codexOk ? (
+          <div className="onboarding-wizard__prereq-detail">
+            <code>{codexCandidate?.command}</code>
+            <button
+              type="button"
+              className="onboarding-wizard__btn onboarding-wizard__btn--ghost"
+              disabled={refreshing}
+              onClick={() => void refresh()}
+            >
+              {refreshing ? "Refreshing…" : "Refresh"}
+            </button>
+          </div>
+        ) : (
+          <div className="onboarding-wizard__prereq-detail">
+            <details className="onboarding-wizard__prereq-paths">
+              <summary>
+                Searched {discovery?.candidates.length ?? 0} location
+                {discovery && discovery.candidates.length === 1 ? "" : "s"}{" "}
+                — none with a usable Codex
+              </summary>
+              <ul>
+                {discovery?.candidates.map((candidate) => (
+                  <li key={candidate.command}>
+                    <code>{candidate.command}</code>
+                    <span className="onboarding-wizard__prereq-paths-reason">
+                      {candidate.executable
+                        ? candidate.failureReason ?? "no version"
+                        : candidate.failureReason === "not_found"
+                          ? "not found"
+                          : candidate.failureReason ?? "not executable"}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </details>
+            <div className="onboarding-wizard__prereq-install">
+              <strong>Install:</strong>
+              <ul>
+                <li>
+                  npm: <code>npm install -g @openai/codex</code>
+                </li>
+                <li>
+                  pnpm: <code>pnpm add -g @openai/codex</code>
+                </li>
+                <li>
+                  Homebrew (macOS / Linux):{" "}
+                  <code>brew install --cask codex</code>
+                </li>
+              </ul>
+              <button
+                type="button"
+                className="onboarding-wizard__btn onboarding-wizard__btn--ghost"
+                disabled={refreshing}
+                onClick={() => void refresh()}
+              >
+                {refreshing ? "Refreshing…" : "Refresh after install"}
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="onboarding-wizard__prereq-card">
+        <div className="onboarding-wizard__prereq-head">
+          <div>
+            <div className="onboarding-wizard__prereq-title">xAI API key</div>
+            <div className="onboarding-wizard__prereq-sub">
+              Required for the Grok backend. Stored in your system keychain.
+            </div>
+          </div>
+          <span
+            className={`onboarding-wizard__prereq-status ${
+              grokOk
+                ? "onboarding-wizard__prereq-status--ok"
+                : "onboarding-wizard__prereq-status--missing"
+            }`}
+          >
+            {grokOk ? "✓ Configured" : "Not configured"}
+          </span>
+        </div>
+        {!grokOk ? (
+          <div className="onboarding-wizard__prereq-detail">
+            <div className="onboarding-wizard__field-row">
+              <input
+                type="password"
+                className="onboarding-wizard__input"
+                placeholder="xai-…"
+                value={grokKeyInput}
+                disabled={savingGrok}
+                onChange={(e) => setGrokKeyInput(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    void saveGrokKey();
+                  }
+                }}
+              />
+              <button
+                type="button"
+                className="onboarding-wizard__btn onboarding-wizard__btn--ghost"
+                disabled={!grokKeyInput.trim() || savingGrok}
+                onClick={() => void saveGrokKey()}
+              >
+                {savingGrok ? "Saving…" : "Save"}
+              </button>
+            </div>
+            <div className="onboarding-wizard__prereq-link">
+              Get a key at{" "}
+              <code>https://console.x.ai/team/default/api-keys</code>
+            </div>
+            {grokError ? (
+              <span className="onboarding-wizard__field-error">
+                {grokError}
+              </span>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
 
 function WelcomeStep() {
   return (

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -11083,15 +11083,11 @@ textarea,
 
 /* ============================================================
    ONBOARDING WIZARD — Step 0: Backend requirements
-   Pre-rail prerequisite check shown before Welcome. Two cards
-   side-by-side conceptually but stacked vertically for narrower
-   widths — Codex CLI discovery + xAI key.
+   Pre-rail prerequisite check shown before Welcome. Uses the
+   --narrow width (same as Welcome / Done) — two stacked cards
+   (Codex CLI + xAI key) read fine at 720px; anything wider just
+   leaves dead horizontal space.
    ============================================================ */
-.onboarding-wizard--medium {
-  width: min(880px, calc(100vw - 64px));
-  grid-template-rows: auto 1fr auto;
-}
-
 .onboarding-wizard__prereqs {
   display: flex;
   flex-direction: column;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -11080,3 +11080,132 @@ textarea,
   letter-spacing: 0.08em;
   word-break: break-all;
 }
+
+/* ============================================================
+   ONBOARDING WIZARD — Step 0: Backend requirements
+   Pre-rail prerequisite check shown before Welcome. Two cards
+   side-by-side conceptually but stacked vertically for narrower
+   widths — Codex CLI discovery + xAI key.
+   ============================================================ */
+.onboarding-wizard--medium {
+  width: min(880px, calc(100vw - 64px));
+  grid-template-rows: auto 1fr auto;
+}
+
+.onboarding-wizard__prereqs {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.onboarding-wizard__prereq-card {
+  background: var(--bg-panel-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: 10px;
+  padding: 14px 16px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.onboarding-wizard__prereq-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+.onboarding-wizard__prereq-title {
+  font: 650 14px/1.2 var(--font-sans, sans-serif);
+  color: var(--text-primary);
+  margin: 0 0 4px;
+}
+.onboarding-wizard__prereq-sub {
+  font: 400 12px/1.5 var(--font-sans, sans-serif);
+  color: var(--text-secondary);
+}
+.onboarding-wizard__prereq-status {
+  font: 600 11px/1 var(--font-sans, sans-serif);
+  padding: 5px 8px;
+  border-radius: 5px;
+  border: 1px solid var(--border-subtle);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.onboarding-wizard__prereq-status--ok {
+  color: var(--success-text);
+  background: var(--success-soft);
+  border-color: var(--success-border);
+}
+.onboarding-wizard__prereq-status--missing {
+  color: var(--danger-text);
+  background: var(--danger-soft);
+  border-color: var(--danger-border);
+}
+.onboarding-wizard__prereq-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.onboarding-wizard__prereq-detail code {
+  font: 500 12px/1.4 var(--font-mono);
+  color: var(--text-secondary);
+  background: var(--bg-input);
+  border: 1px solid var(--border-subtle);
+  border-radius: 4px;
+  padding: 2px 6px;
+  word-break: break-all;
+}
+.onboarding-wizard__prereq-paths summary {
+  font: 500 12px/1.3 var(--font-sans, sans-serif);
+  color: var(--text-muted);
+  cursor: pointer;
+  list-style: revert;
+}
+.onboarding-wizard__prereq-paths ul {
+  list-style: none;
+  margin: 8px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.onboarding-wizard__prereq-paths li {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: center;
+  font: 500 11px/1.3 var(--font-mono);
+}
+.onboarding-wizard__prereq-paths-reason {
+  color: var(--text-muted);
+  font-style: italic;
+}
+.onboarding-wizard__prereq-install {
+  background: var(--bg-input);
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  padding: 10px 12px;
+  font: 400 12px/1.5 var(--font-sans, sans-serif);
+  color: var(--text-secondary);
+}
+.onboarding-wizard__prereq-install ul {
+  list-style: none;
+  margin: 6px 0 8px;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.onboarding-wizard__prereq-install code {
+  font: 500 11px/1.3 var(--font-mono);
+  color: var(--text-primary);
+  background: var(--bg-app);
+  border: 1px solid var(--border-strong);
+  border-radius: 3px;
+  padding: 1px 5px;
+}
+.onboarding-wizard__prereq-link {
+  font: 400 12px/1.4 var(--font-sans, sans-serif);
+  color: var(--text-muted);
+}
+.onboarding-wizard__prereq-link code {
+  font-size: 11px;
+}


### PR DESCRIPTION
Follow-up to #491. Reported by a user running `main` on Linux without Codex CLI installed: PwrAgent still tries to spawn `codex` at startup. PR #500's gate only short-circuited `listThreads` — `describeCodexBackend` (called by `listBackends` on every renderer mount) still ran the full `ensureInitialized → spawn("codex")` path. On Linux without Codex on PATH that ENOENT'd visibly.

Four pieces:

## A. Spawn gate at the client level (`369010cf`)

- `CodexAppServerClient` gains optional `isCodexBootstrapDeferred: () => boolean`. `ensureInitialized` checks it on entry and throws a typed `CodexBootstrapDeferredError` before any `connection.connect()` call.
- `BackendRegistry` wires the predicate to `DesktopSettingsService.isCodexBootstrapDeferred()` — the same single-source-of-truth the `listThreads` gate uses.
- `describeCodexBackend` already catches initialize failures via `Promise.allSettled`, so the renderer renders a clean "Codex unavailable" instead of the ENOENT noise.
- `resolveCodexCommand` no longer falls back to `"codex"` when discovery is empty — throws a typed `CodexCliNotInstalledError`. The fallback was a no-op since `discoverCommands` already searches PATH.

## B. Linux + cross-platform discovery paths (`369010cf`)

`getCodexAppCandidatePaths()` was macOS-only. Renamed to `getCodexInstallCandidatePaths(platform)` with platform-specific candidates:

- **Linux**: `/usr/bin`, `/usr/local/bin`, `/opt/codex/bin`, `/snap/bin`, `~/.local/bin`, `~/.npm-global/bin`, `~/.local/share/pnpm`, `~/.bun/bin`, `~/.cargo/bin`, Linuxbrew prefixes (both system + user)
- **Windows** (symmetric, no field report yet): npm-global `.cmd` shim + `LOCALAPPDATA/Programs/codex`
- **macOS**: unchanged
- **Other unix**: FHS basics

These matter because Electron's spawned-process `PATH` on Linux typically doesn't include `~/.local/bin` or per-language toolchain bin dirs. Explicit auto-candidates fix that.

## C. Wizard Step 0 — Backend requirements (`b6bfec05`)

New first-run-only step *before* Welcome. Two cards:

- **Codex CLI** — auto-discovered executable + version (e.g. `✓ Found v0.131.0-alpha.9 — /Applications/Codex.app/.../codex`). When discovery is empty, lists every path searched + install instructions (`npm`, `pnpm`, `brew`) + Refresh button.
- **xAI API key** — paste-key inline (stored via `replaceSettingsSecret` into the system keychain).

Continue disabled until at least one side satisfies. Footer hint reads "Install Codex CLI or paste an xAI API key to continue" while unsatisfied, "Ready" once met.

Replays (Help → Replay Onboarding) skip Step 0 — already past the gate.

Pre-rail: doesn't alter the existing 4-entry rail (Thread / Codex / Messaging / Review). New eyebrow "PREREQUISITES".

## D. Completion gating (`b6bfec05`)

`onboarding.completed = true` no longer gets written on ESC, close (X), or any "Skip setup" link. Only the Done step's "Open my workspace" persists it. Per the bug report:

> "make sure to ... don't write anything to the config saying we succeeded with the wizard until we really truly did"

A user who closes/skips mid-wizard re-fires the wizard next launch. Combined with Step 0's backend gate, no completion marker without (a) a valid backend AND (b) explicit Finish.

## Tests

- `codex-discovery.test.ts` gains 3 cases: Linux `/usr/local/bin/codex` discoverable with empty PATH, `~/.local/bin/codex` user-install discoverable, `resolveCodexCommand` throws `CodexCliNotInstalledError` when discovery is empty.
- 296 targeted tests pass overall.
- `lint:boundaries` clean (1247 modules / 1926 deps).

## Smoke (macOS, fresh `PWRAGENT_PROFILE=onboarding-smoke`)

- Step 0 auto-renders with Codex `✓ Found v0.131.0-alpha.9` + path, xAI `Not configured` + paste input, Continue enabled
- Sidebar shows "No threads yet" while wizard is open (Codex spawn correctly deferred end-to-end)
- ESC at any step leaves `[onboarding] completed = false` on disk
- Relaunch with same profile fires the wizard again at Step 0 (proves no premature completion)
- Continue → Welcome → existing flow unchanged

## Test plan

- [x] macOS fresh profile — Step 0 finds Codex.app, Continue enabled
- [ ] Linux fresh profile, no Codex installed — Step 0 shows "Not found" + paste xAI key + Continue enables
- [ ] Linux fresh profile, Codex at `~/.local/bin/codex` — Step 0 finds it without setting `CODEX_COMMAND`
- [ ] ESC mid-wizard — relaunch shows wizard again at Step 0
- [ ] Done step "Open my workspace" — completion persists, wizard does not re-fire
- [ ] Replay from Help menu — skips Step 0, starts at Welcome

🤖 Generated with [Claude Code](https://claude.com/claude-code)