### PR TITLE
feat(messaging): expose ACP runtime modes

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -2786,7 +2786,9 @@ describe("MessagingController", () => {
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "confirmation",
       title: "Ready to start",
-      body: expect.stringContaining("Runtime mode: Yolo"),
+      body: expect.stringMatching(
+        /Permissions: Full[\s\S]*Runtime mode: Yolo|Runtime mode: Yolo[\s\S]*Permissions: Full/,
+      ),
     });
 
     await harness.controller.handleInboundEvent(buildTextEvent("Use yolo"));
@@ -2795,10 +2797,87 @@ describe("MessagingController", () => {
       directoryKey: expect.stringMatching(/^messaging:browse:/),
       launchpad: expect.objectContaining({
         backend: "acp:gemini",
+        executionMode: "full-access",
         acpRuntime: expect.objectContaining({
           currentModeId: "yolo",
         }),
       }),
+    });
+  });
+
+  it("uses inherited ACP runtime state when opening the new-thread picker", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.launchpadDefaults = {
+      ...navigation.launchpadDefaults,
+      backend: "acp:gemini",
+      acpRuntime: {
+        currentModeId: "default",
+        updatedAt: 1000,
+      },
+    };
+    navigation.directories[0] = {
+      ...navigation.directories[0]!,
+      launchpad: {
+        directoryKey: "directory:pwragent",
+        directoryKind: "directory",
+        directoryLabel: "PwrAgent",
+        directoryPath: "/repo/pwragent",
+        backend: "acp:gemini",
+        executionMode: "full-access",
+        acpRuntime: {
+          currentModeId: "yolo",
+          updatedAt: 1000,
+        },
+        prompt: "",
+        workMode: "local",
+        createdAt: 1000,
+        updatedAt: 1000,
+      },
+    };
+    const harness = await createHarness({
+      navigation,
+      listBackends: async (): Promise<ListBackendsResponse> => ({
+        fetchedAt: 1000,
+        backends: [buildAcpRuntimeBackendSummary()],
+      }),
+    });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Ready to start",
+      body: expect.stringContaining("Runtime mode: Yolo"),
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "browse:new:runtime-mode" }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Select runtime mode",
+      actions: expect.arrayContaining([
+        expect.objectContaining({
+          id: "browse:new:set-runtime-mode",
+          label: "Yolo (current)",
+          value: {
+            optionId: "mode",
+            source: "mode",
+            value: "yolo",
+          },
+        }),
+      ]),
     });
   });
 

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -14,6 +14,7 @@ import type {
   MaterializeDirectoryLaunchpadRequest,
   MessagingToolUpdateMode,
   NavigationSnapshot,
+  SetAcpSessionRuntimeOptionRequest,
   SetThreadExecutionModeRequest,
   SetThreadModelSettingsRequest,
   StartThreadRequest,
@@ -31,6 +32,7 @@ import type {
   MessagingInboundCallbackEvent,
   MessagingInboundEvent,
   MessagingInboundTextEvent,
+  MessagingJsonValue,
   MessagingSurfaceIntent,
 } from "@pwragent/messaging-interface";
 import { PERMISSIVE_CAPABILITY_PROFILE } from "@pwragent/messaging-interface/testing";
@@ -2698,13 +2700,241 @@ describe("MessagingController", () => {
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "confirmation",
       title: "Ready to start",
-      body: expect.stringContaining("Runtime mode: Agent default (desktop-only)"),
+      body: expect.stringContaining("Runtime mode: Agent default"),
     });
     expect(harness.delivered.at(-1)).toMatchObject({
       body: expect.stringContaining("Model: gemini-3-flash-preview"),
     });
     expect(harness.delivered.at(-1)).toMatchObject({
       body: expect.not.stringContaining("Runtime mode: Gemini 3 Flash Preview"),
+    });
+  });
+
+  it("lets ACP messaging choose a runtime mode before starting a new thread", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.launchpadDefaults = {
+      ...navigation.launchpadDefaults,
+      backend: "acp:gemini",
+      acpRuntime: {
+        currentModeId: "default",
+        updatedAt: 1000,
+      },
+    };
+    const harness = await createHarness({
+      navigation,
+      listBackends: async (): Promise<ListBackendsResponse> => ({
+        fetchedAt: 1000,
+        backends: [buildAcpRuntimeBackendSummary()],
+      }),
+    });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Ready to start",
+      body: expect.stringContaining("Runtime mode: Default"),
+      actions: expect.arrayContaining([
+        expect.objectContaining({
+          id: "browse:new:runtime-mode",
+          label: "Runtime: Default",
+        }),
+      ]),
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "browse:new:runtime-mode" }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Select runtime mode",
+      actions: expect.arrayContaining([
+        expect.objectContaining({
+          id: "browse:new:set-runtime-mode",
+          label: "Yolo",
+          value: {
+            optionId: "mode",
+            source: "mode",
+            value: "yolo",
+          },
+        }),
+      ]),
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:new:set-runtime-mode",
+        value: {
+          optionId: "mode",
+          source: "mode",
+          value: "yolo",
+        },
+      }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Ready to start",
+      body: expect.stringContaining("Runtime mode: Yolo"),
+    });
+
+    await harness.controller.handleInboundEvent(buildTextEvent("Use yolo"));
+
+    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith({
+      directoryKey: expect.stringMatching(/^messaging:browse:/),
+      launchpad: expect.objectContaining({
+        backend: "acp:gemini",
+        acpRuntime: expect.objectContaining({
+          currentModeId: "yolo",
+        }),
+      }),
+    });
+  });
+
+  it("keeps a permissions action when ACP inherits full access defaults", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.launchpadDefaults = {
+      ...navigation.launchpadDefaults,
+      backend: "acp:gemini",
+      executionMode: "full-access",
+      acpRuntime: {
+        currentModeId: "default",
+        updatedAt: 1000,
+      },
+    };
+    const harness = await createHarness({
+      navigation,
+      listBackends: async (): Promise<ListBackendsResponse> => ({
+        fetchedAt: 1000,
+        backends: [buildAcpRuntimeBackendSummary()],
+      }),
+    });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Ready to start",
+      body: expect.stringContaining("Permissions: Full"),
+      actions: expect.arrayContaining([
+        expect.objectContaining({
+          id: "browse:new:permissions",
+          label: "Permissions: Full",
+        }),
+      ]),
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "browse:new:permissions" }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Ready to start",
+      body: expect.not.stringContaining("Permissions: Full"),
+      actions: expect.not.arrayContaining([
+        expect.objectContaining({
+          id: "browse:new:permissions",
+          label: "Permissions: Full",
+        }),
+      ]),
+    });
+  });
+
+  it("warning-gates risky ACP runtime modes from messaging", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.launchpadDefaults = {
+      ...navigation.launchpadDefaults,
+      backend: "acp:gemini",
+      acpRuntime: {
+        currentModeId: "default",
+        updatedAt: 1000,
+      },
+    };
+    const harness = await createHarness({
+      navigation,
+      fullAccessControls: {
+        allowEscalation: true,
+        allowThreadResume: true,
+        warningPolicy: "always",
+      },
+      listBackends: async (): Promise<ListBackendsResponse> => ({
+        fetchedAt: 1000,
+        backends: [buildAcpRuntimeBackendSummary()],
+      }),
+    });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:new:set-runtime-mode",
+        value: {
+          optionId: "mode",
+          source: "mode",
+          value: "yolo",
+        },
+      }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Enable Yolo?",
+      body: expect.stringContaining("Yolo may allow the ACP agent"),
+      actions: expect.arrayContaining([
+        expect.objectContaining({
+          id: "acp-runtime-risk:accept",
+        }),
+      ]),
+    });
+
+    const warningIntent = harness.delivered.at(-1) as {
+      actions?: Array<{ id: string; value?: unknown }>;
+    };
+    const acceptAction = warningIntent.actions?.find(
+      (action) => action.id === "acp-runtime-risk:accept",
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "acp-runtime-risk:accept",
+        value: acceptAction?.value as MessagingJsonValue | undefined,
+      }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Ready to start",
+      body: expect.stringContaining("Runtime mode: Yolo"),
     });
   });
 
@@ -7897,6 +8127,87 @@ describe("MessagingController", () => {
     );
   });
 
