### PR TITLE
feat(desktop): add Codex thread migration foundation

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -13,6 +13,15 @@ pnpm install
 script = "rm -rf node_modules"
 
 [[actions]]
+name = "Work"
+icon = "run"
+command = '''
+nvm use --silent
+corepack enable
+PWRAGENT_PROFILE=work pnpm dev
+'''
+
+[[actions]]
 name = "Dev - Messaging"
 icon = "run"
 command = '''

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -585,6 +585,7 @@ class MockBackendClient {
   };
   lastForkThreadParams?: {
     threadId: string;
+    path?: string;
     cwd?: string;
     model?: string;
     approvalPolicy?: string;
@@ -854,6 +855,7 @@ class MockBackendClient {
 
   async forkThread(params: {
     threadId: string;
+    path?: string;
     cwd?: string;
     model?: string;
     approvalPolicy?: string;
@@ -7585,6 +7587,45 @@ script = "printf setup-output"
       model: "gpt-5.5",
       serviceTier: "priority",
       fastMode: true,
+    });
+
+    await registry.close();
+  });
+
+  it("passes a CAS-provided source rollout path when forking for migration", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/fork"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      gitDirectoryService: {
+        prepareLaunchpadWorkspace: vi.fn(async () => ({
+          cwd: "/repo/app",
+          workMode: "local" as const,
+        })),
+        recordCodexWorktreeOwnerThread: vi.fn(async () => {}),
+      } as never,
+    });
+
+    await registry.forkThread({
+      backend: "codex",
+      sourceThreadId: "source-thread",
+      sourceThreadPath: "/Users/example/.codex/sessions/source-thread.jsonl",
+      executionMode: "default",
+      directoryKind: "directory",
+      directoryLabel: "app",
+      directoryPath: "/repo/app",
+      workMode: "local",
+    });
+
+    expect(codexClient.lastForkThreadParams).toMatchObject({
+      threadId: "source-thread",
+      path: "/Users/example/.codex/sessions/source-thread.jsonl",
+      cwd: "/repo/app",
     });
 
     await registry.close();

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -4619,6 +4619,39 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("forks a Codex thread from a CAS-provided rollout path without reading it", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    await expect(
+      client.forkThread({
+        threadId: "source-thread",
+        path: "/Users/example/.codex/sessions/source-thread.jsonl",
+        cwd: "/Users/example/project",
+      }),
+    ).resolves.toEqual({
+      threadId: "thread-fork",
+    });
+
+    const request = MockTransport.instances[0]?.sentMessages
+      .map((message) => JSON.parse(message) as { method?: string; params?: unknown })
+      .find((payload) => payload.method === "thread/fork");
+    expect(request?.params).toMatchObject({
+      threadId: "source-thread",
+      path: "/Users/example/.codex/sessions/source-thread.jsonl",
+      cwd: "/Users/example/project",
+      excludeTurns: true,
+      persistExtendedHistory: false,
+      threadSource: "user",
+    });
+
+    await client.close();
+  });
+
   it("passes dynamic tool specs when creating a thread", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
 

--- a/apps/desktop/src/main/__tests__/git-directory-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-directory-service.test.ts
@@ -1,5 +1,13 @@
 import { execFileSync } from "node:child_process";
-import { mkdir, mkdtemp, readFile, realpath, rm, stat } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -315,6 +323,74 @@ describe("GitDirectoryService", () => {
     });
 
     expect(reused).toEqual(workspace);
+  });
+
+  it("does not reuse an excluded source worktree when creating an attached branch worktree", async () => {
+    const repoDir = await createFixtureRepo();
+    cleanupPaths.push(repoDir);
+    const sourceWorktree = path.join(
+      await mkdtemp(path.join(os.tmpdir(), "pwragent-source-worktree-")),
+      "fixture",
+    );
+    cleanupPaths.push(path.dirname(sourceWorktree));
+    runGit(repoDir, ["worktree", "add", sourceWorktree, "release"]);
+    const releaseRevision = runGit(repoDir, ["rev-parse", "release"]);
+    const service = new GitDirectoryService({
+      resolveWorktreeStorage: () => "in-repo",
+    });
+
+    const workspace = await service.prepareLaunchpadWorkspace({
+      directoryKind: "directory",
+      directoryLabel: "FixtureRepo",
+      directoryPath: repoDir,
+      excludedWorktreePaths: [sourceWorktree],
+      workMode: "worktree",
+      branchName: "release",
+      worktreeBranchMode: "attached",
+    });
+
+    expect(workspace.workMode).toBe("worktree");
+    const repoRealPath = await realpath(repoDir);
+    expect(await realpath(workspace.repositoryPath!)).toBe(repoRealPath);
+    expect(await realpath(workspace.cwd!)).not.toBe(await realpath(sourceWorktree));
+    expect(
+      (await realpath(workspace.cwd!)).startsWith(
+        `${path.join(repoRealPath, ".worktrees")}${path.sep}`,
+      ),
+    ).toBe(true);
+    expect(runGit(sourceWorktree, ["branch", "--show-current"])).toBe("");
+    expect(runGit(sourceWorktree, ["rev-parse", "HEAD"])).toBe(releaseRevision);
+    expect(runGit(workspace.cwd!, ["branch", "--show-current"])).toBe("release");
+  });
+
+  it("blocks branch transfer when the excluded source worktree is dirty", async () => {
+    const repoDir = await createFixtureRepo();
+    cleanupPaths.push(repoDir);
+    const sourceWorktree = path.join(
+      await mkdtemp(path.join(os.tmpdir(), "pwragent-dirty-source-worktree-")),
+      "fixture",
+    );
+    cleanupPaths.push(path.dirname(sourceWorktree));
+    runGit(repoDir, ["worktree", "add", sourceWorktree, "release"]);
+    await writeFile(path.join(sourceWorktree, "dirty.txt"), "dirty\n", "utf8");
+    const service = new GitDirectoryService({
+      resolveWorktreeStorage: () => "in-repo",
+    });
+
+    await expect(
+      service.prepareLaunchpadWorkspace({
+        directoryKind: "directory",
+        directoryLabel: "FixtureRepo",
+        directoryPath: repoDir,
+        excludedWorktreePaths: [sourceWorktree],
+        workMode: "worktree",
+        branchName: "release",
+        worktreeBranchMode: "attached",
+      }),
+    ).rejects.toThrow(
+      `Cannot move branch release to a destination worktree because ${await realpath(sourceWorktree)} has uncommitted changes.`,
+    );
+    expect(runGit(sourceWorktree, ["branch", "--show-current"])).toBe("release");
   });
 
   it("passes the prepared git environment to worktree creation commands", async () => {

--- a/apps/desktop/src/main/__tests__/git-directory-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-directory-service.test.ts
@@ -284,6 +284,39 @@ describe("GitDirectoryService", () => {
     expect(branchesAfter).toEqual(branchesBefore);
   });
 
+  it("creates an attached branch worktree and reuses it for the same branch", async () => {
+    const repoDir = await createFixtureRepo();
+    cleanupPaths.push(repoDir);
+    const service = new GitDirectoryService({
+      resolveWorktreeStorage: () => "in-repo",
+    });
+
+    const workspace = await service.prepareLaunchpadWorkspace({
+      directoryKind: "directory",
+      directoryLabel: "FixtureRepo",
+      directoryPath: repoDir,
+      workMode: "worktree",
+      branchName: "main",
+      worktreeBranchMode: "attached",
+    });
+
+    expect(workspace.workMode).toBe("worktree");
+    expect(await realpath(workspace.repositoryPath!)).toBe(await realpath(repoDir));
+    expect(runGit(repoDir, ["branch", "--show-current"])).toBe("");
+    expect(runGit(workspace.cwd!, ["branch", "--show-current"])).toBe("main");
+
+    const reused = await service.prepareLaunchpadWorkspace({
+      directoryKind: "directory",
+      directoryLabel: "FixtureRepo",
+      directoryPath: repoDir,
+      workMode: "worktree",
+      branchName: "main",
+      worktreeBranchMode: "attached",
+    });
+
+    expect(reused).toEqual(workspace);
+  });
+
   it("passes the prepared git environment to worktree creation commands", async () => {
     const repoDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-git-env-"));
     cleanupPaths.push(repoDir);

--- a/apps/desktop/src/main/__tests__/git-directory-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-directory-service.test.ts
@@ -322,7 +322,11 @@ describe("GitDirectoryService", () => {
       worktreeBranchMode: "attached",
     });
 
-    expect(reused).toEqual(workspace);
+    expect(reused).toMatchObject({
+      cwd: workspace.cwd,
+      repositoryPath: workspace.repositoryPath,
+      workMode: workspace.workMode,
+    });
   });
 
   it("does not reuse an excluded source worktree when creating an attached branch worktree", async () => {
@@ -361,6 +365,39 @@ describe("GitDirectoryService", () => {
     expect(runGit(sourceWorktree, ["branch", "--show-current"])).toBe("");
     expect(runGit(sourceWorktree, ["rev-parse", "HEAD"])).toBe(releaseRevision);
     expect(runGit(workspace.cwd!, ["branch", "--show-current"])).toBe("release");
+  });
+
+  it("rolls back an attached branch transfer to an excluded source worktree", async () => {
+    const repoDir = await createFixtureRepo();
+    cleanupPaths.push(repoDir);
+    const sourceWorktree = path.join(
+      await mkdtemp(path.join(os.tmpdir(), "pwragent-rollback-source-worktree-")),
+      "fixture",
+    );
+    cleanupPaths.push(path.dirname(sourceWorktree));
+    runGit(repoDir, ["worktree", "add", sourceWorktree, "release"]);
+    const service = new GitDirectoryService({
+      resolveWorktreeStorage: () => "in-repo",
+    });
+
+    const workspace = await service.prepareLaunchpadWorkspace({
+      directoryKind: "directory",
+      directoryLabel: "FixtureRepo",
+      directoryPath: repoDir,
+      excludedWorktreePaths: [sourceWorktree],
+      workMode: "worktree",
+      branchName: "release",
+      worktreeBranchMode: "attached",
+    });
+
+    expect(workspace.rollback).toEqual(expect.any(Function));
+    expect(runGit(sourceWorktree, ["branch", "--show-current"])).toBe("");
+    expect(runGit(workspace.cwd!, ["branch", "--show-current"])).toBe("release");
+
+    await workspace.rollback?.();
+
+    expect(runGit(sourceWorktree, ["branch", "--show-current"])).toBe("release");
+    await expect(stat(workspace.cwd!)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("blocks branch transfer when the excluded source worktree is dirty", async () => {

--- a/apps/desktop/src/main/__tests__/git-directory-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-directory-service.test.ts
@@ -400,6 +400,69 @@ describe("GitDirectoryService", () => {
     await expect(stat(workspace.cwd!)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it("restores an excluded source branch when destination worktree creation fails", async () => {
+    const repoDir = await createFixtureRepo();
+    cleanupPaths.push(repoDir);
+    const sourceWorktree = path.join(
+      await mkdtemp(path.join(os.tmpdir(), "pwragent-failed-transfer-source-")),
+      "fixture",
+    );
+    cleanupPaths.push(path.dirname(sourceWorktree));
+    runGit(repoDir, ["worktree", "add", sourceWorktree, "release"]);
+    const runGitWithFailedAdd = vi.fn(
+      async (cwd: string, args: string[], env?: NodeJS.ProcessEnv) => {
+        if (args[0] === "worktree" && args[1] === "add") {
+          throw new Error("simulated worktree add failure");
+        }
+        return execFileSync("git", ["-C", cwd, ...args], {
+          encoding: "utf8",
+          env: { ...process.env, ...env },
+        }).trim();
+      },
+    );
+    const service = new GitDirectoryService({
+      resolveWorktreeStorage: () => "in-repo",
+      runGit: runGitWithFailedAdd,
+    });
+
+    await expect(
+      service.prepareLaunchpadWorkspace({
+        directoryKind: "directory",
+        directoryLabel: "FixtureRepo",
+        directoryPath: repoDir,
+        excludedWorktreePaths: [sourceWorktree],
+        workMode: "worktree",
+        branchName: "release",
+        worktreeBranchMode: "attached",
+      }),
+    ).rejects.toThrow("simulated worktree add failure");
+
+    expect(runGit(sourceWorktree, ["branch", "--show-current"])).toBe("release");
+  });
+
+  it("rolls back a detached destination worktree", async () => {
+    const repoDir = await createFixtureRepo();
+    cleanupPaths.push(repoDir);
+    const service = new GitDirectoryService({
+      resolveWorktreeStorage: () => "in-repo",
+    });
+
+    const workspace = await service.prepareLaunchpadWorkspace({
+      directoryKind: "directory",
+      directoryLabel: "FixtureRepo",
+      directoryPath: repoDir,
+      workMode: "worktree",
+      branchName: "release",
+    });
+
+    expect(workspace.rollback).toEqual(expect.any(Function));
+    expect(runGit(workspace.cwd!, ["branch", "--show-current"])).toBe("");
+
+    await workspace.rollback?.();
+
+    await expect(stat(workspace.cwd!)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("blocks branch transfer when the excluded source worktree is dirty", async () => {
     const repoDir = await createFixtureRepo();
     cleanupPaths.push(repoDir);

--- a/apps/desktop/src/main/__tests__/thread-migration-service.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-migration-service.test.ts
@@ -160,6 +160,10 @@ describe("ThreadMigrationService", () => {
       title: "Source thread",
     });
     expect(response.projects[0]!.threads[0]).not.toHaveProperty("rolloutPath");
+    expect(sourceClient.listThreadsForMigration).toHaveBeenCalledWith({
+      archived: false,
+      filter: undefined,
+    });
   });
 
   it("groups source worktrees with their repository project like navigation", async () => {

--- a/apps/desktop/src/main/__tests__/thread-migration-service.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-migration-service.test.ts
@@ -433,6 +433,77 @@ describe("ThreadMigrationService", () => {
     ]);
   });
 
+  it("surfaces diagnostics when a requested destination worktree falls back to local", async () => {
+    const sourceClient = {
+      listThreadsForMigration: vi.fn(async () => [
+        makeSourceThread({
+          gitBranch: "feature/source-work",
+        }),
+      ]),
+      readThread: vi.fn(async () => makeReplay()),
+      archiveThread: vi.fn(async () => ({ threadId: "source-thread" })),
+      close: vi.fn(),
+    };
+    const destination = {
+      forkThread: vi.fn(async (request) => {
+        expect(request).toMatchObject({
+          branchName: "feature/source-work",
+          directoryPath: "/repo/app",
+          workMode: "worktree",
+          worktreeBranchMode: "attached",
+        });
+        return {
+          backend: "codex" as const,
+          sourceThreadId: "source-thread",
+          threadId: "destination-thread",
+          executionMode: "default" as const,
+          linkedDirectory: {
+            id: "local:/repo/app",
+            label: "app",
+            path: "/repo/app",
+            kind: "local" as const,
+          },
+          workMode: "local" as const,
+        };
+      }),
+      readThread: vi.fn(async () => ({ replay: makeReplay() })),
+    };
+    const service = new ThreadMigrationService({
+      destination,
+      settingsService: {
+        readSettings: async () => makeSettingsSnapshot("work"),
+        resolveCodexCommandPreference: () => "codex",
+        resolveCodexSpawnEnv: () => ({}),
+      },
+      sourceClientFactory: () => sourceClient,
+      idFactory: () => "run-1",
+    });
+
+    const response = await service.startMigration({
+      sourceProfile: "",
+      operation: "move",
+      threadIds: ["source-thread"],
+    });
+
+    expect(response.items[0]).toMatchObject({
+      destinationThreadId: "destination-thread",
+      diagnostics: {
+        requestedBranchName: "feature/source-work",
+        requestedDirectoryPath: "/repo/app",
+        requestedWorkMode: "worktree",
+        requestedWorktreeBranchMode: "attached",
+        destinationDirectoryPath: "/repo/app",
+        destinationWorkMode: "local",
+        archivedSource: true,
+      },
+      status: "completed",
+      warnings: expect.arrayContaining([
+        "Destination returned local even though migration requested a worktree.",
+        "Destination did not report a worktree path.",
+      ]),
+    });
+  });
+
   it("copies a source worktree to a detached destination worktree", async () => {
     const sourceClient = {
       listThreadsForMigration: vi.fn(async () => [

--- a/apps/desktop/src/main/__tests__/thread-migration-service.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-migration-service.test.ts
@@ -240,6 +240,52 @@ describe("ThreadMigrationService", () => {
     ]);
   });
 
+  it("copies a non-worktree thread without requiring a branch strategy", async () => {
+    const sourceClient = {
+      listThreadsForMigration: vi.fn(async () => [makeSourceThread()]),
+      readThread: vi.fn(async () => makeReplay()),
+      archiveThread: vi.fn(),
+      close: vi.fn(),
+    };
+    const destination = {
+      forkThread: vi.fn(async () => ({
+        backend: "codex" as const,
+        sourceThreadId: "source-thread",
+        threadId: "destination-thread",
+        executionMode: "default" as const,
+        linkedDirectory: {
+          id: "local:/repo/app",
+          label: "app",
+          path: "/repo/app",
+          kind: "local" as const,
+        },
+        workMode: "local" as const,
+      })),
+      readThread: vi.fn(async () => ({ replay: makeReplay() })),
+    };
+    const service = new ThreadMigrationService({
+      destination,
+      settingsService: {
+        readSettings: async () => makeSettingsSnapshot("work"),
+        resolveCodexCommandPreference: () => "codex",
+        resolveCodexSpawnEnv: () => ({}),
+      },
+      sourceClientFactory: () => sourceClient,
+    });
+
+    const response = await service.startMigration({
+      sourceProfile: "",
+      operation: "copy",
+      threadIds: ["source-thread"],
+    });
+
+    expect(response.items[0]).toMatchObject({
+      destinationThreadId: "destination-thread",
+      status: "completed",
+    });
+    expect(sourceClient.archiveThread).not.toHaveBeenCalled();
+  });
+
   it("blocks Move before fork/archive when a source thread has a profile-owned worktree", async () => {
     const sourceClient = {
       listThreadsForMigration: vi.fn(async () => [
@@ -284,6 +330,55 @@ describe("ThreadMigrationService", () => {
       status: "failed",
       error:
         "Move is blocked until this thread's profile-owned worktree can be migrated first.",
+    });
+    expect(destination.forkThread).not.toHaveBeenCalled();
+    expect(sourceClient.archiveThread).not.toHaveBeenCalled();
+  });
+
+  it("blocks Copy before fork/archive when a source thread has a profile-owned worktree", async () => {
+    const sourceClient = {
+      listThreadsForMigration: vi.fn(async () => [
+        makeSourceThread({
+          linkedDirectories: [
+            {
+              id: "worktree:/Users/alice/.codex/profiles/personal/worktrees/repo/app",
+              label: "app",
+              path: "/repo/app",
+              worktreePath:
+                "/Users/alice/.codex/profiles/personal/worktrees/repo/app",
+              kind: "worktree",
+            },
+          ],
+        }),
+      ]),
+      readThread: vi.fn(),
+      archiveThread: vi.fn(),
+      close: vi.fn(),
+    };
+    const destination = {
+      forkThread: vi.fn(),
+      readThread: vi.fn(),
+    };
+    const service = new ThreadMigrationService({
+      destination,
+      settingsService: {
+        readSettings: async () => makeSettingsSnapshot("work"),
+        resolveCodexCommandPreference: () => "codex",
+        resolveCodexSpawnEnv: () => ({}),
+      },
+      sourceClientFactory: () => sourceClient,
+    });
+
+    const response = await service.startMigration({
+      sourceProfile: "",
+      operation: "copy",
+      threadIds: ["source-thread"],
+    });
+
+    expect(response.items[0]).toMatchObject({
+      status: "failed",
+      error:
+        "Copy is blocked until branch conflict strategies for profile-owned worktrees are implemented.",
     });
     expect(destination.forkThread).not.toHaveBeenCalled();
     expect(sourceClient.archiveThread).not.toHaveBeenCalled();

--- a/apps/desktop/src/main/__tests__/thread-migration-service.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-migration-service.test.ts
@@ -444,4 +444,46 @@ describe("ThreadMigrationService", () => {
     expect(destination.forkThread).not.toHaveBeenCalled();
     expect(sourceClient.archiveThread).not.toHaveBeenCalled();
   });
+
+  it("blocks Move before fork/archive when projectKey is a profile-owned worktree", async () => {
+    const sourceClient = {
+      listThreadsForMigration: vi.fn(async () => [
+        makeSourceThread({
+          projectKey:
+            "/Users/alice/.codex/profiles/personal/worktrees/mph2i055/repo-app",
+          linkedDirectories: [],
+        }),
+      ]),
+      readThread: vi.fn(),
+      archiveThread: vi.fn(),
+      close: vi.fn(),
+    };
+    const destination = {
+      forkThread: vi.fn(),
+      readThread: vi.fn(),
+    };
+    const service = new ThreadMigrationService({
+      destination,
+      settingsService: {
+        readSettings: async () => makeSettingsSnapshot("work"),
+        resolveCodexCommandPreference: () => "codex",
+        resolveCodexSpawnEnv: () => ({}),
+      },
+      sourceClientFactory: () => sourceClient,
+    });
+
+    const response = await service.startMigration({
+      sourceProfile: "",
+      operation: "move",
+      threadIds: ["source-thread"],
+    });
+
+    expect(response.items[0]).toMatchObject({
+      status: "failed",
+      error:
+        "Move is blocked until this thread's profile-owned worktree can be migrated first.",
+    });
+    expect(destination.forkThread).not.toHaveBeenCalled();
+    expect(sourceClient.archiveThread).not.toHaveBeenCalled();
+  });
 });

--- a/apps/desktop/src/main/__tests__/thread-migration-service.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-migration-service.test.ts
@@ -347,10 +347,12 @@ describe("ThreadMigrationService", () => {
     expect(sourceClient.archiveThread).not.toHaveBeenCalled();
   });
 
-  it("blocks Move before fork/archive when a source thread has a profile-owned worktree", async () => {
+  it("moves a profile-owned source worktree into a destination-owned worktree before archiving", async () => {
+    const calls: string[] = [];
     const sourceClient = {
       listThreadsForMigration: vi.fn(async () => [
         makeSourceThread({
+          gitBranch: "feature/source-work",
           linkedDirectories: [
             {
               id: "worktree:/Users/alice/.codex/profiles/personal/worktrees/repo/app",
@@ -363,13 +365,44 @@ describe("ThreadMigrationService", () => {
           ],
         }),
       ]),
-      readThread: vi.fn(),
-      archiveThread: vi.fn(),
+      readThread: vi.fn(async () => {
+        calls.push("source-read");
+        return makeReplay();
+      }),
+      archiveThread: vi.fn(async () => {
+        calls.push("source-archive");
+        return { threadId: "source-thread" };
+      }),
       close: vi.fn(),
     };
     const destination = {
-      forkThread: vi.fn(),
-      readThread: vi.fn(),
+      forkThread: vi.fn(async (request) => {
+        calls.push("destination-fork");
+        expect(request).toMatchObject({
+          branchName: "feature/source-work",
+          directoryPath: "/repo/app",
+          sourceThreadId: "source-thread",
+          workMode: "worktree",
+        });
+        return {
+          backend: "codex" as const,
+          sourceThreadId: "source-thread",
+          threadId: "destination-thread",
+          executionMode: "default" as const,
+          linkedDirectory: {
+            id: "worktree:/Users/alice/.codex/profiles/work/worktrees/repo/app",
+            label: "app",
+            path: "/repo/app",
+            worktreePath: "/Users/alice/.codex/profiles/work/worktrees/repo/app",
+            kind: "worktree" as const,
+          },
+          workMode: "worktree" as const,
+        };
+      }),
+      readThread: vi.fn(async () => {
+        calls.push("destination-read");
+        return { replay: makeReplay() };
+      }),
     };
     const service = new ThreadMigrationService({
       destination,
@@ -388,12 +421,15 @@ describe("ThreadMigrationService", () => {
     });
 
     expect(response.items[0]).toMatchObject({
-      status: "failed",
-      error:
-        "Move is blocked until this thread's profile-owned worktree can be migrated first.",
+      destinationThreadId: "destination-thread",
+      status: "completed",
     });
-    expect(destination.forkThread).not.toHaveBeenCalled();
-    expect(sourceClient.archiveThread).not.toHaveBeenCalled();
+    expect(calls).toEqual([
+      "destination-fork",
+      "source-read",
+      "destination-read",
+      "source-archive",
+    ]);
   });
 
   it("blocks Copy before fork/archive when a source thread has a profile-owned worktree", async () => {
@@ -439,7 +475,7 @@ describe("ThreadMigrationService", () => {
     expect(response.items[0]).toMatchObject({
       status: "failed",
       error:
-        "Copy is blocked until branch conflict strategies for profile-owned worktrees are implemented.",
+        "Copy is disabled for selected managed worktrees. Use Move so the destination worktree is created before the source is archived.",
     });
     expect(destination.forkThread).not.toHaveBeenCalled();
     expect(sourceClient.archiveThread).not.toHaveBeenCalled();
@@ -481,7 +517,7 @@ describe("ThreadMigrationService", () => {
     expect(response.items[0]).toMatchObject({
       status: "failed",
       error:
-        "Move is blocked until this thread's profile-owned worktree can be migrated first.",
+        "Move is blocked because the source managed worktree did not report its repository path.",
     });
     expect(destination.forkThread).not.toHaveBeenCalled();
     expect(sourceClient.archiveThread).not.toHaveBeenCalled();

--- a/apps/desktop/src/main/__tests__/thread-migration-service.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-migration-service.test.ts
@@ -381,6 +381,9 @@ describe("ThreadMigrationService", () => {
         expect(request).toMatchObject({
           branchName: "feature/source-work",
           directoryPath: "/repo/app",
+          excludedWorktreePaths: [
+            "/Users/alice/.codex/profiles/personal/worktrees/repo/app",
+          ],
           sourceThreadId: "source-thread",
           worktreeBranchMode: "attached",
           workMode: "worktree",
@@ -530,6 +533,9 @@ describe("ThreadMigrationService", () => {
         expect(request).toMatchObject({
           branchName: "feature/source-work",
           directoryPath: "/repo/app",
+          excludedWorktreePaths: [
+            "/Users/alice/.codex/profiles/personal/worktrees/repo/app",
+          ],
           sourceThreadId: "source-thread",
           worktreeBranchMode: "detached",
           workMode: "worktree",

--- a/apps/desktop/src/main/__tests__/thread-migration-service.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-migration-service.test.ts
@@ -232,7 +232,9 @@ describe("ThreadMigrationService", () => {
   it("moves a thread by forking the source rollout path, validating, then archiving source", async () => {
     const calls: string[] = [];
     const sourceClient = {
-      listThreadsForMigration: vi.fn(async () => [makeSourceThread()]),
+      listThreadsForMigration: vi.fn(async () => [
+        makeSourceThread({ gitBranch: "feature/local-work" }),
+      ]),
       readThread: vi.fn(async () => {
         calls.push("source-read");
         return makeReplay();
@@ -251,7 +253,9 @@ describe("ThreadMigrationService", () => {
           sourceThreadId: "source-thread",
           sourceThreadPath: "/Users/alice/.codex/sessions/source-thread.jsonl",
           directoryPath: "/repo/app",
+          workMode: "local",
         });
+        expect(request).not.toHaveProperty("worktreeBranchMode");
         return {
           backend: "codex" as const,
           sourceThreadId: "source-thread",
@@ -450,6 +454,16 @@ describe("ThreadMigrationService", () => {
       listThreadsForMigration: vi.fn(async () => [
         makeSourceThread({
           gitBranch: "feature/source-work",
+          linkedDirectories: [
+            {
+              id: "worktree:/Users/alice/.codex/profiles/personal/worktrees/repo/app",
+              label: "app",
+              path: "/repo/app",
+              worktreePath:
+                "/Users/alice/.codex/profiles/personal/worktrees/repo/app",
+              kind: "worktree",
+            },
+          ],
         }),
       ]),
       readThread: vi.fn(async () => makeReplay()),
@@ -592,6 +606,74 @@ describe("ThreadMigrationService", () => {
     expect(sourceClient.archiveThread).not.toHaveBeenCalled();
   });
 
+  it("rolls back prepared source branch transfer when migration validation fails", async () => {
+    const rollback = vi.fn(async () => undefined);
+    const sourceClient = {
+      listThreadsForMigration: vi.fn(async () => [
+        makeSourceThread({
+          gitBranch: "feature/source-work",
+          linkedDirectories: [
+            {
+              id: "worktree:/Users/alice/.codex/profiles/personal/worktrees/repo/app",
+              label: "app",
+              path: "/repo/app",
+              worktreePath:
+                "/Users/alice/.codex/profiles/personal/worktrees/repo/app",
+              kind: "worktree",
+            },
+          ],
+        }),
+      ]),
+      readThread: vi.fn(async () => makeReplay("source")),
+      archiveThread: vi.fn(),
+      restoreThread: vi.fn(),
+      close: vi.fn(),
+    };
+    const destination = {
+      forkThread: vi.fn(async (request) => {
+        request.onPreparedWorkspaceRollback?.(rollback);
+        return {
+          backend: "codex" as const,
+          sourceThreadId: "source-thread",
+          threadId: "destination-thread",
+          executionMode: "default" as const,
+          linkedDirectory: {
+            id: "worktree:/Users/alice/.codex/profiles/work/worktrees/repo/app",
+            label: "app",
+            path: "/repo/app",
+            worktreePath: "/Users/alice/.codex/profiles/work/worktrees/repo/app",
+            kind: "worktree" as const,
+          },
+          workMode: "worktree" as const,
+        };
+      }),
+      readThread: vi.fn(async () => ({ replay: makeReplay("destination") })),
+    };
+    const service = new ThreadMigrationService({
+      destination,
+      settingsService: {
+        readSettings: async () => makeSettingsSnapshot("work"),
+        resolveCodexCommandPreference: () => "codex",
+        resolveCodexSpawnEnv: () => ({}),
+      },
+      sourceClientFactory: () => sourceClient,
+    });
+
+    const response = await service.startMigration({
+      sourceProfile: "",
+      operation: "move",
+      threadIds: ["source-thread"],
+    });
+
+    expect(response.items[0]).toMatchObject({
+      destinationThreadId: "destination-thread",
+      error: "Destination replay did not match source replay.",
+      status: "failed",
+    });
+    expect(rollback).toHaveBeenCalledTimes(1);
+    expect(sourceClient.archiveThread).not.toHaveBeenCalled();
+  });
+
   it("restores source workspace metadata before retrying a failed migration", async () => {
     const calls: string[] = [];
     const staleThread = makeSourceThread({
@@ -730,6 +812,95 @@ describe("ThreadMigrationService", () => {
       "destination-read",
       "source-archive",
     ]);
+  });
+
+  it("rearchives an archived source after a successful copy retry", async () => {
+    const archivedThread = makeSourceThread({
+      archivedAt: 1234,
+      gitBranch: "feature/source-work",
+      linkedDirectories: [
+        {
+          id: "worktree:/Users/alice/.codex/worktrees/0cb4/web-app",
+          label: "web-app",
+          path: "/repo/web-app",
+          worktreePath: "/Users/alice/.codex/worktrees/0cb4/web-app",
+          kind: "worktree",
+        },
+      ],
+      projectKey: "/Users/alice/.codex/worktrees/0cb4/web-app",
+    });
+    const restoredThread = makeSourceThread({
+      gitBranch: "feature/source-work",
+      linkedDirectories: [
+        {
+          id: "worktree:/Users/alice/.codex/worktrees/0cb4/web-app",
+          label: "web-app",
+          path: "/repo/web-app",
+          worktreePath: "/Users/alice/.codex/worktrees/0cb4/web-app",
+          kind: "worktree",
+        },
+      ],
+      projectKey: "/Users/alice/.codex/worktrees/0cb4/web-app",
+    });
+    const sourceClient = {
+      listThreadsForMigration: vi
+        .fn()
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([archivedThread])
+        .mockResolvedValue([restoredThread]),
+      readThread: vi.fn(async () => makeReplay()),
+      archiveThread: vi.fn(async () => ({ threadId: "source-thread" })),
+      restoreThread: vi.fn(async () => ({ threadId: "source-thread" })),
+      close: vi.fn(),
+    };
+    const destination = {
+      forkThread: vi.fn(async () => ({
+        backend: "codex" as const,
+        sourceThreadId: "source-thread",
+        threadId: "destination-thread",
+        executionMode: "default" as const,
+        linkedDirectory: {
+          id: "worktree:/Users/alice/.codex/profiles/work/worktrees/web-app",
+          label: "web-app",
+          path: "/repo/web-app",
+          worktreePath: "/Users/alice/.codex/profiles/work/worktrees/web-app",
+          kind: "worktree" as const,
+        },
+        workMode: "worktree" as const,
+      })),
+      readThread: vi.fn(async () => ({ replay: makeReplay() })),
+    };
+    const service = new ThreadMigrationService({
+      destination,
+      settingsService: {
+        readSettings: async () => makeSettingsSnapshot("work"),
+        resolveCodexCommandPreference: () => "codex",
+        resolveCodexSpawnEnv: () => ({}),
+      },
+      sourceClientFactory: () => sourceClient,
+    });
+
+    const retried = await service.retryMigration({
+      sourceProfile: "",
+      operation: "copy",
+      copyStrategy: "detached-destination",
+      threadId: "source-thread",
+    });
+
+    expect(retried.items[0]).toMatchObject({
+      destinationThreadId: "destination-thread",
+      diagnostics: {
+        archivedSource: true,
+      },
+      status: "completed",
+    });
+    expect(sourceClient.restoreThread).toHaveBeenCalledWith({
+      threadId: "source-thread",
+    });
+    expect(sourceClient.archiveThread).toHaveBeenCalledTimes(1);
+    expect(sourceClient.archiveThread).toHaveBeenCalledWith({
+      threadId: "source-thread",
+    });
   });
 
   it("blocks Move before fork/archive when projectKey is a profile-owned worktree", async () => {

--- a/apps/desktop/src/main/__tests__/thread-migration-service.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-migration-service.test.ts
@@ -124,6 +124,7 @@ describe("ThreadMigrationService", () => {
       listThreadsForMigration: vi.fn(async () => [makeSourceThread()]),
       readThread: vi.fn(),
       archiveThread: vi.fn(),
+      restoreThread: vi.fn(),
       close: vi.fn(),
     };
     const service = new ThreadMigrationService({
@@ -201,6 +202,7 @@ describe("ThreadMigrationService", () => {
       ]),
       readThread: vi.fn(),
       archiveThread: vi.fn(),
+      restoreThread: vi.fn(),
       close: vi.fn(),
     };
     const service = new ThreadMigrationService({
@@ -239,6 +241,7 @@ describe("ThreadMigrationService", () => {
         calls.push("source-archive");
         return { threadId: "source-thread" };
       }),
+      restoreThread: vi.fn(),
       close: vi.fn(),
     };
     const destination = {
@@ -310,6 +313,7 @@ describe("ThreadMigrationService", () => {
       listThreadsForMigration: vi.fn(async () => [makeSourceThread()]),
       readThread: vi.fn(async () => makeReplay()),
       archiveThread: vi.fn(),
+      restoreThread: vi.fn(),
       close: vi.fn(),
     };
     const destination = {
@@ -377,6 +381,7 @@ describe("ThreadMigrationService", () => {
         calls.push("source-archive");
         return { threadId: "source-thread" };
       }),
+      restoreThread: vi.fn(),
       close: vi.fn(),
     };
     const destination = {
@@ -449,6 +454,7 @@ describe("ThreadMigrationService", () => {
       ]),
       readThread: vi.fn(async () => makeReplay()),
       archiveThread: vi.fn(async () => ({ threadId: "source-thread" })),
+      restoreThread: vi.fn(),
       close: vi.fn(),
     };
     const destination = {
@@ -530,6 +536,7 @@ describe("ThreadMigrationService", () => {
       ]),
       readThread: vi.fn(async () => makeReplay()),
       archiveThread: vi.fn(),
+      restoreThread: vi.fn(),
       close: vi.fn(),
     };
     const destination = {
@@ -585,6 +592,146 @@ describe("ThreadMigrationService", () => {
     expect(sourceClient.archiveThread).not.toHaveBeenCalled();
   });
 
+  it("restores source workspace metadata before retrying a failed migration", async () => {
+    const calls: string[] = [];
+    const staleThread = makeSourceThread({
+      projectKey: "/Users/alice/.codex/worktrees/0cb4/web-app",
+      linkedDirectories: [
+        {
+          id: "worktree:/Users/alice/.codex/worktrees/0cb4/web-app",
+          label: "web-app",
+          path: "/repo/web-app",
+          worktreePath: "/Users/alice/.codex/worktrees/0cb4/web-app",
+          kind: "worktree",
+        },
+      ],
+    });
+    const restoredThread = makeSourceThread({
+      gitBranch: "codex/chunk-file-errors",
+      projectKey: "/Users/alice/.codex/worktrees/0cb4/web-app",
+      linkedDirectories: [
+        {
+          id: "worktree:/Users/alice/.codex/worktrees/0cb4/web-app",
+          label: "web-app",
+          path: "/repo/web-app",
+          worktreePath: "/Users/alice/.codex/worktrees/0cb4/web-app",
+          kind: "worktree",
+        },
+      ],
+    });
+    const sourceClient = {
+      listThreadsForMigration: vi
+        .fn()
+        .mockResolvedValueOnce([staleThread])
+        .mockResolvedValue([restoredThread]),
+      readThread: vi.fn(async () => {
+        calls.push("source-read");
+        return makeReplay();
+      }),
+      archiveThread: vi.fn(async () => {
+        calls.push("source-archive");
+        return { threadId: "source-thread" };
+      }),
+      restoreThread: vi.fn(async () => {
+        calls.push("source-restore");
+        return { threadId: "source-thread" };
+      }),
+      close: vi.fn(),
+    };
+    const destination = {
+      forkThread: vi.fn(async (request) => {
+        calls.push("destination-fork");
+        expect(request).toMatchObject({
+          branchName: "codex/chunk-file-errors",
+          directoryPath: "/repo/web-app",
+          excludedWorktreePaths: [
+            "/Users/alice/.codex/worktrees/0cb4/web-app",
+          ],
+          sourceThreadId: "source-thread",
+          workMode: "worktree",
+          worktreeBranchMode: "attached",
+        });
+        return {
+          backend: "codex" as const,
+          sourceThreadId: "source-thread",
+          threadId: "destination-thread",
+          executionMode: "default" as const,
+          linkedDirectory: {
+            id: "worktree:/Users/alice/.codex/profiles/work/worktrees/web-app",
+            label: "web-app",
+            path: "/repo/web-app",
+            worktreePath:
+              "/Users/alice/.codex/profiles/work/worktrees/web-app",
+            kind: "worktree" as const,
+          },
+          workMode: "worktree" as const,
+        };
+      }),
+      readThread: vi.fn(async () => {
+        calls.push("destination-read");
+        return { replay: makeReplay() };
+      }),
+    };
+    const service = new ThreadMigrationService({
+      destination,
+      settingsService: {
+        readSettings: async () => makeSettingsSnapshot("work"),
+        resolveCodexCommandPreference: () => "codex",
+        resolveCodexSpawnEnv: () => ({}),
+      },
+      sourceClientFactory: () => sourceClient,
+      idFactory: () => "run-1",
+    });
+
+    const failed = await service.startMigration({
+      sourceProfile: "",
+      operation: "move",
+      threadIds: ["source-thread"],
+    });
+
+    expect(failed.items[0]).toMatchObject({
+      status: "failed",
+      error:
+        "Migration is blocked because the source managed worktree did not report an attached branch.",
+    });
+    expect(destination.forkThread).not.toHaveBeenCalled();
+    expect(sourceClient.archiveThread).not.toHaveBeenCalled();
+
+    const retried = await service.retryMigration({
+      sourceProfile: "",
+      operation: "move",
+      threadId: "source-thread",
+    });
+
+    expect(retried.items[0]).toMatchObject({
+      destinationThreadId: "destination-thread",
+      diagnostics: {
+        requestedBranchName: "codex/chunk-file-errors",
+        requestedDirectoryPath: "/repo/web-app",
+        requestedWorkMode: "worktree",
+        requestedWorktreeBranchMode: "attached",
+        destinationWorktreePath:
+          "/Users/alice/.codex/profiles/work/worktrees/web-app",
+        archivedSource: true,
+      },
+      status: "completed",
+    });
+    expect(sourceClient.restoreThread).toHaveBeenCalledWith({
+      threadId: "source-thread",
+    });
+    expect(sourceClient.listThreadsForMigration).toHaveBeenNthCalledWith(2, {
+      archived: false,
+      filter: undefined,
+    });
+    expect(calls).toEqual([
+      "source-restore",
+      "destination-fork",
+      "source-read",
+      "destination-read",
+      "source-archive",
+    ]);
+  });
+
   it("blocks Move before fork/archive when projectKey is a profile-owned worktree", async () => {
     const sourceClient = {
       listThreadsForMigration: vi.fn(async () => [
@@ -596,6 +743,7 @@ describe("ThreadMigrationService", () => {
       ]),
       readThread: vi.fn(),
       archiveThread: vi.fn(),
+      restoreThread: vi.fn(),
       close: vi.fn(),
     };
     const destination = {

--- a/apps/desktop/src/main/__tests__/thread-migration-service.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-migration-service.test.ts
@@ -382,6 +382,7 @@ describe("ThreadMigrationService", () => {
           branchName: "feature/source-work",
           directoryPath: "/repo/app",
           sourceThreadId: "source-thread",
+          worktreeBranchMode: "attached",
           workMode: "worktree",
         });
         return {
@@ -432,10 +433,11 @@ describe("ThreadMigrationService", () => {
     ]);
   });
 
-  it("blocks Copy before fork/archive when a source thread has a profile-owned worktree", async () => {
+  it("copies a source worktree to a detached destination worktree", async () => {
     const sourceClient = {
       listThreadsForMigration: vi.fn(async () => [
         makeSourceThread({
+          gitBranch: "feature/source-work",
           linkedDirectories: [
             {
               id: "worktree:/Users/alice/.codex/profiles/personal/worktrees/repo/app",
@@ -448,13 +450,35 @@ describe("ThreadMigrationService", () => {
           ],
         }),
       ]),
-      readThread: vi.fn(),
+      readThread: vi.fn(async () => makeReplay()),
       archiveThread: vi.fn(),
       close: vi.fn(),
     };
     const destination = {
-      forkThread: vi.fn(),
-      readThread: vi.fn(),
+      forkThread: vi.fn(async (request) => {
+        expect(request).toMatchObject({
+          branchName: "feature/source-work",
+          directoryPath: "/repo/app",
+          sourceThreadId: "source-thread",
+          worktreeBranchMode: "detached",
+          workMode: "worktree",
+        });
+        return {
+          backend: "codex" as const,
+          sourceThreadId: "source-thread",
+          threadId: "destination-thread",
+          executionMode: "default" as const,
+          linkedDirectory: {
+            id: "worktree:/Users/alice/.codex/profiles/work/worktrees/repo/app",
+            label: "app",
+            path: "/repo/app",
+            worktreePath: "/Users/alice/.codex/profiles/work/worktrees/repo/app",
+            kind: "worktree" as const,
+          },
+          workMode: "worktree" as const,
+        };
+      }),
+      readThread: vi.fn(async () => ({ replay: makeReplay() })),
     };
     const service = new ThreadMigrationService({
       destination,
@@ -469,15 +493,14 @@ describe("ThreadMigrationService", () => {
     const response = await service.startMigration({
       sourceProfile: "",
       operation: "copy",
+      copyStrategy: "detached-destination",
       threadIds: ["source-thread"],
     });
 
     expect(response.items[0]).toMatchObject({
-      status: "failed",
-      error:
-        "Copy is disabled for selected managed worktrees. Use Move so the destination worktree is created before the source is archived.",
+      destinationThreadId: "destination-thread",
+      status: "completed",
     });
-    expect(destination.forkThread).not.toHaveBeenCalled();
     expect(sourceClient.archiveThread).not.toHaveBeenCalled();
   });
 

--- a/apps/desktop/src/main/__tests__/thread-migration-service.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-migration-service.test.ts
@@ -148,7 +148,7 @@ describe("ThreadMigrationService", () => {
       fetchedAt: 1234,
       projects: [
         {
-          key: "project:/repo/app",
+          key: "directory:/repo/app",
           label: "app",
           path: "/repo/app",
         },
@@ -160,6 +160,67 @@ describe("ThreadMigrationService", () => {
       title: "Source thread",
     });
     expect(response.projects[0]!.threads[0]).not.toHaveProperty("rolloutPath");
+  });
+
+  it("groups source worktrees with their repository project like navigation", async () => {
+    const sourceClient = {
+      listThreadsForMigration: vi.fn(async () => [
+        makeSourceThread({
+          id: "local-thread",
+          projectKey: "/Users/alice/GIPHY/giphy-bandwidth-saver",
+          title: "Local thread",
+          linkedDirectories: [
+            {
+              id: "/Users/alice/GIPHY/giphy-bandwidth-saver",
+              label: "giphy-bandwidth-saver",
+              path: "/Users/alice/GIPHY/giphy-bandwidth-saver",
+              kind: "local",
+            },
+          ],
+        }),
+        makeSourceThread({
+          id: "worktree-thread",
+          projectKey:
+            "/Users/alice/.codex/profiles/work/worktrees/mph2i055/giphy-bandwidth-saver",
+          title: "Worktree thread",
+          linkedDirectories: [
+            {
+              id: "/Users/alice/GIPHY/giphy-bandwidth-saver",
+              label: "giphy-bandwidth-saver",
+              path: "/Users/alice/GIPHY/giphy-bandwidth-saver",
+              worktreePath:
+                "/Users/alice/.codex/profiles/work/worktrees/mph2i055/giphy-bandwidth-saver",
+              kind: "worktree",
+            },
+          ],
+        }),
+      ]),
+      readThread: vi.fn(),
+      archiveThread: vi.fn(),
+      close: vi.fn(),
+    };
+    const service = new ThreadMigrationService({
+      destination: {} as never,
+      settingsService: {
+        readSettings: async () => makeSettingsSnapshot("work"),
+        resolveCodexCommandPreference: () => "codex",
+        resolveCodexSpawnEnv: () => ({}),
+      },
+      sourceClientFactory: () => sourceClient,
+    });
+
+    const response = await service.listSourceThreads({ sourceProfile: "" });
+
+    expect(response.projects).toHaveLength(1);
+    expect(response.projects[0]).toMatchObject({
+      key: "directory:/Users/alice/GIPHY/giphy-bandwidth-saver",
+      label: "giphy-bandwidth-saver",
+      path: "/Users/alice/GIPHY/giphy-bandwidth-saver",
+    });
+    expect(response.projects[0]!.threads.map((thread) => thread.threadId)).toEqual(
+      expect.arrayContaining(["local-thread", "worktree-thread"]),
+    );
+    expect(response.projects[0]!.threads).toHaveLength(2);
   });
 
   it("moves a thread by forking the source rollout path, validating, then archiving source", async () => {

--- a/apps/desktop/src/main/__tests__/thread-migration-service.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-migration-service.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it, vi } from "vitest";
+import type {
+  AppServerThreadReplay,
+  DesktopSettingsSnapshot,
+} from "@pwragent/shared";
+import type { CodexThreadMigrationMetadata } from "../codex-app-server/client";
+import { ThreadMigrationService } from "../app-server/thread-migration-service";
+
+function makeSettingsSnapshot(activeProfile = "work"): DesktopSettingsSnapshot {
+  return {
+    models: {
+      codex: {
+        profile: { value: activeProfile, source: "config" },
+        path: { value: "codex", source: "default" },
+        discovery: {} as never,
+        profiles: {
+          profileRoot: "/Users/alice/.codex/profiles",
+          effectiveCodexHome: "/Users/alice/.codex/profiles/work",
+          profiles: [
+            {
+              name: "",
+              displayName: "System default",
+              codexHome: "/Users/alice/.codex",
+              source: "default",
+              exists: true,
+              selected: activeProfile === "",
+              hasAuthFile: true,
+              hasConfigFile: true,
+              accountEmail: "personal@example.com",
+            },
+            {
+              name: "work",
+              displayName: "work",
+              codexHome: "/Users/alice/.codex/profiles/work",
+              source: "directory",
+              exists: true,
+              selected: activeProfile === "work",
+              hasAuthFile: true,
+              hasConfigFile: true,
+              accountEmail: "work@example.com",
+            },
+            {
+              name: "personal",
+              displayName: "personal",
+              codexHome: "/Users/alice/.codex/profiles/personal",
+              source: "directory",
+              exists: false,
+              selected: false,
+              hasAuthFile: false,
+              hasConfigFile: false,
+            },
+          ],
+        },
+      },
+    },
+  } as unknown as DesktopSettingsSnapshot;
+}
+
+function makeReplay(text = "hello"): AppServerThreadReplay {
+  return {
+    entries: [],
+    messages: [{ id: "m1", role: "user", text }],
+    pagination: {
+      supportsPagination: false,
+      hasPreviousPage: false,
+    },
+  };
+}
+
+function makeSourceThread(
+  overrides: Partial<CodexThreadMigrationMetadata> = {},
+): CodexThreadMigrationMetadata {
+  return {
+    id: "source-thread",
+    title: "Source thread",
+    titleSource: "explicit",
+    source: "codex",
+    projectKey: "/repo/app",
+    linkedDirectories: [
+      {
+        id: "local:/repo/app",
+        label: "app",
+        path: "/repo/app",
+        kind: "local",
+      },
+    ],
+    rolloutPath: "/Users/alice/.codex/sessions/source-thread.jsonl",
+    ...overrides,
+  };
+}
+
+describe("ThreadMigrationService", () => {
+  it("lists source profiles without the active Codex profile", async () => {
+    const service = new ThreadMigrationService({
+      destination: {} as never,
+      settingsService: {
+        readSettings: async () => makeSettingsSnapshot("work"),
+        resolveCodexCommandPreference: () => "codex",
+        resolveCodexSpawnEnv: () => ({}),
+      },
+    });
+
+    const response = await service.listSources();
+
+    expect(response.activeCodexProfile).toBe("work");
+    expect(response.profiles.map((profile) => profile.profile)).toEqual([
+      "",
+      "personal",
+    ]);
+    expect(response.profiles[0]).toMatchObject({
+      displayName: "System default",
+      available: true,
+      accountEmail: "personal@example.com",
+    });
+    expect(response.profiles[1]).toMatchObject({
+      available: false,
+      unavailableReason: "Codex profile directory does not exist.",
+    });
+  });
+
+  it("lists source threads through a captive CAS client without exposing rollout paths", async () => {
+    let capturedEnv: NodeJS.ProcessEnv | undefined;
+    const sourceClient = {
+      listThreadsForMigration: vi.fn(async () => [makeSourceThread()]),
+      readThread: vi.fn(),
+      archiveThread: vi.fn(),
+      close: vi.fn(),
+    };
+    const service = new ThreadMigrationService({
+      destination: {} as never,
+      settingsService: {
+        readSettings: async () => makeSettingsSnapshot("work"),
+        resolveCodexCommandPreference: () => "codex",
+        resolveCodexSpawnEnv: () => ({ PATH: "/bin" }),
+      },
+      sourceClientFactory: ({ env }) => {
+        capturedEnv = env;
+        return sourceClient;
+      },
+      now: () => 1234,
+    });
+
+    const response = await service.listSourceThreads({ sourceProfile: "" });
+
+    expect(capturedEnv?.CODEX_HOME).toBe("/Users/alice/.codex");
+    expect(response).toMatchObject({
+      sourceProfile: "",
+      fetchedAt: 1234,
+      projects: [
+        {
+          key: "project:/repo/app",
+          label: "app",
+          path: "/repo/app",
+        },
+      ],
+    });
+    expect(response.projects[0]!.threads[0]).toMatchObject({
+      sourceProfile: "",
+      threadId: "source-thread",
+      title: "Source thread",
+    });
+    expect(response.projects[0]!.threads[0]).not.toHaveProperty("rolloutPath");
+  });
+
+  it("moves a thread by forking the source rollout path, validating, then archiving source", async () => {
+    const calls: string[] = [];
+    const sourceClient = {
+      listThreadsForMigration: vi.fn(async () => [makeSourceThread()]),
+      readThread: vi.fn(async () => {
+        calls.push("source-read");
+        return makeReplay();
+      }),
+      archiveThread: vi.fn(async () => {
+        calls.push("source-archive");
+        return { threadId: "source-thread" };
+      }),
+      close: vi.fn(),
+    };
+    const destination = {
+      forkThread: vi.fn(async (request) => {
+        calls.push("destination-fork");
+        expect(request).toMatchObject({
+          sourceThreadId: "source-thread",
+          sourceThreadPath: "/Users/alice/.codex/sessions/source-thread.jsonl",
+          directoryPath: "/repo/app",
+        });
+        return {
+          backend: "codex" as const,
+          sourceThreadId: "source-thread",
+          threadId: "destination-thread",
+          executionMode: "default" as const,
+          linkedDirectory: {
+            id: "local:/repo/app",
+            label: "app",
+            path: "/repo/app",
+            kind: "local" as const,
+          },
+          workMode: "local" as const,
+        };
+      }),
+      readThread: vi.fn(async () => {
+        calls.push("destination-read");
+        return { replay: makeReplay() };
+      }),
+    };
+    const service = new ThreadMigrationService({
+      destination,
+      settingsService: {
+        readSettings: async () => makeSettingsSnapshot("work"),
+        resolveCodexCommandPreference: () => "codex",
+        resolveCodexSpawnEnv: () => ({}),
+      },
+      sourceClientFactory: () => sourceClient,
+      idFactory: () => "run-1",
+      now: () => 5678,
+    });
+
+    const response = await service.startMigration({
+      sourceProfile: "",
+      operation: "move",
+      threadIds: ["source-thread"],
+    });
+
+    expect(response.items[0]).toMatchObject({
+      sourceProfile: "",
+      sourceThreadId: "source-thread",
+      destinationThreadId: "destination-thread",
+      status: "completed",
+      validation: {
+        sourceMessageCount: 1,
+        destinationMessageCount: 1,
+        matched: true,
+      },
+    });
+    expect(calls).toEqual([
+      "destination-fork",
+      "source-read",
+      "destination-read",
+      "source-archive",
+    ]);
+  });
+
+  it("blocks Move before fork/archive when a source thread has a profile-owned worktree", async () => {
+    const sourceClient = {
+      listThreadsForMigration: vi.fn(async () => [
+        makeSourceThread({
+          linkedDirectories: [
+            {
+              id: "worktree:/Users/alice/.codex/profiles/personal/worktrees/repo/app",
+              label: "app",
+              path: "/repo/app",
+              worktreePath:
+                "/Users/alice/.codex/profiles/personal/worktrees/repo/app",
+              kind: "worktree",
+            },
+          ],
+        }),
+      ]),
+      readThread: vi.fn(),
+      archiveThread: vi.fn(),
+      close: vi.fn(),
+    };
+    const destination = {
+      forkThread: vi.fn(),
+      readThread: vi.fn(),
+    };
+    const service = new ThreadMigrationService({
+      destination,
+      settingsService: {
+        readSettings: async () => makeSettingsSnapshot("work"),
+        resolveCodexCommandPreference: () => "codex",
+        resolveCodexSpawnEnv: () => ({}),
+      },
+      sourceClientFactory: () => sourceClient,
+    });
+
+    const response = await service.startMigration({
+      sourceProfile: "",
+      operation: "move",
+      threadIds: ["source-thread"],
+    });
+
+    expect(response.items[0]).toMatchObject({
+      status: "failed",
+      error:
+        "Move is blocked until this thread's profile-owned worktree can be migrated first.",
+    });
+    expect(destination.forkThread).not.toHaveBeenCalled();
+    expect(sourceClient.archiveThread).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -323,6 +323,7 @@ type BackendClient = {
   }): Promise<{ threadId: string }>;
   forkThread?(params: {
     threadId: string;
+    path?: string;
     cwd?: string;
     model?: string;
     approvalPolicy?: string;
@@ -382,6 +383,10 @@ type BackendClient = {
     projectPath: string;
     configPath?: string;
   }): Promise<{ projectPath: string; configPath?: string }>;
+};
+
+type BackendRegistryForkThreadRequest = ForkThreadRequest & {
+  sourceThreadPath?: string;
 };
 
 /**
@@ -1081,7 +1086,7 @@ function mergeCommandSummaries(
   return merged;
 }
 
-function buildCodexClientArgs(env?: NodeJS.ProcessEnv): string[] {
+export function buildCodexClientArgs(env?: NodeJS.ProcessEnv): string[] {
   const args = [
     "-c",
     'approval_policy="on-request"',
@@ -4531,7 +4536,9 @@ export class DesktopBackendRegistry {
     };
   }
 
-  async forkThread(request: ForkThreadRequest): Promise<ForkThreadResponse> {
+  async forkThread(
+    request: BackendRegistryForkThreadRequest,
+  ): Promise<ForkThreadResponse> {
     this.assertNotBootstrap("forkThread");
     const backend = request.backend ?? "codex";
     if (backend !== "codex") {
@@ -4571,6 +4578,9 @@ export class DesktopBackendRegistry {
 
     const result = await client.forkThread({
       threadId: request.sourceThreadId,
+      ...(request.sourceThreadPath?.trim()
+        ? { path: request.sourceThreadPath.trim() }
+        : {}),
       cwd,
       ...modelSettings,
       approvalPolicy: request.approvalPolicy ?? modeSettings.approvalPolicy,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -4560,6 +4560,7 @@ export class DesktopBackendRegistry {
       directoryKind,
       directoryLabel,
       directoryPath: request.directoryPath,
+      worktreeBranchMode: request.worktreeBranchMode,
       workMode: request.workMode ?? "local",
     });
     const cwd = preparedWorkspace.cwd;

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -4560,6 +4560,9 @@ export class DesktopBackendRegistry {
       directoryKind,
       directoryLabel,
       directoryPath: request.directoryPath,
+      ...(request.excludedWorktreePaths
+        ? { excludedWorktreePaths: request.excludedWorktreePaths }
+        : {}),
       worktreeBranchMode: request.worktreeBranchMode,
       workMode: request.workMode ?? "local",
     });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -386,6 +386,7 @@ type BackendClient = {
 };
 
 type BackendRegistryForkThreadRequest = ForkThreadRequest & {
+  onPreparedWorkspaceRollback?: (rollback: (() => Promise<void>) | undefined) => void;
   sourceThreadPath?: string;
 };
 
@@ -4566,6 +4567,7 @@ export class DesktopBackendRegistry {
       worktreeBranchMode: request.worktreeBranchMode,
       workMode: request.workMode ?? "local",
     });
+    request.onPreparedWorkspaceRollback?.(preparedWorkspace.rollback);
     const cwd = preparedWorkspace.cwd;
     const linkedDirectories =
       preparedWorkspace.workMode === "worktree"
@@ -4577,83 +4579,99 @@ export class DesktopBackendRegistry {
         : buildLocalLinkedDirectory(cwd);
     const client = this.getClient(backend, executionMode);
     if (!client.forkThread) {
+      await preparedWorkspace.rollback?.();
+      request.onPreparedWorkspaceRollback?.(undefined);
       throw new Error("Selected backend does not support thread/fork.");
     }
 
-    const result = await client.forkThread({
-      threadId: request.sourceThreadId,
-      ...(request.sourceThreadPath?.trim()
-        ? { path: request.sourceThreadPath.trim() }
-        : {}),
-      cwd,
-      ...modelSettings,
-      approvalPolicy: request.approvalPolicy ?? modeSettings.approvalPolicy,
-      sandbox: request.sandbox ?? modeSettings.sandbox,
-    });
-    const forkedAt = Date.now();
-    const gitBranch = cwd ? await readCurrentGitBranch(cwd).catch(() => undefined) : undefined;
-    this.pendingStartedThreads.set(`${backend}:${result.threadId}`, {
-      id: result.threadId,
-      source: backend,
-      title: "Forked thread",
-      titleSource: "fallback",
-      projectKey: cwd,
-      createdAt: forkedAt,
-      updatedAt: forkedAt,
-      executionMode,
-      ...modelSettings,
-      linkedDirectories: linkedDirectories.map(normalizeLinkedDirectoryKind),
-      gitBranch,
-    });
-
-    if (preparedWorkspace.workMode === "worktree") {
-      await this.recordCodexWorktreeOwnerThread({
-        backend,
-        threadId: result.threadId,
-        worktreePath: cwd,
-      });
-    }
-
-    await this.overlayStore.setThreadExecutionMode({
-      backend,
-      threadId: result.threadId,
-      executionMode,
-    });
-    if (
-      modelSettings.model !== undefined ||
-      modelSettings.reasoningEffort !== undefined ||
-      modelSettings.serviceTier !== undefined ||
-      modelSettings.fastMode !== undefined
-    ) {
-      await this.overlayStore.setThreadModelSettings({
-        backend,
-        threadId: result.threadId,
+    let result: { threadId: string };
+    try {
+      result = await client.forkThread({
+        threadId: request.sourceThreadId,
+        ...(request.sourceThreadPath?.trim()
+          ? { path: request.sourceThreadPath.trim() }
+          : {}),
+        cwd,
         ...modelSettings,
+        approvalPolicy: request.approvalPolicy ?? modeSettings.approvalPolicy,
+        sandbox: request.sandbox ?? modeSettings.sandbox,
       });
+    } catch (error) {
+      await preparedWorkspace.rollback?.();
+      request.onPreparedWorkspaceRollback?.(undefined);
+      throw error;
     }
-    if (request.parentThreadId?.trim()) {
-      await this.overlayStore.setThreadParent?.({
+    try {
+      const forkedAt = Date.now();
+      const gitBranch = cwd ? await readCurrentGitBranch(cwd).catch(() => undefined) : undefined;
+      this.pendingStartedThreads.set(`${backend}:${result.threadId}`, {
+        id: result.threadId,
+        source: backend,
+        title: "Forked thread",
+        titleSource: "fallback",
+        projectKey: cwd,
+        createdAt: forkedAt,
+        updatedAt: forkedAt,
+        executionMode,
+        ...modelSettings,
+        linkedDirectories: linkedDirectories.map(normalizeLinkedDirectoryKind),
+        gitBranch,
+      });
+
+      if (preparedWorkspace.workMode === "worktree") {
+        await this.recordCodexWorktreeOwnerThread({
+          backend,
+          threadId: result.threadId,
+          worktreePath: cwd,
+        });
+      }
+
+      await this.overlayStore.setThreadExecutionMode({
         backend,
         threadId: result.threadId,
-        parentThreadId: request.parentThreadId,
+        executionMode,
       });
-      await this.emit({
-        backend,
-        notification: {
-          method: "thread/parent/set",
-          params: {
-            threadId: result.threadId,
-            parentThreadId: request.parentThreadId,
+      if (
+        modelSettings.model !== undefined ||
+        modelSettings.reasoningEffort !== undefined ||
+        modelSettings.serviceTier !== undefined ||
+        modelSettings.fastMode !== undefined
+      ) {
+        await this.overlayStore.setThreadModelSettings({
+          backend,
+          threadId: result.threadId,
+          ...modelSettings,
+        });
+      }
+      if (request.parentThreadId?.trim()) {
+        await this.overlayStore.setThreadParent?.({
+          backend,
+          threadId: result.threadId,
+          parentThreadId: request.parentThreadId,
+        });
+        await this.emit({
+          backend,
+          notification: {
+            method: "thread/parent/set",
+            params: {
+              threadId: result.threadId,
+              parentThreadId: request.parentThreadId,
+            },
           },
-        },
+        });
+      }
+      await this.updateThreadGitBranchMetadata({
+        backend,
+        threadId: result.threadId,
+        branch: gitBranch,
       });
+      this.invalidateThreadListCache(backend);
+    } catch (error) {
+      this.pendingStartedThreads.delete(`${backend}:${result.threadId}`);
+      await preparedWorkspace.rollback?.();
+      request.onPreparedWorkspaceRollback?.(undefined);
+      throw error;
     }
-    await this.updateThreadGitBranchMetadata({
-      backend,
-      threadId: result.threadId,
-      branch: gitBranch,
-    });
-    this.invalidateThreadListCache(backend);
 
     return {
       backend,

--- a/apps/desktop/src/main/app-server/git-directory-service.ts
+++ b/apps/desktop/src/main/app-server/git-directory-service.ts
@@ -22,6 +22,13 @@ type GitCommandRunner = (
   env?: NodeJS.ProcessEnv,
 ) => Promise<string>;
 
+export type PreparedLaunchpadWorkspace = {
+  cwd?: string;
+  repositoryPath?: string;
+  rollback?: () => Promise<void>;
+  workMode: LaunchpadWorkMode;
+};
+
 async function defaultRunGit(
   cwd: string,
   args: string[],
@@ -375,6 +382,19 @@ async function detachCleanWorktreeBranch(params: {
   );
 }
 
+async function restoreDetachedWorktreeBranch(params: {
+  branchName: string;
+  gitEnv?: NodeJS.ProcessEnv;
+  runGit: GitCommandRunner;
+  worktreePath: string;
+}): Promise<void> {
+  await params.runGit(
+    params.worktreePath,
+    ["switch", params.branchName],
+    params.gitEnv,
+  );
+}
+
 type CachedDirectoryStatus = {
   expiresAt: number;
   inFlight?: Promise<NavigationDirectoryGitStatus | undefined>;
@@ -622,7 +642,7 @@ export class GitDirectoryService {
         excludedWorktreePaths?: string[];
         worktreeBranchMode?: "attached" | "detached";
       },
-  ): Promise<{ cwd?: string; repositoryPath?: string; workMode: LaunchpadWorkMode }> {
+  ): Promise<PreparedLaunchpadWorkspace> {
     if (launchpad.directoryKind === "workspace") {
       return {
         cwd: undefined,
@@ -671,6 +691,7 @@ export class GitDirectoryService {
     }
 
     if (launchpad.worktreeBranchMode === "attached") {
+      let detachedSourceWorktreePath: string | undefined;
       const excludedWorktreePaths = new Set(
         await Promise.all(
           (launchpad.excludedWorktreePaths ?? [])
@@ -698,6 +719,7 @@ export class GitDirectoryService {
             workMode: "worktree",
           };
         }
+        detachedSourceWorktreePath = existing.path;
         await detachCleanWorktreeBranch({
           branchName: baseBranch,
           gitEnv: this.gitEnv,
@@ -705,6 +727,7 @@ export class GitDirectoryService {
           worktreePath: existing.path,
         });
       } else if (existingIsRepoRoot) {
+        detachedSourceWorktreePath = repoRoot;
         await detachCleanWorktreeBranch({
           branchName: baseBranch,
           gitEnv: this.gitEnv,
@@ -731,6 +754,22 @@ export class GitDirectoryService {
       return {
         cwd: worktreePath,
         repositoryPath: repoRoot,
+        rollback: async () => {
+          await this.runGitCommand(
+            repoRoot,
+            ["worktree", "remove", "--force", worktreePath],
+            this.gitEnv,
+          );
+          await pruneEmptyWorktreeParents(worktreePath);
+          if (detachedSourceWorktreePath) {
+            await restoreDetachedWorktreeBranch({
+              branchName: baseBranch,
+              gitEnv: this.gitEnv,
+              runGit: this.runGitCommand,
+              worktreePath: detachedSourceWorktreePath,
+            });
+          }
+        },
         workMode: "worktree",
       };
     }

--- a/apps/desktop/src/main/app-server/git-directory-service.ts
+++ b/apps/desktop/src/main/app-server/git-directory-service.ts
@@ -1,4 +1,4 @@
-import { access, mkdir, rmdir, writeFile } from "node:fs/promises";
+import { access, mkdir, realpath, rmdir, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { IterableMapper } from "@shutterstock/p-map-iterable";
@@ -138,6 +138,10 @@ async function pathExists(target: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+async function normalizeFilesystemPath(target: string): Promise<string> {
+  return realpath(target).catch(() => path.resolve(target));
 }
 
 async function pruneEmptyWorktreeParents(worktreePath: string): Promise<void> {
@@ -339,6 +343,36 @@ async function resolveVerifiedWorktreeBaseBranch(params: {
   }
 
   return undefined;
+}
+
+async function detachCleanWorktreeBranch(params: {
+  branchName: string;
+  gitEnv?: NodeJS.ProcessEnv;
+  runGit: GitCommandRunner;
+  worktreePath: string;
+}): Promise<void> {
+  const status = await params
+    .runGit(
+      params.worktreePath,
+      ["status", "--porcelain", "--untracked-files=normal"],
+      params.gitEnv,
+    )
+    .catch(() => "");
+  if (status.trim()) {
+    throw new Error(
+      `Cannot move branch ${params.branchName} to a destination worktree because ${params.worktreePath} has uncommitted changes.`,
+    );
+  }
+  const baseCommit = await params.runGit(
+    params.worktreePath,
+    ["rev-parse", "--verify", `${params.branchName}^{commit}`],
+    params.gitEnv,
+  );
+  await params.runGit(
+    params.worktreePath,
+    ["switch", "--detach", baseCommit.trim()],
+    params.gitEnv,
+  );
 }
 
 type CachedDirectoryStatus = {
@@ -585,6 +619,7 @@ export class GitDirectoryService {
       "branchName" | "directoryKind" | "directoryLabel" | "directoryPath" | "workMode"
     > &
       Partial<Pick<NavigationLaunchpadDraft, "backend">> & {
+        excludedWorktreePaths?: string[];
         worktreeBranchMode?: "attached" | "detached";
       },
   ): Promise<{ cwd?: string; repositoryPath?: string; workMode: LaunchpadWorkMode }> {
@@ -636,6 +671,14 @@ export class GitDirectoryService {
     }
 
     if (launchpad.worktreeBranchMode === "attached") {
+      const excludedWorktreePaths = new Set(
+        await Promise.all(
+          (launchpad.excludedWorktreePaths ?? [])
+            .map((entry) => entry.trim())
+            .filter(Boolean)
+            .map((entry) => normalizeFilesystemPath(entry)),
+        ),
+      );
       const worktreeList = await this.runGitCommand(
         repoRoot,
         ["worktree", "list", "--porcelain"],
@@ -644,34 +687,30 @@ export class GitDirectoryService {
       const existing = parseGitWorktreeEntries(worktreeList).find(
         (entry) => entry.branch === baseBranch,
       );
-      if (existing && path.resolve(existing.path) !== path.resolve(repoRoot)) {
-        return {
-          cwd: existing.path,
-          repositoryPath: repoRoot,
-          workMode: "worktree",
-        };
-      }
-      if (existing) {
-        const status = await this.runGitCommand(
-          repoRoot,
-          ["status", "--porcelain", "--untracked-files=normal"],
-          this.gitEnv,
-        ).catch(() => "");
-        if (status.trim()) {
-          throw new Error(
-            `Cannot move branch ${baseBranch} to a worktree because the local checkout has uncommitted changes.`,
-          );
+      const existingIsRepoRoot =
+        existing && path.resolve(existing.path) === path.resolve(repoRoot);
+      if (existing && !existingIsRepoRoot) {
+        const existingPath = await normalizeFilesystemPath(existing.path);
+        if (!excludedWorktreePaths.has(existingPath)) {
+          return {
+            cwd: existing.path,
+            repositoryPath: repoRoot,
+            workMode: "worktree",
+          };
         }
-        const baseCommit = await this.runGitCommand(
-          repoRoot,
-          ["rev-parse", "--verify", `${baseBranch}^{commit}`],
-          this.gitEnv,
-        );
-        await this.runGitCommand(
-          repoRoot,
-          ["switch", "--detach", baseCommit.trim()],
-          this.gitEnv,
-        );
+        await detachCleanWorktreeBranch({
+          branchName: baseBranch,
+          gitEnv: this.gitEnv,
+          runGit: this.runGitCommand,
+          worktreePath: existing.path,
+        });
+      } else if (existingIsRepoRoot) {
+        await detachCleanWorktreeBranch({
+          branchName: baseBranch,
+          gitEnv: this.gitEnv,
+          runGit: this.runGitCommand,
+          worktreePath: repoRoot,
+        });
       }
 
       const storage = await this.resolveStorage();

--- a/apps/desktop/src/main/app-server/git-directory-service.ts
+++ b/apps/desktop/src/main/app-server/git-directory-service.ts
@@ -163,6 +163,20 @@ async function pruneEmptyWorktreeParents(worktreePath: string): Promise<void> {
   }
 }
 
+async function removeWorktreeAndPrune(params: {
+  gitEnv?: NodeJS.ProcessEnv;
+  repoRoot: string;
+  runGit: GitCommandRunner;
+  worktreePath: string;
+}): Promise<void> {
+  await params.runGit(
+    params.repoRoot,
+    ["worktree", "remove", "--force", params.worktreePath],
+    params.gitEnv,
+  );
+  await pruneEmptyWorktreeParents(params.worktreePath);
+}
+
 export async function computeWorktreePath(params: {
   backend?: AppServerBackendKind;
   codexHome?: string;
@@ -744,23 +758,35 @@ export class GitDirectoryService {
         storage,
         homeDir: this.homeDir,
       });
-      await mkdir(path.dirname(worktreePath), { recursive: true });
-      await this.runGitCommand(
-        repoRoot,
-        ["worktree", "add", worktreePath, baseBranch],
-        this.gitEnv,
-      );
+      try {
+        await mkdir(path.dirname(worktreePath), { recursive: true });
+        await this.runGitCommand(
+          repoRoot,
+          ["worktree", "add", worktreePath, baseBranch],
+          this.gitEnv,
+        );
+      } catch (error) {
+        if (detachedSourceWorktreePath) {
+          await restoreDetachedWorktreeBranch({
+            branchName: baseBranch,
+            gitEnv: this.gitEnv,
+            runGit: this.runGitCommand,
+            worktreePath: detachedSourceWorktreePath,
+          });
+        }
+        throw error;
+      }
 
       return {
         cwd: worktreePath,
         repositoryPath: repoRoot,
         rollback: async () => {
-          await this.runGitCommand(
+          await removeWorktreeAndPrune({
+            gitEnv: this.gitEnv,
             repoRoot,
-            ["worktree", "remove", "--force", worktreePath],
-            this.gitEnv,
-          );
-          await pruneEmptyWorktreeParents(worktreePath);
+            runGit: this.runGitCommand,
+            worktreePath,
+          });
           if (detachedSourceWorktreePath) {
             await restoreDetachedWorktreeBranch({
               branchName: baseBranch,
@@ -792,6 +818,14 @@ export class GitDirectoryService {
     return {
       cwd: worktreePath,
       repositoryPath: repoRoot,
+      rollback: async () => {
+        await removeWorktreeAndPrune({
+          gitEnv: this.gitEnv,
+          repoRoot,
+          runGit: this.runGitCommand,
+          worktreePath,
+        });
+      },
       workMode: "worktree",
     };
   }

--- a/apps/desktop/src/main/app-server/git-directory-service.ts
+++ b/apps/desktop/src/main/app-server/git-directory-service.ts
@@ -584,7 +584,9 @@ export class GitDirectoryService {
       NavigationLaunchpadDraft,
       "branchName" | "directoryKind" | "directoryLabel" | "directoryPath" | "workMode"
     > &
-      Partial<Pick<NavigationLaunchpadDraft, "backend">>,
+      Partial<Pick<NavigationLaunchpadDraft, "backend">> & {
+        worktreeBranchMode?: "attached" | "detached";
+      },
   ): Promise<{ cwd?: string; repositoryPath?: string; workMode: LaunchpadWorkMode }> {
     if (launchpad.directoryKind === "workspace") {
       return {
@@ -630,6 +632,67 @@ export class GitDirectoryService {
       return {
         cwd: directoryPath,
         workMode: "local",
+      };
+    }
+
+    if (launchpad.worktreeBranchMode === "attached") {
+      const worktreeList = await this.runGitCommand(
+        repoRoot,
+        ["worktree", "list", "--porcelain"],
+        this.gitEnv,
+      ).catch(() => "");
+      const existing = parseGitWorktreeEntries(worktreeList).find(
+        (entry) => entry.branch === baseBranch,
+      );
+      if (existing && path.resolve(existing.path) !== path.resolve(repoRoot)) {
+        return {
+          cwd: existing.path,
+          repositoryPath: repoRoot,
+          workMode: "worktree",
+        };
+      }
+      if (existing) {
+        const status = await this.runGitCommand(
+          repoRoot,
+          ["status", "--porcelain", "--untracked-files=normal"],
+          this.gitEnv,
+        ).catch(() => "");
+        if (status.trim()) {
+          throw new Error(
+            `Cannot move branch ${baseBranch} to a worktree because the local checkout has uncommitted changes.`,
+          );
+        }
+        const baseCommit = await this.runGitCommand(
+          repoRoot,
+          ["rev-parse", "--verify", `${baseBranch}^{commit}`],
+          this.gitEnv,
+        );
+        await this.runGitCommand(
+          repoRoot,
+          ["switch", "--detach", baseCommit.trim()],
+          this.gitEnv,
+        );
+      }
+
+      const storage = await this.resolveStorage();
+      const worktreePath = await computeWorktreePath({
+        backend: launchpad.backend,
+        codexHome: launchpad.backend === "codex" ? this.codexHome : undefined,
+        repoRoot,
+        storage,
+        homeDir: this.homeDir,
+      });
+      await mkdir(path.dirname(worktreePath), { recursive: true });
+      await this.runGitCommand(
+        repoRoot,
+        ["worktree", "add", worktreePath, baseBranch],
+        this.gitEnv,
+      );
+
+      return {
+        cwd: worktreePath,
+        repositoryPath: repoRoot,
+        workMode: "worktree",
       };
     }
 

--- a/apps/desktop/src/main/app-server/thread-migration-service.ts
+++ b/apps/desktop/src/main/app-server/thread-migration-service.ts
@@ -187,6 +187,9 @@ export class ThreadMigrationService {
 
     migrationLog.info("thread migration run finished", {
       completedCount: run.items.filter((item) => item.status === "completed").length,
+      completedWithWarningsCount: run.items.filter(
+        (item) => item.status === "completed" && (item.warnings?.length ?? 0) > 0,
+      ).length,
       failedCount: run.items.filter((item) => item.status === "failed").length,
       operation: request.operation,
       runId: run.runId,

--- a/apps/desktop/src/main/app-server/thread-migration-service.ts
+++ b/apps/desktop/src/main/app-server/thread-migration-service.ts
@@ -151,9 +151,6 @@ export class ThreadMigrationService {
     request: StartThreadMigrationRequest,
   ): Promise<StartThreadMigrationResponse> {
     const sourceProfile = normalizeSourceProfile(request.sourceProfile);
-    if (request.operation === "copy" && !request.copyStrategy) {
-      throw new Error("Copy migrations require an explicit branch conflict strategy.");
-    }
     await this.assertProfileSelectable(sourceProfile);
 
     const run: StartThreadMigrationResponse = {
@@ -195,12 +192,11 @@ export class ThreadMigrationService {
       if (!sourceThread.rolloutPath) {
         throw new Error("Source CAS did not provide a rollout path for this thread.");
       }
-      if (
-        request.operation === "move" &&
-        hasProfileOwnedWorktree(sourceThread.linkedDirectories)
-      ) {
+      if (hasProfileOwnedWorktree(sourceThread.linkedDirectories)) {
         throw new Error(
-          "Move is blocked until this thread's profile-owned worktree can be migrated first.",
+          request.operation === "copy"
+            ? "Copy is blocked until branch conflict strategies for profile-owned worktrees are implemented."
+            : "Move is blocked until this thread's profile-owned worktree can be migrated first.",
         );
       }
 

--- a/apps/desktop/src/main/app-server/thread-migration-service.ts
+++ b/apps/desktop/src/main/app-server/thread-migration-service.ts
@@ -51,7 +51,10 @@ type SourceMigrationClient = Pick<
 
 type DestinationMigrationBackend = {
   forkThread(
-    request: ForkThreadRequest & { sourceThreadPath?: string },
+    request: ForkThreadRequest & {
+      onPreparedWorkspaceRollback?: (rollback: (() => Promise<void>) | undefined) => void;
+      sourceThreadPath?: string;
+    },
   ): Promise<ForkThreadResponse>;
   readThread(request: {
     backend?: "codex";
@@ -235,7 +238,11 @@ export class ThreadMigrationService {
       sourceThreadId: request.threadId,
     });
 
-    await this.restoreSourceForRetry({ item, runId: run.runId, sourceProfile });
+    const retrySourceState = await this.restoreSourceForRetry({
+      item,
+      runId: run.runId,
+      sourceProfile,
+    });
     if (item.status !== "failed") {
       await this.migrateOne({
         item,
@@ -248,6 +255,12 @@ export class ThreadMigrationService {
         runId: run.runId,
         sourceProfile,
       });
+    }
+    if (
+      retrySourceState.wasArchived &&
+      item.diagnostics?.archivedSource !== true
+    ) {
+      await this.rearchiveSourceAfterRetry({ item, runId: run.runId, sourceProfile });
     }
 
     migrationLog.info("thread migration retry finished", {
@@ -276,6 +289,7 @@ export class ThreadMigrationService {
     sourceProfile: string;
   }): Promise<void> {
     const { item, request, runId, sourceProfile } = params;
+    let rollbackPreparedWorkspace: (() => Promise<void>) | undefined;
     try {
       const sourceThread = await this.resolveSourceThread(
         sourceProfile,
@@ -335,6 +349,9 @@ export class ThreadMigrationService {
         backend: "codex",
         sourceThreadId: sourceThread.threadId,
         sourceThreadPath: sourceThread.rolloutPath,
+        onPreparedWorkspaceRollback: (rollback) => {
+          rollbackPreparedWorkspace = rollback;
+        },
         directoryKind: destinationWorkspace.directoryPath ? "directory" : "workspace",
         directoryLabel: destinationWorkspace.directoryLabel,
         directoryPath: destinationWorkspace.directoryPath,
@@ -423,6 +440,7 @@ export class ThreadMigrationService {
       }
 
       item.status = "completed";
+      rollbackPreparedWorkspace = undefined;
       const logPayload = {
         ...item.diagnostics,
         destinationThreadId: item.destinationThreadId,
@@ -439,6 +457,35 @@ export class ThreadMigrationService {
         migrationLog.info("thread migration item completed", logPayload);
       }
     } catch (error) {
+      if (rollbackPreparedWorkspace) {
+        try {
+          await rollbackPreparedWorkspace();
+          migrationLog.info("thread migration workspace rollback completed", {
+            ...item.diagnostics,
+            destinationThreadId: item.destinationThreadId,
+            runId,
+            sourceProfile,
+            sourceThreadId: item.sourceThreadId,
+          });
+        } catch (rollbackError) {
+          appendWarnings(item, [
+            `Workspace rollback failed: ${
+              rollbackError instanceof Error ? rollbackError.message : String(rollbackError)
+            }`,
+          ]);
+          migrationLog.warn("thread migration workspace rollback failed", {
+            ...item.diagnostics,
+            destinationThreadId: item.destinationThreadId,
+            error:
+              rollbackError instanceof Error
+                ? rollbackError.message
+                : String(rollbackError),
+            runId,
+            sourceProfile,
+            sourceThreadId: item.sourceThreadId,
+          });
+        }
+      }
       item.status = "failed";
       item.error = error instanceof Error ? error.message : String(error);
       migrationLog.warn("thread migration item failed", {
@@ -476,8 +523,25 @@ export class ThreadMigrationService {
     item: ThreadMigrationRunItem;
     runId: string;
     sourceProfile: string;
-  }): Promise<void> {
+  }): Promise<{ wasArchived: boolean }> {
     const { item, runId, sourceProfile } = params;
+    let wasArchived = false;
+    try {
+      wasArchived = (
+        await this.findSourceThreadState(sourceProfile, item.sourceThreadId)
+      ).archived;
+    } catch (error) {
+      item.status = "failed";
+      item.error = error instanceof Error ? error.message : String(error);
+      migrationLog.warn("thread migration source retry lookup failed", {
+        runId,
+        sourceProfile,
+        sourceThreadId: item.sourceThreadId,
+        error: item.error,
+      });
+      return { wasArchived: false };
+    }
+
     item.status = "restoring-source";
     migrationLog.info("thread migration source restore requested", {
       runId,
@@ -504,6 +568,7 @@ export class ThreadMigrationService {
         warnings: item.warnings,
       });
       item.status = "pending";
+      return { wasArchived };
     } catch (error) {
       item.status = "failed";
       item.error = error instanceof Error ? error.message : String(error);
@@ -513,7 +578,68 @@ export class ThreadMigrationService {
         sourceThreadId: item.sourceThreadId,
         error: item.error,
       });
+      return { wasArchived };
     }
+  }
+
+  private async rearchiveSourceAfterRetry(params: {
+    item: ThreadMigrationRunItem;
+    runId: string;
+    sourceProfile: string;
+  }): Promise<void> {
+    const { item, runId, sourceProfile } = params;
+    try {
+      const sourceClient = await this.getSourceClient(sourceProfile);
+      migrationLog.info("thread migration retry source rearchive requested", {
+        runId,
+        sourceProfile,
+        sourceThreadId: item.sourceThreadId,
+        status: item.status,
+      });
+      await sourceClient.archiveThread({ threadId: item.sourceThreadId });
+      item.diagnostics = {
+        ...item.diagnostics,
+        archivedSource: true,
+      };
+      migrationLog.info("thread migration retry source rearchived", {
+        runId,
+        sourceProfile,
+        sourceThreadId: item.sourceThreadId,
+        status: item.status,
+      });
+    } catch (error) {
+      appendWarnings(item, [
+        `Retry source rearchive failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      ]);
+      migrationLog.warn("thread migration retry source rearchive failed", {
+        error: error instanceof Error ? error.message : String(error),
+        runId,
+        sourceProfile,
+        sourceThreadId: item.sourceThreadId,
+        status: item.status,
+      });
+    }
+  }
+
+  private async findSourceThreadState(
+    sourceProfile: string,
+    threadId: ThreadIdentifier,
+  ): Promise<{ archived: boolean; thread: InternalSourceThread }> {
+    await this.listSourceThreads({ sourceProfile });
+    const active = this.sourceThreadCache.get(sourceProfile)?.get(threadId);
+    if (active) {
+      return { archived: false, thread: active };
+    }
+
+    await this.listSourceThreads({ sourceProfile, archived: true });
+    const archived = this.sourceThreadCache.get(sourceProfile)?.get(threadId);
+    if (archived) {
+      return { archived: true, thread: archived };
+    }
+
+    throw new Error(`Source thread not found for retry: ${threadId}`);
   }
 
   private async refreshSourceThread(
@@ -760,7 +886,7 @@ function resolveDestinationWorkspace(
   }
   const needsDestinationWorktree =
     Boolean(directoryPath && branchName) &&
-    (request.operation === "move" ||
+    ((request.operation === "move" && sourceHasProfileOwnedWorktree) ||
       request.copyStrategy === "detached-destination");
 
   return {

--- a/apps/desktop/src/main/app-server/thread-migration-service.ts
+++ b/apps/desktop/src/main/app-server/thread-migration-service.ts
@@ -1,5 +1,8 @@
+import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
+import { access } from "node:fs/promises";
 import path from "node:path";
+import { promisify } from "node:util";
 import { buildDirectorySummaries } from "@pwragent/agent-core";
 import {
   buildThreadIdentityKey,
@@ -34,6 +37,7 @@ import {
 import { buildCodexClientArgs } from "./backend-registry";
 
 const migrationLog = getMainLogger("pwragent:thread-migration");
+const execFileAsync = promisify(execFile);
 
 type SourceMigrationClient = Pick<
   CodexAppServerClient,
@@ -71,6 +75,8 @@ type ThreadMigrationServiceOptions = {
 type InternalSourceThread = ThreadMigrationSourceThreadSummary & {
   rolloutPath?: string;
 };
+
+type MigrationDiagnostics = NonNullable<ThreadMigrationRunItem["diagnostics"]>;
 
 export class ThreadMigrationService {
   private readonly sourceClients = new Map<string, SourceMigrationClient>();
@@ -166,9 +172,29 @@ export class ThreadMigrationService {
       })),
     };
 
+    migrationLog.info("thread migration run started", {
+      copyStrategy: request.copyStrategy,
+      operation: request.operation,
+      runId: run.runId,
+      sourceProfile,
+      threadCount: request.threadIds.length,
+      threadIds: request.threadIds,
+    });
+
     for (const item of run.items) {
-      await this.migrateOne({ item, request, sourceProfile });
+      await this.migrateOne({ item, request, runId: run.runId, sourceProfile });
     }
+
+    migrationLog.info("thread migration run finished", {
+      completedCount: run.items.filter((item) => item.status === "completed").length,
+      failedCount: run.items.filter((item) => item.status === "failed").length,
+      operation: request.operation,
+      runId: run.runId,
+      warningCount: run.items.reduce(
+        (count, item) => count + (item.warnings?.length ?? 0),
+        0,
+      ),
+    });
 
     return run;
   }
@@ -183,14 +209,27 @@ export class ThreadMigrationService {
   private async migrateOne(params: {
     item: ThreadMigrationRunItem;
     request: StartThreadMigrationRequest;
+    runId: string;
     sourceProfile: string;
   }): Promise<void> {
-    const { item, request, sourceProfile } = params;
+    const { item, request, runId, sourceProfile } = params;
     try {
       const sourceThread = await this.resolveSourceThread(
         sourceProfile,
         item.sourceThreadId,
       );
+      const sourceFacts = await inspectSourceThread(sourceThread);
+      item.diagnostics = sourceFacts.diagnostics;
+      item.warnings = sourceFacts.warnings;
+      migrationLog.info("thread migration item starting", {
+        ...item.diagnostics,
+        operation: request.operation,
+        runId,
+        sourceProfile,
+        sourceThreadId: item.sourceThreadId,
+        warningCount: item.warnings.length,
+        warnings: item.warnings,
+      });
       if (!sourceThread.rolloutPath) {
         throw new Error("Source CAS did not provide a rollout path for this thread.");
       }
@@ -204,8 +243,31 @@ export class ThreadMigrationService {
         );
       }
       const destinationWorkspace = resolveDestinationWorkspace(sourceThread, request);
+      item.diagnostics = {
+        ...item.diagnostics,
+        ...(destinationWorkspace.directoryPath
+          ? { requestedDirectoryPath: destinationWorkspace.directoryPath }
+          : {}),
+        ...(destinationWorkspace.branchName
+          ? { requestedBranchName: destinationWorkspace.branchName }
+          : {}),
+        ...(destinationWorkspace.worktreeBranchMode
+          ? {
+              requestedWorktreeBranchMode:
+                destinationWorkspace.worktreeBranchMode,
+            }
+          : {}),
+        requestedWorkMode: destinationWorkspace.workMode,
+      };
 
       item.status = "copying";
+      migrationLog.info("thread migration fork requested", {
+        ...item.diagnostics,
+        operation: request.operation,
+        runId,
+        sourceProfile,
+        sourceThreadId: item.sourceThreadId,
+      });
       const destination = await this.options.destination.forkThread({
         backend: "codex",
         sourceThreadId: sourceThread.threadId,
@@ -222,6 +284,27 @@ export class ThreadMigrationService {
           : {}),
       });
       item.destinationThreadId = destination.threadId;
+      item.diagnostics = {
+        ...item.diagnostics,
+        ...(destination.linkedDirectory?.path
+          ? { destinationDirectoryPath: destination.linkedDirectory.path }
+          : {}),
+        ...(destination.linkedDirectory?.worktreePath
+          ? { destinationWorktreePath: destination.linkedDirectory.worktreePath }
+          : {}),
+        destinationWorkMode: destination.workMode,
+      };
+      appendWarnings(item, validateDestinationWorkspaceResult(destinationWorkspace, destination));
+      migrationLog.info("thread migration fork completed", {
+        ...item.diagnostics,
+        destinationThreadId: destination.threadId,
+        operation: request.operation,
+        runId,
+        sourceProfile,
+        sourceThreadId: item.sourceThreadId,
+        warningCount: item.warnings?.length ?? 0,
+        warnings: item.warnings ?? [],
+      });
 
       item.status = "validating";
       const sourceClient = await this.getSourceClient(sourceProfile);
@@ -240,23 +323,68 @@ export class ThreadMigrationService {
       if (!validation.matched) {
         throw new Error("Destination replay did not match source replay.");
       }
+      migrationLog.info("thread migration validation completed", {
+        destinationThreadId: destination.threadId,
+        matched: validation.matched,
+        operation: request.operation,
+        runId,
+        sourceMessageCount: validation.sourceMessageCount,
+        destinationMessageCount: validation.destinationMessageCount,
+        sourceProfile,
+        sourceThreadId: item.sourceThreadId,
+      });
 
       item.status = "worktree";
       if (request.operation === "move") {
         item.status = "archiving-source";
+        migrationLog.info("thread migration source archive requested", {
+          destinationThreadId: destination.threadId,
+          runId,
+          sourceProfile,
+          sourceThreadId: sourceThread.threadId,
+        });
         await sourceClient.archiveThread({ threadId: sourceThread.threadId });
+        item.diagnostics = {
+          ...item.diagnostics,
+          archivedSource: true,
+        };
+        migrationLog.info("thread migration source archived", {
+          destinationThreadId: destination.threadId,
+          runId,
+          sourceProfile,
+          sourceThreadId: sourceThread.threadId,
+        });
       }
 
       item.status = "completed";
+      const logPayload = {
+        ...item.diagnostics,
+        destinationThreadId: item.destinationThreadId,
+        operation: request.operation,
+        runId,
+        sourceProfile,
+        sourceThreadId: item.sourceThreadId,
+        warningCount: item.warnings?.length ?? 0,
+        warnings: item.warnings ?? [],
+      };
+      if (item.warnings?.length) {
+        migrationLog.warn("thread migration item completed with warnings", logPayload);
+      } else {
+        migrationLog.info("thread migration item completed", logPayload);
+      }
     } catch (error) {
       item.status = "failed";
       item.error = error instanceof Error ? error.message : String(error);
       migrationLog.warn("thread migration item failed", {
+        ...item.diagnostics,
         sourceProfile,
         sourceThreadId: item.sourceThreadId,
         destinationThreadId: item.destinationThreadId,
         status: item.status,
         error: item.error,
+        runId,
+        warningCount: item.warnings?.length ?? 0,
+        warnings: item.warnings ?? [],
       });
     }
   }
@@ -495,6 +623,11 @@ function resolveDestinationWorkspace(
   }
   const branchName =
     thread.gitBranch && thread.gitBranch !== "HEAD" ? thread.gitBranch : undefined;
+  if (sourceHasProfileOwnedWorktree && !branchName) {
+    throw new Error(
+      "Migration is blocked because the source managed worktree did not report an attached branch.",
+    );
+  }
   const needsDestinationWorktree =
     Boolean(directoryPath && branchName) &&
     (request.operation === "move" ||
@@ -530,6 +663,126 @@ function resolveDestinationDirectoryPath(
   }
 
   return undefined;
+}
+
+async function inspectSourceThread(thread: InternalSourceThread): Promise<{
+  diagnostics: MigrationDiagnostics;
+  warnings: string[];
+}> {
+  const sourceDirectoryPath = resolveDestinationDirectoryPath(thread);
+  const sourceWorktreePath = resolveSourceWorktreePath(thread);
+  const sourceGitBranch =
+    thread.gitBranch && thread.gitBranch !== "HEAD" ? thread.gitBranch : undefined;
+  const [sourceDirectoryExists, sourceWorktreeExists, sourceBranchExists] =
+    await Promise.all([
+      pathExists(sourceDirectoryPath),
+      pathExists(sourceWorktreePath),
+      gitBranchExists(sourceDirectoryPath, sourceGitBranch),
+    ]);
+  const diagnostics: MigrationDiagnostics = {
+    sourceTitle: thread.title,
+    ...(thread.archivedAt ? { sourceArchivedAt: thread.archivedAt } : {}),
+    ...(thread.projectKey ? { sourceProjectKey: thread.projectKey } : {}),
+    ...(sourceDirectoryPath ? { sourceDirectoryPath } : {}),
+    ...(sourceDirectoryExists === undefined ? {} : { sourceDirectoryExists }),
+    ...(sourceWorktreePath ? { sourceWorktreePath } : {}),
+    ...(sourceGitBranch ? { sourceGitBranch } : {}),
+    ...(sourceWorktreeExists === undefined ? {} : { sourceWorktreeExists }),
+    ...(sourceBranchExists === undefined ? {} : { sourceBranchExists }),
+  };
+  const warnings: string[] = [];
+  if (thread.archivedAt) {
+    warnings.push("Source thread was already archived before migration.");
+  }
+  if (sourceDirectoryPath && sourceDirectoryExists === false) {
+    warnings.push(`Source project directory was not found: ${sourceDirectoryPath}`);
+  }
+  if (sourceWorktreePath && sourceWorktreeExists === false) {
+    warnings.push(`Source worktree was not found: ${sourceWorktreePath}`);
+  }
+  if (sourceGitBranch && sourceBranchExists === false) {
+    warnings.push(`Source branch was not found: ${sourceGitBranch}`);
+  }
+  return { diagnostics, warnings };
+}
+
+function resolveSourceWorktreePath(
+  thread: Pick<InternalSourceThread, "linkedDirectories" | "projectKey">,
+): string | undefined {
+  for (const directory of thread.linkedDirectories) {
+    const worktreePath = directory.worktreePath?.trim();
+    if (worktreePath && isToolManagedWorktreePath(worktreePath)) {
+      return worktreePath;
+    }
+    const directoryPath = directory.path?.trim();
+    if (directoryPath && isToolManagedWorktreePath(directoryPath)) {
+      return directoryPath;
+    }
+  }
+  const projectKey = thread.projectKey?.trim();
+  if (projectKey && isToolManagedWorktreePath(projectKey)) {
+    return projectKey;
+  }
+  return undefined;
+}
+
+async function pathExists(filesystemPath: string | undefined): Promise<boolean | undefined> {
+  if (!filesystemPath) {
+    return undefined;
+  }
+  try {
+    await access(filesystemPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function gitBranchExists(
+  repositoryPath: string | undefined,
+  branchName: string | undefined,
+): Promise<boolean | undefined> {
+  if (!repositoryPath || !branchName) {
+    return undefined;
+  }
+  try {
+    await execFileAsync("git", [
+      "-C",
+      repositoryPath,
+      "rev-parse",
+      "--verify",
+      `${branchName}^{commit}`,
+    ]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function validateDestinationWorkspaceResult(
+  requested: ReturnType<typeof resolveDestinationWorkspace>,
+  destination: ForkThreadResponse,
+): string[] {
+  const warnings: string[] = [];
+  if (requested.workMode === "worktree" && destination.workMode !== "worktree") {
+    warnings.push(
+      `Destination returned ${destination.workMode} even though migration requested a worktree.`,
+    );
+  }
+  if (
+    requested.workMode === "worktree" &&
+    !destination.linkedDirectory?.worktreePath
+  ) {
+    warnings.push("Destination did not report a worktree path.");
+  }
+  return warnings;
+}
+
+function appendWarnings(item: ThreadMigrationRunItem, warnings: string[]): void {
+  if (warnings.length === 0) {
+    return;
+  }
+  item.warnings = [...(item.warnings ?? []), ...warnings];
 }
 
 function validateReplay(

--- a/apps/desktop/src/main/app-server/thread-migration-service.ts
+++ b/apps/desktop/src/main/app-server/thread-migration-service.ts
@@ -137,7 +137,7 @@ export class ThreadMigrationService {
 
     const client = await this.getSourceClient(sourceProfile);
     const metadata = await client.listThreadsForMigration({
-      archived: request.archived,
+      archived: request.archived === true,
       filter: request.filter,
     });
     const sourceThreads = metadata.map((thread) =>

--- a/apps/desktop/src/main/app-server/thread-migration-service.ts
+++ b/apps/desktop/src/main/app-server/thread-migration-service.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from "node:crypto";
 import path from "node:path";
+import { buildDirectorySummaries } from "@pwragent/agent-core";
 import {
+  buildThreadIdentityKey,
   isToolManagedWorktreePath,
   type AppServerThreadReplay,
   type ForkThreadRequest,
@@ -15,6 +17,7 @@ import {
   type ThreadMigrationRunItem,
   type ThreadMigrationSourceProjectGroup,
   type ThreadMigrationSourceThreadSummary,
+  type NavigationThreadSummary,
 } from "@pwragent/shared";
 import { getMainLogger } from "../log";
 import { normalizeProfileName } from "../profile";
@@ -378,26 +381,68 @@ function normalizeSourceThread(
 function groupSourceThreads(
   threads: InternalSourceThread[],
 ): ThreadMigrationSourceProjectGroup[] {
-  const groups = new Map<string, ThreadMigrationSourceProjectGroup>();
+  const threadByKey = new Map(
+    threads.map((thread) => [
+      buildThreadIdentityKey("codex", thread.threadId),
+      thread,
+    ]),
+  );
+  const groupedThreadKeys = new Set<string>();
+  const groups = buildDirectorySummaries({
+    threads: threads.map(toNavigationThreadSummary),
+  }).map((directory): ThreadMigrationSourceProjectGroup => {
+    const groupThreads = directory.threadKeys
+      .map((threadKey) => {
+        groupedThreadKeys.add(threadKey);
+        return threadByKey.get(threadKey);
+      })
+      .filter((thread): thread is InternalSourceThread => Boolean(thread))
+      .map(stripInternalThread);
+
+    return {
+      key: directory.key,
+      label: directory.label,
+      ...(directory.path ? { path: directory.path } : {}),
+      threads: groupThreads,
+    };
+  });
+
   for (const thread of threads) {
-    const pathValue =
-      thread.projectKey ?? thread.linkedDirectories[0]?.worktreePath ?? thread.linkedDirectories[0]?.path;
-    const key = pathValue ? `project:${pathValue}` : "unlinked";
-    const existing =
-      groups.get(key) ??
-      ({
-        key,
-        label: pathValue ? path.basename(pathValue) || pathValue : "No project",
-        ...(pathValue ? { path: pathValue } : {}),
-        threads: [],
-      } satisfies ThreadMigrationSourceProjectGroup);
-    existing.threads.push(stripInternalThread(thread));
-    groups.set(key, existing);
+    const threadKey = buildThreadIdentityKey("codex", thread.threadId);
+    if (groupedThreadKeys.has(threadKey)) {
+      continue;
+    }
+    const projectPath = thread.projectKey?.trim();
+    groups.push({
+      key: projectPath ? `directory:${projectPath}` : "unlinked",
+      label: projectPath ? path.basename(projectPath) || projectPath : "No project",
+      ...(projectPath ? { path: projectPath } : {}),
+      threads: [stripInternalThread(thread)],
+    });
   }
 
-  return [...groups.values()].sort((left, right) =>
-    left.label.localeCompare(right.label),
-  );
+  return groups
+    .filter((group) => group.threads.length > 0)
+    .sort((left, right) => left.label.localeCompare(right.label));
+}
+
+function toNavigationThreadSummary(
+  thread: InternalSourceThread,
+): NavigationThreadSummary {
+  return {
+    id: thread.threadId,
+    source: "codex",
+    title: thread.title,
+    titleSource: "explicit",
+    linkedDirectories: thread.linkedDirectories,
+    inbox: { inInbox: false },
+    ...(thread.summary ? { summary: thread.summary } : {}),
+    ...(thread.projectKey ? { projectKey: thread.projectKey } : {}),
+    ...(thread.createdAt ? { createdAt: thread.createdAt } : {}),
+    ...(thread.updatedAt ? { updatedAt: thread.updatedAt } : {}),
+    ...(thread.archivedAt ? { archivedAt: thread.archivedAt } : {}),
+    ...(thread.gitBranch ? { gitBranch: thread.gitBranch } : {}),
+  };
 }
 
 function stripInternalThread(

--- a/apps/desktop/src/main/app-server/thread-migration-service.ts
+++ b/apps/desktop/src/main/app-server/thread-migration-service.ts
@@ -282,6 +282,9 @@ export class ThreadMigrationService {
         ...(destinationWorkspace.branchName
           ? { branchName: destinationWorkspace.branchName }
           : {}),
+        ...(item.diagnostics?.sourceWorktreePath
+          ? { excludedWorktreePaths: [item.diagnostics.sourceWorktreePath] }
+          : {}),
       });
       item.destinationThreadId = destination.threadId;
       item.diagnostics = {

--- a/apps/desktop/src/main/app-server/thread-migration-service.ts
+++ b/apps/desktop/src/main/app-server/thread-migration-service.ts
@@ -1,0 +1,449 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import {
+  isToolManagedWorktreePath,
+  type AppServerThreadReplay,
+  type ForkThreadRequest,
+  type ForkThreadResponse,
+  type LinkedDirectorySummary,
+  type ListThreadMigrationSourceThreadsRequest,
+  type ListThreadMigrationSourceThreadsResponse,
+  type ListThreadMigrationSourcesResponse,
+  type StartThreadMigrationRequest,
+  type StartThreadMigrationResponse,
+  type ThreadIdentifier,
+  type ThreadMigrationRunItem,
+  type ThreadMigrationSourceProjectGroup,
+  type ThreadMigrationSourceThreadSummary,
+} from "@pwragent/shared";
+import { getMainLogger } from "../log";
+import { normalizeProfileName } from "../profile";
+import type { DesktopSettingsService } from "../settings/desktop-settings-service";
+import { getDesktopSettingsService } from "../settings/desktop-settings-singleton";
+import {
+  discoverCodexAuthProfiles,
+  resolveDefaultCodexHome,
+  resolveCodexHomeForProfile,
+} from "../settings/codex-profiles";
+import {
+  CodexAppServerClient,
+  type CodexThreadMigrationMetadata,
+} from "../codex-app-server/client";
+import { buildCodexClientArgs } from "./backend-registry";
+
+const migrationLog = getMainLogger("pwragent:thread-migration");
+
+type SourceMigrationClient = Pick<
+  CodexAppServerClient,
+  "archiveThread" | "close" | "listThreadsForMigration" | "readThread"
+>;
+
+type DestinationMigrationBackend = {
+  forkThread(
+    request: ForkThreadRequest & { sourceThreadPath?: string },
+  ): Promise<ForkThreadResponse>;
+  readThread(request: {
+    backend?: "codex";
+    threadId: ThreadIdentifier;
+  }): Promise<{ replay: AppServerThreadReplay }>;
+};
+
+type ThreadMigrationServiceOptions = {
+  destination: DestinationMigrationBackend;
+  settingsService?: Pick<
+    DesktopSettingsService,
+    "readSettings" | "resolveCodexCommandPreference" | "resolveCodexSpawnEnv"
+  >;
+  sourceClientFactory?: (params: {
+    codexHome: string;
+    command?: string;
+    env: NodeJS.ProcessEnv;
+    profile: string;
+  }) => SourceMigrationClient;
+  idFactory?: () => string;
+  now?: () => number;
+  env?: NodeJS.ProcessEnv;
+  homeDir?: string;
+};
+
+type InternalSourceThread = ThreadMigrationSourceThreadSummary & {
+  rolloutPath?: string;
+};
+
+export class ThreadMigrationService {
+  private readonly sourceClients = new Map<string, SourceMigrationClient>();
+  private readonly sourceThreadCache = new Map<
+    string,
+    Map<ThreadIdentifier, InternalSourceThread>
+  >();
+
+  constructor(private readonly options: ThreadMigrationServiceOptions) {}
+
+  async listSources(): Promise<ListThreadMigrationSourcesResponse> {
+    const settingsService = this.getSettingsService();
+    const settings = await settingsService.readSettings();
+    const activeCodexProfile = normalizeSourceProfile(
+      settings.models.codex.profile.value,
+    );
+    const discovery =
+      settings.models.codex.profiles ??
+      discoverCodexAuthProfiles({
+        configuredProfile: activeCodexProfile,
+        env: this.options.env,
+        homeDir: this.options.homeDir,
+      });
+
+    return {
+      activeCodexProfile,
+      profiles: discovery.profiles
+        .filter((profile) => normalizeSourceProfile(profile.name) !== activeCodexProfile)
+        .map((profile) => {
+          const hasAuth = Boolean(profile.hasAuthFile);
+          const available = Boolean(profile.exists && hasAuth);
+          return {
+            profile: normalizeSourceProfile(profile.name),
+            displayName: profile.displayName,
+            codexHome: profile.codexHome,
+            source: profile.source,
+            exists: profile.exists,
+            selected: false,
+            available,
+            ...(available
+              ? {}
+              : {
+                  unavailableReason: profile.exists
+                    ? "Codex auth is not configured for this profile."
+                    : "Codex profile directory does not exist.",
+                }),
+            ...(profile.accountEmail ? { accountEmail: profile.accountEmail } : {}),
+          };
+        }),
+    };
+  }
+
+  async listSourceThreads(
+    request: ListThreadMigrationSourceThreadsRequest,
+  ): Promise<ListThreadMigrationSourceThreadsResponse> {
+    const sourceProfile = normalizeSourceProfile(request.sourceProfile);
+    await this.assertProfileSelectable(sourceProfile);
+
+    const client = await this.getSourceClient(sourceProfile);
+    const metadata = await client.listThreadsForMigration({
+      archived: request.archived,
+      filter: request.filter,
+    });
+    const sourceThreads = metadata.map((thread) =>
+      normalizeSourceThread(sourceProfile, thread),
+    );
+    this.sourceThreadCache.set(
+      sourceProfile,
+      new Map(sourceThreads.map((thread) => [thread.threadId, thread])),
+    );
+
+    return {
+      sourceProfile,
+      fetchedAt: this.now(),
+      projects: groupSourceThreads(sourceThreads),
+    };
+  }
+
+  async startMigration(
+    request: StartThreadMigrationRequest,
+  ): Promise<StartThreadMigrationResponse> {
+    const sourceProfile = normalizeSourceProfile(request.sourceProfile);
+    if (request.operation === "copy" && !request.copyStrategy) {
+      throw new Error("Copy migrations require an explicit branch conflict strategy.");
+    }
+    await this.assertProfileSelectable(sourceProfile);
+
+    const run: StartThreadMigrationResponse = {
+      runId: this.createRunId(),
+      operation: request.operation,
+      startedAt: this.now(),
+      items: request.threadIds.map((sourceThreadId) => ({
+        sourceProfile,
+        sourceThreadId,
+        status: "pending",
+      })),
+    };
+
+    for (const item of run.items) {
+      await this.migrateOne({ item, request, sourceProfile });
+    }
+
+    return run;
+  }
+
+  async dispose(): Promise<void> {
+    const clients = [...this.sourceClients.values()];
+    this.sourceClients.clear();
+    this.sourceThreadCache.clear();
+    await Promise.allSettled(clients.map((client) => client.close()));
+  }
+
+  private async migrateOne(params: {
+    item: ThreadMigrationRunItem;
+    request: StartThreadMigrationRequest;
+    sourceProfile: string;
+  }): Promise<void> {
+    const { item, request, sourceProfile } = params;
+    try {
+      const sourceThread = await this.resolveSourceThread(
+        sourceProfile,
+        item.sourceThreadId,
+      );
+      if (!sourceThread.rolloutPath) {
+        throw new Error("Source CAS did not provide a rollout path for this thread.");
+      }
+      if (
+        request.operation === "move" &&
+        hasProfileOwnedWorktree(sourceThread.linkedDirectories)
+      ) {
+        throw new Error(
+          "Move is blocked until this thread's profile-owned worktree can be migrated first.",
+        );
+      }
+
+      item.status = "copying";
+      const destination = await this.options.destination.forkThread({
+        backend: "codex",
+        sourceThreadId: sourceThread.threadId,
+        sourceThreadPath: sourceThread.rolloutPath,
+        directoryKind: sourceThread.projectKey ? "directory" : "workspace",
+        directoryLabel: sourceThread.projectKey
+          ? path.basename(sourceThread.projectKey)
+          : sourceThread.title,
+        directoryPath: sourceThread.projectKey,
+        workMode: "local",
+      });
+      item.destinationThreadId = destination.threadId;
+
+      item.status = "validating";
+      const sourceClient = await this.getSourceClient(sourceProfile);
+      const [sourceReplay, destinationReplay] = await Promise.all([
+        sourceClient.readThread({ threadId: sourceThread.threadId }),
+        this.options.destination.readThread({
+          backend: "codex",
+          threadId: destination.threadId,
+        }),
+      ]);
+      const validation: NonNullable<ThreadMigrationRunItem["validation"]> = validateReplay(
+        sourceReplay,
+        destinationReplay.replay,
+      );
+      item.validation = validation;
+      if (!validation.matched) {
+        throw new Error("Destination replay did not match source replay.");
+      }
+
+      item.status = "worktree";
+      if (request.operation === "move") {
+        item.status = "archiving-source";
+        await sourceClient.archiveThread({ threadId: sourceThread.threadId });
+      }
+
+      item.status = "completed";
+    } catch (error) {
+      item.status = "failed";
+      item.error = error instanceof Error ? error.message : String(error);
+      migrationLog.warn("thread migration item failed", {
+        sourceProfile,
+        sourceThreadId: item.sourceThreadId,
+        destinationThreadId: item.destinationThreadId,
+        status: item.status,
+        error: item.error,
+      });
+    }
+  }
+
+  private async resolveSourceThread(
+    sourceProfile: string,
+    threadId: ThreadIdentifier,
+  ): Promise<InternalSourceThread> {
+    const cached = this.sourceThreadCache.get(sourceProfile)?.get(threadId);
+    if (cached) {
+      return cached;
+    }
+
+    await this.listSourceThreads({ sourceProfile });
+    const refreshed = this.sourceThreadCache.get(sourceProfile)?.get(threadId);
+    if (!refreshed) {
+      throw new Error(`Source thread not found: ${threadId}`);
+    }
+    return refreshed;
+  }
+
+  private async assertProfileSelectable(sourceProfile: string): Promise<void> {
+    const sources = await this.listSources();
+    const source = sources.profiles.find((profile) => profile.profile === sourceProfile);
+    if (!source) {
+      throw new Error("Source profile is not available for migration.");
+    }
+    if (!source.available) {
+      throw new Error(source.unavailableReason ?? "Source profile is unavailable.");
+    }
+  }
+
+  private async getSourceClient(sourceProfile: string): Promise<SourceMigrationClient> {
+    const cached = this.sourceClients.get(sourceProfile);
+    if (cached) {
+      return cached;
+    }
+
+    const source = (await this.listSources()).profiles.find(
+      (profile) => profile.profile === sourceProfile,
+    );
+    const codexHome =
+      source?.codexHome ?? resolveCodexHome(sourceProfile, this.options);
+    const settingsService = this.getSettingsService();
+    const baseEnv = settingsService.resolveCodexSpawnEnv();
+    const env = {
+      ...baseEnv,
+      CODEX_HOME: codexHome,
+    };
+    const command = settingsService.resolveCodexCommandPreference();
+    const client =
+      this.options.sourceClientFactory?.({
+        codexHome,
+        command,
+        env,
+        profile: sourceProfile,
+      }) ??
+      new CodexAppServerClient({
+        args: buildCodexClientArgs(env),
+        command,
+        env,
+      });
+    this.sourceClients.set(sourceProfile, client);
+    return client;
+  }
+
+  private getSettingsService(): Pick<
+    DesktopSettingsService,
+    "readSettings" | "resolveCodexCommandPreference" | "resolveCodexSpawnEnv"
+  > {
+    return this.options.settingsService ?? getDesktopSettingsService();
+  }
+
+  private now(): number {
+    return this.options.now?.() ?? Date.now();
+  }
+
+  private createRunId(): string {
+    return this.options.idFactory?.() ?? randomUUID();
+  }
+}
+
+function resolveCodexHome(
+  sourceProfile: string,
+  options: Pick<ThreadMigrationServiceOptions, "env" | "homeDir">,
+): string {
+  if (!sourceProfile) {
+    return resolveDefaultCodexHome(options);
+  }
+  const codexHome = resolveCodexHomeForProfile(sourceProfile, options);
+  if (!codexHome) {
+    throw new Error("Invalid source profile.");
+  }
+  return codexHome;
+}
+
+function normalizeSourceProfile(value: string | undefined): string {
+  const raw = value?.trim() ?? "";
+  if (!raw) {
+    return "";
+  }
+  const normalized = normalizeProfileName(raw);
+  if (!normalized) {
+    throw new Error(`Invalid Codex profile "${value}".`);
+  }
+  return normalized;
+}
+
+function normalizeSourceThread(
+  sourceProfile: string,
+  thread: CodexThreadMigrationMetadata,
+): InternalSourceThread {
+  return {
+    sourceProfile,
+    threadId: thread.id,
+    title: thread.title,
+    ...(thread.summary ? { summary: thread.summary } : {}),
+    ...(thread.projectKey ? { projectKey: thread.projectKey } : {}),
+    ...(thread.createdAt ? { createdAt: thread.createdAt } : {}),
+    ...(thread.updatedAt ? { updatedAt: thread.updatedAt } : {}),
+    ...(thread.archivedAt ? { archivedAt: thread.archivedAt } : {}),
+    ...(thread.gitBranch ? { gitBranch: thread.gitBranch } : {}),
+    linkedDirectories: thread.linkedDirectories,
+    ...(thread.rolloutPath ? { rolloutPath: thread.rolloutPath } : {}),
+  };
+}
+
+function groupSourceThreads(
+  threads: InternalSourceThread[],
+): ThreadMigrationSourceProjectGroup[] {
+  const groups = new Map<string, ThreadMigrationSourceProjectGroup>();
+  for (const thread of threads) {
+    const pathValue =
+      thread.projectKey ?? thread.linkedDirectories[0]?.worktreePath ?? thread.linkedDirectories[0]?.path;
+    const key = pathValue ? `project:${pathValue}` : "unlinked";
+    const existing =
+      groups.get(key) ??
+      ({
+        key,
+        label: pathValue ? path.basename(pathValue) || pathValue : "No project",
+        ...(pathValue ? { path: pathValue } : {}),
+        threads: [],
+      } satisfies ThreadMigrationSourceProjectGroup);
+    existing.threads.push(stripInternalThread(thread));
+    groups.set(key, existing);
+  }
+
+  return [...groups.values()].sort((left, right) =>
+    left.label.localeCompare(right.label),
+  );
+}
+
+function stripInternalThread(
+  thread: InternalSourceThread,
+): ThreadMigrationSourceThreadSummary {
+  const { rolloutPath: _rolloutPath, ...publicThread } = thread;
+  return publicThread;
+}
+
+function hasProfileOwnedWorktree(directories: LinkedDirectorySummary[]): boolean {
+  return directories.some(
+    (directory) =>
+      isToolManagedWorktreePath(directory.worktreePath) ||
+      isToolManagedWorktreePath(directory.path),
+  );
+}
+
+function validateReplay(
+  source: AppServerThreadReplay,
+  destination: AppServerThreadReplay,
+): NonNullable<ThreadMigrationRunItem["validation"]> {
+  const sourceFingerprint = fingerprintReplay(source);
+  const destinationFingerprint = fingerprintReplay(destination);
+  return {
+    sourceMessageCount: sourceFingerprint.length,
+    destinationMessageCount: destinationFingerprint.length,
+    matched:
+      sourceFingerprint.length === destinationFingerprint.length &&
+      sourceFingerprint.every((entry, index) => entry === destinationFingerprint[index]),
+  };
+}
+
+function fingerprintReplay(replay: AppServerThreadReplay): string[] {
+  return replay.messages.map((message) =>
+    JSON.stringify({
+      role: message.role,
+      text: message.text,
+      parts: message.parts?.map((part) =>
+        part.type === "text"
+          ? { type: "text", text: part.text }
+          : { type: "image", alt: part.alt ?? "", url: part.url },
+      ),
+    }),
+  );
+}

--- a/apps/desktop/src/main/app-server/thread-migration-service.ts
+++ b/apps/desktop/src/main/app-server/thread-migration-service.ts
@@ -458,8 +458,10 @@ function hasProfileOwnedWorktree(
     (thread.projectKey && isToolManagedWorktreePath(thread.projectKey)) ||
       thread.linkedDirectories.some(
         (directory) =>
-          isToolManagedWorktreePath(directory.worktreePath) ||
-          isToolManagedWorktreePath(directory.path),
+          Boolean(directory) &&
+          typeof directory === "object" &&
+          (isToolManagedWorktreePath(directory.worktreePath) ||
+            isToolManagedWorktreePath(directory.path)),
       ),
   );
 }

--- a/apps/desktop/src/main/app-server/thread-migration-service.ts
+++ b/apps/desktop/src/main/app-server/thread-migration-service.ts
@@ -12,6 +12,7 @@ import {
   type ForkThreadResponse,
   type ListThreadMigrationSourceThreadsRequest,
   type ListThreadMigrationSourceThreadsResponse,
+  type RetryThreadMigrationRequest,
   type ListThreadMigrationSourcesResponse,
   type StartThreadMigrationRequest,
   type StartThreadMigrationResponse,
@@ -41,7 +42,11 @@ const execFileAsync = promisify(execFile);
 
 type SourceMigrationClient = Pick<
   CodexAppServerClient,
-  "archiveThread" | "close" | "listThreadsForMigration" | "readThread"
+  | "archiveThread"
+  | "close"
+  | "listThreadsForMigration"
+  | "readThread"
+  | "restoreThread"
 >;
 
 type DestinationMigrationBackend = {
@@ -197,6 +202,61 @@ export class ThreadMigrationService {
         (count, item) => count + (item.warnings?.length ?? 0),
         0,
       ),
+    });
+
+    return run;
+  }
+
+  async retryMigration(
+    request: RetryThreadMigrationRequest,
+  ): Promise<StartThreadMigrationResponse> {
+    const sourceProfile = normalizeSourceProfile(request.sourceProfile);
+    await this.assertProfileSelectable(sourceProfile);
+
+    const run: StartThreadMigrationResponse = {
+      runId: this.createRunId(),
+      operation: request.operation,
+      startedAt: this.now(),
+      items: [
+        {
+          sourceProfile,
+          sourceThreadId: request.threadId,
+          status: "pending",
+        },
+      ],
+    };
+    const item = run.items[0]!;
+
+    migrationLog.info("thread migration retry started", {
+      copyStrategy: request.copyStrategy,
+      operation: request.operation,
+      runId: run.runId,
+      sourceProfile,
+      sourceThreadId: request.threadId,
+    });
+
+    await this.restoreSourceForRetry({ item, runId: run.runId, sourceProfile });
+    if (item.status !== "failed") {
+      await this.migrateOne({
+        item,
+        request: {
+          copyStrategy: request.copyStrategy,
+          operation: request.operation,
+          sourceProfile,
+          threadIds: [request.threadId],
+        },
+        runId: run.runId,
+        sourceProfile,
+      });
+    }
+
+    migrationLog.info("thread migration retry finished", {
+      operation: request.operation,
+      runId: run.runId,
+      sourceProfile,
+      sourceThreadId: request.threadId,
+      status: item.status,
+      warningCount: item.warnings?.length ?? 0,
     });
 
     return run;
@@ -410,6 +470,68 @@ export class ThreadMigrationService {
       throw new Error(`Source thread not found: ${threadId}`);
     }
     return refreshed;
+  }
+
+  private async restoreSourceForRetry(params: {
+    item: ThreadMigrationRunItem;
+    runId: string;
+    sourceProfile: string;
+  }): Promise<void> {
+    const { item, runId, sourceProfile } = params;
+    item.status = "restoring-source";
+    migrationLog.info("thread migration source restore requested", {
+      runId,
+      sourceProfile,
+      sourceThreadId: item.sourceThreadId,
+    });
+    try {
+      const sourceClient = await this.getSourceClient(sourceProfile);
+      await sourceClient.restoreThread({ threadId: item.sourceThreadId });
+      this.sourceThreadCache.delete(sourceProfile);
+      const refreshed = await this.refreshSourceThread(
+        sourceProfile,
+        item.sourceThreadId,
+      );
+      const sourceFacts = await inspectSourceThread(refreshed);
+      item.diagnostics = sourceFacts.diagnostics;
+      item.warnings = sourceFacts.warnings;
+      migrationLog.info("thread migration source restore completed", {
+        ...item.diagnostics,
+        runId,
+        sourceProfile,
+        sourceThreadId: item.sourceThreadId,
+        warningCount: item.warnings.length,
+        warnings: item.warnings,
+      });
+      item.status = "pending";
+    } catch (error) {
+      item.status = "failed";
+      item.error = error instanceof Error ? error.message : String(error);
+      migrationLog.warn("thread migration source restore failed", {
+        runId,
+        sourceProfile,
+        sourceThreadId: item.sourceThreadId,
+        error: item.error,
+      });
+    }
+  }
+
+  private async refreshSourceThread(
+    sourceProfile: string,
+    threadId: ThreadIdentifier,
+  ): Promise<InternalSourceThread> {
+    await this.listSourceThreads({ sourceProfile });
+    const active = this.sourceThreadCache.get(sourceProfile)?.get(threadId);
+    if (active) {
+      return active;
+    }
+
+    await this.listSourceThreads({ sourceProfile, archived: true });
+    const archived = this.sourceThreadCache.get(sourceProfile)?.get(threadId);
+    if (!archived) {
+      throw new Error(`Source thread not found after restore: ${threadId}`);
+    }
+    return archived;
   }
 
   private async assertProfileSelectable(sourceProfile: string): Promise<void> {

--- a/apps/desktop/src/main/app-server/thread-migration-service.ts
+++ b/apps/desktop/src/main/app-server/thread-migration-service.ts
@@ -513,6 +513,7 @@ function normalizeSourceThread(
     ...(thread.updatedAt ? { updatedAt: thread.updatedAt } : {}),
     ...(thread.archivedAt ? { archivedAt: thread.archivedAt } : {}),
     ...(thread.gitBranch ? { gitBranch: thread.gitBranch } : {}),
+    ...(thread.gitOriginUrl ? { gitOriginUrl: thread.gitOriginUrl } : {}),
     linkedDirectories: thread.linkedDirectories ?? [],
     ...(thread.rolloutPath ? { rolloutPath: thread.rolloutPath } : {}),
   };
@@ -582,6 +583,7 @@ function toNavigationThreadSummary(
     ...(thread.updatedAt ? { updatedAt: thread.updatedAt } : {}),
     ...(thread.archivedAt ? { archivedAt: thread.archivedAt } : {}),
     ...(thread.gitBranch ? { gitBranch: thread.gitBranch } : {}),
+    ...(thread.gitOriginUrl ? { gitOriginUrl: thread.gitOriginUrl } : {}),
   };
 }
 

--- a/apps/desktop/src/main/app-server/thread-migration-service.ts
+++ b/apps/desktop/src/main/app-server/thread-migration-service.ts
@@ -372,7 +372,7 @@ function normalizeSourceThread(
     ...(thread.updatedAt ? { updatedAt: thread.updatedAt } : {}),
     ...(thread.archivedAt ? { archivedAt: thread.archivedAt } : {}),
     ...(thread.gitBranch ? { gitBranch: thread.gitBranch } : {}),
-    linkedDirectories: thread.linkedDirectories,
+    linkedDirectories: thread.linkedDirectories ?? [],
     ...(thread.rolloutPath ? { rolloutPath: thread.rolloutPath } : {}),
   };
 }

--- a/apps/desktop/src/main/app-server/thread-migration-service.ts
+++ b/apps/desktop/src/main/app-server/thread-migration-service.ts
@@ -194,15 +194,16 @@ export class ThreadMigrationService {
       if (!sourceThread.rolloutPath) {
         throw new Error("Source CAS did not provide a rollout path for this thread.");
       }
-      const sourceHasProfileOwnedWorktree = hasProfileOwnedWorktree(sourceThread);
-      if (request.operation === "copy" && sourceHasProfileOwnedWorktree) {
+      if (
+        request.operation === "copy" &&
+        request.copyStrategy &&
+        request.copyStrategy !== "detached-destination"
+      ) {
         throw new Error(
-          "Copy is disabled for selected managed worktrees. Use Move so the destination worktree is created before the source is archived.",
+          "Only detached destination Copy is implemented for branch/worktree migration.",
         );
       }
-      const destinationWorkspace = resolveDestinationWorkspace(sourceThread, {
-        sourceHasProfileOwnedWorktree,
-      });
+      const destinationWorkspace = resolveDestinationWorkspace(sourceThread, request);
 
       item.status = "copying";
       const destination = await this.options.destination.forkThread({
@@ -213,6 +214,9 @@ export class ThreadMigrationService {
         directoryLabel: destinationWorkspace.directoryLabel,
         directoryPath: destinationWorkspace.directoryPath,
         workMode: destinationWorkspace.workMode,
+        ...(destinationWorkspace.worktreeBranchMode
+          ? { worktreeBranchMode: destinationWorkspace.worktreeBranchMode }
+          : {}),
         ...(destinationWorkspace.branchName
           ? { branchName: destinationWorkspace.branchName }
           : {}),
@@ -474,30 +478,39 @@ function resolveDestinationWorkspace(
     InternalSourceThread,
     "gitBranch" | "linkedDirectories" | "projectKey" | "title"
   >,
-  options: { sourceHasProfileOwnedWorktree: boolean },
+  request: Pick<StartThreadMigrationRequest, "copyStrategy" | "operation">,
 ): {
   branchName?: string;
   directoryLabel: string;
   directoryPath?: string;
   workMode: ForkThreadRequest["workMode"];
+  worktreeBranchMode?: ForkThreadRequest["worktreeBranchMode"];
 } {
   const directoryPath = resolveDestinationDirectoryPath(thread);
-  if (options.sourceHasProfileOwnedWorktree && !directoryPath) {
+  const sourceHasProfileOwnedWorktree = hasProfileOwnedWorktree(thread);
+  if (sourceHasProfileOwnedWorktree && !directoryPath) {
     throw new Error(
       "Move is blocked because the source managed worktree did not report its repository path.",
     );
   }
-
   const branchName =
-    options.sourceHasProfileOwnedWorktree && thread.gitBranch !== "HEAD"
-      ? thread.gitBranch
-      : undefined;
+    thread.gitBranch && thread.gitBranch !== "HEAD" ? thread.gitBranch : undefined;
+  const needsDestinationWorktree =
+    Boolean(directoryPath && branchName) &&
+    (request.operation === "move" ||
+      request.copyStrategy === "detached-destination");
 
   return {
     directoryLabel: directoryPath ? path.basename(directoryPath) : thread.title,
     ...(directoryPath ? { directoryPath } : {}),
     ...(branchName ? { branchName } : {}),
-    workMode: options.sourceHasProfileOwnedWorktree ? "worktree" : "local",
+    ...(needsDestinationWorktree
+      ? {
+          worktreeBranchMode:
+            request.operation === "move" ? "attached" : "detached",
+        }
+      : {}),
+    workMode: needsDestinationWorktree ? "worktree" : "local",
   };
 }
 

--- a/apps/desktop/src/main/app-server/thread-migration-service.ts
+++ b/apps/desktop/src/main/app-server/thread-migration-service.ts
@@ -7,7 +7,6 @@ import {
   type AppServerThreadReplay,
   type ForkThreadRequest,
   type ForkThreadResponse,
-  type LinkedDirectorySummary,
   type ListThreadMigrationSourceThreadsRequest,
   type ListThreadMigrationSourceThreadsResponse,
   type ListThreadMigrationSourcesResponse,
@@ -195,7 +194,7 @@ export class ThreadMigrationService {
       if (!sourceThread.rolloutPath) {
         throw new Error("Source CAS did not provide a rollout path for this thread.");
       }
-      if (hasProfileOwnedWorktree(sourceThread.linkedDirectories)) {
+      if (hasProfileOwnedWorktree(sourceThread)) {
         throw new Error(
           request.operation === "copy"
             ? "Copy is blocked until branch conflict strategies for profile-owned worktrees are implemented."
@@ -452,11 +451,16 @@ function stripInternalThread(
   return publicThread;
 }
 
-function hasProfileOwnedWorktree(directories: LinkedDirectorySummary[]): boolean {
-  return directories.some(
-    (directory) =>
-      isToolManagedWorktreePath(directory.worktreePath) ||
-      isToolManagedWorktreePath(directory.path),
+function hasProfileOwnedWorktree(
+  thread: Pick<InternalSourceThread, "linkedDirectories" | "projectKey">,
+): boolean {
+  return Boolean(
+    (thread.projectKey && isToolManagedWorktreePath(thread.projectKey)) ||
+      thread.linkedDirectories.some(
+        (directory) =>
+          isToolManagedWorktreePath(directory.worktreePath) ||
+          isToolManagedWorktreePath(directory.path),
+      ),
   );
 }
 

--- a/apps/desktop/src/main/app-server/thread-migration-service.ts
+++ b/apps/desktop/src/main/app-server/thread-migration-service.ts
@@ -194,25 +194,28 @@ export class ThreadMigrationService {
       if (!sourceThread.rolloutPath) {
         throw new Error("Source CAS did not provide a rollout path for this thread.");
       }
-      if (hasProfileOwnedWorktree(sourceThread)) {
+      const sourceHasProfileOwnedWorktree = hasProfileOwnedWorktree(sourceThread);
+      if (request.operation === "copy" && sourceHasProfileOwnedWorktree) {
         throw new Error(
-          request.operation === "copy"
-            ? "Copy is blocked until branch conflict strategies for profile-owned worktrees are implemented."
-            : "Move is blocked until this thread's profile-owned worktree can be migrated first.",
+          "Copy is disabled for selected managed worktrees. Use Move so the destination worktree is created before the source is archived.",
         );
       }
+      const destinationWorkspace = resolveDestinationWorkspace(sourceThread, {
+        sourceHasProfileOwnedWorktree,
+      });
 
       item.status = "copying";
       const destination = await this.options.destination.forkThread({
         backend: "codex",
         sourceThreadId: sourceThread.threadId,
         sourceThreadPath: sourceThread.rolloutPath,
-        directoryKind: sourceThread.projectKey ? "directory" : "workspace",
-        directoryLabel: sourceThread.projectKey
-          ? path.basename(sourceThread.projectKey)
-          : sourceThread.title,
-        directoryPath: sourceThread.projectKey,
-        workMode: "local",
+        directoryKind: destinationWorkspace.directoryPath ? "directory" : "workspace",
+        directoryLabel: destinationWorkspace.directoryLabel,
+        directoryPath: destinationWorkspace.directoryPath,
+        workMode: destinationWorkspace.workMode,
+        ...(destinationWorkspace.branchName
+          ? { branchName: destinationWorkspace.branchName }
+          : {}),
       });
       item.destinationThreadId = destination.threadId;
 
@@ -464,6 +467,56 @@ function hasProfileOwnedWorktree(
             isToolManagedWorktreePath(directory.path)),
       ),
   );
+}
+
+function resolveDestinationWorkspace(
+  thread: Pick<
+    InternalSourceThread,
+    "gitBranch" | "linkedDirectories" | "projectKey" | "title"
+  >,
+  options: { sourceHasProfileOwnedWorktree: boolean },
+): {
+  branchName?: string;
+  directoryLabel: string;
+  directoryPath?: string;
+  workMode: ForkThreadRequest["workMode"];
+} {
+  const directoryPath = resolveDestinationDirectoryPath(thread);
+  if (options.sourceHasProfileOwnedWorktree && !directoryPath) {
+    throw new Error(
+      "Move is blocked because the source managed worktree did not report its repository path.",
+    );
+  }
+
+  const branchName =
+    options.sourceHasProfileOwnedWorktree && thread.gitBranch !== "HEAD"
+      ? thread.gitBranch
+      : undefined;
+
+  return {
+    directoryLabel: directoryPath ? path.basename(directoryPath) : thread.title,
+    ...(directoryPath ? { directoryPath } : {}),
+    ...(branchName ? { branchName } : {}),
+    workMode: options.sourceHasProfileOwnedWorktree ? "worktree" : "local",
+  };
+}
+
+function resolveDestinationDirectoryPath(
+  thread: Pick<InternalSourceThread, "linkedDirectories" | "projectKey">,
+): string | undefined {
+  for (const directory of thread.linkedDirectories) {
+    const directoryPath = directory.path?.trim();
+    if (directoryPath && !isToolManagedWorktreePath(directoryPath)) {
+      return directoryPath;
+    }
+  }
+
+  const projectKey = thread.projectKey?.trim();
+  if (projectKey && !isToolManagedWorktreePath(projectKey)) {
+    return projectKey;
+  }
+
+  return undefined;
 }
 
 function validateReplay(

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -154,8 +154,13 @@ type RawCodexThreadSummary = Omit<
   "source" | "linkedDirectories"
 > & {
   originator?: string;
+  path?: string;
   projectKey?: string;
   gitOriginUrl?: string;
+};
+
+export type CodexThreadMigrationMetadata = AppServerThreadSummary & {
+  rolloutPath?: string;
 };
 
 type RawCodexThreadListPage = {
@@ -3812,6 +3817,9 @@ function extractThreadsFromValue(value: unknown): RawCodexThreadSummary[] {
     const originator =
       pickString(record, ["originator"]) ??
       pickString(sessionRecord ?? {}, ["originator"]);
+    const rolloutPath =
+      pickString(record, ["path"]) ??
+      pickString(sessionRecord ?? {}, ["path"]);
     const titleInfo = getThreadTitleInfo(record);
     const rawDerivedTitle =
       pickString(record, ["preview", "snippet", "firstUserMessage", "first_user_message"]) ??
@@ -3849,6 +3857,7 @@ function extractThreadsFromValue(value: unknown): RawCodexThreadSummary[] {
           ? undefined
           : summary,
       originator,
+      path: rolloutPath,
       projectKey,
       model:
         pickString(record, ["model"]) ??
@@ -4246,6 +4255,7 @@ function buildThreadStartPayload(params: {
 
 function buildThreadForkPayload(params: {
   threadId: string;
+  path?: string;
   cwd?: string;
   model?: string;
   approvalPolicy?: string;
@@ -4260,6 +4270,9 @@ function buildThreadForkPayload(params: {
     threadSource: "user",
   };
 
+  if (params.path?.trim()) {
+    base.path = params.path.trim();
+  }
   if (params.cwd?.trim()) {
     base.cwd = params.cwd.trim();
   }
@@ -4994,6 +5007,33 @@ export class CodexAppServerClient {
     });
   }
 
+  async listThreadsForMigration(params?: {
+    archived?: boolean;
+    filter?: string;
+  }): Promise<CodexThreadMigrationMetadata[]> {
+    await this.ensureInitialized();
+
+    const rawThreads = filterVisibleCodexThreads(
+      await requestThreadListPages({
+        archived: params?.archived === true,
+        client: this.connection,
+        filter: params?.filter,
+        requestTimeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+      }),
+    );
+    const enrichedThreads = await this.enrichThreads(rawThreads, {
+      enrichDirectories: true,
+    });
+    const rolloutPathsByThreadId = new Map(
+      rawThreads.map((thread) => [thread.id, thread.path?.trim() || undefined]),
+    );
+
+    return enrichedThreads.map((thread) => ({
+      ...thread,
+      rolloutPath: rolloutPathsByThreadId.get(thread.id),
+    }));
+  }
+
   private getCachedArchivedThreadMetadata(filter?: string): RawCodexThreadSummary[] {
     return this.archivedThreadMetadataByFilter.get(buildThreadMetadataCacheKey(filter)) ?? [];
   }
@@ -5068,6 +5108,7 @@ export class CodexAppServerClient {
         const {
           gitOriginUrl: _gitOriginUrl,
           originator: _originator,
+          path: _path,
           ...publicThread
         } = thread;
         const projectKey = publicThread.projectKey?.trim() || undefined;
@@ -5110,6 +5151,7 @@ export class CodexAppServerClient {
         const enrichment = await this.threadDirectoryEnricher(projectKey);
         const {
           originator: _originator,
+          path: _path,
           ...publicThread
         } = thread;
         return {
@@ -5280,6 +5322,7 @@ export class CodexAppServerClient {
 
   async forkThread(params: {
     threadId: string;
+    path?: string;
     cwd?: string;
     model?: string;
     approvalPolicy?: string;

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -60,6 +60,7 @@ import type {
   ListThreadMigrationSourceThreadsRequest,
   ListThreadMigrationSourceThreadsResponse,
   ListThreadMigrationSourcesResponse,
+  RetryThreadMigrationRequest,
   StartThreadMigrationRequest,
   StartThreadMigrationResponse,
   ResetDirectoryLaunchpadRequest,
@@ -96,6 +97,7 @@ import {
   APP_SERVER_READ_THREAD_CHANNEL,
   THREAD_MIGRATION_LIST_SOURCES_CHANNEL,
   THREAD_MIGRATION_LIST_SOURCE_THREADS_CHANNEL,
+  THREAD_MIGRATION_RETRY_CHANNEL,
   THREAD_MIGRATION_START_CHANNEL,
   FOCUSED_DIFF_ANALYZE_CHANNEL,
   NAVIGATION_GET_GH_STATUS_CHANNEL,
@@ -494,6 +496,12 @@ class DesktopAppServerService {
     request: StartThreadMigrationRequest,
   ): Promise<StartThreadMigrationResponse> {
     return await this.getThreadMigrationService().startMigration(request);
+  }
+
+  async retryThreadMigration(
+    request: RetryThreadMigrationRequest,
+  ): Promise<StartThreadMigrationResponse> {
+    return await this.getThreadMigrationService().retryMigration(request);
   }
 
   async archiveWorktree(
@@ -1599,6 +1607,16 @@ export function registerAppServerIpcHandlers(): void {
       return await appServerService.startThreadMigration(request);
     },
   );
+  ipcMain.removeHandler(THREAD_MIGRATION_RETRY_CHANNEL);
+  ipcMain.handle(
+    THREAD_MIGRATION_RETRY_CHANNEL,
+    async (
+      _event,
+      request: RetryThreadMigrationRequest,
+    ): Promise<StartThreadMigrationResponse> => {
+      return await appServerService.retryThreadMigration(request);
+    },
+  );
   ipcMain.removeHandler(APP_SERVER_ARCHIVE_WORKTREE_CHANNEL);
   ipcMain.handle(
     APP_SERVER_ARCHIVE_WORKTREE_CHANNEL,
@@ -1850,6 +1868,7 @@ export async function disposeAppServerIpcHandlers(): Promise<void> {
   ipcMain.removeHandler(THREAD_MIGRATION_LIST_SOURCES_CHANNEL);
   ipcMain.removeHandler(THREAD_MIGRATION_LIST_SOURCE_THREADS_CHANNEL);
   ipcMain.removeHandler(THREAD_MIGRATION_START_CHANNEL);
+  ipcMain.removeHandler(THREAD_MIGRATION_RETRY_CHANNEL);
   ipcMain.removeHandler(APP_SERVER_ARCHIVE_WORKTREE_CHANNEL);
   ipcMain.removeHandler(APP_SERVER_RESTORE_WORKTREE_CHANNEL);
   ipcMain.removeHandler(APP_SERVER_HANDOFF_THREAD_WORKSPACE_CHANNEL);

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -57,6 +57,11 @@ import type {
   SetThreadPinResponse,
   SetThreadReactionRequest,
   SetThreadReactionResponse,
+  ListThreadMigrationSourceThreadsRequest,
+  ListThreadMigrationSourceThreadsResponse,
+  ListThreadMigrationSourcesResponse,
+  StartThreadMigrationRequest,
+  StartThreadMigrationResponse,
   ResetDirectoryLaunchpadRequest,
   ResetDirectoryLaunchpadResponse,
   RenameThreadRequest,
@@ -89,6 +94,9 @@ import {
   APP_SERVER_RESTORE_WORKTREE_CHANNEL,
   APP_SERVER_RENAME_THREAD_CHANNEL,
   APP_SERVER_READ_THREAD_CHANNEL,
+  THREAD_MIGRATION_LIST_SOURCES_CHANNEL,
+  THREAD_MIGRATION_LIST_SOURCE_THREADS_CHANNEL,
+  THREAD_MIGRATION_START_CHANNEL,
   FOCUSED_DIFF_ANALYZE_CHANNEL,
   NAVIGATION_GET_GH_STATUS_CHANNEL,
   NAVIGATION_REFRESH_DIRECTORY_GIT_STATUSES_CHANNEL,
@@ -118,6 +126,7 @@ import { GithubPrFetcher } from "../pr-status/github-pr-fetcher";
 import { detectPullRequestsForThread } from "../pr-status/pr-detection";
 import { getDesktopSettingsService } from "../settings/desktop-settings-singleton";
 import { resolveScratchProjectsRoots } from "../app-server/scratch-projects";
+import { ThreadMigrationService } from "../app-server/thread-migration-service";
 
 const isDevelopment = process.env.NODE_ENV !== "production";
 const THREAD_PR_REFRESH_MIN_INTERVAL_MS = 60_000;
@@ -342,6 +351,16 @@ class DesktopAppServerService {
   >();
   private readonly pendingDirectoryGitStatusRefreshes = new Map<string, Promise<void>>();
   private readonly pendingDirectoryGitStatusKeys = new Set<string>();
+  private threadMigrationService: ThreadMigrationService | null = null;
+
+  private getThreadMigrationService(): ThreadMigrationService {
+    if (!this.threadMigrationService) {
+      this.threadMigrationService = new ThreadMigrationService({
+        destination: getDesktopBackendRegistry(),
+      });
+    }
+    return this.threadMigrationService;
+  }
 
   async listThreads(
     request: AppServerListThreadsRequest = {}
@@ -459,6 +478,22 @@ class DesktopAppServerService {
     });
 
     return response;
+  }
+
+  async listThreadMigrationSources(): Promise<ListThreadMigrationSourcesResponse> {
+    return await this.getThreadMigrationService().listSources();
+  }
+
+  async listThreadMigrationSourceThreads(
+    request: ListThreadMigrationSourceThreadsRequest,
+  ): Promise<ListThreadMigrationSourceThreadsResponse> {
+    return await this.getThreadMigrationService().listSourceThreads(request);
+  }
+
+  async startThreadMigration(
+    request: StartThreadMigrationRequest,
+  ): Promise<StartThreadMigrationResponse> {
+    return await this.getThreadMigrationService().startMigration(request);
   }
 
   async archiveWorktree(
@@ -1442,6 +1477,8 @@ class DesktopAppServerService {
     this.directoryGitStatusCacheLoaded = false;
     this.automaticDirectoryGitStatusRefreshesStarted = 0;
     this.lastDirectoriesByKey.clear();
+    await this.threadMigrationService?.dispose();
+    this.threadMigrationService = null;
     await disposeDesktopBackendRegistry();
   }
 
@@ -1533,6 +1570,33 @@ export function registerAppServerIpcHandlers(): void {
       request: RestoreThreadRequest,
     ): Promise<RestoreThreadResponse> => {
       return await appServerService.restoreThread(request);
+    },
+  );
+  ipcMain.removeHandler(THREAD_MIGRATION_LIST_SOURCES_CHANNEL);
+  ipcMain.handle(
+    THREAD_MIGRATION_LIST_SOURCES_CHANNEL,
+    async (): Promise<ListThreadMigrationSourcesResponse> => {
+      return await appServerService.listThreadMigrationSources();
+    },
+  );
+  ipcMain.removeHandler(THREAD_MIGRATION_LIST_SOURCE_THREADS_CHANNEL);
+  ipcMain.handle(
+    THREAD_MIGRATION_LIST_SOURCE_THREADS_CHANNEL,
+    async (
+      _event,
+      request: ListThreadMigrationSourceThreadsRequest,
+    ): Promise<ListThreadMigrationSourceThreadsResponse> => {
+      return await appServerService.listThreadMigrationSourceThreads(request);
+    },
+  );
+  ipcMain.removeHandler(THREAD_MIGRATION_START_CHANNEL);
+  ipcMain.handle(
+    THREAD_MIGRATION_START_CHANNEL,
+    async (
+      _event,
+      request: StartThreadMigrationRequest,
+    ): Promise<StartThreadMigrationResponse> => {
+      return await appServerService.startThreadMigration(request);
     },
   );
   ipcMain.removeHandler(APP_SERVER_ARCHIVE_WORKTREE_CHANNEL);
@@ -1783,6 +1847,9 @@ export async function disposeAppServerIpcHandlers(): Promise<void> {
   ipcMain.removeHandler(APP_SERVER_READ_THREAD_CHANNEL);
   ipcMain.removeHandler(APP_SERVER_ARCHIVE_THREAD_CHANNEL);
   ipcMain.removeHandler(APP_SERVER_RESTORE_THREAD_CHANNEL);
+  ipcMain.removeHandler(THREAD_MIGRATION_LIST_SOURCES_CHANNEL);
+  ipcMain.removeHandler(THREAD_MIGRATION_LIST_SOURCE_THREADS_CHANNEL);
+  ipcMain.removeHandler(THREAD_MIGRATION_START_CHANNEL);
   ipcMain.removeHandler(APP_SERVER_ARCHIVE_WORKTREE_CHANNEL);
   ipcMain.removeHandler(APP_SERVER_RESTORE_WORKTREE_CHANNEL);
   ipcMain.removeHandler(APP_SERVER_HANDOFF_THREAD_WORKSPACE_CHANNEL);

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -92,6 +92,7 @@ import type {
   ListThreadMigrationSourceThreadsRequest,
   ListThreadMigrationSourceThreadsResponse,
   ListThreadMigrationSourcesResponse,
+  RetryThreadMigrationRequest,
   MessagingPlatformStatus,
   MessagingPlatformStatusEvent,
   MessagingPairingEntry,
@@ -330,6 +331,7 @@ import {
   SETTINGS_WRITE_CONFIG_CHANNEL,
   THREAD_MIGRATION_LIST_SOURCES_CHANNEL,
   THREAD_MIGRATION_LIST_SOURCE_THREADS_CHANNEL,
+  THREAD_MIGRATION_RETRY_CHANNEL,
   THREAD_MIGRATION_START_CHANNEL,
   WINDOW_FOCUS_SYNC_CHANNEL,
   WINDOW_OPEN_NEW_THREAD_CHANNEL,
@@ -611,6 +613,10 @@ const desktopApi = Object.freeze({
     request: StartThreadMigrationRequest,
   ): Promise<StartThreadMigrationResponse> =>
     await ipcRenderer.invoke(THREAD_MIGRATION_START_CHANNEL, request),
+  retryThreadMigration: async (
+    request: RetryThreadMigrationRequest,
+  ): Promise<StartThreadMigrationResponse> =>
+    await ipcRenderer.invoke(THREAD_MIGRATION_RETRY_CHANNEL, request),
   archiveWorktree: async (
     request: ArchiveWorktreeRequest,
   ): Promise<ArchiveWorktreeResponse> =>

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -89,6 +89,9 @@ import type {
   ListMessagingActivityResponse,
   ListMessagingPairingRequestsRequest,
   ListMessagingPairingRequestsResponse,
+  ListThreadMigrationSourceThreadsRequest,
+  ListThreadMigrationSourceThreadsResponse,
+  ListThreadMigrationSourcesResponse,
   MessagingPlatformStatus,
   MessagingPlatformStatusEvent,
   MessagingPairingEntry,
@@ -124,6 +127,8 @@ import type {
   RunAutomationNowResponse,
   StartReviewRequest,
   StartReviewResponse,
+  StartThreadMigrationRequest,
+  StartThreadMigrationResponse,
   StartThreadRequest,
   StartThreadResponse,
   StartTurnRequest,
@@ -323,6 +328,9 @@ import {
   SETTINGS_START_CODEX_AUTH_PROFILE_LOGIN_CHANNEL,
   SETTINGS_TEST_CREDENTIALS_CHANNEL,
   SETTINGS_WRITE_CONFIG_CHANNEL,
+  THREAD_MIGRATION_LIST_SOURCES_CHANNEL,
+  THREAD_MIGRATION_LIST_SOURCE_THREADS_CHANNEL,
+  THREAD_MIGRATION_START_CHANNEL,
   WINDOW_FOCUS_SYNC_CHANNEL,
   WINDOW_OPEN_NEW_THREAD_CHANNEL,
   WINDOW_OPEN_SETTINGS_CHANNEL,
@@ -593,6 +601,16 @@ const desktopApi = Object.freeze({
     request: RestoreThreadRequest,
   ): Promise<RestoreThreadResponse> =>
     await ipcRenderer.invoke(APP_SERVER_RESTORE_THREAD_CHANNEL, request),
+  listThreadMigrationSources: async (): Promise<ListThreadMigrationSourcesResponse> =>
+    await ipcRenderer.invoke(THREAD_MIGRATION_LIST_SOURCES_CHANNEL),
+  listThreadMigrationSourceThreads: async (
+    request: ListThreadMigrationSourceThreadsRequest,
+  ): Promise<ListThreadMigrationSourceThreadsResponse> =>
+    await ipcRenderer.invoke(THREAD_MIGRATION_LIST_SOURCE_THREADS_CHANNEL, request),
+  startThreadMigration: async (
+    request: StartThreadMigrationRequest,
+  ): Promise<StartThreadMigrationResponse> =>
+    await ipcRenderer.invoke(THREAD_MIGRATION_START_CHANNEL, request),
   archiveWorktree: async (
     request: ArchiveWorktreeRequest,
   ): Promise<ArchiveWorktreeResponse> =>

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -28,7 +28,7 @@ import {
   buildSlackPatchDelta,
   buildTelegramPatchDelta,
 } from "./settings-patch-delta";
-import { Fragment, useCallback, useEffect, useState } from "react";
+import { Fragment, useCallback, useEffect, useRef, useState } from "react";
 
 export type SettingsSection =
   | "general"
@@ -112,6 +112,44 @@ export function SettingsScreen(props: {
   useEffect(() => {
     if (props.initialSection) setSection(props.initialSection);
   }, [props.initialSection]);
+  const scrollClampFrameRef = useRef<number | undefined>(undefined);
+  useEffect(() => {
+    const clampDocumentScroll = () => {
+      if (window.scrollX === 0 && window.scrollY === 0) {
+        return;
+      }
+      const scrollX = window.scrollX;
+      const scrollY = window.scrollY;
+      window.scrollTo(0, 0);
+      void props.desktopApi?.logRendererDiagnostic?.({
+        level: "warn",
+        message: "Settings document scroll clamped.",
+        details: {
+          section,
+          scrollX,
+          scrollY,
+        },
+      })?.catch(() => undefined);
+    };
+    const scheduleClamp = () => {
+      if (scrollClampFrameRef.current !== undefined) {
+        return;
+      }
+      scrollClampFrameRef.current = window.requestAnimationFrame(() => {
+        scrollClampFrameRef.current = undefined;
+        clampDocumentScroll();
+      });
+    };
+    clampDocumentScroll();
+    window.addEventListener("scroll", scheduleClamp, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", scheduleClamp);
+      if (scrollClampFrameRef.current !== undefined) {
+        window.cancelAnimationFrame(scrollClampFrameRef.current);
+        scrollClampFrameRef.current = undefined;
+      }
+    };
+  }, [props.desktopApi, section]);
   const snapshot = props.settings.snapshot;
   const activeSectionLabel =
     SECTIONS.find((entry) => entry.id === section)?.label ?? "Settings";

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -17,6 +17,7 @@ import { ModelsSettings } from "./ModelsSettings";
 import { ProfilesSettings } from "./ProfilesSettings";
 import { ApplicationsSettings } from "./ApplicationsSettings";
 import { ArchivedThreadsSettings } from "./ArchivedThreadsSettings";
+import { ThreadManagementSettings } from "./ThreadManagementSettings";
 import { MessagingStatusBar } from "../messaging-status/MessagingStatusBar";
 import { WorktreesSettings } from "./WorktreesSettings";
 import {
@@ -38,6 +39,7 @@ export type SettingsSection =
   | "profiles"
   | "applications"
   | "worktrees"
+  | "thread-management"
   | "archived"
   | "about";
 
@@ -49,6 +51,7 @@ const SECTIONS: Array<{ id: SettingsSection; label: string }> = [
   { id: "agents", label: "ACP Agents" },
   { id: "messaging", label: "Messaging" },
   { id: "worktrees", label: "Worktrees" },
+  { id: "thread-management", label: "Thread Management" },
   { id: "archived", label: "Archived Threads" },
   { id: "experimental", label: "Experimental" },
   { id: "about", label: "About" },
@@ -72,6 +75,7 @@ const SECTION_LABELS = new Map(
 const ORDERED_SECTION_IDS: SettingsSection[] = [
   ...PRIMARY_SECTIONS,
   "worktrees",
+  "thread-management",
   "archived",
   "experimental",
   "about",
@@ -478,6 +482,10 @@ function SettingsSectionBody(props: {
 
   if (props.section === "archived") {
     return <ArchivedThreadsSettings desktopApi={props.desktopApi} />;
+  }
+
+  if (props.section === "thread-management") {
+    return <ThreadManagementSettings desktopApi={props.desktopApi} />;
   }
 
   if (props.section === "agents") {

--- a/apps/desktop/src/renderer/src/features/settings/ThreadManagementSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ThreadManagementSettings.tsx
@@ -303,7 +303,25 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
         ) : null}
         {threadsState.projects.map((project) => (
           <div className="settings-thread-management__project" key={project.key}>
-            <div className="settings-thread-management__project-head">
+            <label className="settings-thread-management__project-head">
+              <input
+                checked={project.threads.every((thread) =>
+                  selectedThreadIds.has(thread.threadId),
+                )}
+                className="settings-thread-management__checkbox-input"
+                type="checkbox"
+                onChange={() => selectProject(project)}
+              />
+              <span
+                aria-hidden="true"
+                className={`settings-thread-management__checkbox settings-thread-management__checkbox--project${
+                  project.threads.every((thread) =>
+                    selectedThreadIds.has(thread.threadId),
+                  )
+                    ? " is-checked"
+                    : ""
+                }`}
+              />
               <div>
                 <p className="settings-thread-management__project-title">
                   {project.label}
@@ -314,32 +332,14 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
                   </p>
                 ) : null}
               </div>
-              <label className="settings-thread-management__project-select">
-                <input
-                  checked={project.threads.every((thread) =>
-                    selectedThreadIds.has(thread.threadId),
-                  )}
-                  className="settings-thread-management__checkbox-input"
-                  type="checkbox"
-                  onChange={() => selectProject(project)}
-                />
-                <span
-                  aria-hidden="true"
-                  className={`settings-thread-management__checkbox${
-                    project.threads.every((thread) =>
-                      selectedThreadIds.has(thread.threadId),
-                    )
-                      ? " is-checked"
-                      : ""
-                  }`}
-                />
+              <span className="settings-thread-management__project-select">
                 {project.threads.every((thread) =>
                   selectedThreadIds.has(thread.threadId),
                 )
                   ? "Clear"
                   : "Select project"}
-              </label>
-            </div>
+              </span>
+            </label>
             <div>
               {project.threads.map((thread) => (
                 <label

--- a/apps/desktop/src/renderer/src/features/settings/ThreadManagementSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ThreadManagementSettings.tsx
@@ -1,0 +1,517 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  isToolManagedWorktreePath,
+  type ListThreadMigrationSourcesResponse,
+  type StartThreadMigrationResponse,
+  type ThreadIdentifier,
+  type ThreadMigrationCopyStrategy,
+  type ThreadMigrationOperation,
+  type ThreadMigrationRunItem,
+  type ThreadMigrationSourceProjectGroup,
+  type ThreadMigrationSourceProfileSummary,
+} from "@pwragent/shared";
+import type { DesktopApi } from "../../lib/desktop-api";
+import {
+  SettingsPanelHead,
+  SettingsSection,
+  SettingsSectionStack,
+} from "./SettingsLayout";
+
+type SourceThreadsState = {
+  error?: string;
+  fetchedAt?: number;
+  loading: boolean;
+  projects: ThreadMigrationSourceProjectGroup[];
+};
+
+const dateFormatter = new Intl.DateTimeFormat(undefined, {
+  month: "short",
+  day: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+});
+
+export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
+  const [sources, setSources] = useState<ListThreadMigrationSourcesResponse>();
+  const [sourcesError, setSourcesError] = useState<string>();
+  const [sourcesLoading, setSourcesLoading] = useState(true);
+  const [selectedProfile, setSelectedProfile] = useState<string>();
+  const [threadsState, setThreadsState] = useState<SourceThreadsState>({
+    loading: false,
+    projects: [],
+  });
+  const [selectedThreadIds, setSelectedThreadIds] = useState<Set<ThreadIdentifier>>(
+    () => new Set(),
+  );
+  const [operation, setOperation] = useState<ThreadMigrationOperation>("move");
+  const [copyStrategy, setCopyStrategy] =
+    useState<ThreadMigrationCopyStrategy>("source-branch-suffix");
+  const [run, setRun] = useState<StartThreadMigrationResponse>();
+  const [startError, setStartError] = useState<string>();
+  const [starting, setStarting] = useState(false);
+
+  const loadSources = useCallback(async () => {
+    const listSources = props.desktopApi?.listThreadMigrationSources;
+    if (!listSources) {
+      setSourcesError("Desktop bridge is missing listThreadMigrationSources().");
+      setSourcesLoading(false);
+      return;
+    }
+
+    setSourcesLoading(true);
+    setSourcesError(undefined);
+    try {
+      const response = await listSources();
+      setSources(response);
+      setSelectedProfile((current) => {
+        if (current && response.profiles.some((profile) => profile.profile === current)) {
+          return current;
+        }
+        return response.profiles.find((profile) => profile.available)?.profile;
+      });
+    } catch (error) {
+      setSourcesError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setSourcesLoading(false);
+    }
+  }, [props.desktopApi]);
+
+  const loadSourceThreads = useCallback(
+    async (profile: string | undefined) => {
+      if (profile === undefined) {
+        setThreadsState({ loading: false, projects: [] });
+        setSelectedThreadIds(new Set());
+        return;
+      }
+      const listThreads = props.desktopApi?.listThreadMigrationSourceThreads;
+      if (!listThreads) {
+        setThreadsState({
+          error: "Desktop bridge is missing listThreadMigrationSourceThreads().",
+          loading: false,
+          projects: [],
+        });
+        return;
+      }
+
+      setThreadsState((current) => ({
+        ...current,
+        error: undefined,
+        loading: true,
+      }));
+      setSelectedThreadIds(new Set());
+      setRun(undefined);
+      try {
+        const response = await listThreads({ sourceProfile: profile });
+        setThreadsState({
+          fetchedAt: response.fetchedAt,
+          loading: false,
+          projects: response.projects,
+        });
+      } catch (error) {
+        setThreadsState({
+          error: error instanceof Error ? error.message : String(error),
+          loading: false,
+          projects: [],
+        });
+      }
+    },
+    [props.desktopApi],
+  );
+
+  useEffect(() => {
+    void loadSources();
+  }, [loadSources]);
+
+  useEffect(() => {
+    void loadSourceThreads(selectedProfile);
+  }, [loadSourceThreads, selectedProfile]);
+
+  const selectedSource = sources?.profiles.find(
+    (profile) => profile.profile === selectedProfile,
+  );
+  const runItemsByThreadId = useMemo(
+    () =>
+      new Map(
+        run?.items.map((item) => [item.sourceThreadId, item] as const) ?? [],
+      ),
+    [run],
+  );
+  const selectedCount = selectedThreadIds.size;
+  const hasProfileOwnedWorktree = useMemo(
+    () =>
+      threadsState.projects.some((project) =>
+        project.threads.some(
+          (thread) =>
+            selectedThreadIds.has(thread.threadId) &&
+            thread.linkedDirectories.some(
+              (directory) =>
+                isToolManagedWorktreePath(directory.worktreePath) ||
+                isToolManagedWorktreePath(directory.path),
+            ),
+        ),
+      ),
+    [selectedThreadIds, threadsState.projects],
+  );
+  const canStart =
+    Boolean(selectedSource?.available) &&
+    selectedCount > 0 &&
+    !starting &&
+    !threadsState.loading;
+
+  const toggleThread = (threadId: ThreadIdentifier) => {
+    setSelectedThreadIds((current) => {
+      const next = new Set(current);
+      if (next.has(threadId)) {
+        next.delete(threadId);
+      } else {
+        next.add(threadId);
+      }
+      return next;
+    });
+  };
+
+  const selectProject = (project: ThreadMigrationSourceProjectGroup) => {
+    setSelectedThreadIds((current) => {
+      const next = new Set(current);
+      const allSelected = project.threads.every((thread) =>
+        next.has(thread.threadId),
+      );
+      for (const thread of project.threads) {
+        if (allSelected) {
+          next.delete(thread.threadId);
+        } else {
+          next.add(thread.threadId);
+        }
+      }
+      return next;
+    });
+  };
+
+  const startMigration = async () => {
+    const startThreadMigration = props.desktopApi?.startThreadMigration;
+    if (!startThreadMigration || !selectedSource) {
+      setStartError("Desktop bridge is missing startThreadMigration().");
+      return;
+    }
+    setStarting(true);
+    setStartError(undefined);
+    try {
+      const response = await startThreadMigration({
+        sourceProfile: selectedSource.profile,
+        operation,
+        ...(operation === "copy" ? { copyStrategy } : {}),
+        threadIds: [...selectedThreadIds],
+      });
+      setRun(response);
+    } catch (error) {
+      setStartError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setStarting(false);
+    }
+  };
+
+  return (
+    <SettingsSectionStack
+      paneId="thread-management"
+      aria-label="Thread Management settings"
+    >
+      <SettingsPanelHead
+        eyebrow="Thread Management"
+        title="Thread migration"
+        help="Copy or move Codex threads from another Codex auth profile into this profile through Codex App Server."
+        action={
+          <button
+            className="button button--secondary"
+            disabled={sourcesLoading}
+            type="button"
+            onClick={() => {
+              void loadSources();
+            }}
+          >
+            Refresh
+          </button>
+        }
+      />
+
+      <SettingsSection
+        eyebrow="Source"
+        title="Codex profiles"
+        description="The active Codex auth profile is excluded from migration sources."
+        chip={sourcesLoading ? "loading" : `${sources?.profiles.length ?? 0} profiles`}
+        chipKind="muted"
+      >
+        {sourcesLoading ? (
+          <p className="settings-empty settings-thread-management__status">
+            Loading source profiles...
+          </p>
+        ) : null}
+        {sourcesError ? (
+          <p className="settings-row__error settings-thread-management__status" role="alert">
+            {sourcesError}
+          </p>
+        ) : null}
+        {!sourcesLoading && !sourcesError && sources?.profiles.length === 0 ? (
+          <p className="settings-empty settings-thread-management__status">
+            No other Codex profiles found.
+          </p>
+        ) : null}
+        {sources?.profiles.length ? (
+          <div className="settings-paths">
+            {sources.profiles.map((profile) => (
+              <SourceProfileRow
+                key={profile.profile || "__default__"}
+                profile={profile}
+                selected={selectedProfile === profile.profile}
+                onSelect={() => {
+                  if (profile.available) {
+                    setSelectedProfile(profile.profile);
+                  }
+                }}
+              />
+            ))}
+          </div>
+        ) : null}
+      </SettingsSection>
+
+      <SettingsSection
+        eyebrow="Selection"
+        title="Threads"
+        description={selectedSource?.displayName ?? "Choose a source profile."}
+        chip={
+          threadsState.loading
+            ? "loading"
+            : selectedCount
+              ? `${selectedCount} selected`
+              : "none selected"
+        }
+        chipKind={selectedCount ? "ok" : "muted"}
+      >
+        {threadsState.error ? (
+          <p className="settings-row__error settings-thread-management__status" role="alert">
+            {threadsState.error}
+          </p>
+        ) : null}
+        {threadsState.loading ? (
+          <p className="settings-empty settings-thread-management__status">
+            Loading source threads...
+          </p>
+        ) : null}
+        {!threadsState.loading &&
+        !threadsState.error &&
+        selectedSource &&
+        threadsState.projects.length === 0 ? (
+          <p className="settings-empty settings-thread-management__status">
+            No source threads found.
+          </p>
+        ) : null}
+        {threadsState.projects.map((project) => (
+          <div className="settings-thread-management__project" key={project.key}>
+            <div className="settings-thread-management__project-head">
+              <div>
+                <p className="settings-thread-management__project-title">
+                  {project.label}
+                </p>
+                {project.path ? (
+                  <p className="settings-thread-management__project-path">
+                    {project.path}
+                  </p>
+                ) : null}
+              </div>
+              <button
+                className="button button--secondary settings-archive-row__button"
+                type="button"
+                onClick={() => selectProject(project)}
+              >
+                {project.threads.every((thread) =>
+                  selectedThreadIds.has(thread.threadId),
+                )
+                  ? "Clear"
+                  : "Select"}
+              </button>
+            </div>
+            <div>
+              {project.threads.map((thread) => (
+                <button
+                  key={thread.threadId}
+                  className={`settings-archive-row settings-thread-management__thread${
+                    selectedThreadIds.has(thread.threadId) ? " is-selected" : ""
+                  }`}
+                  type="button"
+                  onClick={() => toggleThread(thread.threadId)}
+                >
+                  <span className="settings-archive-row__body">
+                    <span className="settings-archive-row__title">
+                      {thread.title}
+                    </span>
+                    {thread.summary ? (
+                      <span className="settings-archive-row__summary">
+                        {thread.summary}
+                      </span>
+                    ) : null}
+                    <span className="settings-archive-row__meta">
+                      <span>{thread.threadId}</span>
+                      {thread.gitBranch ? <span>{thread.gitBranch}</span> : null}
+                      {thread.updatedAt ? (
+                        <span>Updated {dateFormatter.format(thread.updatedAt)}</span>
+                      ) : null}
+                    </span>
+                  </span>
+                  <span className="settings-archive-row__side">
+                    <RunStatus item={runItemsByThreadId.get(thread.threadId)} />
+                    <span className="settings-pathrow__chip">
+                      {selectedThreadIds.has(thread.threadId)
+                        ? "Selected"
+                        : "Select"}
+                    </span>
+                  </span>
+                </button>
+              ))}
+            </div>
+          </div>
+        ))}
+      </SettingsSection>
+
+      <SettingsSection
+        eyebrow="Run"
+        title="Migration action"
+        description={
+          hasProfileOwnedWorktree
+            ? "Move is guarded until profile-owned worktree relocation is implemented."
+            : "Move copies, validates, then archives source last. Copy leaves source threads active."
+        }
+        chip={operation === "move" ? "recommended" : "advanced"}
+        chipKind={operation === "move" ? "ok" : "warn"}
+      >
+        <div className="settings-thread-management__controls">
+          <div className="settings-thread-management__segmented" role="group">
+            <button
+              className={`button ${
+                operation === "move" ? "button--primary" : "button--secondary"
+              }`}
+              type="button"
+              onClick={() => setOperation("move")}
+            >
+              Move
+            </button>
+            <button
+              className={`button ${
+                operation === "copy" ? "button--primary" : "button--secondary"
+              }`}
+              type="button"
+              onClick={() => setOperation("copy")}
+            >
+              Copy
+            </button>
+          </div>
+          {operation === "copy" ? (
+            <label className="settings-thread-management__strategy">
+              <span>Copy strategy</span>
+              <select
+                className="settings-select"
+                value={copyStrategy}
+                onChange={(event) =>
+                  setCopyStrategy(event.target.value as ThreadMigrationCopyStrategy)
+                }
+              >
+                <option value="source-branch-suffix">Rename source branch</option>
+                <option value="destination-branch-suffix">
+                  Rename destination branch
+                </option>
+                <option value="detached-destination">Detached destination</option>
+              </select>
+            </label>
+          ) : null}
+          <button
+            className="button button--primary"
+            disabled={!canStart}
+            type="button"
+            onClick={() => {
+              void startMigration();
+            }}
+          >
+            {starting
+              ? "Starting"
+              : operation === "move"
+                ? `Move ${selectedCount || ""}`.trim()
+                : `Copy ${selectedCount || ""}`.trim()}
+          </button>
+        </div>
+        {startError ? (
+          <p className="settings-row__error settings-thread-management__status" role="alert">
+            {startError}
+          </p>
+        ) : null}
+        {run ? (
+          <p className="settings-thread-management__status" role="status">
+            Run {run.runId}: {run.items.filter((item) => item.status === "completed").length} of{" "}
+            {run.items.length} completed.
+          </p>
+        ) : null}
+      </SettingsSection>
+    </SettingsSectionStack>
+  );
+}
+
+function SourceProfileRow(props: {
+  profile: ThreadMigrationSourceProfileSummary;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  const label = props.profile.displayName || props.profile.profile || "System default";
+  return (
+    <button
+      className={`settings-pathrow settings-thread-management__profile${
+        props.selected ? " is-selected" : ""
+      }`}
+      disabled={!props.profile.available}
+      type="button"
+      onClick={props.onSelect}
+    >
+      <span className="settings-pathrow__body">
+        <span className="settings-pathrow__title">{label}</span>
+        <span className="settings-pathrow__path">{props.profile.codexHome}</span>
+        {props.profile.accountEmail ? (
+          <span className="settings-pathrow__meta">
+            {props.profile.accountEmail}
+          </span>
+        ) : null}
+        {props.profile.unavailableReason ? (
+          <span className="settings-row__error">
+            {props.profile.unavailableReason}
+          </span>
+        ) : null}
+      </span>
+      <span className="settings-pathrow__chips">
+        <span
+          className={`settings-pathrow__chip ${
+            props.profile.available
+              ? "settings-pathrow__chip--ok"
+              : "settings-pathrow__chip--err"
+          }`}
+        >
+          {props.profile.available ? "Available" : "Unavailable"}
+        </span>
+      </span>
+    </button>
+  );
+}
+
+function RunStatus(props: { item?: ThreadMigrationRunItem }) {
+  if (!props.item) {
+    return null;
+  }
+  return (
+    <span
+      className={`settings-pathrow__chip ${
+        props.item.status === "completed"
+          ? "settings-pathrow__chip--ok"
+          : props.item.status === "failed"
+            ? "settings-pathrow__chip--err"
+            : "settings-pathrow__chip--warn"
+      }`}
+      title={props.item.error}
+    >
+      {props.item.status}
+    </span>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/settings/ThreadManagementSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ThreadManagementSettings.tsx
@@ -4,7 +4,6 @@ import {
   type ListThreadMigrationSourcesResponse,
   type StartThreadMigrationResponse,
   type ThreadIdentifier,
-  type ThreadMigrationCopyStrategy,
   type ThreadMigrationOperation,
   type ThreadMigrationRunItem,
   type ThreadMigrationSourceProjectGroup,
@@ -44,8 +43,6 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
     () => new Set(),
   );
   const [operation, setOperation] = useState<ThreadMigrationOperation>("move");
-  const [copyStrategy, setCopyStrategy] =
-    useState<ThreadMigrationCopyStrategy>("source-branch-suffix");
   const [run, setRun] = useState<StartThreadMigrationResponse>();
   const [startError, setStartError] = useState<string>();
   const [starting, setStarting] = useState(false);
@@ -137,7 +134,7 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
     [run],
   );
   const selectedCount = selectedThreadIds.size;
-  const hasProfileOwnedWorktree = useMemo(
+  const selectedHasProfileOwnedWorktree = useMemo(
     () =>
       threadsState.projects.some((project) =>
         project.threads.some(
@@ -155,6 +152,7 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
   const canStart =
     Boolean(selectedSource?.available) &&
     selectedCount > 0 &&
+    !selectedHasProfileOwnedWorktree &&
     !starting &&
     !threadsState.loading;
 
@@ -199,7 +197,6 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
       const response = await startThreadMigration({
         sourceProfile: selectedSource.profile,
         operation,
-        ...(operation === "copy" ? { copyStrategy } : {}),
         threadIds: [...selectedThreadIds],
       });
       setRun(response);
@@ -317,28 +314,52 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
                   </p>
                 ) : null}
               </div>
-              <button
-                className="button button--secondary settings-archive-row__button"
-                type="button"
-                onClick={() => selectProject(project)}
-              >
+              <label className="settings-thread-management__project-select">
+                <input
+                  checked={project.threads.every((thread) =>
+                    selectedThreadIds.has(thread.threadId),
+                  )}
+                  className="settings-thread-management__checkbox-input"
+                  type="checkbox"
+                  onChange={() => selectProject(project)}
+                />
+                <span
+                  aria-hidden="true"
+                  className={`settings-thread-management__checkbox${
+                    project.threads.every((thread) =>
+                      selectedThreadIds.has(thread.threadId),
+                    )
+                      ? " is-checked"
+                      : ""
+                  }`}
+                />
                 {project.threads.every((thread) =>
                   selectedThreadIds.has(thread.threadId),
                 )
                   ? "Clear"
-                  : "Select"}
-              </button>
+                  : "Select project"}
+              </label>
             </div>
             <div>
               {project.threads.map((thread) => (
-                <button
+                <label
                   key={thread.threadId}
-                  className={`settings-archive-row settings-thread-management__thread${
+                  className={`settings-thread-management__thread${
                     selectedThreadIds.has(thread.threadId) ? " is-selected" : ""
                   }`}
-                  type="button"
-                  onClick={() => toggleThread(thread.threadId)}
                 >
+                  <input
+                    checked={selectedThreadIds.has(thread.threadId)}
+                    className="settings-thread-management__checkbox-input"
+                    type="checkbox"
+                    onChange={() => toggleThread(thread.threadId)}
+                  />
+                  <span
+                    aria-hidden="true"
+                    className={`settings-thread-management__checkbox${
+                      selectedThreadIds.has(thread.threadId) ? " is-checked" : ""
+                    }`}
+                  />
                   <span className="settings-archive-row__body">
                     <span className="settings-archive-row__title">
                       {thread.title}
@@ -358,13 +379,8 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
                   </span>
                   <span className="settings-archive-row__side">
                     <RunStatus item={runItemsByThreadId.get(thread.threadId)} />
-                    <span className="settings-pathrow__chip">
-                      {selectedThreadIds.has(thread.threadId)
-                        ? "Selected"
-                        : "Select"}
-                    </span>
                   </span>
-                </button>
+                </label>
               ))}
             </div>
           </div>
@@ -375,8 +391,8 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
         eyebrow="Run"
         title="Migration action"
         description={
-          hasProfileOwnedWorktree
-            ? "Move is guarded until profile-owned worktree relocation is implemented."
+          selectedHasProfileOwnedWorktree
+            ? "Profile-owned worktree migration is blocked until branch and worktree relocation is implemented."
             : "Move copies, validates, then archives source last. Copy leaves source threads active."
         }
         chip={operation === "move" ? "recommended" : "advanced"}
@@ -403,24 +419,6 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
               Copy
             </button>
           </div>
-          {operation === "copy" ? (
-            <label className="settings-thread-management__strategy">
-              <span>Copy strategy</span>
-              <select
-                className="settings-select"
-                value={copyStrategy}
-                onChange={(event) =>
-                  setCopyStrategy(event.target.value as ThreadMigrationCopyStrategy)
-                }
-              >
-                <option value="source-branch-suffix">Rename source branch</option>
-                <option value="destination-branch-suffix">
-                  Rename destination branch
-                </option>
-                <option value="detached-destination">Detached destination</option>
-              </select>
-            </label>
-          ) : null}
           <button
             className="button button--primary"
             disabled={!canStart}
@@ -439,6 +437,12 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
         {startError ? (
           <p className="settings-row__error settings-thread-management__status" role="alert">
             {startError}
+          </p>
+        ) : null}
+        {selectedHasProfileOwnedWorktree ? (
+          <p className="settings-row__error settings-thread-management__status" role="alert">
+            Selected threads include a profile-owned worktree. This PR blocks
+            that path until branch conflict strategies are implemented.
           </p>
         ) : null}
         {run ? (

--- a/apps/desktop/src/renderer/src/features/settings/ThreadManagementSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ThreadManagementSettings.tsx
@@ -42,10 +42,10 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
   const [selectedThreadIds, setSelectedThreadIds] = useState<Set<ThreadIdentifier>>(
     () => new Set(),
   );
-  const [operation, setOperation] = useState<ThreadMigrationOperation>("move");
   const [run, setRun] = useState<StartThreadMigrationResponse>();
   const [startError, setStartError] = useState<string>();
-  const [starting, setStarting] = useState(false);
+  const [startingOperation, setStartingOperation] =
+    useState<ThreadMigrationOperation>();
   const sourceThreadsRequestIdRef = useRef(0);
 
   const loadSources = useCallback(async () => {
@@ -150,7 +150,7 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
           (thread) =>
             selectedThreadIds.has(thread.threadId) &&
             (isToolManagedWorktreePath(thread.projectKey) ||
-              thread.linkedDirectories.some(
+              (thread.linkedDirectories ?? []).some(
                 (directory) =>
                   isToolManagedWorktreePath(directory.worktreePath) ||
                   isToolManagedWorktreePath(directory.path),
@@ -163,7 +163,7 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
     Boolean(selectedSource?.available) &&
     selectedCount > 0 &&
     !selectedHasProfileOwnedWorktree &&
-    !starting &&
+    !startingOperation &&
     !threadsState.loading;
 
   const toggleThread = (threadId: ThreadIdentifier) => {
@@ -195,13 +195,13 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
     });
   };
 
-  const startMigration = async () => {
+  const startMigration = async (operation: ThreadMigrationOperation) => {
     const startThreadMigration = props.desktopApi?.startThreadMigration;
     if (!startThreadMigration || !selectedSource) {
       setStartError("Desktop bridge is missing startThreadMigration().");
       return;
     }
-    setStarting(true);
+    setStartingOperation(operation);
     setStartError(undefined);
     try {
       const response = await startThreadMigration({
@@ -213,7 +213,7 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
     } catch (error) {
       setStartError(error instanceof Error ? error.message : String(error));
     } finally {
-      setStarting(false);
+      setStartingOperation(undefined);
     }
   };
 
@@ -311,131 +311,128 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
             No source threads found.
           </p>
         ) : null}
-        {threadsState.projects.map((project) => (
-          <div className="settings-thread-management__project" key={project.key}>
-            <label className="settings-thread-management__project-head">
-              <input
-                checked={project.threads.every((thread) =>
-                  selectedThreadIds.has(thread.threadId),
-                )}
-                className="settings-thread-management__checkbox-input"
-                type="checkbox"
-                onChange={() => selectProject(project)}
-              />
-              <span
-                aria-hidden="true"
-                className={`settings-thread-management__checkbox settings-thread-management__checkbox--project${
-                  project.threads.every((thread) =>
-                    selectedThreadIds.has(thread.threadId),
-                  )
-                    ? " is-checked"
-                    : ""
-                }`}
-              />
-              <div>
-                <p className="settings-thread-management__project-title">
-                  {project.label}
-                </p>
-                {project.path ? (
-                  <p className="settings-thread-management__project-path">
-                    {project.path}
-                  </p>
-                ) : null}
-              </div>
-            </label>
-            <div>
-              {project.threads.map((thread) => (
-                <label
-                  key={thread.threadId}
-                  className={`settings-thread-management__thread${
-                    selectedThreadIds.has(thread.threadId) ? " is-selected" : ""
-                  }`}
-                >
+        <div className="settings-thread-management__selection-shell">
+          <div className="settings-thread-management__projects-list">
+            {threadsState.projects.map((project) => (
+              <div className="settings-thread-management__project" key={project.key}>
+                <label className="settings-thread-management__project-head">
                   <input
-                    checked={selectedThreadIds.has(thread.threadId)}
+                    checked={project.threads.every((thread) =>
+                      selectedThreadIds.has(thread.threadId),
+                    )}
                     className="settings-thread-management__checkbox-input"
                     type="checkbox"
-                    onChange={() => toggleThread(thread.threadId)}
+                    onChange={() => selectProject(project)}
                   />
                   <span
                     aria-hidden="true"
-                    className={`settings-thread-management__checkbox${
-                      selectedThreadIds.has(thread.threadId) ? " is-checked" : ""
+                    className={`settings-thread-management__checkbox settings-thread-management__checkbox--project${
+                      project.threads.every((thread) =>
+                        selectedThreadIds.has(thread.threadId),
+                      )
+                        ? " is-checked"
+                        : ""
                     }`}
                   />
-                  <span className="settings-archive-row__body">
-                    <span className="settings-archive-row__title">
-                      {thread.title}
-                    </span>
-                    {thread.summary ? (
-                      <span className="settings-archive-row__summary">
-                        {thread.summary}
-                      </span>
+                  <div>
+                    <p className="settings-thread-management__project-title">
+                      {project.label}
+                    </p>
+                    {project.path ? (
+                      <p className="settings-thread-management__project-path">
+                        {project.path}
+                      </p>
                     ) : null}
-                    <span className="settings-archive-row__meta">
-                      <span>{thread.threadId}</span>
-                      {thread.gitBranch ? <span>{thread.gitBranch}</span> : null}
-                      {thread.updatedAt ? (
-                        <span>Updated {dateFormatter.format(thread.updatedAt)}</span>
-                      ) : null}
-                    </span>
-                  </span>
-                  <span className="settings-archive-row__side">
-                    <RunStatus item={runItemsByThreadId.get(thread.threadId)} />
-                  </span>
+                  </div>
                 </label>
-              ))}
+                <div>
+                  {project.threads.map((thread) => (
+                    <label
+                      key={thread.threadId}
+                      className={`settings-thread-management__thread${
+                        selectedThreadIds.has(thread.threadId) ? " is-selected" : ""
+                      }`}
+                    >
+                      <input
+                        checked={selectedThreadIds.has(thread.threadId)}
+                        className="settings-thread-management__checkbox-input"
+                        type="checkbox"
+                        onChange={() => toggleThread(thread.threadId)}
+                      />
+                      <span
+                        aria-hidden="true"
+                        className={`settings-thread-management__checkbox${
+                          selectedThreadIds.has(thread.threadId)
+                            ? " is-checked"
+                            : ""
+                        }`}
+                      />
+                      <span className="settings-archive-row__body">
+                        <span className="settings-archive-row__title">
+                          {thread.title}
+                        </span>
+                        {thread.summary ? (
+                          <span className="settings-archive-row__summary">
+                            {thread.summary}
+                          </span>
+                        ) : null}
+                        <span className="settings-archive-row__meta">
+                          <span>{thread.threadId}</span>
+                          {thread.gitBranch ? <span>{thread.gitBranch}</span> : null}
+                          {thread.updatedAt ? (
+                            <span>Updated {dateFormatter.format(thread.updatedAt)}</span>
+                          ) : null}
+                        </span>
+                      </span>
+                      <span className="settings-archive-row__side">
+                        <RunStatus item={runItemsByThreadId.get(thread.threadId)} />
+                      </span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="settings-thread-management__actionbar">
+            <div className="settings-thread-management__actioncopy">
+              <p className="settings-thread-management__action-title">
+                Migration action
+              </p>
+              <p className="settings-thread-management__action-description">
+                {selectedHasProfileOwnedWorktree
+                  ? "Profile-owned worktree migration is blocked until branch and worktree relocation is implemented."
+                  : selectedCount > 0
+                    ? "Move copies, validates, then archives source last. Copy leaves source threads active."
+                    : "Select one or more threads to enable Move or Copy."}
+              </p>
+            </div>
+            <div className="settings-thread-management__controls">
+              <button
+                className="button button--primary"
+                disabled={!canStart}
+                type="button"
+                onClick={() => {
+                  void startMigration("move");
+                }}
+              >
+                {startingOperation === "move"
+                  ? `Moving ${selectedCount}`
+                  : `Move ${selectedCount}`}
+              </button>
+              <button
+                className="button button--secondary"
+                disabled={!canStart}
+                type="button"
+                onClick={() => {
+                  void startMigration("copy");
+                }}
+              >
+                {startingOperation === "copy"
+                  ? `Copying ${selectedCount}`
+                  : `Copy ${selectedCount}`}
+              </button>
             </div>
           </div>
-        ))}
-      </SettingsSection>
-
-      <SettingsSection
-        eyebrow="Run"
-        title="Migration action"
-        description={
-          selectedHasProfileOwnedWorktree
-            ? "Profile-owned worktree migration is blocked until branch and worktree relocation is implemented."
-            : "Move copies, validates, then archives source last. Copy leaves source threads active."
-        }
-        chip={operation === "move" ? "recommended" : "advanced"}
-        chipKind={operation === "move" ? "ok" : "warn"}
-      >
-        <div className="settings-thread-management__controls">
-          <div className="settings-thread-management__segmented" role="group">
-            <button
-              className={`button ${
-                operation === "move" ? "button--primary" : "button--secondary"
-              }`}
-              type="button"
-              onClick={() => setOperation("move")}
-            >
-              Move
-            </button>
-            <button
-              className={`button ${
-                operation === "copy" ? "button--primary" : "button--secondary"
-              }`}
-              type="button"
-              onClick={() => setOperation("copy")}
-            >
-              Copy
-            </button>
-          </div>
-          <button
-            className="button button--primary"
-            disabled={!canStart}
-            type="button"
-            onClick={() => {
-              void startMigration();
-            }}
-          >
-            {starting
-              ? "Starting"
-              : operation === "move"
-                ? `Move ${selectedCount || ""}`.trim()
-                : `Copy ${selectedCount || ""}`.trim()}
-          </button>
         </div>
         {startError ? (
           <p className="settings-row__error settings-thread-management__status" role="alert">

--- a/apps/desktop/src/renderer/src/features/settings/ThreadManagementSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ThreadManagementSettings.tsx
@@ -332,13 +332,6 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
                   </p>
                 ) : null}
               </div>
-              <span className="settings-thread-management__project-select">
-                {project.threads.every((thread) =>
-                  selectedThreadIds.has(thread.threadId),
-                )
-                  ? "Clear"
-                  : "Select project"}
-              </span>
             </label>
             <div>
               {project.threads.map((thread) => (

--- a/apps/desktop/src/renderer/src/features/settings/ThreadManagementSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ThreadManagementSettings.tsx
@@ -4,6 +4,7 @@ import {
   type ListThreadMigrationSourcesResponse,
   type StartThreadMigrationResponse,
   type ThreadIdentifier,
+  type ThreadMigrationCopyStrategy,
   type ThreadMigrationOperation,
   type ThreadMigrationRunItem,
   type ThreadMigrationSourceProjectGroup,
@@ -85,6 +86,8 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
   const [startError, setStartError] = useState<string>();
   const [startingOperation, setStartingOperation] =
     useState<ThreadMigrationOperation>();
+  const [copyStrategy, setCopyStrategy] =
+    useState<ThreadMigrationCopyStrategy>("detached-destination");
   const sourceThreadsRequestIdRef = useRef(0);
 
   const loadSources = useCallback(async () => {
@@ -199,7 +202,7 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
     !startingOperation &&
     !threadsState.loading;
   const canMove = canStartBase;
-  const canCopy = canStartBase && !selectedHasManagedWorktree;
+  const canCopy = canStartBase;
 
   const toggleThread = (threadId: ThreadIdentifier) => {
     setSelectedThreadIds((current) => {
@@ -258,6 +261,7 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
       const response = await startThreadMigration({
         sourceProfile: selectedSource.profile,
         operation,
+        ...(operation === "copy" ? { copyStrategy } : {}),
         threadIds: [...selectedThreadIds],
       });
       setRun(response);
@@ -372,11 +376,28 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
                 {selectedCount === 0
                   ? "Select one or more threads to enable Move or Copy."
                   : selectedHasManagedWorktree
-                    ? "Move creates destination worktrees before archiving the source. Copy is disabled for selected managed worktrees."
+                    ? "Move transfers branches to destination worktrees before archiving the source. Copy leaves source branches active and uses the selected strategy."
                     : "Move copies, validates, then archives source last. Copy leaves source threads active."}
               </p>
             </div>
             <div className="settings-thread-management__controls">
+              {selectedHasManagedWorktree ? (
+                <label className="settings-thread-management__copy-strategy">
+                  <span>Copy strategy</span>
+                  <select
+                    value={copyStrategy}
+                    onChange={(event) =>
+                      setCopyStrategy(
+                        event.target.value as ThreadMigrationCopyStrategy,
+                      )
+                    }
+                  >
+                    <option value="detached-destination">
+                      Detached destination
+                    </option>
+                  </select>
+                </label>
+              ) : null}
               <button
                 className="button button--primary"
                 disabled={!canMove}
@@ -393,11 +414,6 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
                 className="button button--secondary"
                 disabled={!canCopy}
                 type="button"
-                title={
-                  selectedHasManagedWorktree
-                    ? "Copy is disabled for selected managed worktrees. Use Move."
-                    : undefined
-                }
                 onClick={() => {
                   void startMigration("copy");
                 }}

--- a/apps/desktop/src/renderer/src/features/settings/ThreadManagementSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ThreadManagementSettings.tsx
@@ -184,6 +184,9 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
       ),
     [run],
   );
+  const runWarningCount =
+    run?.items.reduce((count, item) => count + (item.warnings?.length ?? 0), 0) ??
+    0;
   const selectedCount = selectedThreadIds.size;
   const selectedHasManagedWorktree = useMemo(
     () =>
@@ -502,6 +505,9 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
                               </span>
                             ) : null}
                           </span>
+                          <RunDiagnostics
+                            item={runItemsByThreadId.get(thread.threadId)}
+                          />
                         </span>
                         <span className="settings-archive-row__side">
                           <RunStatus item={runItemsByThreadId.get(thread.threadId)} />
@@ -522,7 +528,11 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
         {run ? (
           <p className="settings-thread-management__status" role="status">
             Run {run.runId}: {run.items.filter((item) => item.status === "completed").length} of{" "}
-            {run.items.length} completed.
+            {run.items.length} completed
+            {runWarningCount > 0
+              ? `, ${runWarningCount} ${runWarningCount === 1 ? "warning" : "warnings"}`
+              : ""}
+            .
           </p>
         ) : null}
       </SettingsSection>
@@ -592,4 +602,49 @@ function RunStatus(props: { item?: ThreadMigrationRunItem }) {
       {props.item.status}
     </span>
   );
+}
+
+function RunDiagnostics(props: { item?: ThreadMigrationRunItem }) {
+  const item = props.item;
+  if (!item) {
+    return null;
+  }
+  const detail = describeRunDetail(item);
+  return (
+    <span className="settings-thread-management__run-details">
+      {detail ? (
+        <span className="settings-thread-management__run-detail">{detail}</span>
+      ) : null}
+      {item.warnings?.map((warning) => (
+        <span
+          className="settings-thread-management__run-warning"
+          key={warning}
+        >
+          {warning}
+        </span>
+      ))}
+      {item.error ? (
+        <span className="settings-thread-management__run-warning">
+          {item.error}
+        </span>
+      ) : null}
+    </span>
+  );
+}
+
+function describeRunDetail(item: ThreadMigrationRunItem): string | undefined {
+  const diagnostics = item.diagnostics;
+  if (!diagnostics) {
+    return undefined;
+  }
+  if (diagnostics.destinationWorktreePath) {
+    return `Destination worktree ${diagnostics.destinationWorktreePath}`;
+  }
+  if (diagnostics.destinationDirectoryPath) {
+    return `Destination ${diagnostics.destinationWorkMode ?? "local"} ${diagnostics.destinationDirectoryPath}`;
+  }
+  if (diagnostics.requestedWorkMode) {
+    return `Requested ${diagnostics.requestedWorkMode}`;
+  }
+  return undefined;
 }

--- a/apps/desktop/src/renderer/src/features/settings/ThreadManagementSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ThreadManagementSettings.tsx
@@ -231,11 +231,11 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
     }
     setSelectedThreadIds((current) => {
       const next = new Set(current);
-      const allSelected = projectThreads.every((thread) =>
+      const currentAllSelected = projectThreads.every((thread) =>
         next.has(thread.threadId),
       );
       for (const thread of projectThreads) {
-        if (allSelected) {
+        if (currentAllSelected) {
           next.delete(thread.threadId);
         } else {
           next.add(thread.threadId);

--- a/apps/desktop/src/renderer/src/features/settings/ThreadManagementSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ThreadManagementSettings.tsx
@@ -7,6 +7,7 @@ import {
   type ThreadMigrationOperation,
   type ThreadMigrationRunItem,
   type ThreadMigrationSourceProjectGroup,
+  type ThreadMigrationSourceThreadSummary,
   type ThreadMigrationSourceProfileSummary,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
@@ -29,6 +30,44 @@ const dateFormatter = new Intl.DateTimeFormat(undefined, {
   hour: "numeric",
   minute: "2-digit",
 });
+
+function safeProjectThreads(
+  project: ThreadMigrationSourceProjectGroup,
+): ThreadMigrationSourceThreadSummary[] {
+  return Array.isArray(project.threads)
+    ? project.threads.filter((thread): thread is ThreadMigrationSourceThreadSummary =>
+        Boolean(thread),
+      )
+    : [];
+}
+
+function hasMalformedLinkedDirectories(
+  thread: ThreadMigrationSourceThreadSummary,
+): boolean {
+  return (
+    !Array.isArray(thread.linkedDirectories) ||
+    thread.linkedDirectories.some(
+      (directory) => !directory || typeof directory !== "object",
+    )
+  );
+}
+
+function hasProfileOwnedWorktree(
+  thread: ThreadMigrationSourceThreadSummary,
+): boolean {
+  return (
+    isToolManagedWorktreePath(thread.projectKey) ||
+    (Array.isArray(thread.linkedDirectories)
+      ? thread.linkedDirectories.some(
+          (directory) =>
+            Boolean(directory) &&
+            typeof directory === "object" &&
+            (isToolManagedWorktreePath(directory.worktreePath) ||
+              isToolManagedWorktreePath(directory.path)),
+        )
+      : false)
+  );
+}
 
 export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
   const [sources, setSources] = useState<ListThreadMigrationSourcesResponse>();
@@ -146,15 +185,10 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
   const selectedHasProfileOwnedWorktree = useMemo(
     () =>
       threadsState.projects.some((project) =>
-        project.threads.some(
+        safeProjectThreads(project).some(
           (thread) =>
             selectedThreadIds.has(thread.threadId) &&
-            (isToolManagedWorktreePath(thread.projectKey) ||
-              (thread.linkedDirectories ?? []).some(
-                (directory) =>
-                  isToolManagedWorktreePath(directory.worktreePath) ||
-                  isToolManagedWorktreePath(directory.path),
-              )),
+            hasProfileOwnedWorktree(thread),
         ),
       ),
     [selectedThreadIds, threadsState.projects],
@@ -179,12 +213,28 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
   };
 
   const selectProject = (project: ThreadMigrationSourceProjectGroup) => {
+    const projectThreads = safeProjectThreads(project);
+    const malformedThreadCount = projectThreads.filter(
+      hasMalformedLinkedDirectories,
+    ).length;
+    if (malformedThreadCount > 0) {
+      void props.desktopApi?.logRendererDiagnostic?.({
+        level: "warn",
+        message: "Thread migration source project has malformed linked directories.",
+        details: {
+          malformedThreadCount,
+          projectKey: project.key,
+          projectLabel: project.label,
+          threadCount: projectThreads.length,
+        },
+      })?.catch(() => undefined);
+    }
     setSelectedThreadIds((current) => {
       const next = new Set(current);
-      const allSelected = project.threads.every((thread) =>
+      const allSelected = projectThreads.every((thread) =>
         next.has(thread.threadId),
       );
-      for (const thread of project.threads) {
+      for (const thread of projectThreads) {
         if (allSelected) {
           next.delete(thread.threadId);
         } else {
@@ -313,85 +363,93 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
         ) : null}
         <div className="settings-thread-management__selection-shell">
           <div className="settings-thread-management__projects-list">
-            {threadsState.projects.map((project) => (
-              <div className="settings-thread-management__project" key={project.key}>
-                <label className="settings-thread-management__project-head">
-                  <input
-                    checked={project.threads.every((thread) =>
-                      selectedThreadIds.has(thread.threadId),
-                    )}
-                    className="settings-thread-management__checkbox-input"
-                    type="checkbox"
-                    onChange={() => selectProject(project)}
-                  />
-                  <span
-                    aria-hidden="true"
-                    className={`settings-thread-management__checkbox settings-thread-management__checkbox--project${
-                      project.threads.every((thread) =>
-                        selectedThreadIds.has(thread.threadId),
-                      )
-                        ? " is-checked"
-                        : ""
-                    }`}
-                  />
-                  <div>
-                    <p className="settings-thread-management__project-title">
-                      {project.label}
-                    </p>
-                    {project.path ? (
-                      <p className="settings-thread-management__project-path">
-                        {project.path}
-                      </p>
-                    ) : null}
-                  </div>
-                </label>
-                <div>
-                  {project.threads.map((thread) => (
-                    <label
-                      key={thread.threadId}
-                      className={`settings-thread-management__thread${
-                        selectedThreadIds.has(thread.threadId) ? " is-selected" : ""
+            {threadsState.projects.map((project) => {
+              const projectThreads = safeProjectThreads(project);
+              const projectSelected =
+                projectThreads.length > 0 &&
+                projectThreads.every((thread) =>
+                  selectedThreadIds.has(thread.threadId),
+                );
+              return (
+                <div className="settings-thread-management__project" key={project.key}>
+                  <label className="settings-thread-management__project-head">
+                    <input
+                      checked={projectSelected}
+                      className="settings-thread-management__checkbox-input"
+                      type="checkbox"
+                      onChange={() => selectProject(project)}
+                    />
+                    <span
+                      aria-hidden="true"
+                      className={`settings-thread-management__checkbox settings-thread-management__checkbox--project${
+                        projectSelected ? " is-checked" : ""
                       }`}
-                    >
-                      <input
-                        checked={selectedThreadIds.has(thread.threadId)}
-                        className="settings-thread-management__checkbox-input"
-                        type="checkbox"
-                        onChange={() => toggleThread(thread.threadId)}
-                      />
-                      <span
-                        aria-hidden="true"
-                        className={`settings-thread-management__checkbox${
+                    />
+                    <div>
+                      <p className="settings-thread-management__project-title">
+                        {project.label}
+                      </p>
+                      {project.path ? (
+                        <p className="settings-thread-management__project-path">
+                          {project.path}
+                        </p>
+                      ) : null}
+                    </div>
+                  </label>
+                  <div>
+                    {projectThreads.map((thread) => (
+                      <label
+                        key={thread.threadId}
+                        className={`settings-thread-management__thread${
                           selectedThreadIds.has(thread.threadId)
-                            ? " is-checked"
+                            ? " is-selected"
                             : ""
                         }`}
-                      />
-                      <span className="settings-archive-row__body">
-                        <span className="settings-archive-row__title">
-                          {thread.title}
-                        </span>
-                        {thread.summary ? (
-                          <span className="settings-archive-row__summary">
-                            {thread.summary}
+                      >
+                        <input
+                          checked={selectedThreadIds.has(thread.threadId)}
+                          className="settings-thread-management__checkbox-input"
+                          type="checkbox"
+                          onChange={() => toggleThread(thread.threadId)}
+                        />
+                        <span
+                          aria-hidden="true"
+                          className={`settings-thread-management__checkbox${
+                            selectedThreadIds.has(thread.threadId)
+                              ? " is-checked"
+                              : ""
+                          }`}
+                        />
+                        <span className="settings-archive-row__body">
+                          <span className="settings-archive-row__title">
+                            {thread.title}
                           </span>
-                        ) : null}
-                        <span className="settings-archive-row__meta">
-                          <span>{thread.threadId}</span>
-                          {thread.gitBranch ? <span>{thread.gitBranch}</span> : null}
-                          {thread.updatedAt ? (
-                            <span>Updated {dateFormatter.format(thread.updatedAt)}</span>
+                          {thread.summary ? (
+                            <span className="settings-archive-row__summary">
+                              {thread.summary}
+                            </span>
                           ) : null}
+                          <span className="settings-archive-row__meta">
+                            <span>{thread.threadId}</span>
+                            {thread.gitBranch ? (
+                              <span>{thread.gitBranch}</span>
+                            ) : null}
+                            {thread.updatedAt ? (
+                              <span>
+                                Updated {dateFormatter.format(thread.updatedAt)}
+                              </span>
+                            ) : null}
+                          </span>
                         </span>
-                      </span>
-                      <span className="settings-archive-row__side">
-                        <RunStatus item={runItemsByThreadId.get(thread.threadId)} />
-                      </span>
-                    </label>
-                  ))}
+                        <span className="settings-archive-row__side">
+                          <RunStatus item={runItemsByThreadId.get(thread.threadId)} />
+                        </span>
+                      </label>
+                    ))}
+                  </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
           <div className="settings-thread-management__actionbar">
             <div className="settings-thread-management__actioncopy">

--- a/apps/desktop/src/renderer/src/features/settings/ThreadManagementSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ThreadManagementSettings.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   isToolManagedWorktreePath,
   type ListThreadMigrationSourcesResponse,
@@ -46,6 +46,7 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
   const [run, setRun] = useState<StartThreadMigrationResponse>();
   const [startError, setStartError] = useState<string>();
   const [starting, setStarting] = useState(false);
+  const sourceThreadsRequestIdRef = useRef(0);
 
   const loadSources = useCallback(async () => {
     const listSources = props.desktopApi?.listThreadMigrationSources;
@@ -75,6 +76,8 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
 
   const loadSourceThreads = useCallback(
     async (profile: string | undefined) => {
+      const requestId = sourceThreadsRequestIdRef.current + 1;
+      sourceThreadsRequestIdRef.current = requestId;
       if (profile === undefined) {
         setThreadsState({ loading: false, projects: [] });
         setSelectedThreadIds(new Set());
@@ -99,12 +102,18 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
       setRun(undefined);
       try {
         const response = await listThreads({ sourceProfile: profile });
+        if (sourceThreadsRequestIdRef.current !== requestId) {
+          return;
+        }
         setThreadsState({
           fetchedAt: response.fetchedAt,
           loading: false,
           projects: response.projects,
         });
       } catch (error) {
+        if (sourceThreadsRequestIdRef.current !== requestId) {
+          return;
+        }
         setThreadsState({
           error: error instanceof Error ? error.message : String(error),
           loading: false,
@@ -140,11 +149,12 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
         project.threads.some(
           (thread) =>
             selectedThreadIds.has(thread.threadId) &&
-            thread.linkedDirectories.some(
-              (directory) =>
-                isToolManagedWorktreePath(directory.worktreePath) ||
-                isToolManagedWorktreePath(directory.path),
-            ),
+            (isToolManagedWorktreePath(thread.projectKey) ||
+              thread.linkedDirectories.some(
+                (directory) =>
+                  isToolManagedWorktreePath(directory.worktreePath) ||
+                  isToolManagedWorktreePath(directory.path),
+              )),
         ),
       ),
     [selectedThreadIds, threadsState.projects],

--- a/apps/desktop/src/renderer/src/features/settings/ThreadManagementSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ThreadManagementSettings.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type MouseEventHandler,
+} from "react";
 import {
   isToolManagedWorktreePath,
   type ListThreadMigrationSourcesResponse,
@@ -86,6 +93,7 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
   const [startError, setStartError] = useState<string>();
   const [startingOperation, setStartingOperation] =
     useState<ThreadMigrationOperation>();
+  const [retryingThreadId, setRetryingThreadId] = useState<ThreadIdentifier>();
   const [copyStrategy, setCopyStrategy] =
     useState<ThreadMigrationCopyStrategy>("detached-destination");
   const [includeArchived, setIncludeArchived] = useState(false);
@@ -280,6 +288,43 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
       setStartError(error instanceof Error ? error.message : String(error));
     } finally {
       setStartingOperation(undefined);
+    }
+  };
+
+  const retryMigration = async (threadId: ThreadIdentifier) => {
+    const retryThreadMigration = props.desktopApi?.retryThreadMigration;
+    if (!retryThreadMigration || !selectedSource || !run) {
+      setStartError("Desktop bridge is missing retryThreadMigration().");
+      return;
+    }
+    setRetryingThreadId(threadId);
+    setStartError(undefined);
+    try {
+      const response = await retryThreadMigration({
+        sourceProfile: selectedSource.profile,
+        operation: run.operation,
+        ...(run.operation === "copy" ? { copyStrategy } : {}),
+        threadId,
+      });
+      const retryItem = response.items[0];
+      if (!retryItem) {
+        return;
+      }
+      setRun((current) => {
+        if (!current) {
+          return response;
+        }
+        return {
+          ...current,
+          items: current.items.map((item) =>
+            item.sourceThreadId === retryItem.sourceThreadId ? retryItem : item,
+          ),
+        };
+      });
+    } catch (error) {
+      setStartError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setRetryingThreadId(undefined);
     }
   };
 
@@ -529,6 +574,15 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
                         </span>
                         <span className="settings-archive-row__side">
                           <RunStatus item={runItemsByThreadId.get(thread.threadId)} />
+                          <RetryMigrationButton
+                            item={runItemsByThreadId.get(thread.threadId)}
+                            retrying={retryingThreadId === thread.threadId}
+                            onRetry={(event) => {
+                              event.preventDefault();
+                              event.stopPropagation();
+                              void retryMigration(thread.threadId);
+                            }}
+                          />
                         </span>
                       </label>
                     ))}
@@ -627,6 +681,26 @@ function RunStatus(props: { item?: ThreadMigrationRunItem }) {
     >
       {completedWithWarnings ? "completed with warning" : props.item.status}
     </span>
+  );
+}
+
+function RetryMigrationButton(props: {
+  item?: ThreadMigrationRunItem;
+  retrying: boolean;
+  onRetry: MouseEventHandler<HTMLButtonElement>;
+}) {
+  if (!props.item || props.item.status !== "failed") {
+    return null;
+  }
+  return (
+    <button
+      className="button button--secondary settings-thread-management__retry"
+      disabled={props.retrying}
+      type="button"
+      onClick={props.onRetry}
+    >
+      {props.retrying ? "Trying" : "Try harder"}
+    </button>
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/settings/ThreadManagementSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ThreadManagementSettings.tsx
@@ -88,6 +88,7 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
     useState<ThreadMigrationOperation>();
   const [copyStrategy, setCopyStrategy] =
     useState<ThreadMigrationCopyStrategy>("detached-destination");
+  const [includeArchived, setIncludeArchived] = useState(false);
   const sourceThreadsRequestIdRef = useRef(0);
 
   const loadSources = useCallback(async () => {
@@ -117,7 +118,7 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
   }, [props.desktopApi]);
 
   const loadSourceThreads = useCallback(
-    async (profile: string | undefined) => {
+    async (profile: string | undefined, archived: boolean) => {
       const requestId = sourceThreadsRequestIdRef.current + 1;
       sourceThreadsRequestIdRef.current = requestId;
       if (profile === undefined) {
@@ -143,7 +144,10 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
       setSelectedThreadIds(new Set());
       setRun(undefined);
       try {
-        const response = await listThreads({ sourceProfile: profile });
+        const response = await listThreads({
+          sourceProfile: profile,
+          archived,
+        });
         if (sourceThreadsRequestIdRef.current !== requestId) {
           return;
         }
@@ -171,8 +175,8 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
   }, [loadSources]);
 
   useEffect(() => {
-    void loadSourceThreads(selectedProfile);
-  }, [loadSourceThreads, selectedProfile]);
+    void loadSourceThreads(selectedProfile, includeArchived);
+  }, [includeArchived, loadSourceThreads, selectedProfile]);
 
   const selectedSource = sources?.profiles.find(
     (profile) => profile.profile === selectedProfile,
@@ -388,6 +392,16 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
               </p>
             </div>
             <div className="settings-thread-management__controls">
+              <label className="settings-thread-management__toggle">
+                <input
+                  checked={includeArchived}
+                  type="checkbox"
+                  onChange={(event) => {
+                    setIncludeArchived(event.target.checked);
+                  }}
+                />
+                <span>Show archived</span>
+              </label>
               {selectedHasManagedWorktree ? (
                 <label className="settings-thread-management__copy-strategy">
                   <span>Copy strategy</span>

--- a/apps/desktop/src/renderer/src/features/settings/ThreadManagementSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ThreadManagementSettings.tsx
@@ -187,6 +187,10 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
   const runWarningCount =
     run?.items.reduce((count, item) => count + (item.warnings?.length ?? 0), 0) ??
     0;
+  const runCompletedWithWarningsCount =
+    run?.items.filter(
+      (item) => item.status === "completed" && (item.warnings?.length ?? 0) > 0,
+    ).length ?? 0;
   const selectedCount = selectedThreadIds.size;
   const selectedHasManagedWorktree = useMemo(
     () =>
@@ -530,7 +534,9 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
             Run {run.runId}: {run.items.filter((item) => item.status === "completed").length} of{" "}
             {run.items.length} completed
             {runWarningCount > 0
-              ? `, ${runWarningCount} ${runWarningCount === 1 ? "warning" : "warnings"}`
+              ? `, ${runCompletedWithWarningsCount} with ${
+                  runWarningCount === 1 ? "a warning" : "warnings"
+                }`
               : ""}
             .
           </p>
@@ -588,18 +594,24 @@ function RunStatus(props: { item?: ThreadMigrationRunItem }) {
   if (!props.item) {
     return null;
   }
+  const completedWithWarnings =
+    props.item.status === "completed" && (props.item.warnings?.length ?? 0) > 0;
   return (
     <span
       className={`settings-pathrow__chip ${
-        props.item.status === "completed"
+        completedWithWarnings
+          ? "settings-pathrow__chip--warn"
+          : props.item.status === "completed"
           ? "settings-pathrow__chip--ok"
           : props.item.status === "failed"
             ? "settings-pathrow__chip--err"
             : "settings-pathrow__chip--warn"
       }`}
-      title={props.item.error}
+      title={[props.item.error, ...(props.item.warnings ?? [])]
+        .filter(Boolean)
+        .join("\n")}
     >
-      {props.item.status}
+      {completedWithWarnings ? "completed with warning" : props.item.status}
     </span>
   );
 }

--- a/apps/desktop/src/renderer/src/features/settings/ThreadManagementSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ThreadManagementSettings.tsx
@@ -182,7 +182,7 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
     [run],
   );
   const selectedCount = selectedThreadIds.size;
-  const selectedHasProfileOwnedWorktree = useMemo(
+  const selectedHasManagedWorktree = useMemo(
     () =>
       threadsState.projects.some((project) =>
         safeProjectThreads(project).some(
@@ -193,12 +193,13 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
       ),
     [selectedThreadIds, threadsState.projects],
   );
-  const canStart =
+  const canStartBase =
     Boolean(selectedSource?.available) &&
     selectedCount > 0 &&
-    !selectedHasProfileOwnedWorktree &&
     !startingOperation &&
     !threadsState.loading;
+  const canMove = canStartBase;
+  const canCopy = canStartBase && !selectedHasManagedWorktree;
 
   const toggleThread = (threadId: ThreadIdentifier) => {
     setSelectedThreadIds((current) => {
@@ -362,6 +363,51 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
           </p>
         ) : null}
         <div className="settings-thread-management__selection-shell">
+          <div className="settings-thread-management__actionbar">
+            <div className="settings-thread-management__actioncopy">
+              <p className="settings-thread-management__action-title">
+                Migration action
+              </p>
+              <p className="settings-thread-management__action-description">
+                {selectedCount === 0
+                  ? "Select one or more threads to enable Move or Copy."
+                  : selectedHasManagedWorktree
+                    ? "Move creates destination worktrees before archiving the source. Copy is disabled for selected managed worktrees."
+                    : "Move copies, validates, then archives source last. Copy leaves source threads active."}
+              </p>
+            </div>
+            <div className="settings-thread-management__controls">
+              <button
+                className="button button--primary"
+                disabled={!canMove}
+                type="button"
+                onClick={() => {
+                  void startMigration("move");
+                }}
+              >
+                {startingOperation === "move"
+                  ? `Moving ${selectedCount}`
+                  : `Move ${selectedCount}`}
+              </button>
+              <button
+                className="button button--secondary"
+                disabled={!canCopy}
+                type="button"
+                title={
+                  selectedHasManagedWorktree
+                    ? "Copy is disabled for selected managed worktrees. Use Move."
+                    : undefined
+                }
+                onClick={() => {
+                  void startMigration("copy");
+                }}
+              >
+                {startingOperation === "copy"
+                  ? `Copying ${selectedCount}`
+                  : `Copy ${selectedCount}`}
+              </button>
+            </div>
+          </div>
           <div className="settings-thread-management__projects-list">
             {threadsState.projects.map((project) => {
               const projectThreads = safeProjectThreads(project);
@@ -451,56 +497,10 @@ export function ThreadManagementSettings(props: { desktopApi?: DesktopApi }) {
               );
             })}
           </div>
-          <div className="settings-thread-management__actionbar">
-            <div className="settings-thread-management__actioncopy">
-              <p className="settings-thread-management__action-title">
-                Migration action
-              </p>
-              <p className="settings-thread-management__action-description">
-                {selectedHasProfileOwnedWorktree
-                  ? "Profile-owned worktree migration is blocked until branch and worktree relocation is implemented."
-                  : selectedCount > 0
-                    ? "Move copies, validates, then archives source last. Copy leaves source threads active."
-                    : "Select one or more threads to enable Move or Copy."}
-              </p>
-            </div>
-            <div className="settings-thread-management__controls">
-              <button
-                className="button button--primary"
-                disabled={!canStart}
-                type="button"
-                onClick={() => {
-                  void startMigration("move");
-                }}
-              >
-                {startingOperation === "move"
-                  ? `Moving ${selectedCount}`
-                  : `Move ${selectedCount}`}
-              </button>
-              <button
-                className="button button--secondary"
-                disabled={!canStart}
-                type="button"
-                onClick={() => {
-                  void startMigration("copy");
-                }}
-              >
-                {startingOperation === "copy"
-                  ? `Copying ${selectedCount}`
-                  : `Copy ${selectedCount}`}
-              </button>
-            </div>
-          </div>
         </div>
         {startError ? (
           <p className="settings-row__error settings-thread-management__status" role="alert">
             {startError}
-          </p>
-        ) : null}
-        {selectedHasProfileOwnedWorktree ? (
-          <p className="settings-row__error settings-thread-management__status" role="alert">
-            Selected threads include a profile-owned worktree. This PR blocks
-            that path until branch conflict strategies are implemented.
           </p>
         ) : null}
         {run ? (

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/ThreadManagementSettings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/ThreadManagementSettings.test.tsx
@@ -140,11 +140,15 @@ describe("ThreadManagementSettings", () => {
   });
 
   it("uses direct action buttons and tolerates threads without linked directories", async () => {
-    const threadsResponse = migrationThreadsResponse("", "Thread without dirs");
-    threadsResponse.projects[0]!.threads[0]!.linkedDirectories = undefined as never;
+    const threadsResponse = migrationThreadsResponse("", "GIFusion thread");
+    threadsResponse.projects[0]!.label = "GIFusion";
+    threadsResponse.projects[0]!.path = "/Users/alice/GIPHY/GIFusion";
+    threadsResponse.projects[0]!.threads[0]!.linkedDirectories = [null] as never;
+    const logRendererDiagnostic = vi.fn(async () => undefined);
     const desktopApi: DesktopApi = {
       listThreadMigrationSources: vi.fn(async () => migrationSourcesResponse()),
       listThreadMigrationSourceThreads: vi.fn(async () => threadsResponse),
+      logRendererDiagnostic,
     };
 
     render(<ThreadManagementSettings desktopApi={desktopApi} />);
@@ -154,9 +158,19 @@ describe("ThreadManagementSettings", () => {
     expect(screen.queryByRole("button", { name: "Move" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Copy" })).not.toBeInTheDocument();
 
-    fireEvent.click(await screen.findByRole("checkbox", { name: /System default/ }));
+    fireEvent.click((await screen.findAllByRole("checkbox", { name: /GIFusion/ }))[0]!);
 
     expect(screen.getByRole("button", { name: "Move 1" })).toBeEnabled();
     expect(screen.getByRole("button", { name: "Copy 1" })).toBeEnabled();
+    expect(logRendererDiagnostic).toHaveBeenCalledWith({
+      level: "warn",
+      message: "Thread migration source project has malformed linked directories.",
+      details: {
+        malformedThreadCount: 1,
+        projectKey: "directory:/repo/default",
+        projectLabel: "GIFusion",
+        threadCount: 1,
+      },
+    });
   });
 });

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/ThreadManagementSettings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/ThreadManagementSettings.test.tsx
@@ -110,6 +110,7 @@ describe("ThreadManagementSettings", () => {
 
     await waitFor(() => {
       expect(listThreadMigrationSourceThreads).toHaveBeenCalledWith({
+        archived: false,
         sourceProfile: "",
       });
     });
@@ -118,6 +119,7 @@ describe("ThreadManagementSettings", () => {
 
     await waitFor(() => {
       expect(listThreadMigrationSourceThreads).toHaveBeenCalledWith({
+        archived: false,
         sourceProfile: "personal",
       });
     });
@@ -172,6 +174,38 @@ describe("ThreadManagementSettings", () => {
         projectLabel: "GIFusion",
         threadCount: 1,
       },
+    });
+  });
+
+  it("hides archived source threads by default and reloads when enabled", async () => {
+    const listThreadMigrationSourceThreads = vi.fn<
+      NonNullable<DesktopApi["listThreadMigrationSourceThreads"]>
+    >(async (request) =>
+      migrationThreadsResponse(
+        request.sourceProfile,
+        request.archived ? "Archived thread" : "Active thread",
+      ),
+    );
+    const desktopApi: DesktopApi = {
+      listThreadMigrationSources: vi.fn(async () => migrationSourcesResponse()),
+      listThreadMigrationSourceThreads,
+    };
+
+    render(<ThreadManagementSettings desktopApi={desktopApi} />);
+
+    expect(await screen.findByText("Active thread")).toBeInTheDocument();
+    expect(screen.queryByText("Archived thread")).not.toBeInTheDocument();
+    expect(listThreadMigrationSourceThreads).toHaveBeenLastCalledWith({
+      archived: false,
+      sourceProfile: "",
+    });
+
+    fireEvent.click(screen.getByLabelText("Show archived"));
+
+    expect(await screen.findByText("Archived thread")).toBeInTheDocument();
+    expect(listThreadMigrationSourceThreads).toHaveBeenLastCalledWith({
+      archived: true,
+      sourceProfile: "",
     });
   });
 
@@ -255,7 +289,9 @@ describe("ThreadManagementSettings", () => {
 
     render(<ThreadManagementSettings desktopApi={desktopApi} />);
 
-    fireEvent.click((await screen.findAllByRole("checkbox"))[1]!);
+    fireEvent.click(
+      await screen.findByRole("checkbox", { name: /GIFusion thread/ }),
+    );
     fireEvent.click(screen.getByRole("button", { name: "Move 1" }));
 
     expect(

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/ThreadManagementSettings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/ThreadManagementSettings.test.tsx
@@ -306,4 +306,79 @@ describe("ThreadManagementSettings", () => {
     expect(screen.getByText("Run run-1: 1 of 1 completed, 1 with a warning."))
       .toBeInTheDocument();
   });
+
+  it("offers try harder on failed migrations and merges the retried result", async () => {
+    const threadsResponse = migrationThreadsResponse("", "web-app thread");
+    const failedResponse: StartThreadMigrationResponse = {
+      runId: "run-1",
+      operation: "move",
+      startedAt: 1234,
+      items: [
+        {
+          sourceProfile: "",
+          sourceThreadId: "default-thread",
+          status: "failed",
+          diagnostics: {
+            sourceProjectKey: "/Users/alice/.codex/worktrees/0cb4/web-app",
+            sourceWorktreePath: "/Users/alice/.codex/worktrees/0cb4/web-app",
+            sourceWorktreeExists: false,
+          },
+          error:
+            "Migration is blocked because the source managed worktree did not report an attached branch.",
+          warnings: [
+            "Source worktree was not found: /Users/alice/.codex/worktrees/0cb4/web-app",
+          ],
+        },
+      ],
+    };
+    const retriedResponse: StartThreadMigrationResponse = {
+      runId: "retry-1",
+      operation: "move",
+      startedAt: 2345,
+      items: [
+        {
+          sourceProfile: "",
+          sourceThreadId: "default-thread",
+          destinationThreadId: "destination-thread",
+          status: "completed",
+          diagnostics: {
+            destinationWorktreePath:
+              "/Users/alice/.codex/profiles/work/worktrees/web-app",
+          },
+        },
+      ],
+    };
+    const retryThreadMigration = vi.fn(async () => retriedResponse);
+    const desktopApi: DesktopApi = {
+      listThreadMigrationSources: vi.fn(async () => migrationSourcesResponse()),
+      listThreadMigrationSourceThreads: vi.fn(async () => threadsResponse),
+      startThreadMigration: vi.fn(async () => failedResponse),
+      retryThreadMigration,
+    };
+
+    render(<ThreadManagementSettings desktopApi={desktopApi} />);
+
+    fireEvent.click(
+      await screen.findByRole("checkbox", { name: /web-app thread/ }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Move 1" }));
+
+    expect(await screen.findByText("failed")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Try harder" }));
+
+    await waitFor(() => {
+      expect(retryThreadMigration).toHaveBeenCalledWith({
+        sourceProfile: "",
+        operation: "move",
+        threadId: "default-thread",
+      });
+    });
+    expect(await screen.findByText("completed")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Destination worktree /Users/alice/.codex/profiles/work/worktrees/web-app",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Try harder")).not.toBeInTheDocument();
+  });
 });

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/ThreadManagementSettings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/ThreadManagementSettings.test.tsx
@@ -174,7 +174,7 @@ describe("ThreadManagementSettings", () => {
     });
   });
 
-  it("keeps Move available for selected managed worktrees but disables Copy", async () => {
+  it("keeps Move and detached Copy available for selected managed worktrees", async () => {
     const threadsResponse = migrationThreadsResponse("", "Managed worktree thread");
     threadsResponse.projects[0]!.threads[0]!.linkedDirectories = [
       {
@@ -199,10 +199,13 @@ describe("ThreadManagementSettings", () => {
     );
 
     expect(screen.getByRole("button", { name: "Move 1" })).toBeEnabled();
-    expect(screen.getByRole("button", { name: "Copy 1" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Copy 1" })).toBeEnabled();
+    expect(
+      screen.getByRole("combobox", { name: "Copy strategy" }),
+    ).toHaveValue("detached-destination");
     expect(
       screen.getByText(
-        "Move creates destination worktrees before archiving the source. Copy is disabled for selected managed worktrees.",
+        "Move transfers branches to destination worktrees before archiving the source. Copy leaves source branches active and uses the selected strategy.",
       ),
     ).toBeInTheDocument();
 

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/ThreadManagementSettings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/ThreadManagementSettings.test.tsx
@@ -63,6 +63,32 @@ function migrationThreadsResponse(
   };
 }
 
+function migrationSourcesResponse(): ListThreadMigrationSourcesResponse {
+  return {
+    activeCodexProfile: "work",
+    profiles: [
+      {
+        profile: "",
+        displayName: "System default",
+        codexHome: "/Users/alice/.codex",
+        source: "default",
+        exists: true,
+        selected: false,
+        available: true,
+      },
+      {
+        profile: "personal",
+        displayName: "personal",
+        codexHome: "/Users/alice/.codex/profiles/personal",
+        source: "directory",
+        exists: true,
+        selected: false,
+        available: true,
+      },
+    ],
+  };
+}
+
 describe("ThreadManagementSettings", () => {
   it("ignores stale source thread responses after switching profiles", async () => {
     const defaultThreads = createDeferred<ListThreadMigrationSourceThreadsResponse>();
@@ -75,31 +101,7 @@ describe("ThreadManagementSettings", () => {
         : defaultThreads.promise,
     );
     const desktopApi: DesktopApi = {
-      listThreadMigrationSources: vi.fn(
-        async (): Promise<ListThreadMigrationSourcesResponse> => ({
-          activeCodexProfile: "work",
-          profiles: [
-            {
-              profile: "",
-              displayName: "System default",
-              codexHome: "/Users/alice/.codex",
-              source: "default",
-              exists: true,
-              selected: false,
-              available: true,
-            },
-            {
-              profile: "personal",
-              displayName: "personal",
-              codexHome: "/Users/alice/.codex/profiles/personal",
-              source: "directory",
-              exists: true,
-              selected: false,
-              available: true,
-            },
-          ],
-        }),
-      ),
+      listThreadMigrationSources: vi.fn(async () => migrationSourcesResponse()),
       listThreadMigrationSourceThreads,
     };
 
@@ -135,5 +137,26 @@ describe("ThreadManagementSettings", () => {
 
     expect(screen.getByText("Personal profile thread")).toBeInTheDocument();
     expect(screen.queryByText("Stale default profile thread")).not.toBeInTheDocument();
+  });
+
+  it("uses direct action buttons and tolerates threads without linked directories", async () => {
+    const threadsResponse = migrationThreadsResponse("", "Thread without dirs");
+    threadsResponse.projects[0]!.threads[0]!.linkedDirectories = undefined as never;
+    const desktopApi: DesktopApi = {
+      listThreadMigrationSources: vi.fn(async () => migrationSourcesResponse()),
+      listThreadMigrationSourceThreads: vi.fn(async () => threadsResponse),
+    };
+
+    render(<ThreadManagementSettings desktopApi={desktopApi} />);
+
+    expect(await screen.findByRole("button", { name: "Move 0" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Copy 0" })).toBeDisabled();
+    expect(screen.queryByRole("button", { name: "Move" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Copy" })).not.toBeInTheDocument();
+
+    fireEvent.click(await screen.findByRole("checkbox", { name: /System default/ }));
+
+    expect(screen.getByRole("button", { name: "Move 1" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Copy 1" })).toBeEnabled();
   });
 });

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/ThreadManagementSettings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/ThreadManagementSettings.test.tsx
@@ -11,6 +11,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
   ListThreadMigrationSourceThreadsResponse,
   ListThreadMigrationSourcesResponse,
+  StartThreadMigrationResponse,
   ThreadMigrationSourceProjectGroup,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../../lib/desktop-api";
@@ -221,5 +222,51 @@ describe("ThreadManagementSettings", () => {
       actionbar!.compareDocumentPosition(projectsList!) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
+  });
+
+  it("shows migration diagnostics and warnings returned by the run", async () => {
+    const threadsResponse = migrationThreadsResponse("", "GIFusion thread");
+    const migrationResponse: StartThreadMigrationResponse = {
+      runId: "run-1",
+      operation: "move",
+      startedAt: 1234,
+      items: [
+        {
+          sourceProfile: "",
+          sourceThreadId: "default-thread",
+          destinationThreadId: "destination-thread",
+          status: "completed",
+          diagnostics: {
+            requestedWorkMode: "worktree",
+            destinationDirectoryPath: "/repo/default",
+            destinationWorkMode: "local",
+          },
+          warnings: [
+            "Destination returned local even though migration requested a worktree.",
+          ],
+        },
+      ],
+    };
+    const desktopApi: DesktopApi = {
+      listThreadMigrationSources: vi.fn(async () => migrationSourcesResponse()),
+      listThreadMigrationSourceThreads: vi.fn(async () => threadsResponse),
+      startThreadMigration: vi.fn(async () => migrationResponse),
+    };
+
+    render(<ThreadManagementSettings desktopApi={desktopApi} />);
+
+    fireEvent.click((await screen.findAllByRole("checkbox"))[1]!);
+    fireEvent.click(screen.getByRole("button", { name: "Move 1" }));
+
+    expect(
+      await screen.findByText("Destination local /repo/default"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Destination returned local even though migration requested a worktree.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Run run-1: 1 of 1 completed, 1 warning."))
+      .toBeInTheDocument();
   });
 });

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/ThreadManagementSettings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/ThreadManagementSettings.test.tsx
@@ -266,7 +266,8 @@ describe("ThreadManagementSettings", () => {
         "Destination returned local even though migration requested a worktree.",
       ),
     ).toBeInTheDocument();
-    expect(screen.getByText("Run run-1: 1 of 1 completed, 1 warning."))
+    expect(screen.getByText("completed with warning")).toBeInTheDocument();
+    expect(screen.getByText("Run run-1: 1 of 1 completed, 1 with a warning."))
       .toBeInTheDocument();
   });
 });

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/ThreadManagementSettings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/ThreadManagementSettings.test.tsx
@@ -173,4 +173,50 @@ describe("ThreadManagementSettings", () => {
       },
     });
   });
+
+  it("keeps Move available for selected managed worktrees but disables Copy", async () => {
+    const threadsResponse = migrationThreadsResponse("", "Managed worktree thread");
+    threadsResponse.projects[0]!.threads[0]!.linkedDirectories = [
+      {
+        id: "worktree:/Users/alice/.codex/worktrees/mpabc/app",
+        label: "app",
+        path: "/repo/app",
+        worktreePath: "/Users/alice/.codex/worktrees/mpabc/app",
+        kind: "worktree",
+      },
+    ];
+    const desktopApi: DesktopApi = {
+      listThreadMigrationSources: vi.fn(async () => migrationSourcesResponse()),
+      listThreadMigrationSourceThreads: vi.fn(async () => threadsResponse),
+    };
+
+    const { container } = render(
+      <ThreadManagementSettings desktopApi={desktopApi} />,
+    );
+
+    fireEvent.click(
+      (await screen.findAllByRole("checkbox", { name: /System default/ }))[0]!,
+    );
+
+    expect(screen.getByRole("button", { name: "Move 1" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Copy 1" })).toBeDisabled();
+    expect(
+      screen.getByText(
+        "Move creates destination worktrees before archiving the source. Copy is disabled for selected managed worktrees.",
+      ),
+    ).toBeInTheDocument();
+
+    const actionbar = container.querySelector(
+      ".settings-thread-management__actionbar",
+    );
+    const projectsList = container.querySelector(
+      ".settings-thread-management__projects-list",
+    );
+    expect(actionbar).not.toBeNull();
+    expect(projectsList).not.toBeNull();
+    expect(
+      actionbar!.compareDocumentPosition(projectsList!) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
 });

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/ThreadManagementSettings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/ThreadManagementSettings.test.tsx
@@ -1,0 +1,139 @@
+import "@testing-library/jest-dom/vitest";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  ListThreadMigrationSourceThreadsResponse,
+  ListThreadMigrationSourcesResponse,
+  ThreadMigrationSourceProjectGroup,
+} from "@pwragent/shared";
+import type { DesktopApi } from "../../../lib/desktop-api";
+import { ThreadManagementSettings } from "../ThreadManagementSettings";
+
+afterEach(() => {
+  cleanup();
+});
+
+function createDeferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
+function migrationThreadsResponse(
+  sourceProfile: string,
+  threadTitle: string,
+): ListThreadMigrationSourceThreadsResponse {
+  const project: ThreadMigrationSourceProjectGroup = {
+    key: `directory:/repo/${sourceProfile || "default"}`,
+    label: sourceProfile || "System default",
+    path: `/repo/${sourceProfile || "default"}`,
+    threads: [
+      {
+        sourceProfile,
+        threadId: `${sourceProfile || "default"}-thread`,
+        title: threadTitle,
+        projectKey: `/repo/${sourceProfile || "default"}`,
+        linkedDirectories: [
+          {
+            id: `local:/repo/${sourceProfile || "default"}`,
+            label: sourceProfile || "System default",
+            path: `/repo/${sourceProfile || "default"}`,
+            kind: "local",
+          },
+        ],
+      },
+    ],
+  };
+  return {
+    sourceProfile,
+    fetchedAt: Date.now(),
+    projects: [project],
+  };
+}
+
+describe("ThreadManagementSettings", () => {
+  it("ignores stale source thread responses after switching profiles", async () => {
+    const defaultThreads = createDeferred<ListThreadMigrationSourceThreadsResponse>();
+    const personalThreads = createDeferred<ListThreadMigrationSourceThreadsResponse>();
+    const listThreadMigrationSourceThreads = vi.fn<
+      NonNullable<DesktopApi["listThreadMigrationSourceThreads"]>
+    >((request) =>
+      request.sourceProfile === "personal"
+        ? personalThreads.promise
+        : defaultThreads.promise,
+    );
+    const desktopApi: DesktopApi = {
+      listThreadMigrationSources: vi.fn(
+        async (): Promise<ListThreadMigrationSourcesResponse> => ({
+          activeCodexProfile: "work",
+          profiles: [
+            {
+              profile: "",
+              displayName: "System default",
+              codexHome: "/Users/alice/.codex",
+              source: "default",
+              exists: true,
+              selected: false,
+              available: true,
+            },
+            {
+              profile: "personal",
+              displayName: "personal",
+              codexHome: "/Users/alice/.codex/profiles/personal",
+              source: "directory",
+              exists: true,
+              selected: false,
+              available: true,
+            },
+          ],
+        }),
+      ),
+      listThreadMigrationSourceThreads,
+    };
+
+    render(<ThreadManagementSettings desktopApi={desktopApi} />);
+
+    await waitFor(() => {
+      expect(listThreadMigrationSourceThreads).toHaveBeenCalledWith({
+        sourceProfile: "",
+      });
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: /personal/ }));
+
+    await waitFor(() => {
+      expect(listThreadMigrationSourceThreads).toHaveBeenCalledWith({
+        sourceProfile: "personal",
+      });
+    });
+
+    await act(async () => {
+      personalThreads.resolve(
+        migrationThreadsResponse("personal", "Personal profile thread"),
+      );
+    });
+
+    expect(await screen.findByText("Personal profile thread")).toBeInTheDocument();
+
+    await act(async () => {
+      defaultThreads.resolve(
+        migrationThreadsResponse("", "Stale default profile thread"),
+      );
+    });
+
+    expect(screen.getByText("Personal profile thread")).toBeInTheDocument();
+    expect(screen.queryByText("Stale default profile thread")).not.toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -20,8 +20,22 @@ import type {
 import { SettingsScreen } from "../SettingsScreen";
 import type { DesktopSettingsState } from "../useDesktopSettings";
 
+const originalScrollTo = window.scrollTo;
+
 afterEach(() => {
   cleanup();
+  Object.defineProperty(window, "scrollX", {
+    configurable: true,
+    value: 0,
+  });
+  Object.defineProperty(window, "scrollY", {
+    configurable: true,
+    value: 0,
+  });
+  Object.defineProperty(window, "scrollTo", {
+    configurable: true,
+    value: originalScrollTo,
+  });
   Object.defineProperty(window, "pwragent", {
     configurable: true,
     value: undefined,
@@ -342,6 +356,45 @@ function createArchivedSnapshot(
 }
 
 describe("SettingsScreen", () => {
+  it("clamps accidental document scroll while mounted", async () => {
+    Object.defineProperty(window, "scrollX", {
+      configurable: true,
+      value: 0,
+    });
+    Object.defineProperty(window, "scrollY", {
+      configurable: true,
+      value: 1481,
+    });
+    const scrollTo = vi.fn();
+    Object.defineProperty(window, "scrollTo", {
+      configurable: true,
+      value: scrollTo,
+    });
+    const desktopApi = {
+      logRendererDiagnostic: vi.fn(async () => undefined),
+    };
+
+    render(
+      <SettingsScreen
+        desktopApi={desktopApi}
+        settings={createSettingsState()}
+        onClose={() => undefined}
+      />,
+    );
+
+    await waitFor(() => expect(scrollTo).toHaveBeenCalledWith(0, 0));
+    expect(desktopApi.logRendererDiagnostic).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: "warn",
+        message: "Settings document scroll clamped.",
+        details: expect.objectContaining({
+          scrollX: 0,
+          scrollY: 1481,
+        }),
+      }),
+    );
+  });
+
   it("switches sections and saves settings", async () => {
     const settings = createSettingsState();
     const desktopApi = {

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -2602,6 +2602,7 @@ describe("SettingsScreen", () => {
       "ACP Agents",
       "Messaging",
       "Worktrees",
+      "Thread Management",
       "Archived Threads",
       "Experimental",
       "About",

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -78,6 +78,9 @@ import type {
   ListMessagingActivityResponse,
   ListMessagingPairingRequestsRequest,
   ListMessagingPairingRequestsResponse,
+  ListThreadMigrationSourceThreadsRequest,
+  ListThreadMigrationSourceThreadsResponse,
+  ListThreadMigrationSourcesResponse,
   MessagingPairingEntry,
   MessagingPlatformStatus,
   MessagingPlatformStatusEvent,
@@ -128,6 +131,8 @@ import type {
   StartThreadResponse,
   StartReviewRequest,
   StartReviewResponse,
+  StartThreadMigrationRequest,
+  StartThreadMigrationResponse,
   StartTurnRequest,
   StartTurnResponse,
   SubmitServerRequestRequest,
@@ -323,6 +328,13 @@ export type DesktopApi = {
   restoreThread?: (
     request: RestoreThreadRequest
   ) => Promise<RestoreThreadResponse>;
+  listThreadMigrationSources?: () => Promise<ListThreadMigrationSourcesResponse>;
+  listThreadMigrationSourceThreads?: (
+    request: ListThreadMigrationSourceThreadsRequest,
+  ) => Promise<ListThreadMigrationSourceThreadsResponse>;
+  startThreadMigration?: (
+    request: StartThreadMigrationRequest,
+  ) => Promise<StartThreadMigrationResponse>;
   archiveWorktree?: (
     request: ArchiveWorktreeRequest
   ) => Promise<ArchiveWorktreeResponse>;

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -81,6 +81,7 @@ import type {
   ListThreadMigrationSourceThreadsRequest,
   ListThreadMigrationSourceThreadsResponse,
   ListThreadMigrationSourcesResponse,
+  RetryThreadMigrationRequest,
   MessagingPairingEntry,
   MessagingPlatformStatus,
   MessagingPlatformStatusEvent,
@@ -334,6 +335,9 @@ export type DesktopApi = {
   ) => Promise<ListThreadMigrationSourceThreadsResponse>;
   startThreadMigration?: (
     request: StartThreadMigrationRequest,
+  ) => Promise<StartThreadMigrationResponse>;
+  retryThreadMigration?: (
+    request: RetryThreadMigrationRequest,
   ) => Promise<StartThreadMigrationResponse>;
   archiveWorktree?: (
     request: ArchiveWorktreeRequest

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -178,6 +178,18 @@ describe("Tangerine Terminal theme contract", () => {
     );
   });
 
+  it("keeps thread migration project headers sticky inside the project list", () => {
+    const projectHeaderRule = extractRuleBody(
+      css,
+      ".settings-thread-management__project-head",
+    );
+
+    expect(projectHeaderRule).toContain("position: sticky;");
+    expect(projectHeaderRule).toContain("top: 0;");
+    expect(projectHeaderRule).toContain("z-index: 3;");
+    expect(projectHeaderRule).toContain("background: var(--bg-panel-elevated);");
+  });
+
   it("keeps onboarding and warning overlays clickable without losing window drag affordances", () => {
     const overlayRule = extractRuleBody(css, ".onboarding-wizard-overlay");
     const titlebarRule = extractRuleBody(css, ".onboarding-wizard__titlebar");

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5194,6 +5194,12 @@ textarea,
   color: var(--danger-text);
 }
 
+.settings-thread-management__retry {
+  min-height: 28px;
+  padding: 0 9px;
+  white-space: nowrap;
+}
+
 .settings-thread-management__checkbox-input {
   position: relative;
   z-index: 1;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5170,6 +5170,27 @@ textarea,
   background: var(--bg-row-active);
 }
 
+.settings-thread-management__run-details {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 3px;
+  margin-top: 6px;
+}
+
+.settings-thread-management__run-detail,
+.settings-thread-management__run-warning {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.settings-thread-management__run-warning {
+  color: var(--danger-text);
+}
+
 .settings-thread-management__checkbox-input {
   position: relative;
   z-index: 1;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3278,7 +3278,9 @@ textarea,
 .app-shell__settings-layer {
   display: flex;
   position: absolute;
-  z-index: 30;
+  /* Above thread chrome including the context rail/tooltips. Settings is
+     a full-window surface, not a sibling panel in the thread layout. */
+  z-index: 120;
   inset: 0;
   min-width: 0;
   min-height: 0;
@@ -5099,11 +5101,13 @@ textarea,
 .settings-thread-management__selection-shell {
   display: flex;
   min-height: 0;
+  max-height: clamp(360px, 64vh, 760px);
   flex-direction: column;
 }
 
 .settings-thread-management__projects-list {
-  max-height: clamp(280px, 52vh, 680px);
+  min-height: 0;
+  flex: 1 1 auto;
   overflow: auto;
 }
 
@@ -5224,17 +5228,14 @@ textarea,
 }
 
 .settings-thread-management__actionbar {
-  position: sticky;
-  z-index: 2;
-  bottom: 0;
   display: flex;
+  flex: 0 0 auto;
   align-items: center;
   justify-content: space-between;
   gap: 16px;
   padding: 12px 18px;
   border-top: 1px solid var(--border-subtle);
   background: var(--bg-panel-elevated);
-  box-shadow: 0 -10px 18px var(--shadow-tint-faint);
 }
 
 .settings-thread-management__actioncopy {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5241,7 +5241,7 @@ textarea,
   justify-content: space-between;
   gap: 16px;
   padding: 12px 18px;
-  border-top: 1px solid var(--border-subtle);
+  border-bottom: 1px solid var(--border-subtle);
   background: var(--bg-panel-elevated);
 }
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5103,12 +5103,14 @@ textarea,
   min-height: 0;
   max-height: clamp(360px, 64vh, 760px);
   flex-direction: column;
+  overflow-anchor: none;
 }
 
 .settings-thread-management__projects-list {
   min-height: 0;
   flex: 1 1 auto;
   overflow: auto;
+  overflow-anchor: none;
 }
 
 .settings-thread-management__project {
@@ -5169,17 +5171,21 @@ textarea,
 }
 
 .settings-thread-management__checkbox-input {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
-  clip: rect(0 0 0 0);
-  clip-path: inset(50%);
-  white-space: nowrap;
+  position: relative;
+  z-index: 1;
+  grid-column: 1;
+  grid-row: 1;
+  width: 16px;
+  height: 16px;
+  margin: 1px 0 0;
+  cursor: pointer;
+  opacity: 0;
 }
 
 .settings-thread-management__checkbox {
   position: relative;
+  grid-column: 1;
+  grid-row: 1;
   display: inline-flex;
   width: 16px;
   height: 16px;
@@ -5191,6 +5197,7 @@ textarea,
   border-radius: 4px;
   background: var(--bg-input);
   box-shadow: inset 0 0 0 1px var(--bg-app);
+  pointer-events: none;
 }
 
 .settings-thread-management__checkbox--project {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5267,6 +5267,22 @@ textarea,
   font-weight: 600;
 }
 
+.settings-thread-management__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.settings-thread-management__toggle input {
+  width: 14px;
+  height: 14px;
+  margin: 0;
+  accent-color: var(--accent);
+}
+
 .settings-thread-management__copy-strategy select {
   min-height: 32px;
   padding: 0 28px 0 10px;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5098,6 +5098,7 @@ textarea,
 
 .settings-thread-management__project {
   border-top: 1px solid var(--border-subtle);
+  background: var(--bg-panel);
 }
 
 .settings-thread-management__project:first-child {
@@ -5109,7 +5110,9 @@ textarea,
   gap: 12px;
   align-items: center;
   justify-content: space-between;
-  padding: 14px 18px;
+  padding: 14px 18px 12px;
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-panel-elevated);
 }
 
 .settings-thread-management__project-title,
@@ -5119,7 +5122,7 @@ textarea,
 
 .settings-thread-management__project-title {
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 650;
   line-height: 1.3;
 }
@@ -5133,16 +5136,78 @@ textarea,
 }
 
 .settings-thread-management__thread {
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: start;
   width: 100%;
-  border-right: 0;
-  border-bottom: 0;
-  border-left: 0;
+  padding: 13px 18px 13px 30px;
+  border-top: 1px solid var(--border-subtle);
   background: transparent;
+  cursor: pointer;
   text-align: left;
 }
 
 .settings-thread-management__thread.is-selected {
   background: var(--bg-row-active);
+}
+
+.settings-thread-management__project-select {
+  display: inline-flex;
+  min-height: 30px;
+  align-items: center;
+  gap: 8px;
+  padding: 0 10px;
+  border: 1px solid var(--border-default, var(--border-subtle));
+  border-radius: 6px;
+  background: var(--bg-input);
+  color: var(--text-primary);
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.settings-thread-management__checkbox-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.settings-thread-management__checkbox {
+  position: relative;
+  display: inline-flex;
+  width: 14px;
+  height: 14px;
+  flex: 0 0 14px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border-default, var(--border-subtle));
+  border-radius: 4px;
+  background: var(--bg-input);
+}
+
+.settings-thread-management__checkbox.is-checked {
+  border-color: var(--accent-border);
+  background: var(--accent);
+}
+
+.settings-thread-management__checkbox.is-checked::after {
+  width: 7px;
+  height: 4px;
+  border-bottom: 2px solid var(--bg-app);
+  border-left: 2px solid var(--bg-app);
+  content: "";
+  transform: translateY(-1px) rotate(-45deg);
+}
+
+.settings-thread-management__checkbox-input:focus-visible
+  + .settings-thread-management__checkbox {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--accent-shadow);
 }
 
 .settings-thread-management__controls {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5082,6 +5082,90 @@ textarea,
   white-space: nowrap;
 }
 
+.settings-thread-management__status {
+  padding: 14px 18px;
+}
+
+.settings-thread-management__profile {
+  width: 100%;
+  text-align: left;
+}
+
+.settings-thread-management__profile:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
+.settings-thread-management__project {
+  border-top: 1px solid var(--border-subtle);
+}
+
+.settings-thread-management__project:first-child {
+  border-top: 0;
+}
+
+.settings-thread-management__project-head {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 18px;
+}
+
+.settings-thread-management__project-title,
+.settings-thread-management__project-path {
+  margin: 0;
+}
+
+.settings-thread-management__project-title {
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 650;
+  line-height: 1.3;
+}
+
+.settings-thread-management__project-path {
+  margin-top: 4px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.settings-thread-management__thread {
+  width: 100%;
+  border-right: 0;
+  border-bottom: 0;
+  border-left: 0;
+  background: transparent;
+  text-align: left;
+}
+
+.settings-thread-management__thread.is-selected {
+  background: var(--bg-row-active);
+}
+
+.settings-thread-management__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: end;
+  padding: 14px 18px;
+}
+
+.settings-thread-management__segmented {
+  display: flex;
+  gap: 6px;
+}
+
+.settings-thread-management__strategy {
+  display: grid;
+  min-width: 220px;
+  gap: 6px;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
 .settings-confirm-modal {
   position: fixed;
   z-index: 120;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5107,7 +5107,7 @@ textarea,
 
 .settings-thread-management__project-head {
   display: grid;
-  grid-template-columns: 18px minmax(0, 1fr) auto;
+  grid-template-columns: 18px minmax(0, 1fr);
   gap: 12px;
   align-items: start;
   padding: 14px 18px 12px;
@@ -5151,20 +5151,6 @@ textarea,
 
 .settings-thread-management__thread.is-selected {
   background: var(--bg-row-active);
-}
-
-.settings-thread-management__project-select {
-  display: inline-flex;
-  min-height: 30px;
-  align-items: center;
-  padding: 0 10px;
-  border: 1px solid var(--border-default, var(--border-subtle));
-  border-radius: 6px;
-  background: var(--bg-input);
-  color: var(--text-primary);
-  cursor: pointer;
-  font-size: 12px;
-  font-weight: 650;
 }
 
 .settings-thread-management__checkbox-input {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5106,13 +5106,14 @@ textarea,
 }
 
 .settings-thread-management__project-head {
-  display: flex;
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr) auto;
   gap: 12px;
-  align-items: center;
-  justify-content: space-between;
+  align-items: start;
   padding: 14px 18px 12px;
   border-bottom: 1px solid var(--border-subtle);
   background: var(--bg-panel-elevated);
+  cursor: pointer;
 }
 
 .settings-thread-management__project-title,
@@ -5141,7 +5142,7 @@ textarea,
   gap: 12px;
   align-items: start;
   width: 100%;
-  padding: 13px 18px 13px 30px;
+  padding: 13px 18px 13px 48px;
   border-top: 1px solid var(--border-subtle);
   background: transparent;
   cursor: pointer;
@@ -5156,7 +5157,6 @@ textarea,
   display: inline-flex;
   min-height: 30px;
   align-items: center;
-  gap: 8px;
   padding: 0 10px;
   border: 1px solid var(--border-default, var(--border-subtle));
   border-radius: 6px;
@@ -5180,26 +5180,34 @@ textarea,
 .settings-thread-management__checkbox {
   position: relative;
   display: inline-flex;
-  width: 14px;
-  height: 14px;
-  flex: 0 0 14px;
+  width: 16px;
+  height: 16px;
+  flex: 0 0 16px;
   align-items: center;
   justify-content: center;
-  border: 1px solid var(--border-default, var(--border-subtle));
+  margin-top: 1px;
+  border: 1.5px solid var(--text-muted);
   border-radius: 4px;
   background: var(--bg-input);
+  box-shadow: inset 0 0 0 1px var(--bg-app);
+}
+
+.settings-thread-management__checkbox--project {
+  margin-top: 2px;
+  border-color: var(--text-secondary);
 }
 
 .settings-thread-management__checkbox.is-checked {
   border-color: var(--accent-border);
   background: var(--accent);
+  box-shadow: none;
 }
 
 .settings-thread-management__checkbox.is-checked::after {
-  width: 7px;
-  height: 4px;
-  border-bottom: 2px solid var(--bg-app);
-  border-left: 2px solid var(--bg-app);
+  width: 8px;
+  height: 5px;
+  border-bottom: 2px solid var(--bg-panel);
+  border-left: 2px solid var(--bg-panel);
   content: "";
   transform: translateY(-1px) rotate(-45deg);
 }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5124,6 +5124,9 @@ textarea,
 
 .settings-thread-management__project-head {
   display: grid;
+  position: sticky;
+  top: 0;
+  z-index: 3;
   grid-template-columns: 18px minmax(0, 1fr);
   gap: 12px;
   align-items: start;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5234,6 +5234,25 @@ textarea,
   justify-content: flex-end;
 }
 
+.settings-thread-management__copy-strategy {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.settings-thread-management__copy-strategy select {
+  min-height: 32px;
+  padding: 0 28px 0 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-input);
+  color: var(--text-primary);
+  font: inherit;
+}
+
 .settings-thread-management__actionbar {
   display: flex;
   flex: 0 0 auto;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5096,6 +5096,17 @@ textarea,
   opacity: 0.65;
 }
 
+.settings-thread-management__selection-shell {
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.settings-thread-management__projects-list {
+  max-height: clamp(280px, 52vh, 680px);
+  overflow: auto;
+}
+
 .settings-thread-management__project {
   border-top: 1px solid var(--border-subtle);
   background: var(--bg-panel);
@@ -5207,22 +5218,46 @@ textarea,
 .settings-thread-management__controls {
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
-  align-items: end;
-  padding: 14px 18px;
+  gap: 8px;
+  align-items: center;
+  justify-content: flex-end;
 }
 
-.settings-thread-management__segmented {
+.settings-thread-management__actionbar {
+  position: sticky;
+  z-index: 2;
+  bottom: 0;
   display: flex;
-  gap: 6px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 18px;
+  border-top: 1px solid var(--border-subtle);
+  background: var(--bg-panel-elevated);
+  box-shadow: 0 -10px 18px var(--shadow-tint-faint);
 }
 
-.settings-thread-management__strategy {
-  display: grid;
-  min-width: 220px;
-  gap: 6px;
+.settings-thread-management__actioncopy {
+  min-width: 0;
+}
+
+.settings-thread-management__action-title,
+.settings-thread-management__action-description {
+  margin: 0;
+}
+
+.settings-thread-management__action-title {
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.3;
+}
+
+.settings-thread-management__action-description {
+  margin-top: 3px;
   color: var(--text-secondary);
   font-size: 12px;
+  line-height: 1.4;
 }
 
 .settings-confirm-modal {

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -8,6 +8,11 @@ export const APP_SERVER_RESTORE_WORKTREE_CHANNEL = "app-server:restore-worktree"
 export const APP_SERVER_HANDOFF_THREAD_WORKSPACE_CHANNEL =
   "app-server:handoff-thread-workspace";
 export const APP_SERVER_RENAME_THREAD_CHANNEL = "app-server:rename-thread";
+export const THREAD_MIGRATION_LIST_SOURCES_CHANNEL =
+  "thread-migration:list-sources";
+export const THREAD_MIGRATION_LIST_SOURCE_THREADS_CHANNEL =
+  "thread-migration:list-source-threads";
+export const THREAD_MIGRATION_START_CHANNEL = "thread-migration:start";
 export const FOCUSED_DIFF_ANALYZE_CHANNEL = "focused-diff:analyze";
 export const BACKEND_LIST_CHANNEL = "backend:list";
 export const ACP_AGENTS_LIST_CHANNEL = "acp-agents:list";

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -13,6 +13,7 @@ export const THREAD_MIGRATION_LIST_SOURCES_CHANNEL =
 export const THREAD_MIGRATION_LIST_SOURCE_THREADS_CHANNEL =
   "thread-migration:list-source-threads";
 export const THREAD_MIGRATION_START_CHANNEL = "thread-migration:start";
+export const THREAD_MIGRATION_RETRY_CHANNEL = "thread-migration:retry";
 export const FOCUSED_DIFF_ANALYZE_CHANNEL = "focused-diff:analyze";
 export const BACKEND_LIST_CHANNEL = "backend:list";
 export const ACP_AGENTS_LIST_CHANNEL = "acp-agents:list";

--- a/docs/plans/2026-05-31-001-feat-thread-profile-migration-plan.md
+++ b/docs/plans/2026-05-31-001-feat-thread-profile-migration-plan.md
@@ -1,0 +1,768 @@
+---
+title: feat: Add cross-profile thread migration
+type: feat
+status: active
+date: 2026-05-31
+deepened: 2026-05-31
+---
+
+# feat: Add cross-profile thread migration
+
+## Overview
+
+Add a desktop Thread Management / Thread Migration surface that lets an operator
+copy or move Codex threads from another Codex auth profile into the currently
+owned PwrAgent profile. The implementation must use Codex App Server (CAS) as
+the only interface to Codex-owned thread storage: PwrAgent may pass rollout
+paths to source and destination CAS instances, but must not read or write Codex
+session JSONL, rollout files, or Codex databases directly.
+
+The intended migration primitive is destination CAS `thread/fork` using the
+source thread's rollout path. `thread/inject_items` remains a research fallback
+for edge cases where fork-by-path cannot preserve the necessary model-visible
+history.
+
+## Problem Frame
+
+PwrAgent profiles isolate settings, state, worktrees, and selected Codex auth
+profiles. Today a user running a profile such as `work` cannot conveniently pull
+threads from another Codex profile such as system default or `personal` into the
+current profile. The recent thread-fork work proves that a forked thread can
+preserve history when CAS performs the fork, and the generated Codex protocol
+types show that `thread/fork` can target a rollout `path`. That gives PwrAgent a
+profile-safe way to ask the destination CAS to copy a source thread without
+opening Codex private storage itself.
+
+The hard part is not the thread history copy alone. A real migration must also
+handle selection by source profile/project/thread, validation, source archive,
+and profile-owned worktrees. Move is the safest operator workflow because there
+is one surviving thread/worktree owner after validation. Copy is inherently more
+complex because Git cannot keep the same branch checked out in two worktrees, so
+copy requires an explicit branch-conflict strategy.
+
+## Requirements Trace
+
+- R1. List Codex auth profiles other than the current profile's selected Codex
+  auth profile.
+- R2. Start a captive source CAS instance for a selected source profile, using
+  only CAS methods for source thread list/read/archive behavior.
+- R3. Present source threads grouped by project/workspace, with selection for all
+  threads, one project, or individual threads.
+- R4. Copy selected source threads into the current owned destination CAS by
+  passing source rollout paths to destination `thread/fork`.
+- R5. Validate migrated threads by comparing source and destination CAS-visible
+  replay/history before any destructive source-side action.
+- R6. Make Move the primary workflow: fork/copy, migrate worktrees, validate,
+  then archive the source thread only after the destination is complete.
+- R7. Support Copy as an advanced workflow that leaves source threads intact and
+  forces a branch-conflict strategy for profile-owned source worktrees.
+- R8. Preserve the Codex storage boundary: PwrAgent may pass rollout paths to CAS
+  but must not parse, mutate, or index Codex-owned storage files directly.
+- R9. Keep destination threads in the same project folders where practical, and
+  copy/move profile-owned worktrees into current-profile-owned locations.
+- R10. Surface per-thread migration status, validation failures, and partial
+  completion so the operator can retry or inspect failures without guessing.
+- R11. Avoid logging migrated transcript content, raw Responses items, auth
+  tokens, or source-profile secrets while still logging enough ids/statuses to
+  debug failed runs.
+
+## Scope Boundaries
+
+- In scope: Codex-backed threads and Codex auth profiles discoverable under the
+  existing Codex profile model.
+- In scope: local desktop migration driven from the active PwrAgent profile.
+- In scope: active and archived source thread listing if source CAS supports it.
+- In scope: profile-owned worktree paths under `.codex`, `.pwragent`, or
+  `.pwragnt` worktree roots already recognized by PwrAgent.
+- In scope: Move and Copy with explicit validation and branch conflict handling.
+- Out of scope: migrating Grok or ACP threads.
+- Out of scope: migrating messaging bindings, automations, reactions, pins, or
+  PwrAgent overlay metadata from another PwrAgent profile database.
+- Out of scope: reading or writing Codex rollout/session files directly.
+- Out of scope: cross-machine migration, remote storage synchronization, or
+  resolving divergent Git remotes beyond branch/worktree safety checks.
+- Out of scope: showing source transcript contents in the migration picker before
+  the operator explicitly opens or migrates a source thread.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `apps/desktop/src/main/settings/codex-profiles.ts` already discovers Codex auth
+  profiles and resolves `CODEX_HOME` for a named Codex profile.
+- `apps/desktop/src/main/settings/desktop-settings-service.ts` freezes the active
+  profile's startup `CODEX_HOME` and exposes the environment used for owned
+  Codex subprocesses.
+- `apps/desktop/src/main/codex-app-server/client.ts` owns the stdio JSON-RPC CAS
+  transport, `thread/list`, `thread/read`, `thread/fork`, and `thread/archive`.
+- `packages/codex-app-server-protocol/src/v2/ThreadForkParams.ts` supports
+  `path` as an unstable rollout path input. When present, CAS ignores
+  `threadId`.
+- `packages/codex-app-server-protocol/src/v2/ThreadInjectItemsParams.ts` exposes
+  `thread/inject_items` for raw Responses API items, but PwrAgent currently has
+  no wrapper and normalized `readThread` replay is too lossy to be the first
+  migration primitive.
+- `apps/desktop/src/main/app-server/backend-registry.ts` is the current desktop
+  orchestration boundary for thread fork, archive, read, and worktree owner
+  recording.
+- `apps/desktop/src/main/app-server/git-directory-service.ts` records
+  `codex-thread.json` worktree owner metadata without reading Codex private
+  storage.
+- `apps/desktop/src/main/app-server/worktree-archive-service.ts` contains the
+  existing snapshot/restore pattern for removing and restoring Git worktrees.
+- `packages/shared/src/worktree-paths.ts` centralizes detection of tool-managed
+  worktree paths.
+- `apps/desktop/src/renderer/src/features/settings/ArchivedThreadsSettings.tsx`
+  and `ProfilesSettings.tsx` show existing Settings patterns for grouped thread
+  rows, profile rows, and profile actions.
+- `apps/desktop/src/renderer/src/lib/useThreadNavigation.ts` and
+  `Sidebar.tsx` already consume fork/archive capabilities and can refresh
+  navigation after thread lifecycle changes.
+
+### Institutional Learnings
+
+- `docs/solutions/2026-05-07-codex-permission-mode-state-machine.md` documents
+  that Codex thread state is sticky and CAS-owned. PwrAgent should drive thread
+  changes through CAS APIs rather than assuming on-disk state can be safely
+  patched from the desktop process.
+- `docs/plans/2026-04-16-004-feat-codex-access-mode-toggle-plan.md` established
+  the pattern of keeping Codex profile/process routing below the `codex` backend
+  identity, rather than exposing process/profile internals as separate user
+  backends.
+
+### External References
+
+- None. This plan depends on the generated local Codex App Server protocol types
+  in this repository and on existing PwrAgent profile/worktree architecture.
+
+## Key Technical Decisions
+
+- Use fork-by-path as the primary history migration primitive. Destination CAS
+  can receive the source rollout path and perform the copy without PwrAgent
+  opening Codex private storage. This is better aligned with the repository's
+  Codex storage boundary than reconstructing history from normalized replay.
+- Keep captive source CAS clients main-process only. The renderer sees source
+  profile, project, thread, and status summaries through PwrAgent IPC, not raw
+  CAS clients or filesystem paths beyond operator-facing labels.
+- Exclude the active destination Codex auth profile from selectable sources. A
+  profile should never migrate from itself into itself.
+- Treat Move as the recommended action and Copy as an advanced action. Move has a
+  single final owner and avoids duplicate worktree branch checkout conflicts.
+- Archive the source thread last in Move. Source archive can remove or invalidate
+  worktrees through PwrAgent cleanup or CAS-side lifecycle behavior, so the
+  destination thread and worktree must be complete and validated first.
+- Reuse existing worktree ownership and archive/restore concepts, but add a
+  migration-specific worktree path flow. Migration needs "move/copy to the
+  destination profile-owned location" before source archive, not "archive source
+  first and restore later."
+- Validate at CAS-visible boundaries. Source CAS `thread/read` and destination
+  CAS `thread/read` should agree on the user/assistant-visible history shape
+  before destructive cleanup proceeds.
+- Keep `thread/inject_items` behind a narrow spike or fallback. It requires raw
+  Responses API items and can become subtly lossy if fed from PwrAgent's
+  normalized transcript replay.
+- Persist migration runs in PwrAgent state. Operators need recovery, retry, and
+  failure visibility if a batch partially migrates.
+- Store migration diagnostics as metadata, not transcript content. Run state can
+  record source/destination ids, profile ids, validation counts, status, and
+  error summaries, but should not persist full message text or raw Responses
+  items outside CAS.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should PwrAgent read Codex rollout/session files directly to migrate history?
+  No. PwrAgent may pass rollout paths to CAS but must not parse or mutate Codex
+  private files or databases.
+- Should source archive happen before worktree migration? No. Move must fork,
+  migrate/copy worktrees, validate, and only then archive the source thread.
+- Should Copy be first-class? Yes, but not the primary recommendation. It needs
+  explicit branch conflict handling before proceeding.
+- Should this be placed under Settings or the main thread surface? Plan for a
+  Settings-hosted Thread Management tool first, because it is a profile/data
+  maintenance workflow rather than normal thread navigation.
+
+### Deferred to Implementation
+
+- Whether current CAS `thread/list` summaries always expose the rollout path
+  needed for fork-by-path, or whether source CAS `thread/read` must provide it.
+  Implementation should discover this through protocol tests and add only the
+  minimum normalized metadata needed.
+- Exact validation strictness: implementation should start with message-count,
+  role-order, and text/part checks, then tighten only if CAS returns stable item
+  identifiers across fork-by-path.
+- Exact destination path naming for moved profile-owned worktrees when the
+  destination worktree root already contains a collision.
+- Whether source archived threads should be included in the first release of the
+  picker or deferred behind a toggle.
+- Whether destination CAS returns a source rollout path in `thread/list` or only
+  in `thread/read`; the implementation should prove the least-privilege source
+  call through tests before broadening metadata exposed to the renderer.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review,
+> not implementation specification. The implementing agent should treat it as
+> context, not code to reproduce.*
+
+```mermaid
+sequenceDiagram
+    participant UI as Thread Migration UI
+    participant MIG as ThreadMigrationService
+    participant SRC as Captive Source CAS
+    participant DST as Owned Destination CAS
+    participant GIT as Git/Worktree Services
+
+    UI->>MIG: choose source profile and selection
+    MIG->>SRC: thread/list and thread/read via source CODEX_HOME
+    MIG->>DST: thread/fork with source rollout path
+    MIG->>SRC: thread/read for validation baseline
+    MIG->>DST: thread/read for migrated replay
+    MIG->>GIT: move/copy profile-owned worktree if needed
+    MIG->>DST: update/record destination workspace ownership
+    MIG->>DST: re-read destination for final validation
+    alt Move
+        MIG->>SRC: thread/archive only after validation
+    else Copy
+        MIG->>GIT: apply selected branch conflict strategy
+    end
+    MIG->>UI: per-thread result and retry state
+```
+
+### Operation Matrix
+
+| Operation | Source thread | Source worktree | Destination thread | Destination worktree |
+|---|---|---|---|---|
+| Move | Archived last, after validation | Moved/copied before archive, old owner removed only after success | New fork-by-path copy | Current-profile-owned path |
+| Copy with source suffix | Left active | Source branch renamed with source-profile suffix if needed | New fork-by-path copy | Original or generated branch in destination |
+| Copy with destination suffix | Left active | Left intact | New fork-by-path copy | Destination branch gets generated suffix |
+| Copy detached | Left active | Left intact | New fork-by-path copy | Destination worktree checked out detached when branch cannot be shared |
+
+For Copy, "left active" means the source thread and source worktree remain
+usable. The source-suffix strategy may rename the branch currently checked out
+by the source worktree, but it must not remove or archive the source worktree.
+
+## Implementation Units
+
+- [x] **Unit 1: Add migration contracts and run state**
+
+**Goal:** Define the main/renderer contract for listing source profiles, browsing
+source threads, creating migration runs, and reporting per-thread migration
+status.
+
+**Requirements:** R1, R3, R10
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/shared/src/contracts/agent.ts`
+- Modify: `packages/shared/src/contracts/backend.ts`
+- Modify: `packages/shared/src/contracts/navigation.ts`
+- Modify: `packages/shared/src/contracts/normalized-app-server.ts`
+- Modify: `apps/desktop/src/shared/ipc.ts`
+- Modify: `apps/desktop/src/renderer/src/lib/desktop-api.ts`
+- Modify: `apps/desktop/src/preload/index.ts`
+- Test: `packages/shared/src/__tests__/profile-names.test.ts`
+- Create test: `apps/desktop/src/renderer/src/lib/__tests__/desktop-api.test.ts`
+
+**Approach:**
+- Add explicit types for source Codex profile summaries, source project groups,
+  source thread summaries, migration selection, operation type, branch conflict
+  strategy, and migration run item status.
+- Keep source profile ids aligned with existing Codex profile naming: empty
+  string remains the system default sentinel and named profiles use normalized
+  names.
+- Do not expose raw source CAS handles to the renderer. Expose only bounded
+  summaries and migration action requests.
+- Include enough status structure for partial batch recovery: pending, copying,
+  validating, worktree handling, source archiving, completed, failed, skipped.
+
+**Patterns to follow:**
+- Existing settings/profile contracts in `packages/shared/src/contracts/settings.ts`.
+- Existing thread lifecycle request/response contracts in
+  `packages/shared/src/contracts/normalized-app-server.ts`.
+
+**Test scenarios:**
+- Happy path: a request selecting one source profile and three thread ids
+  serializes through preload without dropping operation or strategy fields.
+- Edge case: the empty source profile id is accepted as the system default but
+  invalid named profile strings are rejected or normalized consistently.
+- Error path: a migration run item can represent a validation failure with an
+  operator-facing reason and without losing the source thread id.
+
+**Verification:**
+- Shared contracts compile across main, preload, and renderer.
+- Renderer-facing APIs expose migration operations without importing desktop
+  main-process modules.
+
+- [x] **Unit 2: Extend Codex client support for fork-by-path and raw migration metadata**
+
+**Goal:** Let PwrAgent ask destination CAS to fork a source rollout path and
+capture the minimum CAS-visible source metadata needed for migration.
+
+**Requirements:** R2, R4, R5, R8
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `apps/desktop/src/main/codex-app-server/client.ts`
+- Modify: `apps/desktop/src/main/app-server/backend-registry.ts`
+- Test: `apps/desktop/src/main/__tests__/codex-client.test.ts`
+- Test: `apps/desktop/src/main/__tests__/backend-registry.test.ts`
+
+**Approach:**
+- Extend the existing `forkThread` path to optionally send a rollout path to CAS
+  while preserving current thread-id fork behavior for sidebar forks.
+- Normalize source rollout path metadata only as data returned by CAS. Do not
+  inspect the file.
+- Add a narrow `readThreadForMigration` or equivalent internal helper only if
+  existing `readThread` cannot expose the necessary path/metadata safely.
+- Add a small `thread/inject_items` client wrapper only if the fork-by-path spike
+  shows a real gap; keep it out of the default migration flow until proven.
+
+**Patterns to follow:**
+- Existing `buildThreadForkPayload` and request fallback patterns in
+  `apps/desktop/src/main/codex-app-server/client.ts`.
+- Existing client tests around `thread/fork` and `thread/archive`.
+
+**Test scenarios:**
+- Happy path: `forkThread` with a source path sends `thread/fork` with `path`
+  and still includes permission/model overrides where applicable.
+- Happy path: existing thread-id sidebar fork requests continue to send
+  `threadId` without `path`.
+- Error path: destination CAS returning no `threadId` still raises the existing
+  normalized error.
+- Integration: backend registry can call the extended client without changing
+  existing sidebar fork behavior.
+
+**Verification:**
+- Existing thread fork tests still pass.
+- New tests prove no Codex storage file is opened by the fork-by-path path.
+- Client diagnostics do not include raw transcript content or raw Responses
+  items.
+
+- [x] **Unit 3: Add captive source CAS lifecycle**
+
+**Goal:** Create, cache, and dispose source-profile CAS clients that list and
+read threads from non-active Codex profiles without contaminating the owned
+destination CAS.
+
+**Requirements:** R1, R2, R3, R8
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Create: `apps/desktop/src/main/app-server/thread-migration-service.ts`
+- Modify: `apps/desktop/src/main/app-server/backend-registry.ts`
+- Modify: `apps/desktop/src/main/settings/codex-profiles.ts`
+- Modify: `apps/desktop/src/main/settings/desktop-settings-service.ts`
+- Test: `apps/desktop/src/main/__tests__/thread-migration-service.test.ts`
+- Test: `apps/desktop/src/main/__tests__/codex-profiles.test.ts`
+
+**Approach:**
+- Build source CAS clients with the same command/args conventions as the owned
+  `CodexAppServerClient`, but with `CODEX_HOME` set to the selected source
+  profile's home.
+- Exclude the active effective destination Codex profile from the source list.
+- Scope lifecycle to the migration window/tool: start lazily when the user opens
+  a source, reuse while browsing that source, close on window close, profile
+  switch, or app shutdown.
+- Keep source CAS read-only until the user confirms Move and the migration item
+  reaches the final archive stage.
+
+**Patterns to follow:**
+- Existing `CodexAppServerClient` construction in `BackendRegistry`.
+- Existing profile discovery and auth status flows in `settings/codex-profiles.ts`
+  and `ipc/profiles.ts`.
+- Existing replay client injection style in backend registry tests.
+
+**Test scenarios:**
+- Happy path: active `work` destination excludes the `work` Codex auth profile
+  and includes system default plus other named profiles.
+- Happy path: selecting `default` starts a source client with `CODEX_HOME` for
+  system default and lists source threads through CAS.
+- Error path: missing auth or missing profile directory returns an unavailable
+  profile row instead of spawning a broken client.
+- Error path: source client startup failure is isolated to the migration tool and
+  does not affect the owned destination CAS.
+- Error path: source profile list includes account/profile availability metadata
+  but does not expose auth tokens or secret material.
+- Integration: closing the migration tool closes any captive source client.
+
+**Verification:**
+- Source and destination clients can be constructed with distinct environments.
+- The active destination profile cannot be selected as its own source.
+
+- [ ] **Unit 4: Implement migration run orchestration and validation**
+
+Progress note 2026-06-01: initial main-process migration orchestration now
+forks by source CAS rollout path, validates source/destination replay
+fingerprints, archives source last for non-worktree Move, and blocks Move before
+fork/archive when a profile-owned worktree is detected. Persistent run storage,
+retry/cancel semantics, and full archive-failure recovery remain open.
+
+**Goal:** Execute batch Copy/Move requests as resumable migration runs with
+per-thread validation, clear failure states, and source archive only after
+destination success.
+
+**Requirements:** R4, R5, R6, R10, R11
+
+**Dependencies:** Units 2 and 3
+
+**Files:**
+- Modify: `apps/desktop/src/main/app-server/thread-migration-service.ts`
+- Modify: `apps/desktop/src/main/state/overlay-store-sqlite.ts`
+- Modify: `packages/agent-core/src/persistence/overlay-store.ts`
+- Create test: `apps/desktop/src/main/__tests__/thread-migration-service.test.ts`
+- Create test: `apps/desktop/src/main/__tests__/thread-migration-store.test.ts`
+
+**Approach:**
+- Persist migration run state in the active PwrAgent profile database or overlay
+  state so a partial batch remains inspectable after restart.
+- For each selected thread, read source metadata/replay through source CAS,
+  fork into destination CAS by path, read destination replay, compare validation
+  fingerprints, then proceed to worktree handling.
+- For Move, call source archive only after destination history and worktree
+  validation pass.
+- Treat failures as per-item failures rather than aborting the entire batch
+  unless the source/destination CAS connection itself becomes unavailable.
+- Store source profile id, source thread id, destination thread id, operation,
+  validation summary, worktree result, and final status.
+- Store validation fingerprints/counts and status summaries, not full transcript
+  text or raw model items.
+
+**Patterns to follow:**
+- Existing per-thread transition logs in overlay store.
+- Existing archive result structure in `ArchiveThreadCleanupResult`.
+- Existing list cache invalidation after archive/fork in `BackendRegistry`.
+
+**Test scenarios:**
+- Happy path: Move forks a source thread, validates replay, migrates worktree
+  metadata, then archives the source thread last.
+- Happy path: Copy forks and validates but never calls source archive.
+- Edge case: a batch with one failing thread and one valid thread completes the
+  valid item and records the failed item with retryable state.
+- Error path: validation mismatch prevents source archive and marks the item
+  failed with source/destination thread ids for inspection.
+- Error path: source archive failure after successful destination migration marks
+  the item as `archive_failed` or equivalent without deleting destination state.
+- Error path: a validation failure stores enough metadata to retry/inspect but
+  does not persist message bodies in the PwrAgent state database.
+- Integration: destination thread list cache is invalidated after successful
+  migration so the new thread appears in navigation.
+
+**Verification:**
+- A failed validation never archives the source thread.
+- A successful Move archives source only after destination history and worktree
+  handling are complete.
+
+- [ ] **Unit 5: Handle profile-owned worktree move/copy and branch conflicts**
+
+**Goal:** Preserve or duplicate profile-owned worktrees safely during migration,
+with explicit branch conflict handling for Copy.
+
+**Requirements:** R6, R7, R9
+
+**Dependencies:** Unit 4
+
+**Files:**
+- Modify: `apps/desktop/src/main/app-server/thread-migration-service.ts`
+- Modify: `apps/desktop/src/main/app-server/git-directory-service.ts`
+- Modify: `apps/desktop/src/main/app-server/worktree-archive-service.ts`
+- Modify: `packages/shared/src/worktree-paths.ts`
+- Test: `apps/desktop/src/main/__tests__/thread-migration-service.test.ts`
+- Test: `apps/desktop/src/main/__tests__/git-directory-service.test.ts`
+- Test: `apps/desktop/src/main/__tests__/backend-registry.test.ts`
+
+**Approach:**
+- Detect source worktrees using existing linked directory metadata and
+  `isToolManagedWorktreePath`.
+- For Move, materialize or relocate the worktree under the destination profile's
+  owned worktree root before source archive. Record destination ownership with
+  `recordCodexWorktreeOwnerThread`.
+- For Copy, require one of the supported strategies before copying a worktree:
+  source branch suffix, destination branch suffix, or detached destination.
+- Prefer branch suffix strategies in the UI copy. Detached destination should be
+  available for expert use but described as less convenient for continued work.
+- Avoid reusing `archiveThreadWorktrees` as the first move step because archive
+  is a cleanup path; migration needs destination materialization before source
+  cleanup.
+
+**Patterns to follow:**
+- Existing worktree owner file logic in `git-directory-service.ts`.
+- Existing snapshot-ref logic in `worktree-archive-service.ts`.
+- Existing archive tests for preserving shared worktrees.
+- Git's own worktree branch exclusivity rules; every strategy must preflight
+  `git worktree list` before changing branch state.
+
+**Test scenarios:**
+- Happy path: Move of a profile-owned source worktree creates a destination-owned
+  worktree and records the destination thread as owner before source archive.
+- Happy path: Move of a local non-profile-owned checkout leaves the checkout in
+  place and only links the destination thread to the same project path.
+- Copy strategy: source suffix renames the branch checked out by the source
+  worktree without removing or archiving the source thread/worktree, then the
+  destination claims or creates the requested branch.
+- Copy strategy: destination suffix creates the destination worktree on a new
+  suffixed branch while leaving source untouched.
+- Copy strategy: detached destination creates a destination worktree without a
+  branch conflict.
+- Error path: dirty worktree or untracked changes that cannot be safely copied
+  block source archive and surface an actionable failure.
+- Error path: branch already exists for the chosen suffix returns a collision
+  error with suggested alternate suffix.
+- Integration: shared worktrees not owned by the source thread are not removed
+  during Move.
+
+**Verification:**
+- Git never has the same branch checked out in two worktrees.
+- Move does not archive source before destination worktree handling finishes.
+
+- [ ] **Unit 6: Build the Thread Management renderer surface**
+
+Progress note 2026-06-01: Settings now includes a Thread Management section
+that lists migration source profiles, groups source threads by project, supports
+project/thread multi-select, runs Move/Copy through the migration IPC, and shows
+per-thread run status. Remaining UI work includes richer progress events,
+retry/cancel affordances, final copy/worktree strategy validation, and visual
+polish against replay-backed fixtures.
+
+**Goal:** Add a Settings-hosted Thread Management tool for source profile
+selection, grouped thread selection, Move/Copy action choice, branch strategy,
+and migration progress.
+
+**Requirements:** R1, R3, R6, R7, R10
+
+**Dependencies:** Units 1, 3, 4, and 5
+
+**Files:**
+- Create: `apps/desktop/src/renderer/src/features/settings/ThreadManagementSettings.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx`
+- Modify: `apps/desktop/src/renderer/src/features/settings/SettingsLayout.tsx`
+- Modify: `apps/desktop/src/renderer/src/lib/useThreadNavigation.ts`
+- Modify: `apps/desktop/src/renderer/src/lib/desktop-api.ts`
+- Modify: `apps/desktop/src/renderer/src/styles/app.css`
+- Test: `apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx`
+- Test: `apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx`
+
+**Approach:**
+- Follow existing Settings section primitives instead of adding a separate visual
+  system.
+- Present source profiles first, then grouped projects, then thread rows with
+  multi-select controls.
+- Make Move the primary action. Copy should require an explicit branch strategy
+  when selected source threads include profile-owned worktrees.
+- Render per-thread run status inline: queued, copied, validating, worktree,
+  archiving, complete, failed.
+- Keep the picker summary-oriented: project, title, source profile, branch, and
+  status are enough for selection. Full transcript content should remain in the
+  normal thread view after migration or in source CAS read/validation internals.
+- After successful destination migration, refresh navigation so migrated threads
+  become visible in Inbox/Recents/Directories.
+
+**Patterns to follow:**
+- `ArchivedThreadsSettings.tsx` for grouped thread rows and restore/archive
+  status copy.
+- `ProfilesSettings.tsx` for profile list rows and profile actions.
+- Existing desktop style guide and app chrome token rules.
+
+**Test scenarios:**
+- Happy path: user selects a source profile, selects a project group, sees Move
+  enabled, starts migration, and sees completed per-thread statuses.
+- Happy path: selecting Copy with worktree threads reveals branch strategy
+  controls and blocks start until a strategy is chosen.
+- Edge case: no other Codex profiles shows an empty state and no migration
+  action.
+- Error path: unavailable source profile shows its failure reason without
+  disabling other profiles.
+- Error path: migration item failure remains visible after a refresh.
+- Accessibility: project and thread selection controls have stable labels and
+  keyboard-operable state.
+
+**Verification:**
+- The Settings UI remains consistent with existing Settings layout.
+- Move is visually and interaction-wise the default recommended action.
+
+- [ ] **Unit 7: Add IPC wiring, progress events, and lifecycle cleanup**
+
+**Goal:** Wire renderer actions to the migration service through preload and IPC,
+with progress notifications and cleanup of captive source clients.
+
+**Requirements:** R2, R3, R10
+
+**Dependencies:** Units 1, 3, 4, and 6
+
+**Files:**
+- Modify: `apps/desktop/src/main/ipc/app-server.ts`
+- Modify: `apps/desktop/src/main/ipc/profiles.ts`
+- Modify: `apps/desktop/src/main/index.ts`
+- Modify: `apps/desktop/src/preload/index.ts`
+- Modify: `apps/desktop/src/shared/ipc.ts`
+- Test: `apps/desktop/src/main/__tests__/profiles-ipc.test.ts`
+- Test: `apps/desktop/src/main/__tests__/backend-registry.test.ts`
+- Test: `apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx`
+
+**Approach:**
+- Add IPC handlers for listing migration sources, listing source profile threads,
+  starting a migration run, reading run status, and cancelling pending items
+  before they become destructive.
+- Emit progress events through existing notification patterns so the renderer
+  does not poll aggressively.
+- Ensure app shutdown, profile switch, and migration window close dispose captive
+  source CAS clients.
+- Keep archive confirmation server-side: the service should never call source
+  archive until the persisted run item has reached the validated pre-archive
+  state.
+
+**Patterns to follow:**
+- Existing app-server IPC methods for list/read/archive thread.
+- Existing profile IPC for open/create/delete profile.
+- Existing notification forwarding in backend registry.
+
+**Test scenarios:**
+- Happy path: IPC start request creates a migration run and progress events
+  update renderer state.
+- Error path: renderer cannot request migration from the active source profile.
+- Error path: cancelling a pending item prevents fork/archive for that item.
+- Lifecycle: closing the tool disposes source clients without interrupting owned
+  destination CAS.
+- Integration: successful migration refreshes navigation and archived-source
+  state only after source archive.
+
+**Verification:**
+- No renderer code imports main-process migration service modules.
+- Captive source clients do not survive past their intended lifecycle.
+
+- [ ] **Unit 8: Add end-to-end replay fixtures and manual validation path**
+
+**Goal:** Prove the migration flow against replay-backed CAS fixtures and a
+manual dev-profile workflow before shipping.
+
+**Requirements:** R4, R5, R6, R7, R8, R9, R10
+
+**Dependencies:** Units 2 through 7
+
+**Files:**
+- Create: `apps/desktop/e2e/thread-profile-migration.spec.ts`
+- Create: `apps/desktop/e2e/fixtures/thread-profile-migration/`
+- Modify: `apps/desktop/package.json`
+- Test: `apps/desktop/e2e/thread-profile-migration.spec.ts`
+
+**Approach:**
+- Seed replay fixtures with two Codex auth profile environments and source
+  threads grouped across at least two projects.
+- Include one profile-owned worktree fixture and one local checkout fixture.
+- Validate Move order explicitly: destination fork and validation happen before
+  source archive.
+- Validate Copy strategy UI and branch conflict handling without depending on
+  real operator Codex data.
+- Add a manual validation checklist in the plan or PR notes rather than
+  hard-coding operator-specific paths.
+
+**Patterns to follow:**
+- Project-local desktop E2E fixture seeding skill guidance in
+  `.agents/skills/desktop-e2e-fixture-seeding/SKILL.md`.
+- Existing archive worktree E2E fixture in
+  `apps/desktop/e2e/thread-archive-worktree-cleanup.spec.ts`.
+
+**Test scenarios:**
+- E2E happy path: Move one source thread, validate the destination appears in
+  current profile navigation, and source archive is called last.
+- E2E happy path: Copy one source thread with destination branch suffix and leave
+  source active.
+- E2E edge case: select an entire project group and migrate multiple threads
+  with independent per-thread statuses.
+- E2E error path: validation mismatch blocks source archive and leaves a visible
+  failed item.
+- E2E boundary: fixture asserts PwrAgent never reads Codex session files
+  directly by routing all source thread access through replayed CAS messages.
+
+**Verification:**
+- Replay-backed desktop E2E covers Move and Copy with worktree and non-worktree
+  threads.
+- Manual validation confirms a real forked/migrated thread has correct history.
+
+## System-Wide Impact
+
+- **Interaction graph:** Settings UI, preload IPC, app-server IPC,
+  `BackendRegistry`, new migration service, owned Codex client, captive source
+  Codex clients, Git worktree services, overlay/state persistence, and
+  navigation refresh all interact in this flow.
+- **Error propagation:** Source profile discovery and source CAS startup errors
+  should remain scoped to the migration UI. Per-thread migration errors should
+  not abort unrelated batch items unless the underlying source/destination client
+  becomes unavailable.
+- **State lifecycle risks:** Migration run state must survive refresh/restart,
+  source clients must be disposed, destination list caches must invalidate after
+  success, and source archive must never occur before destination validation.
+- **API surface parity:** Renderer, preload, shared contracts, and main IPC all
+  need the same operation/status vocabulary.
+- **Integration coverage:** Unit tests alone will not prove the destructive
+  sequencing. E2E or replay-backed integration must assert source archive order
+  relative to fork, validation, and worktree migration.
+- **Unchanged invariants:** PwrAgent still treats Codex-owned storage as private.
+  Existing sidebar thread fork behavior remains thread-id based and should not
+  be coupled to cross-profile migration.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|---|---|
+| CAS does not expose stable rollout path metadata in the current normalized list/read path | Add the smallest CAS-returned metadata field needed; do not fall back to filesystem parsing. |
+| Source archive removes worktrees before they are moved | Make source archive the final Move step and test call ordering explicitly. |
+| Copy creates duplicate branch checkout conflicts | Require an explicit Copy branch strategy and preflight Git worktree state before creating destination worktrees. |
+| Validation is too strict and fails valid forks | Start with role/order/content fingerprints and defer item-id equality unless CAS guarantees it. |
+| Validation is too loose and misses lost context | Include message parts and assistant/user ordering; add manual validation for a real forked thread before shipping. |
+| Captive source CAS leaks process lifetime | Tie source client lifecycle to migration tool/window and app shutdown cleanup. |
+| Migration partially succeeds and confuses the operator | Persist per-item status and expose retryable/failed states in the UI. |
+| Implementation accidentally reads Codex JSONL/session files | Add tests/review checks around migration service and keep all source access behind CAS client calls. |
+| Migration logs leak transcript content or raw Responses payloads | Log ids, statuses, counts, and short error summaries only; keep message bodies inside CAS-visible replay and UI surfaces that already show thread content. |
+
+## Documentation / Operational Notes
+
+- Update the Settings/Thread Management user-facing copy to recommend Move when
+  profile-owned worktrees are involved.
+- PR notes should include a manual validation checklist for one Move and one Copy
+  flow using non-sensitive test profiles.
+- Contributor-facing docs may need a short note in `apps/desktop/AGENTS.md` if
+  the replay fixture seeding process for profile migration differs from existing
+  desktop E2E fixture patterns.
+
+## Alternative Approaches Considered
+
+- **Reconstruct history with `thread/inject_items`:** Rejected as the first
+  approach because PwrAgent's normalized `readThread` replay is not guaranteed to
+  preserve raw Responses API item shape. Keep as a fallback spike only.
+- **Read source Codex rollout files directly:** Rejected because repo guidance
+  explicitly forbids reading Codex-owned storage directly from PwrAgent code.
+- **Archive source first and restore/move worktrees afterward:** Rejected because
+  source archive may remove or invalidate worktree state needed for the
+  destination.
+- **Open another full PwrAgent profile window to migrate:** Rejected for the main
+  flow because it makes CAS ownership and user confirmation harder to reason
+  about; a captive source CAS is narrower and easier to clean up.
+
+## Success Metrics
+
+- A user running one PwrAgent profile can list other Codex profiles and migrate a
+  selected thread without leaving the app.
+- A moved thread appears in the current profile with CAS-visible history matching
+  the source.
+- Source archive happens only after destination validation and worktree handling.
+- Copy cannot proceed on profile-owned worktrees until the operator chooses a
+  branch conflict strategy.
+- Tests cover the CAS boundary: migration uses CAS calls and does not parse
+  Codex private files.
+
+## Sources & References
+
+- Related branch: `feat/thread-subthreads`
+- Related commits: `428b4e822 feat(threads): fork Codex threads from sidebar`,
+  `21d117a8e fix(threads): preserve shared worktrees on archive`
+- Related code: `apps/desktop/src/main/codex-app-server/client.ts`
+- Related code: `apps/desktop/src/main/app-server/backend-registry.ts`
+- Related code: `apps/desktop/src/main/settings/codex-profiles.ts`
+- Related code: `apps/desktop/src/main/app-server/worktree-archive-service.ts`
+- Related protocol: `packages/codex-app-server-protocol/src/v2/ThreadForkParams.ts`
+- Related protocol: `packages/codex-app-server-protocol/src/v2/ThreadInjectItemsParams.ts`

--- a/packages/agent-core/src/__tests__/directory-navigation.test.ts
+++ b/packages/agent-core/src/__tests__/directory-navigation.test.ts
@@ -773,6 +773,97 @@ describe("buildDirectorySummaries", () => {
     );
   });
 
+  it("groups stale same-origin Codex worktree rows when no canonical repo path is known", () => {
+    const directories = buildDirectorySummaries({
+      threads: [
+        buildThread({
+          id: "thread-1",
+          createdAt: 2_000,
+          gitOriginUrl: "git@github.com:Giphy/svc-infra.git",
+          linkedDirectories: [
+            {
+              id: "dir-1",
+              label: "svc-infra",
+              path: "/Users/huntharo/.codex/worktrees/e926/svc-infra",
+              kind: "worktree",
+            },
+          ],
+        }),
+        buildThread({
+          id: "thread-2",
+          createdAt: 1_000,
+          gitOriginUrl: "https://github.com/Giphy/svc-infra.git",
+          linkedDirectories: [
+            {
+              id: "dir-2",
+              label: "svc-infra",
+              path: "/Users/huntharo/.codex/worktrees/3364/svc-infra",
+              kind: "worktree",
+            },
+          ],
+          updatedAt: 2_000,
+        }),
+      ],
+    });
+
+    expect(directories).toEqual([
+      expect.objectContaining({
+        key: "directory:/Users/huntharo/.codex/worktrees/e926/svc-infra",
+        label: "svc-infra",
+        path: "/Users/huntharo/.codex/worktrees/e926/svc-infra",
+        threadKeys: ["codex:thread-1", "codex:thread-2"],
+      }),
+    ]);
+  });
+
+  it("keeps same-label managed worktrees separate when their origins differ", () => {
+    const directories = buildDirectorySummaries({
+      threads: [
+        buildThread({
+          id: "thread-1",
+          createdAt: 2_000,
+          gitOriginUrl: "git@github.com:Giphy/svc-infra.git",
+          linkedDirectories: [
+            {
+              id: "dir-1",
+              label: "svc-infra",
+              path: "/Users/huntharo/.codex/worktrees/e926/svc-infra",
+              kind: "worktree",
+            },
+          ],
+        }),
+        buildThread({
+          id: "thread-2",
+          createdAt: 1_000,
+          gitOriginUrl: "git@github.com:OtherOrg/svc-infra.git",
+          linkedDirectories: [
+            {
+              id: "dir-2",
+              label: "svc-infra",
+              path: "/Users/huntharo/.codex/worktrees/3364/svc-infra",
+              kind: "worktree",
+            },
+          ],
+          updatedAt: 2_000,
+        }),
+      ],
+    });
+
+    expect(directories).toHaveLength(2);
+    expect(directories).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: "directory:/Users/huntharo/.codex/worktrees/e926/svc-infra",
+          threadKeys: ["codex:thread-1"],
+        }),
+        expect.objectContaining({
+          key: "directory:/Users/huntharo/.codex/worktrees/3364/svc-infra",
+          threadKeys: ["codex:thread-2"],
+        }),
+      ]),
+    );
+  });
+
   it("groups multiple worktrees under the same home repo when thread summaries share the canonical directory path", () => {
     const directories = buildDirectorySummaries({
       threads: [

--- a/packages/agent-core/src/domain/directory-navigation.ts
+++ b/packages/agent-core/src/domain/directory-navigation.ts
@@ -32,6 +32,26 @@ function normalizeComparablePath(value?: string): string | undefined {
   return normalized || undefined;
 }
 
+function normalizeGitOriginUrl(value?: string): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const sshMatch = trimmed.match(/^git@([^:]+):(.+)$/i);
+  const candidate = sshMatch
+    ? `${sshMatch[1]}/${sshMatch[2]}`
+    : trimmed.replace(/^[a-z]+:\/\//i, "");
+  const normalized = candidate
+    .replace(/\.git$/i, "")
+    .replace(/^ssh\//i, "")
+    .replace(/^\/+/, "")
+    .replace(/\/+$/, "")
+    .toLowerCase();
+
+  return normalized || undefined;
+}
+
 function isInternalDirectoryLabel(value?: string): boolean {
   return Boolean(value?.startsWith("directory:") || value?.startsWith("workspace:"));
 }
@@ -171,6 +191,60 @@ function collectStablePathByLabel(
       paths.size === 1 ? [...paths][0] : undefined,
     ]),
   );
+}
+
+function collectManagedWorktreeDescriptorByOrigin(
+  threads: NavigationThreadSummary[],
+): Map<string, DirectoryDescriptor> {
+  const descriptorsByOrigin = new Map<string, DirectoryDescriptor>();
+
+  for (const thread of threads) {
+    const origin = normalizeGitOriginUrl(thread.gitOriginUrl);
+    if (!origin || descriptorsByOrigin.has(origin)) {
+      continue;
+    }
+
+    for (const directory of thread.linkedDirectories) {
+      const descriptor = classifyDirectory(directory);
+      if (!descriptor.path || !isToolManagedWorktreePath(descriptor.path)) {
+        continue;
+      }
+      descriptorsByOrigin.set(origin, descriptor);
+      break;
+    }
+  }
+
+  return descriptorsByOrigin;
+}
+
+function normalizeDirectoryDescriptor(
+  descriptor: DirectoryDescriptor,
+  params: {
+    managedWorktreeOriginDescriptor?: DirectoryDescriptor;
+    stablePath?: string;
+  },
+): DirectoryDescriptor {
+  if (descriptor.path && isToolManagedWorktreePath(descriptor.path)) {
+    if (params.stablePath) {
+      return {
+        ...descriptor,
+        key: `directory:${params.stablePath}`,
+        path: params.stablePath,
+      };
+    }
+
+    return params.managedWorktreeOriginDescriptor ?? descriptor;
+  }
+
+  if (descriptor.path || descriptor.kind !== "directory" || !params.stablePath) {
+    return descriptor;
+  }
+
+  return {
+    ...descriptor,
+    key: `directory:${params.stablePath}`,
+    path: params.stablePath,
+  };
 }
 
 function ensureSummary(
@@ -373,6 +447,8 @@ export function buildDirectorySummaries(params: {
 }): NavigationDirectorySummary[] {
   const summaries = new Map<string, NavigationDirectorySummary>();
   const stablePathByLabel = collectStablePathByLabel(params.threads);
+  const managedWorktreeDescriptorByOrigin =
+    collectManagedWorktreeDescriptorByOrigin(params.threads);
   const allowedWorkspaceRoots = workspaceRootSet(params.workspaceRoots);
 
   for (const thread of params.threads) {
@@ -400,22 +476,15 @@ export function buildDirectorySummaries(params: {
     for (const directory of thread.linkedDirectories) {
       const descriptor = classifyDirectory(directory);
       const stablePath = stablePathByLabel.get(descriptor.label);
-      const normalizedDescriptor =
-        descriptor.path && isToolManagedWorktreePath(descriptor.path) && stablePath
-          ? {
-              ...descriptor,
-              key: `directory:${stablePath}`,
-              path: stablePath,
-            }
-          : descriptor.path || descriptor.kind !== "directory"
-          ? descriptor
-          : stablePath
-            ? {
-                ...descriptor,
-                key: `directory:${stablePath}`,
-                path: stablePath,
-              }
-            : descriptor;
+      const origin = normalizeGitOriginUrl(thread.gitOriginUrl);
+      const managedWorktreeOriginDescriptor =
+        descriptor.path && isToolManagedWorktreePath(descriptor.path) && origin
+          ? managedWorktreeDescriptorByOrigin.get(origin)
+          : undefined;
+      const normalizedDescriptor = normalizeDirectoryDescriptor(descriptor, {
+        managedWorktreeOriginDescriptor,
+        stablePath,
+      });
       if (!isAllowedWorkspaceRoot(normalizedDescriptor, allowedWorkspaceRoots)) {
         continue;
       }

--- a/packages/agent-core/src/domain/navigation-state.ts
+++ b/packages/agent-core/src/domain/navigation-state.ts
@@ -271,6 +271,7 @@ export function buildNavigationSnapshotHash(params: {
       projectKey: thread.projectKey ?? null,
       updatedAt: thread.updatedAt ?? null,
       gitBranch: thread.gitBranch ?? null,
+      gitOriginUrl: thread.gitOriginUrl ?? null,
       observedGitBranch: thread.observedGitBranch ?? null,
       retainedBranchDriftPairs: (thread.retainedBranchDriftPairs ?? []).map((pair) => ({
         expectedBranch: pair.expectedBranch,

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -50,6 +50,7 @@ export {
   buildNavigationSnapshot,
   buildNavigationSnapshotHash,
 } from "./domain/navigation-state.js";
+export { buildDirectorySummaries } from "./domain/directory-navigation.js";
 export {
   GrokRolloutStore,
   type AppServerSessionStore,

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -75,10 +75,7 @@ export type ForkThreadResponse = {
 
 export type ThreadMigrationOperation = "move" | "copy";
 
-export type ThreadMigrationCopyStrategy =
-  | "source-branch-suffix"
-  | "destination-branch-suffix"
-  | "detached-destination";
+export type ThreadMigrationCopyStrategy = "detached-destination";
 
 export type ThreadMigrationRunStatus =
   | "pending"

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -82,6 +82,7 @@ export type ThreadMigrationCopyStrategy =
 
 export type ThreadMigrationRunStatus =
   | "pending"
+  | "restoring-source"
   | "copying"
   | "validating"
   | "worktree"
@@ -145,6 +146,13 @@ export type StartThreadMigrationRequest = {
   operation: ThreadMigrationOperation;
   copyStrategy?: ThreadMigrationCopyStrategy;
   threadIds: ThreadIdentifier[];
+};
+
+export type RetryThreadMigrationRequest = {
+  sourceProfile: string;
+  operation: ThreadMigrationOperation;
+  copyStrategy?: ThreadMigrationCopyStrategy;
+  threadId: ThreadIdentifier;
 };
 
 export type ThreadMigrationRunItem = {

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -53,6 +53,7 @@ export type ForkThreadRequest = {
   directoryLabel?: string;
   directoryPath?: string;
   workMode?: LaunchpadWorkMode;
+  worktreeBranchMode?: "attached" | "detached";
   branchName?: string;
   model?: string;
   approvalPolicy?: string;

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -71,6 +71,99 @@ export type ForkThreadResponse = {
   workMode: LaunchpadWorkMode;
 };
 
+export type ThreadMigrationOperation = "move" | "copy";
+
+export type ThreadMigrationCopyStrategy =
+  | "source-branch-suffix"
+  | "destination-branch-suffix"
+  | "detached-destination";
+
+export type ThreadMigrationRunStatus =
+  | "pending"
+  | "copying"
+  | "validating"
+  | "worktree"
+  | "archiving-source"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
+export type ThreadMigrationSourceProfileSummary = {
+  profile: string;
+  displayName: string;
+  codexHome: string;
+  source: "default" | "directory" | "config";
+  exists: boolean;
+  selected: boolean;
+  available: boolean;
+  unavailableReason?: string;
+  accountEmail?: string;
+};
+
+export type ListThreadMigrationSourcesResponse = {
+  activeCodexProfile: string;
+  profiles: ThreadMigrationSourceProfileSummary[];
+};
+
+export type ThreadMigrationSourceThreadSummary = {
+  sourceProfile: string;
+  threadId: ThreadIdentifier;
+  title: string;
+  summary?: string;
+  projectKey?: string;
+  createdAt?: number;
+  updatedAt?: number;
+  archivedAt?: number;
+  gitBranch?: string;
+  linkedDirectories: LinkedDirectorySummary[];
+};
+
+export type ThreadMigrationSourceProjectGroup = {
+  key: string;
+  label: string;
+  path?: string;
+  threads: ThreadMigrationSourceThreadSummary[];
+};
+
+export type ListThreadMigrationSourceThreadsRequest = {
+  sourceProfile: string;
+  archived?: boolean;
+  filter?: string;
+};
+
+export type ListThreadMigrationSourceThreadsResponse = {
+  sourceProfile: string;
+  fetchedAt: number;
+  projects: ThreadMigrationSourceProjectGroup[];
+};
+
+export type StartThreadMigrationRequest = {
+  sourceProfile: string;
+  operation: ThreadMigrationOperation;
+  copyStrategy?: ThreadMigrationCopyStrategy;
+  threadIds: ThreadIdentifier[];
+};
+
+export type ThreadMigrationRunItem = {
+  sourceProfile: string;
+  sourceThreadId: ThreadIdentifier;
+  destinationThreadId?: ThreadIdentifier;
+  status: ThreadMigrationRunStatus;
+  error?: string;
+  validation?: {
+    sourceMessageCount: number;
+    destinationMessageCount: number;
+    matched: boolean;
+  };
+};
+
+export type StartThreadMigrationResponse = {
+  runId: string;
+  operation: ThreadMigrationOperation;
+  startedAt: number;
+  items: ThreadMigrationRunItem[];
+};
+
 export type StartTurnRequest = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -117,6 +117,7 @@ export type ThreadMigrationSourceThreadSummary = {
   updatedAt?: number;
   archivedAt?: number;
   gitBranch?: string;
+  gitOriginUrl?: string;
   linkedDirectories: LinkedDirectorySummary[];
 };
 

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -54,6 +54,7 @@ export type ForkThreadRequest = {
   directoryPath?: string;
   workMode?: LaunchpadWorkMode;
   worktreeBranchMode?: "attached" | "detached";
+  excludedWorktreePaths?: string[];
   branchName?: string;
   model?: string;
   approvalPolicy?: string;

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -151,6 +151,26 @@ export type ThreadMigrationRunItem = {
   destinationThreadId?: ThreadIdentifier;
   status: ThreadMigrationRunStatus;
   error?: string;
+  warnings?: string[];
+  diagnostics?: {
+    sourceTitle?: string;
+    sourceArchivedAt?: number;
+    sourceProjectKey?: string;
+    sourceDirectoryPath?: string;
+    sourceDirectoryExists?: boolean;
+    sourceWorktreePath?: string;
+    sourceGitBranch?: string;
+    sourceWorktreeExists?: boolean;
+    sourceBranchExists?: boolean;
+    requestedDirectoryPath?: string;
+    requestedWorkMode?: LaunchpadWorkMode;
+    requestedWorktreeBranchMode?: "attached" | "detached";
+    requestedBranchName?: string;
+    destinationDirectoryPath?: string;
+    destinationWorktreePath?: string;
+    destinationWorkMode?: LaunchpadWorkMode;
+    archivedSource?: boolean;
+  };
   validation?: {
     sourceMessageCount: number;
     destinationMessageCount: number;

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -244,6 +244,7 @@ export type AppServerThreadSummary = {
   archivedAt?: number;
   linkedDirectories: LinkedDirectorySummary[];
   gitBranch?: string;
+  gitOriginUrl?: string;
   observedGitBranch?: string;
   source: AppServerBackendKind;
   executionMode?: ThreadExecutionMode;


### PR DESCRIPTION
## Summary
- add shared contracts, IPC/preload/renderer API plumbing for cross-profile Codex thread migration
- extend the Codex App Server client and backend registry so destination CAS can fork from a source CAS-provided rollout path without PwrAgent reading Codex thread storage
- add a main-process ThreadMigrationService with captive source CAS clients, grouped source thread listing, fork/validate/archive-last run execution, and a guard that blocks Move before archive when profile-owned worktrees are detected
- add Settings -> Thread Management for source profile/thread selection and Move/Copy starts

## Safety notes
- Source rollout paths stay main-process-only; the migration picker receives bounded profile/project/thread summaries.
- Move archives the source only after destination fork and replay validation.
- Profile-owned worktree Move is currently blocked before fork/archive until the relocation strategy lands.

## Validation
- pnpm --filter @pwragent/shared typecheck && pnpm --filter @pwragent/desktop typecheck
- pnpm exec vitest run --config vitest.workspace.ts apps/desktop/src/main/__tests__/thread-migration-service.test.ts apps/desktop/src/main/__tests__/codex-client.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts -t "ThreadMigrationService|forks a Codex thread from a CAS-provided rollout path|passes a CAS-provided source rollout path when forking for migration"
- pnpm exec vitest run --config vitest.workspace.ts apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
- pnpm lint:codex-storage
- pnpm lint:colors
- pnpm lint:boundaries
- git diff --check