### PR TITLE
fix(desktop): render automation markdown details

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptActivity.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptActivity.tsx
@@ -1,13 +1,20 @@
 import { useId, useState } from "react";
-import type { AppServerThreadActivityEntry } from "@pwragent/shared";
+import type {
+  AppServerSkillSummary,
+  AppServerThreadActivityEntry,
+  DesktopApplicationsSnapshot,
+} from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
+import { ThreadMarkdown } from "./ThreadMarkdown";
 import { TranscriptCommandOutput } from "./TranscriptCommandOutput";
 import { TranscriptCopyButton } from "./TranscriptCopyButton";
 import { TranscriptDiff } from "./TranscriptDiff";
 
 type TranscriptActivityProps = {
-  desktopApi?: Pick<DesktopApi, "copyText">;
+  applications?: DesktopApplicationsSnapshot;
+  desktopApi?: Pick<DesktopApi, "copyText" | "openApplication">;
   entry: AppServerThreadActivityEntry;
+  skills?: AppServerSkillSummary[];
 };
 
 export function TranscriptActivity(props: TranscriptActivityProps) {
@@ -90,6 +97,18 @@ export function TranscriptActivity(props: TranscriptActivityProps) {
             const nestedId = `${detailsId}-${detail.id}`;
             const hasNestedDetails = Boolean(detail.fileDiff || detail.command);
             const isDetailExpanded = expandedDetailIds.has(detail.id);
+            const markdown = detail.markdown?.trim();
+            const markdownContent =
+              markdown && !hasNestedDetails ? (
+                <ThreadMarkdown
+                  applications={props.applications}
+                  className="transcript-activity__detail-markdown"
+                  desktopApi={props.desktopApi}
+                  skills={props.skills}
+                  text={markdown}
+                  variant="summary"
+                />
+              ) : null;
             const label = detail.url && !hasNestedDetails ? (
               <a
                 className="transcript-activity__detail-label"
@@ -105,52 +124,56 @@ export function TranscriptActivity(props: TranscriptActivityProps) {
 
             return (
               <li key={detail.id} className="transcript-activity__detail">
-                <div className="transcript-activity__detail-row">
-                  {hasNestedDetails ? (
-                    <button
-                      type="button"
-                      className="transcript-activity__detail-toggle"
-                      aria-controls={nestedId}
-                      aria-expanded={isDetailExpanded}
-                      onClick={() => {
-                        setExpandedDetailIds((current) => {
-                          const next = new Set(current);
-                          if (next.has(detail.id)) {
-                            next.delete(detail.id);
-                          } else {
-                            next.add(detail.id);
-                          }
-                          return next;
-                        });
-                      }}
-                    >
-                      <span className="transcript-activity__chevron" aria-hidden="true" />
-                      {label}
-                    </button>
-                  ) : (
-                    label
-                  )}
-                  {detail.fileDiff ? (
-                    <span className="transcript-activity__detail-stats" aria-label="File diff summary">
-                      <span className="transcript-activity__detail-stat transcript-activity__detail-stat--removed">
-                        -{detail.fileDiff.removals.toLocaleString()}
+                {markdownContent && !detail.fileDiff && !detail.status ? (
+                  markdownContent
+                ) : (
+                  <div className="transcript-activity__detail-row">
+                    {hasNestedDetails ? (
+                      <button
+                        type="button"
+                        className="transcript-activity__detail-toggle"
+                        aria-controls={nestedId}
+                        aria-expanded={isDetailExpanded}
+                        onClick={() => {
+                          setExpandedDetailIds((current) => {
+                            const next = new Set(current);
+                            if (next.has(detail.id)) {
+                              next.delete(detail.id);
+                            } else {
+                              next.add(detail.id);
+                            }
+                            return next;
+                          });
+                        }}
+                      >
+                        <span className="transcript-activity__chevron" aria-hidden="true" />
+                        {label}
+                      </button>
+                    ) : (
+                      markdownContent ?? label
+                    )}
+                    {detail.fileDiff ? (
+                      <span className="transcript-activity__detail-stats" aria-label="File diff summary">
+                        <span className="transcript-activity__detail-stat transcript-activity__detail-stat--removed">
+                          -{detail.fileDiff.removals.toLocaleString()}
+                        </span>
+                        <span className="transcript-activity__detail-stat transcript-activity__detail-stat--added">
+                          +{detail.fileDiff.additions.toLocaleString()}
+                        </span>
                       </span>
-                      <span className="transcript-activity__detail-stat transcript-activity__detail-stat--added">
-                        +{detail.fileDiff.additions.toLocaleString()}
+                    ) : null}
+                    {detail.status ? (
+                      <span
+                        className={[
+                          "transcript-activity__detail-status",
+                          `transcript-activity__detail-status--${detail.status}`
+                        ].join(" ")}
+                      >
+                        {formatActivityDetailStatus(detail.status)}
                       </span>
-                    </span>
-                  ) : null}
-                  {detail.status ? (
-                    <span
-                      className={[
-                        "transcript-activity__detail-status",
-                        `transcript-activity__detail-status--${detail.status}`
-                      ].join(" ")}
-                    >
-                      {formatActivityDetailStatus(detail.status)}
-                    </span>
-                  ) : null}
-                </div>
+                    ) : null}
+                  </div>
+                )}
                 {hasNestedDetails && isDetailExpanded ? (
                   <div id={nestedId} className="transcript-activity__detail-body">
                     {detail.fileDiff ? <TranscriptDiff detail={detail} /> : null}

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -836,7 +836,12 @@ export function TranscriptList(props: TranscriptListProps) {
                   }}
                 />
               ) : item.entry.type === "activity" ? (
-                <TranscriptActivity desktopApi={props.desktopApi} entry={item.entry} />
+                <TranscriptActivity
+                  applications={props.applications}
+                  desktopApi={props.desktopApi}
+                  entry={item.entry}
+                  skills={skills}
+                />
               ) : item.entry.type === "plan" ? (
                 <TranscriptPlan
                   applications={props.applications}

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptWorkPhaseGroup.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptWorkPhaseGroup.tsx
@@ -82,7 +82,13 @@ function renderEntry(params: {
 }) {
   const entry = params.entry;
   return entry.type === "activity" ? (
-    <TranscriptActivity key={entry.id} desktopApi={params.desktopApi} entry={entry} />
+    <TranscriptActivity
+      key={entry.id}
+      applications={params.applications}
+      desktopApi={params.desktopApi}
+      entry={entry}
+      skills={params.skills}
+    />
   ) : entry.type === "plan" ? (
     <TranscriptPlan
       key={entry.id}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/automation-card-entries.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/automation-card-entries.test.ts
@@ -18,7 +18,7 @@ describe("automation-card-entries", () => {
           runId: "run-1",
           status: "completed",
           summary: "Inbox watch: nothing urgent",
-          details: "No unread priority messages.",
+          details: "**No unread** priority messages.",
           occurredAt: 1_000,
         },
       ]),
@@ -30,7 +30,10 @@ describe("automation-card-entries", () => {
         createdAt: 1_000,
         status: "completed",
         details: [
-          expect.objectContaining({ label: "No unread priority messages." }),
+          expect.objectContaining({
+            label: "**No unread** priority messages.",
+            markdown: "**No unread** priority messages.",
+          }),
           expect.objectContaining({ label: "Source: Inbox watch" }),
           expect.objectContaining({ label: "Run status: completed" }),
         ],

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -1,6 +1,7 @@
 import "@testing-library/jest-dom/vitest";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildAutomationCardActivityEntries } from "../automation-card-entries";
 import { TranscriptList } from "../TranscriptList";
 
 const compactMarkdownTable = `| Key | Value |
@@ -232,6 +233,46 @@ describe("TranscriptList", () => {
     expect(
       screen.queryByRole("button", { name: "Jump to latest message" })
     ).not.toBeInTheDocument();
+  });
+
+  it("renders automation card details as markdown in the transcript", () => {
+    const automationMarkdown = `| Priority | Service | Next step |
+|---|---|---|
+| P1 | \`transcoding-worker\` | Triage failing traces. |`;
+    const { container } = render(
+      <TranscriptList
+        entries={buildAutomationCardActivityEntries([
+          {
+            id: "automation-card:run-1",
+            backend: "codex",
+            threadId: "thread-1",
+            automationId: "automation-1",
+            automationName: "Daily health",
+            runId: "run-1",
+            status: "completed",
+            summary: "Daily health: found actionable outliers",
+            details: automationMarkdown,
+            occurredAt: 1_000,
+          },
+        ])}
+        loading={false}
+        loadingMore={false}
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Automation - Daily health: found actionable outliers/i,
+      })
+    );
+
+    expect(container.querySelector("table.thread-markdown__table")).toBeInTheDocument();
+    expect(screen.getByText("Priority")).toBeInTheDocument();
+    expect(screen.getByText("transcoding-worker")).toHaveClass(
+      "transcript-message__code"
+    );
+    expect(screen.queryByText(automationMarkdown)).not.toBeInTheDocument();
   });
 
   it("renders skill mentions as chips when present alongside markdown text", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/automation-card-entries.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/automation-card-entries.ts
@@ -29,6 +29,7 @@ export function buildAutomationCardActivityEntries(
               id: `${card.runId}:details`,
               kind: "read" as const,
               label: card.details.trim(),
+              markdown: card.details.trim(),
             },
           ]
         : []),

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -1494,6 +1494,7 @@ function activityDetailsEqual(
       leftDetail.id === rightDetail?.id &&
       leftDetail.kind === rightDetail.kind &&
       leftDetail.label === rightDetail.label &&
+      leftDetail.markdown === rightDetail.markdown &&
       leftDetail.path === rightDetail.path &&
       leftDetail.status === rightDetail.status &&
       leftDetail.url === rightDetail.url &&
@@ -1561,6 +1562,7 @@ function liveActivityNotificationSignature(params: {
       detail.id,
       detail.kind,
       detail.label,
+      detail.markdown ?? "",
       detail.path ?? "",
       detail.status ?? "",
       detail.url ?? "",

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -7937,6 +7937,12 @@ textarea,
   color: var(--text-primary);
 }
 
+.transcript-activity__detail-markdown {
+  min-width: 0;
+  width: 100%;
+  color: var(--text-primary);
+}
+
 .transcript-activity__detail-stats {
   display: inline-flex;
   flex: 0 0 auto;

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -348,6 +348,7 @@ export type AppServerThreadActivityDetail = {
   id: string;
   kind: "read" | "write" | "command";
   label: string;
+  markdown?: string;
   path?: string;
   url?: string;
   status?: AppServerThreadActivityStatus;


### PR DESCRIPTION
## Summary
Automation run cards now render markdown details in the chat transcript instead of showing tables, code spans, and emphasis as raw text. Activity details can carry a markdown payload while preserving their plain label for copy text and internal matching, and the transcript reuses the existing markdown renderer so links, tables, and code use the same styling as assistant messages.

## Test Plan
- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/automation-card-entries.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
