### PR TITLE
fix(desktop): make activity errors copyable

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptActivity.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptActivity.tsx
@@ -1,9 +1,12 @@
 import { useId, useState } from "react";
 import type { AppServerThreadActivityEntry } from "@pwragent/shared";
+import type { DesktopApi } from "../../lib/desktop-api";
 import { TranscriptCommandOutput } from "./TranscriptCommandOutput";
+import { TranscriptCopyButton } from "./TranscriptCopyButton";
 import { TranscriptDiff } from "./TranscriptDiff";
 
 type TranscriptActivityProps = {
+  desktopApi?: Pick<DesktopApi, "copyText">;
   entry: AppServerThreadActivityEntry;
 };
 
@@ -12,6 +15,7 @@ export function TranscriptActivity(props: TranscriptActivityProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   const [expandedDetailIds, setExpandedDetailIds] = useState(() => new Set<string>());
   const hasDetails = props.entry.details.length > 0;
+  const activityCopyText = buildActivityCopyText(props.entry);
   const className =
     props.entry.tone === "warning"
       ? "transcript-activity transcript-activity--warning"
@@ -21,17 +25,27 @@ export function TranscriptActivity(props: TranscriptActivityProps) {
     <aside className={className}>
       <header className="transcript-activity__header">
         {hasDetails ? (
-          <button
-            type="button"
-            className="transcript-activity__toggle"
-            aria-controls={detailsId}
-            aria-expanded={isExpanded}
-            onClick={() => {
-              setIsExpanded((current) => !current);
-            }}
-          >
-            <span className="transcript-activity__label">{props.entry.summary}</span>
-            <span className="transcript-activity__meta">
+          <>
+            <button
+              type="button"
+              className="transcript-activity__toggle"
+              aria-controls={detailsId}
+              aria-expanded={isExpanded}
+              onClick={() => {
+                setIsExpanded((current) => !current);
+              }}
+            >
+              <span className="transcript-activity__label">{props.entry.summary}</span>
+              <span className="transcript-activity__chevron" aria-hidden="true" />
+            </button>
+            <span className="transcript-activity__header-actions">
+              <TranscriptCopyButton
+                className="transcript-copy-button--activity"
+                copiedLabel="Copied activity"
+                desktopApi={props.desktopApi}
+                label="Copy activity"
+                text={activityCopyText}
+              />
               {props.entry.createdAt ? (
                 <time className="transcript-activity__time">
                   {new Intl.DateTimeFormat(undefined, {
@@ -42,22 +56,30 @@ export function TranscriptActivity(props: TranscriptActivityProps) {
                   }).format(props.entry.createdAt)}
                 </time>
               ) : null}
-              <span className="transcript-activity__chevron" aria-hidden="true" />
             </span>
-          </button>
+          </>
         ) : (
           <>
             <span className="transcript-activity__label">{props.entry.summary}</span>
-            {props.entry.createdAt ? (
-              <time className="transcript-activity__time">
-                {new Intl.DateTimeFormat(undefined, {
-                  month: "short",
-                  day: "numeric",
-                  hour: "numeric",
-                  minute: "2-digit"
-                }).format(props.entry.createdAt)}
-              </time>
-            ) : null}
+            <span className="transcript-activity__header-actions">
+              <TranscriptCopyButton
+                className="transcript-copy-button--activity"
+                copiedLabel="Copied activity"
+                desktopApi={props.desktopApi}
+                label="Copy activity"
+                text={activityCopyText}
+              />
+              {props.entry.createdAt ? (
+                <time className="transcript-activity__time">
+                  {new Intl.DateTimeFormat(undefined, {
+                    month: "short",
+                    day: "numeric",
+                    hour: "numeric",
+                    minute: "2-digit"
+                  }).format(props.entry.createdAt)}
+                </time>
+              ) : null}
+            </span>
           </>
         )}
       </header>
@@ -142,6 +164,12 @@ export function TranscriptActivity(props: TranscriptActivityProps) {
       ) : null}
     </aside>
   );
+}
+
+function buildActivityCopyText(entry: AppServerThreadActivityEntry): string {
+  return [entry.summary, ...entry.details.map((detail) => detail.label)]
+    .filter((text) => text.trim().length > 0)
+    .join("\n");
 }
 
 function formatActivityDetailStatus(

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -832,7 +832,7 @@ export function TranscriptList(props: TranscriptListProps) {
                   }}
                 />
               ) : item.entry.type === "activity" ? (
-                <TranscriptActivity entry={item.entry} />
+                <TranscriptActivity desktopApi={props.desktopApi} entry={item.entry} />
               ) : item.entry.type === "plan" ? (
                 <TranscriptPlan
                   applications={props.applications}

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptWorkPhaseGroup.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptWorkPhaseGroup.tsx
@@ -82,7 +82,7 @@ function renderEntry(params: {
 }) {
   const entry = params.entry;
   return entry.type === "activity" ? (
-    <TranscriptActivity key={entry.id} entry={entry} />
+    <TranscriptActivity key={entry.id} desktopApi={params.desktopApi} entry={entry} />
   ) : entry.type === "plan" ? (
     <TranscriptPlan
       key={entry.id}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -408,6 +408,53 @@ describe("TranscriptList", () => {
     });
   });
 
+  it("copies failed activity details from the transcript", async () => {
+    const copyText = vi.fn(async () => undefined);
+
+    render(
+      <TranscriptList
+        desktopApi={{ copyText }}
+        entries={[
+          {
+            type: "activity",
+            id: "turn-failed:turn-1",
+            summary: "Turn failed",
+            status: "failed",
+            tone: "warning",
+            details: [
+              {
+                id: "turn-failed:turn-1:detail",
+                kind: "read",
+                label: "json-rpc error (-32603): Internal error: invalid API key",
+                status: "failed",
+              },
+            ],
+          },
+        ]}
+        loading={false}
+        loadingMore={false}
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    const activity = screen.getByText("Turn failed").closest(".transcript-activity");
+    expect(activity).toHaveClass("transcript-activity--warning");
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy activity" }));
+
+    await waitFor(() => {
+      expect(copyText).toHaveBeenCalledWith(
+        "Turn failed\njson-rpc error (-32603): Internal error: invalid API key"
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Turn failed/i }));
+
+    expect(
+      screen.getByText("json-rpc error (-32603): Internal error: invalid API key")
+    ).toBeInTheDocument();
+  });
+
   it("preserves reference-style links inside split wide markdown tables", () => {
     const { container } = render(
       <TranscriptList
@@ -1115,6 +1162,58 @@ describe("TranscriptList", () => {
 
     await waitFor(() => {
       expect(screen.getByRole("button", { name: /Used 2 tools/i })).toBeVisible();
+    });
+  });
+
+  it("copies grouped work activity details through the injected desktop API", async () => {
+    const copyText = vi.fn(async () => undefined);
+    const completedTurn = {
+      id: "turn-1",
+      status: "completed" as const,
+      startedAt: 1_000,
+      completedAt: 72_000,
+      durationMs: 71_000,
+    };
+
+    render(
+      <TranscriptList
+        desktopApi={{ copyText }}
+        entries={[
+          {
+            type: "activity",
+            id: "tool-usage-1",
+            summary: "Used 2 tools",
+            details: [
+              {
+                id: "tool-detail-1",
+                kind: "command",
+                label: "rg -n transcript activity",
+              },
+            ],
+            turn: completedTurn,
+          },
+          {
+            type: "message",
+            id: "message-2",
+            role: "assistant",
+            text: "Fixed.",
+            turn: completedTurn,
+          },
+        ]}
+        loading={false}
+        loadingMore={false}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Worked for 1m 11s/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Copy activity" }));
+
+    await waitFor(() => {
+      expect(copyText).toHaveBeenCalledWith(
+        "Used 2 tools\nrg -n transcript activity"
+      );
     });
   });
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -6212,7 +6212,8 @@ textarea,
 
 @media (hover: none) {
   .transcript-copy-button--message,
-  .transcript-copy-button--section {
+  .transcript-copy-button--section,
+  .transcript-copy-button--activity {
     opacity: 1;
   }
 }
@@ -6648,6 +6649,8 @@ textarea,
   width: min(100%, 760px);
   padding: 12px 0 0;
   border-top: 1px solid var(--border-subtle);
+  -webkit-user-select: text;
+  user-select: text;
 }
 
 .transcript-activity--warning {
@@ -7367,7 +7370,8 @@ textarea,
 
 .transcript-activity__toggle {
   display: flex;
-  width: 100%;
+  min-width: 0;
+  flex: 1 1 auto;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
@@ -7386,16 +7390,24 @@ textarea,
 }
 
 .transcript-activity__label {
+  min-width: 0;
   font-size: 13px;
   font-weight: 600;
   color: var(--text-secondary);
+  overflow-wrap: anywhere;
 }
 
-.transcript-activity__meta {
+.transcript-activity__header-actions {
   display: inline-flex;
   flex: 0 0 auto;
   align-items: center;
   gap: 8px;
+}
+
+.transcript-activity:hover .transcript-copy-button--activity,
+.transcript-activity:focus-within .transcript-copy-button--activity,
+.transcript-copy-button--activity[data-copied="true"] {
+  opacity: 1;
 }
 
 .transcript-activity__time {


### PR DESCRIPTION
## Summary

Transcript activity and error cards can now be selected and copied like normal message bubbles. Failed-turn cards expose the shared transcript copy button and copy the summary plus error details, so users can grab JSON-RPC/API-key failures without retyping them. The activity header still keeps its expand/collapse behavior while matching the existing hover, focus, and touch affordances used elsewhere in the transcript.

## Tests

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)
