### PR TITLE
fix(desktop): wrap long lines in transcript inline + fenced code

### DIFF
--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -597,6 +597,29 @@ describe("Tangerine Terminal theme contract", () => {
     expect(inlineCodeRule).toContain("max-width: 100%;");
   });
 
+  it("wraps fenced code blocks the same way the composer does", () => {
+    // The composer's `<pre>` uses `white-space: pre-wrap` so a pasted
+    // long line wraps inside the input rather than scrolling. The
+    // transcript previously rendered fenced blocks with
+    // `overflow-x: auto` + `white-space: pre`, which meant the same
+    // text the user typed in the composer rendered with horizontal
+    // scroll once it landed in the transcript. Mirror the composer:
+    // `pre-wrap` preserves newlines + indentation but lets soft lines
+    // wrap, and `overflow-wrap: anywhere` lets unbroken strings (URLs,
+    // long identifiers) break at any character. The inner `<code>`
+    // inherits both so its `white-space: pre` default doesn't override
+    // the pre's wrap.
+    const preRule = extractRuleBody(css, ".transcript-message__pre");
+    expect(preRule).toContain("white-space: pre-wrap;");
+    expect(preRule).toContain("overflow-wrap: anywhere;");
+    expect(preRule).not.toContain("overflow-x: auto;");
+
+    const preCodeRule = extractRuleBody(css, ".transcript-message__pre code");
+    expect(preCodeRule).toContain("white-space: inherit;");
+    expect(preCodeRule).toContain("overflow-wrap: inherit;");
+    expect(preCodeRule).not.toContain("white-space: pre;");
+  });
+
   it("keeps thinking scanner variants on one shared visible sweep", () => {
     expect(css).toContain("--thinking-scanner-progress: 0;");
     expect(css).toContain("--thinking-scanner-full-offset: 0px;");

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -580,6 +580,23 @@ describe("Tangerine Terminal theme contract", () => {
     );
   });
 
+  it("wraps long unbroken strings inside inline `code` spans instead of forcing horizontal scroll", () => {
+    // A pasted long URL inside single backticks renders as
+    // `<code class="transcript-message__code">…</code>`. The element is
+    // `display: inline-block` for the padded chip look, which by default
+    // sizes to its intrinsic content width — so an unbroken URL stretches
+    // the inline-block past the message column and pushes the surrounding
+    // transcript into horizontal scroll.
+    //
+    // Lock `overflow-wrap: anywhere;` on the inline code chip so the
+    // browser is allowed to break the string at any character when it
+    // would otherwise overflow, and pair it with `max-width: 100%;` so
+    // the chip cannot exceed the message column.
+    const inlineCodeRule = extractRuleBody(css, ".transcript-message__code");
+    expect(inlineCodeRule).toContain("overflow-wrap: anywhere;");
+    expect(inlineCodeRule).toContain("max-width: 100%;");
+  });
+
   it("keeps thinking scanner variants on one shared visible sweep", () => {
     expect(css).toContain("--thinking-scanner-progress: 0;");
     expect(css).toContain("--thinking-scanner-full-offset: 0px;");

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5839,12 +5839,14 @@ textarea,
 
 .transcript-message__code {
   display: inline-block;
+  max-width: 100%;
   padding: 1px 6px;
   border: 1px solid var(--border-subtle);
   border-radius: 6px;
   background: var(--bg-panel-elevated);
   font-size: 12px;
   font-family: var(--font-mono);
+  overflow-wrap: anywhere;
 }
 
 .transcript-message__pre {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5850,11 +5850,12 @@ textarea,
 }
 
 .transcript-message__pre {
-  overflow-x: auto;
   padding: 12px;
   border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: var(--bg-app);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 .transcript-message__pre code {
@@ -5865,7 +5866,8 @@ textarea,
   font-size: 12px;
   line-height: 1.6;
   font-family: var(--font-mono);
-  white-space: pre;
+  white-space: inherit;
+  overflow-wrap: inherit;
 }
 
 .transcript-message__link {


### PR DESCRIPTION
## Summary

Two related transcript wrap fixes — the trigger was a pasted long URL inside single backticks forcing the transcript message into horizontal scroll, but the same inconsistency existed for fenced blocks: text that wrapped in the composer didn't wrap once it landed in the transcript.

- **Inline code (single backticks).** `.transcript-message__code` is `display: inline-block` for the padded chip look, which sizes to its intrinsic content width. With no `overflow-wrap`, an unbroken URL stretched the chip past the message column. Add `max-width: 100%;` + `overflow-wrap: anywhere;` so the chip wraps inside the column. `max-width: 100%` is required because an `inline-block` otherwise sizes to its intrinsic content width regardless of overflow-wrap.
- **Fenced code blocks (triple backticks).** The composer's `<pre>` uses `white-space: pre-wrap`, so the same text the user pasted there wrapped — but `.transcript-message__pre` was `overflow-x: auto` + `white-space: pre`, so it scrolled in the transcript. That's an authoring/reading inconsistency. Mirror the composer: switch to `pre-wrap` + `overflow-wrap: anywhere`, and have the inner `<code>` inherit both so its `white-space: pre` default doesn't undo the wrap.

Locked in [`theme-contract.test.tsx`](apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx) so a future edit can't quietly drop either contract.

## Test plan

- [x] New `theme-contract.test.tsx` cases fail before the CSS change, pass after
- [x] Full `theme-contract.test.tsx` suite still passes (30/30)
- [x] Visual check in dev: paste a long URL in single backticks — message column does not horizontally scroll
- [x] Visual check in dev: paste a fenced code block with a long line — block wraps in the transcript the same way it wraps in the composer
- [x] Visual check: fenced block with short indented lines still preserves indentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)