### PR TITLE
fix(desktop): hide worktree handoff for non-git workspaces

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -5413,6 +5413,8 @@ function formatThreadWorkspaceLabel(thread?: NavigationThreadSummary): string | 
 
 type ThreadWorkspace = {
   mode: "local" | "worktree";
+  /** True only when the path is known to be a git local/worktree relationship. */
+  gitBacked: boolean;
   /** Repository/local checkout path. In Worktree mode this is not the command CWD. */
   repositoryPath: string;
   /** Current workspace path for opening apps and running thread-scoped commands. */
@@ -5444,6 +5446,7 @@ function getThreadWorkspace(thread: NavigationThreadSummary): ThreadWorkspace | 
   if (worktreeDirectory) {
     return {
       mode: "worktree",
+      gitBacked: true,
       repositoryPath: worktreeDirectory.path,
       sourcePath: worktreeDirectory.worktreePath ?? worktreeDirectory.path,
     };
@@ -5455,8 +5458,18 @@ function getThreadWorkspace(thread: NavigationThreadSummary): ThreadWorkspace | 
   if (localDirectory) {
     return {
       mode: "local",
+      gitBacked: true,
       repositoryPath: localDirectory.path,
       sourcePath: localDirectory.path,
+    };
+  }
+
+  if (thread.projectKey) {
+    return {
+      mode: "local",
+      gitBacked: false,
+      repositoryPath: thread.projectKey,
+      sourcePath: thread.projectKey,
     };
   }
 
@@ -5468,6 +5481,10 @@ function isThreadWorkspaceHandoffEligible(params: {
   threadWorkspace?: ThreadWorkspace;
 }): boolean {
   if (!params.threadWorkspace) {
+    return false;
+  }
+
+  if (!params.threadWorkspace.gitBacked) {
     return false;
   }
 

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -3414,6 +3414,7 @@ export function Composer(props: ComposerProps) {
   const canHandoffThreadWorkspace = Boolean(
     props.thread &&
       threadWorkspace &&
+      isThreadWorkspaceHandoffEligible({ sourceBranch, threadWorkspace }) &&
       props.onHandoffThreadWorkspace &&
       props.thread.workspaceHandoff?.available !== false &&
       !sending &&
@@ -5459,15 +5460,22 @@ function getThreadWorkspace(thread: NavigationThreadSummary): ThreadWorkspace | 
     };
   }
 
-  if (thread.projectKey) {
-    return {
-      mode: "local",
-      repositoryPath: thread.projectKey,
-      sourcePath: thread.projectKey,
-    };
+  return undefined;
+}
+
+function isThreadWorkspaceHandoffEligible(params: {
+  sourceBranch?: string;
+  threadWorkspace?: ThreadWorkspace;
+}): boolean {
+  if (!params.threadWorkspace) {
+    return false;
   }
 
-  return undefined;
+  if (params.threadWorkspace.mode === "worktree") {
+    return true;
+  }
+
+  return Boolean(params.sourceBranch?.trim());
 }
 
 function buildHandoffBranchSuggestion(sourceBranch: string | undefined): string {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -3452,11 +3452,45 @@ describe("Composer", () => {
   });
 
   it("does not offer existing thread workspace handoff for non-git Workspaces", () => {
+    const projectPath = "/Users/test/.pwragent/profiles/dev/projects/2026-05-23-885b8f";
     const onHandoffThreadWorkspace = vi.fn(async () => undefined);
+    const openApplication = vi.fn(async () => ({ opened: true as const }));
+    const runCodexEnvironmentAction = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      codexEnvironmentRuntime: {
+        environmentId: "workspace-tools",
+        environmentName: "Workspace tools",
+        executionTarget: "local" as const,
+      },
+    }));
 
     render(
       <Composer
+        applications={{
+          editors: [
+            {
+              id: "vscode",
+              kind: "editor",
+              name: "VS Code",
+              source: "application",
+              appPath: "/Applications/Visual Studio Code.app",
+              canOpenWorkspace: true,
+            },
+          ],
+          terminals: [],
+          preferredEditorId: { value: "", source: "default" },
+          preferredTerminalId: { value: "", source: "default" },
+          gh: {
+            path: { value: "", source: "default" },
+            discovery: { candidates: [] },
+          },
+          git: {
+            discovery: { candidates: [] },
+          },
+        }}
         backends={[backendSummary("codex")]}
+        desktopApi={{ openApplication, runCodexEnvironmentAction }}
         disabled={false}
         onHandoffThreadWorkspace={onHandoffThreadWorkspace}
         skills={[]}
@@ -3466,8 +3500,20 @@ describe("Composer", () => {
           titleSource: "explicit",
           source: "codex",
           executionMode: "default",
-          projectKey: "/Users/test/.pwragent/profiles/dev/projects/2026-05-23-885b8f",
+          projectKey: projectPath,
           linkedDirectories: [],
+          codexEnvironmentRuntime: {
+            environmentId: "workspace-tools",
+            environmentName: "Workspace tools",
+            executionTarget: "local",
+            actions: [
+              {
+                id: "list-files",
+                name: "List files",
+                command: "ls",
+              },
+            ],
+          },
           inbox: { inInbox: false },
         }}
       />
@@ -3481,6 +3527,21 @@ describe("Composer", () => {
     expect(
       screen.queryByRole("menuitem", { name: "Handoff to New Worktree" })
     ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "VS Code" }));
+    expect(openApplication).toHaveBeenCalledWith({
+      applicationId: "vscode",
+      kind: "editor",
+      targetPath: projectPath,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Run" }));
+    expect(runCodexEnvironmentAction).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      actionId: "list-files",
+      cwd: projectPath,
+    });
   });
 
   it("lets the desktop handoff dialog move the current branch instead", async () => {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -3451,6 +3451,38 @@ describe("Composer", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("does not offer existing thread workspace handoff for non-git Workspaces", () => {
+    const onHandoffThreadWorkspace = vi.fn(async () => undefined);
+
+    render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        disabled={false}
+        onHandoffThreadWorkspace={onHandoffThreadWorkspace}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Create an Agent",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          projectKey: "/Users/test/.pwragent/profiles/dev/projects/2026-05-23-885b8f",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const workspaceMode = screen.queryByLabelText("Workspace mode");
+    if (workspaceMode) {
+      fireEvent.click(workspaceMode);
+    }
+
+    expect(
+      screen.queryByRole("menuitem", { name: "Handoff to New Worktree" })
+    ).not.toBeInTheDocument();
+  });
+
   it("lets the desktop handoff dialog move the current branch instead", async () => {
     const onHandoffThreadWorkspace = vi.fn(async () => undefined);
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -2233,6 +2233,71 @@ describe("useThreadNavigation", () => {
     );
   });
 
+  it("does not fabricate a git workspace relationship for directory-less Workspace threads", async () => {
+    const materializeDirectoryLaunchpad = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      executionMode: "default" as const,
+      workMode: "local" as const,
+    }));
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [],
+      directories: [
+        {
+          key: "workspace:/Users/test/.pwragent/projects",
+          kind: "workspace" as const,
+          label: "Workspaces",
+          path: "/Users/test/.pwragent/projects",
+          threadKeys: [],
+          needsAttentionCount: 0,
+          launchpad: {
+            directoryKey: "workspace:/Users/test/.pwragent/projects",
+            directoryKind: "workspace" as const,
+            directoryLabel: "Workspaces",
+            directoryPath: "/Users/test/.pwragent/projects",
+            backend: "codex" as const,
+            executionMode: "default" as const,
+            prompt: "Create an Agent",
+            workMode: "local" as const,
+            createdAt: 1,
+            updatedAt: 2,
+          },
+        },
+      ],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      materializeDirectoryLaunchpad,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.selectedLaunchpad?.directoryKind).toBe("workspace");
+    });
+
+    await act(async () => {
+      await result.current.materializeDirectoryLaunchpad(
+        "workspace:/Users/test/.pwragent/projects",
+      );
+    });
+
+    expect(result.current.selectedThread).toMatchObject({
+      id: "thread-1",
+      linkedDirectories: [],
+    });
+  });
+
   it("refreshes the selected thread when only the observed branch changes", async () => {
     const listeners = new Set<(event: any) => void>();
     let navigationCallCount = 0;

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -1278,16 +1278,17 @@ function buildOptimisticThreadFromLaunchpad(params: {
     acpRuntime: params.launchpad.acpRuntime,
     codexEnvironmentRuntime: params.codexEnvironmentRuntime,
     optimisticUserMessage: params.optimisticUserMessage,
-    linkedDirectories: params.launchpad.directoryPath || params.launchpad.directoryKind === "workspace"
-      ? [
-          {
-            id: `launchpad:${params.launchpad.directoryKey}`,
-            label: params.launchpad.directoryLabel,
-            path: params.launchpad.directoryPath ?? "",
-            kind: params.workMode === "worktree" ? "worktree" : "local",
-          },
-        ]
-      : [],
+    linkedDirectories:
+      params.launchpad.directoryPath && params.launchpad.directoryKind !== "workspace"
+        ? [
+            {
+              id: `launchpad:${params.launchpad.directoryKey}`,
+              label: params.launchpad.directoryLabel,
+              path: params.launchpad.directoryPath,
+              kind: params.workMode === "worktree" ? "worktree" : "local",
+            },
+          ]
+        : [],
     gitBranch:
       params.workMode === "worktree"
         ? "HEAD"


### PR DESCRIPTION
## Summary

- I hide existing-thread workspace handoff for non-git Workspace chats unless the thread has a real git-backed linked workspace.
- I preserve projectKey-only Workspace paths for non-handoff actions, including editor/terminal launch buttons and Codex environment command cwd.
- I stop optimistic Workspace thread creation from fabricating a local linked directory for the scratch project root.
- I added regression tests for the born-thread handoff menu, preserved Workspace actions, and directory-less Workspace creation path.

## Verification

- I verified `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx` passes.
- I verified `pnpm --filter @pwragent/desktop typecheck` passes.

## Notes

- Workspaces remain plain chats until the user initializes a `.git` repo inside the workspace, so Worktree is no longer presented for those non-git cases.
