### PR TITLE
chore(deps): group dependabot ecosystem updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,10 +26,47 @@ updates:
       - dependency-name: "@types/node"
         update-types:
           - "version-update:semver-major"
+      # Electron majors need a planned desktop runtime migration. Native module
+      # prebuild availability, packaging behavior, and Electron breaking changes
+      # need human review before a PR is worth opening.
+      - dependency-name: "electron"
+        update-types:
+          - "version-update:semver-major"
     groups:
+      vite-toolchain:
+        patterns:
+          - "vite"
+          - "@vitejs/plugin-react"
+          - "electron-vite"
+        dependency-type: "development"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
+      electron-runtime-minor-patch:
+        patterns:
+          - "electron"
+          - "@electron/*"
+          - "electron-builder"
+          - "electron-updater"
+        update-types:
+          - "minor"
+          - "patch"
+      tiptap-prosemirror:
+        patterns:
+          - "@tiptap/*"
+          - "prosemirror-*"
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
       npm-production-minor-patch:
         patterns:
           - "*"
+        exclude-patterns:
+          - "@tiptap/*"
+          - "prosemirror-*"
+          - "electron-updater"
         dependency-type: "production"
         update-types:
           - "minor"
@@ -37,6 +74,13 @@ updates:
       npm-development-minor-patch:
         patterns:
           - "*"
+        exclude-patterns:
+          - "vite"
+          - "@vitejs/plugin-react"
+          - "electron-vite"
+          - "electron"
+          - "@electron/*"
+          - "electron-builder"
         dependency-type: "development"
         update-types:
           - "minor"


### PR DESCRIPTION
## Summary
Dependabot now opens dependency PRs by the ecosystem boundaries we actually review: Vite tooling, Electron runtime packages, and Tiptap/ProseMirror editor updates move independently instead of being mixed into broad catch-all groups.

Electron major bumps are no longer opened automatically, since those require a planned desktop runtime migration with native module and packaging review.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml"); puts "dependabot.yml parses"'`
- `git diff --check -- .github/dependabot.yml`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-000000)
