### PR TITLE
feat(desktop): durable ACP capability cache — stop launching agents on every settings open

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-capability-freshness.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-capability-freshness.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import {
+  ACP_CAPABILITY_MAX_AGE_MS,
+  shouldReprobeAcpCapabilities,
+} from "../acp/acp-capability-freshness";
+import type { AcpInstalledAgentRecord } from "../acp/acp-registry-types";
+
+const NOW = 1_000_000_000_000;
+
+function record(
+  overrides: Partial<AcpInstalledAgentRecord> = {},
+): AcpInstalledAgentRecord {
+  return {
+    backendId: "acp:grok",
+    registryId: "grok",
+    name: "Grok",
+    version: "0.2.3",
+    distributionKind: "local",
+    installStatus: "installed",
+    authStatus: "not-required",
+    verificationStatus: "not-applicable",
+    installedAt: NOW - 10_000,
+    updatedAt: NOW - 10_000,
+    // A cached, fresh capability probe by default.
+    runtimeCapabilities: { discoveredAt: NOW } as never,
+    lastDiscoveredAt: NOW,
+    ...overrides,
+  } as AcpInstalledAgentRecord;
+}
+
+describe("shouldReprobeAcpCapabilities", () => {
+  it("reuses cache for a fresh, version-matched record", () => {
+    expect(shouldReprobeAcpCapabilities(record(), "0.2.3", NOW)).toBe(false);
+  });
+
+  it("probes when forced, even if cache is fresh", () => {
+    expect(
+      shouldReprobeAcpCapabilities(record(), "0.2.3", NOW, { force: true }),
+    ).toBe(true);
+  });
+
+  it("probes an undiscovered agent (no cached record)", () => {
+    expect(shouldReprobeAcpCapabilities(undefined, "0.2.3", NOW)).toBe(true);
+  });
+
+  it("probes when the record has no runtime capabilities yet", () => {
+    expect(
+      shouldReprobeAcpCapabilities(
+        record({ runtimeCapabilities: undefined }),
+        "0.2.3",
+        NOW,
+      ),
+    ).toBe(true);
+  });
+
+  it("probes when never timestamped", () => {
+    expect(
+      shouldReprobeAcpCapabilities(
+        record({ lastDiscoveredAt: undefined }),
+        "0.2.3",
+        NOW,
+      ),
+    ).toBe(true);
+  });
+
+  it("probes when the CLI version changed since the last probe", () => {
+    expect(
+      shouldReprobeAcpCapabilities(record({ version: "0.2.3" }), "0.3.0", NOW),
+    ).toBe(true);
+  });
+
+  it("does not treat an unknown discovered version as a change", () => {
+    expect(
+      shouldReprobeAcpCapabilities(record({ version: "0.2.3" }), undefined, NOW),
+    ).toBe(false);
+  });
+
+  it("probes when the cached probe is older than the freshness window", () => {
+    const stale = record({ lastDiscoveredAt: NOW - ACP_CAPABILITY_MAX_AGE_MS - 1 });
+    expect(shouldReprobeAcpCapabilities(stale, "0.2.3", NOW)).toBe(true);
+  });
+
+  it("keeps using cache right at the freshness boundary", () => {
+    const edge = record({ lastDiscoveredAt: NOW - ACP_CAPABILITY_MAX_AGE_MS });
+    expect(shouldReprobeAcpCapabilities(edge, "0.2.3", NOW)).toBe(false);
+  });
+
+  it("honors a custom maxAgeMs", () => {
+    const rec = record({ lastDiscoveredAt: NOW - 5_000 });
+    expect(shouldReprobeAcpCapabilities(rec, "0.2.3", NOW, { maxAgeMs: 1_000 })).toBe(
+      true,
+    );
+    expect(shouldReprobeAcpCapabilities(rec, "0.2.3", NOW, { maxAgeMs: 10_000 })).toBe(
+      false,
+    );
+  });
+});

--- a/apps/desktop/src/main/__tests__/settings-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-ipc.test.ts
@@ -951,6 +951,79 @@ describe("settings ipc", () => {
     }
   });
 
