### PR TITLE
fix(desktop): surface subagent review activity

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -3112,7 +3112,11 @@ describe("CodexAppServerClient", () => {
                 agentsStates: {
                   "019e5630-b147-7980-9f33-3cd7997c235a": {
                     status: "completed",
-                    message: "{\"reviewer\":\"correctness\"}",
+                    message: [
+                      "{\"reviewer\":\"correctness\",",
+                      "\"summary\":\"This is the returned review transcript that should not be collapsed before rendering.\",",
+                      "\"finding\":\"full transcript tail\"}",
+                    ].join("\n"),
                   },
                 },
               },
@@ -3192,6 +3196,14 @@ describe("CodexAppServerClient", () => {
         },
       },
     ]);
+    const activity = replay.entries[1];
+    expect(activity.type).toBe("activity");
+    if (activity.type === "activity") {
+      expect(activity.details[2]?.command?.output).toContain("full transcript tail");
+      expect(activity.details[2]?.command?.output).toContain(
+        "019e5630-b147-7980-9f33-3cd7997c235a"
+      );
+    }
 
     await client.close();
   });

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -3058,6 +3058,144 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("hydrates collaboration agent tool calls as transcript activity", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.readThreadResultByThreadId.set("thread-collab-agents", {
+      thread: {
+        turns: [
+          {
+            id: "turn-review",
+            status: "completed",
+            startedAt: 1_763_500_260,
+            completedAt: 1_763_500_290,
+            items: [
+              {
+                type: "agentMessage",
+                id: "message-1",
+                content: [{ type: "text", text: "Review team:" }],
+              },
+              {
+                type: "collabAgentToolCall",
+                id: "collab-spawn-1",
+                tool: "spawnAgent",
+                status: "completed",
+                senderThreadId: "parent-thread",
+                receiverThreadIds: ["019e5630-b147-7980-9f33-3cd7997c235a"],
+                prompt: "You are the correctness reviewer.",
+                model: "gpt-5.4-mini",
+                reasoningEffort: "medium",
+                agentsStates: {
+                  "019e5630-b147-7980-9f33-3cd7997c235a": {
+                    status: "running",
+                    message: "Inspecting the diff.",
+                  },
+                },
+              },
+              {
+                type: "collabAgentToolCall",
+                id: "collab-spawn-2",
+                tool: "spawnAgent",
+                status: "failed",
+                senderThreadId: "parent-thread",
+                receiverThreadIds: [],
+                prompt: "You are the API contract reviewer.",
+                agentsStates: {},
+              },
+              {
+                type: "collabAgentToolCall",
+                id: "collab-wait-1",
+                tool: "wait",
+                status: "completed",
+                senderThreadId: "parent-thread",
+                receiverThreadIds: ["019e5630-b147-7980-9f33-3cd7997c235a"],
+                prompt: null,
+                agentsStates: {
+                  "019e5630-b147-7980-9f33-3cd7997c235a": {
+                    status: "completed",
+                    message: "{\"reviewer\":\"correctness\"}",
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    const replay = await client.readThread({
+      threadId: "thread-collab-agents",
+    });
+
+    expect(replay.entries).toEqual([
+      {
+        type: "message",
+        id: "message-1",
+        role: "assistant",
+        text: "Review team:",
+        createdAt: 1_763_500_260_000,
+        parts: [{ type: "text", text: "Review team:" }],
+        turn: {
+          id: "turn-review",
+          status: "completed",
+          startedAt: 1_763_500_260_000,
+          completedAt: 1_763_500_290_000,
+        },
+      },
+      {
+        type: "activity",
+        id: "activity-collab-spawn-1",
+        summary: "Spawned 1 agent, Waited on 1 agent, 1 collaboration tool failed",
+        createdAt: 1_763_500_260_000,
+        status: "failed",
+        details: [
+          expect.objectContaining({
+            id: "collab-spawn-1",
+            kind: "command",
+            label: "Spawned agent 019e5630",
+            status: "completed",
+            command: expect.objectContaining({
+              displayCommand: "spawnAgent 019e5630",
+              output: expect.stringContaining("Prompt: You are the correctness reviewer."),
+            }),
+          }),
+          expect.objectContaining({
+            id: "collab-spawn-2",
+            kind: "command",
+            label: "Failed to spawn agent",
+            status: "failed",
+            command: expect.objectContaining({
+              displayCommand: "spawnAgent",
+              output: expect.stringContaining("Prompt: You are the API contract reviewer."),
+            }),
+          }),
+          expect.objectContaining({
+            id: "collab-wait-1",
+            kind: "command",
+            label: "Waited on agent 019e5630",
+            status: "completed",
+            command: expect.objectContaining({
+              displayCommand: "wait 019e5630",
+              output: expect.stringContaining("019e5630: completed"),
+            }),
+          }),
+        ],
+        turn: {
+          id: "turn-review",
+          status: "completed",
+          startedAt: 1_763_500_260_000,
+          completedAt: 1_763_500_290_000,
+        },
+      },
+    ]);
+
+    await client.close();
+  });
+
   it("normalizes request_user_input requests from rpc envelope ids", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
 

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -2565,19 +2565,34 @@ function formatCollabAgentToolLabel(params: {
   const failedPrefix = params.status === "failed" ? "Failed to " : "";
 
   if (params.tool === "spawnAgent") {
-    return `${failedPrefix}${params.status === "failed" ? "spawn" : "Spawned"} ${targetLabel}`;
+    if (params.status === "failed") {
+      return `${failedPrefix}spawn ${targetLabel}`;
+    }
+    return `${params.status === "in_progress" ? "Spawning" : "Spawned"} ${targetLabel}`;
   }
   if (params.tool === "wait") {
-    return `${failedPrefix}${params.status === "failed" ? "wait on" : "Waited on"} ${targetLabel}`;
+    if (params.status === "failed") {
+      return `${failedPrefix}wait on ${targetLabel}`;
+    }
+    return `${params.status === "in_progress" ? "Waiting on" : "Waited on"} ${targetLabel}`;
   }
   if (params.tool === "sendInput") {
-    return `${failedPrefix}${params.status === "failed" ? "send input to" : "Sent input to"} ${targetLabel}`;
+    if (params.status === "failed") {
+      return `${failedPrefix}send input to ${targetLabel}`;
+    }
+    return `${params.status === "in_progress" ? "Sending input to" : "Sent input to"} ${targetLabel}`;
   }
   if (params.tool === "resumeAgent") {
-    return `${failedPrefix}${params.status === "failed" ? "resume" : "Resumed"} ${targetLabel}`;
+    if (params.status === "failed") {
+      return `${failedPrefix}resume ${targetLabel}`;
+    }
+    return `${params.status === "in_progress" ? "Resuming" : "Resumed"} ${targetLabel}`;
   }
   if (params.tool === "closeAgent") {
-    return `${failedPrefix}${params.status === "failed" ? "close" : "Closed"} ${targetLabel}`;
+    if (params.status === "failed") {
+      return `${failedPrefix}close ${targetLabel}`;
+    }
+    return `${params.status === "in_progress" ? "Closing" : "Closed"} ${targetLabel}`;
   }
   return `${failedPrefix}Used ${params.tool}`;
 }
@@ -2591,7 +2606,7 @@ function buildCollabAgentCommandDetail(params: {
   const prompt = pickString(params.item, ["prompt"]);
   const model = pickString(params.item, ["model"]);
   const reasoningEffort = pickString(params.item, ["reasoningEffort", "reasoning_effort"]);
-  const stateSummary = summarizeCollabAgentStates(asRecord(params.item.agentsStates));
+  const stateSummary = formatCollabAgentStates(asRecord(params.item.agentsStates));
   const output = [
     params.receiverThreadIds.length > 0
       ? `Agents: ${params.receiverThreadIds.join(", ")}`
@@ -2613,7 +2628,7 @@ function buildCollabAgentCommandDetail(params: {
   };
 }
 
-function summarizeCollabAgentStates(
+function formatCollabAgentStates(
   states: Record<string, unknown> | null
 ): string | undefined {
   if (!states) {
@@ -2626,11 +2641,23 @@ function summarizeCollabAgentStates(
     }
     const status = pickString(record, ["status"]) ?? "unknown";
     const message = pickString(record, ["message"]);
-    return [
-      `${shortAgentId(agentId)}: ${status}${message ? ` - ${truncateActivityText(message, 240)}` : ""}`
-    ];
+    const header = `${shortAgentId(agentId)}: ${status} (${agentId})`;
+    if (!message) {
+      return [header];
+    }
+    return [`${header}\nOutput:\n${indentCollabAgentMessage(message)}`];
   });
   return lines.length > 0 ? lines.join("\n") : undefined;
+}
+
+function indentCollabAgentMessage(message: string): string {
+  return message
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n")
+    .trim()
+    .split("\n")
+    .map((line) => `  ${line}`)
+    .join("\n");
 }
 
 function shortAgentId(agentId: string): string {

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -2101,6 +2101,7 @@ function isActivityItemType(itemType: string | undefined): boolean {
     normalized === "functioncall" ||
     normalized === "mcptoolcall" ||
     normalized === "dynamictoolcall" ||
+    normalized === "collabagenttoolcall" ||
     normalized === "websearch" ||
     normalized === "imageview" ||
     normalized === "imagegeneration"
@@ -2258,6 +2259,9 @@ function summarizeActivityItems(
   let changedFileAdditions = 0;
   let changedFileRemovals = 0;
   let toolCalls = 0;
+  let spawnedAgents = 0;
+  let waitedAgents = 0;
+  let failedCollabCalls = 0;
   let status: AppServerThreadActivityStatus | undefined;
 
   for (const item of items) {
@@ -2435,6 +2439,35 @@ function summarizeActivityItems(
       continue;
     }
 
+    if (normalizedItemType === "collabagenttoolcall") {
+      const receiverThreadIds = readStringArray(item.receiverThreadIds);
+      const tool = pickString(item, ["tool"]) ?? "collabAgent";
+      if (tool === "spawnAgent" && itemStatus !== "failed") {
+        spawnedAgents += receiverThreadIds.length || 1;
+      } else if (tool === "wait") {
+        waitedAgents += receiverThreadIds.length;
+      }
+      if (itemStatus === "failed") {
+        failedCollabCalls += 1;
+      }
+
+      const label = formatCollabAgentToolLabel({ tool, receiverThreadIds, status: itemStatus });
+      const commandDetail = buildCollabAgentCommandDetail({
+        item,
+        label,
+        receiverThreadIds,
+        tool,
+      });
+      pushActivityDetail(details, {
+        id: itemId,
+        kind: "command",
+        label: appendElapsedLabel(label, elapsedMs),
+        command: commandDetail,
+        status: itemStatus
+      });
+      continue;
+    }
+
     if (
       normalizedItemType === "mcptoolcall" ||
       normalizedItemType === "dynamictoolcall" ||
@@ -2481,6 +2514,17 @@ function summarizeActivityItems(
   if (toolCalls > 0) {
     summaryParts.push(`Used ${toolCalls} tool${toolCalls === 1 ? "" : "s"}`);
   }
+  if (spawnedAgents > 0) {
+    summaryParts.push(`Spawned ${spawnedAgents} agent${spawnedAgents === 1 ? "" : "s"}`);
+  }
+  if (waitedAgents > 0) {
+    summaryParts.push(`Waited on ${waitedAgents} agent${waitedAgents === 1 ? "" : "s"}`);
+  }
+  if (failedCollabCalls > 0) {
+    summaryParts.push(
+      `${failedCollabCalls} collaboration tool${failedCollabCalls === 1 ? "" : "s"} failed`
+    );
+  }
 
   if (summaryParts.length === 0 && details.length === 0) {
     return undefined;
@@ -2498,6 +2542,104 @@ function summarizeActivityItems(
     details,
     ...(turn ? { turn } : {})
   };
+}
+
+function readStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string" && entry.trim() !== "")
+    : [];
+}
+
+function formatCollabAgentToolLabel(params: {
+  tool: string;
+  receiverThreadIds: string[];
+  status: AppServerThreadActivityStatus | undefined;
+}): string {
+  const targetCount = params.receiverThreadIds.length;
+  const targetLabel =
+    targetCount === 1
+      ? `agent ${shortAgentId(params.receiverThreadIds[0] ?? "")}`
+      : targetCount > 1
+        ? `${targetCount} agents`
+        : "agent";
+  const failedPrefix = params.status === "failed" ? "Failed to " : "";
+
+  if (params.tool === "spawnAgent") {
+    return `${failedPrefix}${params.status === "failed" ? "spawn" : "Spawned"} ${targetLabel}`;
+  }
+  if (params.tool === "wait") {
+    return `${failedPrefix}${params.status === "failed" ? "wait on" : "Waited on"} ${targetLabel}`;
+  }
+  if (params.tool === "sendInput") {
+    return `${failedPrefix}${params.status === "failed" ? "send input to" : "Sent input to"} ${targetLabel}`;
+  }
+  if (params.tool === "resumeAgent") {
+    return `${failedPrefix}${params.status === "failed" ? "resume" : "Resumed"} ${targetLabel}`;
+  }
+  if (params.tool === "closeAgent") {
+    return `${failedPrefix}${params.status === "failed" ? "close" : "Closed"} ${targetLabel}`;
+  }
+  return `${failedPrefix}Used ${params.tool}`;
+}
+
+function buildCollabAgentCommandDetail(params: {
+  item: Record<string, unknown>;
+  label: string;
+  receiverThreadIds: string[];
+  tool: string;
+}): AppServerThreadCommandDetail {
+  const prompt = pickString(params.item, ["prompt"]);
+  const model = pickString(params.item, ["model"]);
+  const reasoningEffort = pickString(params.item, ["reasoningEffort", "reasoning_effort"]);
+  const stateSummary = summarizeCollabAgentStates(asRecord(params.item.agentsStates));
+  const output = [
+    params.receiverThreadIds.length > 0
+      ? `Agents: ${params.receiverThreadIds.join(", ")}`
+      : undefined,
+    model ? `Model: ${model}` : undefined,
+    reasoningEffort ? `Reasoning effort: ${reasoningEffort}` : undefined,
+    prompt ? `Prompt: ${truncateActivityText(prompt, 1_000)}` : undefined,
+    stateSummary ? `Agent states:\n${stateSummary}` : undefined,
+  ].filter((entry): entry is string => Boolean(entry)).join("\n\n");
+
+  const displayCommand =
+    params.receiverThreadIds.length > 0
+      ? `${params.tool} ${params.receiverThreadIds.map(shortAgentId).join(", ")}`
+      : params.tool;
+  return {
+    displayCommand,
+    rawCommand: params.tool,
+    ...(output ? { output } : {}),
+  };
+}
+
+function summarizeCollabAgentStates(
+  states: Record<string, unknown> | null
+): string | undefined {
+  if (!states) {
+    return undefined;
+  }
+  const lines = Object.entries(states).flatMap(([agentId, value]) => {
+    const record = asRecord(value);
+    if (!record) {
+      return [];
+    }
+    const status = pickString(record, ["status"]) ?? "unknown";
+    const message = pickString(record, ["message"]);
+    return [
+      `${shortAgentId(agentId)}: ${status}${message ? ` - ${truncateActivityText(message, 240)}` : ""}`
+    ];
+  });
+  return lines.length > 0 ? lines.join("\n") : undefined;
+}
+
+function shortAgentId(agentId: string): string {
+  return agentId.length > 8 ? agentId.slice(0, 8) : agentId;
+}
+
+function truncateActivityText(text: string, maxLength: number): string {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  return normalized.length > maxLength ? `${normalized.slice(0, maxLength - 3)}...` : normalized;
 }
 
 function extractThreadEntries(value: unknown): AppServerThreadEntry[] {

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptActivity.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptActivity.tsx
@@ -118,6 +118,16 @@ export function TranscriptActivity(props: TranscriptActivityProps) {
                       </span>
                     </span>
                   ) : null}
+                  {detail.status ? (
+                    <span
+                      className={[
+                        "transcript-activity__detail-status",
+                        `transcript-activity__detail-status--${detail.status}`
+                      ].join(" ")}
+                    >
+                      {formatActivityDetailStatus(detail.status)}
+                    </span>
+                  ) : null}
                 </div>
                 {hasNestedDetails && isDetailExpanded ? (
                   <div id={nestedId} className="transcript-activity__detail-body">
@@ -132,4 +142,16 @@ export function TranscriptActivity(props: TranscriptActivityProps) {
       ) : null}
     </aside>
   );
+}
+
+function formatActivityDetailStatus(
+  status: NonNullable<AppServerThreadActivityEntry["status"]>
+): string {
+  if (status === "in_progress") {
+    return "Running";
+  }
+  if (status === "completed") {
+    return "Done";
+  }
+  return status[0]?.toUpperCase() ? `${status[0].toUpperCase()}${status.slice(1)}` : status;
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptCommandOutput.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptCommandOutput.tsx
@@ -19,11 +19,12 @@ export function TranscriptCommandOutput(props: TranscriptCommandOutputProps) {
 
   const preview = buildOutputPreview(output, isExpanded);
   const statusText = formatCommandStatus(props.detail);
+  const sourceLabel = isAgentCommand(command.rawCommand) ? "Agent" : "Shell";
 
   return (
     <div className="transcript-command">
       <div className="transcript-command__meta">
-        <span className="transcript-command__source">Shell</span>
+        <span className="transcript-command__source">{sourceLabel}</span>
         {statusText ? (
           <span className="transcript-command__status">{statusText}</span>
         ) : null}
@@ -75,6 +76,14 @@ export function TranscriptCommandOutput(props: TranscriptCommandOutputProps) {
       ) : null}
     </div>
   );
+}
+
+function isAgentCommand(rawCommand: string | undefined): boolean {
+  return rawCommand === "spawnAgent" ||
+    rawCommand === "wait" ||
+    rawCommand === "sendInput" ||
+    rawCommand === "resumeAgent" ||
+    rawCommand === "closeAgent";
 }
 
 function sanitizeCommandOutput(value: string | undefined): string {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { buildLiveToolDetails } from "../live-transcript-activity";
+
+describe("buildLiveToolDetails", () => {
+  it("surfaces collaboration agent activity from live tool items", () => {
+    const details = buildLiveToolDetails({
+      type: "collabAgentToolCall",
+      id: "collab-spawn-1",
+      tool: "spawnAgent",
+      status: "inProgress",
+      senderThreadId: "parent-thread",
+      receiverThreadIds: ["019e5630-b147-7980-9f33-3cd7997c235a"],
+      prompt: "You are the correctness reviewer.",
+      agentsStates: {
+        "019e5630-b147-7980-9f33-3cd7997c235a": {
+          status: "running",
+          message: "Inspecting the diff.",
+        },
+      },
+    });
+
+    expect(details).toEqual([
+      {
+        id: "collab-spawn-1",
+        kind: "command",
+        label: "Spawned agent 019e5630",
+        status: "in_progress",
+        command: expect.objectContaining({
+          displayCommand: "spawnAgent 019e5630",
+          output: expect.stringContaining("Prompt: You are the correctness reviewer."),
+        }),
+      },
+    ]);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts
@@ -14,7 +14,7 @@ describe("buildLiveToolDetails", () => {
       agentsStates: {
         "019e5630-b147-7980-9f33-3cd7997c235a": {
           status: "running",
-          message: "Inspecting the diff.",
+          message: "Inspecting the diff.\nStill running reviewer output.",
         },
       },
     });
@@ -23,7 +23,7 @@ describe("buildLiveToolDetails", () => {
       {
         id: "collab-spawn-1",
         kind: "command",
-        label: "Spawned agent 019e5630",
+        label: "Spawning agent 019e5630",
         status: "in_progress",
         command: expect.objectContaining({
           displayCommand: "spawnAgent 019e5630",
@@ -31,5 +31,6 @@ describe("buildLiveToolDetails", () => {
         }),
       },
     ]);
+    expect(details[0]?.command?.output).toContain("Still running reviewer output.");
   });
 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-command-output.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-command-output.test.tsx
@@ -30,7 +30,32 @@ describe("TranscriptCommandOutput", () => {
 
     expect(screen.getByText("$ npm view dive")).toBeInTheDocument();
     expect(screen.getByText("dive@0.5.0 | Proprietary | deps: none")).toBeInTheDocument();
+    expect(screen.getByText("Shell")).toBeInTheDocument();
     expect(screen.getByText("Success · ran for 373ms")).toBeInTheDocument();
+  });
+
+  it("labels collaboration agent output separately from shell output", () => {
+    render(
+      <TranscriptCommandOutput
+        detail={{
+          id: "agent-1",
+          kind: "command",
+          label: "Waited on agent 019e5630",
+          status: "completed",
+          command: {
+            displayCommand: "wait 019e5630",
+            rawCommand: "wait",
+            output: "019e5630: completed\nOutput:\n  Review transcript",
+          },
+        }}
+      />
+    );
+
+    expect(screen.getByText("Agent")).toBeInTheDocument();
+    expect(screen.getByText("$ wait 019e5630")).toBeInTheDocument();
+    expect(screen.getAllByText((_, element) =>
+      element?.textContent?.includes("Review transcript") ?? false
+    ).length).toBeGreaterThan(0);
   });
 
   it("truncates long output and expands on demand", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
@@ -44,6 +44,12 @@ function readRecord(value: unknown): Record<string, unknown> | undefined {
     : undefined;
 }
 
+function readStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string" && entry.trim() !== "")
+    : [];
+}
+
 function normalizeTimestamp(value: unknown): number | undefined {
   if (typeof value !== "number" || !Number.isFinite(value)) {
     return undefined;
@@ -307,6 +313,14 @@ function buildLiveToolLabel(
   status: AppServerThreadActivityDetail["status"],
   toolName: string
 ): string {
+  if (itemType === "collabagenttoolcall") {
+    return formatCollabAgentToolLabel({
+      receiverThreadIds: readStringArray(item.receiverThreadIds),
+      status,
+      tool: toolName,
+    });
+  }
+
   if (itemType === "commandexecution") {
     const command = readString(item, "command");
     return (
@@ -324,6 +338,95 @@ function buildLiveToolLabel(
   return formatLiveToolName(toolName, status);
 }
 
+function formatCollabAgentToolLabel(params: {
+  tool: string;
+  receiverThreadIds: string[];
+  status: AppServerThreadActivityDetail["status"];
+}): string {
+  const targetCount = params.receiverThreadIds.length;
+  const targetLabel =
+    targetCount === 1
+      ? `agent ${shortAgentId(params.receiverThreadIds[0] ?? "")}`
+      : targetCount > 1
+        ? `${targetCount} agents`
+        : "agent";
+  const failedPrefix = params.status === "failed" ? "Failed to " : "";
+
+  if (params.tool === "spawnAgent") {
+    return `${failedPrefix}${params.status === "failed" ? "spawn" : "Spawned"} ${targetLabel}`;
+  }
+  if (params.tool === "wait") {
+    return `${failedPrefix}${params.status === "failed" ? "wait on" : "Waited on"} ${targetLabel}`;
+  }
+  if (params.tool === "sendInput") {
+    return `${failedPrefix}${params.status === "failed" ? "send input to" : "Sent input to"} ${targetLabel}`;
+  }
+  if (params.tool === "resumeAgent") {
+    return `${failedPrefix}${params.status === "failed" ? "resume" : "Resumed"} ${targetLabel}`;
+  }
+  if (params.tool === "closeAgent") {
+    return `${failedPrefix}${params.status === "failed" ? "close" : "Closed"} ${targetLabel}`;
+  }
+  return `${failedPrefix}Used ${params.tool}`;
+}
+
+function buildCollabAgentCommandDetail(
+  item: Record<string, unknown>,
+  toolName: string,
+  receiverThreadIds: string[]
+): AppServerThreadCommandDetail {
+  const prompt = readString(item, "prompt");
+  const model = readString(item, "model");
+  const reasoningEffort =
+    readString(item, "reasoningEffort") ?? readString(item, "reasoning_effort");
+  const stateSummary = summarizeCollabAgentStates(readRecord(item.agentsStates));
+  const output = [
+    receiverThreadIds.length > 0 ? `Agents: ${receiverThreadIds.join(", ")}` : undefined,
+    model ? `Model: ${model}` : undefined,
+    reasoningEffort ? `Reasoning effort: ${reasoningEffort}` : undefined,
+    prompt ? `Prompt: ${truncateActivityText(prompt, 1_000)}` : undefined,
+    stateSummary ? `Agent states:\n${stateSummary}` : undefined,
+  ].filter((entry): entry is string => Boolean(entry)).join("\n\n");
+
+  return {
+    displayCommand:
+      receiverThreadIds.length > 0
+        ? `${toolName} ${receiverThreadIds.map(shortAgentId).join(", ")}`
+        : toolName,
+    rawCommand: toolName,
+    ...(output ? { output } : {}),
+  };
+}
+
+function summarizeCollabAgentStates(
+  states: Record<string, unknown> | undefined
+): string | undefined {
+  if (!states) {
+    return undefined;
+  }
+  const lines = Object.entries(states).flatMap(([agentId, value]) => {
+    const record = readRecord(value);
+    if (!record) {
+      return [];
+    }
+    const status = readString(record, "status") ?? "unknown";
+    const message = readString(record, "message");
+    return [
+      `${shortAgentId(agentId)}: ${status}${message ? ` - ${truncateActivityText(message, 240)}` : ""}`
+    ];
+  });
+  return lines.length > 0 ? lines.join("\n") : undefined;
+}
+
+function shortAgentId(agentId: string): string {
+  return agentId.length > 8 ? agentId.slice(0, 8) : agentId;
+}
+
+function truncateActivityText(text: string, maxLength: number): string {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  return normalized.length > maxLength ? `${normalized.slice(0, maxLength - 3)}...` : normalized;
+}
+
 export function buildLiveToolDetails(
   item: Record<string, unknown>
 ): AppServerThreadActivityDetail[] {
@@ -332,6 +435,7 @@ export function buildLiveToolDetails(
     itemType !== "dynamictoolcall" &&
     itemType !== "commandexecution" &&
     itemType !== "mcptoolcall" &&
+    itemType !== "collabagenttoolcall" &&
     itemType !== "websearch"
   ) {
     return [];
@@ -354,6 +458,8 @@ export function buildLiveToolDetails(
   const command = itemType === "commandexecution" ? readString(item, "command") : undefined;
   const commandDetail = itemType === "commandexecution"
     ? buildLiveCommandDetail(item, command, elapsedMs)
+    : itemType === "collabagenttoolcall"
+      ? buildCollabAgentCommandDetail(item, toolName, readStringArray(item.receiverThreadIds))
     : undefined;
   const details: AppServerThreadActivityDetail[] = [
     {

--- a/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
@@ -353,19 +353,34 @@ function formatCollabAgentToolLabel(params: {
   const failedPrefix = params.status === "failed" ? "Failed to " : "";
 
   if (params.tool === "spawnAgent") {
-    return `${failedPrefix}${params.status === "failed" ? "spawn" : "Spawned"} ${targetLabel}`;
+    if (params.status === "failed") {
+      return `${failedPrefix}spawn ${targetLabel}`;
+    }
+    return `${params.status === "in_progress" ? "Spawning" : "Spawned"} ${targetLabel}`;
   }
   if (params.tool === "wait") {
-    return `${failedPrefix}${params.status === "failed" ? "wait on" : "Waited on"} ${targetLabel}`;
+    if (params.status === "failed") {
+      return `${failedPrefix}wait on ${targetLabel}`;
+    }
+    return `${params.status === "in_progress" ? "Waiting on" : "Waited on"} ${targetLabel}`;
   }
   if (params.tool === "sendInput") {
-    return `${failedPrefix}${params.status === "failed" ? "send input to" : "Sent input to"} ${targetLabel}`;
+    if (params.status === "failed") {
+      return `${failedPrefix}send input to ${targetLabel}`;
+    }
+    return `${params.status === "in_progress" ? "Sending input to" : "Sent input to"} ${targetLabel}`;
   }
   if (params.tool === "resumeAgent") {
-    return `${failedPrefix}${params.status === "failed" ? "resume" : "Resumed"} ${targetLabel}`;
+    if (params.status === "failed") {
+      return `${failedPrefix}resume ${targetLabel}`;
+    }
+    return `${params.status === "in_progress" ? "Resuming" : "Resumed"} ${targetLabel}`;
   }
   if (params.tool === "closeAgent") {
-    return `${failedPrefix}${params.status === "failed" ? "close" : "Closed"} ${targetLabel}`;
+    if (params.status === "failed") {
+      return `${failedPrefix}close ${targetLabel}`;
+    }
+    return `${params.status === "in_progress" ? "Closing" : "Closed"} ${targetLabel}`;
   }
   return `${failedPrefix}Used ${params.tool}`;
 }
@@ -379,7 +394,7 @@ function buildCollabAgentCommandDetail(
   const model = readString(item, "model");
   const reasoningEffort =
     readString(item, "reasoningEffort") ?? readString(item, "reasoning_effort");
-  const stateSummary = summarizeCollabAgentStates(readRecord(item.agentsStates));
+  const stateSummary = formatCollabAgentStates(readRecord(item.agentsStates));
   const output = [
     receiverThreadIds.length > 0 ? `Agents: ${receiverThreadIds.join(", ")}` : undefined,
     model ? `Model: ${model}` : undefined,
@@ -398,7 +413,7 @@ function buildCollabAgentCommandDetail(
   };
 }
 
-function summarizeCollabAgentStates(
+function formatCollabAgentStates(
   states: Record<string, unknown> | undefined
 ): string | undefined {
   if (!states) {
@@ -411,11 +426,23 @@ function summarizeCollabAgentStates(
     }
     const status = readString(record, "status") ?? "unknown";
     const message = readString(record, "message");
-    return [
-      `${shortAgentId(agentId)}: ${status}${message ? ` - ${truncateActivityText(message, 240)}` : ""}`
-    ];
+    const header = `${shortAgentId(agentId)}: ${status} (${agentId})`;
+    if (!message) {
+      return [header];
+    }
+    return [`${header}\nOutput:\n${indentCollabAgentMessage(message)}`];
   });
   return lines.length > 0 ? lines.join("\n") : undefined;
+}
+
+function indentCollabAgentMessage(message: string): string {
+  return message
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n")
+    .trim()
+    .split("\n")
+    .map((line) => `  ${line}`)
+    .join("\n");
 }
 
 function shortAgentId(agentId: string): string {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -7341,6 +7341,29 @@ textarea,
   font-size: 12px;
 }
 
+.transcript-activity__detail-status {
+  flex: 0 0 auto;
+  padding: 1px 7px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.transcript-activity__detail-status--completed {
+  color: var(--success-text);
+}
+
+.transcript-activity__detail-status--failed {
+  color: var(--danger-text);
+}
+
+.transcript-activity__detail-status--in_progress {
+  color: var(--info-text);
+}
+
 .transcript-activity__detail-body {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary

- Surface Codex collaboration agent tool calls in thread activity instead of dropping them from transcripts
- Show spawned/waited agent status inline and preserve returned agent output in expandable transcript drawers
- Label collaboration output as Agent rather than Shell and cover replay/live hydration paths with tests

## Verification

- I ran `pnpm test apps/desktop/src/main/__tests__/codex-client.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-command-output.test.tsx`
- I ran `pnpm --filter @pwragent/desktop typecheck`
- I ran `git diff --check`

## Notes

- This makes `$ce:review` subagent spawn/wait activity visible in PwrAgent transcripts. The underlying Codex subagents are platform `spawn_agent` calls, not shell-launched Codex or Claude CLI processes.
