### PR TITLE
fix(desktop): gate onboarding startup on Linux

### DIFF
--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -26,6 +26,7 @@ import {
 } from "./settings/appearance-bootstrap";
 
 const isDevelopment = process.env.NODE_ENV !== "production";
+const isMac = process.platform === "darwin";
 const mainLog = getMainLogger("pwragent:main");
 const heapLog = getMainLogger("pwragent:heap");
 const rendererConsoleLog = getMainLogger("pwragent:renderer:console");
@@ -178,6 +179,12 @@ export function createMainWindow(options?: {
 }): BrowserWindow {
   const preloadPath = getPreloadPath();
   const appearance = readBootstrapAppearance();
+  const macWindowChrome = isMac
+    ? {
+        titleBarStyle: "hiddenInset" as const,
+        trafficLightPosition: { x: 20, y: 18 },
+      }
+    : {};
   const window = new BrowserWindow({
     width: 1440,
     height: 960,
@@ -185,8 +192,7 @@ export function createMainWindow(options?: {
     minHeight: 760,
     show: false,
     title: "PwrAgent",
-    titleBarStyle: "hiddenInset",
-    trafficLightPosition: { x: 20, y: 18 },
+    ...macWindowChrome,
     // Pre-tinted so the OS window fill matches the renderer's first
     // paint and we don't flash dark before a light renderer mounts.
     //
@@ -231,9 +237,25 @@ export function createMainWindow(options?: {
     void window.loadFile(rendererEntry.value);
   }
 
-  window.once("ready-to-show", () => {
+  let windowShown = false;
+  const showWindow = (reason: "ready-to-show" | "fallback"): void => {
+    if (windowShown || window.isDestroyed?.()) {
+      return;
+    }
+    windowShown = true;
+    if (isDevelopment) {
+      mainLog.info("showing window", { reason });
+    }
     window.show();
+  };
+  window.once("ready-to-show", () => {
+    showWindow("ready-to-show");
   });
+  if (!isMac) {
+    window.webContents.once("did-finish-load", () => {
+      setTimeout(() => showWindow("fallback"), 500);
+    });
+  }
 
   const { webContents } = window;
   attachWindowFocusSync(window);

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -144,12 +144,19 @@ function DesktopAppShell(props: {
     void desktopApi?.openMessagingActivityWindow?.();
   }, [desktopApi]);
   const settings = props.settings;
+  const normalAppEnabled =
+    !desktopApi?.readSettings ||
+    (Boolean(settings.snapshot) &&
+      settings.snapshot?.onboarding?.completed.value !== false);
   const profiles = usePwrAgentProfiles(desktopApi);
   const runtimeIdentity = useRuntimeIdentity(desktopApi);
   const navigation = useThreadNavigation(desktopApi, {
+    enabled: normalAppEnabled,
     threadViewVisible: mainView === "thread",
   });
-  const backendSummaries = useBackendSummaries(desktopApi);
+  const backendSummaries = useBackendSummaries(desktopApi, {
+    enabled: normalAppEnabled,
+  });
   const pullRequests = usePullRequestRefresh({
     desktopApi,
     onRefreshNavigation: navigation.refresh,
@@ -516,6 +523,7 @@ function DesktopAppShell(props: {
               await desktopApi.completeOnboardingCodexBootstrap({
                 connect: true,
               });
+              await settings.refresh();
             }
             setOnboardingOpen(null);
           }}
@@ -528,7 +536,7 @@ function DesktopAppShell(props: {
               // restart) will surface them.
               void desktopApi?.completeOnboardingCodexBootstrap?.({
                 connect: false,
-              });
+              }).then(() => settings.refresh());
             }
             setOnboardingOpen(null);
           }}

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -93,7 +93,7 @@ describe("App", () => {
     cleanup();
   });
 
-  it("shows the thread shell while the startup settings read is pending", async () => {
+  it("shows the thread shell without starting backends while the startup settings read is pending", async () => {
     const listBackends = vi.fn(async () => ({
       fetchedAt: Date.now(),
       backends: [],
@@ -133,10 +133,8 @@ describe("App", () => {
     await waitFor(() => {
       expect(readSettings).toHaveBeenCalledTimes(1);
     });
-    await waitFor(() => {
-      expect(listBackends).toHaveBeenCalledTimes(1);
-      expect(getNavigationSnapshot).toHaveBeenCalledTimes(1);
-    });
+    expect(listBackends).not.toHaveBeenCalled();
+    expect(getNavigationSnapshot).not.toHaveBeenCalled();
   });
 
   it("blocks the app shell when desktop settings config is malformed", async () => {
@@ -344,7 +342,7 @@ describe("App", () => {
     expect(screen.queryByRole("complementary", { name: "Threads" })).not.toBeInTheDocument();
   });
 
-  it("starts loading navigation before settings discovery completes", async () => {
+  it("starts loading navigation after settings discovery completes", async () => {
     const settings = createDeferred<{ snapshot: DesktopSettingsSnapshot }>();
     const getNavigationSnapshot = vi.fn(async () => ({
       backend: "all" as const,
@@ -373,6 +371,33 @@ describe("App", () => {
     });
 
     render(<App />);
+
+    expect(getNavigationSnapshot).not.toHaveBeenCalled();
+
+    await act(async () => {
+      settings.resolve({
+        snapshot: {
+          general: {
+            appearance: {
+              theme: { value: "system", source: "default" },
+              density: { value: "mission-control", source: "default" },
+            },
+          },
+          onboarding: {
+            completed: { value: true, source: "default" },
+          },
+          imageUploads: {
+            pastedImageMaxPatches: { value: 1536, source: "default" },
+          },
+          experimental: {
+            fullAccessRiskWarningDismissed: {
+              value: false,
+              source: "default",
+            },
+          },
+        } as DesktopSettingsSnapshot,
+      });
+    });
 
     await waitFor(() => {
       expect(getNavigationSnapshot).toHaveBeenCalledTimes(1);

--- a/apps/desktop/src/renderer/src/lib/useBackendSummaries.ts
+++ b/apps/desktop/src/renderer/src/lib/useBackendSummaries.ts
@@ -10,12 +10,24 @@ type BackendSummaryState = {
 export const BACKEND_SUMMARIES_REFRESH_EVENT =
   "pwragent:backend-summaries-refresh";
 
-export function useBackendSummaries(desktopApi?: DesktopApi): BackendSummaryState {
+export function useBackendSummaries(
+  desktopApi?: DesktopApi,
+  options: { enabled?: boolean } = {},
+): BackendSummaryState {
+  const enabled = options.enabled ?? true;
   const [state, setState] = useState<BackendSummaryState>({
     backends: []
   });
 
   const refresh = useCallback(async (): Promise<void> => {
+    if (!enabled) {
+      setState({
+        backends: [],
+        error: undefined
+      });
+      return;
+    }
+
     if (!desktopApi?.listBackends) {
       setState({
         backends: [],
@@ -38,21 +50,24 @@ export function useBackendSummaries(desktopApi?: DesktopApi): BackendSummaryStat
         error: error instanceof Error ? error.message : String(error)
       });
     }
-  }, [desktopApi]);
+  }, [desktopApi, enabled]);
 
   useEffect(() => {
     void refresh();
   }, [refresh]);
 
   useEffect(() => {
+    if (!enabled) {
+      return;
+    }
     window.addEventListener(BACKEND_SUMMARIES_REFRESH_EVENT, refresh);
     return () => {
       window.removeEventListener(BACKEND_SUMMARIES_REFRESH_EVENT, refresh);
     };
-  }, [refresh]);
+  }, [enabled, refresh]);
 
   useEffect(() => {
-    if (!desktopApi?.onAgentEvent) {
+    if (!enabled || !desktopApi?.onAgentEvent) {
       return;
     }
     return desktopApi.onAgentEvent((event) => {
@@ -64,7 +79,7 @@ export function useBackendSummaries(desktopApi?: DesktopApi): BackendSummaryStat
         void refresh();
       }
     });
-  }, [desktopApi, refresh]);
+  }, [desktopApi, enabled, refresh]);
 
   return state;
 }

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -1310,6 +1310,7 @@ function buildOptimisticUserMessage(
 }
 
 type UseThreadNavigationOptions = {
+  enabled?: boolean;
   threadViewVisible?: boolean;
 };
 
@@ -1434,6 +1435,7 @@ export function useThreadNavigation(
   const cancelThreadExecutionModeQueueRequest =
     desktopApi?.cancelThreadExecutionModeQueue;
   const setThreadModelSettings = desktopApi?.setThreadModelSettings;
+  const enabled = options.enabled ?? true;
   const threadViewVisible = options.threadViewVisible ?? true;
   const [browseMode, setBrowseMode] = useState<BrowseMode>("inbox");
   const [selectedItemKey, setSelectedItemKey] = useState<string>();
@@ -1464,7 +1466,7 @@ export function useThreadNavigation(
   const [pickDirectoryError, setPickDirectoryError] = useState<string>();
   const [pickingDirectory, setPickingDirectory] = useState(false);
   const [state, setState] = useState<NavigationState>({
-    loading: true,
+    loading: enabled,
     refreshing: false,
   });
   const [viewForeground, setViewForeground] = useState(isRendererViewForeground);
@@ -1523,6 +1525,16 @@ export function useThreadNavigation(
       preferredOptimisticThread?: NavigationThreadSummary,
       forcePreferredSelection = false
     ): Promise<void> => {
+      if (!enabled) {
+        setState({
+          loading: false,
+          refreshing: false,
+          error: undefined,
+          response: undefined,
+        });
+        return;
+      }
+
       if (!desktopApi?.getNavigationSnapshot) {
         setState({
           loading: false,
@@ -1613,7 +1625,7 @@ export function useThreadNavigation(
         }));
       }
     },
-    [desktopApi]
+    [desktopApi, enabled]
   );
 
   const refresh = useCallback(
@@ -1720,11 +1732,21 @@ export function useThreadNavigation(
   }, []);
 
   useEffect(() => {
+    if (!enabled) {
+      setState({
+        loading: false,
+        refreshing: false,
+        error: undefined,
+        response: undefined,
+      });
+      return;
+    }
+
     void refresh();
-  }, [refresh]);
+  }, [enabled, refresh]);
 
   useEffect(() => {
-    if (!desktopApi?.getNavigationSnapshot) {
+    if (!enabled || !desktopApi?.getNavigationSnapshot) {
       return;
     }
 
@@ -1735,20 +1757,20 @@ export function useThreadNavigation(
     return () => {
       clearInterval(timer);
     };
-  }, [desktopApi?.getNavigationSnapshot, scheduleRefresh]);
+  }, [desktopApi?.getNavigationSnapshot, enabled, scheduleRefresh]);
 
   useEffect(() => {
-    if (!desktopApi?.onWindowFocus) {
+    if (!enabled || !desktopApi?.onWindowFocus) {
       return;
     }
 
     return desktopApi.onWindowFocus(() => {
       scheduleRefresh();
     });
-  }, [desktopApi, scheduleRefresh]);
+  }, [desktopApi, enabled, scheduleRefresh]);
 
   useEffect(() => {
-    if (!desktopApi?.onAgentEvent) {
+    if (!enabled || !desktopApi?.onAgentEvent) {
       return;
     }
 
@@ -2086,7 +2108,7 @@ export function useThreadNavigation(
         scheduleRefresh();
       }
     });
-  }, [desktopApi, scheduleRefresh, state.response]);
+  }, [desktopApi, enabled, scheduleRefresh, state.response]);
 
   // Bindings live in the navigation snapshot but are mutated outside
   // the agent-event bus (a Telegram callback creates a binding, a
@@ -2094,13 +2116,13 @@ export function useThreadNavigation(
   // backend notifications). Without this hook the binding chip stays
   // stale until the next backend tick. See issue #191.
   useEffect(() => {
-    if (!desktopApi?.onMessagingBindingsChanged) {
+    if (!enabled || !desktopApi?.onMessagingBindingsChanged) {
       return;
     }
     return desktopApi.onMessagingBindingsChanged(() => {
       scheduleRefresh();
     });
-  }, [desktopApi, scheduleRefresh]);
+  }, [desktopApi, enabled, scheduleRefresh]);
 
   const threads = useMemo(() => {
     const currentThreads = state.response?.threads ?? [];


### PR DESCRIPTION
## Summary

PwrAgent now treats first-run onboarding as a blocking startup state, so a fresh Linux profile can reach the wizard without the renderer immediately asking the backend layer to launch Codex.

This also makes the main window more tolerant of Linux desktop environments where Electron's `ready-to-show` never fires, which we hit in VMware Fusion: the window now falls back to showing after the renderer finishes loading, while keeping the existing macOS chrome behavior unchanged on Darwin.

## Test Plan

- `pnpm --filter @pwragent/desktop typecheck`
- Manual Ubuntu VM smoke test on VMware Fusion: fresh profile reached the onboarding wizard and showed the window via `reason=fallback`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
