### PR TITLE
fix(desktop): gate ACP runtime behavior

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import type { AcpBackendId } from "@pwragent/shared";
+import { describeInstalledAcpBackend } from "../app-server/acp-backend-adapter";
+import type { AcpInstalledAgentRecord } from "../acp/acp-registry-types";
+
+describe("describeInstalledAcpBackend", () => {
+  it("does not advertise session/load when the agent reports it is unsupported", () => {
+    const backend = describeInstalledAcpBackend({
+      ...buildInstalledAgent(),
+      runtimeCapabilities: {
+        schemaVersion: 1,
+        status: "discovered",
+        agentCapabilities: {
+          loadSession: false,
+        },
+        checkedAt: 1000,
+      },
+    });
+
+    expect(backend.methods).toEqual([
+      "session/new",
+      "session/prompt",
+      "session/cancel",
+    ]);
+  });
+
+  it("keeps session/load advertised for agents without explicit load capability data", () => {
+    const backend = describeInstalledAcpBackend(buildInstalledAgent());
+
+    expect(backend.methods).toContain("session/load");
+  });
+});
+
+function buildInstalledAgent(): AcpInstalledAgentRecord {
+  return {
+    backendId: "acp:gemini" as AcpBackendId,
+    registryId: "gemini",
+    name: "Gemini CLI",
+    distributionKind: "local",
+    distributionSource: "gemini",
+    installStatus: "installed",
+    authStatus: "not-required",
+    verificationStatus: "not-applicable",
+    allowlistRuleId: "local-gemini-cli",
+    installedAt: 1000,
+    updatedAt: 1000,
+  };
+}

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -722,6 +722,41 @@ describe("AcpAgentClient", () => {
     ]);
   });
 
