### PR TITLE
fix(desktop): round in-thread list prices

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts
@@ -63,12 +63,31 @@ describe("buildTokenUsageActivityEntry", () => {
     });
     expect(entry?.summary).toContain("2,432 cached");
     expect(entry?.summary).toContain("174 out (25 reasoning)");
-    expect(entry?.summary).toContain("$0.1042 list price");
+    expect(entry?.summary).toContain("$0.11 list price");
     expect(entry?.details.map((detail) => detail.label)).toEqual([
       "Input: 21,981 tokens (19,549 uncached, 2,432 cached)",
       "Output: 174 tokens, including 25 reasoning",
-      "Cost: $0.1042 list price for gpt-5.5",
+      "Cost: $0.11 list price for gpt-5.5",
     ]);
+  });
+
+  it("rounds list-price costs below ten cents to tenths of a penny", () => {
+    const entry = buildTokenUsageActivityEntry({
+      id: "usage-small-cost",
+      model: "gpt-5.4-mini",
+      tokenUsage: {
+        total: {
+          inputTokens: 1_000,
+          cachedInputTokens: 0,
+          outputTokens: 1_000,
+        },
+      },
+    });
+
+    expect(entry?.summary).toContain("$0.006 list price");
+    expect(entry?.details.at(-1)?.label).toBe(
+      "Cost: $0.006 list price for gpt-5.4-mini",
+    );
   });
 
   it("reports unavailable cost without dropping token accounting", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
@@ -404,15 +404,24 @@ function formatTokenCount(value: number): string {
 }
 
 function formatUsd(value: number): string {
-  if (value > 0 && value < 0.01) {
-    return "<$0.01";
+  if (value > 0 && value < 0.001) {
+    return "<$0.001";
   }
+  if (value < 0.1) {
+    return new Intl.NumberFormat(undefined, {
+      currency: "USD",
+      maximumFractionDigits: 3,
+      minimumFractionDigits: 3,
+      style: "currency",
+    }).format(Math.ceil(value * 1_000) / 1_000);
+  }
+
   return new Intl.NumberFormat(undefined, {
     currency: "USD",
-    maximumFractionDigits: value < 1 ? 4 : 2,
-    minimumFractionDigits: value < 1 ? 2 : 2,
+    maximumFractionDigits: 2,
+    minimumFractionDigits: 2,
     style: "currency",
-  }).format(value);
+  }).format(Math.ceil(value * 100) / 100);
 }
 
 function readCommandActionLabel(item: Record<string, unknown>): string | undefined {


### PR DESCRIPTION
## Summary

- I changed the in-thread list price display so costs under $0.10 round up to tenths of a penny, while costs at or above $0.10 round up to cents.
- This keeps usage rows from showing overly precise estimates like `$0.1042`, while still preserving useful precision for very small turns.

## Verification

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts`

## Notes

- The branch contains signed checkpoint commit `ca1994f0`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
