### PR TITLE
feat(messaging): select backend for new threads

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -6,6 +6,7 @@ import type {
   AgentEvent,
   AppServerListSkillsResponse,
   AppServerPendingRequestNotification,
+  BackendSummary,
   CancelThreadExecutionModeQueueRequest,
   HandoffThreadWorkspaceRequest,
   ListBackendsResponse,
@@ -18,6 +19,7 @@ import type {
   StartTurnRequest,
   SteerTurnRequest,
   SubmitServerRequestRequest,
+  UpdateDirectoryLaunchpadRequest,
 } from "@pwragent/shared";
 import type {
   MessagingCapabilityProfile,
@@ -2293,6 +2295,196 @@ describe("MessagingController", () => {
       kind: "project_picker",
       fallbackText: expect.stringContaining("new PwrAgent thread"),
       prompt: expect.stringContaining("Choose a project"),
+    });
+  });
+
+  it("reports zero create-capable backends before opening the new-thread picker", async () => {
+    const harness = await createHarness({
+      listBackends: async (): Promise<ListBackendsResponse> => ({
+        fetchedAt: 1000,
+        backends: [
+          buildBackendSummary({
+            available: false,
+          }),
+        ],
+      }),
+    });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/new"));
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "error",
+      title: "No backends available",
+      recoverable: true,
+    });
+    expect(harness.delivered).not.toContainEqual(
+      expect.objectContaining({ kind: "project_picker" }),
+    );
+  });
+
+  it("lets a pending new-thread session switch providers before creation", async () => {
+    const harness = await createHarness({
+      listBackends: async (): Promise<ListBackendsResponse> => ({
+        fetchedAt: 1000,
+        backends: [
+          buildBackendSummary({
+            kind: "codex",
+            label: "Codex",
+            launchpadOptions: {
+              models: [{ id: "gpt-5.3-codex", label: "GPT-5.3 Codex" }],
+              reasoningEfforts: ["low", "medium", "high"],
+              supportsFastMode: true,
+            },
+          }),
+          buildBackendSummary({
+            kind: "grok",
+            label: "Grok",
+            launchpadOptions: {
+              models: [{ id: "grok-4.20-reasoning", label: "Grok 4.20 Reasoning" }],
+              reasoningEfforts: ["low", "medium", "high"],
+              supportsFastMode: false,
+            },
+          }),
+        ],
+      }),
+    });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Ready to start",
+      body: expect.stringContaining("Provider: Codex"),
+      actions: expect.arrayContaining([
+        expect.objectContaining({
+          id: "browse:new:backend",
+          label: "Provider: Codex",
+        }),
+      ]),
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "browse:new:backend" }),
+    );
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Select provider",
+      actions: expect.arrayContaining([
+        expect.objectContaining({
+          id: "browse:new:set-backend",
+          label: "Codex ✓",
+          value: { backend: "codex" },
+        }),
+        expect.objectContaining({
+          id: "browse:new:set-backend",
+          label: "Grok",
+          value: { backend: "grok" },
+        }),
+      ]),
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:new:set-backend",
+        value: { backend: "grok" },
+      }),
+    );
+
+    const grokReadyIntent = harness.delivered.at(-1);
+    expect(grokReadyIntent).toMatchObject({
+      kind: "confirmation",
+      title: "Ready to start",
+      body: expect.stringContaining("Provider: Grok"),
+      actions: expect.arrayContaining([
+        expect.objectContaining({
+          id: "browse:new:backend",
+          label: "Provider: Grok",
+        }),
+      ]),
+    });
+    expect(grokReadyIntent).toMatchObject({
+      actions: expect.not.arrayContaining([
+        expect.objectContaining({ id: "browse:new:fast" }),
+      ]),
+    });
+    expect(harness.updateDirectoryLaunchpad).toHaveBeenCalledWith({
+      directoryKey: "directory:pwragent",
+      stickySettingsChanged: true,
+      patch: expect.objectContaining({
+        backend: "grok",
+      }),
+    });
+
+    await harness.controller.handleInboundEvent(buildTextEvent("Fix bug with Grok"));
+
+    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith({
+      directoryKey: expect.stringMatching(/^messaging:browse:/),
+      launchpad: expect.objectContaining({
+        backend: "grok",
+        directoryKey: "directory:pwragent",
+      }),
+    });
+    expect(harness.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: "grok",
+        threadId: "new-thread-1",
+      }),
+    );
+    await expect(
+      harness.store.findActiveBindingForChannel(buildCommandEvent("/new").channel),
+    ).resolves.toMatchObject({
+      backend: "grok",
+      threadId: "new-thread-1",
+    });
+  });
+
+  it("updates sticky launchpad defaults when selecting a pending new-thread model", async () => {
+    const harness = await createHarness();
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "browse:new:model" }),
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:new:set-model",
+        value: {
+          model: "gpt-5.3-codex",
+        },
+      }),
+    );
+
+    expect(harness.updateDirectoryLaunchpad).toHaveBeenCalledWith({
+      directoryKey: "directory:pwragent",
+      stickySettingsChanged: true,
+      patch: {
+        model: "gpt-5.3-codex",
+      },
+    });
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Ready to start",
+      body: expect.stringContaining("Model: gpt-5.3-codex"),
     });
   });
 
@@ -5375,6 +5567,7 @@ describe("MessagingController", () => {
         model: "gpt-5.3-codex",
       }),
     );
