### PR TITLE
feat(messaging): add Telegram topic ownership

### DIFF
--- a/apps/desktop/src/main/__tests__/composer-draft-recovery-store.test.ts
+++ b/apps/desktop/src/main/__tests__/composer-draft-recovery-store.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { ComposerDraftSnapshotRecord } from "@pwragent/shared";
 import { ComposerDraftRecoveryStore } from "../state/composer-draft-recovery-store";
-import { StateDb } from "../state/state-db";
+import { CURRENT_STATE_DB_USER_VERSION, StateDb } from "../state/state-db";
 
 let stateDb: StateDb;
 let store: ComposerDraftRecoveryStore;
@@ -23,7 +23,9 @@ afterEach(() => {
 
 describe("ComposerDraftRecoveryStore", () => {
   it("creates the durable draft schema at the current state DB version", () => {
-    expect(stateDb.raw.pragma("user_version", { simple: true })).toBe(7);
+    expect(stateDb.raw.pragma("user_version", { simple: true })).toBe(
+      CURRENT_STATE_DB_USER_VERSION,
+    );
     expect(
       stateDb.raw
         .prepare(

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -2675,6 +2675,67 @@ describe("MessagingController", () => {
     });
   });
 
+  it("opens Telegram topic controls from the Monitor card", async () => {
+    const createManagedConversation = vi.fn(async () => ({
+      channel: "telegram" as const,
+      conversation: {
+        id: "400",
+        kind: "topic" as const,
+        parentId: "-1001",
+        parentTitle: "Ops",
+        title: "PwrAgent topic owner",
+      },
+      outcome: "created" as const,
+      routingState: { opaque: { chatId: -1001, messageThreadId: 400 } },
+      updatedAt: 1000,
+    }));
+    const harness = await createHarness({ createManagedConversation });
+    const event = buildTelegramChannelCommandEvent("/monitor");
+
+    await harness.controller.handleInboundEvent(event);
+
+    const topicAction = findAction(harness.delivered.at(-1), "monitor:topics");
+    expect(topicAction).toMatchObject({
+      fallbackText: "monitor topics",
+      label: "Topics",
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: topicAction.id,
+        channel: event.channel,
+      }),
+    );
+
+    expect(createManagedConversation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parent: event.channel,
+        title: "PwrAgent topic owner",
+      }),
+    );
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "PwrAgent topic owner",
+      audit: expect.objectContaining({
+        channel: {
+          channel: "telegram",
+          conversation: {
+            id: "400",
+            kind: "topic",
+            parentId: "-1001",
+            parentTitle: "Ops",
+            title: "PwrAgent topic owner",
+          },
+        },
+      }),
+      targetSurface: {
+        channel: "telegram",
+        id: expect.stringContaining("topic:topic:telegram:-1001:400"),
+        state: { opaque: { chatId: -1001, messageThreadId: 400 } },
+      },
+    });
+  });
+
   it("preserves command routing state for the initial Monitor render", async () => {
     const harness = await createHarness();
     const event = {
@@ -8698,6 +8759,27 @@ function buildTopicCommandEvent(
       opaque: {
         chatId: -1001,
         messageThreadId: Number(topicId),
+      },
+    },
+  };
+}
+
+function buildTelegramChannelCommandEvent(
+  rawText: string,
+): MessagingInboundEvent & { kind: "command" } {
+  return {
+    ...buildCommandEvent(rawText),
+    channel: {
+      channel: "telegram",
+      conversation: {
+        id: "-1001",
+        kind: "channel",
+        title: "Ops",
+      },
+    },
+    routingState: {
+      opaque: {
+        chatId: -1001,
       },
     },
   };

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -2909,6 +2909,150 @@ describe("MessagingController", () => {
     });
   });
 
+  it("establishes a Telegram topic owner surface from /monitor topics", async () => {
+    const getManagedConversationRights = vi.fn(async () => ({
+      channel: "telegram" as const,
+      conversation: buildTopicChannel("100").conversation,
+      outcome: "ok" as const,
+      operations: [
+        { operation: "create_child" as const, supported: true },
+        { operation: "close" as const, supported: true },
+        { operation: "reopen" as const, supported: true },
+        { operation: "delete" as const, supported: false, missingPermission: "can_delete_messages" },
+      ],
+      updatedAt: 1000,
+    }));
+    const harness = await createHarness({ getManagedConversationRights });
+    const event = buildTopicCommandEvent("/monitor topics", "100");
+
+    await harness.controller.handleInboundEvent(event);
+
+    expect(getManagedConversationRights).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: event.channel,
+      }),
+    );
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "PwrAgent topic owner",
+      body: expect.stringContaining("Known topics: 1"),
+      actions: expect.arrayContaining([
+        expect.objectContaining({ id: "monitor:topics:cleanup" }),
+        expect.objectContaining({ id: "monitor:topics:fanout" }),
+      ]),
+    });
+    await expect(
+      harness.store.findManagedTopicByConversation({
+        channel: "telegram",
+        supergroupId: "-1001",
+        topicId: "100",
+      }),
+    ).resolves.toMatchObject({
+      source: "owned",
+      lifecycle: "open",
+    });
+  });
+
+  it("renders Telegram topic cleanup as dry-run proposals", async () => {
+    const closeManagedConversation = vi.fn(async () => ({
+      channel: "telegram" as const,
+      conversation: buildTopicChannel("200").conversation,
+      operation: "close" as const,
+      outcome: "updated" as const,
+      updatedAt: 1000,
+    }));
+    const harness = await createHarness({ closeManagedConversation });
+
+    await harness.controller.handleInboundEvent(buildTopicCommandEvent("/monitor topics", "100"));
+    await harness.controller.handleInboundEvent(
+      buildTextEvent("hello", { channel: buildTopicChannel("200") }),
+    );
+    harness.delivered.splice(0);
+
+    await harness.controller.handleInboundEvent(
+      buildTopicCommandEvent("/monitor topics cleanup", "100"),
+    );
+
+    expect(closeManagedConversation).not.toHaveBeenCalled();
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Topic cleanup dry run",
+      body: expect.stringContaining("Dry run only"),
+      actions: expect.arrayContaining([
+        expect.objectContaining({
+          id: expect.stringContaining("monitor:topics:approve:"),
+          label: expect.stringContaining("Close"),
+        }),
+      ]),
+    });
+
+    const approve = (harness.delivered.at(-1) as { actions?: Array<{ id: string }> })
+      .actions?.find((action) => action.id.includes(":200"));
+    if (!approve) throw new Error("approval action missing");
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: approve.id, channel: buildTopicChannel("100") }),
+    );
+
+    expect(closeManagedConversation).toHaveBeenCalledTimes(1);
+    await expect(
+      harness.store.findManagedTopicByConversation({
+        channel: "telegram",
+        supergroupId: "-1001",
+        topicId: "200",
+      }),
+    ).resolves.toMatchObject({
+      lifecycle: "closed",
+    });
+  });
+
+  it("fans monitor threads out to one Telegram topic per thread without duplicates", async () => {
+    const createManagedConversation = vi.fn(async () => ({
+      channel: "telegram" as const,
+      conversation: {
+        id: "300",
+        kind: "topic" as const,
+        parentId: "-1001",
+        parentTitle: "Ops",
+        title: "Thread one",
+      },
+      outcome: "created" as const,
+      routingState: { opaque: { chatId: -1001, messageThreadId: 300 } },
+      updatedAt: 1000,
+    }));
+    const harness = await createHarness({ createManagedConversation });
+    const control = buildTopicCommandEvent("/monitor topics fanout", "100");
+
+    await harness.controller.handleInboundEvent(control);
+    await harness.controller.handleInboundEvent(control);
+
+    expect(createManagedConversation).toHaveBeenCalledTimes(1);
+    await expect(
+      harness.store.findThreadTopicLink({
+        backend: "codex",
+        channel: "telegram",
+        supergroupId: "-1001",
+        threadId: "thread-1",
+      }),
+    ).resolves.toMatchObject({
+      topicRecordId: "topic:telegram:-1001:300",
+    });
+    await expect(
+      harness.store.findActiveBindingForChannel(buildTopicChannel("300")),
+    ).resolves.toMatchObject({
+      backend: "codex",
+      threadId: "thread-1",
+      routingState: { opaque: { chatId: -1001, messageThreadId: 300 } },
+    });
+    expect(
+      harness.delivered.filter(
+        (intent) =>
+          intent.kind === "message" &&
+          intent.audit?.action === "topics.seed",
+      ),
+    ).toHaveLength(1);
+  });
+
   it("does not create duplicate Monitor timers for repeated starts", async () => {
     vi.useFakeTimers();
     const harness = await createHarness();
@@ -7914,6 +8058,10 @@ async function createHarness(options?: {
   onFullAccessPolicyViolation?: MessagingControllerOptions["onFullAccessPolicyViolation"];
   onDeliveryBudgetEvent?: MessagingControllerOptions["onDeliveryBudgetEvent"];
   resolveDeliveryScope?: MessagingAdapter["resolveDeliveryScope"];
+  getManagedConversationRights?: MessagingAdapter["getManagedConversationRights"];
+  createManagedConversation?: MessagingAdapter["createManagedConversation"];
+  closeManagedConversation?: MessagingAdapter["closeManagedConversation"];
+  deleteManagedConversation?: MessagingAdapter["deleteManagedConversation"];
   materializeDirectoryLaunchpad?: NonNullable<
     MessagingBackendBridge["materializeDirectoryLaunchpad"]
   >;
@@ -7993,6 +8141,18 @@ async function createHarness(options?: {
     ),
     ...(options?.setConversationTitle
       ? { setConversationTitle: options.setConversationTitle }
+      : {}),
+    ...(options?.getManagedConversationRights
+      ? { getManagedConversationRights: options.getManagedConversationRights }
+      : {}),
+    ...(options?.createManagedConversation
+      ? { createManagedConversation: options.createManagedConversation }
+      : {}),
+    ...(options?.closeManagedConversation
+      ? { closeManagedConversation: options.closeManagedConversation }
+      : {}),
+    ...(options?.deleteManagedConversation
+      ? { deleteManagedConversation: options.deleteManagedConversation }
       : {}),
   };
   const getNavigationSnapshot = vi.fn(
@@ -8524,6 +8684,35 @@ function buildCommandEvent(
     args: parts.slice(1),
     rawText,
     receivedAt: 1000,
+  };
+}
+
+function buildTopicCommandEvent(
+  rawText: string,
+  topicId: string,
+): MessagingInboundEvent & { kind: "command" } {
+  return {
+    ...buildCommandEvent(rawText),
+    channel: buildTopicChannel(topicId),
+    routingState: {
+      opaque: {
+        chatId: -1001,
+        messageThreadId: Number(topicId),
+      },
+    },
+  };
+}
+
+function buildTopicChannel(topicId: string): MessagingInboundEvent["channel"] {
+  return {
+    channel: "telegram",
+    conversation: {
+      id: topicId,
+      kind: "topic",
+      parentId: "-1001",
+      parentTitle: "Ops",
+      title: topicId === "100" ? "PwrAgent" : `Topic ${topicId}`,
+    },
   };
 }
 

--- a/apps/desktop/src/main/__tests__/messaging-monitor-card.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-monitor-card.test.ts
@@ -62,6 +62,9 @@ describe("buildMonitorStatusIntent", () => {
         }),
       ]),
     });
+    expect(intent.actions).not.toContainEqual(
+      expect.objectContaining({ id: "monitor:topics" }),
+    );
     expect(intent.text).toContain("Pins: 5 | Recent: 5");
     expect(intent.text).toContain("Status: inline | Snippet: off");
     expect(intent.text).toContain("Pins\nP1. Pinned release watch (codex) - idle - updated just now - PwrAgent");
@@ -69,6 +72,24 @@ describe("buildMonitorStatusIntent", () => {
     expect(intent.text).toContain("2. Review provider commands (grok) - queued permissions - updated just now - Messaging");
     expect(intent.text).toContain(`Interval: ${MESSAGING_MONITOR_INTERVAL_MS / 60_000} min`);
     expect(intent.text).not.toContain("undefined");
+  });
+
+  it("adds topic controls when the monitor surface supports Telegram topics", () => {
+    const intent = buildMonitorStatusIntent({
+      binding: buildBinding(),
+      createdAt: 121_000,
+      id: "monitor-1",
+      navigation: buildNavigationSnapshot(),
+      topicControls: true,
+    });
+
+    expect(intent.actions).toContainEqual(
+      expect.objectContaining({
+        id: "monitor:topics",
+        fallbackText: "monitor topics",
+        label: "Topics",
+      }),
+    );
   });
 
   it("updates the existing monitor surface when one is stored", () => {

--- a/apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts
@@ -5,8 +5,11 @@ import { afterEach, describe, expect, it } from "vitest";
 import type {
   MessagingBindingRecord,
   MessagingCallbackHandleRecord,
+  MessagingManagedTopicRecord,
   MessagingMonitorSubscriptionRecord,
   MessagingPendingIntentRecord,
+  MessagingThreadTopicLinkRecord,
+  MessagingTopicCleanupProposalRecord,
 } from "@pwragent/messaging-interface";
 import { SqliteMessagingStore } from "../state/messaging-store-sqlite";
 import { StateDb } from "../state/state-db";
@@ -63,6 +66,69 @@ function buildMonitorSubscription(
       intervalMs: 60_000,
       updatedAt: 1000,
     },
+    ...overrides,
+  };
+}
+
+function buildManagedTopic(
+  overrides: Partial<MessagingManagedTopicRecord> = {},
+): MessagingManagedTopicRecord {
+  return {
+    id: "topic:telegram:-1001:100",
+    authorizedActorIds: ["user-1"],
+    channel: "telegram",
+    conversation: {
+      id: "100",
+      kind: "topic",
+      parentId: "-1001",
+      title: "PwrAgent",
+    },
+    createdAt: 1000,
+    lifecycle: "open",
+    source: "owned",
+    supergroupId: "-1001",
+    title: "PwrAgent",
+    topicId: "100",
+    updatedAt: 1000,
+    ...overrides,
+  };
+}
+
+function buildTopicLink(
+  overrides: Partial<MessagingThreadTopicLinkRecord> = {},
+): MessagingThreadTopicLinkRecord {
+  return {
+    id: "topic-link:telegram:-1001:codex:thread-1",
+    backend: "codex",
+    channel: "telegram",
+    createdAt: 1000,
+    supergroupId: "-1001",
+    threadId: "thread-1",
+    topicRecordId: "topic:telegram:-1001:100",
+    updatedAt: 1000,
+    ...overrides,
+  };
+}
+
+function buildCleanupProposal(
+  overrides: Partial<MessagingTopicCleanupProposalRecord> = {},
+): MessagingTopicCleanupProposalRecord {
+  return {
+    id: "proposal-1",
+    authorizedActorIds: ["user-1"],
+    channel: "telegram",
+    createdAt: 1000,
+    items: [
+      {
+        id: "100",
+        action: "close",
+        reason: "inactive",
+        topicRecordId: "topic:telegram:-1001:100",
+      },
+    ],
+    status: "pending",
+    supergroupId: "-1001",
+    updatedAt: 1000,
     ...overrides,
   };
 }
@@ -451,5 +517,55 @@ describe("SqliteMessagingStore", () => {
       .toMatchObject({
         id: "other-callback",
       });
+  });
+
+  it("persists managed topics, thread-topic links, and cleanup proposals", async () => {
+    const store = await createStore();
+
+    await store.upsertManagedTopic(buildManagedTopic());
+    await store.upsertThreadTopicLink(buildTopicLink());
+    await store.upsertTopicCleanupProposal(buildCleanupProposal());
+
+    await expect(
+      store.findManagedTopicByConversation({
+        channel: "telegram",
+        supergroupId: "-1001",
+        topicId: "100",
+      }),
+    ).resolves.toMatchObject({
+      id: "topic:telegram:-1001:100",
+      source: "owned",
+    });
+    await expect(
+      store.findThreadTopicLink({
+        backend: "codex",
+        channel: "telegram",
+        supergroupId: "-1001",
+        threadId: "thread-1",
+      }),
+    ).resolves.toMatchObject({
+      topicRecordId: "topic:telegram:-1001:100",
+    });
+    await expect(store.getTopicCleanupProposal("proposal-1")).resolves.toMatchObject({
+      status: "pending",
+      items: [expect.objectContaining({ action: "close" })],
+    });
+    await expect(store.readSnapshot()).resolves.toMatchObject({
+      topics: {
+        "topic:telegram:-1001:100": expect.objectContaining({
+          source: "owned",
+        }),
+      },
+      topicLinks: {
+        "topic-link:telegram:-1001:codex:thread-1": expect.objectContaining({
+          threadId: "thread-1",
+        }),
+      },
+      topicCleanupProposals: {
+        "proposal-1": expect.objectContaining({
+          status: "pending",
+        }),
+      },
+    });
   });
 });

--- a/apps/desktop/src/main/__tests__/messaging-store.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-store.test.ts
@@ -6,7 +6,10 @@ import type {
   MessagingBindingRecord,
   MessagingBrowseSessionRecord,
   MessagingCallbackHandleRecord,
+  MessagingManagedTopicRecord,
   MessagingPendingIntentRecord,
+  MessagingThreadTopicLinkRecord,
+  MessagingTopicCleanupProposalRecord,
 } from "@pwragent/messaging-interface";
 import { MessagingStore } from "../messaging/core/messaging-store";
 
