### PR TITLE
feat(desktop): bound long transcript blocks

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
@@ -115,7 +115,11 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
         );
 
         return (
-          <blockquote className="transcript-message__blockquote">
+          <blockquote
+            className="transcript-message__blockquote"
+            aria-label="Quoted text"
+            tabIndex={0}
+          >
             {copyText ? (
               <TranscriptCopyButton
                 className="transcript-copy-button--section"
@@ -194,7 +198,13 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
                 text={copyText}
               />
             ) : null}
-            <pre className="transcript-message__pre">{preProps.children}</pre>
+            <pre
+              className="transcript-message__pre"
+              aria-label="Code block"
+              tabIndex={0}
+            >
+              {preProps.children}
+            </pre>
           </div>
         );
       },

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
@@ -265,6 +265,21 @@ describe("ThreadMarkdown", () => {
     });
   });
 
+  it("renders long fenced code blocks without expand controls", () => {
+    const lines = Array.from({ length: 21 }, (_, index) => `line ${index + 1}`);
+
+    const { container } = render(
+      <ThreadMarkdown text={`\`\`\`txt\n${lines.join("\n")}\n\`\`\``} />
+    );
+
+    const codeBlock = container.querySelector("pre.transcript-message__pre");
+    expect(codeBlock).toBeInTheDocument();
+    expect(codeBlock).toHaveAttribute("aria-label", "Code block");
+    expect(codeBlock).toHaveAttribute("tabindex", "0");
+    expect(screen.queryByRole("button", { name: /Show full code/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Collapse code/ })).not.toBeInTheDocument();
+  });
+
   it("copies blockquotes without quote markers", async () => {
     const copyText = vi.fn(async () => undefined);
 
@@ -280,6 +295,22 @@ describe("ThreadMarkdown", () => {
     await waitFor(() => {
       expect(copyText).toHaveBeenCalledWith("Replay this prompt\nexactly as written");
     });
+  });
+
+  it("renders long blockquotes without expand controls", () => {
+    const quote = Array.from(
+      { length: 21 },
+      (_, index) => `> quoted line ${index + 1}`
+    ).join("\n");
+
+    const { container } = render(<ThreadMarkdown text={quote} />);
+
+    const blockquote = container.querySelector("blockquote.transcript-message__blockquote");
+    expect(blockquote).toBeInTheDocument();
+    expect(blockquote).toHaveAttribute("aria-label", "Quoted text");
+    expect(blockquote).toHaveAttribute("tabindex", "0");
+    expect(screen.queryByRole("button", { name: /Show full quote/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Collapse quote/ })).not.toBeInTheDocument();
   });
 
   it("renders markdown image syntax as literal text instead of an image", () => {

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -687,6 +687,28 @@ describe("Tangerine Terminal theme contract", () => {
     expect(preCodeRule).not.toContain("white-space: pre;");
   });
 
+  it("bounds long transcript code and quote blocks with their own vertical scroll", () => {
+    const preRule = extractRuleBody(css, ".transcript-message__pre");
+    expect(preRule).toContain("max-height:");
+    expect(preRule).toContain("overflow-y: auto;");
+    expect(preRule).toContain("scrollbar-gutter: stable;");
+
+    const quoteRule = extractRuleBody(css, ".transcript-message__blockquote");
+    expect(quoteRule).toContain("max-height:");
+    expect(quoteRule).toContain("overflow-y: auto;");
+    expect(quoteRule).toContain("overflow-x: hidden;");
+    expect(quoteRule).toContain("scrollbar-gutter: stable;");
+
+    const focusRule = extractRuleBody(
+      css,
+      ".transcript-message__blockquote:focus-visible,\n.transcript-message__pre:focus-visible"
+    );
+    expect(focusRule).toContain("outline: 2px solid var(--focus-ring);");
+    expect(focusRule).toContain("outline-offset: 2px;");
+
+    expect(css).not.toContain("transcript-message__collapse-toggle");
+  });
+
   it("keeps thinking scanner variants on one shared visible sweep", () => {
     expect(css).toContain("--thinking-scanner-progress: 0;");
     expect(css).toContain("--thinking-scanner-full-offset: 0px;");

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -6561,10 +6561,20 @@ textarea,
   position: relative;
   margin: 0;
   min-height: 28px;
+  max-height: 31em;
   padding-right: 38px;
   padding-left: 12px;
   border-left: 2px solid var(--border-subtle);
   color: var(--text-secondary);
+  overflow-x: hidden;
+  overflow-y: auto;
+  scrollbar-gutter: stable;
+}
+
+.transcript-message__blockquote:focus-visible,
+.transcript-message__pre:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
 }
 
 .transcript-message__code {
@@ -6613,10 +6623,13 @@ textarea,
 }
 
 .transcript-message__pre {
+  max-height: calc(32em + 24px);
   padding: 12px 44px 12px 12px;
   border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: var(--bg-app);
+  overflow-y: auto;
+  scrollbar-gutter: stable;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
 }


### PR DESCRIPTION
## Summary
- bound transcript fenced code blocks and block quotes to a readable max height with their own vertical scrolling
- keep those scroll regions keyboard-reachable with accessible labels and visible focus styling
- remove the expand/collapse controls from the earlier version so long content stays visible in place without extra message chrome
- add focused renderer and CSS contract coverage for the no-toggle and keyboard-accessible scroll behavior

## Verification
- pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
- pnpm --filter @pwragent/desktop typecheck
- git diff --check
