### PR TITLE
feat(threads): add sub-thread grouping and Codex forks

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -10441,6 +10441,148 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("retains parent worktree snapshots for archived same-worktree children", async () => {
+    const worktreePath = "/Users/test/.codex/worktrees/shared/PwrAgnt";
+    const parentThread: AppServerThreadSummary = {
+      id: "thread-parent",
+      title: "Parent thread",
+      titleSource: "explicit",
+      linkedDirectories: [
+        {
+          id: "directory:/repo/PwrAgnt",
+          label: "PwrAgnt",
+          path: "/repo/PwrAgnt",
+          kind: "worktree",
+          worktreePath,
+        },
+      ],
+      source: "codex",
+      gitBranch: "codex/shared",
+      updatedAt: 1,
+    };
+    const childThread: AppServerThreadSummary = {
+      id: "thread-child",
+      title: "Child thread",
+      titleSource: "explicit",
+      linkedDirectories: [
+        {
+          id: `directory:${worktreePath}`,
+          label: "PwrAgnt",
+          path: worktreePath,
+          kind: "local",
+        },
+      ],
+      source: "codex",
+      gitBranch: "codex/shared",
+      updatedAt: 2,
+    };
+    const archivedThreads: AppServerThreadSummary[] = [];
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "thread/archive"] },
+      archivedThreads,
+      threads: [parentThread, childThread],
+    });
+    const snapshot: WorktreeSnapshotSummary = {
+      id: "snapshot-1",
+      backend: "codex",
+      threadId: "thread-parent",
+      worktreePath,
+      repositoryPath: "/repo/PwrAgnt",
+      snapshotRef: "refs/codex/snapshots/snapshot-1",
+      snapshotCommit: "abc123",
+      sourceBranch: "codex/shared",
+      sourceHead: "def456",
+      createdAt: 1000,
+      archivedAt: 1000,
+      state: "archived",
+      ignoredFilesExcluded: true,
+    };
+    const archiveWorktree = vi.fn(async () => snapshot);
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-child": {
+          backend: "codex",
+          threadId: "thread-child",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          parentThreadId: "thread-parent",
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+      worktreeArchiveService: {
+        archive: archiveWorktree,
+      } as unknown as WorktreeArchiveService,
+    });
+
+    const childResponse = await registry.archiveThread({
+      backend: "codex",
+      threadId: "thread-child",
+    });
+    expect(childResponse.cleanup).toEqual([
+      {
+        worktreePath,
+        branch: "codex/shared",
+        removedWorktree: false,
+        deletedBranch: false,
+        skippedReason: "Worktree is still used by another active thread: thread-parent.",
+      },
+    ]);
+    expect(archiveWorktree).not.toHaveBeenCalled();
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-child",
+      }),
+    ).resolves.not.toMatchObject({
+      worktreeSnapshots: expect.any(Array),
+    });
+
+    archivedThreads.push(childThread);
+    codexClient.setThreads([parentThread]);
+    const parentResponse = await registry.archiveThread({
+      backend: "codex",
+      threadId: "thread-parent",
+    });
+
+    expect(parentResponse.cleanup).toEqual([
+      {
+        worktreePath,
+        branch: "codex/shared",
+        removedWorktree: true,
+        deletedBranch: false,
+      },
+    ]);
+    expect(archiveWorktree).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-parent",
+      worktreePath,
+      repositoryPath: "/repo/PwrAgnt",
+    });
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-child",
+      }),
+    ).resolves.toMatchObject({
+      worktreeSnapshots: [
+        expect.objectContaining({
+          id: "snapshot-1",
+          threadId: "thread-child",
+          worktreePath,
+          snapshotRef: "refs/codex/snapshots/snapshot-1",
+        }),
+      ],
+    });
+
+    await registry.close();
+  });
+
   it("does not report a cleanup failure when an archived thread has no linked worktrees", async () => {
     const thread: AppServerThreadSummary = {
       id: "thread-1",

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -10353,6 +10353,94 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("removes a local same-worktree child worktree when no active threads still use it", async () => {
+    const childThread: AppServerThreadSummary = {
+      id: "thread-child",
+      title: "Child thread",
+      titleSource: "explicit",
+      linkedDirectories: [
+        {
+          id: "directory:/Users/test/.codex/worktrees/shared/PwrAgnt",
+          label: "PwrAgnt",
+          path: "/Users/test/.codex/worktrees/shared/PwrAgnt",
+          kind: "local",
+        },
+      ],
+      source: "codex",
+      gitBranch: "codex/shared",
+      updatedAt: 2,
+    };
+    const archivedParentThread: AppServerThreadSummary = {
+      id: "thread-parent",
+      title: "Already archived parent",
+      titleSource: "explicit",
+      linkedDirectories: [
+        {
+          id: "directory:/repo/PwrAgnt",
+          label: "PwrAgnt",
+          path: "/repo/PwrAgnt",
+          kind: "worktree",
+          worktreePath: "/Users/test/.codex/worktrees/shared/PwrAgnt",
+        },
+      ],
+      source: "codex",
+      gitBranch: "codex/shared",
+      updatedAt: 1,
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "thread/archive"] },
+      archivedThreads: [archivedParentThread],
+      threads: [childThread],
+    });
+    const archiveWorktree = vi.fn(async () => ({
+      id: "snapshot-1",
+      backend: "codex" as const,
+      threadId: "thread-child",
+      worktreePath: "/Users/test/.codex/worktrees/shared/PwrAgnt",
+      repositoryPath: "/repo/PwrAgnt",
+      snapshotRef: "refs/codex/snapshots/snapshot-1",
+      snapshotCommit: "abc123",
+      sourceBranch: "codex/shared",
+      sourceHead: "def456",
+      createdAt: 1000,
+      archivedAt: 1000,
+      state: "archived" as const,
+      ignoredFilesExcluded: true,
+    }));
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      worktreeArchiveService: {
+        archive: archiveWorktree,
+      } as unknown as WorktreeArchiveService,
+    });
+
+    const response = await registry.archiveThread({
+      backend: "codex",
+      threadId: "thread-child",
+    });
+
+    expect(archiveWorktree).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-child",
+      worktreePath: "/Users/test/.codex/worktrees/shared/PwrAgnt",
+      repositoryPath: "/Users/test/.codex/worktrees/shared/PwrAgnt",
+    });
+    expect(response.cleanup).toEqual([
+      {
+        worktreePath: "/Users/test/.codex/worktrees/shared/PwrAgnt",
+        branch: "codex/shared",
+        removedWorktree: true,
+        deletedBranch: false,
+      },
+    ]);
+
+    await registry.close();
+  });
+
   it("does not report a cleanup failure when an archived thread has no linked worktrees", async () => {
     const thread: AppServerThreadSummary = {
       id: "thread-1",

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -10037,6 +10037,158 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("skips worktree cleanup when another active thread still uses the same worktree", async () => {
+    const parentThread: AppServerThreadSummary = {
+      id: "019e79f9-7ff1-7f31-9a67-f92435a1c9fa",
+      title: "Parent thread",
+      titleSource: "explicit",
+      linkedDirectories: [
+        {
+          id: "directory:/repo/app",
+          label: "app",
+          path: "/repo/app",
+          kind: "worktree",
+          worktreePath: "/repo/.worktrees/shared",
+        },
+      ],
+      source: "codex",
+      gitBranch: "codex/parent",
+      updatedAt: 1,
+    };
+    const forkedThread: AppServerThreadSummary = {
+      id: "019e7f4d-6fbb-75f1-8cc9-cc78f7ccc844",
+      title: "Forked thread",
+      titleSource: "explicit",
+      linkedDirectories: [
+        {
+          id: "directory:/repo/app",
+          label: "app",
+          path: "/repo/app",
+          kind: "worktree",
+          worktreePath: "/repo/.worktrees/shared",
+        },
+      ],
+      source: "codex",
+      gitBranch: "codex/parent",
+      updatedAt: 2,
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "thread/archive"] },
+      threads: [parentThread, forkedThread],
+    });
+    const archiveWorktree = vi.fn();
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      worktreeArchiveService: {
+        archive: archiveWorktree,
+      } as unknown as WorktreeArchiveService,
+    });
+
+    const response = await registry.archiveThread({
+      backend: "codex",
+      threadId: "019e7f4d-6fbb-75f1-8cc9-cc78f7ccc844",
+    });
+
+    expect(codexClient.lastArchiveThreadParams).toEqual({
+      threadId: "019e7f4d-6fbb-75f1-8cc9-cc78f7ccc844",
+    });
+    expect(archiveWorktree).not.toHaveBeenCalled();
+    expect(response.cleanup).toEqual([
+      {
+        worktreePath: "/repo/.worktrees/shared",
+        branch: "codex/parent",
+        removedWorktree: false,
+        deletedBranch: false,
+        skippedReason:
+          "Worktree is still used by another active thread: 019e79f9-7ff1-7f31-9a67-f92435a1c9fa.",
+      },
+    ]);
+
+    await registry.close();
+  });
+
+  it("removes a linked worktree when only archived threads still reference it", async () => {
+    const activeThread: AppServerThreadSummary = {
+      id: "thread-active",
+      title: "Archive me",
+      titleSource: "explicit",
+      linkedDirectories: [
+        {
+          id: "directory:/repo/app",
+          label: "app",
+          path: "/repo/app",
+          kind: "worktree",
+          worktreePath: "/repo/.worktrees/shared",
+        },
+      ],
+      source: "codex",
+      gitBranch: "codex/shared",
+      updatedAt: 2,
+    };
+    const archivedThread: AppServerThreadSummary = {
+      ...activeThread,
+      id: "thread-already-archived",
+      title: "Already archived",
+      updatedAt: 1,
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "thread/archive"] },
+      archivedThreads: [archivedThread],
+      threads: [activeThread],
+    });
+    const archiveWorktree = vi.fn(async () => ({
+      id: "snapshot-1",
+      backend: "codex" as const,
+      threadId: "thread-active",
+      worktreePath: "/repo/.worktrees/shared",
+      repositoryPath: "/repo/app",
+      snapshotRef: "refs/codex/snapshots/snapshot-1",
+      snapshotCommit: "abc123",
+      sourceBranch: "codex/shared",
+      sourceHead: "def456",
+      createdAt: 1000,
+      archivedAt: 1000,
+      state: "archived" as const,
+      ignoredFilesExcluded: true,
+    }));
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      worktreeArchiveService: {
+        archive: archiveWorktree,
+      } as unknown as WorktreeArchiveService,
+    });
+
+    const response = await registry.archiveThread({
+      backend: "codex",
+      threadId: "thread-active",
+    });
+
+    expect(archiveWorktree).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-active",
+      worktreePath: "/repo/.worktrees/shared",
+      repositoryPath: "/repo/app",
+    });
+    expect(response.cleanup).toEqual([
+      {
+        worktreePath: "/repo/.worktrees/shared",
+        branch: "codex/shared",
+        removedWorktree: true,
+        deletedBranch: false,
+      },
+    ]);
+
+    await registry.close();
+  });
+
   it("does not report a cleanup failure when an archived thread has no linked worktrees", async () => {
     const thread: AppServerThreadSummary = {
       id: "thread-1",

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -235,6 +235,29 @@ function createOverlayStoreMock(params?: {
       overlays.set(key, next);
       return next;
     },
+    setThreadParent: async ({
+      backend,
+      threadId,
+      parentThreadId,
+    }: {
+      backend: "codex" | "grok";
+      threadId: string;
+      parentThreadId?: string;
+    }) => {
+      const key = `${backend}:${threadId}`;
+      const current = overlays.get(key) ?? {
+        backend,
+        threadId,
+        executionMode: "default" as const,
+        extraLinkedDirectories: [],
+      };
+      const next = {
+        ...current,
+        parentThreadId,
+      } as ThreadOverlayState;
+      overlays.set(key, next);
+      return next;
+    },
     setThreadAgent: async (settings: {
       backend: "codex" | "grok";
       threadId: string;
@@ -560,6 +583,15 @@ class MockBackendClient {
     reasoningEffort?: string;
     fastMode?: boolean;
   };
+  lastForkThreadParams?: {
+    threadId: string;
+    cwd?: string;
+    model?: string;
+    approvalPolicy?: string;
+    sandbox?: string;
+    serviceTier?: string;
+    fastMode?: boolean;
+  };
   lastStartTurnParams?: {
     backend?: "codex" | "grok";
     threadId: string;
@@ -818,6 +850,19 @@ class MockBackendClient {
   }): Promise<{ threadId: string }> {
     this.lastStartThreadParams = params;
     return { threadId: "thread-1" };
+  }
+
+  async forkThread(params: {
+    threadId: string;
+    cwd?: string;
+    model?: string;
+    approvalPolicy?: string;
+    sandbox?: string;
+    serviceTier?: string;
+    fastMode?: boolean;
+  }): Promise<{ threadId: string }> {
+    this.lastForkThreadParams = params;
+    return { threadId: "thread-fork" };
   }
 
   async startTurn(params: {
@@ -7435,6 +7480,134 @@ script = "printf setup-output"
       label: "app",
       path: "/repo/app",
       worktreePath: "/repo/app/.worktrees/thread-1/app",
+    });
+
+    await registry.close();
+  });
+
+  it("forks a Codex thread into the same worktree and records the visual parent", async () => {
+    const overlayStore = createOverlayStoreMock();
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/fork"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+      gitDirectoryService: {
+        prepareLaunchpadWorkspace: vi.fn(async () => ({
+          cwd: "/repo/app/.worktrees/parent/app",
+          workMode: "local" as const,
+        })),
+        recordCodexWorktreeOwnerThread: vi.fn(async () => {}),
+      } as never,
+    });
+
+    const response = await registry.forkThread({
+      backend: "codex",
+      sourceThreadId: "thread-parent",
+      parentThreadId: "thread-parent",
+      executionMode: "default",
+      directoryKind: "directory",
+      directoryLabel: "app",
+      directoryPath: "/repo/app/.worktrees/parent/app",
+      workMode: "local",
+      model: "gpt-5.5",
+      serviceTier: "fast",
+      fastMode: true,
+    });
+
+    expect(codexClient.lastForkThreadParams).toMatchObject({
+      threadId: "thread-parent",
+      cwd: "/repo/app/.worktrees/parent/app",
+      model: "gpt-5.5",
+      serviceTier: "fast",
+      fastMode: true,
+      approvalPolicy: "on-request",
+      sandbox: "workspace-write",
+    });
+    expect(response).toMatchObject({
+      backend: "codex",
+      sourceThreadId: "thread-parent",
+      threadId: "thread-fork",
+      workMode: "local",
+      linkedDirectory: {
+        kind: "local",
+        path: "/repo/app/.worktrees/parent/app",
+      },
+    });
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-fork",
+      }),
+    ).resolves.toMatchObject({
+      parentThreadId: "thread-parent",
+      executionMode: "default",
+      model: "gpt-5.5",
+      serviceTier: "fast",
+      fastMode: true,
+    });
+
+    await registry.close();
+  });
+
+  it("forks a Codex thread into a new managed worktree", async () => {
+    const recordCodexWorktreeOwnerThread = vi.fn(async () => {});
+    const prepareLaunchpadWorkspace = vi.fn(async () => ({
+      cwd: "/repo/app/.worktrees/thread-fork/app",
+      repositoryPath: "/repo/app",
+      workMode: "worktree" as const,
+    }));
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/fork"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      gitDirectoryService: {
+        prepareLaunchpadWorkspace,
+        recordCodexWorktreeOwnerThread,
+      } as never,
+    });
+
+    const response = await registry.forkThread({
+      backend: "codex",
+      sourceThreadId: "thread-parent",
+      parentThreadId: "thread-parent",
+      executionMode: "default",
+      directoryKind: "directory",
+      directoryLabel: "app",
+      directoryPath: "/repo/app",
+      workMode: "worktree",
+    });
+
+    expect(prepareLaunchpadWorkspace).toHaveBeenCalledWith({
+      backend: "codex",
+      branchName: undefined,
+      directoryKind: "directory",
+      directoryLabel: "app",
+      directoryPath: "/repo/app",
+      workMode: "worktree",
+    });
+    expect(codexClient.lastForkThreadParams?.cwd).toBe(
+      "/repo/app/.worktrees/thread-fork/app",
+    );
+    expect(recordCodexWorktreeOwnerThread).toHaveBeenCalledWith({
+      worktreePath: "/repo/app/.worktrees/thread-fork/app",
+      threadId: "thread-fork",
+    });
+    expect(response.linkedDirectory).toEqual({
+      id: "/repo/app",
+      kind: "worktree",
+      label: "app",
+      path: "/repo/app",
+      worktreePath: "/repo/app/.worktrees/thread-fork/app",
     });
 
     await registry.close();

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -10147,6 +10147,134 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("skips worktree cleanup when an active same-worktree child is recorded as local", async () => {
+    const parentThread: AppServerThreadSummary = {
+      id: "thread-parent",
+      title: "Parent thread",
+      titleSource: "explicit",
+      linkedDirectories: [
+        {
+          id: "directory:/repo/app",
+          label: "app",
+          path: "/repo/app",
+          kind: "worktree",
+          worktreePath: "/repo/.worktrees/shared",
+        },
+      ],
+      source: "codex",
+      gitBranch: "codex/parent",
+      updatedAt: 1,
+    };
+    const childThread: AppServerThreadSummary = {
+      id: "thread-child",
+      title: "Child thread",
+      titleSource: "explicit",
+      linkedDirectories: [
+        {
+          id: "directory:/repo/.worktrees/shared",
+          label: "app",
+          path: "/repo/.worktrees/shared",
+          kind: "local",
+        },
+      ],
+      source: "codex",
+      gitBranch: "codex/parent",
+      updatedAt: 2,
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "thread/archive"] },
+      threads: [parentThread, childThread],
+    });
+    const archiveWorktree = vi.fn();
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      worktreeArchiveService: {
+        archive: archiveWorktree,
+      } as unknown as WorktreeArchiveService,
+    });
+
+    const response = await registry.archiveThread({
+      backend: "codex",
+      threadId: "thread-parent",
+    });
+
+    expect(archiveWorktree).not.toHaveBeenCalled();
+    expect(response.cleanup).toEqual([
+      {
+        worktreePath: "/repo/.worktrees/shared",
+        branch: "codex/parent",
+        removedWorktree: false,
+        deletedBranch: false,
+        skippedReason:
+          "Worktree is still used by another active thread: thread-child.",
+      },
+    ]);
+
+    await registry.close();
+  });
+
+  it("ungroups active child threads when archiving only the parent", async () => {
+    const parentThread: AppServerThreadSummary = {
+      id: "thread-parent",
+      title: "Parent thread",
+      titleSource: "explicit",
+      linkedDirectories: [],
+      source: "codex",
+      updatedAt: 1,
+    };
+    const childThread: AppServerThreadSummary = {
+      id: "thread-child",
+      title: "Child thread",
+      titleSource: "explicit",
+      linkedDirectories: [],
+      source: "codex",
+      updatedAt: 2,
+    };
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-child": {
+          backend: "codex",
+          threadId: "thread-child",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          parentThreadId: "thread-parent",
+        },
+      },
+    });
+    const setThreadParent = vi.spyOn(overlayStore, "setThreadParent");
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "thread/archive"] },
+      threads: [parentThread, childThread],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+      worktreeArchiveService: {
+        archive: vi.fn(),
+      } as unknown as WorktreeArchiveService,
+    });
+
+    await registry.archiveThread({
+      backend: "codex",
+      threadId: "thread-parent",
+    });
+
+    expect(setThreadParent).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-child",
+      parentThreadId: undefined,
+    });
+
+    await registry.close();
+  });
+
   it("removes a linked worktree when only archived threads still reference it", async () => {
     const activeThread: AppServerThreadSummary = {
       id: "thread-active",

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -5946,6 +5946,42 @@ script = "pnpm install"
     await registry.close();
   });
 
+  it("keeps sub-thread parent metadata when launchpad drafts update", async () => {
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/start"] },
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+
+    await registry.ensureDirectoryLaunchpad({
+      directoryKey: "subthread:codex:thread-parent:new-worktree",
+      directoryKind: "directory",
+      directoryLabel: "Repo A",
+      directoryPath: "/repo-a",
+      currentBranch: "main",
+      parentThreadId: "thread-parent",
+      parentThreadTitle: "Issue 193 Markdown attachments",
+    });
+
+    const updated = await registry.updateDirectoryLaunchpad({
+      directoryKey: "subthread:codex:thread-parent:new-worktree",
+      patch: { prompt: "Start a child investigation" },
+    });
+
+    expect(updated.launchpad).toMatchObject({
+      parentThreadId: "thread-parent",
+      parentThreadTitle: "Issue 193 Markdown attachments",
+      prompt: "Start a child investigation",
+    });
+
+    await registry.close();
+  });
+
   it("repairs stale non-empty launchpad directory metadata when reopened", async () => {
     const overlayStore = createOverlayStoreMock();
     const registry = new DesktopBackendRegistry({

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -7523,7 +7523,7 @@ script = "printf setup-output"
       threadId: "thread-parent",
       cwd: "/repo/app/.worktrees/parent/app",
       model: "gpt-5.5",
-      serviceTier: "fast",
+      serviceTier: "priority",
       fastMode: true,
       approvalPolicy: "on-request",
       sandbox: "workspace-write",
@@ -7547,7 +7547,7 @@ script = "printf setup-output"
       parentThreadId: "thread-parent",
       executionMode: "default",
       model: "gpt-5.5",
-      serviceTier: "fast",
+      serviceTier: "priority",
       fastMode: true,
     });
 

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -4509,7 +4509,7 @@ describe("CodexAppServerClient", () => {
       model: "gpt-5.5",
       approvalPolicy: "on-request",
       sandbox: "workspace-write",
-      serviceTier: "fast",
+      serviceTier: "priority",
       config: {
         fast_mode: true,
       },

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -28,6 +28,15 @@ class MockTransport implements JsonRpcTransport {
     },
     model: "gpt-5.4"
   };
+  static threadForkResult: unknown = {
+    thread: {
+      id: "thread-fork",
+      forkedFromId: "thread-2",
+      cwd: "/Users/huntharo/pwrdrvr/PwrAgent",
+    },
+    model: "gpt-5.4",
+    cwd: "/Users/huntharo/pwrdrvr/PwrAgent",
+  };
   static threadResumeResult: unknown = {
     threadId: "thread-2",
     threadName: "Ship desktop shell",
@@ -751,6 +760,17 @@ class MockTransport implements JsonRpcTransport {
       return;
     }
 
+    if (payload.method === "thread/fork") {
+      this.messageHandler(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: payload.id,
+          result: MockTransport.threadForkResult
+        })
+      );
+      return;
+    }
+
     if (payload.method === "thread/resume") {
       if (MockTransport.threadResumeError) {
         this.messageHandler(
@@ -922,6 +942,15 @@ describe("CodexAppServerClient", () => {
         cwd: "/Users/huntharo/.pwragent/projects/2026-04-16-ab12cd"
       },
       model: "gpt-5.4"
+    };
+    MockTransport.threadForkResult = {
+      thread: {
+        id: "thread-fork",
+        forkedFromId: "thread-2",
+        cwd: "/Users/huntharo/pwrdrvr/PwrAgent",
+      },
+      model: "gpt-5.4",
+      cwd: "/Users/huntharo/pwrdrvr/PwrAgent",
     };
     MockTransport.threadResumeResult = {
       threadId: "thread-2",
@@ -4445,6 +4474,48 @@ describe("CodexAppServerClient", () => {
 
     expect(created).toEqual({
       threadId: "thread-3"
+    });
+
+    await client.close();
+  });
+
+  it("forks a Codex thread through thread/fork with workspace and permission overrides", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    const forked = await client.forkThread({
+      threadId: "thread-2",
+      cwd: "/Users/huntharo/pwrdrvr/PwrAgent",
+      model: "gpt-5.5",
+      approvalPolicy: "on-request",
+      sandbox: "workspace-write",
+      serviceTier: "fast",
+      fastMode: true,
+    });
+
+    expect(forked).toEqual({
+      threadId: "thread-fork",
+    });
+    const request = MockTransport.instances[0]?.sentMessages
+      .map((message) => JSON.parse(message) as { method?: string; params?: unknown })
+      .find((payload) => payload.method === "thread/fork");
+    expect(request?.params).toMatchObject({
+      threadId: "thread-2",
+      cwd: "/Users/huntharo/pwrdrvr/PwrAgent",
+      model: "gpt-5.5",
+      approvalPolicy: "on-request",
+      sandbox: "workspace-write",
+      serviceTier: "fast",
+      config: {
+        fast_mode: true,
+      },
+      excludeTurns: true,
+      persistExtendedHistory: false,
+      threadSource: "user",
     });
 
     await client.close();

--- a/apps/desktop/src/main/__tests__/overlay-store-pins.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-pins.test.ts
@@ -98,4 +98,45 @@ describe("SqliteOverlayStore — thread pins", () => {
     }>;
     expect(rows.map((row) => row.thread_id)).toEqual(["acp%3Agemini:thread-1"]);
   });
+
+  it("persists sub-thread parent, order, and collapsed state", async () => {
+    await store.setThreadParent({
+      backend: "codex",
+      threadId: "review-thread",
+      parentThreadId: "parent-thread",
+    });
+    await store.updateSubthreadOrder({
+      backend: "codex",
+      parentThreadId: "parent-thread",
+      threadIds: ["review-thread", "scratch-thread"],
+    });
+    await store.setSubthreadsCollapsed({
+      backend: "codex",
+      parentThreadId: "parent-thread",
+      collapsed: true,
+    });
+
+    stateDb.close();
+
+    const reopenedDb = StateDb.open(path.join(tempDir, "state.db"));
+    const reopenedStore = new SqliteOverlayStore(reopenedDb);
+    await expect(
+      reopenedStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "review-thread",
+      }),
+    ).resolves.toMatchObject({
+      parentThreadId: "parent-thread",
+    });
+    await expect(
+      reopenedStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "parent-thread",
+      }),
+    ).resolves.toMatchObject({
+      subthreadOrder: ["review-thread", "scratch-thread"],
+      subthreadsCollapsed: true,
+    });
+    reopenedDb.close();
+  });
 });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -743,7 +743,10 @@ type WorktreeRestoreCandidate = {
 function linkedDirectoryWorktreePath(
   directory: LinkedDirectorySummary,
 ): string | undefined {
-  return directory.worktreePath ?? (directory.kind === "worktree" ? directory.path : undefined);
+  return directory.worktreePath ??
+    (directory.kind === "worktree" || directory.kind === "local"
+      ? directory.path
+      : undefined);
 }
 
 function normalizeWorktreePathForComparison(worktreePath: string): string {
@@ -3867,6 +3870,11 @@ export class DesktopBackendRegistry {
       backend,
       threadId: result.threadId,
       origin: "thread-archive",
+    });
+    await this.ungroupChildrenOfArchivedThread({
+      backend,
+      activeThreads: cleanupMetadata?.activeThreads ?? [],
+      parentThreadId: result.threadId,
     });
     const cleanup = cleanupMetadata
       ? await this.archiveThreadWorktrees({
@@ -8713,6 +8721,42 @@ export class DesktopBackendRegistry {
         );
       });
     });