@@ -38,6 +41,69 @@ function buildBinding(
     threadId: "thread-1",
     authorizedActorIds: ["user-1"],
     createdAt: 1000,
+    updatedAt: 1000,
+    ...overrides,
+  };
+}
+
+function buildManagedTopic(
+  overrides: Partial<MessagingManagedTopicRecord> = {},
+): MessagingManagedTopicRecord {
+  return {
+    id: "topic:telegram:-1001:100",
+    authorizedActorIds: ["user-1"],
+    channel: "telegram",
+    conversation: {
+      id: "100",
+      kind: "topic",
+      parentId: "-1001",
+      title: "PwrAgent",
+    },
+    createdAt: 1000,
+    lifecycle: "open",
+    source: "owned",
+    supergroupId: "-1001",
+    title: "PwrAgent",
+    topicId: "100",
+    updatedAt: 1000,
+    ...overrides,
+  };
+}
+
+function buildTopicLink(
+  overrides: Partial<MessagingThreadTopicLinkRecord> = {},
+): MessagingThreadTopicLinkRecord {
+  return {
+    id: "topic-link:telegram:-1001:codex:thread-1",
+    backend: "codex",
+    channel: "telegram",
+    createdAt: 1000,
+    supergroupId: "-1001",
+    threadId: "thread-1",
+    topicRecordId: "topic:telegram:-1001:100",
+    updatedAt: 1000,
+    ...overrides,
+  };
+}
+
+function buildCleanupProposal(
+  overrides: Partial<MessagingTopicCleanupProposalRecord> = {},
+): MessagingTopicCleanupProposalRecord {
+  return {
+    id: "proposal-1",
+    authorizedActorIds: ["user-1"],
+    channel: "telegram",
+    createdAt: 1000,
+    items: [
+      {
+        id: "100",
+        action: "close",
+        reason: "inactive",
+        topicRecordId: "topic:telegram:-1001:100",
+      },
+    ],
+    status: "pending",
+    supergroupId: "-1001",
     updatedAt: 1000,
     ...overrides,
   };
@@ -709,5 +775,38 @@ describe("MessagingStore", () => {
 
     expect(binding?.authorizedActorIds).toEqual(["stable-user-id"]);
     expect(binding?.authorizedActorIds).not.toContain("Mutable Username");
+  });
+
+  it("persists managed topics, thread-topic links, and cleanup proposals", async () => {
+    const { store } = await createStore();
+
+    await store.upsertManagedTopic(buildManagedTopic());
+    await store.upsertThreadTopicLink(buildTopicLink());
+    await store.upsertTopicCleanupProposal(buildCleanupProposal());
+
+    await expect(
+      store.findManagedTopicByConversation({
+        channel: "telegram",
+        supergroupId: "-1001",
+        topicId: "100",
+      }),
+    ).resolves.toMatchObject({
+      id: "topic:telegram:-1001:100",
+      source: "owned",
+    });
+    await expect(
+      store.findThreadTopicLink({
+        backend: "codex",
+        channel: "telegram",
+        supergroupId: "-1001",
+        threadId: "thread-1",
+      }),
+    ).resolves.toMatchObject({
+      topicRecordId: "topic:telegram:-1001:100",
+    });
+    await expect(store.getTopicCleanupProposal("proposal-1")).resolves.toMatchObject({
+      status: "pending",
+      items: [expect.objectContaining({ action: "close" })],
+    });
   });
 });

--- a/apps/desktop/src/main/messaging/core/messaging-adapter.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-adapter.ts
@@ -49,6 +49,12 @@ import type {
   MessagingAdapterRenderingPreferencesUpdate,
   MessagingChannelRef,
   MessagingChannelKind,
+  MessagingManagedConversationActionRequest,
+  MessagingManagedConversationActionResult,
+  MessagingManagedConversationCreateRequest,
+  MessagingManagedConversationCreateResult,
+  MessagingManagedConversationRightsRequest,
+  MessagingManagedConversationRightsResult,
   MessagingReconnectInfo,
   MessagingSurfaceIntent,
 } from "@pwragent/messaging-interface";
