### PR TITLE
fix(desktop): add sidebar masthead action tooltips

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -2,6 +2,7 @@ import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type {
   KeyboardEvent as ReactKeyboardEvent,
   MouseEvent as ReactMouseEvent,
+  ReactNode,
   PointerEvent,
 } from "react";
 import type {
@@ -709,35 +710,32 @@ export function Sidebar(props: SidebarProps) {
         <p className="sidebar__brand">Pwr<span className="sidebar__brand-accent">Agent</span></p>
 
         <div className="sidebar__masthead-actions">
-          <button
-            aria-label="Open automations"
-            aria-pressed={props.automationsActive}
+          <MastheadActionButton
+            ariaLabel="Open automations"
+            ariaPressed={props.automationsActive}
             className={`sidebar__icon-button${props.automationsActive ? " is-active" : ""}`}
-            type="button"
             onClick={props.onOpenAutomations}
           >
             <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><path d="M8 2v4"/><path d="M16 2v4"/><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M3 10h18"/><path d="M8 14h.01"/><path d="M12 14h.01"/><path d="M16 14h.01"/><path d="M8 18h.01"/><path d="M12 18h.01"/></svg>
-          </button>
-          <button
-            aria-label="Open settings"
-            aria-pressed={props.settingsActive}
+          </MastheadActionButton>
+          <MastheadActionButton
+            ariaLabel="Open settings"
+            ariaPressed={props.settingsActive}
             className={`sidebar__icon-button${props.settingsActive ? " is-active" : ""}`}
-            type="button"
             onClick={props.onOpenSettings}
           >
             <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/></svg>
-          </button>
-          <button
-            aria-label="New thread"
+          </MastheadActionButton>
+          <MastheadActionButton
+            ariaLabel="New thread"
             className="sidebar__icon-button"
             disabled={Boolean(props.creatingThread)}
-            type="button"
             onClick={() => {
               void props.onCreateThread();
             }}
           >
             <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/><line x1="12" y1="18" x2="12" y2="12"/><line x1="9" y1="15" x2="15" y2="15"/></svg>
-          </button>
+          </MastheadActionButton>
         </div>
       </header>
 
@@ -1439,6 +1437,40 @@ function ProfileIdentityButton(props: {
         onMouseLeave={tooltip.hide}
       >
         <span className="runtime-identity__text">{props.label}</span>
+      </button>
+      {tooltip.tooltipNode}
+    </>
+  );
+}
+
+function MastheadActionButton(props: {
+  ariaLabel: string;
+  ariaPressed?: boolean;
+  children: ReactNode;
+  className: string;
+  disabled?: boolean;
+  onClick?: () => void;
+}) {
+  const tooltip = useViewportTooltip({ className: "viewport-tooltip" });
+
+  return (
+    <>
+      <button
+        aria-label={props.ariaLabel}
+        aria-pressed={props.ariaPressed}
+        className={props.className}
+        disabled={props.disabled}
+        type="button"
+        onBlur={tooltip.hide}
+        onClick={() => {
+          tooltip.hide();
+          props.onClick?.();
+        }}
+        onFocus={(event) => tooltip.show(event.currentTarget, props.ariaLabel)}
+        onMouseEnter={(event) => tooltip.show(event.currentTarget, props.ariaLabel)}
+        onMouseLeave={tooltip.hide}
+      >
+        {props.children}
       </button>
       {tooltip.tooltipNode}
     </>

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -216,6 +216,56 @@ describe("Sidebar", () => {
     expect(screen.getAllByText("OpenAI").length).toBeGreaterThan(0);
   });
 
+  it("shows masthead action tooltips and preserves button handlers", async () => {
+    const onOpenAutomations = vi.fn();
+    const onOpenSettings = vi.fn();
+    const onCreateThread = vi.fn(async () => undefined);
+
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="recents"
+        createThreadError={undefined}
+        directories={directories}
+        inboxThreads={[sharedThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey="codex:thread-1"
+        threads={[sharedThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={onCreateThread}
+        onOpenAutomations={onOpenAutomations}
+        onOpenLaunchpad={async () => undefined}
+        onOpenSettings={onOpenSettings}
+        onSelectThread={() => undefined}
+      />
+    );
+
+    const automationsButton = screen.getByRole("button", { name: "Open automations" });
+    fireEvent.mouseEnter(automationsButton);
+    expect((await screen.findByRole("tooltip")).textContent).toBe("Open automations");
+    fireEvent.click(automationsButton);
+    expect(onOpenAutomations).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+
+    const settingsButton = screen.getByRole("button", { name: "Open settings" });
+    fireEvent.focus(settingsButton);
+    expect((await screen.findByRole("tooltip")).textContent).toBe("Open settings");
+    fireEvent.blur(settingsButton);
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    fireEvent.click(settingsButton);
+    expect(onOpenSettings).toHaveBeenCalledTimes(1);
+
+    const newThreadButton = screen.getByRole("button", { name: "New thread" });
+    fireEvent.mouseEnter(newThreadButton);
+    expect((await screen.findByRole("tooltip")).textContent).toBe("New thread");
+    fireEvent.mouseLeave(newThreadButton);
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    fireEvent.click(newThreadButton);
+    expect(onCreateThread).toHaveBeenCalledTimes(1);
+  });
+
   it("groups sub-threads under their parent and persists collapse clicks", () => {
     const childThread = {
       ...sharedThread,

--- a/docs/plans/2026-06-02-001-feat-sidebar-masthead-tooltips-plan.md
+++ b/docs/plans/2026-06-02-001-feat-sidebar-masthead-tooltips-plan.md
@@ -1,0 +1,152 @@
+---
+title: feat: Add sidebar masthead action tooltips
+type: feat
+status: completed
+date: 2026-06-02
+---
+
+# feat: Add sidebar masthead action tooltips
+
+## Overview
+
+Add hover and focus tooltips for the three icon-only actions in the left sidebar masthead so operators do not have to infer meaning from the icons alone. The change should reuse the desktop app's existing viewport-safe tooltip pattern and keep the visible chrome unchanged.
+
+## Problem Frame
+
+The sidebar masthead currently exposes three icon-only buttons for automations, settings, and new thread creation. They already have `aria-label` text for assistive technology, but pointer users and sighted keyboard users do not get an on-screen caption that confirms what each icon does. This creates unnecessary guesswork in a high-frequency navigation surface.
+
+## Requirements Trace
+
+- R1. The Automations masthead button shows a readable caption on hover and keyboard focus.
+- R2. The Settings masthead button shows a readable caption on hover and keyboard focus.
+- R3. The New thread masthead button shows a readable caption on hover and keyboard focus.
+- R4. The tooltip implementation must follow existing desktop tooltip patterns for clipped sidebar surfaces and must not change click behavior, disabled behavior, or active-state styling of the buttons.
+
+## Scope Boundaries
+
+- No redesign of the sidebar masthead layout, iconography, or button ordering.
+- No rename of the existing actions beyond whatever text is chosen for tooltip copy consistency.
+- No broader tooltip rollout for other sidebar controls outside these three masthead buttons.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx` renders the three masthead icon buttons and already contains tooltip-aware helper buttons for profile and runtime identity rows.
+- `apps/desktop/src/renderer/src/lib/useViewportTooltip.tsx` is the shared portal tooltip hook for surfaces that can clip pseudo-element tooltips.
+- `apps/desktop/src/renderer/src/styles/app.css` defines the shared `.viewport-tooltip` styling consumed by the hook.
+- `apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx` already verifies sidebar tooltip behavior for profile identity and runtime identity buttons, so it is the right home for regression coverage.
+
+### Institutional Learnings
+
+- No directly relevant `docs/solutions/` entry was found for this sidebar tooltip affordance.
+
+### External References
+
+- None. Local patterns are already strong and specific for this UI surface.
+
+## Key Technical Decisions
+
+- Reuse `useViewportTooltip` and `.viewport-tooltip` instead of native `title` attributes or CSS pseudo-element tooltips because `apps/desktop/AGENTS.md` explicitly calls for viewport tooltips inside clipped sidebar surfaces.
+- Keep tooltip copy aligned with the semantic action names already exposed via `aria-label` so visible and assistive labels do not drift.
+- Implement the masthead buttons through a small local helper component or shared event wiring inside `Sidebar.tsx` rather than introducing a new global button primitive for a three-button-only need.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Which tooltip mechanism should be used: the existing viewport tooltip hook, not `title` and not `tooltip-target`.
+- Should the tooltip text differ from the button accessibility labels: no, keep them aligned unless implementation reveals a strong product-copy reason to diverge.
+
+### Deferred to Implementation
+
+- Whether the masthead buttons should share one local tooltip controller or each render through a tiny reusable helper component. Either is acceptable if it keeps event handling straightforward and testable.
+
+## Implementation Units
+
+- U1. **Wire masthead icon buttons to viewport tooltips**
+
+**Goal:** Add visible hover/focus captions to the Automations, Settings, and New thread buttons in the sidebar masthead without changing their existing actions or visual states.
+
+**Requirements:** R1, R2, R3, R4
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx`
+- Test: `apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx`
+
+**Approach:**
+- Extend the masthead action rendering so each icon button shows a viewport tooltip on `mouseenter` and `focus`, and hides it on `mouseleave`, `blur`, and click as appropriate.
+- Use the same text as the existing labels: `Open automations`, `Open settings`, and `New thread`, unless implementation chooses to trim the leading verb consistently across all three.
+- Keep the current `aria-label`, `aria-pressed`, `disabled`, and `onClick` semantics intact.
+- Prefer colocated helper logic in `Sidebar.tsx` because that file already contains sidebar-specific tooltip button patterns.
+
+**Patterns to follow:**
+- `apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx` `ProfileIdentityButton`
+- `apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx` `RuntimeIdentityButton`
+- `apps/desktop/src/renderer/src/lib/useViewportTooltip.tsx`
+
+**Test scenarios:**
+- Happy path: hovering the Automations button renders a tooltip with the expected caption.
+- Happy path: hovering the Settings button renders a tooltip with the expected caption.
+- Happy path: hovering the New thread button renders a tooltip with the expected caption when the button is enabled.
+- Edge case: focusing each button by keyboard renders the same tooltip copy as hover.
+- Edge case: leaving or blurring the button removes the tooltip from the DOM.
+- Error path: when `creatingThread` disables the New thread button, the button remains disabled and does not regress its disabled semantics while tooltip wiring is present.
+- Integration: clicking each button still invokes the existing handler path and does not leave a stale tooltip visible after activation.
+
+**Verification:**
+- Sidebar masthead buttons remain visually unchanged except for visible hover/focus captions.
+- Tooltips escape the sidebar without clipping and disappear when the interaction ends.
+- Existing button interactions still work exactly as before.
+
+---
+
+- U2. **Add focused sidebar regression coverage**
+
+**Goal:** Lock the new masthead tooltip behavior into the sidebar test suite so future icon-only changes do not silently remove the captions.
+
+**Requirements:** R1, R2, R3, R4
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx`
+
+**Approach:**
+- Add one or two targeted tests near the existing tooltip coverage instead of scattering assertions throughout unrelated sidebar tests.
+- Reuse the existing render shape and `fireEvent.mouseEnter` / `fireEvent.mouseLeave` / focus assertions already used for other sidebar tooltip tests.
+- Cover both visibility and interaction safety so the tests protect against regressions where a tooltip appears but button behavior changes.
+
+**Patterns to follow:**
+- `apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx` profile tooltip test
+- `apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx` runtime identity tooltip tests
+
+**Test scenarios:**
+- Happy path: each masthead button shows the expected tooltip text on hover.
+- Edge case: tooltip visibility can move from one masthead button to another without leaving duplicate tooltips behind.
+- Integration: clicking the Automations and Settings buttons still calls their handlers after tooltip hover.
+- Integration: clicking New thread still calls `onCreateThread` when enabled.
+
+**Verification:**
+- The sidebar test suite fails if tooltip copy disappears, if hover/focus stops producing a tooltip, or if button handler behavior regresses.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Tooltip implementation gets clipped or layered behind the sidebar surface | Reuse `useViewportTooltip` with `.viewport-tooltip`, per `apps/desktop/AGENTS.md` guidance |
+| Tooltip wiring changes click or disabled behavior on the icon buttons | Keep existing button props intact and add sidebar interaction assertions in tests |
+| Tooltip copy drifts from accessibility labels | Derive tooltip strings from the same semantic action labels or keep them adjacent in one helper |
+
+## Documentation / Operational Notes
+
+- No docs update is required. This is a self-evident UI affordance improvement in the desktop shell.
+
+## Sources & References
+
+- Related code: `apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx`
+- Related code: `apps/desktop/src/renderer/src/lib/useViewportTooltip.tsx`
+- Related tests: `apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx`
+- Guidance: `apps/desktop/AGENTS.md`


### PR DESCRIPTION
## Summary
- add visible hover and focus tooltips to the sidebar masthead Automations, Settings, and New Thread icon buttons
- reuse the existing viewport-safe sidebar tooltip pattern so captions are not clipped and existing button behavior stays intact
- add sidebar regression coverage that verifies the new captions and preserves the original click handlers

## Testing
- `pnpm test apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx`

## Post-Deploy Monitoring & Validation
No additional operational monitoring required. This is a renderer-only tooltip affordance change with no backend, persistence, or runtime contract impact.
