### PR TITLE
fix(desktop): tame linux auxiliary window menus

### DIFF
--- a/apps/desktop/src/main/__tests__/auxiliary-window-chrome.test.ts
+++ b/apps/desktop/src/main/__tests__/auxiliary-window-chrome.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { BrowserWindow } from "electron";
+
+const originalPlatform = process.platform;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", {
+    configurable: true,
+    value: platform,
+  });
+}
+
+function createWindow(): BrowserWindow {
+  const listeners = new Map<string, Array<() => void>>();
+  const window = {
+    id: 41,
+    focus: vi.fn(),
+    isAlwaysOnTop: vi.fn(() => false),
+    isDestroyed: vi.fn(() => false),
+    isMinimized: vi.fn(() => false),
+    moveTop: vi.fn(),
+    once: vi.fn((event: string, listener: () => void) => {
+      listeners.set(event, [...(listeners.get(event) ?? []), listener]);
+    }),
+    restore: vi.fn(),
+    setAlwaysOnTop: vi.fn(),
+    show: vi.fn(),
+  };
+
+  return window as unknown as BrowserWindow;
+}
+
+afterEach(() => {
+  Object.defineProperty(process, "platform", {
+    configurable: true,
+    value: originalPlatform,
+  });
+  vi.useRealTimers();
+  vi.resetModules();
+});
+
+describe("auxiliary window chrome", () => {
+  it("retries Linux raises after the window has had time to map", async () => {
+    vi.useFakeTimers();
+    setPlatform("linux");
+    const { showAndFocusAuxiliaryWindow } = await import(
+      "../auxiliary-window-chrome"
+    );
+    const window = createWindow();
+
+    showAndFocusAuxiliaryWindow(window);
+
+    expect(window.show).toHaveBeenCalledTimes(1);
+    expect(window.focus).toHaveBeenCalledTimes(1);
+    expect(window.moveTop).not.toHaveBeenCalled();
+    expect(window.setAlwaysOnTop).toHaveBeenCalledWith(true);
+
+    vi.advanceTimersByTime(100);
+    expect(window.show).toHaveBeenCalledTimes(2);
+    expect(window.focus).toHaveBeenCalledTimes(2);
+
+    vi.advanceTimersByTime(250);
+    expect(window.show).toHaveBeenCalledTimes(3);
+    expect(window.focus).toHaveBeenCalledTimes(3);
+
+    vi.advanceTimersByTime(450);
+    expect(window.show).toHaveBeenCalledTimes(4);
+    expect(window.focus).toHaveBeenCalledTimes(4);
+  });
+
+  it("uses moveTop without delayed retries when the platform supports it", async () => {
+    vi.useFakeTimers();
+    setPlatform("darwin");
+    const { showAndFocusAuxiliaryWindow } = await import(
+      "../auxiliary-window-chrome"
+    );
+    const window = createWindow();
+
+    showAndFocusAuxiliaryWindow(window);
+    vi.runOnlyPendingTimers();
+
+    expect(window.show).toHaveBeenCalledTimes(1);
+    expect(window.focus).toHaveBeenCalledTimes(1);
+    expect(window.moveTop).toHaveBeenCalledTimes(1);
+    expect(window.setAlwaysOnTop).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/__tests__/auxiliary-window-chrome.test.ts
+++ b/apps/desktop/src/main/__tests__/auxiliary-window-chrome.test.ts
@@ -134,6 +134,23 @@ describe("auxiliary window chrome", () => {
     expect(window.focus).toHaveBeenCalledTimes(1);
   });
 
+  it("does not refocus when load finishes after ready-to-show already showed the window", async () => {
+    vi.useFakeTimers();
+    setPlatform("darwin");
+    const { showAuxiliaryWindowWhenReady } = await import(
+      "../auxiliary-window-chrome"
+    );
+    const window = createWindow();
+
+    showAuxiliaryWindowWhenReady(window);
+    window.emitWindowEvent("ready-to-show");
+    window.emitWebContentsEvent("did-finish-load");
+    vi.advanceTimersByTime(100);
+
+    expect(window.show).toHaveBeenCalledTimes(1);
+    expect(window.focus).toHaveBeenCalledTimes(1);
+  });
+
   it("shows first-open windows after load if ready-to-show is late", async () => {
     vi.useFakeTimers();
     setPlatform("darwin");
@@ -145,6 +162,23 @@ describe("auxiliary window chrome", () => {
     showAuxiliaryWindowWhenReady(window);
     window.emitWebContentsEvent("did-finish-load");
     vi.advanceTimersByTime(100);
+
+    expect(window.show).toHaveBeenCalledTimes(1);
+    expect(window.focus).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not refocus from the fallback after load already showed the window", async () => {
+    vi.useFakeTimers();
+    setPlatform("darwin");
+    const { showAuxiliaryWindowWhenReady } = await import(
+      "../auxiliary-window-chrome"
+    );
+    const window = createWindow();
+
+    showAuxiliaryWindowWhenReady(window);
+    window.emitWebContentsEvent("did-finish-load");
+    vi.advanceTimersByTime(100);
+    vi.advanceTimersByTime(900);
 
     expect(window.show).toHaveBeenCalledTimes(1);
     expect(window.focus).toHaveBeenCalledTimes(1);

--- a/apps/desktop/src/main/__tests__/auxiliary-window-chrome.test.ts
+++ b/apps/desktop/src/main/__tests__/auxiliary-window-chrome.test.ts
@@ -3,6 +3,11 @@ import type { BrowserWindow } from "electron";
 
 const originalPlatform = process.platform;
 
+type TestBrowserWindow = BrowserWindow & {
+  emitWebContentsEvent: (event: string) => void;
+  emitWindowEvent: (event: string) => void;
+};
+
 function setPlatform(platform: NodeJS.Platform): void {
   Object.defineProperty(process, "platform", {
     configurable: true,
@@ -10,9 +15,20 @@ function setPlatform(platform: NodeJS.Platform): void {
   });
 }
 
-function createWindow(): BrowserWindow {
-  const listeners = new Map<string, Array<() => void>>();
+function createWindow(): TestBrowserWindow {
+  const windowListeners = new Map<string, Array<() => void>>();
+  const webContentsListeners = new Map<string, Array<() => void>>();
   const window = {
+    emitWebContentsEvent: (event: string) => {
+      for (const listener of webContentsListeners.get(event) ?? []) {
+        listener();
+      }
+    },
+    emitWindowEvent: (event: string) => {
+      for (const listener of windowListeners.get(event) ?? []) {
+        listener();
+      }
+    },
     id: 41,
     focus: vi.fn(),
     isAlwaysOnTop: vi.fn(() => false),
@@ -20,14 +36,25 @@ function createWindow(): BrowserWindow {
     isMinimized: vi.fn(() => false),
     moveTop: vi.fn(),
     once: vi.fn((event: string, listener: () => void) => {
-      listeners.set(event, [...(listeners.get(event) ?? []), listener]);
+      windowListeners.set(event, [
+        ...(windowListeners.get(event) ?? []),
+        listener,
+      ]);
     }),
     restore: vi.fn(),
     setAlwaysOnTop: vi.fn(),
     show: vi.fn(),
+    webContents: {
+      once: vi.fn((event: string, listener: () => void) => {
+        webContentsListeners.set(event, [
+          ...(webContentsListeners.get(event) ?? []),
+          listener,
+        ]);
+      }),
+    },
   };
 
-  return window as unknown as BrowserWindow;
+  return window as unknown as TestBrowserWindow;
 }
 
 afterEach(() => {
@@ -83,5 +110,62 @@ describe("auxiliary window chrome", () => {
     expect(window.focus).toHaveBeenCalledTimes(1);
     expect(window.moveTop).toHaveBeenCalledTimes(1);
     expect(window.setAlwaysOnTop).not.toHaveBeenCalled();
+  });
+
+  it("shows first-open windows on ready-to-show", async () => {
+    vi.useFakeTimers();
+    setPlatform("darwin");
+    const { showAuxiliaryWindowWhenReady } = await import(
+      "../auxiliary-window-chrome"
+    );
+    const window = createWindow();
+
+    showAuxiliaryWindowWhenReady(window);
+
+    expect(window.show).not.toHaveBeenCalled();
+    window.emitWindowEvent("ready-to-show");
+
+    expect(window.show).toHaveBeenCalledTimes(1);
+    expect(window.focus).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(1_000);
+
+    expect(window.show).toHaveBeenCalledTimes(1);
+    expect(window.focus).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows first-open windows after load if ready-to-show is late", async () => {
+    vi.useFakeTimers();
+    setPlatform("darwin");
+    const { showAuxiliaryWindowWhenReady } = await import(
+      "../auxiliary-window-chrome"
+    );
+    const window = createWindow();
+
+    showAuxiliaryWindowWhenReady(window);
+    window.emitWebContentsEvent("did-finish-load");
+    vi.advanceTimersByTime(100);
+
+    expect(window.show).toHaveBeenCalledTimes(1);
+    expect(window.focus).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows first-open windows from a timed fallback", async () => {
+    vi.useFakeTimers();
+    setPlatform("darwin");
+    const { showAuxiliaryWindowWhenReady } = await import(
+      "../auxiliary-window-chrome"
+    );
+    const window = createWindow();
+
+    showAuxiliaryWindowWhenReady(window);
+    vi.advanceTimersByTime(999);
+
+    expect(window.show).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+
+    expect(window.show).toHaveBeenCalledTimes(1);
+    expect(window.focus).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/desktop/src/main/__tests__/menu.test.ts
+++ b/apps/desktop/src/main/__tests__/menu.test.ts
@@ -11,6 +11,11 @@ function buildTemplate(
     openProfilesSettings?: () => void;
     openSettings?: () => void;
     profiles?: DesktopPwrAgentProfileSummary[];
+    windows?: Array<{
+      focused: boolean;
+      id: number;
+      title: string;
+    }>;
   },
 ): MenuItemConstructorOptions[] {
   return buildApplicationMenuTemplate({
@@ -22,8 +27,13 @@ function buildTemplate(
       profile("default", { active: true, default: true }),
       profile("personal"),
     ],
+    windows: options?.windows ?? [
+      { focused: true, id: 1, title: "PwrAgent" },
+      { focused: false, id: 2, title: "Logs" },
+    ],
     actions: {
       checkForUpdates: vi.fn(),
+      focusWindow: vi.fn(),
       openDocumentation: vi.fn(),
       openIssueReporter: vi.fn(),
       openProfile: options?.openProfile ?? vi.fn(),
@@ -226,6 +236,41 @@ describe("buildApplicationMenuTemplate", () => {
       const template = buildTemplate(false, { isMac: false });
       const appMenu = template.find((item) => item.label === "PwrAgent");
       expect(appMenu).toBeUndefined();
+    });
+  });
+
+  describe("Window menu", () => {
+    it("keeps the native Window menu role on macOS", () => {
+      const windowMenu = buildTemplate(false).find(
+        (item) => item.role === "windowMenu",
+      );
+
+      expect(windowMenu).toBeDefined();
+    });
+
+    it("lists open windows on non-Mac platforms", () => {
+      const items = submenuItems(buildTemplate(false, { isMac: false }), "Window");
+
+      expect(items.map((item) => item.label ?? item.role ?? item.type)).toEqual([
+        "minimize",
+        "close",
+        "separator",
+        "PwrAgent",
+        "Logs",
+      ]);
+      expect(items[3]?.type).toBe("checkbox");
+      expect(items[3]?.checked).toBe(true);
+      expect(items[4]?.checked).toBe(false);
+    });
+
+    it("shows an empty state when no windows are open on non-Mac platforms", () => {
+      const items = submenuItems(
+        buildTemplate(false, { isMac: false, windows: [] }),
+        "Window",
+      );
+
+      expect(items.at(-1)?.label).toBe("No Open Windows");
+      expect(items.at(-1)?.enabled).toBe(false);
     });
   });
 });

--- a/apps/desktop/src/main/__tests__/menu.test.ts
+++ b/apps/desktop/src/main/__tests__/menu.test.ts
@@ -258,9 +258,10 @@ describe("buildApplicationMenuTemplate", () => {
         "PwrAgent",
         "Logs",
       ]);
-      expect(items[3]?.type).toBe("checkbox");
-      expect(items[3]?.checked).toBe(true);
-      expect(items[4]?.checked).toBe(false);
+      expect(items[3]?.type).toBeUndefined();
+      expect(items[3]?.checked).toBeUndefined();
+      expect(items[4]?.type).toBeUndefined();
+      expect(items[4]?.checked).toBeUndefined();
     });
 
     it("shows an empty state when no windows are open on non-Mac platforms", () => {

--- a/apps/desktop/src/main/app-log-window.ts
+++ b/apps/desktop/src/main/app-log-window.ts
@@ -21,11 +21,13 @@ import {
 import {
   auxiliaryWindowChromeOptions,
   hideAuxiliaryWindowMenuBar,
+  registerAuxiliaryWindowTitle,
   showAndFocusAuxiliaryWindow,
 } from "./auxiliary-window-chrome";
 
 const log = getMainLogger("pwragent:app-log-window");
 const LOGS_HASH = "logs";
+const LOGS_WINDOW_TITLE = "Logs";
 
 let appLogWindow: BrowserWindow | undefined;
 
@@ -42,7 +44,7 @@ export function showAppLogWindow(): void {
     minWidth: 700,
     minHeight: 500,
     show: false,
-    title: "Logs - PwrAgent",
+    title: LOGS_WINDOW_TITLE,
     ...auxiliaryWindowChromeOptions(),
     backgroundColor: themedWindowBackgroundColor(appearance),
     webPreferences: {
@@ -53,6 +55,7 @@ export function showAppLogWindow(): void {
       additionalArguments: themedWindowAdditionalArguments(appearance),
     },
   });
+  registerAuxiliaryWindowTitle(window, LOGS_WINDOW_TITLE);
   hideAuxiliaryWindowMenuBar(window);
 
   applyWindowSecurityHardening(window);

--- a/apps/desktop/src/main/app-log-window.ts
+++ b/apps/desktop/src/main/app-log-window.ts
@@ -21,6 +21,7 @@ import {
 import {
   auxiliaryWindowChromeOptions,
   hideAuxiliaryWindowMenuBar,
+  showAndFocusAuxiliaryWindow,
 } from "./auxiliary-window-chrome";
 
 const log = getMainLogger("pwragent:app-log-window");
@@ -30,11 +31,7 @@ let appLogWindow: BrowserWindow | undefined;
 
 export function showAppLogWindow(): void {
   if (appLogWindow && !appLogWindow.isDestroyed()) {
-    if (appLogWindow.isMinimized()) {
-      appLogWindow.restore();
-    }
-    appLogWindow.show();
-    appLogWindow.focus();
+    showAndFocusAuxiliaryWindow(appLogWindow);
     return;
   }
 
@@ -72,7 +69,7 @@ export function showAppLogWindow(): void {
   }
 
   window.once("ready-to-show", () => {
-    window.show();
+    showAndFocusAuxiliaryWindow(window);
   });
 
   window.on("closed", () => {

--- a/apps/desktop/src/main/app-log-window.ts
+++ b/apps/desktop/src/main/app-log-window.ts
@@ -18,6 +18,10 @@ import {
   themedWindowAdditionalArguments,
   themedWindowBackgroundColor,
 } from "./settings/appearance-bootstrap";
+import {
+  auxiliaryWindowChromeOptions,
+  hideAuxiliaryWindowMenuBar,
+} from "./auxiliary-window-chrome";
 
 const log = getMainLogger("pwragent:app-log-window");
 const LOGS_HASH = "logs";
@@ -42,8 +46,7 @@ export function showAppLogWindow(): void {
     minHeight: 500,
     show: false,
     title: "Logs - PwrAgent",
-    titleBarStyle: "hiddenInset",
-    trafficLightPosition: { x: 20, y: 18 },
+    ...auxiliaryWindowChromeOptions(),
     backgroundColor: themedWindowBackgroundColor(appearance),
     webPreferences: {
       preload: getPreloadPath(),
@@ -53,6 +56,7 @@ export function showAppLogWindow(): void {
       additionalArguments: themedWindowAdditionalArguments(appearance),
     },
   });
+  hideAuxiliaryWindowMenuBar(window);
 
   applyWindowSecurityHardening(window);
   registerWindowChannels(window, WINDOW_KIND_APP_LOGS, [

--- a/apps/desktop/src/main/app-log-window.ts
+++ b/apps/desktop/src/main/app-log-window.ts
@@ -23,6 +23,7 @@ import {
   hideAuxiliaryWindowMenuBar,
   registerAuxiliaryWindowTitle,
   showAndFocusAuxiliaryWindow,
+  showAuxiliaryWindowWhenReady,
 } from "./auxiliary-window-chrome";
 
 const log = getMainLogger("pwragent:app-log-window");
@@ -71,9 +72,7 @@ export function showAppLogWindow(): void {
     void window.loadFile(rendererEntry.value, { hash: LOGS_HASH });
   }
 
-  window.once("ready-to-show", () => {
-    showAndFocusAuxiliaryWindow(window);
-  });
+  showAuxiliaryWindowWhenReady(window);
 
   window.on("closed", () => {
     appLogWindow = undefined;

--- a/apps/desktop/src/main/auxiliary-window-chrome.ts
+++ b/apps/desktop/src/main/auxiliary-window-chrome.ts
@@ -2,7 +2,6 @@ import type {
   BrowserWindow,
   BrowserWindowConstructorOptions,
 } from "electron";
-import { app } from "electron";
 
 const supportsPerWindowMenuBar =
   process.platform === "linux" || process.platform === "win32";
@@ -61,8 +60,8 @@ export function showAndFocusAuxiliaryWindow(window: BrowserWindow): void {
     window.restore();
   }
   window.show();
+  window.moveTop();
   window.focus();
-  app.focus({ steal: true });
 }
 
 export function reapplyAuxiliaryWindowMenuBars(): void {

--- a/apps/desktop/src/main/auxiliary-window-chrome.ts
+++ b/apps/desktop/src/main/auxiliary-window-chrome.ts
@@ -2,6 +2,7 @@ import type {
   BrowserWindow,
   BrowserWindowConstructorOptions,
 } from "electron";
+import { app } from "electron";
 
 const supportsPerWindowMenuBar =
   process.platform === "linux" || process.platform === "win32";
@@ -33,6 +34,15 @@ export function hideAuxiliaryWindowMenuBar(window: BrowserWindow): void {
   window.once("closed", () => {
     hiddenMenuBarWindows.delete(window);
   });
+}
+
+export function showAndFocusAuxiliaryWindow(window: BrowserWindow): void {
+  if (window.isMinimized()) {
+    window.restore();
+  }
+  window.show();
+  window.focus();
+  app.focus({ steal: true });
 }
 
 export function reapplyAuxiliaryWindowMenuBars(): void {

--- a/apps/desktop/src/main/auxiliary-window-chrome.ts
+++ b/apps/desktop/src/main/auxiliary-window-chrome.ts
@@ -5,6 +5,7 @@ import type {
 
 const supportsPerWindowMenuBar =
   process.platform === "linux" || process.platform === "win32";
+const supportsMoveTop = process.platform !== "linux";
 
 const hiddenMenuBarWindows = new Set<BrowserWindow>();
 const auxiliaryWindowTitles = new Map<number, string>();
@@ -60,8 +61,23 @@ export function showAndFocusAuxiliaryWindow(window: BrowserWindow): void {
     window.restore();
   }
   window.show();
-  window.moveTop();
+  if (supportsMoveTop) {
+    window.moveTop();
+  } else {
+    pulseAuxiliaryWindowToTop(window);
+  }
   window.focus();
+}
+
+function pulseAuxiliaryWindowToTop(window: BrowserWindow): void {
+  const wasAlwaysOnTop = window.isAlwaysOnTop();
+  window.setAlwaysOnTop(true);
+  setTimeout(() => {
+    if (window.isDestroyed() || wasAlwaysOnTop) {
+      return;
+    }
+    window.setAlwaysOnTop(false);
+  }, 250);
 }
 
 export function reapplyAuxiliaryWindowMenuBars(): void {

--- a/apps/desktop/src/main/auxiliary-window-chrome.ts
+++ b/apps/desktop/src/main/auxiliary-window-chrome.ts
@@ -1,0 +1,49 @@
+import type {
+  BrowserWindow,
+  BrowserWindowConstructorOptions,
+} from "electron";
+
+const supportsPerWindowMenuBar =
+  process.platform === "linux" || process.platform === "win32";
+
+const hiddenMenuBarWindows = new Set<BrowserWindow>();
+
+export function auxiliaryWindowChromeOptions(): Pick<
+  BrowserWindowConstructorOptions,
+  "autoHideMenuBar" | "titleBarStyle" | "trafficLightPosition"
+> {
+  if (process.platform === "darwin") {
+    return {
+      titleBarStyle: "hiddenInset",
+      trafficLightPosition: { x: 20, y: 18 },
+    };
+  }
+
+  return {
+    autoHideMenuBar: true,
+  };
+}
+
+export function hideAuxiliaryWindowMenuBar(window: BrowserWindow): void {
+  if (!supportsPerWindowMenuBar) return;
+
+  hiddenMenuBarWindows.add(window);
+  window.setAutoHideMenuBar(true);
+  window.setMenuBarVisibility(false);
+  window.once("closed", () => {
+    hiddenMenuBarWindows.delete(window);
+  });
+}
+
+export function reapplyAuxiliaryWindowMenuBars(): void {
+  if (!supportsPerWindowMenuBar) return;
+
+  for (const window of hiddenMenuBarWindows) {
+    if (window.isDestroyed()) {
+      hiddenMenuBarWindows.delete(window);
+      continue;
+    }
+    window.setAutoHideMenuBar(true);
+    window.setMenuBarVisibility(false);
+  }
+}

--- a/apps/desktop/src/main/auxiliary-window-chrome.ts
+++ b/apps/desktop/src/main/auxiliary-window-chrome.ts
@@ -69,30 +69,39 @@ export function showAndFocusAuxiliaryWindow(window: BrowserWindow): void {
 }
 
 export function showAuxiliaryWindowWhenReady(window: BrowserWindow): void {
+  let shown = false;
   let fallbackTimer: ReturnType<typeof setTimeout> | undefined;
   let postLoadTimer: ReturnType<typeof setTimeout> | undefined;
 
-  const showAndClearFallback = (): void => {
+  const clearFirstOpenTimers = (): void => {
     if (fallbackTimer) {
       clearTimeout(fallbackTimer);
       fallbackTimer = undefined;
     }
+    if (postLoadTimer) {
+      clearTimeout(postLoadTimer);
+      postLoadTimer = undefined;
+    }
+  };
+
+  const showOnce = (): void => {
+    if (shown) return;
+
+    shown = true;
+    clearFirstOpenTimers();
     showAndFocusAuxiliaryWindow(window);
   };
 
-  window.once("ready-to-show", showAndClearFallback);
+  window.once("ready-to-show", showOnce);
   window.webContents.once("did-finish-load", () => {
-    postLoadTimer = setTimeout(showAndClearFallback, postLoadRaiseDelayMs);
+    if (shown) return;
+
+    postLoadTimer = setTimeout(showOnce, postLoadRaiseDelayMs);
   });
-  fallbackTimer = setTimeout(showAndClearFallback, firstOpenFallbackDelayMs);
+  fallbackTimer = setTimeout(showOnce, firstOpenFallbackDelayMs);
 
   window.once("closed", () => {
-    if (fallbackTimer) {
-      clearTimeout(fallbackTimer);
-    }
-    if (postLoadTimer) {
-      clearTimeout(postLoadTimer);
-    }
+    clearFirstOpenTimers();
   });
 }
 

--- a/apps/desktop/src/main/auxiliary-window-chrome.ts
+++ b/apps/desktop/src/main/auxiliary-window-chrome.ts
@@ -6,9 +6,14 @@ import type {
 const supportsPerWindowMenuBar =
   process.platform === "linux" || process.platform === "win32";
 const supportsMoveTop = process.platform !== "linux";
+const linuxRaiseRetryDelaysMs = [100, 350, 800] as const;
 
 const hiddenMenuBarWindows = new Set<BrowserWindow>();
 const auxiliaryWindowTitles = new Map<number, string>();
+const auxiliaryWindowRaiseRetryTimers = new Map<
+  number,
+  Array<ReturnType<typeof setTimeout>>
+>();
 
 export function auxiliaryWindowChromeOptions(): Pick<
   BrowserWindowConstructorOptions,
@@ -57,6 +62,14 @@ export function getAuxiliaryWindowMenuTitle(window: BrowserWindow): string {
 }
 
 export function showAndFocusAuxiliaryWindow(window: BrowserWindow): void {
+  raiseAuxiliaryWindow(window);
+  scheduleAuxiliaryWindowRaiseRetries(window);
+}
+
+function raiseAuxiliaryWindow(window: BrowserWindow): void {
+  if (window.isDestroyed()) {
+    return;
+  }
   if (window.isMinimized()) {
     window.restore();
   }
@@ -67,6 +80,43 @@ export function showAndFocusAuxiliaryWindow(window: BrowserWindow): void {
     pulseAuxiliaryWindowToTop(window);
   }
   window.focus();
+}
+
+function scheduleAuxiliaryWindowRaiseRetries(window: BrowserWindow): void {
+  if (supportsMoveTop) return;
+
+  clearAuxiliaryWindowRaiseRetries(window);
+  const timers: Array<ReturnType<typeof setTimeout>> = [];
+  for (const [index, delayMs] of linuxRaiseRetryDelaysMs.entries()) {
+    const timer = setTimeout(() => {
+      if (auxiliaryWindowRaiseRetryTimers.get(window.id) !== timers) {
+        return;
+      }
+      if (window.isDestroyed()) {
+        clearAuxiliaryWindowRaiseRetries(window);
+        return;
+      }
+      raiseAuxiliaryWindow(window);
+      if (index === linuxRaiseRetryDelaysMs.length - 1) {
+        auxiliaryWindowRaiseRetryTimers.delete(window.id);
+      }
+    }, delayMs);
+    timers.push(timer);
+  }
+  auxiliaryWindowRaiseRetryTimers.set(window.id, timers);
+  window.once("closed", () => {
+    clearAuxiliaryWindowRaiseRetries(window);
+  });
+}
+
+function clearAuxiliaryWindowRaiseRetries(window: BrowserWindow): void {
+  const timers = auxiliaryWindowRaiseRetryTimers.get(window.id);
+  if (!timers) return;
+
+  for (const timer of timers) {
+    clearTimeout(timer);
+  }
+  auxiliaryWindowRaiseRetryTimers.delete(window.id);
 }
 
 function pulseAuxiliaryWindowToTop(window: BrowserWindow): void {

--- a/apps/desktop/src/main/auxiliary-window-chrome.ts
+++ b/apps/desktop/src/main/auxiliary-window-chrome.ts
@@ -8,6 +8,7 @@ const supportsPerWindowMenuBar =
   process.platform === "linux" || process.platform === "win32";
 
 const hiddenMenuBarWindows = new Set<BrowserWindow>();
+const auxiliaryWindowTitles = new Map<number, string>();
 
 export function auxiliaryWindowChromeOptions(): Pick<
   BrowserWindowConstructorOptions,
@@ -34,6 +35,25 @@ export function hideAuxiliaryWindowMenuBar(window: BrowserWindow): void {
   window.once("closed", () => {
     hiddenMenuBarWindows.delete(window);
   });
+}
+
+export function registerAuxiliaryWindowTitle(
+  window: BrowserWindow,
+  title: string,
+): void {
+  auxiliaryWindowTitles.set(window.id, title);
+  window.setTitle(title);
+  window.webContents.on("page-title-updated", (event) => {
+    event.preventDefault();
+    window.setTitle(title);
+  });
+  window.once("closed", () => {
+    auxiliaryWindowTitles.delete(window.id);
+  });
+}
+
+export function getAuxiliaryWindowMenuTitle(window: BrowserWindow): string {
+  return auxiliaryWindowTitles.get(window.id) ?? window.getTitle();
 }
 
 export function showAndFocusAuxiliaryWindow(window: BrowserWindow): void {

--- a/apps/desktop/src/main/auxiliary-window-chrome.ts
+++ b/apps/desktop/src/main/auxiliary-window-chrome.ts
@@ -7,6 +7,8 @@ const supportsPerWindowMenuBar =
   process.platform === "linux" || process.platform === "win32";
 const supportsMoveTop = process.platform !== "linux";
 const linuxRaiseRetryDelaysMs = [100, 350, 800] as const;
+const firstOpenFallbackDelayMs = 1_000;
+const postLoadRaiseDelayMs = 100;
 
 const hiddenMenuBarWindows = new Set<BrowserWindow>();
 const auxiliaryWindowTitles = new Map<number, string>();
@@ -64,6 +66,34 @@ export function getAuxiliaryWindowMenuTitle(window: BrowserWindow): string {
 export function showAndFocusAuxiliaryWindow(window: BrowserWindow): void {
   raiseAuxiliaryWindow(window);
   scheduleAuxiliaryWindowRaiseRetries(window);
+}
+
+export function showAuxiliaryWindowWhenReady(window: BrowserWindow): void {
+  let fallbackTimer: ReturnType<typeof setTimeout> | undefined;
+  let postLoadTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const showAndClearFallback = (): void => {
+    if (fallbackTimer) {
+      clearTimeout(fallbackTimer);
+      fallbackTimer = undefined;
+    }
+    showAndFocusAuxiliaryWindow(window);
+  };
+
+  window.once("ready-to-show", showAndClearFallback);
+  window.webContents.once("did-finish-load", () => {
+    postLoadTimer = setTimeout(showAndClearFallback, postLoadRaiseDelayMs);
+  });
+  fallbackTimer = setTimeout(showAndClearFallback, firstOpenFallbackDelayMs);
+
+  window.once("closed", () => {
+    if (fallbackTimer) {
+      clearTimeout(fallbackTimer);
+    }
+    if (postLoadTimer) {
+      clearTimeout(postLoadTimer);
+    }
+  });
 }
 
 function raiseAuxiliaryWindow(window: BrowserWindow): void {

--- a/apps/desktop/src/main/changelog-window.ts
+++ b/apps/desktop/src/main/changelog-window.ts
@@ -20,6 +20,7 @@ import {
   hideAuxiliaryWindowMenuBar,
   registerAuxiliaryWindowTitle,
   showAndFocusAuxiliaryWindow,
+  showAuxiliaryWindowWhenReady,
 } from "./auxiliary-window-chrome";
 
 const log = getMainLogger("pwragent:changelog-window");
@@ -67,9 +68,7 @@ export function showChangelogWindow(): void {
     void window.loadFile(rendererEntry.value, { hash: CHANGELOG_HASH });
   }
 
-  window.once("ready-to-show", () => {
-    showAndFocusAuxiliaryWindow(window);
-  });
+  showAuxiliaryWindowWhenReady(window);
 
   window.on("closed", () => {
     changelogWindow = undefined;

--- a/apps/desktop/src/main/changelog-window.ts
+++ b/apps/desktop/src/main/changelog-window.ts
@@ -15,6 +15,10 @@ import {
   themedWindowAdditionalArguments,
   themedWindowBackgroundColor,
 } from "./settings/appearance-bootstrap";
+import {
+  auxiliaryWindowChromeOptions,
+  hideAuxiliaryWindowMenuBar,
+} from "./auxiliary-window-chrome";
 
 const log = getMainLogger("pwragent:changelog-window");
 const CHANGELOG_HASH = "changelog";
@@ -39,8 +43,7 @@ export function showChangelogWindow(): void {
     minHeight: 480,
     show: false,
     title: "Changelog - PwrAgent",
-    titleBarStyle: "hiddenInset",
-    trafficLightPosition: { x: 20, y: 18 },
+    ...auxiliaryWindowChromeOptions(),
     backgroundColor: themedWindowBackgroundColor(appearance),
     webPreferences: {
       preload: getPreloadPath(),
@@ -50,6 +53,7 @@ export function showChangelogWindow(): void {
       additionalArguments: themedWindowAdditionalArguments(appearance),
     },
   });
+  hideAuxiliaryWindowMenuBar(window);
 
   applyWindowSecurityHardening(window);
   registerWindowChannels(window, WINDOW_KIND_CHANGELOG, [

--- a/apps/desktop/src/main/changelog-window.ts
+++ b/apps/desktop/src/main/changelog-window.ts
@@ -18,11 +18,13 @@ import {
 import {
   auxiliaryWindowChromeOptions,
   hideAuxiliaryWindowMenuBar,
+  registerAuxiliaryWindowTitle,
   showAndFocusAuxiliaryWindow,
 } from "./auxiliary-window-chrome";
 
 const log = getMainLogger("pwragent:changelog-window");
 const CHANGELOG_HASH = "changelog";
+const CHANGELOG_WINDOW_TITLE = "Changelog";
 
 let changelogWindow: BrowserWindow | undefined;
 
@@ -39,7 +41,7 @@ export function showChangelogWindow(): void {
     minWidth: 640,
     minHeight: 480,
     show: false,
-    title: "Changelog - PwrAgent",
+    title: CHANGELOG_WINDOW_TITLE,
     ...auxiliaryWindowChromeOptions(),
     backgroundColor: themedWindowBackgroundColor(appearance),
     webPreferences: {
@@ -50,6 +52,7 @@ export function showChangelogWindow(): void {
       additionalArguments: themedWindowAdditionalArguments(appearance),
     },
   });
+  registerAuxiliaryWindowTitle(window, CHANGELOG_WINDOW_TITLE);
   hideAuxiliaryWindowMenuBar(window);
 
   applyWindowSecurityHardening(window);

--- a/apps/desktop/src/main/changelog-window.ts
+++ b/apps/desktop/src/main/changelog-window.ts
@@ -18,6 +18,7 @@ import {
 import {
   auxiliaryWindowChromeOptions,
   hideAuxiliaryWindowMenuBar,
+  showAndFocusAuxiliaryWindow,
 } from "./auxiliary-window-chrome";
 
 const log = getMainLogger("pwragent:changelog-window");
@@ -27,11 +28,7 @@ let changelogWindow: BrowserWindow | undefined;
 
 export function showChangelogWindow(): void {
   if (changelogWindow && !changelogWindow.isDestroyed()) {
-    if (changelogWindow.isMinimized()) {
-      changelogWindow.restore();
-    }
-    changelogWindow.show();
-    changelogWindow.focus();
+    showAndFocusAuxiliaryWindow(changelogWindow);
     return;
   }
 
@@ -68,7 +65,7 @@ export function showChangelogWindow(): void {
   }
 
   window.once("ready-to-show", () => {
-    window.show();
+    showAndFocusAuxiliaryWindow(window);
   });
 
   window.on("closed", () => {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -91,6 +91,7 @@ import { subscribersForChannel } from "./window-channels";
 import { requestOpenSettings } from "./window-open-settings";
 import { requestReplayOnboarding } from "./window-replay-onboarding";
 import { buildApplicationMenuTemplate } from "./menu";
+import { reapplyAuxiliaryWindowMenuBars } from "./auxiliary-window-chrome";
 import {
   assertUnreachableProfileBootDecision,
   cleanupBootstrapProfile,
@@ -278,14 +279,34 @@ function installProfileFocusRequestWatcher(): void {
 function installApplicationMenu(): void {
   const developerMode = getDesktopSettingsService().resolveDeveloperMode();
   const profiles = listDesktopPwrAgentProfiles().profiles;
+  const windows = BrowserWindow.getAllWindows()
+    .filter((window) => !window.isDestroyed())
+    .map((window) => ({
+      focused: window.isFocused(),
+      id: window.id,
+      title: window.getTitle(),
+    }));
   const template = buildApplicationMenuTemplate({
     appName: APP_NAME,
     developerMode,
     isMac,
     profiles,
+    windows,
     actions: {
       checkForUpdates: () => {
         void checkForAppUpdatesNow("menu");
+      },
+      focusWindow: (windowId) => {
+        const window = BrowserWindow.fromId(windowId);
+        if (!window || window.isDestroyed()) {
+          installApplicationMenu();
+          return;
+        }
+        if (window.isMinimized()) {
+          window.restore();
+        }
+        window.show();
+        window.focus();
       },
       openDocumentation: async () => {
         await shell.openExternal(PWRAGENT_DOCUMENTATION_URL);
@@ -321,6 +342,19 @@ function installApplicationMenu(): void {
   });
 
   Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+  reapplyAuxiliaryWindowMenuBars();
+}
+
+function installWindowMenuRefreshHandlers(): void {
+  app.on("browser-window-created", (_event, window) => {
+    const refresh = (): void => {
+      installApplicationMenu();
+    };
+
+    window.on("focus", refresh);
+    window.on("closed", refresh);
+    window.on("page-title-updated", refresh);
+  });
 }
 
 /**
@@ -422,6 +456,7 @@ export function bootstrapApp(): void {
       installProfileFocusRequestWatcher();
     }
     installApplicationMenu();
+    installWindowMenuRefreshHandlers();
     registerAppServerIpcHandlers();
     registerAgentIpcHandlers();
     registerApplicationIpcHandlers();

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -91,7 +91,10 @@ import { subscribersForChannel } from "./window-channels";
 import { requestOpenSettings } from "./window-open-settings";
 import { requestReplayOnboarding } from "./window-replay-onboarding";
 import { buildApplicationMenuTemplate } from "./menu";
-import { reapplyAuxiliaryWindowMenuBars } from "./auxiliary-window-chrome";
+import {
+  getAuxiliaryWindowMenuTitle,
+  reapplyAuxiliaryWindowMenuBars,
+} from "./auxiliary-window-chrome";
 import {
   assertUnreachableProfileBootDecision,
   cleanupBootstrapProfile,
@@ -284,7 +287,7 @@ function installApplicationMenu(): void {
     .map((window) => ({
       focused: window.isFocused(),
       id: window.id,
-      title: window.getTitle(),
+      title: getAuxiliaryWindowMenuTitle(window),
     }));
   const template = buildApplicationMenuTemplate({
     appName: APP_NAME,

--- a/apps/desktop/src/main/license-document-window.ts
+++ b/apps/desktop/src/main/license-document-window.ts
@@ -18,6 +18,7 @@ import {
 import {
   auxiliaryWindowChromeOptions,
   hideAuxiliaryWindowMenuBar,
+  showAndFocusAuxiliaryWindow,
 } from "./auxiliary-window-chrome";
 
 const log = getMainLogger("pwragent:license-document-window");
@@ -57,11 +58,7 @@ function showLicenseDocumentWindow(options: {
 }): void {
   const existingWindow = options.windowRef();
   if (existingWindow && !existingWindow.isDestroyed()) {
-    if (existingWindow.isMinimized()) {
-      existingWindow.restore();
-    }
-    existingWindow.show();
-    existingWindow.focus();
+    showAndFocusAuxiliaryWindow(existingWindow);
     return;
   }
 
@@ -98,7 +95,7 @@ function showLicenseDocumentWindow(options: {
   }
 
   window.once("ready-to-show", () => {
-    window.show();
+    showAndFocusAuxiliaryWindow(window);
   });
 
   window.on("closed", () => {

--- a/apps/desktop/src/main/license-document-window.ts
+++ b/apps/desktop/src/main/license-document-window.ts
@@ -20,6 +20,7 @@ import {
   hideAuxiliaryWindowMenuBar,
   registerAuxiliaryWindowTitle,
   showAndFocusAuxiliaryWindow,
+  showAuxiliaryWindowWhenReady,
 } from "./auxiliary-window-chrome";
 
 const log = getMainLogger("pwragent:license-document-window");
@@ -96,9 +97,7 @@ function showLicenseDocumentWindow(options: {
     void window.loadFile(rendererEntry.value, { hash: options.hash });
   }
 
-  window.once("ready-to-show", () => {
-    showAndFocusAuxiliaryWindow(window);
-  });
+  showAuxiliaryWindowWhenReady(window);
 
   window.on("closed", () => {
     options.setWindowRef(undefined);

--- a/apps/desktop/src/main/license-document-window.ts
+++ b/apps/desktop/src/main/license-document-window.ts
@@ -18,6 +18,7 @@ import {
 import {
   auxiliaryWindowChromeOptions,
   hideAuxiliaryWindowMenuBar,
+  registerAuxiliaryWindowTitle,
   showAndFocusAuxiliaryWindow,
 } from "./auxiliary-window-chrome";
 
@@ -31,7 +32,7 @@ let thirdPartyNoticesWindow: BrowserWindow | undefined;
 export function showLicenseWindow(): void {
   showLicenseDocumentWindow({
     hash: LICENSE_HASH,
-    title: "MIT License - PwrAgent",
+    title: "License",
     windowRef: () => licenseWindow,
     setWindowRef: (window) => {
       licenseWindow = window;
@@ -42,7 +43,7 @@ export function showLicenseWindow(): void {
 export function showThirdPartyNoticesWindow(): void {
   showLicenseDocumentWindow({
     hash: THIRD_PARTY_NOTICES_HASH,
-    title: "Third-Party Notices - PwrAgent",
+    title: "Third-Party Notices",
     windowRef: () => thirdPartyNoticesWindow,
     setWindowRef: (window) => {
       thirdPartyNoticesWindow = window;
@@ -80,6 +81,7 @@ function showLicenseDocumentWindow(options: {
       additionalArguments: themedWindowAdditionalArguments(appearance),
     },
   });
+  registerAuxiliaryWindowTitle(window, options.title);
   hideAuxiliaryWindowMenuBar(window);
 
   applyWindowSecurityHardening(window);

--- a/apps/desktop/src/main/license-document-window.ts
+++ b/apps/desktop/src/main/license-document-window.ts
@@ -15,6 +15,10 @@ import {
   themedWindowAdditionalArguments,
   themedWindowBackgroundColor,
 } from "./settings/appearance-bootstrap";
+import {
+  auxiliaryWindowChromeOptions,
+  hideAuxiliaryWindowMenuBar,
+} from "./auxiliary-window-chrome";
 
 const log = getMainLogger("pwragent:license-document-window");
 const LICENSE_HASH = "license";
@@ -69,8 +73,7 @@ function showLicenseDocumentWindow(options: {
     minHeight: 480,
     show: false,
     title: options.title,
-    titleBarStyle: "hiddenInset",
-    trafficLightPosition: { x: 20, y: 18 },
+    ...auxiliaryWindowChromeOptions(),
     backgroundColor: themedWindowBackgroundColor(appearance),
     webPreferences: {
       preload: getPreloadPath(),
@@ -80,6 +83,7 @@ function showLicenseDocumentWindow(options: {
       additionalArguments: themedWindowAdditionalArguments(appearance),
     },
   });
+  hideAuxiliaryWindowMenuBar(window);
 
   applyWindowSecurityHardening(window);
   registerWindowChannels(window, WINDOW_KIND_LICENSE_DOCUMENT, [

--- a/apps/desktop/src/main/menu.ts
+++ b/apps/desktop/src/main/menu.ts
@@ -159,8 +159,6 @@ function buildWindowMenu(options: ApplicationMenuOptions): MenuItemConstructorOp
   const windowItems: MenuItemConstructorOptions[] = options.windows.length
     ? options.windows.map((window) => ({
         label: window.title || "Untitled Window",
-        type: "checkbox",
-        checked: window.focused,
         click: () => {
           options.actions.focusWindow(window.id);
         },

--- a/apps/desktop/src/main/menu.ts
+++ b/apps/desktop/src/main/menu.ts
@@ -3,6 +3,7 @@ import type { DesktopPwrAgentProfileSummary } from "@pwragent/shared";
 
 export type ApplicationMenuActions = {
   checkForUpdates: () => void;
+  focusWindow: (windowId: number) => void;
   openDocumentation: () => void | Promise<void>;
   openIssueReporter: () => void | Promise<void>;
   openProfile: (profile: string) => void | Promise<void>;
@@ -17,11 +18,18 @@ export type ApplicationMenuActions = {
   showThirdPartyNoticesWindow: () => void;
 };
 
+export type ApplicationMenuWindow = {
+  focused: boolean;
+  id: number;
+  title: string;
+};
+
 export type ApplicationMenuOptions = {
   appName: string;
   developerMode: boolean;
   isMac: boolean;
   profiles: DesktopPwrAgentProfileSummary[];
+  windows: ApplicationMenuWindow[];
   actions: ApplicationMenuActions;
 };
 
@@ -34,7 +42,7 @@ export function buildApplicationMenuTemplate(
     { role: "editMenu" },
     buildViewMenu(options.developerMode),
     buildProfilesMenu(options),
-    { role: "windowMenu" },
+    buildWindowMenu(options),
     buildHelpMenu(options),
   ];
 }
@@ -139,6 +147,38 @@ function buildProfilesMenu(options: ApplicationMenuOptions): MenuItemConstructor
         label: "Manage Profiles…",
         click: options.actions.openProfilesSettings,
       },
+    ],
+  };
+}
+
+function buildWindowMenu(options: ApplicationMenuOptions): MenuItemConstructorOptions {
+  if (options.isMac) {
+    return { role: "windowMenu" };
+  }
+
+  const windowItems: MenuItemConstructorOptions[] = options.windows.length
+    ? options.windows.map((window) => ({
+        label: window.title || "Untitled Window",
+        type: "checkbox",
+        checked: window.focused,
+        click: () => {
+          options.actions.focusWindow(window.id);
+        },
+      }))
+    : [
+        {
+          label: "No Open Windows",
+          enabled: false,
+        },
+      ];
+
+  return {
+    label: "Window",
+    submenu: [
+      { role: "minimize" },
+      { role: "close" },
+      { type: "separator" },
+      ...windowItems,
     ],
   };
 }

--- a/apps/desktop/src/main/messaging-activity-window.ts
+++ b/apps/desktop/src/main/messaging-activity-window.ts
@@ -18,10 +18,12 @@ import {
 import {
   auxiliaryWindowChromeOptions,
   hideAuxiliaryWindowMenuBar,
+  registerAuxiliaryWindowTitle,
   showAndFocusAuxiliaryWindow,
 } from "./auxiliary-window-chrome";
 
 const log = getMainLogger("pwragent:activity-window");
+const ACTIVITY_WINDOW_TITLE = "Messaging Activity";
 
 /**
  * Hash that the renderer (`main.tsx`) reads to decide whether to mount
@@ -56,7 +58,7 @@ export function showMessagingActivityWindow(): void {
     minWidth: 640,
     minHeight: 480,
     show: false,
-    title: "Messaging Activity — PwrAgent",
+    title: ACTIVITY_WINDOW_TITLE,
     ...auxiliaryWindowChromeOptions(),
     backgroundColor: themedWindowBackgroundColor(appearance),
     webPreferences: {
@@ -67,6 +69,7 @@ export function showMessagingActivityWindow(): void {
       additionalArguments: themedWindowAdditionalArguments(appearance),
     },
   });
+  registerAuxiliaryWindowTitle(window, ACTIVITY_WINDOW_TITLE);
   hideAuxiliaryWindowMenuBar(window);
 
   applyWindowSecurityHardening(window);

--- a/apps/desktop/src/main/messaging-activity-window.ts
+++ b/apps/desktop/src/main/messaging-activity-window.ts
@@ -15,6 +15,10 @@ import {
   themedWindowAdditionalArguments,
   themedWindowBackgroundColor,
 } from "./settings/appearance-bootstrap";
+import {
+  auxiliaryWindowChromeOptions,
+  hideAuxiliaryWindowMenuBar,
+} from "./auxiliary-window-chrome";
 
 const log = getMainLogger("pwragent:activity-window");
 
@@ -56,8 +60,7 @@ export function showMessagingActivityWindow(): void {
     minHeight: 480,
     show: false,
     title: "Messaging Activity — PwrAgent",
-    titleBarStyle: "hiddenInset",
-    trafficLightPosition: { x: 20, y: 18 },
+    ...auxiliaryWindowChromeOptions(),
     backgroundColor: themedWindowBackgroundColor(appearance),
     webPreferences: {
       preload: getPreloadPath(),
@@ -67,6 +70,7 @@ export function showMessagingActivityWindow(): void {
       additionalArguments: themedWindowAdditionalArguments(appearance),
     },
   });
+  hideAuxiliaryWindowMenuBar(window);
 
   applyWindowSecurityHardening(window);
   // The activity window does not subscribe to any push events today

--- a/apps/desktop/src/main/messaging-activity-window.ts
+++ b/apps/desktop/src/main/messaging-activity-window.ts
@@ -20,6 +20,7 @@ import {
   hideAuxiliaryWindowMenuBar,
   registerAuxiliaryWindowTitle,
   showAndFocusAuxiliaryWindow,
+  showAuxiliaryWindowWhenReady,
 } from "./auxiliary-window-chrome";
 
 const log = getMainLogger("pwragent:activity-window");
@@ -93,9 +94,7 @@ export function showMessagingActivityWindow(): void {
     void window.loadFile(rendererEntry.value, { hash: ACTIVITY_HASH });
   }
 
-  window.once("ready-to-show", () => {
-    showAndFocusAuxiliaryWindow(window);
-  });
+  showAuxiliaryWindowWhenReady(window);
 
   window.on("closed", () => {
     // The top-of-function "already-open" guard prevents two activity

--- a/apps/desktop/src/main/messaging-activity-window.ts
+++ b/apps/desktop/src/main/messaging-activity-window.ts
@@ -18,6 +18,7 @@ import {
 import {
   auxiliaryWindowChromeOptions,
   hideAuxiliaryWindowMenuBar,
+  showAndFocusAuxiliaryWindow,
 } from "./auxiliary-window-chrome";
 
 const log = getMainLogger("pwragent:activity-window");
@@ -44,11 +45,7 @@ let activityWindow: BrowserWindow | undefined;
  */
 export function showMessagingActivityWindow(): void {
   if (activityWindow && !activityWindow.isDestroyed()) {
-    if (activityWindow.isMinimized()) {
-      activityWindow.restore();
-    }
-    activityWindow.show();
-    activityWindow.focus();
+    showAndFocusAuxiliaryWindow(activityWindow);
     return;
   }
 
@@ -94,7 +91,7 @@ export function showMessagingActivityWindow(): void {
   }
 
   window.once("ready-to-show", () => {
-    window.show();
+    showAndFocusAuxiliaryWindow(window);
   });
 
   window.on("closed", () => {

--- a/apps/desktop/src/renderer/src/features/license/LicenseDocumentWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/license/LicenseDocumentWindow.tsx
@@ -16,14 +16,15 @@ export function LicenseDocumentWindow() {
   const documentKind = currentDocumentKind();
   const fallbackTitle =
     documentKind === "license" ? "MIT License" : "Third-Party Notices";
+  const windowTitle = documentKind === "license" ? "License" : fallbackTitle;
   const [licenseDocument, setLicenseDocument] = useState<
     AppLicenseDocument | undefined
   >();
   const [error, setError] = useState<string | undefined>();
 
   useEffect(() => {
-    document.title = fallbackTitle;
-  }, [fallbackTitle]);
+    document.title = windowTitle;
+  }, [windowTitle]);
 
   useEffect(() => {
     let cancelled = false;

--- a/apps/desktop/src/renderer/src/features/license/__tests__/license-document-window.test.tsx
+++ b/apps/desktop/src/renderer/src/features/license/__tests__/license-document-window.test.tsx
@@ -8,6 +8,8 @@ import { LicenseDocumentWindow } from "../LicenseDocumentWindow";
 afterEach(() => {
   cleanup();
   delete (window as Window & { pwragent?: unknown }).pwragent;
+  window.history.replaceState(null, "", "/");
+  document.title = "";
 });
 
 describe("LicenseDocumentWindow", () => {
@@ -27,5 +29,27 @@ describe("LicenseDocumentWindow", () => {
       expect(readLicenseDocument).toHaveBeenCalledWith("third-party-licenses");
     });
     expect(await screen.findByText(/react@19\.2\.5/)).toBeInTheDocument();
+  });
+
+  it("uses License for the window title while keeping MIT License in the document chrome", async () => {
+    window.history.replaceState(null, "", "/#license");
+    const readLicenseDocument = vi.fn(async (kind: AppLicenseDocumentKind) => ({
+      kind,
+      title: "MIT License",
+      content: "MIT License\n\nPermission is hereby granted.",
+    }));
+    (window as Window & { pwragent?: DesktopApi }).pwragent = {
+      readLicenseDocument,
+    };
+
+    render(<LicenseDocumentWindow />);
+
+    await waitFor(() => {
+      expect(readLicenseDocument).toHaveBeenCalledWith("license");
+    });
+    await screen.findByText(/Permission is hereby granted/);
+
+    expect(document.title).toBe("License");
+    expect(screen.getByText("MIT License")).toBeInTheDocument();
   });
 });

--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -33,9 +33,13 @@ const desktopApi = (
           density: DesktopAppearanceDensity;
         }) => void,
       ) => () => void;
+      platform?: string;
     };
   }
 ).pwragent;
+if (desktopApi?.platform) {
+  document.documentElement.dataset.platform = desktopApi.platform;
+}
 const unsubscribeAppearance = desktopApi?.onAppearanceChanged?.(
   (appearance) => {
     applyAppearanceAttributes(

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -503,6 +503,15 @@ describe("Tangerine Terminal theme contract", () => {
     expect(activityCurrent).toContain("color: var(--text-primary);");
   });
 
+  it("drops the auxiliary titlebar stoplight gutter outside macOS and Windows", () => {
+    const activityTitlebar = extractRuleBody(css, ".activity-titlebar");
+
+    expect(activityTitlebar).toContain("padding: 10px 14px 0 96px;");
+    expect(css).toMatch(
+      /:root\[data-platform\]:not\(\[data-platform="darwin"\]\):not\(\[data-platform="win32"\]\)\s*\.activity-titlebar\s*\{[\s\S]*?padding-left:\s*14px;[\s\S]*?\}/,
+    );
+  });
+
   it("mirrors thread-row drop-indicator + recents divider tokens for directory pinning", () => {
     // Plan 2026-05-09-002 Units L + P. The directory-pin CSS is
     // explicitly a steal-the-pattern of the thread-pin CSS: the

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -503,12 +503,22 @@ describe("Tangerine Terminal theme contract", () => {
     expect(activityCurrent).toContain("color: var(--text-primary);");
   });
 
-  it("drops the auxiliary titlebar stoplight gutter outside macOS and Windows", () => {
+  it("drops titlebar stoplight gutters outside macOS and Windows", () => {
     const activityTitlebar = extractRuleBody(css, ".activity-titlebar");
+    const sidebarMasthead = extractRuleBody(css, ".sidebar__masthead");
+    const settingsMasthead = extractRuleBody(css, ".settings-nav__masthead");
 
     expect(activityTitlebar).toContain("padding: 10px 14px 0 96px;");
+    expect(sidebarMasthead).toContain("padding: 10px 0 0 80px;");
+    expect(settingsMasthead).toContain("padding: 10px 0 0 80px;");
     expect(css).toMatch(
       /:root\[data-platform\]:not\(\[data-platform="darwin"\]\):not\(\[data-platform="win32"\]\)\s*\.activity-titlebar\s*\{[\s\S]*?padding-left:\s*14px;[\s\S]*?\}/,
+    );
+    expect(css).toMatch(
+      /:root\[data-platform\]:not\(\[data-platform="darwin"\]\):not\(\[data-platform="win32"\]\)\s*\.sidebar__masthead\s*\{[\s\S]*?padding-left:\s*0;[\s\S]*?\}/,
+    );
+    expect(css).toMatch(
+      /:root\[data-platform\]:not\(\[data-platform="darwin"\]\):not\(\[data-platform="win32"\]\)\s*\.settings-nav__masthead\s*\{[\s\S]*?padding-left:\s*0;[\s\S]*?\}/,
     );
   });
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -750,13 +750,12 @@ textarea,
   background: var(--bg-app);
 }
 
-/* Title-bar strip — single-row chrome with stoplight clearance on
-   the left. Padding mirrors `.settings-nav__masthead` (10/0/0/96)
-   so the brand visually aligns with the macOS traffic-light center
-   on `titleBarStyle: "hiddenInset"` windows. The 96px left clearance
-   matches the effective Settings-nav left offset (16px nav padding +
-   80px masthead padding); stoplights end at ~x=72, brand lands at
-   x=96, giving 24px breathing room. */
+/* Title-bar strip — single-row chrome. Base padding keeps macOS
+   stoplight clearance on the left: `.settings-nav__masthead`
+   (10/0/0/96) alignment, stoplights end at ~x=72, brand lands at
+   x=96. Platforms without macOS/Windows chrome conventions override
+   the left padding below so auxiliary-window titles don't float
+   awkwardly away from the window edge. */
 .activity-titlebar {
   display: flex;
   align-items: center;
@@ -767,6 +766,11 @@ textarea,
   border-bottom: 1px solid var(--border-subtle);
   background: var(--bg-panel-elevated);
   -webkit-app-region: drag;
+}
+
+:root[data-platform]:not([data-platform="darwin"]):not([data-platform="win32"])
+  .activity-titlebar {
+  padding-left: 14px;
 }
 
 .activity-titlebar button,

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -501,6 +501,11 @@ textarea,
   border-bottom: none;
 }
 
+:root[data-platform]:not([data-platform="darwin"]):not([data-platform="win32"])
+  .sidebar__masthead {
+  padding-left: 0;
+}
+
 /* .sidebar__identity removed — brand is direct child of masthead */
 
 .sidebar__masthead-actions {
@@ -3224,6 +3229,11 @@ textarea,
   min-height: 44px;
   padding: 10px 0 0 80px;
   -webkit-app-region: drag;
+}
+
+:root[data-platform]:not([data-platform="darwin"]):not([data-platform="win32"])
+  .settings-nav__masthead {
+  padding-left: 0;
 }
 
 .settings-nav__masthead * {


### PR DESCRIPTION
## Summary

I hid the Linux/Windows menu bar by default on auxiliary PwrAgent windows so Changelog, Logs, License, Third-Party Notices, and Messaging Activity no longer open with a full edit/menu control strip in the window content area. The menu remains available with `Alt`, which matches Electron's platform behavior for `autoHideMenuBar`.

I also replaced the non-mac `Window` menu's default role with an explicit list of open PwrAgent windows, so Ubuntu users can switch back to Changelog, Logs, and other app windows from the menu like they can on macOS.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/menu.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm --filter @pwragent/desktop build`

I verified the Electron API usage and menu-template behavior locally. I could not visually verify Ubuntu window chrome from this macOS host.
