### PR TITLE
fix(desktop): surface codex turn failures to the UI and messaging

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -3974,6 +3974,104 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("remaps a failed turn/completed into turn/failed with a readable error", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => []
+    });
+
+    await client.getInitializeResult();
+
+    const notifications: Array<{ method: string; params: Record<string, unknown> }> = [];
+    client.onNotification((notification) => {
+      notifications.push(
+        notification as { method: string; params: Record<string, unknown> }
+      );
+    });
+
+    const transport = MockTransport.instances.at(-1);
+    expect(transport).toBeDefined();
+
+    transport!.emitInbound({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: {
+        threadId: "thread-2",
+        turn: {
+          id: "turn-failed-1",
+          status: "failed",
+          items: [],
+          error: {
+            message:
+              '{ "type": "error", "error": { "type": "image_generation_user_error", "code": "invalid_value", "message": "The model \'gpt-image-2\' does not exist.", "param": "tools" }, "status": 400 }',
+            codexErrorInfo: "other",
+            additionalDetails: null
+          },
+          startedAt: 1_763_500_300,
+          completedAt: 1_763_500_360,
+          durationMs: 60_000
+        }
+      }
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(notifications).toEqual([
+      {
+        method: "turn/failed",
+        params: expect.objectContaining({
+          threadId: "thread-2",
+          turnId: "turn-failed-1",
+          turn: expect.objectContaining({
+            id: "turn-failed-1",
+            status: "failed",
+            error: { message: "The model 'gpt-image-2' does not exist." }
+          })
+        })
+      }
+    ]);
+
+    await client.close();
+  });
+
+  it("does not log a Codex error notification as an unknown notification", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => []
+    });
+
+    await client.getInitializeResult();
+
+    const transport = MockTransport.instances.at(-1);
+    expect(transport).toBeDefined();
+
+    codexClientLogWarn.mockClear();
+
+    transport!.emitInbound({
+      jsonrpc: "2.0",
+      method: "error",
+      params: {
+        error: { message: "boom", codexErrorInfo: "other", additionalDetails: null },
+        threadId: "thread-2",
+        turnId: "turn-1",
+        willRetry: false
+      }
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(codexClientLogWarn).not.toHaveBeenCalledWith(
+      "unknown codex notification",
+      expect.anything()
+    );
+
+    await client.close();
+  });
+
   it("normalizes Codex thread settings service tier notifications", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
 

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -1585,6 +1585,83 @@ describe("MessagingController", () => {
     });
   });
 