@@ -91,6 +97,21 @@ export type MessagingAdapter = {
   setConversationTitle?(
     request: MessagingConversationTitleUpdateRequest,
   ): Promise<MessagingConversationTitleUpdateResult>;
+  getManagedConversationRights?(
+    request: MessagingManagedConversationRightsRequest,
+  ): Promise<MessagingManagedConversationRightsResult>;
+  createManagedConversation?(
+    request: MessagingManagedConversationCreateRequest,
+  ): Promise<MessagingManagedConversationCreateResult>;
+  closeManagedConversation?(
+    request: MessagingManagedConversationActionRequest,
+  ): Promise<MessagingManagedConversationActionResult>;
+  reopenManagedConversation?(
+    request: MessagingManagedConversationActionRequest,
+  ): Promise<MessagingManagedConversationActionResult>;
+  deleteManagedConversation?(
+    request: MessagingManagedConversationActionRequest,
+  ): Promise<MessagingManagedConversationActionResult>;
 };
 
 export type MessagingBackendBridge = {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -46,12 +46,18 @@ import type {
   MessagingAdapterState,
   MessagingJsonValue,
   MessagingMessageIntent,
+  MessagingManagedConversationActionResult,
+  MessagingManagedConversationOperationSupport,
+  MessagingManagedTopicRecord,
   MessagingMonitorState,
   MessagingMonitorSubscriptionRecord,
   MessagingPendingIntentRecord,
   MessagingStreamUpdateIntent,
   MessagingSurfaceRef,
   MessagingSurfaceIntent,
+  MessagingThreadTopicLinkRecord,
+  MessagingTopicCleanupProposalItem,
+  MessagingTopicCleanupProposalRecord,
 } from "@pwragent/messaging-interface";
 import { MESSAGING_CALLBACK_HANDLE_TTL_MS } from "@pwragent/messaging-interface";
 import {
@@ -178,6 +184,9 @@ type MonitorCommandAction =
   | { kind: "start" }
   | { kind: "stop" }
   | { kind: "refresh" }
+  | { kind: "topics-adopt" }
+  | { kind: "topics-cleanup" }
+  | { kind: "topics-fanout" }
   | { kind: "cycle-interval" }
   | { kind: "cycle-pinned" }
   | { kind: "cycle-recent" }
@@ -576,8 +585,9 @@ export class MessagingController {
     // source of truth for routing. Log and continue.
     try {
       await this.refreshBindingFromInbound(event);
+      await this.observeManagedTopicFromInbound(event);
     } catch (error) {
-      this.logger.debug?.("messaging binding refresh failed", {
+      this.logger.debug?.("messaging inbound metadata refresh failed", {
         eventId: event.id,
         platform: event.channel.channel,
         error: error instanceof Error ? error.message : String(error),
@@ -4218,6 +4228,14 @@ export class MessagingController {
 
   private async handleMonitorCommand(event: MessagingInboundCommandEvent): Promise<void> {
     const action = normalizeMonitorCommandAction(event.args);
+    if (
+      action.kind === "topics-adopt" ||
+      action.kind === "topics-cleanup" ||
+      action.kind === "topics-fanout"
+    ) {
+      await this.handleMonitorTopicCommand(event, action);
+      return;
+    }
     if (action.kind === "stop") {
       await this.stopMonitoringForChannel(event);
       return;
@@ -4230,12 +4248,552 @@ export class MessagingController {
     event: MessagingInboundCallbackEvent,
     actionId: string,
   ): Promise<void> {
+    if (actionId.startsWith("monitor:topics:")) {
+      await this.handleMonitorTopicCallback(event, actionId);
+      return;
+    }
     if (actionId === "monitor:stop") {
       await this.stopMonitoringForChannel(event);
       return;
     }
 
     await this.enableAndRenderChannelMonitor(event, normalizeMonitorCallbackAction(actionId));
+  }
+
+  private async handleMonitorTopicCommand(
+    event: MessagingInboundCommandEvent,
+    action: Extract<
+      MonitorCommandAction,
+      { kind: "topics-adopt" | "topics-cleanup" | "topics-fanout" }
+    >,
+  ): Promise<void> {
+    if (event.channel.conversation.kind !== "topic") {
+      await this.deliver(
+        buildErrorIntent({
+          id: this.newIntentId("topics-not-topic"),
+          createdAt: this.now(),
+          title: "Telegram topic required",
+          body: "Run this from a Telegram supergroup topic so PwrAgent can infer the supergroup and topic route.",
+          recoverable: true,
+        }),
+        undefined,
+        event,
+      );
+      return;
+    }
+    if (event.channel.channel !== "telegram") {
+      await this.deliver(
+        buildErrorIntent({
+          id: this.newIntentId("topics-unsupported"),
+          createdAt: this.now(),
+          title: "Topic management unavailable",
+          body: "Topic cleanup and fanout are currently implemented for Telegram supergroup topics only.",
+          recoverable: true,
+        }),
+        undefined,
+        event,
+      );
+      return;
+    }
+
+    const topic = await this.upsertManagedTopicFromChannel(event, {
+      source: "owned",
+      lifecycle: "open",
+      recommendation: "keep",
+    });
+    if (action.kind === "topics-cleanup") {
+      await this.renderTopicCleanupProposal(event, topic);
+      return;
+    }
+    if (action.kind === "topics-fanout") {
+      await this.runTopicMonitorFanout(event, topic);
+      return;
+    }
+
+    await this.renderTopicControlStatus(event, topic);
+  }
+
+  private async handleMonitorTopicCallback(
+    event: MessagingInboundCallbackEvent,
+    actionId: string,
+  ): Promise<void> {
+    if (actionId === "monitor:topics:cleanup") {
+      await this.handleMonitorTopicCommand(
+        {
+          ...event,
+          kind: "command",
+          command: "monitor",
+          args: ["topics", "cleanup"],
+          rawText: "/monitor topics cleanup",
+        },
+        { kind: "topics-cleanup" },
+      );
+      return;
+    }
+    if (actionId === "monitor:topics:fanout") {
+      await this.handleMonitorTopicCommand(
+        {
+          ...event,
+          kind: "command",
+          command: "monitor",
+          args: ["topics", "fanout"],
+          rawText: "/monitor topics fanout",
+        },
+        { kind: "topics-fanout" },
+      );
+      return;
+    }
+    const approvePrefix = "monitor:topics:approve:";
+    if (!actionId.startsWith(approvePrefix)) {
+      await this.handleMonitorTopicCommand(
+        {
+          ...event,
+          kind: "command",
+          command: "monitor",
+          args: ["topics"],
+          rawText: "/monitor topics",
+        },
+        { kind: "topics-adopt" },
+      );
+      return;
+    }
+
+    const approvalKey = actionId.slice(approvePrefix.length);
+    const separatorIndex = approvalKey.lastIndexOf(":");
+    const proposalId = separatorIndex > 0 ? approvalKey.slice(0, separatorIndex) : "";
+    const itemId = separatorIndex > 0 ? approvalKey.slice(separatorIndex + 1) : "";
+    if (!proposalId || !itemId) {
+      await this.deliverInvalidTopicApproval(event);
+      return;
+    }
+    const proposal = await this.options.store.getTopicCleanupProposal(proposalId);
+    const item = proposal?.items.find((candidate) => candidate.id === itemId);
+    if (!proposal || proposal.status !== "pending" || !item) {
+      await this.deliverInvalidTopicApproval(event);
+      return;
+    }
+
+    const topic = await this.options.store.getManagedTopic(item.topicRecordId);
+    if (!topic) {
+      await this.deliverInvalidTopicApproval(event);
+      return;
+    }
+
+    let result: MessagingManagedConversationActionResult | undefined;
+    if (item.action === "close") {
+      result = await this.options.adapter.closeManagedConversation?.({
+        actor: event.actor,
+        channel: topicChannelRef(topic),
+        routingState: topic.routingState,
+      });
+    } else if (item.action === "delete") {
+      result = await this.options.adapter.deleteManagedConversation?.({
+        actor: event.actor,
+        channel: topicChannelRef(topic),
+        routingState: topic.routingState,
+      });
+    }
+    const now = this.now();
+    if (!result || result.outcome !== "updated") {
+      await this.deliver(
+        buildErrorIntent({
+          id: this.newIntentId("topics-approval-failed"),
+          createdAt: now,
+          title: "Topic action failed",
+          body: result?.errorMessage ?? "The Telegram adapter could not apply that topic action.",
+          recoverable: true,
+        }),
+        undefined,
+        event,
+      );
+      return;
+    }
+
+    await this.options.store.upsertManagedTopic({
+      ...topic,
+      closedAt: item.action === "close" ? now : topic.closedAt,
+      deletedAt: item.action === "delete" ? now : topic.deletedAt,
+      lifecycle: item.action === "delete" ? "deleted" : "closed",
+      recommendation: item.action,
+      updatedAt: now,
+    });
+    await this.options.store.upsertTopicCleanupProposal({
+      ...proposal,
+      appliedAt: now,
+      status: "applied",
+      updatedAt: now,
+    });
+    await this.deliver(
+      buildConfirmationIntent({
+        id: this.newIntentId("topics-action-applied"),
+        capabilityProfile: this.capabilityProfile,
+        createdAt: now,
+        title: "Topic action applied",
+        body: `${item.action === "delete" ? "Deleted" : "Closed"} ${topic.title ?? topic.topicId}.`,
+        actions: [],
+      }),
+      undefined,
+      event,
+    );
+  }
+
+  private async deliverInvalidTopicApproval(
+    event: MessagingInboundEvent,
+  ): Promise<void> {
+    await this.deliver(
+      buildErrorIntent({
+        id: this.newIntentId("topics-approval-invalid"),
+        createdAt: this.now(),
+        title: "Topic action expired",
+        body: "That cleanup proposal is no longer active. Run /monitor topics cleanup to refresh it.",
+        recoverable: true,
+      }),
+      undefined,
+      event,
+    );
+  }
+
+  private async renderTopicControlStatus(
+    event: MessagingInboundEvent,
+    topic: MessagingManagedTopicRecord,
+  ): Promise<void> {
+    const rights = await this.options.adapter.getManagedConversationRights?.({
+      actor: event.actor,
+      channel: event.channel,
+      routingState: event.routingState,
+    });
+    const topics = await this.options.store.findManagedTopicsForSupergroup({
+      channel: event.channel.channel,
+      supergroupId: topic.supergroupId,
+    });
+    const rightsLines = rights
+      ? formatManagedTopicRights(rights.operations)
+      : ["Topic operations: unsupported by this adapter"];
+    await this.deliver(
+      buildConfirmationIntent({
+        id: this.newIntentId("topics-control"),
+        capabilityProfile: this.capabilityProfile,
+        createdAt: this.now(),
+        title: "PwrAgent topic owner",
+        body: [
+          `Control topic: ${topic.title ?? topic.topicId}`,
+          `Known topics: ${topics.length}`,
+          "",
+          ...rightsLines,
+          "",
+          "Use /monitor topics cleanup for a dry-run cleanup proposal.",
+          "Use /monitor topics fanout to create or reuse per-thread monitor topics.",
+        ].join("\n"),
+        actions: [
+          {
+            id: "monitor:topics:cleanup",
+            label: "Dry Run Cleanup",
+            style: "secondary",
+            fallbackText: "/monitor topics cleanup",
+          },
+          {
+            id: "monitor:topics:fanout",
+            label: "Fanout",
+            style: "secondary",
+            fallbackText: "/monitor topics fanout",
+          },
+        ],
+      }),
+      undefined,
+      event,
+    );
+  }
+
+  private async renderTopicCleanupProposal(
+    event: MessagingInboundEvent,
+    controlTopic: MessagingManagedTopicRecord,
+  ): Promise<void> {
+    const topics = await this.options.store.findManagedTopicsForSupergroup({
+      channel: event.channel.channel,
+      supergroupId: controlTopic.supergroupId,
+    });
+    const now = this.now();
+    const items = topics
+      .filter((topic) => topic.lifecycle !== "deleted")
+      .map((topic): MessagingTopicCleanupProposalItem => {
+        const action =
+          topic.id === controlTopic.id ||
+          topic.source === "owned" ||
+          topic.source === "linked"
+            ? "keep"
+            : topic.lifecycle === "closed"
+              ? "delete"
+              : "close";
+        return {
+          id: topic.topicId,
+          action,
+          reason:
+            action === "keep"
+              ? "owned or linked topic"
+              : action === "delete"
+                ? "already closed known topic"
+                : "known topic not owned or linked to a PwrAgent thread",
+          title: topic.title,
+          topicRecordId: topic.id,
+        };
+      });
+    const proposal: MessagingTopicCleanupProposalRecord = {
+      id: `topic-cleanup:${controlTopic.supergroupId}:${now}`,
+      authorizedActorIds: this.monitorAuthorizedActorIds(event),
+      channel: event.channel.channel,
+      controlTopicRecordId: controlTopic.id,
+      createdAt: now,
+      items,
+      status: "pending",
+      supergroupId: controlTopic.supergroupId,
+      updatedAt: now,
+    };
+    await this.options.store.upsertTopicCleanupProposal(proposal);
+    const actions = items
+      .filter((item) => item.action === "close" || item.action === "delete")
+      .slice(0, 6)
+      .map((item) => ({
+        id: `monitor:topics:approve:${proposal.id}:${item.id}`,
+        label: `${item.action === "delete" ? "Delete" : "Close"} ${item.title ?? item.id}`,
+        style: item.action === "delete" ? "danger" as const : "secondary" as const,
+        fallbackText: `/monitor topics approve ${proposal.id} ${item.id}`,
+      }));
+    await this.deliver(
+      buildConfirmationIntent({
+        id: this.newIntentId("topics-cleanup"),
+        capabilityProfile: this.capabilityProfile,
+        createdAt: now,
+        title: "Topic cleanup dry run",
+        body: formatTopicCleanupProposalBody(items),
+        actions,
+      }),
+      undefined,
+      event,
+    );
+  }
+
+  private async runTopicMonitorFanout(
+    event: MessagingInboundEvent,
+    controlTopic: MessagingManagedTopicRecord,
+  ): Promise<void> {
+    if (!this.options.adapter.createManagedConversation) {
+      await this.deliver(
+        buildErrorIntent({
+          id: this.newIntentId("topics-fanout-unsupported"),
+          createdAt: this.now(),
+          title: "Topic creation unavailable",
+          body: "This adapter cannot create managed topics.",
+          recoverable: true,
+        }),
+        undefined,
+        event,
+      );
+      return;
+    }
+
+    const snapshot = await this.options.backend.getNavigationSnapshot({ backend: "all" });
+    const selected = selectMonitorThreads({ navigation: snapshot }).threads.slice(0, 3);
+    const created: string[] = [];
+    const reused: string[] = [];
+    const failed: string[] = [];
+    for (const thread of selected) {
+      const existing = await this.options.store.findThreadTopicLink({
+        backend: thread.source,
+        channel: event.channel.channel,
+        supergroupId: controlTopic.supergroupId,
+        threadId: thread.id,
+      });
+      if (existing) {
+        const topic = await this.options.store.getManagedTopic(existing.topicRecordId);
+        if (topic) {
+          await this.ensureManagedTopicBinding(event, topic, thread);
+        }
+        reused.push(thread.title);
+        continue;
+      }
+      const result = await this.options.adapter.createManagedConversation({
+        actor: event.actor,
+        parent: event.channel,
+        routingState: event.routingState,
+        title: topicTitleForThread(thread),
+      });
+      if (result.outcome !== "created" || !result.conversation) {
+        failed.push(thread.title);
+        continue;
+      }
+      const topic = await this.options.store.upsertManagedTopic(
+        managedTopicRecordFromConversation({
+          actorIds: this.monitorAuthorizedActorIds(event),
+          channel: event.channel.channel,
+          conversation: result.conversation,
+          now: this.now(),
+          routingState: result.routingState,
+          source: "linked",
+        }),
+      );
+      await this.options.store.upsertThreadTopicLink({
+        id: `topic-link:${event.channel.channel}:${controlTopic.supergroupId}:${thread.source}:${thread.id}`,
+        backend: thread.source,
+        channel: event.channel.channel,
+        createdAt: this.now(),
+        supergroupId: controlTopic.supergroupId,
+        threadId: thread.id,
+        topicRecordId: topic.id,
+        updatedAt: this.now(),
+      });
+      const bindingOutcome = await this.ensureManagedTopicBinding(event, topic, thread);
+      if (bindingOutcome === "conflict") {
+        failed.push(thread.title);
+        continue;
+      }
+      await this.deliverTopicSeed(event, topic, thread);
+      created.push(thread.title);
+    }
+
+    await this.deliver(
+      buildConfirmationIntent({
+        id: this.newIntentId("topics-fanout"),
+        capabilityProfile: this.capabilityProfile,
+        createdAt: this.now(),
+        title: "Topic fanout complete",
+        body: [
+          `Created: ${created.length}${created.length ? ` (${created.join(", ")})` : ""}`,
+          `Reused: ${reused.length}${reused.length ? ` (${reused.join(", ")})` : ""}`,
+          `Failed: ${failed.length}${failed.length ? ` (${failed.join(", ")})` : ""}`,
+        ].join("\n"),
+        actions: [],
+      }),
+      undefined,
+      event,
+    );
+  }
+
+  private async deliverTopicSeed(
+    event: MessagingInboundEvent,
+    topic: MessagingManagedTopicRecord,
+    thread: NavigationThreadSummary,
+  ): Promise<void> {
+    const project =
+      thread.linkedDirectories[0]?.label ??
+      thread.linkedDirectories[0]?.path;
+    await this.deliver({
+      id: this.newIntentId("topic-seed"),
+      kind: "message",
+      createdAt: this.now(),
+      audit: buildMessagingAuditContext({
+        action: "topics.seed",
+        actor: event.actor,
+        backend: thread.source,
+        channel: topicChannelRef(topic),
+        now: this.now(),
+        threadId: thread.id,
+      }),
+      parts: [
+        {
+          type: "text",
+          text: [
+            `Monitoring: ${thread.title}`,
+            `Backend: ${thread.source}`,
+            project ? `Project: ${project}` : undefined,
+            thread.updatedAt ? `Updated: ${formatTimeOfDay(thread.updatedAt)}` : undefined,
+            "",
+            "This topic is attached to the thread for follow-up messages.",
+          ].filter(Boolean).join("\n"),
+        },
+      ],
+    });
+  }
+
+  private async ensureManagedTopicBinding(
+    event: MessagingInboundEvent,
+    topic: MessagingManagedTopicRecord,
+    thread: NavigationThreadSummary,
+  ): Promise<"bound" | "existing" | "conflict"> {
+    const channel = topicChannelRef(topic);
+    const existing = await this.options.store.findActiveBindingForChannel(channel);
+    if (existing) {
+      if (existing.backend === thread.source && existing.threadId === thread.id) {
+        return "existing";
+      }
+      this.logger.debug?.("managed topic already bound to another thread", {
+        backend: existing.backend,
+        bindingId: existing.id,
+        threadId: existing.threadId,
+        topicId: topic.topicId,
+      });
+      return "conflict";
+    }
+
+    await this.bindChannelToThread(
+      {
+        ...event,
+        id: `${event.id}:topic-bind:${topic.id}`,
+        kind: "command",
+        channel,
+        command: "monitor",
+        args: ["topics", "fanout"],
+        rawText: "/monitor topics fanout",
+        receivedAt: this.now(),
+        routingState: topic.routingState ?? event.routingState,
+      } satisfies MessagingInboundCommandEvent,
+      {
+        backend: thread.source,
+        threadId: thread.id,
+      },
+    );
+    return "bound";
+  }
+
+  private async observeManagedTopicFromInbound(
+    event: MessagingInboundEvent,
+  ): Promise<void> {
+    if (
+      event.channel.conversation.kind !== "topic" ||
+      !event.channel.conversation.parentId
+    ) {
+      return;
+    }
+    await this.upsertManagedTopicFromChannel(event, {
+      source: "observed",
+      lifecycle: "open",
+    });
+  }
+
+  private async upsertManagedTopicFromChannel(
+    event: MessagingInboundEvent,
+    options: Pick<
+      MessagingManagedTopicRecord,
+      "source" | "lifecycle" | "recommendation"
+    >,
+  ): Promise<MessagingManagedTopicRecord> {
+    const now = this.now();
+    const existing = await this.options.store.findManagedTopicByConversation({
+      channel: event.channel.channel,
+      supergroupId: event.channel.conversation.parentId ?? "",
+      topicId: event.channel.conversation.id,
+    });
+    return await this.options.store.upsertManagedTopic({
+      ...managedTopicRecordFromConversation({
+        actorIds: this.monitorAuthorizedActorIds(event),
+        channel: event.channel.channel,
+        conversation: event.channel.conversation,
+        now,
+        routingState: event.routingState,
+        source: options.source,
+      }),
+      ...existing,
+      authorizedActorIds: existing?.authorizedActorIds.length
+        ? existing.authorizedActorIds
+        : this.monitorAuthorizedActorIds(event),
+      lastObservedAt: now,
+      lifecycle: options.lifecycle,
+      recommendation: options.recommendation ?? existing?.recommendation,
+      routingState: event.routingState ?? existing?.routingState,
+      source: existing?.source === "owned" || existing?.source === "linked"
+        ? existing.source
+        : options.source,
+      updatedAt: now,
+    });
   }
 
   private async enableAndRenderChannelMonitor(
@@ -7811,6 +8369,24 @@ function normalizeMonitorCommandAction(
   if (normalized === "refresh" || normalized === "now") {
     return { kind: "refresh" };
   }
+  if (normalized === "topic" || normalized === "topics") {
+    const topicAction = args?.[1]?.trim().toLowerCase();
+    if (
+      topicAction === "cleanup" ||
+      topicAction === "clean" ||
+      topicAction === "sweep"
+    ) {
+      return { kind: "topics-cleanup" };
+    }
+    if (
+      topicAction === "fanout" ||
+      topicAction === "fan-out" ||
+      topicAction === "attach"
+    ) {
+      return { kind: "topics-fanout" };
+    }
+    return { kind: "topics-adopt" };
+  }
   if (
     normalized === "interval" ||
     normalized === "every" ||
@@ -7982,6 +8558,9 @@ function resolveMonitorStateOptions(
     case "refresh":
     case "start":
     case "stop":
+    case "topics-adopt":
+    case "topics-cleanup":
+    case "topics-fanout":
       return {
         intervalMs: currentIntervalMs,
         pinnedThreadLimit: currentPinned,
@@ -8057,6 +8636,89 @@ function parseMonitorBooleanArg(arg: string | undefined): boolean | undefined {
 
 function buildMonitorSubscriptionId(channel: MessagingChannelRef): string {
   return `monitor:${buildMessagingConversationKey(channel)}`;
+}
+
+function managedTopicRecordFromConversation(params: {
+  actorIds: string[];
+  channel: MessagingChannelKind;
+  conversation: MessagingChannelRef["conversation"];
+  now: number;
+  routingState?: MessagingAdapterState;
+  source: MessagingManagedTopicRecord["source"];
+}): MessagingManagedTopicRecord {
+  const supergroupId = params.conversation.parentId ?? params.conversation.id;
+  const topicId = params.conversation.kind === "topic"
+    ? params.conversation.id
+    : "";
+  return {
+    id: `topic:${params.channel}:${supergroupId}:${topicId}`,
+    authorizedActorIds: params.actorIds,
+    channel: params.channel,
+    conversation: params.conversation,
+    createdAt: params.now,
+    lastObservedAt: params.now,
+    lifecycle: "open",
+    routingState: params.routingState,
+    source: params.source,
+    supergroupId,
+    title: params.conversation.title,
+    topicId,
+    updatedAt: params.now,
+  };
+}
+
+function topicChannelRef(topic: MessagingManagedTopicRecord): MessagingChannelRef {
+  return {
+    channel: topic.channel,
+    conversation: topic.conversation,
+  };
+}
+
+function topicTitleForThread(thread: NavigationThreadSummary): string {
+  const trimmed = thread.title.trim();
+  return trimmed.length > 0 ? trimmed.slice(0, 120) : `${thread.source} thread`;
+}
+
+function formatManagedTopicRights(
+  operations: readonly MessagingManagedConversationOperationSupport[],
+): string[] {
+  return operations.map((operation) => {
+    const label =
+      operation.operation === "create_child"
+        ? "create"
+        : operation.operation;
+    if (operation.supported) {
+      return `${label}: available`;
+    }
+    return `${label}: unavailable${operation.missingPermission ? ` (${operation.missingPermission})` : operation.reason ? ` (${operation.reason})` : ""}`;
+  });
+}
+
+function formatTopicCleanupProposalBody(
+  items: readonly MessagingTopicCleanupProposalItem[],
+): string {
+  if (items.length === 0) {
+    return [
+      "No known topics yet.",
+      "",
+      "Telegram bots cannot list every historical topic. Adopt topics from inside the topic first, then run cleanup again.",
+    ].join("\n");
+  }
+  const grouped = {
+    keep: items.filter((item) => item.action === "keep"),
+    close: items.filter((item) => item.action === "close"),
+    delete: items.filter((item) => item.action === "delete"),
+  };
+  return [
+    "Dry run only. No topic will be closed or deleted until you approve one of the actions below.",
+    "",
+    `Keep: ${grouped.keep.length}`,
+    ...grouped.keep.slice(0, 5).map((item) => `- ${item.title ?? item.id}: ${item.reason}`),
+    `Close candidates: ${grouped.close.length}`,
+    ...grouped.close.slice(0, 5).map((item) => `- ${item.title ?? item.id}: ${item.reason}`),
+    `Delete candidates: ${grouped.delete.length}`,
+    ...grouped.delete.slice(0, 5).map((item) => `- ${item.title ?? item.id}: ${item.reason}`),
+  ].join("\n");
 }
 
 /**

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -4248,7 +4248,7 @@ export class MessagingController {
     event: MessagingInboundCallbackEvent,
     actionId: string,
   ): Promise<void> {
-    if (actionId.startsWith("monitor:topics:")) {
+    if (actionId === "monitor:topics" || actionId.startsWith("monitor:topics:")) {
       await this.handleMonitorTopicCallback(event, actionId);
       return;
     }
@@ -4267,20 +4267,6 @@ export class MessagingController {
       { kind: "topics-adopt" | "topics-cleanup" | "topics-fanout" }
     >,
   ): Promise<void> {
-    if (event.channel.conversation.kind !== "topic") {
-      await this.deliver(
-        buildErrorIntent({
-          id: this.newIntentId("topics-not-topic"),
-          createdAt: this.now(),
-          title: "Telegram topic required",
-          body: "Run this from a Telegram supergroup topic so PwrAgent can infer the supergroup and topic route.",
-          recoverable: true,
-        }),
-        undefined,
-        event,
-      );
-      return;
-    }
     if (event.channel.channel !== "telegram") {
       await this.deliver(
         buildErrorIntent({
@@ -4296,21 +4282,137 @@ export class MessagingController {
       return;
     }
 
-    const topic = await this.upsertManagedTopicFromChannel(event, {
-      source: "owned",
-      lifecycle: "open",
-      recommendation: "keep",
-    });
+    const topic = await this.resolveMonitorControlTopic(event);
+    if (!topic) {
+      return;
+    }
+    const topicEvent = this.eventForManagedTopic(
+      event,
+      topic,
+      action.kind === "topics-cleanup"
+        ? ["topics", "cleanup"]
+        : action.kind === "topics-fanout"
+          ? ["topics", "fanout"]
+          : ["topics"],
+    );
     if (action.kind === "topics-cleanup") {
-      await this.renderTopicCleanupProposal(event, topic);
+      await this.renderTopicCleanupProposal(topicEvent, topic);
       return;
     }
     if (action.kind === "topics-fanout") {
-      await this.runTopicMonitorFanout(event, topic);
+      await this.runTopicMonitorFanout(topicEvent, topic);
       return;
     }
 
-    await this.renderTopicControlStatus(event, topic);
+    await this.renderTopicControlStatus(topicEvent, topic);
+  }
+
+  private supportsMonitorTopicControls(channel: MessagingChannelRef): boolean {
+    return channel.channel === "telegram" &&
+      (channel.conversation.kind === "topic" || channel.conversation.kind === "channel");
+  }
+
+  private async resolveMonitorControlTopic(
+    event: MessagingInboundCommandEvent,
+  ): Promise<MessagingManagedTopicRecord | undefined> {
+    if (event.channel.conversation.kind === "topic") {
+      return await this.upsertManagedTopicFromChannel(event, {
+        source: "owned",
+        lifecycle: "open",
+        recommendation: "keep",
+      });
+    }
+
+    if (event.channel.conversation.kind !== "channel") {
+      await this.deliver(
+        buildErrorIntent({
+          id: this.newIntentId("topics-not-supergroup"),
+          createdAt: this.now(),
+          title: "Telegram supergroup required",
+          body: "Open Monitor from a Telegram supergroup or one of its topics so PwrAgent can manage forum topics.",
+          recoverable: true,
+        }),
+        undefined,
+        event,
+      );
+      return undefined;
+    }
+
+    const supergroupId = event.channel.conversation.id;
+    const knownTopics = await this.options.store.findManagedTopicsForSupergroup({
+      channel: event.channel.channel,
+      supergroupId,
+    });
+    const existing = knownTopics.find(
+      (topic) => topic.source === "owned" && topic.lifecycle !== "deleted",
+    );
+    if (existing) {
+      return existing;
+    }
+
+    if (!this.options.adapter.createManagedConversation) {
+      await this.deliver(
+        buildErrorIntent({
+          id: this.newIntentId("topics-create-unsupported"),
+          createdAt: this.now(),
+          title: "Topic creation unavailable",
+          body: "This adapter cannot create a PwrAgent control topic. Run this from an existing Telegram topic to adopt it instead.",
+          recoverable: true,
+        }),
+        undefined,
+        event,
+      );
+      return undefined;
+    }
+
+    const result = await this.options.adapter.createManagedConversation({
+      actor: event.actor,
+      parent: event.channel,
+      routingState: event.routingState,
+      title: "PwrAgent topic owner",
+    });
+    if (result.outcome !== "created" || !result.conversation) {
+      await this.deliver(
+        buildErrorIntent({
+          id: this.newIntentId("topics-create-failed"),
+          createdAt: this.now(),
+          title: "Topic creation failed",
+          body: result.errorMessage ?? "Telegram could not create the PwrAgent control topic.",
+          recoverable: true,
+        }),
+        undefined,
+        event,
+      );
+      return undefined;
+    }
+
+    return await this.options.store.upsertManagedTopic(
+      managedTopicRecordFromConversation({
+        actorIds: this.monitorAuthorizedActorIds(event),
+        channel: event.channel.channel,
+        conversation: result.conversation,
+        now: this.now(),
+        routingState: result.routingState,
+        source: "owned",
+      }),
+    );
+  }
+
+  private eventForManagedTopic(
+    event: MessagingInboundEvent,
+    topic: MessagingManagedTopicRecord,
+    args: string[],
+  ): MessagingInboundCommandEvent {
+    return {
+      ...event,
+      id: `${event.id}:topic:${topic.id}`,
+      kind: "command",
+      channel: topicChannelRef(topic),
+      command: "monitor",
+      args,
+      rawText: `/monitor ${args.join(" ")}`,
+      routingState: topic.routingState ?? event.routingState,
+    };
   }
 
   private async handleMonitorTopicCallback(
@@ -7165,6 +7267,7 @@ export class MessagingController {
       id: this.newIntentId("monitor"),
       navigation: snapshot,
       snippetsByThreadKey,
+      topicControls: this.supportsMonitorTopicControls(event?.channel ?? binding.channel),
     });
     const result = await this.deliver(intent, binding, event);
     const latestBinding = await this.options.store.getBinding(binding.id);
@@ -7221,6 +7324,7 @@ export class MessagingController {
         monitorSurface: subscription.monitorSurface,
         navigation: snapshot,
         snippetsByThreadKey,
+        topicControls: this.supportsMonitorTopicControls(event?.channel ?? subscription.channel),
       }),
       allowedActorIds: subscription.authorizedActorIds,
       ...(event

--- a/apps/desktop/src/main/messaging/core/messaging-migrations.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-migrations.ts
@@ -3,8 +3,11 @@ import type {
   MessagingBrowseSessionRecord,
   MessagingCallbackHandleRecord,
   MessagingDeliveryResult,
+  MessagingManagedTopicRecord,
   MessagingMonitorSubscriptionRecord,
   MessagingPendingIntentRecord,
+  MessagingThreadTopicLinkRecord,
+  MessagingTopicCleanupProposalRecord,
 } from "@pwragent/messaging-interface";
 
 // SCHEMA-DRIFT-CHECKPOINT: when bumping CURRENT_MESSAGING_STORE_VERSION,
@@ -30,6 +33,9 @@ export type MessagingStoreData = {
   bindings: Record<string, MessagingBindingRecord>;
   callbackHandles: Record<string, MessagingCallbackHandleRecord>;
   monitorSubscriptions: Record<string, MessagingMonitorSubscriptionRecord>;
+  topicCleanupProposals: Record<string, MessagingTopicCleanupProposalRecord>;
+  topicLinks: Record<string, MessagingThreadTopicLinkRecord>;
+  topics: Record<string, MessagingManagedTopicRecord>;
   pendingIntents: Record<string, MessagingPendingIntentRecord>;
   deliveries: Record<string, MessagingDeliveryRecord>;
 };
@@ -40,6 +46,9 @@ const EMPTY_MESSAGING_STORE_DATA: MessagingStoreData = {
   bindings: {},
   callbackHandles: {},
   monitorSubscriptions: {},
+  topicCleanupProposals: {},
+  topicLinks: {},
+  topics: {},
   pendingIntents: {},
   deliveries: {},
 };
@@ -59,6 +68,12 @@ export function migrateMessagingStoreData(raw: unknown): MessagingStoreData {
       record.monitorSubscriptions,
       isMessagingMonitorSubscriptionRecord,
     ),
+    topicCleanupProposals: migrateRecord(
+      record.topicCleanupProposals,
+      isMessagingTopicCleanupProposalRecord,
+    ),
+    topicLinks: migrateRecord(record.topicLinks, isMessagingThreadTopicLinkRecord),
+    topics: migrateRecord(record.topics, isMessagingManagedTopicRecord),
     pendingIntents: migrateRecord(record.pendingIntents, isMessagingPendingIntentRecord),
     deliveries: migrateRecord(record.deliveries, isMessagingDeliveryRecord),
   };
@@ -150,6 +165,61 @@ function isMessagingMonitorSubscriptionRecord(
       typeof monitor.enabled === "boolean" &&
       typeof monitor.intervalMs === "number" &&
       typeof monitor.updatedAt === "number",
+  );
+}
+
+function isMessagingManagedTopicRecord(
+  value: unknown,
+): value is MessagingManagedTopicRecord {
+  const record = asRecord(value);
+  const conversation = asRecord(record?.conversation);
+  return Boolean(
+    record &&
+      typeof record.id === "string" &&
+      typeof record.channel === "string" &&
+      typeof record.supergroupId === "string" &&
+      typeof record.topicId === "string" &&
+      typeof conversation?.id === "string" &&
+      typeof conversation?.kind === "string" &&
+      Array.isArray(record.authorizedActorIds) &&
+      typeof record.createdAt === "number" &&
+      typeof record.updatedAt === "number" &&
+      typeof record.lifecycle === "string" &&
+      typeof record.source === "string",
+  );
+}
+
+function isMessagingThreadTopicLinkRecord(
+  value: unknown,
+): value is MessagingThreadTopicLinkRecord {
+  const record = asRecord(value);
+  return Boolean(
+    record &&
+      typeof record.id === "string" &&
+      typeof record.backend === "string" &&
+      typeof record.channel === "string" &&
+      typeof record.supergroupId === "string" &&
+      typeof record.threadId === "string" &&
+      typeof record.topicRecordId === "string" &&
+      typeof record.createdAt === "number" &&
+      typeof record.updatedAt === "number",
+  );
+}
+
+function isMessagingTopicCleanupProposalRecord(
+  value: unknown,
+): value is MessagingTopicCleanupProposalRecord {
+  const record = asRecord(value);
+  return Boolean(
+    record &&
+      typeof record.id === "string" &&
+      typeof record.channel === "string" &&
+      typeof record.supergroupId === "string" &&
+      Array.isArray(record.authorizedActorIds) &&
+      Array.isArray(record.items) &&
+      typeof record.createdAt === "number" &&
+      typeof record.updatedAt === "number" &&
+      typeof record.status === "string",
   );
 }
 

--- a/apps/desktop/src/main/messaging/core/messaging-monitor-card.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-monitor-card.ts
@@ -59,6 +59,7 @@ export function buildMonitorStatusIntent(params: {
   navigation: NavigationSnapshot;
   snippetsByThreadKey?: ReadonlyMap<string, string>;
   threadLimit?: number;
+  topicControls?: boolean;
 }): MessagingStatusIntent {
   const monitor = params.binding?.monitor ?? params.monitor;
   const monitorSurface = params.binding?.monitorSurface ?? params.monitorSurface;
@@ -114,6 +115,7 @@ export function buildMonitorStatusIntent(params: {
       recentThreadLimit: selection.recentThreadLimit,
       showSnippets: monitor?.showLastResponseSnippet === true,
       showStatusLine: monitor?.showStatusLine === true,
+      topicControls: params.topicControls === true,
     }),
   };
 }
@@ -204,6 +206,7 @@ function buildMonitorActions(params: {
   recentThreadLimit: number;
   showSnippets: boolean;
   showStatusLine: boolean;
+  topicControls: boolean;
 }): MessagingSurfaceAction[] {
   const { profile } = params;
   if (profile && !capabilityProfileSupportsActionCount(profile, MONITOR_MIN_ACTIONS)) {
@@ -263,6 +266,17 @@ function buildMonitorActions(params: {
         fallbackText: `monitor snippet ${params.showSnippets ? "off" : "on"}`,
         priority: 7,
       },
+      ...(params.topicControls
+        ? [
+            {
+              id: "monitor:topics",
+              label: "Topics",
+              style: "secondary" as const,
+              fallbackText: "monitor topics",
+              priority: 8,
+            },
+          ]
+        : []),
     ],
     profile,
   );

--- a/apps/desktop/src/main/messaging/core/messaging-store.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-store.ts
@@ -8,8 +8,11 @@ import type {
   MessagingCallbackHandleRecord,
   MessagingChannelRef,
   MessagingJsonValue,
+  MessagingManagedTopicRecord,
   MessagingMonitorSubscriptionRecord,
   MessagingPendingIntentRecord,
+  MessagingThreadTopicLinkRecord,
+  MessagingTopicCleanupProposalRecord,
 } from "@pwragent/messaging-interface";
 import {
   CURRENT_MESSAGING_STORE_VERSION,
@@ -182,6 +185,113 @@ export class MessagingStore {
       );
       return revoked ? structuredClone(revoked) : undefined;
     });
+  }
+
+  async upsertManagedTopic(
+    topic: MessagingManagedTopicRecord,
+  ): Promise<MessagingManagedTopicRecord> {
+    const sanitized = sanitizeManagedTopic(topic);
+    return await this.withData((data) => {
+      data.topics[sanitized.id] = sanitized;
+      return structuredClone(sanitized);
+    });
+  }
+
+  async getManagedTopic(
+    id: string,
+  ): Promise<MessagingManagedTopicRecord | undefined> {
+    return await this.withReadData((data) => cloneOptional(data.topics[id]));
+  }
+
+  async findManagedTopicsForSupergroup(params: {
+    channel: MessagingChannelRef["channel"];
+    supergroupId: string;
+  }): Promise<MessagingManagedTopicRecord[]> {
+    return await this.withReadData((data) =>
+      Object.values(data.topics)
+        .filter(
+          (topic) =>
+            topic.channel === params.channel &&
+            topic.supergroupId === params.supergroupId,
+        )
+        .sort((a, b) => b.updatedAt - a.updatedAt || b.createdAt - a.createdAt)
+        .map((topic) => structuredClone(topic)),
+    );
+  }
+
+  async findManagedTopicByConversation(params: {
+    channel: MessagingChannelRef["channel"];
+    supergroupId: string;
+    topicId: string;
+  }): Promise<MessagingManagedTopicRecord | undefined> {
+    return await this.withReadData((data) =>
+      cloneOptional(
+        Object.values(data.topics).find(
+          (topic) =>
+            topic.channel === params.channel &&
+            topic.supergroupId === params.supergroupId &&
+            topic.topicId === params.topicId,
+        ),
+      ),
+    );
+  }
+
+  async upsertThreadTopicLink(
+    link: MessagingThreadTopicLinkRecord,
+  ): Promise<MessagingThreadTopicLinkRecord> {
+    const sanitized = structuredClone(link);
+    return await this.withData((data) => {
+      for (const [id, existing] of Object.entries(data.topicLinks)) {
+        if (
+          id !== sanitized.id &&
+          existing.channel === sanitized.channel &&
+          existing.supergroupId === sanitized.supergroupId &&
+          existing.backend === sanitized.backend &&
+          existing.threadId === sanitized.threadId
+        ) {
+          delete data.topicLinks[id];
+        }
+      }
+      data.topicLinks[sanitized.id] = sanitized;
+      return structuredClone(sanitized);
+    });
+  }
+
+  async findThreadTopicLink(params: {
+    backend: MessagingThreadTopicLinkRecord["backend"];
+    channel: MessagingChannelRef["channel"];
+    supergroupId: string;
+    threadId: string;
+  }): Promise<MessagingThreadTopicLinkRecord | undefined> {
+    return await this.withReadData((data) =>
+      cloneOptional(
+        Object.values(data.topicLinks).find(
+          (link) =>
+            link.backend === params.backend &&
+            link.channel === params.channel &&
+            link.supergroupId === params.supergroupId &&
+            link.threadId === params.threadId,
+        ),
+      ),
+    );
+  }
+
+  async upsertTopicCleanupProposal(
+    proposal: MessagingTopicCleanupProposalRecord,
+  ): Promise<MessagingTopicCleanupProposalRecord> {
+    const sanitized = structuredClone(proposal);
+    return await this.withData((data) => {
+      data.topicCleanupProposals[sanitized.id] = sanitized;
+      return structuredClone(sanitized);
+    });
+  }
+
+  async getTopicCleanupProposal(
+    id: string,
+  ): Promise<MessagingTopicCleanupProposalRecord | undefined> {
+    return await this.withReadData((data) =>
+      cloneOptional(data.topicCleanupProposals[id]),
+    );
   }
 
   async upsertPendingIntent(
@@ -582,6 +692,16 @@ function sanitizeMonitorSubscription(
     ...subscription,
     authorizedActorIds: [...new Set(subscription.authorizedActorIds)],
     monitorSurface: sanitizeSurfaceRef(subscription.monitorSurface),
+  };
+}
+
+function sanitizeManagedTopic(
+  topic: MessagingManagedTopicRecord,
+): MessagingManagedTopicRecord {
+  return {
+    ...topic,
+    authorizedActorIds: [...new Set(topic.authorizedActorIds)],
+    routingState: sanitizeAdapterState(topic.routingState),
   };
 }
 

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -39,6 +39,12 @@ import type {
   MessagingDeliveryScope,
   MessagingInboundEvent,
   MessagingInboundRejectedListener,
+  MessagingManagedConversationActionRequest,
+  MessagingManagedConversationActionResult,
+  MessagingManagedConversationCreateRequest,
+  MessagingManagedConversationCreateResult,
+  MessagingManagedConversationRightsRequest,
+  MessagingManagedConversationRightsResult,
   MessagingRateLimitInfo,
   MessagingReconnectInfo,
   MessagingRejectedInboundEvent,
@@ -96,6 +102,21 @@ export type DesktopMessagingAdapter = {
   setConversationTitle?(
     request: MessagingConversationTitleUpdateRequest,
   ): Promise<MessagingConversationTitleUpdateResult>;
+  getManagedConversationRights?(
+    request: MessagingManagedConversationRightsRequest,
+  ): Promise<MessagingManagedConversationRightsResult>;
+  createManagedConversation?(
+    request: MessagingManagedConversationCreateRequest,
+  ): Promise<MessagingManagedConversationCreateResult>;
+  closeManagedConversation?(
+    request: MessagingManagedConversationActionRequest,
+  ): Promise<MessagingManagedConversationActionResult>;
+  reopenManagedConversation?(
+    request: MessagingManagedConversationActionRequest,
+  ): Promise<MessagingManagedConversationActionResult>;
+  deleteManagedConversation?(
+    request: MessagingManagedConversationActionRequest,
+  ): Promise<MessagingManagedConversationActionResult>;
   start?(listener: (event: MessagingInboundEvent) => Promise<void>): Promise<void>;
   stop?(): Promise<void>;
 };

--- a/apps/desktop/src/main/state/messaging-store-sqlite.ts
+++ b/apps/desktop/src/main/state/messaging-store-sqlite.ts
@@ -5,8 +5,11 @@ import type {
   MessagingCallbackHandleRecord,
   MessagingChannelRef,
   MessagingJsonValue,
+  MessagingManagedTopicRecord,
   MessagingMonitorSubscriptionRecord,
   MessagingPendingIntentRecord,
+  MessagingThreadTopicLinkRecord,
+  MessagingTopicCleanupProposalRecord,
 } from "@pwragent/messaging-interface";
 import type { StateDb } from "./state-db.js";
 import type {
@@ -219,6 +222,137 @@ export class SqliteMessagingStore {
     await this.upsertMonitorSubscription(revoked);
     await this.deletePendingIntentsForChannel({ channel: current.channel });
     return structuredClone(revoked);
+  }
+
+  async upsertManagedTopic(
+    topic: MessagingManagedTopicRecord,
+  ): Promise<MessagingManagedTopicRecord> {
+    const sanitized = sanitizeManagedTopic(topic);
+    this.stateDb.raw
+      .prepare(
+        `INSERT OR REPLACE INTO messaging_managed_topics(topic_record_id, channel_kind, supergroup_id, topic_id, status, created_at, updated_at, payload)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        sanitized.id,
+        sanitized.channel,
+        sanitized.supergroupId,
+        sanitized.topicId,
+        sanitized.lifecycle,
+        sanitized.createdAt,
+        sanitized.updatedAt,
+        JSON.stringify(sanitized),
+      );
+    return structuredClone(sanitized);
+  }
+
+  async getManagedTopic(
+    id: string,
+  ): Promise<MessagingManagedTopicRecord | undefined> {
+    const row = this.stateDb.raw
+      .prepare("SELECT payload FROM messaging_managed_topics WHERE topic_record_id = ?")
+      .get(id) as { payload: string } | undefined;
+    return row ? JSON.parse(row.payload) : undefined;
+  }
+
+  async findManagedTopicsForSupergroup(params: {
+    channel: MessagingChannelRef["channel"];
+    supergroupId: string;
+  }): Promise<MessagingManagedTopicRecord[]> {
+    const rows = this.stateDb.raw
+      .prepare(
+        "SELECT payload FROM messaging_managed_topics WHERE channel_kind = ? AND supergroup_id = ? ORDER BY updated_at DESC, created_at DESC",
+      )
+      .all(params.channel, params.supergroupId) as { payload: string }[];
+    return rows.map((row) => JSON.parse(row.payload) as MessagingManagedTopicRecord);
+  }
+
+  async findManagedTopicByConversation(params: {
+    channel: MessagingChannelRef["channel"];
+    supergroupId: string;
+    topicId: string;
+  }): Promise<MessagingManagedTopicRecord | undefined> {
+    const row = this.stateDb.raw
+      .prepare(
+        "SELECT payload FROM messaging_managed_topics WHERE channel_kind = ? AND supergroup_id = ? AND topic_id = ?",
+      )
+      .get(params.channel, params.supergroupId, params.topicId) as
+      | { payload: string }
+      | undefined;
+    return row ? JSON.parse(row.payload) : undefined;
+  }
+
+  async upsertThreadTopicLink(
+    link: MessagingThreadTopicLinkRecord,
+  ): Promise<MessagingThreadTopicLinkRecord> {
+    const sanitized = structuredClone(link);
+    this.stateDb.raw
+      .prepare(
+        `INSERT OR REPLACE INTO messaging_thread_topic_links(link_id, channel_kind, supergroup_id, backend, thread_id, topic_record_id, created_at, updated_at, payload)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        sanitized.id,
+        sanitized.channel,
+        sanitized.supergroupId,
+        sanitized.backend,
+        sanitized.threadId,
+        sanitized.topicRecordId,
+        sanitized.createdAt,
+        sanitized.updatedAt,
+        JSON.stringify(sanitized),
+      );
+    return structuredClone(sanitized);
+  }
+
+  async findThreadTopicLink(params: {
+    backend: MessagingThreadTopicLinkRecord["backend"];
+    channel: MessagingChannelRef["channel"];
+    supergroupId: string;
+    threadId: string;
+  }): Promise<MessagingThreadTopicLinkRecord | undefined> {
+    const row = this.stateDb.raw
+      .prepare(
+        "SELECT payload FROM messaging_thread_topic_links WHERE channel_kind = ? AND supergroup_id = ? AND backend = ? AND thread_id = ?",
+      )
+      .get(params.channel, params.supergroupId, params.backend, params.threadId) as
+      | { payload: string }
+      | undefined;
+    return row ? JSON.parse(row.payload) : undefined;
+  }
+
+  async upsertTopicCleanupProposal(
+    proposal: MessagingTopicCleanupProposalRecord,
+  ): Promise<MessagingTopicCleanupProposalRecord> {
+    const sanitized = structuredClone(proposal);
+    this.stateDb.raw
+      .prepare(
+        `INSERT OR REPLACE INTO messaging_topic_cleanup_proposals(proposal_id, channel_kind, supergroup_id, status, created_at, updated_at, applied_at, expires_at, payload)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        sanitized.id,
+        sanitized.channel,
+        sanitized.supergroupId,
+        sanitized.status,
+        sanitized.createdAt,
+        sanitized.updatedAt,
+        sanitized.appliedAt ?? null,
+        sanitized.expiresAt ?? null,
+        JSON.stringify(sanitized),
+      );
+    return structuredClone(sanitized);
+  }
+
+  async getTopicCleanupProposal(
+    id: string,
+  ): Promise<MessagingTopicCleanupProposalRecord | undefined> {
+    const row = this.stateDb.raw
+      .prepare(
+        "SELECT payload FROM messaging_topic_cleanup_proposals WHERE proposal_id = ?",
+      )
+      .get(id) as { payload: string } | undefined;
+    return row ? JSON.parse(row.payload) : undefined;
   }
 
   async upsertPendingIntent(
@@ -655,6 +789,9 @@ export class SqliteMessagingStore {
     const browseSessions: Record<string, MessagingBrowseSessionRecord> = {};
     const callbackHandles: Record<string, MessagingCallbackHandleRecord> = {};
     const deliveries: Record<string, MessagingDeliveryRecord> = {};
+    const topicCleanupProposals: Record<string, MessagingTopicCleanupProposalRecord> = {};
+    const topicLinks: Record<string, MessagingThreadTopicLinkRecord> = {};
+    const topics: Record<string, MessagingManagedTopicRecord> = {};
 
     for (const row of this.stateDb.raw
       .prepare("SELECT binding_id, payload FROM bindings")
@@ -686,11 +823,29 @@ export class SqliteMessagingStore {
       .all() as { delivery_id: string; payload: string }[]) {
       deliveries[row.delivery_id] = JSON.parse(row.payload);
     }
+    for (const row of this.stateDb.raw
+      .prepare("SELECT topic_record_id, payload FROM messaging_managed_topics")
+      .all() as { topic_record_id: string; payload: string }[]) {
+      topics[row.topic_record_id] = JSON.parse(row.payload);
+    }
+    for (const row of this.stateDb.raw
+      .prepare("SELECT link_id, payload FROM messaging_thread_topic_links")
+      .all() as { link_id: string; payload: string }[]) {
+      topicLinks[row.link_id] = JSON.parse(row.payload);
+    }
+    for (const row of this.stateDb.raw
+      .prepare("SELECT proposal_id, payload FROM messaging_topic_cleanup_proposals")
+      .all() as { proposal_id: string; payload: string }[]) {
+      topicCleanupProposals[row.proposal_id] = JSON.parse(row.payload);
+    }
 
     return {
       version: CURRENT_MESSAGING_STORE_VERSION,
       bindings,
       monitorSubscriptions,
+      topicCleanupProposals,
+      topicLinks,
+      topics,
       pendingIntents,
       browseSessions,
       callbackHandles,
@@ -753,6 +908,16 @@ function sanitizeMonitorSubscription(
     ...subscription,
     authorizedActorIds: [...new Set(subscription.authorizedActorIds)],
     monitorSurface: sanitizeSurfaceRef(subscription.monitorSurface),
+  };
+}
+
+function sanitizeManagedTopic(
+  topic: MessagingManagedTopicRecord,
+): MessagingManagedTopicRecord {
+  return {
+    ...topic,
+    authorizedActorIds: [...new Set(topic.authorizedActorIds)],
+    routingState: sanitizeAdapterState(topic.routingState),
   };
 }
 
@@ -835,6 +1000,14 @@ export type MessagingStoreLike = Pick<
   | "findActiveMonitorSubscriptionForChannel"
   | "findActiveMonitorSubscriptionsForChannelKind"
   | "revokeMonitorSubscription"
+  | "upsertManagedTopic"
+  | "getManagedTopic"
+  | "findManagedTopicsForSupergroup"
+  | "findManagedTopicByConversation"
+  | "upsertThreadTopicLink"
+  | "findThreadTopicLink"
+  | "upsertTopicCleanupProposal"
+  | "getTopicCleanupProposal"
   | "upsertPendingIntent"
   | "getPendingIntent"
   | "findActivePendingIntentForChannel"

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -234,6 +234,51 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_composer_draft_journal_scope_hash_status
   ON composer_draft_journal(scope_key, content_hash, status);
 `;
 
+const MESSAGING_TOPIC_MANAGEMENT_SCHEMA = `
+CREATE TABLE IF NOT EXISTS messaging_managed_topics (
+  topic_record_id TEXT PRIMARY KEY,
+  channel_kind    TEXT NOT NULL,
+  supergroup_id   TEXT NOT NULL,
+  topic_id        TEXT NOT NULL,
+  status          TEXT NOT NULL,
+  created_at      INTEGER NOT NULL,
+  updated_at      INTEGER NOT NULL,
+  payload         TEXT NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_messaging_managed_topics_conversation
+  ON messaging_managed_topics(channel_kind, supergroup_id, topic_id);
+CREATE INDEX IF NOT EXISTS idx_messaging_managed_topics_supergroup
+  ON messaging_managed_topics(channel_kind, supergroup_id, updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS messaging_thread_topic_links (
+  link_id         TEXT PRIMARY KEY,
+  channel_kind    TEXT NOT NULL,
+  supergroup_id   TEXT NOT NULL,
+  backend         TEXT NOT NULL,
+  thread_id       TEXT NOT NULL,
+  topic_record_id TEXT NOT NULL,
+  created_at      INTEGER NOT NULL,
+  updated_at      INTEGER NOT NULL,
+  payload         TEXT NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_messaging_thread_topic_links_unique
+  ON messaging_thread_topic_links(channel_kind, supergroup_id, backend, thread_id);
+
+CREATE TABLE IF NOT EXISTS messaging_topic_cleanup_proposals (
+  proposal_id   TEXT PRIMARY KEY,
+  channel_kind  TEXT NOT NULL,
+  supergroup_id TEXT NOT NULL,
+  status        TEXT NOT NULL,
+  created_at    INTEGER NOT NULL,
+  updated_at    INTEGER NOT NULL,
+  applied_at    INTEGER,
+  expires_at    INTEGER,
+  payload       TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_messaging_topic_cleanup_proposals_supergroup
+  ON messaging_topic_cleanup_proposals(channel_kind, supergroup_id, updated_at DESC);
+`;
+
 const DELIVERIES_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 const REVOKED_BINDINGS_RETENTION_MS = 90 * 24 * 60 * 60 * 1000;
 const APP_RUNTIME_INSTANCE_RETENTION_MS = 60 * 60 * 1000;
@@ -322,6 +367,12 @@ export class StateDb {
         // converge.
         db.exec(DIRECTORY_OVERLAY_SCHEMA);
         db.pragma("user_version = 7");
+      })();
+    }
+    if ((db.pragma("user_version", { simple: true }) as number) < 8) {
+      db.transaction(() => {
+        db.exec(MESSAGING_TOPIC_MANAGEMENT_SCHEMA);
+        db.pragma("user_version = 8");
       })();
     }
 
@@ -464,6 +515,7 @@ function ensureCurrentSchema(db: BetterSqlite3.Database): void {
     db.exec(DIRECTORY_GIT_STATUS_SCHEMA);
     db.exec(DIRECTORY_OVERLAY_SCHEMA);
     db.exec(COMPOSER_DRAFT_RECOVERY_SCHEMA);
+    db.exec(MESSAGING_TOPIC_MANAGEMENT_SCHEMA);
     if ((db.pragma("user_version", { simple: true }) as number) < 4) {
       db.pragma("user_version = 4");
     }

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -4,6 +4,8 @@ import Database from "better-sqlite3";
 import type BetterSqlite3 from "better-sqlite3";
 import { getNativeBinding } from "./native-binding.js";
 
+export const CURRENT_STATE_DB_USER_VERSION = 8;
+
 const SCHEMA_V1 = `
 CREATE TABLE meta (
   key   TEXT PRIMARY KEY,
@@ -372,7 +374,7 @@ export class StateDb {
     if ((db.pragma("user_version", { simple: true }) as number) < 8) {
       db.transaction(() => {
         db.exec(MESSAGING_TOPIC_MANAGEMENT_SCHEMA);
-        db.pragma("user_version = 8");
+        db.pragma(`user_version = ${CURRENT_STATE_DB_USER_VERSION}`);
       })();
     }
 

--- a/docs-site/providers/telegram.md
+++ b/docs-site/providers/telegram.md
@@ -92,6 +92,17 @@ supported platform; the screenshots there happen to be Telegram.
   supergroup, they share the supergroup's ~20 msg/min budget. Use one
   supergroup per active thread for serious work; topics are fine for
   read-mostly bindings.
+- **Forum topic ownership needs admin rights.** To let PwrAgent create,
+  rename, close, or reopen topics, make the bot an admin with topic
+  management rights. To let PwrAgent delete a topic, also grant delete
+  message rights. Telegram deletion removes the topic and its messages,
+  so PwrAgent treats cleanup as a dry run until you approve a specific
+  action.
+- **Telegram bots cannot list every historical topic.** PwrAgent can
+  manage topics it creates, topics it observes through normal traffic or
+  forum-topic service messages, and topics you adopt from inside the
+  topic. A first cleanup sweep may therefore say it only knows about
+  adopted/observed topics.
 - **DM budget is roughly 60 msg/min.** Plenty for normal use, but
   streaming-on responses can burn through this in a single long turn.
 - **PwrAgent clears any configured Telegram webhook on startup.** If

--- a/docs-site/providers/telegram.md
+++ b/docs-site/providers/telegram.md
@@ -97,7 +97,8 @@ supported platform; the screenshots there happen to be Telegram.
   management rights. To let PwrAgent delete a topic, also grant delete
   message rights. Telegram deletion removes the topic and its messages,
   so PwrAgent treats cleanup as a dry run until you approve a specific
-  action.
+  action. Start with `/monitor`, then use the monitor card's **Topics**
+  button to create or reuse the PwrAgent control topic.
 - **Telegram bots cannot list every historical topic.** PwrAgent can
   manage topics it creates, topics it observes through normal traffic or
   forum-topic service messages, and topics you adopt from inside the

--- a/docs-site/using-codex.md
+++ b/docs-site/using-codex.md
@@ -732,6 +732,14 @@ Running `/monitor` in a conversation that already has a monitor
 binding refreshes the existing card rather than posting a duplicate.
 Each monitor-bound conversation hosts exactly one monitor card.
 
+In Telegram forum supergroups, `/monitor topics` establishes or adopts the
+current topic as PwrAgent's topic-owner surface. From that topic,
+`/monitor topics cleanup` posts a dry-run cleanup proposal for known or adopted
+topics, and `/monitor topics fanout` creates or reuses one topic for each
+selected recent thread. Telegram bots cannot list every historical topic in a
+supergroup, so cleanup only covers topics PwrAgent has created, observed, or you
+have adopted from inside the topic.
+
 The monitor binding survives PwrAgent restarts — on startup, every
 monitor-bound conversation resumes its refresh ticks automatically.
 The set of threads the card shows is derived live from your desktop

--- a/docs-site/using-codex.md
+++ b/docs-site/using-codex.md
@@ -725,6 +725,7 @@ desktop.
 | **Pins** | Cycle pinned-thread count: `0` → `5` → `10` (default 5) |
 | **Recent** | Cycle recent-thread count: `0` → `5` → `10` (default 5) |
 | **Snippet** | Toggle the per-thread response snippet on / off (default on; fixed ~100-character preview when on) |
+| **Topics** | Open Telegram topic-owner controls when the monitor is running in a Telegram supergroup or topic |
 | **Refresh** | Re-render right now |
 | **Stop** | Convert the monitor binding back to a regular conversation (no binding) |
 
@@ -732,13 +733,15 @@ Running `/monitor` in a conversation that already has a monitor
 binding refreshes the existing card rather than posting a duplicate.
 Each monitor-bound conversation hosts exactly one monitor card.
 
-In Telegram forum supergroups, `/monitor topics` establishes or adopts the
-current topic as PwrAgent's topic-owner surface. From that topic,
-`/monitor topics cleanup` posts a dry-run cleanup proposal for known or adopted
-topics, and `/monitor topics fanout` creates or reuses one topic for each
-selected recent thread. Telegram bots cannot list every historical topic in a
-supergroup, so cleanup only covers topics PwrAgent has created, observed, or you
-have adopted from inside the topic.
+In Telegram forum supergroups, use the monitor card's **Topics** button to open
+PwrAgent's topic-owner controls. From a normal supergroup surface, PwrAgent
+creates or reuses its control topic; from inside an existing topic, it adopts
+that topic as the owner surface. `/monitor topics` is the typed fallback for the
+same flow. The owner controls can post a dry-run cleanup proposal for known or
+adopted topics, and fan out selected recent threads into one topic per thread.
+Telegram bots cannot list every historical topic in a supergroup, so cleanup
+only covers topics PwrAgent has created, observed, or you have adopted from
+inside the topic.
 
 The monitor binding survives PwrAgent restarts — on startup, every
 monitor-bound conversation resumes its refresh ticks automatically.

--- a/docs/brainstorms/2026-05-22-telegram-topic-ownership-requirements.md
+++ b/docs/brainstorms/2026-05-22-telegram-topic-ownership-requirements.md
@@ -1,0 +1,181 @@
+---
+date: 2026-05-22
+topic: telegram-topic-ownership
+---
+
+# Telegram Topic Ownership and Monitor Fanout
+
+## Problem Frame
+
+PwrAgent works well enough in Telegram supergroup topics to bind and steer
+threads, but the supergroup topic list can become a maintenance burden. A user
+who works from Telegram wants PwrAgent to own a control topic, create useful
+per-thread topics when monitoring recent work, and help clean up stale or messy
+topics without destructive surprises.
+
+Telegram's Bot API supports topic management, but it does not expose a bot
+method that lists every forum topic in a supergroup. That means PwrAgent cannot
+reliably sweep all historical topics from Telegram alone. It can manage topics
+it created, topics it has observed through service messages or inbound traffic,
+and topics explicitly adopted by the user through an ID/link/manual command.
+
+## Requirements
+
+- **R1. Topic owner surface.** PwrAgent can establish or adopt a dedicated
+  Telegram forum topic for operator commands, status, and approvals related to
+  supergroup maintenance.
+- **R2. Permission clarity.** The operator can tell whether the bot has the
+  Telegram admin rights required for each action before relying on automation:
+  create/rename/close/reopen require topic-management rights; delete requires
+  delete-message rights.
+- **R3. Topic registry.** PwrAgent persists a local registry of Telegram forum
+  topics it owns, creates, observes, or adopts, including supergroup id, topic id,
+  title, lifecycle state, source, linked PwrAgent thread when known, last observed
+  activity, and last proposed cleanup decision.
+- **R4. Explicit adoption path.** Since Telegram does not list all topics for
+  bots, the user can adopt an existing topic by issuing a command from inside
+  that topic or by providing a Telegram topic link/id where the adapter can
+  validate it.
+- **R5. Dry-run cleanup by default.** Topic cleanup evaluates stale or unmanaged
+  topics and posts a proposed action list. Closing and deletion do not happen
+  until the user approves specific proposed actions.
+- **R6. Conservative deletion.** Deleting a topic is never automatic in the
+  default mode. The confirmation surface must make clear that Telegram deletes
+  the topic along with its messages.
+- **R7. Close before delete.** Cleanup proposals prefer closing inactive topics
+  before deleting them, unless the topic is known to be empty/test-created or the
+  user explicitly asks for delete candidates.
+- **R8. Monitor topic fanout.** A topic-aware monitor mode can summarize recent
+  changed PwrAgent threads and ensure each selected thread has exactly one topic
+  in the target supergroup.
+- **R9. No duplicate topic attachment.** If a PwrAgent thread is already linked
+  to a topic in the same supergroup, monitor fanout reuses that topic instead of
+  creating a second one.
+- **R10. Context seeding.** When monitor fanout creates a topic for a thread, it
+  posts a compact context message into that topic: thread title, backend, project
+  or directory label when available, recent activity/status, and how to control
+  the thread from that topic.
+- **R11. Existing `/monitor` preserved.** The current channel-level `/monitor`
+  card continues to work. Topic fanout is an explicit mode or subcommand, not a
+  silent behavior change to every monitor subscription.
+- **R12. Supergroup rate budget respected.** Topic fanout and cleanup avoid
+  bursty posts because Telegram supergroup write budgets are shared across
+  topics.
+- **R13. Authorization preserved.** Only authorized actors in authorized
+  supergroups can invoke topic ownership, adoption, cleanup, or monitor fanout.
+- **R14. Provider isolation preserved.** Telegram Bot API calls and SDK types
+  stay inside `packages/messaging/providers/telegram`; desktop workflow code
+  uses provider-neutral messaging capabilities and opaque routing state.
+
+## User Flows
+
+### F1. Establish the Control Topic
+
+1. User adds the PwrAgent bot to a Telegram supergroup and grants admin rights.
+2. User sends a topic-owner command from the desired control topic, or asks
+   PwrAgent to create one.
+3. PwrAgent verifies the conversation is an authorized Telegram supergroup topic.
+4. PwrAgent records the topic as the supergroup's control topic and replies with
+   the current permission status and available actions.
+
+### F2. Dry-Run Cleanup
+
+1. User asks the control topic to sweep the supergroup topics.
+2. PwrAgent evaluates known/adopted topics from its local registry.
+3. PwrAgent posts a cleanup proposal grouped by recommendation:
+   keep, adopt/label, close candidate, delete candidate, unknown/unseen.
+4. User approves selected actions.
+5. PwrAgent performs approved close/delete operations, records outcomes, and
+   posts a compact completion summary.
+
+### F3. Adopt an Existing Topic
+
+1. User posts an adoption command from inside an existing Telegram topic, or
+   gives PwrAgent a topic link/id in the control topic.
+2. PwrAgent validates the topic route it can infer from Telegram message state.
+3. PwrAgent records the topic in the local registry as user-adopted.
+4. Future cleanup and monitor fanout can reason about that topic.
+
+### F4. Topic-Aware Monitor Fanout
+
+1. User asks the control topic to monitor recent changed threads into topics.
+2. PwrAgent selects recent threads with meaningful activity in the configured
+   window, starting with a one-day default.
+3. For each selected thread, PwrAgent finds an existing topic link for the same
+   supergroup or creates a new topic if no link exists.
+4. PwrAgent posts a compact context seed into newly created topics and updates
+   the registry.
+5. Ongoing monitor refreshes update or post into the appropriate topic without
+   attaching the same thread to multiple topics in the same supergroup.
+
+## Scope Boundaries
+
+- In scope: Telegram supergroup forum topics, a PwrAgent control topic, local
+  topic registry, adoption commands, dry-run cleanup proposal and approval,
+  explicit close/delete execution, and a topic-aware monitor fanout mode.
+- In scope: permission checks and user-facing explanation of missing Telegram
+  admin rights.
+- In scope: preserving current `/monitor` behavior as the default monitor card.
+- Out of scope: using Telegram MTProto/TDLib user APIs to list topics. PwrAgent
+  should stay on the Bot API path.
+- Out of scope: autonomous deletion as the default behavior.
+- Out of scope: broad topic cleanup for topics PwrAgent has never observed and
+  the user has not adopted.
+- Out of scope: provider-specific cleanup behavior for Discord, Slack,
+  Mattermost, Feishu, LINE, or other platforms in the first implementation.
+
+## Success Criteria
+
+- A user can set up a Telegram supergroup so PwrAgent clearly reports whether it
+  has the rights needed to create, close, rename, and delete topics.
+- A user can designate a PwrAgent control topic and issue maintenance commands
+  from that topic.
+- Cleanup produces a readable dry-run proposal and requires explicit approval
+  before closing or deleting topics.
+- PwrAgent never deletes a Telegram topic unless the user approved that exact
+  proposed action.
+- Topic-aware monitor fanout creates or reuses one topic per selected PwrAgent
+  thread per supergroup and seeds each new topic with useful context.
+- Re-running topic-aware monitor fanout does not create duplicate topics for an
+  already linked thread in the same supergroup.
+- Restarting PwrAgent preserves the topic registry, control topic, monitor
+  fanout links, and pending cleanup proposal state.
+
+## Key Decisions
+
+- **Default cleanup mode is dry-run approval.** The user selected this as the
+  safety posture. Deletion is destructive and must remain an explicit approval
+  step.
+- **Topic inventory is local and adopted, not globally fetched.** Telegram's Bot
+  API exposes service messages and topic-management methods, but not a complete
+  bot-side topic listing endpoint. PwrAgent must be honest about this limitation.
+- **Monitor topic fanout is opt-in.** The existing `/monitor` card remains the
+  current low-noise summary. Creating topics is a stronger action and should be
+  requested explicitly.
+- **The control topic is the natural command surface.** It gives the user a
+  stable place to tell PwrAgent to clean, adopt, monitor, and approve without
+  mixing maintenance commands into every per-thread topic.
+
+## Dependencies and Assumptions
+
+- The bot must be an admin in the Telegram supergroup.
+- For create, rename, close, and reopen, the bot needs topic-management rights
+  unless it is acting on a topic it created where Telegram permits that.
+- For delete, the bot needs delete-message rights because Telegram deletes the
+  topic and all its messages.
+- The supergroup must be authorized in PwrAgent's Telegram settings and the
+  invoking actor must be authorized.
+- Existing topic state can only be complete after adoption or observation. A
+  first sweep may report "known topics only" and ask the user to adopt more.
+
+## Open Questions
+
+- Should the first user-facing command be a new `/topics` command, or a
+  capability-aware `/monitor topics` and `/monitor cleanup` subcommand family?
+- Should cleanup proposals expire after a fixed time, or remain pending until
+  approved/rejected from the control topic?
+- What is the first default staleness threshold for close candidates: no
+  observed activity for 7 days, 14 days, or user-configured per sweep?
+- Should thread-topic names be renamed automatically when the PwrAgent thread
+  title changes, or should renames be proposed in the dry-run cleanup surface?
+

--- a/docs/messaging-adapter-contract.md
+++ b/docs/messaging-adapter-contract.md
@@ -24,6 +24,8 @@ Adapters should support:
 - best-effort dismiss or update when the platform supports it
 - attachment capability metadata for provider-owned download and upload limits
 - optional assistant response stream updates
+- optional managed-conversation operations such as creating, closing, reopening,
+  deleting, or probing rights for topic-like child conversations
 
 ## Outputs
 
@@ -57,6 +59,14 @@ Adapters own routing and surface state. PwrAgent may persist and echo
 `MessagingAdapterState`, but workflow code must not parse it. Platform message
 IDs, interaction tokens, thread IDs, callback payloads, and permission details
 belong inside adapter-owned opaque state.
+
+Managed-conversation operations follow the same rule. A controller may request
+"create a child conversation under this channel" or "close this topic-like
+conversation" using `MessagingChannelRef` plus opaque routing state, but only
+the adapter may parse Telegram chat IDs, forum topic IDs, Discord thread IDs, or
+provider permission payloads. Unsupported providers should omit the optional
+methods so workflow code can render an unavailable capability instead of
+branching on platform names.
 
 Interactive callbacks should use compact opaque platform handles backed by
 long-lived sqlite records:

--- a/docs/messaging-platform-integration.md
+++ b/docs/messaging-platform-integration.md
@@ -11,7 +11,7 @@ truth for:
   reference for every field above and below the Test button.
 - **Usage** — bound threads, slash commands, at-mention commands,
   resume browser, new-thread starter, start card, debounce / queue
-  / steer, monitor cards, detach, archive — all at
+  / steer, monitor cards, Telegram topic cleanup/fanout, detach, archive — all at
   <https://docs.pwragent.ai/using-codex/>.
 - **Rate limits and budgets** —
   <https://docs.pwragent.ai/rate-limits/> with per-platform measured

--- a/docs/plans/2026-05-22-001-feat-telegram-topic-ownership-monitor-plan.md
+++ b/docs/plans/2026-05-22-001-feat-telegram-topic-ownership-monitor-plan.md
@@ -1,0 +1,382 @@
+---
+title: feat: Add Telegram topic ownership and monitor fanout
+type: feat
+status: completed
+date: 2026-05-22
+origin: docs/brainstorms/2026-05-22-telegram-topic-ownership-requirements.md
+---
+
+# feat: Add Telegram topic ownership and monitor fanout
+
+## Overview
+
+Add a Telegram-first topic ownership workflow so PwrAgent can manage a dedicated
+control topic, maintain a local registry of known/adopted forum topics, propose
+safe cleanup actions, and optionally fan recent PwrAgent thread monitoring out
+into one Telegram topic per thread.
+
+This plan deliberately preserves the current `/monitor` behavior. Topic fanout
+is an explicit mode because creating or deleting Telegram topics changes the
+shape of the supergroup and can remove message history.
+
+## Problem Frame
+
+The current messaging system can bind Telegram topics to PwrAgent threads and
+can rename a topic through `setConversationTitle`. It does not have an owned
+topic registry, topic creation/deletion/close operations, a control topic, or a
+cleanup approval flow. Telegram's Bot API also does not provide a bot method to
+list every forum topic in a supergroup, so cleanup must be honest about acting
+on known or adopted topics only.
+
+## Requirements Trace
+
+- R1. Establish or adopt a Telegram control topic for supergroup maintenance.
+- R2. Report whether Telegram admin rights support create/rename/close/reopen
+  and delete operations.
+- R3. Persist a local topic registry for owned, observed, and adopted topics.
+- R4. Provide explicit adoption paths for existing topics.
+- R5. Make cleanup dry-run by default and require approval for close/delete.
+- R6. Never delete without explicit confirmation for the exact proposal item.
+- R7. Prefer close-before-delete recommendations.
+- R8. Add explicit topic-aware monitor fanout for recent changed threads.
+- R9. Reuse an existing thread topic in the same supergroup instead of creating
+  duplicates.
+- R10. Seed newly created monitor topics with context.
+- R11. Preserve existing `/monitor` card behavior.
+- R12. Respect Telegram supergroup write budget.
+- R13. Preserve actor and supergroup authorization.
+- R14. Keep Telegram SDK/API details inside the Telegram provider.
+
+## Scope Boundaries
+
+- In scope: Telegram forum topic management through Bot API-backed provider
+  capabilities, local topic registry persistence, command/control surfaces,
+  dry-run cleanup proposals, approval callbacks, and topic fanout monitor
+  behavior.
+- In scope: focused operator docs explaining required Telegram permissions and
+  the Bot API inventory limitation.
+- Out of scope: MTProto/TDLib topic enumeration, autonomous deletion, broad
+  cross-provider cleanup, and changing the current default `/monitor` card.
+- Out of scope: renderer UI for the topic registry in the first implementation.
+
+## Context and Research
+
+### Telegram Bot API Constraints
+
+- `ChatAdministratorRights.can_manage_topics` covers creating, renaming,
+  closing, and reopening forum topics in supergroups.
+- `deleteForumTopic` deletes a topic along with all messages and requires
+  `can_delete_messages` in a supergroup.
+- `forum_topic_created`, `forum_topic_edited`, `forum_topic_closed`, and
+  `forum_topic_reopened` arrive as service-message fields on `Message`.
+- No Bot API method lists all forum topics in a supergroup. Topic registry
+  completeness must come from created topics, observed service messages, inbound
+  messages, and explicit adoption.
+
+### Existing Code and Patterns
+
+- `packages/messaging/providers/telegram/src/telegram-adapter.ts` already
+  recognizes topic service-message payloads, maps topic messages into
+  `MessagingConversationKind: "topic"`, caches topic names, routes with
+  `message_thread_id`, and implements `setConversationTitle` with
+  `editForumTopic`.
+- `packages/messaging/interface/src/index.ts` is the correct place for new
+  provider-neutral capability types. It already defines generic channel refs,
+  conversation refs, surface refs, adapter state, monitor subscription records,
+  and callback handle storage.
+- `apps/desktop/src/main/messaging/core/messaging-controller.ts` owns command
+  dispatch, authorization-aware inbound handling, monitor subscriptions, timers,
+  and managed delivery.
+- `apps/desktop/src/main/state/state-db.ts` and
+  `apps/desktop/src/main/state/messaging-store-sqlite.ts` are the durable
+  sqlite path for profile-scoped messaging state.
+- `apps/desktop/src/main/messaging/core/messaging-store.ts` remains the file
+  store used by tests and legacy paths; store shape changes need parity there.
+- `apps/desktop/src/main/messaging/core/messaging-command-catalog.ts` is the
+  canonical messaging command catalog and help-surface source.
+- `apps/desktop/src/main/messaging/core/messaging-monitor-card.ts` already
+  selects pinned/recent threads and formats the existing monitor card.
+- `docs-site/providers/telegram.md` already documents Telegram supergroup write
+  budgets and General-topic edit limitations.
+
+## Key Technical Decisions
+
+- **Use provider-neutral topic-management capabilities.** Extend the messaging
+  adapter contract with generic managed-conversation operations such as create,
+  close, reopen, delete, and inspect rights. Implement them in Telegram only for
+  this slice. Controller code should not import `grammy` or Telegram request
+  types.
+- **Persist topic state in desktop sqlite, not inside the provider.** Providers
+  must not touch persistence. The provider reports observed topic lifecycle
+  events and performs requested operations; the desktop store owns the registry,
+  proposals, approvals, and thread-topic links.
+- **Use dry-run proposal records for cleanup.** A cleanup sweep creates a durable
+  proposal with action ids. Approvals execute only the selected proposal items
+  and reject stale approvals when the proposal has expired or has already been
+  applied.
+- **Add a capability-aware topic command surface.** Prefer a new `topics`
+  command if help rendering can hide unsupported commands by provider
+  capability. If that becomes too wide for the first slice, use `/monitor topics`
+  and `/monitor cleanup` subcommands so the existing monitor command owns the
+  topic-aware extension without globally adding an unsupported command to every
+  provider.
+- **Keep topic fanout separate from channel monitor subscriptions.** A channel
+  monitor updates one monitor card in one conversation. Topic fanout is a
+  supergroup-level monitor mode that maps selected PwrAgent threads to topics.
+- **Use one thread-topic link per supergroup.** The registry should key links by
+  provider, supergroup id, backend, and thread id so repeated fanout can reuse an
+  existing topic.
+- **Prefer closing over deleting.** Cleanup scoring should default to keep or
+  close proposals. Delete candidates require stronger evidence and still require
+  explicit approval.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should cleanup be autonomous?** No. The user selected dry-run approval as the
+  default safety mode.
+- **Can the bot list all topics?** No official Bot API listing method exists.
+  The feature must operate on known/adopted topics and explain that limitation.
+- **Does the bot need extra permissions?** Yes for full operation: admin with
+  topic-management rights for create/rename/close/reopen, and delete-message
+  rights for topic deletion.
+
+### Deferred to Implementation
+
+- Exact command spelling: `/topics ...` versus `/monitor topics ...`.
+- Exact staleness threshold defaults for close/delete candidates.
+- Whether cleanup proposals expire after a fixed TTL or remain pending until
+  superseded.
+- Whether automatic topic renames follow PwrAgent thread title changes in the
+  first slice or appear as cleanup proposals.
+
+## Implementation Units
+
+- [ ] **Unit 1: Extend provider-neutral managed-conversation capability**
+
+**Goal:** Add a generic adapter capability for topic-like conversation
+management while keeping Telegram API details isolated.
+
+**Requirements:** R1, R2, R5, R6, R13, R14
+
+**Files:**
+- `packages/messaging/interface/src/index.ts`
+- `packages/messaging/interface/src/__tests__/messaging-contract.test.ts`
+- `docs/messaging-adapter-contract.md`
+
+**Design Notes:**
+- Add provider-neutral request/result types for managed conversation operations:
+  rights probe, create child conversation, close, reopen, delete, and possibly
+  adopt/resolve existing conversation.
+- Use `MessagingChannelRef`, `MessagingConversationRef`, and
+  `MessagingAdapterState` rather than provider ids in controller-facing types.
+- Include operation-level support and failure reasons so the controller can
+  render "missing topic-management rights" versus "missing delete rights."
+
+**Test Scenarios:**
+- Happy path: capability result type can express create/close/delete support
+  without provider-specific fields.
+- Edge case: unsupported providers can omit the capability and the controller can
+  render an unsupported response.
+- Regression: interface package still imports only allowed lower-layer packages.
+
+- [ ] **Unit 2: Implement Telegram Bot API topic operations**
+
+**Goal:** Teach the Telegram provider to create, close, reopen, delete, and
+rights-check forum topics through the Bot API.
+
+**Requirements:** R1, R2, R4, R6, R13, R14
+
+**Files:**
+- `packages/messaging/providers/telegram/src/telegram-adapter.ts`
+- `packages/messaging/providers/telegram/src/__tests__/telegram-grammy-adapter.test.ts`
+- `packages/messaging/providers/telegram/src/__tests__/telegram-adapter-security.test.ts`
+- `packages/messaging/providers/telegram/src/__tests__/telegram-mention.test.ts`
+
+**Design Notes:**
+- Extend `TelegramBotApi`, `TelegramGrammyBotLike`, and `adaptGrammyBot` with
+  Bot API methods needed for topic lifecycle and rights inspection.
+- Keep `message_thread_id` and `chat_id` inside provider-owned opaque state or
+  provider-local parsing.
+- Continue capturing topic lifecycle service messages; emit enough normalized
+  lifecycle information for the desktop controller/store to update the registry.
+- Handle Telegram 400/403 failures as operation results that the controller can
+  explain, not uncaught provider crashes.
+
+**Test Scenarios:**
+- Happy path: create topic maps to the grammY positional API and returns a topic
+  channel ref with routing state.
+- Happy path: close/reopen/delete map to the right Bot API calls.
+- Happy path: rights probe reports topic-management and delete-message rights.
+- Edge case: missing admin rights returns an operation failure with a user-safe
+  reason.
+- Edge case: General topic is not treated as a normal delete candidate.
+- Regression: existing send/edit/pin/topic rename tests continue to pass.
+
+- [ ] **Unit 3: Persist Telegram topic registry and cleanup proposals**
+
+**Goal:** Add durable profile-scoped state for known topics, thread-topic links,
+control topic configuration, and dry-run cleanup proposals.
+
+**Requirements:** R1, R3, R4, R5, R6, R7, R9, R13
+
+**Files:**
+- `apps/desktop/src/main/state/state-db.ts`
+- `apps/desktop/src/main/state/messaging-store-sqlite.ts`
+- `apps/desktop/src/main/messaging/core/messaging-store.ts`
+- `apps/desktop/src/main/messaging/core/messaging-migrations.ts`
+- `apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts`
+- `apps/desktop/src/main/__tests__/messaging-store.test.ts`
+
+**Design Notes:**
+- Add store methods for upserting observed/adopted/owned topics, finding the
+  control topic by supergroup, linking a PwrAgent thread to a topic in a
+  supergroup, and persisting cleanup proposals.
+- Store provider-specific routing only as opaque adapter state; index on
+  provider-neutral channel kind, supergroup conversation id, topic conversation
+  id, backend, and thread id.
+- Sanitize payloads with the existing secret-key pattern helpers before
+  persistence.
+
+**Test Scenarios:**
+- Happy path: an observed topic round-trips through sqlite and file stores.
+- Happy path: a thread-topic link prevents duplicate links for the same backend,
+  thread id, and supergroup.
+- Happy path: a cleanup proposal with selected actions persists and can be
+  marked applied.
+- Edge case: malformed opaque state is sanitized or ignored rather than
+  crashing store reads.
+- Regression: existing binding and monitor subscription rows still migrate and
+  round-trip.
+
+- [ ] **Unit 4: Add topic command/control flow**
+
+**Goal:** Let authorized Telegram users establish the control topic, adopt
+topics, request dry-run cleanup, and approve proposed cleanup actions.
+
+**Requirements:** R1, R2, R4, R5, R6, R7, R13
+
+**Files:**
+- `apps/desktop/src/main/messaging/core/messaging-command-catalog.ts`
+- `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- `apps/desktop/src/main/messaging/core/messaging-topic-control-card.ts`
+- `apps/desktop/src/main/__tests__/messaging-command-catalog.test.ts`
+- `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+
+**Design Notes:**
+- Add capability-aware command/help rendering if a new `topics` command is used.
+  Otherwise extend `monitor` subcommand parsing and keep non-Telegram providers
+  on the existing help surface.
+- Render a control card showing known permissions, known/adopted topic count,
+  pending cleanup proposal state, and available actions.
+- Cleanup action callbacks must include proposal id and item id; stale or
+  mismatched approvals render a recoverable error.
+- Cleanup execution should rate-limit/batch close/delete calls and post a
+  completion summary.
+
+**Test Scenarios:**
+- Happy path: authorized user can establish the current topic as the control
+  topic.
+- Happy path: adoption from inside a topic records that topic.
+- Happy path: cleanup dry-run renders keep/close/delete/unknown groups without
+  executing close/delete calls.
+- Happy path: approving one close candidate executes only that proposal item.
+- Edge case: unauthorized actor or unauthorized supergroup cannot manage topics.
+- Edge case: stale approval is rejected and does not call the provider.
+- Regression: `/help`, `/monitor`, `/status`, `/resume`, `/new`, and `/detach`
+  continue to route as before.
+
+- [ ] **Unit 5: Add topic-aware monitor fanout**
+
+**Goal:** Let the control topic create or reuse per-thread Telegram topics for
+recently changed PwrAgent threads and seed each created topic with context.
+
+**Requirements:** R8, R9, R10, R11, R12, R13
+
+**Files:**
+- `apps/desktop/src/main/messaging/core/messaging-monitor-card.ts`
+- `apps/desktop/src/main/messaging/core/messaging-topic-monitor.ts`
+- `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- `apps/desktop/src/main/__tests__/messaging-monitor-card.test.ts`
+- `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+
+**Design Notes:**
+- Reuse the existing navigation snapshot and monitor-thread selection helpers
+  where possible, but add a "changed in window" selection layer for the
+  topic-fanout command.
+- Before creating a topic, query the topic registry for an existing link for
+  the same supergroup, backend, and thread id.
+- Seed only newly created topics. Existing linked topics should get at most a
+  compact refresh/update unless explicitly requested.
+- Respect Telegram supergroup write budgets by batching creates/posts and
+  honoring provider rate-limit results.
+
+**Test Scenarios:**
+- Happy path: three recent changed threads create three topics and seed context.
+- Happy path: rerunning fanout reuses existing links and creates no duplicates.
+- Happy path: a thread already bound to a topic in the same supergroup is reused.
+- Edge case: topic creation failure for one thread does not prevent other
+  selected threads from being processed.
+- Edge case: rate-limit response pauses or defers remaining topic writes instead
+  of spinning.
+- Regression: existing channel-level monitor subscriptions still render one
+  monitor card and do not create topics.
+
+- [ ] **Unit 6: Document Telegram setup, limitations, and operations**
+
+**Goal:** Make the operator-facing docs clear about permissions, known-topic
+limits, dry-run cleanup, and monitor fanout.
+
+**Requirements:** R2, R5, R6, R11, R12
+
+**Files:**
+- `docs-site/providers/telegram.md`
+- `docs-site/using-codex.md`
+- `docs/messaging-platform-integration.md`
+
+**Design Notes:**
+- Document required admin rights separately for topic management and deletion.
+- State plainly that Bot API cannot list every historical topic; adoption fills
+  gaps.
+- Explain the difference between normal `/monitor` and topic-aware monitor
+  fanout.
+
+**Test Scenarios:**
+- Happy path: docs mention required Telegram rights and dry-run deletion safety.
+- Happy path: docs link existing `/monitor` guidance to topic fanout without
+  implying fanout is the default.
+- Regression: docs-site link tests pass after adding anchors or links.
+
+## Sequencing
+
+1. Land provider-neutral capability types and Telegram provider operations.
+2. Add store persistence for topic registry, thread-topic links, and cleanup
+   proposals.
+3. Add control/adoption/cleanup command flow with dry-run approvals.
+4. Add topic-aware monitor fanout.
+5. Update operator docs.
+
+This sequencing keeps destructive operations behind a visible proposal flow
+before adding fanout automation that can create many topics.
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| User expects complete topic sweep, but Bot API cannot list all topics. | Say "known/adopted topics" in command output and docs; provide adoption commands. |
+| Accidental destructive cleanup deletes messages. | Default to dry-run, require exact proposal approval, and make delete wording explicit. |
+| Telegram permissions differ from what the user granted. | Add a rights probe and operation-specific failure messages. |
+| Topic fanout floods the supergroup or hits 429s. | Batch topic creates/posts, reuse existing links, and honor provider rate-limit results. |
+| Controller becomes Telegram-specific. | Add provider-neutral managed-conversation types and keep Telegram parsing/API calls in the provider. |
+| Duplicate topics for the same thread create more mess. | Enforce one link per supergroup/backend/thread id and test reruns. |
+
+## Verification
+
+- `pnpm --filter @pwragent/messaging-provider-telegram test`
+- `pnpm --filter @pwragent/desktop test -- apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+- `pnpm --filter @pwragent/desktop test -- apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts`
+- `pnpm --filter @pwragent/desktop test -- apps/desktop/src/main/__tests__/messaging-monitor-card.test.ts`
+- `pnpm lint:boundaries`
+- Manual Telegram supergroup check with a test bot granted topic-management
+  rights first, then delete-message rights for delete approval verification.

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -315,6 +315,65 @@ export type MessagingAdapterRenderingPreferencesUpdate = {
   toolUpdateDefaultMode?: MessagingToolUpdateMode;
 };
 
+export type MessagingManagedConversationOperation =
+  | "create_child"
+  | "close"
+  | "reopen"
+  | "delete";
+
+export type MessagingManagedConversationOperationSupport = {
+  operation: MessagingManagedConversationOperation;
+  supported: boolean;
+  missingPermission?: string;
+  reason?: string;
+};
+
+export type MessagingManagedConversationRightsRequest = {
+  actor?: MessagingActorIdentity;
+  channel: MessagingChannelRef;
+  routingState?: MessagingAdapterState;
+};
+
+export type MessagingManagedConversationRightsResult = {
+  channel: MessagingChannelKind;
+  conversation: MessagingConversationRef;
+  errorMessage?: string;
+  operations: MessagingManagedConversationOperationSupport[];
+  outcome: "ok" | "unsupported" | "failed";
+  updatedAt: number;
+};
+
+export type MessagingManagedConversationCreateRequest = {
+  actor?: MessagingActorIdentity;
+  parent: MessagingChannelRef;
+  routingState?: MessagingAdapterState;
+  title: string;
+};
+
+export type MessagingManagedConversationCreateResult = {
+  channel: MessagingChannelKind;
+  conversation?: MessagingConversationRef;
+  errorMessage?: string;
+  outcome: "created" | "unsupported" | "failed";
+  routingState?: MessagingAdapterState;
+  updatedAt: number;
+};
+
+export type MessagingManagedConversationActionRequest = {
+  actor?: MessagingActorIdentity;
+  channel: MessagingChannelRef;
+  routingState?: MessagingAdapterState;
+};
+
+export type MessagingManagedConversationActionResult = {
+  channel: MessagingChannelKind;
+  conversation: MessagingConversationRef;
+  errorMessage?: string;
+  operation: Exclude<MessagingManagedConversationOperation, "create_child">;
+  outcome: "updated" | "unsupported" | "failed";
+  updatedAt: number;
+};
+
 export type MessagingChannelRef = {
   channel: MessagingChannelKind;
   conversation: MessagingConversationRef;
@@ -930,6 +989,84 @@ export type MessagingMonitorSubscriptionRecord = {
   revokedAt?: number;
   monitor: MessagingMonitorState;
   monitorSurface?: MessagingSurfaceRef;
+};
+
+export type MessagingManagedTopicSource =
+  | "owned"
+  | "created"
+  | "observed"
+  | "adopted"
+  | "linked";
+
+export type MessagingManagedTopicLifecycle =
+  | "open"
+  | "closed"
+  | "deleted"
+  | "unknown";
+
+export type MessagingManagedTopicCleanupRecommendation =
+  | "keep"
+  | "adopt"
+  | "close"
+  | "delete"
+  | "unknown";
+
+export type MessagingManagedTopicRecord = {
+  id: string;
+  channel: MessagingChannelKind;
+  supergroupId: string;
+  topicId: string;
+  conversation: MessagingConversationRef;
+  authorizedActorIds: string[];
+  createdAt: number;
+  updatedAt: number;
+  adoptedAt?: number;
+  closedAt?: number;
+  deletedAt?: number;
+  lastObservedAt?: number;
+  lifecycle: MessagingManagedTopicLifecycle;
+  recommendation?: MessagingManagedTopicCleanupRecommendation;
+  routingState?: MessagingAdapterState;
+  source: MessagingManagedTopicSource;
+  title?: string;
+};
+
+export type MessagingThreadTopicLinkRecord = {
+  id: string;
+  backend: AppServerBackendKind;
+  channel: MessagingChannelKind;
+  supergroupId: string;
+  threadId: ThreadIdentifier;
+  topicRecordId: string;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type MessagingTopicCleanupProposalAction =
+  | "keep"
+  | "close"
+  | "delete";
+
+export type MessagingTopicCleanupProposalItem = {
+  id: string;
+  action: MessagingTopicCleanupProposalAction;
+  reason: string;
+  topicRecordId: string;
+  title?: string;
+};
+
+export type MessagingTopicCleanupProposalRecord = {
+  id: string;
+  channel: MessagingChannelKind;
+  supergroupId: string;
+  controlTopicRecordId?: string;
+  authorizedActorIds: string[];
+  createdAt: number;
+  updatedAt: number;
+  appliedAt?: number;
+  expiresAt?: number;
+  items: MessagingTopicCleanupProposalItem[];
+  status: "pending" | "applied" | "expired" | "cancelled";
 };
 
 export type MessagingThreadDisplaySummary = {

--- a/packages/messaging/providers/telegram/src/__tests__/telegram-adapter-security.test.ts
+++ b/packages/messaging/providers/telegram/src/__tests__/telegram-adapter-security.test.ts
@@ -366,10 +366,21 @@ function fakeBot(): TelegramBotLike & {
   return {
     api: {
       answerCallbackQuery: vi.fn(async () => true),
+      closeForumTopic: vi.fn(async () => true),
+      createForumTopic: vi.fn(async () => ({
+        message_thread_id: 44,
+        name: "Topic",
+      })),
       deleteWebhook: vi.fn(async () => true),
+      deleteForumTopic: vi.fn(async () => true),
       editForumTopic: vi.fn(async () => true),
       editMessageText: vi.fn(async () => sentMessage),
       getFile: vi.fn(async () => ({})),
+      getChatMember: vi.fn(async () => ({
+        can_delete_messages: true,
+        can_manage_topics: true,
+        status: "administrator" as const,
+      })),
       getMe: vi.fn(async () => ({ id: 999, is_bot: true, username: "PwrAgentBot" })),
       getWebhookInfo: vi.fn(async () => ({ url: "" })),
       pinChatMessage: vi.fn(async () => true),
@@ -377,6 +388,7 @@ function fakeBot(): TelegramBotLike & {
       sendDocument: vi.fn(async () => sentMessage),
       sendMessage: vi.fn(async () => sentMessage),
       sendPhoto: vi.fn(async () => sentMessage),
+      reopenForumTopic: vi.fn(async () => true),
       setMyCommands: vi.fn(async () => true),
       unpinChatMessage: vi.fn(async () => true),
     },

--- a/packages/messaging/providers/telegram/src/__tests__/telegram-grammy-adapter.test.ts
+++ b/packages/messaging/providers/telegram/src/__tests__/telegram-grammy-adapter.test.ts
@@ -40,6 +40,23 @@ describe("adaptGrammyBot", () => {
       parse_mode: "HTML",
       text: "Choose a thread",
     });
+    await bot.api.createForumTopic({
+      chat_id: 42,
+      name: "Thread topic",
+    });
+    await bot.api.closeForumTopic({
+      chat_id: 42,
+      message_thread_id: 9,
+    });
+    await bot.api.reopenForumTopic({
+      chat_id: 42,
+      message_thread_id: 9,
+    });
+    await bot.api.deleteForumTopic({
+      chat_id: 42,
+      message_thread_id: 9,
+    });
+    await bot.api.getChatMember(42, 123);
     await bot.api.editMessageText({
       chat_id: 42,
       message_id: 7,
@@ -95,6 +112,14 @@ describe("adaptGrammyBot", () => {
         parse_mode: "HTML",
       },
     );
+    expect(grammyBot.api.createForumTopic).toHaveBeenCalledWith(
+      42,
+      "Thread topic",
+    );
+    expect(grammyBot.api.closeForumTopic).toHaveBeenCalledWith(42, 9);
+    expect(grammyBot.api.reopenForumTopic).toHaveBeenCalledWith(42, 9);
+    expect(grammyBot.api.deleteForumTopic).toHaveBeenCalledWith(42, 9);
+    expect(grammyBot.api.getChatMember).toHaveBeenCalledWith(42, 123);
     expect(grammyBot.api.editMessageText).toHaveBeenCalledWith(
       42,
       7,
@@ -479,10 +504,14 @@ describe("TelegramAdapter callback persistence", () => {
 function createGrammyBot(): TelegramGrammyBotLike & {
   api: {
     answerCallbackQuery: ReturnType<typeof vi.fn>;
+    closeForumTopic: ReturnType<typeof vi.fn>;
+    createForumTopic: ReturnType<typeof vi.fn>;
     deleteWebhook: ReturnType<typeof vi.fn>;
+    deleteForumTopic: ReturnType<typeof vi.fn>;
     editForumTopic: ReturnType<typeof vi.fn>;
     editMessageText: ReturnType<typeof vi.fn>;
     getFile: ReturnType<typeof vi.fn>;
+    getChatMember: ReturnType<typeof vi.fn>;
     getMe: ReturnType<typeof vi.fn>;
     getWebhookInfo: ReturnType<typeof vi.fn>;
     pinChatMessage: ReturnType<typeof vi.fn>;
@@ -490,6 +519,7 @@ function createGrammyBot(): TelegramGrammyBotLike & {
     sendDocument: ReturnType<typeof vi.fn>;
     sendMessage: ReturnType<typeof vi.fn>;
     sendPhoto: ReturnType<typeof vi.fn>;
+    reopenForumTopic: ReturnType<typeof vi.fn>;
     setMyCommands: ReturnType<typeof vi.fn>;
     unpinChatMessage: ReturnType<typeof vi.fn>;
   };
@@ -497,7 +527,13 @@ function createGrammyBot(): TelegramGrammyBotLike & {
   return {
     api: {
       answerCallbackQuery: vi.fn(async () => true),
+      closeForumTopic: vi.fn(async () => true),
+      createForumTopic: vi.fn(async (_chatId, name) => ({
+        message_thread_id: 44,
+        name,
+      })),
       deleteWebhook: vi.fn(async () => true),
+      deleteForumTopic: vi.fn(async () => true),
       editForumTopic: vi.fn(async () => true),
       editMessageText: vi.fn(
         async (
@@ -517,6 +553,11 @@ function createGrammyBot(): TelegramGrammyBotLike & {
         }),
       ),
       getFile: vi.fn(async () => ({ file_path: "documents/file.txt" })),
+      getChatMember: vi.fn(async () => ({
+        can_delete_messages: true,
+        can_manage_topics: true,
+        status: "administrator" as const,
+      })),
       getMe: vi.fn(async () => ({ id: 123, is_bot: true, username: "TestBot" })),
       getWebhookInfo: vi.fn(async () => ({ url: "" })),
       pinChatMessage: vi.fn(
@@ -575,6 +616,7 @@ function createGrammyBot(): TelegramGrammyBotLike & {
           message_id: 201,
         }),
       ),
+      reopenForumTopic: vi.fn(async () => true),
       setMyCommands: vi.fn(async () => true),
       unpinChatMessage: vi.fn(
         async (
@@ -610,7 +652,13 @@ function fakeCallbackStore(): MessagingCallbackHandleStore & {
 function fakeTelegramApi(): TelegramBotApi {
   return {
     answerCallbackQuery: async () => true,
+    closeForumTopic: async () => true,
+    createForumTopic: async (request) => ({
+      message_thread_id: 44,
+      name: request.name,
+    }),
     deleteWebhook: async () => true,
+    deleteForumTopic: async () => true,
     editForumTopic: async () => true,
     editMessageText: async (request) => ({
       chat: {
@@ -620,6 +668,11 @@ function fakeTelegramApi(): TelegramBotApi {
       message_id: request.message_id,
     }),
     getFile: async () => ({ file_path: "documents/file.txt" }),
+    getChatMember: async () => ({
+      can_delete_messages: true,
+      can_manage_topics: true,
+      status: "administrator",
+    }),
     getMe: async () => ({ id: 123, is_bot: true, username: "TestBot" }),
     getWebhookInfo: async () => ({ url: "" }),
     pinChatMessage: async () => true,
@@ -645,6 +698,7 @@ function fakeTelegramApi(): TelegramBotApi {
       },
       message_id: 201,
     }),
+    reopenForumTopic: async () => true,
     setMyCommands: async () => true,
     unpinChatMessage: async () => true,
   };

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -17,6 +17,12 @@ import type {
   MessagingClientRateLimitStrategy,
   MessagingInboundEvent,
   MessagingInboundRejectedListener,
+  MessagingManagedConversationActionRequest,
+  MessagingManagedConversationActionResult,
+  MessagingManagedConversationCreateRequest,
+  MessagingManagedConversationCreateResult,
+  MessagingManagedConversationRightsRequest,
+  MessagingManagedConversationRightsResult,
   MessagingRateLimitInfo,
   MessagingRejectedInboundEvent,
   MessagingSurfaceAction,
@@ -200,6 +206,29 @@ export type TelegramEditForumTopicRequest = {
   name: string;
 };
 
+export type TelegramCreateForumTopicRequest = {
+  chat_id: number | string;
+  name: string;
+};
+
+export type TelegramForumTopic = {
+  icon_color?: number;
+  icon_custom_emoji_id?: string;
+  message_thread_id: number;
+  name: string;
+};
+
+export type TelegramForumTopicActionRequest = {
+  chat_id: number | string;
+  message_thread_id: number;
+};
+
+export type TelegramChatMember = {
+  can_delete_messages?: boolean;
+  can_manage_topics?: boolean;
+  status: "creator" | "administrator" | "member" | "restricted" | "left" | "kicked";
+};
+
 export type TelegramSendPhotoRequest = {
   caption?: string;
   chat_id: number | string;
@@ -247,10 +276,18 @@ export type TelegramBotApi = {
     callback_query_id: string;
     text?: string;
   }): Promise<boolean>;
+  closeForumTopic(request: TelegramForumTopicActionRequest): Promise<boolean>;
+  createForumTopic(request: TelegramCreateForumTopicRequest): Promise<TelegramForumTopic>;
   deleteWebhook(params?: { drop_pending_updates?: boolean }): Promise<boolean>;
+  deleteForumTopic(request: TelegramForumTopicActionRequest): Promise<boolean>;
   editForumTopic(request: TelegramEditForumTopicRequest): Promise<boolean>;
+  getChatMember(
+    chatId: number | string,
+    userId: number | string,
+  ): Promise<TelegramChatMember>;
   editMessageText(request: TelegramEditMessageTextRequest): Promise<TelegramSentMessage>;
   getMe(): Promise<{ id: number; is_bot: boolean; username?: string }>;
+  reopenForumTopic(request: TelegramForumTopicActionRequest): Promise<boolean>;
   getWebhookInfo(): Promise<{ url: string }>;
   getFile(fileId: string): Promise<{ file_path?: string }>;
   pinChatMessage(request: TelegramPinChatMessageRequest): Promise<boolean>;
@@ -279,7 +316,19 @@ export type TelegramGrammyBotLike = {
       callbackQueryId: string,
       other?: { text?: string },
     ): Promise<boolean>;
+    closeForumTopic(
+      chatId: number | string,
+      messageThreadId: number,
+    ): Promise<boolean>;
+    createForumTopic(
+      chatId: number | string,
+      name: string,
+    ): Promise<TelegramForumTopic>;
     deleteWebhook(params?: { drop_pending_updates?: boolean }): Promise<boolean>;
+    deleteForumTopic(
+      chatId: number | string,
+      messageThreadId: number,
+    ): Promise<boolean>;
     editForumTopic(
       chatId: number | string,
       messageThreadId: number,
@@ -300,6 +349,14 @@ export type TelegramGrammyBotLike = {
     // match `TelegramBotApi.getMe` and avoid a structural narrowing
     // surprise if grammy ever loosens the type.
     getMe(): Promise<{ id: number; is_bot: boolean; username?: string }>;
+    reopenForumTopic(
+      chatId: number | string,
+      messageThreadId: number,
+    ): Promise<boolean>;
+    getChatMember(
+      chatId: number | string,
+      userId: number | string,
+    ): Promise<TelegramChatMember>;
     getWebhookInfo(): Promise<{ url: string }>;
     getFile(fileId: string): Promise<{ file_path?: string }>;
     pinChatMessage(
@@ -371,6 +428,21 @@ export type TelegramProviderAdapter = {
   setConversationTitle(
     request: MessagingConversationTitleUpdateRequest,
   ): Promise<MessagingConversationTitleUpdateResult>;
+  getManagedConversationRights(
+    request: MessagingManagedConversationRightsRequest,
+  ): Promise<MessagingManagedConversationRightsResult>;
+  createManagedConversation(
+    request: MessagingManagedConversationCreateRequest,
+  ): Promise<MessagingManagedConversationCreateResult>;
+  closeManagedConversation(
+    request: MessagingManagedConversationActionRequest,
+  ): Promise<MessagingManagedConversationActionResult>;
+  reopenManagedConversation(
+    request: MessagingManagedConversationActionRequest,
+  ): Promise<MessagingManagedConversationActionResult>;
+  deleteManagedConversation(
+    request: MessagingManagedConversationActionRequest,
+  ): Promise<MessagingManagedConversationActionResult>;
   start?(listener: (event: MessagingInboundEvent) => Promise<void>): Promise<void>;
   stop?(): Promise<void>;
 };
@@ -1090,6 +1162,199 @@ export class TelegramAdapter implements TelegramProviderAdapter {
         errorMessage: errorMessage(error),
         outcome: "failed",
         title,
+        updatedAt: this.now(),
+      };
+    }
+  }
+
+  async getManagedConversationRights(
+    request: MessagingManagedConversationRightsRequest,
+  ): Promise<MessagingManagedConversationRightsResult> {
+    const conversation = request.channel.conversation;
+    const target =
+      this.telegramStateFromChannel(conversation) ??
+      this.telegramStateFromSurface(request.routingState);
+    if (!target) {
+      return {
+        channel: this.channel,
+        conversation,
+        errorMessage: "Telegram topic management needs a supergroup or topic target.",
+        operations: unsupportedManagedTopicOperations("unsupported target"),
+        outcome: "unsupported",
+        updatedAt: this.now(),
+      };
+    }
+
+    try {
+      const me = await this.bot.api.getMe();
+      const member = await this.bot.api.getChatMember(target.chatId, me.id);
+      const isAdmin = member.status === "creator" || member.status === "administrator";
+      const canManageTopics =
+        member.status === "creator" || member.can_manage_topics === true;
+      const canDeleteMessages =
+        member.status === "creator" || member.can_delete_messages === true;
+      return {
+        channel: this.channel,
+        conversation,
+        operations: [
+          {
+            operation: "create_child",
+            supported: isAdmin && canManageTopics,
+            missingPermission: isAdmin && !canManageTopics ? "can_manage_topics" : undefined,
+            reason: isAdmin ? undefined : "bot is not an administrator",
+          },
+          {
+            operation: "close",
+            supported: isAdmin && canManageTopics,
+            missingPermission: isAdmin && !canManageTopics ? "can_manage_topics" : undefined,
+            reason: isAdmin ? undefined : "bot is not an administrator",
+          },
+          {
+            operation: "reopen",
+            supported: isAdmin && canManageTopics,
+            missingPermission: isAdmin && !canManageTopics ? "can_manage_topics" : undefined,
+            reason: isAdmin ? undefined : "bot is not an administrator",
+          },
+          {
+            operation: "delete",
+            supported: isAdmin && canDeleteMessages,
+            missingPermission: isAdmin && !canDeleteMessages ? "can_delete_messages" : undefined,
+            reason: isAdmin ? undefined : "bot is not an administrator",
+          },
+        ],
+        outcome: "ok",
+        updatedAt: this.now(),
+      };
+    } catch (error) {
+      return {
+        channel: this.channel,
+        conversation,
+        errorMessage: errorMessage(error),
+        operations: unsupportedManagedTopicOperations(errorMessage(error)),
+        outcome: "failed",
+        updatedAt: this.now(),
+      };
+    }
+  }
+
+  async createManagedConversation(
+    request: MessagingManagedConversationCreateRequest,
+  ): Promise<MessagingManagedConversationCreateResult> {
+    const parent = request.parent.conversation;
+    const target =
+      this.telegramStateFromChannel(parent) ??
+      this.telegramStateFromSurface(request.routingState);
+    if (!target) {
+      return {
+        channel: this.channel,
+        errorMessage: "Telegram topic creation needs a supergroup target.",
+        outcome: "unsupported",
+        updatedAt: this.now(),
+      };
+    }
+
+    const title = sanitizeTelegramTopicName(request.title);
+    try {
+      const topic = await this.bot.api.createForumTopic({
+        chat_id: target.chatId,
+        name: title,
+      });
+      const conversation = {
+        id: String(topic.message_thread_id),
+        kind: "topic" as const,
+        parentId: String(target.chatId),
+        parentTitle: parent.kind === "topic" ? parent.parentTitle : parent.title,
+        title: topic.name,
+      };
+      this.topicNameCache.set(
+        this.topicCacheKey(target.chatId, topic.message_thread_id),
+        topic.name,
+      );
+      return {
+        channel: this.channel,
+        conversation,
+        outcome: "created",
+        routingState: {
+          opaque: {
+            chatId: target.chatId,
+            messageThreadId: topic.message_thread_id,
+          },
+        },
+        updatedAt: this.now(),
+      };
+    } catch (error) {
+      return {
+        channel: this.channel,
+        errorMessage: errorMessage(error),
+        outcome: "failed",
+        updatedAt: this.now(),
+      };
+    }
+  }
+
+  async closeManagedConversation(
+    request: MessagingManagedConversationActionRequest,
+  ): Promise<MessagingManagedConversationActionResult> {
+    return await this.applyManagedTopicAction(request, "close");
+  }
+
+  async reopenManagedConversation(
+    request: MessagingManagedConversationActionRequest,
+  ): Promise<MessagingManagedConversationActionResult> {
+    return await this.applyManagedTopicAction(request, "reopen");
+  }
+
+  async deleteManagedConversation(
+    request: MessagingManagedConversationActionRequest,
+  ): Promise<MessagingManagedConversationActionResult> {
+    return await this.applyManagedTopicAction(request, "delete");
+  }
+
+  private async applyManagedTopicAction(
+    request: MessagingManagedConversationActionRequest,
+    operation: "close" | "reopen" | "delete",
+  ): Promise<MessagingManagedConversationActionResult> {
+    const conversation = request.channel.conversation;
+    const target =
+      this.telegramStateFromChannel(conversation) ??
+      this.telegramStateFromSurface(request.routingState);
+    if (conversation.kind !== "topic" || !target?.messageThreadId) {
+      return {
+        channel: this.channel,
+        conversation,
+        errorMessage: "Telegram topic action needs a forum topic target.",
+        operation,
+        outcome: "unsupported",
+        updatedAt: this.now(),
+      };
+    }
+
+    try {
+      const payload = {
+        chat_id: target.chatId,
+        message_thread_id: target.messageThreadId,
+      };
+      if (operation === "close") {
+        await this.bot.api.closeForumTopic(payload);
+      } else if (operation === "reopen") {
+        await this.bot.api.reopenForumTopic(payload);
+      } else {
+        await this.bot.api.deleteForumTopic(payload);
+      }
+      return {
+        channel: this.channel,
+        conversation,
+        operation,
+        outcome: "updated",
+        updatedAt: this.now(),
+      };
+    } catch (error) {
+      return {
+        channel: this.channel,
+        conversation,
+        errorMessage: errorMessage(error),
+        operation,
+        outcome: "failed",
         updatedAt: this.now(),
       };
     }
@@ -2372,6 +2637,19 @@ function uploadableFileParts(intent: MessagingSurfaceIntent): MessagingFilePart[
   );
 }
 
+function unsupportedManagedTopicOperations(reason: string) {
+  return ([
+    "create_child",
+    "close",
+    "reopen",
+    "delete",
+  ] as const).map((operation) => ({
+    operation,
+    reason,
+    supported: false,
+  }));
+}
+
 function textForTelegramIntentWithoutFiles(intent: MessagingSurfaceIntent): string {
   if (intent.kind !== "message") {
     return textForTelegramIntent(intent);
@@ -2413,7 +2691,19 @@ export function adaptGrammyBot(bot: TelegramGrammyBotLike): TelegramBotLike {
         await bot.api.answerCallbackQuery(params.callback_query_id, {
           text: params.text,
         }),
+      closeForumTopic: async (request) =>
+        await bot.api.closeForumTopic(
+          request.chat_id,
+          request.message_thread_id,
+        ),
+      createForumTopic: async (request) =>
+        await bot.api.createForumTopic(request.chat_id, request.name),
       deleteWebhook: async (params) => await bot.api.deleteWebhook(params),
+      deleteForumTopic: async (request) =>
+        await bot.api.deleteForumTopic(
+          request.chat_id,
+          request.message_thread_id,
+        ),
       editForumTopic: async (request) =>
         await bot.api.editForumTopic(
           request.chat_id,
@@ -2422,6 +2712,8 @@ export function adaptGrammyBot(bot: TelegramGrammyBotLike): TelegramBotLike {
             name: request.name,
           },
         ),
+      getChatMember: async (chatId, userId) =>
+        await bot.api.getChatMember(chatId, userId),
       editMessageText: async (request) => {
         const { chat_id, message_id, text, ...other } = request;
         return coerceTelegramSentMessage(
@@ -2430,6 +2722,11 @@ export function adaptGrammyBot(bot: TelegramGrammyBotLike): TelegramBotLike {
         );
       },
       getMe: async () => await bot.api.getMe(),
+      reopenForumTopic: async (request) =>
+        await bot.api.reopenForumTopic(
+          request.chat_id,
+          request.message_thread_id,
+        ),
       getWebhookInfo: async () => await bot.api.getWebhookInfo(),
       getFile: async (fileId) => await bot.api.getFile(fileId),
       pinChatMessage: async (request) => {


### PR DESCRIPTION
## Summary

PwrAgent can now own Telegram forum topics instead of treating them as passive message surfaces. Operators can establish a `/monitor topics` control topic, see whether the bot has the Telegram rights needed to create, close, reopen, or delete topics, and run cleanup as a dry run before approving any destructive action.

Monitor fanout can create one Telegram topic per selected PwrAgent thread, seed it with thread context, persist the thread-topic link, and bind that topic to the thread so follow-up messages route back to the right agent thread. The implementation keeps cleanup honest about Telegram's Bot API limitation: bots can manage topics they know about, but cannot enumerate every historical topic in a supergroup.

## Design Notes

| Area | Decision |
|---|---|
| Adapter contract | Added optional managed-conversation operations so non-Telegram providers are not forced into topic semantics. |
| Telegram permissions | Uses `getChatMember` to report `can_manage_topics` and `can_delete_messages` support before surfacing cleanup actions. |
| Persistence | Stores managed topic records, thread-topic links, and cleanup proposals so fanout and approvals are idempotent. |
| Safety | Cleanup starts as a proposal; close/delete only runs after approving the exact proposal item. |
| Fanout | Existing thread-topic links are reused, and newly created topics are immediately bound to their PwrAgent thread. |

## Validation

- `pnpm --filter @pwragent/messaging-provider-telegram typecheck`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm --filter @pwragent/messaging-provider-telegram exec vitest run src/__tests__/telegram-grammy-adapter.test.ts src/__tests__/telegram-adapter-security.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/messaging-store.test.ts apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts apps/desktop/src/main/__tests__/messaging-controller.test.ts`
- `pnpm lint:boundaries`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
