### PR TITLE
feat(desktop): show thread project breadcrumb

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -151,6 +151,16 @@ function DesktopAppShell(props: {
   const openMessagingActivityWindow = useCallback(() => {
     void desktopApi?.openMessagingActivityWindow?.();
   }, [desktopApi]);
+  const revealSelectedThreadInList = useCallback(() => {
+    const selectedRow = document.querySelector<HTMLElement>(
+      ".sidebar .thread-row.is-selected",
+    );
+    selectedRow?.scrollIntoView({
+      behavior: "smooth",
+      block: "center",
+      inline: "nearest",
+    });
+  }, []);
   const settings = props.settings;
   const normalAppEnabled =
     !desktopApi?.readSettings ||
@@ -368,6 +378,7 @@ function DesktopAppShell(props: {
       }
     },
     onOpenMessagingActivity: openMessagingActivityWindow,
+    onRevealSelectedThreadInList: revealSelectedThreadInList,
     onHandoffThreadWorkspace: navigation.selectedThread
       ? async (request) =>
           await navigation.handoffThreadWorkspace(

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -681,11 +681,11 @@ describe("App", () => {
         name: "Build Codex client"
       })
     ).toBeInTheDocument();
-    const headerTitleButton = screen
-      .getAllByRole("button", { name: "Build Codex client" })
-      .find((button) => button.closest(".thread-header"));
-    expect(headerTitleButton).toBeDefined();
-    fireEvent.click(headerTitleButton!);
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Show selected thread in thread list",
+      }),
+    );
     expect(scrollIntoView).toHaveBeenCalledWith({
       behavior: "smooth",
       block: "center",

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -407,6 +407,11 @@ describe("App", () => {
 
   it("renders the live thread shell with transcript history", async () => {
     const copyText = vi.fn(async () => undefined);
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: scrollIntoView,
+    });
     const listSkills = vi.fn(async () => ({
       backend: "codex" as const,
       fetchedAt: Date.now(),
@@ -676,6 +681,16 @@ describe("App", () => {
         name: "Build Codex client"
       })
     ).toBeInTheDocument();
+    const headerTitleButton = screen
+      .getAllByRole("button", { name: "Build Codex client" })
+      .find((button) => button.closest(".thread-header"));
+    expect(headerTitleButton).toBeDefined();
+    fireEvent.click(headerTitleButton!);
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      behavior: "smooth",
+      block: "center",
+      inline: "nearest",
+    });
     expect(screen.getAllByText("PwrAgent").length).toBeGreaterThan(0);
     expect(await screen.findByText(".worktrees/pwragent-fix-t...ng-moioth2352")).toBeInTheDocument();
     expect(screen.getByText("codex/fix-thread-naming-ephemeral")).toBeInTheDocument();

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
@@ -10,9 +10,11 @@ import type { DesktopApi } from "../../lib/desktop-api";
 
 type ThreadHeaderProps = {
   desktopApi?: DesktopApi;
+  projectLabel?: string;
   thread: NavigationThreadSummary;
   /** Forwarded to MessagingStatusBar — fires when a platform chip is clicked. */
   onOpenMessagingActivity?: (platform: MessagingChannelKind) => void;
+  onRevealSelectedThreadInList?: () => void;
 };
 
 function missingDirectoryPath(thread: NavigationThreadSummary): string | undefined {
@@ -26,6 +28,7 @@ function missingDirectoryPath(thread: NavigationThreadSummary): string | undefin
 
 export function ThreadHeader(props: ThreadHeaderProps) {
   const missingPath = missingDirectoryPath(props.thread);
+  const projectLabel = props.projectLabel?.trim();
   const branchDrifted = isBranchDrifted(
     props.thread.gitBranch,
     props.thread.observedGitBranch,
@@ -35,9 +38,32 @@ export function ThreadHeader(props: ThreadHeaderProps) {
     <header className="thread-header">
       <div className="thread-header__main">
         <div className="thread-header__eyebrow-row">
-          <h2 className="thread-header__compact-title" title={props.thread.title}>
-            {props.thread.title}
-          </h2>
+          <div className="thread-header__breadcrumb">
+            {projectLabel ? (
+              <>
+                <span className="thread-header__eyebrow" title={projectLabel}>
+                  {projectLabel}
+                </span>
+                <span aria-hidden="true" className="thread-header__separator">
+                  ›
+                </span>
+              </>
+            ) : null}
+            <h2 className="thread-header__compact-title" title={props.thread.title}>
+              {props.onRevealSelectedThreadInList ? (
+                <button
+                  className="thread-header__title-button"
+                  title="Show in thread list"
+                  type="button"
+                  onClick={props.onRevealSelectedThreadInList}
+                >
+                  {props.thread.title}
+                </button>
+              ) : (
+                props.thread.title
+              )}
+            </h2>
+          </div>
           <span className="chip chip--backend">
             {formatBackendLabel(props.thread.source)}
           </span>

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
@@ -49,7 +49,11 @@ export function ThreadHeader(props: ThreadHeaderProps) {
                 </span>
               </>
             ) : null}
-            <h2 className="thread-header__compact-title" title={props.thread.title}>
+            <h2
+              aria-label={props.thread.title}
+              className="thread-header__compact-title"
+              title={props.thread.title}
+            >
               {props.onRevealSelectedThreadInList ? (
                 <button
                   aria-label="Show selected thread in thread list"

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
@@ -52,6 +52,7 @@ export function ThreadHeader(props: ThreadHeaderProps) {
             <h2 className="thread-header__compact-title" title={props.thread.title}>
               {props.onRevealSelectedThreadInList ? (
                 <button
+                  aria-label="Show selected thread in thread list"
                   className="thread-header__title-button"
                   title="Show in thread list"
                   type="button"

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -810,6 +810,7 @@ export type ThreadViewProps = {
   onDismissFullAccessRiskWarning?: () => Promise<void>;
   /** Forwarded to ThreadHeader → MessagingStatusBar — opens the Activity screen. */
   onOpenMessagingActivity?: (platform: MessagingChannelKind) => void;
+  onRevealSelectedThreadInList?: () => void;
   onLoadOlder: () => Promise<void>;
   onArchiveThread?: (thread: NavigationThreadSummary) => Promise<void>;
   onRefreshNavigation?: () => Promise<void>;
@@ -1989,8 +1990,10 @@ export function ThreadView(props: ThreadViewProps) {
     >
       <ThreadHeader
         desktopApi={props.desktopApi}
+        projectLabel={props.selectedDirectory?.label}
         thread={selectedThread!}
         onOpenMessagingActivity={props.onOpenMessagingActivity}
+        onRevealSelectedThreadInList={props.onRevealSelectedThreadInList}
       />
 
       <div

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadHeader.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadHeader.test.tsx
@@ -1,0 +1,45 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { NavigationThreadSummary } from "@pwragent/shared";
+import { ThreadHeader } from "../ThreadHeader";
+
+afterEach(() => {
+  cleanup();
+});
+
+const thread: NavigationThreadSummary = {
+  id: "thread-1",
+  title: "AI API Rate Limiting",
+  titleSource: "explicit",
+  source: "codex",
+  executionMode: "default",
+  updatedAt: Date.now(),
+  linkedDirectories: [],
+  inbox: {
+    inInbox: true,
+  },
+};
+
+describe("ThreadHeader", () => {
+  it("renders the project breadcrumb and reveals the selected row from title click", () => {
+    const onRevealSelectedThreadInList = vi.fn();
+
+    render(
+      <ThreadHeader
+        projectLabel="PwrSnap"
+        thread={thread}
+        onRevealSelectedThreadInList={onRevealSelectedThreadInList}
+      />,
+    );
+
+    expect(screen.getByText("PwrSnap")).toHaveClass("thread-header__eyebrow");
+    expect(
+      screen.getByRole("heading", { level: 2, name: "AI API Rate Limiting" }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "AI API Rate Limiting" }));
+
+    expect(onRevealSelectedThreadInList).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadHeader.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadHeader.test.tsx
@@ -38,7 +38,11 @@ describe("ThreadHeader", () => {
       screen.getByRole("heading", { level: 2, name: "AI API Rate Limiting" }),
     ).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "AI API Rate Limiting" }));
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Show selected thread in thread list",
+      }),
+    );
 
     expect(onRevealSelectedThreadInList).toHaveBeenCalledOnce();
   });

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5084,6 +5084,36 @@ textarea,
   min-width: 0;
 }
 
+.thread-header__breadcrumb {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  flex: 1 1 auto;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.thread-header__eyebrow {
+  overflow: hidden;
+  flex: 0 1 auto;
+  max-width: min(28ch, 34vw);
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 650;
+  line-height: 1.3;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.thread-header__separator {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+  font-size: 13px;
+  line-height: 1;
+}
+
 .thread-header__eyebrow-row > .eyebrow {
   display: inline-flex;
   height: 24px;
@@ -5105,6 +5135,33 @@ textarea,
   line-height: 1.25;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.thread-header__title-button {
+  display: block;
+  width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  line-height: inherit;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.thread-header__title-button:hover {
+  color: var(--accent-bright);
+}
+
+.thread-header__title-button:focus-visible {
+  border-radius: 4px;
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
 }
 
 .thread-header__eyebrow-row > .thread-row__chip {


### PR DESCRIPTION
## Summary

- I added a compact project breadcrumb to the selected thread header so directory-launched threads read like `PwrSnap › AI API Rate Limiting` instead of leaving the project context implicit.
- I made the thread title in that breadcrumb clickable; clicking it scrolls the selected row back into view in the sidebar thread list.
- I kept the styling on the existing Tangerine Terminal tokens and covered the header callback plus app-shell scroll behavior with renderer tests.

## Verification

- I ran `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadHeader.test.tsx`.
- I ran `pnpm test apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx`.
- I ran `pnpm test apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx`.
- I ran `pnpm lint:colors`.
- I ran `pnpm --filter @pwragent/desktop typecheck`.
- I ran `pnpm --filter @pwragent/desktop build`.
- I ran `pnpm --filter @pwragent/desktop exec playwright test -c playwright.config.ts e2e/a11y.spec.ts -g "open thread view"`.

## Notes

- This is a focused renderer-only change.

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
Generated with GPT-5 via [Codex](https://openai.com/codex)
