### PR TITLE
fix(desktop): clean up generated Codex chats

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -1190,6 +1190,73 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("filters PwrSnap-generated Codex threads when Codex reports them as normal vscode sessions", async () => {
+    MockTransport.threadListResultBySearchTerm.set("pwrsnap-workspace-filter", [
+      {
+        id: "thread-pwrsnap-library-chat",
+        preview:
+          '<runtime_context source="pwrsnap" note="runtime-generated, not user-authored">...',
+        updatedAt: 1_780_282_928,
+        cwd: "/Users/huntharo/Documents/PwrSnap/Chats/2026-06-01-001-chat-2026-05-31",
+        source: "vscode",
+      },
+      {
+        id: "thread-pwrsnap-metadata",
+        name: "PwrSnap Capture Metadata Worker",
+        preview: "Capture metadata:\n- Source application name: Electron",
+        updatedAt: 1_780_272_250,
+        cwd: "/Users/huntharo/Documents/PwrSnap/Chats/.capture-metadata",
+        source: "vscode",
+      },
+      {
+        id: "thread-pwrsnap-repo-work",
+        name: "Fix PwrSnap export",
+        preview: "Work on the product codebase.",
+        updatedAt: 1_780_200_000,
+        cwd: "/Users/huntharo/github/PwrSnap",
+        source: "vscode",
+      },
+      {
+        id: "thread-pwragent",
+        name: "PwrAgent workspace chat",
+        preview: "Normal Codex thread",
+        updatedAt: 1_780_100_000,
+        cwd: "/Users/huntharo/github/PwrAgnt",
+        source: "vscode",
+      },
+    ]);
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const threadDirectoryEnricher = vi.fn(async (projectKey?: string) => ({
+      linkedDirectories: projectKey
+        ? [
+            {
+              id: projectKey,
+              label: path.basename(projectKey),
+              path: projectKey,
+              kind: "local" as const,
+            },
+          ]
+        : [],
+    }));
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      threadDirectoryEnricher,
+    });
+
+    const threads = await client.listThreads({ filter: "pwrsnap-workspace-filter" });
+
+    expect(threads.map((thread) => thread.id)).toEqual([
+      "thread-pwrsnap-repo-work",
+      "thread-pwragent",
+    ]);
+    expect(threadDirectoryEnricher).toHaveBeenCalledTimes(2);
+    expect(threadDirectoryEnricher).toHaveBeenCalledWith("/Users/huntharo/github/PwrSnap");
+    expect(threadDirectoryEnricher).toHaveBeenCalledWith("/Users/huntharo/github/PwrAgnt");
+
+    await client.close();
+  });
+
   it("preserves thread order while enriching directories concurrently", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
     const threadDirectoryEnricher = vi.fn(async (projectKey?: string) => {

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -1040,10 +1040,44 @@ function isAllowedCodexSessionOriginator(value: string | undefined): boolean {
   );
 }
 
+function normalizeComparableFilesystemPath(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  return path.resolve(trimmed).replace(/[\\/]+$/, "").replaceAll("\\", "/");
+}
+
+function isPwrSnapChatWorkspacePath(value: string | undefined): boolean {
+  const normalized = normalizeComparableFilesystemPath(value);
+  return Boolean(normalized?.match(/\/Documents\/PwrSnap\/Chats(?:\/|$)/));
+}
+
+function isPwrSnapRuntimeContext(value: string | undefined): boolean {
+  return Boolean(value?.trim().startsWith('<runtime_context source="pwrsnap"'));
+}
+
+function isKnownCompanionAppCodexThread(thread: RawCodexThreadSummary): boolean {
+  if (isPwrSnapChatWorkspacePath(thread.projectKey)) {
+    return true;
+  }
+
+  if (thread.title.trim() === "PwrSnap Capture Metadata Worker") {
+    return true;
+  }
+
+  return isPwrSnapRuntimeContext(thread.title) || isPwrSnapRuntimeContext(thread.summary);
+}
+
 function filterVisibleCodexThreads(
   threads: RawCodexThreadSummary[]
 ): RawCodexThreadSummary[] {
-  return threads.filter((thread) => isAllowedCodexSessionOriginator(thread.originator));
+  return threads.filter(
+    (thread) =>
+      isAllowedCodexSessionOriginator(thread.originator) &&
+      !isKnownCompanionAppCodexThread(thread),
+  );
 }
 
 function isPlaceholderThreadTitle(value: string | undefined): boolean {

--- a/packages/agent-core/src/__tests__/directory-navigation.test.ts
+++ b/packages/agent-core/src/__tests__/directory-navigation.test.ts
@@ -400,6 +400,76 @@ describe("buildDirectorySummaries", () => {
     ]);
   });
 
+  it("groups Codex Desktop no-directory chats under Codex Chats", () => {
+    const directories = buildDirectorySummaries({
+      threads: [
+        buildThread({
+          id: "019e8142-230d-78d1-928c-8b4ba1f20d92",
+          createdAt: 2_000,
+          linkedDirectories: [
+            {
+              id: "/Users/huntharo/Documents/Codex/2026-05-31/testing-another-chat",
+              label: "testing-another-chat",
+              path: "/Users/huntharo/Documents/Codex/2026-05-31/testing-another-chat",
+              kind: "local",
+            },
+          ],
+        }),
+        buildThread({
+          id: "019e8142-078b-7cd0-9417-3206124d762e",
+          createdAt: 1_000,
+          linkedDirectories: [
+            {
+              id: "/Users/huntharo/Documents/Codex/2026-05-31/testing-a-chat",
+              label: "testing-a-chat",
+              path: "/Users/huntharo/Documents/Codex/2026-05-31/testing-a-chat",
+              kind: "local",
+            },
+          ],
+          updatedAt: 2_000,
+        }),
+      ],
+    });
+
+    expect(directories).toEqual([
+      expect.objectContaining({
+        key: "directory:/Users/huntharo/Documents/Codex",
+        kind: "directory",
+        label: "Codex Chats",
+        path: "/Users/huntharo/Documents/Codex",
+        threadKeys: [
+          "codex:019e8142-230d-78d1-928c-8b4ba1f20d92",
+          "codex:019e8142-078b-7cd0-9417-3206124d762e",
+        ],
+      }),
+    ]);
+  });
+
+  it("does not treat arbitrary Documents/Codex children as Codex Chats", () => {
+    const directories = buildDirectorySummaries({
+      threads: [
+        buildThread({
+          linkedDirectories: [
+            {
+              id: "/Users/huntharo/Documents/Codex/MyProject",
+              label: "MyProject",
+              path: "/Users/huntharo/Documents/Codex/MyProject",
+              kind: "local",
+            },
+          ],
+        }),
+      ],
+    });
+
+    expect(directories).toEqual([
+      expect.objectContaining({
+        key: "directory:/Users/huntharo/Documents/Codex/MyProject",
+        label: "MyProject",
+        path: "/Users/huntharo/Documents/Codex/MyProject",
+      }),
+    ]);
+  });
+
   it("filters profile-scoped workspace roots outside the active profile", () => {
     const defaultProjectsRoot = "/Users/huntharo/.pwragent/profiles/default/projects";
     const preProfileProjectsRoot = "/Users/huntharo/.pwragent/projects";

--- a/packages/agent-core/src/domain/directory-navigation.ts
+++ b/packages/agent-core/src/domain/directory-navigation.ts
@@ -76,6 +76,13 @@ function matchScratchProjectsRoot(value: string): string | undefined {
   return scratchWorkspaceMatch?.[1];
 }
 
+function matchCodexChatsRoot(value: string): string | undefined {
+  const codexChatsRootMatch = value.match(
+    /^(.*[\\/]Documents[\\/]Codex)(?:[\\/]\d{4}-\d{2}-\d{2}(?:[\\/].*)?)?$/,
+  );
+  return codexChatsRootMatch?.[1];
+}
+
 function classifyDirectory(directory: LinkedDirectorySummary): DirectoryDescriptor {
   // Match both current ".pwragent" and legacy ".pwragnt" home directory names
   // so pre-rebrand thread data classifies correctly.
@@ -86,6 +93,16 @@ function classifyDirectory(directory: LinkedDirectorySummary): DirectoryDescript
       kind: "workspace",
       label: "Workspaces",
       path: scratchProjectsRoot,
+    };
+  }
+
+  const codexChatsRoot = matchCodexChatsRoot(directory.path);
+  if (codexChatsRoot) {
+    return {
+      key: `directory:${codexChatsRoot}`,
+      kind: "directory",
+      label: "Codex Chats",
+      path: codexChatsRoot,
     };
   }
 


### PR DESCRIPTION
## Summary

- PwrAgent now hides PwrSnap-owned Codex chat and capture-metadata worker threads before they reach directory enrichment or the navigation sidebar.
- The filter handles the real shape Codex reports today: these PwrSnap sessions can arrive as normal `vscode` Codex threads, so the guard keys off PwrSnap chat workspace paths, metadata-worker title, and PwrSnap runtime-context previews instead of relying on `sourceKinds`.
- Normal PwrSnap repo work remains visible; only PwrSnap's app-generated chat workspaces under `~/Documents/PwrSnap/Chats` are filtered.
- Codex Desktop projectless chats reported under dated `~/Documents/Codex/...` folders now roll up into one `Codex Chats` directory row instead of appearing as separate generated folders.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/codex-client.test.ts`
- `pnpm test packages/agent-core/src/__tests__/directory-navigation.test.ts apps/desktop/src/main/__tests__/codex-client.test.ts`
- `pnpm lint:boundaries`
- `pnpm --filter @pwragent/desktop typecheck`
- I verified against the `default` Codex profile that the PwrSnap-generated threads disappeared.
- I also verified the `dev` profile still allows adding a folder and seeing it on the next run.
- I checked the Codex App Server response for the two reported Codex chats and confirmed both use `cwd` values under `~/Documents/Codex/2026-05-31/...`.

## Notes

- Codex Desktop appears to avoid these threads by only keeping recent threads whose `cwd` is the active project root or a child of it. PwrAgent is intentionally global, so this PR adds a companion-app noise filter at the Codex client boundary.
- For projectless Codex chats, PwrAgent now preserves the chat threads but normalizes the generated dated folder shape into a stable `Codex Chats` grouping.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
