### PR TITLE
fix(desktop): show unavailable reason when Codex is logged out

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -509,7 +509,10 @@ function DesktopAppShell(props: {
         automationsActive={mainView === "automations"}
         settingsActive={mainView === "settings"}
         onBrowseModeChange={navigation.setBrowseMode}
-        onCreateThread={navigation.createThread}
+        onCreateThread={async () => {
+          setMainView("thread");
+          await navigation.createThread();
+        }}
         onOpenAutomations={() => {
           setMainView("automations");
         }}

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -91,6 +91,7 @@ type ComposerProps = {
   draftStore?: ComposerDraftStore;
   launchpad?: NavigationLaunchpadDraft;
   launchpadError?: string;
+  unavailableReason?: string;
   onActiveTurnIdChange?: (turnId?: string) => void;
   fullAccessRiskWarningDismissed?: boolean;
   onEnsureSkillsLoaded?: () => void | Promise<void>;
@@ -4887,6 +4888,11 @@ export function Composer(props: ComposerProps) {
       {workspaceHandoffDialog}
 
       {props.skillError ? <p className="composer__meta composer__meta--error">{props.skillError}</p> : null}
+      {props.unavailableReason ? (
+       <p className="composer__meta composer__meta--error">
+         {props.unavailableReason}
+       </p>
+      ) : null}
       {props.launchpadError ? (
         <CopyableComposerError
           desktopApi={props.desktopApi}

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -330,6 +330,34 @@ describe("Composer", () => {
     });
   });
 
+  it("renders unavailable reason when provided", async () => {
+    const unavailableReason = "Codex profile not logged in. Please check your settings.";
+    render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        disabled={true}
+        launchpad={{
+          directoryKey: "directory:/repo",
+          directoryKind: "directory",
+          directoryLabel: "PwrAgent",
+          directoryPath: "/repo",
+          backend: "codex",
+          executionMode: "default",
+          prompt: "",
+          workMode: "local",
+          branchName: "main",
+          createdAt: 1,
+          updatedAt: 1,
+        }}
+        unavailableReason={unavailableReason}
+        skills={[]}
+      />
+    );
+
+    expect(screen.getByText(unavailableReason)).toBeInTheDocument();
+    expect(screen.getByText(unavailableReason)).toHaveClass("composer__meta--error");
+  });
+
   it("opens the current workspace in discovered applications", async () => {
     const openApplication = vi.fn(async () => ({ opened: true as const }));
 

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -173,16 +173,6 @@ export function Sidebar(props: SidebarProps) {
   const [renameThread, setRenameThread] = useState<NavigationThreadSummary>();
   const [renameDraft, setRenameDraft] = useState("");
   const [renameValidationError, setRenameValidationError] = useState<string>();
-  const hasCreateThreadOptions = useMemo(
-    () =>
-      props.backends.some(
-        (backend) =>
-          backend.available &&
-          backend.capabilities.createThread &&
-          backend.executionModes.some((mode) => mode.available)
-      ),
-    [props.backends]
-  );
   const onArchiveThread = props.onArchiveThread ?? (async () => undefined);
   const onRenameThread = props.onRenameThread ?? (async () => undefined);
   const [copiedRuntimeValue, setCopiedRuntimeValue] = useState<"branch" | "cwd">();
@@ -642,7 +632,7 @@ export function Sidebar(props: SidebarProps) {
           <button
             aria-label="New thread"
             className="sidebar__icon-button"
-            disabled={!hasCreateThreadOptions || Boolean(props.creatingThread)}
+            disabled={Boolean(props.creatingThread)}
             type="button"
             onClick={() => {
               void props.onCreateThread();

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1009,6 +1009,13 @@ export function ThreadView(props: ThreadViewProps) {
   }, [props.activeTurnId]);
 
   const selectedThread = props.selectedThread;
+  const selectedThreadBackend = useMemo(
+    () =>
+      selectedThread
+        ? props.backends.find((backend) => backend.kind === selectedThread.source)
+        : undefined,
+    [props.backends, selectedThread],
+  );
   const selectedLaunchpad = props.selectedLaunchpad;
 
   useEffect(() => {
@@ -1988,6 +1995,7 @@ export function ThreadView(props: ThreadViewProps) {
               directory={props.selectedDirectory}
               directories={props.directories}
               disabled={!launchpadBackend?.available}
+              unavailableReason={launchpadBackend?.unavailableReason}
               launchpad={selectedLaunchpad}
               launchpadError={props.launchpadError}
               pastedImageMaxPatches={props.pastedImageMaxPatches}
@@ -2167,6 +2175,7 @@ export function ThreadView(props: ThreadViewProps) {
             draftStore={props.composerDraftStore}
             directory={props.selectedDirectory}
             disabled={props.composerDisabled}
+            unavailableReason={selectedThreadBackend?.unavailableReason}
             contextWindow={props.contextWindow}
             fullAccessRiskWarningDismissed={
               props.fullAccessRiskWarningDismissed

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1994,7 +1994,7 @@ export function ThreadView(props: ThreadViewProps) {
               draftStore={props.composerDraftStore}
               directory={props.selectedDirectory}
               directories={props.directories}
-              disabled={!launchpadBackend?.available}
+              disabled={launchpadBackend ? !launchpadBackend.available : false}
               unavailableReason={launchpadBackend?.unavailableReason}
               launchpad={selectedLaunchpad}
               launchpadError={props.launchpadError}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -381,6 +381,125 @@ describe("ThreadView", () => {
     expect(screen.getByRole("group", { name: "Messaging platform status" })).toBeInTheDocument();
   });
 
+  it("keeps launchpad drafts editable until a known backend reports unavailable", async () => {
+    const selectedDirectory = {
+      key: "workspace:new-thread",
+      kind: "workspace",
+      label: "Workspaces",
+      threadKeys: [],
+      needsAttentionCount: 0,
+    } satisfies NavigationDirectorySummary;
+    const selectedLaunchpad = {
+      backend: "codex",
+      createdAt: 1000,
+      directoryKey: selectedDirectory.key,
+      directoryKind: selectedDirectory.kind,
+      directoryLabel: selectedDirectory.label,
+      executionMode: "default",
+      prompt: "",
+      updatedAt: 1000,
+      workMode: "local",
+    } satisfies NavigationLaunchpadDraft;
+
+    render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[]}
+        clearPendingRequest={() => undefined}
+        composerDisabled={false}
+        loading={false}
+        loadingMore={false}
+        messageCount={0}
+        selectedDirectory={selectedDirectory}
+        selectedLaunchpad={selectedLaunchpad}
+        skills={[]}
+        transcriptEntries={[]}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+      />
+    );
+
+    expect(await screen.findByRole("textbox", { name: "New thread" })).toBeEnabled();
+  });
+
+  it("surfaces ACP unavailable reasons in launchpad drafts", async () => {
+    const selectedDirectory = {
+      key: "workspace:new-thread",
+      kind: "workspace",
+      label: "Workspaces",
+      threadKeys: [],
+      needsAttentionCount: 0,
+    } satisfies NavigationDirectorySummary;
+    const selectedLaunchpad = {
+      backend: "acp:gemini",
+      createdAt: 1000,
+      directoryKey: selectedDirectory.key,
+      directoryKind: selectedDirectory.kind,
+      directoryLabel: selectedDirectory.label,
+      executionMode: "default",
+      prompt: "",
+      updatedAt: 1000,
+      workMode: "local",
+    } satisfies NavigationLaunchpadDraft;
+
+    render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[
+          {
+            kind: "acp:gemini",
+            label: "Gemini",
+            available: false,
+            methods: [],
+            capabilities: {
+              listThreads: true,
+              createThread: true,
+              resumeThread: true,
+              renameThread: true,
+              readThread: true,
+              startTurn: true,
+              interruptTurn: true,
+              steerTurn: false,
+              transcriptPagination: true,
+              toolUse: false,
+              approvalRequests: true,
+              multiDirectoryThreads: false,
+            },
+            executionModes: [
+              {
+                mode: "default",
+                label: "Default",
+                available: false,
+                isDefault: true,
+                unavailableReason: "ACP agent authentication required",
+              },
+            ],
+            unavailableReason: "ACP agent authentication required",
+          },
+        ]}
+        clearPendingRequest={() => undefined}
+        composerDisabled={false}
+        loading={false}
+        loadingMore={false}
+        messageCount={0}
+        selectedDirectory={selectedDirectory}
+        selectedLaunchpad={selectedLaunchpad}
+        skills={[]}
+        transcriptEntries={[]}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+      />
+    );
+
+    expect(
+      await screen.findByText("ACP agent authentication required")
+    ).toHaveClass("composer__meta--error");
+    expect(screen.getByRole("textbox", { name: "New thread" })).toHaveAttribute(
+      "contenteditable",
+      "false",
+    );
+  });
+
   it("shows missing recorded working directory details and copies the thread id", async () => {
     const copyText = vi.fn(async () => undefined);
     Object.defineProperty(window, "pwragent", {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -2233,6 +2233,155 @@ describe("useThreadNavigation", () => {
     );
   });
 
+  it("opens masthead new-thread drafts while the initial navigation snapshot is loading", async () => {
+    const initialSnapshot = createDeferred<NavigationSnapshot>();
+    const emptySnapshot: NavigationSnapshot = {
+      backend: "all",
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+    };
+    const launchpad: NavigationLaunchpadDraft = {
+      directoryKey: "workspace:new-thread",
+      directoryKind: "workspace",
+      directoryLabel: "Workspaces",
+      backend: "codex",
+      executionMode: "default",
+      prompt: "",
+      workMode: "local",
+      createdAt: 1,
+      updatedAt: 2,
+    };
+    const ensureDirectoryLaunchpad = vi.fn(async () => ({
+      launchpad,
+      defaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const getNavigationSnapshot = vi
+      .fn()
+      .mockReturnValueOnce(initialSnapshot.promise)
+      .mockResolvedValue(emptySnapshot);
+    const desktopApi: DesktopApi = {
+      ensureDirectoryLaunchpad,
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    let create!: Promise<void>;
+    act(() => {
+      create = result.current.createThread();
+    });
+
+    await waitFor(() => {
+      expect(ensureDirectoryLaunchpad).toHaveBeenCalled();
+    });
+
+    await act(async () => {
+      initialSnapshot.resolve(emptySnapshot);
+      await create;
+    });
+
+    expect(ensureDirectoryLaunchpad).toHaveBeenCalledWith({
+      directoryKey: "workspace:new-thread",
+      directoryKind: "workspace",
+      directoryLabel: "Workspaces",
+      directoryPath: undefined,
+      preferredBackend: undefined,
+    });
+    await waitFor(() => {
+      expect(result.current.selectedLaunchpad?.directoryKey).toBe(
+        "workspace:new-thread"
+      );
+      expect(result.current.selectedDirectory?.kind).toBe("workspace");
+    });
+  });
+
+  it("removes server-backed launchpads when a refreshed snapshot omits them", async () => {
+    const directoryKey = "directory:/Users/test/PwrAgent";
+    const snapshotWithLaunchpad: NavigationSnapshot = {
+      backend: "all",
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [],
+      directories: [
+        {
+          key: directoryKey,
+          kind: "directory",
+          label: "PwrAgent",
+          path: "/Users/test/PwrAgent",
+          threadKeys: [],
+          needsAttentionCount: 0,
+          launchpad: {
+            directoryKey,
+            directoryKind: "directory",
+            directoryLabel: "PwrAgent",
+            directoryPath: "/Users/test/PwrAgent",
+            backend: "codex",
+            executionMode: "default",
+            prompt: "Build the feature",
+            workMode: "worktree",
+            createdAt: 1,
+            updatedAt: 2,
+          },
+        },
+      ],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+    };
+    const snapshotWithoutLaunchpad: NavigationSnapshot = {
+      ...snapshotWithLaunchpad,
+      fetchedAt: snapshotWithLaunchpad.fetchedAt + 1,
+      directories: [
+        {
+          key: directoryKey,
+          kind: "directory",
+          label: "PwrAgent",
+          path: "/Users/test/PwrAgent",
+          threadKeys: [],
+          needsAttentionCount: 0,
+        },
+      ],
+    };
+    const getNavigationSnapshot = vi
+      .fn()
+      .mockResolvedValueOnce(snapshotWithLaunchpad)
+      .mockResolvedValueOnce(snapshotWithoutLaunchpad);
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.directories[0]?.launchpad?.prompt).toBe(
+        "Build the feature"
+      );
+    });
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    await waitFor(() => {
+      expect(result.current.directories[0]?.launchpad).toBeUndefined();
+      expect(result.current.selectedLaunchpad).toBeUndefined();
+    });
+  });
+
   it("does not fabricate a git workspace relationship for directory-less Workspace threads", async () => {
     const materializeDirectoryLaunchpad = vi.fn(async () => ({
       backend: "codex" as const,

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -78,6 +78,44 @@ function sortNavigationDirectories(
   return [...directories].sort(compareNavigationDirectoriesByLabel);
 }
 
+function upsertLaunchpadDirectory(
+  directories: NavigationSnapshot["directories"],
+  launchpad: NavigationLaunchpadDraft,
+): NavigationSnapshot["directories"] {
+  let foundDirectory = false;
+  const nextDirectories = directories.map((directory) => {
+    if (directory.key !== launchpad.directoryKey) {
+      return directory;
+    }
+
+    foundDirectory = true;
+    return {
+      ...directory,
+      kind: launchpad.directoryKind,
+      label: launchpad.directoryLabel,
+      path: launchpad.directoryPath ?? directory.path,
+      launchpad,
+    };
+  });
+
+  return sortNavigationDirectories(
+    foundDirectory
+      ? nextDirectories
+      : [
+          ...nextDirectories,
+          {
+            key: launchpad.directoryKey,
+            kind: launchpad.directoryKind,
+            label: launchpad.directoryLabel,
+            path: launchpad.directoryPath,
+            threadKeys: [],
+            needsAttentionCount: 0,
+            launchpad,
+          },
+        ],
+  );
+}
+
 function directoryKeysForThread(
   directories: NavigationSnapshot["directories"],
   threadKey?: string,
@@ -405,17 +443,20 @@ function reconcileNavigationSnapshot(
   const previousByDirectoryKey = new Map(
     previous.directories.map((directory) => [directory.key, directory])
   );
+  const reconciledDirectories = next.directories.map((directory) => {
+    const previousDirectory = previousByDirectoryKey.get(directory.key);
+    return {
+      ...directory,
+      ...(previousDirectory?.gitStatus &&
+      !Object.prototype.hasOwnProperty.call(directory, "gitStatus")
+        ? { gitStatus: previousDirectory.gitStatus }
+        : {}),
+    };
+  });
+
   return {
     ...next,
-    directories: next.directories.map((directory) => {
-      if (Object.prototype.hasOwnProperty.call(directory, "gitStatus")) {
-        return directory;
-      }
-      const previousDirectory = previousByDirectoryKey.get(directory.key);
-      return previousDirectory?.gitStatus
-        ? { ...directory, gitStatus: previousDirectory.gitStatus }
-        : directory;
-    }),
+    directories: sortNavigationDirectories(reconciledDirectories),
     threads: next.threads.map((thread) => {
       const previousThread = previousByThreadKey.get(
         buildThreadIdentityKey(thread.source, thread.id)
@@ -1063,43 +1104,20 @@ function applyLaunchpadUpdate(
   defaults: NavigationSnapshot["launchpadDefaults"]
 ): NavigationSnapshot | undefined {
   if (!snapshot) {
-    return snapshot;
-  }
-
-  let foundDirectory = false;
-  const directories = snapshot.directories.map((directory) => {
-    if (directory.key !== launchpad.directoryKey) {
-      return directory;
-    }
-
-    foundDirectory = true;
     return {
-      ...directory,
-      kind: launchpad.directoryKind,
-      label: launchpad.directoryLabel,
-      path: launchpad.directoryPath ?? directory.path,
-      launchpad,
+      backend: "all",
+      fetchedAt: Date.now(),
+      unchanged: false,
+      threads: [],
+      inboxThreadKeys: [],
+      directories: upsertLaunchpadDirectory([], launchpad),
+      launchpadDefaults: defaults,
     };
-  });
+  }
 
   return {
     ...snapshot,
-    directories: sortNavigationDirectories(
-      foundDirectory
-        ? directories
-        : [
-            ...directories,
-            {
-              key: launchpad.directoryKey,
-              kind: launchpad.directoryKind,
-              label: launchpad.directoryLabel,
-              path: launchpad.directoryPath,
-              threadKeys: [],
-              needsAttentionCount: 0,
-              launchpad,
-            },
-          ],
-    ),
+    directories: upsertLaunchpadDirectory(snapshot.directories, launchpad),
     launchpadDefaults: defaults,
   };
 }
@@ -1109,10 +1127,14 @@ function applyLaunchpadUpdateIfMissing(
   launchpad: NavigationLaunchpadDraft,
   defaults: NavigationSnapshot["launchpadDefaults"],
 ): NavigationSnapshot | undefined {
-  if (
-    !snapshot ||
-    snapshot.directories.some((directory) => directory.key === launchpad.directoryKey)
-  ) {
+  if (!snapshot) {
+    return applyLaunchpadUpdate(snapshot, launchpad, defaults);
+  }
+
+  if (snapshot.directories.some(
+    (directory) =>
+      directory.key === launchpad.directoryKey && Boolean(directory.launchpad)
+  )) {
     return snapshot;
   }
 
@@ -1560,6 +1582,9 @@ export function useThreadNavigation(
     backend: AppServerBackendKind;
     executionMode: ThreadExecutionMode;
   }>();
+  const [localLaunchpads, setLocalLaunchpads] = useState<
+    Record<string, NavigationLaunchpadDraft>
+  >({});
   const [createThreadError, setCreateThreadError] = useState<string>();
   const [launchpadError, setLaunchpadError] = useState<string>();
   const [archiveThreadError, setArchiveThreadError] = useState<string>();
@@ -2310,8 +2335,15 @@ export function useThreadNavigation(
 
   const directories = useMemo(
     () => {
+      const launchpads = Object.values(localLaunchpads);
+      const currentDirectories = launchpads.reduce(
+        (nextDirectories, launchpad) =>
+          upsertLaunchpadDirectory(nextDirectories, launchpad),
+        state.response?.directories ?? [],
+      );
+
       if (!optimisticThread) {
-        return state.response?.directories ?? [];
+        return currentDirectories;
       }
 
       const optimisticThreadKey = buildThreadIdentityKey(
@@ -2323,11 +2355,16 @@ export function useThreadNavigation(
       );
 
       return projectOptimisticThreadIntoDirectories(
-        state.response?.directories ?? [],
+        currentDirectories,
         hasHydratedThread ? undefined : optimisticThread
       );
     },
-    [optimisticThread, state.response?.directories, state.response?.threads]
+    [
+      localLaunchpads,
+      optimisticThread,
+      state.response?.directories,
+      state.response?.threads,
+    ]
   );
 
   const inboxThreads = threads;
@@ -2570,18 +2607,42 @@ export function useThreadNavigation(
           launchpad = updated.launchpad;
           defaults = updated.defaults;
         }
+        setLocalLaunchpads((current) => ({
+          ...current,
+          [directoryKey]: launchpad,
+        }));
         setState((current) => ({
           ...current,
           response: applyLaunchpadUpdate(current.response, launchpad, defaults),
         }));
-        setSelectedItemKey(buildLaunchpadSelectionKey(directoryKey));
+        const selectionKey = buildLaunchpadSelectionKey(directoryKey);
+        pendingPickedLaunchpadRef.current.set(directoryKey, launchpad);
+        setSelectedItemKey(selectionKey);
+        await refresh(selectionKey, undefined, true);
+        const pendingLaunchpad =
+          pendingPickedLaunchpadRef.current.get(directoryKey) ?? launchpad;
+        setState((current) => ({
+          ...current,
+          response: applyLaunchpadUpdateIfMissing(
+            current.response,
+            pendingLaunchpad,
+            defaults,
+          ),
+        }));
+        setSelectedItemKey(selectionKey);
       } catch (error) {
         setCreateThreadError(error instanceof Error ? error.message : String(error));
       } finally {
+        const workspaceDirectory = directories.find(
+          (directory) => directory.kind === "workspace"
+        );
+        pendingPickedLaunchpadRef.current.delete(
+          workspaceDirectory?.key ?? ROOT_NEW_THREAD_WORKSPACE_LAUNCHPAD_KEY
+        );
         setCreatingThread(undefined);
       }
     },
-    [desktopApi, directories]
+    [desktopApi, directories, refresh]
   );
 
   const openDirectoryLaunchpad = useCallback(
@@ -2609,6 +2670,10 @@ export function useThreadNavigation(
           currentBranch: directory.gitStatus?.currentBranch,
           preferredBackend,
         });
+        setLocalLaunchpads((current) => ({
+          ...current,
+          [directory.key]: response.launchpad,
+        }));
         setState((current) => ({
           ...current,
           response: applyLaunchpadUpdate(
@@ -2663,6 +2728,10 @@ export function useThreadNavigation(
         }
         pendingPickedDirectoryKey = result.directoryKey;
         pendingPickedLaunchpadRef.current.set(result.directoryKey, result.launchpad);
+        setLocalLaunchpads((current) => ({
+          ...current,
+          [result.directoryKey]: result.launchpad,
+        }));
         setState((current) => ({
           ...current,
           response: applyLaunchpadUpdate(
@@ -2747,6 +2816,21 @@ export function useThreadNavigation(
           ),
         };
       });
+      setLocalLaunchpads((current) => {
+        const currentLaunchpad = current[directoryKey];
+        if (!currentLaunchpad) {
+          return current;
+        }
+        return {
+          ...current,
+          [directoryKey]: {
+            ...currentLaunchpad,
+            ...patch,
+            directoryKey,
+            updatedAt: Date.now(),
+          },
+        };
+      });
       const pendingPickedLaunchpad = pendingPickedLaunchpadRef.current.get(directoryKey);
       if (pendingPickedLaunchpad) {
         pendingPickedLaunchpadRef.current.set(directoryKey, {
@@ -2766,6 +2850,14 @@ export function useThreadNavigation(
         if (launchpadUpdateRevisionRef.current.get(directoryKey) !== revision) {
           return;
         }
+        setLocalLaunchpads((current) =>
+          current[directoryKey]
+            ? {
+                ...current,
+                [directoryKey]: response.launchpad,
+              }
+            : current
+        );
         setState((current) => ({
           ...current,
           response: applyLaunchpadUpdate(
@@ -2813,6 +2905,14 @@ export function useThreadNavigation(
 
       try {
         const response = await desktopApi.resetDirectoryLaunchpad({ directoryKey });
+        setLocalLaunchpads((current) => {
+          if (!current[directoryKey]) {
+            return current;
+          }
+          const next = { ...current };
+          delete next[directoryKey];
+          return next;
+        });
         setState((current) => ({
           ...current,
           response: applyLaunchpadReset(
@@ -2888,6 +2988,14 @@ export function useThreadNavigation(
           optimisticUserMessage: buildOptimisticUserMessage(input),
         });
         const nextThreadKey = buildThreadIdentityKey(response.backend, response.threadId);
+        setLocalLaunchpads((current) => {
+          if (!current[directoryKey]) {
+            return current;
+          }
+          const next = { ...current };
+          delete next[directoryKey];
+          return next;
+        });
         setOptimisticThread(optimisticMaterializedThread);
         setSelectedItemKey(nextThreadKey);
         setPendingSeenThreadKey(nextThreadKey);


### PR DESCRIPTION
Fixes #523.

Changes:
- Sidebar: Enable 'New thread' button even when no backend is available.
- App: Ensure 'New thread' switches to thread view.
- Composer: Add unavailableReason prop to display backend-specific error messages.
- ThreadView: Pass unavailableReason from the selected backend to the Composer.
- Tests: Added coverage for the new unavailableReason prop in the composer.