### PR TITLE
fix(desktop): diagnose environment action spawn failures

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
@@ -10,7 +10,7 @@ import {
 } from "../app-server/codex-environment-runtime";
 
 describe("codex environment runtime", () => {
-  it("rejects detached actions that fail before spawn", async () => {
+  it("rejects detached actions with a clear missing-cwd error before spawn", async () => {
     await expect(
       startLocalCodexEnvironmentAction({
         actionId: "start-dev",
@@ -29,7 +29,9 @@ describe("codex environment runtime", () => {
           ],
         },
       }),
-    ).rejects.toThrow();
+    ).rejects.toThrow(
+      "Codex environment working directory does not exist: /definitely/not/a/pwragent/worktree",
+    );
   });
 
   it("runs detached actions with the provided hydrated environment", async () => {
@@ -142,6 +144,48 @@ describe("codex environment runtime", () => {
           return output;
         }),
       ).resolves.toBe(expectedOutput);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back when the hydrated shell path is stale", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-env-shell-fallback-"));
+    const outputPath = path.join(root, "env.txt");
+
+    try {
+      const result = await startLocalCodexEnvironmentAction({
+        actionId: "start-dev",
+        runId: "test-run-shell-fallback",
+        env: {
+          ...process.env,
+          SHELL: path.join(root, "missing-shell"),
+        },
+        runtime: {
+          environmentId: "env",
+          environmentName: "Env",
+          executionTarget: "local",
+          cwd: root,
+          actions: [
+            {
+              id: "start-dev",
+              name: "Start dev",
+              command: `printf fallback > ${JSON.stringify(outputPath)}`,
+            },
+          ],
+        },
+      });
+
+      expect(result.actionRuns).toEqual([
+        expect.objectContaining({
+          runId: "test-run-shell-fallback",
+          actionId: "start-dev",
+          status: "started",
+        }),
+      ]);
+      await expect(
+        expectEventually(async () => await readFile(outputPath, "utf8")),
+      ).resolves.toBe("fallback");
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
@@ -191,6 +191,48 @@ describe("codex environment runtime", () => {
     }
   });
 
+  it("falls back when the stale hydrated shell is a Windows absolute path", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-env-win-shell-fallback-"));
+    const outputPath = path.join(root, "env.txt");
+
+    try {
+      const result = await startLocalCodexEnvironmentAction({
+        actionId: "start-dev",
+        runId: "test-run-win-shell-fallback",
+        env: {
+          ...process.env,
+          SHELL: "C:\\Users\\operator\\missing-shell.exe",
+        },
+        runtime: {
+          environmentId: "env",
+          environmentName: "Env",
+          executionTarget: "local",
+          cwd: root,
+          actions: [
+            {
+              id: "start-dev",
+              name: "Start dev",
+              command: `printf fallback > ${JSON.stringify(outputPath)}`,
+            },
+          ],
+        },
+      });
+
+      expect(result.actionRuns).toEqual([
+        expect.objectContaining({
+          runId: "test-run-win-shell-fallback",
+          actionId: "start-dev",
+          status: "started",
+        }),
+      ]);
+      await expect(
+        expectEventually(async () => await readFile(outputPath, "utf8")),
+      ).resolves.toBe("fallback");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("chooses the command shell from the provided hydrated environment", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-env-shell-"));
     const shellPath = path.join(root, "test-shell.sh");

--- a/apps/desktop/src/main/app-server/codex-environment-runtime.ts
+++ b/apps/desktop/src/main/app-server/codex-environment-runtime.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
+import { accessSync, constants, statSync } from "node:fs";
 import type {
   CodexEnvironmentActionRun,
   CodexEnvironmentOption,
@@ -417,7 +418,11 @@ function runShellCommand(
   params: CodexEnvironmentCommandParams,
 ): Promise<CodexEnvironmentCommandResult> {
   const commandEnv = sanitizeLocalEnvironmentCommandEnv(params.env ?? process.env);
-  const shell = commandEnv.SHELL?.trim() || process.env.SHELL?.trim() || "/bin/sh";
+  const cwdProblem = inspectCommandCwd(params.cwd);
+  if (cwdProblem) {
+    return Promise.reject(new CodexEnvironmentCommandError(cwdProblem.message));
+  }
+  const shell = resolveCommandShell(commandEnv);
   const processId = `pwragent-env-${randomUUID()}`;
   const startedAt = Date.now();
   environmentRuntimeLog.info("codex-environment-command-start", {
@@ -557,12 +562,16 @@ function runShellCommand(
     });
 
     child.once("error", (error) => {
+      const message = describeSpawnError(error, {
+        cwd: params.cwd,
+        shell,
+      });
       environmentRuntimeLog.error("codex-environment-command-error", {
         processId,
-        message: error.message,
+        message,
       });
       settle(() => {
-        reject(error);
+        reject(new CodexEnvironmentCommandError(message));
       });
     });
 
@@ -752,6 +761,120 @@ function isParentElectronRuntimeEnvKey(key: string): boolean {
     key.startsWith("PRELOAD_VITE_") ||
     key.startsWith("RENDERER_VITE_")
   );
+}
+
+function resolveCommandShell(env: NodeJS.ProcessEnv): string {
+  const requested = env.SHELL?.trim() || process.env.SHELL?.trim();
+  const candidates = [
+    requested,
+    process.platform === "win32" ? process.env.ComSpec : undefined,
+    "/bin/zsh",
+    "/bin/bash",
+    "/bin/sh",
+  ];
+  const inspected: Array<{ shell: string; reason: string }> = [];
+
+  for (const shell of [...new Set(candidates.filter(Boolean))] as string[]) {
+    const availability = inspectCommandPath(shell);
+    if (availability.available) {
+      if (requested && shell !== requested) {
+        environmentRuntimeLog.warn("codex-environment-shell-fallback", {
+          requested,
+          shell,
+          failures: inspected
+            .map((entry) => `${entry.shell}:${entry.reason}`)
+            .join("; "),
+        });
+      }
+      return shell;
+    }
+    inspected.push({ shell, reason: availability.reason });
+  }
+
+  // Preserve the old behavior when no candidate can be statted. The
+  // spawn error path below will attach cwd/shell diagnostics.
+  return requested || (process.platform === "win32" ? "cmd.exe" : "/bin/sh");
+}
+
+function inspectCommandPath(shell: string): { available: true } | {
+  available: false;
+  reason: string;
+} {
+  if (!shell.startsWith("/")) {
+    return { available: true };
+  }
+
+  try {
+    const stats = statSync(shell);
+    if (!stats.isFile()) {
+      return { available: false, reason: "not a file" };
+    }
+    accessSync(shell, constants.X_OK);
+    return { available: true };
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT" || code === "ENOTDIR") {
+      return { available: false, reason: "not found" };
+    }
+    if (code === "EACCES" || code === "EPERM") {
+      return { available: false, reason: "not executable" };
+    }
+    return {
+      available: false,
+      reason: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function inspectCommandCwd(cwd: string | undefined): { message: string } | undefined {
+  const trimmed = cwd?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  try {
+    const stats = statSync(trimmed);
+    if (!stats.isDirectory()) {
+      return {
+        message: `Codex environment working directory is not a directory: ${trimmed}`,
+      };
+    }
+    return undefined;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT" || code === "ENOTDIR") {
+      return {
+        message: `Codex environment working directory does not exist: ${trimmed}`,
+      };
+    }
+    return {
+      message: `Codex environment working directory is not accessible: ${trimmed}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    };
+  }
+}
+
+function describeSpawnError(
+  error: Error,
+  params: { cwd?: string; shell: string },
+): string {
+  const code = (error as NodeJS.ErrnoException).code;
+  if (code !== "ENOENT") {
+    return error.message;
+  }
+
+  const cwdProblem = inspectCommandCwd(params.cwd);
+  if (cwdProblem) {
+    return `${error.message}; ${cwdProblem.message}`;
+  }
+
+  const shellAvailability = inspectCommandPath(params.shell);
+  if (!shellAvailability.available) {
+    return `${error.message}; Codex environment shell is not available: ${params.shell} (${shellAvailability.reason})`;
+  }
+
+  return error.message;
 }
 
 function readCodexEnvironmentSetupTimeoutMs(env: NodeJS.ProcessEnv): number {

--- a/apps/desktop/src/main/app-server/codex-environment-runtime.ts
+++ b/apps/desktop/src/main/app-server/codex-environment-runtime.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { accessSync, constants, statSync } from "node:fs";
+import path from "node:path";
 import type {
   CodexEnvironmentActionRun,
   CodexEnvironmentOption,
@@ -767,7 +768,6 @@ function resolveCommandShell(env: NodeJS.ProcessEnv): string {
   const requested = env.SHELL?.trim() || process.env.SHELL?.trim();
   const candidates = [
     requested,
-    process.platform === "win32" ? process.env.ComSpec : undefined,
     "/bin/zsh",
     "/bin/bash",
     "/bin/sh",
@@ -793,14 +793,14 @@ function resolveCommandShell(env: NodeJS.ProcessEnv): string {
 
   // Preserve the old behavior when no candidate can be statted. The
   // spawn error path below will attach cwd/shell diagnostics.
-  return requested || (process.platform === "win32" ? "cmd.exe" : "/bin/sh");
+  return requested || "/bin/sh";
 }
 
 function inspectCommandPath(shell: string): { available: true } | {
   available: false;
   reason: string;
 } {
-  if (!shell.startsWith("/")) {
+  if (!isAbsoluteCommandPath(shell)) {
     return { available: true };
   }
 
@@ -824,6 +824,10 @@ function inspectCommandPath(shell: string): { available: true } | {
       reason: error instanceof Error ? error.message : String(error),
     };
   }
+}
+
+function isAbsoluteCommandPath(value: string): boolean {
+  return path.isAbsolute(value) || path.win32.isAbsolute(value);
 }
 
 function inspectCommandCwd(cwd: string | undefined): { message: string } | undefined {


### PR DESCRIPTION
## Summary

- I fixed Codex environment run buttons so startup failures now point at the real broken input. A missing or inaccessible environment working directory is reported directly instead of surfacing Node's ambiguous `spawn /bin/zsh ENOENT`.
- I also made the runner tolerate a stale hydrated `SHELL` path by falling back to the standard local shells before spawning the action.
- I added regression coverage for both the missing-workdir diagnostic and stale-shell fallback paths.

## Verification

- I verified `pnpm test apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts`
- I verified `pnpm --filter @pwragent/desktop typecheck`
- I verified `git diff --check`

## Notes

- The original PwrSnap path and `/bin/zsh` both existed when I inspected them after the failure, so I could not reproduce the exact transient state. This change makes the next failure actionable by checking `cwd` and shell availability before relying on Node's spawn error text.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