+    expect(harness.updateDirectoryLaunchpad).not.toHaveBeenCalled();
     await expect(
       harness.store.findActiveBindingForChannel(buildCommandEvent("/status").channel),
     ).resolves.toMatchObject({
@@ -7151,6 +7344,7 @@ async function createHarness(options?: {
   handoff?: false;
   inputDebounceMs?: number;
   logger?: MessagingControllerOptions["logger"];
+  listBackends?: NonNullable<MessagingBackendBridge["listBackends"]>;
   listSkills?: NonNullable<MessagingBackendBridge["listSkills"]> | false;
   navigation?: NavigationSnapshot;
   now?: () => number;
@@ -7162,6 +7356,9 @@ async function createHarness(options?: {
   resolveDeliveryScope?: MessagingAdapter["resolveDeliveryScope"];
   materializeDirectoryLaunchpad?: NonNullable<
     MessagingBackendBridge["materializeDirectoryLaunchpad"]
+  >;
+  updateDirectoryLaunchpad?: NonNullable<
+    MessagingBackendBridge["updateDirectoryLaunchpad"]
   >;
   streamingResponsesDefault?: boolean;
   /**
@@ -7204,6 +7401,7 @@ async function createHarness(options?: {
   startTurn: ReturnType<typeof vi.fn>;
   steerTurn: ReturnType<typeof vi.fn>;
   submitServerRequest: ReturnType<typeof vi.fn>;
+  updateDirectoryLaunchpad: ReturnType<typeof vi.fn>;
   store: MessagingStore;
 }> {
   const store = await createStore();
@@ -7395,10 +7593,33 @@ async function createHarness(options?: {
           warnings: [],
           completedAt: 1000,
         }));
-  const listBackends = vi.fn(async (): Promise<ListBackendsResponse> => ({
-    fetchedAt: 1000,
-    backends: [buildBackendSummary()],
-  }));
+  const listBackends = vi.fn(
+    options?.listBackends ??
+      (async (): Promise<ListBackendsResponse> => ({
+        fetchedAt: 1000,
+        backends: [buildBackendSummary()],
+      })),
+  );
+  const updateDirectoryLaunchpad = vi.fn(
+    options?.updateDirectoryLaunchpad ??
+      (async (
+        request: UpdateDirectoryLaunchpadRequest,
+      ) => ({
+        defaults: buildNavigationSnapshot().launchpadDefaults,
+        launchpad: {
+          directoryKey: request.directoryKey,
+          directoryKind: "directory" as const,
+          directoryLabel: "PwrAgent",
+          directoryPath: "/repo/pwragent",
+          backend: request.patch.backend ?? "codex",
+          executionMode: request.patch.executionMode ?? "default",
+          prompt: "",
+          workMode: request.patch.workMode ?? "local",
+          createdAt: 1000,
+          updatedAt: 1000,
+        },
+      })),
+  );
   const readThreadLastAssistantMessage = vi.fn(
     options?.readThreadLastAssistantMessage ?? (async () => undefined),
   );
@@ -7432,6 +7653,7 @@ async function createHarness(options?: {
     startTurn,
     steerTurn,
     submitServerRequest,
+    updateDirectoryLaunchpad,
   };
 
   const onBindingChanged = vi.fn();
@@ -7486,6 +7708,7 @@ async function createHarness(options?: {
     startTurn,
     steerTurn,
     submitServerRequest,
+    updateDirectoryLaunchpad,
     store,
   };
 }
@@ -7504,10 +7727,11 @@ async function bindThread(
   );
 }
 
-function buildBackendSummary(): ListBackendsResponse["backends"][number] {
-  return {
-    kind: "codex",
-    label: "Codex",
+function buildBackendSummary(overrides: Partial<BackendSummary> = {}): BackendSummary {
+  const kind = overrides.kind ?? "codex";
+  const base: BackendSummary = {
+    kind,
+    label: kind === "grok" ? "Grok" : "Codex",
     available: true,
     methods: [],
     capabilities: {
@@ -7540,13 +7764,23 @@ function buildBackendSummary(): ListBackendsResponse["backends"][number] {
     launchpadOptions: {
       models: [
         {
-          id: "gpt-5.3-codex",
-          label: "GPT-5.3 Codex",
+          id: kind === "grok" ? "grok-4.20-reasoning" : "gpt-5.3-codex",
+          label: kind === "grok" ? "Grok 4.20 Reasoning" : "GPT-5.3 Codex",
         },
       ],
       reasoningEfforts: ["low", "medium", "high"],
       supportsFastMode: true,
     },
+  };
+  return {
+    ...base,
+    ...overrides,
+    capabilities: {
+      ...base.capabilities,
+      ...overrides.capabilities,
+    },
+    executionModes: overrides.executionModes ?? base.executionModes,
+    launchpadOptions: overrides.launchpadOptions ?? base.launchpadOptions,
   };
 }
 

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -2448,6 +2448,63 @@ describe("MessagingController", () => {
     });
   });
 
+  it("does not fall back to another provider when the selected backend becomes unavailable before creation", async () => {
+    const codexBackend = buildBackendSummary({
+      kind: "codex",
+      label: "Codex",
+    });
+    const grokBackend = buildBackendSummary({
+      kind: "grok",
+      label: "Grok",
+      launchpadOptions: {
+        models: [{ id: "grok-4.20-reasoning", label: "Grok 4.20 Reasoning" }],
+        reasoningEfforts: ["low", "medium", "high"],
+        supportsFastMode: false,
+      },
+    });
+    let availableBackends = [codexBackend, grokBackend];
+    const harness = await createHarness({
+      listBackends: async (): Promise<ListBackendsResponse> => ({
+        fetchedAt: 1000,
+        backends: availableBackends,
+      }),
+    });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:new:set-backend",
+        value: { backend: "grok" },
+      }),
+    );
+    availableBackends = [codexBackend];
+
+    await harness.controller.handleInboundEvent(buildTextEvent("Fix bug with Grok"));
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "error",
+      title: "Backend unavailable",
+      body: expect.stringContaining("selected backend is no longer available"),
+      recoverable: true,
+    });
+    expect(harness.materializeDirectoryLaunchpad).not.toHaveBeenCalled();
+    expect(harness.startThread).not.toHaveBeenCalled();
+    expect(harness.startTurn).not.toHaveBeenCalled();
+    await expect(
+      harness.store.findActiveBindingForChannel(buildCommandEvent("/new").channel),
+    ).resolves.toBeUndefined();
+  });
+
   it("updates sticky launchpad defaults when selecting a pending new-thread model", async () => {
     const harness = await createHarness();
 

--- a/apps/desktop/src/main/messaging/core/messaging-adapter.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-adapter.ts
@@ -31,6 +31,8 @@ import type {
   SubmitServerRequestRequest,
   SubmitServerRequestResponse,
   ThreadMessagingBindingTransition,
+  UpdateDirectoryLaunchpadRequest,
+  UpdateDirectoryLaunchpadResponse,
 } from "@pwragent/shared";
 import type {
   MessagingDeliveryResult,
@@ -113,6 +115,9 @@ export type MessagingBackendBridge = {
   materializeDirectoryLaunchpad?(
     request: MaterializeDirectoryLaunchpadRequest,
   ): Promise<MaterializeDirectoryLaunchpadResponse>;
+  updateDirectoryLaunchpad?(
+    request: UpdateDirectoryLaunchpadRequest,
+  ): Promise<UpdateDirectoryLaunchpadResponse>;
   startThread?(request: StartThreadRequest): Promise<StartThreadResponse>;
   startTurn(request: StartTurnRequest): Promise<StartTurnResponse>;
   steerTurn?(request: SteerTurnRequest): Promise<SteerTurnResponse>;

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -1,9 +1,14 @@
 import { createHash, randomUUID } from "node:crypto";
-import { buildThreadIdentityKey } from "@pwragent/shared";
+import {
+  buildThreadIdentityKey,
+  resolveNewThreadBackend,
+  selectableNewThreadBackends,
+} from "@pwragent/shared";
 import type {
   AgentEvent,
   AppServerTurnInputItem,
   AppServerBackendKind,
+  BackendSummary,
   AppServerPendingRequestNotification,
   AppServerToolRequestUserInputNotification,
   DesktopAuthorizedContact,
@@ -20,6 +25,7 @@ import type {
   ThreadMessagingBindingTransition,
   ThreadExecutionMode,
   ThreadIdentifier,
+  UpdateDirectoryLaunchpadRequest,
 } from "@pwragent/shared";
 import type {
   MessagingBindingRecord,
@@ -2670,6 +2676,18 @@ export class MessagingController {
       backend: "all",
       filter: parsed.query,
     });
+    const selectedBackend =
+      parsed.launchAction === "start_new_thread"
+        ? await this.resolveNewThreadBackendForSession(
+            {
+              launchpadBackend: navigation.launchpadDefaults.backend,
+            },
+            event,
+          )
+        : undefined;
+    if (parsed.launchAction === "start_new_thread" && !selectedBackend) {
+      return;
+    }
     const selectedDirectory = parsed.cwd
       ? navigation.directories.find(
           (directory) => directory.path === parsed.cwd || directory.key === parsed.cwd,
@@ -2678,6 +2696,7 @@ export class MessagingController {
     const session: MessagingBrowseSessionRecord = {
       id: this.newIntentId("browse"),
       allowedActorIds: [event.actor.platformUserId],
+      backend: selectedBackend?.kind,
       channel: event.channel,
       createdAt: this.now(),
       updatedAt: this.now(),
@@ -2778,9 +2797,20 @@ export class MessagingController {
       return;
     }
     if (actionId === "browse:mode:new") {
+      const selectedBackend = await this.resolveNewThreadBackendForSession(
+        {
+          launchpadBackend: navigation.launchpadDefaults.backend,
+          session: nextSession,
+        },
+        event,
+      );
+      if (!selectedBackend) {
+        return;
+      }
       await this.renderResumeBrowser(
         {
           ...nextSession,
+          backend: selectedBackend.kind,
           launchAction: "start_new_thread",
           mode: "new_project",
           pageIndex: 0,
@@ -2857,6 +2887,10 @@ export class MessagingController {
       return;
     }
     if (actionId === "browse:new:workspace:local") {
+      await this.updateNewThreadStickySettings(nextSession, {
+        branchName: undefined,
+        workMode: "local",
+      });
       await this.presentNewThreadPromptGate(
         {
           ...nextSession,
@@ -2884,11 +2918,16 @@ export class MessagingController {
         );
         return;
       }
+      const branchName = resolveNewThreadBaseBranch(nextSession, navigation);
+      await this.updateNewThreadStickySettings(nextSession, {
+        branchName,
+        workMode: "worktree",
+      });
       await this.presentNewThreadPromptGate(
         {
           ...nextSession,
           workMode: "worktree",
-          branchName: resolveNewThreadBaseBranch(nextSession, navigation),
+          branchName,
         },
         event,
         navigation,
@@ -2947,6 +2986,10 @@ export class MessagingController {
         );
         return;
       }
+      await this.updateNewThreadStickySettings(nextSession, {
+        branchName,
+        workMode: "worktree",
+      });
       await this.presentNewThreadPromptGate(
         {
           ...nextSession,
@@ -2972,6 +3015,9 @@ export class MessagingController {
           return;
         }
       }
+      await this.updateNewThreadStickySettings(nextSession, {
+        executionMode,
+      });
       await this.presentNewThreadPromptGate(
         {
           ...nextSession,
@@ -2993,6 +3039,9 @@ export class MessagingController {
         navigation.launchpadDefaults.fastMode ??
         false
       );
+      await this.updateNewThreadStickySettings(nextSession, {
+        fastMode,
+      });
       await this.presentNewThreadPromptGate(
         {
           ...nextSession,
@@ -3026,11 +3075,51 @@ export class MessagingController {
       );
       return;
     }
+    if (actionId === "browse:new:backend") {
+      await this.presentNewThreadBackendPicker(nextSession, event, navigation);
+      return;
+    }
+    if (actionId === "browse:new:set-backend") {
+      const backend = readStringValue(event.value, "backend");
+      const selectedBackend = await this.resolveNewThreadBackendForSession(
+        {
+          launchpadBackend: navigation.launchpadDefaults.backend,
+          preferredBackend: backend,
+          session: nextSession,
+          requirePreferred: true,
+        },
+        event,
+      );
+      if (!selectedBackend) {
+        return;
+      }
+      const normalizedSession = normalizeNewThreadSessionForBackend(
+        {
+          ...nextSession,
+          backend: selectedBackend.kind,
+        },
+        selectedBackend,
+        this.now(),
+      );
+      await this.updateNewThreadStickySettings(normalizedSession, {
+        backend: selectedBackend.kind,
+        fastMode: normalizedSession.preferences?.fastMode,
+        model: normalizedSession.preferences?.model,
+        reasoningEffort: normalizedSession.preferences?.reasoningEffort,
+        serviceTier: normalizedSession.preferences?.serviceTier,
+      });
+      await this.presentNewThreadPromptGate(
+        normalizedSession,
+        event,
+        navigation,
+      );
+      return;
+    }
     if (actionId === "browse:new:model") {
       await this.presentNewThreadModelPicker(
         nextSession,
         event,
-        navigation.launchpadDefaults.backend,
+        nextSession.backend ?? navigation.launchpadDefaults.backend,
       );
       return;
     }
@@ -3040,6 +3129,9 @@ export class MessagingController {
         await this.deliverInvalidBrowseSelection(event);
         return;
       }
+      await this.updateNewThreadStickySettings(nextSession, {
+        model,
+      });
       await this.presentNewThreadPromptGate(
         {
           ...nextSession,
@@ -3058,7 +3150,7 @@ export class MessagingController {
       await this.presentNewThreadReasoningPicker(
         nextSession,
         event,
-        navigation.launchpadDefaults.backend,
+        nextSession.backend ?? navigation.launchpadDefaults.backend,
       );
       return;
     }
@@ -3068,6 +3160,9 @@ export class MessagingController {
         await this.deliverInvalidBrowseSelection(event);
         return;
       }
+      await this.updateNewThreadStickySettings(nextSession, {
+        reasoningEffort,
+      });
       await this.presentNewThreadPromptGate(
         {
           ...nextSession,
@@ -3210,6 +3305,107 @@ export class MessagingController {
     }
   }
 
+  private async updateNewThreadStickySettings(
+    session: MessagingBrowseSessionRecord,
+    patch: UpdateDirectoryLaunchpadRequest["patch"],
+  ): Promise<void> {
+    const directoryKey = session.selectedProject?.directoryKey;
+    if (!directoryKey || !this.options.backend.updateDirectoryLaunchpad) {
+      return;
+    }
+
+    try {
+      await this.options.backend.updateDirectoryLaunchpad({
+        directoryKey,
+        patch,
+        stickySettingsChanged: true,
+      });
+    } catch (error) {
+      this.logger.debug?.("messaging new-thread sticky launchpad update failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  private async loadNewThreadBackendChoices(
+    event: MessagingInboundEvent,
+  ): Promise<{ backends: BackendSummary[]; selectable: BackendSummary[] } | undefined> {
+    try {
+      const response = await this.options.backend.listBackends?.({
+        includeUnavailable: true,
+      });
+      if (!response) {
+        throw new Error("backend discovery is unavailable");
+      }
+      const selectable = selectableNewThreadBackends(response.backends);
+      if (selectable.length === 0) {
+        await this.deliver(
+          buildErrorIntent({
+            id: this.newIntentId("new-thread-no-backends"),
+            createdAt: this.now(),
+            title: "No backends available",
+            body: "No backends are available to create a thread right now.",
+            recoverable: true,
+          }),
+          undefined,
+          event,
+        );
+        return undefined;
+      }
+      return {
+        backends: response.backends,
+        selectable,
+      };
+    } catch (error) {
+      await this.deliver(
+        buildErrorIntent({
+          id: this.newIntentId("new-thread-backends-unavailable"),
+          createdAt: this.now(),
+          title: "Backends unavailable",
+          body: "Backend choices are unavailable right now. Try /new again in a moment.",
+          recoverable: true,
+        }),
+        undefined,
+        event,
+      );
+      this.logger.debug?.("messaging new-thread backend discovery failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return undefined;
+    }
+  }
+
+  private async resolveNewThreadBackendForSession(
+    params: {
+      launchpadBackend: AppServerBackendKind;
+      preferredBackend?: string;
+      requirePreferred?: boolean;
+      session?: MessagingBrowseSessionRecord;
+    },
+    event: MessagingInboundEvent,
+  ): Promise<BackendSummary | undefined> {
+    const choices = await this.loadNewThreadBackendChoices(event);
+    if (!choices) {
+      return undefined;
+    }
+
+    if (params.requirePreferred) {
+      const selected = choices.selectable.find(
+        (backend) => backend.kind === params.preferredBackend,
+      );
+      if (!selected) {
+        await this.deliverInvalidBrowseSelection(event);
+        return undefined;
+      }
+      return selected;
+    }
+
+    return resolveNewThreadBackend(
+      choices.backends,
+      params.session?.backend ?? params.launchpadBackend,
+    );
+  }
+
   private async resolveCallbackHandleForEvent(
     event: MessagingInboundCallbackEvent,
   ): Promise<MessagingCallbackHandleRecord | undefined> {
@@ -3278,6 +3474,16 @@ export class MessagingController {
     }
 
     const directory = directoryForProjectSelection(navigation, project);
+    const selectedBackend = await this.resolveNewThreadBackendForSession(
+      {
+        launchpadBackend: navigation.launchpadDefaults.backend,
+        session,
+      },
+      event,
+    );
+    if (!selectedBackend) {
+      return;
+    }
     const workMode = resolveNewThreadWorkMode({
       requestedWorkMode:
         session.workMode ??
@@ -3287,8 +3493,9 @@ export class MessagingController {
       directory,
     });
     await this.presentNewThreadPromptGate(
-      {
+      normalizeNewThreadSessionForBackend({
         ...session,
+        backend: selectedBackend.kind,
         mode: "new_thread_options",
         pageIndex: 0,
         workMode,
@@ -3296,7 +3503,7 @@ export class MessagingController {
         selectedProject: project,
         updatedAt: this.now(),
         expiresAt: this.now() + this.pendingIntentTtlMs,
-      },
+      }, selectedBackend, this.now()),
       event,
       navigation,
     );
@@ -3310,34 +3517,91 @@ export class MessagingController {
     const snapshot = navigation ?? await this.options.backend.getNavigationSnapshot({
       backend: "all",
     });
-    const directory = session.selectedProject
-      ? directoryForProjectSelection(snapshot, session.selectedProject)
+    const backendChoices = await this.loadNewThreadBackendChoices(event);
+    if (!backendChoices) {
+      return;
+    }
+    const selectedBackend = session.backend
+      ? backendChoices.selectable.find((backend) => backend.kind === session.backend)
+      : resolveNewThreadBackend(
+          backendChoices.backends,
+          snapshot.launchpadDefaults.backend,
+        );
+    if (!selectedBackend) {
+      await this.deliver(
+        buildErrorIntent({
+          id: this.newIntentId("new-thread-selected-backend-unavailable"),
+          createdAt: this.now(),
+          title: "Backend unavailable",
+          body: "The selected backend is no longer available to create a thread. Use /new to start again.",
+          recoverable: true,
+        }),
+        undefined,
+        event,
+      );
+      return;
+    }
+    const effectiveSession = normalizeNewThreadSessionForBackend(
+      {
+        ...session,
+        backend: selectedBackend.kind,
+      },
+      selectedBackend,
+      this.now(),
+    );
+    const directory = effectiveSession.selectedProject
+      ? directoryForProjectSelection(snapshot, effectiveSession.selectedProject)
       : undefined;
     const options = newThreadOptionsForSession(
-      session,
+      effectiveSession,
       snapshot,
       directory,
       this.streamingResponsesDefault,
+      selectedBackend,
     );
     const canCreateWorktree = canCreateNewThreadWorktree(directory);
     const fullAccessControls = await this.resolveFullAccessControls();
-    await this.options.store.upsertBrowseSession(session);
+    const hasMultipleBackends = backendChoices.selectable.length > 1;
+    const supportsModel = (selectedBackend.launchpadOptions?.models?.length ?? 0) > 0;
+    const supportsReasoning =
+      (selectedBackend.launchpadOptions?.reasoningEfforts?.length ?? 0) > 0 ||
+      Boolean(
+        selectedBackend.launchpadOptions?.models?.some(
+          (model) => model.supportsReasoning,
+        ),
+      );
+    const supportsFast =
+      Boolean(selectedBackend.launchpadOptions?.supportsFastMode) ||
+      Boolean(
+        selectedBackend.launchpadOptions?.models?.some((model) => model.supportsFast),
+      );
+    await this.options.store.upsertBrowseSession(effectiveSession);
     const intent = buildConfirmationIntent({
       id: this.newIntentId("new-thread-ready"),
       capabilityProfile: this.capabilityProfile,
-      browseSessionId: session.id,
+      browseSessionId: effectiveSession.id,
       createdAt: this.now(),
-      delivery: session.surface
+      delivery: effectiveSession.surface
         ? {
             mode: "update",
             replaceMarkup: true,
           }
         : undefined,
       title: "Ready to start",
-      body: newThreadPromptGateBody(session, options),
+      body: newThreadPromptGateBody(effectiveSession, options, selectedBackend),
       fallbackText: "Send your first instruction, or use the option buttons before sending it.",
-      targetSurface: session.surface,
+      targetSurface: effectiveSession.surface,
       actions: [
+        ...(hasMultipleBackends
+          ? [
+              {
+                id: "browse:new:backend",
+                label: `Provider: ${selectedBackend.label}`,
+                style: "secondary" as const,
+                fallbackText: "provider",
+              },
+            ]
+          : []),
         {
           id: "browse:new:workspace:local",
           label: options.workMode === "local" ? "Local ✓" : "Local",
@@ -3379,30 +3643,42 @@ export class MessagingController {
               },
             ]
           : []),
-        {
-          id: "browse:new:fast",
-          label: options.fastMode ? "Fast: on" : "Fast: off",
-          style: "secondary",
-          fallbackText: "fast",
-        },
+        ...(supportsFast
+          ? [
+              {
+                id: "browse:new:fast",
+                label: options.fastMode ? "Fast: on" : "Fast: off",
+                style: "secondary" as const,
+                fallbackText: "fast",
+              },
+            ]
+          : []),
         {
           id: "browse:new:streaming",
           label: options.streamingResponses ? "Stream: on" : "Stream: off",
           style: "secondary",
           fallbackText: "stream",
         },
-        {
-          id: "browse:new:model",
-          label: "Model",
-          style: "secondary",
-          fallbackText: "model",
-        },
-        {
-          id: "browse:new:reasoning",
-          label: `Reasoning: ${options.reasoningEffort}`,
-          style: "secondary",
-          fallbackText: "reasoning",
-        },
+        ...(supportsModel
+          ? [
+              {
+                id: "browse:new:model",
+                label: "Model",
+                style: "secondary" as const,
+                fallbackText: "model",
+              },
+            ]
+          : []),
+        ...(supportsReasoning && options.reasoningEffort
+          ? [
+              {
+                id: "browse:new:reasoning",
+                label: `Reasoning: ${options.reasoningEffort}`,
+                style: "secondary" as const,
+                fallbackText: "reasoning",
+              },
+            ]
+          : []),
         {
           id: "browse:mode:new",
           label: "Back",
@@ -3424,7 +3700,7 @@ export class MessagingController {
     }
 
     const updatedSession = {
-      ...session,
+      ...effectiveSession,
       workMode: options.workMode,
       branchName: options.workMode === "worktree" ? options.branchName : undefined,
       surface: result.surface,
@@ -3440,6 +3716,63 @@ export class MessagingController {
       expiresAt: this.now() + this.pendingIntentTtlMs,
       surface: result.surface,
     });
+  }
+
+  private async presentNewThreadBackendPicker(
+    session: MessagingBrowseSessionRecord,
+    event: MessagingInboundEvent,
+    navigation: Awaited<ReturnType<MessagingBackendBridge["getNavigationSnapshot"]>>,
+  ): Promise<void> {
+    const choices = await this.loadNewThreadBackendChoices(event);
+    if (!choices) {
+      return;
+    }
+    const selectedBackend =
+      choices.selectable.find((backend) => backend.kind === session.backend) ??
+      resolveNewThreadBackend(choices.backends, navigation.launchpadDefaults.backend);
+    const intent = buildConfirmationIntent({
+      id: this.newIntentId("new-thread-backend"),
+      capabilityProfile: this.capabilityProfile,
+      browseSessionId: session.id,
+      createdAt: this.now(),
+      delivery: session.surface
+        ? { mode: "update", replaceMarkup: true }
+        : undefined,
+      title: "Select provider",
+      body: "Choose the provider for the new thread.",
+      fallbackText: "Choose a provider, or reply back.",
+      targetSurface: session.surface,
+      actions: [
+        ...choices.selectable.map((backend, index) => ({
+          id: "browse:new:set-backend",
+          label: `${backend.label}${backend.kind === selectedBackend?.kind ? " ✓" : ""}`,
+          style: backend.kind === selectedBackend?.kind
+            ? "primary" as const
+            : "secondary" as const,
+          fallbackText: String(index + 1),
+          priority: 10 + index,
+          value: { backend: backend.kind },
+        })),
+        {
+          id: session.workMode === "worktree"
+            ? "browse:new:workspace:worktree"
+            : "browse:new:workspace:local",
+          label: "Back",
+          style: "secondary" as const,
+          fallbackText: "back",
+          priority: 1,
+        },
+      ],
+    });
+    await this.storePendingIntent(intent, undefined, event);
+    const result = await this.deliver(intent, undefined, event);
+    if (result.surface) {
+      await this.options.store.upsertBrowseSession({
+        ...session,
+        surface: result.surface,
+        updatedAt: this.now(),
+      });
+    }
   }
 
   private async presentNewThreadBranchPicker(
@@ -3667,29 +4000,49 @@ export class MessagingController {
     const navigation = await this.options.backend.getNavigationSnapshot({
       backend: "all",
     });
+    const selectedBackend = await this.resolveNewThreadBackendForSession(
+      {
+        launchpadBackend: navigation.launchpadDefaults.backend,
+        session: bundle.session,
+      },
+      event,
+    );
+    if (!selectedBackend) {
+      return;
+    }
+    const session = normalizeNewThreadSessionForBackend(
+      {
+        ...bundle.session,
+        backend: selectedBackend.kind,
+      },
+      selectedBackend,
+      this.now(),
+    );
     const project = bundle.session.selectedProject;
     const directory = directoryForProjectSelection(navigation, project);
-    const preferences = bundle.session.preferences;
+    const preferences = session.preferences;
     const options = newThreadOptionsForSession(
-      bundle.session,
+      session,
       navigation,
       directory,
       this.streamingResponsesDefault,
+      selectedBackend,
     );
     if (
       options.executionMode === "full-access" &&
-      !(await this.isFullAccessRiskAcceptedForSession(bundle.session, event))
+      !(await this.isFullAccessRiskAcceptedForSession(session, event))
     ) {
       await this.presentFullAccessRiskWarning(
-        { kind: "new-thread", session: bundle.session },
+        { kind: "new-thread", session },
         event,
       );
       return;
     }
     const materialized = this.options.backend.materializeDirectoryLaunchpad
       ? await this.options.backend.materializeDirectoryLaunchpad({
-          directoryKey: messagingLaunchpadMaterializationKey(bundle.session),
+          directoryKey: messagingLaunchpadMaterializationKey(session),
           launchpad: launchpadForMessagingProject({
+            backend: selectedBackend.kind,
             directory,
             navigation,
             preferences,
@@ -3701,14 +4054,13 @@ export class MessagingController {
         })
       : undefined;
     const started = materialized ?? (await this.options.backend.startThread!({
-      backend: navigation.launchpadDefaults.backend,
+      backend: selectedBackend.kind,
       cwd: directory?.path ?? project.path,
       executionMode: options.executionMode,
-      fastMode: preferences?.fastMode ?? navigation.launchpadDefaults.fastMode,
-      model: preferences?.model ?? navigation.launchpadDefaults.model,
-      reasoningEffort:
-        preferences?.reasoningEffort ?? navigation.launchpadDefaults.reasoningEffort,
-      serviceTier: preferences?.serviceTier ?? navigation.launchpadDefaults.serviceTier,
+      fastMode: options.supportsFast ? options.fastMode : undefined,
+      model: options.supportsModel ? options.model : undefined,
+      reasoningEffort: options.supportsReasoning ? options.reasoningEffort : undefined,
+      serviceTier: preferences?.serviceTier,
       ...(options.workMode === "worktree"
         ? {
             workMode: "worktree" as const,
@@ -3737,13 +4089,17 @@ export class MessagingController {
       linkedDirectory: materialized?.linkedDirectory,
       navigation,
       now: this.now(),
+      model: options.supportsModel ? options.model : undefined,
+      reasoningEffort: options.supportsReasoning ? options.reasoningEffort : undefined,
+      serviceTier: preferences?.serviceTier,
+      fastMode: options.supportsFast ? options.fastMode : undefined,
       preferences,
       project,
       threadId: started.threadId,
       worktreePath: materialized?.linkedDirectory?.worktreePath,
       workMode: materialized?.workMode ?? options.workMode,
     });
-    await this.options.store.deleteBrowseSession(bundle.session.id);
+    await this.options.store.deleteBrowseSession(session.id);
     await this.startPreparedInput({
       binding: updatedBinding,
       input: prepared.input,
@@ -7832,12 +8188,83 @@ function handoffSuccessText(result: HandoffThreadWorkspaceResponse): string {
     .join("\n");
 }
 
+function normalizeNewThreadSessionForBackend(
+  session: MessagingBrowseSessionRecord,
+  backend: BackendSummary,
+  updatedAt: number,
+): MessagingBrowseSessionRecord {
+  if (!session.preferences) {
+    return session;
+  }
+
+  const preferences = { ...session.preferences };
+  const models = backend.launchpadOptions?.models ?? [];
+  if (preferences.model !== undefined) {
+    const modelIsValid = models.some((model) => model.id === preferences.model);
+    if (models.length === 0) {
+      delete preferences.model;
+    } else if (!modelIsValid) {
+      preferences.model = defaultBackendModel(models)?.id;
+    }
+  }
+
+  const selectedModel =
+    models.find((model) => model.id === preferences.model) ??
+    defaultBackendModel(models);
+  const reasoningEfforts = backend.launchpadOptions?.reasoningEfforts ?? [];
+  if (preferences.reasoningEffort !== undefined) {
+    if (reasoningEfforts.length === 0) {
+      delete preferences.reasoningEffort;
+    } else if (!reasoningEfforts.includes(preferences.reasoningEffort)) {
+      preferences.reasoningEffort = reasoningEfforts[0];
+    }
+  }
+
+  const supportsFast =
+    Boolean(backend.launchpadOptions?.supportsFastMode) ||
+    Boolean(selectedModel?.supportsFast);
+  if (!supportsFast) {
+    delete preferences.fastMode;
+  }
+
+  const serviceTiers = backend.launchpadOptions?.serviceTiers ?? [];
+  if (preferences.serviceTier !== undefined) {
+    if (serviceTiers.length === 0) {
+      delete preferences.serviceTier;
+    } else if (!serviceTiers.includes(preferences.serviceTier)) {
+      preferences.serviceTier = serviceTiers[0];
+    }
+  }
+
+  const hasPreferences = Object.keys(preferences).some((key) => key !== "updatedAt");
+  return {
+    ...session,
+    preferences: hasPreferences
+      ? {
+          ...preferences,
+          updatedAt,
+        }
+      : undefined,
+  };
+}
+
+function defaultBackendModel(
+  models: NonNullable<BackendSummary["launchpadOptions"]>["models"] = [],
+) {
+  return models.find((model) => model.current) ?? models[0];
+}
+
 type NewThreadOptionsSummary = {
+  backend: AppServerBackendKind;
+  backendLabel: string;
   branchName: string;
   executionMode: ThreadExecutionMode;
   fastMode: boolean;
   model: string;
-  reasoningEffort: string;
+  reasoningEffort?: string;
+  supportsFast: boolean;
+  supportsModel: boolean;
+  supportsReasoning: boolean;
   streamingResponses: boolean;
   workMode: LaunchpadWorkMode;
 };
@@ -7847,6 +8274,7 @@ function newThreadOptionsForSession(
   navigation: NavigationSnapshot,
   directory: NavigationDirectorySummary | undefined,
   streamingResponsesDefault: boolean,
+  backend: BackendSummary,
 ): NewThreadOptionsSummary {
   const workMode = resolveNewThreadWorkMode({
     requestedWorkMode:
@@ -7857,18 +8285,41 @@ function newThreadOptionsForSession(
     directory,
   });
   const streamingMode = session.preferences?.streamingResponses ?? "inherit";
+  const models = backend.launchpadOptions?.models ?? [];
+  const modelOption =
+    models.find((model) => model.id === session.preferences?.model) ??
+    models.find((model) => model.id === navigation.launchpadDefaults.model) ??
+    models.find((model) => model.current) ??
+    models[0];
+  const reasoningEfforts = backend.launchpadOptions?.reasoningEfforts ?? [];
+  const reasoningEffort =
+    session.preferences?.reasoningEffort &&
+    reasoningEfforts.includes(session.preferences.reasoningEffort)
+      ? session.preferences.reasoningEffort
+      : navigation.launchpadDefaults.reasoningEffort &&
+          reasoningEfforts.includes(navigation.launchpadDefaults.reasoningEffort)
+        ? navigation.launchpadDefaults.reasoningEffort
+        : reasoningEfforts[0];
+  const supportsFast =
+    Boolean(backend.launchpadOptions?.supportsFastMode) ||
+    Boolean(modelOption?.supportsFast);
+  const supportsReasoning =
+    reasoningEfforts.length > 0 || Boolean(modelOption?.supportsReasoning);
   return {
+    backend: backend.kind,
+    backendLabel: backend.label,
     branchName: resolveNewThreadBaseBranch(session, navigation, directory),
     executionMode:
       session.preferences?.executionMode ?? navigation.launchpadDefaults.executionMode,
     fastMode:
-      session.preferences?.fastMode ?? navigation.launchpadDefaults.fastMode ?? false,
-    model:
-      session.preferences?.model ?? navigation.launchpadDefaults.model ?? "default",
-    reasoningEffort:
-      session.preferences?.reasoningEffort ??
-      navigation.launchpadDefaults.reasoningEffort ??
-      "medium",
+      supportsFast
+        ? session.preferences?.fastMode ?? navigation.launchpadDefaults.fastMode ?? false
+        : false,
+    model: session.preferences?.model ?? modelOption?.id ?? "default",
+    reasoningEffort,
+    supportsFast,
+    supportsModel: models.length > 0,
+    supportsReasoning,
     streamingResponses:
       streamingMode === "inherit"
         ? streamingResponsesDefault
@@ -7901,16 +8352,20 @@ function resolveNewThreadWorkMode(params: {
 function newThreadPromptGateBody(
   session: MessagingBrowseSessionRecord,
   options: NewThreadOptionsSummary,
+  backend: BackendSummary,
 ): string {
   return [
     `Send the first instruction for ${session.selectedProject?.label ?? "this project"}.`,
     "The thread will be created when that message arrives.",
+    `Provider: ${backend.label}`,
     `Workspace: ${options.workMode === "worktree" ? "New Worktree" : "Local"}`,
     options.workMode === "worktree" ? `Base branch: ${options.branchName}` : undefined,
     `Permissions: ${formatPermissionsShortLabel(options.executionMode)}`,
-    `Model: ${options.model}`,
-    `Reasoning: ${options.reasoningEffort}`,
-    `Fast mode: ${options.fastMode ? "on" : "off"}`,
+    options.supportsModel ? `Model: ${options.model}` : undefined,
+    options.supportsReasoning && options.reasoningEffort
+      ? `Reasoning: ${options.reasoningEffort}`
+      : undefined,
+    options.supportsFast ? `Fast mode: ${options.fastMode ? "on" : "off"}` : undefined,
     `Streaming: ${options.streamingResponses ? "on" : "off"}`,
   ]
     .filter((line): line is string => Boolean(line))
@@ -8503,10 +8958,14 @@ function navigationWithStartedThread(params: {
   directory?: NavigationDirectorySummary;
   executionMode?: ThreadExecutionMode;
   linkedDirectory?: LinkedDirectorySummary;
+  fastMode?: boolean;
+  model?: string;
   navigation: NavigationSnapshot;
   now: number;
   preferences?: MessagingBrowseSessionRecord["preferences"];
   project: NonNullable<ReturnType<typeof selectProjectFromValue>>;
+  reasoningEffort?: string;
+  serviceTier?: string;
   threadId: ThreadIdentifier;
   worktreePath?: string;
   workMode: LaunchpadWorkMode;
@@ -8544,14 +9003,10 @@ function navigationWithStartedThread(params: {
         createdAt: params.now,
         updatedAt: params.now,
         executionMode: params.executionMode,
-        model: params.preferences?.model ?? params.navigation.launchpadDefaults.model,
-        reasoningEffort:
-          params.preferences?.reasoningEffort ??
-          params.navigation.launchpadDefaults.reasoningEffort,
-        serviceTier:
-          params.preferences?.serviceTier ?? params.navigation.launchpadDefaults.serviceTier,
-        fastMode:
-          params.preferences?.fastMode ?? params.navigation.launchpadDefaults.fastMode,
+        model: params.model,
+        reasoningEffort: params.reasoningEffort,
+        serviceTier: params.serviceTier,
+        fastMode: params.fastMode,
         linkedDirectories: linkedDirectory ? [linkedDirectory] : [],
         inbox: {
           inInbox: true,
@@ -8578,6 +9033,7 @@ function navigationWithStartedThread(params: {
 }
 
 function launchpadForMessagingProject(params: {
+  backend: AppServerBackendKind;
   branchName: string;
   directory?: NavigationDirectorySummary;
   navigation: NavigationSnapshot;
@@ -8597,7 +9053,7 @@ function launchpadForMessagingProject(params: {
     directoryKind: params.directory?.kind ?? "directory",
     directoryLabel: params.directory?.label ?? params.project.label,
     directoryPath,
-    backend: defaults.backend,
+    backend: params.backend,
     executionMode: defaults.executionMode,
     model: defaults.model,
     reasoningEffort: defaults.reasoningEffort,
@@ -8612,7 +9068,7 @@ function launchpadForMessagingProject(params: {
 
   return {
     ...base,
-    backend: base.backend,
+    backend: params.backend,
     executionMode: params.preferences?.executionMode ?? base.executionMode,
     model: params.preferences?.model ?? base.model,
     reasoningEffort: params.preferences?.reasoningEffort ?? base.reasoningEffort,

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -3526,19 +3526,9 @@ export class MessagingController {
       : resolveNewThreadBackend(
           backendChoices.backends,
           snapshot.launchpadDefaults.backend,
-        );
+    );
     if (!selectedBackend) {
-      await this.deliver(
-        buildErrorIntent({
-          id: this.newIntentId("new-thread-selected-backend-unavailable"),
-          createdAt: this.now(),
-          title: "Backend unavailable",
-          body: "The selected backend is no longer available to create a thread. Use /new to start again.",
-          recoverable: true,
-        }),
-        undefined,
-        event,
-      );
+      await this.deliverSelectedNewThreadBackendUnavailable(event);
       return;
     }
     const effectiveSession = normalizeNewThreadSessionForBackend(
@@ -3775,6 +3765,22 @@ export class MessagingController {
     }
   }
 
+  private async deliverSelectedNewThreadBackendUnavailable(
+    event: MessagingInboundEvent,
+  ): Promise<void> {
+    await this.deliver(
+      buildErrorIntent({
+        id: this.newIntentId("new-thread-selected-backend-unavailable"),
+        createdAt: this.now(),
+        title: "Backend unavailable",
+        body: "The selected backend is no longer available to create a thread. Use /new to start again.",
+        recoverable: true,
+      }),
+      undefined,
+      event,
+    );
+  }
+
   private async presentNewThreadBranchPicker(
     session: MessagingBrowseSessionRecord,
     navigation: Awaited<ReturnType<MessagingBackendBridge["getNavigationSnapshot"]>>,
@@ -4000,13 +4006,28 @@ export class MessagingController {
     const navigation = await this.options.backend.getNavigationSnapshot({
       backend: "all",
     });
-    const selectedBackend = await this.resolveNewThreadBackendForSession(
-      {
-        launchpadBackend: navigation.launchpadDefaults.backend,
-        session: bundle.session,
-      },
-      event,
-    );
+    let selectedBackend: BackendSummary | undefined;
+    if (bundle.session.backend) {
+      const backendChoices = await this.loadNewThreadBackendChoices(event);
+      if (!backendChoices) {
+        return;
+      }
+      selectedBackend = backendChoices.selectable.find(
+        (backend) => backend.kind === bundle.session.backend,
+      );
+      if (!selectedBackend) {
+        await this.deliverSelectedNewThreadBackendUnavailable(event);
+        return;
+      }
+    } else {
+      selectedBackend = await this.resolveNewThreadBackendForSession(
+        {
+          launchpadBackend: navigation.launchpadDefaults.backend,
+          session: bundle.session,
+        },
+        event,
+      );
+    }
     if (!selectedBackend) {
       return;
     }

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -32,6 +32,8 @@ import type {
   SubmitServerRequestRequest,
   SubmitServerRequestResponse,
   ThreadMessagingBindingTransition,
+  UpdateDirectoryLaunchpadRequest,
+  UpdateDirectoryLaunchpadResponse,
 } from "@pwragent/shared";
 import type {
   MessagingBackendBridge,
@@ -137,6 +139,12 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
     request: MaterializeDirectoryLaunchpadRequest,
   ): Promise<MaterializeDirectoryLaunchpadResponse> {
     return await this.registry.materializeDirectoryLaunchpad(request);
+  }
+
+  async updateDirectoryLaunchpad(
+    request: UpdateDirectoryLaunchpadRequest,
+  ): Promise<UpdateDirectoryLaunchpadResponse> {
+    return await this.registry.updateDirectoryLaunchpad(request);
   }
 
   async startTurn(request: StartTurnRequest): Promise<StartTurnResponse> {

--- a/docs-site/using-codex.md
+++ b/docs-site/using-codex.md
@@ -308,7 +308,8 @@ text bind, and the Full Access resume escalation path.
 `/new` (or `@PwrAgent new`, or **New** from `/help`) opens a project
 picker. Selecting a project advances to the [Start Card](#start-card-buttons)
 where you set the thread's initial model, reasoning, fast mode, and
-permissions before sending the first prompt.
+permissions before sending the first prompt. `/resume --new` is the
+compatibility spelling for the same flow.
 
 Same pagination and text-fallback semantics as the Resume browser:
 8 rows per page, button-or-reply-with-number, `next`/`back`/`cancel`.
@@ -316,28 +317,35 @@ Same pagination and text-fallback semantics as the Resume browser:
 If you only have one project configured, the picker is skipped and
 you land on the Start Card directly.
 
+If PwrAgent has more than one backend that can create threads, the
+Start Card also shows **Provider**. The initial provider comes from the
+same sticky launchpad default used by the desktop app. Changing it
+updates the available Model, Reasoning, Fast, and other setup controls
+because capabilities vary by backend.
+
 ## Start Card buttons {#start-card-buttons}
 
 After picking a thread (or a project for a new thread), you see the
-**Start Card** before the first prompt is sent. Four buttons let
-you set the thread's initial state:
+**Start Card** before the first prompt is sent. These buttons let you
+set the thread's initial state:
 
 | Button | What you change |
 |---|---|
-| **Model** | The Codex model the thread will use (e.g., Claude Opus, Claude Sonnet, etc.) |
+| **Provider** | The backend that will create the thread; shown only when multiple create-capable backends are available |
+| **Model** | The model the selected provider will use |
 | **Reasoning** | Reasoning effort (Low, Medium, High) |
 | **Fast: on / off** | Toggles Fast mode for the thread |
 | **Permissions** | Cycles between Default Access and Full Access |
 
-Each setting is **per-thread** in PwrAgent — unlike Codex Desktop,
-where these are global. You can run a high-stakes refactor with
-**Full Access** on a strong model while a low-stakes throwaway script
-runs in **Default Access** on a cheaper model, and the two settings
-don't bleed into each other.
+Buttons appear only when the selected provider advertises support for
+the setting. For example, a provider without Fast mode won't show a
+Fast button on the Start Card.
 
-**Defaults** come from the desktop's global Settings → Models page.
-You can override per-thread here on the Start Card; the override
-persists for the lifetime of the thread.
+**Defaults** come from the desktop launchpad sticky defaults. Changing
+Provider, Model, Reasoning, Fast, or Permissions on the Start Card also
+updates those sticky defaults for the next launchpad. Once the thread
+is created, the provider is fixed; model, reasoning, fast mode, and
+permissions remain thread-scoped controls on the status card.
 
 ### A note on Permissions mid-turn
 
@@ -399,8 +407,8 @@ menu or `/detach` (which is a no-op if nothing's bound yet but always
 safe).
 
 The binding-confirmation message the bot posts back includes the
-chosen model, reasoning, fast mode, and permissions so you can verify
-the Start Card state was captured correctly.
+chosen provider, model, reasoning, fast mode, and permissions so you
+can verify the Start Card state was captured correctly.
 
 ## Status card on a bound thread {#status-card-bound}
 
@@ -410,7 +418,11 @@ the Start Card state was captured correctly.
 After the binding completes, the **Start Card** evolves into the
 **bound-thread status card**, pinned (or repeatedly posted, where the
 platform doesn't support pinning) to the conversation. It carries the
-same four state buttons as the Start Card plus four runtime controls:
+setup controls that remain mutable plus runtime controls:
+
+The status card shows the backend that owns the thread, but it does
+not offer a Provider button. To use another backend, start a new
+thread.
 
 | Button | What it does |
 |---|---|

--- a/docs/brainstorms/2026-05-22-messaging-new-thread-backend-selection-requirements.md
+++ b/docs/brainstorms/2026-05-22-messaging-new-thread-backend-selection-requirements.md
@@ -1,0 +1,109 @@
+---
+date: 2026-05-22
+topic: messaging-new-thread-backend-selection
+---
+
+# Messaging New Thread Backend Selection
+
+## Problem Frame
+
+Messaging users can now start a thread directly with `/new`, but the new-thread
+flow still treats backend selection as an invisible launchpad default. That was
+acceptable when one backend was effectively usable from messaging, but it breaks
+down as PwrAgent grows from Codex and Grok toward additional ACP-backed agents
+such as Gemini.
+
+The desktop launchpad already treats backend, model, reasoning, fast mode, and
+related controls as pre-thread settings. Messaging should follow that product
+model: start from the same sticky launchpad defaults, let the user change the
+backend before the first prompt, adapt the remaining option buttons to that
+backend's capabilities, then freeze the backend once the thread exists.
+
+| Flow state | Backend control | Model/settings controls | Backend shown after creation |
+| --- | --- | --- | --- |
+| One usable backend | Hidden; selected silently | For that backend only | Status card |
+| Multiple usable backends | Editable before first prompt | Recomputed after backend changes | Status card |
+| Existing/resumed thread | Not editable | Thread-scoped settings only | Status card |
+
+## Requirements
+
+**Backend Choice Before Thread Creation**
+- R1. `/new`, the New help action, and the supported `/resume --new` compatibility path must use the same backend-selection behavior.
+- R2. If zero backends are currently usable for creating a thread, messaging must present a recoverable error instead of continuing into a misleading project or prompt flow.
+- R3. If exactly one backend is usable for creating a thread, messaging must select it silently and avoid presenting a backend button or chooser.
+- R4. If two or more backends are usable for creating a thread, messaging must show an editable backend/provider control in the new-thread options surface before the first prompt is sent.
+- R5. The initial selected backend must come from the same sticky launchpad default the desktop launchpad would use, falling back to a valid create-capable backend if that default is unavailable.
+- R6. Changing the backend in messaging must update the pending new-thread session only; it must not switch any existing thread.
+
+**Capability-Driven Options**
+- R7. The Model, Reasoning, Fast, permissions, workspace, and any service-tier or future option buttons shown in the messaging new-thread options surface must reflect the currently selected backend's capabilities.
+- R8. When the user changes backend, messaging must recompute available models and other backend-specific controls for the newly selected backend.
+- R9. If the previous pending model or option value is not valid for the newly selected backend, messaging must fall back to that backend's valid default rather than carrying an incompatible value forward.
+- R10. Messaging must avoid showing option buttons that imply unsupported behavior for the selected backend.
+- R11. ACP/Gemini must fit this selection model as another backend/provider when it becomes available, but this brainstorm does not define ACP's final internal request shape.
+
+**Thread Creation And Immutability**
+- R12. Thread creation from messaging must use the backend selected in the pending new-thread session, not blindly use the global launchpad default.
+- R13. Directory launchpad materialization from messaging must preserve the selected backend and selected backend-specific settings.
+- R14. Once the first prompt creates the thread, the backend/provider control disappears; backend switching is not available for existing threads.
+- R15. Existing thread status cards must continue to identify which backend/provider owns the thread, using user-facing labels as they become available.
+
+**Launchpad Default Parity**
+- R16. Messaging must read the same sticky launchpad defaults used by the desktop launchpad for backend, model, reasoning, fast mode, service tier, and workspace mode.
+- R17. A backend change made inside a pending messaging new-thread flow should become the user's new sticky launchpad default if the desktop launchpad would treat the same change as sticky.
+- R18. Sticky-default writes must happen only for pre-thread launchpad choices, not for existing thread status-card changes.
+
+**Messaging Surface Behavior**
+- R19. Backend selection must be represented in channel-neutral messaging intents and actions, with provider adapters only rendering according to their capability profile.
+- R20. Text fallback must remain usable on providers with limited or no button support, so a user can still identify and choose among available backends.
+- R21. Pagination and action counts must respect the connected messaging provider's capability profile; adding backend choices must not make the new-thread options surface exceed provider limits.
+- R22. Authorization and browse-session scoping must remain unchanged: backend choices must not reveal projects, threads, or capabilities to unauthorized actors.
+
+## Success Criteria
+
+- A messaging user running `/new` sees the same default backend they would get from the desktop launchpad.
+- When more than one create-capable backend is available, the user can change backend before sending the first prompt.
+- Changing backend updates model/reasoning/fast availability before thread creation.
+- The created thread is bound to the selected backend, and the status card identifies that backend afterward.
+- No existing thread can be switched between Codex, Grok, Gemini, or any future backend through this flow.
+
+## Scope Boundaries
+
+- In scope: new-thread backend selection for messaging surfaces before first prompt.
+- In scope: launchpad-default parity for pre-thread backend and model settings.
+- In scope: retaining `/resume --new` compatibility while treating `/new` as the primary command.
+- Out of scope: switching the backend of an existing thread.
+- Out of scope: final ACP/Gemini protocol shape, beyond ensuring the selection model can accept additional backend kinds.
+- Out of scope: redesigning the desktop launchpad UI.
+- Out of scope: provider-specific messaging branches for Telegram, Discord, Slack, Mattermost, LINE, or Feishu.
+
+## Key Decisions
+
+- Editable launchpad option, not mandatory first step: the old issue proposed a backend chooser before project selection, but the current product shape is better served by a backend button in the new-thread options surface.
+- Sticky default parity: messaging should reflect and update the same launchpad defaults as desktop for pre-thread choices.
+- Immutable after birth: provider/backend is a creation-time decision and becomes status-card metadata once the thread exists.
+- Capability-driven controls: backend choice determines which model and settings buttons are meaningful.
+
+## Dependencies / Assumptions
+
+- The backend registry can report available create-capable backends and launchpad options through `BackendSummary`.
+- Messaging browse sessions remain the right place to hold pending pre-thread choices until the first prompt is submitted.
+- Backend labels will be user-facing enough for messaging controls; where needed, UI copy can map internal identifiers to `Codex`, `Grok`, and `Gemini`.
+- ACP/Gemini work may expand the backend kind model, but this requirement only depends on messaging not assuming there are exactly two backend kinds.
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+(None.)
+
+### Deferred to Planning
+
+- [Affects R11][Technical] How should the shared backend kind/type model evolve so messaging does not keep hard-coded `codex | grok` validation once ACP/Gemini lands?
+- [Affects R17][Technical] Which messaging backend bridge call should update sticky launchpad defaults when a pre-thread backend or model choice changes?
+- [Affects R20][Technical] What text fallback command syntax should select a backend on text-only or button-constrained providers?
+- [Affects R21][Technical] Should backend selection live on the ready-to-start options surface only, or also be reachable from the project picker when action budgets allow?
+
+## Next Steps
+
+-> `/prompts:ce-plan` for structured implementation planning

--- a/docs/messaging-architecture.md
+++ b/docs/messaging-architecture.md
@@ -299,6 +299,39 @@ Available command-bus entry points today, all on `DesktopMessagingRuntime`:
 
 If no controller's scope matches a `request*` event (messaging is disabled, or the platform's adapter failed to start), the runtime falls back to a store-only revoke so the renderer chip clears regardless. Best-effort platform notification, guaranteed local cleanup.
 
+### New-thread backend selection is pre-thread state
+
+`/new`, **New** from `/help`, and `/resume --new` all enter the same
+new-thread browse session. Before rendering the project picker, the
+controller asks the backend bridge for current backend summaries and
+keeps only backends that are available, can create threads, and have at
+least one available execution mode. If none qualify, the controller
+returns a recoverable error instead of silently falling back to stale
+launchpad defaults.
+
+The selected backend lives on `MessagingBrowseSessionRecord`, not on
+binding preferences. It is seeded from the desktop launchpad sticky
+default when that backend is usable, otherwise from the shared backend
+resolver's fallback. With one usable backend the Start Card shows no
+provider control. With multiple usable backends it shows a **Provider**
+action that opens a single-select picker. Changing Provider normalizes
+pending model, reasoning, service-tier, and fast-mode choices against
+that backend's advertised `launchpadOptions`, then re-renders the Start
+Card with only supported controls.
+
+Pending new-thread settings that mirror desktop launchpad settings
+flow through `MessagingBackendBridge.updateDirectoryLaunchpad` with
+`stickySettingsChanged: true`, so messaging and desktop launchpads share
+the same sticky defaults. Existing bound-thread status-card changes do
+not use this path; they remain thread-scoped mutations such as
+`setThreadModelSettings`.
+
+When the first prompt arrives, the controller revalidates the selected
+backend before materializing or starting the thread. The resulting
+binding stores the backend as immutable thread identity. After that,
+there is no Provider button; the bound-thread status card only reports
+which backend owns the thread.
+
 ### Permission-mode queue audit messages
 
 When a user toggles a thread's permission mode (Default Access ↔ Full Access) while a turn is running, the registry queues the change at the resume boundary instead of applying it immediately. The messaging controller surfaces this lifecycle in the bound conversation as audit chat messages, so users on Telegram and Discord see the same story the desktop transcript tells:
@@ -349,7 +382,7 @@ Four things consume the catalog:
 
 1. **The controller's `handleCommand` dispatch.** `matchMessagingCommandVerb` resolves an inbound `MessagingInboundCommandEvent.command` to a known verb (or `undefined` for unrecognized commands). Verbs in the catalog dispatch to typed handlers; everything else falls through to the help surface.
 2. **The user-facing `/help` body.** `formatMessagingCommandHelpBody` derives the plain-text command list from the catalog so adding or renaming a verb in one place updates the help text everywhere it's rendered. The body avoids Markdown markers because confirmation surfaces render as plain text on some providers.
-3. **The `/help` action row.** `paginateHelpCatalog` + `buildHelpActions` render one `command:<verb>` button per catalog entry on the current page, with generic two-column row hints for providers that support compact button rows. Pages overflow with capability-aware Prev/Next/Cancel navigation when the catalog grows past the profile's action budget; for today's small catalog every button fits on one page and no nav row is rendered. The `Resume` button is styled primary to match the previous single-button shape; `New` jumps directly to the existing new-thread browser mode; everything else is neutral. Pagination is **stateless** — the next/previous page index travels in `action.value.pageIndex` and comes back through `MessagingInboundCallbackEvent.value`, so the controller can re-render without persistent session state (unlike the resume browser which uses a `MessagingBrowseSessionRecord`).
+3. **The `/help` action row.** `paginateHelpCatalog` + `buildHelpActions` render one `command:<verb>` button per catalog entry on the current page, with generic two-column row hints for providers that support compact button rows. Pages overflow with capability-aware Prev/Next/Cancel navigation when the catalog grows past the profile's action budget; for today's small catalog every button fits on one page and no nav row is rendered. The `Resume` button is styled primary to match the previous single-button shape; `New` jumps directly to the existing backend-aware new-thread browser mode; everything else is neutral. Pagination is **stateless** — the next/previous page index travels in `action.value.pageIndex` and comes back through `MessagingInboundCallbackEvent.value`, so the controller can re-render without persistent session state (unlike the resume browser which uses a `MessagingBrowseSessionRecord`).
 4. **Provider adapters that register native slash commands.** Today each adapter maintains its own list (`packages/messaging/providers/discord/src/discord-commands.ts`, `packages/messaging/providers/mattermost/src/mattermost-commands.ts`). A future refactor can collapse those onto the shared catalog so a new verb only requires touching one file. Until then, adapter-side lists must stay in sync with the catalog by convention.
 
 To add a new canonical verb:

--- a/docs/messaging-platform-integration.md
+++ b/docs/messaging-platform-integration.md
@@ -39,6 +39,26 @@ stay in this repo:
 - Package boundary rules and `pnpm lint:boundaries` enforcement live in
   [`packages/messaging/AGENTS.md`](../packages/messaging/AGENTS.md).
 
+## New-thread backend selection smoke
+
+The operator-facing `/new` walkthrough lives in
+[`docs-site/using-codex.md`](../docs-site/using-codex.md), but
+contributors changing messaging workflow should keep these checks in
+sync with tests:
+
+- With one create-capable backend, `/new`, **New** from `/help`, and
+  `/resume --new` open the same project picker and Start Card without a
+  Provider button.
+- With multiple create-capable backends, the Start Card is seeded from
+  the desktop launchpad sticky backend and includes a Provider button.
+  Changing Provider re-renders Model, Reasoning, Fast, and related
+  controls from that backend's advertised capabilities.
+- Changing Provider or Model before the first prompt updates the
+  desktop launchpad sticky defaults through `updateDirectoryLaunchpad`.
+- Sending the first prompt creates the thread on the selected backend.
+  After binding, the status card reports the backend identity and does
+  not offer a Provider switch.
+
 ## Chat SDK decision (contributor context)
 
 Vercel Chat SDK is not the runtime boundary for PwrAgent. The current

--- a/docs/plans/2026-05-22-001-feat-messaging-new-thread-backend-selection-plan.md
+++ b/docs/plans/2026-05-22-001-feat-messaging-new-thread-backend-selection-plan.md
@@ -164,7 +164,7 @@ flowchart TB
 **Verification:**
 - Messaging has an explicit place to store pending backend selection without breaking existing persisted sessions.
 
-- [ ] **Unit 2: Add backend preflight and picker to the new-thread messaging flow**
+- [x] **Unit 2: Add backend preflight and picker to the new-thread messaging flow**
 
 **Goal:** Make `/new`, New button, and `/resume --new` handle zero/one/multiple backend cases and expose backend switching before the first prompt.
 
@@ -205,7 +205,7 @@ flowchart TB
 **Verification:**
 - Users can see and change provider/backend before sending the first prompt when more than one backend can create threads.
 
-- [ ] **Unit 3: Normalize backend-specific options and create threads with the selected backend**
+- [x] **Unit 3: Normalize backend-specific options and create threads with the selected backend**
 
 **Goal:** Ensure model/reasoning/fast controls and thread creation use the pending backend rather than `navigation.launchpadDefaults.backend`.
 
@@ -248,7 +248,7 @@ flowchart TB
 **Verification:**
 - No new-thread creation path uses `navigation.launchpadDefaults.backend` after a session backend has been selected.
 
-- [ ] **Unit 4: Preserve launchpad sticky-default parity from messaging**
+- [x] **Unit 4: Preserve launchpad sticky-default parity from messaging**
 
 **Goal:** Make backend/model/settings changes in a pending messaging new-thread flow update the same sticky launchpad defaults used by desktop launchpads.
 

--- a/docs/plans/2026-05-22-001-feat-messaging-new-thread-backend-selection-plan.md
+++ b/docs/plans/2026-05-22-001-feat-messaging-new-thread-backend-selection-plan.md
@@ -1,0 +1,361 @@
+---
+title: "feat(messaging): Add backend selection to new-thread flow"
+type: feat
+status: active
+date: 2026-05-22
+origin: docs/brainstorms/2026-05-22-messaging-new-thread-backend-selection-requirements.md
+deepened: 2026-05-22
+---
+
+# feat(messaging): Add backend selection to new-thread flow
+
+## Overview
+
+Add backend/provider selection to the messaging `/new` flow before a thread is
+created. Messaging should seed the pending thread from the desktop launchpad's
+sticky backend/model defaults, allow backend changes when multiple create-capable
+backends are available, recompute model/settings options from the selected
+backend, and create the thread against that selected backend.
+
+The implementation should extend the existing resume/new-thread browse-session
+flow instead of creating provider-specific messaging branches. `/new`, the New
+help action, and `/resume --new` remain aliases for the same flow.
+
+## Problem Frame
+
+Issue #194 originally described `/resume --new`, but the product has moved on:
+`/new` now exists and routes to the new-thread project picker. The current
+messaging flow already has a ready-to-start options surface with Model,
+Reasoning, Fast, Streaming, Permissions, and workspace controls, but it still
+uses `navigation.launchpadDefaults.backend` when opening model/reasoning pickers
+and when materializing or starting the thread.
+
+As Codex, Grok, and upcoming ACP/Gemini backends coexist, invisible backend
+selection is no longer acceptable. Messaging should mirror the desktop launchpad
+model from the origin document: backend is editable only before the first prompt,
+then becomes immutable thread identity shown on the status card.
+
+## Requirements Trace
+
+- R1. `/new`, New button, and `/resume --new` use the same backend-selection behavior.
+- R2-R5. Zero/one/multiple usable backend cases are handled from current backend summaries, seeded from launchpad defaults.
+- R6, R12-R14. Pending backend changes affect only the browse session and the created thread; existing thread backend switching remains unavailable.
+- R7-R10. Model/reasoning/fast and related buttons reflect the selected backend's advertised capabilities.
+- R11. The design avoids introducing new hard-coded assumptions that would block ACP/Gemini from joining as another backend kind later.
+- R15. Existing status cards continue to identify the owning backend/provider after thread creation.
+- R16-R18. Pending new-thread choices read and update launchpad sticky defaults where the desktop launchpad would do the same.
+- R19-R22. The flow remains channel-neutral, capability-profile-aware, and scoped to authorized browse sessions.
+
+## Scope Boundaries
+
+- Do not switch an existing thread between Codex, Grok, Gemini, or any future backend.
+- Do not define ACP/Gemini protocol shape in this pass.
+- Do not redesign the desktop launchpad UI.
+- Do not add Telegram/Discord/Slack/Mattermost/LINE/Feishu workflow branches.
+- Do not replace the existing `/new` project picker; add backend selection to the existing new-thread flow.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `apps/desktop/src/main/messaging/core/messaging-controller.ts` owns `/new`, `/resume --new`, browse callbacks, the ready-to-start options surface, model/reasoning pickers, and thread creation.
+- `apps/desktop/src/main/messaging/core/messaging-resume-browser.ts` parses `--new`, renders project/thread pickers, and validates thread/project selections.
+- `packages/messaging/interface/src/index.ts` defines `MessagingBrowseSessionRecord` and `MessagingBindingPreferences`.
+- `apps/desktop/src/main/messaging/core/messaging-migrations.ts` and `apps/desktop/src/main/messaging/core/messaging-store.ts` sanitize and retain persisted browse sessions.
+- `apps/desktop/src/main/messaging/core/messaging-adapter.ts` already exposes optional backend bridge methods including `listBackends`; it does not yet expose `updateDirectoryLaunchpad`.
+- `apps/desktop/src/main/messaging/desktop-backend-bridge.ts` forwards bridge methods to `DesktopBackendRegistry`.
+- `apps/desktop/src/main/app-server/backend-registry.ts` has `resolveLaunchpadBackend`, `updateDirectoryLaunchpad`, `materializeDirectoryLaunchpad`, and sticky launchpad default updates via `stickySettingsChanged`.
+- `packages/shared/src/contracts/backend.ts` defines `BackendSummary`, `BackendLaunchpadOptions`, and per-model capability flags.
+- `packages/shared/src/contracts/navigation.ts` defines `NavigationLaunchpadDefaults` and `NavigationLaunchpadDraft`.
+- `docs/messaging-architecture.md` documents that command surfaces, pickers, status cards, and capability profiles must stay channel-neutral.
+- `docs/plans/2026-05-12-001-feat-messaging-mention-help-new-plan.md` established `/new` as a first-class shortcut backed by the existing new-thread browser.
+- `docs/plans/2026-05-04-002-feat-messaging-capability-discovery-plan.md` established producer-side capability adaptation rather than provider-specific workflow branching.
+
+### Institutional Learnings
+
+- `docs/solutions/2026-05-07-codex-permission-mode-state-machine.md` is relevant by analogy: avoid silent fallbacks across backend/permission routing boundaries, and make state transitions explicit. For this plan, that means thread creation must log/use the selected backend rather than silently falling back to launchpad defaults.
+
+### External References
+
+- Not used. Existing repository patterns and issue context are sufficient.
+
+## Key Technical Decisions
+
+- Store pending backend on `MessagingBrowseSessionRecord`, not `MessagingBindingPreferences`: backend is immutable thread identity after creation, while binding preferences are mutable per-thread settings.
+- Add a shared create-capable backend selection helper: renderer and messaging already use the same predicate informally (`available && capabilities.createThread` plus available execution modes). A small shared helper keeps zero/one/many behavior consistent.
+- Put backend selection on the ready-to-start options surface: the old issue proposed a mandatory chooser before project selection, but the origin document updates the product direction to match desktop launchpad controls.
+- Normalize settings whenever backend changes: incompatible pending model/reasoning/fast values should be dropped or replaced with that backend's valid defaults before display or thread creation.
+- Reuse `updateDirectoryLaunchpad` for sticky defaults: it is the existing path that updates directory launchpads and global launchpad defaults when `stickySettingsChanged` is true. Messaging should reach it through `MessagingBackendBridge` rather than writing defaults directly.
+- Keep text fallback simple for this pass: button-capable providers get the normal picker; constrained/text fallback should expose numbered backend choices and stable fallback words without adding provider branches.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Where does pending backend live? On `MessagingBrowseSessionRecord`, because it is creation-time state and not a post-creation binding preference.
+- Which surface owns backend selection? The new-thread ready/options surface, with a backend picker action when multiple create-capable backends exist.
+- How should sticky defaults be updated? Through an optional `updateDirectoryLaunchpad` bridge method with `stickySettingsChanged: true`, matching the desktop launchpad path.
+- Should `/new` get a separate flow? No. `/new`, New help action, and `/resume --new` all continue through the existing resume browser new-thread mode.
+
+### Deferred to Implementation
+
+- Exact helper names and module placement for backend selection may adjust after implementation touches shared exports.
+- The final ACP/Gemini backend kind is deferred to the ACP work, but implementation should avoid adding new `codex | grok` validation in the new backend-selection path.
+- Exact text fallback parsing for backend picker replies should follow the existing pending-intent and fallback mapper behavior once implementation reaches that code.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TB
+    Command["/new or /resume --new"] --> Snapshot["Navigation snapshot + backend summaries"]
+    Snapshot --> Usable{"Create-capable backends?"}
+    Usable -->|0| Error["Recoverable no-backends error"]
+    Usable -->|1| Project["Project picker with selected backend"]
+    Usable -->|2+| Project
+    Project --> Ready["Ready-to-start options"]
+    Ready --> BackendButton["Provider button when 2+ usable"]
+    BackendButton --> BackendPicker["Backend picker"]
+    BackendPicker --> Normalize["Normalize model/settings for backend"]
+    Normalize --> Ready
+    Ready --> Prompt["First user prompt"]
+    Prompt --> Materialize["Materialize/start thread with selected backend"]
+    Materialize --> Status["Status card shows backend; no backend switch"]
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Add create-capable backend selection state and helpers**
+
+**Goal:** Represent the pending new-thread backend explicitly and provide one predicate/resolver for usable backend selection.
+
+**Requirements:** R2-R6, R11, R16, R19
+
+**Dependencies:** None.
+
+**Files:**
+- Create: `packages/shared/src/backend-selection.ts`
+- Modify: `packages/shared/src/index.ts`
+- Modify: `packages/messaging/interface/src/index.ts`
+- Modify: `apps/desktop/src/main/messaging/core/messaging-migrations.ts`
+- Test: `packages/shared/src/__tests__/backend-selection.test.ts`
+- Test: `packages/messaging/interface/src/__tests__/messaging-contract.test.ts`
+
+**Approach:**
+- Add a shared helper that returns backends usable for new thread creation. It should require `available`, `capabilities.createThread`, and at least one available execution mode.
+- Add a resolver that chooses the requested/default backend when usable, otherwise falls back to a create-capable backend using the same Codex-preferred behavior as the launchpad registry where applicable.
+- Extend `MessagingBrowseSessionRecord` with optional `backend?: AppServerBackendKind`.
+- Keep the migration/sanitization path backward-compatible: old browse sessions without `backend` remain valid and resolve from defaults when loaded.
+- Avoid broad ACP type changes here. If `AppServerBackendKind` is still `codex | grok`, keep the helper generic over the current contract and avoid adding new regex-style hard-coding elsewhere.
+
+**Patterns to follow:**
+- `apps/desktop/src/main/app-server/backend-registry.ts` `resolveLaunchpadBackend`
+- `apps/desktop/src/renderer/src/features/composer/Composer.tsx` provider filtering
+- `packages/messaging/interface/src/__tests__/messaging-contract.test.ts`
+
+**Test scenarios:**
+- Happy path: helper returns only available create-capable backends with at least one available execution mode.
+- Happy path: resolver picks the sticky launchpad default when it is usable.
+- Edge case: resolver falls back to another usable backend when the sticky default is unavailable.
+- Edge case: helper returns an empty list when all backends are unavailable or lack `createThread`.
+- Integration: a serialized browse session without `backend` still passes contract/migration validation.
+
+**Verification:**
+- Messaging has an explicit place to store pending backend selection without breaking existing persisted sessions.
+
+- [ ] **Unit 2: Add backend preflight and picker to the new-thread messaging flow**
+
+**Goal:** Make `/new`, New button, and `/resume --new` handle zero/one/multiple backend cases and expose backend switching before the first prompt.
+
+**Requirements:** R1-R6, R19-R22
+
+**Dependencies:** Unit 1.
+
+**Files:**
+- Modify: `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- Modify: `apps/desktop/src/main/messaging/core/messaging-resume-browser.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-resume-browser.test.ts`
+
+**Approach:**
+- In the new-thread entry path, call `listBackends({ includeUnavailable: true })` and resolve the selected backend before rendering the project picker.
+- If no create-capable backend exists, deliver a recoverable error and do not create a browse session or project picker.
+- If exactly one create-capable backend exists, store it in the browse session and keep the ready surface free of backend chooser UI.
+- If multiple create-capable backends exist, store the resolved sticky default and show a `Provider` action on the ready-to-start options surface.
+- Add `browse:new:backend` and `browse:new:set-backend` actions that render a single-select backend picker and return to the ready surface after selection.
+- Ensure the picker uses backend labels from `BackendSummary.label`, with any user-facing label mapping handled centrally rather than in provider adapters.
+- Preserve the current New/Resume back navigation behavior from nested pickers.
+- Treat backend discovery failures like other recoverable browse errors: report that backend choices are unavailable right now rather than falling through to stale launchpad defaults.
+
+**Patterns to follow:**
+- `presentNewThreadModelPicker` and `presentNewThreadReasoningPicker` in `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- `buildProjectPickerIntent` navigation actions in `apps/desktop/src/main/messaging/core/messaging-resume-browser.ts`
+- capability-profile action budgeting from `docs/plans/2026-05-04-002-feat-messaging-capability-discovery-plan.md`
+
+**Test scenarios:**
+- Happy path: `/new` with one create-capable backend opens the project picker and later ready surface without a Provider button.
+- Happy path: `/new` with Codex and Grok create-capable backends opens the project picker seeded to the sticky default and ready surface includes `browse:new:backend`.
+- Happy path: selecting `browse:new:set-backend` updates the browse session and re-renders ready-to-start with the new provider label.
+- Edge case: zero create-capable backends returns a recoverable "No backends available" error and does not render a project picker.
+- Error path: `listBackends` failure returns a recoverable backend-discovery error and does not create a project picker with implicit defaults.
+- Error path: stale or malformed backend picker callback returns the existing invalid browse selection error.
+- Integration: clicking the New help action and `/resume --new` exercise the same backend preflight behavior as `/new`.
+
+**Verification:**
+- Users can see and change provider/backend before sending the first prompt when more than one backend can create threads.
+
+- [ ] **Unit 3: Normalize backend-specific options and create threads with the selected backend**
+
+**Goal:** Ensure model/reasoning/fast controls and thread creation use the pending backend rather than `navigation.launchpadDefaults.backend`.
+
+**Requirements:** R7-R14, R16, R19-R21
+
+**Dependencies:** Units 1 and 2.
+
+**Files:**
+- Modify: `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+
+**Approach:**
+- Add a small controller-local resolver for "effective new-thread backend" that reads `session.backend`, then launchpad defaults, then the shared fallback resolver.
+- Update model and reasoning picker calls to use the effective selected backend.
+- Build the ready-to-start options from the selected backend's `BackendSummary.launchpadOptions`.
+- Hide or omit buttons that the selected backend does not support: for example, hide Fast when neither backend-level nor model-level fast support is advertised; hide Reasoning when no reasoning efforts are available and no selected model supports reasoning.
+- When backend changes, normalize pending preferences:
+  - model becomes the selected backend's current/default/first model when the previous model is not valid.
+  - reasoning effort becomes the selected backend's default or first available effort when unsupported.
+  - fast mode is cleared or false when unsupported.
+  - service tier is cleared or defaulted when unsupported.
+- Pass the selected backend to `materializeDirectoryLaunchpad` launchpad drafts and to the direct `startThread` fallback.
+- Update optimistic navigation/status-card creation so the resulting binding and status card reflect the selected backend.
+- Revalidate the selected backend immediately before materialize/start. If it is no longer create-capable, show a recoverable error instead of silently switching to another backend.
+
+**Patterns to follow:**
+- `newThreadOptionsForSession`, `launchpadForMessagingProject`, and `navigationWithStartedThread` in `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- `buildBindingStatusIntent` in `apps/desktop/src/main/messaging/core/messaging-status-card.ts`
+- backend model handling in `apps/desktop/src/renderer/src/features/composer/Composer.tsx`
+
+**Test scenarios:**
+- Happy path: selecting Grok then sending the first prompt materializes/starts a Grok thread and starts the turn with `backend: "grok"`.
+- Happy path: selecting Codex then choosing a Codex model sends that model to the materialized launchpad and subsequent turn.
+- Edge case: changing from Codex to Grok drops a Codex-only model and renders a Grok-valid model choice.
+- Edge case: a backend with no model choices hides the Model button and still allows thread creation if `createThread` is available.
+- Edge case: a backend without fast support hides Fast or clears the pending fast value before creation.
+- Error path: a backend that was selectable earlier but becomes unavailable before the first prompt fails recoverably and does not create a thread on a different backend.
+- Integration: the final status card text includes the selected backend identity and no Provider action is available after binding.
+
+**Verification:**
+- No new-thread creation path uses `navigation.launchpadDefaults.backend` after a session backend has been selected.
+
+- [ ] **Unit 4: Preserve launchpad sticky-default parity from messaging**
+
+**Goal:** Make backend/model/settings changes in a pending messaging new-thread flow update the same sticky launchpad defaults used by desktop launchpads.
+
+**Requirements:** R16-R18
+
+**Dependencies:** Units 1-3.
+
+**Files:**
+- Modify: `apps/desktop/src/main/messaging/core/messaging-adapter.ts`
+- Modify: `apps/desktop/src/main/messaging/desktop-backend-bridge.ts`
+- Modify: `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+- Test: `apps/desktop/src/main/__tests__/backend-registry.test.ts` only if implementation needs registry behavior beyond existing coverage.
+
+**Approach:**
+- Add optional `updateDirectoryLaunchpad` to `MessagingBackendBridge`, forwarding to `DesktopBackendRegistry.updateDirectoryLaunchpad`.
+- On pending new-thread option changes that are equivalent to desktop launchpad sticky settings, call the bridge with `stickySettingsChanged: true`.
+- Use the selected project's directory key and existing directory launchpad when available, so messaging does not invent a parallel default store.
+- Do not call sticky update paths for existing-thread status-card changes; those remain binding/thread-scoped settings.
+- Treat bridge absence as non-fatal in tests or alternate runtimes: the pending session still updates, but sticky default parity depends on the desktop bridge implementation.
+
+**Patterns to follow:**
+- `DesktopBackendRegistry.updateDirectoryLaunchpad` sticky patch handling in `apps/desktop/src/main/app-server/backend-registry.ts`
+- renderer launchpad update calls through `UpdateDirectoryLaunchpadRequest`
+- existing messaging bridge wrappers in `apps/desktop/src/main/messaging/desktop-backend-bridge.ts`
+
+**Test scenarios:**
+- Happy path: changing Provider on a pending new-thread session calls `updateDirectoryLaunchpad` with `stickySettingsChanged: true` and the selected backend.
+- Happy path: changing Model from the pending new-thread model picker calls the same sticky path with the selected model.
+- Edge case: sticky bridge unavailable still updates the pending session and can create the selected backend thread.
+- Regression: changing model from an existing thread status card calls `setThreadModelSettings` and does not call `updateDirectoryLaunchpad`.
+- Integration: a later `/new` session seeds from the updated sticky backend/default when navigation reflects the updated defaults.
+
+**Verification:**
+- Messaging and desktop launchpad defaults stay aligned for pre-thread choices without changing existing thread preferences.
+
+- [ ] **Unit 5: Update documentation and lock cross-surface behavior with focused tests**
+
+**Goal:** Document the new backend-selection behavior and ensure future backend additions do not regress the flow.
+
+**Requirements:** R1-R22
+
+**Dependencies:** Units 1-4.
+
+**Files:**
+- Modify: `docs/messaging-architecture.md`
+- Modify: `docs/messaging-platform-integration.md`
+- Test: `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-resume-browser.test.ts`
+- Test: `packages/shared/src/__tests__/backend-selection.test.ts`
+
+**Approach:**
+- Update messaging architecture docs to say `/new` starts from launchpad defaults, exposes Provider only when multiple create-capable backends exist, and freezes backend after creation.
+- Update operator/manual smoke docs to cover `/new` with one backend, multiple backends, model changes after backend change, and status-card backend confirmation.
+- Add regression tests around command parity: `/new`, `command:new`, and `/resume --new` should all reach the same backend-aware path.
+- Add tests for capability-profile action budgets if adding the Provider button affects the ready surface's action count on constrained profiles.
+- Keep docs channel-neutral and avoid promising ACP/Gemini internals.
+
+**Patterns to follow:**
+- command catalog documentation in `docs/messaging-architecture.md`
+- manual smoke flow style in `docs/messaging-platform-integration.md`
+- command/new tests in `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+
+**Test scenarios:**
+- Happy path: docs and tests agree that `/new` is the primary command and `/resume --new` is compatibility.
+- Happy path: constrained capability profile keeps required ready-surface actions reachable after adding Provider.
+- Regression: unauthorized actors cannot open the new backend picker or enumerate backend/project choices.
+- Regression: project picker pagination and Back/Cancel behavior remain unchanged.
+
+**Verification:**
+- The documented operator flow matches tested behavior, and adding another backend kind later has one obvious selection path to extend.
+
+## System-Wide Impact
+
+- **Interaction graph:** Slash command and help actions enter `MessagingController`, which creates a browse session, renders project/options/backend pickers, persists pending selections, materializes a launchpad or starts a thread, binds the conversation, then renders a status card.
+- **Error propagation:** Backend discovery failures or zero usable backend states should produce recoverable messaging errors. Invalid callbacks should continue through existing invalid browse/status selection errors.
+- **State lifecycle risks:** Browse sessions are temporary and restart-safe enough for callback handles. Adding optional `backend` must preserve old sessions and must not leak into binding preferences after creation.
+- **API surface parity:** Desktop launchpad sticky defaults and messaging pre-thread defaults should converge through `updateDirectoryLaunchpad`; existing-thread messaging status controls remain thread/binding scoped.
+- **Integration coverage:** Unit tests need to prove the full command -> project picker -> ready options -> backend picker -> prompt -> materialize/start -> status card path.
+- **Unchanged invariants:** Messaging providers stay channel-neutral; provider adapters render intents but do not decide backend workflow. Existing thread backend switching stays impossible.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+| --- | --- |
+| Pending backend gets stored as a mutable binding preference | Keep it on `MessagingBrowseSessionRecord`; created bindings already have immutable `backend`. |
+| Model/reasoning values from one backend bleed into another | Normalize preferences immediately after backend selection and again before materialize/start. |
+| Sticky default updates accidentally mutate existing thread settings | Use `updateDirectoryLaunchpad` only from pending new-thread flows; keep status-card changes on `setThreadModelSettings`. |
+| Adding Provider exceeds tight messaging action budgets | Use capability-profile action limiting and add constrained-profile tests. |
+| ACP/Gemini introduces new backend kinds after this lands | Avoid new hard-coded `codex | grok` checks in the backend-selection path; defer shared type widening to ACP work. |
+| Backend summary is stale between picker and prompt | Re-resolve/normalize against current `listBackends` or navigation defaults before creation; show recoverable error if selected backend is no longer usable. |
+
+## Documentation / Operational Notes
+
+- Update messaging docs with manual smoke coverage for one-backend and multi-backend `/new`.
+- Mention that provider/backend is a creation-time choice and appears on the status card after creation.
+- Do not document ACP/Gemini setup details until the ACP PR defines them.
+
+## Sources & References
+
+- **Origin document:** `docs/brainstorms/2026-05-22-messaging-new-thread-backend-selection-requirements.md`
+- Related issue: `https://github.com/pwrdrvr/PwrAgent/issues/194`
+- Related plan: `docs/plans/2026-05-12-001-feat-messaging-mention-help-new-plan.md`
+- Related plan: `docs/plans/2026-05-04-002-feat-messaging-capability-discovery-plan.md`
+- Related requirements: `docs/brainstorms/2026-04-20-desktop-provider-thread-model-selectors-requirements.md`
+- Related code: `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- Related code: `apps/desktop/src/main/messaging/core/messaging-resume-browser.ts`
+- Related code: `packages/messaging/interface/src/index.ts`
+- Related code: `packages/shared/src/contracts/backend.ts`
+- Related code: `apps/desktop/src/main/app-server/backend-registry.ts`

--- a/docs/plans/2026-05-22-001-feat-messaging-new-thread-backend-selection-plan.md
+++ b/docs/plans/2026-05-22-001-feat-messaging-new-thread-backend-selection-plan.md
@@ -126,7 +126,7 @@ flowchart TB
 
 ## Implementation Units
 
-- [ ] **Unit 1: Add create-capable backend selection state and helpers**
+- [x] **Unit 1: Add create-capable backend selection state and helpers**
 
 **Goal:** Represent the pending new-thread backend explicitly and provide one predicate/resolver for usable backend selection.
 

--- a/docs/plans/2026-05-22-001-feat-messaging-new-thread-backend-selection-plan.md
+++ b/docs/plans/2026-05-22-001-feat-messaging-new-thread-backend-selection-plan.md
@@ -285,7 +285,7 @@ flowchart TB
 **Verification:**
 - Messaging and desktop launchpad defaults stay aligned for pre-thread choices without changing existing thread preferences.
 
-- [ ] **Unit 5: Update documentation and lock cross-surface behavior with focused tests**
+- [x] **Unit 5: Update documentation and lock cross-surface behavior with focused tests**
 
 **Goal:** Document the new backend-selection behavior and ensure future backend additions do not regress the flow.
 

--- a/packages/messaging/interface/src/__tests__/messaging-contract.test.ts
+++ b/packages/messaging/interface/src/__tests__/messaging-contract.test.ts
@@ -556,6 +556,7 @@ describe("messaging surface contract", () => {
     const browseSession = {
       id: "browse-1",
       allowedActorIds: ["telegram-user-1"],
+      backend: "codex",
       bindingId: "binding-1",
       channel: binding.channel,
       createdAt: 1000,

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -1017,6 +1017,7 @@ export type MessagingBrowseReturnTarget = {
 export type MessagingBrowseSessionRecord = {
   id: string;
   allowedActorIds: string[];
+  backend?: AppServerBackendKind;
   bindingId?: string;
   channel: MessagingChannelRef;
   createdAt: number;

--- a/packages/shared/src/__tests__/backend-selection.test.ts
+++ b/packages/shared/src/__tests__/backend-selection.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import type { BackendSummary } from "../contracts/backend";
+import {
+  resolveNewThreadBackend,
+  selectableNewThreadBackends,
+} from "../backend-selection";
+
+describe("backend selection helpers", () => {
+  it("returns available create-capable backends with available execution modes", () => {
+    const backends = [
+      backendSummary("codex", { available: true, createThread: true }),
+      backendSummary("grok", { available: true, createThread: false }),
+      backendSummary("grok", {
+        available: true,
+        createThread: true,
+        executionModeAvailable: false,
+        label: "Grok unavailable mode",
+      }),
+    ];
+
+    expect(selectableNewThreadBackends(backends)).toEqual([
+      expect.objectContaining({ kind: "codex" }),
+    ]);
+  });
+
+  it("resolves the preferred backend when it is selectable", () => {
+    const backends = [
+      backendSummary("codex", { available: true, createThread: true }),
+      backendSummary("grok", { available: true, createThread: true }),
+    ];
+
+    expect(resolveNewThreadBackend(backends, "grok")).toMatchObject({
+      kind: "grok",
+    });
+  });
+
+  it("falls back to Codex before the first selectable backend", () => {
+    const backends = [
+      backendSummary("grok", { available: true, createThread: true }),
+      backendSummary("codex", { available: true, createThread: true }),
+    ];
+
+    expect(resolveNewThreadBackend(backends, undefined)).toMatchObject({
+      kind: "codex",
+    });
+  });
+
+  it("returns undefined when no backend can create threads", () => {
+    expect(
+      resolveNewThreadBackend([
+        backendSummary("codex", { available: false, createThread: true }),
+        backendSummary("grok", { available: true, createThread: false }),
+      ]),
+    ).toBeUndefined();
+  });
+});
+
+function backendSummary(
+  kind: "codex" | "grok",
+  options: {
+    available: boolean;
+    createThread: boolean;
+    executionModeAvailable?: boolean;
+    label?: string;
+  },
+): BackendSummary {
+  return {
+    kind,
+    label: options.label ?? (kind === "codex" ? "Codex" : "Grok"),
+    available: options.available,
+    methods: [],
+    capabilities: {
+      listThreads: true,
+      createThread: options.createThread,
+      resumeThread: true,
+      renameThread: true,
+      readThread: true,
+      startTurn: true,
+      interruptTurn: true,
+      steerTurn: false,
+      transcriptPagination: false,
+      toolUse: true,
+      approvalRequests: true,
+      multiDirectoryThreads: true,
+    },
+    executionModes: [
+      {
+        mode: "default",
+        label: "Default",
+        available: options.executionModeAvailable ?? true,
+      },
+    ],
+  };
+}

--- a/packages/shared/src/backend-selection.ts
+++ b/packages/shared/src/backend-selection.ts
@@ -1,0 +1,25 @@
+import type { AppServerBackendKind } from "./contracts/normalized-app-server";
+import type { BackendSummary } from "./contracts/backend";
+
+export function selectableNewThreadBackends(
+  backends: BackendSummary[],
+): BackendSummary[] {
+  return backends.filter(
+    (backend) =>
+      backend.available &&
+      backend.capabilities.createThread &&
+      backend.executionModes.some((mode) => mode.available),
+  );
+}
+
+export function resolveNewThreadBackend(
+  backends: BackendSummary[],
+  preferredBackend?: AppServerBackendKind,
+): BackendSummary | undefined {
+  const selectable = selectableNewThreadBackends(backends);
+  return (
+    selectable.find((backend) => backend.kind === preferredBackend) ??
+    selectable.find((backend) => backend.kind === "codex") ??
+    selectable[0]
+  );
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./contracts/normalized-app-server";
+export * from "./backend-selection";
 export * from "./codex-environment-action-runs";
 export * from "./contracts/backend";
 export * from "./contracts/agent";


### PR DESCRIPTION
## Summary

- I added explicit backend/provider selection to the messaging `/new` flow, including `/resume --new` and the **New** help action.
- I seed pending new-thread sessions from the launchpad sticky backend, show a Provider picker only when multiple create-capable backends are available, and create the thread on the selected backend.
- I normalize model, reasoning, fast mode, and service-tier options against the selected backend capabilities, then keep the provider immutable after the thread is created.
- I wired pending new-thread settings through `updateDirectoryLaunchpad` so messaging updates the same sticky defaults as the desktop launchpad.
- I updated contributor and operator docs for the new Provider behavior.

## Verification

- I ran `pnpm test packages/shared/src/__tests__/backend-selection.test.ts packages/messaging/interface/src/__tests__/messaging-contract.test.ts apps/desktop/src/main/__tests__/messaging-controller.test.ts apps/desktop/src/main/__tests__/messaging-resume-browser.test.ts`.
- I ran `pnpm typecheck`.
- I ran `pnpm lint:boundaries`.

## Notes

- Closes #194.
- I rebased onto `origin/main` before opening this PR so the diff does not revert the latest release metadata.
