### PR TITLE
fix(messaging): stabilize full access approvals

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -6733,6 +6733,139 @@ describe("MessagingController", () => {
     );
   });
 
+  it("does not capture ordinary text into a warned /new session after the picker TTL", async () => {
+    let now = 1000;
+    const navigation = buildNavigationSnapshot();
+    navigation.launchpadDefaults = {
+      ...navigation.launchpadDefaults,
+      executionMode: "full-access",
+    };
+    const harness = await createHarness({
+      navigation,
+      now: () => now,
+      pendingIntentTtlMs: 60_000,
+      fullAccessControls: {
+        allowEscalation: true,
+        allowThreadResume: true,
+        warningPolicy: "always",
+        authorizedUsers: {
+          telegram: [{ id: "user-1", displayName: "" }],
+        },
+      },
+    });
+    await bindThread(harness);
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+    await harness.controller.handleInboundEvent(buildTextEvent("new thread prompt"));
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Enable Full Access?",
+    });
+    const warning = harness.delivered.at(-1);
+    harness.startTurn.mockClear();
+    harness.materializeDirectoryLaunchpad.mockClear();
+
+    now += 90_000;
+    await harness.controller.handleInboundEvent(buildTextEvent("normal followup"));
+
+    expect(harness.materializeDirectoryLaunchpad).not.toHaveBeenCalled();
+    expect(harness.startTurn).not.toHaveBeenCalled();
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "full-access-risk:accept",
+        value: findAction(warning, "full-access-risk:accept").value,
+      }),
+    );
+
+    expect(harness.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        executionMode: "full-access",
+        input: [
+          {
+            type: "text",
+            text: "new thread prompt",
+          },
+        ],
+      }),
+    );
+  });
+
+  it("delivers the normal start failure if approved Full Access prompt startup throws", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.launchpadDefaults = {
+      ...navigation.launchpadDefaults,
+      executionMode: "full-access",
+    };
+    const materializeDirectoryLaunchpad = vi.fn(async () => {
+      throw new Error("boom");
+    });
+    const harness = await createHarness({
+      navigation,
+      materializeDirectoryLaunchpad,
+      fullAccessControls: {
+        allowEscalation: true,
+        allowThreadResume: true,
+        warningPolicy: "always",
+        authorizedUsers: {
+          telegram: [{ id: "user-1", displayName: "" }],
+        },
+      },
+    });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+    await harness.controller.handleInboundEvent(buildTextEvent("fix bug"));
+    const warning = harness.delivered.at(-1);
+    const accept = findAction(warning, "full-access-risk:accept");
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: accept.id,
+        value: accept.value,
+      }),
+    );
+
+    expect(harness.startTurn).not.toHaveBeenCalled();
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "error",
+      title: "Thread could not start",
+      body: "boom",
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: accept.id,
+        value: accept.value,
+      }),
+    );
+
+    expect(materializeDirectoryLaunchpad).toHaveBeenCalledTimes(2);
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "error",
+      title: "Thread could not start",
+    });
+  });
+
   it("reports specific copy when a first-prompt Full Access approval lost its prompt", async () => {
     const navigation = buildNavigationSnapshot();
     navigation.launchpadDefaults = {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -6466,6 +6466,375 @@ describe("MessagingController", () => {
     });
   });
 
+  it("starts a new inherited Full Access thread without a dismissable warning", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.launchpadDefaults = {
+      ...navigation.launchpadDefaults,
+      executionMode: "full-access",
+    };
+    const harness = await createHarness({
+      navigation,
+      fullAccessControls: {
+        allowEscalation: true,
+        allowThreadResume: true,
+        warningPolicy: "dismissable",
+        authorizedUsers: {
+          telegram: [{ id: "user-1", displayName: "" }],
+        },
+      },
+    });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+    harness.delivered.length = 0;
+
+    await harness.controller.handleInboundEvent(buildTextEvent("fix bug"));
+
+    expect(harness.delivered).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "confirmation",
+          title: "Enable Full Access?",
+        }),
+      ]),
+    );
+    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith(
+      expect.objectContaining({
+        launchpad: expect.objectContaining({
+          executionMode: "full-access",
+        }),
+      }),
+    );
+    expect(harness.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        executionMode: "full-access",
+        input: [
+          {
+            type: "text",
+            text: "fix bug",
+          },
+        ],
+      }),
+    );
+  });
+
+  it("starts a new thread from a directory launchpad Full Access default without a dismissable warning", async () => {
+    const navigation = buildFullAccessDirectoryLaunchpadNavigationSnapshot();
+    const harness = await createHarness({
+      navigation,
+      fullAccessControls: {
+        allowEscalation: true,
+        allowThreadResume: true,
+        warningPolicy: "dismissable",
+        authorizedUsers: {
+          telegram: [{ id: "user-1", displayName: "" }],
+        },
+      },
+    });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+    harness.delivered.length = 0;
+
+    await harness.controller.handleInboundEvent(buildTextEvent("fix bug"));
+
+    expect(harness.delivered).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "confirmation",
+          title: "Enable Full Access?",
+        }),
+      ]),
+    );
+    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith(
+      expect.objectContaining({
+        launchpad: expect.objectContaining({
+          executionMode: "full-access",
+        }),
+      }),
+    );
+    expect(harness.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        executionMode: "full-access",
+      }),
+    );
+  });
+
+  it("posts the first-prompt Full Access warning as a direct response when always warning", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.launchpadDefaults = {
+      ...navigation.launchpadDefaults,
+      executionMode: "full-access",
+    };
+    const harness = await createHarness({
+      navigation,
+      fullAccessControls: {
+        allowEscalation: true,
+        allowThreadResume: true,
+        warningPolicy: "always",
+        authorizedUsers: {
+          telegram: [{ id: "user-1", displayName: "" }],
+        },
+      },
+    });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+    harness.delivered.length = 0;
+
+    await harness.controller.handleInboundEvent(buildTextEvent("fix bug"));
+
+    expect(harness.startTurn).not.toHaveBeenCalled();
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Enable Full Access?",
+    });
+    expect(harness.delivered.at(-1)).not.toMatchObject({
+      delivery: expect.anything(),
+      targetSurface: expect.anything(),
+    });
+  });
+
+  it("blocks an inherited Full Access new thread when messaging escalation is disabled", async () => {
+    const onFullAccessPolicyViolation = vi.fn();
+    const navigation = buildNavigationSnapshot();
+    navigation.launchpadDefaults = {
+      ...navigation.launchpadDefaults,
+      executionMode: "full-access",
+    };
+    const harness = await createHarness({
+      navigation,
+      fullAccessControls: {
+        allowEscalation: false,
+        allowThreadResume: true,
+        warningPolicy: "dismissable",
+      },
+      onFullAccessPolicyViolation,
+    });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+    harness.delivered.length = 0;
+
+    await harness.controller.handleInboundEvent(buildTextEvent("fix bug"));
+
+    expect(harness.materializeDirectoryLaunchpad).not.toHaveBeenCalled();
+    expect(harness.startTurn).not.toHaveBeenCalled();
+    expect(onFullAccessPolicyViolation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorId: "user-1",
+        requestedAction: "messaging.full_access.start_new_thread",
+      }),
+    );
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "error",
+      title: "Full Access blocked",
+      body: expect.stringContaining("Starting a Full Access thread"),
+    });
+  });
+
+  it("keeps a first-prompt Full Access approval usable after the browse TTL", async () => {
+    let now = 1000;
+    const navigation = buildNavigationSnapshot();
+    navigation.launchpadDefaults = {
+      ...navigation.launchpadDefaults,
+      executionMode: "full-access",
+    };
+    const harness = await createHarness({
+      navigation,
+      now: () => now,
+      pendingIntentTtlMs: 60_000,
+      fullAccessControls: {
+        allowEscalation: true,
+        allowThreadResume: true,
+        warningPolicy: "always",
+        authorizedUsers: {
+          telegram: [{ id: "user-1", displayName: "" }],
+        },
+      },
+    });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+    await harness.controller.handleInboundEvent(buildTextEvent("fix bug"));
+    const warning = harness.delivered.at(-1);
+
+    now += 90_000;
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "full-access-risk:accept",
+        value: findAction(warning, "full-access-risk:accept").value,
+      }),
+    );
+
+    expect(harness.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        executionMode: "full-access",
+        input: [
+          {
+            type: "text",
+            text: "fix bug",
+          },
+        ],
+      }),
+    );
+    expect(harness.delivered).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "error",
+          title: "Invalid selection",
+        }),
+      ]),
+    );
+  });
+
+  it("reports specific copy when a first-prompt Full Access approval lost its prompt", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.launchpadDefaults = {
+      ...navigation.launchpadDefaults,
+      executionMode: "full-access",
+    };
+    const harness = await createHarness({
+      navigation,
+      fullAccessControls: {
+        allowEscalation: true,
+        allowThreadResume: true,
+        warningPolicy: "always",
+        authorizedUsers: {
+          telegram: [{ id: "user-1", displayName: "" }],
+        },
+      },
+    });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+    await harness.controller.handleInboundEvent(buildTextEvent("fix bug"));
+    const warning = harness.delivered.at(-1);
+    (
+      harness.controller as unknown as {
+        pendingFullAccessNewThreadPrompts: Map<string, unknown>;
+      }
+    ).pendingFullAccessNewThreadPrompts.clear();
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "full-access-risk:accept",
+        value: findAction(warning, "full-access-risk:accept").value,
+      }),
+    );
+
+    expect(harness.startTurn).not.toHaveBeenCalled();
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "error",
+      title: "Full Access prompt expired",
+      body: expect.stringContaining("pending prompt"),
+    });
+  });
+
+  it("reports specific copy when a Full Access approval lost its session", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.launchpadDefaults = {
+      ...navigation.launchpadDefaults,
+      executionMode: "full-access",
+    };
+    const harness = await createHarness({
+      navigation,
+      fullAccessControls: {
+        allowEscalation: true,
+        allowThreadResume: true,
+        warningPolicy: "always",
+        authorizedUsers: {
+          telegram: [{ id: "user-1", displayName: "" }],
+        },
+      },
+    });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+    await harness.controller.handleInboundEvent(buildTextEvent("fix bug"));
+    const warning = harness.delivered.at(-1);
+    const accept = findAction(warning, "full-access-risk:accept");
+    const value = accept.value as { sessionId: string };
+    await harness.store.deleteBrowseSession(value.sessionId);
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: accept.id,
+        value: accept.value,
+      }),
+    );
+
+    expect(harness.startTurn).not.toHaveBeenCalled();
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "error",
+      title: "Full Access approval expired",
+      body: expect.stringContaining("Full Access approval"),
+    });
+  });
+
   it("posts a permissions-queue audit message with a Cancel button on thread/executionMode/queued", async () => {
     const harness = await createHarness();
     await bindThread(harness);
@@ -7405,6 +7774,7 @@ async function createHarness(options?: {
   listSkills?: NonNullable<MessagingBackendBridge["listSkills"]> | false;
   navigation?: NavigationSnapshot;
   now?: () => number;
+  pendingIntentTtlMs?: number;
   channel?: MessagingChannelKind;
   capabilityProfile?: MessagingCapabilityProfile;
   fullAccessControls?: MessagingControllerOptions["fullAccessControls"];
@@ -7723,6 +8093,7 @@ async function createHarness(options?: {
     inputDebounceMs: options?.inputDebounceMs ?? 0,
     logger: options?.logger,
     now: options?.now ?? (() => 1000),
+    pendingIntentTtlMs: options?.pendingIntentTtlMs,
     fullAccessControls: options?.fullAccessControls ?? {
       allowEscalation: true,
       allowThreadResume: true,
@@ -7903,6 +8274,26 @@ function buildWorktreeLaunchpadNavigationSnapshot(): NavigationSnapshot {
       executionMode: "default",
       prompt: "",
       workMode: "worktree",
+      createdAt: 1000,
+      updatedAt: 1000,
+    },
+  };
+  return snapshot;
+}
+
+function buildFullAccessDirectoryLaunchpadNavigationSnapshot(): NavigationSnapshot {
+  const snapshot = buildNavigationSnapshot();
+  snapshot.directories[0] = {
+    ...snapshot.directories[0]!,
+    launchpad: {
+      directoryKey: "directory:pwragent",
+      directoryKind: "directory",
+      directoryLabel: "PwrAgent",
+      directoryPath: "/repo/pwragent",
+      backend: "codex",
+      executionMode: "full-access",
+      prompt: "",
+      workMode: "local",
       createdAt: 1000,
       updatedAt: 1000,
     },

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -1216,7 +1216,8 @@ export class MessagingController {
     if (
       session?.launchAction === "start_new_thread" &&
       session.mode === "new_thread_options" &&
-      session.selectedProject
+      session.selectedProject &&
+      (session.textInputExpiresAt ?? session.expiresAt) > this.now()
     ) {
       return session;
     }
@@ -5586,6 +5587,8 @@ export class MessagingController {
       await this.options.store.upsertBrowseSession({
         ...context.session,
         expiresAt: Math.max(context.session.expiresAt, expiresAt),
+        textInputExpiresAt:
+          context.session.textInputExpiresAt ?? context.session.expiresAt,
         updatedAt: this.now(),
       });
     }
@@ -5697,11 +5700,25 @@ export class MessagingController {
         return;
       }
       if (pendingPrompt) {
-        this.pendingFullAccessNewThreadPrompts.delete(session.id);
-        await this.createNewThreadFromPromptBundle({
-          events: pendingPrompt.events,
-          session: acceptedSession,
-        });
+        try {
+          await this.createNewThreadFromPromptBundle({
+            events: pendingPrompt.events,
+            session: acceptedSession,
+          });
+        } catch (error) {
+          this.logger.warn?.("messaging new-thread prompt failed", {
+            channel: pendingPrompt.session.channel.channel,
+            error: error instanceof Error ? error.message : String(error),
+            sessionId: pendingPrompt.session.id,
+          });
+          await this.deliverNewThreadPromptFailure(
+            {
+              events: pendingPrompt.events,
+              session: acceptedSession,
+            },
+            error,
+          );
+        }
         return;
       }
       await this.presentNewThreadPromptGate(acceptedSession, event);

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -53,6 +53,7 @@ import type {
   MessagingSurfaceRef,
   MessagingSurfaceIntent,
 } from "@pwragent/messaging-interface";
+import { MESSAGING_CALLBACK_HANDLE_TTL_MS } from "@pwragent/messaging-interface";
 import {
   buildHelpActions,
   formatMessagingCommandHelpBody,
@@ -324,6 +325,7 @@ type FullAccessEscalationContext =
     }
   | {
       kind: "new-thread";
+      pendingPrompt?: boolean;
       session: MessagingBrowseSessionRecord;
     }
   | {
@@ -341,6 +343,7 @@ type FullAccessRiskWarningContext =
     }
   | {
       kind: "new-thread";
+      pendingPrompt?: boolean;
       sessionId: string;
     }
   | {
@@ -357,8 +360,11 @@ type FullAccessRiskPresentation = {
 
 type FullAccessWarningResolution = {
   canDismiss: boolean;
+  policy: DesktopMessagingFullAccessWarningGlobalPolicy;
   shouldWarn: boolean;
 };
+
+type FullAccessRiskPresentationMode = "surface" | "message";
 
 export type MessagingControllerDeliveryBudgetEvent = {
   at: number;
@@ -468,6 +474,10 @@ export class MessagingController {
   private readonly toolUpdatePolicy: MessagingToolUpdatePolicy;
   private readonly turnAdmission: MessagingTurnAdmission;
   private readonly pendingNewThreadPrompts = new Map<string, PendingNewThreadPromptWindow>();
+  private readonly pendingFullAccessNewThreadPrompts = new Map<
+    string,
+    PendingNewThreadPromptBundle
+  >();
   private readonly monitorTimersByBindingId = new Map<
     string,
     ReturnType<typeof setTimeout>
@@ -2605,6 +2615,7 @@ export class MessagingController {
       }
     }
     this.pendingNewThreadPrompts.clear();
+    this.pendingFullAccessNewThreadPrompts.clear();
     this.toolUpdatePolicy.dispose();
   }
 
@@ -3284,6 +3295,7 @@ export class MessagingController {
     session: MessagingBrowseSessionRecord,
   ): Promise<void> {
     this.clearPendingNewThreadPrompt(session.id);
+    this.pendingFullAccessNewThreadPrompts.delete(session.id);
     await this.options.store.deleteBrowseSession(session.id);
     try {
       const removed = await this.options.store.deletePendingIntentsForChannel({
@@ -4049,15 +4061,27 @@ export class MessagingController {
       this.streamingResponsesDefault,
       selectedBackend,
     );
-    if (
-      options.executionMode === "full-access" &&
-      !(await this.isFullAccessRiskAcceptedForSession(session, event))
-    ) {
-      await this.presentFullAccessRiskWarning(
-        { kind: "new-thread", session },
+    if (options.executionMode === "full-access") {
+      const decision = await this.resolveFullAccessRiskForSession(
+        session,
         event,
+        options,
       );
-      return;
+      if (decision === "blocked") {
+        return;
+      }
+      if (decision === "warning") {
+        this.pendingFullAccessNewThreadPrompts.set(session.id, {
+          events: bundle.events,
+          session,
+        });
+        await this.presentFullAccessRiskWarning(
+          { kind: "new-thread", session },
+          event,
+          { presentationMode: "message" },
+        );
+        return;
+      }
     }
     const materialized = this.options.backend.materializeDirectoryLaunchpad
       ? await this.options.backend.materializeDirectoryLaunchpad({
@@ -4120,6 +4144,7 @@ export class MessagingController {
       worktreePath: materialized?.linkedDirectory?.worktreePath,
       workMode: materialized?.workMode ?? options.workMode,
     });
+    this.pendingFullAccessNewThreadPrompts.delete(session.id);
     await this.options.store.deleteBrowseSession(session.id);
     await this.startPreparedInput({
       binding: updatedBinding,
@@ -5473,6 +5498,7 @@ export class MessagingController {
   private async presentFullAccessRiskWarning(
     context: FullAccessEscalationContext,
     event: MessagingInboundEvent,
+    options: { presentationMode?: FullAccessRiskPresentationMode } = {},
   ): Promise<void> {
     const controls = await this.resolveFullAccessControls();
     const warning = await this.resolveFullAccessWarning(controls, event);
@@ -5486,6 +5512,9 @@ export class MessagingController {
         : context.kind === "new-thread"
           ? {
             kind: "new-thread",
+            ...(options.presentationMode === "message"
+              ? { pendingPrompt: true }
+              : {}),
             sessionId: context.session.id,
           }
           : {
@@ -5493,8 +5522,11 @@ export class MessagingController {
               kind: "resume-thread",
               sessionId: context.session.id,
               threadId: context.threadId,
-            };
-    const presentation = fullAccessRiskPresentationForContext(context);
+          };
+    const presentation = fullAccessRiskPresentationForContext(
+      context,
+      options.presentationMode ?? "surface",
+    );
     const actions: MessagingConfirmationIntent["actions"] = [
       {
         id: `${FULL_ACCESS_RISK_ACTION_PREFIX}accept`,
@@ -5543,7 +5575,26 @@ export class MessagingController {
       actions,
       targetSurface: presentation.surface,
     });
-    const pending = await this.storePendingIntent(intent, presentation.binding, event);
+    const expiresAt =
+      context.kind === "new-thread" || context.kind === "resume-thread"
+        ? this.now() + MESSAGING_CALLBACK_HANDLE_TTL_MS
+        : undefined;
+    if (
+      expiresAt !== undefined &&
+      (context.kind === "new-thread" || context.kind === "resume-thread")
+    ) {
+      await this.options.store.upsertBrowseSession({
+        ...context.session,
+        expiresAt: Math.max(context.session.expiresAt, expiresAt),
+        updatedAt: this.now(),
+      });
+    }
+    const pending = await this.storePendingIntent(
+      intent,
+      presentation.binding,
+      event,
+      expiresAt === undefined ? undefined : { expiresAt },
+    );
     const result = await this.deliver(intent, presentation.binding, event);
     if (result.surface) {
       await this.options.store.upsertPendingIntent({
@@ -5568,8 +5619,11 @@ export class MessagingController {
           now: this.now(),
         });
         if (!session) {
-          await this.deliverInvalidBrowseSelection(event);
+          await this.deliverStaleFullAccessWarning(event);
           return;
+        }
+        if (context.kind === "new-thread") {
+          this.pendingFullAccessNewThreadPrompts.delete(session.id);
         }
         const navigation = await this.options.backend.getNavigationSnapshot({
           backend: "all",
@@ -5627,19 +5681,30 @@ export class MessagingController {
 
     if (escalationContext.kind === "new-thread") {
       const { session } = escalationContext;
-      await this.presentNewThreadPromptGate(
-        {
-          ...session,
-          fullAccessRiskAcceptedAt: this.now(),
-          preferences: {
-            ...session.preferences,
-            executionMode: "full-access",
-            permissionsMode: "full-access",
-            updatedAt: this.now(),
-          },
+      const acceptedSession = {
+        ...session,
+        fullAccessRiskAcceptedAt: this.now(),
+        preferences: {
+          ...session.preferences,
+          executionMode: "full-access" as const,
+          permissionsMode: "full-access" as const,
+          updatedAt: this.now(),
         },
-        event,
-      );
+      };
+      const pendingPrompt = this.pendingFullAccessNewThreadPrompts.get(session.id);
+      if (escalationContext.pendingPrompt && !pendingPrompt) {
+        await this.deliverMissingFullAccessPrompt(event);
+        return;
+      }
+      if (pendingPrompt) {
+        this.pendingFullAccessNewThreadPrompts.delete(session.id);
+        await this.createNewThreadFromPromptBundle({
+          events: pendingPrompt.events,
+          session: acceptedSession,
+        });
+        return;
+      }
+      await this.presentNewThreadPromptGate(acceptedSession, event);
       return;
     }
 
@@ -5712,10 +5777,14 @@ export class MessagingController {
         now: this.now(),
       });
       if (!session) {
-        await this.deliverInvalidBrowseSelection(event);
+        await this.deliverStaleFullAccessWarning(event);
         return undefined;
       }
-      return { kind: "new-thread", session };
+      return {
+        kind: "new-thread",
+        pendingPrompt: context.pendingPrompt,
+        session,
+      };
     }
 
     if (context.kind === "resume-thread") {
@@ -5723,7 +5792,7 @@ export class MessagingController {
         now: this.now(),
       });
       if (!session) {
-        await this.deliverInvalidBrowseSelection(event);
+        await this.deliverStaleFullAccessWarning(event);
         return undefined;
       }
       return {
@@ -5779,12 +5848,13 @@ export class MessagingController {
     return await this.canResumeFullAccessThreads();
   }
 
-  private async isFullAccessRiskAcceptedForSession(
+  private async resolveFullAccessRiskForSession(
     session: MessagingBrowseSessionRecord,
     event: MessagingInboundEvent,
-  ): Promise<boolean> {
+    options: NewThreadOptionsSummary,
+  ): Promise<"accepted" | "blocked" | "warning"> {
     if (session.fullAccessRiskAcceptedAt) {
-      return true;
+      return "accepted";
     }
     const controls = await this.resolveFullAccessControls();
     if (!controls.allowEscalation) {
@@ -5797,10 +5867,16 @@ export class MessagingController {
         event,
         "Starting a Full Access thread from messaging is disabled in Settings.",
       );
-      return false;
+      return "blocked";
     }
     const warning = await this.resolveFullAccessWarning(controls, event);
-    return !warning.shouldWarn;
+    if (
+      warning.policy === "dismissable" &&
+      options.executionModeSource !== "session"
+    ) {
+      return "accepted";
+    }
+    return warning.shouldWarn ? "warning" : "accepted";
   }
 
   private async resolveFullAccessControls(): Promise<MessagingFullAccessControls> {
@@ -5828,10 +5904,10 @@ export class MessagingController {
     const effectivePolicy =
       policy === "default" ? controls.warningPolicy : policy;
     if (effectivePolicy === "never") {
-      return { canDismiss: false, shouldWarn: false };
+      return { canDismiss: false, policy: effectivePolicy, shouldWarn: false };
     }
     if (effectivePolicy === "always") {
-      return { canDismiss: false, shouldWarn: true };
+      return { canDismiss: false, policy: effectivePolicy, shouldWarn: true };
     }
     const canPersistDismissal =
       controls.canDismissWarning
@@ -5842,6 +5918,7 @@ export class MessagingController {
         : Boolean(controls.dismissWarning);
     return {
       canDismiss: Boolean(controls.dismissWarning) && canPersistDismissal,
+      policy: effectivePolicy,
       shouldWarn: contact?.fullAccessWarningDismissed !== true,
     };
   }
@@ -6958,6 +7035,38 @@ export class MessagingController {
     );
   }
 
+  private async deliverStaleFullAccessWarning(
+    event: MessagingInboundEvent,
+  ): Promise<void> {
+    await this.deliver(
+      buildErrorIntent({
+        id: this.newIntentId("stale-full-access-warning"),
+        createdAt: this.now(),
+        title: "Full Access approval expired",
+        body: "That Full Access approval is no longer available. Start the command again.",
+        recoverable: true,
+      }),
+      undefined,
+      event,
+    );
+  }
+
+  private async deliverMissingFullAccessPrompt(
+    event: MessagingInboundEvent,
+  ): Promise<void> {
+    await this.deliver(
+      buildErrorIntent({
+        id: this.newIntentId("missing-full-access-prompt"),
+        createdAt: this.now(),
+        title: "Full Access prompt expired",
+        body: "That Full Access approval no longer has the pending prompt. Send the prompt again.",
+        recoverable: true,
+      }),
+      undefined,
+      event,
+    );
+  }
+
   /**
    * Best-effort fan-out to the runtime's bindings-changed listener.
    * Wrapped so a misbehaving listener (e.g. closed BrowserWindow) can
@@ -7128,6 +7237,7 @@ export class MessagingController {
     intent: MessagingSurfaceIntent,
     binding?: MessagingBindingRecord,
     event?: MessagingInboundEvent,
+    options: { expiresAt?: number } = {},
   ): Promise<MessagingPendingIntentRecord> {
     return await this.options.store.upsertPendingIntent({
       id: intent.id,
@@ -7138,7 +7248,7 @@ export class MessagingController {
         event?.actor.platformUserId ?? "unknown",
       ],
       createdAt: this.now(),
-      expiresAt: this.now() + this.pendingIntentTtlMs,
+      expiresAt: options.expiresAt ?? this.now() + this.pendingIntentTtlMs,
     });
   }
 
@@ -7980,6 +8090,7 @@ function readFullAccessRiskContext(
   if (value.kind === "new-thread" && typeof value.sessionId === "string") {
     return {
       kind: "new-thread",
+      ...(value.pendingPrompt === true ? { pendingPrompt: true } : {}),
       sessionId: value.sessionId,
     };
   }
@@ -8012,7 +8123,11 @@ function readFullAccessRiskContext(
 
 function fullAccessRiskPresentationForContext(
   context: FullAccessEscalationContext,
+  presentationMode: FullAccessRiskPresentationMode,
 ): FullAccessRiskPresentation {
+  if (presentationMode === "message") {
+    return {};
+  }
   if (context.kind === "thread") {
     return {
       binding: context.binding,
@@ -8280,6 +8395,7 @@ type NewThreadOptionsSummary = {
   backendLabel: string;
   branchName: string;
   executionMode: ThreadExecutionMode;
+  executionModeSource: "session" | "directory-launchpad" | "launchpad-defaults";
   fastMode: boolean;
   model: string;
   reasoningEffort?: string;
@@ -8326,12 +8442,21 @@ function newThreadOptionsForSession(
     Boolean(modelOption?.supportsFast);
   const supportsReasoning =
     reasoningEfforts.length > 0 || Boolean(modelOption?.supportsReasoning);
+  const executionMode =
+    session.preferences?.executionMode ??
+    directory?.launchpad?.executionMode ??
+    navigation.launchpadDefaults.executionMode;
+  const executionModeSource = session.preferences?.executionMode
+    ? "session"
+    : directory?.launchpad?.executionMode
+      ? "directory-launchpad"
+      : "launchpad-defaults";
   return {
     backend: backend.kind,
     backendLabel: backend.label,
     branchName: resolveNewThreadBaseBranch(session, navigation, directory),
-    executionMode:
-      session.preferences?.executionMode ?? navigation.launchpadDefaults.executionMode,
+    executionMode,
+    executionModeSource,
     fastMode:
       supportsFast
         ? session.preferences?.fastMode ?? navigation.launchpadDefaults.fastMode ?? false

--- a/docs/brainstorms/2026-05-22-messaging-full-access-approval-requirements.md
+++ b/docs/brainstorms/2026-05-22-messaging-full-access-approval-requirements.md
@@ -1,0 +1,147 @@
+---
+date: 2026-05-22
+topic: messaging-full-access-approval
+---
+
+# Messaging Full Access Approval
+
+## Problem Frame
+
+Messaging new-thread startup can show Full Access as the selected launchpad
+default, accept the user's first prompt, and then replace the existing
+new-thread settings surface with a Full Access warning before starting the
+thread. If the user returns after the browse session expires, the approval
+button resolves to "Invalid selection" and the original prompt is gone.
+
+This makes an already-approved default feel like a surprise second gate, and it
+puts a new required action above the user's submitted prompt instead of in
+direct response to an explicit settings-card action.
+
+Current source observations:
+- New-thread options inherit `navigation.launchpadDefaults.executionMode` when
+  the session has no explicit override.
+- New-thread creation checks Full Access warning acceptance after the first
+  prompt is prepared, immediately before materializing the thread.
+- Browse sessions and pending intents currently use a 15-minute controller TTL,
+  while provider callback handles are designed for a much longer lifetime.
+- Full Access warnings for new/resume browse flows target the existing session
+  surface, so a text-triggered gate can rewrite an older card.
+
+## User Flow
+
+```mermaid
+flowchart TB
+  A[/new] --> B[Settings card shows inherited Full Access]
+  B --> C[User sends first prompt]
+  C --> D{Full Access was inherited and policy allows it?}
+  D -->|yes| E[Start new thread immediately]
+  D -->|no, explicit escalation requires warning| F[Show warning in response context]
+  F --> G{User approves}
+  G -->|yes| H[Start or return without losing the submitted intent]
+  G -->|cancel| I[Do not start Full Access]
+```
+
+## Requirements
+
+**Inherited Defaults**
+- R1. A new messaging thread whose initial settings already show Full Access
+  because of launchpad defaults or a directory launchpad must not require a
+  second Full Access warning under the dismissable warning policy.
+- R2. The `Always` warning policy remains authoritative: if the operator chose
+  to warn every time, messaging must still warn even when Full Access came from
+  an inherited default.
+- R3. Explicit messaging escalation from Default Access to Full Access must keep
+  the warning gate when the effective warning policy says to warn.
+
+**Warning Placement**
+- R4. Messaging may update an existing status/settings/picker card with a Full
+  Access warning only when the warning was triggered by a callback from that
+  same interactive surface.
+- R5. If a text or media message triggers a Full Access interlock, messaging
+  must not rewrite an older card above the user's message. It must either avoid
+  the interlock through inherited-default acceptance, or post the warning as the
+  direct response below the submitted message.
+
+**Held Prompt Behavior**
+- R6. If a first prompt is legitimately blocked by a Full Access warning,
+  approving the warning must not discard the prompt. The system should either
+  start the thread with the already-submitted prompt after approval, or clearly
+  avoid accepting/holding the prompt until the warning is resolved.
+- R7. Visible Full Access warning actions must not expire on the 15-minute
+  browse-session TTL. They should remain valid until they are superseded,
+  cancelled, or reach the same long-lived callback validity expected of other
+  persistent messaging buttons.
+- R8. Stale warnings, if they can still occur, must fail with copy specific to
+  the Full Access warning rather than the generic resume-browser "Invalid
+  selection" message.
+
+**Regression Coverage**
+- R9. Add coverage for `/new` with launchpad defaults set to Full Access and a
+  dismissable warning policy: the first prompt starts a Full Access thread
+  without rendering a warning.
+- R10. Add coverage for text-triggered warning placement if any warning path
+  remains for submitted prompts.
+- R11. Add coverage that a visible Full Access warning approval does not fail
+  merely because the underlying browse session aged past the current picker TTL.
+- R12. Keep existing coverage for explicit Full Access escalation from a status
+  or picker button, including the warning, cancel, dismiss, and policy-disabled
+  cases.
+
+## Success Criteria
+
+- Starting a `/new` thread from an already-Full-Access launchpad default begins
+  the thread on the first submitted prompt.
+- Users never see a required approval card inserted above their submitted text
+  unless they caused it by pressing a button on that same card.
+- Clicking a visible Full Access approval after a long delay does not produce
+  "Invalid selection" for the normal case.
+- Explicit escalation and operator policy controls still protect Default Access
+  threads from silently becoming Full Access.
+
+## Scope Boundaries
+
+- Do not remove the global ability to block messaging Full Access escalation.
+- Do not remove the `Always` warning policy.
+- Do not redesign the whole resume/new-thread browser flow.
+- Do not change provider-specific callback behavior unless required to preserve
+  the generic messaging contract.
+
+## Key Decisions
+
+- Inherited Full Access defaults under a dismissable warning policy count as
+  already user-selected for new-thread startup. The product should not treat the
+  first prompt as a new escalation event.
+- Warning placement should follow event causality. Callback-triggered warnings
+  can update the clicked surface; text-triggered warnings should respond in the
+  conversation flow.
+- Full Access warning approvals should not be governed by the short browse
+  picker TTL. A visible safety decision should stay actionable or explain its
+  invalidation precisely.
+
+## Dependencies / Assumptions
+
+- The operator remains responsible for deciding which messaging actors are
+  authorized to use messaging at all.
+- This work can be implemented inside desktop messaging orchestration and the
+  generic messaging contract without adding provider-specific policy branches.
+- Focused source review did not reveal another obvious path that rewrites a
+  status/settings card to ask for user input in response to plain text rather
+  than a card callback.
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R1][Technical] Determine whether the implementation should mark the
+  browse session as accepted when it is created with an inherited Full Access
+  default, or skip the warning check based on provenance at start time.
+- [Affects R6][Technical] If any submitted-prompt warning remains, decide
+  whether to persist the pending first prompt across process restart or only
+  guarantee it during the current controller lifetime.
+- [Affects R7][Technical] Decide whether Full Access warnings should use a
+  dedicated non-expiring domain record, the long callback-handle TTL, or a
+  refreshed browse-session record.
+
+## Next Steps
+
+-> `/prompts:ce-plan` for structured implementation planning.

--- a/docs/plans/2026-05-22-001-fix-messaging-full-access-approval-plan.md
+++ b/docs/plans/2026-05-22-001-fix-messaging-full-access-approval-plan.md
@@ -1,0 +1,475 @@
+---
+title: fix: Stabilize Messaging Full Access Approval
+type: fix
+status: active
+date: 2026-05-22
+origin: docs/brainstorms/2026-05-22-messaging-full-access-approval-requirements.md
+deepened: 2026-05-22
+---
+
+# fix: Stabilize Messaging Full Access Approval
+
+## Overview
+
+Messaging should not surprise a user with a second Full Access warning when a
+new thread starts from an already-Full-Access launchpad default. The fix is to
+separate inherited Full Access from explicit messaging escalation, keep the
+`Always` policy authoritative, and harden the remaining warning path so visible
+approval buttons are not invalidated by the short browse-session TTL.
+
+This is a Standard plan: the change is narrowly scoped to desktop messaging
+orchestration and tests, but it touches a security-sensitive permission mode
+and cross-provider callback behavior.
+
+## Problem Frame
+
+The origin requirements describe a `/new` flow where the settings card showed
+Full Access, the user sent the first prompt, and messaging then rewrote the
+existing settings card into a Full Access warning instead of starting the
+thread. The warning later resolved as a generic "Invalid selection" because the
+browse session used the controller's 15-minute pending-intent TTL, even though
+provider callback handles are designed to survive much longer.
+
+The product intent is that inherited Full Access defaults under the
+dismissable warning policy count as already user-selected for new-thread
+startup, while explicit Default Access -> Full Access escalation remains gated
+when the effective policy says to warn (see origin:
+`docs/brainstorms/2026-05-22-messaging-full-access-approval-requirements.md`).
+
+## Requirements Trace
+
+- R1. Inherited Full Access from launchpad defaults or directory launchpads
+  should not trigger a second warning under the dismissable policy.
+- R2. The `Always` warning policy must still warn even for inherited Full
+  Access.
+- R3. Explicit messaging escalation from Default Access to Full Access must keep
+  the warning gate.
+- R4. Callback-triggered warnings may update the clicked card; non-callback
+  warnings must not rewrite older cards.
+- R5. Text/media-triggered interlocks must either be avoided for inherited
+  defaults or posted as direct responses below the submitted message.
+- R6. If a submitted first prompt is legitimately blocked by a warning, approval
+  must not silently discard it during the current controller lifetime.
+- R7. Visible Full Access warning actions must not expire merely because the
+  browse session crossed the 15-minute picker TTL.
+- R8. Stale Full Access warnings need Full-Access-specific failure copy rather
+  than generic resume-browser invalid-selection copy.
+- R9-R12. Regression coverage must lock inherited-default startup, remaining
+  warning placement, stale-warning handling, and existing explicit-escalation
+  behavior.
+
+## Scope Boundaries
+
+- Do not weaken `allowEscalation`, `allowThreadResume`, or the `Always` warning
+  policy.
+- Do not redesign the whole `/resume` and `/new` browser.
+- Do not add provider-specific policy branches.
+- Do not change Codex permission-mode execution semantics or backend registry
+  queue behavior.
+- Do not persist arbitrary submitted prompts across process restart in this
+  pass.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `apps/desktop/src/main/messaging/core/messaging-controller.ts` owns the
+  new-thread browser, pending first-prompt debounce, Full Access warning
+  presentation, and callback handling.
+- `newThreadOptionsForSession` currently resolves `executionMode` from
+  `session.preferences?.executionMode ?? navigation.launchpadDefaults.executionMode`;
+  it does not expose whether Full Access was explicitly selected in messaging
+  or inherited from launchpad state.
+- `launchpadForMessagingProject` can materialize from an existing directory
+  launchpad whose `executionMode` differs from `navigation.launchpadDefaults`.
+  The implementation should reconcile this with the warning check so the mode
+  being approved is the mode actually materialized.
+- `createNewThreadFromPromptBundle` prepares the submitted prompt, then checks
+  `isFullAccessRiskAcceptedForSession`, and only then materializes the thread
+  and starts the turn.
+- `presentFullAccessRiskWarning` stores the warning as a normal pending intent
+  with `this.pendingIntentTtlMs`, currently 15 minutes.
+- `resolveFullAccessRiskCallbackContext` looks up new/resume warning context
+  through `getBrowseSession`; if the session expired, it falls through to the
+  generic browse invalid-selection response.
+- `packages/messaging/interface/src/index.ts` defines
+  `MESSAGING_CALLBACK_HANDLE_TTL_MS` as 30 days, and provider adapters persist
+  callback handles with that TTL while also storing `browseSessionId`.
+- Existing controller coverage lives in
+  `apps/desktop/src/main/__tests__/messaging-controller.test.ts`, including
+  explicit Full Access warning, dismiss, cancel, policy-disabled, and new-thread
+  picker-surface behavior.
+- Store coverage lives in `apps/desktop/src/main/__tests__/messaging-store.test.ts`
+  for file-backed state and `apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts`
+  for profile sqlite state.
+
+### Institutional Learnings
+
+- `docs/solutions/2026-05-07-codex-permission-mode-state-machine.md` is directly
+  relevant: permission-mode routing is security-sensitive, silent fallbacks are
+  dangerous, and every mode decision should be explicit, observable, and tested.
+
+### External References
+
+- None used. This is repo-specific state orchestration with strong local
+  patterns; external framework research would not materially improve the plan.
+
+## Key Technical Decisions
+
+- Track or derive execution-mode provenance for new-thread startup instead of
+  treating every Full Access start as escalation. This is the smallest way to
+  satisfy R1 without weakening explicit escalation gates.
+- Resolve inherited-default acceptance at start time, not by eagerly marking
+  every browse session accepted. Start-time resolution has access to the final
+  selected directory, directory launchpad, and global launchpad defaults, so it
+  can distinguish explicit messaging preferences from inherited launchpad state.
+- Keep the existing warning path for explicit escalation, but make warning
+  presentation aware of trigger source. Callback-triggered warnings can update
+  the clicked surface; text-triggered warnings should be delivered as a new
+  direct response.
+- Use the existing callback-handle durability model for visible Full Access
+  warning actions. Extend the warning's domain state to survive as long as the
+  button is meant to work instead of adding provider-specific callback logic.
+- Preserve prompt holding in memory for the rare explicit text-triggered warning
+  path. Persisting arbitrary first prompts across restart would expand scope and
+  data-retention risk; if the in-memory bundle is gone, the user should receive
+  Full-Access-specific resubmission copy rather than a generic invalid-selection
+  message.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should implementation mark inherited Full Access sessions accepted at
+  creation, or skip warning based on provenance at start time?
+  Resolution: skip based on provenance at start time. Directory launchpad
+  selection can change which inherited defaults apply, and start-time logic is
+  easier to keep honest.
+- Should submitted prompts blocked by explicit text-triggered warnings be
+  persisted across restart?
+  Resolution: no for this pass. Hold them for the current controller lifetime
+  and return specific resubmission copy if the prompt bundle is no longer
+  available.
+- Should Full Access warning actions use a dedicated non-expiring domain record?
+  Resolution: no new domain record initially. Reuse pending intent and browse
+  session records with a Full Access warning TTL aligned to the provider
+  callback-handle TTL, then add specific stale-warning handling for cases where
+  state is still missing.
+
+### Deferred to Implementation
+
+- Exact helper names and shape for execution-mode provenance should follow the
+  surrounding `newThreadOptionsForSession` and `resolve*` helper style.
+- The final in-memory pending-prompt key should be chosen while touching the
+  existing `pendingNewThreadPrompts` map to avoid duplicate cleanup paths.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for
+> review, not implementation specification. The implementing agent should treat
+> it as context, not code to reproduce.*
+
+```mermaid
+flowchart TB
+  A[New-thread session] --> B[Resolve final options and provenance]
+  B --> C{Full Access?}
+  C -->|no| H[Materialize thread and start prompt]
+  C -->|yes| D{Effective policy}
+  D -->|never| H
+  D -->|always| E[Warn]
+  D -->|dismissable| F{Explicit messaging escalation?}
+  F -->|no, inherited launchpad default| H
+  F -->|yes| E
+  E --> G{Trigger source}
+  G -->|callback| I[Update clicked surface]
+  G -->|text/media| J[Post direct warning and hold prompt]
+  I --> K[Approve/cancel]
+  J --> K
+  K -->|approve| H
+  K -->|cancel| L[Return to safe non-Full-Access state]
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Classify New-Thread Full Access Provenance**
+
+**Goal:** Distinguish inherited Full Access defaults from explicit messaging
+escalation before deciding whether the warning gate applies.
+
+**Requirements:** R1, R2, R3, R9, R12
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+
+**Approach:**
+- Extend the new-thread option resolution path so it reports both the resolved
+  execution mode and its source: explicit session preference, directory
+  launchpad, or global launchpad default.
+- Make that resolved execution mode the same mode that will be passed to
+  materialization/startup. Avoid a split where the warning check sees the global
+  default but materialization later uses a directory launchpad's Full Access
+  mode.
+- Treat explicit session preference as messaging escalation when it selects Full
+  Access from a Default Access baseline. This includes picker toggles and
+  command-parsed preferences such as `--yolo`.
+- Treat directory/global launchpad Full Access as inherited for `/new`
+  startup. Under `dismissable`, inherited Full Access should pass the warning
+  check; under `always`, it should still warn.
+- Keep `allowEscalation: false` authoritative. Even inherited Full Access from
+  messaging should still be blocked when messaging Full Access escalation is
+  disabled.
+
+**Execution note:** Implement behavior test-first because this is
+security-sensitive permission routing.
+
+**Patterns to follow:**
+- `newThreadOptionsForSession` and nearby launchpad helper functions in
+  `apps/desktop/src/main/messaging/core/messaging-controller.ts`.
+- Existing Full Access warning tests in
+  `apps/desktop/src/main/__tests__/messaging-controller.test.ts`.
+
+**Test scenarios:**
+- Happy path: `/resume --new` with `launchpadDefaults.executionMode =
+  "full-access"` and `warningPolicy = "dismissable"`; selecting a project and
+  sending the first prompt starts/materializes a Full Access thread and starts
+  the turn without delivering `Enable Full Access?`.
+- Happy path: selected directory has a persisted launchpad with
+  `executionMode = "full-access"` while global defaults remain Default Access;
+  sending the first prompt starts/materializes Full Access without a warning
+  under `dismissable`.
+- Happy path: same inherited default with `warningPolicy = "never"` also starts
+  without a warning.
+- Error path: same inherited default with `allowEscalation = false` does not
+  start and delivers `Full Access blocked`.
+- Edge case: inherited default with `warningPolicy = "always"` still delivers
+  `Enable Full Access?`.
+- Integration: explicit picker toggle from Default Access to Full Access still
+  renders the warning and only applies Full Access after approval.
+
+**Verification:**
+- New-thread startup tests show inherited Full Access and explicit escalation
+  take different warning paths.
+- Existing explicit escalation tests continue to pass without weakening policy
+  controls.
+
+- [ ] **Unit 2: Make Full Access Warning Presentation Causal and Long-Lived**
+
+**Goal:** Ensure Full Access warnings update only the surface that caused them
+and remain actionable beyond the short browse-picker TTL.
+
+**Requirements:** R4, R5, R7, R8, R10, R11
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- Modify only if the chosen TTL shape requires shared type/doc adjustment:
+  `packages/messaging/interface/src/index.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+- Test if store TTL behavior is adjusted directly:
+  `apps/desktop/src/main/__tests__/messaging-store.test.ts`
+- Test if sqlite store TTL behavior is adjusted directly:
+  `apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts`
+
+**Approach:**
+- Add a trigger-source parameter to Full Access warning presentation, or derive
+  it from the call site: status/picker callbacks are interactive-surface
+  triggers; text/media prompt submission is conversation-flow triggered.
+- For interactive-surface triggers, preserve the existing update-in-place
+  behavior.
+- For text/media-triggered warnings, deliver a fresh confirmation below the
+  submitted message rather than targeting the session surface.
+- When a Full Access warning is created for a browse session, extend the
+  relevant browse-session and pending-intent expiry to the same long-lived
+  window as callback handles, or otherwise make the callback context independent
+  of the short picker TTL.
+- Replace generic browse invalid-selection handling for missing Full Access
+  warning context with copy that names the Full Access warning and tells the
+  user whether to retry the command, resubmit the prompt, or refresh the browser.
+
+**Patterns to follow:**
+- Provider callback handles already use `MESSAGING_CALLBACK_HANDLE_TTL_MS` in
+  Telegram and Discord adapters.
+- `findBrowseSessionForCallback` already prefers callback-handle-scoped session
+  lookup before falling back to active channel session lookup.
+- Existing error intent builders and invalid-selection copy in
+  `messaging-controller.ts`.
+
+**Test scenarios:**
+- Happy path: explicit `browse:new:permissions` callback warning still updates
+  the ready-to-start picker surface.
+- Happy path: explicit text-triggered Full Access warning posts as a new
+  confirmation without `delivery.mode = "update"` and without targeting the old
+  picker surface.
+- Edge case: after warning creation, advancing the controller clock beyond 15
+  minutes but within callback-handle lifetime still lets `full-access-risk:accept`
+  resolve the session instead of returning generic `Invalid selection`.
+- Error path: accepting a Full Access warning whose session or pending prompt is
+  genuinely gone returns Full-Access-specific stale-warning copy.
+- Integration: Telegram/Discord-style callback handle values still route through
+  the generic callback handling path with no provider-specific policy branches.
+
+**Verification:**
+- Warning placement reflects trigger source.
+- Visible warning buttons are not tied to the short picker TTL.
+- Stale cases no longer use resume-browser invalid-selection copy.
+
+- [ ] **Unit 3: Preserve Submitted Prompt Continuation for Explicit Warning Path**
+
+**Goal:** If a first prompt is blocked by a legitimate explicit Full Access
+warning, approval should continue the submitted prompt during the active
+controller lifetime instead of returning to the ready card and losing context.
+
+**Requirements:** R6, R10, R11
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+
+**Approach:**
+- When `createNewThreadFromPromptBundle` hits a warning for an explicit
+  messaging escalation, keep a small in-memory pending bundle keyed by the
+  browse session or warning context.
+- Include enough warning context to find that bundle after approval.
+- On approval, continue through the same thread materialization and
+  `startPreparedInput` path using the original prepared prompt events.
+- On cancel, clear the pending bundle and return to the safe ready state or
+  browser state.
+- On cleanup, clear pending warning bundles when the browse session retires,
+  when a new prompt supersedes the old one, or when the controller handles a
+  stale/missing warning context.
+- Do not persist the prompt payload in profile state for this pass; use specific
+  resubmission copy if a restart or cleanup removes the in-memory bundle.
+
+**Patterns to follow:**
+- Existing `pendingNewThreadPrompts` debounce map and `clearPendingNewThreadPrompt`.
+- Existing `createNewThreadFromPromptBundle` path for materialization, binding,
+  status-surface preservation, and optimistic navigation.
+
+**Test scenarios:**
+- Happy path: explicit text-triggered Full Access warning holds the submitted
+  prompt; accepting the warning starts the new Full Access thread and calls
+  `startTurn` with the original prompt text.
+- Edge case: canceling the warning clears the held prompt and does not create a
+  thread or start a turn.
+- Error path: accepting after the held prompt bundle is missing returns specific
+  resubmission copy and does not create an empty thread.
+- Integration: cleanup after successful start deletes the browse session and
+  pending prompt bundle.
+
+**Verification:**
+- Legitimately blocked first prompts are not dropped during normal long-delay
+  approval within one running controller.
+- Missing in-memory prompt state fails explicitly and safely.
+
+- [ ] **Unit 4: Tighten Regression Coverage and Policy Invariants**
+
+**Goal:** Lock the security and UX invariants across controller, store, and
+callback lifecycle tests so future changes do not reintroduce the stale warning
+or silent permission escalation behavior.
+
+**Requirements:** R1-R12
+
+**Dependencies:** Units 1-3
+
+**Files:**
+- Modify: `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+- Modify if direct store behavior changed:
+  `apps/desktop/src/main/__tests__/messaging-store.test.ts`
+- Modify if sqlite store behavior changed:
+  `apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts`
+
+**Approach:**
+- Add focused controller tests near the existing Full Access warning tests so
+  related behavior stays visible in one section.
+- Prefer small navigation overrides in the existing harness over broad fixture
+  creation.
+- Assert both positive behavior and absence of the bad behavior: no warning for
+  inherited dismissable defaults, no `Invalid selection` for long-lived visible
+  warnings, no start when escalation is disabled.
+- Keep store tests only if the implementation changes generic store TTL or
+  cleanup behavior. If TTL extension is done by writing longer expiration values
+  from the controller, controller tests are enough for store behavior.
+
+**Patterns to follow:**
+- Harness helpers in `apps/desktop/src/main/__tests__/messaging-controller.test.ts`.
+- File-backed and sqlite store round-trip/expiry tests only if persistence
+  contract changes.
+
+**Test scenarios:**
+- Happy path: inherited Full Access dismissable startup starts the turn with
+  Full Access.
+- Edge case: inherited Full Access `Always` warns.
+- Error path: inherited Full Access while escalation disabled blocks.
+- Happy path: explicit callback escalation preserves the current update-in-place
+  warning behavior.
+- Happy path: explicit text-triggered warning approval after more than 15
+  minutes continues correctly.
+- Error path: stale Full Access warning state returns specific stale-warning
+  copy.
+
+**Verification:**
+- The controller test suite covers every origin regression requirement.
+- Store tests, if changed, prove file-backed and sqlite state agree.
+
+## System-Wide Impact
+
+- **Interaction graph:** Inbound command/callback/text events enter
+  `MessagingController`, which coordinates browse sessions, pending intents,
+  callback handles, and backend thread start/turn start. Provider adapters
+  should remain generic button transport layers.
+- **Error propagation:** Policy denial remains `Full Access blocked`; stale Full
+  Access approval becomes a specific recoverable error; generic browse
+  invalid-selection remains for non-Full-Access browser callbacks.
+- **State lifecycle risks:** Extending warning state beyond the browse picker
+  TTL must not keep obsolete generic browser sessions active indefinitely.
+  Restrict longer lifetime to active Full Access warning contexts, and clean
+  them up on approval, cancellation, supersession, and browse retirement.
+- **API surface parity:** Telegram, Discord, LINE, Slack, Feishu, and Mattermost
+  should not need provider-specific policy logic. Any shape changes should stay
+  inside the generic messaging contract or desktop controller.
+- **Integration coverage:** Controller tests must cover button-style callbacks
+  and fallback/stale context behavior. Provider tests are only needed if the
+  generic intent shape changes.
+- **Unchanged invariants:** Existing thread permission queue behavior, Codex
+  sandbox routing, messaging allowlists, and global Full Access policy controls
+  remain authoritative.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Accidentally treating explicit `--yolo` or picker escalation as inherited | Model execution-mode provenance explicitly and test both inherited and explicit paths. |
+| Weakening `Always` warning or `allowEscalation: false` | Keep policy checks centralized and add tests for both settings. |
+| Long-lived warning state keeps stale browser sessions alive | Extend only Full Access warning-related state and clean it up on terminal transitions. |
+| Holding first prompts in memory creates restart ambiguity | Document and test the current-lifetime guarantee; return specific resubmission copy if memory state is gone. |
+| Provider-specific behavior drifts | Keep changes in the generic controller/contract layer and rely on existing callback-handle persistence. |
+
+## Documentation / Operational Notes
+
+- No operator-facing docs change is required unless implementation changes the
+  wording or semantics of Settings -> Messaging Full Access controls.
+- Add a short code comment only where provenance or long-lived warning state
+  would otherwise look like an accidental bypass of the warning gate.
+- This plan should be executed with focused controller tests before broader
+  desktop typecheck/lint gates.
+
+## Sources & References
+
+- Origin document:
+  `docs/brainstorms/2026-05-22-messaging-full-access-approval-requirements.md`
+- `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- `apps/desktop/src/main/messaging/core/messaging-store.ts`
+- `apps/desktop/src/main/state/messaging-store-sqlite.ts`
+- `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+- `apps/desktop/src/main/__tests__/messaging-store.test.ts`
+- `apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts`
+- `packages/messaging/interface/src/index.ts`
+- `packages/messaging/providers/telegram/src/telegram-adapter.ts`
+- `packages/messaging/providers/discord/src/discord-adapter.ts`
+- `docs/solutions/2026-05-07-codex-permission-mode-state-machine.md`

--- a/docs/plans/2026-05-22-001-fix-messaging-full-access-approval-plan.md
+++ b/docs/plans/2026-05-22-001-fix-messaging-full-access-approval-plan.md
@@ -1,7 +1,7 @@
 ---
 title: fix: Stabilize Messaging Full Access Approval
 type: fix
-status: active
+status: completed
 date: 2026-05-22
 origin: docs/brainstorms/2026-05-22-messaging-full-access-approval-requirements.md
 deepened: 2026-05-22
@@ -191,7 +191,7 @@ flowchart TB
 
 ## Implementation Units
 
-- [ ] **Unit 1: Classify New-Thread Full Access Provenance**
+- [x] **Unit 1: Classify New-Thread Full Access Provenance**
 
 **Goal:** Distinguish inherited Full Access defaults from explicit messaging
 escalation before deciding whether the warning gate applies.
@@ -255,7 +255,7 @@ security-sensitive permission routing.
 - Existing explicit escalation tests continue to pass without weakening policy
   controls.
 
-- [ ] **Unit 2: Make Full Access Warning Presentation Causal and Long-Lived**
+- [x] **Unit 2: Make Full Access Warning Presentation Causal and Long-Lived**
 
 **Goal:** Ensure Full Access warnings update only the surface that caused them
 and remain actionable beyond the short browse-picker TTL.
@@ -317,7 +317,7 @@ and remain actionable beyond the short browse-picker TTL.
 - Visible warning buttons are not tied to the short picker TTL.
 - Stale cases no longer use resume-browser invalid-selection copy.
 
-- [ ] **Unit 3: Preserve Submitted Prompt Continuation for Explicit Warning Path**
+- [x] **Unit 3: Preserve Submitted Prompt Continuation for Explicit Warning Path**
 
 **Goal:** If a first prompt is blocked by a legitimate explicit Full Access
 warning, approval should continue the submitted prompt during the active
@@ -367,7 +367,7 @@ controller lifetime instead of returning to the ready card and losing context.
   approval within one running controller.
 - Missing in-memory prompt state fails explicitly and safely.
 
-- [ ] **Unit 4: Tighten Regression Coverage and Policy Invariants**
+- [x] **Unit 4: Tighten Regression Coverage and Policy Invariants**
 
 **Goal:** Lock the security and UX invariants across controller, store, and
 callback lifecycle tests so future changes do not reintroduce the stale warning

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -1034,6 +1034,7 @@ export type MessagingBrowseSessionRecord = {
   branchName?: string;
   selectedProject?: MessagingBrowseSelectedProject;
   surface?: MessagingSurfaceRef;
+  textInputExpiresAt?: number;
   updatedAt: number;
 };
 


### PR DESCRIPTION
## Summary

- Fix messaging `/new` Full Access approval so inherited launchpad Full Access starts without a duplicate dismissable warning
- Keep explicit Full Access escalation guarded, preserve `Always` warnings, and keep `allowEscalation: false` authoritative
- Make prompt-triggered warnings post as direct replies, keep approval callbacks usable past the picker TTL, and continue the held first prompt after approval
- Add stale/missing approval copy plus retry/failure handling for approved first-prompt startup

## Verification

- `pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts`
- `pnpm lint`

## Notes

- I verified the controller regression suite and the full lint pipeline pass locally.
