### PR TITLE
fix(desktop): make empty thread pane draggable

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -18,6 +18,7 @@ import {
   type DesktopSettingsState,
 } from "./features/settings/useDesktopSettings";
 import type { ThreadViewProps } from "./features/thread-detail/ThreadView";
+import { ThreadPlaceholderHeader } from "./features/thread-detail/ThreadPlaceholderHeader";
 import { useComposerDraftStore } from "./features/composer/useComposerDraftStore";
 import { useDurableComposerDraftStore } from "./features/composer/useDurableComposerDraftStore";
 import { useAppearance, type AppearanceController } from "./lib/useAppearance";
@@ -403,10 +404,12 @@ function DesktopAppShell(props: {
     removeOptimisticMessage: session.removeOptimisticMessage,
     transcriptViewport: session.viewport,
   } satisfies ThreadViewProps;
+  const selectedThreadPending =
+    Boolean(navigation.selectedThreadKey) &&
+    !navigation.selectedThread &&
+    !navigation.selectedLaunchpad;
   const threadDetailPending =
-    mainView === "thread" &&
-    (!ThreadViewComponent ||
-      (!navigation.selectedThread && !navigation.selectedLaunchpad));
+    mainView === "thread" && (!ThreadViewComponent || selectedThreadPending);
 
   const resizeSidebar = (nextWidth: number): void => {
     setSidebarWidth(Math.min(sidebarMaxWidth, Math.max(sidebarMinWidth, nextWidth)));
@@ -497,7 +500,17 @@ function DesktopAppShell(props: {
           threadDetailPending ? " app-main--thread-detail-pending" : ""
         }`}
       >
-        {ThreadViewComponent ? <ThreadViewComponent {...threadViewProps} /> : null}
+        {threadDetailPending ? (
+          <section className="thread-view thread-view--pending">
+            <ThreadPlaceholderHeader
+              desktopApi={desktopApi}
+              title="Loading..."
+              onOpenMessagingActivity={openMessagingActivityWindow}
+            />
+          </section>
+        ) : ThreadViewComponent ? (
+          <ThreadViewComponent {...threadViewProps} />
+        ) : null}
       </main>
 
       {mainView === "settings" ? (

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -403,6 +403,10 @@ function DesktopAppShell(props: {
     removeOptimisticMessage: session.removeOptimisticMessage,
     transcriptViewport: session.viewport,
   } satisfies ThreadViewProps;
+  const threadDetailPending =
+    mainView === "thread" &&
+    (!ThreadViewComponent ||
+      (!navigation.selectedThread && !navigation.selectedLaunchpad));
 
   const resizeSidebar = (nextWidth: number): void => {
     setSidebarWidth(Math.min(sidebarMaxWidth, Math.max(sidebarMinWidth, nextWidth)));
@@ -488,7 +492,11 @@ function DesktopAppShell(props: {
         sidebarMaxWidth={sidebarMaxWidth}
       />
 
-      <main className="app-main">
+      <main
+        className={`app-main${
+          threadDetailPending ? " app-main--thread-detail-pending" : ""
+        }`}
+      >
         {ThreadViewComponent ? <ThreadViewComponent {...threadViewProps} /> : null}
       </main>
 

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -407,7 +407,8 @@ function DesktopAppShell(props: {
   const selectedThreadPending =
     Boolean(navigation.selectedThreadKey) &&
     !navigation.selectedThread &&
-    !navigation.selectedLaunchpad;
+    !navigation.selectedLaunchpad &&
+    (navigation.loading || navigation.refreshing);
   const threadDetailPending =
     mainView === "thread" && (!ThreadViewComponent || selectedThreadPending);
 

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -130,6 +130,9 @@ describe("App", () => {
 
     expect(screen.queryByText("Exit Settings")).not.toBeInTheDocument();
     expect(screen.getByRole("complementary", { name: "Threads" })).toBeInTheDocument();
+    expect(document.querySelector(".app-main")).toHaveClass(
+      "app-main--thread-detail-pending"
+    );
     await waitFor(() => {
       expect(readSettings).toHaveBeenCalledTimes(1);
     });
@@ -1702,9 +1705,11 @@ describe("App", () => {
 
     const transcript = screen.getByRole("region", { name: "Transcript" });
     const header = document.querySelector(".thread-header");
+    const main = document.querySelector(".app-main");
 
     expect(await within(transcript).findByText(response)).toBeInTheDocument();
     expect(header).not.toBeNull();
+    expect(main).not.toHaveClass("app-main--thread-detail-pending");
     expect(within(header as HTMLElement).queryByText(response)).not.toBeInTheDocument();
     expect(within(header as HTMLElement).queryByText(summary)).toBeNull();
   });

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -1716,6 +1716,183 @@ describe("App", () => {
     expect(within(header as HTMLElement).queryByText(summary)).toBeNull();
   });
 
+  it("falls back from loading chrome when a selected thread disappears after refresh", async () => {
+    const agentEventListeners = new Set<
+      (event: {
+        backend: "codex" | "grok";
+        notification: {
+          method: string;
+          params: Record<string, unknown>;
+        };
+      }) => void
+    >();
+    let navigationSnapshot: any = {
+      backend: "all",
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: ["codex:thread-stale"],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+      threads: [
+        {
+          id: "thread-stale",
+          title: "Thread that disappears",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: {
+            inInbox: true,
+            reason: "new-thread",
+          },
+          updatedAt: Date.now(),
+        },
+      ],
+    };
+    const getNavigationSnapshot = vi.fn(async () => navigationSnapshot);
+
+    Object.defineProperty(window, "pwragent", {
+      configurable: true,
+      value: {
+        ping: () => "pong",
+        listSkills: async () => ({
+          backend: "codex",
+          fetchedAt: Date.now(),
+          data: [],
+        }),
+        listBackends: async () => ({
+          fetchedAt: Date.now(),
+          backends: [
+            {
+              kind: "codex",
+              label: "Codex app server",
+              available: true,
+              methods: ["thread/list", "thread/read", "turn/start"],
+              capabilities: {
+                listThreads: true,
+                createThread: true,
+                resumeThread: true,
+                renameThread: false,
+                readThread: true,
+                startTurn: true,
+                interruptTurn: false,
+                steerTurn: false,
+                transcriptPagination: false,
+                toolUse: false,
+                approvalRequests: false,
+                multiDirectoryThreads: true,
+              },
+              executionModes: [
+                {
+                  mode: "default",
+                  label: "Default Access",
+                  available: true,
+                  isDefault: true,
+                },
+              ],
+            },
+          ],
+        }),
+        getNavigationSnapshot,
+        markThreadSeen: async () => ({
+          backend: "codex",
+          threadId: "thread-stale",
+          seenAt: Date.now(),
+        }),
+        onAgentEvent: (
+          listener: (event: {
+            backend: "codex" | "grok";
+            notification: {
+              method: string;
+              params: Record<string, unknown>;
+            };
+          }) => void
+        ) => {
+          agentEventListeners.add(listener);
+          return () => {
+            agentEventListeners.delete(listener);
+          };
+        },
+        onWindowFocus: () => () => undefined,
+        readThread: async () => ({
+          backend: "codex",
+          fetchedAt: Date.now(),
+          threadId: "thread-stale",
+          replay: {
+            entries: [],
+            messages: [],
+            pagination: {
+              supportsPagination: false,
+              hasPreviousPage: false,
+            },
+          },
+        }),
+        platform: "darwin",
+        startTurn: async () => ({
+          backend: "codex",
+          threadId: "thread-stale",
+          turnId: "turn-1",
+        }),
+        versions: {
+          electron: "41.2.1",
+        },
+      },
+    });
+
+    render(<App />);
+
+    expect(
+      await screen.findByRole("heading", {
+        level: 2,
+        name: "Thread that disappears",
+      })
+    ).toBeInTheDocument();
+
+    navigationSnapshot = {
+      backend: "all",
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+      threads: [],
+    };
+
+    await act(async () => {
+      for (const listener of agentEventListeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "turn/completed",
+            params: {
+              threadId: "thread-stale",
+              turnId: "turn-1",
+            },
+          },
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(getNavigationSnapshot).toHaveBeenCalledTimes(2);
+    });
+    expect(
+      screen.queryByRole("heading", { level: 2, name: "Loading..." })
+    ).toBeNull();
+    expect(
+      screen.getByRole("heading", { level: 2, name: "Pick a Thread" })
+    ).toBeInTheDocument();
+    expect(document.querySelector(".app-main")).not.toHaveClass(
+      "app-main--thread-detail-pending"
+    );
+  });
+
   it("keeps a newly created Codex thread selected when thread/list lags behind creation", async () => {
     const materializeDirectoryLaunchpad = vi.fn(async () => ({
       backend: "codex" as const,

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -133,6 +133,7 @@ describe("App", () => {
     expect(document.querySelector(".app-main")).toHaveClass(
       "app-main--thread-detail-pending"
     );
+    expect(screen.getByRole("heading", { level: 2, name: "Loading..." })).toBeInTheDocument();
     await waitFor(() => {
       expect(readSettings).toHaveBeenCalledTimes(1);
     });
@@ -1710,6 +1711,7 @@ describe("App", () => {
     expect(await within(transcript).findByText(response)).toBeInTheDocument();
     expect(header).not.toBeNull();
     expect(main).not.toHaveClass("app-main--thread-detail-pending");
+    expect(screen.queryByRole("heading", { level: 2, name: "Loading..." })).toBeNull();
     expect(within(header as HTMLElement).queryByText(response)).not.toBeInTheDocument();
     expect(within(header as HTMLElement).queryByText(summary)).toBeNull();
   });

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadPlaceholderHeader.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadPlaceholderHeader.tsx
@@ -1,0 +1,25 @@
+import type { MessagingChannelKind } from "@pwragent/shared";
+import type { DesktopApi } from "../../lib/desktop-api";
+import { MessagingStatusBar } from "../messaging-status/MessagingStatusBar";
+
+type ThreadPlaceholderHeaderProps = {
+  desktopApi?: DesktopApi;
+  title: string;
+  onOpenMessagingActivity?: (platform: MessagingChannelKind) => void;
+};
+
+export function ThreadPlaceholderHeader(props: ThreadPlaceholderHeaderProps) {
+  return (
+    <header className="thread-header thread-header--placeholder">
+      <div className="thread-header__main">
+        <div className="thread-header__eyebrow-row">
+          <h2 className="thread-header__compact-title">{props.title}</h2>
+        </div>
+      </div>
+      <MessagingStatusBar
+        desktopApi={props.desktopApi}
+        onOpenActivity={props.onOpenMessagingActivity}
+      />
+    </header>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -43,6 +43,7 @@ import type { ComposerDraftStore } from "../composer/useComposerDraftStore";
 import { MessagingStatusBar } from "../messaging-status/MessagingStatusBar";
 import { ThreadContextPanel } from "./ThreadContextPanel";
 import { ThreadHeader } from "./ThreadHeader";
+import { ThreadPlaceholderHeader } from "./ThreadPlaceholderHeader";
 import { TranscriptImageLightbox } from "./TranscriptImageLightbox";
 import { TranscriptList } from "./TranscriptList";
 import { LiveWorkRail, type LiveWorkRailDock } from "./LiveWorkRail";
@@ -1776,14 +1777,21 @@ export function ThreadView(props: ThreadViewProps) {
 
   if (!selectedThread && !selectedLaunchpad) {
     return (
-      <section className="thread-empty-state">
-        <div className="thread-empty-state__content">
-          <p className="eyebrow">Thread detail</p>
-          <h2>Select a thread</h2>
-          <p>
-            Inbox stays above every other lens. Pick a thread to read the full
-            transcript, or open a project launchpad from Directories.
-          </p>
+      <section className="thread-view thread-view--empty">
+        <ThreadPlaceholderHeader
+          desktopApi={props.desktopApi}
+          title="Pick a Thread"
+          onOpenMessagingActivity={props.onOpenMessagingActivity}
+        />
+        <div className="thread-empty-state">
+          <div className="thread-empty-state__content">
+            <p className="eyebrow">Thread detail</p>
+            <h2>Select a thread</h2>
+            <p>
+              Inbox stays above every other lens. Pick a thread to read the full
+              transcript, or open a project launchpad from Directories.
+            </p>
+          </div>
         </div>
       </section>
     );

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1777,12 +1777,14 @@ export function ThreadView(props: ThreadViewProps) {
   if (!selectedThread && !selectedLaunchpad) {
     return (
       <section className="thread-empty-state">
-        <p className="eyebrow">Thread detail</p>
-        <h2>Select a thread</h2>
-        <p>
-          Inbox stays above every other lens. Pick a thread to read the full
-          transcript, or open a project launchpad from Directories.
-        </p>
+        <div className="thread-empty-state__content">
+          <p className="eyebrow">Thread detail</p>
+          <h2>Select a thread</h2>
+          <p>
+            Inbox stays above every other lens. Pick a thread to read the full
+            transcript, or open a project launchpad from Directories.
+          </p>
+        </div>
       </section>
     );
   }

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -33,6 +33,32 @@ describe("ThreadView", () => {
     cleanup();
   });
 
+  it("makes the empty thread detail pane a window drag region", () => {
+    render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[]}
+        clearPendingRequest={() => undefined}
+        composerDisabled={false}
+        loading={false}
+        loadingMore={false}
+        messageCount={0}
+        skills={[]}
+        transcriptEntries={[]}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+      />
+    );
+
+    const emptyState = screen
+      .getByRole("heading", { level: 2, name: "Select a thread" })
+      .closest(".thread-empty-state");
+
+    expect(emptyState).not.toBeNull();
+    expect(emptyState?.querySelector(".thread-empty-state__content")).not.toBeNull();
+    expect(document.querySelector(".thread-header")).toBeNull();
+  });
+
   it("renders a directory-less thread with transcript history and context", () => {
     const { rerender } = render(
       <ThreadView

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -33,13 +33,26 @@ describe("ThreadView", () => {
     cleanup();
   });
 
-  it("makes the empty thread detail pane a window drag region", () => {
+  it("shows draggable empty thread chrome with messaging status", async () => {
+    const statuses = [
+      {
+        changedAt: 1000,
+        health: "enabled",
+        platform: "telegram",
+        account: "@pwragent_bot",
+      },
+    ] satisfies MessagingPlatformStatus[];
+
     render(
       <ThreadView
         addOptimisticUserMessage={(_text) => "optimistic-1"}
         backends={[]}
         clearPendingRequest={() => undefined}
         composerDisabled={false}
+        desktopApi={{
+          getMessagingPlatformStatuses: vi.fn(async () => statuses),
+          onMessagingPlatformStatusEvent: vi.fn(() => () => {}),
+        }}
         loading={false}
         loadingMore={false}
         messageCount={0}
@@ -50,13 +63,20 @@ describe("ThreadView", () => {
       />
     );
 
+    expect(
+      screen.getByRole("heading", { level: 2, name: "Pick a Thread" })
+    ).toBeInTheDocument();
     const emptyState = screen
       .getByRole("heading", { level: 2, name: "Select a thread" })
       .closest(".thread-empty-state");
+    const header = document.querySelector(".thread-header--placeholder");
 
     expect(emptyState).not.toBeNull();
     expect(emptyState?.querySelector(".thread-empty-state__content")).not.toBeNull();
-    expect(document.querySelector(".thread-header")).toBeNull();
+    expect(header).not.toBeNull();
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Telegram: Enabled/)).toBeInTheDocument();
+    });
   });
 
   it("renders a directory-less thread with transcript history and context", () => {

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -164,18 +164,17 @@ describe("Tangerine Terminal theme contract", () => {
     );
   });
 
-  it("keeps the startup thread detail empty state off the sidebar edge", () => {
+  it("keeps unavailable thread detail surfaces draggable", () => {
     const emptyStateRule = extractRuleBody(css, ".thread-empty-state");
     const pendingMainRule = extractRuleBody(css, ".app-main--thread-detail-pending");
 
     expect(emptyStateRule).toContain("padding: 0 16px;");
+    expect(emptyStateRule).toContain("flex: 1;");
+    expect(emptyStateRule).toContain("min-height: 0;");
     expect(emptyStateRule).toContain("-webkit-app-region: drag;");
     expect(pendingMainRule).toContain("-webkit-app-region: drag;");
     expect(css).toMatch(
       /\.thread-empty-state \*\s*\{[\s\S]*?-webkit-app-region:\s*drag;[\s\S]*?\}/
-    );
-    expect(css).toMatch(
-      /\.app-main--thread-detail-pending \*\s*\{[\s\S]*?-webkit-app-region:\s*drag;[\s\S]*?\}/
     );
   });
 

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -166,11 +166,16 @@ describe("Tangerine Terminal theme contract", () => {
 
   it("keeps the startup thread detail empty state off the sidebar edge", () => {
     const emptyStateRule = extractRuleBody(css, ".thread-empty-state");
+    const pendingMainRule = extractRuleBody(css, ".app-main--thread-detail-pending");
 
     expect(emptyStateRule).toContain("padding: 0 16px;");
     expect(emptyStateRule).toContain("-webkit-app-region: drag;");
+    expect(pendingMainRule).toContain("-webkit-app-region: drag;");
     expect(css).toMatch(
       /\.thread-empty-state \*\s*\{[\s\S]*?-webkit-app-region:\s*drag;[\s\S]*?\}/
+    );
+    expect(css).toMatch(
+      /\.app-main--thread-detail-pending \*\s*\{[\s\S]*?-webkit-app-region:\s*drag;[\s\S]*?\}/
     );
   });
 

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -168,6 +168,10 @@ describe("Tangerine Terminal theme contract", () => {
     const emptyStateRule = extractRuleBody(css, ".thread-empty-state");
 
     expect(emptyStateRule).toContain("padding: 0 16px;");
+    expect(emptyStateRule).toContain("-webkit-app-region: drag;");
+    expect(css).toMatch(
+      /\.thread-empty-state \*\s*\{[\s\S]*?-webkit-app-region:\s*drag;[\s\S]*?\}/
+    );
   });
 
   it("lets transcript scroll restoration own scroll anchoring", () => {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9740,8 +9740,18 @@ textarea,
   flex-direction: column;
   justify-content: center;
   min-height: calc(100vh - 48px);
-  max-width: 520px;
   padding: 0 16px;
+  width: 100%;
+  box-sizing: border-box;
+  -webkit-app-region: drag;
+}
+
+.thread-empty-state * {
+  -webkit-app-region: drag;
+}
+
+.thread-empty-state__content {
+  max-width: 520px;
 }
 
 .renderer-error-boundary {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2978,10 +2978,6 @@ textarea,
   -webkit-app-region: drag;
 }
 
-.app-main--thread-detail-pending * {
-  -webkit-app-region: drag;
-}
-
 .app-shell__settings-layer {
   display: flex;
   position: absolute;
@@ -9745,9 +9741,10 @@ textarea,
 
 .thread-empty-state {
   display: flex;
+  flex: 1;
   flex-direction: column;
   justify-content: center;
-  min-height: calc(100vh - 48px);
+  min-height: 0;
   padding: 0 16px;
   width: 100%;
   box-sizing: border-box;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2974,6 +2974,14 @@ textarea,
   overflow: hidden;
 }
 
+.app-main--thread-detail-pending {
+  -webkit-app-region: drag;
+}
+
+.app-main--thread-detail-pending * {
+  -webkit-app-region: drag;
+}
+
 .app-shell__settings-layer {
   display: flex;
   position: absolute;


### PR DESCRIPTION
## Summary

- Made the empty thread detail pane a full-width Electron drag region
- Added visible placeholder thread headers for the "Pick a Thread" and "Loading..." states so messaging indicators stay visible without a loaded thread
- Made the transient pending thread-detail pane draggable while the thread view is lazy-loading or the selected thread key has not resolved yet
- Kept the empty-state copy constrained to its existing readable width
- Added focused renderer and CSS contract coverage for the startup, empty, and pending detail states

## Verification

- I verified this with `pnpm test apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx`

## Notes

- Root cause: the post-wizard "Select a thread" state and the transient selected-thread loading gap did not render any `.thread-header` chrome, so the right side of the window had no visible titlebar surface, no messaging indicators, and no obvious drag target until a thread or launchpad was fully available.
