### PR TITLE
fix(desktop): ignore unrelated live transcript events

### DIFF
--- a/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
@@ -36,6 +36,22 @@ describe("desktopSettingsPatchToEdits — experimental", () => {
       },
     ]);
   });
+
+  it("writes the live transcript event filtering flag", () => {
+    const edits = desktopSettingsPatchToEdits({
+      experimental: {
+        liveTranscriptEventFiltering: true,
+      },
+    });
+
+    expect(edits).toEqual([
+      {
+        op: "set",
+        path: ["experimental", "live_transcript_event_filtering"],
+        value: true,
+      },
+    ]);
+  });
 });
 
 describe("desktopSettingsPatchToEdits — image uploads", () => {

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -1378,6 +1378,37 @@ describe("DesktopSettingsService", () => {
     );
   });
 
+  it("defaults live transcript event filtering to false and persists it", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    const service = new DesktopSettingsService({
+      configPath,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    const initial = await service.readSettings();
+    expect(initial.experimental.liveTranscriptEventFiltering).toEqual({
+      value: false,
+      source: "default",
+    });
+
+    await service.writeConfigPatch({
+      experimental: {
+        liveTranscriptEventFiltering: true,
+      },
+    });
+
+    const updated = await service.readSettings();
+    expect(updated.experimental.liveTranscriptEventFiltering).toEqual({
+      value: true,
+      source: "config",
+    });
+    expect(fs.readFileSync(configPath, "utf8")).toContain(
+      "live_transcript_event_filtering = true",
+    );
+  });
+
   it("preserves unknown sections written by other builds when saving a patch", async () => {
     const root = createTempRoot();
     const configPath = path.join(root, "config.toml");

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -74,6 +74,7 @@ export type DesktopSettingsConfig = {
   experimental?: {
     chatReplyComposer?: StoredChatReplyComposer;
     fullAccessRiskWarningDismissed?: boolean;
+    liveTranscriptEventFiltering?: boolean;
     diffCondensation?: {
       enabled?: boolean;
       model?: string;
@@ -344,6 +345,12 @@ export function desktopSettingsPatchToEdits(
     set(
       ["experimental", "full_access_risk_warning_dismissed"],
       patch.experimental.fullAccessRiskWarningDismissed,
+    );
+  }
+  if (patch.experimental?.liveTranscriptEventFiltering !== undefined) {
+    set(
+      ["experimental", "live_transcript_event_filtering"],
+      patch.experimental.liveTranscriptEventFiltering,
     );
   }
   if (patch.experimental?.diffCondensation?.model !== undefined) {
@@ -818,6 +825,9 @@ function normalizeDesktopConfig(
       chatReplyComposer: readComposer(experimental?.chat_reply_composer),
       fullAccessRiskWarningDismissed: readBoolean(
         experimental?.full_access_risk_warning_dismissed,
+      ),
+      liveTranscriptEventFiltering: readBoolean(
+        experimental?.live_transcript_event_filtering,
       ),
       diffCondensation: {
         enabled: readBoolean(diffCondensation?.enabled),

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -362,6 +362,10 @@ export class DesktopSettingsService {
           config.experimental?.fullAccessRiskWarningDismissed,
           false,
         ),
+        liveTranscriptEventFiltering: this.resolveConfigBoolean(
+          config.experimental?.liveTranscriptEventFiltering,
+          false,
+        ),
         diffCondensation: {
           enabled: this.resolveDiffCondensationEnabled(
             config.experimental?.diffCondensation?.enabled,

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -299,6 +299,8 @@ function DesktopAppShell(props: {
   const loadThreadDetail = threadViewReady && mainView === "thread";
   const session = useThreadSessionState({
     desktopApi,
+    liveTranscriptEventFiltering:
+      settings.snapshot?.experimental.liveTranscriptEventFiltering?.value ?? false,
     thread: loadThreadDetail ? navigation.selectedThread : undefined,
   });
   const skills = useThreadSkills({

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -342,6 +342,10 @@ describe("App", () => {
           value: false,
           source: "default",
         },
+        liveTranscriptEventFiltering: {
+          value: false,
+          source: "default",
+        },
         diffCondensation: {
           enabled: { value: false, source: "default" },
           model: { value: "auto", source: "default" },

--- a/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
@@ -26,6 +26,11 @@ const DIFF_CONDENSATION_MODEL_OPTIONS: Array<{ label: string; value: string }> =
   { label: "grok-3", value: "grok-3" },
 ];
 
+const DEFAULT_LIVE_TRANSCRIPT_EVENT_FILTERING = {
+  value: false,
+  source: "default" as const,
+};
+
 export function ExperimentalSettings(props: {
   saving: boolean;
   snapshot: DesktopSettingsSnapshot;
@@ -35,7 +40,8 @@ export function ExperimentalSettings(props: {
 }) {
   const condensation = props.snapshot.experimental.diffCondensation;
   const liveTranscriptEventFiltering =
-    props.snapshot.experimental.liveTranscriptEventFiltering;
+    props.snapshot.experimental.liveTranscriptEventFiltering ??
+    DEFAULT_LIVE_TRANSCRIPT_EVENT_FILTERING;
   const knownCondensationModel = DIFF_CONDENSATION_MODEL_OPTIONS.some(
     (option) => option.value === condensation.model.value,
   );

--- a/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
@@ -31,8 +31,11 @@ export function ExperimentalSettings(props: {
   snapshot: DesktopSettingsSnapshot;
   onDiffCondensationEnabledChange: (enabled: boolean) => Promise<void>;
   onDiffCondensationModelChange: (model: string) => Promise<void>;
+  onLiveTranscriptEventFilteringChange: (enabled: boolean) => Promise<void>;
 }) {
   const condensation = props.snapshot.experimental.diffCondensation;
+  const liveTranscriptEventFiltering =
+    props.snapshot.experimental.liveTranscriptEventFiltering;
   const knownCondensationModel = DIFF_CONDENSATION_MODEL_OPTIONS.some(
     (option) => option.value === condensation.model.value,
   );
@@ -109,6 +112,32 @@ export function ExperimentalSettings(props: {
                   </button>
                 ) : null}
               </div>
+            }
+          />
+        </div>
+      </SettingsSection>
+
+      <SettingsSection
+        eyebrow="Experimental"
+        title="Live Transcript Event Filtering"
+        description="Reduce renderer work from live transcript notifications by ignoring unrelated thread-local events and skipping duplicate activity updates. Disabled by default."
+        chip={liveTranscriptEventFiltering.value ? "On" : "Off"}
+        chipKind={liveTranscriptEventFiltering.value ? "ok" : "default"}
+      >
+        <div className="settings-fields">
+          <SettingsField
+            label="Enable live transcript event filtering"
+            sub="When on, live transcript notifications for other threads no longer update the focused thread view."
+            source={sourceBadge(liveTranscriptEventFiltering)}
+            control={
+              <SettingsSwitch
+                checked={liveTranscriptEventFiltering.value}
+                disabled={props.saving}
+                label="Enable live transcript event filtering"
+                onChange={(enabled) => {
+                  void props.onLiveTranscriptEventFilteringChange(enabled);
+                }}
+              />
             }
           />
         </div>

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -319,6 +319,11 @@ function SettingsSectionBody(props: {
             experimental: { diffCondensation: { model } },
           });
         }}
+        onLiveTranscriptEventFilteringChange={async (enabled: boolean) => {
+          await props.settings.writeConfig({
+            experimental: { liveTranscriptEventFiltering: enabled },
+          });
+        }}
       />
     );
   }

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -74,6 +74,10 @@ function createSnapshot(
         value: false,
         source: "default",
       },
+      liveTranscriptEventFiltering: {
+        value: false,
+        source: "default",
+      },
       diffCondensation: {
         enabled: { value: false, source: "default" },
         model: { value: "auto", source: "default" },
@@ -413,6 +417,17 @@ describe("SettingsScreen", () => {
     await waitFor(() => {
       expect(settings.writeConfig).toHaveBeenCalledWith({
         experimental: { diffCondensation: { enabled: true } },
+      });
+    });
+
+    fireEvent.click(
+      screen.getByRole("switch", {
+        name: "Enable live transcript event filtering",
+      }),
+    );
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        experimental: { liveTranscriptEventFiltering: true },
       });
     });
 

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -568,6 +568,31 @@ describe("SettingsScreen", () => {
     );
   }, 15_000);
 
+  it("defaults live transcript event filtering off for stale snapshots", async () => {
+    const snapshot = createSnapshot() as any;
+    delete snapshot.experimental.liveTranscriptEventFiltering;
+    const settings = createSettingsState(snapshot);
+
+    render(
+      <SettingsScreen
+        initialSection="experimental"
+        settings={settings}
+      />,
+    );
+
+    const filteringSwitch = screen.getByRole("switch", {
+      name: "Enable live transcript event filtering",
+    });
+    expect(filteringSwitch).toHaveAttribute("aria-checked", "false");
+
+    fireEvent.click(filteringSwitch);
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        experimental: { liveTranscriptEventFiltering: true },
+      });
+    });
+  });
+
   it("lists archived threads and restores one", async () => {
     const archivedThread: AppServerThreadSummary = {
       id: "thread-archived",

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -2941,6 +2941,233 @@ describe("useThreadSessionState", () => {
     expect(result.current.contextWindow).toBeUndefined();
   });
 
+  it("ignores live transcript activity for unrelated threads", async () => {
+    const agentEventListeners = new Set<
+      Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+    >();
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (listener) => {
+        agentEventListeners.add(listener);
+        return () => {
+          agentEventListeners.delete(listener);
+        };
+      },
+      readThread: async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitForThreadHydration(result);
+
+    act(() => {
+      for (const listener of agentEventListeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "item/started",
+            params: {
+              threadId: "thread-2",
+              turnId: "turn-2",
+              item: {
+                id: "tool-2",
+                type: "commandExecution",
+                command: "pnpm test",
+                status: "inProgress",
+              },
+            },
+          },
+        } as any);
+      }
+    });
+
+    expect(result.current.entries).toEqual([]);
+    expect(result.current.thinkingThreadKeys["codex:thread-2"]).toBeUndefined();
+  });
+
+  it("keeps non-focused compaction invalidations for cached threads", async () => {
+    const agentEventListeners = new Set<
+      Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+    >();
+    const readThread = vi.fn(
+      async ({
+        backend,
+        threadId,
+      }: {
+        backend?: AppServerBackendKind;
+        threadId: string;
+      }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [
+            {
+              type: "message" as const,
+              id: `${threadId}-assistant`,
+              role: "assistant" as const,
+              text: `Cached transcript for ${threadId}.`,
+            },
+          ],
+          messages: [
+            {
+              id: `${threadId}-assistant`,
+              role: "assistant" as const,
+              text: `Cached transcript for ${threadId}.`,
+            },
+          ],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      })
+    );
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (listener) => {
+        agentEventListeners.add(listener);
+        return () => {
+          agentEventListeners.delete(listener);
+        };
+      },
+      readThread,
+    };
+
+    const thread1 = buildThread({ id: "thread-1", updatedAt: 1_000 });
+    const thread2 = buildThread({ id: "thread-2", updatedAt: 1_000 });
+    const { result, rerender } = renderHook(
+      ({ thread }) =>
+        useThreadSessionState({
+          desktopApi,
+          thread,
+        }),
+      {
+        initialProps: {
+          thread: thread2,
+        },
+      }
+    );
+
+    await waitForThreadHydration(result, "thread-2");
+    expect(readThread).toHaveBeenCalledTimes(1);
+
+    rerender({ thread: thread1 });
+    await waitForThreadHydration(result, "thread-1");
+    expect(readThread).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      for (const listener of agentEventListeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "thread/compacted",
+            params: {
+              threadId: "thread-2",
+              itemId: "compact-item-2",
+            },
+          },
+        });
+      }
+    });
+
+    rerender({ thread: thread2 });
+
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(3);
+    });
+    await waitForThreadHydration(result, "thread-2");
+  });
+
+  it("keeps repeated identical live activity updates as renderer no-ops", async () => {
+    const agentEventListeners = new Set<
+      Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+    >();
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (listener) => {
+        agentEventListeners.add(listener);
+        return () => {
+          agentEventListeners.delete(listener);
+        };
+      },
+      readThread: async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }),
+    };
+
+    let renderCount = 0;
+    const { result } = renderHook(() => {
+      renderCount += 1;
+      return useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      });
+    });
+
+    await waitForThreadHydration(result);
+
+    const event = {
+      backend: "codex" as const,
+      notification: {
+        method: "item/started",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "tool-1",
+            type: "commandExecution",
+            command: "pnpm test",
+            status: "inProgress",
+          },
+        },
+      },
+    };
+
+    act(() => {
+      for (const listener of agentEventListeners) {
+        listener(event as any);
+      }
+    });
+
+    expect(transcriptLabels(result.current.entries)).toEqual(["activity:pnpm test"]);
+    await flushReactUpdates();
+    const rendersAfterFirstUpdate = renderCount;
+
+    act(() => {
+      for (const listener of agentEventListeners) {
+        listener(event as any);
+      }
+    });
+
+    expect(transcriptLabels(result.current.entries)).toEqual(["activity:pnpm test"]);
+    expect(renderCount).toBe(rendersAfterFirstUpdate);
+  });
+
   it("returns to thinking when context compaction completes and the turn continues", async () => {
     const agentEventListeners = new Set<
       Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -2970,6 +2970,7 @@ describe("useThreadSessionState", () => {
     const { result } = renderHook(() =>
       useThreadSessionState({
         desktopApi,
+        liveTranscriptEventFiltering: true,
         thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
       })
     );
@@ -2999,6 +3000,65 @@ describe("useThreadSessionState", () => {
 
     expect(result.current.entries).toEqual([]);
     expect(result.current.thinkingThreadKeys["codex:thread-2"]).toBeUndefined();
+  });
+
+  it("keeps unrelated live transcript activity when filtering is disabled", async () => {
+    const agentEventListeners = new Set<
+      Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+    >();
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (listener) => {
+        agentEventListeners.add(listener);
+        return () => {
+          agentEventListeners.delete(listener);
+        };
+      },
+      readThread: async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitForThreadHydration(result);
+
+    act(() => {
+      for (const listener of agentEventListeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "item/started",
+            params: {
+              threadId: "thread-2",
+              turnId: "turn-2",
+              item: {
+                id: "tool-2",
+                type: "commandExecution",
+                command: "pnpm test",
+                status: "inProgress",
+              },
+            },
+          },
+        } as any);
+      }
+    });
+
+    expect(result.current.thinkingThreadKeys["codex:thread-2"]).toBe(true);
   });
 
   it("keeps non-focused compaction invalidations for cached threads", async () => {
@@ -3055,6 +3115,7 @@ describe("useThreadSessionState", () => {
       ({ thread }) =>
         useThreadSessionState({
           desktopApi,
+          liveTranscriptEventFiltering: true,
           thread,
         }),
       {
@@ -3125,6 +3186,7 @@ describe("useThreadSessionState", () => {
       renderCount += 1;
       return useThreadSessionState({
         desktopApi,
+        liveTranscriptEventFiltering: true,
         thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
       });
     });

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -3061,6 +3061,124 @@ describe("useThreadSessionState", () => {
     expect(result.current.thinkingThreadKeys["codex:thread-2"]).toBe(true);
   });
 
+  it("clears unrelated completed turn state without appending transcript output when filtering is enabled", async () => {
+    const agentEventListeners = new Set<
+      Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+    >();
+    const readThread = vi.fn(
+      async ({
+        backend,
+        threadId,
+      }: {
+        backend?: AppServerBackendKind;
+        threadId: string;
+      }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [
+            {
+              type: "message" as const,
+              id: `${threadId}-assistant`,
+              role: "assistant" as const,
+              text: `Hydrated transcript for ${threadId}.`,
+            },
+          ],
+          messages: [
+            {
+              id: `${threadId}-assistant`,
+              role: "assistant" as const,
+              text: `Hydrated transcript for ${threadId}.`,
+            },
+          ],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }),
+    );
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (listener) => {
+        agentEventListeners.add(listener);
+        return () => {
+          agentEventListeners.delete(listener);
+        };
+      },
+      readThread,
+    };
+
+    const thread1 = buildThread({ id: "thread-1", updatedAt: 1_000 });
+    const thread2 = buildThread({ id: "thread-2", updatedAt: 1_000 });
+    const { result, rerender } = renderHook(
+      ({ thread }) =>
+        useThreadSessionState({
+          desktopApi,
+          liveTranscriptEventFiltering: true,
+          thread,
+        }),
+      {
+        initialProps: {
+          thread: thread1,
+        },
+      },
+    );
+
+    await waitForThreadHydration(result, "thread-1");
+
+    act(() => {
+      for (const listener of agentEventListeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "turn/started",
+            params: {
+              threadId: "thread-2",
+              turnId: "turn-2",
+              turn: {
+                id: "turn-2",
+                status: "in_progress",
+              },
+            },
+          } as any,
+        });
+      }
+    });
+
+    expect(result.current.thinkingThreadKeys["codex:thread-2"]).toBe(true);
+
+    act(() => {
+      for (const listener of agentEventListeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "turn/completed",
+            params: {
+              threadId: "thread-2",
+              turnId: "turn-2",
+              turn: {
+                id: "turn-2",
+                status: "completed",
+                output: [{ type: "text", text: "Background final answer." }],
+              },
+            },
+          },
+        });
+      }
+    });
+
+    expect(result.current.thinkingThreadKeys["codex:thread-2"]).toBeUndefined();
+
+    rerender({ thread: thread2 });
+
+    await waitForThreadHydration(result, "thread-2");
+    expect(readThread).toHaveBeenCalledTimes(2);
+    expect(transcriptLabels(result.current.entries)).toEqual([
+      "message:Hydrated transcript for thread-2.",
+    ]);
+  });
+
   it("keeps non-focused compaction invalidations for cached threads", async () => {
     const agentEventListeners = new Set<
       Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
@@ -3228,6 +3346,80 @@ describe("useThreadSessionState", () => {
 
     expect(transcriptLabels(result.current.entries)).toEqual(["activity:pnpm test"]);
     expect(renderCount).toBe(rendersAfterFirstUpdate);
+  });
+
+  it("handles repeated identical live activity updates when filtering is disabled", async () => {
+    const agentEventListeners = new Set<
+      Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+    >();
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (listener) => {
+        agentEventListeners.add(listener);
+        return () => {
+          agentEventListeners.delete(listener);
+        };
+      },
+      readThread: async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }),
+    };
+
+    let renderCount = 0;
+    const { result } = renderHook(() => {
+      renderCount += 1;
+      return useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      });
+    });
+
+    await waitForThreadHydration(result);
+
+    const event = {
+      backend: "codex" as const,
+      notification: {
+        method: "item/started",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "tool-1",
+            type: "commandExecution",
+            command: "pnpm test",
+            status: "inProgress",
+          },
+        },
+      },
+    };
+
+    act(() => {
+      for (const listener of agentEventListeners) {
+        listener(event as any);
+      }
+    });
+
+    expect(transcriptLabels(result.current.entries)).toEqual(["activity:pnpm test"]);
+    await flushReactUpdates();
+    const rendersAfterFirstUpdate = renderCount;
+
+    act(() => {
+      for (const listener of agentEventListeners) {
+        listener(event as any);
+      }
+    });
+
+    expect(transcriptLabels(result.current.entries)).toEqual(["activity:pnpm test"]);
+    expect(renderCount).toBeGreaterThan(rendersAfterFirstUpdate);
   });
 
   it("returns to thinking when context compaction completes and the turn continues", async () => {

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -8,6 +8,7 @@ import type {
   AppServerThreadActivityDetail,
   AppServerThreadActivityEntry,
   AppServerToolRequestUserInputNotification,
+  AppServerThreadCommandDetail,
   AppServerThreadEntry,
   AppServerThreadMessage,
   AppServerThreadMessageEntry,
@@ -1110,6 +1111,13 @@ function updateActivityEntry(
   turn: AppServerThreadTurnMetadata | undefined
 ): AppServerThreadActivityEntry {
   const mergedDetails = mergeActivityDetails(entry.details, details);
+  if (
+    activityDetailsEqual(entry.details, mergedDetails) &&
+    turnMetadataEqual(entry.turn, entry.turn ?? turn)
+  ) {
+    return entry;
+  }
+
   return {
     ...entry,
     summary: summarizeLiveActivity(mergedDetails),
@@ -1117,6 +1125,114 @@ function updateActivityEntry(
     details: mergedDetails,
     ...(entry.turn ?? turn ? { turn: entry.turn ?? turn } : {}),
   };
+}
+
+function activityCommandDetailsEqual(
+  left: AppServerThreadCommandDetail | undefined,
+  right: AppServerThreadCommandDetail | undefined
+): boolean {
+  return (
+    left?.displayCommand === right?.displayCommand &&
+    left?.rawCommand === right?.rawCommand &&
+    left?.cwd === right?.cwd &&
+    left?.output === right?.output &&
+    left?.exitCode === right?.exitCode &&
+    left?.durationMs === right?.durationMs
+  );
+}
+
+function activityDetailsEqual(
+  left: AppServerThreadActivityDetail[],
+  right: AppServerThreadActivityDetail[]
+): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  return left.every((leftDetail, index) => {
+    const rightDetail = right[index];
+    return (
+      leftDetail.id === rightDetail?.id &&
+      leftDetail.kind === rightDetail.kind &&
+      leftDetail.label === rightDetail.label &&
+      leftDetail.status === rightDetail.status &&
+      leftDetail.url === rightDetail.url &&
+      leftDetail.fileDiff === rightDetail.fileDiff &&
+      activityCommandDetailsEqual(leftDetail.command, rightDetail.command)
+    );
+  });
+}
+
+function turnMetadataEqual(
+  left: AppServerThreadTurnMetadata | undefined,
+  right: AppServerThreadTurnMetadata | undefined
+): boolean {
+  return (
+    left?.id === right?.id &&
+    left?.status === right?.status &&
+    left?.startedAt === right?.startedAt &&
+    left?.completedAt === right?.completedAt &&
+    left?.durationMs === right?.durationMs
+  );
+}
+
+function isThreadLocalTranscriptNotification(
+  notification: AppServerNotification
+): boolean {
+  return (
+    notification.method === "item/started" ||
+    notification.method === "item/completed" ||
+    notification.method === "item/agentMessage/delta" ||
+    notification.method === "item/mcpToolCall/progress" ||
+    notification.method === "item/commandExecution/outputDelta" ||
+    notification.method === "item/fileChange/outputDelta" ||
+    notification.method === "thread/tokenUsage/updated"
+  );
+}
+
+function liveActivityNotificationSignature(params: {
+  backend: string;
+  notification: AppServerNotification;
+  threadId: string;
+}): string | undefined {
+  if (
+    params.notification.method !== "item/started" &&
+    params.notification.method !== "item/completed"
+  ) {
+    return undefined;
+  }
+
+  const item = getNotificationItem(params.notification.params);
+  const details = item ? buildLiveToolDetails(item) : [];
+  if (details.length === 0) {
+    return undefined;
+  }
+
+  const turnId =
+    typeof params.notification.params.turnId === "string"
+      ? params.notification.params.turnId
+      : "";
+  const signatureParts = [
+    params.backend,
+    params.threadId,
+    params.notification.method,
+    turnId,
+    ...details.flatMap((detail) => [
+      detail.id,
+      detail.kind,
+      detail.label,
+      detail.status ?? "",
+      detail.url ?? "",
+      detail.command?.displayCommand ?? "",
+      detail.command?.rawCommand ?? "",
+      detail.command?.cwd ?? "",
+      detail.command?.output ?? "",
+      typeof detail.command?.exitCode === "number" ? String(detail.command.exitCode) : "",
+      typeof detail.command?.durationMs === "number" ? String(detail.command.durationMs) : "",
+    ]),
+  ];
+
+  return signatureParts.join("\u0000");
 }
 
 function upsertLiveActivityEntry(
@@ -1143,11 +1259,15 @@ function upsertLiveActivityEntry(
   if (matchingIndex !== -1) {
     const optimisticEntries = [...flushed.optimisticEntries];
     const existing = optimisticEntries[matchingIndex] as AppServerThreadActivityEntry;
-    optimisticEntries[matchingIndex] = updateActivityEntry(
+    const updated = updateActivityEntry(
       existing,
       params.details,
       params.turn
     );
+    if (updated === existing) {
+      return flushed;
+    }
+    optimisticEntries[matchingIndex] = updated;
     return {
       ...flushed,
       expectOwnUpdate: true,
@@ -1163,6 +1283,15 @@ function upsertLiveActivityEntry(
     lastOptimisticEntry.turn?.id === params.turn?.id;
 
   if (canMergeWithLastActivity) {
+    const updated = updateActivityEntry(
+      lastOptimisticEntry as AppServerThreadActivityEntry,
+      params.details,
+      params.turn
+    );
+    if (updated === lastOptimisticEntry) {
+      return flushed;
+    }
+
     return {
       ...flushed,
       expectOwnUpdate: true,
@@ -1170,11 +1299,7 @@ function upsertLiveActivityEntry(
       lastTouchedAt: params.now,
       optimisticEntries: [
         ...flushed.optimisticEntries.slice(0, -1),
-        updateActivityEntry(
-          lastOptimisticEntry as AppServerThreadActivityEntry,
-          params.details,
-          params.turn
-        ),
+        updated,
       ],
     };
   }
@@ -1728,6 +1853,7 @@ export function useThreadSessionState(params: {
     ? buildThreadIdentityKey(thread.source, thread.id)
     : undefined;
   const selectedThreadKeyRef = useRef<string | undefined>(undefined);
+  const lastLiveActivitySignatureRef = useRef<Record<string, string>>({});
   const requestVersionsRef = useRef<Record<string, number>>({});
   const staleThinkingLogKeysRef = useRef<Set<string>>(new Set());
   const [sessions, setSessions] = useState<ThreadSessionState>({});
@@ -2085,6 +2211,24 @@ export function useThreadSessionState(params: {
       }
 
       const targetThreadKey = buildThreadIdentityKey(event.backend, notificationThreadId);
+      if (
+        targetThreadKey !== selectedThreadKeyRef.current &&
+        isThreadLocalTranscriptNotification(event.notification)
+      ) {
+        return;
+      }
+
+      const liveActivitySignature = liveActivityNotificationSignature({
+        backend: event.backend,
+        notification: event.notification,
+        threadId: notificationThreadId,
+      });
+      if (liveActivitySignature) {
+        if (lastLiveActivitySignatureRef.current[targetThreadKey] === liveActivitySignature) {
+          return;
+        }
+        lastLiveActivitySignatureRef.current[targetThreadKey] = liveActivitySignature;
+      }
 
       updateSession(targetThreadKey, (current) => {
         const nextLastTouchedAt = Date.now();

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -1808,6 +1808,7 @@ function didHydrateCompletedTurn(
 
 export function useThreadSessionState(params: {
   desktopApi?: DesktopApi;
+  liveTranscriptEventFiltering?: boolean;
   thread?: NavigationThreadSummary;
 }): {
   activeTurnId?: string;
@@ -1848,7 +1849,7 @@ export function useThreadSessionState(params: {
   setViewport: (viewport?: ThreadViewportState) => void;
   viewport?: ThreadViewportState;
 } {
-  const { desktopApi, thread } = params;
+  const { desktopApi, liveTranscriptEventFiltering = false, thread } = params;
   const threadKey = thread
     ? buildThreadIdentityKey(thread.source, thread.id)
     : undefined;
@@ -2212,22 +2213,25 @@ export function useThreadSessionState(params: {
 
       const targetThreadKey = buildThreadIdentityKey(event.backend, notificationThreadId);
       if (
+        liveTranscriptEventFiltering &&
         targetThreadKey !== selectedThreadKeyRef.current &&
         isThreadLocalTranscriptNotification(event.notification)
       ) {
         return;
       }
 
-      const liveActivitySignature = liveActivityNotificationSignature({
-        backend: event.backend,
-        notification: event.notification,
-        threadId: notificationThreadId,
-      });
-      if (liveActivitySignature) {
-        if (lastLiveActivitySignatureRef.current[targetThreadKey] === liveActivitySignature) {
-          return;
+      if (liveTranscriptEventFiltering) {
+        const liveActivitySignature = liveActivityNotificationSignature({
+          backend: event.backend,
+          notification: event.notification,
+          threadId: notificationThreadId,
+        });
+        if (liveActivitySignature) {
+          if (lastLiveActivitySignatureRef.current[targetThreadKey] === liveActivitySignature) {
+            return;
+          }
+          lastLiveActivitySignatureRef.current[targetThreadKey] = liveActivitySignature;
         }
-        lastLiveActivitySignatureRef.current[targetThreadKey] = liveActivitySignature;
       }
 
       updateSession(targetThreadKey, (current) => {
@@ -2840,7 +2844,7 @@ export function useThreadSessionState(params: {
         return current;
       });
     });
-  }, [desktopApi, thread, threadKey, updateSession]);
+  }, [desktopApi, liveTranscriptEventFiltering, thread, threadKey, updateSession]);
 
   const selectedSession = threadKey ? sessions[threadKey] : undefined;
 

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -1108,10 +1108,12 @@ function flushPendingAssistantToOptimistic(
 function updateActivityEntry(
   entry: AppServerThreadActivityEntry,
   details: AppServerThreadActivityDetail[],
-  turn: AppServerThreadTurnMetadata | undefined
+  turn: AppServerThreadTurnMetadata | undefined,
+  options: { suppressNoop?: boolean } = {}
 ): AppServerThreadActivityEntry {
   const mergedDetails = mergeActivityDetails(entry.details, details);
   if (
+    options.suppressNoop &&
     activityDetailsEqual(entry.details, mergedDetails) &&
     turnMetadataEqual(entry.turn, entry.turn ?? turn)
   ) {
@@ -1155,6 +1157,7 @@ function activityDetailsEqual(
       leftDetail.id === rightDetail?.id &&
       leftDetail.kind === rightDetail.kind &&
       leftDetail.label === rightDetail.label &&
+      leftDetail.path === rightDetail.path &&
       leftDetail.status === rightDetail.status &&
       leftDetail.url === rightDetail.url &&
       leftDetail.fileDiff === rightDetail.fileDiff &&
@@ -1221,6 +1224,7 @@ function liveActivityNotificationSignature(params: {
       detail.id,
       detail.kind,
       detail.label,
+      detail.path ?? "",
       detail.status ?? "",
       detail.url ?? "",
       detail.command?.displayCommand ?? "",
@@ -1240,6 +1244,7 @@ function upsertLiveActivityEntry(
   params: {
     details: AppServerThreadActivityDetail[];
     now: number;
+    suppressDuplicateLiveActivityUpdates?: boolean;
     threadId: string;
     turn?: AppServerThreadTurnMetadata;
   }
@@ -1262,7 +1267,8 @@ function upsertLiveActivityEntry(
     const updated = updateActivityEntry(
       existing,
       params.details,
-      params.turn
+      params.turn,
+      { suppressNoop: params.suppressDuplicateLiveActivityUpdates }
     );
     if (updated === existing) {
       return flushed;
@@ -1286,7 +1292,8 @@ function upsertLiveActivityEntry(
     const updated = updateActivityEntry(
       lastOptimisticEntry as AppServerThreadActivityEntry,
       params.details,
-      params.turn
+      params.turn,
+      { suppressNoop: params.suppressDuplicateLiveActivityUpdates }
     );
     if (updated === lastOptimisticEntry) {
       return flushed;
@@ -2212,9 +2219,10 @@ export function useThreadSessionState(params: {
       }
 
       const targetThreadKey = buildThreadIdentityKey(event.backend, notificationThreadId);
+      const isUnfocusedThread = targetThreadKey !== selectedThreadKeyRef.current;
       if (
         liveTranscriptEventFiltering &&
-        targetThreadKey !== selectedThreadKeyRef.current &&
+        isUnfocusedThread &&
         isThreadLocalTranscriptNotification(event.notification)
       ) {
         return;
@@ -2314,6 +2322,7 @@ export function useThreadSessionState(params: {
           return upsertLiveActivityEntry(current, {
             details,
             now: nextLastTouchedAt,
+            suppressDuplicateLiveActivityUpdates: liveTranscriptEventFiltering,
             threadId: notificationThreadId,
             turn,
           });
@@ -2401,6 +2410,7 @@ export function useThreadSessionState(params: {
           return upsertLiveActivityEntry(current, {
             details: [detail],
             now: nextLastTouchedAt,
+            suppressDuplicateLiveActivityUpdates: liveTranscriptEventFiltering,
             threadId: notificationThreadId,
             turn,
           });
@@ -2602,6 +2612,7 @@ export function useThreadSessionState(params: {
             return upsertLiveActivityEntry(current, {
               details,
               now: nextLastTouchedAt,
+              suppressDuplicateLiveActivityUpdates: liveTranscriptEventFiltering,
               threadId: notificationThreadId,
               turn,
             });
@@ -2615,6 +2626,21 @@ export function useThreadSessionState(params: {
             fallbackStatus: "completed",
             turn: event.notification.params.turn,
           });
+          if (liveTranscriptEventFiltering && isUnfocusedThread) {
+            return {
+              ...current,
+              activeTurnId: undefined,
+              activeTurnStartedAt: undefined,
+              error: undefined,
+              lastTouchedAt: nextLastTouchedAt,
+              pendingAssistantMessage: undefined,
+              pendingMcpInteraction: undefined,
+              pendingRequest: undefined,
+              pendingUserInput: undefined,
+              pendingStatusText: undefined,
+            };
+          }
+
           const completedTurnHasReview = hasReviewEntryForTurn(
             current.response,
             completedTurn?.id

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -43,6 +43,10 @@ describe("desktop settings contracts", () => {
           value: false,
           source: "default",
         },
+        liveTranscriptEventFiltering: {
+          value: false,
+          source: "default",
+        },
         diffCondensation: {
           enabled: { value: false, source: "default" },
           model: { value: "auto", source: "default" },

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -413,6 +413,13 @@ export type DesktopSettingsSnapshot = {
     chatReplyComposer: DesktopSettingsValue<DesktopChatReplyComposer>;
     fullAccessRiskWarningDismissed: DesktopSettingsValue<boolean>;
     /**
+     * Gates renderer-side live transcript event reductions. When disabled,
+     * every thread event is handled as before. When enabled, unrelated
+     * thread-local transcript events are ignored and duplicate live activity
+     * updates become no-ops.
+     */
+    liveTranscriptEventFiltering: DesktopSettingsValue<boolean>;
+    /**
      * Diff condensation (a.k.a. "diff eliding") gates whether we send
      * focused-diff requests to xAI. When enabled, less-relevant diff
      * hunks are hidden via an xAI judgment call. When disabled, every
@@ -544,6 +551,7 @@ export type DesktopSettingsConfigPatch = {
   };
   experimental?: {
     fullAccessRiskWarningDismissed?: boolean;
+    liveTranscriptEventFiltering?: boolean;
     diffCondensation?: {
       enabled?: boolean;
       /** "auto" or a specific model id. Empty string is coerced to "auto". */


### PR DESCRIPTION
## Summary

- Add an off-by-default Settings → Experimental toggle for live transcript event filtering.
- When enabled, filter unrelated live transcript/activity notifications in the renderer so other threads do not create React session state, while still allowing compaction invalidations through.
- Treat repeated identical live activity notifications as no-ops before updating hook state when the toggle is enabled.
- Add regression tests for the settings toggle, default-off behavior, unrelated-thread activity, compaction invalidation, and duplicate live activity events.

## Verification

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx`
- `pnpm test apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx`
- `pnpm test apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx`
- `pnpm test apps/desktop/src/main/__tests__/desktop-settings-service.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts`
- `pnpm test packages/shared/src/contracts/__tests__/settings.test.ts`
- `pnpm --filter @pwragent/desktop exec tsc --noEmit --pretty false`
- `pnpm lint:boundaries`

## Notes

- Root cause: the renderer subscribed to global agent events and processed transcript/activity notifications for every thread, so a noisy background thread could churn the active window.
- The optimization is now opt-in under Experimental so it can be dogfooded before becoming default behavior or being removed.
- When enabled, the change keeps turn lifecycle, approval/input events, and compaction invalidations available globally, while filtering transcript-local payloads to the selected thread.
