### PR TITLE
fix(desktop): repair stale review thinking state

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -978,6 +978,11 @@ function parseStaleSteerError(
   return undefined;
 }
 
+function parseStaleInterruptError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.toLowerCase().includes("no active turn to interrupt");
+}
+
 function reviewCommandToDraftText(command: {
   target: AppServerReviewTarget;
 }): string {
@@ -2435,6 +2440,13 @@ export function Composer(props: ComposerProps) {
         event.notification.params.turn !== null
           ? (event.notification.params.turn as { id?: unknown })
           : undefined;
+      const startedTurnId =
+        typeof startedTurnRecord?.id === "string"
+          ? startedTurnRecord.id
+          : event.notification.method === "turn/started" &&
+              typeof event.notification.params.turnId === "string"
+            ? event.notification.params.turnId
+            : undefined;
       const turnQueueRecord =
         event.notification.method === "thread/turnQueue/updated" &&
         typeof event.notification.params === "object" &&
@@ -2526,19 +2538,19 @@ export function Composer(props: ComposerProps) {
 
       if (
         event.notification.method === "turn/started" &&
-        typeof startedTurnRecord?.id === "string"
+        typeof startedTurnId === "string"
       ) {
         if (
           activeReviewTurnIdRef.current &&
-          startedTurnRecord.id !== activeReviewTurnIdRef.current
+          startedTurnId !== activeReviewTurnIdRef.current
         ) {
           // Codex reviews can surface a separate turn/started id while all
           // review items and the terminal event stay on review/start's turn.
           // Keep Stop/active-turn wiring pointed at the real review turn.
           return;
         }
-        updateActiveTurnId(startedTurnRecord.id);
-        props.onActiveTurnIdChange?.(startedTurnRecord.id);
+        updateActiveTurnId(startedTurnId);
+        props.onActiveTurnIdChange?.(startedTurnId);
       }
 
       if (
@@ -3394,6 +3406,17 @@ export function Composer(props: ComposerProps) {
       });
     } catch (error) {
       setInterrupting(false);
+      if (parseStaleInterruptError(error)) {
+        globalQueuedTurnReleaseScopeKeys.delete(composerScopeKey);
+        queuedAutoReleaseAttemptIdRef.current = undefined;
+        updateSending(false);
+        setSteering(false);
+        updateActiveTurnId(undefined);
+        props.onActiveTurnIdChange?.(undefined);
+        props.onPendingStatusChange?.(undefined);
+        setSendError(undefined);
+        return;
+      }
       props.onPendingStatusChange?.(
         props.pendingRequestActive
           ? "Waiting for approval"

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -7955,10 +7955,11 @@ describe("Composer", () => {
                 method: "turn/started";
                 params: {
                   threadId: string;
+                  turnId?: string;
                   turn: {
                     id: string;
                     status: string;
-                  };
+                  } | undefined;
                 };
               }
             | {
@@ -8030,10 +8031,8 @@ describe("Composer", () => {
           method: "turn/started",
           params: {
             threadId: "thread-1",
-            turn: {
-              id: "turn-99",
-              status: "inProgress",
-            },
+            turnId: "turn-99",
+            turn: undefined,
           },
         },
       });
@@ -8070,6 +8069,132 @@ describe("Composer", () => {
     await waitFor(() => {
       expect(screen.queryByRole("button", { name: "Stop" })).not.toBeInTheDocument();
     });
+  });
+
+  it("clears stale thinking when Stop finds no active backend turn", async () => {
+    const interruptTurn = vi.fn(async () => {
+      throw new Error("json-rpc error (-32600): no active turn to interrupt");
+    });
+    const onActiveTurnIdChange = vi.fn();
+    const onPendingStatusChange = vi.fn();
+
+    render(
+      <Composer
+        activeTurnId="turn-stale"
+        desktopApi={{
+          interruptTurn,
+          startTurn: async () => ({
+            backend: "codex",
+            threadId: "thread-1",
+            turnId: "turn-1",
+          }),
+        }}
+        disabled={false}
+        onActiveTurnIdChange={onActiveTurnIdChange}
+        onPendingStatusChange={onPendingStatusChange}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Build Codex client",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument();
+
+    await clickButton("Stop");
+
+    await waitFor(() => {
+      expect(interruptTurn).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        turnId: "turn-stale",
+      });
+      expect(screen.queryByRole("button", { name: "Stop" })).not.toBeInTheDocument();
+    });
+    expect(onActiveTurnIdChange).toHaveBeenCalledWith(undefined);
+    expect(onPendingStatusChange).toHaveBeenCalledWith(undefined);
+    expect(
+      screen.queryByText(/no active turn to interrupt/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it("releases the queued-turn lock when Stop repairs stale active state", async () => {
+    const draftStore = createComposerDraftStore();
+    const scopeKey = "thread:codex:thread-stale-queue";
+    draftStore.setQueuedTurns(scopeKey, [
+      {
+        id: "queued-1",
+        text: "First queued stale turn",
+        imageAttachments: [],
+        input: [{ type: "text", text: "First queued stale turn" }],
+      },
+      {
+        id: "queued-2",
+        text: "Second queued follow-up",
+        imageAttachments: [],
+        input: [{ type: "text", text: "Second queued follow-up" }],
+      },
+    ]);
+    const interruptTurn = vi.fn(async () => {
+      throw new Error("json-rpc error (-32600): no active turn to interrupt");
+    });
+    const startTurn = vi.fn(async (request: StartTurnRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      turnId: `turn-${startTurn.mock.calls.length}`,
+    }));
+
+    render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        desktopApi={{
+          interruptTurn,
+          startTurn,
+        }}
+        disabled={false}
+        draftStore={draftStore}
+        skills={[]}
+        thread={{
+          id: "thread-stale-queue",
+          title: "Stale queued stop",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledTimes(1);
+    });
+    expect(startTurn).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        input: [{ type: "text", text: "First queued stale turn" }],
+      })
+    );
+
+    await clickButton("Stop");
+
+    await waitFor(() => {
+      expect(interruptTurn).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-stale-queue",
+        turnId: "turn-1",
+      });
+      expect(startTurn).toHaveBeenCalledTimes(2);
+    });
+    expect(startTurn).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        input: [{ type: "text", text: "Second queued follow-up" }],
+      })
+    );
   });
 
   it("keeps the stop button visible when idle status arrives before completion", async () => {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -5381,6 +5381,7 @@ describe("useThreadSessionState", () => {
     await waitForThreadHydration(result);
 
     act(() => {
+      result.current.addOptimisticReviewEntry("Review changes against main");
       agentEventHandler?.({
         backend: "codex",
         notification: {
@@ -5449,6 +5450,9 @@ describe("useThreadSessionState", () => {
       expect(
         result.current.entries.filter((entry) => entry.type === "review")
       ).toHaveLength(2);
+      expect(
+        result.current.entries.some((entry) => entry.id.startsWith("optimistic-review-"))
+      ).toBe(false);
     });
   });
 

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -3103,9 +3103,7 @@ export function useThreadSessionState(params: {
               interacted: true,
               lastTouchedAt: nextLastTouchedAt,
               optimisticEntries: current.optimisticEntries.filter(
-                (entry) =>
-                  entry.type !== "review" ||
-                  !reviewEntriesMatch(reviewEntry, entry)
+                (entry) => entry.type !== "review"
               ),
               response: nextResponse,
             };


### PR DESCRIPTION
## Summary
- adopt Codex turn/started ids from either params.turn.id or params.turnId so Stop follows the actual running turn
- clear local Thinking/Stop state when interrupt reports there is no active backend turn
- retire optimistic review placeholders when real review-mode entries arrive, even if Codex text differs from the optimistic label

## Tests
- pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx -t "updates the stop target"
- pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx -t "clears stale thinking"
- pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx -t "keeps the stop button visible"
- pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx -t "keeps a review turn active"
- pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx -t "does not keep list thinking"
- git diff --check