### PR TITLE
feat(desktop): make wizard messaging setup actually work end-to-end

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-status-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-ipc.test.ts
@@ -44,6 +44,9 @@ const leaseCoordinatorMock = vi.hoisted(() => ({
     await runtime.stop();
     return { enabled: false, disabledReasonKind: "runtime_stopped" };
   }),
+  shutdown: vi.fn(async (runtime: typeof runtimeMock) => {
+    await runtime.stop();
+  }),
 }));
 
 vi.mock("electron", () => ({
@@ -124,6 +127,7 @@ describe("messaging status ipc", () => {
     messagingConfigMocks.loadDesktopMessagingConfigFromSettings.mockClear();
     leaseCoordinatorMock.applyLatestConfig.mockClear();
     leaseCoordinatorMock.disableForSession.mockClear();
+    leaseCoordinatorMock.shutdown.mockClear();
   });
 
   it("loads startup eligibility diagnostics when enabling messaging at runtime", async () => {
@@ -338,6 +342,47 @@ describe("messaging status ipc", () => {
         },
       },
     });
+  });
+
+  it("shuts the messaging runtime down on graduation request", async () => {
+    // The wizard's graduation path calls this IPC right before it
+    // spawns the operator's chosen profile in a child Electron — the
+    // child's own adapters can't start cleanly if the bootstrap is
+    // still polling. Asserting the IPC routes through to the lease
+    // coordinator's `shutdown` (which both stops the runtime AND
+    // releases its lease, mirroring the SIGTERM cleanup).
+    const { registerMessagingStatusIpcHandlers } = await import(
+      "../ipc/messaging-status"
+    );
+    const { MESSAGING_SHUTDOWN_RUNTIME_CHANNEL } = await import("../../shared/ipc");
+
+    registerMessagingStatusIpcHandlers();
+
+    await expect(
+      handlers.get(MESSAGING_SHUTDOWN_RUNTIME_CHANNEL)?.(),
+    ).resolves.toBeUndefined();
+
+    expect(leaseCoordinatorMock.shutdown).toHaveBeenCalledWith(runtimeMock);
+    expect(runtimeMock.stop).toHaveBeenCalled();
+  });
+
+  it("swallows shutdown errors so a failing teardown can't block the spawn", async () => {
+    // The wizard cannot recover if `shutdownMessagingRuntime`
+    // throws — it still needs to spawn the new profile. The IPC
+    // must catch internally and return success; the failure is
+    // logged but the spawn proceeds. Otherwise a stuck adapter
+    // teardown would strand the operator with no main window.
+    leaseCoordinatorMock.shutdown.mockRejectedValueOnce(new Error("boom"));
+    const { registerMessagingStatusIpcHandlers } = await import(
+      "../ipc/messaging-status"
+    );
+    const { MESSAGING_SHUTDOWN_RUNTIME_CHANNEL } = await import("../../shared/ipc");
+
+    registerMessagingStatusIpcHandlers();
+
+    await expect(
+      handlers.get(MESSAGING_SHUTDOWN_RUNTIME_CHANNEL)?.(),
+    ).resolves.toBeUndefined();
   });
 });
 

--- a/apps/desktop/src/main/ipc/messaging-status.ts
+++ b/apps/desktop/src/main/ipc/messaging-status.ts
@@ -43,6 +43,7 @@ import {
   MESSAGING_PLATFORM_STATUS_EVENT_CHANNEL,
   MESSAGING_REJECT_PAIRING_CHANNEL,
   MESSAGING_SET_ENABLED_CHANNEL,
+  MESSAGING_SHUTDOWN_RUNTIME_CHANNEL,
   MESSAGING_UNBIND_THREAD_CHANNEL,
 } from "../../shared/ipc";
 
