### PR TITLE
fix(desktop): improve terminal notifications

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -14304,21 +14304,33 @@ command = "pnpm dev"
       await registry.close();
     });
 
-    it("calls notifyTerminal on turn/completed and includes the cached thread title", async () => {
+    it("calls notifyTerminal on turn/completed with project and thread context", async () => {
       resetNotificationMocks();
       const registry = makeRegistry();
 
-      // Seed the title cache via thread/name/updated, then complete the turn.
+      // Seed the notification context cache via thread/started, then complete the turn.
       await registry.publishLocalEvent({
         backend: "codex",
         notification: {
-          method: "thread/name/updated",
+          method: "thread/started",
           params: {
             threadId: "thread-2",
-            threadName: "My Investigation",
+            thread: {
+              id: "thread-2",
+              title: "My Investigation",
+              linkedDirectories: [
+                {
+                  kind: "local",
+                  label: "PwrAgent",
+                  path: "/Users/example/PwrAgent",
+                },
+              ],
+            },
           },
         } as AppServerNotification,
       });
+      desktopNotificationServiceMock.clearAttentionKey.mockClear();
+
       await registry.publishLocalEvent({
         backend: "codex",
         notification: {
@@ -14338,10 +14350,62 @@ command = "pnpm dev"
       expect(desktopNotificationServiceMock.notifyTerminal).toHaveBeenCalledTimes(1);
       const call = desktopNotificationServiceMock.notifyTerminal.mock.calls[0]?.[0];
       expect(call).toMatchObject({
+        key: "codex:thread-2:turn-terminal",
         title: "PwrAgent turn completed",
       });
-      expect(call.body).toContain("My Investigation");
+      expect(call.body).toContain("PwrAgent > My Investigation");
       expect(call.body).toContain("completed");
+      expect(typeof call.onShow).toBe("function");
+
+      call.onShow?.();
+      expect(requestShowThreadMock).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-2",
+      });
+
+      await registry.close();
+    });
+
+    it("clears a previous terminal notification when a new turn starts", async () => {
+      resetNotificationMocks();
+      const registry = makeRegistry();
+
+      await registry.publishLocalEvent({
+        backend: "codex",
+        notification: {
+          method: "turn/completed",
+          params: {
+            threadId: "thread-2",
+            turnId: "turn-1",
+            turn: {
+              id: "turn-1",
+              status: "completed",
+              output: [],
+            },
+          },
+        },
+      });
+      expect(desktopNotificationServiceMock.notifyTerminal).toHaveBeenCalledTimes(1);
+      desktopNotificationServiceMock.clearAttentionKey.mockClear();
+
+      await registry.publishLocalEvent({
+        backend: "codex",
+        notification: {
+          method: "turn/started",
+          params: {
+            threadId: "thread-2",
+            turnId: "turn-2",
+            turn: {
+              id: "turn-2",
+              status: "in_progress",
+            },
+          },
+        },
+      });
+
+      expect(desktopNotificationServiceMock.clearAttentionKey).toHaveBeenCalledWith(
+        "codex:thread-2:turn-terminal",
+      );
 
       await registry.close();
     });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -14366,6 +14366,59 @@ command = "pnpm dev"
       await registry.close();
     });
 
+    it("looks up terminal notification context when no thread event seeded the cache", async () => {
+      resetNotificationMocks();
+      const codexClient = new MockBackendClient({
+        threads: [
+          {
+            id: "thread-lookup",
+            title: "Notification Followup",
+            titleSource: "derived",
+            source: "codex",
+            linkedDirectories: [
+              {
+                id: "local:/Users/example/PwrAgent",
+                kind: "local",
+                label: "PwrAgent",
+                path: "/Users/example/PwrAgent",
+              },
+            ],
+          },
+        ],
+      });
+      const registry = new DesktopBackendRegistry({
+        codexClient,
+        grokClient: new MockBackendClient({
+          initializeError: new Error(
+            "grok app server unavailable: XAI_API_KEY is not set",
+          ),
+        }),
+        overlayStore: createOverlayStoreMock(),
+      });
+
+      await registry.publishLocalEvent({
+        backend: "codex",
+        notification: {
+          method: "turn/completed",
+          params: {
+            threadId: "thread-lookup",
+            turnId: "turn-1",
+            turn: {
+              id: "turn-1",
+              status: "completed",
+              output: [],
+            },
+          },
+        },
+      });
+
+      const call = desktopNotificationServiceMock.notifyTerminal.mock.calls[0]?.[0];
+      expect(call.body).toContain("PwrAgent > Notification Followup");
+      expect(call.body).toContain("completed");
+
+      await registry.close();
+    });
+
     it("clears a previous terminal notification when a new turn starts", async () => {
       resetNotificationMocks();
       const registry = makeRegistry();

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2465,6 +2465,7 @@ describe("DesktopBackendRegistry", () => {
     expect(cancelledSessions).toEqual(["session-1"]);
     expect(emittedEvents.map((event) => event.notification.method)).toEqual([
       "turn/started",
+      "thread/name/updated",
       "turn/completed",
       "turn/started",
       "turn/completed",

--- a/apps/desktop/src/main/__tests__/desktop-notification-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-notification-service.test.ts
@@ -72,7 +72,8 @@ const {
     }
 
     emitAction(actionIndex: number): void {
-      this.actionHandler?.({ actionIndex }, actionIndex, -1);
+      const event = { actionIndex, preventDefault: vi.fn() };
+      this.actionHandler?.(event, actionIndex, -1);
     }
 
     emitClick(): void {
@@ -226,61 +227,68 @@ describe("DesktopNotificationService", () => {
     expect(shownNotifications).toEqual([]);
   });
 
-  it("renders terminal notifications with show action and auto-closes them", () => {
-    vi.useFakeTimers();
-    try {
-      const service = new DesktopNotificationService();
-      const onShow = vi.fn();
-      getAllWindows.mockReturnValue([
-        { isDestroyed: () => false, isFocused: () => false, isMinimized: () => false },
-      ]);
-      const serviceWithActionButtons = service as unknown as {
-        supportsActionButtons: () => boolean;
-      };
-      const serviceWithLiveNotifications = service as unknown as {
-        liveNotifications: Set<unknown>;
-      };
-      vi.spyOn(
-        serviceWithActionButtons,
-        "supportsActionButtons",
-      ).mockReturnValue(true);
+  it("renders terminal notifications as body-click notifications until explicit cleanup", () => {
+    const service = new DesktopNotificationService();
+    const onShow = vi.fn();
+    getAllWindows.mockReturnValue([
+      { isDestroyed: () => false, isFocused: () => false, isMinimized: () => false },
+    ]);
+    const serviceWithActionButtons = service as unknown as {
+      supportsActionButtons: () => boolean;
+    };
+    const serviceWithLiveNotifications = service as unknown as {
+      attentionKeys: Set<string>;
+      liveNotifications: Set<unknown>;
+    };
+    vi.spyOn(
+      serviceWithActionButtons,
+      "supportsActionButtons",
+    ).mockReturnValue(true);
 
-      service.notifyTerminal({
-        enabled: true,
-        key: "codex:thread-1:turn-terminal",
-        title: "PwrAgent turn completed",
-        body: "PwrAgent > npm view eslint · turn completed.",
-        onShow,
-      });
+    service.notifyTerminal({
+      enabled: true,
+      key: "codex:thread-1:turn-terminal",
+      title: "PwrAgent turn completed",
+      body: "PwrAgent > npm view eslint · turn completed.",
+      onShow,
+    });
 
-      expect(shownNotifications[0]?.actions).toEqual([
-        { type: "button", text: "Show" },
-      ]);
-      expect(serviceWithLiveNotifications.liveNotifications.size).toBe(1);
+    expect(shownNotifications[0]?.actions).toBeUndefined();
+    expect(serviceWithLiveNotifications.liveNotifications.size).toBe(1);
+    expect(
+      serviceWithLiveNotifications.attentionKeys.has(
+        "codex:thread-1:turn-terminal",
+      ),
+    ).toBe(true);
 
-      shownNotifications[0]?.instance.emitAction(0);
+    shownNotifications[0]?.instance.emitClick();
 
-      expect(onShow).toHaveBeenCalledTimes(1);
-      expect(serviceWithLiveNotifications.liveNotifications.size).toBe(0);
+    expect(onShow).toHaveBeenCalledTimes(1);
+    expect(serviceWithLiveNotifications.liveNotifications.size).toBe(0);
+    expect(
+      serviceWithLiveNotifications.attentionKeys.has(
+        "codex:thread-1:turn-terminal",
+      ),
+    ).toBe(true);
 
-      service.notifyTerminal({
-        closeAfterMs: 5000,
-        enabled: true,
-        key: "codex:thread-1:turn-terminal",
-        title: "PwrAgent turn completed",
-        body: "PwrAgent > npm view eslint · turn completed.",
-        onShow,
-      });
+    service.notifyTerminal({
+      enabled: true,
+      key: "codex:thread-1:turn-terminal",
+      title: "PwrAgent turn completed",
+      body: "PwrAgent > npm view eslint · turn completed again.",
+      onShow,
+    });
+    expect(shownNotifications).toHaveLength(1);
 
-      expect(serviceWithLiveNotifications.liveNotifications.size).toBe(1);
-      vi.advanceTimersByTime(5000);
-      expect(serviceWithLiveNotifications.liveNotifications.size).toBe(0);
-    } finally {
-      vi.useRealTimers();
-    }
+    service.clearAttentionKey("codex:thread-1:turn-terminal");
+    expect(
+      serviceWithLiveNotifications.attentionKeys.has(
+        "codex:thread-1:turn-terminal",
+      ),
+    ).toBe(false);
   });
 
-  it("renders approval intents with native show, approve, and decline actions", () => {
+  it("renders approval intents with a native approve action and opens the thread on click", () => {
     const service = new DesktopNotificationService();
     const onDecision = vi.fn();
     const onShow = vi.fn();
@@ -304,9 +312,7 @@ describe("DesktopNotificationService", () => {
     });
 
     expect(shownNotifications[0]?.actions).toEqual([
-      { type: "button", text: "Show" },
       { type: "button", text: "Approve" },
-      { type: "button", text: "Decline" },
     ]);
     expect(shownNotifications[0]?.title).toBe("PwrAgent approval needed");
     expect(shownNotifications[0]?.body).toContain("Command Approval");
@@ -314,10 +320,7 @@ describe("DesktopNotificationService", () => {
     expect(shownNotifications[0]?.body).not.toContain("```shell");
     expect(shownNotifications[0]?.body).not.toContain("Reply with");
 
-    shownNotifications[0]?.instance.emitAction(0);
-    shownNotifications[0]?.instance.emitAction(1);
-    shownNotifications[0]?.instance.emitAction(2);
-
+    shownNotifications[0]?.instance.emitClick();
     expect(onShow).toHaveBeenCalledTimes(1);
     expect(onDecision).not.toHaveBeenCalled();
 
@@ -328,22 +331,12 @@ describe("DesktopNotificationService", () => {
       onDecision,
       onShow,
     });
-    shownNotifications[1]?.instance.emitAction(1);
+    shownNotifications[1]?.instance.emitAction(0);
+    shownNotifications[1]?.instance.emitClick();
 
     expect(onDecision).toHaveBeenCalledTimes(1);
     expect(onDecision).toHaveBeenLastCalledWith("accept");
-
-    service.notifyApproval({
-      enabled: true,
-      key: "codex:thread-1:req-2c",
-      intent: approvalIntent(),
-      onDecision,
-      onShow,
-    });
-    shownNotifications[2]?.instance.emitAction(2);
-
-    expect(onDecision).toHaveBeenCalledTimes(2);
-    expect(onDecision).toHaveBeenLastCalledWith("decline");
+    expect(onShow).toHaveBeenCalledTimes(1);
   });
 
   it("keeps the native approve action when a fallback prompt includes command details", () => {
@@ -378,7 +371,6 @@ describe("DesktopNotificationService", () => {
 
     expect(shownNotifications[0]?.actions).toEqual([
       { type: "button", text: "Approve" },
-      { type: "button", text: "Decline" },
     ]);
     expect(shownNotifications[0]?.body).toContain("npm view eslint");
     expect(shownNotifications[0]?.body).not.toContain("Approve this action?");
@@ -418,13 +410,10 @@ describe("DesktopNotificationService", () => {
 
     expect(shownNotifications[0]?.body).toMatch(/\.\.\.$/);
     expect(shownNotifications[0]?.body).not.toContain("--dangerous-flag");
-    expect(shownNotifications[0]?.actions).toEqual([
-      { type: "button", text: "Show" },
-      { type: "button", text: "Decline" },
-    ]);
+    expect(shownNotifications[0]?.actions).toBeUndefined();
 
-    shownNotifications[0]?.instance.emitAction(1);
-    expect(onDecision).toHaveBeenCalledWith("decline");
+    shownNotifications[0]?.instance.emitAction(0);
+    expect(onDecision).not.toHaveBeenCalled();
     expect(onDecision).not.toHaveBeenCalledWith("accept");
   });
 
@@ -524,7 +513,7 @@ describe("DesktopNotificationService", () => {
     expect(onDecision).not.toHaveBeenCalled();
   });
 
-  it("keeps only safe native approval actions when the intent lacks details", () => {
+  it("keeps approval notifications passive when the intent lacks details", () => {
     const service = new DesktopNotificationService();
     const onDecision = vi.fn();
     const onShow = vi.fn();
@@ -552,29 +541,13 @@ describe("DesktopNotificationService", () => {
       onShow,
     });
 
-    expect(shownNotifications[0]?.actions).toEqual([
-      { type: "button", text: "Show" },
-      { type: "button", text: "Decline" },
-    ]);
-    shownNotifications[0]?.instance.emitAction(0);
+    expect(shownNotifications[0]?.actions).toBeUndefined();
+    shownNotifications[0]?.instance.emitClick();
     expect(onShow).toHaveBeenCalledTimes(1);
     expect(onDecision).not.toHaveBeenCalled();
 
-    service.notifyApproval({
-      enabled: true,
-      key: "codex:thread-1:req-generic-decline",
-      intent: approvalIntent({
-        body: [
-          "Approve this action?",
-          "Reply with \"1\", \"2\", \"yes\", \"yes for this session\", \"no\", or use a button.",
-        ].join("\n\n"),
-      }),
-      onDecision,
-      onShow,
-    });
-    shownNotifications[1]?.instance.emitAction(1);
-
-    expect(onDecision).toHaveBeenCalledWith("decline");
+    shownNotifications[0]?.instance.emitAction(0);
+    expect(onDecision).not.toHaveBeenCalled();
     expect(onDecision).not.toHaveBeenCalledWith("accept");
   });
 

--- a/apps/desktop/src/main/__tests__/desktop-notification-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-notification-service.test.ts
@@ -226,6 +226,60 @@ describe("DesktopNotificationService", () => {
     expect(shownNotifications).toEqual([]);
   });
 
+  it("renders terminal notifications with show action and auto-closes them", () => {
+    vi.useFakeTimers();
+    try {
+      const service = new DesktopNotificationService();
+      const onShow = vi.fn();
+      getAllWindows.mockReturnValue([
+        { isDestroyed: () => false, isFocused: () => false, isMinimized: () => false },
+      ]);
+      const serviceWithActionButtons = service as unknown as {
+        supportsActionButtons: () => boolean;
+      };
+      const serviceWithLiveNotifications = service as unknown as {
+        liveNotifications: Set<unknown>;
+      };
+      vi.spyOn(
+        serviceWithActionButtons,
+        "supportsActionButtons",
+      ).mockReturnValue(true);
+
+      service.notifyTerminal({
+        enabled: true,
+        key: "codex:thread-1:turn-terminal",
+        title: "PwrAgent turn completed",
+        body: "PwrAgent > npm view eslint · turn completed.",
+        onShow,
+      });
+
+      expect(shownNotifications[0]?.actions).toEqual([
+        { type: "button", text: "Show" },
+      ]);
+      expect(serviceWithLiveNotifications.liveNotifications.size).toBe(1);
+
+      shownNotifications[0]?.instance.emitAction(0);
+
+      expect(onShow).toHaveBeenCalledTimes(1);
+      expect(serviceWithLiveNotifications.liveNotifications.size).toBe(0);
+
+      service.notifyTerminal({
+        closeAfterMs: 5000,
+        enabled: true,
+        key: "codex:thread-1:turn-terminal",
+        title: "PwrAgent turn completed",
+        body: "PwrAgent > npm view eslint · turn completed.",
+        onShow,
+      });
+
+      expect(serviceWithLiveNotifications.liveNotifications.size).toBe(1);
+      vi.advanceTimersByTime(5000);
+      expect(serviceWithLiveNotifications.liveNotifications.size).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("renders approval intents with native show, approve, and decline actions", () => {
     const service = new DesktopNotificationService();
     const onDecision = vi.fn();

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -2278,7 +2278,8 @@ export class DesktopBackendRegistry {
    * only to label native attention/terminal notifications so multiple
    * background turns are distinguishable. Populated from `thread/started` and
    * `thread/name/updated` notifications as they fan out through `emit()`.
-   * Falls back to a generic body when context hasn't been observed yet.
+   * Falls back to a thread-list lookup, then a generic body when context still
+   * isn't available.
    */
   private readonly notificationThreadTitles = new Map<string, string>();
   private readonly notificationThreadProjectLabels = new Map<string, string>();
@@ -9586,24 +9587,30 @@ export class DesktopBackendRegistry {
       if (typeof threadId !== "string") {
         return;
       }
-      const thread = params.thread;
-      const candidate =
-        (typeof thread?.title === "string" ? thread.title : undefined) ??
-        (typeof thread?.name === "string" ? thread.name : undefined);
-      const trimmed = candidate?.trim();
-      if (trimmed) {
-        this.notificationThreadTitles.set(
-          `${event.backend}:${threadId}`,
-          trimmed,
-        );
-      }
-      const projectLabel = readNotificationProjectLabel(thread);
-      if (projectLabel) {
-        this.notificationThreadProjectLabels.set(
-          `${event.backend}:${threadId}`,
-          projectLabel,
-        );
-      }
+      this.rememberThreadNotificationContext(event.backend, threadId, params.thread);
+    }
+  }
+
+  private rememberThreadNotificationContext(
+    backend: AppServerBackendKind,
+    threadId: string,
+    thread: unknown,
+  ): void {
+    if (!thread || typeof thread !== "object" || Array.isArray(thread)) {
+      return;
+    }
+    const record = thread as Record<string, unknown>;
+    const candidate =
+      (typeof record.title === "string" ? record.title : undefined) ??
+      (typeof record.name === "string" ? record.name : undefined);
+    const trimmed = candidate?.trim();
+    const key = `${backend}:${threadId}`;
+    if (trimmed) {
+      this.notificationThreadTitles.set(key, trimmed);
+    }
+    const projectLabel = readNotificationProjectLabel(record);
+    if (projectLabel) {
+      this.notificationThreadProjectLabels.set(key, projectLabel);
     }
   }
 
@@ -9618,6 +9625,35 @@ export class DesktopBackendRegistry {
       return `${projectLabel} > ${threadTitle}`;
     }
     return threadTitle ?? projectLabel;
+  }
+
+  private async notificationThreadContextLabelForTerminal(
+    backend: AppServerBackendKind,
+    threadId: string,
+  ): Promise<string | undefined> {
+    const cached = this.notificationThreadContextLabel(backend, threadId);
+    if (cached) {
+      return cached;
+    }
+    try {
+      const threads = await this.listThreads({
+        backend,
+        callerReason: "notification-context",
+        enrichDirectories: true,
+      });
+      const thread = threads.find((candidate) => candidate.id === threadId);
+      if (thread) {
+        this.rememberThreadNotificationContext(backend, threadId, thread);
+        return this.notificationThreadContextLabel(backend, threadId);
+      }
+    } catch (error) {
+      backendRegistryLog.debug("native terminal notification context lookup failed", {
+        backend,
+        error: error instanceof Error ? error.message : String(error),
+        threadId,
+      });
+    }
+    return undefined;
   }
 
   private notifyForAttentionRequired(event: AgentEvent): void {
@@ -9737,7 +9773,7 @@ export class DesktopBackendRegistry {
     );
   }
 
-  private notifyForTerminalOutcome(event: AgentEvent): void {
+  private async notifyForTerminalOutcome(event: AgentEvent): Promise<void> {
     if (event.notification.method === "turn/started") {
       const threadId = (event.notification.params as { threadId?: unknown })
         .threadId;
@@ -9777,7 +9813,7 @@ export class DesktopBackendRegistry {
       .threadId;
     const contextLabel =
       typeof threadId === "string"
-        ? this.notificationThreadContextLabel(event.backend, threadId)
+        ? await this.notificationThreadContextLabelForTerminal(event.backend, threadId)
         : undefined;
     const body = contextLabel
       ? `${contextLabel} · turn ${status}.`
@@ -10059,7 +10095,7 @@ export class DesktopBackendRegistry {
 
     this.rememberThreadTitleFromEvent(event);
     this.notifyForAttentionRequired(event);
-    this.notifyForTerminalOutcome(event);
+    await this.notifyForTerminalOutcome(event);
 
     for (const listener of this.eventListeners) {
       try {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1121,6 +1121,44 @@ function buildPendingRequestKey(params: {
   return `${params.backend}:${params.threadId}:${params.requestId}`;
 }
 
+function buildTerminalNotificationKey(params: {
+  backend: AppServerBackendKind;
+  threadId: string;
+}): string {
+  return `${params.backend}:${params.threadId}:turn-terminal`;
+}
+
+function readNotificationProjectLabel(
+  thread: Record<string, unknown> | undefined,
+): string | undefined {
+  if (!thread) {
+    return undefined;
+  }
+  const linkedDirectories = Array.isArray(thread.linkedDirectories)
+    ? thread.linkedDirectories
+    : [];
+  for (const directory of linkedDirectories) {
+    if (!directory || typeof directory !== "object" || Array.isArray(directory)) {
+      continue;
+    }
+    const record = directory as Record<string, unknown>;
+    const label = readNonEmptyString(record.label);
+    if (label) {
+      return label;
+    }
+    const directoryPath = readNonEmptyString(record.path);
+    if (directoryPath) {
+      return path.basename(directoryPath);
+    }
+  }
+  const projectKey = readNonEmptyString(thread.projectKey);
+  return projectKey ? path.basename(projectKey) : undefined;
+}
+
+function readNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
 function isAcpPermissionRequest(
   request: AppServerPendingRequestNotification,
 ): boolean {
@@ -2236,13 +2274,14 @@ export class DesktopBackendRegistry {
   private readonly reservedAcpStartThreadKeys = new Set<string>();
   private readonly activeTurnKeys = new Set<string>();
   /**
-   * Best-effort cache of thread titles keyed by `${backend}:${threadId}`, used
+   * Best-effort cache of thread labels keyed by `${backend}:${threadId}`, used
    * only to label native attention/terminal notifications so multiple
    * background turns are distinguishable. Populated from `thread/started` and
    * `thread/name/updated` notifications as they fan out through `emit()`.
-   * Falls back to a generic body when a title hasn't been observed yet.
+   * Falls back to a generic body when context hasn't been observed yet.
    */
   private readonly notificationThreadTitles = new Map<string, string>();
+  private readonly notificationThreadProjectLabels = new Map<string, string>();
   private hasLoggedNotificationsEnabledError = false;
   private readonly threadTurnQueue: ThreadTurnQueue;
   private automationInspectionHandler?: AutomationInspectionHandler;
@@ -9558,7 +9597,27 @@ export class DesktopBackendRegistry {
           trimmed,
         );
       }
+      const projectLabel = readNotificationProjectLabel(thread);
+      if (projectLabel) {
+        this.notificationThreadProjectLabels.set(
+          `${event.backend}:${threadId}`,
+          projectLabel,
+        );
+      }
     }
+  }
+
+  private notificationThreadContextLabel(
+    backend: AppServerBackendKind,
+    threadId: string,
+  ): string | undefined {
+    const key = `${backend}:${threadId}`;
+    const projectLabel = this.notificationThreadProjectLabels.get(key);
+    const threadTitle = this.notificationThreadTitles.get(key);
+    if (projectLabel && threadTitle) {
+      return `${projectLabel} > ${threadTitle}`;
+    }
+    return threadTitle ?? projectLabel;
   }
 
   private notifyForAttentionRequired(event: AgentEvent): void {
@@ -9679,6 +9738,28 @@ export class DesktopBackendRegistry {
   }
 
   private notifyForTerminalOutcome(event: AgentEvent): void {
+    if (event.notification.method === "turn/started") {
+      const threadId = (event.notification.params as { threadId?: unknown })
+        .threadId;
+      if (typeof threadId !== "string") {
+        return;
+      }
+      try {
+        getDesktopNotificationService().clearAttentionKey(
+          buildTerminalNotificationKey({
+            backend: event.backend,
+            threadId,
+          }),
+        );
+      } catch (error) {
+        backendRegistryLog.warn("native terminal notification cleanup failed", {
+          backend: event.backend,
+          error: error instanceof Error ? error.message : String(error),
+          threadId,
+        });
+      }
+      return;
+    }
     if (
       event.notification.method !== "turn/completed" &&
       event.notification.method !== "turn/failed" &&
@@ -9694,18 +9775,34 @@ export class DesktopBackendRegistry {
           : "cancelled";
     const threadId = (event.notification.params as { threadId?: unknown })
       .threadId;
-    const threadTitle =
+    const contextLabel =
       typeof threadId === "string"
-        ? this.notificationThreadTitles.get(`${event.backend}:${threadId}`)
+        ? this.notificationThreadContextLabel(event.backend, threadId)
         : undefined;
-    const body = threadTitle
-      ? `${threadTitle} · turn ${status}.`
+    const body = contextLabel
+      ? `${contextLabel} · turn ${status}.`
       : `A turn ${status}.`;
     try {
       getDesktopNotificationService().notifyTerminal({
         enabled: this.notificationsEnabled(),
+        key:
+          typeof threadId === "string"
+            ? buildTerminalNotificationKey({
+                backend: event.backend,
+                threadId,
+              })
+            : undefined,
         title: `PwrAgent turn ${status}`,
         body,
+        onShow:
+          typeof threadId === "string"
+            ? () => {
+                requestShowThread({
+                  backend: event.backend,
+                  threadId,
+                });
+              }
+            : undefined,
       });
     } catch (error) {
       backendRegistryLog.warn("native terminal notification failed", {

--- a/apps/desktop/src/main/notifications/desktop-notification-service.ts
+++ b/apps/desktop/src/main/notifications/desktop-notification-service.ts
@@ -7,6 +7,7 @@ import { getMainLogger } from "../log";
 
 const notificationLog = getMainLogger("pwragent:notifications");
 const NATIVE_NOTIFICATION_BODY_MAX_LENGTH = 220;
+const TERMINAL_NOTIFICATION_CLOSE_AFTER_MS = 5000;
 
 type NativeNotificationAction = {
   text: string;
@@ -104,9 +105,12 @@ export class DesktopNotificationService {
   }
 
   notifyTerminal(params: {
+    key?: string;
     enabled: boolean;
     title: string;
     body: string;
+    onShow?: () => void;
+    closeAfterMs?: number;
   }): void {
     if (!params.enabled) {
       return;
@@ -118,8 +122,19 @@ export class DesktopNotificationService {
       return;
     }
     this.show({
+      attentionKey: params.key,
       title: params.title,
       body: params.body,
+      actions: params.onShow
+        ? [
+            {
+              text: "Show",
+              run: params.onShow,
+            },
+          ]
+        : undefined,
+      onClick: params.onShow,
+      closeAfterMs: params.closeAfterMs ?? TERMINAL_NOTIFICATION_CLOSE_AFTER_MS,
     });
   }
 
@@ -138,6 +153,7 @@ export class DesktopNotificationService {
   private show(params: {
     attentionKey?: string;
     actions?: NativeNotificationAction[];
+    closeAfterMs?: number;
     onClick?: () => void;
     title: string;
     body: string;
@@ -168,7 +184,12 @@ export class DesktopNotificationService {
         }
         notifications.add(notification);
       }
+      let closeTimer: ReturnType<typeof setTimeout> | undefined;
       const cleanup = () => {
+        if (closeTimer !== undefined) {
+          clearTimeout(closeTimer);
+          closeTimer = undefined;
+        }
         this.liveNotifications.delete(notification);
         if (params.attentionKey) {
           const notifications = this.attentionNotifications.get(params.attentionKey);
@@ -198,6 +219,17 @@ export class DesktopNotificationService {
           handled = true;
           action.run();
         });
+      }
+      if (params.closeAfterMs && params.closeAfterMs > 0) {
+        closeTimer = setTimeout(() => {
+          try {
+            notification.close();
+          } catch (error) {
+            notificationLog.warn("failed to auto-close native notification", {
+              error: error instanceof Error ? error.message : String(error),
+            });
+          }
+        }, params.closeAfterMs);
       }
       notification.show();
     } catch (error) {

--- a/apps/desktop/src/main/notifications/desktop-notification-service.ts
+++ b/apps/desktop/src/main/notifications/desktop-notification-service.ts
@@ -7,7 +7,6 @@ import { getMainLogger } from "../log";
 
 const notificationLog = getMainLogger("pwragent:notifications");
 const NATIVE_NOTIFICATION_BODY_MAX_LENGTH = 220;
-const TERMINAL_NOTIFICATION_CLOSE_AFTER_MS = 5000;
 
 type NativeNotificationAction = {
   text: string;
@@ -110,9 +109,8 @@ export class DesktopNotificationService {
     title: string;
     body: string;
     onShow?: () => void;
-    closeAfterMs?: number;
   }): void {
-    if (!params.enabled) {
+    if (!params.enabled || (params.key && this.attentionKeys.has(params.key))) {
       return;
     }
     if (!this.isAppInactive()) {
@@ -121,20 +119,14 @@ export class DesktopNotificationService {
     if (!Notification.isSupported()) {
       return;
     }
+    if (params.key) {
+      this.attentionKeys.add(params.key);
+    }
     this.show({
       attentionKey: params.key,
       title: params.title,
       body: params.body,
-      actions: params.onShow
-        ? [
-            {
-              text: "Show",
-              run: params.onShow,
-            },
-          ]
-        : undefined,
       onClick: params.onShow,
-      closeAfterMs: params.closeAfterMs ?? TERMINAL_NOTIFICATION_CLOSE_AFTER_MS,
     });
   }
 
@@ -153,7 +145,6 @@ export class DesktopNotificationService {
   private show(params: {
     attentionKey?: string;
     actions?: NativeNotificationAction[];
-    closeAfterMs?: number;
     onClick?: () => void;
     title: string;
     body: string;
@@ -184,12 +175,7 @@ export class DesktopNotificationService {
         }
         notifications.add(notification);
       }
-      let closeTimer: ReturnType<typeof setTimeout> | undefined;
       const cleanup = () => {
-        if (closeTimer !== undefined) {
-          clearTimeout(closeTimer);
-          closeTimer = undefined;
-        }
         this.liveNotifications.delete(notification);
         if (params.attentionKey) {
           const notifications = this.attentionNotifications.get(params.attentionKey);
@@ -199,7 +185,11 @@ export class DesktopNotificationService {
           }
         }
       };
+      let handledAction = false;
       notification.on("click", () => {
+        if (handledAction) {
+          return;
+        }
         cleanup();
         params.onClick?.();
       });
@@ -217,19 +207,9 @@ export class DesktopNotificationService {
             return;
           }
           handled = true;
+          handledAction = true;
           action.run();
         });
-      }
-      if (params.closeAfterMs && params.closeAfterMs > 0) {
-        closeTimer = setTimeout(() => {
-          try {
-            notification.close();
-          } catch (error) {
-            notificationLog.warn("failed to auto-close native notification", {
-              error: error instanceof Error ? error.message : String(error),
-            });
-          }
-        }, params.closeAfterMs);
       }
       notification.show();
     } catch (error) {
@@ -248,24 +228,11 @@ function nativeApprovalActions(
   },
 ): NativeNotificationAction[] | undefined {
   const actions: NativeNotificationAction[] = [];
-  if (callbacks.onShow) {
-    actions.push({
-      text: "Show",
-      run: callbacks.onShow,
-    });
-  }
   const accept = intent.decisions.find((action) => action.decision === "accept");
   if (accept && callbacks.onDecision && nativeApprovalCanApproveInline(intent)) {
     actions.push({
       text: "Approve",
       run: () => callbacks.onDecision?.(accept.decision),
-    });
-  }
-  const decline = intent.decisions.find((action) => action.decision === "decline");
-  if (decline && callbacks.onDecision) {
-    actions.push({
-      text: "Decline",
-      run: () => callbacks.onDecision?.(decline.decision),
     });
   }
   return actions.length > 0 ? actions : undefined;

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -8218,6 +8218,9 @@ describe("Composer", () => {
       })
     );
 
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument();
+    });
     await clickButton("Stop");
 
     await waitFor(() => {


### PR DESCRIPTION
## Summary
- auto-close terminal outcome notifications after a short delay
- clear stale terminal notifications when a new turn starts on the same thread
- add Show routing and Project > Thread context to terminal notifications

## Verification
- pnpm test apps/desktop/src/main/__tests__/desktop-notification-service.test.ts
- pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts -t "notification wiring"
- pnpm lint:boundaries
- timeout 180 pnpm --filter @pwragent/desktop typecheck