### PR TITLE
feat(desktop): add hot renderer CPU diagnostics

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -19,6 +19,7 @@
     "dev": "node scripts/ensure-electron-runtime.mjs && node scripts/rebuild-native-for-electron.mjs && electron-vite dev --",
     "dev:dev": "node scripts/ensure-electron-runtime.mjs && node scripts/rebuild-native-for-electron.mjs && electron-vite dev -- --profile dev",
     "dev:no-messaging": "node scripts/ensure-electron-runtime.mjs && node scripts/rebuild-native-for-electron.mjs && PWRAGENT_DISABLE_MESSAGING=1 electron-vite dev -- --disable-messaging",
+    "profile:hot-cpu": "node scripts/ensure-electron-runtime.mjs && node scripts/rebuild-native-for-electron.mjs && PWRAGENT_HOT_CPU_PROFILING=1 electron-vite dev --",
     "profile:startup": "node scripts/ensure-electron-runtime.mjs && node scripts/rebuild-native-for-electron.mjs && PWRAGENT_STARTUP_CPU_PROFILING=1 PWRAGENT_STARTUP_CPU_PROFILE_QUIT_ON_COMPLETE=1 PWRAGENT_DISABLE_MESSAGING=1 electron-vite dev -- --disable-messaging",
     "derive:replay-fixture": "tsx ./scripts/derive-replay-fixture.ts",
     "export:session-capture": "tsx ./scripts/export-session-capture.ts",

--- a/apps/desktop/src/main/__tests__/app-bootstrap.test.ts
+++ b/apps/desktop/src/main/__tests__/app-bootstrap.test.ts
@@ -189,6 +189,12 @@ vi.mock("../diagnostics/main-process-heap-monitor", () => ({
   MainProcessHeapMonitor: MainProcessHeapMonitorMock
 }));
 