+  }
+
+  private async ungroupChildrenOfArchivedThread(params: {
+    activeThreads: AppServerThreadSummary[];
+    backend: AppServerBackendKind;
+    parentThreadId: string;
+  }): Promise<void> {
+    const setThreadParent = this.overlayStore.setThreadParent;
+    if (!setThreadParent) {
+      return;
+    }
+
+    const activeThreadIds = params.activeThreads
+      .filter((thread) => thread.source === params.backend)
+      .map((thread) => thread.id);
+    const overlaysByThreadId = await this.overlayStore.getThreadOverlayStates({
+      backend: params.backend,
+      threadIds: activeThreadIds,
+    });
+    const childThreadIds = activeThreadIds.filter(
+      (threadId) =>
+        overlaysByThreadId[threadId]?.parentThreadId === params.parentThreadId,
+    );
+    if (childThreadIds.length === 0) {
+      return;
+    }
+
+    await Promise.all(
+      childThreadIds.map((threadId) =>
+        setThreadParent.call(this.overlayStore, {
+          backend: params.backend,
+          threadId,
+          parentThreadId: undefined,
+        }),
+      ),
+    );
   }
 
   private async restoreThreadWorktrees(params: {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -980,6 +980,11 @@ function buildCapabilities(methods: string[], backend: AppServerBackendKind): Ba
       supported.has("thread/start") ||
       supported.has("thread/new") ||
       assumeCodexAppServerSurface,
+    // Empty Codex method lists are emitted by older supported app-server
+    // surfaces that predate method discovery. PwrAgent's supported Codex
+    // floor includes thread/fork, so keep the legacy "assume app-server
+    // surface" behavior for empty lists while respecting explicit method
+    // lists from feature-gated builds.
     forkThread: supported.has("thread/fork") || assumeCodexAppServerSurface,
     resumeThread: supported.has("thread/resume") || assumeCodexAppServerSurface,
     archiveThread: supported.has("thread/archive") || assumeCodexAppServerSurface,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -730,6 +730,7 @@ type WorktreeArchiveCandidate = {
 
 type ArchiveCleanupMetadata = {
   activeThreads: AppServerThreadSummary[];
+  archivedThreads: AppServerThreadSummary[];
   thread: AppServerThreadSummary;
 };
 
@@ -3890,6 +3891,7 @@ export class DesktopBackendRegistry {
       ? await this.archiveThreadWorktrees({
           backend,
           activeThreads: cleanupMetadata.activeThreads,
+          archivedThreads: cleanupMetadata.archivedThreads,
           thread: cleanupMetadata.thread,
         })
       : this.buildArchiveCleanupMetadataSkippedResult({
@@ -8403,22 +8405,36 @@ export class DesktopBackendRegistry {
       callerReason: "archive-cleanup",
     });
     const activeThread = activeThreads.find((thread) => thread.id === params.threadId);
+    let archivedThreads: AppServerThreadSummary[] = [];
+    try {
+      archivedThreads = await this.listThreads({
+        backend: params.backend,
+        archived: true,
+        callerReason: "archive-cleanup",
+      });
+    } catch (error) {
+      if (!activeThread) {
+        throw error;
+      }
+      backendRegistryLog.warn("archive cleanup archived-thread lookup failed", {
+        backend: params.backend,
+        threadId: params.threadId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
     if (activeThread) {
       return {
         activeThreads,
+        archivedThreads,
         thread: activeThread,
       };
     }
 
-    const archivedThreads = await this.listThreads({
-      backend: params.backend,
-      archived: true,
-      callerReason: "archive-cleanup",
-    });
     const archivedThread = archivedThreads.find((thread) => thread.id === params.threadId);
     if (archivedThread) {
       return {
         activeThreads,
+        archivedThreads,
         thread: archivedThread,
       };
     }
@@ -8557,6 +8573,7 @@ export class DesktopBackendRegistry {
 
   private async archiveThreadWorktrees(params: {
     activeThreads: AppServerThreadSummary[];
+    archivedThreads: AppServerThreadSummary[];
     backend: AppServerBackendKind;
     thread: AppServerThreadSummary;
   }): Promise<ArchiveThreadCleanupResult[]> {
@@ -8641,6 +8658,13 @@ export class DesktopBackendRegistry {
             threadId: params.thread.id,
             snapshot,
           });
+          await this.retainSharedWorktreeSnapshotForArchivedThreads({
+            archivedThreadId: params.thread.id,
+            archivedThreads: params.archivedThreads,
+            backend: params.backend,
+            snapshot,
+            worktreePath: candidate.worktreePath,
+          });
 
           let worktreeStillExists = false;
           try {
@@ -8708,6 +8732,46 @@ export class DesktopBackendRegistry {
           };
         }
       }),
+    );
+  }
+
+  private async retainSharedWorktreeSnapshotForArchivedThreads(params: {
+    archivedThreadId: string;
+    archivedThreads: AppServerThreadSummary[];
+    backend: AppServerBackendKind;
+    snapshot: WorktreeSnapshotSummary;
+    worktreePath: string;
+  }): Promise<void> {
+    const archivedWorktreePath = normalizeWorktreePathForComparison(params.worktreePath);
+    const siblingThreads = params.archivedThreads.filter((thread) => {
+      if (thread.source !== params.backend || thread.id === params.archivedThreadId) {
+        return false;
+      }
+
+      return thread.linkedDirectories.some((directory) => {
+        const candidatePath = linkedDirectoryWorktreePath(directory);
+        return (
+          candidatePath !== undefined &&
+          normalizeWorktreePathForComparison(candidatePath) === archivedWorktreePath
+        );
+      });
+    });
+
+    if (siblingThreads.length === 0) {
+      return;
+    }
+
+    await Promise.all(
+      siblingThreads.map((thread) =>
+        this.overlayStore.upsertWorktreeSnapshot({
+          backend: params.backend,
+          threadId: thread.id,
+          snapshot: {
+            ...params.snapshot,
+            threadId: thread.id,
+          },
+        }),
+      ),
     );
   }
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -728,12 +728,27 @@ type WorktreeArchiveCandidate = {
   worktreePath: string;
 };
 
+type ArchiveCleanupMetadata = {
+  activeThreads: AppServerThreadSummary[];
+  thread: AppServerThreadSummary;
+};
+
 type WorktreeRestoreCandidate = {
   branch?: string;
   repositoryPath?: string;
   snapshot?: WorktreeSnapshotSummary;
   worktreePath: string;
 };
+
+function linkedDirectoryWorktreePath(
+  directory: LinkedDirectorySummary,
+): string | undefined {
+  return directory.worktreePath ?? (directory.kind === "worktree" ? directory.path : undefined);
+}
+
+function normalizeWorktreePathForComparison(worktreePath: string): string {
+  return path.normalize(worktreePath.trim());
+}
 
 const BACKEND_LABELS: Record<AppServerBackendKind, string> = {
   codex: "OpenAI",
@@ -3825,10 +3840,10 @@ export class DesktopBackendRegistry {
         threadId: request.threadId,
       });
     }
-    let thread: AppServerThreadSummary | undefined;
+    let cleanupMetadata: ArchiveCleanupMetadata | undefined;
     let cleanupMetadataError: string | undefined;
     try {
-      thread = await this.findThreadForArchiveCleanup({
+      cleanupMetadata = await this.findThreadForArchiveCleanup({
         backend,
         threadId: request.threadId,
       });
@@ -3853,10 +3868,11 @@ export class DesktopBackendRegistry {
       threadId: result.threadId,
       origin: "thread-archive",
     });
-    const cleanup = thread
+    const cleanup = cleanupMetadata
       ? await this.archiveThreadWorktrees({
           backend,
-          thread,
+          activeThreads: cleanupMetadata.activeThreads,
+          thread: cleanupMetadata.thread,
         })
       : this.buildArchiveCleanupMetadataSkippedResult({
           backend,
@@ -8347,7 +8363,7 @@ export class DesktopBackendRegistry {
   private async findThreadForArchiveCleanup(params: {
     backend: AppServerBackendKind;
     threadId: string;
-  }): Promise<AppServerThreadSummary> {
+  }): Promise<ArchiveCleanupMetadata> {
     const activeThreads = await this.listThreads({
       backend: params.backend,
       archived: false,
@@ -8355,7 +8371,10 @@ export class DesktopBackendRegistry {
     });
     const activeThread = activeThreads.find((thread) => thread.id === params.threadId);
     if (activeThread) {
-      return activeThread;
+      return {
+        activeThreads,
+        thread: activeThread,
+      };
     }
 
     const archivedThreads = await this.listThreads({
@@ -8365,7 +8384,10 @@ export class DesktopBackendRegistry {
     });
     const archivedThread = archivedThreads.find((thread) => thread.id === params.threadId);
     if (archivedThread) {
-      return archivedThread;
+      return {
+        activeThreads,
+        thread: archivedThread,
+      };
     }
 
     throw new Error("Thread metadata was not found.");
@@ -8501,6 +8523,7 @@ export class DesktopBackendRegistry {
   }
 
   private async archiveThreadWorktrees(params: {
+    activeThreads: AppServerThreadSummary[];
     backend: AppServerBackendKind;
     thread: AppServerThreadSummary;
   }): Promise<ArchiveThreadCleanupResult[]> {
@@ -8542,6 +8565,33 @@ export class DesktopBackendRegistry {
     return await Promise.all(
       uniqueCandidates.map(async (candidate): Promise<ArchiveThreadCleanupResult> => {
         try {
+          const activeUsers = this.findActiveThreadsUsingWorktree({
+            activeThreads: params.activeThreads,
+            archivedThreadId: params.thread.id,
+            worktreePath: candidate.worktreePath,
+          });
+          if (activeUsers.length > 0) {
+            const activeThreadIds = activeUsers.map((thread) => thread.id);
+            const skippedReason =
+              activeThreadIds.length === 1
+                ? `Worktree is still used by another active thread: ${activeThreadIds[0]}.`
+                : `Worktree is still used by other active threads: ${activeThreadIds.join(", ")}.`;
+            backendRegistryLog.info("archive thread worktree cleanup skipped: shared worktree", {
+              backend: params.backend,
+              threadId: params.thread.id,
+              activeThreadIds,
+              repositoryPath: candidate.repositoryPath,
+              worktreePath: candidate.worktreePath,
+            });
+            return {
+              worktreePath: candidate.worktreePath,
+              branch: params.thread.observedGitBranch ?? params.thread.gitBranch,
+              removedWorktree: false,
+              deletedBranch: false,
+              skippedReason,
+            };
+          }
+
           backendRegistryLog.info("archive thread worktree cleanup removing worktree", {
             backend: params.backend,
             threadId: params.thread.id,
@@ -8627,6 +8677,27 @@ export class DesktopBackendRegistry {
         }
       }),
     );
+  }
+
+  private findActiveThreadsUsingWorktree(params: {
+    activeThreads: AppServerThreadSummary[];
+    archivedThreadId: string;
+    worktreePath: string;
+  }): AppServerThreadSummary[] {
+    const archivedWorktreePath = normalizeWorktreePathForComparison(params.worktreePath);
+    return params.activeThreads.filter((thread) => {
+      if (thread.id === params.archivedThreadId) {
+        return false;
+      }
+
+      return thread.linkedDirectories.some((directory) => {
+        const candidatePath = linkedDirectoryWorktreePath(directory);
+        return (
+          candidatePath !== undefined &&
+          normalizeWorktreePathForComparison(candidatePath) === archivedWorktreePath
+        );
+      });
+    });
   }
 
   private async restoreThreadWorktrees(params: {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -743,10 +743,20 @@ type WorktreeRestoreCandidate = {
 function linkedDirectoryWorktreePath(
   directory: LinkedDirectorySummary,
 ): string | undefined {
-  return directory.worktreePath ??
-    (directory.kind === "worktree" || directory.kind === "local"
-      ? directory.path
-      : undefined);
+  const explicitWorktreePath = directory.worktreePath?.trim();
+  if (explicitWorktreePath) {
+    return explicitWorktreePath;
+  }
+
+  if (directory.kind === "worktree") {
+    return directory.path;
+  }
+
+  if (directory.kind === "local" && isLikelyToolManagedWorktreePath(directory.path)) {
+    return directory.path;
+  }
+
+  return undefined;
 }
 
 function normalizeWorktreePathForComparison(worktreePath: string): string {
@@ -8552,8 +8562,7 @@ export class DesktopBackendRegistry {
   }): Promise<ArchiveThreadCleanupResult[]> {
     const candidates: WorktreeArchiveCandidate[] =
       params.thread.linkedDirectories.flatMap((directory) => {
-        const worktreePath =
-          directory.worktreePath ?? (directory.kind === "worktree" ? directory.path : undefined);
+        const worktreePath = linkedDirectoryWorktreePath(directory);
         if (!worktreePath?.trim()) {
           return [];
         }

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -44,6 +44,8 @@ import {
   type BackendSummary,
   type CheckThreadBranchDriftRequest,
   type CheckThreadBranchDriftResponse,
+  type ForkThreadRequest,
+  type ForkThreadResponse,
   isBranchDrifted,
   type HandoffThreadWorkspaceRequest,
   type HandoffThreadWorkspaceResponse,
@@ -318,6 +320,15 @@ type BackendClient = {
     fastMode?: boolean;
     codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
     dynamicTools?: CodexDynamicToolSpec[];
+  }): Promise<{ threadId: string }>;
+  forkThread?(params: {
+    threadId: string;
+    cwd?: string;
+    model?: string;
+    approvalPolicy?: string;
+    sandbox?: string;
+    serviceTier?: string;
+    fastMode?: boolean;
   }): Promise<{ threadId: string }>;
   startTurn(params: {
     threadId: string;
@@ -969,6 +980,7 @@ function buildCapabilities(methods: string[], backend: AppServerBackendKind): Ba
       supported.has("thread/start") ||
       supported.has("thread/new") ||
       assumeCodexAppServerSurface,
+    forkThread: supported.has("thread/fork") || assumeCodexAppServerSurface,
     resumeThread: supported.has("thread/resume") || assumeCodexAppServerSurface,
     archiveThread: supported.has("thread/archive") || assumeCodexAppServerSurface,
     restoreThread: supported.has("thread/unarchive") || assumeCodexAppServerSurface,
@@ -4465,6 +4477,126 @@ export class DesktopBackendRegistry {
       threadId: result.threadId,
       executionMode: effectiveExecutionMode,
       codexEnvironmentRuntime: request.codexEnvironmentRuntime,
+    };
+  }
+
+  async forkThread(request: ForkThreadRequest): Promise<ForkThreadResponse> {
+    this.assertNotBootstrap("forkThread");
+    const backend = request.backend ?? "codex";
+    if (backend !== "codex") {
+      throw new Error("Thread forking is currently supported only by the Codex backend.");
+    }
+
+    const executionMode = request.executionMode ?? "default";
+    const modeSettings = EXECUTION_MODE_SUMMARIES[executionMode];
+    const modelSettings = await this.resolveModelSettings(backend, request);
+    const directoryKind =
+      request.directoryKind ?? (request.directoryPath?.trim() ? "directory" : "workspace");
+    const directoryLabel =
+      request.directoryLabel?.trim() ||
+      (request.directoryPath ? path.basename(request.directoryPath) : undefined) ||
+      "Forked thread";
+    const preparedWorkspace = await this.gitDirectoryService.prepareLaunchpadWorkspace({
+      backend,
+      branchName: request.branchName,
+      directoryKind,
+      directoryLabel,
+      directoryPath: request.directoryPath,
+      workMode: request.workMode ?? "local",
+    });
+    const cwd = preparedWorkspace.cwd;
+    const linkedDirectories =
+      preparedWorkspace.workMode === "worktree"
+        ? buildWorktreeLinkedDirectory({
+            label: directoryLabel,
+            repositoryPath: preparedWorkspace.repositoryPath ?? request.directoryPath,
+            worktreePath: cwd,
+          })
+        : buildLocalLinkedDirectory(cwd);
+    const client = this.getClient(backend, executionMode);
+    if (!client.forkThread) {
+      throw new Error("Selected backend does not support thread/fork.");
+    }
+
+    const result = await client.forkThread({
+      threadId: request.sourceThreadId,
+      cwd,
+      ...modelSettings,
+      approvalPolicy: request.approvalPolicy ?? modeSettings.approvalPolicy,
+      sandbox: request.sandbox ?? modeSettings.sandbox,
+    });
+    const forkedAt = Date.now();
+    const gitBranch = cwd ? await readCurrentGitBranch(cwd).catch(() => undefined) : undefined;
+    this.pendingStartedThreads.set(`${backend}:${result.threadId}`, {
+      id: result.threadId,
+      source: backend,
+      title: "Forked thread",
+      titleSource: "fallback",
+      projectKey: cwd,
+      createdAt: forkedAt,
+      updatedAt: forkedAt,
+      executionMode,
+      ...modelSettings,
+      linkedDirectories: linkedDirectories.map(normalizeLinkedDirectoryKind),
+      gitBranch,
+    });
+
+    if (preparedWorkspace.workMode === "worktree") {
+      await this.recordCodexWorktreeOwnerThread({
+        backend,
+        threadId: result.threadId,
+        worktreePath: cwd,
+      });
+    }
+
+    await this.overlayStore.setThreadExecutionMode({
+      backend,
+      threadId: result.threadId,
+      executionMode,
+    });
+    if (
+      modelSettings.model !== undefined ||
+      modelSettings.reasoningEffort !== undefined ||
+      modelSettings.serviceTier !== undefined ||
+      modelSettings.fastMode !== undefined
+    ) {
+      await this.overlayStore.setThreadModelSettings({
+        backend,
+        threadId: result.threadId,
+        ...modelSettings,
+      });
+    }
+    if (request.parentThreadId?.trim()) {
+      await this.overlayStore.setThreadParent?.({
+        backend,
+        threadId: result.threadId,
+        parentThreadId: request.parentThreadId,
+      });
+      await this.emit({
+        backend,
+        notification: {
+          method: "thread/parent/set",
+          params: {
+            threadId: result.threadId,
+            parentThreadId: request.parentThreadId,
+          },
+        },
+      });
+    }
+    await this.updateThreadGitBranchMetadata({
+      backend,
+      threadId: result.threadId,
+      branch: gitBranch,
+    });
+    this.invalidateThreadListCache(backend);
+
+    return {
+      backend,
+      sourceThreadId: request.sourceThreadId,
+      threadId: result.threadId,
+      executionMode,
+      linkedDirectory: linkedDirectories[0],
+      workMode: preparedWorkspace.workMode,
     };
   }
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6818,6 +6818,23 @@ export class DesktopBackendRegistry {
       codexEnvironmentRuntime,
     });
     pendingActionThreadId = startThreadResponse.threadId;
+    if (request.parentThreadId?.trim()) {
+      await this.overlayStore.setThreadParent?.({
+        backend: startThreadResponse.backend,
+        threadId: startThreadResponse.threadId,
+        parentThreadId: request.parentThreadId,
+      });
+      await this.emit({
+        backend: startThreadResponse.backend,
+        notification: {
+          method: "thread/parent/set",
+          params: {
+            threadId: startThreadResponse.threadId,
+            parentThreadId: request.parentThreadId,
+          },
+        },
+      });
+    }
     if (codexEnvironmentSelection?.action?.id) {
       for (const event of queuedActionDetachedOutputs) {
         void this.handleCodexEnvironmentActionDetachedOutput({
@@ -7417,7 +7434,11 @@ export class DesktopBackendRegistry {
       method === "thread/executionMode/queued" ||
       method === "thread/executionMode/updated" ||
       method === "thread/name/updated" ||
+      method === "thread/parent/cleared" ||
+      method === "thread/parent/set" ||
       method === "thread/started" ||
+      method === "thread/subthreadOrder/updated" ||
+      method === "thread/subthreadsCollapsed/updated" ||
       method === "thread/unarchived" ||
       method === "turn/completed" ||
       method === "turn/failed"

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6293,10 +6293,18 @@ export class DesktopBackendRegistry {
         executionMode,
         ...modelSettings,
       };
+      const requestParentThreadId =
+        request.parentThreadId ?? normalizedExisting.parentThreadId;
+      const requestParentThreadTitle =
+        request.parentThreadTitle ?? normalizedExisting.parentThreadTitle;
       const identityChanged =
         normalizedExisting.directoryKind !== request.directoryKind ||
         normalizedExisting.directoryLabel !== request.directoryLabel ||
         normalizedExisting.directoryPath !== request.directoryPath;
+      const parentChanged =
+        request.parentThreadId !== undefined &&
+        (normalizedExisting.parentThreadId !== request.parentThreadId ||
+          normalizedExisting.parentThreadTitle !== request.parentThreadTitle);
 
       if (isEmptyDirectoryLaunchpadDraft(existing)) {
         const refreshed: NavigationLaunchpadDraft = {
@@ -6312,6 +6320,8 @@ export class DesktopBackendRegistry {
           fastMode: defaults.fastMode,
           workMode: defaultLaunchpadWorkMode(request, defaults),
           branchName: existing.branchName ?? request.currentBranch,
+          parentThreadId: requestParentThreadId,
+          parentThreadTitle: requestParentThreadTitle,
           registeredAt,
           updatedAt: Date.now(),
         };
@@ -6332,7 +6342,8 @@ export class DesktopBackendRegistry {
         normalizedExisting.reasoningEffort !== existing.reasoningEffort ||
         normalizedExisting.serviceTier !== existing.serviceTier ||
         normalizedExisting.fastMode !== existing.fastMode ||
-        registeredAt !== existing.registeredAt
+        registeredAt !== existing.registeredAt ||
+        parentChanged
       ) {
         return {
           launchpad: withCodexEnvironmentOptions(
@@ -6341,6 +6352,8 @@ export class DesktopBackendRegistry {
               directoryKind: request.directoryKind,
               directoryLabel: request.directoryLabel,
               directoryPath: request.directoryPath,
+              parentThreadId: requestParentThreadId,
+              parentThreadTitle: requestParentThreadTitle,
               registeredAt,
               updatedAt: Date.now(),
             }),
@@ -6371,6 +6384,8 @@ export class DesktopBackendRegistry {
       registeredAt: request.registeredAt,
       workMode: defaultLaunchpadWorkMode(request, defaults),
       branchName: request.currentBranch,
+      parentThreadId: request.parentThreadId,
+      parentThreadTitle: request.parentThreadTitle,
       createdAt: Date.now(),
       updatedAt: Date.now(),
     };

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -52,6 +52,7 @@ import type {
   SandboxPolicy as CodexSandboxPolicy,
   ReviewStartParams as CodexReviewStartParams,
   SkillsListParams as CodexSkillsListParams,
+  ThreadForkParams as CodexThreadForkParams,
   ThreadListParams as CodexThreadListParams,
   ThreadReadParams as CodexThreadReadParams,
   ThreadResumeParams as CodexThreadResumeParams,
@@ -4168,6 +4169,53 @@ function buildThreadStartPayload(params: {
   return base;
 }
 
+function buildThreadForkPayload(params: {
+  threadId: string;
+  cwd?: string;
+  model?: string;
+  approvalPolicy?: string;
+  sandbox?: string;
+  serviceTier?: string;
+  fastMode?: boolean;
+}): CodexThreadForkParams {
+  const base: CodexThreadForkParams = {
+    threadId: params.threadId,
+    excludeTurns: true,
+    persistExtendedHistory: false,
+    threadSource: "user",
+  };
+
+  if (params.cwd?.trim()) {
+    base.cwd = params.cwd.trim();
+  }
+  if (params.model?.trim()) {
+    base.model = params.model.trim();
+  }
+
+  const approvalPolicy = normalizeCodexApprovalPolicy(params.approvalPolicy);
+  if (approvalPolicy) {
+    base.approvalPolicy = approvalPolicy;
+  }
+
+  const sandbox = normalizeCodexSandboxMode(params.sandbox);
+  if (sandbox) {
+    base.sandbox = sandbox;
+  }
+
+  const serviceTier = normalizeCodexServiceTier(params.serviceTier);
+  if (serviceTier) {
+    base.serviceTier = serviceTier;
+  }
+
+  if (typeof params.fastMode === "boolean") {
+    base.config = {
+      fast_mode: params.fastMode,
+    };
+  }
+
+  return base;
+}
+
 function buildThreadResumePayloads(params: {
   threadId: string;
   cwd?: string;
@@ -5145,6 +5193,37 @@ export class CodexAppServerClient {
     const threadId = extractThreadIdFromValue(result);
     if (!threadId) {
       throw new Error("codex app server thread/start did not return threadId");
+    }
+
+    this.pendingFirstTurnThreadResults.set(threadId, result);
+    await this.recordThreadNameWithCodex(result);
+
+    return {
+      threadId,
+    };
+  }
+
+  async forkThread(params: {
+    threadId: string;
+    cwd?: string;
+    model?: string;
+    approvalPolicy?: string;
+    sandbox?: string;
+    serviceTier?: string;
+    fastMode?: boolean;
+  }): Promise<{ threadId: string }> {
+    await this.ensureInitialized();
+
+    const result = await requestWithFallbacks({
+      client: this.connection,
+      methods: ["thread/fork"],
+      payloads: [buildThreadForkPayload(params)],
+      timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+    });
+
+    const threadId = extractThreadIdFromValue(result);
+    if (!threadId) {
+      throw new Error("codex app server thread/fork did not return threadId");
     }
 
     this.pendingFirstTurnThreadResults.set(threadId, result);

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -8,6 +8,8 @@ import type {
   CheckThreadBranchDriftResponse,
   CompactThreadRequest,
   CompactThreadResponse,
+  ForkThreadRequest,
+  ForkThreadResponse,
   MaterializeDirectoryLaunchpadRequest,
   MaterializeDirectoryLaunchpadResponse,
   InterruptTurnRequest,
@@ -48,6 +50,7 @@ import { getDesktopBackendRegistry } from "../app-server/backend-registry";
 import {
   AGENT_CANCEL_THREAD_EXECUTION_MODE_QUEUE_CHANNEL,
   AGENT_EVENT_CHANNEL,
+  AGENT_FORK_THREAD_CHANNEL,
   AGENT_LATEST_CODEX_CONFIG_WARNING_CHANNEL,
   AGENT_CHECK_THREAD_BRANCH_DRIFT_CHANNEL,
   AGENT_COMPACT_THREAD_CHANNEL,
@@ -290,6 +293,17 @@ export function registerAgentIpcHandlers(): void {
       request: StartThreadRequest
     ): Promise<StartThreadResponse> => {
       return await registry.startThread(request);
+    },
+  );
+
+  ipcMain.removeHandler(AGENT_FORK_THREAD_CHANNEL);
+  ipcMain.handle(
+    AGENT_FORK_THREAD_CHANNEL,
+    async (
+      _event,
+      request: ForkThreadRequest,
+    ): Promise<ForkThreadResponse> => {
+      return await registry.forkThread(request);
     },
   );
 
@@ -631,6 +645,7 @@ export function disposeAgentIpcHandlers(): void {
   unsubscribeRegistryEvents = undefined;
   ipcMain.removeHandler(BACKEND_LIST_CHANNEL);
   ipcMain.removeHandler(AGENT_START_THREAD_CHANNEL);
+  ipcMain.removeHandler(AGENT_FORK_THREAD_CHANNEL);
   ipcMain.removeHandler(AGENT_START_REVIEW_CHANNEL);
   ipcMain.removeHandler(AGENT_COMPACT_THREAD_CHANNEL);
   ipcMain.removeHandler(AGENT_START_TURN_CHANNEL);

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -45,8 +45,12 @@ import type {
   ReorderDirectoryPinsResponse,
   ReorderThreadPinsRequest,
   ReorderThreadPinsResponse,
+  SetSubthreadsCollapsedRequest,
+  SetSubthreadsCollapsedResponse,
   SetDirectoryPinRequest,
   SetDirectoryPinResponse,
+  SetThreadParentRequest,
+  SetThreadParentResponse,
   SetThreadAgentRequest,
   SetThreadAgentResponse,
   SetThreadPinRequest,
@@ -64,6 +68,8 @@ import type {
   ThreadOverlayState,
   UpdateDirectoryLaunchpadRequest,
   UpdateDirectoryLaunchpadResponse,
+  UpdateSubthreadOrderRequest,
+  UpdateSubthreadOrderResponse,
 } from "@pwragent/shared";
 import { registerDirectoryFromDisk } from "../app-server/directory-registration-service";
 import {
@@ -90,7 +96,9 @@ import {
   NAVIGATION_REORDER_DIRECTORY_PINS_CHANNEL,
   NAVIGATION_REORDER_THREAD_PINS_CHANNEL,
   NAVIGATION_MARK_THREAD_SEEN_CHANNEL,
+  NAVIGATION_SET_SUBTHREADS_COLLAPSED_CHANNEL,
   NAVIGATION_SET_DIRECTORY_PIN_CHANNEL,
+  NAVIGATION_SET_THREAD_PARENT_CHANNEL,
   NAVIGATION_SET_THREAD_AGENT_CHANNEL,
   NAVIGATION_SET_THREAD_PIN_CHANNEL,
   NAVIGATION_SET_THREAD_REACTION_CHANNEL,
@@ -99,6 +107,7 @@ import {
   NAVIGATION_REGISTER_DIRECTORY_FROM_DISK_CHANNEL,
   NAVIGATION_RESET_DIRECTORY_LAUNCHPAD_CHANNEL,
   NAVIGATION_SNAPSHOT_CHANNEL,
+  NAVIGATION_UPDATE_SUBTHREAD_ORDER_CHANNEL,
   NAVIGATION_UPDATE_DIRECTORY_LAUNCHPAD_CHANNEL,
 } from "../../shared/ipc";
 import { FocusedDiffService } from "../diff-focus/focused-diff-service";
@@ -1103,6 +1112,111 @@ class DesktopAppServerService {
     return { backend, pinnedRanks };
   }
 
+  async setThreadParent(
+    request: SetThreadParentRequest,
+  ): Promise<SetThreadParentResponse> {
+    const backend = request.backend ?? "codex";
+    const overlay = await this.getOverlayStore().setThreadParent({
+      backend,
+      threadId: request.threadId,
+      parentThreadId: request.parentThreadId,
+    });
+
+    logDebug("setThreadParent", {
+      backend,
+      threadId: request.threadId,
+      parentThreadId: overlay.parentThreadId ?? null,
+    });
+
+    await getDesktopBackendRegistry().publishLocalEvent({
+      backend,
+      notification: overlay.parentThreadId
+        ? {
+            method: "thread/parent/set",
+            params: {
+              threadId: request.threadId,
+              parentThreadId: overlay.parentThreadId,
+            },
+          }
+        : {
+            method: "thread/parent/cleared",
+            params: {
+              threadId: request.threadId,
+            },
+          },
+    });
+
+    return {
+      backend,
+      threadId: request.threadId,
+      parentThreadId: overlay.parentThreadId,
+    };
+  }
+
+  async updateSubthreadOrder(
+    request: UpdateSubthreadOrderRequest,
+  ): Promise<UpdateSubthreadOrderResponse> {
+    const backend = request.backend ?? "codex";
+    const threadIds = await this.getOverlayStore().updateSubthreadOrder({
+      backend,
+      parentThreadId: request.parentThreadId,
+      threadIds: request.threadIds,
+    });
+
+    logDebug("updateSubthreadOrder", {
+      backend,
+      parentThreadId: request.parentThreadId,
+      childCount: threadIds.length,
+    });
+
+    await getDesktopBackendRegistry().publishLocalEvent({
+      backend,
+      notification: {
+        method: "thread/subthreadOrder/updated",
+        params: {
+          parentThreadId: request.parentThreadId,
+          threadIds,
+        },
+      },
+    });
+
+    return { backend, parentThreadId: request.parentThreadId, threadIds };
+  }
+
+  async setSubthreadsCollapsed(
+    request: SetSubthreadsCollapsedRequest,
+  ): Promise<SetSubthreadsCollapsedResponse> {
+    const backend = request.backend ?? "codex";
+    const overlay = await this.getOverlayStore().setSubthreadsCollapsed({
+      backend,
+      parentThreadId: request.parentThreadId,
+      collapsed: request.collapsed,
+    });
+
+    logDebug("setSubthreadsCollapsed", {
+      backend,
+      parentThreadId: request.parentThreadId,
+      collapsed: overlay.subthreadsCollapsed === true,
+    });
+
+    await getDesktopBackendRegistry().publishLocalEvent({
+      backend,
+      notification: {
+        method: "thread/subthreadsCollapsed/updated",
+        params: {
+          parentThreadId: request.parentThreadId,
+          collapsed: overlay.subthreadsCollapsed === true,
+        },
+      },
+    });
+
+    return {
+      backend,
+      parentThreadId: request.parentThreadId,
+      collapsed: overlay.subthreadsCollapsed === true,
+    };
+  }
+
   /**
    * Directory pin handlers (plan 2026-05-09-002, Unit G). Mirror of
    * `setThreadPin` / `reorderThreadPins` with the `backend` dim
@@ -1529,6 +1643,36 @@ export function registerAppServerIpcHandlers(): void {
       request: ReorderThreadPinsRequest,
     ): Promise<ReorderThreadPinsResponse> => {
       return await appServerService.reorderThreadPins(request);
+    },
+  );
+  ipcMain.removeHandler(NAVIGATION_SET_THREAD_PARENT_CHANNEL);
+  ipcMain.handle(
+    NAVIGATION_SET_THREAD_PARENT_CHANNEL,
+    async (
+      _event,
+      request: SetThreadParentRequest,
+    ): Promise<SetThreadParentResponse> => {
+      return await appServerService.setThreadParent(request);
+    },
+  );
+  ipcMain.removeHandler(NAVIGATION_UPDATE_SUBTHREAD_ORDER_CHANNEL);
+  ipcMain.handle(
+    NAVIGATION_UPDATE_SUBTHREAD_ORDER_CHANNEL,
+    async (
+      _event,
+      request: UpdateSubthreadOrderRequest,
+    ): Promise<UpdateSubthreadOrderResponse> => {
+      return await appServerService.updateSubthreadOrder(request);
+    },
+  );
+  ipcMain.removeHandler(NAVIGATION_SET_SUBTHREADS_COLLAPSED_CHANNEL);
+  ipcMain.handle(
+    NAVIGATION_SET_SUBTHREADS_COLLAPSED_CHANNEL,
+    async (
+      _event,
+      request: SetSubthreadsCollapsedRequest,
+    ): Promise<SetSubthreadsCollapsedResponse> => {
+      return await appServerService.setSubthreadsCollapsed(request);
     },
   );
   ipcMain.removeHandler(NAVIGATION_SET_DIRECTORY_PIN_CHANNEL);

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -691,7 +691,11 @@ export class MessagingController {
     if (
       event.notification.method === "thread/executionMode/updated" ||
       event.notification.method === "thread/modelSettings/updated" ||
-      event.notification.method === "thread/codexEnvironment/updated"
+      event.notification.method === "thread/codexEnvironment/updated" ||
+      event.notification.method === "thread/parent/set" ||
+      event.notification.method === "thread/parent/cleared" ||
+      event.notification.method === "thread/subthreadOrder/updated" ||
+      event.notification.method === "thread/subthreadsCollapsed/updated"
     ) {
       await this.refreshStatusSurfacesForThread(
         event.backend,
@@ -10453,8 +10457,14 @@ function sharedConversationMentionInstruction(
 }
 
 function threadIdForBackendEvent(event: AgentEvent): ThreadIdentifier | undefined {
-  const params = event.notification.params as { threadId?: unknown };
-  return typeof params.threadId === "string" ? params.threadId : undefined;
+  const params = event.notification.params as {
+    parentThreadId?: unknown;
+    threadId?: unknown;
+  };
+  if (typeof params.threadId === "string") {
+    return params.threadId;
+  }
+  return typeof params.parentThreadId === "string" ? params.parentThreadId : undefined;
 }
 
 function turnIdForBackendEvent(event: AgentEvent): string | undefined {

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -122,6 +122,9 @@ export class SqliteOverlayStore {
           extraLinkedDirectories: current?.extraLinkedDirectories ?? [],
           worktreeSnapshots: current?.worktreeSnapshots ?? [],
           pinnedRank: current?.pinnedRank,
+          parentThreadId: current?.parentThreadId,
+          subthreadOrder: current?.subthreadOrder,
+          subthreadsCollapsed: current?.subthreadsCollapsed,
           permissionTransitionLog: current?.permissionTransitionLog,
           messagingBindingTransitionLog:
             current?.messagingBindingTransitionLog,
@@ -391,6 +394,92 @@ export class SqliteOverlayStore {
     });
     write();
     return pinnedRanks;
+  }
+
+  async setThreadParent(params: {
+    backend: ThreadOverlayState["backend"];
+    threadId: string;
+    parentThreadId?: string | null;
+  }): Promise<ThreadOverlayState> {
+    if (params.parentThreadId === params.threadId) {
+      throw new Error("A thread cannot be its own parent.");
+    }
+    const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+    const current = this.getThread(threadKey) ?? {
+      backend: params.backend,
+      threadId: params.threadId,
+      executionMode: "default" as const,
+      extraLinkedDirectories: [],
+    };
+    const parentThreadId = params.parentThreadId?.trim();
+    const nextState: ThreadOverlayState = {
+      ...current,
+      parentThreadId: parentThreadId || undefined,
+      pinnedRank: parentThreadId ? undefined : current.pinnedRank,
+    };
+    this.putThread(threadKey, nextState);
+    if (parentThreadId) {
+      const parentKey = buildThreadIdentityKey(params.backend, parentThreadId);
+      const parent = this.getThread(parentKey) ?? {
+        backend: params.backend,
+        threadId: parentThreadId,
+        executionMode: "default" as const,
+        extraLinkedDirectories: [],
+      };
+      this.putThread(parentKey, {
+        ...parent,
+        subthreadOrder: [
+          ...(parent.subthreadOrder ?? []).filter((id) => id !== params.threadId),
+          params.threadId,
+        ],
+      });
+    }
+    return nextState;
+  }
+
+  async updateSubthreadOrder(params: {
+    backend: ThreadOverlayState["backend"];
+    parentThreadId: string;
+    threadIds: string[];
+  }): Promise<string[]> {
+    const parentKey = buildThreadIdentityKey(params.backend, params.parentThreadId);
+    const parent = this.getThread(parentKey) ?? {
+      backend: params.backend,
+      threadId: params.parentThreadId,
+      executionMode: "default" as const,
+      extraLinkedDirectories: [],
+    };
+    const seen = new Set<string>();
+    const threadIds = params.threadIds.filter((threadId) => {
+      if (seen.has(threadId)) return false;
+      seen.add(threadId);
+      return threadId !== params.parentThreadId;
+    });
+    this.putThread(parentKey, {
+      ...parent,
+      subthreadOrder: threadIds,
+    });
+    return threadIds;
+  }
+
+  async setSubthreadsCollapsed(params: {
+    backend: ThreadOverlayState["backend"];
+    parentThreadId: string;
+    collapsed: boolean;
+  }): Promise<ThreadOverlayState> {
+    const parentKey = buildThreadIdentityKey(params.backend, params.parentThreadId);
+    const parent = this.getThread(parentKey) ?? {
+      backend: params.backend,
+      threadId: params.parentThreadId,
+      executionMode: "default" as const,
+      extraLinkedDirectories: [],
+    };
+    const nextState: ThreadOverlayState = {
+      ...parent,
+      subthreadsCollapsed: params.collapsed,
+    };
+    this.putThread(parentKey, nextState);
+    return nextState;
   }
 
   /**
@@ -1043,8 +1132,11 @@ export type OverlayStoreLike = Pick<
   | "getThreadOverlayStates"
   | "setThreadReaction"
   | "setThreadPin"
+  | "setThreadParent"
   | "setThreadAgent"
   | "reorderThreadPins"
+  | "updateSubthreadOrder"
+  | "setSubthreadsCollapsed"
   | "setDirectoryPin"
   | "reorderDirectoryPins"
   | "getDirectoryOverlayState"

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -13,6 +13,8 @@ import type {
   CancelThreadExecutionModeQueueResponse,
   EnsureDirectoryLaunchpadRequest,
   EnsureDirectoryLaunchpadResponse,
+  ForkThreadRequest,
+  ForkThreadResponse,
   InterruptTurnRequest,
   InterruptTurnResponse,
   ListAutomationCardsRequest,
@@ -196,6 +198,7 @@ import type {
 import {
   AGENT_CANCEL_THREAD_EXECUTION_MODE_QUEUE_CHANNEL,
   AGENT_EVENT_CHANNEL,
+  AGENT_FORK_THREAD_CHANNEL,
   AGENT_LATEST_CODEX_CONFIG_WARNING_CHANNEL,
   APPEARANCE_CHANGED_EVENT_CHANNEL,
   AGENT_CHECK_THREAD_BRANCH_DRIFT_CHANNEL,
@@ -613,6 +616,10 @@ const desktopApi = Object.freeze({
     request: StartThreadRequest
   ): Promise<StartThreadResponse> =>
     await ipcRenderer.invoke(AGENT_START_THREAD_CHANNEL, request),
+  forkThread: async (
+    request: ForkThreadRequest,
+  ): Promise<ForkThreadResponse> =>
+    await ipcRenderer.invoke(AGENT_FORK_THREAD_CHANNEL, request),
   startReview: async (
     request: StartReviewRequest
   ): Promise<StartReviewResponse> =>

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -66,8 +66,12 @@ import type {
   ReorderDirectoryPinsResponse,
   ReorderThreadPinsRequest,
   ReorderThreadPinsResponse,
+  SetSubthreadsCollapsedRequest,
+  SetSubthreadsCollapsedResponse,
   SetDirectoryPinRequest,
   SetDirectoryPinResponse,
+  SetThreadParentRequest,
+  SetThreadParentResponse,
   SetThreadPinRequest,
   SetThreadPinResponse,
   SetThreadReactionRequest,
@@ -176,6 +180,8 @@ import type {
   StartDesktopCodexAuthProfileLoginResponse,
   UpdateDirectoryLaunchpadRequest,
   UpdateDirectoryLaunchpadResponse,
+  UpdateSubthreadOrderRequest,
+  UpdateSubthreadOrderResponse,
   UpdateThreadExpectedBranchRequest,
   UpdateThreadExpectedBranchResponse,
   WriteDesktopSettingsConfigRequest,
@@ -277,12 +283,15 @@ import {
   NAVIGATION_REORDER_THREAD_PINS_CHANNEL,
   NAVIGATION_REGISTER_DIRECTORY_FROM_DISK_CHANNEL,
   NAVIGATION_MARK_THREAD_SEEN_CHANNEL,
+  NAVIGATION_SET_SUBTHREADS_COLLAPSED_CHANNEL,
   NAVIGATION_SET_DIRECTORY_PIN_CHANNEL,
+  NAVIGATION_SET_THREAD_PARENT_CHANNEL,
   NAVIGATION_SET_THREAD_AGENT_CHANNEL,
   NAVIGATION_SET_THREAD_PIN_CHANNEL,
   NAVIGATION_SET_THREAD_REACTION_CHANNEL,
   NAVIGATION_RESET_DIRECTORY_LAUNCHPAD_CHANNEL,
   NAVIGATION_SNAPSHOT_CHANNEL,
+  NAVIGATION_UPDATE_SUBTHREAD_ORDER_CHANNEL,
   NAVIGATION_UPDATE_DIRECTORY_LAUNCHPAD_CHANNEL,
   ONBOARDING_COMPLETE_CODEX_BOOTSTRAP_CHANNEL,
   PRELOAD_LOG_CHANNEL,
@@ -717,6 +726,18 @@ const desktopApi = Object.freeze({
     request: ReorderThreadPinsRequest,
   ): Promise<ReorderThreadPinsResponse> =>
     await ipcRenderer.invoke(NAVIGATION_REORDER_THREAD_PINS_CHANNEL, request),
+  setThreadParent: async (
+    request: SetThreadParentRequest,
+  ): Promise<SetThreadParentResponse> =>
+    await ipcRenderer.invoke(NAVIGATION_SET_THREAD_PARENT_CHANNEL, request),
+  updateSubthreadOrder: async (
+    request: UpdateSubthreadOrderRequest,
+  ): Promise<UpdateSubthreadOrderResponse> =>
+    await ipcRenderer.invoke(NAVIGATION_UPDATE_SUBTHREAD_ORDER_CHANNEL, request),
+  setSubthreadsCollapsed: async (
+    request: SetSubthreadsCollapsedRequest,
+  ): Promise<SetSubthreadsCollapsedResponse> =>
+    await ipcRenderer.invoke(NAVIGATION_SET_SUBTHREADS_COLLAPSED_CHANNEL, request),
   setDirectoryPin: async (
     request: SetDirectoryPinRequest,
   ): Promise<SetDirectoryPinResponse> =>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -515,6 +515,10 @@ function DesktopAppShell(props: {
           setMainView("thread");
           await navigation.createThread();
         }}
+        onCreateSubthread={async (thread, mode) => {
+          setMainView("thread");
+          await navigation.createSubthread(thread, mode);
+        }}
         onOpenAutomations={() => {
           setMainView("automations");
         }}
@@ -536,6 +540,9 @@ function DesktopAppShell(props: {
         onSetThreadReaction={navigation.setThreadReaction}
         onSetThreadPin={navigation.setThreadPin}
         onReorderThreadPins={navigation.reorderThreadPins}
+        onSetThreadParent={navigation.setThreadParent}
+        onUpdateSubthreadOrder={navigation.updateSubthreadOrder}
+        onSetSubthreadsCollapsed={navigation.setSubthreadsCollapsed}
         onSetDirectoryPin={navigation.setDirectoryPin}
         onReorderDirectoryPins={navigation.reorderDirectoryPins}
         onPrefetchPullRequests={pullRequests.prefetch}

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -34,6 +34,7 @@ import { useThreadSessionState } from "./lib/useThreadSessionState";
 import { useThreadSkills } from "./lib/useThreadSkills";
 import { useQueuedTurnRelease } from "./lib/useQueuedTurnRelease";
 import { CodexConfigWarningBanner } from "./features/codex-config/CodexConfigWarningBanner";
+import { AppNoticeToast } from "./features/notifications/AppNoticeToast";
 import { AppUpdateBanner } from "./features/update/AppUpdateBanner";
 import { AutomationsScreen } from "./features/automations/AutomationsScreen";
 
@@ -697,7 +698,14 @@ function DesktopAppShell(props: {
       ) : null}
 
       <CodexConfigWarningBanner desktopApi={desktopApi} />
-      <AppUpdateBanner desktopApi={desktopApi} />
+      <div className="app-toast-stack" aria-live="polite">
+        <AppNoticeToast
+          desktopApi={desktopApi}
+          notice={navigation.archiveThreadNotice}
+          onDismiss={navigation.dismissArchiveThreadNotice}
+        />
+        <AppUpdateBanner desktopApi={desktopApi} />
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -519,6 +519,10 @@ function DesktopAppShell(props: {
           setMainView("thread");
           await navigation.createSubthread(thread, mode);
         }}
+        onForkThread={async (thread, mode) => {
+          setMainView("thread");
+          await navigation.forkThread(thread, mode);
+        }}
         onOpenAutomations={() => {
           setMainView("automations");
         }}

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -3787,6 +3787,9 @@ export function Composer(props: ComposerProps) {
     launchpadWorkspaceOptions.some((option) => option.value === props.launchpad?.workMode)
       ? props.launchpad.workMode
       : "local";
+  const launchpadBranchOptions = props.launchpad
+    ? buildLaunchpadBranchOptions(props.launchpad, props.directory)
+    : [];
   const launchpadCodexEnvironmentOptions =
     props.launchpad?.codexEnvironmentOptions ?? [];
   const selectedCodexEnvironment = launchpadCodexEnvironmentOptions.find(
@@ -5183,7 +5186,7 @@ export function Composer(props: ComposerProps) {
 
           {props.launchpad &&
           launchpadWorkspaceValue === "worktree" &&
-          (props.directory?.gitStatus?.branches?.length ?? 0) > 0 ? (
+          launchpadBranchOptions.length > 0 ? (
             <ComposerDropdown
               ariaLabel="Base branch"
               id="launchpad-branch"
@@ -5195,7 +5198,7 @@ export function Composer(props: ComposerProps) {
                 props.directory?.gitStatus?.currentBranch ??
                 ""
               }
-              options={(props.directory?.gitStatus?.branches ?? []).map((branch) => ({
+              options={launchpadBranchOptions.map((branch) => ({
                 label: branch,
                 value: branch,
               }))}
@@ -5872,7 +5875,9 @@ function buildLaunchpadWorkspaceOptions(
     directory?.path &&
       directory.kind === "directory" &&
       (directory.gitStatus?.currentBranch ||
-        (directory.gitStatus?.branches?.length ?? 0) > 0)
+        (directory.gitStatus?.branches?.length ?? 0) > 0 ||
+        (launchpad.workMode === "worktree" &&
+          Boolean(launchpad.parentThreadId)))
   );
   const options: Array<{ value: NavigationLaunchpadDraft["workMode"]; label: string }> = [
     { value: "local", label: localLabel ?? "Local" },
@@ -5883,6 +5888,25 @@ function buildLaunchpadWorkspaceOptions(
   }
 
   return options;
+}
+
+function buildLaunchpadBranchOptions(
+  launchpad: NavigationLaunchpadDraft,
+  directory?: NavigationDirectorySummary,
+): string[] {
+  const candidates = [
+    launchpad.branchName,
+    directory?.gitStatus?.currentBranch,
+    ...(directory?.gitStatus?.branches ?? []),
+  ];
+  const options = new Set<string>();
+  for (const candidate of candidates) {
+    const value = candidate?.trim();
+    if (value) {
+      options.add(value);
+    }
+  }
+  return [...options];
 }
 
 function formatThreadWorkspaceLabel(thread?: NavigationThreadSummary): string | undefined {

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -43,6 +43,7 @@ import {
   formatExecutionModeLabel,
   getAcpRuntimeModeControl,
 } from "../../lib/execution-mode";
+import { isSameWorktreeSubthreadLaunchpad } from "../../lib/subthread-launchpads";
 import { normalizeImageFile } from "../../lib/image-normalization";
 import type { ThreadContextWindowState } from "../../lib/useThreadSessionState";
 import {
@@ -5854,6 +5855,10 @@ function formatLaunchpadWorkspaceLabel(
     return "New worktree";
   }
 
+  if (isSameWorktreeSubthreadLaunchpad(launchpad.directoryKey)) {
+    return "Same worktree";
+  }
+
   if (directory?.kind === "workspace") {
     return "Workspace";
   }
@@ -5871,6 +5876,10 @@ function buildLaunchpadWorkspaceOptions(
     { ...launchpad, workMode: "local" },
     directory
   );
+  if (isSameWorktreeSubthreadLaunchpad(launchpad.directoryKey)) {
+    return [{ value: "local", label: localLabel ?? "Same worktree" }];
+  }
+
   const canCreateWorktree = Boolean(
     directory?.path &&
       directory.kind === "directory" &&

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -4853,6 +4853,109 @@ describe("Composer", () => {
     });
   });
 
+  it("keeps a new-worktree launchpad selected before git status loads", () => {
+    const onUpdateLaunchpad = vi.fn(async () => undefined);
+
+    render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        directory={{
+          key: "subthread:codex:thread-parent:new-worktree",
+          kind: "directory",
+          label: "PwrAgent",
+          path: "/Users/huntharo/pwrdrvr/PwrAgent",
+          threadKeys: [],
+          needsAttentionCount: 0,
+        }}
+        launchpad={{
+          directoryKey: "subthread:codex:thread-parent:new-worktree",
+          directoryKind: "directory",
+          directoryLabel: "PwrAgent",
+          directoryPath: "/Users/huntharo/pwrdrvr/PwrAgent",
+          backend: "codex",
+          executionMode: "default",
+          prompt: "",
+          workMode: "worktree",
+          branchName: "main",
+          parentThreadId: "thread-parent",
+          parentThreadTitle: "Issue 193 Markdown attachments",
+          createdAt: 1,
+          updatedAt: 1,
+        }}
+        onUpdateLaunchpad={onUpdateLaunchpad}
+        skills={[]}
+      />
+    );
+
+    const workspaceMode = screen.getByLabelText("Workspace mode");
+    expect(workspaceMode).toHaveValue("worktree");
+    expect(workspaceMode).toHaveTextContent("New worktree");
+    expect(screen.getByLabelText("Base branch")).toHaveValue("main");
+  });
+
+  it("does not flip a new-worktree launchpad to local when review draft toggles", async () => {
+    const onUpdateLaunchpad = vi.fn(async () => undefined);
+    const launchpad = {
+      directoryKey: "subthread:codex:thread-parent:new-worktree",
+      directoryKind: "directory" as const,
+      directoryLabel: "PwrAgent",
+      directoryPath: "/Users/huntharo/pwrdrvr/PwrAgent",
+      backend: "codex" as const,
+      executionMode: "default" as const,
+      prompt: "",
+      workMode: "worktree" as const,
+      branchName: "main",
+      parentThreadId: "thread-parent",
+      parentThreadTitle: "Issue 193 Markdown attachments",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    const { rerender } = render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        directory={{
+          key: "subthread:codex:thread-parent:new-worktree",
+          kind: "directory",
+          label: "PwrAgent",
+          path: "/Users/huntharo/pwrdrvr/PwrAgent",
+          threadKeys: [],
+          needsAttentionCount: 0,
+        }}
+        launchpad={launchpad}
+        onUpdateLaunchpad={onUpdateLaunchpad}
+        skills={[]}
+      />
+    );
+
+    const input = screen.getByLabelText("New thread");
+    fireEvent.change(input, { target: { value: "/review" } });
+    await clickButton("Start thread");
+    expect(screen.getByLabelText("Workspace mode")).toHaveValue("worktree");
+    expect(screen.getByRole("group", { name: "Review target" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    rerender(
+      <Composer
+        backends={[backendSummary("codex")]}
+        directory={{
+          key: "subthread:codex:thread-parent:new-worktree",
+          kind: "directory",
+          label: "PwrAgent",
+          path: "/Users/huntharo/pwrdrvr/PwrAgent",
+          threadKeys: [],
+          needsAttentionCount: 0,
+        }}
+        launchpad={{ ...launchpad, prompt: "/review", updatedAt: 2 }}
+        onUpdateLaunchpad={onUpdateLaunchpad}
+        skills={[]}
+      />
+    );
+
+    expect(screen.getByLabelText("Workspace mode")).toHaveValue("worktree");
+    expect(screen.getByLabelText("Workspace mode")).toHaveTextContent("New worktree");
+  });
+
   it("does not offer worktree launchpad mode for non-git directories", () => {
     render(
       <Composer

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -4956,6 +4956,45 @@ describe("Composer", () => {
     expect(screen.getByLabelText("Workspace mode")).toHaveTextContent("New worktree");
   });
 
+  it("locks same-worktree sub-thread launchpads to the shared worktree", () => {
+    render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        directory={{
+          key: "subthread:codex:thread-parent:same-worktree",
+          kind: "directory",
+          label: "PwrAgent",
+          path: "/Users/huntharo/.codex/worktrees/mpsmzvdh/PwrAgnt",
+          threadKeys: [],
+          needsAttentionCount: 0,
+        }}
+        launchpad={{
+          directoryKey: "subthread:codex:thread-parent:same-worktree",
+          directoryKind: "directory",
+          directoryLabel: "PwrAgent",
+          directoryPath: "/Users/huntharo/.codex/worktrees/mpsmzvdh/PwrAgnt",
+          backend: "codex",
+          executionMode: "default",
+          prompt: "",
+          workMode: "local",
+          branchName: "feat/messaging-artifact-delivery",
+          parentThreadId: "thread-parent",
+          parentThreadTitle: "Issue 193 Markdown attachments",
+          createdAt: 1,
+          updatedAt: 1,
+        }}
+        onUpdateLaunchpad={async () => undefined}
+        skills={[]}
+      />
+    );
+
+    const workspaceMode = screen.getByLabelText("Workspace mode");
+    expect(workspaceMode).toBeDisabled();
+    expect(workspaceMode).toHaveValue("local");
+    expect(workspaceMode).toHaveTextContent("Same worktree");
+    expect(screen.queryByRole("option", { name: "New worktree" })).not.toBeInTheDocument();
+  });
+
   it("does not offer worktree launchpad mode for non-git directories", () => {
     render(
       <Composer

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -1,5 +1,6 @@
 import {
   useEffect,
+  Fragment,
   useMemo,
   useRef,
   useState,
@@ -52,6 +53,14 @@ type DirectoriesListProps = {
   onReorderThreadPins?: (
     backend: AppServerBackendKind,
     threadIds: string[],
+  ) => Promise<void>;
+  onUpdateSubthreadOrder?: (
+    parent: NavigationThreadSummary,
+    threadIds: string[],
+  ) => Promise<void>;
+  onSetSubthreadsCollapsed?: (
+    parent: NavigationThreadSummary,
+    collapsed: boolean,
   ) => Promise<void>;
   /**
    * Directory pinning (plan 2026-05-09-002, Unit K). When both
@@ -421,10 +430,71 @@ export function DirectoriesList(props: DirectoriesListProps) {
     const visibleThreads = directory.threadKeys
       .map((threadKey) => threadsByKey.get(threadKey))
       .filter((thread): thread is NavigationThreadSummary => Boolean(thread));
-    const directoryPinnedThreads = visibleThreads
+    const visibleThreadKeys = new Set(
+      visibleThreads.map((thread) => buildThreadIdentityKey(thread.source, thread.id)),
+    );
+    const childThreadsByParentKey = new Map<string, NavigationThreadSummary[]>();
+    for (const thread of visibleThreads) {
+      if (!thread.parentThreadId) continue;
+      const parentKey = buildThreadIdentityKey(thread.source, thread.parentThreadId);
+      if (!visibleThreadKeys.has(parentKey)) continue;
+      const children = childThreadsByParentKey.get(parentKey) ?? [];
+      children.push(thread);
+      childThreadsByParentKey.set(parentKey, children);
+    }
+    const topLevelVisibleThreads = visibleThreads.filter((thread) => {
+      if (!thread.parentThreadId) return true;
+      return !visibleThreadKeys.has(buildThreadIdentityKey(thread.source, thread.parentThreadId));
+    });
+    const sortSubthreads = (
+      parent: NavigationThreadSummary,
+      children: NavigationThreadSummary[],
+    ): NavigationThreadSummary[] => {
+      const order = new Map(
+        (parent.subthreadOrder ?? []).map((threadId, index) => [threadId, index]),
+      );
+      return [...children].sort((left, right) => {
+        const leftRank = order.get(left.id);
+        const rightRank = order.get(right.id);
+        if (leftRank !== undefined || rightRank !== undefined) {
+          return (leftRank ?? Number.MAX_SAFE_INTEGER) - (rightRank ?? Number.MAX_SAFE_INTEGER);
+        }
+        return (right.createdAt ?? 0) - (left.createdAt ?? 0);
+      });
+    };
+    const renderStaticSubthreads = (parent: NavigationThreadSummary): ReactElement | null => {
+      const parentKey = buildThreadIdentityKey(parent.source, parent.id);
+      const children = sortSubthreads(parent, childThreadsByParentKey.get(parentKey) ?? []);
+      if (children.length === 0 || parent.subthreadsCollapsed) {
+        return null;
+      }
+      return (
+        <div className="subthread-list subthread-list--compact" role="list" aria-label={`Sub-threads of ${parent.title}`}>
+          {children.map((child) => (
+            <ThreadRow
+              key={`${directory.key}:${buildThreadIdentityKey(child.source, child.id)}`}
+              approvalRequestThreadKeys={props.approvalRequestThreadKeys}
+              compact
+              includeLinkedDirectories
+              linkedDirectoryMode="kind"
+              nested
+              selectedThreadKey={props.selectedItemKey}
+              thinkingThreadKeys={props.thinkingThreadKeys}
+              thread={child}
+              onOpenContextMenu={props.onOpenThreadContextMenu}
+              onPrefetchPullRequests={props.onPrefetchPullRequests}
+              onSelectThread={props.onSelectThread}
+              onSetReaction={props.onSetReaction}
+              onUnbindMessagingBinding={props.onUnbindMessagingBinding}
+            />
+          ))}
+        </div>
+      );
+    };
+    const directoryPinnedThreads = topLevelVisibleThreads
       .filter(isPinnedThread)
       .sort(comparePinnedThreads);
-    const directoryUnpinnedThreads = visibleThreads.filter(
+    const directoryUnpinnedThreads = topLevelVisibleThreads.filter(
       (thread) => !isPinnedThread(thread),
     );
 
@@ -681,11 +751,14 @@ export function DirectoriesList(props: DirectoriesListProps) {
                 {visibleThreads.length > 0 ? (
                   <div className="sidebar-list sidebar-list--compact directory-row__threads">
                     {directoryPinnedThreads.map((thread) => {
-                      const threadKey = buildThreadIdentityKey(thread.source, thread.id);
-                      const rowDropKey = `${directory.key}:${threadKey}`;
-                      return (
-                        <ThreadRow
-                          key={`${directory.key}:${threadKey}`}
+	                      const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+	                      const rowDropKey = `${directory.key}:${threadKey}`;
+                          const subthreadCount =
+                            childThreadsByParentKey.get(threadKey)?.length ?? 0;
+	                      return (
+                            <Fragment key={`${directory.key}:${threadKey}`}>
+	                        <ThreadRow
+	                          key={`${directory.key}:${threadKey}`}
                           approvalRequestThreadKeys={props.approvalRequestThreadKeys}
                           compact
                           dropIndicator={
@@ -696,9 +769,20 @@ export function DirectoriesList(props: DirectoriesListProps) {
                           draggable={Boolean(props.onReorderThreadPins)}
                           includeLinkedDirectories
                           linkedDirectoryMode="kind"
-                          selectedThreadKey={props.selectedItemKey}
-                          thinkingThreadKeys={props.thinkingThreadKeys}
-                          thread={thread}
+	                          selectedThreadKey={props.selectedItemKey}
+                              subthreadCount={subthreadCount}
+                              subthreadsCollapsed={thread.subthreadsCollapsed === true}
+	                          thinkingThreadKeys={props.thinkingThreadKeys}
+	                          thread={thread}
+                              onToggleSubthreads={
+                                subthreadCount > 0 && props.onSetSubthreadsCollapsed
+                                  ? () =>
+                                      void props.onSetSubthreadsCollapsed!(
+                                        thread,
+                                        thread.subthreadsCollapsed !== true,
+                                      )
+                                  : undefined
+                              }
                           onDragOverThread={(event) => {
                             event.preventDefault();
                             const draggedThread = draggedThreadKey
@@ -763,9 +847,11 @@ export function DirectoriesList(props: DirectoriesListProps) {
                           onPrefetchPullRequests={props.onPrefetchPullRequests}
                           onSelectThread={props.onSelectThread}
                           onSetReaction={props.onSetReaction}
-                          onUnbindMessagingBinding={props.onUnbindMessagingBinding}
-                        />
-                      );
+	                          onUnbindMessagingBinding={props.onUnbindMessagingBinding}
+	                        />
+                              {renderStaticSubthreads(thread)}
+                            </Fragment>
+	                      );
                     })}
 
                     {directoryPinnedThreads.length > 0 &&
@@ -812,19 +898,33 @@ export function DirectoriesList(props: DirectoriesListProps) {
                       </div>
                     ) : null}
 
-                    {directoryUnpinnedThreads.map((thread) => {
-                      const threadKey = buildThreadIdentityKey(thread.source, thread.id);
-                      return (
-                        <ThreadRow
-                          key={`${directory.key}:${threadKey}`}
+	                    {directoryUnpinnedThreads.map((thread) => {
+	                      const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+                          const subthreadCount =
+                            childThreadsByParentKey.get(threadKey)?.length ?? 0;
+	                      return (
+                            <Fragment key={`${directory.key}:${threadKey}`}>
+	                        <ThreadRow
+	                          key={`${directory.key}:${threadKey}`}
                           approvalRequestThreadKeys={props.approvalRequestThreadKeys}
                           compact
                           draggable={Boolean(props.onReorderThreadPins)}
                           includeLinkedDirectories
-                          linkedDirectoryMode="kind"
-                          selectedThreadKey={props.selectedItemKey}
-                          thinkingThreadKeys={props.thinkingThreadKeys}
-                          thread={thread}
+	                          linkedDirectoryMode="kind"
+	                          selectedThreadKey={props.selectedItemKey}
+                              subthreadCount={subthreadCount}
+                              subthreadsCollapsed={thread.subthreadsCollapsed === true}
+	                          thinkingThreadKeys={props.thinkingThreadKeys}
+	                          thread={thread}
+                              onToggleSubthreads={
+                                subthreadCount > 0 && props.onSetSubthreadsCollapsed
+                                  ? () =>
+                                      void props.onSetSubthreadsCollapsed!(
+                                        thread,
+                                        thread.subthreadsCollapsed !== true,
+                                      )
+                                  : undefined
+                              }
                           onDragStartThread={(event) => {
                             setDraggedThreadKey(threadKey);
                             event.dataTransfer.effectAllowed = "move";
@@ -839,9 +939,11 @@ export function DirectoriesList(props: DirectoriesListProps) {
                           onPrefetchPullRequests={props.onPrefetchPullRequests}
                           onSelectThread={props.onSelectThread}
                           onSetReaction={props.onSetReaction}
-                          onUnbindMessagingBinding={props.onUnbindMessagingBinding}
-                        />
-                      );
+	                          onUnbindMessagingBinding={props.onUnbindMessagingBinding}
+	                        />
+                              {renderStaticSubthreads(thread)}
+                            </Fragment>
+	                      );
                     })}
                   </div>
                 ) : (

--- a/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
@@ -32,6 +32,14 @@ type RecentsListProps = {
     backend: AppServerBackendKind,
     threadIds: string[],
   ) => Promise<void>;
+  onUpdateSubthreadOrder?: (
+    parent: NavigationThreadSummary,
+    threadIds: string[],
+  ) => Promise<void>;
+  onSetSubthreadsCollapsed?: (
+    parent: NavigationThreadSummary,
+    collapsed: boolean,
+  ) => Promise<void>;
   onSelectThread: (thread: NavigationThreadSummary) => void;
   onSetReaction?: (
     thread: NavigationThreadSummary,
@@ -52,19 +60,48 @@ export function RecentsList(props: RecentsListProps) {
   const [draggedThreadKey, setDraggedThreadKey] = useState<string | undefined>(
     undefined,
   );
-  const pinnedThreads = props.threads
-    .filter(isPinnedThread)
-    .sort(comparePinnedThreads);
-  const pinnedThreadKeys = pinnedThreads.map((thread) =>
-    buildThreadIdentityKey(thread.source, thread.id),
-  );
   const threadByKey = new Map(
     props.threads.map((thread) => [
       buildThreadIdentityKey(thread.source, thread.id),
       thread,
     ]),
   );
-  const unpinnedThreads = props.threads.filter((thread) => !isPinnedThread(thread));
+  const topLevelThreads = props.threads.filter((thread) => {
+    if (!thread.parentThreadId) return true;
+    return !threadByKey.has(buildThreadIdentityKey(thread.source, thread.parentThreadId));
+  });
+  const childrenByParentKey = new Map<string, NavigationThreadSummary[]>();
+  for (const thread of props.threads) {
+    if (!thread.parentThreadId) continue;
+    const parentKey = buildThreadIdentityKey(thread.source, thread.parentThreadId);
+    if (!threadByKey.has(parentKey)) continue;
+    const children = childrenByParentKey.get(parentKey) ?? [];
+    children.push(thread);
+    childrenByParentKey.set(parentKey, children);
+  }
+  const sortSubthreads = (
+    parent: NavigationThreadSummary,
+    children: NavigationThreadSummary[],
+  ): NavigationThreadSummary[] => {
+    const order = new Map(
+      (parent.subthreadOrder ?? []).map((threadId, index) => [threadId, index]),
+    );
+    return [...children].sort((left, right) => {
+      const leftRank = order.get(left.id);
+      const rightRank = order.get(right.id);
+      if (leftRank !== undefined || rightRank !== undefined) {
+        return (leftRank ?? Number.MAX_SAFE_INTEGER) - (rightRank ?? Number.MAX_SAFE_INTEGER);
+      }
+      return (right.createdAt ?? 0) - (left.createdAt ?? 0);
+    });
+  };
+  const pinnedThreads = topLevelThreads
+    .filter(isPinnedThread)
+    .sort(comparePinnedThreads);
+  const pinnedThreadKeys = pinnedThreads.map((thread) =>
+    buildThreadIdentityKey(thread.source, thread.id),
+  );
+  const unpinnedThreads = topLevelThreads.filter((thread) => !isPinnedThread(thread));
 
   const pinnedThreadKeysForBackend = (backend: AppServerBackendKind): string[] =>
     pinnedThreads
@@ -106,87 +143,216 @@ export function RecentsList(props: RecentsListProps) {
     );
   };
 
+  const renderSubthreads = (parent: NavigationThreadSummary) => {
+    const parentKey = buildThreadIdentityKey(parent.source, parent.id);
+    const children = sortSubthreads(parent, childrenByParentKey.get(parentKey) ?? []);
+    if (children.length === 0 || parent.subthreadsCollapsed) {
+      return null;
+    }
+
+    const childIds = children.map((child) => child.id);
+    return (
+      <div className="subthread-list" role="list" aria-label={`Sub-threads of ${parent.title}`}>
+        {children.map((child) => {
+          const childKey = buildThreadIdentityKey(child.source, child.id);
+          const rowDropKey = `${parentKey}:${childKey}`;
+          return (
+            <ThreadRow
+              key={childKey}
+              approvalRequestThreadKeys={props.approvalRequestThreadKeys}
+              dropIndicator={
+                dropIndicator?.targetKey === rowDropKey
+                  ? dropIndicator.position
+                  : undefined
+              }
+              draggable={children.length > 1 && Boolean(props.onUpdateSubthreadOrder)}
+              includeLinkedDirectories
+              nested
+              selectedThreadKey={props.selectedThreadKey}
+              thinkingThreadKeys={props.thinkingThreadKeys}
+              thread={child}
+              onDragOverThread={(event) => {
+                event.preventDefault();
+                const draggedKey = draggedThreadKey;
+                const draggedThread = draggedKey ? threadByKey.get(draggedKey) : undefined;
+                if (!draggedThread || draggedThread.parentThreadId !== parent.id) {
+                  event.dataTransfer.dropEffect = "none";
+                  setDropIndicator(undefined);
+                  return;
+                }
+                event.dataTransfer.dropEffect = "move";
+                setDropIndicator({
+                  targetKey: rowDropKey,
+                  position: getDropIndicatorPosition(event),
+                });
+              }}
+              onDragStartThread={(event) => {
+                setDraggedThreadKey(childKey);
+                event.dataTransfer.effectAllowed = "move";
+                event.dataTransfer.setData("text/plain", childKey);
+                event.dataTransfer.setData("application/x-pwragent-subthread", childKey);
+              }}
+              onDragLeaveThread={(event) => {
+                if (didDragLeaveCurrentTarget(event)) {
+                  setDropIndicator(undefined);
+                }
+              }}
+              onDragEndThread={() => {
+                setDraggedThreadKey(undefined);
+                setDropIndicator(undefined);
+              }}
+              onDropOnThread={(event) => {
+                event.preventDefault();
+                setDraggedThreadKey(undefined);
+                setDropIndicator(undefined);
+                const draggedKey =
+                  event.dataTransfer.getData("application/x-pwragent-subthread") ||
+                  event.dataTransfer.getData("text/plain");
+                const draggedThread = threadByKey.get(draggedKey);
+                if (!draggedThread || draggedThread.parentThreadId !== parent.id) {
+                  return;
+                }
+                const draggedId = parseThreadIdentityKey(draggedKey)?.threadId;
+                if (!draggedId) return;
+                const nextKeys = moveThreadKey(
+                  childIds.map((threadId) => buildThreadIdentityKey(parent.source, threadId)),
+                  draggedKey,
+                  childKey,
+                  getDropIndicatorPosition(event),
+                );
+                void props.onUpdateSubthreadOrder?.(
+                  parent,
+                  nextKeys
+                    .map((threadKey) => parseThreadIdentityKey(threadKey)?.threadId)
+                    .filter((threadId): threadId is string => Boolean(threadId)),
+                );
+              }}
+              onOpenContextMenu={props.onOpenThreadContextMenu}
+              onPrefetchPullRequests={props.onPrefetchPullRequests}
+              onSelectThread={props.onSelectThread}
+              onSetReaction={props.onSetReaction}
+              onUnbindMessagingBinding={props.onUnbindMessagingBinding}
+            />
+          );
+        })}
+      </div>
+    );
+  };
+
+  const renderThreadGroup = (thread: NavigationThreadSummary) => {
+    const key = buildThreadIdentityKey(thread.source, thread.id);
+    const children = sortSubthreads(thread, childrenByParentKey.get(key) ?? []);
+    const pinned = isPinnedThread(thread);
+    return (
+      <div key={key} className="thread-group">
+        <ThreadRow
+          approvalRequestThreadKeys={props.approvalRequestThreadKeys}
+          dropIndicator={
+            dropIndicator?.targetKey === key
+              ? dropIndicator.position
+              : undefined
+          }
+          draggable={pinned || pinnedThreads.length > 0}
+          includeLinkedDirectories
+          selectedThreadKey={props.selectedThreadKey}
+          subthreadCount={children.length}
+          subthreadsCollapsed={thread.subthreadsCollapsed === true}
+          thinkingThreadKeys={props.thinkingThreadKeys}
+          thread={thread}
+          onToggleSubthreads={
+            children.length > 0 && props.onSetSubthreadsCollapsed
+              ? () =>
+                  void props.onSetSubthreadsCollapsed!(
+                    thread,
+                    thread.subthreadsCollapsed !== true,
+                  )
+              : undefined
+          }
+          onDragOverThread={
+            pinned
+              ? (event) => {
+                  event.preventDefault();
+                  const draggedThread = draggedThreadKey
+                    ? threadByKey.get(draggedThreadKey)
+                    : undefined;
+                  if (
+                    !draggedThread ||
+                    draggedThread.source !== thread.source ||
+                    draggedThread.parentThreadId
+                  ) {
+                    event.dataTransfer.dropEffect = "none";
+                    setDropIndicator(undefined);
+                    return;
+                  }
+
+                  event.dataTransfer.dropEffect = "move";
+                  setDropIndicator({
+                    targetKey: key,
+                    position: getDropIndicatorPosition(event),
+                  });
+                  setDividerDropTarget(false);
+                }
+              : undefined
+          }
+          onDragStartThread={(event) => {
+            setDraggedThreadKey(key);
+            event.dataTransfer.effectAllowed = "move";
+            event.dataTransfer.setData("text/plain", key);
+          }}
+          onDragLeaveThread={(event) => {
+            if (didDragLeaveCurrentTarget(event)) {
+              setDropIndicator(undefined);
+            }
+          }}
+          onDragEndThread={() => {
+            setDraggedThreadKey(undefined);
+            setDropIndicator(undefined);
+            setDividerDropTarget(false);
+          }}
+          onDropOnThread={
+            pinned
+              ? (event) => {
+                  event.preventDefault();
+                  setDraggedThreadKey(undefined);
+                  setDropIndicator(undefined);
+                  setDividerDropTarget(false);
+                  const draggedKey = event.dataTransfer.getData("text/plain");
+                  if (!draggedKey) return;
+                  const draggedThread = threadByKey.get(draggedKey);
+                  if (
+                    !draggedThread ||
+                    draggedThread.source !== thread.source ||
+                    draggedThread.parentThreadId
+                  ) return;
+                  const backendPinnedThreadKeys = pinnedThreadKeysForBackend(thread.source);
+                  const position = getDropIndicatorPosition(event);
+                  const nextKeys = backendPinnedThreadKeys.includes(draggedKey)
+                    ? moveThreadKey(backendPinnedThreadKeys, draggedKey, key, position)
+                    : moveThreadKey(
+                        [...backendPinnedThreadKeys, draggedKey],
+                        draggedKey,
+                        key,
+                        position,
+                      );
+                  reorderPins(thread.source, nextKeys);
+                }
+              : undefined
+          }
+          onMovePinnedThread={pinned ? movePinnedThreadByKeyboard : undefined}
+          onOpenContextMenu={props.onOpenThreadContextMenu}
+          onPrefetchPullRequests={props.onPrefetchPullRequests}
+          onSelectThread={props.onSelectThread}
+          onSetReaction={props.onSetReaction}
+          onUnbindMessagingBinding={props.onUnbindMessagingBinding}
+        />
+        {renderSubthreads(thread)}
+      </div>
+    );
+  };
+
   return (
     <div className="sidebar-list sidebar-list--dense" role="list">
-      {pinnedThreads.map((thread) => {
-        const key = buildThreadIdentityKey(thread.source, thread.id);
-        return (
-          <ThreadRow
-            key={key}
-            approvalRequestThreadKeys={props.approvalRequestThreadKeys}
-            dropIndicator={
-              dropIndicator?.targetKey === key
-                ? dropIndicator.position
-                : undefined
-            }
-            draggable
-            includeLinkedDirectories
-            selectedThreadKey={props.selectedThreadKey}
-            thinkingThreadKeys={props.thinkingThreadKeys}
-            thread={thread}
-            onDragOverThread={(event) => {
-              event.preventDefault();
-              const draggedThread = draggedThreadKey
-                ? threadByKey.get(draggedThreadKey)
-                : undefined;
-              if (!draggedThread || draggedThread.source !== thread.source) {
-                event.dataTransfer.dropEffect = "none";
-                setDropIndicator(undefined);
-                return;
-              }
-
-              event.dataTransfer.dropEffect = "move";
-              setDropIndicator({
-                targetKey: key,
-                position: getDropIndicatorPosition(event),
-              });
-              setDividerDropTarget(false);
-            }}
-            onDragStartThread={(event) => {
-              setDraggedThreadKey(key);
-              event.dataTransfer.effectAllowed = "move";
-              event.dataTransfer.setData("text/plain", key);
-            }}
-            onDragLeaveThread={(event) => {
-              if (didDragLeaveCurrentTarget(event)) {
-                setDropIndicator(undefined);
-              }
-            }}
-            onDragEndThread={() => {
-              setDraggedThreadKey(undefined);
-              setDropIndicator(undefined);
-              setDividerDropTarget(false);
-            }}
-            onDropOnThread={(event) => {
-              event.preventDefault();
-              setDraggedThreadKey(undefined);
-              setDropIndicator(undefined);
-              setDividerDropTarget(false);
-              const draggedKey = event.dataTransfer.getData("text/plain");
-              if (!draggedKey) return;
-              const draggedThread = threadByKey.get(draggedKey);
-              if (!draggedThread || draggedThread.source !== thread.source) return;
-              const backendPinnedThreadKeys = pinnedThreadKeysForBackend(thread.source);
-              const position = getDropIndicatorPosition(event);
-              const nextKeys = backendPinnedThreadKeys.includes(draggedKey)
-                ? moveThreadKey(backendPinnedThreadKeys, draggedKey, key, position)
-                : moveThreadKey(
-                    [...backendPinnedThreadKeys, draggedKey],
-                    draggedKey,
-                    key,
-                    position,
-                  );
-              reorderPins(thread.source, nextKeys);
-            }}
-            onMovePinnedThread={movePinnedThreadByKeyboard}
-            onOpenContextMenu={props.onOpenThreadContextMenu}
-            onPrefetchPullRequests={props.onPrefetchPullRequests}
-            onSelectThread={props.onSelectThread}
-            onSetReaction={props.onSetReaction}
-            onUnbindMessagingBinding={props.onUnbindMessagingBinding}
-          />
-        );
-      })}
+      {pinnedThreads.map((thread) => renderThreadGroup(thread))}
       {pinnedThreads.length > 0 ? (
         <div
           className={`recents-pinned-divider${
@@ -202,6 +368,7 @@ export function RecentsList(props: RecentsListProps) {
             if (
               !draggedThread ||
               !draggedThreadKey ||
+              draggedThread.parentThreadId ||
               pinnedThreadKeys.includes(draggedThreadKey)
             ) {
               event.dataTransfer.dropEffect = "none";
@@ -224,7 +391,7 @@ export function RecentsList(props: RecentsListProps) {
             setDividerDropTarget(false);
             const draggedKey = event.dataTransfer.getData("text/plain");
             const draggedThread = threadByKey.get(draggedKey);
-            if (!draggedThread || pinnedThreadKeys.includes(draggedKey)) return;
+            if (!draggedThread || draggedThread.parentThreadId || pinnedThreadKeys.includes(draggedKey)) return;
             reorderPins(draggedThread.source, [
               ...pinnedThreadKeysForBackend(draggedThread.source),
               draggedKey,
@@ -234,35 +401,7 @@ export function RecentsList(props: RecentsListProps) {
           <span>Recent threads</span>
         </div>
       ) : null}
-      {unpinnedThreads.map((thread) => {
-        const key = buildThreadIdentityKey(thread.source, thread.id);
-        return (
-          <ThreadRow
-            key={key}
-            approvalRequestThreadKeys={props.approvalRequestThreadKeys}
-            draggable={pinnedThreads.length > 0}
-            includeLinkedDirectories
-            selectedThreadKey={props.selectedThreadKey}
-            thinkingThreadKeys={props.thinkingThreadKeys}
-            thread={thread}
-            onDragStartThread={(event) => {
-              setDraggedThreadKey(key);
-              event.dataTransfer.effectAllowed = "move";
-              event.dataTransfer.setData("text/plain", key);
-            }}
-            onDragEndThread={() => {
-              setDraggedThreadKey(undefined);
-              setDropIndicator(undefined);
-              setDividerDropTarget(false);
-            }}
-            onOpenContextMenu={props.onOpenThreadContextMenu}
-            onPrefetchPullRequests={props.onPrefetchPullRequests}
-            onSelectThread={props.onSelectThread}
-            onSetReaction={props.onSetReaction}
-            onUnbindMessagingBinding={props.onUnbindMessagingBinding}
-          />
-        );
-      })}
+      {unpinnedThreads.map((thread) => renderThreadGroup(thread))}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -24,7 +24,11 @@ import {
 import type { RuntimeIdentity } from "../../../../shared/runtime-identity";
 import { copyText } from "../../lib/copy-text";
 import { BranchIcon, FolderIcon } from "../../icons";
-import type { BrowseMode, ThreadWorkspaceMode } from "../../lib/useThreadNavigation";
+import type {
+  ArchiveThreadOptions,
+  BrowseMode,
+  ThreadWorkspaceMode,
+} from "../../lib/useThreadNavigation";
 import {
   formatRuntimeGitRef,
   formatRuntimePath,
@@ -87,7 +91,10 @@ type SidebarProps = {
   onOpenSettings?: () => void;
   onOpenProfile?: (profile: string) => Promise<void>;
   onSelectThread: (thread: NavigationThreadSummary) => void;
-  onArchiveThread?: (thread: NavigationThreadSummary) => Promise<void>;
+  onArchiveThread?: (
+    thread: NavigationThreadSummary,
+    options?: ArchiveThreadOptions,
+  ) => Promise<void>;
   onRenameThread?: (thread: NavigationThreadSummary, name: string) => Promise<void>;
   onSetThreadReaction?: (
     thread: NavigationThreadSummary,
@@ -417,8 +424,15 @@ export function Sidebar(props: SidebarProps) {
     setRenameValidationError(undefined);
   };
 
-  const archiveFromContextMenu = (thread: NavigationThreadSummary): void => {
+  const archiveFromContextMenu = (
+    thread: NavigationThreadSummary,
+    options?: ArchiveThreadOptions,
+  ): void => {
     setContextMenu(undefined);
+    if (options) {
+      void onArchiveThread(thread, options);
+      return;
+    }
     void onArchiveThread(thread);
   };
 
@@ -576,6 +590,14 @@ export function Sidebar(props: SidebarProps) {
   const contextMenuCanArchive = contextMenu
     ? canArchiveThread(contextMenu.thread)
     : false;
+  const contextMenuChildThreadCount = contextMenu
+    ? props.threads.filter(
+        (thread) =>
+          thread.source === contextMenu.thread.source &&
+          thread.parentThreadId === contextMenu.thread.id,
+      ).length
+    : 0;
+  const contextMenuHasChildThreads = contextMenuChildThreadCount > 0;
   const contextMenuLocalPath = contextMenu?.thread.linkedDirectories.find(
     (directory) => directory.kind === "local"
   )?.path;
@@ -1042,7 +1064,51 @@ export function Sidebar(props: SidebarProps) {
                   Rename Thread
                 </button>
               ) : null}
-              {contextMenuCanArchive ? (
+              {contextMenuCanArchive && contextMenuHasChildThreads ? (
+                <>
+                  <button
+                    aria-label={`Archive Thread Only. Ungroup ${
+                      contextMenuChildThreadCount === 1
+                        ? "1 sub-thread"
+                        : `${contextMenuChildThreadCount} sub-threads`
+                    }`}
+                    className="thread-context-menu__button--stacked"
+                    role="menuitem"
+                    type="button"
+                    onClick={() =>
+                      archiveFromContextMenu(contextMenu.thread, {
+                        includeSubthreads: false,
+                      })
+                    }
+                  >
+                    <span>Archive Thread Only</span>
+                    <span className="thread-context-menu__item-detail">
+                      Ungroup{" "}
+                      {contextMenuChildThreadCount === 1
+                        ? "1 sub-thread"
+                        : `${contextMenuChildThreadCount} sub-threads`}
+                    </span>
+                  </button>
+                  <button
+                    aria-label={`Archive Thread and Sub-Threads. Archive ${
+                      contextMenuChildThreadCount + 1
+                    } threads`}
+                    className="thread-context-menu__button--stacked"
+                    role="menuitem"
+                    type="button"
+                    onClick={() =>
+                      archiveFromContextMenu(contextMenu.thread, {
+                        includeSubthreads: true,
+                      })
+                    }
+                  >
+                    <span>Archive Thread + Sub-Threads</span>
+                    <span className="thread-context-menu__item-detail">
+                      Archive {contextMenuChildThreadCount + 1} threads
+                    </span>
+                  </button>
+                </>
+              ) : contextMenuCanArchive ? (
                 <button
                   role="menuitem"
                   type="button"

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -24,7 +24,7 @@ import {
 import type { RuntimeIdentity } from "../../../../shared/runtime-identity";
 import { copyText } from "../../lib/copy-text";
 import { BranchIcon, FolderIcon } from "../../icons";
-import type { BrowseMode } from "../../lib/useThreadNavigation";
+import type { BrowseMode, ThreadWorkspaceMode } from "../../lib/useThreadNavigation";
 import {
   formatRuntimeGitRef,
   formatRuntimePath,
@@ -73,11 +73,11 @@ type SidebarProps = {
   onCreateThread: () => Promise<void>;
   onCreateSubthread?: (
     thread: NavigationThreadSummary,
-    mode: "same-worktree" | "new-worktree",
+    mode: ThreadWorkspaceMode,
   ) => Promise<void>;
   onForkThread?: (
     thread: NavigationThreadSummary,
-    mode: "same-worktree" | "new-worktree",
+    mode: ThreadWorkspaceMode,
   ) => Promise<void>;
   onOpenAutomations?: () => void;
   onOpenLaunchpad: (
@@ -424,7 +424,7 @@ export function Sidebar(props: SidebarProps) {
 
   const createSubthreadFromContextMenu = (
     thread: NavigationThreadSummary,
-    mode: "same-worktree" | "new-worktree",
+    mode: ThreadWorkspaceMode,
   ): void => {
     setContextMenu(undefined);
     void props.onCreateSubthread?.(thread, mode);
@@ -432,7 +432,7 @@ export function Sidebar(props: SidebarProps) {
 
   const forkThreadFromContextMenu = (
     thread: NavigationThreadSummary,
-    mode: "same-worktree" | "new-worktree",
+    mode: ThreadWorkspaceMode,
   ): void => {
     setContextMenu(undefined);
     void props.onForkThread?.(thread, mode);
@@ -584,15 +584,23 @@ export function Sidebar(props: SidebarProps) {
   );
   const contextMenuWorktreeCopyPath =
     contextMenuWorktreePath?.worktreePath ?? contextMenuWorktreePath?.path;
+  const contextMenuHasLocalWorkspace = Boolean(contextMenuLocalPath);
+  const contextMenuHasWorktreeWorkspace = Boolean(contextMenuWorktreePath);
+  const contextMenuHasWorkspace =
+    contextMenuHasLocalWorkspace || contextMenuHasWorktreeWorkspace;
   const contextMenuBranchName = contextMenu?.thread.gitBranch;
   const contextMenuIsSubthread = Boolean(contextMenu?.thread.parentThreadId);
   const contextMenuCanCreateSubthread = Boolean(
-    contextMenu && !contextMenuIsSubthread && props.onCreateSubthread,
+    contextMenu &&
+      !contextMenuIsSubthread &&
+      contextMenuHasWorkspace &&
+      props.onCreateSubthread,
   );
   const contextMenuCanFork = Boolean(
     contextMenu &&
       contextMenu.thread.source === "codex" &&
       !contextMenuIsSubthread &&
+      contextMenuHasWorkspace &&
       canForkThread(contextMenu.thread) &&
       props.onForkThread,
   );
@@ -891,46 +899,90 @@ export function Sidebar(props: SidebarProps) {
               {contextMenuCanCreateSubthread || contextMenuCanFork ? (
                 <>
                   {contextMenuCanCreateSubthread ? (
-                    <button
-                      role="menuitem"
-                      type="button"
-                      onClick={() =>
-                        createSubthreadFromContextMenu(
-                          contextMenu.thread,
-                          "same-worktree",
-                        )
-                      }
-                    >
-                      New Sub-thread
-                    </button>
+                    contextMenuHasWorktreeWorkspace ? (
+                      <>
+                        <button
+                          role="menuitem"
+                          type="button"
+                          onClick={() =>
+                            createSubthreadFromContextMenu(
+                              contextMenu.thread,
+                              "same-worktree",
+                            )
+                          }
+                        >
+                          Sub-thread in Same Worktree
+                        </button>
+                        <button
+                          role="menuitem"
+                          type="button"
+                          onClick={() =>
+                            createSubthreadFromContextMenu(
+                              contextMenu.thread,
+                              "new-worktree",
+                            )
+                          }
+                        >
+                          Sub-thread in New Worktree
+                        </button>
+                      </>
+                    ) : (
+                      <button
+                        role="menuitem"
+                        type="button"
+                        onClick={() =>
+                          createSubthreadFromContextMenu(
+                            contextMenu.thread,
+                            "local",
+                          )
+                        }
+                      >
+                        Sub-thread in Local
+                      </button>
+                    )
                   ) : null}
                   {contextMenuCanFork ? (
-                    <>
+                    contextMenuHasWorktreeWorkspace ? (
+                      <>
+                        <button
+                          role="menuitem"
+                          type="button"
+                          onClick={() =>
+                            forkThreadFromContextMenu(
+                              contextMenu.thread,
+                              "same-worktree",
+                            )
+                          }
+                        >
+                          Fork into Same Worktree
+                        </button>
+                        <button
+                          role="menuitem"
+                          type="button"
+                          onClick={() =>
+                            forkThreadFromContextMenu(
+                              contextMenu.thread,
+                              "new-worktree",
+                            )
+                          }
+                        >
+                          Fork into New Worktree
+                        </button>
+                      </>
+                    ) : (
                       <button
                         role="menuitem"
                         type="button"
                         onClick={() =>
                           forkThreadFromContextMenu(
                             contextMenu.thread,
-                            "same-worktree",
+                            "local",
                           )
                         }
                       >
-                        Fork into Same Worktree
+                        Fork in Local
                       </button>
-                      <button
-                        role="menuitem"
-                        type="button"
-                        onClick={() =>
-                          forkThreadFromContextMenu(
-                            contextMenu.thread,
-                            "new-worktree",
-                          )
-                        }
-                      >
-                        Fork into New Worktree
-                      </button>
-                    </>
+                    )
                   ) : null}
                 </>
               ) : null}

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -259,6 +259,14 @@ export function Sidebar(props: SidebarProps) {
         backend.capabilities.archiveThread === true
     );
 
+  const canForkThread = (thread: NavigationThreadSummary): boolean =>
+    props.backends.some(
+      (backend) =>
+        backend.kind === thread.source &&
+        backend.available &&
+        backend.capabilities.forkThread === true
+    );
+
   useEffect(() => {
     if (!contextMenu) {
       return;
@@ -585,6 +593,7 @@ export function Sidebar(props: SidebarProps) {
     contextMenu &&
       contextMenu.thread.source === "codex" &&
       !contextMenuIsSubthread &&
+      canForkThread(contextMenu.thread) &&
       props.onForkThread,
   );
   const contextMenuCanUnlinkSubthread = Boolean(

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -71,6 +71,10 @@ type SidebarProps = {
   threads: NavigationThreadSummary[];
   onBrowseModeChange: (browseMode: BrowseMode) => void;
   onCreateThread: () => Promise<void>;
+  onCreateSubthread?: (
+    thread: NavigationThreadSummary,
+    mode: "same-worktree" | "new-worktree",
+  ) => Promise<void>;
   onOpenAutomations?: () => void;
   onOpenLaunchpad: (
     directory: NavigationDirectorySummary,
@@ -93,6 +97,18 @@ type SidebarProps = {
   onReorderThreadPins?: (
     backend: AppServerBackendKind,
     threadIds: string[],
+  ) => Promise<void>;
+  onSetThreadParent?: (
+    thread: NavigationThreadSummary,
+    parentThreadId?: string,
+  ) => Promise<void>;
+  onUpdateSubthreadOrder?: (
+    parent: NavigationThreadSummary,
+    threadIds: string[],
+  ) => Promise<void>;
+  onSetSubthreadsCollapsed?: (
+    parent: NavigationThreadSummary,
+    collapsed: boolean,
   ) => Promise<void>;
   /**
    * Directory pinning (plan 2026-05-09-002). Mirror of thread-pin
@@ -394,6 +410,19 @@ export function Sidebar(props: SidebarProps) {
     void onArchiveThread(thread);
   };
 
+  const createSubthreadFromContextMenu = (
+    thread: NavigationThreadSummary,
+    mode: "same-worktree" | "new-worktree",
+  ): void => {
+    setContextMenu(undefined);
+    void props.onCreateSubthread?.(thread, mode);
+  };
+
+  const unlinkSubthreadFromContextMenu = (thread: NavigationThreadSummary): void => {
+    setContextMenu(undefined);
+    void props.onSetThreadParent?.(thread, undefined);
+  };
+
   const togglePinFromContextMenu = (thread: NavigationThreadSummary): void => {
     setContextMenu(undefined);
     void props.onSetThreadPin?.(thread, !thread.pinnedRank);
@@ -536,7 +565,16 @@ export function Sidebar(props: SidebarProps) {
   const contextMenuWorktreeCopyPath =
     contextMenuWorktreePath?.worktreePath ?? contextMenuWorktreePath?.path;
   const contextMenuBranchName = contextMenu?.thread.gitBranch;
-  const contextMenuCanPin = Boolean(contextMenu && props.onSetThreadPin);
+  const contextMenuIsSubthread = Boolean(contextMenu?.thread.parentThreadId);
+  const contextMenuCanCreateSubthread = Boolean(
+    contextMenu && !contextMenuIsSubthread && props.onCreateSubthread,
+  );
+  const contextMenuCanUnlinkSubthread = Boolean(
+    contextMenuIsSubthread && props.onSetThreadParent,
+  );
+  const contextMenuCanPin = Boolean(
+    contextMenu && !contextMenuIsSubthread && props.onSetThreadPin,
+  );
   /**
    * Move Up / Move Down show as menu items only when the target
    * thread is pinned (reorder only applies inside the pinned
@@ -564,6 +602,8 @@ export function Sidebar(props: SidebarProps) {
     contextMenuPinnedThreadIndex < contextMenuPinnedThreadCount - 1;
   const contextMenuHasTopActions =
     contextMenuCanPin ||
+    contextMenuCanCreateSubthread ||
+    contextMenuCanUnlinkSubthread ||
     contextMenuShowMoveItems ||
     contextMenuCanRename ||
     contextMenuCanArchive;
@@ -763,6 +803,8 @@ export function Sidebar(props: SidebarProps) {
               onOpenLaunchpad={props.onOpenLaunchpad}
               onPrefetchPullRequests={props.onPrefetchPullRequests}
               onReorderThreadPins={props.onReorderThreadPins}
+              onUpdateSubthreadOrder={props.onUpdateSubthreadOrder}
+              onSetSubthreadsCollapsed={props.onSetSubthreadsCollapsed}
               onSetDirectoryPin={props.onSetDirectoryPin}
               onReorderDirectoryPins={props.onReorderDirectoryPins}
               onOpenDirectoryContextMenu={
@@ -784,6 +826,8 @@ export function Sidebar(props: SidebarProps) {
                 onOpenThreadContextMenu={openThreadContextMenu}
                 onPrefetchPullRequests={props.onPrefetchPullRequests}
                 onReorderThreadPins={props.onReorderThreadPins}
+                onUpdateSubthreadOrder={props.onUpdateSubthreadOrder}
+                onSetSubthreadsCollapsed={props.onSetSubthreadsCollapsed}
                 onSelectThread={props.onSelectThread}
                 onSetReaction={props.onSetThreadReaction}
                 onUnbindMessagingBinding={props.onUnbindMessagingBinding}
@@ -814,6 +858,55 @@ export function Sidebar(props: SidebarProps) {
                   onClick={() => togglePinFromContextMenu(contextMenu.thread)}
                 >
                   {contextMenu.thread.pinnedRank ? "Unpin Thread" : "Pin Thread"}
+                </button>
+              ) : null}
+              {contextMenuCanCreateSubthread ? (
+                <>
+                  <button
+                    role="menuitem"
+                    type="button"
+                    onClick={() =>
+                      createSubthreadFromContextMenu(
+                        contextMenu.thread,
+                        "same-worktree",
+                      )
+                    }
+                  >
+                    New Sub-thread
+                  </button>
+                  <button
+                    role="menuitem"
+                    type="button"
+                    onClick={() =>
+                      createSubthreadFromContextMenu(
+                        contextMenu.thread,
+                        "same-worktree",
+                      )
+                    }
+                  >
+                    Fork into Same Worktree
+                  </button>
+                  <button
+                    role="menuitem"
+                    type="button"
+                    onClick={() =>
+                      createSubthreadFromContextMenu(
+                        contextMenu.thread,
+                        "new-worktree",
+                      )
+                    }
+                  >
+                    Fork into New Worktree
+                  </button>
+                </>
+              ) : null}
+              {contextMenuCanUnlinkSubthread ? (
+                <button
+                  role="menuitem"
+                  type="button"
+                  onClick={() => unlinkSubthreadFromContextMenu(contextMenu.thread)}
+                >
+                  Unlink from Parent
                 </button>
               ) : null}
               {contextMenuShowMoveItems ? (

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -75,6 +75,10 @@ type SidebarProps = {
     thread: NavigationThreadSummary,
     mode: "same-worktree" | "new-worktree",
   ) => Promise<void>;
+  onForkThread?: (
+    thread: NavigationThreadSummary,
+    mode: "same-worktree" | "new-worktree",
+  ) => Promise<void>;
   onOpenAutomations?: () => void;
   onOpenLaunchpad: (
     directory: NavigationDirectorySummary,
@@ -418,6 +422,14 @@ export function Sidebar(props: SidebarProps) {
     void props.onCreateSubthread?.(thread, mode);
   };
 
+  const forkThreadFromContextMenu = (
+    thread: NavigationThreadSummary,
+    mode: "same-worktree" | "new-worktree",
+  ): void => {
+    setContextMenu(undefined);
+    void props.onForkThread?.(thread, mode);
+  };
+
   const unlinkSubthreadFromContextMenu = (thread: NavigationThreadSummary): void => {
     setContextMenu(undefined);
     void props.onSetThreadParent?.(thread, undefined);
@@ -569,6 +581,12 @@ export function Sidebar(props: SidebarProps) {
   const contextMenuCanCreateSubthread = Boolean(
     contextMenu && !contextMenuIsSubthread && props.onCreateSubthread,
   );
+  const contextMenuCanFork = Boolean(
+    contextMenu &&
+      contextMenu.thread.source === "codex" &&
+      !contextMenuIsSubthread &&
+      props.onForkThread,
+  );
   const contextMenuCanUnlinkSubthread = Boolean(
     contextMenuIsSubthread && props.onSetThreadParent,
   );
@@ -603,6 +621,7 @@ export function Sidebar(props: SidebarProps) {
   const contextMenuHasTopActions =
     contextMenuCanPin ||
     contextMenuCanCreateSubthread ||
+    contextMenuCanFork ||
     contextMenuCanUnlinkSubthread ||
     contextMenuShowMoveItems ||
     contextMenuCanRename ||
@@ -860,44 +879,50 @@ export function Sidebar(props: SidebarProps) {
                   {contextMenu.thread.pinnedRank ? "Unpin Thread" : "Pin Thread"}
                 </button>
               ) : null}
-              {contextMenuCanCreateSubthread ? (
+              {contextMenuCanCreateSubthread || contextMenuCanFork ? (
                 <>
-                  <button
-                    role="menuitem"
-                    type="button"
-                    onClick={() =>
-                      createSubthreadFromContextMenu(
-                        contextMenu.thread,
-                        "same-worktree",
-                      )
-                    }
-                  >
-                    New Sub-thread
-                  </button>
-                  <button
-                    role="menuitem"
-                    type="button"
-                    onClick={() =>
-                      createSubthreadFromContextMenu(
-                        contextMenu.thread,
-                        "same-worktree",
-                      )
-                    }
-                  >
-                    Fork into Same Worktree
-                  </button>
-                  <button
-                    role="menuitem"
-                    type="button"
-                    onClick={() =>
-                      createSubthreadFromContextMenu(
-                        contextMenu.thread,
-                        "new-worktree",
-                      )
-                    }
-                  >
-                    Fork into New Worktree
-                  </button>
+                  {contextMenuCanCreateSubthread ? (
+                    <button
+                      role="menuitem"
+                      type="button"
+                      onClick={() =>
+                        createSubthreadFromContextMenu(
+                          contextMenu.thread,
+                          "same-worktree",
+                        )
+                      }
+                    >
+                      New Sub-thread
+                    </button>
+                  ) : null}
+                  {contextMenuCanFork ? (
+                    <>
+                      <button
+                        role="menuitem"
+                        type="button"
+                        onClick={() =>
+                          forkThreadFromContextMenu(
+                            contextMenu.thread,
+                            "same-worktree",
+                          )
+                        }
+                      >
+                        Fork into Same Worktree
+                      </button>
+                      <button
+                        role="menuitem"
+                        type="button"
+                        onClick={() =>
+                          forkThreadFromContextMenu(
+                            contextMenu.thread,
+                            "new-worktree",
+                          )
+                        }
+                      >
+                        Fork into New Worktree
+                      </button>
+                    </>
+                  ) : null}
                 </>
               ) : null}
               {contextMenuCanUnlinkSubthread ? (

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -37,7 +37,10 @@ type ThreadRowProps = {
   draggable?: boolean;
   includeLinkedDirectories?: boolean;
   linkedDirectoryMode?: "label" | "kind";
+  nested?: boolean;
   selectedThreadKey?: string;
+  subthreadCount?: number;
+  subthreadsCollapsed?: boolean;
   thinkingThreadKeys?: Record<string, boolean>;
   thread: NavigationThreadSummary;
   onOpenContextMenu: (
@@ -60,6 +63,7 @@ type ThreadRowProps = {
     binding: MessagingThreadBindingSummary,
   ) => Promise<void>;
   onSelectThread: (thread: NavigationThreadSummary) => void;
+  onToggleSubthreads?: () => void;
   onDragStartThread?: (event: DragEvent<HTMLDivElement>) => void;
   onDragOverThread?: (event: DragEvent<HTMLDivElement>) => void;
   onDragLeaveThread?: (event: DragEvent<HTMLDivElement>) => void;
@@ -135,6 +139,8 @@ export function ThreadRow(props: ThreadRowProps) {
     <div
       className={`thread-row-shell${props.draggable ? " is-draggable" : ""}${
         props.dropIndicator ? ` is-drop-target-${props.dropIndicator}` : ""
+      }${props.nested ? " thread-row-shell--nested" : ""}${
+        props.subthreadCount ? " has-subthreads" : ""
       }`}
       draggable={props.draggable}
       role="listitem"
@@ -156,6 +162,20 @@ export function ThreadRow(props: ThreadRowProps) {
         });
       }}
     >
+      {props.subthreadCount ? (
+        <button
+          aria-expanded={!props.subthreadsCollapsed}
+          aria-label={`${props.subthreadsCollapsed ? "Expand" : "Collapse"} sub-threads for ${props.thread.title}`}
+          className={`thread-row__subthread-toggle${
+            props.subthreadsCollapsed ? "" : " is-open"
+          }`}
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation();
+            props.onToggleSubthreads?.();
+          }}
+        />
+      ) : null}
       <button
         aria-label={props.thread.title}
         aria-pressed={selected}
@@ -215,7 +235,7 @@ export function ThreadRow(props: ThreadRowProps) {
             thread={props.thread}
           />
 
-          {props.thread.pinnedRank ? (
+          {props.thread.pinnedRank && !props.thread.parentThreadId ? (
             <span className="thread-row__chip thread-row__chip--pin">
               Pinned
             </span>

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -1026,6 +1026,106 @@ describe("Sidebar", () => {
     expect(onArchiveThread).toHaveBeenCalledWith(sharedThread);
   });
 
+  it("splits parent archive actions between ungrouping children and archiving the group", () => {
+    const onArchiveThread = vi.fn(async () => undefined);
+    const childThread = {
+      ...sharedThread,
+      id: "thread-child",
+      title: "Child thread",
+      parentThreadId: sharedThread.id,
+      updatedAt: sharedThread.updatedAt + 1,
+    };
+
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="recents"
+        createThreadError={undefined}
+        directories={directories}
+        inboxThreads={[sharedThread, childThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey="codex:thread-1"
+        threads={[sharedThread, childThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+        onArchiveThread={onArchiveThread}
+      />
+    );
+
+    fireEvent.click(
+      screen.getAllByRole("button", { name: "Open thread actions" })[0]!
+    );
+
+    expect(
+      screen.getByRole("menuitem", {
+        name: "Archive Thread Only. Ungroup 1 sub-thread",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", {
+        name: "Archive Thread and Sub-Threads. Archive 2 threads",
+      }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("menuitem", {
+        name: "Archive Thread Only. Ungroup 1 sub-thread",
+      }),
+    );
+
+    expect(onArchiveThread).toHaveBeenCalledWith(sharedThread, {
+      includeSubthreads: false,
+    });
+  });
+
+  it("archives the whole group from the parent row menu", () => {
+    const onArchiveThread = vi.fn(async () => undefined);
+    const childThread = {
+      ...sharedThread,
+      id: "thread-child",
+      title: "Child thread",
+      parentThreadId: sharedThread.id,
+      updatedAt: sharedThread.updatedAt + 1,
+    };
+
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="recents"
+        createThreadError={undefined}
+        directories={directories}
+        inboxThreads={[sharedThread, childThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey="codex:thread-1"
+        threads={[sharedThread, childThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+        onArchiveThread={onArchiveThread}
+      />
+    );
+
+    fireEvent.click(
+      screen.getAllByRole("button", { name: "Open thread actions" })[0]!
+    );
+    fireEvent.click(
+      screen.getByRole("menuitem", {
+        name: "Archive Thread and Sub-Threads. Archive 2 threads",
+      }),
+    );
+
+    expect(onArchiveThread).toHaveBeenCalledWith(sharedThread, {
+      includeSubthreads: true,
+    });
+  });
+
   it("pins from the row menu and renders pinned threads above recents", () => {
     const onSetThreadPin = vi.fn(async () => undefined);
     const pinnedThread = {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -202,6 +202,70 @@ describe("Sidebar", () => {
     expect(screen.getAllByText("OpenAI").length).toBeGreaterThan(0);
   });
 
+  it("groups sub-threads under their parent and persists collapse clicks", () => {
+    const childThread = {
+      ...sharedThread,
+      id: "thread-review",
+      title: "Adversarial review",
+      parentThreadId: sharedThread.id,
+      updatedAt: sharedThread.updatedAt + 1,
+    };
+    const onSetSubthreadsCollapsed = vi.fn(async () => undefined);
+
+    const { container } = render(
+      <Sidebar
+        backends={backends}
+        browseMode="inbox"
+        directories={directories}
+        inboxThreads={[childThread, sharedThread]}
+        loading={false}
+        selectedItemKey="codex:thread-1"
+        threads={[childThread, sharedThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+        onSetSubthreadsCollapsed={onSetSubthreadsCollapsed}
+      />,
+    );
+
+    expect(container.querySelector(".subthread-list")).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Cross-project cleanup" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Adversarial review" })).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Collapse sub-threads for Cross-project cleanup",
+      }),
+    );
+    expect(onSetSubthreadsCollapsed).toHaveBeenCalledWith(sharedThread, true);
+  });
+
+  it("opens a sub-thread launchpad from the thread context menu", () => {
+    const onCreateSubthread = vi.fn(async () => undefined);
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="inbox"
+        directories={directories}
+        inboxThreads={[sharedThread]}
+        loading={false}
+        selectedItemKey="codex:thread-1"
+        threads={[sharedThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onCreateSubthread={onCreateSubthread}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />,
+    );
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: "Cross-project cleanup" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "New Sub-thread" }));
+
+    expect(onCreateSubthread).toHaveBeenCalledWith(sharedThread, "same-worktree");
+  });
+
   it("shows the active PwrAgent and Codex profiles with account tooltip details", async () => {
     render(
       <Sidebar

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -266,6 +266,31 @@ describe("Sidebar", () => {
     expect(onCreateSubthread).toHaveBeenCalledWith(sharedThread, "same-worktree");
   });
 
+  it("forks a Codex thread from the thread context menu", () => {
+    const onForkThread = vi.fn(async () => undefined);
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="inbox"
+        directories={directories}
+        inboxThreads={[sharedThread]}
+        loading={false}
+        selectedItemKey="codex:thread-1"
+        threads={[sharedThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onForkThread={onForkThread}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />,
+    );
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: "Cross-project cleanup" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Fork into New Worktree" }));
+
+    expect(onForkThread).toHaveBeenCalledWith(sharedThread, "new-worktree");
+  });
+
   it("shows the active PwrAgent and Codex profiles with account tooltip details", async () => {
     render(
       <Sidebar

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -268,9 +268,18 @@ describe("Sidebar", () => {
 
   it("forks a Codex thread from the thread context menu", () => {
     const onForkThread = vi.fn(async () => undefined);
+    const forkBackends: BackendSummary[] = [
+      {
+        ...backends[0]!,
+        capabilities: {
+          ...backends[0]!.capabilities,
+          forkThread: true,
+        },
+      },
+    ];
     render(
       <Sidebar
-        backends={backends}
+        backends={forkBackends}
         browseMode="inbox"
         directories={directories}
         inboxThreads={[sharedThread]}
@@ -289,6 +298,31 @@ describe("Sidebar", () => {
     fireEvent.click(screen.getByRole("menuitem", { name: "Fork into New Worktree" }));
 
     expect(onForkThread).toHaveBeenCalledWith(sharedThread, "new-worktree");
+  });
+
+  it("hides fork actions when the backend does not advertise fork support", () => {
+    const onForkThread = vi.fn(async () => undefined);
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="inbox"
+        directories={directories}
+        inboxThreads={[sharedThread]}
+        loading={false}
+        selectedItemKey="codex:thread-1"
+        threads={[sharedThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onForkThread={onForkThread}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />,
+    );
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: "Cross-project cleanup" }));
+
+    expect(screen.queryByRole("menuitem", { name: "Fork into Same Worktree" })).toBeNull();
+    expect(screen.queryByRole("menuitem", { name: "Fork into New Worktree" })).toBeNull();
   });
 
   it("shows the active PwrAgent and Codex profiles with account tooltip details", async () => {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -112,6 +112,20 @@ const sharedThread = {
   ],
 };
 
+const localThread = {
+  ...sharedThread,
+  id: "thread-local",
+  title: "Local checkout cleanup",
+  linkedDirectories: [
+    {
+      id: "dir-local",
+      label: "PwrAgent",
+      path: "/Users/huntharo/pwrdrvr/PwrAgent",
+      kind: "local" as const,
+    },
+  ],
+};
+
 const updatedSinceSeenThread = {
   ...sharedThread,
   id: "thread-updated",
@@ -241,7 +255,7 @@ describe("Sidebar", () => {
     expect(onSetSubthreadsCollapsed).toHaveBeenCalledWith(sharedThread, true);
   });
 
-  it("opens a sub-thread launchpad from the thread context menu", () => {
+  it("opens worktree sub-thread launchpads from the thread context menu", () => {
     const onCreateSubthread = vi.fn(async () => undefined);
     render(
       <Sidebar
@@ -261,9 +275,37 @@ describe("Sidebar", () => {
     );
 
     fireEvent.contextMenu(screen.getByRole("button", { name: "Cross-project cleanup" }));
-    fireEvent.click(screen.getByRole("menuitem", { name: "New Sub-thread" }));
+    expect(screen.queryByRole("menuitem", { name: "Sub-thread in Local" })).toBeNull();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Sub-thread in Same Worktree" }));
 
     expect(onCreateSubthread).toHaveBeenCalledWith(sharedThread, "same-worktree");
+  });
+
+  it("opens a local sub-thread launchpad only for local parent threads", () => {
+    const onCreateSubthread = vi.fn(async () => undefined);
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="inbox"
+        directories={directories}
+        inboxThreads={[localThread]}
+        loading={false}
+        selectedItemKey="codex:thread-local"
+        threads={[localThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onCreateSubthread={onCreateSubthread}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />,
+    );
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: "Local checkout cleanup" }));
+    expect(screen.queryByRole("menuitem", { name: "Sub-thread in Same Worktree" })).toBeNull();
+    expect(screen.queryByRole("menuitem", { name: "Sub-thread in New Worktree" })).toBeNull();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Sub-thread in Local" }));
+
+    expect(onCreateSubthread).toHaveBeenCalledWith(localThread, "local");
   });
 
   it("forks a Codex thread from the thread context menu", () => {
@@ -300,6 +342,42 @@ describe("Sidebar", () => {
     expect(onForkThread).toHaveBeenCalledWith(sharedThread, "new-worktree");
   });
 
+  it("forks local parent threads in Local instead of Same Worktree", () => {
+    const onForkThread = vi.fn(async () => undefined);
+    const forkBackends: BackendSummary[] = [
+      {
+        ...backends[0]!,
+        capabilities: {
+          ...backends[0]!.capabilities,
+          forkThread: true,
+        },
+      },
+    ];
+    render(
+      <Sidebar
+        backends={forkBackends}
+        browseMode="inbox"
+        directories={directories}
+        inboxThreads={[localThread]}
+        loading={false}
+        selectedItemKey="codex:thread-local"
+        threads={[localThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onForkThread={onForkThread}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />,
+    );
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: "Local checkout cleanup" }));
+    expect(screen.queryByRole("menuitem", { name: "Fork into Same Worktree" })).toBeNull();
+    expect(screen.queryByRole("menuitem", { name: "Fork into New Worktree" })).toBeNull();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Fork in Local" }));
+
+    expect(onForkThread).toHaveBeenCalledWith(localThread, "local");
+  });
+
   it("hides fork actions when the backend does not advertise fork support", () => {
     const onForkThread = vi.fn(async () => undefined);
     render(
@@ -323,6 +401,7 @@ describe("Sidebar", () => {
 
     expect(screen.queryByRole("menuitem", { name: "Fork into Same Worktree" })).toBeNull();
     expect(screen.queryByRole("menuitem", { name: "Fork into New Worktree" })).toBeNull();
+    expect(screen.queryByRole("menuitem", { name: "Fork in Local" })).toBeNull();
   });
 
   it("shows the active PwrAgent and Codex profiles with account tooltip details", async () => {

--- a/apps/desktop/src/renderer/src/features/notifications/AppNoticeToast.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/AppNoticeToast.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useRef, useState } from "react";
+import { CloseIcon, CopyIcon } from "../../icons";
+import { copyText } from "../../lib/copy-text";
+import type { DesktopApi } from "../../lib/desktop-api";
+
+const AUTO_DISMISS_MS = 9_000;
+
+export type AppNoticeToastNotice = {
+  id: string;
+  title: string;
+  message: string;
+  detail?: string;
+};
+
+export function AppNoticeToast(props: {
+  desktopApi?: Pick<DesktopApi, "copyText">;
+  notice?: AppNoticeToastNotice;
+  onDismiss: () => void;
+}) {
+  const [paused, setPaused] = useState(false);
+  const timeoutRef = useRef<number | undefined>(undefined);
+  const onDismissRef = useRef(props.onDismiss);
+
+  useEffect(() => {
+    onDismissRef.current = props.onDismiss;
+  }, [props.onDismiss]);
+
+  useEffect(() => {
+    if (timeoutRef.current) {
+      window.clearTimeout(timeoutRef.current);
+      timeoutRef.current = undefined;
+    }
+    setPaused(false);
+  }, [props.notice?.id]);
+
+  useEffect(() => {
+    if (!props.notice || paused) {
+      return;
+    }
+
+    timeoutRef.current = window.setTimeout(() => {
+      timeoutRef.current = undefined;
+      onDismissRef.current();
+    }, AUTO_DISMISS_MS);
+
+    return () => {
+      if (timeoutRef.current) {
+        window.clearTimeout(timeoutRef.current);
+        timeoutRef.current = undefined;
+      }
+    };
+  }, [paused, props.notice?.id]);
+
+  if (!props.notice) {
+    return null;
+  }
+
+  const copyValue = [props.notice.title, props.notice.message, props.notice.detail]
+    .filter(Boolean)
+    .join("\n");
+
+  return (
+    <aside
+      className="app-notice-toast"
+      role="status"
+      aria-live="polite"
+      onMouseEnter={() => setPaused(true)}
+      onMouseLeave={() => setPaused(false)}
+      onFocus={() => setPaused(true)}
+      onBlur={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget)) {
+          setPaused(false);
+        }
+      }}
+    >
+      <div className="app-notice-toast__content">
+        <p className="app-notice-toast__eyebrow">{props.notice.title}</p>
+        <p className="app-notice-toast__message">{props.notice.message}</p>
+        {props.notice.detail ? (
+          <p className="app-notice-toast__detail">{props.notice.detail}</p>
+        ) : null}
+      </div>
+      <div className="app-notice-toast__actions">
+        <button
+          className="app-notice-toast__icon-button"
+          type="button"
+          aria-label="Copy notice"
+          title="Copy notice"
+          onClick={() => {
+            void copyText(copyValue, props.desktopApi);
+          }}
+        >
+          <CopyIcon size={14} aria-hidden="true" />
+        </button>
+        <button
+          className="app-notice-toast__icon-button"
+          type="button"
+          aria-label="Dismiss notice"
+          title="Dismiss notice"
+          onClick={props.onDismiss}
+        >
+          <CloseIcon size={14} aria-hidden="true" />
+        </button>
+      </div>
+      <span
+        className="app-notice-toast__timer"
+        aria-hidden="true"
+        data-paused={paused ? "true" : undefined}
+      />
+    </aside>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeToast.test.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeToast.test.tsx
@@ -1,0 +1,63 @@
+import "@testing-library/jest-dom/vitest";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AppNoticeToast } from "../AppNoticeToast";
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("AppNoticeToast", () => {
+  const notice = {
+    id: "notice-1",
+    title: "Worktree kept",
+    message: "Thread archived. The worktree was kept because another active thread is still using it.",
+    detail: "/repo/.worktrees/shared: Worktree is still used by another active thread.",
+  };
+
+  it("renders selectable notice text with copy and dismiss controls", () => {
+    const copyText = vi.fn(async () => undefined);
+    const onDismiss = vi.fn();
+
+    render(
+      <AppNoticeToast
+        desktopApi={{ copyText }}
+        notice={notice}
+        onDismiss={onDismiss}
+      />,
+    );
+
+    expect(screen.getByText("Worktree kept")).toBeInTheDocument();
+    expect(screen.getByText(notice.message)).toBeInTheDocument();
+    expect(screen.getByText(notice.detail)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy notice" }));
+    expect(copyText).toHaveBeenCalledWith(
+      [notice.title, notice.message, notice.detail].join("\n"),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss notice" }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("auto-dismisses unless the notice is hovered", () => {
+    vi.useFakeTimers();
+    const onDismiss = vi.fn();
+
+    render(<AppNoticeToast notice={notice} onDismiss={onDismiss} />);
+
+    const toast = screen.getByRole("status");
+    fireEvent.mouseEnter(toast);
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    fireEvent.mouseLeave(toast);
+    act(() => {
+      vi.advanceTimersByTime(9_000);
+    });
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1865,6 +1865,22 @@ export function ThreadView(props: ThreadViewProps) {
       props.selectedDirectory.kind === "workspace"
         ? "New thread"
         : selectedLaunchpad.directoryLabel;
+    const launchpadBranchLabel =
+      selectedLaunchpad.workMode === "worktree"
+        ? selectedLaunchpad.branchName ??
+          props.selectedDirectory.gitStatus?.currentBranch ??
+          "Pick one"
+        : props.selectedDirectory.gitStatus?.currentBranch ?? "Not attached";
+    const launchpadBranchDetailLabel =
+      selectedLaunchpad.workMode === "worktree" ? "Base branch" : "Current branch";
+    const launchpadBranchDetailValue =
+      selectedLaunchpad.workMode === "worktree"
+        ? launchpadBranchLabel
+        : props.selectedDirectory.gitStatus?.currentBranch ??
+          (props.selectedDirectory.gitStatus?.syncState === "status-unavailable"
+            ? "Unavailable"
+            : "Not a Git repo");
+    const launchpadIsSubthread = Boolean(selectedLaunchpad.parentThreadId);
     const launchpadRunningCodexEnvironmentSetup = Boolean(
       selectedLaunchpad.codexEnvironmentId &&
         selectedLaunchpad.codexEnvironmentSetupEnabled,
@@ -1923,13 +1939,7 @@ export function ThreadView(props: ThreadViewProps) {
               </div>
               <div>
                 <span className="thread-header__stat-label">Branch</span>
-                <strong>
-                  {selectedLaunchpad.workMode === "worktree"
-                    ? selectedLaunchpad.branchName ??
-                      props.selectedDirectory.gitStatus?.currentBranch ??
-                      "Pick one"
-                    : props.selectedDirectory.gitStatus?.currentBranch ?? "Not attached"}
-                </strong>
+                <strong>{launchpadBranchLabel}</strong>
               </div>
             </div>
             <MessagingStatusBar
@@ -1952,9 +1962,23 @@ export function ThreadView(props: ThreadViewProps) {
                 {props.selectedDirectory.threadKeys.length === 1 ? "" : "s"}
               </strong>
             </div>
+            {launchpadIsSubthread ? (
+              <div>
+                <span className="launchpad-panel__label">Grouped under</span>
+                <strong
+                  title={selectedLaunchpad.parentThreadTitle ?? selectedLaunchpad.parentThreadId}
+                >
+                  {selectedLaunchpad.parentThreadTitle ?? selectedLaunchpad.parentThreadId}
+                </strong>
+              </div>
+            ) : null}
             <div>
-              <span className="launchpad-panel__label">Status</span>
-              <strong>{syncLabel ?? "Directory context only"}</strong>
+              <span className="launchpad-panel__label">
+                {launchpadIsSubthread ? "History" : "Status"}
+              </span>
+              <strong>
+                {launchpadIsSubthread ? "Starts empty" : syncLabel ?? "Directory context only"}
+              </strong>
             </div>
           </div>
 
@@ -1964,13 +1988,8 @@ export function ThreadView(props: ThreadViewProps) {
               <dd>{props.selectedDirectory.path ?? "Not recorded"}</dd>
             </div>
             <div>
-              <dt>Current branch</dt>
-              <dd>
-                {props.selectedDirectory.gitStatus?.currentBranch ??
-                  (props.selectedDirectory.gitStatus?.syncState === "status-unavailable"
-                    ? "Unavailable"
-                    : "Not a Git repo")}
-              </dd>
+              <dt>{launchpadBranchDetailLabel}</dt>
+              <dd>{launchpadBranchDetailValue}</dd>
             </div>
             <div>
               <dt>Upstream</dt>

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -41,6 +41,7 @@ import {
   formatAccessModeLabel,
   formatExecutionModeLabel,
 } from "../../lib/execution-mode";
+import { isSameWorktreeSubthreadLaunchpad } from "../../lib/subthread-launchpads";
 import { useMediaQuery } from "../../lib/useMediaQuery";
 import { Composer } from "../composer/Composer";
 import type { ComposerDraftStore } from "../composer/useComposerDraftStore";
@@ -1855,12 +1856,20 @@ export function ThreadView(props: ThreadViewProps) {
       (backend) => backend.kind === selectedLaunchpad.backend
     );
     const syncLabel = formatDirectorySync(props.selectedDirectory);
+    const sameWorktreeSubthread = isSameWorktreeSubthreadLaunchpad(
+      selectedLaunchpad.directoryKey,
+    );
+    const launchpadIsSubthread = Boolean(selectedLaunchpad.parentThreadId);
+    const launchpadCurrentBranch =
+      props.selectedDirectory.gitStatus?.currentBranch ?? selectedLaunchpad.branchName;
     const workspaceLabel =
       props.selectedDirectory.kind === "workspace"
         ? "Workspace"
-        : selectedLaunchpad.workMode === "worktree"
-          ? "New worktree"
-          : "Local checkout";
+        : sameWorktreeSubthread
+          ? "Same worktree"
+          : selectedLaunchpad.workMode === "worktree"
+            ? "New worktree"
+            : "Local checkout";
     const launchpadTitle =
       props.selectedDirectory.kind === "workspace"
         ? "New thread"
@@ -1870,17 +1879,25 @@ export function ThreadView(props: ThreadViewProps) {
         ? selectedLaunchpad.branchName ??
           props.selectedDirectory.gitStatus?.currentBranch ??
           "Pick one"
-        : props.selectedDirectory.gitStatus?.currentBranch ?? "Not attached";
+        : launchpadCurrentBranch ?? "Not attached";
     const launchpadBranchDetailLabel =
       selectedLaunchpad.workMode === "worktree" ? "Base branch" : "Current branch";
     const launchpadBranchDetailValue =
       selectedLaunchpad.workMode === "worktree"
         ? launchpadBranchLabel
-        : props.selectedDirectory.gitStatus?.currentBranch ??
+        : launchpadCurrentBranch ??
           (props.selectedDirectory.gitStatus?.syncState === "status-unavailable"
             ? "Unavailable"
             : "Not a Git repo");
-    const launchpadIsSubthread = Boolean(selectedLaunchpad.parentThreadId);
+    const launchpadStatusValue =
+      launchpadIsSubthread
+        ? "Starts empty"
+        : syncLabel ?? "Directory context only";
+    const launchpadDirectoryStatusValue =
+      syncLabel ??
+      (sameWorktreeSubthread && selectedLaunchpad.branchName
+        ? "Git worktree"
+        : "Directory context only");
     const launchpadRunningCodexEnvironmentSetup = Boolean(
       selectedLaunchpad.codexEnvironmentId &&
         selectedLaunchpad.codexEnvironmentSetupEnabled,
@@ -1976,9 +1993,7 @@ export function ThreadView(props: ThreadViewProps) {
               <span className="launchpad-panel__label">
                 {launchpadIsSubthread ? "History" : "Status"}
               </span>
-              <strong>
-                {launchpadIsSubthread ? "Starts empty" : syncLabel ?? "Directory context only"}
-              </strong>
+              <strong>{launchpadStatusValue}</strong>
             </div>
           </div>
 
@@ -1997,7 +2012,7 @@ export function ThreadView(props: ThreadViewProps) {
             </div>
             <div>
               <dt>Status</dt>
-              <dd>{syncLabel ?? "Directory context only"}</dd>
+              <dd>{launchpadDirectoryStatusValue}</dd>
             </div>
           </dl>
         </div>

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -381,6 +381,58 @@ describe("ThreadView", () => {
     expect(screen.getByRole("group", { name: "Messaging platform status" })).toBeInTheDocument();
   });
 
+  it("describes sub-thread launchpads as grouped children with empty history", () => {
+    const selectedDirectory = {
+      key: "subthread:codex:thread-parent:new-worktree",
+      kind: "directory",
+      label: "PwrAgnt",
+      path: "/Users/huntharo/pwrdrvr/PwrAgnt",
+      threadKeys: [],
+      needsAttentionCount: 0,
+    } satisfies NavigationDirectorySummary;
+    const selectedLaunchpad = {
+      backend: "codex",
+      branchName: "main",
+      createdAt: 1000,
+      directoryKey: selectedDirectory.key,
+      directoryKind: selectedDirectory.kind,
+      directoryLabel: selectedDirectory.label,
+      directoryPath: selectedDirectory.path,
+      executionMode: "default",
+      parentThreadId: "thread-parent",
+      parentThreadTitle: "Issue 193 Markdown attachments",
+      prompt: "",
+      updatedAt: 1000,
+      workMode: "worktree",
+    } satisfies NavigationLaunchpadDraft;
+
+    render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[]}
+        clearPendingRequest={() => undefined}
+        composerDisabled={false}
+        loading={false}
+        loadingMore={false}
+        messageCount={0}
+        selectedDirectory={selectedDirectory}
+        selectedLaunchpad={selectedLaunchpad}
+        skills={[]}
+        transcriptEntries={[]}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+      />
+    );
+
+    expect(screen.getByText("Grouped under")).toBeInTheDocument();
+    expect(screen.getByText("Issue 193 Markdown attachments")).toBeInTheDocument();
+    expect(screen.getByText("History")).toBeInTheDocument();
+    expect(screen.getByText("Starts empty")).toBeInTheDocument();
+    expect(screen.getByText("Base branch")).toBeInTheDocument();
+    expect(screen.getAllByText("main").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Not a Git repo")).not.toBeInTheDocument();
+  });
+
   it("keeps launchpad drafts editable until a known backend reports unavailable", async () => {
     const selectedDirectory = {
       key: "workspace:new-thread",

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -433,6 +433,62 @@ describe("ThreadView", () => {
     expect(screen.queryByText("Not a Git repo")).not.toBeInTheDocument();
   });
 
+  it("describes same-worktree sub-thread launchpads as shared worktrees", () => {
+    const selectedDirectory = {
+      key: "subthread:codex:thread-parent:same-worktree",
+      kind: "directory",
+      label: "PwrAgnt",
+      path: "/Users/huntharo/.codex/worktrees/mpsmzvdh/PwrAgnt",
+      threadKeys: [],
+      needsAttentionCount: 0,
+    } satisfies NavigationDirectorySummary;
+    const selectedLaunchpad = {
+      backend: "codex",
+      branchName: "feat/messaging-artifact-delivery",
+      createdAt: 1000,
+      directoryKey: selectedDirectory.key,
+      directoryKind: selectedDirectory.kind,
+      directoryLabel: selectedDirectory.label,
+      directoryPath: selectedDirectory.path,
+      executionMode: "default",
+      parentThreadId: "thread-parent",
+      parentThreadTitle: "Issue 193 Markdown attachments",
+      prompt: "",
+      updatedAt: 1000,
+      workMode: "local",
+    } satisfies NavigationLaunchpadDraft;
+
+    render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[]}
+        clearPendingRequest={() => undefined}
+        composerDisabled={false}
+        loading={false}
+        loadingMore={false}
+        messageCount={0}
+        selectedDirectory={selectedDirectory}
+        selectedLaunchpad={selectedLaunchpad}
+        skills={[]}
+        transcriptEntries={[]}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+      />
+    );
+
+    expect(screen.getByText("Workspace").nextElementSibling).toHaveTextContent(
+      "Same worktree",
+    );
+    expect(screen.getByText("Current branch").nextElementSibling).toHaveTextContent(
+      "feat/messaging-artifact-delivery",
+    );
+    expect(screen.getByText("Status").nextElementSibling).toHaveTextContent(
+      "Git worktree",
+    );
+    expect(screen.queryByText("Local checkout")).not.toBeInTheDocument();
+    expect(screen.queryByText("Not a Git repo")).not.toBeInTheDocument();
+  });
+
   it("keeps launchpad drafts editable until a known backend reports unavailable", async () => {
     const selectedDirectory = {
       key: "workspace:new-thread",

--- a/apps/desktop/src/renderer/src/icons/CloseIcon.tsx
+++ b/apps/desktop/src/renderer/src/icons/CloseIcon.tsx
@@ -1,0 +1,10 @@
+import { resolveIconSvgProps, type IconProps } from "./icon-types";
+
+export function CloseIcon(props: IconProps) {
+  return (
+    <svg {...resolveIconSvgProps(props)}>
+      <path d="M18 6 6 18" />
+      <path d="m6 6 12 12" />
+    </svg>
+  );
+}

--- a/apps/desktop/src/renderer/src/icons/__tests__/icons.test.tsx
+++ b/apps/desktop/src/renderer/src/icons/__tests__/icons.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, render } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   BranchIcon,
+  CloseIcon,
   CopyIcon,
   DiscordIcon,
   FileCodeIcon,
@@ -32,6 +33,7 @@ const ALL_ICONS = [
   ["SmileyIcon", SmileyIcon],
   ["NewThreadIcon", NewThreadIcon],
   ["CopyIcon", CopyIcon],
+  ["CloseIcon", CloseIcon],
 ] as const;
 
 describe("icon library", () => {

--- a/apps/desktop/src/renderer/src/icons/index.ts
+++ b/apps/desktop/src/renderer/src/icons/index.ts
@@ -1,4 +1,5 @@
 export { BranchIcon } from "./BranchIcon";
+export { CloseIcon } from "./CloseIcon";
 export { CopyIcon } from "./CopyIcon";
 export { DiscordIcon } from "./DiscordIcon";
 export { EditorIcon } from "./EditorIcon";

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -2457,6 +2457,23 @@ describe("useThreadNavigation", () => {
       model: "gpt-5.5",
       serviceTier: "fast",
       fastMode: true,
+      messagingBindings: [
+        {
+          bindingId: "binding-parent",
+          platform: "telegram" as const,
+          conversationTitle: "Parent DM",
+        },
+      ],
+      prs: [
+        {
+          number: 123,
+          org: "pwrdrvr",
+          repo: "PwrAgent",
+          state: "passing" as const,
+          url: "https://github.com/pwrdrvr/PwrAgent/pull/123",
+        },
+      ],
+      reactions: ["👀"],
       linkedDirectories: [
         {
           id: "/repo/app",
@@ -2539,6 +2556,9 @@ describe("useThreadNavigation", () => {
         },
       ],
     });
+    expect(result.current.selectedThread?.messagingBindings).toBeUndefined();
+    expect(result.current.selectedThread?.prs).toBeUndefined();
+    expect(result.current.selectedThread?.reactions).toBeUndefined();
   });
 
   it("refreshes the selected thread when only the observed branch changes", async () => {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -2837,6 +2837,113 @@ describe("useThreadNavigation", () => {
     });
   });
 
+  it("opens new-worktree sub-thread launchpads with stable worktree mode", async () => {
+    const parentThread = {
+      id: "thread-parent",
+      title: "Worktree parent",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      executionMode: "default" as const,
+      linkedDirectories: [
+        {
+          id: "/repo/app",
+          label: "app",
+          path: "/repo/app",
+          worktreePath: "/repo/app/.worktrees/parent/app",
+          kind: "worktree" as const,
+        },
+      ],
+      gitBranch: "feature/parent",
+      inbox: {
+        inInbox: true,
+        reason: "new-thread" as const,
+      },
+      createdAt: 1_000,
+      updatedAt: 2_000,
+    };
+    const ensureDirectoryLaunchpad = vi.fn(async () => ({
+      launchpad: {
+        directoryKey: "subthread:codex:thread-parent:new-worktree",
+        directoryKind: "directory" as const,
+        directoryLabel: "app",
+        directoryPath: "/repo/app",
+        workMode: "local" as const,
+        backend: "codex" as const,
+        executionMode: "default" as const,
+        prompt: "",
+        branchName: "main",
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      defaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const updateDirectoryLaunchpad = vi.fn(async () => ({
+      launchpad: {
+        directoryKey: "subthread:codex:thread-parent:new-worktree",
+        directoryKind: "directory" as const,
+        directoryLabel: "app",
+        directoryPath: "/repo/app",
+        workMode: "worktree" as const,
+        backend: "codex" as const,
+        executionMode: "default" as const,
+        prompt: "",
+        branchName: "main",
+        createdAt: 1,
+        updatedAt: 2,
+      },
+      defaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: ["codex:thread-parent"],
+      threads: [parentThread],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const desktopApi: DesktopApi = {
+      ensureDirectoryLaunchpad,
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+      updateDirectoryLaunchpad,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.id).toBe("thread-parent");
+    });
+
+    await act(async () => {
+      await result.current.createSubthread(parentThread, "new-worktree");
+    });
+
+    expect(updateDirectoryLaunchpad).toHaveBeenCalledWith({
+      directoryKey: "subthread:codex:thread-parent:new-worktree",
+      patch: expect.objectContaining({
+        workMode: "worktree",
+        directoryPath: "/repo/app",
+        parentThreadId: "thread-parent",
+      }),
+    });
+    expect(result.current.selectedLaunchpad).toMatchObject({
+      directoryKey: "subthread:codex:thread-parent:new-worktree",
+      workMode: "worktree",
+      parentThreadId: "thread-parent",
+      parentThreadTitle: "Worktree parent",
+    });
+  });
+
   it("refreshes the selected thread when only the observed branch changes", async () => {
     const listeners = new Set<(event: any) => void>();
     let navigationCallCount = 0;

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -1262,6 +1262,81 @@ describe("useThreadNavigation", () => {
     expect(result.current.archiveThreadNotice).toBeUndefined();
   });
 
+  it("archives sub-threads before the parent when archiving a group", async () => {
+    const archivedThreadIds = new Set<string>();
+    const parentThread = {
+      id: "thread-parent",
+      title: "Parent thread",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+      updatedAt: 1_000,
+    };
+    const childThread = {
+      id: "thread-child",
+      title: "Child thread",
+      titleSource: "explicit" as const,
+      parentThreadId: "thread-parent",
+      source: "codex" as const,
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+      updatedAt: 2_000,
+    };
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [parentThread, childThread].filter(
+        (thread) => !archivedThreadIds.has(thread.id),
+      ),
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const archiveThread = vi.fn(async (request: { threadId: string }) => {
+      archivedThreadIds.add(request.threadId);
+      return {
+        backend: "codex" as const,
+        threadId: request.threadId,
+        archivedAt: 3_000,
+        cleanup: [],
+      };
+    });
+
+    const desktopApi: DesktopApi = {
+      archiveThread,
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.threads.map((thread) => thread.id)).toEqual([
+        "thread-parent",
+        "thread-child",
+      ]);
+    });
+
+    await act(async () => {
+      await result.current.archiveThread(result.current.threads[0]!, {
+        includeSubthreads: true,
+      });
+    });
+
+    expect(archiveThread.mock.calls.map(([request]) => request.threadId)).toEqual([
+      "thread-child",
+      "thread-parent",
+    ]);
+    await waitFor(() => {
+      expect(result.current.threads).toEqual([]);
+    });
+  });
+
   it("restores focus to the selected thread when archive fails", async () => {
     const navigationSnapshot = {
       backend: "all" as const,

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -2447,6 +2447,100 @@ describe("useThreadNavigation", () => {
     });
   });
 
+  it("forks a parent thread through the desktop bridge and selects the optimistic fork", async () => {
+    const parentThread = {
+      id: "thread-parent",
+      title: "Implement grouped threads",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      executionMode: "default" as const,
+      model: "gpt-5.5",
+      serviceTier: "fast",
+      fastMode: true,
+      linkedDirectories: [
+        {
+          id: "/repo/app",
+          label: "app",
+          path: "/repo/app",
+          worktreePath: "/repo/app/.worktrees/parent/app",
+          kind: "worktree" as const,
+        },
+      ],
+      inbox: {
+        inInbox: true,
+        reason: "new-thread" as const,
+      },
+      createdAt: 1_000,
+      updatedAt: 2_000,
+    };
+    const forkThread = vi.fn(async () => ({
+      backend: "codex" as const,
+      sourceThreadId: "thread-parent",
+      threadId: "thread-fork",
+      executionMode: "default" as const,
+      workMode: "worktree" as const,
+      linkedDirectory: {
+        id: "/repo/app",
+        label: "app",
+        path: "/repo/app",
+        worktreePath: "/repo/app/.worktrees/thread-fork/app",
+        kind: "worktree" as const,
+      },
+    }));
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: ["codex:thread-parent"],
+      threads: [parentThread],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const desktopApi: DesktopApi = {
+      forkThread,
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.id).toBe("thread-parent");
+    });
+
+    await act(async () => {
+      await result.current.forkThread(parentThread, "new-worktree");
+    });
+
+    expect(forkThread).toHaveBeenCalledWith({
+      backend: "codex",
+      sourceThreadId: "thread-parent",
+      parentThreadId: "thread-parent",
+      executionMode: "default",
+      directoryKind: "directory",
+      directoryLabel: "app",
+      directoryPath: "/repo/app",
+      workMode: "worktree",
+      model: "gpt-5.5",
+      reasoningEffort: undefined,
+      serviceTier: "fast",
+      fastMode: true,
+    });
+    expect(result.current.selectedThread).toMatchObject({
+      id: "thread-fork",
+      parentThreadId: "thread-parent",
+      linkedDirectories: [
+        {
+          kind: "worktree",
+          worktreePath: "/repo/app/.worktrees/thread-fork/app",
+        },
+      ],
+    });
+  });
+
   it("refreshes the selected thread when only the observed branch changes", async () => {
     const listeners = new Set<(event: any) => void>();
     let navigationCallCount = 0;

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -2944,6 +2944,126 @@ describe("useThreadNavigation", () => {
     });
   });
 
+  it("opens same-worktree sub-thread launchpads on the parent worktree branch", async () => {
+    const parentThread = {
+      id: "thread-parent",
+      title: "Worktree parent",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      executionMode: "default" as const,
+      linkedDirectories: [
+        {
+          id: "/repo/app",
+          label: "app",
+          path: "/repo/app",
+          worktreePath: "/repo/app/.worktrees/parent/app",
+          kind: "worktree" as const,
+        },
+      ],
+      gitBranch: "feature/parent",
+      observedGitBranch: "feature/parent",
+      inbox: {
+        inInbox: true,
+        reason: "new-thread" as const,
+      },
+      createdAt: 1_000,
+      updatedAt: 2_000,
+    };
+    const ensureDirectoryLaunchpad = vi.fn(async () => ({
+      launchpad: {
+        directoryKey: "subthread:codex:thread-parent:same-worktree",
+        directoryKind: "directory" as const,
+        directoryLabel: "app",
+        directoryPath: "/repo/app/.worktrees/parent/app",
+        workMode: "local" as const,
+        backend: "codex" as const,
+        executionMode: "default" as const,
+        prompt: "",
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      defaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const updateDirectoryLaunchpad = vi.fn(async () => ({
+      launchpad: {
+        directoryKey: "subthread:codex:thread-parent:same-worktree",
+        directoryKind: "directory" as const,
+        directoryLabel: "app",
+        directoryPath: "/repo/app/.worktrees/parent/app",
+        workMode: "local" as const,
+        backend: "codex" as const,
+        executionMode: "default" as const,
+        prompt: "",
+        branchName: "feature/parent",
+        parentThreadId: "thread-parent",
+        parentThreadTitle: "Worktree parent",
+        createdAt: 1,
+        updatedAt: 2,
+      },
+      defaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: ["codex:thread-parent"],
+      threads: [parentThread],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const desktopApi: DesktopApi = {
+      ensureDirectoryLaunchpad,
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+      updateDirectoryLaunchpad,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.id).toBe("thread-parent");
+    });
+
+    await act(async () => {
+      await result.current.createSubthread(parentThread, "same-worktree");
+    });
+
+    expect(ensureDirectoryLaunchpad).toHaveBeenCalledWith({
+      directoryKey: "subthread:codex:thread-parent:same-worktree",
+      directoryKind: "directory",
+      directoryLabel: "app",
+      directoryPath: "/repo/app/.worktrees/parent/app",
+      parentThreadId: "thread-parent",
+      parentThreadTitle: "Worktree parent",
+      preferredBackend: "codex",
+    });
+    expect(updateDirectoryLaunchpad).toHaveBeenCalledWith({
+      directoryKey: "subthread:codex:thread-parent:same-worktree",
+      patch: expect.objectContaining({
+        workMode: "local",
+        directoryPath: "/repo/app/.worktrees/parent/app",
+        branchName: "feature/parent",
+        parentThreadId: "thread-parent",
+      }),
+    });
+    expect(result.current.selectedLaunchpad).toMatchObject({
+      directoryKey: "subthread:codex:thread-parent:same-worktree",
+      workMode: "local",
+      branchName: "feature/parent",
+      parentThreadId: "thread-parent",
+      parentThreadTitle: "Worktree parent",
+    });
+  });
+
   it("refreshes the selected thread when only the observed branch changes", async () => {
     const listeners = new Set<(event: any) => void>();
     let navigationCallCount = 0;

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -1104,9 +1104,13 @@ describe("useThreadNavigation", () => {
       await result.current.archiveThread(result.current.threads[0]!);
     });
 
-    expect(result.current.archiveThreadError).toBe(
-      "Thread archived, but worktree cleanup failed for /repo/.worktrees/archive-me: Worktree is not registered with Git",
-    );
+    expect(result.current.archiveThreadError).toBeUndefined();
+    expect(result.current.archiveThreadNotice).toMatchObject({
+      title: "Worktree cleanup skipped",
+      message: "Thread archived. The worktree cleanup did not complete.",
+      detail:
+        "/repo/.worktrees/archive-me: Worktree is not registered with Git",
+    });
   });
 
   it("surfaces archive cleanup metadata lookup skips without requiring a worktree path", async () => {
@@ -1173,9 +1177,89 @@ describe("useThreadNavigation", () => {
       await result.current.archiveThread(result.current.threads[0]!);
     });
 
-    expect(result.current.archiveThreadError).toBe(
-      "Thread archived, but worktree cleanup was skipped: Unable to load thread metadata for archive cleanup: thread list unavailable",
-    );
+    expect(result.current.archiveThreadError).toBeUndefined();
+    expect(result.current.archiveThreadNotice).toMatchObject({
+      title: "Worktree cleanup skipped",
+      message: "Thread archived. The worktree cleanup did not complete.",
+      detail:
+        "Unable to load thread metadata for archive cleanup: thread list unavailable",
+    });
+  });
+
+  it("surfaces shared worktree archive cleanup skips as informational notices", async () => {
+    let archived = false;
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: archived
+        ? []
+        : [
+            {
+              id: "thread-archived",
+              title: "Archive me",
+              titleSource: "explicit" as const,
+              source: "codex" as const,
+              linkedDirectories: [],
+              inbox: { inInbox: false },
+              updatedAt: 1_000,
+            },
+          ],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const archiveThread = vi.fn(async () => {
+      archived = true;
+      return {
+        backend: "codex" as const,
+        threadId: "thread-archived",
+        archivedAt: 3_000,
+        cleanup: [
+          {
+            worktreePath: "/repo/.worktrees/shared",
+            removedWorktree: false,
+            deletedBranch: false,
+            skippedReason: "Worktree is still used by another active thread: thread-parent.",
+          },
+        ],
+      };
+    });
+
+    const desktopApi: DesktopApi = {
+      archiveThread,
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.threads.map((thread) => thread.id)).toEqual([
+        "thread-archived",
+      ]);
+    });
+
+    await act(async () => {
+      await result.current.archiveThread(result.current.threads[0]!);
+    });
+
+    expect(result.current.archiveThreadError).toBeUndefined();
+    expect(result.current.archiveThreadNotice).toMatchObject({
+      title: "Worktree kept",
+      message:
+        "Thread archived. The worktree was kept because another active thread is still using it.",
+      detail:
+        "/repo/.worktrees/shared: Worktree is still used by another active thread: thread-parent.",
+    });
+
+    act(() => {
+      result.current.dismissArchiveThreadNotice();
+    });
+    expect(result.current.archiveThreadNotice).toBeUndefined();
   });
 
   it("restores focus to the selected thread when archive fails", async () => {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -2616,6 +2616,8 @@ describe("useThreadNavigation", () => {
       model: "gpt-5.5",
       serviceTier: "fast",
       fastMode: true,
+      gitBranch: "feature/parent",
+      observedGitBranch: "feature/parent",
       messagingBindings: [
         {
           bindingId: "binding-parent",
@@ -2699,6 +2701,7 @@ describe("useThreadNavigation", () => {
       directoryKind: "directory",
       directoryLabel: "app",
       directoryPath: "/repo/app",
+      branchName: "feature/parent",
       workMode: "worktree",
       model: "gpt-5.5",
       reasoningEffort: undefined,
@@ -2933,6 +2936,7 @@ describe("useThreadNavigation", () => {
       patch: expect.objectContaining({
         workMode: "worktree",
         directoryPath: "/repo/app",
+        branchName: "feature/parent",
         parentThreadId: "thread-parent",
       }),
     });

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -2653,6 +2653,8 @@ describe("useThreadNavigation", () => {
       directoryKind: "directory",
       directoryLabel: "app",
       directoryPath: "/repo/app",
+      parentThreadId: "thread-parent",
+      parentThreadTitle: "Local parent",
       preferredBackend: "codex",
     });
     expect(updateDirectoryLaunchpad).toHaveBeenCalledWith({
@@ -2663,11 +2665,17 @@ describe("useThreadNavigation", () => {
         workMode: "local",
         directoryLabel: "app",
         directoryPath: "/repo/app",
+        parentThreadId: "thread-parent",
+        parentThreadTitle: "Local parent",
       },
     });
     expect(result.current.selectedLaunchpad?.directoryKey).toBe(
       "subthread:codex:thread-parent:local",
     );
+    expect(result.current.selectedLaunchpad).toMatchObject({
+      parentThreadId: "thread-parent",
+      parentThreadTitle: "Local parent",
+    });
   });
 
   it("refreshes the selected thread when only the observed branch changes", async () => {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -2561,6 +2561,115 @@ describe("useThreadNavigation", () => {
     expect(result.current.selectedThread?.reactions).toBeUndefined();
   });
 
+  it("opens local sub-thread launchpads against the parent's local checkout", async () => {
+    const parentThread = {
+      id: "thread-parent",
+      title: "Local parent",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      executionMode: "default" as const,
+      linkedDirectories: [
+        {
+          id: "/repo/app",
+          label: "app",
+          path: "/repo/app",
+          kind: "local" as const,
+        },
+      ],
+      inbox: {
+        inInbox: true,
+        reason: "new-thread" as const,
+      },
+      createdAt: 1_000,
+      updatedAt: 2_000,
+    };
+    const ensureDirectoryLaunchpad = vi.fn(async () => ({
+      launchpad: {
+        directoryKey: "subthread:codex:thread-parent:local",
+        directoryKind: "directory" as const,
+        directoryLabel: "app",
+        directoryPath: "/repo/app",
+        workMode: "local" as const,
+        backend: "codex" as const,
+        executionMode: "default" as const,
+        prompt: "",
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      defaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const updateDirectoryLaunchpad = vi.fn(async () => ({
+      launchpad: {
+        directoryKey: "subthread:codex:thread-parent:local",
+        directoryKind: "directory" as const,
+        directoryLabel: "app",
+        directoryPath: "/repo/app",
+        workMode: "local" as const,
+        backend: "codex" as const,
+        executionMode: "default" as const,
+        prompt: "",
+        createdAt: 1,
+        updatedAt: 2,
+      },
+      defaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: ["codex:thread-parent"],
+      threads: [parentThread],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const desktopApi: DesktopApi = {
+      ensureDirectoryLaunchpad,
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+      updateDirectoryLaunchpad,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.id).toBe("thread-parent");
+    });
+
+    await act(async () => {
+      await result.current.createSubthread(parentThread, "local");
+    });
+
+    expect(ensureDirectoryLaunchpad).toHaveBeenCalledWith({
+      directoryKey: "subthread:codex:thread-parent:local",
+      directoryKind: "directory",
+      directoryLabel: "app",
+      directoryPath: "/repo/app",
+      preferredBackend: "codex",
+    });
+    expect(updateDirectoryLaunchpad).toHaveBeenCalledWith({
+      directoryKey: "subthread:codex:thread-parent:local",
+      patch: {
+        backend: "codex",
+        executionMode: "default",
+        workMode: "local",
+        directoryLabel: "app",
+        directoryPath: "/repo/app",
+      },
+    });
+    expect(result.current.selectedLaunchpad?.directoryKey).toBe(
+      "subthread:codex:thread-parent:local",
+    );
+  });
+
   it("refreshes the selected thread when only the observed branch changes", async () => {
     const listeners = new Set<(event: any) => void>();
     let navigationCallCount = 0;

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -55,10 +55,14 @@ import type {
   ReorderDirectoryPinsResponse,
   ReorderThreadPinsRequest,
   ReorderThreadPinsResponse,
+  SetSubthreadsCollapsedRequest,
+  SetSubthreadsCollapsedResponse,
   SetDirectoryPinRequest,
   SetDirectoryPinResponse,
   SetThreadReactionRequest,
   SetThreadReactionResponse,
+  SetThreadParentRequest,
+  SetThreadParentResponse,
   SetThreadPinRequest,
   SetThreadPinResponse,
   GetGhStatusRequest,
@@ -182,6 +186,8 @@ import type {
   StartDesktopCodexAuthProfileLoginResponse,
   UpdateDirectoryLaunchpadRequest,
   UpdateDirectoryLaunchpadResponse,
+  UpdateSubthreadOrderRequest,
+  UpdateSubthreadOrderResponse,
   UpdateThreadExpectedBranchRequest,
   UpdateThreadExpectedBranchResponse,
   WriteDesktopSettingsConfigRequest,
@@ -454,6 +460,15 @@ export type DesktopApi = {
   reorderThreadPins?: (
     request: ReorderThreadPinsRequest
   ) => Promise<ReorderThreadPinsResponse>;
+  setThreadParent?: (
+    request: SetThreadParentRequest
+  ) => Promise<SetThreadParentResponse>;
+  updateSubthreadOrder?: (
+    request: UpdateSubthreadOrderRequest
+  ) => Promise<UpdateSubthreadOrderResponse>;
+  setSubthreadsCollapsed?: (
+    request: SetSubthreadsCollapsedRequest
+  ) => Promise<SetSubthreadsCollapsedResponse>;
   /**
    * Directory pin IPC (plan 2026-05-09-002, Unit H). Mirror of
    * setThreadPin / reorderThreadPins minus the per-backend

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -25,6 +25,8 @@ import type {
   AppServerListThreadsResponse,
   FocusedDiffAnalysisRequest,
   FocusedDiffAnalysisResponse,
+  ForkThreadRequest,
+  ForkThreadResponse,
   AppServerReadThreadRequest,
   AppServerReadThreadResponse,
   GetAutomationRunArtifactRequest,
@@ -334,6 +336,7 @@ export type DesktopApi = {
     request: RenameThreadRequest
   ) => Promise<RenameThreadResponse>;
   startThread?: (request: StartThreadRequest) => Promise<StartThreadResponse>;
+  forkThread?: (request: ForkThreadRequest) => Promise<ForkThreadResponse>;
   startReview?: (request: StartReviewRequest) => Promise<StartReviewResponse>;
   compactThread?: (
     request: CompactThreadRequest

--- a/apps/desktop/src/renderer/src/lib/subthread-launchpads.ts
+++ b/apps/desktop/src/renderer/src/lib/subthread-launchpads.ts
@@ -1,0 +1,43 @@
+import type { NavigationThreadSummary } from "@pwragent/shared";
+
+export type ThreadWorkspaceMode = "local" | "same-worktree" | "new-worktree";
+
+export function buildSubthreadLaunchpadKey(
+  parent: Pick<NavigationThreadSummary, "id" | "source">,
+  mode: ThreadWorkspaceMode,
+): string {
+  return `subthread:${encodeURIComponent(parent.source)}:${encodeURIComponent(parent.id)}:${mode}`;
+}
+
+export function getSubthreadLaunchpadMode(
+  directoryKey: string,
+): ThreadWorkspaceMode | undefined {
+  const parts = directoryKey.split(":");
+  if (parts.length !== 4 || parts[0] !== "subthread") {
+    return undefined;
+  }
+
+  const mode = parts[3];
+  if (mode === "local" || mode === "same-worktree" || mode === "new-worktree") {
+    return mode;
+  }
+  return undefined;
+}
+
+export function getParentThreadIdFromSubthreadLaunchpadKey(
+  directoryKey: string,
+): string | undefined {
+  const parts = directoryKey.split(":");
+  if (parts.length !== 4 || parts[0] !== "subthread") {
+    return undefined;
+  }
+  try {
+    return decodeURIComponent(parts[2]!);
+  } catch {
+    return undefined;
+  }
+}
+
+export function isSameWorktreeSubthreadLaunchpad(directoryKey: string): boolean {
+  return getSubthreadLaunchpadMode(directoryKey) === "same-worktree";
+}

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -2976,11 +2976,15 @@ export function useThreadNavigation(
           ? [response.linkedDirectory]
           : parent.linkedDirectories;
         const optimisticFork: NavigationThreadSummary = {
-          ...parent,
           id: response.threadId,
           title: parent.title,
           titleSource: parent.titleSource,
+          summary: parent.summary,
           source: response.backend,
+          projectKey:
+            response.linkedDirectory?.worktreePath ??
+            response.linkedDirectory?.path ??
+            parent.projectKey,
           createdAt: now,
           updatedAt: now,
           inbox: {
@@ -2988,11 +2992,14 @@ export function useThreadNavigation(
             reason: "new-thread",
           },
           executionMode: response.executionMode,
+          model: parent.model,
+          reasoningEffort: parent.reasoningEffort,
+          serviceTier: parent.serviceTier,
+          fastMode: parent.fastMode,
+          gitBranch: parent.gitBranch,
+          observedGitBranch: parent.observedGitBranch,
           linkedDirectories,
           parentThreadId: parent.id,
-          pinnedRank: undefined,
-          subthreadOrder: undefined,
-          subthreadsCollapsed: undefined,
         };
         const nextThreadKey = buildThreadIdentityKey(response.backend, response.threadId);
         setOptimisticThread(optimisticFork);

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -64,6 +64,58 @@ function getDirectoryKeyFromLaunchpadSelection(selectionKey?: string): string | 
   return selectionKey.slice("launchpad:".length);
 }
 
+function buildSubthreadLaunchpadKey(
+  parent: Pick<NavigationThreadSummary, "id" | "source">,
+  mode: "same-worktree" | "new-worktree",
+): string {
+  return `subthread:${encodeURIComponent(parent.source)}:${encodeURIComponent(parent.id)}:${mode}`;
+}
+
+function getParentThreadIdFromSubthreadLaunchpadKey(directoryKey: string): string | undefined {
+  const parts = directoryKey.split(":");
+  if (parts.length !== 4 || parts[0] !== "subthread") {
+    return undefined;
+  }
+  try {
+    return decodeURIComponent(parts[2]!);
+  } catch {
+    return undefined;
+  }
+}
+
+function selectThreadWorkspace(
+  thread: NavigationThreadSummary,
+  mode: "same-worktree" | "new-worktree",
+): {
+  directoryKind: NavigationDirectorySummary["kind"];
+  directoryLabel: string;
+  directoryPath?: string;
+  workMode: NavigationLaunchpadDraft["workMode"];
+} {
+  const worktree = thread.linkedDirectories.find((directory) => directory.kind === "worktree");
+  const local = thread.linkedDirectories.find((directory) => directory.kind === "local");
+  const preferred = worktree ?? local;
+
+  if (mode === "new-worktree") {
+    const repository = preferred?.path ?? thread.projectKey;
+    return {
+      directoryKind: repository ? "directory" : "workspace",
+      directoryLabel: preferred?.label ?? thread.title,
+      directoryPath: repository,
+      workMode: "worktree",
+    };
+  }
+
+  const sameWorkspacePath =
+    worktree?.worktreePath ?? worktree?.path ?? local?.path ?? thread.projectKey;
+  return {
+    directoryKind: sameWorkspacePath ? "directory" : "workspace",
+    directoryLabel: preferred?.label ?? thread.title,
+    directoryPath: sameWorkspacePath,
+    workMode: "local",
+  };
+}
+
 function compareNavigationDirectoriesByLabel(
   left: NavigationDirectorySummary,
   right: NavigationDirectorySummary
@@ -389,6 +441,10 @@ function threadSummariesEqual(
     JSON.stringify(left.workspaceHandoff ?? {}) ===
       JSON.stringify(right.workspaceHandoff ?? {}) &&
     left.pinnedRank === right.pinnedRank &&
+    left.parentThreadId === right.parentThreadId &&
+    JSON.stringify(left.subthreadOrder ?? []) ===
+      JSON.stringify(right.subthreadOrder ?? []) &&
+    left.subthreadsCollapsed === right.subthreadsCollapsed &&
     retainedBranchDriftPairsEqual(
       left.retainedBranchDriftPairs,
       right.retainedBranchDriftPairs
@@ -610,6 +666,91 @@ function updateThreadPinsInSnapshot(
     }
     changed = true;
     return { ...thread, pinnedRank };
+  });
+
+  return changed ? { ...snapshot, threads } : snapshot;
+}
+
+function updateThreadParentInSnapshot(
+  snapshot: NavigationSnapshot | undefined,
+  params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    parentThreadId?: string;
+  },
+): NavigationSnapshot | undefined {
+  if (!snapshot) {
+    return snapshot;
+  }
+
+  let changed = false;
+  const threads = snapshot.threads.map((thread) => {
+    if (thread.source !== params.backend || thread.id !== params.threadId) {
+      return thread;
+    }
+    if (thread.parentThreadId === params.parentThreadId) {
+      return thread;
+    }
+    changed = true;
+    return {
+      ...thread,
+      parentThreadId: params.parentThreadId,
+      pinnedRank: params.parentThreadId ? undefined : thread.pinnedRank,
+    };
+  });
+
+  return changed ? { ...snapshot, threads } : snapshot;
+}
+
+function updateSubthreadOrderInSnapshot(
+  snapshot: NavigationSnapshot | undefined,
+  params: {
+    backend: AppServerBackendKind;
+    parentThreadId: string;
+    threadIds: string[];
+  },
+): NavigationSnapshot | undefined {
+  if (!snapshot) {
+    return snapshot;
+  }
+
+  let changed = false;
+  const threads = snapshot.threads.map((thread) => {
+    if (thread.source !== params.backend || thread.id !== params.parentThreadId) {
+      return thread;
+    }
+    if (JSON.stringify(thread.subthreadOrder ?? []) === JSON.stringify(params.threadIds)) {
+      return thread;
+    }
+    changed = true;
+    return { ...thread, subthreadOrder: params.threadIds };
+  });
+
+  return changed ? { ...snapshot, threads } : snapshot;
+}
+
+function updateSubthreadsCollapsedInSnapshot(
+  snapshot: NavigationSnapshot | undefined,
+  params: {
+    backend: AppServerBackendKind;
+    parentThreadId: string;
+    collapsed: boolean;
+  },
+): NavigationSnapshot | undefined {
+  if (!snapshot) {
+    return snapshot;
+  }
+
+  let changed = false;
+  const threads = snapshot.threads.map((thread) => {
+    if (thread.source !== params.backend || thread.id !== params.parentThreadId) {
+      return thread;
+    }
+    if (thread.subthreadsCollapsed === params.collapsed) {
+      return thread;
+    }
+    changed = true;
+    return { ...thread, subthreadsCollapsed: params.collapsed };
   });
 
   return changed ? { ...snapshot, threads } : snapshot;
@@ -1333,6 +1474,7 @@ function buildOptimisticThreadFromLaunchpad(params: {
   workMode: NavigationLaunchpadDraft["workMode"];
   codexEnvironmentRuntime?: NavigationThreadSummary["codexEnvironmentRuntime"];
   optimisticUserMessage?: NavigationThreadSummary["optimisticUserMessage"];
+  parentThreadId?: string;
 }): NavigationThreadSummary {
   const titlePrompt =
     params.optimisticUserMessage?.text?.trim() || params.launchpad.prompt.trim();
@@ -1350,6 +1492,7 @@ function buildOptimisticThreadFromLaunchpad(params: {
     reasoningEffort: params.launchpad.reasoningEffort,
     serviceTier: params.launchpad.serviceTier,
     fastMode: params.launchpad.fastMode,
+    parentThreadId: params.parentThreadId,
     acpRuntime: params.launchpad.acpRuntime,
     codexEnvironmentRuntime: params.codexEnvironmentRuntime,
     optimisticUserMessage: params.optimisticUserMessage,
@@ -1445,6 +1588,10 @@ export function useThreadNavigation(
     backend?: AppServerBackendKind,
     executionMode?: ThreadExecutionMode
   ) => Promise<void>;
+  createSubthread: (
+    parent: NavigationThreadSummary,
+    mode?: "same-worktree" | "new-worktree",
+  ) => Promise<void>;
   createThreadError?: string;
   creatingThread?: {
     backend: AppServerBackendKind;
@@ -1465,7 +1612,8 @@ export function useThreadNavigation(
     directoryKey: string,
     input?: AppServerTurnInputItem[],
     collaborationMode?: AppServerCollaborationModeRequest,
-    reviewTarget?: AppServerReviewTarget
+    reviewTarget?: AppServerReviewTarget,
+    parentThreadId?: string,
   ) => Promise<void>;
   openDirectoryLaunchpad: (
     directory: NavigationDirectorySummary,
@@ -1549,6 +1697,18 @@ export function useThreadNavigation(
   reorderThreadPins: (
     backend: AppServerBackendKind,
     threadIds: string[],
+  ) => Promise<void>;
+  setThreadParent: (
+    thread: NavigationThreadSummary,
+    parentThreadId?: string,
+  ) => Promise<void>;
+  updateSubthreadOrder: (
+    parent: NavigationThreadSummary,
+    threadIds: string[],
+  ) => Promise<void>;
+  setSubthreadsCollapsed: (
+    parent: NavigationThreadSummary,
+    collapsed: boolean,
   ) => Promise<void>;
   /** Directory pin: optimistic patch → IPC → reconcile. Plan Unit J. */
   setDirectoryPin: (
@@ -2218,6 +2378,71 @@ export function useThreadNavigation(
         return;
       }
 
+      if (method === "thread/parent/set") {
+        const { threadId, parentThreadId } = event.notification.params as {
+          threadId: string;
+          parentThreadId: string;
+        };
+        setState((current) => ({
+          ...current,
+          response: updateThreadParentInSnapshot(current.response, {
+            backend: event.backend,
+            threadId,
+            parentThreadId,
+          }),
+        }));
+        scheduleRefresh();
+        return;
+      }
+
+      if (method === "thread/parent/cleared") {
+        const { threadId } = event.notification.params as {
+          threadId: string;
+        };
+        setState((current) => ({
+          ...current,
+          response: updateThreadParentInSnapshot(current.response, {
+            backend: event.backend,
+            threadId,
+            parentThreadId: undefined,
+          }),
+        }));
+        scheduleRefresh();
+        return;
+      }
+
+      if (method === "thread/subthreadOrder/updated") {
+        const { parentThreadId, threadIds } = event.notification.params as {
+          parentThreadId: string;
+          threadIds: string[];
+        };
+        setState((current) => ({
+          ...current,
+          response: updateSubthreadOrderInSnapshot(current.response, {
+            backend: event.backend,
+            parentThreadId,
+            threadIds,
+          }),
+        }));
+        return;
+      }
+
+      if (method === "thread/subthreadsCollapsed/updated") {
+        const { parentThreadId, collapsed } = event.notification.params as {
+          parentThreadId: string;
+          collapsed: boolean;
+        };
+        setState((current) => ({
+          ...current,
+          response: updateSubthreadsCollapsedInSnapshot(current.response, {
+            backend: event.backend,
+            parentThreadId,
+            collapsed,
+          }),
+        }));
+        return;
+      }
+
       // Directory pin bus events (plan 2026-05-09-002, Unit I).
       // Patcher short-circuits when the rank already matches so the
       // IPC response → patch → bus event → patch chain collapses
@@ -2645,6 +2870,66 @@ export function useThreadNavigation(
     [desktopApi, directories, refresh]
   );
 
+  const createSubthread = useCallback(
+    async (
+      parent: NavigationThreadSummary,
+      mode: "same-worktree" | "new-worktree" = "same-worktree",
+    ): Promise<void> => {
+      if (!desktopApi?.ensureDirectoryLaunchpad) {
+        setCreateThreadError("Desktop bridge is missing ensureDirectoryLaunchpad().");
+        return;
+      }
+
+      const directory = selectThreadWorkspace(parent, mode);
+      const directoryKey = buildSubthreadLaunchpadKey(parent, mode);
+      setCreatingThread({
+        backend: parent.source,
+        executionMode: parent.executionMode ?? "default",
+      });
+      setCreateThreadError(undefined);
+      setLaunchpadError(undefined);
+      setArchiveThreadError(undefined);
+      setSetThreadModelSettingsError(undefined);
+
+      try {
+        const response = await desktopApi.ensureDirectoryLaunchpad({
+          directoryKey,
+          directoryKind: directory.directoryKind,
+          directoryLabel: directory.directoryLabel,
+          directoryPath: directory.directoryPath,
+          preferredBackend: parent.source,
+        });
+        let launchpad = response.launchpad;
+        let defaults: NavigationLaunchpadDefaults = response.defaults;
+        const patch: Parameters<NonNullable<DesktopApi["updateDirectoryLaunchpad"]>>[0]["patch"] = {
+          backend: parent.source,
+          executionMode: parent.executionMode ?? response.launchpad.executionMode,
+          workMode: directory.workMode,
+          directoryLabel: directory.directoryLabel,
+          directoryPath: directory.directoryPath,
+        };
+        if (desktopApi.updateDirectoryLaunchpad) {
+          const updated = await desktopApi.updateDirectoryLaunchpad({
+            directoryKey,
+            patch,
+          });
+          launchpad = updated.launchpad;
+          defaults = updated.defaults;
+        }
+        setState((current) => ({
+          ...current,
+          response: applyLaunchpadUpdate(current.response, launchpad, defaults),
+        }));
+        setSelectedItemKey(buildLaunchpadSelectionKey(directoryKey));
+      } catch (error) {
+        setCreateThreadError(error instanceof Error ? error.message : String(error));
+      } finally {
+        setCreatingThread(undefined);
+      }
+    },
+    [desktopApi],
+  );
+
   const openDirectoryLaunchpad = useCallback(
     async (
       directory: NavigationDirectorySummary,
@@ -2953,7 +3238,8 @@ export function useThreadNavigation(
       directoryKey: string,
       input?: AppServerTurnInputItem[],
       collaborationMode?: AppServerCollaborationModeRequest,
-      reviewTarget?: AppServerReviewTarget
+      reviewTarget?: AppServerReviewTarget,
+      parentThreadId?: string,
     ): Promise<void> => {
       if (!desktopApi?.materializeDirectoryLaunchpad) {
         setLaunchpadError("Desktop bridge is missing materializeDirectoryLaunchpad().");
@@ -2970,12 +3256,17 @@ export function useThreadNavigation(
       setLaunchpadError(undefined);
 
       try {
+        const materializeParentThreadId =
+          parentThreadId ?? getParentThreadIdFromSubthreadLaunchpadKey(directoryKey);
         const response = await desktopApi.materializeDirectoryLaunchpad({
           directoryKey,
           launchpad,
           input,
           collaborationMode,
           reviewTarget,
+          ...(materializeParentThreadId
+            ? { parentThreadId: materializeParentThreadId }
+            : {}),
         });
         const optimisticMaterializedThread = buildOptimisticThreadFromLaunchpad({
           directory,
@@ -2986,6 +3277,7 @@ export function useThreadNavigation(
           workMode: response.workMode,
           codexEnvironmentRuntime: response.codexEnvironmentRuntime,
           optimisticUserMessage: buildOptimisticUserMessage(input),
+          parentThreadId: materializeParentThreadId,
         });
         const nextThreadKey = buildThreadIdentityKey(response.backend, response.threadId);
         setLocalLaunchpads((current) => {
@@ -3232,6 +3524,9 @@ export function useThreadNavigation(
   const setThreadPinRequest = desktopApi?.setThreadPin;
   const setThreadAgentRequest = desktopApi?.setThreadAgent;
   const reorderThreadPinsRequest = desktopApi?.reorderThreadPins;
+  const setThreadParentRequest = desktopApi?.setThreadParent;
+  const updateSubthreadOrderRequest = desktopApi?.updateSubthreadOrder;
+  const setSubthreadsCollapsedRequest = desktopApi?.setSubthreadsCollapsed;
   const setDirectoryPinRequest = desktopApi?.setDirectoryPin;
   const reorderDirectoryPinsRequest = desktopApi?.reorderDirectoryPins;
   const setThreadReaction = useCallback(
@@ -3363,6 +3658,123 @@ export function useThreadNavigation(
       }
     },
     [refresh, reorderThreadPinsRequest],
+  );
+
+  const setThreadParent = useCallback(
+    async (
+      thread: NavigationThreadSummary,
+      parentThreadId?: string,
+    ): Promise<void> => {
+      if (!setThreadParentRequest) {
+        return;
+      }
+
+      setState((current) => ({
+        ...current,
+        response: updateThreadParentInSnapshot(current.response, {
+          backend: thread.source,
+          threadId: thread.id,
+          parentThreadId,
+        }),
+      }));
+
+      try {
+        const result = await setThreadParentRequest({
+          backend: thread.source,
+          threadId: thread.id,
+          parentThreadId,
+        });
+        setState((current) => ({
+          ...current,
+          response: updateThreadParentInSnapshot(current.response, {
+            backend: result.backend,
+            threadId: result.threadId,
+            parentThreadId: result.parentThreadId,
+          }),
+        }));
+      } catch {
+        await refresh(buildThreadIdentityKey(thread.source, thread.id));
+      }
+    },
+    [refresh, setThreadParentRequest],
+  );
+
+  const updateSubthreadOrder = useCallback(
+    async (
+      parent: NavigationThreadSummary,
+      threadIds: string[],
+    ): Promise<void> => {
+      if (!updateSubthreadOrderRequest) {
+        return;
+      }
+
+      setState((current) => ({
+        ...current,
+        response: updateSubthreadOrderInSnapshot(current.response, {
+          backend: parent.source,
+          parentThreadId: parent.id,
+          threadIds,
+        }),
+      }));
+
+      try {
+        const result = await updateSubthreadOrderRequest({
+          backend: parent.source,
+          parentThreadId: parent.id,
+          threadIds,
+        });
+        setState((current) => ({
+          ...current,
+          response: updateSubthreadOrderInSnapshot(current.response, {
+            backend: result.backend,
+            parentThreadId: result.parentThreadId,
+            threadIds: result.threadIds,
+          }),
+        }));
+      } catch {
+        await refresh(buildThreadIdentityKey(parent.source, parent.id));
+      }
+    },
+    [refresh, updateSubthreadOrderRequest],
+  );
+
+  const setSubthreadsCollapsed = useCallback(
+    async (
+      parent: NavigationThreadSummary,
+      collapsed: boolean,
+    ): Promise<void> => {
+      if (!setSubthreadsCollapsedRequest) {
+        return;
+      }
+
+      setState((current) => ({
+        ...current,
+        response: updateSubthreadsCollapsedInSnapshot(current.response, {
+          backend: parent.source,
+          parentThreadId: parent.id,
+          collapsed,
+        }),
+      }));
+
+      try {
+        const result = await setSubthreadsCollapsedRequest({
+          backend: parent.source,
+          parentThreadId: parent.id,
+          collapsed,
+        });
+        setState((current) => ({
+          ...current,
+          response: updateSubthreadsCollapsedInSnapshot(current.response, {
+            backend: result.backend,
+            parentThreadId: result.parentThreadId,
+            collapsed: result.collapsed,
+          }),
+        }));
+      } catch {
+        await refresh(buildThreadIdentityKey(parent.source, parent.id));
+      }
+    },
+    [refresh, setSubthreadsCollapsedRequest],
   );
 
   const setThreadAgent = useCallback(
@@ -3684,6 +4096,7 @@ export function useThreadNavigation(
   return {
     browseMode,
     createThread,
+    createSubthread,
     createThreadError,
     creatingThread,
     directories,
@@ -3728,6 +4141,9 @@ export function useThreadNavigation(
     setThreadPin,
     setThreadAgent,
     reorderThreadPins,
+    setThreadParent,
+    updateSubthreadOrder,
+    setSubthreadsCollapsed,
     setDirectoryPin,
     reorderDirectoryPins,
     snapshot: state.response,

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -37,6 +37,10 @@ export type ArchiveThreadNotice = {
   detail?: string;
 };
 
+export type ArchiveThreadOptions = {
+  includeSubthreads?: boolean;
+};
+
 const ROOT_NEW_THREAD_WORKSPACE_LAUNCHPAD_KEY = "workspace:new-thread";
 const ROOT_NEW_THREAD_WORKSPACE_LABEL = "Workspaces";
 const NAVIGATION_BACKGROUND_REFRESH_INTERVAL_MS = 30_000;
@@ -725,6 +729,64 @@ function updateThreadParentInSnapshot(
   });
 
   return changed ? { ...snapshot, threads } : snapshot;
+}
+
+function ungroupChildThreadsInSnapshot(
+  snapshot: NavigationSnapshot | undefined,
+  params: {
+    backend: AppServerBackendKind;
+    parentThreadId: string;
+  },
+): NavigationSnapshot | undefined {
+  if (!snapshot) {
+    return snapshot;
+  }
+
+  let changed = false;
+  const threads = snapshot.threads.map((thread) => {
+    if (
+      thread.source !== params.backend ||
+      thread.parentThreadId !== params.parentThreadId
+    ) {
+      return thread;
+    }
+    changed = true;
+    return { ...thread, parentThreadId: undefined };
+  });
+
+  return changed ? { ...snapshot, threads } : snapshot;
+}
+
+function collectDescendantThreads(
+  threads: NavigationThreadSummary[],
+  parent: NavigationThreadSummary,
+): NavigationThreadSummary[] {
+  const descendants: NavigationThreadSummary[] = [];
+  const queue = threads.filter(
+    (thread) =>
+      thread.source === parent.source &&
+      thread.parentThreadId === parent.id,
+  );
+  const seen = new Set<string>();
+
+  while (queue.length > 0) {
+    const thread = queue.shift()!;
+    const key = buildThreadIdentityKey(thread.source, thread.id);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    descendants.push(thread);
+    queue.push(
+      ...threads.filter(
+        (candidate) =>
+          candidate.source === thread.source &&
+          candidate.parentThreadId === thread.id,
+      ),
+    );
+  }
+
+  return descendants;
 }
 
 function updateSubthreadOrderInSnapshot(
@@ -1699,7 +1761,10 @@ export function useThreadNavigation(
   ) => Promise<void>;
   setBrowseMode: (browseMode: BrowseMode) => void;
   selectThread: (thread: NavigationThreadSummary) => void;
-  archiveThread: (thread: NavigationThreadSummary) => Promise<void>;
+  archiveThread: (
+    thread: NavigationThreadSummary,
+    options?: ArchiveThreadOptions,
+  ) => Promise<void>;
   archiveWorktree: (
     thread: NavigationThreadSummary,
     directory: LinkedDirectorySummary
@@ -3445,7 +3510,10 @@ export function useThreadNavigation(
   );
 
   const archiveThread = useCallback(
-    async (thread: NavigationThreadSummary): Promise<void> => {
+    async (
+      thread: NavigationThreadSummary,
+      options?: ArchiveThreadOptions,
+    ): Promise<void> => {
       if (!archiveThreadRequest) {
         setArchiveThreadError("Desktop bridge is missing archiveThread().");
         return;
@@ -3455,8 +3523,18 @@ export function useThreadNavigation(
       const optimisticThreadKey = optimisticThread
         ? buildThreadIdentityKey(optimisticThread.source, optimisticThread.id)
         : undefined;
+      const targetThreads = options?.includeSubthreads
+        ? [...collectDescendantThreads(threads, thread).reverse(), thread]
+        : [thread];
+      const targetThreadKeys = new Set(
+        targetThreads.map((target) =>
+          buildThreadIdentityKey(target.source, target.id)
+        )
+      );
 
-      suppressedArchivedThreadKeysRef.current.add(threadKey);
+      for (const targetKey of targetThreadKeys) {
+        suppressedArchivedThreadKeysRef.current.add(targetKey);
+      }
       setArchiveThreadError(undefined);
       setArchiveThreadNotice(undefined);
       setCreateThreadError(undefined);
@@ -3465,13 +3543,22 @@ export function useThreadNavigation(
       setSetThreadModelSettingsError(undefined);
       setState((current) => ({
         ...current,
-        response: removeThreadFromSnapshot(current.response, {
-          backend: thread.source,
-          threadId: thread.id,
-        }),
+        response: targetThreads.reduce(
+          (snapshot, target) =>
+            removeThreadFromSnapshot(snapshot, {
+              backend: target.source,
+              threadId: target.id,
+            }),
+          options?.includeSubthreads
+            ? current.response
+            : ungroupChildThreadsInSnapshot(current.response, {
+                backend: thread.source,
+                parentThreadId: thread.id,
+              })
+        ),
       }));
       setSelectedItemKey((current) =>
-        current === threadKey
+        current && targetThreadKeys.has(current)
           ? getFallbackSelectionAfterRemoval(state.response, {
               backend: thread.source,
               threadId: thread.id,
@@ -3480,29 +3567,37 @@ export function useThreadNavigation(
           : current
       );
       setRetainedUnreadThread((current) =>
-        current?.source === thread.source && current.id === thread.id ? undefined : current
+        current && targetThreadKeys.has(buildThreadIdentityKey(current.source, current.id))
+          ? undefined
+          : current
       );
       setOptimisticThread((current) =>
-        current?.source === thread.source && current.id === thread.id ? undefined : current
+        current && targetThreadKeys.has(buildThreadIdentityKey(current.source, current.id))
+          ? undefined
+          : current
       );
 
       try {
-        const response = await archiveThreadRequest({
-          backend: thread.source,
-          threadId: thread.id,
-        });
-        const cleanupNotice = formatArchiveCleanupNotice(response.cleanup);
-        if (cleanupNotice) {
-          setArchiveThreadNotice(cleanupNotice);
+        for (const target of targetThreads) {
+          const response = await archiveThreadRequest({
+            backend: target.source,
+            threadId: target.id,
+          });
+          const cleanupNotice = formatArchiveCleanupNotice(response.cleanup);
+          if (cleanupNotice) {
+            setArchiveThreadNotice(cleanupNotice);
+          }
         }
         await refresh();
       } catch (error) {
-        suppressedArchivedThreadKeysRef.current.delete(threadKey);
+        for (const targetKey of targetThreadKeys) {
+          suppressedArchivedThreadKeysRef.current.delete(targetKey);
+        }
         setArchiveThreadError(error instanceof Error ? error.message : String(error));
         await refresh(threadKey, undefined, true);
       }
     },
-    [archiveThreadRequest, optimisticThread, refresh, state.response]
+    [archiveThreadRequest, optimisticThread, refresh, state.response, threads]
   );
 
   const archiveWorktree = useCallback(

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -28,6 +28,7 @@ import {
 import type { DesktopApi } from "./desktop-api";
 
 export type BrowseMode = "inbox" | "recents" | "directories";
+export type ThreadWorkspaceMode = "local" | "same-worktree" | "new-worktree";
 
 const ROOT_NEW_THREAD_WORKSPACE_LAUNCHPAD_KEY = "workspace:new-thread";
 const ROOT_NEW_THREAD_WORKSPACE_LABEL = "Workspaces";
@@ -66,7 +67,7 @@ function getDirectoryKeyFromLaunchpadSelection(selectionKey?: string): string | 
 
 function buildSubthreadLaunchpadKey(
   parent: Pick<NavigationThreadSummary, "id" | "source">,
-  mode: "same-worktree" | "new-worktree",
+  mode: ThreadWorkspaceMode,
 ): string {
   return `subthread:${encodeURIComponent(parent.source)}:${encodeURIComponent(parent.id)}:${mode}`;
 }
@@ -85,7 +86,7 @@ function getParentThreadIdFromSubthreadLaunchpadKey(directoryKey: string): strin
 
 function selectThreadWorkspace(
   thread: NavigationThreadSummary,
-  mode: "same-worktree" | "new-worktree",
+  mode: ThreadWorkspaceMode,
 ): {
   directoryKind: NavigationDirectorySummary["kind"];
   directoryLabel: string;
@@ -107,10 +108,15 @@ function selectThreadWorkspace(
   }
 
   const sameWorkspacePath =
-    worktree?.worktreePath ?? worktree?.path ?? local?.path ?? thread.projectKey;
+    mode === "same-worktree"
+      ? worktree?.worktreePath ?? worktree?.path ?? local?.path ?? thread.projectKey
+      : local?.path ?? thread.projectKey;
   return {
     directoryKind: sameWorkspacePath ? "directory" : "workspace",
-    directoryLabel: preferred?.label ?? thread.title,
+    directoryLabel:
+      mode === "local"
+        ? local?.label ?? thread.title
+        : preferred?.label ?? thread.title,
     directoryPath: sameWorkspacePath,
     workMode: "local",
   };
@@ -1590,11 +1596,11 @@ export function useThreadNavigation(
   ) => Promise<void>;
   createSubthread: (
     parent: NavigationThreadSummary,
-    mode?: "same-worktree" | "new-worktree",
+    mode?: ThreadWorkspaceMode,
   ) => Promise<void>;
   forkThread: (
     parent: NavigationThreadSummary,
-    mode: "same-worktree" | "new-worktree",
+    mode: ThreadWorkspaceMode,
   ) => Promise<void>;
   createThreadError?: string;
   creatingThread?: {
@@ -2878,7 +2884,7 @@ export function useThreadNavigation(
   const createSubthread = useCallback(
     async (
       parent: NavigationThreadSummary,
-      mode: "same-worktree" | "new-worktree" = "same-worktree",
+      mode: ThreadWorkspaceMode = "same-worktree",
     ): Promise<void> => {
       if (!desktopApi?.ensureDirectoryLaunchpad) {
         setCreateThreadError("Desktop bridge is missing ensureDirectoryLaunchpad().");
@@ -2938,7 +2944,7 @@ export function useThreadNavigation(
   const forkThread = useCallback(
     async (
       parent: NavigationThreadSummary,
-      mode: "same-worktree" | "new-worktree",
+      mode: ThreadWorkspaceMode,
     ): Promise<void> => {
       if (!forkThreadRequest) {
         setCreateThreadError("Desktop bridge is missing forkThread().");

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -1322,6 +1322,8 @@ function mergeLaunchpadUpdateResponse(
   preserveSetting("fastMode");
   preserveSetting("workMode");
   preserveSetting("branchName");
+  preserveSetting("parentThreadId");
+  preserveSetting("parentThreadTitle");
   preserveEnvironment("codexEnvironmentId");
   preserveEnvironment("codexEnvironmentExecutionTarget");
   preserveEnvironment("codexEnvironmentSetupEnabled");
@@ -2908,9 +2910,15 @@ export function useThreadNavigation(
           directoryKind: directory.directoryKind,
           directoryLabel: directory.directoryLabel,
           directoryPath: directory.directoryPath,
+          parentThreadId: parent.id,
+          parentThreadTitle: parent.title,
           preferredBackend: parent.source,
         });
-        let launchpad = response.launchpad;
+        let launchpad: NavigationLaunchpadDraft = {
+          ...response.launchpad,
+          parentThreadId: parent.id,
+          parentThreadTitle: parent.title,
+        };
         let defaults: NavigationLaunchpadDefaults = response.defaults;
         const patch: Parameters<NonNullable<DesktopApi["updateDirectoryLaunchpad"]>>[0]["patch"] = {
           backend: parent.source,
@@ -2918,15 +2926,25 @@ export function useThreadNavigation(
           workMode: directory.workMode,
           directoryLabel: directory.directoryLabel,
           directoryPath: directory.directoryPath,
+          parentThreadId: parent.id,
+          parentThreadTitle: parent.title,
         };
         if (desktopApi.updateDirectoryLaunchpad) {
           const updated = await desktopApi.updateDirectoryLaunchpad({
             directoryKey,
             patch,
           });
-          launchpad = updated.launchpad;
+          launchpad = {
+            ...updated.launchpad,
+            parentThreadId: parent.id,
+            parentThreadTitle: parent.title,
+          };
           defaults = updated.defaults;
         }
+        setLocalLaunchpads((current) => ({
+          ...current,
+          [directoryKey]: launchpad,
+        }));
         setState((current) => ({
           ...current,
           response: applyLaunchpadUpdate(current.response, launchpad, defaults),
@@ -3230,7 +3248,11 @@ export function useThreadNavigation(
           current[directoryKey]
             ? {
                 ...current,
-                [directoryKey]: response.launchpad,
+                [directoryKey]: mergeLaunchpadUpdateResponse(
+                  current[directoryKey],
+                  response.launchpad,
+                  patch,
+                ),
               }
             : current
         );

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -98,6 +98,7 @@ function selectThreadWorkspace(
   if (mode === "new-worktree") {
     const repository = preferred?.path ?? thread.projectKey;
     return {
+      branchName: thread.observedGitBranch ?? thread.gitBranch,
       directoryKind: repository ? "directory" : "workspace",
       directoryLabel: preferred?.label ?? thread.title,
       directoryPath: repository,
@@ -3067,6 +3068,7 @@ export function useThreadNavigation(
           directoryKind: directory.directoryKind,
           directoryLabel: directory.directoryLabel,
           directoryPath: directory.directoryPath,
+          ...(directory.branchName ? { branchName: directory.branchName } : {}),
           workMode: directory.workMode,
           model: parent.model,
           reasoningEffort: parent.reasoningEffort,

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -1592,6 +1592,10 @@ export function useThreadNavigation(
     parent: NavigationThreadSummary,
     mode?: "same-worktree" | "new-worktree",
   ) => Promise<void>;
+  forkThread: (
+    parent: NavigationThreadSummary,
+    mode: "same-worktree" | "new-worktree",
+  ) => Promise<void>;
   createThreadError?: string;
   creatingThread?: {
     backend: AppServerBackendKind;
@@ -1720,6 +1724,7 @@ export function useThreadNavigation(
   threads: NavigationThreadSummary[];
 } {
   const markThreadSeen = desktopApi?.markThreadSeen;
+  const forkThreadRequest = desktopApi?.forkThread;
   const archiveThreadRequest = desktopApi?.archiveThread;
   const archiveWorktreeRequest = desktopApi?.archiveWorktree;
   const restoreWorktreeRequest = desktopApi?.restoreWorktree;
@@ -2930,6 +2935,79 @@ export function useThreadNavigation(
     [desktopApi],
   );
 
+  const forkThread = useCallback(
+    async (
+      parent: NavigationThreadSummary,
+      mode: "same-worktree" | "new-worktree",
+    ): Promise<void> => {
+      if (!forkThreadRequest) {
+        setCreateThreadError("Desktop bridge is missing forkThread().");
+        return;
+      }
+
+      const directory = selectThreadWorkspace(parent, mode);
+      const executionMode = parent.executionMode ?? "default";
+      setCreatingThread({
+        backend: parent.source,
+        executionMode,
+      });
+      setCreateThreadError(undefined);
+      setLaunchpadError(undefined);
+      setArchiveThreadError(undefined);
+      setSetThreadModelSettingsError(undefined);
+
+      try {
+        const response = await forkThreadRequest({
+          backend: parent.source,
+          sourceThreadId: parent.id,
+          parentThreadId: parent.id,
+          executionMode,
+          directoryKind: directory.directoryKind,
+          directoryLabel: directory.directoryLabel,
+          directoryPath: directory.directoryPath,
+          workMode: directory.workMode,
+          model: parent.model,
+          reasoningEffort: parent.reasoningEffort,
+          serviceTier: parent.serviceTier,
+          fastMode: parent.fastMode,
+        });
+        const now = Date.now();
+        const linkedDirectories = response.linkedDirectory
+          ? [response.linkedDirectory]
+          : parent.linkedDirectories;
+        const optimisticFork: NavigationThreadSummary = {
+          ...parent,
+          id: response.threadId,
+          title: parent.title,
+          titleSource: parent.titleSource,
+          source: response.backend,
+          createdAt: now,
+          updatedAt: now,
+          inbox: {
+            inInbox: true,
+            reason: "new-thread",
+          },
+          executionMode: response.executionMode,
+          linkedDirectories,
+          parentThreadId: parent.id,
+          pinnedRank: undefined,
+          subthreadOrder: undefined,
+          subthreadsCollapsed: undefined,
+        };
+        const nextThreadKey = buildThreadIdentityKey(response.backend, response.threadId);
+        setOptimisticThread(optimisticFork);
+        setSelectedItemKey(nextThreadKey);
+        setPendingSeenThreadKey(nextThreadKey);
+        await refresh(nextThreadKey, optimisticFork, true);
+      } catch (error) {
+        setCreateThreadError(error instanceof Error ? error.message : String(error));
+      } finally {
+        setCreatingThread(undefined);
+      }
+    },
+    [forkThreadRequest, refresh],
+  );
+
   const openDirectoryLaunchpad = useCallback(
     async (
       directory: NavigationDirectorySummary,
@@ -4097,6 +4175,7 @@ export function useThreadNavigation(
     browseMode,
     createThread,
     createSubthread,
+    forkThread,
     createThreadError,
     creatingThread,
     directories,

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -30,6 +30,13 @@ import type { DesktopApi } from "./desktop-api";
 export type BrowseMode = "inbox" | "recents" | "directories";
 export type ThreadWorkspaceMode = "local" | "same-worktree" | "new-worktree";
 
+export type ArchiveThreadNotice = {
+  id: string;
+  title: string;
+  message: string;
+  detail?: string;
+};
+
 const ROOT_NEW_THREAD_WORKSPACE_LAUNCHPAD_KEY = "workspace:new-thread";
 const ROOT_NEW_THREAD_WORKSPACE_LABEL = "Workspaces";
 const NAVIGATION_BACKGROUND_REFRESH_INTERVAL_MS = 30_000;
@@ -187,9 +194,9 @@ function directoryKeysForThread(
     .map((directory) => directory.key);
 }
 
-function formatArchiveCleanupFailure(
+function formatArchiveCleanupNotice(
   cleanup: ArchiveThreadCleanupResult[]
-): string | undefined {
+): ArchiveThreadNotice | undefined {
   const failures = cleanup.filter(
     (item) => !item.removedWorktree || item.error || item.skippedReason
   );
@@ -199,9 +206,21 @@ function formatArchiveCleanupFailure(
   }
 
   const reason = firstFailure.error ?? firstFailure.skippedReason ?? "cleanup was skipped";
-  return firstFailure.worktreePath
-    ? `Thread archived, but worktree cleanup failed for ${firstFailure.worktreePath}: ${reason}`
-    : `Thread archived, but worktree cleanup was skipped: ${reason}`;
+  const sharedWorktree = reason.startsWith("Worktree is still used by");
+  const title = sharedWorktree ? "Worktree kept" : "Worktree cleanup skipped";
+  const message = sharedWorktree
+    ? "Thread archived. The worktree was kept because another active thread is still using it."
+    : "Thread archived. The worktree cleanup did not complete.";
+  const detail = firstFailure.worktreePath
+    ? `${firstFailure.worktreePath}: ${reason}`
+    : reason;
+
+  return {
+    id: [firstFailure.worktreePath ?? "no-worktree", reason, Date.now().toString()].join("\n"),
+    title,
+    message,
+    detail,
+  };
 }
 
 function linkedDirectoriesEqual(
@@ -1615,6 +1634,8 @@ export function useThreadNavigation(
   recentThreads: NavigationThreadSummary[];
   launchpadError?: string;
   archiveThreadError?: string;
+  archiveThreadNotice?: ArchiveThreadNotice;
+  dismissArchiveThreadNotice: () => void;
   worktreeArchiveError?: string;
   renameThreadError?: string;
   loading: boolean;
@@ -1761,6 +1782,7 @@ export function useThreadNavigation(
   const [createThreadError, setCreateThreadError] = useState<string>();
   const [launchpadError, setLaunchpadError] = useState<string>();
   const [archiveThreadError, setArchiveThreadError] = useState<string>();
+  const [archiveThreadNotice, setArchiveThreadNotice] = useState<ArchiveThreadNotice>();
   const [worktreeArchiveError, setWorktreeArchiveError] = useState<string>();
   const [renameThreadError, setRenameThreadError] = useState<string>();
   const [updatingThreadExecutionMode, setUpdatingThreadExecutionMode] =
@@ -3436,6 +3458,7 @@ export function useThreadNavigation(
 
       suppressedArchivedThreadKeysRef.current.add(threadKey);
       setArchiveThreadError(undefined);
+      setArchiveThreadNotice(undefined);
       setCreateThreadError(undefined);
       setLaunchpadError(undefined);
       setSetThreadExecutionModeError(undefined);
@@ -3468,9 +3491,9 @@ export function useThreadNavigation(
           backend: thread.source,
           threadId: thread.id,
         });
-        const cleanupFailure = formatArchiveCleanupFailure(response.cleanup);
-        if (cleanupFailure) {
-          setArchiveThreadError(cleanupFailure);
+        const cleanupNotice = formatArchiveCleanupNotice(response.cleanup);
+        if (cleanupNotice) {
+          setArchiveThreadNotice(cleanupNotice);
         }
         await refresh();
       } catch (error) {
@@ -4206,6 +4229,10 @@ export function useThreadNavigation(
     [refresh, setAcpSessionRuntimeOption]
   );
 
+  const dismissArchiveThreadNotice = useCallback((): void => {
+    setArchiveThreadNotice(undefined);
+  }, []);
+
   return {
     browseMode,
     createThread,
@@ -4219,6 +4246,8 @@ export function useThreadNavigation(
     recentThreads,
     launchpadError,
     archiveThreadError,
+    archiveThreadNotice,
+    dismissArchiveThreadNotice,
     worktreeArchiveError,
     renameThreadError,
     loading: state.loading,

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -26,9 +26,14 @@ import {
   shortenDerivedThreadTitle,
 } from "@pwragent/shared";
 import type { DesktopApi } from "./desktop-api";
+import {
+  buildSubthreadLaunchpadKey,
+  getParentThreadIdFromSubthreadLaunchpadKey,
+  type ThreadWorkspaceMode,
+} from "./subthread-launchpads";
 
 export type BrowseMode = "inbox" | "recents" | "directories";
-export type ThreadWorkspaceMode = "local" | "same-worktree" | "new-worktree";
+export type { ThreadWorkspaceMode } from "./subthread-launchpads";
 
 export type ArchiveThreadNotice = {
   id: string;
@@ -76,25 +81,6 @@ function getDirectoryKeyFromLaunchpadSelection(selectionKey?: string): string | 
   return selectionKey.slice("launchpad:".length);
 }
 
-function buildSubthreadLaunchpadKey(
-  parent: Pick<NavigationThreadSummary, "id" | "source">,
-  mode: ThreadWorkspaceMode,
-): string {
-  return `subthread:${encodeURIComponent(parent.source)}:${encodeURIComponent(parent.id)}:${mode}`;
-}
-
-function getParentThreadIdFromSubthreadLaunchpadKey(directoryKey: string): string | undefined {
-  const parts = directoryKey.split(":");
-  if (parts.length !== 4 || parts[0] !== "subthread") {
-    return undefined;
-  }
-  try {
-    return decodeURIComponent(parts[2]!);
-  } catch {
-    return undefined;
-  }
-}
-
 function selectThreadWorkspace(
   thread: NavigationThreadSummary,
   mode: ThreadWorkspaceMode,
@@ -103,6 +89,7 @@ function selectThreadWorkspace(
   directoryLabel: string;
   directoryPath?: string;
   workMode: NavigationLaunchpadDraft["workMode"];
+  branchName?: string;
 } {
   const worktree = thread.linkedDirectories.find((directory) => directory.kind === "worktree");
   const local = thread.linkedDirectories.find((directory) => directory.kind === "local");
@@ -130,6 +117,9 @@ function selectThreadWorkspace(
         : preferred?.label ?? thread.title,
     directoryPath: sameWorkspacePath,
     workMode: "local",
+    ...(mode === "same-worktree"
+      ? { branchName: thread.observedGitBranch ?? thread.gitBranch }
+      : {}),
   };
 }
 
@@ -3013,6 +3003,7 @@ export function useThreadNavigation(
           workMode: directory.workMode,
           directoryLabel: directory.directoryLabel,
           directoryPath: directory.directoryPath,
+          ...(directory.branchName ? { branchName: directory.branchName } : {}),
           parentThreadId: parent.id,
           parentThreadTitle: parent.title,
         };

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1960,6 +1960,69 @@ textarea,
   min-width: 0;
 }
 
+.thread-group {
+  min-width: 0;
+}
+
+.subthread-list {
+  position: relative;
+  display: grid;
+  gap: 2px;
+  margin: 1px 0 4px 18px;
+  padding-left: 10px;
+  border-left: 1px solid var(--border-subtle);
+}
+
+.subthread-list--compact {
+  margin-left: 14px;
+}
+
+.thread-row-shell--nested .thread-row {
+  padding-left: 12px;
+}
+
+.thread-row-shell.has-subthreads .thread-row {
+  padding-left: 30px;
+}
+
+.thread-row__subthread-toggle {
+  position: absolute;
+  top: 13px;
+  left: 8px;
+  z-index: 4;
+  display: grid;
+  width: 18px;
+  height: 18px;
+  place-items: center;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.thread-row__subthread-toggle::before {
+  width: 0;
+  height: 0;
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  border-left: 5px solid currentColor;
+  content: "";
+  transition: transform 120ms ease;
+}
+
+.thread-row__subthread-toggle.is-open::before {
+  transform: rotate(90deg);
+}
+
+.thread-row__subthread-toggle:hover,
+.thread-row__subthread-toggle:focus-visible {
+  border-color: var(--accent-border);
+  background: var(--bg-row-active);
+  color: var(--accent-bright);
+}
+
 .thread-row-shell.is-draggable {
   cursor: grab;
 }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3142,6 +3142,25 @@ textarea,
   cursor: default;
 }
 
+.thread-context-menu .thread-context-menu__button--stacked {
+  min-height: 46px;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  gap: 2px;
+}
+
+.thread-context-menu__item-detail {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.thread-context-menu button:hover:not(:disabled) .thread-context-menu__item-detail,
+.thread-context-menu button:focus-visible:not(:disabled) .thread-context-menu__item-detail {
+  color: var(--accent-bright);
+}
+
 /* macOS-native pattern: action label on the left, keyboard
    shortcut hint chip on the right (margin-left: auto). Used by
    the pin/move items in the thread + directory context menus so

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3340,31 +3340,59 @@ textarea,
   padding: 0 10px;
 }
 
-.app-update-banner {
+.app-toast-stack {
   position: fixed;
   z-index: 80;
   left: 16px;
   bottom: 16px;
+  display: flex;
+  max-width: min(420px, calc(100vw - 32px));
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 10px;
+  pointer-events: none;
+}
+
+.app-toast-stack > * {
+  pointer-events: auto;
+}
+
+.app-notice-toast,
+.app-update-banner {
+  position: relative;
   display: grid;
   width: max-content;
-  max-width: min(300px, calc(100vw - 32px));
+  max-width: 100%;
   grid-template-columns: minmax(0, 1fr);
   gap: 12px;
   padding: 14px;
-  border: 1px solid var(--accent-border);
   border-radius: 8px;
-  background: color-mix(in srgb, var(--bg-panel-elevated) 94%, var(--accent) 6%);
   box-shadow: var(--shadow-popover);
   animation: app-update-banner-enter 160ms ease-out;
+  -webkit-app-region: no-drag;
 }
 
+.app-notice-toast {
+  overflow: hidden;
+  grid-template-columns: minmax(0, 1fr) auto;
+  border: 1px solid var(--border-subtle);
+  background: color-mix(in srgb, var(--bg-panel-elevated) 96%, var(--text-muted) 4%);
+}
+
+.app-update-banner {
+  border: 1px solid var(--accent-border);
+  background: color-mix(in srgb, var(--bg-panel-elevated) 94%, var(--accent) 6%);
+}
+
+.app-notice-toast__content,
 .app-update-banner__content {
   min-width: 0;
+  user-select: text;
 }
 
+.app-notice-toast__eyebrow,
 .app-update-banner__eyebrow {
   margin: 0 0 4px;
-  color: var(--accent-bright);
   font-size: 11px;
   font-weight: 700;
   letter-spacing: 0;
@@ -3372,15 +3400,33 @@ textarea,
   text-transform: uppercase;
 }
 
+.app-notice-toast__eyebrow {
+  color: var(--text-secondary);
+}
+
+.app-update-banner__eyebrow {
+  color: var(--accent-bright);
+}
+
+.app-notice-toast__message,
+.app-notice-toast__detail,
 .app-update-banner__message,
 .app-update-banner__error {
   margin: 0;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
   font-size: 13px;
   line-height: 1.35;
 }
 
+.app-notice-toast__message,
 .app-update-banner__message {
   color: var(--text-primary);
+}
+
+.app-notice-toast__detail {
+  margin-top: 8px;
+  color: var(--text-secondary);
 }
 
 .app-update-banner__error {
@@ -3388,16 +3434,65 @@ textarea,
   color: var(--danger-text);
 }
 
+.app-notice-toast__actions,
 .app-update-banner__actions {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
 }
 
+.app-notice-toast__actions {
+  align-self: start;
+}
+
+.app-notice-toast__icon-button {
+  display: inline-grid;
+  width: 30px;
+  height: 30px;
+  place-items: center;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-secondary);
+}
+
+.app-notice-toast__icon-button:hover,
+.app-notice-toast__icon-button:focus-visible {
+  border-color: var(--accent-border);
+  background: var(--accent-soft);
+  color: var(--accent-bright);
+  outline: none;
+}
+
+.app-notice-toast__timer {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 2px;
+  background: color-mix(in srgb, var(--text-muted) 42%, transparent);
+  transform-origin: left center;
+  animation: app-notice-toast-countdown 9000ms linear forwards;
+}
+
+.app-notice-toast__timer[data-paused="true"] {
+  animation-play-state: paused;
+}
+
 .app-update-banner__restart,
 .app-update-banner__dismiss {
   min-height: 30px;
   padding: 0 10px;
+}
+
+@keyframes app-notice-toast-countdown {
+  from {
+    transform: scaleX(1);
+  }
+
+  to {
+    transform: scaleX(0);
+  }
 }
 
 @keyframes app-update-banner-enter {

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -12,6 +12,7 @@ export const FOCUSED_DIFF_ANALYZE_CHANNEL = "focused-diff:analyze";
 export const BACKEND_LIST_CHANNEL = "backend:list";
 export const ACP_AGENTS_LIST_CHANNEL = "acp-agents:list";
 export const AGENT_START_THREAD_CHANNEL = "agent:start-thread";
+export const AGENT_FORK_THREAD_CHANNEL = "agent:fork-thread";
 export const AGENT_START_TURN_CHANNEL = "agent:start-turn";
 export const AGENT_START_REVIEW_CHANNEL = "agent:start-review";
 export const AGENT_COMPACT_THREAD_CHANNEL = "agent:compact-thread";

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -53,6 +53,12 @@ export const NAVIGATION_SET_THREAD_AGENT_CHANNEL =
   "navigation:set-thread-agent";
 export const NAVIGATION_REORDER_THREAD_PINS_CHANNEL =
   "navigation:reorder-thread-pins";
+export const NAVIGATION_SET_THREAD_PARENT_CHANNEL =
+  "navigation:set-thread-parent";
+export const NAVIGATION_UPDATE_SUBTHREAD_ORDER_CHANNEL =
+  "navigation:update-subthread-order";
+export const NAVIGATION_SET_SUBTHREADS_COLLAPSED_CHANNEL =
+  "navigation:set-subthreads-collapsed";
 /**
  * Directory pin IPC (plan 2026-05-09-002, Unit G). Mirror of the
  * thread-pin channels with the per-backend dimension dropped —

--- a/packages/agent-core/src/domain/navigation-state.ts
+++ b/packages/agent-core/src/domain/navigation-state.ts
@@ -173,6 +173,9 @@ export function materializeNavigationThreads(params: {
       worktreeSnapshots: overlay?.worktreeSnapshots ?? thread.worktreeSnapshots ?? [],
       reactions: overlay?.reactions ?? [],
       pinnedRank: overlay?.pinnedRank,
+      parentThreadId: overlay?.parentThreadId,
+      subthreadOrder: overlay?.subthreadOrder,
+      subthreadsCollapsed: overlay?.subthreadsCollapsed,
       prs: overlay?.prs ?? [],
       messagingBindings: messagingBindings && messagingBindings.length > 0
         ? messagingBindings
@@ -395,6 +398,9 @@ export function buildNavigationSnapshotHash(params: {
       },
       reactions: thread.reactions ?? [],
       pinnedRank: thread.pinnedRank ?? null,
+      parentThreadId: thread.parentThreadId ?? null,
+      subthreadOrder: thread.subthreadOrder ?? [],
+      subthreadsCollapsed: thread.subthreadsCollapsed ?? null,
       // Include prs in the hash so refreshThreadPullRequests writes to
       // the overlay actually propagate to the renderer. Without this,
       // the next snapshot tick computes an identical hash, gets marked

--- a/packages/agent-core/src/persistence/overlay-store.ts
+++ b/packages/agent-core/src/persistence/overlay-store.ts
@@ -71,6 +71,9 @@ export class OverlayStore {
             extraLinkedDirectories: current?.extraLinkedDirectories ?? [],
             worktreeSnapshots: current?.worktreeSnapshots ?? [],
             pinnedRank: current?.pinnedRank,
+            parentThreadId: current?.parentThreadId,
+            subthreadOrder: current?.subthreadOrder,
+            subthreadsCollapsed: current?.subthreadsCollapsed,
             permissionTransitionLog: current?.permissionTransitionLog,
             messagingBindingTransitionLog:
               current?.messagingBindingTransitionLog,
@@ -510,6 +513,98 @@ export class OverlayStore {
         };
       });
       return pinnedRanks;
+    });
+  }
+
+  async setThreadParent(params: {
+    backend: ThreadOverlayState["backend"];
+    threadId: string;
+    parentThreadId?: string | null;
+  }): Promise<ThreadOverlayState> {
+    return await this.withData(async (data) => {
+      if (params.parentThreadId === params.threadId) {
+        throw new Error("A thread cannot be its own parent.");
+      }
+      const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+      const current = data.threads[threadKey] ?? {
+        backend: params.backend,
+        threadId: params.threadId,
+        executionMode: "default" as const,
+        extraLinkedDirectories: [],
+      };
+      const parentThreadId = params.parentThreadId?.trim();
+      const nextState: ThreadOverlayState = {
+        ...current,
+        parentThreadId: parentThreadId || undefined,
+        pinnedRank: parentThreadId ? undefined : current.pinnedRank,
+      };
+      data.threads[threadKey] = nextState;
+      if (parentThreadId) {
+        const parentKey = buildThreadIdentityKey(params.backend, parentThreadId);
+        const parent = data.threads[parentKey] ?? {
+          backend: params.backend,
+          threadId: parentThreadId,
+          executionMode: "default" as const,
+          extraLinkedDirectories: [],
+        };
+        data.threads[parentKey] = {
+          ...parent,
+          subthreadOrder: [
+            ...(parent.subthreadOrder ?? []).filter((id) => id !== params.threadId),
+            params.threadId,
+          ],
+        };
+      }
+      return nextState;
+    });
+  }
+
+  async updateSubthreadOrder(params: {
+    backend: ThreadOverlayState["backend"];
+    parentThreadId: string;
+    threadIds: string[];
+  }): Promise<string[]> {
+    return await this.withData(async (data) => {
+      const parentKey = buildThreadIdentityKey(params.backend, params.parentThreadId);
+      const parent = data.threads[parentKey] ?? {
+        backend: params.backend,
+        threadId: params.parentThreadId,
+        executionMode: "default" as const,
+        extraLinkedDirectories: [],
+      };
+      const seen = new Set<string>();
+      const threadIds = params.threadIds.filter((threadId) => {
+        if (seen.has(threadId)) return false;
+        seen.add(threadId);
+        return threadId !== params.parentThreadId;
+      });
+      data.threads[parentKey] = {
+        ...parent,
+        subthreadOrder: threadIds,
+      };
+      return threadIds;
+    });
+  }
+
+  async setSubthreadsCollapsed(params: {
+    backend: ThreadOverlayState["backend"];
+    parentThreadId: string;
+    collapsed: boolean;
+  }): Promise<ThreadOverlayState> {
+    return await this.withData(async (data) => {
+      const parentKey = buildThreadIdentityKey(params.backend, params.parentThreadId);
+      const parent = data.threads[parentKey] ?? {
+        backend: params.backend,
+        threadId: params.parentThreadId,
+        executionMode: "default" as const,
+        extraLinkedDirectories: [],
+      };
+      const nextState: ThreadOverlayState = {
+        ...parent,
+        subthreadsCollapsed: params.collapsed,
+      };
+      data.threads[parentKey] = nextState;
+      return nextState;
     });
   }
 

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -44,6 +44,33 @@ export type StartThreadResponse = {
   codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
 };
 
+export type ForkThreadRequest = {
+  backend: AppServerBackendKind;
+  sourceThreadId: ThreadIdentifier;
+  parentThreadId?: ThreadIdentifier;
+  executionMode?: ThreadExecutionMode;
+  directoryKind?: DirectorySummaryKind;
+  directoryLabel?: string;
+  directoryPath?: string;
+  workMode?: LaunchpadWorkMode;
+  branchName?: string;
+  model?: string;
+  approvalPolicy?: string;
+  sandbox?: string;
+  serviceTier?: string;
+  reasoningEffort?: string;
+  fastMode?: boolean;
+};
+
+export type ForkThreadResponse = {
+  backend: AppServerBackendKind;
+  sourceThreadId: ThreadIdentifier;
+  threadId: ThreadIdentifier;
+  executionMode: ThreadExecutionMode;
+  linkedDirectory?: LinkedDirectorySummary;
+  workMode: LaunchpadWorkMode;
+};
+
 export type StartTurnRequest = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -316,6 +316,7 @@ export type MaterializeDirectoryLaunchpadRequest = {
   input?: AppServerTurnInputItem[];
   collaborationMode?: AppServerCollaborationModeRequest;
   reviewTarget?: AppServerReviewTarget;
+  parentThreadId?: ThreadIdentifier;
 };
 
 export type MaterializeDirectoryLaunchpadResponse = {

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -286,6 +286,8 @@ export type EnsureDirectoryLaunchpadRequest = {
   directoryLabel: string;
   directoryPath?: string;
   currentBranch?: string;
+  parentThreadId?: string;
+  parentThreadTitle?: string;
   preferredBackend?: AppServerBackendKind;
   registeredAt?: number;
 };
@@ -312,6 +314,8 @@ export type UpdateDirectoryLaunchpadRequest = {
       | "acpRuntime"
       | "workMode"
       | "branchName"
+      | "parentThreadId"
+      | "parentThreadTitle"
       | "codexEnvironmentId"
       | "codexEnvironmentExecutionTarget"
       | "codexEnvironmentSetupEnabled"

--- a/packages/shared/src/contracts/backend.ts
+++ b/packages/shared/src/contracts/backend.ts
@@ -132,6 +132,7 @@ export type BackendAcpSummary = {
 export type BackendCapabilities = {
   listThreads: boolean;
   createThread: boolean;
+  forkThread?: boolean;
   resumeThread: boolean;
   archiveThread?: boolean;
   restoreThread?: boolean;

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -211,6 +211,8 @@ export type NavigationLaunchpadDraft = NavigationLaunchpadDefaults & {
   settingsTouchedAt?: number;
   workMode: LaunchpadWorkMode;
   branchName?: string;
+  parentThreadId?: string;
+  parentThreadTitle?: string;
   codexEnvironmentId?: string;
   codexEnvironmentExecutionTarget?: CodexEnvironmentExecutionTarget;
   codexEnvironmentSetupEnabled?: boolean;

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -49,6 +49,15 @@ export type NavigationThreadSummary = AppServerThreadSummary & {
   agent?: ThreadAgentMetadata;
   /** User-curated position in the pinned section. Lower ranks sort first. */
   pinnedRank?: string;
+  /**
+   * UI-only sub-thread relationship. The child remains an independent
+   * agent thread; this only controls sidebar grouping.
+   */
+  parentThreadId?: ThreadIdentifier;
+  /** User-curated child order, stored on the parent thread overlay. */
+  subthreadOrder?: ThreadIdentifier[];
+  /** Persisted disclosure state for the parent's child section. */
+  subthreadsCollapsed?: boolean;
   retainedBranchDriftPairs?: ThreadBranchDriftPair[];
   /**
    * Pending permission mode change waiting for the active turn to end.
@@ -432,6 +441,42 @@ export type ReorderThreadPinsResponse = {
   pinnedRanks: Record<ThreadIdentifier, string>;
 };
 
+export type SetThreadParentRequest = {
+  backend?: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  parentThreadId?: ThreadIdentifier | null;
+};
+
+export type SetThreadParentResponse = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  parentThreadId?: ThreadIdentifier;
+};
+
+export type UpdateSubthreadOrderRequest = {
+  backend?: AppServerBackendKind;
+  parentThreadId: ThreadIdentifier;
+  threadIds: ThreadIdentifier[];
+};
+
+export type UpdateSubthreadOrderResponse = {
+  backend: AppServerBackendKind;
+  parentThreadId: ThreadIdentifier;
+  threadIds: ThreadIdentifier[];
+};
+
+export type SetSubthreadsCollapsedRequest = {
+  backend?: AppServerBackendKind;
+  parentThreadId: ThreadIdentifier;
+  collapsed: boolean;
+};
+
+export type SetSubthreadsCollapsedResponse = {
+  backend: AppServerBackendKind;
+  parentThreadId: ThreadIdentifier;
+  collapsed: boolean;
+};
+
 /**
  * Directory pinning (mirror of thread pinning, sans the `backend`
  * dimension). Directory keys are globally unique — a directory
@@ -563,6 +608,15 @@ export type ThreadOverlayState = {
   reactions?: string[];
   /** User-curated position in the pinned section. Undefined means unpinned. */
   pinnedRank?: string;
+  /**
+   * UI-only parent relationship. This does not grant the child agent
+   * access to the parent transcript or state.
+   */
+  parentThreadId?: ThreadIdentifier;
+  /** Child thread ids in user-curated order, stored on the parent. */
+  subthreadOrder?: ThreadIdentifier[];
+  /** Persisted disclosure state for the parent's child section. */
+  subthreadsCollapsed?: boolean;
   /**
    * GitHub pull requests detected for this thread, persisted across
    * restarts so chips appear instantly on relaunch and so we can

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -1095,6 +1095,33 @@ export type AppServerNotification =
         pinnedRanks: Record<string, string>;
       };
     }
+  | {
+      method: "thread/parent/set";
+      params: {
+        threadId: string;
+        parentThreadId: string;
+      };
+    }
+  | {
+      method: "thread/parent/cleared";
+      params: {
+        threadId: string;
+      };
+    }
+  | {
+      method: "thread/subthreadOrder/updated";
+      params: {
+        parentThreadId: string;
+        threadIds: string[];
+      };
+    }
+  | {
+      method: "thread/subthreadsCollapsed/updated";
+      params: {
+        parentThreadId: string;
+        collapsed: boolean;
+      };
+    }
   /**
    * Directory pin lifecycle — mirror of `thread/pin/*` minus the
    * implicit per-backend dimension (directories are


### PR DESCRIPTION
## Summary

Adds desktop sidebar support for visually grouped sub-threads and real Codex thread forks. Operators can right-click a parent thread, open a UI-only sub-thread launchpad, or create a true Codex fork in the same worktree or in a newly prepared managed worktree.

Refs pwrdrvr/PwrAgent#543.

## What Changed

- Extends navigation overlay contracts and stores with UI-owned `parentThreadId`, `subthreadOrder`, and `subthreadsCollapsed` state.
- Adds IPC, preload, desktop API, and backend bus plumbing for parent assignment, child ordering, and collapse persistence.
- Adds `forkThread` across shared contracts, desktop IPC, the registry, and the Codex app-server client, backed by Codex `thread/fork`.
- Routes `Fork into Same Worktree` and `Fork into New Worktree` through real Codex fork semantics while stamping the fork as a visual child of the source thread.
- Keeps `New Sub-thread` as the issue-specified UI-only launchpad path: independent thread, inherited workspace prefill, no parent transcript/context access.
- Renders sub-thread groups in Inbox, Recents, and Directories; Recents supports child drag reorder within a parent group.
- Refreshes messaging/sidebar navigation state when sub-thread metadata changes.

## Known Gaps

- Archive/delete cascade prompts from issue 543 are not implemented in this PR.
- Directory lens renders and collapses sub-thread groups, but child drag reorder is currently implemented only in Recents.

## Testing

- `pnpm test apps/desktop/src/main/__tests__/codex-client.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx -t fork`
- `pnpm test apps/desktop/src/main/__tests__/codex-client.test.ts -- --testNamePattern "forks a Codex thread"`
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts -t "forks a Codex thread"`
- `pnpm test apps/desktop/src/main/__tests__/overlay-store-pins.test.ts apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx`
- `pnpm --filter @pwragent/desktop exec tsc --noEmit`
- `pnpm lint:boundaries`

Note: a broad run including all of `backend-registry.test.ts` hit an unrelated existing env-action concurrency flake caused by local shell startup/npm warning noise being captured in action output. The fork-specific backend-registry tests pass.

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with GPT-5 via [Codex](https://openai.com/codex)