### PR TITLE
fix(desktop): escape composer inline modes

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -671,6 +671,9 @@ function insertPlainSpaceAtTextblockEnd(editor: TiptapEditor): boolean {
   if (currentPos.pos !== currentPos.end()) {
     return false;
   }
+  if (currentPos.parent.type.name === "codeBlock") {
+    return false;
+  }
 
   const currentMarks = editor.state.storedMarks ?? currentPos.marks();
   const textBeforeCursor = currentPos.parent.textBetween(

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -646,6 +646,56 @@ function insertWysiwygSoftBreak(editor: TiptapEditor): boolean {
   return editor.commands.setHardBreak();
 }
 
+function getTrailingComposerToken(text: string): string | undefined {
+  return text.match(/(?:^|\s)(\S+)$/)?.[1];
+}
+
+function isLinkLikeComposerToken(token: string): boolean {
+  const trimmed = token.replace(/[),.;:!?]+$/, "");
+  if (/^(?:https?:\/\/|www\.)\S+\.\S+$/i.test(trimmed)) {
+    return true;
+  }
+  if (/^[^\s/]+\/\S+$/.test(trimmed)) {
+    return true;
+  }
+  return /^[^\s/]+\.[A-Za-z]{2,}(?:\/\S*)?$/.test(trimmed);
+}
+
+function insertPlainSpaceAtTextblockEnd(editor: TiptapEditor): boolean {
+  const { selection } = editor.state;
+  if (!selection.empty) {
+    return false;
+  }
+
+  const currentPos = selection.$from;
+  if (currentPos.pos !== currentPos.end()) {
+    return false;
+  }
+
+  const currentMarks = editor.state.storedMarks ?? currentPos.marks();
+  const textBeforeCursor = currentPos.parent.textBetween(
+    0,
+    currentPos.parentOffset,
+    undefined,
+    "\uFFFC",
+  );
+  const trailingToken = getTrailingComposerToken(textBeforeCursor);
+  if (
+    currentMarks.length === 0 &&
+    (!trailingToken || !isLinkLikeComposerToken(trailingToken))
+  ) {
+    return false;
+  }
+
+  let transaction = editor.state.tr;
+  currentMarks.forEach((mark) => {
+    transaction = transaction.removeStoredMark(mark);
+  });
+  transaction = transaction.insertText(" ", currentPos.pos).scrollIntoView();
+  editor.view.dispatch(transaction);
+  return true;
+}
+
 function getPlainTextFromPaste(event: ClipboardEvent<HTMLDivElement>): string {
   return event.clipboardData?.getData("text/plain").replace(/\r\n?/g, "\n") ?? "";
 }
@@ -1333,6 +1383,21 @@ export const ComposerTiptapInput = forwardRef<
             }
             event.preventDefault();
             return runUndoOrRedo(currentEditor, "undo");
