### PR TITLE
fix(desktop): harden shutdown window lifecycle

### DIFF
--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -817,6 +817,45 @@ describe("bootstrapApp", () => {
     expect(createMainWindowMock).toHaveBeenCalledTimes(1);
   });
 
+  it("does not recreate a window from profile focus after quit begins", async () => {
+    startupProfilerInstance.start.mockResolvedValue();
+
+    await import("../index");
+    await flushMicrotasks();
+
+    const watcherCalls = startProfileFocusRequestWatcherMock.mock.calls as unknown as Array<
+      [string, { onFocus: () => void }]
+    >;
+    const onFocus = watcherCalls[0]?.[1].onFocus;
+    expect(onFocus).toBeTypeOf("function");
+    if (!onFocus) {
+      return;
+    }
+
+    appEventHandlers.get("before-quit")?.();
+    onFocus();
+
+    expect(createMainWindowMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps ipc handlers registered until Electron reaches will-quit", async () => {
+    startupProfilerInstance.start.mockResolvedValue();
+
+    await import("../index");
+    await flushMicrotasks();
+
+    appEventHandlers.get("before-quit")?.();
+
+    expect(disposeComposerDraftIpcHandlersMock).not.toHaveBeenCalled();
+    expect(disposeSettingsIpcHandlersMock).not.toHaveBeenCalled();
+
+    appEventHandlers.get("will-quit")?.();
+
+    expect(disposeComposerDraftIpcHandlersMock).toHaveBeenCalledTimes(1);
+    expect(disposeSettingsIpcHandlersMock).toHaveBeenCalledTimes(1);
+    expect(disposeDesktopMessagingRuntimeMock).toHaveBeenCalledTimes(1);
+  });
+
   it("routes closing the last window through the shared quit flow", async () => {
     startupProfilerInstance.start.mockResolvedValue();
 
@@ -893,7 +932,7 @@ describe("bootstrapApp", () => {
 
     expect(registerRuntimeIdentityIpcHandlersMock).not.toHaveBeenCalled();
 
-    appEventHandlers.get("before-quit")?.();
+    appEventHandlers.get("will-quit")?.();
     expect(disposeApplicationIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(disposeComposerDraftIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(disposeSettingsIpcHandlersMock).toHaveBeenCalledTimes(1);

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -869,6 +869,30 @@ describe("bootstrapApp", () => {
     });
   });
 
+  it("does not re-enter quit when the confirmation window closes after cancellation", async () => {
+    let resolveQuit!: (didQuit: boolean) => void;
+    requestQuitMock.mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        resolveQuit = resolve;
+      }),
+    );
+    startupProfilerInstance.start.mockResolvedValue();
+
+    await import("../index");
+    await flushMicrotasks();
+
+    appEventHandlers.get("window-all-closed")?.();
+    appEventHandlers.get("window-all-closed")?.();
+
+    expect(requestQuitMock).toHaveBeenCalledTimes(1);
+
+    resolveQuit(false);
+    await flushMicrotasks();
+    appEventHandlers.get("activate")?.();
+
+    expect(createMainWindowMock).toHaveBeenCalledTimes(2);
+  });
+
   it("initializes app state in active-profile mode when boot decision is open", async () => {
     startupProfilerInstance.start.mockResolvedValue();
 

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -893,6 +893,27 @@ describe("bootstrapApp", () => {
     expect(createMainWindowMock).toHaveBeenCalledTimes(2);
   });
 
+  it("completes quit when all windows close after before-quit approves shutdown", async () => {
+    const event = { preventDefault: vi.fn() };
+    isQuitAllowedMock.mockReturnValue(false);
+    requestQuitMock.mockImplementation(async () => {
+      isQuitAllowedMock.mockReturnValue(true);
+      return true;
+    });
+    startupProfilerInstance.start.mockResolvedValue();
+
+    await import("../index");
+    await flushMicrotasks();
+
+    appEventHandlers.get("before-quit")?.(event);
+    await flushMicrotasks();
+    appEventHandlers.get("window-all-closed")?.();
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(requestQuitMock).toHaveBeenCalledWith({ source: "before-quit" });
+    expect(quitMock).toHaveBeenCalledTimes(1);
+  });
+
   it("initializes app state in active-profile mode when boot decision is open", async () => {
     startupProfilerInstance.start.mockResolvedValue();
 

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -805,6 +805,31 @@ describe("bootstrapApp", () => {
     });
   });
 
+  it("does not recreate a window from Dock activation after quit teardown begins", async () => {
+    startupProfilerInstance.start.mockResolvedValue();
+
+    await import("../index");
+    await flushMicrotasks();
+
+    appEventHandlers.get("before-quit")?.();
+    appEventHandlers.get("activate")?.();
+
+    expect(createMainWindowMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("routes closing the last window through the shared quit flow", async () => {
+    startupProfilerInstance.start.mockResolvedValue();
+
+    await import("../index");
+    await flushMicrotasks();
+
+    appEventHandlers.get("window-all-closed")?.();
+
+    expect(requestQuitMock).toHaveBeenCalledWith({
+      source: "window-all-closed",
+    });
+  });
+
   it("initializes app state in active-profile mode when boot decision is open", async () => {
     startupProfilerInstance.start.mockResolvedValue();
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -565,6 +565,10 @@ export function bootstrapApp(): void {
     initAutoUpdater();
 
     app.on("activate", () => {
+      if (mainProcessResourcesDisposed) {
+        mainLog.info("ignoring activate after main process teardown");
+        return;
+      }
       if (BrowserWindow.getAllWindows().length === 0) {
         createMainWindow({
           startupCpuProfiler,
@@ -574,9 +578,7 @@ export function bootstrapApp(): void {
   });
 
   app.on("window-all-closed", () => {
-    if (process.platform !== "darwin") {
-      void requestQuit({ source: "window-all-closed" });
-    }
+    void requestQuit({ source: "window-all-closed" });
   });
 
   app.on("before-quit", (event) => {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -605,6 +605,10 @@ export function bootstrapApp(): void {
   });
 
   app.on("window-all-closed", () => {
+    if (quitInProgress) {
+      mainLog.info("ignoring window-all-closed during shutdown");
+      return;
+    }
     beginQuitInProgress("window-all-closed");
     void requestQuit({ source: "window-all-closed" }).then((didQuit) => {
       if (!didQuit) {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -124,6 +124,7 @@ const isMac = process.platform === "darwin";
 const isDevelopment = process.env.NODE_ENV !== "production";
 const mainLog = getMainLogger("pwragent:main");
 let mainProcessResourcesDisposed = false;
+let quitInProgress = false;
 let profileFocusRequestWatcher: ProfileFocusRequestWatcher | null = null;
 let startupCpuProfilerForNewWindows:
   | NonNullable<Parameters<typeof createMainWindow>[0]>["startupCpuProfiler"]
@@ -225,9 +226,30 @@ function disposeMainProcessResourcesSync(): void {
   disposeAppState();
 }
 
+function beginQuitInProgress(source: string): void {
+  if (quitInProgress) {
+    return;
+  }
+  quitInProgress = true;
+  mainLog.info("quit in progress", { source });
+}
+
+function cancelQuitInProgress(source: string): void {
+  if (!quitInProgress) {
+    return;
+  }
+  quitInProgress = false;
+  mainLog.info("quit cancelled", { source });
+}
+
+function isWindowCreationBlocked(): boolean {
+  return quitInProgress || mainProcessResourcesDisposed;
+}
+
 function installProcessShutdownHandlers(): void {
   const handleSignal = (signal: NodeJS.Signals): void => {
     mainLog.info("main process shutdown signal received", { signal });
+    beginQuitInProgress(signal);
     disposeMainProcessResourcesSync();
     appQuitManager.allowImmediateQuit();
     app.quit();
@@ -255,6 +277,11 @@ function installDevelopmentDockIcon(): void {
 }
 
 function focusPwrAgentWindows(): void {
+  if (isWindowCreationBlocked()) {
+    mainLog.info("ignoring focus request during shutdown");
+    return;
+  }
+
   const windows = subscribersForChannel(WINDOW_OPEN_SETTINGS_CHANNEL)
     .map((webContents) => BrowserWindow.fromWebContents(webContents))
     .filter((window): window is BrowserWindow =>
@@ -565,8 +592,8 @@ export function bootstrapApp(): void {
     initAutoUpdater();
 
     app.on("activate", () => {
-      if (mainProcessResourcesDisposed) {
-        mainLog.info("ignoring activate after main process teardown");
+      if (isWindowCreationBlocked()) {
+        mainLog.info("ignoring activate during shutdown");
         return;
       }
       if (BrowserWindow.getAllWindows().length === 0) {
@@ -578,15 +605,29 @@ export function bootstrapApp(): void {
   });
 
   app.on("window-all-closed", () => {
-    void requestQuit({ source: "window-all-closed" });
+    beginQuitInProgress("window-all-closed");
+    void requestQuit({ source: "window-all-closed" }).then((didQuit) => {
+      if (!didQuit) {
+        cancelQuitInProgress("window-all-closed");
+      }
+    });
   });
 
   app.on("before-quit", (event) => {
     if (!appQuitManager.isQuitAllowed()) {
       event?.preventDefault();
-      void requestQuit({ source: "before-quit" });
+      beginQuitInProgress("before-quit");
+      void requestQuit({ source: "before-quit" }).then((didQuit) => {
+        if (!didQuit) {
+          cancelQuitInProgress("before-quit");
+        }
+      });
       return;
     }
+    beginQuitInProgress("before-quit");
+  });
+
+  app.on("will-quit", () => {
     disposeMainProcessResourcesSync();
   });
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -606,6 +606,11 @@ export function bootstrapApp(): void {
 
   app.on("window-all-closed", () => {
     if (quitInProgress) {
+      if (appQuitManager.isQuitAllowed()) {
+        mainLog.info("quitting after windows closed during shutdown");
+        app.quit();
+        return;
+      }
       mainLog.info("ignoring window-all-closed during shutdown");
       return;
     }


### PR DESCRIPTION
## Summary

- I fixed the macOS last-window-close and Dock Quit lifecycle so quitting now enters an explicit shutdown state instead of leaving a half-torn-down app able to recreate windows.
- I deferred normal IPC and runtime cleanup from `before-quit` to `will-quit`, so an existing renderer is not left alive with its IPC handlers already removed.
- I guarded activation and profile focus paths during shutdown so late Dock activation or focus requests cannot create a broken renderer while the app is exiting.
- I ignored repeated `window-all-closed` events while a quit request is still pending, so closing the quit confirmation dialog after cancellation does not immediately re-enter the quit flow.
- I still complete shutdown when `window-all-closed` arrives after the quit request has been approved, which keeps Playwright/Electron teardown from hanging.

## Verification

- I ran `pnpm test apps/desktop/src/main/__tests__/index.test.ts -- --runInBand`.
- I ran `pnpm --filter @pwragent/desktop typecheck`.
- I ran `git diff --check`.

## Notes

- I added regression coverage for the last-window-close quit path, post-shutdown activation/focus paths, the `before-quit` to `will-quit` cleanup ordering, quit-confirmation cancellation, and approved shutdown completion after windows close.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5_Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
