### PR TITLE
fix(desktop): throttle thinking scanner updates

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/ThinkingScanner.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThinkingScanner.tsx
@@ -5,10 +5,11 @@ type ThinkingScannerProps = {
 };
 
 const SCAN_DURATION_MS = 1800;
+const SCAN_FRAME_INTERVAL_MS = 1000 / 30;
 const FULL_SCAN_TRAVEL_PX = 44;
 const MINI_SCAN_TRAVEL_PX = 10;
 let activeScannerCount = 0;
-let animationFrameId: number | undefined;
+let scannerTimerId: number | undefined;
 
 function easedPingPong(progress: number): number {
   const linear = progress < 0.5 ? progress * 2 : (1 - progress) * 2;
@@ -16,7 +17,12 @@ function easedPingPong(progress: number): number {
   return 0.5 - Math.cos(linear * Math.PI) / 2;
 }
 
-function setThinkingScannerProgress(timestamp: number) {
+function scheduleThinkingScannerTick() {
+  scannerTimerId = window.setTimeout(setThinkingScannerProgress, SCAN_FRAME_INTERVAL_MS);
+}
+
+function setThinkingScannerProgress() {
+  const timestamp = performance.now();
   const progress = (timestamp % SCAN_DURATION_MS) / SCAN_DURATION_MS;
   const easedProgress = easedPingPong(progress);
   const rootStyle = document.documentElement.style;
@@ -31,23 +37,23 @@ function setThinkingScannerProgress(timestamp: number) {
     `${(easedProgress * MINI_SCAN_TRAVEL_PX).toFixed(2)}px`
   );
 
-  animationFrameId = window.requestAnimationFrame(setThinkingScannerProgress);
+  scheduleThinkingScannerTick();
 }
 
 function startThinkingScannerClock() {
   activeScannerCount += 1;
 
   if (activeScannerCount === 1) {
-    animationFrameId = window.requestAnimationFrame(setThinkingScannerProgress);
+    setThinkingScannerProgress();
   }
 }
 
 function stopThinkingScannerClock() {
   activeScannerCount = Math.max(0, activeScannerCount - 1);
 
-  if (activeScannerCount === 0 && animationFrameId !== undefined) {
-    window.cancelAnimationFrame(animationFrameId);
-    animationFrameId = undefined;
+  if (activeScannerCount === 0 && scannerTimerId !== undefined) {
+    window.clearTimeout(scannerTimerId);
+    scannerTimerId = undefined;
   }
 }
 
@@ -56,8 +62,10 @@ export function ThinkingScanner(props: ThinkingScannerProps = {}) {
     if (
       typeof window === "undefined" ||
       typeof document === "undefined" ||
-      typeof window.requestAnimationFrame !== "function" ||
-      typeof window.cancelAnimationFrame !== "function"
+      typeof window.setTimeout !== "function" ||
+      typeof window.clearTimeout !== "function" ||
+      typeof performance === "undefined" ||
+      typeof performance.now !== "function"
     ) {
       return;
     }

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThinkingScanner.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThinkingScanner.test.tsx
@@ -1,0 +1,42 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ThinkingScanner } from "../ThinkingScanner";
+
+describe("ThinkingScanner", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("drives every scanner from one shared 30 FPS clock", () => {
+    const setTimeoutSpy = vi.spyOn(window, "setTimeout");
+    const clearTimeoutSpy = vi.spyOn(window, "clearTimeout");
+
+    const { unmount } = render(
+      <>
+        <ThinkingScanner />
+        <ThinkingScanner compact />
+      </>
+    );
+
+    expect(setTimeoutSpy).toHaveBeenCalledTimes(1);
+    expect(Number(setTimeoutSpy.mock.calls[0]?.[1])).toBeCloseTo(1000 / 30);
+    expect(
+      document.documentElement.style.getPropertyValue("--thinking-scanner-progress")
+    ).not.toBe("");
+
+    vi.advanceTimersByTime(34);
+
+    expect(setTimeoutSpy).toHaveBeenCalledTimes(2);
+    expect(Number(setTimeoutSpy.mock.calls[1]?.[1])).toBeCloseTo(1000 / 30);
+
+    unmount();
+
+    expect(clearTimeoutSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

The thinking scanner now keeps its shared visible sweep without driving root CSS variable updates at browser refresh rate. It updates once immediately, then ticks at 30 FPS through one shared timer for all scanner instances, reducing document-level style churn while preserving synchronization.

This is intentionally conservative: it leaves the shared root CSS variables in place so we can dogfood whether lowering update frequency drops renderer wakeups before moving to a local-animation approach.

## Test Plan

- `node_modules/.bin/vitest run --config vitest.workspace.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThinkingScanner.test.tsx`
- `node_modules/.bin/vitest run --config vitest.workspace.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx`
- `node_modules/.bin/tsc --noEmit -p apps/desktop/tsconfig.json`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
