### PR TITLE
fix(desktop): remove misleading Codex profile setting

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -6,7 +6,11 @@ import {
   type CSSProperties,
   type PointerEvent,
 } from "react";
-import type { DesktopBootInfo } from "@pwragent/shared";
+import type {
+  DesktopBootInfo,
+  DesktopCodexProfileModel,
+  DesktopPwrAgentProfileSummary,
+} from "@pwragent/shared";
 import { Sidebar } from "./features/navigation/Sidebar";
 import { OnboardingWizard } from "./features/onboarding/OnboardingWizard";
 import {
@@ -190,6 +194,12 @@ function DesktopAppShell(props: {
     baseComposerDraftStore,
     desktopApi,
   );
+  const replayCodexProfileSetup = settings.snapshot
+    ? inferReplayCodexProfileSetup(
+        settings.snapshot.general.codexProfileModel?.value ?? "shared",
+        profiles.profiles,
+      )
+    : undefined;
   useQueuedTurnRelease({
     backends: backendSummaries.backends,
     composerDraftStore,
@@ -276,9 +286,11 @@ function DesktopAppShell(props: {
       return;
     }
     return desktopApi.onReplayOnboardingRequested(() => {
-      setOnboardingOpen("replay");
+      void profiles.refresh().finally(() => {
+        setOnboardingOpen("replay");
+      });
     });
-  }, [desktopApi]);
+  }, [desktopApi, profiles.refresh]);
   useEffect(() => {
     // Auto-launch on the first snapshot where `completed === false`.
     // `autoOpenSeen` blocks re-opens after the user dismissed without
@@ -579,7 +591,14 @@ function DesktopAppShell(props: {
           initialDensity={settings.snapshot.general.appearance.density.value}
           initialTheme={settings.snapshot.general.appearance.theme.value}
           initialCodexProfileModel={
-            settings.snapshot.general.codexProfileModel.value
+            onboardingOpen === "replay" && replayCodexProfileSetup
+              ? replayCodexProfileSetup.model
+              : settings.snapshot.general.codexProfileModel.value
+          }
+          initialCodexProfileNames={
+            onboardingOpen === "replay"
+              ? replayCodexProfileSetup?.profileNames
+              : undefined
           }
           appearanceController={props.appearanceController}
           settings={settings}
@@ -659,4 +678,39 @@ function isSettingsSection(
   return (
     section !== undefined && SETTINGS_SECTIONS.has(section as SettingsSection)
   );
+}
+
+export type ReplayCodexProfileSetup = {
+  model: DesktopCodexProfileModel;
+  profileNames?: readonly string[];
+};
+
+export function inferReplayCodexProfileSetup(
+  persisted: DesktopCodexProfileModel,
+  profiles: readonly DesktopPwrAgentProfileSummary[],
+): ReplayCodexProfileSetup {
+  const namedPairings = profiles.filter((profile) => profile.codexProfile.name);
+  if (namedPairings.length >= 2) {
+    return {
+      model: "multiple",
+      profileNames: namedPairings.map((profile) => profile.name),
+    };
+  }
+
+  const activeProfile = profiles.find((profile) => profile.active);
+  const isolatedProfile = activeProfile?.codexProfile.name
+    ? activeProfile
+    : namedPairings[0];
+  if (isolatedProfile) {
+    return { model: "isolated", profileNames: [isolatedProfile.name] };
+  }
+
+  return { model: persisted };
+}
+
+export function inferReplayCodexProfileModel(
+  persisted: DesktopCodexProfileModel,
+  profiles: readonly DesktopPwrAgentProfileSummary[],
+): DesktopCodexProfileModel {
+  return inferReplayCodexProfileSetup(persisted, profiles).model;
 }

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -10,12 +10,17 @@ import {
 } from "@testing-library/react";
 import type {
   AgentEvent,
+  DesktopPwrAgentProfileSummary,
   DesktopSettingsSnapshot,
   StartTurnRequest,
   StartTurnResponse,
 } from "@pwragent/shared";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
-import { App } from "../App";
+import {
+  App,
+  inferReplayCodexProfileModel,
+  inferReplayCodexProfileSetup,
+} from "../App";
 
 beforeAll(() => {
   const emptyRect = {
@@ -87,6 +92,65 @@ function createDeferred<T>(): {
   });
   return { promise, resolve, reject };
 }
+
+function profileSummary(
+  name: string,
+  codexProfileName: string,
+  active = false,
+): DesktopPwrAgentProfileSummary {
+  return {
+    name,
+    active,
+    canDelete: name !== "default",
+    codexProfile: {
+      name: codexProfileName,
+      displayName: codexProfileName || "System default",
+      codexHome: codexProfileName
+        ? `/home/example/.codex/profiles/${codexProfileName}`
+        : "/home/example/.codex",
+      exists: true,
+      hasAuthFile: true,
+      hasConfigFile: true,
+      selected: true,
+      source: codexProfileName ? "directory" : "default",
+    },
+    default: name === "default",
+    profileDir: `/home/example/.pwragent/profiles/${name}`,
+  };
+}
+
+describe("inferReplayCodexProfileModel", () => {
+  it("opens Replay Onboarding in Multiple when multiple profiles have named Codex pairings", () => {
+    const profiles = [
+      profileSummary("personal", "personal", true),
+      profileSummary("work", "work"),
+    ];
+
+    expect(inferReplayCodexProfileModel("shared", profiles)).toBe("multiple");
+    expect(inferReplayCodexProfileSetup("shared", profiles)).toEqual({
+      model: "multiple",
+      profileNames: ["personal", "work"],
+    });
+  });
+
+  it("opens Replay Onboarding in Isolated when the active profile has a named Codex pairing", () => {
+    const profiles = [profileSummary("pwragent", "pwragent", true)];
+
+    expect(inferReplayCodexProfileModel("shared", profiles)).toBe("isolated");
+    expect(inferReplayCodexProfileSetup("shared", profiles)).toEqual({
+      model: "isolated",
+      profileNames: ["pwragent"],
+    });
+  });
+
+  it("falls back to the persisted wizard choice when profile pairings are shared", () => {
+    expect(
+      inferReplayCodexProfileModel("multiple", [
+        profileSummary("default", "", true),
+      ]),
+    ).toBe("multiple");
+  });
+});
 
 describe("App", () => {
   afterEach(async () => {

--- a/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
+++ b/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
@@ -97,6 +97,7 @@ export type OnboardingWizardProps = {
   initialDensity: DesktopAppearanceDensity;
   initialTheme: DesktopAppearanceTheme;
   initialCodexProfileModel: DesktopCodexProfileModel;
+  initialCodexProfileNames?: readonly string[];
   /** Live theme + density controller. The wizard calls setTheme / setDensity
    *  as the operator picks so the app flips in real time. */
   appearanceController: AppearanceController;
@@ -170,6 +171,12 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
   // as the Isolated default. This lets the operator confirm "yes,
   // create `foo`" without retyping the name in the Profiles step.
   const [codexProfileNames, setCodexProfileNames] = useState<string[]>(() => {
+    const initialNames = props.initialCodexProfileNames
+      ?.map((name) => name.trim())
+      .filter(isValidProfileName);
+    if (initialNames?.length) {
+      return [...initialNames];
+    }
     const requested =
       props.bootInfo?.decisionKind === "missing-named-profile"
         ? props.bootInfo.requestedProfileName?.trim()
@@ -348,6 +355,9 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
           if (codexProfileModel === "shared") {
             return sharedNeedsLogin ? "shared-codex-login" : "messaging-safety";
           }
+          if (props.isReplay) {
+            return "messaging-safety";
+          }
           return "name-codex-profiles";
         case "name-codex-profiles":
           return "messaging-safety";
@@ -370,7 +380,13 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
           return null;
       }
     },
-    [codexProfileModel, orderedProviders.length, providerSetupIndex, sharedNeedsLogin],
+    [
+      codexProfileModel,
+      orderedProviders.length,
+      props.isReplay,
+      providerSetupIndex,
+      sharedNeedsLogin,
+    ],
   );
   // Did this wizard session start at the bootstrap-confirm step?
   // Only true when the boot decision named a missing profile —
@@ -403,6 +419,9 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
           if (codexProfileModel === "shared") {
             return sharedNeedsLogin ? "shared-codex-login" : "codex-profile";
           }
+          if (props.isReplay) {
+            return "codex-profile";
+          }
           return "name-codex-profiles";
         case "messaging-providers":
           return "messaging-safety";
@@ -420,6 +439,7 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
       codexProfileModel,
       entryWasBootstrapConfirm,
       orderedProviders.length,
+      props.isReplay,
       providerSetupIndex,
       sharedNeedsLogin,
     ],
@@ -637,27 +657,37 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
         };
         await props.onComplete(patch);
 
-        // Isolated + Multiple paths: provision paired PwrAgent + Codex
-        // profiles with the same names on both sides. The user's
-        // existing `default` PwrAgent profile and `default` Codex
-        // profile both stay untouched. Codex login per pair is deferred
-        // to Settings → Profiles — we don't fire N SSO browser windows
-        // mid-wizard. See `provisionPairedProfiles` for the IPC sequence
-        // and best-effort error handling.
-        //
-        // After the provisioning loop, auto-switch the operator INTO the
-        // newly-created profile (the first one for Multiple). The wizard
-        // was running on the operator's *original* session profile
-        // (typically `default`), but the whole point of Isolated/Multiple
-        // is "I want to work in a different profile" — landing the
-        // operator there at Finish closes that loop. The created
-        // profiles have `onboarding.completed = true` already seeded
-        // (see `provisionPairedProfiles`), so the wizard does NOT
-        // re-fire when the new window opens. Best-effort: a missing
-        // `openPwrAgentProfile` IPC just leaves the operator in the
-        // original session — they can switch later from the Profiles
-        // menu.
-        if (codexProfileModel !== "shared") {
+        if (isReplay) {
+          // Replay Onboarding reflects the current profile setup but
+          // must not create, pair, or switch profiles on Finish.
+          // Buffered secrets still graduate to the active profile if
+          // the replay collected any.
+          const activeProfile = props.bootInfo?.activeProfileName;
+          if (activeProfile) {
+            await writeBufferedSecretsIfAny(activeProfile, bufferedSecrets);
+          }
+        } else if (codexProfileModel !== "shared") {
+          // Isolated + Multiple paths: provision paired PwrAgent +
+          // Codex profiles with the same names on both sides. The
+          // user's existing `default` PwrAgent profile and `default`
+          // Codex profile both stay untouched. Codex login per pair is
+          // deferred to Settings → Profiles — we don't fire N SSO
+          // browser windows mid-wizard. See `provisionPairedProfiles`
+          // for the IPC sequence and best-effort error handling.
+          //
+          // After the provisioning loop, auto-switch the operator INTO
+          // the newly-created profile (the first one for Multiple).
+          // The wizard was running on the operator's *original*
+          // session profile (typically `default`), but the whole point
+          // of Isolated/Multiple is "I want to work in a different
+          // profile" — landing the operator there at Finish closes
+          // that loop. The created profiles have
+          // `onboarding.completed = true` already seeded (see
+          // `provisionPairedProfiles`), so the wizard does NOT re-fire
+          // when the new window opens. Best-effort: a missing
+          // `openPwrAgentProfile` IPC just leaves the operator in the
+          // original session — they can switch later from the Profiles
+          // menu.
           const created = await provisionPairedProfiles(
             props.desktopApi,
             codexProfileNames,
@@ -967,7 +997,9 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
               // post-launch Settings trip. Shared mode collapses to a
               // single profile so we skip the notice.
               multiProfileTarget={
-                codexProfileModel !== "shared" && codexProfileNames.length >= 1
+                codexProfileModel !== "shared" &&
+                !isReplay &&
+                codexProfileNames.length >= 1
                   ? {
                       firstProfileName: codexProfileNames[0]!,
                       otherProfileNames: codexProfileNames.slice(1),

--- a/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
 import type {
-  DesktopCodexProfileModel,
   DesktopSettingsSnapshot,
   DesktopUpdateChannel,
 } from "@pwragent/shared";
@@ -44,16 +43,6 @@ const DENSITY_OPTIONS: Array<{
     value: "mission-control",
   },
   { label: "Compact", meta: "Chips hidden", value: "compact" },
-];
-
-const CODEX_PROFILE_MODEL_OPTIONS: Array<{
-  label: string;
-  meta: string;
-  value: DesktopCodexProfileModel;
-}> = [
-  { label: "Shared", meta: "Reuse Codex login", value: "shared" },
-  { label: "Isolated", meta: "Fresh profile", value: "isolated" },
-  { label: "Multiple", meta: "Power user", value: "multiple" },
 ];
 
 const PASTED_IMAGE_PATCH_OPTIONS: Array<{
@@ -115,7 +104,6 @@ export function GeneralSettings(props: {
   onDeveloperModeChange: (value: boolean) => Promise<void>;
   onPastedImageMaxPatchesChange: (value: number) => Promise<void>;
   onUpdateChannelChange: (value: DesktopUpdateChannel) => Promise<void>;
-  onCodexProfileModelChange: (value: DesktopCodexProfileModel) => Promise<void>;
   onClearMessagingAcknowledgment: () => Promise<void>;
 }) {
   const [releaseVersions, setReleaseVersions] = useState<
@@ -125,7 +113,6 @@ export function GeneralSettings(props: {
     props.snapshot.imageUploads.pastedImageMaxPatches;
   const developerMode = props.snapshot.general.developerMode;
   const updateChannel = props.snapshot.updates.channel;
-  const codexProfileModel = props.snapshot.general.codexProfileModel;
   const messagingAcknowledgment =
     props.snapshot.general.messagingAcknowledgment;
   const activeOption = PASTED_IMAGE_PATCH_OPTIONS.find(
@@ -340,50 +327,6 @@ export function GeneralSettings(props: {
                     }}
                   >
                     {option.label}
-                  </button>
-                ))}
-              </div>
-            }
-          />
-        </div>
-      </SettingsSection>
-
-      <SettingsSection
-        eyebrow="General"
-        title="Codex profile"
-        chip={sourceBadge(codexProfileModel)}
-      >
-        <div className="settings-fields">
-          <SettingsField
-            label="Codex profile model"
-            sub="How PwrAgent relates to your Codex install for this profile. Mode changes may require re-authentication."
-            source={sourceBadge(codexProfileModel)}
-            control={
-              <div
-                className="settings-segmented"
-                role="radiogroup"
-                aria-label="Codex profile model"
-              >
-                {CODEX_PROFILE_MODEL_OPTIONS.map((option) => (
-                  <button
-                    key={option.value}
-                    aria-checked={codexProfileModel.value === option.value}
-                    className={`settings-segmented__button settings-segmented__button--stacked${
-                      codexProfileModel.value === option.value
-                        ? " is-active"
-                        : ""
-                    }`}
-                    disabled={props.saving}
-                    role="radio"
-                    type="button"
-                    onClick={() => {
-                      void props.onCodexProfileModelChange(option.value);
-                    }}
-                  >
-                    <span>{option.label}</span>
-                    <span className="settings-segmented__meta">
-                      {option.meta}
-                    </span>
                   </button>
                 ))}
               </div>

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -290,11 +290,6 @@ function SettingsSectionBody(props: {
             },
           });
         }}
-        onCodexProfileModelChange={async (codexProfileModel) => {
-          await props.settings.writeConfig({
-            general: { codexProfileModel },
-          });
-        }}
         onClearMessagingAcknowledgment={async () => {
           await props.settings.writeConfig({
             general: { messagingAcknowledgment: null },


### PR DESCRIPTION
## Summary

- Remove the editable Codex profile model control from Settings → General.
- Keep the wizard strategy value for onboarding, but use actual PwrAgent/Codex profile pairings to seed Replay Onboarding when available.
- Add focused coverage for replay inference so multi-profile setups reopen as Multiple instead of falling back to Shared.

## Validation

- pnpm test apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
- pnpm test apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
- pnpm --filter @pwragent/desktop typecheck
- git diff --check
