### PR TITLE
feat(desktop): expose automation inspection to agent threads

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -222,6 +222,68 @@ describe("AcpAgentClient", () => {
     expect(sessionUpdates).toEqual([]);
   });
 
+  it("passes configured MCP servers when an ACP session id is known", async () => {
+    const transport = new FakeAcpAgentTransport();
+    const client = new AcpAgentClient({
+      backendId: "acp:gemini",
+      store,
+      transport,
+      now: () => 1000,
+      mcpServers: ({ backendId, cwd, sessionId }) =>
+        sessionId
+          ? [
+              {
+                name: "pwragent_automations",
+                command: "pwragent-automation-tools",
+                args: [backendId, cwd, sessionId],
+              },
+            ]
+          : [],
+    });
+
+    await client.initialize();
+    await client.startSession({
+      sessionId: "app-session-1",
+      cwd: "/repo",
+      executionMode: "default",
+    });
+    store.upsertSession({
+      backendId: "acp:gemini",
+      sessionId: "loaded-session-1",
+      title: "Loaded ACP session",
+      cwd: "/repo",
+      createdAt: 900,
+      updatedAt: 950,
+      executionMode: "default",
+      status: "idle",
+    });
+    await client.refreshSession(
+      store.getSession("acp:gemini", "loaded-session-1")!,
+    );
+
+    expect(transport.requests[1]?.params).toEqual({
+      cwd: "/repo",
+      mcpServers: [
+        {
+          name: "pwragent_automations",
+          command: "pwragent-automation-tools",
+          args: ["acp:gemini", "/repo", "app-session-1"],
+        },
+      ],
+    });
+    expect(transport.requests[2]?.params).toEqual({
+      cwd: "/repo",
+      mcpServers: [
+        {
+          name: "pwragent_automations",
+          command: "pwragent-automation-tools",
+          args: ["acp:gemini", "/repo", "loaded-session-1"],
+        },
+      ],
+      sessionId: "loaded-session-1",
+    });
+  });
+
   it("sends pasted images as ACP image content and keeps structured parts in live replay", async () => {
     const transport = new FakeAcpAgentTransport();
     const imageUrl = "data:image/png;base64,aGVsbG8=";

--- a/apps/desktop/src/main/__tests__/automation-inspection-bus.test.ts
+++ b/apps/desktop/src/main/__tests__/automation-inspection-bus.test.ts
@@ -146,6 +146,7 @@ describe("AutomationInspectionBus", () => {
           transcriptEvents: [{ id: "event-1" }],
           transcriptEventsTruncated: true,
           card: {
+            details: "yyyyy",
             summary: "Check weather: Long output",
           },
         },

--- a/apps/desktop/src/main/__tests__/automation-inspection-bus.test.ts
+++ b/apps/desktop/src/main/__tests__/automation-inspection-bus.test.ts
@@ -1,0 +1,214 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { AutomationInspectionBus } from "../automations/automation-inspection-bus";
+import { AutomationStore } from "../automations/automation-store";
+import { StateDb } from "../state/state-db";
+
+let tempDir: string;
+let stateDb: StateDb;
+let store: AutomationStore;
+let bus: AutomationInspectionBus;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-automation-tools-"));
+  stateDb = StateDb.open(path.join(tempDir, "state.db"));
+  store = new AutomationStore(stateDb);
+  bus = new AutomationInspectionBus(store);
+});
+
+afterEach(() => {
+  stateDb.close();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("AutomationInspectionBus", () => {
+  it("lists attached automations with latest run summaries", () => {
+    const automation = createAutomation({ id: "automation:weather" });
+    const run = store.createRun({
+      id: "automation-run:weather-1",
+      automationId: automation.id,
+      trigger: "scheduled",
+      status: "completed",
+      scheduledFor: 1_000,
+      now: 1_100,
+    });
+    expect(run).toBeDefined();
+    store.upsertRunArtifact({
+      runId: run!.id,
+      status: "completed",
+      finalText: "Rain is starting.",
+      outputDecision: {
+        kind: "post_card",
+        summary: "Rain is starting.",
+      },
+      now: 1_200,
+    });
+
+    expect(
+      bus.inspect({
+        operation: "list_automations",
+        context: { backend: "codex", threadId: "agent-thread" },
+        args: {},
+      }),
+    ).toMatchObject({
+      ok: true,
+      data: {
+        automations: [
+          {
+            id: automation.id,
+            name: "Check weather",
+            latestRun: {
+              id: "automation-run:weather-1",
+              outputSummary: "Rain is starting.",
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it("summarizes recent runs for an Agent thread", () => {
+    const automation = createAutomation({ id: "automation:weather" });
+    store.createRun({
+      id: "automation-run:weather-1",
+      automationId: automation.id,
+      trigger: "scheduled",
+      status: "completed",
+      scheduledFor: 1_000,
+      now: 1_100,
+    });
+
+    const response = bus.inspect({
+      operation: "summarize_automation_status",
+      context: { backend: "codex", threadId: "agent-thread" },
+      args: {},
+    });
+
+    expect(response).toMatchObject({
+      ok: true,
+      data: {
+        summary: expect.stringContaining("1 automation attached"),
+        recentRuns: [
+          expect.objectContaining({
+            automationName: "Check weather",
+            status: "completed",
+          }),
+        ],
+      },
+    });
+  });
+
+  it("bounds artifact transcript events and text", () => {
+    const automation = createAutomation({ id: "automation:weather" });
+    const run = store.createRun({
+      id: "automation-run:weather-1",
+      automationId: automation.id,
+      trigger: "manual",
+      status: "completed",
+      now: 1_000,
+    });
+    store.upsertRunArtifact({
+      runId: run!.id,
+      status: "completed",
+      finalText: "x".repeat(20),
+      outputDecision: {
+        kind: "post_card",
+        summary: "Long output",
+        details: "y".repeat(20),
+      },
+      transcriptEvents: [
+        { id: "event-1", at: 1, kind: "invocation", text: "one" },
+        { id: "event-2", at: 2, kind: "assistant_final", text: "two" },
+      ],
+      now: 1_200,
+    });
+
+    expect(
+      bus.inspect({
+        operation: "get_automation_run_artifact",
+        context: { backend: "codex", threadId: "agent-thread" },
+        args: {
+          runId: run!.id,
+          eventLimit: 1,
+          textLimitChars: 5,
+        },
+      }),
+    ).toMatchObject({
+      ok: true,
+      data: {
+        artifact: {
+          finalText: "xxxxx",
+          finalTextTruncated: true,
+          detailsTextTruncated: true,
+          transcriptEvents: [{ id: "event-1" }],
+          transcriptEventsTruncated: true,
+          card: {
+            summary: "Check weather: Long output",
+          },
+        },
+      },
+    });
+  });
+
+  it("rejects cross-thread automation and run inspection", () => {
+    const automation = createAutomation({
+      id: "automation:weather",
+      threadId: "other-agent",
+    });
+    const run = store.createRun({
+      id: "automation-run:weather-1",
+      automationId: automation.id,
+      trigger: "scheduled",
+      status: "completed",
+      now: 1_000,
+    });
+
+    expect(
+      bus.inspect({
+        operation: "list_automation_runs",
+        context: { backend: "codex", threadId: "agent-thread" },
+        args: {
+          automationId: automation.id,
+        },
+      }),
+    ).toMatchObject({
+      ok: false,
+      error: { code: "forbidden" },
+    });
+    expect(
+      bus.inspect({
+        operation: "get_automation_run",
+        context: { backend: "codex", threadId: "agent-thread" },
+        args: {
+          runId: run!.id,
+        },
+      }),
+    ).toMatchObject({
+      ok: false,
+      error: { code: "forbidden" },
+    });
+  });
+});
+
+function createAutomation(params: {
+  id: string;
+  threadId?: string;
+}) {
+  return store.createAutomation({
+    id: params.id,
+    backend: "codex",
+    threadId: params.threadId ?? "agent-thread",
+    name: "Check weather",
+    taskPrompt: "Check the weather",
+    schedule: {
+      kind: "interval",
+      every: 5,
+      unit: "minutes",
+    },
+    status: "enabled",
+    now: 1_000,
+  });
+}

--- a/apps/desktop/src/main/__tests__/automation-inspection-bus.test.ts
+++ b/apps/desktop/src/main/__tests__/automation-inspection-bus.test.ts
@@ -192,6 +192,44 @@ describe("AutomationInspectionBus", () => {
       error: { code: "forbidden" },
     });
   });
+
+  it("does not expose deleted automations through agent inspection", () => {
+    const automation = createAutomation({ id: "automation:weather" });
+    const run = store.createRun({
+      id: "automation-run:weather-1",
+      automationId: automation.id,
+      trigger: "scheduled",
+      status: "completed",
+      now: 1_000,
+    });
+    expect(run).toBeDefined();
+    store.deleteAutomation(automation.id);
+
+    expect(
+      bus.inspect({
+        operation: "list_automations",
+        context: { backend: "codex", threadId: "agent-thread" },
+        args: {},
+      }),
+    ).toMatchObject({
+      ok: true,
+      data: {
+        automations: [],
+      },
+    });
+    expect(
+      bus.inspect({
+        operation: "get_automation_run",
+        context: { backend: "codex", threadId: "agent-thread" },
+        args: {
+          runId: run!.id,
+        },
+      }),
+    ).toMatchObject({
+      ok: false,
+      error: { code: "forbidden" },
+    });
+  });
 });
 
 function createAutomation(params: {

--- a/apps/desktop/src/main/__tests__/automation-inspection-cli.test.ts
+++ b/apps/desktop/src/main/__tests__/automation-inspection-cli.test.ts
@@ -1,11 +1,22 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  AUTOMATION_INSPECTION_MCP_COMMAND_ENV,
   buildAutomationInspectionAcpMcpServers,
+  resolveAutomationInspectionMcpCommand,
   runAutomationInspectionCli,
 } from "../automations/automation-inspection-cli";
 
 describe("automation inspection CLI adapter", () => {
+  it("resolves the ACP MCP command from the runtime environment", () => {
+    expect(
+      resolveAutomationInspectionMcpCommand({
+        [AUTOMATION_INSPECTION_MCP_COMMAND_ENV]: "  /usr/local/bin/pwragent-mcp  ",
+      } as NodeJS.ProcessEnv),
+    ).toBe("/usr/local/bin/pwragent-mcp");
+    expect(resolveAutomationInspectionMcpCommand({} as NodeJS.ProcessEnv)).toBeUndefined();
+  });
+
   it("builds ACP MCP server config only when MCP and session context are available", () => {
     expect(
       buildAutomationInspectionAcpMcpServers({

--- a/apps/desktop/src/main/__tests__/automation-inspection-cli.test.ts
+++ b/apps/desktop/src/main/__tests__/automation-inspection-cli.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildAutomationInspectionAcpMcpServers,
+  runAutomationInspectionCli,
+} from "../automations/automation-inspection-cli";
+
+describe("automation inspection CLI adapter", () => {
+  it("builds ACP MCP server config only when MCP and session context are available", () => {
+    expect(
+      buildAutomationInspectionAcpMcpServers({
+        backend: "acp:gemini",
+        command: "pwragent-automation-tools",
+        runtimeCapabilities: {
+          schemaVersion: 1,
+          status: "discovered",
+          agentCapabilities: {
+            mcp: {
+              http: true,
+            },
+          },
+        },
+        threadId: "agent-thread",
+      }),
+    ).toEqual([
+      {
+        name: "pwragent_automations",
+        command: "pwragent-automation-tools",
+        args: [
+          "automation-inspection-mcp",
+          "--backend",
+          "acp:gemini",
+          "--thread-id",
+          "agent-thread",
+        ],
+        env: {
+          PWRAGENT_AUTOMATION_BACKEND: "acp:gemini",
+          PWRAGENT_AUTOMATION_THREAD_ID: "agent-thread",
+        },
+      },
+    ]);
+
+    expect(
+      buildAutomationInspectionAcpMcpServers({
+        backend: "acp:gemini",
+        command: "pwragent-automation-tools",
+        runtimeCapabilities: {
+          schemaVersion: 1,
+          status: "discovered",
+        },
+        threadId: "agent-thread",
+      }),
+    ).toEqual([]);
+  });
+
+  it("runs read-only automation inspection operations from CLI argv", async () => {
+    const result = await runAutomationInspectionCli({
+      argv: [
+        "list_automations",
+        "--backend",
+        "codex",
+        "--thread-id",
+        "agent-thread",
+        "--args",
+        "{\"limit\":1}",
+      ],
+      handler: (request) => {
+        expect(request).toEqual({
+          operation: "list_automations",
+          context: {
+            backend: "codex",
+            threadId: "agent-thread",
+          },
+          args: { limit: 1 },
+        });
+        return {
+          ok: true,
+          operation: "list_automations",
+          data: {
+            automations: [],
+          },
+        };
+      },
+    });
+
+    expect(result).toEqual({
+      exitCode: 0,
+      stdout: `${JSON.stringify({ automations: [] }, null, 2)}\n`,
+      stderr: "",
+    });
+  });
+
+  it("fails closed when required scope is missing", async () => {
+    await expect(
+      runAutomationInspectionCli({
+        argv: ["list_automations", "--backend", "codex"],
+        handler: undefined,
+      }),
+    ).resolves.toEqual({
+      exitCode: 2,
+      stdout: "",
+      stderr: "Required options: --backend and --thread-id.\n",
+    });
+  });
+});

--- a/apps/desktop/src/main/__tests__/automation-inspection-mcp.test.ts
+++ b/apps/desktop/src/main/__tests__/automation-inspection-mcp.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildAutomationInspectionMcpTools,
+  handleAutomationInspectionMcpToolCall,
+} from "../automations/automation-inspection-mcp";
+
+describe("automation inspection MCP adapter", () => {
+  it("lists the shared automation inspection tools", () => {
+    expect(buildAutomationInspectionMcpTools()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "list_automations",
+          inputSchema: expect.objectContaining({ type: "object" }),
+        }),
+        expect.objectContaining({
+          name: "get_automation_run_artifact",
+          inputSchema: expect.objectContaining({ type: "object" }),
+        }),
+      ]),
+    );
+  });
+
+  it("routes tool calls through the shared inspection handler", async () => {
+    const response = await handleAutomationInspectionMcpToolCall({
+      backend: "codex",
+      threadId: "agent-thread",
+      tool: "list_automations",
+      args: { limit: 1 },
+      handler: (request) => {
+        expect(request).toEqual({
+          operation: "list_automations",
+          context: {
+            backend: "codex",
+            threadId: "agent-thread",
+          },
+          args: { limit: 1 },
+        });
+        return {
+          ok: true,
+          operation: "list_automations",
+          data: {
+            automations: [],
+          },
+        };
+      },
+    });
+
+    expect(response).toEqual({
+      structuredContent: { automations: [] },
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({ automations: [] }, null, 2),
+        },
+      ],
+    });
+  });
+
+  it("returns an MCP tool error for unsupported tools", async () => {
+    await expect(
+      handleAutomationInspectionMcpToolCall({
+        backend: "codex",
+        threadId: "agent-thread",
+        tool: "delete_automation",
+        args: {},
+        handler: undefined,
+      }),
+    ).resolves.toMatchObject({
+      isError: true,
+      structuredContent: {
+        code: "unsupported_operation",
+      },
+    });
+  });
+});

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -7806,7 +7806,7 @@ command = "pnpm dev"
     await registry.close();
   });
 
-  it("prepends automation context to non-automation thread turns", async () => {
+  it("submits non-automation thread turns without synthetic automation context", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start", "thread/read"] },
     });
@@ -7817,12 +7817,6 @@ command = "pnpm dev"
       }),
       overlayStore: createOverlayStoreMock(),
     });
-    registry.setAutomationTurnContextProvider(() => [
-      {
-        type: "text",
-        text: "Recent automation updates for this Agent thread:\n- Weather: rain.",
-      },
-    ]);
 
     await registry.startTurn({
       backend: "codex",
@@ -7831,15 +7825,6 @@ command = "pnpm dev"
     });
 
     expect(codexClient.lastStartTurnParams?.input).toEqual([
-      {
-        type: "text",
-        text: [
-          "## Automation Context",
-          "Recent automation updates for this Agent thread:\n- Weather: rain.",
-          "## User Message",
-          "",
-        ].join("\n\n"),
-      },
       { type: "text", text: "What happened?" },
     ]);
 

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -5023,7 +5023,7 @@ script = "pnpm install"
       threadId: "thread-1",
       executionMode: "default",
     });
-    expect(codexClient.lastStartThreadParams).toEqual({
+    expect(codexClient.lastStartThreadParams).toMatchObject({
       cwd: "/Users/test/.pwragent/projects/2026-04-16-a1b2c3",
       model: "gpt-5.5",
       reasoningEffort: "medium",
@@ -5031,6 +5031,12 @@ script = "pnpm install"
       fastMode: undefined,
       approvalPolicy: "on-request",
       sandbox: "workspace-write",
+      dynamicTools: expect.arrayContaining([
+        expect.objectContaining({
+          namespace: "pwragent_automations",
+          name: "list_automations",
+        }),
+      ]),
     });
 
     await registry.close();

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -7928,7 +7928,18 @@ command = "pnpm dev"
         },
       };
     });
-
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+    events.length = 0;
     const response = await codexClient.emitRequest({
       method: "item/tool/call",
       params: {
@@ -7959,6 +7970,65 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("rejects automation inspection dynamic tool calls that do not match an active turn", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+    });
+    const handler = vi.fn();
+    registry.setAutomationInspectionHandler(handler);
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "agent-thread-2",
+        turnId: "turn-1",
+        callId: "call-1",
+        requestId: "call-1",
+        namespace: "pwragent_automations",
+        tool: "list_automations",
+        arguments: {},
+      },
+    } as AppServerPendingRequestNotification);
+
+    expect(response).toEqual({
+      success: false,
+      contentItems: [
+        {
+          type: "inputText",
+          text: JSON.stringify(
+            {
+              code: "forbidden",
+              message:
+                "Automation inspection tool calls must originate from an active turn on the same thread.",
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    });
+    expect(handler).not.toHaveBeenCalled();
+
+    await registry.close();
+  });
+
   it("returns a tool error for unknown PwrAgent automation dynamic tools", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start"] },
@@ -7974,6 +8044,18 @@ command = "pnpm dev"
     const unsubscribe = registry.onEvent((event) => {
       events.push(event);
     });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+    events.length = 0;
 
     const response = await codexClient.emitRequest({
       method: "item/tool/call",

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -509,6 +509,7 @@ class MockBackendClient {
   };
   lastStartThreadParams?: {
     cwd?: string;
+    dynamicTools?: unknown;
     ephemeral?: boolean;
     model?: string;
     approvalPolicy?: string;
@@ -756,6 +757,7 @@ class MockBackendClient {
 
   async startThread(params?: {
     cwd?: string;
+    dynamicTools?: unknown;
     ephemeral?: boolean;
     model?: string;
     approvalPolicy?: string;
@@ -3579,6 +3581,40 @@ script = "echo setup"
       },
     ]);
     expect(codexClient.lastStartThreadParams?.model).toBe("gpt-5.4");
+
+    await registry.close();
+  });
+
+  it("passes automation inspection dynamic tools when starting Codex threads", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: {
+        serverInfo: { name: "Codex App Server", version: "1.0.0" },
+        methods: ["thread/start", "turn/start"],
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      createScratchProjectDirectory: async () => "/tmp/pwragent-scratch",
+    });
+
+    await registry.startThread({ backend: "codex" });
+
+    expect(codexClient.lastStartThreadParams?.dynamicTools).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          namespace: "pwragent_automations",
+          name: "list_automations",
+        }),
+        expect.objectContaining({
+          namespace: "pwragent_automations",
+          name: "get_automation_run_artifact",
+        }),
+      ]),
+    );
 
     await registry.close();
   });
