### PR TITLE
fix(desktop): approve notification requests from native alerts

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -98,6 +98,7 @@ mac:
   helperPluginBundleId: com.pwrdrvr.pwragent.helper.Plugin
   extendInfo:
     NSHumanReadableCopyright: "Copyright © 2026 PwrDrvr LLC."
+    NSUserNotificationAlertStyle: alert
     LSMinimumSystemVersion: "12.0"
     LSApplicationCategoryType: public.app-category.developer-tools
   target:

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -49,11 +49,13 @@ const localAcpDiscoveryMock = vi.hoisted(() => ({
 vi.mock("../acp/acp-local-discovery", () => localAcpDiscoveryMock);
 
 const desktopNotificationServiceMock = vi.hoisted(() => {
+  const notifyApproval = vi.fn();
   const notifyAttention = vi.fn();
   const notifyTerminal = vi.fn();
   const clearAttentionKey = vi.fn();
-  const service = { notifyAttention, notifyTerminal, clearAttentionKey };
+  const service = { notifyApproval, notifyAttention, notifyTerminal, clearAttentionKey };
   return {
+    notifyApproval,
     notifyAttention,
     notifyTerminal,
     clearAttentionKey,
@@ -64,6 +66,12 @@ const desktopNotificationServiceMock = vi.hoisted(() => {
 vi.mock("../notifications/desktop-notification-service", () => ({
   getDesktopNotificationService:
     desktopNotificationServiceMock.getDesktopNotificationService,
+}));
+
+const requestShowThreadMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../window-show-thread", () => ({
+  requestShowThread: requestShowThreadMock,
 }));
 
 // These tests pre-date the agent-core Grok experimental flag and exercise
@@ -9680,6 +9688,76 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("does not turn inbound serverRequest/resolved notifications into approval rejection responses", async () => {
+    desktopNotificationServiceMock.clearAttentionKey.mockClear();
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+    });
+    const events: AgentEvent[] = [];
+    const unsubscribe = registry.onEvent((event) => {
+      events.push(event);
+    });
+
+    const request: AppServerPendingRequestNotification = {
+      method: "item/commandExecution/requestApproval",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "call-1",
+        requestId: "approval-1",
+        command: "npm view eslint",
+      },
+    };
+    const responsePromise = codexClient.emitRequest(request);
+    await waitForCondition(() => events.length === 1);
+
+    let resolvedResponse: unknown;
+    responsePromise.then((response) => {
+      resolvedResponse = response;
+    });
+
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "serverRequest/resolved",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          requestId: "approval-1",
+        },
+      },
+    });
+    await flushAsync();
+
+    expect(resolvedResponse).toBeUndefined();
+    expect(events.map((event) => event.notification.method)).toEqual([
+      "item/commandExecution/requestApproval",
+    ]);
+    expect(desktopNotificationServiceMock.clearAttentionKey).not.toHaveBeenCalledWith(
+      "codex:thread-1:approval-1",
+    );
+
+    await registry.submitServerRequest({
+      backend: "codex",
+      threadId: "thread-1",
+      turnId: "turn-1",
+      requestId: "approval-1",
+      response: { decision: "accept" },
+    });
+
+    await expect(responsePromise).resolves.toEqual({ decision: "accept" });
+
+    unsubscribe();
+    await registry.close();
+  });
+
   it("handles automation inspection dynamic tool calls without surfacing pending requests", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start"] },
@@ -13722,12 +13800,53 @@ command = "pnpm dev"
     }
 
     function resetNotificationMocks(): void {
+      desktopNotificationServiceMock.notifyApproval.mockClear();
       desktopNotificationServiceMock.notifyAttention.mockClear();
       desktopNotificationServiceMock.notifyTerminal.mockClear();
       desktopNotificationServiceMock.clearAttentionKey.mockClear();
+      requestShowThreadMock.mockClear();
     }
 
-    it("calls notifyAttention on turn/requestApproval with a backend:thread:request key", async () => {
+    it("renders approval requests through the native approval intent surface", async () => {
+      resetNotificationMocks();
+      const registry = makeRegistry();
+
+      await registry.publishLocalEvent({
+        backend: "codex",
+        notification: {
+          method: "turn/requestApproval",
+          params: {
+            threadId: "thread-1",
+            requestId: "req-1",
+            prompt: "Approve this turn?",
+          },
+        } as AppServerNotification,
+      });
+
+      expect(desktopNotificationServiceMock.notifyAttention).not.toHaveBeenCalled();
+      expect(desktopNotificationServiceMock.notifyApproval).toHaveBeenCalledTimes(1);
+      const call = desktopNotificationServiceMock.notifyApproval.mock.calls[0]?.[0];
+      expect(call).toMatchObject({
+        key: "codex:thread-1:req-1",
+        intent: {
+          kind: "approval",
+          requestContext: {
+            backend: "codex",
+            method: "turn/requestApproval",
+            requestId: "req-1",
+            threadId: "thread-1",
+          },
+          title: "Approval Needed",
+        },
+      });
+      expect(typeof call.enabled).toBe("boolean");
+      expect(typeof call.onDecision).toBe("function");
+      expect(typeof call.onShow).toBe("function");
+
+      await registry.close();
+    });
+
+    it("passes no-detail approval requests to the native approval surface without a direct registry resolver", async () => {
       resetNotificationMocks();
       const registry = makeRegistry();
 
@@ -13742,15 +13861,110 @@ command = "pnpm dev"
         } as AppServerNotification,
       });
 
-      expect(desktopNotificationServiceMock.notifyAttention).toHaveBeenCalledTimes(1);
-      const call = desktopNotificationServiceMock.notifyAttention.mock.calls[0]?.[0];
-      expect(call).toMatchObject({
-        key: "codex:thread-1:req-1",
-        title: "PwrAgent approval needed",
+      const call = desktopNotificationServiceMock.notifyApproval.mock.calls[0]?.[0];
+      expect(call?.intent.body).toContain("Approve this action?");
+      expect(typeof call?.onDecision).toBe("function");
+      expect(typeof call?.onShow).toBe("function");
+      expect(desktopNotificationServiceMock.notifyAttention).not.toHaveBeenCalled();
+
+      await registry.close();
+    });
+
+    it("uses the current command approval details instead of the cached thread title", async () => {
+      resetNotificationMocks();
+      const registry = makeRegistry();
+
+      await registry.publishLocalEvent({
+        backend: "codex",
+        notification: {
+          method: "thread/name/updated",
+          params: {
+            threadId: "thread-1",
+            threadName: "npm view openclaw",
+          },
+        } as AppServerNotification,
       });
-      expect(typeof call.body).toBe("string");
-      expect(typeof call.enabled).toBe("boolean");
-      expect(typeof call.onApprove).toBe("function");
+
+      await registry.publishLocalEvent({
+        backend: "codex",
+        notification: {
+          method: "item/commandExecution/requestApproval",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-2",
+            itemId: "call-2",
+            requestId: "approval-2",
+            prompt:
+              "Do you want to allow network access so I can query the npm registry for yarn?",
+            command: "npm view yarn",
+          },
+        } as AppServerNotification,
+      });
+
+      const call = desktopNotificationServiceMock.notifyApproval.mock.calls[0]?.[0];
+      expect(call?.intent.body).toContain("npm view yarn");
+      expect(call?.intent.body).not.toContain("openclaw");
+
+      await registry.close();
+    });
+
+    it("notification approval for a later request resolves that request, not the first request on the thread", async () => {
+      resetNotificationMocks();
+      const codexClient = new MockBackendClient({
+        initializeResult: { methods: ["turn/start"] },
+      });
+      const registry = new DesktopBackendRegistry({
+        codexClient,
+        grokClient: new MockBackendClient({
+          initializeError: new Error(
+            "grok app server unavailable: XAI_API_KEY is not set",
+          ),
+        }),
+        overlayStore: createOverlayStoreMock(),
+      });
+
+      const firstRequest: AppServerPendingRequestNotification = {
+        method: "item/commandExecution/requestApproval",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: "call-1",
+          requestId: "approval-1",
+          command: "npm view openclaw",
+        },
+      };
+      const secondRequest: AppServerPendingRequestNotification = {
+        method: "item/commandExecution/requestApproval",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-2",
+          itemId: "call-2",
+          requestId: "approval-2",
+          command: "npm view yarn",
+        },
+      };
+      const firstResponsePromise = codexClient.emitRequest(firstRequest);
+      await waitForCondition(
+        () => desktopNotificationServiceMock.notifyApproval.mock.calls.length === 1,
+      );
+      const secondResponsePromise = codexClient.emitRequest(secondRequest);
+      await waitForCondition(
+        () => desktopNotificationServiceMock.notifyApproval.mock.calls.length === 2,
+      );
+
+      let firstResolved = false;
+      firstResponsePromise.then(() => {
+        firstResolved = true;
+      });
+
+      desktopNotificationServiceMock.notifyApproval.mock.calls[1]?.[0]?.onDecision?.("accept");
+
+      await expect(secondResponsePromise).resolves.toEqual({ decision: "accept" });
+      await flushAsync();
+      expect(firstResolved).toBe(false);
+
+      desktopNotificationServiceMock.notifyApproval.mock.calls[0]?.[0]?.onDecision?.("accept");
+      await expect(firstResponsePromise).resolves.toEqual({ decision: "accept" });
 
       await registry.close();
     });
@@ -13775,7 +13989,7 @@ command = "pnpm dev"
         key: "codex:thread-q:req-q",
         title: "PwrAgent question waiting",
       });
-      expect(call.onApprove).toBeUndefined();
+      expect(call.onDecision).toBeUndefined();
 
       await registry.close();
     });
@@ -13811,14 +14025,14 @@ command = "pnpm dev"
       };
       const responsePromise = codexClient.emitRequest(request);
       await waitForCondition(
-        () => desktopNotificationServiceMock.notifyAttention.mock.calls.length === 1,
+        () => desktopNotificationServiceMock.notifyApproval.mock.calls.length === 1,
       );
 
       const notificationCall =
-        desktopNotificationServiceMock.notifyAttention.mock.calls[0]?.[0];
-      expect(typeof notificationCall?.onApprove).toBe("function");
+        desktopNotificationServiceMock.notifyApproval.mock.calls[0]?.[0];
+      expect(typeof notificationCall?.onDecision).toBe("function");
 
-      notificationCall?.onApprove?.();
+      notificationCall?.onDecision?.("accept");
 
       await expect(responsePromise).resolves.toEqual({ decision: "accept" });
       await waitForCondition(() =>
@@ -13834,6 +14048,218 @@ command = "pnpm dev"
       );
 
       unsubscribe();