+  it("coalesces concurrent forced ACP refreshes onto one probe pass", async () => {
+    const tempRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "pwragent-settings-ipc-"),
+    );
+    tempRoots.push(tempRoot);
+    vi.stubEnv("PWRAGENT_HOME", tempRoot);
+    localAcpDiscoveryMock.discoverLocalAcpAgents.mockResolvedValue([
+      {
+        backendId: "acp:gemini",
+        registryId: "gemini",
+        name: "Gemini CLI",
+        version: "0.42.0",
+        distributionKind: "local",
+        distributionSource: "gemini --acp --skip-trust",
+        installStatus: "installed",
+        authStatus: "not-required",
+        verificationStatus: "not-applicable",
+        allowlistRuleId: "local-gemini-cli",
+        installedAt: 1234,
+        updatedAt: 1234,
+        launchDescriptor: {
+          backendId: "acp:gemini",
+          registryId: "gemini",
+          distributionKind: "local",
+          command: "gemini",
+          args: ["--acp", "--skip-trust"],
+          env: {},
+        },
+      },
+    ]);
+    const probedAt = Date.now();
+    acpRuntimeDiscoveryMock.discoverAcpRuntimeCapabilities.mockResolvedValue({
+      runtimeCapabilities: {
+        schemaVersion: 1,
+        status: "discovered",
+        discoveredAt: probedAt,
+        checkedAt: probedAt,
+        source: "session-new",
+        configOptions: [],
+      },
+    });
+    const { initializeAppState, disposeAppState } = await import(
+      "../state/app-state"
+    );
+    const { registerSettingsIpcHandlers } = await import("../ipc/settings");
+    const { ACP_AGENTS_LIST_CHANNEL } = await import("../../shared/ipc");
+    const service = new DesktopSettingsService({
+      configPath: path.join(tempRoot, "config.toml"),
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+      now: () => 20,
+    });
+
+    initializeAppState();
+    try {
+      registerSettingsIpcHandlers(service);
+      const probe = acpRuntimeDiscoveryMock.discoverAcpRuntimeCapabilities;
+      const handler = handlers.get(ACP_AGENTS_LIST_CHANNEL);
+
+      // Two rapid "Discover new" clicks fire before the first pass resolves.
+      // Both are forced, so freshness can't gate the second — only the
+      // in-flight coalescing keeps them from launching the agent twice in
+      // parallel. The second must ride the first's forced pass: one probe.
+      await Promise.all([
+        handler?.({}, { refresh: true, force: true }),
+        handler?.({}, { refresh: true, force: true }),
+      ]);
+      expect(probe).toHaveBeenCalledTimes(1);
+    } finally {
+      disposeAppState();
+    }
+  });
+
   // The wizard PR (#491) calls this IPC the moment the operator picks
   // a Codex profile model. The handler must (1) persist the wizard
   // signal idempotently, (2) fire the same thread-list prefetch the

--- a/apps/desktop/src/main/__tests__/settings-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-ipc.test.ts
@@ -871,6 +871,86 @@ describe("settings ipc", () => {
     }
   });
 
+  it("reuses cached ACP capabilities across refreshes and re-probes only when forced", async () => {
+    const tempRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "pwragent-settings-ipc-"),
+    );
+    tempRoots.push(tempRoot);
+    vi.stubEnv("PWRAGENT_HOME", tempRoot);
+    localAcpDiscoveryMock.discoverLocalAcpAgents.mockResolvedValue([
+      {
+        backendId: "acp:gemini",
+        registryId: "gemini",
+        name: "Gemini CLI",
+        version: "0.42.0",
+        distributionKind: "local",
+        distributionSource: "gemini --acp --skip-trust",
+        installStatus: "installed",
+        authStatus: "not-required",
+        verificationStatus: "not-applicable",
+        allowlistRuleId: "local-gemini-cli",
+        installedAt: 1234,
+        updatedAt: 1234,
+        launchDescriptor: {
+          backendId: "acp:gemini",
+          registryId: "gemini",
+          distributionKind: "local",
+          command: "gemini",
+          args: ["--acp", "--skip-trust"],
+          env: {},
+        },
+      },
+    ]);
+    // A recent probe timestamp so the persisted capabilities stay "fresh"
+    // across the subsequent refreshes within this test.
+    const probedAt = Date.now();
+    acpRuntimeDiscoveryMock.discoverAcpRuntimeCapabilities.mockResolvedValue({
+      runtimeCapabilities: {
+        schemaVersion: 1,
+        status: "discovered",
+        discoveredAt: probedAt,
+        checkedAt: probedAt,
+        source: "session-new",
+        configOptions: [],
+      },
+    });
+    const { initializeAppState, disposeAppState } = await import(
+      "../state/app-state"
+    );
+    const { registerSettingsIpcHandlers } = await import("../ipc/settings");
+    const { ACP_AGENTS_LIST_CHANNEL } = await import("../../shared/ipc");
+    const service = new DesktopSettingsService({
+      configPath: path.join(tempRoot, "config.toml"),
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+      now: () => 20,
+    });
+
+    initializeAppState();
+    try {
+      registerSettingsIpcHandlers(service);
+      const probe =
+        acpRuntimeDiscoveryMock.discoverAcpRuntimeCapabilities;
+
+      // First refresh: the agent is undiscovered → it must be probed once.
+      await handlers.get(ACP_AGENTS_LIST_CHANNEL)?.({}, { refresh: true });
+      expect(probe).toHaveBeenCalledTimes(1);
+
+      // Second refresh: cached capabilities are fresh + version-matched → the
+      // expensive probe must be skipped (no new launch).
+      await handlers.get(ACP_AGENTS_LIST_CHANNEL)?.({}, { refresh: true });
+      expect(probe).toHaveBeenCalledTimes(1);
+
+      // Forced refresh ("Discover new"): re-probe regardless of freshness.
+      await handlers
+        .get(ACP_AGENTS_LIST_CHANNEL)
+        ?.({}, { refresh: true, force: true });
+      expect(probe).toHaveBeenCalledTimes(2);
+    } finally {
+      disposeAppState();
+    }
+  });
+
   // The wizard PR (#491) calls this IPC the moment the operator picks
   // a Codex profile model. The handler must (1) persist the wizard
   // signal idempotently, (2) fire the same thread-list prefetch the

