### PR TITLE
feat(desktop): expose provider commands in composer

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -716,6 +716,57 @@ describe("AcpAgentClient", () => {
     ]);
   });
 
+  it("stores available command updates as session metadata", async () => {
+    const transport = new FakeAcpAgentTransport();
+    const client = new AcpAgentClient({
+      backendId: "acp:kimi",
+      store,
+      transport,
+      now: () => 1000,
+    });
+
+    await client.initialize();
+    const session = await client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+      title: "Kimi ACP",
+    });
+
+    transport.emitSessionUpdate(session.sessionId, {
+      sessionUpdate: "available_commands_update",
+      availableCommands: [
+        {
+          name: "skill:frontend-design",
+          description: "Load frontend-design",
+          aliases: ["fd", "frontend"],
+        },
+        {
+          name: "help",
+        },
+      ],
+    });
+
+    expect(store.getSession("acp:kimi", "session-1")?.availableCommands).toEqual([
+      {
+        name: "skill:frontend-design",
+        description: "Load frontend-design",
+        aliases: ["fd", "frontend"],
+        backend: "acp:kimi",
+        scope: "session",
+        source: "provider",
+      },
+      {
+        name: "help",
+        backend: "acp:kimi",
+        scope: "session",
+        source: "provider",
+      },
+    ]);
+    expect(readRawAcpSessionPayload("acp:kimi", "session-1")?.availableCommands).toEqual(
+      store.getSession("acp:kimi", "session-1")?.availableCommands,
+    );
+  });
+
   it("loads ACP transcript replay from provider session/load without storing it in the DB", async () => {
     const transport = new FakeAcpAgentTransport();
     const client = new AcpAgentClient({

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -9,6 +9,7 @@ import type {
   AcpBackendId,
   AgentEvent,
   AppServerNotification,
+  AppServerAvailableCommandSummary,
   AppServerPendingRequestNotification,
   AppServerSkillSummary,
   AppServerThreadReplay,
@@ -655,7 +656,11 @@ class MockBackendClient {
       initializeError?: Error;
       threads?: AppServerThreadSummary[];
       replay?: AppServerThreadReplay;
-      skills?: Array<{ cwd?: string; skills: AppServerSkillSummary[] }>;
+      skills?: Array<{
+        commands?: AppServerAvailableCommandSummary[];
+        cwd?: string;
+        skills: AppServerSkillSummary[];
+      }>;
       models?: Array<{
         id: string;
         label?: string;
@@ -736,7 +741,11 @@ class MockBackendClient {
     return { threadId: params.threadId };
   }
 
-  async listSkills(): Promise<Array<{ cwd?: string; skills: AppServerSkillSummary[] }>> {
+  async listSkills(): Promise<Array<{
+    commands?: AppServerAvailableCommandSummary[];
+    cwd?: string;
+    skills: AppServerSkillSummary[];
+  }>> {
     return this.options.skills ?? [];
   }
 
@@ -1233,6 +1242,54 @@ describe("DesktopBackendRegistry", () => {
         {
           skills: [],
           commands: session.availableCommands,
+        },
+      ],
+    });
+  });
+
+  it("adds Codex app-server method commands to listSkills", async () => {
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: {
+          methods: ["skills/list", "review/start", "thread/compact/start"],
+        },
+        skills: [
+          {
+            cwd: "/repo",
+            skills: [],
+          },
+        ],
+      }),
+      grokClient: new MockBackendClient({ threads: [] }),
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await expect(
+      registry.listSkills({
+        backend: "codex",
+        cwd: "/repo",
+      }),
+    ).resolves.toEqual({
+      data: [
+        {
+          cwd: "/repo",
+          skills: [],
+          commands: [
+            {
+              name: "review",
+              description: "Run a Codex code review.",
+              backend: "codex",
+              scope: "backend",
+              source: "provider",
+            },
+            {
+              name: "compact",
+              description: "Compact this thread's context.",
+              backend: "codex",
+              scope: "backend",
+              source: "provider",
+            },
+          ],
         },
       ],
     });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1247,7 +1247,7 @@ describe("DesktopBackendRegistry", () => {
     });
   });
 
-  it("adds Codex app-server method commands to listSkills", async () => {
+  it("adds Codex compact app-server command to listSkills", async () => {
     const registry = new DesktopBackendRegistry({
       codexClient: new MockBackendClient({
         initializeResult: {
@@ -1275,13 +1275,6 @@ describe("DesktopBackendRegistry", () => {
           cwd: "/repo",
           skills: [],
           commands: [
-            {
-              name: "review",
-              description: "Run a Codex code review.",
-              backend: "codex",
-              scope: "backend",
-              source: "provider",
-            },
             {
               name: "compact",
               description: "Compact this thread's context.",

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1195,6 +1195,49 @@ function createKimiAcpRegistry(options?: {
 }
 
 describe("DesktopBackendRegistry", () => {
+  it("returns ACP provider commands from session metadata", async () => {
+    const session: AcpSessionMetadata = {
+      backendId: "acp:kimi",
+      sessionId: "kimi-session-1",
+      title: "Kimi session",
+      createdAt: 1000,
+      updatedAt: 1000,
+      executionMode: "default",
+      status: "idle",
+      availableCommands: [
+        {
+          name: "skill:frontend-design",
+          description: "Load frontend-design",
+          aliases: ["fd"],
+          backend: "acp:kimi",
+          scope: "session",
+          source: "provider",
+        },
+      ],
+    };
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      grokClient: new MockBackendClient({ threads: [] }),
+      overlayStore: createOverlayStoreMock(),
+      acpAgentStore: createAcpAgentStoreMock([createKimiAgentRecord("acp:kimi")]),
+      acpSessionStore: createAcpSessionStoreMock([session]),
+    });
+
+    await expect(
+      registry.listSkills({
+        backend: "acp:kimi",
+        threadId: "kimi-session-1",
+      }),
+    ).resolves.toEqual({
+      data: [
+        {
+          skills: [],
+          commands: session.availableCommands,
+        },
+      ],
+    });
+  });
+
   it("reports backend availability and capabilities", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: {

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -851,6 +851,13 @@ class MockTransport implements JsonRpcTransport {
                     enabled: true,
                   },
                 ],
+                commands: [
+                  {
+                    name: "resume",
+                    description: "Resume the active task.",
+                    aliases: ["continue"],
+                  },
+                ],
                 errors: [],
               },
             ],
@@ -3795,6 +3802,15 @@ describe("CodexAppServerClient", () => {
 
     expect(skills).toEqual([
       {
+        commands: [
+          {
+            name: "resume",
+            description: "Resume the active task.",
+            aliases: ["continue"],
+            scope: "backend",
+            source: "provider",
+          },
+        ],
         cwd: "/Users/huntharo/pwrdrvr/PwrAgent",
         skills: [
           {

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -1,5 +1,6 @@
 import type {
   AcpBackendId,
+  AppServerAvailableCommandSummary,
   AppServerPendingRequestNotification,
   AppServerThreadReplay,
   AppServerThreadMessagePart,
@@ -584,6 +585,7 @@ export class AcpAgentClient {
     const sessionId = this.appSessionIdFor(protocolSessionId);
     const receivedAt = this.now();
     const activeTurn = this.activeTurns.get(sessionId);
+    const updateKind = readUpdateKind(update);
     const runtimeState = acpSessionRuntimeStateFromUpdate(update, receivedAt);
     if (runtimeState) {
       this.updateSessionRuntimeState(sessionId, runtimeState);
@@ -592,12 +594,14 @@ export class AcpAgentClient {
       ).catch(() => undefined);
       return;
     }
+    if (updateKind === "available_commands_update") {
+      this.updateSessionAvailableCommands(sessionId, update, receivedAt);
+    }
     const title = this.updateSessionTitleFromAcpUpdate(sessionId, update, receivedAt);
     if (isConversationHistoryUpdate(update)) {
       this.markSessionHasConversationHistory(sessionId, receivedAt);
     }
     this.appendHistoryUpdate(sessionId, receivedAt, update);
-    const updateKind = readUpdateKind(update);
     const isAssistantTextUpdate =
       updateKind === "agent_message_chunk" || updateKind === "agent_thought_chunk";
     const text = readUpdateText(update);
@@ -740,6 +744,25 @@ export class AcpAgentClient {
     this.options.store.upsertSession({
       ...metadata,
       hasConversationHistory: true,
+      updatedAt: Math.max(metadata.updatedAt, receivedAt),
+    });
+  }
+
+  private updateSessionAvailableCommands(
+    sessionId: string,
+    update: Record<string, unknown>,
+    receivedAt: number,
+  ): void {
+    const metadata = this.options.store.getSession(this.options.backendId, sessionId);
+    if (!metadata) {
+      return;
+    }
+    this.options.store.upsertSession({
+      ...metadata,
+      availableCommands: normalizeAvailableCommandsUpdate(
+        update,
+        this.options.backendId,
+      ),
       updatedAt: Math.max(metadata.updatedAt, receivedAt),
     });
   }
@@ -1033,6 +1056,60 @@ function readUpdateText(update: Record<string, unknown>): string | undefined {
     return update.output_text;
   }
   return readAcpContentText(update.content);
+}
+
+function normalizeAvailableCommandsUpdate(
+  update: Record<string, unknown>,
+  backend: AcpBackendId,
+): AppServerAvailableCommandSummary[] {
+  const rawCommands = Array.isArray(update.availableCommands)
+    ? update.availableCommands
+    : Array.isArray(update.available_commands)
+      ? update.available_commands
+      : [];
+  const commands = new Map<string, AppServerAvailableCommandSummary>();
+
+  for (const rawCommand of rawCommands) {
+    const command = asRecord(rawCommand);
+    const name = readNonEmptyString(command, "name");
+    if (!name) {
+      continue;
+    }
+    const description = readNonEmptyString(command, "description");
+    const aliases = readStringArray(command?.aliases);
+    commands.set(name, {
+      name,
+      backend,
+      scope: "session",
+      source: "provider",
+      ...(description ? { description } : {}),
+      ...(aliases.length > 0 ? { aliases } : {}),
+    });
+  }
+
+  return [...commands.values()];
+}
+
+function readNonEmptyString(
+  record: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
+  const value = record?.[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function readStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return [
+    ...new Set(
+      value
+        .filter((item): item is string => typeof item === "string")
+        .map((item) => item.trim())
+        .filter(Boolean),
+    ),
+  ];
 }
 
 function errorMessage(error: unknown): string {

--- a/apps/desktop/src/main/acp/acp-session-store.ts
+++ b/apps/desktop/src/main/acp/acp-session-store.ts
@@ -1,5 +1,6 @@
 import type {
   AcpBackendId,
+  AppServerAvailableCommandSummary,
   AppServerThreadTitleSource,
   BackendAcpSessionRuntimeState,
   ThreadExecutionMode,
@@ -21,6 +22,7 @@ export type AcpSessionMetadata = {
   updatedAt: number;
   executionMode: ThreadExecutionMode;
   acpRuntime?: BackendAcpSessionRuntimeState;
+  availableCommands?: AppServerAvailableCommandSummary[];
   status: "active" | "idle" | "failed" | "unknown";
   hasConversationHistory?: boolean;
   requiresAgentSessionRebind?: boolean;

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -1122,6 +1122,20 @@ export class AcpBackendAdapter {
             },
           });
         }
+        if (updateKind === "available_commands_update") {
+          await this.emit({
+            backend: agent.backendId,
+            notification: {
+              method: "thread/availableCommands/updated",
+              params: {
+                threadId: sessionId,
+                commands:
+                  this.getSession(agent.backendId, sessionId)?.availableCommands ??
+                  [],
+              },
+            },
+          });
+        }
         const kimiYoloExecutionMode =
           agent.registryId === "kimi"
             ? readKimiYoloExecutionModeFromText(readAcpUpdateText(update) ?? "")

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -2747,10 +2747,22 @@ export class DesktopBackendRegistry {
     backend?: AppServerBackendKind;
     cwd?: string;
     cwds?: string[];
+    threadId?: string;
   } = {}): Promise<Pick<AppServerListSkillsResponse, "data">> {
     const backend = params.backend ?? "codex";
     if (isAcpBackendId(backend)) {
-      return { data: [] };
+      if (!params.threadId) {
+        return { data: [] };
+      }
+      const session = this.acpBackend.getSession(backend, params.threadId);
+      return {
+        data: [
+          {
+            commands: session?.availableCommands ?? [],
+            skills: [],
+          },
+        ],
+      };
     }
 
     const data = await this.getClient(backend).listSkills({

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -26,6 +26,7 @@ import {
   type AppServerThreadReplay,
   type AppServerThreadSummary,
   type AppServerTurnInputItem,
+  type AppServerAvailableCommandSummary,
   type AppServerBackendKind,
   type AppServerCollaborationModeRequest,
   type BackendAccountSummary,
@@ -927,6 +928,64 @@ function buildCapabilities(methods: string[], backend: AppServerBackendKind): Ba
     approvalRequests: true,
     multiDirectoryThreads: backend === "codex",
   };
+}
+
+function backendMethodCommands(
+  backend: AppServerBackendKind,
+  methods: string[],
+): AppServerAvailableCommandSummary[] {
+  if (backend !== "codex") {
+    return [];
+  }
+
+  const supported = new Set(methods);
+  const assumeCodexAppServerSurface = methods.length === 0;
+  const commands: AppServerAvailableCommandSummary[] = [];
+
+  if (supported.has("review/start") || assumeCodexAppServerSurface) {
+    commands.push({
+      name: "review",
+      description: "Run a Codex code review.",
+      backend,
+      scope: "backend",
+      source: "provider",
+    });
+  }
+
+  if (supported.has("thread/compact/start") || assumeCodexAppServerSurface) {
+    commands.push({
+      name: "compact",
+      description: "Compact this thread's context.",
+      backend,
+      scope: "backend",
+      source: "provider",
+    });
+  }
+
+  return commands;
+}
+
+function mergeCommandSummaries(
+  current: AppServerAvailableCommandSummary[] | undefined,
+  incoming: AppServerAvailableCommandSummary[],
+): AppServerAvailableCommandSummary[] {
+  const merged: AppServerAvailableCommandSummary[] = [];
+  const seen = new Set<string>();
+
+  for (const command of [...(current ?? []), ...incoming]) {
+    const commandName = command.name.startsWith("/")
+      ? command.name.slice(1)
+      : command.name;
+    const key = `${command.backend ?? ""}:${commandName}`;
+    if (seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    merged.push(command);
+  }
+
+  return merged;
 }
 
 function buildCodexClientArgs(env?: NodeJS.ProcessEnv): string[] {
@@ -2765,12 +2824,41 @@ export class DesktopBackendRegistry {
       };
     }
 
-    const data = await this.getClient(backend).listSkills({
+    const client = this.getClient(backend);
+    const data = await client.listSkills({
       cwd: params.cwd,
       cwds: params.cwds,
     });
+    const commands = backendMethodCommands(
+      backend,
+      (await client.getInitializeResult()).methods ?? [],
+    );
 
-    return { data };
+    if (commands.length === 0) {
+      return { data };
+    }
+
+    if (data.length === 0) {
+      return {
+        data: [
+          {
+            commands,
+            skills: [],
+          },
+        ],
+      };
+    }
+
+    return {
+      data: data.map((entry, index) =>
+        index === 0
+          ? {
+              ...entry,
+              commands: mergeCommandSummaries(entry.commands, commands),
+            }
+          : entry,
+      ),
+    };
   }
 
   private async listAllInstalledAcpThreads(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -942,16 +942,6 @@ function backendMethodCommands(
   const assumeCodexAppServerSurface = methods.length === 0;
   const commands: AppServerAvailableCommandSummary[] = [];
 
-  if (supported.has("review/start") || assumeCodexAppServerSurface) {
-    commands.push({
-      name: "review",
-      description: "Run a Codex code review.",
-      backend,
-      scope: "backend",
-      source: "provider",
-    });
-  }
-
   if (supported.has("thread/compact/start") || assumeCodexAppServerSurface) {
     commands.push({
       name: "compact",

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -4,6 +4,7 @@ import {
   shortenDerivedThreadTitle,
 } from "@pwragent/shared";
 import type {
+  AppServerAvailableCommandSummary,
   AppServerNotification,
   AppServerPendingRequestNotification,
   AppServerThreadCommandDetail,
@@ -161,6 +162,7 @@ type RawCodexThreadListPage = {
 };
 
 type SkillCatalogEntry = {
+  commands?: AppServerAvailableCommandSummary[];
   cwd?: string;
   skills: AppServerSkillSummary[];
 };
@@ -2929,6 +2931,28 @@ function extractSkillSummary(value: unknown): AppServerSkillSummary | undefined 
   };
 }
 
+function extractAvailableCommandSummary(
+  value: unknown,
+): AppServerAvailableCommandSummary | undefined {
+  const record = asRecord(value);
+  if (!record) {
+    return undefined;
+  }
+
+  const name = pickString(record, ["name", "id", "command"]);
+  if (!name) {
+    return undefined;
+  }
+
+  return {
+    name,
+    description: pickString(record, ["description", "summary"]),
+    aliases: pickStringArray(record.aliases),
+    scope: "backend",
+    source: "provider",
+  };
+}
+
 function extractSkillCatalog(value: unknown): SkillCatalogEntry[] {
   const record = asRecord(value);
   const data = Array.isArray(record?.data)
@@ -2952,14 +2976,39 @@ function extractSkillCatalog(value: unknown): SkillCatalogEntry[] {
       const normalized = extractSkillSummary(skill);
       return normalized ? [normalized] : [];
     });
+    const rawCommands = Array.isArray(entryRecord.commands)
+      ? entryRecord.commands
+      : Array.isArray(entryRecord.availableCommands)
+        ? entryRecord.availableCommands
+        : [];
+    const commands = rawCommands.flatMap((command) => {
+      const normalized = extractAvailableCommandSummary(command);
+      return normalized ? [normalized] : [];
+    });
 
     return [
       {
+        ...(commands.length > 0 ? { commands } : {}),
         cwd: pickString(entryRecord, ["cwd"]),
         skills
       }
     ];
   });
+}
+
+function pickStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const strings = [
+    ...new Set(
+      value
+        .filter((item): item is string => typeof item === "string")
+        .map((item) => item.trim())
+        .filter(Boolean),
+    ),
+  ];
+  return strings.length > 0 ? strings : undefined;
 }
 
 function extractModelOptions(value: unknown): BackendModelOption[] {

--- a/apps/desktop/src/main/grok-app-server/client.ts
+++ b/apps/desktop/src/main/grok-app-server/client.ts
@@ -10,6 +10,7 @@ import {
   shortenDerivedThreadTitle,
 } from "@pwragent/shared";
 import type {
+  AppServerAvailableCommandSummary,
   AppServerNotification,
   AppServerPendingRequestNotification,
   AppServerThreadEntry,
@@ -96,6 +97,7 @@ type RawThreadSummary = {
 };
 
 type SkillCatalogEntry = {
+  commands?: AppServerAvailableCommandSummary[];
   cwd?: string;
   skills: AppServerSkillSummary[];
 };
@@ -713,14 +715,62 @@ function extractSkillsList(value: unknown): SkillCatalogEntry[] {
         },
       ];
     });
+    const rawCommands = Array.isArray(record.commands)
+      ? record.commands
+      : Array.isArray(record.availableCommands)
+        ? record.availableCommands
+        : [];
+    const commands = rawCommands.flatMap((command): AppServerAvailableCommandSummary[] => {
+      if (!command || typeof command !== "object" || Array.isArray(command)) {
+        return [];
+      }
+
+      const item = command as Record<string, unknown>;
+      const name =
+        typeof item.name === "string" && item.name.trim()
+          ? item.name.trim()
+          : typeof item.command === "string" && item.command.trim()
+            ? item.command.trim()
+            : "";
+      if (!name) {
+        return [];
+      }
+
+      return [
+        {
+          name,
+          description:
+            typeof item.description === "string" ? item.description : undefined,
+          aliases: readStringArray(item.aliases),
+          scope: "backend",
+          source: "provider",
+        },
+      ];
+    });
 
     return [
       {
+        ...(commands.length > 0 ? { commands } : {}),
         cwd: typeof record.cwd === "string" ? record.cwd : undefined,
         skills,
       },
     ];
   });
+}
+
+function readStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const strings = [
+    ...new Set(
+      value
+        .filter((item): item is string => typeof item === "string")
+        .map((item) => item.trim())
+        .filter(Boolean),
+    ),
+  ];
+  return strings.length > 0 ? strings : undefined;
 }
 
 function extractModelOptions(value: unknown): BackendModelOption[] {

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -6,6 +6,8 @@ import type {
   CancelThreadExecutionModeQueueResponse,
   CheckThreadBranchDriftRequest,
   CheckThreadBranchDriftResponse,
+  CompactThreadRequest,
+  CompactThreadResponse,
   MaterializeDirectoryLaunchpadRequest,
   MaterializeDirectoryLaunchpadResponse,
   InterruptTurnRequest,
@@ -48,6 +50,7 @@ import {
   AGENT_EVENT_CHANNEL,
   AGENT_LATEST_CODEX_CONFIG_WARNING_CHANNEL,
   AGENT_CHECK_THREAD_BRANCH_DRIFT_CHANNEL,
+  AGENT_COMPACT_THREAD_CHANNEL,
   AGENT_INTERRUPT_TURN_CHANNEL,
   AGENT_MATERIALIZE_DIRECTORY_LAUNCHPAD_CHANNEL,
   AGENT_QUEUE_THREAD_EXECUTION_MODE_CHANNEL,
@@ -380,6 +383,38 @@ export function registerAgentIpcHandlers(): void {
     },
   );
 
+  ipcMain.removeHandler(AGENT_COMPACT_THREAD_CHANNEL);
+  ipcMain.handle(
+    AGENT_COMPACT_THREAD_CHANNEL,
+    async (
+      _event,
+      request: CompactThreadRequest
+    ): Promise<CompactThreadResponse> => {
+      logDebug("compactThread", {
+        backend: request.backend,
+        threadId: request.threadId,
+      });
+
+      try {
+        const response = await registry.compactThread(request);
+        logDebug("compactThreadResult", {
+          backend: response.backend,
+          threadId: response.threadId,
+          turnId: response.turnId,
+          itemId: response.itemId,
+        });
+        return response;
+      } catch (error) {
+        appServerLog.error("compactThread failed", {
+          backend: request.backend,
+          threadId: request.threadId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        throw error;
+      }
+    },
+  );
+
   ipcMain.removeHandler(AGENT_INTERRUPT_TURN_CHANNEL);
   ipcMain.handle(
     AGENT_INTERRUPT_TURN_CHANNEL,
@@ -597,6 +632,7 @@ export function disposeAgentIpcHandlers(): void {
   ipcMain.removeHandler(BACKEND_LIST_CHANNEL);
   ipcMain.removeHandler(AGENT_START_THREAD_CHANNEL);
   ipcMain.removeHandler(AGENT_START_REVIEW_CHANNEL);
+  ipcMain.removeHandler(AGENT_COMPACT_THREAD_CHANNEL);
   ipcMain.removeHandler(AGENT_START_TURN_CHANNEL);
   ipcMain.removeHandler(AGENT_INTERRUPT_TURN_CHANNEL);
   ipcMain.removeHandler(AGENT_STEER_TURN_CHANNEL);

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -370,6 +370,7 @@ class DesktopAppServerService {
       backend,
       cwd: request.cwd,
       cwds: request.cwds,
+      threadId: request.threadId,
     });
 
     logDebug("listSkills", {
@@ -377,6 +378,10 @@ class DesktopAppServerService {
       cwd: request.cwd ?? null,
       cwds: request.cwds ?? [],
       entries: response.data.length,
+      commands: response.data.reduce(
+        (count, entry) => count + (entry.commands?.length ?? 0),
+        0,
+      ),
       skills: response.data.reduce((count, entry) => count + entry.skills.length, 0),
     });
 

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -51,6 +51,8 @@ import type {
   AppServerReadThreadResponse,
   CheckThreadBranchDriftRequest,
   CheckThreadBranchDriftResponse,
+  CompactThreadRequest,
+  CompactThreadResponse,
   CodexEnvironmentSetupProgressEvent,
   CreateAutomationRequest,
   GetNavigationSnapshotRequest,
@@ -191,6 +193,7 @@ import {
   AGENT_LATEST_CODEX_CONFIG_WARNING_CHANNEL,
   APPEARANCE_CHANGED_EVENT_CHANNEL,
   AGENT_CHECK_THREAD_BRANCH_DRIFT_CHANNEL,
+  AGENT_COMPACT_THREAD_CHANNEL,
   AGENT_INTERRUPT_TURN_CHANNEL,
   AGENT_MATERIALIZE_DIRECTORY_LAUNCHPAD_CHANNEL,
   AGENT_QUEUE_THREAD_EXECUTION_MODE_CHANNEL,
@@ -605,6 +608,10 @@ const desktopApi = Object.freeze({
     request: StartReviewRequest
   ): Promise<StartReviewResponse> =>
     await ipcRenderer.invoke(AGENT_START_REVIEW_CHANNEL, request),
+  compactThread: async (
+    request: CompactThreadRequest
+  ): Promise<CompactThreadResponse> =>
+    await ipcRenderer.invoke(AGENT_COMPACT_THREAD_CHANNEL, request),
   startTurn: async (
     request: StartTurnRequest
   ): Promise<StartTurnResponse> =>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -386,6 +386,7 @@ function DesktopAppShell(props: {
     setThreadModelSettingsError: navigation.setThreadModelSettingsError,
     skillError: skills.error,
     skillLoading: skills.loading,
+    providerCommands: skills.providerCommands,
     skills: skills.skills,
     transcriptEntries: session.entries,
     transcriptError: session.error,

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -13,6 +13,7 @@ import {
 import { createPortal, flushSync } from "react-dom";
 import type { JSONContent } from "@tiptap/react";
 import type {
+  AppServerAvailableCommandSummary,
   AppServerCollaborationModeRequest,
   AppServerReviewTarget,
   AppServerSkillSummary,
@@ -149,6 +150,7 @@ type ComposerProps = {
   setExecutionModeError?: string;
   skillError?: string;
   skillLoading?: boolean;
+  providerCommands?: AppServerAvailableCommandSummary[];
   skills: AppServerSkillSummary[];
   thread?: NavigationThreadSummary;
   updatingExecutionMode?: ThreadExecutionMode;
@@ -234,6 +236,7 @@ type SlashCommandSuggestion = {
   id: string;
   insertText: string;
   label: string;
+  aliases?: string[];
 };
 
 type AutocompleteKind = "skills" | "slash";
@@ -275,6 +278,21 @@ const SLASH_COMMANDS: SlashCommandSuggestion[] = [
     description: "Review current staged, unstaged, and untracked changes",
   },
 ];
+
+function providerCommandToSlashSuggestion(
+  command: AppServerAvailableCommandSummary,
+): SlashCommandSuggestion {
+  const commandName = command.name.startsWith("/")
+    ? command.name.slice(1)
+    : command.name;
+  return {
+    id: `provider:${command.backend ?? "unknown"}:${commandName}`,
+    label: `/${commandName}`,
+    insertText: `/${commandName}`,
+    description: command.description ?? "Provider command",
+    aliases: command.aliases,
+  };
+}
 
 const REVIEW_TARGET_OPTIONS: Array<{
   description: string;
@@ -1911,18 +1929,26 @@ export function Composer(props: ComposerProps) {
       })
       .map((match) => match.skill);
   }, [props.skills, trigger]);
+  const slashCommandSuggestions = useMemo(() => {
+    const commands = props.providerCommands?.map(providerCommandToSlashSuggestion) ?? [];
+    return supportsReview ? [...SLASH_COMMANDS, ...commands] : commands;
+  }, [props.providerCommands, supportsReview]);
   const filteredSlashCommands = useMemo(() => {
-    if (!slashTrigger || !supportsReview) {
+    if (!slashTrigger) {
       return [];
     }
 
     const typed = draft.slice(slashTrigger.start, slashTrigger.end).trim().toLowerCase();
-    return SLASH_COMMANDS.filter(
-      (command) =>
+    const query = typed.slice(1);
+    return slashCommandSuggestions.filter((command) => {
+      const aliases = command.aliases ?? [];
+      return (
         command.label.toLowerCase().startsWith(typed) ||
-        command.description.toLowerCase().includes(typed.slice(1))
-    );
-  }, [draft, slashTrigger, supportsReview]);
+        aliases.some((alias) => `/${alias}`.toLowerCase().startsWith(typed)) ||
+        command.description.toLowerCase().includes(query)
+      );
+    });
+  }, [draft, slashCommandSuggestions, slashTrigger]);
   const availableAutocompleteKind: AutocompleteKind | undefined = trigger && filteredSkills.length > 0
     ? "skills"
     : slashTrigger && filteredSlashCommands.length > 0
@@ -2119,12 +2145,12 @@ export function Composer(props: ComposerProps) {
   }, [activeAutocompleteIndex, autocompleteKind]);
 
   useEffect(() => {
-    if (!trigger) {
+    if (!trigger && !slashTrigger) {
       return;
     }
 
     void props.onEnsureSkillsLoaded?.();
-  }, [props.onEnsureSkillsLoaded, trigger]);
+  }, [props.onEnsureSkillsLoaded, slashTrigger, trigger]);
 
   useEffect(() => {
     if (!isLaunchpad) {

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -3761,19 +3761,7 @@ export function Composer(props: ComposerProps) {
     );
   };
 
-  const runExactSlashCommand = (): boolean => {
-    if (autocompleteKind !== "slash" || !slashTrigger) {
-      return false;
-    }
-
-    const currentSlashText = `/${slashTrigger.query}`.toLowerCase();
-    const command = filteredSlashCommands.find((candidate) =>
-      slashCommandMatchesText(candidate, currentSlashText)
-    );
-    if (!command) {
-      return false;
-    }
-
+  const runSlashCommand = (command: SlashCommandSuggestion): boolean => {
     if (command.id === "review-current") {
       enterReviewComposer();
       return true;
@@ -3785,6 +3773,25 @@ export function Composer(props: ComposerProps) {
     }
 
     return false;
+  };
+
+  const getActiveSlashCommand = (): SlashCommandSuggestion | undefined => {
+    if (autocompleteKind !== "slash") {
+      return undefined;
+    }
+
+    const currentSlashText = slashTrigger
+      ? `/${slashTrigger.query}`.toLowerCase()
+      : undefined;
+    return (
+      (currentSlashText
+        ? filteredSlashCommands.find((candidate) =>
+            slashCommandMatchesText(candidate, currentSlashText)
+          )
+        : undefined) ??
+      filteredSlashCommands[activeSlashIndex] ??
+      filteredSlashCommands[0]
+    );
   };
 
   const restoreDeletedSkillToken = (
@@ -3892,7 +3899,14 @@ export function Composer(props: ComposerProps) {
         return;
       }
       event.preventDefault();
-      if (event.key === "Enter" && runExactSlashCommand()) {
+      const slashCommand =
+        event.key === "Enter" && autocompleteKind === "slash"
+          ? getActiveSlashCommand()
+          : undefined;
+      if (
+        slashCommand &&
+        runSlashCommand(slashCommand)
+      ) {
         return;
       }
       commitActiveAutocomplete();

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -232,11 +232,13 @@ type ModelOption = NonNullable<
 >[number];
 
 type SlashCommandSuggestion = {
+  aliases?: string[];
   description: string;
   id: string;
   insertText: string;
   label: string;
-  aliases?: string[];
+  source: "provider" | "pwragent";
+  sourceLabel: string;
 };
 
 type AutocompleteKind = "skills" | "slash";
@@ -276,21 +278,29 @@ const SLASH_COMMANDS: SlashCommandSuggestion[] = [
     label: "/review",
     insertText: "/review",
     description: "Review current staged, unstaged, and untracked changes",
+    source: "pwragent",
+    sourceLabel: "PwrAgent",
   },
 ];
 
 function providerCommandToSlashSuggestion(
   command: AppServerAvailableCommandSummary,
+  backends: BackendSummary[] = [],
 ): SlashCommandSuggestion {
   const commandName = command.name.startsWith("/")
     ? command.name.slice(1)
     : command.name;
+  const sourceLabel = command.backend
+    ? formatBackendLabel(command.backend, backends)
+    : "Provider";
   return {
     id: `provider:${command.backend ?? "unknown"}:${commandName}`,
     label: `/${commandName}`,
     insertText: `/${commandName}`,
     description: command.description ?? "Provider command",
     aliases: command.aliases,
+    source: "provider",
+    sourceLabel,
   };
 }
 
@@ -1386,6 +1396,17 @@ export function Composer(props: ComposerProps) {
     backend?.kind.startsWith("acp:") === true
       ? backend.capabilities.startReview !== false
       : true;
+  const supportsCompactCommand = Boolean(
+    props.providerCommands?.some((command) => {
+      const commandName = command.name.startsWith("/")
+        ? command.name.slice(1)
+        : command.name;
+      return (
+        commandName === "compact" &&
+        (!props.thread || !command.backend || command.backend === props.thread.source)
+      );
+    })
+  );
 
   const selectionStart = Math.min(
     inputRef.current?.selectionStart ?? draft.length,
@@ -1930,16 +1951,19 @@ export function Composer(props: ComposerProps) {
       .map((match) => match.skill);
   }, [props.skills, trigger]);
   const slashCommandSuggestions = useMemo(() => {
-    const commands = props.providerCommands?.map(providerCommandToSlashSuggestion) ?? [];
+    const commands =
+      props.providerCommands?.map((command) =>
+        providerCommandToSlashSuggestion(command, props.backends)
+      ) ?? [];
     return supportsReview ? [...SLASH_COMMANDS, ...commands] : commands;
-  }, [props.providerCommands, supportsReview]);
+  }, [props.backends, props.providerCommands, supportsReview]);
   const filteredSlashCommands = useMemo(() => {
     if (!slashTrigger) {
       return [];
     }
 
-    const typed = draft.slice(slashTrigger.start, slashTrigger.end).trim().toLowerCase();
-    const query = typed.slice(1);
+    const typed = `/${slashTrigger.query}`.toLowerCase();
+    const query = slashTrigger.query.toLowerCase();
     return slashCommandSuggestions.filter((command) => {
       const aliases = command.aliases ?? [];
       return (
@@ -1948,7 +1972,7 @@ export function Composer(props: ComposerProps) {
         command.description.toLowerCase().includes(query)
       );
     });
-  }, [draft, slashCommandSuggestions, slashTrigger]);
+  }, [slashCommandSuggestions, slashTrigger?.query]);
   const availableAutocompleteKind: AutocompleteKind | undefined = trigger && filteredSkills.length > 0
     ? "skills"
     : slashTrigger && filteredSlashCommands.length > 0
@@ -1958,10 +1982,7 @@ export function Composer(props: ComposerProps) {
     availableAutocompleteKind === "skills" && trigger
       ? `skills:${trigger.start}:${trigger.end}:${trigger.query}`
       : availableAutocompleteKind === "slash" && slashTrigger
-        ? `slash:${slashTrigger.start}:${slashTrigger.end}:${draft.slice(
-            slashTrigger.start,
-            slashTrigger.end,
-          )}`
+        ? `slash:${slashTrigger.start}:${slashTrigger.end}:/${slashTrigger.query}`
         : undefined;
   const displayedAutocompleteKind =
     autocompleteKey && autocompleteKey === dismissedAutocompleteKey
@@ -1995,6 +2016,7 @@ export function Composer(props: ComposerProps) {
     [props.directory, props.thread]
   );
   const isBareReviewCommand = draft.trim() === "/review";
+  const isCompactCommand = supportsCompactCommand && draft.trim() === "/compact";
   const isReviewComposerOpen = Boolean(
     supportsReview && reviewConfig && isBareReviewCommand
   );
@@ -2150,7 +2172,15 @@ export function Composer(props: ComposerProps) {
     }
 
     void props.onEnsureSkillsLoaded?.();
-  }, [props.onEnsureSkillsLoaded, slashTrigger, trigger]);
+  }, [
+    props.onEnsureSkillsLoaded,
+    slashTrigger?.end,
+    slashTrigger?.query,
+    slashTrigger?.start,
+    trigger?.end,
+    trigger?.query,
+    trigger?.start,
+  ]);
 
   useEffect(() => {
     if (!isLaunchpad) {
@@ -2503,6 +2533,55 @@ export function Composer(props: ComposerProps) {
       updateActiveTurnId(undefined);
       props.onActiveTurnIdChange?.(undefined);
       restoreQueuedTurnIfClaimed(options?.queued, options?.queueClaimed);
+      setSendError(error instanceof Error ? error.message : String(error));
+    }
+  };
+
+  const submitCompactThread = async (): Promise<void> => {
+    if (props.disabled) {
+      return;
+    }
+    if (!supportsCompactCommand) {
+      setSendError("Selected backend does not support compaction.");
+      return;
+    }
+    if (imageAttachments.length > 0) {
+      setSendError("/compact does not accept image attachments.");
+      return;
+    }
+    if (shouldQueueThreadSubmit()) {
+      setSendError("Cannot compact while a turn is in progress.");
+      return;
+    }
+    if (!props.thread || !props.desktopApi?.compactThread) {
+      setSendError("Compaction is not available for this thread.");
+      return;
+    }
+
+    setSendError(undefined);
+    updateSending(true);
+    props.onPendingStatusChange?.("Compacting");
+
+    try {
+      const response = await props.desktopApi.compactThread({
+        backend: props.thread.source,
+        threadId: props.thread.id,
+      });
+      updateActiveTurnId(response.turnId);
+      props.onActiveTurnIdChange?.(response.turnId);
+      recordComposerDraftHistory(
+        composerScopeKey,
+        latestDraftSnapshotRef.current.snapshot,
+        "sent",
+      );
+      clearComposerDraftSnapshot(composerScopeKey);
+      clearComposerDraft();
+    } catch (error) {
+      props.onPendingStatusChange?.(undefined);
+      updateSending(false);
+      setInterrupting(false);
+      updateActiveTurnId(undefined);
+      props.onActiveTurnIdChange?.(undefined);
       setSendError(error instanceof Error ? error.message : String(error));
     }
   };
@@ -2902,6 +2981,11 @@ export function Composer(props: ComposerProps) {
 
   const submitTurn = async (mode: "default" | "steer" = "default"): Promise<void> => {
     const reviewCommand = supportsReview ? parseReviewCommand(draft) : undefined;
+    if (isCompactCommand) {
+      await submitCompactThread();
+      return;
+    }
+
     if (shouldQueueThreadSubmit()) {
       if (activeTurnIdRef.current && mode === "steer") {
         steerCurrentDraft();
@@ -4567,10 +4651,13 @@ export function Composer(props: ComposerProps) {
                   <span className="composer__autocomplete-token" aria-hidden="true">/</span>
                   <HighlightedAutocompleteLabel
                     label={command.label}
-                    query={slashTrigger
-                      ? draft.slice(slashTrigger.start, slashTrigger.end).trim()
-                      : "/"}
+                    query={slashTrigger ? `/${slashTrigger.query}` : "/"}
                   />
+                  <span
+                    className={`composer__autocomplete-source composer__autocomplete-source--${command.source}`}
+                  >
+                    {command.sourceLabel}
+                  </span>
                 </span>
                 <span className="composer__autocomplete-meta">
                   {command.description}

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -2574,6 +2574,32 @@ export function Composer(props: ComposerProps) {
     setSendError(undefined);
     updateSending(true);
     props.onPendingStatusChange?.("Compacting");
+    const submittedScopeKey = composerScopeKey;
+    const submittedSnapshot = latestDraftSnapshotRef.current.snapshot;
+    const emptySnapshot: ComposerDraftSnapshot = {
+      draft: "",
+      editorDocument: undefined,
+      imageAttachments: [],
+      skillTokens: [],
+    };
+    clearComposerDraftSnapshot(submittedScopeKey);
+    latestDraftSnapshotRef.current = {
+      scopeKey: submittedScopeKey,
+      snapshot: emptySnapshot,
+    };
+    pendingProgrammaticComposerChangeRef.current = {
+      expectedDraft: "",
+      expectedSkillTokensSignature: getComposerSkillTokensSignature([]),
+      staleDraft: submittedSnapshot.draft,
+      staleSkillTokensSignature: getComposerSkillTokensSignature(
+        submittedSnapshot.skillTokens,
+      ),
+    };
+    flushSync(() => {
+      clearComposerDraft();
+      setImageAttachments([]);
+      setReviewConfig(undefined);
+    });
 
     try {
       const response = await props.desktopApi.compactThread({
@@ -2583,13 +2609,20 @@ export function Composer(props: ComposerProps) {
       updateActiveTurnId(response.turnId);
       props.onActiveTurnIdChange?.(response.turnId);
       recordComposerDraftHistory(
-        composerScopeKey,
-        latestDraftSnapshotRef.current.snapshot,
+        submittedScopeKey,
+        submittedSnapshot,
         "sent",
       );
-      clearComposerDraftSnapshot(composerScopeKey);
-      clearComposerDraft();
     } catch (error) {
+      latestDraftSnapshotRef.current = {
+        scopeKey: submittedScopeKey,
+        snapshot: submittedSnapshot,
+      };
+      saveComposerDraftSnapshot(submittedScopeKey, submittedSnapshot);
+      setDraft(submittedSnapshot.draft);
+      setEditorDocument(submittedSnapshot.editorDocument);
+      setImageAttachments(submittedSnapshot.imageAttachments);
+      setSkillTokens(submittedSnapshot.skillTokens);
       props.onPendingStatusChange?.(undefined);
       updateSending(false);
       setInterrupting(false);

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -304,6 +304,19 @@ function providerCommandToSlashSuggestion(
   };
 }
 
+function slashCommandMatchesText(
+  command: SlashCommandSuggestion,
+  text: string,
+): boolean {
+  const normalizedText = text.toLowerCase();
+  return (
+    command.label.toLowerCase() === normalizedText ||
+    (command.aliases ?? []).some(
+      (alias) => `/${alias}`.toLowerCase() === normalizedText,
+    )
+  );
+}
+
 const REVIEW_TARGET_OPTIONS: Array<{
   description: string;
   label: string;
@@ -3733,9 +3746,45 @@ export function Composer(props: ComposerProps) {
       return;
     }
 
+    const currentSlashText = slashTrigger
+      ? `/${slashTrigger.query}`.toLowerCase()
+      : undefined;
+    const exactSlashCommand = currentSlashText
+      ? filteredSlashCommands.find((command) =>
+          slashCommandMatchesText(command, currentSlashText)
+        )
+      : undefined;
     applySlashCommand(
-      filteredSlashCommands[activeSlashIndex] ?? filteredSlashCommands[0]!
+      exactSlashCommand ??
+        filteredSlashCommands[activeSlashIndex] ??
+        filteredSlashCommands[0]!
     );
+  };
+
+  const runExactSlashCommand = (): boolean => {
+    if (autocompleteKind !== "slash" || !slashTrigger) {
+      return false;
+    }
+
+    const currentSlashText = `/${slashTrigger.query}`.toLowerCase();
+    const command = filteredSlashCommands.find((candidate) =>
+      slashCommandMatchesText(candidate, currentSlashText)
+    );
+    if (!command) {
+      return false;
+    }
+
+    if (command.id === "review-current") {
+      enterReviewComposer();
+      return true;
+    }
+
+    if (command.label.toLowerCase() === "/compact") {
+      void submitCompactThread();
+      return true;
+    }
+
+    return false;
   };
 
   const restoreDeletedSkillToken = (
@@ -3843,6 +3892,9 @@ export function Composer(props: ComposerProps) {
         return;
       }
       event.preventDefault();
+      if (event.key === "Enter" && runExactSlashCommand()) {
+        return;
+      }
       commitActiveAutocomplete();
     }
   };

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -4083,7 +4083,7 @@ export function Composer(props: ComposerProps) {
         return;
       }
 
-      if (event.key === "Enter" && !event.shiftKey) {
+      if (event.key === "Enter" && !event.shiftKey && !event.altKey) {
         event.preventDefault();
         void submitTurn(event.metaKey ? "steer" : "default");
       }

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -1768,6 +1768,13 @@ export const ComposerTiptapInput = forwardRef<
           }
           return;
         }
+        if (event.key === "Enter") {
+          propsRef.current.onKeyDown?.(event as unknown as KeyboardEvent<HTMLDivElement>);
+          if (event.defaultPrevented) {
+            event.stopPropagation();
+          }
+          return;
+        }
         if (
           event.key.toLowerCase() === "z" &&
           (event.metaKey || event.ctrlKey) &&

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -1768,7 +1768,7 @@ export const ComposerTiptapInput = forwardRef<
           }
           return;
         }
-        if (event.key === "Enter") {
+        if (event.key === "Enter" && !event.shiftKey && !event.altKey) {
           propsRef.current.onKeyDown?.(event as unknown as KeyboardEvent<HTMLDivElement>);
           if (event.defaultPrevented) {
             event.stopPropagation();

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx
@@ -49,6 +49,27 @@ function setComposerSelection(textbox: HTMLElement, index: number): void {
 }
 
 describe("ComposerTiptapInput", () => {
+  it("keeps Alt+Enter inside the editor instead of routing it to the composer", async () => {
+    const onKeyDown = vi.fn();
+    render(
+      <ComposerTiptapInput
+        id="reply"
+        label="Reply"
+        markdownConversion
+        onChange={() => undefined}
+        onKeyDown={onKeyDown}
+        placeholder="Ask anything"
+        skillTokens={[]}
+        value="- Some item\n- Second item"
+      />
+    );
+
+    const textbox = await screen.findByRole("textbox", { name: "Reply" });
+    fireEvent.keyDown(textbox, { key: "Enter", altKey: true });
+
+    expect(onKeyDown).not.toHaveBeenCalled();
+  });
+
   it("does not render initial URLs or path-like markdown filenames as links", async () => {
     const { container } = renderTiptapInput({
       value:

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -3495,6 +3495,54 @@ describe("Composer", () => {
     expect(within(commands).getByRole("button", { name: /\/review/i })).toBeInTheDocument();
   });
 
+  it("inserts provider-native skill commands from slash autocomplete", async () => {
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn: async () => ({
+            backend: "acp:kimi",
+            threadId: "thread-1",
+            turnId: "turn-1",
+          }),
+        }}
+        disabled={false}
+        providerCommands={[
+          {
+            name: "skill:frontend-design",
+            description: "Load frontend-design",
+            aliases: ["fd"],
+            backend: "acp:kimi",
+            scope: "session",
+            source: "provider",
+          },
+        ]}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Kimi thread",
+          titleSource: "explicit",
+          source: "acp:kimi",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "/ski" } });
+
+    const commands = screen.getByRole("listbox", { name: "Commands" });
+    fireEvent.click(
+      within(commands).getByRole("button", { name: /\/skill:frontend-design/i }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Reply")).toHaveValue("/skill:frontend-design ");
+    });
+  });
+
   it("opens review composer from the focused slash command option", async () => {
     render(
       <Composer

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -2,6 +2,7 @@ import "@testing-library/jest-dom/vitest";
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import type {
   BackendSummary,
+  CompactThreadRequest,
   ComposerDraftRecoveryCandidate,
   NavigationThreadSummary,
   NavigationLaunchpadDraft,
@@ -980,7 +981,6 @@ describe("Composer", () => {
 
     render(
       <Composer
-        backends={[backendSummary("codex")]}
         desktopApi={{
           onAgentEvent: () => () => undefined,
           startTurn,
@@ -1031,7 +1031,6 @@ describe("Composer", () => {
 
     render(
       <Composer
-        backends={[backendSummary("codex")]}
         desktopApi={{
           onAgentEvent: () => () => undefined,
           startTurn,
@@ -3493,6 +3492,139 @@ describe("Composer", () => {
     const commands = screen.getByRole("listbox", { name: "Commands" });
     expect(commands).toBeInTheDocument();
     expect(within(commands).getByRole("button", { name: /\/review/i })).toBeInTheDocument();
+  });
+
+  it("keeps slash review autocomplete visible while editing the prefix", async () => {
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn: async () => ({
+            backend: "codex",
+            threadId: "thread-1",
+            turnId: "turn-1",
+          }),
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Review thread",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    for (const value of ["/", "/r", "/re", "/r"]) {
+      fireEvent.change(textarea, { target: { value } });
+
+      const commands = screen.getByRole("listbox", { name: "Commands" });
+      expect(commands).toBeInTheDocument();
+      expect(within(commands).getByRole("button", { name: /\/review/i })).toBeInTheDocument();
+    }
+  });
+
+  it("keeps duplicate local and provider slash commands labeled by source", async () => {
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn: async () => ({
+            backend: "codex",
+            threadId: "thread-1",
+            turnId: "turn-1",
+          }),
+        }}
+        disabled={false}
+        providerCommands={[
+          {
+            name: "review",
+            description: "Run a Codex code review.",
+            backend: "codex",
+            scope: "backend",
+            source: "provider",
+          },
+        ]}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Review thread",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "/r" } });
+
+    const commands = screen.getByRole("listbox", { name: "Commands" });
+    expect(within(commands).getAllByRole("button", { name: /\/review/i })).toHaveLength(2);
+    expect(within(commands).getByText("PwrAgent")).toBeInTheDocument();
+    expect(within(commands).getByText("OpenAI")).toBeInTheDocument();
+  });
+
+  it("routes Codex compact slash commands to thread compaction", async () => {
+    const compactThread = vi.fn(async (request: CompactThreadRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      turnId: "compact-turn-1",
+    }));
+    const startTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    }));
+
+    render(
+      <Composer
+        desktopApi={{
+          compactThread,
+          onAgentEvent: () => () => undefined,
+          startTurn,
+        }}
+        disabled={false}
+        providerCommands={[
+          {
+            name: "compact",
+            description: "Compact this thread's context.",
+            backend: "codex",
+            scope: "backend",
+            source: "provider",
+          },
+        ]}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Review thread",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "/compact" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() => {
+      expect(compactThread).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+      });
+    });
+    expect(startTurn).not.toHaveBeenCalled();
   });
 
   it("inserts provider-native skill commands from slash autocomplete", async () => {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -3627,6 +3627,77 @@ describe("Composer", () => {
     expect(startTurn).not.toHaveBeenCalled();
   });
 
+  it("runs exact compact slash command on Enter even after review was selected", async () => {
+    const compactThread = vi.fn(async (request: CompactThreadRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      turnId: "compact-turn-1",
+    }));
+    const startReview = vi.fn();
+
+    render(
+      <Composer
+        desktopApi={{
+          compactThread,
+          onAgentEvent: () => () => undefined,
+          startReview,
+          startTurn: async () => ({
+            backend: "codex",
+            threadId: "thread-1",
+            turnId: "turn-1",
+          }),
+        }}
+        disabled={false}
+        providerCommands={[
+          {
+            name: "compact",
+            description: "Compact this thread's context.",
+            backend: "codex",
+            scope: "backend",
+            source: "provider",
+          },
+        ]}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Review thread",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "/r" } });
+    expect(
+      within(screen.getByRole("listbox", { name: "Commands" })).getByRole(
+        "button",
+        { name: /\/review/i },
+      ),
+    ).toHaveAttribute("aria-selected", "true");
+
+    fireEvent.change(textarea, { target: { value: "/compact" } });
+    const commands = screen.getByRole("listbox", { name: "Commands" });
+    expect(within(commands).queryByRole("button", { name: /\/review/i })).not.toBeInTheDocument();
+    expect(within(commands).getByRole("button", { name: /\/compact/i })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+
+    fireEvent.keyDown(textarea, { key: "Enter", code: "Enter" });
+
+    await waitFor(() => {
+      expect(compactThread).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+      });
+    });
+    expect(startReview).not.toHaveBeenCalled();
+  });
+
   it("inserts provider-native skill commands from slash autocomplete", async () => {
     render(
       <Composer

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -70,6 +70,20 @@ async function flushReactUpdates(): Promise<void> {
   });
 }
 
+function createDeferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
+
 afterEach(async () => {
   await flushReactUpdates();
   vi.mocked(normalizeImageFile).mockClear();
@@ -3628,11 +3642,15 @@ describe("Composer", () => {
   });
 
   it("runs exact compact slash command on Enter even after review was selected", async () => {
-    const compactThread = vi.fn(async (request: CompactThreadRequest) => ({
-      backend: request.backend,
-      threadId: request.threadId,
-      turnId: "compact-turn-1",
-    }));
+    const compactThreadResponse = createDeferred<{
+      backend: CompactThreadRequest["backend"];
+      threadId: CompactThreadRequest["threadId"];
+      turnId: string;
+    }>();
+    const compactThread = vi.fn((request: CompactThreadRequest) => {
+      void request;
+      return compactThreadResponse.promise;
+    });
     const startReview = vi.fn();
 
     render(
@@ -3679,7 +3697,7 @@ describe("Composer", () => {
       ),
     ).toHaveAttribute("aria-selected", "true");
 
-    fireEvent.change(textarea, { target: { value: "/compact" } });
+    fireEvent.change(textarea, { target: { value: "/co" } });
     const commands = screen.getByRole("listbox", { name: "Commands" });
     expect(within(commands).queryByRole("button", { name: /\/review/i })).not.toBeInTheDocument();
     expect(within(commands).getByRole("button", { name: /\/compact/i })).toHaveAttribute(
@@ -3695,7 +3713,17 @@ describe("Composer", () => {
         threadId: "thread-1",
       });
     });
+    await waitFor(() => {
+      expect(screen.queryByRole("listbox", { name: "Commands" })).not.toBeInTheDocument();
+      expect(screen.getByLabelText("Reply")).toHaveValue("");
+    });
     expect(startReview).not.toHaveBeenCalled();
+
+    compactThreadResponse.resolve({
+      backend: "codex",
+      threadId: "thread-1",
+      turnId: "compact-turn-1",
+    });
   });
 
   it("inserts provider-native skill commands from slash autocomplete", async () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -7,6 +7,7 @@ import {
   type CSSProperties,
 } from "react";
 import type {
+  AppServerAvailableCommandSummary,
   AppServerCollaborationModeRequest,
   AppServerPendingRequestNotification,
   AppServerReviewTarget,
@@ -808,6 +809,7 @@ export type ThreadViewProps = {
   worktreeArchiveError?: string;
   skillError?: string;
   skillLoading?: boolean;
+  providerCommands?: AppServerAvailableCommandSummary[];
   skills: AppServerSkillSummary[];
   transcriptEntries: AppServerThreadEntry[];
   transcriptError?: string;
@@ -2015,6 +2017,7 @@ export function ThreadView(props: ThreadViewProps) {
               pickingDirectory={props.pickingDirectory}
               skillError={props.skillError}
               skillLoading={props.skillLoading}
+              providerCommands={props.providerCommands ?? []}
               skills={props.skills}
             />
           )}
@@ -2210,6 +2213,7 @@ export function ThreadView(props: ThreadViewProps) {
             threadModelSettingsError={props.setThreadModelSettingsError}
             skillError={props.skillError}
             skillLoading={props.skillLoading}
+            providerCommands={props.providerCommands ?? []}
             skills={props.skills}
             thread={selectedThread!}
             updatingExecutionMode={props.updatingExecutionMode}

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSkills.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSkills.test.tsx
@@ -129,4 +129,78 @@ describe("useThreadSkills", () => {
       ]);
     });
   });
+
+  it("updates cached ACP provider commands when session metadata changes", async () => {
+    const listSkills = vi.fn(async () => ({
+      backend: "acp:kimi" as const,
+      fetchedAt: Date.now(),
+      data: [
+        {
+          skills: [],
+          commands: [],
+        },
+      ],
+    }));
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    const desktopApi: DesktopApi = {
+      listSkills,
+      onAgentEvent: (handler) => {
+        agentEventHandler = handler;
+        return () => {
+          agentEventHandler = undefined;
+        };
+      },
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSkills({
+        desktopApi,
+        thread: {
+          id: "session-1",
+          title: "Kimi session",
+          titleSource: "explicit",
+          source: "acp:kimi",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        },
+      })
+    );
+
+    await act(async () => {
+      await result.current.ensureLoaded();
+    });
+
+    expect(result.current.providerCommands).toEqual([]);
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "acp:kimi",
+        notification: {
+          method: "thread/availableCommands/updated",
+          params: {
+            threadId: "session-1",
+            commands: [
+              {
+                name: "skill:frontend-design",
+                description: "Load frontend-design",
+                backend: "acp:kimi",
+                scope: "session",
+                source: "provider",
+              },
+            ],
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.providerCommands.map((command) => command.name)).toEqual([
+        "skill:frontend-design",
+      ]);
+    });
+    expect(listSkills).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSkills.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSkills.test.tsx
@@ -76,4 +76,57 @@ describe("useThreadSkills", () => {
       ]);
     });
   });
+
+  it("loads provider commands for an ACP thread session", async () => {
+    const listSkills = vi.fn(async () => ({
+      backend: "acp:kimi" as const,
+      fetchedAt: Date.now(),
+      data: [
+        {
+          skills: [],
+          commands: [
+            {
+              name: "skill:frontend-design",
+              description: "Load frontend-design",
+              aliases: ["fd"],
+              backend: "acp:kimi" as const,
+              scope: "session" as const,
+              source: "provider" as const,
+            },
+          ],
+        },
+      ],
+    }));
+
+    const { result } = renderHook(() =>
+      useThreadSkills({
+        desktopApi: { listSkills },
+        thread: {
+          id: "session-1",
+          title: "Kimi session",
+          titleSource: "explicit",
+          source: "acp:kimi",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        },
+      })
+    );
+
+    await act(async () => {
+      await result.current.ensureLoaded();
+    });
+
+    expect(listSkills).toHaveBeenCalledWith({
+      backend: "acp:kimi",
+      threadId: "session-1",
+    });
+
+    await waitFor(() => {
+      expect(result.current.skills).toEqual([]);
+      expect(result.current.providerCommands.map((command) => command.name)).toEqual([
+        "skill:frontend-design",
+      ]);
+    });
+  });
 });

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -18,6 +18,8 @@ import type {
   AppServerListSkillsResponse,
   CheckThreadBranchDriftRequest,
   CheckThreadBranchDriftResponse,
+  CompactThreadRequest,
+  CompactThreadResponse,
   CreateAutomationRequest,
   AppServerListThreadsRequest,
   AppServerListThreadsResponse,
@@ -327,6 +329,9 @@ export type DesktopApi = {
   ) => Promise<RenameThreadResponse>;
   startThread?: (request: StartThreadRequest) => Promise<StartThreadResponse>;
   startReview?: (request: StartReviewRequest) => Promise<StartReviewResponse>;
+  compactThread?: (
+    request: CompactThreadRequest
+  ) => Promise<CompactThreadResponse>;
   startTurn?: (request: StartTurnRequest) => Promise<StartTurnResponse>;
   interruptTurn?: (
     request: InterruptTurnRequest

--- a/apps/desktop/src/renderer/src/lib/useThreadSkills.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSkills.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
   AppServerAvailableCommandSummary,
   AppServerListSkillsResponse,
@@ -65,6 +65,50 @@ export function useThreadSkills(params: {
     return undefined;
   }, [launchpad, thread]);
   const state = skillTarget ? stateByThreadKey[skillTarget.key] : undefined;
+
+  useEffect(() => {
+    if (!desktopApi?.onAgentEvent || !skillTarget?.threadId) {
+      return;
+    }
+
+    const { backend, key, threadId } = skillTarget;
+    return desktopApi.onAgentEvent((event) => {
+      if (
+        event.backend !== backend ||
+        event.notification.method !== "thread/availableCommands/updated" ||
+        event.notification.params.threadId !== threadId
+      ) {
+        return;
+      }
+
+      const commands = Array.isArray(
+        (event.notification.params as { commands?: unknown }).commands,
+      )
+        ? ((event.notification.params as {
+            commands: AppServerAvailableCommandSummary[];
+          }).commands)
+        : [];
+      requestVersionsRef.current[key] =
+        (requestVersionsRef.current[key] ?? 0) + 1;
+      setStateByThreadKey((current) => ({
+        ...current,
+        [key]: {
+          error: undefined,
+          loading: false,
+          response: {
+            backend,
+            fetchedAt: Date.now(),
+            data: [
+              {
+                commands,
+                skills: [],
+              },
+            ],
+          },
+        },
+      }));
+    });
+  }, [desktopApi, skillTarget]);
 
   const ensureLoaded = useCallback(async (): Promise<void> => {
     if (!skillTarget) {

--- a/apps/desktop/src/renderer/src/lib/useThreadSkills.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSkills.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useRef, useState } from "react";
 import type {
+  AppServerAvailableCommandSummary,
   AppServerListSkillsResponse,
   AppServerSkillSummary,
   NavigationLaunchpadDraft,
@@ -26,6 +27,7 @@ export function useThreadSkills(params: {
   ensureLoaded: () => Promise<void>;
   error?: string;
   loading: boolean;
+  providerCommands: AppServerAvailableCommandSummary[];
   response?: AppServerListSkillsResponse;
   skills: AppServerSkillSummary[];
 } {
@@ -33,7 +35,7 @@ export function useThreadSkills(params: {
   const requestVersionsRef = useRef<Record<string, number>>({});
   const [stateByThreadKey, setStateByThreadKey] = useState<Record<string, SkillState>>({});
   const skillTarget = useMemo(() => {
-    if (thread && thread.source === "codex") {
+    if (thread) {
       const cwds = [
         ...new Set(
           thread.linkedDirectories
@@ -46,6 +48,7 @@ export function useThreadSkills(params: {
         backend: thread.source,
         cwds,
         key: buildThreadIdentityKey(thread.source, thread.id),
+        threadId: thread.id,
       };
     }
 
@@ -55,6 +58,7 @@ export function useThreadSkills(params: {
         backend: launchpad.backend,
         cwds,
         key: `launchpad:${launchpad.backend}:${launchpad.directoryKey}`,
+        threadId: undefined,
       };
     }
 
@@ -99,8 +103,9 @@ export function useThreadSkills(params: {
     try {
       const response = await desktopApi.listSkills({
         backend: skillTarget.backend,
-        cwd: cwds.length === 1 ? cwds[0] : undefined,
-        cwds: cwds.length > 0 ? cwds : undefined,
+        ...(cwds.length === 1 ? { cwd: cwds[0] } : {}),
+        ...(cwds.length > 0 ? { cwds } : {}),
+        ...(skillTarget.threadId ? { threadId: skillTarget.threadId } : {}),
       });
 
       if (requestVersionsRef.current[skillTarget.key] !== requestVersion) {
@@ -146,10 +151,28 @@ export function useThreadSkills(params: {
     );
   }, [state?.response?.data]);
 
+  const providerCommands = useMemo(() => {
+    const deduped = new Map<string, AppServerAvailableCommandSummary>();
+
+    for (const entry of state?.response?.data ?? []) {
+      for (const command of entry.commands ?? []) {
+        deduped.set(
+          `${command.backend ?? skillTarget?.backend ?? "unknown"}:${command.name}`,
+          command,
+        );
+      }
+    }
+
+    return [...deduped.values()].sort((left, right) =>
+      left.name.localeCompare(right.name)
+    );
+  }, [skillTarget?.backend, state?.response?.data]);
+
   return {
     ensureLoaded,
     error: state?.error,
     loading: state?.loading ?? false,
+    providerCommands,
     response: state?.response,
     skills,
   };

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -10229,6 +10229,7 @@ textarea,
   gap: 8px;
   font-size: 13px;
   font-weight: 600;
+  min-width: 0;
 }
 
 .composer__autocomplete-match {
@@ -10247,6 +10248,34 @@ textarea,
   font-family: var(--font-mono);
   font-size: 12px;
   line-height: 1;
+}
+
+.composer__autocomplete-source {
+  display: inline-flex;
+  max-width: 104px;
+  min-width: 0;
+  flex: 0 1 auto;
+  align-items: center;
+  overflow: hidden;
+  padding: 2px 6px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1.2;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.composer__autocomplete-source--pwragent {
+  border-color: var(--accent-border);
+  color: var(--accent-bright);
+}
+
+.composer__autocomplete-source--provider {
+  background: var(--bg-panel);
 }
 
 .composer__autocomplete-meta {

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -14,6 +14,7 @@ export const ACP_AGENTS_LIST_CHANNEL = "acp-agents:list";
 export const AGENT_START_THREAD_CHANNEL = "agent:start-thread";
 export const AGENT_START_TURN_CHANNEL = "agent:start-turn";
 export const AGENT_START_REVIEW_CHANNEL = "agent:start-review";
+export const AGENT_COMPACT_THREAD_CHANNEL = "agent:compact-thread";
 export const AGENT_INTERRUPT_TURN_CHANNEL = "agent:interrupt-turn";
 export const AGENT_STEER_TURN_CHANNEL = "agent:steer-turn";
 export const AGENT_SET_THREAD_EXECUTION_MODE_CHANNEL = "agent:set-thread-execution-mode";

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -998,6 +998,13 @@ export type AppServerNotification =
       };
     }
   | {
+      method: "thread/availableCommands/updated";
+      params: {
+        threadId: string;
+        commands: AppServerAvailableCommandSummary[];
+      };
+    }
+  | {
       method: "thread/codexEnvironment/updated";
       params: {
         threadId: string;

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -32,6 +32,15 @@ export type AppServerSkillSummary = {
   scope?: string;
 };
 
+export type AppServerAvailableCommandSummary = {
+  name: string;
+  description?: string;
+  aliases?: string[];
+  backend?: AppServerBackendKind;
+  scope?: "backend" | "session";
+  source?: "provider";
+};
+
 export type AppServerTurnInputItem =
   | AppServerTextInputItem
   | AppServerImageInputItem
@@ -577,12 +586,14 @@ export type AppServerListSkillsRequest = {
   backend?: AppServerBackendKind;
   cwd?: string;
   cwds?: string[];
+  threadId?: ThreadIdentifier;
 };
 
 export type AppServerListSkillsResponse = {
   backend: AppServerBackendKind;
   fetchedAt: number;
   data: Array<{
+    commands?: AppServerAvailableCommandSummary[];
     cwd?: string;
     skills: AppServerSkillSummary[];
   }>;


### PR DESCRIPTION
## Summary

- Add backend-neutral provider command metadata to the desktop `listSkills` contract.
- Persist ACP `available_commands_update` payloads on session metadata and expose them to the selected thread's composer.
- Show provider-native commands in slash autocomplete, including Kimi ACP `skill:*` commands, while preserving local `$skill` mention behavior.
- Preserve future Codex/Grok app-server `commands` / `availableCommands` fields from `skills/list` responses.

Closes #553

## Verification

- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`
- `pnpm test apps/desktop/src/main/__tests__/codex-client.test.ts -t "skills/list"`
- `pnpm test apps/desktop/src/main/__tests__/acp-client.test.ts apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts apps/desktop/src/renderer/src/lib/__tests__/useThreadSkills.test.tsx apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx -t "available command|provider-native skill commands|ACP thread session"`
- `git diff --check`

Note: an earlier broader focused run that included all of `backend-registry.test.ts` hit an existing concurrency test timeout because shell startup/npm warnings polluted command output. The new backend-registry provider-command assertion passes when run directly.