### PR TITLE
fix(desktop): open threads at the bottom and make jump-to-latest one-shot

### DIFF
--- a/apps/desktop/e2e/thread-open-scroll-stability.spec.ts
+++ b/apps/desktop/e2e/thread-open-scroll-stability.spec.ts
@@ -276,3 +276,216 @@ test("keeps a bottom-pinned long transcript glued when a reply image preview res
     await app.close();
   }
 });
+
+test("clicking jump-to-latest reaches the bottom in a single click", async () => {
+  const app = await launchElectronApp({
+    fixturePath: path.resolve(
+      specDir,
+      "fixtures/long-thread-scroll-stability/replay.fixture.json"
+    ),
+    windowSize: {
+      width: 1280,
+      height: 720,
+    },
+  });
+
+  try {
+    await app.window
+      .getByRole("button", { name: /Long scroll stability thread/i })
+      .first()
+      .click();
+
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "Long scroll stability thread"
+      })
+    ).toBeVisible();
+
+    const list = app.window.locator(".transcript-list__items");
+    const jumpToLatest = app.window.getByRole("button", {
+      name: "Jump to latest message",
+    });
+
+    await expect
+      .poll(async () =>
+        await list.evaluate((element) =>
+          Math.round(Math.max(element.scrollHeight - element.clientHeight, 0))
+        )
+      )
+      .toBeGreaterThan(2000);
+
+    await expect
+      .poll(async () => await distanceFromTranscriptBottom(list))
+      .toBeLessThanOrEqual(4);
+
+    // Manually scroll to the top so the jump-to-latest button is exposed.
+    await list.evaluate((element) => {
+      element.scrollTop = 0;
+      element.dispatchEvent(new Event("scroll", { bubbles: true }));
+    });
+
+    await expect(jumpToLatest).toBeVisible();
+    await expect
+      .poll(async () => await list.evaluate((element) => Math.round(element.scrollTop)))
+      .toBeLessThan(50);
+
+    // A single click must take the user all the way to the bottom — not 90%,
+    // then 95%, then 100% across three clicks. The window for the scroll to
+    // settle is intentionally tight so smooth-scroll regressions that need
+    // multiple clicks (or content growth that outraces a smooth-scroll
+    // target captured at click time) fail the assertion.
+    await jumpToLatest.click();
+
+    await expect
+      .poll(async () => await distanceFromTranscriptBottom(list), {
+        timeout: 600,
+      })
+      .toBeLessThanOrEqual(4);
+    await expect(jumpToLatest).toHaveCount(0);
+  } finally {
+    await app.close();
+  }
+});
+
+test("jump-to-latest re-enters glue mode so later content stays pinned", async () => {
+  const app = await launchElectronApp({
+    fixturePath: path.resolve(
+      specDir,
+      "fixtures/long-thread-scroll-stability/replay.fixture.json"
+    ),
+    windowSize: {
+      width: 1280,
+      height: 720,
+    },
+  });
+
+  try {
+    await app.window
+      .getByRole("button", { name: /Long scroll stability thread/i })
+      .first()
+      .click();
+
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "Long scroll stability thread"
+      })
+    ).toBeVisible();
+
+    const list = app.window.locator(".transcript-list__items");
+    const jumpToLatest = app.window.getByRole("button", {
+      name: "Jump to latest message",
+    });
+
+    await expect
+      .poll(async () => await distanceFromTranscriptBottom(list))
+      .toBeLessThanOrEqual(4);
+
+    // Scroll to the top, then click jump-to-latest to re-enter glue mode.
+    await list.evaluate((element) => {
+      element.scrollTop = 0;
+      element.dispatchEvent(new Event("scroll", { bubbles: true }));
+    });
+    await expect(jumpToLatest).toBeVisible();
+    await jumpToLatest.click();
+
+    // Wait for the scroll to settle and the button to hide.
+    await expect
+      .poll(async () => await distanceFromTranscriptBottom(list), {
+        timeout: 600,
+      })
+      .toBeLessThanOrEqual(4);
+    await expect(jumpToLatest).toHaveCount(0);
+
+    // Simulate content growing after we re-glued (mimics images / code
+    // blocks finishing their layout after the click landed). Glue should
+    // keep us pinned to the new bottom; if a stale smooth-scroll target
+    // left us unglued, we'd drift away from the bottom and the button
+    // would reappear.
+    await list.evaluate((element) => {
+      const content = element.querySelector<HTMLDivElement>(
+        ".transcript-list__content"
+      );
+      if (!content) {
+        throw new Error("transcript content not found");
+      }
+      const spacer = document.createElement("div");
+      spacer.style.height = "1200px";
+      spacer.dataset.testid = "post-jump-growth-spacer";
+      content.appendChild(spacer);
+    });
+
+    await expect
+      .poll(async () => await distanceFromTranscriptBottom(list), {
+        timeout: 1000,
+      })
+      .toBeLessThanOrEqual(4);
+    await expect(jumpToLatest).toHaveCount(0);
+  } finally {
+    await app.close();
+  }
+});
+
+test("opens at the bottom and stays glued when content grows after first paint", async () => {
+  const app = await launchElectronApp({
+    fixturePath: path.resolve(
+      specDir,
+      "fixtures/long-thread-scroll-stability/replay.fixture.json"
+    ),
+    windowSize: {
+      width: 1280,
+      height: 720,
+    },
+  });
+
+  try {
+    await app.window
+      .getByRole("button", { name: /Long scroll stability thread/i })
+      .first()
+      .click();
+
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "Long scroll stability thread"
+      })
+    ).toBeVisible();
+
+    const list = app.window.locator(".transcript-list__items");
+    const jumpToLatest = app.window.getByRole("button", {
+      name: "Jump to latest message",
+    });
+
+    await expect
+      .poll(async () => await distanceFromTranscriptBottom(list))
+      .toBeLessThanOrEqual(4);
+    await expect(jumpToLatest).toHaveCount(0);
+
+    // Simulate post-initial-paint layout growth (e.g. an image finishing
+    // load, a code block finishing syntax highlighting). The transcript
+    // should re-anchor to the new bottom — opening a thread should leave
+    // the user looking at the latest message, not stranded above it.
+    await list.evaluate((element) => {
+      const content = element.querySelector<HTMLDivElement>(
+        ".transcript-list__content"
+      );
+      if (!content) {
+        throw new Error("transcript content not found");
+      }
+      const spacer = document.createElement("div");
+      spacer.style.height = "1800px";
+      spacer.dataset.testid = "post-open-growth-spacer";
+      content.appendChild(spacer);
+    });
+
+    await expect
+      .poll(async () => await distanceFromTranscriptBottom(list), {
+        timeout: 1000,
+      })
+      .toBeLessThanOrEqual(4);
+    await expect(jumpToLatest).toHaveCount(0);
+  } finally {
+    await app.close();
+  }
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -480,23 +480,60 @@ export function TranscriptList(props: TranscriptListProps) {
     }
   }, [captureSnapshot]);
 
