### PR TITLE
feat(desktop): expand thread reaction picker

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/ReactionPicker.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ReactionPicker.tsx
@@ -19,7 +19,7 @@ import { createPortal } from "react-dom";
 const REACTION_GROUPS: { label: string; emojis: string[] }[] = [
   {
     label: "Status",
-    emojis: ["👀", "✋", "✅", "❌", "😢", "🚀", "🎉", "🙏"],
+    emojis: ["👀", "✋", "✅", "❌", "😢", "🚀", "🎉", "🙏", "🤔", "😱", "💩"],
   },
   {
     label: "Numbers",

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
@@ -184,6 +184,31 @@ describe("ThreadRow chip flow", () => {
     expect(onSelectThread).not.toHaveBeenCalled();
   });
 
+  it("includes the expanded first-row reaction presets", () => {
+    const { container } = renderRow();
+    const addReaction = container.querySelector(
+      ".thread-row__chip--add-reaction",
+    ) as HTMLElement;
+
+    fireEvent.click(addReaction);
+
+    const statusGroup = screen.getByRole("group", { name: "Status" });
+    const options = within(statusGroup).getAllByRole("menuitemradio");
+    expect(options.map((option) => option.textContent)).toEqual([
+      "👀",
+      "✋",
+      "✅",
+      "❌",
+      "😢",
+      "🚀",
+      "🎉",
+      "🙏",
+      "🤔",
+      "😱",
+      "💩",
+    ]);
+  });
+
   it("does not invoke onSelectThread when an existing reaction chip is clicked", () => {
     const { container, onSelectThread, onSetReaction } = renderRow();
     const reaction = container.querySelector(


### PR DESCRIPTION
## Summary

The thread-list reaction picker now fills the open first-row slots with 🤔, 😱, and 💩 so those common reactions are available without using the custom emoji input.

A focused renderer test opens the picker and locks the first-row preset order.

## Validation

- `./node_modules/.bin/vitest run --config vitest.workspace.ts apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
