### PR TITLE
chore(desktop): update Electron to 41.6.1

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -80,7 +80,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.2.0",
     "axe-core": "^4.11.4",
-    "electron": "^41.2.1",
+    "electron": "41.6.1",
     "electron-builder": "^26.8.1",
     "electron-vite": "^5.0.0",
     "tsx": "^4.20.6",

--- a/apps/desktop/scripts/rebuild-native-for-electron.mjs
+++ b/apps/desktop/scripts/rebuild-native-for-electron.mjs
@@ -6,15 +6,25 @@
  * when running inside Electron, while unit tests use the default Node binary.
  */
 
-import { execSync } from "node:child_process";
-import { existsSync, mkdirSync, copyFileSync, unlinkSync } from "node:fs";
+import { execFileSync, execSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  copyFileSync,
+  unlinkSync,
+  readFileSync,
+  renameSync
+} from "node:fs";
+import { rm, writeFile } from "node:fs/promises";
 import { resolve, dirname, join } from "node:path";
 import { createRequire } from "node:module";
 
 const require = createRequire(import.meta.url);
 
 const betterSqlite3Dir = dirname(require.resolve("better-sqlite3/package.json"));
-const electronPkg = require("electron/package.json");
+const electronPackageJsonPath = require.resolve("electron/package.json");
+const electronDir = dirname(electronPackageJsonPath);
+const electronPkg = require(electronPackageJsonPath);
 const electronVersion = electronPkg.version;
 
 const prebuildBin = resolve(betterSqlite3Dir, "node_modules", ".bin", "prebuild-install");
@@ -25,6 +35,8 @@ const electronNativeDir = join(betterSqlite3Dir, "electron-native");
 const targetBinary = join(electronNativeDir, "better_sqlite3.node");
 const defaultBinary = join(betterSqlite3Dir, "build", "Release", "better_sqlite3.node");
 const backupBinary = join(betterSqlite3Dir, "build", "Release", "better_sqlite3.node.bak");
