### PR TITLE
fix(release): make larksuite axios-range shim version-agnostic

### DIFF
--- a/apps/desktop/scripts/release.mjs
+++ b/apps/desktop/scripts/release.mjs
@@ -177,29 +177,50 @@ function publishLinuxArtifacts(distDir) {
 
 function patchStageDependencyManifests() {
   // pnpm overrides can intentionally install a newer dependency than a
-  // package's own manifest range. electron-builder's Linux dependency walker
-  // validates the deployed manifests before packaging, so keep the disposable
-  // release-stage metadata aligned with the tree pnpm deployed.
-  const feishuSdkPackage = join(
-    stageDir,
-    "node_modules",
-    ".pnpm",
-    "@larksuiteoapi+node-sdk@1.63.1",
-    "node_modules",
-    "@larksuiteoapi",
-    "node-sdk",
-    "package.json",
-  );
-  if (!existsSync(feishuSdkPackage)) {
+  // package's own manifest range (here: axios, pinned newer than
+  // @larksuiteoapi/node-sdk's tilde range). electron-builder's dependency
+  // walker validates the deployed manifests before packaging, so keep the
+  // disposable release-stage metadata aligned with the tree pnpm deployed.
+  //
+  // Version-agnostic on purpose: this used to hardcode
+  // `@larksuiteoapi+node-sdk@<version>`, which silently skipped the patch
+  // every time the SDK bumped (the dir no longer existed), reintroducing the
+  // "Production dependency axios not found" packaging failure. Glob the SDK
+  // dir and align its axios range to whatever pnpm actually deployed.
+  const pnpmDir = join(stageDir, "node_modules", ".pnpm");
+  if (!existsSync(pnpmDir)) {
     return;
   }
-  const packageJson = JSON.parse(readFileSync(feishuSdkPackage, "utf8"));
-  if (packageJson.dependencies?.axios !== "~1.13.3") {
+  const entries = readdirSync(pnpmDir);
+  const axiosDir = entries.find((name) => /^axios@\d/.test(name));
+  const deployedAxios = axiosDir ? axiosDir.slice("axios@".length) : undefined;
+  if (!deployedAxios) {
     return;
   }
-  packageJson.dependencies.axios = "^1.16.0";
-  writeFileSync(feishuSdkPackage, `${JSON.stringify(packageJson, null, 2)}\n`);
-  console.log("  patched @larksuiteoapi/node-sdk axios range for release-stage dependency collection");
+  const desiredAxiosRange = `^${deployedAxios}`;
+  for (const sdkDir of entries.filter((name) => /^@larksuiteoapi\+node-sdk@/.test(name))) {
+    const manifestPath = join(
+      pnpmDir,
+      sdkDir,
+      "node_modules",
+      "@larksuiteoapi",
+      "node-sdk",
+      "package.json",
+    );
+    if (!existsSync(manifestPath)) {
+      continue;
+    }
+    const packageJson = JSON.parse(readFileSync(manifestPath, "utf8"));
+    const currentRange = packageJson.dependencies?.axios;
+    if (!currentRange || currentRange === desiredAxiosRange) {
+      continue;
+    }
+    packageJson.dependencies.axios = desiredAxiosRange;
+    writeFileSync(manifestPath, `${JSON.stringify(packageJson, null, 2)}\n`);
+    console.log(
+      `  patched ${sdkDir} axios range ${currentRange} -> ${desiredAxiosRange} for release-stage dependency collection`,
+    );
+  }
 }
 
 // 1. Decode CI-provided Apple API key (if present) to a real .p8 file.


### PR DESCRIPTION
## Problem

`pnpm --filter @pwragent/desktop package:dryrun` (and the signed `package` / release flows) abort during electron-builder packaging with:

```
⨯ Production dependency axios not found for package @larksuiteoapi/node-sdk  version=~1.13.3
```

### Root cause

`patchStageDependencyManifests()` in `apps/desktop/scripts/release.mjs` exists to reconcile a known mismatch: a pnpm override deploys **axios 1.16.x**, but `@larksuiteoapi/node-sdk`'s own manifest pins `axios: ~1.13.3`. electron-builder's dependency walker validates deployed manifests and fails because `1.16.x` doesn't satisfy `~1.13.3`.

The shim was guarded by a **hardcoded path** — `@larksuiteoapi+node-sdk@1.63.1`. The SDK has since bumped to **1.66.0**, so `existsSync()` returned false, the shim **silently skipped**, and the stale range reached electron-builder. By construction this re-breaks on *every* SDK version bump.

## Fix

Make the shim version-agnostic:
- **Glob** `@larksuiteoapi+node-sdk@*` in the deployed `.pnpm` store instead of pinning a version.
- Read the axios version pnpm **actually deployed** (`axios@*` in the store).
- Rewrite the SDK manifest's axios range to `^<deployed>` (skip if already correct), logging each patch.

No more silent skips on SDK bumps; the range always tracks what's deployed.

## Verification

Clean `package:dryrun` universal build end-to-end:
```
patched @larksuiteoapi+node-sdk@1.66.0 axios range ~1.13.3 -> ^1.16.1 for release-stage dependency collection
...
verify-asar-contents: OK (6452 entries, no forbidden patterns)
→ done
```
Produces a valid ad-hoc-signed universal (`x86_64 arm64`) `PwrAgent.app`. `node --check` passes.

## Notes

Pre-existing release-tooling bug, independent of the agent-kit migration — surfaced while producing a local packaged build. Same code path is used by the Linux `.deb` flow (the original comment referenced the Linux walker), so this also de-risks that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)