### PR TITLE
docs(desktop): screenshot captures for onboarding wizard + LiveWorkRail

### DIFF
--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -149,7 +149,7 @@ Pieces, all under `apps/desktop/`:
 | File | What it does |
 |---|---|
 | `e2e/readme-screenshots.inspect.spec.ts` | Five tests, one per surface. Gated behind `PWRAGENT_SCREENSHOT_CAPTURE=1`. |
-| `e2e/docs-site-screenshots.inspect.spec.ts` | Tests producing PNGs for `docs.pwragent.ai` (Settings panels + per-provider Messaging panels + Recents hero + composer features). Gated behind `PWRAGENT_DOCS_SITE_SCREENSHOT_CAPTURE=1`. Output lands in the **sibling docs repo's** `assets/screenshots/` (default `~/github/docs.pwragent.ai/`, override with `PWRAGENT_DOCS_SITE_REPO`). |
+| `e2e/docs-site-screenshots.inspect.spec.ts` | Tests producing PNGs for `docs.pwragent.ai` (Settings panels + per-provider Messaging panels + Recents hero + composer features + first-run onboarding wizard + live work rail). Gated behind `PWRAGENT_DOCS_SITE_SCREENSHOT_CAPTURE=1`. Output lands in the **sibling docs repo's** `assets/screenshots/` (default `~/github/docs.pwragent.ai/`, override with `PWRAGENT_DOCS_SITE_REPO`). |
 | `e2e/fixtures/readme-recents-hero/replay.fixture.json` | Hand-crafted populated thread list for the hero shot. Edit by hand to retune. |
 | `e2e/fixtures/readme-state-seeding.ts` | Direct sqlite/config seeders for messaging bindings, activity log entries, pairing tokens, and Telegram-enabled config. |
 | `e2e/fixtures/docs-site-state-seeding.ts` | All-providers-enabled `config.toml` seeder so the per-platform Settings → Messaging captures can scroll directly to each platform's section without driving the Enabled toggle in the UI. |

--- a/apps/desktop/e2e/docs-site-screenshots.inspect.spec.ts
+++ b/apps/desktop/e2e/docs-site-screenshots.inspect.spec.ts
@@ -939,3 +939,120 @@ test("desktop-queued-turns — composer with /review queued behind an in-flight 
     await rm(tmpRoot, { recursive: true, force: true });
   }
 });
+
+// ────────────────────── First-run onboarding wizard ──────────────────────
+
+test("desktop-onboarding-wizard — Codex profile step", async () => {
+  test.setTimeout(120_000);
+
+  // No fixturePath: the wizard runs against a fresh PWRAGENT_HOME (no
+  // ~/.pwragent/profiles/default/ pre-seeded), so the boot decision
+  // returns `no-profile-configured` and the wizard fires for real.
+  // `suppressOnboarding: false` is the explicit opt-in, and the
+  // wizard doesn't need the replay driver until it tries to spawn a
+  // thread (which we won't do — we stop on the Codex Profile step).
+  const app = await launchElectronApp({
+    suppressOnboarding: false,
+    requiresReplayDriver: false,
+    windowSize: WINDOW_SIZE,
+    appearance: SCREENSHOT_APPEARANCE,
+  });
+
+  try {
+    // Welcome → Thread presentation → Models / Providers → Codex
+    // profile. The Codex profile step is the most distinctive shot —
+    // it shows the Shared / Isolated / Multiple cards that frame how
+    // PwrAgent relates to a Codex install.
+    await expect(
+      app.window.getByRole("heading", { name: /A few short choices/i }),
+    ).toBeVisible();
+    await app.window.getByRole("button", { name: /Get started/i }).click();
+
+    // Thread presentation — accept defaults.
+    await expect(
+      app.window.getByRole("heading", {
+        name: /Pick your appearance and thread density/i,
+      }),
+    ).toBeVisible();
+    await app.window.getByRole("button", { name: /^Continue/i }).click();
+
+    // Models / Providers — paste a dummy xAI key to clear the gate
+    // (Codex CLI isn't on PATH in the screenshot run env).
+    await expect(
+      app.window.getByRole("heading", {
+        name: /Pick at least one model backend/i,
+      }),
+    ).toBeVisible();
+    await app.window
+      .locator('input[type="password"]')
+      .first()
+      .fill("xai-screenshot-placeholder-key");
+    await app.window.getByRole("button", { name: /Use this key/i }).click();
+    await app.window.getByRole("button", { name: /^Continue/i }).click();
+
+    // Codex profile — this is the screenshot target.
+    await expect(
+      app.window.getByRole("heading", {
+        name: /How should PwrAgent relate to your Codex install/i,
+      }),
+    ).toBeVisible();
+
+    await bringToFront(app.electronApp);
+    captureNative("desktop-onboarding-codex-profile.png");
+  } finally {
+    await app.close();
+  }
+});
+
+// ────────────────────── Live work rail ──────────────────────
+
+test("desktop-live-work-rail — in-flight turn with diff + plan in the rail", async () => {
+  test.setTimeout(120_000);
+
+  // Reuses the existing live-work-rail-toggle fixture from the e2e
+  // test suite. That fixture's turn/diff/updated landing ends with
+  // the protocol-summary "Edited 2 files, +4, -1" — a tight, visually
+  // interesting state for the rail.
+  const app = await launchElectronApp({
+    fixturePath: path.resolve(
+      specDir,
+      "fixtures/live-work-rail-toggle/replay.fixture.json",
+    ),
+    windowSize: WINDOW_SIZE,
+    appearance: SCREENSHOT_APPEARANCE,
+  });
+
+  try {
+    await app.window
+      .getByRole("button", { name: /LiveWorkRail chevron toggle replay/i })
+      .first()
+      .click();
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "LiveWorkRail chevron toggle replay",
+      }),
+    ).toBeVisible();
+
+    // Kick the turn so the rail populates with diff + plan content.
+    await app.window
+      .getByLabel("Reply")
+      .fill("Make a small disposable edit to two files.");
+    await app.window.getByRole("button", { name: "Send" }).click();
+
+    // Advance the replay through the diff lifecycle.
+    await app.advance({ stepId: "status-active-1" });
+    await app.advance({ stepId: "turn-started-1" });
+    await app.advance({ stepId: "turn-diff-updated-1" });
+
+    // The rail's landmark name reflects the cumulative diff summary.
+    await expect(
+      app.window.getByRole("complementary", { name: /Edited 2 files/i }),
+    ).toBeVisible();
+
+    await bringToFront(app.electronApp);
+    captureNative("desktop-live-work-rail.png");
+  } finally {
+    await app.close();
+  }
+});


