### PR TITLE
fix(desktop): queue sends while thread is thinking

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -363,6 +363,7 @@ function DesktopAppShell(props: {
     pendingRequest: session.pendingRequest,
     pendingUserInput: session.pendingUserInput,
     pendingStatusText: session.pendingStatusText,
+    threadBusy: session.threadBusy,
     pastedImageMaxPatches:
       settings.snapshot?.imageUploads.pastedImageMaxPatches.value,
     platform: desktopApi?.platform,

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -151,6 +151,8 @@ type ComposerProps = {
   skillLoading?: boolean;
   skills: AppServerSkillSummary[];
   thread?: NavigationThreadSummary;
+  /** Selected-thread Thinking state from useThreadSessionState. Do not rebuild it here. */
+  threadBusy?: boolean;
   updatingExecutionMode?: ThreadExecutionMode;
   onSetExecutionMode?: (executionMode: ThreadExecutionMode) => Promise<void>;
   onSetAcpRuntimeOption?: (params: {
@@ -266,6 +268,8 @@ function createQueuedTurnId(): string {
   queuedTurnIdSequence += 1;
   return `queued-turn-${Date.now().toString(36)}-${queuedTurnIdSequence.toString(36)}`;
 }
+
+const globalQueuedTurnReleaseScopeKeys = new Set<string>();
 
 const SLASH_COMMANDS: SlashCommandSuggestion[] = [
   {
@@ -1799,6 +1803,14 @@ export function Composer(props: ComposerProps) {
       restoreClaimedQueuedTurn(queued);
     }
   };
+  const releaseQueuedTurnScopeLockIfClaimed = (
+    queued: QueuedTurnDraft | undefined,
+    queueClaimed: boolean | undefined,
+  ): void => {
+    if (queued && queueClaimed) {
+      globalQueuedTurnReleaseScopeKeys.delete(composerScopeKey);
+    }
+  };
   const setPendingSteer = (nextPendingSteer?: PendingSteerDraft): void => {
     if (nextPendingSteer?.status === "pending") {
       savePendingSteerSnapshot(composerScopeKey, nextPendingSteer);
@@ -2180,6 +2192,12 @@ export function Composer(props: ComposerProps) {
   }, [composerScopeKey, props.thread]);
 
   useEffect(() => {
+    return () => {
+      globalQueuedTurnReleaseScopeKeys.delete(composerScopeKey);
+    };
+  }, [composerScopeKey]);
+
+  useEffect(() => {
     updateActiveTurnId(props.activeTurnId);
 
     if (!props.activeTurnId) {
@@ -2246,6 +2264,7 @@ export function Composer(props: ComposerProps) {
           turnQueueRecord.status === "failed" ||
           turnQueueRecord.status === "cancelled"
         ) {
+          globalQueuedTurnReleaseScopeKeys.delete(composerScopeKey);
           updateServerQueuedTurnEntryId(undefined);
         }
       }
@@ -2281,6 +2300,21 @@ export function Composer(props: ComposerProps) {
         event.notification.method === "turn/failed" ||
         event.notification.method === "turn/cancelled"
       ) {
+        const terminalTurnId =
+          typeof event.notification.params.turnId === "string"
+            ? event.notification.params.turnId
+            : undefined;
+        if (
+          activeTurnIdRef.current &&
+          terminalTurnId &&
+          terminalTurnId !== activeTurnIdRef.current
+        ) {
+          return;
+        }
+        const clearsReleasedQueuedTurn =
+          Boolean(activeTurnIdRef.current) &&
+          (!terminalTurnId || terminalTurnId === activeTurnIdRef.current);
+
         if (
           activeOptimisticMessageId &&
           (event.notification.method === "turn/failed" ||
@@ -2289,6 +2323,9 @@ export function Composer(props: ComposerProps) {
           props.removeOptimisticMessage?.(activeOptimisticMessageId);
         }
         props.onPendingStatusChange?.(undefined);
+        if (clearsReleasedQueuedTurn) {
+          globalQueuedTurnReleaseScopeKeys.delete(composerScopeKey);
+        }
         updateSending(false);
         setInterrupting(false);
         setSteering(false);
@@ -2384,10 +2421,12 @@ export function Composer(props: ComposerProps) {
   }): Promise<void> => {
     if (props.disabled) {
       restoreQueuedTurnIfClaimed(options?.queued, options?.queueClaimed);
+      releaseQueuedTurnScopeLockIfClaimed(options?.queued, options?.queueClaimed);
       return;
     }
     if (!supportsReview) {
       restoreQueuedTurnIfClaimed(options?.queued, options?.queueClaimed);
+      releaseQueuedTurnScopeLockIfClaimed(options?.queued, options?.queueClaimed);
       setSendError("Selected backend does not support reviews.");
       return;
     }
@@ -2426,6 +2465,7 @@ export function Composer(props: ComposerProps) {
         unmarkComposerDraftSubmitted(submittedScopeKey);
         props.onPendingStatusChange?.(undefined);
         restoreQueuedTurnIfClaimed(options?.queued, options?.queueClaimed);
+        releaseQueuedTurnScopeLockIfClaimed(options?.queued, options?.queueClaimed);
         setSendError(error instanceof Error ? error.message : String(error));
       } finally {
         updateSending(false);
@@ -2437,6 +2477,7 @@ export function Composer(props: ComposerProps) {
       props.onPendingStatusChange?.(undefined);
       updateSending(false);
       restoreQueuedTurnIfClaimed(options?.queued, options?.queueClaimed);
+      releaseQueuedTurnScopeLockIfClaimed(options?.queued, options?.queueClaimed);
       return;
     }
 
@@ -2477,6 +2518,7 @@ export function Composer(props: ComposerProps) {
       updateActiveTurnId(undefined);
       props.onActiveTurnIdChange?.(undefined);
       restoreQueuedTurnIfClaimed(options?.queued, options?.queueClaimed);
+      releaseQueuedTurnScopeLockIfClaimed(options?.queued, options?.queueClaimed);
       setSendError(error instanceof Error ? error.message : String(error));
     }
   };
@@ -2531,6 +2573,9 @@ export function Composer(props: ComposerProps) {
   ): Promise<void> => {
     if (!props.thread || !props.desktopApi?.startTurn) {
       restoreQueuedTurnIfClaimed(queued, options?.queueClaimed);
+      if (queued && options?.queueClaimed) {
+        globalQueuedTurnReleaseScopeKeys.delete(composerScopeKey);
+      }
       return;
     }
 
@@ -2539,6 +2584,9 @@ export function Composer(props: ComposerProps) {
       : buildTurnPayload(canonicalDraft, imageAttachments);
     if (payload.input.length === 0 || props.disabled) {
       restoreQueuedTurnIfClaimed(queued, options?.queueClaimed);
+      if (queued && options?.queueClaimed) {
+        globalQueuedTurnReleaseScopeKeys.delete(composerScopeKey);
+      }
       return;
     }
 
@@ -2555,6 +2603,9 @@ export function Composer(props: ComposerProps) {
     if (props.onBeforeStartTurn && !(await props.onBeforeStartTurn())) {
       updateSending(false);
       restoreQueuedTurnIfClaimed(queued, options?.queueClaimed);
+      if (queued && options?.queueClaimed) {
+        globalQueuedTurnReleaseScopeKeys.delete(composerScopeKey);
+      }
       return;
     }
 
@@ -2615,6 +2666,9 @@ export function Composer(props: ComposerProps) {
       props.onActiveTurnIdChange?.(undefined);
       setActiveOptimisticMessageId(undefined);
       restoreQueuedTurnIfClaimed(queued, options?.queueClaimed);
+      if (queued && options?.queueClaimed) {
+        globalQueuedTurnReleaseScopeKeys.delete(composerScopeKey);
+      }
       setSendError(error instanceof Error ? error.message : String(error));
     }
   };
@@ -2622,6 +2676,7 @@ export function Composer(props: ComposerProps) {
   const sendQueuedTurn = async (queued: QueuedTurnDraft): Promise<void> => {
     const claimedQueuedTurn = claimQueuedTurn(queued);
     if (!claimedQueuedTurn) {
+      globalQueuedTurnReleaseScopeKeys.delete(composerScopeKey);
       return;
     }
 
@@ -2643,6 +2698,8 @@ export function Composer(props: ComposerProps) {
     }
     if (
       !queuedTurn ||
+      globalQueuedTurnReleaseScopeKeys.has(composerScopeKey) ||
+      props.threadBusy ||
       activeTurnId ||
       serverQueuedTurnEntryId ||
       sending ||
@@ -2656,6 +2713,7 @@ export function Composer(props: ComposerProps) {
     }
 
     queuedAutoReleaseAttemptIdRef.current = queuedTurn.id;
+    globalQueuedTurnReleaseScopeKeys.add(composerScopeKey);
     updateSending(true);
     void sendQueuedTurn(queuedTurn).finally(() => {
       updateSending(false);
@@ -2665,6 +2723,7 @@ export function Composer(props: ComposerProps) {
     queuedTurn,
     serverQueuedTurnEntryId,
     sending,
+    props.threadBusy,
     props.disabled,
     props.launchpad,
   ]);
@@ -2744,7 +2803,8 @@ export function Composer(props: ComposerProps) {
 
   const shouldQueueThreadSubmit = (): boolean =>
     !props.launchpad &&
-    (Boolean(activeTurnIdRef.current) ||
+    (Boolean(props.threadBusy) ||
+      Boolean(activeTurnIdRef.current) ||
       Boolean(serverQueuedTurnEntryIdRef.current) ||
       sendingRef.current);
 
@@ -5159,7 +5219,7 @@ export function Composer(props: ComposerProps) {
             }
             type="submit"
           >
-            {activeTurnId || serverQueuedTurnEntryId
+            {activeTurnId || serverQueuedTurnEntryId || props.threadBusy
               ? "Queue"
               : sending
               ? props.launchpad

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1,5 +1,6 @@
 import "@testing-library/jest-dom/vitest";
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { StrictMode } from "react";
 import type {
   BackendSummary,
   ComposerDraftRecoveryCandidate,
@@ -1265,6 +1266,61 @@ describe("Composer", () => {
     });
   });
 
+  it("queues Enter while the selected thread is busy before an active turn id arrives", async () => {
+    const startTurn = vi.fn(async (request: StartTurnRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      turnId: "turn-2",
+    }));
+    const baseProps = {
+      backends: [backendSummary("codex")],
+      desktopApi: {
+        onAgentEvent: () => () => undefined,
+        startTurn,
+      },
+      disabled: false,
+      skills: [],
+      thread: {
+        id: "thread-1",
+        title: "Busy thread",
+        titleSource: "explicit" as const,
+        source: "codex" as const,
+        executionMode: "default" as const,
+        linkedDirectories: [],
+        inbox: { inInbox: false },
+      },
+    };
+
+    const { rerender } = render(
+      <Composer
+        {...baseProps}
+        threadBusy
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "Follow up after thinking" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(startTurn).not.toHaveBeenCalled();
+    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+      "Follow up after thinking"
+    );
+    expect(textarea).toHaveValue("");
+
+    rerender(<Composer {...baseProps} threadBusy={false} />);
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          backend: "codex",
+          threadId: "thread-1",
+          input: [{ type: "text", text: "Follow up after thinking" }],
+        })
+      );
+    });
+  });
+
   it("keeps active-turn messages in oldest-first queue order", async () => {
     const startTurn = vi.fn(async (request: StartTurnRequest) => ({
       backend: request.backend,
@@ -1325,6 +1381,247 @@ describe("Composer", () => {
     expect(screen.getByLabelText("Queued message")).toHaveTextContent(
       "Second queued reply"
     );
+  });
+
+  it("keeps the second queued turn waiting after the first queued turn dispatches", async () => {
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex";
+          notification: {
+            method: string;
+            params: Record<string, unknown>;
+          };
+        }) => void)
+      | undefined;
+    const startTurn = vi.fn(async (request: StartTurnRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      turnId: `turn-${startTurn.mock.calls.length + 1}`,
+    }));
+    const baseProps = {
+      backends: [backendSummary("codex")],
+      desktopApi: {
+        onAgentEvent: (callback: NonNullable<DesktopApi["onAgentEvent"]> extends (
+          listener: infer Listener,
+        ) => unknown
+          ? Listener
+          : never) => {
+          agentEventHandler = callback as typeof agentEventHandler;
+          return () => undefined;
+        },
+        startTurn,
+      },
+      disabled: false,
+      skills: [],
+      thread: {
+        id: "thread-1",
+        title: "Stacked queue",
+        titleSource: "explicit" as const,
+        source: "codex" as const,
+        executionMode: "default" as const,
+        linkedDirectories: [],
+        inbox: { inInbox: false },
+      },
+    };
+
+    const { rerender } = render(
+      <StrictMode>
+        <Composer {...baseProps} activeTurnId="turn-1" />
+      </StrictMode>
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "First queued turn" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    fireEvent.change(textarea, { target: { value: "Second queued turn" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+      "First queued turn"
+    );
+    expect(screen.getByLabelText("Queued message 2")).toHaveTextContent(
+      "Second queued turn"
+    );
+
+    rerender(
+      <StrictMode>
+        <Composer {...baseProps} activeTurnId={undefined} />
+      </StrictMode>
+    );
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledTimes(1);
+    });
+    await flushReactUpdates();
+
+    expect(startTurn).toHaveBeenCalledTimes(1);
+    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+      "Second queued turn"
+    );
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+          },
+        },
+      });
+    });
+    await flushReactUpdates();
+
+    expect(startTurn).toHaveBeenCalledTimes(1);
+    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+      "Second queued turn"
+    );
+  });
+
+  it("only releases one queued turn when duplicate focused composers share a queue", async () => {
+    const draftStore = createComposerDraftStore();
+    const thread = {
+      id: "thread-1",
+      title: "Duplicate queue owner",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      executionMode: "default" as const,
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const scopeKey = "thread:codex:thread-1";
+    draftStore.setQueuedTurns(scopeKey, [
+      {
+        id: "queued-1",
+        text: "First duplicate-owned turn",
+        imageAttachments: [],
+        input: [{ type: "text", text: "First duplicate-owned turn" }],
+      },
+      {
+        id: "queued-2",
+        text: "Second duplicate-owned turn",
+        imageAttachments: [],
+        input: [{ type: "text", text: "Second duplicate-owned turn" }],
+      },
+      {
+        id: "queued-3",
+        text: "Third duplicate-owned turn",
+        imageAttachments: [],
+        input: [{ type: "text", text: "Third duplicate-owned turn" }],
+      },
+    ]);
+    const startTurn = vi.fn(async (request: StartTurnRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      turnId: `turn-${startTurn.mock.calls.length + 1}`,
+    }));
+    const baseProps = {
+      backends: [backendSummary("codex")],
+      desktopApi: {
+        onAgentEvent: () => () => undefined,
+        startTurn,
+      },
+      disabled: false,
+      draftStore,
+      skills: [],
+      thread,
+    };
+
+    render(
+      <>
+        <Composer {...baseProps} />
+        <Composer {...baseProps} />
+      </>
+    );
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledTimes(1);
+    });
+    await flushReactUpdates();
+
+    expect(startTurn).toHaveBeenCalledTimes(1);
+    expect(draftStore.getQueuedTurns(scopeKey).map((entry) => entry.text)).toEqual([
+      "Second duplicate-owned turn",
+      "Third duplicate-owned turn",
+    ]);
+  });
+
+  it("releases the queued-turn lock when a queued review start fails", async () => {
+    const draftStore = createComposerDraftStore();
+    const scopeKey = "thread:codex:thread-1";
+    draftStore.setQueuedTurns(scopeKey, [
+      {
+        id: "queued-review",
+        text: "/review main",
+        imageAttachments: [],
+        reviewCommand: {
+          displayText: "Review changes against main",
+          target: { type: "baseBranch", branch: "main" },
+        },
+      },
+      {
+        id: "queued-turn",
+        text: "Run after failed review",
+        imageAttachments: [],
+        input: [{ type: "text", text: "Run after failed review" }],
+      },
+    ]);
+    const startReview = vi.fn(async () => {
+      throw new Error("review unavailable");
+    });
+    const startTurn = vi.fn(async (request: StartTurnRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      turnId: "turn-after-review",
+    }));
+
+    render(
+      <Composer
+        backends={[
+          {
+            ...backendSummary("codex"),
+            capabilities: {
+              ...backendSummary("codex").capabilities,
+              startReview: true,
+            },
+            methods: ["thread/start", "turn/start", "review/start"],
+          },
+        ]}
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview,
+          startTurn,
+        }}
+        disabled={false}
+        draftStore={draftStore}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Failed queued review",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(startReview).toHaveBeenCalledTimes(1);
+    });
+    expect(startTurn).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Delete" })[0]);
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: [{ type: "text", text: "Run after failed review" }],
+        })
+      );
+    });
   });
 
   it("keeps a queued review local when the previous queued turn lands in the server queue", async () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -785,6 +785,7 @@ export type ThreadViewProps = {
   pendingRequest?: AppServerPendingRequestNotification;
   pendingUserInput?: PendingQuestionnaireState;
   pendingStatusText?: string;
+  threadBusy?: boolean;
   pastedImageMaxPatches?: number;
   platform?: string;
   selectedDirectory?: NavigationDirectorySummary;
@@ -2212,6 +2213,7 @@ export function ThreadView(props: ThreadViewProps) {
             skillLoading={props.skillLoading}
             skills={props.skills}
             thread={selectedThread!}
+            threadBusy={props.threadBusy}
             updatingExecutionMode={props.updatingExecutionMode}
           />
         </div>

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -115,6 +115,127 @@ describe("useThreadSessionState", () => {
     expect(getContextWindowMoonPhase(100.01)).toBe(8);
   });
 
+  it("exposes selected thread busy state from the same thinking state as row indicators", () => {
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread: vi.fn(async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        threadStatus: "idle" as const,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      })),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    expect(result.current.threadBusy).toBe(false);
+
+    act(() => {
+      result.current.setPendingStatusText("Thinking");
+    });
+
+    expect(result.current.threadBusy).toBe(true);
+    expect(result.current.thinkingThreadKeys["codex:thread-1"]).toBe(true);
+
+    act(() => {
+      result.current.setPendingStatusText(undefined);
+    });
+
+    expect(result.current.threadBusy).toBe(false);
+    expect(result.current.thinkingThreadKeys["codex:thread-1"]).toBeUndefined();
+  });
+
+  it("keeps a newer active turn busy when an older turn completion arrives", async () => {
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex" | "grok";
+          notification: {
+            method: string;
+            params: Record<string, unknown>;
+          };
+        }) => void)
+      | undefined;
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback as typeof agentEventHandler;
+        return () => undefined;
+      },
+      readThread: vi.fn(async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        threadStatus: "active" as const,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      })),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(agentEventHandler).toBeDefined();
+    });
+
+    act(() => {
+      result.current.setActiveTurnId("turn-2");
+      result.current.setPendingStatusText("Thinking");
+    });
+    expect(result.current.threadBusy).toBe(true);
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            turn: {
+              id: "turn-1",
+              status: "completed",
+              output: [{ type: "text", text: "First turn finished late." }],
+            },
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        result.current.entries.map((entry) =>
+          entry.type === "message" ? `${entry.role}:${entry.text}` : entry.type
+        )
+      ).toContain("assistant:First turn finished late.");
+    });
+    expect(result.current.activeTurnId).toBe("turn-2");
+    expect(result.current.threadBusy).toBe(true);
+    expect(result.current.pendingStatusText).toBe("Thinking");
+  });
+
   it("keeps the optimistic user message ahead of the completed assistant reply", async () => {
     let agentEventHandler:
       | ((event: {

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -1035,6 +1035,17 @@ function buildTurnMetadata(params: {
   };
 }
 
+function terminalTurnMatchesActiveTurn(
+  session: ThreadSessionEntry,
+  terminalTurnId: string | undefined,
+): boolean {
+  return Boolean(
+    !session.activeTurnId ||
+      !terminalTurnId ||
+      terminalTurnId === session.activeTurnId
+  );
+}
+
 function withTurnMetadata<T extends AppServerThreadMessageEntry>(
   entry: T,
   turn: AppServerThreadTurnMetadata | undefined
@@ -1915,6 +1926,7 @@ export function useThreadSessionState(params: {
     updater: (state: PendingMcpInteractionState) => PendingMcpInteractionState
   ) => void;
   setPendingStatusText: (status?: string) => void;
+  threadBusy: boolean;
   thinkingThreadKeys: Record<string, boolean>;
   setViewport: (viewport?: ThreadViewportState) => void;
   viewport?: ThreadViewportState;
@@ -2740,18 +2752,36 @@ export function useThreadSessionState(params: {
             fallbackStatus: "completed",
             turn: event.notification.params.turn,
           });
+          const completedTurnMatchesActive = terminalTurnMatchesActiveTurn(
+            current,
+            completedTurn?.id,
+          );
           if (liveTranscriptEventFiltering && isUnfocusedThread) {
             return {
               ...current,
-              activeTurnId: undefined,
-              activeTurnStartedAt: undefined,
+              activeTurnId: completedTurnMatchesActive
+                ? undefined
+                : current.activeTurnId,
+              activeTurnStartedAt: completedTurnMatchesActive
+                ? undefined
+                : current.activeTurnStartedAt,
               error: undefined,
               lastTouchedAt: nextLastTouchedAt,
-              pendingAssistantMessage: undefined,
-              pendingMcpInteraction: undefined,
-              pendingRequest: undefined,
-              pendingUserInput: undefined,
-              pendingStatusText: undefined,
+              pendingAssistantMessage: completedTurnMatchesActive
+                ? undefined
+                : current.pendingAssistantMessage,
+              pendingMcpInteraction: completedTurnMatchesActive
+                ? undefined
+                : current.pendingMcpInteraction,
+              pendingRequest: completedTurnMatchesActive
+                ? undefined
+                : current.pendingRequest,
+              pendingUserInput: completedTurnMatchesActive
+                ? undefined
+                : current.pendingUserInput,
+              pendingStatusText: completedTurnMatchesActive
+                ? undefined
+                : current.pendingStatusText,
             };
           }
 
@@ -2789,7 +2819,7 @@ export function useThreadSessionState(params: {
                   )
                   : entry
               ),
-            ...(current.pendingAssistantMessage
+            ...(current.pendingAssistantMessage && completedTurnMatchesActive
               ? completedTurnHasReview
                 ? []
                 : [
@@ -2857,9 +2887,15 @@ export function useThreadSessionState(params: {
 
           return {
             ...current,
-            activeTurnId: undefined,
-            activeTurnStartedAt: undefined,
-            completionHydrationRetries: 0,
+            activeTurnId: completedTurnMatchesActive
+              ? undefined
+              : current.activeTurnId,
+            activeTurnStartedAt: completedTurnMatchesActive
+              ? undefined
+              : current.activeTurnStartedAt,
+            completionHydrationRetries: completedTurnMatchesActive
+              ? 0
+              : current.completionHydrationRetries,
             error: undefined,
             expectOwnUpdate: true,
             hydratedUpdatedAt:
@@ -2871,22 +2907,45 @@ export function useThreadSessionState(params: {
             interacted: true,
             lastTouchedAt: nextLastTouchedAt,
             needsHydrationAfterCompletion:
-              !completedText || shouldHydrateUnknownPhaseAssistant,
+              completedTurnMatchesActive
+                ? !completedText || shouldHydrateUnknownPhaseAssistant
+                : current.needsHydrationAfterCompletion ||
+                  !completedText ||
+                  shouldHydrateUnknownPhaseAssistant,
             nextLiveEntrySequence:
               shouldAppendFinalMessage && completedText
                 ? current.nextLiveEntrySequence + 1
                 : current.nextLiveEntrySequence,
             optimisticEntries: remainingOptimisticEntries,
-            pendingAssistantMessage: undefined,
-            pendingMcpInteraction: undefined,
-            pendingRequest: undefined,
-            pendingUserInput: undefined,
-            pendingStatusText: undefined,
+            pendingAssistantMessage: completedTurnMatchesActive
+              ? undefined
+              : current.pendingAssistantMessage,
+            pendingMcpInteraction: completedTurnMatchesActive
+              ? undefined
+              : current.pendingMcpInteraction,
+            pendingRequest: completedTurnMatchesActive
+              ? undefined
+              : current.pendingRequest,
+            pendingUserInput: completedTurnMatchesActive
+              ? undefined
+              : current.pendingUserInput,
+            pendingStatusText: completedTurnMatchesActive
+              ? undefined
+              : current.pendingStatusText,
             response: nextResponse,
           };
         }
 
         if (event.notification.method === "turn/failed") {
+          if (
+            !terminalTurnMatchesActiveTurn(
+              current,
+              event.notification.params.turnId,
+            )
+          ) {
+            return current;
+          }
+
           const errorMessage =
             typeof event.notification.params.turn.error?.message === "string" &&
             event.notification.params.turn.error.message.trim()
@@ -2911,6 +2970,15 @@ export function useThreadSessionState(params: {
         }
 
         if (event.notification.method === "turn/cancelled") {
+          if (
+            !terminalTurnMatchesActiveTurn(
+              current,
+              event.notification.params.turnId,
+            )
+          ) {
+            return current;
+          }
+
           return {
             ...current,
             activeTurnId: undefined,
@@ -3352,6 +3420,7 @@ export function useThreadSessionState(params: {
   const pendingStatusText =
     selectedSession?.pendingStatusText ??
     (selectedSession?.activeTurnId ? "Thinking" : undefined);
+  const threadBusy = selectedSession ? hasThinkingState(selectedSession) : false;
 
   return {
     activeTurnId: selectedSession?.activeTurnId,
@@ -3379,6 +3448,7 @@ export function useThreadSessionState(params: {
     updatePendingUserInput,
     updatePendingMcpInteraction,
     setPendingStatusText,
+    threadBusy,
     thinkingThreadKeys,
     setViewport,
     viewport: selectedSession?.viewport,


### PR DESCRIPTION
## Summary
Queued follow-up turns now stay queued until the turn that was actually dispatched finishes. The composer consumes the centralized selected-thread busy state from `useThreadSessionState`, ignores stale terminal events for older turns, and uses a per-thread queued-release lock so duplicate focused Composer owners cannot claim multiple queued turns from the same draft store.

The broken paths were turn-end races: after queued turn one dispatched, stale completion events or a second release owner could make queued turn two look eligible before queued turn one was established as the busy turn. Review feedback is also addressed: failed queued reviews release the scope lock again, and late completions for older turns still record their transcript output while preserving the newer active turn state.

## Validation
- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
