### PR TITLE
fix(desktop): preserve env action output order

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
@@ -74,6 +74,55 @@ describe("codex environment runtime", () => {
     }
   }, 15_000);
 
+  it("captures detached stdout and stderr in arrival order", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-env-output-order-"));
+    try {
+      const detachedExit = new Promise<{ output: string }>((resolve, reject) => {
+        void startLocalCodexEnvironmentAction({
+          actionId: "start-dev",
+          runId: "test-run-output-order",
+          env: {
+            ...process.env,
+            SHELL: "/bin/sh",
+          },
+          onDetachedExit: resolve,
+          runtime: {
+            environmentId: "env",
+            environmentName: "Env",
+            executionTarget: "local",
+            cwd: root,
+            actions: [
+              {
+                id: "start-dev",
+                name: "Start dev",
+                command: [
+                  "printf 'stdout first\\n'",
+                  "sleep 0.05",
+                  "printf 'stderr second\\n' >&2",
+                  "sleep 0.05",
+                  "printf 'stdout third\\n'",
+                  "sleep 0.05",
+                  "printf 'stderr fourth\\n' >&2",
+                ].join("\n"),
+              },
+            ],
+          },
+        }).catch(reject);
+      });
+
+      await expect(detachedExit).resolves.toMatchObject({
+        output: [
+          "stdout first",
+          "stderr second",
+          "stdout third",
+          "stderr fourth",
+        ].join("\n"),
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  }, 15_000);
+
   it("strips parent Electron runtime variables from detached actions", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-env-electron-"));
     const shellPath = path.join(root, "test-shell.sh");
@@ -463,25 +512,27 @@ describe("codex environment runtime", () => {
 
 describe("buildExitErrorSuffix", () => {
   it("returns an empty suffix when both streams are blank", () => {
-    expect(buildExitErrorSuffix("", "")).toBe("");
-    expect(buildExitErrorSuffix("   \n  ", "\n\n")).toBe("");
+    expect(buildExitErrorSuffix("")).toBe("");
+    expect(buildExitErrorSuffix("   \n  ")).toBe("");
   });
 
-  it("returns the stderr line when only stderr has content", () => {
-    expect(buildExitErrorSuffix("", "v24.14.1 is already installed.")).toBe(
+  it("returns the output line when only one stream has content", () => {
+    expect(buildExitErrorSuffix("v24.14.1 is already installed.")).toBe(
       ": v24.14.1 is already installed.",
     );
   });
 
-  it("returns the stdout content when only stdout has content (modern-CLI case)", () => {
-    expect(buildExitErrorSuffix("ERR_PNPM_IGNORED_BUILDS the actual reason for exit 1", "")).toBe(
+  it("returns the stdout-style content for modern CLI failures", () => {
+    expect(buildExitErrorSuffix("ERR_PNPM_IGNORED_BUILDS the actual reason for exit 1")).toBe(
       ": ERR_PNPM_IGNORED_BUILDS the actual reason for exit 1",
     );
   });
 
-  it("includes both streams concatenated when both have content", () => {
-    expect(buildExitErrorSuffix("first stdout line", "first stderr line")).toBe(
-      ": first stdout line\nfirst stderr line",
+  it("preserves already-interleaved stdout and stderr order", () => {
+    expect(
+      buildExitErrorSuffix("first stdout line\nfirst stderr line\nsecond stdout line"),
+    ).toBe(
+      ": first stdout line\nfirst stderr line\nsecond stdout line",
     );
   });
 
@@ -498,7 +549,7 @@ describe("buildExitErrorSuffix", () => {
       "line 9",
       "line 10",
     ].join("\n");
-    const suffix = buildExitErrorSuffix(stdout, "");
+    const suffix = buildExitErrorSuffix(stdout);
     // Last 8 of 10 lines, joined with newlines and prefixed by ": "
     expect(suffix).toBe(
       ": line 3\nline 4\nline 5\nline 6\nline 7\nline 8\nline 9\nline 10",
@@ -510,13 +561,13 @@ describe("buildExitErrorSuffix", () => {
     // its real exit-1 diagnostic to stdout, while stderr only contains
     // unrelated benign chatter from an earlier `nvm install`. Both must
     // survive into the suffix so the dialog headline isn't misled.
-    const stdout = [
+    const output = [
       "Scope: all 5 workspace projects",
+      "v24.14.1 is already installed.",
       "Progress: resolved 463, reused 463, downloaded 0, added 463, done",
       "ERR_PNPM_IGNORED_BUILDS Ignored build scripts: @ffmpeg-installer/darwin-arm64",
     ].join("\n");
-    const stderr = "v24.14.1 is already installed.";
-    const suffix = buildExitErrorSuffix(stdout, stderr);
+    const suffix = buildExitErrorSuffix(output);
     expect(suffix).toContain("ERR_PNPM_IGNORED_BUILDS");
     expect(suffix).toContain("v24.14.1 is already installed.");
   });

--- a/apps/desktop/src/main/app-server/codex-environment-runtime.ts
+++ b/apps/desktop/src/main/app-server/codex-environment-runtime.ts
@@ -34,15 +34,13 @@ function truncateForLog(value: string | undefined): string | undefined {
  * stderr buffer (e.g. nvm's "v24.14.1 is already installed" trailing a
  * pnpm install that exited 1 with ERR_PNPM_IGNORED_BUILDS on stdout).
  *
- * The fix: include the tail of the combined stdout+stderr buffer, the way
+ * The fix: include the tail of the arrival-ordered stdout+stderr buffer, the way
  * a user running the script in a terminal would have seen it. The full
  * output is still preserved on `CodexEnvironmentCommandError.output` for
  * the dialog's collapsible details — this is just the headline.
  */
-export function buildExitErrorSuffix(stdout: string, stderr: string): string {
-  const combined = [stdout.trimEnd(), stderr.trimEnd()]
-    .filter(Boolean)
-    .join("\n");
+export function buildExitErrorSuffix(output: string): string {
+  const combined = output.trimEnd();
   if (!combined) return "";
   const lines = combined.split("\n");
   const tail =
@@ -441,13 +439,16 @@ function runShellCommand(
       stdio: "pipe",
     });
 
-    let stdout = "";
-    let stderr = "";
+    let combinedOutput = "";
     let settled = false;
     let closed = false;
     let timedOut = false;
     let timeoutHandle: NodeJS.Timeout | undefined;
     let killHandle: NodeJS.Timeout | undefined;
+
+    const appendOutput = (text: string) => {
+      combinedOutput = `${combinedOutput}${text}`.slice(-32_000);
+    };
 
     const terminateChild = (signal: NodeJS.Signals) => {
       if (!child.pid) {
@@ -515,11 +516,8 @@ function runShellCommand(
       }
       snapshotTimer = setTimeout(() => {
         snapshotTimer = undefined;
-        const snapshotOutput = [stdout.trimEnd(), stderr.trimEnd()]
-          .filter(Boolean)
-          .join("\n");
         try {
-          params.onDetachedOutput?.({ output: snapshotOutput });
+          params.onDetachedOutput?.({ output: combinedOutput.trimEnd() });
         } catch (callbackError) {
           environmentRuntimeLog.warn(
             "codex-environment-detached-output-callback-failed",
@@ -537,7 +535,7 @@ function runShellCommand(
 
     child.stdout?.on("data", (chunk: Buffer) => {
       const text = chunk.toString("utf8");
-      stdout = `${stdout}${text}`.slice(-32_000);
+      appendOutput(text);
       params.onProgress?.({
         phase: "stdout",
         chunk: text,
@@ -547,7 +545,7 @@ function runShellCommand(
     });
     child.stderr?.on("data", (chunk: Buffer) => {
       const text = chunk.toString("utf8");
-      stderr = `${stderr}${text}`.slice(-4096);
+      appendOutput(text);
       params.onProgress?.({
         phase: "stderr",
         chunk: text,
@@ -609,9 +607,7 @@ function runShellCommand(
           snapshotTimer = undefined;
         }
         const durationMs = Date.now() - startedAt;
-        const combinedOutput = [stdout.trimEnd(), stderr.trimEnd()]
-          .filter(Boolean)
-          .join("\n");
+        const output = combinedOutput.trimEnd();
         if (code === 0) {
           environmentRuntimeLog.info("codex-environment-detached-exit", {
             processId,
@@ -629,7 +625,7 @@ function runShellCommand(
             durationMs,
             command: params.command,
             cwd: params.cwd,
-            output: truncateForLog(combinedOutput),
+            output: truncateForLog(output),
           });
         }
         try {
@@ -637,7 +633,7 @@ function runShellCommand(
             exitCode: typeof code === "number" ? code : null,
             exitSignal: signal ?? null,
             durationMs,
-            output: combinedOutput,
+            output,
           });
         } catch (callbackError) {
           environmentRuntimeLog.warn(
@@ -662,9 +658,7 @@ function runShellCommand(
         killHandle = undefined;
       }
       const durationMs = Date.now() - startedAt;
-      const combinedOutput = [stdout.trimEnd(), stderr.trimEnd()]
-        .filter(Boolean)
-        .join("\n");
+      const output = combinedOutput.trimEnd();
       if (timedOut) {
         environmentRuntimeLog.error("codex-environment-command-exit", {
           processId,
@@ -674,7 +668,7 @@ function runShellCommand(
           timedOut: true,
           command: params.command,
           cwd: params.cwd,
-          output: truncateForLog(combinedOutput),
+          output: truncateForLog(output),
         });
         settle(() => {
           reject(
@@ -682,7 +676,7 @@ function runShellCommand(
               `Codex environment command timed out after ${params.timeoutMs}ms`,
               {
                 durationMs,
-                output: combinedOutput,
+                output,
               },
             ),
           );
@@ -700,7 +694,7 @@ function runShellCommand(
           resolve({
             durationMs,
             exitCode: code,
-            output: combinedOutput,
+            output,
             pid: child.pid,
           });
         });
@@ -713,9 +707,9 @@ function runShellCommand(
         durationMs,
         command: params.command,
         cwd: params.cwd,
-        output: truncateForLog(combinedOutput),
+        output: truncateForLog(output),
       });
-      const suffix = buildExitErrorSuffix(stdout, stderr);
+      const suffix = buildExitErrorSuffix(output);
       settle(() => {
         reject(
           new CodexEnvironmentCommandError(
@@ -723,7 +717,7 @@ function runShellCommand(
             {
               durationMs,
               exitCode: typeof code === "number" ? code : undefined,
-              output: combinedOutput,
+              output,
             },
           ),
         );

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -6,6 +6,7 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
   useEffect,
   useId,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -491,6 +492,56 @@ function tailLines(text: string, maxLines: number): string {
   ].join("\n");
 }
 
+type EnvActionOutputChunk = {
+  id: number;
+  text: string;
+};
+
+type EnvActionOutputState = {
+  rawOutput: string;
+  chunks: EnvActionOutputChunk[];
+  nextChunkId: number;
+};
+
+function buildEnvActionOutputState(
+  output: string,
+  nextChunkId = 1,
+): EnvActionOutputState {
+  const text = tailLines(output, ENV_ACTION_OUTPUT_MAX_LINES);
+  return {
+    rawOutput: output,
+    chunks: text ? [{ id: nextChunkId - 1, text }] : [],
+    nextChunkId,
+  };
+}
+
+function trimEnvActionOutputChunks(
+  chunks: EnvActionOutputChunk[],
+): EnvActionOutputChunk[] {
+  const text = chunks.map((chunk) => chunk.text).join("");
+  const trimmed = tailLines(text, ENV_ACTION_OUTPUT_MAX_LINES);
+  if (trimmed === text) return chunks;
+  return [{ id: chunks.at(-1)?.id ?? 0, text: trimmed }];
+}
+
+function elementContainsSelection(element: HTMLElement | null): boolean {
+  if (!element) return false;
+  const selection = element.ownerDocument.getSelection();
+  if (!selection || selection.rangeCount === 0 || selection.isCollapsed) {
+    return false;
+  }
+  for (let index = 0; index < selection.rangeCount; index += 1) {
+    const range = selection.getRangeAt(index);
+    if (
+      element.contains(range.startContainer) ||
+      element.contains(range.endContainer)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
 // Exported for unit testing; the existing call sites import via the
 // in-file identifier.
 export function formatDurationMs(
@@ -653,7 +704,10 @@ export function EnvActionAnchorEntry(props: {
     }
   }
 
-  const truncatedOutput = tailLines((run.output ?? "").trim(), ENV_ACTION_OUTPUT_MAX_LINES);
+  const output = (run.output ?? "").trim();
+  const outputLineCount = output
+    ? tailLines(output, ENV_ACTION_OUTPUT_MAX_LINES).split("\n").length
+    : 0;
   const modifier =
     status === "failed"
       ? "composer__queued--env-action-failed"
@@ -706,23 +760,74 @@ export function EnvActionAnchorEntry(props: {
         <div className="composer__queued-env-action-section">
           <div className="composer__queued-env-action-section-label">
             Output
-            {truncatedOutput
-              ? ` · ${truncatedOutput.split("\n").length} line${
-                  truncatedOutput.split("\n").length === 1 ? "" : "s"
+            {outputLineCount
+              ? ` · ${outputLineCount} line${
+                  outputLineCount === 1 ? "" : "s"
                 }`
               : ""}
           </div>
-          <pre className="composer__queued-env-action-output">
-            <code>
-              {truncatedOutput ||
-                (status === "started"
-                  ? "(no output yet — waiting for the command to print something)"
-                  : "(no output captured)")}
-            </code>
-          </pre>
+          <EnvActionOutputBlock output={output} status={status} />
         </div>
       </div>
     </details>
+  );
+}
+
+function EnvActionOutputBlock(props: {
+  output: string;
+  status: CodexEnvironmentActionRun["status"];
+}): ReactNode {
+  const outputRef = useRef<HTMLPreElement | null>(null);
+  const [state, setState] = useState<EnvActionOutputState>(() =>
+    buildEnvActionOutputState(props.output),
+  );
+
+  useLayoutEffect(() => {
+    setState((current) => {
+      if (current.rawOutput === props.output) {
+        return current;
+      }
+
+      if (
+        current.rawOutput &&
+        props.output.startsWith(current.rawOutput)
+      ) {
+        const appended = props.output.slice(current.rawOutput.length);
+        if (!appended) {
+          return { ...current, rawOutput: props.output };
+        }
+        const nextChunks = [
+          ...current.chunks,
+          { id: current.nextChunkId, text: appended },
+        ];
+        return {
+          rawOutput: props.output,
+          chunks: elementContainsSelection(outputRef.current)
+            ? nextChunks
+            : trimEnvActionOutputChunks(nextChunks),
+          nextChunkId: current.nextChunkId + 1,
+        };
+      }
+
+      return buildEnvActionOutputState(props.output, current.nextChunkId + 1);
+    });
+  }, [props.output]);
+
+  const placeholder =
+    props.status === "started"
+      ? "(no output yet — waiting for the command to print something)"
+      : "(no output captured)";
+
+  return (
+    <pre className="composer__queued-env-action-output" ref={outputRef}>
+      <code>
+        {state.chunks.length > 0
+          ? state.chunks.map((chunk) => (
+              <span key={chunk.id}>{chunk.text}</span>
+            ))
+          : placeholder}
+      </code>
+    </pre>
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/EnvActionAnchorEntry.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/EnvActionAnchorEntry.test.tsx
@@ -148,6 +148,44 @@ describe("EnvActionAnchorEntry", () => {
         screen.getByText("(no output captured)"),
       ).toBeInTheDocument();
     });
+
+    it("appends live output without moving an existing text selection", () => {
+      const run = buildRun({
+        status: "started",
+        output: "alpha\nbeta",
+      });
+      const { container, rerender } = render(
+        <EnvActionAnchorEntry
+          run={run}
+          environmentName={undefined}
+          onDismiss={() => {}}
+        />,
+      );
+      const outputBlock = container.querySelector(
+        ".composer__queued-env-action-output",
+      );
+      const firstChunk = outputBlock?.querySelector("span")?.firstChild;
+      expect(firstChunk).toBeInstanceOf(Text);
+
+      const range = document.createRange();
+      range.setStart(firstChunk!, 0);
+      range.setEnd(firstChunk!, "alpha".length);
+      const selection = window.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+      expect(selection?.toString()).toBe("alpha");
+
+      rerender(
+        <EnvActionAnchorEntry
+          run={{ ...run, output: "alpha\nbeta\ngamma" }}
+          environmentName={undefined}
+          onDismiss={() => {}}
+        />,
+      );
+
+      expect(outputBlock?.textContent).toContain("gamma");
+      expect(selection?.toString()).toBe("alpha");
+    });
   });
 
   describe("dismiss interaction", () => {


### PR DESCRIPTION
## Summary

Environment action output now preserves the order users would see in a terminal, so stderr no longer drops below earlier stdout. The live output viewer also appends new text into stable DOM chunks, which keeps an active text selection anchored to the text the user actually selected while the command continues printing.

The runtime now stores one arrival-ordered output buffer for detached action snapshots, final exit output, and failure suffixes. The renderer keeps append-only chunks for growing output snapshots and falls back to a full reset only when the backend sends a non-prefix replacement.

## Test Plan

- `pnpm test apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts apps/desktop/src/renderer/src/features/composer/__tests__/EnvActionAnchorEntry.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