+      await registry.close();
+    });
+
+    it("translates native approval decisions through the request protocol", async () => {
+      resetNotificationMocks();
+      const codexClient = new MockBackendClient({
+        initializeResult: { methods: ["turn/start"] },
+      });
+      const registry = new DesktopBackendRegistry({
+        codexClient,
+        grokClient: new MockBackendClient({
+          initializeError: new Error(
+            "grok app server unavailable: XAI_API_KEY is not set",
+          ),
+        }),
+        overlayStore: createOverlayStoreMock(),
+      });
+
+      const request: AppServerPendingRequestNotification = {
+        method: "turn/requestApproval",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          requestId: "approval-1",
+          prompt: "Approve this turn?",
+        },
+      };
+      const responsePromise = codexClient.emitRequest(request);
+      await waitForCondition(
+        () => desktopNotificationServiceMock.notifyApproval.mock.calls.length === 1,
+      );
+
+      const notificationCall =
+        desktopNotificationServiceMock.notifyApproval.mock.calls[0]?.[0];
+      notificationCall?.onDecision?.("accept");
+
+      await expect(responsePromise).resolves.toEqual({ decision: "approve" });
+
+      await registry.close();
+    });
+
+    it("focuses the approval thread when the notification show action fires", async () => {
+      resetNotificationMocks();
+      const codexClient = new MockBackendClient({
+        initializeResult: { methods: ["turn/start"] },
+      });
+      const registry = new DesktopBackendRegistry({
+        codexClient,
+        grokClient: new MockBackendClient({
+          initializeError: new Error(
+            "grok app server unavailable: XAI_API_KEY is not set",
+          ),
+        }),
+        overlayStore: createOverlayStoreMock(),
+      });
+
+      const request: AppServerPendingRequestNotification = {
+        method: "item/commandExecution/requestApproval",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: "call-1",
+          requestId: "approval-1",
+          command: "npm view dive",
+        },
+      };
+      const responsePromise = codexClient.emitRequest(request);
+      await waitForCondition(
+        () => desktopNotificationServiceMock.notifyApproval.mock.calls.length === 1,
+      );
+
+      const notificationCall =
+        desktopNotificationServiceMock.notifyApproval.mock.calls[0]?.[0];
+      notificationCall?.onShow?.();
+
+      expect(requestShowThreadMock).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+      });
+
+      let resolved = false;
+      responsePromise.then(() => {
+        resolved = true;
+      });
+      await flushAsync();
+      expect(resolved).toBe(false);
+
+      await registry.submitServerRequest({
+        backend: "codex",
+        threadId: "thread-1",
+        turnId: "turn-1",
+        requestId: "approval-1",
+        response: { decision: "decline" },
+      });
+      await expect(responsePromise).resolves.toEqual({ decision: "decline" });
+
+      await registry.close();
+    });
+
+    it("still emits pending approvals when native notification rendering throws", async () => {
+      resetNotificationMocks();
+      desktopNotificationServiceMock.notifyApproval.mockImplementationOnce(() => {
+        throw new Error("notification focus API missing");
+      });
+      const codexClient = new MockBackendClient({
+        initializeResult: { methods: ["turn/start"] },
+      });
+      const registry = new DesktopBackendRegistry({
+        codexClient,
+        grokClient: new MockBackendClient({
+          initializeError: new Error(
+            "grok app server unavailable: XAI_API_KEY is not set",
+          ),
+        }),
+        overlayStore: createOverlayStoreMock(),
+      });
+      const events: AgentEvent[] = [];
+      const unsubscribe = registry.onEvent((event) => {
+        events.push(event);
+      });
+
+      const request: AppServerPendingRequestNotification = {
+        method: "item/commandExecution/requestApproval",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: "call-1",
+          requestId: "approval-1",
+          command: "npm view eslint",
+        },
+      };
+      const responsePromise = codexClient.emitRequest(request);
+      await waitForCondition(() => events.length === 1);
+
+      expect(events[0]).toEqual({
+        backend: "codex",
+        notification: request,
+      });
+
+      await registry.submitServerRequest({
+        backend: "codex",
+        threadId: "thread-1",
+        turnId: "turn-1",
+        requestId: "approval-1",
+        response: { decision: "accept" },
+      });
+
+      await expect(responsePromise).resolves.toEqual({ decision: "accept" });
+
+      unsubscribe();
+      await registry.close();
+    });
+
+    it("keeps approval requests pending when an event listener throws", async () => {
+      resetNotificationMocks();
+      const codexClient = new MockBackendClient({
+        initializeResult: { methods: ["turn/start"] },
+      });
+      const registry = new DesktopBackendRegistry({
+        codexClient,
+        grokClient: new MockBackendClient({
+          initializeError: new Error(
+            "grok app server unavailable: XAI_API_KEY is not set",
+          ),
+        }),
+        overlayStore: createOverlayStoreMock(),
+      });
+      const events: AgentEvent[] = [];
+      const unsubscribeThrowing = registry.onEvent(() => {
+        throw new Error("renderer bridge crashed");
+      });
+      const unsubscribeCollecting = registry.onEvent((event) => {
+        events.push(event);
+      });
+
+      const request: AppServerPendingRequestNotification = {
+        method: "item/commandExecution/requestApproval",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: "call-1",
+          requestId: "approval-1",
+          command: "npm view eslint",
+        },
+      };
+      const responsePromise = codexClient.emitRequest(request);
+
+      await waitForCondition(() => events.length === 1);
+      expect(events[0]).toEqual({
+        backend: "codex",
+        notification: request,
+      });
+
+      let resolved = false;
+      responsePromise.then(() => {
+        resolved = true;
+      });
+      await flushAsync();
+      expect(resolved).toBe(false);
+
+      await registry.submitServerRequest({
+        backend: "codex",
+        threadId: "thread-1",
+        turnId: "turn-1",
+        requestId: "approval-1",
+        response: { decision: "decline" },
+      });
+
+      await expect(responsePromise).resolves.toEqual({ decision: "decline" });
+
+      unsubscribeThrowing();
+      unsubscribeCollecting();
       await registry.close();
     });
 
@@ -13921,9 +14347,9 @@ command = "pnpm dev"
           },
         } as AppServerNotification,
       });
-      expect(desktopNotificationServiceMock.notifyAttention).toHaveBeenCalledTimes(1);
+      expect(desktopNotificationServiceMock.notifyApproval).toHaveBeenCalledTimes(1);
       expect(
-        desktopNotificationServiceMock.notifyAttention.mock.calls[0]?.[0]?.key,
+        desktopNotificationServiceMock.notifyApproval.mock.calls[0]?.[0]?.key,
       ).toBe("codex:thread-legacy:approval-7");
 
       await registry.publishLocalEvent({

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -13750,6 +13750,7 @@ command = "pnpm dev"
       });
       expect(typeof call.body).toBe("string");
       expect(typeof call.enabled).toBe("boolean");
+      expect(typeof call.onApprove).toBe("function");
 
       await registry.close();
     });
@@ -13774,7 +13775,65 @@ command = "pnpm dev"
         key: "codex:thread-q:req-q",
         title: "PwrAgent question waiting",
       });
+      expect(call.onApprove).toBeUndefined();
 
+      await registry.close();
+    });
+
+    it("resolves a pending approval when the notification approve action fires", async () => {
+      resetNotificationMocks();
+      const codexClient = new MockBackendClient({
+        initializeResult: { methods: ["turn/start"] },
+      });
+      const registry = new DesktopBackendRegistry({
+        codexClient,
+        grokClient: new MockBackendClient({
+          initializeError: new Error(
+            "grok app server unavailable: XAI_API_KEY is not set",
+          ),
+        }),
+        overlayStore: createOverlayStoreMock(),
+      });
+      const events: AgentEvent[] = [];
+      const unsubscribe = registry.onEvent((event) => {
+        events.push(event);
+      });
+
+      const request: AppServerPendingRequestNotification = {
+        method: "item/commandExecution/requestApproval",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: "call-1",
+          requestId: "approval-1",
+          command: "npm view dive",
+        },
+      };
+      const responsePromise = codexClient.emitRequest(request);
+      await waitForCondition(
+        () => desktopNotificationServiceMock.notifyAttention.mock.calls.length === 1,
+      );
+
+      const notificationCall =
+        desktopNotificationServiceMock.notifyAttention.mock.calls[0]?.[0];
+      expect(typeof notificationCall?.onApprove).toBe("function");
+
+      notificationCall?.onApprove?.();
+
+      await expect(responsePromise).resolves.toEqual({ decision: "accept" });
+      await waitForCondition(() =>
+        events.some((event) => event.notification.method === "serverRequest/resolved"),
+      );
+
+      expect(events.map((event) => event.notification.method)).toEqual([
+        "item/commandExecution/requestApproval",
+        "serverRequest/resolved",
+      ]);
+      expect(desktopNotificationServiceMock.clearAttentionKey).toHaveBeenCalledWith(
+        "codex:thread-1:approval-1",
+      );
+
+      unsubscribe();
       await registry.close();
     });
 

--- a/apps/desktop/src/main/__tests__/desktop-notification-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-notification-service.test.ts
@@ -97,6 +97,11 @@ vi.mock("electron", () => ({
   },
 }));
 
