### PR TITLE
[codex] fix Codex Fast mode service tier plumbing

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -28,7 +28,11 @@ import type {
 } from "@pwragent/shared";
 import type { MessagingBindingRecord } from "@pwragent/messaging-interface";
 import { buildNavigationSnapshot } from "@pwragent/agent-core";
-import { DesktopBackendRegistry } from "../app-server/backend-registry";
+import {
+  buildCodexFastModeMismatchNotificationParams,
+  DesktopBackendRegistry,
+  getCodexFastModeMismatchWarning,
+} from "../app-server/backend-registry";
 import {
   CodexEnvironmentCommandError,
   type CodexEnvironmentCommandRunner,
@@ -4926,6 +4930,56 @@ script = "echo setup"
     await registry.close();
   });
 
+  it("clears stale Codex Fast serviceTier from launchpad defaults when Fast mode changes", async () => {
+    const overlayStore = createOverlayStoreMock({
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+        workMode: "local",
+        model: "gpt-5.5",
+        reasoningEffort: "medium",
+        serviceTier: "fast",
+        fastMode: false,
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/start"] },
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+
+    await registry.ensureDirectoryLaunchpad({
+      directoryKey: "directory:/repo-a",
+      directoryKind: "directory",
+      directoryLabel: "Repo A",
+      directoryPath: "/repo-a",
+    });
+    const updated = await registry.updateDirectoryLaunchpad({
+      directoryKey: "directory:/repo-a",
+      patch: { fastMode: true },
+      stickySettingsChanged: true,
+    });
+    const next = await registry.ensureDirectoryLaunchpad({
+      directoryKey: "directory:/repo-b",
+      directoryKind: "directory",
+      directoryLabel: "Repo B",
+      directoryPath: "/repo-b",
+    });
+
+    expect(updated.defaults.fastMode).toBe(true);
+    expect(updated.defaults.serviceTier).toBeUndefined();
+    expect(updated.launchpad.fastMode).toBe(true);
+    expect(updated.launchpad.serviceTier).toBeUndefined();
+    expect(next.launchpad.fastMode).toBe(true);
+    expect(next.launchpad.serviceTier).toBeUndefined();
+
+    await registry.close();
+  });
+
   it("keeps environment options available after switching a launchpad to ACP", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-acp-env-options-"));
     await mkdir(path.join(root, ".codex", "environments"), { recursive: true });
@@ -5438,6 +5492,82 @@ script = "pnpm install"
     expect(codexClient.lastStartThreadParams?.cwd).toBe(
       "/Users/test/.pwragent/projects/2026-05-02-a1b2c3",
     );
+
+    await registry.close();
+  });
+
+  it("uses submitted launchpad Fast mode instead of stale persisted launchpad settings", async () => {
+    const overlayStore = createOverlayStoreMock();
+    await overlayStore.upsertDirectoryLaunchpad({
+      directoryKey: "directory:/repo/app",
+      directoryKind: "directory",
+      directoryLabel: "app",
+      directoryPath: "/repo/app",
+      backend: "codex",
+      executionMode: "default",
+      prompt: "stale prompt",
+      workMode: "worktree",
+      model: "gpt-5.5",
+      reasoningEffort: "low",
+      serviceTier: "fast",
+      fastMode: false,
+      createdAt: 1_000,
+      updatedAt: 2_000,
+    });
+
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/start", "turn/start"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+      gitDirectoryService: {
+        prepareLaunchpadWorkspace: vi.fn(async () => ({
+          cwd: "/repo/app/.worktrees/thread-1/app",
+          repositoryPath: "/repo/app",
+          workMode: "worktree" as const,
+        })),
+        recordCodexWorktreeOwnerThread: vi.fn(async () => {}),
+      } as never,
+    });
+
+    await registry.materializeDirectoryLaunchpad({
+      directoryKey: "directory:/repo/app",
+      input: [{ type: "text", text: "submitted prompt" }],
+      launchpad: {
+        directoryKey: "directory:/repo/app",
+        directoryKind: "directory",
+        directoryLabel: "app",
+        directoryPath: "/repo/app",
+        backend: "codex",
+        executionMode: "default",
+        prompt: "",
+        workMode: "worktree",
+        model: "gpt-5.5",
+        reasoningEffort: "medium",
+        fastMode: true,
+        createdAt: 1_000,
+        updatedAt: 2_500,
+      },
+    });
+
+    expect(codexClient.lastStartThreadParams).toMatchObject({
+      model: "gpt-5.5",
+      reasoningEffort: "medium",
+      serviceTier: "priority",
+      fastMode: true,
+    });
+    expect(codexClient.lastStartTurnParams).toMatchObject({
+      threadId: "thread-1",
+      input: [{ type: "text", text: "submitted prompt" }],
+      model: "gpt-5.5",
+      reasoningEffort: "medium",
+      serviceTier: "priority",
+      fastMode: true,
+    });
 
     await registry.close();
   });
@@ -6941,6 +7071,7 @@ command = "pnpm dev"
       serviceTier: "priority",
       reasoningEffort: "high",
       fastMode: true,
+      collaborationMode: undefined,
     });
 
     await registry.startTurn({
@@ -6958,9 +7089,260 @@ command = "pnpm dev"
       serviceTier: undefined,
       reasoningEffort: "medium",
       fastMode: undefined,
+      collaborationMode: undefined,
     });
 
     await registry.close();
