### PR TITLE
fix(desktop): keep review turns stable

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -8853,6 +8853,65 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("treats a Codex review as active until its terminal turn notification", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start", "review/start"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await registry.startReview({
+      backend: "codex",
+      threadId: "thread-1",
+      target: { type: "baseBranch", branch: "main" },
+      delivery: "inline",
+    });
+
+    await codexClient.emit({
+      method: "thread/status/changed",
+      params: {
+        threadId: "thread-1",
+        status: { type: "idle" },
+      },
+    });
+
+    await expect(
+      registry.startTurn({
+        backend: "codex",
+        threadId: "thread-1",
+        input: [{ type: "text", text: "Follow-up while review is running" }],
+      }),
+    ).rejects.toThrow("A turn is already active for this thread.");
+    expect(codexClient.startTurnCallCount).toBe(0);
+
+    await codexClient.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-review-1",
+        turn: {
+          id: "turn-review-1",
+          status: "completed",
+          output: [],
+        },
+      },
+    });
+
+    await registry.startTurn({
+      backend: "codex",
+      threadId: "thread-1",
+      input: [{ type: "text", text: "Follow-up after review" }],
+    });
+    expect(codexClient.startTurnCallCount).toBe(1);
+
+    await registry.close();
+  });
+
   it("normalizes backend notifications with backend identity", async () => {
     const grokClient = new MockBackendClient({
       initializeResult: { methods: ["thread/list"] },

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -800,6 +800,7 @@ describe("MessagingController", () => {
   });
 
   it("debounces split first prompts before creating a messaging-started thread", async () => {
+    vi.useFakeTimers();
     const harness = await createHarness({ inputDebounceMs: 100 });
 
     await harness.controller.handleInboundEvent(buildCommandEvent("/resume --new"));
@@ -819,7 +820,7 @@ describe("MessagingController", () => {
     expect(harness.startThread).not.toHaveBeenCalled();
     expect(harness.materializeDirectoryLaunchpad).not.toHaveBeenCalled();
 
-    await new Promise((resolve) => setTimeout(resolve, 125));
+    await vi.advanceTimersByTimeAsync(100);
 
     await vi.waitFor(() => {
       expect(harness.startThread).not.toHaveBeenCalled();

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1121,42 +1121,51 @@ function buildActiveTurnKey(
   return `${backend}:${threadId}:${turnId}`;
 }
 
+function parseThreadTurnKeyBody(
+  body: string,
+): { threadId: string; turnId: string } | undefined {
+  const pendingSeparator = body.indexOf(":pending:");
+  if (pendingSeparator > 0) {
+    const beforePending = body.slice(0, pendingSeparator);
+    const afterPending = body.slice(pendingSeparator + ":pending:".length);
+    if (beforePending === afterPending || afterPending.startsWith(`${beforePending}:`)) {
+      return { threadId: beforePending, turnId: `pending:${afterPending}` };
+    }
+  }
+  const turnSeparator = body.lastIndexOf(":");
+  if (turnSeparator <= 0) return undefined;
+  return {
+    threadId: body.slice(0, turnSeparator),
+    turnId: body.slice(turnSeparator + 1),
+  };
+}
+
 function parseActiveTurnKey(
   key: string,
-): { backend: AppServerBackendKind; threadId: string } | undefined {
+): { backend: AppServerBackendKind; threadId: string; turnId: string } | undefined {
   if (key.startsWith("acp:")) {
     const registrySeparator = key.indexOf(":", "acp:".length);
     if (registrySeparator <= "acp:".length) return undefined;
     const backend = key.slice(0, registrySeparator);
     if (!isAcpBackendId(backend)) return undefined;
-    const threadId = parseThreadIdFromThreadTurnKeyBody(
+    const parsed = parseThreadTurnKeyBody(
       key.slice(registrySeparator + 1),
     );
-    return threadId ? { backend, threadId } : undefined;
+    return parsed ? { backend, ...parsed } : undefined;
   }
 
   const backendSeparator = key.indexOf(":");
   if (backendSeparator <= 0) return undefined;
   const backend = key.slice(0, backendSeparator);
   if (backend !== "codex" && backend !== "grok") return undefined;
-  const threadId = parseThreadIdFromThreadTurnKeyBody(
+  const parsed = parseThreadTurnKeyBody(
     key.slice(backendSeparator + 1),
   );
-  return threadId ? { backend, threadId } : undefined;
+  return parsed ? { backend, ...parsed } : undefined;
 }
 
 function parseThreadIdFromThreadTurnKeyBody(body: string): string | undefined {
-  const pendingSeparator = body.indexOf(":pending:");
-  if (pendingSeparator > 0) {
-    const beforePending = body.slice(0, pendingSeparator);
-    const afterPending = body.slice(pendingSeparator + ":pending:".length);
-    if (beforePending === afterPending || afterPending.startsWith(`${beforePending}:`)) {
-      return beforePending;
-    }
-  }
-  const turnSeparator = body.lastIndexOf(":");
-  if (turnSeparator <= 0) return undefined;
-  return body.slice(0, turnSeparator);
+  return parseThreadTurnKeyBody(body)?.threadId;
 }
 
 function buildHeadlessAutomationTurnKey(
@@ -2150,6 +2159,7 @@ export class DesktopBackendRegistry {
     }
   >();
   private readonly activeCodexTurnModes = new Map<string, ThreadExecutionMode>();
+  private readonly activeCodexReviewTurnKeys = new Set<string>();
   private readonly observedCodexSettingsByThread = new Map<string, ObservedCodexSettings>();
   private readonly reservedCodexStartThreadIds = new Set<string>();
   private readonly reservedAcpStartThreadKeys = new Set<string>();
@@ -4849,30 +4859,69 @@ export class DesktopBackendRegistry {
     if (isAcpBackendId(params.backend)) {
       throw new Error("Selected backend does not support review/start");
     }
-    if (params.backend === "codex" && this.threadHasActiveTurn(params.threadId)) {
-      throw new Error(`Thread already has an active turn in progress: ${params.threadId}`);
-    }
-    if (params.backend === "codex") {
-      await this.flushQueuedExecutionModeIfPresent(params.threadId);
-    }
-
-    const startWithClient = async (
-      client: BackendClient,
-    ): Promise<{ threadId: string; reviewThreadId: string; turnId: string }> => {
-      if (!client.startReview) {
-        throw new Error("Selected backend does not support review/start");
+    const reserveCodexReviewStart = params.backend === "codex";
+    if (reserveCodexReviewStart) {
+      if (this.threadHasActiveTurn(params.threadId)) {
+        throw new Error(`Thread already has an active turn in progress: ${params.threadId}`);
       }
-      return await client.startReview({
-        threadId: params.threadId,
-        target: params.target,
-        delivery: params.delivery ?? "inline",
-      });
-    };
+      this.reservedCodexStartThreadIds.add(params.threadId);
+    }
 
-    const result =
-      params.backend === "codex"
-        ? await this.withCodexThreadClient(params.threadId, startWithClient)
-        : await startWithClient(this.getClient(params.backend));
+    let result: { threadId: string; reviewThreadId: string; turnId: string };
+    try {
+      if (params.backend === "codex") {
+        await this.flushQueuedExecutionModeIfPresent(params.threadId);
+      }
+
+      const startWithClient = async (
+        client: BackendClient,
+      ): Promise<{ threadId: string; reviewThreadId: string; turnId: string }> => {
+        if (!client.startReview) {
+          throw new Error("Selected backend does not support review/start");
+        }
+        return await client.startReview({
+          threadId: params.threadId,
+          target: params.target,
+          delivery: params.delivery ?? "inline",
+        });
+      };
+
+      result =
+        params.backend === "codex"
+          ? await this.withCodexThreadClient(params.threadId, startWithClient)
+          : await startWithClient(this.getClient(params.backend));
+    } catch (error) {
+      if (reserveCodexReviewStart) {
+        this.reservedCodexStartThreadIds.delete(params.threadId);
+      }
+      throw error;
+    }
+
+    if (params.backend === "codex") {
+      try {
+        const reviewThreadId = result.reviewThreadId || result.threadId;
+        // Codex review/start returns the real review turn id, but current
+        // Codex builds can also emit a lone, mismatched turn/started for the
+        // same thread. Treat the returned review turn as active so queued
+        // turns cannot release in parallel and so the matching terminal
+        // review notification clears the active state.
+        const activeTurnMode = await this.resolveCodexThreadExecutionModeForActiveTurn(
+          reviewThreadId,
+        );
+        this.activeTurnKeys.add(
+          buildActiveTurnKey(params.backend, reviewThreadId, result.turnId),
+        );
+        this.activeCodexTurnModes.set(
+          buildActiveTurnModeKey(reviewThreadId, result.turnId),
+          activeTurnMode,
+        );
+        this.activeCodexReviewTurnKeys.add(
+          buildActiveTurnModeKey(reviewThreadId, result.turnId),
+        );
+      } finally {
+        this.reservedCodexStartThreadIds.delete(params.threadId);
+      }
+    }
 
     return {
       backend: params.backend,
@@ -4924,9 +4973,9 @@ export class DesktopBackendRegistry {
         : await this.grokClient.interruptTurn(params);
 
     if (params.backend === "codex") {
-      this.activeCodexTurnModes.delete(
-        buildActiveTurnModeKey(result.threadId, result.turnId),
-      );
+      const activeTurnModeKey = buildActiveTurnModeKey(result.threadId, result.turnId);
+      this.activeCodexTurnModes.delete(activeTurnModeKey);
+      this.activeCodexReviewTurnKeys.delete(activeTurnModeKey);
     }
 
     return {
@@ -5691,6 +5740,16 @@ export class DesktopBackendRegistry {
     }
     const prefix = `${backend}:${threadId}:`;
     for (const key of this.activeTurnKeys) {
+      if (key.startsWith(prefix)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private threadHasActiveCodexReviewTurn(threadId: string): boolean {
+    const prefix = `${threadId}:`;
+    for (const key of this.activeCodexReviewTurnKeys) {
       if (key.startsWith(prefix)) {
         return true;
       }
@@ -9213,6 +9272,7 @@ export class DesktopBackendRegistry {
           !turnId.startsWith("pending:") &&
           this.activeCodexTurnModes.has(activeTurnModeKey);
         this.activeCodexTurnModes.delete(activeTurnModeKey);
+        this.activeCodexReviewTurnKeys.delete(activeTurnModeKey);
         if (wasKnownActiveTurn) {
           await this.adoptThreadBranchChangeFromActiveTurn({
             backend: event.backend,
@@ -9278,9 +9338,23 @@ export class DesktopBackendRegistry {
       event.notification.method === "thread/status/changed" &&
       readStatusType(event.notification.params.status) !== "active"
     ) {
+      const threadId = event.notification.params.threadId;
+      const hasActiveCodexReviewTurn =
+        event.backend === "codex" &&
+        this.threadHasActiveCodexReviewTurn(threadId);
       const genericKeyPrefix = `${event.backend}:${event.notification.params.threadId}:`;
       for (const key of Array.from(this.activeTurnKeys)) {
         if (key.startsWith(genericKeyPrefix)) {
+          const parsed = parseActiveTurnKey(key);
+          if (
+            hasActiveCodexReviewTurn &&
+            parsed?.backend === "codex" &&
+            this.activeCodexReviewTurnKeys.has(
+              buildActiveTurnModeKey(parsed.threadId, parsed.turnId),
+            )
+          ) {
+            continue;
+          }
           this.activeTurnKeys.delete(key);
         }
       }
@@ -9302,6 +9376,9 @@ export class DesktopBackendRegistry {
         let hadKnownActiveTurn = false;
         for (const key of this.activeCodexTurnModes.keys()) {
           if (key.startsWith(keyPrefix)) {
+            if (this.activeCodexReviewTurnKeys.has(key)) {
+              continue;
+            }
             if (!key.startsWith(`${keyPrefix}pending:`)) {
               hadKnownActiveTurn = true;
             }
@@ -9318,9 +9395,19 @@ export class DesktopBackendRegistry {
         // `thread/status/changed → idle` path (codex emits both, depending
         // on the protocol shape; we cover both for resilience). Idempotent
         // when no queue is set.
-        void this.flushQueuedExecutionModeIfPresent(
-          event.notification.params.threadId,
-        );
+        if (!hasActiveCodexReviewTurn) {
+          void this.flushQueuedExecutionModeIfPresent(
+            event.notification.params.threadId,
+          );
+        }
+      }
+      if (hasActiveCodexReviewTurn) {
+        // Codex review/start currently returns the real review turn id, then
+        // may emit a mismatched turn/started and an idle status before the
+        // review's own terminal event. Do not release queued turns at that
+        // stray idle boundary; the matching review turn/completed is the real
+        // point where the thread becomes available again.
+        return;
       }
       void this.threadTurnQueue.releaseThread({
         backend: event.backend,

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -2478,6 +2478,9 @@ export function Composer(props: ComposerProps) {
           activeReviewTurnIdRef.current &&
           startedTurnRecord.id !== activeReviewTurnIdRef.current
         ) {
+          // Codex reviews can surface a separate turn/started id while all
+          // review items and the terminal event stay on review/start's turn.
+          // Keep Stop/active-turn wiring pointed at the real review turn.
           return;
         }
         updateActiveTurnId(startedTurnRecord.id);

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1371,6 +1371,7 @@ export function Composer(props: ComposerProps) {
   const inputWrapRef = useRef<HTMLDivElement>(null);
   const autocompleteListRef = useRef<HTMLDivElement>(null);
   const activeTurnIdRef = useRef<string | undefined>(props.activeTurnId);
+  const activeReviewTurnIdRef = useRef<string | undefined>(undefined);
   const autocompleteOptionRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const skillListboxId = useId();
   const slashListboxId = useId();
@@ -2048,7 +2049,15 @@ export function Composer(props: ComposerProps) {
     saveComposerDraftSnapshot(scopeKey, snapshot);
     persistLaunchpadDraftSnapshot(scopeKey, snapshot);
   };
-  const updateActiveTurnId = (nextTurnId?: string): void => {
+  const updateActiveTurnId = (
+    nextTurnId?: string,
+    options?: { review?: boolean },
+  ): void => {
+    if (options?.review) {
+      activeReviewTurnIdRef.current = nextTurnId;
+    } else if (!nextTurnId || activeReviewTurnIdRef.current !== nextTurnId) {
+      activeReviewTurnIdRef.current = undefined;
+    }
     activeTurnIdRef.current = nextTurnId;
     setActiveTurnId(nextTurnId);
   };
@@ -2465,6 +2474,12 @@ export function Composer(props: ComposerProps) {
         event.notification.method === "turn/started" &&
         typeof startedTurnRecord?.id === "string"
       ) {
+        if (
+          activeReviewTurnIdRef.current &&
+          startedTurnRecord.id !== activeReviewTurnIdRef.current
+        ) {
+          return;
+        }
         updateActiveTurnId(startedTurnRecord.id);
         props.onActiveTurnIdChange?.(startedTurnRecord.id);
       }
@@ -2666,7 +2681,7 @@ export function Composer(props: ComposerProps) {
         target: reviewCommand.target,
         delivery: "inline",
       });
-      updateActiveTurnId(response.turnId);
+      updateActiveTurnId(response.turnId, { review: true });
       props.onActiveTurnIdChange?.(response.turnId);
       if (options?.queued) {
         if (!options.queueClaimed) {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -3378,6 +3378,98 @@ describe("Composer", () => {
     expect(startTurn).not.toHaveBeenCalled();
   });
 
+  it("keeps review completion tied to the review/start turn id", async () => {
+    let agentEventHandler: ((event: {
+      backend: "codex";
+      notification: {
+        method: string;
+        params: Record<string, unknown>;
+      };
+    }) => void) | undefined;
+    const startReview = vi.fn(async (request: StartReviewRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      reviewThreadId: request.threadId,
+      turnId: "turn-review-response",
+    }));
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: (callback) => {
+            agentEventHandler = callback as typeof agentEventHandler;
+            return () => undefined;
+          },
+          startReview,
+          startTurn: vi.fn(),
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Review thread",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review main" },
+    });
+    await clickButton("Send");
+
+    expect(await screen.findByRole("button", { name: "Stop" })).toBeInTheDocument();
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/started",
+          params: {
+            threadId: "thread-1",
+            turn: {
+              id: "turn-started-notification",
+              status: "inProgress",
+            },
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "thread/status/changed",
+          params: {
+            threadId: "thread-1",
+            status: { type: "idle" },
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-review-response",
+            turn: {
+              id: "turn-review-response",
+              status: "completed",
+              output: [],
+            },
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "Stop" })).not.toBeInTheDocument();
+    });
+  });
+
   it("does not open the review picker for backends without review support", async () => {
     const kimiBackend = backendSummary("acp:kimi" as BackendSummary["kind"]);
     const startReview = vi.fn();

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -5785,6 +5785,79 @@ describe("useThreadSessionState", () => {
     expect(result.current.thinkingThreadKeys["codex:thread-1"]).toBeUndefined();
   });
 
+  it("does not keep list thinking from completed usage with stale turn metadata", async () => {
+    let agentEventHandler: Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0] | undefined;
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback;
+        return () => undefined;
+      },
+      readThread: vi.fn(async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      })),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitForThreadHydration(result);
+
+    act(() => {
+      result.current.setActiveTurnId("turn-2");
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "thread/tokenUsage/updated",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            tokenUsage: {
+              last_token_usage: {
+                input_tokens: 1_200,
+                cached_input_tokens: 200,
+                output_tokens: 50,
+                reasoning_output_tokens: 10,
+              },
+            },
+          },
+        },
+      });
+    });
+
+    expect(result.current.entries).toEqual([
+      expect.objectContaining({
+        id: "live-token-usage-turn-1",
+        status: "completed",
+        type: "activity",
+        turn: expect.objectContaining({
+          id: "turn-1",
+          status: "in_progress",
+        }),
+      }),
+    ]);
+    expect(result.current.thinkingThreadKeys["codex:thread-1"]).toBe(true);
+
+    act(() => {
+      result.current.setActiveTurnId(undefined);
+    });
+
+    expect(result.current.thinkingThreadKeys["codex:thread-1"]).toBeUndefined();
+  });
+
   it("logs and clears stale thinking when a selected thread read proves the thread is idle", async () => {
     const logRendererDiagnostic = vi.fn(async () => undefined);
     const readThread = vi

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -5347,6 +5347,111 @@ describe("useThreadSessionState", () => {
     ]);
   });
 
+  it("keeps a review turn active when a separate turn/started arrives", async () => {
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback;
+        return () => undefined;
+      },
+      readThread: async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitForThreadHydration(result);
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-review",
+            item: {
+              id: "turn-review-entered",
+              type: "enteredReviewMode",
+              review: "Review changes against main",
+            },
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/started",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-stray",
+            turn: {
+              id: "turn-stray",
+              status: "inProgress",
+            },
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-review",
+            item: {
+              id: "turn-review-exited",
+              type: "exitedReviewMode",
+              review: "No findings.",
+            },
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-review",
+            turn: {
+              id: "turn-review",
+              status: "completed",
+              output: [],
+            },
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.activeTurnId).toBeUndefined();
+      expect(result.current.pendingStatusText).toBeUndefined();
+      expect(result.current.threadBusy).toBe(false);
+      expect(
+        result.current.entries.filter((entry) => entry.type === "review")
+      ).toHaveLength(2);
+    });
+  });
+
   it("stores context window usage from token usage notifications", async () => {
     let agentEventHandler: Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0] | undefined;
     const desktopApi: DesktopApi = {

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -1333,6 +1333,25 @@ function terminalTurnMatchesActiveTurn(
   );
 }
 
+function shouldAdoptStartedTurn(
+  session: ThreadSessionEntry,
+  startedTurnId: string | undefined,
+): boolean {
+  if (!startedTurnId) {
+    return false;
+  }
+
+  if (!session.activeTurnId) {
+    return true;
+  }
+
+  if (startedTurnId === session.activeTurnId) {
+    return true;
+  }
+
+  return session.activeTurnId.startsWith("pending:");
+}
+
 function withTurnMetadata<T extends AppServerThreadMessageEntry>(
   entry: T,
   turn: AppServerThreadTurnMetadata | undefined
@@ -2916,6 +2935,10 @@ export function useThreadSessionState(params: {
           const startedAt =
             normalizeNotificationTimestamp(startedTurnRecord?.startedAt) ?? Date.now();
 
+          if (!shouldAdoptStartedTurn(current, turnId)) {
+            return current;
+          }
+
           return {
             ...current,
             activeTurnId: turnId,
@@ -3060,6 +3083,14 @@ export function useThreadSessionState(params: {
 
             return {
               ...current,
+              activeTurnId:
+                reviewEntry.turn?.status === "in_progress" && reviewEntry.turn.id
+                  ? reviewEntry.turn.id
+                  : current.activeTurnId,
+              activeTurnStartedAt:
+                reviewEntry.turn?.status === "in_progress" && reviewEntry.turn.id
+                  ? current.activeTurnStartedAt ?? Date.now()
+                  : current.activeTurnStartedAt,
               expectOwnUpdate: true,
               interacted: true,
               lastTouchedAt: nextLastTouchedAt,

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -981,6 +981,10 @@ function isLiveOptimisticEntry(entry: AppServerThreadEntry): boolean {
     return true;
   }
 
+  if (entry.type === "activity" && entry.status !== "in_progress") {
+    return false;
+  }
+
   if (entry.turn?.status) {
     return entry.turn.status === "in_progress";
   }
@@ -1349,6 +1353,10 @@ function shouldAdoptStartedTurn(
     return true;
   }
 
+  // Review turns are claimed from review/start and review-mode items before
+  // Codex may emit a lone, mismatched turn/started. Do not let that stray
+  // lifecycle notification replace the review turn; it has no matching items
+  // or terminal event, so adopting it leaves the thread stuck as thinking.
   return session.activeTurnId.startsWith("pending:");
 }
 


### PR DESCRIPTION
## Summary
- Keep composer review completion tied to the review/start turn id so later lifecycle events cannot retarget controls to a stray turn.
- Keep renderer session state locked to the active review turn when a separate turn/started notification arrives.
- Mark Codex review/start responses as active turns in the desktop registry, since current Codex review turns do not emit parent turn/started notifications.
- Stabilize the messaging-controller debounce assertion that failed CI when this review fix was carried on PR #603.

## Verification
- pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts -t \"treats a Codex review as active\"
- pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx -t \"keeps a review turn active\"
- pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx -t \"keeps review completion tied\"
- pnpm --filter @pwragent/desktop exec tsc --noEmit

## Notes
- Current ~/github/codex source indicates review turns do not emit parent turn/started; PwrAgent now treats review/start's returned turn id as active until the terminal notification.
- Full backend-registry.test.ts hit an unrelated local env-action output failure due shell/npm/starship warnings in command output.