+type NotificationServiceWithPrivateHooks = DesktopNotificationService & {
+  liveNotifications: Set<unknown>;
+  supportsActionButtons: () => boolean;
+};
+
 describe("DesktopNotificationService", () => {
   beforeEach(() => {
     shownNotifications.length = 0;
@@ -154,7 +159,10 @@ describe("DesktopNotificationService", () => {
     getAllWindows.mockReturnValue([
       { isDestroyed: () => false, isFocused: () => false, isMinimized: () => false },
     ]);
-    vi.spyOn(service as never, "supportsActionButtons").mockReturnValue(true);
+    vi.spyOn(
+      service as NotificationServiceWithPrivateHooks,
+      "supportsActionButtons",
+    ).mockReturnValue(true);
 
     service.notifyAttention({
       enabled: true,
@@ -173,15 +181,13 @@ describe("DesktopNotificationService", () => {
   });
 
   it("retains live notifications until the native notification resolves", () => {
-    const service = new DesktopNotificationService() as never as {
-      liveNotifications: Set<unknown>;
-      notifyAttention: DesktopNotificationService["notifyAttention"];
-    };
+    const service =
+      new DesktopNotificationService() as NotificationServiceWithPrivateHooks;
     const onApprove = vi.fn();
     getAllWindows.mockReturnValue([
       { isDestroyed: () => false, isFocused: () => false, isMinimized: () => false },
     ]);
-    vi.spyOn(service as never, "supportsActionButtons").mockReturnValue(true);
+    vi.spyOn(service, "supportsActionButtons").mockReturnValue(true);
 
     service.notifyAttention({
       enabled: true,
@@ -215,7 +221,10 @@ describe("DesktopNotificationService", () => {
     getAllWindows.mockReturnValue([
       { isDestroyed: () => false, isFocused: () => false, isMinimized: () => false },
     ]);
-    vi.spyOn(service as never, "supportsActionButtons").mockReturnValue(false);
+    vi.spyOn(
+      service as NotificationServiceWithPrivateHooks,
+      "supportsActionButtons",
+    ).mockReturnValue(false);
 
     service.notifyAttention({
       enabled: true,

--- a/apps/desktop/src/main/__tests__/desktop-notification-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-notification-service.test.ts
@@ -97,11 +97,6 @@ vi.mock("electron", () => ({
   },
 }));
 
-type NotificationServiceWithPrivateHooks = DesktopNotificationService & {
-  liveNotifications: Set<unknown>;
-  supportsActionButtons: () => boolean;
-};
-
 describe("DesktopNotificationService", () => {
   beforeEach(() => {
     shownNotifications.length = 0;
@@ -159,8 +154,11 @@ describe("DesktopNotificationService", () => {
     getAllWindows.mockReturnValue([
       { isDestroyed: () => false, isFocused: () => false, isMinimized: () => false },
     ]);
+    const serviceWithActionButtons = service as unknown as {
+      supportsActionButtons: () => boolean;
+    };
     vi.spyOn(
-      service as NotificationServiceWithPrivateHooks,
+      serviceWithActionButtons,
       "supportsActionButtons",
     ).mockReturnValue(true);
 
@@ -181,13 +179,18 @@ describe("DesktopNotificationService", () => {
   });
 
   it("retains live notifications until the native notification resolves", () => {
-    const service =
-      new DesktopNotificationService() as NotificationServiceWithPrivateHooks;
+    const service = new DesktopNotificationService();
     const onApprove = vi.fn();
     getAllWindows.mockReturnValue([
       { isDestroyed: () => false, isFocused: () => false, isMinimized: () => false },
     ]);
-    vi.spyOn(service, "supportsActionButtons").mockReturnValue(true);
+    const serviceWithActionButtons = service as unknown as {
+      supportsActionButtons: () => boolean;
+    };
+    const serviceWithLiveNotifications = service as unknown as {
+      liveNotifications: Set<unknown>;
+    };
+    vi.spyOn(serviceWithActionButtons, "supportsActionButtons").mockReturnValue(true);
 
     service.notifyAttention({
       enabled: true,
@@ -197,10 +200,10 @@ describe("DesktopNotificationService", () => {
       onApprove,
     });
 
-    expect(service.liveNotifications.size).toBe(1);
+    expect(serviceWithLiveNotifications.liveNotifications.size).toBe(1);
 
     shownNotifications[0]?.instance.emitAction(0);
-    expect(service.liveNotifications.size).toBe(0);
+    expect(serviceWithLiveNotifications.liveNotifications.size).toBe(0);
 
     service.notifyAttention({
       enabled: true,
@@ -210,9 +213,9 @@ describe("DesktopNotificationService", () => {
       onApprove,
     });
 
-    expect(service.liveNotifications.size).toBe(1);
+    expect(serviceWithLiveNotifications.liveNotifications.size).toBe(1);
     shownNotifications[1]?.instance.emitClick();
-    expect(service.liveNotifications.size).toBe(0);
+    expect(serviceWithLiveNotifications.liveNotifications.size).toBe(0);
   });
 
   it("falls back to a passive notification when action buttons are unsupported", () => {
@@ -221,8 +224,11 @@ describe("DesktopNotificationService", () => {
     getAllWindows.mockReturnValue([
       { isDestroyed: () => false, isFocused: () => false, isMinimized: () => false },
     ]);
+    const serviceWithActionButtons = service as unknown as {
+      supportsActionButtons: () => boolean;
+    };
     vi.spyOn(
-      service as NotificationServiceWithPrivateHooks,
+      serviceWithActionButtons,
       "supportsActionButtons",
     ).mockReturnValue(false);
 

--- a/apps/desktop/src/main/__tests__/desktop-notification-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-notification-service.test.ts
@@ -6,7 +6,12 @@ const {
   getAllWindows,
   MockNotification,
 } = vi.hoisted(() => {
-  const shown: Array<{ title: string; body: string }> = [];
+  const shown: Array<{
+    title: string;
+    body: string;
+    actions?: Array<{ type: string; text: string }>;
+    instance: NotificationMock;
+  }> = [];
   const windows = vi.fn(() => [] as Array<{
     isDestroyed: () => boolean;
     isFocused: () => boolean;
@@ -15,11 +20,66 @@ const {
 
   class NotificationMock {
     static isSupported = vi.fn(() => true);
+    private actionHandler?: (
+      details: { preventDefault?: () => void },
+      actionIndex: number,
+      selectionIndex: number,
+    ) => void;
+    private clickHandler?: () => void;
+    private closeHandler?: () => void;
 
-    constructor(private readonly payload: { title: string; body: string }) {}
+    constructor(
+      private readonly payload: {
+        title: string;
+        body: string;
+        actions?: Array<{ type: string; text: string }>;
+      },
+    ) {}
+
+    on(
+      event: "action" | "click" | "close",
+      handler: (
+        details: { preventDefault?: () => void },
+        actionIndex: number,
+        selectionIndex: number,
+      ) => void,
+    ): void {
+      if (event === "action") {
+        this.actionHandler = handler;
+        return;
+      }
+      if (event === "click") {
+        this.clickHandler = () => {
+          (handler as unknown as () => void)();
+        };
+        return;
+      }
+      if (event === "close") {
+        this.closeHandler = () => {
+          (handler as unknown as () => void)();
+        };
+      }
+    }
 
     show(): void {
-      shown.push(this.payload);
+      shown.push({
+        title: this.payload.title,
+        body: this.payload.body,
+        actions: this.payload.actions,
+        instance: this,
+      });
+    }
+
+    emitAction(actionIndex: number): void {
+      this.actionHandler?.({}, actionIndex, -1);
+    }
+
+    emitClick(): void {
+      this.clickHandler?.();
+    }
+
+    emitClose(): void {
+      this.closeHandler?.();
     }
   }
 
@@ -64,7 +124,12 @@ describe("DesktopNotificationService", () => {
     });
 
     expect(shownNotifications).toEqual([
-      { title: "Approval needed", body: "Please approve" },
+      {
+        title: "Approval needed",
+        body: "Please approve",
+        actions: undefined,
+        instance: shownNotifications[0]?.instance,
+      },
     ]);
   });
 
@@ -81,5 +146,87 @@ describe("DesktopNotificationService", () => {
     });
 
     expect(shownNotifications).toEqual([]);
+  });
+
+  it("adds a single approve action and fires it only once on supported platforms", () => {
+    const service = new DesktopNotificationService();
+    const onApprove = vi.fn();
+    getAllWindows.mockReturnValue([
+      { isDestroyed: () => false, isFocused: () => false, isMinimized: () => false },
+    ]);
+    vi.spyOn(service as never, "supportsActionButtons").mockReturnValue(true);
+
+    service.notifyAttention({
+      enabled: true,
+      key: "codex:thread-1:req-2",
+      title: "Approval needed",
+      body: "Please approve",
+      onApprove,
+    });
+
+    expect(shownNotifications[0]?.actions).toEqual([{ type: "button", text: "Approve" }]);
+
+    shownNotifications[0]?.instance.emitAction(0);
+    shownNotifications[0]?.instance.emitAction(0);
+
+    expect(onApprove).toHaveBeenCalledTimes(1);
+  });
+
+  it("retains live notifications until the native notification resolves", () => {
+    const service = new DesktopNotificationService() as never as {
+      liveNotifications: Set<unknown>;
+      notifyAttention: DesktopNotificationService["notifyAttention"];
+    };
+    const onApprove = vi.fn();
+    getAllWindows.mockReturnValue([
+      { isDestroyed: () => false, isFocused: () => false, isMinimized: () => false },
+    ]);
+    vi.spyOn(service as never, "supportsActionButtons").mockReturnValue(true);
+
+    service.notifyAttention({
+      enabled: true,
+      key: "codex:thread-1:req-live",
+      title: "Approval needed",
+      body: "Please approve",
+      onApprove,
+    });
+
+    expect(service.liveNotifications.size).toBe(1);
+
+    shownNotifications[0]?.instance.emitAction(0);
+    expect(service.liveNotifications.size).toBe(0);
+
+    service.notifyAttention({
+      enabled: true,
+      key: "codex:thread-1:req-click",
+      title: "Approval needed",
+      body: "Please approve",
+      onApprove,
+    });
+
+    expect(service.liveNotifications.size).toBe(1);
+    shownNotifications[1]?.instance.emitClick();
+    expect(service.liveNotifications.size).toBe(0);
+  });
+
+  it("falls back to a passive notification when action buttons are unsupported", () => {
+    const service = new DesktopNotificationService();
+    const onApprove = vi.fn();
+    getAllWindows.mockReturnValue([
+      { isDestroyed: () => false, isFocused: () => false, isMinimized: () => false },
+    ]);
+    vi.spyOn(service as never, "supportsActionButtons").mockReturnValue(false);
+
+    service.notifyAttention({
+      enabled: true,
+      key: "codex:thread-1:req-3",
+      title: "Approval needed",
+      body: "Please approve",
+      onApprove,
+    });
+
+    expect(shownNotifications[0]?.actions).toBeUndefined();
+    shownNotifications[0]?.instance.emitAction(0);
+    expect(onApprove).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/main/__tests__/desktop-notification-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-notification-service.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MessagingApprovalIntent } from "@pwragent/messaging-interface";
 import { DesktopNotificationService } from "../notifications/desktop-notification-service";
 
 const {
@@ -21,7 +22,7 @@ const {
   class NotificationMock {
     static isSupported = vi.fn(() => true);
     private actionHandler?: (
-      details: { preventDefault?: () => void },
+      details: { actionIndex?: number; preventDefault?: () => void },
       actionIndex: number,
       selectionIndex: number,
     ) => void;
@@ -39,7 +40,7 @@ const {
     on(
       event: "action" | "click" | "close",
       handler: (
-        details: { preventDefault?: () => void },
+        details: { actionIndex?: number; preventDefault?: () => void },
         actionIndex: number,
         selectionIndex: number,
       ) => void,
@@ -71,7 +72,7 @@ const {
     }
 
     emitAction(actionIndex: number): void {
-      this.actionHandler?.({}, actionIndex, -1);
+      this.actionHandler?.({ actionIndex }, actionIndex, -1);
     }
 
     emitClick(): void {
@@ -80,6 +81,10 @@ const {
 
     emitClose(): void {
       this.closeHandler?.();
+    }
+
+    close(): void {
+      this.emitClose();
     }
   }
 
@@ -96,6 +101,47 @@ vi.mock("electron", () => ({
     getAllWindows,
   },
 }));
+
+function approvalIntent(params?: {
+  body?: string;
+  decisions?: MessagingApprovalIntent["decisions"];
+}): MessagingApprovalIntent {
+  return {
+    id: "approval-intent-1",
+    kind: "approval",
+    createdAt: 1000,
+    title: "Command Approval",
+    body:
+      params?.body ??
+      [
+        "Run command?",
+        "Command:",
+        "```shell",
+        "npm view eslint",
+        "```",
+        "Reply with \"1\", \"2\", \"yes\", \"yes for this session\", \"no\", or use a button.",
+      ].join("\n"),
+    fallbackText: "Reply yes, yes for this session, no, cancel, or a choice number.",
+    decisions:
+      params?.decisions ??
+      [
+        {
+          id: "approval:accept",
+          label: "Approve Once",
+          decision: "accept",
+          style: "primary",
+          fallbackText: "1",
+        },
+        {
+          id: "approval:decline",
+          label: "Decline",
+          decision: "decline",
+          style: "danger",
+          fallbackText: "no",
+        },
+      ],
+  };
+}
 
 describe("DesktopNotificationService", () => {
   beforeEach(() => {
@@ -148,9 +194,42 @@ describe("DesktopNotificationService", () => {
     expect(shownNotifications).toEqual([]);
   });
 
-  it("adds a single approve action and fires it only once on supported platforms", () => {
+  it("does not emit attention notifications while a window is focused", () => {
     const service = new DesktopNotificationService();
-    const onApprove = vi.fn();
+    getAllWindows.mockReturnValue([
+      { isDestroyed: () => false, isFocused: () => true, isMinimized: () => false },
+    ]);
+
+    service.notifyAttention({
+      enabled: true,
+      key: "codex:thread-1:req-focused",
+      title: "Approval needed",
+      body: "Please approve",
+    });
+
+    expect(shownNotifications).toEqual([]);
+  });
+
+  it("does not emit approval notifications while a window is focused", () => {
+    const service = new DesktopNotificationService();
+    getAllWindows.mockReturnValue([
+      { isDestroyed: () => false, isFocused: () => true, isMinimized: () => false },
+    ]);
+
+    service.notifyApproval({
+      enabled: true,
+      key: "codex:thread-1:req-focused-approval",
+      intent: approvalIntent(),
+      onDecision: vi.fn(),
+    });
+
+    expect(shownNotifications).toEqual([]);
+  });
+
+  it("renders approval intents with native show, approve, and decline actions", () => {
+    const service = new DesktopNotificationService();
+    const onDecision = vi.fn();
+    const onShow = vi.fn();
     getAllWindows.mockReturnValue([
       { isDestroyed: () => false, isFocused: () => false, isMinimized: () => false },
     ]);
@@ -162,25 +241,142 @@ describe("DesktopNotificationService", () => {
       "supportsActionButtons",
     ).mockReturnValue(true);
 
-    service.notifyAttention({
+    service.notifyApproval({
       enabled: true,
       key: "codex:thread-1:req-2",
-      title: "Approval needed",
-      body: "Please approve",
-      onApprove,
+      intent: approvalIntent(),
+      onDecision,
+      onShow,
     });
 
-    expect(shownNotifications[0]?.actions).toEqual([{ type: "button", text: "Approve" }]);
+    expect(shownNotifications[0]?.actions).toEqual([
+      { type: "button", text: "Show" },
+      { type: "button", text: "Approve" },
+      { type: "button", text: "Decline" },
+    ]);
+    expect(shownNotifications[0]?.title).toBe("PwrAgent approval needed");
+    expect(shownNotifications[0]?.body).toContain("Command Approval");
+    expect(shownNotifications[0]?.body).toContain("npm view eslint");
+    expect(shownNotifications[0]?.body).not.toContain("```shell");
+    expect(shownNotifications[0]?.body).not.toContain("Reply with");
 
     shownNotifications[0]?.instance.emitAction(0);
-    shownNotifications[0]?.instance.emitAction(0);
+    shownNotifications[0]?.instance.emitAction(1);
+    shownNotifications[0]?.instance.emitAction(2);
 
-    expect(onApprove).toHaveBeenCalledTimes(1);
+    expect(onShow).toHaveBeenCalledTimes(1);
+    expect(onDecision).not.toHaveBeenCalled();
+
+    service.notifyApproval({
+      enabled: true,
+      key: "codex:thread-1:req-2b",
+      intent: approvalIntent(),
+      onDecision,
+      onShow,
+    });
+    shownNotifications[1]?.instance.emitAction(1);
+
+    expect(onDecision).toHaveBeenCalledTimes(1);
+    expect(onDecision).toHaveBeenLastCalledWith("accept");
+
+    service.notifyApproval({
+      enabled: true,
+      key: "codex:thread-1:req-2c",
+      intent: approvalIntent(),
+      onDecision,
+      onShow,
+    });
+    shownNotifications[2]?.instance.emitAction(2);
+
+    expect(onDecision).toHaveBeenCalledTimes(2);
+    expect(onDecision).toHaveBeenLastCalledWith("decline");
+  });
+
+  it("keeps the native approve action when a fallback prompt includes command details", () => {
+    const service = new DesktopNotificationService();
+    const onDecision = vi.fn();
+    getAllWindows.mockReturnValue([
+      { isDestroyed: () => false, isFocused: () => false, isMinimized: () => false },
+    ]);
+    const serviceWithActionButtons = service as unknown as {
+      supportsActionButtons: () => boolean;
+    };
+    vi.spyOn(
+      serviceWithActionButtons,
+      "supportsActionButtons",
+    ).mockReturnValue(true);
+
+    service.notifyApproval({
+      enabled: true,
+      key: "codex:thread-1:req-fallback-command",
+      intent: approvalIntent({
+        body: [
+          "Approve this action?",
+          "Command:",
+          "```shell",
+          "npm view eslint",
+          "```",
+          "Reply with \"1\", \"2\", \"yes\", \"yes for this session\", \"no\", or use a button.",
+        ].join("\n\n"),
+      }),
+      onDecision,
+    });
+
+    expect(shownNotifications[0]?.actions).toEqual([
+      { type: "button", text: "Approve" },
+      { type: "button", text: "Decline" },
+    ]);
+    expect(shownNotifications[0]?.body).toContain("npm view eslint");
+    expect(shownNotifications[0]?.body).not.toContain("Approve this action?");
+  });
+
+  it("hides approve when approval details are truncated", () => {
+    const service = new DesktopNotificationService();
+    const onDecision = vi.fn();
+    const onShow = vi.fn();
+    getAllWindows.mockReturnValue([
+      { isDestroyed: () => false, isFocused: () => false, isMinimized: () => false },
+    ]);
+    const serviceWithActionButtons = service as unknown as {
+      supportsActionButtons: () => boolean;
+    };
+    vi.spyOn(
+      serviceWithActionButtons,
+      "supportsActionButtons",
+    ).mockReturnValue(true);
+
+    service.notifyApproval({
+      enabled: true,
+      key: "codex:thread-1:req-long-command",
+      intent: approvalIntent({
+        body: [
+          "Run command?",
+          "Command:",
+          "```shell",
+          `npm run deploy -- --target production ${"x".repeat(260)} --dangerous-flag`,
+          "```",
+          "Reply with \"1\", \"2\", \"yes\", \"yes for this session\", \"no\", or use a button.",
+        ].join("\n"),
+      }),
+      onDecision,
+      onShow,
+    });
+
+    expect(shownNotifications[0]?.body).toMatch(/\.\.\.$/);
+    expect(shownNotifications[0]?.body).not.toContain("--dangerous-flag");
+    expect(shownNotifications[0]?.actions).toEqual([
+      { type: "button", text: "Show" },
+      { type: "button", text: "Decline" },
+    ]);
+
+    shownNotifications[0]?.instance.emitAction(1);
+    expect(onDecision).toHaveBeenCalledWith("decline");
+    expect(onDecision).not.toHaveBeenCalledWith("accept");
   });
 
   it("retains live notifications until the native notification resolves", () => {
     const service = new DesktopNotificationService();
-    const onApprove = vi.fn();
+    const onDecision = vi.fn();
     getAllWindows.mockReturnValue([
       { isDestroyed: () => false, isFocused: () => false, isMinimized: () => false },
     ]);
@@ -192,12 +388,11 @@ describe("DesktopNotificationService", () => {
     };
     vi.spyOn(serviceWithActionButtons, "supportsActionButtons").mockReturnValue(true);
 
-    service.notifyAttention({
+    service.notifyApproval({
       enabled: true,
       key: "codex:thread-1:req-live",
-      title: "Approval needed",
-      body: "Please approve",
-      onApprove,
+      intent: approvalIntent(),
+      onDecision,
     });
 
     expect(serviceWithLiveNotifications.liveNotifications.size).toBe(1);
@@ -205,12 +400,11 @@ describe("DesktopNotificationService", () => {
     shownNotifications[0]?.instance.emitAction(0);
     expect(serviceWithLiveNotifications.liveNotifications.size).toBe(0);
 
-    service.notifyAttention({
+    service.notifyApproval({
       enabled: true,
       key: "codex:thread-1:req-click",
-      title: "Approval needed",
-      body: "Please approve",
-      onApprove,
+      intent: approvalIntent(),
+      onDecision,
     });
 
     expect(serviceWithLiveNotifications.liveNotifications.size).toBe(1);
@@ -218,9 +412,41 @@ describe("DesktopNotificationService", () => {
     expect(serviceWithLiveNotifications.liveNotifications.size).toBe(0);
   });
 
-  it("falls back to a passive notification when action buttons are unsupported", () => {
+  it("closes a live attention notification when its key is cleared", () => {
     const service = new DesktopNotificationService();
-    const onApprove = vi.fn();
+    getAllWindows.mockReturnValue([
+      { isDestroyed: () => false, isFocused: () => false, isMinimized: () => false },
+    ]);
+    const serviceWithLiveNotifications = service as unknown as {
+      liveNotifications: Set<unknown>;
+    };
+
+    service.notifyAttention({
+      enabled: true,
+      key: "codex:thread-1:req-clear",
+      title: "Approval needed",
+      body: "Please approve",
+    });
+
+    expect(serviceWithLiveNotifications.liveNotifications.size).toBe(1);
+
+    service.clearAttentionKey("codex:thread-1:req-clear");
+
+    expect(serviceWithLiveNotifications.liveNotifications.size).toBe(0);
+
+    service.notifyAttention({
+      enabled: true,
+      key: "codex:thread-1:req-clear",
+      title: "Approval needed",
+      body: "Please approve again",
+    });
+
+    expect(shownNotifications.at(-1)?.body).toBe("Please approve again");
+  });
+
+  it("falls back to a passive approval notification when action buttons are unsupported", () => {
+    const service = new DesktopNotificationService();
+    const onDecision = vi.fn();
     getAllWindows.mockReturnValue([
       { isDestroyed: () => false, isFocused: () => false, isMinimized: () => false },
     ]);
@@ -232,16 +458,91 @@ describe("DesktopNotificationService", () => {
       "supportsActionButtons",
     ).mockReturnValue(false);
 
-    service.notifyAttention({
+    service.notifyApproval({
       enabled: true,
       key: "codex:thread-1:req-3",
-      title: "Approval needed",
-      body: "Please approve",
-      onApprove,
+      intent: approvalIntent(),
+      onDecision,
     });
 
     expect(shownNotifications[0]?.actions).toBeUndefined();
     shownNotifications[0]?.instance.emitAction(0);
-    expect(onApprove).not.toHaveBeenCalled();
+    expect(onDecision).not.toHaveBeenCalled();
+  });
+
+  it("keeps only safe native approval actions when the intent lacks details", () => {
+    const service = new DesktopNotificationService();
+    const onDecision = vi.fn();
+    const onShow = vi.fn();
+    getAllWindows.mockReturnValue([
+      { isDestroyed: () => false, isFocused: () => false, isMinimized: () => false },
+    ]);
+    const serviceWithActionButtons = service as unknown as {
+      supportsActionButtons: () => boolean;
+    };
+    vi.spyOn(
+      serviceWithActionButtons,
+      "supportsActionButtons",
+    ).mockReturnValue(true);
+
+    service.notifyApproval({
+      enabled: true,
+      key: "codex:thread-1:req-generic",
+      intent: approvalIntent({
+        body: [
+          "Approve this action?",
+          "Reply with \"1\", \"2\", \"yes\", \"yes for this session\", \"no\", or use a button.",
+        ].join("\n\n"),
+      }),
+      onDecision,
+      onShow,
+    });
+
+    expect(shownNotifications[0]?.actions).toEqual([
+      { type: "button", text: "Show" },
+      { type: "button", text: "Decline" },
+    ]);
+    shownNotifications[0]?.instance.emitAction(0);
+    expect(onShow).toHaveBeenCalledTimes(1);
+    expect(onDecision).not.toHaveBeenCalled();
+
+    service.notifyApproval({
+      enabled: true,
+      key: "codex:thread-1:req-generic-decline",
+      intent: approvalIntent({
+        body: [
+          "Approve this action?",
+          "Reply with \"1\", \"2\", \"yes\", \"yes for this session\", \"no\", or use a button.",
+        ].join("\n\n"),
+      }),
+      onDecision,
+      onShow,
+    });
+    shownNotifications[1]?.instance.emitAction(1);
+
+    expect(onDecision).toHaveBeenCalledWith("decline");
+    expect(onDecision).not.toHaveBeenCalledWith("accept");
+  });
+
+  it("focuses the approval thread when clicking the notification body", () => {
+    const service = new DesktopNotificationService();
+    const onDecision = vi.fn();
+    const onShow = vi.fn();
+    getAllWindows.mockReturnValue([
+      { isDestroyed: () => false, isFocused: () => false, isMinimized: () => false },
+    ]);
+
+    service.notifyApproval({
+      enabled: true,
+      key: "codex:thread-1:req-click-show",
+      intent: approvalIntent(),
+      onDecision,
+      onShow,
+    });
+
+    shownNotifications[0]?.instance.emitClick();
+
+    expect(onShow).toHaveBeenCalledTimes(1);
+    expect(onDecision).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/main/__tests__/window-show-thread.test.ts
+++ b/apps/desktop/src/main/__tests__/window-show-thread.test.ts
@@ -1,0 +1,86 @@
+import type { WebContents } from "electron";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { WINDOW_SHOW_THREAD_CHANNEL } from "../../shared/ipc";
+import { requestShowThread } from "../window-show-thread";
+import { subscribersForChannel } from "../window-channels";
+
+const { getFocusedWindowMock, fromWebContentsMock } = vi.hoisted(() => ({
+  getFocusedWindowMock: vi.fn(),
+  fromWebContentsMock: vi.fn(),
+}));
+
+vi.mock("electron", () => ({
+  BrowserWindow: {
+    getFocusedWindow: getFocusedWindowMock,
+    fromWebContents: fromWebContentsMock,
+  },
+}));
+
+vi.mock("../window-channels", () => ({
+  subscribersForChannel: vi.fn(),
+}));
+
+describe("requestShowThread", () => {
+  beforeEach(() => {
+    getFocusedWindowMock.mockReset();
+    fromWebContentsMock.mockReset();
+    vi.mocked(subscribersForChannel).mockReset();
+  });
+
+  it("sends to the focused subscribed main window", () => {
+    const request = { backend: "codex" as const, threadId: "thread-1" };
+    const send = vi.fn();
+    const focusedWebContents = { send } as unknown as WebContents;
+    const focusedWindow = {
+      focus: vi.fn(),
+      isDestroyed: () => false,
+      isMinimized: () => false,
+      show: vi.fn(),
+      webContents: focusedWebContents,
+    };
+
+    getFocusedWindowMock.mockReturnValue(focusedWindow);
+    vi.mocked(subscribersForChannel).mockReturnValue([focusedWindow.webContents]);
+
+    requestShowThread(request);
+
+    expect(subscribersForChannel).toHaveBeenCalledWith(WINDOW_SHOW_THREAD_CHANNEL);
+    expect(focusedWindow.show).toHaveBeenCalledOnce();
+    expect(focusedWindow.focus).toHaveBeenCalledOnce();
+    expect(send).toHaveBeenCalledWith(WINDOW_SHOW_THREAD_CHANNEL, request);
+  });
+
+  it("restores a minimized fallback subscriber", () => {
+    const request = { backend: "codex" as const, threadId: "thread-2" };
+    const fallbackSend = vi.fn();
+    const fallbackContents = { send: fallbackSend } as unknown as WebContents;
+    const fallbackWindow = {
+      focus: vi.fn(),
+      isDestroyed: () => false,
+      isMinimized: () => true,
+      restore: vi.fn(),
+      show: vi.fn(),
+    };
+
+    getFocusedWindowMock.mockReturnValue(null);
+    vi.mocked(subscribersForChannel).mockReturnValue([fallbackContents]);
+    fromWebContentsMock.mockReturnValue(fallbackWindow);
+
+    requestShowThread(request);
+
+    expect(fallbackWindow.restore).toHaveBeenCalledOnce();
+    expect(fallbackWindow.show).toHaveBeenCalledOnce();
+    expect(fallbackWindow.focus).toHaveBeenCalledOnce();
+    expect(fallbackSend).toHaveBeenCalledWith(WINDOW_SHOW_THREAD_CHANNEL, request);
+  });
+
+  it("no-ops when no window is subscribed", () => {
+    getFocusedWindowMock.mockReturnValue(null);
+    vi.mocked(subscribersForChannel).mockReturnValue([]);
+
+    expect(() =>
+      requestShowThread({ backend: "codex", threadId: "thread-3" }),
+    ).not.toThrow();
+    expect(fromWebContentsMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -9545,8 +9545,13 @@ export class DesktopBackendRegistry {
     notification: AgentEvent["notification"],
   ): notification is AppServerPendingRequestNotification {
     return (
-      notification.method !== "item/tool/requestUserInput" &&
-      notification.method !== "mcpServer/elicitation/request"
+      notification.method === "turn/requestApproval" ||
+      notification.method === "review/requestApproval" ||
+      notification.method === "item/commandExecution/requestApproval" ||
+      notification.method === "item/fileChange/requestApproval" ||
+      notification.method === "item/permissions/requestApproval" ||
+      notification.method === "applyPatchApproval" ||
+      notification.method === "execCommandApproval"
     );
   }
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -9525,16 +9525,19 @@ export class DesktopBackendRegistry {
       ? "waiting for your response"
       : "waiting for your approval";
     const body = threadTitle ? `${threadTitle} · ${baseBody}.` : `A turn ${baseBody}.`;
+    const approvalRequest = this.isApprovalAttentionNotification(event.notification)
+      ? event.notification
+      : undefined;
     getDesktopNotificationService().notifyAttention({
       enabled: this.notificationsEnabled(),
       key: `${event.backend}:${threadId}:${requestId}`,
       title,
       body,
-      onApprove: this.isApprovalAttentionNotification(event.notification)
+      onApprove: approvalRequest
         ? () => {
             void this.resolvePendingServerRequestFromNotification({
               backend: event.backend,
-              request: event.notification,
+              request: approvalRequest,
             });
           }
         : undefined,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -108,6 +108,7 @@ import {
   type EnsureDirectoryLaunchpadRequest,
   type EnsureDirectoryLaunchpadResponse,
   applyCodexEnvironmentActionRunUpdate,
+  buildPendingRequestResponse,
   buildThreadIdentityKey,
   isAcpBackendId,
   readCodexEnvironmentActionRuns,
@@ -9529,6 +9530,52 @@ export class DesktopBackendRegistry {
       key: `${event.backend}:${threadId}:${requestId}`,
       title,
       body,
+      onApprove: this.isApprovalAttentionNotification(event.notification)
+        ? () => {
+            void this.resolvePendingServerRequestFromNotification({
+              backend: event.backend,
+              request: event.notification,
+            });
+          }
+        : undefined,
+    });
+  }
+
+  private isApprovalAttentionNotification(
+    notification: AgentEvent["notification"],
+  ): notification is AppServerPendingRequestNotification {
+    return (
+      notification.method !== "item/tool/requestUserInput" &&
+      notification.method !== "mcpServer/elicitation/request"
+    );
+  }
+
+  private async resolvePendingServerRequestFromNotification(params: {
+    backend: AppServerBackendKind;
+    request: AppServerPendingRequestNotification;
+  }): Promise<void> {
+    const key = buildPendingRequestKey({
+      backend: params.backend,
+      threadId: params.request.params.threadId,
+      requestId: params.request.params.requestId,
+    });
+    const pending = this.pendingServerRequests.get(key);
+    if (!pending) {
+      return;
+    }
+
+    this.pendingServerRequests.delete(key);
+    pending.resolve(buildPendingRequestResponse(params.request, "approve"));
+    await this.emit({
+      backend: params.backend,
+      notification: {
+        method: "serverRequest/resolved",
+        params: {
+          threadId: params.request.params.threadId,
+          turnId: params.request.params.turnId,
+          requestId: params.request.params.requestId,
+        },
+      },
     });
   }
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -5,8 +5,10 @@ import { stat } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 import type { DynamicToolSpec as CodexDynamicToolSpec } from "@pwragent/codex-app-server-protocol/v2";
+import type { MessagingApprovalDecision } from "@pwragent/messaging-interface";
 import { getAppStateMode } from "../state/app-state";
 import type { OverlayStoreLike } from "../state/overlay-store-sqlite";
+import { requestShowThread } from "../window-show-thread";
 import { PerKeyAsyncLock } from "../util/per-key-async-lock";
 import {
   type AcpBackendId,
@@ -111,6 +113,7 @@ import {
   buildPendingRequestResponse,
   buildThreadIdentityKey,
   isAcpBackendId,
+  type PendingRequestDecision,
   readCodexEnvironmentActionRuns,
 } from "@pwragent/shared";
 import {
@@ -165,6 +168,7 @@ import {
 import { getMainLogger } from "../log";
 import { getDesktopSettingsService } from "../settings/desktop-settings-singleton";
 import { getDesktopNotificationService } from "../notifications/desktop-notification-service";
+import { buildApprovalIntent } from "../messaging/core/messaging-approval-renderer";
 import { resolveAgentCoreGrokEnabled } from "../settings/desktop-config";
 import {
   BackendModelCatalog,
@@ -1118,6 +1122,20 @@ function isAcpPermissionRequest(
     request.method === "item/commandExecution/requestApproval" &&
     request.params.acpMethod === "session/request_permission"
   );
+}
+
+function pendingRequestDecisionFromMessagingApproval(
+  decision: MessagingApprovalDecision,
+): PendingRequestDecision {
+  switch (decision) {
+    case "accept":
+    case "accept_for_session":
+      return "approve";
+    case "decline":
+      return "decline";
+    case "cancel":
+      return "cancel";
+  }
 }
 
 function acpRuntimeHasExecutionModeSelection(params: {
@@ -9424,12 +9442,20 @@ export class DesktopBackendRegistry {
     return await new Promise<SubmitServerRequestRequest["response"]>((resolve, reject) => {
       this.pendingServerRequests.set(key, { resolve, reject });
 
-      this.emit({
+      void this.emit({
         backend,
         notification: request as AppServerNotification,
       }).catch((error) => {
-        this.pendingServerRequests.delete(key);
-        reject(error instanceof Error ? error : new Error(String(error)));
+        backendRegistryLog.error(
+          "failed to publish pending server request; keeping request pending",
+          {
+            backend,
+            error: error instanceof Error ? error.message : String(error),
+            requestId: request.params.requestId,
+            threadId: request.params.threadId,
+            turnId: request.params.turnId,
+          },
+        );
       });
     });
   }
@@ -9521,27 +9547,89 @@ export class DesktopBackendRegistry {
     const threadTitle = this.notificationThreadTitles.get(
       `${event.backend}:${threadId}`,
     );
+    const approvalRequest = this.isApprovalAttentionNotification(event.notification)
+      ? event.notification
+      : undefined;
+    const key = `${event.backend}:${threadId}:${requestId}`;
+    if (approvalRequest) {
+      const intent = buildApprovalIntent({
+        createdAt: Date.now(),
+        id: key,
+        request: approvalRequest,
+      });
+      intent.requestContext = {
+        backend: event.backend,
+        method: approvalRequest.method,
+        requestId,
+        threadId,
+        turnId:
+          typeof approvalRequest.params.turnId === "string"
+            ? approvalRequest.params.turnId
+            : undefined,
+      };
+      try {
+        getDesktopNotificationService().notifyApproval({
+          enabled: this.notificationsEnabled(),
+          key,
+          intent,
+          onShow: () => {
+            requestShowThread({
+              backend: event.backend,
+              threadId,
+            });
+          },
+          onDecision: (decision) => {
+            void this.submitServerRequest({
+              backend: event.backend,
+              threadId,
+              turnId:
+                typeof approvalRequest.params.turnId === "string"
+                  ? approvalRequest.params.turnId
+                  : undefined,
+              requestId,
+              response: buildPendingRequestResponse(
+                approvalRequest,
+                pendingRequestDecisionFromMessagingApproval(decision),
+              ),
+            }).catch((error) => {
+              backendRegistryLog.warn("native approval notification decision failed", {
+                backend: event.backend,
+                error: error instanceof Error ? error.message : String(error),
+                requestId,
+                threadId,
+              });
+            });
+          },
+        });
+      } catch (error) {
+        backendRegistryLog.warn("native approval notification failed", {
+          backend: event.backend,
+          error: error instanceof Error ? error.message : String(error),
+          requestId,
+          threadId,
+        });
+      }
+      return;
+    }
     const baseBody = isQuestion
       ? "waiting for your response"
       : "waiting for your approval";
     const body = threadTitle ? `${threadTitle} · ${baseBody}.` : `A turn ${baseBody}.`;
-    const approvalRequest = this.isApprovalAttentionNotification(event.notification)
-      ? event.notification
-      : undefined;
-    getDesktopNotificationService().notifyAttention({
-      enabled: this.notificationsEnabled(),
-      key: `${event.backend}:${threadId}:${requestId}`,
-      title,
-      body,
-      onApprove: approvalRequest
-        ? () => {
-            void this.resolvePendingServerRequestFromNotification({
-              backend: event.backend,
-              request: approvalRequest,
-            });
-          }
-        : undefined,
-    });
+    try {
+      getDesktopNotificationService().notifyAttention({
+        enabled: this.notificationsEnabled(),
+        key,
+        title,
+        body,
+      });
+    } catch (error) {
+      backendRegistryLog.warn("native attention notification failed", {
+        backend: event.backend,
+        error: error instanceof Error ? error.message : String(error),
+        requestId,
+        threadId,
+      });
+    }
   }
 
   private isApprovalAttentionNotification(
@@ -9556,35 +9644,6 @@ export class DesktopBackendRegistry {
       notification.method === "applyPatchApproval" ||
       notification.method === "execCommandApproval"
     );
-  }
-
-  private async resolvePendingServerRequestFromNotification(params: {
-    backend: AppServerBackendKind;
-    request: AppServerPendingRequestNotification;
-  }): Promise<void> {
-    const key = buildPendingRequestKey({
-      backend: params.backend,
-      threadId: params.request.params.threadId,
-      requestId: params.request.params.requestId,
-    });
-    const pending = this.pendingServerRequests.get(key);
-    if (!pending) {
-      return;
-    }
-
-    this.pendingServerRequests.delete(key);
-    pending.resolve(buildPendingRequestResponse(params.request, "approve"));
-    await this.emit({
-      backend: params.backend,
-      notification: {
-        method: "serverRequest/resolved",
-        params: {
-          threadId: params.request.params.threadId,
-          turnId: params.request.params.turnId,
-          requestId: params.request.params.requestId,
-        },
-      },
-    });
   }
 
   private notifyForTerminalOutcome(event: AgentEvent): void {
@@ -9610,11 +9669,19 @@ export class DesktopBackendRegistry {
     const body = threadTitle
       ? `${threadTitle} · turn ${status}.`
       : `A turn ${status}.`;
-    getDesktopNotificationService().notifyTerminal({
-      enabled: this.notificationsEnabled(),
-      title: `PwrAgent turn ${status}`,
-      body,
-    });
+    try {
+      getDesktopNotificationService().notifyTerminal({
+        enabled: this.notificationsEnabled(),
+        title: `PwrAgent turn ${status}`,
+        body,
+      });
+    } catch (error) {
+      backendRegistryLog.warn("native terminal notification failed", {
+        backend: event.backend,
+        error: error instanceof Error ? error.message : String(error),
+        threadId,
+      });
+    }
   }
 
   private async emit(event: AgentEvent): Promise<void> {
@@ -9838,12 +9905,27 @@ export class DesktopBackendRegistry {
         threadId: event.notification.params.threadId,
         requestId: event.notification.params.requestId,
       });
-      const pending = this.pendingServerRequests.get(key);
-      if (pending) {
-        this.pendingServerRequests.delete(key);
-        pending.resolve({ decision: "cancel" });
+      if (this.pendingServerRequests.has(key)) {
+        backendRegistryLog.warn(
+          "serverRequest/resolved received while request is still pending; ignoring premature resolution",
+          {
+            backend: event.backend,
+            threadId: event.notification.params.threadId,
+            requestId: event.notification.params.requestId,
+          },
+        );
+        return;
       }
-      getDesktopNotificationService().clearAttentionKey(key);
+      try {
+        getDesktopNotificationService().clearAttentionKey(key);
+      } catch (error) {
+        backendRegistryLog.warn("native notification cleanup failed", {
+          backend: event.backend,
+          error: error instanceof Error ? error.message : String(error),
+          requestId: event.notification.params.requestId,
+          threadId: event.notification.params.threadId,
+        });
+      }
     }
 
     this.rememberThreadTitleFromEvent(event);
@@ -9851,7 +9933,27 @@ export class DesktopBackendRegistry {
     this.notifyForTerminalOutcome(event);
 
     for (const listener of this.eventListeners) {
-      await listener(event);
+      try {
+        await listener(event);
+      } catch (error) {
+        backendRegistryLog.error("desktop event listener failed", {
+          backend: event.backend,
+          error: error instanceof Error ? error.message : String(error),
+          method: event.notification.method,
+          requestId:
+            "requestId" in event.notification.params
+              ? event.notification.params.requestId
+              : undefined,
+          threadId:
+            "threadId" in event.notification.params
+              ? event.notification.params.threadId
+              : undefined,
+          turnId:
+            "turnId" in event.notification.params
+              ? event.notification.params.turnId
+              : undefined,
+        });
+      }
     }
   }
 }

--- a/apps/desktop/src/main/notifications/desktop-notification-service.ts
+++ b/apps/desktop/src/main/notifications/desktop-notification-service.ts
@@ -2,6 +2,7 @@ import { BrowserWindow, Notification } from "electron";
 import { getMainLogger } from "../log";
 
 const notificationLog = getMainLogger("pwragent:notifications");
+const APPROVE_ACTION_INDEX = 0;
 
 /**
  * Native attention/terminal notifications for unattended turns.
@@ -17,6 +18,7 @@ const notificationLog = getMainLogger("pwragent:notifications");
  */
 export class DesktopNotificationService {
   private readonly attentionKeys = new Set<string>();
+  private readonly liveNotifications = new Set<Notification>();
 
   clearAttentionKey(key: string): void {
     this.attentionKeys.delete(key);
@@ -27,6 +29,7 @@ export class DesktopNotificationService {
     key: string;
     title: string;
     body: string;
+    onApprove?: () => void;
   }): void {
     if (!params.enabled || this.attentionKeys.has(params.key)) {
       return;
@@ -38,7 +41,11 @@ export class DesktopNotificationService {
       return;
     }
     this.attentionKeys.add(params.key);
-    this.show(params.title, params.body);
+    this.show({
+      title: params.title,
+      body: params.body,
+      onApprove: params.onApprove,
+    });
   }
 
   notifyTerminal(params: {
@@ -55,7 +62,14 @@ export class DesktopNotificationService {
     if (!Notification.isSupported()) {
       return;
     }
-    this.show(params.title, params.body);
+    this.show({
+      title: params.title,
+      body: params.body,
+    });
+  }
+
+  private supportsActionButtons(): boolean {
+    return process.platform === "darwin" || process.platform === "win32";
   }
 
   private isAppInactive(): boolean {
@@ -66,12 +80,39 @@ export class DesktopNotificationService {
     return windows.every((window) => window.isMinimized() || !window.isFocused());
   }
 
-  private show(title: string, body: string): void {
+  private show(params: {
+    title: string;
+    body: string;
+    onApprove?: () => void;
+  }): void {
     try {
-      new Notification({
-        title,
-        body,
-      }).show();
+      const notification = new Notification({
+        title: params.title,
+        body: params.body,
+        ...(params.onApprove && this.supportsActionButtons()
+          ? {
+              actions: [{ type: "button", text: "Approve" }],
+            }
+          : {}),
+      });
+      this.liveNotifications.add(notification);
+      const cleanup = () => {
+        this.liveNotifications.delete(notification);
+      };
+      notification.on("click", cleanup);
+      notification.on("close", cleanup);
+      if (params.onApprove && this.supportsActionButtons()) {
+        let handled = false;
+        notification.on("action", (_event, actionIndex) => {
+          cleanup();
+          if (handled || actionIndex !== APPROVE_ACTION_INDEX) {
+            return;
+          }
+          handled = true;
+          params.onApprove?.();
+        });
+      }
+      notification.show();
     } catch (error) {
       notificationLog.warn("failed to display native notification", {
         error: error instanceof Error ? error.message : String(error),

--- a/apps/desktop/src/main/notifications/desktop-notification-service.ts
+++ b/apps/desktop/src/main/notifications/desktop-notification-service.ts
@@ -1,8 +1,17 @@
 import { BrowserWindow, Notification } from "electron";
+import type {
+  MessagingApprovalDecision,
+  MessagingApprovalIntent,
+} from "@pwragent/messaging-interface";
 import { getMainLogger } from "../log";
 
 const notificationLog = getMainLogger("pwragent:notifications");
-const APPROVE_ACTION_INDEX = 0;
+const NATIVE_NOTIFICATION_BODY_MAX_LENGTH = 220;
+
+type NativeNotificationAction = {
+  text: string;
+  run: () => void;
+};
 
 /**
  * Native attention/terminal notifications for unattended turns.
@@ -18,10 +27,26 @@ const APPROVE_ACTION_INDEX = 0;
  */
 export class DesktopNotificationService {
   private readonly attentionKeys = new Set<string>();
+  private readonly attentionNotifications = new Map<string, Set<Notification>>();
   private readonly liveNotifications = new Set<Notification>();
 
   clearAttentionKey(key: string): void {
     this.attentionKeys.delete(key);
+    const notifications = this.attentionNotifications.get(key);
+    if (!notifications) {
+      return;
+    }
+    this.attentionNotifications.delete(key);
+    for (const notification of notifications) {
+      this.liveNotifications.delete(notification);
+      try {
+        notification.close();
+      } catch (error) {
+        notificationLog.warn("failed to close native notification", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
   }
 
   notifyAttention(params: {
@@ -29,7 +54,6 @@ export class DesktopNotificationService {
     key: string;
     title: string;
     body: string;
-    onApprove?: () => void;
   }): void {
     if (!params.enabled || this.attentionKeys.has(params.key)) {
       return;
@@ -42,9 +66,40 @@ export class DesktopNotificationService {
     }
     this.attentionKeys.add(params.key);
     this.show({
+      attentionKey: params.key,
       title: params.title,
       body: params.body,
-      onApprove: params.onApprove,
+    });
+  }
+
+  notifyApproval(params: {
+    enabled: boolean;
+    key: string;
+    intent: MessagingApprovalIntent;
+    onDecision?: (decision: MessagingApprovalDecision) => void;
+    onShow?: () => void;
+  }): void {
+    if (!params.enabled || this.attentionKeys.has(params.key)) {
+      return;
+    }
+    if (!this.isAppInactive()) {
+      return;
+    }
+    if (!Notification.isSupported()) {
+      return;
+    }
+
+    const nativeActions = nativeApprovalActions(params.intent, {
+      onDecision: params.onDecision,
+      onShow: params.onShow,
+    });
+    this.attentionKeys.add(params.key);
+    this.show({
+      attentionKey: params.key,
+      title: "PwrAgent approval needed",
+      body: nativeApprovalBody(params.intent),
+      actions: nativeActions,
+      onClick: params.onShow,
     });
   }
 
@@ -81,35 +136,67 @@ export class DesktopNotificationService {
   }
 
   private show(params: {
+    attentionKey?: string;
+    actions?: NativeNotificationAction[];
+    onClick?: () => void;
     title: string;
     body: string;
-    onApprove?: () => void;
   }): void {
     try {
+      const actions =
+        params.actions && params.actions.length > 0 && this.supportsActionButtons()
+          ? params.actions
+          : undefined;
       const notification = new Notification({
         title: params.title,
         body: params.body,
-        ...(params.onApprove && this.supportsActionButtons()
+        ...(actions
           ? {
-              actions: [{ type: "button", text: "Approve" }],
+              actions: actions.map((action) => ({
+                type: "button" as const,
+                text: action.text,
+              })),
             }
           : {}),
       });
       this.liveNotifications.add(notification);
+      if (params.attentionKey) {
+        let notifications = this.attentionNotifications.get(params.attentionKey);
+        if (!notifications) {
+          notifications = new Set<Notification>();
+          this.attentionNotifications.set(params.attentionKey, notifications);
+        }
+        notifications.add(notification);
+      }
       const cleanup = () => {
         this.liveNotifications.delete(notification);
+        if (params.attentionKey) {
+          const notifications = this.attentionNotifications.get(params.attentionKey);
+          notifications?.delete(notification);
+          if (notifications?.size === 0) {
+            this.attentionNotifications.delete(params.attentionKey);
+          }
+        }
       };
-      notification.on("click", cleanup);
+      notification.on("click", () => {
+        cleanup();
+        params.onClick?.();
+      });
       notification.on("close", cleanup);
-      if (params.onApprove && this.supportsActionButtons()) {
+      if (actions) {
         let handled = false;
-        notification.on("action", (_event, actionIndex) => {
+        notification.on("action", (event, deprecatedActionIndex) => {
           cleanup();
-          if (handled || actionIndex !== APPROVE_ACTION_INDEX) {
+          if (handled) {
+            return;
+          }
+          const actionIndex = notificationActionIndex(event, deprecatedActionIndex);
+          const action = actions[actionIndex];
+          if (!action) {
             return;
           }
           handled = true;
-          params.onApprove?.();
+          action.run();
         });
       }
       notification.show();
@@ -119,6 +206,80 @@ export class DesktopNotificationService {
       });
     }
   }
+}
+
+function nativeApprovalActions(
+  intent: MessagingApprovalIntent,
+  callbacks: {
+    onDecision?: (decision: MessagingApprovalDecision) => void;
+    onShow?: () => void;
+  },
+): NativeNotificationAction[] | undefined {
+  const actions: NativeNotificationAction[] = [];
+  if (callbacks.onShow) {
+    actions.push({
+      text: "Show",
+      run: callbacks.onShow,
+    });
+  }
+  const accept = intent.decisions.find((action) => action.decision === "accept");
+  if (accept && callbacks.onDecision && nativeApprovalCanApproveInline(intent)) {
+    actions.push({
+      text: "Approve",
+      run: () => callbacks.onDecision?.(accept.decision),
+    });
+  }
+  const decline = intent.decisions.find((action) => action.decision === "decline");
+  if (decline && callbacks.onDecision) {
+    actions.push({
+      text: "Decline",
+      run: () => callbacks.onDecision?.(decline.decision),
+    });
+  }
+  return actions.length > 0 ? actions : undefined;
+}
+
+function nativeApprovalCanApproveInline(intent: MessagingApprovalIntent): boolean {
+  return (
+    nativeApprovalBodyLines(intent).length > 0 &&
+    nativeApprovalBodyFullText(intent).length <= NATIVE_NOTIFICATION_BODY_MAX_LENGTH
+  );
+}
+
+function nativeApprovalBody(intent: MessagingApprovalIntent): string {
+  const next = nativeApprovalBodyFullText(intent);
+  if (next.length <= NATIVE_NOTIFICATION_BODY_MAX_LENGTH) {
+    return next;
+  }
+  return `${next.slice(0, NATIVE_NOTIFICATION_BODY_MAX_LENGTH - 3)}...`;
+}
+
+function nativeApprovalBodyFullText(intent: MessagingApprovalIntent): string {
+  const body = nativeApprovalBodyLines(intent)
+    .join(" · ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return body ? `${intent.title}: ${body}` : intent.title;
+}
+
+function nativeApprovalBodyLines(intent: MessagingApprovalIntent): string[] {
+  return intent.body
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith("Reply with "))
+    .filter((line) => line !== "```shell" && line !== "```")
+    .filter((line) => line !== "Approve this action?");
+}
+
+function notificationActionIndex(
+  event: unknown,
+  deprecatedActionIndex: unknown,
+): number {
+  const details = event as { actionIndex?: unknown } | undefined;
+  if (typeof details?.actionIndex === "number") {
+    return details.actionIndex;
+  }
+  return typeof deprecatedActionIndex === "number" ? deprecatedActionIndex : -1;
 }
 
 let service: DesktopNotificationService | undefined;

--- a/apps/desktop/src/main/window-show-thread.ts
+++ b/apps/desktop/src/main/window-show-thread.ts
@@ -1,0 +1,38 @@
+import { BrowserWindow } from "electron";
+import { WINDOW_SHOW_THREAD_CHANNEL } from "../shared/ipc";
+import type { WindowShowThreadRequest } from "../shared/window-show-thread";
+import { subscribersForChannel } from "./window-channels";
+
+export function requestShowThread(request: WindowShowThreadRequest): void {
+  const focused = BrowserWindow.getFocusedWindow();
+  const subscribers = subscribersForChannel(WINDOW_SHOW_THREAD_CHANNEL);
+
+  if (focused && !focused.isDestroyed()) {
+    const focusedSubscriber = subscribers.find(
+      (subscriber) => subscriber === focused.webContents,
+    );
+    if (focusedSubscriber) {
+      showWindow(focused);
+      focusedSubscriber.send(WINDOW_SHOW_THREAD_CHANNEL, request);
+      return;
+    }
+  }
+
+  const fallback = subscribers[0];
+  if (!fallback) {
+    return;
+  }
+  const fallbackWindow = BrowserWindow.fromWebContents(fallback);
+  if (fallbackWindow && !fallbackWindow.isDestroyed()) {
+    showWindow(fallbackWindow);
+  }
+  fallback.send(WINDOW_SHOW_THREAD_CHANNEL, request);
+}
+
+function showWindow(window: BrowserWindow): void {
+  if (window.isMinimized()) {
+    window.restore();
+  }
+  window.show();
+  window.focus();
+}

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -32,6 +32,7 @@ import {
   WINDOW_OPEN_NEW_THREAD_CHANNEL,
   WINDOW_OPEN_SETTINGS_CHANNEL,
   WINDOW_REPLAY_ONBOARDING_CHANNEL,
+  WINDOW_SHOW_THREAD_CHANNEL,
 } from "../shared/ipc";
 import {
   readBootstrapAppearance,
@@ -607,6 +608,7 @@ export function createMainWindow(options?: {
     WINDOW_OPEN_NEW_THREAD_CHANNEL,
     WINDOW_OPEN_SETTINGS_CHANNEL,
     WINDOW_REPLAY_ONBOARDING_CHANNEL,
+    WINDOW_SHOW_THREAD_CHANNEL,
   ]);
 
   window.on("closed", () => {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -328,9 +328,11 @@ import {
   WINDOW_OPEN_SETTINGS_CHANNEL,
   WINDOW_POINTER_SNAPSHOT_CHANNEL,
   WINDOW_REPLAY_ONBOARDING_CHANNEL,
+  WINDOW_SHOW_THREAD_CHANNEL,
 } from "../shared/ipc";
 import type { RuntimeIdentity } from "../shared/runtime-identity";
 import type { WindowPointerSnapshot } from "../shared/window-pointer";
+import type { WindowShowThreadRequest } from "../shared/window-show-thread";
 import type {
   AppChangelogDocument,
   AppLogEntry,
@@ -851,6 +853,18 @@ const desktopApi = Object.freeze({
     ipcRenderer.on(WINDOW_OPEN_NEW_THREAD_CHANNEL, listener);
     return () => {
       ipcRenderer.off(WINDOW_OPEN_NEW_THREAD_CHANNEL, listener);
+    };
+  },
+  onShowThreadRequested: (
+    callback: (request: WindowShowThreadRequest) => void,
+  ): (() => void) => {
+    const listener = (
+      _event: Electron.IpcRendererEvent,
+      request: WindowShowThreadRequest,
+    ) => callback(request);
+    ipcRenderer.on(WINDOW_SHOW_THREAD_CHANNEL, listener);
+    return () => {
+      ipcRenderer.off(WINDOW_SHOW_THREAD_CHANNEL, listener);
     };
   },
   onReplayOnboardingRequested: (callback: () => void): (() => void) => {

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -299,6 +299,15 @@ function DesktopAppShell(props: {
     });
   }, [desktopApi, navigation]);
   useEffect(() => {
+    if (!desktopApi?.onShowThreadRequested) {
+      return;
+    }
+    return desktopApi.onShowThreadRequested((request) => {
+      setMainView("thread");
+      void navigation.showThread(request);
+    });
+  }, [desktopApi, navigation]);
+  useEffect(() => {
     // Subscribe to Help → Replay Onboarding push from the menu. Forces
     // the wizard overlay open in "replay" mode — dismissal does NOT
     // touch `onboarding.completed`.

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -33,7 +33,11 @@ import type {
   NavigationThreadSummary,
   ThreadExecutionMode,
 } from "@pwragent/shared";
-import { isBranchDrifted, readCodexEnvironmentActionRuns } from "@pwragent/shared";
+import {
+  buildPendingRequestResponse,
+  isBranchDrifted,
+  readCodexEnvironmentActionRuns,
+} from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 import type { ThreadContextWindowState } from "../../lib/useThreadSessionState";
 import { formatBackendLabel } from "../../lib/backend-label";
@@ -2505,86 +2509,6 @@ function executionModeLabel(mode: ThreadExecutionMode): string {
   return "Default Access";
 }
 
-function buildPendingRequestResponse(
-  request: AppServerPendingRequestNotification,
-  decision: "approve" | "decline" | "cancel"
-): { decision: string } {
-  const availableDecision = selectAvailableDecision(request.params, decision);
-  if (availableDecision) {
-    return { decision: availableDecision };
-  }
-
-  if (request.method.includes("commandExecution/requestApproval")) {
-    return {
-      decision:
-        decision === "approve"
-          ? "accept"
-          : decision === "decline"
-            ? "decline"
-            : "cancel",
-    };
-  }
-
-  if (request.method.includes("fileChange/requestApproval")) {
-    return {
-      decision:
-        decision === "approve"
-          ? "accept"
-          : decision === "decline"
-            ? "decline"
-            : "cancel",
-    };
-  }
-
-  return { decision };
-}
-
-function selectAvailableDecision(
-  params: AppServerPendingRequestNotification["params"],
-  decision: "approve" | "decline" | "cancel"
-): string | undefined {
-  const rawDecisions =
-    readDecisionStrings(params.availableDecisions) ?? readDecisionStrings(params.decisions);
-  if (!rawDecisions?.length) {
-    return undefined;
-  }
-
-  const acceptedAliases =
-    decision === "approve"
-      ? ["accept", "approve", "allow"]
-      : decision === "decline"
-        ? ["decline", "deny", "reject"]
-        : ["cancel", "abort", "stop"];
-
-  return rawDecisions.find((value) =>
-    acceptedAliases.some((alias) => value.toLowerCase().includes(alias))
-  );
-}
-
-function readDecisionStrings(value: unknown): string[] | undefined {
-  if (!Array.isArray(value)) {
-    return undefined;
-  }
-
-  return value
-    .map((entry) => {
-      if (typeof entry === "string") {
-        return entry.trim();
-      }
-      if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
-        return undefined;
-      }
-      const record = entry as Record<string, unknown>;
-      for (const key of ["decision", "value", "name", "id"]) {
-        const raw = record[key];
-        if (typeof raw === "string" && raw.trim()) {
-          return raw.trim();
-        }
-      }
-      return undefined;
-    })
-    .filter((entry): entry is string => Boolean(entry));
-}
 
 function formatDirectorySync(directory: NavigationDirectorySummary): string | undefined {
   const status = directory.gitStatus;

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -196,6 +196,7 @@ import type {
 } from "@pwragent/shared";
 import type { RuntimeIdentity } from "../../../shared/runtime-identity";
 import type { WindowPointerSnapshot } from "../../../shared/window-pointer";
+import type { WindowShowThreadRequest } from "../../../shared/window-show-thread";
 import type {
   AppChangelogDocument,
   AppLogEntry,
@@ -619,6 +620,13 @@ export type DesktopApi = {
    * or presses the native `CmdOrCtrl+N` accelerator.
    */
   onOpenNewThreadRequested?: (callback: () => void) => () => void;
+  /**
+   * Main -> renderer push: focuses an existing thread from an
+   * out-of-app surface such as a native notification.
+   */
+  onShowThreadRequested?: (
+    callback: (request: WindowShowThreadRequest) => void,
+  ) => () => void;
   /**
    * Main → renderer push: fires when the user invokes Help →
    * Replay Onboarding…. Re-opens the first-run wizard overlay

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -1800,6 +1800,10 @@ export function useThreadNavigation(
   ) => Promise<void>;
   setBrowseMode: (browseMode: BrowseMode) => void;
   selectThread: (thread: NavigationThreadSummary) => void;
+  showThread: (params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }) => Promise<void>;
   archiveThread: (
     thread: NavigationThreadSummary,
     options?: ArchiveThreadOptions,
@@ -2928,6 +2932,26 @@ export function useThreadNavigation(
       setRetainedUnreadThread(thread);
     }
   }, [refreshThreadDirectoryGitStatuses, releaseRetainedUnreadThread]);
+
+  const showThread = useCallback(
+    async (params: {
+      backend: AppServerBackendKind;
+      threadId: string;
+    }): Promise<void> => {
+      const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+      const thread = state.response?.threads.find(
+        (candidate) =>
+          candidate.source === params.backend && candidate.id === params.threadId,
+      );
+      if (thread) {
+        selectThread(thread);
+        return;
+      }
+      setSelectedItemKey(threadKey);
+      await refresh(threadKey, undefined, true);
+    },
+    [refresh, selectThread, state.response?.threads],
+  );
 
   const createThread = useCallback(
     async (
@@ -4412,6 +4436,7 @@ export function useThreadNavigation(
     updateDirectoryLaunchpad,
     setBrowseMode,
     selectThread,
+    showThread,
     archiveThread,
     archiveWorktree,
     restoreWorktree,

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -202,6 +202,11 @@ export const WINDOW_POINTER_SNAPSHOT_CHANNEL = "window:pointer-snapshot";
  */
 export const WINDOW_OPEN_NEW_THREAD_CHANNEL = "window:open-new-thread";
 /**
+ * Main -> renderer push: fired when an out-of-app surface, such as a
+ * native approval notification, asks the main window to focus a known thread.
+ */
+export const WINDOW_SHOW_THREAD_CHANNEL = "window:show-thread";
+/**
  * Main → renderer push: fired when the user invokes the app's
  * "Settings…" menu item (PwrAgent → Settings… on macOS, Help → ...
  * on Linux/Windows). The renderer's `App` shell listens on this

--- a/apps/desktop/src/shared/window-show-thread.ts
+++ b/apps/desktop/src/shared/window-show-thread.ts
@@ -1,0 +1,6 @@
+import type { AppServerBackendKind } from "@pwragent/shared";
+
+export type WindowShowThreadRequest = {
+  backend: AppServerBackendKind;
+  threadId: string;
+};

--- a/packages/shared/src/__tests__/pending-request-response.test.ts
+++ b/packages/shared/src/__tests__/pending-request-response.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import type { AppServerPendingRequestNotification } from "../contracts/normalized-app-server";
+import { buildPendingRequestResponse } from "../pending-request-response";
+
+function createRequest(
+  overrides: Partial<AppServerPendingRequestNotification> = {},
+): AppServerPendingRequestNotification {
+  return {
+    method: "item/commandExecution/requestApproval",
+    params: {
+      threadId: "thread-1",
+      requestId: "request-1",
+      ...("params" in overrides ? overrides.params : {}),
+    },
+    ...overrides,
+  } as AppServerPendingRequestNotification;
+}
+
+describe("buildPendingRequestResponse", () => {
+  it("uses an explicit approve decision when available", () => {
+    const request = createRequest({
+      params: {
+        threadId: "thread-1",
+        requestId: "request-1",
+        availableDecisions: ["approve", "reject"],
+      },
+    });
+
+    expect(buildPendingRequestResponse(request, "approve")).toEqual({
+      decision: "approve",
+    });
+  });
+
+  it("maps approve to accept when that alias is provided", () => {
+    const request = createRequest({
+      params: {
+        threadId: "thread-1",
+        requestId: "request-1",
+        availableDecisions: ["accept", "decline"],
+      },
+    });
+
+    expect(buildPendingRequestResponse(request, "approve")).toEqual({
+      decision: "accept",
+    });
+  });
+
+  it("falls back to legacy command approval semantics without explicit decisions", () => {
+    const request = createRequest();
+
+    expect(buildPendingRequestResponse(request, "approve")).toEqual({
+      decision: "accept",
+    });
+  });
+
+  it("reads structured decision descriptors", () => {
+    const request = createRequest({
+      params: {
+        threadId: "thread-1",
+        requestId: "request-1",
+        decisions: [{ value: "allow" }, { value: "deny" }],
+      },
+    });
+
+    expect(buildPendingRequestResponse(request, "approve")).toEqual({
+      decision: "allow",
+    });
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -16,6 +16,7 @@ export * from "./messaging-contact-labels";
 export * from "./messaging-id-validation";
 export * from "./profile-names";
 export * from "./directory-pins";
+export * from "./pending-request-response";
 export * from "./thread-pins";
 export * from "./thread-titles";
 export * from "./worktree-paths";

--- a/packages/shared/src/pending-request-response.ts
+++ b/packages/shared/src/pending-request-response.ts
@@ -1,0 +1,84 @@
+import type { AppServerPendingRequestNotification } from "./contracts/normalized-app-server";
+
+export type PendingRequestDecision = "approve" | "decline" | "cancel";
+
+export function buildPendingRequestResponse(
+  request: AppServerPendingRequestNotification,
+  decision: PendingRequestDecision,
+): { decision: string } {
+  const availableDecision = selectAvailableDecision(request.params, decision);
+  if (availableDecision) {
+    return { decision: availableDecision };
+  }
+
+  if (request.method.includes("commandExecution/requestApproval")) {
+    return {
+      decision:
+        decision === "approve"
+          ? "accept"
+          : decision === "decline"
+            ? "decline"
+            : "cancel",
+    };
+  }
+
+  if (request.method.includes("fileChange/requestApproval")) {
+    return {
+      decision:
+        decision === "approve"
+          ? "accept"
+          : decision === "decline"
+            ? "decline"
+            : "cancel",
+    };
+  }
+
+  return { decision };
+}
+
+function selectAvailableDecision(
+  params: AppServerPendingRequestNotification["params"],
+  decision: PendingRequestDecision,
+): string | undefined {
+  const rawDecisions =
+    readDecisionStrings(params.availableDecisions) ?? readDecisionStrings(params.decisions);
+  if (!rawDecisions?.length) {
+    return undefined;
+  }
+
+  const acceptedAliases =
+    decision === "approve"
+      ? ["accept", "approve", "allow"]
+      : decision === "decline"
+        ? ["decline", "deny", "reject"]
+        : ["cancel", "abort", "stop"];
+
+  return rawDecisions.find((value) =>
+    acceptedAliases.some((alias) => value.toLowerCase().includes(alias)),
+  );
+}
+
+function readDecisionStrings(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  return value
+    .map((entry) => {
+      if (typeof entry === "string") {
+        return entry.trim();
+      }
+      if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+        return undefined;
+      }
+      const record = entry as Record<string, unknown>;
+      for (const key of ["decision", "value", "name", "id"]) {
+        const raw = record[key];
+        if (typeof raw === "string" && raw.trim()) {
+          return raw.trim();
+        }
+      }
+      return undefined;
+    })
+    .filter((entry): entry is string => Boolean(entry));
+}


### PR DESCRIPTION
## Summary
- add an `Approve` action to native desktop approval notifications on supported platforms
- resolve the existing pending server request from the notification path so approval clears the pending state through the normal `serverRequest/resolved` flow
- move pending-request response mapping into `@pwragent/shared` so the renderer and notification approval path use the same decision translation

## Testing
- `pnpm test apps/desktop/src/main/__tests__/desktop-notification-service.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts --testNamePattern "resolves a pending approval when the notification approve action fires|calls notifyAttention on turn/requestApproval with a backend:thread:request key"`
- manual replay-backed desktop verification on macOS: triggered a native approval notification and confirmed the notification `Approve` button resolves the pending approval

## Notes
- unsupported platforms keep the passive notification behavior with no action button
- macOS still focuses the app when the notification action is pressed; this PR only makes the action approve successfully

--------
[Compound Engineering](https://compound.engineering)