+vi.mock("../settings/desktop-settings-singleton", () => ({
+  getDesktopSettingsService: () => ({
+    resolveHotCpuProfilingEnabled: () => false,
+  }),
+}));
+
 describe("createMainWindow", () => {
   beforeEach(() => {
     vi.resetModules();

--- a/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
@@ -19,6 +19,22 @@ describe("desktopSettingsPatchToEdits — general", () => {
     ]);
   });
 
+  it("writes hot CPU profiling", () => {
+    const edits = desktopSettingsPatchToEdits({
+      general: {
+        hotCpuProfilingEnabled: true,
+      },
+    });
+
+    expect(edits).toEqual([
+      {
+        op: "set",
+        path: ["general", "hot_cpu_profiling_enabled"],
+        value: true,
+      },
+    ]);
+  });
+
   it("writes quit confirmation preference", () => {
     const edits = desktopSettingsPatchToEdits({
       general: {

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -269,6 +269,38 @@ describe("DesktopSettingsService", () => {
     expect(service.resolveDeveloperMode()).toBe(true);
   });
 
+  it("defaults hot CPU profiling to disabled and persists overrides", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    const service = new DesktopSettingsService({
+      configPath,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    const initial = await service.readSettings();
+    expect(initial.general.hotCpuProfilingEnabled).toEqual({
+      value: false,
+      source: "default",
+    });
+    expect(service.resolveHotCpuProfilingEnabled()).toBe(false);
+
+    await service.writeConfigPatch({
+      general: {
+        hotCpuProfilingEnabled: true,
+      },
+    });
+
+    const saved = fs.readFileSync(configPath, "utf8");
+    expect(saved).toContain("[general]");
+    expect(saved).toContain("hot_cpu_profiling_enabled = true");
+    expect((await service.readSettings()).general.hotCpuProfilingEnabled).toEqual({
+      value: true,
+      source: "config",
+    });
+    expect(service.resolveHotCpuProfilingEnabled()).toBe(true);
+  });
+
   it("defaults notifications to disabled and persists overrides", async () => {
     const root = createTempRoot();
     const configPath = path.join(root, "config.toml");

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -168,6 +168,7 @@ vi.mock("electron", () => ({
 
 vi.mock("../window", () => ({
   createMainWindow: createMainWindowMock,
+  syncHotCpuProfilersFromSettings: vi.fn(),
 }));
 
 vi.mock("../window-open-settings", () => ({

--- a/apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts
@@ -1,0 +1,394 @@
+import fs from "node:fs/promises";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createTemporaryTestDirectory } from "@pwragent/agent-core";
+import type { ProcessMetric } from "electron";
+import { resolveHotCpuProfileConfig } from "../diagnostics/hot-cpu-profile-config";
+import { createHotCpuProfileSession } from "../diagnostics/hot-cpu-profile-session";
+import { RendererHotCpuProfiler } from "../diagnostics/renderer-hot-cpu-profiler";
+
+function createEnabledConfig(repoRoot: string) {
+  const config = resolveHotCpuProfileConfig({
+    env: {
+      PWRAGENT_HOT_CPU_PROFILING: "1",
+      PWRAGENT_HOT_CPU_PROFILING_INTERVAL_MS: "5",
+      PWRAGENT_HOT_CPU_PROFILING_THRESHOLD_PERCENT: "50",
+      PWRAGENT_HOT_CPU_PROFILING_CONSECUTIVE_SAMPLES: "2",
+      PWRAGENT_HOT_CPU_PROFILING_DURATION_MS: "10",
+      PWRAGENT_HOT_CPU_PROFILING_COOLDOWN_MS: "20",
+      PWRAGENT_HOT_CPU_PROFILING_MAX_PROFILES: "2",
+    },
+    repoRoot,
+  });
+
+  expect(config.enabled).toBe(true);
+  if (!config.enabled) {
+    throw new Error("Expected hot CPU profiling to be enabled.");
+  }
+
+  return config;
+}
+
+function createMetric(percentCPUUsage: number): ProcessMetric {
+  return {
+    pid: 1234,
+    type: "Tab",
+    serviceName: "Tab",
+    name: "PwrAgent Renderer",
+    cpu: {
+      percentCPUUsage,
+      cumulativeCPUUsage: 42,
+      idleWakeupsPerSecond: 3,
+    },
+    creationTime: 1_780_000_000_000,
+    memory: {
+      workingSetSize: 512 * 1024,
+      peakWorkingSetSize: 1024 * 1024,
+    },
+  } as ProcessMetric;
+}
+
+function createTarget() {
+  let attached = false;
+  let destroyed = false;
+  const debuggerApi = {
+    attach: vi.fn(() => {
+      attached = true;
+    }),
+    detach: vi.fn(() => {
+      attached = false;
+    }),
+    isAttached: vi.fn(() => attached),
+    sendCommand: vi.fn(async (method: string) => {
+      if (method === "Profiler.stop") {
+        return {
+          profile: {
+            nodes: [{ id: 1, callFrame: { functionName: "(root)", url: "" } }],
+            samples: [],
+            timeDeltas: [],
+          },
+        };
+      }
+
+      return {};
+    }),
+    on: vi.fn(),
+    off: vi.fn(),
+  };
+
+  return {
+    target: {
+      debugger: debuggerApi,
+      getOSProcessId: vi.fn(() => 1234),
+      isDestroyed: vi.fn(() => destroyed),
+      takeHeapSnapshot: vi.fn(async () => undefined),
+    },
+    debuggerApi,
+    setDestroyed: (value: boolean) => {
+      destroyed = value;
+    },
+  };
+}
+
+describe("RendererHotCpuProfiler", () => {
+  const cleanups: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()));
+  });
+
+  it("records a renderer CPU profile after sustained hot samples", async () => {
+    const workspace = await createTemporaryTestDirectory();
+    cleanups.push(workspace.cleanup);
+
+    const config = createEnabledConfig(workspace.path);
+    const sessionResult = await createHotCpuProfileSession({
+      config,
+      createdAt: new Date(2026, 5, 1, 15, 30, 0),
+      sessionId: "abc123",
+      versions: {
+        appVersion: "1.0.0",
+        electronVersion: "41.2.1",
+        chromeVersion: "146.0.0.0",
+        nodeVersion: "24.0.0",
+      },
+    });
+    expect(sessionResult.ok).toBe(true);
+    if (!sessionResult.ok) return;
+
+    const { target, debuggerApi } = createTarget();
+    const metrics = [createMetric(0), createMetric(72), createMetric(89)];
+    const profiler = new RendererHotCpuProfiler({
+      config,
+      getAppMetrics: () => [metrics.shift() ?? createMetric(0)],
+      session: sessionResult.session,
+      target,
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+      now: () => new Date(),
+    });
+
+    await profiler.start();
+    await vi.waitFor(() => {
+      expect(debuggerApi.attach).toHaveBeenCalledWith("1.3");
+    });
+
+    expect(debuggerApi.sendCommand).toHaveBeenNthCalledWith(1, "Profiler.enable");
+    expect(debuggerApi.sendCommand).toHaveBeenNthCalledWith(2, "Profiler.start");
+
+    await vi.waitFor(async () => {
+      const profile = JSON.parse(
+        await fs.readFile(
+          sessionResult.session.createProfilePath(1),
+          "utf8",
+        ),
+      );
+      expect(profile).toMatchObject({ nodes: [{ id: 1 }] });
+    });
+
+    await profiler.stop("test-complete");
+
+    expect(debuggerApi.sendCommand).toHaveBeenCalledWith("Profiler.stop");
+    expect(debuggerApi.detach).toHaveBeenCalled();
+
+    const profile = JSON.parse(
+      await fs.readFile(
+        sessionResult.session.createProfilePath(1),
+        "utf8",
+      ),
+    );
+    expect(profile).toMatchObject({ nodes: [{ id: 1 }] });
+
+    const events = (await fs.readFile(sessionResult.session.eventsPath, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "profile-started" }),
+        expect.objectContaining({ type: "profile-written" }),
+      ]),
+    );
+  });
+
+  it("skips profiling when a debugger is already attached", async () => {
+    const workspace = await createTemporaryTestDirectory();
+    cleanups.push(workspace.cleanup);
+
+    const config = createEnabledConfig(workspace.path);
+    const sessionResult = await createHotCpuProfileSession({
+      config,
+      createdAt: new Date(2026, 5, 1, 15, 30, 0),
+      sessionId: "abc123",
+      versions: {
+        appVersion: "1.0.0",
+        electronVersion: "41.2.1",
+        chromeVersion: "146.0.0.0",
+        nodeVersion: "24.0.0",
+      },
+    });
+    expect(sessionResult.ok).toBe(true);
+    if (!sessionResult.ok) return;
+
+    const { target, debuggerApi } = createTarget();
+    debuggerApi.isAttached.mockReturnValue(true);
+    const profiler = new RendererHotCpuProfiler({
+      config,
+      getAppMetrics: () => [createMetric(95)],
+      session: sessionResult.session,
+      target,
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+    });
+
+    await profiler.start();
+    await vi.waitFor(async () => {
+      const events = (await fs.readFile(sessionResult.session.eventsPath, "utf8"))
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+
+      expect(events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "profile-skipped",
+            detail: expect.objectContaining({
+              reason: "debugger-already-attached",
+            }),
+          }),
+        ]),
+      );
+    });
+
+    expect(debuggerApi.attach).not.toHaveBeenCalled();
+
+    const events = (await fs.readFile(sessionResult.session.eventsPath, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "profile-skipped",
+          detail: expect.objectContaining({
+            reason: "debugger-already-attached",
+          }),
+        }),
+      ]),
+    );
+
+    await profiler.stop("test-complete");
+  });
+
+  it("clears the profile duration timer when profiling stops early", async () => {
+    const workspace = await createTemporaryTestDirectory();
+    cleanups.push(workspace.cleanup);
+
+    const config = createEnabledConfig(workspace.path);
+    const sessionResult = await createHotCpuProfileSession({
+      config,
+      createdAt: new Date(2026, 5, 1, 15, 30, 0),
+      sessionId: "abc123",
+      versions: {
+        appVersion: "1.0.0",
+        electronVersion: "41.2.1",
+        chromeVersion: "146.0.0.0",
+        nodeVersion: "24.0.0",
+      },
+    });
+    expect(sessionResult.ok).toBe(true);
+    if (!sessionResult.ok) return;
+
+    vi.useFakeTimers();
+
+    const { target, debuggerApi } = createTarget();
+    const profiler = new RendererHotCpuProfiler({
+      config,
+      getAppMetrics: () => [createMetric(89)],
+      session: sessionResult.session,
+      target,
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+    });
+
+    await (
+      profiler as unknown as {
+        startProfile: (options: {
+          capturedAt: string;
+          cpuPercent: number;
+          pid: number;
+        }) => Promise<void>;
+      }
+    ).startProfile({
+      capturedAt: new Date().toISOString(),
+      cpuPercent: 89,
+      pid: 1234,
+    });
+
+    expect(debuggerApi.attach).toHaveBeenCalledWith("1.3");
+    expect(vi.getTimerCount()).toBe(1);
+
+    await profiler.stop("settings-disabled");
+
+    expect(vi.getTimerCount()).toBe(0);
+    await vi.advanceTimersByTimeAsync(20);
+    expect(
+      debuggerApi.sendCommand.mock.calls.filter(([method]) => method === "Profiler.stop"),
+    ).toHaveLength(1);
+  });
+
+  it("does not query debugger attachment when the renderer is destroyed", async () => {
+    const workspace = await createTemporaryTestDirectory();
+    cleanups.push(workspace.cleanup);
+
+    const config = createEnabledConfig(workspace.path);
+    const sessionResult = await createHotCpuProfileSession({
+      config,
+      createdAt: new Date(2026, 5, 1, 15, 30, 0),
+      sessionId: "abc123",
+      versions: {
+        appVersion: "1.0.0",
+        electronVersion: "41.2.1",
+        chromeVersion: "146.0.0.0",
+        nodeVersion: "24.0.0",
+      },
+    });
+    expect(sessionResult.ok).toBe(true);
+    if (!sessionResult.ok) return;
+
+    const { target, debuggerApi, setDestroyed } = createTarget();
+    debuggerApi.sendCommand.mockImplementation(async (method: string) => {
+      if (method === "Profiler.stop") {
+        throw new Error("Object has been destroyed");
+      }
+
+      return {};
+    });
+
+    const profiler = new RendererHotCpuProfiler({
+      config,
+      getAppMetrics: () => [createMetric(89)],
+      session: sessionResult.session,
+      target,
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+    });
+
+    await (
+      profiler as unknown as {
+        startProfile: (options: {
+          capturedAt: string;
+          cpuPercent: number;
+          pid: number;
+        }) => Promise<void>;
+      }
+    ).startProfile({
+      capturedAt: new Date().toISOString(),
+      cpuPercent: 89,
+      pid: 1234,
+    });
+
+    expect(debuggerApi.attach).toHaveBeenCalledWith("1.3");
+    debuggerApi.isAttached.mockClear();
+    debuggerApi.detach.mockClear();
+    setDestroyed(true);
+
+    await profiler.stop("render-process-gone");
+
+    expect(debuggerApi.isAttached).not.toHaveBeenCalled();
+    expect(debuggerApi.detach).not.toHaveBeenCalled();
+
+    const events = (await fs.readFile(sessionResult.session.eventsPath, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "profile-stop-failed",
+          detail: expect.objectContaining({
+            reason: "render-process-gone",
+          }),
+        }),
+        expect.objectContaining({
+          type: "monitor-stopped",
+          detail: expect.objectContaining({
+            reason: "render-process-gone",
+          }),
+        }),
+      ]),
+    );
+  });
+});

