### PR TITLE
feat(desktop): add Kimi ACP support ✋ ❌ #556 supersedes

### DIFF
--- a/apps/desktop/e2e/codex-environment-setup.spec.ts
+++ b/apps/desktop/e2e/codex-environment-setup.spec.ts
@@ -366,7 +366,7 @@ async function readActionCwdMarker(params: {
   return "";
 }
 
-test("selected Codex environments run setup and show transcript output", async () => {
+test("selected environments run setup and show transcript output", async () => {
   const fixture = await createCodexEnvironmentSetupFixture();
   const app = await launchElectronApp({
     fixturePath: fixture.fixturePath,
@@ -380,7 +380,7 @@ test("selected Codex environments run setup and show transcript output", async (
 
     await expect(app.window.getByRole("textbox", { name: "New thread" })).toBeVisible();
     const launchpadTools = app.window.getByLabel("Composer tools");
-    await launchpadTools.getByRole("button", { name: "Codex environment" }).click();
+    await launchpadTools.getByRole("button", { name: "Environment", exact: true }).click();
     await app.window.getByRole("option", { name: "Fixture Env" }).click();
     await expect(
       launchpadTools.locator("label", { hasText: "Run setup" }).locator("input"),
@@ -425,7 +425,7 @@ test("selected Codex environments run setup and show transcript output", async (
   }
 });
 
-test("existing running thread keeps selected Codex environment after pending state clears", async () => {
+test("existing running thread keeps selected environment after pending state clears", async () => {
   const fixture = await createCodexEnvironmentSetupFixture({
     includeExistingRunningSteps: true,
   });
@@ -445,7 +445,10 @@ test("existing running thread keeps selected Codex environment after pending sta
     await app.advance({ stepId: "existing-thread-turn-started" });
     await expect(app.window.getByRole("button", { name: "Stop" })).toBeVisible();
 
-    const environmentDropdown = app.window.getByLabel("Codex environment");
+    const environmentDropdown = app.window.getByRole("button", {
+      name: "Environment",
+      exact: true,
+    });
     await expect(environmentDropdown).toHaveAttribute("data-value", "");
     await environmentDropdown.click();
     await app.window.getByRole("option", { name: "Fixture Env" }).click();
@@ -473,9 +476,11 @@ test("thread environment Run command uses the current cwd after workspace handof
       app.window.getByRole("heading", { level: 2, name: "Existing directory thread" }),
     ).toBeVisible();
 
-    await app.window.getByLabel("Codex environment").click();
+    await app.window.getByRole("button", { name: "Environment", exact: true }).click();
     await app.window.getByRole("option", { name: "Fixture Env" }).click();
-    await expect(app.window.getByLabel("Codex environment")).toContainText(
+    await expect(
+      app.window.getByRole("button", { name: "Environment", exact: true }),
+    ).toContainText(
       "Fixture Env",
     );
     await expect(app.window.getByLabel("Environment command")).toContainText(
@@ -554,7 +559,7 @@ test("thread environment Run command uses the current cwd after workspace handof
   }
 });
 
-test("directory launchpad keeps selected Codex environment controls after snapshot reload", async () => {
+test("directory launchpad keeps selected environment controls after snapshot reload", async () => {
   const fixture = await createCodexEnvironmentSetupFixture({
     includeExistingThread: false,
   });
@@ -612,7 +617,9 @@ test("directory launchpad keeps selected Codex environment controls after snapsh
       "worktree",
     );
     const tools = secondApp.window.getByLabel("Composer tools");
-    await expect(tools.getByLabel("Codex environment")).toContainText(
+    await expect(
+      tools.getByRole("button", { name: "Environment", exact: true }),
+    ).toContainText(
       "Fixture Env",
     );
     await expect(tools.getByLabel("Run setup")).toBeChecked();
@@ -646,7 +653,9 @@ test("directory launchpad opens without an environment picker when no environmen
       app.window.getByRole("heading", { level: 2, name: "NoEnvRepo" }),
     ).toBeVisible();
     await expect(app.window.getByRole("textbox", { name: "New thread" })).toBeVisible();
-    await expect(app.window.getByLabel("Codex environment")).toHaveCount(0);
+    await expect(
+      app.window.getByRole("button", { name: "Environment", exact: true }),
+    ).toHaveCount(0);
     await expect(
       app.window.getByText(/Error invoking remote method|ENOTDIR/),
     ).toHaveCount(0);

--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -1,7 +1,16 @@
-import { describe, expect, it } from "vitest";
-import type { AcpBackendId } from "@pwragent/shared";
-import { describeInstalledAcpBackend } from "../app-server/acp-backend-adapter";
+import { describe, expect, it, vi } from "vitest";
+import type {
+  AcpBackendId,
+  AgentEvent,
+  AppServerPendingRequestNotification,
+} from "@pwragent/shared";
+import {
+  AcpBackendAdapter,
+  describeInstalledAcpBackend,
+  type AcpSessionMetadata,
+} from "../app-server/acp-backend-adapter";
 import type { AcpInstalledAgentRecord } from "../acp/acp-registry-types";
+import { FakeAcpAgentTransport } from "../acp/testing/fake-acp-agent";
 
 describe("describeInstalledAcpBackend", () => {
   it("does not advertise session/load when the agent reports it is unsupported", () => {
@@ -28,6 +37,124 @@ describe("describeInstalledAcpBackend", () => {
     const backend = describeInstalledAcpBackend(buildInstalledAgent());
 
     expect(backend.methods).toContain("session/load");
+  });
+});
+
+describe("AcpBackendAdapter", () => {
+  it("passes the installed agent name to ACP approval prompts", async () => {
+    const backendId = "acp:kimi" as AcpBackendId;
+    const transport = new FakeAcpAgentTransport();
+    const events: AgentEvent[] = [];
+    const sessions: AcpSessionMetadata[] = [];
+    const requests: AppServerPendingRequestNotification[] = [];
+    const agent: AcpInstalledAgentRecord = {
+      backendId,
+      registryId: "kimi",
+      name: "Kimi Code CLI",
+      version: "1.44.0",
+      distributionKind: "local",
+      distributionSource: "kimi acp",
+      installStatus: "installed",
+      authStatus: "not-required",
+      verificationStatus: "not-applicable",
+      allowlistRuleId: "local-kimi-cli",
+      installedAt: 1000,
+      updatedAt: 1000,
+      launchDescriptor: {
+        backendId,
+        registryId: "kimi",
+        distributionKind: "local",
+        command: "kimi",
+        args: ["acp"],
+        env: {},
+      },
+    };
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => agent,
+        listInstalledAgents: () => [agent],
+        upsertInstalledAgent: vi.fn(),
+      },
+      acpSessionStore: {
+        listSessions: () => sessions,
+        getSession: (_backendId, sessionId) =>
+          sessions.find((session) => session.sessionId === sessionId),
+        upsertSession: (metadata) => {
+          const index = sessions.findIndex(
+            (session) => session.sessionId === metadata.sessionId,
+          );
+          if (index >= 0) {
+            sessions[index] = metadata;
+          } else {
+            sessions.push(metadata);
+          }
+        },
+      },
+      captureStores: [],
+      createAcpTransport: () => transport,
+      emit: async (event) => {
+        events.push(event);
+      },
+      handleServerRequest: async (_requestBackend, request) => {
+        requests.push(request);
+        return { decision: "accept" };
+      },
+    });
+
+    const client = await adapter.getClient(backendId);
+    const session = await client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+    });
+    client.startPrompt({
+      sessionId: session.sessionId,
+      prompt: "Run npm view openclaw",
+      turnId: "turn-1",
+    });
+
+    await transport.emitRequest(
+      "session/request_permission",
+      {
+        sessionId: session.sessionId,
+        toolCall: {
+          toolCallId: "run_shell_command_1",
+          kind: "execute",
+          title: "npm view openclaw",
+        },
+        options: [{ optionId: "proceed_once", kind: "allow_once" }],
+      },
+      0,
+    );
+
+    expect(requests[0]?.params.prompt).toBe(
+      "Kimi Code CLI wants to run execute: npm view openclaw",
+    );
+    expect(requests[0]?.params.reason).toBe(
+      "Kimi Code CLI wants to run execute: npm view openclaw",
+    );
+
+    transport.emitSessionUpdate(session.sessionId, {
+      sessionUpdate: "agent_message_chunk",
+      content: {
+        type: "text",
+        text: "You only live once! All actions will be auto-approved.",
+      },
+    });
+    await vi.waitFor(() => {
+      expect(sessions[0]?.executionMode).toBe("full-access");
+    });
+    expect(events).toContainEqual({
+      backend: backendId,
+      notification: {
+        method: "thread/executionMode/updated",
+        params: {
+          threadId: session.sessionId,
+          executionMode: "full-access",
+        },
+      },
+    });
+
+    await adapter.close();
   });
 });
 

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -245,7 +245,8 @@ describe("AcpAgentClient", () => {
     const transport = new FakeAcpAgentTransport();
     const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
     const client = new AcpAgentClient({
-      backendId: "acp:gemini",
+      backendId: "acp:kimi",
+      agentDisplayName: "Kimi Code CLI",
       store,
       transport,
       now: () => 1000,
@@ -304,6 +305,8 @@ describe("AcpAgentClient", () => {
         threadId: "session-1",
         turnId: "turn-1",
         requestId: "0",
+        prompt: "Kimi Code CLI wants to run execute: npm view openclaw",
+        reason: "Kimi Code CLI wants to run execute: npm view openclaw",
         command: "npm view openclaw",
         acpMethod: "session/request_permission",
         acpToolCallId: "run_shell_command_1",

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -132,6 +132,54 @@ describe("AcpAgentClient", () => {
     expect(sessionUpdates).toEqual(["session-1"]);
   });
 
+  it("sends control prompts without recording transcript updates", async () => {
+    const promptResponse = createDeferred<unknown>();
+    const transport = new FakeAcpAgentTransport({
+      "session/prompt": promptResponse.promise,
+    });
+    const sessionUpdates: string[] = [];
+    const client = new AcpAgentClient({
+      backendId: "acp:kimi",
+      store,
+      transport,
+      now: () => 1000,
+      onSessionUpdate: ({ sessionId }) => {
+        sessionUpdates.push(sessionId);
+      },
+    });
+
+    await client.initialize();
+    const session = await client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+      title: "Kimi ACP",
+    });
+    const controlPrompt = client.sendControlPrompt({
+      sessionId: session.sessionId,
+      prompt: "/yolo",
+    });
+    transport.emitSessionUpdate(session.sessionId, {
+      sessionUpdate: "agent_message_chunk",
+      content: {
+        type: "text",
+        text: "You only live once! All actions will be auto-approved.",
+      },
+    });
+    promptResponse.resolve({ stopReason: "end_turn" });
+    await controlPrompt;
+
+    expect(transport.requests.at(-1)).toEqual({
+      method: "session/prompt",
+      params: {
+        sessionId: "session-1",
+        prompt: [{ type: "text", text: "/yolo" }],
+      },
+    });
+    expect(client.readReplay("session-1").messages).toEqual([]);
+    expect(store.getSession("acp:kimi", "session-1")?.transcriptUpdates).toBeUndefined();
+    expect(sessionUpdates).toEqual([]);
+  });
+
   it("sends pasted images as ACP image content and persists structured transcript parts", async () => {
     const transport = new FakeAcpAgentTransport();
     const imageUrl = "data:image/png;base64,aGVsbG8=";

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -166,7 +166,9 @@ describe("AcpAgentClient", () => {
       },
     });
     promptResponse.resolve({ stopReason: "end_turn" });
-    await controlPrompt;
+    await expect(controlPrompt).resolves.toEqual({
+      text: "You only live once! All actions will be auto-approved.",
+    });
 
     expect(transport.requests.at(-1)).toEqual({
       method: "session/prompt",

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -18,6 +18,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   stateDb.close();
   rmSync(tempDir, { recursive: true, force: true });
 });
@@ -45,6 +46,7 @@ describe("AcpAgentClient", () => {
       store,
       transport,
       now: () => 1000,
+      transcriptPersistenceFlushDelayMs: 0,
       onSessionUpdate: ({ sessionId }) => {
         sessionUpdates.push(sessionId);
       },
@@ -1437,5 +1439,134 @@ describe("AcpAgentClient", () => {
     });
     expect(updateEvents).toEqual([]);
     expect(client.readReplay("session-1").lastAssistantMessage).toBe("Previous answer.");
+  });
+
+  it("batches and coalesces streaming transcript persistence", async () => {
+    vi.useFakeTimers();
+    const promptResponse = createDeferred<unknown>();
+    const transport = new FakeAcpAgentTransport({
+      "session/prompt": promptResponse.promise,
+    });
+    const upsertSession = vi.spyOn(store, "upsertSession");
+    const client = new AcpAgentClient({
+      backendId: "acp:kimi",
+      store,
+      transport,
+      now: () => 1000,
+      transcriptPersistenceFlushDelayMs: 1000,
+    });
+
+    await client.initialize();
+    const session = await client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+    });
+    const upsertCountAfterStart = upsertSession.mock.calls.length;
+    client.startPrompt({
+      sessionId: session.sessionId,
+      prompt: "hello",
+      turnId: "turn-1",
+    });
+    const upsertCountAfterPrompt = upsertSession.mock.calls.length;
+
+    transport.emitSessionUpdate(session.sessionId, {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "Hel" },
+    });
+    transport.emitSessionUpdate(session.sessionId, {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "lo" },
+    });
+
+    expect(upsertSession.mock.calls.length).toBe(upsertCountAfterPrompt);
+    expect(store.getSession("acp:kimi", session.sessionId)?.transcriptUpdates)
+      .toEqual([
+        {
+          receivedAt: 1000,
+          update: {
+            kind: "pwragent_user_prompt",
+            prompt: "hello",
+            turnId: "turn-1",
+          },
+        },
+      ]);
+
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(upsertSession.mock.calls.length).toBe(upsertCountAfterPrompt + 1);
+    expect(store.getSession("acp:kimi", session.sessionId)?.transcriptUpdates)
+      .toEqual([
+        {
+          receivedAt: 1000,
+          update: {
+            kind: "pwragent_user_prompt",
+            prompt: "hello",
+            turnId: "turn-1",
+          },
+        },
+        {
+          receivedAt: 1000,
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text: "Hello" },
+          },
+        },
+      ]);
+    expect(upsertCountAfterStart).toBeGreaterThan(0);
+
+    promptResponse.resolve({ turnId: "turn-1" });
+    await Promise.resolve();
+    await client.dispose();
+  });
+
+  it("compacts adjacent text chunks when upserting stored sessions", () => {
+    store.upsertSession({
+      backendId: "acp:kimi",
+      sessionId: "session-1",
+      title: "ACP session",
+      cwd: "/repo",
+      createdAt: 900,
+      updatedAt: 1000,
+      executionMode: "default",
+      status: "idle",
+      transcriptUpdates: [
+        {
+          receivedAt: 950,
+          update: {
+            sessionUpdate: "agent_thought_chunk",
+            content: { type: "text", text: "Thinking " },
+          },
+        },
+        {
+          receivedAt: 975,
+          update: {
+            sessionUpdate: "agent_thought_chunk",
+            content: { type: "text", text: "hard." },
+          },
+        },
+        {
+          receivedAt: 1000,
+          update: {
+            sessionUpdate: "turn_finished",
+          },
+        },
+      ],
+    });
+
+    expect(store.getSession("acp:kimi", "session-1")?.transcriptUpdates).toEqual([
+      {
+        receivedAt: 975,
+        update: {
+          sessionUpdate: "agent_thought_chunk",
+          content: { type: "text", text: "Thinking hard." },
+        },
+      },
+      {
+        receivedAt: 1000,
+        update: {
+          sessionUpdate: "turn_finished",
+        },
+      },
+    ]);
   });
 });

--- a/apps/desktop/src/main/__tests__/acp-local-discovery.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-local-discovery.test.ts
@@ -43,6 +43,53 @@ describe("discoverLocalAcpAgents", () => {
     ]);
   });
 
+  it("discovers Kimi Code CLI when the local command supports ACP", async () => {
+    const probe = vi.fn<LocalAcpAgentProbe>(async (command, args) => {
+      if (command !== "kimi") {
+        throw Object.assign(new Error("missing"), { code: "ENOENT" });
+      }
+      if (args[0] === "--version") {
+        return { stdout: "kimi, version 1.44.0\n" };
+      }
+      if (args[0] === "acp" && args[1] === "--help") {
+        return { stdout: "Usage: kimi acp [OPTIONS]\nRun Kimi Code CLI ACP server.\n" };
+      }
+      throw new Error("unexpected probe");
+    });
+
+    await expect(
+      discoverLocalAcpAgents({ probe, now: () => 5678 }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        backendId: "acp:kimi",
+        registryId: "kimi",
+        name: "Kimi Code CLI",
+        version: "1.44.0",
+        distributionKind: "local",
+        distributionSource: "kimi acp",
+        installStatus: "installed",
+        authStatus: "not-required",
+        verificationStatus: "not-applicable",
+        allowlistRuleId: "local-kimi-cli",
+        installedAt: 5678,
+        updatedAt: 5678,
+        launchDescriptor: {
+          backendId: "acp:kimi",
+          registryId: "kimi",
+          distributionKind: "local",
+          command: "kimi",
+          args: ["acp"],
+          env: {},
+        },
+        registryAgent: expect.objectContaining({
+          id: "kimi",
+          authors: ["Moonshot AI"],
+          auth: { required: false, methods: ["agent-managed"] },
+        }),
+      }),
+    ]);
+  });
+
   it("ignores missing local commands", async () => {
     const probe = vi.fn<LocalAcpAgentProbe>(async () => {
       throw Object.assign(new Error("missing"), { code: "ENOENT" });
@@ -57,6 +104,20 @@ describe("discoverLocalAcpAgents", () => {
         return { stdout: "0.41.0\n" };
       }
       return { stdout: "Usage: gemini [options]\n" };
+    });
+
+    await expect(discoverLocalAcpAgents({ probe })).resolves.toEqual([]);
+  });
+
+  it("ignores Kimi CLI versions that do not advertise ACP mode", async () => {
+    const probe = vi.fn<LocalAcpAgentProbe>(async (command, args) => {
+      if (command !== "kimi") {
+        throw Object.assign(new Error("missing"), { code: "ENOENT" });
+      }
+      if (args[0] === "--version") {
+        return { stdout: "kimi, version 1.40.0\n" };
+      }
+      return { stdout: "Usage: kimi [OPTIONS] COMMAND [ARGS]...\n" };
     });
 
     await expect(discoverLocalAcpAgents({ probe })).resolves.toEqual([]);

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -353,7 +353,7 @@ describe("app server ipc", () => {
       backend: "all",
       fetchedAt: expect.any(Number),
       messagingBindingsByThreadKey: undefined,
-      queuedExecutionModesByThreadId: {},
+      queuedExecutionModesByThreadKey: {},
       threads: [
         expect.objectContaining({ source: "codex", id: "thread-1" }),
         expect.objectContaining({ source: "grok", id: "thread-1" }),

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1053,6 +1053,8 @@ function createKimiAcpRegistry(options?: {
   startPrompt?: KimiStartPrompt;
   overlayStore?: ReturnType<typeof createOverlayStoreMock>;
   codexClient?: MockBackendClient;
+  codexEnvironmentCommandRunner?: CodexEnvironmentCommandRunner;
+  gitDirectoryService?: unknown;
 }) {
   const acpBackendId = options?.acpBackendId ?? ("acp:kimi" as AcpBackendId);
   const sessions = options?.sessions ?? [];
@@ -1066,6 +1068,7 @@ function createKimiAcpRegistry(options?: {
     options?.startPrompt ??
     vi.fn(() => ({ sessionId, turnId: "turn-1" }));
   const acpClient = {
+    controlPromptReceiverMarker: true,
     initialize: vi.fn(async () => undefined),
     dispose: vi.fn(),
     startSession: vi.fn(async (params: {
@@ -1116,6 +1119,8 @@ function createKimiAcpRegistry(options?: {
     acpAgentStore: createAcpAgentStoreMock([createKimiAgentRecord(acpBackendId)]),
     acpSessionStore: createAcpSessionStoreMock(sessions),
     createAcpClient: () => acpClient,
+    codexEnvironmentCommandRunner: options?.codexEnvironmentCommandRunner,
+    gitDirectoryService: options?.gitDirectoryService as never,
   });
   return {
     acpBackendId,
@@ -2432,6 +2437,123 @@ describe("DesktopBackendRegistry", () => {
     expect(sessions[0]?.executionMode).toBe("default");
 
     await registry.close();
+  });
+
+  it("keeps the ACP client receiver when sending Kimi /yolo prompts", async () => {
+    const sendControlPrompt = vi.fn(function (
+      this: { controlPromptReceiverMarker?: boolean } | undefined,
+    ) {
+      if (this?.controlPromptReceiverMarker !== true) {
+        throw new Error("lost ACP client receiver");
+      }
+      return Promise.resolve({
+        text: "You only live once! All actions will be auto-approved.",
+      });
+    });
+    const { acpBackendId, registry } = createKimiAcpRegistry({
+      sendControlPrompt,
+    });
+
+    await expect(
+      registry.startThread({
+        backend: acpBackendId,
+        cwd: "/repo/project",
+        executionMode: "full-access",
+      }),
+    ).resolves.toMatchObject({
+      backend: acpBackendId,
+      threadId: "kimi-session-1",
+      executionMode: "full-access",
+    });
+
+    expect(sendControlPrompt).toHaveBeenCalledWith({
+      sessionId: "kimi-session-1",
+      prompt: "/yolo",
+    });
+
+    await registry.close();
+  });
+
+  it("materializes Kimi worktree launchpads without running Codex environment setup", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-kimi-launchpad-"));
+    const worktreePath = path.join(root, ".worktrees", "thread-1", "app");
+    await mkdir(path.join(root, ".codex", "environments"), { recursive: true });
+    await writeFile(
+      path.join(root, ".codex", "environments", "environment.toml"),
+      `
+version = 1
+name = "Repo Environment"
+
+[setup]
+script = "echo setup"
+`,
+      "utf8",
+    );
+    const commandRunner = vi.fn(async () => ({ output: "setup", exitCode: 0 }));
+    const recordCodexWorktreeOwnerThread = vi.fn(async () => {});
+    const { acpBackendId, registry, sendControlPrompt, sessions } =
+      createKimiAcpRegistry({
+        codexEnvironmentCommandRunner: commandRunner,
+        gitDirectoryService: {
+          prepareLaunchpadWorkspace: vi.fn(async () => ({
+            cwd: worktreePath,
+            repositoryPath: root,
+            workMode: "worktree" as const,
+          })),
+          recordCodexWorktreeOwnerThread,
+        },
+      });
+
+    try {
+      const response = await registry.materializeDirectoryLaunchpad({
+        directoryKey: `directory:${root}`,
+        launchpad: {
+          directoryKey: `directory:${root}`,
+          directoryKind: "directory",
+          directoryLabel: "app",
+          directoryPath: root,
+          backend: acpBackendId,
+          executionMode: "full-access",
+          prompt: "",
+          workMode: "worktree",
+          model: "kimi-for-coding",
+          codexEnvironmentId: "environment",
+          codexEnvironmentExecutionTarget: "local",
+          codexEnvironmentSetupEnabled: true,
+          createdAt: 1_000,
+          updatedAt: 2_000,
+        },
+      });
+
+      expect(response).toMatchObject({
+        backend: acpBackendId,
+        threadId: "kimi-session-1",
+        executionMode: "full-access",
+        workMode: "worktree",
+        linkedDirectory: {
+          id: root,
+          kind: "worktree",
+          label: "app",
+          path: root,
+          worktreePath,
+        },
+      });
+      expect(response.codexEnvironmentRuntime).toBeUndefined();
+      expect(response.codexEnvironmentStartupFailure).toBeUndefined();
+      expect(commandRunner).not.toHaveBeenCalled();
+      expect(recordCodexWorktreeOwnerThread).not.toHaveBeenCalled();
+      expect(sendControlPrompt).toHaveBeenCalledWith({
+        sessionId: "kimi-session-1",
+        prompt: "/yolo",
+      });
+      expect(sessions[0]).toMatchObject({
+        cwd: worktreePath,
+        executionMode: "full-access",
+      });
+    } finally {
+      await registry.close();
+      await rm(root, { recursive: true, force: true });
+    }
   });
 
   it("keeps new Kimi sessions at default when startup /yolo fails", async () => {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -5173,6 +5173,64 @@ command = "pnpm dev:messaging"
     }
   });
 
+  it("surfaces environment options on existing ACP threads", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-acp-thread-env-"));
+    await mkdir(path.join(root, ".codex", "environments"), { recursive: true });
+    await writeFile(
+      path.join(root, ".codex", "environments", "environment.toml"),
+      `
+version = 1
+name = "PwrAgnt"
+
+[[actions]]
+name = "Dev - Messaging"
+command = "pnpm dev:messaging"
+`,
+      "utf8",
+    );
+
+    const { acpBackendId, registry } = createKimiAcpRegistry({
+      sessions: [
+        {
+          backendId: "acp:kimi" as AcpBackendId,
+          sessionId: "kimi-session-1",
+          title: "Kimi thread",
+          titleSource: "explicit",
+          cwd: root,
+          createdAt: 1_000,
+          updatedAt: 2_000,
+          executionMode: "default",
+          status: "idle",
+        },
+      ],
+    });
+
+    try {
+      await expect(registry.listThreads({ backend: acpBackendId })).resolves.toEqual([
+        expect.objectContaining({
+          id: "kimi-session-1",
+          source: acpBackendId,
+          codexEnvironmentOptions: [
+            expect.objectContaining({
+              id: "environment",
+              name: "PwrAgnt",
+              actions: [
+                expect.objectContaining({
+                  id: "dev-messaging",
+                  name: "Dev - Messaging",
+                  command: "pnpm dev:messaging",
+                }),
+              ],
+            }),
+          ],
+        }),
+      ]);
+    } finally {
+      await registry.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("lets existing Codex threads select a local environment for command actions", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-thread-env-select-"));
     await mkdir(path.join(root, ".codex", "environments"), { recursive: true });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -4534,6 +4534,64 @@ script = "echo setup"
     await registry.close();
   });
 
+  it("keeps environment options available after switching a launchpad to ACP", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-acp-env-options-"));
+    await mkdir(path.join(root, ".codex", "environments"), { recursive: true });
+    await writeFile(
+      path.join(root, ".codex", "environments", "environment.toml"),
+      `
+version = 1
+name = "Repo Environment"
+
+[setup]
+script = "pnpm install"
+`,
+      "utf8",
+    );
+
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/start"] },
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    try {
+      await registry.ensureDirectoryLaunchpad({
+        directoryKey: `directory:${root}`,
+        directoryKind: "directory",
+        directoryLabel: "repo",
+        directoryPath: root,
+      });
+
+      const updated = await registry.updateDirectoryLaunchpad({
+        directoryKey: `directory:${root}`,
+        patch: {
+          backend: "acp:kimi" as AcpBackendId,
+          codexEnvironmentId: undefined,
+          codexEnvironmentExecutionTarget: undefined,
+          codexEnvironmentSetupEnabled: false,
+          codexEnvironmentActionId: undefined,
+        },
+      });
+
+      expect(updated.launchpad.backend).toBe("acp:kimi");
+      expect(updated.launchpad.codexEnvironmentOptions).toMatchObject([
+        {
+          id: "environment",
+          name: "Repo Environment",
+          setupScript: "pnpm install",
+        },
+      ]);
+    } finally {
+      await registry.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("refreshes empty saved directory drafts from current launchpad work mode defaults", async () => {
     const registry = new DesktopBackendRegistry({
       codexClient: new MockBackendClient({

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2474,7 +2474,7 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
-  it("materializes Kimi worktree launchpads without running Codex environment setup", async () => {
+  it("materializes Kimi worktree launchpads with local environment setup", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-kimi-launchpad-"));
     const worktreePath = path.join(root, ".worktrees", "thread-1", "app");
     await mkdir(path.join(root, ".codex", "environments"), { recursive: true });
@@ -2538,9 +2538,24 @@ script = "echo setup"
           worktreePath,
         },
       });
-      expect(response.codexEnvironmentRuntime).toBeUndefined();
+      expect(response.codexEnvironmentRuntime).toMatchObject({
+        environmentId: "environment",
+        environmentName: "Repo Environment",
+        executionTarget: "local",
+        cwd: worktreePath,
+        setupEnabled: true,
+        setupStatus: "completed",
+        setupCommand: "echo setup",
+        setupOutput: "setup",
+      });
       expect(response.codexEnvironmentStartupFailure).toBeUndefined();
-      expect(commandRunner).not.toHaveBeenCalled();
+      expect(commandRunner).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cwd: worktreePath,
+          command: "echo setup",
+          mode: "wait",
+        }),
+      );
       expect(recordCodexWorktreeOwnerThread).not.toHaveBeenCalled();
       expect(sendControlPrompt).toHaveBeenCalledWith({
         sessionId: "kimi-session-1",

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 import { describe, expect, it, vi } from "vitest";
+import { buildThreadIdentityKey } from "@pwragent/shared";
 import type {
   AcpBackendId,
   AgentEvent,
@@ -1001,6 +1002,128 @@ function createAcpSessionStoreMock(records: AcpSessionMetadata[]) {
         records[index] = metadata;
       }
     },
+  };
+}
+
+function createKimiAgentRecord(
+  backendId: AcpBackendId = "acp:kimi" as AcpBackendId,
+): AcpInstalledAgentRecord {
+  return {
+    backendId,
+    registryId: "kimi",
+    name: "Kimi Code CLI",
+    version: "1.44.0",
+    distributionKind: "local",
+    distributionSource: "kimi acp",
+    installStatus: "installed",
+    authStatus: "not-required",
+    verificationStatus: "not-applicable",
+    allowlistRuleId: "local-kimi-cli",
+    installedAt: 1000,
+    updatedAt: 2000,
+    launchDescriptor: {
+      backendId,
+      registryId: "kimi",
+      distributionKind: "local",
+      command: "kimi",
+      args: ["acp"],
+      env: {},
+    },
+  };
+}
+
+type KimiSendControlPrompt = (params: {
+  sessionId: string;
+  prompt: string;
+}) => Promise<{ text: string }>;
+
+type KimiStartPrompt = (params: {
+  sessionId: string;
+  prompt: string;
+  promptContent?: unknown[];
+  parts?: unknown[];
+  turnId?: string;
+}) => { sessionId: string; turnId: string };
+
+function createKimiAcpRegistry(options?: {
+  acpBackendId?: AcpBackendId;
+  sessionId?: string;
+  sessions?: AcpSessionMetadata[];
+  sendControlPrompt?: KimiSendControlPrompt;
+  startPrompt?: KimiStartPrompt;
+  overlayStore?: ReturnType<typeof createOverlayStoreMock>;
+  codexClient?: MockBackendClient;
+}) {
+  const acpBackendId = options?.acpBackendId ?? ("acp:kimi" as AcpBackendId);
+  const sessions = options?.sessions ?? [];
+  const sessionId = options?.sessionId ?? "kimi-session-1";
+  const sendControlPrompt: KimiSendControlPrompt =
+    options?.sendControlPrompt ??
+    vi.fn(async () => ({
+      text: "You only live once! All actions will be auto-approved.",
+    }));
+  const startPrompt: KimiStartPrompt =
+    options?.startPrompt ??
+    vi.fn(() => ({ sessionId, turnId: "turn-1" }));
+  const acpClient = {
+    initialize: vi.fn(async () => undefined),
+    dispose: vi.fn(),
+    startSession: vi.fn(async (params: {
+      cwd?: string;
+      executionMode: "default" | "full-access";
+    }) => {
+      const metadata: AcpSessionMetadata = {
+        backendId: acpBackendId,
+        sessionId,
+        title: "ACP session",
+        cwd: params.cwd,
+        createdAt: 1000,
+        updatedAt: 1000,
+        executionMode: params.executionMode,
+        status: "idle",
+      };
+      sessions.push(metadata);
+      return metadata;
+    }),
+    startPrompt,
+    sendControlPrompt,
+    ensureSession: vi.fn(async () => undefined),
+    loadSession: vi.fn(async (): Promise<AppServerThreadReplay> => ({
+      entries: [],
+      messages: [],
+      pagination: {
+        supportsPagination: false,
+        hasPreviousPage: false,
+      },
+      threadStatus: "idle",
+    })),
+    refreshSession: vi.fn(async () => undefined),
+    cancelSession: vi.fn(),
+    readReplay: vi.fn((): AppServerThreadReplay => ({
+      entries: [],
+      messages: [],
+      pagination: {
+        supportsPagination: false,
+        hasPreviousPage: false,
+      },
+      threadStatus: "idle",
+    })),
+  };
+  const registry = new DesktopBackendRegistry({
+    codexClient: options?.codexClient ?? new MockBackendClient({ threads: [] }),
+    grokClient: new MockBackendClient({ threads: [] }),
+    overlayStore: options?.overlayStore ?? createOverlayStoreMock(),
+    acpAgentStore: createAcpAgentStoreMock([createKimiAgentRecord(acpBackendId)]),
+    acpSessionStore: createAcpSessionStoreMock(sessions),
+    createAcpClient: () => acpClient,
+  });
+  return {
+    acpBackendId,
+    acpClient,
+    registry,
+    sendControlPrompt,
+    sessions,
+    startPrompt,
   };
 }
 
@@ -2144,7 +2267,14 @@ describe("DesktopBackendRegistry", () => {
   it("runs Kimi ACP execution mode changes through slash control prompts", async () => {
     const sessions: AcpSessionMetadata[] = [];
     const acpBackendId = "acp:kimi" as AcpBackendId;
-    const sendControlPrompt = vi.fn(async () => undefined);
+    const sendControlPrompt = vi
+      .fn()
+      .mockResolvedValueOnce({
+        text: "You only live once! All actions will be auto-approved.",
+      })
+      .mockResolvedValueOnce({
+        text: "You only die once! Actions will require approval.",
+      });
     const acpClient = {
       initialize: vi.fn(async () => undefined),
       dispose: vi.fn(),
@@ -2264,6 +2394,246 @@ describe("DesktopBackendRegistry", () => {
       prompt: "/yolo",
     });
     expect(sessions[0]?.executionMode).toBe("default");
+
+    await registry.close();
+  });
+
+  it("does not persist Kimi execution mode when /yolo confirms the wrong state", async () => {
+    const { acpBackendId, registry, sendControlPrompt, sessions } =
+      createKimiAcpRegistry({
+        sessions: [
+          {
+            backendId: "acp:kimi" as AcpBackendId,
+            sessionId: "kimi-session-1",
+            title: "ACP session",
+            createdAt: 1000,
+            updatedAt: 1000,
+            executionMode: "default",
+            status: "idle",
+          },
+        ],
+        sendControlPrompt: vi.fn(async () => ({
+          text: "You only die once! Actions will require approval.",
+        })),
+      });
+
+    await expect(
+      registry.setThreadExecutionMode({
+        backend: acpBackendId,
+        threadId: "kimi-session-1",
+        executionMode: "full-access",
+      }),
+    ).rejects.toThrow(/did not confirm Full Access/);
+
+    expect(sendControlPrompt).toHaveBeenCalledWith({
+      sessionId: "kimi-session-1",
+      prompt: "/yolo",
+    });
+    expect(sessions[0]?.executionMode).toBe("default");
+
+    await registry.close();
+  });
+
+  it("keeps new Kimi sessions at default when startup /yolo fails", async () => {
+    const { acpBackendId, registry, sessions } = createKimiAcpRegistry({
+      sendControlPrompt: vi.fn(async () => {
+        throw new Error("control prompt failed");
+      }),
+    });
+
+    await expect(
+      registry.startThread({
+        backend: acpBackendId,
+        cwd: "/repo/project",
+        executionMode: "full-access",
+      }),
+    ).rejects.toThrow("control prompt failed");
+
+    expect(sessions[0]?.executionMode).toBe("default");
+
+    await registry.close();
+  });
+
+  it("queues Kimi ACP execution mode changes during active turns and flushes once", async () => {
+    const events: AgentEvent[] = [];
+    const { acpBackendId, registry, sendControlPrompt, sessions } =
+      createKimiAcpRegistry({
+        sessions: [
+          {
+            backendId: "acp:kimi" as AcpBackendId,
+            sessionId: "kimi-session-1",
+            title: "ACP session",
+            createdAt: 1000,
+            updatedAt: 1000,
+            executionMode: "default",
+            status: "idle",
+          },
+        ],
+        sendControlPrompt: vi.fn(async () => ({
+          text: "You only live once! All actions will be auto-approved.",
+        })),
+      });
+    registry.onEvent((event) => {
+      events.push(event);
+    });
+
+    await registry.startTurn({
+      backend: acpBackendId,
+      threadId: "kimi-session-1",
+      input: [{ type: "text", text: "work" }],
+    });
+
+    await expect(
+      registry.setThreadExecutionMode({
+        backend: acpBackendId,
+        threadId: "kimi-session-1",
+        executionMode: "full-access",
+      }),
+    ).resolves.toEqual({
+      backend: acpBackendId,
+      threadId: "kimi-session-1",
+      executionMode: "full-access",
+    });
+    expect(sendControlPrompt).not.toHaveBeenCalled();
+
+    await (registry as unknown as { emit(event: AgentEvent): Promise<void> }).emit({
+      backend: acpBackendId,
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "kimi-session-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            output: [],
+          },
+        },
+      },
+    });
+    await vi.waitFor(() => {
+      expect(sendControlPrompt).toHaveBeenCalledTimes(1);
+    });
+
+    expect(sessions[0]?.executionMode).toBe("full-access");
+    const methods = events.map((event) => event.notification.method);
+    expect(methods).toContain("thread/executionMode/queued");
+    expect(methods).toContain("thread/executionMode/updated");
+    expect(methods).toContain("thread/executionMode/queueCleared");
+
+    await registry.close();
+  });
+
+  it("serializes Kimi control prompts before starting the next ACP turn", async () => {
+    const controlPrompt = createDeferred<{ text: string }>();
+    const startPrompt = vi.fn(() => ({
+      sessionId: "kimi-session-1",
+      turnId: "turn-1",
+    }));
+    const sendControlPrompt = vi.fn(() => controlPrompt.promise);
+    const { acpBackendId, registry } = createKimiAcpRegistry({
+      sessions: [
+        {
+          backendId: "acp:kimi" as AcpBackendId,
+          sessionId: "kimi-session-1",
+          title: "ACP session",
+          createdAt: 1000,
+          updatedAt: 1000,
+          executionMode: "default",
+          status: "idle",
+        },
+      ],
+      sendControlPrompt,
+      startPrompt,
+    });
+
+    const modeChange = registry.setThreadExecutionMode({
+      backend: acpBackendId,
+      threadId: "kimi-session-1",
+      executionMode: "full-access",
+    });
+    await vi.waitFor(() => {
+      expect(sendControlPrompt).toHaveBeenCalledTimes(1);
+    });
+    const turnStart = registry.startTurn({
+      backend: acpBackendId,
+      threadId: "kimi-session-1",
+      input: [{ type: "text", text: "after mode change" }],
+    });
+    await flushAsync();
+    expect(startPrompt).not.toHaveBeenCalled();
+
+    controlPrompt.resolve({
+      text: "You only live once! All actions will be auto-approved.",
+    });
+    await expect(modeChange).resolves.toMatchObject({
+      backend: acpBackendId,
+      executionMode: "full-access",
+    });
+    await expect(turnStart).resolves.toMatchObject({
+      backend: acpBackendId,
+      threadId: "kimi-session-1",
+      turnId: "turn-1",
+    });
+    expect(startPrompt).toHaveBeenCalledTimes(1);
+
+    await registry.close();
+  });
+
+  it("isolates queued execution modes by backend when thread ids collide", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/resume"] },
+    });
+    const { acpBackendId, registry } = createKimiAcpRegistry({
+      codexClient,
+      sessions: [
+        {
+          backendId: "acp:kimi" as AcpBackendId,
+          sessionId: "same-thread",
+          title: "ACP session",
+          createdAt: 1000,
+          updatedAt: 1000,
+          executionMode: "default",
+          status: "idle",
+        },
+      ],
+    });
+
+    await registry.queueThreadExecutionMode({
+      backend: "codex",
+      threadId: "same-thread",
+      executionMode: "full-access",
+    });
+    await registry.queueThreadExecutionMode({
+      backend: acpBackendId,
+      threadId: "same-thread",
+      executionMode: "full-access",
+    });
+
+    expect(registry.getQueuedExecutionModesSnapshot()).toMatchObject({
+      [buildThreadIdentityKey("codex", "same-thread")]: {
+        mode: "full-access",
+      },
+      [buildThreadIdentityKey(acpBackendId, "same-thread")]: {
+        mode: "full-access",
+      },
+    });
+
+    await registry.cancelThreadExecutionModeQueue({
+      backend: "codex",
+      threadId: "same-thread",
+    });
+
+    expect(registry.getQueuedExecutionModesSnapshot()).toMatchObject({
+      [buildThreadIdentityKey(acpBackendId, "same-thread")]: {
+        mode: "full-access",
+      },
+    });
+    expect(
+      registry.getQueuedExecutionModesSnapshot()[
+        buildThreadIdentityKey("codex", "same-thread")
+      ],
+    ).toBeUndefined();
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2141,6 +2141,133 @@ describe("DesktopBackendRegistry", () => {
     expect(acpClient.dispose).toHaveBeenCalledTimes(1);
   });
 
+  it("runs Kimi ACP execution mode changes through slash control prompts", async () => {
+    const sessions: AcpSessionMetadata[] = [];
+    const acpBackendId = "acp:kimi" as AcpBackendId;
+    const sendControlPrompt = vi.fn(async () => undefined);
+    const acpClient = {
+      initialize: vi.fn(async () => undefined),
+      dispose: vi.fn(),
+      startSession: vi.fn(async (params: {
+        cwd?: string;
+        executionMode: "default" | "full-access";
+      }) => {
+        const metadata: AcpSessionMetadata = {
+          backendId: acpBackendId,
+          sessionId: "kimi-session-1",
+          title: "ACP session",
+          cwd: params.cwd,
+          createdAt: 1000,
+          updatedAt: 1000,
+          executionMode: params.executionMode,
+          status: "idle",
+        };
+        sessions.push(metadata);
+        return metadata;
+      }),
+      startPrompt: vi.fn(),
+      sendControlPrompt,
+      ensureSession: vi.fn(async () => undefined),
+      loadSession: vi.fn(async (): Promise<AppServerThreadReplay> => ({
+        entries: [],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+        threadStatus: "idle",
+      })),
+      refreshSession: vi.fn(async () => undefined),
+      cancelSession: vi.fn(),
+      readReplay: vi.fn((): AppServerThreadReplay => ({
+        entries: [],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+        threadStatus: "idle",
+      })),
+    };
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      grokClient: new MockBackendClient({ threads: [] }),
+      overlayStore: createOverlayStoreMock(),
+      acpAgentStore: createAcpAgentStoreMock([
+        {
+          backendId: acpBackendId,
+          registryId: "kimi",
+          name: "Kimi Code CLI",
+          version: "1.44.0",
+          distributionKind: "local",
+          distributionSource: "kimi acp",
+          installStatus: "installed",
+          authStatus: "not-required",
+          verificationStatus: "not-applicable",
+          allowlistRuleId: "local-kimi-cli",
+          installedAt: 1000,
+          updatedAt: 2000,
+          launchDescriptor: {
+            backendId: acpBackendId,
+            registryId: "kimi",
+            distributionKind: "local",
+            command: "kimi",
+            args: ["acp"],
+            env: {},
+          },
+        },
+      ]),
+      acpSessionStore: createAcpSessionStoreMock(sessions),
+      createAcpClient: () => acpClient,
+    });
+
+    const backends = await registry.listBackends({ includeUnavailable: true });
+    expect(backends.backends.find((backend) => backend.kind === acpBackendId))
+      .toMatchObject({
+        executionModes: [
+          { mode: "default", available: true },
+          { mode: "full-access", available: true },
+        ],
+      });
+
+    await expect(
+      registry.startThread({
+        backend: acpBackendId,
+        cwd: "/repo/project",
+        executionMode: "full-access",
+      }),
+    ).resolves.toMatchObject({
+      backend: acpBackendId,
+      threadId: "kimi-session-1",
+      executionMode: "full-access",
+    });
+
+    expect(sendControlPrompt).toHaveBeenCalledWith({
+      sessionId: "kimi-session-1",
+      prompt: "/yolo",
+    });
+
+    sendControlPrompt.mockClear();
+    await expect(
+      registry.setThreadExecutionMode({
+        backend: acpBackendId,
+        threadId: "kimi-session-1",
+        executionMode: "default",
+      }),
+    ).resolves.toEqual({
+      backend: acpBackendId,
+      threadId: "kimi-session-1",
+      executionMode: "default",
+    });
+    expect(sendControlPrompt).toHaveBeenCalledWith({
+      sessionId: "kimi-session-1",
+      prompt: "/yolo",
+    });
+    expect(sessions[0]?.executionMode).toBe("default");
+
+    await registry.close();
+  });
+
   it("reads persisted ACP sessions locally and refreshes the agent in the background", async () => {
     const acpBackendId = "acp:gemini" as AcpBackendId;
     const localReplay: AppServerThreadReplay = {

--- a/apps/desktop/src/main/__tests__/codex-environment-config.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-environment-config.test.ts
@@ -2,9 +2,11 @@ import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import type { NavigationLaunchpadDraft } from "@pwragent/shared";
 import {
   listCodexEnvironmentOptions,
   parseCodexEnvironmentToml,
+  withCodexEnvironmentOptions,
 } from "../app-server/codex-environment-config";
 
 describe("codex environment config", () => {
@@ -115,5 +117,40 @@ command = "pnpm dev:alt"
         command: "pnpm dev:alt",
       },
     ]);
+  });
+
+  it("hydrates environment options for ACP launchpads", () => {
+    const launchpad: NavigationLaunchpadDraft = {
+      directoryKey: "directory:/repo",
+      directoryKind: "directory",
+      directoryLabel: "repo",
+      directoryPath: "/repo",
+      backend: "acp:kimi",
+      executionMode: "default",
+      prompt: "",
+      workMode: "local",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    expect(
+      withCodexEnvironmentOptions(launchpad, [
+        {
+          id: "environment",
+          name: "Repo Environment",
+          sourcePath: "/repo/.codex/environments/environment.toml",
+          setupScript: "pnpm install",
+          actions: [],
+        },
+      ]),
+    ).toMatchObject({
+      backend: "acp:kimi",
+      codexEnvironmentOptions: [
+        {
+          id: "environment",
+          name: "Repo Environment",
+        },
+      ],
+    });
   });
 });

--- a/apps/desktop/src/main/acp/acp-agent-capabilities.ts
+++ b/apps/desktop/src/main/acp/acp-agent-capabilities.ts
@@ -10,6 +10,9 @@ const ACP_AGENT_CAPABILITY_CATALOG: Record<string, AcpAgentCapabilities> = {
   gemini: {
     liveWorkspaceHandoff: false,
   },
+  kimi: {
+    liveWorkspaceHandoff: false,
+  },
 };
 
 export function acpAgentCapabilitiesForRegistryId(

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -24,6 +24,7 @@ import type {
   AcpSessionMetadata,
   AcpSessionStore,
 } from "./acp-session-store.js";
+import { appendCoalescedTranscriptUpdate } from "./acp-session-store.js";
 import type { JsonRpcId } from "../codex-app-server/json-rpc.js";
 
 export type AcpJsonRpcTransport = {
@@ -43,6 +44,7 @@ export type AcpJsonRpcTransport = {
 };
 
 const ACP_PROTOCOL_VERSION = 1;
+const DEFAULT_TRANSCRIPT_PERSISTENCE_FLUSH_DELAY_MS = 1000;
 
 export type AcpPromptContentBlock =
   | { type: "text"; text: string }
@@ -84,6 +86,7 @@ export type AcpAgentClientOptions = {
   onRequest?: (
     request: AppServerPendingRequestNotification
   ) => Promise<unknown> | unknown;
+  transcriptPersistenceFlushDelayMs?: number;
 };
 
 export class AcpAgentClient {
@@ -106,6 +109,15 @@ export class AcpAgentClient {
   private readonly appSessionIdsByAgentSessionId = new Map<string, string>();
   private readonly now: () => number;
   private readonly approvalRequesterName: string;
+  private readonly transcriptPersistenceFlushDelayMs: number;
+  private readonly pendingTranscriptUpdates = new Map<
+    string,
+    AcpPersistedTranscriptUpdate[]
+  >();
+  private readonly transcriptPersistenceTimers = new Map<
+    string,
+    ReturnType<typeof setTimeout>
+  >();
   private unsubscribe?: () => void;
   private unsubscribeRequest?: () => void;
   private runtimeCapabilities?: BackendAcpRuntimeCapabilities;
@@ -114,6 +126,9 @@ export class AcpAgentClient {
     this.now = options.now ?? Date.now;
     this.runtimeCapabilities = options.initialRuntimeCapabilities;
     this.approvalRequesterName = approvalRequesterNameForOptions(options);
+    this.transcriptPersistenceFlushDelayMs =
+      options.transcriptPersistenceFlushDelayMs ??
+      DEFAULT_TRANSCRIPT_PERSISTENCE_FLUSH_DELAY_MS;
   }
 
   async initialize(): Promise<void> {
@@ -154,6 +169,7 @@ export class AcpAgentClient {
     this.unsubscribe = undefined;
     this.unsubscribeRequest?.();
     this.unsubscribeRequest = undefined;
+    this.flushAllPendingTranscriptUpdates();
     this.agentSessionIdsByAppSessionId.clear();
     this.appSessionIdsByAgentSessionId.clear();
     this.loadedSessionCwds.clear();
@@ -533,10 +549,14 @@ export class AcpAgentClient {
       update,
       receivedAt,
     } satisfies AcpSessionUpdate);
-    this.persistTranscriptUpdate(sessionId, {
-      receivedAt,
-      update,
-    });
+    this.persistTranscriptUpdate(
+      sessionId,
+      {
+        receivedAt,
+        update,
+      },
+      { flush: "deferred" },
+    );
     void this.notifySessionUpdate({
       sessionId,
       replay,
@@ -669,15 +689,58 @@ export class AcpAgentClient {
   private persistTranscriptUpdate(
     sessionId: string,
     update: AcpPersistedTranscriptUpdate,
+    options?: { flush?: "deferred" | "immediate" },
   ): void {
+    const pending = this.pendingTranscriptUpdates.get(sessionId) ?? [];
+    appendCoalescedTranscriptUpdate(pending, update);
+    this.pendingTranscriptUpdates.set(sessionId, pending);
+    if (
+      options?.flush !== "deferred" ||
+      this.transcriptPersistenceFlushDelayMs <= 0
+    ) {
+      this.flushPendingTranscriptUpdates(sessionId);
+      return;
+    }
+    if (this.transcriptPersistenceTimers.has(sessionId)) {
+      return;
+    }
+    const timer = setTimeout(() => {
+      this.transcriptPersistenceTimers.delete(sessionId);
+      this.flushPendingTranscriptUpdates(sessionId);
+    }, this.transcriptPersistenceFlushDelayMs);
+    timer.unref?.();
+    this.transcriptPersistenceTimers.set(sessionId, timer);
+  }
+
+  private flushAllPendingTranscriptUpdates(): void {
+    for (const sessionId of [...this.pendingTranscriptUpdates.keys()]) {
+      this.flushPendingTranscriptUpdates(sessionId);
+    }
+  }
+
+  private flushPendingTranscriptUpdates(sessionId: string): void {
+    const timer = this.transcriptPersistenceTimers.get(sessionId);
+    if (timer) {
+      clearTimeout(timer);
+      this.transcriptPersistenceTimers.delete(sessionId);
+    }
+    const pending = this.pendingTranscriptUpdates.get(sessionId);
+    if (!pending?.length) {
+      return;
+    }
+    this.pendingTranscriptUpdates.delete(sessionId);
     const metadata = this.options.store.getSession(this.options.backendId, sessionId);
     if (!metadata) {
       return;
     }
+    const updatedAt = pending.reduce(
+      (latest, item) => Math.max(latest, item.receivedAt),
+      metadata.updatedAt,
+    );
     this.options.store.upsertSession({
       ...metadata,
-      updatedAt: Math.max(metadata.updatedAt, update.receivedAt),
-      transcriptUpdates: [...(metadata.transcriptUpdates ?? []), update],
+      updatedAt,
+      transcriptUpdates: [...(metadata.transcriptUpdates ?? []), ...pending],
     });
   }
 

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -55,6 +55,7 @@ type AcpSessionStoreLike = Pick<
 
 export type AcpAgentClientOptions = {
   backendId: AcpBackendId;
+  agentDisplayName?: string;
   initialRuntimeCapabilities?: BackendAcpRuntimeCapabilities;
   store: AcpSessionStoreLike;
   transport: AcpJsonRpcTransport;
@@ -101,6 +102,7 @@ export class AcpAgentClient {
   private readonly agentSessionIdsByAppSessionId = new Map<string, string>();
   private readonly appSessionIdsByAgentSessionId = new Map<string, string>();
   private readonly now: () => number;
+  private readonly approvalRequesterName: string;
   private unsubscribe?: () => void;
   private unsubscribeRequest?: () => void;
   private runtimeCapabilities?: BackendAcpRuntimeCapabilities;
@@ -108,6 +110,7 @@ export class AcpAgentClient {
   constructor(private readonly options: AcpAgentClientOptions) {
     this.now = options.now ?? Date.now;
     this.runtimeCapabilities = options.initialRuntimeCapabilities;
+    this.approvalRequesterName = approvalRequesterNameForOptions(options);
   }
 
   async initialize(): Promise<void> {
@@ -579,8 +582,8 @@ export class AcpAgentClient {
         threadId: sessionId,
         ...(activeTurn?.turnId ? { turnId: activeTurn.turnId } : {}),
         requestId,
-        prompt: permissionPrompt(title, toolCall),
-        reason: permissionPrompt(title, toolCall),
+        prompt: permissionPrompt(this.approvalRequesterName, title, toolCall),
+        reason: permissionPrompt(this.approvalRequesterName, title, toolCall),
         command: title,
         displayCommand: title,
         acpMethod: "session/request_permission",
@@ -987,13 +990,36 @@ function readPermissionOptions(value: unknown): AcpPermissionOption[] {
   });
 }
 
-function permissionPrompt(title: string, toolCall: Record<string, unknown>): string {
+function approvalRequesterNameForOptions(options: Pick<
+  AcpAgentClientOptions,
+  "agentDisplayName" | "backendId"
+>): string {
+  const configured = options.agentDisplayName?.trim();
+  if (configured) {
+    return configured;
+  }
+  const backendName = options.backendId
+    .replace(/^acp:/, "")
+    .split(/[-_:]+/)
+    .map((part) => (part ? part[0].toUpperCase() + part.slice(1) : part))
+    .join(" ")
+    .trim();
+  return backendName || "ACP agent";
+}
+
+function permissionPrompt(
+  requesterName: string,
+  title: string,
+  toolCall: Record<string, unknown>,
+): string {
   const contentText = readToolCallText(toolCall.content);
   if (contentText) {
     return contentText;
   }
   const kind = typeof toolCall.kind === "string" ? toolCall.kind : undefined;
-  return kind ? `Gemini wants to run ${kind}: ${title}` : `Gemini wants to run ${title}`;
+  return kind
+    ? `${requesterName} wants to run ${kind}: ${title}`
+    : `${requesterName} wants to run ${title}`;
 }
 
 function readToolCallText(value: unknown): string | undefined {

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -96,6 +96,7 @@ export class AcpAgentClient {
   >();
   private readonly loadedSessionCwds = new Map<string, string | undefined>();
   private readonly suppressLoadReplaySessions = new Set<string>();
+  private readonly suppressedControlPromptSessions = new Set<string>();
   private readonly hydratedTranscriptSessions = new Set<string>();
   private readonly agentSessionIdsByAppSessionId = new Map<string, string>();
   private readonly appSessionIdsByAgentSessionId = new Map<string, string>();
@@ -373,6 +374,22 @@ export class AcpAgentClient {
     });
   }
 
+  async sendControlPrompt(params: {
+    sessionId: string;
+    prompt: string;
+  }): Promise<void> {
+    const protocolSessionId = this.protocolSessionIdFor(params.sessionId);
+    this.suppressedControlPromptSessions.add(protocolSessionId);
+    try {
+      await this.options.transport.request("session/prompt", {
+        sessionId: protocolSessionId,
+        prompt: textPrompt(params.prompt),
+      });
+    } finally {
+      this.suppressedControlPromptSessions.delete(protocolSessionId);
+    }
+  }
+
   async setRuntimeOption(params: {
     sessionId: string;
     source: BackendAcpRuntimeOptionSource;
@@ -465,6 +482,9 @@ export class AcpAgentClient {
       typeof params.sessionId === "string" ? params.sessionId : undefined;
     const update = asRecord(params.update);
     if (!protocolSessionId || !update) {
+      return;
+    }
+    if (this.suppressedControlPromptSessions.has(protocolSessionId)) {
       return;
     }
     const sessionId = this.appSessionIdFor(protocolSessionId);

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -97,7 +97,10 @@ export class AcpAgentClient {
   >();
   private readonly loadedSessionCwds = new Map<string, string | undefined>();
   private readonly suppressLoadReplaySessions = new Set<string>();
-  private readonly suppressedControlPromptSessions = new Set<string>();
+  private readonly suppressedControlPromptSessions = new Map<
+    string,
+    { textChunks: string[] }
+  >();
   private readonly hydratedTranscriptSessions = new Set<string>();
   private readonly agentSessionIdsByAppSessionId = new Map<string, string>();
   private readonly appSessionIdsByAgentSessionId = new Map<string, string>();
@@ -380,14 +383,16 @@ export class AcpAgentClient {
   async sendControlPrompt(params: {
     sessionId: string;
     prompt: string;
-  }): Promise<void> {
+  }): Promise<{ text: string }> {
     const protocolSessionId = this.protocolSessionIdFor(params.sessionId);
-    this.suppressedControlPromptSessions.add(protocolSessionId);
+    const suppression = { textChunks: [] };
+    this.suppressedControlPromptSessions.set(protocolSessionId, suppression);
     try {
       await this.options.transport.request("session/prompt", {
         sessionId: protocolSessionId,
         prompt: textPrompt(params.prompt),
       });
+      return { text: suppression.textChunks.join("\n").trim() };
     } finally {
       this.suppressedControlPromptSessions.delete(protocolSessionId);
     }
@@ -487,7 +492,13 @@ export class AcpAgentClient {
     if (!protocolSessionId || !update) {
       return;
     }
-    if (this.suppressedControlPromptSessions.has(protocolSessionId)) {
+    const suppressedControlPrompt =
+      this.suppressedControlPromptSessions.get(protocolSessionId);
+    if (suppressedControlPrompt) {
+      const text = readUpdateText(update);
+      if (text) {
+        suppressedControlPrompt.textChunks.push(text);
+      }
       return;
     }
     const sessionId = this.appSessionIdFor(protocolSessionId);

--- a/apps/desktop/src/main/acp/acp-local-discovery.ts
+++ b/apps/desktop/src/main/acp/acp-local-discovery.ts
@@ -21,8 +21,13 @@ export async function discoverLocalAcpAgents(options?: {
   probe?: LocalAcpAgentProbe;
   now?: () => number;
 }): Promise<AcpInstalledAgentRecord[]> {
-  const gemini = await discoverLocalGemini(options);
-  return gemini ? [gemini] : [];
+  const discovered = await Promise.all([
+    discoverLocalGemini(options),
+    discoverLocalKimi(options),
+  ]);
+  return discovered.filter((agent): agent is AcpInstalledAgentRecord =>
+    Boolean(agent)
+  );
 }
 
 async function discoverLocalGemini(options?: {
@@ -82,6 +87,63 @@ async function discoverLocalGemini(options?: {
   };
 }
 
+async function discoverLocalKimi(options?: {
+  probe?: LocalAcpAgentProbe;
+  now?: () => number;
+}): Promise<AcpInstalledAgentRecord | undefined> {
+  const probe = options?.probe ?? defaultProbe;
+  const [versionResult, acpHelpResult] = await Promise.all([
+    probeCommand(probe, "kimi", ["--version"]),
+    probeCommand(probe, "kimi", ["acp", "--help"]),
+  ]);
+  if (!versionResult || !acpHelpResult) {
+    return undefined;
+  }
+
+  const acpHelpText = resultText(acpHelpResult);
+  if (!/\bACP server\b/i.test(acpHelpText)) {
+    return undefined;
+  }
+
+  const now = options?.now?.() ?? Date.now();
+  const backendId = "acp:kimi" as AcpBackendId;
+  const version = parseCliVersion(resultText(versionResult));
+  return {
+    backendId,
+    registryId: "kimi",
+    name: "Kimi Code CLI",
+    version,
+    distributionKind: "local",
+    distributionSource: "kimi acp",
+    installStatus: "installed",
+    authStatus: "not-required",
+    verificationStatus: "not-applicable",
+    allowlistRuleId: "local-kimi-cli",
+    installedAt: now,
+    updatedAt: now,
+    capabilities: acpAgentCapabilitiesForRegistryId("kimi"),
+    launchDescriptor: normalizeAcpLaunchDescriptor({
+      backendId,
+      registryId: "kimi",
+      distributionKind: "local",
+      command: "kimi",
+      args: ["acp"],
+      env: {},
+    }),
+    registryAgent: {
+      id: "kimi",
+      backendId,
+      name: "Kimi Code CLI",
+      version,
+      authors: ["Moonshot AI"],
+      distributions: [],
+      distributionKinds: ["local"],
+      auth: { required: false, methods: ["agent-managed"] },
+      raw: { source: "local-cli" },
+    },
+  };
+}
+
 async function defaultProbe(
   command: string,
   args: string[],
@@ -112,6 +174,10 @@ function resultText(result: LocalAcpProbeResult): string {
 }
 
 function parseGeminiVersion(output: string): string | undefined {
+  return parseCliVersion(output);
+}
+
+function parseCliVersion(output: string): string | undefined {
   const trimmed = output.trim();
   if (!trimmed) {
     return undefined;

--- a/apps/desktop/src/main/acp/acp-session-store.ts
+++ b/apps/desktop/src/main/acp/acp-session-store.ts
@@ -37,6 +37,7 @@ export class AcpSessionStore {
   constructor(private readonly stateDb: StateDb) {}
 
   upsertSession(metadata: AcpSessionMetadata): void {
+    const compactedMetadata = compactAcpSessionMetadata(metadata);
     this.stateDb.raw
       .prepare(
         `INSERT OR REPLACE INTO acp_sessions(
@@ -49,11 +50,11 @@ export class AcpSessionStore {
          VALUES (?, ?, ?, ?, ?)`,
       )
       .run(
-        metadata.backendId,
-        metadata.sessionId,
-        metadata.createdAt,
-        metadata.updatedAt,
-        JSON.stringify(metadata),
+        compactedMetadata.backendId,
+        compactedMetadata.sessionId,
+        compactedMetadata.createdAt,
+        compactedMetadata.updatedAt,
+        JSON.stringify(compactedMetadata),
       );
   }
 
@@ -91,6 +92,120 @@ export class AcpSessionStore {
     const parsed = row ? parseJson(row.payload) : undefined;
     return isSessionMetadata(parsed) ? parsed : undefined;
   }
+}
+
+function compactAcpSessionMetadata(metadata: AcpSessionMetadata): AcpSessionMetadata {
+  if (!metadata.transcriptUpdates?.length) {
+    return metadata;
+  }
+  return {
+    ...metadata,
+    transcriptUpdates: compactAcpTranscriptUpdates(metadata.transcriptUpdates),
+  };
+}
+
+export function compactAcpTranscriptUpdates(
+  updates: AcpPersistedTranscriptUpdate[],
+): AcpPersistedTranscriptUpdate[] {
+  const compacted: AcpPersistedTranscriptUpdate[] = [];
+  for (const update of updates) {
+    appendCoalescedTranscriptUpdate(compacted, update);
+  }
+  return compacted;
+}
+
+export function appendCoalescedTranscriptUpdate(
+  updates: AcpPersistedTranscriptUpdate[],
+  next: AcpPersistedTranscriptUpdate,
+): void {
+  const previous = updates.at(-1);
+  const coalesced = previous ? coalesceTranscriptUpdate(previous, next) : undefined;
+  if (coalesced) {
+    updates[updates.length - 1] = coalesced;
+    return;
+  }
+  updates.push(next);
+}
+
+function coalesceTranscriptUpdate(
+  previous: AcpPersistedTranscriptUpdate,
+  next: AcpPersistedTranscriptUpdate,
+): AcpPersistedTranscriptUpdate | undefined {
+  const previousKind = readUpdateKind(previous.update);
+  const nextKind = readUpdateKind(next.update);
+  if (
+    previousKind !== nextKind ||
+    !isCoalescibleTranscriptChunkKind(previousKind)
+  ) {
+    return undefined;
+  }
+  if (messageIdentity(previous.update) !== messageIdentity(next.update)) {
+    return undefined;
+  }
+  const previousText = readUpdateText(previous.update);
+  const nextText = readUpdateText(next.update);
+  if (previousText === undefined || nextText === undefined) {
+    return undefined;
+  }
+  return {
+    receivedAt: next.receivedAt,
+    update: writeUpdateText(previous.update, `${previousText}${nextText}`),
+  };
+}
+
+function readUpdateKind(update: Record<string, unknown>): string | undefined {
+  const kind = update.sessionUpdate ?? update.kind ?? update.type;
+  return typeof kind === "string" ? kind : undefined;
+}
+
+function isCoalescibleTranscriptChunkKind(kind: string | undefined): boolean {
+  return (
+    kind === "agent_message_chunk" ||
+    kind === "agent_thought_chunk" ||
+    kind === "user_message_chunk"
+  );
+}
+
+function messageIdentity(update: Record<string, unknown>): string {
+  const messageId = update.messageId ?? update.id;
+  return typeof messageId === "string" ? messageId : "";
+}
+
+function readUpdateText(update: Record<string, unknown>): string | undefined {
+  if (typeof update.text === "string") {
+    return update.text;
+  }
+  const content = update.content;
+  if (!content || typeof content !== "object" || Array.isArray(content)) {
+    return undefined;
+  }
+  const contentRecord = content as Record<string, unknown>;
+  return contentRecord.type === "text" && typeof contentRecord.text === "string"
+    ? contentRecord.text
+    : undefined;
+}
+
+function writeUpdateText(
+  update: Record<string, unknown>,
+  text: string,
+): Record<string, unknown> {
+  if (typeof update.text === "string") {
+    return { ...update, text };
+  }
+  const content = update.content;
+  if (content && typeof content === "object" && !Array.isArray(content)) {
+    const contentRecord = content as Record<string, unknown>;
+    if (contentRecord.type === "text" && typeof contentRecord.text === "string") {
+      return {
+        ...update,
+        content: {
+          ...contentRecord,
+          text,
+        },
+      };
+    }
+  }
+  return update;
 }
 
 function parseJson(value: string): unknown {

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -72,7 +72,7 @@ export type AcpRuntimeClient = Pick<
   | "startPrompt"
   | "startSession"
 > &
-  Partial<Pick<AcpAgentClient, "setRuntimeOption">>;
+  Partial<Pick<AcpAgentClient, "sendControlPrompt" | "setRuntimeOption">>;
 
 export type AcpClientFactory = (agent: AcpInstalledAgentRecord) => AcpRuntimeClient;
 export type LocalAcpDiscovery = () => Promise<AcpInstalledAgentRecord[]>;
@@ -194,10 +194,35 @@ export function describeInstalledAcpBackend(
       "session/cancel",
     ],
     capabilities: buildAcpCapabilities(),
-    executionModes: [],
+    executionModes: buildAcpExecutionModes(agent, available, unavailableReason),
     launchpadOptions: buildAcpLaunchpadOptions(agent.runtimeCapabilities),
     unavailableReason,
   };
+}
+
+function buildAcpExecutionModes(
+  agent: AcpInstalledAgentRecord,
+  available: boolean,
+  unavailableReason: string | undefined,
+): BackendSummary["executionModes"] {
+  if (agent.registryId !== "kimi") {
+    return [];
+  }
+  return [
+    {
+      mode: "default",
+      label: "Default Access",
+      available,
+      isDefault: true,
+      unavailableReason,
+    },
+    {
+      mode: "full-access",
+      label: "Full Access",
+      available,
+      unavailableReason,
+    },
+  ];
 }
 
 export function buildAcpLaunchpadOptions(

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -771,6 +771,7 @@ export class AcpBackendAdapter {
     }
     return new AcpAgentClient({
       backendId: agent.backendId,
+      agentDisplayName: agent.name,
       initialRuntimeCapabilities: agent.runtimeCapabilities,
       store: this.acpSessionStore as AcpSessionStoreContract,
       transport: new AcpStdioJsonRpcTransport({

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -15,6 +15,7 @@ import {
   type BackendLaunchpadOptions,
   type BackendModelOption,
   type BackendSummary,
+  type ThreadExecutionMode,
   isAcpBackendId,
 } from "@pwragent/shared";
 import {
@@ -28,6 +29,7 @@ import {
 } from "../acp/acp-agent-capabilities";
 import {
   AcpAgentClient,
+  type AcpJsonRpcTransport,
   type AcpPromptContentBlock,
 } from "../acp/acp-client";
 import { discoverLocalAcpAgents } from "../acp/acp-local-discovery";
@@ -75,6 +77,9 @@ export type AcpRuntimeClient = Pick<
   Partial<Pick<AcpAgentClient, "sendControlPrompt" | "setRuntimeOption">>;
 
 export type AcpClientFactory = (agent: AcpInstalledAgentRecord) => AcpRuntimeClient;
+export type AcpTransportFactory = (
+  agent: AcpInstalledAgentRecord,
+) => AcpJsonRpcTransport;
 export type LocalAcpDiscovery = () => Promise<AcpInstalledAgentRecord[]>;
 
 export type AcpSessionStoreLike =
@@ -95,6 +100,7 @@ export type AcpBackendAdapterOptions = {
   acpSessionStore?: AcpSessionStoreLike | null;
   captureStores: ProtocolCaptureStore[];
   createAcpClient?: AcpClientFactory;
+  createAcpTransport?: AcpTransportFactory;
   discoverLocalAcpAgents?: LocalAcpDiscovery;
   emit: (event: AgentEvent) => Promise<void>;
   handleServerRequest: (
@@ -127,6 +133,22 @@ export function readAcpUpdateText(
   return contentRecord.type === "text" && typeof contentRecord.text === "string"
     ? contentRecord.text
     : undefined;
+}
+
+export function readKimiYoloExecutionModeFromText(
+  text: string,
+): ThreadExecutionMode | undefined {
+  const normalized = text.toLowerCase();
+  if (normalized.includes("all actions will be auto-approved")) {
+    return "full-access";
+  }
+  if (normalized.includes("tool calls remain auto-approved")) {
+    return "full-access";
+  }
+  if (normalized.includes("actions will require approval")) {
+    return "default";
+  }
+  return undefined;
 }
 
 export function buildAcpCapabilities(): BackendCapabilities {
@@ -542,6 +564,7 @@ export class AcpBackendAdapter {
   private readonly acpSessionStore?: AcpSessionStoreLike;
   private readonly captureStores: ProtocolCaptureStore[];
   private readonly createAcpClient: AcpClientFactory;
+  private readonly createAcpTransport?: AcpTransportFactory;
   private readonly discoverLocalAcpAgents: LocalAcpDiscovery;
   private readonly emit: (event: AgentEvent) => Promise<void>;
   private readonly handleServerRequest: (
@@ -571,6 +594,7 @@ export class AcpBackendAdapter {
             : undefined);
     this.discoverLocalAcpAgents =
       options.discoverLocalAcpAgents ?? discoverLocalAcpAgents;
+    this.createAcpTransport = options.createAcpTransport;
     this.createAcpClient =
       options.createAcpClient ?? ((agent) => this.createDefaultClient(agent));
   }
@@ -774,15 +798,17 @@ export class AcpBackendAdapter {
       agentDisplayName: agent.name,
       initialRuntimeCapabilities: agent.runtimeCapabilities,
       store: this.acpSessionStore as AcpSessionStoreContract,
-      transport: new AcpStdioJsonRpcTransport({
-        launchDescriptor: agent.launchDescriptor,
-        observer: createCompositeJsonRpcObserver([
-          acpCapture?.observer,
-          createProtocolLogObserverFromEnv({
-            backend: agent.backendId,
-          }),
-        ]),
-      }),
+      transport:
+        this.createAcpTransport?.(agent) ??
+        new AcpStdioJsonRpcTransport({
+          launchDescriptor: agent.launchDescriptor,
+          observer: createCompositeJsonRpcObserver([
+            acpCapture?.observer,
+            createProtocolLogObserverFromEnv({
+              backend: agent.backendId,
+            }),
+          ]),
+        }),
       onSessionUpdate: async ({ sessionId, replay, title, turnId, update }) => {
         const updateKind = readAcpUpdateKind(update);
         if (title) {
@@ -796,6 +822,33 @@ export class AcpBackendAdapter {
               },
             },
           });
+        }
+        const kimiYoloExecutionMode =
+          agent.registryId === "kimi"
+            ? readKimiYoloExecutionModeFromText(readAcpUpdateText(update) ?? "")
+            : undefined;
+        if (kimiYoloExecutionMode) {
+          const metadata = this.getSession(agent.backendId, sessionId);
+          if (
+            metadata &&
+            (metadata.executionMode ?? "default") !== kimiYoloExecutionMode
+          ) {
+            this.acpSessionStore?.upsertSession?.({
+              ...metadata,
+              executionMode: kimiYoloExecutionMode,
+              updatedAt: Math.max(metadata.updatedAt, Date.now()),
+            });
+            await this.emit({
+              backend: agent.backendId,
+              notification: {
+                method: "thread/executionMode/updated",
+                params: {
+                  threadId: sessionId,
+                  executionMode: kimiYoloExecutionMode,
+                },
+              },
+            });
+          }
         }
         if (updateKind === "agent_message_chunk") {
           const delta = readAcpUpdateText(update);

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -2341,29 +2341,51 @@ export class DesktopBackendRegistry {
     filter?: string,
     archived?: boolean,
   ): Promise<AppServerThreadSummary[]> {
-    return (await this.acpBackend.listAvailableAgents()).flatMap((agent) =>
-      this.listInstalledAcpThreads(agent.backendId, filter, archived),
+    const threadLists = await Promise.all(
+      (await this.acpBackend.listAvailableAgents()).map((agent) =>
+        this.listInstalledAcpThreads(agent.backendId, filter, archived),
+      ),
     );
+    return threadLists.flat();
   }
 
-  private listInstalledAcpThreads(
+  private async listInstalledAcpThreads(
     backendId: AppServerBackendKind,
     filter?: string,
     archived?: boolean,
-  ): AppServerThreadSummary[] {
+  ): Promise<AppServerThreadSummary[]> {
     if (!isAcpBackendId(backendId)) {
       return [];
     }
     const normalizedFilter = filter?.trim().toLowerCase();
-    return this.acpBackend
+    const threads = this.acpBackend
       .listSessions(backendId, { archived })
-      .map((session) => this.acpBackend.sessionToThreadSummary(session))
-      .filter(
-        (thread) =>
-          !normalizedFilter ||
-          thread.title.toLowerCase().includes(normalizedFilter) ||
-          thread.id.toLowerCase().includes(normalizedFilter),
-      );
+      .map((session) => this.acpBackend.sessionToThreadSummary(session));
+    const enrichedThreads = await Promise.all(
+      threads.map(async (thread) => {
+        const overlay = await this.overlayStore.getThreadOverlayState({
+          backend: backendId,
+          threadId: thread.id,
+        });
+        const cwd = resolveThreadWorkspaceCwd(
+          thread,
+          overlay?.extraLinkedDirectories ?? [],
+        );
+        const codexEnvironmentOptions = cwd
+          ? await listCodexEnvironmentOptions(cwd).catch(() => [])
+          : [];
+        return {
+          ...thread,
+          codexEnvironmentOptions,
+        };
+      }),
+    );
+    return enrichedThreads.filter(
+      (thread) =>
+        !normalizedFilter ||
+        thread.title.toLowerCase().includes(normalizedFilter) ||
+        thread.id.toLowerCase().includes(normalizedFilter),
+    );
   }
 
   private async readAcpThread(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -4533,14 +4533,14 @@ export class DesktopBackendRegistry {
     if (params.fromExecutionMode === params.toExecutionMode) {
       return;
     }
-    if (!params.client.sendControlPrompt) {
+    const client = params.client;
+    if (!client.sendControlPrompt) {
       throw new Error("Kimi ACP execution mode updates require control prompts");
     }
-    const sendControlPrompt = params.client.sendControlPrompt;
     const result = await this.acpSessionPromptLocks.run(
       executionModeQueueKey(params.backend, params.sessionId),
       async () =>
-        await sendControlPrompt({
+        await client.sendControlPrompt!({
           sessionId: params.sessionId,
           prompt: "/yolo",
         }),

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1613,14 +1613,15 @@ export class DesktopBackendRegistry {
   /**
    * In-memory queue of pending permission-mode changes, keyed by
    * threadId. Populated when a user toggles execution mode while a turn
-   * is active; flushed to codex at the resume boundary (turn-end, or
-   * just before the next turn-start). Not persisted across app restart
-   * by design — the corresponding audit-log entries on overlay state
-   * carry the historical record.
+   * is active; flushed at the resume boundary (turn-end, or just before
+   * the next turn-start). Not persisted across app restart by design —
+   * the corresponding audit-log entries on overlay state carry the
+   * historical record.
    */
   private readonly queuedExecutionModes = new Map<
     string,
     {
+      backend: AppServerBackendKind;
       mode: ThreadExecutionMode;
       queuedAt: number;
       queueId: string;
@@ -2381,6 +2382,13 @@ export class DesktopBackendRegistry {
       cwd: params.cwd,
       executionMode: params.executionMode,
       acpRuntime: params.acpRuntime,
+    });
+    await this.applyKimiAcpExecutionModeControlPrompt({
+      backend: params.backend,
+      client,
+      sessionId: session.sessionId,
+      fromExecutionMode: "default",
+      toExecutionMode: params.executionMode,
     });
     await this.applyAcpRuntimeSelection(client, session.sessionId, params.acpRuntime);
     return { threadId: session.sessionId };
@@ -3567,6 +3575,12 @@ export class DesktopBackendRegistry {
       }
       this.reservedAcpStartThreadKeys.add(reservationKey);
       try {
+        if (this.usesKimiSlashExecutionModes(params.backend)) {
+          await this.flushQueuedExecutionModeIfPresent(
+            params.threadId,
+            params.backend,
+          );
+        }
         await this.flushQueuedAcpRuntimeOptionIfPresent(
           params.backend,
           params.threadId,
@@ -3975,6 +3989,15 @@ export class DesktopBackendRegistry {
     params: SetThreadExecutionModeRequest
   ): Promise<SetThreadExecutionModeResponse> {
     if (params.backend !== "codex") {
+      if (
+        isAcpBackendId(params.backend) &&
+        this.usesKimiSlashExecutionModes(params.backend)
+      ) {
+        return await this.setSlashControlledAcpExecutionMode({
+          ...params,
+          backend: params.backend,
+        });
+      }
       // Non-codex backends (e.g. Grok) currently no-op on execution
       // mode — no overlay write, no backend change. We still emit on
       // the bus so all surfaces stay visually consistent with the
@@ -4041,6 +4064,40 @@ export class DesktopBackendRegistry {
     return await this.applyThreadExecutionMode(params);
   }
 
+  private async setSlashControlledAcpExecutionMode(
+    params: SetThreadExecutionModeRequest & { backend: AcpBackendId },
+  ): Promise<SetThreadExecutionModeResponse> {
+    const currentApplied = await this.readAppliedExecutionMode(
+      params.backend,
+      params.threadId,
+    );
+    const hasActiveTurn = this.threadHasActiveTurn(params.threadId, params.backend);
+    const hasQueue = this.queuedExecutionModes.has(params.threadId);
+
+    if (hasQueue && params.executionMode === currentApplied) {
+      await this.cancelThreadExecutionModeQueue({
+        backend: params.backend,
+        threadId: params.threadId,
+      });
+      return {
+        backend: params.backend,
+        threadId: params.threadId,
+        executionMode: currentApplied,
+      };
+    }
+
+    if (hasActiveTurn && params.executionMode !== currentApplied) {
+      const queued = await this.queueThreadExecutionMode(params);
+      return {
+        backend: params.backend,
+        threadId: params.threadId,
+        executionMode: queued.queuedExecutionMode,
+      };
+    }
+
+    return await this.applyThreadExecutionMode(params);
+  }
+
   /**
    * Snapshot of in-memory queued execution modes keyed by `threadId`.
    * Consumed by the navigation snapshot path so the renderer sees
@@ -4066,10 +4123,44 @@ export class DesktopBackendRegistry {
     return snapshot;
   }
 
+  private usesKimiSlashExecutionModes(
+    backend: AppServerBackendKind,
+  ): backend is AcpBackendId {
+    return (
+      isAcpBackendId(backend) &&
+      this.acpBackend.getInstalledAgent(backend)?.registryId === "kimi"
+    );
+  }
+
+  private backendUsesQueuedExecutionModes(
+    backend: AppServerBackendKind,
+  ): boolean {
+    return backend === "codex" || this.usesKimiSlashExecutionModes(backend);
+  }
+
+  private async readAppliedExecutionMode(
+    backend: AppServerBackendKind,
+    threadId: string,
+  ): Promise<ThreadExecutionMode> {
+    if (backend === "codex") {
+      const overlay = await this.overlayStore.getThreadOverlayState({
+        backend,
+        threadId,
+      });
+      return overlay?.executionMode ?? "default";
+    }
+    if (this.usesKimiSlashExecutionModes(backend)) {
+      return (
+        this.acpBackend.getSession(backend, threadId)?.executionMode ?? "default"
+      );
+    }
+    return "default";
+  }
+
   async queueThreadExecutionMode(
     params: QueueThreadExecutionModeRequest,
   ): Promise<QueueThreadExecutionModeResponse> {
-    if (params.backend !== "codex") {
+    if (!this.backendUsesQueuedExecutionModes(params.backend)) {
       // Non-codex backends don't have a queue concept; fall through to
       // immediate apply so the caller observes consistent semantics.
       await this.setThreadExecutionMode(params);
@@ -4081,15 +4172,15 @@ export class DesktopBackendRegistry {
       };
     }
 
-    const overlay = await this.overlayStore.getThreadOverlayState({
-      backend: "codex",
-      threadId: params.threadId,
-    });
-    const currentApplied = overlay?.executionMode ?? "default";
+    const currentApplied = await this.readAppliedExecutionMode(
+      params.backend,
+      params.threadId,
+    );
     const queuedAt = Date.now();
     const queueId = randomUUID();
 
     this.queuedExecutionModes.set(params.threadId, {
+      backend: params.backend,
       mode: params.executionMode,
       queuedAt,
       queueId,
@@ -4097,6 +4188,7 @@ export class DesktopBackendRegistry {
     });
 
     await this.appendPermissionTransition({
+      backend: params.backend,
       threadId: params.threadId,
       transition: {
         id: randomUUID(),
@@ -4116,7 +4208,7 @@ export class DesktopBackendRegistry {
     });
 
     await this.emit({
-      backend: "codex",
+      backend: params.backend,
       notification: {
         method: "thread/executionMode/queued",
         params: {
@@ -4128,7 +4220,7 @@ export class DesktopBackendRegistry {
     });
 
     return {
-      backend: "codex",
+      backend: params.backend,
       threadId: params.threadId,
       queuedExecutionMode: params.executionMode,
       queuedAt,
@@ -4138,17 +4230,13 @@ export class DesktopBackendRegistry {
   async cancelThreadExecutionModeQueue(
     params: CancelThreadExecutionModeQueueRequest,
   ): Promise<CancelThreadExecutionModeQueueResponse> {
-    const overlay =
-      params.backend === "codex"
-        ? await this.overlayStore.getThreadOverlayState({
-            backend: "codex",
-            threadId: params.threadId,
-          })
-        : undefined;
-    const currentApplied = overlay?.executionMode ?? "default";
+    const currentApplied = await this.readAppliedExecutionMode(
+      params.backend,
+      params.threadId,
+    );
 
     const queue =
-      params.backend === "codex"
+      this.backendUsesQueuedExecutionModes(params.backend)
         ? this.queuedExecutionModes.get(params.threadId)
         : undefined;
     if (!queue) {
@@ -4164,6 +4252,7 @@ export class DesktopBackendRegistry {
     this.queuedExecutionModes.delete(params.threadId);
 
     await this.appendPermissionTransition({
+      backend: params.backend,
       threadId: params.threadId,
       transition: {
         id: randomUUID(),
@@ -4183,7 +4272,7 @@ export class DesktopBackendRegistry {
     });
 
     await this.emit({
-      backend: "codex",
+      backend: params.backend,
       notification: {
         method: "thread/executionMode/queueCleared",
         params: {
@@ -4212,6 +4301,18 @@ export class DesktopBackendRegistry {
     options?: { fromQueue?: boolean; queueId?: string },
   ): Promise<SetThreadExecutionModeResponse> {
     if (params.backend !== "codex") {
+      if (
+        isAcpBackendId(params.backend) &&
+        this.usesKimiSlashExecutionModes(params.backend)
+      ) {
+        return await this.applyKimiAcpThreadExecutionMode(
+          {
+            ...params,
+            backend: params.backend,
+          },
+          options,
+        );
+      }
       // The non-codex grok no-op path — preserved for symmetry. Direct
       // callers route through setThreadExecutionMode which short-circuits
       // before reaching this method, so we should never get here, but
@@ -4310,6 +4411,98 @@ export class DesktopBackendRegistry {
     };
   }
 
+  private async applyKimiAcpThreadExecutionMode(
+    params: SetThreadExecutionModeRequest & { backend: AcpBackendId },
+    options?: { fromQueue?: boolean; queueId?: string },
+  ): Promise<SetThreadExecutionModeResponse> {
+    const session = this.acpBackend.getSession(params.backend, params.threadId);
+    if (!session) {
+      throw new Error(`ACP session not found: ${params.threadId}`);
+    }
+    const previousApplied = session.executionMode ?? "default";
+    const client = await this.acpBackend.getClient(params.backend);
+    await client.ensureSession?.(session);
+    await this.applyKimiAcpExecutionModeControlPrompt({
+      backend: params.backend,
+      client,
+      sessionId: params.threadId,
+      fromExecutionMode: previousApplied,
+      toExecutionMode: params.executionMode,
+    });
+
+    const updatedAt = Date.now();
+    this.acpBackend.upsertSession({
+      ...session,
+      executionMode: params.executionMode,
+      updatedAt: Math.max(session.updatedAt, updatedAt),
+    });
+
+    await this.appendPermissionTransition({
+      backend: params.backend,
+      threadId: params.threadId,
+      transition: {
+        id: randomUUID(),
+        fromExecutionMode: previousApplied,
+        toExecutionMode: params.executionMode,
+        status: "applied",
+        occurredAt: updatedAt,
+        queueId: options?.queueId,
+      },
+    });
+
+    await this.emit({
+      backend: params.backend,
+      notification: {
+        method: "thread/executionMode/updated",
+        params: {
+          threadId: params.threadId,
+          executionMode: params.executionMode,
+        },
+      },
+    });
+
+    if (options?.fromQueue) {
+      await this.emit({
+        backend: params.backend,
+        notification: {
+          method: "thread/executionMode/queueCleared",
+          params: {
+            threadId: params.threadId,
+            reason: "applied",
+          },
+        },
+      });
+    }
+
+    return {
+      backend: params.backend,
+      threadId: params.threadId,
+      executionMode: params.executionMode,
+    };
+  }
+
+  private async applyKimiAcpExecutionModeControlPrompt(params: {
+    backend: AcpBackendId;
+    client: AcpRuntimeClient;
+    sessionId: string;
+    fromExecutionMode: ThreadExecutionMode;
+    toExecutionMode: ThreadExecutionMode;
+  }): Promise<void> {
+    if (!this.usesKimiSlashExecutionModes(params.backend)) {
+      return;
+    }
+    if (params.fromExecutionMode === params.toExecutionMode) {
+      return;
+    }
+    if (!params.client.sendControlPrompt) {
+      throw new Error("Kimi ACP execution mode updates require control prompts");
+    }
+    await params.client.sendControlPrompt({
+      sessionId: params.sessionId,
+      prompt: "/yolo",
+    });
+  }
+
   /**
    * Returns true iff the registry currently believes a turn is in
    * flight on this thread. `activeCodexTurnModes` is keyed by
@@ -4399,6 +4592,7 @@ export class DesktopBackendRegistry {
    */
   private async flushQueuedExecutionModeIfPresent(
     threadId: string,
+    backend: AppServerBackendKind = "codex",
   ): Promise<void> {
     const activeFlush = this.queuedExecutionModeFlushes.get(threadId);
     if (activeFlush) {
@@ -4408,6 +4602,7 @@ export class DesktopBackendRegistry {
 
     const queue = this.queuedExecutionModes.get(threadId);
     if (!queue) return;
+    if (queue.backend !== backend) return;
     // Atomic claim: in JS's single-threaded event loop, `Map.delete`
     // returning true gives this caller exclusive ownership of the
     // apply. Concurrent flushes (one from the emit-listener turn-end
@@ -4433,6 +4628,7 @@ export class DesktopBackendRegistry {
   private async applyClaimedQueuedExecutionMode(
     threadId: string,
     queue: {
+      backend: AppServerBackendKind;
       mode: ThreadExecutionMode;
       queuedAt: number;
       queueId: string;
@@ -4442,7 +4638,7 @@ export class DesktopBackendRegistry {
     try {
       await this.applyThreadExecutionMode(
         {
-          backend: "codex",
+          backend: queue.backend,
           threadId,
           executionMode: queue.mode,
         },
@@ -4468,11 +4664,15 @@ export class DesktopBackendRegistry {
           },
         );
         const overlay = await this.overlayStore
-          .getThreadOverlayState({ backend: "codex", threadId })
+          .getThreadOverlayState({ backend: queue.backend, threadId })
           .catch(() => undefined);
-        const currentApplied = overlay?.executionMode ?? "default";
+        const currentApplied =
+          queue.backend === "codex"
+            ? overlay?.executionMode ?? "default"
+            : await this.readAppliedExecutionMode(queue.backend, threadId);
         this.queuedExecutionModes.delete(threadId);
         await this.appendPermissionTransition({
+          backend: queue.backend,
           threadId,
           transition: {
             id: randomUUID(),
@@ -4485,7 +4685,7 @@ export class DesktopBackendRegistry {
           },
         });
         await this.emit({
-          backend: "codex",
+          backend: queue.backend,
           notification: {
             method: "thread/executionMode/queueCleared",
             params: {
@@ -7453,6 +7653,12 @@ export class DesktopBackendRegistry {
           notification.params.threadId,
         );
       } else if (isAcpBackendId(event.backend)) {
+        if (this.usesKimiSlashExecutionModes(event.backend)) {
+          void this.flushQueuedExecutionModeIfPresent(
+            notification.params.threadId,
+            event.backend,
+          );
+        }
         void this.flushQueuedAcpRuntimeOptionIfPresent(
           event.backend,
           notification.params.threadId,
@@ -7472,6 +7678,12 @@ export class DesktopBackendRegistry {
       }
       if (event.backend !== "codex") {
         if (isAcpBackendId(event.backend)) {
+          if (this.usesKimiSlashExecutionModes(event.backend)) {
+            void this.flushQueuedExecutionModeIfPresent(
+              event.notification.params.threadId,
+              event.backend,
+            );
+          }
           void this.flushQueuedAcpRuntimeOptionIfPresent(
             event.backend,
             event.notification.params.threadId,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -100,6 +100,7 @@ import {
   type EnsureDirectoryLaunchpadRequest,
   type EnsureDirectoryLaunchpadResponse,
   applyCodexEnvironmentActionRunUpdate,
+  buildThreadIdentityKey,
   isAcpBackendId,
   readCodexEnvironmentActionRuns,
 } from "@pwragent/shared";
@@ -113,6 +114,7 @@ import {
   inputToAcpPrompt,
   isAcpSessionMissingForProjectError,
   mergeAcpRuntimeState,
+  readKimiYoloExecutionModeFromText,
   withAcpModelRuntimeSelection,
   type AcpBackendAdapterOptions,
   type AcpClientFactory,
@@ -900,6 +902,17 @@ function buildPendingRequestKey(params: {
   return `${params.backend}:${params.threadId}:${params.requestId}`;
 }
 
+function executionModeQueueKey(
+  backend: AppServerBackendKind,
+  threadId: string,
+): string {
+  return buildThreadIdentityKey(backend, threadId);
+}
+
+function formatExecutionModeForError(mode: ThreadExecutionMode): string {
+  return mode === "full-access" ? "Full Access" : "Default Access";
+}
+
 function buildActiveTurnModeKey(threadId: string, turnId: string): string {
   return `${threadId}:${turnId}`;
 }
@@ -1629,6 +1642,7 @@ export class DesktopBackendRegistry {
     }
   >();
   private readonly queuedExecutionModeFlushes = new Map<string, Promise<void>>();
+  private readonly acpSessionPromptLocks = new PerKeyAsyncLock();
   private readonly queuedAcpRuntimeOptions = new Map<
     string,
     {
@@ -2378,23 +2392,40 @@ export class DesktopBackendRegistry {
     acpRuntime?: BackendAcpSessionRuntimeState;
   }): Promise<{ threadId: string }> {
     const client = await this.acpBackend.getClient(params.backend);
+    const initialExecutionMode = this.usesKimiSlashExecutionModes(params.backend)
+      ? "default"
+      : params.executionMode;
     const session = await client.startSession({
       cwd: params.cwd,
-      executionMode: params.executionMode,
+      executionMode: initialExecutionMode,
       acpRuntime: params.acpRuntime,
     });
-    await this.applyKimiAcpExecutionModeControlPrompt({
-      backend: params.backend,
-      client,
-      sessionId: session.sessionId,
-      fromExecutionMode: "default",
-      toExecutionMode: params.executionMode,
-    });
+    if (
+      this.usesKimiSlashExecutionModes(params.backend) &&
+      params.executionMode !== "default"
+    ) {
+      await this.applyKimiAcpThreadExecutionMode({
+        backend: params.backend,
+        threadId: session.sessionId,
+        executionMode: params.executionMode,
+      });
+    }
     await this.applyAcpRuntimeSelection(client, session.sessionId, params.acpRuntime);
     return { threadId: session.sessionId };
   }
 
   private async startAcpTurn(params: {
+    backend: AcpBackendId;
+    threadId: string;
+    input: AppServerTurnInputItem[];
+  }): Promise<{ backend: AppServerBackendKind; threadId: string; turnId: string }> {
+    return await this.acpSessionPromptLocks.run(
+      executionModeQueueKey(params.backend, params.threadId),
+      async () => await this.startAcpTurnLocked(params),
+    );
+  }
+
+  private async startAcpTurnLocked(params: {
     backend: AcpBackendId;
     threadId: string;
     input: AppServerTurnInputItem[];
@@ -4026,7 +4057,8 @@ export class DesktopBackendRegistry {
     });
     const currentApplied = overlay?.executionMode ?? "default";
     const hasActiveTurn = this.threadHasActiveTurn(params.threadId, "codex");
-    const hasQueue = this.queuedExecutionModes.has(params.threadId);
+    const queueKey = executionModeQueueKey("codex", params.threadId);
+    const hasQueue = this.queuedExecutionModes.has(queueKey);
 
     // Toggling back to the currently-applied mode while a queue is
     // pending is a cancel — the user changed their mind. No codex call,
@@ -4072,7 +4104,8 @@ export class DesktopBackendRegistry {
       params.threadId,
     );
     const hasActiveTurn = this.threadHasActiveTurn(params.threadId, params.backend);
-    const hasQueue = this.queuedExecutionModes.has(params.threadId);
+    const queueKey = executionModeQueueKey(params.backend, params.threadId);
+    const hasQueue = this.queuedExecutionModes.has(queueKey);
 
     if (hasQueue && params.executionMode === currentApplied) {
       await this.cancelThreadExecutionModeQueue({
@@ -4099,7 +4132,7 @@ export class DesktopBackendRegistry {
   }
 
   /**
-   * Snapshot of in-memory queued execution modes keyed by `threadId`.
+   * Snapshot of in-memory queued execution modes keyed by thread identity.
    * Consumed by the navigation snapshot path so the renderer sees
    * queued state on the very first snapshot after restart, without
    * waiting for a follow-up bus event. The queue map itself is not
@@ -4114,8 +4147,8 @@ export class DesktopBackendRegistry {
       string,
       { mode: ThreadExecutionMode; queuedAt: number }
     > = {};
-    for (const [threadId, entry] of this.queuedExecutionModes) {
-      snapshot[threadId] = {
+    for (const [queueKey, entry] of this.queuedExecutionModes) {
+      snapshot[queueKey] = {
         mode: entry.mode,
         queuedAt: entry.queuedAt,
       };
@@ -4179,7 +4212,9 @@ export class DesktopBackendRegistry {
     const queuedAt = Date.now();
     const queueId = randomUUID();
 
-    this.queuedExecutionModes.set(params.threadId, {
+    const queueKey = executionModeQueueKey(params.backend, params.threadId);
+
+    this.queuedExecutionModes.set(queueKey, {
       backend: params.backend,
       mode: params.executionMode,
       queuedAt,
@@ -4237,7 +4272,9 @@ export class DesktopBackendRegistry {
 
     const queue =
       this.backendUsesQueuedExecutionModes(params.backend)
-        ? this.queuedExecutionModes.get(params.threadId)
+        ? this.queuedExecutionModes.get(
+            executionModeQueueKey(params.backend, params.threadId),
+          )
         : undefined;
     if (!queue) {
       // Idempotent: cancel of nothing is a no-op that returns the
@@ -4249,7 +4286,9 @@ export class DesktopBackendRegistry {
       };
     }
 
-    this.queuedExecutionModes.delete(params.threadId);
+    this.queuedExecutionModes.delete(
+      executionModeQueueKey(params.backend, params.threadId),
+    );
 
     await this.appendPermissionTransition({
       backend: params.backend,
@@ -4497,10 +4536,25 @@ export class DesktopBackendRegistry {
     if (!params.client.sendControlPrompt) {
       throw new Error("Kimi ACP execution mode updates require control prompts");
     }
-    await params.client.sendControlPrompt({
-      sessionId: params.sessionId,
-      prompt: "/yolo",
-    });
+    const sendControlPrompt = params.client.sendControlPrompt;
+    const result = await this.acpSessionPromptLocks.run(
+      executionModeQueueKey(params.backend, params.sessionId),
+      async () =>
+        await sendControlPrompt({
+          sessionId: params.sessionId,
+          prompt: "/yolo",
+        }),
+    );
+    const observedMode = readKimiYoloExecutionModeFromText(result.text);
+    if (observedMode !== params.toExecutionMode) {
+      const target = formatExecutionModeForError(params.toExecutionMode);
+      const observed = observedMode
+        ? formatExecutionModeForError(observedMode)
+        : "unknown state";
+      throw new Error(
+        `Kimi ACP /yolo did not confirm ${target}; observed ${observed}`,
+      );
+    }
   }
 
   /**
@@ -4594,15 +4648,15 @@ export class DesktopBackendRegistry {
     threadId: string,
     backend: AppServerBackendKind = "codex",
   ): Promise<void> {
-    const activeFlush = this.queuedExecutionModeFlushes.get(threadId);
+    const queueKey = executionModeQueueKey(backend, threadId);
+    const activeFlush = this.queuedExecutionModeFlushes.get(queueKey);
     if (activeFlush) {
       await activeFlush;
       return;
     }
 
-    const queue = this.queuedExecutionModes.get(threadId);
+    const queue = this.queuedExecutionModes.get(queueKey);
     if (!queue) return;
-    if (queue.backend !== backend) return;
     // Atomic claim: in JS's single-threaded event loop, `Map.delete`
     // returning true gives this caller exclusive ownership of the
     // apply. Concurrent flushes (one from the emit-listener turn-end
@@ -4610,23 +4664,24 @@ export class DesktopBackendRegistry {
     // queue but only one's delete returns true — the other no-ops.
     // Without this, both callers race on applyThreadExecutionMode and
     // each appends a duplicate "applied" transition entry.
-    if (!this.queuedExecutionModes.delete(threadId)) {
+    if (!this.queuedExecutionModes.delete(queueKey)) {
       return;
     }
 
-    const flush = this.applyClaimedQueuedExecutionMode(threadId, queue);
-    this.queuedExecutionModeFlushes.set(threadId, flush);
+    const flush = this.applyClaimedQueuedExecutionMode(threadId, queueKey, queue);
+    this.queuedExecutionModeFlushes.set(queueKey, flush);
     try {
       await flush;
     } finally {
-      if (this.queuedExecutionModeFlushes.get(threadId) === flush) {
-        this.queuedExecutionModeFlushes.delete(threadId);
+      if (this.queuedExecutionModeFlushes.get(queueKey) === flush) {
+        this.queuedExecutionModeFlushes.delete(queueKey);
       }
     }
   }
 
   private async applyClaimedQueuedExecutionMode(
     threadId: string,
+    queueKey: string,
     queue: {
       backend: AppServerBackendKind;
       mode: ThreadExecutionMode;
@@ -4646,7 +4701,7 @@ export class DesktopBackendRegistry {
       );
     } catch (error) {
       const attempts = queue.flushAttempts + 1;
-      const stillRetained = this.queuedExecutionModes.get(threadId);
+      const stillRetained = this.queuedExecutionModes.get(queueKey);
       if (stillRetained && stillRetained.queueId !== queue.queueId) {
         // The queue was replaced while we were mid-apply (the user
         // queued a different target). Discard our retry — the new
@@ -4670,7 +4725,7 @@ export class DesktopBackendRegistry {
           queue.backend === "codex"
             ? overlay?.executionMode ?? "default"
             : await this.readAppliedExecutionMode(queue.backend, threadId);
-        this.queuedExecutionModes.delete(threadId);
+        this.queuedExecutionModes.delete(queueKey);
         await this.appendPermissionTransition({
           backend: queue.backend,
           threadId,
@@ -4696,7 +4751,7 @@ export class DesktopBackendRegistry {
         });
         return;
       }
-      this.queuedExecutionModes.set(threadId, {
+      this.queuedExecutionModes.set(queueKey, {
         ...queue,
         flushAttempts: attempts,
       });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1268,7 +1268,7 @@ function resolveCodexEnvironmentSelection(
   launchpad: NavigationLaunchpadDraft,
   options: CodexEnvironmentOption[],
 ): CodexEnvironmentSelection | undefined {
-  if (launchpad.backend !== "codex" || !launchpad.codexEnvironmentId) {
+  if (!launchpad.codexEnvironmentId) {
     return undefined;
   }
 
@@ -1296,7 +1296,7 @@ async function resetLaunchpadAfterMaterialize(params: {
     directoryKey: launchpad.directoryKey,
   });
 
-  if (launchpad.backend !== "codex" || !launchpad.codexEnvironmentId) {
+  if (!launchpad.codexEnvironmentId) {
     return;
   }
 
@@ -1306,7 +1306,7 @@ async function resetLaunchpadAfterMaterialize(params: {
     directoryKind: launchpad.directoryKind,
     directoryLabel: launchpad.directoryLabel,
     directoryPath: launchpad.directoryPath,
-    backend: "codex",
+    backend: defaults.backend,
     executionMode: defaults.executionMode,
     model: defaults.model,
     reasoningEffort: defaults.reasoningEffort,
@@ -3553,13 +3553,13 @@ export class DesktopBackendRegistry {
         threadId: result.threadId,
         branch: gitBranch,
       });
-      if (request.codexEnvironmentRuntime) {
-        await this.overlayStore.setThreadCodexEnvironmentRuntime?.({
-          backend,
-          threadId: result.threadId,
-          codexEnvironmentRuntime: request.codexEnvironmentRuntime,
-        });
-      }
+    }
+    if (request.codexEnvironmentRuntime) {
+      await this.overlayStore.setThreadCodexEnvironmentRuntime?.({
+        backend,
+        threadId: result.threadId,
+        codexEnvironmentRuntime: request.codexEnvironmentRuntime,
+      });
     }
     if (
       modelSettings.model !== undefined ||
@@ -3663,7 +3663,11 @@ export class DesktopBackendRegistry {
       });
       cwd =
         params.backend === "codex"
-          ? await this.resolveCodexThreadTurnCwd(params.threadId, overlay)
+          ? await this.resolveThreadEnvironmentCwd(
+              params.backend,
+              params.threadId,
+              overlay,
+            )
           : undefined;
       await this.emit({
         backend: params.backend,
@@ -5199,10 +5203,6 @@ export class DesktopBackendRegistry {
   async runCodexEnvironmentAction(
     request: RunCodexEnvironmentActionRequest,
   ): Promise<RunCodexEnvironmentActionResponse> {
-    if (request.backend !== "codex") {
-      throw new Error("Codex environment actions are only available for Codex threads.");
-    }
-
     // Serialise the read-modify-write under the per-thread lock so two
     // concurrent Run-button clicks can't clobber each other's appended
     // run entry.
@@ -5216,14 +5216,16 @@ export class DesktopBackendRegistry {
         });
         const runtime = overlay?.codexEnvironmentRuntime;
         if (!runtime) {
-          throw new Error(
-            "This thread does not have a selected Codex environment.",
-          );
+          throw new Error("This thread does not have a selected environment.");
         }
 
         const currentCwd =
           request.cwd?.trim() ||
-          (await this.resolveCodexThreadTurnCwd(request.threadId, overlay));
+          (await this.resolveThreadEnvironmentCwd(
+            request.backend,
+            request.threadId,
+            overlay,
+          ));
         const runtimeForAction = await this.refreshCodexEnvironmentRuntimeActions(
           currentCwd?.trim() ? { ...runtime, cwd: currentCwd.trim() } : runtime,
           request.actionId,
@@ -5328,10 +5330,6 @@ export class DesktopBackendRegistry {
   async setCodexThreadEnvironment(
     request: SetCodexThreadEnvironmentRequest,
   ): Promise<SetCodexThreadEnvironmentResponse> {
-    if (request.backend !== "codex") {
-      throw new Error("Codex environments are only available for Codex threads.");
-    }
-
     if (!request.environmentId) {
       await this.overlayStore.setThreadCodexEnvironmentRuntime?.({
         backend: request.backend,
@@ -5354,13 +5352,17 @@ export class DesktopBackendRegistry {
       backend: request.backend,
       threadId: request.threadId,
     });
-    const cwd = await this.resolveCodexThreadTurnCwd(request.threadId, overlay);
+    const cwd = await this.resolveThreadEnvironmentCwd(
+      request.backend,
+      request.threadId,
+      overlay,
+    );
     const options = await listCodexEnvironmentOptions(cwd);
     const environment = options.find(
       (candidate) => candidate.id === request.environmentId,
     );
     if (!environment) {
-      throw new Error("Selected Codex environment is not available for this thread.");
+      throw new Error("Selected environment is not available for this thread.");
     }
 
     const codexEnvironmentRuntime: CodexThreadEnvironmentRuntime = {
@@ -5666,36 +5668,34 @@ export class DesktopBackendRegistry {
       queuedActionDetachedOutputs.length = 0;
       queuedActionDetachedOutputs.push(event);
     };
-    if (launchpad.backend === "codex") {
-      try {
-        codexEnvironmentRuntime = await applyLocalCodexEnvironmentSelection({
-          commandRunner: this.codexEnvironmentCommandRunner,
-          cwd: workspace.cwd,
-          env: this.codexEnvironmentCommandEnv,
-          onSetupProgress: options?.onCodexEnvironmentSetupProgress
-            ? (event) => {
-                options.onCodexEnvironmentSetupProgress?.({
-                  directoryKey: launchpad.directoryKey,
-                  ...event,
-                });
-              }
-            : undefined,
-          onActionDetachedExit,
-          onActionDetachedOutput,
-          actionRunId: autoActionRunId,
-          selection: codexEnvironmentSelection,
-        });
-      } catch (error) {
-        if (!(error instanceof CodexEnvironmentStartupError)) {
-          throw error;
-        }
-        codexEnvironmentRuntime = error.runtime;
-        codexEnvironmentStartupFailure = {
-          message: error.message,
-          phase: error.phase,
-          worktreeCleanupAvailable: workspace.workMode === "worktree",
-        };
+    try {
+      codexEnvironmentRuntime = await applyLocalCodexEnvironmentSelection({
+        commandRunner: this.codexEnvironmentCommandRunner,
+        cwd: workspace.cwd,
+        env: this.codexEnvironmentCommandEnv,
+        onSetupProgress: options?.onCodexEnvironmentSetupProgress
+          ? (event) => {
+              options.onCodexEnvironmentSetupProgress?.({
+                directoryKey: launchpad.directoryKey,
+                ...event,
+              });
+            }
+          : undefined,
+        onActionDetachedExit,
+        onActionDetachedOutput,
+        actionRunId: autoActionRunId,
+        selection: codexEnvironmentSelection,
+      });
+    } catch (error) {
+      if (!(error instanceof CodexEnvironmentStartupError)) {
+        throw error;
       }
+      codexEnvironmentRuntime = error.runtime;
+      codexEnvironmentStartupFailure = {
+        message: error.message,
+        phase: error.phase,
+        worktreeCleanupAvailable: workspace.workMode === "worktree",
+      };
     }
     const startThreadResponse = await this.startThread({
       backend: launchpad.backend,
@@ -6990,7 +6990,8 @@ export class DesktopBackendRegistry {
       .catch(() => undefined);
   }
 
-  private async resolveCodexThreadTurnCwd(
+  private async resolveThreadEnvironmentCwd(
+    backend: AppServerBackendKind,
     threadId: string,
     overlay?: ThreadOverlayState,
   ): Promise<string | undefined> {
@@ -7001,14 +7002,14 @@ export class DesktopBackendRegistry {
       return overlayCwd.trim();
     }
 
-    const pendingThread = this.pendingStartedThreads.get(`codex:${threadId}`);
+    const pendingThread = this.pendingStartedThreads.get(`${backend}:${threadId}`);
     const pendingCwd = resolveThreadWorkspaceCwd(pendingThread);
     if (pendingCwd?.trim()) {
       return pendingCwd.trim();
     }
 
     const thread = await this.findThreadForWorkspaceHandoff({
-      backend: "codex",
+      backend,
       callerReason: "turn-cwd",
       threadId,
     });

--- a/apps/desktop/src/main/app-server/codex-environment-config.ts
+++ b/apps/desktop/src/main/app-server/codex-environment-config.ts
@@ -88,13 +88,6 @@ export function withCodexEnvironmentOptions(
   launchpad: NavigationLaunchpadDraft,
   options: CodexEnvironmentOption[],
 ): NavigationLaunchpadDraft {
-  if (launchpad.backend !== "codex") {
-    return {
-      ...launchpad,
-      codexEnvironmentOptions: [],
-    };
-  }
-
   if (options.length === 0) {
     return {
       ...launchpad,

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -529,14 +529,14 @@ class DesktopAppServerService {
     const bindingsStartedAt = Date.now();
     const messagingBindingsByThreadKey = await buildMessagingBindingsByThreadKey(threads);
     const bindingsDurationMs = Date.now() - bindingsStartedAt;
-    const queuedExecutionModesByThreadId = getDesktopBackendRegistry()
+    const queuedExecutionModesByThreadKey = getDesktopBackendRegistry()
       .getQueuedExecutionModesSnapshot();
     const overlayStartedAt = Date.now();
     const snapshot = await this.getOverlayStore().reconcileNavigationSnapshot({
       backend,
       fetchedAt: Date.now(),
       messagingBindingsByThreadKey,
-      queuedExecutionModesByThreadId,
+      queuedExecutionModesByThreadKey,
       threads,
       workspaceRoots: resolveScratchProjectsRoots(),
     });

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -62,13 +62,13 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
       filter: request.filter,
     });
     const messagingBindingsByThreadKey = await buildMessagingBindingsByThreadKey(threads);
-    const queuedExecutionModesByThreadId =
+    const queuedExecutionModesByThreadKey =
       this.registry.getQueuedExecutionModesSnapshot();
     const snapshot = await getDesktopOverlayStore().reconcileNavigationSnapshot({
       backend,
       fetchedAt: Date.now(),
       messagingBindingsByThreadKey,
-      queuedExecutionModesByThreadId,
+      queuedExecutionModesByThreadKey,
       threads,
       workspaceRoots: resolveScratchProjectsRoots(),
     });

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -66,13 +66,13 @@ export class SqliteOverlayStore {
       MessagingThreadBindingSummary[] | undefined
     >;
     /**
-     * In-memory permission-mode queue map keyed by `threadId`. The queue
+     * In-memory permission-mode queue map keyed by thread identity. The queue
      * lives on the registry (not in sqlite) but must be merged onto the
      * snapshot so renderers connecting after the queued bus event still
      * see the queued state. Also feeds the snapshot hash so changes
      * invalidate the cache.
      */
-    queuedExecutionModesByThreadId?: Record<
+    queuedExecutionModesByThreadKey?: Record<
       string,
       { mode: ThreadExecutionMode; queuedAt: number } | undefined
     >;
@@ -116,7 +116,7 @@ export class SqliteOverlayStore {
       params.threads.map((thread) => {
         const threadKey = buildThreadIdentityKey(thread.source, thread.id);
         const overlay = this.getThread(threadKey);
-        const queue = params.queuedExecutionModesByThreadId?.[thread.id];
+        const queue = params.queuedExecutionModesByThreadKey?.[threadKey];
         if (queue) {
           // Merge the in-memory queue onto the persisted overlay so
           // mid-restart / mid-connect renderers see the queued state

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -3184,7 +3184,6 @@ export function Composer(props: ComposerProps) {
   const runThreadCodexEnvironmentAction = async (): Promise<void> => {
     if (
       !props.thread ||
-      props.thread.source !== "codex" ||
       !props.desktopApi?.runCodexEnvironmentAction ||
       !selectedThreadCodexAction
     ) {
@@ -3213,7 +3212,6 @@ export function Composer(props: ComposerProps) {
   ): Promise<void> => {
     if (
       !props.thread ||
-      props.thread.source !== "codex" ||
       !props.desktopApi?.setCodexThreadEnvironment
     ) {
       return;
@@ -3222,7 +3220,7 @@ export function Composer(props: ComposerProps) {
     setSendError(undefined);
     setSelectedThreadCodexActionId("");
     props.onPendingStatusChange?.(
-      environmentId ? "Selecting Codex environment" : "Clearing Codex environment",
+      environmentId ? "Selecting environment" : "Clearing environment",
     );
     try {
       await props.desktopApi.setCodexThreadEnvironment({
@@ -3351,24 +3349,18 @@ export function Composer(props: ComposerProps) {
       ? props.launchpad.workMode
       : "local";
   const launchpadCodexEnvironmentOptions =
-    props.launchpad?.backend === "codex"
-      ? props.launchpad.codexEnvironmentOptions ?? []
-      : [];
+    props.launchpad?.codexEnvironmentOptions ?? [];
   const selectedCodexEnvironment = launchpadCodexEnvironmentOptions.find(
     (environment) => environment.id === props.launchpad?.codexEnvironmentId,
   );
   const threadCodexEnvironmentOptions =
-    props.thread?.source === "codex"
-      ? props.thread.codexEnvironmentOptions ?? []
-      : [];
+    props.thread?.codexEnvironmentOptions ?? [];
   const selectedThreadCodexEnvironmentOption = threadCodexEnvironmentOptions.find(
     (environment) =>
       environment.id === props.thread?.codexEnvironmentRuntime?.environmentId,
   );
   const runtimeThreadCodexEnvironmentActions =
-    props.thread?.source === "codex"
-      ? props.thread.codexEnvironmentRuntime?.actions ?? []
-      : [];
+    props.thread?.codexEnvironmentRuntime?.actions ?? [];
   const threadCodexEnvironmentActions =
     runtimeThreadCodexEnvironmentActions.length > 0
       ? runtimeThreadCodexEnvironmentActions
@@ -4897,7 +4889,7 @@ export function Composer(props: ComposerProps) {
           <div className="composer__application-actions" aria-label="Composer tools">
             {props.launchpad && launchpadCodexEnvironmentOptions.length > 0 ? (
               <ComposerDropdown
-                ariaLabel="Codex environment"
+                ariaLabel="Environment"
                 compact
                 disabled={launchpadSubmitting}
                 icon={FileCodeIcon}
@@ -4945,7 +4937,7 @@ export function Composer(props: ComposerProps) {
 
             {!props.launchpad && threadCodexEnvironmentOptions.length > 0 ? (
               <ComposerDropdown
-                ariaLabel="Codex environment"
+                ariaLabel="Environment"
                 compact
                 disabled={!props.desktopApi?.setCodexThreadEnvironment}
                 icon={FileCodeIcon}

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -4522,7 +4522,7 @@ export function Composer(props: ComposerProps) {
           ) : null}
 
           {availableExecutionModes.length > 0 &&
-          (props.launchpad || (props.thread?.source === "codex" && props.onSetExecutionMode)) ? (
+          (props.launchpad || (props.thread && props.onSetExecutionMode)) ? (
             <ComposerDropdown
               ariaLabel="Access mode"
               compact

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -3234,6 +3234,55 @@ describe("Composer", () => {
     });
   });
 
+  it("shows ACP thread access in the composer", async () => {
+    const onSetExecutionMode = vi.fn(async () => undefined);
+
+    render(
+      <Composer
+        backends={[
+          {
+            ...backendSummary("acp:kimi"),
+            label: "Kimi Code CLI",
+            executionModes: [
+              {
+                mode: "default",
+                label: "Default Access",
+                available: true,
+                isDefault: true,
+              },
+              {
+                mode: "full-access",
+                label: "Full Access",
+                available: true,
+              },
+            ],
+          },
+        ]}
+        disabled={false}
+        fullAccessRiskWarningDismissed
+        onSetExecutionMode={onSetExecutionMode}
+        skills={[]}
+        thread={{
+          id: "kimi-session-1",
+          title: "Kimi thread",
+          titleSource: "explicit",
+          source: "acp:kimi",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />,
+    );
+
+    expect(screen.getByLabelText("Access mode")).toHaveValue("default");
+
+    chooseDropdownOption("Access mode", "Full Access");
+
+    await waitFor(() => {
+      expect(onSetExecutionMode).toHaveBeenCalledWith("full-access");
+    });
+  });
+
   it("submits a local-to-worktree handoff on a new branch", async () => {
     const onHandoffThreadWorkspace = vi.fn(async () => undefined);
 

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -535,7 +535,7 @@ describe("Composer", () => {
       />,
     );
 
-    expect(screen.getByLabelText("Codex environment")).toHaveTextContent("PwrAgnt");
+    expect(screen.getByLabelText("Environment")).toHaveTextContent("PwrAgnt");
     expect(screen.getByLabelText("Environment command")).toHaveTextContent(
       "Dev - Messaging",
     );
@@ -549,7 +549,7 @@ describe("Composer", () => {
       });
     });
 
-    chooseDropdownOption("Codex environment", "No environment");
+    chooseDropdownOption("Environment", "No environment");
     await waitFor(() => {
       expect(setCodexThreadEnvironment).toHaveBeenCalledWith({
         backend: "codex",
@@ -596,7 +596,7 @@ describe("Composer", () => {
       "No commands",
     );
     expect(screen.getByLabelText("Environment command")).toBeDisabled();
-    expect(screen.getByLabelText("Codex environment")).toHaveTextContent("PwrAgnt");
+    expect(screen.getByLabelText("Environment")).toHaveTextContent("PwrAgnt");
   });
 
   it("hides thread environment commands when no environment is selected", () => {
@@ -632,7 +632,7 @@ describe("Composer", () => {
       />,
     );
 
-    expect(screen.getByLabelText("Codex environment")).toHaveTextContent(
+    expect(screen.getByLabelText("Environment")).toHaveTextContent(
       "No environment",
     );
     expect(screen.queryByLabelText("Environment command")).not.toBeInTheDocument();
@@ -685,10 +685,62 @@ describe("Composer", () => {
       />,
     );
 
-    expect(screen.getByLabelText("Codex environment")).toHaveTextContent("PwrAgnt");
+    expect(screen.getByLabelText("Environment")).toHaveTextContent("PwrAgnt");
     expect(screen.getByText("Run setup")).toBeInTheDocument();
     expect(screen.queryByLabelText("Environment command")).not.toBeInTheDocument();
     expect(screen.queryByText("No command")).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ["acp:gemini", acpGeminiBackendSummary()],
+    ["acp:kimi", backendSummary("acp:kimi")],
+  ] as const)("shows the launchpad environment picker for %s", (_backendId, backend) => {
+    const updateLaunchpad = vi.fn(async () => undefined);
+    render(
+      <Composer
+        backends={[backend]}
+        disabled={false}
+        launchpad={{
+          directoryKey: "directory:/repo/PwrAgent",
+          directoryKind: "directory",
+          directoryLabel: "PwrAgent",
+          directoryPath: "/repo/PwrAgent",
+          backend: backend.kind,
+          executionMode: "default",
+          prompt: "",
+          workMode: "local",
+          codexEnvironmentOptions: [
+            {
+              id: "environment",
+              name: "PwrAgnt",
+              sourcePath: "/repo/.codex/environments/environment.toml",
+              setupScript: "pnpm install",
+              actions: [],
+            },
+          ],
+          createdAt: 1,
+          updatedAt: 1,
+        }}
+        onUpdateLaunchpad={updateLaunchpad}
+        skills={[]}
+      />,
+    );
+
+    expect(screen.getByLabelText("Environment")).toHaveTextContent(
+      "No environment",
+    );
+
+    chooseDropdownOption("Environment", "PwrAgnt");
+
+    expect(updateLaunchpad).toHaveBeenCalledWith(
+      "directory:/repo/PwrAgent",
+      expect.objectContaining({
+        codexEnvironmentId: "environment",
+        codexEnvironmentExecutionTarget: "local",
+        codexEnvironmentSetupEnabled: true,
+      }),
+      expect.any(Object),
+    );
   });
 
   it("shows an orange moon for reported context window usage", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -2055,7 +2055,7 @@ export function ThreadView(props: ThreadViewProps) {
               }
               environmentName={
                 selectedThread.codexEnvironmentRuntime?.environmentName ??
-                "Codex environment"
+                "Environment"
               }
               error={props.archiveThreadError ?? setupFailureContinueError}
               exitCode={

--- a/apps/desktop/src/renderer/src/lib/__tests__/backend-label.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/backend-label.test.ts
@@ -35,6 +35,8 @@ describe("formatBackendLabel", () => {
   it("falls back to stable built-in and ACP labels", () => {
     expect(formatBackendLabel("codex")).toBe("OpenAI");
     expect(formatBackendLabel("grok")).toBe("Grok");
+    expect(formatBackendLabel("acp:gemini")).toBe("Gemini");
+    expect(formatBackendLabel("acp:kimi")).toBe("Kimi");
     expect(formatBackendLabel("acp:unknown")).toBe("unknown");
   });
 });

--- a/apps/desktop/src/renderer/src/lib/backend-label.ts
+++ b/apps/desktop/src/renderer/src/lib/backend-label.ts
@@ -14,5 +14,15 @@ export function formatBackendLabel(
   if (backend === "grok") {
     return "Grok";
   }
-  return backend.startsWith("acp:") ? backend.slice("acp:".length) : backend;
+  if (backend.startsWith("acp:")) {
+    const registryId = backend.slice("acp:".length);
+    if (registryId === "gemini") {
+      return "Gemini";
+    }
+    if (registryId === "kimi") {
+      return "Kimi";
+    }
+    return registryId;
+  }
+  return backend;
 }


### PR DESCRIPTION
## Summary

- I added local discovery for the installed Kimi Code CLI ACP backend.
- I exposed Kimi ACP execution modes and route mode changes through suppressed `/yolo` control prompts because Kimi ACP only reports `Default` through `session/new` and rejects non-default `session/set_mode`.
- I verify Kimi `/yolo` responses before updating PwrAgent execution mode, synchronize manual `/yolo` responses back into session state, serialize hidden control prompts with real ACP turns, and keep queued execution-mode state backend-qualified.
- I fixed Kimi launchpad materialization by preserving the ACP client receiver when hidden `/yolo` control prompts run, including the worktree + stale Codex environment setup case.
- I made local environment selection and environment command execution backend-independent so Kimi and Gemini ACP launchpads/threads can use the same `.codex/environments` scripts as Codex.
- I made ACP approval prompt labels use the selected installed ACP agent name, so Kimi approvals no longer say Gemini.
- I made compact ACP backend chips render known local backends as `Kimi` and `Gemini`.

## Verification

- I verified local Kimi ACP `session/new` only reports `Default`, `session/set_mode` rejects `yolo`, and no config-option handler is present.
- `pnpm --filter @pwragent/desktop exec vitest run src/main/__tests__/acp-client.test.ts src/main/__tests__/acp-local-discovery.test.ts src/main/__tests__/backend-registry.test.ts -t "Kimi|control prompts|ACP|queued permission-mode changes"`
- `pnpm --filter @pwragent/desktop exec vitest run src/main/__tests__/acp-client.test.ts`
- `pnpm --filter @pwragent/desktop exec vitest run src/main/__tests__/acp-client.test.ts src/main/__tests__/acp-backend-adapter.test.ts src/main/__tests__/acp-local-discovery.test.ts src/main/__tests__/backend-registry.test.ts src/main/__tests__/app-server-ipc.test.ts src/main/__tests__/overlay-store-permission-transitions.test.ts`
- `pnpm --filter @pwragent/desktop exec vitest run src/main/__tests__/backend-registry.test.ts src/renderer/src/lib/__tests__/backend-label.test.ts`
- `pnpm --filter @pwragent/desktop exec vitest run --environment jsdom src/renderer/src/features/composer/__tests__/composer.test.tsx`
- `pnpm --filter @pwragent/desktop exec tsc --noEmit --pretty false`
- `pnpm lint:boundaries`
- `git diff --check`

## Notes

- I left the existing unrelated renderer working tree edits unstaged and out of this PR.
