### PR TITLE
fix(codex): preserve local environment hydration

### DIFF
--- a/apps/desktop/e2e/codex-environment-setup.spec.ts
+++ b/apps/desktop/e2e/codex-environment-setup.spec.ts
@@ -382,9 +382,7 @@ test("selected environments run setup and show transcript output", async () => {
     const launchpadTools = app.window.getByLabel("Composer tools");
     await launchpadTools.getByRole("button", { name: "Environment", exact: true }).click();
     await app.window.getByRole("option", { name: "Fixture Env" }).click();
-    await expect(
-      launchpadTools.locator("label", { hasText: "Run setup" }).locator("input"),
-    ).toBeChecked();
+    await expect(launchpadTools.getByLabel("Run setup")).toHaveCount(0);
 
     await app.window.getByRole("textbox", { name: "New thread" }).fill("hello env");
     await app.window.getByRole("button", { name: "Start thread" }).click();
@@ -622,7 +620,7 @@ test("directory launchpad keeps selected environment controls after snapshot rel
     ).toContainText(
       "Fixture Env",
     );
-    await expect(tools.getByLabel("Run setup")).toBeChecked();
+    await expect(tools.getByLabel("Run setup")).toHaveCount(0);
   } finally {
     if (secondApp) {
       await secondApp.close();

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -20,6 +20,7 @@ import type {
   BackendAcpRuntimeOptionSource,
   BackendAcpSessionRuntimeState,
   BackendRateLimitSummary,
+  CodexThreadEnvironmentRuntime,
   NavigationLaunchpadDefaults,
   NavigationLaunchpadDraft,
   ThreadExecutionMode,
@@ -590,6 +591,7 @@ class MockBackendClient {
     serviceTier?: string;
     reasoningEffort?: string;
     fastMode?: boolean;
+    codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
   };
   lastForkThreadParams?: {
     threadId: string;
@@ -600,6 +602,7 @@ class MockBackendClient {
     sandbox?: string;
     serviceTier?: string;
     fastMode?: boolean;
+    codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
   };
   lastStartTurnParams?: {
     backend?: "codex" | "grok";
@@ -613,6 +616,7 @@ class MockBackendClient {
     serviceTier?: string;
     reasoningEffort?: string;
     fastMode?: boolean;
+    codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
   };
   startTurnCallCount = 0;
   lastSteerTurnParams?: {
@@ -624,6 +628,8 @@ class MockBackendClient {
     threadId: string;
     target: AppServerReviewTarget;
     delivery?: "inline" | "detached";
+    cwd?: string;
+    codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
   };
   lastCompactThreadParams?: {
     threadId: string;
@@ -856,6 +862,7 @@ class MockBackendClient {
     serviceTier?: string;
     reasoningEffort?: string;
     fastMode?: boolean;
+    codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
   }): Promise<{ threadId: string }> {
     this.lastStartThreadParams = params;
     return { threadId: "thread-1" };
@@ -870,6 +877,7 @@ class MockBackendClient {
     sandbox?: string;
     serviceTier?: string;
     fastMode?: boolean;
+    codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
   }): Promise<{ threadId: string }> {
     this.lastForkThreadParams = params;
     return { threadId: "thread-fork" };
@@ -888,6 +896,7 @@ class MockBackendClient {
     serviceTier?: string;
     reasoningEffort?: string;
     fastMode?: boolean;
+    codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
   }): Promise<{ threadId: string; turnId: string }> {
     this.startTurnCallCount += 1;
     if (this.options.startTurnError) {
@@ -901,6 +910,8 @@ class MockBackendClient {
     threadId: string;
     target: AppServerReviewTarget;
     delivery?: "inline" | "detached";
+    cwd?: string;
+    codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
   }): Promise<{ threadId: string; reviewThreadId: string; turnId: string }> {
     this.lastStartReviewParams = params;
     return {
@@ -6664,6 +6675,108 @@ command = "pnpm dev:messaging"
     }
   });
 
+  it("persists selected Codex environment actions per thread environment", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-thread-env-action-select-"));
+    await mkdir(path.join(root, ".codex", "environments"), { recursive: true });
+    await writeFile(
+      path.join(root, ".codex", "environments", "environment.toml"),
+      `
+version = 1
+name = "PwrAgnt"
+
+[[actions]]
+name = "Dev"
+command = "pnpm dev"
+
+[[actions]]
+name = "Test"
+command = "pnpm test"
+`,
+      "utf8",
+    );
+
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          codexEnvironmentRuntime: {
+            environmentId: "environment",
+            environmentName: "PwrAgnt",
+            executionTarget: "local",
+            cwd: root,
+            setupEnabled: true,
+            setupStatus: "completed",
+            shellEnvironment: {
+              PATH: "/Users/huntharo/.nvm/versions/node/v24.14.1/bin:/usr/bin",
+            },
+            selectedActionIdByEnvironmentId: {
+              environment: "dev",
+            },
+          },
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/list"] },
+        threads: [
+          {
+            id: "thread-1",
+            title: "Thread",
+            titleSource: "explicit",
+            source: "codex",
+            updatedAt: 1,
+            projectKey: root,
+            linkedDirectories: [
+              {
+                id: root,
+                kind: "local",
+                label: "repo",
+                path: root,
+              },
+            ],
+          },
+        ],
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+
+    try {
+      await registry.setCodexThreadEnvironment({
+        backend: "codex",
+        threadId: "thread-1",
+        environmentId: "environment",
+        actionId: "test",
+      });
+
+      await expect(
+        overlayStore.getThreadOverlayState({
+          backend: "codex",
+          threadId: "thread-1",
+        }),
+      ).resolves.toMatchObject({
+        codexEnvironmentRuntime: {
+          environmentId: "environment",
+          shellEnvironment: {
+            PATH: "/Users/huntharo/.nvm/versions/node/v24.14.1/bin:/usr/bin",
+          },
+          selectedActionIdByEnvironmentId: {
+            environment: "test",
+          },
+        },
+      });
+    } finally {
+      await registry.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("refreshes stale thread environment actions before running a command", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-thread-env-run-"));
     const outputPath = path.join(root, "action.txt");
@@ -7640,6 +7753,233 @@ script = "printf setup-output"
     await registry.close();
   });
 
+  it("copies Codex environment selection and hydration when forking within the same workspace", async () => {
+    const sourceRuntime: CodexThreadEnvironmentRuntime = {
+      environmentId: "pwragent",
+      environmentName: "PwrAgent",
+      executionTarget: "local",
+      cwd: "/repo/app",
+      setupEnabled: true,
+      setupStatus: "completed",
+      setupCommand: "nvm use",
+      shellEnvironment: {
+        PATH: "/Users/huntharo/.nvm/versions/node/v24.14.1/bin:/usr/bin",
+        NVM_DIR: "/Users/huntharo/.nvm",
+      },
+      selectedActionIdByEnvironmentId: {
+        pwragent: "start-dev",
+      },
+      actions: [
+        {
+          id: "start-dev",
+          name: "Start dev",
+          command: "pnpm dev",
+        },
+      ],
+      actionRuns: [
+        {
+          runId: "parent-action-run",
+          actionId: "start-dev",
+          actionName: "Start dev",
+          command: "pnpm dev",
+          status: "started",
+          startedAt: 1_000,
+        },
+      ],
+      sourcePath: "/repo/app/.codex/environments/pwragent.toml",
+    };
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-parent": {
+          backend: "codex",
+          threadId: "thread-parent",
+          executionMode: "default",
+          codexEnvironmentRuntime: sourceRuntime,
+          extraLinkedDirectories: [],
+        },
+      },
+    });
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/fork"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+      gitDirectoryService: {
+        prepareLaunchpadWorkspace: vi.fn(async () => ({
+          cwd: "/repo/app",
+          workMode: "local" as const,
+        })),
+        recordCodexWorktreeOwnerThread: vi.fn(async () => {}),
+      } as never,
+    });
+
+    const response = await registry.forkThread({
+      backend: "codex",
+      sourceThreadId: "thread-parent",
+      parentThreadId: "thread-parent",
+      executionMode: "default",
+      directoryKind: "directory",
+      directoryLabel: "app",
+      directoryPath: "/repo/app",
+      workMode: "local",
+    });
+
+    const { actionRuns: _actionRuns, ...sourceRuntimeWithoutRuns } = sourceRuntime;
+    const expectedRuntime = {
+      ...sourceRuntimeWithoutRuns,
+      cwd: "/repo/app",
+    };
+    expect(codexClient.lastForkThreadParams?.codexEnvironmentRuntime).toEqual(
+      expectedRuntime,
+    );
+    expect(response.codexEnvironmentRuntime).toEqual(expectedRuntime);
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-fork",
+      }),
+    ).resolves.toMatchObject({
+      codexEnvironmentRuntime: expectedRuntime,
+    });
+    expect(response.codexEnvironmentRuntime?.actionRuns).toBeUndefined();
+
+    await registry.close();
+  });
+
+  it("reruns selected Codex environment setup when forking into a new worktree", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-fork-env-setup-"));
+    const repoPath = path.join(root, "repo");
+    const worktreePath = path.join(root, "worktree");
+    await mkdir(path.join(worktreePath, ".codex", "environments"), { recursive: true });
+    await writeFile(
+      path.join(worktreePath, ".codex", "environments", "environment.toml"),
+      `
+version = 1
+name = "PwrAgnt"
+
+[setup]
+script = "printf setup"
+
+[[actions]]
+name = "Dev"
+command = "pnpm dev"
+`,
+      "utf8",
+    );
+
+    const commandRunner: CodexEnvironmentCommandRunner = vi.fn(async (params) => {
+      expect(params).toMatchObject({
+        cwd: worktreePath,
+        command: "printf setup",
+        mode: "wait",
+        captureShellEnvironment: true,
+      });
+      return {
+        durationMs: 5,
+        exitCode: 0,
+        output: "setup",
+        shellEnvironment: {
+          PATH: `${worktreePath}/.venv/bin:/usr/bin`,
+          VIRTUAL_ENV: `${worktreePath}/.venv`,
+        },
+      };
+    });
+    const sourceRuntime: CodexThreadEnvironmentRuntime = {
+      environmentId: "environment",
+      environmentName: "PwrAgnt",
+      executionTarget: "local",
+      cwd: repoPath,
+      setupEnabled: true,
+      setupStatus: "completed",
+      setupCommand: "printf setup",
+      shellEnvironment: {
+        PATH: `${repoPath}/.venv/bin:/usr/bin`,
+        VIRTUAL_ENV: `${repoPath}/.venv`,
+      },
+      selectedActionIdByEnvironmentId: {
+        environment: "dev",
+      },
+      actions: [
+        {
+          id: "dev",
+          name: "Dev",
+          command: "pnpm dev",
+        },
+      ],
+    };
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-parent": {
+          backend: "codex",
+          threadId: "thread-parent",
+          executionMode: "default",
+          codexEnvironmentRuntime: sourceRuntime,
+          extraLinkedDirectories: [],
+        },
+      },
+    });
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/fork"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      codexEnvironmentCommandRunner: commandRunner,
+      overlayStore,
+      gitDirectoryService: {
+        prepareLaunchpadWorkspace: vi.fn(async () => ({
+          cwd: worktreePath,
+          repositoryPath: repoPath,
+          workMode: "worktree" as const,
+        })),
+        recordCodexWorktreeOwnerThread: vi.fn(async () => {}),
+      } as never,
+    });
+
+    try {
+      const response = await registry.forkThread({
+        backend: "codex",
+        sourceThreadId: "thread-parent",
+        parentThreadId: "thread-parent",
+        executionMode: "default",
+        directoryKind: "directory",
+        directoryLabel: "repo",
+        directoryPath: repoPath,
+        workMode: "worktree",
+      });
+
+      expect(commandRunner).toHaveBeenCalledTimes(1);
+      expect(codexClient.lastForkThreadParams?.codexEnvironmentRuntime).toMatchObject({
+        environmentId: "environment",
+        cwd: worktreePath,
+        setupStatus: "completed",
+        shellEnvironment: {
+          PATH: `${worktreePath}/.venv/bin:/usr/bin`,
+          VIRTUAL_ENV: `${worktreePath}/.venv`,
+        },
+        selectedActionIdByEnvironmentId: {
+          environment: "dev",
+        },
+      });
+      expect(
+        codexClient.lastForkThreadParams?.codexEnvironmentRuntime?.shellEnvironment
+          ?.VIRTUAL_ENV,
+      ).not.toBe(`${repoPath}/.venv`);
+      expect(response.codexEnvironmentRuntime).toEqual(
+        codexClient.lastForkThreadParams?.codexEnvironmentRuntime,
+      );
+    } finally {
+      await registry.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("forks a Codex thread into a new managed worktree", async () => {
     const recordCodexWorktreeOwnerThread = vi.fn(async () => {});
     const prepareLaunchpadWorkspace = vi.fn(async () => ({
@@ -8043,6 +8383,51 @@ command = "pnpm dev"
       reasoningEffort: "medium",
       fastMode: undefined,
       collaborationMode: undefined,
+    });
+
+    await registry.close();
+  });
+
+  it("passes persisted Codex environment hydration when starting turns", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+    });
+    const codexEnvironmentRuntime: CodexThreadEnvironmentRuntime = {
+      environmentId: "env",
+      environmentName: "Env",
+      executionTarget: "local",
+      shellEnvironment: {
+        PATH: "/Users/huntharo/.nvm/versions/node/v24.14.1/bin:/usr/bin",
+        NVM_DIR: "/Users/huntharo/.nvm",
+      },
+    };
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock({
+        overlays: {
+          "codex:thread-env": {
+            backend: "codex",
+            threadId: "thread-env",
+            executionMode: "default",
+            codexEnvironmentRuntime,
+            extraLinkedDirectories: [],
+          },
+        },
+      }),
+    });
+
+    await registry.startTurn({
+      backend: "codex",
+      threadId: "thread-env",
+      input: [{ type: "text", text: "Use hydrated environment" }],
+    });
+
+    expect(codexClient.lastStartTurnParams).toMatchObject({
+      threadId: "thread-env",
+      codexEnvironmentRuntime,
     });
 
     await registry.close();
