### PR TITLE
fix(desktop): copy PR URLs from chip context menu

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -11,6 +11,7 @@ import type {
   MessagingThreadBindingSummary,
   NavigationDirectorySummary,
   NavigationThreadSummary,
+  PrSummary,
 } from "@pwragent/shared";
 import {
   buildThreadIdentityKey,
@@ -43,6 +44,11 @@ type DirectoriesListProps = {
   onOpenThreadContextMenu: (
     thread: NavigationThreadSummary,
     position: { x: number; y: number }
+  ) => void;
+  onOpenPullRequestContextMenu?: (
+    thread: NavigationThreadSummary,
+    pr: PrSummary,
+    position: { x: number; y: number; anchorTop?: number }
   ) => void;
   onOpenLaunchpad: (
     directory: NavigationDirectorySummary,
@@ -482,6 +488,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
               thinkingThreadKeys={props.thinkingThreadKeys}
               thread={child}
               onOpenContextMenu={props.onOpenThreadContextMenu}
+              onOpenPullRequestContextMenu={props.onOpenPullRequestContextMenu}
               onPrefetchPullRequests={props.onPrefetchPullRequests}
               onSelectThread={props.onSelectThread}
               onSetReaction={props.onSetReaction}
@@ -844,6 +851,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
                             );
                           }}
                           onOpenContextMenu={props.onOpenThreadContextMenu}
+                          onOpenPullRequestContextMenu={props.onOpenPullRequestContextMenu}
                           onPrefetchPullRequests={props.onPrefetchPullRequests}
                           onSelectThread={props.onSelectThread}
                           onSetReaction={props.onSetReaction}
@@ -936,6 +944,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
                             setDividerDropTarget(undefined);
                           }}
                           onOpenContextMenu={props.onOpenThreadContextMenu}
+                          onOpenPullRequestContextMenu={props.onOpenPullRequestContextMenu}
                           onPrefetchPullRequests={props.onPrefetchPullRequests}
                           onSelectThread={props.onSelectThread}
                           onSetReaction={props.onSetReaction}