+  it("lets ACP messaging change runtime mode from the status card", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.threads[0] = {
+      ...navigation.threads[0]!,
+      source: "acp:gemini",
+      executionMode: "default",
+      acpRuntime: {
+        currentModeId: "default",
+        updatedAt: 1000,
+      },
+    };
+    const harness = await createHarness({
+      navigation,
+      listBackends: async (): Promise<ListBackendsResponse> => ({
+        fetchedAt: 1000,
+        backends: [buildAcpRuntimeBackendSummary()],
+      }),
+    });
+    await harness.store.upsertBinding({
+      id: "binding:telegram:dm::chat-1:acp:gemini:thread-1",
+      authorizedActorIds: ["user-1"],
+      backend: "acp:gemini",
+      channel: buildCommandEvent("/status").channel,
+      createdAt: 900,
+      threadId: "thread-1",
+      updatedAt: 900,
+    });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/status"));
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "status",
+      text: expect.stringContaining("Runtime mode: Default"),
+      actions: expect.arrayContaining([
+        expect.objectContaining({
+          id: "status:runtime-mode",
+          label: "Runtime: Default",
+        }),
+      ]),
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "status:runtime-mode" }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "single_select",
+      prompt: "Select Runtime Mode",
+      choices: expect.arrayContaining([
+        expect.objectContaining({
+          id: "status:set-runtime-mode",
+          label: "Yolo",
+          value: {
+            optionId: "mode",
+            source: "mode",
+            value: "yolo",
+          },
+        }),
+      ]),
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "status:set-runtime-mode",
+        value: {
+          optionId: "mode",
+          source: "mode",
+          value: "yolo",
+        },
+      }),
+    );
+
+    expect(harness.setAcpSessionRuntimeOption).toHaveBeenCalledWith({
+      backend: "acp:gemini",
+      threadId: "thread-1",
+      source: "mode",
+      optionId: "mode",
+      value: "yolo",
+    });
+  });
+
   it("uses live thread permissions instead of stale binding preferences", async () => {
     const harness = await createHarness();
     const navigation = buildNavigationSnapshot();
@@ -8522,6 +8833,9 @@ async function createHarness(options?: {
   readThreadLastAssistantReply?: NonNullable<
     MessagingBackendBridge["readThreadLastAssistantReply"]
   >;
+  setAcpSessionRuntimeOption?: NonNullable<
+    MessagingBackendBridge["setAcpSessionRuntimeOption"]
+  >;
   setConversationTitle?: MessagingAdapter["setConversationTitle"];
   startThread?: NonNullable<MessagingBackendBridge["startThread"]>;
   toolUpdateDefaultMode?: MessagingToolUpdateMode;
@@ -8541,6 +8855,7 @@ async function createHarness(options?: {
   readThreadLastAssistantReply: ReturnType<typeof vi.fn>;
   readThreadStatus: ReturnType<typeof vi.fn>;
   recordMessagingBindingTransition: ReturnType<typeof vi.fn>;
+  setAcpSessionRuntimeOption: ReturnType<typeof vi.fn>;
   setThreadExecutionMode: ReturnType<typeof vi.fn>;
   setThreadModelSettings: ReturnType<typeof vi.fn>;
   startThread: ReturnType<typeof vi.fn>;
@@ -8694,6 +9009,47 @@ async function createHarness(options?: {
     }
     return request;
   });
+  const setAcpSessionRuntimeOption = vi.fn(
+    options?.setAcpSessionRuntimeOption ??
+      (async (request: SetAcpSessionRuntimeOptionRequest) => {
+        if (controllerRef) {
+          await controllerRef.handleBackendEvent({
+            backend: request.backend,
+            notification: {
+              method: "thread/acpRuntime/updated",
+              params: {
+                threadId: request.threadId,
+                acpRuntime: {
+                  ...(request.source === "configOption"
+                    ? { configValues: { [request.optionId]: request.value } }
+                    : {}),
+                  ...(request.source === "mode" || request.source === "configOption"
+                    ? { currentModeId: request.value }
+                    : {}),
+                  ...(request.source === "model"
+                    ? { currentModelId: request.value }
+                    : {}),
+                  updatedAt: 1000,
+                },
+              },
+            },
+          });
+        }
+        return {
+          backend: request.backend,
+          threadId: request.threadId,
+          runtimeState: {
+            ...(request.source === "configOption"
+              ? { configValues: { [request.optionId]: request.value } }
+              : {}),
+            ...(request.source === "mode" || request.source === "configOption"
+              ? { currentModeId: request.value }
+              : {}),
+            updatedAt: 1000,
+          },
+        };
+      }),
+  );
   const cancelThreadExecutionModeQueue = vi.fn(
     async (request: CancelThreadExecutionModeQueueRequest) => ({
       backend: request.backend,
@@ -8805,6 +9161,7 @@ async function createHarness(options?: {
     readThreadLastAssistantMessage,
     readThreadStatus,
     recordMessagingBindingTransition,
+    setAcpSessionRuntimeOption,
     setThreadExecutionMode,
     setThreadModelSettings,
     startThread,
@@ -8861,6 +9218,7 @@ async function createHarness(options?: {
     readThreadLastAssistantReply,
     readThreadStatus,
     recordMessagingBindingTransition,
+    setAcpSessionRuntimeOption,
     setThreadExecutionMode,
     setThreadModelSettings,
     startThread,
@@ -8948,6 +9306,42 @@ function buildBackendSummary(overrides: Partial<BackendSummary> = {}): BackendSu
     executionModes: overrides.executionModes ?? base.executionModes,
     launchpadOptions: overrides.launchpadOptions ?? base.launchpadOptions,
   };
+}
+
+function buildAcpRuntimeBackendSummary(
+  overrides: Partial<BackendSummary> = {},
+): BackendSummary {
+  return buildBackendSummary({
+    kind: "acp:gemini",
+    label: "Gemini CLI",
+    source: "acp",
+    executionModes: [],
+    acp: {
+      registryId: "gemini",
+      distributionKinds: ["local"],
+      installStatus: "installed",
+      authStatus: "authenticated",
+      verificationStatus: "not-applicable",
+      runtime: {
+        schemaVersion: 1,
+        status: "discovered",
+        modes: {
+          currentModeId: "default",
+          availableModes: [
+            { id: "default", label: "Default" },
+            { id: "auto_edit", label: "Auto Edit" },
+            { id: "yolo", label: "Yolo" },
+          ],
+        },
+      },
+    },
+    launchpadOptions: {
+      models: [{ id: "gemini-3-flash-preview", label: "Gemini 3 Flash Preview" }],
+      reasoningEfforts: [],
+      supportsFastMode: false,
+    },
+    ...overrides,
+  });
 }
 
 function buildNavigationSnapshot(): NavigationSnapshot {

--- a/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type {
+  BackendSummary,
   NavigationSnapshot,
 } from "@pwragent/shared";
 import type {
@@ -301,13 +302,20 @@ describe("buildBindingStatusIntent", () => {
     const intent = buildBindingStatusIntent({
       id: "status-acp-runtime",
       createdAt: 1000,
+      backendSummary: buildAcpBackendSummary(),
       binding,
       threadState: resolveMessagingThreadState({ binding, navigation }),
     });
 
     expect(intent.text).toContain("Binding: Thread one (acp:gemini)");
-    expect(intent.text).toContain("Runtime mode: Yolo (desktop-only)");
+    expect(intent.text).toContain("Runtime mode: Yolo");
     expect(intent.text).not.toContain("Permissions:");
+    expect(intent.actions).toContainEqual(
+      expect.objectContaining({
+        id: "status:runtime-mode",
+        label: "Runtime: Yolo",
+      }),
+    );
     expect(intent.actions).not.toContainEqual(
       expect.objectContaining({
         id: "status:permissions",
@@ -335,12 +343,41 @@ describe("buildBindingStatusIntent", () => {
     const intent = buildBindingStatusIntent({
       id: "status-acp-model-config",
       createdAt: 1000,
+      backendSummary: {
+        ...buildAcpBackendSummary(),
+        acp: {
+          ...buildAcpBackendSummary().acp!,
+          runtime: {
+            schemaVersion: 1,
+            status: "discovered",
+            configOptions: [
+              {
+                id: "model",
+                label: "Model",
+                type: "select",
+                category: "model",
+                values: [
+                  {
+                    value: "gemini-3-flash-preview",
+                    label: "Gemini 3 Flash Preview",
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      },
       binding,
       threadState: resolveMessagingThreadState({ binding, navigation }),
     });
 
-    expect(intent.text).toContain("Runtime mode: Agent default (desktop-only)");
+    expect(intent.text).toContain("Runtime mode: Agent default");
     expect(intent.text).not.toContain("Runtime mode: Gemini 3 Flash Preview");
+    expect(intent.actions).not.toContainEqual(
+      expect.objectContaining({
+        id: "status:runtime-mode",
+      }),
+    );
   });
 
   it("renders live thread state ahead of stale binding display metadata", () => {
@@ -737,5 +774,49 @@ function buildNavigationSnapshot(): NavigationSnapshot {
       },
     ],
     unchanged: false,
+  };
+}
+
+function buildAcpBackendSummary(): BackendSummary {
+  return {
+    kind: "acp:gemini",
+    source: "acp",
+    label: "Gemini CLI",
+    available: true,
+    methods: [],
+    capabilities: {
+      listThreads: true,
+      createThread: true,
+      resumeThread: true,
+      renameThread: true,
+      readThread: true,
+      startTurn: true,
+      interruptTurn: true,
+      steerTurn: false,
+      transcriptPagination: false,
+      toolUse: true,
+      approvalRequests: true,
+      multiDirectoryThreads: true,
+    },
+    executionModes: [],
+    acp: {
+      registryId: "gemini",
+      distributionKinds: ["local"],
+      installStatus: "installed",
+      authStatus: "authenticated",
+      verificationStatus: "not-applicable",
+      runtime: {
+        schemaVersion: 1,
+        status: "discovered",
+        modes: {
+          currentModeId: "default",
+          availableModes: [
+            { id: "default", label: "Default" },
+            { id: "auto_edit", label: "Auto Edit" },
+            { id: "yolo", label: "Yolo" },
+          ],
+        },
+      },
+    },
   };
 }

--- a/apps/desktop/src/main/messaging/core/messaging-acp-runtime.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-acp-runtime.ts
@@ -1,0 +1,170 @@
+import type {
+  BackendAcpRuntimeConfigOption,
+  BackendAcpRuntimeOptionSource,
+  BackendAcpSessionRuntimeState,
+  BackendSummary,
+} from "@pwragent/shared";
+import { isAcpBackendId } from "@pwragent/shared";
+
+export type MessagingAcpRuntimeModeChoice = {
+  description?: string;
+  label: string;
+  optionId: string;
+  privileged: boolean;
+  selected: boolean;
+  source: BackendAcpRuntimeOptionSource;
+  value: string;
+};
+
+export type MessagingAcpRuntimeModeSummary = {
+  choices: MessagingAcpRuntimeModeChoice[];
+  currentLabel: string;
+  currentValue?: string;
+};
+
+export function buildMessagingAcpRuntimeModeSummary(params: {
+  backend?: BackendSummary;
+  runtime?: BackendAcpSessionRuntimeState;
+}): MessagingAcpRuntimeModeSummary {
+  const backend = params.backend;
+  if (!backend || !isAcpBackendId(backend.kind)) {
+    return {
+      choices: [],
+      currentLabel: "Agent default",
+    };
+  }
+
+  const runtimeCapabilities = backend.acp?.runtime;
+  const modeChoices =
+    runtimeCapabilities?.modes?.availableModes.map((mode) => ({
+      description: mode.description,
+      label: formatMessagingAcpRuntimeModeLabel(mode.label || mode.id),
+      optionId: "mode",
+      privileged: messagingAcpRuntimeValueLooksPrivileged(mode.id),
+      selected: false,
+      source: "mode" as const,
+      value: mode.id,
+    })) ?? [];
+  if (modeChoices.length > 0) {
+    const currentValue =
+      params.runtime?.currentModeId ??
+      runtimeCapabilities?.modes?.currentModeId ??
+      defaultRuntimeModeValue(modeChoices);
+    const choices = modeChoices.map((choice) => ({
+      ...choice,
+      selected: choice.value === currentValue,
+    }));
+    return {
+      choices,
+      currentLabel: labelForRuntimeValue(choices, currentValue),
+      currentValue,
+    };
+  }
+
+  const modeConfigOptions =
+    runtimeCapabilities?.configOptions?.filter(isRuntimeModeConfigOption) ?? [];
+  const configChoices = modeConfigOptions.flatMap((option) => {
+    const currentValue =
+      params.runtime?.configValues?.[option.id] ??
+      option.currentValue ??
+      defaultConfigOptionValue(option);
+    return option.values.map((value) => ({
+      description: value.description,
+      label: formatMessagingAcpRuntimeModeLabel(value.label || value.value),
+      optionId: option.id,
+      privileged: messagingAcpRuntimeValueLooksPrivileged(value.value),
+      selected: value.value === currentValue,
+      source: "configOption" as const,
+      value: value.value,
+    }));
+  });
+  if (configChoices.length > 0) {
+    const selected = configChoices.find((choice) => choice.selected);
+    return {
+      choices: configChoices,
+      currentLabel: selected?.label ?? "Agent default",
+      currentValue: selected?.value,
+    };
+  }
+
+  const fallbackValue = resolveAcpRuntimeModeValue(params.runtime);
+  return {
+    choices: [],
+    currentLabel: fallbackValue
+      ? formatMessagingAcpRuntimeModeLabel(fallbackValue)
+      : "Agent default",
+    currentValue: fallbackValue,
+  };
+}
+
+export function resolveAcpRuntimeModeValue(
+  runtime: BackendAcpSessionRuntimeState | undefined,
+): string | undefined {
+  return (
+    runtime?.currentModeId ??
+    (runtime?.configValues
+      ? Object.entries(runtime.configValues).find(([key]) =>
+          isFallbackRuntimeModeConfigKey(key),
+        )?.[1]
+      : undefined)
+  );
+}
+
+export function formatMessagingAcpRuntimeModeLabel(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return value;
+  }
+  if (trimmed.toLowerCase() === "yolo") {
+    return "Yolo";
+  }
+  return trimmed
+    .replace(/[_-]+/g, " ")
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .replace(/\b\w/g, (match) => match.toUpperCase());
+}
+
+export function messagingAcpRuntimeValueLooksPrivileged(
+  value: string | undefined,
+): boolean {
+  return value === "yolo" || value === "autoEdit" || value === "auto_edit";
+}
+
+function isRuntimeModeConfigOption(option: BackendAcpRuntimeConfigOption): boolean {
+  return option.category === "mode";
+}
+
+function defaultRuntimeModeValue(
+  choices: MessagingAcpRuntimeModeChoice[],
+): string | undefined {
+  return (
+    choices.find((choice) => choice.value === "default")?.value ??
+    choices[0]?.value
+  );
+}
+
+function defaultConfigOptionValue(
+  option: BackendAcpRuntimeConfigOption,
+): string | undefined {
+  return (
+    option.values.find((value) => value.value === "default")?.value ??
+    option.values[0]?.value
+  );
+}
+
+function labelForRuntimeValue(
+  choices: MessagingAcpRuntimeModeChoice[],
+  value: string | undefined,
+): string {
+  if (!value) {
+    return "Agent default";
+  }
+  return (
+    choices.find((choice) => choice.value === value)?.label ??
+    formatMessagingAcpRuntimeModeLabel(value)
+  );
+}
+
+function isFallbackRuntimeModeConfigKey(key: string): boolean {
+  return key.trim().toLowerCase().endsWith("mode");
+}

--- a/apps/desktop/src/main/messaging/core/messaging-adapter.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-adapter.ts
@@ -18,6 +18,8 @@ import type {
   MaterializeDirectoryLaunchpadRequest,
   MaterializeDirectoryLaunchpadResponse,
   NavigationSnapshot,
+  SetAcpSessionRuntimeOptionRequest,
+  SetAcpSessionRuntimeOptionResponse,
   SetThreadExecutionModeRequest,
   SetThreadExecutionModeResponse,
   SetThreadModelSettingsRequest,
@@ -151,6 +153,9 @@ export type MessagingBackendBridge = {
   setThreadExecutionMode?(
     request: SetThreadExecutionModeRequest,
   ): Promise<SetThreadExecutionModeResponse>;
+  setAcpSessionRuntimeOption?(
+    request: SetAcpSessionRuntimeOptionRequest,
+  ): Promise<SetAcpSessionRuntimeOptionResponse>;
   cancelThreadExecutionModeQueue?(
     request: CancelThreadExecutionModeQueueRequest,
   ): Promise<CancelThreadExecutionModeQueueResponse>;

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -10,6 +10,7 @@ import type {
   AgentEvent,
   AppServerTurnInputItem,
   AppServerBackendKind,
+  BackendAcpRuntimeOptionSource,
   BackendAcpSessionRuntimeState,
   BackendSummary,
   AppServerPendingRequestNotification,
@@ -114,6 +115,7 @@ import {
 } from "./messaging-resume-browser.js";
 import {
   buildBindingStatusIntent,
+  buildStatusAcpRuntimeModePickerIntent,
   buildBranchPickerPage,
   buildHandoffBranchPickerIntent,
   buildHandoffConfirmationIntent,
@@ -128,6 +130,10 @@ import {
   resolveMessagingToolUpdateMode,
   type MessagingWorkspaceHandoffContext,
 } from "./messaging-status-card.js";
+import {
+  buildMessagingAcpRuntimeModeSummary,
+  messagingAcpRuntimeValueLooksPrivileged,
+} from "./messaging-acp-runtime.js";
 import {
   buildSkillRemovedIntent,
   buildSkillSelectedIntent,
@@ -365,6 +371,25 @@ type FullAccessRiskWarningContext =
       threadId: ThreadIdentifier;
     };
 
+type AcpRuntimeRiskWarningContext =
+  | {
+      kind: "new-thread";
+      label: string;
+      optionId: string;
+      sessionId: string;
+      source: BackendAcpRuntimeOptionSource;
+      value: string;
+    }
+  | {
+      bindingId: string;
+      kind: "thread";
+      label: string;
+      optionId: string;
+      source: BackendAcpRuntimeOptionSource;
+      threadId: ThreadIdentifier;
+      value: string;
+    };
+
 type FullAccessRiskPresentation = {
   binding?: MessagingBindingRecord;
   surface?: MessagingSurfaceRef;
@@ -420,6 +445,7 @@ type PendingQueueAuditMessage = {
 
 const PERMISSIONS_QUEUE_CANCEL_ACTION_PREFIX = "permissions:queue:cancel:";
 const FULL_ACCESS_RISK_ACTION_PREFIX = "full-access-risk:";
+const ACP_RUNTIME_RISK_ACTION_PREFIX = "acp-runtime-risk:";
 
 type PendingNewThreadPromptWindow = {
   events: MessagingTurnInputEvent[];
@@ -1823,6 +1849,12 @@ export class MessagingController {
       return;
     }
 
+    const acpRuntimeRiskAction = readAcpRuntimeRiskAction(event);
+    if (acpRuntimeRiskAction) {
+      await this.handleAcpRuntimeRiskCallback(event, acpRuntimeRiskAction);
+      return;
+    }
+
     const statusAction = readStatusAction(event);
     if (statusAction) {
       await this.handleStatusCallback(event, statusAction);
@@ -3143,6 +3175,18 @@ export class MessagingController {
       await this.presentNewThreadBackendPicker(nextSession, event, navigation);
       return;
     }
+    if (actionId === "browse:new:runtime-mode") {
+      await this.presentNewThreadAcpRuntimeModePicker(
+        nextSession,
+        event,
+        nextSession.backend ?? navigation.launchpadDefaults.backend,
+      );
+      return;
+    }
+    if (actionId === "browse:new:set-runtime-mode") {
+      await this.setNewThreadAcpRuntimeMode(nextSession, event, navigation);
+      return;
+    }
     if (actionId === "browse:new:set-backend") {
       const backend = readStringValue(event.value, "backend");
       const selectedBackend = await this.resolveNewThreadBackendForSession(
@@ -3633,6 +3677,12 @@ export class MessagingController {
     const supportsPermissionsControls =
       !isAcpBackendId(selectedBackend.kind) ||
       options.executionMode === "full-access";
+    const acpRuntimeMode = isAcpBackendId(selectedBackend.kind)
+      ? buildMessagingAcpRuntimeModeSummary({
+          backend: selectedBackend,
+          runtime: options.acpRuntime,
+        })
+      : undefined;
     await this.options.store.upsertBrowseSession(effectiveSession);
     const intent = buildConfirmationIntent({
       id: this.newIntentId("new-thread-ready"),
@@ -3699,6 +3749,16 @@ export class MessagingController {
                 label: `Permissions: ${formatPermissionsShortLabel(options.executionMode)}`,
                 style: "secondary" as const,
                 fallbackText: "permissions",
+              },
+            ]
+          : []),
+        ...(acpRuntimeMode && acpRuntimeMode.choices.length > 0
+          ? [
+              {
+                id: "browse:new:runtime-mode",
+                label: `Runtime: ${acpRuntimeMode.currentLabel}`,
+                style: "secondary" as const,
+                fallbackText: "runtime",
               },
             ]
           : []),
@@ -3988,6 +4048,175 @@ export class MessagingController {
         updatedAt: this.now(),
       });
     }
+  }
+
+  private async presentNewThreadAcpRuntimeModePicker(
+    session: MessagingBrowseSessionRecord,
+    event: MessagingInboundEvent,
+    backend: AppServerBackendKind,
+  ): Promise<void> {
+    const summary = await this.getBackendSummary(backend);
+    const runtimeMode = buildMessagingAcpRuntimeModeSummary({
+      backend: summary,
+      runtime: session.preferences?.acpRuntime,
+    });
+    if (!summary || runtimeMode.choices.length === 0) {
+      await this.deliver(
+        buildErrorIntent({
+          id: this.newIntentId("new-thread-runtime-unavailable"),
+          createdAt: this.now(),
+          title: "Runtime modes unavailable",
+          body: "This ACP backend did not report runtime mode choices.",
+          recoverable: true,
+        }),
+        undefined,
+        event,
+      );
+      return;
+    }
+
+    const intent = buildConfirmationIntent({
+      id: this.newIntentId("new-thread-runtime"),
+      capabilityProfile: this.capabilityProfile,
+      browseSessionId: session.id,
+      createdAt: this.now(),
+      delivery: session.surface
+        ? { mode: "update", replaceMarkup: true }
+        : undefined,
+      title: "Select runtime mode",
+      body: "Choose the runtime mode for the new thread.",
+      fallbackText: "Choose a runtime mode, or reply back.",
+      targetSurface: session.surface,
+      actions: [
+        ...runtimeMode.choices.map((choice, index) => ({
+          id: "browse:new:set-runtime-mode",
+          label: `${choice.label}${choice.selected ? " (current)" : ""}`,
+          style: "secondary" as const,
+          fallbackText: String(index + 1),
+          priority: 10 + index,
+          value: {
+            optionId: choice.optionId,
+            source: choice.source,
+            value: choice.value,
+          },
+        })),
+        {
+          id: session.workMode === "worktree"
+            ? "browse:new:workspace:worktree"
+            : "browse:new:workspace:local",
+          label: "Back",
+          style: "secondary" as const,
+          fallbackText: "back",
+          priority: 1,
+        },
+      ],
+    });
+    await this.storePendingIntent(intent, undefined, event);
+    const result = await this.deliver(intent, undefined, event);
+    if (result.surface) {
+      await this.options.store.upsertBrowseSession({
+        ...session,
+        surface: result.surface,
+        updatedAt: this.now(),
+      });
+    }
+  }
+
+  private async setNewThreadAcpRuntimeMode(
+    session: MessagingBrowseSessionRecord,
+    event: MessagingInboundCallbackEvent,
+    navigation: NavigationSnapshot,
+  ): Promise<void> {
+    const source = readAcpRuntimeOptionSource(event.value);
+    const optionId = readStringValue(event.value, "optionId");
+    const value = readStringValue(event.value, "value");
+    if (!source || !optionId || !value) {
+      await this.deliverInvalidBrowseSelection(event);
+      return;
+    }
+
+    const backend = session.backend ?? navigation.launchpadDefaults.backend;
+    const summary = await this.getBackendSummary(backend);
+    const currentRuntime =
+      session.preferences?.acpRuntime ??
+      navigation.launchpadDefaults.acpRuntime;
+    const currentRuntimeMode = buildMessagingAcpRuntimeModeSummary({
+      backend: summary,
+      runtime: currentRuntime,
+    });
+    const choice = currentRuntimeMode.choices.find(
+      (candidate) =>
+        candidate.source === source &&
+        candidate.optionId === optionId &&
+        candidate.value === value,
+    );
+    if (!choice) {
+      await this.deliverInvalidBrowseSelection(event);
+      return;
+    }
+
+    const riskContext: AcpRuntimeRiskWarningContext = {
+      kind: "new-thread",
+      label: choice.label,
+      optionId,
+      sessionId: session.id,
+      source,
+      value,
+    };
+    if (
+      choice.privileged &&
+      !messagingAcpRuntimeValueLooksPrivileged(currentRuntimeMode.currentValue)
+    ) {
+      const allowed = await this.ensureAcpRuntimeModeAllowed(
+        riskContext,
+        event,
+      );
+      if (!allowed) {
+        return;
+      }
+    }
+
+    await this.applyNewThreadAcpRuntimeMode(session, event, navigation, riskContext);
+  }
+
+  private async applyNewThreadAcpRuntimeMode(
+    session: MessagingBrowseSessionRecord,
+    event: MessagingInboundEvent,
+    navigation: NavigationSnapshot,
+    selection: AcpRuntimeRiskWarningContext & { kind: "new-thread" },
+  ): Promise<void> {
+    const currentRuntime =
+      session.preferences?.acpRuntime ??
+      navigation.launchpadDefaults.acpRuntime;
+    const acpRuntime: BackendAcpSessionRuntimeState = {
+      ...currentRuntime,
+      configValues:
+        selection.source === "configOption"
+          ? {
+              ...(currentRuntime?.configValues ?? {}),
+              [selection.optionId]: selection.value,
+            }
+          : currentRuntime?.configValues,
+      currentModeId: selection.source === "mode" || selection.source === "configOption"
+        ? selection.value
+        : currentRuntime?.currentModeId,
+      updatedAt: this.now(),
+    };
+    await this.updateNewThreadStickySettings(session, {
+      acpRuntime,
+    });
+    await this.presentNewThreadPromptGate(
+      {
+        ...session,
+        preferences: {
+          ...session.preferences,
+          acpRuntime,
+          updatedAt: this.now(),
+        },
+      },
+      event,
+      navigation,
+    );
   }
 
   private async presentNewThreadReasoningPicker(
@@ -5335,12 +5564,20 @@ export class MessagingController {
       await this.presentReasoningPicker(binding, event);
       return;
     }
+    if (actionId === "status:runtime-mode") {
+      await this.presentStatusAcpRuntimeModePicker(binding, event);
+      return;
+    }
     if (actionId === "status:set-model") {
       await this.setBindingModel(binding, event);
       return;
     }
     if (actionId === "status:set-reasoning") {
       await this.setBindingReasoning(binding, event);
+      return;
+    }
+    if (actionId === "status:set-runtime-mode") {
+      await this.setBindingAcpRuntimeMode(binding, event);
       return;
     }
     if (actionId === "status:fast") {
@@ -6057,6 +6294,47 @@ export class MessagingController {
     );
   }
 
+  private async presentStatusAcpRuntimeModePicker(
+    binding: MessagingBindingRecord,
+    event: MessagingInboundEvent,
+  ): Promise<void> {
+    const summary = await this.getBackendSummary(binding.backend);
+    const navigation = await this.options.backend.getNavigationSnapshot({
+      backend: "all",
+    });
+    const thread = findThreadForBinding(navigation, binding);
+    const runtimeMode = buildMessagingAcpRuntimeModeSummary({
+      backend: summary,
+      runtime: thread?.acpRuntime ?? binding.preferences?.acpRuntime,
+    });
+    if (!summary || runtimeMode.choices.length === 0) {
+      await this.deliver(
+        buildErrorIntent({
+          id: this.newIntentId("status-runtime-unavailable"),
+          createdAt: this.now(),
+          title: "Runtime modes unavailable",
+          body: "This ACP backend did not report runtime mode choices. Use /status to refresh.",
+          recoverable: true,
+        }),
+        binding,
+        event,
+      );
+      return;
+    }
+
+    await this.deliver(
+      buildStatusAcpRuntimeModePickerIntent({
+        id: this.newIntentId("status-runtime-picker"),
+        capabilityProfile: this.capabilityProfile,
+        binding,
+        choices: runtimeMode.choices,
+        createdAt: this.now(),
+      }),
+      binding,
+      event,
+    );
+  }
+
   private async setBindingModel(
     binding: MessagingBindingRecord,
     event: MessagingInboundCallbackEvent,
@@ -6106,6 +6384,109 @@ export class MessagingController {
     });
     // Refresh handled by the thread-state update bus on
     // thread/modelSettings/updated — see refreshStatusSurfacesForThread.
+  }
+
+  private async setBindingAcpRuntimeMode(
+    binding: MessagingBindingRecord,
+    event: MessagingInboundCallbackEvent,
+  ): Promise<void> {
+    const source = readAcpRuntimeOptionSource(event.value);
+    const optionId = readStringValue(event.value, "optionId");
+    const value = readStringValue(event.value, "value");
+    if (!source || !optionId || !value) {
+      await this.deliverInvalidStatusSelection(event);
+      return;
+    }
+    if (!isAcpBackendId(binding.backend) || !this.options.backend.setAcpSessionRuntimeOption) {
+      await this.renderBindingStatus(binding, event);
+      return;
+    }
+
+    const summary = await this.getBackendSummary(binding.backend);
+    const navigation = await this.options.backend.getNavigationSnapshot({
+      backend: "all",
+    });
+    const thread = findThreadForBinding(navigation, binding);
+    const currentRuntime = thread?.acpRuntime ?? binding.preferences?.acpRuntime;
+    const runtimeMode = buildMessagingAcpRuntimeModeSummary({
+      backend: summary,
+      runtime: currentRuntime,
+    });
+    const choice = runtimeMode.choices.find(
+      (candidate) =>
+        candidate.source === source &&
+        candidate.optionId === optionId &&
+        candidate.value === value,
+    );
+    if (!choice) {
+      await this.deliverInvalidStatusSelection(event);
+      return;
+    }
+
+    const riskContext: AcpRuntimeRiskWarningContext = {
+      bindingId: binding.id,
+      kind: "thread",
+      label: choice.label,
+      optionId,
+      source,
+      threadId: binding.threadId,
+      value,
+    };
+    if (
+      choice.privileged &&
+      !messagingAcpRuntimeValueLooksPrivileged(runtimeMode.currentValue)
+    ) {
+      const allowed = await this.ensureAcpRuntimeModeAllowed(
+        riskContext,
+        event,
+      );
+      if (!allowed) {
+        return;
+      }
+    }
+
+    await this.applyBindingAcpRuntimeMode(binding, event, riskContext);
+  }
+
+  private async applyBindingAcpRuntimeMode(
+    binding: MessagingBindingRecord,
+    event: MessagingInboundEvent,
+    selection: AcpRuntimeRiskWarningContext & { kind: "thread" },
+  ): Promise<void> {
+    if (!isAcpBackendId(binding.backend) || !this.options.backend.setAcpSessionRuntimeOption) {
+      await this.renderBindingStatus(binding, event);
+      return;
+    }
+    const navigation = await this.options.backend.getNavigationSnapshot({
+      backend: "all",
+    });
+    const thread = findThreadForBinding(navigation, binding);
+    const currentRuntime = thread?.acpRuntime ?? binding.preferences?.acpRuntime;
+    const acpRuntime: BackendAcpSessionRuntimeState = {
+      ...currentRuntime,
+      configValues:
+        selection.source === "configOption"
+          ? {
+              ...(currentRuntime?.configValues ?? {}),
+              [selection.optionId]: selection.value,
+            }
+          : currentRuntime?.configValues,
+      currentModeId: selection.source === "mode" || selection.source === "configOption"
+        ? selection.value
+        : currentRuntime?.currentModeId,
+      updatedAt: this.now(),
+    };
+    await this.updateBindingPreferences(binding, {
+      acpRuntime,
+    });
+    await this.options.backend.setAcpSessionRuntimeOption({
+      backend: binding.backend,
+      threadId: binding.threadId,
+      source: selection.source,
+      optionId: selection.optionId,
+      value: selection.value,
+    });
+    // Refresh handled by thread/acpRuntime/updated or queue audit refresh.
   }
 
   private async toggleFastMode(
@@ -6183,6 +6564,127 @@ export class MessagingController {
     });
     // Refresh handled by the thread-state update bus on
     // thread/executionMode/updated — see refreshStatusSurfacesForThread.
+  }
+
+  private async ensureAcpRuntimeModeAllowed(
+    context: AcpRuntimeRiskWarningContext,
+    event: MessagingInboundEvent,
+  ): Promise<boolean> {
+    const controls = await this.resolveFullAccessControls();
+    if (!controls.allowEscalation) {
+      await this.deliverFullAccessPolicyError(
+        context.kind === "thread"
+          ? await this.options.store.getBinding(context.bindingId)
+          : undefined,
+        event,
+        `Runtime mode ${context.label} is disabled from messaging by Full Access settings.`,
+      );
+      return false;
+    }
+
+    const warning = await this.resolveFullAccessWarning(controls, event);
+    if (!warning.shouldWarn) {
+      return true;
+    }
+
+    await this.presentAcpRuntimeRiskWarning(context, event);
+    return false;
+  }
+
+  private async presentAcpRuntimeRiskWarning(
+    context: AcpRuntimeRiskWarningContext,
+    event: MessagingInboundEvent,
+  ): Promise<void> {
+    const controls = await this.resolveFullAccessControls();
+    const warning = await this.resolveFullAccessWarning(controls, event);
+    const binding =
+      context.kind === "thread"
+        ? await this.options.store.getBinding(context.bindingId)
+        : undefined;
+    const session =
+      context.kind === "new-thread"
+        ? await this.options.store.getBrowseSession(context.sessionId, {
+            now: this.now(),
+          })
+        : undefined;
+    const surface =
+      context.kind === "thread"
+        ? binding?.statusSurface ?? binding?.pinnedStatusSurface
+        : session?.surface;
+    const actions: MessagingConfirmationIntent["actions"] = [
+      {
+        id: `${ACP_RUNTIME_RISK_ACTION_PREFIX}accept`,
+        label: "Yes",
+        style: "primary",
+        fallbackText: "yes",
+        value: context,
+      },
+      ...(warning.canDismiss
+        ? [
+            {
+              id: `${ACP_RUNTIME_RISK_ACTION_PREFIX}dismiss`,
+              label: "Yes - and stop warning me",
+              style: "primary" as const,
+              fallbackText: "yes and stop warning me",
+              value: context,
+            },
+          ]
+        : []),
+      {
+        id: `${ACP_RUNTIME_RISK_ACTION_PREFIX}cancel`,
+        label: "Cancel",
+        style: "secondary",
+        fallbackText: "cancel",
+        value: context,
+      },
+    ];
+
+    const intent = buildConfirmationIntent({
+      id: this.newIntentId("acp-runtime-risk"),
+      capabilityProfile: this.capabilityProfile,
+      createdAt: this.now(),
+      delivery: surface
+        ? {
+            mode: "update",
+            replaceMarkup: true,
+          }
+        : undefined,
+      title: `Enable ${context.label}?`,
+      body: [
+        `${context.label} may allow the ACP agent to run commands or edit files with fewer prompts.`,
+        "Only enable it for workspaces and prompts you trust.",
+      ].join("\n\n"),
+      fallbackText: warning.canDismiss
+        ? "Reply Yes, Yes - and stop warning me, or Cancel."
+        : "Reply Yes or Cancel.",
+      actions,
+      targetSurface: surface,
+    });
+    const expiresAt =
+      context.kind === "new-thread"
+        ? this.now() + MESSAGING_CALLBACK_HANDLE_TTL_MS
+        : undefined;
+    if (expiresAt !== undefined && session) {
+      await this.options.store.upsertBrowseSession({
+        ...session,
+        expiresAt: Math.max(session.expiresAt, expiresAt),
+        textInputExpiresAt: session.textInputExpiresAt ?? session.expiresAt,
+        updatedAt: this.now(),
+      });
+    }
+    const pending = await this.storePendingIntent(
+      intent,
+      binding,
+      event,
+      expiresAt === undefined ? undefined : { expiresAt },
+    );
+    const result = await this.deliver(intent, binding, event);
+    if (result.surface) {
+      await this.options.store.upsertPendingIntent({
+        ...pending,
+        surface: result.surface,
+      });
+    }
   }
 
   private async ensureFullAccessEscalationAllowed(
@@ -6496,6 +6998,95 @@ export class MessagingController {
       threadId: escalationContext.threadId,
       executionMode: "full-access",
     });
+  }
+
+  private async handleAcpRuntimeRiskCallback(
+    event: MessagingInboundCallbackEvent,
+    action: "accept" | "dismiss" | "cancel",
+  ): Promise<void> {
+    const context = readAcpRuntimeRiskContext(event.value);
+    if (!context) {
+      await this.deliverInvalidStatusSelection(event);
+      return;
+    }
+
+    if (action === "cancel") {
+      if (context.kind === "new-thread") {
+        const session = await this.options.store.getBrowseSession(context.sessionId, {
+          now: this.now(),
+        });
+        if (!session) {
+          await this.deliverStaleFullAccessWarning(event);
+          return;
+        }
+        const navigation = await this.options.backend.getNavigationSnapshot({
+          backend: "all",
+        });
+        await this.presentNewThreadPromptGate(session, event, navigation);
+        return;
+      }
+      const binding = await this.options.store.getBinding(context.bindingId);
+      if (!binding) {
+        await this.deliverInvalidStatusSelection(event);
+        return;
+      }
+      await this.renderBindingStatus(binding, event);
+      return;
+    }
+
+    if (!(await this.ensureAcpRuntimeRiskCallbackAllowed(context, event))) {
+      return;
+    }
+    if (action === "dismiss") {
+      const controls = await this.resolveFullAccessControls();
+      const warning = await this.resolveFullAccessWarning(controls, event);
+      if (warning.canDismiss) {
+        await controls.dismissWarning?.({
+          actorId: event.actor.platformUserId,
+          channel: event.channel.channel,
+        });
+      }
+    }
+
+    if (context.kind === "new-thread") {
+      const session = await this.options.store.getBrowseSession(context.sessionId, {
+        now: this.now(),
+      });
+      if (!session) {
+        await this.deliverStaleFullAccessWarning(event);
+        return;
+      }
+      const navigation = await this.options.backend.getNavigationSnapshot({
+        backend: "all",
+      });
+      await this.applyNewThreadAcpRuntimeMode(session, event, navigation, context);
+      return;
+    }
+
+    const binding = await this.options.store.getBinding(context.bindingId);
+    if (!binding) {
+      await this.deliverInvalidStatusSelection(event);
+      return;
+    }
+    await this.applyBindingAcpRuntimeMode(binding, event, context);
+  }
+
+  private async ensureAcpRuntimeRiskCallbackAllowed(
+    context: AcpRuntimeRiskWarningContext,
+    event: MessagingInboundEvent,
+  ): Promise<boolean> {
+    const controls = await this.resolveFullAccessControls();
+    if (controls.allowEscalation) {
+      return true;
+    }
+    await this.deliverFullAccessPolicyError(
+      context.kind === "thread"
+        ? await this.options.store.getBinding(context.bindingId)
+        : undefined,
+      event,
+      `Runtime mode ${context.label} is disabled from messaging by Full Access settings.`,
+    );
+    return false;
   }
 
   private async resolveFullAccessRiskCallbackContext(
@@ -7259,10 +7850,14 @@ export class MessagingController {
       binding,
       "status_refresh",
     );
+    const backendSummary = isAcpBackendId(binding.backend)
+      ? await this.getBackendSummary(binding.backend)
+      : undefined;
     const intent = buildBindingStatusIntent({
       id: this.newIntentId("status"),
       allowFullAccessEscalation: (await this.resolveFullAccessControls())
         .allowEscalation,
+      backendSummary,
       binding,
       capabilityProfile: this.capabilityProfile,
       createdAt: this.now(),
@@ -8917,6 +9512,70 @@ function readFullAccessRiskAction(
     : undefined;
 }
 
+function readAcpRuntimeRiskAction(
+  event: MessagingInboundCallbackEvent,
+): "accept" | "dismiss" | "cancel" | undefined {
+  const actionId = event.actionId ?? event.interaction.id;
+  if (!actionId.startsWith(ACP_RUNTIME_RISK_ACTION_PREFIX)) {
+    return undefined;
+  }
+  const action = actionId.slice(ACP_RUNTIME_RISK_ACTION_PREFIX.length);
+  return action === "accept" || action === "dismiss" || action === "cancel"
+    ? action
+    : undefined;
+}
+
+function readAcpRuntimeRiskContext(
+  value: MessagingJsonValue | undefined,
+): AcpRuntimeRiskWarningContext | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const source =
+    value.source === "mode" ||
+    value.source === "configOption" ||
+    value.source === "model"
+      ? value.source
+      : undefined;
+  if (
+    value.kind === "new-thread" &&
+    typeof value.sessionId === "string" &&
+    typeof value.optionId === "string" &&
+    typeof value.value === "string" &&
+    typeof value.label === "string" &&
+    source
+  ) {
+    return {
+      kind: "new-thread",
+      label: value.label,
+      optionId: value.optionId,
+      sessionId: value.sessionId,
+      source,
+      value: value.value,
+    };
+  }
+  if (
+    value.kind === "thread" &&
+    typeof value.bindingId === "string" &&
+    typeof value.threadId === "string" &&
+    typeof value.optionId === "string" &&
+    typeof value.value === "string" &&
+    typeof value.label === "string" &&
+    source
+  ) {
+    return {
+      bindingId: value.bindingId,
+      kind: "thread",
+      label: value.label,
+      optionId: value.optionId,
+      source,
+      threadId: value.threadId,
+      value: value.value,
+    };
+  }
+  return undefined;
+}
+
 function readFullAccessRiskContext(
   value: MessagingJsonValue | undefined,
 ): FullAccessRiskWarningContext | undefined {
@@ -9352,6 +10011,12 @@ function newThreadPromptGateBody(
   options: NewThreadOptionsSummary,
   backend: BackendSummary,
 ): string {
+  const acpRuntimeMode = isAcpBackendId(options.backend)
+    ? buildMessagingAcpRuntimeModeSummary({
+        backend,
+        runtime: options.acpRuntime,
+      })
+    : undefined;
   return [
     `Send the first instruction for ${session.selectedProject?.label ?? "this project"}.`,
     "The thread will be created when that message arrives.",
@@ -9361,8 +10026,8 @@ function newThreadPromptGateBody(
     !isAcpBackendId(options.backend) || options.executionMode === "full-access"
       ? `Permissions: ${formatPermissionsShortLabel(options.executionMode)}`
       : undefined,
-    isAcpBackendId(options.backend)
-      ? `Runtime mode: ${formatMessagingAcpRuntimeLineLabel(options.acpRuntime)} (desktop-only)`
+    acpRuntimeMode
+      ? `Runtime mode: ${acpRuntimeMode.currentLabel}`
       : undefined,
     options.supportsModel ? `Model: ${options.model}` : undefined,
     options.supportsReasoning && options.reasoningEffort
@@ -9377,37 +10042,6 @@ function newThreadPromptGateBody(
 
 function formatPermissionsShortLabel(mode: ThreadExecutionMode): string {
   return mode === "full-access" ? "Full" : "Default";
-}
-
-function formatMessagingAcpRuntimeLineLabel(
-  runtime: BackendAcpSessionRuntimeState | undefined,
-): string {
-  const mode =
-    runtime?.currentModeId ??
-    (runtime?.configValues
-      ? Object.entries(runtime.configValues).find(([key]) =>
-          isMessagingAcpRuntimeModeConfigKey(key),
-        )?.[1]
-      : undefined);
-  return mode ? formatMessagingAcpRuntimeModeLabel(mode) : "Agent default";
-}
-
-function isMessagingAcpRuntimeModeConfigKey(key: string): boolean {
-  return key.trim().toLowerCase().endsWith("mode");
-}
-
-function formatMessagingAcpRuntimeModeLabel(value: string): string {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return value;
-  }
-  if (trimmed.toLowerCase() === "yolo") {
-    return "Yolo";
-  }
-  return trimmed
-    .replace(/[_-]+/g, " ")
-    .replace(/([a-z])([A-Z])/g, "$1 $2")
-    .replace(/\b\w/g, (match) => match.toUpperCase());
 }
 
 function resolveNewThreadBaseBranch(
@@ -10283,6 +10917,15 @@ function readStringValue(
 
   const result = value[key];
   return typeof result === "string" ? result : undefined;
+}
+
+function readAcpRuntimeOptionSource(
+  value: MessagingJsonValue | undefined,
+): BackendAcpRuntimeOptionSource | undefined {
+  const source = readStringValue(value, "source");
+  return source === "mode" || source === "configOption" || source === "model"
+    ? source
+    : undefined;
 }
 
 function describeOutboundIntent(intent: MessagingSurfaceIntent): string {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -3180,6 +3180,7 @@ export class MessagingController {
         nextSession,
         event,
         nextSession.backend ?? navigation.launchpadDefaults.backend,
+        navigation,
       );
       return;
     }
@@ -4054,13 +4055,38 @@ export class MessagingController {
     session: MessagingBrowseSessionRecord,
     event: MessagingInboundEvent,
     backend: AppServerBackendKind,
+    navigation: NavigationSnapshot,
   ): Promise<void> {
     const summary = await this.getBackendSummary(backend);
+    if (!summary) {
+      await this.deliver(
+        buildErrorIntent({
+          id: this.newIntentId("new-thread-runtime-unavailable"),
+          createdAt: this.now(),
+          title: "Runtime modes unavailable",
+          body: "This ACP backend did not report runtime mode choices.",
+          recoverable: true,
+        }),
+        undefined,
+        event,
+      );
+      return;
+    }
+    const directory = session.selectedProject
+      ? directoryForProjectSelection(navigation, session.selectedProject)
+      : undefined;
+    const options = newThreadOptionsForSession(
+      session,
+      navigation,
+      directory,
+      this.streamingResponsesDefault,
+      summary,
+    );
     const runtimeMode = buildMessagingAcpRuntimeModeSummary({
       backend: summary,
-      runtime: session.preferences?.acpRuntime,
+      runtime: options.acpRuntime,
     });
-    if (!summary || runtimeMode.choices.length === 0) {
+    if (runtimeMode.choices.length === 0) {
       await this.deliver(
         buildErrorIntent({
           id: this.newIntentId("new-thread-runtime-unavailable"),
@@ -4137,9 +4163,21 @@ export class MessagingController {
 
     const backend = session.backend ?? navigation.launchpadDefaults.backend;
     const summary = await this.getBackendSummary(backend);
-    const currentRuntime =
-      session.preferences?.acpRuntime ??
-      navigation.launchpadDefaults.acpRuntime;
+    if (!summary) {
+      await this.deliverInvalidBrowseSelection(event);
+      return;
+    }
+    const directory = session.selectedProject
+      ? directoryForProjectSelection(navigation, session.selectedProject)
+      : undefined;
+    const options = newThreadOptionsForSession(
+      session,
+      navigation,
+      directory,
+      this.streamingResponsesDefault,
+      summary,
+    );
+    const currentRuntime = options.acpRuntime;
     const currentRuntimeMode = buildMessagingAcpRuntimeModeSummary({
       backend: summary,
       runtime: currentRuntime,
@@ -4202,8 +4240,12 @@ export class MessagingController {
         : currentRuntime?.currentModeId,
       updatedAt: this.now(),
     };
+    const executionMode = messagingAcpRuntimeValueLooksPrivileged(selection.value)
+      ? "full-access"
+      : "default";
     await this.updateNewThreadStickySettings(session, {
       acpRuntime,
+      executionMode,
     });
     await this.presentNewThreadPromptGate(
       {
@@ -4211,6 +4253,8 @@ export class MessagingController {
         preferences: {
           ...session.preferences,
           acpRuntime,
+          executionMode,
+          permissionsMode: executionMode,
           updatedAt: this.now(),
         },
       },
@@ -9832,9 +9876,6 @@ function normalizeNewThreadSessionForBackend(
   const preferences = { ...session.preferences };
   if (isAcpBackendId(backend.kind)) {
     delete preferences.permissionsMode;
-    if (preferences.executionMode === "full-access") {
-      delete preferences.executionMode;
-    }
   } else {
     delete preferences.acpRuntime;
   }

--- a/apps/desktop/src/main/messaging/core/messaging-status-card.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-status-card.ts
@@ -1,6 +1,6 @@
 import type {
   AppServerBackendKind,
-  BackendAcpSessionRuntimeState,
+  BackendSummary,
   HandoffThreadWorkspaceRequest,
   MessagingToolUpdateMode,
   ThreadExecutionMode,
@@ -24,6 +24,10 @@ import {
   truncateActionsByPriority,
 } from "@pwragent/messaging-interface";
 import type { MessagingResolvedThreadState } from "./messaging-thread-state.js";
+import {
+  buildMessagingAcpRuntimeModeSummary,
+  type MessagingAcpRuntimeModeChoice,
+} from "./messaging-acp-runtime.js";
 
 /**
  * Minimum action count for a usable status card. Below this, drop all
@@ -48,6 +52,7 @@ export const HANDOFF_BRANCH_PAGE_SIZE = BRANCH_PICKER_PAGE_SIZE;
 
 export function buildBindingStatusIntent(params: {
   allowFullAccessEscalation?: boolean;
+  backendSummary?: BackendSummary;
   binding: MessagingBindingRecord;
   capabilityProfile?: MessagingCapabilityProfile;
   createdAt: number;
@@ -97,8 +102,17 @@ export function buildBindingStatusIntent(params: {
     params.streamingResponsesDefault,
   );
   const acpRuntimeLabel = isAcpBackendId(params.binding.backend)
-    ? formatAcpRuntimeLineLabel(params.threadState.acpRuntime)
+    ? buildMessagingAcpRuntimeModeSummary({
+        backend: params.backendSummary,
+        runtime: params.threadState.acpRuntime,
+      }).currentLabel
     : undefined;
+  const acpRuntimeChoices = isAcpBackendId(params.binding.backend)
+    ? buildMessagingAcpRuntimeModeSummary({
+        backend: params.backendSummary,
+        runtime: params.threadState.acpRuntime,
+      }).choices
+    : [];
 
   return {
     id: params.id,
@@ -125,7 +139,7 @@ export function buildBindingStatusIntent(params: {
       `Fast mode: ${fastMode === undefined ? unavailable() : fastMode ? "on" : "off"}`,
       "Plan mode: unavailable",
       acpRuntimeLabel
-        ? `Runtime mode: ${acpRuntimeLabel} (desktop-only)`
+        ? `Runtime mode: ${acpRuntimeLabel}`
         : `Permissions: ${formatPermissionsLineLabel(permissionsMode, queuedExecutionMode)}`,
       `Tool updates: ${formatMessagingToolUpdateModeLabel(toolUpdateMode)}`,
       `Streaming: ${streamingLabel}`,
@@ -146,6 +160,7 @@ export function buildBindingStatusIntent(params: {
       fastMode,
       handoff: params.handoff,
       permissionsMode,
+      runtimeChoices: acpRuntimeChoices,
       supportsPermissionsAction: !acpRuntimeLabel,
       queuedExecutionMode,
       reasoning,
@@ -170,43 +185,13 @@ function mentionRequiredLine(
     ?? capabilityProfile.conversationInput.sharedConversationMentionInstruction;
 }
 
-function formatAcpRuntimeLineLabel(
-  runtime: BackendAcpSessionRuntimeState | undefined,
-): string {
-  const mode =
-    runtime?.currentModeId ??
-    (runtime?.configValues
-      ? Object.entries(runtime.configValues).find(([key]) =>
-          isAcpRuntimeModeConfigKey(key),
-        )?.[1]
-      : undefined);
-  return mode ? formatAcpRuntimeModeLabel(mode) : "Agent default";
-}
-
-function isAcpRuntimeModeConfigKey(key: string): boolean {
-  return key.trim().toLowerCase().endsWith("mode");
-}
-
-function formatAcpRuntimeModeLabel(value: string): string {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return value;
-  }
-  if (trimmed.toLowerCase() === "yolo") {
-    return "Yolo";
-  }
-  return trimmed
-    .replace(/[_-]+/g, " ")
-    .replace(/([a-z])([A-Z])/g, "$1 $2")
-    .replace(/\b\w/g, (match) => match.toUpperCase());
-}
-
 function buildStatusActions(params: {
   allowFullAccessEscalation?: boolean;
   capabilityProfile?: MessagingCapabilityProfile;
   fastMode: boolean | undefined;
   handoff?: MessagingWorkspaceHandoffContext;
   permissionsMode: string;
+  runtimeChoices?: MessagingAcpRuntimeModeChoice[];
   supportsPermissionsAction?: boolean;
   queuedExecutionMode?: ThreadExecutionMode;
   reasoning: string;
@@ -235,6 +220,21 @@ function buildStatusActions(params: {
           priority: 7,
         }
       : undefined;
+  const runtimeAction:
+    | MessagingSurfaceAction
+    | undefined =
+    params.runtimeChoices && params.runtimeChoices.length > 0
+      ? {
+          id: "status:runtime-mode",
+          label: `Runtime: ${
+            params.runtimeChoices.find((choice) => choice.selected)?.label ??
+            "Agent default"
+          }`,
+          style: "secondary",
+          fallbackText: "runtime",
+          priority: 7,
+        }
+      : undefined;
   const allActions: MessagingSurfaceAction[] = [
     {
       id: "status:model",
@@ -258,6 +258,7 @@ function buildStatusActions(params: {
       priority: 6,
     },
     ...(permissionsAction ? [permissionsAction] : []),
+    ...(runtimeAction ? [runtimeAction] : []),
     ...(params.handoff
       ? [
           {
@@ -929,6 +930,52 @@ export function buildStatusReasoningPickerIntent(params: {
           priority: 10 + index,
           value: {
             reasoningEffort: effort,
+          },
+        })),
+        {
+          id: "status:refresh",
+          label: "Back",
+          fallbackText: "back",
+          style: "secondary" as const,
+          priority: 1,
+        },
+      ],
+      params.capabilityProfile,
+    ),
+  };
+}
+
+export function buildStatusAcpRuntimeModePickerIntent(params: {
+  binding: MessagingBindingRecord;
+  capabilityProfile?: MessagingCapabilityProfile;
+  choices: MessagingAcpRuntimeModeChoice[];
+  createdAt: number;
+  id: string;
+}): MessagingSingleSelectIntent {
+  return {
+    id: params.id,
+    kind: "single_select",
+    bindingId: params.binding.id,
+    createdAt: params.createdAt,
+    delivery: {
+      mode: params.binding.statusSurface ? "update" : "present",
+      fallback: "present_new",
+    },
+    targetSurface: params.binding.statusSurface,
+    fallbackText: "Reply with a runtime mode number, Refresh, or Detach.",
+    prompt: "Select Runtime Mode",
+    choices: applyActionCapabilityLimits(
+      [
+        ...params.choices.map((choice, index) => ({
+          id: "status:set-runtime-mode",
+          label: `${choice.label}${choice.selected ? " (current)" : ""}`,
+          fallbackText: String(index + 1),
+          style: "secondary" as const,
+          priority: 10 + index,
+          value: {
+            optionId: choice.optionId,
+            source: choice.source,
+            value: choice.value,
           },
         })),
         {

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -19,6 +19,8 @@ import type {
   MaterializeDirectoryLaunchpadRequest,
   MaterializeDirectoryLaunchpadResponse,
   NavigationSnapshot,
+  SetAcpSessionRuntimeOptionRequest,
+  SetAcpSessionRuntimeOptionResponse,
   SetThreadExecutionModeRequest,
   SetThreadExecutionModeResponse,
   SetThreadModelSettingsRequest,
@@ -181,6 +183,12 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
     request: SetThreadExecutionModeRequest,
   ): Promise<SetThreadExecutionModeResponse> {
     return await this.registry.setThreadExecutionMode(request);
+  }
+
+  async setAcpSessionRuntimeOption(
+    request: SetAcpSessionRuntimeOptionRequest,
+  ): Promise<SetAcpSessionRuntimeOptionResponse> {
+    return await this.registry.setAcpSessionRuntimeOption(request);
   }
 
   async cancelThreadExecutionModeQueue(

--- a/docs/plans/2026-05-23-001-feat-acp-messaging-runtime-modes-plan.md
+++ b/docs/plans/2026-05-23-001-feat-acp-messaging-runtime-modes-plan.md
@@ -1,0 +1,429 @@
+---
+title: "feat: Add ACP Runtime Modes to Messaging"
+type: feat
+status: implemented
+date: 2026-05-23
+origin: docs/brainstorms/2026-05-17-acp-registry-backends-requirements.md
+---
+
+# feat: Add ACP Runtime Modes to Messaging
+
+## Overview
+
+Messaging can already create threads against ACP backends, and the desktop
+thread UI can already drive ACP runtime modes such as Gemini `default`, `yolo`,
+and edit-oriented modes. The missing feature is messaging parity: `/new` and
+bound-thread status cards should expose the ACP agent's discovered runtime
+modes through the same generic messaging action system used for providers,
+models, workspace, streaming, and Codex permissions.
+
+This is a Standard plan. The implementation should be small in concept, but it
+touches security-relevant access posture, messaging callback state, and
+backend-specific capability discovery.
+
+## Problem Frame
+
+The current messaging slice is conservative: ACP new-thread and status cards
+show `Runtime mode: ... (desktop-only)` and hide the generic Codex permission
+toggle unless an inherited Full Access default must be cleared. That prevents
+messaging users from selecting the ACP runtime mode that the desktop launchpad
+can already select.
+
+This also creates a misleading model. `Full Access` is a Codex-facing
+execution-mode label; ACP agents advertise provider-specific runtime modes and
+config options. Messaging should not invent a Codex Full Access toggle for ACP,
+but it should map discovered ACP runtime choices into a generic `Runtime mode`
+action with the same warning/policy treatment for risky choices.
+
+## Requirements Trace
+
+- ACP backends must reflect capabilities honestly and hide unsupported features
+  rather than papering over them (see origin:
+  `docs/brainstorms/2026-05-17-acp-registry-backends-requirements.md`).
+- ACP access modes must use PwrAgent's Default/Full Access model wherever ACP
+  gives the client control over permission behavior, while preserving clear
+  visibility into what is enforced by PwrAgent versus the ACP agent.
+- Messaging `/new` must adapt provider-specific option buttons to the selected
+  backend before the first prompt, including ACP/Gemini as another backend (see
+  `docs/brainstorms/2026-05-22-messaging-new-thread-backend-selection-requirements.md`).
+- Messaging Full Access policy remains authoritative: explicit escalation to a
+  risky runtime mode must be warning-gated or blocked according to settings
+  (see `docs/brainstorms/2026-05-22-messaging-full-access-approval-requirements.md`).
+- Bound-thread mode changes must follow the same queue-at-turn-boundary
+  semantics as desktop ACP runtime changes and Codex permission changes.
+
+## Scope Boundaries
+
+- Do not add ACP provider-specific branches for Gemini, Kimi, or any future
+  agent. Use discovered `BackendAcpRuntimeCapabilities`.
+- Do not expose a Codex `Full Access` toggle for ACP as the primary control.
+  Messaging should show `Runtime mode`, with labels derived from ACP metadata.
+- Do not invent runtime controls for ACP agents that advertise no modes and no
+  mode-like config options.
+- Do not change Codex permission-mode behavior.
+- Do not broaden ACP discovery or install behavior in this work.
+- Do not make model-only ACP config options appear as runtime modes.
+
+## Context & Research
+
+### Existing Patterns
+
+- `apps/desktop/src/main/app-server/backend-registry.ts` already owns
+  `setAcpSessionRuntimeOption`, queues ACP runtime changes while a turn is
+  active, emits `thread/acpRuntime/updated`, and records permission-transition
+  audit entries with labels derived from ACP metadata.
+- `apps/desktop/src/main/app-server/acp-backend-adapter.ts` already exposes
+  `acpRuntimeValueLooksPrivileged`, `formatAcpRuntimeLabel`, and
+  `buildAcpLaunchpadOptions`. Today the launchpad helper only exports model
+  choices; runtime mode choices remain available in ACP runtime capabilities.
+- `apps/desktop/src/renderer/src/lib/useThreadNavigation.ts` already performs
+  optimistic desktop updates before calling `setAcpSessionRuntimeOption`.
+- `apps/desktop/src/main/messaging/core/messaging-controller.ts` already stores
+  `acpRuntime` in `MessagingBindingPreferences` and new-thread preferences, but
+  it renders the runtime as desktop-only and provides no runtime picker.
+- `apps/desktop/src/main/messaging/core/messaging-status-card.ts` already
+  renders ACP runtime state and suppresses Codex permission controls for ACP.
+- `packages/messaging/interface/src/index.ts` already includes
+  `MessagingBindingPreferences.acpRuntime`, so the interface contract likely
+  needs evolution rather than a brand-new persistence surface.
+
+### Institutional Learnings
+
+- `docs/solutions/2026-05-07-codex-permission-mode-state-machine.md` is the
+  relevant permission precedent: never silently cross security-relevant routing
+  boundaries, never trust implicit defaults, and queue mode changes at the
+  turn boundary when the backend cannot apply them mid-turn.
+- `docs/plans/2026-05-22-001-fix-messaging-full-access-approval-plan.md`
+  established the inherited-versus-explicit Full Access distinction. ACP
+  runtime mode changes should follow the same provenance principle: inherited
+  defaults are not surprise escalations, explicit user selection of a risky ACP
+  mode is.
+
+### External Research
+
+None used. The required behavior is a local mapping between existing PwrAgent
+ACP capability data and existing PwrAgent messaging actions.
+
+## Key Technical Decisions
+
+- Add a provider-neutral ACP runtime mode descriptor helper in desktop main
+  code. Messaging and status rendering should consume a normalized list of
+  choices instead of guessing from string substrings in multiple places.
+- Keep the helper pure and dependency-light. Do not make messaging import the
+  full ACP backend adapter module just to reuse label/risk helpers; extract
+  pure helpers to a shared/main utility if needed so ACP process/client code
+  stays isolated.
+- Treat ACP runtime modes as their own messaging action family:
+  `Runtime mode: <label>`, not `Permissions: <label>`.
+- Derive choices from, in priority order, advertised ACP modes and ACP config
+  options whose category is `mode`. Keep the existing `endsWith("mode")`
+  fallback only as a compatibility fallback for state display, not for
+  constructing new selectable options when richer metadata exists.
+- Use `acpRuntimeValueLooksPrivileged` as the first risk classifier. If an ACP
+  choice is privileged, it should use the existing messaging Full Access
+  warning/block policy before the selection is stored or applied.
+- For new threads, store the selected ACP runtime in the pending browse session
+  and pass it through `startThread`. For existing bound threads, call
+  `setAcpSessionRuntimeOption` and let the backend registry decide
+  apply-versus-queue.
+- Show queued/applied runtime changes in the same audit/status language users
+  already see for permission transitions, but with ACP labels such as
+  `Default -> Yolo` rather than Codex-only `Default Access -> Full Access`.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should messaging allow ACP escalation by using the Codex `Full Access`
+  permission toggle?
+  Resolution: no. The user-facing control should be `Runtime mode`, because
+  ACP agents expose provider-specific modes. Risky selections still map into
+  the existing Full Access policy gate.
+- Should model config options be included in runtime mode choices?
+  Resolution: no. Model selection stays the model action. Only ACP `modes` and
+  `configOptions` with `category: "mode"` should become runtime mode choices.
+- Should this require backend-registry protocol changes?
+  Resolution: likely no. Existing `setAcpSessionRuntimeOption` and
+  `acpRuntime` start-thread plumbing are sufficient unless implementation finds
+  a missing bridge method in messaging's backend facade.
+
+### Deferred to Implementation
+
+- Exact callback IDs and pagination shape should follow existing
+  `browse:new:*` and `status:*` picker conventions.
+- If an ACP agent exposes both `modes.availableModes` and a `category: "mode"`
+  config option, implementation should confirm which one `setRuntimeOption`
+  expects for that specific discovered capability. Prefer advertised modes
+  first, then config option modes.
+
+## Implementation Units
+
+- [x] **Unit 1: Centralize ACP Runtime Mode Choice Normalization**
+
+**Goal:** Provide one main-process helper that turns ACP runtime capabilities and
+session state into selectable messaging/runtime choices.
+
+**Requirements:** ACP capability honesty, no model-as-mode regression,
+provider-neutral labels.
+
+**Files:**
+- Modify or add: `apps/desktop/src/main/messaging/core/messaging-acp-runtime.ts`
+- Modify: `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- Modify: `apps/desktop/src/main/messaging/core/messaging-status-card.ts`
+- Modify as needed: `apps/desktop/src/main/app-server/acp-backend-adapter.ts`
+- Modify as needed: `packages/shared/src/contracts/backend.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-status-card.test.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+
+**Approach:**
+- Build a helper that accepts `BackendSummary`, current
+  `BackendAcpSessionRuntimeState`, and launchpad/default runtime state.
+- Return the current label plus a list of choices with `source`, `optionId`,
+  `value`, `label`, `description`, `selected`, and `privileged`.
+- Include `runtime.modes.availableModes` as `source: "mode"` choices.
+- Include `runtime.configOptions` with `category: "mode"` as
+  `source: "configOption"` choices.
+- Exclude `category: "model"` and non-mode config options from runtime-mode
+  pickers.
+- Use `formatAcpRuntimeLabel` for fallback label formatting and
+  `acpRuntimeValueLooksPrivileged` for initial risk classification.
+- If those helpers remain in `acp-backend-adapter.ts`, extract their pure
+  behavior before using them from messaging so importing runtime-mode UI logic
+  does not pull in ACP stdio/client implementation details.
+
+**Test scenarios:**
+- Gemini-like capabilities with modes `default`, `auto_edit`, and `yolo`
+  produce three runtime choices with `Yolo` marked privileged.
+- Config option `{ id: "approval-mode", category: "mode" }` produces choices
+  with `source: "configOption"` and `optionId: "approval-mode"`.
+- Config option `{ id: "model", category: "model" }` does not produce runtime
+  mode choices.
+- Backend with no ACP runtime capabilities produces no choices and no action.
+- Current runtime state selects the matching choice from `currentModeId` or the
+  matching mode config option.
+
+- [x] **Unit 2: Add ACP Runtime Mode Picker to Messaging New-Thread Flow**
+
+**Goal:** Let messaging users choose an ACP runtime mode before the first prompt
+when the selected provider advertises mode choices.
+
+**Requirements:** Messaging backend option parity, launchpad default parity,
+explicit-risk gating, no Codex label leakage.
+
+**Files:**
+- Modify: `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- Modify if needed: `packages/messaging/interface/src/index.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+
+**Approach:**
+- Replace the `Runtime mode: ... (desktop-only)` line in the ready-to-start
+  body with `Runtime mode: <label>` when choices exist.
+- Add a `browse:new:runtime-mode` action when the selected backend is ACP and
+  mode choices exist.
+- Present a picker listing available runtime modes, respecting messaging
+  capability profile action limits and using text fallback for constrained
+  providers.
+- On selection, if the target choice is privileged and the current effective
+  runtime is not privileged, run the same Full Access warning/block policy used
+  by explicit messaging escalation.
+- Store approved selection in `session.preferences.acpRuntime` and
+  `MessagingBindingPreferences.acpRuntime` as appropriate, without writing
+  `executionMode: "full-access"` for ACP.
+- Ensure `startThread` receives the selected `acpRuntime` so backend registry
+  applies it before the session prompt.
+
+**Test scenarios:**
+- `/new` with Gemini selected shows `Runtime mode: Default` and a runtime-mode
+  action, not `Runtime mode: ... (desktop-only)`.
+- Selecting `Yolo` from the picker updates the ready card to
+  `Runtime mode: Yolo` and passes `acpRuntime.currentModeId = "yolo"` to
+  thread creation.
+- Selecting privileged `Yolo` from `Default` is blocked when messaging Full
+  Access escalation is disabled.
+- Selecting privileged `Yolo` under a warning policy shows the existing warning
+  flow and only stores the runtime after approval.
+- Selecting non-privileged `Default` or equivalent applies without a warning.
+- Changing provider away from ACP clears incompatible `acpRuntime` preferences.
+- Changing from one ACP backend to another drops runtime selections that are
+  not valid for the new backend.
+
+- [x] **Unit 3: Add ACP Runtime Mode Actions to Bound Thread Status Cards**
+
+**Goal:** Let messaging users change runtime mode on existing ACP threads using
+the backend registry's existing apply-or-queue behavior.
+
+**Requirements:** Existing-thread parity, queue semantics, status accuracy.
+
+**Files:**
+- Modify: `apps/desktop/src/main/messaging/core/messaging-status-card.ts`
+- Modify: `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- Modify: `apps/desktop/src/main/messaging/core/messaging-adapter.ts`
+- Modify bridge wiring where the desktop registry is adapted into
+  `MessagingBackendBridge`
+- Test: `apps/desktop/src/main/__tests__/messaging-status-card.test.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+- Test as needed: `apps/desktop/src/main/__tests__/backend-registry.test.ts`
+
+**Approach:**
+- Replace the current ACP status copy `Runtime mode: <label> (desktop-only)`
+  with `Runtime mode: <label>`.
+- Add a `status:runtime-mode` action for ACP bindings when choices exist.
+- Add `setAcpSessionRuntimeOption` to `MessagingBackendBridge`, then wire it to
+  the existing backend registry method rather than adding a messaging-specific
+  ACP mutation path.
+- Picker selections should call `backend.setAcpSessionRuntimeOption` with the
+  normalized `source`, `optionId`, and `value`.
+- Before applying a privileged target, reuse the Full Access warning/block
+  policy. If the current or queued target is already privileged, changing among
+  privileged ACP modes should still be explicit but should not be mislabeled as
+  Codex Full Access.
+- Optimistically update binding preferences only after warning approval. Then
+  rely on `thread/acpRuntime/updated` or queue/audit refresh to render
+  canonical state.
+- If the thread is active, the registry should queue the mode change and the
+  status card should show the queued transition from the permission-transition
+  audit or an ACP runtime queue state if exposed.
+
+**Test scenarios:**
+- ACP status card renders a `Runtime mode: Yolo` action and no
+  `Permissions: Full Access` action.
+- Selecting `Default -> Yolo` on an idle thread calls
+  `setAcpSessionRuntimeOption` with the correct ACP request.
+- Selecting `Default -> Yolo` on an active thread results in queued transition
+  copy and no claim that the change applied immediately.
+- Selecting `Yolo -> Default` clears the privileged mode without requiring a
+  warning.
+- A backend with no runtime choices renders status text only and no runtime
+  action.
+- Existing Codex status-card permission tests continue to pass unchanged.
+
+- [x] **Unit 4: Unify ACP Runtime Risk Copy and Audit Display**
+
+**Goal:** Make warnings and transcript/status audit entries understandable for
+provider-specific ACP modes.
+
+**Requirements:** Clear security copy, no raw provider jargon unless it is the
+mode label, queue/audit visibility.
+
+**Files:**
+- Modify: `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- Modify: `apps/desktop/src/main/messaging/core/messaging-status-card.ts`
+- Modify as needed: `apps/desktop/src/main/app-server/backend-registry.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-status-card.test.ts`
+
+**Approach:**
+- Keep the policy concept as Full Access escalation internally, but tailor
+  messaging copy to the ACP runtime target:
+  `Yolo may allow the ACP agent to run commands or edit files with fewer
+  prompts.`
+- Continue using permission-transition records for audit, but use ACP labels
+  in user-visible text.
+- Avoid showing a generic `Full Access` chip/action when the selected backend is
+  ACP unless the actual launchpad execution mode is still inherited
+  Full Access and needs clearing.
+
+**Test scenarios:**
+- Privileged ACP warning mentions the selected runtime mode label.
+- Warning cancel leaves the runtime at the previous mode.
+- Warning approve updates/persists the selected ACP runtime.
+- Audit/status text says `Default -> Yolo` or `Yolo -> Default`, not
+  `Default Access -> Full Access`, for ACP runtime transitions.
+
+- [x] **Unit 5: Add End-to-End Coverage for Messaging ACP Runtime Modes**
+
+**Goal:** Lock the user-visible messaging path so ACP mode parity does not
+regress again.
+
+**Requirements:** Regression coverage across new-thread and existing-thread
+messaging flows.
+
+**Files:**
+- Add or modify: `apps/desktop/e2e/*`
+- Add or modify fixtures as needed under existing desktop E2E fixture paths
+- Test support: `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+
+**Approach:**
+- Use the existing desktop replay/mock backend approach rather than launching a
+  real ACP agent.
+- Seed a fake ACP backend with discovered runtime capabilities for
+  `default`, `auto_edit`, and `yolo`.
+- Exercise at least one provider-neutral messaging flow through controller tests
+  and one desktop E2E/replay path if the existing harness already covers
+  messaging startup cards.
+
+**Test scenarios:**
+- New thread from messaging selects Gemini, chooses `Yolo`, approves warning,
+  starts a thread, and the resulting thread summary shows ACP runtime `Yolo`.
+- Bound ACP thread status changes from `Default` to `Yolo` while idle and the
+  status card refreshes.
+- Bound ACP thread changes from `Default` to `Yolo` while a turn is active and
+  the queue/audit state is visible.
+
+**Implementation note:** Messaging-specific ACP runtime flows are covered in
+`messaging-controller.test.ts` and `messaging-status-card.test.ts`, where the
+controller can drive provider callbacks without a real Telegram/Discord
+adapter. The existing replay-backed desktop ACP runtime E2E spec was run as the
+cross-surface regression for ACP runtime labels, mode updates, tool progress,
+image replay ordering, replay noise, and handoff gating.
+
+## Sequencing
+
+1. Normalize ACP runtime choices first. This prevents duplicate string
+   heuristics from spreading across new-thread and status-card flows.
+2. Implement the new-thread picker next because it is creation-time state and
+   already has `acpRuntime` preference plumbing.
+3. Implement bound-thread status changes after new-thread storage is correct,
+   reusing the same choice helper and risk gate.
+4. Polish warning/audit copy once the behavior exists end to end.
+5. Add E2E/replay coverage after unit tests define the state contract.
+
+## Risks and Mitigations
+
+- **Risk:** Messaging exposes a risky ACP mode without warning.
+  **Mitigation:** Centralize `privileged` classification and route every
+  explicit privileged selection through the existing Full Access controls.
+- **Risk:** Model config options are mislabeled as runtime mode again.
+  **Mitigation:** Build selectable runtime choices only from modes and
+  `category: "mode"` config options; keep a regression test for model-only
+  config.
+- **Risk:** ACP agents use different names for equivalent privileged behavior.
+  **Mitigation:** Start with existing classifier and make it centralized so new
+  known privileged identifiers can be added in one place.
+- **Risk:** Messaging providers with limited buttons overflow their action
+  budgets.
+  **Mitigation:** Use existing capability-profile prioritization and text
+  fallback patterns.
+- **Risk:** Mid-turn changes appear applied immediately.
+  **Mitigation:** Route existing-thread changes only through
+  `setAcpSessionRuntimeOption` and surface queued state from backend registry
+  notifications/audit.
+
+## Verification Plan
+
+- Run focused unit tests:
+  - `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+  - `apps/desktop/src/main/__tests__/messaging-status-card.test.ts`
+  - `apps/desktop/src/main/__tests__/backend-registry.test.ts`
+- Run shared typecheck for contract changes.
+- Run desktop E2E/replay coverage if Unit 5 adds or touches replay fixtures.
+- Run existing ACP runtime replay E2E coverage as a cross-surface regression.
+- Manually verify, using a dev profile with Gemini ACP enabled, that Telegram
+  and desktop-created ACP threads show the same runtime mode labels and that
+  choosing `Yolo` from messaging starts or resumes with the same behavior as
+  the desktop control.
+
+## Acceptance Criteria
+
+- Messaging `/new` for ACP backends shows and can change ACP runtime mode before
+  the first prompt.
+- Messaging status cards for bound ACP threads show and can change ACP runtime
+  mode when the backend advertises choices.
+- Risky ACP runtime selections are blocked or warning-gated by the existing
+  Full Access messaging settings.
+- ACP runtime mode labels are provider-neutral and do not leak Codex
+  `Default Access` / `Full Access` labels except where inherited execution mode
+  genuinely matters.
+- Model-only ACP config values are never displayed as runtime modes.
+- Mid-turn ACP runtime changes queue and display honestly instead of claiming
+  immediate application.


### PR DESCRIPTION
## Summary

- Added a generic ACP runtime mode helper for messaging so mode choices come from discovered ACP capabilities instead of string heuristics.
- Wired ACP runtime mode selection into messaging `/new` and bound-thread status cards, including risk gating for privileged modes like `Yolo`.
- Preserved the inherited Full Access escape hatch for ACP messaging flows so users can clear a Full Access default when one is already applied.

## Verification

- `pnpm --filter @pwragent/desktop exec vitest run src/main/__tests__/messaging-status-card.test.ts src/main/__tests__/messaging-controller.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`
- `pnpm --filter @pwragent/desktop test:e2e -- acp-runtime-modes.spec.ts`

## Notes

- Branch is based on current `origin/main`, including the squash-merged `fix/acp-runtime-gates` work.
