### PR TITLE
chore(deps): isolate desktop runtime updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,12 +43,15 @@ updates:
           - "major"
           - "minor"
           - "patch"
-      electron-runtime-minor-patch:
+      desktop-runtime-minor-patch:
         patterns:
           - "electron"
           - "@electron/*"
+          - "better-sqlite3"
           - "electron-builder"
+          - "electron-log"
           - "electron-updater"
+          - "@types/better-sqlite3"
         update-types:
           - "minor"
           - "patch"
@@ -66,6 +69,8 @@ updates:
         exclude-patterns:
           - "@tiptap/*"
           - "prosemirror-*"
+          - "better-sqlite3"
+          - "electron-log"
           - "electron-updater"
         dependency-type: "production"
         update-types:
@@ -80,6 +85,7 @@ updates:
           - "electron-vite"
           - "electron"
           - "@electron/*"
+          - "@types/better-sqlite3"
           - "electron-builder"
         dependency-type: "development"
         update-types:

--- a/apps/desktop/scripts/rebuild-native-for-electron.mjs
+++ b/apps/desktop/scripts/rebuild-native-for-electron.mjs
@@ -6,16 +6,120 @@
  * when running inside Electron, while unit tests use the default Node binary.
  */
 
-import { execSync } from "node:child_process";
-import { existsSync, mkdirSync, copyFileSync, unlinkSync } from "node:fs";
+import { execFileSync, execSync } from "node:child_process";
+import {
+  readdirSync,
+  existsSync,
+  mkdirSync,
+  copyFileSync,
+  readFileSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { resolve, dirname, join } from "node:path";
+import { homedir } from "node:os";
 import { createRequire } from "node:module";
 
 const require = createRequire(import.meta.url);
 
 const betterSqlite3Dir = dirname(require.resolve("better-sqlite3/package.json"));
+const electronDir = dirname(require.resolve("electron/package.json"));
 const electronPkg = require("electron/package.json");
 const electronVersion = electronPkg.version;
+
+function getElectronPlatformPath() {
+  switch (process.platform) {
+    case "darwin":
+      return "Electron.app/Contents/MacOS/Electron";
+    case "freebsd":
+    case "openbsd":
+    case "linux":
+      return "electron";
+    case "win32":
+      return "electron.exe";
+    default:
+      throw new Error(
+        `Electron builds are not available on platform: ${process.platform}`,
+      );
+  }
+}
+
+function getElectronArtifactPlatform() {
+  return process.platform === "win32" ? "win32" : process.platform;
+}
+
+function findElectronArtifactZip() {
+  const filename = `electron-v${electronVersion}-${getElectronArtifactPlatform()}-${process.arch}.zip`;
+  const roots = [
+    process.env.electron_config_cache,
+    join(homedir(), ".cache", "electron"),
+    join(homedir(), "Library", "Caches", "electron"),
+  ].filter(Boolean);
+
+  for (const root of roots) {
+    if (!existsSync(root)) {
+      continue;
+    }
+
+    const direct = join(root, filename);
+    if (existsSync(direct)) {
+      return direct;
+    }
+
+    for (const entry of readdirSync(root, { withFileTypes: true })) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+      const candidate = join(root, entry.name, filename);
+      if (existsSync(candidate)) {
+        return candidate;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function ensureElectronRuntime() {
+  const platformPath = getElectronPlatformPath();
+  const distDir = join(electronDir, "dist");
+  const binaryPath = join(electronDir, "dist", platformPath);
+  const pathMarker = join(electronDir, "path.txt");
+  const markerMatches =
+    existsSync(pathMarker) && readFileSync(pathMarker, "utf8") === platformPath;
+
+  if (existsSync(binaryPath) && markerMatches) {
+    return;
+  }
+
+  console.log(
+    `Ensuring Electron ${electronVersion} runtime binary is installed...`,
+  );
+  execFileSync(process.execPath, [join(electronDir, "install.js")], {
+    cwd: electronDir,
+    stdio: "inherit",
+  });
+
+  if (existsSync(binaryPath)) {
+    return;
+  }
+
+  const artifactZip = findElectronArtifactZip();
+  if (!artifactZip) {
+    throw new Error(
+      `Electron ${electronVersion} artifact zip was not found in cache`,
+    );
+  }
+
+  console.log(`Extracting Electron runtime from ${artifactZip}...`);
+  rmSync(distDir, { recursive: true, force: true });
+  mkdirSync(distDir, { recursive: true });
+  execFileSync("unzip", ["-q", "-o", artifactZip, "-d", distDir], {
+    stdio: "inherit",
+  });
+  writeFileSync(pathMarker, platformPath);
+}
 
 const prebuildBin = resolve(betterSqlite3Dir, "node_modules", ".bin", "prebuild-install");
 const prebuildFallback = resolve(betterSqlite3Dir, "..", "prebuild-install", "bin.js");
@@ -25,6 +129,8 @@ const electronNativeDir = join(betterSqlite3Dir, "electron-native");
 const targetBinary = join(electronNativeDir, "better_sqlite3.node");
 const defaultBinary = join(betterSqlite3Dir, "build", "Release", "better_sqlite3.node");
 const backupBinary = join(betterSqlite3Dir, "build", "Release", "better_sqlite3.node.bak");
+
+ensureElectronRuntime();
 
 if (existsSync(targetBinary)) {
   console.log(`Electron native binary already exists, skipping rebuild.`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,7 +146,7 @@ importers:
         version: 4.11.4
       electron:
         specifier: ^41.2.1
-        version: 41.7.0
+        version: 41.2.1
       electron-builder:
         specifier: ^26.8.1
         version: 26.8.1(electron-builder-squirrel-windows@26.8.1)
@@ -2218,8 +2218,8 @@ packages:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
 
-  electron@41.7.0:
-    resolution: {integrity: sha512-U6KAKivjk6YQ0Z5+eloJBjwhbHRE206gvy1UBMw2bSluWtMh5waeXMvX6AT/Ujm5ymYXVJOp7g9N7vOFw16wBQ==}
+  electron@41.2.1:
+    resolution: {integrity: sha512-teeRThiYGTPKf/2yOW7zZA1bhb91KEQ4yLBPOg7GxpmnkLFLugKgQaAKOrCgdzwsXh/5mFIfmkm+4+wACJKwaA==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
 
@@ -5872,7 +5872,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@41.7.0:
+  electron@41.2.1:
     dependencies:
       '@electron/get': 2.0.3
       '@types/node': 24.12.4


### PR DESCRIPTION
## Summary
- move Electron-adjacent desktop runtime packages into a dedicated Dependabot group
- keep better-sqlite3, electron-log, and @types/better-sqlite3 out of broad prod/dev dependency batches
- revert the lockfile back to Electron 41.2.1 after the merged Electron 41.7.0 bump left CI without a runnable Electron binary
- make the desktop postinstall verify the Electron runtime binary exists, with a cache-zip extraction fallback for Node 24 / extract-zip installs that only partially extract Electron

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml"); puts "dependabot.yml parses"'
- git diff --check -- .github/dependabot.yml pnpm-lock.yaml apps/desktop/scripts/rebuild-native-for-electron.mjs
- pnpm licenses:check
- pnpm test apps/desktop/src/main/__tests__/log.test.ts