### PR TITLE
fix(desktop): account for image token usage

### DIFF
--- a/apps/desktop/e2e/composer-image-normalization.spec.ts
+++ b/apps/desktop/e2e/composer-image-normalization.spec.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { expect, test } from "@playwright/test";
@@ -147,14 +147,19 @@ test("pasted WebP image is uploaded as bounded JPEG or PNG", async () => {
 
     await expect.poll(async () => await app.getLastStartTurn()).not.toBeNull();
     const request = await app.getLastStartTurn();
-    const imageItem = (request as { input: Array<{ type: string; url?: string }> }).input.find(
-      (item) => item.type === "image",
+    const imageItem = (request as { input: Array<{ type: string; path?: string }> }).input.find(
+      (item) => item.type === "localImage",
     );
-    const imageUrl = imageItem?.url;
-    if (!imageUrl) {
-      throw new Error("Expected turn/start payload to include an image data URL");
+    const imagePath = imageItem?.path;
+    if (!imagePath) {
+      throw new Error("Expected turn/start payload to include a local image file");
     }
-    expect(imageUrl).toMatch(/^data:image\/(jpeg|png);base64,/);
+    expect(imagePath).toMatch(/\.(?:jpe?g|png)$/i);
+
+    const extension = path.extname(imagePath).toLowerCase();
+    const mimeType = extension === ".png" ? "image/png" : "image/jpeg";
+    const imageBuffer = await readFile(imagePath);
+    const imageUrl = `data:${mimeType};base64,${imageBuffer.toString("base64")}`;
 
     const dimensions = await app.window.evaluate(async (dataUrl) => {
       const image = new Image();

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -8734,6 +8734,45 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("materializes data URL images before starting Codex turns", async () => {
+    const tempHome = await mkdtemp(path.join(os.tmpdir(), "pwragent-image-turn-"));
+    const previousHome = process.env.PWRAGENT_HOME;
+    process.env.PWRAGENT_HOME = tempHome;
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok unavailable"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    try {
+      await registry.startTurn({
+        backend: "codex",
+        threadId: "thread-image",
+        input: [{ type: "image", url: "data:image/png;base64,AQID" }],
+      });
+
+      const input = codexClient.lastStartTurnParams?.input;
+      expect(input).toHaveLength(1);
+      expect(input?.[0]).toMatchObject({ type: "localImage" });
+      const imagePath = input?.[0]?.type === "localImage" ? input[0].path : "";
+      expect(imagePath).toContain(path.join("state", "image-inputs"));
+      await expect(readFile(imagePath)).resolves.toEqual(Buffer.from([1, 2, 3]));
+    } finally {
+      await registry.close();
+      await rm(tempHome, { recursive: true, force: true });
+      if (previousHome === undefined) {
+        delete process.env.PWRAGENT_HOME;
+      } else {
+        process.env.PWRAGENT_HOME = previousHome;
+      }
+    }
+  });
+
   it("routes review start to the selected backend client", async () => {
     const grokClient = new MockBackendClient({
       initializeResult: { methods: ["review/start"] },

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -2620,6 +2620,356 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("deduplicates Codex raw event user messages when a response item carries the image", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.readThreadResultByThreadId.set("thread-raw-image-events", {
+      events: [
+        {
+          type: "response_item",
+          timestamp: "2026-05-30T23:37:32.719Z",
+          payload: {
+            type: "message",
+            role: "user",
+            content: [
+              {
+                type: "input_text",
+                text: "What's in this image?",
+              },
+              {
+                type: "input_text",
+                text: "<image name=[Image #1]>",
+              },
+              {
+                type: "input_image",
+                image_url: "data:image/png;base64,AQID",
+              },
+              {
+                type: "input_text",
+                text: "</image>",
+              },
+            ],
+          },
+        },
+        {
+          type: "event_msg",
+          timestamp: "2026-05-30T23:37:32.720Z",
+          payload: {
+            type: "user_message",
+            message: "What's in this image?",
+            images: [],
+            local_images: ["/tmp/materialized.png"],
+            text_elements: [],
+          },
+        },
+        {
+          type: "event_msg",
+          timestamp: "2026-05-30T23:37:37.556Z",
+          payload: {
+            type: "agent_message",
+            message: "The image shows the PwrAgent desktop app.",
+            phase: "final_answer",
+          },
+        },
+        {
+          type: "response_item",
+          timestamp: "2026-05-30T23:37:37.556Z",
+          payload: {
+            type: "message",
+            role: "assistant",
+            phase: "final_answer",
+            content: [
+              {
+                type: "output_text",
+                text: "The image shows the PwrAgent desktop app.",
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    const replay = await client.readThread({
+      threadId: "thread-raw-image-events",
+    });
+
+    expect(replay.entries.map((entry) => `${entry.type}:${entry.id}`)).toEqual([
+      "message:message-1",
+      "message:message-2",
+    ]);
+    expect(replay.messages.map((message) => `${message.role}:${message.text}`)).toEqual([
+      "user:What's in this image?",
+      "assistant:The image shows the PwrAgent desktop app.",
+    ]);
+    expect(replay.entries).toMatchObject([
+      {
+        type: "message",
+        role: "user",
+        text: "What's in this image?",
+        parts: [
+          { type: "text", text: "What's in this image?" },
+          { type: "image", url: "data:image/png;base64,AQID" },
+        ],
+      },
+      {
+        type: "message",
+        role: "assistant",
+        text: "The image shows the PwrAgent desktop app.",
+      },
+    ]);
+
+    await client.close();
+  });
+
+  it("keeps distinct same-text image prompts with different image sources", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.readThreadResultByThreadId.set("thread-distinct-image-prompts", {
+      events: [
+        {
+          type: "response_item",
+          timestamp: "2026-05-30T23:37:32.719Z",
+          payload: {
+            type: "message",
+            role: "user",
+            content: [
+              { type: "input_text", text: "What's in this image?" },
+              { type: "input_image", image_url: "data:image/png;base64,AQID" },
+            ],
+          },
+        },
+        {
+          type: "response_item",
+          timestamp: "2026-05-30T23:37:32.720Z",
+          payload: {
+            type: "message",
+            role: "user",
+            content: [
+              { type: "input_text", text: "What's in this image?" },
+              { type: "input_image", image_url: "data:image/png;base64,BAUG" },
+            ],
+          },
+        },
+      ],
+    });
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    const replay = await client.readThread({
+      threadId: "thread-distinct-image-prompts",
+    });
+
+    expect(replay.messages).toMatchObject([
+      {
+        role: "user",
+        text: "What's in this image?",
+        parts: [
+          { type: "text", text: "What's in this image?" },
+          { type: "image", url: "data:image/png;base64,AQID" },
+        ],
+      },
+      {
+        role: "user",
+        text: "What's in this image?",
+        parts: [
+          { type: "text", text: "What's in this image?" },
+          { type: "image", url: "data:image/png;base64,BAUG" },
+        ],
+      },
+    ]);
+    expect(replay.entries).toHaveLength(2);
+
+    await client.close();
+  });
+
+  it("restores token usage activity from Codex rollout token_count events", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.readThreadResultByThreadId.set("thread-token-count-events", {
+      events: [
+        {
+          type: "event_msg",
+          timestamp: "2026-05-31T16:51:41.062Z",
+          payload: {
+            type: "agent_message",
+            message: "Done.",
+            phase: "final_answer",
+          },
+        },
+        {
+          type: "event_msg",
+          timestamp: "2026-05-31T16:51:41.079Z",
+          payload: {
+            type: "token_count",
+            info: {
+              last_token_usage: {
+                input_tokens: 21_743,
+                cached_input_tokens: 4_480,
+                output_tokens: 148,
+                reasoning_output_tokens: 0,
+                total_tokens: 21_891,
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    const replay = await client.readThread({
+      threadId: "thread-token-count-events",
+    });
+
+    expect(replay.entries).toMatchObject([
+      {
+        type: "message",
+        role: "assistant",
+        text: "Done.",
+      },
+      {
+        type: "activity",
+        id: "live-token-usage-1780246301079",
+        summary: "Usage: 17,263 uncached in · 4,480 cached · 148 out",
+        status: "completed",
+      },
+    ]);
+
+    await client.close();
+  });
+
+  it("preserves local image fields from durable user message records", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.readThreadResultByThreadId.set("thread-local-image-records", {
+      thread: {
+        turns: [
+          {
+            id: "turn-local-image",
+            startedAt: 1_763_500_300,
+            items: [
+              {
+                type: "user_message",
+                id: "user-local-image",
+                message: "what's in this?",
+                local_images: ["/tmp/materialized.png"],
+              },
+              {
+                type: "agent_message",
+                id: "assistant-final",
+                phase: "final_answer",
+                message: "It is a screenshot of PwrAgent.",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    const replay = await client.readThread({
+      threadId: "thread-local-image-records",
+    });
+
+    expect(replay.entries).toMatchObject([
+      {
+        type: "message",
+        role: "user",
+        text: "what's in this?",
+        parts: [
+          { type: "text", text: "what's in this?" },
+          { type: "image", url: "file:///tmp/materialized.png" },
+        ],
+      },
+      {
+        type: "message",
+        role: "assistant",
+        text: "It is a screenshot of PwrAgent.",
+      },
+    ]);
+
+    await client.close();
+  });
+
+  it("preserves durable localImage content parts after restart", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.readThreadResultByThreadId.set("thread-local-image-content", {
+      thread: {
+        turns: [
+          {
+            id: "turn-local-image-content",
+            startedAt: 1_764_000_300,
+            itemsView: "full",
+            items: [
+              {
+                type: "userMessage",
+                id: "user-local-image-content",
+                content: [
+                  {
+                    type: "input_text",
+                    text: "what's in this?",
+                  },
+                  {
+                    type: "localImage",
+                    path: "/Users/test/.pwragent/profiles/dev/state/image-inputs/materialized.png",
+                  },
+                ],
+              },
+              {
+                type: "agentMessage",
+                id: "assistant-local-image-content",
+                phase: "final_answer",
+                text: "It is a screenshot of PwrAgent.",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    const replay = await client.readThread({
+      threadId: "thread-local-image-content",
+    });
+
+    expect(replay.entries).toMatchObject([
+      {
+        type: "message",
+        role: "user",
+        text: "what's in this?",
+        parts: [
+          { type: "text", text: "what's in this?" },
+          {
+            type: "image",
+            url: "file:///Users/test/.pwragent/profiles/dev/state/image-inputs/materialized.png",
+          },
+        ],
+      },
+      {
+        type: "message",
+        role: "assistant",
+        text: "It is a screenshot of PwrAgent.",
+      },
+    ]);
+
+    await client.close();
+  });
+
   it("extracts structured plan items from thread/read", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
     MockTransport.readThreadResultByThreadId.set("thread-plan-item", {

--- a/apps/desktop/src/main/__tests__/image-input-files.test.ts
+++ b/apps/desktop/src/main/__tests__/image-input-files.test.ts
@@ -1,0 +1,95 @@
+import { mkdtemp, readFile, rm, writeFile as writeFileFs } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { materializeLocalImageInputs } from "../app-server/image-input-files";
+
+describe("image input files", () => {
+  it("materializes PNG data URLs as stable local image inputs", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-image-inputs-"));
+    const dataUrl = "data:image/png;base64,AQID";
+    try {
+      const first = await materializeLocalImageInputs(
+        [
+          { type: "text", text: "Describe it" },
+          { type: "image", url: dataUrl },
+        ],
+        { resolveRoot: () => tempDir },
+      );
+      const second = await materializeLocalImageInputs(
+        [{ type: "image", url: dataUrl }],
+        { resolveRoot: () => tempDir },
+      );
+
+      expect(first[0]).toEqual({ type: "text", text: "Describe it" });
+      expect(first[1]).toMatchObject({ type: "localImage" });
+      expect(second[0]).toEqual(first[1]);
+      const imagePath = first[1]?.type === "localImage" ? first[1].path : "";
+      expect(path.basename(imagePath)).toMatch(/^[a-f0-9]{64}\.png$/);
+      await expect(readFile(imagePath)).resolves.toEqual(Buffer.from([1, 2, 3]));
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("leaves unsupported image URLs untouched", async () => {
+    const result = await materializeLocalImageInputs(
+      [
+        { type: "image", url: "data:image/gif;base64,R0lGODlh" },
+        { type: "image", url: "https://example.test/image.png" },
+      ],
+      { resolveRoot: () => "/tmp/unused-pwragent-image-inputs" },
+    );
+
+    expect(result).toEqual([
+      { type: "image", url: "data:image/gif;base64,R0lGODlh" },
+      { type: "image", url: "https://example.test/image.png" },
+    ]);
+  });
+
+  it("converts file URLs for supported local image paths", async () => {
+    const result = await materializeLocalImageInputs([
+      { type: "image", url: "file:///tmp/screenshot%20one.jpg" },
+    ]);
+
+    expect(result).toEqual([
+      { type: "localImage", path: "/tmp/screenshot one.jpg" },
+    ]);
+  });
+
+  it("does not delete a reused stale cached image while materializing it", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-image-inputs-"));
+    const unlinkedPaths: string[] = [];
+    try {
+      const [materialized] = await materializeLocalImageInputs(
+        [{ type: "image", url: "data:image/png;base64,AQID" }],
+        { resolveRoot: () => tempDir },
+      );
+      const imagePath = materialized?.type === "localImage" ? materialized.path : "";
+      await writeFileFs(imagePath, Buffer.from([9, 9, 9]));
+
+      const [reused] = await materializeLocalImageInputs(
+        [{ type: "image", url: "data:image/png;base64,AQID" }],
+        {
+          now: () => 10 * 24 * 60 * 60 * 1000,
+          readdir: async () => [path.basename(imagePath)],
+          resolveRoot: () => tempDir,
+          stat: async () => ({
+            isFile: () => true,
+            mtimeMs: 0,
+          }),
+          unlink: async (filePath) => {
+            unlinkedPaths.push(String(filePath));
+          },
+        },
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(reused).toEqual({ type: "localImage", path: imagePath });
+      expect(unlinkedPaths).not.toContain(imagePath);
+      await expect(readFile(imagePath)).resolves.toEqual(Buffer.from([1, 2, 3]));
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -92,6 +92,8 @@ const whenReadyMock = vi.fn(() => Promise.resolve());
 const quitMock = vi.fn();
 const getAllWindowsMock = vi.fn(() => []);
 const dockSetIconMock = vi.fn();
+const protocolHandleMock = vi.fn();
+const protocolRegisterSchemesAsPrivilegedMock = vi.fn();
 const nativeImageMock = {
   isEmpty: vi.fn(() => false),
 };
@@ -154,6 +156,10 @@ vi.mock("electron", () => ({
   },
   shell: {
     openExternal: shellOpenExternalMock,
+  },
+  protocol: {
+    handle: protocolHandleMock,
+    registerSchemesAsPrivileged: protocolRegisterSchemesAsPrivilegedMock,
   },
   nativeImage: {
     createFromPath: nativeImageCreateFromPathMock,
@@ -470,6 +476,8 @@ describe("bootstrapApp", () => {
     quitMock.mockReset();
     getAllWindowsMock.mockReset();
     getAllWindowsMock.mockReturnValue([]);
+    protocolHandleMock.mockReset();
+    protocolRegisterSchemesAsPrivilegedMock.mockReset();
     profileFocusRequestWatcherStopMock.mockReset();
     resolveActiveProfileNameMock.mockReset();
     resolveActiveProfileNameMock.mockReturnValue("default");
@@ -529,6 +537,13 @@ describe("bootstrapApp", () => {
     expect(registerSettingsIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(registerWindowPointerIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(registerRuntimeIdentityIpcHandlersMock).toHaveBeenCalledTimes(1);
+    expect(protocolRegisterSchemesAsPrivilegedMock).toHaveBeenCalledWith([
+      expect.objectContaining({ scheme: "pwragent-image" }),
+    ]);
+    expect(protocolHandleMock).toHaveBeenCalledWith(
+      "pwragent-image",
+      expect.any(Function)
+    );
     expect(startProfileFocusRequestWatcherMock).toHaveBeenCalledWith(
       "default",
       expect.objectContaining({ onFocus: expect.any(Function) }),

--- a/apps/desktop/src/main/__tests__/transcript-image-protocol.test.ts
+++ b/apps/desktop/src/main/__tests__/transcript-image-protocol.test.ts
@@ -1,0 +1,199 @@
+import { mkdtemp, mkdir, realpath, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const protocolHandleMock = vi.fn();
+const protocolRegisterSchemesAsPrivilegedMock = vi.fn();
+
+vi.mock("electron", () => ({
+  protocol: {
+    handle: protocolHandleMock,
+    registerSchemesAsPrivileged: protocolRegisterSchemesAsPrivilegedMock,
+  },
+}));
+
+describe("transcript image protocol", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-transcript-images-"));
+    protocolHandleMock.mockReset();
+    protocolRegisterSchemesAsPrivilegedMock.mockReset();
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("registers a secure custom image protocol", async () => {
+    const { registerTranscriptImageProtocolScheme } = await import(
+      "../transcript-image-protocol"
+    );
+
+    registerTranscriptImageProtocolScheme();
+
+    expect(protocolRegisterSchemesAsPrivilegedMock).toHaveBeenCalledWith([
+      {
+        scheme: "pwragent-image",
+        privileges: {
+          standard: true,
+          secure: true,
+          supportFetchAPI: true,
+        },
+      },
+    ]);
+  });
+
+  it("resolves raster images from any PwrAgent profile under the configured root", async () => {
+    const { resolveTranscriptImageProtocolRequest } = await import(
+      "../transcript-image-protocol"
+    );
+    const pwragentHome = path.join(tempDir, "pwragent-home");
+    const imagePath = path.join(
+      pwragentHome,
+      "profiles",
+      "test-profile",
+      "state",
+      "image-inputs",
+      "image.png"
+    );
+    await mkdir(path.dirname(imagePath), { recursive: true });
+    await writeFile(imagePath, Buffer.from([1, 2, 3]));
+
+    const result = await resolveTranscriptImageProtocolRequest(
+      toProtocolUrl(imagePath),
+      {
+        env: { PWRAGENT_HOME: pwragentHome } as NodeJS.ProcessEnv,
+        homeDir: path.join(tempDir, "home"),
+      }
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      path: await realpath(imagePath),
+      mimeType: "image/png",
+    });
+  });
+
+  it("rewrites file image URLs in thread/read responses before they reach the renderer", async () => {
+    const { rewriteTranscriptImageUrlsForRenderer } = await import(
+      "../transcript-image-protocol"
+    );
+    const fileUrl = "file:///Users/test/.pwragent/profiles/dev/state/image-inputs/image.png";
+    const dataUrl = "data:image/png;base64,AQID";
+
+    const response = rewriteTranscriptImageUrlsForRenderer({
+      backend: "codex",
+      fetchedAt: 1,
+      threadId: "thread-images",
+      replay: {
+        entries: [
+          {
+            type: "message",
+            id: "entry-1",
+            role: "user",
+            text: "what's in this?",
+            parts: [
+              { type: "text", text: "what's in this?" },
+              { type: "image", url: fileUrl },
+            ],
+          },
+        ],
+        messages: [
+          {
+            id: "message-1",
+            role: "user",
+            text: "what's in this?",
+            parts: [
+              { type: "image", url: fileUrl },
+              { type: "image", url: dataUrl },
+            ],
+          },
+        ],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+      },
+    });
+
+    expect(response.replay.entries[0]).toMatchObject({
+      parts: [
+        { type: "text", text: "what's in this?" },
+        { type: "image", url: `pwragent-image://file/${encodeURIComponent(fileUrl)}` },
+      ],
+    });
+    expect(response.replay.messages[0]).toMatchObject({
+      parts: [
+        { type: "image", url: `pwragent-image://file/${encodeURIComponent(fileUrl)}` },
+        { type: "image", url: dataUrl },
+      ],
+    });
+  });
+
+  it("resolves raster images from the default Codex home", async () => {
+    const { resolveTranscriptImageProtocolRequest } = await import(
+      "../transcript-image-protocol"
+    );
+    const homeDir = path.join(tempDir, "home");
+    const imagePath = path.join(homeDir, ".codex", "sessions", "image.webp");
+    await mkdir(path.dirname(imagePath), { recursive: true });
+    await writeFile(imagePath, Buffer.from([1, 2, 3]));
+
+    const result = await resolveTranscriptImageProtocolRequest(toProtocolUrl(imagePath), {
+      env: {} as NodeJS.ProcessEnv,
+      homeDir,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      path: await realpath(imagePath),
+      mimeType: "image/webp",
+    });
+  });
+
+  it("rejects non-image files under allowed roots", async () => {
+    const { resolveTranscriptImageProtocolRequest } = await import(
+      "../transcript-image-protocol"
+    );
+    const pwragentHome = path.join(tempDir, "pwragent-home");
+    const textPath = path.join(pwragentHome, "profiles", "dev", "state.db");
+    await mkdir(path.dirname(textPath), { recursive: true });
+    await writeFile(textPath, "not an image");
+
+    await expect(
+      resolveTranscriptImageProtocolRequest(toProtocolUrl(textPath), {
+        env: { PWRAGENT_HOME: pwragentHome } as NodeJS.ProcessEnv,
+        homeDir: path.join(tempDir, "home"),
+      })
+    ).resolves.toMatchObject({
+      ok: false,
+      status: 415,
+    });
+  });
+
+  it("rejects image files outside PwrAgent and Codex roots", async () => {
+    const { resolveTranscriptImageProtocolRequest } = await import(
+      "../transcript-image-protocol"
+    );
+    const imagePath = path.join(tempDir, "outside", "image.png");
+    await mkdir(path.dirname(imagePath), { recursive: true });
+    await writeFile(imagePath, Buffer.from([1, 2, 3]));
+
+    await expect(
+      resolveTranscriptImageProtocolRequest(toProtocolUrl(imagePath), {
+        env: {} as NodeJS.ProcessEnv,
+        homeDir: path.join(tempDir, "home"),
+      })
+    ).resolves.toMatchObject({
+      ok: false,
+      status: 403,
+    });
+  });
+});
+
+function toProtocolUrl(filePath: string): string {
+  return `pwragent-image://file/${encodeURIComponent(pathToFileURL(filePath).toString())}`;
+}

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -187,6 +187,7 @@ import {
   type ThreadTurnQueueOrigin,
   type ThreadTurnQueueSubmissionResult,
 } from "./thread-turn-queue";
+import { materializeLocalImageInputs } from "./image-input-files";
 import type { MessagingStoreLike } from "../state/messaging-store-sqlite";
 
 type InitializeResult = {
@@ -4610,6 +4611,7 @@ export class DesktopBackendRegistry {
       }
     }
 
+    const input = await materializeLocalImageInputs(params.input);
     const reserveCodexStart = params.backend === "codex";
     if (reserveCodexStart) {
       if (this.threadHasActiveTurn(params.threadId)) {
@@ -4630,7 +4632,6 @@ export class DesktopBackendRegistry {
     let turnParams!: ModelSettings;
     let cwd: string | undefined;
     let activeTurnMode: ThreadExecutionMode | undefined;
-    const input = params.input;
     try {
       if (params.backend === "codex") {
         await this.flushQueuedExecutionModeIfPresent(params.threadId);

--- a/apps/desktop/src/main/app-server/image-input-files.ts
+++ b/apps/desktop/src/main/app-server/image-input-files.ts
@@ -1,0 +1,142 @@
+import { createHash } from "node:crypto";
+import { mkdir, readdir, stat, unlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+import type { AppServerTurnInputItem } from "@pwragent/shared";
+import { resolveActiveProfilePath } from "../profile";
+
+const LOCAL_IMAGE_INPUT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+export type ImageInputFileDependencies = {
+  now: () => number;
+  resolveRoot: () => string;
+  writeFile: (filePath: string, data: Buffer) => Promise<unknown>;
+  mkdir: (dirPath: string, options: { recursive: true }) => Promise<unknown>;
+  readdir: (dirPath: string) => Promise<string[]>;
+  stat: (filePath: string) => Promise<{ isFile: () => boolean; mtimeMs: number }>;
+  unlink: (filePath: string) => Promise<unknown>;
+};
+
+const defaultDependencies: ImageInputFileDependencies = {
+  now: () => Date.now(),
+  resolveRoot: () => resolveActiveProfilePath(path.join("state", "image-inputs")),
+  writeFile,
+  mkdir,
+  readdir,
+  stat,
+  unlink,
+};
+
+export async function materializeLocalImageInputs(
+  input: AppServerTurnInputItem[],
+  dependencies: Partial<ImageInputFileDependencies> = {},
+): Promise<AppServerTurnInputItem[]> {
+  const deps = { ...defaultDependencies, ...dependencies };
+  const materialized: AppServerTurnInputItem[] = [];
+  const materializedFilePaths = new Set<string>();
+  let materializedRoot: string | undefined;
+
+  for (const item of input) {
+    if (item.type !== "image") {
+      materialized.push(item);
+      continue;
+    }
+
+    const dataImage = parseSupportedImageDataUrl(item.url);
+    if (dataImage) {
+      const root = deps.resolveRoot();
+      materializedRoot = root;
+      await deps.mkdir(root, { recursive: true });
+      const filePath = path.join(
+        root,
+        `${dataImage.sha256}.${extensionForMimeType(dataImage.mimeType)}`,
+      );
+      await deps.writeFile(filePath, dataImage.buffer);
+      materializedFilePaths.add(filePath);
+      materialized.push({ type: "localImage", path: filePath });
+      continue;
+    }
+
+    const filePath = filePathFromFileUrl(item.url);
+    if (filePath && isSupportedImagePath(filePath)) {
+      materialized.push({ type: "localImage", path: filePath });
+      continue;
+    }
+
+    materialized.push(item);
+  }
+
+  if (materializedRoot) {
+    void cleanupOldImageInputs(
+      materializedRoot,
+      deps,
+      materializedFilePaths,
+    ).catch(() => undefined);
+  }
+
+  return materialized;
+}
+
+function parseSupportedImageDataUrl(
+  url: string,
+): { buffer: Buffer; mimeType: "image/jpeg" | "image/png"; sha256: string } | undefined {
+  const match = /^data:(image\/(?:jpeg|jpg|png));base64,([a-z0-9+/=]+)$/iu.exec(url);
+  if (!match) {
+    return undefined;
+  }
+
+  const mimeType = match[1]?.toLowerCase() === "image/png" ? "image/png" : "image/jpeg";
+  const payload = match[2] ?? "";
+  const buffer = Buffer.from(payload, "base64");
+  if (buffer.byteLength === 0) {
+    return undefined;
+  }
+
+  return {
+    buffer,
+    mimeType,
+    sha256: createHash("sha256").update(buffer).digest("hex"),
+  };
+}
+
+function filePathFromFileUrl(url: string): string | undefined {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "file:" ? decodeURIComponent(parsed.pathname) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function extensionForMimeType(mimeType: "image/jpeg" | "image/png"): "jpg" | "png" {
+  return mimeType === "image/png" ? "png" : "jpg";
+}
+
+function isSupportedImagePath(filePath: string): boolean {
+  const extension = path.extname(filePath).toLowerCase();
+  return extension === ".jpg" || extension === ".jpeg" || extension === ".png";
+}
+
+async function cleanupOldImageInputs(
+  root: string,
+  deps: ImageInputFileDependencies,
+  excludedFilePaths: ReadonlySet<string>,
+): Promise<void> {
+  const cutoff = deps.now() - LOCAL_IMAGE_INPUT_MAX_AGE_MS;
+  const entries = await deps.readdir(root).catch(() => []);
+  await Promise.all(
+    entries.map(async (entry) => {
+      const filePath = path.join(root, entry);
+      if (excludedFilePaths.has(filePath)) {
+        return;
+      }
+      if (!isSupportedImagePath(filePath)) {
+        return;
+      }
+      const info = await deps.stat(filePath).catch(() => undefined);
+      if (!info?.isFile() || info.mtimeMs >= cutoff) {
+        return;
+      }
+      await deps.unlink(filePath).catch(() => undefined);
+    }),
+  );
+}

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -999,6 +999,11 @@ function dedupeJoinedText(parts: string[]): string | undefined {
   return unique.join("\n\n");
 }
 
+function isCodexImageBoundaryText(value: string): boolean {
+  const trimmed = value.trim();
+  return /^<image\b[^>]*>$/i.test(trimmed) || /^<\/image>$/i.test(trimmed);
+}
+
 function normalizeThreadSummary(value: string | undefined): string | undefined {
   const trimmed = value?.replace(/\s+/g, " ").trim();
   if (!trimmed) {
@@ -1157,7 +1162,7 @@ function buildProjectKeyLinkedDirectories(
 function normalizeConversationRole(
   value: string | undefined
 ): "user" | "assistant" | undefined {
-  const normalized = value?.trim().toLowerCase();
+  const normalized = value?.trim().replace(/[-_\s]/g, "").toLowerCase();
   if (normalized === "user" || normalized === "usermessage") {
     return "user";
   }
@@ -1236,7 +1241,6 @@ function isCodexInternalReviewPrompt(
     normalizedType === "usermessage" &&
     normalizedText.startsWith("review ") &&
     normalizedText.includes("code changes") &&
-    normalizedText.includes("base branch") &&
     normalizedText.includes("prioritized") &&
     normalizedText.includes("findings")
   );
@@ -1371,6 +1375,59 @@ function normalizeRenderableImageUrl(value: string | undefined): string | undefi
   return undefined;
 }
 
+function buildImagePartFromUrl(value: string | undefined): AppServerThreadImagePart | undefined {
+  const url = normalizeRenderableImageUrl(value);
+  return url ? { type: "image", url } : undefined;
+}
+
+function extractImagePartsFromValue(value: unknown): AppServerThreadImagePart[] {
+  if (typeof value === "string") {
+    const part = buildImagePartFromUrl(value);
+    return part ? [part] : [];
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => extractImagePartsFromValue(entry));
+  }
+
+  const record = asRecord(value);
+  if (!record) {
+    return [];
+  }
+
+  const part = buildImagePartFromUrl(
+    pickString(record, [
+      "image_url",
+      "imageUrl",
+      "url",
+      "src",
+      "uri",
+      "path",
+      "localPath",
+      "local_path"
+    ])
+  );
+  if (!part) {
+    return [];
+  }
+
+  const alt = pickString(record, ["alt", "altText", "alt_text", "title", "name"]);
+  if (alt) {
+    part.alt = alt;
+  }
+  return [part];
+}
+
+function extractDirectImageParts(record: Record<string, unknown>): AppServerThreadImagePart[] {
+  return [
+    ...extractImagePartsFromValue(record.local_images),
+    ...extractImagePartsFromValue(record.localImages),
+    ...extractImagePartsFromValue(record.images),
+    ...extractImagePartsFromValue(record.image_urls),
+    ...extractImagePartsFromValue(record.imageUrls)
+  ];
+}
+
 function extractStructuredMessageParts(value: unknown): AppServerThreadMessagePart[] {
   if (Array.isArray(value)) {
     return value.flatMap((entry) => extractStructuredMessageParts(entry));
@@ -1391,10 +1448,13 @@ function extractStructuredMessageParts(value: unknown): AppServerThreadMessagePa
     normalizedType === "output_text"
   ) {
     const text = pickString(record, ["text", "value", "content"]);
+    if (text && isCodexImageBoundaryText(text)) {
+      return [];
+    }
     return text ? [{ type: "text", text }] : [];
   }
 
-  const imageUrl = normalizeRenderableImageUrl(
+  const imagePart = buildImagePartFromUrl(
     pickString(record, [
       "image_url",
       "imageUrl",
@@ -1407,23 +1467,21 @@ function extractStructuredMessageParts(value: unknown): AppServerThreadMessagePa
     ])
   );
   if (
-    imageUrl &&
+    imagePart &&
     (normalizedType === "image" ||
       normalizedType === "input_image" ||
+      normalizedType === "localimage" ||
+      normalizedType === "local_image" ||
       normalizedType === "output_image" ||
       normalizedType === "image_url" ||
       "image_url" in record ||
       "imageUrl" in record)
   ) {
-    const part: AppServerThreadImagePart = {
-      type: "image",
-      url: imageUrl
-    };
     const alt = pickString(record, ["alt", "altText", "alt_text", "title", "name"]);
     if (alt) {
-      part.alt = alt;
+      imagePart.alt = alt;
     }
-    return [part];
+    return [imagePart];
   }
 
   for (const nestedKey of ["content", "parts", "input", "output", "data"]) {
@@ -1442,22 +1500,140 @@ function buildMessageContent(record: Record<string, unknown>): {
 } {
   const structuredParts = [
     ...extractStructuredMessageParts(record.content),
-    ...extractStructuredMessageParts(record.parts)
+    ...extractStructuredMessageParts(record.parts),
+    ...extractDirectImageParts(record)
   ];
 
   if (structuredParts.length > 0) {
-    const text = dedupeJoinedText(
-      structuredParts.flatMap((part) => (part.type === "text" ? [part.text] : []))
-    ) ?? "";
+    const text =
+      dedupeJoinedText(
+        structuredParts.flatMap((part) => (part.type === "text" ? [part.text] : []))
+      ) ?? collectLegacyMessageText(record);
+    const parts =
+      structuredParts.some((part) => part.type === "text") || !text
+        ? structuredParts
+        : [{ type: "text" as const, text }, ...structuredParts];
 
     return {
-      parts: structuredParts,
+      parts,
       text
     };
   }
 
   const text = collectLegacyMessageText(record);
   return { text };
+}
+
+function hasThreadMessageImages(
+  message: Pick<AppServerThreadMessageEntry, "parts">
+): boolean {
+  return threadMessageImageUrls(message).length > 0;
+}
+
+function threadMessageImageUrls(
+  message: Pick<AppServerThreadMessageEntry, "parts">
+): string[] {
+  return (
+    message.parts
+      ?.filter((part): part is Extract<AppServerThreadMessagePart, { type: "image" }> =>
+        part.type === "image"
+      )
+      .map((part) => part.url) ?? []
+  );
+}
+
+function imageUrlsMatch(left: string[], right: string[]): boolean {
+  return left.length === right.length && left.every((url, index) => url === right[index]);
+}
+
+function imageUrlsAreRawEventMirror(left: string[], right: string[]): boolean {
+  if (left.length === 0 || left.length !== right.length) {
+    return false;
+  }
+
+  const leftDataUrls = left.every((url) => url.startsWith("data:image/"));
+  const rightDataUrls = right.every((url) => url.startsWith("data:image/"));
+  const leftFileUrls = left.every((url) => url.startsWith("file://"));
+  const rightFileUrls = right.every((url) => url.startsWith("file://"));
+
+  return (leftDataUrls && rightFileUrls) || (leftFileUrls && rightDataUrls);
+}
+
+function messageTimestampsAreWithin(
+  left: AppServerThreadReplay["messages"][number],
+  right: AppServerThreadReplay["messages"][number],
+  windowMs: number
+): boolean {
+  if (typeof left.createdAt !== "number" || typeof right.createdAt !== "number") {
+    return false;
+  }
+
+  return Math.abs(left.createdAt - right.createdAt) <= windowMs;
+}
+
+function messagesAreNearDuplicateImagePrompts(
+  left: AppServerThreadReplay["messages"][number],
+  right: AppServerThreadReplay["messages"][number]
+): boolean {
+  if (left.role !== right.role || left.text !== right.text) {
+    return false;
+  }
+
+  const leftImageUrls = threadMessageImageUrls(left);
+  const rightImageUrls = threadMessageImageUrls(right);
+  const leftHasImages = leftImageUrls.length > 0;
+  const rightHasImages = rightImageUrls.length > 0;
+
+  if (!leftHasImages && !rightHasImages) {
+    if (left.role !== "assistant") {
+      return false;
+    }
+
+    if (typeof left.createdAt !== "number" || typeof right.createdAt !== "number") {
+      return true;
+    }
+
+    return messageTimestampsAreWithin(left, right, 1_000);
+  }
+
+  if (leftHasImages && rightHasImages) {
+    if (imageUrlsMatch(leftImageUrls, rightImageUrls)) {
+      return (
+        typeof left.createdAt !== "number" ||
+        typeof right.createdAt !== "number" ||
+        messageTimestampsAreWithin(left, right, 1_000)
+      );
+    }
+
+    return (
+      imageUrlsAreRawEventMirror(leftImageUrls, rightImageUrls) &&
+      messageTimestampsAreWithin(left, right, 100)
+    );
+  }
+
+  if (typeof left.createdAt !== "number" || typeof right.createdAt !== "number") {
+    return true;
+  }
+
+  return messageTimestampsAreWithin(left, right, 1_000);
+}
+
+function appendConversationMessage(
+  output: AppServerThreadReplay["messages"],
+  message: AppServerThreadReplay["messages"][number]
+): void {
+  const existingIndex = output.findIndex((candidate) =>
+    messagesAreNearDuplicateImagePrompts(candidate, message)
+  );
+  if (existingIndex === -1) {
+    output.push(message);
+    return;
+  }
+
+  const existing = output[existingIndex];
+  if (existing && !hasThreadMessageImages(existing) && hasThreadMessageImages(message)) {
+    output[existingIndex] = message;
+  }
 }
 
 function extractConversationMessages(value: unknown): AppServerThreadReplay["messages"] {
@@ -1489,7 +1665,7 @@ function extractConversationMessages(value: unknown): AppServerThreadReplay["mes
       (content.text || content.parts?.length) &&
       !shouldSuppressConversationMessage(record, suppressedAssistantTexts)
     ) {
-      output.push({
+      appendConversationMessage(output, {
         id:
           pickString(record, ["id", "messageId", "message_id", "itemId", "item_id"]) ??
           `message-${output.length + 1}`,
@@ -2194,6 +2370,132 @@ function formatElapsedMs(elapsedMs: number): string {
   return seconds >= 10 ? `${seconds.toFixed(0)}s` : `${seconds.toFixed(1)}s`;
 }
 
+type TokenUsageBreakdown = {
+  cachedInputTokens?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  reasoningOutputTokens?: number;
+  totalTokens?: number;
+};
+
+function readTokenUsageBreakdown(
+  record: Record<string, unknown>
+): TokenUsageBreakdown | undefined {
+  const explicitTotal = pickNumber(record, ["totalTokens", "total_tokens"]);
+  const inputTokens = pickNumber(record, ["inputTokens", "input_tokens"]);
+  const cachedInputTokens = pickNumber(record, [
+    "cachedInputTokens",
+    "cached_input_tokens",
+  ]);
+  const outputTokens = pickNumber(record, ["outputTokens", "output_tokens"]);
+  const reasoningOutputTokens = pickNumber(record, [
+    "reasoningOutputTokens",
+    "reasoning_output_tokens",
+  ]);
+  const derivedTotal =
+    (inputTokens ?? 0) + (outputTokens ?? 0) + (reasoningOutputTokens ?? 0);
+  const totalTokens = explicitTotal ?? (derivedTotal > 0 ? derivedTotal : undefined);
+
+  if (
+    totalTokens === undefined &&
+    inputTokens === undefined &&
+    cachedInputTokens === undefined &&
+    outputTokens === undefined &&
+    reasoningOutputTokens === undefined
+  ) {
+    return undefined;
+  }
+
+  return {
+    cachedInputTokens,
+    inputTokens,
+    outputTokens,
+    reasoningOutputTokens,
+    totalTokens,
+  };
+}
+
+function normalizeTokenUsagePayload(
+  record: Record<string, unknown>
+): TokenUsageBreakdown | undefined {
+  const root =
+    asRecord(record.tokenUsage) ??
+    asRecord(record.token_usage) ??
+    asRecord(record.info) ??
+    record;
+  const currentUsage =
+    asRecord(root.last) ??
+    asRecord(root.last_token_usage) ??
+    asRecord(root.total) ??
+    asRecord(root.total_token_usage) ??
+    root;
+
+  return readTokenUsageBreakdown(currentUsage);
+}
+
+function formatTokenCount(value: number): string {
+  return Math.round(value).toLocaleString();
+}
+
+function summarizeTokenUsageActivity(
+  record: Record<string, unknown>,
+  createdAt?: number,
+  turn?: AppServerThreadTurnMetadata
+): AppServerThreadActivityEntry | undefined {
+  const normalizedType = normalizeItemType(pickString(record, ["type"]));
+  if (normalizedType !== "tokencount" && normalizedType !== "tokenusage") {
+    return undefined;
+  }
+
+  const tokens = normalizeTokenUsagePayload(record);
+  if (!tokens) {
+    return undefined;
+  }
+
+  const cachedInputTokens = Math.max(0, tokens.cachedInputTokens ?? 0);
+  const inputTokens = Math.max(0, tokens.inputTokens ?? 0);
+  const uncachedInputTokens = Math.max(0, inputTokens - cachedInputTokens);
+  const outputTokens = Math.max(0, tokens.outputTokens ?? 0);
+  const reasoningOutputTokens = Math.max(0, tokens.reasoningOutputTokens ?? 0);
+  const idSuffix = typeof createdAt === "number" ? Math.round(createdAt) : "unknown";
+  const summaryParts = [
+    `${formatTokenCount(uncachedInputTokens)} uncached in`,
+    `${formatTokenCount(cachedInputTokens)} cached`,
+    reasoningOutputTokens > 0
+      ? `${formatTokenCount(outputTokens)} out (${formatTokenCount(reasoningOutputTokens)} reasoning)`
+      : `${formatTokenCount(outputTokens)} out`,
+  ];
+
+  return {
+    type: "activity",
+    id: `live-token-usage-${turn?.id ?? idSuffix}`,
+    createdAt,
+    summary: `Usage: ${summaryParts.join(" · ")}`,
+    status: "completed",
+    details: [
+      {
+        id: `token-usage-${idSuffix}-input`,
+        kind: "read",
+        label: `Input: ${formatTokenCount(inputTokens)} tokens (${formatTokenCount(
+          uncachedInputTokens
+        )} uncached, ${formatTokenCount(cachedInputTokens)} cached)`,
+        status: "completed",
+      },
+      {
+        id: `token-usage-${idSuffix}-output`,
+        kind: "read",
+        label: `Output: ${formatTokenCount(outputTokens)} tokens${
+          reasoningOutputTokens > 0
+            ? `, including ${formatTokenCount(reasoningOutputTokens)} reasoning`
+            : ""
+        }`,
+        status: "completed",
+      },
+    ],
+    ...(turn ? { turn } : {}),
+  };
+}
+
 function readActivityElapsedMs(item: Record<string, unknown>): number | undefined {
   const data = asRecord(item.data);
   const direct =
@@ -2800,6 +3102,62 @@ function truncateActivityText(text: string, maxLength: number): string {
   return normalized.length > maxLength ? `${normalized.slice(0, maxLength - 3)}...` : normalized;
 }
 
+function extractTokenUsageEntries(value: unknown): AppServerThreadActivityEntry[] {
+  const output: AppServerThreadActivityEntry[] = [];
+
+  const visit = (node: unknown, inheritedCreatedAt?: number): void => {
+    if (Array.isArray(node)) {
+      node.forEach((entry) => visit(entry, inheritedCreatedAt));
+      return;
+    }
+
+    const record = asRecord(node);
+    if (!record) {
+      return;
+    }
+
+    const recordCreatedAt = normalizeEpochTimestamp(
+      pickNumber(record, ["createdAt", "created_at", "timestamp", "time"])
+    );
+    const createdAt = recordCreatedAt ?? inheritedCreatedAt;
+    const tokenUsageActivity = summarizeTokenUsageActivity(record, createdAt);
+    if (tokenUsageActivity) {
+      output.push(tokenUsageActivity);
+    }
+
+    for (const key of ["events", "payload", "item", "data", "thread", "response", "result"]) {
+      visit(record[key], createdAt);
+    }
+  };
+
+  visit(value);
+  return output;
+}
+
+function sortEntriesByCreatedAt(entries: AppServerThreadEntry[]): AppServerThreadEntry[] {
+  return entries
+    .map((entry, index) => ({ entry, index }))
+    .sort((left, right) => {
+      const leftCreatedAt = left.entry.createdAt;
+      const rightCreatedAt = right.entry.createdAt;
+      if (
+        typeof leftCreatedAt === "number" &&
+        typeof rightCreatedAt === "number" &&
+        leftCreatedAt !== rightCreatedAt
+      ) {
+        return leftCreatedAt - rightCreatedAt;
+      }
+      if (typeof leftCreatedAt === "number" && typeof rightCreatedAt !== "number") {
+        return -1;
+      }
+      if (typeof leftCreatedAt !== "number" && typeof rightCreatedAt === "number") {
+        return 1;
+      }
+      return left.index - right.index;
+    })
+    .map((item) => item.entry);
+}
+
 function extractThreadEntries(value: unknown): AppServerThreadEntry[] {
   const record = asRecord(value);
   const thread = asRecord(record?.thread);
@@ -2810,12 +3168,15 @@ function extractThreadEntries(value: unknown): AppServerThreadEntry[] {
     : [];
 
   if (turns.length === 0) {
-    return extractConversationMessages(value).map(
-      (message): AppServerThreadMessageEntry => ({
-        type: "message",
-        ...message
-      })
-    );
+    return sortEntriesByCreatedAt([
+      ...extractConversationMessages(value).map(
+        (message): AppServerThreadMessageEntry => ({
+          type: "message",
+          ...message
+        }),
+      ),
+      ...extractTokenUsageEntries(value),
+    ]);
   }
 
   const entries: AppServerThreadEntry[] = [];
@@ -2904,6 +3265,13 @@ function extractThreadEntries(value: unknown): AppServerThreadEntry[] {
               }
             : reviewEntry
         );
+        continue;
+      }
+
+      const tokenUsageActivity = summarizeTokenUsageActivity(item, createdAt, turnMetadata);
+      if (tokenUsageActivity) {
+        flushActivityItems();
+        entries.push(tokenUsageActivity);
         continue;
       }
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -101,6 +101,10 @@ import { requestReplayOnboarding } from "./window-replay-onboarding";
 import { buildApplicationMenuTemplate } from "./menu";
 import { appQuitManager, requestQuit } from "./quit-manager";
 import {
+  installTranscriptImageProtocol,
+  registerTranscriptImageProtocolScheme,
+} from "./transcript-image-protocol";
+import {
   getAuxiliaryWindowMenuTitle,
   reapplyAuxiliaryWindowMenuBars,
 } from "./auxiliary-window-chrome";
@@ -128,6 +132,8 @@ let profileFocusRequestWatcher: ProfileFocusRequestWatcher | null = null;
 let startupCpuProfilerForNewWindows:
   | NonNullable<Parameters<typeof createMainWindow>[0]>["startupCpuProfiler"]
   | undefined;
+
+registerTranscriptImageProtocolScheme();
 
 function logBootDecision(decision: ProfileBootDecision): void {
   // Single structured log line on every boot so troubleshooting
@@ -487,6 +493,7 @@ export function bootstrapApp(): void {
     });
     registerComposerDraftIpcHandlers();
     registerImageNormalizationIpcHandlers();
+    installTranscriptImageProtocol();
     registerPreloadLogIpcHandlers();
     registerProfilesIpcHandlers({ onProfilesChanged: installApplicationMenu });
     registerRendererErrorIpcHandlers();

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -70,6 +70,7 @@ import {
   disposeDesktopBackendRegistry,
   getDesktopBackendRegistry,
 } from "../app-server/backend-registry";
+import { rewriteTranscriptImageUrlsForRenderer } from "../transcript-image-protocol";
 import { hydrateLaunchpadCodexEnvironmentOptions } from "../app-server/codex-environment-config";
 import { getDesktopOverlayStore } from "../app-server/desktop-overlay-store";
 import {
@@ -413,7 +414,7 @@ class DesktopAppServerService {
       threadStatus: response.threadStatus ?? response.replay.threadStatus,
     });
 
-    return response;
+    return rewriteTranscriptImageUrlsForRenderer(response);
   }
 
   async archiveThread(

--- a/apps/desktop/src/main/transcript-image-protocol.ts
+++ b/apps/desktop/src/main/transcript-image-protocol.ts
@@ -1,0 +1,255 @@
+import { protocol } from "electron";
+import type {
+  AppServerReadThreadResponse,
+  AppServerThreadEntry,
+  AppServerThreadMessage,
+  AppServerThreadMessageEntry,
+  AppServerThreadMessagePart,
+} from "@pwragent/shared";
+import { readFile, realpath, stat } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { resolvePwragentRoot } from "./profile";
+import { resolveDefaultCodexHome } from "./settings/codex-profiles";
+
+export const TRANSCRIPT_IMAGE_PROTOCOL_SCHEME = "pwragent-image";
+
+const IMAGE_MIME_TYPES = new Map<string, string>([
+  [".avif", "image/avif"],
+  [".bmp", "image/bmp"],
+  [".gif", "image/gif"],
+  [".jpeg", "image/jpeg"],
+  [".jpg", "image/jpeg"],
+  [".png", "image/png"],
+  [".webp", "image/webp"],
+]);
+
+export type TranscriptImageProtocolOptions = {
+  env?: NodeJS.ProcessEnv;
+  homeDir?: string;
+};
+
+export type TranscriptImageFileResolution =
+  | { ok: true; path: string; mimeType: string }
+  | { ok: false; status: number; message: string };
+
+export function toTranscriptImageProtocolUrl(src: string): string {
+  return `pwragent-image://file/${encodeURIComponent(src)}`;
+}
+
+export function rewriteTranscriptImageUrlsForRenderer(
+  response: AppServerReadThreadResponse,
+): AppServerReadThreadResponse {
+  return {
+    ...response,
+    replay: {
+      ...response.replay,
+      entries: response.replay.entries.map(rewriteTranscriptEntryImageUrls),
+      messages: response.replay.messages.map(rewriteTranscriptMessageImageUrls),
+    },
+  };
+}
+
+export function registerTranscriptImageProtocolScheme(): void {
+  protocol.registerSchemesAsPrivileged([
+    {
+      scheme: TRANSCRIPT_IMAGE_PROTOCOL_SCHEME,
+      privileges: {
+        standard: true,
+        secure: true,
+        supportFetchAPI: true,
+      },
+    },
+  ]);
+}
+
+function rewriteTranscriptEntryImageUrls(entry: AppServerThreadEntry): AppServerThreadEntry {
+  if (entry.type !== "message") {
+    return entry;
+  }
+
+  return rewriteTranscriptMessageImageUrls(entry) as AppServerThreadMessageEntry;
+}
+
+function rewriteTranscriptMessageImageUrls<T extends AppServerThreadMessage>(
+  message: T,
+): T {
+  if (!message.parts?.some((part) => part.type === "image" && isFileImageUrl(part.url))) {
+    return message;
+  }
+
+  return {
+    ...message,
+    parts: message.parts.map(rewriteTranscriptMessagePartImageUrl),
+  };
+}
+
+function rewriteTranscriptMessagePartImageUrl(
+  part: AppServerThreadMessagePart,
+): AppServerThreadMessagePart {
+  if (part.type !== "image" || !isFileImageUrl(part.url)) {
+    return part;
+  }
+
+  return {
+    ...part,
+    url: toTranscriptImageProtocolUrl(part.url),
+  };
+}
+
+function isFileImageUrl(url: string): boolean {
+  return url.startsWith("file://");
+}
+
+export function installTranscriptImageProtocol(): void {
+  protocol.handle(TRANSCRIPT_IMAGE_PROTOCOL_SCHEME, async (request) => {
+    const resolution = await resolveTranscriptImageProtocolRequest(request.url);
+    if (!resolution.ok) {
+      return new Response(resolution.message, {
+        status: resolution.status,
+        headers: { "content-type": "text/plain; charset=utf-8" },
+      });
+    }
+
+    const bytes = await readFile(resolution.path);
+    return new Response(new Uint8Array(bytes), {
+      headers: {
+        "cache-control": "public, max-age=31536000, immutable",
+        "content-type": resolution.mimeType,
+      },
+    });
+  });
+}
+
+export async function resolveTranscriptImageProtocolRequest(
+  requestUrl: string,
+  options?: TranscriptImageProtocolOptions,
+): Promise<TranscriptImageFileResolution> {
+  const sourcePath = decodeTranscriptImageProtocolRequest(requestUrl);
+  if (!sourcePath) {
+    return { ok: false, status: 400, message: "invalid transcript image URL" };
+  }
+
+  return await resolveTranscriptImageFile(sourcePath, options);
+}
+
+function decodeTranscriptImageProtocolRequest(requestUrl: string): string | undefined {
+  let parsed: URL;
+  try {
+    parsed = new URL(requestUrl);
+  } catch {
+    return undefined;
+  }
+
+  if (
+    parsed.protocol !== `${TRANSCRIPT_IMAGE_PROTOCOL_SCHEME}:` ||
+    parsed.hostname !== "file"
+  ) {
+    return undefined;
+  }
+
+  const encodedSource = parsed.pathname.replace(/^\//, "");
+  if (!encodedSource) {
+    return undefined;
+  }
+
+  let sourceUrl: string;
+  try {
+    sourceUrl = decodeURIComponent(encodedSource);
+  } catch {
+    return undefined;
+  }
+
+  if (!sourceUrl.startsWith("file://")) {
+    return undefined;
+  }
+
+  try {
+    return fileURLToPath(sourceUrl);
+  } catch {
+    return undefined;
+  }
+}
+
+async function resolveTranscriptImageFile(
+  sourcePath: string,
+  options?: TranscriptImageProtocolOptions,
+): Promise<TranscriptImageFileResolution> {
+  const mimeType = mimeTypeForImagePath(sourcePath);
+  if (!mimeType) {
+    return { ok: false, status: 415, message: "unsupported transcript image type" };
+  }
+
+  let resolvedPath: string;
+  try {
+    resolvedPath = await realpath(sourcePath);
+  } catch {
+    return { ok: false, status: 404, message: "transcript image not found" };
+  }
+
+  let fileStat;
+  try {
+    fileStat = await stat(resolvedPath);
+  } catch {
+    return { ok: false, status: 404, message: "transcript image not found" };
+  }
+
+  if (!fileStat.isFile()) {
+    return { ok: false, status: 404, message: "transcript image not found" };
+  }
+
+  if (!(await isAllowedTranscriptImagePath(resolvedPath, options))) {
+    return { ok: false, status: 403, message: "transcript image path is not allowed" };
+  }
+
+  return { ok: true, path: resolvedPath, mimeType };
+}
+
+async function isAllowedTranscriptImagePath(
+  resolvedPath: string,
+  options?: TranscriptImageProtocolOptions,
+): Promise<boolean> {
+  const roots = collectTranscriptImageRoots(options);
+  for (const root of roots) {
+    let resolvedRoot: string;
+    try {
+      resolvedRoot = await realpath(root);
+    } catch {
+      continue;
+    }
+
+    if (isPathInsideRoot(resolvedPath, resolvedRoot)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function collectTranscriptImageRoots(options?: TranscriptImageProtocolOptions): string[] {
+  const env = options?.env ?? process.env;
+  const homeDir = options?.homeDir ?? os.homedir();
+  const roots = new Set<string>();
+
+  roots.add(path.join(resolvePwragentRoot({ env, homeDir }), "profiles"));
+  roots.add(path.join(resolvePwragentRoot({ env: {}, homeDir }), "profiles"));
+  roots.add(resolveDefaultCodexHome({ env, homeDir }));
+  roots.add(resolveDefaultCodexHome({ env: {}, homeDir }));
+
+  return [...roots];
+}
+
+function isPathInsideRoot(targetPath: string, rootPath: string): boolean {
+  const relativePath = path.relative(rootPath, targetPath);
+  return (
+    relativePath === "" ||
+    (relativePath !== "" &&
+      !relativePath.startsWith("..") &&
+      !path.isAbsolute(relativePath))
+  );
+}
+
+function mimeTypeForImagePath(filePath: string): string | undefined {
+  return IMAGE_MIME_TYPES.get(path.extname(filePath).toLowerCase());
+}

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -3504,6 +3504,7 @@ export function Composer(props: ComposerProps) {
           const normalized = await normalizeImageFile(file, {
             fallback: props.desktopApi?.normalizeImageForUpload,
             maxPatchCount: props.pastedImageMaxPatches,
+            sourceMimeType: type,
           });
           void props.desktopApi?.recordImageUploadNormalization?.({
             fileName: file.name || fallbackName,

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -915,6 +915,8 @@ export function ThreadView(props: ThreadViewProps) {
     useState<AppServerThreadActivityEntry>();
   const [pendingProtocolActivityEntry, setPendingProtocolActivityEntry] =
     useState<AppServerThreadActivityEntry>();
+  const [pendingUsageActivityEntry, setPendingUsageActivityEntry] =
+    useState<AppServerThreadActivityEntry>();
   const [pendingPlanEntry, setPendingPlanEntry] =
     useState<AppServerThreadPlanEntry>();
   // Snapshots of the two rail-owned live entries at turn/completed
@@ -938,6 +940,9 @@ export function ThreadView(props: ThreadViewProps) {
   const pendingProtocolActivityEntryRef = useRef<
     AppServerThreadActivityEntry | undefined
   >(undefined);
+  const pendingUsageActivityEntryRef = useRef<AppServerThreadActivityEntry | undefined>(
+    undefined,
+  );
   const pendingPlanEntryRef = useRef<AppServerThreadPlanEntry | undefined>(undefined);
   const [pendingRequestBusy, setPendingRequestBusy] = useState(false);
   const [pendingRequestError, setPendingRequestError] = useState<string>();
@@ -972,6 +977,7 @@ export function ThreadView(props: ThreadViewProps) {
   useEffect(() => {
     setPendingActivityEntry(undefined);
     setPendingProtocolActivityEntry(undefined);
+    setPendingUsageActivityEntry(undefined);
     setPendingPlanEntry(undefined);
     setLastCompletedActivityEntry(undefined);
     setLastCompletedPlanEntry(undefined);
@@ -994,8 +1000,14 @@ export function ThreadView(props: ThreadViewProps) {
   useEffect(() => {
     pendingActivityEntryRef.current = pendingActivityEntry;
     pendingProtocolActivityEntryRef.current = pendingProtocolActivityEntry;
+    pendingUsageActivityEntryRef.current = pendingUsageActivityEntry;
     pendingPlanEntryRef.current = pendingPlanEntry;
-  }, [pendingActivityEntry, pendingProtocolActivityEntry, pendingPlanEntry]);
+  }, [
+    pendingActivityEntry,
+    pendingProtocolActivityEntry,
+    pendingUsageActivityEntry,
+    pendingPlanEntry,
+  ]);
 
   // When a new turn begins, clear the pinned snapshots from the prior
   // turn so the LiveWorkRail reflects the in-flight turn's work, not
@@ -1504,6 +1516,7 @@ export function ThreadView(props: ThreadViewProps) {
       ) {
         setPendingActivityEntry(undefined);
         setPendingProtocolActivityEntry(undefined);
+        setPendingUsageActivityEntry(undefined);
         return;
       }
 
@@ -1552,6 +1565,14 @@ export function ThreadView(props: ThreadViewProps) {
             deferLiveTranscriptEntry(completedProtocolActivity);
           }
           setPendingProtocolActivityEntry(undefined);
+
+          const completedUsageActivity = completeEntryTurn(
+            pendingUsageActivityEntryRef.current,
+          );
+          if (completedUsageActivity) {
+            deferLiveTranscriptEntry(completedUsageActivity);
+          }
+          setPendingUsageActivityEntry(undefined);
 
           const completedPlan = completeEntryTurn(pendingPlanEntryRef.current);
           if (completedPlan) {
@@ -2130,6 +2151,7 @@ export function ThreadView(props: ThreadViewProps) {
               reglueRequestKey={transcriptReglueRequestKey}
               skills={props.skills}
               pendingProtocolActivityEntry={pendingProtocolActivityEntry}
+              pendingUsageActivityEntry={pendingUsageActivityEntry}
               threadId={`${selectedThread!.source}:${selectedThread!.id}`}
               onLoadOlder={props.onLoadOlder}
               onOpenImage={setExpandedImage}

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -58,6 +58,7 @@ type TranscriptListProps = {
   loadingMore: boolean;
   pendingActivityEntry?: AppServerThreadActivityEntry;
   pendingProtocolActivityEntry?: AppServerThreadActivityEntry;
+  pendingUsageActivityEntry?: AppServerThreadActivityEntry;
   pendingAssistantMessage?: AppServerThreadMessageEntry;
   pendingPlanEntry?: AppServerThreadPlanEntry;
   pendingRequest?: AppServerPendingRequestNotification;
@@ -339,6 +340,7 @@ export function TranscriptList(props: TranscriptListProps) {
   const hasPendingContent = Boolean(
     props.pendingActivityEntry ||
       props.pendingProtocolActivityEntry ||
+      props.pendingUsageActivityEntry ||
       props.pendingAssistantMessage ||
       props.pendingPlanEntry ||
       props.pendingRequest ||
@@ -399,6 +401,7 @@ export function TranscriptList(props: TranscriptListProps) {
       props.pendingPlanEntry,
       props.pendingActivityEntry,
       props.pendingProtocolActivityEntry,
+      props.pendingUsageActivityEntry,
       props.pendingAssistantMessage,
     ])) {
       insertPendingEntry(entries, pendingEntry);
@@ -415,6 +418,7 @@ export function TranscriptList(props: TranscriptListProps) {
     props.entries,
     props.pendingActivityEntry,
     props.pendingProtocolActivityEntry,
+    props.pendingUsageActivityEntry,
     props.pendingAssistantMessage,
     props.pendingPlanEntry,
     props.messagingBindingTransitions,

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo, type ReactNode } from "react";
+import { memo, useMemo, useState, type ReactNode } from "react";
 import type {
   DesktopApplicationsSnapshot,
   AppServerSkillSummary,
@@ -315,22 +315,13 @@ function renderMessageSegment(params: {
     return (
       <div key={`images:${params.index}`} className="transcript-message__image-grid">
         {imageSegment.parts.map((imagePart, imageIndex) => (
-          <button
-            key={`image:${imageSegment.startIndex + imageIndex}`}
-            type="button"
-            className="transcript-message__image-button"
-            aria-label={`Expand transcript image ${imageSegment.startIndex + imageIndex + 1}`}
-            onClick={() => {
-              params.onOpenImage?.(imagePart);
-            }}
-          >
-            <TranscriptImage
-              className="transcript-message__image-preview"
-              src={imagePart.url}
-              alt={imagePart.alt ?? "Transcript image"}
-              loading="lazy"
-            />
-          </button>
+          <TranscriptImageTile
+            key={`image:${imageSegment.startIndex + imageIndex}:${imagePart.url}`}
+            desktopApi={params.desktopApi}
+            imagePart={imagePart}
+            imageNumber={imageSegment.startIndex + imageIndex + 1}
+            onOpenImage={params.onOpenImage}
+          />
         ))}
       </div>
     );
@@ -346,6 +337,95 @@ function renderMessageSegment(params: {
       text={params.segment.type === "table" ? params.segment.text : params.segment.part.text}
     />
   );
+}
+
+function TranscriptImageTile(props: {
+  desktopApi?: Pick<DesktopApi, "copyText">;
+  imagePart: AppServerThreadImagePart;
+  imageNumber: number;
+  onOpenImage?: (image: AppServerThreadImagePart) => void;
+}): ReactNode {
+  const [failed, setFailed] = useState(false);
+  const sourceLabel = useMemo(
+    () => formatTranscriptImageSourceLabel(props.imagePart.url),
+    [props.imagePart.url]
+  );
+
+  if (failed) {
+    return (
+      <div className="transcript-message__image-fallback">
+        <div className="transcript-message__image-fallback-main">
+          <span className="transcript-message__image-fallback-title">Image failed to load</span>
+          <code
+            className="transcript-message__image-fallback-path"
+            title={sourceLabel}
+          >
+            {sourceLabel}
+          </code>
+        </div>
+        <TranscriptCopyButton
+          className="transcript-copy-button--image-path"
+          copiedLabel="Copied image path"
+          desktopApi={props.desktopApi}
+          label="Copy image path"
+          text={sourceLabel}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      className="transcript-message__image-button"
+      aria-label={`Expand transcript image ${props.imageNumber}`}
+      onClick={() => {
+        props.onOpenImage?.(props.imagePart);
+      }}
+    >
+      <TranscriptImage
+        className="transcript-message__image-preview"
+        src={props.imagePart.url}
+        alt={props.imagePart.alt ?? "Transcript image"}
+        loading="lazy"
+        onError={() => setFailed(true)}
+      />
+    </button>
+  );
+}
+
+function formatTranscriptImageSourceLabel(url: string): string {
+  const transcriptImageSourceUrl = decodeTranscriptImageProtocolUrl(url);
+  if (transcriptImageSourceUrl) {
+    return formatTranscriptImageSourceLabel(transcriptImageSourceUrl);
+  }
+
+  if (!url.startsWith("file://")) {
+    return url;
+  }
+
+  try {
+    return decodeURIComponent(new URL(url).pathname);
+  } catch {
+    const stripped = url.replace(/^file:\/\//, "");
+    try {
+      return decodeURIComponent(stripped);
+    } catch {
+      return stripped;
+    }
+  }
+}
+
+function decodeTranscriptImageProtocolUrl(url: string): string | undefined {
+  if (!url.startsWith("pwragent-image://file/")) {
+    return undefined;
+  }
+
+  try {
+    return decodeURIComponent(new URL(url).pathname.replace(/^\//, ""));
+  } catch {
+    return undefined;
+  }
 }
 
 function renderMessageHeader(params: {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { buildLiveToolDetails } from "../live-transcript-activity";
+import {
+  buildLiveToolDetails,
+  buildTokenUsageActivityEntry,
+} from "../live-transcript-activity";
 
 describe("buildLiveToolDetails", () => {
   it("surfaces collaboration agent activity from live tool items", () => {
@@ -32,5 +35,58 @@ describe("buildLiveToolDetails", () => {
       },
     ]);
     expect(details[0]?.command?.output).toContain("Still running reviewer output.");
+  });
+});
+
+describe("buildTokenUsageActivityEntry", () => {
+  it("summarizes cached, uncached, output, reasoning, and list-price cost", () => {
+    const entry = buildTokenUsageActivityEntry({
+      id: "usage-1",
+      model: "gpt-5.5",
+      tokenUsage: {
+        last_token_usage: {
+          input_tokens: 21_981,
+          cached_input_tokens: 2_432,
+          output_tokens: 174,
+          reasoning_output_tokens: 25,
+        },
+      },
+      turn: { id: "turn-1", status: "in_progress" },
+    });
+
+    expect(entry).toMatchObject({
+      type: "activity",
+      id: "usage-1",
+      summary: expect.stringContaining("19,549 uncached in"),
+      status: "completed",
+      turn: { id: "turn-1" },
+    });
+    expect(entry?.summary).toContain("2,432 cached");
+    expect(entry?.summary).toContain("174 out (25 reasoning)");
+    expect(entry?.summary).toContain("$0.1042 list price");
+    expect(entry?.details.map((detail) => detail.label)).toEqual([
+      "Input: 21,981 tokens (19,549 uncached, 2,432 cached)",
+      "Output: 174 tokens, including 25 reasoning",
+      "Cost: $0.1042 list price for gpt-5.5",
+    ]);
+  });
+
+  it("reports unavailable cost without dropping token accounting", () => {
+    const entry = buildTokenUsageActivityEntry({
+      id: "usage-unknown",
+      model: "custom-model",
+      tokenUsage: {
+        total: {
+          inputTokens: 100,
+          cachedInputTokens: 20,
+          outputTokens: 30,
+        },
+      },
+    });
+
+    expect(entry?.summary).toBe("Usage: 80 uncached in · 20 cached · 30 out");
+    expect(entry?.details.at(-1)?.label).toBe(
+      "Cost unavailable: no local pricing entry for custom-model",
+    );
   });
 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -757,6 +757,62 @@ describe("TranscriptList", () => {
     });
   });
 
+  it("shows a copyable source when an inline image fails to load", async () => {
+    const copyText = vi.fn(async () => undefined);
+    const fileUrl =
+      "file:///Users/test/.pwragent/profiles/dev/state/image-inputs/missing.png";
+    const renderUrl = `pwragent-image://file/${encodeURIComponent(fileUrl)}`;
+
+    render(
+      <TranscriptList
+        desktopApi={{ copyText }}
+        entries={[
+          {
+            type: "message",
+            id: "message-1",
+            role: "user",
+            text: "What's in this?",
+            parts: [
+              {
+                type: "text",
+                text: "What's in this?",
+              },
+              {
+                type: "image",
+                url: renderUrl,
+                alt: "Missing transcript image",
+              },
+            ],
+          },
+        ]}
+        loading={false}
+        loadingMore={false}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    const image = screen.getByAltText("Missing transcript image");
+    expect(image).toHaveAttribute("src", renderUrl);
+
+    fireEvent.error(image);
+
+    await waitFor(() => {
+      expect(screen.getByText("Image failed to load")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText("/Users/test/.pwragent/profiles/dev/state/image-inputs/missing.png")
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy image path" }));
+
+    await waitFor(() => {
+      expect(copyText).toHaveBeenCalledWith(
+        "/Users/test/.pwragent/profiles/dev/state/image-inputs/missing.png"
+      );
+    });
+  });
+
   it("renders pending status inside the transcript list", () => {
     render(
       <TranscriptList

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts
@@ -540,6 +540,35 @@ describe("buildTranscriptRenderItems", () => {
     ]);
   });
 
+  it("renders token usage as top-level activity without disrupting commentary collapse", () => {
+    const turn = completedTurn("turn-1", 20_000);
+    const usageActivity: AppServerThreadActivityEntry = {
+      type: "activity",
+      id: "live-token-usage-turn-1",
+      summary: "Usage: 1.2k uncached in / 0 cached / 12 out",
+      details: [],
+      turn,
+    };
+    const update = commentary("c1", "Checking the result.", turn);
+    const answer = final("f1", "Final answer.", turn);
+
+    const items = buildTranscriptRenderItems({
+      entries: [usageActivity, update, answer],
+    });
+
+    expect(items).toEqual([
+      { type: "entry", entry: usageActivity },
+      {
+        type: "workPhaseGroup",
+        id: "commentary:turn-1:c1:complete",
+        collapsible: true,
+        entries: [update],
+        label: "1 previous message",
+      },
+      { type: "entry", entry: answer },
+    ]);
+  });
+
   it("only collapses consecutive commentary in the fallback path", () => {
     const first = commentary("c1", "First scan.");
     const answer = final("f1", "Interim answer.");

--- a/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
@@ -38,10 +38,48 @@ function readNumber(record: Record<string, unknown> | undefined, key: string): n
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
+function readFiniteNumber(
+  record: Record<string, unknown> | undefined,
+  keys: string[],
+): number | undefined {
+  for (const key of keys) {
+    const value = readNumber(record, key);
+    if (value !== undefined) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
 function readRecord(value: unknown): Record<string, unknown> | undefined {
   return typeof value === "object" && value !== null && !Array.isArray(value)
     ? value as Record<string, unknown>
     : undefined;
+}
+
+function findFirstNestedValue(
+  value: unknown,
+  keys: string[],
+): unknown {
+  const record = readRecord(value);
+  if (!record) {
+    return undefined;
+  }
+
+  for (const key of keys) {
+    if (record[key] !== undefined) {
+      return record[key];
+    }
+  }
+
+  for (const child of Object.values(record)) {
+    const nested = findFirstNestedValue(child, keys);
+    if (nested !== undefined) {
+      return nested;
+    }
+  }
+
+  return undefined;
 }
 
 function readStringArray(value: unknown): string[] {
@@ -169,6 +207,212 @@ function buildLiveCommandDetail(
     ...(typeof exitCode === "number" ? { exitCode } : {}),
     ...(typeof elapsedMs === "number" ? { durationMs: elapsedMs } : {}),
   };
+}
+
+type TokenUsageBreakdown = {
+  cachedInputTokens?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  reasoningOutputTokens?: number;
+  totalTokens?: number;
+};
+
+type PricingCatalogEntry = {
+  cachedInputUsdPerMillion: number;
+  inputUsdPerMillion: number;
+  model: string;
+  outputUsdPerMillion: number;
+};
+
+const PRICING_CATALOG: readonly PricingCatalogEntry[] = [
+  {
+    model: "gpt-5.5",
+    inputUsdPerMillion: 5,
+    cachedInputUsdPerMillion: 0.5,
+    outputUsdPerMillion: 30,
+  },
+  {
+    model: "gpt-5.4",
+    inputUsdPerMillion: 2.5,
+    cachedInputUsdPerMillion: 0.25,
+    outputUsdPerMillion: 15,
+  },
+  {
+    model: "gpt-5.4-mini",
+    inputUsdPerMillion: 0.75,
+    cachedInputUsdPerMillion: 0.075,
+    outputUsdPerMillion: 4.5,
+  },
+];
+
+export function buildTokenUsageActivityEntry(params: {
+  id: string;
+  model?: string;
+  tokenUsage: unknown;
+  turn?: AppServerThreadTurnMetadata;
+}): AppServerThreadActivityEntry | undefined {
+  const tokens = normalizeTokenUsage(params.tokenUsage);
+  if (!tokens) {
+    return undefined;
+  }
+
+  const cachedInputTokens = Math.max(0, tokens.cachedInputTokens ?? 0);
+  const inputTokens = Math.max(0, tokens.inputTokens ?? 0);
+  const uncachedInputTokens = Math.max(0, inputTokens - cachedInputTokens);
+  const outputTokens = Math.max(0, tokens.outputTokens ?? 0);
+  const reasoningOutputTokens = Math.max(0, tokens.reasoningOutputTokens ?? 0);
+  const cost = estimateUsageCost({
+    cachedInputTokens,
+    model: params.model,
+    outputTokens,
+    uncachedInputTokens,
+  });
+  const summaryParts = [
+    `${formatTokenCount(uncachedInputTokens)} uncached in`,
+    `${formatTokenCount(cachedInputTokens)} cached`,
+    reasoningOutputTokens > 0
+      ? `${formatTokenCount(outputTokens)} out (${formatTokenCount(reasoningOutputTokens)} reasoning)`
+      : `${formatTokenCount(outputTokens)} out`,
+    cost ? `${formatUsd(cost.totalUsd)} list price` : undefined,
+  ].filter((part): part is string => Boolean(part));
+
+  const details: AppServerThreadActivityDetail[] = [
+    {
+      id: `${params.id}-input`,
+      kind: "read",
+      label: `Input: ${formatTokenCount(inputTokens)} tokens (${formatTokenCount(
+        uncachedInputTokens,
+      )} uncached, ${formatTokenCount(cachedInputTokens)} cached)`,
+      status: "completed",
+    },
+    {
+      id: `${params.id}-output`,
+      kind: "read",
+      label: `Output: ${formatTokenCount(outputTokens)} tokens${
+        reasoningOutputTokens > 0
+          ? `, including ${formatTokenCount(reasoningOutputTokens)} reasoning`
+          : ""
+      }`,
+      status: "completed",
+    },
+  ];
+  if (cost) {
+    details.push({
+      id: `${params.id}-cost`,
+      kind: "read",
+      label: `Cost: ${formatUsd(cost.totalUsd)} list price for ${cost.model}`,
+      status: "completed",
+    });
+  } else if (params.model) {
+    details.push({
+      id: `${params.id}-cost-unavailable`,
+      kind: "read",
+      label: `Cost unavailable: no local pricing entry for ${params.model}`,
+      status: "completed",
+    });
+  }
+
+  return {
+    type: "activity",
+    id: params.id,
+    createdAt: Date.now(),
+    summary: `Usage: ${summaryParts.join(" · ")}`,
+    status: "completed",
+    details,
+    ...(params.turn ? { turn: params.turn } : {}),
+  };
+}
+
+function normalizeTokenUsage(tokenUsage: unknown): TokenUsageBreakdown | undefined {
+  const root =
+    readRecord(findFirstNestedValue(tokenUsage, ["tokenUsage", "token_usage", "info"])) ??
+    readRecord(tokenUsage);
+  if (!root) {
+    return undefined;
+  }
+
+  const currentUsageRecord =
+    readRecord(findFirstNestedValue(root, ["last", "last_token_usage"])) ??
+    readRecord(root.last) ??
+    readRecord(root.last_token_usage) ??
+    readRecord(findFirstNestedValue(root, ["total", "total_token_usage"])) ??
+    readRecord(root.total) ??
+    readRecord(root.total_token_usage) ??
+    root;
+
+  return readTokenBreakdown(currentUsageRecord);
+}
+
+function readTokenBreakdown(record: Record<string, unknown>): TokenUsageBreakdown | undefined {
+  const explicitTotal = readFiniteNumber(record, ["totalTokens", "total_tokens"]);
+  const inputTokens = readFiniteNumber(record, ["inputTokens", "input_tokens"]);
+  const cachedInputTokens = readFiniteNumber(record, [
+    "cachedInputTokens",
+    "cached_input_tokens",
+  ]);
+  const outputTokens = readFiniteNumber(record, ["outputTokens", "output_tokens"]);
+  const reasoningOutputTokens = readFiniteNumber(record, [
+    "reasoningOutputTokens",
+    "reasoning_output_tokens",
+  ]);
+  const derivedTotal =
+    (inputTokens ?? 0) + (outputTokens ?? 0) + (reasoningOutputTokens ?? 0);
+  const totalTokens = explicitTotal ?? (derivedTotal > 0 ? derivedTotal : undefined);
+
+  if (
+    totalTokens === undefined &&
+    inputTokens === undefined &&
+    cachedInputTokens === undefined &&
+    outputTokens === undefined &&
+    reasoningOutputTokens === undefined
+  ) {
+    return undefined;
+  }
+
+  return {
+    cachedInputTokens,
+    inputTokens,
+    outputTokens,
+    reasoningOutputTokens,
+    totalTokens,
+  };
+}
+
+function estimateUsageCost(params: {
+  cachedInputTokens: number;
+  model?: string;
+  outputTokens: number;
+  uncachedInputTokens: number;
+}): { model: string; totalUsd: number } | undefined {
+  const model = params.model?.trim();
+  if (!model) {
+    return undefined;
+  }
+  const entry = PRICING_CATALOG.find((candidate) => candidate.model === model);
+  if (!entry) {
+    return undefined;
+  }
+  const totalUsd =
+    (params.uncachedInputTokens * entry.inputUsdPerMillion) / 1_000_000 +
+    (params.cachedInputTokens * entry.cachedInputUsdPerMillion) / 1_000_000 +
+    (params.outputTokens * entry.outputUsdPerMillion) / 1_000_000;
+  return { model, totalUsd };
+}
+
+function formatTokenCount(value: number): string {
+  return Math.round(value).toLocaleString();
+}
+
+function formatUsd(value: number): string {
+  if (value > 0 && value < 0.01) {
+    return "<$0.01";
+  }
+  return new Intl.NumberFormat(undefined, {
+    currency: "USD",
+    maximumFractionDigits: value < 1 ? 4 : 2,
+    minimumFractionDigits: value < 1 ? 2 : 2,
+    style: "currency",
+  }).format(value);
 }
 
 function readCommandActionLabel(item: Record<string, unknown>): string | undefined {

--- a/apps/desktop/src/renderer/src/features/thread-detail/transcript-render-items.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/transcript-render-items.ts
@@ -267,7 +267,11 @@ function isWorkPhaseEntry(
   | AppServerThreadActivityEntry
   | AppServerThreadPlanEntry {
   if (entry.type === "activity") {
-    return !isTerminalTurnFailureActivity(entry) && !isFileDiffActivity(entry);
+    return (
+      !isTerminalTurnFailureActivity(entry) &&
+      !isFileDiffActivity(entry) &&
+      !isTokenUsageActivity(entry)
+    );
   }
 
   if (entry.type === "plan") {
@@ -288,7 +292,8 @@ function isConcreteWorkEntry(
     entry.type === "plan" ||
     (entry.type === "activity" &&
       !isTerminalTurnFailureActivity(entry) &&
-      !isFileDiffActivity(entry))
+      !isFileDiffActivity(entry) &&
+      !isTokenUsageActivity(entry))
   );
 }
 
@@ -304,6 +309,10 @@ function isTerminalTurnFailureActivity(
 
 function isFileDiffActivity(entry: AppServerThreadActivityEntry): boolean {
   return entry.details.some((detail) => Boolean(detail.fileDiff?.diff));
+}
+
+function isTokenUsageActivity(entry: AppServerThreadActivityEntry): boolean {
+  return entry.id.startsWith("live-token-usage-") || entry.summary.startsWith("Usage:");
 }
 
 function readCompletedTurn(

--- a/apps/desktop/src/renderer/src/lib/__tests__/image-normalization.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/image-normalization.test.ts
@@ -278,6 +278,38 @@ describe("image normalization", () => {
     });
   });
 
+  it("preserves PNG bytes when clipboard item MIME fills an empty File type", async () => {
+    const dependencies = makeDependencies({
+      decode: vi.fn(async () => ({
+        width: 640,
+        height: 480,
+        draw: vi.fn(),
+      })),
+    });
+
+    const normalized = await normalizeImageFile(
+      new File([new Uint8Array([1, 2, 3])], "image"),
+      {
+        dependencies,
+        maxPatchCount: 1536,
+        sourceMimeType: "image/png",
+      },
+    );
+
+    expect(dependencies.encodeCanvas).not.toHaveBeenCalled();
+    expect(normalized).toMatchObject({
+      dataUrl: "data:image/png;base64,AQID",
+      height: 480,
+      mimeType: "image/png",
+      original: {
+        mimeType: "image/png",
+        size: 3,
+      },
+      size: 3,
+      width: 640,
+    });
+  });
+
   it("retries JPEG encoding when a resized output is larger than the source", async () => {
     const encodeCanvas = vi.fn(async (_canvas, mimeType, quality) => {
       const size = quality >= 0.85 ? 140 : 90;
@@ -336,7 +368,7 @@ describe("image normalization", () => {
     });
   });
 
-  it("normalizes extension-inferred JPEG files with empty blob MIME types", async () => {
+  it("preserves extension-inferred JPEG files with empty blob MIME types", async () => {
     const dependencies = makeDependencies({
       decode: vi.fn(async () => ({
         width: 640,
@@ -350,11 +382,7 @@ describe("image normalization", () => {
       { dependencies, maxPatchCount: 1536 },
     );
 
-    expect(dependencies.encodeCanvas).toHaveBeenCalledWith(
-      expect.anything(),
-      "image/jpeg",
-      expect.any(Number),
-    );
+    expect(dependencies.encodeCanvas).not.toHaveBeenCalled();
     expect(normalized).toMatchObject({
       dataUrl: "data:image/jpeg;base64,AQID",
       height: 480,

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -343,6 +343,277 @@ describe("useThreadSessionState", () => {
     ]);
   });
 
+  it("keeps an optimistic image user message ahead of a hydrated assistant final", async () => {
+    const readThread = vi.fn(
+      async ({
+        backend,
+        threadId,
+      }: {
+        backend?: AppServerBackendKind;
+        threadId: string;
+      }) => {
+        return {
+          backend: backend ?? "codex",
+          fetchedAt: Date.now(),
+          threadId,
+          replay: {
+            entries: [
+              {
+                type: "message" as const,
+                id: "assistant-final",
+                role: "assistant" as const,
+                phase: "final" as const,
+                text: "It is a screenshot of PwrAgent.",
+                createdAt: 2_000,
+              },
+            ],
+            messages: [
+              {
+                id: "assistant-final",
+                role: "assistant" as const,
+                text: "It is a screenshot of PwrAgent.",
+                createdAt: 2_000,
+              },
+            ],
+            pagination: {
+              supportsPagination: false,
+              hasPreviousPage: false,
+            },
+          },
+        };
+      }
+    );
+    const desktopApi: DesktopApi = { readThread };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: {
+          ...buildThread({ id: "thread-1", updatedAt: 2_000 }),
+          optimisticUserMessage: {
+            text: "What's in this image?",
+            createdAt: 1_000,
+            imageParts: [{ type: "image", url: "data:image/png;base64,AQID" }],
+          },
+        },
+      })
+    );
+
+    await waitForThreadHydration(result);
+    await waitFor(() => {
+      expect(
+        result.current.entries.map((entry) =>
+          entry.type === "message" ? `${entry.role}:${entry.text}` : entry.type
+        )
+      ).toEqual([
+        "user:What's in this image?",
+        "assistant:It is a screenshot of PwrAgent.",
+      ]);
+    });
+    expect(
+      result.current.messages.map((message) => `${message.role}:${message.text}`)
+    ).toEqual([
+      "user:What's in this image?",
+      "assistant:It is a screenshot of PwrAgent.",
+    ]);
+  });
+
+  it("deduplicates hydrated image prompt wrappers against selected optimistic input", async () => {
+    const readThread = vi.fn(
+      async ({
+        backend,
+        threadId,
+      }: {
+        backend?: AppServerBackendKind;
+        threadId: string;
+      }) => {
+        return {
+          backend: backend ?? "codex",
+          fetchedAt: Date.now(),
+          threadId,
+          replay: {
+            entries: [
+              {
+                type: "message" as const,
+                id: "hydrated-user",
+                role: "user" as const,
+                text: "What's in this image?\n\n<image name=[Image #1]>\n\n</image>",
+                parts: [
+                  { type: "text" as const, text: "What's in this image?" },
+                  { type: "text" as const, text: "<image name=[Image #1]>" },
+                  { type: "image" as const, url: "file:///tmp/materialized.png" },
+                  { type: "text" as const, text: "</image>" },
+                ],
+                createdAt: 2_000,
+              },
+              {
+                type: "message" as const,
+                id: "assistant-final",
+                role: "assistant" as const,
+                phase: "final" as const,
+                text: "It is a screenshot of PwrAgent.",
+                createdAt: 3_000,
+              },
+            ],
+            messages: [
+              {
+                id: "hydrated-user",
+                role: "user" as const,
+                text: "What's in this image?\n\n<image name=[Image #1]>\n\n</image>",
+                parts: [
+                  { type: "text" as const, text: "What's in this image?" },
+                  { type: "text" as const, text: "<image name=[Image #1]>" },
+                  { type: "image" as const, url: "file:///tmp/materialized.png" },
+                  { type: "text" as const, text: "</image>" },
+                ],
+                createdAt: 2_000,
+              },
+              {
+                id: "assistant-final",
+                role: "assistant" as const,
+                text: "It is a screenshot of PwrAgent.",
+                createdAt: 3_000,
+              },
+            ],
+            pagination: {
+              supportsPagination: false,
+              hasPreviousPage: false,
+            },
+          },
+        };
+      }
+    );
+    const desktopApi: DesktopApi = { readThread };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: {
+          ...buildThread({ id: "thread-1", updatedAt: 3_000 }),
+          optimisticUserMessage: {
+            text: "What's in this image?",
+            createdAt: 1_000,
+            imageParts: [{ type: "image", url: "data:image/png;base64,AQID" }],
+          },
+        },
+      })
+    );
+
+    await waitForThreadHydration(result);
+    await waitFor(() => {
+      expect(
+        result.current.entries.map((entry) =>
+          entry.type === "message" ? `${entry.role}:${entry.text}` : entry.type
+        )
+      ).toEqual([
+        "user:What's in this image?",
+        "assistant:It is a screenshot of PwrAgent.",
+      ]);
+    });
+    const [userEntry] = result.current.entries;
+    expect(userEntry).toMatchObject({
+      type: "message",
+      role: "user",
+      text: "What's in this image?",
+      parts: [
+        { type: "text", text: "What's in this image?" },
+        { type: "image", url: "file:///tmp/materialized.png" },
+      ],
+    });
+  });
+
+  it("preserves selected optimistic image input when hydrated prompt is text-only", async () => {
+    const readThread = vi.fn(
+      async ({
+        backend,
+        threadId,
+      }: {
+        backend?: AppServerBackendKind;
+        threadId: string;
+      }) => {
+        return {
+          backend: backend ?? "codex",
+          fetchedAt: Date.now(),
+          threadId,
+          replay: {
+            entries: [
+              {
+                type: "message" as const,
+                id: "hydrated-user",
+                role: "user" as const,
+                text: "what's in this?",
+                createdAt: 2_000,
+              },
+              {
+                type: "message" as const,
+                id: "assistant-final",
+                role: "assistant" as const,
+                phase: "final" as const,
+                text: "It is a screenshot of PwrAgent.",
+                createdAt: 3_000,
+              },
+            ],
+            messages: [
+              {
+                id: "hydrated-user",
+                role: "user" as const,
+                text: "what's in this?",
+                createdAt: 2_000,
+              },
+              {
+                id: "assistant-final",
+                role: "assistant" as const,
+                text: "It is a screenshot of PwrAgent.",
+                createdAt: 3_000,
+              },
+            ],
+            pagination: {
+              supportsPagination: false,
+              hasPreviousPage: false,
+            },
+          },
+        };
+      }
+    );
+    const desktopApi: DesktopApi = { readThread };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: {
+          ...buildThread({ id: "thread-1", updatedAt: 3_000 }),
+          optimisticUserMessage: {
+            text: "what's in this?",
+            createdAt: 1_000,
+            imageParts: [{ type: "image", url: "data:image/png;base64,AQID" }],
+          },
+        },
+      })
+    );
+
+    await waitForThreadHydration(result);
+    await waitFor(() => {
+      expect(
+        result.current.entries.map((entry) =>
+          entry.type === "message" ? `${entry.role}:${entry.text}` : entry.type
+        )
+      ).toEqual([
+        "user:what's in this?",
+        "assistant:It is a screenshot of PwrAgent.",
+      ]);
+    });
+    const [userEntry] = result.current.entries;
+    expect(userEntry).toMatchObject({
+      type: "message",
+      role: "user",
+      text: "what's in this?",
+      parts: [
+        { type: "text", text: "what's in this?" },
+        { type: "image", url: "data:image/png;base64,AQID" },
+      ],
+    });
+  });
+
   it("materializes completed steer user messages in the transcript", async () => {
     let agentEventHandler:
       | ((event: {
@@ -471,6 +742,103 @@ describe("useThreadSessionState", () => {
         "user:Steer while thinking.",
         "assistant:Steer acknowledged.",
       ]);
+    });
+  });
+
+  it("preserves optimistic image attachments when Codex echoes a text-only user message", async () => {
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex" | "grok";
+          notification: {
+            method: string;
+            params: Record<string, unknown>;
+          };
+        }) => void)
+      | undefined;
+    const readThread = vi.fn(
+      async ({
+        backend,
+        threadId,
+      }: {
+        backend?: AppServerBackendKind;
+        threadId: string;
+      }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      })
+    );
+
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback as typeof agentEventHandler;
+        return () => undefined;
+      },
+      readThread,
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitForThreadHydration(result);
+
+    act(() => {
+      result.current.addOptimisticUserMessage("What's in this image?", [
+        { type: "image", url: "data:image/png;base64,AQID" },
+      ]);
+    });
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: {
+              type: "userMessage",
+              id: "user-message-1",
+              content: [
+                {
+                  type: "text",
+                  text: "What's in this image?",
+                },
+              ],
+            },
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        result.current.entries.map((entry) =>
+          entry.type === "message" ? `${entry.role}:${entry.text}` : entry.type
+        )
+      ).toEqual(["user:What's in this image?"]);
+    });
+    const [entry] = result.current.entries;
+    expect(entry).toMatchObject({
+      type: "message",
+      role: "user",
+      text: "What's in this image?",
+      parts: [
+        { type: "text", text: "What's in this image?" },
+        { type: "image", url: "data:image/png;base64,AQID" },
+      ],
     });
   });
 
@@ -2979,6 +3347,212 @@ describe("useThreadSessionState", () => {
 
     expect(result.current.pendingStatusText).toBe("Thinking");
     expect(result.current.activeTurnId).toBe("turn-1");
+  });
+
+  it("stores token usage updates as session-owned transcript entries", async () => {
+    let agentEventHandler: Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0] | undefined;
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback;
+        return () => undefined;
+      },
+      readThread: async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitForThreadHydration(result);
+
+    act(() => {
+      result.current.setActiveTurnId("turn-1");
+    });
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "thread/tokenUsage/updated",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            tokenUsage: {
+              last_token_usage: {
+                input_tokens: 1_200,
+                cached_input_tokens: 200,
+                output_tokens: 50,
+                reasoning_output_tokens: 10,
+              },
+            },
+          },
+        },
+      });
+    });
+
+    expect(result.current.entries).toEqual([]);
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            turn: {
+              id: "turn-1",
+              status: "completed",
+              output: [{ type: "text", text: "Done." }],
+            },
+          },
+        },
+      });
+    });
+
+    expect(transcriptLabels(result.current.entries)).toEqual([
+      "message:Done.",
+      "activity:Usage: 1,000 uncached in · 200 cached · 50 out (10 reasoning)",
+    ]);
+    expect(result.current.entries.at(-1)).toMatchObject({
+      id: "live-token-usage-turn-1",
+      turn: {
+        id: "turn-1",
+        status: "completed",
+      },
+    });
+  });
+
+  it("keeps completed token usage before the next turn user prompt during hydration", async () => {
+    let now = 10_000;
+    vi.spyOn(Date, "now").mockImplementation(() => now++);
+    let agentEventHandler: Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0] | undefined;
+    let readCount = 0;
+    const readThread = vi.fn(async ({ backend, threadId }) => {
+      readCount += 1;
+      const secondHydration = readCount > 1;
+      return {
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: secondHydration
+            ? [
+                {
+                  type: "message" as const,
+                  id: "assistant-turn-1",
+                  role: "assistant" as const,
+                  phase: "final" as const,
+                  text: "Done.",
+                  createdAt: 10_000,
+                },
+                {
+                  type: "message" as const,
+                  id: "user-turn-2",
+                  role: "user" as const,
+                  text: "Take another look",
+                  createdAt: 20_000,
+                },
+              ]
+            : [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      };
+    });
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback;
+        return () => undefined;
+      },
+      readThread,
+    };
+
+    const { result, rerender } = renderHook(
+      ({ thread }) =>
+        useThreadSessionState({
+          desktopApi,
+          thread,
+        }),
+      {
+        initialProps: {
+          thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+        },
+      }
+    );
+
+    await waitForThreadHydration(result);
+
+    act(() => {
+      result.current.setActiveTurnId("turn-1");
+    });
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "thread/tokenUsage/updated",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            tokenUsage: {
+              last_token_usage: {
+                input_tokens: 1_200,
+                cached_input_tokens: 200,
+                output_tokens: 50,
+              },
+            },
+          },
+        },
+      });
+    });
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            turn: {
+              id: "turn-1",
+              status: "completed",
+              output: [{ type: "text", text: "Done." }],
+            },
+          },
+        },
+      });
+    });
+
+    rerender({ thread: buildThread({ id: "thread-1", updatedAt: 2_000 }) });
+
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(2);
+    });
+    await waitFor(() => {
+      expect(transcriptLabels(result.current.entries)).toEqual([
+        "message:Done.",
+        "activity:Usage: 1,000 uncached in · 200 cached · 50 out",
+        "message:Take another look",
+      ]);
+    });
   });
 
   it("derives the transcript thinking status from an active turn when status text is cleared", async () => {

--- a/apps/desktop/src/renderer/src/lib/image-normalization.ts
+++ b/apps/desktop/src/renderer/src/lib/image-normalization.ts
@@ -66,6 +66,7 @@ type NormalizeImageFileOptions = {
   maxLongEdge?: number;
   maxShortEdge?: number;
   qualityProfile?: ImageUploadQualityProfile;
+  sourceMimeType?: string;
   dependencies?: Partial<ImageNormalizationDependencies>;
 };
 
@@ -176,8 +177,13 @@ export async function normalizeImageFile(
     IMAGE_UPLOAD_QUALITY_PROFILES[
       options.qualityProfile ?? DEFAULT_IMAGE_UPLOAD_QUALITY_PROFILE
     ];
+  const originalMimeType = inferImageMimeType(file, options.sourceMimeType);
+  const blob =
+    !file.type && originalMimeType
+      ? new Blob([file], { type: originalMimeType })
+      : file;
   return await normalizeBlob({
-    blob: file,
+    blob,
     fallback: options.fallback,
     fileName: file.name || "pasted-image",
     jpegQuality: options.jpegQuality ?? profile.jpegQuality,
@@ -186,7 +192,7 @@ export async function normalizeImageFile(
       options.maxPatchCount ??
       (options.qualityProfile ? undefined : DEFAULT_PASTED_IMAGE_MAX_PATCHES),
     maxShortEdge: options.maxShortEdge ?? profile.maxShortEdge,
-    originalMimeType: inferImageMimeType(file),
+    originalMimeType,
     originalSize: file.size,
     dependencies: {
       ...defaultImageNormalizationDependencies,
@@ -558,8 +564,9 @@ const defaultImageNormalizationDependencies: ImageNormalizationDependencies = {
     }),
 };
 
-function inferImageMimeType(file: File): string {
-  const sourceType = normalizeSourceMimeType(file.type);
+function inferImageMimeType(file: File, sourceMimeType?: string): string {
+  const sourceType =
+    normalizeSourceMimeType(sourceMimeType ?? "") || normalizeSourceMimeType(file.type);
   if (sourceType) {
     return sourceType;
   }

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -12,6 +12,7 @@ import type {
   AppServerThreadEntry,
   AppServerThreadMessage,
   AppServerThreadMessageEntry,
+  AppServerThreadMessagePart,
   AppServerThreadReviewEntry,
   AppServerThreadTurnMetadata,
   AppServerThreadImagePart,
@@ -34,6 +35,7 @@ import {
   buildLiveActivityEntry,
   buildLiveToolDetails,
   buildMcpProgressDetail,
+  buildTokenUsageActivityEntry,
   formatChangedFileSummary,
   getNotificationItem,
   mergeActivityDetails,
@@ -119,6 +121,7 @@ type ThreadSessionEntry = {
   nextLiveEntrySequence: number;
   optimisticEntries: AppServerThreadEntry[];
   pendingAssistantMessage?: AppServerThreadMessageEntry;
+  pendingUsageActivityEntry?: AppServerThreadActivityEntry;
   pendingMcpInteraction?: PendingMcpInteractionState;
   pendingRequest?: AppServerPendingRequestNotification;
   pendingUserInput?: PendingQuestionnaireState;
@@ -176,9 +179,17 @@ function isTerminalTurnEntry(entry: AppServerThreadEntry): boolean {
   }
 
   return (
+    isTokenUsageActivityEntry(entry) ||
     entry.type === "message" &&
     entry.role === "assistant" &&
     entry.phase === "final"
+  );
+}
+
+function isTokenUsageActivityEntry(entry: AppServerThreadEntry): boolean {
+  return (
+    entry.type === "activity" &&
+    (entry.id.startsWith("live-token-usage-") || entry.summary.startsWith("Usage:"))
   );
 }
 
@@ -201,8 +212,36 @@ function mergeTranscriptEntries(
         ? optimisticEntry.createdAt
         : undefined;
     const optimisticSequence = readRendererSequence(optimisticEntry);
+    if (isTokenUsageActivityEntry(optimisticEntry) && optimisticTurnId) {
+      const sameTurnIndex = merged.findLastIndex(
+        (entry) => entry.turn?.id === optimisticTurnId
+      );
+      if (sameTurnIndex !== -1) {
+        merged.splice(sameTurnIndex + 1, 0, optimisticEntry);
+        continue;
+      }
+
+      const usageTimedIndex =
+        typeof optimisticCreatedAt === "number"
+          ? merged.findIndex((entry) => {
+              const entryCreatedAt =
+                typeof entry.createdAt === "number" ? entry.createdAt : undefined;
+              return (
+                typeof entryCreatedAt === "number" &&
+                entryCreatedAt > optimisticCreatedAt
+              );
+            })
+          : -1;
+      if (usageTimedIndex !== -1) {
+        merged.splice(usageTimedIndex, 0, optimisticEntry);
+        continue;
+      }
+    }
+
     const timedIndex =
-      optimisticTurnId && typeof optimisticCreatedAt === "number"
+      optimisticTurnId &&
+      typeof optimisticCreatedAt === "number" &&
+      !isTokenUsageActivityEntry(optimisticEntry)
         ? merged.findIndex((entry) => {
             const entryCreatedAt =
               typeof entry.createdAt === "number" ? entry.createdAt : undefined;
@@ -229,6 +268,22 @@ function mergeTranscriptEntries(
 
     if (timedIndex !== -1) {
       merged.splice(timedIndex, 0, optimisticEntry);
+      continue;
+    }
+
+    const globalTimedIndex =
+      !optimisticTurnId && typeof optimisticCreatedAt === "number"
+        ? merged.findIndex((entry) => {
+            const entryCreatedAt =
+              typeof entry.createdAt === "number" ? entry.createdAt : undefined;
+            return (
+              typeof entryCreatedAt === "number" &&
+              entryCreatedAt > optimisticCreatedAt
+            );
+          })
+        : -1;
+    if (globalTimedIndex !== -1) {
+      merged.splice(globalTimedIndex, 0, optimisticEntry);
       continue;
     }
 
@@ -259,6 +314,226 @@ function mergeTranscriptEntries(
   }
 
   return merged;
+}
+
+function mergeTranscriptMessages(
+  responseMessages: AppServerThreadMessage[],
+  optimisticMessages: AppServerThreadMessage[]
+): AppServerThreadMessage[] {
+  const merged = [...responseMessages];
+
+  for (const optimisticMessage of optimisticMessages) {
+    const existingIndex = merged.findIndex((message) => message.id === optimisticMessage.id);
+    if (existingIndex !== -1) {
+      merged[existingIndex] = optimisticMessage;
+      continue;
+    }
+
+    const optimisticCreatedAt =
+      typeof optimisticMessage.createdAt === "number"
+        ? optimisticMessage.createdAt
+        : undefined;
+    const timedIndex =
+      typeof optimisticCreatedAt === "number"
+        ? merged.findIndex((message) => {
+            const messageCreatedAt =
+              typeof message.createdAt === "number" ? message.createdAt : undefined;
+            return (
+              typeof messageCreatedAt === "number" &&
+              messageCreatedAt > optimisticCreatedAt
+            );
+          })
+        : -1;
+    if (timedIndex !== -1) {
+      merged.splice(timedIndex, 0, optimisticMessage);
+      continue;
+    }
+
+    merged.push(optimisticMessage);
+  }
+
+  return merged;
+}
+
+function isCodexImageBoundaryText(value: string): boolean {
+  const trimmed = value.trim();
+  return /^<image\b[^>]*>$/i.test(trimmed) || /^<\/image>$/i.test(trimmed);
+}
+
+function stripCodexImageBoundaryText(value: string): string {
+  const lines = value.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");
+  if (!lines.some((line) => isCodexImageBoundaryText(line))) {
+    return value;
+  }
+
+  return lines
+    .filter((line) => !isCodexImageBoundaryText(line))
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function stripCodexImageBoundaryParts(
+  parts: AppServerThreadMessagePart[] | undefined
+): AppServerThreadMessagePart[] | undefined {
+  if (!parts?.length) {
+    return parts;
+  }
+
+  let changed = false;
+  const strippedParts = parts.flatMap((part): AppServerThreadMessagePart[] => {
+    if (part.type !== "text") {
+      return [part];
+    }
+
+    const text = stripCodexImageBoundaryText(part.text);
+    changed = changed || text !== part.text;
+    return text ? [{ ...part, text }] : [];
+  });
+
+  if (!changed) {
+    return parts;
+  }
+
+  return strippedParts.length > 0 ? strippedParts : undefined;
+}
+
+function normalizeMessageImageBoundaryText<
+  T extends AppServerThreadMessage | AppServerThreadMessageEntry,
+>(message: T): T {
+  const text = stripCodexImageBoundaryText(message.text);
+  const parts = stripCodexImageBoundaryParts(message.parts);
+  if (text === message.text && parts === message.parts) {
+    return message;
+  }
+
+  const nextMessage = {
+    ...message,
+    text,
+  };
+  if (parts) {
+    return {
+      ...nextMessage,
+      parts,
+    };
+  }
+
+  delete (nextMessage as { parts?: AppServerThreadMessagePart[] }).parts;
+  return nextMessage;
+}
+
+function normalizeResponseImageBoundaryText(
+  response: AppServerReadThreadResponse
+): AppServerReadThreadResponse {
+  let changed = false;
+  const entries = response.replay.entries.map((entry) => {
+    if (entry.type !== "message") {
+      return entry;
+    }
+
+    const normalizedEntry = normalizeMessageImageBoundaryText(entry);
+    changed = changed || normalizedEntry !== entry;
+    return normalizedEntry;
+  });
+  const messages = response.replay.messages.map((message) => {
+    const normalizedMessage = normalizeMessageImageBoundaryText(message);
+    changed = changed || normalizedMessage !== message;
+    return normalizedMessage;
+  });
+
+  if (!changed) {
+    return response;
+  }
+
+  return {
+    ...response,
+    replay: {
+      ...response.replay,
+      entries,
+      messages,
+    },
+  };
+}
+
+function hasImageParts(
+  message: Pick<AppServerThreadMessageEntry | AppServerThreadMessage, "parts">
+): boolean {
+  return Boolean(message.parts?.some((part) => part.type === "image"));
+}
+
+function imageMessageSources(
+  sources: AppServerThreadEntry[]
+): AppServerThreadMessageEntry[] {
+  return sources.filter(
+    (entry): entry is AppServerThreadMessageEntry =>
+      entry.type === "message" && entry.role === "user" && hasImageParts(entry)
+  );
+}
+
+function mergeImagePartsFromSources<
+  T extends AppServerThreadMessage | AppServerThreadMessageEntry,
+>(
+  message: T,
+  sources: AppServerThreadMessageEntry[]
+): T {
+  if (message.role !== "user" || hasImageParts(message)) {
+    return message;
+  }
+
+  const source = sources.find((candidate) =>
+    messageTextMatchesOptimisticEntry(message, candidate)
+  );
+  if (!source?.parts) {
+    return message;
+  }
+
+  return {
+    ...message,
+    parts: source.parts,
+  };
+}
+
+function mergeImagePartsIntoResponse(
+  response: AppServerReadThreadResponse | undefined,
+  sources: AppServerThreadEntry[]
+): AppServerReadThreadResponse | undefined {
+  if (!response || sources.length === 0) {
+    return response;
+  }
+
+  const imageSources = imageMessageSources(sources);
+  if (imageSources.length === 0) {
+    return response;
+  }
+
+  let changed = false;
+  const entries = response.replay.entries.map((entry) => {
+    if (entry.type !== "message") {
+      return entry;
+    }
+
+    const nextEntry = mergeImagePartsFromSources(entry, imageSources);
+    changed = changed || nextEntry !== entry;
+    return nextEntry;
+  });
+  const messages = response.replay.messages.map((message) => {
+    const nextMessage = mergeImagePartsFromSources(message, imageSources);
+    changed = changed || nextMessage !== message;
+    return nextMessage;
+  });
+
+  if (!changed) {
+    return response;
+  }
+
+  return {
+    ...response,
+    replay: {
+      ...response.replay,
+      entries,
+      messages,
+    },
+  };
 }
 
 function buildEmptyResponse(params: {
@@ -299,7 +574,9 @@ function pruneOptimisticEntries(
   return optimisticEntries.filter((entry) => {
     if (entry.type === "message") {
       return !response.replay.messages.some((message) =>
-        messageMatchesOptimisticEntry(message, entry)
+        messageMatchesOptimisticEntry(message, entry, {
+          allowImageUrlMismatch: true,
+        })
       );
     }
 
@@ -380,9 +657,14 @@ function activityEntriesMatch(
     return false;
   }
 
+  const tokenUsageMatch =
+    isTokenUsageActivityEntry(candidate) && isTokenUsageActivityEntry(optimisticEntry);
   return optimisticEntry.details.every((detail) =>
     candidate.details.some((candidateDetail) => {
       if (candidateDetail.id === detail.id) {
+        return true;
+      }
+      if (tokenUsageMatch && candidateDetail.label === detail.label) {
         return true;
       }
       if (detail.command?.displayCommand) {
@@ -417,7 +699,8 @@ function transcriptEntriesMatch(
         parts: candidate.parts,
         createdAt: candidate.createdAt,
       },
-      existingEntry
+      existingEntry,
+      { allowImageUrlMismatch: true }
     );
   }
 
@@ -473,6 +756,7 @@ function carryForwardTranscriptEntryOrder(
     return {
       ...entry,
       createdAt: source.createdAt,
+      ...(source.turn && !entry.turn ? { turn: source.turn } : {}),
     };
   });
 
@@ -510,17 +794,20 @@ function carryForwardTranscriptEntryOrder(
     entries = mergeTranscriptEntries(entries, [source]);
   }
 
-  if (!changed) {
-    return response;
-  }
+  const responseWithOrderedEntries = changed
+    ? {
+        ...response,
+        replay: {
+          ...response.replay,
+          entries,
+        },
+      }
+    : response;
 
-  return {
-    ...response,
-    replay: {
-      ...response.replay,
-      entries,
-    },
-  };
+  return (
+    mergeImagePartsIntoResponse(responseWithOrderedEntries, sources) ??
+    responseWithOrderedEntries
+  );
 }
 
 function latestTranscriptTurnId(entries: AppServerThreadEntry[]): string | undefined {
@@ -1456,9 +1743,10 @@ function appendLiveCommandOutputDelta(
 
 function messageMatchesOptimisticEntry(
   message: AppServerThreadMessage,
-  entry: AppServerThreadMessageEntry
+  entry: AppServerThreadMessageEntry,
+  options: { allowImageUrlMismatch?: boolean } = {}
 ): boolean {
-  if (message.role !== entry.role || message.text !== entry.text) {
+  if (!messageTextMatchesOptimisticEntry(message, entry)) {
     return false;
   }
 
@@ -1468,10 +1756,53 @@ function messageMatchesOptimisticEntry(
   }
 
   const messageImages = (message.parts ?? []).filter((part) => part.type === "image");
+  if (
+    options.allowImageUrlMismatch &&
+    messageImages.length === entryImages.length
+  ) {
+    return true;
+  }
+
   return (
     messageImages.length === entryImages.length &&
     entryImages.every((image, index) => messageImages[index]?.url === image.url)
   );
+}
+
+function messageTextMatchesOptimisticEntry(
+  message: AppServerThreadMessage,
+  entry: AppServerThreadMessageEntry
+): boolean {
+  if (
+    message.role !== entry.role ||
+    stripCodexImageBoundaryText(message.text) !==
+      stripCodexImageBoundaryText(entry.text)
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+function mergeCompletedUserMessageWithOptimisticEntry(
+  message: AppServerThreadMessageEntry,
+  optimisticEntries: AppServerThreadEntry[]
+): AppServerThreadMessageEntry {
+  const optimisticEntry = optimisticEntries.find(
+    (entry): entry is AppServerThreadMessageEntry =>
+      entry.type === "message" &&
+      message.role === "user" &&
+      messageTextMatchesOptimisticEntry(message, entry)
+  );
+  if (!optimisticEntry?.parts?.some((part) => part.type === "image")) {
+    return message;
+  }
+
+  return {
+    ...message,
+    parts: optimisticEntry.parts,
+    createdAt: optimisticEntry.createdAt ?? message.createdAt,
+  };
 }
 
 function appendMessageEntries(
@@ -1503,8 +1834,8 @@ function appendMessageEntries(
     fetchedAt: Date.now(),
     replay: {
       ...baseResponse.replay,
-      entries: mergeItems(baseResponse.replay.entries, entries),
-      messages: mergeItems(baseResponse.replay.messages, nextMessages),
+      entries: mergeTranscriptEntries(baseResponse.replay.entries, entries),
+      messages: mergeTranscriptMessages(baseResponse.replay.messages, nextMessages),
       lastUserMessage,
       lastAssistantMessage,
     },
@@ -2064,10 +2395,10 @@ export function useThreadSessionState(params: {
       }));
 
       try {
-        const response = await readThread({
+        const response = normalizeResponseImageBoundaryText(await readThread({
           backend: targetThread.source,
           threadId: targetThread.id,
-        });
+        }));
 
         if (requestVersionsRef.current[targetThreadKey] !== requestVersion) {
           return;
@@ -2190,7 +2521,12 @@ export function useThreadSessionState(params: {
 
       updateSession(threadKey, (current) => {
         const persistedMessageExists = current.response?.replay.messages.some((message) =>
-          messageMatchesOptimisticEntry(message, optimisticEntry)
+          messageMatchesOptimisticEntry(message, optimisticEntry, {
+            allowImageUrlMismatch: true,
+          })
+        );
+        const persistedTextMessageExists = current.response?.replay.messages.some(
+          (message) => messageTextMatchesOptimisticEntry(message, optimisticEntry)
         );
         const optimisticMessageExists = optimisticMessageEntries(
           current.optimisticEntries
@@ -2203,12 +2539,20 @@ export function useThreadSessionState(params: {
               parts: entry.parts,
               createdAt: entry.createdAt,
             },
-            optimisticEntry
+            optimisticEntry,
+            { allowImageUrlMismatch: true }
           )
         );
 
-        if (persistedMessageExists || optimisticMessageExists) {
-          return current;
+        if (persistedMessageExists || optimisticMessageExists || persistedTextMessageExists) {
+          const response = mergeImagePartsIntoResponse(current.response, [optimisticEntry]);
+          return response && response !== current.response
+            ? {
+                ...current,
+                lastTouchedAt: Date.now(),
+                response,
+              }
+            : current;
         }
 
         return {
@@ -2619,13 +2963,17 @@ export function useThreadSessionState(params: {
             event.notification.params
           );
           if (userMessageEntry) {
+            const completedUserMessageEntry = mergeCompletedUserMessageWithOptimisticEntry(
+              userMessageEntry,
+              current.optimisticEntries
+            );
             const nextResponse = appendMessageEntries(
               current.response,
               {
                 backend: event.backend,
                 threadId: notificationThreadId,
               },
-              [userMessageEntry]
+              [completedUserMessageEntry]
             );
 
             return {
@@ -2636,7 +2984,7 @@ export function useThreadSessionState(params: {
               optimisticEntries: current.optimisticEntries.filter(
                 (entry) =>
                   entry.type !== "message" ||
-                  !messageMatchesOptimisticEntry(userMessageEntry, entry)
+                  !messageTextMatchesOptimisticEntry(completedUserMessageEntry, entry)
               ),
               response: nextResponse,
             };
@@ -2884,6 +3232,10 @@ export function useThreadSessionState(params: {
                 ? { ...entry, turn: completedTurn }
                 : entry
             );
+          const completedUsageActivity =
+            current.pendingUsageActivityEntry && completedTurn
+              ? { ...current.pendingUsageActivityEntry, turn: completedTurn }
+              : current.pendingUsageActivityEntry;
 
           return {
             ...current,
@@ -2916,7 +3268,10 @@ export function useThreadSessionState(params: {
               shouldAppendFinalMessage && completedText
                 ? current.nextLiveEntrySequence + 1
                 : current.nextLiveEntrySequence,
-            optimisticEntries: remainingOptimisticEntries,
+            optimisticEntries:
+              completedTurnMatchesActive && completedUsageActivity
+                ? mergeItems(remainingOptimisticEntries, [completedUsageActivity])
+                : remainingOptimisticEntries,
             pendingAssistantMessage: completedTurnMatchesActive
               ? undefined
               : current.pendingAssistantMessage,
@@ -2926,6 +3281,9 @@ export function useThreadSessionState(params: {
             pendingRequest: completedTurnMatchesActive
               ? undefined
               : current.pendingRequest,
+            pendingUsageActivityEntry: completedTurnMatchesActive
+              ? undefined
+              : current.pendingUsageActivityEntry,
             pendingUserInput: completedTurnMatchesActive
               ? undefined
               : current.pendingUserInput,
@@ -2964,6 +3322,7 @@ export function useThreadSessionState(params: {
             pendingAssistantMessage: undefined,
             pendingMcpInteraction: undefined,
             pendingRequest: undefined,
+            pendingUsageActivityEntry: undefined,
             pendingUserInput: undefined,
             pendingStatusText: undefined,
           };
@@ -2991,6 +3350,7 @@ export function useThreadSessionState(params: {
             pendingAssistantMessage: undefined,
             pendingMcpInteraction: undefined,
             pendingRequest: undefined,
+            pendingUsageActivityEntry: undefined,
             pendingUserInput: undefined,
             pendingStatusText: undefined,
           };
@@ -3029,6 +3389,7 @@ export function useThreadSessionState(params: {
             failedHydrationVersion: undefined,
             hydratedUpdatedAt: undefined,
             lastTouchedAt: nextLastTouchedAt,
+            pendingUsageActivityEntry: undefined,
             pendingStatusText: undefined,
             response: undefined,
           };
@@ -3038,14 +3399,52 @@ export function useThreadSessionState(params: {
           const contextWindow = normalizeThreadContextWindowState(
             event.notification.params.tokenUsage
           );
-          if (!contextWindow) {
+          const turn = buildTurnMetadata({
+            fallbackId:
+              typeof event.notification.params.turnId === "string"
+                ? event.notification.params.turnId
+                : current.activeTurnId,
+            fallbackStartedAt: current.activeTurnStartedAt,
+            fallbackStatus: current.activeTurnId ? "in_progress" : "completed",
+          });
+          const usageEntry = buildTokenUsageActivityEntry({
+            id: `live-token-usage-${turn?.id ?? notificationThreadId}`,
+            model:
+              thread?.source === event.backend && thread.id === notificationThreadId
+                ? thread.model
+                : undefined,
+            tokenUsage: event.notification.params.tokenUsage,
+            turn,
+          });
+          if (!contextWindow && !usageEntry) {
             return current;
           }
 
+          const holdUsageUntilTurnCompletes = Boolean(
+            usageEntry &&
+              current.activeTurnId &&
+              turn?.id === current.activeTurnId &&
+              turn.status !== "completed"
+          );
+
           return {
             ...current,
-            contextWindow,
+            ...(contextWindow ? { contextWindow } : {}),
+            expectOwnUpdate:
+              usageEntry && !holdUsageUntilTurnCompletes
+                ? true
+                : current.expectOwnUpdate,
+            interacted:
+              usageEntry && !holdUsageUntilTurnCompletes
+                ? true
+                : current.interacted,
             lastTouchedAt: nextLastTouchedAt,
+            optimisticEntries: usageEntry && !holdUsageUntilTurnCompletes
+              ? mergeItems(current.optimisticEntries, [usageEntry])
+              : current.optimisticEntries,
+            pendingUsageActivityEntry: holdUsageUntilTurnCompletes
+              ? usageEntry
+              : current.pendingUsageActivityEntry,
           };
         }
 
@@ -3385,7 +3784,7 @@ export function useThreadSessionState(params: {
 
   const messages = useMemo(
     () => {
-      const mergedMessages = mergeItems(
+      const mergedMessages = mergeTranscriptMessages(
         selectedSession?.response?.replay.messages ?? [],
         visibleOptimisticEntries
           .filter((entry): entry is AppServerThreadMessageEntry => entry.type === "message")

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -6605,6 +6605,51 @@ textarea,
   object-fit: contain;
 }
 
+.transcript-message__image-fallback {
+  box-sizing: border-box;
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  justify-self: start;
+  max-width: min(100%, 640px);
+  padding: 10px 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-panel-elevated);
+}
+
+.transcript-message__image-fallback-main {
+  display: grid;
+  min-width: 0;
+  gap: 4px;
+}
+
+.transcript-message__image-fallback-title {
+  color: var(--text-primary);
+  font-size: 0.86rem;
+  font-weight: 650;
+}
+
+.transcript-message__image-fallback-path {
+  display: block;
+  max-width: 100%;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 0.78rem;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+  user-select: text;
+  white-space: normal;
+  word-break: break-word;
+}
+
+.transcript-copy-button--image-path {
+  flex: 0 0 auto;
+  opacity: 1;
+}
+
 .thread-header__summary .transcript-message__paragraph,
 .thread-header__summary .transcript-message__list,
 .thread-header__summary .transcript-message__blockquote {


### PR DESCRIPTION
## Summary

This PR adds desktop transcript token/cost accounting for Codex-reported usage, including cached input, uncached input, output, reasoning tokens, and a list-price estimate for known OpenAI models. Unknown model pricing stays explicit rather than inferred.

It also reduces pasted image token and transport overhead by preserving unchanged PNG/JPEG bytes where possible and materializing image inputs as stable local image files instead of repeatedly sending base64 data URLs through JSON-RPC. Identical pasted pixels now reuse a content-addressed file path.

During dogfooding, this exposed transcript hydration regressions around image turns, so the PR also hardens image-message parsing and reconciliation: Codex image boundary marker text is stripped, optimistic user messages are deduped against hydrated durable turns, local image parts are preserved after completion, durable `localImage` content parts from `thread/read` render correctly after app restart, and transcript image previews load local PwrAgent/Codex image files through a scoped `pwragent-image://` protocol with a copyable fallback when loading still fails.

Fixes pwrdrvr/PwrAgent#420.

## Testing

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts apps/desktop/src/main/__tests__/codex-client.test.ts apps/desktop/src/renderer/src/lib/__tests__/image-normalization.test.ts apps/desktop/src/main/__tests__/image-input-files.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/main/__tests__/transcript-image-protocol.test.ts apps/desktop/src/main/__tests__/index.test.ts`
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)