### PR DESCRIPTION
## Summary

Two new tests in \`apps/desktop/e2e/docs-site-screenshots.inspect.spec.ts\` that produce PNGs the docs.pwragent.ai site already references (or will after the matching content PR lands at [pwrdrvr/docs.pwragent.ai#1](https://github.com/pwrdrvr/docs.pwragent.ai/pull/1)).

| New capture | Replay strategy |
|---|---|
| **\`desktop-onboarding-codex-profile.png\`** | \`suppressOnboarding: false\` + no fixturePath → fresh \`PWRAGENT_HOME\`, wizard fires for real. Walks Welcome → Thread Presentation (defaults) → Models / Providers (dummy xAI key to clear the gate when Codex CLI isn't on PATH) → captures on the **Codex Profile** step (Shared / Isolated / Multiple cards). Most distinctive shot — frames how PwrAgent relates to Codex. |
| **\`desktop-live-work-rail.png\`** | Reuses the existing \`fixtures/live-work-rail-toggle/replay.fixture.json\`. Drives the same three step-advances as the regression test (\`status-active-1 → turn-started-1 → turn-diff-updated-1\`), lands on the cumulative-diff "Edited 2 files, +4, -1" state, captures. |

PNGs land in the sibling docs.pwragent.ai checkout per the path convention established in PR #563.

## Run

From a \`pwrdrvr/PwrAgent\` checkout:

\`\`\`bash
pnpm --filter @pwragent/desktop screenshot:docs-site
\`\`\`

The new captures land at:

- \`~/github/docs.pwragent.ai/assets/screenshots/desktop-onboarding-codex-profile.png\`
- \`~/github/docs.pwragent.ai/assets/screenshots/desktop-live-work-rail.png\`

Then \`cd ~/github/docs.pwragent.ai\` to review + commit the PNGs.

## Profiles app menu screenshot — deliberately not in this PR

The existing \`capture-window.swift\` resolves a CGWindowID by app name + window title and shells out to \`screencapture -l <id>\`. That works for Electron windows; it doesn't work for the macOS menu bar dropdown, which lives in a SystemUIServer-owned window the script can't resolve. Options:

- **New screen-region capture variant** (\`screencapture -R x,y,w,h\`) — adds infra, more invasive.
- **Manual screencapture** — open the app, open the Profiles menu, ⌘⇧4-Space to grab it.

Either way, it's its own follow-up. The docs content for the Profiles menu already lives at \`docs.pwragent.ai/desktop/#profiles-app-menu\` as text-only.

## Test plan

- \`pnpm typecheck\` clean for these changes (pre-existing errors in \`a11y.spec.ts\` and \`ComposerTiptapInput.tsx\` are unrelated).
- Run \`pnpm --filter @pwragent/desktop screenshot:docs-site\` against this branch; confirm:
  - Onboarding test successfully navigates Welcome → Thread Presentation → Models → Codex Profile step
  - LiveWorkRail test gets the "Edited 2 files" landmark visible before capture
  - Both PNGs land in \`~/github/docs.pwragent.ai/assets/screenshots/\`
- Noise filter runs against the new repo and reverts no-op re-encodes via the \`--root\` flag already wired in \`screenshot:docs-site\`.

🤖 Generated with Claude Opus 4.7 via [Claude Code](https://claude.com/claude-code)