### PR TITLE
feat(messaging): add status controller popover

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-activity-log.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-activity-log.test.ts
@@ -134,6 +134,53 @@ describe("MessagingActivityLog", () => {
     ]);
   });
 
+  it("summarizes latest request and response timestamps by platform", () => {
+    log.record({
+      platform: "telegram",
+      kind: "inbound-routed",
+      summary: "telegram request",
+      createdAt: 1_000,
+    });
+    log.record({
+      platform: "telegram",
+      kind: "outbound",
+      summary: "telegram response",
+      createdAt: 2_000,
+    });
+    log.record({
+      platform: "telegram",
+      kind: "inbound-rejected",
+      summary: "newer telegram request",
+      createdAt: 3_000,
+    });
+    log.record({
+      platform: "discord",
+      kind: "outbound",
+      summary: "discord response",
+      createdAt: 4_000,
+    });
+    log.record({
+      platform: "discord",
+      kind: "diagnostic",
+      summary: "not request or response",
+      createdAt: 5_000,
+    });
+
+    expect(log.getPlatformActivitySummary()).toEqual({
+      summaries: expect.arrayContaining([
+        expect.objectContaining({
+          platform: "telegram",
+          lastRequestAt: 3_000,
+          lastResponseAt: 2_000,
+        }),
+        expect.objectContaining({
+          platform: "discord",
+          lastResponseAt: 4_000,
+        }),
+      ]),
+    });
+  });
+
   it("clamps the limit to the [1, 500] range", () => {
     for (let i = 0; i < 10; i += 1) {
       log.record({

--- a/apps/desktop/src/main/__tests__/messaging-status-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-ipc.test.ts
@@ -20,6 +20,7 @@ const pairingStoreMock = vi.hoisted(() => ({
   markStatus: vi.fn(),
 }));
 const activityLogMock = vi.hoisted(() => ({
+  getPlatformActivitySummary: vi.fn(() => ({ summaries: [] as unknown[] })),
   record: vi.fn(),
 }));
 const messagingConfigMocks = vi.hoisted(() => ({
@@ -123,6 +124,8 @@ describe("messaging status ipc", () => {
       configPath: "/tmp/pwragent-config.toml",
     });
     pairingStoreMock.markStatus.mockReset();
+    activityLogMock.getPlatformActivitySummary.mockClear();
+    activityLogMock.getPlatformActivitySummary.mockReturnValue({ summaries: [] });
     activityLogMock.record.mockClear();
     messagingConfigMocks.loadDesktopMessagingConfigFromSettings.mockClear();
     leaseCoordinatorMock.applyLatestConfig.mockClear();
@@ -364,6 +367,32 @@ describe("messaging status ipc", () => {
 
     expect(leaseCoordinatorMock.shutdown).toHaveBeenCalledWith(runtimeMock);
     expect(runtimeMock.stop).toHaveBeenCalled();
+  });
+
+  it("returns persisted per-provider request and response activity summaries", async () => {
+    const summary = {
+      summaries: [
+        {
+          platform: "telegram",
+          lastRequestAt: 1_000,
+          lastResponseAt: 2_000,
+        },
+      ],
+    };
+    activityLogMock.getPlatformActivitySummary.mockReturnValue(summary);
+    const { registerMessagingStatusIpcHandlers } = await import(
+      "../ipc/messaging-status"
+    );
+    const { MESSAGING_GET_ACTIVITY_SUMMARY_CHANNEL } = await import(
+      "../../shared/ipc"
+    );
+
+    registerMessagingStatusIpcHandlers();
+
+    await expect(
+      handlers.get(MESSAGING_GET_ACTIVITY_SUMMARY_CHANNEL)?.(),
+    ).resolves.toEqual(summary);
+    expect(activityLogMock.getPlatformActivitySummary).toHaveBeenCalled();
   });
 
   it("swallows shutdown errors so a failing teardown can't block the spawn", async () => {

--- a/apps/desktop/src/main/ipc/messaging-status.ts
+++ b/apps/desktop/src/main/ipc/messaging-status.ts
@@ -7,6 +7,7 @@ import type {
   DesktopSettingsSnapshot,
   GenerateMessagingPairingTokenRequest,
   GenerateMessagingPairingTokenResponse,
+  GetMessagingActivitySummaryResponse,
   ListMessagingActivityRequest,
   ListMessagingActivityResponse,
   ListMessagingPairingRequestsRequest,
@@ -35,6 +36,7 @@ import {
   MESSAGING_BINDINGS_CHANGED_EVENT_CHANNEL,
   MESSAGING_APPROVE_PAIRING_CHANNEL,
   MESSAGING_GENERATE_PAIRING_TOKEN_CHANNEL,
+  MESSAGING_GET_ACTIVITY_SUMMARY_CHANNEL,
   MESSAGING_GET_PLATFORM_STATUSES_CHANNEL,
   MESSAGING_LIST_ACTIVITY_CHANNEL,
   MESSAGING_LIST_PAIRING_REQUESTS_CHANNEL,
@@ -327,6 +329,14 @@ export function registerMessagingStatusIpcHandlers(): void {
     },
   );
 
+  ipcMain.removeHandler(MESSAGING_GET_ACTIVITY_SUMMARY_CHANNEL);
+  ipcMain.handle(
+    MESSAGING_GET_ACTIVITY_SUMMARY_CHANNEL,
+    async (): Promise<GetMessagingActivitySummaryResponse> => {
+      return getDesktopMessagingActivityLog().getPlatformActivitySummary();
+    },
+  );
+
   ipcMain.removeHandler(MESSAGING_GENERATE_PAIRING_TOKEN_CHANNEL);
   ipcMain.handle(
     MESSAGING_GENERATE_PAIRING_TOKEN_CHANNEL,
@@ -510,6 +520,7 @@ export async function disposeMessagingStatusIpcHandlers(): Promise<void> {
   unsubscribePairingChanged = undefined;
   ipcMain.removeHandler(MESSAGING_GET_PLATFORM_STATUSES_CHANNEL);
   ipcMain.removeHandler(MESSAGING_LIST_ACTIVITY_CHANNEL);
+  ipcMain.removeHandler(MESSAGING_GET_ACTIVITY_SUMMARY_CHANNEL);
   ipcMain.removeHandler(MESSAGING_GENERATE_PAIRING_TOKEN_CHANNEL);
   ipcMain.removeHandler(MESSAGING_LIST_PAIRING_REQUESTS_CHANNEL);
   ipcMain.removeHandler(MESSAGING_APPROVE_PAIRING_CHANNEL);

--- a/apps/desktop/src/main/messaging/messaging-activity-log.ts
+++ b/apps/desktop/src/main/messaging/messaging-activity-log.ts
@@ -1,5 +1,6 @@
 import type {
   AppServerBackendKind,
+  GetMessagingActivitySummaryResponse,
   MessagingActivityEntry,
   MessagingActivityKind,
   MessagingChannelKind,
@@ -112,6 +113,41 @@ export class MessagingActivityLog {
           .all(limit) as RawActivityRow[]);
     return rows.map(rowToEntry);
   }
+
+  getPlatformActivitySummary(): GetMessagingActivitySummaryResponse {
+    const rows = this.stateDb.raw
+      .prepare(
+        `SELECT
+           platform,
+           MAX(
+             CASE
+               WHEN kind IN ('inbound-routed', 'inbound-rejected', 'inbound-ignored')
+               THEN created_at
+             END
+           ) AS last_request_at,
+           MAX(
+             CASE
+               WHEN kind = 'outbound'
+               THEN created_at
+             END
+           ) AS last_response_at
+         FROM messaging_activity_log
+         GROUP BY platform
+         HAVING last_request_at IS NOT NULL OR last_response_at IS NOT NULL`,
+      )
+      .all() as RawActivitySummaryRow[];
+    return {
+      summaries: rows.map((row) => ({
+        platform: row.platform as MessagingChannelKind,
+        ...(row.last_request_at !== null
+          ? { lastRequestAt: row.last_request_at }
+          : {}),
+        ...(row.last_response_at !== null
+          ? { lastResponseAt: row.last_response_at }
+          : {}),
+      })),
+    };
+  }
 }
 
 type RawActivityRow = {
@@ -127,6 +163,12 @@ type RawActivityRow = {
   summary: string;
   created_at: number;
   payload: string;
+};
+
+type RawActivitySummaryRow = {
+  platform: string;
+  last_request_at: number | null;
+  last_response_at: number | null;
 };
 
 function rowToEntry(row: RawActivityRow): MessagingActivityEntry {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -76,6 +76,7 @@ import type {
   ApproveMessagingPairingResponse,
   GenerateMessagingPairingTokenRequest,
   GenerateMessagingPairingTokenResponse,
+  GetMessagingActivitySummaryResponse,
   ListMessagingActivityRequest,
   ListMessagingActivityResponse,
   ListMessagingPairingRequestsRequest,
@@ -254,6 +255,7 @@ import {
   MESSAGING_BINDINGS_CHANGED_EVENT_CHANNEL,
   MESSAGING_APPROVE_PAIRING_CHANNEL,
   MESSAGING_GENERATE_PAIRING_TOKEN_CHANNEL,
+  MESSAGING_GET_ACTIVITY_SUMMARY_CHANNEL,
   MESSAGING_GET_PLATFORM_STATUSES_CHANNEL,
   MESSAGING_LIST_ACTIVITY_CHANNEL,
   MESSAGING_LIST_PAIRING_REQUESTS_CHANNEL,
@@ -869,6 +871,9 @@ const desktopApi = Object.freeze({
     request?: ListMessagingActivityRequest,
   ): Promise<ListMessagingActivityResponse> =>
     await ipcRenderer.invoke(MESSAGING_LIST_ACTIVITY_CHANNEL, request),
+  getMessagingActivitySummary:
+    async (): Promise<GetMessagingActivitySummaryResponse> =>
+      await ipcRenderer.invoke(MESSAGING_GET_ACTIVITY_SUMMARY_CHANNEL),
   generateMessagingPairingToken: async (
     request: GenerateMessagingPairingTokenRequest,
   ): Promise<GenerateMessagingPairingTokenResponse> =>

--- a/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.test.tsx
@@ -1,7 +1,8 @@
 import "@testing-library/jest-dom/vitest";
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
+  DesktopSettingsSnapshot,
   MessagingPlatformStatus,
   MessagingPlatformStatusEvent,
 } from "@pwragent/shared";
@@ -32,11 +33,20 @@ describe("MessagingStatusBar", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByLabelText(/Feishu \/ Lark: Enabled/),
+        screen.getByRole("button", { name: /1 online/ }),
       ).toBeInTheDocument();
     });
     expect(container.querySelector(".messaging-status-chip img")).not.toBeNull();
     expect(container.querySelector(".messaging-status-chip__fallback")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /Feishu \/ Lark/ }));
+
+    const popover = await screen.findByRole("dialog", {
+      name: "Messaging platforms",
+    });
+    expect(popover).toHaveTextContent("open.larksuite.com");
+    expect(popover).toHaveTextContent("Bot: PwrAgent");
+    expect(popover).not.toHaveTextContent("Account detail: open.larksuite.com");
   });
 
   it("renders degraded status with rate-limit detail in the tooltip", async () => {
@@ -71,21 +81,24 @@ describe("MessagingStatusBar", () => {
 
     render(<MessagingStatusBar desktopApi={desktopApi} />);
 
-    const chip = await screen.findByRole("group", {
-      name: "Messaging platform status",
+    fireEvent.click(await screen.findByRole("button", { name: /1 degraded/ }));
+
+    const popover = await screen.findByRole("dialog", {
+      name: "Messaging platforms",
     });
     await waitFor(() => {
       expect(
-        screen.getByLabelText(/Telegram: Degraded/),
+        screen.getByText("Telegram"),
       ).toBeInTheDocument();
     });
-    expect(chip).toHaveTextContent("Rate limited");
-    expect(chip).toHaveTextContent("Telegram group -100123");
-    expect(chip).toHaveTextContent("Bot: @pwragent_bot");
-    expect(chip).toHaveTextContent("Account detail: api.telegram.org");
+    expect(popover).toHaveTextContent("Rate limited");
+    expect(popover).toHaveTextContent("Telegram group -100123");
+    expect(popover).toHaveTextContent("remaining");
+    expect(popover).toHaveTextContent("Bot: @pwragent_bot");
+    expect(popover).toHaveTextContent("Account detail: api.telegram.org");
   });
 
-  it("clears credential identity when health event omits account metadata", async () => {
+  it("keeps credential identity visible when messaging is suspended", async () => {
     const statuses = [
       {
         changedAt: 1000,
@@ -107,14 +120,17 @@ describe("MessagingStatusBar", () => {
 
     render(<MessagingStatusBar desktopApi={desktopApi} />);
 
-    const chip = await screen.findByRole("group", {
-      name: "Messaging platform status",
+    fireEvent.click(await screen.findByRole("button", { name: /1 online/ }));
+
+    const popover = await screen.findByRole("dialog", {
+      name: "Messaging platforms",
     });
     await waitFor(() => {
-      expect(screen.getByLabelText(/Telegram: Enabled/)).toBeInTheDocument();
+      expect(screen.getByText("Telegram")).toBeInTheDocument();
     });
-    expect(chip).toHaveTextContent("Bot: @pwragent_bot");
-    expect(chip).toHaveTextContent("Account detail: api.telegram.org");
+    expect(popover).toHaveTextContent("Bot: @pwragent_bot");
+    expect(popover).toHaveTextContent("api.telegram.org");
+    expect(popover).not.toHaveTextContent("Account detail: api.telegram.org");
 
     act(() => {
       emitStatusEvent?.({
@@ -126,9 +142,358 @@ describe("MessagingStatusBar", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByLabelText(/Telegram: Suspended/)).toBeInTheDocument();
+      expect(screen.getByText("Globally disabled")).toBeInTheDocument();
     });
-    expect(chip).not.toHaveTextContent("Bot: @pwragent_bot");
-    expect(chip).not.toHaveTextContent("Account detail: api.telegram.org");
+    expect(popover).toHaveTextContent("Bot: @pwragent_bot");
+    expect(popover).toHaveTextContent("Account detail: api.telegram.org");
+  });
+
+  it("pins the popover and toggles messaging from the status controller", async () => {
+    const statuses = [
+      {
+        changedAt: 1000,
+        health: "enabled",
+        platform: "telegram",
+      },
+    ] satisfies MessagingPlatformStatus[];
+    const setMessagingEnabled = vi.fn(async () => ({
+      enabled: false,
+      overridden: false,
+      disabledReason: "Messaging is stopped for this app instance.",
+      disabledReasonKind: "runtime_stopped" as const,
+    }));
+    const desktopApi: DesktopApi = {
+      getMessagingPlatformStatuses: vi.fn(async () => statuses),
+      onMessagingPlatformStatusEvent: vi.fn(() => () => {}),
+      setMessagingEnabled,
+    };
+
+    render(<MessagingStatusBar desktopApi={desktopApi} />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /1 online/ }));
+    expect(
+      await screen.findByRole("dialog", { name: "Messaging platforms" }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "On" }));
+
+    await waitFor(() => {
+      expect(setMessagingEnabled).toHaveBeenCalledWith({ enabled: false });
+    });
+    expect(screen.getByRole("button", { name: "Off" })).toBeInTheDocument();
+  });
+
+  it("uses runtime-disabled settings instead of stale errored platform health", async () => {
+    const statuses = [
+      {
+        changedAt: 1000,
+        health: "errored",
+        platform: "telegram",
+        reason: "Invalid token",
+      },
+    ] satisfies MessagingPlatformStatus[];
+    const setMessagingEnabled = vi.fn(async () => ({
+      enabled: true,
+      overridden: false,
+    }));
+    const desktopApi: DesktopApi = {
+      getMessagingPlatformStatuses: vi.fn(async () => statuses),
+      onMessagingPlatformStatusEvent: vi.fn(() => () => {}),
+      readSettings: vi.fn(async () => ({
+        snapshot: messagingSettingsSnapshot(
+          { telegram: true },
+          { runtimeMessagingDisabled: true },
+        ),
+      })),
+      setMessagingEnabled,
+    };
+
+    render(<MessagingStatusBar desktopApi={desktopApi} />);
+
+    const controller = await screen.findByRole("button", {
+      name: /1 configured platform off/,
+    });
+    expect(controller).toHaveTextContent("Off");
+
+    fireEvent.click(controller);
+    fireEvent.click(await screen.findByRole("button", { name: "Off" }));
+
+    await waitFor(() => {
+      expect(setMessagingEnabled).toHaveBeenCalledWith({ enabled: true });
+    });
+  });
+
+  it("persists per-platform enabled toggles from the popover rows", async () => {
+    const statuses = [
+      {
+        changedAt: 1000,
+        health: "enabled",
+        platform: "telegram",
+        account: "@pwragent_bot",
+      },
+    ] satisfies MessagingPlatformStatus[];
+    const writeSettingsConfig = vi.fn(async () => ({
+      snapshot: messagingSettingsSnapshot({ telegram: false }),
+    }));
+    const desktopApi: DesktopApi = {
+      getMessagingPlatformStatuses: vi.fn(async () => statuses),
+      onMessagingPlatformStatusEvent: vi.fn(() => () => {}),
+      readSettings: vi.fn(async () => ({
+        snapshot: messagingSettingsSnapshot({ telegram: true }),
+      })),
+      writeSettingsConfig,
+    };
+
+    render(<MessagingStatusBar desktopApi={desktopApi} />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /1 online/ }));
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Disable Telegram" }),
+    );
+
+    await waitFor(() => {
+      expect(writeSettingsConfig).toHaveBeenCalledWith({
+        patch: { messaging: { telegram: { enabled: false } } },
+      });
+    });
+  });
+
+  it("does not write provider settings while messaging is stopped for the session", async () => {
+    const statuses = [
+      {
+        changedAt: 1000,
+        health: "enabled",
+        platform: "telegram",
+      },
+    ] satisfies MessagingPlatformStatus[];
+    const setMessagingEnabled = vi.fn(async () => ({
+      enabled: false,
+      overridden: false,
+      disabledReasonKind: "runtime_stopped" as const,
+    }));
+    const writeSettingsConfig = vi.fn(async () => ({
+      snapshot: messagingSettingsSnapshot({ telegram: false }),
+    }));
+    const desktopApi: DesktopApi = {
+      getMessagingPlatformStatuses: vi.fn(async () => statuses),
+      onMessagingPlatformStatusEvent: vi.fn(() => () => {}),
+      readSettings: vi.fn(async () => ({
+        snapshot: messagingSettingsSnapshot({ telegram: true }),
+      })),
+      setMessagingEnabled,
+      writeSettingsConfig,
+    };
+
+    render(<MessagingStatusBar desktopApi={desktopApi} />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /1 online/ }));
+    fireEvent.click(screen.getByRole("button", { name: "On" }));
+
+    await waitFor(() => {
+      expect(setMessagingEnabled).toHaveBeenCalledWith({ enabled: false });
+    });
+
+    const platformSwitch = await screen.findByRole("button", {
+      name: "Disable Telegram",
+    });
+    expect(platformSwitch).toBeDisabled();
+
+    fireEvent.click(platformSwitch);
+    expect(writeSettingsConfig).not.toHaveBeenCalled();
+  });
+
+  it("shows configured disabled platforms omitted by runtime startup and enables them from the row", async () => {
+    const writeSettingsConfig = vi.fn(async () => ({
+      snapshot: messagingSettingsSnapshot(
+        { line: true },
+        { configured: { line: true } },
+      ),
+    }));
+    const desktopApi: DesktopApi = {
+      getMessagingPlatformStatuses: vi.fn(async () => []),
+      onMessagingPlatformStatusEvent: vi.fn(() => () => {}),
+      readSettings: vi.fn(async () => ({
+        snapshot: messagingSettingsSnapshot(
+          { line: false },
+          { configured: { line: true } },
+        ),
+      })),
+      writeSettingsConfig,
+    };
+
+    render(<MessagingStatusBar desktopApi={desktopApi} />);
+
+    const controller = await screen.findByRole("button", { name: /LINE/ });
+    expect(controller).toHaveTextContent("Msg");
+
+    fireEvent.click(controller);
+    expect(
+      await screen.findByRole("dialog", { name: "Messaging platforms" }),
+    ).toHaveTextContent("LINE");
+
+    fireEvent.click(await screen.findByRole("button", { name: "Enable LINE" }));
+
+    await waitFor(() => {
+      expect(writeSettingsConfig).toHaveBeenCalledWith({
+        patch: { messaging: { line: { enabled: true } } },
+      });
+    });
+  });
+
+  it("shows persisted provider request and response activity summaries", async () => {
+    const now = Date.now();
+    const statuses = [
+      {
+        changedAt: 1000,
+        health: "enabled",
+        platform: "telegram",
+      },
+    ] satisfies MessagingPlatformStatus[];
+    const desktopApi: DesktopApi = {
+      getMessagingPlatformStatuses: vi.fn(async () => statuses),
+      getMessagingActivitySummary: vi.fn(async () => ({
+        summaries: [
+          {
+            platform: "telegram" as const,
+            lastRequestAt: now - 60_000,
+            lastResponseAt: now - 30_000,
+          },
+        ],
+      })),
+      onMessagingPlatformStatusEvent: vi.fn(() => () => {}),
+    };
+
+    render(<MessagingStatusBar desktopApi={desktopApi} />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /1 online/ }));
+
+    const popover = await screen.findByRole("dialog", {
+      name: "Messaging platforms",
+    });
+    await waitFor(() => {
+      expect(popover).toHaveTextContent("Last request:");
+      expect(popover).toHaveTextContent("Last response:");
+    });
+  });
+
+  it("shows an explicit empty response state when only requests have been recorded", async () => {
+    const now = Date.now();
+    const statuses = [
+      {
+        changedAt: 1000,
+        health: "enabled",
+        platform: "telegram",
+      },
+    ] satisfies MessagingPlatformStatus[];
+    const desktopApi: DesktopApi = {
+      getMessagingPlatformStatuses: vi.fn(async () => statuses),
+      getMessagingActivitySummary: vi.fn(async () => ({
+        summaries: [
+          {
+            platform: "telegram" as const,
+            lastRequestAt: now - 60_000,
+          },
+        ],
+      })),
+      onMessagingPlatformStatusEvent: vi.fn(() => () => {}),
+    };
+
+    render(<MessagingStatusBar desktopApi={desktopApi} />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /1 online/ }));
+
+    const popover = await screen.findByRole("dialog", {
+      name: "Messaging platforms",
+    });
+    await waitFor(() => {
+      expect(popover).toHaveTextContent("Last request:");
+      expect(popover).toHaveTextContent("Last response: none yet");
+    });
+  });
+
+  it("dismisses a pinned popover with Escape and outside pointerdown", async () => {
+    const statuses = [
+      {
+        changedAt: 1000,
+        health: "enabled",
+        platform: "telegram",
+      },
+    ] satisfies MessagingPlatformStatus[];
+    const desktopApi: DesktopApi = {
+      getMessagingPlatformStatuses: vi.fn(async () => statuses),
+      onMessagingPlatformStatusEvent: vi.fn(() => () => {}),
+    };
+
+    render(<MessagingStatusBar desktopApi={desktopApi} />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /Telegram/ }));
+    expect(
+      await screen.findByRole("dialog", { name: "Messaging platforms" }),
+    ).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Messaging platforms" }),
+      ).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Telegram/ }));
+    expect(
+      await screen.findByRole("dialog", { name: "Messaging platforms" }),
+    ).toBeInTheDocument();
+
+    fireEvent.pointerDown(document.body);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Messaging platforms" }),
+      ).not.toBeInTheDocument();
+    });
   });
 });
+
+function messagingSettingsSnapshot(enabled: {
+  telegram?: boolean;
+  discord?: boolean;
+  mattermost?: boolean;
+  slack?: boolean;
+  feishu?: boolean;
+  line?: boolean;
+}, options: {
+  configured?: {
+    telegram?: boolean;
+    discord?: boolean;
+    mattermost?: boolean;
+    slack?: boolean;
+    feishu?: boolean;
+    line?: boolean;
+  };
+  runtimeMessagingDisabled?: boolean;
+} = {}): DesktopSettingsSnapshot {
+  const setting = (value: boolean) => ({ value, source: "config" });
+  const secret = (configured: boolean | undefined) => ({
+    configured: configured ?? false,
+    source: "keychain",
+    writable: true,
+  });
+  return {
+    runtime: {
+      messaging: {
+        disabled: options.runtimeMessagingDisabled ?? false,
+      },
+    },
+    messaging: {
+      telegram: { enabled: setting(enabled.telegram ?? true) },
+      discord: { enabled: setting(enabled.discord ?? true) },
+      mattermost: { enabled: setting(enabled.mattermost ?? true) },
+      slack: { enabled: setting(enabled.slack ?? true) },
+      feishu: { enabled: setting(enabled.feishu ?? true) },
+      line: {
+        enabled: setting(enabled.line ?? true),
+        channelAccessToken: secret(options.configured?.line),
+      },
+    },
+  } as unknown as DesktopSettingsSnapshot;
+}

--- a/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.tsx
+++ b/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.tsx
@@ -1,7 +1,10 @@
-import { useId } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
 import type {
+  DesktopSettingsConfigPatch,
+  DesktopSettingsSnapshot,
   MessagingChannelKind,
   MessagingDegradationReason,
+  MessagingPlatformActivitySummary,
   MessagingPlatformHealth,
   MessagingPlatformStatus,
 } from "@pwragent/shared";
@@ -18,6 +21,25 @@ const HEALTH_LABEL: Record<MessagingPlatformHealth, string> = {
   suspended: "Suspended",
   errored: "Errored",
   unknown: "Loading",
+};
+
+type ConfigurableMessagingPlatform = Extract<
+  MessagingChannelKind,
+  "discord" | "feishu" | "line" | "mattermost" | "slack" | "telegram"
+>;
+
+const CONFIGURABLE_MESSAGING_PLATFORMS = [
+  "telegram",
+  "discord",
+  "mattermost",
+  "slack",
+  "feishu",
+  "line",
+] as const satisfies readonly ConfigurableMessagingPlatform[];
+
+type PlatformActivitySummary = {
+  lastRequestAt?: number;
+  lastResponseAt?: number;
 };
 
 /**
@@ -38,60 +60,366 @@ export function MessagingStatusBar(props: {
    * that platform. Receives the chosen platform so the parent could
    * scope the screen to it in the future.
    */
-  onOpenActivity?: (platform: MessagingChannelKind) => void;
+  onOpenActivity?: (platform?: MessagingChannelKind) => void;
 }) {
   const { statuses, activeAtByPlatform } = useMessagingPlatformStatuses(
     props.desktopApi,
   );
+  const [open, setOpen] = useState(false);
+  const [pinned, setPinned] = useState(false);
+  const [now, setNow] = useState(() => Date.now());
+  const [togglePending, setTogglePending] = useState(false);
+  const [toggleError, setToggleError] = useState<string | null>(null);
+  const [platformTogglePending, setPlatformTogglePending] = useState<
+    Partial<Record<ConfigurableMessagingPlatform, boolean>>
+  >({});
+  const [platformToggleError, setPlatformToggleError] = useState<string | null>(
+    null,
+  );
+  const [sessionOverride, setSessionOverride] = useState<boolean | null>(null);
+  const [settingsSnapshot, setSettingsSnapshot] =
+    useState<DesktopSettingsSnapshot | null>(null);
+  const [activityByPlatform, setActivityByPlatform] = useState<
+    Partial<Record<MessagingChannelKind, PlatformActivitySummary>>
+  >({});
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const popoverId = useId();
 
-  if (statuses.length === 0) {
+  const runtimeMessagingEnabled =
+    settingsSnapshot?.runtime?.messaging?.disabled !== undefined
+      ? !settingsSnapshot.runtime.messaging.disabled
+      : null;
+  const displayStatuses = useMemo(
+    () => withConfiguredSettingsStatuses(statuses, settingsSnapshot),
+    [settingsSnapshot, statuses],
+  );
+  const messagingOn = sessionOverride
+    ?? runtimeMessagingEnabled
+    ?? inferMessagingEnabled(displayStatuses);
+  const activePlatforms = displayStatuses.filter((status) =>
+    hasRecentActivity(status, activeAtByPlatform[status.platform])
+  );
+  const hasDegradation = displayStatuses.some(
+    (status) => (status.degradationReasons ?? []).length > 0,
+  );
+  const summary = buildStatusSummary(
+    displayStatuses,
+    messagingOn,
+    activePlatforms.length,
+  );
+  const controllerLabel = displayStatuses
+    .map(
+      (status) =>
+        `${formatMessagingPlatformName(status.platform)}: ${HEALTH_LABEL[status.health]}`,
+    )
+    .join("; ");
+
+  useEffect(() => {
+    if (!open) return;
+    const intervalId = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(intervalId);
+  }, [open]);
+
+  useEffect(() => {
+    if (
+      !props.desktopApi?.getMessagingPlatformStatuses
+      || !props.desktopApi?.readSettings
+    ) {
+      return;
+    }
+    let cancelled = false;
+    void props.desktopApi.readSettings({}).then((response) => {
+      if (!cancelled) setSettingsSnapshot(response.snapshot);
+    }).catch(() => {
+      // Settings screen owns user-facing errors; keep this controller quiet.
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [props.desktopApi, statuses.length]);
+
+  useEffect(() => {
+    if (
+      !open
+      || !props.desktopApi?.getMessagingPlatformStatuses
+      || !props.desktopApi?.readSettings
+    ) {
+      return;
+    }
+    let cancelled = false;
+    void props.desktopApi.readSettings({}).then((response) => {
+      if (!cancelled) setSettingsSnapshot(response.snapshot);
+    }).catch(() => {
+      // Settings screen owns user-facing errors; keep this controller quiet.
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, props.desktopApi]);
+
+  useEffect(() => {
+    if (!open || !props.desktopApi?.getMessagingActivitySummary) return;
+    let cancelled = false;
+    const refresh = async (): Promise<void> => {
+      try {
+        const response = await props.desktopApi!.getMessagingActivitySummary!();
+        if (!cancelled) {
+          setActivityByPlatform(summarizeActivityByPlatform(response.summaries));
+        }
+      } catch {
+        // Activity is best-effort; the full Activity window surfaces errors.
+      }
+    };
+    void refresh();
+    const intervalId = window.setInterval(() => {
+      void refresh();
+    }, 5_000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+    };
+  }, [open, props.desktopApi]);
+
+  useEffect(() => {
+    const observed =
+      runtimeMessagingEnabled ?? inferMessagingEnabled(displayStatuses);
+    setSessionOverride((current) => (current === observed ? null : current));
+  }, [displayStatuses, runtimeMessagingEnabled]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (event: PointerEvent) => {
+      if (rootRef.current?.contains(event.target as Node)) return;
+      setOpen(false);
+      setPinned(false);
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      setOpen(false);
+      setPinned(false);
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open]);
+
+  const handleToggleMessaging = async (): Promise<void> => {
+    if (!props.desktopApi?.setMessagingEnabled) {
+      setToggleError("Messaging can only be toggled from the desktop app.");
+      return;
+    }
+    const nextEnabled = !messagingOn;
+    setTogglePending(true);
+    setToggleError(null);
+    setSessionOverride(nextEnabled);
+    try {
+      const result = await props.desktopApi.setMessagingEnabled({
+        enabled: nextEnabled,
+      });
+      setSessionOverride(result.enabled);
+      if (nextEnabled && !result.enabled) {
+        setToggleError(
+          result.disabledReason
+            ?? result.overrideReason
+            ?? "Messaging could not be started.",
+        );
+      }
+    } catch (error) {
+      setSessionOverride(null);
+      setToggleError(
+        error instanceof Error ? error.message : "Messaging toggle failed.",
+      );
+    } finally {
+      setTogglePending(false);
+    }
+  };
+
+  const handleTogglePlatform = async (
+    platform: ConfigurableMessagingPlatform,
+    enabled: boolean,
+  ): Promise<void> => {
+    if (!messagingOn) {
+      setPlatformToggleError("Turn messaging on before changing a platform.");
+      return;
+    }
+    if (!props.desktopApi?.writeSettingsConfig) {
+      setPlatformToggleError("Settings are unavailable.");
+      return;
+    }
+    setPlatformToggleError(null);
+    setPlatformTogglePending((current) => ({
+      ...current,
+      [platform]: true,
+    }));
+    try {
+      const response = await props.desktopApi.writeSettingsConfig({
+        patch: platformEnabledPatch(platform, enabled),
+      });
+      setSettingsSnapshot(response.snapshot);
+    } catch (error) {
+      setPlatformToggleError(
+        error instanceof Error
+          ? error.message
+          : `Could not update ${formatMessagingPlatformName(platform)}.`,
+      );
+    } finally {
+      setPlatformTogglePending((current) => {
+        const next = { ...current };
+        delete next[platform];
+        return next;
+      });
+    }
+  };
+
+  if (displayStatuses.length === 0) {
     return null;
   }
 
   return (
-    <div className="messaging-status-bar" role="group" aria-label="Messaging platform status">
-      {statuses.map((status) => (
-        <PlatformChip
-          key={status.platform}
-          status={status}
-          active={hasRecentActivity(status, activeAtByPlatform[status.platform])}
-          onClick={
-            props.onOpenActivity
-              ? () => props.onOpenActivity!(status.platform)
-              : undefined
+    <div
+      ref={rootRef}
+      className="messaging-status-bar"
+      role="group"
+      aria-label="Messaging platform status"
+      onPointerEnter={() => setOpen(true)}
+      onPointerLeave={() => {
+        if (!pinned) setOpen(false);
+      }}
+    >
+      <button
+        type="button"
+        className={`messaging-status-controller${
+          messagingOn ? "" : " is-off"
+        }${hasDegradation ? " has-warning" : ""}`}
+        aria-controls={open ? popoverId : undefined}
+        aria-expanded={open}
+        aria-label={`${controllerLabel}. ${summary}. Click to ${
+          pinned ? "close" : "pin"
+        } messaging status.`}
+        onClick={() => {
+          if (pinned) {
+            setOpen(false);
+            setPinned(false);
+            return;
           }
-        />
-      ))}
+          setOpen(true);
+          setPinned(true);
+        }}
+      >
+        <span className="messaging-status-controller__label">
+          {messagingOn ? "Msg" : "Off"}
+        </span>
+        <span className="messaging-status-controller__platforms">
+          {displayStatuses.map((status) => (
+            <PlatformGlyph
+              key={status.platform}
+              status={status}
+              active={hasRecentActivity(status, activeAtByPlatform[status.platform])}
+              forcedOff={!messagingOn}
+            />
+          ))}
+        </span>
+      </button>
+      {open ? (
+        <div
+          id={popoverId}
+          className="messaging-status-popover"
+          role="dialog"
+          aria-label="Messaging platforms"
+        >
+          <div className="messaging-status-popover__head">
+            <div>
+              <div className="messaging-status-popover__title">
+                Messaging platforms
+              </div>
+              <div className="messaging-status-popover__summary">
+                {summary}
+              </div>
+            </div>
+            <button
+              type="button"
+              className={`settings-switch messaging-status-popover__switch${
+                messagingOn ? " is-on" : ""
+              }`}
+              aria-pressed={messagingOn}
+              disabled={togglePending}
+              onClick={() => {
+                void handleToggleMessaging();
+              }}
+            >
+              <span aria-hidden="true" className="settings-switch__track">
+                <span className="settings-switch__thumb" />
+              </span>
+              <span>{togglePending ? "..." : messagingOn ? "On" : "Off"}</span>
+            </button>
+          </div>
+          <div className="messaging-status-popover__rows">
+            {displayStatuses.map((status) => (
+              <PlatformStatusRow
+                key={status.platform}
+                status={status}
+                active={hasRecentActivity(status, activeAtByPlatform[status.platform])}
+                activity={activityByPlatform[status.platform]}
+                forcedOff={!messagingOn}
+                platformEnabled={platformEnabledFromSnapshot(
+                  settingsSnapshot,
+                  status.platform,
+                )}
+                platformTogglePending={
+                  configurablePlatform(status.platform)
+                    ? platformTogglePending[status.platform] === true
+                    : false
+                }
+                platformToggleDisabled={!messagingOn}
+                now={now}
+                onTogglePlatform={handleTogglePlatform}
+              />
+            ))}
+          </div>
+          {toggleError || platformToggleError ? (
+            <p className="messaging-status-popover__error" role="alert">
+              {toggleError ?? platformToggleError}
+            </p>
+          ) : null}
+          {props.onOpenActivity ? (
+            <button
+              type="button"
+              className="messaging-status-popover__activity"
+              onClick={() => {
+                setOpen(false);
+                setPinned(false);
+                props.onOpenActivity?.();
+              }}
+            >
+              Open Messaging Activity
+            </button>
+          ) : null}
+        </div>
+      ) : null}
     </div>
   );
 }
 
-function PlatformChip(props: {
+function PlatformGlyph(props: {
   status: MessagingPlatformStatus;
   active: boolean;
-  onClick?: () => void;
+  forcedOff?: boolean;
 }) {
-  const { status, active, onClick } = props;
-  const tooltipId = useId();
+  const { status, active, forcedOff = false } = props;
   const Icon = MESSAGING_PLATFORM_ICONS[status.platform];
-  const labelLines = [
-    `${formatMessagingPlatformName(status.platform)}: ${HEALTH_LABEL[status.health]}`,
-    status.account ? `Bot: ${status.account}` : undefined,
-    status.detail ? `Account detail: ${status.detail}` : undefined,
-    status.reason,
-    ...formatDegradationReasons(status.degradationReasons ?? []),
-  ]
-    .filter((line): line is string => Boolean(line));
-  const baseLabel = labelLines.join("\n");
-  const label = onClick
-    ? `${baseLabel} — click to view messaging activity`
-    : baseLabel;
-  const className = `messaging-status-chip messaging-status-chip--${status.health}${
-    active ? " is-active" : ""
-  }`;
-  const blink = active || status.health === "unknown";
-  const content = (
-    <>
+  const effectiveHealth = forcedOff ? "suspended" : status.health;
+  const blink = !forcedOff && (active || status.health === "unknown");
+  return (
+    <span
+      className={`messaging-status-chip messaging-status-chip--${effectiveHealth}${
+        active && !forcedOff ? " is-active" : ""
+      }`}
+      title={formatMessagingPlatformName(status.platform)}
+      aria-hidden="true"
+    >
       {Icon ? (
         <Icon size={14} />
       ) : (
@@ -100,36 +428,218 @@ function PlatformChip(props: {
         </span>
       )}
       <span
-        className={`status-dot status-dot--${dotTone(status.health)}${
+        className={`status-dot status-dot--${dotTone(effectiveHealth)}${
           blink ? " status-dot--blink" : ""
         }`}
         aria-hidden="true"
       />
-      <span className="messaging-status-chip__tooltip" id={tooltipId} role="tooltip">
-        {labelLines.map((line) => (
-          <span key={line}>{line}</span>
-        ))}
-      </span>
-    </>
+    </span>
   );
-  if (!onClick) {
-    return (
-      <span className={className} aria-describedby={tooltipId} aria-label={label}>
-        {content}
-      </span>
-    );
-  }
+}
+
+function PlatformStatusRow(props: {
+  status: MessagingPlatformStatus;
+  active: boolean;
+  activity?: PlatformActivitySummary;
+  forcedOff: boolean;
+  platformEnabled?: boolean;
+  platformToggleDisabled: boolean;
+  platformTogglePending: boolean;
+  now: number;
+  onTogglePlatform: (
+    platform: ConfigurableMessagingPlatform,
+    enabled: boolean,
+  ) => void | Promise<void>;
+}) {
+  const { status, active, forcedOff, now } = props;
+  const configurable = configurablePlatform(status.platform)
+    ? status.platform
+    : undefined;
+  const platformEnabled = props.platformEnabled ?? status.health !== "suspended";
+  const statusLabel = forcedOff || platformEnabled === false
+    ? "Off"
+    : HEALTH_LABEL[status.health];
+  const stateHealth = forcedOff || platformEnabled === false
+    ? "suspended"
+    : status.health;
+  const subline = forcedOff
+    ? "Globally disabled"
+    : formatPlatformSubline(status, now);
+  const labelLines = [
+    `${formatMessagingPlatformName(status.platform)}: ${HEALTH_LABEL[status.health]}`,
+    status.account && status.account !== subline
+      ? `Bot: ${status.account}`
+      : undefined,
+    status.detail && status.detail !== subline
+      ? `Account detail: ${status.detail}`
+      : undefined,
+    ...formatPlatformActivity(props.activity, now),
+    status.reason,
+    ...formatDegradationReasons(status.degradationReasons ?? [], now),
+  ]
+    .filter((line): line is string => Boolean(line));
+
   return (
-    <button
-      type="button"
-      className={`${className} messaging-status-chip--clickable`}
-      aria-describedby={tooltipId}
-      aria-label={label}
-      onClick={onClick}
-    >
-      {content}
-    </button>
+    <div className="messaging-status-popover__row">
+      <PlatformGlyph status={status} active={active} forcedOff={forcedOff} />
+      <div className="messaging-status-popover__row-main">
+        <div className="messaging-status-popover__row-title">
+          {formatMessagingPlatformName(status.platform)}
+        </div>
+        <div className="messaging-status-popover__row-sub">{subline}</div>
+        {labelLines.length > 1 ? (
+          <div className="messaging-status-popover__details">
+            {labelLines.slice(1).map((line) => (
+              <span key={line}>{line}</span>
+            ))}
+          </div>
+        ) : null}
+      </div>
+      <div className="messaging-status-popover__row-actions">
+        <span
+          className={`messaging-status-popover__state messaging-status-popover__state--${stateHealth}`}
+        >
+          {statusLabel}
+        </span>
+        {configurable ? (
+          <button
+            type="button"
+            className={`settings-switch messaging-status-popover__platform-switch${
+              platformEnabled ? " is-on" : ""
+            }`}
+            aria-label={`${platformEnabled ? "Disable" : "Enable"} ${formatMessagingPlatformName(status.platform)}`}
+            aria-pressed={platformEnabled}
+            disabled={props.platformTogglePending || props.platformToggleDisabled}
+            onClick={() => {
+              void props.onTogglePlatform(configurable, !platformEnabled);
+            }}
+          >
+            <span aria-hidden="true" className="settings-switch__track">
+              <span className="settings-switch__thumb" />
+            </span>
+            <span>
+              {props.platformTogglePending
+                ? "..."
+                : platformEnabled
+                  ? "On"
+                  : "Off"}
+            </span>
+          </button>
+        ) : null}
+      </div>
+    </div>
   );
+}
+
+function withConfiguredSettingsStatuses(
+  runtimeStatuses: readonly MessagingPlatformStatus[],
+  snapshot: DesktopSettingsSnapshot | null,
+): MessagingPlatformStatus[] {
+  if (!snapshot) return [...runtimeStatuses];
+  const seen = new Set(runtimeStatuses.map((status) => status.platform));
+  const configuredFromSettings = CONFIGURABLE_MESSAGING_PLATFORMS
+    .filter((platform) => !seen.has(platform))
+    .filter((platform) => platformConfiguredFromSnapshot(snapshot, platform))
+    .map((platform): MessagingPlatformStatus => ({
+      platform,
+      health: platformEnabledFromSnapshot(snapshot, platform)
+        ? "unknown"
+        : "suspended",
+      changedAt: snapshot.fetchedAt ?? Date.now(),
+      ...platformIdentityFromSnapshot(snapshot, platform),
+    }));
+  return [...runtimeStatuses, ...configuredFromSettings];
+}
+
+function platformConfiguredFromSnapshot(
+  snapshot: DesktopSettingsSnapshot,
+  platform: ConfigurableMessagingPlatform,
+): boolean {
+  switch (platform) {
+    case "telegram":
+      return snapshot.messaging?.telegram?.botToken?.configured === true;
+    case "discord":
+      return snapshot.messaging?.discord?.botToken?.configured === true;
+    case "mattermost":
+      return snapshot.messaging?.mattermost?.botToken?.configured === true;
+    case "slack":
+      return snapshot.messaging?.slack?.botToken?.configured === true;
+    case "feishu":
+      return snapshot.messaging?.feishu?.appSecret?.configured === true;
+    case "line":
+      return snapshot.messaging?.line?.channelAccessToken?.configured === true;
+  }
+}
+
+function platformIdentityFromSnapshot(
+  snapshot: DesktopSettingsSnapshot,
+  platform: ConfigurableMessagingPlatform,
+): Pick<MessagingPlatformStatus, "account" | "detail"> {
+  switch (platform) {
+    case "line":
+      return snapshot.messaging?.line?.botUserId?.value
+        ? { account: snapshot.messaging.line.botUserId.value }
+        : {};
+    case "feishu":
+      return snapshot.messaging?.feishu?.tenantUrl?.value
+        ? { detail: snapshot.messaging.feishu.tenantUrl.value }
+        : {};
+    default:
+      return {};
+  }
+}
+
+function configurablePlatform(
+  platform: MessagingChannelKind,
+): platform is ConfigurableMessagingPlatform {
+  return CONFIGURABLE_MESSAGING_PLATFORMS.some((entry) => entry === platform);
+}
+
+function platformEnabledFromSnapshot(
+  snapshot: DesktopSettingsSnapshot | null,
+  platform: MessagingChannelKind,
+): boolean | undefined {
+  if (!snapshot || !configurablePlatform(platform)) return undefined;
+  return snapshot.messaging?.[platform]?.enabled?.value;
+}
+
+function platformEnabledPatch(
+  platform: ConfigurableMessagingPlatform,
+  enabled: boolean,
+): DesktopSettingsConfigPatch {
+  return { messaging: { [platform]: { enabled } } };
+}
+
+function summarizeActivityByPlatform(
+  summaries: readonly MessagingPlatformActivitySummary[],
+): Partial<Record<MessagingChannelKind, PlatformActivitySummary>> {
+  const next: Partial<Record<MessagingChannelKind, PlatformActivitySummary>> = {};
+  for (const summary of summaries) {
+    next[summary.platform] = {
+      lastRequestAt: summary.lastRequestAt,
+      lastResponseAt: summary.lastResponseAt,
+    };
+  }
+  return next;
+}
+
+function formatPlatformActivity(
+  activity: PlatformActivitySummary | undefined,
+  now: number,
+): string[] {
+  if (!activity) return [];
+  return [
+    `Last request: ${
+      activity.lastRequestAt !== undefined
+        ? formatRelativeTime(activity.lastRequestAt, now)
+        : "none yet"
+    }`,
+    `Last response: ${
+      activity.lastResponseAt !== undefined
+        ? formatRelativeTime(activity.lastResponseAt, now)
+        : "none yet"
+    }`,
+  ];
 }
 
 function hasRecentActivity(
@@ -159,22 +669,87 @@ function dotTone(
   }
 }
 
+function inferMessagingEnabled(
+  statuses: readonly MessagingPlatformStatus[],
+): boolean {
+  return statuses.some((status) => status.health !== "suspended");
+}
+
+function buildStatusSummary(
+  statuses: readonly MessagingPlatformStatus[],
+  messagingOn: boolean,
+  activeCount: number,
+): string {
+  const counts = statuses.reduce<Record<MessagingPlatformHealth, number>>(
+    (acc, status) => {
+      acc[status.health] += 1;
+      return acc;
+    },
+    { degraded: 0, enabled: 0, errored: 0, suspended: 0, unknown: 0 },
+  );
+  if (!messagingOn) {
+    return `${statuses.length} configured platform${statuses.length === 1 ? "" : "s"} off`;
+  }
+  const parts = [
+    counts.enabled > 0 ? `${counts.enabled} online` : undefined,
+    counts.degraded > 0 ? `${counts.degraded} degraded` : undefined,
+    counts.errored > 0 ? `${counts.errored} errored` : undefined,
+    counts.suspended > 0 ? `${counts.suspended} suspended` : undefined,
+    activeCount > 0 ? `${activeCount} active` : undefined,
+  ].filter((part): part is string => Boolean(part));
+  return parts.length > 0 ? parts.join(", ") : "Messaging starting";
+}
+
+function formatPlatformSubline(
+  status: MessagingPlatformStatus,
+  now: number,
+): string {
+  if (status.health === "enabled") {
+    return status.lastActivityAt
+      ? `Last activity ${formatRelativeTime(status.lastActivityAt, now)}`
+      : status.detail ?? status.account ?? "Listening";
+  }
+  if (status.health === "degraded") {
+    const firstReason = status.degradationReasons?.[0];
+    return firstReason
+      ? formatDegradationReason(firstReason, now)
+      : status.reason ?? "Temporarily constrained";
+  }
+  if (status.health === "errored") {
+    return status.reason ?? "Connection error";
+  }
+  if (status.health === "suspended") {
+    return "Configured, currently suspended";
+  }
+  return "Starting";
+}
+
 function formatDegradationReasons(
   reasons: readonly MessagingDegradationReason[],
+  now = Date.now(),
 ): string[] {
-  return reasons.map((reason) => {
-    const scopeLabel = reason.scope?.label ? ` (${reason.scope.label})` : "";
-    switch (reason.kind) {
-      case "rate-limited":
-        return `Rate limited${scopeLabel}${formatRetry(reason.retryAfterMs)}`;
-      case "reconnecting":
-        return `Reconnecting${formatAttempt(reason.attemptCount)}${reason.lastFailureReason ? `: ${reason.lastFailureReason}` : ""}`;
-      case "missing-permission":
-        return `Missing permission${reason.permission ? `: ${reason.permission}` : ""}`;
-      case "warning":
-        return reason.message ?? `Warning${scopeLabel}`;
-    }
-  });
+  return reasons.map((reason) => formatDegradationReason(reason, now));
+}
+
+function formatDegradationReason(
+  reason: MessagingDegradationReason,
+  now: number,
+): string {
+  const scopeLabel = reason.scope?.label ? ` (${reason.scope.label})` : "";
+  const started = `since ${formatClockTime(reason.startedAt)}`;
+  const remaining = "expiresAt" in reason && reason.expiresAt
+    ? `, ${formatRemaining(reason.expiresAt, now)} remaining`
+    : "";
+  switch (reason.kind) {
+    case "rate-limited":
+      return `Rate limited${scopeLabel}; ${started}${remaining}${formatRetry(reason.retryAfterMs)}`;
+    case "reconnecting":
+      return `Reconnecting${formatAttempt(reason.attemptCount)}; ${started}${reason.lastFailureReason ? `: ${reason.lastFailureReason}` : ""}`;
+    case "missing-permission":
+      return `Missing permission${reason.permission ? `: ${reason.permission}` : ""}; ${started}`;
+    case "warning":
+      return `${reason.message ?? `Warning${scopeLabel}`}; ${started}${remaining}`;
+  }
 }
 
 function formatRetry(retryAfterMs: number | undefined): string {
@@ -185,4 +760,27 @@ function formatRetry(retryAfterMs: number | undefined): string {
 
 function formatAttempt(attemptCount: number | undefined): string {
   return attemptCount === undefined ? "" : ` (attempt ${attemptCount})`;
+}
+
+function formatClockTime(at: number): string {
+  return new Intl.DateTimeFormat(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(at));
+}
+
+function formatRelativeTime(at: number, now: number): string {
+  const seconds = Math.max(1, Math.round((now - at) / 1000));
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  return `${hours}h ago`;
+}
+
+function formatRemaining(expiresAt: number, now: number): string {
+  const seconds = Math.max(0, Math.ceil((expiresAt - now) / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.ceil(seconds / 60);
+  return `${minutes}m`;
 }

--- a/apps/desktop/src/renderer/src/features/messaging-status/useMessagingPlatformStatuses.ts
+++ b/apps/desktop/src/renderer/src/features/messaging-status/useMessagingPlatformStatuses.ts
@@ -96,13 +96,14 @@ function upsertHealth(
 ): MessagingPlatformStatus[] {
   const platform: MessagingChannelKind = event.platform;
   const existing = current.find((entry) => entry.platform === platform);
+  const preserveCredentialMetadata = event.health === "suspended";
   const {
     account: _existingAccount,
     detail: _existingDetail,
     ...existingWithoutCredentialMetadata
   } = existing ?? {};
   const next: MessagingPlatformStatus = {
-    ...existingWithoutCredentialMetadata,
+    ...(preserveCredentialMetadata ? existing : existingWithoutCredentialMetadata),
     platform,
     health: event.health,
     ...(event.account !== undefined ? { account: event.account } : {}),

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -95,10 +95,10 @@ export function SettingsScreen(props: {
   /** Initial section to render. Defaults to Applications. */
   initialSection?: SettingsSection;
   onClose?: () => void;
-  /** Fired when a platform chip in the title-bar strip is clicked.
+  /** Fired from the title-bar messaging controller.
    *  The App-level handler closes the Settings overlay and opens the
    *  Messaging Activity overlay (its own top-level mainView). */
-  onOpenMessagingActivity?: () => void;
+  onOpenMessagingActivity?: (platform?: MessagingChannelKind) => void;
 }) {
   const [section, setSection] = useState<SettingsSection>(
     props.initialSection ?? "general",
@@ -116,8 +116,8 @@ export function SettingsScreen(props: {
   // handler swaps mainView for us; no internal state change here.
   const onOpenMessagingActivity = props.onOpenMessagingActivity;
   const onOpenActivity = useCallback(
-    (_platform?: MessagingChannelKind) => {
-      onOpenMessagingActivity?.();
+    (platform?: MessagingChannelKind) => {
+      onOpenMessagingActivity?.(platform);
     },
     [onOpenMessagingActivity],
   );

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -2465,7 +2465,7 @@ describe("SettingsScreen", () => {
     expect(current?.textContent).toBe("Messaging");
   });
 
-  it("fires onOpenMessagingActivity when a title-bar platform chip is clicked", async () => {
+  it("fires onOpenMessagingActivity from the title-bar messaging popover", async () => {
     // Activity is its own top-level mainView, NOT a settings section,
     // so a chip click in the Settings title-bar strip delegates to
     // App.tsx via this callback. The App-level handler closes the
@@ -2492,9 +2492,12 @@ describe("SettingsScreen", () => {
 
     const chip = await screen.findByRole("button", { name: /Telegram/i });
     fireEvent.click(chip);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Open Messaging Activity" }),
+    );
 
     await waitFor(() => {
-      expect(onOpenMessagingActivity).toHaveBeenCalled();
+      expect(onOpenMessagingActivity).toHaveBeenCalledWith(undefined);
     });
     // The breadcrumb stays on whatever section was active — chip
     // clicks no longer mutate the section selection.

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
@@ -15,8 +15,8 @@ type ThreadHeaderProps = {
   projectLabel?: string;
   thread: NavigationThreadSummary;
   backends?: BackendSummary[];
-  /** Forwarded to MessagingStatusBar — fires when a platform chip is clicked. */
-  onOpenMessagingActivity?: (platform: MessagingChannelKind) => void;
+  /** Forwarded to MessagingStatusBar - opens Messaging Activity. */
+  onOpenMessagingActivity?: (platform?: MessagingChannelKind) => void;
   onRevealSelectedThreadInList?: () => void;
 };
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadPlaceholderHeader.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadPlaceholderHeader.tsx
@@ -5,7 +5,7 @@ import { MessagingStatusBar } from "../messaging-status/MessagingStatusBar";
 type ThreadPlaceholderHeaderProps = {
   desktopApi?: DesktopApi;
   title: string;
-  onOpenMessagingActivity?: (platform: MessagingChannelKind) => void;
+  onOpenMessagingActivity?: (platform?: MessagingChannelKind) => void;
 };
 
 export function ThreadPlaceholderHeader(props: ThreadPlaceholderHeaderProps) {

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -816,8 +816,8 @@ export type ThreadViewProps = {
   onActiveTurnIdChange?: (turnId?: string) => void;
   onEnsureSkillsLoaded?: () => void | Promise<void>;
   onDismissFullAccessRiskWarning?: () => Promise<void>;
-  /** Forwarded to ThreadHeader → MessagingStatusBar — opens the Activity screen. */
-  onOpenMessagingActivity?: (platform: MessagingChannelKind) => void;
+  /** Forwarded to ThreadHeader -> MessagingStatusBar - opens Messaging Activity. */
+  onOpenMessagingActivity?: (platform?: MessagingChannelKind) => void;
   onRevealSelectedThreadInList?: () => void;
   onLoadOlder: () => Promise<void>;
   onArchiveThread?: (thread: NavigationThreadSummary) => Promise<void>;

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -65,6 +65,7 @@ import type {
   ApproveMessagingPairingResponse,
   GenerateMessagingPairingTokenRequest,
   GenerateMessagingPairingTokenResponse,
+  GetMessagingActivitySummaryResponse,
   ListMessagingActivityRequest,
   ListMessagingActivityResponse,
   ListMessagingPairingRequestsRequest,
@@ -553,6 +554,8 @@ export type DesktopApi = {
   listMessagingActivity?: (
     request?: ListMessagingActivityRequest,
   ) => Promise<ListMessagingActivityResponse>;
+  getMessagingActivitySummary?: () =>
+    Promise<GetMessagingActivitySummaryResponse>;
   generateMessagingPairingToken?: (
     request: GenerateMessagingPairingTokenRequest,
   ) => Promise<GenerateMessagingPairingTokenResponse>;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -583,7 +583,7 @@ textarea,
 .messaging-status-bar {
   display: flex;
   align-items: center;
-  gap: 6px;
+  position: relative;
   flex: 0 0 auto;
   min-width: max-content;
   padding: 4px 8px;
@@ -599,8 +599,8 @@ textarea,
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 24px;
-  height: 24px;
+  width: 22px;
+  height: 22px;
   border-radius: 6px;
   background: var(--bg-panel-elevated);
   color: var(--text-muted);
@@ -627,36 +627,182 @@ textarea,
   border: 1.5px solid var(--bg-panel);
 }
 
-.messaging-status-chip__tooltip {
+.messaging-status-controller {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 30px;
+  padding: 3px 8px 3px 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-panel);
+  color: var(--text-primary);
+  cursor: pointer;
+  transition:
+    border-color 120ms ease,
+    background 120ms ease,
+    color 120ms ease;
+}
+
+.messaging-status-controller:hover,
+.messaging-status-controller:focus-visible,
+.messaging-status-controller[aria-expanded="true"] {
+  border-color: var(--accent-border);
+  background: var(--bg-panel-elevated);
+  outline: none;
+}
+
+.messaging-status-controller.is-off {
+  color: var(--text-muted);
+}
+
+.messaging-status-controller.has-warning {
+  border-color: var(--status-warning);
+}
+
+.messaging-status-controller__label {
+  font: 700 10px/1 var(--font-sans, sans-serif);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.messaging-status-controller__platforms {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+}
+
+.messaging-status-popover {
   position: absolute;
   top: calc(100% + 8px);
   right: 0;
-  z-index: 50;
-  display: none;
-  width: max-content;
-  max-width: min(280px, calc(100vw - 32px));
-  padding: 8px 10px;
+  z-index: 60;
+  width: min(420px, calc(100vw - 32px));
+  padding: 10px;
   border: 1px solid var(--border-strong);
   border-radius: 8px;
   background: var(--bg-panel-elevated);
-  box-shadow: 0 8px 24px var(--shadow-tint-soft);
+  box-shadow: var(--shadow-popover);
   color: var(--text-primary);
-  font-size: 11px;
-  font-weight: 500;
-  line-height: 1.35;
-  pointer-events: none;
   text-align: left;
-  white-space: normal;
 }
 
-.messaging-status-chip__tooltip > span {
-  display: block;
+.messaging-status-popover__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 6px 8px 10px;
+  border-bottom: 1px solid var(--border-subtle);
 }
 
-.messaging-status-chip:hover .messaging-status-chip__tooltip,
-.messaging-status-chip:focus-visible .messaging-status-chip__tooltip,
-.messaging-status-chip:focus-within .messaging-status-chip__tooltip {
-  display: block;
+.messaging-status-popover__title {
+  color: var(--text-primary);
+  font: 700 13px/1.2 var(--font-sans, sans-serif);
+}
+
+.messaging-status-popover__summary {
+  margin-top: 4px;
+  color: var(--text-muted);
+  font: 500 11px/1.3 var(--font-sans, sans-serif);
+}
+
+.messaging-status-popover__switch {
+  flex: 0 0 auto;
+}
+
+.messaging-status-popover__rows {
+  display: flex;
+  flex-direction: column;
+}
+
+.messaging-status-popover__row {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 10px 8px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.messaging-status-popover__row-main {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.messaging-status-popover__row-title {
+  color: var(--text-primary);
+  font: 650 12px/1.25 var(--font-sans, sans-serif);
+}
+
+.messaging-status-popover__row-sub {
+  margin-top: 2px;
+  color: var(--text-muted);
+  font: 500 11px/1.35 var(--font-sans, sans-serif);
+}
+
+.messaging-status-popover__details {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-top: 6px;
+  color: var(--text-secondary);
+  font: 500 11px/1.35 var(--font-sans, sans-serif);
+  overflow-wrap: anywhere;
+}
+
+.messaging-status-popover__row-actions {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: flex-end;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.messaging-status-popover__state {
+  color: var(--text-muted);
+  font: 700 10px/1 var(--font-sans, sans-serif);
+  text-transform: uppercase;
+}
+
+.messaging-status-popover__state--enabled {
+  color: var(--status-ok);
+}
+
+.messaging-status-popover__state--degraded {
+  color: var(--status-warning);
+}
+
+.messaging-status-popover__state--errored {
+  color: var(--status-error);
+}
+
+.messaging-status-popover__platform-switch {
+  height: 24px;
+  padding-right: 8px;
+  font-size: 10px;
+}
+
+.messaging-status-popover__activity {
+  width: 100%;
+  padding: 10px 12px 4px;
+  border: none;
+  background: transparent;
+  color: var(--accent);
+  cursor: pointer;
+  font: 700 12px/1.2 var(--font-sans, sans-serif);
+  text-align: center;
+}
+
+.messaging-status-popover__activity:hover,
+.messaging-status-popover__activity:focus-visible {
+  color: var(--accent-bright);
+  outline: none;
+}
+
+.messaging-status-popover__error {
+  margin: 8px 8px 0;
+  color: var(--status-error);
+  font: 600 11px/1.35 var(--font-sans, sans-serif);
 }
 
 /* Binding chip menu — small popover anchored to the chip wrap. The
@@ -707,17 +853,6 @@ textarea,
   color: var(--text-muted);
   font-size: 11px;
   line-height: 1.4;
-}
-
-.messaging-status-chip--clickable {
-  cursor: pointer;
-  border: none;
-  padding: 0;
-  background: transparent;
-}
-
-.messaging-status-chip--clickable:hover {
-  color: var(--text-primary);
 }
 
 /* ============================================================

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -77,6 +77,8 @@ export const MESSAGING_PLATFORM_STATUS_EVENT_CHANNEL =
 export const MESSAGING_UNBIND_THREAD_CHANNEL = "messaging:unbind-thread";
 export const MESSAGING_SET_ENABLED_CHANNEL = "messaging:set-enabled";
 export const MESSAGING_LIST_ACTIVITY_CHANNEL = "messaging:list-activity";
+export const MESSAGING_GET_ACTIVITY_SUMMARY_CHANNEL =
+  "messaging:get-activity-summary";
 export const MESSAGING_GENERATE_PAIRING_TOKEN_CHANNEL =
   "messaging:generate-pairing-token";
 export const MESSAGING_LIST_PAIRING_REQUESTS_CHANNEL =

--- a/packages/shared/src/contracts/messaging.ts
+++ b/packages/shared/src/contracts/messaging.ts
@@ -221,6 +221,18 @@ export type ListMessagingActivityResponse = {
   entries: MessagingActivityEntry[];
 };
 
+export type MessagingPlatformActivitySummary = {
+  platform: MessagingChannelKind;
+  /** Most recent inbound request observed for this provider. */
+  lastRequestAt?: number;
+  /** Most recent outbound response sent through this provider. */
+  lastResponseAt?: number;
+};
+
+export type GetMessagingActivitySummaryResponse = {
+  summaries: MessagingPlatformActivitySummary[];
+};
+
 export type UnbindMessagingThreadRequest = {
   bindingId: string;
 };


### PR DESCRIPTION
## Summary
- Replaces the tooltip-only messaging status strip with a compact controller button and rich popover.
- Adds a master messaging on/off switch from the title bar, per-platform status rows, degradation detail with live remaining time, and activity actions.
- Keeps thread/settings/automation chrome wired to Messaging Activity while preserving existing configured-platform icons.

Closes #296.

## Verification
- `pnpm test apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.test.tsx apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm --filter @pwragent/desktop build`