+
+await ensureElectronBinaryInstalled();
 
 if (existsSync(targetBinary)) {
   console.log(`Electron native binary already exists, skipping rebuild.`);
@@ -66,3 +78,108 @@ if (existsSync(backupBinary)) {
 
 console.log(`Electron native binary placed at ${targetBinary}`);
 console.log(`Node native binary preserved at ${defaultBinary}`);
+
+async function ensureElectronBinaryInstalled() {
+  const platformPath = getElectronPlatformPath();
+  const pathFile = join(electronDir, "path.txt");
+  const executablePath = join(electronDir, "dist", platformPath);
+  const frameworkPath = join(
+    electronDir,
+    "dist",
+    "Electron.app",
+    "Contents",
+    "Frameworks",
+    "Electron Framework.framework",
+    "Versions",
+    "A",
+    "Electron Framework"
+  );
+  const requiredPaths = [executablePath];
+
+  if (platformPath.startsWith("Electron.app/")) {
+    requiredPaths.push(frameworkPath);
+  }
+
+  if (
+    requiredPaths.every((requiredPath) => existsSync(requiredPath)) &&
+    existsSync(pathFile) &&
+    readFileSync(pathFile, "utf8") === platformPath
+  ) {
+    return;
+  }
+
+  console.log(`Installing Electron ${electronVersion} binary...`);
+
+  const electronRequire = createRequire(join(electronDir, "index.js"));
+  const { downloadArtifact } = electronRequire("@electron/get");
+  const checksums = electronRequire("./checksums.json");
+  const platform =
+    process.env.ELECTRON_INSTALL_PLATFORM || process.env.npm_config_platform || process.platform;
+  const arch = process.env.ELECTRON_INSTALL_ARCH || process.env.npm_config_arch || process.arch;
+  const distPath = join(electronDir, "dist");
+  const zipPath = await downloadArtifact({
+    version: electronVersion,
+    artifactName: "electron",
+    force: process.env.force_no_cache === "true",
+    cacheRoot: process.env.electron_config_cache,
+    checksums:
+      process.env.electron_use_remote_checksums || process.env.npm_config_electron_use_remote_checksums
+        ? undefined
+        : checksums,
+    platform,
+    arch
+  });
+
+  await rm(distPath, { recursive: true, force: true });
+  extractElectronZip(zipPath, distPath);
+
+  const extractedTypes = join(distPath, "electron.d.ts");
+  if (existsSync(extractedTypes)) {
+    renameSync(extractedTypes, join(electronDir, "electron.d.ts"));
+  }
+
+  await writeFile(pathFile, platformPath);
+
+  if (!existsSync(executablePath)) {
+    throw new Error(`Electron binary install did not create ${executablePath}`);
+  }
+}
+
+function extractElectronZip(zipPath, distPath) {
+  // Use the host unzipper so postinstall/dev bootstrap waits for extraction.
+  if (process.platform === "win32") {
+    execFileSync(
+      "powershell.exe",
+      [
+        "-NoProfile",
+        "-Command",
+        "Expand-Archive -LiteralPath $args[0] -DestinationPath $args[1] -Force",
+        zipPath,
+        distPath
+      ],
+      { stdio: "inherit" }
+    );
+    return;
+  }
+
+  execFileSync("unzip", ["-q", zipPath, "-d", distPath], { stdio: "inherit" });
+}
+
+function getElectronPlatformPath() {
+  const platform =
+    process.env.ELECTRON_INSTALL_PLATFORM || process.env.npm_config_platform || process.platform;
+
+  switch (platform) {
+    case "mas":
+    case "darwin":
+      return "Electron.app/Contents/MacOS/Electron";
+    case "freebsd":
+    case "openbsd":
+    case "linux":
+      return "electron";
+    case "win32":
+      return "electron.exe";
+    default:
+      throw new Error(`Electron builds are not available on platform: ${platform}`);
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,8 +144,8 @@ importers:
         specifier: ^4.11.4
         version: 4.11.4
       electron:
-        specifier: ^41.2.1
-        version: 41.2.1
+        specifier: 41.6.1
+        version: 41.6.1
       electron-builder:
         specifier: ^26.8.1
         version: 26.8.1(electron-builder-squirrel-windows@26.8.1)
@@ -2060,8 +2060,8 @@ packages:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
 
-  electron@41.2.1:
-    resolution: {integrity: sha512-teeRThiYGTPKf/2yOW7zZA1bhb91KEQ4yLBPOg7GxpmnkLFLugKgQaAKOrCgdzwsXh/5mFIfmkm+4+wACJKwaA==}
+  electron@41.6.1:
+    resolution: {integrity: sha512-3y1Q0AkPnqwaJJZV146KlZ63VIVlQVlWdLiArkwnGUOxZAZD5cvag4TMUsu/gN+FZhkkpelgvdTXPZvTb34I8A==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
 
@@ -5629,7 +5629,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@41.2.1:
+  electron@41.6.1:
     dependencies:
       '@electron/get': 2.0.3
       '@types/node': 24.12.2


### PR DESCRIPTION
## Summary
- update the desktop Electron pin from 41.2.1 to exact 41.6.1
- keep the native bootstrap deterministic by ensuring the Electron binary is installed before fetching the better-sqlite3 Electron prebuild
- refresh pnpm-lock.yaml for the Electron package update

## Notes
- Electron 42.1.0 is the newest stable release older than 7 days, but it is not viable here yet: better-sqlite3 has no Electron 42.1.0 prebuild, and a source build fails against Electron 42/V8 headers.
- Electron 41.6.1 is the newest compatible stable release older than 7 days that installs cleanly with the current native dependency stack.

## Validation
- pnpm install
- pnpm --filter @pwragent/desktop exec electron --version -> v41.6.1
- pnpm --filter @pwragent/desktop build