### PR TITLE
fix(desktop): prevent duplicate queued turn release

### DIFF
--- a/apps/desktop/e2e/queued-review-release.spec.ts
+++ b/apps/desktop/e2e/queued-review-release.spec.ts
@@ -173,6 +173,96 @@ async function createQueuedReviewReleaseFixture(): Promise<{
   };
 }
 
+async function createDuplicateTurnStartGuardFixture(): Promise<{
+  cleanup: () => Promise<void>;
+  fixturePath: string;
+}> {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-duplicate-turn-"));
+  const fixturePath = path.join(rootDir, "duplicate-turn-start.fixture.json");
+  const replay = {
+    entries: [],
+    messages: [],
+    pagination: {
+      supportsPagination: false,
+      hasPreviousPage: false,
+    },
+  };
+
+  await writeFile(
+    fixturePath,
+    JSON.stringify(
+      {
+        metadata: {
+          backend: "codex",
+          scenario: "duplicate-turn-start-guard",
+        },
+        steps: [
+          {
+            id: "initialize-1",
+            kind: "response",
+            method: "initialize",
+            result: {
+              serverInfo: { name: "Replay Codex", version: "1.0.0" },
+              methods: ["thread/list", "thread/read", "turn/start"],
+            },
+          },
+          {
+            id: "thread-list-1",
+            kind: "response",
+            method: "thread/list",
+            result: [
+              {
+                id: "thread-active",
+                title: "Active duplicate guard",
+                titleSource: "explicit",
+                summary: "Reject duplicate startTurn calls",
+                source: "codex",
+                executionMode: "default",
+                linkedDirectories: [],
+                updatedAt: 1_000,
+              },
+            ],
+          },
+          {
+            id: "thread-read-1",
+            kind: "response",
+            method: "thread/read",
+            result: replay,
+          },
+          {
+            id: "turn-start-1",
+            kind: "response",
+            method: "turn/start",
+            result: {
+              threadId: "thread-active",
+              turnId: "turn-active",
+            },
+          },
+          {
+            id: "turn-start-duplicate",
+            kind: "response",
+            method: "turn/start",
+            result: {
+              threadId: "thread-active",
+              turnId: "turn-duplicate",
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+
+  return {
+    fixturePath,
+    cleanup: async () => {
+      await rm(rootDir, { recursive: true, force: true });
+    },
+  };
+}
+
 test("background queued review releases after active turn branch adoption", async () => {
   const fixture = await createQueuedReviewReleaseFixture();
   const app = await launchElectronApp({
@@ -232,6 +322,81 @@ test("background queued review releases after active turn branch adoption", asyn
         },
         delivery: "inline",
       });
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
+test("duplicate Codex turn starts are rejected while the thread is active", async () => {
+  const fixture = await createDuplicateTurnStartGuardFixture();
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+    windowSize: { width: 1100, height: 760 },
+  });
+
+  try {
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "Active duplicate guard",
+      }),
+    ).toBeVisible();
+
+    const first = await app.window.evaluate(async () => {
+      const api = (window as unknown as {
+        pwragent: {
+          startTurn: (request: {
+            backend: "codex";
+            executionMode: "default";
+            input: Array<{ type: "text"; text: string }>;
+            threadId: string;
+          }) => Promise<unknown>;
+        };
+      }).pwragent;
+      return await api.startTurn({
+        backend: "codex",
+        threadId: "thread-active",
+        input: [{ type: "text", text: "First queued release" }],
+        executionMode: "default",
+      });
+    });
+    expect(first).toMatchObject({
+      backend: "codex",
+      threadId: "thread-active",
+      turnId: "turn-active",
+    });
+
+    const second = await app.window.evaluate(async () => {
+      const api = (window as unknown as {
+        pwragent: {
+          startTurn: (request: {
+            backend: "codex";
+            executionMode: "default";
+            input: Array<{ type: "text"; text: string }>;
+            threadId: string;
+          }) => Promise<unknown>;
+        };
+      }).pwragent;
+      try {
+        const response = await api.startTurn({
+          backend: "codex",
+          threadId: "thread-active",
+          input: [{ type: "text", text: "First queued release" }],
+          executionMode: "default",
+        });
+        return { ok: true, response };
+      } catch (error) {
+        return {
+          ok: false,
+          message: error instanceof Error ? error.message : String(error),
+        };
+      }
+    });
+    expect(second).toMatchObject({
+      ok: false,
+      message: expect.stringContaining("already active"),
+    });
   } finally {
     await app.close();
     await fixture.cleanup();

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -495,6 +495,7 @@ class MockBackendClient {
     reasoningEffort?: string;
     fastMode?: boolean;
   };
+  startTurnCallCount = 0;
   lastSteerTurnParams?: {
     threadId: string;
     input: AppServerTurnInputItem[];
@@ -744,6 +745,7 @@ class MockBackendClient {
     if (this.options.startTurnError) {
       throw this.options.startTurnError;
     }
+    this.startTurnCallCount += 1;
     this.lastStartTurnParams = params;
     return { threadId: params.threadId, turnId: "turn-1" };
   }
@@ -4183,6 +4185,56 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("rejects duplicate Codex turn starts while the thread is already active", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok unavailable"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await registry.startTurn({
+      backend: "codex",
+      threadId: "thread-1",
+      input: [{ type: "text", text: "first queued release" }],
+    });
+
+    await expect(
+      registry.startTurn({
+        backend: "codex",
+        threadId: "thread-1",
+        input: [{ type: "text", text: "first queued release" }],
+      }),
+    ).rejects.toThrow("A turn is already active for this thread.");
+    expect(codexClient.startTurnCallCount).toBe(1);
+
+    await codexClient.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        turn: {
+          id: "turn-1",
+          status: "completed",
+          output: [],
+        },
+      },
+    });
+
+    await registry.startTurn({
+      backend: "codex",
+      threadId: "thread-1",
+      input: [{ type: "text", text: "next queued release" }],
+    });
+    expect(codexClient.startTurnCallCount).toBe(2);
+
+    await registry.close();
+  });
+
   it("applies generated Codex thread titles after starting turns", async () => {
     const titleService = {
       generateTitle: vi.fn(async () => ({
@@ -4307,6 +4359,18 @@ command = "pnpm dev"
       input: [{ type: "text", text: "Make button" }],
     });
     await waitForCondition(() => titleService.generateTitle.mock.calls.length === 1);
+    await codexClient.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-title",
+        turnId: "turn-1",
+        turn: {
+          id: "turn-1",
+          status: "completed",
+          output: [],
+        },
+      },
+    });
 
     await registry.startTurn({
       backend: "codex",
@@ -6876,6 +6940,18 @@ command = "pnpm dev"
       threadId: "thread-toggle",
       approvalPolicy: "never",
       sandbox: "danger-full-access",
+    });
+    await codexClient.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-toggle",
+        turnId: "turn-1",
+        turn: {
+          id: "turn-1",
+          status: "completed",
+          output: [],
+        },
+      },
     });
 
     await registry.setThreadExecutionMode({

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -742,10 +742,10 @@ class MockBackendClient {
     reasoningEffort?: string;
     fastMode?: boolean;
   }): Promise<{ threadId: string; turnId: string }> {
+    this.startTurnCallCount += 1;
     if (this.options.startTurnError) {
       throw this.options.startTurnError;
     }
-    this.startTurnCallCount += 1;
     this.lastStartTurnParams = params;
     return { threadId: params.threadId, turnId: "turn-1" };
   }
@@ -4230,6 +4230,70 @@ command = "pnpm dev"
       threadId: "thread-1",
       input: [{ type: "text", text: "next queued release" }],
     });
