### PR TITLE
fix(desktop): restore slash autocomplete after query edits

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -2273,6 +2273,16 @@ export function Composer(props: ComposerProps) {
   }, [slashTrigger?.query, props.launchpad?.directoryKey, props.thread?.id]);
 
   useEffect(() => {
+    if (!dismissedAutocompleteKey) {
+      return;
+    }
+
+    if (!autocompleteKey || autocompleteKey !== dismissedAutocompleteKey) {
+      setDismissedAutocompleteKey(undefined);
+    }
+  }, [autocompleteKey, dismissedAutocompleteKey]);
+
+  useEffect(() => {
     deletedSkillTokenHistoryRef.current = [];
     if (skillTokens.length === 0 && draft.includes("](")) {
       const hydrated = hydrateComposerDraft(draft, props.skills);

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -4242,6 +4242,44 @@ describe("Composer", () => {
     }
   });
 
+  it("reopens slash autocomplete for a previously dismissed query after editing away", async () => {
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn: async () => ({
+            backend: "codex",
+            threadId: "thread-1",
+            turnId: "turn-1",
+          }),
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Review thread",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "/re" } });
+    fireEvent.keyDown(textarea, { key: "Escape", code: "Escape" });
+    expect(screen.queryByRole("listbox", { name: "Commands" })).not.toBeInTheDocument();
+
+    fireEvent.change(textarea, { target: { value: "/r" } });
+    expect(screen.getByRole("listbox", { name: "Commands" })).toBeInTheDocument();
+
+    fireEvent.change(textarea, { target: { value: "/re" } });
+    const commands = screen.getByRole("listbox", { name: "Commands" });
+    expect(within(commands).getByRole("button", { name: /\/review/i })).toBeInTheDocument();
+  });
+
   it("keeps duplicate local and provider slash commands labeled by source", async () => {
     render(
       <Composer


### PR DESCRIPTION
## Summary
- Clear stale slash/skill autocomplete dismissal state once the user edits away from the dismissed query.
- Add a regression for dismissing `/re`, editing back to `/r`, then returning to `/re` so `/review` stays visible.

## Root Cause
Slash autocomplete stored an exact dismissed key such as `slash:0:3:/re`. Editing to `/r` produced a different key and reopened the popup, but typing `/re` again matched the stale dismissed key and suppressed the Commands list even though `/review` still matched.

## Validation
- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx -t "reopens slash autocomplete"`
- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx -t "slash review|slash autocomplete|slash commands|compact slash|provider-native skill commands"`
- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