+          }
+
+          if (
+            propsRef.current.markdownConversion &&
+            event.key === "ArrowRight" &&
+            !event.metaKey &&
+            !event.ctrlKey &&
+            !event.altKey &&
+            !event.shiftKey
+          ) {
+            const currentEditor = editorRef.current;
+            if (currentEditor && insertPlainSpaceAtTextblockEnd(currentEditor)) {
+              event.preventDefault();
+              return true;
+            }
           }
 
           if (

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx
@@ -173,6 +173,22 @@ describe("ComposerTiptapInput", () => {
     expect(onChange).not.toHaveBeenCalledWith(`${value} `, []);
   });
 
+  it("does not insert an escape space inside code blocks ending in paths", async () => {
+    const codeContent = "docs/brainstorms/example.md";
+    const value = `\`\`\`md\n${codeContent}\n\`\`\``;
+    const { container, onChange } = renderTiptapInput({ value });
+    const textbox = await screen.findByRole("textbox", { name: "Reply" });
+
+    setComposerSelection(textbox, "```md\n".length + codeContent.length);
+    fireEvent.keyDown(textbox, { key: "ArrowRight" });
+
+    expect(onChange).not.toHaveBeenCalledWith(`\`\`\`md\n${codeContent} \n\`\`\``, []);
+    expect(container.querySelector("pre code")).toHaveTextContent(codeContent);
+    expect(container.querySelector("pre code")).not.toHaveTextContent(
+      `${codeContent} `,
+    );
+  });
+
   // The `is-empty` class on `.composer-tiptap-input` is the contract
   // hook for empty-state styling — currently used for the placeholder
   // appearance, but reserved for any future CSS that distinguishes

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx
@@ -40,6 +40,14 @@ function renderTiptapInput(props?: {
   return { ...result, onChange };
 }
 
+function setComposerSelection(textbox: HTMLElement, index: number): void {
+  (
+    textbox as HTMLElement & {
+      setSelectionRange: (start: number, end?: number) => void;
+    }
+  ).setSelectionRange(index);
+}
+
 describe("ComposerTiptapInput", () => {
   it("does not render initial URLs or path-like markdown filenames as links", async () => {
     const { container } = renderTiptapInput({
@@ -121,6 +129,48 @@ describe("ComposerTiptapInput", () => {
     expect(container.querySelector("strong")).toHaveTextContent("this bold word");
     expect(container.querySelector("em")).toHaveTextContent("this italic");
     expect(container.querySelector("code")).toHaveTextContent("inline code");
+  });
+
+  it("pressing ArrowRight at the end of a bold run exits the mark with a plain space", async () => {
+    const original = "**GitHub PR title**";
+    const { container, onChange } = renderTiptapInput({ value: original });
+    const textbox = await screen.findByRole("textbox", { name: "Reply" });
+
+    setComposerSelection(textbox, original.length);
+    fireEvent.keyDown(textbox, { key: "ArrowRight" });
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith(`${original} `, []);
+    });
+    expect(container.querySelector("strong")).toHaveTextContent("GitHub PR title");
+    expect(container.querySelector("strong")).not.toHaveTextContent(
+      "GitHub PR title ",
+    );
+  });
+
+  it("pressing ArrowRight after a pasted path-like token inserts an escape space", async () => {
+    const path =
+      "docs/brainstorms/2026-05-22-messaging-full-access-approval-requirements.md";
+    const { onChange } = renderTiptapInput({ value: path });
+    const textbox = await screen.findByRole("textbox", { name: "Reply" });
+
+    setComposerSelection(textbox, path.length);
+    fireEvent.keyDown(textbox, { key: "ArrowRight" });
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith(`${path} `, []);
+    });
+  });
+
+  it("does not turn ArrowRight at the end of normal prose into a space", async () => {
+    const value = "plain prose";
+    const { onChange } = renderTiptapInput({ value });
+    const textbox = await screen.findByRole("textbox", { name: "Reply" });
+
+    setComposerSelection(textbox, value.length);
+    fireEvent.keyDown(textbox, { key: "ArrowRight" });
+
+    expect(onChange).not.toHaveBeenCalledWith(`${value} `, []);
   });
 
   // The `is-empty` class on `.composer-tiptap-input` is the contract


### PR DESCRIPTION
## Summary

- I added an ArrowRight escape path for the composer when the cursor is at the end of an inline formatted run, so bold, italic, strikethrough, code, and similar mark states can be exited with a plain inserted space.
- I also handle trailing URL/path-like composer tokens, including copied local markdown file links that land as `.md` paths, so the user can get out of that mode the same way.
- I added focused regression coverage for bold escape, `.md` path escape, and normal prose staying unchanged.

## Verification

- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`

## Notes

- I checked the referenced local Codex thread. The copied value came from an explicit markdown local-file link in the assistant response, not just a bare `.md` path in the response text.

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
Generated with Codex via [Codex](https://openai.com/codex)