--- a/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
@@ -3,6 +3,7 @@ import type {
   AppServerBackendKind,
   MessagingThreadBindingSummary,
   NavigationThreadSummary,
+  PrSummary,
 } from "@pwragent/shared";
 import {
   buildThreadIdentityKey,
@@ -26,6 +27,11 @@ type RecentsListProps = {
   onOpenThreadContextMenu: (
     thread: NavigationThreadSummary,
     position: { x: number; y: number }
+  ) => void;
+  onOpenPullRequestContextMenu?: (
+    thread: NavigationThreadSummary,
+    pr: PrSummary,
+    position: { x: number; y: number; anchorTop?: number }
   ) => void;
   onPrefetchPullRequests?: (thread: NavigationThreadSummary) => void;
   onReorderThreadPins?: (
@@ -228,6 +234,7 @@ export function RecentsList(props: RecentsListProps) {
                 );
               }}
               onOpenContextMenu={props.onOpenThreadContextMenu}
+              onOpenPullRequestContextMenu={props.onOpenPullRequestContextMenu}
               onPrefetchPullRequests={props.onPrefetchPullRequests}
               onSelectThread={props.onSelectThread}
               onSetReaction={props.onSetReaction}
@@ -340,6 +347,7 @@ export function RecentsList(props: RecentsListProps) {
           }
           onMovePinnedThread={pinned ? movePinnedThreadByKeyboard : undefined}
           onOpenContextMenu={props.onOpenThreadContextMenu}
+          onOpenPullRequestContextMenu={props.onOpenPullRequestContextMenu}
           onPrefetchPullRequests={props.onPrefetchPullRequests}
           onSelectThread={props.onSelectThread}
           onSetReaction={props.onSetReaction}

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -11,6 +11,7 @@ import type {
   MessagingThreadBindingSummary,
   NavigationDirectorySummary,
   NavigationThreadSummary,
+  PrSummary,
   ThreadExecutionMode,
 } from "@pwragent/shared";
 import {
@@ -177,6 +178,7 @@ export function Sidebar(props: SidebarProps) {
     | {
         requestedPosition: ThreadContextMenuPosition;
         position?: { x: number; y: number };
+        pullRequest?: PrSummary;
         thread: NavigationThreadSummary;
       }
     | undefined
@@ -417,6 +419,16 @@ export function Sidebar(props: SidebarProps) {
     setContextMenu({ requestedPosition: position, thread });
   };
 
+  const openPullRequestContextMenu = (
+    thread: NavigationThreadSummary,
+    pullRequest: PrSummary,
+    position: ThreadContextMenuPosition,
+  ): void => {
+    setRenameThread(undefined);
+    setDirectoryContextMenu(undefined);
+    setContextMenu({ requestedPosition: position, pullRequest, thread });
+  };
+
   const requestRenameFromContextMenu = (thread: NavigationThreadSummary): void => {
     setContextMenu(undefined);
     setRenameThread(thread);
@@ -611,6 +623,7 @@ export function Sidebar(props: SidebarProps) {
   const contextMenuHasWorkspace =
     contextMenuHasLocalWorkspace || contextMenuHasWorktreeWorkspace;
   const contextMenuBranchName = contextMenu?.thread.gitBranch;
+  const contextMenuPullRequest = contextMenu?.pullRequest;
   const contextMenuIsSubthread = Boolean(contextMenu?.thread.parentThreadId);
   const contextMenuCanCreateSubthread = Boolean(
     contextMenu &&
@@ -868,6 +881,7 @@ export function Sidebar(props: SidebarProps) {
               onOpenDirectoryContextMenu={
                 props.onSetDirectoryPin ? openDirectoryContextMenu : undefined
               }
+              onOpenPullRequestContextMenu={openPullRequestContextMenu}
               onSelectThread={props.onSelectThread}
               onSetReaction={props.onSetThreadReaction}
               onUnbindMessagingBinding={props.onUnbindMessagingBinding}
@@ -882,6 +896,7 @@ export function Sidebar(props: SidebarProps) {
                 thinkingThreadKeys={props.thinkingThreadKeys}
                 threads={visibleThreads}
                 onOpenThreadContextMenu={openThreadContextMenu}
+                onOpenPullRequestContextMenu={openPullRequestContextMenu}
                 onPrefetchPullRequests={props.onPrefetchPullRequests}
                 onReorderThreadPins={props.onReorderThreadPins}
                 onUpdateSubthreadOrder={props.onUpdateSubthreadOrder}
@@ -1148,6 +1163,15 @@ export function Sidebar(props: SidebarProps) {
             </>
           ) : null}
           <div className="thread-context-menu__section">
+            {contextMenuPullRequest ? (
+              <button
+                role="menuitem"
+                type="button"
+                onClick={() => copyFromContextMenu(contextMenuPullRequest.url)}
+              >
+                Copy Pull Request URL
+              </button>
+            ) : null}
             <button
               role="menuitem"
               type="button"

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -47,6 +47,11 @@ type ThreadRowProps = {
     thread: NavigationThreadSummary,
     position: { x: number; y: number; anchorTop?: number }
   ) => void;
+  onOpenPullRequestContextMenu?: (
+    thread: NavigationThreadSummary,
+    pr: PrSummary,
+    position: { x: number; y: number; anchorTop?: number }
+  ) => void;
   /**
    * Fired after a 750ms hover over a non-merged PR chip. The parent
    * decides whether to actually issue an IPC fetch (e.g. dedupe by
@@ -247,6 +252,16 @@ export function ThreadRow(props: ThreadRowProps) {
               pr={pr}
               showRepoPrefix={showRepoPrefix}
               onOpen={openPr}
+              onOpenContextMenu={
+                props.onOpenPullRequestContextMenu
+                  ? (targetPr, position) =>
+                      props.onOpenPullRequestContextMenu!(
+                        props.thread,
+                        targetPr,
+                        position,
+                      )
+                  : undefined
+              }
             />
           ))}
 

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -9,7 +9,11 @@ import {
   within,
 } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { BackendSummary, NavigationDirectorySummary } from "@pwragent/shared";
+import type {
+  BackendSummary,
+  NavigationDirectorySummary,
+  NavigationThreadSummary,
+} from "@pwragent/shared";
 import { Sidebar } from "../Sidebar";
 
 async function clickElement(element: HTMLElement): Promise<void> {
@@ -108,6 +112,19 @@ const sharedThread = {
       path: "/Users/huntharo/pwrdrvr/PwrAgent",
       worktreePath: "/Users/huntharo/.codex/worktrees/0f38/PwrAgent",
       kind: "worktree" as const,
+    },
+  ],
+};
+
+const pullRequestThread: NavigationThreadSummary = {
+  ...sharedThread,
+  prs: [
+    {
+      number: 202,
+      org: "Giphy",
+      repo: "GifGrabber",
+      state: "passing",
+      url: "https://github.com/Giphy/GifGrabber/pull/202",
     },
   ],
 };
@@ -2114,6 +2131,49 @@ describe("Sidebar", () => {
     expect(
       screen.queryByText("Line up the desktop shell with the app server")
     ).not.toBeInTheDocument();
+  });
+
+  it("copies a pull request URL from the PR chip context menu", async () => {
+    const copyText = vi.fn(async () => undefined);
+    const onSelectThread = vi.fn();
+    Object.defineProperty(window, "pwragent", {
+      configurable: true,
+      value: {
+        copyText,
+      },
+    });
+
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="recents"
+        createThreadError={undefined}
+        directories={directories}
+        inboxThreads={[pullRequestThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey="codex:thread-1"
+        threads={[pullRequestThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={onSelectThread}
+      />
+    );
+
+    const prChip = screen.getByRole("button", {
+      name: "Open Giphy/GifGrabber#202 (passing) in browser",
+    });
+    fireEvent.contextMenu(prChip, { clientX: 48, clientY: 64 });
+    await clickElement(
+      screen.getByRole("menuitem", { name: "Copy Pull Request URL" }),
+    );
+
+    expect(copyText).toHaveBeenCalledWith(
+      "https://github.com/Giphy/GifGrabber/pull/202",
+    );
+    expect(onSelectThread).not.toHaveBeenCalled();
   });
 
   it("shows compact runtime identity chips that copy full values", async () => {

--- a/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
@@ -6,6 +6,10 @@ type PrChipProps = {
   /** When the thread spans multiple repos, render the org/repo prefix. */
   showRepoPrefix: boolean;
   onOpen: (url: string) => void;
+  onOpenContextMenu?: (
+    pr: PrSummary,
+    position: { x: number; y: number; anchorTop?: number },
+  ) => void;
 };
 
 export function PrChip(props: PrChipProps) {
@@ -34,6 +38,19 @@ export function PrChip(props: PrChipProps) {
       title={tooltip}
       className={`pr-chip pr-chip--${pr.state}`}
       onClick={handleActivate}
+      onContextMenu={(event) => {
+        if (!props.onOpenContextMenu) {
+          return;
+        }
+        event.preventDefault();
+        event.stopPropagation();
+        const rect = event.currentTarget.getBoundingClientRect();
+        props.onOpenContextMenu(pr, {
+          x: event.clientX,
+          y: event.clientY,
+          anchorTop: rect.top,
+        });
+      }}
       onKeyDown={(event) => {
         if (event.key === "Enter" || event.key === " ") {
           handleActivate(event);


### PR DESCRIPTION
## Summary

Right-clicking a PR chip in the thread list now offers a direct `Copy Pull Request URL` action, so users can copy the GitHub URL without opening the PR first. Left-click and keyboard activation still open the PR as before, and the right-click handler is wired through Recents, Directories, compact rows, and subthreads.

## Tests

- `pnpm test apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
