### PR TITLE
fix(desktop): suppress selection bar overlap on directory header

### DIFF
--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -312,6 +312,24 @@ describe("Tangerine Terminal theme contract", () => {
     expect(summaryMetaRule).toContain("flex: 0 0 auto;");
   });
 
+  it("suppresses the selection-indicator bar on directory-summary rows so it can't paint over the folder icon", () => {
+    // `.directory-row__summary` reuses `.thread-row` for typography and
+    // selection tokens, but tightens its lateral padding to 4px so the
+    // folder icon sits close to the row edge. The base
+    // `.thread-row.is-selected::before` accent bar (positioned at
+    // left:5px, width:3px) would paint over the folder icon under that
+    // tighter inset. The header already conveys selection via the
+    // accent border + tinted background from `.thread-row.is-selected`,
+    // so the redundant bar is suppressed via `content: none`. If this
+    // override is removed, the orange bar reappears across the folder
+    // glyph the next time a directory header is selected.
+    const overrideRule = extractRuleBody(
+      css,
+      ".directory-row__summary.is-selected::before",
+    );
+    expect(overrideRule).toContain("content: none;");
+  });
+
   it("keeps thread context menu hover states visible (skipping disabled rows)", () => {
     // The `:not(:disabled)` qualifier was added so disabled menu
     // items (Move Up at top of pinned list / Move Down at bottom)

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2104,6 +2104,17 @@ textarea,
   pointer-events: none;
 }
 
+/* Directory-summary rows reuse `.thread-row` for typography + selection
+   tokens, but the row's lateral padding is tightened to 4px so the
+   folder icon sits close to the row edge. The base `::before` accent
+   bar (positioned at left:5px) would paint over the folder icon under
+   that tighter inset. The row already telegraphs selection via the
+   accent border and tinted background from `.thread-row.is-selected`,
+   so the redundant bar is suppressed here. */
+.directory-row__summary.is-selected::before {
+  content: none;
+}
+
 .thread-row__header {
   display: flex;
   align-items: baseline;


### PR DESCRIPTION
## Summary

- The `.thread-row.is-selected::before` accent bar (positioned at `left: 5px`, width `3px`) was painting over the folder icon on selected directory-summary rows. `.directory-row__summary` tightens the row's left padding to `4px`, so the icon's left edge (x=4) sits directly under the bar (x=5–8).
- Repro: open the sidebar's Directories lens, click any directory header to expand it, then click its `+` (launchpad) button — the directory row picks up `is-selected` and the orange bar paints over the folder icon.
- Fix: suppress the `::before` bar specifically for `.directory-row__summary.is-selected` via `content: none`. The header already telegraphs selection via the accent border and tinted background from `.thread-row.is-selected`, so the extra bar was redundant here. Thread rows under the header are unaffected.

## Test plan

- [x] `pnpm test apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx` — 27/27 passing
- [x] Visual verification in the running dev app (port 5175): click a pinned directory header, click `+`, confirm the orange overlap is gone and the row still reads as selected via the accent border + background

🤖 Generated with [Claude Code](https://claude.com/claude-code)