@@ -9061,6 +9446,60 @@ command = "pnpm dev"
       threadId: "thread-1",
       target: { type: "baseBranch", branch: "main" },
       delivery: "inline",
+    });
+
+    await registry.close();
+  });
+
+  it("passes persisted Codex environment hydration when starting reviews", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["review/start"] },
+    });
+    const codexEnvironmentRuntime: CodexThreadEnvironmentRuntime = {
+      environmentId: "env",
+      environmentName: "Env",
+      executionTarget: "local",
+      shellEnvironment: {
+        PATH: "/repo/app/.venv/bin:/usr/bin",
+        VIRTUAL_ENV: "/repo/app/.venv",
+      },
+    };
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock({
+        overlays: {
+          "codex:thread-env": {
+            backend: "codex",
+            threadId: "thread-env",
+            executionMode: "default",
+            codexEnvironmentRuntime,
+            extraLinkedDirectories: [
+              {
+                id: "/repo/app",
+                kind: "local",
+                label: "app",
+                path: "/repo/app",
+              },
+            ],
+          },
+        },
+      }),
+    });
+
+    await registry.startReview({
+      backend: "codex",
+      threadId: "thread-env",
+      target: { type: "baseBranch", branch: "main" },
+      delivery: "inline",
+    });
+
+    expect(codexClient.lastStartReviewParams).toMatchObject({
+      threadId: "thread-env",
+      cwd: "/repo/app",
+      codexEnvironmentRuntime,
     });
 
     await registry.close();

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -4593,6 +4593,15 @@ describe("CodexAppServerClient", () => {
       sandbox: "workspace-write",
       serviceTier: "fast",
       fastMode: true,
+      codexEnvironmentRuntime: {
+        environmentId: "pwragent",
+        environmentName: "PwrAgent",
+        executionTarget: "local",
+        shellEnvironment: {
+          PATH: "/Users/huntharo/.nvm/versions/node/v24.14.1/bin:/usr/bin",
+          NVM_DIR: "/Users/huntharo/.nvm",
+        },
+      },
     });
 
     expect(forked).toEqual({
@@ -4610,6 +4619,9 @@ describe("CodexAppServerClient", () => {
       serviceTier: "priority",
       config: {
         fast_mode: true,
+        "shell_environment_policy.set.PATH":
+          "/Users/huntharo/.nvm/versions/node/v24.14.1/bin:/usr/bin",
+        "shell_environment_policy.set.NVM_DIR": "/Users/huntharo/.nvm",
       },
       excludeTurns: true,
       persistExtendedHistory: false,
@@ -4696,6 +4708,46 @@ describe("CodexAppServerClient", () => {
           deferLoading: false,
         },
       ],
+    });
+
+    await client.close();
+  });
+
+  it("passes local environment shell hydration to Codex thread/start config", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    await client.startThread({
+      cwd: "/Users/huntharo/pwrdrvr/PwrAgent",
+      codexEnvironmentRuntime: {
+        environmentId: "env",
+        environmentName: "Env",
+        executionTarget: "local",
+        cwd: "/Users/huntharo/pwrdrvr/PwrAgent",
+        shellEnvironment: {
+          PATH: "/Users/huntharo/.nvm/versions/node/v26.0.0/bin:/usr/bin",
+          NVM_DIR: "/Users/huntharo/.nvm",
+        },
+      },
+    });
+
+    const transport = MockTransport.instances.at(-1);
+    expect(transport).toBeDefined();
+    const startPayload = transport!.sentMessages
+      .map((message) => JSON.parse(message) as { method?: string; params?: unknown })
+      .find((payload) => payload.method === "thread/start");
+
+    expect(startPayload?.params).toMatchObject({
+      cwd: "/Users/huntharo/pwrdrvr/PwrAgent",
+      config: {
+        "shell_environment_policy.set.PATH":
+          "/Users/huntharo/.nvm/versions/node/v26.0.0/bin:/usr/bin",
+        "shell_environment_policy.set.NVM_DIR": "/Users/huntharo/.nvm",
+      },
     });
 
     await client.close();
@@ -5471,7 +5523,17 @@ describe("CodexAppServerClient", () => {
       threadId: "thread-2",
       input: [{ type: "text", text: "Reply to the existing thread" }],
       cwd: "/repo/app/.worktrees/thread-2/app",
-      model: "gpt-5.4"
+      model: "gpt-5.4",
+      codexEnvironmentRuntime: {
+        environmentId: "env",
+        environmentName: "Env",
+        executionTarget: "local",
+        cwd: "/repo/app/.worktrees/thread-2/app",
+        shellEnvironment: {
+          PATH: "/Users/huntharo/.nvm/versions/node/v24.14.1/bin:/usr/bin",
+          NVM_DIR: "/Users/huntharo/.nvm",
+        },
+      },
     });
 
     expect(result).toEqual({
@@ -5503,6 +5565,11 @@ describe("CodexAppServerClient", () => {
     expect(resumePayload?.params).toMatchObject({
       threadId: "thread-2",
       cwd: "/repo/app/.worktrees/thread-2/app",
+      config: {
+        "shell_environment_policy.set.PATH":
+          "/Users/huntharo/.nvm/versions/node/v24.14.1/bin:/usr/bin",
+        "shell_environment_policy.set.NVM_DIR": "/Users/huntharo/.nvm",
+      },
     });
     expect(turnStartPayload?.params).toMatchObject({
       threadId: "thread-2",
@@ -5525,6 +5592,14 @@ describe("CodexAppServerClient", () => {
       input: [{ type: "text", text: "Reply quickly" }],
       model: "gpt-5.5",
       fastMode: true,
+      codexEnvironmentRuntime: {
+        environmentId: "env",
+        environmentName: "Env",
+        executionTarget: "local",
+        shellEnvironment: {
+          PATH: "/Users/huntharo/.nvm/versions/node/v24.14.1/bin:/usr/bin",
+        },
+      },
     });
 
     const transport = MockTransport.instances.at(-1);
@@ -5542,6 +5617,11 @@ describe("CodexAppServerClient", () => {
         params: expect.objectContaining({
           model: "gpt-5.5",
           serviceTier: "priority",
+          config: {
+            fast_mode: true,
+            "shell_environment_policy.set.PATH":
+              "/Users/huntharo/.nvm/versions/node/v24.14.1/bin:/usr/bin",
+          },
         }),
       }),
     );
@@ -5723,6 +5803,16 @@ describe("CodexAppServerClient", () => {
       threadId: "thread-2",
       target: { type: "baseBranch", branch: "main" },
       delivery: "inline",
+      cwd: "/Users/example/project",
+      codexEnvironmentRuntime: {
+        environmentId: "env",
+        environmentName: "Env",
+        executionTarget: "local",
+        shellEnvironment: {
+          PATH: "/Users/example/project/.venv/bin:/usr/bin",
+          VIRTUAL_ENV: "/Users/example/project/.venv",
+        },
+      },
     });
 
     expect(result).toEqual({
@@ -5737,6 +5827,21 @@ describe("CodexAppServerClient", () => {
       (message) => JSON.parse(message) as { method?: string; params?: unknown }
     );
     expect(requests.map((request) => request.method)).toContain("thread/resume");
+    expect(requests).toContainEqual(
+      expect.objectContaining({
+        method: "thread/resume",
+        params: expect.objectContaining({
+          threadId: "thread-2",
+          cwd: "/Users/example/project",
+          "config": {
+            "shell_environment_policy.set.PATH":
+              "/Users/example/project/.venv/bin:/usr/bin",
+            "shell_environment_policy.set.VIRTUAL_ENV":
+              "/Users/example/project/.venv",
+          },
+        }),
+      }),
+    );
     expect(requests).toContainEqual(
       expect.objectContaining({
         method: "review/start",

--- a/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
@@ -397,6 +397,169 @@ describe("codex environment runtime", () => {
     }
   });
 
+  it("captures the successful setup shell environment without leaking it into setup output", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-env-capture-"));
+    const toolPath = path.join(root, "node-bin");
+
+    try {
+      await mkdir(toolPath, { recursive: true });
+      const runtime = await applyLocalCodexEnvironmentSelection({
+        cwd: root,
+        env: {
+          ...process.env,
+          SHELL: "/bin/sh",
+        },
+        selection: {
+          environment: {
+            id: "env",
+            name: "Env",
+            sourcePath: path.join(root, "environment.toml"),
+            setupScript: [
+              `export PATH=${JSON.stringify(toolPath)}:$PATH`,
+              `export NVM_DIR=${JSON.stringify(path.join(root, ".nvm"))}`,
+              "export PWRAGENT_SHOULD_NOT_PERSIST=1",
+              "export GITHUB_TOKEN=secret",
+              "printf setup-output",
+            ].join("\n"),
+            actions: [],
+          },
+          executionTarget: "local",
+          setupEnabled: true,
+        },
+      });
+
+      expect(runtime?.setupOutput).toBe("setup-output");
+      expect(runtime?.shellEnvironment).toMatchObject({
+        NVM_DIR: path.join(root, ".nvm"),
+      });
+      expect(runtime?.shellEnvironment?.PATH).toContain(toolPath);
+      expect(runtime?.shellEnvironment).not.toHaveProperty("GITHUB_TOKEN");
+      expect(runtime?.shellEnvironment).not.toHaveProperty(
+        "PWRAGENT_SHOULD_NOT_PERSIST",
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not persist allow-listed env values that contain URL credentials", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-env-capture-secret-"));
+    const pnpmHome = path.join(root, "pnpm-home");
+
+    try {
+      await mkdir(pnpmHome, { recursive: true });
+      const runtime = await applyLocalCodexEnvironmentSelection({
+        cwd: root,
+        env: {
+          ...process.env,
+          SHELL: "/bin/sh",
+        },
+        selection: {
+          environment: {
+            id: "env",
+            name: "Env",
+            sourcePath: path.join(root, "environment.toml"),
+            setupScript: [
+              `export PNPM_HOME=${JSON.stringify(pnpmHome)}`,
+              "export NPM_CONFIG_PROXY=http://user:pass@proxy.example.test",
+              "export npm_config_registry=https://token@registry.example.test/npm/",
+              "printf setup-output",
+            ].join("\n"),
+            actions: [],
+          },
+          executionTarget: "local",
+          setupEnabled: true,
+        },
+      });
+
+      expect(runtime?.shellEnvironment).toMatchObject({
+        PNPM_HOME: pnpmHome,
+      });
+      expect(runtime?.shellEnvironment).not.toHaveProperty("NPM_CONFIG_PROXY");
+      expect(runtime?.shellEnvironment).not.toHaveProperty("npm_config_registry");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not fail setup when PATH no longer contains env", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-env-capture-path-"));
+    const toolPath = path.join(root, "toolchain-bin");
+
+    try {
+      await mkdir(toolPath, { recursive: true });
+      const runtime = await applyLocalCodexEnvironmentSelection({
+        cwd: root,
+        env: {
+          ...process.env,
+          SHELL: "/bin/sh",
+        },
+        selection: {
+          environment: {
+            id: "env",
+            name: "Env",
+            sourcePath: path.join(root, "environment.toml"),
+            setupScript: [
+              `export PATH=${JSON.stringify(toolPath)}`,
+              "printf setup-output",
+            ].join("\n"),
+            actions: [],
+          },
+          executionTarget: "local",
+          setupEnabled: true,
+        },
+      });
+
+      expect(runtime).toMatchObject({
+        setupStatus: "completed",
+        setupOutput: "setup-output",
+      });
+      expect(runtime?.shellEnvironment?.PATH).toBe(toolPath);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("reuses cached shell hydration when setup is disabled", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-env-cache-"));
+    try {
+      const cachedEnvironment = {
+        PATH: "/cached/node/bin:/usr/bin",
+        NVM_DIR: path.join(root, ".nvm"),
+      };
+      const runtime = await applyLocalCodexEnvironmentSelection({
+        cwd: root,
+        hydrationStore: {
+          get: () => ({
+            key: "cache-key",
+            environmentId: "env",
+            setupScriptHash: "hash",
+            shellEnvironment: cachedEnvironment,
+            updatedAt: Date.now(),
+          }),
+          set: () => {
+            throw new Error("setup-disabled environment should not update cache");
+          },
+        },
+        selection: {
+          environment: {
+            id: "env",
+            name: "Env",
+            sourcePath: path.join(root, "environment.toml"),
+            setupScript: "printf setup",
+            actions: [],
+          },
+          executionTarget: "local",
+          setupEnabled: false,
+        },
+      });
+
+      expect(runtime?.shellEnvironment).toEqual(cachedEnvironment);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("fails setup immediately when an earlier script command exits non-zero", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-env-strict-"));
     const shellPath = path.join(root, "test-shell.sh");

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import { promisify } from "node:util";
 import type { DynamicToolSpec as CodexDynamicToolSpec } from "@pwrdrvr/codex-app-server-protocol/v2";
 import type { MessagingApprovalDecision } from "@pwragent/messaging-interface";
-import { getAppStateMode } from "../state/app-state";
+import { getAppStateDb, getAppStateMode } from "../state/app-state";
 import type { OverlayStoreLike } from "../state/overlay-store-sqlite";
 import { requestShowThread } from "../window-show-thread";
 import { PerKeyAsyncLock } from "../util/per-key-async-lock";
@@ -57,6 +57,7 @@ import {
   type LinkedDirectorySummary,
   type MaterializeDirectoryLaunchpadRequest,
   type MaterializeDirectoryLaunchpadResponse,
+  type LaunchpadWorkMode,
   type NavigationDirectoryGitStatus,
   type NavigationDirectorySummary,
   type NavigationLaunchpadDraft,
@@ -176,6 +177,8 @@ import {
 } from "./backend-model-catalog";
 import {
   listCodexEnvironmentOptions,
+  pruneCodexEnvironmentActionMap,
+  resolveCodexEnvironmentActionId,
   withCodexEnvironmentOptions,
 } from "./codex-environment-config";
 import {
@@ -187,6 +190,10 @@ import {
   type CodexEnvironmentDetachedOutput,
   type CodexEnvironmentSelection,
 } from "./codex-environment-runtime";
+import {
+  CodexEnvironmentHydrationStore,
+  type CodexEnvironmentHydrationStoreLike,
+} from "./codex-environment-hydration-store";
 import {
   ThreadTurnQueue,
   type ThreadTurnQueueEntry,
@@ -335,6 +342,7 @@ type BackendClient = {
     sandbox?: string;
     serviceTier?: string;
     fastMode?: boolean;
+    codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
   }): Promise<{ threadId: string }>;
   startTurn(params: {
     threadId: string;
@@ -347,6 +355,7 @@ type BackendClient = {
     serviceTier?: string;
     reasoningEffort?: string;
     fastMode?: boolean;
+    codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
   }): Promise<{
     threadId: string;
     turnId: string;
@@ -355,6 +364,8 @@ type BackendClient = {
     threadId: string;
     target: StartReviewRequest["target"];
     delivery?: StartReviewRequest["delivery"];
+    cwd?: string;
+    codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
   }): Promise<{ threadId: string; reviewThreadId: string; turnId: string }>;
   listModels?(diagnostics?: {
     callerReason?: string;
@@ -1753,7 +1764,7 @@ function resolveCodexEnvironmentSelection(
   return {
     environment,
     executionTarget: launchpad.codexEnvironmentExecutionTarget ?? "local",
-    setupEnabled: Boolean(launchpad.codexEnvironmentSetupEnabled),
+    setupEnabled: Boolean(environment.setupScript),
   };
 }
 
@@ -1848,6 +1859,74 @@ function appendCodexEnvironmentSetupActivity(params: {
     ...params.replay,
     entries: [activity, ...params.replay.entries],
   };
+}
+
+function createDefaultCodexEnvironmentHydrationStore():
+  | CodexEnvironmentHydrationStore
+  | undefined {
+  try {
+    return new CodexEnvironmentHydrationStore(getAppStateDb());
+  } catch {
+    return undefined;
+  }
+}
+
+function cloneCodexEnvironmentRuntimeForFork(
+  runtime: CodexThreadEnvironmentRuntime,
+  cwd?: string,
+): CodexThreadEnvironmentRuntime {
+  const {
+    actionRuns: _actionRuns,
+    actionId: _actionId,
+    actionName: _actionName,
+    actionCommand: _actionCommand,
+    actionStatus: _actionStatus,
+    actionPid: _actionPid,
+    actionStartedAt: _actionStartedAt,
+    actionExitedAt: _actionExitedAt,
+    actionExitCode: _actionExitCode,
+    actionExitSignal: _actionExitSignal,
+    actionDurationMs: _actionDurationMs,
+    actionOutput: _actionOutput,
+    selectedActionIdByEnvironmentId,
+    ...rest
+  } = runtime;
+  const inheritedSelectedActionIdByEnvironmentId =
+    selectedActionIdByEnvironmentId ??
+    (_actionId ? { [runtime.environmentId]: _actionId } : undefined);
+  const next: CodexThreadEnvironmentRuntime = {
+    ...rest,
+    ...(inheritedSelectedActionIdByEnvironmentId
+      ? {
+          selectedActionIdByEnvironmentId: {
+            ...inheritedSelectedActionIdByEnvironmentId,
+          },
+        }
+      : {}),
+    ...(runtime.actions
+      ? { actions: runtime.actions.map((action) => ({ ...action })) }
+      : {}),
+    ...(runtime.shellEnvironment
+      ? { shellEnvironment: { ...runtime.shellEnvironment } }
+      : {}),
+  };
+  const trimmedCwd = cwd?.trim();
+  if (trimmedCwd) {
+    next.cwd = trimmedCwd;
+  }
+  return next;
+}
+
+function readSelectedActionIdByEnvironmentIdForFork(
+  runtime: CodexThreadEnvironmentRuntime,
+): Record<string, string> | undefined {
+  if (runtime.selectedActionIdByEnvironmentId) {
+    return { ...runtime.selectedActionIdByEnvironmentId };
+  }
+  if (runtime.actionId) {
+    return { [runtime.environmentId]: runtime.actionId };
+  }
+  return undefined;
 }
 
 function extractFirstMeaningfulTextInput(input: AppServerTurnInputItem[]): string | undefined {
@@ -2249,6 +2328,7 @@ export class DesktopBackendRegistry {
   private readonly modelCatalog: BackendModelCatalog;
   private readonly codexEnvironmentCommandEnv?: NodeJS.ProcessEnv;
   private readonly codexEnvironmentCommandRunner?: CodexEnvironmentCommandRunner;
+  private readonly codexEnvironmentHydrationStore?: CodexEnvironmentHydrationStoreLike;
   private readonly threadListCacheOwnerId = `backend-thread-list-cache-${++threadListCacheSequence}`;
   private readonly threadListCache = new Map<string, ThreadListCacheState>();
   private readonly activeThreadIdsByBackend = new Map<AppServerBackendKind, Set<string>>();
@@ -2383,6 +2463,7 @@ export class DesktopBackendRegistry {
     automationInspectionMcpCommand?: string;
     createScratchProjectDirectory?: () => Promise<string>;
     codexEnvironmentCommandRunner?: CodexEnvironmentCommandRunner;
+    codexEnvironmentHydrationStore?: CodexEnvironmentHydrationStoreLike;
     threadTitleGenerationService?: ThreadTitleService | null;
     isCodexBootstrapDeferred?: () => boolean;
     isBootstrapMode?: () => boolean;
@@ -2432,6 +2513,9 @@ export class DesktopBackendRegistry {
         : undefined;
     this.codexEnvironmentCommandEnv = codexEnv;
     this.codexEnvironmentCommandRunner = options?.codexEnvironmentCommandRunner;
+    this.codexEnvironmentHydrationStore =
+      options?.codexEnvironmentHydrationStore ??
+      createDefaultCodexEnvironmentHydrationStore();
     const codexHome = codexEnv?.CODEX_HOME?.trim() || undefined;
     const createsLiveGrokClient = !options?.grokClient && !replayClients?.grokClient;
     const grokApiKey = createsLiveGrokClient
@@ -4596,6 +4680,57 @@ export class DesktopBackendRegistry {
     };
   }
 
+  private async buildForkedCodexEnvironmentRuntime(params: {
+    cwd?: string;
+    sourceRuntime?: CodexThreadEnvironmentRuntime;
+    workMode: LaunchpadWorkMode;
+  }): Promise<CodexThreadEnvironmentRuntime | undefined> {
+    const { cwd, sourceRuntime, workMode } = params;
+    if (!sourceRuntime) {
+      return undefined;
+    }
+    if (
+      workMode !== "worktree" ||
+      sourceRuntime.executionTarget !== "local" ||
+      !cwd?.trim()
+    ) {
+      return cloneCodexEnvironmentRuntimeForFork(sourceRuntime, cwd);
+    }
+
+    const environment = (await listCodexEnvironmentOptions(cwd))
+      .find((candidate) => candidate.id === sourceRuntime.environmentId);
+    if (!environment) {
+      throw new Error(
+        `Selected Codex environment '${sourceRuntime.environmentName}' is not available in the forked worktree.`,
+      );
+    }
+
+    const runtime = await applyLocalCodexEnvironmentSelection({
+      commandRunner: this.codexEnvironmentCommandRunner,
+      cwd,
+      env: this.codexEnvironmentCommandEnv,
+      hydrationStore: this.codexEnvironmentHydrationStore,
+      selection: {
+        environment,
+        executionTarget: "local",
+        setupEnabled: Boolean(environment.setupScript),
+      },
+    });
+    if (!runtime) {
+      return undefined;
+    }
+    const selectedActionIdByEnvironmentId = pruneCodexEnvironmentActionMap(
+      readSelectedActionIdByEnvironmentIdForFork(sourceRuntime),
+      [environment],
+    );
+    return {
+      ...runtime,
+      ...(Object.keys(selectedActionIdByEnvironmentId).length > 0
+        ? { selectedActionIdByEnvironmentId }
+        : {}),
+    };
+  }
+
   async forkThread(
     request: BackendRegistryForkThreadRequest,
   ): Promise<ForkThreadResponse> {
@@ -4614,6 +4749,10 @@ export class DesktopBackendRegistry {
       request.directoryLabel?.trim() ||
       (request.directoryPath ? path.basename(request.directoryPath) : undefined) ||
       "Forked thread";
+    const sourceOverlay = await this.overlayStore.getThreadOverlayState({
+      backend,
+      threadId: request.sourceThreadId,
+    });
     const preparedWorkspace = await this.gitDirectoryService.prepareLaunchpadWorkspace({
       backend,
       branchName: request.branchName,
@@ -4644,7 +4783,13 @@ export class DesktopBackendRegistry {
     }
 
     let result: { threadId: string };
+    let forkedCodexEnvironmentRuntime: CodexThreadEnvironmentRuntime | undefined;
     try {
+      forkedCodexEnvironmentRuntime = await this.buildForkedCodexEnvironmentRuntime({
+        cwd,
+        sourceRuntime: sourceOverlay?.codexEnvironmentRuntime,
+        workMode: preparedWorkspace.workMode,
+      });
       result = await client.forkThread({
         threadId: request.sourceThreadId,
         ...(request.sourceThreadPath?.trim()
@@ -4654,6 +4799,7 @@ export class DesktopBackendRegistry {
         ...modelSettings,
         approvalPolicy: request.approvalPolicy ?? modeSettings.approvalPolicy,
         sandbox: request.sandbox ?? modeSettings.sandbox,
+        codexEnvironmentRuntime: forkedCodexEnvironmentRuntime,
       });
     } catch (error) {
       await preparedWorkspace.rollback?.();
@@ -4673,6 +4819,9 @@ export class DesktopBackendRegistry {
         updatedAt: forkedAt,
         executionMode,
         ...modelSettings,
+        ...(forkedCodexEnvironmentRuntime
+          ? { codexEnvironmentRuntime: forkedCodexEnvironmentRuntime }
+          : {}),
         linkedDirectories: linkedDirectories.map(normalizeLinkedDirectoryKind),
         gitBranch,
       });
@@ -4700,6 +4849,13 @@ export class DesktopBackendRegistry {
           backend,
           threadId: result.threadId,
           ...modelSettings,
+        });
+      }
+      if (forkedCodexEnvironmentRuntime) {
+        await this.overlayStore.setThreadCodexEnvironmentRuntime?.({
+          backend,
+          threadId: result.threadId,
+          codexEnvironmentRuntime: forkedCodexEnvironmentRuntime,
         });
       }
       if (request.parentThreadId?.trim()) {
@@ -4739,6 +4895,7 @@ export class DesktopBackendRegistry {
       executionMode,
       linkedDirectory: linkedDirectories[0],
       workMode: preparedWorkspace.workMode,
+      codexEnvironmentRuntime: forkedCodexEnvironmentRuntime,
     };
   }
 
@@ -4969,6 +5126,9 @@ export class DesktopBackendRegistry {
                 ...turnParams,
                 approvalPolicy: params.approvalPolicy ?? modeSettings.approvalPolicy,
                 sandbox: params.sandbox ?? modeSettings.sandbox,
+                ...(overlay?.codexEnvironmentRuntime
+                  ? { codexEnvironmentRuntime: overlay.codexEnvironmentRuntime }
+                  : {}),
               });
               activeTurnMode = effectiveMode;
               return started;
@@ -5136,6 +5296,21 @@ export class DesktopBackendRegistry {
       if (params.backend === "codex") {
         await this.flushQueuedExecutionModeIfPresent(params.threadId);
       }
+      const overlay =
+        params.backend === "codex"
+          ? await this.overlayStore.getThreadOverlayState({
+              backend: params.backend,
+              threadId: params.threadId,
+            })
+          : undefined;
+      const cwd =
+        params.backend === "codex"
+          ? await this.resolveThreadEnvironmentCwd(
+              params.backend,
+              params.threadId,
+              overlay,
+            )
+          : undefined;
 
       const startWithClient = async (
         client: BackendClient,
@@ -5147,6 +5322,10 @@ export class DesktopBackendRegistry {
           threadId: params.threadId,
           target: params.target,
           delivery: params.delivery ?? "inline",
+          ...(cwd ? { cwd } : {}),
+          ...(overlay?.codexEnvironmentRuntime
+            ? { codexEnvironmentRuntime: overlay.codexEnvironmentRuntime }
+            : {}),
         });
       };
 
@@ -6671,10 +6850,17 @@ export class DesktopBackendRegistry {
             request.threadId,
             overlay,
           ));
-        const runtimeForAction = await this.refreshCodexEnvironmentRuntimeActions(
+        const refreshedRuntimeForAction = await this.refreshCodexEnvironmentRuntimeActions(
           currentCwd?.trim() ? { ...runtime, cwd: currentCwd.trim() } : runtime,
           request.actionId,
         );
+        const runtimeForAction: CodexThreadEnvironmentRuntime = {
+          ...refreshedRuntimeForAction,
+          selectedActionIdByEnvironmentId: {
+            ...(refreshedRuntimeForAction.selectedActionIdByEnvironmentId ?? {}),
+            [refreshedRuntimeForAction.environmentId]: request.actionId,
+          },
+        };
         const runId = randomUUID();
         let nextRuntime: CodexThreadEnvironmentRuntime;
         try {
@@ -6809,15 +6995,38 @@ export class DesktopBackendRegistry {
     if (!environment) {
       throw new Error("Selected environment is not available for this thread.");
     }
+    const selectedActionIdByEnvironmentId = pruneCodexEnvironmentActionMap(
+      overlay?.codexEnvironmentRuntime?.selectedActionIdByEnvironmentId,
+      options,
+    );
+    const selectedActionId = resolveCodexEnvironmentActionId({
+      actionId: request.actionId,
+      environment,
+      selectedActionIdByEnvironmentId,
+    });
+    if (selectedActionId) {
+      selectedActionIdByEnvironmentId[environment.id] = selectedActionId;
+    } else {
+      delete selectedActionIdByEnvironmentId[environment.id];
+    }
 
+    const existingRuntime =
+      overlay?.codexEnvironmentRuntime?.environmentId === environment.id
+        ? overlay.codexEnvironmentRuntime
+        : undefined;
     const codexEnvironmentRuntime: CodexThreadEnvironmentRuntime = {
+      ...(existingRuntime ?? {}),
       environmentId: environment.id,
       environmentName: environment.name,
-      executionTarget: "local",
+      executionTarget: existingRuntime?.executionTarget ?? "local",
       cwd,
-      setupEnabled: false,
+      setupEnabled: existingRuntime?.setupEnabled ?? false,
       setupCommand: environment.setupScript,
       actions: environment.actions,
+      selectedActionIdByEnvironmentId:
+        Object.keys(selectedActionIdByEnvironmentId).length > 0
+          ? selectedActionIdByEnvironmentId
+          : undefined,
       sourcePath: environment.sourcePath,
     };
     await this.overlayStore.setThreadCodexEnvironmentRuntime?.({
@@ -7130,6 +7339,7 @@ export class DesktopBackendRegistry {
         onActionDetachedExit,
         onActionDetachedOutput,
         actionRunId: autoActionRunId,
+        hydrationStore: this.codexEnvironmentHydrationStore,
         selection: codexEnvironmentSelection,
       });
     } catch (error) {

--- a/apps/desktop/src/main/app-server/codex-environment-config.ts
+++ b/apps/desktop/src/main/app-server/codex-environment-config.ts
@@ -113,6 +113,39 @@ export function withCodexEnvironmentOptions(
   };
 }
 
+export function pruneCodexEnvironmentActionMap(
+  map: Record<string, string> | undefined,
+  options: CodexEnvironmentOption[],
+): Record<string, string> {
+  if (!map) {
+    return {};
+  }
+  return Object.fromEntries(
+    Object.entries(map).filter(([environmentId, actionId]) => {
+      const environment = options.find((candidate) => candidate.id === environmentId);
+      return Boolean(
+        environment?.actions.some((action) => action.id === actionId),
+      );
+    }),
+  );
+}
+
+export function resolveCodexEnvironmentActionId(params: {
+  actionId?: string;
+  environment: CodexEnvironmentOption;
+  selectedActionIdByEnvironmentId: Record<string, string>;
+}): string | undefined {
+  if (params.environment.actions.some((action) => action.id === params.actionId)) {
+    return params.actionId;
+  }
+  const mappedActionId =
+    params.selectedActionIdByEnvironmentId[params.environment.id];
+  if (params.environment.actions.some((action) => action.id === mappedActionId)) {
+    return mappedActionId;
+  }
+  return params.environment.actions[0]?.id;
+}
+
 export async function hydrateLaunchpadCodexEnvironmentOptions(
   launchpad: NavigationLaunchpadDraft,
 ): Promise<NavigationLaunchpadDraft> {

--- a/apps/desktop/src/main/app-server/codex-environment-hydration-store.ts
+++ b/apps/desktop/src/main/app-server/codex-environment-hydration-store.ts
@@ -1,0 +1,140 @@
+import { createHash } from "node:crypto";
+import type { StateDb } from "../state/state-db";
+
+const CACHE_META_KEY = "codex_environment_hydration_cache_v1";
+const MAX_CACHE_ENTRIES = 100;
+
+export type CodexEnvironmentHydrationCacheEntry = {
+  key: string;
+  environmentId: string;
+  sourcePath?: string;
+  cwd?: string;
+  setupScriptHash: string;
+  shellEnvironment: Record<string, string>;
+  updatedAt: number;
+};
+
+export type CodexEnvironmentHydrationCacheLookup = {
+  environmentId: string;
+  sourcePath?: string;
+  cwd?: string;
+  setupScript?: string;
+};
+
+type CachePayload = {
+  version: 1;
+  entries: CodexEnvironmentHydrationCacheEntry[];
+};
+
+export interface CodexEnvironmentHydrationStoreLike {
+  get(
+    params: CodexEnvironmentHydrationCacheLookup,
+  ): CodexEnvironmentHydrationCacheEntry | undefined;
+  set(params: {
+    environmentId: string;
+    sourcePath?: string;
+    cwd?: string;
+    setupScript?: string;
+    shellEnvironment: Record<string, string>;
+    updatedAt?: number;
+  }): CodexEnvironmentHydrationCacheEntry;
+}
+
+export class CodexEnvironmentHydrationStore
+  implements CodexEnvironmentHydrationStoreLike
+{
+  constructor(private readonly stateDb: StateDb) {}
+
+  get(
+    params: CodexEnvironmentHydrationCacheLookup,
+  ): CodexEnvironmentHydrationCacheEntry | undefined {
+    const key = buildCodexEnvironmentHydrationCacheKey(params);
+    return this.readPayload().entries.find((entry) => entry.key === key);
+  }
+
+  set(params: {
+    environmentId: string;
+    sourcePath?: string;
+    cwd?: string;
+    setupScript?: string;
+    shellEnvironment: Record<string, string>;
+    updatedAt?: number;
+  }): CodexEnvironmentHydrationCacheEntry {
+    const payload = this.readPayload();
+    const key = buildCodexEnvironmentHydrationCacheKey(params);
+    const entry: CodexEnvironmentHydrationCacheEntry = {
+      key,
+      environmentId: params.environmentId,
+      sourcePath: params.sourcePath,
+      cwd: params.cwd,
+      setupScriptHash: hashText(params.setupScript ?? ""),
+      shellEnvironment: params.shellEnvironment,
+      updatedAt: params.updatedAt ?? Date.now(),
+    };
+    const entries = [
+      entry,
+      ...payload.entries.filter((candidate) => candidate.key !== key),
+    ].slice(0, MAX_CACHE_ENTRIES);
+    this.stateDb.setMeta(
+      CACHE_META_KEY,
+      JSON.stringify({
+        version: 1,
+        entries,
+      } satisfies CachePayload),
+    );
+    return entry;
+  }
+
+  private readPayload(): CachePayload {
+    const raw = this.stateDb.getMeta(CACHE_META_KEY);
+    if (!raw) {
+      return { version: 1, entries: [] };
+    }
+    try {
+      const parsed = JSON.parse(raw) as Partial<CachePayload>;
+      if (parsed.version !== 1 || !Array.isArray(parsed.entries)) {
+        return { version: 1, entries: [] };
+      }
+      return {
+        version: 1,
+        entries: parsed.entries.filter(isValidCacheEntry),
+      };
+    } catch {
+      return { version: 1, entries: [] };
+    }
+  }
+}
+
+export function buildCodexEnvironmentHydrationCacheKey(
+  params: CodexEnvironmentHydrationCacheLookup,
+): string {
+  return hashText(
+    [
+      params.environmentId,
+      params.sourcePath ?? "",
+      params.cwd ?? "",
+      hashText(params.setupScript ?? ""),
+    ].join("\0"),
+  );
+}
+
+function isValidCacheEntry(
+  value: unknown,
+): value is CodexEnvironmentHydrationCacheEntry {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as Partial<CodexEnvironmentHydrationCacheEntry>;
+  return (
+    typeof candidate.key === "string" &&
+    typeof candidate.environmentId === "string" &&
+    typeof candidate.setupScriptHash === "string" &&
+    typeof candidate.updatedAt === "number" &&
+    Boolean(candidate.shellEnvironment) &&
+    typeof candidate.shellEnvironment === "object"
+  );
+}
+
+function hashText(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}

--- a/apps/desktop/src/main/app-server/codex-environment-runtime.ts
+++ b/apps/desktop/src/main/app-server/codex-environment-runtime.ts
@@ -1,6 +1,14 @@
 import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { accessSync, constants, statSync } from "node:fs";
+import {
+  accessSync,
+  constants,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+} from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import type {
   CodexEnvironmentActionRun,
@@ -13,6 +21,7 @@ import {
   readCodexEnvironmentActionRuns,
 } from "@pwragent/shared";
 import { getMainLogger } from "../log";
+import type { CodexEnvironmentHydrationStoreLike } from "./codex-environment-hydration-store";
 
 const environmentRuntimeLog = getMainLogger("pwragent:codex-environment-runtime");
 
@@ -103,6 +112,7 @@ export type CodexEnvironmentCommandParams = {
   env?: NodeJS.ProcessEnv;
   mode: "wait" | "detach";
   timeoutMs?: number;
+  captureShellEnvironment?: boolean;
   onProgress?: (
     event: Pick<CodexEnvironmentSetupProgressEvent, "phase" | "chunk" | "at">,
   ) => void;
@@ -145,6 +155,12 @@ export type CodexEnvironmentCommandResult = {
   exitCode?: number;
   output?: string;
   pid?: number;
+  shellEnvironment?: Record<string, string>;
+};
+
+type ShellEnvironmentCaptureTarget = {
+  dirPath: string;
+  filePath: string;
 };
 
 export type CodexEnvironmentCommandRunner = (
@@ -162,6 +178,7 @@ export async function applyLocalCodexEnvironmentSelection(params: {
   onActionDetachedOutput?: (event: CodexEnvironmentDetachedOutput) => void;
   /** Optional caller-generated runId for the auto-action; falls back to a fresh UUID. */
   actionRunId?: string;
+  hydrationStore?: CodexEnvironmentHydrationStoreLike;
   selection?: CodexEnvironmentSelection;
   setupTimeoutMs?: number;
 }): Promise<CodexThreadEnvironmentRuntime | undefined> {
@@ -180,6 +197,9 @@ export async function applyLocalCodexEnvironmentSelection(params: {
       setupStatus: selection.setupEnabled ? "skipped" : undefined,
       setupCommand: selection.environment.setupScript,
       actions: selection.environment.actions,
+      selectedActionIdByEnvironmentId: selection.action
+        ? { [selection.environment.id]: selection.action.id }
+        : undefined,
       actionId: selection.action?.id,
       actionName: selection.action?.name,
       actionCommand: selection.action?.command,
@@ -195,8 +215,18 @@ export async function applyLocalCodexEnvironmentSelection(params: {
     setupEnabled: selection.setupEnabled,
     setupCommand: selection.environment.setupScript,
     actions: selection.environment.actions,
+    selectedActionIdByEnvironmentId: selection.action
+      ? { [selection.environment.id]: selection.action.id }
+      : undefined,
     sourcePath: selection.environment.sourcePath,
   };
+  const cachedShellEnvironment =
+    params.hydrationStore?.get({
+      environmentId: selection.environment.id,
+      sourcePath: selection.environment.sourcePath,
+      cwd,
+      setupScript: selection.environment.setupScript,
+    })?.shellEnvironment;
 
   if (selection.setupEnabled && selection.environment.setupScript) {
     const emitSetupProgress = (
@@ -224,6 +254,7 @@ export async function applyLocalCodexEnvironmentSelection(params: {
         command: selection.environment.setupScript,
         env: params.env,
         mode: "wait",
+        captureShellEnvironment: true,
         timeoutMs:
           params.setupTimeoutMs ??
           readCodexEnvironmentSetupTimeoutMs(params.env ?? process.env),
@@ -235,6 +266,16 @@ export async function applyLocalCodexEnvironmentSelection(params: {
       runtime.setupOutput = result.output;
       runtime.setupExitCode = result.exitCode;
       runtime.setupDurationMs = result.durationMs;
+      runtime.shellEnvironment = result.shellEnvironment ?? cachedShellEnvironment;
+      if (result.shellEnvironment) {
+        params.hydrationStore?.set({
+          environmentId: selection.environment.id,
+          sourcePath: selection.environment.sourcePath,
+          cwd,
+          setupScript: selection.environment.setupScript,
+          shellEnvironment: result.shellEnvironment,
+        });
+      }
       emitSetupProgress({
         phase: "completed",
         output: result.output,
@@ -280,6 +321,13 @@ export async function applyLocalCodexEnvironmentSelection(params: {
   } else if (selection.setupEnabled) {
     runtime.setupStatus = "skipped";
   }
+  if (!runtime.shellEnvironment && cachedShellEnvironment) {
+    runtime.shellEnvironment = cachedShellEnvironment;
+  }
+
+  const actionEnv = runtime.shellEnvironment
+    ? { ...(params.env ?? process.env), ...runtime.shellEnvironment }
+    : params.env;
 
   if (selection.action) {
     const runId = params.actionRunId ?? randomUUID();
@@ -296,7 +344,7 @@ export async function applyLocalCodexEnvironmentSelection(params: {
       const result = await (params.commandRunner ?? runShellCommand)({
         cwd,
         command: selection.action.command,
-        env: params.env,
+        env: actionEnv,
         mode: "detach",
         onDetachedExit: params.onActionDetachedExit,
         onDetachedOutput: params.onActionDetachedOutput,
@@ -368,10 +416,13 @@ export async function startLocalCodexEnvironmentAction(params: {
   const existingRuns = readCodexEnvironmentActionRuns(params.runtime);
 
   try {
+    const actionEnv = params.runtime.shellEnvironment
+      ? { ...(params.env ?? process.env), ...params.runtime.shellEnvironment }
+      : params.env;
     const result = await (params.commandRunner ?? runShellCommand)({
       cwd: params.runtime.cwd,
       command: action.command,
-      env: params.env,
+      env: actionEnv,
       mode: "detach",
       onDetachedExit: params.onDetachedExit,
       onDetachedOutput: params.onDetachedOutput,
@@ -432,18 +483,25 @@ function runShellCommand(
     shell,
     pathPreview: truncateForLog(commandEnv.PATH),
   });
+  const capture = params.captureShellEnvironment
+    ? createShellEnvironmentCaptureTarget()
+    : undefined;
 
   return new Promise((resolve, reject) => {
-    const child = spawn(shell, ["-lc", wrapShellCommand(shell, params.command)], {
-      cwd: params.cwd,
-      detached: params.mode === "detach" || Boolean(params.timeoutMs),
-      env: commandEnv,
-      // Pipe output even in detach mode so we can drain to a ring buffer,
-      // stream to the renderer's anchored output UI, and log non-zero exits.
-      // Caller still resolves on spawn for detach mode; we keep listening so
-      // long-running children (e.g., `pnpm dev`) report failures.
-      stdio: "pipe",
-    });
+    const child = spawn(
+      shell,
+      ["-lc", wrapShellCommand(shell, params.command, capture?.filePath)],
+      {
+        cwd: params.cwd,
+        detached: params.mode === "detach" || Boolean(params.timeoutMs),
+        env: commandEnv,
+        // Pipe output even in detach mode so we can drain to a ring buffer,
+        // stream to the renderer's anchored output UI, and log non-zero exits.
+        // Caller still resolves on spawn for detach mode; we keep listening so
+        // long-running children (e.g., `pnpm dev`) report failures.
+        stdio: "pipe",
+      },
+    );
 
     let combinedOutput = "";
     let settled = false;
@@ -488,6 +546,7 @@ function runShellCommand(
         clearTimeout(killHandle);
         killHandle = undefined;
       }
+      cleanupShellEnvironmentCaptureTarget(capture);
       callback();
     };
 
@@ -694,11 +753,17 @@ function runShellCommand(
         return;
       }
       if (code === 0) {
+        const shellEnvironment = capture
+          ? readCapturedShellEnvironment(capture.filePath)
+          : undefined;
         environmentRuntimeLog.info("codex-environment-command-exit", {
           processId,
           code,
           signal,
           durationMs,
+          capturedEnvKeys: shellEnvironment
+            ? Object.keys(shellEnvironment).sort()
+            : undefined,
         });
         settle(() => {
           resolve({
@@ -706,6 +771,7 @@ function runShellCommand(
             exitCode: code,
             output,
             pid: child.pid,
+            shellEnvironment,
           });
         });
         return;
@@ -746,6 +812,137 @@ function sanitizeLocalEnvironmentCommandEnv(
     }
   }
   return sanitized;
+}
+
+function createShellEnvironmentCaptureTarget():
+  | ShellEnvironmentCaptureTarget
+  | undefined {
+  try {
+    const dirPath = mkdtempSync(path.join(os.tmpdir(), "pwragent-codex-env-"));
+    return {
+      dirPath,
+      filePath: path.join(dirPath, "env"),
+    };
+  } catch (error) {
+    environmentRuntimeLog.warn("codex-environment-capture-target-failed", {
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return undefined;
+  }
+}
+
+function cleanupShellEnvironmentCaptureTarget(
+  capture: ShellEnvironmentCaptureTarget | undefined,
+): void {
+  if (!capture) {
+    return;
+  }
+  try {
+    rmSync(capture.dirPath, { recursive: true, force: true });
+  } catch (error) {
+    environmentRuntimeLog.warn("codex-environment-capture-cleanup-failed", {
+      dirPath: capture.dirPath,
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+function readCapturedShellEnvironment(
+  filePath: string,
+): Record<string, string> | undefined {
+  let raw: string;
+  try {
+    raw = readFileSync(filePath, "utf8");
+  } catch (error) {
+    environmentRuntimeLog.warn("codex-environment-capture-read-failed", {
+      filePath,
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return undefined;
+  }
+
+  const parsed: Record<string, string> = {};
+  for (const line of raw.split("\n")) {
+    const separatorIndex = line.indexOf("=");
+    if (separatorIndex <= 0) {
+      continue;
+    }
+    const key = line.slice(0, separatorIndex);
+    const value = line.slice(separatorIndex + 1);
+    if (shouldPersistCapturedShellEnvironmentKey(key, value)) {
+      parsed[key] = value;
+    }
+  }
+  return Object.keys(parsed).length ? parsed : undefined;
+}
+
+function shouldPersistCapturedShellEnvironmentKey(
+  key: string,
+  value: string,
+): boolean {
+  if (!key || value.includes("\0") || key.includes("=")) {
+    return false;
+  }
+  if (containsUrlUserInfo(value)) {
+    return false;
+  }
+  const upperKey = key.toUpperCase();
+  if (
+    upperKey.includes("TOKEN") ||
+    upperKey.includes("SECRET") ||
+    upperKey.includes("PASSWORD") ||
+    upperKey.includes("PASSWD") ||
+    upperKey.includes("AUTH") ||
+    upperKey.includes("CREDENTIAL") ||
+    upperKey.includes("COOKIE") ||
+    upperKey.includes("KEY")
+  ) {
+    return false;
+  }
+  if (
+    upperKey === "PATH" ||
+    upperKey === "MANPATH" ||
+    upperKey === "INFOPATH" ||
+    upperKey === "JAVA_HOME" ||
+    upperKey === "MAVEN_HOME" ||
+    upperKey === "GRADLE_HOME" ||
+    upperKey === "GOROOT" ||
+    upperKey === "GOPATH" ||
+    upperKey === "GOBIN" ||
+    upperKey === "CARGO_HOME" ||
+    upperKey === "RUSTUP_HOME" ||
+    upperKey === "GEM_HOME" ||
+    upperKey === "GEM_PATH" ||
+    upperKey === "VIRTUAL_ENV" ||
+    upperKey === "CONDA_PREFIX"
+  ) {
+    return true;
+  }
+  return [
+    "NVM_",
+    "NODE_",
+    "npm_",
+    "NPM_",
+    "PNPM_",
+    "COREPACK_",
+    "YARN_",
+    "VOLTA_",
+    "ASDF_",
+    "MISE_",
+    "PYENV_",
+    "POETRY_",
+    "PIPX_",
+    "RBENV_",
+    "CHRUBY_",
+    "RVM_",
+    "BUN_",
+    "DENO_",
+    "SDKMAN_",
+  ].some((prefix) => key.startsWith(prefix));
+}
+
+function containsUrlUserInfo(value: string): boolean {
+  return /(?:^|[\s,;])(?:[a-z][a-z0-9+.-]*):\/\/[^/\s?#@]+@/i.test(value);
 }
 
 function isParentElectronRuntimeEnvKey(key: string): boolean {
@@ -893,14 +1090,25 @@ function readCodexEnvironmentSetupTimeoutMs(env: NodeJS.ProcessEnv): number {
   return Math.round(parsed);
 }
 
-function wrapShellCommand(shell: string, command: string): string {
+function wrapShellCommand(
+  shell: string,
+  command: string,
+  captureEnvPath?: string,
+): string {
   return [
     ...shellStartupCommands(shell),
     '[ -n "${NVM_DIR:-}" ] && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"',
     '[ -z "${NVM_DIR:-}" ] && [ -s "$HOME/.nvm/nvm.sh" ] && . "$HOME/.nvm/nvm.sh"',
     "set -e",
     command,
+    ...(captureEnvPath
+      ? [`{ /usr/bin/env || /bin/env || env; } > ${quoteShellArg(captureEnvPath)} || true`]
+      : []),
   ].join("\n");
+}
+
+function quoteShellArg(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
 function shellStartupCommands(shell: string): string[] {

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -4231,8 +4231,12 @@ function buildThreadStartPayload(params: {
   if (params.ephemeral !== undefined) {
     base.ephemeral = params.ephemeral;
   }
-  if (params.config) {
-    base.config = params.config;
+  const config = mergeCodexShellEnvironmentPolicyConfig(
+    params.config,
+    params.codexEnvironmentRuntime,
+  );
+  if (config) {
+    base.config = config;
   }
   if (params.dynamicTools) {
     base.dynamicTools = params.dynamicTools;
@@ -4253,6 +4257,44 @@ function buildThreadStartPayload(params: {
   return base;
 }
 
+function mergeCodexShellEnvironmentPolicyConfig(
+  config: CodexThreadStartParams["config"] | undefined,
+  runtime: CodexThreadEnvironmentRuntime | undefined,
+): CodexThreadStartParams["config"] | undefined {
+  if (runtime?.executionTarget !== "local" || !runtime.shellEnvironment) {
+    return config;
+  }
+  const shellEnvironment = Object.fromEntries(
+    Object.entries(runtime.shellEnvironment).filter(
+      (entry): entry is [string, string] =>
+        typeof entry[0] === "string" &&
+        entry[0].length > 0 &&
+        typeof entry[1] === "string",
+    ),
+  );
+  if (!Object.keys(shellEnvironment).length) {
+    return config;
+  }
+  const baseConfig = isPlainRecord(config) ? config : {};
+  return Object.entries(shellEnvironment).reduce<Record<string, unknown>>(
+    (nextConfig, [key, value]) => {
+      if (isShellEnvironmentVariableName(key)) {
+        nextConfig[`shell_environment_policy.set.${key}`] = value;
+      }
+      return nextConfig;
+    },
+    { ...baseConfig },
+  ) as CodexThreadStartParams["config"];
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isShellEnvironmentVariableName(value: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(value);
+}
+
 function buildThreadForkPayload(params: {
   threadId: string;
   path?: string;
@@ -4262,6 +4304,7 @@ function buildThreadForkPayload(params: {
   sandbox?: string;
   serviceTier?: string;
   fastMode?: boolean;
+  codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
 }): CodexThreadForkParams {
   const base: CodexThreadForkParams = {
     threadId: params.threadId,
@@ -4300,6 +4343,13 @@ function buildThreadForkPayload(params: {
       fast_mode: params.fastMode,
     };
   }
+  const config = mergeCodexShellEnvironmentPolicyConfig(
+    base.config,
+    params.codexEnvironmentRuntime,
+  );
+  if (config) {
+    base.config = config;
+  }
 
   return base;
 }
@@ -4313,6 +4363,7 @@ function buildThreadResumePayloads(params: {
   serviceTier?: string | null;
   reasoningEffort?: string;
   fastMode?: boolean;
+  codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
 }): CodexThreadResumeParams[] {
   const base: CodexThreadResumeParams = {
     threadId: params.threadId,
@@ -4345,6 +4396,13 @@ function buildThreadResumePayloads(params: {
     base.config = {
       fast_mode: params.fastMode,
     };
+  }
+  const config = mergeCodexShellEnvironmentPolicyConfig(
+    base.config,
+    params.codexEnvironmentRuntime,
+  );
+  if (config) {
+    base.config = config;
   }
 
   return [base];
@@ -5329,6 +5387,7 @@ export class CodexAppServerClient {
     sandbox?: string;
     serviceTier?: string;
     fastMode?: boolean;
+    codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
   }): Promise<{ threadId: string }> {
     await this.ensureInitialized();
 
@@ -5363,6 +5422,7 @@ export class CodexAppServerClient {
     serviceTier?: string | null;
     reasoningEffort?: string;
     fastMode?: boolean;
+    codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
   }): Promise<{
     threadId: string;
     turnId: string;
@@ -5387,7 +5447,8 @@ export class CodexAppServerClient {
           model: params.model,
           serviceTier: params.serviceTier,
           reasoningEffort: params.reasoningEffort,
-          fastMode: params.fastMode
+          fastMode: params.fastMode,
+          codexEnvironmentRuntime: params.codexEnvironmentRuntime,
         }),
         timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS
       }).catch((error: unknown) => {
@@ -5529,6 +5590,8 @@ export class CodexAppServerClient {
     threadId: string;
     target: AppServerReviewTarget;
     delivery?: AppServerReviewDelivery;
+    cwd?: string;
+    codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
   }): Promise<{ threadId: string; reviewThreadId: string; turnId: string }> {
     await this.ensureInitialized();
 
@@ -5538,6 +5601,8 @@ export class CodexAppServerClient {
         methods: ["thread/resume"],
         payloads: buildThreadResumePayloads({
           threadId: params.threadId,
+          cwd: params.cwd,
+          codexEnvironmentRuntime: params.codexEnvironmentRuntime,
         }),
         timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
       }).catch(() => undefined);

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -21,6 +21,7 @@ import type {
   AppServerThreadImagePart,
   AppServerTurnInputItem,
   BackendSummary,
+  CodexEnvironmentOption,
   CodexEnvironmentActionRun,
   CodexThreadEnvironmentRuntime,
   DesktopApplicationDiscoveryCandidate,
@@ -191,6 +192,25 @@ type ComposerDropdownOption = {
 };
 
 type ComposerDropdownIcon = (props: { size?: number }) => ReactNode;
+
+function resolveSelectedCodexEnvironmentActionId(params: {
+  environment?: CodexEnvironmentOption;
+  actionId?: string;
+  actionIdByEnvironmentId?: Record<string, string>;
+}): string | undefined {
+  const { environment } = params;
+  if (!environment) {
+    return undefined;
+  }
+  if (environment.actions.some((action) => action.id === params.actionId)) {
+    return params.actionId;
+  }
+  const mappedActionId = params.actionIdByEnvironmentId?.[environment.id];
+  if (environment.actions.some((action) => action.id === mappedActionId)) {
+    return mappedActionId;
+  }
+  return environment.actions[0]?.id;
+}
 
 type QueuedTurnDraft = {
   id: string;
@@ -2716,7 +2736,7 @@ export function Composer(props: ComposerProps) {
       markComposerDraftSubmitted(submittedScopeKey);
       props.onPendingStatusChange?.(
         props.launchpad.codexEnvironmentId &&
-          props.launchpad.codexEnvironmentSetupEnabled
+          selectedCodexEnvironment?.setupScript
           ? "Running environment setup"
           : "Reviewing",
       );
@@ -3359,7 +3379,7 @@ export function Composer(props: ComposerProps) {
       markComposerDraftSubmitted(submittedScopeKey);
       props.onPendingStatusChange?.(
         props.launchpad.codexEnvironmentId &&
-          props.launchpad.codexEnvironmentSetupEnabled
+          selectedCodexEnvironment?.setupScript
           ? "Running environment setup"
           : collaborationMode
             ? "Planning"
@@ -3753,6 +3773,7 @@ export function Composer(props: ComposerProps) {
 
   const setThreadCodexEnvironment = async (
     environmentId?: string,
+    actionId?: string,
   ): Promise<void> => {
     if (
       !props.thread ||
@@ -3762,7 +3783,6 @@ export function Composer(props: ComposerProps) {
     }
 
     setSendError(undefined);
-    setSelectedThreadCodexActionId("");
     props.onPendingStatusChange?.(
       environmentId ? "Selecting environment" : "Clearing environment",
     );
@@ -3771,6 +3791,7 @@ export function Composer(props: ComposerProps) {
         backend: props.thread.source,
         threadId: props.thread.id,
         environmentId,
+        actionId,
       });
     } catch (error) {
       setSendError(error instanceof Error ? error.message : String(error));
@@ -3912,8 +3933,25 @@ export function Composer(props: ComposerProps) {
     runtimeThreadCodexEnvironmentActions.length > 0
       ? runtimeThreadCodexEnvironmentActions
       : selectedThreadCodexEnvironmentOption?.actions ?? [];
-  const [selectedThreadCodexActionId, setSelectedThreadCodexActionId] =
-    useState<string>("");
+  const selectedThreadCodexEnvironmentForAction =
+    selectedThreadCodexEnvironmentOption ??
+    (props.thread?.codexEnvironmentRuntime
+      ? {
+          id: props.thread.codexEnvironmentRuntime.environmentId,
+          name: props.thread.codexEnvironmentRuntime.environmentName,
+          sourcePath: props.thread.codexEnvironmentRuntime.sourcePath ?? "",
+          actions: threadCodexEnvironmentActions,
+        }
+      : undefined);
+  const selectedThreadCodexActionId = resolveSelectedCodexEnvironmentActionId({
+    environment: selectedThreadCodexEnvironmentForAction,
+    actionId:
+      props.thread?.codexEnvironmentRuntime?.selectedActionIdByEnvironmentId?.[
+        props.thread.codexEnvironmentRuntime.environmentId
+      ],
+    actionIdByEnvironmentId:
+      props.thread?.codexEnvironmentRuntime?.selectedActionIdByEnvironmentId,
+  });
   const selectedThreadCodexAction =
     threadCodexEnvironmentActions.find(
       (action) => action.id === selectedThreadCodexActionId,
@@ -5466,7 +5504,7 @@ export function Composer(props: ComposerProps) {
       {props.launchpad &&
       launchpadSubmitting &&
       props.launchpad.codexEnvironmentId &&
-      props.launchpad.codexEnvironmentSetupEnabled ? (
+      selectedCodexEnvironment?.setupScript ? (
         <p className="composer__meta">Running environment setup…</p>
       ) : null}
       {props.updatingExecutionMode ? (
@@ -5528,22 +5566,6 @@ export function Composer(props: ComposerProps) {
               />
             ) : null}
 
-            {props.launchpad && selectedCodexEnvironment?.setupScript ? (
-              <label className="composer__checkbox">
-                <input
-                  checked={Boolean(props.launchpad.codexEnvironmentSetupEnabled)}
-                  disabled={launchpadSubmitting}
-                  type="checkbox"
-                  onChange={(event) => {
-                    handleLaunchpadPatch({
-                      codexEnvironmentSetupEnabled: event.target.checked,
-                    });
-                  }}
-                />
-                <span>Run setup</span>
-              </label>
-            ) : null}
-
             {!props.launchpad && threadCodexEnvironmentOptions.length > 0 ? (
               <ComposerDropdown
                 ariaLabel="Environment"
@@ -5559,7 +5581,16 @@ export function Composer(props: ComposerProps) {
                   })),
                 ]}
                 onChange={(value) => {
-                  void setThreadCodexEnvironment(value || undefined);
+                  const environment = threadCodexEnvironmentOptions.find(
+                    (candidate) => candidate.id === value,
+                  );
+                  const actionId = resolveSelectedCodexEnvironmentActionId({
+                    environment,
+                    actionIdByEnvironmentId:
+                      props.thread?.codexEnvironmentRuntime
+                        ?.selectedActionIdByEnvironmentId,
+                  });
+                  void setThreadCodexEnvironment(value || undefined, actionId);
                 }}
               />
             ) : null}
@@ -5583,7 +5614,10 @@ export function Composer(props: ComposerProps) {
                       : [{ label: "No commands", value: "" }]
                   }
                   onChange={(value) => {
-                    setSelectedThreadCodexActionId(value);
+                    void setThreadCodexEnvironment(
+                      props.thread?.codexEnvironmentRuntime?.environmentId,
+                      value || undefined,
+                    );
                   }}
                 />
                 <button

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -631,8 +631,160 @@ describe("Composer", () => {
         backend: "codex",
         threadId: "thread-1",
         environmentId: undefined,
+        actionId: undefined,
       });
     });
+  });
+
+  it("restores thread environment command selections from the per-env sticky map", () => {
+    const buildThread = (
+      id: string,
+      actionId: string,
+    ): NavigationThreadSummary => ({
+      id,
+      title: id,
+      titleSource: "explicit",
+      source: "codex",
+      executionMode: "default",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+      codexEnvironmentRuntime: {
+        environmentId: "environment",
+        environmentName: "PwrAgnt",
+        executionTarget: "local",
+        selectedActionIdByEnvironmentId: {
+          environment: actionId,
+        },
+      },
+      codexEnvironmentOptions: [
+        {
+          id: "environment",
+          name: "PwrAgnt",
+          sourcePath: "/repo/.codex/environments/environment.toml",
+          actions: [
+            {
+              id: "dev",
+              name: "Dev",
+              command: "pnpm dev",
+            },
+            {
+              id: "test",
+              name: "Test",
+              command: "pnpm test",
+            },
+          ],
+        },
+      ],
+    });
+
+    const { rerender } = render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        desktopApi={{ setCodexThreadEnvironment: vi.fn() }}
+        disabled={false}
+        skills={[]}
+        thread={buildThread("thread-a", "test")}
+      />,
+    );
+
+    expect(screen.getByLabelText("Environment command")).toHaveTextContent("Test");
+
+    rerender(
+      <Composer
+        backends={[backendSummary("codex")]}
+        desktopApi={{ setCodexThreadEnvironment: vi.fn() }}
+        disabled={false}
+        skills={[]}
+        thread={buildThread("thread-b", "dev")}
+      />,
+    );
+
+    expect(screen.getByLabelText("Environment command")).toHaveTextContent("Dev");
+
+    rerender(
+      <Composer
+        backends={[backendSummary("codex")]}
+        desktopApi={{ setCodexThreadEnvironment: vi.fn() }}
+        disabled={false}
+        skills={[]}
+        thread={buildThread("thread-a", "test")}
+      />,
+    );
+
+    expect(screen.getByLabelText("Environment command")).toHaveTextContent("Test");
+  });
+
+  it("persists thread environment command changes without running the action", async () => {
+    const setCodexThreadEnvironment = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      codexEnvironmentRuntime: {
+        environmentId: "environment",
+        environmentName: "PwrAgnt",
+        executionTarget: "local" as const,
+        selectedActionIdByEnvironmentId: {
+          environment: "test",
+        },
+      },
+    }));
+    const runCodexEnvironmentAction = vi.fn();
+
+    render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        desktopApi={{ runCodexEnvironmentAction, setCodexThreadEnvironment }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Environment commands",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+          codexEnvironmentRuntime: {
+            environmentId: "environment",
+            environmentName: "PwrAgnt",
+            executionTarget: "local",
+            selectedActionIdByEnvironmentId: {
+              environment: "dev",
+            },
+          },
+          codexEnvironmentOptions: [
+            {
+              id: "environment",
+              name: "PwrAgnt",
+              sourcePath: "/repo/.codex/environments/environment.toml",
+              actions: [
+                {
+                  id: "dev",
+                  name: "Dev",
+                  command: "pnpm dev",
+                },
+                {
+                  id: "test",
+                  name: "Test",
+                  command: "pnpm test",
+                },
+              ],
+            },
+          ],
+        }}
+      />,
+    );
+
+    chooseDropdownOption("Environment command", "Test");
+
+    await waitFor(() => {
+      expect(setCodexThreadEnvironment).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        environmentId: "environment",
+        actionId: "test",
+      });
+    });
+    expect(runCodexEnvironmentAction).not.toHaveBeenCalled();
   });
 
   it("shows an explicit empty state when a selected environment has no commands", () => {
@@ -762,7 +914,7 @@ describe("Composer", () => {
     );
 
     expect(screen.getByLabelText("Environment")).toHaveTextContent("PwrAgnt");
-    expect(screen.getByText("Run setup")).toBeInTheDocument();
+    expect(screen.queryByText("Run setup")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Environment command")).not.toBeInTheDocument();
     expect(screen.queryByText("No command")).not.toBeInTheDocument();
   });
@@ -814,6 +966,81 @@ describe("Composer", () => {
         codexEnvironmentId: "environment",
         codexEnvironmentExecutionTarget: "local",
         codexEnvironmentSetupEnabled: true,
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("does not show launchpad environment commands", () => {
+    const updateLaunchpad = vi.fn(async () => undefined);
+    render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        disabled={false}
+        launchpad={{
+          directoryKey: "directory:/repo/PwrAgent",
+          directoryKind: "directory",
+          directoryLabel: "PwrAgent",
+          directoryPath: "/repo/PwrAgent",
+          backend: "codex",
+          executionMode: "default",
+          prompt: "",
+          workMode: "local",
+          codexEnvironmentId: "lunch",
+          codexEnvironmentOptions: [
+            {
+              id: "lunch",
+              name: "Lunch",
+              sourcePath: "/repo/.codex/environments/lunch.toml",
+              actions: [
+                {
+                  id: "sandwich",
+                  name: "Sandwich",
+                  command: "make sandwich",
+                },
+                {
+                  id: "dessert",
+                  name: "Dessert",
+                  command: "make dessert",
+                },
+              ],
+            },
+            {
+              id: "dinner",
+              name: "Dinner",
+              sourcePath: "/repo/.codex/environments/dinner.toml",
+              actions: [
+                {
+                  id: "pasta",
+                  name: "Pasta",
+                  command: "make pasta",
+                },
+                {
+                  id: "wine",
+                  name: "Wine",
+                  command: "open wine",
+                },
+              ],
+            },
+          ],
+          createdAt: 1,
+          updatedAt: 1,
+        }}
+        onUpdateLaunchpad={updateLaunchpad}
+        skills={[]}
+      />,
+    );
+
+    expect(screen.getByLabelText("Environment")).toHaveTextContent("Lunch");
+    expect(screen.queryByLabelText("Environment command")).not.toBeInTheDocument();
+
+    chooseDropdownOption("Environment", "Dinner");
+
+    expect(updateLaunchpad).toHaveBeenCalledWith(
+      "directory:/repo/PwrAgent",
+      expect.objectContaining({
+        codexEnvironmentId: "dinner",
+        codexEnvironmentActionId: undefined,
       }),
       expect.any(Object),
     );

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -2893,6 +2893,15 @@ describe("useThreadNavigation", () => {
       fastMode: true,
       gitBranch: "feature/parent",
       observedGitBranch: "feature/parent",
+      codexEnvironmentRuntime: {
+        environmentId: "pwragent",
+        environmentName: "PwrAgent",
+        executionTarget: "local" as const,
+        cwd: "/repo/app/.worktrees/parent/app",
+        shellEnvironment: {
+          PATH: "/Users/huntharo/.nvm/versions/node/v24.14.1/bin:/usr/bin",
+        },
+      },
       messagingBindings: [
         {
           bindingId: "binding-parent",
@@ -2938,6 +2947,15 @@ describe("useThreadNavigation", () => {
         path: "/repo/app",
         worktreePath: "/repo/app/.worktrees/thread-fork/app",
         kind: "worktree" as const,
+      },
+      codexEnvironmentRuntime: {
+        environmentId: "pwragent",
+        environmentName: "PwrAgent",
+        executionTarget: "local" as const,
+        cwd: "/repo/app/.worktrees/thread-fork/app",
+        shellEnvironment: {
+          PATH: "/Users/huntharo/.nvm/versions/node/v24.14.1/bin:/usr/bin",
+        },
       },
     }));
     const getNavigationSnapshot = vi.fn(async () => ({
@@ -2992,6 +3010,11 @@ describe("useThreadNavigation", () => {
           worktreePath: "/repo/app/.worktrees/thread-fork/app",
         },
       ],
+      codexEnvironmentRuntime: {
+        environmentId: "pwragent",
+        environmentName: "PwrAgent",
+        cwd: "/repo/app/.worktrees/thread-fork/app",
+      },
     });
     expect(result.current.selectedThread?.messagingBindings).toBeUndefined();
     expect(result.current.selectedThread?.prs).toBeUndefined();

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -3207,6 +3207,7 @@ export function useThreadNavigation(
           fastMode: parent.fastMode,
           gitBranch: parent.gitBranch,
           observedGitBranch: parent.observedGitBranch,
+          codexEnvironmentRuntime: response.codexEnvironmentRuntime,
           linkedDirectories,
           parentThreadId: parent.id,
         };

--- a/packages/agent-core/src/domain/navigation-state.ts
+++ b/packages/agent-core/src/domain/navigation-state.ts
@@ -314,6 +314,8 @@ export function buildNavigationSnapshotHash(params: {
             environmentId: thread.codexEnvironmentRuntime.environmentId,
             environmentName: thread.codexEnvironmentRuntime.environmentName,
             executionTarget: thread.codexEnvironmentRuntime.executionTarget,
+            selectedActionIdByEnvironmentId:
+              thread.codexEnvironmentRuntime.selectedActionIdByEnvironmentId ?? null,
             cwd: thread.codexEnvironmentRuntime.cwd ?? null,
             setupEnabled: thread.codexEnvironmentRuntime.setupEnabled ?? null,
             setupStatus: thread.codexEnvironmentRuntime.setupStatus ?? null,

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -71,6 +71,7 @@ export type ForkThreadResponse = {
   executionMode: ThreadExecutionMode;
   linkedDirectory?: LinkedDirectorySummary;
   workMode: LaunchpadWorkMode;
+  codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
 };
 
 export type ThreadMigrationOperation = "move" | "copy";
@@ -523,6 +524,7 @@ export type SetCodexThreadEnvironmentRequest = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;
   environmentId?: string;
+  actionId?: string;
 };
 
 export type SetCodexThreadEnvironmentResponse = {

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -165,6 +165,7 @@ export type CodexThreadEnvironmentRuntime = {
   environmentId: string;
   environmentName: string;
   executionTarget: CodexEnvironmentExecutionTarget;
+  selectedActionIdByEnvironmentId?: Record<string, string>;
   /**
    * CWD used when this environment runtime was selected or last launched.
    * This is persisted runtime state and can become stale after workspace
@@ -179,6 +180,12 @@ export type CodexThreadEnvironmentRuntime = {
   setupOutput?: string;
   setupExitCode?: number;
   setupDurationMs?: number;
+  /**
+   * Non-secret toolchain environment captured after a successful local
+   * Codex environment setup. Used by PwrAgent to start local Codex
+   * app-server threads with the same PATH/version-manager context.
+   */
+  shellEnvironment?: Record<string, string>;
   actions?: CodexEnvironmentAction[];
   /**
    * Live + recently-finished action invocations on this thread, oldest


### PR DESCRIPTION
## Summary

Preserve the local Codex environment setup result so future local Codex App Server threads can run with the same toolchain context instead of rediscovering `nvm`, `pnpm`, Corepack, and related PATH state on every command.

## Changes

- Capture a filtered post-setup shell environment after successful local `.codex/environments/*.toml` setup.
- Persist the non-secret toolchain environment in the active PwrAgent profile state so it survives app restarts.
- Reuse cached hydration when setup is disabled or skipped.
- Pass the hydrated env to local Codex `thread/start` through `config.shell_environment_policy.set`.
- Apply the hydrated env to local environment actions as well.
- Add focused coverage for capture/filtering, cache reuse, and Codex `thread/start` payload generation.

## Root Cause

PwrAgent ran environment setup commands in a child shell, but the resulting shell state could not mutate the parent Electron process or the Codex App Server thread config. That left local Codex turns with only the default process/login shell environment, so tools installed through project-specific version managers could be missing.

## Validation

- `./node_modules/.bin/tsc --noEmit -p apps/desktop/tsconfig.json`
- `./node_modules/.bin/vitest run apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts apps/desktop/src/main/__tests__/codex-client.test.ts`
- `git diff --check`
