### PR TITLE
fix(desktop): make launchpad errors copyable

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -54,6 +54,7 @@ import {
 } from "./ComposerInputTypes";
 import { ComposerTiptapInput } from "./ComposerTiptapInput";
 import { ProjectPicker } from "./ProjectPicker";
+import { TranscriptCopyButton } from "../thread-detail/TranscriptCopyButton";
 import {
   useComposerDraftStore,
   type ComposerDraftSnapshot,
@@ -1144,6 +1145,25 @@ function ComposerApplicationButton(props: {
       )}
       <span>{props.label}</span>
     </button>
+  );
+}
+
+function CopyableComposerError(props: {
+  desktopApi?: Pick<DesktopApi, "copyText">;
+  label: string;
+  text: string;
+}) {
+  return (
+    <div className="composer__meta composer__meta--error composer__meta--copyable">
+      <span className="composer__meta-text">{props.text}</span>
+      <TranscriptCopyButton
+        className="transcript-copy-button--composer-error"
+        copiedLabel="Copied error"
+        desktopApi={props.desktopApi}
+        label={props.label}
+        text={props.text}
+      />
+    </div>
   );
 }
 
@@ -4689,7 +4709,11 @@ export function Composer(props: ComposerProps) {
 
       {props.skillError ? <p className="composer__meta composer__meta--error">{props.skillError}</p> : null}
       {props.launchpadError ? (
-        <p className="composer__meta composer__meta--error">{props.launchpadError}</p>
+        <CopyableComposerError
+          desktopApi={props.desktopApi}
+          label="Copy launchpad error"
+          text={props.launchpadError}
+        />
       ) : null}
       {sendError ? <p className="composer__meta composer__meta--error">{sendError}</p> : null}
       {applicationOpenError ? (

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -265,6 +265,43 @@ function renderComposerWithRegressionSkills(
 }
 
 describe("Composer", () => {
+  it("lets launchpad errors be copied with the transcript copy control", async () => {
+    const copyText = vi.fn(async () => undefined);
+    const launchpadError =
+      "Error invoking remote method 'agent:materialize-directory-launchpad': Cannot enable privileged approval modes in an untrusted folder.";
+
+    render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        desktopApi={{ copyText }}
+        disabled={false}
+        launchpad={{
+          directoryKey: "directory:/repo",
+          directoryKind: "directory",
+          directoryLabel: "PwrAgent",
+          directoryPath: "/repo",
+          backend: "codex",
+          executionMode: "default",
+          prompt: "",
+          workMode: "local",
+          branchName: "main",
+          createdAt: 1,
+          updatedAt: 1,
+        }}
+        launchpadError={launchpadError}
+        skills={[]}
+      />
+    );
+
+    expect(screen.getByText(launchpadError)).toHaveClass("composer__meta-text");
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy launchpad error" }));
+
+    await waitFor(() => {
+      expect(copyText).toHaveBeenCalledWith(launchpadError);
+    });
+  });
+
   it("opens the current workspace in discovered applications", async () => {
     const openApplication = vi.fn(async () => ({ opened: true as const }));
 

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -240,6 +240,19 @@ describe("Tangerine Terminal theme contract", () => {
     expect(setupComposerRule).toContain("min-height: 0;");
   });
 
+  it("keeps launchpad composer errors selectable and directly copyable", () => {
+    const errorRule = extractRuleBody(css, ".composer__meta--copyable");
+    const errorTextRule = extractRuleBody(css, ".composer__meta-text");
+    const copyButtonRule = extractRuleBody(
+      css,
+      ".transcript-copy-button--composer-error"
+    );
+
+    expect(errorRule).toContain("user-select: text;");
+    expect(errorTextRule).toContain("user-select: text;");
+    expect(copyButtonRule).toContain("opacity: 1;");
+  });
+
   it("reserves opened context rail width for the thread header status area", () => {
     expect(css).toMatch(
       /\.thread-view:has\(\.context-rail\.is-open\) \.thread-header\s*\{[\s\S]*?padding-right:\s*calc\(min\(var\(--context-rail-width, 380px\), calc\(100% - 32px\)\) \+ 12px\);[\s\S]*?\}/

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9575,6 +9575,28 @@ textarea,
   color: var(--danger-text);
 }
 
+.composer__meta--copyable {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  min-width: 0;
+  -webkit-user-select: text;
+  user-select: text;
+}
+
+.composer__meta-text {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  -webkit-user-select: text;
+  user-select: text;
+}
+
+.transcript-copy-button--composer-error {
+  flex: 0 0 auto;
+  opacity: 1;
+}
+
 .composer__actions {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

- I made launchpad materialization errors render as selectable text.
- I added the existing transcript-style copy button to launchpad errors so the full error can be copied directly.
- I covered the behavior with a composer test and locked the selection/copy CSS contract.

## Verification

- I ran `pnpm install --frozen-lockfile` to populate this worktree's locked dependencies.
- I ran `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx`.
- I ran `pnpm --filter @pwragent/desktop exec tsc --noEmit`.
- I ran `pnpm lint:boundaries`.
- I ran `git diff --check`.

## Notes

- Commit is signed.
