### PR TITLE
feat(desktop): add Kimi ACP support

### DIFF
--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -216,6 +216,16 @@ The desktop config writer must preserve recognized legacy shapes when possible,
 mark them with the `pwragent-legacy-settings` comment, lazily convert on save,
 and avoid whole-file rewrites that discard user comments.
 
+## Thread History Persistence
+
+Thread transcripts, rollout events, streamed message deltas, prompt text,
+assistant text, and command output history must not be written into the desktop
+sqlite database. Store only desktop metadata there. For the full rule and the
+ACP fallback direction, read
+[../../docs/thread-history-persistence.md](../../docs/thread-history-persistence.md)
+before changing ACP session storage, thread replay restoration, or rollout
+persistence.
+
 ## Thread-State Update Bus
 
 When mutating persistent thread state (model, reasoning effort, fast mode,

--- a/apps/desktop/e2e/acp-runtime-modes.spec.ts
+++ b/apps/desktop/e2e/acp-runtime-modes.spec.ts
@@ -644,21 +644,21 @@ test("renders ACP-native runtime modes and keeps live mode chrome in sync", asyn
     await expect(
       app.window.getByRole("heading", { level: 2, name: "ACP Yolo Thread" }),
     ).toBeVisible();
-    const modeChip = app.window.locator(".thread-header .chip--mode");
-    await expect(modeChip).toHaveText("Default");
+    const accessChip = app.window.locator(".thread-header .chip--mode");
+    await expect(accessChip).toHaveText("Default Access");
 
-    const acpMode = app.window.getByLabel("ACP mode");
-    await expect(acpMode).toBeEnabled();
-    await expect(acpMode).toHaveAttribute("data-value", "default");
+    const agentMode = app.window.getByLabel("Agent mode");
+    await expect(agentMode).toBeEnabled();
+    await expect(agentMode).toHaveAttribute("data-value", "default");
 
-    await acpMode.click();
+    await agentMode.click();
     await app.window.getByRole("option", { name: "YOLO" }).click();
 
-    await expect(acpMode).toHaveAttribute("data-value", "yolo");
-    await expect(modeChip).toHaveText("Yolo");
+    await expect(agentMode).toHaveAttribute("data-value", "yolo");
+    await expect(accessChip).toHaveText("Default Access");
     await app.window.waitForTimeout(300);
-    await expect(acpMode).toHaveAttribute("data-value", "yolo");
-    await expect(modeChip).toHaveText("Yolo");
+    await expect(agentMode).toHaveAttribute("data-value", "yolo");
+    await expect(accessChip).toHaveText("Default Access");
     await expect(app.window.getByText("[MODE_UPDATE]")).toHaveCount(0);
   } finally {
     await app.close();
@@ -677,19 +677,19 @@ test("keeps ACP config-option mode controls in sync when the agent echoes stale 
   try {
     await app.window.getByRole("button", { name: /ACP Config Mode Thread/i }).click();
 
-    const modeChip = app.window.locator(".thread-header .chip--mode");
-    const acpMode = app.window.getByLabel("ACP mode");
-    await expect(modeChip).toHaveText("Default");
-    await expect(acpMode).toHaveAttribute("data-value", "default");
+    const accessChip = app.window.locator(".thread-header .chip--mode");
+    const agentMode = app.window.getByLabel("Agent mode");
+    await expect(accessChip).toHaveText("Default Access");
+    await expect(agentMode).toHaveAttribute("data-value", "default");
 
-    await acpMode.click();
+    await agentMode.click();
     await app.window.getByRole("option", { name: "YOLO" }).click();
 
-    await expect(acpMode).toHaveAttribute("data-value", "yolo");
-    await expect(modeChip).toHaveText("Yolo");
+    await expect(agentMode).toHaveAttribute("data-value", "yolo");
+    await expect(accessChip).toHaveText("Default Access");
     await app.window.waitForTimeout(300);
-    await expect(acpMode).toHaveAttribute("data-value", "yolo");
-    await expect(modeChip).toHaveText("Yolo");
+    await expect(agentMode).toHaveAttribute("data-value", "yolo");
+    await expect(accessChip).toHaveText("Default Access");
     await expect(app.window.getByText("[MODE_UPDATE]")).toHaveCount(0);
   } finally {
     await app.close();

--- a/apps/desktop/e2e/acp-runtime-modes.spec.ts
+++ b/apps/desktop/e2e/acp-runtime-modes.spec.ts
@@ -11,6 +11,8 @@ import { launchElectronApp } from "./fixtures/electron-app";
 const specDir = path.dirname(fileURLToPath(import.meta.url));
 
 const geminiBackendId = "acp:gemini" as AcpBackendId;
+const legacyImageDataUrl =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
 
 function acpMockScript(): string {
   return `
@@ -25,12 +27,113 @@ rl.on("line", (line) => {
     return;
   }
   if (msg.method === "session/load") {
+    const loadModeId =
+      msg.params?.sessionId === "acp-replay-noise-thread" ? "yolo" : currentModeId;
+    if (msg.params?.sessionId === "acp-replay-noise-thread") {
+      send({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId: msg.params.sessionId,
+          update: {
+            kind: "pwragent_user_prompt",
+            prompt: "What is this project?",
+            turnId: "pending:acp-replay-noise-thread:1779400000000"
+          }
+        }
+      });
+      send({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId: msg.params.sessionId,
+          update: {
+            sessionUpdate: "user_message_chunk",
+            content: { type: "text", text: "What is " }
+          }
+        }
+      });
+      send({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId: msg.params.sessionId,
+          update: {
+            sessionUpdate: "user_message_chunk",
+            content: { type: "text", text: "this project?" }
+          }
+        }
+      });
+      send({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId: msg.params.sessionId,
+          update: { kind: "agent_message_chunk", content: "[MODE_UPDATE] yolo" }
+        }
+      });
+      send({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId: msg.params.sessionId,
+          update: { kind: "agent_message_chunk", content: "It is PwrAgent." }
+        }
+      });
+      send({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId: msg.params.sessionId,
+          update: {
+            kind: "turn_finished",
+            turnId: "pending:acp-replay-noise-thread:1779400000000"
+          }
+        }
+      });
+    }
+    if (msg.params?.sessionId === "acp-legacy-image-thread") {
+      send({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId: msg.params.sessionId,
+          update: {
+            kind: "pwragent_user_prompt",
+            prompt: "What's in this image?\\n[Image: ${legacyImageDataUrl}]",
+            turnId: "pending:acp-legacy-image-thread:1779400000000"
+          }
+        }
+      });
+      send({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId: msg.params.sessionId,
+          update: {
+            kind: "agent_message_chunk",
+            content: "This image is a detailed screenshot."
+          }
+        }
+      });
+      send({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId: msg.params.sessionId,
+          update: {
+            kind: "turn_finished",
+            turnId: "pending:acp-legacy-image-thread:1779400000000"
+          }
+        }
+      });
+    }
     send({
       jsonrpc: "2.0",
       id: msg.id,
       result: {
         modes: {
-          currentModeId,
+          currentModeId: loadModeId,
           availableModes: [
             { id: "default", name: "Default" },
             { id: "autoEdit", name: "Auto Edit" },
@@ -254,15 +357,6 @@ async function seedAcpGemini(homeRoot: string): Promise<void> {
         updatedAt: 1779400000000,
       },
       status: "idle",
-      transcriptUpdates: [
-        {
-          receivedAt: 1779400000000,
-          update: {
-            kind: "agent_message_chunk",
-            content: "Ready.",
-          },
-        },
-      ],
     });
   } finally {
     db.close();
@@ -430,15 +524,7 @@ async function seedAcpGeminiWithHistory(homeRoot: string): Promise<void> {
       updatedAt: 1779400000000,
       executionMode: "default",
       status: "idle",
-      transcriptUpdates: [
-        {
-          receivedAt: 1779400000000,
-          update: {
-            kind: "pwragent_user_prompt",
-            prompt: "What is this project?",
-          },
-        },
-      ],
+      hasConversationHistory: true,
     });
   } finally {
     db.close();
@@ -494,51 +580,7 @@ async function seedAcpGeminiReplayNoise(homeRoot: string): Promise<void> {
       updatedAt: 1779400005000,
       executionMode: "default",
       status: "idle",
-      transcriptUpdates: [
-        {
-          receivedAt: 1779400000000,
-          update: {
-            kind: "pwragent_user_prompt",
-            prompt: "What is this project?",
-            turnId: "pending:acp-replay-noise-thread:1779400000000",
-          },
-        },
-        {
-          receivedAt: 1779400000100,
-          update: {
-            sessionUpdate: "user_message_chunk",
-            content: { type: "text", text: "What is " },
-          },
-        },
-        {
-          receivedAt: 1779400000200,
-          update: {
-            sessionUpdate: "user_message_chunk",
-            content: { type: "text", text: "this project?" },
-          },
-        },
-        {
-          receivedAt: 1779400000300,
-          update: {
-            kind: "agent_message_chunk",
-            content: "[MODE_UPDATE] yolo",
-          },
-        },
-        {
-          receivedAt: 1779400000400,
-          update: {
-            kind: "agent_message_chunk",
-            content: "It is PwrAgent.",
-          },
-        },
-        {
-          receivedAt: 1779400000500,
-          update: {
-            kind: "turn_finished",
-            turnId: "pending:acp-replay-noise-thread:1779400000000",
-          },
-        },
-      ],
+      hasConversationHistory: true,
     });
   } finally {
     db.close();
@@ -549,8 +591,6 @@ async function seedAcpGeminiLegacyImagePrompt(homeRoot: string): Promise<void> {
   const dbPath = path.join(homeRoot, ".pwragent/profiles/default/state/state.db");
   await mkdir(path.dirname(dbPath), { recursive: true });
   const db = StateDb.open(dbPath, { profileName: "default" });
-  const imageUrl =
-    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
   try {
     new AcpAgentStore(db).upsertInstalledAgent({
       backendId: geminiBackendId,
@@ -582,30 +622,7 @@ async function seedAcpGeminiLegacyImagePrompt(homeRoot: string): Promise<void> {
       updatedAt: 1779400005000,
       executionMode: "default",
       status: "idle",
-      transcriptUpdates: [
-        {
-          receivedAt: 1779400000000,
-          update: {
-            kind: "pwragent_user_prompt",
-            prompt: `What's in this image?\n[Image: ${imageUrl}]`,
-            turnId: "pending:acp-legacy-image-thread:1779400000000",
-          },
-        },
-        {
-          receivedAt: 1779400001000,
-          update: {
-            kind: "agent_message_chunk",
-            content: "This image is a detailed screenshot.",
-          },
-        },
-        {
-          receivedAt: 1779400002000,
-          update: {
-            kind: "turn_finished",
-            turnId: "pending:acp-legacy-image-thread:1779400000000",
-          },
-        },
-      ],
+      hasConversationHistory: true,
     });
   } finally {
     db.close();
@@ -753,9 +770,6 @@ test("normalizes ACP replay noise without duplicate prompts or mode marker text"
     await expect(app.window.getByText("What is this project?")).toHaveCount(1);
     await expect(app.window.getByText("It is PwrAgent.")).toBeVisible();
     await expect(app.window.getByText("[MODE_UPDATE]")).toHaveCount(0);
-
-    const modeChip = app.window.locator(".thread-header .chip--mode");
-    await expect(modeChip).toHaveText("Yolo");
   } finally {
     await app.close();
   }

--- a/apps/desktop/e2e/codex-environment-setup.spec.ts
+++ b/apps/desktop/e2e/codex-environment-setup.spec.ts
@@ -366,7 +366,7 @@ async function readActionCwdMarker(params: {
   return "";
 }
 
-test("selected Codex environments run setup and show transcript output", async () => {
+test("selected environments run setup and show transcript output", async () => {
   const fixture = await createCodexEnvironmentSetupFixture();
   const app = await launchElectronApp({
     fixturePath: fixture.fixturePath,
@@ -380,7 +380,7 @@ test("selected Codex environments run setup and show transcript output", async (
 
     await expect(app.window.getByRole("textbox", { name: "New thread" })).toBeVisible();
     const launchpadTools = app.window.getByLabel("Composer tools");
-    await launchpadTools.getByRole("button", { name: "Codex environment" }).click();
+    await launchpadTools.getByRole("button", { name: "Environment", exact: true }).click();
     await app.window.getByRole("option", { name: "Fixture Env" }).click();
     await expect(
       launchpadTools.locator("label", { hasText: "Run setup" }).locator("input"),
@@ -425,7 +425,7 @@ test("selected Codex environments run setup and show transcript output", async (
   }
 });
 
-test("existing running thread keeps selected Codex environment after pending state clears", async () => {
+test("existing running thread keeps selected environment after pending state clears", async () => {
   const fixture = await createCodexEnvironmentSetupFixture({
     includeExistingRunningSteps: true,
   });
@@ -445,7 +445,10 @@ test("existing running thread keeps selected Codex environment after pending sta
     await app.advance({ stepId: "existing-thread-turn-started" });
     await expect(app.window.getByRole("button", { name: "Stop" })).toBeVisible();
 
-    const environmentDropdown = app.window.getByLabel("Codex environment");
+    const environmentDropdown = app.window.getByRole("button", {
+      name: "Environment",
+      exact: true,
+    });
     await expect(environmentDropdown).toHaveAttribute("data-value", "");
     await environmentDropdown.click();
     await app.window.getByRole("option", { name: "Fixture Env" }).click();
@@ -473,9 +476,11 @@ test("thread environment Run command uses the current cwd after workspace handof
       app.window.getByRole("heading", { level: 2, name: "Existing directory thread" }),
     ).toBeVisible();
 
-    await app.window.getByLabel("Codex environment").click();
+    await app.window.getByRole("button", { name: "Environment", exact: true }).click();
     await app.window.getByRole("option", { name: "Fixture Env" }).click();
-    await expect(app.window.getByLabel("Codex environment")).toContainText(
+    await expect(
+      app.window.getByRole("button", { name: "Environment", exact: true }),
+    ).toContainText(
       "Fixture Env",
     );
     await expect(app.window.getByLabel("Environment command")).toContainText(
@@ -554,7 +559,7 @@ test("thread environment Run command uses the current cwd after workspace handof
   }
 });
 
-test("directory launchpad keeps selected Codex environment controls after snapshot reload", async () => {
+test("directory launchpad keeps selected environment controls after snapshot reload", async () => {
   const fixture = await createCodexEnvironmentSetupFixture({
     includeExistingThread: false,
   });
@@ -612,7 +617,9 @@ test("directory launchpad keeps selected Codex environment controls after snapsh
       "worktree",
     );
     const tools = secondApp.window.getByLabel("Composer tools");
-    await expect(tools.getByLabel("Codex environment")).toContainText(
+    await expect(
+      tools.getByRole("button", { name: "Environment", exact: true }),
+    ).toContainText(
       "Fixture Env",
     );
     await expect(tools.getByLabel("Run setup")).toBeChecked();
@@ -646,7 +653,9 @@ test("directory launchpad opens without an environment picker when no environmen
       app.window.getByRole("heading", { level: 2, name: "NoEnvRepo" }),
     ).toBeVisible();
     await expect(app.window.getByRole("textbox", { name: "New thread" })).toBeVisible();
-    await expect(app.window.getByLabel("Codex environment")).toHaveCount(0);
+    await expect(
+      app.window.getByRole("button", { name: "Environment", exact: true }),
+    ).toHaveCount(0);
     await expect(
       app.window.getByText(/Error invoking remote method|ENOTDIR/),
     ).toHaveCount(0);

--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -156,6 +156,102 @@ describe("AcpBackendAdapter", () => {
 
     await adapter.close();
   });
+
+  it("coalesces unchanged ACP live tool notifications", async () => {
+    const backendId = "acp:kimi" as AcpBackendId;
+    const transport = new FakeAcpAgentTransport();
+    const events: AgentEvent[] = [];
+    const sessions: AcpSessionMetadata[] = [];
+    const agent: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      backendId,
+      registryId: "kimi",
+      name: "Kimi Code CLI",
+      launchDescriptor: {
+        backendId,
+        registryId: "kimi",
+        distributionKind: "local",
+        command: "kimi",
+        args: ["acp"],
+        env: {},
+      },
+    };
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => agent,
+        listInstalledAgents: () => [agent],
+        upsertInstalledAgent: vi.fn(),
+      },
+      acpSessionStore: {
+        listSessions: () => sessions,
+        getSession: (_backendId, sessionId) =>
+          sessions.find((session) => session.sessionId === sessionId),
+        upsertSession: (metadata) => {
+          const index = sessions.findIndex(
+            (session) => session.sessionId === metadata.sessionId,
+          );
+          if (index >= 0) {
+            sessions[index] = metadata;
+          } else {
+            sessions.push(metadata);
+          }
+        },
+      },
+      captureStores: [],
+      createAcpTransport: () => transport,
+      emit: async (event) => {
+        events.push(event);
+      },
+      handleServerRequest: async () => ({ decision: "accept" }),
+    });
+
+    const client = await adapter.getClient(backendId);
+    const session = await client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+    });
+    client.startPrompt({
+      sessionId: session.sessionId,
+      prompt: "Build",
+      turnId: "turn-1",
+    });
+
+    for (let index = 0; index < 5; index += 1) {
+      transport.emitSessionUpdate(session.sessionId, {
+        session_update: "tool_call_update",
+        tool_call_id: "turn-1:tool-1",
+        title: "pnpm build",
+        status: "in_progress",
+      });
+    }
+
+    const itemStartedEvents = events.filter(
+      (event) => event.notification.method === "item/started",
+    );
+    expect(itemStartedEvents).toHaveLength(1);
+    expect(itemStartedEvents[0]?.notification.params).toEqual(
+      expect.objectContaining({
+        item: expect.objectContaining({
+          id: "turn-1:tool-1",
+          status: "in_progress",
+        }),
+      }),
+    );
+
+    transport.emitSessionUpdate(session.sessionId, {
+      session_update: "tool_call_update",
+      tool_call_id: "turn-1:tool-1",
+      title: "pnpm build",
+      status: "completed",
+      content: { type: "text", text: "Build succeeded" },
+    });
+
+    expect(
+      events.filter((event) => event.notification.method === "item/completed"),
+    ).toHaveLength(1);
+
+    await adapter.close();
+  });
 });
 
 function buildInstalledAgent(): AcpInstalledAgentRecord {

--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -268,6 +268,89 @@ describe("AcpBackendAdapter", () => {
     await adapter.close();
   });
 
+  it("emits ACP thought chunks as live assistant commentary", async () => {
+    const backendId = "acp:kimi" as AcpBackendId;
+    const transport = new FakeAcpAgentTransport();
+    const events: AgentEvent[] = [];
+    const sessions: AcpSessionMetadata[] = [];
+    const agent: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      backendId,
+      registryId: "kimi",
+      name: "Kimi Code CLI",
+      launchDescriptor: {
+        backendId,
+        registryId: "kimi",
+        distributionKind: "local",
+        command: "kimi",
+        args: ["acp"],
+        env: {},
+      },
+    };
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => agent,
+        listInstalledAgents: () => [agent],
+        upsertInstalledAgent: vi.fn(),
+      },
+      acpSessionStore: {
+        listSessions: () => sessions,
+        getSession: (_backendId, sessionId) =>
+          sessions.find((session) => session.sessionId === sessionId),
+        upsertSession: (metadata) => {
+          const index = sessions.findIndex(
+            (session) => session.sessionId === metadata.sessionId,
+          );
+          if (index >= 0) {
+            sessions[index] = metadata;
+          } else {
+            sessions.push(metadata);
+          }
+        },
+      },
+      captureStores: [],
+      createAcpTransport: () => transport,
+      emit: async (event) => {
+        events.push(event);
+      },
+      handleServerRequest: async () => ({ decision: "accept" }),
+    });
+
+    const client = await adapter.getClient(backendId);
+    const session = await client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+    });
+    client.startPrompt({
+      sessionId: session.sessionId,
+      prompt: "Inspect this",
+      turnId: "turn-1",
+    });
+
+    transport.emitSessionUpdate(session.sessionId, {
+      session_update: "agent_thought_chunk",
+      content: { type: "text", text: "I should inspect the build setup." },
+    });
+
+    await vi.waitFor(() => {
+      expect(events).toContainEqual({
+        backend: backendId,
+        notification: {
+          method: "item/agentMessage/delta",
+          params: {
+            threadId: session.sessionId,
+            turnId: "turn-1",
+            itemId: "thought:turn-1",
+            delta: "I should inspect the build setup.",
+            phase: "commentary",
+          },
+        },
+      });
+    });
+
+    await adapter.close();
+  });
+
   it("reads Kimi replay from local rollout history instead of session/load", async () => {
     const backendId = "acp:kimi" as AcpBackendId;
     const agent: AcpInstalledAgentRecord = {

--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -39,7 +39,7 @@ describe("describeInstalledAcpBackend", () => {
     expect(backend.methods).toContain("session/load");
   });
 
-  it("does not advertise session/load for Kimi even without stored capability data", () => {
+  it("advertises session/load for Kimi unless the agent reports it is unsupported", () => {
     const backend = describeInstalledAcpBackend({
       ...buildInstalledAgent(),
       backendId: "acp:kimi" as AcpBackendId,
@@ -47,11 +47,7 @@ describe("describeInstalledAcpBackend", () => {
       name: "Kimi Code CLI",
     });
 
-    expect(backend.methods).toEqual([
-      "session/new",
-      "session/prompt",
-      "session/cancel",
-    ]);
+    expect(backend.methods).toContain("session/load");
   });
 });
 
@@ -516,6 +512,13 @@ describe("AcpBackendAdapter", () => {
       backendId,
       registryId: "kimi",
       name: "Kimi Code CLI",
+      runtimeCapabilities: {
+        schemaVersion: 1,
+        status: "discovered",
+        agentCapabilities: {
+          loadSession: false,
+        },
+      },
     };
     const session: AcpSessionMetadata = {
       backendId,
@@ -592,6 +595,103 @@ describe("AcpBackendAdapter", () => {
       lastAssistantMessage: "Restored from rollout",
     });
     expect(loadSession).not.toHaveBeenCalled();
+
+    await adapter.close();
+  });
+
+  it("falls back to rollout history when Kimi session/load returns no replay", async () => {
+    const backendId = "acp:kimi" as AcpBackendId;
+    const agent: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      backendId,
+      registryId: "kimi",
+      name: "Kimi Code CLI",
+    };
+    const session: AcpSessionMetadata = {
+      backendId,
+      sessionId: "session-1",
+      title: "Kimi thread",
+      createdAt: 1000,
+      updatedAt: 1000,
+      executionMode: "default",
+      status: "idle",
+      hasConversationHistory: true,
+    };
+    const replay = {
+      entries: [
+        {
+          type: "message" as const,
+          id: "assistant:1",
+          role: "assistant" as const,
+          text: "Restored from rollout",
+          createdAt: 1001,
+        },
+      ],
+      messages: [
+        {
+          id: "assistant:1",
+          role: "assistant" as const,
+          text: "Restored from rollout",
+          createdAt: 1001,
+        },
+      ],
+      lastAssistantMessage: "Restored from rollout",
+      pagination: {
+        supportsPagination: false,
+        hasPreviousPage: false,
+      },
+      threadStatus: "idle" as const,
+    };
+    const loadSession = vi.fn(async () => ({
+      entries: [],
+      messages: [],
+      pagination: {
+        supportsPagination: false,
+        hasPreviousPage: false,
+      },
+      threadStatus: "idle" as const,
+    }));
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => agent,
+        listInstalledAgents: () => [agent],
+        upsertInstalledAgent: vi.fn(),
+      },
+      acpRolloutStore: {
+        appendUpdate: vi.fn(),
+        readUpdates: vi.fn(() => []),
+        readReplay: vi.fn(() => replay),
+      },
+      acpSessionStore: {
+        listSessions: () => [session],
+        getSession: () => session,
+        upsertSession: vi.fn(),
+      },
+      captureStores: [],
+      createAcpClient: () =>
+        ({
+          initialize: vi.fn(async () => undefined),
+          loadSession,
+          readReplay: vi.fn(() => ({
+            entries: [],
+            messages: [],
+            pagination: {
+              supportsPagination: false,
+              hasPreviousPage: false,
+            },
+            threadStatus: "idle",
+          })),
+          dispose: vi.fn(async () => undefined),
+          refreshSession: vi.fn(async () => undefined),
+        }) as never,
+      emit: vi.fn(async () => undefined),
+      handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
+    });
+
+    await expect(adapter.readReplay(backendId, "session-1")).resolves.toMatchObject({
+      lastAssistantMessage: "Restored from rollout",
+    });
+    expect(loadSession).toHaveBeenCalled();
 
     await adapter.close();
   });

--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -350,6 +350,74 @@ describe("AcpBackendAdapter", () => {
     await adapter.close();
   });
 
+  it("emits a backend update when ACP runtime capabilities are discovered", async () => {
+    const backendId = "acp:kimi" as AcpBackendId;
+    const transport = new FakeAcpAgentTransport({
+      initialize: {
+        protocolVersion: 1,
+        agentCapabilities: {
+          loadSession: true,
+        },
+        models: {
+          currentModelId: "kimi-code/kimi-for-coding,thinking",
+          availableModels: [
+            {
+              modelId: "kimi-code/kimi-for-coding,thinking",
+              name: "kimi-for-coding (thinking)",
+            },
+          ],
+        },
+      },
+    });
+    const events: AgentEvent[] = [];
+    const agent: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      backendId,
+      registryId: "kimi",
+      name: "Kimi Code CLI",
+      launchDescriptor: {
+        backendId,
+        registryId: "kimi",
+        distributionKind: "local",
+        command: "kimi",
+        args: ["acp"],
+        env: {},
+      },
+    };
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => agent,
+        listInstalledAgents: () => [agent],
+        upsertInstalledAgent: vi.fn(),
+      },
+      acpSessionStore: {
+        listSessions: () => [],
+        getSession: () => undefined,
+        upsertSession: vi.fn(),
+      },
+      captureStores: [],
+      createAcpTransport: () => transport,
+      emit: async (event) => {
+        events.push(event);
+      },
+      handleServerRequest: async () => ({ decision: "accept" }),
+    });
+
+    await adapter.getClient(backendId);
+
+    expect(events).toContainEqual({
+      backend: backendId,
+      notification: {
+        method: "backend/acpRuntimeCapabilities/updated",
+        params: {
+          backend: backendId,
+        },
+      },
+    });
+
+    await adapter.close();
+  });
+
   it("reads Kimi replay from local rollout history instead of session/load", async () => {
     const backendId = "acp:kimi" as AcpBackendId;
     const agent: AcpInstalledAgentRecord = {

--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -1,7 +1,16 @@
-import { describe, expect, it } from "vitest";
-import type { AcpBackendId } from "@pwragent/shared";
-import { describeInstalledAcpBackend } from "../app-server/acp-backend-adapter";
+import { describe, expect, it, vi } from "vitest";
+import type {
+  AcpBackendId,
+  AgentEvent,
+  AppServerPendingRequestNotification,
+} from "@pwragent/shared";
+import {
+  AcpBackendAdapter,
+  describeInstalledAcpBackend,
+  type AcpSessionMetadata,
+} from "../app-server/acp-backend-adapter";
 import type { AcpInstalledAgentRecord } from "../acp/acp-registry-types";
+import { FakeAcpAgentTransport } from "../acp/testing/fake-acp-agent";
 
 describe("describeInstalledAcpBackend", () => {
   it("does not advertise session/load when the agent reports it is unsupported", () => {
@@ -28,6 +37,124 @@ describe("describeInstalledAcpBackend", () => {
     const backend = describeInstalledAcpBackend(buildInstalledAgent());
 
     expect(backend.methods).toContain("session/load");
+  });
+});
+
+describe("AcpBackendAdapter", () => {
+  it("passes the installed agent name to ACP approval prompts", async () => {
+    const backendId = "acp:kimi" as AcpBackendId;
+    const transport = new FakeAcpAgentTransport();
+    const events: AgentEvent[] = [];
+    const sessions: AcpSessionMetadata[] = [];
+    const requests: AppServerPendingRequestNotification[] = [];
+    const agent: AcpInstalledAgentRecord = {
+      backendId,
+      registryId: "kimi",
+      name: "Kimi Code CLI",
+      version: "1.44.0",
+      distributionKind: "local",
+      distributionSource: "kimi acp",
+      installStatus: "installed",
+      authStatus: "not-required",
+      verificationStatus: "not-applicable",
+      allowlistRuleId: "local-kimi-cli",
+      installedAt: 1000,
+      updatedAt: 1000,
+      launchDescriptor: {
+        backendId,
+        registryId: "kimi",
+        distributionKind: "local",
+        command: "kimi",
+        args: ["acp"],
+        env: {},
+      },
+    };
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => agent,
+        listInstalledAgents: () => [agent],
+        upsertInstalledAgent: vi.fn(),
+      },
+      acpSessionStore: {
+        listSessions: () => sessions,
+        getSession: (_backendId, sessionId) =>
+          sessions.find((session) => session.sessionId === sessionId),
+        upsertSession: (metadata) => {
+          const index = sessions.findIndex(
+            (session) => session.sessionId === metadata.sessionId,
+          );
+          if (index >= 0) {
+            sessions[index] = metadata;
+          } else {
+            sessions.push(metadata);
+          }
+        },
+      },
+      captureStores: [],
+      createAcpTransport: () => transport,
+      emit: async (event) => {
+        events.push(event);
+      },
+      handleServerRequest: async (_requestBackend, request) => {
+        requests.push(request);
+        return { decision: "accept" };
+      },
+    });
+
+    const client = await adapter.getClient(backendId);
+    const session = await client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+    });
+    client.startPrompt({
+      sessionId: session.sessionId,
+      prompt: "Run npm view openclaw",
+      turnId: "turn-1",
+    });
+
+    await transport.emitRequest(
+      "session/request_permission",
+      {
+        sessionId: session.sessionId,
+        toolCall: {
+          toolCallId: "run_shell_command_1",
+          kind: "execute",
+          title: "npm view openclaw",
+        },
+        options: [{ optionId: "proceed_once", kind: "allow_once" }],
+      },
+      0,
+    );
+
+    expect(requests[0]?.params.prompt).toBe(
+      "Kimi Code CLI wants to run execute: npm view openclaw",
+    );
+    expect(requests[0]?.params.reason).toBe(
+      "Kimi Code CLI wants to run execute: npm view openclaw",
+    );
+
+    transport.emitSessionUpdate(session.sessionId, {
+      sessionUpdate: "agent_message_chunk",
+      content: {
+        type: "text",
+        text: "You only live once! All actions will be auto-approved.",
+      },
+    });
+    await vi.waitFor(() => {
+      expect(sessions[0]?.executionMode).toBe("full-access");
+    });
+    expect(events).toContainEqual({
+      backend: backendId,
+      notification: {
+        method: "thread/executionMode/updated",
+        params: {
+          threadId: session.sessionId,
+          executionMode: "full-access",
+        },
+      },
+    });
+
+    await adapter.close();
   });
 });
 

--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -38,6 +38,21 @@ describe("describeInstalledAcpBackend", () => {
 
     expect(backend.methods).toContain("session/load");
   });
+
+  it("does not advertise session/load for Kimi even without stored capability data", () => {
+    const backend = describeInstalledAcpBackend({
+      ...buildInstalledAgent(),
+      backendId: "acp:kimi" as AcpBackendId,
+      registryId: "kimi",
+      name: "Kimi Code CLI",
+    });
+
+    expect(backend.methods).toEqual([
+      "session/new",
+      "session/prompt",
+      "session/cancel",
+    ]);
+  });
 });
 
 describe("AcpBackendAdapter", () => {
@@ -249,6 +264,93 @@ describe("AcpBackendAdapter", () => {
     expect(
       events.filter((event) => event.notification.method === "item/completed"),
     ).toHaveLength(1);
+
+    await adapter.close();
+  });
+
+  it("reads Kimi replay from local rollout history instead of session/load", async () => {
+    const backendId = "acp:kimi" as AcpBackendId;
+    const agent: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      backendId,
+      registryId: "kimi",
+      name: "Kimi Code CLI",
+    };
+    const session: AcpSessionMetadata = {
+      backendId,
+      sessionId: "session-1",
+      title: "Kimi thread",
+      createdAt: 1000,
+      updatedAt: 1000,
+      executionMode: "default",
+      status: "idle",
+      hasConversationHistory: true,
+    };
+    const replay = {
+      entries: [
+        {
+          type: "message" as const,
+          id: "assistant:1",
+          role: "assistant" as const,
+          text: "Restored from rollout",
+          createdAt: 1001,
+        },
+      ],
+      messages: [
+        {
+          id: "assistant:1",
+          role: "assistant" as const,
+          text: "Restored from rollout",
+          createdAt: 1001,
+        },
+      ],
+      lastAssistantMessage: "Restored from rollout",
+      pagination: {
+        supportsPagination: false,
+        hasPreviousPage: false,
+      },
+      threadStatus: "idle" as const,
+    };
+    const loadSession = vi.fn();
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => agent,
+        listInstalledAgents: () => [agent],
+        upsertInstalledAgent: vi.fn(),
+      },
+      acpRolloutStore: {
+        appendUpdate: vi.fn(),
+        readUpdates: vi.fn(() => []),
+        readReplay: vi.fn(() => replay),
+      },
+      acpSessionStore: {
+        listSessions: () => [session],
+        getSession: () => session,
+        upsertSession: vi.fn(),
+      },
+      captureStores: [],
+      createAcpClient: () =>
+        ({
+          initialize: vi.fn(async () => undefined),
+          loadSession,
+          readReplay: vi.fn(() => ({
+            entries: [],
+            messages: [],
+            pagination: {
+              supportsPagination: false,
+              hasPreviousPage: false,
+            },
+            threadStatus: "idle",
+          })),
+        }) as never,
+      emit: vi.fn(async () => undefined),
+      handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
+    });
+
+    await expect(adapter.readReplay(backendId, "session-1")).resolves.toMatchObject({
+      lastAssistantMessage: "Restored from rollout",
+    });
+    expect(loadSession).not.toHaveBeenCalled();
 
     await adapter.close();
   });

--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -268,7 +268,7 @@ describe("AcpBackendAdapter", () => {
     await adapter.close();
   });
 
-  it("emits ACP thought chunks as live assistant commentary", async () => {
+  it("emits ACP thought chunks as live assistant response text", async () => {
     const backendId = "acp:kimi" as AcpBackendId;
     const transport = new FakeAcpAgentTransport();
     const events: AgentEvent[] = [];
@@ -340,9 +340,8 @@ describe("AcpBackendAdapter", () => {
           params: {
             threadId: session.sessionId,
             turnId: "turn-1",
-            itemId: "thought:turn-1",
+            itemId: "assistant:turn-1",
             delta: "I should inspect the build setup.",
-            phase: "commentary",
           },
         },
       });

--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -340,11 +340,102 @@ describe("AcpBackendAdapter", () => {
           params: {
             threadId: session.sessionId,
             turnId: "turn-1",
-            itemId: "assistant:turn-1",
+            itemId: "assistant:turn-1:0",
             delta: "I should inspect the build setup.",
           },
         },
       });
+    });
+
+    await adapter.close();
+  });
+
+  it("uses separate live assistant item ids for ACP text separated by tools", async () => {
+    const backendId = "acp:kimi" as AcpBackendId;
+    const transport = new FakeAcpAgentTransport();
+    const events: AgentEvent[] = [];
+    const sessions: AcpSessionMetadata[] = [];
+    const agent: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      backendId,
+      registryId: "kimi",
+      name: "Kimi Code CLI",
+      launchDescriptor: {
+        backendId,
+        registryId: "kimi",
+        distributionKind: "local",
+        command: "kimi",
+        args: ["acp"],
+        env: {},
+      },
+    };
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => agent,
+        listInstalledAgents: () => [agent],
+        upsertInstalledAgent: vi.fn(),
+      },
+      acpSessionStore: {
+        listSessions: () => sessions,
+        getSession: (_backendId, sessionId) =>
+          sessions.find((session) => session.sessionId === sessionId),
+        upsertSession: (metadata) => {
+          const index = sessions.findIndex(
+            (session) => session.sessionId === metadata.sessionId,
+          );
+          if (index >= 0) {
+            sessions[index] = metadata;
+          } else {
+            sessions.push(metadata);
+          }
+        },
+      },
+      captureStores: [],
+      createAcpTransport: () => transport,
+      emit: async (event) => {
+        events.push(event);
+      },
+      handleServerRequest: async () => ({ decision: "accept" }),
+    });
+
+    const client = await adapter.getClient(backendId);
+    const session = await client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+    });
+    client.startPrompt({
+      sessionId: session.sessionId,
+      prompt: "does it build?",
+      turnId: "turn-1",
+    });
+
+    transport.emitSessionUpdate(session.sessionId, {
+      session_update: "agent_thought_chunk",
+      content: { type: "text", text: "I will inspect the scripts." },
+    });
+    transport.emitSessionUpdate(session.sessionId, {
+      session_update: "tool_call",
+      tool_call_id: "tool-1",
+      title: "cat package.json",
+      status: "completed",
+    });
+    transport.emitSessionUpdate(session.sessionId, {
+      session_update: "agent_thought_chunk",
+      content: { type: "text", text: "Now I will run the build." },
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        events
+          .filter(
+            (event) => event.notification.method === "item/agentMessage/delta",
+          )
+          .map((event) =>
+            event.notification.method === "item/agentMessage/delta"
+              ? event.notification.params.itemId
+              : undefined,
+          ),
+      ).toEqual(["assistant:turn-1:0", "assistant:turn-1:1"]);
     });
 
     await adapter.close();

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -245,7 +245,8 @@ describe("AcpAgentClient", () => {
     const transport = new FakeAcpAgentTransport();
     const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
     const client = new AcpAgentClient({
-      backendId: "acp:gemini",
+      backendId: "acp:kimi",
+      agentDisplayName: "Kimi Code CLI",
       store,
       transport,
       now: () => 1000,
@@ -304,6 +305,8 @@ describe("AcpAgentClient", () => {
         threadId: "session-1",
         turnId: "turn-1",
         requestId: "0",
+        prompt: "Kimi Code CLI wants to run execute: npm view openclaw",
+        reason: "Kimi Code CLI wants to run execute: npm view openclaw",
         command: "npm view openclaw",
         acpMethod: "session/request_permission",
         acpToolCallId: "run_shell_command_1",

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -416,31 +416,33 @@ describe("AcpAgentClient", () => {
         currentModelId: "gemini-3-flash-preview",
       },
     });
-    expect(runtimeEvents).toMatchObject([
-      {
-        sessionId: "gemini-session",
-        runtimeCapabilities: {
-          status: "discovered",
-          source: "session-new",
-          modes: {
-            currentModeId: "default",
-            availableModes: [
-              { id: "default", label: "Default" },
-              { id: "yolo", label: "YOLO" },
-            ],
-          },
-          models: {
-            currentModelId: "gemini-3-flash-preview",
-            availableModels: [
-              {
-                id: "gemini-3-flash-preview",
-                label: "gemini-3-flash-preview",
-              },
-            ],
-          },
-        },
-      },
-    ]);
+    expect(runtimeEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          sessionId: "gemini-session",
+          runtimeCapabilities: expect.objectContaining({
+            status: "discovered",
+            source: "session-new",
+            modes: expect.objectContaining({
+              currentModeId: "default",
+              availableModes: expect.arrayContaining([
+                expect.objectContaining({ id: "default", label: "Default" }),
+                expect.objectContaining({ id: "yolo", label: "YOLO" }),
+              ]),
+            }),
+            models: expect.objectContaining({
+              currentModelId: "gemini-3-flash-preview",
+              availableModels: expect.arrayContaining([
+                expect.objectContaining({
+                  id: "gemini-3-flash-preview",
+                  label: "gemini-3-flash-preview",
+                }),
+              ]),
+            }),
+          }),
+        }),
+      ]),
+    );
   });
 
   it("updates ACP runtime state without rendering config notifications", async () => {

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -132,6 +132,54 @@ describe("AcpAgentClient", () => {
     expect(sessionUpdates).toEqual(["session-1"]);
   });
 
+  it("sends control prompts without recording transcript updates", async () => {
+    const promptResponse = createDeferred<unknown>();
+    const transport = new FakeAcpAgentTransport({
+      "session/prompt": promptResponse.promise,
+    });
+    const sessionUpdates: string[] = [];
+    const client = new AcpAgentClient({
+      backendId: "acp:kimi",
+      store,
+      transport,
+      now: () => 1000,
+      onSessionUpdate: ({ sessionId }) => {
+        sessionUpdates.push(sessionId);
+      },
+    });
+
+    await client.initialize();
+    const session = await client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+      title: "Kimi ACP",
+    });
+    const controlPrompt = client.sendControlPrompt({
+      sessionId: session.sessionId,
+      prompt: "/yolo",
+    });
+    transport.emitSessionUpdate(session.sessionId, {
+      sessionUpdate: "agent_message_chunk",
+      content: {
+        type: "text",
+        text: "You only live once! All actions will be auto-approved.",
+      },
+    });
+    promptResponse.resolve({ stopReason: "end_turn" });
+    await controlPrompt;
+
+    expect(transport.requests.at(-1)).toEqual({
+      method: "session/prompt",
+      params: {
+        sessionId: "session-1",
+        prompt: [{ type: "text", text: "/yolo" }],
+      },
+    });
+    expect(client.readReplay("session-1").messages).toEqual([]);
+    expect(store.getSession("acp:kimi", "session-1")?.transcriptUpdates).toBeUndefined();
+    expect(sessionUpdates).toEqual([]);
+  });
+
   it("sends pasted images as ACP image content and persists structured transcript parts", async () => {
     const transport = new FakeAcpAgentTransport();
     const imageUrl = "data:image/png;base64,aGVsbG8=";

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -817,6 +817,62 @@ describe("AcpAgentClient", () => {
     ).toBeUndefined();
   });
 
+  it("does not write local rollout history when the ACP agent advertises session replay", async () => {
+    const rolloutStore = {
+      appendUpdate: vi.fn(),
+      readUpdates: vi.fn(() => []),
+      flushAll: vi.fn(),
+    };
+    const transport = new FakeAcpAgentTransport({
+      initialize: {
+        protocolVersion: 1,
+        agentCapabilities: {
+          loadSession: true,
+        },
+        sessionCapabilities: {
+          _meta: {
+            kimi: {
+              sessionHistoryReplay: true,
+            },
+          },
+        },
+      },
+    });
+    const client = new AcpAgentClient({
+      backendId: "acp:kimi",
+      rolloutStore,
+      store,
+      transport,
+      now: () => 1000,
+    });
+
+    await client.initialize();
+    const session = await client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+    });
+    client.startPrompt({
+      sessionId: session.sessionId,
+      prompt: "hello",
+      turnId: "turn-1",
+    });
+    transport.emitSessionUpdate(session.sessionId, {
+      session_update: "agent_message_chunk",
+      content: { type: "text", text: "Kimi says hi." },
+    });
+
+    await vi.waitFor(() => {
+      expect(client.readReplay(session.sessionId).lastAssistantMessage).toBe(
+        "Kimi says hi.",
+      );
+    });
+    await vi.waitFor(() => {
+      expect(client.readReplay(session.sessionId).threadStatus).toBe("idle");
+    });
+
+    expect(rolloutStore.appendUpdate).not.toHaveBeenCalled();
+  });
+
   it("does not call session/load when the ACP agent says loading is unsupported", async () => {
     const transport = new FakeAcpAgentTransport({
       initialize: {

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AcpAgentClient } from "../acp/acp-client";
+import { AcpRolloutStore } from "../acp/acp-rollout-store";
 import { AcpSessionStore } from "../acp/acp-session-store";
 import { FakeAcpAgentTransport } from "../acp/testing/fake-acp-agent";
 import { StateDb } from "../state/state-db";
@@ -746,6 +747,72 @@ describe("AcpAgentClient", () => {
     expect(transport.requests.map((request) => request.method)).toEqual([
       "initialize",
     ]);
+  });
+
+  it("restores ACP replay from local rollout history when session/load is unsupported", async () => {
+    const rolloutStore = new AcpRolloutStore(path.join(tempDir, "rollouts"));
+    const firstTransport = new FakeAcpAgentTransport({
+      initialize: {
+        protocolVersion: 1,
+        agentCapabilities: {
+          loadSession: false,
+        },
+      },
+    });
+    const firstClient = new AcpAgentClient({
+      backendId: "acp:kimi",
+      rolloutStore,
+      store,
+      transport: firstTransport,
+      now: () => 1000,
+    });
+
+    await firstClient.initialize();
+    const session = await firstClient.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+    });
+    firstClient.startPrompt({
+      sessionId: session.sessionId,
+      prompt: "hello",
+      turnId: "turn-1",
+    });
+    firstTransport.emitSessionUpdate(session.sessionId, {
+      session_update: "agent_message_chunk",
+      content: { type: "text", text: "Kimi says hi." },
+    });
+
+    const secondTransport = new FakeAcpAgentTransport({
+      initialize: {
+        protocolVersion: 1,
+        agentCapabilities: {
+          loadSession: false,
+        },
+      },
+    });
+    const secondClient = new AcpAgentClient({
+      backendId: "acp:kimi",
+      rolloutStore,
+      store,
+      transport: secondTransport,
+      now: () => 2000,
+    });
+
+    await secondClient.initialize();
+    const replay = await secondClient.loadSession(
+      store.getSession("acp:kimi", session.sessionId)!,
+    );
+
+    expect(replay.messages.map((message) => message.text)).toEqual([
+      "hello",
+      "Kimi says hi.",
+    ]);
+    expect(secondTransport.requests.map((request) => request.method)).toEqual([
+      "initialize",
+    ]);
+    expect(
+      readRawAcpSessionPayload("acp:kimi", session.sessionId)?.transcriptUpdates,
+    ).toBeUndefined();
   });
 
   it("does not call session/load when the ACP agent says loading is unsupported", async () => {

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -37,6 +37,18 @@ function createDeferred<T>(): {
   return { promise, reject, resolve };
 }
 
+function readRawAcpSessionPayload(
+  backendId: string,
+  sessionId: string,
+): Record<string, unknown> | undefined {
+  const row = stateDb.raw
+    .prepare(
+      `SELECT payload FROM acp_sessions WHERE backend_id = ? AND session_id = ?`,
+    )
+    .get(backendId, sessionId) as { payload: string } | undefined;
+  return row ? (JSON.parse(row.payload) as Record<string, unknown>) : undefined;
+}
+
 describe("AcpAgentClient", () => {
   it("initializes, starts sessions, sends prompts, and normalizes updates", async () => {
     const transport = new FakeAcpAgentTransport();
@@ -46,7 +58,6 @@ describe("AcpAgentClient", () => {
       store,
       transport,
       now: () => 1000,
-      transcriptPersistenceFlushDelayMs: 0,
       onSessionUpdate: ({ sessionId }) => {
         sessionUpdates.push(sessionId);
       },
@@ -103,34 +114,12 @@ describe("AcpAgentClient", () => {
       title: "Test ACP",
       cwd: "/repo",
       executionMode: "default",
+      hasConversationHistory: true,
     });
     expect(client.readReplay("session-1").lastAssistantMessage).toBe("Done");
-    expect(store.getSession("acp:codex-acp", "session-1")?.transcriptUpdates)
-      .toEqual([
-        {
-          receivedAt: 1000,
-          update: {
-            kind: "pwragent_user_prompt",
-            prompt: "hello",
-            turnId: "pending:session-1:1000",
-          },
-        },
-        {
-          receivedAt: 1000,
-          update: {
-            kind: "turn_finished",
-            outputText: "",
-            turnId: "pending:session-1:1000",
-          },
-        },
-        {
-          receivedAt: 1000,
-          update: {
-            kind: "agent_message_chunk",
-            content: "Done",
-          },
-        },
-      ]);
+    expect(
+      readRawAcpSessionPayload("acp:codex-acp", "session-1")?.transcriptUpdates,
+    ).toBeUndefined();
     expect(sessionUpdates).toEqual(["session-1"]);
   });
 
@@ -180,11 +169,16 @@ describe("AcpAgentClient", () => {
       },
     });
     expect(client.readReplay("session-1").messages).toEqual([]);
-    expect(store.getSession("acp:kimi", "session-1")?.transcriptUpdates).toBeUndefined();
+    expect(store.getSession("acp:kimi", "session-1")).not.toHaveProperty(
+      "hasConversationHistory",
+    );
+    expect(
+      readRawAcpSessionPayload("acp:kimi", "session-1")?.transcriptUpdates,
+    ).toBeUndefined();
     expect(sessionUpdates).toEqual([]);
   });
 
-  it("sends pasted images as ACP image content and persists structured transcript parts", async () => {
+  it("sends pasted images as ACP image content and keeps structured parts in live replay", async () => {
     const transport = new FakeAcpAgentTransport();
     const imageUrl = "data:image/png;base64,aGVsbG8=";
     const client = new AcpAgentClient({
@@ -230,19 +224,12 @@ describe("AcpAgentClient", () => {
         ],
       }),
     ]);
-    expect(store.getSession("acp:gemini", "session-1")?.transcriptUpdates?.[0])
-      .toEqual({
-        receivedAt: 1000,
-        update: {
-          kind: "pwragent_user_prompt",
-          prompt: "What's in this image?",
-          parts: [
-            { type: "text", text: "What's in this image?" },
-            { type: "image", url: imageUrl },
-          ],
-          turnId: "turn-1",
-        },
-      });
+    expect(store.getSession("acp:gemini", "session-1")).toMatchObject({
+      hasConversationHistory: true,
+    });
+    expect(
+      readRawAcpSessionPayload("acp:gemini", "session-1")?.transcriptUpdates,
+    ).toBeUndefined();
   });
 
   it("surfaces ACP permission requests and returns the selected option", async () => {
@@ -621,112 +608,25 @@ describe("AcpAgentClient", () => {
     ]);
   });
 
-  it("hydrates persisted Gemini mode markers as runtime state without transcript noise", async () => {
-    const transport = new FakeAcpAgentTransport();
-    const client = new AcpAgentClient({
-      backendId: "acp:gemini",
-      store,
-      transport,
-      now: () => 2000,
-    });
-    store.upsertSession({
-      backendId: "acp:gemini",
-      sessionId: "session-1",
-      title: "ACP session",
-      cwd: "/repo",
-      createdAt: 1000,
-      updatedAt: 1000,
-      executionMode: "default",
-      status: "idle",
-      transcriptUpdates: [
-        {
-          receivedAt: 1000,
-          update: {
-            kind: "agent_message_chunk",
-            content: "[MODE_UPDATE] yolo",
-          },
-        },
-      ],
-    });
-
-    await client.initialize();
-    const replay = client.readReplay("session-1");
-
-    expect(replay.entries).toEqual([]);
-    expect(store.getSession("acp:gemini", "session-1")).toMatchObject({
-      acpRuntime: {
-        currentModeId: "yolo",
-      },
-    });
-  });
-
-  it("hydrates persisted ACP transcripts once without replaying session/load as new messages", async () => {
-    const transport = new FakeAcpAgentTransport();
-    const client = new AcpAgentClient({
-      backendId: "acp:gemini",
-      store,
-      transport,
-      now: () => 2000,
-    });
-    store.upsertSession({
-      backendId: "acp:gemini",
-      sessionId: "session-1",
-      title: "ACP session",
-      cwd: "/repo",
-      createdAt: 1000,
-      updatedAt: 1000,
-      executionMode: "default",
-      status: "idle",
-      transcriptUpdates: [
-        {
-          receivedAt: 1000,
-          update: {
-            kind: "pwragent_user_prompt",
-            prompt: "first",
-            turnId: "turn-1",
-          },
-        },
-        {
-          receivedAt: 1100,
-          update: {
-            kind: "agent_message_chunk",
-            content: "reply",
-          },
-        },
-      ],
-    });
-
-    await client.initialize();
-    const firstReplay = await client.loadSession(store.getSession("acp:gemini", "session-1")!);
-    const secondReplay = await client.loadSession(store.getSession("acp:gemini", "session-1")!);
-
-    expect(firstReplay.messages.map((message) => message.text)).toEqual([
-      "first",
-      "reply",
-    ]);
-    expect(secondReplay.messages.map((message) => message.text)).toEqual([
-      "first",
-      "reply",
-    ]);
-    expect(transport.requests.map((request) => request.method)).toEqual([
-      "initialize",
-    ]);
-  });
-
-  it("returns persisted session replay without blocking on agent session/load", async () => {
-    let resolveLoad: ((value: unknown) => void) | undefined;
+  it("loads ACP transcript replay from provider session/load without storing it in the DB", async () => {
     const transport = new FakeAcpAgentTransport();
     const client = new AcpAgentClient({
       backendId: "acp:gemini",
       store,
       transport: {
         request: async (method, params) => {
+          const result = await transport.request(method, params);
           if (method === "session/load") {
-            return await new Promise((resolve) => {
-              resolveLoad = resolve;
+            transport.emitSessionUpdate("session-1", {
+              sessionUpdate: "user_message_chunk",
+              content: { type: "text", text: "first" },
+            });
+            transport.emitSessionUpdate("session-1", {
+              sessionUpdate: "agent_message_chunk",
+              content: { type: "text", text: "reply" },
             });
           }
-          return await transport.request(method, params);
+          return result;
         },
         notify: (method, params) => transport.notify(method, params),
         close: () => transport.close(),
@@ -743,23 +643,55 @@ describe("AcpAgentClient", () => {
       updatedAt: 1000,
       executionMode: "default",
       status: "idle",
-      transcriptUpdates: [
-        {
-          receivedAt: 1000,
-          update: {
-            kind: "pwragent_user_prompt",
-            prompt: "what is this?",
-            turnId: "turn-1",
-          },
+      hasConversationHistory: true,
+    });
+
+    await client.initialize();
+    const firstReplay = await client.loadSession(store.getSession("acp:gemini", "session-1")!);
+    const secondReplay = await client.loadSession(store.getSession("acp:gemini", "session-1")!);
+
+    expect(firstReplay.messages.map((message) => message.text)).toEqual([
+      "first",
+      "reply",
+    ]);
+    expect(secondReplay.messages.map((message) => message.text)).toEqual([
+      "first",
+      "reply",
+    ]);
+    expect(transport.requests.map((request) => request.method)).toEqual([
+      "initialize",
+      "session/load",
+    ]);
+    expect(
+      readRawAcpSessionPayload("acp:gemini", "session-1")?.transcriptUpdates,
+    ).toBeUndefined();
+  });
+
+  it("returns empty replay when no provider session/load support is advertised", async () => {
+    const transport = new FakeAcpAgentTransport({
+      initialize: {
+        protocolVersion: 1,
+        agentCapabilities: {
+          loadSession: false,
         },
-        {
-          receivedAt: 1100,
-          update: {
-            kind: "agent_message_chunk",
-            content: "cached answer",
-          },
-        },
-      ],
+      },
+    });
+    const client = new AcpAgentClient({
+      backendId: "acp:gemini",
+      store,
+      transport,
+      now: () => 2000,
+    });
+    store.upsertSession({
+      backendId: "acp:gemini",
+      sessionId: "session-1",
+      title: "ACP session",
+      cwd: "/repo",
+      createdAt: 1000,
+      updatedAt: 1000,
+      executionMode: "default",
+      status: "idle",
+      hasConversationHistory: true,
     });
 
     await client.initialize();
@@ -767,11 +699,7 @@ describe("AcpAgentClient", () => {
       store.getSession("acp:gemini", "session-1")!,
     );
 
-    expect(replay.messages.map((message) => message.text)).toEqual([
-      "what is this?",
-      "cached answer",
-    ]);
-    expect(resolveLoad).toBeUndefined();
+    expect(replay.messages).toEqual([]);
     expect(transport.requests.map((request) => request.method)).toEqual([
       "initialize",
     ]);
@@ -842,16 +770,12 @@ describe("AcpAgentClient", () => {
       lastUserMessage: "keep going",
       threadStatus: "active",
     });
-    expect(persistedSession?.transcriptUpdates).toEqual([
-      {
-        receivedAt: 1000,
-        update: {
-          kind: "pwragent_user_prompt",
-          prompt: "keep going",
-          turnId: "pending:session-1:1000",
-        },
-      },
-    ]);
+    expect(persistedSession).toMatchObject({
+      hasConversationHistory: true,
+    });
+    expect(
+      readRawAcpSessionPayload("acp:codex-acp", "session-1")?.transcriptUpdates,
+    ).toBeUndefined();
     expect(transport.requests.map((request) => request.method)).toEqual([
       "initialize",
       "session/new",
@@ -1191,25 +1115,14 @@ describe("AcpAgentClient", () => {
     expect(errors[0]?.error).toBeInstanceOf(Error);
     expect((errors[0]?.error as Error).message).toBe(quotaError);
     expect(sessionUpdateKinds).not.toContain("turn_finished");
-    expect(store.getSession("acp:codex-acp", "session-1")?.transcriptUpdates)
-      .toEqual([
-        {
-          receivedAt: 1000,
-          update: {
-            kind: "pwragent_user_prompt",
-            prompt: "keep going",
-            turnId: "pending:session-1",
-          },
-        },
-        {
-          receivedAt: 1000,
-          update: {
-            kind: "pwragent_turn_failed",
-            turnId: "pending:session-1",
-            error: quotaError,
-          },
-        },
-      ]);
+    expect(store.getSession("acp:codex-acp", "session-1")).toMatchObject({
+      hasConversationHistory: true,
+      lastError: quotaError,
+      status: "idle",
+    });
+    expect(
+      readRawAcpSessionPayload("acp:codex-acp", "session-1")?.transcriptUpdates,
+    ).toBeUndefined();
     const expectedEntries = [
       expect.objectContaining({
         type: "message",
@@ -1237,12 +1150,10 @@ describe("AcpAgentClient", () => {
       transport,
       now: () => 1000,
     });
-    expect(reloadedClient.readReplay("session-1").entries).toEqual(
-      expectedEntries,
-    );
+    expect(reloadedClient.readReplay("session-1").entries).toEqual([]);
   });
 
-  it("refreshes stored session metadata without ingesting session/load replay", async () => {
+  it("refreshes stored session metadata without ingesting returned session/load payloads", async () => {
     const transport = new FakeAcpAgentTransport();
     const loadRequests: Array<Record<string, unknown> | undefined> = [];
     const client = new AcpAgentClient({
@@ -1302,7 +1213,7 @@ describe("AcpAgentClient", () => {
     expect(transport.closeCount).toBe(1);
   });
 
-  it("persists ACP topic updates replayed during session/load refresh", async () => {
+  it("applies ACP updates replayed during provider session/load refresh", async () => {
     let notificationListener:
       | ((method: string, params: Record<string, unknown>) => void)
       | undefined;
@@ -1330,7 +1241,7 @@ describe("AcpAgentClient", () => {
               sessionId: "session-1",
               update: {
                 kind: "agent_message_chunk",
-                content: "Suppressed replay response",
+                content: "Loaded replay response",
               },
             });
             return {};
@@ -1369,10 +1280,16 @@ describe("AcpAgentClient", () => {
     });
     await client.refreshSession(store.getSession("acp:gemini", "session-1")!);
 
-    expect(replay.lastAssistantMessage).toBeUndefined();
+    expect(replay.lastAssistantMessage).toBe("Loaded replay response");
     expect(store.getSession("acp:gemini", "session-1")?.title).toBe(
       "Loaded Project Research",
     );
+    expect(store.getSession("acp:gemini", "session-1")).toMatchObject({
+      hasConversationHistory: true,
+    });
+    expect(
+      readRawAcpSessionPayload("acp:gemini", "session-1")?.transcriptUpdates,
+    ).toBeUndefined();
     expect(titleUpdates).toEqual(["Loaded Project Research"]);
   });
 
@@ -1399,15 +1316,7 @@ describe("AcpAgentClient", () => {
       updatedAt: 950,
       executionMode: "default",
       status: "idle",
-      transcriptUpdates: [
-        {
-          receivedAt: 950,
-          update: {
-            sessionUpdate: "agent_message_chunk",
-            content: { type: "text", text: "Previous answer." },
-          },
-        },
-      ],
+      hasConversationHistory: true,
     });
     const ensurePromise = client.ensureSession(
       store.getSession("acp:gemini", "session-1")!,
@@ -1437,12 +1346,16 @@ describe("AcpAgentClient", () => {
       mcpServers: [],
       sessionId: "session-1",
     });
-    expect(updateEvents).toEqual([]);
-    expect(client.readReplay("session-1").lastAssistantMessage).toBe("Previous answer.");
+    expect(updateEvents).toEqual([
+      "agent_message_chunk",
+      "agent_message_chunk",
+    ]);
+    expect(client.readReplay("session-1").lastAssistantMessage).toBe(
+      "Replayed from load.Late replay from load.",
+    );
   });
 
-  it("batches and coalesces streaming transcript persistence", async () => {
-    vi.useFakeTimers();
+  it("does not write streaming transcript updates into ACP session metadata", async () => {
     const promptResponse = createDeferred<unknown>();
     const transport = new FakeAcpAgentTransport({
       "session/prompt": promptResponse.promise,
@@ -1453,7 +1366,6 @@ describe("AcpAgentClient", () => {
       store,
       transport,
       now: () => 1000,
-      transcriptPersistenceFlushDelayMs: 1000,
     });
 
     await client.initialize();
@@ -1479,39 +1391,13 @@ describe("AcpAgentClient", () => {
     });
 
     expect(upsertSession.mock.calls.length).toBe(upsertCountAfterPrompt);
-    expect(store.getSession("acp:kimi", session.sessionId)?.transcriptUpdates)
-      .toEqual([
-        {
-          receivedAt: 1000,
-          update: {
-            kind: "pwragent_user_prompt",
-            prompt: "hello",
-            turnId: "turn-1",
-          },
-        },
-      ]);
-
-    await vi.advanceTimersByTimeAsync(1000);
-
-    expect(upsertSession.mock.calls.length).toBe(upsertCountAfterPrompt + 1);
-    expect(store.getSession("acp:kimi", session.sessionId)?.transcriptUpdates)
-      .toEqual([
-        {
-          receivedAt: 1000,
-          update: {
-            kind: "pwragent_user_prompt",
-            prompt: "hello",
-            turnId: "turn-1",
-          },
-        },
-        {
-          receivedAt: 1000,
-          update: {
-            sessionUpdate: "agent_message_chunk",
-            content: { type: "text", text: "Hello" },
-          },
-        },
-      ]);
+    expect(store.getSession("acp:kimi", session.sessionId)).toMatchObject({
+      hasConversationHistory: true,
+    });
+    expect(
+      readRawAcpSessionPayload("acp:kimi", session.sessionId)?.transcriptUpdates,
+    ).toBeUndefined();
+    expect(client.readReplay(session.sessionId).lastAssistantMessage).toBe("Hello");
     expect(upsertCountAfterStart).toBeGreaterThan(0);
 
     promptResponse.resolve({ turnId: "turn-1" });
@@ -1519,7 +1405,7 @@ describe("AcpAgentClient", () => {
     await client.dispose();
   });
 
-  it("compacts adjacent text chunks when upserting stored sessions", () => {
+  it("strips legacy transcript updates when upserting stored sessions", () => {
     store.upsertSession({
       backendId: "acp:kimi",
       sessionId: "session-1",
@@ -1551,22 +1437,46 @@ describe("AcpAgentClient", () => {
           },
         },
       ],
+    } as Parameters<AcpSessionStore["upsertSession"]>[0] & {
+      transcriptUpdates: unknown[];
     });
 
-    expect(store.getSession("acp:kimi", "session-1")?.transcriptUpdates).toEqual([
-      {
-        receivedAt: 975,
-        update: {
-          sessionUpdate: "agent_thought_chunk",
-          content: { type: "text", text: "Thinking hard." },
+    expect(store.getSession("acp:kimi", "session-1")).not.toHaveProperty(
+      "transcriptUpdates",
+    );
+    expect(
+      readRawAcpSessionPayload("acp:kimi", "session-1")?.transcriptUpdates,
+    ).toBeUndefined();
+  });
+
+  it("derives conversation metadata while stripping legacy transcript updates", () => {
+    store.upsertSession({
+      backendId: "acp:kimi",
+      sessionId: "session-1",
+      title: "ACP session",
+      cwd: "/repo",
+      createdAt: 900,
+      updatedAt: 1000,
+      executionMode: "default",
+      status: "idle",
+      transcriptUpdates: [
+        {
+          receivedAt: 950,
+          update: {
+            kind: "pwragent_user_prompt",
+            prompt: "hello",
+          },
         },
-      },
-      {
-        receivedAt: 1000,
-        update: {
-          sessionUpdate: "turn_finished",
-        },
-      },
-    ]);
+      ],
+    } as Parameters<AcpSessionStore["upsertSession"]>[0] & {
+      transcriptUpdates: unknown[];
+    });
+
+    expect(store.getSession("acp:kimi", "session-1")).toMatchObject({
+      hasConversationHistory: true,
+    });
+    expect(
+      readRawAcpSessionPayload("acp:kimi", "session-1")?.transcriptUpdates,
+    ).toBeUndefined();
   });
 });

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -109,6 +109,7 @@ describe("AcpAgentClient", () => {
       sessionId: "session-1",
       prompt: [{ type: "text", text: "hello" }],
     });
+    expect(transport.requests[2]?.timeoutMs).toBe(60 * 60_000);
     expect(prompt).toEqual({ sessionId: "session-1", turnId: "turn-1" });
     expect(store.getSession("acp:codex-acp", "session-1")).toMatchObject({
       title: "Test ACP",
@@ -121,6 +122,47 @@ describe("AcpAgentClient", () => {
       readRawAcpSessionPayload("acp:codex-acp", "session-1")?.transcriptUpdates,
     ).toBeUndefined();
     expect(sessionUpdates).toEqual(["session-1"]);
+  });
+
+  it("records Kimi snake_case assistant chunks as active turn text", async () => {
+    const promptResponse = createDeferred<unknown>();
+    const transport = new FakeAcpAgentTransport({
+      "session/prompt": promptResponse.promise,
+    });
+    const sessionUpdates: string[] = [];
+    const client = new AcpAgentClient({
+      backendId: "acp:kimi",
+      store,
+      transport,
+      now: () => 1000,
+      onSessionUpdate: ({ update }) => {
+        sessionUpdates.push(String(update.session_update ?? update.kind));
+      },
+    });
+
+    await client.initialize();
+    const session = await client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+    });
+    client.startPrompt({
+      sessionId: session.sessionId,
+      prompt: "hello",
+      turnId: "turn-1",
+    });
+    transport.emitSessionUpdate(session.sessionId, {
+      session_update: "agent_message_chunk",
+      content: { type: "text", text: "Kimi says hi." },
+    });
+    promptResponse.resolve({});
+    await vi.waitFor(() => {
+      expect(client.readReplay(session.sessionId).lastAssistantMessage).toBe(
+        "Kimi says hi.",
+      );
+    });
+
+    expect(sessionUpdates).toContain("agent_message_chunk");
+    expect(transport.requests[2]?.timeoutMs).toBe(60 * 60_000);
   });
 
   it("sends control prompts without recording transcript updates", async () => {
@@ -167,6 +209,7 @@ describe("AcpAgentClient", () => {
         sessionId: "session-1",
         prompt: [{ type: "text", text: "/yolo" }],
       },
+      timeoutMs: 60 * 60_000,
     });
     expect(client.readReplay("session-1").messages).toEqual([]);
     expect(store.getSession("acp:kimi", "session-1")).not.toHaveProperty(

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -166,7 +166,9 @@ describe("AcpAgentClient", () => {
       },
     });
     promptResponse.resolve({ stopReason: "end_turn" });
-    await controlPrompt;
+    await expect(controlPrompt).resolves.toEqual({
+      text: "You only live once! All actions will be auto-approved.",
+    });
 
     expect(transport.requests.at(-1)).toEqual({
       method: "session/prompt",

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -18,6 +18,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   stateDb.close();
   rmSync(tempDir, { recursive: true, force: true });
 });
@@ -45,6 +46,7 @@ describe("AcpAgentClient", () => {
       store,
       transport,
       now: () => 1000,
+      transcriptPersistenceFlushDelayMs: 0,
       onSessionUpdate: ({ sessionId }) => {
         sessionUpdates.push(sessionId);
       },
@@ -1437,5 +1439,134 @@ describe("AcpAgentClient", () => {
     });
     expect(updateEvents).toEqual([]);
     expect(client.readReplay("session-1").lastAssistantMessage).toBe("Previous answer.");
+  });
+
+  it("batches and coalesces streaming transcript persistence", async () => {
+    vi.useFakeTimers();
+    const promptResponse = createDeferred<unknown>();
+    const transport = new FakeAcpAgentTransport({
+      "session/prompt": promptResponse.promise,
+    });
+    const upsertSession = vi.spyOn(store, "upsertSession");
+    const client = new AcpAgentClient({
+      backendId: "acp:kimi",
+      store,
+      transport,
+      now: () => 1000,
+      transcriptPersistenceFlushDelayMs: 1000,
+    });
+
+    await client.initialize();
+    const session = await client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+    });
+    const upsertCountAfterStart = upsertSession.mock.calls.length;
+    client.startPrompt({
+      sessionId: session.sessionId,
+      prompt: "hello",
+      turnId: "turn-1",
+    });
+    const upsertCountAfterPrompt = upsertSession.mock.calls.length;
+
+    transport.emitSessionUpdate(session.sessionId, {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "Hel" },
+    });
+    transport.emitSessionUpdate(session.sessionId, {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "lo" },
+    });
+
+    expect(upsertSession.mock.calls.length).toBe(upsertCountAfterPrompt);
+    expect(store.getSession("acp:kimi", session.sessionId)?.transcriptUpdates)
+      .toEqual([
+        {
+          receivedAt: 1000,
+          update: {
+            kind: "pwragent_user_prompt",
+            prompt: "hello",
+            turnId: "turn-1",
+          },
+        },
+      ]);
+
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(upsertSession.mock.calls.length).toBe(upsertCountAfterPrompt + 1);
+    expect(store.getSession("acp:kimi", session.sessionId)?.transcriptUpdates)
+      .toEqual([
+        {
+          receivedAt: 1000,
+          update: {
+            kind: "pwragent_user_prompt",
+            prompt: "hello",
+            turnId: "turn-1",
+          },
+        },
+        {
+          receivedAt: 1000,
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text: "Hello" },
+          },
+        },
+      ]);
+    expect(upsertCountAfterStart).toBeGreaterThan(0);
+
+    promptResponse.resolve({ turnId: "turn-1" });
+    await Promise.resolve();
+    await client.dispose();
+  });
+
+  it("compacts adjacent text chunks when upserting stored sessions", () => {
+    store.upsertSession({
+      backendId: "acp:kimi",
+      sessionId: "session-1",
+      title: "ACP session",
+      cwd: "/repo",
+      createdAt: 900,
+      updatedAt: 1000,
+      executionMode: "default",
+      status: "idle",
+      transcriptUpdates: [
+        {
+          receivedAt: 950,
+          update: {
+            sessionUpdate: "agent_thought_chunk",
+            content: { type: "text", text: "Thinking " },
+          },
+        },
+        {
+          receivedAt: 975,
+          update: {
+            sessionUpdate: "agent_thought_chunk",
+            content: { type: "text", text: "hard." },
+          },
+        },
+        {
+          receivedAt: 1000,
+          update: {
+            sessionUpdate: "turn_finished",
+          },
+        },
+      ],
+    });
+
+    expect(store.getSession("acp:kimi", "session-1")?.transcriptUpdates).toEqual([
+      {
+        receivedAt: 975,
+        update: {
+          sessionUpdate: "agent_thought_chunk",
+          content: { type: "text", text: "Thinking hard." },
+        },
+      },
+      {
+        receivedAt: 1000,
+        update: {
+          sessionUpdate: "turn_finished",
+        },
+      },
+    ]);
   });
 });

--- a/apps/desktop/src/main/__tests__/acp-live-notifications.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-live-notifications.test.ts
@@ -86,6 +86,33 @@ describe("acpToolUpdateNotifications", () => {
     ]);
   });
 
+  it("maps Kimi snake_case ACP tool updates to stable live item ids", () => {
+    const notifications = acpToolUpdateNotifications({
+      threadId: "session-1",
+      turnId: "turn-1",
+      update: {
+        session_update: "tool_call_update",
+        tool_call_id: "turn-1:tool-7",
+        title: "pnpm build",
+        status: "in_progress",
+      },
+    });
+
+    expect(notifications).toEqual([
+      expect.objectContaining({
+        method: "item/started",
+        params: expect.objectContaining({
+          item: expect.objectContaining({
+            id: "turn-1:tool-7",
+            command: "pnpm build",
+            toolName: "tool",
+            status: "in_progress",
+          }),
+        }),
+      }),
+    ]);
+  });
+
   it("does not render ACP topic updates as live tool activity", () => {
     expect(
       acpToolUpdateNotifications({

--- a/apps/desktop/src/main/__tests__/acp-local-discovery.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-local-discovery.test.ts
@@ -43,6 +43,53 @@ describe("discoverLocalAcpAgents", () => {
     ]);
   });
 
+  it("discovers Kimi Code CLI when the local command supports ACP", async () => {
+    const probe = vi.fn<LocalAcpAgentProbe>(async (command, args) => {
+      if (command !== "kimi") {
+        throw Object.assign(new Error("missing"), { code: "ENOENT" });
+      }
+      if (args[0] === "--version") {
+        return { stdout: "kimi, version 1.44.0\n" };
+      }
+      if (args[0] === "acp" && args[1] === "--help") {
+        return { stdout: "Usage: kimi acp [OPTIONS]\nRun Kimi Code CLI ACP server.\n" };
+      }
+      throw new Error("unexpected probe");
+    });
+
+    await expect(
+      discoverLocalAcpAgents({ probe, now: () => 5678 }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        backendId: "acp:kimi",
+        registryId: "kimi",
+        name: "Kimi Code CLI",
+        version: "1.44.0",
+        distributionKind: "local",
+        distributionSource: "kimi acp",
+        installStatus: "installed",
+        authStatus: "not-required",
+        verificationStatus: "not-applicable",
+        allowlistRuleId: "local-kimi-cli",
+        installedAt: 5678,
+        updatedAt: 5678,
+        launchDescriptor: {
+          backendId: "acp:kimi",
+          registryId: "kimi",
+          distributionKind: "local",
+          command: "kimi",
+          args: ["acp"],
+          env: {},
+        },
+        registryAgent: expect.objectContaining({
+          id: "kimi",
+          authors: ["Moonshot AI"],
+          auth: { required: false, methods: ["agent-managed"] },
+        }),
+      }),
+    ]);
+  });
+
   it("ignores missing local commands", async () => {
     const probe = vi.fn<LocalAcpAgentProbe>(async () => {
       throw Object.assign(new Error("missing"), { code: "ENOENT" });
@@ -57,6 +104,20 @@ describe("discoverLocalAcpAgents", () => {
         return { stdout: "0.41.0\n" };
       }
       return { stdout: "Usage: gemini [options]\n" };
+    });
+
+    await expect(discoverLocalAcpAgents({ probe })).resolves.toEqual([]);
+  });
+
+  it("ignores Kimi CLI versions that do not advertise ACP mode", async () => {
+    const probe = vi.fn<LocalAcpAgentProbe>(async (command, args) => {
+      if (command !== "kimi") {
+        throw Object.assign(new Error("missing"), { code: "ENOENT" });
+      }
+      if (args[0] === "--version") {
+        return { stdout: "kimi, version 1.40.0\n" };
+      }
+      return { stdout: "Usage: kimi [OPTIONS] COMMAND [ARGS]...\n" };
     });
 
     await expect(discoverLocalAcpAgents({ probe })).resolves.toEqual([]);

--- a/apps/desktop/src/main/__tests__/acp-rollout-store.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-rollout-store.test.ts
@@ -68,4 +68,51 @@ describe("AcpRolloutStore", () => {
 
     expect(store.readUpdates({ backendId, sessionId: "session-1" })).toHaveLength(1);
   });
+
+  it("coalesces adjacent streaming text chunks before writing rollout records", () => {
+    const store = new AcpRolloutStore(tempDir);
+    const backendId = "acp:kimi" as AcpBackendId;
+
+    store.appendUpdate({
+      backendId,
+      sessionId: "session-1",
+      receivedAt: 1000,
+      update: {
+        kind: "pwragent_user_prompt",
+        prompt: "hello",
+        turnId: "turn-1",
+      },
+    });
+    for (const text of ["Kim", "i says", " hi"]) {
+      store.appendUpdate({
+        backendId,
+        sessionId: "session-1",
+        receivedAt: 1001,
+        update: {
+          session_update: "agent_message_chunk",
+          content: { type: "text", text },
+        },
+      });
+    }
+    store.appendUpdate({
+      backendId,
+      sessionId: "session-1",
+      receivedAt: 1002,
+      update: {
+        kind: "turn_finished",
+        turnId: "turn-1",
+      },
+    });
+
+    const records = store.readUpdates({ backendId, sessionId: "session-1" });
+
+    expect(records.map((record) => record.update)).toEqual([
+      expect.objectContaining({ kind: "pwragent_user_prompt" }),
+      expect.objectContaining({
+        session_update: "agent_message_chunk",
+        content: { type: "text", text: "Kimi says hi" },
+      }),
+      expect.objectContaining({ kind: "turn_finished" }),
+    ]);
+  });
 });

--- a/apps/desktop/src/main/__tests__/acp-rollout-store.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-rollout-store.test.ts
@@ -1,0 +1,71 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AcpRolloutStore } from "../acp/acp-rollout-store";
+import type { AcpBackendId } from "@pwragent/shared";
+
+describe("AcpRolloutStore", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pwragent-acp-rollout-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("restores Kimi ACP transcript history from append-only JSONL", () => {
+    const store = new AcpRolloutStore(tempDir);
+    const backendId = "acp:kimi" as AcpBackendId;
+
+    store.appendUpdate({
+      backendId,
+      sessionId: "session-1",
+      receivedAt: 1000,
+      update: {
+        kind: "pwragent_user_prompt",
+        prompt: "hello",
+        turnId: "turn-1",
+      },
+    });
+    store.appendUpdate({
+      backendId,
+      sessionId: "session-1",
+      receivedAt: 1001,
+      update: {
+        session_update: "agent_message_chunk",
+        content: { type: "text", text: "Hi" },
+      },
+    });
+
+    const replay = store.readReplay({ backendId, sessionId: "session-1" });
+
+    expect(replay.messages).toEqual([
+      expect.objectContaining({ role: "user", text: "hello" }),
+      expect.objectContaining({ role: "assistant", text: "Hi" }),
+    ]);
+  });
+
+  it("coalesces unchanged tool updates before writing rollout records", () => {
+    const store = new AcpRolloutStore(tempDir);
+    const backendId = "acp:kimi" as AcpBackendId;
+
+    for (let index = 0; index < 5; index += 1) {
+      store.appendUpdate({
+        backendId,
+        sessionId: "session-1",
+        receivedAt: 1000 + index,
+        update: {
+          session_update: "tool_call_update",
+          tool_call_id: "turn-1:tool-1",
+          title: "pnpm build",
+          status: "in_progress",
+        },
+      });
+    }
+
+    expect(store.readUpdates({ backendId, sessionId: "session-1" })).toHaveLength(1);
+  });
+});

--- a/apps/desktop/src/main/__tests__/acp-runtime-capabilities.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-runtime-capabilities.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  acpRuntimeSupportsSessionHistoryReplay,
+  normalizeAcpRuntimeCapabilities,
+} from "../acp/acp-runtime-capabilities";
+
+describe("ACP runtime capabilities", () => {
+  it("reads Kimi session history replay metadata from ACP session capabilities", () => {
+    const capabilities = normalizeAcpRuntimeCapabilities({
+      now: 1000,
+      source: "initialize",
+      value: {
+        protocolVersion: 1,
+        agentCapabilities: {
+          loadSession: true,
+        },
+        sessionCapabilities: {
+          _meta: {
+            kimi: {
+              sessionHistoryReplay: true,
+            },
+          },
+        },
+      },
+    });
+
+    expect(capabilities?.agentCapabilities).toMatchObject({
+      loadSession: true,
+      sessionHistoryReplay: true,
+    });
+    expect(acpRuntimeSupportsSessionHistoryReplay(capabilities)).toBe(true);
+  });
+
+  it("does not infer session history replay from load_session alone", () => {
+    const capabilities = normalizeAcpRuntimeCapabilities({
+      now: 1000,
+      source: "initialize",
+      value: {
+        protocol_version: 1,
+        agent_capabilities: {
+          load_session: true,
+        },
+        session_capabilities: {
+          _meta: {
+            kimi: {},
+          },
+        },
+      },
+    });
+
+    expect(capabilities?.agentCapabilities?.loadSession).toBe(true);
+    expect(acpRuntimeSupportsSessionHistoryReplay(capabilities)).toBe(false);
+  });
+});

--- a/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
@@ -40,6 +40,24 @@ describe("AcpSessionReplayNormalizer", () => {
     expect(replay.lastAssistantMessage).toBe("OK.");
   });
 
+  it("reads Kimi snake_case assistant chunks", () => {
+    const normalizer = new AcpSessionReplayNormalizer();
+
+    const replay = normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1000,
+      update: {
+        session_update: "agent_message_chunk",
+        content: { type: "text", text: "Kimi text." },
+      },
+    });
+
+    expect(replay.messages).toEqual([
+      expect.objectContaining({ role: "assistant", text: "Kimi text." }),
+    ]);
+    expect(replay.lastAssistantMessage).toBe("Kimi text.");
+  });
+
   it("renders ACP user message chunks as transcript messages", () => {
     const normalizer = new AcpSessionReplayNormalizer();
 
@@ -381,6 +399,41 @@ describe("AcpSessionReplayNormalizer", () => {
             path: "/repo/README.md",
           }),
         ],
+      }),
+    ]);
+  });
+
+  it("merges Kimi snake_case tool call updates into the original activity", () => {
+    const normalizer = new AcpSessionReplayNormalizer();
+
+    normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1000,
+      update: {
+        session_update: "tool_call",
+        tool_call_id: "turn-1:tool-1",
+        title: "pnpm build",
+        status: "in_progress",
+      },
+    });
+    const replay = normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1001,
+      update: {
+        session_update: "tool_call_update",
+        tool_call_id: "turn-1:tool-1",
+        title: "pnpm build",
+        status: "completed",
+        content: { type: "text", text: "Build succeeded" },
+      },
+    });
+
+    expect(replay.entries).toEqual([
+      expect.objectContaining({
+        type: "activity",
+        id: "turn-1:tool-1",
+        summary: "pnpm build",
+        status: "completed",
       }),
     ]);
   });

--- a/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
@@ -585,7 +585,7 @@ describe("AcpSessionReplayNormalizer", () => {
     expect(replay.entries).toEqual([]);
   });
 
-  it("records thought chunks as assistant commentary", () => {
+  it("records thought chunks as assistant response messages", () => {
     const normalizer = new AcpSessionReplayNormalizer();
 
     const replay = normalizer.apply({
@@ -600,12 +600,12 @@ describe("AcpSessionReplayNormalizer", () => {
     expect(replay.entries).toEqual([
       expect.objectContaining({
         type: "message",
-        id: "thought:session-1",
+        id: "assistant:session-1",
         role: "assistant",
-        phase: "commentary",
         text: "Inspecting project files.",
       }),
     ]);
+    expect(replay.lastAssistantMessage).toBe("Inspecting project files.");
   });
 
   it("preserves unknown update variants as structured activity", () => {

--- a/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
@@ -325,9 +325,9 @@ describe("AcpSessionReplayNormalizer", () => {
 
     expect(replay.messages.map((message) => [message.id, message.text])).toEqual([
       ["user:pending:session-1:1000", "What is this project?"],
-      ["assistant:pending:session-1:1000", "It is PwrSnap."],
+      ["assistant:pending:session-1:1000:0", "It is PwrSnap."],
       ["user:pending:session-1:2000", "What is the CWD?"],
-      ["assistant:pending:session-1:2000", "/repo/project"],
+      ["assistant:pending:session-1:2000:0", "/repo/project"],
     ]);
     expect(replay.lastUserMessage).toBe("What is the CWD?");
     expect(replay.lastAssistantMessage).toBe("/repo/project");
@@ -600,7 +600,7 @@ describe("AcpSessionReplayNormalizer", () => {
     expect(replay.entries).toEqual([
       expect.objectContaining({
         type: "message",
-        id: "assistant:session-1",
+        id: "assistant:session-1:0",
         role: "assistant",
         text: "Inspecting project files.",
       }),
@@ -657,6 +657,57 @@ describe("AcpSessionReplayNormalizer", () => {
           }),
         ],
       }),
+    ]);
+  });
+
+  it("splits assistant response messages around tool activity", () => {
+    const normalizer = new AcpSessionReplayNormalizer();
+
+    normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1000,
+      update: {
+        kind: "pwragent_user_prompt",
+        prompt: "does it build?",
+        turnId: "turn-1",
+      },
+    });
+    normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1001,
+      update: {
+        sessionUpdate: "agent_thought_chunk",
+        content: { type: "text", text: "I will inspect package scripts." },
+      },
+    });
+    normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1002,
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "tool-1",
+        title: "cat package.json",
+        status: "completed",
+      },
+    });
+    const replay = normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1003,
+      update: {
+        sessionUpdate: "agent_thought_chunk",
+        content: { type: "text", text: "The build script is available." },
+      },
+    });
+
+    expect(
+      replay.entries.map((entry) =>
+        entry.type === "message" ? `${entry.id}:${entry.text}` : entry.type
+      ),
+    ).toEqual([
+      "user:turn-1:does it build?",
+      "assistant:turn-1:0:I will inspect package scripts.",
+      "activity",
+      "assistant:turn-1:1:The build script is available.",
     ]);
   });
 });

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -353,7 +353,7 @@ describe("app server ipc", () => {
       backend: "all",
       fetchedAt: expect.any(Number),
       messagingBindingsByThreadKey: undefined,
-      queuedExecutionModesByThreadId: {},
+      queuedExecutionModesByThreadKey: {},
       threads: [
         expect.objectContaining({ source: "codex", id: "thread-1" }),
         expect.objectContaining({ source: "grok", id: "thread-1" }),

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1436,7 +1436,7 @@ describe("DesktopBackendRegistry", () => {
         expect.objectContaining({
           kind: "acp:gemini",
           source: "acp",
-          label: "Gemini CLI",
+          label: "Gemini",
           available: true,
           acp: expect.objectContaining({
             registryId: "gemini",
@@ -1529,7 +1529,7 @@ describe("DesktopBackendRegistry", () => {
         expect.objectContaining({
           kind: "acp:gemini",
           source: "acp",
-          label: "Gemini CLI",
+          label: "Gemini",
           available: true,
           acp: expect.objectContaining({
             registryId: "gemini",

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2497,7 +2497,7 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
-  it("materializes Kimi worktree launchpads without running Codex environment setup", async () => {
+  it("materializes Kimi worktree launchpads with local environment setup", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-kimi-launchpad-"));
     const worktreePath = path.join(root, ".worktrees", "thread-1", "app");
     await mkdir(path.join(root, ".codex", "environments"), { recursive: true });
@@ -2561,9 +2561,24 @@ script = "echo setup"
           worktreePath,
         },
       });
-      expect(response.codexEnvironmentRuntime).toBeUndefined();
+      expect(response.codexEnvironmentRuntime).toMatchObject({
+        environmentId: "environment",
+        environmentName: "Repo Environment",
+        executionTarget: "local",
+        cwd: worktreePath,
+        setupEnabled: true,
+        setupStatus: "completed",
+        setupCommand: "echo setup",
+        setupOutput: "setup",
+      });
       expect(response.codexEnvironmentStartupFailure).toBeUndefined();
-      expect(commandRunner).not.toHaveBeenCalled();
+      expect(commandRunner).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cwd: worktreePath,
+          command: "echo setup",
+          mode: "wait",
+        }),
+      );
       expect(recordCodexWorktreeOwnerThread).not.toHaveBeenCalled();
       expect(sendControlPrompt).toHaveBeenCalledWith({
         sessionId: "kimi-session-1",

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 import { describe, expect, it, vi } from "vitest";
+import { buildThreadIdentityKey } from "@pwragent/shared";
 import type {
   AcpBackendId,
   AgentEvent,
@@ -1024,6 +1025,128 @@ function createAcpSessionStoreMock(records: AcpSessionMetadata[]) {
         records[index] = metadata;
       }
     },
+  };
+}
+
+function createKimiAgentRecord(
+  backendId: AcpBackendId = "acp:kimi" as AcpBackendId,
+): AcpInstalledAgentRecord {
+  return {
+    backendId,
+    registryId: "kimi",
+    name: "Kimi Code CLI",
+    version: "1.44.0",
+    distributionKind: "local",
+    distributionSource: "kimi acp",
+    installStatus: "installed",
+    authStatus: "not-required",
+    verificationStatus: "not-applicable",
+    allowlistRuleId: "local-kimi-cli",
+    installedAt: 1000,
+    updatedAt: 2000,
+    launchDescriptor: {
+      backendId,
+      registryId: "kimi",
+      distributionKind: "local",
+      command: "kimi",
+      args: ["acp"],
+      env: {},
+    },
+  };
+}
+
+type KimiSendControlPrompt = (params: {
+  sessionId: string;
+  prompt: string;
+}) => Promise<{ text: string }>;
+
+type KimiStartPrompt = (params: {
+  sessionId: string;
+  prompt: string;
+  promptContent?: unknown[];
+  parts?: unknown[];
+  turnId?: string;
+}) => { sessionId: string; turnId: string };
+
+function createKimiAcpRegistry(options?: {
+  acpBackendId?: AcpBackendId;
+  sessionId?: string;
+  sessions?: AcpSessionMetadata[];
+  sendControlPrompt?: KimiSendControlPrompt;
+  startPrompt?: KimiStartPrompt;
+  overlayStore?: ReturnType<typeof createOverlayStoreMock>;
+  codexClient?: MockBackendClient;
+}) {
+  const acpBackendId = options?.acpBackendId ?? ("acp:kimi" as AcpBackendId);
+  const sessions = options?.sessions ?? [];
+  const sessionId = options?.sessionId ?? "kimi-session-1";
+  const sendControlPrompt: KimiSendControlPrompt =
+    options?.sendControlPrompt ??
+    vi.fn(async () => ({
+      text: "You only live once! All actions will be auto-approved.",
+    }));
+  const startPrompt: KimiStartPrompt =
+    options?.startPrompt ??
+    vi.fn(() => ({ sessionId, turnId: "turn-1" }));
+  const acpClient = {
+    initialize: vi.fn(async () => undefined),
+    dispose: vi.fn(),
+    startSession: vi.fn(async (params: {
+      cwd?: string;
+      executionMode: "default" | "full-access";
+    }) => {
+      const metadata: AcpSessionMetadata = {
+        backendId: acpBackendId,
+        sessionId,
+        title: "ACP session",
+        cwd: params.cwd,
+        createdAt: 1000,
+        updatedAt: 1000,
+        executionMode: params.executionMode,
+        status: "idle",
+      };
+      sessions.push(metadata);
+      return metadata;
+    }),
+    startPrompt,
+    sendControlPrompt,
+    ensureSession: vi.fn(async () => undefined),
+    loadSession: vi.fn(async (): Promise<AppServerThreadReplay> => ({
+      entries: [],
+      messages: [],
+      pagination: {
+        supportsPagination: false,
+        hasPreviousPage: false,
+      },
+      threadStatus: "idle",
+    })),
+    refreshSession: vi.fn(async () => undefined),
+    cancelSession: vi.fn(),
+    readReplay: vi.fn((): AppServerThreadReplay => ({
+      entries: [],
+      messages: [],
+      pagination: {
+        supportsPagination: false,
+        hasPreviousPage: false,
+      },
+      threadStatus: "idle",
+    })),
+  };
+  const registry = new DesktopBackendRegistry({
+    codexClient: options?.codexClient ?? new MockBackendClient({ threads: [] }),
+    grokClient: new MockBackendClient({ threads: [] }),
+    overlayStore: options?.overlayStore ?? createOverlayStoreMock(),
+    acpAgentStore: createAcpAgentStoreMock([createKimiAgentRecord(acpBackendId)]),
+    acpSessionStore: createAcpSessionStoreMock(sessions),
+    createAcpClient: () => acpClient,
+  });
+  return {
+    acpBackendId,
+    acpClient,
+    registry,
+    sendControlPrompt,
+    sessions,
+    startPrompt,
   };
 }
 
@@ -2167,7 +2290,14 @@ describe("DesktopBackendRegistry", () => {
   it("runs Kimi ACP execution mode changes through slash control prompts", async () => {
     const sessions: AcpSessionMetadata[] = [];
     const acpBackendId = "acp:kimi" as AcpBackendId;
-    const sendControlPrompt = vi.fn(async () => undefined);
+    const sendControlPrompt = vi
+      .fn()
+      .mockResolvedValueOnce({
+        text: "You only live once! All actions will be auto-approved.",
+      })
+      .mockResolvedValueOnce({
+        text: "You only die once! Actions will require approval.",
+      });
     const acpClient = {
       initialize: vi.fn(async () => undefined),
       dispose: vi.fn(),
@@ -2287,6 +2417,246 @@ describe("DesktopBackendRegistry", () => {
       prompt: "/yolo",
     });
     expect(sessions[0]?.executionMode).toBe("default");
+
+    await registry.close();
+  });
+
+  it("does not persist Kimi execution mode when /yolo confirms the wrong state", async () => {
+    const { acpBackendId, registry, sendControlPrompt, sessions } =
+      createKimiAcpRegistry({
+        sessions: [
+          {
+            backendId: "acp:kimi" as AcpBackendId,
+            sessionId: "kimi-session-1",
+            title: "ACP session",
+            createdAt: 1000,
+            updatedAt: 1000,
+            executionMode: "default",
+            status: "idle",
+          },
+        ],
+        sendControlPrompt: vi.fn(async () => ({
+          text: "You only die once! Actions will require approval.",
+        })),
+      });
+
+    await expect(
+      registry.setThreadExecutionMode({
+        backend: acpBackendId,
+        threadId: "kimi-session-1",
+        executionMode: "full-access",
+      }),
+    ).rejects.toThrow(/did not confirm Full Access/);
+
+    expect(sendControlPrompt).toHaveBeenCalledWith({
+      sessionId: "kimi-session-1",
+      prompt: "/yolo",
+    });
+    expect(sessions[0]?.executionMode).toBe("default");
+
+    await registry.close();
+  });
+
+  it("keeps new Kimi sessions at default when startup /yolo fails", async () => {
+    const { acpBackendId, registry, sessions } = createKimiAcpRegistry({
+      sendControlPrompt: vi.fn(async () => {
+        throw new Error("control prompt failed");
+      }),
+    });
+
+    await expect(
+      registry.startThread({
+        backend: acpBackendId,
+        cwd: "/repo/project",
+        executionMode: "full-access",
+      }),
+    ).rejects.toThrow("control prompt failed");
+
+    expect(sessions[0]?.executionMode).toBe("default");
+
+    await registry.close();
+  });
+
+  it("queues Kimi ACP execution mode changes during active turns and flushes once", async () => {
+    const events: AgentEvent[] = [];
+    const { acpBackendId, registry, sendControlPrompt, sessions } =
+      createKimiAcpRegistry({
+        sessions: [
+          {
+            backendId: "acp:kimi" as AcpBackendId,
+            sessionId: "kimi-session-1",
+            title: "ACP session",
+            createdAt: 1000,
+            updatedAt: 1000,
+            executionMode: "default",
+            status: "idle",
+          },
+        ],
+        sendControlPrompt: vi.fn(async () => ({
+          text: "You only live once! All actions will be auto-approved.",
+        })),
+      });
+    registry.onEvent((event) => {
+      events.push(event);
+    });
+
+    await registry.startTurn({
+      backend: acpBackendId,
+      threadId: "kimi-session-1",
+      input: [{ type: "text", text: "work" }],
+    });
+
+    await expect(
+      registry.setThreadExecutionMode({
+        backend: acpBackendId,
+        threadId: "kimi-session-1",
+        executionMode: "full-access",
+      }),
+    ).resolves.toEqual({
+      backend: acpBackendId,
+      threadId: "kimi-session-1",
+      executionMode: "full-access",
+    });
+    expect(sendControlPrompt).not.toHaveBeenCalled();
+
+    await (registry as unknown as { emit(event: AgentEvent): Promise<void> }).emit({
+      backend: acpBackendId,
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "kimi-session-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            output: [],
+          },
+        },
+      },
+    });
+    await vi.waitFor(() => {
+      expect(sendControlPrompt).toHaveBeenCalledTimes(1);
+    });
+
+    expect(sessions[0]?.executionMode).toBe("full-access");
+    const methods = events.map((event) => event.notification.method);
+    expect(methods).toContain("thread/executionMode/queued");
+    expect(methods).toContain("thread/executionMode/updated");
+    expect(methods).toContain("thread/executionMode/queueCleared");
+
+    await registry.close();
+  });
+
+  it("serializes Kimi control prompts before starting the next ACP turn", async () => {
+    const controlPrompt = createDeferred<{ text: string }>();
+    const startPrompt = vi.fn(() => ({
+      sessionId: "kimi-session-1",
+      turnId: "turn-1",
+    }));
+    const sendControlPrompt = vi.fn(() => controlPrompt.promise);
+    const { acpBackendId, registry } = createKimiAcpRegistry({
+      sessions: [
+        {
+          backendId: "acp:kimi" as AcpBackendId,
+          sessionId: "kimi-session-1",
+          title: "ACP session",
+          createdAt: 1000,
+          updatedAt: 1000,
+          executionMode: "default",
+          status: "idle",
+        },
+      ],
+      sendControlPrompt,
+      startPrompt,
+    });
+
+    const modeChange = registry.setThreadExecutionMode({
+      backend: acpBackendId,
+      threadId: "kimi-session-1",
+      executionMode: "full-access",
+    });
+    await vi.waitFor(() => {
+      expect(sendControlPrompt).toHaveBeenCalledTimes(1);
+    });
+    const turnStart = registry.startTurn({
+      backend: acpBackendId,
+      threadId: "kimi-session-1",
+      input: [{ type: "text", text: "after mode change" }],
+    });
+    await flushAsync();
+    expect(startPrompt).not.toHaveBeenCalled();
+
+    controlPrompt.resolve({
+      text: "You only live once! All actions will be auto-approved.",
+    });
+    await expect(modeChange).resolves.toMatchObject({
+      backend: acpBackendId,
+      executionMode: "full-access",
+    });
+    await expect(turnStart).resolves.toMatchObject({
+      backend: acpBackendId,
+      threadId: "kimi-session-1",
+      turnId: "turn-1",
+    });
+    expect(startPrompt).toHaveBeenCalledTimes(1);
+
+    await registry.close();
+  });
+
+  it("isolates queued execution modes by backend when thread ids collide", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/resume"] },
+    });
+    const { acpBackendId, registry } = createKimiAcpRegistry({
+      codexClient,
+      sessions: [
+        {
+          backendId: "acp:kimi" as AcpBackendId,
+          sessionId: "same-thread",
+          title: "ACP session",
+          createdAt: 1000,
+          updatedAt: 1000,
+          executionMode: "default",
+          status: "idle",
+        },
+      ],
+    });
+
+    await registry.queueThreadExecutionMode({
+      backend: "codex",
+      threadId: "same-thread",
+      executionMode: "full-access",
+    });
+    await registry.queueThreadExecutionMode({
+      backend: acpBackendId,
+      threadId: "same-thread",
+      executionMode: "full-access",
+    });
+
+    expect(registry.getQueuedExecutionModesSnapshot()).toMatchObject({
+      [buildThreadIdentityKey("codex", "same-thread")]: {
+        mode: "full-access",
+      },
+      [buildThreadIdentityKey(acpBackendId, "same-thread")]: {
+        mode: "full-access",
+      },
+    });
+
+    await registry.cancelThreadExecutionModeQueue({
+      backend: "codex",
+      threadId: "same-thread",
+    });
+
+    expect(registry.getQueuedExecutionModesSnapshot()).toMatchObject({
+      [buildThreadIdentityKey(acpBackendId, "same-thread")]: {
+        mode: "full-access",
+      },
+    });
+    expect(
+      registry.getQueuedExecutionModesSnapshot()[
+        buildThreadIdentityKey("codex", "same-thread")
+      ],
+    ).toBeUndefined();
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2749,6 +2749,72 @@ script = "echo setup"
     await registry.close();
   });
 
+  it("uses the latest applied Kimi permission transition when session metadata is stale", async () => {
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "acp:kimi:kimi-session-1": {
+          backend: "acp:kimi",
+          threadId: "kimi-session-1",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          permissionTransitionLog: [
+            {
+              id: "transition-1",
+              fromExecutionMode: "default",
+              toExecutionMode: "full-access",
+              status: "applied",
+              occurredAt: 2000,
+            },
+          ],
+        } as ThreadOverlayState,
+      },
+    });
+    const sendControlPrompt = vi.fn(async () => ({
+      text: "You only live once! All actions will be auto-approved.",
+    }));
+    const { acpBackendId, registry, sessions } = createKimiAcpRegistry({
+      overlayStore,
+      sendControlPrompt,
+      sessions: [
+        {
+          backendId: "acp:kimi" as AcpBackendId,
+          sessionId: "kimi-session-1",
+          title: "ACP session",
+          createdAt: 1000,
+          updatedAt: 1000,
+          executionMode: "default",
+          status: "idle",
+        },
+      ],
+    });
+
+    await expect(
+      registry.listThreads({ backend: acpBackendId }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        id: "kimi-session-1",
+        executionMode: "full-access",
+      }),
+    ]);
+
+    await expect(
+      registry.setThreadExecutionMode({
+        backend: acpBackendId,
+        threadId: "kimi-session-1",
+        executionMode: "full-access",
+      }),
+    ).resolves.toEqual({
+      backend: acpBackendId,
+      threadId: "kimi-session-1",
+      executionMode: "full-access",
+    });
+
+    expect(sendControlPrompt).not.toHaveBeenCalled();
+    expect(sessions[0]?.executionMode).toBe("default");
+
+    await registry.close();
+  });
+
   it("isolates queued execution modes by backend when thread ids collide", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/resume"] },

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1076,6 +1076,8 @@ function createKimiAcpRegistry(options?: {
   startPrompt?: KimiStartPrompt;
   overlayStore?: ReturnType<typeof createOverlayStoreMock>;
   codexClient?: MockBackendClient;
+  codexEnvironmentCommandRunner?: CodexEnvironmentCommandRunner;
+  gitDirectoryService?: unknown;
 }) {
   const acpBackendId = options?.acpBackendId ?? ("acp:kimi" as AcpBackendId);
   const sessions = options?.sessions ?? [];
@@ -1089,6 +1091,7 @@ function createKimiAcpRegistry(options?: {
     options?.startPrompt ??
     vi.fn(() => ({ sessionId, turnId: "turn-1" }));
   const acpClient = {
+    controlPromptReceiverMarker: true,
     initialize: vi.fn(async () => undefined),
     dispose: vi.fn(),
     startSession: vi.fn(async (params: {
@@ -1139,6 +1142,8 @@ function createKimiAcpRegistry(options?: {
     acpAgentStore: createAcpAgentStoreMock([createKimiAgentRecord(acpBackendId)]),
     acpSessionStore: createAcpSessionStoreMock(sessions),
     createAcpClient: () => acpClient,
+    codexEnvironmentCommandRunner: options?.codexEnvironmentCommandRunner,
+    gitDirectoryService: options?.gitDirectoryService as never,
   });
   return {
     acpBackendId,
@@ -2455,6 +2460,123 @@ describe("DesktopBackendRegistry", () => {
     expect(sessions[0]?.executionMode).toBe("default");
 
     await registry.close();
+  });
+
+  it("keeps the ACP client receiver when sending Kimi /yolo prompts", async () => {
+    const sendControlPrompt = vi.fn(function (
+      this: { controlPromptReceiverMarker?: boolean } | undefined,
+    ) {
+      if (this?.controlPromptReceiverMarker !== true) {
+        throw new Error("lost ACP client receiver");
+      }
+      return Promise.resolve({
+        text: "You only live once! All actions will be auto-approved.",
+      });
+    });
+    const { acpBackendId, registry } = createKimiAcpRegistry({
+      sendControlPrompt,
+    });
+
+    await expect(
+      registry.startThread({
+        backend: acpBackendId,
+        cwd: "/repo/project",
+        executionMode: "full-access",
+      }),
+    ).resolves.toMatchObject({
+      backend: acpBackendId,
+      threadId: "kimi-session-1",
+      executionMode: "full-access",
+    });
+
+    expect(sendControlPrompt).toHaveBeenCalledWith({
+      sessionId: "kimi-session-1",
+      prompt: "/yolo",
+    });
+
+    await registry.close();
+  });
+
+  it("materializes Kimi worktree launchpads without running Codex environment setup", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-kimi-launchpad-"));
+    const worktreePath = path.join(root, ".worktrees", "thread-1", "app");
+    await mkdir(path.join(root, ".codex", "environments"), { recursive: true });
+    await writeFile(
+      path.join(root, ".codex", "environments", "environment.toml"),
+      `
+version = 1
+name = "Repo Environment"
+
+[setup]
+script = "echo setup"
+`,
+      "utf8",
+    );
+    const commandRunner = vi.fn(async () => ({ output: "setup", exitCode: 0 }));
+    const recordCodexWorktreeOwnerThread = vi.fn(async () => {});
+    const { acpBackendId, registry, sendControlPrompt, sessions } =
+      createKimiAcpRegistry({
+        codexEnvironmentCommandRunner: commandRunner,
+        gitDirectoryService: {
+          prepareLaunchpadWorkspace: vi.fn(async () => ({
+            cwd: worktreePath,
+            repositoryPath: root,
+            workMode: "worktree" as const,
+          })),
+          recordCodexWorktreeOwnerThread,
+        },
+      });
+
+    try {
+      const response = await registry.materializeDirectoryLaunchpad({
+        directoryKey: `directory:${root}`,
+        launchpad: {
+          directoryKey: `directory:${root}`,
+          directoryKind: "directory",
+          directoryLabel: "app",
+          directoryPath: root,
+          backend: acpBackendId,
+          executionMode: "full-access",
+          prompt: "",
+          workMode: "worktree",
+          model: "kimi-for-coding",
+          codexEnvironmentId: "environment",
+          codexEnvironmentExecutionTarget: "local",
+          codexEnvironmentSetupEnabled: true,
+          createdAt: 1_000,
+          updatedAt: 2_000,
+        },
+      });
+
+      expect(response).toMatchObject({
+        backend: acpBackendId,
+        threadId: "kimi-session-1",
+        executionMode: "full-access",
+        workMode: "worktree",
+        linkedDirectory: {
+          id: root,
+          kind: "worktree",
+          label: "app",
+          path: root,
+          worktreePath,
+        },
+      });
+      expect(response.codexEnvironmentRuntime).toBeUndefined();
+      expect(response.codexEnvironmentStartupFailure).toBeUndefined();
+      expect(commandRunner).not.toHaveBeenCalled();
+      expect(recordCodexWorktreeOwnerThread).not.toHaveBeenCalled();
+      expect(sendControlPrompt).toHaveBeenCalledWith({
+        sessionId: "kimi-session-1",
+        prompt: "/yolo",
+      });
+      expect(sessions[0]).toMatchObject({
+        cwd: worktreePath,
+        executionMode: "full-access",
+      });
+    } finally {
+      await registry.close();
+      await rm(root, { recursive: true, force: true });
+    }
   });
 
   it("keeps new Kimi sessions at default when startup /yolo fails", async () => {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -5196,6 +5196,64 @@ command = "pnpm dev:messaging"
     }
   });
 
+  it("surfaces environment options on existing ACP threads", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-acp-thread-env-"));
+    await mkdir(path.join(root, ".codex", "environments"), { recursive: true });
+    await writeFile(
+      path.join(root, ".codex", "environments", "environment.toml"),
+      `
+version = 1
+name = "PwrAgnt"
+
+[[actions]]
+name = "Dev - Messaging"
+command = "pnpm dev:messaging"
+`,
+      "utf8",
+    );
+
+    const { acpBackendId, registry } = createKimiAcpRegistry({
+      sessions: [
+        {
+          backendId: "acp:kimi" as AcpBackendId,
+          sessionId: "kimi-session-1",
+          title: "Kimi thread",
+          titleSource: "explicit",
+          cwd: root,
+          createdAt: 1_000,
+          updatedAt: 2_000,
+          executionMode: "default",
+          status: "idle",
+        },
+      ],
+    });
+
+    try {
+      await expect(registry.listThreads({ backend: acpBackendId })).resolves.toEqual([
+        expect.objectContaining({
+          id: "kimi-session-1",
+          source: acpBackendId,
+          codexEnvironmentOptions: [
+            expect.objectContaining({
+              id: "environment",
+              name: "PwrAgnt",
+              actions: [
+                expect.objectContaining({
+                  id: "dev-messaging",
+                  name: "Dev - Messaging",
+                  command: "pnpm dev:messaging",
+                }),
+              ],
+            }),
+          ],
+        }),
+      ]);
+    } finally {
+      await registry.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("lets existing Codex threads select a local environment for command actions", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-thread-env-select-"));
     await mkdir(path.join(root, ".codex", "environments"), { recursive: true });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2164,6 +2164,133 @@ describe("DesktopBackendRegistry", () => {
     expect(acpClient.dispose).toHaveBeenCalledTimes(1);
   });
 
+  it("runs Kimi ACP execution mode changes through slash control prompts", async () => {
+    const sessions: AcpSessionMetadata[] = [];
+    const acpBackendId = "acp:kimi" as AcpBackendId;
+    const sendControlPrompt = vi.fn(async () => undefined);
+    const acpClient = {
+      initialize: vi.fn(async () => undefined),
+      dispose: vi.fn(),
+      startSession: vi.fn(async (params: {
+        cwd?: string;
+        executionMode: "default" | "full-access";
+      }) => {
+        const metadata: AcpSessionMetadata = {
+          backendId: acpBackendId,
+          sessionId: "kimi-session-1",
+          title: "ACP session",
+          cwd: params.cwd,
+          createdAt: 1000,
+          updatedAt: 1000,
+          executionMode: params.executionMode,
+          status: "idle",
+        };
+        sessions.push(metadata);
+        return metadata;
+      }),
+      startPrompt: vi.fn(),
+      sendControlPrompt,
+      ensureSession: vi.fn(async () => undefined),
+      loadSession: vi.fn(async (): Promise<AppServerThreadReplay> => ({
+        entries: [],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+        threadStatus: "idle",
+      })),
+      refreshSession: vi.fn(async () => undefined),
+      cancelSession: vi.fn(),
+      readReplay: vi.fn((): AppServerThreadReplay => ({
+        entries: [],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+        threadStatus: "idle",
+      })),
+    };
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      grokClient: new MockBackendClient({ threads: [] }),
+      overlayStore: createOverlayStoreMock(),
+      acpAgentStore: createAcpAgentStoreMock([
+        {
+          backendId: acpBackendId,
+          registryId: "kimi",
+          name: "Kimi Code CLI",
+          version: "1.44.0",
+          distributionKind: "local",
+          distributionSource: "kimi acp",
+          installStatus: "installed",
+          authStatus: "not-required",
+          verificationStatus: "not-applicable",
+          allowlistRuleId: "local-kimi-cli",
+          installedAt: 1000,
+          updatedAt: 2000,
+          launchDescriptor: {
+            backendId: acpBackendId,
+            registryId: "kimi",
+            distributionKind: "local",
+            command: "kimi",
+            args: ["acp"],
+            env: {},
+          },
+        },
+      ]),
+      acpSessionStore: createAcpSessionStoreMock(sessions),
+      createAcpClient: () => acpClient,
+    });
+
+    const backends = await registry.listBackends({ includeUnavailable: true });
+    expect(backends.backends.find((backend) => backend.kind === acpBackendId))
+      .toMatchObject({
+        executionModes: [
+          { mode: "default", available: true },
+          { mode: "full-access", available: true },
+        ],
+      });
+
+    await expect(
+      registry.startThread({
+        backend: acpBackendId,
+        cwd: "/repo/project",
+        executionMode: "full-access",
+      }),
+    ).resolves.toMatchObject({
+      backend: acpBackendId,
+      threadId: "kimi-session-1",
+      executionMode: "full-access",
+    });
+
+    expect(sendControlPrompt).toHaveBeenCalledWith({
+      sessionId: "kimi-session-1",
+      prompt: "/yolo",
+    });
+
+    sendControlPrompt.mockClear();
+    await expect(
+      registry.setThreadExecutionMode({
+        backend: acpBackendId,
+        threadId: "kimi-session-1",
+        executionMode: "default",
+      }),
+    ).resolves.toEqual({
+      backend: acpBackendId,
+      threadId: "kimi-session-1",
+      executionMode: "default",
+    });
+    expect(sendControlPrompt).toHaveBeenCalledWith({
+      sessionId: "kimi-session-1",
+      prompt: "/yolo",
+    });
+    expect(sessions[0]?.executionMode).toBe("default");
+
+    await registry.close();
+  });
+
   it("reads persisted ACP sessions locally and refreshes the agent in the background", async () => {
     const acpBackendId = "acp:gemini" as AcpBackendId;
     const localReplay: AppServerThreadReplay = {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -4557,6 +4557,64 @@ script = "echo setup"
     await registry.close();
   });
 
+  it("keeps environment options available after switching a launchpad to ACP", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-acp-env-options-"));
+    await mkdir(path.join(root, ".codex", "environments"), { recursive: true });
+    await writeFile(
+      path.join(root, ".codex", "environments", "environment.toml"),
+      `
+version = 1
+name = "Repo Environment"
+
+[setup]
+script = "pnpm install"
+`,
+      "utf8",
+    );
+
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/start"] },
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    try {
+      await registry.ensureDirectoryLaunchpad({
+        directoryKey: `directory:${root}`,
+        directoryKind: "directory",
+        directoryLabel: "repo",
+        directoryPath: root,
+      });
+
+      const updated = await registry.updateDirectoryLaunchpad({
+        directoryKey: `directory:${root}`,
+        patch: {
+          backend: "acp:kimi" as AcpBackendId,
+          codexEnvironmentId: undefined,
+          codexEnvironmentExecutionTarget: undefined,
+          codexEnvironmentSetupEnabled: false,
+          codexEnvironmentActionId: undefined,
+        },
+      });
+
+      expect(updated.launchpad.backend).toBe("acp:kimi");
+      expect(updated.launchpad.codexEnvironmentOptions).toMatchObject([
+        {
+          id: "environment",
+          name: "Repo Environment",
+          setupScript: "pnpm install",
+        },
+      ]);
+    } finally {
+      await registry.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("refreshes empty saved directory drafts from current launchpad work mode defaults", async () => {
     const registry = new DesktopBackendRegistry({
       codexClient: new MockBackendClient({

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2629,6 +2629,15 @@ script = "echo setup"
       events.push(event);
     });
 
+    await expect(
+      registry.listThreads({ backend: acpBackendId }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        id: "kimi-session-1",
+        executionMode: "default",
+      }),
+    ]);
+
     await registry.startTurn({
       backend: acpBackendId,
       threadId: "kimi-session-1",
@@ -2668,6 +2677,14 @@ script = "echo setup"
     });
 
     expect(sessions[0]?.executionMode).toBe("full-access");
+    await expect(
+      registry.listThreads({ backend: acpBackendId }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        id: "kimi-session-1",
+        executionMode: "full-access",
+      }),
+    ]);
     const methods = events.map((event) => event.notification.method);
     expect(methods).toContain("thread/executionMode/queued");
     expect(methods).toContain("thread/executionMode/updated");
@@ -7160,6 +7177,21 @@ command = "pnpm dev"
       target: { type: "baseBranch", branch: "main" },
       delivery: "inline",
     });
+
+    await registry.close();
+  });
+
+  it("rejects review start for ACP backends instead of routing through built-in clients", async () => {
+    const { acpBackendId, registry } = createKimiAcpRegistry();
+
+    await expect(
+      registry.startReview({
+        backend: acpBackendId,
+        threadId: "kimi-session-1",
+        target: { type: "baseBranch", branch: "main" },
+        delivery: "inline",
+      }),
+    ).rejects.toThrow("Selected backend does not support review/start");
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1636,15 +1636,7 @@ describe("DesktopBackendRegistry", () => {
           updatedAt: 3000,
           executionMode: "default",
           status: "idle",
-          transcriptUpdates: [
-            {
-              receivedAt: 2000,
-              update: {
-                kind: "pwragent_user_prompt",
-                prompt: "What is this project?",
-              },
-            },
-          ],
+          hasConversationHistory: true,
         },
       ]),
     });
@@ -3353,23 +3345,7 @@ script = "echo setup"
       updatedAt: 3000,
       executionMode: "default",
       status: "idle",
-      transcriptUpdates: [
-        {
-          receivedAt: 2000,
-          update: {
-            kind: "pwragent_user_prompt",
-            prompt: "What is this project?",
-            turnId: "pending:session-1",
-          },
-        },
-        {
-          receivedAt: 2100,
-          update: {
-            sessionUpdate: "agent_message_chunk",
-            content: { type: "text", text: "It is PwrSnap." },
-          },
-        },
-      ],
+      hasConversationHistory: true,
     };
     const acpClient = {
       initialize: vi.fn(async () => undefined),
@@ -9074,7 +9050,6 @@ command = "pnpm dev"
       executionMode: ThreadExecutionMode;
       title?: string;
       createdAt?: number;
-      transcriptUpdates?: AcpSessionMetadata["transcriptUpdates"];
     }) => {
       const metadata: AcpSessionMetadata = {
         backendId: acpBackendId,
@@ -9086,7 +9061,6 @@ command = "pnpm dev"
         updatedAt: 2000,
         executionMode: params.executionMode,
         status: "idle",
-        transcriptUpdates: params.transcriptUpdates,
       };
       sessionStore.upsertSession(metadata);
       return metadata;
@@ -9183,7 +9157,6 @@ command = "pnpm dev"
       executionMode: ThreadExecutionMode;
       title?: string;
       createdAt?: number;
-      transcriptUpdates?: AcpSessionMetadata["transcriptUpdates"];
     }) => {
       const metadata: AcpSessionMetadata = {
         backendId: acpBackendId,
@@ -9195,7 +9168,6 @@ command = "pnpm dev"
         updatedAt: 2000,
         executionMode: params.executionMode,
         status: "idle",
-        transcriptUpdates: params.transcriptUpdates,
       };
       sessionStore.upsertSession(metadata);
       return metadata;
@@ -9340,16 +9312,7 @@ command = "pnpm dev"
           updatedAt: 1000,
           executionMode: "default",
           status: "idle",
-          transcriptUpdates: [
-            {
-              receivedAt: 1000,
-              update: {
-                kind: "pwragent_user_prompt",
-                prompt: "What is this project?",
-                turnId: "pending:session-1:1000",
-              },
-            },
-          ],
+          hasConversationHistory: true,
         },
       ]),
       gitWorkspaceHandoffService: {
@@ -9382,16 +9345,7 @@ command = "pnpm dev"
         updatedAt: 1000,
         executionMode: "default",
         status: "idle",
-        transcriptUpdates: [
-          {
-            receivedAt: 1000,
-            update: {
-              kind: "pwragent_user_prompt",
-              prompt: "What is this project?",
-              turnId: "pending:session-1:1000",
-            },
-          },
-        ],
+        hasConversationHistory: true,
       },
     ]);
     const ensureSession = vi.fn(async () => {
@@ -9405,7 +9359,6 @@ command = "pnpm dev"
       executionMode: ThreadExecutionMode;
       title?: string;
       createdAt?: number;
-      transcriptUpdates?: AcpSessionMetadata["transcriptUpdates"];
     }) => {
       const metadata: AcpSessionMetadata = {
         backendId: acpBackendId,
@@ -9417,7 +9370,6 @@ command = "pnpm dev"
         updatedAt: 2000,
         executionMode: params.executionMode,
         status: "idle",
-        transcriptUpdates: params.transcriptUpdates,
       };
       sessionStore.upsertSession(metadata);
       return metadata;

--- a/apps/desktop/src/main/__tests__/codex-environment-config.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-environment-config.test.ts
@@ -2,9 +2,11 @@ import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import type { NavigationLaunchpadDraft } from "@pwragent/shared";
 import {
   listCodexEnvironmentOptions,
   parseCodexEnvironmentToml,
+  withCodexEnvironmentOptions,
 } from "../app-server/codex-environment-config";
 
 describe("codex environment config", () => {
@@ -115,5 +117,40 @@ command = "pnpm dev:alt"
         command: "pnpm dev:alt",
       },
     ]);
+  });
+
+  it("hydrates environment options for ACP launchpads", () => {
+    const launchpad: NavigationLaunchpadDraft = {
+      directoryKey: "directory:/repo",
+      directoryKind: "directory",
+      directoryLabel: "repo",
+      directoryPath: "/repo",
+      backend: "acp:kimi",
+      executionMode: "default",
+      prompt: "",
+      workMode: "local",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    expect(
+      withCodexEnvironmentOptions(launchpad, [
+        {
+          id: "environment",
+          name: "Repo Environment",
+          sourcePath: "/repo/.codex/environments/environment.toml",
+          setupScript: "pnpm install",
+          actions: [],
+        },
+      ]),
+    ).toMatchObject({
+      backend: "acp:kimi",
+      codexEnvironmentOptions: [
+        {
+          id: "environment",
+          name: "Repo Environment",
+        },
+      ],
+    });
   });
 });

--- a/apps/desktop/src/main/__tests__/protocol-capture.test.ts
+++ b/apps/desktop/src/main/__tests__/protocol-capture.test.ts
@@ -14,6 +14,7 @@ describe("ProtocolCaptureStore", () => {
   const cleanupPaths: string[] = [];
 
   afterEach(async () => {
+    delete process.env.PWRAGENT_APP_SERVER_PROTOCOL_LOG;
     delete process.env.PWRAGENT_PROTOCOL_CAPTURE;
     delete process.env.PWRAGENT_PROTOCOL_CAPTURE_ROOT;
 
@@ -177,6 +178,43 @@ describe("ProtocolCaptureStore", () => {
     expect(Object.values(index)).toHaveLength(1);
     expect(Object.values(index)[0]?.backend).toBe("codex");
     expect(Object.values(index)[0]?.backendInstance).toBe("default");
+  });
+
+  it("creates raw captures when compact protocol logging is enabled", async () => {
+    const rootDir = await createTempDir();
+    cleanupPaths.push(rootDir);
+    process.env.PWRAGENT_APP_SERVER_PROTOCOL_LOG = "1";
+    process.env.PWRAGENT_PROTOCOL_CAPTURE_ROOT = rootDir;
+
+    const capture = createProtocolCaptureFromEnv({
+      backend: "acp:kimi",
+      backendInstance: "default",
+    });
+
+    expect(capture).toBeDefined();
+    await capture?.observer.onMessage({
+      direction: "inbound",
+      raw: '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"session-1","update":{"session_update":"agent_message_chunk"}}}',
+      envelope: {
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId: "session-1",
+          update: {
+            session_update: "agent_message_chunk",
+          },
+        },
+      },
+    });
+    await capture?.store.close();
+
+    const index = JSON.parse(
+      await fs.readFile(path.join(rootDir, "index.json"), "utf8"),
+    ) as Record<string, { backend: string; threadIds: string[] }>;
+    expect(Object.values(index)[0]).toMatchObject({
+      backend: "acp:kimi",
+      threadIds: ["session-1"],
+    });
   });
 
   it("captures ACP traffic and indexes session ids", async () => {

--- a/apps/desktop/src/main/__tests__/protocol-log-observer.test.ts
+++ b/apps/desktop/src/main/__tests__/protocol-log-observer.test.ts
@@ -159,11 +159,9 @@ describe("protocol log observer", () => {
         params: {
           sessionId: "session-1",
           update: {
-            sessionUpdate: "agent_message_chunk",
-            content: {
-              type: "text",
-              text: "hidden from protocol summaries",
-            },
+            sessionUpdate: "tool_call_update",
+            tool_call_id: "tool-1",
+            status: "in_progress",
           },
         },
       }),
@@ -176,8 +174,52 @@ describe("protocol log observer", () => {
       method: "session/update",
       paramKeys: ["sessionId", "update"],
       sessionId: "session-1",
-      updateKind: "agent_message_chunk",
+      updateKind: "tool_call_update",
     });
+  });
+
+  it("coalesces ACP streaming session update chunks", () => {
+    let now = 1_000;
+    const info = vi.fn();
+    const observer = createProtocolLogObserver({
+      backend: "acp:kimi",
+      logger: { info },
+      now: () => now,
+      streamLogIntervalMs: 500,
+    });
+
+    for (const text of ["a", " ", "c"]) {
+      observer.onMessage(
+        createEvent({
+          jsonrpc: "2.0",
+          method: "session/update",
+          params: {
+            sessionId: "session-1",
+            update: {
+              session_update: "agent_thought_chunk",
+              content: {
+                type: "text",
+                text,
+              },
+            },
+          },
+        }),
+      );
+      now += 100;
+    }
+
+    expect(info).toHaveBeenCalledTimes(1);
+    expect(info).toHaveBeenLastCalledWith(
+      "stream delta",
+      expect.objectContaining({
+        backend: "acp:kimi",
+        chars: 1,
+        count: 1,
+        reason: "interval",
+        streamKey: expect.stringContaining("session:session-1"),
+        text: "a",
+      }),
+    );
   });
 
   it("logs response error codes and messages", () => {

--- a/apps/desktop/src/main/__tests__/protocol-log-observer.test.ts
+++ b/apps/desktop/src/main/__tests__/protocol-log-observer.test.ts
@@ -174,8 +174,108 @@ describe("protocol log observer", () => {
       method: "session/update",
       paramKeys: ["sessionId", "update"],
       sessionId: "session-1",
+      status: "in_progress",
+      toolCallId: "tool-1",
       updateKind: "tool_call_update",
     });
+  });
+
+  it("coalesces repeated ACP tool call update summaries", () => {
+    let now = 1_000;
+    const info = vi.fn();
+    const observer = createProtocolLogObserver({
+      backend: "acp:kimi",
+      coalescedMessageLogIntervalMs: 500,
+      logger: { info },
+      now: () => now,
+    });
+
+    for (const title of ["Shell: p", "Shell: pn", "Shell: pnpm"]) {
+      observer.onMessage(
+        createEvent({
+          jsonrpc: "2.0",
+          method: "session/update",
+          params: {
+            sessionId: "session-1",
+            update: {
+              sessionUpdate: "tool_call_update",
+              status: "in_progress",
+              title,
+              toolCallId: "tool-1",
+            },
+          },
+        }),
+      );
+      now += 100;
+    }
+
+    expect(info).toHaveBeenCalledTimes(1);
+    expect(info).toHaveBeenLastCalledWith(
+      "message",
+      expect.objectContaining({
+        backend: "acp:kimi",
+        status: "in_progress",
+        title: "Shell: p",
+        toolCallId: "tool-1",
+        updateKind: "tool_call_update",
+      }),
+    );
+
+    now = 1_600;
+    observer.onMessage(
+      createEvent({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId: "session-1",
+          update: {
+            sessionUpdate: "tool_call_update",
+            status: "in_progress",
+            title: "Shell: pnpm build",
+            toolCallId: "tool-1",
+          },
+        },
+      }),
+    );
+
+    expect(info).toHaveBeenCalledTimes(2);
+    expect(info).toHaveBeenLastCalledWith(
+      "message coalesced",
+      expect.objectContaining({
+        backend: "acp:kimi",
+        coalescedDurationMs: 600,
+        status: "in_progress",
+        suppressedCount: 3,
+        title: "Shell: pnpm build",
+        toolCallId: "tool-1",
+        updateKind: "tool_call_update",
+      }),
+    );
+
+    observer.onMessage(
+      createEvent({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId: "session-1",
+          update: {
+            sessionUpdate: "tool_call_update",
+            status: "completed",
+            title: "Shell: pnpm build",
+            toolCallId: "tool-1",
+          },
+        },
+      }),
+    );
+
+    expect(info).toHaveBeenCalledTimes(3);
+    expect(info).toHaveBeenLastCalledWith(
+      "message",
+      expect.objectContaining({
+        status: "completed",
+        toolCallId: "tool-1",
+      }),
+    );
   });
 
   it("coalesces ACP streaming session update chunks", () => {

--- a/apps/desktop/src/main/acp/acp-agent-capabilities.ts
+++ b/apps/desktop/src/main/acp/acp-agent-capabilities.ts
@@ -10,6 +10,9 @@ const ACP_AGENT_CAPABILITY_CATALOG: Record<string, AcpAgentCapabilities> = {
   gemini: {
     liveWorkspaceHandoff: false,
   },
+  kimi: {
+    liveWorkspaceHandoff: false,
+  },
 };
 
 export function acpAgentCapabilitiesForRegistryId(

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -70,6 +70,13 @@ type AcpRolloutStoreLike = {
   }): AcpRolloutRecord[];
 };
 
+type AcpActiveTurn = {
+  activeAssistantMessageItemId?: string;
+  assistantText: string;
+  assistantMessageSequence: number;
+  turnId: string;
+};
+
 export type AcpAgentClientOptions = {
   backendId: AcpBackendId;
   agentDisplayName?: string;
@@ -79,6 +86,7 @@ export type AcpAgentClientOptions = {
   transport: AcpJsonRpcTransport;
   now?: () => number;
   onSessionUpdate?: (event: {
+    assistantMessageItemId?: string;
     sessionId: string;
     replay: AppServerThreadReplay;
     title?: string;
@@ -106,13 +114,7 @@ export type AcpAgentClientOptions = {
 
 export class AcpAgentClient {
   private readonly normalizers = new Map<string, AcpSessionReplayNormalizer>();
-  private readonly activeTurns = new Map<
-    string,
-    {
-      assistantText: string;
-      turnId: string;
-    }
-  >();
+  private readonly activeTurns = new Map<string, AcpActiveTurn>();
   private readonly loadedSessionCwds = new Map<string, string | undefined>();
   private readonly suppressedControlPromptSessions = new Map<
     string,
@@ -547,8 +549,21 @@ export class AcpAgentClient {
       this.markSessionHasConversationHistory(sessionId, receivedAt);
     }
     this.appendHistoryUpdate(sessionId, receivedAt, update);
-    if (readUpdateKind(update) === "agent_message_chunk" && activeTurn) {
-      activeTurn.assistantText += readUpdateText(update) ?? "";
+    const updateKind = readUpdateKind(update);
+    const isAssistantTextUpdate =
+      updateKind === "agent_message_chunk" || updateKind === "agent_thought_chunk";
+    const text = readUpdateText(update);
+    let assistantMessageItemId: string | undefined;
+    if (isAssistantTextUpdate && activeTurn && text) {
+      assistantMessageItemId = assistantMessageItemIdForUpdate({
+        activeTurn,
+        update,
+      });
+      if (updateKind === "agent_message_chunk") {
+        activeTurn.assistantText += text;
+      }
+    } else if (!isAssistantTextUpdate && activeTurn) {
+      activeTurn.activeAssistantMessageItemId = undefined;
     }
     const replay = this.normalizerFor(sessionId).apply({
       sessionId,
@@ -556,6 +571,7 @@ export class AcpAgentClient {
       receivedAt,
     } satisfies AcpSessionUpdate);
     void this.notifySessionUpdate({
+      assistantMessageItemId,
       sessionId,
       replay,
       title,
@@ -729,6 +745,7 @@ export class AcpAgentClient {
   }
 
   private async notifySessionUpdate(event: {
+    assistantMessageItemId?: string;
     sessionId: string;
     replay: AppServerThreadReplay;
     title?: string;
@@ -787,6 +804,7 @@ export class AcpAgentClient {
     }
     this.activeTurns.set(sessionId, {
       assistantText: "",
+      assistantMessageSequence: 0,
       turnId,
     });
     this.updateSessionStatus(sessionId, "active");
@@ -1118,6 +1136,28 @@ function selectPermissionOptionId(
 
 function textPrompt(text: string): AcpPromptContentBlock[] {
   return [{ type: "text", text }];
+}
+
+function assistantMessageItemIdForUpdate(params: {
+  activeTurn: AcpActiveTurn;
+  update: Record<string, unknown>;
+}): string {
+  const explicitId =
+    typeof params.update.messageId === "string"
+      ? params.update.messageId
+      : typeof params.update.message_id === "string"
+        ? params.update.message_id
+        : undefined;
+  if (explicitId) {
+    params.activeTurn.activeAssistantMessageItemId = explicitId;
+    return explicitId;
+  }
+
+  if (!params.activeTurn.activeAssistantMessageItemId) {
+    params.activeTurn.activeAssistantMessageItemId =
+      `assistant:${params.activeTurn.turnId}:${params.activeTurn.assistantMessageSequence++}`;
+  }
+  return params.activeTurn.activeAssistantMessageItemId;
 }
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -10,6 +10,7 @@ import type {
 } from "@pwragent/shared";
 import {
   AcpSessionReplayNormalizer,
+  readAcpContentText,
   readAcpTopicTitle,
   type AcpSessionUpdate,
 } from "./acp-session-normalizer.js";
@@ -26,7 +27,11 @@ import type {
 import type { JsonRpcId } from "../codex-app-server/json-rpc.js";
 
 export type AcpJsonRpcTransport = {
-  request(method: string, params?: Record<string, unknown>): Promise<unknown>;
+  request(
+    method: string,
+    params?: Record<string, unknown>,
+    timeoutMs?: number,
+  ): Promise<unknown>;
   notify?(method: string, params?: Record<string, unknown>): Promise<void>;
   close?(): Promise<void>;
   onNotification(
@@ -42,6 +47,7 @@ export type AcpJsonRpcTransport = {
 };
 
 const ACP_PROTOCOL_VERSION = 1;
+const ACP_PROMPT_REQUEST_TIMEOUT_MS = 60 * 60_000;
 export type AcpPromptContentBlock =
   | { type: "text"; text: string }
   | { type: "image"; mimeType: string; data: string };
@@ -237,10 +243,14 @@ export class AcpAgentClient {
     let result: unknown;
     const protocolSessionId = this.protocolSessionIdFor(params.sessionId);
     try {
-      const promptRequest = this.options.transport.request("session/prompt", {
-        sessionId: protocolSessionId,
-        prompt: params.promptContent ?? textPrompt(params.prompt),
-      });
+      const promptRequest = this.options.transport.request(
+        "session/prompt",
+        {
+          sessionId: protocolSessionId,
+          prompt: params.promptContent ?? textPrompt(params.prompt),
+        },
+        ACP_PROMPT_REQUEST_TIMEOUT_MS,
+      );
       result = await promptRequest;
     } catch (error) {
       this.finishTrackedTurn(params.sessionId);
@@ -307,10 +317,14 @@ export class AcpAgentClient {
     });
     this.markSessionHasConversationHistory(params.sessionId, receivedAt);
     const protocolSessionId = this.protocolSessionIdFor(params.sessionId);
-    const promptRequest = this.options.transport.request("session/prompt", {
-      sessionId: protocolSessionId,
-      prompt: params.promptContent ?? textPrompt(params.prompt),
-    });
+    const promptRequest = this.options.transport.request(
+      "session/prompt",
+      {
+        sessionId: protocolSessionId,
+        prompt: params.promptContent ?? textPrompt(params.prompt),
+      },
+      ACP_PROMPT_REQUEST_TIMEOUT_MS,
+    );
     void promptRequest
       .then(() => {
         const finished = this.finishTrackedTurn(params.sessionId);
@@ -358,10 +372,14 @@ export class AcpAgentClient {
     const suppression = { textChunks: [] };
     this.suppressedControlPromptSessions.set(protocolSessionId, suppression);
     try {
-      await this.options.transport.request("session/prompt", {
-        sessionId: protocolSessionId,
-        prompt: textPrompt(params.prompt),
-      });
+      await this.options.transport.request(
+        "session/prompt",
+        {
+          sessionId: protocolSessionId,
+          prompt: textPrompt(params.prompt),
+        },
+        ACP_PROMPT_REQUEST_TIMEOUT_MS,
+      );
       return { text: suppression.textChunks.join("\n").trim() };
     } finally {
       this.suppressedControlPromptSessions.delete(protocolSessionId);
@@ -539,7 +557,11 @@ export class AcpAgentClient {
         ? toolCall.title.trim()
         : "ACP tool call";
     const toolCallId =
-      typeof toolCall.toolCallId === "string" ? toolCall.toolCallId : undefined;
+      typeof toolCall.toolCallId === "string"
+        ? toolCall.toolCallId
+        : typeof toolCall.tool_call_id === "string"
+          ? toolCall.tool_call_id
+          : undefined;
     const requestId = id == null ? toolCallId ?? `acp:${this.now()}` : String(id);
     const activeTurn = this.activeTurns.get(sessionId);
 
@@ -820,7 +842,8 @@ function protocolSessionIdForMetadata(metadata: AcpSessionMetadata): string {
 }
 
 function readUpdateKind(update: Record<string, unknown>): string | undefined {
-  const kind = update.sessionUpdate ?? update.kind ?? update.type;
+  const kind =
+    update.sessionUpdate ?? update.session_update ?? update.kind ?? update.type;
   return typeof kind === "string" ? kind : undefined;
 }
 
@@ -837,14 +860,13 @@ function readUpdateText(update: Record<string, unknown>): string | undefined {
   if (typeof update.text === "string") {
     return update.text;
   }
-  const content = update.content;
-  if (!content || typeof content !== "object" || Array.isArray(content)) {
-    return undefined;
+  if (typeof update.outputText === "string") {
+    return update.outputText;
   }
-  const contentRecord = content as Record<string, unknown>;
-  return contentRecord.type === "text" && typeof contentRecord.text === "string"
-    ? contentRecord.text
-    : undefined;
+  if (typeof update.output_text === "string") {
+    return update.output_text;
+  }
+  return readAcpContentText(update.content);
 }
 
 function errorMessage(error: unknown): string {

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -24,6 +24,7 @@ import type {
   AcpSessionMetadata,
   AcpSessionStore,
 } from "./acp-session-store.js";
+import { appendCoalescedTranscriptUpdate } from "./acp-session-store.js";
 import type { JsonRpcId } from "../codex-app-server/json-rpc.js";
 
 export type AcpJsonRpcTransport = {
@@ -43,6 +44,7 @@ export type AcpJsonRpcTransport = {
 };
 
 const ACP_PROTOCOL_VERSION = 1;
+const DEFAULT_TRANSCRIPT_PERSISTENCE_FLUSH_DELAY_MS = 1000;
 
 export type AcpPromptContentBlock =
   | { type: "text"; text: string }
@@ -84,6 +86,7 @@ export type AcpAgentClientOptions = {
   onRequest?: (
     request: AppServerPendingRequestNotification
   ) => Promise<unknown> | unknown;
+  transcriptPersistenceFlushDelayMs?: number;
 };
 
 export class AcpAgentClient {
@@ -106,6 +109,15 @@ export class AcpAgentClient {
   private readonly appSessionIdsByAgentSessionId = new Map<string, string>();
   private readonly now: () => number;
   private readonly approvalRequesterName: string;
+  private readonly transcriptPersistenceFlushDelayMs: number;
+  private readonly pendingTranscriptUpdates = new Map<
+    string,
+    AcpPersistedTranscriptUpdate[]
+  >();
+  private readonly transcriptPersistenceTimers = new Map<
+    string,
+    ReturnType<typeof setTimeout>
+  >();
   private unsubscribe?: () => void;
   private unsubscribeRequest?: () => void;
   private runtimeCapabilities?: BackendAcpRuntimeCapabilities;
@@ -114,6 +126,9 @@ export class AcpAgentClient {
     this.now = options.now ?? Date.now;
     this.runtimeCapabilities = options.initialRuntimeCapabilities;
     this.approvalRequesterName = approvalRequesterNameForOptions(options);
+    this.transcriptPersistenceFlushDelayMs =
+      options.transcriptPersistenceFlushDelayMs ??
+      DEFAULT_TRANSCRIPT_PERSISTENCE_FLUSH_DELAY_MS;
   }
 
   async initialize(): Promise<void> {
@@ -154,6 +169,7 @@ export class AcpAgentClient {
     this.unsubscribe = undefined;
     this.unsubscribeRequest?.();
     this.unsubscribeRequest = undefined;
+    this.flushAllPendingTranscriptUpdates();
     this.agentSessionIdsByAppSessionId.clear();
     this.appSessionIdsByAgentSessionId.clear();
     this.loadedSessionCwds.clear();
@@ -533,10 +549,14 @@ export class AcpAgentClient {
       update,
       receivedAt,
     } satisfies AcpSessionUpdate);
-    this.persistTranscriptUpdate(sessionId, {
-      receivedAt,
-      update,
-    });
+    this.persistTranscriptUpdate(
+      sessionId,
+      {
+        receivedAt,
+        update,
+      },
+      { flush: "deferred" },
+    );
     void this.notifySessionUpdate({
       sessionId,
       replay,
@@ -669,15 +689,58 @@ export class AcpAgentClient {
   private persistTranscriptUpdate(
     sessionId: string,
     update: AcpPersistedTranscriptUpdate,
+    options?: { flush?: "deferred" | "immediate" },
   ): void {
+    const pending = this.pendingTranscriptUpdates.get(sessionId) ?? [];
+    appendCoalescedTranscriptUpdate(pending, update);
+    this.pendingTranscriptUpdates.set(sessionId, pending);
+    if (
+      options?.flush !== "deferred" ||
+      this.transcriptPersistenceFlushDelayMs <= 0
+    ) {
+      this.flushPendingTranscriptUpdates(sessionId);
+      return;
+    }
+    if (this.transcriptPersistenceTimers.has(sessionId)) {
+      return;
+    }
+    const timer = setTimeout(() => {
+      this.transcriptPersistenceTimers.delete(sessionId);
+      this.flushPendingTranscriptUpdates(sessionId);
+    }, this.transcriptPersistenceFlushDelayMs);
+    timer.unref?.();
+    this.transcriptPersistenceTimers.set(sessionId, timer);
+  }
+
+  private flushAllPendingTranscriptUpdates(): void {
+    for (const sessionId of [...this.pendingTranscriptUpdates.keys()]) {
+      this.flushPendingTranscriptUpdates(sessionId);
+    }
+  }
+
+  private flushPendingTranscriptUpdates(sessionId: string): void {
+    const timer = this.transcriptPersistenceTimers.get(sessionId);
+    if (timer) {
+      clearTimeout(timer);
+      this.transcriptPersistenceTimers.delete(sessionId);
+    }
+    const pending = this.pendingTranscriptUpdates.get(sessionId);
+    if (!pending?.length) {
+      return;
+    }
+    this.pendingTranscriptUpdates.delete(sessionId);
     const metadata = this.options.store.getSession(this.options.backendId, sessionId);
     if (!metadata) {
       return;
     }
+    const updatedAt = pending.reduce(
+      (latest, item) => Math.max(latest, item.receivedAt),
+      metadata.updatedAt,
+    );
     this.options.store.upsertSession({
       ...metadata,
-      updatedAt: Math.max(metadata.updatedAt, update.receivedAt),
-      transcriptUpdates: [...(metadata.transcriptUpdates ?? []), update],
+      updatedAt,
+      transcriptUpdates: [...(metadata.transcriptUpdates ?? []), ...pending],
     });
   }
 

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -159,9 +159,12 @@ export class AcpAgentClient {
         version: "0.0.0",
       },
     });
-    this.captureRuntimeCapabilities({
+    const runtimeCapabilities = this.captureRuntimeCapabilities({
       source: "initialize",
       result,
+    });
+    this.notifyRuntimeCapabilities({
+      runtimeCapabilities,
     });
   }
 

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -63,6 +63,7 @@ type AcpSessionStoreLike = Pick<
 
 type AcpRolloutStoreLike = {
   appendUpdate(params: AcpRolloutStoreAppendParams): void;
+  flushAll?(): void;
   readUpdates(params: {
     backendId: AcpBackendId;
     sessionId: string;
@@ -165,6 +166,7 @@ export class AcpAgentClient {
   }
 
   async dispose(): Promise<void> {
+    this.options.rolloutStore?.flushAll?.();
     this.unsubscribe?.();
     this.unsubscribe = undefined;
     this.unsubscribeRequest?.();

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -24,6 +24,10 @@ import type {
   AcpSessionMetadata,
   AcpSessionStore,
 } from "./acp-session-store.js";
+import type {
+  AcpRolloutRecord,
+  AcpRolloutStoreAppendParams,
+} from "./acp-rollout-store.js";
 import type { JsonRpcId } from "../codex-app-server/json-rpc.js";
 
 export type AcpJsonRpcTransport = {
@@ -57,10 +61,19 @@ type AcpSessionStoreLike = Pick<
   "getSession" | "listSessions" | "upsertSession"
 >;
 
+type AcpRolloutStoreLike = {
+  appendUpdate(params: AcpRolloutStoreAppendParams): void;
+  readUpdates(params: {
+    backendId: AcpBackendId;
+    sessionId: string;
+  }): AcpRolloutRecord[];
+};
+
 export type AcpAgentClientOptions = {
   backendId: AcpBackendId;
   agentDisplayName?: string;
   initialRuntimeCapabilities?: BackendAcpRuntimeCapabilities;
+  rolloutStore?: AcpRolloutStoreLike;
   store: AcpSessionStoreLike;
   transport: AcpJsonRpcTransport;
   now?: () => number;
@@ -239,6 +252,12 @@ export class AcpAgentClient {
       turnId,
       receivedAt,
     });
+    this.appendHistoryUpdate(params.sessionId, receivedAt, {
+      kind: "pwragent_user_prompt",
+      prompt: params.prompt,
+      ...(params.parts?.length ? { parts: params.parts } : {}),
+      turnId,
+    });
     this.markSessionHasConversationHistory(params.sessionId, receivedAt);
     let result: unknown;
     const protocolSessionId = this.protocolSessionIdFor(params.sessionId);
@@ -258,6 +277,11 @@ export class AcpAgentClient {
       throw error;
     }
     this.finishTrackedTurn(params.sessionId);
+    const finishedAt = this.now();
+    this.appendHistoryUpdate(params.sessionId, finishedAt, {
+      kind: "turn_finished",
+      turnId,
+    });
     const record = asRecord(result);
     return {
       sessionId: params.sessionId,
@@ -273,6 +297,8 @@ export class AcpAgentClient {
     this.rememberSessionIds(metadata);
     if (this.supportsSessionLoad()) {
       await this.ensureSession(metadata);
+    } else {
+      this.hydrateSessionFromHistory(metadata);
     }
     return this.replayForSessionMetadata(metadata);
   }
@@ -315,6 +341,12 @@ export class AcpAgentClient {
       turnId,
       receivedAt,
     });
+    this.appendHistoryUpdate(params.sessionId, receivedAt, {
+      kind: "pwragent_user_prompt",
+      prompt: params.prompt,
+      ...(params.parts?.length ? { parts: params.parts } : {}),
+      turnId,
+    });
     this.markSessionHasConversationHistory(params.sessionId, receivedAt);
     const protocolSessionId = this.protocolSessionIdFor(params.sessionId);
     const promptRequest = this.options.transport.request(
@@ -328,6 +360,12 @@ export class AcpAgentClient {
     void promptRequest
       .then(() => {
         const finished = this.finishTrackedTurn(params.sessionId);
+        const receivedAt = this.now();
+        this.appendHistoryUpdate(params.sessionId, receivedAt, {
+          kind: "turn_finished",
+          ...(finished.turnId ? { turnId: finished.turnId } : {}),
+          outputText: finished.assistantText,
+        });
         void this.notifySessionUpdate({
           sessionId: params.sessionId,
           replay: finished.replay,
@@ -503,6 +541,7 @@ export class AcpAgentClient {
     if (isConversationHistoryUpdate(update)) {
       this.markSessionHasConversationHistory(sessionId, receivedAt);
     }
+    this.appendHistoryUpdate(sessionId, receivedAt, update);
     if (readUpdateKind(update) === "agent_message_chunk" && activeTurn) {
       activeTurn.assistantText += readUpdateText(update) ?? "";
     }
@@ -601,6 +640,24 @@ export class AcpAgentClient {
       ...replay,
       threadStatus: acpSessionThreadStatus(metadata.status, replay.threadStatus),
     };
+  }
+
+  private hydrateSessionFromHistory(metadata: AcpSessionMetadata): void {
+    if (!this.options.rolloutStore) {
+      return;
+    }
+    const normalizer = new AcpSessionReplayNormalizer();
+    for (const record of this.options.rolloutStore.readUpdates({
+      backendId: this.options.backendId,
+      sessionId: metadata.sessionId,
+    })) {
+      normalizer.apply({
+        sessionId: metadata.sessionId,
+        receivedAt: record.receivedAt,
+        update: record.update,
+      });
+    }
+    this.normalizers.set(metadata.sessionId, normalizer);
   }
 
   private markSessionHasConversationHistory(
@@ -764,11 +821,29 @@ export class AcpAgentClient {
         updatedAt: Math.max(metadata.updatedAt, receivedAt),
       });
     }
+    this.appendHistoryUpdate(sessionId, receivedAt, {
+      kind: "pwragent_turn_failed",
+      turnId,
+      error: message,
+    });
     return this.normalizerFor(sessionId).recordTurnFailed({
       sessionId,
       turnId,
       error: message,
       receivedAt,
+    });
+  }
+
+  private appendHistoryUpdate(
+    sessionId: string,
+    receivedAt: number,
+    update: Record<string, unknown>,
+  ): void {
+    this.options.rolloutStore?.appendUpdate({
+      backendId: this.options.backendId,
+      sessionId,
+      receivedAt,
+      update,
     });
   }
 

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -55,6 +55,7 @@ type AcpSessionStoreLike = Pick<
 
 export type AcpAgentClientOptions = {
   backendId: AcpBackendId;
+  agentDisplayName?: string;
   initialRuntimeCapabilities?: BackendAcpRuntimeCapabilities;
   store: AcpSessionStoreLike;
   transport: AcpJsonRpcTransport;
@@ -101,6 +102,7 @@ export class AcpAgentClient {
   private readonly agentSessionIdsByAppSessionId = new Map<string, string>();
   private readonly appSessionIdsByAgentSessionId = new Map<string, string>();
   private readonly now: () => number;
+  private readonly approvalRequesterName: string;
   private unsubscribe?: () => void;
   private unsubscribeRequest?: () => void;
   private runtimeCapabilities?: BackendAcpRuntimeCapabilities;
@@ -108,6 +110,7 @@ export class AcpAgentClient {
   constructor(private readonly options: AcpAgentClientOptions) {
     this.now = options.now ?? Date.now;
     this.runtimeCapabilities = options.initialRuntimeCapabilities;
+    this.approvalRequesterName = approvalRequesterNameForOptions(options);
   }
 
   async initialize(): Promise<void> {
@@ -579,8 +582,8 @@ export class AcpAgentClient {
         threadId: sessionId,
         ...(activeTurn?.turnId ? { turnId: activeTurn.turnId } : {}),
         requestId,
-        prompt: permissionPrompt(title, toolCall),
-        reason: permissionPrompt(title, toolCall),
+        prompt: permissionPrompt(this.approvalRequesterName, title, toolCall),
+        reason: permissionPrompt(this.approvalRequesterName, title, toolCall),
         command: title,
         displayCommand: title,
         acpMethod: "session/request_permission",
@@ -987,13 +990,36 @@ function readPermissionOptions(value: unknown): AcpPermissionOption[] {
   });
 }
 
-function permissionPrompt(title: string, toolCall: Record<string, unknown>): string {
+function approvalRequesterNameForOptions(options: Pick<
+  AcpAgentClientOptions,
+  "agentDisplayName" | "backendId"
+>): string {
+  const configured = options.agentDisplayName?.trim();
+  if (configured) {
+    return configured;
+  }
+  const backendName = options.backendId
+    .replace(/^acp:/, "")
+    .split(/[-_:]+/)
+    .map((part) => (part ? part[0].toUpperCase() + part.slice(1) : part))
+    .join(" ")
+    .trim();
+  return backendName || "ACP agent";
+}
+
+function permissionPrompt(
+  requesterName: string,
+  title: string,
+  toolCall: Record<string, unknown>,
+): string {
   const contentText = readToolCallText(toolCall.content);
   if (contentText) {
     return contentText;
   }
   const kind = typeof toolCall.kind === "string" ? toolCall.kind : undefined;
-  return kind ? `Gemini wants to run ${kind}: ${title}` : `Gemini wants to run ${title}`;
+  return kind
+    ? `${requesterName} wants to run ${kind}: ${title}`
+    : `${requesterName} wants to run ${title}`;
 }
 
 function readToolCallText(value: unknown): string | undefined {

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -20,11 +20,9 @@ import {
   normalizeAcpRuntimeCapabilities,
 } from "./acp-runtime-capabilities.js";
 import type {
-  AcpPersistedTranscriptUpdate,
   AcpSessionMetadata,
   AcpSessionStore,
 } from "./acp-session-store.js";
-import { appendCoalescedTranscriptUpdate } from "./acp-session-store.js";
 import type { JsonRpcId } from "../codex-app-server/json-rpc.js";
 
 export type AcpJsonRpcTransport = {
@@ -44,8 +42,6 @@ export type AcpJsonRpcTransport = {
 };
 
 const ACP_PROTOCOL_VERSION = 1;
-const DEFAULT_TRANSCRIPT_PERSISTENCE_FLUSH_DELAY_MS = 1000;
-
 export type AcpPromptContentBlock =
   | { type: "text"; text: string }
   | { type: "image"; mimeType: string; data: string };
@@ -86,7 +82,6 @@ export type AcpAgentClientOptions = {
   onRequest?: (
     request: AppServerPendingRequestNotification
   ) => Promise<unknown> | unknown;
-  transcriptPersistenceFlushDelayMs?: number;
 };
 
 export class AcpAgentClient {
@@ -99,25 +94,14 @@ export class AcpAgentClient {
     }
   >();
   private readonly loadedSessionCwds = new Map<string, string | undefined>();
-  private readonly suppressLoadReplaySessions = new Set<string>();
   private readonly suppressedControlPromptSessions = new Map<
     string,
     { textChunks: string[] }
   >();
-  private readonly hydratedTranscriptSessions = new Set<string>();
   private readonly agentSessionIdsByAppSessionId = new Map<string, string>();
   private readonly appSessionIdsByAgentSessionId = new Map<string, string>();
   private readonly now: () => number;
   private readonly approvalRequesterName: string;
-  private readonly transcriptPersistenceFlushDelayMs: number;
-  private readonly pendingTranscriptUpdates = new Map<
-    string,
-    AcpPersistedTranscriptUpdate[]
-  >();
-  private readonly transcriptPersistenceTimers = new Map<
-    string,
-    ReturnType<typeof setTimeout>
-  >();
   private unsubscribe?: () => void;
   private unsubscribeRequest?: () => void;
   private runtimeCapabilities?: BackendAcpRuntimeCapabilities;
@@ -126,9 +110,6 @@ export class AcpAgentClient {
     this.now = options.now ?? Date.now;
     this.runtimeCapabilities = options.initialRuntimeCapabilities;
     this.approvalRequesterName = approvalRequesterNameForOptions(options);
-    this.transcriptPersistenceFlushDelayMs =
-      options.transcriptPersistenceFlushDelayMs ??
-      DEFAULT_TRANSCRIPT_PERSISTENCE_FLUSH_DELAY_MS;
   }
 
   async initialize(): Promise<void> {
@@ -169,12 +150,9 @@ export class AcpAgentClient {
     this.unsubscribe = undefined;
     this.unsubscribeRequest?.();
     this.unsubscribeRequest = undefined;
-    this.flushAllPendingTranscriptUpdates();
     this.agentSessionIdsByAppSessionId.clear();
     this.appSessionIdsByAgentSessionId.clear();
     this.loadedSessionCwds.clear();
-    this.suppressLoadReplaySessions.clear();
-    this.hydratedTranscriptSessions.clear();
     await this.options.transport.close?.();
   }
 
@@ -185,7 +163,6 @@ export class AcpAgentClient {
     title?: string;
     createdAt?: number;
     acpRuntime?: BackendAcpSessionRuntimeState;
-    transcriptUpdates?: AcpPersistedTranscriptUpdate[];
   }): Promise<AcpSessionMetadata> {
     const cwd = params.cwd ?? process.cwd();
     const result = await this.options.transport.request("session/new", {
@@ -228,7 +205,6 @@ export class AcpAgentClient {
       executionMode: params.executionMode,
       acpRuntime: combinedRuntimeState,
       status: "idle",
-      transcriptUpdates: params.transcriptUpdates,
     };
     this.options.store.upsertSession(metadata);
     this.rememberSessionIds(metadata);
@@ -247,7 +223,6 @@ export class AcpAgentClient {
     promptContent?: AcpPromptContentBlock[];
     parts?: AppServerThreadMessagePart[];
   }): Promise<{ sessionId: string; turnId: string }> {
-    this.hydratePersistedTranscriptForSession(params.sessionId);
     const turnId = `pending:${params.sessionId}:${this.now()}`;
     const receivedAt = this.now();
     this.startTrackedTurn(params.sessionId, turnId);
@@ -258,15 +233,7 @@ export class AcpAgentClient {
       turnId,
       receivedAt,
     });
-    this.persistTranscriptUpdate(params.sessionId, {
-      receivedAt,
-      update: {
-        kind: "pwragent_user_prompt",
-        prompt: params.prompt,
-        ...(params.parts?.length ? { parts: params.parts } : {}),
-        turnId,
-      },
-    });
+    this.markSessionHasConversationHistory(params.sessionId, receivedAt);
     let result: unknown;
     const protocolSessionId = this.protocolSessionIdFor(params.sessionId);
     try {
@@ -274,10 +241,9 @@ export class AcpAgentClient {
         sessionId: protocolSessionId,
         prompt: params.promptContent ?? textPrompt(params.prompt),
       });
-      this.clearLoadReplaySuppression(protocolSessionId);
       result = await promptRequest;
     } catch (error) {
-      this.finishTrackedTurn(params.sessionId, { persistFinished: false });
+      this.finishTrackedTurn(params.sessionId);
       this.recordPromptFailure(params.sessionId, turnId, error);
       throw error;
     }
@@ -295,16 +261,14 @@ export class AcpAgentClient {
   async loadSession(metadata: AcpSessionMetadata): Promise<AppServerThreadReplay> {
     this.options.store.upsertSession(metadata);
     this.rememberSessionIds(metadata);
-    return this.hydratePersistedTranscript(metadata);
+    if (this.supportsSessionLoad()) {
+      await this.ensureSession(metadata);
+    }
+    return this.replayForSessionMetadata(metadata);
   }
 
   async refreshSession(metadata: AcpSessionMetadata): Promise<void> {
-    this.options.store.upsertSession(metadata);
-    this.rememberSessionIds(metadata);
-    if (!this.supportsSessionLoad()) {
-      return;
-    }
-    await this.loadSessionFromAgent(metadata);
+    await this.ensureSession(metadata);
   }
 
   async ensureSession(metadata: AcpSessionMetadata): Promise<void> {
@@ -331,7 +295,6 @@ export class AcpAgentClient {
     parts?: AppServerThreadMessagePart[];
     turnId?: string;
   }): { sessionId: string; turnId: string } {
-    this.hydratePersistedTranscriptForSession(params.sessionId);
     const turnId = params.turnId ?? `pending:${params.sessionId}:${this.now()}`;
     const receivedAt = this.now();
     this.startTrackedTurn(params.sessionId, turnId);
@@ -342,21 +305,12 @@ export class AcpAgentClient {
       turnId,
       receivedAt,
     });
-    this.persistTranscriptUpdate(params.sessionId, {
-      receivedAt,
-      update: {
-        kind: "pwragent_user_prompt",
-        prompt: params.prompt,
-        ...(params.parts?.length ? { parts: params.parts } : {}),
-        turnId,
-      },
-    });
+    this.markSessionHasConversationHistory(params.sessionId, receivedAt);
     const protocolSessionId = this.protocolSessionIdFor(params.sessionId);
     const promptRequest = this.options.transport.request("session/prompt", {
       sessionId: protocolSessionId,
       prompt: params.promptContent ?? textPrompt(params.prompt),
     });
-    this.clearLoadReplaySuppression(protocolSessionId);
     void promptRequest
       .then(() => {
         const finished = this.finishTrackedTurn(params.sessionId);
@@ -371,7 +325,7 @@ export class AcpAgentClient {
         });
       })
       .catch((error) => {
-        this.finishTrackedTurn(params.sessionId, { persistFinished: false });
+        this.finishTrackedTurn(params.sessionId);
         this.recordPromptFailure(params.sessionId, turnId, error);
         return Promise.resolve(
           this.options.onPromptError?.({
@@ -497,7 +451,6 @@ export class AcpAgentClient {
   }
 
   readReplay(sessionId: string): AppServerThreadReplay {
-    this.hydratePersistedTranscriptForSession(sessionId);
     return this.normalizerFor(sessionId).replay();
   }
 
@@ -529,17 +482,8 @@ export class AcpAgentClient {
       return;
     }
     const title = this.updateSessionTitleFromAcpUpdate(sessionId, update, receivedAt);
-    if (this.suppressLoadReplaySessions.has(protocolSessionId)) {
-      if (title) {
-        void this.notifySessionUpdate({
-          sessionId,
-          replay: this.normalizerFor(sessionId).replay(),
-          title,
-          turnId: activeTurn?.turnId,
-          update,
-        });
-      }
-      return;
+    if (isConversationHistoryUpdate(update)) {
+      this.markSessionHasConversationHistory(sessionId, receivedAt);
     }
     if (readUpdateKind(update) === "agent_message_chunk" && activeTurn) {
       activeTurn.assistantText += readUpdateText(update) ?? "";
@@ -549,14 +493,6 @@ export class AcpAgentClient {
       update,
       receivedAt,
     } satisfies AcpSessionUpdate);
-    this.persistTranscriptUpdate(
-      sessionId,
-      {
-        receivedAt,
-        update,
-      },
-      { flush: "deferred" },
-    );
     void this.notifySessionUpdate({
       sessionId,
       replay,
@@ -634,113 +570,29 @@ export class AcpAgentClient {
     return normalizer;
   }
 
-  private applyPersistedTranscriptUpdates(
-    normalizer: AcpSessionReplayNormalizer,
+  private replayForSessionMetadata(
     metadata: AcpSessionMetadata,
   ): AppServerThreadReplay {
-    let replay = normalizer.replay();
-    for (const item of metadata.transcriptUpdates ?? []) {
-      const runtimeState = acpSessionRuntimeStateFromUpdate(
-        item.update,
-        item.receivedAt,
-      );
-      if (runtimeState) {
-        this.updateSessionRuntimeState(metadata.sessionId, runtimeState);
-      }
-      this.updateSessionTitleFromAcpUpdate(
-        metadata.sessionId,
-        item.update,
-        item.receivedAt,
-      );
-      replay = normalizer.apply({
-        sessionId: metadata.sessionId,
-        update: item.update,
-        receivedAt: item.receivedAt,
-      });
-    }
+    const normalizer = this.normalizerFor(metadata.sessionId);
+    const replay = normalizer.replay();
     return {
       ...replay,
       threadStatus: acpSessionThreadStatus(metadata.status, replay.threadStatus),
     };
   }
 
-  private hydratePersistedTranscriptForSession(sessionId: string): AppServerThreadReplay {
-    const metadata = this.options.store.getSession(this.options.backendId, sessionId);
-    if (!metadata) {
-      return this.normalizerFor(sessionId).replay();
-    }
-    return this.hydratePersistedTranscript(metadata);
-  }
-
-  private hydratePersistedTranscript(
-    metadata: AcpSessionMetadata,
-  ): AppServerThreadReplay {
-    const normalizer = this.normalizerFor(metadata.sessionId);
-    if (!this.hydratedTranscriptSessions.has(metadata.sessionId)) {
-      this.applyPersistedTranscriptUpdates(normalizer, metadata);
-      this.hydratedTranscriptSessions.add(metadata.sessionId);
-    }
-    return {
-      ...normalizer.replay(),
-      threadStatus: acpSessionThreadStatus(metadata.status, normalizer.replay().threadStatus),
-    };
-  }
-
-  private persistTranscriptUpdate(
+  private markSessionHasConversationHistory(
     sessionId: string,
-    update: AcpPersistedTranscriptUpdate,
-    options?: { flush?: "deferred" | "immediate" },
+    receivedAt: number,
   ): void {
-    const pending = this.pendingTranscriptUpdates.get(sessionId) ?? [];
-    appendCoalescedTranscriptUpdate(pending, update);
-    this.pendingTranscriptUpdates.set(sessionId, pending);
-    if (
-      options?.flush !== "deferred" ||
-      this.transcriptPersistenceFlushDelayMs <= 0
-    ) {
-      this.flushPendingTranscriptUpdates(sessionId);
-      return;
-    }
-    if (this.transcriptPersistenceTimers.has(sessionId)) {
-      return;
-    }
-    const timer = setTimeout(() => {
-      this.transcriptPersistenceTimers.delete(sessionId);
-      this.flushPendingTranscriptUpdates(sessionId);
-    }, this.transcriptPersistenceFlushDelayMs);
-    timer.unref?.();
-    this.transcriptPersistenceTimers.set(sessionId, timer);
-  }
-
-  private flushAllPendingTranscriptUpdates(): void {
-    for (const sessionId of [...this.pendingTranscriptUpdates.keys()]) {
-      this.flushPendingTranscriptUpdates(sessionId);
-    }
-  }
-
-  private flushPendingTranscriptUpdates(sessionId: string): void {
-    const timer = this.transcriptPersistenceTimers.get(sessionId);
-    if (timer) {
-      clearTimeout(timer);
-      this.transcriptPersistenceTimers.delete(sessionId);
-    }
-    const pending = this.pendingTranscriptUpdates.get(sessionId);
-    if (!pending?.length) {
-      return;
-    }
-    this.pendingTranscriptUpdates.delete(sessionId);
     const metadata = this.options.store.getSession(this.options.backendId, sessionId);
-    if (!metadata) {
+    if (!metadata || metadata.hasConversationHistory) {
       return;
     }
-    const updatedAt = pending.reduce(
-      (latest, item) => Math.max(latest, item.receivedAt),
-      metadata.updatedAt,
-    );
     this.options.store.upsertSession({
       ...metadata,
-      updatedAt,
-      transcriptUpdates: [...(metadata.transcriptUpdates ?? []), ...pending],
+      hasConversationHistory: true,
+      updatedAt: Math.max(metadata.updatedAt, receivedAt),
     });
   }
 
@@ -810,7 +662,6 @@ export class AcpAgentClient {
     }
     const cwd = metadata.cwd ?? process.cwd();
     const protocolSessionId = protocolSessionIdForMetadata(metadata);
-    this.suppressLoadReplaySessions.add(protocolSessionId);
     const result = await this.options.transport.request("session/load", {
       cwd,
       mcpServers: [],
@@ -826,6 +677,12 @@ export class AcpAgentClient {
     );
     if (runtimeState) {
       this.updateSessionRuntimeState(metadata.sessionId, runtimeState);
+      void Promise.resolve(
+        this.options.onSessionRuntimeStateChange?.({
+          sessionId: metadata.sessionId,
+          runtimeState,
+        }),
+      ).catch(() => undefined);
     }
     this.notifyRuntimeCapabilities({
       sessionId: metadata.sessionId,
@@ -840,10 +697,6 @@ export class AcpAgentClient {
     return acpRuntimeSupportsSessionLoad(this.runtimeCapabilities);
   }
 
-  private clearLoadReplaySuppression(sessionId: string): void {
-    this.suppressLoadReplaySessions.delete(sessionId);
-  }
-
   private startTrackedTurn(sessionId: string, turnId: string): void {
     if (this.activeTurns.has(sessionId)) {
       throw new Error("A turn is already active for this ACP session.");
@@ -855,10 +708,7 @@ export class AcpAgentClient {
     this.updateSessionStatus(sessionId, "active");
   }
 
-  private finishTrackedTurn(
-    sessionId: string,
-    options?: { persistFinished?: boolean },
-  ): {
+  private finishTrackedTurn(sessionId: string): {
     assistantText: string;
     replay: AppServerThreadReplay;
     turnId?: string;
@@ -869,16 +719,6 @@ export class AcpAgentClient {
       activeTurn?.turnId,
     );
     this.updateSessionStatus(sessionId, "idle");
-    if (activeTurn && options?.persistFinished !== false) {
-      this.persistTranscriptUpdate(sessionId, {
-        receivedAt: this.now(),
-        update: {
-          kind: "turn_finished",
-          outputText: activeTurn.assistantText,
-          turnId: activeTurn.turnId,
-        },
-      });
-    }
     return {
       assistantText: activeTurn?.assistantText ?? "",
       replay,
@@ -893,14 +733,6 @@ export class AcpAgentClient {
   ): AppServerThreadReplay {
     const message = errorMessage(error);
     const receivedAt = this.now();
-    this.persistTranscriptUpdate(sessionId, {
-      receivedAt,
-      update: {
-        kind: "pwragent_turn_failed",
-        turnId,
-        error: message,
-      },
-    });
     const metadata = this.options.store.getSession(this.options.backendId, sessionId);
     if (metadata) {
       this.options.store.upsertSession({
@@ -990,6 +822,15 @@ function protocolSessionIdForMetadata(metadata: AcpSessionMetadata): string {
 function readUpdateKind(update: Record<string, unknown>): string | undefined {
   const kind = update.sessionUpdate ?? update.kind ?? update.type;
   return typeof kind === "string" ? kind : undefined;
+}
+
+function isConversationHistoryUpdate(update: Record<string, unknown>): boolean {
+  const kind = readUpdateKind(update);
+  return (
+    kind === "pwragent_user_prompt" ||
+    kind === "user_message_chunk" ||
+    kind === "agent_message_chunk"
+  );
 }
 
 function readUpdateText(update: Record<string, unknown>): string | undefined {

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -96,6 +96,7 @@ export class AcpAgentClient {
   >();
   private readonly loadedSessionCwds = new Map<string, string | undefined>();
   private readonly suppressLoadReplaySessions = new Set<string>();
+  private readonly suppressedControlPromptSessions = new Set<string>();
   private readonly hydratedTranscriptSessions = new Set<string>();
   private readonly agentSessionIdsByAppSessionId = new Map<string, string>();
   private readonly appSessionIdsByAgentSessionId = new Map<string, string>();
@@ -373,6 +374,22 @@ export class AcpAgentClient {
     });
   }
 
+  async sendControlPrompt(params: {
+    sessionId: string;
+    prompt: string;
+  }): Promise<void> {
+    const protocolSessionId = this.protocolSessionIdFor(params.sessionId);
+    this.suppressedControlPromptSessions.add(protocolSessionId);
+    try {
+      await this.options.transport.request("session/prompt", {
+        sessionId: protocolSessionId,
+        prompt: textPrompt(params.prompt),
+      });
+    } finally {
+      this.suppressedControlPromptSessions.delete(protocolSessionId);
+    }
+  }
+
   async setRuntimeOption(params: {
     sessionId: string;
     source: BackendAcpRuntimeOptionSource;
@@ -465,6 +482,9 @@ export class AcpAgentClient {
       typeof params.sessionId === "string" ? params.sessionId : undefined;
     const update = asRecord(params.update);
     if (!protocolSessionId || !update) {
+      return;
+    }
+    if (this.suppressedControlPromptSessions.has(protocolSessionId)) {
       return;
     }
     const sessionId = this.appSessionIdFor(protocolSessionId);

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -15,6 +15,7 @@ import {
   type AcpSessionUpdate,
 } from "./acp-session-normalizer.js";
 import {
+  acpRuntimeSupportsSessionHistoryReplay,
   acpRuntimeSupportsSessionLoad,
   acpSessionRuntimeStateFromCapabilities,
   acpSessionRuntimeStateFromUpdate,
@@ -862,6 +863,9 @@ export class AcpAgentClient {
     receivedAt: number,
     update: Record<string, unknown>,
   ): void {
+    if (acpRuntimeSupportsSessionHistoryReplay(this.runtimeCapabilities)) {
+      return;
+    }
     this.options.rolloutStore?.appendUpdate({
       backendId: this.options.backendId,
       sessionId,

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -97,7 +97,10 @@ export class AcpAgentClient {
   >();
   private readonly loadedSessionCwds = new Map<string, string | undefined>();
   private readonly suppressLoadReplaySessions = new Set<string>();
-  private readonly suppressedControlPromptSessions = new Set<string>();
+  private readonly suppressedControlPromptSessions = new Map<
+    string,
+    { textChunks: string[] }
+  >();
   private readonly hydratedTranscriptSessions = new Set<string>();
   private readonly agentSessionIdsByAppSessionId = new Map<string, string>();
   private readonly appSessionIdsByAgentSessionId = new Map<string, string>();
@@ -380,14 +383,16 @@ export class AcpAgentClient {
   async sendControlPrompt(params: {
     sessionId: string;
     prompt: string;
-  }): Promise<void> {
+  }): Promise<{ text: string }> {
     const protocolSessionId = this.protocolSessionIdFor(params.sessionId);
-    this.suppressedControlPromptSessions.add(protocolSessionId);
+    const suppression = { textChunks: [] };
+    this.suppressedControlPromptSessions.set(protocolSessionId, suppression);
     try {
       await this.options.transport.request("session/prompt", {
         sessionId: protocolSessionId,
         prompt: textPrompt(params.prompt),
       });
+      return { text: suppression.textChunks.join("\n").trim() };
     } finally {
       this.suppressedControlPromptSessions.delete(protocolSessionId);
     }
@@ -487,7 +492,13 @@ export class AcpAgentClient {
     if (!protocolSessionId || !update) {
       return;
     }
-    if (this.suppressedControlPromptSessions.has(protocolSessionId)) {
+    const suppressedControlPrompt =
+      this.suppressedControlPromptSessions.get(protocolSessionId);
+    if (suppressedControlPrompt) {
+      const text = readUpdateText(update);
+      if (text) {
+        suppressedControlPrompt.textChunks.push(text);
+      }
       return;
     }
     const sessionId = this.appSessionIdFor(protocolSessionId);

--- a/apps/desktop/src/main/acp/acp-live-notifications.ts
+++ b/apps/desktop/src/main/acp/acp-live-notifications.ts
@@ -38,8 +38,10 @@ function liveItemForAcpToolUpdate(
   const toolKind = readString(update, "kind") ?? "tool";
   const id =
     readString(update, "toolCallId") ??
+    readString(update, "tool_call_id") ??
     readString(update, "id") ??
-    readString(update, "itemId");
+    readString(update, "itemId") ??
+    readString(update, "item_id");
   const title =
     readString(update, "title") ??
     readString(update, "command") ??
@@ -128,6 +130,7 @@ function readAcpToolOutput(record: Record<string, unknown>): string | undefined 
 function readKind(update: Record<string, unknown>): string {
   return (
     readString(update, "sessionUpdate") ??
+    readString(update, "session_update") ??
     readString(update, "kind") ??
     readString(update, "type") ??
     "unknown"

--- a/apps/desktop/src/main/acp/acp-local-discovery.ts
+++ b/apps/desktop/src/main/acp/acp-local-discovery.ts
@@ -21,8 +21,13 @@ export async function discoverLocalAcpAgents(options?: {
   probe?: LocalAcpAgentProbe;
   now?: () => number;
 }): Promise<AcpInstalledAgentRecord[]> {
-  const gemini = await discoverLocalGemini(options);
-  return gemini ? [gemini] : [];
+  const discovered = await Promise.all([
+    discoverLocalGemini(options),
+    discoverLocalKimi(options),
+  ]);
+  return discovered.filter((agent): agent is AcpInstalledAgentRecord =>
+    Boolean(agent)
+  );
 }
 
 async function discoverLocalGemini(options?: {
@@ -82,6 +87,63 @@ async function discoverLocalGemini(options?: {
   };
 }
 
+async function discoverLocalKimi(options?: {
+  probe?: LocalAcpAgentProbe;
+  now?: () => number;
+}): Promise<AcpInstalledAgentRecord | undefined> {
+  const probe = options?.probe ?? defaultProbe;
+  const [versionResult, acpHelpResult] = await Promise.all([
+    probeCommand(probe, "kimi", ["--version"]),
+    probeCommand(probe, "kimi", ["acp", "--help"]),
+  ]);
+  if (!versionResult || !acpHelpResult) {
+    return undefined;
+  }
+
+  const acpHelpText = resultText(acpHelpResult);
+  if (!/\bACP server\b/i.test(acpHelpText)) {
+    return undefined;
+  }
+
+  const now = options?.now?.() ?? Date.now();
+  const backendId = "acp:kimi" as AcpBackendId;
+  const version = parseCliVersion(resultText(versionResult));
+  return {
+    backendId,
+    registryId: "kimi",
+    name: "Kimi Code CLI",
+    version,
+    distributionKind: "local",
+    distributionSource: "kimi acp",
+    installStatus: "installed",
+    authStatus: "not-required",
+    verificationStatus: "not-applicable",
+    allowlistRuleId: "local-kimi-cli",
+    installedAt: now,
+    updatedAt: now,
+    capabilities: acpAgentCapabilitiesForRegistryId("kimi"),
+    launchDescriptor: normalizeAcpLaunchDescriptor({
+      backendId,
+      registryId: "kimi",
+      distributionKind: "local",
+      command: "kimi",
+      args: ["acp"],
+      env: {},
+    }),
+    registryAgent: {
+      id: "kimi",
+      backendId,
+      name: "Kimi Code CLI",
+      version,
+      authors: ["Moonshot AI"],
+      distributions: [],
+      distributionKinds: ["local"],
+      auth: { required: false, methods: ["agent-managed"] },
+      raw: { source: "local-cli" },
+    },
+  };
+}
+
 async function defaultProbe(
   command: string,
   args: string[],
@@ -112,6 +174,10 @@ function resultText(result: LocalAcpProbeResult): string {
 }
 
 function parseGeminiVersion(output: string): string | undefined {
+  return parseCliVersion(output);
+}
+
+function parseCliVersion(output: string): string | undefined {
   const trimmed = output.trim();
   if (!trimmed) {
     return undefined;

--- a/apps/desktop/src/main/acp/acp-local-discovery.ts
+++ b/apps/desktop/src/main/acp/acp-local-discovery.ts
@@ -122,6 +122,16 @@ async function discoverLocalKimi(options?: {
     installedAt: now,
     updatedAt: now,
     capabilities: acpAgentCapabilitiesForRegistryId("kimi"),
+    runtimeCapabilities: {
+      schemaVersion: 1,
+      status: "discovered",
+      discoveredAt: now,
+      checkedAt: now,
+      source: "local-probe",
+      agentCapabilities: {
+        loadSession: false,
+      },
+    },
     launchDescriptor: normalizeAcpLaunchDescriptor({
       backendId,
       registryId: "kimi",

--- a/apps/desktop/src/main/acp/acp-local-discovery.ts
+++ b/apps/desktop/src/main/acp/acp-local-discovery.ts
@@ -122,16 +122,6 @@ async function discoverLocalKimi(options?: {
     installedAt: now,
     updatedAt: now,
     capabilities: acpAgentCapabilitiesForRegistryId("kimi"),
-    runtimeCapabilities: {
-      schemaVersion: 1,
-      status: "discovered",
-      discoveredAt: now,
-      checkedAt: now,
-      source: "local-probe",
-      agentCapabilities: {
-        loadSession: false,
-      },
-    },
     launchDescriptor: normalizeAcpLaunchDescriptor({
       backendId,
       registryId: "kimi",

--- a/apps/desktop/src/main/acp/acp-rollout-store.ts
+++ b/apps/desktop/src/main/acp/acp-rollout-store.ts
@@ -20,7 +20,18 @@ export type AcpRolloutStoreAppendParams = {
   update: Record<string, unknown>;
 };
 
+type ChunkBuffer = {
+  backendId: AcpBackendId;
+  receivedAt: number;
+  sessionId: string;
+  update: Record<string, unknown>;
+  text: string;
+};
+
+const CHUNK_FLUSH_TEXT_LENGTH = 2_048;
+
 export class AcpRolloutStore {
+  private readonly chunkBuffers = new Map<string, ChunkBuffer>();
   private readonly lastFingerprints = new Map<string, string>();
 
   constructor(private readonly rootDir: string) {}
@@ -29,6 +40,13 @@ export class AcpRolloutStore {
     if (!shouldPersistUpdate(params.update)) {
       return;
     }
+    const chunkKey = streamingChunkKey(params);
+    if (chunkKey) {
+      this.appendChunk(chunkKey, params);
+      return;
+    }
+    this.flushSession(params.backendId, params.sessionId);
+
     const duplicateKey = updateDuplicateKey(params);
     const fingerprint = updateFingerprint(params.update);
     if (duplicateKey && fingerprint) {
@@ -39,23 +57,14 @@ export class AcpRolloutStore {
       this.lastFingerprints.set(duplicateKey, fingerprint);
     }
 
-    const rolloutPath = this.rolloutPath(params.backendId, params.sessionId);
-    fs.mkdirSync(path.dirname(rolloutPath), { recursive: true });
-    fs.appendFileSync(
-      rolloutPath,
-      `${JSON.stringify({
-        type: "update",
-        receivedAt: params.receivedAt,
-        update: params.update,
-      } satisfies AcpRolloutRecord)}\n`,
-      "utf8",
-    );
+    this.writeRecord(params);
   }
 
   readUpdates(params: {
     backendId: AcpBackendId;
     sessionId: string;
   }): AcpRolloutRecord[] {
+    this.flushSession(params.backendId, params.sessionId);
     const rolloutPath = this.rolloutPath(params.backendId, params.sessionId);
     if (!fs.existsSync(rolloutPath)) {
       return [];
@@ -87,6 +96,78 @@ export class AcpRolloutStore {
     return normalizer.replay();
   }
 
+  flushAll(): void {
+    for (const key of [...this.chunkBuffers.keys()]) {
+      this.flushChunk(key);
+    }
+  }
+
+  private appendChunk(
+    chunkKey: string,
+    params: AcpRolloutStoreAppendParams,
+  ): void {
+    const text = readUpdateText(params.update);
+    if (!text) {
+      return;
+    }
+    const existing = this.chunkBuffers.get(chunkKey);
+    if (existing) {
+      existing.text += text;
+      if (existing.text.length >= CHUNK_FLUSH_TEXT_LENGTH) {
+        this.flushChunk(chunkKey);
+      }
+      return;
+    }
+
+    this.chunkBuffers.set(chunkKey, {
+      backendId: params.backendId,
+      receivedAt: params.receivedAt,
+      sessionId: params.sessionId,
+      update: params.update,
+      text,
+    });
+    if (text.length >= CHUNK_FLUSH_TEXT_LENGTH) {
+      this.flushChunk(chunkKey);
+    }
+  }
+
+  private flushSession(backendId: AcpBackendId, sessionId: string): void {
+    const prefix = `${backendId}:${sessionId}:`;
+    for (const key of [...this.chunkBuffers.keys()]) {
+      if (key.startsWith(prefix)) {
+        this.flushChunk(key);
+      }
+    }
+  }
+
+  private flushChunk(chunkKey: string): void {
+    const buffer = this.chunkBuffers.get(chunkKey);
+    if (!buffer) {
+      return;
+    }
+    this.chunkBuffers.delete(chunkKey);
+    this.writeRecord({
+      backendId: buffer.backendId,
+      sessionId: buffer.sessionId,
+      receivedAt: buffer.receivedAt,
+      update: updateWithText(buffer.update, buffer.text),
+    });
+  }
+
+  private writeRecord(params: AcpRolloutStoreAppendParams): void {
+    const rolloutPath = this.rolloutPath(params.backendId, params.sessionId);
+    fs.mkdirSync(path.dirname(rolloutPath), { recursive: true });
+    fs.appendFileSync(
+      rolloutPath,
+      `${JSON.stringify({
+        type: "update",
+        receivedAt: params.receivedAt,
+        update: params.update,
+      } satisfies AcpRolloutRecord)}\n`,
+      "utf8",
+    );
+  }
+
   private rolloutPath(backendId: AcpBackendId, sessionId: string): string {
     return path.join(
       this.rootDir,
@@ -110,6 +191,21 @@ function shouldPersistUpdate(update: Record<string, unknown>): boolean {
     return false;
   }
   return kind !== "unknown";
+}
+
+function streamingChunkKey(
+  params: AcpRolloutStoreAppendParams,
+): string | undefined {
+  const kind = readKind(params.update);
+  if (kind !== "agent_message_chunk" && kind !== "agent_thought_chunk") {
+    return undefined;
+  }
+  const id =
+    readString(params.update, "messageId") ??
+    readString(params.update, "message_id") ??
+    readString(params.update, "id") ??
+    "default";
+  return `${params.backendId}:${params.sessionId}:${kind}:${id}`;
 }
 
 function updateDuplicateKey(
@@ -145,6 +241,30 @@ function updateFingerprint(update: Record<string, unknown>): string | undefined 
     status: readString(update, "status"),
     title: readString(update, "title"),
   });
+}
+
+function readUpdateText(update: Record<string, unknown>): string | undefined {
+  return readAcpContentText(update.content) ?? readString(update, "text");
+}
+
+function updateWithText(
+  update: Record<string, unknown>,
+  text: string,
+): Record<string, unknown> {
+  const content = update.content;
+  if (content && typeof content === "object" && !Array.isArray(content)) {
+    return {
+      ...update,
+      content: {
+        ...content,
+        text,
+      },
+    };
+  }
+  return {
+    ...update,
+    text,
+  };
 }
 
 function readKind(update: Record<string, unknown>): string {

--- a/apps/desktop/src/main/acp/acp-rollout-store.ts
+++ b/apps/desktop/src/main/acp/acp-rollout-store.ts
@@ -1,0 +1,200 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { AcpBackendId, AppServerThreadReplay } from "@pwragent/shared";
+import {
+  AcpSessionReplayNormalizer,
+  readAcpContentText,
+  readAcpTopicTitle,
+} from "./acp-session-normalizer.js";
+
+export type AcpRolloutRecord = {
+  type: "update";
+  receivedAt: number;
+  update: Record<string, unknown>;
+};
+
+export type AcpRolloutStoreAppendParams = {
+  backendId: AcpBackendId;
+  sessionId: string;
+  receivedAt: number;
+  update: Record<string, unknown>;
+};
+
+export class AcpRolloutStore {
+  private readonly lastFingerprints = new Map<string, string>();
+
+  constructor(private readonly rootDir: string) {}
+
+  appendUpdate(params: AcpRolloutStoreAppendParams): void {
+    if (!shouldPersistUpdate(params.update)) {
+      return;
+    }
+    const duplicateKey = updateDuplicateKey(params);
+    const fingerprint = updateFingerprint(params.update);
+    if (duplicateKey && fingerprint) {
+      const previous = this.lastFingerprints.get(duplicateKey);
+      if (previous === fingerprint) {
+        return;
+      }
+      this.lastFingerprints.set(duplicateKey, fingerprint);
+    }
+
+    const rolloutPath = this.rolloutPath(params.backendId, params.sessionId);
+    fs.mkdirSync(path.dirname(rolloutPath), { recursive: true });
+    fs.appendFileSync(
+      rolloutPath,
+      `${JSON.stringify({
+        type: "update",
+        receivedAt: params.receivedAt,
+        update: params.update,
+      } satisfies AcpRolloutRecord)}\n`,
+      "utf8",
+    );
+  }
+
+  readUpdates(params: {
+    backendId: AcpBackendId;
+    sessionId: string;
+  }): AcpRolloutRecord[] {
+    const rolloutPath = this.rolloutPath(params.backendId, params.sessionId);
+    if (!fs.existsSync(rolloutPath)) {
+      return [];
+    }
+    return fs
+      .readFileSync(rolloutPath, "utf8")
+      .split(/\r?\n/)
+      .flatMap((line) => {
+        if (!line.trim()) {
+          return [];
+        }
+        const parsed = parseJson(line);
+        return isRolloutRecord(parsed) ? [parsed] : [];
+      });
+  }
+
+  readReplay(params: {
+    backendId: AcpBackendId;
+    sessionId: string;
+  }): AppServerThreadReplay {
+    const normalizer = new AcpSessionReplayNormalizer();
+    for (const record of this.readUpdates(params)) {
+      normalizer.apply({
+        sessionId: params.sessionId,
+        receivedAt: record.receivedAt,
+        update: record.update,
+      });
+    }
+    return normalizer.replay();
+  }
+
+  private rolloutPath(backendId: AcpBackendId, sessionId: string): string {
+    return path.join(
+      this.rootDir,
+      encodePathSegment(backendId),
+      encodePathSegment(sessionId),
+      "rollout.jsonl",
+    );
+  }
+}
+
+function shouldPersistUpdate(update: Record<string, unknown>): boolean {
+  const kind = readKind(update);
+  if (
+    kind === "available_commands_update" ||
+    kind === "config_option_update" ||
+    kind === "current_mode_update"
+  ) {
+    return false;
+  }
+  if (readAcpTopicTitle(update)) {
+    return false;
+  }
+  return kind !== "unknown";
+}
+
+function updateDuplicateKey(
+  params: AcpRolloutStoreAppendParams,
+): string | undefined {
+  const kind = readKind(params.update);
+  if (kind !== "tool_call" && kind !== "tool_call_update") {
+    return undefined;
+  }
+  const id =
+    readString(params.update, "toolCallId") ??
+    readString(params.update, "tool_call_id") ??
+    readString(params.update, "id") ??
+    readString(params.update, "itemId") ??
+    readString(params.update, "item_id") ??
+    readString(params.update, "title");
+  return id
+    ? `${params.backendId}:${params.sessionId}:${kind}:${id}`
+    : undefined;
+}
+
+function updateFingerprint(update: Record<string, unknown>): string | undefined {
+  const kind = readKind(update);
+  if (kind !== "tool_call" && kind !== "tool_call_update") {
+    return undefined;
+  }
+  const content = readAcpContentText(update.content) ?? "";
+  return JSON.stringify({
+    command: readString(update, "command"),
+    contentHash: hashString(content),
+    contentLength: content.length,
+    kind,
+    status: readString(update, "status"),
+    title: readString(update, "title"),
+  });
+}
+
+function readKind(update: Record<string, unknown>): string {
+  return (
+    readString(update, "sessionUpdate") ??
+    readString(update, "session_update") ??
+    readString(update, "kind") ??
+    readString(update, "type") ??
+    "unknown"
+  );
+}
+
+function readString(
+  record: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const value = record[key];
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function hashString(value: string): string {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 31 + value.charCodeAt(index)) | 0;
+  }
+  return hash.toString(16);
+}
+
+function encodePathSegment(value: string): string {
+  return encodeURIComponent(value).replaceAll("%", "_");
+}
+
+function parseJson(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function isRolloutRecord(value: unknown): value is AcpRolloutRecord {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return (
+    record.type === "update" &&
+    typeof record.receivedAt === "number" &&
+    record.update !== null &&
+    typeof record.update === "object" &&
+    !Array.isArray(record.update)
+  );
+}

--- a/apps/desktop/src/main/acp/acp-runtime-capabilities.ts
+++ b/apps/desktop/src/main/acp/acp-runtime-capabilities.ts
@@ -108,7 +108,8 @@ export function acpSessionRuntimeStateFromUpdate(
   update: Record<string, unknown>,
   now: number,
 ): BackendAcpSessionRuntimeState | undefined {
-  const kind = update.sessionUpdate ?? update.kind ?? update.type;
+  const kind =
+    update.sessionUpdate ?? update.session_update ?? update.kind ?? update.type;
   if (kind === "agent_message_chunk") {
     const modeId = readModeUpdateMarker(update);
     return modeId ? { currentModeId: modeId, updatedAt: now } : undefined;
@@ -116,7 +117,9 @@ export function acpSessionRuntimeStateFromUpdate(
   if (kind === "current_mode_update") {
     const currentModeId =
       readString(update, "currentModeId") ??
+      readString(update, "current_mode_id") ??
       readString(update, "modeId") ??
+      readString(update, "mode_id") ??
       readString(update, "id");
     return currentModeId ? { currentModeId, updatedAt: now } : undefined;
   }

--- a/apps/desktop/src/main/acp/acp-runtime-capabilities.ts
+++ b/apps/desktop/src/main/acp/acp-runtime-capabilities.ts
@@ -22,12 +22,15 @@ export function normalizeAcpRuntimeCapabilities(params: {
   const modes = readModes(record.modes);
   const models = readModels(record.models);
   const agentCapabilities = readAgentCapabilities(
-    record.agentCapabilities ?? record.capabilities,
+    record.agentCapabilities ?? record.agent_capabilities ?? record.capabilities,
+    record.sessionCapabilities ?? record.session_capabilities,
   );
   const agentInfo = readAgentInfo(record.agentInfo ?? record.agent_info);
   const protocolVersion =
     typeof record.protocolVersion === "number"
       ? record.protocolVersion
+      : typeof record.protocol_version === "number"
+        ? record.protocol_version
       : params.initialize?.protocolVersion;
 
   const hasRuntimeData =
@@ -102,6 +105,12 @@ export function acpRuntimeSupportsSessionLoad(
   capabilities: BackendAcpRuntimeCapabilities | undefined,
 ): boolean {
   return capabilities?.agentCapabilities?.loadSession !== false;
+}
+
+export function acpRuntimeSupportsSessionHistoryReplay(
+  capabilities: BackendAcpRuntimeCapabilities | undefined,
+): boolean {
+  return capabilities?.agentCapabilities?.sessionHistoryReplay === true;
 }
 
 export function acpSessionRuntimeStateFromUpdate(
@@ -268,26 +277,39 @@ function readModel(value: unknown): BackendAcpRuntimeModel[] {
 
 function readAgentCapabilities(
   value: unknown,
+  sessionCapabilitiesValue?: unknown,
 ): BackendAcpRuntimeCapabilities["agentCapabilities"] {
   const record = asRecord(value);
-  if (!record) {
+  const sessionCapabilities = asRecord(sessionCapabilitiesValue);
+  const sessionMeta = asRecord(sessionCapabilities?._meta);
+  const kimiMeta = asRecord(sessionMeta?.kimi);
+  if (!record && !sessionCapabilities) {
     return undefined;
   }
   const loadSession =
-    readBoolean(record, "loadSession") ?? readBoolean(asRecord(record.session), "load");
-  const close = readBoolean(asRecord(record.session), "close");
-  const cancel = readBoolean(asRecord(record.session), "cancel");
+    readBoolean(record, "loadSession") ??
+    readBoolean(record, "load_session") ??
+    readBoolean(asRecord(record?.session), "load");
+  const close = readBoolean(asRecord(record?.session), "close");
+  const cancel = readBoolean(asRecord(record?.session), "cancel");
+  const sessionHistoryReplay =
+    readBoolean(kimiMeta, "sessionHistoryReplay") ??
+    readBoolean(kimiMeta, "session_history_replay");
   const hasData =
-    loadSession !== undefined || close !== undefined || cancel !== undefined;
+    loadSession !== undefined ||
+    close !== undefined ||
+    cancel !== undefined ||
+    sessionHistoryReplay !== undefined;
   return hasData
     ? {
         ...(loadSession !== undefined ? { loadSession } : {}),
+        ...(sessionHistoryReplay !== undefined ? { sessionHistoryReplay } : {}),
         ...(close !== undefined || cancel !== undefined
           ? { session: { ...(close !== undefined ? { close } : {}), ...(cancel !== undefined ? { cancel } : {}) } }
           : {}),
-        raw: record,
+        raw: record ?? sessionCapabilities,
       }
-    : { raw: record };
+    : { raw: record ?? sessionCapabilities };
 }
 
 function readAgentInfo(value: unknown): BackendAcpRuntimeCapabilities["agentInfo"] {

--- a/apps/desktop/src/main/acp/acp-session-normalizer.ts
+++ b/apps/desktop/src/main/acp/acp-session-normalizer.ts
@@ -202,10 +202,9 @@ export class AcpSessionReplayNormalizer {
     }
     const id =
       readString(update.update, "messageId") ??
-      `thought:${this.currentTurnId ?? update.sessionId}`;
+      `assistant:${this.currentTurnId ?? update.sessionId}`;
     this.appendMessageChunk({
       id,
-      phase: "commentary",
       role: "assistant",
       text,
       createdAt,

--- a/apps/desktop/src/main/acp/acp-session-normalizer.ts
+++ b/apps/desktop/src/main/acp/acp-session-normalizer.ts
@@ -21,6 +21,8 @@ export class AcpSessionReplayNormalizer {
   private messages: AppServerThreadMessage[] = [];
   private status: AppServerThreadStatus = "idle";
   private currentTurnId?: string;
+  private activeAssistantMessageId?: string;
+  private assistantMessageSequence = 0;
   private generatedMessageSequence = 0;
 
   recordUserPrompt(params: {
@@ -34,6 +36,8 @@ export class AcpSessionReplayNormalizer {
     const id = `user:${params.turnId}`;
     const normalizedPrompt = normalizeUserPrompt(params.prompt, params.parts);
     this.currentTurnId = params.turnId;
+    this.activeAssistantMessageId = undefined;
+    this.assistantMessageSequence = 0;
     this.upsertMessage({
       id,
       role: "user",
@@ -49,6 +53,7 @@ export class AcpSessionReplayNormalizer {
     if (!turnId || this.currentTurnId === turnId) {
       this.currentTurnId = undefined;
     }
+    this.activeAssistantMessageId = undefined;
     this.status = "idle";
     return this.replay();
   }
@@ -63,6 +68,7 @@ export class AcpSessionReplayNormalizer {
     if (this.currentTurnId === params.turnId) {
       this.currentTurnId = undefined;
     }
+    this.activeAssistantMessageId = undefined;
     this.status = "idle";
     this.upsertActivity({
       type: "activity",
@@ -91,46 +97,56 @@ export class AcpSessionReplayNormalizer {
   apply(update: AcpSessionUpdate): AppServerThreadReplay {
     const kind = readKind(update.update);
     const createdAt = update.receivedAt ?? Date.now();
+    const isAssistantTextUpdate =
+      kind === "agent_message_chunk" || kind === "agent_thought_chunk";
 
-    if (kind === "agent_message_chunk") {
-      this.applyAgentMessageChunk(update, createdAt);
+    if (isAssistantTextUpdate) {
+      // Consecutive ACP text chunks form one live bubble, but text after a tool
+      // call should become a new bubble instead of overwriting earlier text.
+      if (kind === "agent_message_chunk") {
+        this.applyAgentMessageChunk(update, createdAt);
+      } else {
+        this.applyAgentThoughtChunk(update, createdAt);
+      }
     } else if (kind === "user_message_chunk") {
+      this.activeAssistantMessageId = undefined;
       this.applyUserMessageChunk(update, createdAt);
-    } else if (kind === "agent_thought_chunk") {
-      this.applyAgentThoughtChunk(update, createdAt);
     } else if (kind === "available_commands_update") {
       // Command metadata belongs in provider capabilities, not the transcript.
     } else if (kind === "config_option_update" || kind === "current_mode_update") {
       // Runtime configuration changes belong in ACP session metadata.
     } else if (readAcpTopicTitle(update.update)) {
       // Topic updates are thread metadata, not transcript entries.
-    } else if (kind === "plan") {
-      this.upsertPlan(update, createdAt);
-    } else if (kind === "tool_call" || kind === "tool_call_update") {
-      this.upsertActivity(toolActivity(update, kind, createdAt));
-    } else if (kind === "file" || kind === "terminal") {
-      this.upsertActivity(toolActivity(update, kind, createdAt));
-    } else if (kind === "turn_started") {
-      this.status = "active";
-    } else if (kind === "turn_finished") {
-      this.recordTurnFinished(readString(update.update, "turnId"));
-    } else if (kind === "pwragent_turn_failed") {
-      this.recordTurnFailed({
-        sessionId: update.sessionId,
-        turnId: readString(update.update, "turnId") ?? `pending:${update.sessionId}`,
-        error: readString(update.update, "error") ?? "Turn failed.",
-        receivedAt: createdAt,
-      });
-    } else if (kind === "pwragent_user_prompt") {
-      this.recordUserPrompt({
-        sessionId: update.sessionId,
-        prompt: readString(update.update, "prompt") ?? "",
-        parts: readMessageParts(update.update),
-        turnId: readString(update.update, "turnId") ?? `pending:${update.sessionId}`,
-        receivedAt: createdAt,
-      });
     } else {
-      this.upsertActivity(unknownActivity(update, kind, createdAt));
+      this.activeAssistantMessageId = undefined;
+      if (kind === "plan") {
+        this.upsertPlan(update, createdAt);
+      } else if (kind === "tool_call" || kind === "tool_call_update") {
+        this.upsertActivity(toolActivity(update, kind, createdAt));
+      } else if (kind === "file" || kind === "terminal") {
+        this.upsertActivity(toolActivity(update, kind, createdAt));
+      } else if (kind === "turn_started") {
+        this.status = "active";
+      } else if (kind === "turn_finished") {
+        this.recordTurnFinished(readString(update.update, "turnId"));
+      } else if (kind === "pwragent_turn_failed") {
+        this.recordTurnFailed({
+          sessionId: update.sessionId,
+          turnId: readString(update.update, "turnId") ?? `pending:${update.sessionId}`,
+          error: readString(update.update, "error") ?? "Turn failed.",
+          receivedAt: createdAt,
+        });
+      } else if (kind === "pwragent_user_prompt") {
+        this.recordUserPrompt({
+          sessionId: update.sessionId,
+          prompt: readString(update.update, "prompt") ?? "",
+          parts: readMessageParts(update.update),
+          turnId: readString(update.update, "turnId") ?? `pending:${update.sessionId}`,
+          receivedAt: createdAt,
+        });
+      } else {
+        this.upsertActivity(unknownActivity(update, kind, createdAt));
+      }
     }
 
     return this.replay();
@@ -162,9 +178,7 @@ export class AcpSessionReplayNormalizer {
     if (isModeUpdateMarker(text)) {
       return;
     }
-    const id =
-      readString(update.update, "messageId") ??
-      `assistant:${this.currentTurnId ?? update.sessionId}`;
+    const id = this.assistantMessageIdForChunk(update);
     this.appendMessageChunk({ id, role: "assistant", text, createdAt });
   }
 
@@ -200,15 +214,28 @@ export class AcpSessionReplayNormalizer {
     if (!text) {
       return;
     }
-    const id =
-      readString(update.update, "messageId") ??
-      `assistant:${this.currentTurnId ?? update.sessionId}`;
+    const id = this.assistantMessageIdForChunk(update);
     this.appendMessageChunk({
       id,
       role: "assistant",
       text,
       createdAt,
     });
+  }
+
+  private assistantMessageIdForChunk(update: AcpSessionUpdate): string {
+    const explicitId =
+      readString(update.update, "messageId") ??
+      readString(update.update, "message_id");
+    if (explicitId) {
+      this.activeAssistantMessageId = explicitId;
+      return explicitId;
+    }
+    if (!this.activeAssistantMessageId) {
+      this.activeAssistantMessageId =
+        `assistant:${this.currentTurnId ?? update.sessionId}:${this.assistantMessageSequence++}`;
+    }
+    return this.activeAssistantMessageId;
   }
 
   private upsertPlan(update: AcpSessionUpdate, createdAt: number): void {

--- a/apps/desktop/src/main/acp/acp-session-normalizer.ts
+++ b/apps/desktop/src/main/acp/acp-session-normalizer.ts
@@ -330,6 +330,7 @@ function shouldSeparateTranscriptChunks(existing: string, next: string): boolean
 function readKind(update: Record<string, unknown>): string {
   return (
     readString(update, "sessionUpdate") ??
+    readString(update, "session_update") ??
     readString(update, "kind") ??
     readString(update, "type") ??
     "unknown"
@@ -339,7 +340,8 @@ function readKind(update: Record<string, unknown>): string {
 export function readAcpTopicTitle(
   update: Record<string, unknown>,
 ): string | undefined {
-  const sessionUpdate = readString(update, "sessionUpdate");
+  const sessionUpdate =
+    readString(update, "sessionUpdate") ?? readString(update, "session_update");
   const kind = readString(update, "kind");
   const isToolUpdate =
     sessionUpdate === "tool_call" ||
@@ -532,7 +534,10 @@ function toolActivity(
 ): AppServerThreadActivityEntry {
   const id =
     readString(update.update, "toolCallId") ??
+    readString(update.update, "tool_call_id") ??
     readString(update.update, "id") ??
+    readString(update.update, "itemId") ??
+    readString(update.update, "item_id") ??
     `${kind}:${update.sessionId}`;
   const label =
     readString(update.update, "title") ??

--- a/apps/desktop/src/main/acp/acp-session-store.ts
+++ b/apps/desktop/src/main/acp/acp-session-store.ts
@@ -22,13 +22,13 @@ export type AcpSessionMetadata = {
   executionMode: ThreadExecutionMode;
   acpRuntime?: BackendAcpSessionRuntimeState;
   status: "active" | "idle" | "failed" | "unknown";
+  hasConversationHistory?: boolean;
   requiresAgentSessionRebind?: boolean;
   archivedAt?: number;
   lastError?: string;
-  transcriptUpdates?: AcpPersistedTranscriptUpdate[];
 };
 
-export type AcpPersistedTranscriptUpdate = {
+type AcpPersistedTranscriptUpdate = {
   receivedAt: number;
   update: Record<string, unknown>;
 };
@@ -37,7 +37,7 @@ export class AcpSessionStore {
   constructor(private readonly stateDb: StateDb) {}
 
   upsertSession(metadata: AcpSessionMetadata): void {
-    const compactedMetadata = compactAcpSessionMetadata(metadata);
+    const persistableMetadata = stripAcpSessionHistory(metadata);
     this.stateDb.raw
       .prepare(
         `INSERT OR REPLACE INTO acp_sessions(
@@ -50,11 +50,11 @@ export class AcpSessionStore {
          VALUES (?, ?, ?, ?, ?)`,
       )
       .run(
-        compactedMetadata.backendId,
-        compactedMetadata.sessionId,
-        compactedMetadata.createdAt,
-        compactedMetadata.updatedAt,
-        JSON.stringify(compactedMetadata),
+        persistableMetadata.backendId,
+        persistableMetadata.sessionId,
+        persistableMetadata.createdAt,
+        persistableMetadata.updatedAt,
+        JSON.stringify(persistableMetadata),
       );
   }
 
@@ -75,7 +75,9 @@ export class AcpSessionStore {
       if (!isSessionMetadata(parsed)) {
         return [];
       }
-      return Boolean(parsed.archivedAt) === archived ? [parsed] : [];
+      return Boolean(parsed.archivedAt) === archived
+        ? [stripAcpSessionHistory(parsed)]
+        : [];
     });
   }
 
@@ -90,122 +92,8 @@ export class AcpSessionStore {
       )
       .get(backendId, sessionId) as { payload: string } | undefined;
     const parsed = row ? parseJson(row.payload) : undefined;
-    return isSessionMetadata(parsed) ? parsed : undefined;
+    return isSessionMetadata(parsed) ? stripAcpSessionHistory(parsed) : undefined;
   }
-}
-
-function compactAcpSessionMetadata(metadata: AcpSessionMetadata): AcpSessionMetadata {
-  if (!metadata.transcriptUpdates?.length) {
-    return metadata;
-  }
-  return {
-    ...metadata,
-    transcriptUpdates: compactAcpTranscriptUpdates(metadata.transcriptUpdates),
-  };
-}
-
-export function compactAcpTranscriptUpdates(
-  updates: AcpPersistedTranscriptUpdate[],
-): AcpPersistedTranscriptUpdate[] {
-  const compacted: AcpPersistedTranscriptUpdate[] = [];
-  for (const update of updates) {
-    appendCoalescedTranscriptUpdate(compacted, update);
-  }
-  return compacted;
-}
-
-export function appendCoalescedTranscriptUpdate(
-  updates: AcpPersistedTranscriptUpdate[],
-  next: AcpPersistedTranscriptUpdate,
-): void {
-  const previous = updates.at(-1);
-  const coalesced = previous ? coalesceTranscriptUpdate(previous, next) : undefined;
-  if (coalesced) {
-    updates[updates.length - 1] = coalesced;
-    return;
-  }
-  updates.push(next);
-}
-
-function coalesceTranscriptUpdate(
-  previous: AcpPersistedTranscriptUpdate,
-  next: AcpPersistedTranscriptUpdate,
-): AcpPersistedTranscriptUpdate | undefined {
-  const previousKind = readUpdateKind(previous.update);
-  const nextKind = readUpdateKind(next.update);
-  if (
-    previousKind !== nextKind ||
-    !isCoalescibleTranscriptChunkKind(previousKind)
-  ) {
-    return undefined;
-  }
-  if (messageIdentity(previous.update) !== messageIdentity(next.update)) {
-    return undefined;
-  }
-  const previousText = readUpdateText(previous.update);
-  const nextText = readUpdateText(next.update);
-  if (previousText === undefined || nextText === undefined) {
-    return undefined;
-  }
-  return {
-    receivedAt: next.receivedAt,
-    update: writeUpdateText(previous.update, `${previousText}${nextText}`),
-  };
-}
-
-function readUpdateKind(update: Record<string, unknown>): string | undefined {
-  const kind = update.sessionUpdate ?? update.kind ?? update.type;
-  return typeof kind === "string" ? kind : undefined;
-}
-
-function isCoalescibleTranscriptChunkKind(kind: string | undefined): boolean {
-  return (
-    kind === "agent_message_chunk" ||
-    kind === "agent_thought_chunk" ||
-    kind === "user_message_chunk"
-  );
-}
-
-function messageIdentity(update: Record<string, unknown>): string {
-  const messageId = update.messageId ?? update.id;
-  return typeof messageId === "string" ? messageId : "";
-}
-
-function readUpdateText(update: Record<string, unknown>): string | undefined {
-  if (typeof update.text === "string") {
-    return update.text;
-  }
-  const content = update.content;
-  if (!content || typeof content !== "object" || Array.isArray(content)) {
-    return undefined;
-  }
-  const contentRecord = content as Record<string, unknown>;
-  return contentRecord.type === "text" && typeof contentRecord.text === "string"
-    ? contentRecord.text
-    : undefined;
-}
-
-function writeUpdateText(
-  update: Record<string, unknown>,
-  text: string,
-): Record<string, unknown> {
-  if (typeof update.text === "string") {
-    return { ...update, text };
-  }
-  const content = update.content;
-  if (content && typeof content === "object" && !Array.isArray(content)) {
-    const contentRecord = content as Record<string, unknown>;
-    if (contentRecord.type === "text" && typeof contentRecord.text === "string") {
-      return {
-        ...update,
-        content: {
-          ...contentRecord,
-          text,
-        },
-      };
-    }
-  }
-  return update;
 }
 
 function parseJson(value: string): unknown {
@@ -214,6 +102,53 @@ function parseJson(value: string): unknown {
   } catch {
     return undefined;
   }
+}
+
+function stripAcpSessionHistory(metadata: AcpSessionMetadata): AcpSessionMetadata {
+  const legacyTranscriptUpdates = readLegacyTranscriptUpdates(metadata);
+  const {
+    transcriptUpdates: _transcriptUpdates,
+    ...metadataWithoutHistory
+  } = metadata as AcpSessionMetadata & {
+    transcriptUpdates?: AcpPersistedTranscriptUpdate[];
+  };
+  const hasConversationHistory =
+    metadata.hasConversationHistory ??
+    (legacyTranscriptUpdates.some(isConversationTranscriptUpdate) || undefined);
+  return {
+    ...metadataWithoutHistory,
+    ...(hasConversationHistory === undefined ? {} : { hasConversationHistory }),
+  };
+}
+
+function readLegacyTranscriptUpdates(
+  metadata: AcpSessionMetadata,
+): AcpPersistedTranscriptUpdate[] {
+  const value = (metadata as { transcriptUpdates?: unknown }).transcriptUpdates;
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.flatMap((item) => {
+    const record = item as Partial<AcpPersistedTranscriptUpdate>;
+    return typeof record.receivedAt === "number" &&
+      record.update &&
+      typeof record.update === "object" &&
+      !Array.isArray(record.update)
+      ? [{ receivedAt: record.receivedAt, update: record.update }]
+      : [];
+  });
+}
+
+function isConversationTranscriptUpdate(
+  item: AcpPersistedTranscriptUpdate,
+): boolean {
+  const update = item.update;
+  const kind = update.kind ?? update.type ?? update.sessionUpdate;
+  return (
+    kind === "pwragent_user_prompt" ||
+    kind === "user_message_chunk" ||
+    kind === "agent_message_chunk"
+  );
 }
 
 function isSessionMetadata(value: unknown): value is AcpSessionMetadata {

--- a/apps/desktop/src/main/acp/acp-session-store.ts
+++ b/apps/desktop/src/main/acp/acp-session-store.ts
@@ -37,6 +37,7 @@ export class AcpSessionStore {
   constructor(private readonly stateDb: StateDb) {}
 
   upsertSession(metadata: AcpSessionMetadata): void {
+    const compactedMetadata = compactAcpSessionMetadata(metadata);
     this.stateDb.raw
       .prepare(
         `INSERT OR REPLACE INTO acp_sessions(
@@ -49,11 +50,11 @@ export class AcpSessionStore {
          VALUES (?, ?, ?, ?, ?)`,
       )
       .run(
-        metadata.backendId,
-        metadata.sessionId,
-        metadata.createdAt,
-        metadata.updatedAt,
-        JSON.stringify(metadata),
+        compactedMetadata.backendId,
+        compactedMetadata.sessionId,
+        compactedMetadata.createdAt,
+        compactedMetadata.updatedAt,
+        JSON.stringify(compactedMetadata),
       );
   }
 
@@ -91,6 +92,120 @@ export class AcpSessionStore {
     const parsed = row ? parseJson(row.payload) : undefined;
     return isSessionMetadata(parsed) ? parsed : undefined;
   }
+}
+
+function compactAcpSessionMetadata(metadata: AcpSessionMetadata): AcpSessionMetadata {
+  if (!metadata.transcriptUpdates?.length) {
+    return metadata;
+  }
+  return {
+    ...metadata,
+    transcriptUpdates: compactAcpTranscriptUpdates(metadata.transcriptUpdates),
+  };
+}
+
+export function compactAcpTranscriptUpdates(
+  updates: AcpPersistedTranscriptUpdate[],
+): AcpPersistedTranscriptUpdate[] {
+  const compacted: AcpPersistedTranscriptUpdate[] = [];
+  for (const update of updates) {
+    appendCoalescedTranscriptUpdate(compacted, update);
+  }
+  return compacted;
+}
+
+export function appendCoalescedTranscriptUpdate(
+  updates: AcpPersistedTranscriptUpdate[],
+  next: AcpPersistedTranscriptUpdate,
+): void {
+  const previous = updates.at(-1);
+  const coalesced = previous ? coalesceTranscriptUpdate(previous, next) : undefined;
+  if (coalesced) {
+    updates[updates.length - 1] = coalesced;
+    return;
+  }
+  updates.push(next);
+}
+
+function coalesceTranscriptUpdate(
+  previous: AcpPersistedTranscriptUpdate,
+  next: AcpPersistedTranscriptUpdate,
+): AcpPersistedTranscriptUpdate | undefined {
+  const previousKind = readUpdateKind(previous.update);
+  const nextKind = readUpdateKind(next.update);
+  if (
+    previousKind !== nextKind ||
+    !isCoalescibleTranscriptChunkKind(previousKind)
+  ) {
+    return undefined;
+  }
+  if (messageIdentity(previous.update) !== messageIdentity(next.update)) {
+    return undefined;
+  }
+  const previousText = readUpdateText(previous.update);
+  const nextText = readUpdateText(next.update);
+  if (previousText === undefined || nextText === undefined) {
+    return undefined;
+  }
+  return {
+    receivedAt: next.receivedAt,
+    update: writeUpdateText(previous.update, `${previousText}${nextText}`),
+  };
+}
+
+function readUpdateKind(update: Record<string, unknown>): string | undefined {
+  const kind = update.sessionUpdate ?? update.kind ?? update.type;
+  return typeof kind === "string" ? kind : undefined;
+}
+
+function isCoalescibleTranscriptChunkKind(kind: string | undefined): boolean {
+  return (
+    kind === "agent_message_chunk" ||
+    kind === "agent_thought_chunk" ||
+    kind === "user_message_chunk"
+  );
+}
+
+function messageIdentity(update: Record<string, unknown>): string {
+  const messageId = update.messageId ?? update.id;
+  return typeof messageId === "string" ? messageId : "";
+}
+
+function readUpdateText(update: Record<string, unknown>): string | undefined {
+  if (typeof update.text === "string") {
+    return update.text;
+  }
+  const content = update.content;
+  if (!content || typeof content !== "object" || Array.isArray(content)) {
+    return undefined;
+  }
+  const contentRecord = content as Record<string, unknown>;
+  return contentRecord.type === "text" && typeof contentRecord.text === "string"
+    ? contentRecord.text
+    : undefined;
+}
+
+function writeUpdateText(
+  update: Record<string, unknown>,
+  text: string,
+): Record<string, unknown> {
+  if (typeof update.text === "string") {
+    return { ...update, text };
+  }
+  const content = update.content;
+  if (content && typeof content === "object" && !Array.isArray(content)) {
+    const contentRecord = content as Record<string, unknown>;
+    if (contentRecord.type === "text" && typeof contentRecord.text === "string") {
+      return {
+        ...update,
+        content: {
+          ...contentRecord,
+          text,
+        },
+      };
+    }
+  }
+  return update;
 }
 
 function parseJson(value: string): unknown {

--- a/apps/desktop/src/main/acp/acp-session-store.ts
+++ b/apps/desktop/src/main/acp/acp-session-store.ts
@@ -143,7 +143,8 @@ function isConversationTranscriptUpdate(
   item: AcpPersistedTranscriptUpdate,
 ): boolean {
   const update = item.update;
-  const kind = update.kind ?? update.type ?? update.sessionUpdate;
+  const kind =
+    update.kind ?? update.type ?? update.sessionUpdate ?? update.session_update;
   return (
     kind === "pwragent_user_prompt" ||
     kind === "user_message_chunk" ||

--- a/apps/desktop/src/main/acp/acp-stdio-transport.ts
+++ b/apps/desktop/src/main/acp/acp-stdio-transport.ts
@@ -87,9 +87,13 @@ export class AcpStdioJsonRpcTransport implements AcpJsonRpcTransport {
     await this.connection.close();
   }
 
-  async request(method: string, params?: Record<string, unknown>): Promise<unknown> {
+  async request(
+    method: string,
+    params?: Record<string, unknown>,
+    timeoutMs?: number,
+  ): Promise<unknown> {
     await this.connection.connect();
-    return await this.connection.request(method, params);
+    return await this.connection.request(method, params, timeoutMs);
   }
 
   async notify(method: string, params?: Record<string, unknown>): Promise<void> {

--- a/apps/desktop/src/main/acp/testing/fake-acp-agent.ts
+++ b/apps/desktop/src/main/acp/testing/fake-acp-agent.ts
@@ -1,7 +1,11 @@
 import type { AcpJsonRpcTransport } from "../acp-client.js";
 
 export class FakeAcpAgentTransport implements AcpJsonRpcTransport {
-  readonly requests: Array<{ method: string; params?: Record<string, unknown> }> = [];
+  readonly requests: Array<{
+    method: string;
+    params?: Record<string, unknown>;
+    timeoutMs?: number;
+  }> = [];
   readonly notifications: Array<{ method: string; params?: Record<string, unknown> }> = [];
   closeCount = 0;
   private listeners = new Set<(method: string, params: Record<string, unknown>) => void>();
@@ -18,8 +22,16 @@ export class FakeAcpAgentTransport implements AcpJsonRpcTransport {
     private readonly responses: Partial<Record<string, unknown>> = {},
   ) {}
 
-  async request(method: string, params?: Record<string, unknown>): Promise<unknown> {
-    this.requests.push({ method, params });
+  async request(
+    method: string,
+    params?: Record<string, unknown>,
+    timeoutMs?: number,
+  ): Promise<unknown> {
+    this.requests.push({
+      method,
+      params,
+      ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+    });
     if (method in this.responses) {
       return this.responses[method];
     }

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -1095,6 +1095,15 @@ export class AcpBackendAdapter {
           lastDiscoveryError: runtimeCapabilities.lastError,
           updatedAt: Math.max(current.updatedAt, now),
         });
+        await this.emit({
+          backend: agent.backendId,
+          notification: {
+            method: "backend/acpRuntimeCapabilities/updated",
+            params: {
+              backend: agent.backendId,
+            },
+          },
+        });
         if (sessionId && runtimeState && this.acpSessionStore?.upsertSession) {
           const metadata = this.getSession(agent.backendId, sessionId);
           if (metadata) {

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -9,8 +9,8 @@ import {
   type AppServerThreadStatus,
   type AppServerThreadSummary,
   type AppServerTurnInputItem,
-  type BackendAcpRuntimeCapabilities,
   type BackendAcpSessionRuntimeState,
+  type BackendAcpRuntimeCapabilities,
   type BackendCapabilities,
   type BackendLaunchpadOptions,
   type BackendModelOption,
@@ -35,10 +35,7 @@ import {
 import { discoverLocalAcpAgents } from "../acp/acp-local-discovery";
 import { acpToolUpdateNotifications } from "../acp/acp-live-notifications";
 import type { AcpInstalledAgentRecord } from "../acp/acp-registry-types";
-import {
-  acpRuntimeSupportsSessionLoad,
-  acpSessionRuntimeStateFromUpdate,
-} from "../acp/acp-runtime-capabilities";
+import { acpRuntimeSupportsSessionLoad } from "../acp/acp-runtime-capabilities";
 import {
   AcpSessionStore,
   type AcpSessionMetadata,
@@ -360,10 +357,6 @@ export function acpSessionToThreadSummary(
   const workspaceHandoffAvailable =
     !acpSessionHasConversationHistory(session) ||
     capabilities?.liveWorkspaceHandoff === true;
-  const acpRuntime = mergeAcpRuntimeState(
-    session.acpRuntime,
-    deriveAcpRuntimeStateFromTranscript(session),
-  );
   return {
     id: session.sessionId,
     title: session.title,
@@ -385,7 +378,7 @@ export function acpSessionToThreadSummary(
       : [],
     source: session.backendId,
     executionMode: session.executionMode,
-    acpRuntime,
+    acpRuntime: session.acpRuntime,
     workspaceHandoff: workspaceHandoffAvailable
       ? { available: true }
       : {
@@ -399,11 +392,6 @@ export function acpSessionLoadFallbackReplay(
   session: AcpSessionMetadata,
   error: unknown,
 ): AppServerThreadReplay {
-  const persistedReplay = replayPersistedAcpTranscript(session);
-  if (persistedReplay.entries.length > 0 || persistedReplay.messages.length > 0) {
-    return persistedReplay;
-  }
-
   const message = error instanceof Error ? error.message : String(error);
   return {
     entries: [
@@ -431,37 +419,6 @@ export function acpSessionLoadFallbackReplay(
   };
 }
 
-export function replayPersistedAcpTranscript(
-  session: AcpSessionMetadata,
-): AppServerThreadReplay {
-  const normalizer = new AcpSessionReplayNormalizer();
-  let replay = normalizer.replay();
-  for (const item of session.transcriptUpdates ?? []) {
-    replay = normalizer.apply({
-      sessionId: session.sessionId,
-      update: item.update,
-      receivedAt: item.receivedAt,
-    });
-  }
-  return {
-    ...replay,
-    threadStatus: acpSessionThreadStatus(session.status),
-  };
-}
-
-export function deriveAcpRuntimeStateFromTranscript(
-  session: AcpSessionMetadata,
-): BackendAcpSessionRuntimeState | undefined {
-  let runtimeState: BackendAcpSessionRuntimeState | undefined;
-  for (const item of session.transcriptUpdates ?? []) {
-    runtimeState = mergeAcpRuntimeState(
-      runtimeState,
-      acpSessionRuntimeStateFromUpdate(item.update, item.receivedAt),
-    );
-  }
-  return runtimeState;
-}
-
 export function acpSessionThreadStatus(
   status: AcpSessionMetadata["status"],
 ): AppServerThreadStatus {
@@ -478,14 +435,7 @@ export function isAcpSessionMissingForProjectError(error: unknown): boolean {
 export function acpSessionHasConversationHistory(
   session: AcpSessionMetadata,
 ): boolean {
-  return (session.transcriptUpdates ?? []).some((item) => {
-    const kind = item.update.kind ?? item.update.type ?? item.update.sessionUpdate;
-    return (
-      kind === "pwragent_user_prompt" ||
-      kind === "user_message_chunk" ||
-      kind === "agent_message_chunk"
-    );
-  });
+  return session.hasConversationHistory === true;
 }
 
 export function inputToAcpPrompt(
@@ -650,22 +600,41 @@ export class AcpBackendAdapter {
     backend: AcpBackendId,
     sessionId: string,
   ): Promise<AppServerThreadReplay> {
+    const session = this.getSession(backend, sessionId);
     const cachedClient = await this.acpClients.get(backend)?.catch(() => undefined);
     if (cachedClient) {
-      return cachedClient.readReplay(sessionId);
+      const replay = cachedClient.readReplay(sessionId);
+      if (
+        session &&
+        acpSessionHasConversationHistory(session) &&
+        replay.entries.length === 0 &&
+        acpRuntimeSupportsSessionLoad(
+          this.getInstalledAgent(backend)?.runtimeCapabilities,
+        )
+      ) {
+        try {
+          return await cachedClient.loadSession(session);
+        } catch (error) {
+          acpBackendAdapterLog.warn("acp_session_load_failed", {
+            backend,
+            error: error instanceof Error ? error.message : String(error),
+            sessionId,
+          });
+          return acpSessionLoadFallbackReplay(session, error);
+        }
+      }
+      return replay;
     }
 
-    const session = this.getSession(backend, sessionId);
     if (!session) {
       return new AcpSessionReplayNormalizer().replay();
     }
 
-    if (
-      !acpRuntimeSupportsSessionLoad(
-        this.getInstalledAgent(backend)?.runtimeCapabilities,
-      )
-    ) {
-      return replayPersistedAcpTranscript(session);
+    if (!acpRuntimeSupportsSessionLoad(this.getInstalledAgent(backend)?.runtimeCapabilities)) {
+      return {
+        ...new AcpSessionReplayNormalizer().replay(),
+        threadStatus: acpSessionThreadStatus(session.status),
+      };
     }
     const client = await this.getClient(backend);
     try {

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -997,7 +997,6 @@ export class AcpBackendAdapter {
         ) {
           const delta = readAcpUpdateText(update);
           if (delta) {
-            const isThoughtChunk = updateKind === "agent_thought_chunk";
             await this.emit({
               backend: agent.backendId,
               notification: {
@@ -1005,11 +1004,8 @@ export class AcpBackendAdapter {
                 params: {
                   threadId: sessionId,
                   turnId,
-                  itemId: `${isThoughtChunk ? "thought" : "assistant"}:${
-                    turnId ?? sessionId
-                  }`,
+                  itemId: `assistant:${turnId ?? sessionId}`,
                   delta,
-                  ...(isThoughtChunk ? { phase: "commentary" } : {}),
                 },
               },
             });

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -35,6 +35,7 @@ import {
 } from "../acp/acp-client";
 import { discoverLocalAcpAgents } from "../acp/acp-local-discovery";
 import { acpToolUpdateNotifications } from "../acp/acp-live-notifications";
+import { AcpRolloutStore } from "../acp/acp-rollout-store";
 import type { AcpInstalledAgentRecord } from "../acp/acp-registry-types";
 import { acpRuntimeSupportsSessionLoad } from "../acp/acp-runtime-capabilities";
 import {
@@ -48,7 +49,15 @@ import {
 } from "../acp/acp-session-normalizer";
 import { AcpStdioJsonRpcTransport } from "../acp/acp-stdio-transport";
 import { getMainLogger } from "../log";
-import { getAppStateDb, isAppStateInitialized } from "../state/app-state";
+import {
+  getAppStateDb,
+  getAppStateMode,
+  isAppStateInitialized,
+} from "../state/app-state";
+import {
+  resolveActiveProfilePath,
+  resolveBootstrapProfilePath,
+} from "../profile";
 import type { ProtocolCaptureStore } from "../testing/capture-store";
 import { createProtocolCaptureFromEnv } from "../testing/protocol-capture";
 import {
@@ -98,6 +107,7 @@ export type AcpBackendAdapterOptions = {
     AcpAgentStoreLike,
     "getInstalledAgent" | "listInstalledAgents" | "upsertInstalledAgent"
   > | null;
+  acpRolloutStore?: Pick<AcpRolloutStore, "appendUpdate" | "readReplay" | "readUpdates"> | null;
   acpSessionStore?: AcpSessionStoreLike | null;
   captureStores: ProtocolCaptureStore[];
   createAcpClient?: AcpClientFactory;
@@ -232,6 +242,7 @@ export function buildAcpCapabilities(): BackendCapabilities {
 export function describeInstalledAcpBackend(
   agent: AcpInstalledAgentRecord,
 ): BackendSummary {
+  const runtimeCapabilities = acpRuntimeCapabilitiesForAgent(agent);
   const available =
     agent.installStatus === "installed" &&
     (agent.authStatus === "not-required" || agent.authStatus === "authenticated");
@@ -261,11 +272,11 @@ export function describeInstalledAcpBackend(
       websiteUrl: agent.registryAgent?.websiteUrl,
       allowlistRuleId: agent.allowlistRuleId,
       license: agent.registryAgent?.license,
-      runtime: agent.runtimeCapabilities,
+      runtime: runtimeCapabilities,
     },
     methods: [
       "session/new",
-      ...(acpRuntimeSupportsSessionLoad(agent.runtimeCapabilities)
+      ...(acpRuntimeSupportsSessionLoad(runtimeCapabilities)
         ? ["session/load"]
         : []),
       "session/prompt",
@@ -273,9 +284,44 @@ export function describeInstalledAcpBackend(
     ],
     capabilities: buildAcpCapabilities(),
     executionModes: buildAcpExecutionModes(agent, available, unavailableReason),
-    launchpadOptions: buildAcpLaunchpadOptions(agent.runtimeCapabilities),
+    launchpadOptions: buildAcpLaunchpadOptions(runtimeCapabilities),
     unavailableReason,
   };
+}
+
+function acpRuntimeCapabilitiesForAgent(
+  agent: AcpInstalledAgentRecord,
+): BackendAcpRuntimeCapabilities | undefined {
+  if (agent.registryId !== "kimi") {
+    return agent.runtimeCapabilities;
+  }
+  const now = Date.now();
+  return {
+    schemaVersion: 1,
+    status: "discovered",
+    checkedAt: agent.runtimeCapabilities?.checkedAt ?? agent.updatedAt ?? now,
+    source: agent.runtimeCapabilities?.source ?? "local-probe",
+    ...agent.runtimeCapabilities,
+    agentCapabilities: {
+      ...agent.runtimeCapabilities?.agentCapabilities,
+      loadSession: false,
+    },
+  };
+}
+
+function normalizeInstalledAcpAgent(
+  agent: AcpInstalledAgentRecord,
+): AcpInstalledAgentRecord {
+  const runtimeCapabilities = acpRuntimeCapabilitiesForAgent(agent);
+  return runtimeCapabilities === agent.runtimeCapabilities
+    ? agent
+    : { ...agent, runtimeCapabilities };
+}
+
+function resolveDefaultAcpRolloutRoot(): string {
+  return getAppStateMode() === "bootstrap"
+    ? resolveBootstrapProfilePath("state/acp-rollouts")
+    : resolveActiveProfilePath("state/acp-rollouts");
 }
 
 function buildAcpExecutionModes(
@@ -570,6 +616,10 @@ export class AcpBackendAdapter {
     AcpAgentStoreLike,
     "getInstalledAgent" | "listInstalledAgents" | "upsertInstalledAgent"
   >;
+  private readonly acpRolloutStore?: Pick<
+    AcpRolloutStore,
+    "appendUpdate" | "readReplay" | "readUpdates"
+  >;
   private readonly acpSessionStore?: AcpSessionStoreLike;
   private readonly captureStores: ProtocolCaptureStore[];
   private readonly createAcpClient: AcpClientFactory;
@@ -601,6 +651,13 @@ export class AcpBackendAdapter {
         : options.acpSessionStore ??
           (isAppStateInitialized()
             ? new AcpSessionStore(getAppStateDb())
+            : undefined);
+    this.acpRolloutStore =
+      options.acpRolloutStore === null
+        ? undefined
+        : options.acpRolloutStore ??
+          (isAppStateInitialized()
+            ? new AcpRolloutStore(resolveDefaultAcpRolloutRoot())
             : undefined);
     this.discoverLocalAcpAgents =
       options.discoverLocalAcpAgents ?? discoverLocalAcpAgents;
@@ -634,7 +691,8 @@ export class AcpBackendAdapter {
   }
 
   getInstalledAgent(backendId: AcpBackendId): AcpInstalledAgentRecord | undefined {
-    return this.acpAgentStore?.getInstalledAgent(backendId);
+    const agent = this.acpAgentStore?.getInstalledAgent(backendId);
+    return agent ? normalizeInstalledAcpAgent(agent) : undefined;
   }
 
   sessionToThreadSummary(session: AcpSessionMetadata): AppServerThreadSummary {
@@ -683,6 +741,15 @@ export class AcpBackendAdapter {
           return acpSessionLoadFallbackReplay(session, error);
         }
       }
+      if (
+        session &&
+        replay.entries.length === 0 &&
+        !acpRuntimeSupportsSessionLoad(
+          this.getInstalledAgent(backend)?.runtimeCapabilities,
+        )
+      ) {
+        return this.readRolloutReplay(session);
+      }
       return replay;
     }
 
@@ -690,11 +757,12 @@ export class AcpBackendAdapter {
       return new AcpSessionReplayNormalizer().replay();
     }
 
-    if (!acpRuntimeSupportsSessionLoad(this.getInstalledAgent(backend)?.runtimeCapabilities)) {
-      return {
-        ...new AcpSessionReplayNormalizer().replay(),
-        threadStatus: acpSessionThreadStatus(session.status),
-      };
+    if (
+      !acpRuntimeSupportsSessionLoad(
+        this.getInstalledAgent(backend)?.runtimeCapabilities,
+      )
+    ) {
+      return this.readRolloutReplay(session);
     }
     const client = await this.getClient(backend);
     try {
@@ -738,6 +806,18 @@ export class AcpBackendAdapter {
     return await clientPromise;
   }
 
+  private readRolloutReplay(session: AcpSessionMetadata): AppServerThreadReplay {
+    const replay =
+      this.acpRolloutStore?.readReplay({
+        backendId: session.backendId,
+        sessionId: session.sessionId,
+      }) ?? new AcpSessionReplayNormalizer().replay();
+    return {
+      ...replay,
+      threadStatus: acpSessionThreadStatus(session.status),
+    };
+  }
+
   async resolveInstalledAgent(
     backend: AcpBackendId,
   ): Promise<AcpInstalledAgentRecord> {
@@ -765,15 +845,15 @@ export class AcpBackendAdapter {
   }
 
   async listAvailableAgents(): Promise<AcpInstalledAgentRecord[]> {
-    const installedAgents = (this.acpAgentStore?.listInstalledAgents() ?? []).filter(
-      (agent) => !isBannedAcpRegistryId(agent.registryId),
-    );
+    const installedAgents = (this.acpAgentStore?.listInstalledAgents() ?? [])
+      .map(normalizeInstalledAcpAgent)
+      .filter((agent) => !isBannedAcpRegistryId(agent.registryId));
     const installedBackendIds = new Set(
       installedAgents.map((agent) => agent.backendId),
     );
-    const discoveredAgents = (await this.readLocalAgentsOnce()).filter(
-      (agent) => !isBannedAcpRegistryId(agent.registryId),
-    );
+    const discoveredAgents = (await this.readLocalAgentsOnce())
+      .map(normalizeInstalledAcpAgent)
+      .filter((agent) => !isBannedAcpRegistryId(agent.registryId));
     for (const agent of discoveredAgents) {
       if (!installedBackendIds.has(agent.backendId)) {
         this.acpAgentStore?.upsertInstalledAgent(agent);
@@ -856,7 +936,8 @@ export class AcpBackendAdapter {
     return new AcpAgentClient({
       backendId: agent.backendId,
       agentDisplayName: agent.name,
-      initialRuntimeCapabilities: agent.runtimeCapabilities,
+      initialRuntimeCapabilities: acpRuntimeCapabilitiesForAgent(agent),
+      rolloutStore: this.acpRolloutStore,
       store: this.acpSessionStore as AcpSessionStoreContract,
       transport:
         this.createAcpTransport?.(agent) ??

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -3,6 +3,7 @@ import {
   type AcpBackendId,
   type AgentEvent,
   type AppServerBackendKind,
+  type AppServerNotification,
   type AppServerPendingRequestNotification,
   type AppServerThreadMessagePart,
   type AppServerThreadReplay,
@@ -41,7 +42,10 @@ import {
   type AcpSessionMetadata,
   type AcpSessionStore as AcpSessionStoreContract,
 } from "../acp/acp-session-store";
-import { AcpSessionReplayNormalizer } from "../acp/acp-session-normalizer";
+import {
+  AcpSessionReplayNormalizer,
+  readAcpContentText,
+} from "../acp/acp-session-normalizer";
 import { AcpStdioJsonRpcTransport } from "../acp/acp-stdio-transport";
 import { getMainLogger } from "../log";
 import { getAppStateDb, isAppStateInitialized } from "../state/app-state";
@@ -109,7 +113,8 @@ export type AcpBackendAdapterOptions = {
 export function readAcpUpdateKind(
   update: Record<string, unknown>,
 ): string | undefined {
-  const kind = update.sessionUpdate ?? update.kind ?? update.type;
+  const kind =
+    update.sessionUpdate ?? update.session_update ?? update.kind ?? update.type;
   return typeof kind === "string" ? kind : undefined;
 }
 
@@ -122,14 +127,10 @@ export function readAcpUpdateText(
   if (typeof update.outputText === "string") {
     return update.outputText;
   }
-  const content = update.content;
-  if (!content || typeof content !== "object" || Array.isArray(content)) {
-    return undefined;
+  if (typeof update.output_text === "string") {
+    return update.output_text;
   }
-  const contentRecord = content as Record<string, unknown>;
-  return contentRecord.type === "text" && typeof contentRecord.text === "string"
-    ? contentRecord.text
-    : undefined;
+  return readAcpContentText(update.content);
 }
 
 export function readKimiYoloExecutionModeFromText(
@@ -146,6 +147,64 @@ export function readKimiYoloExecutionModeFromText(
     return "default";
   }
   return undefined;
+}
+
+function liveToolNotificationKey(
+  backend: AcpBackendId,
+  notification: AppServerNotification,
+): string | undefined {
+  const params = asPlainRecord(notification.params);
+  const item = asPlainRecord(params?.item);
+  const threadId = readNonEmptyString(params, "threadId");
+  const turnId = readNonEmptyString(params, "turnId") ?? "no-turn";
+  const itemId = readNonEmptyString(item, "id");
+  return threadId && itemId
+    ? `${backend}:${threadId}:${turnId}:${itemId}`
+    : undefined;
+}
+
+function liveToolNotificationFingerprint(
+  notification: AppServerNotification,
+): string | undefined {
+  const params = asPlainRecord(notification.params);
+  const item = asPlainRecord(params?.item);
+  if (!item) {
+    return undefined;
+  }
+  const data = asPlainRecord(item.data);
+  const output = readNonEmptyString(data, "output") ?? "";
+  return JSON.stringify({
+    method: notification.method,
+    type: item.type,
+    toolName: item.toolName,
+    status: item.status,
+    command: item.command,
+    commandActions: item.commandActions,
+    outputHash: hashString(output),
+    outputLength: output.length,
+  });
+}
+
+function asPlainRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function readNonEmptyString(
+  record: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
+  const value = record?.[key];
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function hashString(value: string): string {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 31 + value.charCodeAt(index)) | 0;
+  }
+  return hash.toString(16);
 }
 
 export function buildAcpCapabilities(): BackendCapabilities {
@@ -522,6 +581,7 @@ export class AcpBackendAdapter {
     request: AppServerPendingRequestNotification,
   ) => Promise<unknown>;
   private readonly acpClients = new Map<AcpBackendId, Promise<AcpRuntimeClient>>();
+  private readonly liveNotificationFingerprints = new Map<string, string>();
   private localAcpAgentsPromise?: Promise<AcpInstalledAgentRecord[]>;
 
   constructor(options: AcpBackendAdapterOptions) {
@@ -730,12 +790,43 @@ export class AcpBackendAdapter {
   async close(): Promise<void> {
     const acpClients = [...this.acpClients.values()];
     this.acpClients.clear();
+    this.liveNotificationFingerprints.clear();
     await Promise.all(
       acpClients.map(async (clientPromise) => {
         const client = await clientPromise.catch(() => undefined);
         await client?.dispose();
       }),
     );
+  }
+
+  private shouldEmitLiveToolNotification(
+    backend: AcpBackendId,
+    notification: AppServerNotification,
+  ): boolean {
+    const key = liveToolNotificationKey(backend, notification);
+    const fingerprint = liveToolNotificationFingerprint(notification);
+    if (!key || !fingerprint) {
+      return true;
+    }
+    const previous = this.liveNotificationFingerprints.get(key);
+    if (previous === fingerprint) {
+      return false;
+    }
+    this.liveNotificationFingerprints.set(key, fingerprint);
+    return true;
+  }
+
+  private clearLiveToolNotificationFingerprints(params: {
+    backend: AcpBackendId;
+    threadId: string;
+    turnId: string;
+  }): void {
+    const prefix = `${params.backend}:${params.threadId}:${params.turnId}:`;
+    for (const key of this.liveNotificationFingerprints.keys()) {
+      if (key.startsWith(prefix)) {
+        this.liveNotificationFingerprints.delete(key);
+      }
+    }
   }
 
   private async readLocalAgentsOnce(): Promise<AcpInstalledAgentRecord[]> {
@@ -836,17 +927,25 @@ export class AcpBackendAdapter {
             });
           }
         }
-        for (const notification of acpToolUpdateNotifications({
+        const toolNotifications = acpToolUpdateNotifications({
           threadId: sessionId,
           turnId,
           update,
-        })) {
+        }).filter((notification) =>
+          this.shouldEmitLiveToolNotification(agent.backendId, notification),
+        );
+        for (const notification of toolNotifications) {
           await this.emit({
             backend: agent.backendId,
             notification,
           });
         }
         if (updateKind === "turn_finished" && turnId) {
+          this.clearLiveToolNotificationFingerprints({
+            backend: agent.backendId,
+            threadId: sessionId,
+            turnId,
+          });
           const outputText = readAcpUpdateText(update);
           await this.emit({
             backend: agent.backendId,

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -950,7 +950,14 @@ export class AcpBackendAdapter {
             }),
           ]),
         }),
-      onSessionUpdate: async ({ sessionId, replay, title, turnId, update }) => {
+      onSessionUpdate: async ({
+        assistantMessageItemId,
+        sessionId,
+        replay,
+        title,
+        turnId,
+        update,
+      }) => {
         const updateKind = readAcpUpdateKind(update);
         if (title) {
           await this.emit({
@@ -1004,7 +1011,8 @@ export class AcpBackendAdapter {
                 params: {
                   threadId: sessionId,
                   turnId,
-                  itemId: `assistant:${turnId ?? sessionId}`,
+                  itemId:
+                    assistantMessageItemId ?? `assistant:${turnId ?? sessionId}`,
                   delta,
                 },
               },

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -72,7 +72,7 @@ export type AcpRuntimeClient = Pick<
   | "startPrompt"
   | "startSession"
 > &
-  Partial<Pick<AcpAgentClient, "setRuntimeOption">>;
+  Partial<Pick<AcpAgentClient, "sendControlPrompt" | "setRuntimeOption">>;
 
 export type AcpClientFactory = (agent: AcpInstalledAgentRecord) => AcpRuntimeClient;
 export type LocalAcpDiscovery = () => Promise<AcpInstalledAgentRecord[]>;
@@ -194,10 +194,35 @@ export function describeInstalledAcpBackend(
       "session/cancel",
     ],
     capabilities: buildAcpCapabilities(),
-    executionModes: [],
+    executionModes: buildAcpExecutionModes(agent, available, unavailableReason),
     launchpadOptions: buildAcpLaunchpadOptions(agent.runtimeCapabilities),
     unavailableReason,
   };
+}
+
+function buildAcpExecutionModes(
+  agent: AcpInstalledAgentRecord,
+  available: boolean,
+  unavailableReason: string | undefined,
+): BackendSummary["executionModes"] {
+  if (agent.registryId !== "kimi") {
+    return [];
+  }
+  return [
+    {
+      mode: "default",
+      label: "Default Access",
+      available,
+      isDefault: true,
+      unavailableReason,
+    },
+    {
+      mode: "full-access",
+      label: "Full Access",
+      available,
+      unavailableReason,
+    },
+  ];
 }
 
 export function buildAcpLaunchpadOptions(

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -292,21 +292,7 @@ export function describeInstalledAcpBackend(
 function acpRuntimeCapabilitiesForAgent(
   agent: AcpInstalledAgentRecord,
 ): BackendAcpRuntimeCapabilities | undefined {
-  if (agent.registryId !== "kimi") {
-    return agent.runtimeCapabilities;
-  }
-  const now = Date.now();
-  return {
-    schemaVersion: 1,
-    status: "discovered",
-    checkedAt: agent.runtimeCapabilities?.checkedAt ?? agent.updatedAt ?? now,
-    source: agent.runtimeCapabilities?.source ?? "local-probe",
-    ...agent.runtimeCapabilities,
-    agentCapabilities: {
-      ...agent.runtimeCapabilities?.agentCapabilities,
-      loadSession: false,
-    },
-  };
+  return agent.runtimeCapabilities;
 }
 
 function normalizeInstalledAcpAgent(
@@ -731,14 +717,23 @@ export class AcpBackendAdapter {
         )
       ) {
         try {
-          return await cachedClient.loadSession(session);
+          const replay = await cachedClient.loadSession(session);
+          return this.providerReplayOrRolloutFallback({
+            backend,
+            replay,
+            session,
+          });
         } catch (error) {
           acpBackendAdapterLog.warn("acp_session_load_failed", {
             backend,
             error: error instanceof Error ? error.message : String(error),
             sessionId,
           });
-          return acpSessionLoadFallbackReplay(session, error);
+          return this.loadFailureReplayOrRolloutFallback({
+            backend,
+            error,
+            session,
+          });
         }
       }
       if (
@@ -748,13 +743,28 @@ export class AcpBackendAdapter {
           this.getInstalledAgent(backend)?.runtimeCapabilities,
         )
       ) {
-        return this.readRolloutReplay(session);
+        return this.readRolloutReplay(session, "rollout-session-load-unsupported");
       }
+      this.logSessionReplaySource({
+        backend,
+        entries: replay.entries.length,
+        messages: replay.messages.length,
+        sessionId,
+        source: "memory",
+      });
       return replay;
     }
 
     if (!session) {
-      return new AcpSessionReplayNormalizer().replay();
+      const replay = new AcpSessionReplayNormalizer().replay();
+      this.logSessionReplaySource({
+        backend,
+        entries: 0,
+        messages: 0,
+        sessionId,
+        source: "empty-no-session",
+      });
+      return replay;
     }
 
     if (
@@ -762,7 +772,7 @@ export class AcpBackendAdapter {
         this.getInstalledAgent(backend)?.runtimeCapabilities,
       )
     ) {
-      return this.readRolloutReplay(session);
+      return this.readRolloutReplay(session, "rollout-session-load-unsupported");
     }
     const client = await this.getClient(backend);
     try {
@@ -774,14 +784,22 @@ export class AcpBackendAdapter {
           sessionId,
         });
       });
-      return replay;
+      return this.providerReplayOrRolloutFallback({
+        backend,
+        replay,
+        session,
+      });
     } catch (error) {
       acpBackendAdapterLog.warn("acp_session_load_failed", {
         backend,
         error: error instanceof Error ? error.message : String(error),
         sessionId,
       });
-      return acpSessionLoadFallbackReplay(session, error);
+      return this.loadFailureReplayOrRolloutFallback({
+        backend,
+        error,
+        session,
+      });
     }
   }
 
@@ -806,16 +824,124 @@ export class AcpBackendAdapter {
     return await clientPromise;
   }
 
-  private readRolloutReplay(session: AcpSessionMetadata): AppServerThreadReplay {
+  private readRolloutReplay(
+    session: AcpSessionMetadata,
+    source: string,
+  ): AppServerThreadReplay {
     const replay =
       this.acpRolloutStore?.readReplay({
         backendId: session.backendId,
         sessionId: session.sessionId,
       }) ?? new AcpSessionReplayNormalizer().replay();
+    this.logSessionReplaySource({
+      backend: session.backendId,
+      entries: replay.entries.length,
+      messages: replay.messages.length,
+      sessionId: session.sessionId,
+      source,
+    });
     return {
       ...replay,
       threadStatus: acpSessionThreadStatus(session.status),
     };
+  }
+
+  private providerReplayOrRolloutFallback(params: {
+    backend: AcpBackendId;
+    replay: AppServerThreadReplay;
+    session: AcpSessionMetadata;
+  }): AppServerThreadReplay {
+    const { backend, replay, session } = params;
+    if (replay.entries.length > 0 || !acpSessionHasConversationHistory(session)) {
+      this.logSessionReplaySource({
+        backend,
+        entries: replay.entries.length,
+        messages: replay.messages.length,
+        sessionId: session.sessionId,
+        source:
+          replay.entries.length > 0
+            ? "provider-session-load"
+            : "provider-session-load-empty",
+      });
+      return replay;
+    }
+
+    const rolloutReplay =
+      this.acpRolloutStore?.readReplay({
+        backendId: session.backendId,
+        sessionId: session.sessionId,
+      }) ?? new AcpSessionReplayNormalizer().replay();
+    if (rolloutReplay.entries.length === 0) {
+      this.logSessionReplaySource({
+        backend,
+        entries: replay.entries.length,
+        messages: replay.messages.length,
+        sessionId: session.sessionId,
+        source: "provider-session-load-empty-no-rollout",
+      });
+      return replay;
+    }
+
+    this.logSessionReplaySource({
+      backend,
+      entries: rolloutReplay.entries.length,
+      messages: rolloutReplay.messages.length,
+      providerEntries: replay.entries.length,
+      providerMessages: replay.messages.length,
+      sessionId: session.sessionId,
+      source: "rollout-provider-empty",
+    });
+    return {
+      ...rolloutReplay,
+      threadStatus: acpSessionThreadStatus(session.status),
+    };
+  }
+
+  private loadFailureReplayOrRolloutFallback(params: {
+    backend: AcpBackendId;
+    error: unknown;
+    session: AcpSessionMetadata;
+  }): AppServerThreadReplay {
+    const rolloutReplay =
+      this.acpRolloutStore?.readReplay({
+        backendId: params.session.backendId,
+        sessionId: params.session.sessionId,
+      }) ?? new AcpSessionReplayNormalizer().replay();
+    if (rolloutReplay.entries.length > 0) {
+      this.logSessionReplaySource({
+        backend: params.backend,
+        entries: rolloutReplay.entries.length,
+        messages: rolloutReplay.messages.length,
+        sessionId: params.session.sessionId,
+        source: "rollout-session-load-failed",
+      });
+      return {
+        ...rolloutReplay,
+        threadStatus: acpSessionThreadStatus(params.session.status),
+      };
+    }
+
+    const replay = acpSessionLoadFallbackReplay(params.session, params.error);
+    this.logSessionReplaySource({
+      backend: params.backend,
+      entries: replay.entries.length,
+      messages: replay.messages.length,
+      sessionId: params.session.sessionId,
+      source: "session-load-failed",
+    });
+    return replay;
+  }
+
+  private logSessionReplaySource(params: {
+    backend: AcpBackendId;
+    entries: number;
+    messages: number;
+    providerEntries?: number;
+    providerMessages?: number;
+    sessionId: string;
+    source: string;
+  }): void {
+    acpBackendAdapterLog.info("acp_session_replay_source", params);
   }
 
   async resolveInstalledAgent(

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -771,6 +771,7 @@ export class AcpBackendAdapter {
     }
     return new AcpAgentClient({
       backendId: agent.backendId,
+      agentDisplayName: agent.name,
       initialRuntimeCapabilities: agent.runtimeCapabilities,
       store: this.acpSessionStore as AcpSessionStoreContract,
       transport: new AcpStdioJsonRpcTransport({

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -257,7 +257,7 @@ export function describeInstalledAcpBackend(
   return {
     kind: agent.backendId,
     source: "acp",
-    label: agent.name,
+    label: formatAcpAgentDisplayName(agent),
     available,
     acp: {
       registryId: agent.registryId,
@@ -287,6 +287,16 @@ export function describeInstalledAcpBackend(
     launchpadOptions: buildAcpLaunchpadOptions(runtimeCapabilities),
     unavailableReason,
   };
+}
+
+function formatAcpAgentDisplayName(agent: AcpInstalledAgentRecord): string {
+  if (agent.registryId === "gemini") {
+    return "Gemini";
+  }
+  if (agent.registryId === "kimi") {
+    return "Kimi";
+  }
+  return agent.name;
 }
 
 function acpRuntimeCapabilitiesForAgent(

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -15,6 +15,7 @@ import {
   type BackendLaunchpadOptions,
   type BackendModelOption,
   type BackendSummary,
+  type ThreadExecutionMode,
   isAcpBackendId,
 } from "@pwragent/shared";
 import {
@@ -28,6 +29,7 @@ import {
 } from "../acp/acp-agent-capabilities";
 import {
   AcpAgentClient,
+  type AcpJsonRpcTransport,
   type AcpPromptContentBlock,
 } from "../acp/acp-client";
 import { discoverLocalAcpAgents } from "../acp/acp-local-discovery";
@@ -75,6 +77,9 @@ export type AcpRuntimeClient = Pick<
   Partial<Pick<AcpAgentClient, "sendControlPrompt" | "setRuntimeOption">>;
 
 export type AcpClientFactory = (agent: AcpInstalledAgentRecord) => AcpRuntimeClient;
+export type AcpTransportFactory = (
+  agent: AcpInstalledAgentRecord,
+) => AcpJsonRpcTransport;
 export type LocalAcpDiscovery = () => Promise<AcpInstalledAgentRecord[]>;
 
 export type AcpSessionStoreLike =
@@ -95,6 +100,7 @@ export type AcpBackendAdapterOptions = {
   acpSessionStore?: AcpSessionStoreLike | null;
   captureStores: ProtocolCaptureStore[];
   createAcpClient?: AcpClientFactory;
+  createAcpTransport?: AcpTransportFactory;
   discoverLocalAcpAgents?: LocalAcpDiscovery;
   emit: (event: AgentEvent) => Promise<void>;
   handleServerRequest: (
@@ -127,6 +133,22 @@ export function readAcpUpdateText(
   return contentRecord.type === "text" && typeof contentRecord.text === "string"
     ? contentRecord.text
     : undefined;
+}
+
+export function readKimiYoloExecutionModeFromText(
+  text: string,
+): ThreadExecutionMode | undefined {
+  const normalized = text.toLowerCase();
+  if (normalized.includes("all actions will be auto-approved")) {
+    return "full-access";
+  }
+  if (normalized.includes("tool calls remain auto-approved")) {
+    return "full-access";
+  }
+  if (normalized.includes("actions will require approval")) {
+    return "default";
+  }
+  return undefined;
 }
 
 export function buildAcpCapabilities(): BackendCapabilities {
@@ -542,6 +564,7 @@ export class AcpBackendAdapter {
   private readonly acpSessionStore?: AcpSessionStoreLike;
   private readonly captureStores: ProtocolCaptureStore[];
   private readonly createAcpClient: AcpClientFactory;
+  private readonly createAcpTransport?: AcpTransportFactory;
   private readonly discoverLocalAcpAgents: LocalAcpDiscovery;
   private readonly emit: (event: AgentEvent) => Promise<void>;
   private readonly handleServerRequest: (
@@ -571,6 +594,7 @@ export class AcpBackendAdapter {
             : undefined);
     this.discoverLocalAcpAgents =
       options.discoverLocalAcpAgents ?? discoverLocalAcpAgents;
+    this.createAcpTransport = options.createAcpTransport;
     this.createAcpClient =
       options.createAcpClient ?? ((agent) => this.createDefaultClient(agent));
   }
@@ -774,15 +798,17 @@ export class AcpBackendAdapter {
       agentDisplayName: agent.name,
       initialRuntimeCapabilities: agent.runtimeCapabilities,
       store: this.acpSessionStore as AcpSessionStoreContract,
-      transport: new AcpStdioJsonRpcTransport({
-        launchDescriptor: agent.launchDescriptor,
-        observer: createCompositeJsonRpcObserver([
-          acpCapture?.observer,
-          createProtocolLogObserverFromEnv({
-            backend: agent.backendId,
-          }),
-        ]),
-      }),
+      transport:
+        this.createAcpTransport?.(agent) ??
+        new AcpStdioJsonRpcTransport({
+          launchDescriptor: agent.launchDescriptor,
+          observer: createCompositeJsonRpcObserver([
+            acpCapture?.observer,
+            createProtocolLogObserverFromEnv({
+              backend: agent.backendId,
+            }),
+          ]),
+        }),
       onSessionUpdate: async ({ sessionId, replay, title, turnId, update }) => {
         const updateKind = readAcpUpdateKind(update);
         if (title) {
@@ -796,6 +822,33 @@ export class AcpBackendAdapter {
               },
             },
           });
+        }
+        const kimiYoloExecutionMode =
+          agent.registryId === "kimi"
+            ? readKimiYoloExecutionModeFromText(readAcpUpdateText(update) ?? "")
+            : undefined;
+        if (kimiYoloExecutionMode) {
+          const metadata = this.getSession(agent.backendId, sessionId);
+          if (
+            metadata &&
+            (metadata.executionMode ?? "default") !== kimiYoloExecutionMode
+          ) {
+            this.acpSessionStore?.upsertSession?.({
+              ...metadata,
+              executionMode: kimiYoloExecutionMode,
+              updatedAt: Math.max(metadata.updatedAt, Date.now()),
+            });
+            await this.emit({
+              backend: agent.backendId,
+              notification: {
+                method: "thread/executionMode/updated",
+                params: {
+                  threadId: sessionId,
+                  executionMode: kimiYoloExecutionMode,
+                },
+              },
+            });
+          }
         }
         if (updateKind === "agent_message_chunk") {
           const delta = readAcpUpdateText(update);

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -991,9 +991,13 @@ export class AcpBackendAdapter {
             });
           }
         }
-        if (updateKind === "agent_message_chunk") {
+        if (
+          updateKind === "agent_message_chunk" ||
+          updateKind === "agent_thought_chunk"
+        ) {
           const delta = readAcpUpdateText(update);
           if (delta) {
+            const isThoughtChunk = updateKind === "agent_thought_chunk";
             await this.emit({
               backend: agent.backendId,
               notification: {
@@ -1001,8 +1005,11 @@ export class AcpBackendAdapter {
                 params: {
                   threadId: sessionId,
                   turnId,
-                  itemId: `assistant:${turnId ?? sessionId}`,
+                  itemId: `${isThoughtChunk ? "thought" : "assistant"}:${
+                    turnId ?? sessionId
+                  }`,
                   delta,
+                  ...(isThoughtChunk ? { phase: "commentary" } : {}),
                 },
               },
             });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1399,7 +1399,7 @@ function resolveCodexEnvironmentSelection(
   launchpad: NavigationLaunchpadDraft,
   options: CodexEnvironmentOption[],
 ): CodexEnvironmentSelection | undefined {
-  if (launchpad.backend !== "codex" || !launchpad.codexEnvironmentId) {
+  if (!launchpad.codexEnvironmentId) {
     return undefined;
   }
 
@@ -1427,7 +1427,7 @@ async function resetLaunchpadAfterMaterialize(params: {
     directoryKey: launchpad.directoryKey,
   });
 
-  if (launchpad.backend !== "codex" || !launchpad.codexEnvironmentId) {
+  if (!launchpad.codexEnvironmentId) {
     return;
   }
 
@@ -1437,7 +1437,7 @@ async function resetLaunchpadAfterMaterialize(params: {
     directoryKind: launchpad.directoryKind,
     directoryLabel: launchpad.directoryLabel,
     directoryPath: launchpad.directoryPath,
-    backend: "codex",
+    backend: defaults.backend,
     executionMode: defaults.executionMode,
     model: defaults.model,
     reasoningEffort: defaults.reasoningEffort,
@@ -3890,13 +3890,13 @@ export class DesktopBackendRegistry {
         threadId: result.threadId,
         branch: gitBranch,
       });
-      if (request.codexEnvironmentRuntime) {
-        await this.overlayStore.setThreadCodexEnvironmentRuntime?.({
-          backend,
-          threadId: result.threadId,
-          codexEnvironmentRuntime: request.codexEnvironmentRuntime,
-        });
-      }
+    }
+    if (request.codexEnvironmentRuntime) {
+      await this.overlayStore.setThreadCodexEnvironmentRuntime?.({
+        backend,
+        threadId: result.threadId,
+        codexEnvironmentRuntime: request.codexEnvironmentRuntime,
+      });
     }
     if (
       modelSettings.model !== undefined ||
@@ -4058,7 +4058,11 @@ export class DesktopBackendRegistry {
       });
       cwd =
         params.backend === "codex"
-          ? await this.resolveCodexThreadTurnCwd(params.threadId, overlay)
+          ? await this.resolveThreadEnvironmentCwd(
+              params.backend,
+              params.threadId,
+              overlay,
+            )
           : undefined;
       input = await this.buildTurnInputWithAutomationContext({
         backend: params.backend,
@@ -5600,10 +5604,6 @@ export class DesktopBackendRegistry {
   async runCodexEnvironmentAction(
     request: RunCodexEnvironmentActionRequest,
   ): Promise<RunCodexEnvironmentActionResponse> {
-    if (request.backend !== "codex") {
-      throw new Error("Codex environment actions are only available for Codex threads.");
-    }
-
     // Serialise the read-modify-write under the per-thread lock so two
     // concurrent Run-button clicks can't clobber each other's appended
     // run entry.
@@ -5617,14 +5617,16 @@ export class DesktopBackendRegistry {
         });
         const runtime = overlay?.codexEnvironmentRuntime;
         if (!runtime) {
-          throw new Error(
-            "This thread does not have a selected Codex environment.",
-          );
+          throw new Error("This thread does not have a selected environment.");
         }
 
         const currentCwd =
           request.cwd?.trim() ||
-          (await this.resolveCodexThreadTurnCwd(request.threadId, overlay));
+          (await this.resolveThreadEnvironmentCwd(
+            request.backend,
+            request.threadId,
+            overlay,
+          ));
         const runtimeForAction = await this.refreshCodexEnvironmentRuntimeActions(
           currentCwd?.trim() ? { ...runtime, cwd: currentCwd.trim() } : runtime,
           request.actionId,
@@ -5729,10 +5731,6 @@ export class DesktopBackendRegistry {
   async setCodexThreadEnvironment(
     request: SetCodexThreadEnvironmentRequest,
   ): Promise<SetCodexThreadEnvironmentResponse> {
-    if (request.backend !== "codex") {
-      throw new Error("Codex environments are only available for Codex threads.");
-    }
-
     if (!request.environmentId) {
       await this.overlayStore.setThreadCodexEnvironmentRuntime?.({
         backend: request.backend,
@@ -5755,13 +5753,17 @@ export class DesktopBackendRegistry {
       backend: request.backend,
       threadId: request.threadId,
     });
-    const cwd = await this.resolveCodexThreadTurnCwd(request.threadId, overlay);
+    const cwd = await this.resolveThreadEnvironmentCwd(
+      request.backend,
+      request.threadId,
+      overlay,
+    );
     const options = await listCodexEnvironmentOptions(cwd);
     const environment = options.find(
       (candidate) => candidate.id === request.environmentId,
     );
     if (!environment) {
-      throw new Error("Selected Codex environment is not available for this thread.");
+      throw new Error("Selected environment is not available for this thread.");
     }
 
     const codexEnvironmentRuntime: CodexThreadEnvironmentRuntime = {
@@ -6067,36 +6069,34 @@ export class DesktopBackendRegistry {
       queuedActionDetachedOutputs.length = 0;
       queuedActionDetachedOutputs.push(event);
     };
-    if (launchpad.backend === "codex") {
-      try {
-        codexEnvironmentRuntime = await applyLocalCodexEnvironmentSelection({
-          commandRunner: this.codexEnvironmentCommandRunner,
-          cwd: workspace.cwd,
-          env: this.codexEnvironmentCommandEnv,
-          onSetupProgress: options?.onCodexEnvironmentSetupProgress
-            ? (event) => {
-                options.onCodexEnvironmentSetupProgress?.({
-                  directoryKey: launchpad.directoryKey,
-                  ...event,
-                });
-              }
-            : undefined,
-          onActionDetachedExit,
-          onActionDetachedOutput,
-          actionRunId: autoActionRunId,
-          selection: codexEnvironmentSelection,
-        });
-      } catch (error) {
-        if (!(error instanceof CodexEnvironmentStartupError)) {
-          throw error;
-        }
-        codexEnvironmentRuntime = error.runtime;
-        codexEnvironmentStartupFailure = {
-          message: error.message,
-          phase: error.phase,
-          worktreeCleanupAvailable: workspace.workMode === "worktree",
-        };
+    try {
+      codexEnvironmentRuntime = await applyLocalCodexEnvironmentSelection({
+        commandRunner: this.codexEnvironmentCommandRunner,
+        cwd: workspace.cwd,
+        env: this.codexEnvironmentCommandEnv,
+        onSetupProgress: options?.onCodexEnvironmentSetupProgress
+          ? (event) => {
+              options.onCodexEnvironmentSetupProgress?.({
+                directoryKey: launchpad.directoryKey,
+                ...event,
+              });
+            }
+          : undefined,
+        onActionDetachedExit,
+        onActionDetachedOutput,
+        actionRunId: autoActionRunId,
+        selection: codexEnvironmentSelection,
+      });
+    } catch (error) {
+      if (!(error instanceof CodexEnvironmentStartupError)) {
+        throw error;
       }
+      codexEnvironmentRuntime = error.runtime;
+      codexEnvironmentStartupFailure = {
+        message: error.message,
+        phase: error.phase,
+        worktreeCleanupAvailable: workspace.workMode === "worktree",
+      };
     }
     const startThreadResponse = await this.startThread({
       backend: launchpad.backend,
@@ -7534,7 +7534,8 @@ export class DesktopBackendRegistry {
       .catch(() => undefined);
   }
 
-  private async resolveCodexThreadTurnCwd(
+  private async resolveThreadEnvironmentCwd(
+    backend: AppServerBackendKind,
     threadId: string,
     overlay?: ThreadOverlayState,
   ): Promise<string | undefined> {
@@ -7545,14 +7546,14 @@ export class DesktopBackendRegistry {
       return overlayCwd.trim();
     }
 
-    const pendingThread = this.pendingStartedThreads.get(`codex:${threadId}`);
+    const pendingThread = this.pendingStartedThreads.get(`${backend}:${threadId}`);
     const pendingCwd = resolveThreadWorkspaceCwd(pendingThread);
     if (pendingCwd?.trim()) {
       return pendingCwd.trim();
     }
 
     const thread = await this.findThreadForWorkspaceHandoff({
-      backend: "codex",
+      backend,
       callerReason: "turn-cwd",
       threadId,
     });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -2204,7 +2204,11 @@ export class DesktopBackendRegistry {
     });
     const cwd =
       params.backend === "codex"
-        ? await this.resolveCodexThreadTurnCwd(params.agentThreadId, overlay)
+        ? await this.resolveThreadEnvironmentCwd(
+            params.backend,
+            params.agentThreadId,
+            overlay,
+          )
         : undefined;
     const input = prependAutomationRuntimeContext({
       approvalPolicy,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -4282,6 +4282,9 @@ export class DesktopBackendRegistry {
 
   async startReview(params: StartReviewRequest): Promise<StartReviewResponse> {
     this.assertNotBootstrap("startReview");
+    if (isAcpBackendId(params.backend)) {
+      throw new Error("Selected backend does not support review/start");
+    }
     if (params.backend === "codex" && this.threadHasActiveTurn(params.threadId)) {
       throw new Error(`Thread already has an active turn in progress: ${params.threadId}`);
     }
@@ -4305,7 +4308,7 @@ export class DesktopBackendRegistry {
     const result =
       params.backend === "codex"
         ? await this.withCodexThreadClient(params.threadId, startWithClient)
-        : await startWithClient(this.grokClient);
+        : await startWithClient(this.getClient(params.backend));
 
     return {
       backend: params.backend,
@@ -6715,6 +6718,9 @@ export class DesktopBackendRegistry {
     return (
       method === "thread/archived" ||
       method === "thread/acpRuntime/updated" ||
+      method === "thread/executionMode/queueCleared" ||
+      method === "thread/executionMode/queued" ||
+      method === "thread/executionMode/updated" ||
       method === "thread/name/updated" ||
       method === "thread/started" ||
       method === "thread/unarchived" ||

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -3298,7 +3298,6 @@ export class DesktopBackendRegistry {
       executionMode: session.executionMode,
       title: session.title,
       createdAt: session.createdAt,
-      transcriptUpdates: session.transcriptUpdates,
     });
   }
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -4934,14 +4934,14 @@ export class DesktopBackendRegistry {
     if (params.fromExecutionMode === params.toExecutionMode) {
       return;
     }
-    if (!params.client.sendControlPrompt) {
+    const client = params.client;
+    if (!client.sendControlPrompt) {
       throw new Error("Kimi ACP execution mode updates require control prompts");
     }
-    const sendControlPrompt = params.client.sendControlPrompt;
     const result = await this.acpSessionPromptLocks.run(
       executionModeQueueKey(params.backend, params.sessionId),
       async () =>
-        await sendControlPrompt({
+        await client.sendControlPrompt!({
           sessionId: params.sessionId,
           prompt: "/yolo",
         }),

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -102,6 +102,7 @@ import {
   type EnsureDirectoryLaunchpadRequest,
   type EnsureDirectoryLaunchpadResponse,
   applyCodexEnvironmentActionRunUpdate,
+  buildThreadIdentityKey,
   isAcpBackendId,
   readCodexEnvironmentActionRuns,
 } from "@pwragent/shared";
@@ -115,6 +116,7 @@ import {
   inputToAcpPrompt,
   isAcpSessionMissingForProjectError,
   mergeAcpRuntimeState,
+  readKimiYoloExecutionModeFromText,
   withAcpModelRuntimeSelection,
   type AcpBackendAdapterOptions,
   type AcpClientFactory,
@@ -914,6 +916,17 @@ function buildPendingRequestKey(params: {
   requestId: string;
 }): string {
   return `${params.backend}:${params.threadId}:${params.requestId}`;
+}
+
+function executionModeQueueKey(
+  backend: AppServerBackendKind,
+  threadId: string,
+): string {
+  return buildThreadIdentityKey(backend, threadId);
+}
+
+function formatExecutionModeForError(mode: ThreadExecutionMode): string {
+  return mode === "full-access" ? "Full Access" : "Default Access";
 }
 
 function buildActiveTurnModeKey(threadId: string, turnId: string): string {
@@ -1772,6 +1785,7 @@ export class DesktopBackendRegistry {
     }
   >();
   private readonly queuedExecutionModeFlushes = new Map<string, Promise<void>>();
+  private readonly acpSessionPromptLocks = new PerKeyAsyncLock();
   private readonly queuedAcpRuntimeOptions = new Map<
     string,
     {
@@ -2715,23 +2729,40 @@ export class DesktopBackendRegistry {
     acpRuntime?: BackendAcpSessionRuntimeState;
   }): Promise<{ threadId: string }> {
     const client = await this.acpBackend.getClient(params.backend);
+    const initialExecutionMode = this.usesKimiSlashExecutionModes(params.backend)
+      ? "default"
+      : params.executionMode;
     const session = await client.startSession({
       cwd: params.cwd,
-      executionMode: params.executionMode,
+      executionMode: initialExecutionMode,
       acpRuntime: params.acpRuntime,
     });
-    await this.applyKimiAcpExecutionModeControlPrompt({
-      backend: params.backend,
-      client,
-      sessionId: session.sessionId,
-      fromExecutionMode: "default",
-      toExecutionMode: params.executionMode,
-    });
+    if (
+      this.usesKimiSlashExecutionModes(params.backend) &&
+      params.executionMode !== "default"
+    ) {
+      await this.applyKimiAcpThreadExecutionMode({
+        backend: params.backend,
+        threadId: session.sessionId,
+        executionMode: params.executionMode,
+      });
+    }
     await this.applyAcpRuntimeSelection(client, session.sessionId, params.acpRuntime);
     return { threadId: session.sessionId };
   }
 
   private async startAcpTurn(params: {
+    backend: AcpBackendId;
+    threadId: string;
+    input: AppServerTurnInputItem[];
+  }): Promise<{ backend: AppServerBackendKind; threadId: string; turnId: string }> {
+    return await this.acpSessionPromptLocks.run(
+      executionModeQueueKey(params.backend, params.threadId),
+      async () => await this.startAcpTurnLocked(params),
+    );
+  }
+
+  private async startAcpTurnLocked(params: {
     backend: AcpBackendId;
     threadId: string;
     input: AppServerTurnInputItem[];
@@ -4427,7 +4458,8 @@ export class DesktopBackendRegistry {
     });
     const currentApplied = overlay?.executionMode ?? "default";
     const hasActiveTurn = this.threadHasActiveTurn(params.threadId, "codex");
-    const hasQueue = this.queuedExecutionModes.has(params.threadId);
+    const queueKey = executionModeQueueKey("codex", params.threadId);
+    const hasQueue = this.queuedExecutionModes.has(queueKey);
 
     // Toggling back to the currently-applied mode while a queue is
     // pending is a cancel — the user changed their mind. No codex call,
@@ -4473,7 +4505,8 @@ export class DesktopBackendRegistry {
       params.threadId,
     );
     const hasActiveTurn = this.threadHasActiveTurn(params.threadId, params.backend);
-    const hasQueue = this.queuedExecutionModes.has(params.threadId);
+    const queueKey = executionModeQueueKey(params.backend, params.threadId);
+    const hasQueue = this.queuedExecutionModes.has(queueKey);
 
     if (hasQueue && params.executionMode === currentApplied) {
       await this.cancelThreadExecutionModeQueue({
@@ -4500,7 +4533,7 @@ export class DesktopBackendRegistry {
   }
 
   /**
-   * Snapshot of in-memory queued execution modes keyed by `threadId`.
+   * Snapshot of in-memory queued execution modes keyed by thread identity.
    * Consumed by the navigation snapshot path so the renderer sees
    * queued state on the very first snapshot after restart, without
    * waiting for a follow-up bus event. The queue map itself is not
@@ -4515,8 +4548,8 @@ export class DesktopBackendRegistry {
       string,
       { mode: ThreadExecutionMode; queuedAt: number }
     > = {};
-    for (const [threadId, entry] of this.queuedExecutionModes) {
-      snapshot[threadId] = {
+    for (const [queueKey, entry] of this.queuedExecutionModes) {
+      snapshot[queueKey] = {
         mode: entry.mode,
         queuedAt: entry.queuedAt,
       };
@@ -4580,7 +4613,9 @@ export class DesktopBackendRegistry {
     const queuedAt = Date.now();
     const queueId = randomUUID();
 
-    this.queuedExecutionModes.set(params.threadId, {
+    const queueKey = executionModeQueueKey(params.backend, params.threadId);
+
+    this.queuedExecutionModes.set(queueKey, {
       backend: params.backend,
       mode: params.executionMode,
       queuedAt,
@@ -4638,7 +4673,9 @@ export class DesktopBackendRegistry {
 
     const queue =
       this.backendUsesQueuedExecutionModes(params.backend)
-        ? this.queuedExecutionModes.get(params.threadId)
+        ? this.queuedExecutionModes.get(
+            executionModeQueueKey(params.backend, params.threadId),
+          )
         : undefined;
     if (!queue) {
       // Idempotent: cancel of nothing is a no-op that returns the
@@ -4650,7 +4687,9 @@ export class DesktopBackendRegistry {
       };
     }
 
-    this.queuedExecutionModes.delete(params.threadId);
+    this.queuedExecutionModes.delete(
+      executionModeQueueKey(params.backend, params.threadId),
+    );
 
     await this.appendPermissionTransition({
       backend: params.backend,
@@ -4898,10 +4937,25 @@ export class DesktopBackendRegistry {
     if (!params.client.sendControlPrompt) {
       throw new Error("Kimi ACP execution mode updates require control prompts");
     }
-    await params.client.sendControlPrompt({
-      sessionId: params.sessionId,
-      prompt: "/yolo",
-    });
+    const sendControlPrompt = params.client.sendControlPrompt;
+    const result = await this.acpSessionPromptLocks.run(
+      executionModeQueueKey(params.backend, params.sessionId),
+      async () =>
+        await sendControlPrompt({
+          sessionId: params.sessionId,
+          prompt: "/yolo",
+        }),
+    );
+    const observedMode = readKimiYoloExecutionModeFromText(result.text);
+    if (observedMode !== params.toExecutionMode) {
+      const target = formatExecutionModeForError(params.toExecutionMode);
+      const observed = observedMode
+        ? formatExecutionModeForError(observedMode)
+        : "unknown state";
+      throw new Error(
+        `Kimi ACP /yolo did not confirm ${target}; observed ${observed}`,
+      );
+    }
   }
 
   /**
@@ -4995,15 +5049,15 @@ export class DesktopBackendRegistry {
     threadId: string,
     backend: AppServerBackendKind = "codex",
   ): Promise<void> {
-    const activeFlush = this.queuedExecutionModeFlushes.get(threadId);
+    const queueKey = executionModeQueueKey(backend, threadId);
+    const activeFlush = this.queuedExecutionModeFlushes.get(queueKey);
     if (activeFlush) {
       await activeFlush;
       return;
     }
 
-    const queue = this.queuedExecutionModes.get(threadId);
+    const queue = this.queuedExecutionModes.get(queueKey);
     if (!queue) return;
-    if (queue.backend !== backend) return;
     // Atomic claim: in JS's single-threaded event loop, `Map.delete`
     // returning true gives this caller exclusive ownership of the
     // apply. Concurrent flushes (one from the emit-listener turn-end
@@ -5011,23 +5065,24 @@ export class DesktopBackendRegistry {
     // queue but only one's delete returns true — the other no-ops.
     // Without this, both callers race on applyThreadExecutionMode and
     // each appends a duplicate "applied" transition entry.
-    if (!this.queuedExecutionModes.delete(threadId)) {
+    if (!this.queuedExecutionModes.delete(queueKey)) {
       return;
     }
 
-    const flush = this.applyClaimedQueuedExecutionMode(threadId, queue);
-    this.queuedExecutionModeFlushes.set(threadId, flush);
+    const flush = this.applyClaimedQueuedExecutionMode(threadId, queueKey, queue);
+    this.queuedExecutionModeFlushes.set(queueKey, flush);
     try {
       await flush;
     } finally {
-      if (this.queuedExecutionModeFlushes.get(threadId) === flush) {
-        this.queuedExecutionModeFlushes.delete(threadId);
+      if (this.queuedExecutionModeFlushes.get(queueKey) === flush) {
+        this.queuedExecutionModeFlushes.delete(queueKey);
       }
     }
   }
 
   private async applyClaimedQueuedExecutionMode(
     threadId: string,
+    queueKey: string,
     queue: {
       backend: AppServerBackendKind;
       mode: ThreadExecutionMode;
@@ -5047,7 +5102,7 @@ export class DesktopBackendRegistry {
       );
     } catch (error) {
       const attempts = queue.flushAttempts + 1;
-      const stillRetained = this.queuedExecutionModes.get(threadId);
+      const stillRetained = this.queuedExecutionModes.get(queueKey);
       if (stillRetained && stillRetained.queueId !== queue.queueId) {
         // The queue was replaced while we were mid-apply (the user
         // queued a different target). Discard our retry — the new
@@ -5071,7 +5126,7 @@ export class DesktopBackendRegistry {
           queue.backend === "codex"
             ? overlay?.executionMode ?? "default"
             : await this.readAppliedExecutionMode(queue.backend, threadId);
-        this.queuedExecutionModes.delete(threadId);
+        this.queuedExecutionModes.delete(queueKey);
         await this.appendPermissionTransition({
           backend: queue.backend,
           threadId,
@@ -5097,7 +5152,7 @@ export class DesktopBackendRegistry {
         });
         return;
       }
-      this.queuedExecutionModes.set(threadId, {
+      this.queuedExecutionModes.set(queueKey, {
         ...queue,
         flushAttempts: attempts,
       });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -2704,6 +2704,9 @@ export class DesktopBackendRegistry {
           backend: backendId,
           threadId: thread.id,
         });
+        const executionMode =
+          this.latestAppliedExecutionModeFromOverlay(overlay) ??
+          thread.executionMode;
         const cwd = resolveThreadWorkspaceCwd(
           thread,
           overlay?.extraLinkedDirectories ?? [],
@@ -2713,6 +2716,7 @@ export class DesktopBackendRegistry {
           : [];
         return {
           ...thread,
+          executionMode,
           codexEnvironmentOptions,
         };
       }),
@@ -4548,6 +4552,14 @@ export class DesktopBackendRegistry {
       };
     }
 
+    if (params.executionMode === currentApplied) {
+      return {
+        backend: params.backend,
+        threadId: params.threadId,
+        executionMode: currentApplied,
+      };
+    }
+
     if (hasActiveTurn && params.executionMode !== currentApplied) {
       const queued = await this.queueThreadExecutionMode(params);
       return {
@@ -4612,11 +4624,25 @@ export class DesktopBackendRegistry {
       return overlay?.executionMode ?? "default";
     }
     if (this.usesKimiSlashExecutionModes(backend)) {
+      const overlay = await this.overlayStore.getThreadOverlayState({
+        backend,
+        threadId,
+      });
       return (
+        this.latestAppliedExecutionModeFromOverlay(overlay) ??
         this.acpBackend.getSession(backend, threadId)?.executionMode ?? "default"
       );
     }
     return "default";
+  }
+
+  private latestAppliedExecutionModeFromOverlay(
+    overlay: ThreadOverlayState | undefined,
+  ): ThreadExecutionMode | undefined {
+    return [...(overlay?.permissionTransitionLog ?? [])]
+      .reverse()
+      .find((transition) => transition.status === "applied")
+      ?.toExecutionMode;
   }
 
   async queueThreadExecutionMode(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -2678,29 +2678,51 @@ export class DesktopBackendRegistry {
     filter?: string,
     archived?: boolean,
   ): Promise<AppServerThreadSummary[]> {
-    return (await this.acpBackend.listAvailableAgents()).flatMap((agent) =>
-      this.listInstalledAcpThreads(agent.backendId, filter, archived),
+    const threadLists = await Promise.all(
+      (await this.acpBackend.listAvailableAgents()).map((agent) =>
+        this.listInstalledAcpThreads(agent.backendId, filter, archived),
+      ),
     );
+    return threadLists.flat();
   }
 
-  private listInstalledAcpThreads(
+  private async listInstalledAcpThreads(
     backendId: AppServerBackendKind,
     filter?: string,
     archived?: boolean,
-  ): AppServerThreadSummary[] {
+  ): Promise<AppServerThreadSummary[]> {
     if (!isAcpBackendId(backendId)) {
       return [];
     }
     const normalizedFilter = filter?.trim().toLowerCase();
-    return this.acpBackend
+    const threads = this.acpBackend
       .listSessions(backendId, { archived })
-      .map((session) => this.acpBackend.sessionToThreadSummary(session))
-      .filter(
-        (thread) =>
-          !normalizedFilter ||
-          thread.title.toLowerCase().includes(normalizedFilter) ||
-          thread.id.toLowerCase().includes(normalizedFilter),
-      );
+      .map((session) => this.acpBackend.sessionToThreadSummary(session));
+    const enrichedThreads = await Promise.all(
+      threads.map(async (thread) => {
+        const overlay = await this.overlayStore.getThreadOverlayState({
+          backend: backendId,
+          threadId: thread.id,
+        });
+        const cwd = resolveThreadWorkspaceCwd(
+          thread,
+          overlay?.extraLinkedDirectories ?? [],
+        );
+        const codexEnvironmentOptions = cwd
+          ? await listCodexEnvironmentOptions(cwd).catch(() => [])
+          : [];
+        return {
+          ...thread,
+          codexEnvironmentOptions,
+        };
+      }),
+    );
+    return enrichedThreads.filter(
+      (thread) =>
+        !normalizedFilter ||
+        thread.title.toLowerCase().includes(normalizedFilter) ||
+        thread.id.toLowerCase().includes(normalizedFilter),
+    );
   }
 
   private async readAcpThread(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1756,14 +1756,15 @@ export class DesktopBackendRegistry {
   /**
    * In-memory queue of pending permission-mode changes, keyed by
    * threadId. Populated when a user toggles execution mode while a turn
-   * is active; flushed to codex at the resume boundary (turn-end, or
-   * just before the next turn-start). Not persisted across app restart
-   * by design — the corresponding audit-log entries on overlay state
-   * carry the historical record.
+   * is active; flushed at the resume boundary (turn-end, or just before
+   * the next turn-start). Not persisted across app restart by design —
+   * the corresponding audit-log entries on overlay state carry the
+   * historical record.
    */
   private readonly queuedExecutionModes = new Map<
     string,
     {
+      backend: AppServerBackendKind;
       mode: ThreadExecutionMode;
       queuedAt: number;
       queueId: string;
@@ -2718,6 +2719,13 @@ export class DesktopBackendRegistry {
       cwd: params.cwd,
       executionMode: params.executionMode,
       acpRuntime: params.acpRuntime,
+    });
+    await this.applyKimiAcpExecutionModeControlPrompt({
+      backend: params.backend,
+      client,
+      sessionId: session.sessionId,
+      fromExecutionMode: "default",
+      toExecutionMode: params.executionMode,
     });
     await this.applyAcpRuntimeSelection(client, session.sessionId, params.acpRuntime);
     return { threadId: session.sessionId };
@@ -3961,6 +3969,12 @@ export class DesktopBackendRegistry {
       }
       this.reservedAcpStartThreadKeys.add(reservationKey);
       try {
+        if (this.usesKimiSlashExecutionModes(params.backend)) {
+          await this.flushQueuedExecutionModeIfPresent(
+            params.threadId,
+            params.backend,
+          );
+        }
         await this.flushQueuedAcpRuntimeOptionIfPresent(
           params.backend,
           params.threadId,
@@ -4376,6 +4390,15 @@ export class DesktopBackendRegistry {
     params: SetThreadExecutionModeRequest
   ): Promise<SetThreadExecutionModeResponse> {
     if (params.backend !== "codex") {
+      if (
+        isAcpBackendId(params.backend) &&
+        this.usesKimiSlashExecutionModes(params.backend)
+      ) {
+        return await this.setSlashControlledAcpExecutionMode({
+          ...params,
+          backend: params.backend,
+        });
+      }
       // Non-codex backends (e.g. Grok) currently no-op on execution
       // mode — no overlay write, no backend change. We still emit on
       // the bus so all surfaces stay visually consistent with the
@@ -4442,6 +4465,40 @@ export class DesktopBackendRegistry {
     return await this.applyThreadExecutionMode(params);
   }
 
+  private async setSlashControlledAcpExecutionMode(
+    params: SetThreadExecutionModeRequest & { backend: AcpBackendId },
+  ): Promise<SetThreadExecutionModeResponse> {
+    const currentApplied = await this.readAppliedExecutionMode(
+      params.backend,
+      params.threadId,
+    );
+    const hasActiveTurn = this.threadHasActiveTurn(params.threadId, params.backend);
+    const hasQueue = this.queuedExecutionModes.has(params.threadId);
+
+    if (hasQueue && params.executionMode === currentApplied) {
+      await this.cancelThreadExecutionModeQueue({
+        backend: params.backend,
+        threadId: params.threadId,
+      });
+      return {
+        backend: params.backend,
+        threadId: params.threadId,
+        executionMode: currentApplied,
+      };
+    }
+
+    if (hasActiveTurn && params.executionMode !== currentApplied) {
+      const queued = await this.queueThreadExecutionMode(params);
+      return {
+        backend: params.backend,
+        threadId: params.threadId,
+        executionMode: queued.queuedExecutionMode,
+      };
+    }
+
+    return await this.applyThreadExecutionMode(params);
+  }
+
   /**
    * Snapshot of in-memory queued execution modes keyed by `threadId`.
    * Consumed by the navigation snapshot path so the renderer sees
@@ -4467,10 +4524,44 @@ export class DesktopBackendRegistry {
     return snapshot;
   }
 
+  private usesKimiSlashExecutionModes(
+    backend: AppServerBackendKind,
+  ): backend is AcpBackendId {
+    return (
+      isAcpBackendId(backend) &&
+      this.acpBackend.getInstalledAgent(backend)?.registryId === "kimi"
+    );
+  }
+
+  private backendUsesQueuedExecutionModes(
+    backend: AppServerBackendKind,
+  ): boolean {
+    return backend === "codex" || this.usesKimiSlashExecutionModes(backend);
+  }
+
+  private async readAppliedExecutionMode(
+    backend: AppServerBackendKind,
+    threadId: string,
+  ): Promise<ThreadExecutionMode> {
+    if (backend === "codex") {
+      const overlay = await this.overlayStore.getThreadOverlayState({
+        backend,
+        threadId,
+      });
+      return overlay?.executionMode ?? "default";
+    }
+    if (this.usesKimiSlashExecutionModes(backend)) {
+      return (
+        this.acpBackend.getSession(backend, threadId)?.executionMode ?? "default"
+      );
+    }
+    return "default";
+  }
+
   async queueThreadExecutionMode(
     params: QueueThreadExecutionModeRequest,
   ): Promise<QueueThreadExecutionModeResponse> {
-    if (params.backend !== "codex") {
+    if (!this.backendUsesQueuedExecutionModes(params.backend)) {
       // Non-codex backends don't have a queue concept; fall through to
       // immediate apply so the caller observes consistent semantics.
       await this.setThreadExecutionMode(params);
@@ -4482,15 +4573,15 @@ export class DesktopBackendRegistry {
       };
     }
 
-    const overlay = await this.overlayStore.getThreadOverlayState({
-      backend: "codex",
-      threadId: params.threadId,
-    });
-    const currentApplied = overlay?.executionMode ?? "default";
+    const currentApplied = await this.readAppliedExecutionMode(
+      params.backend,
+      params.threadId,
+    );
     const queuedAt = Date.now();
     const queueId = randomUUID();
 
     this.queuedExecutionModes.set(params.threadId, {
+      backend: params.backend,
       mode: params.executionMode,
       queuedAt,
       queueId,
@@ -4498,6 +4589,7 @@ export class DesktopBackendRegistry {
     });
 
     await this.appendPermissionTransition({
+      backend: params.backend,
       threadId: params.threadId,
       transition: {
         id: randomUUID(),
@@ -4517,7 +4609,7 @@ export class DesktopBackendRegistry {
     });
 
     await this.emit({
-      backend: "codex",
+      backend: params.backend,
       notification: {
         method: "thread/executionMode/queued",
         params: {
@@ -4529,7 +4621,7 @@ export class DesktopBackendRegistry {
     });
 
     return {
-      backend: "codex",
+      backend: params.backend,
       threadId: params.threadId,
       queuedExecutionMode: params.executionMode,
       queuedAt,
@@ -4539,17 +4631,13 @@ export class DesktopBackendRegistry {
   async cancelThreadExecutionModeQueue(
     params: CancelThreadExecutionModeQueueRequest,
   ): Promise<CancelThreadExecutionModeQueueResponse> {
-    const overlay =
-      params.backend === "codex"
-        ? await this.overlayStore.getThreadOverlayState({
-            backend: "codex",
-            threadId: params.threadId,
-          })
-        : undefined;
-    const currentApplied = overlay?.executionMode ?? "default";
+    const currentApplied = await this.readAppliedExecutionMode(
+      params.backend,
+      params.threadId,
+    );
 
     const queue =
-      params.backend === "codex"
+      this.backendUsesQueuedExecutionModes(params.backend)
         ? this.queuedExecutionModes.get(params.threadId)
         : undefined;
     if (!queue) {
@@ -4565,6 +4653,7 @@ export class DesktopBackendRegistry {
     this.queuedExecutionModes.delete(params.threadId);
 
     await this.appendPermissionTransition({
+      backend: params.backend,
       threadId: params.threadId,
       transition: {
         id: randomUUID(),
@@ -4584,7 +4673,7 @@ export class DesktopBackendRegistry {
     });
 
     await this.emit({
-      backend: "codex",
+      backend: params.backend,
       notification: {
         method: "thread/executionMode/queueCleared",
         params: {
@@ -4613,6 +4702,18 @@ export class DesktopBackendRegistry {
     options?: { fromQueue?: boolean; queueId?: string },
   ): Promise<SetThreadExecutionModeResponse> {
     if (params.backend !== "codex") {
+      if (
+        isAcpBackendId(params.backend) &&
+        this.usesKimiSlashExecutionModes(params.backend)
+      ) {
+        return await this.applyKimiAcpThreadExecutionMode(
+          {
+            ...params,
+            backend: params.backend,
+          },
+          options,
+        );
+      }
       // The non-codex grok no-op path — preserved for symmetry. Direct
       // callers route through setThreadExecutionMode which short-circuits
       // before reaching this method, so we should never get here, but
@@ -4711,6 +4812,98 @@ export class DesktopBackendRegistry {
     };
   }
 
+  private async applyKimiAcpThreadExecutionMode(
+    params: SetThreadExecutionModeRequest & { backend: AcpBackendId },
+    options?: { fromQueue?: boolean; queueId?: string },
+  ): Promise<SetThreadExecutionModeResponse> {
+    const session = this.acpBackend.getSession(params.backend, params.threadId);
+    if (!session) {
+      throw new Error(`ACP session not found: ${params.threadId}`);
+    }
+    const previousApplied = session.executionMode ?? "default";
+    const client = await this.acpBackend.getClient(params.backend);
+    await client.ensureSession?.(session);
+    await this.applyKimiAcpExecutionModeControlPrompt({
+      backend: params.backend,
+      client,
+      sessionId: params.threadId,
+      fromExecutionMode: previousApplied,
+      toExecutionMode: params.executionMode,
+    });
+
+    const updatedAt = Date.now();
+    this.acpBackend.upsertSession({
+      ...session,
+      executionMode: params.executionMode,
+      updatedAt: Math.max(session.updatedAt, updatedAt),
+    });
+
+    await this.appendPermissionTransition({
+      backend: params.backend,
+      threadId: params.threadId,
+      transition: {
+        id: randomUUID(),
+        fromExecutionMode: previousApplied,
+        toExecutionMode: params.executionMode,
+        status: "applied",
+        occurredAt: updatedAt,
+        queueId: options?.queueId,
+      },
+    });
+
+    await this.emit({
+      backend: params.backend,
+      notification: {
+        method: "thread/executionMode/updated",
+        params: {
+          threadId: params.threadId,
+          executionMode: params.executionMode,
+        },
+      },
+    });
+
+    if (options?.fromQueue) {
+      await this.emit({
+        backend: params.backend,
+        notification: {
+          method: "thread/executionMode/queueCleared",
+          params: {
+            threadId: params.threadId,
+            reason: "applied",
+          },
+        },
+      });
+    }
+
+    return {
+      backend: params.backend,
+      threadId: params.threadId,
+      executionMode: params.executionMode,
+    };
+  }
+
+  private async applyKimiAcpExecutionModeControlPrompt(params: {
+    backend: AcpBackendId;
+    client: AcpRuntimeClient;
+    sessionId: string;
+    fromExecutionMode: ThreadExecutionMode;
+    toExecutionMode: ThreadExecutionMode;
+  }): Promise<void> {
+    if (!this.usesKimiSlashExecutionModes(params.backend)) {
+      return;
+    }
+    if (params.fromExecutionMode === params.toExecutionMode) {
+      return;
+    }
+    if (!params.client.sendControlPrompt) {
+      throw new Error("Kimi ACP execution mode updates require control prompts");
+    }
+    await params.client.sendControlPrompt({
+      sessionId: params.sessionId,
+      prompt: "/yolo",
+    });
+  }
+
   /**
    * Returns true iff the registry currently believes a turn is in
    * flight on this thread. `activeCodexTurnModes` is keyed by
@@ -4800,6 +4993,7 @@ export class DesktopBackendRegistry {
    */
   private async flushQueuedExecutionModeIfPresent(
     threadId: string,
+    backend: AppServerBackendKind = "codex",
   ): Promise<void> {
     const activeFlush = this.queuedExecutionModeFlushes.get(threadId);
     if (activeFlush) {
@@ -4809,6 +5003,7 @@ export class DesktopBackendRegistry {
 
     const queue = this.queuedExecutionModes.get(threadId);
     if (!queue) return;
+    if (queue.backend !== backend) return;
     // Atomic claim: in JS's single-threaded event loop, `Map.delete`
     // returning true gives this caller exclusive ownership of the
     // apply. Concurrent flushes (one from the emit-listener turn-end
@@ -4834,6 +5029,7 @@ export class DesktopBackendRegistry {
   private async applyClaimedQueuedExecutionMode(
     threadId: string,
     queue: {
+      backend: AppServerBackendKind;
       mode: ThreadExecutionMode;
       queuedAt: number;
       queueId: string;
@@ -4843,7 +5039,7 @@ export class DesktopBackendRegistry {
     try {
       await this.applyThreadExecutionMode(
         {
-          backend: "codex",
+          backend: queue.backend,
           threadId,
           executionMode: queue.mode,
         },
@@ -4869,11 +5065,15 @@ export class DesktopBackendRegistry {
           },
         );
         const overlay = await this.overlayStore
-          .getThreadOverlayState({ backend: "codex", threadId })
+          .getThreadOverlayState({ backend: queue.backend, threadId })
           .catch(() => undefined);
-        const currentApplied = overlay?.executionMode ?? "default";
+        const currentApplied =
+          queue.backend === "codex"
+            ? overlay?.executionMode ?? "default"
+            : await this.readAppliedExecutionMode(queue.backend, threadId);
         this.queuedExecutionModes.delete(threadId);
         await this.appendPermissionTransition({
+          backend: queue.backend,
           threadId,
           transition: {
             id: randomUUID(),
@@ -4886,7 +5086,7 @@ export class DesktopBackendRegistry {
           },
         });
         await this.emit({
-          backend: "codex",
+          backend: queue.backend,
           notification: {
             method: "thread/executionMode/queueCleared",
             params: {
@@ -8023,6 +8223,12 @@ export class DesktopBackendRegistry {
           notification.params.threadId,
         );
       } else if (isAcpBackendId(event.backend)) {
+        if (this.usesKimiSlashExecutionModes(event.backend)) {
+          void this.flushQueuedExecutionModeIfPresent(
+            notification.params.threadId,
+            event.backend,
+          );
+        }
         void this.flushQueuedAcpRuntimeOptionIfPresent(
           event.backend,
           notification.params.threadId,
@@ -8042,6 +8248,12 @@ export class DesktopBackendRegistry {
       }
       if (event.backend !== "codex") {
         if (isAcpBackendId(event.backend)) {
+          if (this.usesKimiSlashExecutionModes(event.backend)) {
+            void this.flushQueuedExecutionModeIfPresent(
+              event.notification.params.threadId,
+              event.backend,
+            );
+          }
           void this.flushQueuedAcpRuntimeOptionIfPresent(
             event.backend,
             event.notification.params.threadId,

--- a/apps/desktop/src/main/app-server/codex-environment-config.ts
+++ b/apps/desktop/src/main/app-server/codex-environment-config.ts
@@ -88,13 +88,6 @@ export function withCodexEnvironmentOptions(
   launchpad: NavigationLaunchpadDraft,
   options: CodexEnvironmentOption[],
 ): NavigationLaunchpadDraft {
-  if (launchpad.backend !== "codex") {
-    return {
-      ...launchpad,
-      codexEnvironmentOptions: [],
-    };
-  }
-
   if (options.length === 0) {
     return {
       ...launchpad,

--- a/apps/desktop/src/main/app-server/protocol-log-observer.ts
+++ b/apps/desktop/src/main/app-server/protocol-log-observer.ts
@@ -200,7 +200,13 @@ export function createProtocolLogObserver(
           sessionId: pickString(params, "sessionId"),
           turnId: pickString(params, "turnId"),
           threadId: pickString(params, "threadId"),
-          updateKind: pickString(update, "sessionUpdate", "kind", "type"),
+          updateKind: pickString(
+            update,
+            "sessionUpdate",
+            "session_update",
+            "kind",
+            "type",
+          ),
         }),
       );
       if (kind === "response" && id) {

--- a/apps/desktop/src/main/app-server/protocol-log-observer.ts
+++ b/apps/desktop/src/main/app-server/protocol-log-observer.ts
@@ -138,9 +138,18 @@ export function createProtocolLogObserver(
       const kind = classifyEnvelope(envelope);
       const method =
         envelope.method ?? (id ? requestMethodsById.get(id) : undefined) ?? "response";
+      const updateKind = pickString(
+        update,
+        "sessionUpdate",
+        "session_update",
+        "kind",
+        "type",
+      );
       const diagnostics =
         event.diagnostics ?? (id ? requestDiagnosticsById.get(id) : undefined);
-      const delta = pickRawString(params, "delta");
+      const delta =
+        pickRawString(params, "delta") ??
+        pickAcpStreamingSessionUpdateText(method, updateKind, update);
       const deltaKey = delta
         ? buildDeltaKey({
             backend: options.backend,
@@ -200,13 +209,7 @@ export function createProtocolLogObserver(
           sessionId: pickString(params, "sessionId"),
           turnId: pickString(params, "turnId"),
           threadId: pickString(params, "threadId"),
-          updateKind: pickString(
-            update,
-            "sessionUpdate",
-            "session_update",
-            "kind",
-            "type",
-          ),
+          updateKind,
         }),
       );
       if (kind === "response" && id) {
@@ -287,6 +290,22 @@ function pickRawString(
   return undefined;
 }
 
+function pickAcpStreamingSessionUpdateText(
+  method: string,
+  updateKind: string | undefined,
+  update: Record<string, unknown> | undefined,
+): string | undefined {
+  if (
+    method !== "session/update" ||
+    (updateKind !== "agent_message_chunk" &&
+      updateKind !== "agent_thought_chunk")
+  ) {
+    return undefined;
+  }
+  const content = asRecord(update?.content);
+  return pickRawString(content, "text") ?? pickRawString(update, "text");
+}
+
 function pickNumberOrString(
   record: Record<string, unknown> | undefined,
   ...keys: string[]
@@ -321,13 +340,19 @@ function buildDeltaKey(params: {
   params?: Record<string, unknown>;
 }): string {
   const item = asRecord(params.params?.item);
+  const update = asRecord(params.params?.update);
   return [
     `backend:${params.backend}`,
     `direction:${params.direction}`,
     `method:${params.method}`,
+    `session:${pickString(params.params, "sessionId") ?? "unknown"}`,
     `thread:${pickString(params.params, "threadId") ?? "unknown"}`,
     `turn:${pickString(params.params, "turnId") ?? "unknown"}`,
     `item:${pickString(params.params, "itemId") ?? pickString(item, "id") ?? "unknown"}`,
-    `stream:${pickString(params.params, "stream") ?? "text"}`,
+    `stream:${
+      pickString(params.params, "stream") ??
+      pickString(update, "sessionUpdate", "session_update", "kind", "type") ??
+      "text"
+    }`,
   ].join(" ");
 }

--- a/apps/desktop/src/main/app-server/protocol-log-observer.ts
+++ b/apps/desktop/src/main/app-server/protocol-log-observer.ts
@@ -3,6 +3,7 @@ import { getMainLogger } from "../log";
 
 const PROTOCOL_LOG_ENV = "PWRAGENT_APP_SERVER_PROTOCOL_LOG";
 const STREAM_LOG_INTERVAL_MS = 500;
+const COALESCED_MESSAGE_LOG_INTERVAL_MS = 1_000;
 const PREVIEW_LIMIT = 160;
 
 type ProtocolLogBackend = string;
@@ -14,6 +15,7 @@ type ProtocolLogObserverOptions = {
   logger?: ProtocolLogger;
   now?: () => number;
   streamLogIntervalMs?: number;
+  coalescedMessageLogIntervalMs?: number;
 };
 
 type JsonRpcEnvelope = JsonRpcObserverEvent["envelope"];
@@ -25,6 +27,14 @@ type DeltaBuffer = {
   lastAt: number;
   lastLoggedAt: number;
   preview: string;
+};
+
+type CoalescedMessageBuffer = {
+  firstAt: number;
+  lastAt: number;
+  lastLoggedAt: number;
+  lastFields: Partial<Record<string, unknown>>;
+  suppressedCount: number;
 };
 
 export function createCompositeJsonRpcObserver(
@@ -73,7 +83,10 @@ export function createProtocolLogObserver(
   const now = options.now ?? (() => Date.now());
   const streamLogIntervalMs =
     options.streamLogIntervalMs ?? STREAM_LOG_INTERVAL_MS;
+  const coalescedMessageLogIntervalMs =
+    options.coalescedMessageLogIntervalMs ?? COALESCED_MESSAGE_LOG_INTERVAL_MS;
   const deltaBuffers = new Map<string, DeltaBuffer>();
+  const coalescedMessageBuffers = new Map<string, CoalescedMessageBuffer>();
   const requestMethodsById = new Map<string, string>();
   const requestDiagnosticsById = new Map<
     string,
@@ -124,6 +137,62 @@ export function createProtocolLogObserver(
 
       logDeltaBuffer(key, buffer, "final");
       deltaBuffers.delete(key);
+    }
+  }
+
+  function logCoalescedMessageBuffer(
+    key: string,
+    buffer: CoalescedMessageBuffer,
+    reason: "interval",
+  ): void {
+    if (buffer.suppressedCount === 0) {
+      return;
+    }
+
+    logger.info(
+      "message coalesced",
+      compactFields({
+        ...buffer.lastFields,
+        coalescedDurationMs: buffer.lastAt - buffer.firstAt,
+        messageKey: key,
+        reason,
+        suppressedCount: buffer.suppressedCount,
+      }),
+    );
+  }
+
+  function logMessage(
+    fields: Partial<Record<string, unknown>>,
+    coalescedKey: string | undefined,
+  ): void {
+    if (!coalescedKey) {
+      logger.info("message", fields);
+      return;
+    }
+
+    const timestamp = now();
+    const buffer = coalescedMessageBuffers.get(coalescedKey);
+    if (!buffer) {
+      coalescedMessageBuffers.set(coalescedKey, {
+        firstAt: timestamp,
+        lastAt: timestamp,
+        lastFields: fields,
+        lastLoggedAt: timestamp,
+        suppressedCount: 0,
+      });
+      logger.info("message", fields);
+      return;
+    }
+
+    buffer.lastAt = timestamp;
+    buffer.lastFields = fields;
+    buffer.suppressedCount += 1;
+
+    if (timestamp - buffer.lastLoggedAt >= coalescedMessageLogIntervalMs) {
+      logCoalescedMessageBuffer(coalescedKey, buffer, "interval");
+      buffer.firstAt = timestamp;
+      buffer.lastLoggedAt = timestamp;
+      buffer.suppressedCount = 0;
     }
   }
 
@@ -192,26 +261,39 @@ export function createProtocolLogObserver(
         }
       }
       const paramKeys = Object.keys(params ?? {});
-      logger.info(
-        "message",
-        compactFields({
-          backend: options.backend,
-          callerReason: diagnostics?.callerReason,
-          direction: compactDirection(event.direction),
-          errorCode: pickNumberOrString(error, "code"),
-          errorMessage: pickString(error, "message"),
-          id,
-          itemId: pickString(params, "itemId") ?? pickString(item, "id"),
-          kind,
-          method,
-          ownerId: diagnostics?.ownerId,
-          paramKeys: paramKeys.length > 0 ? paramKeys : undefined,
-          sessionId: pickString(params, "sessionId"),
-          turnId: pickString(params, "turnId"),
-          threadId: pickString(params, "threadId"),
-          updateKind,
-        }),
-      );
+      const messageFields = compactFields({
+        backend: options.backend,
+        callerReason: diagnostics?.callerReason,
+        direction: compactDirection(event.direction),
+        errorCode: pickNumberOrString(error, "code"),
+        errorMessage: pickString(error, "message"),
+        id,
+        itemId: pickString(params, "itemId") ?? pickString(item, "id"),
+        kind,
+        method,
+        ownerId: diagnostics?.ownerId,
+        paramKeys: paramKeys.length > 0 ? paramKeys : undefined,
+        sessionId: pickString(params, "sessionId"),
+        status: pickString(update, "status"),
+        title: pickString(update, "title"),
+        toolCallId: pickString(update, "toolCallId", "tool_call_id", "id"),
+        turnId: pickString(params, "turnId"),
+        threadId: pickString(params, "threadId"),
+        updateKind,
+      });
+      const coalescedMessageKey = shouldCoalesceMessage({
+        backend: options.backend,
+        method,
+        updateKind,
+      })
+        ? buildCoalescedMessageKey({
+            backend: options.backend,
+            direction: event.direction,
+            method,
+            params,
+          })
+        : undefined;
+      logMessage(messageFields, coalescedMessageKey);
       if (kind === "response" && id) {
         requestMethodsById.delete(id);
         requestDiagnosticsById.delete(id);
@@ -323,6 +405,18 @@ function pickNumberOrString(
   return undefined;
 }
 
+function shouldCoalesceMessage(params: {
+  backend: ProtocolLogBackend;
+  method: string;
+  updateKind: string | undefined;
+}): boolean {
+  return (
+    params.backend.startsWith("acp:") &&
+    params.method === "session/update" &&
+    params.updateKind === "tool_call_update"
+  );
+}
+
 function appendPreview(existing: string, delta: string): string {
   const combined = `${existing}${delta}`;
   if (combined.length <= PREVIEW_LIMIT) {
@@ -354,5 +448,26 @@ function buildDeltaKey(params: {
       pickString(update, "sessionUpdate", "session_update", "kind", "type") ??
       "text"
     }`,
+  ].join(" ");
+}
+
+function buildCoalescedMessageKey(params: {
+  backend: ProtocolLogBackend;
+  direction: JsonRpcObserverEvent["direction"];
+  method: string;
+  params?: Record<string, unknown>;
+}): string {
+  const update = asRecord(params.params?.update);
+  return [
+    `backend:${params.backend}`,
+    `direction:${params.direction}`,
+    `method:${params.method}`,
+    `session:${pickString(params.params, "sessionId") ?? "unknown"}`,
+    `update:${
+      pickString(update, "sessionUpdate", "session_update", "kind", "type") ??
+      "unknown"
+    }`,
+    `tool:${pickString(update, "toolCallId", "tool_call_id", "id") ?? "unknown"}`,
+    `status:${pickString(update, "status") ?? "unknown"}`,
   ].join(" ");
 }

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -73,6 +73,17 @@ let unsubscribeRegistryEvents: (() => void) | undefined;
 
 const isDevelopment = process.env.NODE_ENV !== "production";
 const appServerLog = getMainLogger("pwragent:app-server");
+const AGENT_EVENT_LOG_INTERVAL_MS = 1_000;
+
+type CoalescedAgentEventLog = {
+  firstSuppressedAt: number;
+  lastLoggedAt: number;
+  lastSuppressedAt: number;
+  latestSummary: Record<string, unknown>;
+  suppressedCount: number;
+};
+
+const coalescedAgentEventLogs = new Map<string, CoalescedAgentEventLog>();
 
 function logDebug(event: string, payload: Record<string, unknown>): void {
   if (!isDevelopment) {
@@ -173,10 +184,71 @@ function summarizeAgentEvent(event: AgentEvent): Record<string, unknown> | undef
   return summary;
 }
 
+function logAgentEventSummary(summary: Record<string, unknown>): void {
+  if (!isDevelopment) {
+    return;
+  }
+
+  const key = coalescedAgentEventLogKey(summary);
+  if (!key) {
+    appServerLog.info("agentEvent", summary);
+    return;
+  }
+
+  const now = Date.now();
+  const existing = coalescedAgentEventLogs.get(key);
+  if (!existing) {
+    coalescedAgentEventLogs.set(key, {
+      firstSuppressedAt: now,
+      lastLoggedAt: now,
+      lastSuppressedAt: now,
+      latestSummary: summary,
+      suppressedCount: 0,
+    });
+    appServerLog.info("agentEvent", summary);
+    return;
+  }
+
+  existing.latestSummary = summary;
+  existing.lastSuppressedAt = now;
+  existing.suppressedCount += 1;
+  if (now - existing.lastLoggedAt < AGENT_EVENT_LOG_INTERVAL_MS) {
+    return;
+  }
+
+  appServerLog.info("agentEventCoalesced", {
+    ...existing.latestSummary,
+    coalescedDurationMs: existing.lastSuppressedAt - existing.firstSuppressedAt,
+    suppressedCount: existing.suppressedCount,
+  });
+  existing.firstSuppressedAt = now;
+  existing.lastLoggedAt = now;
+  existing.lastSuppressedAt = now;
+  existing.suppressedCount = 0;
+}
+
+function coalescedAgentEventLogKey(
+  summary: Record<string, unknown>,
+): string | undefined {
+  const method = summary.method;
+  if (method !== "item/started" && method !== "item/completed") {
+    return undefined;
+  }
+  return JSON.stringify({
+    backend: summary.backend,
+    itemType: summary.itemType,
+    method,
+    status: summary.status,
+    threadId: summary.threadId,
+    toolName: summary.toolName,
+    turnId: summary.turnId,
+  });
+}
+
 function broadcastAgentEvent(event: AgentEvent): void {
   const eventSummary = summarizeAgentEvent(event);
   if (eventSummary) {
-    logDebug("agentEvent", eventSummary);
+    logAgentEventSummary(eventSummary);
   }
 
   // Only deliver to windows that registered for this channel.

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -548,7 +548,7 @@ class DesktopAppServerService {
     const messagingBindingsByThreadKey = await buildMessagingBindingsByThreadKey(threads);
     const bindingsDurationMs = Date.now() - bindingsStartedAt;
     const automationsByThreadKey = buildAutomationSummariesByThreadKey();
-    const queuedExecutionModesByThreadId = getDesktopBackendRegistry()
+    const queuedExecutionModesByThreadKey = getDesktopBackendRegistry()
       .getQueuedExecutionModesSnapshot();
     const overlayStartedAt = Date.now();
     const snapshot = await this.getOverlayStore().reconcileNavigationSnapshot({
@@ -556,7 +556,7 @@ class DesktopAppServerService {
       automationsByThreadKey,
       fetchedAt: Date.now(),
       messagingBindingsByThreadKey,
-      queuedExecutionModesByThreadId,
+      queuedExecutionModesByThreadKey,
       threads,
       workspaceRoots: resolveScratchProjectsRoots(),
     });

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -62,13 +62,13 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
       filter: request.filter,
     });
     const messagingBindingsByThreadKey = await buildMessagingBindingsByThreadKey(threads);
-    const queuedExecutionModesByThreadId =
+    const queuedExecutionModesByThreadKey =
       this.registry.getQueuedExecutionModesSnapshot();
     const snapshot = await getDesktopOverlayStore().reconcileNavigationSnapshot({
       backend,
       fetchedAt: Date.now(),
       messagingBindingsByThreadKey,
-      queuedExecutionModesByThreadId,
+      queuedExecutionModesByThreadKey,
       threads,
       workspaceRoots: resolveScratchProjectsRoots(),
     });

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -69,13 +69,13 @@ export class SqliteOverlayStore {
     >;
     automationsByThreadKey?: Record<string, AutomationThreadSummary | undefined>;
     /**
-     * In-memory permission-mode queue map keyed by `threadId`. The queue
+     * In-memory permission-mode queue map keyed by thread identity. The queue
      * lives on the registry (not in sqlite) but must be merged onto the
      * snapshot so renderers connecting after the queued bus event still
      * see the queued state. Also feeds the snapshot hash so changes
      * invalidate the cache.
      */
-    queuedExecutionModesByThreadId?: Record<
+    queuedExecutionModesByThreadKey?: Record<
       string,
       { mode: ThreadExecutionMode; queuedAt: number } | undefined
     >;
@@ -120,7 +120,7 @@ export class SqliteOverlayStore {
       params.threads.map((thread) => {
         const threadKey = buildThreadIdentityKey(thread.source, thread.id);
         const overlay = this.getThread(threadKey);
-        const queue = params.queuedExecutionModesByThreadId?.[thread.id];
+        const queue = params.queuedExecutionModesByThreadKey?.[threadKey];
         if (queue) {
           // Merge the in-memory queue onto the persisted overlay so
           // mid-restart / mid-connect renderers see the queued state

--- a/apps/desktop/src/main/testing/protocol-capture.ts
+++ b/apps/desktop/src/main/testing/protocol-capture.ts
@@ -6,6 +6,7 @@ import { ProtocolCaptureStore } from "./capture-store";
 
 const CAPTURE_ENABLED_ENV = "PWRAGENT_PROTOCOL_CAPTURE";
 const CAPTURE_ROOT_ENV = "PWRAGENT_PROTOCOL_CAPTURE_ROOT";
+const PROTOCOL_LOG_ENV = "PWRAGENT_APP_SERVER_PROTOCOL_LOG";
 const protocolCaptureLog = getMainLogger("pwragent:protocol-capture");
 
 export function createProtocolCaptureObserver(params: {
@@ -31,7 +32,8 @@ export function createProtocolCaptureFromEnv(params: {
   store: ProtocolCaptureStore;
   observer: JsonRpcObserver;
 } | undefined {
-  if (!isCaptureEnabled(process.env[CAPTURE_ENABLED_ENV])) {
+  const enabledBy = captureEnabledBy();
+  if (!enabledBy) {
     return undefined;
   }
 
@@ -49,6 +51,7 @@ export function createProtocolCaptureFromEnv(params: {
     backend: params.backend,
     backendInstance: params.backendInstance,
     captureId,
+    enabledBy,
     path: store.captureFilePath,
     indexPath: store.indexFilePath,
   });
@@ -70,6 +73,16 @@ function buildCaptureId(backend: string, backendInstance: string): string {
 function sanitizeCapturePart(value: string): string {
   const normalized = value.trim().toLowerCase().replace(/[^a-z0-9_-]+/g, "-");
   return normalized || "default";
+}
+
+function captureEnabledBy(): string | undefined {
+  if (isCaptureEnabled(process.env[CAPTURE_ENABLED_ENV])) {
+    return CAPTURE_ENABLED_ENV;
+  }
+  if (isCaptureEnabled(process.env[PROTOCOL_LOG_ENV])) {
+    return PROTOCOL_LOG_ENV;
+  }
+  return undefined;
 }
 
 function isCaptureEnabled(value: string | undefined): boolean {

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1318,6 +1318,7 @@ export function Composer(props: ComposerProps) {
       ),
     [props.backends, props.launchpad?.backend, props.thread?.source]
   );
+  const supportsReview = backend ? backend.capabilities.startReview !== false : true;
 
   const selectionStart = Math.min(
     inputRef.current?.selectionStart ?? draft.length,
@@ -1862,7 +1863,7 @@ export function Composer(props: ComposerProps) {
       .map((match) => match.skill);
   }, [props.skills, trigger]);
   const filteredSlashCommands = useMemo(() => {
-    if (!slashTrigger) {
+    if (!slashTrigger || !supportsReview) {
       return [];
     }
 
@@ -1872,7 +1873,7 @@ export function Composer(props: ComposerProps) {
         command.label.toLowerCase().startsWith(typed) ||
         command.description.toLowerCase().includes(typed.slice(1))
     );
-  }, [draft, slashTrigger]);
+  }, [draft, slashTrigger, supportsReview]);
   const availableAutocompleteKind: AutocompleteKind | undefined = trigger && filteredSkills.length > 0
     ? "skills"
     : slashTrigger && filteredSlashCommands.length > 0
@@ -1919,7 +1920,15 @@ export function Composer(props: ComposerProps) {
     [props.directory, props.thread]
   );
   const isBareReviewCommand = draft.trim() === "/review";
-  const isReviewComposerOpen = Boolean(reviewConfig && isBareReviewCommand);
+  const isReviewComposerOpen = Boolean(
+    supportsReview && reviewConfig && isBareReviewCommand
+  );
+
+  useEffect(() => {
+    if (!supportsReview && reviewConfig) {
+      setReviewConfig(undefined);
+    }
+  }, [reviewConfig, supportsReview]);
 
   useEffect(() => {
     return () => {
@@ -2293,6 +2302,11 @@ export function Composer(props: ComposerProps) {
   }): Promise<void> => {
     if (props.disabled) {
       restoreQueuedTurnIfClaimed(options?.queued, options?.queueClaimed);
+      return;
+    }
+    if (!supportsReview) {
+      restoreQueuedTurnIfClaimed(options?.queued, options?.queueClaimed);
+      setSendError("Selected backend does not support reviews.");
       return;
     }
     if (!options?.queued && imageAttachments.length > 0) {
@@ -2760,7 +2774,7 @@ export function Composer(props: ComposerProps) {
   };
 
   const submitTurn = async (mode: "default" | "steer" = "default"): Promise<void> => {
-    const reviewCommand = parseReviewCommand(draft);
+    const reviewCommand = supportsReview ? parseReviewCommand(draft) : undefined;
     if (shouldQueueThreadSubmit()) {
       if (activeTurnIdRef.current && mode === "steer") {
         steerCurrentDraft();

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -3186,7 +3186,6 @@ export function Composer(props: ComposerProps) {
   const runThreadCodexEnvironmentAction = async (): Promise<void> => {
     if (
       !props.thread ||
-      props.thread.source !== "codex" ||
       !props.desktopApi?.runCodexEnvironmentAction ||
       !selectedThreadCodexAction
     ) {
@@ -3215,7 +3214,6 @@ export function Composer(props: ComposerProps) {
   ): Promise<void> => {
     if (
       !props.thread ||
-      props.thread.source !== "codex" ||
       !props.desktopApi?.setCodexThreadEnvironment
     ) {
       return;
@@ -3224,7 +3222,7 @@ export function Composer(props: ComposerProps) {
     setSendError(undefined);
     setSelectedThreadCodexActionId("");
     props.onPendingStatusChange?.(
-      environmentId ? "Selecting Codex environment" : "Clearing Codex environment",
+      environmentId ? "Selecting environment" : "Clearing environment",
     );
     try {
       await props.desktopApi.setCodexThreadEnvironment({
@@ -3353,24 +3351,18 @@ export function Composer(props: ComposerProps) {
       ? props.launchpad.workMode
       : "local";
   const launchpadCodexEnvironmentOptions =
-    props.launchpad?.backend === "codex"
-      ? props.launchpad.codexEnvironmentOptions ?? []
-      : [];
+    props.launchpad?.codexEnvironmentOptions ?? [];
   const selectedCodexEnvironment = launchpadCodexEnvironmentOptions.find(
     (environment) => environment.id === props.launchpad?.codexEnvironmentId,
   );
   const threadCodexEnvironmentOptions =
-    props.thread?.source === "codex"
-      ? props.thread.codexEnvironmentOptions ?? []
-      : [];
+    props.thread?.codexEnvironmentOptions ?? [];
   const selectedThreadCodexEnvironmentOption = threadCodexEnvironmentOptions.find(
     (environment) =>
       environment.id === props.thread?.codexEnvironmentRuntime?.environmentId,
   );
   const runtimeThreadCodexEnvironmentActions =
-    props.thread?.source === "codex"
-      ? props.thread.codexEnvironmentRuntime?.actions ?? []
-      : [];
+    props.thread?.codexEnvironmentRuntime?.actions ?? [];
   const threadCodexEnvironmentActions =
     runtimeThreadCodexEnvironmentActions.length > 0
       ? runtimeThreadCodexEnvironmentActions
@@ -4899,7 +4891,7 @@ export function Composer(props: ComposerProps) {
           <div className="composer__application-actions" aria-label="Composer tools">
             {props.launchpad && launchpadCodexEnvironmentOptions.length > 0 ? (
               <ComposerDropdown
-                ariaLabel="Codex environment"
+                ariaLabel="Environment"
                 compact
                 disabled={launchpadSubmitting}
                 icon={FileCodeIcon}
@@ -4947,7 +4939,7 @@ export function Composer(props: ComposerProps) {
 
             {!props.launchpad && threadCodexEnvironmentOptions.length > 0 ? (
               <ComposerDropdown
-                ariaLabel="Codex environment"
+                ariaLabel="Environment"
                 compact
                 disabled={!props.desktopApi?.setCodexThreadEnvironment}
                 icon={FileCodeIcon}

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -4524,7 +4524,7 @@ export function Composer(props: ComposerProps) {
           ) : null}
 
           {availableExecutionModes.length > 0 &&
-          (props.launchpad || (props.thread?.source === "codex" && props.onSetExecutionMode)) ? (
+          (props.launchpad || (props.thread && props.onSetExecutionMode)) ? (
             <ComposerDropdown
               ariaLabel="Access mode"
               compact

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -4564,7 +4564,7 @@ export function Composer(props: ComposerProps) {
 
           {acpRuntimeModeControl ? (
             <ComposerDropdown
-              ariaLabel="ACP mode"
+              ariaLabel="Agent mode"
               compact
               disabled={
                 launchpadSubmitting ||

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1318,7 +1318,10 @@ export function Composer(props: ComposerProps) {
       ),
     [props.backends, props.launchpad?.backend, props.thread?.source]
   );
-  const supportsReview = backend ? backend.capabilities.startReview !== false : true;
+  const supportsReview =
+    backend?.kind.startsWith("acp:") === true
+      ? backend.capabilities.startReview !== false
+      : true;
 
   const selectionStart = Math.min(
     inputRef.current?.selectionStart ?? draft.length,

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -3234,6 +3234,55 @@ describe("Composer", () => {
     });
   });
 
+  it("shows ACP thread access in the composer", async () => {
+    const onSetExecutionMode = vi.fn(async () => undefined);
+
+    render(
+      <Composer
+        backends={[
+          {
+            ...backendSummary("acp:kimi"),
+            label: "Kimi Code CLI",
+            executionModes: [
+              {
+                mode: "default",
+                label: "Default Access",
+                available: true,
+                isDefault: true,
+              },
+              {
+                mode: "full-access",
+                label: "Full Access",
+                available: true,
+              },
+            ],
+          },
+        ]}
+        disabled={false}
+        fullAccessRiskWarningDismissed
+        onSetExecutionMode={onSetExecutionMode}
+        skills={[]}
+        thread={{
+          id: "kimi-session-1",
+          title: "Kimi thread",
+          titleSource: "explicit",
+          source: "acp:kimi",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />,
+    );
+
+    expect(screen.getByLabelText("Access mode")).toHaveValue("default");
+
+    chooseDropdownOption("Access mode", "Full Access");
+
+    await waitFor(() => {
+      expect(onSetExecutionMode).toHaveBeenCalledWith("full-access");
+    });
+  });
+
   it("submits a local-to-worktree handoff on a new branch", async () => {
     const onHandoffThreadWorkspace = vi.fn(async () => undefined);
 

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -535,7 +535,7 @@ describe("Composer", () => {
       />,
     );
 
-    expect(screen.getByLabelText("Codex environment")).toHaveTextContent("PwrAgnt");
+    expect(screen.getByLabelText("Environment")).toHaveTextContent("PwrAgnt");
     expect(screen.getByLabelText("Environment command")).toHaveTextContent(
       "Dev - Messaging",
     );
@@ -549,7 +549,7 @@ describe("Composer", () => {
       });
     });
 
-    chooseDropdownOption("Codex environment", "No environment");
+    chooseDropdownOption("Environment", "No environment");
     await waitFor(() => {
       expect(setCodexThreadEnvironment).toHaveBeenCalledWith({
         backend: "codex",
@@ -596,7 +596,7 @@ describe("Composer", () => {
       "No commands",
     );
     expect(screen.getByLabelText("Environment command")).toBeDisabled();
-    expect(screen.getByLabelText("Codex environment")).toHaveTextContent("PwrAgnt");
+    expect(screen.getByLabelText("Environment")).toHaveTextContent("PwrAgnt");
   });
 
   it("hides thread environment commands when no environment is selected", () => {
@@ -632,7 +632,7 @@ describe("Composer", () => {
       />,
     );
 
-    expect(screen.getByLabelText("Codex environment")).toHaveTextContent(
+    expect(screen.getByLabelText("Environment")).toHaveTextContent(
       "No environment",
     );
     expect(screen.queryByLabelText("Environment command")).not.toBeInTheDocument();
@@ -685,10 +685,62 @@ describe("Composer", () => {
       />,
     );
 
-    expect(screen.getByLabelText("Codex environment")).toHaveTextContent("PwrAgnt");
+    expect(screen.getByLabelText("Environment")).toHaveTextContent("PwrAgnt");
     expect(screen.getByText("Run setup")).toBeInTheDocument();
     expect(screen.queryByLabelText("Environment command")).not.toBeInTheDocument();
     expect(screen.queryByText("No command")).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ["acp:gemini", acpGeminiBackendSummary()],
+    ["acp:kimi", backendSummary("acp:kimi")],
+  ] as const)("shows the launchpad environment picker for %s", (_backendId, backend) => {
+    const updateLaunchpad = vi.fn(async () => undefined);
+    render(
+      <Composer
+        backends={[backend]}
+        disabled={false}
+        launchpad={{
+          directoryKey: "directory:/repo/PwrAgent",
+          directoryKind: "directory",
+          directoryLabel: "PwrAgent",
+          directoryPath: "/repo/PwrAgent",
+          backend: backend.kind,
+          executionMode: "default",
+          prompt: "",
+          workMode: "local",
+          codexEnvironmentOptions: [
+            {
+              id: "environment",
+              name: "PwrAgnt",
+              sourcePath: "/repo/.codex/environments/environment.toml",
+              setupScript: "pnpm install",
+              actions: [],
+            },
+          ],
+          createdAt: 1,
+          updatedAt: 1,
+        }}
+        onUpdateLaunchpad={updateLaunchpad}
+        skills={[]}
+      />,
+    );
+
+    expect(screen.getByLabelText("Environment")).toHaveTextContent(
+      "No environment",
+    );
+
+    chooseDropdownOption("Environment", "PwrAgnt");
+
+    expect(updateLaunchpad).toHaveBeenCalledWith(
+      "directory:/repo/PwrAgent",
+      expect.objectContaining({
+        codexEnvironmentId: "environment",
+        codexEnvironmentExecutionTarget: "local",
+        codexEnvironmentSetupEnabled: true,
+      }),
+      expect.any(Object),
+    );
   });
 
   it("shows an orange moon for reported context window usage", () => {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -2640,6 +2640,63 @@ describe("Composer", () => {
     expect(startTurn).not.toHaveBeenCalled();
   });
 
+  it("does not open the review picker for backends without review support", async () => {
+    const kimiBackend = backendSummary("acp:kimi" as BackendSummary["kind"]);
+    const startReview = vi.fn();
+    const startTurn = vi.fn(async (request: StartTurnRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      turnId: "turn-1",
+    }));
+
+    render(
+      <Composer
+        backends={[
+          {
+            ...kimiBackend,
+            capabilities: {
+              ...kimiBackend.capabilities,
+              startReview: false,
+            },
+          },
+        ]}
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview,
+          startTurn,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "kimi-session-1",
+          title: "Kimi thread",
+          titleSource: "explicit",
+          source: "acp:kimi",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review" },
+    });
+    await clickButton("Send");
+
+    expect(screen.queryByRole("group", { name: "Review target" })).not.toBeInTheDocument();
+    expect(startReview).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          backend: "acp:kimi",
+          threadId: "kimi-session-1",
+          input: [{ type: "text", text: "/review" }],
+        }),
+      );
+    });
+  });
+
   it("queues review target submissions while a turn is active", async () => {
     const startReview = vi.fn(async (request: StartReviewRequest) => ({
       backend: request.backend,

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -4841,7 +4841,7 @@ describe("Composer", () => {
       />
     );
 
-    chooseDropdownOption("ACP mode", "Yolo");
+    chooseDropdownOption("Agent mode", "Yolo");
 
     await waitFor(() => {
       expect(onUpdateLaunchpad).toHaveBeenCalledWith(

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -2055,7 +2055,7 @@ export function ThreadView(props: ThreadViewProps) {
               }
               environmentName={
                 selectedThread.codexEnvironmentRuntime?.environmentName ??
-                "Codex environment"
+                "Environment"
               }
               error={props.archiveThreadError ?? setupFailureContinueError}
               exitCode={

--- a/apps/desktop/src/renderer/src/lib/__tests__/backend-label.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/backend-label.test.ts
@@ -3,7 +3,7 @@ import type { BackendSummary } from "@pwragent/shared";
 import { formatBackendLabel } from "../backend-label";
 
 describe("formatBackendLabel", () => {
-  it("uses backend summaries for dynamic ACP labels", () => {
+  it("uses canonical labels for known ACP providers", () => {
     expect(
       formatBackendLabel("acp:gemini", [
         {
@@ -29,7 +29,62 @@ describe("formatBackendLabel", () => {
           executionModes: [],
         } satisfies BackendSummary,
       ]),
-    ).toBe("Gemini CLI");
+    ).toBe("Gemini");
+    expect(
+      formatBackendLabel("acp:kimi", [
+        {
+          kind: "acp:kimi",
+          source: "acp",
+          label: "Kimi Code CLI",
+          available: true,
+          methods: [],
+          capabilities: {
+            listThreads: true,
+            createThread: true,
+            resumeThread: true,
+            renameThread: false,
+            readThread: true,
+            startTurn: true,
+            interruptTurn: true,
+            steerTurn: false,
+            transcriptPagination: false,
+            toolUse: true,
+            approvalRequests: true,
+            multiDirectoryThreads: true,
+          },
+          executionModes: [],
+        } satisfies BackendSummary,
+      ]),
+    ).toBe("Kimi");
+  });
+
+  it("uses backend summaries for unknown dynamic ACP labels", () => {
+    expect(
+      formatBackendLabel("acp:custom", [
+        {
+          kind: "acp:custom",
+          source: "acp",
+          label: "Custom ACP",
+          available: true,
+          methods: [],
+          capabilities: {
+            listThreads: true,
+            createThread: true,
+            resumeThread: true,
+            renameThread: false,
+            readThread: true,
+            startTurn: true,
+            interruptTurn: true,
+            steerTurn: false,
+            transcriptPagination: false,
+            toolUse: true,
+            approvalRequests: true,
+            multiDirectoryThreads: true,
+          },
+          executionModes: [],
+        } satisfies BackendSummary,
+      ]),
+    ).toBe("Custom ACP");
   });
 
   it("falls back to stable built-in and ACP labels", () => {

--- a/apps/desktop/src/renderer/src/lib/__tests__/backend-label.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/backend-label.test.ts
@@ -35,6 +35,8 @@ describe("formatBackendLabel", () => {
   it("falls back to stable built-in and ACP labels", () => {
     expect(formatBackendLabel("codex")).toBe("OpenAI");
     expect(formatBackendLabel("grok")).toBe("Grok");
+    expect(formatBackendLabel("acp:gemini")).toBe("Gemini");
+    expect(formatBackendLabel("acp:kimi")).toBe("Kimi");
     expect(formatBackendLabel("acp:unknown")).toBe("unknown");
   });
 });

--- a/apps/desktop/src/renderer/src/lib/__tests__/execution-mode.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/execution-mode.test.ts
@@ -86,6 +86,25 @@ describe("ACP execution mode labels", () => {
       source: "configOption",
       value: "yolo",
     });
-    expect(formatAccessModeLabel(thread, acpBackend)).toBe("Yolo");
+    expect(formatAccessModeLabel(thread, acpBackend)).toBe("Default Access");
+  });
+
+  it("does not expose single-option ACP runtime modes as composer controls", () => {
+    const singleModeBackend = {
+      ...acpBackend,
+      acp: {
+        ...acpBackend.acp,
+        runtime: {
+          schemaVersion: 1,
+          status: "discovered",
+          modes: {
+            availableModes: [{ id: "default", label: "Default" }],
+            currentModeId: "default",
+          },
+        },
+      },
+    } satisfies BackendSummary;
+
+    expect(getAcpRuntimeModeControl(singleModeBackend, thread)).toBeUndefined();
   });
 });

--- a/apps/desktop/src/renderer/src/lib/__tests__/useBackendSummaries.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useBackendSummaries.test.tsx
@@ -225,4 +225,114 @@ describe("useBackendSummaries", () => {
     });
     expect(listBackends).toHaveBeenCalledTimes(2);
   });
+
+  it("refreshes ACP model details when runtime capabilities update", async () => {
+    let eventHandler: ((event: AgentEvent) => void) | undefined;
+    const listBackends = vi
+      .fn<NonNullable<DesktopApi["listBackends"]>>()
+      .mockResolvedValueOnce({
+        fetchedAt: 1,
+        backends: [
+          {
+            kind: "acp:kimi",
+            source: "acp",
+            label: "Kimi Code CLI",
+            available: true,
+            methods: [],
+            capabilities: {
+              listThreads: true,
+              createThread: true,
+              resumeThread: true,
+              archiveThread: true,
+              restoreThread: true,
+              archiveWorktree: false,
+              restoreWorktree: false,
+              renameThread: true,
+              readThread: true,
+              startTurn: true,
+              startReview: false,
+              interruptTurn: true,
+              steerTurn: false,
+              transcriptPagination: false,
+              toolUse: true,
+              approvalRequests: true,
+              multiDirectoryThreads: true,
+            },
+            executionModes: [],
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        fetchedAt: 2,
+        backends: [
+          {
+            kind: "acp:kimi",
+            source: "acp",
+            label: "Kimi Code CLI",
+            available: true,
+            methods: [],
+            capabilities: {
+              listThreads: true,
+              createThread: true,
+              resumeThread: true,
+              archiveThread: true,
+              restoreThread: true,
+              archiveWorktree: false,
+              restoreWorktree: false,
+              renameThread: true,
+              readThread: true,
+              startTurn: true,
+              startReview: false,
+              interruptTurn: true,
+              steerTurn: false,
+              transcriptPagination: false,
+              toolUse: true,
+              approvalRequests: true,
+              multiDirectoryThreads: true,
+            },
+            executionModes: [],
+            launchpadOptions: {
+              models: [
+                {
+                  id: "kimi-code/kimi-for-coding,thinking",
+                  label: "kimi-for-coding (thinking)",
+                  current: true,
+                },
+              ],
+            },
+          },
+        ],
+      });
+    const desktopApi: DesktopApi = {
+      listBackends,
+      onAgentEvent: (callback) => {
+        eventHandler = callback;
+        return () => undefined;
+      },
+    };
+
+    const { result } = renderHook(() => useBackendSummaries(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.backends[0]?.launchpadOptions).toBeUndefined();
+    });
+
+    eventHandler?.({
+      backend: "acp:kimi",
+      notification: {
+        method: "backend/acpRuntimeCapabilities/updated",
+        params: {
+          backend: "acp:kimi",
+        },
+      },
+    });
+
+    await waitFor(() => {
+      expect(result.current.backends[0]?.launchpadOptions?.models?.[0]).toMatchObject({
+        id: "kimi-code/kimi-for-coding,thinking",
+        label: "kimi-for-coding (thinking)",
+      });
+    });
+    expect(listBackends).toHaveBeenCalledTimes(2);
+  });
 });

--- a/apps/desktop/src/renderer/src/lib/backend-label.ts
+++ b/apps/desktop/src/renderer/src/lib/backend-label.ts
@@ -14,5 +14,15 @@ export function formatBackendLabel(
   if (backend === "grok") {
     return "Grok";
   }
-  return backend.startsWith("acp:") ? backend.slice("acp:".length) : backend;
+  if (backend.startsWith("acp:")) {
+    const registryId = backend.slice("acp:".length);
+    if (registryId === "gemini") {
+      return "Gemini";
+    }
+    if (registryId === "kimi") {
+      return "Kimi";
+    }
+    return registryId;
+  }
+  return backend;
 }

--- a/apps/desktop/src/renderer/src/lib/backend-label.ts
+++ b/apps/desktop/src/renderer/src/lib/backend-label.ts
@@ -4,6 +4,12 @@ export function formatBackendLabel(
   backend: AppServerBackendKind,
   summaries: BackendSummary[] = [],
 ): string {
+  if (backend === "acp:gemini") {
+    return "Gemini";
+  }
+  if (backend === "acp:kimi") {
+    return "Kimi";
+  }
   const summary = summaries.find((candidate) => candidate.kind === backend);
   if (summary?.label) {
     return summary.label;
@@ -16,12 +22,6 @@ export function formatBackendLabel(
   }
   if (backend.startsWith("acp:")) {
     const registryId = backend.slice("acp:".length);
-    if (registryId === "gemini") {
-      return "Gemini";
-    }
-    if (registryId === "kimi") {
-      return "Kimi";
-    }
     return registryId;
   }
   return backend;

--- a/apps/desktop/src/renderer/src/lib/execution-mode.ts
+++ b/apps/desktop/src/renderer/src/lib/execution-mode.ts
@@ -35,6 +35,9 @@ export function getAcpRuntimeModeControl(
     (option) => option.category === "mode" && option.values.length > 0,
   );
   if (modeConfigOption) {
+    if (modeConfigOption.values.length < 2) {
+      return undefined;
+    }
     const currentModeValue =
       settings?.acpRuntime?.currentModeId &&
       modeConfigOption.values.some(
@@ -60,7 +63,7 @@ export function getAcpRuntimeModeControl(
   }
 
   const modeOptions = runtime.modes?.availableModes ?? [];
-  if (modeOptions.length === 0) {
+  if (modeOptions.length < 2) {
     return undefined;
   }
 
@@ -81,15 +84,8 @@ export function getAcpRuntimeModeControl(
 
 export function formatAccessModeLabel(
   settings: NavigationLaunchpadDraft | NavigationThreadSummary,
-  backend?: BackendSummary,
+  _backend?: BackendSummary,
 ): string {
-  const acpMode = getAcpRuntimeModeControl(backend, settings);
-  if (acpMode) {
-    return (
-      acpMode.options.find((option) => option.value === acpMode.value)?.label ??
-      formatAcpRuntimeModeLabel(acpMode.value)
-    );
-  }
   return formatExecutionModeLabel(settings.executionMode);
 }
 

--- a/apps/desktop/src/renderer/src/lib/useBackendSummaries.ts
+++ b/apps/desktop/src/renderer/src/lib/useBackendSummaries.ts
@@ -72,9 +72,10 @@ export function useBackendSummaries(
     }
     return desktopApi.onAgentEvent((event) => {
       if (
-        event.backend === "codex" &&
-        (event.notification.method === "account/rateLimits/updated" ||
-          event.notification.method === "account/updated")
+        (event.backend === "codex" &&
+          (event.notification.method === "account/rateLimits/updated" ||
+            event.notification.method === "account/updated")) ||
+        event.notification.method === "backend/acpRuntimeCapabilities/updated"
       ) {
         void refresh();
       }

--- a/docs/acp-registry-backends.md
+++ b/docs/acp-registry-backends.md
@@ -55,6 +55,12 @@ the active PwrAgent profile sqlite database under `~/.pwragent/profiles/<name>/`
 Installed agents continue to be listed from profile state when the registry is
 temporarily unavailable.
 
+ACP session metadata does not include full transcript history. Providers that
+support `session/load` remain the source of truth for restored ACP transcripts.
+If PwrAgent later needs to persist fallback history for an ACP provider that
+cannot restore its own sessions, use append-only JSONL rollout files rather
+than sqlite; see [thread-history-persistence.md](thread-history-persistence.md).
+
 ## Rollout Notes
 
 Ship with a narrow allowlist. Add new agents only after agent-specific smoke

--- a/docs/state-layout.md
+++ b/docs/state-layout.md
@@ -50,7 +50,16 @@ graph TD
     Shell -.->|opt-in recording| Observer
 ```
 
-**Desktop** uses sqlite for all structured persistent state (messaging, overlay, secrets). **Agent-Core** uses append-only JSONL files for thread conversation history and flat TOML for per-thread configuration. The two layers communicate over JSON-RPC via stdio — they do not share a database.
+**Desktop** uses sqlite for structured persistent state (messaging, overlay,
+secrets, launchpad defaults, and thread metadata). It must not store full
+thread conversation history in sqlite. **Agent-Core** uses append-only JSONL
+files for thread conversation history and flat TOML for per-thread
+configuration. The two layers communicate over JSON-RPC via stdio — they do not
+share a database.
+
+See [thread-history-persistence.md](thread-history-persistence.md) for the
+history storage boundary, including ACP provider restore and JSONL fallback
+rules.
 
 ## Directory Structure
 

--- a/docs/thread-history-persistence.md
+++ b/docs/thread-history-persistence.md
@@ -1,0 +1,43 @@
+# Thread History Persistence
+
+Thread conversation history must not be stored in the desktop sqlite database.
+The profile database is for structured desktop state: thread metadata, overlays,
+launchpad defaults, messaging bindings, pending approvals, secrets, and similar
+control-plane records. Full prompts, assistant messages, streamed transcript
+updates, command output history, and provider rollout events do not belong in
+sqlite payload columns.
+
+## Source of Truth
+
+- Codex App Server threads are restored from Codex-owned thread/session data.
+  Desktop may add metadata and overlay records, but it must not keep a full
+  duplicate transcript copy in `state.db`.
+- ACP providers that support `session/load` should restore history from the ACP
+  provider process. Desktop should cache only the session metadata needed to
+  locate and resume that provider-owned session.
+- Agent-Core/Grok stores conversation history in append-only per-thread JSONL
+  rollout files, currently implemented by
+  `packages/agent-core/src/persistence/grok-rollout-store.ts`.
+- If an ACP provider cannot return history itself and PwrAgent must persist a
+  fallback transcript, that fallback must use append-only JSONL rollout files,
+  not sqlite.
+
+## Desktop Metadata
+
+Desktop may persist scalar metadata derived from history when it is needed for
+navigation or safety checks. For ACP sessions, `hasConversationHistory` is the
+intended marker for decisions such as whether a live workspace handoff is still
+safe. The marker is allowed; the messages that caused it are not.
+
+When reading legacy rows that accidentally contain transcript history, strip the
+history before returning or re-writing the row. Preserve only metadata that is
+needed for behavior, such as deriving `hasConversationHistory` from a legacy
+user-message update.
+
+## Future Shared Storage
+
+Before adding ACP-owned fallback history, extract the append-only JSONL rollout
+file implementation into a shared library usable by both Agent-Core and desktop
+ACP clients. The shared API should preserve the current rollout properties:
+append-only writes, provider continuity metadata, replay reconstruction, and
+path-specific errors for malformed rollout files.

--- a/docs/thread-history-persistence.md
+++ b/docs/thread-history-persistence.md
@@ -36,8 +36,10 @@ user-message update.
 
 ## Future Shared Storage
 
-Before adding ACP-owned fallback history, extract the append-only JSONL rollout
-file implementation into a shared library usable by both Agent-Core and desktop
-ACP clients. The shared API should preserve the current rollout properties:
-append-only writes, provider continuity metadata, replay reconstruction, and
-path-specific errors for malformed rollout files.
+The initial ACP fallback may use a narrowly scoped desktop-local append-only
+JSONL store for providers that do not implement usable history loading. Before
+expanding that fallback beyond the first provider-specific need, extract the
+append-only JSONL rollout implementation into a shared library usable by both
+Agent-Core and desktop ACP clients. The shared API should preserve the current
+rollout properties: append-only writes, provider continuity metadata, replay
+reconstruction, and path-specific errors for malformed rollout files.

--- a/packages/shared/src/contracts/backend.ts
+++ b/packages/shared/src/contracts/backend.ts
@@ -70,6 +70,7 @@ export type BackendAcpRuntimeModelState = {
 
 export type BackendAcpRuntimeAgentCapabilities = {
   loadSession?: boolean;
+  sessionHistoryReplay?: boolean;
   session?: {
     close?: boolean;
     cancel?: boolean;

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -846,6 +846,12 @@ export type AppServerNotification =
       };
     }
   | {
+      method: "backend/acpRuntimeCapabilities/updated";
+      params: {
+        backend: AppServerBackendKind;
+      };
+    }
+  | {
       method: "item/commandExecution/outputDelta";
       params: {
         threadId: string;

--- a/scripts/kimi-acp-chatty-repro.mjs
+++ b/scripts/kimi-acp-chatty-repro.mjs
@@ -1,0 +1,349 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { createInterface } from "node:readline";
+import { setTimeout as delay } from "node:timers/promises";
+
+const DEFAULT_FIRST_PROMPT = "does this build?";
+const DEFAULT_SECOND_PROMPT =
+  "can you reduce big bundle sizes? make sure each messaging library is in a chunk so it doesn't get pulled in unless used";
+const DEFAULT_TIMEOUT_MS = 60 * 60_000;
+const PREVIEW_LIMIT = 180;
+
+const args = parseArgs(process.argv.slice(2));
+if (args.help || args.h) {
+  printHelp();
+  process.exit(0);
+}
+const cwd = args.cwd ?? process.cwd();
+const firstPrompt = args.first ?? DEFAULT_FIRST_PROMPT;
+const secondPrompt = args.second ?? DEFAULT_SECOND_PROMPT;
+const timeoutMs = Number(args.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+
+let nextId = 1;
+let child;
+let closed = false;
+let lastMessageAt = 0;
+let totalInbound = 0;
+let loggedSecondTurn = false;
+let previousText = "";
+let secondTurnStartedAt = 0;
+const pending = new Map();
+const counts = new Map();
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack ?? error.message : error);
+  process.exitCode = 1;
+  cleanup();
+});
+
+async function main() {
+  console.log("Starting kimi acp");
+  console.log(`cwd: ${cwd}`);
+  console.log(`first prompt: ${firstPrompt}`);
+  console.log(`second prompt: ${secondPrompt}`);
+
+  child = spawn("kimi", ["acp"], {
+    cwd,
+    env: process.env,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  child.on("close", (code, signal) => {
+    closed = true;
+    for (const { reject, timer } of pending.values()) {
+      clearTimeout(timer);
+      reject(new Error(`kimi acp exited code=${code} signal=${signal}`));
+    }
+    pending.clear();
+  });
+  child.on("error", (error) => {
+    closed = true;
+    for (const { reject, timer } of pending.values()) {
+      clearTimeout(timer);
+      reject(error);
+    }
+    pending.clear();
+  });
+  child.stderr.on("data", (chunk) => {
+    process.stderr.write(`[kimi stderr] ${chunk.toString("utf8")}`);
+  });
+
+  const reader = createInterface({ input: child.stdout });
+  reader.on("line", (line) => {
+    handleLine(line);
+  });
+
+  process.once("SIGINT", () => {
+    cleanup();
+    process.exit(130);
+  });
+  process.once("SIGTERM", () => {
+    cleanup();
+    process.exit(143);
+  });
+
+  await request("initialize", {
+    protocolVersion: 1,
+    clientCapabilities: {
+      auth: { terminal: false },
+      fs: { readTextFile: false, writeTextFile: false },
+      terminal: false,
+    },
+    clientInfo: {
+      name: "kimi-acp-chatty-repro",
+      title: "Kimi ACP Chatty Repro",
+      version: "0.0.0",
+    },
+  });
+
+  const session = await request("session/new", {
+    cwd,
+    mcpServers: [],
+  });
+  const sessionId = session?.sessionId ?? session?.session_id;
+  if (typeof sessionId !== "string" || sessionId.length === 0) {
+    throw new Error(`session/new did not return a session id: ${JSON.stringify(session)}`);
+  }
+  console.log(`sessionId: ${sessionId}`);
+
+  console.log("Running first prompt and waiting for completion...");
+  await request("session/prompt", {
+    sessionId,
+    prompt: textPrompt(firstPrompt),
+  }, timeoutMs);
+  console.log("First prompt completed.");
+
+  console.log("Running second prompt; logging inbound ACP traffic...");
+  loggedSecondTurn = true;
+  previousText = "";
+  secondTurnStartedAt = Date.now();
+  await request("session/prompt", {
+    sessionId,
+    prompt: textPrompt(secondPrompt),
+  }, timeoutMs);
+
+  console.log("Second prompt completed.");
+  printSummary();
+  await delay(50);
+  cleanup();
+}
+
+function request(method, params, requestTimeoutMs = timeoutMs) {
+  if (closed || !child?.stdin) {
+    return Promise.reject(new Error("kimi acp is not running"));
+  }
+
+  const id = `rpc-${nextId++}`;
+  const envelope = {
+    jsonrpc: "2.0",
+    id,
+    method,
+    params: params ?? {},
+  };
+
+  const promise = new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      pending.delete(id);
+      reject(new Error(`json-rpc timeout: ${method}`));
+    }, requestTimeoutMs);
+    pending.set(id, { method, resolve, reject, timer });
+  });
+
+  child.stdin.write(`${JSON.stringify(envelope)}\n`);
+  return promise;
+}
+
+function handleLine(line) {
+  let envelope;
+  try {
+    envelope = JSON.parse(line);
+  } catch {
+    console.log(`non-json stdout: ${truncate(line)}`);
+    return;
+  }
+
+  if (envelope.id != null && (Object.hasOwn(envelope, "result") || Object.hasOwn(envelope, "error"))) {
+    const key = String(envelope.id);
+    const requestState = pending.get(key);
+    if (!requestState) {
+      return;
+    }
+    pending.delete(key);
+    clearTimeout(requestState.timer);
+    if (envelope.error) {
+      requestState.reject(new Error(`${requestState.method}: ${JSON.stringify(envelope.error)}`));
+      return;
+    }
+    requestState.resolve(envelope.result);
+    return;
+  }
+
+  if (envelope.id != null && envelope.method) {
+    child.stdin.write(`${JSON.stringify({
+      jsonrpc: "2.0",
+      id: envelope.id,
+      result: {},
+    })}\n`);
+  }
+
+  totalInbound += 1;
+  const now = Date.now();
+  const gapMs = lastMessageAt === 0 ? 0 : now - lastMessageAt;
+  lastMessageAt = now;
+
+  const method = envelope.method ?? "unknown";
+  const update = asRecord(envelope.params?.update);
+  const updateKind =
+    stringValue(update?.sessionUpdate) ??
+    stringValue(update?.session_update) ??
+    stringValue(update?.kind) ??
+    stringValue(update?.type) ??
+    method;
+  counts.set(updateKind, (counts.get(updateKind) ?? 0) + 1);
+
+  if (!loggedSecondTurn) {
+    return;
+  }
+
+  const text = extractText(envelope);
+  const overlap = text ? overlapPercent(previousText, text) : undefined;
+  if (text) {
+    previousText = text;
+  }
+
+  const elapsedMs = now - secondTurnStartedAt;
+  const fields = [
+    `n=${totalInbound}`,
+    `elapsedMs=${elapsedMs}`,
+    `gapMs=${gapMs}`,
+    `method=${method}`,
+    `kind=${updateKind}`,
+    update?.status ? `status=${update.status}` : undefined,
+    update?.title ? `title=${JSON.stringify(truncate(String(update.title), 80))}` : undefined,
+    update?.toolCallId ? `toolCallId=${shortId(String(update.toolCallId))}` : undefined,
+    text ? `textChars=${text.length}` : undefined,
+    overlap === undefined ? undefined : `overlapPrevPct=${overlap.toFixed(1)}`,
+    text ? `text=${JSON.stringify(truncate(text))}` : undefined,
+  ].filter(Boolean);
+
+  console.log(fields.join(" "));
+}
+
+function printSummary() {
+  console.log("Inbound message counts:");
+  for (const [kind, count] of [...counts.entries()].sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${kind}: ${count}`);
+  }
+  console.log(`  total: ${totalInbound}`);
+}
+
+function textPrompt(text) {
+  return [{ type: "text", text }];
+}
+
+function extractText(envelope) {
+  const update = asRecord(envelope.params?.update);
+  return extractContentText(update?.content) ?? stringValue(update?.text) ?? "";
+}
+
+function extractContentText(content) {
+  if (Array.isArray(content)) {
+    return content.map((entry) => extractContentText(entry)).filter(Boolean).join("");
+  }
+  const record = asRecord(content);
+  if (!record) {
+    return undefined;
+  }
+  if (typeof record.text === "string") {
+    return record.text;
+  }
+  return extractContentText(record.content);
+}
+
+function overlapPercent(previous, current) {
+  if (!previous || !current) {
+    return 0;
+  }
+  const limit = Math.min(previous.length, current.length);
+  let commonPrefix = 0;
+  while (
+    commonPrefix < limit &&
+    previous.charCodeAt(commonPrefix) === current.charCodeAt(commonPrefix)
+  ) {
+    commonPrefix += 1;
+  }
+  return (commonPrefix / Math.max(1, current.length)) * 100;
+}
+
+function truncate(value, limit = PREVIEW_LIMIT) {
+  if (value.length <= limit) {
+    return value;
+  }
+  const head = Math.ceil((limit - 3) / 2);
+  const tail = Math.floor((limit - 3) / 2);
+  return `${value.slice(0, head)}...${value.slice(-tail)}`;
+}
+
+function shortId(id) {
+  return id.length <= 18 ? id : `${id.slice(0, 8)}...${id.slice(-8)}`;
+}
+
+function stringValue(value) {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function asRecord(value) {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value
+    : undefined;
+}
+
+function parseArgs(rawArgs) {
+  const parsed = {};
+  for (let index = 0; index < rawArgs.length; index += 1) {
+    const arg = rawArgs[index];
+    if (!arg.startsWith("--")) {
+      continue;
+    }
+    const assignment = arg.slice(2);
+    const equalsIndex = assignment.indexOf("=");
+    if (equalsIndex !== -1) {
+      parsed[assignment.slice(0, equalsIndex)] = assignment.slice(equalsIndex + 1);
+      continue;
+    }
+    const key = assignment;
+    const next = rawArgs[index + 1];
+    if (next && !next.startsWith("--")) {
+      parsed[key] = next;
+      index += 1;
+      continue;
+    }
+    parsed[key] = "1";
+  }
+  return parsed;
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/kimi-acp-chatty-repro.mjs [options]
+
+Starts kimi acp, creates a new ACP session, sends two prompts, then logs inbound
+ACP traffic during the second prompt with timing, text length, and immediate
+prior-message overlap metrics.
+
+Options:
+  --cwd <path>          Working directory for the ACP session. Defaults to cwd.
+  --first <prompt>      First prompt. Defaults to: ${DEFAULT_FIRST_PROMPT}
+  --second <prompt>     Second prompt. Defaults to the bundle-size repro prompt.
+  --timeout-ms <ms>     session/prompt timeout. Defaults to ${DEFAULT_TIMEOUT_MS}.
+  --help               Show this help.
+
+Warning: the default prompts allow Kimi to inspect and edit files in --cwd.
+Run this in a disposable clone or worktree when collecting repro data.`);
+}
+
+function cleanup() {
+  if (child && !child.killed) {
+    child.kill();
+  }
+}

--- a/scripts/kimi-acp-chatty-repro.mjs
+++ b/scripts/kimi-acp-chatty-repro.mjs
@@ -238,7 +238,7 @@ function handleLine(line) {
   }
 
   const text = extractText(envelope);
-  const overlap = text ? overlapPercent(previousText, text) : undefined;
+  const overlap = text ? retransmittedPrefixPercent(previousText, text) : undefined;
   if (text) {
     previousText = text;
   }
@@ -321,19 +321,20 @@ function extractContentText(content) {
   return extractContentText(record.content);
 }
 
-function overlapPercent(previous, current) {
-  if (!previous || !current) {
+function retransmittedPrefixPercent(previous, current) {
+  const normalizedPrevious = previous.trimStart();
+  const normalizedCurrent = current.trimStart();
+  if (
+    !normalizedPrevious ||
+    !normalizedCurrent ||
+    normalizedCurrent.length <= normalizedPrevious.length
+  ) {
     return 0;
   }
-  const limit = Math.min(previous.length, current.length);
-  let commonPrefix = 0;
-  while (
-    commonPrefix < limit &&
-    previous.charCodeAt(commonPrefix) === current.charCodeAt(commonPrefix)
-  ) {
-    commonPrefix += 1;
+  if (!normalizedCurrent.startsWith(normalizedPrevious)) {
+    return 0;
   }
-  return (commonPrefix / Math.max(1, current.length)) * 100;
+  return (normalizedPrevious.length / normalizedCurrent.length) * 100;
 }
 
 function truncate(value, limit = PREVIEW_LIMIT) {

--- a/scripts/kimi-acp-chatty-repro.mjs
+++ b/scripts/kimi-acp-chatty-repro.mjs
@@ -8,6 +8,7 @@ const DEFAULT_FIRST_PROMPT = "does this build?";
 const DEFAULT_SECOND_PROMPT =
   "can you reduce big bundle sizes? make sure each messaging library is in a chunk so it doesn't get pulled in unless used";
 const DEFAULT_TIMEOUT_MS = 60 * 60_000;
+const DEFAULT_IDLE_TIMEOUT_MS = 30_000;
 const PREVIEW_LIMIT = 180;
 
 const args = parseArgs(process.argv.slice(2));
@@ -19,6 +20,9 @@ const cwd = args.cwd ?? process.cwd();
 const firstPrompt = args.first ?? DEFAULT_FIRST_PROMPT;
 const secondPrompt = args.second ?? DEFAULT_SECOND_PROMPT;
 const timeoutMs = Number(args.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+const idleTimeoutMs = Number(
+  args.idleTimeoutMs ?? args["idle-timeout-ms"] ?? DEFAULT_IDLE_TIMEOUT_MS,
+);
 const enableYolo = Boolean(args.yolo);
 
 let nextId = 1;
@@ -29,6 +33,7 @@ let totalInbound = 0;
 let loggedSecondTurn = false;
 let previousText = "";
 let secondTurnStartedAt = 0;
+let lastLoggedEventSummary = "";
 const pending = new Map();
 const counts = new Map();
 
@@ -44,6 +49,7 @@ async function main() {
   console.log(`cwd: ${cwd}`);
   console.log(`command: kimi ${kimiArgs.join(" ")}`);
   console.log(`yolo: ${enableYolo ? "enabled via top-level --yolo" : "disabled"}`);
+  console.log(`idle timeout: ${idleTimeoutMs}ms`);
   console.log(`first prompt: ${firstPrompt}`);
   console.log(`second prompt: ${secondPrompt}`);
 
@@ -122,10 +128,20 @@ async function main() {
   loggedSecondTurn = true;
   previousText = "";
   secondTurnStartedAt = Date.now();
-  await request("session/prompt", {
-    sessionId,
-    prompt: textPrompt(secondPrompt),
-  }, timeoutMs);
+  try {
+    await withSecondTurnIdleTimeout(
+      request("session/prompt", {
+        sessionId,
+        prompt: textPrompt(secondPrompt),
+      }, timeoutMs),
+    );
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    printSummary();
+    cleanup();
+    process.exitCode = 2;
+    return;
+  }
 
   console.log("Second prompt completed.");
   printSummary();
@@ -184,6 +200,17 @@ function handleLine(line) {
   }
 
   if (envelope.id != null && envelope.method) {
+    if (loggedSecondTurn) {
+      console.log(
+        [
+          `n=${totalInbound + 1}`,
+          "direction=inbound-request",
+          `method=${envelope.method}`,
+          `id=${envelope.id}`,
+          `params=${JSON.stringify(truncate(JSON.stringify(envelope.params ?? {})))}`,
+        ].join(" "),
+      );
+    }
     child.stdin.write(`${JSON.stringify({
       jsonrpc: "2.0",
       id: envelope.id,
@@ -231,7 +258,36 @@ function handleLine(line) {
     text ? `text=${JSON.stringify(truncate(text))}` : undefined,
   ].filter(Boolean);
 
-  console.log(fields.join(" "));
+  lastLoggedEventSummary = fields.join(" ");
+  console.log(lastLoggedEventSummary);
+}
+
+function withSecondTurnIdleTimeout(promise) {
+  let timer;
+  const idlePromise = new Promise((_, reject) => {
+    timer = setInterval(() => {
+      if (!loggedSecondTurn || secondTurnStartedAt === 0) {
+        return;
+      }
+      const referenceTime = lastMessageAt || secondTurnStartedAt;
+      const idleMs = Date.now() - referenceTime;
+      if (idleMs < idleTimeoutMs) {
+        return;
+      }
+      clearInterval(timer);
+      reject(
+        new Error(
+          `Idle timeout after ${idleMs}ms without inbound ACP messages. Last event: ${
+            lastLoggedEventSummary || "none"
+          }`,
+        ),
+      );
+    }, Math.min(1_000, Math.max(100, idleTimeoutMs)));
+  });
+
+  return Promise.race([promise, idlePromise]).finally(() => {
+    clearInterval(timer);
+  });
 }
 
 function printSummary() {
@@ -340,6 +396,8 @@ Options:
   --first <prompt>      First prompt. Defaults to: ${DEFAULT_FIRST_PROMPT}
   --second <prompt>     Second prompt. Defaults to the bundle-size repro prompt.
   --timeout-ms <ms>     session/prompt timeout. Defaults to ${DEFAULT_TIMEOUT_MS}.
+  --idle-timeout-ms <ms> Exit if the second turn receives no ACP messages for
+                       this long. Defaults to ${DEFAULT_IDLE_TIMEOUT_MS}.
   --yolo               Launch ACP as kimi --yolo acp.
   --help               Show this help.
 

--- a/scripts/kimi-acp-chatty-repro.mjs
+++ b/scripts/kimi-acp-chatty-repro.mjs
@@ -19,6 +19,7 @@ if (args.help || args.h) {
 const cwd = args.cwd ?? process.cwd();
 const firstPrompt = args.first ?? DEFAULT_FIRST_PROMPT;
 const secondPrompt = args.second ?? DEFAULT_SECOND_PROMPT;
+const kimiCommand = args.kimiCommand ?? args["kimi-command"] ?? "kimi";
 const timeoutMs = Number(args.timeoutMs ?? DEFAULT_TIMEOUT_MS);
 const idleTimeoutMs = Number(
   args.idleTimeoutMs ?? args["idle-timeout-ms"] ?? DEFAULT_IDLE_TIMEOUT_MS,
@@ -47,13 +48,13 @@ async function main() {
   const kimiArgs = enableYolo ? ["--yolo", "acp"] : ["acp"];
   console.log("Starting kimi acp");
   console.log(`cwd: ${cwd}`);
-  console.log(`command: kimi ${kimiArgs.join(" ")}`);
+  console.log(`command: ${kimiCommand} ${kimiArgs.join(" ")}`);
   console.log(`yolo: ${enableYolo ? "enabled via top-level --yolo" : "disabled"}`);
   console.log(`idle timeout: ${idleTimeoutMs}ms`);
   console.log(`first prompt: ${firstPrompt}`);
   console.log(`second prompt: ${secondPrompt}`);
 
-  child = spawn("kimi", kimiArgs, {
+  child = spawn(kimiCommand, kimiArgs, {
     cwd,
     env: process.env,
     stdio: ["pipe", "pipe", "pipe"],
@@ -250,9 +251,16 @@ function handleLine(line) {
     `gapMs=${gapMs}`,
     `method=${method}`,
     `kind=${updateKind}`,
+    update?.messageId || update?.message_id
+      ? `messageId=${shortId(String(update.messageId ?? update.message_id))}`
+      : undefined,
+    update?.itemId || update?.item_id
+      ? `itemId=${shortId(String(update.itemId ?? update.item_id))}`
+      : undefined,
     update?.status ? `status=${update.status}` : undefined,
     update?.title ? `title=${JSON.stringify(truncate(String(update.title), 80))}` : undefined,
     update?.toolCallId ? `toolCallId=${shortId(String(update.toolCallId))}` : undefined,
+    update?.tool_call_id ? `toolCallId=${shortId(String(update.tool_call_id))}` : undefined,
     text ? `textChars=${text.length}` : undefined,
     overlap === undefined ? undefined : `overlapPrevPct=${overlap.toFixed(1)}`,
     text ? `text=${JSON.stringify(truncate(text))}` : undefined,
@@ -393,6 +401,7 @@ ACP traffic during the second prompt with timing, text length, and immediate
 prior-message overlap metrics.
 
 Options:
+  --kimi-command <path> ACP executable. Defaults to resolving "kimi" from PATH.
   --cwd <path>          Working directory for the ACP session. Defaults to cwd.
   --first <prompt>      First prompt. Defaults to: ${DEFAULT_FIRST_PROMPT}
   --second <prompt>     Second prompt. Defaults to the bundle-size repro prompt.

--- a/scripts/kimi-acp-chatty-repro.mjs
+++ b/scripts/kimi-acp-chatty-repro.mjs
@@ -39,13 +39,15 @@ main().catch((error) => {
 });
 
 async function main() {
+  const kimiArgs = enableYolo ? ["--yolo", "acp"] : ["acp"];
   console.log("Starting kimi acp");
   console.log(`cwd: ${cwd}`);
-  console.log(`yolo: ${enableYolo ? "enabled via /yolo prompt" : "disabled"}`);
+  console.log(`command: kimi ${kimiArgs.join(" ")}`);
+  console.log(`yolo: ${enableYolo ? "enabled via top-level --yolo" : "disabled"}`);
   console.log(`first prompt: ${firstPrompt}`);
   console.log(`second prompt: ${secondPrompt}`);
 
-  child = spawn("kimi", ["acp"], {
+  child = spawn("kimi", kimiArgs, {
     cwd,
     env: process.env,
     stdio: ["pipe", "pipe", "pipe"],
@@ -108,15 +110,6 @@ async function main() {
     throw new Error(`session/new did not return a session id: ${JSON.stringify(session)}`);
   }
   console.log(`sessionId: ${sessionId}`);
-
-  if (enableYolo) {
-    console.log("Enabling YOLO mode with /yolo and waiting for completion...");
-    await request("session/prompt", {
-      sessionId,
-      prompt: textPrompt("/yolo"),
-    }, timeoutMs);
-    console.log("YOLO mode request completed.");
-  }
 
   console.log("Running first prompt and waiting for completion...");
   await request("session/prompt", {
@@ -347,7 +340,7 @@ Options:
   --first <prompt>      First prompt. Defaults to: ${DEFAULT_FIRST_PROMPT}
   --second <prompt>     Second prompt. Defaults to the bundle-size repro prompt.
   --timeout-ms <ms>     session/prompt timeout. Defaults to ${DEFAULT_TIMEOUT_MS}.
-  --yolo               Send /yolo before the repro prompts.
+  --yolo               Launch ACP as kimi --yolo acp.
   --help               Show this help.
 
 Warning: the default prompts allow Kimi to inspect and edit files in --cwd.

--- a/scripts/kimi-acp-chatty-repro.mjs
+++ b/scripts/kimi-acp-chatty-repro.mjs
@@ -19,6 +19,7 @@ const cwd = args.cwd ?? process.cwd();
 const firstPrompt = args.first ?? DEFAULT_FIRST_PROMPT;
 const secondPrompt = args.second ?? DEFAULT_SECOND_PROMPT;
 const timeoutMs = Number(args.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+const enableYolo = Boolean(args.yolo);
 
 let nextId = 1;
 let child;
@@ -40,6 +41,7 @@ main().catch((error) => {
 async function main() {
   console.log("Starting kimi acp");
   console.log(`cwd: ${cwd}`);
+  console.log(`yolo: ${enableYolo ? "enabled via /yolo prompt" : "disabled"}`);
   console.log(`first prompt: ${firstPrompt}`);
   console.log(`second prompt: ${secondPrompt}`);
 
@@ -106,6 +108,15 @@ async function main() {
     throw new Error(`session/new did not return a session id: ${JSON.stringify(session)}`);
   }
   console.log(`sessionId: ${sessionId}`);
+
+  if (enableYolo) {
+    console.log("Enabling YOLO mode with /yolo and waiting for completion...");
+    await request("session/prompt", {
+      sessionId,
+      prompt: textPrompt("/yolo"),
+    }, timeoutMs);
+    console.log("YOLO mode request completed.");
+  }
 
   console.log("Running first prompt and waiting for completion...");
   await request("session/prompt", {
@@ -336,10 +347,13 @@ Options:
   --first <prompt>      First prompt. Defaults to: ${DEFAULT_FIRST_PROMPT}
   --second <prompt>     Second prompt. Defaults to the bundle-size repro prompt.
   --timeout-ms <ms>     session/prompt timeout. Defaults to ${DEFAULT_TIMEOUT_MS}.
+  --yolo               Send /yolo before the repro prompts.
   --help               Show this help.
 
 Warning: the default prompts allow Kimi to inspect and edit files in --cwd.
-Run this in a disposable clone or worktree when collecting repro data.`);
+Run this in a disposable clone or worktree when collecting repro data.
+Use --yolo when you want Kimi to complete tool-heavy prompts without stopping
+for approval in Default mode.`);
 }
 
 function cleanup() {


### PR DESCRIPTION
## Summary

This PR adds Kimi Code CLI as a first-class local ACP backend in PwrAgent.

- I added local discovery for the installed `kimi` CLI, ACP backend labeling, compact `Kimi` chips, Kimi-specific approval labels, and launchpad/runtime plumbing so Kimi appears alongside Codex, Grok, and Gemini.
- I wired Kimi execution-mode changes through suppressed `/yolo` control prompts because current Kimi ACP reports only `Default` from `session/new` and rejects `session/set_mode` for non-default modes.
- I synchronize Kimi mode changes back into PwrAgent session state, verify `/yolo` responses before marking a thread as full access, serialize hidden control prompts with real ACP turns, and keep queued permission-mode changes backend-qualified.
- I made `.codex/environments` launchpad selection and setup execution backend-independent so Kimi and Gemini ACP threads can use the same environment scripts as Codex.
- I fixed Kimi launchpad materialization around worktree setup, stale Codex environment setup state, and hidden control prompt receiver preservation.

## ACP Session History And Transcript Handling

- I changed ACP session rows to store metadata only, such as `hasConversationHistory`, instead of embedding transcript/history payloads in sqlite.
- I added append-only ACP rollout JSONL storage for local fallback history and updated Kimi replay restoration to use that fallback while Kimi does not support `session/load` history.
- I changed restore behavior to prefer provider `session/load` replay when an ACP backend supports it, including cached-client restores, so future Kimi history support can supersede our local rollout replay cleanly.
- I made ACP thought/commentary chunks stream as assistant response text, preserve multiple assistant message segments around tool calls, and respect provider-supplied `messageId`s while falling back to PwrAgent-generated segment ids when needed.

## Protocol Observability And Noise Control

- I added ACP protocol capture support and protocol-log observer coverage for debugging Kimi/Gemini ACP traffic.
- I coalesced noisy ACP live tool updates and protocol logs so repeated Kimi tool updates do not flood app logs every few milliseconds.
- I added `scripts/kimi-acp-chatty-repro.mjs` to reproduce and measure Kimi ACP traffic, including `--yolo`, stalled-run idle timeout handling, local Kimi binary selection, and emitted `messageId`/`itemId` visibility.

## Verification

- I verified local Kimi ACP `session/new` only reports `Default`, `session/set_mode` rejects `yolo`, and no config-option handler is present.
- I verified the local Kimi branch at `/Users/huntharo/.codex/worktrees/mpjxx6jo/kimi-cli/.venv/bin/kimi` emits `messageId`s for ACP thought and final message chunks.
- `pnpm --filter @pwragent/desktop exec vitest run src/main/__tests__/acp-client.test.ts src/main/__tests__/acp-local-discovery.test.ts src/main/__tests__/backend-registry.test.ts -t "Kimi|control prompts|ACP|queued permission-mode changes"`
- `pnpm --filter @pwragent/desktop exec vitest run src/main/__tests__/acp-client.test.ts src/main/__tests__/acp-backend-adapter.test.ts src/main/__tests__/acp-local-discovery.test.ts src/main/__tests__/backend-registry.test.ts src/main/__tests__/app-server-ipc.test.ts src/main/__tests__/overlay-store-permission-transitions.test.ts`
- `pnpm --filter @pwragent/desktop exec vitest run src/main/__tests__/backend-registry.test.ts src/renderer/src/lib/__tests__/backend-label.test.ts`
- `pnpm --filter @pwragent/desktop exec vitest run --environment jsdom src/renderer/src/features/composer/__tests__/composer.test.tsx`
- `pnpm --filter @pwragent/desktop exec vitest run src/main/__tests__/acp-client.test.ts src/main/__tests__/acp-session-normalizer.test.ts src/main/__tests__/acp-backend-adapter.test.ts`
- `pnpm --filter @pwragent/desktop exec vitest run --environment jsdom src/renderer/src/lib/__tests__/useBackendSummaries.test.tsx`
- `pnpm --filter @pwragent/desktop exec vitest run src/main/__tests__/protocol-capture.test.ts src/main/__tests__/protocol-log-observer.test.ts src/main/__tests__/acp-rollout-store.test.ts src/main/__tests__/acp-live-notifications.test.ts`
- `pnpm --filter @pwragent/desktop test:e2e -- e2e/acp-runtime-modes.spec.ts`
- `pnpm --filter @pwragent/desktop exec tsc --noEmit --pretty false`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`
- `git diff --check`

## Notes

- This PR supersedes #546 and carries forward its Kimi ACP support notes.
- Kimi history support is intentionally staged: today Kimi replay uses local rollout JSONL because PwrAgent forces Kimi `loadSession: false`; once Kimi returns real `session/load` history, PwrAgent should prefer provider history and ignore rollout-assigned fallback ids for reconciliation.
