### PR TITLE
fix(desktop): prevent queued review dispatch race

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1310,6 +1310,13 @@ export function Composer(props: ComposerProps) {
     savedInitialQueuedTurns ?? []
   );
   const queuedAutoReleaseAttemptIdRef = useRef<string | undefined>(undefined);
+  const serverQueuedTurnEntryIdRef = useRef<string | undefined>(undefined);
+  const [serverQueuedTurnEntryId, setServerQueuedTurnEntryIdState] =
+    useState<string>();
+  const updateServerQueuedTurnEntryId = (nextEntryId?: string): void => {
+    serverQueuedTurnEntryIdRef.current = nextEntryId;
+    setServerQueuedTurnEntryIdState(nextEntryId);
+  };
   const [pendingSteer, setPendingSteerState] = useState<
     PendingSteerDraft | undefined
   >(
@@ -2021,6 +2028,7 @@ export function Composer(props: ComposerProps) {
     updateSending(false);
     setInterrupting(false);
     setSteering(false);
+    updateServerQueuedTurnEntryId(undefined);
     updateActiveTurnId(undefined);
     setActiveOptimisticMessageId(undefined);
     setReviewConfig(undefined);
@@ -2145,6 +2153,7 @@ export function Composer(props: ComposerProps) {
     updateSending(false);
     setInterrupting(false);
     setSteering(false);
+    updateServerQueuedTurnEntryId(undefined);
     updateActiveTurnId(undefined);
     setActiveOptimisticMessageId(undefined);
     setReviewConfig(undefined);
@@ -2205,9 +2214,40 @@ export function Composer(props: ComposerProps) {
         event.notification.params.turn !== null
           ? (event.notification.params.turn as { id?: unknown })
           : undefined;
+      const turnQueueRecord =
+        event.notification.method === "thread/turnQueue/updated" &&
+        typeof event.notification.params === "object" &&
+        event.notification.params !== null
+          ? (event.notification.params as {
+              queueEntryId?: unknown;
+              status?: unknown;
+              turnId?: unknown;
+            })
+          : undefined;
 
       if (event.backend !== thread.source || notificationThreadId !== thread.id) {
         return;
+      }
+
+      if (
+        typeof turnQueueRecord?.queueEntryId === "string" &&
+        turnQueueRecord.queueEntryId === serverQueuedTurnEntryIdRef.current
+      ) {
+        if (
+          turnQueueRecord.status === "started" &&
+          typeof turnQueueRecord.turnId === "string"
+        ) {
+          updateActiveTurnId(turnQueueRecord.turnId);
+          props.onActiveTurnIdChange?.(turnQueueRecord.turnId);
+          props.onPendingStatusChange?.("Thinking");
+        }
+        if (
+          turnQueueRecord.status === "terminal" ||
+          turnQueueRecord.status === "failed" ||
+          turnQueueRecord.status === "cancelled"
+        ) {
+          updateServerQueuedTurnEntryId(undefined);
+        }
       }
 
       if (
@@ -2540,7 +2580,9 @@ export function Composer(props: ComposerProps) {
           ? Boolean(currentSettings?.fastMode)
           : undefined,
       });
-      if (response.queueStatus !== "queued") {
+      if (response.queueStatus === "queued") {
+        updateServerQueuedTurnEntryId(response.queueEntryId ?? response.turnId);
+      } else {
         updateActiveTurnId(response.turnId);
         props.onActiveTurnIdChange?.(response.turnId);
       }
@@ -2599,7 +2641,14 @@ export function Composer(props: ComposerProps) {
       queuedAutoReleaseAttemptIdRef.current = undefined;
       return;
     }
-    if (!queuedTurn || activeTurnId || sending || props.launchpad || props.disabled) {
+    if (
+      !queuedTurn ||
+      activeTurnId ||
+      serverQueuedTurnEntryId ||
+      sending ||
+      props.launchpad ||
+      props.disabled
+    ) {
       return;
     }
     if (queuedAutoReleaseAttemptIdRef.current === queuedTurn.id) {
@@ -2611,7 +2660,14 @@ export function Composer(props: ComposerProps) {
     void sendQueuedTurn(queuedTurn).finally(() => {
       updateSending(false);
     });
-  }, [activeTurnId, queuedTurn, sending, props.disabled, props.launchpad]);
+  }, [
+    activeTurnId,
+    queuedTurn,
+    serverQueuedTurnEntryId,
+    sending,
+    props.disabled,
+    props.launchpad,
+  ]);
 
   useEffect(() => {
     if (
@@ -2687,7 +2743,10 @@ export function Composer(props: ComposerProps) {
   };
 
   const shouldQueueThreadSubmit = (): boolean =>
-    !props.launchpad && (Boolean(activeTurnIdRef.current) || sendingRef.current);
+    !props.launchpad &&
+    (Boolean(activeTurnIdRef.current) ||
+      Boolean(serverQueuedTurnEntryIdRef.current) ||
+      sendingRef.current);
 
   const submitPendingSteer = async (pending: QueuedTurnDraft): Promise<void> => {
     const turnId = activeTurnIdRef.current;
@@ -3469,6 +3528,7 @@ export function Composer(props: ComposerProps) {
       props.thread.workspaceHandoff?.available !== false &&
       !sending &&
       !activeTurnId &&
+      !serverQueuedTurnEntryId &&
       !props.pendingRequestActive &&
       !props.pendingUserInputActive &&
       !handoffSubmitting
@@ -5099,7 +5159,7 @@ export function Composer(props: ComposerProps) {
             }
             type="submit"
           >
-            {activeTurnId
+            {activeTurnId || serverQueuedTurnEntryId
               ? "Queue"
               : sending
               ? props.launchpad

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1327,6 +1327,234 @@ describe("Composer", () => {
     );
   });
 
+  it("keeps a queued review local when the previous queued turn lands in the server queue", async () => {
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex";
+          notification: {
+            method: string;
+            params: Record<string, unknown>;
+          };
+        }) => void)
+      | undefined;
+    const startTurn = vi.fn(async (request: StartTurnRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      turnId: "server-queue-entry-1",
+      queueStatus: "queued" as const,
+      queueEntryId: "server-queue-entry-1",
+    }));
+    const startReview = vi.fn(async (request: StartReviewRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      reviewThreadId: request.threadId,
+      turnId: "turn-review-1",
+    }));
+    const baseProps = {
+      backends: [backendSummary("codex")],
+      desktopApi: {
+        onAgentEvent: (callback: NonNullable<DesktopApi["onAgentEvent"]> extends (
+          listener: infer Listener,
+        ) => unknown
+          ? Listener
+          : never) => {
+          agentEventHandler = callback as typeof agentEventHandler;
+          return () => undefined;
+        },
+        startReview,
+        startTurn,
+      },
+      disabled: false,
+      skills: [],
+      thread: {
+        id: "thread-1",
+        title: "Server queue race",
+        titleSource: "explicit" as const,
+        source: "codex" as const,
+        executionMode: "default" as const,
+        linkedDirectories: [],
+        inbox: { inInbox: false },
+      },
+    };
+
+    const { rerender } = render(
+      <Composer
+        {...baseProps}
+        activeTurnId="turn-1"
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "make a branch and PR" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    fireEvent.change(textarea, { target: { value: "/review main" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+      "make a branch and PR"
+    );
+    expect(screen.getByLabelText("Queued message 2")).toHaveTextContent(
+      "Review changes against main"
+    );
+
+    rerender(<Composer {...baseProps} activeTurnId={undefined} />);
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          backend: "codex",
+          threadId: "thread-1",
+          input: [{ type: "text", text: "make a branch and PR" }],
+        })
+      );
+    });
+    await flushReactUpdates();
+
+    expect(startReview).not.toHaveBeenCalled();
+    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+      "Review changes against main"
+    );
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "thread/turnQueue/updated",
+          params: {
+            threadId: "thread-1",
+            queueEntryId: "server-queue-entry-1",
+            status: "started",
+            turnId: "turn-2",
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-2",
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "thread/turnQueue/updated",
+          params: {
+            threadId: "thread-1",
+            queueEntryId: "server-queue-entry-1",
+            status: "terminal",
+            turnId: "turn-2",
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(startReview).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        target: { type: "baseBranch", branch: "main" },
+        delivery: "inline",
+      });
+    });
+  });
+
+  it("resets server queued turn state when switching composer scopes", async () => {
+    const startTurn = vi.fn(async (request: StartTurnRequest) => {
+      if (request.threadId === "thread-1") {
+        return {
+          backend: request.backend,
+          threadId: request.threadId,
+          turnId: "server-queue-entry-1",
+          queueStatus: "queued" as const,
+          queueEntryId: "server-queue-entry-1",
+        };
+      }
+
+      return {
+        backend: request.backend,
+        threadId: request.threadId,
+        turnId: "turn-thread-2",
+      };
+    });
+    const baseProps = {
+      backends: [backendSummary("codex")],
+      desktopApi: {
+        onAgentEvent: () => () => undefined,
+        startTurn,
+      },
+      disabled: false,
+      skills: [],
+    };
+    const threadA = {
+      id: "thread-1",
+      title: "Server queued thread",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      executionMode: "default" as const,
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const threadB = {
+      ...threadA,
+      id: "thread-2",
+      title: "Other thread",
+    };
+
+    const { rerender } = render(
+      <Composer
+        {...baseProps}
+        activeTurnId="turn-1"
+        thread={threadA}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "make a branch and PR" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    rerender(
+      <Composer
+        {...baseProps}
+        activeTurnId={undefined}
+        thread={threadA}
+      />
+    );
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          threadId: "thread-1",
+          input: [{ type: "text", text: "make a branch and PR" }],
+        })
+      );
+    });
+    await flushReactUpdates();
+
+    rerender(
+      <Composer
+        {...baseProps}
+        activeTurnId={undefined}
+        thread={threadB}
+      />
+    );
+
+    const nextTextarea = screen.getByLabelText("Reply");
+    fireEvent.change(nextTextarea, { target: { value: "work on thread two" } });
+    await clickButton("Send");
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          threadId: "thread-2",
+          input: [{ type: "text", text: "work on thread two" }],
+        })
+      );
+    });
+  });
+
   it("does not remove the next queued message when the in-flight queued chip is edited", async () => {
     let resolveStartTurn: ((value: StartTurnResponse) => void) | undefined;
     const startTurn = vi.fn(


### PR DESCRIPTION
## Summary

Fixes a composer queue race where a local queued follow-up could dispatch immediately after the previous queued turn was accepted into the main-process server queue. In that state the thread is not locally active yet, but it is still not safe to start the next `/review`; the backend rejects it with “Thread already has an active turn in progress.”

## Changes

- Track the server queue entry returned by `startTurn` when `queueStatus: "queued"`.
- Treat that server-queued entry as an active blocker for local composer submission and auto-release logic.
- Clear the blocker only when the matching `thread/turnQueue/updated` lifecycle reports terminal, failed, or cancelled.
- Add a regression test covering `make a branch and PR` followed by queued `/review main`.

## Verification

- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
