### PR TITLE
fix(desktop): restore clickability for onboarding and warning overlay

### DIFF
--- a/apps/desktop/e2e/onboarding-wizard.spec.ts
+++ b/apps/desktop/e2e/onboarding-wizard.spec.ts
@@ -26,6 +26,39 @@ const wizardLaunchOptions = {
 };
 
 test.describe("Onboarding wizard", () => {
+  test("Get started and Back buttons are clickable", async () => {
+    const app = await launchElectronApp(wizardLaunchOptions);
+    try {
+      await expect(
+        app.window.getByRole("heading", {
+          name: /A few short choices/i,
+        }),
+      ).toBeVisible();
+
+      const getStarted = app.window.getByRole("button", { name: /Get started/i });
+      await expect(getStarted).toBeVisible();
+      await getStarted.click();
+
+      await expect(
+        app.window.getByRole("heading", {
+          name: /Pick your appearance and thread density/i,
+        }),
+      ).toBeVisible();
+
+      const back = app.window.getByRole("button", { name: /^← Back/i });
+      await expect(back).toBeVisible();
+      await back.click();
+
+      await expect(
+        app.window.getByRole("heading", {
+          name: /A few short choices/i,
+        }),
+      ).toBeVisible();
+    } finally {
+      await app.close();
+    }
+  });
+
   test("fires on a fresh PWRAGENT_HOME and walks Welcome → Done in Shared mode", async () => {
     const app = await launchElectronApp(wizardLaunchOptions);
     try {

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -178,6 +178,22 @@ describe("Tangerine Terminal theme contract", () => {
     );
   });
 
+  it("keeps onboarding and warning overlays clickable without losing window drag affordances", () => {
+    const overlayRule = extractRuleBody(css, ".onboarding-wizard-overlay");
+    const titlebarRule = extractRuleBody(css, ".onboarding-wizard__titlebar");
+    const warningBannerRule = extractRuleBody(css, ".codex-config-warning-banner");
+
+    expect(overlayRule).toContain("-webkit-app-region: no-drag;");
+    expect(css).toMatch(
+      /\.onboarding-wizard-overlay__scrim\s*\{[\s\S]*?pointer-events:\s*none;[\s\S]*?\}/
+    );
+    expect(titlebarRule).toContain("-webkit-app-region: drag;");
+    expect(css).toMatch(
+      /\.onboarding-wizard__titlebar button,\s*\.onboarding-wizard__titlebar input,\s*\.onboarding-wizard__titlebar a,\s*\.onboarding-wizard__titlebar select,\s*\.onboarding-wizard__titlebar \[role="button"\]\s*\{[\s\S]*?-webkit-app-region:\s*no-drag;[\s\S]*?\}/
+    );
+    expect(warningBannerRule).toContain("-webkit-app-region: no-drag;");
+  });
+
   it("lets transcript scroll restoration own scroll anchoring", () => {
     expect(css).toMatch(
       /\.transcript-list__items\s*\{[\s\S]*?overflow-anchor:\s*none;[\s\S]*?\}/

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3020,6 +3020,7 @@ textarea,
   background: color-mix(in srgb, var(--bg-panel-elevated) 92%, var(--status-warning) 8%);
   box-shadow: var(--shadow-popover);
   animation: app-update-banner-enter 160ms ease-out;
+  -webkit-app-region: no-drag;
 }
 
 .codex-config-warning-banner__content {
@@ -10791,14 +10792,18 @@ textarea,
   display: flex;
   align-items: center;
   justify-content: center;
+  -webkit-app-region: no-drag;
 }
 .onboarding-wizard-overlay__scrim {
   position: absolute;
   inset: 0;
+  z-index: 0;
   background: var(--scrim-strong);
+  pointer-events: none;
 }
 .onboarding-wizard {
   position: relative;
+  z-index: 1;
   width: min(1120px, calc(100vw - 64px));
   max-height: calc(100vh - 64px);
   background: var(--bg-panel);
@@ -10884,6 +10889,14 @@ textarea,
   padding: 14px 18px 12px;
   border-bottom: 1px solid var(--border-subtle);
   background: var(--bg-panel);
+  -webkit-app-region: drag;
+}
+.onboarding-wizard__titlebar button,
+.onboarding-wizard__titlebar input,
+.onboarding-wizard__titlebar a,
+.onboarding-wizard__titlebar select,
+.onboarding-wizard__titlebar [role="button"] {
+  -webkit-app-region: no-drag;
 }
 .onboarding-wizard__eyebrow {
   font: 600 10px/1 var(--font-sans, sans-serif);


### PR DESCRIPTION
## Summary
In the onboarding wizard, most controls were not clickable while the overlay was open (notably only `Skip setup` remained usable).
`codex-config-warning-banner` controls could become non-interactive in overlapping drag-region contexts.

## Changes
- Fixed onboarding wizard overlay clickability regression without breaking layout:
  - Kept `.onboarding-wizard-overlay` fixed/centered.
  - Set overlay to `-webkit-app-region: no-drag`.
  - Kept scrim non-interactive (`pointer-events: none`) and behind wizard.
  - Raised wizard above scrim with explicit z-index.
- Restored window dragging while wizard is open:
  - Made `.onboarding-wizard__titlebar` a drag region.
  - Marked interactive titlebar controls as `-webkit-app-region: no-drag`.
- Fixed identical clickability issue for `codex-config-warning-banner` by setting it to `-webkit-app-region: no-drag`.
- Added renderer style contract coverage for this drag/click behavior.
- Added a focused onboarding E2E regression test that validates `Get started` and `← Back` click transitions.

## Verification

- `pnpm test apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx` ✅
- `pnpm --filter @pwragent/desktop test:e2e e2e/onboarding-wizard.spec.ts --grep "Get started and Back buttons are clickable"` ✅ 
- manual test: onboarding completed ✅ 