### PR TITLE
feat(desktop): remember thread lens selection

### DIFF
--- a/apps/desktop/src/main/__tests__/overlay-store-launchpad-defaults.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-launchpad-defaults.test.ts
@@ -36,6 +36,23 @@ function readDefaultValue(key: string): unknown {
 }
 
 describe("SqliteOverlayStore - launchpad defaults", () => {
+  it("persists the selected navigation browse mode", async () => {
+    expect(store.getNavigationBrowseModeSync()).toBe("inbox");
+
+    await expect(store.setNavigationBrowseMode("directories")).resolves.toBe(
+      "directories",
+    );
+    await expect(store.getNavigationBrowseMode()).resolves.toBe("directories");
+
+    const reopenedDb = StateDb.open(path.join(tempDir, "state.db"));
+    const reopenedStore = new SqliteOverlayStore(reopenedDb);
+    try {
+      expect(reopenedStore.getNavigationBrowseModeSync()).toBe("directories");
+    } finally {
+      reopenedDb.close();
+    }
+  });
+
   it("does not persist Codex Fast serviceTier in launchpad defaults", async () => {
     const defaults = await store.setLaunchpadDefaults({
       model: "gpt-5.5",

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -57,6 +57,8 @@ import type {
   SetThreadPinResponse,
   SetThreadReactionRequest,
   SetThreadReactionResponse,
+  SetNavigationBrowseModeRequest,
+  SetNavigationBrowseModeResponse,
   ListThreadMigrationSourceThreadsRequest,
   ListThreadMigrationSourceThreadsResponse,
   ListThreadMigrationSourcesResponse,
@@ -116,6 +118,7 @@ import {
   NAVIGATION_PICK_DIRECTORY_FROM_DISK_CHANNEL,
   NAVIGATION_REGISTER_DIRECTORY_FROM_DISK_CHANNEL,
   NAVIGATION_RESET_DIRECTORY_LAUNCHPAD_CHANNEL,
+  NAVIGATION_SET_BROWSE_MODE_CHANNEL,
   NAVIGATION_SNAPSHOT_CHANNEL,
   NAVIGATION_UPDATE_SUBTHREAD_ORDER_CHANNEL,
   NAVIGATION_UPDATE_DIRECTORY_LAUNCHPAD_CHANNEL,
@@ -584,6 +587,18 @@ class DesktopAppServerService {
     this.pendingNavigationSnapshots.set(requestKey, promise);
 
     return await promise;
+  }
+
+  async setNavigationBrowseMode(
+    request: SetNavigationBrowseModeRequest,
+  ): Promise<SetNavigationBrowseModeResponse> {
+    const browseMode = await this.getOverlayStore().setNavigationBrowseMode(
+      request.browseMode,
+    );
+
+    logDebug("setNavigationBrowseMode", { browseMode });
+
+    return { browseMode };
   }
 
   private async readNavigationSnapshot(
@@ -1677,6 +1692,16 @@ export function registerAppServerIpcHandlers(): void {
       return await appServerService.getNavigationSnapshot(request);
     },
   );
+  ipcMain.removeHandler(NAVIGATION_SET_BROWSE_MODE_CHANNEL);
+  ipcMain.handle(
+    NAVIGATION_SET_BROWSE_MODE_CHANNEL,
+    async (
+      _event,
+      request: SetNavigationBrowseModeRequest,
+    ): Promise<SetNavigationBrowseModeResponse> => {
+      return await appServerService.setNavigationBrowseMode(request);
+    },
+  );
   ipcMain.removeHandler(NAVIGATION_MARK_THREAD_SEEN_CHANNEL);
   ipcMain.handle(
     NAVIGATION_MARK_THREAD_SEEN_CHANNEL,
@@ -1875,6 +1900,7 @@ export async function disposeAppServerIpcHandlers(): Promise<void> {
   ipcMain.removeHandler(APP_SERVER_RENAME_THREAD_CHANNEL);
   ipcMain.removeHandler(FOCUSED_DIFF_ANALYZE_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_SNAPSHOT_CHANNEL);
+  ipcMain.removeHandler(NAVIGATION_SET_BROWSE_MODE_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_MARK_THREAD_SEEN_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_SET_THREAD_REACTION_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_SET_THREAD_AGENT_CHANNEL);

--- a/apps/desktop/src/main/navigation-browse-mode-bootstrap.ts
+++ b/apps/desktop/src/main/navigation-browse-mode-bootstrap.ts
@@ -1,0 +1,58 @@
+/**
+ * Synchronous navigation browse-mode read for the main BrowserWindow.
+ *
+ * The thread lens must be correct before React's first visible render.
+ * Reading the active profile's sqlite-backed overlay store here lets the
+ * renderer initialize from the same profile-scoped value it later updates
+ * through IPC, avoiding an "Inbox first, then jump" startup path.
+ */
+
+import type { NavigationBrowseMode } from "@pwragent/shared";
+import { getAppOverlayStore } from "./state/app-state";
+import { normalizeNavigationBrowseMode } from "./state/overlay-store-sqlite";
+
+export type BootstrapNavigationPreferences = {
+  browseMode: NavigationBrowseMode;
+};
+
+export const BOOTSTRAP_NAVIGATION_ARG_PREFIX =
+  "--pwragent-navigation-preferences=";
+
+export function readBootstrapNavigationPreferences(): BootstrapNavigationPreferences {
+  try {
+    return {
+      browseMode: getAppOverlayStore().getNavigationBrowseModeSync(),
+    };
+  } catch {
+    return { browseMode: "inbox" };
+  }
+}
+
+export function navigationPreferencesAdditionalArguments(
+  preferences: BootstrapNavigationPreferences,
+): string[] {
+  return [serializeBootstrapNavigationPreferences(preferences)];
+}
+
+export function serializeBootstrapNavigationPreferences(
+  preferences: BootstrapNavigationPreferences,
+): string {
+  return `${BOOTSTRAP_NAVIGATION_ARG_PREFIX}${JSON.stringify(preferences)}`;
+}
+
+export function parseBootstrapNavigationPreferencesArg(
+  argv: readonly string[],
+): BootstrapNavigationPreferences | undefined {
+  for (const arg of argv) {
+    if (!arg.startsWith(BOOTSTRAP_NAVIGATION_ARG_PREFIX)) continue;
+    try {
+      const raw = JSON.parse(arg.slice(BOOTSTRAP_NAVIGATION_ARG_PREFIX.length));
+      return {
+        browseMode: normalizeNavigationBrowseMode(raw?.browseMode),
+      };
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+}

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -7,6 +7,7 @@ import type {
   LinkedDirectorySummary,
   MarkThreadSeenResponse,
   MessagingThreadBindingSummary,
+  NavigationBrowseMode,
   NavigationDirectoryGitStatus,
   NavigationLaunchpadDefaults,
   NavigationSnapshot,
@@ -62,6 +63,17 @@ function normalizeLaunchpadDefaults(
     delete next.serviceTier;
   }
   return next;
+}
+
+const NAVIGATION_BROWSE_MODE_META_KEY = "navigation_browse_mode";
+const DEFAULT_NAVIGATION_BROWSE_MODE: NavigationBrowseMode = "inbox";
+
+export function normalizeNavigationBrowseMode(
+  value: unknown,
+): NavigationBrowseMode {
+  return value === "inbox" || value === "recents" || value === "directories"
+    ? value
+    : DEFAULT_NAVIGATION_BROWSE_MODE;
 }
 
 export class SqliteOverlayStore {
@@ -826,6 +838,24 @@ export class SqliteOverlayStore {
     return next;
   }
 
+  getNavigationBrowseModeSync(): NavigationBrowseMode {
+    return normalizeNavigationBrowseMode(
+      this.stateDb.getMeta(NAVIGATION_BROWSE_MODE_META_KEY),
+    );
+  }
+
+  async getNavigationBrowseMode(): Promise<NavigationBrowseMode> {
+    return this.getNavigationBrowseModeSync();
+  }
+
+  async setNavigationBrowseMode(
+    browseMode: NavigationBrowseMode,
+  ): Promise<NavigationBrowseMode> {
+    const normalized = normalizeNavigationBrowseMode(browseMode);
+    this.stateDb.setMeta(NAVIGATION_BROWSE_MODE_META_KEY, normalized);
+    return normalized;
+  }
+
   async getDirectoryLaunchpad(params: {
     directoryKey: string;
   }): Promise<DirectoryLaunchpadOverlayState | undefined> {
@@ -1152,6 +1182,8 @@ export type OverlayStoreLike = Pick<
   | "appendMessagingBindingTransition"
   | "getLaunchpadDefaults"
   | "setLaunchpadDefaults"
+  | "getNavigationBrowseMode"
+  | "setNavigationBrowseMode"
   | "getDirectoryLaunchpad"
   | "listDirectoryLaunchpads"
   | "upsertDirectoryLaunchpad"

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -39,6 +39,10 @@ import {
   themedWindowAdditionalArguments,
   themedWindowBackgroundColor,
 } from "./settings/appearance-bootstrap";
+import {
+  navigationPreferencesAdditionalArguments,
+  readBootstrapNavigationPreferences,
+} from "./navigation-browse-mode-bootstrap";
 
 const isDevelopment = process.env.NODE_ENV !== "production";
 const isMac = process.platform === "darwin";
@@ -292,6 +296,7 @@ export function createMainWindow(options?: {
 }): BrowserWindow {
   const preloadPath = getPreloadPath();
   const appearance = readBootstrapAppearance();
+  const navigationPreferences = readBootstrapNavigationPreferences();
   const macWindowChrome = isMac
     ? {
         titleBarStyle: "hiddenInset" as const,
@@ -330,7 +335,10 @@ export function createMainWindow(options?: {
       // theme). The renderer's writeSettingsConfig IPC keeps the TOML
       // in sync; the next launch reads the updated value back via this
       // same path.
-      additionalArguments: themedWindowAdditionalArguments(appearance),
+      additionalArguments: [
+        ...themedWindowAdditionalArguments(appearance),
+        ...navigationPreferencesAdditionalArguments(navigationPreferences),
+      ],
     }
   });
 

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -62,6 +62,7 @@ import type {
   HandoffThreadWorkspaceResponse,
   ListAcpAgentSettingsRequest,
   ListAcpAgentSettingsResponse,
+  NavigationBrowseMode,
   MarkThreadSeenRequest,
   MarkThreadSeenResponse,
   ReorderDirectoryPinsRequest,
@@ -184,6 +185,8 @@ import type {
   WriteDesktopSecretsToProfileResponse,
   SetDefaultDesktopPwrAgentProfileRequest,
   SetDefaultDesktopPwrAgentProfileResponse,
+  SetNavigationBrowseModeRequest,
+  SetNavigationBrowseModeResponse,
   StartDesktopCodexAuthProfileLoginRequest,
   StartDesktopCodexAuthProfileLoginResponse,
   UpdateDirectoryLaunchpadRequest,
@@ -292,6 +295,7 @@ import {
   NAVIGATION_REORDER_THREAD_PINS_CHANNEL,
   NAVIGATION_REGISTER_DIRECTORY_FROM_DISK_CHANNEL,
   NAVIGATION_MARK_THREAD_SEEN_CHANNEL,
+  NAVIGATION_SET_BROWSE_MODE_CHANNEL,
   NAVIGATION_SET_SUBTHREADS_COLLAPSED_CHANNEL,
   NAVIGATION_SET_DIRECTORY_PIN_CHANNEL,
   NAVIGATION_SET_THREAD_PARENT_CHANNEL,
@@ -740,6 +744,10 @@ const desktopApi = Object.freeze({
     request?: GetNavigationSnapshotRequest,
   ): Promise<NavigationSnapshot> =>
     await ipcRenderer.invoke(NAVIGATION_SNAPSHOT_CHANNEL, request),
+  setNavigationBrowseMode: async (
+    request: SetNavigationBrowseModeRequest,
+  ): Promise<SetNavigationBrowseModeResponse> =>
+    await ipcRenderer.invoke(NAVIGATION_SET_BROWSE_MODE_CHANNEL, request),
   markThreadSeen: async (
     request: MarkThreadSeenRequest,
   ): Promise<MarkThreadSeenResponse> =>
@@ -1055,9 +1063,40 @@ function readBootstrapAppearance(): {
 }
 const bootstrapAppearance = readBootstrapAppearance();
 
+// Decode the navigation preference hint passed from main via
+// `webPreferences.additionalArguments`. React reads this during the
+// initial useState call so the thread lens is correct before first paint.
+const NAVIGATION_ARG_PREFIX = "--pwragent-navigation-preferences=";
+function readBootstrapNavigationPreferences(): {
+  browseMode: NavigationBrowseMode;
+} {
+  for (const arg of process.argv) {
+    if (!arg.startsWith(NAVIGATION_ARG_PREFIX)) continue;
+    try {
+      const raw = JSON.parse(arg.slice(NAVIGATION_ARG_PREFIX.length));
+      const browseMode =
+        raw &&
+        (raw.browseMode === "inbox" ||
+          raw.browseMode === "recents" ||
+          raw.browseMode === "directories")
+          ? raw.browseMode
+          : "inbox";
+      return { browseMode };
+    } catch {
+      break;
+    }
+  }
+  return { browseMode: "inbox" };
+}
+const bootstrapNavigationPreferences = readBootstrapNavigationPreferences();
+
 if (process.contextIsolated) {
   contextBridge.exposeInMainWorld("pwragent", desktopApi);
   contextBridge.exposeInMainWorld("__pwragentAppearance", bootstrapAppearance);
+  contextBridge.exposeInMainWorld(
+    "__pwragentNavigationPreferences",
+    bootstrapNavigationPreferences,
+  );
   recordPreloadLog("info", "exposed context bridge", {
     keys: Object.keys(desktopApi)
   });

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -17,6 +17,9 @@ describe("useThreadNavigation", () => {
   });
 
   afterEach(() => {
+    delete (window as unknown as {
+      __pwragentNavigationPreferences?: unknown;
+    }).__pwragentNavigationPreferences;
     vi.restoreAllMocks();
   });
 
@@ -4121,6 +4124,65 @@ describe("useThreadNavigation", () => {
     });
 
     expect(result.current.refresh).toBe(initialRefresh);
+  });
+
+  it("initializes browse mode from bridged navigation preferences", async () => {
+    Object.defineProperty(window, "__pwragentNavigationPreferences", {
+      configurable: true,
+      value: { browseMode: "recents" },
+    });
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    expect(result.current.browseMode).toBe("recents");
+  });
+
+  it("persists browse mode changes through the desktop bridge", async () => {
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const setNavigationBrowseMode = vi.fn(async (request) => request);
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+      setNavigationBrowseMode,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    act(() => {
+      result.current.setBrowseMode("directories");
+    });
+
+    expect(result.current.browseMode).toBe("directories");
+    expect(setNavigationBrowseMode).toHaveBeenCalledWith({
+      browseMode: "directories",
+    });
   });
 
   describe("pickAndRegisterDirectory (issue #223)", () => {

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -190,6 +190,8 @@ import type {
   WriteDesktopSecretsToProfileResponse,
   SetDefaultDesktopPwrAgentProfileRequest,
   SetDefaultDesktopPwrAgentProfileResponse,
+  SetNavigationBrowseModeRequest,
+  SetNavigationBrowseModeResponse,
   StartDesktopCodexAuthProfileLoginRequest,
   StartDesktopCodexAuthProfileLoginResponse,
   UpdateDirectoryLaunchpadRequest,
@@ -406,6 +408,9 @@ export type DesktopApi = {
   getNavigationSnapshot?: (
     request?: GetNavigationSnapshotRequest
   ) => Promise<NavigationSnapshot>;
+  setNavigationBrowseMode?: (
+    request: SetNavigationBrowseModeRequest,
+  ) => Promise<SetNavigationBrowseModeResponse>;
   listBackends?: (
     request?: ListBackendsRequest
   ) => Promise<ListBackendsResponse>;

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -8,6 +8,7 @@ import type {
   ArchiveThreadCleanupResult,
   HandoffThreadWorkspaceRequest,
   LinkedDirectorySummary,
+  NavigationBrowseMode,
   NavigationDirectoryGitStatusUpdatedNotification,
   NavigationDirectorySummary,
   NavigationLaunchpadDefaults,
@@ -32,7 +33,7 @@ import {
   type ThreadWorkspaceMode,
 } from "./subthread-launchpads";
 
-export type BrowseMode = "inbox" | "recents" | "directories";
+export type BrowseMode = NavigationBrowseMode;
 export type { ThreadWorkspaceMode } from "./subthread-launchpads";
 
 export type ArchiveThreadNotice = {
@@ -49,6 +50,23 @@ export type ArchiveThreadOptions = {
 const ROOT_NEW_THREAD_WORKSPACE_LAUNCHPAD_KEY = "workspace:new-thread";
 const ROOT_NEW_THREAD_WORKSPACE_LABEL = "Workspaces";
 const NAVIGATION_BACKGROUND_REFRESH_INTERVAL_MS = 30_000;
+const DEFAULT_BROWSE_MODE: BrowseMode = "inbox";
+
+function normalizeBrowseMode(value: unknown): BrowseMode {
+  return value === "inbox" || value === "recents" || value === "directories"
+    ? value
+    : DEFAULT_BROWSE_MODE;
+}
+
+function readBridgedBrowseMode(): BrowseMode {
+  if (typeof window === "undefined") {
+    return DEFAULT_BROWSE_MODE;
+  }
+  const bridged = (window as unknown as {
+    __pwragentNavigationPreferences?: { browseMode?: unknown };
+  }).__pwragentNavigationPreferences;
+  return normalizeBrowseMode(bridged?.browseMode);
+}
 
 function isRendererViewForeground(): boolean {
   if (typeof document === "undefined") {
@@ -1872,9 +1890,10 @@ export function useThreadNavigation(
   const cancelThreadExecutionModeQueueRequest =
     desktopApi?.cancelThreadExecutionModeQueue;
   const setThreadModelSettings = desktopApi?.setThreadModelSettings;
+  const setNavigationBrowseModeRequest = desktopApi?.setNavigationBrowseMode;
   const enabled = options.enabled ?? true;
   const threadViewVisible = options.threadViewVisible ?? true;
-  const [browseMode, setBrowseMode] = useState<BrowseMode>("inbox");
+  const [browseMode, setBrowseMode] = useState<BrowseMode>(readBridgedBrowseMode);
   const [selectedItemKey, setSelectedItemKey] = useState<string>();
   const [pendingSeenThreadKey, setPendingSeenThreadKey] = useState<string>();
   const [retainedUnreadThread, setRetainedUnreadThread] =
@@ -1931,9 +1950,22 @@ export function useThreadNavigation(
   );
   const launchpadUpdateRevisionRef = useRef(new Map<string, number>());
   const pendingPickedLaunchpadRef = useRef(new Map<string, NavigationLaunchpadDraft>());
+  const setNavigationBrowseModeRequestRef = useRef(setNavigationBrowseModeRequest);
 
   optimisticThreadRef.current = optimisticThread;
   retainedUnreadThreadRef.current = retainedUnreadThread;
+
+  useEffect(() => {
+    setNavigationBrowseModeRequestRef.current = setNavigationBrowseModeRequest;
+  }, [setNavigationBrowseModeRequest]);
+
+  const updateBrowseMode = useCallback((nextBrowseMode: BrowseMode): void => {
+    const normalized = normalizeBrowseMode(nextBrowseMode);
+    setBrowseMode(normalized);
+    void setNavigationBrowseModeRequestRef.current?.({
+      browseMode: normalized,
+    }).catch(() => undefined);
+  }, []);
 
   const releaseRetainedUnreadThread = useCallback((nextSelectionKey?: string): void => {
     const retainedThread = retainedUnreadThreadRef.current;
@@ -4434,7 +4466,7 @@ export function useThreadNavigation(
     setThreadModelSettingsError,
     updatingThreadExecutionMode,
     updateDirectoryLaunchpad,
-    setBrowseMode,
+    setBrowseMode: updateBrowseMode,
     selectThread,
     showThread,
     archiveThread,

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -51,6 +51,8 @@ export const AGENT_LATEST_CODEX_CONFIG_WARNING_CHANNEL =
   "agent:latest-codex-config-warning";
 export const AGENT_EVENT_CHANNEL = "agent:event";
 export const NAVIGATION_SNAPSHOT_CHANNEL = "navigation:get-snapshot";
+export const NAVIGATION_SET_BROWSE_MODE_CHANNEL =
+  "navigation:set-browse-mode";
 export const NAVIGATION_MARK_THREAD_SEEN_CHANNEL = "navigation:mark-thread-seen";
 export const NAVIGATION_SET_THREAD_REACTION_CHANNEL =
   "navigation:set-thread-reaction";

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -171,6 +171,7 @@ export type PrSummary = {
 };
 
 export type DirectorySummaryKind = "directory" | "workspace" | "unlinked";
+export type NavigationBrowseMode = "inbox" | "recents" | "directories";
 export type LaunchpadWorkMode = "local" | "worktree";
 
 export type CodexEnvironmentOption = {
@@ -370,6 +371,14 @@ export type NavigationSnapshot = {
 export type GetNavigationSnapshotRequest = {
   backend?: AppServerBackendScope;
   filter?: string;
+};
+
+export type SetNavigationBrowseModeRequest = {
+  browseMode: NavigationBrowseMode;
+};
+
+export type SetNavigationBrowseModeResponse = {
+  browseMode: NavigationBrowseMode;
 };
 
 export type MarkThreadSeenRequest = {


### PR DESCRIPTION
## Summary

- Persist the selected thread-list lens (`Inbox`, `Created`, or `Directories`) in the profile state database.
- Pass the persisted lens through the main-window preload bootstrap so React initializes with the right tab before first paint.
- Add renderer, IPC, shared contract, and overlay-store coverage for browse-mode restore and persistence.

## Impact

The desktop app now reopens directly on the last-used thread-list tab without rendering Inbox first and jumping later.

## Validation

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx apps/desktop/src/main/__tests__/overlay-store-launchpad-defaults.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`
