### PR TITLE
fix(desktop): surface Codex config trust warnings

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -537,6 +537,10 @@ class MockBackendClient {
     reasoningEffort?: string;
     fastMode?: boolean;
   };
+  lastTrustProjectParams?: {
+    projectPath: string;
+    configPath?: string;
+  };
   listThreadsCallCount = 0;
   listModelsCallCount = 0;
   steerTurnCallCount = 0;
@@ -811,6 +815,14 @@ class MockBackendClient {
       turnId: "compact-turn-1",
       itemId: "compact-item-1",
     };
+  }
+
+  async trustProject(params: {
+    projectPath: string;
+    configPath?: string;
+  }): Promise<{ projectPath: string; configPath?: string }> {
+    this.lastTrustProjectParams = params;
+    return params;
   }
 
   async emit(notification: AppServerNotification): Promise<void> {
@@ -1098,6 +1110,32 @@ describe("DesktopBackendRegistry", () => {
         unavailableReason: "grok app server unavailable: XAI_API_KEY is not set",
       },
     ]);
+
+    await registry.close();
+  });
+
+  it("delegates Codex project trust to the Codex client", async () => {
+    const codexClient = new MockBackendClient({});
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({}),
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    const response = await registry.trustCodexProject({
+      projectPath: "/Users/huntharo/github/PwrAgnt",
+      configPath: "/Users/huntharo/.codex/profiles/acp-smoke/config.toml",
+    });
+
+    expect(response).toEqual({
+      projectPath: "/Users/huntharo/github/PwrAgnt",
+      configPath: "/Users/huntharo/.codex/profiles/acp-smoke/config.toml",
+      trusted: true,
+    });
+    expect(codexClient.lastTrustProjectParams).toEqual({
+      projectPath: "/Users/huntharo/github/PwrAgnt",
+      configPath: "/Users/huntharo/.codex/profiles/acp-smoke/config.toml",
+    });
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1140,6 +1140,51 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
+  it("buffers the latest Codex config warning until the project is trusted", async () => {
+    const codexClient = new MockBackendClient({});
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({}),
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    expect(registry.getLatestCodexConfigWarning()).toEqual({});
+
+    await codexClient.emit({
+      method: "configWarning",
+      params: {
+        summary: "Project-local config is disabled.",
+        details: null,
+        trustedProjectPath: "/Users/huntharo/github/PwrAgnt",
+        configPath: "/Users/huntharo/.codex/profiles/acp-smoke/config.toml",
+      },
+    });
+
+    expect(registry.getLatestCodexConfigWarning()).toEqual({
+      event: {
+        backend: "codex",
+        notification: {
+          method: "configWarning",
+          params: {
+            summary: "Project-local config is disabled.",
+            details: null,
+            trustedProjectPath: "/Users/huntharo/github/PwrAgnt",
+            configPath: "/Users/huntharo/.codex/profiles/acp-smoke/config.toml",
+          },
+        },
+      },
+    });
+
+    await registry.trustCodexProject({
+      projectPath: "/Users/huntharo/github/PwrAgnt",
+      configPath: "/Users/huntharo/.codex/profiles/acp-smoke/config.toml",
+    });
+
+    expect(registry.getLatestCodexConfigWarning()).toEqual({});
+
+    await registry.close();
+  });
+
   it("reads Codex models once from the default client and reuses them", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: {

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -75,6 +75,11 @@ class MockTransport implements JsonRpcTransport {
   static modelListResult: unknown = {
     data: []
   };
+  static configValueWriteResult: unknown = {
+    status: "ok",
+    filePath: "/Users/huntharo/.codex/config.toml"
+  };
+  static lastConfigValueWritePayload: unknown;
   static rateLimitsResult: unknown = {
     rateLimitsByLimitId: {}
   };
@@ -506,6 +511,18 @@ class MockTransport implements JsonRpcTransport {
       return;
     }
 
+    if (payload.method === "config/value/write") {
+      MockTransport.lastConfigValueWritePayload = JSON.parse(message).params;
+      this.messageHandler(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: payload.id,
+          result: MockTransport.configValueWriteResult,
+        })
+      );
+      return;
+    }
+
     if (payload.method === "account/rateLimits/read") {
       this.messageHandler(
         JSON.stringify({
@@ -900,6 +917,11 @@ describe("CodexAppServerClient", () => {
     MockTransport.modelListResult = {
       data: []
     };
+    MockTransport.configValueWriteResult = {
+      status: "ok",
+      filePath: "/Users/huntharo/.codex/config.toml"
+    };
+    MockTransport.lastConfigValueWritePayload = undefined;
     MockTransport.rateLimitsResult = {
       rateLimitsByLimitId: {}
     };
@@ -3236,6 +3258,89 @@ describe("CodexAppServerClient", () => {
         }
       }
     ]);
+
+    await client.close();
+  });
+
+  it("normalizes config warnings with project trust metadata", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => []
+    });
+
+    await client.getInitializeResult();
+
+    const notifications: Array<{ method: string; params: Record<string, unknown> }> = [];
+    client.onNotification((notification) => {
+      notifications.push(
+        notification as { method: string; params: Record<string, unknown> }
+      );
+    });
+
+    const transport = MockTransport.instances.at(-1);
+    expect(transport).toBeDefined();
+
+    transport!.emitInbound({
+      jsonrpc: "2.0",
+      method: "configWarning",
+      params: {
+        summary:
+          "Project-local config, hooks, and exec policies are disabled in the following folders until the project is trusted, but skills still load.\n" +
+          "    1. /Users/huntharo/.codex/worktrees/mp9wyft8/PwrAgnt/.codex\n" +
+          "       To load project-local config, hooks, and exec policies, add /Users/huntharo/github/PwrAgnt as a trusted project in /Users/huntharo/.codex/profiles/acp-smoke/config.toml.\n",
+        details: null
+      }
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(codexClientLogWarn).not.toHaveBeenCalledWith(
+      "unknown codex notification",
+      expect.anything()
+    );
+    expect(notifications).toEqual([
+      {
+        method: "configWarning",
+        params: expect.objectContaining({
+          trustedProjectPath: "/Users/huntharo/github/PwrAgnt",
+          configPath: "/Users/huntharo/.codex/profiles/acp-smoke/config.toml",
+          details: null
+        })
+      }
+    ]);
+
+    await client.close();
+  });
+
+  it("writes Codex project trust through config/value/write", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => []
+    });
+
+    const response = await client.trustProject({
+      projectPath: "/Users/huntharo/github/PwrAgnt",
+      configPath: "/Users/huntharo/.codex/profiles/acp-smoke/config.toml"
+    });
+
+    expect(response).toEqual({
+      projectPath: "/Users/huntharo/github/PwrAgnt",
+      configPath: "/Users/huntharo/.codex/profiles/acp-smoke/config.toml"
+    });
+    expect(MockTransport.lastConfigValueWritePayload).toEqual({
+      keyPath: "projects",
+      value: {
+        "/Users/huntharo/github/PwrAgnt": {
+          trust_level: "trusted"
+        }
+      },
+      mergeStrategy: "upsert",
+      filePath: "/Users/huntharo/.codex/profiles/acp-smoke/config.toml"
+    });
 
     await client.close();
   });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -82,6 +82,8 @@ import {
   type StartThreadResponse,
   type SubmitServerRequestRequest,
   type SubmitServerRequestResponse,
+  type TrustCodexProjectRequest,
+  type TrustCodexProjectResponse,
   type ThreadExecutionMode,
   type ThreadOverlayState,
   type WorktreeSnapshotSummary,
@@ -301,6 +303,10 @@ type BackendClient = {
     reasoningEffort?: string;
     fastMode?: boolean;
   }): Promise<{ threadId: string }>;
+  trustProject?(params: {
+    projectPath: string;
+    configPath?: string;
+  }): Promise<{ projectPath: string; configPath?: string }>;
 };
 
 /**
@@ -1868,6 +1874,24 @@ export class DesktopBackendRegistry {
 
   async publishLocalEvent(event: AgentEvent): Promise<void> {
     await this.emit(event);
+  }
+
+  async trustCodexProject(
+    request: TrustCodexProjectRequest,
+  ): Promise<TrustCodexProjectResponse> {
+    if (!this.codexClient.trustProject) {
+      throw new Error("Codex project trust is not available.");
+    }
+
+    const result = await this.codexClient.trustProject({
+      projectPath: request.projectPath,
+      ...(request.configPath ? { configPath: request.configPath } : {}),
+    });
+    return {
+      projectPath: result.projectPath,
+      ...(result.configPath ? { configPath: result.configPath } : {}),
+      trusted: true,
+    };
   }
 
   async listBackends(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -40,6 +40,7 @@ import {
   isBranchDrifted,
   type HandoffThreadWorkspaceRequest,
   type HandoffThreadWorkspaceResponse,
+  type LatestCodexConfigWarningResponse,
   type ListBackendsRequest,
   type ListBackendsResponse,
   type LinkedDirectorySummary,
@@ -1500,6 +1501,7 @@ export class DesktopBackendRegistry {
   private readonly eventListeners = new Set<
     (event: AgentEvent) => void | Promise<void>
   >();
+  private latestCodexConfigWarning?: AgentEvent;
   private readonly unsubscribers: Array<() => void> = [];
   private readonly pendingServerRequests = new Map<string, PendingServerRequest>();
   private readonly pendingTitleGenerations = new Map<
@@ -1876,6 +1878,12 @@ export class DesktopBackendRegistry {
     await this.emit(event);
   }
 
+  getLatestCodexConfigWarning(): LatestCodexConfigWarningResponse {
+    return this.latestCodexConfigWarning
+      ? { event: this.latestCodexConfigWarning }
+      : {};
+  }
+
   async trustCodexProject(
     request: TrustCodexProjectRequest,
   ): Promise<TrustCodexProjectResponse> {
@@ -1887,6 +1895,16 @@ export class DesktopBackendRegistry {
       projectPath: request.projectPath,
       ...(request.configPath ? { configPath: request.configPath } : {}),
     });
+    if (
+      this.latestCodexConfigWarning?.notification.method === "configWarning" &&
+      this.latestCodexConfigWarning.notification.params.trustedProjectPath ===
+        request.projectPath &&
+      (!request.configPath ||
+        this.latestCodexConfigWarning.notification.params.configPath ===
+          request.configPath)
+    ) {
+      this.latestCodexConfigWarning = undefined;
+    }
     return {
       projectPath: result.projectPath,
       ...(result.configPath ? { configPath: result.configPath } : {}),
@@ -6353,6 +6371,13 @@ export class DesktopBackendRegistry {
   }
 
   private async emit(event: AgentEvent): Promise<void> {
+    if (
+      event.backend === "codex" &&
+      event.notification.method === "configWarning"
+    ) {
+      this.latestCodexConfigWarning = event;
+    }
+
     if (
       event.backend === "codex" &&
       event.notification.method === "turn/started"

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -46,6 +46,7 @@ import type {
 } from "@pwragent/codex-app-server-protocol";
 import type {
   AskForApproval as CodexAskForApproval,
+  ConfigValueWriteParams as CodexConfigValueWriteParams,
   ModelListParams as CodexModelListParams,
   SandboxMode as CodexSandboxMode,
   SandboxPolicy as CodexSandboxPolicy,
@@ -185,6 +186,7 @@ const KNOWN_NOTIFICATION_METHODS = new Set<string>([
   "turn/diff/updated",
   "serverRequest/resolved",
   "warning",
+  "configWarning",
   "thread/compacted",
   "thread/archived",
   "thread/unarchived",
@@ -205,6 +207,7 @@ const KNOWN_NOTIFICATION_METHODS = new Set<string>([
 ]);
 const GENERATED_CODEX_NOTIFICATION_METHODS = new Set<string>([
   "warning",
+  "configWarning",
   "thread/started",
   "turn/started",
   "turn/completed",
@@ -582,16 +585,49 @@ function normalizeServerNotification(
       ? normalizeLiveNotificationItem(itemRecord)
       : undefined;
 
+  const configWarningMetadata =
+    method === "configWarning"
+      ? extractConfigWarningMetadata(record)
+      : undefined;
+
   return {
     method: method as AppServerNotification["method"],
     params: {
       ...record,
+      ...(configWarningMetadata ?? {}),
       ...(normalizedItem ? { item: normalizedItem } : {}),
       ...(metadata.threadId ? { threadId: metadata.threadId } : {}),
       ...(metadata.turnId ? { turnId: metadata.turnId } : {}),
       ...(metadata.requestId ? { requestId: metadata.requestId } : {}),
     } as AppServerNotification["params"],
   } as AppServerNotification;
+}
+
+function extractConfigWarningMetadata(
+  record: Record<string, unknown>,
+): { trustedProjectPath?: string; configPath?: string } | undefined {
+  const summary = pickString(record, ["summary"]);
+  if (!summary) {
+    return undefined;
+  }
+
+  const trustLine = summary
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find((line) => /as a trusted project in/i.test(line));
+  const trustMatch = trustLine?.match(
+    /add\s+(.+?)\s+as a trusted project in\s+(.+?)\s*\.?$/i,
+  );
+  if (!trustMatch) {
+    return undefined;
+  }
+
+  const trustedProjectPath = trustMatch[1]?.trim();
+  const configPath = trustMatch[2]?.trim();
+  return {
+    ...(trustedProjectPath ? { trustedProjectPath } : {}),
+    ...(configPath ? { configPath } : {}),
+  };
 }
 
 function normalizeLiveNotificationItem(
@@ -3792,6 +3828,44 @@ export class CodexAppServerClient {
   async getInitializeResult(): Promise<InitializeResult> {
     await this.ensureInitialized();
     return this.initializeResult ?? {};
+  }
+
+  async trustProject(params: {
+    projectPath: string;
+    configPath?: string;
+  }): Promise<{ projectPath: string; configPath?: string }> {
+    const projectPath = params.projectPath.trim();
+    if (!projectPath) {
+      throw new Error("projectPath is required");
+    }
+    await this.ensureInitialized();
+
+    const payload: CodexConfigValueWriteParams = {
+      keyPath: "projects",
+      value: {
+        [projectPath]: {
+          trust_level: "trusted",
+        },
+      },
+      mergeStrategy: "upsert",
+      ...(params.configPath?.trim()
+        ? { filePath: params.configPath.trim() }
+        : {}),
+    };
+
+    await requestWithFallbacks({
+      client: this.connection,
+      methods: ["config/value/write"],
+      payloads: [payload],
+      timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+    });
+
+    return {
+      projectPath,
+      ...(params.configPath?.trim()
+        ? { configPath: params.configPath.trim() }
+        : {}),
+    };
   }
 
   private async recordThreadNameWithCodex(value: unknown): Promise<void> {

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -34,6 +34,8 @@ import type {
   StartTurnResponse,
   SubmitServerRequestRequest,
   SubmitServerRequestResponse,
+  TrustCodexProjectRequest,
+  TrustCodexProjectResponse,
   UpdateThreadExpectedBranchRequest,
   UpdateThreadExpectedBranchResponse,
 } from "@pwragent/shared";
@@ -55,6 +57,7 @@ import {
   AGENT_START_TURN_CHANNEL,
   AGENT_STEER_TURN_CHANNEL,
   AGENT_SUBMIT_SERVER_REQUEST_CHANNEL,
+  AGENT_TRUST_CODEX_PROJECT_CHANNEL,
   AGENT_UPDATE_THREAD_EXPECTED_BRANCH_CHANNEL,
   BACKEND_LIST_CHANNEL,
   CODEX_ENVIRONMENT_SETUP_PROGRESS_CHANNEL,
@@ -459,6 +462,17 @@ export function registerAgentIpcHandlers(): void {
       return await registry.submitServerRequest(request);
     },
   );
+
+  ipcMain.removeHandler(AGENT_TRUST_CODEX_PROJECT_CHANNEL);
+  ipcMain.handle(
+    AGENT_TRUST_CODEX_PROJECT_CHANNEL,
+    async (
+      _event,
+      request: TrustCodexProjectRequest,
+    ): Promise<TrustCodexProjectResponse> => {
+      return await registry.trustCodexProject(request);
+    },
+  );
 }
 
 export function disposeAgentIpcHandlers(): void {
@@ -481,4 +495,5 @@ export function disposeAgentIpcHandlers(): void {
   ipcMain.removeHandler(AGENT_RUN_CODEX_ENVIRONMENT_ACTION_CHANNEL);
   ipcMain.removeHandler(AGENT_SET_CODEX_THREAD_ENVIRONMENT_CHANNEL);
   ipcMain.removeHandler(AGENT_SUBMIT_SERVER_REQUEST_CHANNEL);
+  ipcMain.removeHandler(AGENT_TRUST_CODEX_PROJECT_CHANNEL);
 }

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -10,6 +10,7 @@ import type {
   MaterializeDirectoryLaunchpadResponse,
   InterruptTurnRequest,
   InterruptTurnResponse,
+  LatestCodexConfigWarningResponse,
   ListBackendsRequest,
   ListBackendsResponse,
   QueueThreadExecutionModeRequest,
@@ -43,6 +44,7 @@ import { getDesktopBackendRegistry } from "../app-server/backend-registry";
 import {
   AGENT_CANCEL_THREAD_EXECUTION_MODE_QUEUE_CHANNEL,
   AGENT_EVENT_CHANNEL,
+  AGENT_LATEST_CODEX_CONFIG_WARNING_CHANNEL,
   AGENT_CHECK_THREAD_BRANCH_DRIFT_CHANNEL,
   AGENT_INTERRUPT_TURN_CHANNEL,
   AGENT_MATERIALIZE_DIRECTORY_LAUNCHPAD_CHANNEL,
@@ -473,6 +475,14 @@ export function registerAgentIpcHandlers(): void {
       return await registry.trustCodexProject(request);
     },
   );
+
+  ipcMain.removeHandler(AGENT_LATEST_CODEX_CONFIG_WARNING_CHANNEL);
+  ipcMain.handle(
+    AGENT_LATEST_CODEX_CONFIG_WARNING_CHANNEL,
+    async (): Promise<LatestCodexConfigWarningResponse> => {
+      return registry.getLatestCodexConfigWarning();
+    },
+  );
 }
 
 export function disposeAgentIpcHandlers(): void {
@@ -496,4 +506,5 @@ export function disposeAgentIpcHandlers(): void {
   ipcMain.removeHandler(AGENT_SET_CODEX_THREAD_ENVIRONMENT_CHANNEL);
   ipcMain.removeHandler(AGENT_SUBMIT_SERVER_REQUEST_CHANNEL);
   ipcMain.removeHandler(AGENT_TRUST_CODEX_PROJECT_CHANNEL);
+  ipcMain.removeHandler(AGENT_LATEST_CODEX_CONFIG_WARNING_CHANNEL);
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -20,6 +20,7 @@ import type {
   MaterializeDirectoryLaunchpadResponse,
   QueueThreadExecutionModeRequest,
   QueueThreadExecutionModeResponse,
+  LatestCodexConfigWarningResponse,
   SetThreadExecutionModeRequest,
   SetThreadExecutionModeResponse,
   SetThreadModelSettingsRequest,
@@ -167,6 +168,7 @@ import type {
 import {
   AGENT_CANCEL_THREAD_EXECUTION_MODE_QUEUE_CHANNEL,
   AGENT_EVENT_CHANNEL,
+  AGENT_LATEST_CODEX_CONFIG_WARNING_CHANNEL,
   APPEARANCE_CHANGED_EVENT_CHANNEL,
   AGENT_CHECK_THREAD_BRANCH_DRIFT_CHANNEL,
   AGENT_INTERRUPT_TURN_CHANNEL,
@@ -597,6 +599,8 @@ const desktopApi = Object.freeze({
     request: TrustCodexProjectRequest,
   ): Promise<TrustCodexProjectResponse> =>
     await ipcRenderer.invoke(AGENT_TRUST_CODEX_PROJECT_CHANNEL, request),
+  getLatestCodexConfigWarning: async (): Promise<LatestCodexConfigWarningResponse> =>
+    await ipcRenderer.invoke(AGENT_LATEST_CODEX_CONFIG_WARNING_CHANNEL),
   getNavigationSnapshot: async (
     request?: GetNavigationSnapshotRequest,
   ): Promise<NavigationSnapshot> =>

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -102,6 +102,8 @@ import type {
   StartTurnResponse,
   SubmitServerRequestRequest,
   SubmitServerRequestResponse,
+  TrustCodexProjectRequest,
+  TrustCodexProjectResponse,
   CheckDesktopCodexAuthProfileStatusRequest,
   CheckDesktopCodexAuthProfileStatusResponse,
   ClearDesktopSettingsSecretRequest,
@@ -180,6 +182,7 @@ import {
   AGENT_START_TURN_CHANNEL,
   AGENT_STEER_TURN_CHANNEL,
   AGENT_SUBMIT_SERVER_REQUEST_CHANNEL,
+  AGENT_TRUST_CODEX_PROJECT_CHANNEL,
   AGENT_UPDATE_THREAD_EXPECTED_BRANCH_CHANNEL,
   APP_CHANGELOG_DOCUMENT_READ_CHANNEL,
   APP_CHANGELOG_WINDOW_OPEN_CHANNEL,
@@ -590,6 +593,10 @@ const desktopApi = Object.freeze({
     request: SubmitServerRequestRequest
   ): Promise<SubmitServerRequestResponse> =>
     await ipcRenderer.invoke(AGENT_SUBMIT_SERVER_REQUEST_CHANNEL, request),
+  trustCodexProject: async (
+    request: TrustCodexProjectRequest,
+  ): Promise<TrustCodexProjectResponse> =>
+    await ipcRenderer.invoke(AGENT_TRUST_CODEX_PROJECT_CHANNEL, request),
   getNavigationSnapshot: async (
     request?: GetNavigationSnapshotRequest,
   ): Promise<NavigationSnapshot> =>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -31,6 +31,7 @@ import { usePullRequestRefresh } from "./features/pr-status/usePullRequestRefres
 import { useThreadSessionState } from "./lib/useThreadSessionState";
 import { useThreadSkills } from "./lib/useThreadSkills";
 import { useQueuedTurnRelease } from "./lib/useQueuedTurnRelease";
+import { CodexConfigWarningBanner } from "./features/codex-config/CodexConfigWarningBanner";
 import { AppUpdateBanner } from "./features/update/AppUpdateBanner";
 
 const SETTINGS_SECTIONS = new Set<SettingsSection>([
@@ -614,6 +615,7 @@ function DesktopAppShell(props: {
         />
       ) : null}
 
+      <CodexConfigWarningBanner desktopApi={desktopApi} />
       <AppUpdateBanner desktopApi={desktopApi} />
     </div>
   );

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -9,6 +9,7 @@ import {
   within
 } from "@testing-library/react";
 import type {
+  AgentEvent,
   DesktopSettingsSnapshot,
   StartTurnRequest,
   StartTurnResponse,
@@ -139,6 +140,85 @@ describe("App", () => {
     });
     expect(listBackends).not.toHaveBeenCalled();
     expect(getNavigationSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("surfaces Codex config warnings and can trust the indicated project", async () => {
+    const agentEventListeners = new Set<(event: AgentEvent) => void>();
+    const trustCodexProject = vi.fn(
+      async (request: { projectPath: string; configPath?: string }) => ({
+        ...request,
+        trusted: true,
+      }),
+    );
+
+    Object.defineProperty(window, "pwragent", {
+      configurable: true,
+      value: {
+        listBackends: async () => ({
+          fetchedAt: Date.now(),
+          backends: [],
+        }),
+        getNavigationSnapshot: async () => ({
+          backend: "all" as const,
+          fetchedAt: Date.now(),
+          unchanged: false,
+          inboxThreadKeys: [],
+          threads: [],
+          directories: [],
+          launchpadDefaults: {
+            backend: "codex" as const,
+            executionMode: "default" as const,
+          },
+        }),
+        onAgentEvent: (listener: (event: AgentEvent) => void) => {
+          agentEventListeners.add(listener);
+          return () => {
+            agentEventListeners.delete(listener);
+          };
+        },
+        trustCodexProject,
+      },
+    });
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(agentEventListeners.size).toBeGreaterThan(0);
+    });
+
+    await act(async () => {
+      for (const listener of agentEventListeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "configWarning",
+            params: {
+              summary:
+                "Project-local config, hooks, and exec policies are disabled.\n" +
+                "To load project-local config, hooks, and exec policies, add /Users/huntharo/github/PwrAgnt as a trusted project in /Users/huntharo/.codex/profiles/acp-smoke/config.toml.",
+              details: null,
+              trustedProjectPath: "/Users/huntharo/github/PwrAgnt",
+              configPath: "/Users/huntharo/.codex/profiles/acp-smoke/config.toml",
+            },
+          },
+        });
+      }
+    });
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Codex config warning"
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Trust PwrAgnt" }));
+
+    await waitFor(() => {
+      expect(trustCodexProject).toHaveBeenCalledWith({
+        projectPath: "/Users/huntharo/github/PwrAgnt",
+        configPath: "/Users/huntharo/.codex/profiles/acp-smoke/config.toml",
+      });
+    });
+    await waitFor(() => {
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
   });
 
   it("blocks the app shell when desktop settings config is malformed", async () => {

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -221,6 +221,71 @@ describe("App", () => {
     });
   });
 
+  it("surfaces a buffered Codex config warning captured before renderer subscription", async () => {
+    const trustCodexProject = vi.fn(
+      async (request: { projectPath: string; configPath?: string }) => ({
+        ...request,
+        trusted: true,
+      }),
+    );
+    const getLatestCodexConfigWarning = vi.fn(async () => ({
+      event: {
+        backend: "codex" as const,
+        notification: {
+          method: "configWarning" as const,
+          params: {
+            summary:
+              "Project-local config, hooks, and exec policies are disabled.\n" +
+              "To load project-local config, hooks, and exec policies, add /Users/huntharo/github/PwrAgnt as a trusted project in /Users/huntharo/.codex/profiles/acp-smoke/config.toml.",
+            details: null,
+            trustedProjectPath: "/Users/huntharo/github/PwrAgnt",
+            configPath: "/Users/huntharo/.codex/profiles/acp-smoke/config.toml",
+          },
+        },
+      },
+    }));
+
+    Object.defineProperty(window, "pwragent", {
+      configurable: true,
+      value: {
+        listBackends: async () => ({
+          fetchedAt: Date.now(),
+          backends: [],
+        }),
+        getNavigationSnapshot: async () => ({
+          backend: "all" as const,
+          fetchedAt: Date.now(),
+          unchanged: false,
+          inboxThreadKeys: [],
+          threads: [],
+          directories: [],
+          launchpadDefaults: {
+            backend: "codex" as const,
+            executionMode: "default" as const,
+          },
+        }),
+        getLatestCodexConfigWarning,
+        trustCodexProject,
+      },
+    });
+
+    render(<App />);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Codex config warning"
+    );
+    expect(getLatestCodexConfigWarning).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Trust PwrAgnt" }));
+
+    await waitFor(() => {
+      expect(trustCodexProject).toHaveBeenCalledWith({
+        projectPath: "/Users/huntharo/github/PwrAgnt",
+        configPath: "/Users/huntharo/.codex/profiles/acp-smoke/config.toml",
+      });
+    });
+  });
+
   it("blocks the app shell when desktop settings config is malformed", async () => {
     const listBackends = vi.fn(async () => ({
       fetchedAt: Date.now(),

--- a/apps/desktop/src/renderer/src/features/codex-config/CodexConfigWarningBanner.tsx
+++ b/apps/desktop/src/renderer/src/features/codex-config/CodexConfigWarningBanner.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useMemo, useState } from "react";
+import type { AgentEvent } from "@pwragent/shared";
+import type { DesktopApi } from "../../lib/desktop-api";
+
+type ConfigWarningNotice = {
+  id: string;
+  summary: string;
+  details?: string | null;
+  trustedProjectPath?: string;
+  configPath?: string;
+};
+
+function noticeFromEvent(event: AgentEvent): ConfigWarningNotice | undefined {
+  if (event.backend !== "codex" || event.notification.method !== "configWarning") {
+    return undefined;
+  }
+
+  const params = event.notification.params as Record<string, unknown>;
+  const rawSummary = params.summary;
+  const summary = typeof rawSummary === "string" ? rawSummary.trim() : "";
+  if (!summary) {
+    return undefined;
+  }
+
+  const rawTrustedProjectPath = params.trustedProjectPath;
+  const rawConfigPath = params.configPath;
+  const rawDetails = params.details;
+  const trustedProjectPath =
+    typeof rawTrustedProjectPath === "string"
+      ? rawTrustedProjectPath.trim()
+      : undefined;
+  const configPath =
+    typeof rawConfigPath === "string" ? rawConfigPath.trim() : undefined;
+  const details = typeof rawDetails === "string" ? rawDetails : null;
+  const id = [
+    summary,
+    trustedProjectPath ?? "",
+    configPath ?? "",
+  ].join("\n");
+
+  return {
+    id,
+    summary,
+    ...(details ? { details } : {}),
+    ...(trustedProjectPath ? { trustedProjectPath } : {}),
+    ...(configPath ? { configPath } : {}),
+  };
+}
+
+export function CodexConfigWarningBanner(props: { desktopApi?: DesktopApi }) {
+  const [notice, setNotice] = useState<ConfigWarningNotice | null>(null);
+  const [dismissedIds, setDismissedIds] = useState<Set<string>>(() => new Set());
+  const [trusting, setTrusting] = useState(false);
+  const [trustError, setTrustError] = useState<string | null>(null);
+  const desktopApi = props.desktopApi;
+
+  useEffect(() => {
+    if (!desktopApi?.onAgentEvent) {
+      return;
+    }
+    return desktopApi.onAgentEvent((event) => {
+      const nextNotice = noticeFromEvent(event);
+      if (!nextNotice) {
+        return;
+      }
+      if (dismissedIds.has(nextNotice.id)) {
+        return;
+      }
+      setNotice(nextNotice);
+      setTrustError(null);
+      setTrusting(false);
+    });
+  }, [desktopApi, dismissedIds]);
+
+  const actionLabel = useMemo(() => {
+    const projectPath = notice?.trustedProjectPath;
+    if (!projectPath) {
+      return "Trust Project";
+    }
+    const label = projectPath.split(/[\\/]/).filter(Boolean).at(-1);
+    return label ? `Trust ${label}` : "Trust Project";
+  }, [notice?.trustedProjectPath]);
+
+  if (!notice) {
+    return null;
+  }
+
+  const trustProject = async (): Promise<void> => {
+    if (!notice.trustedProjectPath || !desktopApi?.trustCodexProject) {
+      setTrustError("Project trust is not available in this build.");
+      return;
+    }
+
+    setTrusting(true);
+    setTrustError(null);
+    try {
+      await desktopApi.trustCodexProject({
+        projectPath: notice.trustedProjectPath,
+        ...(notice.configPath ? { configPath: notice.configPath } : {}),
+      });
+      setDismissedIds((current) => new Set(current).add(notice.id));
+      setNotice(null);
+    } catch (error) {
+      setTrustError(error instanceof Error ? error.message : String(error));
+      setTrusting(false);
+    }
+  };
+
+  const dismiss = (): void => {
+    setDismissedIds((current) => new Set(current).add(notice.id));
+    setNotice(null);
+  };
+
+  return (
+    <aside className="codex-config-warning-banner" role="alert">
+      <div className="codex-config-warning-banner__content">
+        <p className="codex-config-warning-banner__eyebrow">Codex config warning</p>
+        <p className="codex-config-warning-banner__message">{notice.summary}</p>
+        {notice.details ? (
+          <p className="codex-config-warning-banner__detail">{notice.details}</p>
+        ) : null}
+        {trustError ? (
+          <p className="codex-config-warning-banner__error">{trustError}</p>
+        ) : null}
+      </div>
+      <div className="codex-config-warning-banner__actions">
+        {notice.trustedProjectPath ? (
+          <button
+            className="button button--primary"
+            type="button"
+            disabled={trusting}
+            onClick={() => {
+              void trustProject();
+            }}
+          >
+            {trusting ? "Trusting..." : actionLabel}
+          </button>
+        ) : null}
+        <button
+          className="button button--ghost"
+          type="button"
+          disabled={trusting}
+          onClick={dismiss}
+        >
+          Dismiss
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/codex-config/CodexConfigWarningBanner.tsx
+++ b/apps/desktop/src/renderer/src/features/codex-config/CodexConfigWarningBanner.tsx
@@ -55,10 +55,15 @@ export function CodexConfigWarningBanner(props: { desktopApi?: DesktopApi }) {
   const desktopApi = props.desktopApi;
 
   useEffect(() => {
-    if (!desktopApi?.onAgentEvent) {
+    if (!desktopApi?.onAgentEvent && !desktopApi?.getLatestCodexConfigWarning) {
       return;
     }
-    return desktopApi.onAgentEvent((event) => {
+
+    let cancelled = false;
+    const applyEvent = (event: AgentEvent): void => {
+      if (cancelled) {
+        return;
+      }
       const nextNotice = noticeFromEvent(event);
       if (!nextNotice) {
         return;
@@ -69,7 +74,23 @@ export function CodexConfigWarningBanner(props: { desktopApi?: DesktopApi }) {
       setNotice(nextNotice);
       setTrustError(null);
       setTrusting(false);
-    });
+    };
+
+    const unsubscribe = desktopApi.onAgentEvent?.(applyEvent);
+    void desktopApi.getLatestCodexConfigWarning?.()
+      .then((response) => {
+        if (response.event) {
+          applyEvent(response.event);
+        }
+      })
+      .catch(() => {
+        // Live events still cover builds that cannot provide a snapshot.
+      });
+
+    return () => {
+      cancelled = true;
+      unsubscribe?.();
+    };
   }, [desktopApi, dismissedIds]);
 
   const actionLabel = useMemo(() => {

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -29,6 +29,7 @@ import type {
   HandoffThreadWorkspaceResponse,
   InterruptTurnRequest,
   InterruptTurnResponse,
+  LatestCodexConfigWarningResponse,
   ListBackendsRequest,
   ListBackendsResponse,
   ListDesktopPwrAgentProfilesResponse,
@@ -317,6 +318,7 @@ export type DesktopApi = {
   trustCodexProject?: (
     request: TrustCodexProjectRequest,
   ) => Promise<TrustCodexProjectResponse>;
+  getLatestCodexConfigWarning?: () => Promise<LatestCodexConfigWarningResponse>;
   getNavigationSnapshot?: (
     request?: GetNavigationSnapshotRequest
   ) => Promise<NavigationSnapshot>;

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -104,6 +104,8 @@ import type {
   StartTurnResponse,
   SubmitServerRequestRequest,
   SubmitServerRequestResponse,
+  TrustCodexProjectRequest,
+  TrustCodexProjectResponse,
   CheckDesktopCodexAuthProfileStatusRequest,
   CheckDesktopCodexAuthProfileStatusResponse,
   ClearDesktopSettingsSecretRequest,
@@ -312,6 +314,9 @@ export type DesktopApi = {
   submitServerRequest?: (
     request: SubmitServerRequestRequest
   ) => Promise<SubmitServerRequestResponse>;
+  trustCodexProject?: (
+    request: TrustCodexProjectRequest,
+  ) => Promise<TrustCodexProjectResponse>;
   getNavigationSnapshot?: (
     request?: GetNavigationSnapshotRequest
   ) => Promise<NavigationSnapshot>;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3002,6 +3002,74 @@ textarea,
   background: var(--bg-app);
 }
 
+.codex-config-warning-banner {
+  position: fixed;
+  z-index: 82;
+  top: 16px;
+  right: 16px;
+  display: grid;
+  width: max-content;
+  max-width: min(520px, calc(100vw - 32px));
+  grid-template-columns: minmax(0, 1fr);
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid color-mix(in srgb, var(--status-warning) 52%, var(--border-subtle));
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--bg-panel-elevated) 92%, var(--status-warning) 8%);
+  box-shadow: var(--shadow-popover);
+  animation: app-update-banner-enter 160ms ease-out;
+}
+
+.codex-config-warning-banner__content {
+  min-width: 0;
+}
+
+.codex-config-warning-banner__eyebrow {
+  margin: 0 0 4px;
+  color: var(--status-warning);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.codex-config-warning-banner__message,
+.codex-config-warning-banner__detail,
+.codex-config-warning-banner__error {
+  margin: 0;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  font-size: 13px;
+  line-height: 1.35;
+}
+
+.codex-config-warning-banner__message {
+  color: var(--text-primary);
+}
+
+.codex-config-warning-banner__detail {
+  margin-top: 8px;
+  color: var(--text-secondary);
+}
+
+.codex-config-warning-banner__error {
+  margin-top: 8px;
+  color: var(--danger-text);
+}
+
+.codex-config-warning-banner__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.codex-config-warning-banner__actions .button {
+  min-height: 30px;
+  padding: 0 10px;
+}
+
 .app-update-banner {
   position: fixed;
   z-index: 80;

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -35,6 +35,7 @@ export const AGENT_RUN_CODEX_ENVIRONMENT_ACTION_CHANNEL =
 export const AGENT_SET_CODEX_THREAD_ENVIRONMENT_CHANNEL =
   "agent:set-codex-thread-environment";
 export const AGENT_SUBMIT_SERVER_REQUEST_CHANNEL = "agent:submit-server-request";
+export const AGENT_TRUST_CODEX_PROJECT_CHANNEL = "agent:trust-codex-project";
 export const AGENT_EVENT_CHANNEL = "agent:event";
 export const NAVIGATION_SNAPSHOT_CHANNEL = "navigation:get-snapshot";
 export const NAVIGATION_MARK_THREAD_SEEN_CHANNEL = "navigation:mark-thread-seen";

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -36,6 +36,8 @@ export const AGENT_SET_CODEX_THREAD_ENVIRONMENT_CHANNEL =
   "agent:set-codex-thread-environment";
 export const AGENT_SUBMIT_SERVER_REQUEST_CHANNEL = "agent:submit-server-request";
 export const AGENT_TRUST_CODEX_PROJECT_CHANNEL = "agent:trust-codex-project";
+export const AGENT_LATEST_CODEX_CONFIG_WARNING_CHANNEL =
+  "agent:latest-codex-config-warning";
 export const AGENT_EVENT_CHANNEL = "agent:event";
 export const NAVIGATION_SNAPSHOT_CHANNEL = "navigation:get-snapshot";
 export const NAVIGATION_MARK_THREAD_SEEN_CHANNEL = "navigation:mark-thread-seen";

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -220,6 +220,17 @@ export type SubmitServerRequestResponse = {
   requestId: string;
 };
 
+export type TrustCodexProjectRequest = {
+  projectPath: string;
+  configPath?: string;
+};
+
+export type TrustCodexProjectResponse = {
+  projectPath: string;
+  configPath?: string;
+  trusted: boolean;
+};
+
 export type EnsureDirectoryLaunchpadRequest = {
   directoryKey: string;
   directoryKind: DirectorySummaryKind;

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -411,6 +411,10 @@ export type AgentEvent = {
   notification: AppServerNotification;
 };
 
+export type LatestCodexConfigWarningResponse = {
+  event?: AgentEvent;
+};
+
 export type AppServerCollaborationModeRequest = {
   mode: "default" | "plan";
   settings?: {

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -901,6 +901,17 @@ export type AppServerNotification =
       };
     }
   | {
+      method: "configWarning";
+      params: {
+        summary: string;
+        details?: string | null;
+        path?: string;
+        range?: unknown;
+        trustedProjectPath?: string;
+        configPath?: string;
+      };
+    }
+  | {
       method: "thread/name/updated";
       params: {
         threadId: string;


### PR DESCRIPTION
## Summary

- I surface Codex `configWarning` notifications in the desktop UI when project-local config, hooks, or exec policies are disabled because a project has not been trusted yet.
- I parse the Codex warning summary for the trusted project path and target config path, then add a Trust action that writes the trusted project entry through the Codex App Server `config/value/write` protocol.
- I added the shared IPC contract, main/preload/renderer bridge, backend registry method, banner UI, and focused tests for the client normalization, IPC path, and renderer behavior.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/codex-client.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`
- `git diff --check`

## Notes

- The Trust action uses the generic Codex App Server config write protocol because there is not a dedicated trust-project method in the captured notification flow.
