### PR TITLE
fix(desktop): show spellcheck context menu

### DIFF
--- a/apps/desktop/src/main/__tests__/app-bootstrap.test.ts
+++ b/apps/desktop/src/main/__tests__/app-bootstrap.test.ts
@@ -28,6 +28,8 @@ const mainMonitorStartMock = vi.fn();
 const mainMonitorStopMock = vi.fn();
 const shellOpenExternalMock = vi.fn();
 const clipboardWriteTextMock = vi.fn();
+const addWordToSpellCheckerDictionaryMock = vi.fn();
+const replaceMisspellingMock = vi.fn();
 const menuPopupMock = vi.fn();
 const buildFromTemplateMock = vi.fn((template: MenuItemConstructorOptions[]) => ({
   popup: menuPopupMock,
@@ -128,6 +130,10 @@ const BrowserWindowMock = vi.fn(function BrowserWindow(
           locationHref: "http://127.0.0.1:5173"
         })
       ),
+      replaceMisspelling: replaceMisspellingMock,
+      session: {
+        addWordToSpellCheckerDictionary: addWordToSpellCheckerDictionaryMock,
+      },
       debugger: {
         attach: vi.fn(),
         detach: vi.fn(),
@@ -196,6 +202,8 @@ describe("createMainWindow", () => {
     mainMonitorStopMock.mockReset();
     shellOpenExternalMock.mockReset();
     clipboardWriteTextMock.mockReset();
+    addWordToSpellCheckerDictionaryMock.mockReset();
+    replaceMisspellingMock.mockReset();
     menuPopupMock.mockReset();
     buildFromTemplateMock.mockClear();
     RendererHeapMonitorMock.mockClear();
@@ -345,6 +353,76 @@ describe("createMainWindow", () => {
 
     expect(clipboardWriteTextMock).toHaveBeenCalledWith(
       "file:///Users/huntharo/project/AGENTS.md:12"
+    );
+  });
+
+  it("shows native spelling suggestions when editable text is right-clicked", async () => {
+    const { createMainWindow } = await import("../window");
+    createMainWindow();
+
+    emitWebContentsEvent(
+      "context-menu",
+      {},
+      {
+        dictionarySuggestions: ["superseded", "supersede"],
+        editFlags: {
+          canCopy: true,
+          canCut: true,
+          canDelete: true,
+          canEditRichly: true,
+          canPaste: true,
+          canRedo: false,
+          canSelectAll: true,
+          canUndo: true,
+        },
+        isEditable: true,
+        misspelledWord: "superseeded",
+        x: 40,
+        y: 64,
+      }
+    );
+
+    const template = buildFromTemplateMock.mock.calls[0]?.[0];
+    expect(template).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "superseded",
+          click: expect.any(Function),
+        }),
+        expect.objectContaining({
+          label: "supersede",
+          click: expect.any(Function),
+        }),
+        expect.objectContaining({
+          label: 'Add "superseeded" to Dictionary',
+          click: expect.any(Function),
+        }),
+        expect.objectContaining({ role: "paste" }),
+      ])
+    );
+    expect(menuPopupMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        x: 40,
+        y: 64,
+      })
+    );
+
+    const suggestionItem = template?.find(
+      (item) => item.label === "superseded"
+    );
+    const suggestionClick = suggestionItem?.click as (() => void) | undefined;
+    suggestionClick?.();
+
+    expect(replaceMisspellingMock).toHaveBeenCalledWith("superseded");
+
+    const dictionaryItem = template?.find(
+      (item) => item.label === 'Add "superseeded" to Dictionary'
+    );
+    const dictionaryClick = dictionaryItem?.click as (() => void) | undefined;
+    dictionaryClick?.();
+
+    expect(addWordToSpellCheckerDictionaryMock).toHaveBeenCalledWith(
+      "superseeded"
     );
   });
 

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -1,4 +1,12 @@
-import { app, BrowserWindow, clipboard, Menu, shell } from "electron";
+import {
+  app,
+  BrowserWindow,
+  clipboard,
+  Menu,
+  shell,
+  type ContextMenuParams,
+  type MenuItemConstructorOptions,
+} from "electron";
 import { join, resolve } from "node:path";
 import { resolveHeapMonitorConfig } from "./diagnostics/heap-monitor-config";
 import { createHeapSession } from "./diagnostics/heap-session";
