### PR TITLE
fix(desktop): discover Kimi Code at its default install path

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-local-discovery.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-local-discovery.test.ts
@@ -1,3 +1,4 @@
+import { homedir } from "node:os";
 import { describe, expect, it, vi } from "vitest";
 import { discoverLocalAcpAgents, type LocalAcpAgentProbe } from "../acp/acp-local-discovery";
 
@@ -91,6 +92,80 @@ describe("discoverLocalAcpAgents", () => {
         }),
       }),
     ]);
+  });
+
+  it("discovers Kimi at its default install path when not on $PATH", async () => {
+    const kimiInstallPath = `${homedir()}/.kimi-code/bin/kimi`;
+    const seen: string[] = [];
+    const probe = vi.fn<LocalAcpAgentProbe>(async (command, args) => {
+      seen.push(command);
+      // Simulate the GUI-launch case: bare `kimi` is NOT on PATH, but the
+      // installer's default location exists.
+      if (command !== kimiInstallPath) {
+        throw Object.assign(new Error("missing"), { code: "ENOENT" });
+      }
+      if (args[0] === "--version") {
+        return { stdout: "kimi, version 1.44.0\n" };
+      }
+      if (args[0] === "acp" && args[1] === "--help") {
+        return { stdout: "Usage: kimi acp [OPTIONS]\nRun Kimi Code CLI ACP server.\n" };
+      }
+      throw new Error("unexpected probe");
+    });
+
+    const result = await discoverLocalAcpAgents({ probe, now: () => 4242 });
+    expect(result).toEqual([
+      expect.objectContaining({
+        backendId: "acp:kimi",
+        registryId: "kimi",
+        distributionSource: `${kimiInstallPath} acp`,
+        launchDescriptor: expect.objectContaining({
+          command: kimiInstallPath,
+          args: ["acp"],
+        }),
+      }),
+    ]);
+    // Bare `kimi` is probed first (fast path), then the installer location.
+    const kimiProbes = seen.filter((command) =>
+      command === "kimi" || command.endsWith("/kimi"),
+    );
+    expect(kimiProbes[0]).toBe("kimi");
+    expect(kimiProbes).toContain(kimiInstallPath);
+  });
+
+  it("honors a Kimi CLI path override before probing $PATH", async () => {
+    const seen: string[] = [];
+    const probe = vi.fn<LocalAcpAgentProbe>(async (command, args) => {
+      seen.push(command);
+      if (command !== "/custom/kimi") {
+        throw Object.assign(new Error("missing"), { code: "ENOENT" });
+      }
+      if (args[0] === "--version") {
+        return { stdout: "kimi, version 1.44.0\n" };
+      }
+      if (args[0] === "acp" && args[1] === "--help") {
+        return { stdout: "Usage: kimi acp [OPTIONS]\nRun Kimi Code CLI ACP server.\n" };
+      }
+      throw new Error("unexpected probe");
+    });
+
+    const result = await discoverLocalAcpAgents({
+      probe,
+      now: () => 1,
+      overrides: { kimi: "/custom/kimi" },
+    });
+    expect(result).toEqual([
+      expect.objectContaining({
+        backendId: "acp:kimi",
+        launchDescriptor: expect.objectContaining({
+          command: "/custom/kimi",
+        }),
+      }),
+    ]);
+    const kimiProbes = seen.filter((command) =>
+      command === "/custom/kimi" || command === "kimi" || command.endsWith("/kimi"),
+    );
+    expect(kimiProbes[0]).toBe("/custom/kimi");
   });
 
   it("ignores missing local commands", async () => {

--- a/apps/desktop/src/main/acp/acp-local-discovery.ts
+++ b/apps/desktop/src/main/acp/acp-local-discovery.ts
@@ -29,6 +29,7 @@ export type LocalAcpDiscoveryOptions = {
   overrides?: {
     grok?: string;
     qwen?: string;
+    kimi?: string;
   };
 };
 
@@ -103,61 +104,64 @@ async function discoverLocalGemini(options?: {
   };
 }
 
-async function discoverLocalKimi(options?: {
-  probe?: LocalAcpAgentProbe;
-  now?: () => number;
-}): Promise<AcpInstalledAgentRecord | undefined> {
+async function discoverLocalKimi(
+  options?: LocalAcpDiscoveryOptions,
+): Promise<AcpInstalledAgentRecord | undefined> {
   const probe = options?.probe ?? defaultProbe;
-  const [versionResult, acpHelpResult] = await Promise.all([
-    probeCommand(probe, "kimi", ["--version"]),
-    probeCommand(probe, "kimi", ["acp", "--help"]),
-  ]);
-  if (!versionResult || !acpHelpResult) {
-    return undefined;
-  }
+  const candidates = kimiCandidatePaths(options?.overrides?.kimi);
+  for (const command of candidates) {
+    const [versionResult, acpHelpResult] = await Promise.all([
+      probeCommand(probe, command, ["--version"]),
+      probeCommand(probe, command, ["acp", "--help"]),
+    ]);
+    if (!versionResult || !acpHelpResult) {
+      continue;
+    }
 
-  const acpHelpText = resultText(acpHelpResult);
-  if (!/\bACP server\b/i.test(acpHelpText)) {
-    return undefined;
-  }
+    const acpHelpText = resultText(acpHelpResult);
+    if (!/\bACP server\b/i.test(acpHelpText)) {
+      continue;
+    }
 
-  const now = options?.now?.() ?? Date.now();
-  const backendId = "acp:kimi" as AcpBackendId;
-  const version = parseCliVersion(resultText(versionResult));
-  return {
-    backendId,
-    registryId: "kimi",
-    name: "Kimi Code CLI",
-    version,
-    distributionKind: "local",
-    distributionSource: "kimi acp",
-    installStatus: "installed",
-    authStatus: "not-required",
-    verificationStatus: "not-applicable",
-    allowlistRuleId: "local-kimi-cli",
-    installedAt: now,
-    updatedAt: now,
-    capabilities: acpAgentCapabilitiesForRegistryId("kimi"),
-    launchDescriptor: normalizeAcpLaunchDescriptor({
+    const now = options?.now?.() ?? Date.now();
+    const backendId = "acp:kimi" as AcpBackendId;
+    const version = parseCliVersion(resultText(versionResult));
+    return {
       backendId,
       registryId: "kimi",
-      distributionKind: "local",
-      command: "kimi",
-      args: ["acp"],
-      env: {},
-    }),
-    registryAgent: {
-      id: "kimi",
-      backendId,
       name: "Kimi Code CLI",
       version,
-      authors: ["Moonshot AI"],
-      distributions: [],
-      distributionKinds: ["local"],
-      auth: { required: false, methods: ["agent-managed"] },
-      raw: { source: "local-cli" },
-    },
-  };
+      distributionKind: "local",
+      distributionSource: `${command} acp`,
+      installStatus: "installed",
+      authStatus: "not-required",
+      verificationStatus: "not-applicable",
+      allowlistRuleId: "local-kimi-cli",
+      installedAt: now,
+      updatedAt: now,
+      capabilities: acpAgentCapabilitiesForRegistryId("kimi"),
+      launchDescriptor: normalizeAcpLaunchDescriptor({
+        backendId,
+        registryId: "kimi",
+        distributionKind: "local",
+        command,
+        args: ["acp"],
+        env: {},
+      }),
+      registryAgent: {
+        id: "kimi",
+        backendId,
+        name: "Kimi Code CLI",
+        version,
+        authors: ["Moonshot AI"],
+        distributions: [],
+        distributionKinds: ["local"],
+        auth: { required: false, methods: ["agent-managed"] },
+        raw: { source: "local-cli" },
+      },
+    };
+  }
+  return undefined;
 }
 
 async function discoverLocalGrok(
@@ -318,6 +322,29 @@ function qwenCandidatePaths(override?: string): string[] {
   candidates.push(path.join(homedir(), ".qwen", "bin", "qwen"));
   candidates.push("/opt/homebrew/bin/qwen");
   candidates.push("/usr/local/bin/qwen");
+  return Array.from(new Set(candidates));
+}
+
+/**
+ * Build the ordered list of Kimi Code CLI candidate paths to probe.
+ *
+ * Kimi Code's official installer drops the binary at
+ * `~/.kimi-code/bin/kimi` and appends that directory to the user's shell
+ * PATH. GUI-launched apps don't always inherit that interactive PATH, so —
+ * mirroring {@link grokCandidatePaths} / {@link qwenCandidatePaths} — we
+ * probe the bare `kimi` command first (fast path when it IS on PATH), then
+ * the installer's default location, then the standard Homebrew prefixes.
+ * The same trust model documented on {@link grokCandidatePaths} applies.
+ */
+function kimiCandidatePaths(override?: string): string[] {
+  const candidates: string[] = [];
+  if (override && override.trim().length > 0) {
+    candidates.push(override.trim());
+  }
+  candidates.push("kimi");
+  candidates.push(path.join(homedir(), ".kimi-code", "bin", "kimi"));
+  candidates.push("/opt/homebrew/bin/kimi");
+  candidates.push("/usr/local/bin/kimi");
   return Array.from(new Set(candidates));
 }
 


### PR DESCRIPTION
## Problem

Right after installing **Kimi Code**, a discovery refresh didn't find it. Its official macOS installer puts the binary at `~/.kimi-code/bin/kimi` and appends that dir to the shell PATH — but **GUI-launched apps don't reliably inherit the interactive PATH**, so probing only the bare `kimi` command misses an otherwise-installed Kimi.

## Why Kimi specifically

Grok and Qwen already probe known install locations (`grokCandidatePaths` / `qwenCandidatePaths` → `~/.grok/bin`, `~/.qwen/bin`, Homebrew prefixes). **Kimi only probed the bare `kimi` command** — it was the odd one out.

## Fix

Give Kimi the same candidate-path treatment in `acp-local-discovery.ts` (in-tree; ACP discovery is not part of the agent-kit migration):

1. bare `kimi` (fast path when it IS on PATH)
2. `~/.kimi-code/bin/kimi` (installer default)
3. `/opt/homebrew/bin/kimi`, `/usr/local/bin/kimi`

The discovered command flows into the launch descriptor + `distributionSource`, so a Kimi found off-PATH is also **launchable**, not just detectable. Adds an optional `kimi` override to `LocalAcpDiscoveryOptions` for parity with grok/qwen.

## Tests

- New: discovers Kimi at `~/.kimi-code/bin/kimi` when bare `kimi` is ENOENT (the GUI-launch case), asserting probe order (bare first) + the resolved launch command.
- New: honors an explicit `kimi` path override before `$PATH`.
- `acp-local-discovery` suite **13/13**; `@pwragent/desktop` typecheck clean.

## Follow-up (not in this PR)

Full parity would add a Settings **"Kimi CLI path"** field + `PWRAGENT_ACP_AGENTS_KIMI_CLI_PATH` env override (grok/qwen have these). That's a larger Settings change and fits the staged ACP Settings-parity work — flagged, not bundled here. Gemini has the same bare-command-only gap and could get the same treatment if a non-PATH install location surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)