@@ -476,6 +477,28 @@ export function registerMessagingStatusIpcHandlers(): void {
   ipcMain.handle(MESSAGING_OPEN_ACTIVITY_WINDOW_CHANNEL, async (): Promise<void> => {
     showMessagingActivityWindow();
   });
+
+  ipcMain.removeHandler(MESSAGING_SHUTDOWN_RUNTIME_CHANNEL);
+  ipcMain.handle(MESSAGING_SHUTDOWN_RUNTIME_CHANNEL, async (): Promise<void> => {
+    // Called by the wizard right before it spawns the operator's
+    // chosen profile in a new Electron process. The bootstrap's
+    // adapters (Telegram long-poll, Discord gateway, etc.) hold
+    // exclusive resources upstream; if we don't release them first
+    // the child process's adapters race and lose (Telegram 409,
+    // Discord "another shard already connected", etc.).
+    //
+    // `shutdown` stops the runtime AND releases the runtime-messaging
+    // lease, mirroring the SIGTERM cleanup path. Idempotent — calling
+    // it twice or when nothing is running is a no-op.
+    try {
+      await getRuntimeMessagingLeaseCoordinator().shutdown(runtime);
+      log.info("messaging runtime shutdown via wizard graduation");
+    } catch (error) {
+      log.warn("messaging runtime shutdown failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  });
 }
 
 export async function disposeMessagingStatusIpcHandlers(): Promise<void> {
@@ -494,4 +517,5 @@ export async function disposeMessagingStatusIpcHandlers(): Promise<void> {
   ipcMain.removeHandler(MESSAGING_UNBIND_THREAD_CHANNEL);
   ipcMain.removeHandler(MESSAGING_SET_ENABLED_CHANNEL);
   ipcMain.removeHandler(MESSAGING_OPEN_ACTIVITY_WINDOW_CHANNEL);
+  ipcMain.removeHandler(MESSAGING_SHUTDOWN_RUNTIME_CHANNEL);
 }

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -27,6 +27,7 @@ import type {
   WriteDesktopSettingsConfigRequest,
 } from "@pwragent/shared";
 import {
+  isMessagingRuntimeSecret,
   sanitizeMessagingContactHandle,
   sanitizeMessagingContactLabel,
 } from "@pwragent/shared";
@@ -303,17 +304,10 @@ function messagingPatchTouchesRuntime(
 function messagingSecretTouchesRuntime(
   secret: DesktopSettingsSecretName,
 ): boolean {
-  return secret === "telegramBotToken"
-    || secret === "discordBotToken"
-    || secret === "mattermostBotToken"
-    || secret === "mattermostHmacSecret"
-    || secret === "slackBotToken"
-    || secret === "slackAppToken"
-    || secret === "slackSigningSecret"
-    || secret === "feishuAppId"
-    || secret === "feishuAppSecret"
-    || secret === "feishuEncryptKey"
-    || secret === "feishuVerificationToken";
+  // Delegates to the shared predicate so the renderer's onboarding
+  // wizard and the main-process IPC layer agree on which secret
+  // names should re-evaluate the runtime when they change.
+  return isMessagingRuntimeSecret(secret);
 }
 
 async function applyLatestMessagingRuntimeConfig(

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -226,6 +226,7 @@ import {
   MESSAGING_PLATFORM_STATUS_EVENT_CHANNEL,
   MESSAGING_REJECT_PAIRING_CHANNEL,
   MESSAGING_SET_ENABLED_CHANNEL,
+  MESSAGING_SHUTDOWN_RUNTIME_CHANNEL,
   MESSAGING_UNBIND_THREAD_CHANNEL,
   NAVIGATION_GET_GH_STATUS_CHANNEL,
   NAVIGATION_PICK_DIRECTORY_FROM_DISK_CHANNEL,
@@ -788,6 +789,9 @@ const desktopApi = Object.freeze({
     await ipcRenderer.invoke(MESSAGING_REJECT_PAIRING_CHANNEL, request),
   openMessagingActivityWindow: async (): Promise<void> => {
     await ipcRenderer.invoke(MESSAGING_OPEN_ACTIVITY_WINDOW_CHANNEL);
+  },
+  shutdownMessagingRuntime: async (): Promise<void> => {
+    await ipcRenderer.invoke(MESSAGING_SHUTDOWN_RUNTIME_CHANNEL);
   },
   onMessagingPlatformStatusEvent: (
     callback: (event: MessagingPlatformStatusEvent) => void,

--- a/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
+++ b/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
@@ -18,7 +18,10 @@ import type {
   DesktopSettingsSnapshot,
   MessagingChannelKind,
   MessagingPairingScope,
+  SettingsCredentialTestKind,
+  SettingsCredentialTestResult,
 } from "@pwragent/shared";
+import { isMessagingRuntimeSecret } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 import type { AppearanceController } from "../../lib/useAppearance";
 import type { DesktopSettingsState } from "../settings/useDesktopSettings";
@@ -517,6 +520,31 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
     async (targetProfile: string): Promise<void> => {
       const api = props.desktopApi;
       if (!api?.openPwrAgentProfile) return;
+      // Release any messaging adapters this process is holding before
+      // we spawn the operator's chosen profile in a new Electron.
+      // Adapters like Telegram long-poll and Discord gateway hold
+      // exclusive resources upstream; without this release the child
+      // process's runtime collides with ours and the upstream returns
+      // 409 / "another shard already connected" / similar — leaving
+      // the operator with a *visually* online runtime in the new
+      // window's titlebar but broken inbound delivery.
+      //
+      // We only need this in bootstrap mode (where we're about to
+      // quit anyway), but calling it unconditionally is safe — the
+      // IPC is idempotent and the active-profile path will restart
+      // the runtime on the same process on the next config write.
+      if (api.shutdownMessagingRuntime) {
+        try {
+          await api.shutdownMessagingRuntime();
+        } catch (caught) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            "Onboarding: shutdownMessagingRuntime failed before spawn — "
+              + "child process may collide with stale adapters",
+            caught,
+          );
+        }
+      }
       try {
         await api.openPwrAgentProfile({ profile: targetProfile });
       } catch (caught) {
@@ -932,6 +960,20 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
               onSkipMessaging={skipMessaging}
               onContinue={goNext}
               submitting={submitting}
+              // Multi-profile context: in Multiple / Isolated modes the
+              // wizard provisions N profiles and lands the operator
+              // inside the first one. Messaging is configured for that
+              // first profile only; the others need their own
+              // post-launch Settings trip. Shared mode collapses to a
+              // single profile so we skip the notice.
+              multiProfileTarget={
+                codexProfileModel !== "shared" && codexProfileNames.length >= 1
+                  ? {
+                      firstProfileName: codexProfileNames[0]!,
+                      otherProfileNames: codexProfileNames.slice(1),
+                    }
+                  : undefined
+              }
             />
           ) : null}
           {step === "messaging-providers" ? (
@@ -948,6 +990,11 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
               desktopApi={props.desktopApi}
               bufferedSecrets={bufferedSecrets}
               onBufferSecret={setBufferedSecret}
+              targetProfileName={
+                codexProfileModel !== "shared"
+                  ? codexProfileNames[0]
+                  : undefined
+              }
             />
           ) : null}
           {step === "done" ? (
@@ -1967,6 +2014,18 @@ function MessagingSafetyStep(props: {
   onSkipMessaging: () => void;
   onContinue: () => void;
   submitting: boolean;
+  /**
+   * In Multiple / Isolated modes, identifies the profile messaging
+   * will be configured for during this wizard (always the first
+   * named profile — they're created in order, and we land the
+   * operator inside the first one at Finish). When set, the safety
+   * step prepends a notice so the operator knows the other profiles
+   * stay messaging-free until they configure each one from Settings.
+   *
+   * `undefined` for Shared mode (only one profile exists — no
+   * disambiguation needed).
+   */
+  multiProfileTarget?: { firstProfileName: string; otherProfileNames: readonly string[] };
 }) {
   return (
     <div className="onboarding-wizard__safety">
@@ -1981,6 +2040,26 @@ function MessagingSafetyStep(props: {
         You can also skip this and stay on the desktop. Either way, three
         principles to read before you decide.
       </p>
+      {props.multiProfileTarget
+      && props.multiProfileTarget.otherProfileNames.length > 0 ? (
+        <div className="onboarding-wizard__safety-multi-notice" role="note">
+          <strong>Heads up:</strong> we'll set up messaging for{" "}
+          <code>{props.multiProfileTarget.firstProfileName}</code> here. The
+          other profile{props.multiProfileTarget.otherProfileNames.length === 1 ? "" : "s"}{" "}
+          (
+          {props.multiProfileTarget.otherProfileNames.map((name, i) => (
+            <span key={name}>
+              {i > 0 ? ", " : ""}
+              <code>{name}</code>
+            </span>
+          ))}
+          ) start without messaging. To configure messaging for{" "}
+          {props.multiProfileTarget.otherProfileNames.length === 1 ? "it" : "them"},
+          open each profile after the wizard finishes and use{" "}
+          <strong>Settings → Messaging</strong>. Each profile needs its own
+          bot — one bot token can only be polled by one process at a time.
+        </div>
+      ) : null}
       <ul className="onboarding-wizard__safety-list">
         <li>
           <strong>Try personal first.</strong> Use a personal computer and
@@ -3399,10 +3478,36 @@ const PROVIDER_SETUP_CONFIGS: Record<OnboardingProvider, ProviderSetupConfig> = 
         label: "Pair a Supergroup / Forum (just you + the bot)",
         help: (
           <>
-            Add the bot to a supergroup or forum that contains only you and
-            it, then send the pairing message inside any topic. Threads will
-            land in that topic. Best for keeping the bot conversation in its
-            own room separate from your DMs.
+            <p>
+              Add the bot to a supergroup or forum that contains only you and
+              it, then send the pairing message inside any topic. Threads will
+              land in that topic. Best for keeping the bot conversation in its
+              own room separate from your DMs.
+            </p>
+            <p className="onboarding-wizard__pairing-warning">
+              <strong>⚠ Telegram bot privacy:</strong> by default BotFather
+              ships new bots with <em>privacy mode on</em>, which means the
+              bot can&rsquo;t see plain messages in groups — only commands,
+              @mentions, and replies. If your pairing message never gets a
+              reply from the bot, you need to do <strong>one</strong> of:
+            </p>
+            <ul className="onboarding-wizard__pairing-warning-list">
+              <li>
+                <strong>@mention the bot</strong> in your pair message — e.g.{" "}
+                <code>@yourbot pair &lt;token&gt;</code>. You&rsquo;ll need to
+                @mention it on every message you want the bot to see.
+              </li>
+              <li>
+                <strong>Make the bot an admin</strong> in the group. Admins
+                always see all messages regardless of privacy mode.
+              </li>
+              <li>
+                <strong>Turn privacy mode off</strong> in BotFather:{" "}
+                <code>/mybots</code> → pick your bot → Bot Settings → Group
+                Privacy → Turn off. The bot then sees every message in groups
+                it&rsquo;s a member of.
+              </li>
+            </ul>
           </>
         ),
       },
@@ -3657,6 +3762,15 @@ function ProviderSetupStep(props: {
   desktopApi?: DesktopApi;
   bufferedSecrets: Record<string, string>;
   onBufferSecret: (name: string, value: string) => void;
+  /**
+   * In Multiple / Isolated modes, the profile name that will receive
+   * this messaging config at Finish. Surfaced as an eyebrow on the
+   * step header so the operator knows which profile they're
+   * pasting tokens for — important when the operator has two or
+   * more bot tokens in their head ("personal Telegram on this one,
+   * work Telegram on the other"). `undefined` in Shared mode.
+   */
+  targetProfileName?: string;
 }) {
   const config = PROVIDER_SETUP_CONFIGS[props.provider];
   const snapshot = props.settings.snapshot;
@@ -3677,6 +3791,11 @@ function ProviderSetupStep(props: {
   return (
     <div className="onboarding-wizard__provider-setup">
       <header className="onboarding-wizard__head">
+        {props.targetProfileName ? (
+          <span className="onboarding-wizard__provider-setup-eyebrow">
+            For profile <code>{props.targetProfileName}</code>
+          </span>
+        ) : null}
         <h1 className="onboarding-wizard__title">
           <span className="onboarding-wizard__provider-setup-icon">
             {providerIcon(props.provider, 22)}
@@ -3696,9 +3815,16 @@ function ProviderSetupStep(props: {
             bufferedSecrets={props.bufferedSecrets}
             onBufferSecret={props.onBufferSecret}
             writeConfig={props.settings.writeConfig}
+            replaceSecret={props.settings.replaceSecret}
+            clearSecret={props.settings.clearSecret}
           />
         ))}
       </div>
+      <ProviderIdentityProbe
+        provider={props.provider}
+        snapshot={snapshot}
+        desktopApi={props.desktopApi}
+      />
       {config.pairingOptions && config.pairingOptions.length > 0 ? (
         <PairingBlock
           platform={props.provider}
@@ -3719,6 +3845,11 @@ function ProviderFieldRow(props: {
   bufferedSecrets: Record<string, string>;
   onBufferSecret: (name: string, value: string) => void;
   writeConfig: (patch: DesktopSettingsConfigPatch) => Promise<boolean>;
+  replaceSecret: (
+    secret: DesktopSettingsSecretName,
+    value: string,
+  ) => Promise<boolean>;
+  clearSecret: (secret: DesktopSettingsSecretName) => Promise<boolean>;
 }) {
   if (props.field.kind === "secret") {
     // Capture the narrowed name into a local so the closure passed
@@ -3731,6 +3862,8 @@ function ProviderFieldRow(props: {
         snapshot={props.snapshot}
         bufferedValue={props.bufferedSecrets[secretName] ?? ""}
         onBuffer={(value) => props.onBufferSecret(secretName, value)}
+        replaceSecret={props.replaceSecret}
+        clearSecret={props.clearSecret}
       />
     );
   }
@@ -3756,26 +3889,216 @@ function ProviderFieldRow(props: {
   );
 }
 
-function SecretFieldRow(props: {
+/**
+ * Probe the provider's credentials and surface the bot identity
+ * inline (e.g. "Connected as @pwragent_bot · api.telegram.org") so
+ * the operator immediately sees the token landed on the right bot
+ * account. Mirrors the Settings → Messaging "test connection"
+ * affordance, but runs *automatically* once the underlying secret
+ * is configured — the wizard's step is already a setup moment, so
+ * the operator shouldn't need a separate Test click.
+ *
+ * Probe trigger: re-runs whenever the snapshot's primary-secret
+ * `configured` flips from false → true, or the snapshot's
+ * fetchedAt advances after a live secret replace. Failure surfaces
+ * a short error line; the snapshot's "✓ saved" pill on the field
+ * row still indicates the token *was* persisted.
+ */
+function ProviderIdentityProbe(props: {
+  provider: OnboardingProvider;
+  snapshot?: DesktopSettingsSnapshot;
+  desktopApi?: DesktopApi;
+}) {
+  const [result, setResult] = useState<SettingsCredentialTestResult | undefined>(
+    undefined,
+  );
+  const [running, setRunning] = useState(false);
+  const configured = isPlatformPrimarySecretConfigured(props.provider, props.snapshot);
+  const desktopApi = props.desktopApi;
+  const probeKind: SettingsCredentialTestKind = props.provider;
+
+  useEffect(() => {
+    if (!configured || !desktopApi?.testSettingsCredentials) {
+      // Nothing to probe — clear stale result when the secret is
+      // unconfigured (e.g. operator pressed Clear).
+      setResult(undefined);
+      return;
+    }
+    let cancelled = false;
+    setRunning(true);
+    void desktopApi
+      .testSettingsCredentials({ kind: probeKind })
+      .then((next) => {
+        if (!cancelled) setResult(next);
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        setResult({
+          kind: probeKind,
+          status: "failed",
+          testedAt: Date.now(),
+          durationMs: 0,
+          errorMessage: error instanceof Error ? error.message : String(error),
+        });
+      })
+      .finally(() => {
+        if (!cancelled) setRunning(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [configured, desktopApi, probeKind]);
+
+  if (!configured && !running && !result) return null;
+
+  const status = running ? "testing" : (result?.status ?? "idle");
+  return (
+    <div
+      className="onboarding-wizard__provider-identity"
+      data-status={status}
+      aria-live="polite"
+    >
+      {running ? (
+        <span className="onboarding-wizard__provider-identity-text">
+          Checking the bot account…
+        </span>
+      ) : result?.status === "ok" ? (
+        <span className="onboarding-wizard__provider-identity-text">
+          <span className="onboarding-wizard__provider-identity-pill is-ok">
+            ✓ Connected
+          </span>
+          {result.account ? (
+            <strong className="onboarding-wizard__provider-identity-account">
+              {result.account}
+            </strong>
+          ) : null}
+          {result.detail ? (
+            <span className="onboarding-wizard__provider-identity-detail">
+              {result.detail}
+            </span>
+          ) : null}
+        </span>
+      ) : result?.status === "failed" ? (
+        <span className="onboarding-wizard__provider-identity-text">
+          <span className="onboarding-wizard__provider-identity-pill is-err">
+            ✕ Could not reach the bot
+          </span>
+          {result.errorMessage ? (
+            <span className="onboarding-wizard__provider-identity-detail">
+              {result.errorMessage}
+            </span>
+          ) : null}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * Read the configured state of a platform's *primary* identity-bearing
+ * secret. Used by `ProviderIdentityProbe` to know when to run the
+ * `testSettingsCredentials` probe. Each platform's identity-revealing
+ * probe needs its own primary secret to be set — Telegram needs the
+ * bot token, Slack needs both bot + signing secret, etc. We pick the
+ * single most-load-bearing one per platform and call that the trigger.
+ *
+ * (We don't try to gate on EVERY secret being present — that would
+ * silently hide the probe for multi-field providers like Slack until
+ * all 3 are entered. Better to attempt the probe once the primary
+ * token is present; the probe surfaces its own "missing X" message
+ * for the rest.)
+ */
+function isPlatformPrimarySecretConfigured(
+  provider: OnboardingProvider,
+  snapshot?: DesktopSettingsSnapshot,
+): boolean {
+  if (!snapshot) return false;
+  switch (provider) {
+    case "telegram":
+      return snapshot.messaging?.telegram?.botToken?.configured === true;
+    case "discord":
+      return snapshot.messaging?.discord?.botToken?.configured === true;
+    case "mattermost":
+      return snapshot.messaging?.mattermost?.botToken?.configured === true;
+    case "slack":
+      return snapshot.messaging?.slack?.botToken?.configured === true;
+    case "feishu":
+      return snapshot.messaging?.feishu?.appSecret?.configured === true;
+    case "line":
+      return snapshot.messaging?.line?.channelAccessToken?.configured === true;
+  }
+}
+
+/**
+ * Exported for unit tests in `__tests__/secret-field-row.test.tsx`.
+ * Not intended to be imported from outside the onboarding feature.
+ */
+export function SecretFieldRow(props: {
   field: Extract<ProviderField, { kind: "secret" }>;
   snapshot?: DesktopSettingsSnapshot;
   /** Currently-buffered value (held in wizard state, encrypted +
    *  written to the chosen profile's keychain at Finish). */
   bufferedValue: string;
   onBuffer: (value: string) => void;
+  /** Live-write a secret to the *current* profile's keychain (in
+   *  bootstrap mode that's `.bootstrap`; otherwise the active
+   *  profile). Used for messaging-runtime secrets so the runtime
+   *  can actually start mid-wizard and the operator can complete
+   *  pairing without leaving the wizard. The buffer still tracks
+   *  the value too — at graduation `writeBufferedSecretsIfAny`
+   *  copies it onto the target profile. */
+  replaceSecret: (
+    secret: DesktopSettingsSecretName,
+    value: string,
+  ) => Promise<boolean>;
+  clearSecret: (secret: DesktopSettingsSecretName) => Promise<boolean>;
 }) {
   const [value, setValue] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [liveError, setLiveError] = useState<string | undefined>(undefined);
   const state = readSecretState(props.snapshot, props.field.name);
   const configured = state?.configured ?? false;
   const buffered = props.bufferedValue.length > 0;
+  const isRuntimeSecret = isMessagingRuntimeSecret(props.field.name);
 
-  const save = (): void => {
-    if (!value) return;
+  const save = async (): Promise<void> => {
+    if (!value || busy) return;
+    setLiveError(undefined);
+    // Always buffer first — graduation reads from the buffer when
+    // copying secrets onto the target profile.
     props.onBuffer(value);
+    if (isRuntimeSecret) {
+      // Messaging-runtime secrets must also land in the *current*
+      // profile's keychain *now* so the runtime can start and the
+      // operator's pairing message gets observed. In bootstrap mode
+      // this writes to `.bootstrap/state.db`, which is fine — the
+      // throwaway profile is torn down on graduation, and we
+      // re-write the value onto the target profile from the buffer.
+      setBusy(true);
+      try {
+        const ok = await props.replaceSecret(props.field.name, value);
+        if (!ok) {
+          setLiveError("Could not enable this provider — try again.");
+          return;
+        }
+      } finally {
+        setBusy(false);
+      }
+    }
     setValue("");
   };
-  const clear = (): void => {
+  const clear = async (): Promise<void> => {
+    if (busy) return;
     props.onBuffer("");
+    if (isRuntimeSecret && configured) {
+      setBusy(true);
+      setLiveError(undefined);
+      try {
+        await props.clearSecret(props.field.name);
+      } finally {
+        setBusy(false);
+      }
+    }
   };
   return (
     <div className="onboarding-wizard__field">
@@ -3806,32 +4129,37 @@ function SecretFieldRow(props: {
                 : props.field.placeholder
           }
           value={value}
+          disabled={busy}
           onChange={(e) => setValue(e.target.value)}
           onKeyDown={(e) => {
             if (e.key === "Enter") {
               e.preventDefault();
-              save();
+              void save();
             }
           }}
         />
         <button
           type="button"
           className="onboarding-wizard__btn onboarding-wizard__btn--ghost"
-          disabled={!value}
-          onClick={save}
+          disabled={!value || busy}
+          onClick={() => void save()}
         >
-          {buffered || configured ? "Replace" : "Use this"}
+          {busy ? "Saving…" : buffered || configured ? "Replace" : "Use this"}
         </button>
-        {buffered ? (
+        {buffered || (isRuntimeSecret && configured) ? (
           <button
             type="button"
             className="onboarding-wizard__btn onboarding-wizard__btn--link"
-            onClick={clear}
+            disabled={busy}
+            onClick={() => void clear()}
           >
             Clear
           </button>
         ) : null}
       </div>
+      {liveError ? (
+        <span className="onboarding-wizard__field-error">{liveError}</span>
+      ) : null}
     </div>
   );
 }
@@ -3959,6 +4287,30 @@ function SegmentedFieldRow(props: {
    and watches onMessagingPairingChanged for live status updates
    ---------------------------------------------------------------- */
 
+/**
+ * A pairing the operator approved during *this* wizard session.
+ * Used to render a compact "you paired X, Y, Z" summary after the
+ * pairing flow completes, so the operator can see what they've
+ * authorized without leaving the step. Multiple entries accumulate
+ * when the operator clicks "Pair another" — Telegram in particular
+ * commonly wants both a DM pairing and one or more supergroup
+ * pairings on the same bot.
+ *
+ * `actor`/`chat` are display labels resolved from the
+ * pairing-changed event's `observedActor` / `observedChat` (handle
+ * / displayName falling back to id). Kept as plain strings here
+ * because this list is purely cosmetic — the authoritative source
+ * is the per-platform `authorizedUserIds` / `authorizedSupergroups`
+ * snapshot, which the new spawned profile's main window will
+ * pick up after graduation.
+ */
+type SessionPairing = {
+  entryId: string;
+  scope: MessagingPairingScope;
+  actor?: string;
+  chat?: string;
+};
+
 function PairingBlock(props: {
   platform: MessagingChannelKind;
   title: string;
@@ -3975,6 +4327,26 @@ function PairingBlock(props: {
   const [resolution, setResolution] = useState<"observed" | "approved" | undefined>(
     undefined,
   );
+  // Captured display info for the observed actor/chat — used to render
+  // the inline "Approve @huntharo …" affordance and to seed the
+  // session pairing list on approval.
+  const [observedActorLabel, setObservedActorLabel] = useState<string | undefined>(
+    undefined,
+  );
+  const [observedChatLabel, setObservedChatLabel] = useState<string | undefined>(
+    undefined,
+  );
+  const [approving, setApproving] = useState(false);
+  // Pairings approved during this wizard session, in order. Rendered
+  // as a compact summary once at least one pairing has been approved.
+  // Survives the "Pair another" reset (which only clears the *current*
+  // in-flight token, not the running list).
+  const [paired, setPaired] = useState<readonly SessionPairing[]>([]);
+  // Set by "+ Pair another" — re-arms the active flow (Generate code
+  // button, scope picker) without clearing the `paired` summary above.
+  // Cleared on approval so the next approval falls back into compact
+  // mode unless the operator re-clicks "Pair another".
+  const [pairingAnother, setPairingAnother] = useState(false);
   const entryIdRef = useRef<string | undefined>(undefined);
   entryIdRef.current = entryId;
 
@@ -3987,9 +4359,63 @@ function PairingBlock(props: {
       if (event.entry.id !== entryIdRef.current) return;
       if (event.entry.status === "observed" || event.entry.status === "approved") {
         setResolution(event.entry.status);
+        setObservedActorLabel(
+          event.entry.observedActor?.displayName
+            ?? event.entry.observedActor?.id,
+        );
+        setObservedChatLabel(
+          event.entry.observedChat?.title ?? event.entry.observedChat?.id,
+        );
       }
     });
   }, [props.desktopApi, props.platform]);
+
+  const approve = async (): Promise<void> => {
+    const id = entryIdRef.current;
+    if (!id || approving || !props.desktopApi?.approveMessagingPairing) return;
+    setApproving(true);
+    setError(undefined);
+    try {
+      await props.desktopApi.approveMessagingPairing({ entryId: id });
+      setResolution("approved");
+      setPaired((prev) => [
+        ...prev,
+        {
+          entryId: id,
+          scope,
+          actor: observedActorLabel,
+          chat: observedChatLabel,
+        },
+      ]);
+      // Clear the pairing-token surface — the approved entry is now
+      // captured in `paired`. The "Pair another" button (rendered
+      // below when `paired.length > 0`) re-arms the flow.
+      setMessage(undefined);
+      setEntryId(undefined);
+      setObservedActorLabel(undefined);
+      setObservedChatLabel(undefined);
+      setResolution(undefined);
+      setPairingAnother(false);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    } finally {
+      setApproving(false);
+    }
+  };
+
+  const pairAnother = (): void => {
+    // Re-arm the active-flow surface (Generate-code button, scope
+    // picker) so the operator can issue another pairing token.
+    // Keeps the `paired` list intact above the surface so the
+    // previously-approved entities stay visible.
+    setMessage(undefined);
+    setEntryId(undefined);
+    setResolution(undefined);
+    setObservedActorLabel(undefined);
+    setObservedChatLabel(undefined);
+    setError(undefined);
+    setPairingAnother(true);
+  };
 
   const generate = async (): Promise<void> => {
     if (!props.desktopApi?.generateMessagingPairingToken || busy) return;
@@ -4031,12 +4457,33 @@ function PairingBlock(props: {
     setError(undefined);
   };
 
+  // Active-flow gate: when the operator hasn't approved anything
+  // yet (or has clicked "+ Pair another"), render the full
+  // token-generate / approve UI. After the first approval we
+  // collapse to the compact "paired list + Pair another" layout —
+  // surfacing exactly what the operator has authorized rather than
+  // leaving the stale pairing code on screen.
+  //
+  // Note: an in-flight `message` or `resolution === "observed"`
+  // also force active mode — this handles the rare case where a
+  // pairing-changed event arrives *after* approval has already
+  // cleared the surface (we want to react, not get stuck).
+  const isActiveFlow =
+    paired.length === 0
+    || pairingAnother
+    || message !== undefined
+    || resolution === "observed";
+
   return (
     <div className="onboarding-wizard__pairing">
       <div className="onboarding-wizard__pairing-head">
         <span className="onboarding-wizard__field-label">{props.title}</span>
         <span className="onboarding-wizard__field-status">
-          {resolution === "approved" ? (
+          {paired.length > 0 && !isActiveFlow ? (
+            <span className="onboarding-wizard__field-pill is-ok">
+              ✓ paired ({paired.length})
+            </span>
+          ) : resolution === "approved" ? (
             <span className="onboarding-wizard__field-pill is-ok">✓ paired</span>
           ) : resolution === "observed" ? (
             <span className="onboarding-wizard__field-pill is-ok">✓ message seen</span>
@@ -4047,44 +4494,113 @@ function PairingBlock(props: {
           ) : null}
         </span>
       </div>
-      {props.options.length > 1 ? (
-        <div className="onboarding-wizard__segmented" role="radiogroup" aria-label="Pairing target">
-          {props.options.map((option) => (
-            <button
-              key={option.scope}
-              type="button"
-              role="radio"
-              aria-checked={scope === option.scope}
-              className={`onboarding-wizard__segmented-btn${scope === option.scope ? " is-active" : ""}`}
-              onClick={() => switchScope(option.scope)}
+      {paired.length > 0 ? (
+        <ul className="onboarding-wizard__paired-list">
+          {paired.map((entry) => (
+            <li
+              key={entry.entryId}
+              className="onboarding-wizard__paired-row"
             >
-              {option.label}
-            </button>
+              <span className="onboarding-wizard__paired-scope">
+                {labelForPairingScope(props.platform, entry.scope)}
+              </span>
+              <span className="onboarding-wizard__paired-actor">
+                {entry.chat && entry.chat !== entry.actor
+                  ? entry.chat
+                  : entry.actor ?? "(no display name reported)"}
+              </span>
+            </li>
           ))}
-        </div>
+        </ul>
       ) : null}
-      {activeOption?.help ? (
-        <p className="onboarding-wizard__field-sub">{activeOption.help}</p>
-      ) : null}
-      {message ? (
-        <div className="onboarding-wizard__pairing-token">
-          <code>{message}</code>
-          <button
-            type="button"
-            className="onboarding-wizard__btn onboarding-wizard__btn--ghost"
-            onClick={() => void copy()}
-          >
-            Copy
-          </button>
-        </div>
+      {isActiveFlow ? (
+        <>
+          {props.options.length > 1 ? (
+            <div className="onboarding-wizard__segmented" role="radiogroup" aria-label="Pairing target">
+              {props.options.map((option) => (
+                <button
+                  key={option.scope}
+                  type="button"
+                  role="radio"
+                  aria-checked={scope === option.scope}
+                  className={`onboarding-wizard__segmented-btn${scope === option.scope ? " is-active" : ""}`}
+                  onClick={() => switchScope(option.scope)}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+          ) : null}
+          {activeOption?.help ? (
+            // `div`, not `<p>`: help content for some scopes contains
+            // its own `<p>` / `<ul>` blocks (e.g. Telegram bucket
+            // scope surfaces a bot-privacy gotcha with bullets). Nested
+            // `<p>` would be invalid HTML and React would silently
+            // hoist children out, breaking the styling.
+            <div className="onboarding-wizard__field-sub">{activeOption.help}</div>
+          ) : null}
+          {message && resolution !== "observed" ? (
+            // Pairing tokens are one-time-use; once the bot has
+            // reported the message landed we hide the code (the
+            // operator already sent it, displaying it longer just
+            // invites a confusing second paste). Below this block
+            // the Approve banner takes over.
+            <div className="onboarding-wizard__pairing-token">
+              <code>{message}</code>
+              <button
+                type="button"
+                className="onboarding-wizard__btn onboarding-wizard__btn--ghost"
+                onClick={() => void copy()}
+              >
+                Copy
+              </button>
+            </div>
+          ) : !message ? (
+            <button
+              type="button"
+              className="onboarding-wizard__btn onboarding-wizard__btn--ghost"
+              disabled={busy || !props.desktopApi?.generateMessagingPairingToken}
+              onClick={() => void generate()}
+            >
+              {busy ? "Generating…" : "Generate pairing code"}
+            </button>
+          ) : null}
+          {resolution === "observed" ? (
+            // The bot has reported the pairing message — surface an
+            // inline Approve so the operator can finish the pairing
+            // without navigating to Settings → Messaging Activity.
+            <div className="onboarding-wizard__pairing-approve">
+              <div className="onboarding-wizard__pairing-approve-text">
+                <span>
+                  Message received from{" "}
+                  <strong>{observedActorLabel ?? "this contact"}</strong>
+                  {observedChatLabel && observedChatLabel !== observedActorLabel ? (
+                    <>
+                      {" in "}
+                      <strong>{observedChatLabel}</strong>
+                    </>
+                  ) : null}
+                  . Approve to finish pairing.
+                </span>
+              </div>
+              <button
+                type="button"
+                className="onboarding-wizard__btn onboarding-wizard__btn--primary"
+                disabled={approving || !props.desktopApi?.approveMessagingPairing}
+                onClick={() => void approve()}
+              >
+                {approving ? "Approving…" : "Approve"}
+              </button>
+            </div>
+          ) : null}
+        </>
       ) : (
         <button
           type="button"
-          className="onboarding-wizard__btn onboarding-wizard__btn--ghost"
-          disabled={busy || !props.desktopApi?.generateMessagingPairingToken}
-          onClick={() => void generate()}
+          className="onboarding-wizard__btn onboarding-wizard__btn--link"
+          onClick={pairAnother}
         >
-          {busy ? "Generating…" : "Generate pairing code"}
+          + Pair another
         </button>
       )}
       {error ? (
@@ -4092,6 +4608,36 @@ function PairingBlock(props: {
       ) : null}
     </div>
   );
+}
+
+/**
+ * Human label for a pairing scope, scoped by the onboarding-known
+ * platforms so we say "DM" / "Supergroup" for Telegram, "DM" /
+ * "Guild" for Discord, etc. Falls back to a generic "Group" /
+ * "Conversation" label for any platform the wizard doesn't render
+ * a setup step for (currently none — the union is wider than the
+ * wizard's surface area to leave room for future providers).
+ */
+function labelForPairingScope(
+  platform: MessagingChannelKind,
+  scope: MessagingPairingScope,
+): string {
+  if (scope === "user_dm") return "DM";
+  switch (platform) {
+    case "telegram":
+      return "Supergroup";
+    case "discord":
+      return "Guild";
+    case "slack":
+      return "Workspace";
+    case "mattermost":
+      return "Channel";
+    case "feishu":
+    case "line":
+      return "Group";
+    default:
+      return "Conversation";
+  }
 }
 
 /* ----------------------------------------------------------------

--- a/apps/desktop/src/renderer/src/features/onboarding/__tests__/wizard-provider-setup.test.tsx
+++ b/apps/desktop/src/renderer/src/features/onboarding/__tests__/wizard-provider-setup.test.tsx
@@ -1,0 +1,179 @@
+import "@testing-library/jest-dom/vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { DesktopSettingsSecretName } from "@pwragent/shared";
+import { SecretFieldRow } from "../OnboardingWizard";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+/**
+ * The fix this test locks in: messaging-runtime secrets entered in
+ * the wizard's provider-setup step must be persisted *live* (via
+ * `replaceSecret`) so the desktop messaging runtime can evaluate
+ * `hasRunnableAdapters === true` and actually start while the
+ * operator is still on the same step.
+ *
+ * Before the fix, only the renderer-side buffer was updated, so the
+ * runtime stayed in "no_runnable_adapters" — the operator saw the
+ * provider listed as Enabled in Settings but no titlebar icon
+ * appeared, and pairing codes were silently dropped because no
+ * adapter was actually listening.
+ *
+ * The buffer is still maintained alongside — it's the source of
+ * truth for the graduation step that copies secrets onto the
+ * target profile after the wizard finishes.
+ */
+describe("SecretFieldRow live-write contract", () => {
+  it("messaging-runtime secrets: writes via replaceSecret AND buffers", async () => {
+    const onBuffer = vi.fn();
+    const replaceSecret = vi.fn(
+      async (_secret: DesktopSettingsSecretName, _value: string) => true,
+    );
+    const clearSecret = vi.fn(
+      async (_secret: DesktopSettingsSecretName) => true,
+    );
+
+    render(
+      <SecretFieldRow
+        field={{
+          kind: "secret",
+          name: "telegramBotToken",
+          label: "Bot token",
+          placeholder: "0000000000:AAEx",
+        }}
+        bufferedValue=""
+        onBuffer={onBuffer}
+        replaceSecret={replaceSecret}
+        clearSecret={clearSecret}
+      />,
+    );
+
+    const tokenInput = screen.getByPlaceholderText(/0000000000:AAEx/);
+    fireEvent.change(tokenInput, {
+      target: { value: "0000000000:AAEx-fake-telegram-token" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Use this/i }));
+
+    await waitFor(() => {
+      expect(replaceSecret).toHaveBeenCalledWith(
+        "telegramBotToken",
+        "0000000000:AAEx-fake-telegram-token",
+      );
+    });
+    expect(onBuffer).toHaveBeenCalledWith(
+      "0000000000:AAEx-fake-telegram-token",
+    );
+  });
+
+  it("non-runtime secrets (xAI key): buffers but does NOT call replaceSecret", async () => {
+    const onBuffer = vi.fn();
+    const replaceSecret = vi.fn(
+      async (_secret: DesktopSettingsSecretName, _value: string) => true,
+    );
+    const clearSecret = vi.fn(
+      async (_secret: DesktopSettingsSecretName) => true,
+    );
+
+    render(
+      <SecretFieldRow
+        field={{
+          kind: "secret",
+          name: "grokApiKey",
+          label: "xAI API key",
+          placeholder: "xai-…",
+        }}
+        bufferedValue=""
+        onBuffer={onBuffer}
+        replaceSecret={replaceSecret}
+        clearSecret={clearSecret}
+      />,
+    );
+
+    const xaiInput = screen.getByPlaceholderText(/xai-/);
+    fireEvent.change(xaiInput, { target: { value: "xai-test-key-1234" } });
+    fireEvent.click(screen.getByRole("button", { name: /Use this/i }));
+
+    expect(onBuffer).toHaveBeenCalledWith("xai-test-key-1234");
+    // Two microtask flushes to let any async save resolve.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(replaceSecret).not.toHaveBeenCalled();
+  });
+
+  it("messaging secret Clear: calls clearSecret on the runtime AND buffers empty", async () => {
+    const onBuffer = vi.fn();
+    const replaceSecret = vi.fn(
+      async (_secret: DesktopSettingsSecretName, _value: string) => true,
+    );
+    const clearSecret = vi.fn(
+      async (_secret: DesktopSettingsSecretName) => true,
+    );
+
+    render(
+      <SecretFieldRow
+        field={{
+          kind: "secret",
+          name: "telegramBotToken",
+          label: "Bot token",
+          placeholder: "0000000000:AAEx",
+        }}
+        // Pre-populated buffer simulates a value already typed in.
+        bufferedValue="0000000000:AAEx-existing"
+        onBuffer={onBuffer}
+        replaceSecret={replaceSecret}
+        clearSecret={clearSecret}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /^Clear$/i }));
+
+    expect(onBuffer).toHaveBeenCalledWith("");
+    // The runtime clear is skipped when nothing is configured server-side
+    // yet (`configured === false`), to avoid an unnecessary IPC round-trip
+    // on a brand-new field that was only buffered. This keeps the test
+    // surface honest: a Clear with neither a configured secret nor a
+    // buffered value is a no-op, but the buffered-only path still resets
+    // the buffer (asserted above).
+    await Promise.resolve();
+    expect(clearSecret).not.toHaveBeenCalled();
+  });
+
+  it("non-runtime secret Clear: buffers empty, never touches clearSecret", async () => {
+    const onBuffer = vi.fn();
+    const replaceSecret = vi.fn(
+      async (_secret: DesktopSettingsSecretName, _value: string) => true,
+    );
+    const clearSecret = vi.fn(
+      async (_secret: DesktopSettingsSecretName) => true,
+    );
+
+    render(
+      <SecretFieldRow
+        field={{
+          kind: "secret",
+          name: "grokApiKey",
+          label: "xAI API key",
+          placeholder: "xai-…",
+        }}
+        bufferedValue="xai-existing"
+        onBuffer={onBuffer}
+        replaceSecret={replaceSecret}
+        clearSecret={clearSecret}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /^Clear$/i }));
+    expect(onBuffer).toHaveBeenCalledWith("");
+    await Promise.resolve();
+    expect(clearSecret).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -505,6 +505,14 @@ export type DesktopApi = {
   ) => () => void;
   /** Spawns or focuses the dedicated Messaging Activity window. */
   openMessagingActivityWindow?: () => Promise<void>;
+  /** Shut down the messaging runtime in *this* process and release
+   *  its lease. The wizard calls this right before spawning the
+   *  operator's chosen profile in a child Electron, so the bootstrap
+   *  process releases adapter resources (Telegram long-poll, Discord
+   *  gateway, etc.) before the child starts up — otherwise the two
+   *  processes race and the upstream returns 409 / "another shard
+   *  connected" / similar exclusivity errors. Idempotent. */
+  shutdownMessagingRuntime?: () => Promise<void>;
   onWindowFocus?: (callback: () => void) => () => void;
   /**
    * Main → renderer push: fires when the user invokes the app's

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -10897,6 +10897,27 @@ textarea,
   color: var(--accent);
   margin-bottom: 4px;
 }
+.onboarding-wizard__safety-multi-notice {
+  width: 100%;
+  padding: 12px 14px;
+  background: var(--accent-soft);
+  border: 1px solid var(--accent-border);
+  border-radius: 8px;
+  font: 400 13px/1.55 var(--font-sans, sans-serif);
+  color: var(--text-primary);
+}
+.onboarding-wizard__safety-multi-notice strong {
+  color: var(--text-primary);
+}
+.onboarding-wizard__safety-multi-notice code {
+  font: 600 12px/1 var(--font-mono);
+  color: var(--accent-bright);
+  background: var(--bg-input);
+  border: 1px solid var(--border-subtle);
+  border-radius: 4px;
+  padding: 2px 6px;
+  margin: 0 1px;
+}
 .onboarding-wizard__safety-list {
   list-style: none;
   margin: 0;
@@ -11334,6 +11355,24 @@ textarea,
   flex-direction: column;
   gap: 14px;
 }
+.onboarding-wizard__provider-setup-eyebrow {
+  display: inline-block;
+  font: 600 11px/1 var(--font-sans, sans-serif);
+  color: var(--accent);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 6px;
+}
+.onboarding-wizard__provider-setup-eyebrow code {
+  font: 700 11px/1 var(--font-mono);
+  color: var(--accent-bright);
+  background: var(--bg-input);
+  border: 1px solid var(--border-subtle);
+  border-radius: 4px;
+  padding: 2px 6px;
+  margin-left: 4px;
+  letter-spacing: 0;
+}
 .onboarding-wizard__provider-setup-icon {
   display: inline-flex;
   align-items: center;
@@ -11420,6 +11459,54 @@ textarea,
 .onboarding-wizard__input:focus {
   outline: 2px solid var(--focus-ring);
   outline-offset: 1px;
+}
+
+.onboarding-wizard__provider-identity {
+  margin-top: 10px;
+  padding: 8px 12px;
+  background: var(--bg-panel-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  font: 500 12px/1.4 var(--font-sans, sans-serif);
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.onboarding-wizard__provider-identity-text {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.onboarding-wizard__provider-identity-pill {
+  font: 600 10px/1 var(--font-sans, sans-serif);
+  color: var(--text-muted);
+  background: var(--bg-input);
+  border: 1px solid var(--border-subtle);
+  border-radius: 4px;
+  padding: 4px 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.onboarding-wizard__provider-identity-pill.is-ok {
+  color: var(--success-text);
+  background: var(--success-soft);
+  border-color: var(--success-border);
+}
+.onboarding-wizard__provider-identity-pill.is-err {
+  color: var(--danger-text);
+  background: var(--danger-surface, var(--bg-input));
+  border-color: var(--border-strong);
+}
+.onboarding-wizard__provider-identity-account {
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-weight: 600;
+}
+.onboarding-wizard__provider-identity-detail {
+  color: var(--text-muted);
 }
 
 .onboarding-wizard__segmented {
@@ -11521,6 +11608,96 @@ textarea,
   color: var(--accent-bright);
   letter-spacing: 0.08em;
   word-break: break-all;
+}
+.onboarding-wizard__pairing-warning {
+  margin: 8px 0 4px 0;
+  padding: 8px 10px;
+  background: var(--warning-surface, var(--bg-input));
+  border: 1px solid var(--border-strong);
+  border-radius: 6px;
+  color: var(--text-primary);
+  font: 400 12px/1.5 var(--font-sans, sans-serif);
+}
+.onboarding-wizard__pairing-warning strong {
+  color: var(--text-primary);
+}
+.onboarding-wizard__pairing-warning em {
+  color: var(--status-warning);
+  font-style: normal;
+  font-weight: 600;
+}
+.onboarding-wizard__pairing-warning-list {
+  margin: 0 0 4px 0;
+  padding-left: 20px;
+  font: 400 12px/1.55 var(--font-sans, sans-serif);
+  color: var(--text-secondary);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.onboarding-wizard__pairing-warning-list strong {
+  color: var(--text-primary);
+}
+.onboarding-wizard__pairing-warning-list code {
+  font: 600 11px/1.3 var(--font-mono);
+  color: var(--accent-bright);
+  background: var(--bg-input);
+  border: 1px solid var(--border-subtle);
+  border-radius: 4px;
+  padding: 1px 5px;
+}
+.onboarding-wizard__pairing-approve {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 10px;
+  padding: 10px 12px;
+  background: var(--success-soft);
+  border: 1px solid var(--success-border);
+  border-radius: 8px;
+}
+.onboarding-wizard__pairing-approve-text {
+  flex: 1;
+  font: 500 13px/1.4 var(--font-sans, sans-serif);
+  color: var(--text-primary);
+}
+.onboarding-wizard__pairing-approve-text strong {
+  font-weight: 700;
+  color: var(--text-primary);
+}
+.onboarding-wizard__paired-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.onboarding-wizard__paired-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  background: var(--bg-input);
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+}
+.onboarding-wizard__paired-scope {
+  font: 600 10px/1 var(--font-sans, sans-serif);
+  color: var(--text-muted);
+  background: var(--bg-panel-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: 4px;
+  padding: 4px 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  flex-shrink: 0;
+}
+.onboarding-wizard__paired-actor {
+  flex: 1;
+  font: 600 13px/1.3 var(--font-sans, sans-serif);
+  color: var(--text-primary);
+  word-break: break-word;
 }
 
 /* ============================================================

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -87,6 +87,19 @@ export const MESSAGING_PAIRING_CHANGED_EVENT_CHANNEL =
 export const MESSAGING_OPEN_ACTIVITY_WINDOW_CHANNEL =
   "messaging:open-activity-window";
 /**
+ * Stop the messaging runtime in *this* process. Used by the wizard's
+ * graduation path: the bootstrap process is about to spawn a child
+ * Electron pointed at the operator's chosen profile, and both
+ * processes would otherwise compete for the same long-poll (Telegram
+ * `getUpdates` returns 409 when two processes ask at once). Calling
+ * this before the spawn lets the bootstrap release the polling slot
+ * cleanly; the child then comes up without colliding.
+ *
+ * Idempotent — calling it when no runtime is running is a no-op.
+ */
+export const MESSAGING_SHUTDOWN_RUNTIME_CHANNEL =
+  "messaging:shutdown-runtime";
+/**
  * Drives the per-credential "Test" button on Settings → Messaging
  * and Settings → Models. Request payload: `{ kind: "telegram" |
  * "discord" | "grok" | "codex" }`. Response: `SettingsCredentialTestResult`.

--- a/packages/messaging/interface/src/__tests__/messaging-interface.test.ts
+++ b/packages/messaging/interface/src/__tests__/messaging-interface.test.ts
@@ -6,6 +6,7 @@ import type {
 import {
   MESSAGING_SURFACE_INTENT_KINDS,
   extractMessagingPairingToken,
+  looksLikePairingAttempt,
 } from "../index";
 
 type FakeProvider = {
@@ -84,6 +85,45 @@ describe("messaging interface package", () => {
     expect(extractMessagingPairingToken(`pwragent_pair ${token}`)).toBe(token);
     expect(extractMessagingPairingToken(`/pair ${token}`)).toBe(token);
     expect(extractMessagingPairingToken(`/pwragent_pair ${token}`)).toBe(token);
+  });
+
+  it("treats Unicode whitespace between command and token as a separator", () => {
+    // U+00A0 NO-BREAK SPACE — Telegram iOS / some clipboard pipelines
+    // substitute this for a plain space when pasting. Before the
+    // tokenizer learned to recognize Unicode whitespace, a paste like
+    // this would tokenize as one big "pair <token>" blob and
+    // `extractMessagingPairingToken` would return undefined — silently
+    // dropping the operator's pairing attempt.
+    const token = "123456789ABCDEFGHJKLMNPQRSTUVWXY";
+    expect(extractMessagingPairingToken(`pair ${token}`)).toBe(token);
+    expect(extractMessagingPairingToken(`pair ${token}`)).toBe(token);
+    expect(extractMessagingPairingToken(`pair ${token}`)).toBe(token);
+    expect(extractMessagingPairingToken(`pair　${token}`)).toBe(token);
+  });
+
+  it("looksLikePairingAttempt routes typo'd / malformed tokens through", () => {
+    // Source of truth: the runtime's `handlePairingInbound` runs the
+    // strict token validation, not the adapter. Adapters use this
+    // looser predicate so a `pair <garbage>` typed in a fresh group
+    // routes to the runtime (which replies with "That PwrAgent
+    // pairing token is invalid or expired.") instead of being silently
+    // dropped at the conversation-authorization check.
+    expect(looksLikePairingAttempt("pair garbage")).toBe(true);
+    expect(looksLikePairingAttempt("pair x")).toBe(true);
+    expect(looksLikePairingAttempt("/pair anything")).toBe(true);
+    expect(looksLikePairingAttempt("@PwrAgentBot pair anything")).toBe(true);
+    expect(looksLikePairingAttempt("pwragent_pair anything")).toBe(true);
+    // Negative cases: no pairing keyword, or keyword with no follow-up.
+    expect(looksLikePairingAttempt("hello world")).toBe(false);
+    expect(looksLikePairingAttempt("pair")).toBe(false);
+    expect(looksLikePairingAttempt("")).toBe(false);
+    // Mid-sentence "pair" followed by another word IS a false-positive
+    // by design — we'd rather route an over-broad match to the runtime
+    // (which replies with a friendly "invalid or expired" if it's not
+    // a real pairing) than silently drop a real pairing attempt at the
+    // adapter. Verifying the over-broad behavior so it isn't tightened
+    // later without a conscious trade-off.
+    expect(looksLikePairingAttempt("the word pair appears here")).toBe(true);
   });
 
   it("bounds pairing scans over untrusted message text", () => {

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -108,6 +108,45 @@ export function extractMessagingPairingToken(text: string): string | undefined {
   return undefined;
 }
 
+/**
+ * Looser variant of `extractMessagingPairingToken` — returns true
+ * when the text *looks like* a pairing attempt regardless of
+ * whether the token itself parses as a valid 32-char base58 string.
+ *
+ * Provider adapters use this to decide whether to bypass the
+ * "unauthorized conversation" drop: if the operator typed `pair
+ * <something>` in a fresh group they're trying to authorize, we
+ * want the runtime to see the message and reply with a useful
+ * error ("That PwrAgent pairing token is invalid or expired.")
+ * rather than silently dropping the message at the adapter layer.
+ * The runtime's `handlePairingInbound` performs the strict token
+ * validation downstream — adapters only need the heuristic to
+ * route the candidate through.
+ *
+ * Matches when the first two whitespace-separated tokens are
+ * `(/|@bot)?pair` + ANYTHING. Bot-mention prefixes are skipped, so
+ * `@pwragent_bot pair garbage` also routes through.
+ */
+export function looksLikePairingAttempt(text: string): boolean {
+  let previousToken: string | undefined;
+  let skippedMention = false;
+  for (const token of pairingScanTokens(text)) {
+    if (!skippedMention && token.startsWith("@")) {
+      // Bot mention — skip without recording as previousToken so
+      // the `pair` keyword right after the @bot still triggers.
+      skippedMention = true;
+      continue;
+    }
+    if (previousToken && isMessagingPairingCommand(previousToken)) {
+      // Any non-empty follow-up is enough — the runtime will
+      // reject invalid tokens with a useful error message.
+      return token.length > 0;
+    }
+    previousToken = token;
+  }
+  return false;
+}
+
 function* pairingScanTokens(text: string): Generator<string> {
   const scanLength = Math.min(text.length, MESSAGING_PAIRING_SCAN_MAX_CHARS);
   let tokenStart: number | undefined;
@@ -137,12 +176,36 @@ export function isMessagingPairingCommand(command: string | undefined): boolean 
 }
 
 function isAsciiWhitespace(charCode: number): boolean {
-  return charCode === 0x20
-    || charCode === 0x09
-    || charCode === 0x0a
-    || charCode === 0x0b
-    || charCode === 0x0c
-    || charCode === 0x0d;
+  // Includes the common ASCII whitespace plus Unicode whitespace
+  // characters that mobile keyboards and copy-paste pipelines often
+  // substitute for a plain space:
+  //   U+00A0 NO-BREAK SPACE         — Telegram iOS sometimes pastes
+  //                                   this between words.
+  //   U+2007 FIGURE SPACE / U+2008  — narrow / punctuation space.
+  //   U+2009 THIN SPACE
+  //   U+200A HAIR SPACE
+  //   U+202F NARROW NO-BREAK SPACE  — common in French autocorrect.
+  //   U+205F MEDIUM MATHEMATICAL SP.
+  //   U+3000 IDEOGRAPHIC SPACE      — CJK keyboards.
+  // Without these, a `pair<NBSP><token>` paste tokenizes as one
+  // long token and `extractMessagingPairingToken` fails to find
+  // the command/token pair — silently dropping pairing attempts.
+  if (charCode <= 0x20) {
+    return charCode === 0x20
+      || charCode === 0x09
+      || charCode === 0x0a
+      || charCode === 0x0b
+      || charCode === 0x0c
+      || charCode === 0x0d;
+  }
+  return charCode === 0x00a0
+    || charCode === 0x2007
+    || charCode === 0x2008
+    || charCode === 0x2009
+    || charCode === 0x200a
+    || charCode === 0x202f
+    || charCode === 0x205f
+    || charCode === 0x3000;
 }
 
 export type MessagingRateLimitInfo = {

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -23,7 +23,7 @@ import type {
   MessagingSurfaceIntent,
 } from "@pwragent/messaging-interface";
 import {
-  extractMessagingPairingToken,
+  looksLikePairingAttempt,
   layoutMessagingActionRows,
   MESSAGING_CALLBACK_HANDLE_TTL_MS,
 } from "@pwragent/messaging-interface";
@@ -1142,8 +1142,18 @@ export class TelegramAdapter implements TelegramProviderAdapter {
     // Username matching is case-insensitive — Telegram usernames are
     // case-insensitive.
     const mentionCandidate = message.text ?? message.caption;
+    // `isPairingMessage` uses the looser `looksLikePairingAttempt`
+    // (not `extractMessagingPairingToken`) so a typo'd or
+    // freshly-pasted-but-mangled pair-token attempt still routes
+    // through to the runtime. The runtime's `handlePairingInbound`
+    // does the strict validation downstream and either consumes
+    // the token (valid) or replies with "That PwrAgent pairing
+    // token is invalid or expired." (invalid). Silently dropping
+    // here would leave the operator staring at the wizard with no
+    // feedback — the worst possible outcome for someone trying to
+    // authorize a fresh group conversation.
     const isPairingMessage = mentionCandidate
-      ? Boolean(extractMessagingPairingToken(mentionCandidate))
+      ? looksLikePairingAttempt(mentionCandidate)
       : false;
     const mentionRemainder = mentionCandidate
       ? stripTelegramBotMention(mentionCandidate, this.botUsername)

--- a/packages/shared/src/__tests__/isMessagingRuntimeSecret.test.ts
+++ b/packages/shared/src/__tests__/isMessagingRuntimeSecret.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  isMessagingRuntimeSecret,
+  type DesktopSettingsSecretName,
+} from "../contracts/settings";
+
+describe("isMessagingRuntimeSecret", () => {
+  // Enumerate every secret name. This list mirrors the
+  // `DesktopSettingsSecretName` union. If a new secret is added to
+  // the union, TS will narrow it differently and one of these
+  // assertions will fail — forcing the author to make a conscious
+  // decision about whether the new name should re-evaluate the
+  // messaging runtime.
+  const cases: Array<{
+    name: DesktopSettingsSecretName;
+    expected: boolean;
+  }> = [
+    { name: "telegramBotToken", expected: true },
+    { name: "discordBotToken", expected: true },
+    { name: "mattermostBotToken", expected: true },
+    { name: "mattermostHmacSecret", expected: true },
+    { name: "slackBotToken", expected: true },
+    { name: "slackAppToken", expected: true },
+    { name: "slackSigningSecret", expected: true },
+    { name: "feishuAppId", expected: true },
+    { name: "feishuAppSecret", expected: true },
+    { name: "feishuEncryptKey", expected: true },
+    { name: "feishuVerificationToken", expected: true },
+    { name: "lineChannelAccessToken", expected: true },
+    { name: "lineChannelSecret", expected: true },
+    { name: "grokApiKey", expected: false },
+  ];
+
+  for (const { name, expected } of cases) {
+    it(`${name} → ${expected ? "messaging" : "non-messaging"}`, () => {
+      expect(isMessagingRuntimeSecret(name)).toBe(expected);
+    });
+  }
+});

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -148,6 +148,43 @@ export type DesktopSettingsSecretName =
   | "lineChannelAccessToken"
   | "lineChannelSecret";
 
+/**
+ * Predicate: does writing or clearing this secret affect the
+ * messaging runtime? The runtime's "runnable adapters" check
+ * combines `messaging.<provider>.enabled = true` with a present
+ * bot token / per-provider auth secret, so changes to any of these
+ * names need to re-evaluate the runtime (start, stop, or reload).
+ *
+ * Kept here in shared (not in main-process code) so the renderer's
+ * onboarding wizard can reuse the same predicate when deciding
+ * which secret fields must be persisted *live* during the wizard
+ * vs. buffered for graduation-time write. The main process has its
+ * own `messagingSecretTouchesRuntime()` for the IPC layer; they
+ * must agree, and a unit test under shared keeps both honest.
+ */
+export function isMessagingRuntimeSecret(
+  name: DesktopSettingsSecretName,
+): boolean {
+  switch (name) {
+    case "telegramBotToken":
+    case "discordBotToken":
+    case "mattermostBotToken":
+    case "mattermostHmacSecret":
+    case "slackBotToken":
+    case "slackAppToken":
+    case "slackSigningSecret":
+    case "feishuAppId":
+    case "feishuAppSecret":
+    case "feishuEncryptKey":
+    case "feishuVerificationToken":
+    case "lineChannelAccessToken":
+    case "lineChannelSecret":
+      return true;
+    case "grokApiKey":
+      return false;
+  }
+}
+
 export type DesktopSettingsSecretState = {
   configured: boolean;
   source: DesktopSettingsSecretSource;


### PR DESCRIPTION
## Summary

The onboarding wizard's messaging step looked complete but providers never actually started — the runtime checked `hasRunnableAdapters` against a keychain that didn't yet have the bot token (buffered in renderer state per the deferred-secret design), found nothing, and stayed off. Pairing codes were silently dropped, no titlebar icon appeared, and the operator had to toggle messaging off/on in Settings to recover. Plus several adjacent gotchas that compounded the broken UX.

Six interlocking fixes, all rooted in live-testing failure modes:

1. **Wizard-enabled providers actually start.** `SecretFieldRow` live-writes messaging-runtime secrets via `replaceSecret` so the runtime can evaluate `hasRunnableAdapters === true` and start mid-wizard. The buffer is still maintained for graduation. The renderer and main process now share a single `isMessagingRuntimeSecret` predicate in `@pwragent/shared` so they can't drift.
2. **Bot identity surfaced inline.** New `ProviderIdentityProbe` auto-runs `testSettingsCredentials` once the primary secret lands and shows "✓ Connected · @pwragent_bot" (or a friendly error). Mirrors Settings → Messaging's test affordance, no manual click needed.
3. **Inline pairing approval** + paired-entities summary + "Pair another" re-arm. The wizard's `PairingBlock` previously had no approval UI — operators had to navigate to Settings → Messaging Activity. Now: pair message lands → Approve button appears → click → compact list of paired entities ("DM · Harold Hunt", "Supergroup · pwragent-test"). Stale pairing codes hide as soon as the bot reports the message landed (they're one-time-use).
4. **Bootstrap runtime released before child spawn.** New `MESSAGING_SHUTDOWN_RUNTIME_CHANNEL` IPC. The wizard calls it before `openPwrAgentProfile` so the bootstrap releases Telegram's long-poll slot before the child process's adapter tries to claim it — eliminates the 409 Conflict that left the new window with a visually-online runtime but broken inbound delivery.
5. **Multi-profile messaging clarity.** In Multiple / Isolated modes, the safety step renders a notice naming the target profile (always `codexProfileNames[0]`) and the others that start without messaging, with a pointer to Settings → Messaging post-launch. Provider-setup step gets a "FOR PROFILE `personal`" eyebrow so the operator knows which profile their token lands in.
6. **Telegram pairing robustness.** New `looksLikePairingAttempt` predicate routes typo'd / mangled tokens through to the runtime (which replies with "invalid or expired") instead of silently dropping at the adapter. Tokenizer now recognizes 8 Unicode whitespace characters (NBSP, narrow no-break, ideographic, etc.) so iOS Telegram's clipboard-paste substitutions don't break detection. Plus a yellow-bordered warning in the supergroup-pairing help text explaining BotFather's privacy-mode-on default and the three ways to work around it (@mention, admin, or `/setprivacy` off).

## Files

- `packages/shared/src/contracts/settings.ts` — new `isMessagingRuntimeSecret` predicate (exhaustive over `DesktopSettingsSecretName`)
- `packages/messaging/interface/src/index.ts` — new `looksLikePairingAttempt`, broadened Unicode whitespace recognition
- `packages/messaging/providers/telegram/src/telegram-adapter.ts` — switch pairing-bypass from strict `extractMessagingPairingToken` to loose `looksLikePairingAttempt`
- `apps/desktop/src/main/ipc/messaging-status.ts` — new `MESSAGING_SHUTDOWN_RUNTIME_CHANNEL` handler
- `apps/desktop/src/main/ipc/settings.ts` — `messagingSecretTouchesRuntime` delegates to the shared predicate
- `apps/desktop/src/shared/ipc.ts` + `apps/desktop/src/preload/index.ts` + `apps/desktop/src/renderer/src/lib/desktop-api.ts` — new `shutdownMessagingRuntime` IPC plumbing
- `apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx` — live-write `SecretFieldRow`, `ProviderIdentityProbe`, redesigned `PairingBlock` (inline Approve + paired list + Pair another + privacy warning), multi-profile notice + target-profile eyebrow, runtime-shutdown call site
- `apps/desktop/src/renderer/src/styles/app.css` — styling for the new surfaces
- New tests:
  - `packages/shared/src/__tests__/isMessagingRuntimeSecret.test.ts` (14 cases, one per secret name)
  - `apps/desktop/src/renderer/src/features/onboarding/__tests__/wizard-provider-setup.test.tsx` (4 cases — messaging live + buffer, xAI buffer-only, clear paths)
  - `packages/messaging/interface/src/__tests__/messaging-interface.test.ts` (+ 2 cases — Unicode whitespace + `looksLikePairingAttempt`)
  - `apps/desktop/src/main/__tests__/messaging-status-ipc.test.ts` (+ 2 cases — shutdown happy + error-swallow)

## Trade-offs

- **`looksLikePairingAttempt` over-broadness.** A message like `pair john with mary` from an authorized actor in an unauthorized group will route to the runtime and earn a "That PwrAgent pairing token is invalid or expired." reply. Better than silent drops — the operator always gets feedback. Locked in by a test so it isn't accidentally tightened later. The actor-level auth check still gates random senders.
- **Wizard buffer retained for messaging secrets too.** Live-write happens *in addition to* the buffer (not instead of), so graduation still copies the token onto the target profile in Multiple / Isolated modes. Cost: the bootstrap profile's `.bootstrap/state.db` briefly holds messaging secrets, but it's torn down on graduation.
- **Multi-profile messaging is single-target by design.** Only the first named profile gets the graduated config; others get the secrets buffered but `enabled: false`. Telegram's one-bot-per-process exclusivity makes anything else error-prone. Notice + post-launch Settings path is documented in the safety step.

## Test plan

- [ ] Bootstrap mode + Shared: walk wizard, paste Telegram bot token, see "✓ Connected · @yourbot" appear inline, generate pair code, send DM `pair <token>`, see "Approve" banner with actor name, click Approve, see "DM · YourName" in compact paired list
- [ ] Click "+ Pair another", switch scope to Supergroup, see warning about bot privacy mode, generate new token, send `pair <token>` in supergroup, approve, see both DM + Supergroup rows in paired list
- [ ] Bootstrap mode + Multiple: name two profiles, configure Telegram → see "FOR PROFILE `personal`" eyebrow + "Heads up: messaging set up for `personal`, other profiles (`work`) start without messaging" notice on safety step
- [ ] At wizard Finish: new spawned profile's window comes up with Telegram icon in titlebar (no 409 collision), Messaging Activity opens without blank-window race
- [ ] Open profile `work` from menu post-launch → Settings → Messaging → confirm Telegram defaults to disabled, can be enabled separately
- [ ] Replay mode (Help → Replay Onboarding) in existing profile: no spawn happens, live-writes still work against active profile's state.db
- [ ] Lint + typecheck + full test suite (2562 tests pass locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)