+  it("posts a readable error notice when a turn fails", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "running",
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/failed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "failed",
+            error: {
+              message: "The model 'gpt-image-2' does not exist.",
+            },
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(harness.delivered).toContainEqual(
+      expect.objectContaining({
+        kind: "error",
+        title: "Turn failed",
+        body: "The model 'gpt-image-2' does not exist.",
+      }),
+    );
+  });
+
+  it("does not double-post the error notice for the same failed turn", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    const failure: AgentEvent = {
+      backend: "codex",
+      notification: {
+        method: "turn/failed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "failed",
+            error: { message: "boom" },
+          },
+        },
+      },
+    };
+
+    await harness.controller.handleBackendEvent(failure);
+    await harness.controller.handleBackendEvent(failure);
+
+    const errorNotices = harness.delivered.filter(
+      (intent) => intent.kind === "error" && intent.title === "Turn failed",
+    );
+    expect(errorNotices).toHaveLength(1);
+  });
+
   it("posts a durable start notice for automation turns", async () => {
     const harness = await createHarness();
     await bindThread(harness);

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import {
   isToolManagedWorktreePath,
+  parseCodexTurnErrorMessage,
   shortenDerivedThreadTitle,
 } from "@pwragent/shared";
 import type {
@@ -177,6 +178,7 @@ type CodexClientRequestMethod = CodexClientRequest["method"];
 type CodexServerRequestMethod = CodexServerRequest["method"];
 
 const KNOWN_NOTIFICATION_METHODS = new Set<string>([
+  "error",
   "thread/started",
   "turn/started",
   "turn/completed",
@@ -210,6 +212,7 @@ const KNOWN_NOTIFICATION_METHODS = new Set<string>([
   "mcpServer/startupStatus/updated",
 ]);
 const GENERATED_CODEX_NOTIFICATION_METHODS = new Set<string>([
+  "error",
   "warning",
   "configWarning",
   "thread/started",
@@ -592,6 +595,61 @@ function normalizePendingRequestNotification(
   };
 }
 
+/**
+ * Codex signals a failed turn through `turn/completed` with `turn.status` set
+ * to "failed". Translate that into the normalized `turn/failed` notification the
+ * rest of the app already understands, carrying a human-readable error message.
+ * Returns undefined when the notification is not a failed `turn/completed`, in
+ * which case the caller falls through to the generic passthrough normalizer.
+ */
+function normalizeFailedTurnCompletedNotification(
+  method: string,
+  record: Record<string, unknown>,
+  metadata: { threadId?: string; turnId?: string },
+): AppServerNotification | undefined {
+  if (method !== "turn/completed") {
+    return undefined;
+  }
+  const turn = asRecord(record.turn);
+  if (!turn || pickString(turn, ["status"]) !== "failed") {
+    return undefined;
+  }
+
+  const turnId = pickString(turn, ["id", "turnId", "turn_id"]) ?? metadata.turnId;
+  const threadId =
+    metadata.threadId ?? pickString(record, ["threadId", "thread_id"]);
+  if (!turnId || !threadId) {
+    return undefined;
+  }
+
+  const message = parseCodexTurnErrorMessage(
+    pickStringAllowEmpty(asRecord(turn.error), ["message"]),
+  );
+  const startedAt = normalizeEpochTimestamp(
+    pickNumber(turn, ["startedAt", "started_at"]),
+  );
+  const completedAt = normalizeEpochTimestamp(
+    pickNumber(turn, ["completedAt", "completed_at"]),
+  );
+  const durationMs = pickFiniteNumber(turn, ["durationMs", "duration_ms"]);
+
+  return {
+    method: "turn/failed",
+    params: {
+      threadId,
+      turnId,
+      turn: {
+        id: turnId,
+        status: "failed",
+        ...(startedAt !== undefined ? { startedAt } : {}),
+        ...(completedAt !== undefined ? { completedAt } : {}),
+        ...(durationMs !== undefined ? { durationMs } : {}),
+        error: { message },
+      },
+    },
+  };
+}
+
 function normalizeServerNotification(
   method: string,
   params: unknown,
@@ -602,6 +660,23 @@ function normalizeServerNotification(
 
   const record = asRecord(params) ?? {};
   const metadata = extractRequestMetadata(params);
+
+  // Codex reports a failed turn as `turn/completed` whose `turn.status` is
+  // "failed" (with the provider error in `turn.error`), not as a distinct
+  // `turn/failed` method. Re-map it here, at the adapter boundary, so the rest
+  // of the app sees a single, uniform `turn/failed` notification — the renderer
+  // session-error banner, messaging delivery, and headless-automation error
+  // extraction all already key on `turn/failed`. Doing the alias here keeps the
+  // Codex-specific shape out of every downstream consumer.
+  const failedTurn = normalizeFailedTurnCompletedNotification(
+    method,
+    record,
+    metadata,
+  );
+  if (failedTurn) {
+    return failedTurn;
+  }
+
   const itemRecord = asRecord(record.item);
   const normalizedItem =
     itemRecord && (method === "item/started" || method === "item/completed")

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -3,6 +3,7 @@ import {
   buildThreadIdentityKey,
   isAcpBackendId,
   isAppServerBackendKind,
+  parseCodexTurnErrorMessage,
   resolveNewThreadBackend,
   selectableNewThreadBackends,
 } from "@pwragent/shared";
@@ -841,6 +842,15 @@ export class MessagingController {
       } else if (isTerminalTurnLifecycle(activeTurn)) {
         await this.waitForAssistantStreamDeliveriesForEvent(event, binding);
         await this.flushBufferedAssistantStreamsForTerminalEvent(event, binding);
+      }
+
+      // Automation turns surface their own terminal output (incl. errors) via
+      // handleAutomationTurnTerminal, so skip them here to avoid a double post.
+      if (!automationTurnEvent && activeTurn?.status === "failed") {
+        const turnFailureText = errorTextForBackendEvent(event);
+        if (turnFailureText) {
+          await this.deliverTurnFailureMessage(turnFailureText, event, binding);
+        }
       }
 
       if (isThreadNameUpdatedEvent(event)) {
@@ -2677,6 +2687,36 @@ export class MessagingController {
           },
         ],
       },
+      binding,
+    );
+  }
+
+  /**
+   * Surface a failed turn's error in the bound conversation. Previously a Codex
+   * turn failure (e.g. a provider 400) left the chat silent — the turn just
+   * stopped. We post it as a recoverable error notice so the operator can see
+   * what went wrong and retry. Deduped on (event, binding, text) so a re-emitted
+   * terminal turn does not double-post.
+   */
+  private async deliverTurnFailureMessage(
+    text: string,
+    event: AgentEvent,
+    binding: MessagingBindingRecord,
+  ): Promise<void> {
+    if (!this.markAssistantMessageDelivered(event, binding, `turn-failed:${text}`)) {
+      return;
+    }
+    this.logger.debug?.(
+      `messaging turn-failure deliver thread=${binding.threadId} binding=${binding.id} preview="${compactLogPreview(text)}"`,
+    );
+    await this.deliver(
+      buildErrorIntent({
+        id: this.newIntentId("turn-failed"),
+        createdAt: this.now(),
+        title: "Turn failed",
+        body: text,
+        recoverable: true,
+      }),
       binding,
     );
   }
@@ -10745,6 +10785,28 @@ function assistantTextForBackendEvent(event: AgentEvent): string | undefined {
   }
 
   return undefined;
+}
+
+/**
+ * The user-facing error text for a failed terminal turn, or undefined when the
+ * event is not a turn failure. Codex turn failures are normalized to
+ * `turn/failed` at the adapter boundary, so keying on that single method covers
+ * both Codex and synthetic (start-failure / ACP) failures. The message is run
+ * through {@link parseCodexTurnErrorMessage} to unwrap provider JSON envelopes;
+ * the parse is idempotent for already-clean messages.
+ */
+function errorTextForBackendEvent(event: AgentEvent): string | undefined {
+  if (event.notification.method !== "turn/failed") {
+    return undefined;
+  }
+  const params = event.notification.params as {
+    turn?: { error?: { message?: unknown } };
+  };
+  const message = params.turn?.error?.message;
+  if (typeof message !== "string" || !message.trim()) {
+    return undefined;
+  }
+  return parseCodexTurnErrorMessage(message);
 }
 
 function assistantDeltaForBackendEvent(

--- a/packages/shared/src/__tests__/codex-turn-error.test.ts
+++ b/packages/shared/src/__tests__/codex-turn-error.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { parseCodexTurnErrorMessage } from "../codex-turn-error";
+
+describe("parseCodexTurnErrorMessage", () => {
+  it("extracts the human message from a nested provider error envelope", () => {
+    const raw =
+      '{ "type": "error", "error": { "type": "image_generation_user_error", "code": "invalid_value", "message": "The model \'gpt-image-2\' does not exist.", "param": "tools" }, "status": 400 }';
+    expect(parseCodexTurnErrorMessage(raw)).toBe(
+      "The model 'gpt-image-2' does not exist.",
+    );
+  });
+
+  it("returns a plain message unchanged", () => {
+    expect(parseCodexTurnErrorMessage("Something went wrong")).toBe(
+      "Something went wrong",
+    );
+  });
+
+  it("reads a top-level message field", () => {
+    expect(parseCodexTurnErrorMessage('{"message":"boom"}')).toBe("boom");
+  });
+
+  it("reads an error string when there is no message field", () => {
+    expect(parseCodexTurnErrorMessage('{"error":"bad request"}')).toBe(
+      "bad request",
+    );
+  });
+
+  it("falls back to the raw text when JSON has no recognizable message", () => {
+    expect(parseCodexTurnErrorMessage('{"status":500}')).toBe('{"status":500}');
+  });
+
+  it("falls back for empty or missing input", () => {
+    expect(parseCodexTurnErrorMessage("")).toBe("Turn failed.");
+    expect(parseCodexTurnErrorMessage(null)).toBe("Turn failed.");
+    expect(parseCodexTurnErrorMessage(undefined)).toBe("Turn failed.");
+  });
+
+  it("does not choke on malformed JSON", () => {
+    expect(parseCodexTurnErrorMessage('{"error": ')).toBe('{"error":');
+  });
+});

--- a/packages/shared/src/codex-turn-error.ts
+++ b/packages/shared/src/codex-turn-error.ts
@@ -1,0 +1,87 @@
+/**
+ * The Codex App Server reports turn failures via a `TurnError.message` string.
+ * For provider-side failures (e.g. an OpenAI Responses 400) that string is not
+ * a human sentence — it is the upstream JSON error envelope serialized verbatim,
+ * for example:
+ *
+ *   {"type":"error","error":{"type":"image_generation_user_error",
+ *    "code":"invalid_value","message":"The model 'gpt-image-2' does not exist.",
+ *    "param":"tools"},"status":400}
+ *
+ * Surfacing that blob to a user (in the transcript banner or a bound chat) is
+ * noise. `parseCodexTurnErrorMessage` extracts the human-readable sentence when
+ * the message is a recognizable JSON envelope, and otherwise returns the raw
+ * text unchanged. It never throws and always returns a non-empty string.
+ */
+
+const FALLBACK_MESSAGE = "Turn failed.";
+
+function tryParseJsonObject(value: string): Record<string, unknown> | undefined {
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) {
+    return undefined;
+  }
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+/**
+ * Pull the most specific human-readable message out of a parsed error envelope.
+ * Handles the common shapes: `{ message }`, `{ error: { message } }`,
+ * `{ error: "..." }`, and the nested `{ error: { error: { message } } }`.
+ */
+function extractEnvelopeMessage(
+  record: Record<string, unknown>,
+  depth = 0,
+): string | undefined {
+  if (depth > 4) {
+    return undefined;
+  }
+  const directMessage = nonEmptyString(record.message);
+  const nestedError = record.error;
+  const nestedRecord = asRecord(nestedError);
+  if (nestedRecord) {
+    const nestedMessage = extractEnvelopeMessage(nestedRecord, depth + 1);
+    if (nestedMessage) {
+      return nestedMessage;
+    }
+  }
+  const nestedErrorString = nonEmptyString(nestedError);
+  return directMessage ?? nestedErrorString;
+}
+
+export function parseCodexTurnErrorMessage(
+  raw: string | null | undefined,
+): string {
+  const trimmed = (raw ?? "").trim();
+  if (!trimmed) {
+    return FALLBACK_MESSAGE;
+  }
+
+  const parsed = tryParseJsonObject(trimmed);
+  if (parsed) {
+    const message = extractEnvelopeMessage(parsed);
+    if (message) {
+      return message;
+    }
+  }
+
+  return trimmed;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./contracts/normalized-app-server";
 export * from "./backend-selection";
 export * from "./codex-environment-action-runs";
+export * from "./codex-turn-error";
 export * from "./contracts/backend";
 export * from "./contracts/agent";
 export * from "./contracts/automations";


### PR DESCRIPTION
## What

Catch and surface Codex turn failures that PwrAgent was silently dropping.

A user hit repeated turn failures whose only trace was a `warn` log:

```
unknown codex notification method=error payload.error.message="{ ... image_generation_user_error ... The model 'gpt-image-2' does not exist. ... }"
backend lifecycle notification method=turn/completed status=failed
```

Nothing reached the transcript or the bound chat — the turn just stopped.

## Why it was invisible

Two independent gaps:

1. **The `error` notification was dropped.** Codex's top-level `error` method exists in the generated protocol but wasn't in the client's known-method allow-list, so it logged "unknown codex notification" and went nowhere.
2. **Failed turns never produced a `turn/failed`.** Codex reports a failed turn as `turn/completed` with `turn.status: "failed"`, *not* as `turn/failed`. The renderer already has a dormant error path (`useThreadSessionState` → `session.error` → the `transcript-error` banner) and messaging already tracks `turn/failed`, but nothing ever emitted that signal for real Codex failures.

## What changed

Normalized at the **codex adapter boundary** (where the adapter guidance says Codex-specific aliasing belongs), so every downstream consumer sees one uniform `turn/failed`:

- **`packages/shared/src/codex-turn-error.ts`** (new) — `parseCodexTurnErrorMessage` unwraps the provider JSON error envelope (`{"error":{"message":"…"}}`) into the human sentence; idempotent for already-clean messages.
- **`apps/desktop/src/main/codex-app-server/client.ts`** — add `"error"` to the known-method sets (stops the "unknown codex notification" noise) and re-map a failed `turn/completed` into `turn/failed` carrying the clean message. This lights up the **existing** renderer error banner with no renderer changes.
- **`apps/desktop/src/main/messaging/core/messaging-controller.ts`** — post a "Turn failed" error notice to every bound conversation (Telegram/Discord/etc.) on a terminal failed turn, deduped per turn and skipping automation turns (which surface their own output).

## Root cause of the underlying error (not fixed here)

Not a PwrAgent config issue — `gpt-image`/`image_generation` appears nowhere in the repo. **Codex itself** (`codex-cli 0.130.0`) ships a built-in image-generation tool and sends it in the `tools` array of every OpenAI Responses request configured with model `gpt-image-2`, which OpenAI rejects (real model is `gpt-image-1`). Because the bad tool is in *every* request, the API returns a 400 before any work runs, with `willRetry: false` — which is why even "hello?" failed. Operator-side mitigation: update/downgrade `codex-cli` or disable Codex's image-generation tool. This PR only makes the failure **visible**.

Driving the UI off the *terminal turn* (not the `error` notification) also means transient `willRetry: true` errors don't show a false failure — only genuinely terminal ones do.

## Tests

- shared: `parseCodexTurnErrorMessage` (7 cases incl. the exact `gpt-image-2` envelope)
- client: failed `turn/completed` → `turn/failed` remap with readable message; `error` no longer logged as unknown
- messaging: error notice delivered on failure; not double-posted

Verified green: shared, codex-client, messaging-controller (193), backend-registry (203), agent-ipc, renderer session/transcript suites. Full workspace `typecheck`, `lint:boundaries`, and `lint:codex-storage` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)