### PR TITLE
fix(desktop): scope logs by normalized profile

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-profiles.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-profiles.test.ts
@@ -100,10 +100,10 @@ describe("Codex auth profile discovery", () => {
     });
   });
 
-  it("rejects invalid profile names before resolving a CODEX_HOME override", () => {
+  it("returns undefined when a profile name cannot normalize", () => {
     const root = createTempRoot();
     expect(
-      resolveCodexHomeForProfile("../work", {
+      resolveCodexHomeForProfile("!!!", {
         env: { CODEX_HOME: path.join(root, "codex") } as NodeJS.ProcessEnv,
       }),
     ).toBeUndefined();
@@ -113,19 +113,19 @@ describe("Codex auth profile discovery", () => {
     const root = createTempRoot();
     const codexHome = path.join(root, "codex");
 
-    const created = createCodexAuthProfile("work", {
+    const created = createCodexAuthProfile("My Work", {
       env: { CODEX_HOME: codexHome } as NodeJS.ProcessEnv,
     });
 
     expect(created).toEqual({
-      profile: "work",
-      codexHome: path.join(codexHome, "profiles", "work"),
+      profile: "my-work",
+      codexHome: path.join(codexHome, "profiles", "my-work"),
       created: true,
     });
     expect(fs.statSync(created.codexHome).isDirectory()).toBe(true);
 
     expect(
-      createCodexAuthProfile("work", {
+      createCodexAuthProfile("My Work", {
         env: { CODEX_HOME: codexHome } as NodeJS.ProcessEnv,
       }).created,
     ).toBe(false);

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -41,6 +41,20 @@ const disposeSettingsIpcHandlersMock = vi.fn();
 const registerWindowPointerIpcHandlersMock = vi.fn();
 const disposeWindowPointerIpcHandlersMock = vi.fn();
 const initializeMainLoggerMock = vi.fn();
+const resolveMainLogProfileNameMock = vi.fn((decision: BootDecisionLike) => {
+  switch (decision.kind) {
+    case "open":
+      return String(decision.profileName);
+    case "missing-named-profile":
+      return String(decision.requestedName);
+    case "missing-default-profile":
+      return String(decision.configuredName);
+    case "no-profile-configured":
+      return "bootstrap";
+    default:
+      return "bootstrap";
+  }
+});
 const requestOpenSettingsMock = vi.fn();
 const requestQuitMock = vi.fn(async () => true);
 const allowImmediateQuitMock = vi.fn();
@@ -255,6 +269,7 @@ vi.mock("../ipc/window-pointer", () => ({
 
 vi.mock("../log", () => ({
   initializeMainLogger: initializeMainLoggerMock,
+  resolveMainLogProfileName: resolveMainLogProfileNameMock,
   getMainLogger: vi.fn(() => ({
     info: mainLogInfoMock,
     warn: mainLogWarnMock,
@@ -398,6 +413,7 @@ describe("bootstrapApp", () => {
     registerWindowPointerIpcHandlersMock.mockReset();
     disposeWindowPointerIpcHandlersMock.mockReset();
     initializeMainLoggerMock.mockReset();
+    resolveMainLogProfileNameMock.mockClear();
     requestOpenSettingsMock.mockReset();
     requestQuitMock.mockReset();
     requestQuitMock.mockResolvedValue(true);
@@ -795,6 +811,9 @@ describe("bootstrapApp", () => {
     await import("../index");
     await flushMicrotasks();
 
+    expect(initializeMainLoggerMock).toHaveBeenCalledWith({
+      profileName: "default",
+    });
     // Open decision → today's flow. No bootstrap cleanup needed
     // mid-boot (the previous-boot's bootstrap dir, if any, gets
     // wiped only on `open` decisions — see comment in index.ts).
@@ -809,6 +828,9 @@ describe("bootstrapApp", () => {
     await import("../index");
     await flushMicrotasks();
 
+    expect(initializeMainLoggerMock).toHaveBeenCalledWith({
+      profileName: "bootstrap",
+    });
     // Bootstrap mode runs the wizard against the .bootstrap/ dir.
     // No cleanup at boot — we ARE the bootstrap session that will
     // own that dir; cleanup happens at graduation in Task E.
@@ -827,6 +849,9 @@ describe("bootstrapApp", () => {
     await import("../index");
     await flushMicrotasks();
 
+    expect(initializeMainLoggerMock).toHaveBeenCalledWith({
+      profileName: "ghost",
+    });
     // PWRAGENT_PROFILE=ghost on a host that doesn't have a ghost
     // profile dir: pre-#524 silently materialized one. Now we drop
     // into bootstrap mode so the wizard can ask "set up ghost,

--- a/apps/desktop/src/main/__tests__/log.test.ts
+++ b/apps/desktop/src/main/__tests__/log.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import electronLog from "electron-log/main.js";
-import { compactStructuredLogData } from "../log";
+import {
+  compactStructuredLogData,
+  resolveMainLogFileNameForProfile,
+  resolveMainLogProfileName,
+} from "../log";
 
 describe("main logger compact formatting", () => {
   it("suppresses the electron-log console transport during unit tests", () => {
@@ -34,5 +38,40 @@ describe("main logger compact formatting", () => {
       "message ok=true",
       error,
     ]);
+  });
+
+  it("uses profile-scoped main log filenames", () => {
+    expect(resolveMainLogFileNameForProfile("default")).toBe(
+      "profile-default.main.log",
+    );
+    expect(resolveMainLogFileNameForProfile("dev")).toBe("profile-dev.main.log");
+    expect(resolveMainLogFileNameForProfile("work")).toBe("profile-work.main.log");
+  });
+
+  it("derives the log profile from the startup boot decision", () => {
+    expect(
+      resolveMainLogProfileName({
+        kind: "open",
+        profileName: "dev",
+        profileDir: "/profiles/dev",
+        source: "env",
+      }),
+    ).toBe("dev");
+    expect(
+      resolveMainLogProfileName({
+        kind: "missing-named-profile",
+        requestedName: "work",
+        source: "cli",
+      }),
+    ).toBe("work");
+    expect(
+      resolveMainLogProfileName({
+        kind: "missing-default-profile",
+        configuredName: "personal",
+      }),
+    ).toBe("personal");
+    expect(resolveMainLogProfileName({ kind: "no-profile-configured" })).toBe(
+      "bootstrap",
+    );
   });
 });

--- a/apps/desktop/src/main/__tests__/profile.test.ts
+++ b/apps/desktop/src/main/__tests__/profile.test.ts
@@ -23,6 +23,7 @@ import {
   setDefaultProfileName,
   startProfileFocusRequestWatcher,
   startProfileRuntimeHeartbeat,
+  normalizeProfileName,
 } from "../profile";
 
 const roots: string[] = [];
@@ -125,6 +126,13 @@ describe("PwrAgent profiles", () => {
     );
   });
 
+  it("normalizes arbitrary display names into canonical profile ids", () => {
+    expect(normalizeProfileName("My Work Profile")).toBe("my-work-profile");
+    expect(normalizeProfileName("Café Ops")).toBe("cafe-ops");
+    expect(normalizeProfileName("con")).toBe("con-profile");
+    expect(normalizeProfileName("!!!")).toBe("");
+  });
+
   it("deletes inactive custom profiles and clears the startup default", () => {
     const { env, root } = createRoot();
     const activeEnv = {
@@ -218,11 +226,11 @@ describe("PwrAgent profiles", () => {
     it("returns missing-named-profile when PWRAGENT_PROFILE names a non-existent profile", () => {
       const { env } = createRoot();
       const decision = resolveProfileBootDecision({
-        env: { ...env, [PWRAGENT_PROFILE_ENV]: "ghost" },
+        env: { ...env, [PWRAGENT_PROFILE_ENV]: "Ghost Profile" },
       });
       expect(decision).toEqual({
         kind: "missing-named-profile",
-        requestedName: "ghost",
+        requestedName: "ghost-profile",
         source: "env",
       });
     });
@@ -231,11 +239,11 @@ describe("PwrAgent profiles", () => {
       const { env } = createRoot();
       const decision = resolveProfileBootDecision({
         env,
-        argv: ["PwrAgent", "--profile", "ghost"],
+        argv: ["PwrAgent", "--profile", "Ghost Profile"],
       });
       expect(decision).toEqual({
         kind: "missing-named-profile",
-        requestedName: "ghost",
+        requestedName: "ghost-profile",
         source: "cli",
       });
     });
@@ -333,23 +341,26 @@ describe("PwrAgent profiles", () => {
       });
     });
 
-    it("rejects invalid names from CLI before deciding existence", () => {
+    it("normalizes arbitrary names from CLI before deciding existence", () => {
       const { env } = createRoot();
-      expect(() =>
+      expect(
         resolveProfileBootDecision({
           env,
           argv: ["PwrAgent", "--profile", "Bad Name"],
         }),
-      ).toThrow(/Invalid profile name/);
+      ).toMatchObject({
+        kind: "missing-named-profile",
+        requestedName: "bad-name",
+      });
     });
 
-    it("rejects invalid names from env var before deciding existence", () => {
+    it("rejects env names that cannot normalize to a profile id", () => {
       const { env } = createRoot();
       expect(() =>
         resolveProfileBootDecision({
-          env: { ...env, [PWRAGENT_PROFILE_ENV]: "Bad Name" },
+          env: { ...env, [PWRAGENT_PROFILE_ENV]: "!!!" },
         }),
-      ).toThrow(/Invalid PWRAGENT_PROFILE/);
+      ).toThrow(/must contain at least one letter or number/);
     });
 
     it("ignores a stale .bootstrap/ dir — only profiles/ counts for decisions", () => {

--- a/apps/desktop/src/main/__tests__/profiles-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/profiles-ipc.test.ts
@@ -239,6 +239,52 @@ describe("profile IPC helpers", () => {
     expect(contents).not.toContain('completed_source = "wizard"');
   });
 
+  it("createDesktopPwrAgentProfile normalizes arbitrary profile names", async () => {
+    const root = createRoot();
+    const env = {
+      [PWRAGENT_HOME_ENV]: root,
+      [PWRAGENT_PROFILE_ENV]: "dev",
+    } as NodeJS.ProcessEnv;
+    ensureNamedProfileExists("dev", { env });
+    vi.stubEnv(PWRAGENT_HOME_ENV, root);
+    vi.stubEnv(PWRAGENT_PROFILE_ENV, "dev");
+    const { createDesktopPwrAgentProfile } = await import("../ipc/profiles");
+
+    const response = createDesktopPwrAgentProfile({ profile: "My Work Profile" });
+
+    expect(response.profile).toBe("my-work-profile");
+    expect(response.profileDir).toBe(
+      path.join(root, "profiles", "my-work-profile"),
+    );
+    expect(fs.existsSync(response.profileDir)).toBe(true);
+  });
+
+  it("openDesktopPwrAgentProfile normalizes before launching", async () => {
+    const root = createRoot();
+    const env = {
+      [PWRAGENT_HOME_ENV]: root,
+      [PWRAGENT_PROFILE_ENV]: "dev",
+    } as NodeJS.ProcessEnv;
+    ensureNamedProfileExists("dev", { env });
+    ensureNamedProfileExists("my-work-profile", { env });
+    vi.stubEnv(PWRAGENT_HOME_ENV, root);
+    vi.stubEnv(PWRAGENT_PROFILE_ENV, "dev");
+    const { openDesktopPwrAgentProfile } = await import("../ipc/profiles");
+
+    const response = openDesktopPwrAgentProfile({ profile: "My Work Profile" });
+
+    expect(response).toEqual({ opened: true, profile: "my-work-profile" });
+    expect(spawnMock).toHaveBeenCalledWith(
+      process.execPath,
+      expect.arrayContaining(["--profile", "my-work-profile"]),
+      expect.objectContaining({
+        env: expect.objectContaining({
+          [PWRAGENT_PROFILE_ENV]: "my-work-profile",
+        }),
+      }),
+    );
+  });
+
   it("createDesktopPwrAgentProfile with seedOnboardingCompleted=true marks the new profile as wizard-completed", async () => {
     // Wizard's Isolated + Multiple path: the operator just went through
     // the wizard to create this profile, so it should NOT re-fire the
@@ -434,12 +480,12 @@ describe("profile IPC helpers", () => {
       vi.stubEnv(PWRAGENT_HOME_ENV, root);
 
       const { writeDesktopSecretsToProfile } = await import("../ipc/profiles");
-      expect(() =>
-        writeDesktopSecretsToProfile({
-          profile: "Bad Name",
-          secrets: { grokApiKey: "x" },
-        }),
-      ).toThrow(/Invalid profile name/);
+    expect(() =>
+      writeDesktopSecretsToProfile({
+        profile: "!!!",
+        secrets: { grokApiKey: "x" },
+      }),
+    ).toThrow(/must contain at least one letter or number/);
       expect(safeStorageEncryptMock).not.toHaveBeenCalled();
     });
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -71,7 +71,11 @@ import {
   disposeWindowPointerIpcHandlers,
   registerWindowPointerIpcHandlers,
 } from "./ipc/window-pointer";
-import { getMainLogger, initializeMainLogger } from "./log";
+import {
+  getMainLogger,
+  initializeMainLogger,
+  resolveMainLogProfileName,
+} from "./log";
 import { StartupCpuProfiler } from "./diagnostics/startup-cpu-profiler";
 import {
   disposeDesktopMessagingRuntime,
@@ -408,7 +412,10 @@ export function bootstrapApp(): void {
     applicationVersion: app.getVersion(),
     copyright: APP_COPYRIGHT,
   });
-  initializeMainLogger();
+  const bootDecision = resolveProfileBootDecision();
+  initializeMainLogger({
+    profileName: resolveMainLogProfileName(bootDecision),
+  });
   installProcessShutdownHandlers();
 
   app.whenReady().then(async () => {
@@ -425,7 +432,6 @@ export function bootstrapApp(): void {
     // into "bootstrap" mode against the throwaway .bootstrap/ dir.
     // Wizard Finish graduates the bootstrap state into a real
     // profile and opens a new window for it (see Task E).
-    const bootDecision = resolveProfileBootDecision();
     // Reduce the 4-variant decision to a 2-variant app-state mode.
     // The explicit switch (vs. a bare `kind === "open" ? … : …`)
     // forces a compile error if a future variant is added — the

--- a/apps/desktop/src/main/ipc/app-metadata.ts
+++ b/apps/desktop/src/main/ipc/app-metadata.ts
@@ -25,6 +25,7 @@ import { readAppLogSnapshot, subscribeAppLogEntries } from "../app-logs";
 import { showAppLogWindow } from "../app-log-window";
 import { showChangelogWindow } from "../changelog-window";
 import { showThirdPartyNoticesWindow } from "../license-document-window";
+import { getMainLogFilePath } from "../log";
 import { subscribersForChannel } from "../window-channels";
 
 const APP_COPYRIGHT = "Copyright © 2026 PwrDrvr LLC.";
@@ -129,7 +130,11 @@ export function registerAppMetadataIpcHandlers(): void {
   );
   ipcMain.handle(
     APP_LOG_SNAPSHOT_READ_CHANNEL,
-    async (): Promise<AppLogSnapshot> => readAppLogSnapshot(),
+    async (): Promise<AppLogSnapshot> => {
+      const snapshot = readAppLogSnapshot();
+      const logFilePath = getMainLogFilePath();
+      return logFilePath ? { ...snapshot, logFilePath } : snapshot;
+    },
   );
   ipcMain.handle(APP_LOG_WINDOW_OPEN_CHANNEL, async (): Promise<void> => {
     showAppLogWindow();

--- a/apps/desktop/src/main/ipc/boot-info.ts
+++ b/apps/desktop/src/main/ipc/boot-info.ts
@@ -13,7 +13,7 @@ import { getMainLogger } from "../log";
 import {
   assertUnreachableProfileBootDecision,
   findLiveProfileRuntimeMarkers,
-  isValidProfileName,
+  normalizeProfileName,
   resolveActiveProfileName,
 } from "../profile";
 import { getAppStateMode, getBootDecision } from "../state/app-state";
@@ -127,9 +127,11 @@ export function registerBootInfoIpcHandlers(options?: {
       _event,
       request: WaitForDesktopProfileAliveRequest,
     ): Promise<WaitForDesktopProfileAliveResponse> => {
-      const profile = request.profile.trim();
-      if (!isValidProfileName(profile)) {
-        throw new Error(`Invalid profile name "${profile}".`);
+      const profile = normalizeProfileName(request.profile);
+      if (!profile) {
+        throw new Error(
+          `Profile name "${request.profile}" must contain at least one letter or number.`,
+        );
       }
       const timeoutMs = request.timeoutMs ?? 10_000;
       const pollIntervalMs = 200;

--- a/apps/desktop/src/main/ipc/profiles.ts
+++ b/apps/desktop/src/main/ipc/profiles.ts
@@ -37,7 +37,7 @@ import {
   ensureProfileExists,
   ensureNamedProfileExists,
   forgetDeletedProfile,
-  isValidProfileName,
+  normalizeProfileName,
   readProfilesRegistry,
   requestProfileInstanceFocus,
   resolveActiveProfileName,
@@ -128,9 +128,11 @@ function readPwrAgentProfileCodexProfile(profileName: string) {
 export function openDesktopPwrAgentProfile(
   request: OpenDesktopPwrAgentProfileRequest,
 ): OpenDesktopPwrAgentProfileResponse {
-  const profile = request.profile.trim();
-  if (!isValidProfileName(profile)) {
-    throw new Error(`Invalid profile name "${profile}".`);
+  const profile = normalizeProfileName(request.profile);
+  if (!profile) {
+    throw new Error(
+      `Profile name "${request.profile}" must contain at least one letter or number.`,
+    );
   }
 
   const activeProfile = resolveActiveProfileName();
@@ -189,9 +191,11 @@ export function replaceProfileLaunchArgs(
 export function createDesktopPwrAgentProfile(
   request: CreateDesktopPwrAgentProfileRequest,
 ): CreateDesktopPwrAgentProfileResponse {
-  const profile = request.profile.trim();
-  if (!isValidProfileName(profile)) {
-    throw new Error(`Invalid profile name "${profile}".`);
+  const profile = normalizeProfileName(request.profile);
+  if (!profile) {
+    throw new Error(
+      `Profile name "${request.profile}" must contain at least one letter or number.`,
+    );
   }
   const result = ensureNamedProfileExists(profile);
 
@@ -220,9 +224,11 @@ export function createDesktopPwrAgentProfile(
 export function setDefaultDesktopPwrAgentProfile(
   request: SetDefaultDesktopPwrAgentProfileRequest,
 ): SetDefaultDesktopPwrAgentProfileResponse {
-  const profile = request.profile.trim();
-  if (!isValidProfileName(profile)) {
-    throw new Error(`Invalid profile name "${profile}".`);
+  const profile = normalizeProfileName(request.profile);
+  if (!profile) {
+    throw new Error(
+      `Profile name "${request.profile}" must contain at least one letter or number.`,
+    );
   }
   return { profile: setDefaultProfileName(profile) };
 }
@@ -230,7 +236,12 @@ export function setDefaultDesktopPwrAgentProfile(
 export async function deleteDesktopPwrAgentProfile(
   request: DeleteDesktopPwrAgentProfileRequest,
 ): Promise<DeleteDesktopPwrAgentProfileResponse> {
-  const profile = request.profile.trim();
+  const profile = normalizeProfileName(request.profile);
+  if (!profile) {
+    throw new Error(
+      `Profile name "${request.profile}" must contain at least one letter or number.`,
+    );
+  }
   const profileDir = assertProfileCanBeDeleted(profile);
   let movedToTrash = false;
   if (process.platform === "darwin" && fs.existsSync(profileDir)) {
@@ -286,9 +297,11 @@ export async function deleteDesktopPwrAgentProfile(
 export function graduateDesktopBootstrapConfigToProfile(
   request: GraduateDesktopBootstrapConfigToProfileRequest,
 ): GraduateDesktopBootstrapConfigToProfileResponse {
-  const targetProfile = request.targetProfile.trim();
-  if (!isValidProfileName(targetProfile)) {
-    throw new Error(`Invalid profile name "${targetProfile}".`);
+  const targetProfile = normalizeProfileName(request.targetProfile);
+  if (!targetProfile) {
+    throw new Error(
+      `Profile name "${request.targetProfile}" must contain at least one letter or number.`,
+    );
   }
 
   if (getAppStateMode() !== "bootstrap") {
@@ -354,9 +367,11 @@ export function graduateDesktopBootstrapConfigToProfile(
 export function writeDesktopSecretsToProfile(
   request: WriteDesktopSecretsToProfileRequest,
 ): WriteDesktopSecretsToProfileResponse {
-  const profile = request.profile.trim();
-  if (!isValidProfileName(profile)) {
-    throw new Error(`Invalid profile name "${profile}".`);
+  const profile = normalizeProfileName(request.profile);
+  if (!profile) {
+    throw new Error(
+      `Profile name "${request.profile}" must contain at least one letter or number.`,
+    );
   }
   // Dev-only opt-out: skip the entire write path when the env var
   // is set. Returns success with an empty `written` list so the
@@ -419,13 +434,17 @@ export function writeDesktopSecretsToProfile(
 export async function setDesktopPwrAgentProfileCodexProfile(
   request: SetDesktopPwrAgentProfileCodexProfileRequest,
 ): Promise<SetDesktopPwrAgentProfileCodexProfileResponse> {
-  const profile = request.profile.trim();
-  const codexProfile = request.codexProfile.trim();
-  if (!isValidProfileName(profile)) {
-    throw new Error(`Invalid profile name "${profile}".`);
+  const profile = normalizeProfileName(request.profile);
+  const codexProfile = normalizeProfileName(request.codexProfile);
+  if (!profile) {
+    throw new Error(
+      `Profile name "${request.profile}" must contain at least one letter or number.`,
+    );
   }
-  if (codexProfile && !isValidProfileName(codexProfile)) {
-    throw new Error(`Invalid Codex profile name "${codexProfile}".`);
+  if (request.codexProfile.trim() && !codexProfile) {
+    throw new Error(
+      `Codex profile name "${request.codexProfile}" must contain at least one letter or number.`,
+    );
   }
 
   ensureProfileExists({

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -87,7 +87,7 @@ import type {
   AcpRegistrySnapshot,
 } from "../acp/acp-registry-types";
 import { getAppStateDb } from "../state/app-state";
-import { resolveActiveProfileDir } from "../profile";
+import { normalizeProfileName, resolveActiveProfileDir } from "../profile";
 
 const settingsIpcLog = getMainLogger("pwragent:settings");
 const activeCodexLoginProcesses = new Map<
@@ -423,7 +423,13 @@ async function checkCodexProfileAuthStatus(
   service: DesktopSettingsService,
   request: CheckDesktopCodexAuthProfileStatusRequest,
 ): Promise<CheckDesktopCodexAuthProfileStatusResponse> {
-  const profile = request.profile.trim();
+  const profile =
+    request.profile.trim() === "" ? "" : normalizeProfileName(request.profile);
+  if (request.profile.trim() !== "" && !profile) {
+    throw new Error(
+      `Codex profile name "${request.profile}" must contain at least one letter or number.`,
+    );
+  }
   const codexHome = resolveRequiredCodexProfileHome(profile);
   const command = await resolveCodexCommandForProfileWorkflow(service);
   const result = await collectCodexStatus(command, codexHome);
@@ -950,7 +956,13 @@ export function registerSettingsIpcHandlers(
       _event,
       request: StartDesktopCodexAuthProfileLoginRequest,
     ): Promise<StartDesktopCodexAuthProfileLoginResponse> => {
-      const profile = request.profile.trim();
+      const profile =
+        request.profile.trim() === "" ? "" : normalizeProfileName(request.profile);
+      if (request.profile.trim() !== "" && !profile) {
+        throw new Error(
+          `Codex profile name "${request.profile}" must contain at least one letter or number.`,
+        );
+      }
       const codexHome = resolveRequiredCodexProfileHome(profile);
       const command = await resolveCodexCommandForProfileWorkflow(
         getService(service),

--- a/apps/desktop/src/main/log.ts
+++ b/apps/desktop/src/main/log.ts
@@ -1,5 +1,6 @@
 import electronLog from "electron-log/main.js";
 import { appendAppLogEntry } from "./app-logs";
+import type { ProfileBootDecision } from "./profile";
 
 let initialized = false;
 const MAX_COMPACT_STRING_LENGTH = 320;
@@ -15,12 +16,17 @@ if (process.env.VITEST === "true" && electronLogConsoleTransport) {
   electronLogConsoleTransport.level = false;
 }
 
-export function initializeMainLogger(): void {
+export function initializeMainLogger(options?: { profileName?: string }): void {
   if (initialized) {
     return;
   }
 
   initialized = true;
+  if (options?.profileName) {
+    electronLog.transports.file.fileName = resolveMainLogFileNameForProfile(
+      options.profileName,
+    );
+  }
   electronLog.initialize();
   electronLog.scope.labelPadding = false;
   electronLog.hooks.push((
@@ -46,6 +52,33 @@ export function initializeMainLogger(): void {
 
 export function getMainLogger(scope: string) {
   return electronLog.scope(scope);
+}
+
+export function resolveMainLogProfileName(
+  decision: ProfileBootDecision,
+): string {
+  switch (decision.kind) {
+    case "open":
+      return decision.profileName;
+    case "missing-named-profile":
+      return decision.requestedName;
+    case "missing-default-profile":
+      return decision.configuredName;
+    case "no-profile-configured":
+      return "bootstrap";
+  }
+}
+
+export function resolveMainLogFileNameForProfile(profileName: string): string {
+  return `profile-${profileName}.main.log`;
+}
+
+export function getMainLogFilePath(): string | undefined {
+  try {
+    return electronLog.transports?.file?.getFile().path;
+  } catch {
+    return undefined;
+  }
 }
 
 type CompactField = {

--- a/apps/desktop/src/main/profile.ts
+++ b/apps/desktop/src/main/profile.ts
@@ -2,6 +2,12 @@ import fs from "node:fs";
 import { randomUUID } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
+import {
+  isCanonicalProfileName,
+  normalizeProfileName,
+} from "@pwragent/shared";
+
+export { normalizeProfileName };
 
 export const PWRAGENT_PROFILE_ENV = "PWRAGENT_PROFILE";
 export const PWRAGENT_HOME_ENV = "PWRAGENT_HOME";
@@ -20,8 +26,6 @@ export const PWRAGENT_HOME_ENV = "PWRAGENT_HOME";
  */
 export const PWRAGENT_PROFILE_AUTO_CREATE_ENV = "PWRAGENT_PROFILE_AUTO_CREATE";
 
-const PROFILE_NAME_REGEX = /^[a-z0-9][a-z0-9_-]{0,31}$/;
-const RESERVED_NAMES = new Set(["con", "nul", "aux", "prn", ".", ".."]);
 const PROFILE_RUNTIME_HEARTBEAT_INTERVAL_MS = 10_000;
 const PROFILE_RUNTIME_HEARTBEAT_TTL_MS = 45_000;
 
@@ -82,7 +86,7 @@ export type ProfileRuntimeMarker = {
 let cachedProcessActiveProfileName: string | undefined;
 
 export function isValidProfileName(name: string): boolean {
-  return PROFILE_NAME_REGEX.test(name) && !RESERVED_NAMES.has(name);
+  return isCanonicalProfileName(name);
 }
 
 export function resolvePwragentRoot(options?: {
@@ -184,10 +188,10 @@ export function resolveProfileBootDecision(options?: {
   const cliProfile =
     options?.cliProfile?.trim() || readProfileArg(options?.argv)?.trim();
   if (cliProfile) {
-    const name = cliProfile.trim();
-    if (!isValidProfileName(name)) {
+    const name = normalizeProfileName(cliProfile);
+    if (!name) {
       throw new Error(
-        `Invalid profile name "${name}". Must match ${PROFILE_NAME_REGEX.source} and not be a reserved name.`,
+        `Profile name "${cliProfile}" must contain at least one letter or number.`,
       );
     }
     return decideForRequestedName(name, "cli", { env: options?.env, homeDir: options?.homeDir }, autoCreate);
@@ -196,12 +200,13 @@ export function resolveProfileBootDecision(options?: {
   // 2. PWRAGENT_PROFILE env var.
   const envProfile = env[PWRAGENT_PROFILE_ENV]?.trim();
   if (envProfile) {
-    if (!isValidProfileName(envProfile)) {
+    const name = normalizeProfileName(envProfile);
+    if (!name) {
       throw new Error(
-        `Invalid PWRAGENT_PROFILE="${envProfile}". Must match ${PROFILE_NAME_REGEX.source} and not be a reserved name.`,
+        `PWRAGENT_PROFILE="${envProfile}" must contain at least one letter or number.`,
       );
     }
-    return decideForRequestedName(envProfile, "env", { env: options?.env, homeDir: options?.homeDir }, autoCreate);
+    return decideForRequestedName(name, "env", { env: options?.env, homeDir: options?.homeDir }, autoCreate);
   }
 
   // 3. profiles.toml::default_profile.
@@ -299,10 +304,10 @@ function resolveActiveProfileNameUncached(options?: {
   const cliProfile =
     options?.cliProfile?.trim() || readProfileArg(options?.argv)?.trim();
   if (cliProfile) {
-    const name = cliProfile.trim();
-    if (!isValidProfileName(name)) {
+    const name = normalizeProfileName(cliProfile);
+    if (!name) {
       throw new Error(
-        `Invalid profile name "${name}". Must match ${PROFILE_NAME_REGEX.source} and not be a reserved name.`,
+        `Profile name "${cliProfile}" must contain at least one letter or number.`,
       );
     }
     return name;
@@ -311,12 +316,13 @@ function resolveActiveProfileNameUncached(options?: {
   const env = options?.env ?? process.env;
   const envProfile = env[PWRAGENT_PROFILE_ENV]?.trim();
   if (envProfile) {
-    if (!isValidProfileName(envProfile)) {
+    const name = normalizeProfileName(envProfile);
+    if (!name) {
       throw new Error(
-        `Invalid PWRAGENT_PROFILE="${envProfile}". Must match ${PROFILE_NAME_REGEX.source} and not be a reserved name.`,
+        `PWRAGENT_PROFILE="${envProfile}" must contain at least one letter or number.`,
       );
     }
-    return envProfile;
+    return name;
   }
 
   return resolveDefaultProfileName(options);
@@ -337,12 +343,13 @@ export function resolveProfileDir(
   profileName: string,
   options?: { env?: NodeJS.ProcessEnv; homeDir?: string },
 ): string {
-  if (!isValidProfileName(profileName)) {
+  const normalizedProfileName = normalizeProfileName(profileName);
+  if (!normalizedProfileName) {
     throw new Error(
-      `Invalid profile name "${profileName}". Must match ${PROFILE_NAME_REGEX.source} and not be a reserved name.`,
+      `Profile name "${profileName}" must contain at least one letter or number.`,
     );
   }
-  return path.join(resolvePwragentRoot(options), "profiles", profileName);
+  return path.join(resolvePwragentRoot(options), "profiles", normalizedProfileName);
 }
 
 export function resolveActiveProfileDir(options?: {
@@ -435,7 +442,13 @@ export function ensureNamedProfileExists(
     homeDir?: string;
   },
 ): { profileDir: string; profileName: string; created: boolean } {
-  const profileDir = resolveProfileDir(profileName, options);
+  const normalizedProfileName = normalizeProfileName(profileName);
+  if (!normalizedProfileName) {
+    throw new Error(
+      `Profile name "${profileName}" must contain at least one letter or number.`,
+    );
+  }
+  const profileDir = resolveProfileDir(normalizedProfileName, options);
   const created = !fs.existsSync(profileDir);
 
   if (created) {
@@ -444,13 +457,13 @@ export function ensureNamedProfileExists(
   }
 
   const registry = readProfilesRegistry(options);
-  const existing = registry.profiles.find((p) => p.name === profileName);
+  const existing = registry.profiles.find((p) => p.name === normalizedProfileName);
   if (!existing) {
-    registry.profiles.push({ name: profileName });
+    registry.profiles.push({ name: normalizedProfileName });
     writeProfilesRegistry(registry, options);
   }
 
-  return { profileDir, profileName, created };
+  return { profileDir, profileName: normalizedProfileName, created };
 }
 
 /**
@@ -538,57 +551,61 @@ export function setDefaultProfileName(
   profileName: string,
   options?: { env?: NodeJS.ProcessEnv; homeDir?: string },
 ): string {
-  ensureNamedProfileExists(profileName, options);
+  const normalizedProfileName = ensureNamedProfileExists(profileName, options).profileName;
   const registry = readProfilesRegistry(options);
-  registry.default_profile = profileName === "default" ? undefined : profileName;
+  registry.default_profile =
+    normalizedProfileName === "default" ? undefined : normalizedProfileName;
   writeProfilesRegistry(registry, options);
-  return profileName;
+  return normalizedProfileName;
 }
 
 export function deleteProfile(
   profileName: string,
   options?: { env?: NodeJS.ProcessEnv; homeDir?: string },
 ): void {
-  const profileDir = assertProfileCanBeDeleted(profileName, options);
+  const normalizedProfileName = normalizeProfileName(profileName);
+  const profileDir = assertProfileCanBeDeleted(normalizedProfileName, options);
   fs.rmSync(profileDir, { recursive: true, force: true });
-  forgetDeletedProfile(profileName, options);
+  forgetDeletedProfile(normalizedProfileName, options);
 }
 
 export function assertProfileCanBeDeleted(
   profileName: string,
   options?: { env?: NodeJS.ProcessEnv; homeDir?: string; now?: number },
 ): string {
-  if (!isValidProfileName(profileName)) {
-    throw new Error(`Invalid profile name "${profileName}".`);
+  const normalizedProfileName = normalizeProfileName(profileName);
+  if (!normalizedProfileName) {
+    throw new Error(`Profile name "${profileName}" must contain at least one letter or number.`);
   }
-  if (profileName === "default") {
+  if (normalizedProfileName === "default") {
     throw new Error("The default profile cannot be deleted.");
   }
 
   const activeProfile = resolveActiveProfileName(options);
-  if (profileName === activeProfile) {
+  if (normalizedProfileName === activeProfile) {
     throw new Error("The active profile cannot be deleted.");
   }
 
-  const liveMarkers = findLiveProfileRuntimeMarkers(profileName, options);
+  const liveMarkers = findLiveProfileRuntimeMarkers(normalizedProfileName, options);
   if (liveMarkers.length > 0) {
     throw new Error(
-      `Profile "${profileName}" is open in another PwrAgent instance. Close that instance before deleting this profile.`,
+      `Profile "${normalizedProfileName}" is open in another PwrAgent instance. Close that instance before deleting this profile.`,
     );
   }
 
-  return resolveProfileDir(profileName, options);
+  return resolveProfileDir(normalizedProfileName, options);
 }
 
 export function forgetDeletedProfile(
   profileName: string,
   options?: { env?: NodeJS.ProcessEnv; homeDir?: string },
 ): void {
+  const normalizedProfileName = normalizeProfileName(profileName);
   const registry = readProfilesRegistry(options);
   registry.profiles = registry.profiles.filter(
-    (entry) => entry.name !== profileName,
+    (entry) => entry.name !== normalizedProfileName,
   );
-  if (registry.default_profile === profileName) {
+  if (registry.default_profile === normalizedProfileName) {
     registry.default_profile = undefined;
   }
   writeProfilesRegistry(registry, options);
@@ -605,16 +622,20 @@ export function startProfileRuntimeHeartbeat(
     processId?: number;
   },
 ): ProfileRuntimeHeartbeat {
+  const normalizedProfileName = normalizeProfileName(profileName);
+  if (!normalizedProfileName) {
+    throw new Error(`Profile name "${profileName}" must contain at least one letter or number.`);
+  }
   const now = options?.now ?? Date.now;
   const processId = options?.processId ?? process.pid;
   const marker: ProfileRuntimeMarker = {
     instanceId: options?.instanceId ?? randomUUID(),
     processId,
-    profileName,
+    profileName: normalizedProfileName,
     startedAt: now(),
     heartbeatAt: now(),
   };
-  const markerDir = resolveProfileRuntimeMarkerDir(profileName, options);
+  const markerDir = resolveProfileRuntimeMarkerDir(normalizedProfileName, options);
   fs.mkdirSync(markerDir, { recursive: true });
   const markerPath = path.join(markerDir, `${processId}-${marker.instanceId}.json`);
   let interval: ReturnType<typeof setInterval> | undefined;
@@ -662,7 +683,11 @@ export function findLiveProfileRuntimeMarkers(
   profileName: string,
   options?: { env?: NodeJS.ProcessEnv; homeDir?: string; now?: number },
 ): ProfileRuntimeMarker[] {
-  const markerDir = resolveProfileRuntimeMarkerDir(profileName, options);
+  const normalizedProfileName = normalizeProfileName(profileName);
+  if (!normalizedProfileName) {
+    return [];
+  }
+  const markerDir = resolveProfileRuntimeMarkerDir(normalizedProfileName, options);
   if (!fs.existsSync(markerDir)) {
     return [];
   }
@@ -671,7 +696,7 @@ export function findLiveProfileRuntimeMarkers(
   for (const entry of fs.readdirSync(markerDir)) {
     const markerPath = path.join(markerDir, entry);
     const marker = readProfileRuntimeMarker(markerPath);
-    if (!marker || marker.profileName !== profileName) {
+    if (!marker || marker.profileName !== normalizedProfileName) {
       continue;
     }
     if (now - marker.heartbeatAt > PROFILE_RUNTIME_HEARTBEAT_TTL_MS) {
@@ -696,11 +721,15 @@ export function requestProfileInstanceFocus(
     processId?: number;
   },
 ): boolean {
-  if (findLiveProfileRuntimeMarkers(profileName, options).length === 0) {
+  const normalizedProfileName = normalizeProfileName(profileName);
+  if (
+    !normalizedProfileName ||
+    findLiveProfileRuntimeMarkers(normalizedProfileName, options).length === 0
+  ) {
     return false;
   }
 
-  const requestDir = resolveProfileFocusRequestDir(profileName, options);
+  const requestDir = resolveProfileFocusRequestDir(normalizedProfileName, options);
   fs.mkdirSync(requestDir, { recursive: true });
   const now = options?.now ?? Date.now();
   const processId = options?.processId ?? process.pid;
@@ -709,7 +738,7 @@ export function requestProfileInstanceFocus(
     `${now}-${processId}-${randomUUID()}.json`,
   );
   writeJsonAtomic(requestPath, {
-    profileName,
+    profileName: normalizedProfileName,
     processId,
     requestedAt: now,
   });
@@ -726,7 +755,11 @@ export function startProfileFocusRequestWatcher(
     onFocus: () => void;
   },
 ): ProfileFocusRequestWatcher {
-  const requestDir = resolveProfileFocusRequestDir(profileName, options);
+  const normalizedProfileName = normalizeProfileName(profileName);
+  if (!normalizedProfileName) {
+    throw new Error(`Profile name "${profileName}" must contain at least one letter or number.`);
+  }
+  const requestDir = resolveProfileFocusRequestDir(normalizedProfileName, options);
   fs.mkdirSync(requestDir, { recursive: true });
   const seen = new Set<string>();
   const now = options.now ?? Date.now;
@@ -745,7 +778,7 @@ export function startProfileFocusRequestWatcher(
       seen.add(requestPath);
       const request = readProfileFocusRequest(requestPath);
       fs.rmSync(requestPath, { force: true });
-      if (!request || request.profileName !== profileName) {
+      if (!request || request.profileName !== normalizedProfileName) {
         continue;
       }
       if (now() - request.requestedAt > PROFILE_RUNTIME_HEARTBEAT_TTL_MS) {
@@ -768,13 +801,17 @@ export function updateLastUsed(
   profileName: string,
   options?: { env?: NodeJS.ProcessEnv; homeDir?: string },
 ): void {
+  const normalizedProfileName = normalizeProfileName(profileName);
+  if (!normalizedProfileName) {
+    return;
+  }
   const registry = readProfilesRegistry(options);
-  const entry = registry.profiles.find((p) => p.name === profileName);
+  const entry = registry.profiles.find((p) => p.name === normalizedProfileName);
   const now = new Date().toISOString();
   if (entry) {
     entry.last_used = now;
   } else {
-    registry.profiles.push({ name: profileName, last_used: now });
+    registry.profiles.push({ name: normalizedProfileName, last_used: now });
   }
   writeProfilesRegistry(registry, options);
 }

--- a/apps/desktop/src/main/settings/codex-profiles.ts
+++ b/apps/desktop/src/main/settings/codex-profiles.ts
@@ -5,7 +5,7 @@ import type {
   DesktopCodexAuthProfileCandidate,
   DesktopCodexAuthProfileDiscoverySnapshot,
 } from "@pwragent/shared";
-import { isValidProfileName } from "../profile";
+import { isValidProfileName, normalizeProfileName } from "../profile";
 
 export const CODEX_HOME_ENV = "CODEX_HOME";
 
@@ -30,9 +30,8 @@ export function resolveCodexHomeForProfile(
   profileName: string | undefined,
   options?: { env?: NodeJS.ProcessEnv; homeDir?: string },
 ): string | undefined {
-  const name = profileName?.trim();
+  const name = normalizeProfileName(profileName ?? "");
   if (!name) return undefined;
-  if (!isValidProfileName(name)) return undefined;
   return path.join(resolveCodexProfileRoot(options), name);
 }
 
@@ -40,9 +39,9 @@ export function createCodexAuthProfile(
   profileName: string,
   options?: { env?: NodeJS.ProcessEnv; homeDir?: string },
 ): { profile: string; codexHome: string; created: boolean } {
-  const name = profileName.trim();
-  if (!isValidProfileName(name)) {
-    throw new Error("Codex profile names must match PwrAgent profile naming rules.");
+  const name = normalizeProfileName(profileName);
+  if (!name) {
+    throw new Error("Codex profile names must contain at least one letter or number.");
   }
   const codexHome = path.join(resolveCodexProfileRoot(options), name);
   const created = !fs.existsSync(codexHome);
@@ -58,9 +57,7 @@ export function discoverCodexAuthProfiles(options?: {
   const defaultCodexHome = resolveDefaultCodexHome(options);
   const profileRoot = resolveCodexProfileRoot(options);
   const configuredProfile = options?.configuredProfile?.trim() ?? "";
-  const selectedProfile = isValidProfileName(configuredProfile)
-    ? configuredProfile
-    : "";
+  const selectedProfile = normalizeProfileName(configuredProfile);
   const profiles: DesktopCodexAuthProfileCandidate[] = [
     {
       name: "",
@@ -97,7 +94,7 @@ export function discoverCodexAuthProfiles(options?: {
   }
 
   if (configuredProfile && !selectedProfile) {
-    error = `Invalid Codex profile "${configuredProfile}". Profile names must match PwrAgent profile naming rules.`;
+    error = `Invalid Codex profile "${configuredProfile}". Profile names must contain at least one letter or number.`;
   }
 
   const selected =

--- a/apps/desktop/src/renderer/src/features/logs/LogsWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/logs/LogsWindow.tsx
@@ -8,6 +8,8 @@ import {
   type ReactNode,
 } from "react";
 import type { AppLogEntry } from "../../../../shared/app-metadata";
+import { CopyIcon } from "../../icons";
+import { copyText } from "../../lib/copy-text";
 import { useDesktopApi } from "../../lib/desktop-api";
 
 const BOTTOM_THRESHOLD_PX = 32;
@@ -47,8 +49,11 @@ export function LogsWindow() {
   const activeMatchRef = useRef<HTMLElement | null>(null);
   const followingRef = useRef(true);
   const entryBufferRef = useRef(createRenderedLogEntryBuffer());
+  const copyResetTimerRef = useRef<number | undefined>(undefined);
   const [renderVersion, setRenderVersion] = useState(0);
   const [truncated, setTruncated] = useState(false);
+  const [logFilePath, setLogFilePath] = useState<string | undefined>();
+  const [copiedLogFilePath, setCopiedLogFilePath] = useState(false);
   const [error, setError] = useState<string | undefined>();
   const [loading, setLoading] = useState(false);
   const [query, setQuery] = useState("");
@@ -64,6 +69,14 @@ export function LogsWindow() {
     document.title = "Logs";
   }, []);
 
+  useEffect(() => {
+    return () => {
+      if (copyResetTimerRef.current) {
+        window.clearTimeout(copyResetTimerRef.current);
+      }
+    };
+  }, []);
+
   const loadSnapshot = useCallback(async () => {
     const reader = desktopApi?.readAppLogSnapshot;
     if (!reader) {
@@ -75,6 +88,7 @@ export function LogsWindow() {
       const value = await reader();
       entryBufferRef.current = createRenderedLogEntryBuffer(value.entries);
       setRenderVersion((version) => version + 1);
+      setLogFilePath(value.logFilePath);
       setTruncated(value.truncated || value.entries.length > MAX_RENDERED_LOG_ENTRIES);
       setError(undefined);
     } catch (err: unknown) {
@@ -209,6 +223,26 @@ export function LogsWindow() {
     }
   }, [setFollowingMode]);
 
+  const handleCopyLogFilePath = useCallback(() => {
+    if (!logFilePath) {
+      return;
+    }
+    void copyText(logFilePath, desktopApi)
+      .then(() => {
+        if (copyResetTimerRef.current) {
+          window.clearTimeout(copyResetTimerRef.current);
+        }
+        setCopiedLogFilePath(true);
+        copyResetTimerRef.current = window.setTimeout(() => {
+          setCopiedLogFilePath(false);
+          copyResetTimerRef.current = undefined;
+        }, 1400);
+      })
+      .catch((copyError: unknown) => {
+        console.error("Failed to copy log file path", copyError);
+      });
+  }, [desktopApi, logFilePath]);
+
   const activeMatchLabel =
     rendered.matchCount > 0 ? `${activeMatchIndex + 1} / ${rendered.matchCount}` : "0";
 
@@ -269,6 +303,30 @@ export function LogsWindow() {
               Follow
             </button>
           </div>
+
+          {logFilePath ? (
+            <div className="log-window__file" aria-label="Log file path">
+              <span className="log-window__file-label">File</span>
+              <code className="log-window__file-path" title={logFilePath}>
+                {logFilePath}
+              </code>
+              <button
+                className="log-window__file-copy"
+                type="button"
+                data-copied={copiedLogFilePath ? "true" : undefined}
+                aria-label={
+                  copiedLogFilePath ? "Copied log file path" : "Copy log file path"
+                }
+                title={
+                  copiedLogFilePath ? "Copied log file path" : "Copy log file path"
+                }
+                onClick={handleCopyLogFilePath}
+              >
+                <CopyIcon size={13} aria-hidden="true" />
+                <span>{copiedLogFilePath ? "Copied" : "Copy"}</span>
+              </button>
+            </div>
+          ) : null}
 
           <div className="log-window__status">
             <span className="log-window__status-text">

--- a/apps/desktop/src/renderer/src/features/logs/__tests__/logs-window.test.tsx
+++ b/apps/desktop/src/renderer/src/features/logs/__tests__/logs-window.test.tsx
@@ -144,10 +144,13 @@ describe("rendered log entry buffer", () => {
 
 describe("LogsWindow", () => {
   it("loads a log snapshot and renders search controls", async () => {
+    const copyText = vi.fn(async () => undefined);
     const desktopApi = {
+      copyText,
       readAppLogSnapshot: vi.fn(async () => ({
         kind: "log-snapshot",
         title: "Logs",
+        logFilePath: "/Users/example/Library/Logs/PwrAgent/main.log",
         entries: [
           {
             sequence: 1,
@@ -172,8 +175,20 @@ describe("LogsWindow", () => {
     render(<LogsWindow />);
 
     expect(await screen.findByLabelText("Search logs")).toBeInTheDocument();
+    expect(
+      screen.getByText("/Users/example/Library/Logs/PwrAgent/main.log"),
+    ).toBeInTheDocument();
     expect(await screen.findByText("INFO booted")).toBeInTheDocument();
     expect(screen.getByText("Live app log stream")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Copy log file path" }));
+    await waitFor(() => {
+      expect(copyText).toHaveBeenCalledWith(
+        "/Users/example/Library/Logs/PwrAgent/main.log",
+      );
+    });
+    expect(
+      screen.getByRole("button", { name: "Copied log file path" }),
+    ).toBeInTheDocument();
     await waitFor(() => {
       expect(desktopApi.readAppLogSnapshot).toHaveBeenCalled();
     });

--- a/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
+++ b/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
@@ -28,6 +28,7 @@ import type { DesktopSettingsState } from "../settings/useDesktopSettings";
 import { filterBufferedSecrets } from "./filterBufferedSecrets";
 import {
   isValidProfileName,
+  normalizeProfileName,
   provisionPairedProfiles,
 } from "./provisionPairedProfiles";
 import {
@@ -172,8 +173,8 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
   // create `foo`" without retyping the name in the Profiles step.
   const [codexProfileNames, setCodexProfileNames] = useState<string[]>(() => {
     const initialNames = props.initialCodexProfileNames
-      ?.map((name) => name.trim())
-      .filter(isValidProfileName);
+      ?.map((name) => normalizeProfileName(name))
+      .filter(Boolean);
     if (initialNames?.length) {
       return [...initialNames];
     }
@@ -181,8 +182,9 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
       props.bootInfo?.decisionKind === "missing-named-profile"
         ? props.bootInfo.requestedProfileName?.trim()
         : undefined;
-    if (requested && isValidProfileName(requested)) {
-      return [requested];
+    const normalizedRequested = normalizeProfileName(requested ?? "");
+    if (normalizedRequested) {
+      return [normalizedRequested];
     }
     return props.initialCodexProfileModel === "isolated"
       ? ["pwragent"]
@@ -1163,11 +1165,18 @@ function DismissConfirmModal(props: {
   );
 }
 
-function validateProfileNames(names: readonly string[]): boolean {
-  const trimmed = names.map((n) => n.trim()).filter((n) => n.length > 0);
-  if (trimmed.length < 1 || trimmed.length > 5) return false;
-  const set = new Set(trimmed);
-  return set.size === trimmed.length && trimmed.every(isValidProfileName);
+export function validateProfileNames(names: readonly string[]): boolean {
+  const rows = names
+    .map((raw) => ({
+      raw: raw.trim(),
+      normalized: normalizeProfileName(raw),
+    }))
+    .filter((row) => row.raw.length > 0);
+  if (rows.some((row) => !row.normalized)) return false;
+  const normalized = rows.map((row) => row.normalized);
+  if (normalized.length < 1 || normalized.length > 5) return false;
+  const set = new Set(normalized);
+  return set.size === normalized.length;
 }
 
 
@@ -2913,8 +2922,8 @@ function NameCodexProfilesStep(props: {
     const api = apiRef.current;
     if (!api?.checkCodexAuthProfileStatus) return;
     for (const raw of props.names) {
-      const name = raw.trim();
-      if (!isValidProfileName(name)) continue;
+      const name = normalizeProfileName(raw);
+      if (!name) continue;
       if (stateFor(name).kind !== "idle") continue;
       void (async () => {
         try {
@@ -2941,9 +2950,9 @@ function NameCodexProfilesStep(props: {
 
   // Propagate auth completion to the wizard root for Continue gating.
   useEffect(() => {
-    const validNames = props.names
-      .map((name) => name.trim())
-      .filter((name) => isValidProfileName(name));
+  const validNames = props.names
+      .map((name) => normalizeProfileName(name))
+      .filter(Boolean);
     const allAuthed =
       validNames.length > 0 &&
       validNames.every((name) => stateFor(name).kind === "ok");
@@ -2989,9 +2998,10 @@ function NameCodexProfilesStep(props: {
       <div className="onboarding-wizard__profile-list">
         {props.names.map((name, idx) => {
           const trimmed = name.trim();
-          const valid = trimmed === "" || isValidProfileName(trimmed);
-          const state = trimmed ? stateFor(trimmed) : { kind: "idle" as const };
-          const locked = isRowLocked(trimmed);
+          const normalized = normalizeProfileName(name);
+          const valid = trimmed === "" || Boolean(normalized);
+          const state = normalized ? stateFor(normalized) : { kind: "idle" as const };
+          const locked = isRowLocked(normalized);
           return (
             <div
               key={idx}
@@ -3009,11 +3019,11 @@ function NameCodexProfilesStep(props: {
                   readOnly={locked}
                 />
                 <ProfileRowLoginControls
-                  name={trimmed}
-                  valid={valid && trimmed.length > 0}
+                  name={normalized}
+                  valid={valid && Boolean(normalized)}
                   state={state}
-                  onLogin={() => void startLogin(trimmed)}
-                  onCheck={() => void refreshStatus(trimmed)}
+                  onLogin={() => void startLogin(normalized)}
+                  onCheck={() => void refreshStatus(normalized)}
                   onCopyUrl={() => void copyLoginUrl("url" in state ? state.url : undefined)}
                 />
                 {!isSingle && props.names.length > 1 ? (
@@ -3029,13 +3039,13 @@ function NameCodexProfilesStep(props: {
                 ) : null}
               </div>
               <ProfileRowLoginStatus state={state} />
-              {trimmed ? (
+              {normalized ? (
                 <ProfileRowXaiKey
-                  profileName={trimmed}
+                  profileName={normalized}
                   globalKey={props.globalXaiKey}
-                  override={props.xaiKeyByProfile[trimmed] ?? ""}
+                  override={props.xaiKeyByProfile[normalized] ?? ""}
                   onChange={(value) =>
-                    props.onSetXaiKeyForProfile(trimmed, value)
+                    props.onSetXaiKeyForProfile(normalized, value)
                   }
                 />
               ) : null}

--- a/apps/desktop/src/renderer/src/features/onboarding/__tests__/provisionPairedProfiles.test.ts
+++ b/apps/desktop/src/renderer/src/features/onboarding/__tests__/provisionPairedProfiles.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   isValidProfileName,
+  normalizeProfileName,
   provisionPairedProfiles,
   type PairedProfileApi,
 } from "../provisionPairedProfiles";
@@ -67,7 +68,8 @@ describe("isValidProfileName", () => {
     ["personal-2024", true],
     ["my_profile", true],
     ["a".repeat(31), true],
-    ["a".repeat(32), false],
+    ["a".repeat(32), true],
+    ["a".repeat(33), false],
     ["", false],
     ["-leading-hyphen", false],
     ["_leading-underscore", false],
@@ -76,6 +78,11 @@ describe("isValidProfileName", () => {
     ["has.dot", false],
   ])("%j -> %s", (name, expected) => {
     expect(isValidProfileName(name)).toBe(expected);
+  });
+
+  it("normalizes arbitrary display names into canonical profile ids", () => {
+    expect(normalizeProfileName("My Work Profile")).toBe("my-work-profile");
+    expect(normalizeProfileName("Café Ops")).toBe("cafe-ops");
   });
 });
 
@@ -95,6 +102,18 @@ describe("provisionPairedProfiles", () => {
       "pwragent:pwragent",
       "codex:pwragent",
       "pair:pwragent↔pwragent",
+    ]);
+  });
+
+  it("normalizes profile names before provisioning", async () => {
+    const mock = makeApi();
+    const created = await provisionPairedProfiles(mock.api, ["My Work Profile"]);
+
+    expect(created).toEqual(["my-work-profile"]);
+    expect(mock.callLog).toEqual([
+      "pwragent:my-work-profile",
+      "codex:my-work-profile",
+      "pair:my-work-profile↔my-work-profile",
     ]);
   });
 
@@ -167,7 +186,7 @@ describe("provisionPairedProfiles", () => {
     const created = await provisionPairedProfiles(mock.api, [
       "",
       "valid",
-      "UPPERCASE",
+      "!!!",
       "also-valid",
     ]);
     expect(created).toEqual(["valid", "also-valid"]);

--- a/apps/desktop/src/renderer/src/features/onboarding/__tests__/wizard-provider-setup.test.tsx
+++ b/apps/desktop/src/renderer/src/features/onboarding/__tests__/wizard-provider-setup.test.tsx
@@ -8,11 +8,25 @@ import {
 } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { DesktopSettingsSecretName } from "@pwragent/shared";
-import { SecretFieldRow } from "../OnboardingWizard";
+import { SecretFieldRow, validateProfileNames } from "../OnboardingWizard";
 
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
+});
+
+describe("validateProfileNames", () => {
+  it("rejects non-empty rows that cannot normalize", () => {
+    expect(validateProfileNames(["valid", "!!!"])).toBe(false);
+  });
+
+  it("accepts arbitrary names after normalization when every row is usable", () => {
+    expect(validateProfileNames(["My Work Profile", "Café Ops"])).toBe(true);
+  });
+
+  it("rejects duplicate normalized profile ids", () => {
+    expect(validateProfileNames(["My Work", "my-work"])).toBe(false);
+  });
 });
 
 /**

--- a/apps/desktop/src/renderer/src/features/onboarding/provisionPairedProfiles.ts
+++ b/apps/desktop/src/renderer/src/features/onboarding/provisionPairedProfiles.ts
@@ -1,13 +1,19 @@
+import {
+  isCanonicalProfileName,
+  normalizeProfileName,
+} from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
+
+export { normalizeProfileName };
 
 /**
  * Profile-name guard matching the validation rule the main-process
  * `createDesktopPwrAgentProfile` and `setDesktopPwrAgentProfileCodexProfile`
  * IPC handlers enforce: lowercase letters, digits, underscores, hyphens —
- * 1 to 31 characters, must start with a letter or digit.
+ * 1 to 32 characters, must start with a letter or digit.
  */
 export function isValidProfileName(name: string): boolean {
-  return /^[a-z0-9][a-z0-9_-]{0,30}$/.test(name);
+  return isCanonicalProfileName(name);
 }
 
 export type PairedProfileApi = Pick<
@@ -41,8 +47,8 @@ export async function provisionPairedProfiles(
   }
   const created: string[] = [];
   for (const raw of names) {
-    const name = raw.trim();
-    if (!isValidProfileName(name)) continue;
+    const name = normalizeProfileName(raw);
+    if (!name) continue;
     try {
       await api.createPwrAgentProfile({
         profile: name,

--- a/apps/desktop/src/renderer/src/features/settings/CodexAuthProfileSelect.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/CodexAuthProfileSelect.tsx
@@ -3,6 +3,7 @@ import type {
   DesktopCodexAuthProfileCandidate,
   DesktopCodexAuthProfileDiscoverySnapshot,
 } from "@pwragent/shared";
+import { normalizeProfileName } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 
 const CREATE_VALUE = "__create_codex_profile__";
@@ -187,16 +188,16 @@ function CodexAuthProfileCreateDialog(props: {
   const [loginUrl, setLoginUrl] = useState<string>();
   const [statusDetail, setStatusDetail] = useState<string>();
   const authenticatedRef = useRef(false);
-  const normalizedName = profileName.trim();
+  const normalizedName = normalizeProfileName(profileName);
+  const hasInput = profileName.trim().length > 0;
   const existingNames = new Set(props.existingProfiles.map((profile) => profile.name));
-  const nameExists = Boolean(normalizedName) && existingNames.has(normalizedName);
-  const validName = /^[a-z0-9][a-z0-9_-]{0,31}$/.test(normalizedName);
+  const nameExists = hasInput && Boolean(normalizedName) && existingNames.has(normalizedName);
   const canSubmit = Boolean(
     props.desktopApi?.createCodexAuthProfile
       && props.desktopApi.startCodexAuthProfileLogin
       && props.desktopApi.checkCodexAuthProfileStatus
+      && hasInput
       && normalizedName
-      && validName
       && !nameExists,
   );
 
@@ -304,9 +305,14 @@ function CodexAuthProfileCreateDialog(props: {
               value={profileName}
               onChange={(event) => setProfileName(event.currentTarget.value)}
             />
-            {!validName && normalizedName ? (
+            {hasInput && !normalizedName ? (
               <p className="settings-row__error">
-                Use lowercase letters, numbers, dashes, or underscores.
+                Enter at least one letter or number.
+              </p>
+            ) : null}
+            {hasInput && normalizedName ? (
+              <p className="settings-profile-create-dialog__hint">
+                Profile ID: <code>{normalizedName}</code>
               </p>
             ) : null}
             {nameExists ? (

--- a/apps/desktop/src/renderer/src/features/settings/ProfilesSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ProfilesSettings.tsx
@@ -4,6 +4,7 @@ import type {
   DesktopPwrAgentProfileSummary,
   DesktopSettingsSnapshot,
 } from "@pwragent/shared";
+import { normalizeProfileName } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 import {
   usePwrAgentProfiles,
@@ -302,12 +303,12 @@ function ProfileCreateDialog(props: {
   onCreate: (profile: string) => void;
 }) {
   const [profileName, setProfileName] = useState("");
-  const normalizedName = profileName.trim();
-  const validName = /^[a-z0-9][a-z0-9_-]{0,31}$/.test(normalizedName);
+  const normalizedName = normalizeProfileName(profileName);
+  const hasInput = profileName.trim().length > 0;
   const exists = props.existingProfiles.some(
     (profile) => profile.name === normalizedName,
   );
-  const canCreate = Boolean(normalizedName && validName && !exists);
+  const canCreate = Boolean(hasInput && normalizedName && !exists);
 
   return (
     <div className="settings-confirm-modal" role="presentation">
@@ -328,9 +329,14 @@ function ProfileCreateDialog(props: {
           value={profileName}
           onChange={(event) => setProfileName(event.currentTarget.value)}
         />
-        {!validName && normalizedName ? (
+        {hasInput && !normalizedName ? (
           <p className="settings-row__error">
-            Use lowercase letters, numbers, dashes, or underscores.
+            Enter at least one letter or number.
+          </p>
+        ) : null}
+        {hasInput && normalizedName ? (
+          <p className="settings-profile-create-dialog__hint">
+            Profile ID: <code>{normalizedName}</code>
           </p>
         ) : null}
         {exists ? (

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -2228,11 +2228,12 @@ describe("SettingsScreen", () => {
       within(createDialog).getByRole("textbox", {
         name: "PwrAgent profile name",
       }),
-      { target: { value: "work" } },
+      { target: { value: "My Work" } },
     );
+    expect(within(createDialog).getByText("my-work")).toBeInTheDocument();
     fireEvent.click(within(createDialog).getByRole("button", { name: "Add profile" }));
     await waitFor(() => {
-      expect(createPwrAgentProfile).toHaveBeenCalledWith({ profile: "work" });
+      expect(createPwrAgentProfile).toHaveBeenCalledWith({ profile: "my-work" });
     });
 
     expect(await screen.findByText("scratch")).toBeInTheDocument();

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1182,6 +1182,75 @@ textarea,
   opacity: 0.48;
 }
 
+.log-window__file {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  min-height: 32px;
+  padding: 6px 8px 6px 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 7px;
+  background: var(--bg-panel-elevated);
+}
+
+.log-window__file-label {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.log-window__file-path {
+  display: block;
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.4;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  user-select: text;
+  -webkit-user-select: text;
+}
+
+.log-window__file-copy {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  width: 76px;
+  height: 26px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-input);
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.log-window__file-copy:hover {
+  border-color: var(--border-strong);
+  color: var(--text-primary);
+}
+
+.log-window__file-copy:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.log-window__file-copy[data-copied="true"] {
+  border-color: var(--accent-border);
+  background: var(--accent-soft);
+  color: var(--accent-bright);
+}
+
 .log-window__status {
   display: flex;
   flex: 0 0 auto;
@@ -4052,6 +4121,19 @@ textarea,
   color: var(--danger-text);
   font-size: 13px;
   line-height: 1.45;
+}
+
+.settings-profile-create-dialog__hint {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.settings-profile-create-dialog__hint code {
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 12px;
 }
 
 .settings-row__description {

--- a/apps/desktop/src/shared/app-metadata.ts
+++ b/apps/desktop/src/shared/app-metadata.ts
@@ -29,6 +29,7 @@ export type AppChangelogDocument = {
 export type AppLogSnapshot = {
   kind: "log-snapshot";
   title: string;
+  logFilePath?: string;
   entries: AppLogEntry[];
   readAt: number;
   truncated: boolean;

--- a/packages/shared/src/__tests__/profile-names.test.ts
+++ b/packages/shared/src/__tests__/profile-names.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { isCanonicalProfileName, normalizeProfileName } from "../profile-names";
+
+describe("profile names", () => {
+  it.each([
+    ["work", "work"],
+    ["work-", "work-"],
+    ["work_", "work_"],
+    ["Work", "work"],
+    ["My Work Profile", "my-work-profile"],
+    ["Hunt's Ops/Profile", "hunt-s-ops-profile"],
+    ["Café Déjà Vu", "cafe-deja-vu"],
+    [" personal__2026 ", "personal__2026"],
+    ["con", "con-profile"],
+    ["...", ""],
+    ["a".repeat(40), "a".repeat(32)],
+  ])("normalizes %j to %j", (input, expected) => {
+    expect(normalizeProfileName(input)).toBe(expected);
+  });
+
+  it.each([
+    ["work", true],
+    ["personal-2026", true],
+    ["my_profile", true],
+    ["work-", true],
+    ["work_", true],
+    ["a".repeat(32), true],
+    ["a".repeat(33), false],
+    ["Work", false],
+    ["has space", false],
+    ["con", false],
+    ["", false],
+  ])("checks canonical profile id %j -> %s", (input, expected) => {
+    expect(isCanonicalProfileName(input)).toBe(expected);
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -13,6 +13,7 @@ export * from "./contracts/navigation";
 export * from "./contracts/settings";
 export * from "./messaging-contact-labels";
 export * from "./messaging-id-validation";
+export * from "./profile-names";
 export * from "./directory-pins";
 export * from "./thread-pins";
 export * from "./thread-titles";

--- a/packages/shared/src/profile-names.ts
+++ b/packages/shared/src/profile-names.ts
@@ -1,0 +1,39 @@
+const CANONICAL_PROFILE_NAME_REGEX = /^[a-z0-9][a-z0-9_-]{0,31}$/;
+const RESERVED_PROFILE_NAMES = new Set(["con", "nul", "aux", "prn", ".", ".."]);
+
+export function normalizeProfileName(value: string): string {
+  const trimmed = value.trim();
+  if (
+    CANONICAL_PROFILE_NAME_REGEX.test(trimmed) &&
+    !RESERVED_PROFILE_NAMES.has(trimmed)
+  ) {
+    return trimmed;
+  }
+
+  const normalized = trimmed
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^[-_]+|[-_]+$/g, "")
+    .slice(0, 32)
+    .replace(/[-_]+$/g, "");
+
+  if (!normalized) {
+    return "";
+  }
+
+  if (RESERVED_PROFILE_NAMES.has(normalized)) {
+    return `${normalized}-profile`;
+  }
+
+  return normalized;
+}
+
+export function isCanonicalProfileName(value: string): boolean {
+  return (
+    CANONICAL_PROFILE_NAME_REGEX.test(value) &&
+    !RESERVED_PROFILE_NAMES.has(value) &&
+    normalizeProfileName(value) === value
+  );
+}


### PR DESCRIPTION
## Summary

Multiple PwrAgent profiles can now run side by side without sharing one app log: startup resolves the canonical profile ID before initializing `electron-log` and writes `profile-<name>.main.log` for active, requested, and bootstrap sessions.

Profile entry points now accept arbitrary user-facing names and normalize them into safe canonical IDs before touching profile directories, Codex auth profile directories, runtime markers, or log filenames. For example, `My Work Profile` becomes `my-work-profile`, existing canonical IDs such as `my_profile` remain valid, and unusable input like `!!!` still fails clearly.

The Logs window shows the exact resolved log file path for the running instance and provides a copy action for support handoff.

## Test Plan

- `pnpm test packages/shared/src/__tests__/profile-names.test.ts apps/desktop/src/main/__tests__/profile.test.ts apps/desktop/src/main/__tests__/profiles-ipc.test.ts apps/desktop/src/main/__tests__/codex-profiles.test.ts apps/desktop/src/main/__tests__/log.test.ts apps/desktop/src/main/__tests__/index.test.ts apps/desktop/src/renderer/src/features/logs/__tests__/logs-window.test.tsx apps/desktop/src/main/__tests__/app-logs.test.ts apps/desktop/src/renderer/src/features/onboarding/__tests__/provisionPairedProfiles.test.ts apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm --filter @pwragent/shared typecheck`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
