### PR TITLE
fix(desktop): detect kimi by `acp --help` exit code, not help-text prose

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-local-discovery.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-local-discovery.test.ts
@@ -56,7 +56,10 @@ describe("discoverLocalAcpAgents", () => {
         return { stdout: "kimi, version 1.44.0\n" };
       }
       if (args[0] === "acp" && args[1] === "--help") {
-        return { stdout: "Usage: kimi acp [OPTIONS]\nRun Kimi Code CLI ACP server.\n" };
+        return {
+          stdout:
+            "Usage: kimi acp [options]\n\nRun kimi-code as an Agent Client Protocol (ACP) server over stdio.\n",
+        };
       }
       throw new Error("unexpected probe");
     });
@@ -108,7 +111,10 @@ describe("discoverLocalAcpAgents", () => {
         return { stdout: "kimi, version 1.44.0\n" };
       }
       if (args[0] === "acp" && args[1] === "--help") {
-        return { stdout: "Usage: kimi acp [OPTIONS]\nRun Kimi Code CLI ACP server.\n" };
+        return {
+          stdout:
+            "Usage: kimi acp [options]\n\nRun kimi-code as an Agent Client Protocol (ACP) server over stdio.\n",
+        };
       }
       throw new Error("unexpected probe");
     });
@@ -144,7 +150,10 @@ describe("discoverLocalAcpAgents", () => {
         return { stdout: "kimi, version 1.44.0\n" };
       }
       if (args[0] === "acp" && args[1] === "--help") {
-        return { stdout: "Usage: kimi acp [OPTIONS]\nRun Kimi Code CLI ACP server.\n" };
+        return {
+          stdout:
+            "Usage: kimi acp [options]\n\nRun kimi-code as an Agent Client Protocol (ACP) server over stdio.\n",
+        };
       }
       throw new Error("unexpected probe");
     });
@@ -177,7 +186,10 @@ describe("discoverLocalAcpAgents", () => {
   });
 
   it("ignores Gemini CLI versions that do not advertise ACP mode", async () => {
-    const probe = vi.fn<LocalAcpAgentProbe>(async (_command, args) => {
+    const probe = vi.fn<LocalAcpAgentProbe>(async (command, args) => {
+      if (command !== "gemini") {
+        throw Object.assign(new Error("missing"), { code: "ENOENT" });
+      }
       if (args[0] === "--version") {
         return { stdout: "0.41.0\n" };
       }
@@ -379,7 +391,7 @@ describe("discoverLocalAcpAgents", () => {
     await expect(discoverLocalAcpAgents({ probe })).resolves.toEqual([]);
   });
 
-  it("ignores Kimi CLI versions that do not advertise ACP mode", async () => {
+  it("ignores Kimi CLI versions without an `acp` subcommand", async () => {
     const probe = vi.fn<LocalAcpAgentProbe>(async (command, args) => {
       if (command !== "kimi") {
         throw Object.assign(new Error("missing"), { code: "ENOENT" });
@@ -387,7 +399,10 @@ describe("discoverLocalAcpAgents", () => {
       if (args[0] === "--version") {
         return { stdout: "kimi, version 1.40.0\n" };
       }
-      return { stdout: "Usage: kimi [OPTIONS] COMMAND [ARGS]...\n" };
+      // A kimi build without ACP support exits non-zero for `acp --help`
+      // (commander: "error: unknown command 'acp'"), which surfaces as a
+      // rejected probe — the capability signal we rely on.
+      throw Object.assign(new Error("unknown command 'acp'"), { code: 1 });
     });
 
     await expect(discoverLocalAcpAgents({ probe })).resolves.toEqual([]);

--- a/apps/desktop/src/main/acp/acp-local-discovery.ts
+++ b/apps/desktop/src/main/acp/acp-local-discovery.ts
@@ -118,10 +118,14 @@ async function discoverLocalKimi(
       continue;
     }
 
-    const acpHelpText = resultText(acpHelpResult);
-    if (!/\bACP server\b/i.test(acpHelpText)) {
-      continue;
-    }
+    // The capability signal is simply that `kimi acp --help` ran with a zero
+    // exit code (probeCommand returns undefined on non-zero / spawn failure,
+    // handled above). kimi's commander-style CLI exits non-zero for an unknown
+    // subcommand, so a clean `acp --help` proves the `acp` subcommand exists.
+    // We deliberately do NOT parse the help prose — it changed across kimi
+    // versions (0.11.0 prints "Agent Client Protocol (ACP) server", earlier
+    // builds printed "...ACP server"), and a fragile string match made an
+    // installed, working kimi undiscoverable.
 
     const now = options?.now?.() ?? Date.now();
     const backendId = "acp:kimi" as AcpBackendId;


### PR DESCRIPTION
## Problem

Kimi still wasn't appearing in ACP discovery even after #641. #641 fixed the **install-path lookup** (`~/.kimi-code/bin/kimi`) — that part works, the binary is found and `kimi --version` probes fine (0.11.0). But discovery then **rejected** it: `discoverLocalKimi` also required `/\bACP server\b/i` to appear in `kimi acp --help`, and kimi 0.11.0 prints:

```
Run kimi-code as an Agent Client Protocol (ACP) server over stdio.
```

The text is `(ACP) server` — a `)` sits between "ACP" and "server" — so the bare regex never matched and an installed, working kimi got dropped.

## Fix (per review feedback)

Don't parse the help prose at all — it's fragile and **has already changed across kimi versions**. Use the **exit code** as the capability signal: `kimi acp --help` exiting zero proves the `acp` subcommand exists. kimi's commander-style CLI exits **non-zero** for an unknown subcommand, and `probeCommand` already maps a non-zero / spawn failure to a rejected (`undefined`) probe — which is handled by the existing guard. So the string check is simply removed.

This is strictly more robust than matching either the old or new wording, and it generalizes to whatever kimi prints next.

## Tests
- kimi fixtures updated to kimi 0.11.0's **real** help wording.
- Negative case rewritten to simulate the realistic failure: `kimi acp --help` **exits non-zero** ("unknown command 'acp'") → probe rejected → not discovered.
- Gemini negative-test mock made command-specific so it no longer accidentally satisfies kimi's `acp --help` probe.
- `acp-local-discovery` **13/13**; `@pwragent/desktop` typecheck clean. Verified against the locally installed kimi 0.11.0.

Follow-up to #641 (in-tree ACP discovery; not the agent-kit migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)