### PR TITLE
fix(desktop): clear pairing messages from stable callback

### DIFF
--- a/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
@@ -1,4 +1,5 @@
 import {
+  useCallback,
   useEffect,
   useId,
   useRef,
@@ -1604,9 +1605,19 @@ function PairingTokenField(props: {
   const [scope, setScope] = useState<MessagingPairingScope>("user_dm");
   const [message, setMessage] = useState<string | undefined>(undefined);
   const [messageEntryId, setMessageEntryId] = useState<string | undefined>(undefined);
+  const messageEntryIdRef = useRef<string | undefined>(undefined);
   const [entries, setEntries] = useState<MessagingPairingEntry[]>([]);
   const [busyId, setBusyId] = useState<string | undefined>(undefined);
   const [error, setError] = useState<string | undefined>(undefined);
+
+  const setGeneratedMessage = useCallback(
+    (nextMessage: string | undefined, nextEntryId: string | undefined) => {
+      messageEntryIdRef.current = nextEntryId;
+      setMessage(nextMessage);
+      setMessageEntryId(nextEntryId);
+    },
+    [],
+  );
 
   const refresh = async () => {
     if (!props.desktopApi?.listMessagingPairingRequests) return;
@@ -1620,18 +1631,16 @@ function PairingTokenField(props: {
     void refresh();
     return props.desktopApi?.onMessagingPairingChanged?.((event) => {
       if (event.entry.platform !== props.platform) return;
-      if (event.entry.id === messageEntryId && event.entry.status !== "pending") {
-        setMessage(undefined);
-        setMessageEntryId(undefined);
+      if (event.entry.id === messageEntryIdRef.current && event.entry.status !== "pending") {
+        setGeneratedMessage(undefined, undefined);
       }
       void refresh();
     });
-  }, [messageEntryId, props.desktopApi, props.platform]);
+  }, [props.desktopApi, props.platform, setGeneratedMessage]);
 
   const selectScope = (nextScope: MessagingPairingScope) => {
     setScope(nextScope);
-    setMessage(undefined);
-    setMessageEntryId(undefined);
+    setGeneratedMessage(undefined, undefined);
   };
 
   const generate = async () => {
@@ -1643,8 +1652,7 @@ function PairingTokenField(props: {
         platform: props.platform,
         scope,
       });
-      setMessage(result.message);
-      setMessageEntryId(result.entry.id);
+      setGeneratedMessage(result.message, result.entry.id);
       await refresh();
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : String(caught));
@@ -1665,8 +1673,7 @@ function PairingTokenField(props: {
           entryId: entry.id,
         });
         if (result?.entry.id === messageEntryId) {
-          setMessage(undefined);
-          setMessageEntryId(undefined);
+          setGeneratedMessage(undefined, undefined);
         }
         if (result?.added) {
           await props.onSettingsChanged?.();
@@ -1674,8 +1681,7 @@ function PairingTokenField(props: {
       } else {
         const result = await props.desktopApi?.rejectMessagingPairing?.({ entryId: entry.id });
         if (result?.entry.id === messageEntryId) {
-          setMessage(undefined);
-          setMessageEntryId(undefined);
+          setGeneratedMessage(undefined, undefined);
         }
       }
       await refresh();

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -1602,9 +1602,9 @@ describe("SettingsScreen", () => {
       generatedAt: 1,
       expiresAt: 2,
     };
-    let pairingChanged:
-      | ((event: { at: number; entry: MessagingPairingEntry }) => void)
-      | undefined;
+    const pairingChangedCallbacks: Array<
+      (event: { at: number; entry: MessagingPairingEntry }) => void
+    > = [];
     const desktopApi = {
       generateMessagingPairingToken: vi.fn(async () => ({
         entry,
@@ -1614,7 +1614,7 @@ describe("SettingsScreen", () => {
       })),
       listMessagingPairingRequests: vi.fn(async () => ({ entries: [] })),
       onMessagingPairingChanged: vi.fn((callback) => {
-        pairingChanged = callback;
+        pairingChangedCallbacks.push(callback);
         return () => undefined;
       }),
     } as unknown as Parameters<typeof SettingsScreen>[0]["desktopApi"];
@@ -1628,20 +1628,24 @@ describe("SettingsScreen", () => {
       />,
     );
 
+    const initialPairingChangedCallbacks = [...pairingChangedCallbacks];
     fireEvent.click(screen.getAllByRole("button", { name: "Generate" })[0]!);
     expect(await screen.findByText(pairingMessage)).toBeInTheDocument();
+    expect(pairingChangedCallbacks).toHaveLength(initialPairingChangedCallbacks.length);
 
     act(() => {
-      pairingChanged?.({
-        at: 3,
-        entry: {
-          ...entry,
-          status: "observed",
-          observedAt: 3,
-          observedActor: { id: "8460800771", displayName: "Harold Hunt" },
-          observedChat: { id: "8460800771", kind: "dm", title: "Harold Hunt" },
-        },
-      });
+      for (const callback of initialPairingChangedCallbacks) {
+        callback({
+          at: 3,
+          entry: {
+            ...entry,
+            status: "observed",
+            observedAt: 3,
+            observedActor: { id: "8460800771", displayName: "Harold Hunt" },
+            observedChat: { id: "8460800771", kind: "dm", title: "Harold Hunt" },
+          },
+        });
+      }
     });
 
     // Bumped from the default 1000ms because CI runners under load take


### PR DESCRIPTION
## Summary

Pairing messages now clear as soon as the generated token is observed, even if the IPC event arrives before React has resubscribed the settings callback with the latest state.

The settings pairing field keeps the current generated entry id in a ref so the already-registered event callback can match observed or approved entries without waiting on effect timing. The regression test now broadcasts through the initially registered callbacks to cover the stale-closure path directly.

## Test Plan

- `pnpm test apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx -t "clears a generated pairing message after the token is observed"`
- `pnpm test apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
- `git diff --check`

Full `pnpm test` was also run. The fixed settings test passed, but the workspace run still failed with unrelated `desktop-main` 5s timeouts in git/worktree/environment/settings-service tests.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