@@ -88,18 +96,12 @@ export function applyWindowSecurityHardening(window: BrowserWindow): void {
   });
 
   window.webContents.on("context-menu", (_event, params) => {
-    if (!params.linkURL) {
+    const template = buildNativeContextMenuTemplate(window, params);
+    if (template.length === 0) {
       return;
     }
 
-    const menu = Menu.buildFromTemplate([
-      {
-        label: "Copy Link",
-        click: () => {
-          clipboard.writeText(params.linkURL);
-        },
-      },
-    ]);
+    const menu = Menu.buildFromTemplate(template);
 
     menu.popup({
       window,
@@ -107,6 +109,96 @@ export function applyWindowSecurityHardening(window: BrowserWindow): void {
       y: params.y,
     });
   });
+}
+
+function buildNativeContextMenuTemplate(
+  window: BrowserWindow,
+  params: ContextMenuParams,
+): MenuItemConstructorOptions[] {
+  const template: MenuItemConstructorOptions[] = [];
+  const dictionarySuggestions = params.dictionarySuggestions ?? [];
+
+  for (const suggestion of dictionarySuggestions) {
+    template.push({
+      label: suggestion,
+      click: () => {
+        window.webContents.replaceMisspelling(suggestion);
+      },
+    });
+  }
+
+  if (params.misspelledWord) {
+    if (dictionarySuggestions.length > 0) {
+      template.push({ type: "separator" });
+    }
+    template.push({
+      label: `Add "${params.misspelledWord}" to Dictionary`,
+      click: () => {
+        window.webContents.session.addWordToSpellCheckerDictionary(
+          params.misspelledWord,
+        );
+      },
+    });
+  }
+
+  if (params.linkURL) {
+    appendSeparator(template);
+    template.push({
+      label: "Copy Link",
+      click: () => {
+        clipboard.writeText(params.linkURL);
+      },
+    });
+  }
+
+  if (params.isEditable) {
+    appendSeparator(template);
+    appendEditableMenuItems(template, params);
+  } else if (params.selectionText) {
+    appendSeparator(template);
+    template.push({ role: "copy" });
+  }
+
+  return template;
+}
+
+function appendEditableMenuItems(
+  template: MenuItemConstructorOptions[],
+  params: ContextMenuParams,
+): void {
+  template.push(
+    editableRole("undo", params, "canUndo"),
+    editableRole("redo", params, "canRedo"),
+    { type: "separator" },
+    editableRole("cut", params, "canCut"),
+    editableRole("copy", params, "canCopy"),
+    editableRole("paste", params, "canPaste"),
+    editableRole("delete", params, "canDelete"),
+    { type: "separator" },
+    editableRole("selectAll", params, "canSelectAll"),
+  );
+}
+
+function editableRole(
+  role: NonNullable<MenuItemConstructorOptions["role"]>,
+  params: ContextMenuParams,
+  flag: keyof ContextMenuParams["editFlags"],
+): MenuItemConstructorOptions {
+  return {
+    role,
+    enabled: params.editFlags?.[flag] ?? true,
+  };
+}
+
+function appendSeparator(template: MenuItemConstructorOptions[]): void {
+  if (template.length === 0) {
+    return;
+  }
+
+  const last = template[template.length - 1];
+  if (last?.type !== "separator") {
+    template.push({ type: "separator" });
+  }
 }
 
 /**

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -8704,6 +8704,22 @@ textarea,
   white-space: pre-wrap;
 }
 
+.composer-tiptap-input__editor::spelling-error {
+  text-decoration-line: underline;
+  text-decoration-style: wavy;
+  text-decoration-color: var(--status-error);
+  text-decoration-thickness: 1.1px;
+  text-underline-offset: 0.12em;
+}
+
+.composer-tiptap-input__editor::grammar-error {
+  text-decoration-line: underline;
+  text-decoration-style: wavy;
+  text-decoration-color: var(--status-warning);
+  text-decoration-thickness: 1.1px;
+  text-underline-offset: 0.12em;
+}
+
 .composer-tiptap-input__editor p {
   margin: 0;
 }


### PR DESCRIPTION
## Summary

Adds a native Electron context menu for editable text so misspelled words in the Tiptap composer can show spelling suggestions, replace the misspelling, and add words to the spellchecker dictionary.

The same handler now also exposes standard edit actions for editable fields while preserving the existing Copy Link action for renderer links. Spellchecker language selection remains OS/Electron-driven instead of forcing a fixed `lang` value.

## Tests

- `pnpm --filter @pwragent/desktop exec vitest run src/main/__tests__/app-bootstrap.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`