-  const scrollToBottom = useCallback((mode: ScrollBottomMode = "smooth") => {
+  const scrollToBottom = useCallback((mode: ScrollBottomMode = "instant") => {
     const container = scrollContainerRef.current;
     if (!container) {
       return;
     }
 
+    // Mark glued BEFORE issuing the scroll command so the
+    // ResizeObserver and onScroll callbacks that fire during /
+    // immediately after the scroll treat any concurrent layout shift
+    // as "stay pinned" rather than "user navigated away from the
+    // bottom."
+    isGluedToBottomRef.current = true;
+
     if (mode === "smooth" && typeof container.scrollTo === "function") {
       container.scrollTo({
         top: container.scrollHeight,
-        behavior: "smooth"
+        behavior: "smooth",
       });
-    } else {
-      container.scrollTop = container.scrollHeight;
+      // Smooth scrolls converge asynchronously — let the scroll events
+      // fired during the animation drive syncScrollState. Calling
+      // syncScrollState here would observe the pre-animation scrollTop
+      // and immediately flip isGluedToBottomRef back to false, which
+      // surfaces the "Jump to latest" button mid-animation and, worse,
+      // un-glues the transcript so subsequent content growth never
+      // re-anchors.
+      return;
     }
 
-    isGluedToBottomRef.current = true;
+    container.scrollTop = container.scrollHeight;
     syncScrollState();
+
+    // If the transcript's scrollHeight grows between this layout commit
+    // and the next paint (e.g. ThreadMarkdown finishing layout, a lazy
+    // image committing its intrinsic height), re-anchor on the next
+    // animation frame so the user lands at the actual latest message
+    // rather than the latest message at the moment scrollToBottom was
+    // first called.
+    requestAnimationFrame(() => {
+      if (!isGluedToBottomRef.current) {
+        return;
+      }
+      const liveContainer = scrollContainerRef.current;
+      if (!liveContainer) {
+        return;
+      }
+      const maxScrollTop = Math.max(
+        liveContainer.scrollHeight - liveContainer.clientHeight,
+        0
+      );
+      if (liveContainer.scrollTop < maxScrollTop - BOTTOM_THRESHOLD_PX) {
+        liveContainer.scrollTop = liveContainer.scrollHeight;
+        syncScrollState();
+      }
+    });
   }, [syncScrollState]);
 
   const disableBottomGlue = useCallback(() => {
@@ -563,10 +600,18 @@ export function TranscriptList(props: TranscriptListProps) {
           previousSnapshot.pendingStatusText !== props.pendingStatusText ||
           previousSnapshot.itemCount < visibleItemCount)
     );
+    // Re-anchor whenever a glued, same-thread render grows. The previous
+    // implementation also required firstMessageId equality, which broke
+    // the common navigation-preview → full-transcript transition: the
+    // preview entries (lastUserMessage / lastAssistantMessage from the
+    // navigation snapshot) have synthetic ids that don't match any
+    // entries in the eventual readThread response, so when the real
+    // transcript replaced them the renderer concluded "neither prepend,
+    // append, nor grow" and left scrollTop=0, stranding the user at the
+    // top of a thread they expected to open at the bottom.
     const hasGrownWhileFollowingBottom = Boolean(
       previousSnapshot &&
         previousSnapshot.threadId === props.threadId &&
-        previousSnapshot.firstMessageId === firstMessageId &&
         !hasPrependedMessages &&
         isGluedToBottomRef.current &&
         container.scrollHeight > previousSnapshot.scrollHeight
@@ -861,7 +906,7 @@ export function TranscriptList(props: TranscriptListProps) {
           type="button"
           aria-label="Jump to latest message"
           onClick={() => {
-            scrollToBottom();
+            scrollToBottom("instant");
           }}
         >
           <span className="transcript-list__scroll-bottom-icon" aria-hidden="true" />

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -97,7 +97,6 @@ type SyncScrollStateOptions = {
 };
 
 const BOTTOM_THRESHOLD_PX = 24;
-type ScrollBottomMode = "instant" | "smooth";
 
 function isAssistantFinalMessage(entry: AppServerThreadEntry): boolean {
   return (
@@ -480,7 +479,7 @@ export function TranscriptList(props: TranscriptListProps) {
     }
   }, [captureSnapshot]);
 
-  const scrollToBottom = useCallback((mode: ScrollBottomMode = "instant") => {
+  const scrollToBottom = useCallback(() => {
     const container = scrollContainerRef.current;
     if (!container) {
       return;
@@ -492,22 +491,6 @@ export function TranscriptList(props: TranscriptListProps) {
     // as "stay pinned" rather than "user navigated away from the
     // bottom."
     isGluedToBottomRef.current = true;
-
-    if (mode === "smooth" && typeof container.scrollTo === "function") {
-      container.scrollTo({
-        top: container.scrollHeight,
-        behavior: "smooth",
-      });
-      // Smooth scrolls converge asynchronously — let the scroll events
-      // fired during the animation drive syncScrollState. Calling
-      // syncScrollState here would observe the pre-animation scrollTop
-      // and immediately flip isGluedToBottomRef back to false, which
-      // surfaces the "Jump to latest" button mid-animation and, worse,
-      // un-glues the transcript so subsequent content growth never
-      // re-anchors.
-      return;
-    }
-
     container.scrollTop = container.scrollHeight;
     syncScrollState();
 
@@ -555,7 +538,7 @@ export function TranscriptList(props: TranscriptListProps) {
     }
 
     appliedReglueRequestKeyRef.current = props.reglueRequestKey;
-    scrollToBottom("instant");
+    scrollToBottom();
   }, [props.reglueRequestKey, scrollToBottom]);
 
   useEffect(() => {
@@ -592,23 +575,25 @@ export function TranscriptList(props: TranscriptListProps) {
         previousSnapshot.lastMessageId === lastMessageId &&
         previousSnapshot.firstMessageId !== firstMessageId
     );
+    // hasAppendedMessages and hasGrownWhileFollowingBottom both intentionally
+    // skip the firstMessageId equality check that earlier versions of this
+    // file enforced. That check broke the common navigation-preview →
+    // full-transcript transition: the preview entries (lastUserMessage /
+    // lastAssistantMessage from the navigation snapshot) have synthetic ids
+    // that don't match any entries in the eventual readThread response, so
+    // when the real transcript replaced them BOTH firstMessageId and
+    // lastMessageId changed and neither branch fired — leaving the user
+    // staring at the top of a thread they expected to open at the bottom.
+    // hasPrependedMessages already covers the only case the equality check
+    // was protecting against (older messages paginated in at the top).
     const hasAppendedMessages = Boolean(
       previousSnapshot &&
         previousSnapshot.threadId === props.threadId &&
-        previousSnapshot.firstMessageId === firstMessageId &&
+        !hasPrependedMessages &&
         (previousSnapshot.lastMessageId !== lastMessageId ||
           previousSnapshot.pendingStatusText !== props.pendingStatusText ||
           previousSnapshot.itemCount < visibleItemCount)
     );
-    // Re-anchor whenever a glued, same-thread render grows. The previous
-    // implementation also required firstMessageId equality, which broke
-    // the common navigation-preview → full-transcript transition: the
-    // preview entries (lastUserMessage / lastAssistantMessage from the
-    // navigation snapshot) have synthetic ids that don't match any
-    // entries in the eventual readThread response, so when the real
-    // transcript replaced them the renderer concluded "neither prepend,
-    // append, nor grow" and left scrollTop=0, stranding the user at the
-    // top of a thread they expected to open at the bottom.
     const hasGrownWhileFollowingBottom = Boolean(
       previousSnapshot &&
         previousSnapshot.threadId === props.threadId &&
@@ -627,7 +612,7 @@ export function TranscriptList(props: TranscriptListProps) {
           restoredViewport.distanceFromBottom <= BOTTOM_THRESHOLD_PX;
         if (shouldRestoreBottom) {
           isGluedToBottomRef.current = true;
-          scrollToBottom("instant");
+          scrollToBottom();
         } else {
           isGluedToBottomRef.current = false;
           container.scrollTop = Math.min(
@@ -640,21 +625,21 @@ export function TranscriptList(props: TranscriptListProps) {
         return;
       }
 
-      scrollToBottom("instant");
+      scrollToBottom();
       shouldScrollToBottomRef.current = false;
       return;
     } else if (
       shouldScrollToBottomRef.current ||
       !previousSnapshot
     ) {
-      scrollToBottom("instant");
+      scrollToBottom();
       shouldScrollToBottomRef.current = false;
       return;
     } else if (
       isGluedToBottomRef.current &&
       (hasAppendedMessages || hasGrownWhileFollowingBottom)
     ) {
-      scrollToBottom("instant");
+      scrollToBottom();
       return;
     }
 
@@ -682,7 +667,7 @@ export function TranscriptList(props: TranscriptListProps) {
 
     const observer = new ResizeObserver(() => {
       if (isGluedToBottomRef.current) {
-        scrollToBottom("instant");
+        scrollToBottom();
       } else {
         syncScrollState({ preserveGlueOnResize: true });
       }
@@ -906,7 +891,7 @@ export function TranscriptList(props: TranscriptListProps) {
           type="button"
           aria-label="Jump to latest message"
           onClick={() => {
-            scrollToBottom("instant");
+            scrollToBottom();
           }}
         >
           <span className="transcript-list__scroll-bottom-icon" aria-hidden="true" />

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -2682,6 +2682,10 @@ describe("TranscriptList", () => {
     );
 
     const list = screen.getByRole("list");
+    // No assertion about the initial scrollTop here: jsdom doesn't clamp
+    // scrollTop to (scrollHeight - clientHeight) the way Chromium does,
+    // so the value after the preview-only render isn't meaningful. The
+    // contract under test is the AFTER-rerender scrollTop, below.
 
     scrollHeight = 4800;
     rerender(

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -1638,7 +1638,7 @@ describe("TranscriptList", () => {
     expect(screen.getByRole("button", { name: "Jump to latest message" })).toBeInTheDocument();
   });
 
-  it("uses smooth scrolling only for the explicit jump-to-latest action", () => {
+  it("jumps instantly to the bottom when jump-to-latest is clicked", () => {
     render(
       <TranscriptList
         entries={[
@@ -1669,10 +1669,17 @@ describe("TranscriptList", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Jump to latest message" }));
 
-    expect(scrollToMock).toHaveBeenCalledWith({
-      behavior: "smooth",
-      top: 480
-    });
+    // Clicking jump-to-latest goes all the way to the bottom NOW, not
+    // via a smooth animation that captures a stale scrollHeight target
+    // and stops partway when content grows mid-animation. The user
+    // contract is single-click → at the bottom → glued.
+    expect(list.scrollTop).toBe(480);
+    expect(scrollToMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ behavior: "smooth" })
+    );
+    expect(
+      screen.queryByRole("button", { name: "Jump to latest message" })
+    ).not.toBeInTheDocument();
   });
 
   it("restores the previous viewport when switching back to a cached thread", () => {
@@ -2535,12 +2542,10 @@ describe("TranscriptList", () => {
     list.scrollTop = 80;
     fireEvent.scroll(list);
     fireEvent.click(screen.getByRole("button", { name: "Jump to latest message" }));
-    expect(scrollToMock).toHaveBeenLastCalledWith({
-      behavior: "smooth",
-      top: 720
-    });
+    // Instant scroll: lands at scrollHeight in a single click, no
+    // smooth animation that could stop partway.
+    expect(list.scrollTop).toBe(720);
 
-    list.scrollTop = 480;
     fireEvent.scroll(list);
     scrollHeight = 860;
     rerender(
@@ -2646,6 +2651,78 @@ describe("TranscriptList", () => {
     );
 
     expect(list.scrollTop).toBe(860);
+  });
+
+  it("re-anchors to the bottom when navigation preview entries are replaced by the full transcript", () => {
+    // Regression: opening a thread for the first time briefly shows a
+    // single navigation-preview entry (lastAssistantMessage) before
+    // readThread resolves with the full transcript. The preview's
+    // synthetic id never appears in the full entries, so the
+    // first→full transition rewrites BOTH firstMessageId and
+    // lastMessageId. Previously hasGrownWhileFollowingBottom required
+    // firstMessageId equality, which made the renderer conclude "no
+    // change worth re-anchoring," leaving the user looking at the top
+    // of a thread they expected to open at the bottom.
+    scrollHeight = 240;
+    const { rerender } = render(
+      <TranscriptList
+        entries={[
+          {
+            type: "message",
+            id: "preview-assistant",
+            role: "assistant",
+            text: "Preview of the last assistant message from the navigation snapshot.",
+          },
+        ]}
+        loading={false}
+        loadingMore={false}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    const list = screen.getByRole("list");
+
+    scrollHeight = 4800;
+    rerender(
+      <TranscriptList
+        entries={[
+          {
+            type: "message",
+            id: "msg-1",
+            role: "user",
+            text: "Real first message",
+          },
+          {
+            type: "message",
+            id: "msg-2",
+            role: "assistant",
+            text: "Real assistant reply",
+          },
+          {
+            type: "message",
+            id: "msg-3",
+            role: "user",
+            text: "Real follow-up",
+          },
+          {
+            type: "message",
+            id: "msg-final",
+            role: "assistant",
+            text: "Real last message — different id than the preview.",
+          },
+        ]}
+        loading={false}
+        loadingMore={false}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(list.scrollTop).toBe(4800);
+    expect(
+      screen.queryByRole("button", { name: "Jump to latest message" })
+    ).not.toBeInTheDocument();
   });
 
   it("shows command approval reason and command when no prompt is provided", () => {


### PR DESCRIPTION
## Summary

Two stacked bugs in `TranscriptList` made every thread open at the top and made the orange "Jump to latest" button useless — clicking it scrolled ~90%, then needed another click for ~95%, then another to actually reach the bottom.

- **Smooth scroll on the jump button** captured `scrollHeight` at click time and then called `syncScrollState` synchronously. That sync ran before the animation started, so it observed the pre-animation `scrollTop`, flipped `isGluedToBottomRef` back to `false`, and re-surfaced the button. Any content growth mid-animation then stranded the user short of the bottom.
- **`hasGrownWhileFollowingBottom` (and `hasAppendedMessages`) required `firstMessageId` equality.** The first render of a thread shows a one-entry navigation-preview (`lastUserMessage` / `lastAssistantMessage` from the navigation snapshot) whose synthetic id never matches anything in the eventual `readThread` response. When the full transcript landed, *both* first and last id changed, so none of the prepend/append/grow branches fired and the renderer left `scrollTop=0` on a transcript whose `scrollHeight` had jumped from ~740px to ~28000px.

### The fix

- `scrollToBottom` is now parameterless and always instant: it sets `isGluedToBottomRef = true` before issuing the scroll, then runs a `requestAnimationFrame` re-anchor pass so growth between layout-commit and paint still lands the user at the bottom. The old smooth-scroll branch is gone — it was unreachable after the button switched to instant.
- `hasGrownWhileFollowingBottom` and `hasAppendedMessages` no longer require `firstMessageId` equality. If we were glued, on the same thread, and the content grew, and it isn't a prepend (which is still detected via `lastMessageId` equality), re-anchor.

### How this got worse — being honest

The buggy logic itself is old. The `firstMessageId === firstMessageId` check in `hasGrownWhileFollowingBottom` has been there since #60 (Apr 28), and the smooth scroll on the button has been there since #29 (Apr 26). So the latent bug has technically existed for ~4 weeks.

I can't bisect a single PR that flipped this from "rare" to "every-time." The most plausible mechanism is just thread length growth — the bug only strands the user noticeably when the delta between the preview render (~740px) and the full transcript (now ~28000px on real threads) is large. Short threads landed close enough to the bottom that the orange button never appeared, so nobody noticed. Recent refactors that touch the renderer's commit timing (e.g. #493 reordering pending-entry timestamps) could plausibly amplify the visibility too, but I have no evidence beyond "they're in the timeframe and they touch the right area." Better to land the fix than over-claim a root cause.

## Test plan
- [x] `pnpm test` — 2618 passed (+1 new regression test in `transcript-list.test.tsx`)
- [x] `pnpm --filter @pwragent/desktop exec playwright test e2e/thread-open-scroll-stability.spec.ts e2e/thread-scroll-restore.spec.ts` — 6/6 passed (3 new specs added)
- [x] `pnpm typecheck` — clean
- [x] Live dev app — `PwrAgent - Release` and other 400+ message threads now open at the bottom on first click; orange button takes the user all the way to the bottom in a single click and stays hidden after

🤖 Generated with [Claude Code](https://claude.com/claude-code)