--- a/apps/desktop/src/main/acp/acp-capability-freshness.ts
+++ b/apps/desktop/src/main/acp/acp-capability-freshness.ts
@@ -1,0 +1,57 @@
+import type { AcpInstalledAgentRecord } from "./acp-registry-types.js";
+
+/**
+ * How long a persisted ACP runtime-capability probe stays "fresh" before a
+ * refresh will re-launch the agent to re-probe it. Capabilities (model lists,
+ * supported modes) change rarely, and each probe spawns a real agent process
+ * over ACP — so we cache aggressively and only re-probe every couple of days.
+ */
+export const ACP_CAPABILITY_MAX_AGE_MS = 48 * 60 * 60 * 1000; // 48 hours
+
+/**
+ * Decide whether a discovered ACP agent needs its (expensive) runtime
+ * capabilities re-probed, or whether the persisted capabilities can be reused.
+ *
+ * The expensive probe (`discoverAcpRuntimeCapabilities`) launches the agent
+ * over ACP. We avoid it whenever we already hold a fresh, version-matched
+ * result. A re-probe is warranted when:
+ *
+ *  - `force` is requested (the "Discover new" button), OR
+ *  - the agent has never been probed (no persisted capabilities / timestamp), OR
+ *  - the installed CLI version changed since the last probe (capabilities may
+ *    have changed), OR
+ *  - the persisted probe is older than `maxAgeMs`.
+ *
+ * @param cached            The currently-persisted record for this agent, if any.
+ * @param discoveredVersion The CLI version from the latest cheap local discovery.
+ * @param now               Current epoch millis (injectable for tests).
+ */
+export function shouldReprobeAcpCapabilities(
+  cached: AcpInstalledAgentRecord | undefined,
+  discoveredVersion: string | undefined,
+  now: number,
+  options?: { force?: boolean; maxAgeMs?: number },
+): boolean {
+  if (options?.force === true) {
+    return true;
+  }
+  // Never probed, or a prior probe produced no capabilities.
+  if (
+    cached === undefined ||
+    cached.runtimeCapabilities === undefined ||
+    cached.lastDiscoveredAt === undefined
+  ) {
+    return true;
+  }
+  // CLI upgraded/downgraded since the last probe → capabilities may differ.
+  if (
+    discoveredVersion !== undefined &&
+    cached.version !== undefined &&
+    discoveredVersion !== cached.version
+  ) {
+    return true;
+  }
+  // Stale.
+  const maxAgeMs = options?.maxAgeMs ?? ACP_CAPABILITY_MAX_AGE_MS;
+  return now - cached.lastDiscoveredAt > maxAgeMs;
+}

--- a/apps/desktop/src/main/acp/acp-capability-freshness.ts
+++ b/apps/desktop/src/main/acp/acp-capability-freshness.ts
@@ -17,7 +17,10 @@ export const ACP_CAPABILITY_MAX_AGE_MS = 48 * 60 * 60 * 1000; // 48 hours
  * result. A re-probe is warranted when:
  *
  *  - `force` is requested (the "Discover new" button), OR
- *  - the agent has never been probed (no persisted capabilities / timestamp), OR
+ *  - the agent has never been probed (no persisted timestamp), OR
+ *  - a prior probe completed but produced no capabilities — treated as a
+ *    degraded/transient result on purpose, so the agent self-heals on the next
+ *    refresh instead of caching an empty capability set for `maxAgeMs`, OR
  *  - the installed CLI version changed since the last probe (capabilities may
  *    have changed), OR
  *  - the persisted probe is older than `maxAgeMs`.
