### PR TITLE
fix(messaging): return from nested new picker to resume

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -92,6 +92,48 @@ describe("MessagingController", () => {
       });
   });
 
+  it("returns from the nested new-thread picker back to the resume browser", async () => {
+    const harness = await createHarness();
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/resume"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:mode:new",
+      }),
+    );
+
+    const newPicker = harness.delivered.at(-1);
+    expect(newPicker).toMatchObject({
+      kind: "project_picker",
+      prompt: expect.stringContaining("Choose a project for the new PwrAgent thread"),
+      page: {
+        actions: expect.arrayContaining([
+          expect.objectContaining({
+            id: "browse:mode:resume",
+            label: "Resume",
+          }),
+          expect.objectContaining({ id: "browse:cancel" }),
+        ]),
+      },
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:mode:resume",
+      }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "thread_picker",
+      prompt: expect.stringContaining("Choose a thread to resume"),
+      page: {
+        actions: expect.arrayContaining([
+          expect.objectContaining({ id: "browse:mode:new", label: "New" }),
+        ]),
+      },
+    });
+  });
+
   it("filters Full Access threads out of messaging resume when disabled", async () => {
     const navigation = buildNavigationSnapshot();
     navigation.threads = [

--- a/apps/desktop/src/main/__tests__/messaging-resume-browser.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-resume-browser.test.ts
@@ -234,6 +234,38 @@ describe("messaging resume browser", () => {
     expect(intent.prompt).not.toContain("1. PwrAgent");
     expect(intent.fallbackText).toContain("1. PwrAgent");
   });
+
+  it("renders a Resume return action for new-thread pickers opened from resume", () => {
+    const intent = buildResumeIntent({
+      id: "intent-1",
+      createdAt: 1000,
+      navigation: buildNavigationSnapshot(),
+      session: buildBrowseSession({
+        launchAction: "start_new_thread",
+        mode: "new_project",
+        returnTo: {
+          launchAction: "resume_thread",
+          mode: "recents",
+          pageIndex: 0,
+        },
+      }),
+    });
+
+    expect(intent).toMatchObject({
+      kind: "project_picker",
+      fallbackText: expect.stringContaining("resume or cancel"),
+      page: {
+        actions: expect.arrayContaining([
+          expect.objectContaining({
+            id: "browse:mode:resume",
+            label: "Resume",
+            fallbackText: "resume",
+          }),
+          expect.objectContaining({ id: "browse:cancel" }),
+        ]),
+      },
+    });
+  });
 });
 
 function buildBrowseSession(

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -92,6 +92,7 @@ import {
   directoryForProjectSelection,
   parseResumeCommandArgs,
   resumeBrowserPageSize,
+  resumeReturnTargetForSession,
   selectProjectFromValue,
   selectThreadFromValue,
 } from "./messaging-resume-browser.js";
@@ -2783,7 +2784,28 @@ export class MessagingController {
           launchAction: "start_new_thread",
           mode: "new_project",
           pageIndex: 0,
+          returnTo: resumeReturnTargetForSession(nextSession),
           selectedProject: undefined,
+        },
+        navigation,
+        event,
+      );
+      return;
+    }
+    if (actionId === "browse:mode:resume") {
+      const target = session.returnTo;
+      await this.renderResumeBrowser(
+        {
+          ...nextSession,
+          launchAction: "resume_thread",
+          mode: target?.mode ?? "recents",
+          pageIndex: target?.pageIndex ?? 0,
+          preferences: target?.preferences,
+          query: target?.query,
+          returnTo: undefined,
+          selectedProject: target?.selectedProject,
+          workMode: undefined,
+          branchName: undefined,
         },
         navigation,
         event,

--- a/apps/desktop/src/main/messaging/core/messaging-resume-browser.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-resume-browser.ts
@@ -9,6 +9,7 @@ import type {
   MessagingBindingPreferences,
   MessagingBrowseLaunchAction,
   MessagingBrowseMode,
+  MessagingBrowseReturnTarget,
   MessagingBrowseSelectedProject,
   MessagingBrowseSessionRecord,
   MessagingJsonValue,
@@ -479,6 +480,14 @@ function navigationActions(
       fallbackText: "new",
       layout: { row: FOOTER_ROW },
     });
+  } else if (session.returnTo) {
+    actions.push({
+      id: "browse:mode:resume",
+      label: "Resume",
+      style: "navigation",
+      fallbackText: "resume",
+      layout: { row: FOOTER_ROW },
+    });
   }
   actions.push({
     id: "browse:cancel",
@@ -573,6 +582,7 @@ function projectPickerFallbackText(
     page.pageIndex > 0 ? "previous" : undefined,
     page.pageIndex < page.totalPages - 1 ? "next" : undefined,
     session.launchAction === "resume_thread" ? "recent" : undefined,
+    session.returnTo ? "resume" : undefined,
     "cancel",
   ].filter(Boolean);
   return [
@@ -639,4 +649,24 @@ function normalizeOptionDashes(text: string): string {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+export function resumeReturnTargetForSession(
+  session: MessagingBrowseSessionRecord,
+): MessagingBrowseReturnTarget | undefined {
+  if (session.launchAction !== "resume_thread") {
+    return session.returnTo;
+  }
+  if (session.mode === "new_project" || session.mode === "new_thread_options") {
+    return undefined;
+  }
+
+  return {
+    launchAction: "resume_thread",
+    mode: session.mode,
+    pageIndex: session.pageIndex,
+    preferences: session.preferences,
+    query: session.query,
+    selectedProject: session.selectedProject,
+  };
 }

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -942,6 +942,15 @@ export type MessagingBrowseSelectedProject = {
   path?: string;
 };
 
+export type MessagingBrowseReturnTarget = {
+  launchAction: "resume_thread";
+  mode: Exclude<MessagingBrowseMode, "new_project" | "new_thread_options">;
+  pageIndex: number;
+  preferences?: MessagingBindingPreferences;
+  query?: string;
+  selectedProject?: MessagingBrowseSelectedProject;
+};
+
 export type MessagingBrowseSessionRecord = {
   id: string;
   allowedActorIds: string[];
@@ -956,6 +965,7 @@ export type MessagingBrowseSessionRecord = {
   pageSize: number;
   preferences?: MessagingBindingPreferences;
   query?: string;
+  returnTo?: MessagingBrowseReturnTarget;
   workMode?: LaunchpadWorkMode;
   branchName?: string;
   selectedProject?: MessagingBrowseSelectedProject;


### PR DESCRIPTION
## Summary

- I restored the nested `/resume` -> `New` flow so the new-thread project picker keeps a return target for the resume browser.
- I added a `Resume` action to nested new-thread pickers while leaving direct `/new` unchanged.
- I covered the controller callback path and the resume-browser intent builder with regression tests.

## Verification

- I ran `pnpm test apps/desktop/src/main/__tests__/messaging-resume-browser.test.ts apps/desktop/src/main/__tests__/messaging-controller.test.ts`.
- I ran `pnpm --filter @pwragent/messaging-interface typecheck`.
- I ran `pnpm --filter @pwragent/desktop typecheck`.
- I ran `pnpm lint:boundaries`.

## Notes

- The branch was rebased onto current `origin/main` before opening the PR so the diff contains only this messaging fix.
