### PR TITLE
fix(desktop): make codex env profile tests hermetic

### DIFF
--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -973,6 +973,7 @@ describe("DesktopSettingsService", () => {
       configPath,
       env: { CODEX_HOME: path.join(root, "codex") } as NodeJS.ProcessEnv,
       secretStore: new MemoryDesktopSecretStore(),
+      resolveCodexShellEnv: () => ({}),
     });
 
     expect(service.resolveCodexSpawnEnv().CODEX_HOME).toBe(
@@ -992,6 +993,7 @@ describe("DesktopSettingsService", () => {
       configPath,
       env: { CODEX_HOME: path.join(root, "codex") } as NodeJS.ProcessEnv,
       secretStore: new MemoryDesktopSecretStore(),
+      resolveCodexShellEnv: () => ({}),
     });
 
     await service.writeConfigPatch({


### PR DESCRIPTION
## Summary
Codex auth profile tests now stay hermetic when resolving the app-server spawn environment. The `CODEX_HOME` assertions no longer fall through to the real login-shell environment probe, so they verify only the selected-profile path behavior.

## Test Plan
- `./node_modules/.bin/vitest run --config vitest.workspace.ts apps/desktop/src/main/__tests__/desktop-settings-service.test.ts`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