--- a/apps/desktop/src/main/diagnostics/hot-cpu-profile-config.ts
+++ b/apps/desktop/src/main/diagnostics/hot-cpu-profile-config.ts
@@ -1,0 +1,100 @@
+import path from "node:path";
+
+const DEFAULT_INTERVAL_MS = 2_000;
+const DEFAULT_THRESHOLD_PERCENT = 75;
+const DEFAULT_CONSECUTIVE_SAMPLES = 2;
+const DEFAULT_PROFILE_DURATION_MS = 15_000;
+const DEFAULT_COOLDOWN_MS = 60_000;
+const DEFAULT_MAX_PROFILES = 5;
+const DEFAULT_HEAP_SNAPSHOT = false;
+
+export type HotCpuProfileConfig =
+  | { enabled: false }
+  | {
+      enabled: true;
+      repoRoot: string;
+      outputRoot: string;
+      intervalMs: number;
+      thresholdPercent: number;
+      consecutiveSamples: number;
+      profileDurationMs: number;
+      cooldownMs: number;
+      maxProfiles: number;
+      captureHeapSnapshot: boolean;
+    };
+
+function isEnabled(value: string | undefined): boolean {
+  if (!value) return false;
+  return ["1", "true", "yes", "on"].includes(value.trim().toLowerCase());
+}
+
+function parsePositiveInteger(
+  value: string | undefined,
+  fallback: number,
+): number {
+  if (!value) return fallback;
+
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function parsePositiveNumber(
+  value: string | undefined,
+  fallback: number,
+): number {
+  if (!value) return fallback;
+
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function resolveHotCpuProfileConfig(options?: {
+  enabled?: boolean;
+  env?: NodeJS.ProcessEnv;
+  outputRoot?: string;
+  repoRoot?: string;
+}): HotCpuProfileConfig {
+  const env = options?.env ?? process.env;
+  if (!options?.enabled && !isEnabled(env.PWRAGENT_HOT_CPU_PROFILING)) {
+    return { enabled: false };
+  }
+
+  const repoRoot = path.resolve(
+    env.PWRAGENT_HOT_CPU_PROFILING_ROOT ?? options?.repoRoot ?? process.cwd(),
+  );
+  const outputRoot = options?.outputRoot ?? path.join(repoRoot, ".local");
+
+  return {
+    enabled: true,
+    repoRoot,
+    outputRoot,
+    intervalMs: parsePositiveInteger(
+      env.PWRAGENT_HOT_CPU_PROFILING_INTERVAL_MS,
+      DEFAULT_INTERVAL_MS,
+    ),
+    thresholdPercent: parsePositiveNumber(
+      env.PWRAGENT_HOT_CPU_PROFILING_THRESHOLD_PERCENT,
+      DEFAULT_THRESHOLD_PERCENT,
+    ),
+    consecutiveSamples: parsePositiveInteger(
+      env.PWRAGENT_HOT_CPU_PROFILING_CONSECUTIVE_SAMPLES,
+      DEFAULT_CONSECUTIVE_SAMPLES,
+    ),
+    profileDurationMs: parsePositiveInteger(
+      env.PWRAGENT_HOT_CPU_PROFILING_DURATION_MS,
+      DEFAULT_PROFILE_DURATION_MS,
+    ),
+    cooldownMs: parsePositiveInteger(
+      env.PWRAGENT_HOT_CPU_PROFILING_COOLDOWN_MS,
+      DEFAULT_COOLDOWN_MS,
+    ),
+    maxProfiles: parsePositiveInteger(
+      env.PWRAGENT_HOT_CPU_PROFILING_MAX_PROFILES,
+      DEFAULT_MAX_PROFILES,
+    ),
+    captureHeapSnapshot:
+      env.PWRAGENT_HOT_CPU_PROFILING_HEAP_SNAPSHOT === undefined
+        ? DEFAULT_HEAP_SNAPSHOT
+        : isEnabled(env.PWRAGENT_HOT_CPU_PROFILING_HEAP_SNAPSHOT),
+  };
+}

--- a/apps/desktop/src/main/diagnostics/hot-cpu-profile-session.ts
+++ b/apps/desktop/src/main/diagnostics/hot-cpu-profile-session.ts
@@ -1,0 +1,159 @@
+import { randomBytes } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { HotCpuProfileConfig } from "./hot-cpu-profile-config";
+
+export type HotCpuProfileSample = {
+  capturedAt: string;
+  pid: number;
+  cpuPercent: number;
+  cumulativeCpuSeconds?: number;
+  idleWakeupsPerSecond?: number;
+  workingSetSize?: number;
+  peakWorkingSetSize?: number;
+  consecutiveHotSamples: number;
+};
+
+export type HotCpuProfileEvent = {
+  capturedAt: string;
+  type: string;
+  detail?: Record<string, unknown>;
+};
+
+export type HotCpuProfileSession = {
+  id: string;
+  directoryName: string;
+  directoryPath: string;
+  samplesPath: string;
+  eventsPath: string;
+  appendSample: (sample: HotCpuProfileSample) => Promise<void>;
+  appendEvent: (event: HotCpuProfileEvent) => Promise<void>;
+  createProfilePath: (index: number) => string;
+  createHeapSnapshotPath: (index: number) => string;
+  registerArtifact: (filename: string) => Promise<void>;
+};
+
+export type HotCpuProfileSessionCreateResult =
+  | { ok: true; session: HotCpuProfileSession }
+  | { ok: false; code: "SESSION_CREATE_FAILED"; message: string; cause: unknown };
+
+type HotCpuProfileSessionManifest = {
+  id: string;
+  directoryName: string;
+  createdAt: string;
+  outputRoot: string;
+  artifacts: string[];
+  config: {
+    intervalMs: number;
+    thresholdPercent: number;
+    consecutiveSamples: number;
+    profileDurationMs: number;
+    cooldownMs: number;
+    maxProfiles: number;
+    captureHeapSnapshot: boolean;
+  };
+  versions: {
+    appVersion: string;
+    electronVersion: string;
+    chromeVersion: string;
+    nodeVersion: string;
+  };
+};
+
+function formatSessionPrefix(date: Date): string {
+  const year = String(date.getFullYear());
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  return `${year}-${month}-${day}-${hours}${minutes}`;
+}
+
+function serializeNdjsonRecord(record: HotCpuProfileSample | HotCpuProfileEvent): string {
+  return `${JSON.stringify(record)}\n`;
+}
+
+async function writeManifest(
+  manifestPath: string,
+  manifest: HotCpuProfileSessionManifest,
+): Promise<void> {
+  await fs.writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+}
+
+export async function createHotCpuProfileSession(options: {
+  config: Extract<HotCpuProfileConfig, { enabled: true }>;
+  createdAt?: Date;
+  sessionId?: string;
+  versions: HotCpuProfileSessionManifest["versions"];
+}): Promise<HotCpuProfileSessionCreateResult> {
+  const createdAt = options.createdAt ?? new Date();
+  const sessionId = options.sessionId ?? randomBytes(3).toString("hex");
+  const directoryName = `hot-cpu-${formatSessionPrefix(createdAt)}-${sessionId}`;
+  const directoryPath = path.join(options.config.outputRoot, directoryName);
+  const manifestPath = path.join(directoryPath, "session.json");
+  const samplesPath = path.join(directoryPath, "samples.ndjson");
+  const eventsPath = path.join(directoryPath, "events.ndjson");
+  const artifacts: string[] = [];
+
+  const manifest: HotCpuProfileSessionManifest = {
+    id: sessionId,
+    directoryName,
+    createdAt: createdAt.toISOString(),
+    outputRoot: options.config.outputRoot,
+    artifacts,
+    config: {
+      intervalMs: options.config.intervalMs,
+      thresholdPercent: options.config.thresholdPercent,
+      consecutiveSamples: options.config.consecutiveSamples,
+      profileDurationMs: options.config.profileDurationMs,
+      cooldownMs: options.config.cooldownMs,
+      maxProfiles: options.config.maxProfiles,
+      captureHeapSnapshot: options.config.captureHeapSnapshot,
+    },
+    versions: options.versions,
+  };
+
+  try {
+    await fs.mkdir(options.config.outputRoot, { recursive: true });
+    await fs.mkdir(directoryPath);
+    await writeManifest(manifestPath, manifest);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    return {
+      ok: false,
+      code: "SESSION_CREATE_FAILED",
+      message: `Unable to create hot CPU diagnostics session in ${options.config.outputRoot}: ${reason}`,
+      cause: error,
+    };
+  }
+
+  async function appendRecord(
+    targetPath: string,
+    record: HotCpuProfileSample | HotCpuProfileEvent,
+  ): Promise<void> {
+    await fs.appendFile(targetPath, serializeNdjsonRecord(record), "utf8");
+  }
+
+  async function registerArtifact(filename: string): Promise<void> {
+    artifacts.push(filename);
+    await writeManifest(manifestPath, manifest);
+  }
+
+  return {
+    ok: true,
+    session: {
+      id: sessionId,
+      directoryName,
+      directoryPath,
+      samplesPath,
+      eventsPath,
+      appendSample: async (sample) => appendRecord(samplesPath, sample),
+      appendEvent: async (event) => appendRecord(eventsPath, event),
+      createProfilePath: (index) =>
+        path.join(directoryPath, `renderer-hot-${String(index).padStart(4, "0")}.cpuprofile`),
+      createHeapSnapshotPath: (index) =>
+        path.join(directoryPath, `renderer-hot-${String(index).padStart(4, "0")}.heapsnapshot`),
+      registerArtifact,
+    },
+  };
+}

--- a/apps/desktop/src/main/diagnostics/renderer-hot-cpu-profiler.ts
+++ b/apps/desktop/src/main/diagnostics/renderer-hot-cpu-profiler.ts
@@ -1,0 +1,387 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { ProcessMetric } from "electron";
+import type { HotCpuProfileConfig } from "./hot-cpu-profile-config";
+import type { HotCpuProfileSession } from "./hot-cpu-profile-session";
+import { getMainLogger } from "../log";
+
+const CHROME_DEBUGGER_PROTOCOL_VERSION = "1.3";
+
+type Logger = Pick<Console, "info" | "warn" | "error">;
+
+type RendererDebugger = {
+  attach: (version: string) => void;
+  detach: () => void;
+  isAttached: () => boolean;
+  sendCommand: (method: string, params?: Record<string, unknown>) => Promise<unknown>;
+  on: (event: "detach", listener: (event: unknown, reason: string) => void) => void;
+  off?: (event: "detach", listener: (event: unknown, reason: string) => void) => void;
+};
+
+type RendererHotCpuTarget = {
+  debugger: RendererDebugger;
+  getOSProcessId: () => number;
+  isDestroyed?: () => boolean;
+  takeHeapSnapshot?: (filePath: string) => Promise<void>;
+};
+
+function serializeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function artifactFilename(filePath: string): string {
+  return path.basename(filePath);
+}
+
+export class RendererHotCpuProfiler {
+  private readonly detachListener = (_event: unknown, reason: string) => {
+    this.debuggerAttached = false;
+    void this.session.appendEvent({
+      capturedAt: this.now().toISOString(),
+      type: "debugger-detached",
+      detail: { reason },
+    });
+    this.logger.warn("[pwragent:hot-cpu] renderer debugger detached", {
+      reason,
+      sessionDirectory: this.session.directoryPath,
+    });
+  };
+
+  private readonly config: Extract<HotCpuProfileConfig, { enabled: true }>;
+  private readonly getAppMetrics: () => ProcessMetric[];
+  private readonly logger: Logger;
+  private readonly now: () => Date;
+  private readonly session: HotCpuProfileSession;
+  private readonly target: RendererHotCpuTarget;
+
+  private consecutiveHotSamples = 0;
+  private debuggerAttached = false;
+  private intervalTimer: ReturnType<typeof setTimeout> | null = null;
+  private lastProfileAtMs: number | null = null;
+  private profileDurationTimer: ReturnType<typeof setTimeout> | null = null;
+  private profileCount = 0;
+  private profiling = false;
+  private stopped = false;
+
+  constructor(options: {
+    config: Extract<HotCpuProfileConfig, { enabled: true }>;
+    getAppMetrics: () => ProcessMetric[];
+    session: HotCpuProfileSession;
+    target: RendererHotCpuTarget;
+    logger?: Logger;
+    now?: () => Date;
+  }) {
+    this.config = options.config;
+    this.getAppMetrics = options.getAppMetrics;
+    this.logger = options.logger ?? getMainLogger("pwragent:hot-cpu");
+    this.now = options.now ?? (() => new Date());
+    this.session = options.session;
+    this.target = options.target;
+  }
+
+  async start(): Promise<void> {
+    if (this.stopped || this.intervalTimer) {
+      return;
+    }
+
+    await this.session.appendEvent({
+      capturedAt: this.now().toISOString(),
+      type: "monitor-started",
+      detail: {
+        intervalMs: this.config.intervalMs,
+        thresholdPercent: this.config.thresholdPercent,
+        consecutiveSamples: this.config.consecutiveSamples,
+        profileDurationMs: this.config.profileDurationMs,
+      },
+    });
+    this.logger.info("[pwragent:hot-cpu] monitoring started", {
+      sessionDirectory: this.session.directoryPath,
+      thresholdPercent: this.config.thresholdPercent,
+      profileDurationMs: this.config.profileDurationMs,
+    });
+    this.scheduleNextSample();
+  }
+
+  async stop(reason = "stopped"): Promise<void> {
+    if (this.stopped) {
+      return;
+    }
+
+    this.stopped = true;
+    if (this.intervalTimer) {
+      clearTimeout(this.intervalTimer);
+      this.intervalTimer = null;
+    }
+    this.clearProfileDurationTimer();
+
+    if (this.profiling) {
+      await this.stopProfile(reason);
+    }
+
+    this.detachDebugger();
+    await this.session.appendEvent({
+      capturedAt: this.now().toISOString(),
+      type: "monitor-stopped",
+      detail: { reason },
+    });
+  }
+
+  private scheduleNextSample(): void {
+    if (this.stopped) {
+      return;
+    }
+
+    this.intervalTimer = setTimeout(() => this.captureSample(), this.config.intervalMs);
+  }
+
+  private async captureSample(): Promise<void> {
+    this.intervalTimer = null;
+
+    if (this.stopped || this.isTargetDestroyed()) {
+      return;
+    }
+
+    const capturedAt = this.now().toISOString();
+    try {
+      const pid = this.target.getOSProcessId();
+      const metric = this.getAppMetrics().find((candidate) => candidate.pid === pid);
+      if (!metric) {
+        await this.session.appendEvent({
+          capturedAt,
+          type: "sample-skipped",
+          detail: { reason: "metric-not-found", pid },
+        });
+        this.scheduleNextSample();
+        return;
+      }
+
+      const cpuPercent = metric.cpu.percentCPUUsage;
+      this.consecutiveHotSamples =
+        cpuPercent >= this.config.thresholdPercent
+          ? this.consecutiveHotSamples + 1
+          : 0;
+
+      await this.session.appendSample({
+        capturedAt,
+        pid,
+        cpuPercent,
+        cumulativeCpuSeconds: metric.cpu.cumulativeCPUUsage,
+        idleWakeupsPerSecond: metric.cpu.idleWakeupsPerSecond,
+        workingSetSize: metric.memory.workingSetSize,
+        peakWorkingSetSize: metric.memory.peakWorkingSetSize,
+        consecutiveHotSamples: this.consecutiveHotSamples,
+      });
+
+      if (this.shouldStartProfile(cpuPercent, capturedAt)) {
+        await this.startProfile({
+          capturedAt,
+          cpuPercent,
+          pid,
+        });
+      }
+    } catch (error) {
+      await this.session.appendEvent({
+        capturedAt,
+        type: "sample-failed",
+        detail: { error: serializeError(error) },
+      });
+      this.logger.error("[pwragent:hot-cpu] sample failed", error);
+    } finally {
+      this.scheduleNextSample();
+    }
+  }
+
+  private shouldStartProfile(cpuPercent: number, capturedAt: string): boolean {
+    if (this.profiling || cpuPercent < this.config.thresholdPercent) {
+      return false;
+    }
+
+    if (this.consecutiveHotSamples < this.config.consecutiveSamples) {
+      return false;
+    }
+
+    if (this.profileCount >= this.config.maxProfiles) {
+      return false;
+    }
+
+    const capturedAtMs = Date.parse(capturedAt);
+    return (
+      this.lastProfileAtMs === null ||
+      capturedAtMs - this.lastProfileAtMs >= this.config.cooldownMs
+    );
+  }
+
+  private async startProfile(options: {
+    capturedAt: string;
+    cpuPercent: number;
+    pid: number;
+  }): Promise<void> {
+    if (this.target.debugger.isAttached()) {
+      await this.session.appendEvent({
+        capturedAt: options.capturedAt,
+        type: "profile-skipped",
+        detail: {
+          reason: "debugger-already-attached",
+          cpuPercent: options.cpuPercent,
+          pid: options.pid,
+        },
+      });
+      return;
+    }
+
+    try {
+      this.target.debugger.attach(CHROME_DEBUGGER_PROTOCOL_VERSION);
+      this.debuggerAttached = true;
+      this.target.debugger.on("detach", this.detachListener);
+      await this.target.debugger.sendCommand("Profiler.enable");
+      await this.target.debugger.sendCommand("Profiler.start");
+      this.profiling = true;
+      this.profileCount += 1;
+      this.lastProfileAtMs = Date.parse(options.capturedAt);
+      await this.session.appendEvent({
+        capturedAt: options.capturedAt,
+        type: "profile-started",
+        detail: {
+          index: this.profileCount,
+          cpuPercent: options.cpuPercent,
+          pid: options.pid,
+          durationMs: this.config.profileDurationMs,
+        },
+      });
+      this.logger.warn("[pwragent:hot-cpu] CPU profile started", {
+        cpuPercent: options.cpuPercent,
+        pid: options.pid,
+        sessionDirectory: this.session.directoryPath,
+      });
+
+      this.profileDurationTimer = setTimeout(
+        () => this.stopProfile("duration-elapsed"),
+        this.config.profileDurationMs,
+      );
+    } catch (error) {
+      await this.session.appendEvent({
+        capturedAt: this.now().toISOString(),
+        type: "profile-start-failed",
+        detail: { error: serializeError(error) },
+      });
+      this.logger.error("[pwragent:hot-cpu] CPU profile failed to start", error);
+      this.detachDebugger();
+    }
+  }
+
+  private async stopProfile(reason: string): Promise<void> {
+    if (!this.profiling) {
+      return;
+    }
+
+    this.profiling = false;
+    this.clearProfileDurationTimer();
+    const index = this.profileCount;
+    const profilePath = this.session.createProfilePath(index);
+    const profileFilename = artifactFilename(profilePath);
+
+    try {
+      const result = (await this.target.debugger.sendCommand("Profiler.stop")) as {
+        profile?: unknown;
+      };
+      await fs.writeFile(
+        profilePath,
+        `${JSON.stringify(result.profile ?? {}, null, 2)}\n`,
+        "utf8",
+      );
+      await this.session.registerArtifact(profileFilename);
+      await this.session.appendEvent({
+        capturedAt: this.now().toISOString(),
+        type: "profile-written",
+        detail: {
+          filename: profileFilename,
+          reason,
+        },
+      });
+
+      if (this.config.captureHeapSnapshot && this.target.takeHeapSnapshot) {
+        await this.captureHeapSnapshot(index);
+      }
+    } catch (error) {
+      await this.session.appendEvent({
+        capturedAt: this.now().toISOString(),
+        type: "profile-stop-failed",
+        detail: {
+          filename: profileFilename,
+          reason,
+          error: serializeError(error),
+        },
+      });
+      this.logger.error("[pwragent:hot-cpu] CPU profile failed to stop", error);
+    } finally {
+      this.detachDebugger();
+    }
+  }
+
+  private async captureHeapSnapshot(index: number): Promise<void> {
+    if (!this.target.takeHeapSnapshot) {
+      return;
+    }
+
+    const snapshotPath = this.session.createHeapSnapshotPath(index);
+    const snapshotFilename = artifactFilename(snapshotPath);
+    try {
+      await this.target.takeHeapSnapshot(snapshotPath);
+      await this.session.registerArtifact(snapshotFilename);
+      await this.session.appendEvent({
+        capturedAt: this.now().toISOString(),
+        type: "heap-snapshot-written",
+        detail: { filename: snapshotFilename },
+      });
+    } catch (error) {
+      await this.session.appendEvent({
+        capturedAt: this.now().toISOString(),
+        type: "heap-snapshot-failed",
+        detail: {
+          filename: snapshotFilename,
+          error: serializeError(error),
+        },
+      });
+      this.logger.error("[pwragent:hot-cpu] heap snapshot failed", error);
+    }
+  }
+
+  private detachDebugger(): void {
+    if (this.isTargetDestroyed()) {
+      this.debuggerAttached = false;
+      return;
+    }
+
+    try {
+      if (this.target.debugger.off) {
+        this.target.debugger.off("detach", this.detachListener);
+      }
+
+      if (!this.debuggerAttached || !this.target.debugger.isAttached()) {
+        return;
+      }
+
+      this.target.debugger.detach();
+      this.debuggerAttached = false;
+    } catch (error) {
+      this.debuggerAttached = false;
+      this.logger.warn("[pwragent:hot-cpu] renderer debugger detach failed", {
+        error: serializeError(error),
+        sessionDirectory: this.session.directoryPath,
+      });
+    }
+  }
+
+  private isTargetDestroyed(): boolean {
+    return Boolean(this.target.isDestroyed?.());
+  }
+
+  private clearProfileDurationTimer(): void {
+    if (!this.profileDurationTimer) {
+      return;
+    }
+
+    clearTimeout(this.profileDurationTimer);
+    this.profileDurationTimer = null;
+  }
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -94,7 +94,7 @@ import {
   isAppStateInitialized,
   recordBootDecision,
 } from "./state/app-state";
-import { createMainWindow } from "./window";
+import { createMainWindow, syncHotCpuProfilersFromSettings } from "./window";
 import { subscribersForChannel } from "./window-channels";
 import { requestOpenSettings } from "./window-open-settings";
 import { requestReplayOnboarding } from "./window-replay-onboarding";
@@ -531,8 +531,12 @@ export function bootstrapApp(): void {
     });
     registerSettingsIpcHandlers(undefined, {
       onConfigPatchWritten: async (patch) => {
-        if (patch.general?.developerMode !== undefined) {
+        if (
+          patch.general?.developerMode !== undefined ||
+          patch.general?.hotCpuProfilingEnabled !== undefined
+        ) {
           installApplicationMenu();
+          syncHotCpuProfilersFromSettings("settings-changed");
         }
       },
     });

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -66,6 +66,7 @@ export type DesktopSettingsConfig = {
   general?: {
     confirmQuitWithInProgressThreads?: boolean;
     developerMode?: boolean;
+    hotCpuProfilingEnabled?: boolean;
     notificationsEnabled?: boolean;
     appearance?: {
       theme?: DesktopAppearanceTheme;
@@ -443,6 +444,12 @@ export function desktopSettingsPatchToEdits(
   // write new values.
   if (patch.general?.developerMode !== undefined) {
     set(["general", "developer_mode"], patch.general.developerMode);
+  }
+  if (patch.general?.hotCpuProfilingEnabled !== undefined) {
+    set(
+      ["general", "hot_cpu_profiling_enabled"],
+      patch.general.hotCpuProfilingEnabled,
+    );
   }
   if (patch.general?.confirmQuitWithInProgressThreads !== undefined) {
     set(
@@ -945,6 +952,7 @@ function normalizeDesktopConfig(
         general?.confirm_quit_with_in_progress_threads,
       ),
       developerMode: readBoolean(general?.developer_mode),
+      hotCpuProfilingEnabled: readBoolean(general?.hot_cpu_profiling_enabled),
       notificationsEnabled: readBoolean(general?.notifications_enabled),
       appearance: {
         theme: readAppearanceTheme(generalAppearance?.theme),
@@ -1149,6 +1157,7 @@ function pruneEmptyConfig(config: DesktopSettingsConfig): DesktopSettingsConfig 
   const pruned: DesktopSettingsConfig = {};
 
   const developerMode = config.general?.developerMode;
+  const hotCpuProfilingEnabled = config.general?.hotCpuProfilingEnabled;
   const confirmQuitWithInProgressThreads =
     config.general?.confirmQuitWithInProgressThreads;
   const notificationsEnabled = config.general?.notificationsEnabled;
@@ -1158,6 +1167,7 @@ function pruneEmptyConfig(config: DesktopSettingsConfig): DesktopSettingsConfig 
   const messagingAcknowledgment = config.general?.messagingAcknowledgment;
   if (
     developerMode !== undefined ||
+    hotCpuProfilingEnabled !== undefined ||
     confirmQuitWithInProgressThreads !== undefined ||
     notificationsEnabled !== undefined ||
     appearanceDefined ||
@@ -1167,6 +1177,9 @@ function pruneEmptyConfig(config: DesktopSettingsConfig): DesktopSettingsConfig 
     pruned.general = {};
     if (developerMode !== undefined) {
       pruned.general.developerMode = developerMode;
+    }
+    if (hotCpuProfilingEnabled !== undefined) {
+      pruned.general.hotCpuProfilingEnabled = hotCpuProfilingEnabled;
     }
     if (confirmQuitWithInProgressThreads !== undefined) {
       pruned.general.confirmQuitWithInProgressThreads =

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -341,6 +341,10 @@ export class DesktopSettingsService {
           config.general?.developerMode,
           this.defaultDeveloperMode(),
         ),
+        hotCpuProfilingEnabled: this.resolveConfigBoolean(
+          config.general?.hotCpuProfilingEnabled,
+          false,
+        ),
         notificationsEnabled: this.resolveConfigBoolean(
           config.general?.notificationsEnabled,
           false,
@@ -711,6 +715,13 @@ export class DesktopSettingsService {
     return this.resolveConfigBoolean(
       this.readConfig().config.general?.developerMode,
       this.defaultDeveloperMode(),
+    ).value;
+  }
+
+  resolveHotCpuProfilingEnabled(): boolean {
+    return this.resolveConfigBoolean(
+      this.readConfig().config.general?.hotCpuProfilingEnabled,
+      false,
     ).value;
   }
 

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -10,9 +10,14 @@ import {
 import { join, resolve } from "node:path";
 import { resolveHeapMonitorConfig } from "./diagnostics/heap-monitor-config";
 import { createHeapSession } from "./diagnostics/heap-session";
+import { resolveHotCpuProfileConfig } from "./diagnostics/hot-cpu-profile-config";
+import { createHotCpuProfileSession } from "./diagnostics/hot-cpu-profile-session";
 import { MainProcessHeapMonitor } from "./diagnostics/main-process-heap-monitor";
 import { RendererHeapMonitor } from "./diagnostics/renderer-heap-monitor";
+import { RendererHotCpuProfiler } from "./diagnostics/renderer-hot-cpu-profiler";
 import { getMainLogger } from "./log";
+import { resolveActiveProfilePath } from "./profile";
+import { getDesktopSettingsService } from "./settings/desktop-settings-singleton";
 import { attachWindowFocusSync } from "./window-focus-sync";
 import {
   WINDOW_KIND_MAIN,
@@ -37,7 +42,9 @@ const isDevelopment = process.env.NODE_ENV !== "production";
 const isMac = process.platform === "darwin";
 const mainLog = getMainLogger("pwragent:main");
 const heapLog = getMainLogger("pwragent:heap");
+const hotCpuLog = getMainLogger("pwragent:hot-cpu");
 const rendererConsoleLog = getMainLogger("pwragent:renderer:console");
+const hotCpuProfilerSyncHandlers = new Map<number, (reason: string) => void>();
 
 function serializeError(error: unknown): string {
   if (error instanceof Error) {
@@ -264,6 +271,18 @@ function resolveRepoRoot(): string {
   return resolve(app.getAppPath(), "../..");
 }
 
+function resolveHotCpuProfileOutputRoot(): string {
+  return resolveActiveProfilePath(join("state", "diagnostics"));
+}
+
+export function syncHotCpuProfilersFromSettings(
+  reason = "settings-changed",
+): void {
+  for (const sync of hotCpuProfilerSyncHandlers.values()) {
+    sync(reason);
+  }
+}
+
 export function createMainWindow(options?: {
   startupCpuProfiler?: {
     attachWindow: (window: BrowserWindow) => void;
@@ -351,6 +370,107 @@ export function createMainWindow(options?: {
 
   const { webContents } = window;
   attachWindowFocusSync(window);
+  let rendererLoaded = false;
+  let hotCpuProfilerPromise: Promise<RendererHotCpuProfiler | null> | null = null;
+  let hotCpuProfilerGeneration = 0;
+
+  const createHotCpuProfiler = async (
+    hotCpuConfig: Extract<ReturnType<typeof resolveHotCpuProfileConfig>, { enabled: true }>,
+  ): Promise<RendererHotCpuProfiler | null> => {
+    const created = await createHotCpuProfileSession({
+      config: hotCpuConfig,
+      versions: {
+        appVersion: app.getVersion(),
+        electronVersion: process.versions.electron ?? "unknown",
+        chromeVersion: process.versions.chrome ?? "unknown",
+        nodeVersion: process.versions.node,
+      },
+    });
+
+    if (!created.ok) {
+      hotCpuLog.error("failed to initialize hot CPU diagnostics", {
+        message: created.message,
+      });
+      return null;
+    }
+
+    hotCpuLog.info("session directory", {
+      sessionDirectory: created.session.directoryPath,
+    });
+
+    return new RendererHotCpuProfiler({
+      config: hotCpuConfig,
+      getAppMetrics: () => app.getAppMetrics(),
+      session: created.session,
+      target: webContents,
+    });
+  };
+
+  const stopHotCpuProfiler = (reason: string) => {
+    hotCpuProfilerGeneration += 1;
+    const profilerPromise = hotCpuProfilerPromise;
+    hotCpuProfilerPromise = null;
+    if (!profilerPromise) {
+      return;
+    }
+
+    void profilerPromise
+      .then(async (profiler) => {
+        await profiler?.stop(reason);
+      })
+      .catch((error: unknown) => {
+        hotCpuLog.warn("failed to stop hot CPU diagnostics", {
+          reason,
+          error: serializeError(error),
+        });
+      });
+  };
+
+  const syncHotCpuProfiler = (reason: string) => {
+    void (async () => {
+      if (!rendererLoaded || window.isDestroyed?.() || webContents.isDestroyed?.()) {
+        return;
+      }
+
+      const settingsService = getDesktopSettingsService();
+      const hotCpuConfig = resolveHotCpuProfileConfig({
+        enabled: settingsService.resolveHotCpuProfilingEnabled(),
+        outputRoot: resolveHotCpuProfileOutputRoot(),
+        repoRoot: resolveRepoRoot(),
+      });
+
+      if (!hotCpuConfig.enabled) {
+        stopHotCpuProfiler(reason);
+        return;
+      }
+
+      if (hotCpuProfilerPromise) {
+        return;
+      }
+
+      const generation = hotCpuProfilerGeneration;
+      hotCpuProfilerPromise = createHotCpuProfiler(hotCpuConfig);
+      const profiler = await hotCpuProfilerPromise;
+      if (generation !== hotCpuProfilerGeneration) {
+        await profiler?.stop("settings-changed");
+        return;
+      }
+
+      if (!profiler) {
+        hotCpuProfilerPromise = null;
+        return;
+      }
+
+      await profiler.start();
+    })().catch((error: unknown) => {
+      hotCpuLog.warn("failed to sync hot CPU diagnostics", {
+        reason,
+        error: serializeError(error),
+      });
+    });
+  };
+  hotCpuProfilerSyncHandlers.set(window.id, syncHotCpuProfiler);
+
   const heapMonitorPromise = (async () => {
     const heapConfig = resolveHeapMonitorConfig({
       repoRoot: resolveRepoRoot(),
@@ -430,12 +550,15 @@ export function createMainWindow(options?: {
 
     webContents.on("render-process-gone", (_event, details) => {
       stopHeapMonitor("render-process-gone");
+      stopHotCpuProfiler("render-process-gone");
       mainLog.error("renderer process gone", details);
     });
 
     if (typeof webContents.once === "function") {
       webContents.once("did-finish-load", () => {
+        rendererLoaded = true;
         void heapMonitorPromise.then((monitors) => monitors?.rendererMonitor.start());
+        syncHotCpuProfiler("did-finish-load");
       });
     }
   }
@@ -485,7 +608,9 @@ export function createMainWindow(options?: {
   ]);
 
   window.on("closed", () => {
+    hotCpuProfilerSyncHandlers.delete(window.id);
     stopHeapMonitor("window-closed");
+    stopHotCpuProfiler("window-closed");
   });
 
   return window;

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -390,6 +390,10 @@ describe("App", () => {
           value: false,
           source: "default",
         },
+        hotCpuProfilingEnabled: {
+          value: false,
+          source: "default",
+        },
         notificationsEnabled: {
           value: false,
           source: "default",

--- a/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
@@ -102,6 +102,7 @@ export function GeneralSettings(props: {
   saving: boolean;
   snapshot: DesktopSettingsSnapshot;
   onDeveloperModeChange: (value: boolean) => Promise<void>;
+  onHotCpuProfilingEnabledChange: (value: boolean) => Promise<void>;
   onConfirmQuitWithInProgressThreadsChange: (value: boolean) => Promise<void>;
   onPastedImageMaxPatchesChange: (value: number) => Promise<void>;
   onUpdateChannelChange: (value: DesktopUpdateChannel) => Promise<void>;
@@ -116,6 +117,8 @@ export function GeneralSettings(props: {
   const confirmQuitWithInProgressThreads =
     props.snapshot.general.confirmQuitWithInProgressThreads;
   const developerMode = props.snapshot.general.developerMode;
+  const hotCpuProfilingEnabled =
+    props.snapshot.general.hotCpuProfilingEnabled;
   const notificationsEnabled = props.snapshot.general.notificationsEnabled;
   const updateChannel = props.snapshot.updates.channel;
   const messagingAcknowledgment =
@@ -286,6 +289,21 @@ export function GeneralSettings(props: {
                 label="Developer Mode"
                 onChange={(next) => {
                   void props.onDeveloperModeChange(next);
+                }}
+              />
+            }
+          />
+          <SettingsField
+            label="Hot renderer CPU profiling"
+            sub="Capture a short Chrome CPU profile when the renderer stays hot."
+            source={sourceBadge(hotCpuProfilingEnabled)}
+            control={
+              <SettingsSwitch
+                checked={hotCpuProfilingEnabled.value}
+                disabled={props.saving}
+                label="Hot renderer CPU profiling"
+                onChange={(next) => {
+                  void props.onHotCpuProfilingEnabledChange(next);
                 }}
               />
             }

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -278,6 +278,13 @@ function SettingsSectionBody(props: {
             general: { developerMode },
           });
         }}
+        onHotCpuProfilingEnabledChange={async (
+          hotCpuProfilingEnabled: boolean,
+        ) => {
+          await props.settings.writeConfig({
+            general: { hotCpuProfilingEnabled },
+          });
+        }}
         onConfirmQuitWithInProgressThreadsChange={async (
           confirmQuitWithInProgressThreads: boolean,
         ) => {

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -58,6 +58,10 @@ function createSnapshot(
         value: false,
         source: "default",
       },
+      hotCpuProfilingEnabled: {
+        value: false,
+        source: "default",
+      },
       notificationsEnabled: {
         value: false,
         source: "default",
@@ -371,6 +375,9 @@ describe("SettingsScreen", () => {
       "false",
     );
     expect(
+      screen.getByRole("switch", { name: "Hot renderer CPU profiling" }),
+    ).toHaveAttribute("aria-checked", "false");
+    expect(
       screen.getByRole("switch", {
         name: "Confirm quit when threads are in progress",
       }),
@@ -393,6 +400,17 @@ describe("SettingsScreen", () => {
       expect(settings.writeConfig).toHaveBeenCalledWith({
         general: {
           developerMode: true,
+        },
+      });
+    });
+
+    fireEvent.click(
+      screen.getByRole("switch", { name: "Hot renderer CPU profiling" }),
+    );
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        general: {
+          hotCpuProfilingEnabled: true,
         },
       });
     });

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -27,6 +27,10 @@ describe("desktop settings contracts", () => {
           value: false,
           source: "default",
         },
+        hotCpuProfilingEnabled: {
+          value: false,
+          source: "default",
+        },
         notificationsEnabled: {
           value: false,
           source: "default",

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -225,6 +225,7 @@ export type DesktopAppearanceSnapshot = {
 export type DesktopGeneralSettingsSnapshot = {
   confirmQuitWithInProgressThreads: DesktopSettingsValue<boolean>;
   developerMode: DesktopSettingsValue<boolean>;
+  hotCpuProfilingEnabled: DesktopSettingsValue<boolean>;
   notificationsEnabled: DesktopSettingsValue<boolean>;
   appearance: DesktopAppearanceSnapshot;
   codexProfileModel: DesktopSettingsValue<DesktopCodexProfileModel>;
@@ -565,6 +566,7 @@ export type DesktopSettingsConfigPatch = {
   general?: {
     confirmQuitWithInProgressThreads?: boolean;
     developerMode?: boolean;
+    hotCpuProfilingEnabled?: boolean;
     notificationsEnabled?: boolean;
     appearance?: {
       theme?: DesktopAppearanceTheme;


### PR DESCRIPTION
## Summary

Released builds can now turn on hot renderer CPU profiling from Settings, so renderer CPU spikes can be captured in the app instance that is actually misbehaving instead of requiring a terminal-launched dev session.

The monitor samples Electron process metrics and records a short Chrome `.cpuprofile` after sustained hot renderer CPU, then detaches. Artifacts are written under the active PwrAgent profile's `state/diagnostics` directory so packaged apps have a writable, profile-scoped output location. The env-driven dev workflow remains available through `profile:hot-cpu`.

## Test Plan

- `pnpm test apps/desktop/src/main/__tests__/app-bootstrap.test.ts apps/desktop/src/main/__tests__/index.test.ts apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts apps/desktop/src/main/__tests__/desktop-settings-service.test.ts apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts packages/shared/src/contracts/__tests__/settings.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm --filter @pwragent/shared typecheck`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
