### PR TITLE
fix(desktop): filter generated codex app chats

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -1149,6 +1149,90 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("filters generated app chats without hiding normal project threads", async () => {
+    MockTransport.threadListResultBySearchTerm.set("generated-app-chat-filter", [
+      {
+        id: "thread-runtime-context",
+        preview:
+          "<runtime_context source=\"pwrsnap\" note=\"runtime-generated, not user-authored\">\n<current_reel id=\"sz_123\">",
+        updatedAt: 1_777_500_000,
+        cwd: "/Users/huntharo/Documents/PwrSnap/Chats/2026-05-30-004-chat-2026-05-30",
+      },
+      {
+        id: "thread-dated-chat-directory",
+        name: "Make those voiceovers spicier",
+        updatedAt: 1_777_400_000,
+        cwd: "/Users/huntharo/Documents/PwrSnap/Chats/2026-05-29-PwrSnap-8dd7bd",
+      },
+      {
+        id: "thread-runtime-context-in-project",
+        preview:
+          "<runtime_context source=\"pwrsnap\" note=\"runtime-generated, not user-authored\">\n<current_capture id=\"cap_123\">",
+        updatedAt: 1_777_350_000,
+        cwd: "/Users/huntharo/github/PwrSnap/apps/desktop",
+        gitInfo: {
+          branch: "main",
+          originUrl: "git@github.com:pwrdrvr/PwrSnap.git",
+        },
+      },
+      {
+        id: "thread-pwrsnap-project",
+        name: "PwrSnap feature work",
+        updatedAt: 1_777_300_000,
+        cwd: "/Users/huntharo/github/PwrSnap",
+        gitInfo: {
+          branch: "main",
+          originUrl: "git@github.com:pwrdrvr/PwrSnap.git",
+        },
+      },
+      {
+        id: "thread-managed-workspace",
+        name: "PwrAgent workspace chat",
+        updatedAt: 1_777_200_000,
+        cwd: "/Users/huntharo/.pwragent/profiles/default/projects/2026-05-30-ab12cd",
+      },
+      {
+        id: "thread-without-directory",
+        name: "Inbox-only chat",
+        updatedAt: 1_777_100_000,
+      },
+    ]);
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const threadDirectoryEnricher = vi.fn(async (projectKey?: string) => ({
+      linkedDirectories: projectKey
+        ? [
+            {
+              id: projectKey,
+              label: path.basename(projectKey),
+              path: projectKey,
+              kind: "local" as const,
+            },
+          ]
+        : [],
+    }));
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      threadDirectoryEnricher,
+    });
+
+    const threads = await client.listThreads({ filter: "generated-app-chat-filter" });
+
+    expect(threads.map((thread) => thread.id)).toEqual([
+      "thread-pwrsnap-project",
+      "thread-managed-workspace",
+      "thread-without-directory",
+    ]);
+    expect(threadDirectoryEnricher).not.toHaveBeenCalledWith(
+      "/Users/huntharo/Documents/PwrSnap/Chats/2026-05-30-004-chat-2026-05-30",
+    );
+    expect(threadDirectoryEnricher).not.toHaveBeenCalledWith(
+      "/Users/huntharo/Documents/PwrSnap/Chats/2026-05-29-PwrSnap-8dd7bd",
+    );
+
+    await client.close();
+  });
+
   it("uses protocol originator when Codex exposes it directly", async () => {
     MockTransport.threadListResultBySearchTerm.set("protocol-originator-filter", [
       {
@@ -1635,8 +1719,8 @@ describe("CodexAppServerClient", () => {
         expect.objectContaining({
           id: "thread-forked-worktree",
           projectKey: "/Users/huntharo/.codex/worktrees/be87/search-product",
-          linkedDirectories: []
-        })
+          linkedDirectories: [],
+        }),
       ]);
       expect(readFileMock).not.toHaveBeenCalled();
 

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -155,6 +155,7 @@ type RawCodexThreadSummary = Omit<
   originator?: string;
   projectKey?: string;
   gitOriginUrl?: string;
+  rawPreview?: string;
 };
 
 type RawCodexThreadListPage = {
@@ -947,7 +948,51 @@ function isAllowedCodexSessionOriginator(value: string | undefined): boolean {
 function filterVisibleCodexThreads(
   threads: RawCodexThreadSummary[]
 ): RawCodexThreadSummary[] {
-  return threads.filter((thread) => isAllowedCodexSessionOriginator(thread.originator));
+  return threads.filter(
+    (thread) =>
+      isAllowedCodexSessionOriginator(thread.originator) &&
+      !isGeneratedAppRuntimeThread(thread),
+  );
+}
+
+function normalizeAbsoluteDirectoryPath(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed || !path.isAbsolute(trimmed)) {
+    return undefined;
+  }
+  return path.resolve(trimmed);
+}
+
+function hasRuntimeGeneratedContext(value: string | undefined): boolean {
+  const normalized = value?.trim().toLowerCase();
+  return Boolean(
+    normalized?.startsWith("<runtime_context") &&
+      normalized.includes("runtime-generated") &&
+      normalized.includes("not user-authored"),
+  );
+}
+
+function isDatedChatsDirectory(projectKey: string | undefined): boolean {
+  const directoryPath = normalizeAbsoluteDirectoryPath(projectKey);
+  if (!directoryPath) {
+    return false;
+  }
+
+  const parentName = path.basename(path.dirname(directoryPath)).toLowerCase();
+  const directoryName = path.basename(directoryPath);
+  return parentName === "chats" && /^\d{4}-\d{2}-\d{2}(?:$|[-_])/.test(directoryName);
+}
+
+function isGeneratedAppRuntimeThread(thread: RawCodexThreadSummary): boolean {
+  if (
+    hasRuntimeGeneratedContext(thread.rawPreview) ||
+    hasRuntimeGeneratedContext(thread.title) ||
+    hasRuntimeGeneratedContext(thread.summary)
+  ) {
+    return true;
+  }
+
+  return !thread.gitOriginUrl && isDatedChatsDirectory(thread.projectKey);
 }
 
 function isPlaceholderThreadTitle(value: string | undefined): boolean {
@@ -3279,6 +3324,7 @@ function extractThreadsFromValue(value: unknown): RawCodexThreadSummary[] {
           summary === normalizeThreadSummary(rawDerivedTitle))
           ? undefined
           : summary,
+      rawPreview: rawDerivedTitle,
       originator,
       projectKey,
       model:
@@ -4328,9 +4374,12 @@ export class CodexAppServerClient {
         filter: params?.filter,
         requestTimeoutMs: requestParams.timeoutMs,
       });
-      return await this.enrichThreads(filterVisibleCodexThreads(archivedThreads), {
-        enrichDirectories: params?.enrichDirectories ?? true,
-      });
+      return await this.enrichThreads(
+        filterVisibleCodexThreads(archivedThreads),
+        {
+          enrichDirectories: params?.enrichDirectories ?? true,
+        },
+      );
     }
 
     const activeThreads = filterVisibleCodexThreads(
@@ -4427,6 +4476,7 @@ export class CodexAppServerClient {
         const {
           gitOriginUrl: _gitOriginUrl,
           originator: _originator,
+          rawPreview: _rawPreview,
           ...publicThread
         } = thread;
         const projectKey = publicThread.projectKey?.trim() || undefined;
@@ -4469,6 +4519,7 @@ export class CodexAppServerClient {
         const enrichment = await this.threadDirectoryEnricher(projectKey);
         const {
           originator: _originator,
+          rawPreview: _rawPreview,
           ...publicThread
         } = thread;
         return {


### PR DESCRIPTION
## Summary

- Keep normal Codex Desktop project threads visible, including PwrSnap repo/worktree sessions.
- Filter generated app chat sessions from protocol-returned metadata: explicit runtime-generated context and dated `Chats/<date...>` cwd folders without repo metadata.
- Add regression coverage for PwrSnap-style generated chats without reading Codex-owned JSONL or sqlite files.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/codex-client.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:codex-storage`
- `pnpm lint:boundaries`
- `git diff --check`

## Notes

- Uses only `thread/list` protocol metadata; does not inspect Codex-owned storage.