+  it("does not call session/load when the ACP agent says loading is unsupported", async () => {
+    const transport = new FakeAcpAgentTransport({
+      initialize: {
+        protocolVersion: 1,
+        agentCapabilities: {
+          loadSession: false,
+        },
+      },
+    });
+    const client = new AcpAgentClient({
+      backendId: "acp:gemini",
+      store,
+      transport,
+      now: () => 2000,
+    });
+    store.upsertSession({
+      backendId: "acp:gemini",
+      sessionId: "session-1",
+      title: "ACP session",
+      cwd: "/repo",
+      createdAt: 1000,
+      updatedAt: 1000,
+      executionMode: "default",
+      status: "idle",
+    });
+
+    await client.initialize();
+    await client.ensureSession(store.getSession("acp:gemini", "session-1")!);
+    await client.refreshSession(store.getSession("acp:gemini", "session-1")!);
+
+    expect(transport.requests.map((request) => request.method)).toEqual([
+      "initialize",
+    ]);
+  });
+
   it("can start prompts without waiting for completion and cancel sessions", async () => {
     const transport = new FakeAcpAgentTransport();
     const client = new AcpAgentClient({

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -2576,6 +2576,138 @@ describe("MessagingController", () => {
     });
   });
 
+  it("lets ACP messaging clear an inherited Full Access launchpad default", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.launchpadDefaults = {
+      ...navigation.launchpadDefaults,
+      executionMode: "full-access",
+    };
+    const harness = await createHarness({
+      navigation,
+      listBackends: async (): Promise<ListBackendsResponse> => ({
+        fetchedAt: 1000,
+        backends: [
+          buildBackendSummary({
+            kind: "acp:gemini",
+            label: "Gemini CLI",
+            source: "acp",
+            executionModes: [],
+          }),
+        ],
+      }),
+    });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Ready to start",
+      body: expect.stringContaining("Permissions: Full"),
+      actions: expect.arrayContaining([
+        expect.objectContaining({
+          id: "browse:new:permissions",
+          label: "Permissions: Full",
+        }),
+      ]),
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "browse:new:permissions" }),
+    );
+
+    const defaultReadyIntent = harness.delivered.at(-1);
+    expect(defaultReadyIntent).toMatchObject({
+      kind: "confirmation",
+      title: "Ready to start",
+      body: expect.not.stringContaining("Permissions: Full"),
+    });
+    expect(defaultReadyIntent).toMatchObject({
+      actions: expect.not.arrayContaining([
+        expect.objectContaining({ id: "browse:new:permissions" }),
+      ]),
+    });
+
+    await harness.controller.handleInboundEvent(buildTextEvent("Use Gemini"));
+
+    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith({
+      directoryKey: expect.stringMatching(/^messaging:browse:/),
+      launchpad: expect.objectContaining({
+        backend: "acp:gemini",
+        executionMode: "default",
+      }),
+    });
+    expect(harness.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: "acp:gemini",
+        threadId: "new-thread-1",
+      }),
+    );
+  });
+
+  it("does not label ACP model config as runtime mode in the new-thread prompt", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.launchpadDefaults = {
+      ...navigation.launchpadDefaults,
+      acpRuntime: {
+        configValues: {
+          model: "gemini-3-flash-preview",
+        },
+        updatedAt: 1000,
+      },
+    };
+    const harness = await createHarness({
+      navigation,
+      listBackends: async (): Promise<ListBackendsResponse> => ({
+        fetchedAt: 1000,
+        backends: [
+          buildBackendSummary({
+            kind: "acp:gemini",
+            label: "Gemini CLI",
+            source: "acp",
+            executionModes: [],
+            launchpadOptions: {
+              models: [{ id: "gemini-3-flash-preview", label: "Gemini 3 Flash Preview" }],
+            },
+          }),
+        ],
+      }),
+    });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Ready to start",
+      body: expect.stringContaining("Runtime mode: Agent default (desktop-only)"),
+    });
+    expect(harness.delivered.at(-1)).toMatchObject({
+      body: expect.stringContaining("Model: gemini-3-flash-preview"),
+    });
+    expect(harness.delivered.at(-1)).toMatchObject({
+      body: expect.not.stringContaining("Runtime mode: Gemini 3 Flash Preview"),
+    });
+  });
+
   it("does not fall back to another provider when the selected backend becomes unavailable before creation", async () => {
     const codexBackend = buildBackendSummary({
       kind: "codex",

--- a/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
@@ -279,6 +279,70 @@ describe("buildBindingStatusIntent", () => {
     );
   });
 
+  it("renders ACP runtime mode instead of Codex permission controls", () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.launchpadDefaults.acpRuntime = {
+      currentModeId: "default",
+      updatedAt: 1000,
+    };
+    navigation.threads[0] = {
+      ...navigation.threads[0]!,
+      source: "acp:gemini",
+      acpRuntime: {
+        currentModeId: "yolo",
+        updatedAt: 1000,
+      },
+    };
+    const binding = {
+      ...buildBinding(),
+      backend: "acp:gemini",
+    } satisfies MessagingBindingRecord;
+
+    const intent = buildBindingStatusIntent({
+      id: "status-acp-runtime",
+      createdAt: 1000,
+      binding,
+      threadState: resolveMessagingThreadState({ binding, navigation }),
+    });
+
+    expect(intent.text).toContain("Binding: Thread one (acp:gemini)");
+    expect(intent.text).toContain("Runtime mode: Yolo (desktop-only)");
+    expect(intent.text).not.toContain("Permissions:");
+    expect(intent.actions).not.toContainEqual(
+      expect.objectContaining({
+        id: "status:permissions",
+      }),
+    );
+  });
+
+  it("does not treat ACP model config values as runtime modes", () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.threads[0] = {
+      ...navigation.threads[0]!,
+      source: "acp:gemini",
+      acpRuntime: {
+        configValues: {
+          model: "gemini-3-flash-preview",
+        },
+        updatedAt: 1000,
+      },
+    };
+    const binding = {
+      ...buildBinding(),
+      backend: "acp:gemini",
+    } satisfies MessagingBindingRecord;
+
+    const intent = buildBindingStatusIntent({
+      id: "status-acp-model-config",
+      createdAt: 1000,
+      binding,
+      threadState: resolveMessagingThreadState({ binding, navigation }),
+    });
+
+    expect(intent.text).toContain("Runtime mode: Agent default (desktop-only)");
+    expect(intent.text).not.toContain("Runtime mode: Gemini 3 Flash Preview");
+  });
+
   it("renders live thread state ahead of stale binding display metadata", () => {
     const navigation = buildNavigationSnapshot();
     navigation.threads[0]!.title = "Renamed in Desktop";

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -14,6 +14,7 @@ import {
   type AcpSessionUpdate,
 } from "./acp-session-normalizer.js";
 import {
+  acpRuntimeSupportsSessionLoad,
   acpSessionRuntimeStateFromCapabilities,
   acpSessionRuntimeStateFromUpdate,
   normalizeAcpRuntimeCapabilities,
@@ -54,6 +55,7 @@ type AcpSessionStoreLike = Pick<
 
 export type AcpAgentClientOptions = {
   backendId: AcpBackendId;
+  initialRuntimeCapabilities?: BackendAcpRuntimeCapabilities;
   store: AcpSessionStoreLike;
   transport: AcpJsonRpcTransport;
   now?: () => number;
@@ -104,6 +106,7 @@ export class AcpAgentClient {
 
   constructor(private readonly options: AcpAgentClientOptions) {
     this.now = options.now ?? Date.now;
+    this.runtimeCapabilities = options.initialRuntimeCapabilities;
   }
 
   async initialize(): Promise<void> {
@@ -275,12 +278,18 @@ export class AcpAgentClient {
   async refreshSession(metadata: AcpSessionMetadata): Promise<void> {
     this.options.store.upsertSession(metadata);
     this.rememberSessionIds(metadata);
+    if (!this.supportsSessionLoad()) {
+      return;
+    }
     await this.loadSessionFromAgent(metadata);
   }
 
   async ensureSession(metadata: AcpSessionMetadata): Promise<void> {
     this.options.store.upsertSession(metadata);
     this.rememberSessionIds(metadata);
+    if (!this.supportsSessionLoad()) {
+      return;
+    }
     const cwd = metadata.cwd ?? process.cwd();
     const protocolSessionId = protocolSessionIdForMetadata(metadata);
     if (
@@ -699,6 +708,9 @@ export class AcpAgentClient {
   }
 
   private async loadSessionFromAgent(metadata: AcpSessionMetadata): Promise<unknown> {
+    if (!this.supportsSessionLoad()) {
+      return undefined;
+    }
     const cwd = metadata.cwd ?? process.cwd();
     const protocolSessionId = protocolSessionIdForMetadata(metadata);
     this.suppressLoadReplaySessions.add(protocolSessionId);
@@ -725,6 +737,10 @@ export class AcpAgentClient {
     });
     this.loadedSessionCwds.set(protocolSessionId, cwd);
     return result;
+  }
+
+  private supportsSessionLoad(): boolean {
+    return acpRuntimeSupportsSessionLoad(this.runtimeCapabilities);
   }
 
   private clearLoadReplaySuppression(sessionId: string): void {

--- a/apps/desktop/src/main/acp/acp-runtime-capabilities.ts
+++ b/apps/desktop/src/main/acp/acp-runtime-capabilities.ts
@@ -98,6 +98,12 @@ export function acpSessionRuntimeStateFromCapabilities(
   return Object.keys(state).length > 1 ? state : undefined;
 }
 
+export function acpRuntimeSupportsSessionLoad(
+  capabilities: BackendAcpRuntimeCapabilities | undefined,
+): boolean {
+  return capabilities?.agentCapabilities?.loadSession !== false;
+}
+
 export function acpSessionRuntimeStateFromUpdate(
   update: Record<string, unknown>,
   now: number,

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -33,7 +33,10 @@ import {
 import { discoverLocalAcpAgents } from "../acp/acp-local-discovery";
 import { acpToolUpdateNotifications } from "../acp/acp-live-notifications";
 import type { AcpInstalledAgentRecord } from "../acp/acp-registry-types";
-import { acpSessionRuntimeStateFromUpdate } from "../acp/acp-runtime-capabilities";
+import {
+  acpRuntimeSupportsSessionLoad,
+  acpSessionRuntimeStateFromUpdate,
+} from "../acp/acp-runtime-capabilities";
 import {
   AcpSessionStore,
   type AcpSessionMetadata,
@@ -182,7 +185,14 @@ export function describeInstalledAcpBackend(
       license: agent.registryAgent?.license,
       runtime: agent.runtimeCapabilities,
     },
-    methods: ["session/new", "session/load", "session/prompt", "session/cancel"],
+    methods: [
+      "session/new",
+      ...(acpRuntimeSupportsSessionLoad(agent.runtimeCapabilities)
+        ? ["session/load"]
+        : []),
+      "session/prompt",
+      "session/cancel",
+    ],
     capabilities: buildAcpCapabilities(),
     executionModes: [],
     launchpadOptions: buildAcpLaunchpadOptions(agent.runtimeCapabilities),
@@ -601,6 +611,13 @@ export class AcpBackendAdapter {
       return new AcpSessionReplayNormalizer().replay();
     }
 
+    if (
+      !acpRuntimeSupportsSessionLoad(
+        this.getInstalledAgent(backend)?.runtimeCapabilities,
+      )
+    ) {
+      return replayPersistedAcpTranscript(session);
+    }
     const client = await this.getClient(backend);
     try {
       const replay = await client.loadSession(session);
@@ -729,6 +746,7 @@ export class AcpBackendAdapter {
     }
     return new AcpAgentClient({
       backendId: agent.backendId,
+      initialRuntimeCapabilities: agent.runtimeCapabilities,
       store: this.acpSessionStore as AcpSessionStoreContract,
       transport: new AcpStdioJsonRpcTransport({
         launchDescriptor: agent.launchDescriptor,

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 import {
   buildThreadIdentityKey,
+  isAcpBackendId,
   isAppServerBackendKind,
   resolveNewThreadBackend,
   selectableNewThreadBackends,
@@ -9,6 +10,7 @@ import type {
   AgentEvent,
   AppServerTurnInputItem,
   AppServerBackendKind,
+  BackendAcpSessionRuntimeState,
   BackendSummary,
   AppServerPendingRequestNotification,
   AppServerToolRequestUserInputNotification,
@@ -3052,10 +3054,22 @@ export class MessagingController {
       return;
     }
     if (actionId === "browse:new:permissions") {
+      const directory = nextSession.selectedProject
+        ? directoryForProjectSelection(navigation, nextSession.selectedProject)
+        : undefined;
       const currentMode =
         nextSession.preferences?.executionMode ??
+        directory?.launchpad?.executionMode ??
         navigation.launchpadDefaults.executionMode;
       const executionMode = currentMode === "full-access" ? "default" : "full-access";
+      if (
+        nextSession.backend &&
+        isAcpBackendId(nextSession.backend) &&
+        executionMode === "full-access"
+      ) {
+        await this.presentNewThreadPromptGate(nextSession, event, navigation);
+        return;
+      }
       if (executionMode === "full-access") {
         const allowed = await this.ensureFullAccessEscalationAllowed(
           { kind: "new-thread", session: nextSession },
@@ -3616,6 +3630,9 @@ export class MessagingController {
       Boolean(
         selectedBackend.launchpadOptions?.models?.some((model) => model.supportsFast),
       );
+    const supportsPermissionsControls =
+      !isAcpBackendId(selectedBackend.kind) ||
+      options.executionMode === "full-access";
     await this.options.store.upsertBrowseSession(effectiveSession);
     const intent = buildConfirmationIntent({
       id: this.newIntentId("new-thread-ready"),
@@ -3673,8 +3690,9 @@ export class MessagingController {
               },
             ]
           : []),
-        ...(options.executionMode === "full-access" ||
-        fullAccessControls.allowEscalation
+        ...((supportsPermissionsControls &&
+        (options.executionMode === "full-access" ||
+        fullAccessControls.allowEscalation))
           ? [
               {
                 id: "browse:new:permissions",
@@ -4134,6 +4152,7 @@ export class MessagingController {
             now: this.now(),
             workMode: options.workMode,
             branchName: options.branchName,
+            acpRuntime: options.acpRuntime,
           }),
         })
       : undefined;
@@ -4145,6 +4164,7 @@ export class MessagingController {
       model: options.supportsModel ? options.model : undefined,
       reasoningEffort: options.supportsReasoning ? options.reasoningEffort : undefined,
       serviceTier: preferences?.serviceTier,
+      acpRuntime: options.acpRuntime,
       ...(options.workMode === "worktree"
         ? {
             workMode: "worktree" as const,
@@ -4177,6 +4197,7 @@ export class MessagingController {
       reasoningEffort: options.supportsReasoning ? options.reasoningEffort : undefined,
       serviceTier: preferences?.serviceTier,
       fastMode: options.supportsFast ? options.fastMode : undefined,
+      acpRuntime: options.acpRuntime,
       preferences,
       project,
       threadId: started.threadId,
@@ -6110,6 +6131,10 @@ export class MessagingController {
     binding: MessagingBindingRecord,
     event: MessagingInboundEvent,
   ): Promise<void> {
+    if (isAcpBackendId(binding.backend)) {
+      await this.renderBindingStatus(binding, event);
+      return;
+    }
     const navigation = await this.options.backend.getNavigationSnapshot({
       backend: "all",
     });
@@ -9146,6 +9171,14 @@ function normalizeNewThreadSessionForBackend(
   }
 
   const preferences = { ...session.preferences };
+  if (isAcpBackendId(backend.kind)) {
+    delete preferences.permissionsMode;
+    if (preferences.executionMode === "full-access") {
+      delete preferences.executionMode;
+    }
+  } else {
+    delete preferences.acpRuntime;
+  }
   const models = backend.launchpadOptions?.models ?? [];
   if (preferences.model !== undefined) {
     const modelIsValid = models.some((model) => model.id === preferences.model);
@@ -9203,6 +9236,7 @@ function defaultBackendModel(
 }
 
 type NewThreadOptionsSummary = {
+  acpRuntime?: BackendAcpSessionRuntimeState;
   backend: AppServerBackendKind;
   backendLabel: string;
   branchName: string;
@@ -9254,6 +9288,11 @@ function newThreadOptionsForSession(
     Boolean(modelOption?.supportsFast);
   const supportsReasoning =
     reasoningEfforts.length > 0 || Boolean(modelOption?.supportsReasoning);
+  const acpRuntime = isAcpBackendId(backend.kind)
+    ? session.preferences?.acpRuntime ??
+      directory?.launchpad?.acpRuntime ??
+      navigation.launchpadDefaults.acpRuntime
+    : undefined;
   const executionMode =
     session.preferences?.executionMode ??
     directory?.launchpad?.executionMode ??
@@ -9266,6 +9305,7 @@ function newThreadOptionsForSession(
   return {
     backend: backend.kind,
     backendLabel: backend.label,
+    acpRuntime,
     branchName: resolveNewThreadBaseBranch(session, navigation, directory),
     executionMode,
     executionModeSource,
@@ -9318,7 +9358,12 @@ function newThreadPromptGateBody(
     `Provider: ${backend.label}`,
     `Workspace: ${options.workMode === "worktree" ? "New Worktree" : "Local"}`,
     options.workMode === "worktree" ? `Base branch: ${options.branchName}` : undefined,
-    `Permissions: ${formatPermissionsShortLabel(options.executionMode)}`,
+    !isAcpBackendId(options.backend) || options.executionMode === "full-access"
+      ? `Permissions: ${formatPermissionsShortLabel(options.executionMode)}`
+      : undefined,
+    isAcpBackendId(options.backend)
+      ? `Runtime mode: ${formatMessagingAcpRuntimeLineLabel(options.acpRuntime)} (desktop-only)`
+      : undefined,
     options.supportsModel ? `Model: ${options.model}` : undefined,
     options.supportsReasoning && options.reasoningEffort
       ? `Reasoning: ${options.reasoningEffort}`
@@ -9332,6 +9377,37 @@ function newThreadPromptGateBody(
 
 function formatPermissionsShortLabel(mode: ThreadExecutionMode): string {
   return mode === "full-access" ? "Full" : "Default";
+}
+
+function formatMessagingAcpRuntimeLineLabel(
+  runtime: BackendAcpSessionRuntimeState | undefined,
+): string {
+  const mode =
+    runtime?.currentModeId ??
+    (runtime?.configValues
+      ? Object.entries(runtime.configValues).find(([key]) =>
+          isMessagingAcpRuntimeModeConfigKey(key),
+        )?.[1]
+      : undefined);
+  return mode ? formatMessagingAcpRuntimeModeLabel(mode) : "Agent default";
+}
+
+function isMessagingAcpRuntimeModeConfigKey(key: string): boolean {
+  return key.trim().toLowerCase().endsWith("mode");
+}
+
+function formatMessagingAcpRuntimeModeLabel(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return value;
+  }
+  if (trimmed.toLowerCase() === "yolo") {
+    return "Yolo";
+  }
+  return trimmed
+    .replace(/[_-]+/g, " ")
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .replace(/\b\w/g, (match) => match.toUpperCase());
 }
 
 function resolveNewThreadBaseBranch(
@@ -9912,6 +9988,7 @@ type TurnLifecycleParams = {
 };
 
 function navigationWithStartedThread(params: {
+  acpRuntime?: BackendAcpSessionRuntimeState;
   backend: AppServerBackendKind;
   directory?: NavigationDirectorySummary;
   executionMode?: ThreadExecutionMode;
@@ -9961,6 +10038,7 @@ function navigationWithStartedThread(params: {
         createdAt: params.now,
         updatedAt: params.now,
         executionMode: params.executionMode,
+        acpRuntime: params.acpRuntime,
         model: params.model,
         reasoningEffort: params.reasoningEffort,
         serviceTier: params.serviceTier,
@@ -9991,6 +10069,7 @@ function navigationWithStartedThread(params: {
 }
 
 function launchpadForMessagingProject(params: {
+  acpRuntime?: BackendAcpSessionRuntimeState;
   backend: AppServerBackendKind;
   branchName: string;
   directory?: NavigationDirectorySummary;
@@ -10027,6 +10106,7 @@ function launchpadForMessagingProject(params: {
   return {
     ...base,
     backend: params.backend,
+    acpRuntime: params.acpRuntime ?? params.preferences?.acpRuntime ?? base.acpRuntime,
     executionMode: params.preferences?.executionMode ?? base.executionMode,
     model: params.preferences?.model ?? base.model,
     reasoningEffort: params.preferences?.reasoningEffort ?? base.reasoningEffort,

--- a/apps/desktop/src/main/messaging/core/messaging-status-card.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-status-card.ts
@@ -1,5 +1,6 @@
 import type {
   AppServerBackendKind,
+  BackendAcpSessionRuntimeState,
   HandoffThreadWorkspaceRequest,
   MessagingToolUpdateMode,
   ThreadExecutionMode,
@@ -14,7 +15,7 @@ import type {
   MessagingSurfaceAction,
   MessagingStatusIntent,
 } from "@pwragent/messaging-interface";
-import { shortenDerivedThreadTitle } from "@pwragent/shared";
+import { isAcpBackendId, shortenDerivedThreadTitle } from "@pwragent/shared";
 import type { MessagingCapabilityProfile } from "@pwragent/messaging-interface";
 import {
   applyActionCapabilityLimits,
@@ -95,6 +96,9 @@ export function buildBindingStatusIntent(params: {
     streamingMode,
     params.streamingResponsesDefault,
   );
+  const acpRuntimeLabel = isAcpBackendId(params.binding.backend)
+    ? formatAcpRuntimeLineLabel(params.threadState.acpRuntime)
+    : undefined;
 
   return {
     id: params.id,
@@ -120,7 +124,9 @@ export function buildBindingStatusIntent(params: {
       `Reasoning: ${reasoning}`,
       `Fast mode: ${fastMode === undefined ? unavailable() : fastMode ? "on" : "off"}`,
       "Plan mode: unavailable",
-      `Permissions: ${formatPermissionsLineLabel(permissionsMode, queuedExecutionMode)}`,
+      acpRuntimeLabel
+        ? `Runtime mode: ${acpRuntimeLabel} (desktop-only)`
+        : `Permissions: ${formatPermissionsLineLabel(permissionsMode, queuedExecutionMode)}`,
       `Tool updates: ${formatMessagingToolUpdateModeLabel(toolUpdateMode)}`,
       `Streaming: ${streamingLabel}`,
       params.binding.pendingSkillSelection
@@ -140,6 +146,7 @@ export function buildBindingStatusIntent(params: {
       fastMode,
       handoff: params.handoff,
       permissionsMode,
+      supportsPermissionsAction: !acpRuntimeLabel,
       queuedExecutionMode,
       reasoning,
       streamingMode,
@@ -163,12 +170,44 @@ function mentionRequiredLine(
     ?? capabilityProfile.conversationInput.sharedConversationMentionInstruction;
 }
 
+function formatAcpRuntimeLineLabel(
+  runtime: BackendAcpSessionRuntimeState | undefined,
+): string {
+  const mode =
+    runtime?.currentModeId ??
+    (runtime?.configValues
+      ? Object.entries(runtime.configValues).find(([key]) =>
+          isAcpRuntimeModeConfigKey(key),
+        )?.[1]
+      : undefined);
+  return mode ? formatAcpRuntimeModeLabel(mode) : "Agent default";
+}
+
+function isAcpRuntimeModeConfigKey(key: string): boolean {
+  return key.trim().toLowerCase().endsWith("mode");
+}
+
+function formatAcpRuntimeModeLabel(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return value;
+  }
+  if (trimmed.toLowerCase() === "yolo") {
+    return "Yolo";
+  }
+  return trimmed
+    .replace(/[_-]+/g, " ")
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .replace(/\b\w/g, (match) => match.toUpperCase());
+}
+
 function buildStatusActions(params: {
   allowFullAccessEscalation?: boolean;
   capabilityProfile?: MessagingCapabilityProfile;
   fastMode: boolean | undefined;
   handoff?: MessagingWorkspaceHandoffContext;
   permissionsMode: string;
+  supportsPermissionsAction?: boolean;
   queuedExecutionMode?: ThreadExecutionMode;
   reasoning: string;
   streamingMode: MessagingStreamingResponseMode;
@@ -183,7 +222,8 @@ function buildStatusActions(params: {
   const permissionsAction:
     | MessagingSurfaceAction
     | undefined =
-    params.permissionsMode === "full-access" || params.allowFullAccessEscalation !== false
+    params.supportsPermissionsAction !== false &&
+    (params.permissionsMode === "full-access" || params.allowFullAccessEscalation !== false)
       ? {
           id: "status:permissions",
           label: formatPermissionsActionLabel(

--- a/apps/desktop/src/main/messaging/core/messaging-thread-state.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-thread-state.ts
@@ -3,6 +3,7 @@ import type {
   NavigationLaunchpadDefaults,
   NavigationSnapshot,
   NavigationThreadSummary,
+  BackendAcpSessionRuntimeState,
   ThreadExecutionMode,
 } from "@pwragent/shared";
 import type {
@@ -13,6 +14,7 @@ import { buildThreadIdentityKey } from "@pwragent/shared";
 
 export type MessagingResolvedThreadState = {
   activeTurn?: MessagingActiveTurnSummary;
+  acpRuntime?: BackendAcpSessionRuntimeState;
   directoryPath?: string;
   executionMode?: ThreadExecutionMode;
   fastMode?: boolean;
@@ -76,6 +78,7 @@ export function resolveMessagingThreadState(params: {
 
   return {
     activeTurn: params.activeTurn,
+    acpRuntime: thread.acpRuntime,
     directoryPath: linkedDirectory?.path ?? directory?.path,
     executionMode: thread.executionMode,
     fastMode: thread.fastMode,

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -1,5 +1,6 @@
 import type {
   AppServerBackendKind,
+  BackendAcpSessionRuntimeState,
   LaunchpadWorkMode,
   AppServerThreadImagePart,
   AppServerThreadMessagePart,
@@ -951,6 +952,7 @@ export type MessagingInboundEvent =
 export type MessagingPermissionsMode = "default" | "full-access";
 
 export type MessagingBindingPreferences = {
+  acpRuntime?: BackendAcpSessionRuntimeState;
   executionMode?: ThreadExecutionMode;
   fastMode?: boolean;
   model?: string;


### PR DESCRIPTION
## Summary

- Gate ACP session replay/load behavior on the negotiated loadSession capability, including backend method advertisement.
- Surface ACP runtime mode in messaging status/new-thread flows instead of exposing Codex-style permission controls.
- Add focused coverage for ACP load gating and ACP messaging status rendering.

## Verification

- pnpm --filter @pwragent/desktop exec vitest run src/main/__tests__/acp-client.test.ts src/main/__tests__/acp-backend-adapter.test.ts src/main/__tests__/messaging-status-card.test.ts
- pnpm --filter @pwragent/desktop typecheck
- pnpm --filter @pwragent/messaging-interface typecheck

## Notes

- ACP runtime mode selection remains desktop-owned for this slice; messaging reports the current mode and avoids misleading permission actions.
