### PR TITLE
fix(desktop): clear image-only steering cards

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -746,15 +746,53 @@ function collectTextFragments(value: unknown): string[] {
   return [...directText, ...nestedText];
 }
 
-function notificationIncludesDraftText(params: unknown, draft: QueuedTurnDraft): boolean {
+function collectImageUrls(value: unknown): string[] {
+  if (!value || typeof value !== "object") {
+    return [];
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => collectImageUrls(entry));
+  }
+
+  const record = value as Record<string, unknown>;
+  const directImages = Object.entries(record).flatMap(([key, entry]) =>
+    typeof entry === "string" &&
+    (key === "url" ||
+      key === "image_url" ||
+      key === "imageUrl" ||
+      key === "image" ||
+      key === "src" ||
+      entry.startsWith("data:image/"))
+      ? [entry]
+      : []
+  );
+  const nestedImages = Object.values(record).flatMap((entry) =>
+    typeof entry === "string" ? [] : collectImageUrls(entry)
+  );
+  return [...directImages, ...nestedImages];
+}
+
+function notificationIncludesDraftContent(
+  params: unknown,
+  draft: QueuedTurnDraft,
+): boolean {
   const preview = draft.text.trim();
-  if (!preview) {
+  if (preview) {
+    return collectTextFragments(params).some((fragment) =>
+      fragment.includes(preview)
+    );
+  }
+
+  const attachmentUrls = draft.imageAttachments.map(
+    (attachment) => attachment.url,
+  );
+  if (attachmentUrls.length === 0) {
     return false;
   }
 
-  return collectTextFragments(params).some((fragment) =>
-    fragment.includes(preview)
-  );
+  const notificationImageUrls = new Set(collectImageUrls(params));
+  return attachmentUrls.every((url) => notificationImageUrls.has(url));
 }
 
 function isSteerInjectionOpportunity(method: string): boolean {
@@ -2174,7 +2212,7 @@ export function Composer(props: ComposerProps) {
       if (
         pendingSteer?.status === "steering" &&
         event.notification.method === "item/completed" &&
-        notificationIncludesDraftText(event.notification.params, pendingSteer)
+        notificationIncludesDraftContent(event.notification.params, pendingSteer)
       ) {
         setPendingSteer(undefined);
         setSteering(false);

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1631,6 +1631,146 @@ describe("Composer", () => {
     expect(screen.queryByText("Steering now")).not.toBeInTheDocument();
   });
 
+  it("clears an image-only pending steer after Codex acknowledges the image", async () => {
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex";
+          notification: {
+            method: string;
+            params: Record<string, unknown>;
+          };
+        }) => void)
+      | undefined;
+    const steerTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    }));
+    const imageFile = new File([new Uint8Array([1, 2, 3])], "steer.png", {
+      type: "image/png",
+    });
+
+    render(
+      <Composer
+        activeTurnId="turn-1"
+        backends={[
+          {
+            ...backendSummary("codex", {
+              models: [
+                {
+                  id: "gpt-5.5",
+                  label: "GPT-5.5",
+                  current: true,
+                  supportsReasoning: true,
+                  supportsSteering: true,
+                },
+              ],
+            }),
+            capabilities: {
+              ...backendSummary("codex").capabilities,
+              steerTurn: true,
+            },
+          },
+        ]}
+        desktopApi={{
+          onAgentEvent: (callback) => {
+            agentEventHandler = callback as typeof agentEventHandler;
+            return () => undefined;
+          },
+          steerTurn,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Steerable thread",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.paste(textarea, {
+      clipboardData: {
+        files: [],
+        items: [
+          {
+            kind: "file",
+            type: "image/png",
+            getAsFile: () => imageFile,
+          },
+        ],
+      },
+    });
+
+    expect(await screen.findByAltText("steer.png")).toBeInTheDocument();
+    fireEvent.keyDown(textarea, { key: "Enter", metaKey: true });
+
+    expect(screen.getByLabelText("Pending steer message")).toHaveTextContent(
+      "1 image"
+    );
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            item: {
+              type: "tool_call",
+              output: "ready for another instruction",
+            },
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(steerTurn).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        expectedTurnId: "turn-1",
+        input: [
+          {
+            type: "image",
+            url: expect.stringMatching(/^data:image\/png;base64,/),
+          },
+        ],
+      });
+    });
+    expect(screen.getByText("Steering now")).toBeInTheDocument();
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            item: {
+              type: "userMessage",
+              content: [
+                {
+                  type: "image",
+                  url: "data:image/png;base64,AQID",
+                },
+              ],
+            },
+          },
+        },
+      });
+    });
+
+    expect(
+      screen.queryByLabelText("Pending steer message")
+    ).not.toBeInTheDocument();
+  });
+
   it("restores a pending steer after navigating away and back", async () => {
     let agentEventHandler:
       | ((event: {


### PR DESCRIPTION
## Summary
Image-only steering messages now clear from the composer once Codex acknowledges the injected image. Previously the agent could receive and process the image while the desktop UI kept showing `Steering now`, because the acknowledgement matcher only looked for echoed text and image-only steers have none.

The matcher still uses text for text steers, and now falls back to matching the submitted image URL when the steer contains only attachments. The regression test covers the exact image-only flow: paste an image, steer it into an active turn, receive the acknowledged image item, and verify the pending steer card disappears.

## Verification
- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx -t "clears an image-only pending steer"`
- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
