### PR TITLE
feat(desktop): split renderer vendor deps into manual chunks

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -87,7 +87,24 @@ export default defineConfig(({ command }) => {
       },
       build: {
         minify: "esbuild",
-        sourcemap: false
+        sourcemap: false,
+        rollupOptions: {
+          output: {
+            manualChunks(id) {
+              if (id.includes("node_modules")) {
+                if (/[\\/]node_modules[\\/](react|react-dom|scheduler)[\\/]/.test(id)) {
+                  return "vendor-react";
+                }
+                if (/[\\/]node_modules[\\/](react-markdown|remark-|unified|mdast-|micromark|markdown-|vfile|hast-)[\\/]/.test(id)) {
+                  return "vendor-markdown";
+                }
+                if (/[\\/]node_modules[\\/](@tiptap|prosemirror-|@popperjs|tippy)[\\/]/.test(id)) {
+                  return "vendor-tiptap";
+                }
+              }
+            }
+          }
+        }
       }
     }
   };


### PR DESCRIPTION
Split heavy vendor libraries (react, markdown, tiptap) into separate rollup manualChunks to eliminate >500KB renderer bundle warnings.

**Before:**
- index: 598 kB
- ThreadView: 586 kB
- ThreadMarkdown: 166 kB

**After:**
- index: 404 kB
- ThreadView: 205 kB
- ThreadMarkdown: 49 kB
- vendor-react: 193 kB
- vendor-markdown: 118 kB
- vendor-tiptap: 380 kB