@@ -35,7 +38,10 @@ export function shouldReprobeAcpCapabilities(
   if (options?.force === true) {
     return true;
   }
-  // Never probed, or a prior probe produced no capabilities.
+  // Never probed, or a probe that completed but yielded no capabilities. The
+  // latter is re-probed on purpose (degraded/transient self-heal) rather than
+  // cached — see the doc comment above. Probe *errors* don't set
+  // `lastDiscoveredAt`, so they fall under "never probed" and also re-probe.
   if (
     cached === undefined ||
     cached.runtimeCapabilities === undefined ||

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -79,6 +79,7 @@ import { AcpAgentStore } from "../acp/acp-agent-store";
 import { isBannedAcpRegistryId } from "../acp/acp-agent-allowlist";
 import { discoverLocalAcpAgents } from "../acp/acp-local-discovery";
 import { discoverAcpRuntimeCapabilities } from "../acp/acp-runtime-discovery";
+import { shouldReprobeAcpCapabilities } from "../acp/acp-capability-freshness";
 import { describeDistributionSource } from "../acp/acp-install-provenance";
 import { selectAcpDistributionForCurrentPlatform } from "../acp/acp-platform-distribution";
 import { AcpRegistryService } from "../acp/acp-registry-service";
@@ -114,7 +115,33 @@ async function refreshModelBackendsIfNeeded(params: {
   }
 }
 
+// Coalesces concurrent ACP refreshes. A refresh runs cheap local discovery and
+// may launch agents to probe capabilities; React StrictMode double-fires the
+// settings-pane mount effect (dev) and users can double-click "Discover new",
+// so without this two passes would launch the same agents in parallel. Pure
+// cache reads (refresh === false) never launch and are not coalesced. A forced
+// refresh always runs its own pass so "Discover new" is never a no-op.
+let inFlightAcpRefresh: Promise<ListAcpAgentSettingsResponse> | undefined;
+
 async function listAcpAgentSettings(
+  request: ListAcpAgentSettingsRequest = {},
+): Promise<ListAcpAgentSettingsResponse> {
+  if (request.refresh === false) {
+    return await listAcpAgentSettingsImpl(request);
+  }
+  if (request.force !== true && inFlightAcpRefresh) {
+    return await inFlightAcpRefresh;
+  }
+  const run = listAcpAgentSettingsImpl(request).finally(() => {
+    if (inFlightAcpRefresh === run) {
+      inFlightAcpRefresh = undefined;
+    }
+  });
+  inFlightAcpRefresh = run;
+  return await run;
+}
+
+async function listAcpAgentSettingsImpl(
   request: ListAcpAgentSettingsRequest = {},
 ): Promise<ListAcpAgentSettingsResponse> {
   const store = new AcpAgentStore(getAppStateDb());
@@ -134,6 +161,7 @@ async function listAcpAgentSettings(
   snapshot ??= store.readRegistrySnapshot();
   const installed = await listInstalledAndLocalAcpAgents(store, {
     refreshLocal: request.refresh === true,
+    ...(request.force === true ? { force: true } : {}),
   });
   const entries = snapshot
     ? registryService
@@ -164,7 +192,7 @@ async function listAcpAgentSettings(
 
 async function listInstalledAndLocalAcpAgents(
   store: AcpAgentStore,
-  options?: { refreshLocal?: boolean },
+  options?: { refreshLocal?: boolean; force?: boolean },
 ): Promise<AcpInstalledAgentRecord[]> {
   const installed = store.listInstalledAgents();
   let discovered: AcpInstalledAgentRecord[] = [];
@@ -182,6 +210,7 @@ async function listInstalledAndLocalAcpAgents(
             : undefined,
       });
       const discoveryCwd = await ensureAcpRuntimeDiscoveryWorkspace();
+      const now = Date.now();
       for (const record of discovered) {
         const current = store.getInstalledAgent(record.backendId);
         const nextRecord = {
@@ -192,9 +221,23 @@ async function listInstalledAndLocalAcpAgents(
           installedAt: current?.installedAt ?? record.installedAt,
           updatedAt: Math.max(current?.updatedAt ?? 0, record.updatedAt),
         } satisfies AcpInstalledAgentRecord;
-        store.upsertInstalledAgent(
-          await refreshAcpRuntimeCapabilities(nextRecord, discoveryCwd),
-        );
+        // Cheap local discovery (above) always runs to find newly-installed
+        // agents and refresh version metadata. The EXPENSIVE runtime-capability
+        // probe launches the agent over ACP, so gate it: only re-probe agents
+        // that are undiscovered, stale, or version-changed (or when forced).
+        // Otherwise persist the merged record carrying the cached capabilities
+        // without launching anything.
+        if (
+          shouldReprobeAcpCapabilities(current, record.version, now, {
+            ...(options.force === true ? { force: true } : {}),
+          })
+        ) {
+          store.upsertInstalledAgent(
+            await refreshAcpRuntimeCapabilities(nextRecord, discoveryCwd),
+          );
+        } else {
+          store.upsertInstalledAgent(nextRecord);
+        }
       }
     } catch (error) {
       settingsIpcLog.debug("local_acp_discovery_failed", {

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -119,9 +119,18 @@ async function refreshModelBackendsIfNeeded(params: {
 // may launch agents to probe capabilities; React StrictMode double-fires the
 // settings-pane mount effect (dev) and users can double-click "Discover new",
 // so without this two passes would launch the same agents in parallel. Pure
-// cache reads (refresh === false) never launch and are not coalesced. A forced
-// refresh always runs its own pass so "Discover new" is never a no-op.
+// cache reads (refresh === false) never launch and are not coalesced.
+//
+// We track whether the in-flight pass was forced so a caller only rides a pass
+// that satisfies it: a non-forced caller can ride any in-flight pass, but a
+// forced caller ("Discover new") only rides an in-flight *forced* pass —
+// otherwise it would silently inherit a freshness-gated pass that skipped the
+// re-probe it asked for. This is what stops two rapid "Discover new" clicks
+// from launching every agent twice in parallel. A forced caller that arrives
+// while only a non-forced pass is in flight still starts its own pass, so
+// "Discover new" is never a no-op.
 let inFlightAcpRefresh: Promise<ListAcpAgentSettingsResponse> | undefined;
+let inFlightAcpRefreshForced = false;
 
 async function listAcpAgentSettings(
   request: ListAcpAgentSettingsRequest = {},
@@ -129,15 +138,18 @@ async function listAcpAgentSettings(
   if (request.refresh === false) {
     return await listAcpAgentSettingsImpl(request);
   }
-  if (request.force !== true && inFlightAcpRefresh) {
+  const wantsForce = request.force === true;
+  if (inFlightAcpRefresh && (!wantsForce || inFlightAcpRefreshForced)) {
     return await inFlightAcpRefresh;
   }
   const run = listAcpAgentSettingsImpl(request).finally(() => {
     if (inFlightAcpRefresh === run) {
       inFlightAcpRefresh = undefined;
+      inFlightAcpRefreshForced = false;
     }
   });
   inFlightAcpRefresh = run;
+  inFlightAcpRefreshForced = wantsForce;
   return await run;
 }
 
@@ -229,7 +241,7 @@ async function listInstalledAndLocalAcpAgents(
         // without launching anything.
         if (
           shouldReprobeAcpCapabilities(current, record.version, now, {
-            ...(options.force === true ? { force: true } : {}),
+            ...(options?.force === true ? { force: true } : {}),
           })
         ) {
           store.upsertInstalledAgent(

--- a/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
@@ -78,6 +78,16 @@ export function AcpAgentsSettings(props: {
     if (didInitialLoad.current) {
       return;
     }
+    // Don't latch until the preload bridge is actually available. useDesktopApi
+    // resolves the API asynchronously (polling undefined → defined), so this
+    // pane can mount before it's ready. If we latched now we'd stick on the
+    // "unavailable" error forever even after the API arrives. Instead surface
+    // that state without latching and let the effect re-run (dep:
+    // props.desktopApi) to do the real load once the API is present.
+    if (!props.desktopApi?.listAcpAgents) {
+      void refresh(false);
+      return;
+    }
     didInitialLoad.current = true;
     void refresh(false).then(() => refresh(true));
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type {
   AcpAgentSettingsEntry,
   DesktopSettingsSnapshot,
@@ -39,7 +39,10 @@ export function AcpAgentsSettings(props: {
     setQwenCliPathDraft(qwenCliPathSnapshot?.value ?? "");
   }, [qwenCliPathSnapshot?.value]);
 
-  async function refresh(refreshRegistry = false): Promise<void> {
+  async function refresh(
+    refreshRegistry = false,
+    force = false,
+  ): Promise<void> {
     if (!props.desktopApi?.listAcpAgents) {
       setError("ACP registry controls are unavailable in this build.");
       setLoading(false);
@@ -53,6 +56,7 @@ export function AcpAgentsSettings(props: {
     try {
       const response = await props.desktopApi.listAcpAgents({
         refresh: refreshRegistry,
+        ...(force ? { force: true } : {}),
       });
       setEntries(response.entries);
       setError(response.error);
@@ -64,7 +68,17 @@ export function AcpAgentsSettings(props: {
     }
   }
 
+  // Run the initial load exactly once. The mount renders cached agents
+  // immediately (refresh(false), a pure cache read — no agent launches), then
+  // does a registry refresh that only probes undiscovered/stale agents. The
+  // ref guards against React StrictMode double-invoking this effect in dev
+  // (the main process also coalesces concurrent refreshes as a backstop).
+  const didInitialLoad = useRef(false);
   useEffect(() => {
+    if (didInitialLoad.current) {
+      return;
+    }
+    didInitialLoad.current = true;
     void refresh(false).then(() => refresh(true));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.desktopApi]);
@@ -200,7 +214,9 @@ export function AcpAgentsSettings(props: {
             disabled={loading || refreshing}
             type="button"
             onClick={() => {
-              void refresh(true);
+              // Explicit user action: force a re-probe of every agent,
+              // bypassing the freshness cache.
+              void refresh(true, true);
             }}
           >
             {refreshing ? "Discovering..." : "Discover new"}

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/acp-agents-settings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/acp-agents-settings.test.tsx
@@ -1,4 +1,5 @@
 import "@testing-library/jest-dom/vitest";
+import { StrictMode } from "react";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AcpAgentSettingsEntry } from "@pwragent/shared";
@@ -9,6 +10,23 @@ afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
 });
+
+function geminiEntry(): AcpAgentSettingsEntry {
+  return {
+    backendId: "acp:gemini",
+    registryId: "gemini",
+    name: "Gemini CLI",
+    version: "0.42.0",
+    authors: [],
+    distributionKind: "local",
+    distributionSource: "gemini --acp --skip-trust",
+    installable: false,
+    installed: true,
+    installStatus: "installed",
+    authStatus: "not-required",
+    verificationStatus: "not-applicable",
+  } satisfies AcpAgentSettingsEntry;
+}
 
 describe("AcpAgentsSettings", () => {
   it("keeps cached ACP agents visible while background discovery refreshes", async () => {
@@ -119,5 +137,63 @@ describe("AcpAgentsSettings", () => {
     expect(screen.getByText("Apache-2.0")).toBeInTheDocument();
     expect(screen.getByText(/@google\/gemini-cli/)).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /install/i })).not.toBeInTheDocument();
+  });
+
+  it("loads exactly once under StrictMode's double-invoked mount effect", async () => {
+    const listAcpAgents = vi.fn(
+      async (_request?: { refresh?: boolean; force?: boolean }) => ({
+        fetchedAt: 1000,
+        entries: [geminiEntry()],
+      }),
+    );
+
+    render(
+      <StrictMode>
+        <AcpAgentsSettings desktopApi={{ listAcpAgents } as DesktopApi} />
+      </StrictMode>,
+    );
+
+    expect(await screen.findByText("Gemini CLI")).toBeInTheDocument();
+    // StrictMode runs the mount effect twice in dev; the did-initial-load ref
+    // must collapse that into a single gated registry refresh (one
+    // refresh: true), not two parallel discovery passes that storm the agents.
+    await waitFor(() => {
+      expect(
+        listAcpAgents.mock.calls.filter((call) => call[0]?.refresh === true),
+      ).toHaveLength(1);
+    });
+  });
+
+  it("loads once the desktop API bridge becomes available after mount", async () => {
+    const listAcpAgents = vi.fn(
+      async (_request?: { refresh?: boolean; force?: boolean }) => ({
+        fetchedAt: 1000,
+        entries: [geminiEntry()],
+      }),
+    );
+
+    // useDesktopApi resolves the bridge asynchronously, so this pane can mount
+    // with `desktopApi` still undefined. It should surface the unavailable
+    // state without latching the initial-load ref.
+    const { rerender } = render(<AcpAgentsSettings desktopApi={undefined} />);
+    expect(
+      await screen.findByText(
+        "ACP registry controls are unavailable in this build.",
+      ),
+    ).toBeInTheDocument();
+    expect(listAcpAgents).not.toHaveBeenCalled();
+
+    // When the bridge arrives the effect must re-run and load — not stay stuck
+    // on the unavailable error (the regression the un-latched guard prevents).
+    rerender(<AcpAgentsSettings desktopApi={{ listAcpAgents } as DesktopApi} />);
+    expect(await screen.findByText("Gemini CLI")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(listAcpAgents).toHaveBeenCalledWith({ refresh: true });
+    });
+    expect(
+      screen.queryByText(
+        "ACP registry controls are unavailable in this build.",
+      ),
+    ).not.toBeInTheDocument();
   });
 });

--- a/docs/plans/2026-06-05-001-feat-acp-durable-capability-cache-plan.md
+++ b/docs/plans/2026-06-05-001-feat-acp-durable-capability-cache-plan.md
@@ -1,0 +1,97 @@
+---
+title: "feat: durable ACP capability cache (stop launching agents on every settings open)"
+status: in-progress
+date: 2026-06-05
+type: feat
+target_repo: PwrAgnt (this repo)
+---
+
+# feat: durable ACP capability cache
+
+## Problem
+
+Opening the ACP Agents settings pane spawned **real ACP agent processes**
+(Gemini/Grok/Qwen/Kimi) — once per discovered agent — and React StrictMode
+double-fired the mount effect in dev, so each agent launched twice. The
+processes were short-lived (killed after the probe), but the burst happened on
+every pane mount and every "Discover new" click, and it made model lists feel
+slow because they waited on live probes.
+
+Root cause: `AcpAgentsSettings.tsx` mount effect ran `refresh(false).then(refresh(true))`,
+and `refresh(true)` → `listInstalledAndLocalAcpAgents(store, { refreshLocal: true })`
+→ `refreshAcpRuntimeCapabilities` → `discoverAcpRuntimeCapabilities`, which
+launches the agent over ACP to read its runtime capabilities (model lists,
+modes). Nothing consulted the persisted result — it re-probed unconditionally.
+
+## Key insight (from investigation)
+
+The durable substrate **already exists**. `AcpAgentStore` persists every
+`AcpInstalledAgentRecord` (including `runtimeCapabilities`, model lists, and a
+`lastDiscoveredAt` timestamp) into the `acp_installed_agents` SQLite table's
+JSON `payload`. The Composer/backend-registry model-list path already reads
+those cached capabilities and never re-probes. The only gap was that the
+settings refresh path re-probed every time and ignored `lastDiscoveredAt`.
+
+So this is **gating + a freshness policy + a renderer read-path change — no
+schema migration.**
+
+## What shipped (this PR)
+
+### Stage 1 — settings pane stops storming on mount
+- `AcpAgentsSettings.tsx`: a `useRef` "did-initial-load" guard so the mount
+  effect runs once despite StrictMode's dev double-invoke. Mount still renders
+  cached agents instantly via `refresh(false)` (a pure cache read — no launches),
+  then runs one gated `refresh(true)`.
+
+### Stage 2 — freshness gate around the expensive probe
+- New `acp/acp-capability-freshness.ts`: `shouldReprobeAcpCapabilities(cached,
+  discoveredVersion, now, { force, maxAgeMs })`. Re-probe only when: forced, OR
+  never probed (no cached capabilities/timestamp), OR the CLI version changed,
+  OR the cached probe is older than `ACP_CAPABILITY_MAX_AGE_MS` (**48h**).
+- `ipc/settings.ts` `listInstalledAndLocalAcpAgents`: cheap local discovery
+  (execFile `--version`/`--help`) still runs every refresh to find newly
+  installed agents and refresh version metadata, but the **expensive capability
+  probe is now gated** by `shouldReprobeAcpCapabilities`. Fresh, version-matched
+  agents reuse cached capabilities with no launch.
+- New `force?: boolean` on `ListAcpAgentSettingsRequest` (shared contract). The
+  "Discover new" button sets it so a user can always force a re-probe.
+
+### In-flight coalescing (the "guard")
+- `ipc/settings.ts`: concurrent ACP refreshes coalesce onto a single in-flight
+  promise (`inFlightAcpRefresh`). Protects against StrictMode double-fire AND
+  rapid double-clicks launching the same agents in parallel — the temporal
+  freshness gate can't prevent a concurrent double-launch race, this does. Pure
+  cache reads (`refresh: false`) are not coalesced; a forced refresh always runs
+  its own pass so "Discover new" is never a no-op.
+
+### Tests
+- `acp-capability-freshness.test.ts`: 10 cases (fresh reuse, force, undiscovered,
+  no-caps, no-timestamp, version-change, unknown-version, stale, boundary,
+  custom maxAge).
+- `settings-ipc.test.ts`: new integration test — first refresh probes an
+  undiscovered agent once; a second refresh reuses cache (no new probe); a
+  `force` refresh re-probes.
+
+## Deferred (follow-up PRs)
+
+### Stage 3 — background freshness sweeper
+A main-process `AcpFreshnessScheduler` (modeled on `StateDb.startGc`'s
+`setInterval().unref()`) that periodically re-probes stale agents **off the UI
+thread** and updates the store, so capabilities stay fresh without the user
+opening settings. Requires extracting `refreshAcpRuntimeCapabilities` from
+`settings.ts` into a shared helper and wiring `start()/stop()` into app
+lifecycle. Today, staleness is still healed whenever the settings pane is
+opened (the gate re-probes agents older than 48h then), so this is an
+enhancement, not a correctness fix.
+
+### Stage 5 — per-instance model (Wave 2 / existing task)
+Multiple instances of the same agent (e.g. two Grok installs at different
+paths), each with its own capabilities + `lastDiscoveredAt`. Requires an
+`instances` field on the record and a PK-strategy change on
+`acp_installed_agents` (currently keyed by `backend_id`). Tracked with the
+agent-kit Wave 2 ACP work.
+
+## Defaults / knobs
+- Freshness window: **48h** (`ACP_CAPABILITY_MAX_AGE_MS`).
+- Settings-pane mount: probe only undiscovered/stale agents; reuse cache otherwise.
+- "Discover new": always force a full re-probe.

--- a/packages/shared/src/contracts/backend.ts
+++ b/packages/shared/src/contracts/backend.ts
@@ -246,6 +246,14 @@ export type AcpAgentSettingsEntry = {
 
 export type ListAcpAgentSettingsRequest = {
   refresh?: boolean;
+  /**
+   * Force a re-probe of every discovered agent's runtime capabilities,
+   * bypassing the freshness window. The "Discover new" button sets this so a
+   * user can always re-probe on demand. When omitted, a refresh only launches
+   * the (expensive) capability probe for agents that are undiscovered, stale,
+   * or whose CLI version changed — otherwise cached capabilities are reused.
+   */
+  force?: boolean;
 };
 
 export type ListAcpAgentSettingsResponse = {


### PR DESCRIPTION
## Problem

Opening the **ACP Agents** settings pane spawned a real ACP agent **process per discovered agent** (Gemini/Grok/Qwen/Kimi) to probe runtime capabilities over an ACP `initialize`/`session` handshake. React **StrictMode** double-fires the mount effect in dev, so each agent launched **twice**. The processes were short-lived (killed after the probe — no persistent leak), but the burst hit on every pane mount and every "Discover new" click, and it made model lists feel slow because they waited on live probes.

This was observed as "a ton of agent instances" while clicking around Settings.

## Key insight

The **durable store already exists.** `AcpAgentStore` persists each `AcpInstalledAgentRecord` — including `runtimeCapabilities` (with model lists) and a `lastDiscoveredAt` timestamp — into the `acp_installed_agents` SQLite `payload`. The Composer/backend-registry model-list path already reads those cached capabilities and never re-probes. The only gap: the **settings refresh path re-probed unconditionally** and ignored `lastDiscoveredAt`.

So this is **gating + a freshness policy + a renderer read-path change — no schema migration.**

## Changes

**Stage 1 — settings pane stops storming on mount**
- `AcpAgentsSettings.tsx`: `useRef` "did-initial-load" guard so the mount effect runs once despite StrictMode's dev double-invoke. Mount renders cached agents instantly via `refresh(false)` (pure cache read — no launches), then one gated `refresh(true)`.

**Stage 2 — freshness gate around the expensive probe**
- New `acp/acp-capability-freshness.ts`: `shouldReprobeAcpCapabilities(cached, discoveredVersion, now, { force, maxAgeMs })`. Re-probe only when **forced**, **never probed**, **CLI version changed**, or **older than 48h** (`ACP_CAPABILITY_MAX_AGE_MS`).
- `ipc/settings.ts`: cheap local discovery (execFile `--version`/`--help`) still runs every refresh to find newly-installed agents; the **expensive ACP-session probe is now gated**. Fresh, version-matched agents reuse cached capabilities with **zero launches**.
- New `force?: boolean` on `ListAcpAgentSettingsRequest` (shared). "Discover new" sets it so users can always re-probe on demand.

**In-flight coalescing (the "guard")**
- `ipc/settings.ts`: concurrent ACP refreshes coalesce onto one in-flight promise — kills the StrictMode double-fire **and** rapid double-clicks launching the same agents in parallel (a race the temporal freshness gate can't prevent on its own). Pure cache reads aren't coalesced; a forced refresh always runs its own pass.

## Tests
- `acp-capability-freshness.test.ts` — 10 cases (fresh reuse, force, undiscovered, no-caps, no-timestamp, version-change, unknown-version, stale, boundary, custom maxAge).
- `settings-ipc.test.ts` — integration: undiscovered → probe once; refresh → reuse cache (no new probe); `force` → re-probe.
- `desktop-main` **1731 pass**, `desktop-renderer` settings **71 pass**, typecheck clean.

## Deferred (documented in `docs/plans/2026-06-05-001-feat-acp-durable-capability-cache-plan.md`)
- **Stage 3 — background freshness sweeper:** a main-process `setInterval().unref()` service that re-probes stale agents off the UI thread. Staleness is *already* healed when the settings pane is opened (the gate re-probes >48h agents then), so this is an enhancement, not a correctness fix. Needs extracting `refreshAcpRuntimeCapabilities` into a shared helper + app-lifecycle wiring.
- **Stage 5 — per-instance model** (multiple installs of one agent): Wave 2 / existing task.

## Notes
- Not related to the agent-kit migration — entirely in-tree ACP code (the migration's ACP adoption is Wave 2, unstarted).
- No DB migration: reuses the existing `lastDiscoveredAt` field in `payload`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)