### PR TITLE
fix(desktop): constrain thread title hit target

### DIFF
--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -211,11 +211,22 @@ describe("Tangerine Terminal theme contract", () => {
     expect(statusBarRule).toContain("flex: 0 0 auto;");
     expect(statusBarRule).toContain("min-width: max-content;");
     expect(eyebrowRowRule).toContain("min-width: 0;");
-    expect(compactTitleRule).toContain("flex: 1 1 auto;");
+    expect(compactTitleRule).toContain("flex: 0 1 auto;");
     expect(compactTitleRule).toContain("overflow: hidden;");
     expect(css).toMatch(
       /\.thread-header__eyebrow-row > \.thread-row__chip\s*\{[\s\S]*?flex:\s*0 0 auto;[\s\S]*?\}/
     );
+  });
+
+  it("keeps the thread title reveal hit target to the rendered title text", () => {
+    const compactTitleRule = extractRuleBody(css, ".thread-header__compact-title");
+    const titleButtonRule = extractRuleBody(css, ".thread-header__title-button");
+
+    expect(compactTitleRule).toContain("width: fit-content;");
+    expect(compactTitleRule).toContain("max-width: min(58vw, 520px);");
+    expect(titleButtonRule).toContain("display: inline-block;");
+    expect(titleButtonRule).toContain("max-width: 100%;");
+    expect(titleButtonRule).not.toMatch(/(?:^|\n)\s*width:\s*100%;/);
   });
 
   it("keeps launchpad header chips content-sized and aligned with the eyebrow", () => {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5141,7 +5141,8 @@ textarea,
 }
 
 .thread-header__compact-title {
-  flex: 1 1 auto;
+  flex: 0 1 auto;
+  width: fit-content;
   max-width: min(58vw, 520px);
   min-width: 0;
   margin: 0;
@@ -5156,8 +5157,8 @@ textarea,
 }
 
 .thread-header__title-button {
-  display: block;
-  width: 100%;
+  display: inline-block;
+  max-width: 100%;
   min-width: 0;
   overflow: hidden;
   padding: 0;


### PR DESCRIPTION
## Summary
- shrink-wrap the thread header title reveal button so only the rendered title text is clickable
- keep the surrounding Electron title-bar space available for window dragging
- add a theme contract assertion that prevents the title button from regaining a full-width hit target

## Test plan
- `pnpm test apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadHeader.test.tsx`
- `pnpm lint:colors`
