### PR TITLE
chore(deps): ignore node-fetch major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,13 @@ updates:
       - dependency-name: "electron"
         update-types:
           - "version-update:semver-major"
+      # node-fetch is kept at v2 for grammY's current Node runtime shim. The
+      # latest grammY release still depends on node-fetch v2 and its CommonJS
+      # entrypoint; v3 is ESM-only and should be handled as a planned Telegram
+      # runtime change rather than an automated dependency bump.
+      - dependency-name: "node-fetch"
+        update-types:
+          - "version-update:semver-major"
     groups:
       vite-toolchain:
         patterns:


### PR DESCRIPTION
## Summary

- Dependabot now ignores `node-fetch` semver-major bumps because grammY's current Node runtime shim still relies on the v2 CommonJS entrypoint.
- The comment records that moving Telegram to native `globalThis.fetch` should be handled as a planned runtime change with packaged smoke coverage.

## Verification

- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml"); puts "dependabot.yml ok"'`

## Notes

- PR #586 was already closed via `@dependabot ignore this major version`; this config change preserves the rationale in-repo.
- Verified on 2026-05-30 that npm's latest `grammy` is `1.43.0` and still declares `node-fetch@^2.7.0`.
