### PR TITLE
feat(desktop): confirm quit with active threads

### DIFF
--- a/apps/desktop/e2e/fixtures/electron-app.ts
+++ b/apps/desktop/e2e/fixtures/electron-app.ts
@@ -120,6 +120,7 @@ export async function launchElectronApp(params: {
       path.join(seedHomeRoot, ".pwragent/profiles/default/config.toml"),
       {
         general: {
+          confirmQuitWithInProgressThreads: false,
           appearance: {
             theme: params.appearance?.theme ?? "dark",
             density: params.appearance?.density ?? "mission-control",

--- a/apps/desktop/src/main/__tests__/auto-updater.test.ts
+++ b/apps/desktop/src/main/__tests__/auto-updater.test.ts
@@ -157,6 +157,39 @@ describe("auto updater", () => {
       manualResult,
     );
   });
+
+  it("routes downloaded update installs through requestQuit", async () => {
+    const updater = await importAutoUpdater();
+    const requestQuit = vi.fn(async (performQuit: () => void) => {
+      performQuit();
+      return true;
+    });
+
+    updater.initAutoUpdater();
+    updater.registerAppUpdateIpcHandlers({ requestQuit });
+    updateEventHandlers.get("update-downloaded")?.({ version: "1.0.0-beta.8" });
+    const install = ipcHandlers.get("app:install-update");
+
+    await expect(install?.()).resolves.toEqual({ status: "restarting" });
+    expect(requestQuit).toHaveBeenCalledTimes(1);
+    expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not install a downloaded update when quit confirmation is cancelled", async () => {
+    const updater = await importAutoUpdater();
+    const requestQuit = vi.fn(async () => false);
+
+    updater.initAutoUpdater();
+    updater.registerAppUpdateIpcHandlers({ requestQuit });
+    updateEventHandlers.get("update-downloaded")?.({ version: "1.0.0-beta.8" });
+    const install = ipcHandlers.get("app:install-update");
+
+    await expect(install?.()).resolves.toEqual({
+      status: "error",
+      message: "Update restart cancelled.",
+    });
+    expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled();
+  });
 });
 
 describe("compareSemver", () => {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -7068,6 +7068,57 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("reports in-progress quit threads across Codex active, queued, and ACP active turns", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok unavailable"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: null,
+    });
+
+    await registry.startTurn({
+      backend: "codex",
+      threadId: "thread-1",
+      input: [{ type: "text", text: "hello" }],
+    });
+    await registry.submitTurn({
+      backend: "codex",
+      threadId: "thread-1",
+      input: [{ type: "text", text: "queued" }],
+    });
+    await (
+      registry as unknown as {
+        emit(event: AgentEvent): Promise<void>;
+      }
+    ).emit({
+      backend: "acp:grok",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "acp-thread-1",
+          turnId: "acp-turn-1",
+          turn: {
+            id: "acp-turn-1",
+            status: "in_progress",
+            startedAt: Date.now(),
+          },
+        },
+      },
+    });
+
+    expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
+      count: 2,
+      threadIds: ["acp:grok:acp-thread-1", "codex:thread-1"],
+    });
+
+    await registry.close();
+  });
+
   it("applies generated Codex thread titles after starting turns", async () => {
     const titleService = {
       generateTitle: vi.fn(async () => ({

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -7101,9 +7101,9 @@ command = "pnpm dev"
         method: "turn/started",
         params: {
           threadId: "acp-thread-1",
-          turnId: "acp-turn-1",
+          turnId: "pending:acp-thread-1:123456",
           turn: {
-            id: "acp-turn-1",
+            id: "pending:acp-thread-1:123456",
             status: "in_progress",
             startedAt: Date.now(),
           },

--- a/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
@@ -18,6 +18,22 @@ describe("desktopSettingsPatchToEdits — general", () => {
       },
     ]);
   });
+
+  it("writes quit confirmation preference", () => {
+    const edits = desktopSettingsPatchToEdits({
+      general: {
+        confirmQuitWithInProgressThreads: false,
+      },
+    });
+
+    expect(edits).toEqual([
+      {
+        op: "set",
+        path: ["general", "confirm_quit_with_in_progress_threads"],
+        value: false,
+      },
+    ]);
+  });
 });
 
 describe("desktopSettingsPatchToEdits — experimental", () => {

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -31,6 +31,7 @@ describe("DesktopSettingsService", () => {
         'chat_reply_composer = "tiptap-chips"',
         "",
         "[general]",
+        "confirm_quit_with_in_progress_threads = false",
         "developer_mode = true",
         "notifications_enabled = true",
         "",
@@ -93,6 +94,10 @@ describe("DesktopSettingsService", () => {
     });
     expect(snapshot.general.developerMode).toEqual({
       value: true,
+      source: "config",
+    });
+    expect(snapshot.general.confirmQuitWithInProgressThreads).toEqual({
+      value: false,
       source: "config",
     });
     expect(snapshot.general.notificationsEnabled).toEqual({
@@ -292,6 +297,40 @@ describe("DesktopSettingsService", () => {
       value: true,
       source: "config",
     });
+  });
+
+  it("defaults quit confirmation to enabled and persists overrides", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    const service = new DesktopSettingsService({
+      configPath,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    const initial = await service.readSettings();
+    expect(initial.general.confirmQuitWithInProgressThreads).toEqual({
+      value: true,
+      source: "default",
+    });
+    expect(service.resolveConfirmQuitWithInProgressThreads()).toBe(true);
+
+    await service.writeConfigPatch({
+      general: {
+        confirmQuitWithInProgressThreads: false,
+      },
+    });
+
+    const saved = fs.readFileSync(configPath, "utf8");
+    expect(saved).toContain("[general]");
+    expect(saved).toContain("confirm_quit_with_in_progress_threads = false");
+    expect(
+      (await service.readSettings()).general.confirmQuitWithInProgressThreads,
+    ).toEqual({
+      value: false,
+      source: "config",
+    });
+    expect(service.resolveConfirmQuitWithInProgressThreads()).toBe(false);
   });
 
   it("round-trips appearance through writeConfigPatch + readSettings + readBootstrapAppearance", async () => {

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -42,6 +42,9 @@ const registerWindowPointerIpcHandlersMock = vi.fn();
 const disposeWindowPointerIpcHandlersMock = vi.fn();
 const initializeMainLoggerMock = vi.fn();
 const requestOpenSettingsMock = vi.fn();
+const requestQuitMock = vi.fn(async () => true);
+const allowImmediateQuitMock = vi.fn();
+const isQuitAllowedMock = vi.fn(() => true);
 const mainLogInfoMock = vi.fn();
 const mainLogWarnMock = vi.fn();
 const mainLogErrorMock = vi.fn();
@@ -149,6 +152,14 @@ vi.mock("../window", () => ({
 
 vi.mock("../window-open-settings", () => ({
   requestOpenSettings: requestOpenSettingsMock,
+}));
+
+vi.mock("../quit-manager", () => ({
+  appQuitManager: {
+    allowImmediateQuit: allowImmediateQuitMock,
+    isQuitAllowed: isQuitAllowedMock,
+  },
+  requestQuit: requestQuitMock,
 }));
 
 vi.mock("../ipc/app-server", () => ({
@@ -388,6 +399,11 @@ describe("bootstrapApp", () => {
     disposeWindowPointerIpcHandlersMock.mockReset();
     initializeMainLoggerMock.mockReset();
     requestOpenSettingsMock.mockReset();
+    requestQuitMock.mockReset();
+    requestQuitMock.mockResolvedValue(true);
+    allowImmediateQuitMock.mockReset();
+    isQuitAllowedMock.mockReset();
+    isQuitAllowedMock.mockReturnValue(true);
     mainLogInfoMock.mockReset();
     mainLogWarnMock.mockReset();
     mainLogErrorMock.mockReset();

--- a/apps/desktop/src/main/__tests__/menu.test.ts
+++ b/apps/desktop/src/main/__tests__/menu.test.ts
@@ -40,6 +40,7 @@ function buildTemplate(
       openProfilesSettings: options?.openProfilesSettings ?? vi.fn(),
       openSettings: options?.openSettings ?? vi.fn(),
       openWebsite: vi.fn(),
+      quit: vi.fn(),
       replayOnboarding: vi.fn(),
       showAboutPanel: vi.fn(),
       showChangelogWindow: vi.fn(),
@@ -215,6 +216,41 @@ describe("buildApplicationMenuTemplate", () => {
       // — we don't need the args here, just that our action gets called.
       (settings?.click as () => void | undefined)?.();
       expect(openSettings).toHaveBeenCalledOnce();
+    });
+
+    it("routes macOS Quit through the shared quit action", () => {
+      const quit = vi.fn();
+      const template = buildApplicationMenuTemplate({
+        appName: "PwrAgent",
+        developerMode: false,
+        isMac: true,
+        profiles: [],
+        windows: [],
+        actions: {
+          checkForUpdates: vi.fn(),
+          focusWindow: vi.fn(),
+          openDocumentation: vi.fn(),
+          openIssueReporter: vi.fn(),
+          openProfile: vi.fn(),
+          openProfilesSettings: vi.fn(),
+          openSettings: vi.fn(),
+          openWebsite: vi.fn(),
+          quit,
+          replayOnboarding: vi.fn(),
+          showAboutPanel: vi.fn(),
+          showChangelogWindow: vi.fn(),
+          showLicenseWindow: vi.fn(),
+          showLogsWindow: vi.fn(),
+          showThirdPartyNoticesWindow: vi.fn(),
+        },
+      });
+      const quitItem = submenuItems(template, "PwrAgent").find(
+        (item) => item.label === "Quit PwrAgent",
+      );
+
+      expect(quitItem?.accelerator).toBe("Command+Q");
+      (quitItem?.click as () => void | undefined)?.();
+      expect(quit).toHaveBeenCalledOnce();
     });
 
     it("surfaces Settings in Help → About cluster on non-Mac platforms", () => {

--- a/apps/desktop/src/main/__tests__/quit-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/quit-manager.test.ts
@@ -100,6 +100,42 @@ describe("createQuitManager", () => {
     expect(performQuit).not.toHaveBeenCalled();
   });
 
+  it("runs a later custom quit action after an already-open prompt confirms", async () => {
+    const { createQuitManager } = await import("../quit-manager");
+    let resolveConfirm!: (value: "manual-confirm") => void;
+    const performQuit = vi.fn();
+    const installUpdateAndQuit = vi.fn();
+    const confirm = vi.fn(
+      async () =>
+        await new Promise<"manual-confirm">((resolve) => {
+          resolveConfirm = resolve;
+        }),
+    );
+    const manager = createQuitManager({
+      confirm,
+      getConfirmationEnabled: () => true,
+      getInProgressThreads: () => ({
+        count: 1,
+        threadIds: ["codex:thread-1"],
+      }),
+      log: {},
+      performQuit,
+    });
+
+    const normalQuit = manager.requestQuit({ source: "menu" });
+    const updateQuit = manager.requestQuit({
+      performQuit: installUpdateAndQuit,
+      source: "update-install",
+    });
+    resolveConfirm("manual-confirm");
+
+    await expect(normalQuit).resolves.toBe(true);
+    await expect(updateQuit).resolves.toBe(true);
+    expect(confirm).toHaveBeenCalledTimes(1);
+    expect(performQuit).not.toHaveBeenCalled();
+    expect(installUpdateAndQuit).toHaveBeenCalledTimes(1);
+  });
+
   it("quits without prompting when confirmation is disabled", async () => {
     const { createQuitManager } = await import("../quit-manager");
     const performQuit = vi.fn();

--- a/apps/desktop/src/main/__tests__/quit-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/quit-manager.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("electron", () => ({
+  app: {
+    quit: vi.fn(),
+  },
+  BrowserWindow: {
+    getFocusedWindow: vi.fn(() => null),
+  },
+}));
+
+vi.mock("../app-server/backend-registry", () => ({
+  getDesktopBackendRegistry: vi.fn(() => ({
+    getInProgressThreadSnapshotForQuit: () => ({ count: 0, threadIds: [] }),
+  })),
+}));
+
+vi.mock("../settings/desktop-settings-singleton", () => ({
+  getDesktopSettingsService: vi.fn(() => ({
+    resolveConfirmQuitWithInProgressThreads: () => true,
+  })),
+}));
+
+vi.mock("../log", () => ({
+  getMainLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+  })),
+}));
+
+describe("createQuitManager", () => {
+  it("quits immediately when no threads are in progress", async () => {
+    const { createQuitManager } = await import("../quit-manager");
+    const performQuit = vi.fn();
+    const confirm = vi.fn();
+    const manager = createQuitManager({
+      confirm,
+      getConfirmationEnabled: () => true,
+      getInProgressThreads: () => ({ count: 0, threadIds: [] }),
+      log: {},
+      performQuit,
+    });
+
+    await expect(manager.requestQuit({ source: "menu" })).resolves.toBe(true);
+
+    expect(confirm).not.toHaveBeenCalled();
+    expect(performQuit).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows confirmation when threads are in progress", async () => {
+    const { createQuitManager } = await import("../quit-manager");
+    const performQuit = vi.fn();
+    const warn = vi.fn();
+    const confirm = vi.fn(async () => "manual-confirm" as const);
+    const manager = createQuitManager({
+      confirm,
+      getConfirmationEnabled: () => true,
+      getInProgressThreads: () => ({
+        count: 2,
+        threadIds: ["acp:grok:thread-2", "codex:thread-1"],
+      }),
+      log: { warn },
+      performQuit,
+    });
+
+    await expect(manager.requestQuit({ source: "before-quit" })).resolves.toBe(
+      true,
+    );
+
+    expect(confirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        countdownSeconds: 10,
+        inProgressThreadCount: 2,
+      }),
+    );
+    expect(performQuit).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      "quit requested with in-progress threads",
+      expect.objectContaining({ count: 2 }),
+    );
+  });
+
+  it("cancels quit when the operator stays open", async () => {
+    const { createQuitManager } = await import("../quit-manager");
+    const performQuit = vi.fn();
+    const confirm = vi.fn(async () => "manual-cancel" as const);
+    const manager = createQuitManager({
+      confirm,
+      getConfirmationEnabled: () => true,
+      getInProgressThreads: () => ({
+        count: 1,
+        threadIds: ["codex:thread-1"],
+      }),
+      log: {},
+      performQuit,
+    });
+
+    await expect(manager.requestQuit({ source: "ipc" })).resolves.toBe(false);
+
+    expect(performQuit).not.toHaveBeenCalled();
+  });
+
+  it("quits without prompting when confirmation is disabled", async () => {
+    const { createQuitManager } = await import("../quit-manager");
+    const performQuit = vi.fn();
+    const confirm = vi.fn();
+    const manager = createQuitManager({
+      confirm,
+      getConfirmationEnabled: () => false,
+      getInProgressThreads: () => ({
+        count: 1,
+        threadIds: ["codex:thread-1"],
+      }),
+      log: {},
+      performQuit,
+    });
+
+    await expect(manager.requestQuit({ source: "menu" })).resolves.toBe(true);
+
+    expect(confirm).not.toHaveBeenCalled();
+    expect(performQuit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -981,6 +981,44 @@ function buildActiveTurnKey(
   return `${backend}:${threadId}:${turnId}`;
 }
 
+function parseActiveTurnKey(
+  key: string,
+): { backend: AppServerBackendKind; threadId: string } | undefined {
+  if (key.startsWith("acp:")) {
+    const registrySeparator = key.indexOf(":", "acp:".length);
+    if (registrySeparator <= "acp:".length) return undefined;
+    const backend = key.slice(0, registrySeparator);
+    if (!isAcpBackendId(backend)) return undefined;
+    const threadId = parseThreadIdFromThreadTurnKeyBody(
+      key.slice(registrySeparator + 1),
+    );
+    return threadId ? { backend, threadId } : undefined;
+  }
+
+  const backendSeparator = key.indexOf(":");
+  if (backendSeparator <= 0) return undefined;
+  const backend = key.slice(0, backendSeparator);
+  if (backend !== "codex" && backend !== "grok") return undefined;
+  const threadId = parseThreadIdFromThreadTurnKeyBody(
+    key.slice(backendSeparator + 1),
+  );
+  return threadId ? { backend, threadId } : undefined;
+}
+
+function parseThreadIdFromThreadTurnKeyBody(body: string): string | undefined {
+  const pendingSeparator = body.indexOf(":pending:");
+  if (pendingSeparator > 0) {
+    const beforePending = body.slice(0, pendingSeparator);
+    const afterPending = body.slice(pendingSeparator + ":pending:".length);
+    if (beforePending === afterPending) {
+      return beforePending;
+    }
+  }
+  const turnSeparator = body.lastIndexOf(":");
+  if (turnSeparator <= 0) return undefined;
+  return body.slice(0, turnSeparator);
+}
+
 function buildHeadlessAutomationTurnKey(
   backend: AppServerBackendKind,
   threadId: string,
@@ -994,6 +1032,23 @@ function buildTurnStartReservationKey(
   threadId: string,
 ): string {
   return `${backend}\u0000${threadId}`;
+}
+
+function parseReservedAcpStartThreadKey(
+  key: string,
+): { backend: AppServerBackendKind; threadId: string } | undefined {
+  const [backend, threadId] = key.split("\u0000");
+  if (!backend || !threadId || !isAcpBackendId(backend)) {
+    return undefined;
+  }
+  return { backend, threadId };
+}
+
+function formatQuitThreadKey(
+  backend: AppServerBackendKind,
+  threadId: string,
+): string {
+  return `${backend}:${threadId}`;
 }
 
 function prependAutomationRuntimeContext(params: {
@@ -4026,6 +4081,42 @@ export class DesktopBackendRegistry {
     threadId: string;
   }): boolean {
     return this.threadTurnQueue.canStartImmediately(params);
+  }
+
+  getInProgressThreadSnapshotForQuit(): {
+    count: number;
+    threadIds: string[];
+  } {
+    const threadKeys = new Set<string>();
+    for (const key of this.activeTurnKeys) {
+      const parsed = parseActiveTurnKey(key);
+      if (parsed) {
+        threadKeys.add(formatQuitThreadKey(parsed.backend, parsed.threadId));
+      }
+    }
+    for (const key of this.activeCodexTurnModes.keys()) {
+      const threadId = parseThreadIdFromThreadTurnKeyBody(key);
+      if (threadId) {
+        threadKeys.add(formatQuitThreadKey("codex", threadId));
+      }
+    }
+    for (const threadId of this.reservedCodexStartThreadIds) {
+      threadKeys.add(formatQuitThreadKey("codex", threadId));
+    }
+    for (const key of this.reservedAcpStartThreadKeys) {
+      const parsed = parseReservedAcpStartThreadKey(key);
+      if (parsed) {
+        threadKeys.add(formatQuitThreadKey(parsed.backend, parsed.threadId));
+      }
+    }
+    for (const entry of this.threadTurnQueue.getAllQueuedEntries()) {
+      threadKeys.add(formatQuitThreadKey(entry.backend, entry.threadId));
+    }
+    const threadIds = [...threadKeys].sort();
+    return {
+      count: threadIds.length,
+      threadIds,
+    };
   }
 
   async startTurn(params: {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1010,7 +1010,7 @@ function parseThreadIdFromThreadTurnKeyBody(body: string): string | undefined {
   if (pendingSeparator > 0) {
     const beforePending = body.slice(0, pendingSeparator);
     const afterPending = body.slice(pendingSeparator + ":pending:".length);
-    if (beforePending === afterPending) {
+    if (beforePending === afterPending || afterPending.startsWith(`${beforePending}:`)) {
       return beforePending;
     }
   }

--- a/apps/desktop/src/main/app-server/thread-turn-queue.ts
+++ b/apps/desktop/src/main/app-server/thread-turn-queue.ts
@@ -144,6 +144,10 @@ export class ThreadTurnQueue {
     return [...this.queueFor(this.keyFor(params))];
   }
 
+  getAllQueuedEntries(): ThreadTurnQueueEntry[] {
+    return [...this.queuedEntries.values()].flatMap((queue) => [...queue]);
+  }
+
   cancelEntry(entryId: string, reason?: string): ThreadTurnQueueEntry | undefined {
     for (const [key, queue] of this.queuedEntries.entries()) {
       const index = queue.findIndex((entry) => entry.id === entryId);

--- a/apps/desktop/src/main/auto-updater.ts
+++ b/apps/desktop/src/main/auto-updater.ts
@@ -398,7 +398,9 @@ export function initAutoUpdater(): void {
   void checkForAppUpdatesNow("startup");
 }
 
-export function registerAppUpdateIpcHandlers(): void {
+export function registerAppUpdateIpcHandlers(options?: {
+  requestQuit?: (performQuit: () => void) => Promise<boolean>;
+}): void {
   ipcMain.removeHandler(APP_UPDATE_CHECK_CHANNEL);
   ipcMain.removeHandler(APP_UPDATE_STATUS_READ_CHANNEL);
   ipcMain.removeHandler(APP_UPDATE_INSTALL_CHANNEL);
@@ -424,7 +426,20 @@ export function registerAppUpdateIpcHandlers(): void {
       }
       try {
         log.info("installing downloaded update", { version });
-        autoUpdater.quitAndInstall();
+        const performQuit = (): void => {
+          autoUpdater.quitAndInstall();
+        };
+        if (options?.requestQuit) {
+          const quitAccepted = await options.requestQuit(performQuit);
+          if (!quitAccepted) {
+            return {
+              status: "error",
+              message: "Update restart cancelled.",
+            };
+          }
+        } else {
+          performQuit();
+        }
         return { status: "restarting" };
       } catch (err) {
         return {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -95,6 +95,7 @@ import { subscribersForChannel } from "./window-channels";
 import { requestOpenSettings } from "./window-open-settings";
 import { requestReplayOnboarding } from "./window-replay-onboarding";
 import { buildApplicationMenuTemplate } from "./menu";
+import { appQuitManager, requestQuit } from "./quit-manager";
 import {
   getAuxiliaryWindowMenuTitle,
   reapplyAuxiliaryWindowMenuBars,
@@ -224,6 +225,7 @@ function installProcessShutdownHandlers(): void {
   const handleSignal = (signal: NodeJS.Signals): void => {
     mainLog.info("main process shutdown signal received", { signal });
     disposeMainProcessResourcesSync();
+    appQuitManager.allowImmediateQuit();
     app.quit();
   };
   process.once("SIGTERM", handleSignal);
@@ -335,6 +337,9 @@ function installApplicationMenu(): void {
       },
       openWebsite: async () => {
         await shell.openExternal(PWRAGENT_HOMEPAGE_URL);
+      },
+      quit: () => {
+        void requestQuit({ source: "menu" });
       },
       replayOnboarding: () => {
         requestReplayOnboarding();
@@ -470,13 +475,20 @@ export function bootstrapApp(): void {
     registerApplicationIpcHandlers();
     registerAutomationIpcHandlers();
     registerAppMetadataIpcHandlers();
-    registerAppUpdateIpcHandlers();
+    registerAppUpdateIpcHandlers({
+      requestQuit: async (performQuit) =>
+        await requestQuit({ performQuit, source: "update-install" }),
+    });
     registerComposerDraftIpcHandlers();
     registerImageNormalizationIpcHandlers();
     registerPreloadLogIpcHandlers();
     registerProfilesIpcHandlers({ onProfilesChanged: installApplicationMenu });
     registerRendererErrorIpcHandlers();
-    registerBootInfoIpcHandlers();
+    registerBootInfoIpcHandlers({
+      requestQuit: async () => {
+        await requestQuit({ source: "ipc" });
+      },
+    });
     registerSettingsIpcHandlers(undefined, {
       onConfigPatchWritten: async (patch) => {
         if (patch.general?.developerMode !== undefined) {
@@ -557,11 +569,16 @@ export function bootstrapApp(): void {
 
   app.on("window-all-closed", () => {
     if (process.platform !== "darwin") {
-      app.quit();
+      void requestQuit({ source: "window-all-closed" });
     }
   });
 
-  app.on("before-quit", () => {
+  app.on("before-quit", (event) => {
+    if (!appQuitManager.isQuitAllowed()) {
+      event?.preventDefault();
+      void requestQuit({ source: "before-quit" });
+      return;
+    }
     disposeMainProcessResourcesSync();
   });
 }

--- a/apps/desktop/src/main/ipc/boot-info.ts
+++ b/apps/desktop/src/main/ipc/boot-info.ts
@@ -87,7 +87,9 @@ export function buildBootInfo(): DesktopBootInfo {
   }
 }
 
-export function registerBootInfoIpcHandlers(): void {
+export function registerBootInfoIpcHandlers(options?: {
+  requestQuit?: () => Promise<void> | void;
+}): void {
   ipcMain.removeHandler(APP_GET_BOOT_INFO_CHANNEL);
   ipcMain.handle(
     APP_GET_BOOT_INFO_CHANNEL,
@@ -105,6 +107,10 @@ export function registerBootInfoIpcHandlers(): void {
   // by which point the dev server's lifecycle no longer matters.
   ipcMain.removeHandler(APP_QUIT_CHANNEL);
   ipcMain.handle(APP_QUIT_CHANNEL, async (): Promise<void> => {
+    if (options?.requestQuit) {
+      await options.requestQuit();
+      return;
+    }
     app.quit();
   });
 

--- a/apps/desktop/src/main/menu.ts
+++ b/apps/desktop/src/main/menu.ts
@@ -10,6 +10,7 @@ export type ApplicationMenuActions = {
   openProfilesSettings: () => void;
   openSettings: () => void;
   openWebsite: () => void | Promise<void>;
+  quit: () => void | Promise<void>;
   replayOnboarding: () => void;
   showAboutPanel: () => void;
   showChangelogWindow: () => void;
@@ -77,7 +78,13 @@ function buildMacAppMenu(
       { role: "hideOthers" },
       { role: "unhide" },
       { type: "separator" },
-      { role: "quit" },
+      {
+        label: `Quit ${options.appName}`,
+        accelerator: "Command+Q",
+        click: () => {
+          void options.actions.quit();
+        },
+      },
     ],
   };
 }
@@ -89,7 +96,16 @@ function buildFileMenu(options: ApplicationMenuOptions): MenuItemConstructorOpti
       { role: "close" },
       ...(options.isMac
         ? []
-        : [{ type: "separator" as const }, { role: "quit" as const }]),
+        : [
+            { type: "separator" as const },
+            {
+              label: "Quit",
+              accelerator: "CmdOrCtrl+Q",
+              click: () => {
+                void options.actions.quit();
+              },
+            },
+          ]),
     ],
   };
 }

--- a/apps/desktop/src/main/quit-confirmation-dialog.ts
+++ b/apps/desktop/src/main/quit-confirmation-dialog.ts
@@ -1,0 +1,199 @@
+import { BrowserWindow } from "electron";
+
+export type QuitConfirmationDialogResult =
+  | "manual-confirm"
+  | "manual-cancel"
+  | "countdown-expired";
+
+export type QuitConfirmationDialogOptions = {
+  countdownSeconds: number;
+  inProgressThreadCount: number;
+  parent?: BrowserWindow | null;
+};
+
+export async function showQuitConfirmationDialog(
+  options: QuitConfirmationDialogOptions,
+): Promise<QuitConfirmationDialogResult> {
+  const token = `${Date.now()}-${Math.random()
+    .toString(36)
+    .slice(2)}`;
+  const navigationPrefix = `pwragent-quit-confirmation://${token}/`;
+  const parent =
+    options.parent && !options.parent.isDestroyed() ? options.parent : undefined;
+  const window = new BrowserWindow({
+    width: 460,
+    height: 312,
+    resizable: false,
+    minimizable: false,
+    maximizable: false,
+    fullscreenable: false,
+    show: false,
+    modal: Boolean(parent),
+    parent,
+    title: "Quit PwrAgent?",
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+    },
+  });
+
+  return await new Promise<QuitConfirmationDialogResult>((resolve) => {
+    let settled = false;
+    let hardCeiling: NodeJS.Timeout | undefined;
+
+    const finish = (result: QuitConfirmationDialogResult): void => {
+      if (settled) return;
+      settled = true;
+      if (hardCeiling) clearTimeout(hardCeiling);
+      if (!window.isDestroyed()) {
+        window.close();
+      }
+      resolve(result);
+    };
+
+    window.webContents.on("will-navigate", (event, url) => {
+      if (!url.startsWith(navigationPrefix)) {
+        return;
+      }
+      event.preventDefault();
+      const result = url.slice(navigationPrefix.length);
+      if (
+        result === "manual-confirm" ||
+        result === "manual-cancel" ||
+        result === "countdown-expired"
+      ) {
+        finish(result);
+      }
+    });
+    window.once("closed", () => finish("manual-cancel"));
+    hardCeiling = setTimeout(
+      () => finish("countdown-expired"),
+      options.countdownSeconds * 1000,
+    );
+
+    void window.loadURL(
+      `data:text/html;charset=utf-8,${encodeURIComponent(
+        buildQuitConfirmationHtml({
+          countdownSeconds: options.countdownSeconds,
+          inProgressThreadCount: options.inProgressThreadCount,
+          navigationPrefix,
+        }),
+      )}`,
+    );
+    window.once("ready-to-show", () => {
+      window.show();
+      window.focus();
+    });
+  });
+}
+
+function buildQuitConfirmationHtml(options: {
+  countdownSeconds: number;
+  inProgressThreadCount: number;
+  navigationPrefix: string;
+}): string {
+  const countText =
+    options.inProgressThreadCount === 1
+      ? "1 thread has an agent turn in progress."
+      : `${options.inProgressThreadCount} threads have agent turns in progress.`;
+  return `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+      body {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 24px;
+        background: Canvas;
+        color: CanvasText;
+      }
+      h1 {
+        font-size: 20px;
+        line-height: 1.25;
+        margin: 0 0 18px;
+        font-weight: 650;
+      }
+      p {
+        font-size: 14px;
+        line-height: 1.45;
+        margin: 0 0 14px;
+      }
+      .countdown {
+        font-weight: 650;
+        margin-top: 20px;
+      }
+      .actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: 10px;
+        margin-top: 26px;
+      }
+      button {
+        border-radius: 6px;
+        border: 1px solid ButtonBorder;
+        color: ButtonText;
+        background: ButtonFace;
+        min-width: 96px;
+        min-height: 32px;
+        padding: 0 14px;
+        font: inherit;
+      }
+      button.primary {
+        font-weight: 650;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Quit PwrAgent?</h1>
+    <p>${escapeHtml(countText)}</p>
+    <p>If you quit now, those turns will be interrupted. You'll need to find each thread when you restart and tell them to continue.</p>
+    <p class="countdown" id="countdown"></p>
+    <div class="actions">
+      <button id="stay" type="button">Stay Open</button>
+      <button id="quit" class="primary" type="button" autofocus>Quit Now</button>
+    </div>
+    <script>
+      const navigationPrefix = ${JSON.stringify(options.navigationPrefix)};
+      let remaining = ${JSON.stringify(options.countdownSeconds)};
+      const countdown = document.getElementById("countdown");
+      function send(result) {
+        window.location.href = navigationPrefix + result;
+      }
+      function render() {
+        countdown.textContent = "Auto-quitting in " + remaining + " second" + (remaining === 1 ? "" : "s") + "...";
+      }
+      render();
+      const timer = setInterval(() => {
+        remaining -= 1;
+        if (remaining <= 0) {
+          clearInterval(timer);
+          countdown.textContent = "Auto-quitting now...";
+          send("countdown-expired");
+          return;
+        }
+        render();
+      }, 1000);
+      document.getElementById("stay").addEventListener("click", () => send("manual-cancel"));
+      document.getElementById("quit").addEventListener("click", () => send("manual-confirm"));
+      window.addEventListener("keydown", (event) => {
+        if (event.key === "Escape") send("manual-cancel");
+        if (event.key === "Enter") send("manual-confirm");
+      });
+    </script>
+  </body>
+</html>`;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}

--- a/apps/desktop/src/main/quit-manager.ts
+++ b/apps/desktop/src/main/quit-manager.ts
@@ -48,6 +48,7 @@ export function createQuitManager(
   dependencies: QuitManagerDependencies,
 ): QuitManager {
   let quitAllowed = false;
+  let pendingPerformQuit: (() => void) | undefined;
   let promptPromise: Promise<boolean> | undefined;
 
   const requestQuit = async (options: RequestQuitOptions): Promise<boolean> => {
@@ -81,6 +82,9 @@ export function createQuitManager(
     }
 
     if (promptPromise) {
+      if (options.performQuit) {
+        pendingPerformQuit = options.performQuit;
+      }
       return await promptPromise;
     }
 
@@ -90,6 +94,7 @@ export function createQuitManager(
       threadIds: snapshot.threadIds,
     });
 
+    pendingPerformQuit = options.performQuit ?? dependencies.performQuit;
     promptPromise = (async () => {
       const resolution = await (dependencies.confirm ?? showQuitConfirmationDialog)({
         countdownSeconds: QUIT_CONFIRMATION_COUNTDOWN_SECONDS,
@@ -103,10 +108,12 @@ export function createQuitManager(
         threadIds: snapshot.threadIds,
       });
       if (resolution === "manual-cancel") {
+        pendingPerformQuit = undefined;
         return false;
       }
       quitAllowed = true;
-      (options.performQuit ?? dependencies.performQuit)();
+      (pendingPerformQuit ?? dependencies.performQuit)();
+      pendingPerformQuit = undefined;
       return true;
     })().finally(() => {
       promptPromise = undefined;

--- a/apps/desktop/src/main/quit-manager.ts
+++ b/apps/desktop/src/main/quit-manager.ts
@@ -1,0 +1,145 @@
+import { app, BrowserWindow } from "electron";
+import { getDesktopBackendRegistry } from "./app-server/backend-registry";
+import { getMainLogger } from "./log";
+import { getDesktopSettingsService } from "./settings/desktop-settings-singleton";
+import {
+  showQuitConfirmationDialog,
+  type QuitConfirmationDialogResult,
+} from "./quit-confirmation-dialog";
+
+export const QUIT_CONFIRMATION_COUNTDOWN_SECONDS = 10;
+
+export type QuitRequestSource =
+  | "before-quit"
+  | "ipc"
+  | "menu"
+  | "signal"
+  | "update-install"
+  | "window-all-closed";
+
+export type RequestQuitOptions = {
+  performQuit?: () => void;
+  source: QuitRequestSource;
+};
+
+export type QuitManagerDependencies = {
+  confirm?: (params: {
+    countdownSeconds: number;
+    inProgressThreadCount: number;
+    parent?: BrowserWindow | null;
+  }) => Promise<QuitConfirmationDialogResult>;
+  getConfirmationEnabled: () => boolean;
+  getFocusedWindow?: () => BrowserWindow | null;
+  getInProgressThreads: () => { count: number; threadIds: string[] };
+  log: {
+    info?: (message: string, meta?: Record<string, unknown>) => void;
+    warn?: (message: string, meta?: Record<string, unknown>) => void;
+  };
+  performQuit: () => void;
+};
+
+export type QuitManager = {
+  allowImmediateQuit: () => void;
+  isQuitAllowed: () => boolean;
+  requestQuit: (options: RequestQuitOptions) => Promise<boolean>;
+};
+
+export function createQuitManager(
+  dependencies: QuitManagerDependencies,
+): QuitManager {
+  let quitAllowed = false;
+  let promptPromise: Promise<boolean> | undefined;
+
+  const requestQuit = async (options: RequestQuitOptions): Promise<boolean> => {
+    if (quitAllowed) {
+      (options.performQuit ?? dependencies.performQuit)();
+      return true;
+    }
+
+    const snapshot = dependencies.getInProgressThreads();
+    if (snapshot.count <= 0) {
+      dependencies.log.info?.("quit requested with no in-progress threads", {
+        source: options.source,
+      });
+      quitAllowed = true;
+      (options.performQuit ?? dependencies.performQuit)();
+      return true;
+    }
+
+    if (!dependencies.getConfirmationEnabled()) {
+      dependencies.log.warn?.(
+        "quit requested with in-progress threads; confirmation disabled",
+        {
+          count: snapshot.count,
+          source: options.source,
+          threadIds: snapshot.threadIds,
+        },
+      );
+      quitAllowed = true;
+      (options.performQuit ?? dependencies.performQuit)();
+      return true;
+    }
+
+    if (promptPromise) {
+      return await promptPromise;
+    }
+
+    dependencies.log.warn?.("quit requested with in-progress threads", {
+      count: snapshot.count,
+      source: options.source,
+      threadIds: snapshot.threadIds,
+    });
+
+    promptPromise = (async () => {
+      const resolution = await (dependencies.confirm ?? showQuitConfirmationDialog)({
+        countdownSeconds: QUIT_CONFIRMATION_COUNTDOWN_SECONDS,
+        inProgressThreadCount: snapshot.count,
+        parent: dependencies.getFocusedWindow?.(),
+      });
+      dependencies.log.warn?.("quit confirmation resolved", {
+        count: snapshot.count,
+        resolution,
+        source: options.source,
+        threadIds: snapshot.threadIds,
+      });
+      if (resolution === "manual-cancel") {
+        return false;
+      }
+      quitAllowed = true;
+      (options.performQuit ?? dependencies.performQuit)();
+      return true;
+    })().finally(() => {
+      promptPromise = undefined;
+    });
+
+    return await promptPromise;
+  };
+
+  return {
+    allowImmediateQuit: () => {
+      quitAllowed = true;
+    },
+    isQuitAllowed: () => quitAllowed,
+    requestQuit,
+  };
+}
+
+const quitLog = getMainLogger("pwragent:quit");
+
+export const appQuitManager = createQuitManager({
+  getConfirmationEnabled: () =>
+    getDesktopSettingsService().resolveConfirmQuitWithInProgressThreads(),
+  getFocusedWindow: () => BrowserWindow.getFocusedWindow(),
+  getInProgressThreads: () =>
+    getDesktopBackendRegistry().getInProgressThreadSnapshotForQuit(),
+  log: quitLog,
+  performQuit: () => {
+    app.quit();
+  },
+});
+
+export async function requestQuit(
+  options: RequestQuitOptions,
+): Promise<boolean> {
+  return await appQuitManager.requestQuit(options);
+}

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -63,6 +63,7 @@ type StoredChatReplyComposer =
 
 export type DesktopSettingsConfig = {
   general?: {
+    confirmQuitWithInProgressThreads?: boolean;
     developerMode?: boolean;
     notificationsEnabled?: boolean;
     appearance?: {
@@ -418,6 +419,12 @@ export function desktopSettingsPatchToEdits(
   // write new values.
   if (patch.general?.developerMode !== undefined) {
     set(["general", "developer_mode"], patch.general.developerMode);
+  }
+  if (patch.general?.confirmQuitWithInProgressThreads !== undefined) {
+    set(
+      ["general", "confirm_quit_with_in_progress_threads"],
+      patch.general.confirmQuitWithInProgressThreads,
+    );
   }
   if (patch.general?.notificationsEnabled !== undefined) {
     set(["general", "notifications_enabled"], patch.general.notificationsEnabled);
@@ -906,6 +913,9 @@ function normalizeDesktopConfig(
 
   return pruneEmptyConfig({
     general: {
+      confirmQuitWithInProgressThreads: readBoolean(
+        general?.confirm_quit_with_in_progress_threads,
+      ),
       developerMode: readBoolean(general?.developer_mode),
       notificationsEnabled: readBoolean(general?.notifications_enabled),
       appearance: {
@@ -1108,6 +1118,8 @@ function pruneEmptyConfig(config: DesktopSettingsConfig): DesktopSettingsConfig 
   const pruned: DesktopSettingsConfig = {};
 
   const developerMode = config.general?.developerMode;
+  const confirmQuitWithInProgressThreads =
+    config.general?.confirmQuitWithInProgressThreads;
   const notificationsEnabled = config.general?.notificationsEnabled;
   const appearance = config.general?.appearance;
   const appearanceDefined = appearance && hasDefinedValue(appearance);
@@ -1115,6 +1127,7 @@ function pruneEmptyConfig(config: DesktopSettingsConfig): DesktopSettingsConfig 
   const messagingAcknowledgment = config.general?.messagingAcknowledgment;
   if (
     developerMode !== undefined ||
+    confirmQuitWithInProgressThreads !== undefined ||
     notificationsEnabled !== undefined ||
     appearanceDefined ||
     codexProfileModel !== undefined ||
@@ -1123,6 +1136,10 @@ function pruneEmptyConfig(config: DesktopSettingsConfig): DesktopSettingsConfig 
     pruned.general = {};
     if (developerMode !== undefined) {
       pruned.general.developerMode = developerMode;
+    }
+    if (confirmQuitWithInProgressThreads !== undefined) {
+      pruned.general.confirmQuitWithInProgressThreads =
+        confirmQuitWithInProgressThreads;
     }
     if (notificationsEnabled !== undefined) {
       pruned.general.notificationsEnabled = notificationsEnabled;

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -332,6 +332,10 @@ export class DesktopSettingsService {
       },
       secretStorage,
       general: {
+        confirmQuitWithInProgressThreads: this.resolveConfigBoolean(
+          config.general?.confirmQuitWithInProgressThreads,
+          true,
+        ),
         developerMode: this.resolveConfigBoolean(
           config.general?.developerMode,
           this.defaultDeveloperMode(),
@@ -700,6 +704,13 @@ export class DesktopSettingsService {
     return this.resolveConfigBoolean(
       this.readConfig().config.general?.developerMode,
       this.defaultDeveloperMode(),
+    ).value;
+  }
+
+  resolveConfirmQuitWithInProgressThreads(): boolean {
+    return this.resolveConfigBoolean(
+      this.readConfig().config.general?.confirmQuitWithInProgressThreads,
+      true,
     ).value;
   }
 

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -382,6 +382,10 @@ describe("App", () => {
         encrypted: false,
       },
       general: {
+        confirmQuitWithInProgressThreads: {
+          value: true,
+          source: "default",
+        },
         developerMode: {
           value: false,
           source: "default",

--- a/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
@@ -102,6 +102,7 @@ export function GeneralSettings(props: {
   saving: boolean;
   snapshot: DesktopSettingsSnapshot;
   onDeveloperModeChange: (value: boolean) => Promise<void>;
+  onConfirmQuitWithInProgressThreadsChange: (value: boolean) => Promise<void>;
   onPastedImageMaxPatchesChange: (value: number) => Promise<void>;
   onUpdateChannelChange: (value: DesktopUpdateChannel) => Promise<void>;
   onNotificationsEnabledChange: (value: boolean) => Promise<void>;
@@ -112,6 +113,8 @@ export function GeneralSettings(props: {
   >();
   const pastedImageMaxPatches =
     props.snapshot.imageUploads.pastedImageMaxPatches;
+  const confirmQuitWithInProgressThreads =
+    props.snapshot.general.confirmQuitWithInProgressThreads;
   const developerMode = props.snapshot.general.developerMode;
   const notificationsEnabled = props.snapshot.general.notificationsEnabled;
   const updateChannel = props.snapshot.updates.channel;
@@ -216,6 +219,30 @@ export function GeneralSettings(props: {
           </div>
         </SettingsSection>
       ) : null}
+
+      <SettingsSection
+        eyebrow="General"
+        title="Quit confirmation"
+        chip={sourceBadge(confirmQuitWithInProgressThreads)}
+      >
+        <div className="settings-fields">
+          <SettingsField
+            label="Confirm quit when threads are in progress"
+            sub="Warn before quitting while agent turns are running. The prompt auto-quits after a short countdown so shutdown can continue."
+            source={sourceBadge(confirmQuitWithInProgressThreads)}
+            control={
+              <SettingsSwitch
+                checked={confirmQuitWithInProgressThreads.value}
+                disabled={props.saving}
+                label="Confirm quit when threads are in progress"
+                onChange={(next) => {
+                  void props.onConfirmQuitWithInProgressThreadsChange(next);
+                }}
+              />
+            }
+          />
+        </div>
+      </SettingsSection>
 
       <SettingsSection
         eyebrow="General"

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -278,6 +278,13 @@ function SettingsSectionBody(props: {
             general: { developerMode },
           });
         }}
+        onConfirmQuitWithInProgressThreadsChange={async (
+          confirmQuitWithInProgressThreads: boolean,
+        ) => {
+          await props.settings.writeConfig({
+            general: { confirmQuitWithInProgressThreads },
+          });
+        }}
         onUpdateChannelChange={async (channel: DesktopUpdateChannel) => {
           await props.settings.writeConfig({
             updates: { channel },

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -50,6 +50,10 @@ function createSnapshot(
       encrypted: false,
     },
     general: {
+      confirmQuitWithInProgressThreads: {
+        value: true,
+        source: "default",
+      },
       developerMode: {
         value: false,
         source: "default",
@@ -365,6 +369,24 @@ describe("SettingsScreen", () => {
       "aria-checked",
       "false",
     );
+    expect(
+      screen.getByRole("switch", {
+        name: "Confirm quit when threads are in progress",
+      }),
+    ).toHaveAttribute("aria-checked", "true");
+    fireEvent.click(
+      screen.getByRole("switch", {
+        name: "Confirm quit when threads are in progress",
+      }),
+    );
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        general: {
+          confirmQuitWithInProgressThreads: false,
+        },
+      });
+    });
+
     fireEvent.click(screen.getByRole("switch", { name: "Developer Mode" }));
     await waitFor(() => {
       expect(settings.writeConfig).toHaveBeenCalledWith({

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -19,6 +19,10 @@ describe("desktop settings contracts", () => {
         encrypted: true,
       },
       general: {
+        confirmQuitWithInProgressThreads: {
+          value: true,
+          source: "default",
+        },
         developerMode: {
           value: false,
           source: "default",

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -223,6 +223,7 @@ export type DesktopAppearanceSnapshot = {
 };
 
 export type DesktopGeneralSettingsSnapshot = {
+  confirmQuitWithInProgressThreads: DesktopSettingsValue<boolean>;
   developerMode: DesktopSettingsValue<boolean>;
   notificationsEnabled: DesktopSettingsValue<boolean>;
   appearance: DesktopAppearanceSnapshot;
@@ -554,6 +555,7 @@ export type DesktopSettingsSnapshot = {
 
 export type DesktopSettingsConfigPatch = {
   general?: {
+    confirmQuitWithInProgressThreads?: boolean;
     developerMode?: boolean;
     notificationsEnabled?: boolean;
     appearance?: {


### PR DESCRIPTION
## Summary

- Add a shared main-process quit gate that counts active/queued Codex and ACP turns before quitting.
- Show a 10-second countdown confirmation dialog when threads are in progress, with manual confirm/cancel paths and warning-level audit logs.
- Route menu quit, before-quit, non-mac last-window quit, bootstrap quit, and update install/restart through the shared quit path.
- Add the Settings -> General opt-out toggle, defaulting confirmation on.

Closes #473.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/quit-manager.test.ts apps/desktop/src/main/__tests__/auto-updater.test.ts apps/desktop/src/main/__tests__/desktop-settings-service.test.ts apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts -t "reports in-progress quit threads"`
- `pnpm test apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx packages/shared/src/contracts/__tests__/settings.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/index.test.ts apps/desktop/src/main/__tests__/menu.test.ts apps/desktop/src/main/__tests__/thread-turn-queue.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm typecheck`
- `pnpm lint:boundaries`