### PR TITLE
fix(desktop): persist queued turn blockers by thread

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -403,6 +403,10 @@ function getLaunchpadDirectoryKeyFromScope(scopeKey: string): string | undefined
     : undefined;
 }
 
+function getThreadComposerScopeKey(backend: string, threadId: string): string {
+  return `thread:${backend}:${threadId}`;
+}
+
 function createReviewConfig(params: {
   directory?: NavigationDirectorySummary;
   thread?: NavigationThreadSummary;
@@ -1460,12 +1464,21 @@ export function Composer(props: ComposerProps) {
     savedInitialQueuedTurns ?? []
   );
   const queuedAutoReleaseAttemptIdRef = useRef<string | undefined>(undefined);
-  const serverQueuedTurnEntryIdRef = useRef<string | undefined>(undefined);
+  const serverQueuedTurnEntryIdsRef = useRef(new Map<string, string>());
   const [serverQueuedTurnEntryId, setServerQueuedTurnEntryIdState] =
     useState<string>();
-  const updateServerQueuedTurnEntryId = (nextEntryId?: string): void => {
-    serverQueuedTurnEntryIdRef.current = nextEntryId;
-    setServerQueuedTurnEntryIdState(nextEntryId);
+  const updateServerQueuedTurnEntryId = (
+    nextEntryId?: string,
+    scopeKey = composerScopeKey,
+  ): void => {
+    if (nextEntryId) {
+      serverQueuedTurnEntryIdsRef.current.set(scopeKey, nextEntryId);
+    } else {
+      serverQueuedTurnEntryIdsRef.current.delete(scopeKey);
+    }
+    if (scopeKey === composerScopeKey) {
+      setServerQueuedTurnEntryIdState(nextEntryId);
+    }
   };
   const [pendingSteer, setPendingSteerState] = useState<
     PendingSteerDraft | undefined
@@ -2206,7 +2219,9 @@ export function Composer(props: ComposerProps) {
     updateSending(false);
     setInterrupting(false);
     setSteering(false);
-    updateServerQueuedTurnEntryId(undefined);
+    setServerQueuedTurnEntryIdState(
+      serverQueuedTurnEntryIdsRef.current.get(composerScopeKey)
+    );
     updateActiveTurnId(undefined);
     setActiveOptimisticMessageId(undefined);
     setReviewConfig(undefined);
@@ -2339,7 +2354,7 @@ export function Composer(props: ComposerProps) {
     updateSending(false);
     setInterrupting(false);
     setSteering(false);
-    updateServerQueuedTurnEntryId(undefined);
+    setServerQueuedTurnEntryIdState(undefined);
     updateActiveTurnId(undefined);
     setActiveOptimisticMessageId(undefined);
     setReviewConfig(undefined);
@@ -2411,21 +2426,29 @@ export function Composer(props: ComposerProps) {
         typeof event.notification.params === "object" &&
         event.notification.params !== null
           ? (event.notification.params as {
+              errorMessage?: unknown;
               queueEntryId?: unknown;
               status?: unknown;
               turnId?: unknown;
             })
           : undefined;
 
-      if (event.backend !== thread.source || notificationThreadId !== thread.id) {
-        return;
-      }
-
       if (
+        notificationThreadId &&
         typeof turnQueueRecord?.queueEntryId === "string" &&
-        turnQueueRecord.queueEntryId === serverQueuedTurnEntryIdRef.current
+        turnQueueRecord.queueEntryId ===
+          serverQueuedTurnEntryIdsRef.current.get(
+            getThreadComposerScopeKey(event.backend, notificationThreadId)
+          )
       ) {
+        const queueScopeKey = getThreadComposerScopeKey(
+          event.backend,
+          notificationThreadId,
+        );
+        const queueEventIsCurrentThread =
+          event.backend === thread.source && notificationThreadId === thread.id;
         if (
+          queueEventIsCurrentThread &&
           turnQueueRecord.status === "started" &&
           typeof turnQueueRecord.turnId === "string"
         ) {
@@ -2438,9 +2461,35 @@ export function Composer(props: ComposerProps) {
           turnQueueRecord.status === "failed" ||
           turnQueueRecord.status === "cancelled"
         ) {
-          globalQueuedTurnReleaseScopeKeys.delete(composerScopeKey);
-          updateServerQueuedTurnEntryId(undefined);
+          globalQueuedTurnReleaseScopeKeys.delete(queueScopeKey);
+          updateServerQueuedTurnEntryId(undefined, queueScopeKey);
+          if (
+            queueEventIsCurrentThread &&
+            !activeTurnIdRef.current &&
+            (turnQueueRecord.status === "failed" ||
+              turnQueueRecord.status === "cancelled")
+          ) {
+            if (activeOptimisticMessageId) {
+              props.removeOptimisticMessage?.(activeOptimisticMessageId);
+            }
+            props.onPendingStatusChange?.(undefined);
+            updateSending(false);
+            setInterrupting(false);
+            setSteering(false);
+            setActiveOptimisticMessageId(undefined);
+            setSendError(
+              typeof turnQueueRecord.errorMessage === "string"
+                ? turnQueueRecord.errorMessage
+                : turnQueueRecord.status === "cancelled"
+                  ? "Queued turn was cancelled before it started."
+                  : "Queued turn failed before it started."
+            );
+          }
         }
+      }
+
+      if (event.backend !== thread.source || notificationThreadId !== thread.id) {
+        return;
       }
 
       if (
@@ -3061,7 +3110,7 @@ export function Composer(props: ComposerProps) {
     !props.launchpad &&
     (Boolean(props.threadBusy) ||
       Boolean(activeTurnIdRef.current) ||
-      Boolean(serverQueuedTurnEntryIdRef.current) ||
+      Boolean(serverQueuedTurnEntryIdsRef.current.get(composerScopeKey)) ||
       sendingRef.current);
 
   const submitPendingSteer = async (pending: QueuedTurnDraft): Promise<void> => {

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -2192,6 +2192,10 @@ export function Composer(props: ComposerProps) {
       skillTokens,
     };
     flushComposerDraftSnapshot(previousScopeKey, previousSnapshot);
+    if (!props.thread && previousScopeKey.startsWith("thread:")) {
+      serverQueuedTurnEntryIdsRef.current.delete(previousScopeKey);
+      globalQueuedTurnReleaseScopeKeys.delete(previousScopeKey);
+    }
 
     activeComposerScopeKeyRef.current = composerScopeKey;
     const current = pasteScopeRef.current;

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1897,6 +1897,196 @@ describe("Composer", () => {
     });
   });
 
+  it("remembers server queued turn state after switching away and back", async () => {
+    const draftStore = createComposerDraftStore();
+    const startTurn = vi.fn(async (request: StartTurnRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      turnId: "server-queue-entry-1",
+      queueStatus: "queued" as const,
+      queueEntryId: "server-queue-entry-1",
+    }));
+    const startReview = vi.fn(async (request: StartReviewRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      reviewThreadId: request.threadId,
+      turnId: "turn-review-1",
+    }));
+    const baseProps = {
+      backends: [backendSummary("codex")],
+      desktopApi: {
+        onAgentEvent: () => () => undefined,
+        startReview,
+        startTurn,
+      },
+      disabled: false,
+      draftStore,
+      skills: [],
+    };
+    const threadA = {
+      id: "thread-1",
+      title: "Server queued thread",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      executionMode: "default" as const,
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const threadB = {
+      ...threadA,
+      id: "thread-2",
+      title: "Other thread",
+    };
+
+    const { rerender } = render(
+      <Composer
+        {...baseProps}
+        activeTurnId="turn-1"
+        thread={threadA}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "make a branch and PR" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    fireEvent.change(textarea, { target: { value: "/review main" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    rerender(
+      <Composer
+        {...baseProps}
+        activeTurnId={undefined}
+        thread={threadA}
+      />
+    );
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          threadId: "thread-1",
+          input: [{ type: "text", text: "make a branch and PR" }],
+        })
+      );
+    });
+    await flushReactUpdates();
+    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+      "Review changes against main"
+    );
+
+    rerender(
+      <Composer
+        {...baseProps}
+        activeTurnId={undefined}
+        thread={threadB}
+      />
+    );
+    rerender(
+      <Composer
+        {...baseProps}
+        activeTurnId={undefined}
+        thread={threadA}
+      />
+    );
+    await flushReactUpdates();
+
+    expect(startReview).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Queue" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+      "Review changes against main"
+    );
+  });
+
+  it("clears optimistic pending UI when a server queued turn fails before starting", async () => {
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex";
+          notification: {
+            method: string;
+            params: Record<string, unknown>;
+          };
+        }) => void)
+      | undefined;
+    const startTurn = vi.fn(async (request: StartTurnRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      turnId: "server-queue-entry-1",
+      queueStatus: "queued" as const,
+      queueEntryId: "server-queue-entry-1",
+    }));
+    const addOptimisticUserMessage = vi.fn(() => "optimistic-1");
+    const removeOptimisticMessage = vi.fn();
+    const onPendingStatusChange = vi.fn();
+    const baseProps = {
+      backends: [backendSummary("codex")],
+      desktopApi: {
+        onAgentEvent: (callback: NonNullable<DesktopApi["onAgentEvent"]> extends (
+          listener: infer Listener,
+        ) => unknown
+          ? Listener
+          : never) => {
+          agentEventHandler = callback as typeof agentEventHandler;
+          return () => undefined;
+        },
+        startTurn,
+      },
+      addOptimisticUserMessage,
+      disabled: false,
+      onPendingStatusChange,
+      removeOptimisticMessage,
+      skills: [],
+      thread: {
+        id: "thread-1",
+        title: "Server queued thread",
+        titleSource: "explicit" as const,
+        source: "codex" as const,
+        executionMode: "default" as const,
+        linkedDirectories: [],
+        inbox: { inInbox: false },
+      },
+    };
+
+    const { rerender } = render(
+      <Composer
+        {...baseProps}
+        activeTurnId="turn-1"
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "make a branch and PR" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    rerender(<Composer {...baseProps} activeTurnId={undefined} />);
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalled();
+    });
+    expect(addOptimisticUserMessage).toHaveBeenCalledWith(
+      "make a branch and PR",
+      []
+    );
+    expect(onPendingStatusChange).toHaveBeenCalledWith("Thinking");
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "thread/turnQueue/updated",
+          params: {
+            threadId: "thread-1",
+            queueEntryId: "server-queue-entry-1",
+            status: "failed",
+            errorMessage: "Thread queue start failed",
+          },
+        },
+      });
+    });
+
+    expect(removeOptimisticMessage).toHaveBeenCalledWith("optimistic-1");
+    expect(onPendingStatusChange).toHaveBeenLastCalledWith(undefined);
+    expect(screen.getByText("Thread queue start failed")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Send" })).toBeInTheDocument();
+  });
+
   it("does not remove the next queued message when the in-flight queued chip is edited", async () => {
     let resolveStartTurn: ((value: StartTurnResponse) => void) | undefined;
     const startTurn = vi.fn(

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1996,6 +1996,94 @@ describe("Composer", () => {
     );
   });
 
+  it("drops server queued turn state after switching through an empty composer", async () => {
+    const draftStore = createComposerDraftStore();
+    const startTurn = vi.fn(async (request: StartTurnRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      turnId: "server-queue-entry-1",
+      queueStatus: "queued" as const,
+      queueEntryId: "server-queue-entry-1",
+    }));
+    const startReview = vi.fn(async (request: StartReviewRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      reviewThreadId: request.threadId,
+      turnId: "turn-review-1",
+    }));
+    const baseProps = {
+      backends: [backendSummary("codex")],
+      desktopApi: {
+        onAgentEvent: () => () => undefined,
+        startReview,
+        startTurn,
+      },
+      disabled: false,
+      draftStore,
+      skills: [],
+    };
+    const thread = {
+      id: "thread-1",
+      title: "Server queued thread",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      executionMode: "default" as const,
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+
+    const { rerender } = render(
+      <Composer
+        {...baseProps}
+        activeTurnId="turn-1"
+        thread={thread}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "make a branch and PR" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    fireEvent.change(textarea, { target: { value: "/review main" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    rerender(
+      <Composer
+        {...baseProps}
+        activeTurnId={undefined}
+        thread={thread}
+      />
+    );
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          threadId: "thread-1",
+          input: [{ type: "text", text: "make a branch and PR" }],
+        })
+      );
+    });
+    await flushReactUpdates();
+    expect(startReview).not.toHaveBeenCalled();
+
+    rerender(<Composer {...baseProps} activeTurnId={undefined} />);
+    rerender(
+      <Composer
+        {...baseProps}
+        activeTurnId={undefined}
+        thread={thread}
+      />
+    );
+
+    await waitFor(() => {
+      expect(startReview).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        target: { type: "baseBranch", branch: "main" },
+        delivery: "inline",
+      });
+    });
+  });
+
   it("clears optimistic pending UI when a server queued turn fails before starting", async () => {
     let agentEventHandler:
       | ((event: {


### PR DESCRIPTION
## Summary

Fixes two follow-up queue-state issues in the composer after the queued-review race fix:

- Preserve server-queued turn blockers by composer thread scope so switching away and back does not allow the next queued local item, including `/review`, to dispatch while the previous server-queued turn is still waiting to start.
- Clean up visible pending UI when a server-queued manual turn fails or is cancelled before it ever emits a real `turn/started` event.

## Changes

- Replace the single `serverQueuedTurnEntryId` ref with a scope-keyed map keyed by `thread:<backend>:<threadId>`.
- Process matching `thread/turnQueue/updated` lifecycle events by event thread scope, even when the currently selected composer is for another thread.
- On pre-start queue failure/cancel for the visible thread, clear pending status, remove the optimistic user message, reset local in-flight state, and surface the queue error.
- Add regressions for switching away/back and pre-start queue failure cleanup.

## Verification

- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