+  });
+
+  it("maps checked Codex Fast mode to priority serviceTier when starting turns", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock({
+        overlays: {
+          "codex:thread-fast": {
+            backend: "codex",
+            threadId: "thread-fast",
+            executionMode: "default",
+            model: "gpt-5.5",
+            reasoningEffort: "high",
+            fastMode: true,
+            extraLinkedDirectories: [],
+          },
+        },
+      }),
+    });
+
+    await registry.startTurn({
+      backend: "codex",
+      threadId: "thread-fast",
+      input: [{ type: "text", text: "Use fast tier" }],
+    });
+
+    expect(codexClient.lastStartTurnParams).toMatchObject({
+      threadId: "thread-fast",
+      model: "gpt-5.5",
+      reasoningEffort: "high",
+      serviceTier: "priority",
+      fastMode: true,
+    });
+
+    await registry.close();
+  });
+
+  it("clears Codex Fast serviceTier when Fast mode is unchecked", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock({
+        overlays: {
+          "codex:thread-standard": {
+            backend: "codex",
+            threadId: "thread-standard",
+            executionMode: "default",
+            model: "gpt-5.5",
+            reasoningEffort: "high",
+            serviceTier: "fast",
+            fastMode: false,
+            extraLinkedDirectories: [],
+          },
+        },
+      }),
+    });
+
+    await registry.startTurn({
+      backend: "codex",
+      threadId: "thread-standard",
+      input: [{ type: "text", text: "Use standard tier" }],
+    });
+
+    expect(codexClient.lastStartTurnParams).toMatchObject({
+      threadId: "thread-standard",
+      model: "gpt-5.5",
+      reasoningEffort: "high",
+      serviceTier: undefined,
+      fastMode: false,
+    });
+
+    await registry.close();
+  });
+
+  it("clears stale Codex Fast serviceTier when the selected model does not support Fast", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+      models: [
+        {
+          id: "gpt-5.4-mini",
+          label: "GPT 5.4 mini",
+          current: true,
+          supportsReasoning: true,
+          supportsFast: false,
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock({
+        overlays: {
+          "codex:thread-unsupported-fast": {
+            backend: "codex",
+            threadId: "thread-unsupported-fast",
+            executionMode: "default",
+            model: "gpt-5.4-mini",
+            reasoningEffort: "low",
+            serviceTier: "fast",
+            extraLinkedDirectories: [],
+          },
+        },
+      }),
+    });
+
+    await registry.listBackends();
+    await registry.startTurn({
+      backend: "codex",
+      threadId: "thread-unsupported-fast",
+      input: [{ type: "text", text: "Use the unsupported model" }],
+    });
+
+    expect(codexClient.lastStartTurnParams).toMatchObject({
+      threadId: "thread-unsupported-fast",
+      model: "gpt-5.4-mini",
+      reasoningEffort: "low",
+      serviceTier: undefined,
+      fastMode: false,
+    });
+
+    await registry.close();
+  });
+
+  it("detects Codex Fast mode drift when the completed turn reports a mismatched tier", () => {
+    expect(
+      getCodexFastModeMismatchWarning({
+        threadId: "thread-fast",
+        turnId: "turn-1",
+        expectedFastMode: true,
+        notificationParams: {
+          threadId: "thread-fast",
+          turnId: "turn-1",
+          serviceTier: null,
+          turn: { id: "turn-1", status: "completed", output: [] },
+        },
+      }),
+    ).toMatchObject({
+      threadId: "thread-fast",
+      turnId: "turn-1",
+      expectedFastMode: true,
+      observedFastMode: false,
+    });
+
+    expect(
+      getCodexFastModeMismatchWarning({
+        threadId: "thread-fast",
+        turnId: "turn-2",
+        expectedFastMode: false,
+        notificationParams: {
+          threadId: "thread-fast",
+          turnId: "turn-2",
+          serviceTier: "fast",
+          turn: { id: "turn-2", status: "completed", output: [] },
+        },
+      }),
+    ).toMatchObject({
+      threadId: "thread-fast",
+      turnId: "turn-2",
+      expectedFastMode: false,
+      observedFastMode: true,
+    });
+
+    expect(
+      getCodexFastModeMismatchWarning({
+        threadId: "thread-fast",
+        turnId: "turn-3",
+        expectedFastMode: false,
+        notificationParams: {
+          threadId: "thread-fast",
+          turnId: "turn-3",
+          serviceTier: "priority",
+        },
+      }),
+    ).toMatchObject({
+      threadId: "thread-fast",
+      turnId: "turn-3",
+      expectedFastMode: false,
+      observedFastMode: true,
+      observedServiceTier: "priority",
+    });
+  });
+
+  it("checks Codex Fast mode drift against observed thread settings when terminal events omit tier", () => {
+    const notificationParams = buildCodexFastModeMismatchNotificationParams(
+      {
+        threadId: "thread-fast",
+        turn: { id: "turn-1", status: "completed", output: [] },
+      },
+      {
+        fastMode: true,
+        serviceTier: "fast",
+      },
+    );
+
+    expect(
+      getCodexFastModeMismatchWarning({
+        threadId: "thread-fast",
+        turnId: "turn-1",
+        expectedFastMode: false,
+        notificationParams,
+      }),
+    ).toMatchObject({
+      threadId: "thread-fast",
+      turnId: "turn-1",
+      expectedFastMode: false,
+      observedFastMode: true,
+      observedServiceTier: "fast",
+    });
+  });
+
+  it("prefers terminal Codex Fast settings over cached observed thread settings", () => {
+    const notificationParams = buildCodexFastModeMismatchNotificationParams(
+      {
+        threadId: "thread-fast",
+        turn: { id: "turn-1", status: "completed", output: [] },
+        serviceTier: "priority",
+      },
+      {
+        fastMode: false,
+        serviceTier: null,
+      },
+    );
+
+    expect(
+      getCodexFastModeMismatchWarning({
+        threadId: "thread-fast",
+        turnId: "turn-1",
+        expectedFastMode: false,
+        notificationParams,
+      }),
+    ).toMatchObject({
+      threadId: "thread-fast",
+      turnId: "turn-1",
+      expectedFastMode: false,
+      observedFastMode: true,
+      observedServiceTier: "priority",
+    });
   });
 
   it("resumes Codex turns in the current handoff worktree cwd", async () => {

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -1458,7 +1458,7 @@ describe("CodexAppServerClient", () => {
 
     const client = new CodexAppServerClient({
       command: "codex",
-      directoryResolver: async () => []
+      directoryResolver: async () => [],
     });
 
     await client.listThreads({ filter: "web-app" });
@@ -3528,6 +3528,85 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("normalizes Codex thread settings service tier notifications", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => []
+    });
+
+    await client.getInitializeResult();
+
+    const notifications: Array<{ method: string; params: Record<string, unknown> }> = [];
+    client.onNotification((notification) => {
+      notifications.push(
+        notification as { method: string; params: Record<string, unknown> }
+      );
+    });
+
+    const transport = MockTransport.instances.at(-1);
+    expect(transport).toBeDefined();
+
+    transport!.emitInbound({
+      jsonrpc: "2.0",
+      method: "thread/settings/updated",
+      params: {
+        threadId: "thread-2",
+        threadSettings: {
+          model: "gpt-5.5",
+          serviceTier: "priority",
+          effort: "medium"
+        }
+      }
+    });
+    transport!.emitInbound({
+      jsonrpc: "2.0",
+      method: "thread/settings/updated",
+      params: {
+        threadId: "thread-2",
+        threadSettings: {
+          model: "gpt-5.5",
+          serviceTier: "default",
+          effort: "medium"
+        }
+      }
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(codexClientLogWarn).not.toHaveBeenCalledWith(
+      "unknown codex notification",
+      expect.anything()
+    );
+    expect(notifications).toEqual([
+      {
+        method: "thread/codexSettings/observed",
+        params: {
+          threadId: "thread-2",
+          model: "gpt-5.5",
+          reasoningEffort: "medium",
+          rawServiceTier: "priority",
+          serviceTier: "fast",
+          fastMode: true
+        }
+      },
+      {
+        method: "thread/codexSettings/observed",
+        params: {
+          threadId: "thread-2",
+          model: "gpt-5.5",
+          reasoningEffort: "medium",
+          rawServiceTier: "default",
+          serviceTier: null,
+          fastMode: false
+        }
+      }
+    ]);
+
+    await client.close();
+  });
+
   it("logs diagnostics for Codex skills changed notifications", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
 
@@ -4045,6 +4124,60 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("sends Fast mode as Codex priority serviceTier on the first turn of a newly created thread", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    const created = await client.startThread({
+      cwd: "/Users/huntharo/.pwragent/projects/2026-04-16-ab12cd",
+      model: "gpt-5.5",
+      fastMode: true,
+    });
+    await client.startTurn({
+      threadId: created.threadId,
+      input: [{ type: "text", text: "First fast prompt" }],
+      model: "gpt-5.5",
+      fastMode: true,
+    });
+
+    const transport = MockTransport.instances.at(-1);
+    expect(transport).toBeDefined();
+    const requests = transport!.sentMessages.map(
+      (message) =>
+        JSON.parse(message) as {
+          method?: string;
+          params?: Record<string, unknown>;
+        },
+    );
+    expect(requests).not.toContainEqual(
+      expect.objectContaining({ method: "thread/resume" }),
+    );
+    expect(requests).toContainEqual(
+      expect.objectContaining({
+        method: "thread/start",
+        params: expect.objectContaining({
+          model: "gpt-5.5",
+          serviceTier: "priority",
+        }),
+      }),
+    );
+    expect(requests).toContainEqual(
+      expect.objectContaining({
+        method: "turn/start",
+        params: expect.objectContaining({
+          model: "gpt-5.5",
+          serviceTier: "priority",
+        }),
+      }),
+    );
+
+    await client.close();
+  });
+
   it("resumes a created thread again after the first turn has started", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
     MockTransport.turnStartResult = {
@@ -4277,7 +4410,7 @@ describe("CodexAppServerClient", () => {
 
     const client = new CodexAppServerClient({
       command: "codex",
-      directoryResolver: async () => []
+      directoryResolver: async () => [],
     });
 
     await expect(client.archiveThread({ threadId: "thread-2" })).resolves.toEqual({
@@ -4506,7 +4639,7 @@ describe("CodexAppServerClient", () => {
         params: expect.objectContaining({
           ephemeral: true,
           model: "gpt-5.4-mini",
-          serviceTier: "fast",
+          serviceTier: "priority",
           config: {
             web_search: "disabled",
           },
@@ -4519,7 +4652,7 @@ describe("CodexAppServerClient", () => {
         params: expect.objectContaining({
           threadId: "thread-title-helper",
           model: "gpt-5.4-mini",
-          serviceTier: "fast",
+          serviceTier: "priority",
           effort: "low",
           outputSchema: expect.objectContaining({
             type: "object",
@@ -4756,6 +4889,99 @@ describe("CodexAppServerClient", () => {
       threadId: "thread-2",
       cwd: "/repo/app/.worktrees/thread-2/app",
     });
+
+    await client.close();
+  });
+
+  it("sends Fast mode as Codex priority serviceTier when resuming an existing thread", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => []
+    });
+
+    await client.startTurn({
+      threadId: "thread-2",
+      input: [{ type: "text", text: "Reply quickly" }],
+      model: "gpt-5.5",
+      fastMode: true,
+    });
+
+    const transport = MockTransport.instances.at(-1);
+    expect(transport).toBeDefined();
+    const requests = transport!.sentMessages.map(
+      (message) =>
+        JSON.parse(message) as {
+          method?: string;
+          params?: Record<string, unknown>;
+        },
+    );
+    expect(requests).toContainEqual(
+      expect.objectContaining({
+        method: "thread/resume",
+        params: expect.objectContaining({
+          model: "gpt-5.5",
+          serviceTier: "priority",
+        }),
+      }),
+    );
+    expect(requests).toContainEqual(
+      expect.objectContaining({
+        method: "turn/start",
+        params: expect.objectContaining({
+          model: "gpt-5.5",
+          serviceTier: "priority",
+        }),
+      }),
+    );
+
+    await client.close();
+  });
+
+  it("sends an explicit serviceTier clear when Fast mode is unchecked on an existing thread", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    await client.startTurn({
+      threadId: "thread-2",
+      input: [{ type: "text", text: "Reply without fast" }],
+      model: "gpt-5.5",
+      serviceTier: "fast",
+      fastMode: false,
+    });
+
+    const transport = MockTransport.instances.at(-1);
+    expect(transport).toBeDefined();
+    const requests = transport!.sentMessages.map(
+      (message) =>
+        JSON.parse(message) as {
+          method?: string;
+          params?: Record<string, unknown>;
+        },
+    );
+    expect(requests).toContainEqual(
+      expect.objectContaining({
+        method: "thread/resume",
+        params: expect.objectContaining({
+          model: "gpt-5.5",
+          serviceTier: null,
+        }),
+      }),
+    );
+    expect(requests).toContainEqual(
+      expect.objectContaining({
+        method: "turn/start",
+        params: expect.objectContaining({
+          model: "gpt-5.5",
+          serviceTier: null,
+        }),
+      }),
+    );
 
     await client.close();
   });

--- a/apps/desktop/src/main/__tests__/overlay-store-launchpad-defaults.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-launchpad-defaults.test.ts
@@ -1,0 +1,119 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SqliteOverlayStore } from "../state/overlay-store-sqlite";
+import { StateDb } from "../state/state-db";
+
+let stateDb: StateDb;
+let store: SqliteOverlayStore;
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-launchpad-defaults-test-"));
+  stateDb = StateDb.open(path.join(tempDir, "state.db"));
+  store = new SqliteOverlayStore(stateDb);
+});
+
+afterEach(() => {
+  stateDb.close();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+function listDefaultKeys(): string[] {
+  return (
+    stateDb.raw
+      .prepare("SELECT key FROM launchpad_defaults ORDER BY key")
+      .all() as { key: string }[]
+  ).map((row) => row.key);
+}
+
+function readDefaultValue(key: string): unknown {
+  const row = stateDb.raw
+    .prepare("SELECT value FROM launchpad_defaults WHERE key = ?")
+    .get(key) as { value: string } | undefined;
+  return row ? JSON.parse(row.value) : undefined;
+}
+
+describe("SqliteOverlayStore - launchpad defaults", () => {
+  it("does not persist Codex Fast serviceTier in launchpad defaults", async () => {
+    const defaults = await store.setLaunchpadDefaults({
+      model: "gpt-5.5",
+      reasoningEffort: "medium",
+      serviceTier: "priority",
+      fastMode: true,
+    });
+
+    expect(defaults).toMatchObject({
+      backend: "codex",
+      executionMode: "default",
+      model: "gpt-5.5",
+      reasoningEffort: "medium",
+      fastMode: true,
+    });
+    expect(defaults.serviceTier).toBeUndefined();
+    expect(listDefaultKeys()).not.toContain("serviceTier");
+  });
+
+  it("removes legacy Fast serviceTier aliases from launchpad defaults", async () => {
+    const defaults = await store.setLaunchpadDefaults({
+      serviceTier: "fast",
+      fastMode: true,
+    });
+
+    expect(defaults.fastMode).toBe(true);
+    expect(defaults.serviceTier).toBeUndefined();
+    expect(listDefaultKeys()).not.toContain("serviceTier");
+  });
+
+  it("removes stale launchpad default rows when a setting is cleared", async () => {
+    stateDb.raw
+      .prepare("INSERT OR REPLACE INTO launchpad_defaults(key, value) VALUES (?, ?)")
+      .run("backend", JSON.stringify("codex"));
+    stateDb.raw
+      .prepare("INSERT OR REPLACE INTO launchpad_defaults(key, value) VALUES (?, ?)")
+      .run("executionMode", JSON.stringify("default"));
+    stateDb.raw
+      .prepare("INSERT OR REPLACE INTO launchpad_defaults(key, value) VALUES (?, ?)")
+      .run("serviceTier", JSON.stringify("fast"));
+    stateDb.raw
+      .prepare("INSERT OR REPLACE INTO launchpad_defaults(key, value) VALUES (?, ?)")
+      .run("fastMode", JSON.stringify(false));
+
+    const readDefaults = await store.getLaunchpadDefaults();
+    expect(readDefaults.fastMode).toBe(false);
+    expect(readDefaults.serviceTier).toBeUndefined();
+    expect(listDefaultKeys()).toEqual(["backend", "executionMode", "fastMode"]);
+
+    await store.setLaunchpadDefaults({ fastMode: false, serviceTier: undefined });
+
+    expect(listDefaultKeys()).toEqual(["backend", "executionMode", "fastMode"]);
+  });
+
+  it("preserves unknown launchpad default keys while clearing owned keys", async () => {
+    stateDb.raw
+      .prepare("INSERT OR REPLACE INTO launchpad_defaults(key, value) VALUES (?, ?)")
+      .run("backend", JSON.stringify("codex"));
+    stateDb.raw
+      .prepare("INSERT OR REPLACE INTO launchpad_defaults(key, value) VALUES (?, ?)")
+      .run("executionMode", JSON.stringify("default"));
+    stateDb.raw
+      .prepare("INSERT OR REPLACE INTO launchpad_defaults(key, value) VALUES (?, ?)")
+      .run("serviceTier", JSON.stringify("priority"));
+    stateDb.raw
+      .prepare("INSERT OR REPLACE INTO launchpad_defaults(key, value) VALUES (?, ?)")
+      .run("futureExperimentalFlag", JSON.stringify({ enabled: true }));
+
+    const defaults = await store.setLaunchpadDefaults({
+      serviceTier: undefined,
+      fastMode: false,
+    });
+
+    expect(defaults.serviceTier).toBeUndefined();
+    expect(defaults).toMatchObject({
+      futureExperimentalFlag: { enabled: true },
+    });
+    expect(readDefaultValue("serviceTier")).toBeUndefined();
+    expect(readDefaultValue("futureExperimentalFlag")).toEqual({ enabled: true });
+  });
+});

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1419,6 +1419,21 @@ type ModelSettings = {
   fastMode?: boolean;
 };
 
+type CodexFastModeMismatchWarning = {
+  threadId: string;
+  turnId: string;
+  expectedFastMode: boolean;
+  observedFastMode: boolean;
+  observedServiceTier?: string | null;
+};
+
+type ObservedCodexSettings = {
+  fastMode?: boolean;
+  serviceTier?: string | null;
+  rawServiceTier?: string | null;
+  observedAt: number;
+};
+
 type ThreadListCallerReason =
   | "archive-cleanup"
   | "branch-drift"
@@ -1779,12 +1794,189 @@ function resolveModelSettingsFromOptions(
       : getDefaultReasoningEffort(options)
     : undefined;
   const supportsFast = backend === "codex" && Boolean(selectedModel?.supportsFast);
+  const shouldClearCodexFastTier =
+    backend === "codex" &&
+    !supportsFast &&
+    (settings.serviceTier === "fast" ||
+      settings.serviceTier === "priority" ||
+      settings.fastMode === false);
 
   return {
     model: selectedModel?.id,
     reasoningEffort,
-    serviceTier: settings.serviceTier,
-    fastMode: supportsFast ? settings.fastMode : undefined,
+    serviceTier: resolveCodexFastModeServiceTier({
+      backend,
+      serviceTier: settings.serviceTier,
+      fastMode: settings.fastMode,
+      supportsFast,
+    }),
+    fastMode: supportsFast
+      ? settings.fastMode
+      : shouldClearCodexFastTier
+        ? false
+        : undefined,
+  };
+}
+
+function resolveCodexFastModeServiceTier(params: {
+  backend: AppServerBackendKind;
+  fastMode?: boolean;
+  serviceTier?: string;
+  supportsFast: boolean;
+}): string | undefined {
+  if (params.backend !== "codex") {
+    return params.serviceTier;
+  }
+  if (params.fastMode === true && params.supportsFast) {
+    return "priority";
+  }
+  if (params.fastMode === false) {
+    return params.serviceTier &&
+      params.serviceTier !== "fast" &&
+      params.serviceTier !== "priority"
+      ? params.serviceTier
+      : undefined;
+  }
+  if (
+    !params.supportsFast &&
+    (params.serviceTier === "fast" || params.serviceTier === "priority")
+  ) {
+    return undefined;
+  }
+  return params.serviceTier;
+}
+
+function readRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function readStringLike(
+  record: Record<string, unknown> | undefined,
+  keys: string[],
+): string | null | undefined {
+  if (!record) {
+    return undefined;
+  }
+  for (const key of keys) {
+    if (!(key in record)) {
+      continue;
+    }
+    const value = record[key];
+    if (value === null) {
+      return null;
+    }
+    if (typeof value === "string") {
+      return value.trim() || null;
+    }
+  }
+  return undefined;
+}
+
+function readBooleanLike(
+  record: Record<string, unknown> | undefined,
+  keys: string[],
+): boolean | undefined {
+  if (!record) {
+    return undefined;
+  }
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "boolean") {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function firstDefinedStringLike(
+  ...values: Array<string | null | undefined>
+): string | null | undefined {
+  for (const value of values) {
+    if (value !== undefined) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function readObservedCodexFastMode(
+  notificationParams: unknown,
+): { fastMode?: boolean; serviceTier?: string | null } {
+  const params = readRecord(notificationParams);
+  const turn = readRecord(params?.turn);
+  const config = readRecord(params?.config) ?? readRecord(turn?.config);
+  const serviceTier = firstDefinedStringLike(
+    readStringLike(params, ["serviceTier", "service_tier"]),
+    readStringLike(turn, ["serviceTier", "service_tier"]),
+    readStringLike(config, ["service_tier", "serviceTier"]),
+  );
+  if (serviceTier !== undefined) {
+    const normalizedServiceTier =
+      typeof serviceTier === "string" ? serviceTier.toLowerCase() : serviceTier;
+    return {
+      fastMode: normalizedServiceTier === "fast" || normalizedServiceTier === "priority",
+      serviceTier,
+    };
+  }
+
+  const fastMode =
+    readBooleanLike(params, ["fastMode", "fast_mode"]) ??
+    readBooleanLike(turn, ["fastMode", "fast_mode"]) ??
+    readBooleanLike(config, ["fastMode", "fast_mode"]);
+  return { fastMode };
+}
+
+export function getCodexFastModeMismatchWarning(params: {
+  expectedFastMode: boolean;
+  notificationParams: unknown;
+  threadId: string;
+  turnId: string;
+}): CodexFastModeMismatchWarning | undefined {
+  const observed = readObservedCodexFastMode(params.notificationParams);
+  if (observed.fastMode === undefined) {
+    return undefined;
+  }
+  if (observed.fastMode === params.expectedFastMode) {
+    return undefined;
+  }
+  return {
+    threadId: params.threadId,
+    turnId: params.turnId,
+    expectedFastMode: params.expectedFastMode,
+    observedFastMode: observed.fastMode,
+    observedServiceTier: observed.serviceTier,
+  };
+}
+
+export function buildCodexFastModeMismatchNotificationParams(
+  notificationParams: unknown,
+  observedSettings?: { fastMode?: boolean; serviceTier?: string | null },
+): unknown {
+  const base = readRecord(notificationParams) ?? {};
+  if (!observedSettings) {
+    return base;
+  }
+  const hasTerminalFastMode =
+    "fastMode" in base ||
+    "fast_mode" in base ||
+    readRecord(base.turn)?.fastMode !== undefined ||
+    readRecord(base.turn)?.fast_mode !== undefined;
+  const hasTerminalServiceTier =
+    "serviceTier" in base ||
+    "service_tier" in base ||
+    readRecord(base.turn)?.serviceTier !== undefined ||
+    readRecord(base.turn)?.service_tier !== undefined;
+
+  return {
+    ...base,
+    ...(!hasTerminalFastMode && observedSettings.fastMode !== undefined
+      ? { fastMode: observedSettings.fastMode }
+      : {}),
+    ...(!hasTerminalServiceTier && observedSettings.serviceTier !== undefined
+      ? { serviceTier: observedSettings.serviceTier }
+      : {}),
   };
 }
 
@@ -1867,6 +2059,7 @@ export class DesktopBackendRegistry {
     }
   >();
   private readonly activeCodexTurnModes = new Map<string, ThreadExecutionMode>();
+  private readonly observedCodexSettingsByThread = new Map<string, ObservedCodexSettings>();
   private readonly reservedCodexStartThreadIds = new Set<string>();
   private readonly reservedAcpStartThreadKeys = new Set<string>();
   private readonly activeTurnKeys = new Set<string>();
@@ -4046,6 +4239,16 @@ export class DesktopBackendRegistry {
       });
     }
 
+    backendRegistryLog.info("startThread", {
+      backend,
+      cwd,
+      executionMode,
+      model: modelSettings.model ?? null,
+      reasoningEffort: modelSettings.reasoningEffort ?? null,
+      serviceTier: modelSettings.serviceTier ?? null,
+      fastMode: modelSettings.fastMode ?? null,
+    });
+
     const result = isAcpBackendId(backend)
       ? await this.startAcpSession({
           backend,
@@ -5903,6 +6106,9 @@ export class DesktopBackendRegistry {
     const nextLaunchpad: NavigationLaunchpadDraft = {
       ...current,
       ...request.patch,
+      ...("fastMode" in request.patch
+        ? { serviceTier: undefined }
+        : {}),
       directoryKey: request.directoryKey,
       settingsTouchedAt: request.stickySettingsChanged
         ? Date.now()
@@ -5929,6 +6135,7 @@ export class DesktopBackendRegistry {
     }
     if (request.stickySettingsChanged && "fastMode" in request.patch) {
       stickyPatch.fastMode = request.patch.fastMode;
+      stickyPatch.serviceTier = undefined;
     }
     if (request.stickySettingsChanged && request.patch.workMode) {
       stickyPatch.workMode = request.patch.workMode;
@@ -6353,9 +6560,10 @@ export class DesktopBackendRegistry {
     },
   ): Promise<MaterializeDirectoryLaunchpadResponse> {
     const launchpad =
+      request.launchpad ??
       (await this.overlayStore.getDirectoryLaunchpad({
         directoryKey: request.directoryKey,
-      })) ?? request.launchpad;
+      }));
     if (!launchpad) {
       throw new Error(`No launchpad found for ${request.directoryKey}`);
     }
@@ -6465,10 +6673,10 @@ export class DesktopBackendRegistry {
       model: launchpad.model,
       reasoningEffort: launchpad.reasoningEffort,
       serviceTier: launchpad.serviceTier,
-        fastMode: launchpad.backend === "codex" ? launchpad.fastMode : undefined,
-        acpRuntime: launchpad.acpRuntime,
-        codexEnvironmentRuntime,
-      });
+      fastMode: launchpad.backend === "codex" ? launchpad.fastMode : undefined,
+      acpRuntime: launchpad.acpRuntime,
+      codexEnvironmentRuntime,
+    });
     pendingActionThreadId = startThreadResponse.threadId;
     if (codexEnvironmentSelection?.action?.id) {
       for (const event of queuedActionDetachedOutputs) {
@@ -6630,6 +6838,13 @@ export class DesktopBackendRegistry {
       ),
       ...modelSettings,
     };
+    if (
+      resolvedDefaults.backend === "codex" &&
+      (resolvedDefaults.serviceTier === "fast" ||
+        resolvedDefaults.serviceTier === "priority")
+    ) {
+      delete resolvedDefaults.serviceTier;
+    }
 
     if (launchpadDefaultsEqual(storedDefaults, resolvedDefaults)) {
       return storedDefaults;
@@ -6671,6 +6886,9 @@ export class DesktopBackendRegistry {
     this.unsubscribers.push(
       client.onNotification(async (notification) => {
         logBackendLifecycleNotification(backend, notification);
+        if (backend === "codex") {
+          this.recordObservedCodexSettings(notification);
+        }
         if (this.shouldInvalidateThreadListCacheForNotification(notification.method)) {
           this.invalidateThreadListCache(backend);
         }
@@ -6697,6 +6915,38 @@ export class DesktopBackendRegistry {
         client.onRequest(async (request) => await this.handleServerRequest(backend, request)),
       );
     }
+  }
+
+  private recordObservedCodexSettings(notification: AppServerNotification): void {
+    if (notification.method !== "thread/codexSettings/observed") {
+      return;
+    }
+    const params = notification.params as {
+      fastMode?: unknown;
+      rawServiceTier?: unknown;
+      serviceTier?: unknown;
+      threadId?: unknown;
+    };
+    if (typeof params.threadId !== "string") {
+      return;
+    }
+    const observed = {
+      ...(typeof params.fastMode === "boolean" ? { fastMode: params.fastMode } : {}),
+      ...(typeof params.serviceTier === "string" || params.serviceTier === null
+        ? { serviceTier: params.serviceTier }
+        : {}),
+      ...(typeof params.rawServiceTier === "string" || params.rawServiceTier === null
+        ? { rawServiceTier: params.rawServiceTier }
+        : {}),
+      observedAt: Date.now(),
+    };
+    this.observedCodexSettingsByThread.set(params.threadId, observed);
+    backendRegistryLog.info("codex thread settings observed", {
+      threadId: params.threadId,
+      fastMode: observed.fastMode ?? null,
+      serviceTier: observed.serviceTier ?? null,
+      rawServiceTier: observed.rawServiceTier ?? null,
+    });
   }
 
   private async emitHeadlessAutomationLifecycle(
@@ -8758,6 +9008,33 @@ export class DesktopBackendRegistry {
           await this.adoptThreadBranchChangeFromActiveTurn({
             backend: event.backend,
             threadId: notification.params.threadId,
+          });
+        }
+        try {
+          const overlay = await this.overlayStore.getThreadOverlayState({
+            backend: event.backend,
+            threadId: notification.params.threadId,
+          });
+          const observedSettings = this.observedCodexSettingsByThread.get(
+            notification.params.threadId,
+          );
+          const warning = getCodexFastModeMismatchWarning({
+            threadId: notification.params.threadId,
+            turnId,
+            expectedFastMode: Boolean(overlay?.fastMode),
+            notificationParams: buildCodexFastModeMismatchNotificationParams(
+              notification.params,
+              observedSettings,
+            ),
+          });
+          if (warning) {
+            backendRegistryLog.warn("codex fast mode state mismatch", warning);
+          }
+        } catch (error) {
+          backendRegistryLog.warn("codex fast mode state mismatch check failed", {
+            error: error instanceof Error ? error.message : String(error),
+            threadId: notification.params.threadId,
+            turnId,
           });
         }
       }

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -43,7 +43,6 @@ import type {
   InitializeParams as CodexInitializeParams,
   ReasoningEffort as CodexReasoningEffort,
   ServerRequest as CodexServerRequest,
-  ServiceTier as CodexServiceTier,
 } from "@pwragent/codex-app-server-protocol";
 import type {
   AskForApproval as CodexAskForApproval,
@@ -267,7 +266,10 @@ function isHandledServerRequestMethod(method: string): boolean {
 function isKnownCodexNotificationMethod(
   method: string
 ): boolean {
-  return GENERATED_CODEX_NOTIFICATION_METHODS.has(method);
+  return (
+    GENERATED_CODEX_NOTIFICATION_METHODS.has(method) ||
+    method === "thread/settings/updated"
+  );
 }
 
 function isKnownCodexServerRequestMethod(
@@ -593,6 +595,10 @@ function normalizeServerNotification(
   method: string,
   params: unknown,
 ): AppServerNotification {
+  if (method === "thread/settings/updated") {
+    return normalizeThreadSettingsUpdatedNotification(params);
+  }
+
   const record = asRecord(params) ?? {};
   const metadata = extractRequestMetadata(params);
   const itemRecord = asRecord(record.item);
@@ -617,6 +623,91 @@ function normalizeServerNotification(
       ...(metadata.requestId ? { requestId: metadata.requestId } : {}),
     } as AppServerNotification["params"],
   } as AppServerNotification;
+}
+
+function normalizeThreadSettingsUpdatedNotification(
+  params: unknown,
+): AppServerNotification {
+  const record = asRecord(params) ?? {};
+  const settings = asRecord(record.threadSettings) ?? asRecord(record.thread_settings) ?? {};
+  const rawServiceTier =
+    readNullableString(settings, ["serviceTier", "service_tier"]) ??
+    readNullableString(record, ["serviceTier", "service_tier"]);
+  const normalizedServiceTier = normalizeObservedCodexServiceTier(rawServiceTier);
+  const threadId =
+    pickString(record, ["threadId", "thread_id"]) ??
+    pickString(settings, ["threadId", "thread_id"]);
+  return {
+    method: "thread/codexSettings/observed",
+    params: {
+      ...(threadId ? { threadId } : {}),
+      ...pickOptionalString(settings, "model", ["model"]),
+      ...pickOptionalString(settings, "reasoningEffort", ["reasoningEffort", "effort"]),
+      ...(rawServiceTier !== undefined ? { rawServiceTier } : {}),
+      ...(normalizedServiceTier !== undefined
+        ? { serviceTier: normalizedServiceTier }
+        : {}),
+      ...observedFastModeFromCodexServiceTier(rawServiceTier),
+    },
+  } as AppServerNotification;
+}
+
+function readNullableString(
+  record: Record<string, unknown>,
+  keys: string[],
+): string | null | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (value === null) {
+      return null;
+    }
+    if (typeof value !== "string") {
+      continue;
+    }
+    const trimmed = value.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+  return undefined;
+}
+
+function pickOptionalString(
+  record: Record<string, unknown>,
+  outputKey: string,
+  inputKeys: string[],
+): Record<string, string> {
+  const value = pickString(record, inputKeys);
+  return value ? { [outputKey]: value } : {};
+}
+
+function normalizeObservedCodexServiceTier(
+  serviceTier: string | null | undefined,
+): string | null | undefined {
+  if (serviceTier === null) {
+    return null;
+  }
+  const normalized = serviceTier?.trim().toLowerCase();
+  if (!normalized) {
+    return undefined;
+  }
+  if (normalized === "priority") {
+    return "fast";
+  }
+  if (normalized === "default") {
+    return null;
+  }
+  return normalized;
+}
+
+function observedFastModeFromCodexServiceTier(
+  serviceTier: string | null | undefined,
+): { fastMode?: boolean } {
+  const normalized = normalizeObservedCodexServiceTier(serviceTier);
+  if (normalized === undefined) {
+    return {};
+  }
+  return { fastMode: normalized === "fast" };
 }
 
 function extractConfigWarningMetadata(
@@ -3563,13 +3654,36 @@ function buildCodexSandboxPolicy(
 }
 
 function normalizeCodexServiceTier(
-  value?: string
-): CodexServiceTier | undefined {
+  value?: string | null
+): string | null | undefined {
+  if (value === null) {
+    return null;
+  }
   const normalized = value?.trim();
-  if (normalized === "fast" || normalized === "flex") {
+  if (normalized === "fast" || normalized === "priority") {
+    return "priority";
+  }
+  if (normalized === "flex") {
     return normalized;
   }
   return undefined;
+}
+
+function resolveCodexServiceTier(params: {
+  fastMode?: boolean;
+  serviceTier?: string | null;
+}): string | null | undefined {
+  if (params.fastMode === true) {
+    return "priority";
+  }
+  if (params.fastMode === false) {
+    return params.serviceTier &&
+      params.serviceTier !== "fast" &&
+      params.serviceTier !== "priority"
+      ? params.serviceTier
+      : null;
+  }
+  return params.serviceTier;
 }
 
 function normalizeCodexReasoningEffort(
@@ -3594,7 +3708,8 @@ function buildThreadStartPayload(params: {
   model?: string;
   approvalPolicy?: string;
   sandbox?: string;
-  serviceTier?: string;
+  serviceTier?: string | null;
+  fastMode?: boolean;
   ephemeral?: boolean;
   codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
   config?: CodexThreadStartParams["config"];
@@ -3622,8 +3737,8 @@ function buildThreadStartPayload(params: {
     base.sandbox = sandbox;
   }
 
-  const serviceTier = normalizeCodexServiceTier(params.serviceTier);
-  if (serviceTier) {
+  const serviceTier = normalizeCodexServiceTier(resolveCodexServiceTier(params));
+  if (serviceTier !== undefined) {
     base.serviceTier = serviceTier;
   }
   if (params.ephemeral !== undefined) {
@@ -3657,7 +3772,7 @@ function buildThreadResumePayloads(params: {
   model?: string;
   approvalPolicy?: string;
   sandbox?: string;
-  serviceTier?: string;
+  serviceTier?: string | null;
   reasoningEffort?: string;
   fastMode?: boolean;
 }): CodexThreadResumeParams[] {
@@ -3683,8 +3798,8 @@ function buildThreadResumePayloads(params: {
     base.sandbox = sandbox;
   }
 
-  const serviceTier = normalizeCodexServiceTier(params.serviceTier);
-  if (serviceTier) {
+  const serviceTier = normalizeCodexServiceTier(resolveCodexServiceTier(params));
+  if (serviceTier !== undefined) {
     base.serviceTier = serviceTier;
   }
 
@@ -3755,7 +3870,8 @@ function buildTurnStartPayload(params: {
   cwd?: string;
   model?: string;
   reasoningEffort?: string;
-  serviceTier?: string;
+  serviceTier?: string | null;
+  fastMode?: boolean;
   approvalPolicy?: string;
   sandbox?: string;
   outputSchema?: CodexTurnStartParams["outputSchema"];
@@ -3779,8 +3895,8 @@ function buildTurnStartPayload(params: {
   if (reasoningEffort) {
     base.effort = reasoningEffort;
   }
-  const serviceTier = normalizeCodexServiceTier(params.serviceTier);
-  if (serviceTier) {
+  const serviceTier = normalizeCodexServiceTier(resolveCodexServiceTier(params));
+  if (serviceTier !== undefined) {
     base.serviceTier = serviceTier;
   }
   const approvalPolicy = normalizeCodexApprovalPolicy(params.approvalPolicy);
@@ -4609,7 +4725,7 @@ export class CodexAppServerClient {
     model?: string;
     approvalPolicy?: string;
     sandbox?: string;
-    serviceTier?: string;
+    serviceTier?: string | null;
     reasoningEffort?: string;
     fastMode?: boolean;
     codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
@@ -4645,7 +4761,7 @@ export class CodexAppServerClient {
     sandbox?: string;
     model?: string;
     collaborationMode?: AppServerCollaborationModeRequest;
-    serviceTier?: string;
+    serviceTier?: string | null;
     reasoningEffort?: string;
     fastMode?: boolean;
   }): Promise<{
@@ -4696,6 +4812,7 @@ export class CodexAppServerClient {
           model: params.model,
           reasoningEffort: params.reasoningEffort,
           serviceTier: params.serviceTier,
+          fastMode: params.fastMode,
           approvalPolicy: params.approvalPolicy,
           sandbox: params.sandbox,
           collaborationMode: params.collaborationMode,
@@ -4734,7 +4851,7 @@ export class CodexAppServerClient {
         payloads: [
           buildThreadStartPayload({
             model: DEFAULT_CODEX_THREAD_TITLE_MODEL,
-            serviceTier: "fast",
+            serviceTier: "priority",
             ephemeral: true,
             config: CODEX_THREAD_TITLE_CONFIG,
           }),
@@ -4763,7 +4880,7 @@ export class CodexAppServerClient {
             threadId: helperThreadId,
             input: [{ type: "text", text: params.prompt }],
             model: DEFAULT_CODEX_THREAD_TITLE_MODEL,
-            serviceTier: "fast",
+            serviceTier: "priority",
             reasoningEffort: "low",
             outputSchema: params.schema as CodexTurnStartParams["outputSchema"],
           }),

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -51,6 +51,19 @@ function parseDirectoryGitStatusCachePayload(
   }
 }
 
+function normalizeLaunchpadDefaults(
+  defaults: NavigationLaunchpadDefaults,
+): NavigationLaunchpadDefaults {
+  const next: NavigationLaunchpadDefaults = { ...defaults };
+  if (
+    next.backend === "codex" &&
+    (next.serviceTier === "fast" || next.serviceTier === "priority")
+  ) {
+    delete next.serviceTier;
+  }
+  return next;
+}
+
 export class SqliteOverlayStore {
   constructor(private readonly stateDb: StateDb) {}
 
@@ -719,7 +732,7 @@ export class SqliteOverlayStore {
     patch: Partial<NavigationLaunchpadDefaults>,
   ): Promise<NavigationLaunchpadDefaults> {
     const current = this.readLaunchpadDefaults();
-    const next = { ...current, ...patch };
+    const next = normalizeLaunchpadDefaults({ ...current, ...patch });
     this.writeLaunchpadDefaults(next);
     return next;
   }
@@ -913,21 +926,32 @@ export class SqliteOverlayStore {
     for (const row of rows) {
       defaults[row.key] = JSON.parse(row.value);
     }
-    return (
+    const parsed = (
       Object.keys(defaults).length > 0
         ? defaults
         : { backend: "codex", executionMode: "default" }
     ) as NavigationLaunchpadDefaults;
+    const normalized = normalizeLaunchpadDefaults(parsed);
+    if (
+      parsed.backend === "codex" &&
+      (parsed.serviceTier === "fast" || parsed.serviceTier === "priority")
+    ) {
+      this.writeLaunchpadDefaults(normalized);
+    }
+    return normalized;
   }
 
   private writeLaunchpadDefaults(defaults: NavigationLaunchpadDefaults): void {
-    const stmt = this.stateDb.raw.prepare(
+    const normalizedDefaults = normalizeLaunchpadDefaults(defaults);
+    const deleteStmt = this.stateDb.raw.prepare("DELETE FROM launchpad_defaults");
+    const insertStmt = this.stateDb.raw.prepare(
       "INSERT OR REPLACE INTO launchpad_defaults(key, value) VALUES (?, ?)",
     );
     const write = this.stateDb.raw.transaction(() => {
-      for (const [key, value] of Object.entries(defaults)) {
+      deleteStmt.run();
+      for (const [key, value] of Object.entries(normalizedDefaults)) {
         if (value !== undefined) {
-          stmt.run(key, JSON.stringify(value));
+          insertStmt.run(key, JSON.stringify(value));
         }
       }
     });

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -991,6 +991,17 @@ export type AppServerNotification =
       };
     }
   | {
+      method: "thread/codexSettings/observed";
+      params: {
+        threadId: string;
+        model?: string;
+        fastMode?: boolean;
+        reasoningEffort?: string;
+        serviceTier?: string | null;
+        rawServiceTier?: string | null;
+      };
+    }
+  | {
       method: "thread/acpRuntime/updated";
       params: {
         threadId: string;


### PR DESCRIPTION
## Summary

- Wire the PwrAgent `Fast` checkbox (`fastMode`) to Codex's actual Fast-mode wire value: `serviceTier: "priority"` on `thread/start`, `thread/resume`, and `turn/start`.
- Send an explicit `serviceTier: null` clear when Fast is unchecked so existing Codex threads do not keep a sticky priority tier from a previous turn.
- Fix launchpad materialization so the submitted UI launchpad state wins when a new thread is created. Previously, stale persisted directory launchpad settings could override the checkbox/model settings visible in the UI at submit time.
- Stop persisting Codex Fast tier aliases in launchpad defaults. Defaults now treat `fastMode` as the checkbox state and scrub stale `serviceTier: "fast"` / `"priority"` rows while preserving unknown future default keys.
- Normalize Codex settings notifications so observed `serviceTier: "priority"` maps back to `fastMode: true`, and keep legacy `"fast"` as an input/observed alias for compatibility.
- Add a turn-end diagnostic warning for mismatches between expected Fast checkbox state and Codex-observed tier, while preferring terminal event settings over cached `thread/settings/updated` observations.

## Root Cause

There were several independent drifts in the Fast-mode plumbing:

- The renderer stored a checkbox-shaped field, `fastMode`, but Codex requires a service-tier override. The first implementation used the wrong Codex wire value (`"fast"`) instead of Codex Desktop's real Fast value (`"priority"`).
- Existing Codex threads can retain service tier state, so omitting `serviceTier` when Fast was unchecked did not reliably clear a previous Fast/priority turn.
- Directory launchpad persistence could be stale relative to the launchpad object submitted from the UI. On thread creation, we sometimes read the saved launchpad row and overrode what the user actually had checked when they pressed send.
- Global launchpad defaults had accumulated stale `serviceTier` rows, including `serviceTier = "fast"` alongside `fastMode = false`. The SQLite store also did not remove cleared default keys, so stale rows survived across launches.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/codex-client.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/main/__tests__/overlay-store-launchpad-defaults.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `git diff --check origin/main...HEAD`
- Manual protocol-capture verification:
  - checked Fast sends `serviceTier: "priority"` on both `thread/resume` and `turn/start`
  - unchecked Fast sends `serviceTier: null` on both `thread/resume` and `turn/start`