+    expect(codexClient.startTurnCallCount).toBe(2);
+
+    await registry.close();
+  });
+
+  it("reserves Codex turn starts before awaited pre-start work", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok unavailable"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    const firstStart = registry.startTurn({
+      backend: "codex",
+      threadId: "thread-1",
+      input: [{ type: "text", text: "first queued release" }],
+    });
+    const secondStart = registry.startTurn({
+      backend: "codex",
+      threadId: "thread-1",
+      input: [{ type: "text", text: "first queued release" }],
+    });
+
+    await expect(secondStart).rejects.toThrow(
+      "A turn is already active for this thread.",
+    );
+    await firstStart;
+    expect(codexClient.startTurnCallCount).toBe(1);
+
+    await registry.close();
+  });
+
+  it("clears Codex start reservations after startTurn fails", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+      startTurnError: new Error("codex start failed"),
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok unavailable"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await expect(
+      registry.startTurn({
+        backend: "codex",
+        threadId: "thread-1",
+        input: [{ type: "text", text: "first queued release" }],
+      }),
+    ).rejects.toThrow("codex start failed");
+    await expect(
+      registry.startTurn({
+        backend: "codex",
+        threadId: "thread-1",
+        input: [{ type: "text", text: "retry queued release" }],
+      }),
+    ).rejects.toThrow("codex start failed");
     expect(codexClient.startTurnCallCount).toBe(2);
 
     await registry.close();

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -2591,6 +2591,9 @@ export class DesktopBackendRegistry {
     fastMode?: boolean;
   }): Promise<{ backend: AppServerBackendKind; threadId: string; turnId: string }> {
     this.assertNotBootstrap("startTurn");
+    if (params.backend === "codex" && this.threadHasActiveTurn(params.threadId)) {
+      throw new Error("A turn is already active for this thread.");
+    }
     // Race-safe flush: if a queued permission-mode change is still
     // pending when the user fires off the next turn (e.g. submit
     // immediately after the previous turn ended), apply it before
@@ -2689,6 +2692,12 @@ export class DesktopBackendRegistry {
     this.activeCodexTurnModes.delete(
       buildActiveTurnModeKey(params.threadId, syntheticStartedTurnId),
     );
+    if (params.backend === "codex" && activeTurnMode) {
+      this.activeCodexTurnModes.set(
+        buildActiveTurnModeKey(result.threadId, result.turnId),
+        activeTurnMode,
+      );
+    }
 
     if (
       turnParams.model !== undefined ||
@@ -2709,13 +2718,6 @@ export class DesktopBackendRegistry {
         executionMode: params.executionMode,
       });
     }
-    if (params.backend === "codex" && activeTurnMode) {
-      this.activeCodexTurnModes.set(
-        buildActiveTurnModeKey(result.threadId, result.turnId),
-        activeTurnMode,
-      );
-    }
-
     const response = {
       backend: params.backend,
       threadId: result.threadId,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1504,6 +1504,7 @@ export class DesktopBackendRegistry {
     }
   >();
   private readonly activeCodexTurnModes = new Map<string, ThreadExecutionMode>();
+  private readonly reservedCodexStartThreadIds = new Set<string>();
   /**
    * In-memory queue of pending permission-mode changes, keyed by
    * threadId. Populated when a user toggles execution mode while a turn
@@ -2591,8 +2592,12 @@ export class DesktopBackendRegistry {
     fastMode?: boolean;
   }): Promise<{ backend: AppServerBackendKind; threadId: string; turnId: string }> {
     this.assertNotBootstrap("startTurn");
-    if (params.backend === "codex" && this.threadHasActiveTurn(params.threadId)) {
-      throw new Error("A turn is already active for this thread.");
+    const reserveCodexStart = params.backend === "codex";
+    if (reserveCodexStart) {
+      if (this.threadHasActiveTurn(params.threadId)) {
+        throw new Error("A turn is already active for this thread.");
+      }
+      this.reservedCodexStartThreadIds.add(params.threadId);
     }
     // Race-safe flush: if a queued permission-mode change is still
     // pending when the user fires off the next turn (e.g. submit
@@ -2602,41 +2607,54 @@ export class DesktopBackendRegistry {
     // faster path when no immediate user action follows; this is the
     // belt-and-suspenders guarantee. Idempotent — a no-op when no
     // queue is present.
-    if (params.backend === "codex") {
-      await this.flushQueuedExecutionModeIfPresent(params.threadId);
-    }
-    const overlay = await this.overlayStore.getThreadOverlayState({
-      backend: params.backend,
-      threadId: params.threadId,
-    });
-    const turnParams = await this.resolveModelSettings(params.backend, {
-      ...params,
-      model: params.model ?? overlay?.model,
-      serviceTier: params.serviceTier ?? overlay?.serviceTier,
-      reasoningEffort: params.reasoningEffort ?? overlay?.reasoningEffort,
-      fastMode: params.backend === "codex" ? params.fastMode ?? overlay?.fastMode : undefined,
-    });
-    const cwd =
-      params.backend === "codex"
-        ? await this.resolveCodexThreadTurnCwd(params.threadId, overlay)
-        : undefined;
-    let activeTurnMode: ThreadExecutionMode | undefined;
     const syntheticStartedTurnId = `pending:${params.threadId}`;
-    await this.emit({
-      backend: params.backend,
-      notification: {
-        method: "turn/started",
-        params: {
-          threadId: params.threadId,
-          turnId: syntheticStartedTurnId,
-          turn: {
-            id: syntheticStartedTurnId,
-            status: "in_progress",
-            startedAt: Date.now(),
+    let overlay: ThreadOverlayState | undefined;
+    let turnParams!: ModelSettings;
+    let cwd: string | undefined;
+    let activeTurnMode: ThreadExecutionMode | undefined;
+    try {
+      if (params.backend === "codex") {
+        await this.flushQueuedExecutionModeIfPresent(params.threadId);
+      }
+      overlay = await this.overlayStore.getThreadOverlayState({
+        backend: params.backend,
+        threadId: params.threadId,
+      });
+      turnParams = await this.resolveModelSettings(params.backend, {
+        ...params,
+        model: params.model ?? overlay?.model,
+        serviceTier: params.serviceTier ?? overlay?.serviceTier,
+        reasoningEffort: params.reasoningEffort ?? overlay?.reasoningEffort,
+        fastMode: params.backend === "codex" ? params.fastMode ?? overlay?.fastMode : undefined,
+      });
+      cwd =
+        params.backend === "codex"
+          ? await this.resolveCodexThreadTurnCwd(params.threadId, overlay)
+          : undefined;
+      await this.emit({
+        backend: params.backend,
+        notification: {
+          method: "turn/started",
+          params: {
+            threadId: params.threadId,
+            turnId: syntheticStartedTurnId,
+            turn: {
+              id: syntheticStartedTurnId,
+              status: "in_progress",
+              startedAt: Date.now(),
+            },
           },
         },
-      },
-    });
+      });
+    } catch (error) {
+      this.activeCodexTurnModes.delete(
+        buildActiveTurnModeKey(params.threadId, syntheticStartedTurnId),
+      );
+      if (reserveCodexStart) {
+        this.reservedCodexStartThreadIds.delete(params.threadId);
+      }
+      throw error;
+    }
 
     let result: { threadId: string; turnId: string };
     try {
@@ -2687,6 +2705,9 @@ export class DesktopBackendRegistry {
       this.activeCodexTurnModes.delete(
         buildActiveTurnModeKey(params.threadId, syntheticStartedTurnId),
       );
+      if (reserveCodexStart) {
+        this.reservedCodexStartThreadIds.delete(params.threadId);
+      }
       throw error;
     }
     this.activeCodexTurnModes.delete(
@@ -2697,6 +2718,9 @@ export class DesktopBackendRegistry {
         buildActiveTurnModeKey(result.threadId, result.turnId),
         activeTurnMode,
       );
+    }
+    if (reserveCodexStart) {
+      this.reservedCodexStartThreadIds.delete(params.threadId);
     }
 
     if (
@@ -3282,6 +3306,10 @@ export class DesktopBackendRegistry {
    * `${threadId}:${turnId}`; one or more matching keys → active turn.
    */
   private threadHasActiveTurn(threadId: string): boolean {
+    if (this.reservedCodexStartThreadIds.has(threadId)) {
+      return true;
+    }
+
     const prefix = `${threadId}:`;
     for (const key of this.activeCodexTurnModes.keys()) {
       if (key.startsWith(prefix)) {

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1240,6 +1240,7 @@ export function Composer(props: ComposerProps) {
   const [queuedTurns, setQueuedTurnsState] = useState<QueuedTurnDraft[]>(
     savedInitialQueuedTurns ?? []
   );
+  const queuedAutoReleaseAttemptIdRef = useRef<string | undefined>(undefined);
   const [pendingSteer, setPendingSteerState] = useState<
     PendingSteerDraft | undefined
   >(
@@ -1709,6 +1710,14 @@ export function Composer(props: ComposerProps) {
       saveQueuedTurnSnapshots(composerScopeKey, nextQueuedTurns);
       return nextQueuedTurns;
     });
+  };
+  const restoreQueuedTurnIfClaimed = (
+    queued: QueuedTurnDraft | undefined,
+    queueClaimed: boolean | undefined,
+  ): void => {
+    if (queued && queueClaimed) {
+      restoreClaimedQueuedTurn(queued);
+    }
   };
   const setPendingSteer = (nextPendingSteer?: PendingSteerDraft): void => {
     if (nextPendingSteer?.status === "pending") {
@@ -2253,6 +2262,7 @@ export function Composer(props: ComposerProps) {
     queued?: QueuedTurnDraft;
   }): Promise<void> => {
     if (props.disabled) {
+      restoreQueuedTurnIfClaimed(options?.queued, options?.queueClaimed);
       return;
     }
     if (!options?.queued && imageAttachments.length > 0) {
@@ -2289,6 +2299,7 @@ export function Composer(props: ComposerProps) {
       } catch (error) {
         unmarkComposerDraftSubmitted(submittedScopeKey);
         props.onPendingStatusChange?.(undefined);
+        restoreQueuedTurnIfClaimed(options?.queued, options?.queueClaimed);
         setSendError(error instanceof Error ? error.message : String(error));
       } finally {
         updateSending(false);
@@ -2299,6 +2310,7 @@ export function Composer(props: ComposerProps) {
     if (!props.thread || !props.desktopApi?.startReview) {
       props.onPendingStatusChange?.(undefined);
       updateSending(false);
+      restoreQueuedTurnIfClaimed(options?.queued, options?.queueClaimed);
       return;
     }
 
@@ -2338,9 +2350,7 @@ export function Composer(props: ComposerProps) {
       setInterrupting(false);
       updateActiveTurnId(undefined);
       props.onActiveTurnIdChange?.(undefined);
-      if (options?.queued && options.queueClaimed) {
-        restoreClaimedQueuedTurn(options.queued);
-      }
+      restoreQueuedTurnIfClaimed(options?.queued, options?.queueClaimed);
       setSendError(error instanceof Error ? error.message : String(error));
     }
   };
@@ -2394,6 +2404,7 @@ export function Composer(props: ComposerProps) {
     options?: { queueClaimed?: boolean },
   ): Promise<void> => {
     if (!props.thread || !props.desktopApi?.startTurn) {
+      restoreQueuedTurnIfClaimed(queued, options?.queueClaimed);
       return;
     }
 
@@ -2401,6 +2412,7 @@ export function Composer(props: ComposerProps) {
       ? buildTurnPayload(queued.text, queued.imageAttachments)
       : buildTurnPayload(canonicalDraft, imageAttachments);
     if (payload.input.length === 0 || props.disabled) {
+      restoreQueuedTurnIfClaimed(queued, options?.queueClaimed);
       return;
     }
 
@@ -2416,6 +2428,7 @@ export function Composer(props: ComposerProps) {
 
     if (props.onBeforeStartTurn && !(await props.onBeforeStartTurn())) {
       updateSending(false);
+      restoreQueuedTurnIfClaimed(queued, options?.queueClaimed);
       return;
     }
 
@@ -2471,9 +2484,7 @@ export function Composer(props: ComposerProps) {
       updateActiveTurnId(undefined);
       props.onActiveTurnIdChange?.(undefined);
       setActiveOptimisticMessageId(undefined);
-      if (queued && options?.queueClaimed) {
-        restoreClaimedQueuedTurn(queued);
-      }
+      restoreQueuedTurnIfClaimed(queued, options?.queueClaimed);
       setSendError(error instanceof Error ? error.message : String(error));
     }
   };
@@ -2496,10 +2507,18 @@ export function Composer(props: ComposerProps) {
   };
 
   useEffect(() => {
+    if (activeTurnId) {
+      queuedAutoReleaseAttemptIdRef.current = undefined;
+      return;
+    }
     if (!queuedTurn || activeTurnId || sending || props.launchpad || props.disabled) {
       return;
     }
+    if (queuedAutoReleaseAttemptIdRef.current === queuedTurn.id) {
+      return;
+    }
 
+    queuedAutoReleaseAttemptIdRef.current = queuedTurn.id;
     updateSending(true);
     void sendQueuedTurn(queuedTurn).finally(() => {
       updateSending(false);

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1680,6 +1680,36 @@ export function Composer(props: ComposerProps) {
       return nextQueuedTurns;
     });
   };
+  const removeLocalQueuedTurn = (queued: QueuedTurnDraft): void => {
+    setQueuedTurnsState((current) =>
+      current.filter((candidate) => candidate.id !== queued.id)
+    );
+  };
+  const claimQueuedTurn = (queued: QueuedTurnDraft): QueuedTurnDraft | undefined => {
+    if (!isQueuedTurnStoreScope(composerScopeKey)) {
+      return queued;
+    }
+
+    const claimed = draftStore.removeQueuedTurnById(composerScopeKey, queued.id);
+    if (!claimed) {
+      removeLocalQueuedTurn(queued);
+      return undefined;
+    }
+
+    removeLocalQueuedTurn(queued);
+    return claimed as QueuedTurnDraft;
+  };
+  const restoreClaimedQueuedTurn = (queued: QueuedTurnDraft): void => {
+    setQueuedTurnsState((current) => {
+      if (current.some((candidate) => candidate.id === queued.id)) {
+        return current;
+      }
+
+      const nextQueuedTurns = [queued, ...current];
+      saveQueuedTurnSnapshots(composerScopeKey, nextQueuedTurns);
+      return nextQueuedTurns;
+    });
+  };
   const setPendingSteer = (nextPendingSteer?: PendingSteerDraft): void => {
     if (nextPendingSteer?.status === "pending") {
       savePendingSteerSnapshot(composerScopeKey, nextPendingSteer);
@@ -2218,7 +2248,10 @@ export function Composer(props: ComposerProps) {
   const submitReviewCommand = async (reviewCommand: {
     displayText: string;
     target: AppServerReviewTarget;
-  }, options?: { queued?: QueuedTurnDraft }): Promise<void> => {
+  }, options?: {
+    queueClaimed?: boolean;
+    queued?: QueuedTurnDraft;
+  }): Promise<void> => {
     if (props.disabled) {
       return;
     }
@@ -2283,7 +2316,9 @@ export function Composer(props: ComposerProps) {
       updateActiveTurnId(response.turnId);
       props.onActiveTurnIdChange?.(response.turnId);
       if (options?.queued) {
-        removeQueuedTurn(options.queued);
+        if (!options.queueClaimed) {
+          removeQueuedTurn(options.queued);
+        }
       } else {
         recordComposerDraftHistory(
           composerScopeKey,
@@ -2303,6 +2338,9 @@ export function Composer(props: ComposerProps) {
       setInterrupting(false);
       updateActiveTurnId(undefined);
       props.onActiveTurnIdChange?.(undefined);
+      if (options?.queued && options.queueClaimed) {
+        restoreClaimedQueuedTurn(options.queued);
+      }
       setSendError(error instanceof Error ? error.message : String(error));
     }
   };
@@ -2351,7 +2389,10 @@ export function Composer(props: ComposerProps) {
     return { displayText, imageParts, input };
   };
 
-  const sendThreadTurn = async (queued?: QueuedTurnDraft): Promise<void> => {
+  const sendThreadTurn = async (
+    queued?: QueuedTurnDraft,
+    options?: { queueClaimed?: boolean },
+  ): Promise<void> => {
     if (!props.thread || !props.desktopApi?.startTurn) {
       return;
     }
@@ -2403,7 +2444,9 @@ export function Composer(props: ComposerProps) {
       updateActiveTurnId(response.turnId);
       props.onActiveTurnIdChange?.(response.turnId);
       if (queued) {
-        removeQueuedTurn(queued);
+        if (!options?.queueClaimed) {
+          removeQueuedTurn(queued);
+        }
       } else {
         recordComposerDraftHistory(
           composerScopeKey,
@@ -2428,17 +2471,28 @@ export function Composer(props: ComposerProps) {
       updateActiveTurnId(undefined);
       props.onActiveTurnIdChange?.(undefined);
       setActiveOptimisticMessageId(undefined);
+      if (queued && options?.queueClaimed) {
+        restoreClaimedQueuedTurn(queued);
+      }
       setSendError(error instanceof Error ? error.message : String(error));
     }
   };
 
   const sendQueuedTurn = async (queued: QueuedTurnDraft): Promise<void> => {
-    if (queued.reviewCommand) {
-      await submitReviewCommand(queued.reviewCommand, { queued });
+    const claimedQueuedTurn = claimQueuedTurn(queued);
+    if (!claimedQueuedTurn) {
       return;
     }
 
-    await sendThreadTurn(queued);
+    if (claimedQueuedTurn.reviewCommand) {
+      await submitReviewCommand(claimedQueuedTurn.reviewCommand, {
+        queueClaimed: true,
+        queued: claimedQueuedTurn,
+      });
+      return;
+    }
+
+    await sendThreadTurn(claimedQueuedTurn, { queueClaimed: true });
   };
 
   useEffect(() => {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1237,13 +1237,6 @@ describe("Composer", () => {
       );
     });
 
-    fireEvent.click(
-      within(screen.getByLabelText("Queued message")).getByRole("button", {
-        name: "Edit",
-      })
-    );
-
-    expect(textarea).toHaveValue("First queued reply");
     expect(screen.getByLabelText("Queued message")).toHaveTextContent(
       "Second queued reply"
     );
@@ -2305,6 +2298,63 @@ describe("Composer", () => {
     });
     expect(textarea).toHaveValue("Pending steer draft");
     expect(screen.queryByText("Pending steer")).not.toBeInTheDocument();
+  });
+
+  it("does not send a stale local queued turn after another release path claims it", async () => {
+    const draftStore = createComposerDraftStore();
+    const startTurn = vi.fn(async (request: StartTurnRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      turnId: "turn-2",
+    }));
+    const thread = {
+      id: "thread-1",
+      title: "Claimed queue",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      executionMode: "default" as const,
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const props = {
+      backends: [backendSummary("codex")],
+      desktopApi: {
+        onAgentEvent: () => () => undefined,
+        startTurn,
+      },
+      disabled: false,
+      draftStore,
+      skills: [],
+      thread,
+    };
+    const { rerender } = render(
+      <Composer
+        {...props}
+        activeTurnId="turn-1"
+      />,
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "Queued elsewhere" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(screen.getByText("Queued next")).toBeInTheDocument();
+
+    const scopeKey = "thread:codex:thread-1";
+    const queued = draftStore.getQueuedTurn(scopeKey);
+    expect(queued?.text).toBe("Queued elsewhere");
+    draftStore.removeQueuedTurnById(scopeKey, queued!.id);
+
+    rerender(
+      <Composer
+        {...props}
+        activeTurnId={undefined}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText("Queued elsewhere")).not.toBeInTheDocument();
+    });
+    expect(startTurn).not.toHaveBeenCalled();
   });
 
   it("updates model settings without crashing when fast-mode support changes", async () => {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -2357,6 +2357,67 @@ describe("Composer", () => {
     expect(startTurn).not.toHaveBeenCalled();
   });
 
+  it("restores a claimed queued turn when preflight blocks sending", async () => {
+    const draftStore = createComposerDraftStore();
+    const startTurn = vi.fn(async (request: StartTurnRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      turnId: "turn-2",
+    }));
+    const onBeforeStartTurn = vi.fn(async () => false);
+    const thread = {
+      id: "thread-1",
+      title: "Blocked queue",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      executionMode: "default" as const,
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const props = {
+      backends: [backendSummary("codex")],
+      desktopApi: {
+        onAgentEvent: () => () => undefined,
+        startTurn,
+      },
+      disabled: false,
+      draftStore,
+      onBeforeStartTurn,
+      skills: [],
+      thread,
+    };
+    const { rerender } = render(
+      <Composer
+        {...props}
+        activeTurnId="turn-1"
+      />,
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "Queued preflight block" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(screen.getByText("Queued next")).toBeInTheDocument();
+
+    rerender(
+      <Composer
+        {...props}
+        activeTurnId={undefined}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(onBeforeStartTurn).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(screen.getByText("Queued preflight block")).toBeInTheDocument();
+    });
+    expect(
+      draftStore.getQueuedTurn("thread:codex:thread-1")?.text,
+    ).toBe("Queued preflight block");
+    expect(onBeforeStartTurn).toHaveBeenCalledTimes(1);
+    expect(startTurn).not.toHaveBeenCalled();
+  });
+
   it("updates model settings without crashing when fast-mode support changes", async () => {
     const onSetThreadModelSettings = vi.fn(async () => undefined);
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx
@@ -205,6 +205,83 @@ describe("useQueuedTurnRelease", () => {
     ).toBe("Second background reply");
   });
 
+  it("claims a queued message once when duplicate release subscribers see the same completion", async () => {
+    const listeners = new Set<(event: AgentEvent) => void>();
+    const startTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-a",
+      turnId: "turn-next",
+    }));
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (listener) => {
+        listeners.add(listener);
+        return () => {
+          listeners.delete(listener);
+        };
+      },
+      startTurn,
+    };
+    const composerDraftStore = createComposerDraftStore();
+    composerDraftStore.setQueuedTurns("thread:codex:thread-a", [
+      {
+        id: "queued-1",
+        text: "First background reply",
+        imageAttachments: [],
+        input: [{ type: "text", text: "First background reply" }],
+      },
+      {
+        id: "queued-2",
+        text: "Second background reply",
+        imageAttachments: [],
+        input: [{ type: "text", text: "Second background reply" }],
+      },
+    ]);
+    const hookParams = {
+      backends: [backendSummary()],
+      composerDraftStore,
+      desktopApi,
+      selectedThread: thread("thread-b"),
+      threads: [thread("thread-a"), thread("thread-b")],
+    };
+
+    renderHook(() => useQueuedTurnRelease(hookParams));
+    renderHook(() => useQueuedTurnRelease(hookParams));
+
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "turn/completed",
+            params: {
+              threadId: "thread-a",
+              turnId: "turn-1",
+              turn: {
+                id: "turn-1",
+                status: "completed",
+                output: [],
+              },
+            },
+          },
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledTimes(1);
+    });
+    expect(startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: "codex",
+        threadId: "thread-a",
+        input: [{ type: "text", text: "First background reply" }],
+      }),
+    );
+    expect(
+      composerDraftStore.getQueuedTurn("thread:codex:thread-a")?.text,
+    ).toBe("Second background reply");
+  });
+
   it("releases a queued message for a non-focused thread when its status becomes idle", async () => {
     const listeners = new Set<(event: AgentEvent) => void>();
     const startTurn = vi.fn(async () => ({
@@ -496,7 +573,6 @@ describe("useQueuedTurnRelease", () => {
       );
     });
 
-    composerDraftStore.removeQueuedTurnAt("thread:codex:thread-a", 0);
     expect(
       composerDraftStore.getQueuedTurn("thread:codex:thread-a")?.text
     ).toBe("Second background reply");

--- a/apps/desktop/src/renderer/src/lib/useQueuedTurnRelease.ts
+++ b/apps/desktop/src/renderer/src/lib/useQueuedTurnRelease.ts
@@ -21,6 +21,7 @@ const TERMINAL_TURN_METHODS = new Set([
   "turn/cancelled",
 ]);
 const BACKGROUND_QUEUE_RELEASE_INTERVAL_MS = 30_000;
+const globalInFlightScopeKeys = new Set<string>();
 
 function getDefaultModelOption(backend?: BackendSummary): ModelOption | undefined {
   const models = backend?.launchpadOptions?.models ?? [];
@@ -62,6 +63,19 @@ function buildQueuedTurnInput(
       url: attachment.url,
     })),
   ];
+}
+
+function restoreQueuedTurn(
+  composerDraftStore: ComposerDraftStore,
+  scopeKey: string,
+  queuedTurn: ComposerQueuedTurnSnapshot,
+): void {
+  const current = composerDraftStore.getQueuedTurns(scopeKey);
+  if (current.some((entry) => entry.id === queuedTurn.id)) {
+    return;
+  }
+
+  composerDraftStore.setQueuedTurns(scopeKey, [queuedTurn, ...current]);
 }
 
 function readNotificationThreadId(event: AgentEvent): string | undefined {
@@ -138,7 +152,10 @@ export function useQueuedTurnRelease(params: {
   ): Promise<void> => {
     const current = paramsRef.current;
     const scopeKey = getThreadScopeKey(thread);
-    if (inFlightScopeKeysRef.current.has(scopeKey)) {
+    if (
+      inFlightScopeKeysRef.current.has(scopeKey) ||
+      globalInFlightScopeKeys.has(scopeKey)
+    ) {
       return;
     }
 
@@ -191,6 +208,7 @@ export function useQueuedTurnRelease(params: {
     }
 
     inFlightScopeKeysRef.current.add(scopeKey);
+    globalInFlightScopeKeys.add(scopeKey);
     try {
       if (options.verifyIdle) {
         const readThread = paramsRef.current.desktopApi?.readThread;
@@ -253,30 +271,63 @@ export function useQueuedTurnRelease(params: {
           return;
         }
 
-        await startReview({
-          backend: releaseThread.source,
-          threadId: releaseThread.id,
-          target: releaseQueuedSnapshot.reviewCommand.target,
-          delivery: "inline",
-        });
-        releaseState.composerDraftStore.removeQueuedTurnById(
-          scopeKey,
-          releaseQueuedSnapshot.id,
-        );
+        const claimedQueuedTurn =
+          releaseState.composerDraftStore.removeQueuedTurnById(
+            scopeKey,
+            releaseQueuedSnapshot.id,
+          );
+        if (!claimedQueuedTurn) {
+          return;
+        }
+        const reviewCommand = claimedQueuedTurn.reviewCommand;
+        if (!reviewCommand) {
+          restoreQueuedTurn(
+            releaseState.composerDraftStore,
+            scopeKey,
+            claimedQueuedTurn,
+          );
+          return;
+        }
+
+        try {
+          await startReview({
+            backend: releaseThread.source,
+            threadId: releaseThread.id,
+            target: reviewCommand.target,
+            delivery: "inline",
+          });
+        } catch (error) {
+          restoreQueuedTurn(
+            releaseState.composerDraftStore,
+            scopeKey,
+            claimedQueuedTurn,
+          );
+          throw error;
+        }
         return;
       }
 
-      const input = buildQueuedTurnInput(releaseQueuedSnapshot);
-      if (input.length === 0) {
+      const claimedQueuedTurn =
         releaseState.composerDraftStore.removeQueuedTurnById(
           scopeKey,
           releaseQueuedSnapshot.id,
         );
+      if (!claimedQueuedTurn) {
+        return;
+      }
+
+      const input = buildQueuedTurnInput(claimedQueuedTurn);
+      if (input.length === 0) {
         return;
       }
 
       const startTurn = desktopApi?.startTurn;
       if (!startTurn || !backend.capabilities.startTurn) {
+        restoreQueuedTurn(
+          releaseState.composerDraftStore,
+          scopeKey,
+          claimedQueuedTurn,
+        );
         return;
       }
 
@@ -295,31 +346,37 @@ export function useQueuedTurnRelease(params: {
             false
           : false;
 
-      await startTurn({
-        backend: releaseThread.source,
-        threadId: releaseThread.id,
-        input,
-        executionMode: releaseThread.executionMode,
-        model: selectedModelOption?.id,
-        reasoningEffort: supportsReasoning
-          ? getReasoningEffortValue(backend, releaseThread.reasoningEffort)
-          : undefined,
-        serviceTier:
-          releaseThread.serviceTier ?? backend.launchpadOptions?.serviceTiers?.[0],
-        fastMode:
-          releaseThread.source === "codex" && supportsFast
-            ? Boolean(releaseThread.fastMode)
+      try {
+        await startTurn({
+          backend: releaseThread.source,
+          threadId: releaseThread.id,
+          input,
+          executionMode: releaseThread.executionMode,
+          model: selectedModelOption?.id,
+          reasoningEffort: supportsReasoning
+            ? getReasoningEffortValue(backend, releaseThread.reasoningEffort)
             : undefined,
-      });
-      releaseState.composerDraftStore.removeQueuedTurnById(
-        scopeKey,
-        releaseQueuedSnapshot.id,
-      );
+          serviceTier:
+            releaseThread.serviceTier ?? backend.launchpadOptions?.serviceTiers?.[0],
+          fastMode:
+            releaseThread.source === "codex" && supportsFast
+              ? Boolean(releaseThread.fastMode)
+              : undefined,
+        });
+      } catch (error) {
+        restoreQueuedTurn(
+          releaseState.composerDraftStore,
+          scopeKey,
+          claimedQueuedTurn,
+        );
+        throw error;
+      }
     } catch {
       // Keep the queued entry. The next terminal/idle notification or
       // periodic idle probe will retry without losing the user's request.
     } finally {
       inFlightScopeKeysRef.current.delete(scopeKey);
+      globalInFlightScopeKeys.delete(scopeKey);
     }
   };
 


### PR DESCRIPTION
## Summary

I fixed a queued-message regression where two release paths could submit the same queued Codex turn after a prior turn completed.

The fix claims queued turns before sending them, restores the claim on failure, and adds a main-process guard that rejects duplicate Codex `startTurn` calls while a thread is already active.

## Verification

I verified this with:

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx apps/desktop/src/main/__tests__/backend-registry.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm --filter @pwragent/desktop test:e2e e2e/queued-review-release.spec.ts`
- `pnpm lint:boundaries`
- `git diff --check`

## Notes

I also checked the local Codex rollout for thread `019e367e-8d46-7152-b4f3-e073ebff2315` and confirmed the persisted session showed the first queued message duplicated before the second queued message released later.