@@ -7862,6 +7898,122 @@ command = "pnpm dev"
         },
       },
     });
+
+    unsubscribe();
+    await registry.close();
+  });
+
+  it("handles automation inspection dynamic tool calls without surfacing pending requests", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+    });
+    const events: AgentEvent[] = [];
+    const unsubscribe = registry.onEvent((event) => {
+      events.push(event);
+    });
+    registry.setAutomationInspectionHandler((request) => {
+      expect(request).toEqual({
+        operation: "list_automations",
+        context: {
+          backend: "codex",
+          threadId: "thread-1",
+        },
+        args: {
+          limit: 2,
+        },
+      });
+      return {
+        ok: true,
+        operation: "list_automations",
+        data: {
+          automations: [],
+        },
+      };
+    });
+
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-1",
+        requestId: "call-1",
+        namespace: "pwragent_automations",
+        tool: "list_automations",
+        arguments: {
+          limit: 2,
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    expect(response).toEqual({
+      success: true,
+      contentItems: [
+        {
+          type: "inputText",
+          text: JSON.stringify({ automations: [] }, null, 2),
+        },
+      ],
+    });
+    expect(events).toEqual([]);
+
+    unsubscribe();
+    await registry.close();
+  });
+
+  it("returns a tool error for unknown PwrAgent automation dynamic tools", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+    });
+    const events: AgentEvent[] = [];
+    const unsubscribe = registry.onEvent((event) => {
+      events.push(event);
+    });
+
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-1",
+        requestId: "call-1",
+        namespace: "pwragent_automations",
+        tool: "unknown_tool",
+        arguments: {},
+      },
+    } as AppServerPendingRequestNotification);
+
+    expect(response).toEqual({
+      success: false,
+      contentItems: [
+        {
+          type: "inputText",
+          text: JSON.stringify(
+            {
+              code: "unsupported_operation",
+              message: "Unsupported PwrAgent automation tool.",
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    });
+    expect(events).toEqual([]);
 
     unsubscribe();
     await registry.close();

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -3831,6 +3831,55 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("passes dynamic tool specs when creating a thread", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    await client.startThread({
+      cwd: "/Users/huntharo/.pwragent/projects/2026-04-16-ab12cd",
+      dynamicTools: [
+        {
+          namespace: "pwragent_automations",
+          name: "list_automations",
+          description: "List attached automations.",
+          inputSchema: {
+            type: "object",
+            additionalProperties: false,
+          },
+          deferLoading: false,
+        },
+      ],
+    });
+
+    const transport = MockTransport.instances.at(-1);
+    expect(transport).toBeDefined();
+    const startPayload = transport!.sentMessages
+      .map((message) => JSON.parse(message) as { method?: string; params?: unknown })
+      .find((payload) => payload.method === "thread/start");
+
+    expect(startPayload?.params).toMatchObject({
+      cwd: "/Users/huntharo/.pwragent/projects/2026-04-16-ab12cd",
+      dynamicTools: [
+        {
+          namespace: "pwragent_automations",
+          name: "list_automations",
+          description: "List attached automations.",
+          inputSchema: {
+            type: "object",
+            additionalProperties: false,
+          },
+          deferLoading: false,
+        },
+      ],
+    });
+
+    await client.close();
+  });
+
   it("starts the first turn on a newly created thread without a resume preflight", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
     MockTransport.turnStartResult = {

--- a/apps/desktop/src/main/__tests__/desktop-automation-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-automation-service.test.ts
@@ -819,6 +819,8 @@ describe("DesktopAutomationService", () => {
     });
     service.start();
 
+    expect(registry.onEvent).not.toHaveBeenCalled();
+
     const created = await service.create({
       backend: "codex",
       threadId: "thread-1",

--- a/apps/desktop/src/main/__tests__/desktop-automation-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-automation-service.test.ts
@@ -82,7 +82,7 @@ beforeEach(() => {
     publishLocalEvent: vi.fn(async (event: AgentEvent) => {
       publishedEvents.push(event);
     }),
-    setAutomationTurnContextProvider: vi.fn(),
+    setAutomationInspectionHandler: vi.fn(),
   } as unknown as DesktopBackendRegistry;
 });
 
@@ -720,7 +720,7 @@ describe("DesktopAutomationService", () => {
     });
   });
 
-  it("registers recent automation results as Agent turn context", async () => {
+  it("registers automation inspection for Agent tool access", async () => {
     const service = new DesktopAutomationService({ registry, store });
     service.start();
     const created = await service.create({
@@ -758,22 +758,27 @@ describe("DesktopAutomationService", () => {
       },
     });
 
-    const provider = vi.mocked(registry.setAutomationTurnContextProvider).mock
+    const handler = vi.mocked(registry.setAutomationInspectionHandler).mock
       .calls.at(-1)?.[0];
-    expect(provider).toBeDefined();
-    const context = await provider!({
-      backend: "codex",
-      threadId: "thread-1",
-    });
-    expect(context).toEqual([
-      {
-        type: "text",
-        text: expect.stringContaining("Rain is already underway."),
+    expect(handler).toBeDefined();
+    const response = await handler!({
+      operation: "summarize_automation_status",
+      context: {
+        backend: "codex",
+        threadId: "thread-1",
       },
-    ]);
-    expect(context[0]?.type === "text" ? context[0].text : "").toContain(
-      "Hourly forecast shows rain through at least 5 AM.",
-    );
+      args: {},
+    });
+    expect(response).toMatchObject({
+      ok: true,
+      data: {
+        recentRuns: [
+          expect.objectContaining({
+            outputSummary: "Rain is already underway.",
+          }),
+        ],
+      },
+    });
   });
 
   it("cancels every queued automation turn when deleting an automation", async () => {

--- a/apps/desktop/src/main/__tests__/desktop-automation-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-automation-service.test.ts
@@ -781,6 +781,67 @@ describe("DesktopAutomationService", () => {
     });
   });
 
+  it("denies automation inspection for ordinary work threads", async () => {
+    const service = new DesktopAutomationService({ registry, store });
+    service.start();
+    const handler = vi.mocked(registry.setAutomationInspectionHandler).mock
+      .calls.at(-1)?.[0];
+    expect(handler).toBeDefined();
+
+    registry.getThreadAgentMetadata = vi.fn(async () => undefined);
+
+    await expect(
+      handler!({
+        operation: "list_automations",
+        context: {
+          backend: "codex",
+          threadId: "thread-1",
+        },
+        args: {},
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      error: {
+        code: "forbidden",
+        message: "Automation inspection is only available to Agent threads.",
+      },
+    });
+  });
+
+  it("keeps automation state inspectable but blocks runs when automations are disabled", async () => {
+    const service = new DesktopAutomationService({
+      registry,
+      runtime: {
+        disabled: true,
+        disabledReason: "PWRAGENT_DISABLE_AUTOMATIONS is enabled",
+      },
+      store,
+    });
+    service.start();
+
+    const created = await service.create({
+      backend: "codex",
+      threadId: "thread-1",
+      name: "Check weather",
+      taskPrompt: "Check weather",
+      schedule: {
+        kind: "interval",
+        every: 5,
+        unit: "minutes",
+      },
+    });
+
+    expect(service.list({ backend: "codex", threadId: "thread-1" }).automations)
+      .toEqual([expect.objectContaining({ id: created.automation.id })]);
+    await expect(
+      service.runNow({ automationId: created.automation.id }),
+    ).rejects.toThrow(
+      "Automations are disabled for this app instance: PWRAGENT_DISABLE_AUTOMATIONS is enabled",
+    );
+    expect(registry.submitTurn).not.toHaveBeenCalled();
+    expect(registry.startAutomationHeadlessTurn).not.toHaveBeenCalled();
+  });
+
   it("cancels every queued automation turn when deleting an automation", async () => {
     const service = new DesktopAutomationService({ registry, store });
     const created = await service.create({

--- a/apps/desktop/src/main/__tests__/runtime-flags.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-flags.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
+  DISABLE_AUTOMATIONS_ARG,
+  DISABLE_AUTOMATIONS_ENV,
   DISABLE_MESSAGING_ARG,
   DISABLE_MESSAGING_ENV,
+  resolveRuntimeAutomationsOverride,
   resolveRuntimeMessagingOverride,
 } from "../runtime-flags";
 
@@ -29,6 +32,32 @@ describe("runtime flags", () => {
     ).toEqual({
       disabled: true,
       reason: "PWRAGENT_DISABLE_MESSAGING is enabled",
+    });
+  });
+
+  it("disables automations when the command line flag is present", () => {
+    expect(
+      resolveRuntimeAutomationsOverride({
+        argv: ["electron", DISABLE_AUTOMATIONS_ARG],
+        env: {},
+      }),
+    ).toEqual({
+      disabled: true,
+      reason: "--disable-automations was provided at startup",
+    });
+  });
+
+  it("disables automations when the environment fallback is enabled", () => {
+    expect(
+      resolveRuntimeAutomationsOverride({
+        argv: ["electron"],
+        env: {
+          [DISABLE_AUTOMATIONS_ENV]: "1",
+        },
+      }),
+    ).toEqual({
+      disabled: true,
+      reason: "PWRAGENT_DISABLE_AUTOMATIONS is enabled",
     });
   });
 });

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -53,6 +53,14 @@ export type AcpJsonRpcTransport = {
 
 const ACP_PROTOCOL_VERSION = 1;
 const ACP_PROMPT_REQUEST_TIMEOUT_MS = 60 * 60_000;
+
+export type AcpMcpServerConfig = {
+  name: string;
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+};
+
 export type AcpPromptContentBlock =
   | { type: "text"; text: string }
   | { type: "image"; mimeType: string; data: string };
@@ -111,6 +119,11 @@ export type AcpAgentClientOptions = {
   onRequest?: (
     request: AppServerPendingRequestNotification
   ) => Promise<unknown> | unknown;
+  mcpServers?: (context: {
+    backendId: AcpBackendId;
+    cwd: string;
+    sessionId?: string;
+  }) => AcpMcpServerConfig[];
 };
 
 export class AcpAgentClient {
@@ -192,9 +205,13 @@ export class AcpAgentClient {
     acpRuntime?: BackendAcpSessionRuntimeState;
   }): Promise<AcpSessionMetadata> {
     const cwd = params.cwd ?? process.cwd();
+    const mcpServers = this.buildMcpServers({
+      cwd,
+      sessionId: params.sessionId,
+    });
     const result = await this.options.transport.request("session/new", {
       cwd,
-      mcpServers: [],
+      mcpServers,
     });
     const now = this.now();
     const record = asRecord(result);
@@ -764,9 +781,13 @@ export class AcpAgentClient {
     }
     const cwd = metadata.cwd ?? process.cwd();
     const protocolSessionId = protocolSessionIdForMetadata(metadata);
+    const mcpServers = this.buildMcpServers({
+      cwd,
+      sessionId: metadata.sessionId,
+    });
     const result = await this.options.transport.request("session/load", {
       cwd,
-      mcpServers: [],
+      mcpServers,
       sessionId: protocolSessionId,
     });
     const runtimeCapabilities = this.captureRuntimeCapabilities({
@@ -797,6 +818,19 @@ export class AcpAgentClient {
 
   private supportsSessionLoad(): boolean {
     return acpRuntimeSupportsSessionLoad(this.runtimeCapabilities);
+  }
+
+  private buildMcpServers(params: {
+    cwd: string;
+    sessionId?: string;
+  }): AcpMcpServerConfig[] {
+    return (
+      this.options.mcpServers?.({
+        backendId: this.options.backendId,
+        cwd: params.cwd,
+        sessionId: params.sessionId,
+      }) ?? []
+    );
   }
 
   private startTrackedTurn(sessionId: string, turnId: string): void {

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -33,6 +33,7 @@ import {
   type AcpJsonRpcTransport,
   type AcpPromptContentBlock,
 } from "../acp/acp-client";
+import { buildAutomationInspectionAcpMcpServers } from "../automations/automation-inspection-cli.js";
 import { discoverLocalAcpAgents } from "../acp/acp-local-discovery";
 import { acpToolUpdateNotifications } from "../acp/acp-live-notifications";
 import { AcpRolloutStore } from "../acp/acp-rollout-store";
@@ -110,6 +111,7 @@ export type AcpBackendAdapterOptions = {
   acpRolloutStore?: Pick<AcpRolloutStore, "appendUpdate" | "readReplay" | "readUpdates"> | null;
   acpSessionStore?: AcpSessionStoreLike | null;
   captureStores: ProtocolCaptureStore[];
+  automationInspectionMcpCommand?: string;
   createAcpClient?: AcpClientFactory;
   createAcpTransport?: AcpTransportFactory;
   discoverLocalAcpAgents?: LocalAcpDiscovery;
@@ -618,6 +620,7 @@ export class AcpBackendAdapter {
   >;
   private readonly acpSessionStore?: AcpSessionStoreLike;
   private readonly captureStores: ProtocolCaptureStore[];
+  private readonly automationInspectionMcpCommand?: string;
   private readonly createAcpClient: AcpClientFactory;
   private readonly createAcpTransport?: AcpTransportFactory;
   private readonly discoverLocalAcpAgents: LocalAcpDiscovery;
@@ -632,6 +635,7 @@ export class AcpBackendAdapter {
 
   constructor(options: AcpBackendAdapterOptions) {
     this.captureStores = options.captureStores;
+    this.automationInspectionMcpCommand = options.automationInspectionMcpCommand;
     this.emit = options.emit;
     this.handleServerRequest = options.handleServerRequest;
     this.acpAgentStore =
@@ -1306,6 +1310,13 @@ export class AcpBackendAdapter {
       },
       onRequest: async (request) =>
         await this.handleServerRequest(agent.backendId, request),
+      mcpServers: ({ backendId, sessionId }) =>
+        buildAutomationInspectionAcpMcpServers({
+          backend: backendId,
+          command: this.automationInspectionMcpCommand,
+          runtimeCapabilities: agent.runtimeCapabilities,
+          threadId: sessionId,
+        }),
     });
   }
 }

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -685,12 +685,6 @@ type PendingServerRequest = {
   reject: (error: Error) => void;
 };
 
-type AutomationTurnContextProvider = (params: {
-  backend: AppServerBackendKind;
-  origin?: ThreadTurnQueueOrigin;
-  threadId: ThreadIdentifier;
-}) => AppServerTurnInputItem[] | Promise<AppServerTurnInputItem[]>;
-
 type ThreadTitleService = Pick<ThreadTitleGenerationService, "generateTitle">;
 
 type ThreadTitleGenerationLogStatus =
@@ -1009,34 +1003,6 @@ function buildHeadlessAutomationRequestCancelResponse(
   }
 
   return { decision: "cancel" };
-}
-
-function formatAutomationContextForTurnInput(
-  context: AppServerTurnInputItem[],
-): AppServerTurnInputItem[] {
-  const textParts = context
-    .filter((item): item is Extract<AppServerTurnInputItem, { type: "text" }> =>
-      item.type === "text",
-    )
-    .map((item) => item.text.trim())
-    .filter(Boolean);
-  const nonTextParts = context.filter((item) => item.type !== "text");
-  if (textParts.length === 0) {
-    return context;
-  }
-
-  return [
-    {
-      type: "text",
-      text: [
-        "## Automation Context",
-        ...textParts,
-        "## User Message",
-        "",
-      ].join("\n\n"),
-    },
-    ...nonTextParts,
-  ];
 }
 
 function readStatusType(value: unknown): string | undefined {
@@ -1763,7 +1729,6 @@ export class DesktopBackendRegistry {
   private readonly reservedAcpStartThreadKeys = new Set<string>();
   private readonly activeTurnKeys = new Set<string>();
   private readonly threadTurnQueue: ThreadTurnQueue;
-  private automationTurnContextProvider?: AutomationTurnContextProvider;
   private automationInspectionHandler?: AutomationInspectionHandler;
   private readonly headlessAutomationTurns = new Map<
     string,
@@ -2171,12 +2136,6 @@ export class DesktopBackendRegistry {
     cleaner: MessagingArchiveCleaner | null | undefined,
   ): void {
     this.messagingArchiveCleaner = cleaner;
-  }
-
-  setAutomationTurnContextProvider(
-    provider: AutomationTurnContextProvider | null | undefined,
-  ): void {
-    this.automationTurnContextProvider = provider ?? undefined;
   }
 
   setAutomationInspectionHandler(
@@ -4088,7 +4047,7 @@ export class DesktopBackendRegistry {
     let turnParams!: ModelSettings;
     let cwd: string | undefined;
     let activeTurnMode: ThreadExecutionMode | undefined;
-    let input = params.input;
+    const input = params.input;
     try {
       if (params.backend === "codex") {
         await this.flushQueuedExecutionModeIfPresent(params.threadId);
@@ -4112,12 +4071,6 @@ export class DesktopBackendRegistry {
               overlay,
             )
           : undefined;
-      input = await this.buildTurnInputWithAutomationContext({
-        backend: params.backend,
-        input: params.input,
-        origin: params.origin,
-        threadId: params.threadId,
-      });
       await this.emit({
         backend: params.backend,
         notification: {
@@ -6289,36 +6242,6 @@ export class DesktopBackendRegistry {
       await this.getBackendLaunchpadOptions(backend, callerReason),
       settings,
     );
-  }
-
-  private async buildTurnInputWithAutomationContext(params: {
-    backend: AppServerBackendKind;
-    input: AppServerTurnInputItem[];
-    origin?: ThreadTurnQueueOrigin;
-    threadId: ThreadIdentifier;
-  }): Promise<AppServerTurnInputItem[]> {
-    if (!this.automationTurnContextProvider || params.origin === "automation") {
-      return params.input;
-    }
-    try {
-      const context = await this.automationTurnContextProvider({
-        backend: params.backend,
-        origin: params.origin,
-        threadId: params.threadId,
-      });
-      if (context.length === 0) {
-        return params.input;
-      }
-      return [...formatAutomationContextForTurnInput(context), ...params.input];
-    } catch (error) {
-      backendRegistryLog.warn("automation turn context provider failed", {
-        backend: params.backend,
-        error: error instanceof Error ? error.message : String(error),
-        origin: params.origin,
-        threadId: params.threadId,
-      });
-      return params.input;
-    }
   }
 
   private async resolveLaunchpadBackend(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -3835,6 +3835,15 @@ export class DesktopBackendRegistry {
       executionMode,
       runtime: acpRuntimeWithModel,
     });
+    const dynamicTools =
+      backend === "codex" ? buildAutomationInspectionDynamicToolSpecs() : undefined;
+    if (dynamicTools?.length) {
+      backendRegistryLog.info("attaching automation inspection dynamic tools", {
+        backend,
+        toolCount: dynamicTools.length,
+        tools: dynamicTools.map((tool) => tool.name),
+      });
+    }
 
     const result = isAcpBackendId(backend)
       ? await this.startAcpSession({
@@ -3850,10 +3859,7 @@ export class DesktopBackendRegistry {
           approvalPolicy: request.approvalPolicy ?? modeSettings.approvalPolicy,
           sandbox: request.sandbox ?? modeSettings.sandbox,
           codexEnvironmentRuntime: request.codexEnvironmentRuntime,
-          dynamicTools:
-            backend === "codex"
-              ? buildAutomationInspectionDynamicToolSpecs()
-              : undefined,
+          dynamicTools,
         });
     const startedAt = Date.now();
     const gitBranch = cwd ? await readCurrentGitBranch(cwd).catch(() => undefined) : undefined;

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -129,6 +129,7 @@ import {
 import { CodexAppServerClient } from "../codex-app-server/client";
 import { GrokAppServerClient } from "../grok-app-server/client";
 import {
+  buildAutomationInspectionDynamicToolErrorResponse,
   buildAutomationInspectionDynamicToolSpecs,
   handleAutomationInspectionDynamicToolCall,
   readAutomationInspectionDynamicToolCall,
@@ -8163,6 +8164,21 @@ export class DesktopBackendRegistry {
       params: request.params,
     });
     if (dynamicToolCall?.namespace === "pwragent_automations") {
+      if (!this.isLiveAutomationInspectionToolCall(backend, dynamicToolCall)) {
+        backendRegistryLog.warn("rejecting automation inspection dynamic tool call", {
+          backend,
+          callId: dynamicToolCall.callId,
+          namespace: dynamicToolCall.namespace,
+          threadId: dynamicToolCall.threadId,
+          tool: dynamicToolCall.tool,
+          turnId: dynamicToolCall.turnId,
+        });
+        return buildAutomationInspectionDynamicToolErrorResponse({
+          code: "forbidden",
+          message:
+            "Automation inspection tool calls must originate from an active turn on the same thread.",
+        });
+      }
       backendRegistryLog.info("handling automation inspection dynamic tool call", {
         backend,
         callId: dynamicToolCall.callId,
@@ -8215,6 +8231,15 @@ export class DesktopBackendRegistry {
         reject(error instanceof Error ? error : new Error(String(error)));
       });
     });
+  }
+
+  private isLiveAutomationInspectionToolCall(
+    backend: AppServerBackendKind,
+    call: { threadId: string; turnId?: string },
+  ): boolean {
+    const turnId = call.turnId?.trim();
+    if (!turnId) return false;
+    return this.activeTurnKeys.has(buildActiveTurnKey(backend, call.threadId, turnId));
   }
 
   private async emit(event: AgentEvent): Promise<void> {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -134,6 +134,7 @@ import {
   readAutomationInspectionDynamicToolCall,
   type AutomationInspectionHandler,
 } from "../automations/automation-inspection-codex-tools";
+import { resolveAutomationInspectionMcpCommand } from "../automations/automation-inspection-cli";
 import { createScratchProjectDirectory } from "./scratch-projects";
 import { getDesktopOverlayStore } from "./desktop-overlay-store";
 import { createProtocolCaptureFromEnv } from "../testing/protocol-capture";
@@ -1824,6 +1825,7 @@ export class DesktopBackendRegistry {
     createAcpClient?: AcpClientFactory;
     messagingStore?: MessagingArchiveCleanupStore | null;
     messagingArchiveCleaner?: MessagingArchiveCleaner | null;
+    automationInspectionMcpCommand?: string;
     createScratchProjectDirectory?: () => Promise<string>;
     codexEnvironmentCommandRunner?: CodexEnvironmentCommandRunner;
     threadTitleGenerationService?: ThreadTitleService | null;
@@ -1931,6 +1933,9 @@ export class DesktopBackendRegistry {
       emit: async (event) => await this.emit(event),
       handleServerRequest: async (backend, request) =>
         await this.handleServerRequest(backend, request),
+      automationInspectionMcpCommand:
+        options?.automationInspectionMcpCommand ??
+        resolveAutomationInspectionMcpCommand(),
     });
     this.messagingStore = options?.messagingStore;
     this.messagingArchiveCleaner = options?.messagingArchiveCleaner;

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -4,6 +4,7 @@ import { randomUUID } from "node:crypto";
 import { stat } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
+import type { DynamicToolSpec as CodexDynamicToolSpec } from "@pwragent/codex-app-server-protocol/v2";
 import { getAppStateMode } from "../state/app-state";
 import type { OverlayStoreLike } from "../state/overlay-store-sqlite";
 import { PerKeyAsyncLock } from "../util/per-key-async-lock";
@@ -127,6 +128,12 @@ import {
 } from "./acp-backend-adapter";
 import { CodexAppServerClient } from "../codex-app-server/client";
 import { GrokAppServerClient } from "../grok-app-server/client";
+import {
+  buildAutomationInspectionDynamicToolSpecs,
+  handleAutomationInspectionDynamicToolCall,
+  readAutomationInspectionDynamicToolCall,
+  type AutomationInspectionHandler,
+} from "../automations/automation-inspection-codex-tools";
 import { createScratchProjectDirectory } from "./scratch-projects";
 import { getDesktopOverlayStore } from "./desktop-overlay-store";
 import { createProtocolCaptureFromEnv } from "../testing/protocol-capture";
@@ -291,6 +298,7 @@ type BackendClient = {
     reasoningEffort?: string;
     fastMode?: boolean;
     codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
+    dynamicTools?: CodexDynamicToolSpec[];
   }): Promise<{ threadId: string }>;
   startTurn(params: {
     threadId: string;
@@ -1756,6 +1764,7 @@ export class DesktopBackendRegistry {
   private readonly activeTurnKeys = new Set<string>();
   private readonly threadTurnQueue: ThreadTurnQueue;
   private automationTurnContextProvider?: AutomationTurnContextProvider;
+  private automationInspectionHandler?: AutomationInspectionHandler;
   private readonly headlessAutomationTurns = new Map<
     string,
     {
@@ -2168,6 +2177,12 @@ export class DesktopBackendRegistry {
     provider: AutomationTurnContextProvider | null | undefined,
   ): void {
     this.automationTurnContextProvider = provider ?? undefined;
+  }
+
+  setAutomationInspectionHandler(
+    handler: AutomationInspectionHandler | null | undefined,
+  ): void {
+    this.automationInspectionHandler = handler ?? undefined;
   }
 
   async publishLocalEvent(event: AgentEvent): Promise<void> {
@@ -3876,6 +3891,10 @@ export class DesktopBackendRegistry {
           approvalPolicy: request.approvalPolicy ?? modeSettings.approvalPolicy,
           sandbox: request.sandbox ?? modeSettings.sandbox,
           codexEnvironmentRuntime: request.codexEnvironmentRuntime,
+          dynamicTools:
+            backend === "codex"
+              ? buildAutomationInspectionDynamicToolSpecs()
+              : undefined,
         });
     const startedAt = Date.now();
     const gitBranch = cwd ? await readCurrentGitBranch(cwd).catch(() => undefined) : undefined;
@@ -8205,6 +8224,26 @@ export class DesktopBackendRegistry {
     backend: AppServerBackendKind,
     request: AppServerPendingRequestNotification,
   ): Promise<unknown> {
+    const dynamicToolCall = readAutomationInspectionDynamicToolCall({
+      method: request.method,
+      params: request.params,
+    });
+    if (dynamicToolCall?.namespace === "pwragent_automations") {
+      backendRegistryLog.info("handling automation inspection dynamic tool call", {
+        backend,
+        callId: dynamicToolCall.callId,
+        namespace: dynamicToolCall.namespace,
+        threadId: dynamicToolCall.threadId,
+        tool: dynamicToolCall.tool,
+        turnId: dynamicToolCall.turnId,
+      });
+      return await handleAutomationInspectionDynamicToolCall({
+        backend,
+        call: dynamicToolCall,
+        handler: this.automationInspectionHandler,
+      });
+    }
+
     const headlessAutomation = this.findHeadlessAutomationTurnForRequest(
       backend,
       request,

--- a/apps/desktop/src/main/automations/automation-inspection-bus.ts
+++ b/apps/desktop/src/main/automations/automation-inspection-bus.ts
@@ -1,0 +1,477 @@
+import type {
+  AutomationDetail,
+  AutomationInspectionArtifact,
+  AutomationInspectionAutomationSummary,
+  AutomationInspectionContext,
+  AutomationInspectionFailure,
+  AutomationInspectionOperationName,
+  AutomationInspectionRequest,
+  AutomationInspectionResponse,
+  AutomationInspectionRunDetail,
+  AutomationInspectionRunSummary,
+  AutomationInspectionToolArgsByOperation,
+  AutomationInspectionToolDataByOperation,
+  AutomationInspectionToolData,
+  AutomationRunArtifact,
+  AutomationRunStatus,
+  AutomationRunSummary,
+  AutomationTimelineCard,
+} from "@pwragent/shared";
+import {
+  isAutomationInspectionOperationName,
+  normalizeAutomationInspectionEventLimit,
+  normalizeAutomationInspectionRunLimit,
+  normalizeAutomationInspectionTextLimitChars,
+} from "@pwragent/shared";
+import type { AutomationRecord, AutomationStore } from "./automation-store.js";
+
+export class AutomationInspectionBus {
+  constructor(private readonly store: AutomationStore) {}
+
+  inspect(request: AutomationInspectionRequest): AutomationInspectionResponse {
+    const operation = request.operation;
+    try {
+      if (!isAutomationInspectionOperationName(operation)) {
+        return failure(operation, "unsupported_operation", "Unsupported automation inspection operation.");
+      }
+      switch (operation) {
+        case "list_automations":
+          return success(
+            operation,
+            this.listAutomations(request.context, request.args),
+          );
+        case "summarize_automation_status":
+          return success(
+            operation,
+            this.summarizeAutomationStatus(request.context, request.args),
+          );
+        case "list_automation_runs":
+          return success(
+            operation,
+            this.listAutomationRuns(request.context, request.args),
+          );
+        case "get_automation_run":
+          return success(
+            operation,
+            this.getAutomationRun(request.context, request.args),
+          );
+        case "get_automation_run_artifact":
+          return success(
+            operation,
+            this.getAutomationRunArtifact(request.context, request.args),
+          );
+        default:
+          return failure(operation, "unsupported_operation", "Unsupported automation inspection operation.");
+      }
+    } catch (error) {
+      return failure(
+        operation,
+        error instanceof AutomationInspectionError ? error.code : "internal_error",
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  }
+
+  private listAutomations(
+    context: AutomationInspectionContext,
+    args: AutomationInspectionToolArgsByOperation["list_automations"],
+  ): AutomationInspectionToolDataByOperation["list_automations"] {
+    const limit = normalizeAutomationInspectionRunLimit(args.limit);
+    const automations = this.store
+      .listAutomationsForThread({
+        backend: context.backend,
+        threadId: context.threadId,
+        includeDeleted: args.includeDeleted === true,
+      })
+      .filter((automation) => args.includePaused !== false || automation.status !== "paused");
+    return {
+      automations: automations
+        .slice(0, limit)
+        .map((automation) => this.toAutomationSummary(automation)),
+      truncated: automations.length > limit || undefined,
+    };
+  }
+
+  private summarizeAutomationStatus(
+    context: AutomationInspectionContext,
+    args: AutomationInspectionToolArgsByOperation["summarize_automation_status"],
+  ): AutomationInspectionToolDataByOperation["summarize_automation_status"] {
+    const list = this.listAutomations(context, {
+      includePaused: true,
+      limit: args.limit,
+    });
+    const runs = this.listAutomationRuns(context, {
+      limit: args.limit,
+      since: args.since,
+    });
+    return {
+      summary: summarizeStatus(list.automations, runs.runs),
+      automations: list.automations,
+      recentRuns: runs.runs,
+      truncated: list.truncated || runs.truncated || undefined,
+    };
+  }
+
+  private listAutomationRuns(
+    context: AutomationInspectionContext,
+    args: AutomationInspectionToolArgsByOperation["list_automation_runs"],
+  ): AutomationInspectionToolDataByOperation["list_automation_runs"] {
+    const limit = normalizeAutomationInspectionRunLimit(args.limit);
+    const requestedAutomation = args.automationId
+      ? this.getScopedAutomation(args.automationId, context)
+      : undefined;
+    const candidateRuns = requestedAutomation
+      ? this.store.listRunsForAutomation(requestedAutomation.id, limit * 4)
+      : this.store.listRunsForThread({
+          backend: context.backend,
+          threadId: context.threadId,
+          limit: limit * 4,
+        });
+    const statuses = new Set(args.statuses ?? []);
+    const runs = candidateRuns.filter((run) => {
+      const activityAt = runActivityAt(run) ?? 0;
+      if (args.since !== undefined && activityAt < args.since) {
+        return false;
+      }
+      if (statuses.size > 0 && !statuses.has(run.status)) {
+        return false;
+      }
+      return this.isRunInScope(run, context);
+    });
+    return {
+      runs: runs.slice(0, limit).map((run) => this.toRunSummary(run)),
+      truncated: runs.length > limit || undefined,
+    };
+  }
+
+  private getAutomationRun(
+    context: AutomationInspectionContext,
+    args: AutomationInspectionToolArgsByOperation["get_automation_run"],
+  ): AutomationInspectionToolDataByOperation["get_automation_run"] {
+    const run = this.getScopedRun(args.runId, context);
+    return {
+      run: this.toRunDetail(run),
+    };
+  }
+
+  private getAutomationRunArtifact(
+    context: AutomationInspectionContext,
+    args: AutomationInspectionToolArgsByOperation["get_automation_run_artifact"],
+  ): AutomationInspectionToolDataByOperation["get_automation_run_artifact"] {
+    const run = this.getScopedRun(args.runId, context);
+    const artifact = this.store.getRunArtifact(run.id);
+    if (!artifact) {
+      throw new AutomationInspectionError("not_found", "Automation run artifact not found.");
+    }
+    const automation = this.getScopedAutomation(run.automationId, context, {
+      includeDeleted: true,
+    });
+    return {
+      artifact: this.toArtifact({
+        artifact,
+        automation,
+        eventLimit: normalizeAutomationInspectionEventLimit(args.eventLimit),
+        textLimitChars: normalizeAutomationInspectionTextLimitChars(
+          args.textLimitChars,
+        ),
+        run,
+      }),
+    };
+  }
+
+  private getScopedAutomation(
+    automationId: string,
+    context: AutomationInspectionContext,
+    options: { includeDeleted?: boolean } = {},
+  ): AutomationRecord {
+    const automation = this.store.getAutomation(automationId, {
+      includeDeleted: options.includeDeleted,
+    });
+    if (!automation) {
+      throw new AutomationInspectionError("not_found", "Automation not found.");
+    }
+    if (automation.backend !== context.backend || automation.threadId !== context.threadId) {
+      throw new AutomationInspectionError(
+        "forbidden",
+        "Automation is not attached to this Agent thread.",
+      );
+    }
+    return automation;
+  }
+
+  private getScopedRun(
+    runId: string,
+    context: AutomationInspectionContext,
+  ): AutomationRunSummary {
+    const run = this.store.getRun(runId);
+    if (!run) {
+      throw new AutomationInspectionError("not_found", "Automation run not found.");
+    }
+    if (!this.isRunInScope(run, context)) {
+      throw new AutomationInspectionError(
+        "forbidden",
+        "Automation run is not attached to this Agent thread.",
+      );
+    }
+    return run;
+  }
+
+  private isRunInScope(
+    run: AutomationRunSummary,
+    context: AutomationInspectionContext,
+  ): boolean {
+    const automation = this.store.getAutomation(run.automationId, {
+      includeDeleted: true,
+    });
+    return Boolean(
+      automation &&
+        automation.backend === context.backend &&
+        automation.threadId === context.threadId,
+    );
+  }
+
+  private toAutomationSummary(
+    automation: AutomationRecord,
+  ): AutomationInspectionAutomationSummary {
+    const latestRun = this.store.getLatestRunForAutomation(automation.id);
+    return {
+      ...toAutomationDetail(automation, latestRun),
+      latestRun: latestRun ? this.toRunSummary(latestRun) : undefined,
+    };
+  }
+
+  private toRunSummary(run: AutomationRunSummary): AutomationInspectionRunSummary {
+    const automation = this.store.getAutomation(run.automationId, {
+      includeDeleted: true,
+    });
+    const artifact = this.store.getRunArtifact(run.id);
+    return {
+      ...run,
+      automationName: automation?.name,
+      automationStatus: automation?.status,
+      automationBacklogPolicy: automation?.backlogPolicy,
+      outputDecisionKind: artifact?.outputDecision?.kind,
+      outputSummary: summarizeRunOutput(run, artifact),
+    };
+  }
+
+  private toRunDetail(run: AutomationRunSummary): AutomationInspectionRunDetail {
+    const automation = this.store.getAutomation(run.automationId, {
+      includeDeleted: true,
+    });
+    return {
+      ...this.toRunSummary(run),
+      automation: automation ? this.toAutomationSummary(automation) : undefined,
+    };
+  }
+
+  private toArtifact(params: {
+    artifact: AutomationRunArtifact;
+    automation: AutomationRecord;
+    eventLimit: number;
+    textLimitChars: number;
+    run: AutomationRunSummary;
+  }): AutomationInspectionArtifact {
+    const transcriptEvents = params.artifact.transcriptEvents.slice(
+      0,
+      params.eventLimit,
+    );
+    const finalText = truncateText(params.artifact.finalText, params.textLimitChars);
+    const details = truncateText(
+      params.artifact.outputDecision?.details,
+      params.textLimitChars,
+    );
+    const outputDecision = params.artifact.outputDecision
+      ? {
+          ...params.artifact.outputDecision,
+          details: details.value,
+        }
+      : undefined;
+    return {
+      ...params.artifact,
+      finalText: finalText.value,
+      outputDecision,
+      transcriptEvents,
+      transcriptEventsTruncated:
+        params.artifact.transcriptEvents.length > transcriptEvents.length || undefined,
+      finalTextTruncated: finalText.truncated || undefined,
+      detailsTextTruncated: details.truncated || undefined,
+      card: buildAutomationTimelineCard({
+        automation: params.automation,
+        artifact: params.artifact,
+        run: params.run,
+      }),
+    };
+  }
+}
+
+class AutomationInspectionError extends Error {
+  constructor(
+    readonly code: AutomationInspectionFailure["error"]["code"],
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+function success<TOperation extends AutomationInspectionOperationName>(
+  operation: TOperation,
+  data: AutomationInspectionToolData<TOperation>,
+): AutomationInspectionResponse<TOperation> {
+  return {
+    ok: true,
+    operation,
+    data,
+  };
+}
+
+function failure<TOperation extends AutomationInspectionOperationName>(
+  operation: TOperation,
+  code: AutomationInspectionFailure["error"]["code"],
+  message: string,
+): AutomationInspectionFailure<TOperation> {
+  return {
+    ok: false,
+    operation,
+    error: {
+      code,
+      message,
+    },
+  };
+}
+
+function toAutomationDetail(
+  record: AutomationRecord,
+  latestRun?: AutomationRunSummary,
+): AutomationDetail {
+  const latestRunAt = latestRun ? runActivityAt(latestRun) : undefined;
+  const useLatestRun =
+    latestRun !== undefined &&
+    latestRunAt !== undefined &&
+    (record.lastRunAt === undefined || latestRunAt >= record.lastRunAt);
+  return {
+    id: record.id,
+    backend: record.backend,
+    threadId: record.threadId,
+    name: record.name,
+    taskPrompt: record.taskPrompt,
+    gate: record.gate,
+    status: record.status,
+    schedule: record.schedule,
+    scheduleSummary: record.scheduleSummary,
+    backlogPolicy: record.backlogPolicy,
+    nextRunAt: record.nextRunAt,
+    lastRunAt: useLatestRun ? latestRunAt : record.lastRunAt,
+    lastRunStatus: useLatestRun ? latestRun.status : record.lastRunStatus,
+    pendingRunCount: undefined,
+    coalescedWindowCount: undefined,
+    updatedAt: record.updatedAt,
+    createdAt: record.createdAt,
+    deletedAt: record.deletedAt,
+  };
+}
+
+function summarizeStatus(
+  automations: AutomationInspectionAutomationSummary[],
+  recentRuns: AutomationInspectionRunSummary[],
+): string {
+  if (automations.length === 0) {
+    return "No automations are attached to this Agent thread.";
+  }
+  const enabled = automations.filter((automation) => automation.status === "enabled").length;
+  const paused = automations.filter((automation) => automation.status === "paused").length;
+  const running = recentRuns.filter((run) => run.status === "running").length;
+  const latest = recentRuns[0];
+  return [
+    `${automations.length} automation${automations.length === 1 ? "" : "s"} attached`,
+    `${enabled} enabled`,
+    `${paused} paused`,
+    running > 0 ? `${running} running` : undefined,
+    latest
+      ? `latest ${latest.automationName ?? "automation"} run ${latest.status}`
+      : "no recent runs",
+  ]
+    .filter((part): part is string => Boolean(part))
+    .join("; ");
+}
+
+function summarizeRunOutput(
+  run: AutomationRunSummary,
+  artifact: AutomationRunArtifact | undefined,
+): string | undefined {
+  return (
+    artifact?.outputDecision?.summary ??
+    firstLine(artifact?.finalText) ??
+    artifact?.errorMessage ??
+    run.errorMessage
+  );
+}
+
+function buildAutomationTimelineCard(params: {
+  automation: AutomationRecord;
+  artifact?: AutomationRunArtifact;
+  run: AutomationRunSummary;
+}): AutomationTimelineCard | undefined {
+  const notable =
+    params.run.trigger === "manual" ||
+    params.run.status === "failed" ||
+    params.run.status === "cancelled" ||
+    params.artifact?.outputDecision?.kind === "post_card" ||
+    params.artifact?.outputDecision?.kind === "parse_failed" ||
+    (!params.artifact?.outputDecision && Boolean(params.artifact?.finalText));
+  if (!notable) return undefined;
+  return {
+    id: `automation-card:${params.run.id}`,
+    backend: params.automation.backend,
+    threadId: params.automation.threadId,
+    automationId: params.automation.id,
+    automationName: params.automation.name,
+    runId: params.run.id,
+    status: params.run.status,
+    summary: summarizeAutomationCard(params),
+    details: params.artifact?.outputDecision?.details,
+    occurredAt:
+      params.run.completedAt ??
+      params.run.startedAt ??
+      params.run.queuedAt ??
+      params.run.scheduledFor ??
+      Date.now(),
+  };
+}
+
+function summarizeAutomationCard(params: {
+  automation: AutomationRecord;
+  artifact?: AutomationRunArtifact;
+  run: AutomationRunSummary;
+}): string {
+  const summary = summarizeRunOutput(params.run, params.artifact);
+  if (summary) {
+    return `${params.automation.name}: ${summary}`;
+  }
+  if (params.run.status === "completed") {
+    return `${params.automation.name}: completed`;
+  }
+  return `${params.automation.name}: ${params.run.status}`;
+}
+
+function runActivityAt(run: AutomationRunSummary): number | undefined {
+  return run.completedAt ?? run.startedAt ?? run.queuedAt ?? run.scheduledFor;
+}
+
+function firstLine(value: string | undefined): string | undefined {
+  const line = value?.split(/\r?\n/).find((candidate) => candidate.trim());
+  return line?.trim();
+}
+
+function truncateText(
+  value: string | undefined,
+  limit: number,
+): { value?: string; truncated: boolean } {
+  if (value === undefined || value.length <= limit) {
+    return { value, truncated: false };
+  }
+  return {
+    value: value.slice(0, limit),
+    truncated: true,
+  };
+}

--- a/apps/desktop/src/main/automations/automation-inspection-bus.ts
+++ b/apps/desktop/src/main/automations/automation-inspection-bus.ts
@@ -287,10 +287,13 @@ export class AutomationInspectionBus {
           details: details.value,
         }
       : undefined;
-    return {
+    const boundedArtifact = {
       ...params.artifact,
       finalText: finalText.value,
       outputDecision,
+    };
+    return {
+      ...boundedArtifact,
       transcriptEvents,
       transcriptEventsTruncated:
         params.artifact.transcriptEvents.length > transcriptEvents.length || undefined,
@@ -298,7 +301,7 @@ export class AutomationInspectionBus {
       detailsTextTruncated: details.truncated || undefined,
       card: buildAutomationTimelineCard({
         automation: params.automation,
-        artifact: params.artifact,
+        artifact: boundedArtifact,
         run: params.run,
       }),
     };

--- a/apps/desktop/src/main/automations/automation-inspection-bus.ts
+++ b/apps/desktop/src/main/automations/automation-inspection-bus.ts
@@ -81,7 +81,6 @@ export class AutomationInspectionBus {
       .listAutomationsForThread({
         backend: context.backend,
         threadId: context.threadId,
-        includeDeleted: args.includeDeleted === true,
       })
       .filter((automation) => args.includePaused !== false || automation.status !== "paused");
     return {
@@ -163,9 +162,7 @@ export class AutomationInspectionBus {
     if (!artifact) {
       throw new AutomationInspectionError("not_found", "Automation run artifact not found.");
     }
-    const automation = this.getScopedAutomation(run.automationId, context, {
-      includeDeleted: true,
-    });
+    const automation = this.getScopedAutomation(run.automationId, context);
     return {
       artifact: this.toArtifact({
         artifact,
@@ -220,9 +217,7 @@ export class AutomationInspectionBus {
     run: AutomationRunSummary,
     context: AutomationInspectionContext,
   ): boolean {
-    const automation = this.store.getAutomation(run.automationId, {
-      includeDeleted: true,
-    });
+    const automation = this.store.getAutomation(run.automationId);
     return Boolean(
       automation &&
         automation.backend === context.backend &&
@@ -241,9 +236,7 @@ export class AutomationInspectionBus {
   }
 
   private toRunSummary(run: AutomationRunSummary): AutomationInspectionRunSummary {
-    const automation = this.store.getAutomation(run.automationId, {
-      includeDeleted: true,
-    });
+    const automation = this.store.getAutomation(run.automationId);
     const artifact = this.store.getRunArtifact(run.id);
     return {
       ...run,
@@ -256,9 +249,7 @@ export class AutomationInspectionBus {
   }
 
   private toRunDetail(run: AutomationRunSummary): AutomationInspectionRunDetail {
-    const automation = this.store.getAutomation(run.automationId, {
-      includeDeleted: true,
-    });
+    const automation = this.store.getAutomation(run.automationId);
     return {
       ...this.toRunSummary(run),
       automation: automation ? this.toAutomationSummary(automation) : undefined,

--- a/apps/desktop/src/main/automations/automation-inspection-cli.ts
+++ b/apps/desktop/src/main/automations/automation-inspection-cli.ts
@@ -9,6 +9,9 @@ import { AUTOMATION_INSPECTION_TOOL_NAMESPACE } from "@pwragent/shared";
 import type { AutomationInspectionHandler } from "./automation-inspection-codex-tools.js";
 import { isAutomationInspectionMcpToolName } from "./automation-inspection-mcp.js";
 
+export const AUTOMATION_INSPECTION_MCP_COMMAND_ENV =
+  "PWRAGENT_AUTOMATION_INSPECTION_MCP_COMMAND";
+
 export type AcpMcpServerConfig = {
   name: string;
   command: string;
@@ -21,6 +24,12 @@ export type AutomationInspectionCliResult = {
   stdout: string;
   stderr: string;
 };
+
+export function resolveAutomationInspectionMcpCommand(
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  return env[AUTOMATION_INSPECTION_MCP_COMMAND_ENV]?.trim() || undefined;
+}
 
 export function acpRuntimeSupportsAutomationInspectionMcp(
   runtimeCapabilities: BackendAcpRuntimeCapabilities | undefined,

--- a/apps/desktop/src/main/automations/automation-inspection-cli.ts
+++ b/apps/desktop/src/main/automations/automation-inspection-cli.ts
@@ -1,0 +1,193 @@
+import type {
+  AppServerBackendKind,
+  AutomationInspectionOperationName,
+  AutomationInspectionRequest,
+  AutomationInspectionResponse,
+  BackendAcpRuntimeCapabilities,
+} from "@pwragent/shared";
+import { AUTOMATION_INSPECTION_TOOL_NAMESPACE } from "@pwragent/shared";
+import type { AutomationInspectionHandler } from "./automation-inspection-codex-tools.js";
+import { isAutomationInspectionMcpToolName } from "./automation-inspection-mcp.js";
+
+export type AcpMcpServerConfig = {
+  name: string;
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+};
+
+export type AutomationInspectionCliResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+};
+
+export function acpRuntimeSupportsAutomationInspectionMcp(
+  runtimeCapabilities: BackendAcpRuntimeCapabilities | undefined,
+): boolean {
+  const mcp = runtimeCapabilities?.agentCapabilities?.mcp;
+  return mcp?.http === true || mcp?.sse === true;
+}
+
+export function buildAutomationInspectionAcpMcpServers(params: {
+  backend: AppServerBackendKind;
+  command?: string;
+  env?: Record<string, string | undefined>;
+  runtimeCapabilities?: BackendAcpRuntimeCapabilities;
+  threadId?: string;
+}): AcpMcpServerConfig[] {
+  if (
+    !params.threadId ||
+    !params.command ||
+    !acpRuntimeSupportsAutomationInspectionMcp(params.runtimeCapabilities)
+  ) {
+    return [];
+  }
+  return [
+    {
+      name: AUTOMATION_INSPECTION_TOOL_NAMESPACE,
+      command: params.command,
+      args: [
+        "automation-inspection-mcp",
+        "--backend",
+        params.backend,
+        "--thread-id",
+        params.threadId,
+      ],
+      env: compactEnv({
+        ...params.env,
+        PWRAGENT_AUTOMATION_BACKEND: params.backend,
+        PWRAGENT_AUTOMATION_THREAD_ID: params.threadId,
+      }),
+    },
+  ];
+}
+
+export async function runAutomationInspectionCli(params: {
+  argv: string[];
+  handler: AutomationInspectionHandler | undefined;
+}): Promise<AutomationInspectionCliResult> {
+  const parsed = parseAutomationInspectionCliArgs(params.argv);
+  if (!parsed.ok) {
+    return {
+      exitCode: 2,
+      stdout: "",
+      stderr: `${parsed.error}\n`,
+    };
+  }
+  if (!params.handler) {
+    return {
+      exitCode: 1,
+      stdout: "",
+      stderr: "PwrAgent automation inspection is not available.\n",
+    };
+  }
+  const response = await params.handler({
+    operation: parsed.operation,
+    context: {
+      backend: parsed.backend,
+      threadId: parsed.threadId,
+    },
+    args: parsed.args,
+  } as AutomationInspectionRequest);
+  return responseToCliResult(response);
+}
+
+function responseToCliResult(
+  response: AutomationInspectionResponse,
+): AutomationInspectionCliResult {
+  const payload = response.ok ? response.data : response.error;
+  return {
+    exitCode: response.ok ? 0 : 1,
+    stdout: `${JSON.stringify(payload, null, 2)}\n`,
+    stderr: "",
+  };
+}
+
+function parseAutomationInspectionCliArgs(argv: string[]):
+  | {
+      ok: true;
+      operation: AutomationInspectionOperationName;
+      backend: AppServerBackendKind;
+      threadId: string;
+      args: Record<string, unknown>;
+    }
+  | { ok: false; error: string } {
+  const [operationValue, ...rest] = argv;
+  if (!isAutomationInspectionMcpToolName(operationValue)) {
+    return { ok: false, error: "Missing or unsupported automation inspection operation." };
+  }
+  const options = readOptions(rest);
+  const backend = readString(options.backend);
+  const threadId = readString(options["thread-id"] ?? options.threadId);
+  if (!backend || !threadId) {
+    return { ok: false, error: "Required options: --backend and --thread-id." };
+  }
+  const args = parseJsonObject(options.args, "args");
+  if (!args.ok) {
+    return args;
+  }
+  return {
+    ok: true,
+    operation: operationValue,
+    backend: backend as AppServerBackendKind,
+    threadId,
+    args: args.value,
+  };
+}
+
+function readOptions(argv: string[]): Record<string, string | undefined> {
+  const options: Record<string, string | undefined> = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token?.startsWith("--")) {
+      continue;
+    }
+    const key = token.slice(2);
+    const next = argv[index + 1];
+    if (!next || next.startsWith("--")) {
+      options[key] = "true";
+      continue;
+    }
+    options[key] = next;
+    index += 1;
+  }
+  return options;
+}
+
+function parseJsonObject(
+  value: string | undefined,
+  label: string,
+): { ok: true; value: Record<string, unknown> } | { ok: false; error: string } {
+  if (!value) {
+    return { ok: true, value: {} };
+  }
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return { ok: true, value: parsed as Record<string, unknown> };
+    }
+    return { ok: false, error: `--${label} must be a JSON object.` };
+  } catch (error) {
+    return {
+      ok: false,
+      error: `Invalid --${label} JSON: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    };
+  }
+}
+
+function compactEnv(
+  env: Record<string, string | undefined>,
+): Record<string, string> | undefined {
+  const entries = Object.entries(env).filter(
+    (entry): entry is [string, string] =>
+      typeof entry[1] === "string" && entry[1].length > 0,
+  );
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}

--- a/apps/desktop/src/main/automations/automation-inspection-codex-tools.ts
+++ b/apps/desktop/src/main/automations/automation-inspection-codex-tools.ts
@@ -14,93 +14,17 @@ import type {
   DynamicToolCallResponse,
   DynamicToolSpec,
 } from "@pwragent/codex-app-server-protocol/v2";
+import { buildAutomationInspectionToolCatalog } from "./automation-inspection-tool-catalog.js";
 
 export type AutomationInspectionHandler = (
   request: AutomationInspectionRequest,
 ) => AutomationInspectionResponse | Promise<AutomationInspectionResponse>;
 
-type OperationSpec = {
-  description: string;
-  inputSchema: Record<string, unknown>;
-};
-
-const OPERATION_SPECS: Record<AutomationInspectionOperationName, OperationSpec> = {
-  list_automations: {
-    description:
-      "List automations attached to this PwrAgent Agent thread with compact status and latest-run metadata.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        includePaused: { type: "boolean" },
-        includeDeleted: { type: "boolean" },
-        limit: { type: "number", minimum: 1 },
-      },
-      additionalProperties: false,
-    },
-  },
-  summarize_automation_status: {
-    description:
-      "Summarize automation health and recent run activity for this PwrAgent Agent thread.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        limit: { type: "number", minimum: 1 },
-        since: { type: "number" },
-      },
-      additionalProperties: false,
-    },
-  },
-  list_automation_runs: {
-    description:
-      "List recent automation runs for this Agent thread or one attached automation.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        automationId: { type: "string" },
-        limit: { type: "number", minimum: 1 },
-        since: { type: "number" },
-        statuses: {
-          type: "array",
-          items: { type: "string" },
-        },
-      },
-      additionalProperties: false,
-    },
-  },
-  get_automation_run: {
-    description:
-      "Inspect one automation run's status, timing, trigger, output summary, and error metadata.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        runId: { type: "string" },
-      },
-      required: ["runId"],
-      additionalProperties: false,
-    },
-  },
-  get_automation_run_artifact: {
-    description:
-      "Fetch one automation run's stored output artifact, card decision, and bounded transcript events.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        runId: { type: "string" },
-        eventLimit: { type: "number", minimum: 1 },
-        textLimitChars: { type: "number", minimum: 1 },
-      },
-      required: ["runId"],
-      additionalProperties: false,
-    },
-  },
-};
-
 export function buildAutomationInspectionDynamicToolSpecs(): DynamicToolSpec[] {
-  return AUTOMATION_INSPECTION_OPERATION_NAMES.map((name) => {
-    const spec = OPERATION_SPECS[name];
+  return buildAutomationInspectionToolCatalog().map((spec) => {
     return {
       namespace: AUTOMATION_INSPECTION_TOOL_NAMESPACE,
-      name,
+      name: spec.name,
       description: spec.description,
       inputSchema: spec.inputSchema as DynamicToolSpec["inputSchema"],
       deferLoading: false,

--- a/apps/desktop/src/main/automations/automation-inspection-codex-tools.ts
+++ b/apps/desktop/src/main/automations/automation-inspection-codex-tools.ts
@@ -83,6 +83,21 @@ export async function handleAutomationInspectionDynamicToolCall(params: {
   return toDynamicToolResponse(response);
 }
 
+export function buildAutomationInspectionDynamicToolErrorResponse(params: {
+  code: "forbidden" | "internal_error" | "unsupported_operation";
+  message: string;
+  operation?: AutomationInspectionOperationName;
+}): DynamicToolCallResponse {
+  return toDynamicToolResponse({
+    ok: false,
+    operation: params.operation ?? "list_automations",
+    error: {
+      code: params.code,
+      message: params.message,
+    },
+  });
+}
+
 export function readAutomationInspectionDynamicToolCall(
   request: {
     method: string;

--- a/apps/desktop/src/main/automations/automation-inspection-codex-tools.ts
+++ b/apps/desktop/src/main/automations/automation-inspection-codex-tools.ts
@@ -1,0 +1,217 @@
+import type {
+  AppServerBackendKind,
+  AutomationInspectionContext,
+  AutomationInspectionOperationName,
+  AutomationInspectionRequest,
+  AutomationInspectionResponse,
+} from "@pwragent/shared";
+import {
+  AUTOMATION_INSPECTION_OPERATION_NAMES,
+  AUTOMATION_INSPECTION_TOOL_NAMESPACE,
+} from "@pwragent/shared";
+import type {
+  DynamicToolCallParams,
+  DynamicToolCallResponse,
+  DynamicToolSpec,
+} from "@pwragent/codex-app-server-protocol/v2";
+
+export type AutomationInspectionHandler = (
+  request: AutomationInspectionRequest,
+) => AutomationInspectionResponse | Promise<AutomationInspectionResponse>;
+
+type OperationSpec = {
+  description: string;
+  inputSchema: Record<string, unknown>;
+};
+
+const OPERATION_SPECS: Record<AutomationInspectionOperationName, OperationSpec> = {
+  list_automations: {
+    description:
+      "List automations attached to this PwrAgent Agent thread with compact status and latest-run metadata.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        includePaused: { type: "boolean" },
+        includeDeleted: { type: "boolean" },
+        limit: { type: "number", minimum: 1 },
+      },
+      additionalProperties: false,
+    },
+  },
+  summarize_automation_status: {
+    description:
+      "Summarize automation health and recent run activity for this PwrAgent Agent thread.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        limit: { type: "number", minimum: 1 },
+        since: { type: "number" },
+      },
+      additionalProperties: false,
+    },
+  },
+  list_automation_runs: {
+    description:
+      "List recent automation runs for this Agent thread or one attached automation.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        automationId: { type: "string" },
+        limit: { type: "number", minimum: 1 },
+        since: { type: "number" },
+        statuses: {
+          type: "array",
+          items: { type: "string" },
+        },
+      },
+      additionalProperties: false,
+    },
+  },
+  get_automation_run: {
+    description:
+      "Inspect one automation run's status, timing, trigger, output summary, and error metadata.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        runId: { type: "string" },
+      },
+      required: ["runId"],
+      additionalProperties: false,
+    },
+  },
+  get_automation_run_artifact: {
+    description:
+      "Fetch one automation run's stored output artifact, card decision, and bounded transcript events.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        runId: { type: "string" },
+        eventLimit: { type: "number", minimum: 1 },
+        textLimitChars: { type: "number", minimum: 1 },
+      },
+      required: ["runId"],
+      additionalProperties: false,
+    },
+  },
+};
+
+export function buildAutomationInspectionDynamicToolSpecs(): DynamicToolSpec[] {
+  return AUTOMATION_INSPECTION_OPERATION_NAMES.map((name) => {
+    const spec = OPERATION_SPECS[name];
+    return {
+      namespace: AUTOMATION_INSPECTION_TOOL_NAMESPACE,
+      name,
+      description: spec.description,
+      inputSchema: spec.inputSchema as DynamicToolSpec["inputSchema"],
+      deferLoading: false,
+    };
+  });
+}
+
+export function isAutomationInspectionDynamicToolCall(
+  call: Pick<DynamicToolCallParams, "namespace" | "tool">,
+): call is DynamicToolCallParams & {
+  namespace: typeof AUTOMATION_INSPECTION_TOOL_NAMESPACE;
+  tool: AutomationInspectionOperationName;
+} {
+  return (
+    call.namespace === AUTOMATION_INSPECTION_TOOL_NAMESPACE &&
+    AUTOMATION_INSPECTION_OPERATION_NAMES.includes(
+      call.tool as AutomationInspectionOperationName,
+    )
+  );
+}
+
+export async function handleAutomationInspectionDynamicToolCall(params: {
+  backend: AppServerBackendKind;
+  call: DynamicToolCallParams;
+  handler: AutomationInspectionHandler | undefined;
+}): Promise<DynamicToolCallResponse> {
+  if (!isAutomationInspectionDynamicToolCall(params.call)) {
+    return toDynamicToolResponse({
+      ok: false,
+      operation: params.call.tool as AutomationInspectionOperationName,
+      error: {
+        code: "unsupported_operation",
+        message: "Unsupported PwrAgent automation tool.",
+      },
+    });
+  }
+  if (!params.handler) {
+    return toDynamicToolResponse({
+      ok: false,
+      operation: params.call.tool,
+      error: {
+        code: "internal_error",
+        message: "PwrAgent automation inspection is not available.",
+      },
+    });
+  }
+  const context: AutomationInspectionContext = {
+    backend: params.backend,
+    threadId: params.call.threadId,
+  };
+  const response = await params.handler({
+    operation: params.call.tool,
+    context,
+    args: normalizeToolArguments(params.call.arguments),
+  } as AutomationInspectionRequest);
+  return toDynamicToolResponse(response);
+}
+
+export function readAutomationInspectionDynamicToolCall(
+  request: {
+    method: string;
+    params: Record<string, unknown>;
+  },
+): DynamicToolCallParams | undefined {
+  if (request.method !== "item/tool/call") {
+    return undefined;
+  }
+  const call = request.params;
+  const threadId = readString(call.threadId);
+  const turnId = readString(call.turnId) ?? "";
+  const callId = readString(call.callId) ?? readString(call.requestId);
+  const tool = readString(call.tool);
+  const namespace =
+    typeof call.namespace === "string" || call.namespace === null
+      ? call.namespace
+      : undefined;
+  if (!threadId || !callId || !tool || namespace === undefined) {
+    return undefined;
+  }
+  return {
+    threadId,
+    turnId,
+    callId,
+    namespace,
+    tool,
+    arguments: (call.arguments ?? null) as DynamicToolCallParams["arguments"],
+  };
+}
+
+function toDynamicToolResponse(
+  response: AutomationInspectionResponse,
+): DynamicToolCallResponse {
+  return {
+    success: response.ok,
+    contentItems: [
+      {
+        type: "inputText",
+        text: JSON.stringify(response.ok ? response.data : response.error, null, 2),
+      },
+    ],
+  };
+}
+
+function normalizeToolArguments(value: unknown): Record<string, unknown> {
+  return isRecord(value) ? value : {};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}

--- a/apps/desktop/src/main/automations/automation-inspection-mcp.ts
+++ b/apps/desktop/src/main/automations/automation-inspection-mcp.ts
@@ -1,0 +1,111 @@
+import type {
+  AppServerBackendKind,
+  AutomationInspectionContext,
+  AutomationInspectionOperationName,
+  AutomationInspectionRequest,
+  AutomationInspectionResponse,
+} from "@pwragent/shared";
+import {
+  AUTOMATION_INSPECTION_OPERATION_NAMES,
+  AUTOMATION_INSPECTION_TOOL_NAMESPACE,
+} from "@pwragent/shared";
+import type { AutomationInspectionHandler } from "./automation-inspection-codex-tools.js";
+import { buildAutomationInspectionToolCatalog } from "./automation-inspection-tool-catalog.js";
+
+export type AutomationInspectionMcpTool = {
+  name: AutomationInspectionOperationName;
+  description: string;
+  inputSchema: Record<string, unknown>;
+};
+
+export type AutomationInspectionMcpCallResponse = {
+  content: Array<{
+    type: "text";
+    text: string;
+  }>;
+  structuredContent?: unknown;
+  isError?: boolean;
+};
+
+export function buildAutomationInspectionMcpTools(): AutomationInspectionMcpTool[] {
+  return buildAutomationInspectionToolCatalog().map((tool) => ({
+    name: tool.name,
+    description: tool.description,
+    inputSchema: tool.inputSchema,
+  }));
+}
+
+export function isAutomationInspectionMcpToolName(
+  value: unknown,
+): value is AutomationInspectionOperationName {
+  return (
+    typeof value === "string" &&
+    AUTOMATION_INSPECTION_OPERATION_NAMES.includes(
+      value as AutomationInspectionOperationName,
+    )
+  );
+}
+
+export async function handleAutomationInspectionMcpToolCall(params: {
+  backend: AppServerBackendKind;
+  threadId: string;
+  tool: string;
+  args?: unknown;
+  handler: AutomationInspectionHandler | undefined;
+}): Promise<AutomationInspectionMcpCallResponse> {
+  if (!isAutomationInspectionMcpToolName(params.tool)) {
+    return toMcpToolResponse({
+      ok: false,
+      operation: "list_automations",
+      error: {
+        code: "unsupported_operation",
+        message: `Unsupported ${AUTOMATION_INSPECTION_TOOL_NAMESPACE} tool.`,
+      },
+    });
+  }
+  if (!params.handler) {
+    return toMcpToolResponse({
+      ok: false,
+      operation: params.tool,
+      error: {
+        code: "internal_error",
+        message: "PwrAgent automation inspection is not available.",
+      },
+    });
+  }
+  const context: AutomationInspectionContext = {
+    backend: params.backend,
+    threadId: params.threadId,
+  };
+  return toMcpToolResponse(
+    await params.handler({
+      operation: params.tool,
+      context,
+      args: normalizeToolArguments(params.args),
+    } as AutomationInspectionRequest),
+  );
+}
+
+function toMcpToolResponse(
+  response: AutomationInspectionResponse,
+): AutomationInspectionMcpCallResponse {
+  const payload = response.ok ? response.data : response.error;
+  return {
+    isError: response.ok ? undefined : true,
+    structuredContent: payload,
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(payload, null, 2),
+      },
+    ],
+  };
+}
+
+function normalizeToolArguments(value: unknown): Record<string, unknown> {
+  return isRecord(value) ? value : {};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}

--- a/apps/desktop/src/main/automations/automation-inspection-tool-catalog.ts
+++ b/apps/desktop/src/main/automations/automation-inspection-tool-catalog.ts
@@ -1,0 +1,89 @@
+import type { AutomationInspectionOperationName } from "@pwragent/shared";
+import { AUTOMATION_INSPECTION_OPERATION_NAMES } from "@pwragent/shared";
+
+export type AutomationInspectionToolCatalogEntry = {
+  name: AutomationInspectionOperationName;
+  description: string;
+  inputSchema: Record<string, unknown>;
+};
+
+const TOOL_CATALOG: Record<
+  AutomationInspectionOperationName,
+  Omit<AutomationInspectionToolCatalogEntry, "name">
+> = {
+  list_automations: {
+    description:
+      "List automations attached to this PwrAgent Agent thread with compact status and latest-run metadata.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        includePaused: { type: "boolean" },
+        includeDeleted: { type: "boolean" },
+        limit: { type: "number", minimum: 1 },
+      },
+      additionalProperties: false,
+    },
+  },
+  summarize_automation_status: {
+    description:
+      "Summarize automation health and recent run activity for this PwrAgent Agent thread.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        limit: { type: "number", minimum: 1 },
+        since: { type: "number" },
+      },
+      additionalProperties: false,
+    },
+  },
+  list_automation_runs: {
+    description:
+      "List recent automation runs for this Agent thread or one attached automation.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        automationId: { type: "string" },
+        limit: { type: "number", minimum: 1 },
+        since: { type: "number" },
+        statuses: {
+          type: "array",
+          items: { type: "string" },
+        },
+      },
+      additionalProperties: false,
+    },
+  },
+  get_automation_run: {
+    description:
+      "Inspect one automation run's status, timing, trigger, output summary, and error metadata.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        runId: { type: "string" },
+      },
+      required: ["runId"],
+      additionalProperties: false,
+    },
+  },
+  get_automation_run_artifact: {
+    description:
+      "Fetch one automation run's stored output artifact, card decision, and bounded transcript events.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        runId: { type: "string" },
+        eventLimit: { type: "number", minimum: 1 },
+        textLimitChars: { type: "number", minimum: 1 },
+      },
+      required: ["runId"],
+      additionalProperties: false,
+    },
+  },
+};
+
+export function buildAutomationInspectionToolCatalog(): AutomationInspectionToolCatalogEntry[] {
+  return AUTOMATION_INSPECTION_OPERATION_NAMES.map((name) => ({
+    name,
+    ...TOOL_CATALOG[name],
+  }));
+}

--- a/apps/desktop/src/main/automations/automation-inspection-tool-catalog.ts
+++ b/apps/desktop/src/main/automations/automation-inspection-tool-catalog.ts
@@ -18,7 +18,6 @@ const TOOL_CATALOG: Record<
       type: "object",
       properties: {
         includePaused: { type: "boolean" },
-        includeDeleted: { type: "boolean" },
         limit: { type: "number", minimum: 1 },
       },
       additionalProperties: false,

--- a/apps/desktop/src/main/automations/desktop-automation-service.ts
+++ b/apps/desktop/src/main/automations/desktop-automation-service.ts
@@ -27,6 +27,7 @@ import type { DesktopBackendRegistry } from "../app-server/backend-registry.js";
 import { getDesktopBackendRegistry } from "../app-server/backend-registry.js";
 import { getMainLogger } from "../log.js";
 import { getAppAutomationStore } from "../state/app-state.js";
+import { AutomationInspectionBus } from "./automation-inspection-bus.js";
 import { computeNextAutomationRunAt } from "./automation-schedule.js";
 import { ShellAutomationGateRunner } from "./automation-gate-runner.js";
 import { parseAutomationOutputDecision } from "./automation-output-decision.js";
@@ -67,6 +68,7 @@ export function disposeDesktopAutomationService(): void {
 
 export class DesktopAutomationService {
   private readonly scheduler: AutomationScheduler;
+  private readonly inspectionBus: AutomationInspectionBus;
   private unsubscribeRegistryEvents?: () => void;
 
   constructor(
@@ -80,6 +82,7 @@ export class DesktopAutomationService {
       runner: new HeadlessAutomationRunner(options.registry),
       gateRunner: new ShellAutomationGateRunner(),
     });
+    this.inspectionBus = new AutomationInspectionBus(options.store);
     this.reconcileStartupRuns();
   }
 
@@ -92,6 +95,9 @@ export class DesktopAutomationService {
     this.options.registry.setAutomationTurnContextProvider?.((params) =>
       this.buildThreadAutomationContextInput(params),
     );
+    this.options.registry.setAutomationInspectionHandler?.((request) =>
+      this.inspectionBus.inspect(request),
+    );
     this.scheduler.start();
   }
 
@@ -100,6 +106,7 @@ export class DesktopAutomationService {
     this.unsubscribeRegistryEvents?.();
     this.unsubscribeRegistryEvents = undefined;
     this.options.registry.setAutomationTurnContextProvider?.(null);
+    this.options.registry.setAutomationInspectionHandler?.(null);
   }
 
   list(request: ListAutomationsRequest = {}): ListAutomationsResponse {

--- a/apps/desktop/src/main/automations/desktop-automation-service.ts
+++ b/apps/desktop/src/main/automations/desktop-automation-service.ts
@@ -2,7 +2,6 @@ import type {
   AgentEvent,
   AppServerBackendKind,
   AppServerNotification,
-  AppServerTurnInputItem,
   AutomationDetail,
   AutomationIdRequest,
   AutomationMutationResponse,
@@ -92,9 +91,6 @@ export class DesktopAutomationService {
         this.handleRegistryEvent(event),
       );
     }
-    this.options.registry.setAutomationTurnContextProvider?.((params) =>
-      this.buildThreadAutomationContextInput(params),
-    );
     this.options.registry.setAutomationInspectionHandler?.((request) =>
       this.inspectionBus.inspect(request),
     );
@@ -105,7 +101,6 @@ export class DesktopAutomationService {
     this.scheduler.stop();
     this.unsubscribeRegistryEvents?.();
     this.unsubscribeRegistryEvents = undefined;
-    this.options.registry.setAutomationTurnContextProvider?.(null);
     this.options.registry.setAutomationInspectionHandler?.(null);
   }
 
@@ -633,62 +628,6 @@ export class DesktopAutomationService {
         ]),
     );
     this.options.store.reconcileStartup({ now, nextRunAtByAutomationId });
-  }
-
-  private buildThreadAutomationContextInput(params: {
-    backend: AppServerBackendKind;
-    threadId: string;
-  }): AppServerTurnInputItem[] {
-    const lines = this.options.store
-      .listRunsForThread({
-        backend: params.backend,
-        threadId: params.threadId,
-        limit: 10,
-      })
-      .filter((run) =>
-        run.status === "completed" ||
-        run.status === "failed" ||
-        run.status === "cancelled" ||
-        run.status === "skipped"
-      )
-      .slice(0, 5)
-      .map((run) => {
-        const automation = this.options.store.getAutomation(run.automationId, {
-          includeDeleted: true,
-        });
-        const artifact = this.options.store.getRunArtifact(run.id);
-        const when =
-          run.completedAt ??
-          run.startedAt ??
-          run.queuedAt ??
-          run.scheduledFor;
-        const summary =
-          artifact?.outputDecision?.summary ??
-          firstLine(artifact?.finalText) ??
-          artifact?.errorMessage ??
-          run.errorMessage ??
-          run.status;
-        const details = artifact?.outputDecision?.details;
-        return [
-          `- ${automation?.name ?? "Automation"} (${run.status}${when ? ` at ${new Date(when).toISOString()}` : ""}): ${summary}`,
-          details ? `  Details: ${details}` : undefined,
-        ]
-          .filter((line): line is string => Boolean(line))
-          .join("\n");
-      });
-    if (lines.length === 0) {
-      return [];
-    }
-    return [
-      {
-        type: "text",
-        text: [
-          "Recent automation updates for this Agent thread:",
-          ...lines,
-          "These automation updates were delivered out of band and may not appear in the Codex transcript above. Use them when answering questions about automation runs.",
-        ].join("\n"),
-      },
-    ];
   }
 
   private assertValidSchedule(schedule: CreateAutomationRequest["schedule"]): void {

--- a/apps/desktop/src/main/automations/desktop-automation-service.ts
+++ b/apps/desktop/src/main/automations/desktop-automation-service.ts
@@ -3,6 +3,9 @@ import type {
   AppServerBackendKind,
   AppServerNotification,
   AutomationDetail,
+  AutomationInspectionFailure,
+  AutomationInspectionErrorCode,
+  AutomationInspectionResponse,
   AutomationIdRequest,
   AutomationMutationResponse,
   AutomationRunSummary,
@@ -25,6 +28,7 @@ import { validateAutomationScheduleDefinition } from "@pwragent/shared";
 import type { DesktopBackendRegistry } from "../app-server/backend-registry.js";
 import { getDesktopBackendRegistry } from "../app-server/backend-registry.js";
 import { getMainLogger } from "../log.js";
+import { resolveRuntimeAutomationsOverride } from "../runtime-flags.js";
 import { getAppAutomationStore } from "../state/app-state.js";
 import { AutomationInspectionBus } from "./automation-inspection-bus.js";
 import { computeNextAutomationRunAt } from "./automation-schedule.js";
@@ -51,8 +55,13 @@ export function getDesktopAutomationService(
   registry = getDesktopBackendRegistry(),
 ): DesktopAutomationService {
   if (!service) {
+    const runtimeOverride = resolveRuntimeAutomationsOverride();
     service = new DesktopAutomationService({
       registry,
+      runtime: {
+        disabled: runtimeOverride.disabled,
+        disabledReason: runtimeOverride.reason,
+      },
       store: getDesktopAutomationStore(),
     });
     service.start();
@@ -73,6 +82,10 @@ export class DesktopAutomationService {
   constructor(
     private readonly options: {
       registry: DesktopBackendRegistry;
+      runtime?: {
+        disabled?: boolean;
+        disabledReason?: string;
+      };
       store: AutomationStore;
     },
   ) {
@@ -82,7 +95,6 @@ export class DesktopAutomationService {
       gateRunner: new ShellAutomationGateRunner(),
     });
     this.inspectionBus = new AutomationInspectionBus(options.store);
-    this.reconcileStartupRuns();
   }
 
   start(): void {
@@ -91,7 +103,26 @@ export class DesktopAutomationService {
         this.handleRegistryEvent(event),
       );
     }
-    this.options.registry.setAutomationInspectionHandler?.((request) => {
+    this.options.registry.setAutomationInspectionHandler?.(async (request) => {
+      const agent = await this.options.registry.getThreadAgentMetadata({
+        backend: request.context.backend,
+        threadId: request.context.threadId,
+      });
+      if (!agent) {
+        const response = automationInspectionFailure(
+          request.operation,
+          "forbidden",
+          "Automation inspection is only available to Agent threads.",
+        );
+        automationServiceLog.info("automation inspection request denied", {
+          backend: request.context.backend,
+          errorCode: "forbidden",
+          ok: response.ok,
+          operation: request.operation,
+          threadId: request.context.threadId,
+        });
+        return response;
+      }
       const response = this.inspectionBus.inspect(request);
       const payload = response.ok ? response.data : response.error;
       automationServiceLog.info("automation inspection request handled", {
@@ -104,6 +135,13 @@ export class DesktopAutomationService {
       });
       return response;
     });
+    if (this.options.runtime?.disabled) {
+      automationServiceLog.info("automation scheduler disabled for this app instance", {
+        reason: this.options.runtime.disabledReason,
+      });
+      return;
+    }
+    this.reconcileStartupRuns();
     this.scheduler.start();
   }
 
@@ -221,7 +259,7 @@ export class DesktopAutomationService {
       now,
     });
     await this.notifyThreadAutomationsUpdated(automation);
-    this.scheduler.start();
+    this.startSchedulerIfEnabled();
     return { automation: toAutomationDetail(automation) };
   }
 
@@ -288,7 +326,7 @@ export class DesktopAutomationService {
       await this.notifyThreadAutomationsUpdated(current);
     }
     await this.notifyThreadAutomationsUpdated(updated);
-    this.scheduler.start();
+    this.startSchedulerIfEnabled();
     return { automation: toAutomationDetail(updated) };
   }
 
@@ -299,7 +337,7 @@ export class DesktopAutomationService {
     });
     if (!automation) throw new Error("Automation not found.");
     await this.notifyThreadAutomationsUpdated(automation);
-    this.scheduler.start();
+    this.startSchedulerIfEnabled();
     return { automation: toAutomationDetail(automation) };
   }
 
@@ -311,7 +349,7 @@ export class DesktopAutomationService {
     });
     if (!automation) throw new Error("Automation not found.");
     await this.notifyThreadAutomationsUpdated(automation);
-    this.scheduler.start();
+    this.startSchedulerIfEnabled();
     return { automation: toAutomationDetail(automation) };
   }
 
@@ -329,11 +367,12 @@ export class DesktopAutomationService {
       );
     }
     await this.notifyThreadAutomationsUpdated(automation);
-    this.scheduler.start();
+    this.startSchedulerIfEnabled();
     return { automation: toAutomationDetail(automation) };
   }
 
   async runNow(request: AutomationIdRequest): Promise<RunAutomationNowResponse> {
+    this.assertAutomationsEnabled();
     const result = await this.scheduler.runNow(request.automationId);
     const [run] = this.options.store.listRunsForAutomation(request.automationId, 1);
     if (!run) {
@@ -640,6 +679,21 @@ export class DesktopAutomationService {
     this.options.store.reconcileStartup({ now, nextRunAtByAutomationId });
   }
 
+  private startSchedulerIfEnabled(): void {
+    if (!this.options.runtime?.disabled) {
+      this.scheduler.start();
+    }
+  }
+
+  private assertAutomationsEnabled(): void {
+    if (!this.options.runtime?.disabled) return;
+    throw new Error(
+      this.options.runtime.disabledReason
+        ? `Automations are disabled for this app instance: ${this.options.runtime.disabledReason}`
+        : "Automations are disabled for this app instance.",
+    );
+  }
+
   private assertValidSchedule(schedule: CreateAutomationRequest["schedule"]): void {
     const validation = validateAutomationScheduleDefinition(schedule);
     if (!validation.ok) {
@@ -670,6 +724,21 @@ export class DesktopAutomationService {
       },
     });
   }
+}
+
+function automationInspectionFailure(
+  operation: AutomationInspectionResponse["operation"],
+  code: AutomationInspectionErrorCode,
+  message: string,
+): AutomationInspectionFailure {
+  return {
+    ok: false,
+    operation,
+    error: {
+      code,
+      message,
+    },
+  };
 }
 
 function toAutomationDetail(

--- a/apps/desktop/src/main/automations/desktop-automation-service.ts
+++ b/apps/desktop/src/main/automations/desktop-automation-service.ts
@@ -98,11 +98,6 @@ export class DesktopAutomationService {
   }
 
   start(): void {
-    if (!this.unsubscribeRegistryEvents) {
-      this.unsubscribeRegistryEvents = this.options.registry.onEvent((event) =>
-        this.handleRegistryEvent(event),
-      );
-    }
     this.options.registry.setAutomationInspectionHandler?.(async (request) => {
       const agent = await this.options.registry.getThreadAgentMetadata({
         backend: request.context.backend,
@@ -140,6 +135,11 @@ export class DesktopAutomationService {
         reason: this.options.runtime.disabledReason,
       });
       return;
+    }
+    if (!this.unsubscribeRegistryEvents) {
+      this.unsubscribeRegistryEvents = this.options.registry.onEvent((event) =>
+        this.handleRegistryEvent(event),
+      );
     }
     this.reconcileStartupRuns();
     this.scheduler.start();

--- a/apps/desktop/src/main/automations/desktop-automation-service.ts
+++ b/apps/desktop/src/main/automations/desktop-automation-service.ts
@@ -91,9 +91,19 @@ export class DesktopAutomationService {
         this.handleRegistryEvent(event),
       );
     }
-    this.options.registry.setAutomationInspectionHandler?.((request) =>
-      this.inspectionBus.inspect(request),
-    );
+    this.options.registry.setAutomationInspectionHandler?.((request) => {
+      const response = this.inspectionBus.inspect(request);
+      const payload = response.ok ? response.data : response.error;
+      automationServiceLog.info("automation inspection request handled", {
+        backend: request.context.backend,
+        errorCode: response.ok ? undefined : response.error.code,
+        ok: response.ok,
+        operation: request.operation,
+        resultBytes: JSON.stringify(payload).length,
+        threadId: request.context.threadId,
+      });
+      return response;
+    });
     this.scheduler.start();
   }
 

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -59,6 +59,7 @@ import type {
   TurnInterruptParams as CodexTurnInterruptParams,
   TurnStartParams as CodexTurnStartParams,
   TurnSteerParams as CodexTurnSteerParams,
+  DynamicToolSpec as CodexDynamicToolSpec,
   UserInput as CodexUserInput,
 } from "@pwragent/codex-app-server-protocol/v2";
 import { IterableMapper } from "@shutterstock/p-map-iterable";
@@ -253,7 +254,8 @@ function isHandledServerRequestMethod(method: string): boolean {
   return (
     isApprovalLikeMethod(method) ||
     method === "item/tool/requestUserInput" ||
-    method === "mcpServer/elicitation/request"
+    method === "mcpServer/elicitation/request" ||
+    method === "item/tool/call"
   );
 }
 
@@ -3507,6 +3509,7 @@ function buildThreadStartPayload(params: {
   ephemeral?: boolean;
   codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
   config?: CodexThreadStartParams["config"];
+  dynamicTools?: CodexDynamicToolSpec[];
 }): CodexThreadStartParams {
   const base: CodexThreadStartParams = {
     experimentalRawEvents: false,
@@ -3539,6 +3542,9 @@ function buildThreadStartPayload(params: {
   }
   if (params.config) {
     base.config = params.config;
+  }
+  if (params.dynamicTools) {
+    base.dynamicTools = params.dynamicTools;
   }
   if (
     params.codexEnvironmentRuntime?.executionTarget === "remote" &&
@@ -4506,6 +4512,7 @@ export class CodexAppServerClient {
     reasoningEffort?: string;
     fastMode?: boolean;
     codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
+    dynamicTools?: CodexDynamicToolSpec[];
   }): Promise<{ threadId: string }> {
     await this.ensureInitialized();
 

--- a/apps/desktop/src/main/runtime-flags.ts
+++ b/apps/desktop/src/main/runtime-flags.ts
@@ -1,5 +1,7 @@
 export const DISABLE_MESSAGING_ARG = "--disable-messaging";
 export const DISABLE_MESSAGING_ENV = "PWRAGENT_DISABLE_MESSAGING";
+export const DISABLE_AUTOMATIONS_ARG = "--disable-automations";
+export const DISABLE_AUTOMATIONS_ENV = "PWRAGENT_DISABLE_AUTOMATIONS";
 
 export type RuntimeMessagingOverride = {
   disabled: boolean;
@@ -10,21 +12,52 @@ export function resolveRuntimeMessagingOverride(options: {
   argv?: readonly string[];
   env?: NodeJS.ProcessEnv;
 } = {}): RuntimeMessagingOverride {
+  return resolveRuntimeDisableOverride({
+    arg: DISABLE_MESSAGING_ARG,
+    envKey: DISABLE_MESSAGING_ENV,
+    argv: options.argv,
+    env: options.env,
+  });
+}
+
+export type RuntimeAutomationsOverride = {
+  disabled: boolean;
+  reason?: string;
+};
+
+export function resolveRuntimeAutomationsOverride(options: {
+  argv?: readonly string[];
+  env?: NodeJS.ProcessEnv;
+} = {}): RuntimeAutomationsOverride {
+  return resolveRuntimeDisableOverride({
+    arg: DISABLE_AUTOMATIONS_ARG,
+    envKey: DISABLE_AUTOMATIONS_ENV,
+    argv: options.argv,
+    env: options.env,
+  });
+}
+
+function resolveRuntimeDisableOverride(options: {
+  arg: string;
+  envKey: string;
+  argv?: readonly string[];
+  env?: NodeJS.ProcessEnv;
+}): { disabled: boolean; reason?: string } {
   const argv = options.argv ?? process.argv;
   const env = options.env ?? process.env;
 
-  if (argv.includes(DISABLE_MESSAGING_ARG)) {
+  if (argv.includes(options.arg)) {
     return {
       disabled: true,
-      reason: `${DISABLE_MESSAGING_ARG} was provided at startup`,
+      reason: `${options.arg} was provided at startup`,
     };
   }
 
-  const envValue = env[DISABLE_MESSAGING_ENV]?.trim().toLowerCase();
+  const envValue = env[options.envKey]?.trim().toLowerCase();
   if (envValue && ["1", "true", "yes", "on"].includes(envValue)) {
     return {
       disabled: true,
-      reason: `${DISABLE_MESSAGING_ENV} is enabled`,
+      reason: `${options.envKey} is enabled`,
     };
   }
 

--- a/docs/automation-scheduling.md
+++ b/docs/automation-scheduling.md
@@ -68,6 +68,28 @@ On app restart, stale local pending, queued, or running automation records are
 closed as cancelled because queued desktop-local work is not durable across
 process lifetimes.
 
+## Agent Tool Access
+
+Agent-attached automations publish timeline cards out of band. They are not
+inserted into the next user message as fake context. Codex-backed Agent threads
+receive read-only `pwragent_automations` dynamic tools so the Agent can list
+attached automations, inspect recent runs, and fetch stored run artifacts when a
+user asks what happened.
+
+ACP-backed Agent threads use the same inspection operations through MCP/CLI
+adapters when the runtime supports MCP server configuration. Unsupported ACP
+runtimes keep starting with an empty MCP server list instead of failing session
+creation.
+
+Manual smoke test:
+
+1. Create or open an Agent thread.
+2. Attach an interval automation and let it complete a run.
+3. Ask the Agent what happened with that automation.
+4. Confirm the submitted user message remains unchanged and logs show
+   `automation inspection request handled` rather than a synthetic
+   `Automation Context` message.
+
 ## Future Personality Profiles
 
 Personality profile selection is intentionally deferred. If future versions add

--- a/docs/automation-scheduling.md
+++ b/docs/automation-scheduling.md
@@ -68,18 +68,29 @@ On app restart, stale local pending, queued, or running automation records are
 closed as cancelled because queued desktop-local work is not durable across
 process lifetimes.
 
+## Runtime Disable
+
+Use `--disable-automations` or `PWRAGENT_DISABLE_AUTOMATIONS=1` to keep a
+desktop instance from scheduling or manually running automations. The UI and
+read-only history/inspection paths remain available so secondary dev instances
+can inspect the same profile without also executing the profile's schedules.
+
 ## Agent Tool Access
 
 Agent-attached automations publish timeline cards out of band. They are not
 inserted into the next user message as fake context. Codex-backed Agent threads
-receive read-only `pwragent_automations` dynamic tools so the Agent can list
-attached automations, inspect recent runs, and fetch stored run artifacts when a
-user asks what happened.
+receive read-only `pwragent_automations` dynamic tools so the Agent can list its
+own attached automations, inspect recent runs, and fetch stored run artifacts
+when a user asks what happened. PwrAgent authorizes the tool call at execution
+time; ordinary work threads receive a forbidden response even if the Codex
+thread was born with the dynamic tool catalog.
 
 ACP-backed Agent threads use the same inspection operations through MCP/CLI
 adapters when the runtime supports MCP server configuration. Unsupported ACP
 runtimes keep starting with an empty MCP server list instead of failing session
-creation.
+creation. Set `PWRAGENT_AUTOMATION_INSPECTION_MCP_COMMAND` to the command that
+serves the automation inspection MCP bridge for ACP runtimes that support MCP
+server launch configuration.
 
 Manual smoke test:
 

--- a/docs/plans/2026-05-24-001-feat-automation-agent-tool-bridge-plan.md
+++ b/docs/plans/2026-05-24-001-feat-automation-agent-tool-bridge-plan.md
@@ -1,7 +1,7 @@
 ---
 title: feat: Expose automation history through agent tools
 type: feat
-status: active
+status: completed
 date: 2026-05-24
 origin: docs/brainstorms/2026-05-22-agent-thread-attached-automations-requirements.md
 ---

--- a/docs/plans/2026-05-24-001-feat-automation-agent-tool-bridge-plan.md
+++ b/docs/plans/2026-05-24-001-feat-automation-agent-tool-bridge-plan.md
@@ -1,0 +1,551 @@
+---
+title: feat: Expose automation history through agent tools
+type: feat
+status: active
+date: 2026-05-24
+origin: docs/brainstorms/2026-05-22-agent-thread-attached-automations-requirements.md
+---
+
+# feat: Expose automation history through agent tools
+
+## Summary
+
+Build one shared read-only automation inspection substrate, then expose it to
+Agent threads through Codex dynamic tools and ACP-compatible MCP/CLI adapters.
+This replaces the temporary synthetic "automation context" user-message bridge
+with an explicit tool surface: automation cards and run artifacts remain
+out-of-band, and the Agent asks PwrAgent for details only when needed.
+
+---
+
+## Problem Frame
+
+PR #552 made Agent-attached automations usable, but it also introduced a
+short-term bridge that prepends recent automation results into the next
+non-automation turn. That helped the Agent answer "did the weather checker run?"
+but made the operator's actual user message dirty and represented automation
+history as fake user-provided context.
+
+The refined automation requirements are different: the Agent should discover
+attached automation capabilities and fetch recent run artifacts through tools.
+Automation cards stay source-labeled timeline items, not assistant messages, and
+not every automation result should be shoved into the prompt.
+
+## Requirements
+
+- R1. Agent turns must preserve the real user message without prepending recent
+  automation output as a synthetic user message.
+- R2. PwrAgent must expose read-only automation inspection operations for an
+  Agent's attached automations: list automations, list runs, inspect a run,
+  inspect a run artifact, and summarize current automation status.
+- R3. The operation implementation must be shared across exposure paths so Codex
+  dynamic tools and ACP/MCP/CLI adapters cannot drift in behavior.
+- R4. Tool results must be scoped to the current Agent thread by default and
+  must not allow one Agent to enumerate or inspect another Agent's automation
+  history accidentally.
+- R5. Tool outputs must be bounded and structured for agent use: compact lists by
+  default, explicit limits for run history and captured transcript events, and
+  artifact detail only on request.
+- R6. Codex Agent threads must receive PwrAgent automation inspection tools
+  through the Codex dynamic tools protocol where the protocol supports it.
+- R7. ACP-backed Agent threads must have an equivalent MCP-first exposure plan,
+  with a CLI fallback for ACP bridges that cannot accept per-session MCP server
+  configuration.
+- R8. The existing automation cards, run artifacts, run history UI, and
+  messaging notifications must keep working while the prompt-injection bridge is
+  removed.
+- R9. This plan must remain read-only. Mutation/domain action tools such as
+  pause, resume, run-now, delete, or package maintenance are explicitly deferred.
+
+**Origin actors:** Agent thread user, attached automation, Codex backend, ACP backend.
+**Origin flows:** Agent asks about recent automation output; scheduled automation
+posts an out-of-band card; Agent fetches run/artifact details through a tool.
+**Origin acceptance examples:** Agent can answer questions about recent
+automation outputs by discovering attached automation capabilities and fetching
+artifacts by tool.
+
+## Scope Boundaries
+
+- In scope: shared read-only inspection operations, Codex dynamic tool specs and
+  call handling, ACP MCP/CLI exposure strategy, bounded outputs, thread scoping,
+  and removal of the synthetic automation-history turn-input bridge.
+- Out of scope: automation mutation tools, executable card buttons, domain
+  action tools, changing schedule/backlog semantics, cloud/daemon execution, and
+  adding new RBAC semantics.
+- Out of scope: treating automation cards as assistant messages or replaying all
+  automation outputs into every Agent prompt.
+
+### Deferred to Follow-Up Work
+
+- Domain action tools: separate plan/issue after read-only inspection is proven.
+- Per-automation package-defined tool catalogs: separate package/skills work once
+  reusable automation packages exist.
+- ACP bridge enhancements for per-session MCP injection if the active ACP bridge
+  rejects that capability; this plan should add a compatible path, not silently
+  assume support.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/shared/src/contracts/automations.ts` already defines automation
+  details, run summaries, run artifacts, cards, output decisions, and IPC shapes.
+- `apps/desktop/src/main/automations/automation-store.ts` persists automations,
+  runs, latest-run lookup, thread-scoped run lists, and run artifacts.
+- `apps/desktop/src/main/automations/desktop-automation-service.ts` owns the
+  desktop automation orchestration and currently registers the temporary
+  automation turn context provider.
+- `apps/desktop/src/main/app-server/backend-registry.ts` owns thread admission,
+  server request handling, Codex start/resume flows, and the temporary
+  `AutomationTurnContextProvider`.
+- `apps/desktop/src/main/codex-app-server/client.ts` already receives generated
+  `item/tool/call` server requests, but currently treats only approval,
+  user-input, and MCP elicitation requests as handled.
+- `packages/codex-app-server-protocol/src/v2/ThreadStartParams.ts` includes
+  `dynamicTools`, while `TurnStartParams.ts` does not. Dynamic tools are a
+  thread-start capability, not a per-turn attachment.
+- `apps/desktop/src/main/acp/acp-client.ts` currently sends `mcpServers: []` for
+  `session/new` and `session/load`.
+- OpenClaw's Codex integration exposes plugin tools through dynamic tool specs,
+  handles `item/tool/call`, fingerprints tool catalogs, and uses MCP server
+  config for other runtimes. That pattern maps well to PwrAgent's split between
+  Codex dynamic tools and ACP MCP/CLI adapters.
+- OpenClaw's ACP bridge currently rejects non-empty per-session `mcpServers`.
+  PwrAgent should plan for that kind of backend capability variance.
+- `apps/desktop/src/main/messaging/core/messaging-controller.ts` is the right
+  architectural analogy: transport adapters should be thin, while domain
+  decisions live in desktop-owned services. The automation inspection bus should
+  copy that separation, not the full messaging runtime size.
+
+### Institutional Learnings
+
+- `docs/solutions/2026-05-07-codex-permission-mode-state-machine.md` emphasizes
+  removing structurally-confusing state paths instead of compensating for them
+  later. Apply that here by removing the prompt-context shim once tools exist,
+  rather than trying to make fake user messages less bad.
+- The merged automation scheduling work established local scheduler semantics,
+  run artifacts, card publication, and Agent thread attachment. This plan should
+  reuse that foundation and avoid reopening the scheduler model.
+
+### External References
+
+- OpenClaw local source:
+  - `/Users/huntharo/github/openclaw/extensions/codex/src/app-server/dynamic-tools.ts`
+  - `/Users/huntharo/github/openclaw/extensions/codex/src/app-server/run-attempt.ts`
+  - `/Users/huntharo/github/openclaw/src/agents/codex-mcp-config.ts`
+  - `/Users/huntharo/github/openclaw/src/acp/translator.ts`
+- GitHub issue: [#555 Expose automation history through agent-callable tools](https://github.com/pwrdrvr/PwrAgent/issues/555)
+
+## Key Technical Decisions
+
+- **One domain bus, multiple transport adapters.** Implement a small typed
+  automation inspection service/bus that accepts an operation name, scoped
+  caller context, and JSON-like arguments. Codex dynamic tools, MCP tools, and
+  CLI commands adapt into that service instead of querying the store directly.
+- **Read-only first.** The first tool catalog only inspects attached automation
+  state and run artifacts. This avoids approval semantics and destructive
+  ambiguity while proving the Agent-discovery model.
+- **Thread-scoped by construction.** Adapters supply the current backend/thread
+  context. The bus verifies that requested automation/run ids belong to that
+  context before returning data.
+- **Codex uses dynamic tools, not MCP, for the first-class path.** PwrAgent's
+  Codex app-server protocol already supports `dynamicTools` and
+  `item/tool/call`; this avoids requiring Codex to discover an additional local
+  MCP server for the in-app backend.
+- **ACP uses MCP when the backend can accept it, CLI/config fallback otherwise.**
+  ACP backends are not uniform. The plan should add an MCP-compatible adapter,
+  but also expose the same operations through a local CLI fallback so ACP agents
+  without per-session MCP injection still have a path.
+- **No more automation-history user-message bridge.** Once tool exposure is
+  available, remove or disable the temporary `AutomationTurnContextProvider`.
+  Capability discovery belongs in tool catalogs and compact tool descriptions,
+  not in fake user input.
+- **Bounded outputs are part of the contract.** List operations return compact
+  summaries by default. Artifact inspection can return richer details but still
+  applies limits to transcript events, rollout snippets, and raw text.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should this plan include mutation tools?** No. Keep the first implementation
+  read-only and defer domain action tools.
+- **Should PwrAgent use Codex dynamic tools or MCP for Codex?** Use dynamic tools
+  first. The protocol is already present, and OpenClaw has validated the pattern.
+- **Can dynamic tools be attached on every Codex turn?** Not through the current
+  generated `TurnStartParams`. Plan around thread-start/resume behavior and
+  catalog fingerprinting instead of assuming per-turn tool attachment.
+- **Should the shared code be a full messaging-runtime clone?** No. Reuse the
+  separation pattern, not the implementation size: a focused inspection bus with
+  thin adapters is enough.
+
+### Deferred to Implementation
+
+- Exact Codex dynamic-tool catalog refresh behavior for already-started threads
+  after automation attachments change. Implementation should characterize
+  whether thread resume can refresh the catalog or whether tool changes require a
+  new thread-start path/fingerprint warning.
+- Exact ACP MCP transport for each backend. If an ACP backend rejects per-session
+  MCP servers, the implementation should leave MCP available where supported and
+  use the CLI fallback/documented config path for that backend.
+- Exact output size caps after inspecting current artifact sizes in dev profile
+  data. Defaults should be conservative and test-covered.
+
+## Output Structure
+
+    packages/shared/src/contracts/
+      automation-tools.ts
+      __tests__/automation-tools.test.ts
+    apps/desktop/src/main/automations/
+      automation-inspection-bus.ts
+      automation-inspection-codex-tools.ts
+      automation-inspection-mcp.ts
+      automation-inspection-cli.ts
+    apps/desktop/src/main/codex-app-server/
+      client.ts
+    apps/desktop/src/main/app-server/
+      backend-registry.ts
+    apps/desktop/src/main/acp/
+      acp-client.ts
+
+The exact filenames may change during implementation, but the shape should stay
+the same: shared contracts, one domain bus, and separate transport adapters.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart LR
+  Codex["Codex dynamic tool call"] --> CodexAdapter["Codex automation tool adapter"]
+  ACP["ACP MCP tool call"] --> McpAdapter["MCP automation tool adapter"]
+  CLI["Agent-callable CLI"] --> CliAdapter["CLI automation tool adapter"]
+
+  CodexAdapter --> Bus["Automation inspection bus"]
+  McpAdapter --> Bus
+  CliAdapter --> Bus
+
+  Bus --> Scope["Thread/automation scope guard"]
+  Scope --> Store["AutomationStore"]
+  Store --> Runs["Runs + artifacts + cards"]
+  Bus --> Result["Bounded structured result"]
+```
+
+The bus should expose stable operations such as:
+
+- `list_automations`: compact attached automation summaries for the current
+  Agent thread.
+- `summarize_automation_status`: convenience status for common user questions.
+- `list_automation_runs`: recent runs for one automation or the current Agent
+  thread, bounded by limit/since filters.
+- `get_automation_run`: one run's status, trigger, timing, output decision, and
+  error metadata.
+- `get_automation_run_artifact`: one run's stored output card, final response,
+  transcript/event excerpt, and rollout/debug metadata within caps.
+
+Tool names should be namespace-stable and easy for agents to discover. The
+first pass can use a single PwrAgent automation namespace rather than generating
+one physical dynamic tool per automation; per-automation names can be layered on
+later when package-defined tools exist.
+
+## Implementation Units
+
+### U1. Shared Automation Inspection Contracts
+
+**Goal:** Define the read-only operation catalog, argument/result shapes, scoped
+caller context, and output caps shared by all adapters.
+
+**Requirements:** R2, R3, R4, R5, R9
+
+**Dependencies:** None
+
+**Files:**
+- Create: `packages/shared/src/contracts/automation-tools.ts`
+- Modify: `packages/shared/src/contracts/__tests__/automations.test.ts`
+- Test: `packages/shared/src/contracts/__tests__/automation-tools.test.ts`
+
+**Approach:**
+- Add operation names and TypeScript contracts for request context, request
+  args, normalized results, and structured errors.
+- Keep contracts JSON-serializable so the same shapes work for Codex dynamic
+  tool responses, MCP JSON-RPC, and a CLI.
+- Include default limits in the contract layer, but keep enforcement in the bus.
+
+**Patterns to follow:**
+- `packages/shared/src/contracts/automations.ts`
+- `packages/shared/src/contracts/normalized-app-server.ts`
+
+**Test scenarios:**
+- Happy path: each operation name has a stable schema and default limit metadata.
+- Edge case: invalid limit/since/filter values normalize or reject consistently.
+- Error path: cross-thread and not-found errors have stable machine-readable
+  codes without leaking unrelated automation details.
+
+**Verification:**
+- Shared contract tests pass and no renderer imports from desktop main code are
+  introduced.
+
+### U2. Automation Inspection Bus
+
+**Goal:** Implement the shared read-only domain service that resolves operation
+requests against `AutomationStore`, enforces Agent-thread scoping, and returns
+bounded structured results.
+
+**Requirements:** R2, R3, R4, R5, R8, R9
+
+**Dependencies:** U1
+
+**Files:**
+- Create: `apps/desktop/src/main/automations/automation-inspection-bus.ts`
+- Modify: `apps/desktop/src/main/automations/desktop-automation-service.ts`
+- Test: `apps/desktop/src/main/__tests__/desktop-automation-service.test.ts`
+- Test: `apps/desktop/src/main/__tests__/automation-inspection-bus.test.ts`
+
+**Approach:**
+- Wire the bus near `DesktopAutomationService` so it can reuse the existing store
+  and publication lifecycle without duplicating persistence logic.
+- Require caller context with backend id and Agent thread id.
+- Verify requested automation ids and run ids belong to the caller's Agent thread
+  before returning details.
+- Produce compact summaries by default and richer artifact details only through
+  explicit artifact inspection.
+
+**Patterns to follow:**
+- `apps/desktop/src/main/automations/automation-store.ts`
+- `apps/desktop/src/main/automations/desktop-automation-service.ts`
+
+**Test scenarios:**
+- Happy path: an Agent with two attached automations can list them, list recent
+  runs, and inspect an artifact.
+- Edge case: limit caps prevent huge transcripts or rollout details from
+  returning unbounded text.
+- Error path: an Agent cannot inspect another thread's automation or run id.
+- Error path: deleted/missing automations return stable not-found results.
+
+**Verification:**
+- The same bus tests exercise all operations without using Codex, ACP, renderer,
+  or messaging adapters.
+
+### U3. Codex Dynamic Tool Adapter
+
+**Goal:** Expose the shared inspection bus to Codex Agent threads through Codex
+dynamic tools and handle `item/tool/call` requests inside PwrAgent.
+
+**Requirements:** R3, R4, R5, R6, R8
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Create: `apps/desktop/src/main/automations/automation-inspection-codex-tools.ts`
+- Modify: `apps/desktop/src/main/codex-app-server/client.ts`
+- Modify: `apps/desktop/src/main/app-server/backend-registry.ts`
+- Test: `apps/desktop/src/main/__tests__/codex-client.test.ts`
+- Test: `apps/desktop/src/main/__tests__/backend-registry.test.ts`
+
+**Approach:**
+- Add `dynamicTools` plumbing to Codex thread start where it is currently
+  missing in the desktop client.
+- Treat `item/tool/call` as a handled server request and route matching
+  PwrAgent automation tool calls to the adapter.
+- Build tool specs from the shared operation catalog with concise descriptions
+  and JSON schemas.
+- Scope tool calls to the active Agent thread context and return Codex dynamic
+  tool response content from the shared bus result.
+- Add catalog fingerprint/logging so attachment changes are observable when a
+  thread's tool catalog may be stale.
+
+**Patterns to follow:**
+- OpenClaw `extensions/codex/src/app-server/dynamic-tools.ts`
+- OpenClaw `extensions/codex/src/app-server/run-attempt.ts`
+- Existing PwrAgent request handling in `backend-registry.ts`
+
+**Test scenarios:**
+- Happy path: starting a Codex Agent thread includes automation dynamic tool
+  specs when automations are attached.
+- Happy path: a matching `item/tool/call` returns bounded automation data.
+- Edge case: an unknown PwrAgent automation tool returns a tool error rather than
+  falling through to generic request handling.
+- Error path: a tool call for the wrong thread id or non-Agent thread is rejected.
+- Integration: existing approval/user-input/MCP elicitation server requests still
+  route as before.
+
+**Verification:**
+- Backend-registry tests prove Codex dynamic tool calls can answer "what happened
+  with my automation?" without mutating the user turn input.
+
+### U4. ACP MCP and CLI Exposure Adapter
+
+**Goal:** Expose the same read-only inspection operations to ACP agents through
+an MCP-compatible surface where supported and a CLI fallback where per-session
+MCP injection is unavailable.
+
+**Requirements:** R3, R4, R5, R7, R8, R9
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Create: `apps/desktop/src/main/automations/automation-inspection-mcp.ts`
+- Create: `apps/desktop/src/main/automations/automation-inspection-cli.ts`
+- Modify: `apps/desktop/src/main/acp/acp-client.ts`
+- Test: `apps/desktop/src/main/__tests__/acp-client.test.ts`
+- Test: `apps/desktop/src/main/__tests__/automation-inspection-mcp.test.ts`
+- Test: `apps/desktop/src/main/__tests__/automation-inspection-cli.test.ts`
+
+**Approach:**
+- Implement MCP tool list/call handling over the same operation catalog and bus.
+- Add ACP capability detection/configuration so PwrAgent only passes MCP server
+  config when the target backend accepts it.
+- For ACP bridges that reject per-session MCP servers, expose a local
+  agent-callable CLI using the same operation names and JSON outputs.
+- Ensure both MCP and CLI paths require enough thread context to preserve the
+  same scope guard as the Codex dynamic tool path.
+
+**Patterns to follow:**
+- `apps/desktop/src/main/acp/acp-client.ts`
+- OpenClaw `src/agents/codex-mcp-config.ts`
+- OpenClaw `src/acp/translator.ts`
+
+**Test scenarios:**
+- Happy path: MCP `tools/list` and `tools/call` expose the same operations and
+  return the same normalized data as the bus.
+- Happy path: CLI command returns JSON for a valid Agent thread context.
+- Edge case: ACP backend that rejects per-session MCP servers does not fail
+  session creation because of an unconditional non-empty `mcpServers` payload.
+- Error path: missing/invalid thread context fails closed.
+
+**Verification:**
+- ACP client tests cover both supported-MCP and fallback/no-MCP backend behavior.
+
+### U5. Remove Synthetic Automation Context Injection
+
+**Goal:** Retire the temporary bridge that prepends recent automation history to
+the next user turn once tool access exists.
+
+**Requirements:** R1, R6, R7, R8
+
+**Dependencies:** U2, U3
+
+**Files:**
+- Modify: `apps/desktop/src/main/automations/desktop-automation-service.ts`
+- Modify: `apps/desktop/src/main/app-server/backend-registry.ts`
+- Modify: `apps/desktop/src/main/__tests__/desktop-automation-service.test.ts`
+- Modify: `apps/desktop/src/main/__tests__/backend-registry.test.ts`
+- Modify: `apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx`
+
+**Approach:**
+- Remove or disable `AutomationTurnContextProvider` registration.
+- Delete the turn-input formatting helper if it is no longer used.
+- Replace tests that assert context injection with tests that assert the user
+  message remains unchanged and tool discovery is available.
+- Keep transcript cards and messaging delivery paths unchanged; only remove the
+  fake user-message context.
+
+**Patterns to follow:**
+- Existing `thread/automations/updated` and `automation/run/updated` events.
+- Existing transcript-card rendering from #552.
+
+**Test scenarios:**
+- Happy path: user sends "did the weather checker run?" and the submitted user
+  message remains exactly that text.
+- Happy path: the Agent can still answer after calling the inspection tool.
+- Edge case: no attached automations means no synthetic context and no tool
+  catalog beyond the safe empty-state behavior.
+- Integration: automation cards still appear in the thread timeline and
+  messaging surfaces.
+
+**Verification:**
+- No test or runtime path constructs a fake `## Automation Context` user message
+  for ordinary user turns.
+
+### U6. Documentation, Logging, and Manual Test Path
+
+**Goal:** Make the feature observable enough to debug agent tool access without
+digging through protocol dumps.
+
+**Requirements:** R5, R6, R7, R8
+
+**Dependencies:** U3, U4, U5
+
+**Files:**
+- Modify: `docs/brainstorms/2026-05-22-agent-thread-attached-automations-requirements.md` only if a confirmed requirement correction is needed; otherwise do not edit the brainstorm.
+- Modify: relevant desktop developer docs if an automation testing note already exists.
+- Test: focused unit/integration tests from U3-U5.
+
+**Approach:**
+- Add structured logs for tool catalog attachment, tool calls, scope denials,
+  and bus operation results with bounded lengths.
+- Add a short manual test recipe in the implementation PR description or docs:
+  create an Agent thread, attach a weather-like automation, let it run, ask the
+  Agent what happened, and confirm the answer comes from a tool call rather than
+  injected user context.
+- Keep logs free of full artifact bodies unless protocol/debug logging is
+  explicitly enabled.
+
+**Patterns to follow:**
+- Existing `pwragent:automations`, `pwragent:backend-registry`, and
+  `pwragent:messaging` structured log style.
+
+**Test scenarios:**
+- Integration: a tool call produces useful greppable logs with thread id,
+  automation id/run id when present, operation name, and bounded result size.
+- Error path: scope-denied tool calls log enough to debug without leaking the
+  denied artifact.
+
+**Verification:**
+- CI passes and the manual test path can distinguish "Agent used tool" from
+  "Agent saw injected prompt context."
+
+## System-Wide Impact
+
+- **Interaction graph:** Codex server request handling gains a new handled path
+  for `item/tool/call`; ACP session setup may gain conditional MCP configuration
+  or CLI instructions; automation service becomes the owner of read-only tool
+  operations.
+- **Error propagation:** Tool errors should return structured tool-call errors,
+  not crash turns or fall through to pending server-request UI. Scope denials
+  fail closed.
+- **State lifecycle risks:** Dynamic tool catalogs can become stale if
+  automations are attached/detached after a Codex thread starts. The
+  implementation must log/fingerprint catalog state and avoid pretending tools
+  updated when the upstream protocol did not accept an update.
+- **API surface parity:** Codex dynamic tools, ACP MCP, and CLI should all map to
+  the same bus operations and result contracts.
+- **Integration coverage:** Unit tests alone will not prove the Agent uses the
+  tools. Manual or replay-backed integration should verify the submitted user
+  message is clean and the Agent can fetch automation history.
+- **Unchanged invariants:** Automation schedules, coalesce/drop behavior,
+  persisted run artifacts, card publication, and messaging delivery semantics
+  should not change in this plan.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Codex dynamic tool catalogs are thread-start scoped and may not refresh for existing threads. | Add catalog fingerprint logging and implementation-time characterization; do not reintroduce prompt injection as the fallback. |
+| ACP backends differ in MCP support. | Capability-gate per-session MCP config and provide a CLI/config fallback using the same bus. |
+| Tool output leaks another Agent's automation history. | Make backend/thread context required and verify every requested automation/run against it. |
+| Tool outputs get too large and become another prompt-stuffing path. | Enforce default limits and require explicit artifact inspection for detailed output. |
+| Three exposure paths drift. | Keep all domain logic in the shared bus and test adapters against the same contract fixtures. |
+
+## Documentation / Operational Notes
+
+- PR notes should explicitly say the synthetic automation context bridge is
+  removed or disabled, and explain how to test by inspecting tool-call logs.
+- The user-facing behavior should remain: automation cards appear in the Agent
+  timeline and messaging surfaces; asking the Agent about them should work after
+  the Agent calls a tool.
+- Avoid editing the origin brainstorm unless the product decision changes; this
+  plan is the implementation artifact for issue #555.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-05-22-agent-thread-attached-automations-requirements.md](../brainstorms/2026-05-22-agent-thread-attached-automations-requirements.md)
+- Related plan: [docs/plans/2026-05-23-001-feat-agent-attached-automation-delta-plan.md](2026-05-23-001-feat-agent-attached-automation-delta-plan.md)
+- Related issue: [#555 Expose automation history through agent-callable tools](https://github.com/pwrdrvr/PwrAgent/issues/555)
+- Related code: `apps/desktop/src/main/automations/desktop-automation-service.ts`
+- Related code: `apps/desktop/src/main/app-server/backend-registry.ts`
+- Related code: `apps/desktop/src/main/codex-app-server/client.ts`
+- Related code: `apps/desktop/src/main/acp/acp-client.ts`
+- Institutional learning: [docs/solutions/2026-05-07-codex-permission-mode-state-machine.md](../solutions/2026-05-07-codex-permission-mode-state-machine.md)
+- OpenClaw reference: `/Users/huntharo/github/openclaw/extensions/codex/src/app-server/dynamic-tools.ts`
+- OpenClaw reference: `/Users/huntharo/github/openclaw/src/agents/codex-mcp-config.ts`

--- a/packages/shared/src/contracts/__tests__/automation-tools.test.ts
+++ b/packages/shared/src/contracts/__tests__/automation-tools.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AUTOMATION_INSPECTION_OPERATION_NAMES,
+  DEFAULT_AUTOMATION_INSPECTION_EVENT_LIMIT,
+  DEFAULT_AUTOMATION_INSPECTION_RUN_LIMIT,
+  DEFAULT_AUTOMATION_INSPECTION_TEXT_LIMIT_CHARS,
+  MAX_AUTOMATION_INSPECTION_EVENT_LIMIT,
+  MAX_AUTOMATION_INSPECTION_RUN_LIMIT,
+  MAX_AUTOMATION_INSPECTION_TEXT_LIMIT_CHARS,
+  isAutomationInspectionOperationName,
+  normalizeAutomationInspectionEventLimit,
+  normalizeAutomationInspectionRunLimit,
+  normalizeAutomationInspectionTextLimitChars,
+} from "../automation-tools";
+
+describe("automation tool contracts", () => {
+  it("defines the read-only inspection operation catalog", () => {
+    expect(AUTOMATION_INSPECTION_OPERATION_NAMES).toEqual([
+      "list_automations",
+      "summarize_automation_status",
+      "list_automation_runs",
+      "get_automation_run",
+      "get_automation_run_artifact",
+    ]);
+    expect(isAutomationInspectionOperationName("get_automation_run")).toBe(true);
+    expect(isAutomationInspectionOperationName("pause_automation")).toBe(false);
+  });
+
+  it("normalizes run list limits to bounded whole numbers", () => {
+    expect(normalizeAutomationInspectionRunLimit(undefined)).toBe(
+      DEFAULT_AUTOMATION_INSPECTION_RUN_LIMIT,
+    );
+    expect(normalizeAutomationInspectionRunLimit(0)).toBe(1);
+    expect(normalizeAutomationInspectionRunLimit(3.9)).toBe(3);
+    expect(normalizeAutomationInspectionRunLimit(10_000)).toBe(
+      MAX_AUTOMATION_INSPECTION_RUN_LIMIT,
+    );
+  });
+
+  it("normalizes artifact event limits separately from text limits", () => {
+    expect(normalizeAutomationInspectionEventLimit("nope")).toBe(
+      DEFAULT_AUTOMATION_INSPECTION_EVENT_LIMIT,
+    );
+    expect(normalizeAutomationInspectionEventLimit(10_000)).toBe(
+      MAX_AUTOMATION_INSPECTION_EVENT_LIMIT,
+    );
+    expect(normalizeAutomationInspectionTextLimitChars(undefined)).toBe(
+      DEFAULT_AUTOMATION_INSPECTION_TEXT_LIMIT_CHARS,
+    );
+    expect(normalizeAutomationInspectionTextLimitChars(1_000_000)).toBe(
+      MAX_AUTOMATION_INSPECTION_TEXT_LIMIT_CHARS,
+    );
+  });
+});

--- a/packages/shared/src/contracts/automation-tools.ts
+++ b/packages/shared/src/contracts/automation-tools.ts
@@ -94,10 +94,12 @@ export type AutomationInspectionRequest<
   TOperation extends AutomationInspectionOperationName =
     AutomationInspectionOperationName,
 > = {
-  operation: TOperation;
-  context: AutomationInspectionContext;
-  args: AutomationInspectionToolArgs<TOperation>;
-};
+  [TOperationKey in TOperation]: {
+    operation: TOperationKey;
+    context: AutomationInspectionContext;
+    args: AutomationInspectionToolArgs<TOperationKey>;
+  };
+}[TOperation];
 
 export type AutomationInspectionAutomationSummary = Pick<
   AutomationDetail,

--- a/packages/shared/src/contracts/automation-tools.ts
+++ b/packages/shared/src/contracts/automation-tools.ts
@@ -1,0 +1,260 @@
+import type {
+  AppServerBackendKind,
+  ThreadIdentifier,
+} from "./normalized-app-server";
+import type {
+  AutomationBacklogPolicy,
+  AutomationDetail,
+  AutomationRunArtifact,
+  AutomationRunStatus,
+  AutomationRunSummary,
+  AutomationStatus,
+  AutomationTimelineCard,
+} from "./automations";
+
+export const AUTOMATION_INSPECTION_TOOL_NAMESPACE = "pwragent_automations";
+
+export const AUTOMATION_INSPECTION_OPERATION_NAMES = [
+  "list_automations",
+  "summarize_automation_status",
+  "list_automation_runs",
+  "get_automation_run",
+  "get_automation_run_artifact",
+] as const;
+
+export type AutomationInspectionOperationName =
+  (typeof AUTOMATION_INSPECTION_OPERATION_NAMES)[number];
+
+export const DEFAULT_AUTOMATION_INSPECTION_RUN_LIMIT = 5;
+export const MAX_AUTOMATION_INSPECTION_RUN_LIMIT = 25;
+export const DEFAULT_AUTOMATION_INSPECTION_EVENT_LIMIT = 25;
+export const MAX_AUTOMATION_INSPECTION_EVENT_LIMIT = 100;
+export const DEFAULT_AUTOMATION_INSPECTION_TEXT_LIMIT_CHARS = 12_000;
+export const MAX_AUTOMATION_INSPECTION_TEXT_LIMIT_CHARS = 40_000;
+
+export const AUTOMATION_INSPECTION_ERROR_CODES = [
+  "invalid_arguments",
+  "not_found",
+  "forbidden",
+  "unsupported_operation",
+  "internal_error",
+] as const;
+
+export type AutomationInspectionErrorCode =
+  (typeof AUTOMATION_INSPECTION_ERROR_CODES)[number];
+
+export type AutomationInspectionContext = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  now?: number;
+};
+
+export type ListAutomationToolArgs = {
+  includePaused?: boolean;
+  includeDeleted?: boolean;
+  limit?: number;
+};
+
+export type SummarizeAutomationStatusToolArgs = {
+  limit?: number;
+  since?: number;
+};
+
+export type ListAutomationRunsToolArgs = {
+  automationId?: string;
+  limit?: number;
+  since?: number;
+  statuses?: AutomationRunStatus[];
+};
+
+export type GetAutomationRunToolArgs = {
+  runId: string;
+};
+
+export type GetAutomationRunArtifactToolArgs = {
+  runId: string;
+  eventLimit?: number;
+  textLimitChars?: number;
+};
+
+export type AutomationInspectionToolArgsByOperation = {
+  list_automations: ListAutomationToolArgs;
+  summarize_automation_status: SummarizeAutomationStatusToolArgs;
+  list_automation_runs: ListAutomationRunsToolArgs;
+  get_automation_run: GetAutomationRunToolArgs;
+  get_automation_run_artifact: GetAutomationRunArtifactToolArgs;
+};
+
+export type AutomationInspectionToolArgs<
+  TOperation extends AutomationInspectionOperationName =
+    AutomationInspectionOperationName,
+> = AutomationInspectionToolArgsByOperation[TOperation];
+
+export type AutomationInspectionRequest<
+  TOperation extends AutomationInspectionOperationName =
+    AutomationInspectionOperationName,
+> = {
+  operation: TOperation;
+  context: AutomationInspectionContext;
+  args: AutomationInspectionToolArgs<TOperation>;
+};
+
+export type AutomationInspectionAutomationSummary = Pick<
+  AutomationDetail,
+  | "id"
+  | "name"
+  | "status"
+  | "taskPrompt"
+  | "schedule"
+  | "scheduleSummary"
+  | "backlogPolicy"
+  | "nextRunAt"
+  | "lastRunAt"
+  | "lastRunStatus"
+  | "pendingRunCount"
+  | "coalescedWindowCount"
+  | "updatedAt"
+> & {
+  latestRun?: AutomationInspectionRunSummary;
+};
+
+export type AutomationInspectionRunSummary = AutomationRunSummary & {
+  automationName?: string;
+  automationStatus?: AutomationStatus;
+  automationBacklogPolicy?: AutomationBacklogPolicy;
+  outputDecisionKind?: AutomationInspectionOutputDecisionKind;
+  outputSummary?: string;
+};
+
+export type AutomationInspectionRunDetail = AutomationInspectionRunSummary & {
+  automation?: AutomationInspectionAutomationSummary;
+};
+
+export type AutomationInspectionArtifact = Omit<
+  AutomationRunArtifact,
+  "transcriptEvents"
+> & {
+  transcriptEvents: AutomationRunArtifact["transcriptEvents"];
+  transcriptEventsTruncated?: boolean;
+  finalTextTruncated?: boolean;
+  detailsTextTruncated?: boolean;
+  card?: AutomationTimelineCard;
+};
+
+export type AutomationInspectionOutputDecisionKind =
+  | "post_card"
+  | "quiet"
+  | "parse_failed";
+
+export type ListAutomationToolData = {
+  automations: AutomationInspectionAutomationSummary[];
+  truncated?: boolean;
+};
+
+export type SummarizeAutomationStatusToolData = {
+  summary: string;
+  automations: AutomationInspectionAutomationSummary[];
+  recentRuns: AutomationInspectionRunSummary[];
+  truncated?: boolean;
+};
+
+export type ListAutomationRunsToolData = {
+  runs: AutomationInspectionRunSummary[];
+  truncated?: boolean;
+};
+
+export type GetAutomationRunToolData = {
+  run: AutomationInspectionRunDetail;
+};
+
+export type GetAutomationRunArtifactToolData = {
+  artifact: AutomationInspectionArtifact;
+};
+
+export type AutomationInspectionToolDataByOperation = {
+  list_automations: ListAutomationToolData;
+  summarize_automation_status: SummarizeAutomationStatusToolData;
+  list_automation_runs: ListAutomationRunsToolData;
+  get_automation_run: GetAutomationRunToolData;
+  get_automation_run_artifact: GetAutomationRunArtifactToolData;
+};
+
+export type AutomationInspectionToolData<
+  TOperation extends AutomationInspectionOperationName =
+    AutomationInspectionOperationName,
+> = AutomationInspectionToolDataByOperation[TOperation];
+
+export type AutomationInspectionSuccess<
+  TOperation extends AutomationInspectionOperationName =
+    AutomationInspectionOperationName,
+> = {
+  ok: true;
+  operation: TOperation;
+  data: AutomationInspectionToolData<TOperation>;
+};
+
+export type AutomationInspectionFailure<
+  TOperation extends AutomationInspectionOperationName =
+    AutomationInspectionOperationName,
+> = {
+  ok: false;
+  operation: TOperation;
+  error: {
+    code: AutomationInspectionErrorCode;
+    message: string;
+  };
+};
+
+export type AutomationInspectionResponse<
+  TOperation extends AutomationInspectionOperationName =
+    AutomationInspectionOperationName,
+> =
+  | AutomationInspectionSuccess<TOperation>
+  | AutomationInspectionFailure<TOperation>;
+
+export function isAutomationInspectionOperationName(
+  value: unknown,
+): value is AutomationInspectionOperationName {
+  return (
+    typeof value === "string" &&
+    AUTOMATION_INSPECTION_OPERATION_NAMES.includes(
+      value as AutomationInspectionOperationName,
+    )
+  );
+}
+
+export function normalizeAutomationInspectionLimit(
+  value: unknown,
+  options: {
+    defaultValue: number;
+    maxValue: number;
+  },
+): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return options.defaultValue;
+  }
+  return Math.min(options.maxValue, Math.max(1, Math.floor(value)));
+}
+
+export function normalizeAutomationInspectionRunLimit(value: unknown): number {
+  return normalizeAutomationInspectionLimit(value, {
+    defaultValue: DEFAULT_AUTOMATION_INSPECTION_RUN_LIMIT,
+    maxValue: MAX_AUTOMATION_INSPECTION_RUN_LIMIT,
+  });
+}
+
+export function normalizeAutomationInspectionEventLimit(value: unknown): number {
+  return normalizeAutomationInspectionLimit(value, {
+    defaultValue: DEFAULT_AUTOMATION_INSPECTION_EVENT_LIMIT,
+    maxValue: MAX_AUTOMATION_INSPECTION_EVENT_LIMIT,
+  });
+}
+
+export function normalizeAutomationInspectionTextLimitChars(
+  value: unknown,
+): number {
+  return normalizeAutomationInspectionLimit(value, {
+    defaultValue: DEFAULT_AUTOMATION_INSPECTION_TEXT_LIMIT_CHARS,
+    maxValue: MAX_AUTOMATION_INSPECTION_TEXT_LIMIT_CHARS,
+  });
+}

--- a/packages/shared/src/contracts/automation-tools.ts
+++ b/packages/shared/src/contracts/automation-tools.ts
@@ -51,7 +51,6 @@ export type AutomationInspectionContext = {
 
 export type ListAutomationToolArgs = {
   includePaused?: boolean;
-  includeDeleted?: boolean;
   limit?: number;
 };
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -4,6 +4,7 @@ export * from "./codex-environment-action-runs";
 export * from "./contracts/backend";
 export * from "./contracts/agent";
 export * from "./contracts/automations";
+export * from "./contracts/automation-tools";
 export * from "./contracts/branch-drift";
 export * from "./contracts/composer-drafts";
 export * from "./contracts/diff-focus";


### PR DESCRIPTION
## Summary

- Add shared automation inspection contracts and a desktop inspection bus for Agent-thread automation state, recent runs, and run artifacts.
- Expose read-only automation inspection to Codex through dynamic tools and add MCP/CLI exposure paths for ACP-style agents.
- Remove the synthetic automation-context user-message bridge so the operator's real message stays intact.
- Gate inspection to Agent threads, keep deleted automations hidden from agent inspection, and harden runtime gates for disabled automation instances and forged dynamic tool calls.

Closes #555.

## Verification

- I verified the dev-profile flow end to end: a Codex Agent thread used the automation tools to list attached automations and inspect the latest weather automation artifact.
- `pnpm test`
- `pnpm lint:boundaries`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm --filter @pwragent/shared typecheck`

## Notes

- This preserves automation cards/status as out-of-band transcript entries while letting the agent explicitly query automation history when it needs it.
- The dynamic tool catalog is still registered broadly for new Codex threads, but the handler now enforces live active-turn binding and Agent-thread authorization before returning data. We still need to discuss whether to hide the catalog itself from non-Agent threads.
