### PR TITLE
perf(desktop): localize thinking scanner animation phase

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/ThinkingScanner.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThinkingScanner.tsx
@@ -1,78 +1,39 @@
-import { useEffect } from "react";
+import { useRef } from "react";
+import type { CSSProperties } from "react";
 
 type ThinkingScannerProps = {
   compact?: boolean;
 };
 
 const SCAN_DURATION_MS = 1800;
-const FULL_SCAN_TRAVEL_PX = 44;
-const MINI_SCAN_TRAVEL_PX = 10;
-let activeScannerCount = 0;
-let animationFrameId: number | undefined;
 
-function easedPingPong(progress: number): number {
-  const linear = progress < 0.5 ? progress * 2 : (1 - progress) * 2;
+type ThinkingScannerStyle = CSSProperties & {
+  "--thinking-scanner-delay": string;
+};
 
-  return 0.5 - Math.cos(linear * Math.PI) / 2;
-}
-
-function setThinkingScannerProgress(timestamp: number) {
-  const progress = (timestamp % SCAN_DURATION_MS) / SCAN_DURATION_MS;
-  const easedProgress = easedPingPong(progress);
-  const rootStyle = document.documentElement.style;
-
-  rootStyle.setProperty("--thinking-scanner-progress", easedProgress.toFixed(4));
-  rootStyle.setProperty(
-    "--thinking-scanner-full-offset",
-    `${(easedProgress * FULL_SCAN_TRAVEL_PX).toFixed(2)}px`
-  );
-  rootStyle.setProperty(
-    "--thinking-scanner-mini-offset",
-    `${(easedProgress * MINI_SCAN_TRAVEL_PX).toFixed(2)}px`
-  );
-
-  animationFrameId = window.requestAnimationFrame(setThinkingScannerProgress);
-}
-
-function startThinkingScannerClock() {
-  activeScannerCount += 1;
-
-  if (activeScannerCount === 1) {
-    animationFrameId = window.requestAnimationFrame(setThinkingScannerProgress);
+function getThinkingScannerPhaseMs(): number {
+  if (typeof performance === "undefined" || typeof performance.now !== "function") {
+    return 0;
   }
-}
 
-function stopThinkingScannerClock() {
-  activeScannerCount = Math.max(0, activeScannerCount - 1);
-
-  if (activeScannerCount === 0 && animationFrameId !== undefined) {
-    window.cancelAnimationFrame(animationFrameId);
-    animationFrameId = undefined;
-  }
+  return performance.now() % SCAN_DURATION_MS;
 }
 
 export function ThinkingScanner(props: ThinkingScannerProps = {}) {
-  useEffect(() => {
-    if (
-      typeof window === "undefined" ||
-      typeof document === "undefined" ||
-      typeof window.requestAnimationFrame !== "function" ||
-      typeof window.cancelAnimationFrame !== "function"
-    ) {
-      return;
-    }
+  const phaseMsRef = useRef<number | undefined>(undefined);
+  if (phaseMsRef.current === undefined) {
+    phaseMsRef.current = getThinkingScannerPhaseMs();
+  }
 
-    startThinkingScannerClock();
-
-    return () => {
-      stopThinkingScannerClock();
-    };
-  }, []);
+  const style: ThinkingScannerStyle = {
+    "--thinking-scanner-delay": `${-phaseMsRef.current}ms`,
+  };
 
   return (
     <div
       aria-hidden="true"
       className={`thinking-scanner${props.compact ? " thinking-scanner--mini" : ""}`}
+      style={style}
     >
       <div className="thinking-scanner__beam" />
     </div>

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThinkingScanner.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThinkingScanner.test.tsx
@@ -1,0 +1,31 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ThinkingScanner } from "../ThinkingScanner";
+
+describe("ThinkingScanner", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("syncs scanners with a local animation phase and no runtime clock", () => {
+    vi.spyOn(performance, "now").mockReturnValue(2250);
+    const requestAnimationFrameSpy = vi.spyOn(window, "requestAnimationFrame");
+    const setTimeoutSpy = vi.spyOn(window, "setTimeout");
+
+    render(
+      <>
+        <ThinkingScanner />
+        <ThinkingScanner compact />
+      </>
+    );
+
+    const scanners = Array.from(document.querySelectorAll<HTMLElement>(".thinking-scanner"));
+    expect(scanners).toHaveLength(2);
+    expect(
+      scanners.map((scanner) => scanner.style.getPropertyValue("--thinking-scanner-delay"))
+    ).toEqual(["-450ms", "-450ms"]);
+    expect(requestAnimationFrameSpy).not.toHaveBeenCalled();
+    expect(setTimeoutSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -128,10 +128,17 @@ describe("Tangerine Terminal theme contract", () => {
   });
 
   it("does not leave unresolved theme token references in app.css", () => {
+    const localTokens = new Set([
+      "thinking-scanner-beam-width",
+      "thinking-scanner-delay",
+      "thinking-scanner-travel",
+    ]);
     const tokenReferences = [...css.matchAll(/var\(--([a-z0-9-]+)\)/g)].map(
       ([, token]) => token
     );
-    const missingTokens = tokenReferences.filter((token) => !tokens[token]);
+    const missingTokens = tokenReferences.filter(
+      (token) => !tokens[token] && !localTokens.has(token)
+    );
 
     expect([...new Set(missingTokens)]).toEqual([]);
   });
@@ -722,18 +729,18 @@ describe("Tangerine Terminal theme contract", () => {
   });
 
   it("keeps thinking scanner variants on one shared visible sweep", () => {
-    expect(css).toContain("--thinking-scanner-progress: 0;");
-    expect(css).toContain("--thinking-scanner-full-offset: 0px;");
-    expect(css).toContain("--thinking-scanner-mini-offset: 0px;");
-    expect(css).not.toContain("@keyframes pwragent-kitt-scan");
+    expect(css).not.toContain("--thinking-scanner-progress");
+    expect(css).not.toContain("--thinking-scanner-full-offset");
+    expect(css).not.toContain("--thinking-scanner-mini-offset");
+    expect(css).toContain("@keyframes pwragent-thinking-scanner-sweep");
     expect(css).toMatch(
-      /\.thinking-scanner\s*\{[\s\S]*?--thinking-scanner-beam-width:\s*18px;[\s\S]*?--thinking-scanner-offset:\s*var\(--thinking-scanner-full-offset\);[\s\S]*?width:\s*62px;[\s\S]*?\}/
+      /\.thinking-scanner\s*\{[\s\S]*?--thinking-scanner-beam-width:\s*18px;[\s\S]*?--thinking-scanner-delay:\s*0ms;[\s\S]*?--thinking-scanner-travel:\s*44px;[\s\S]*?width:\s*62px;[\s\S]*?\}/
     );
     expect(css).toMatch(
-      /\.thinking-scanner--mini\s*\{[\s\S]*?--thinking-scanner-beam-width:\s*6px;[\s\S]*?--thinking-scanner-offset:\s*var\(--thinking-scanner-mini-offset\);[\s\S]*?width:\s*16px;[\s\S]*?\}/
+      /\.thinking-scanner--mini\s*\{[\s\S]*?--thinking-scanner-beam-width:\s*6px;[\s\S]*?--thinking-scanner-travel:\s*10px;[\s\S]*?width:\s*16px;[\s\S]*?\}/
     );
     expect(css).toMatch(
-      /\.thinking-scanner__beam\s*\{[\s\S]*?transform:\s*translateX\(var\(--thinking-scanner-offset\)\);[\s\S]*?\}/
+      /\.thinking-scanner__beam\s*\{[\s\S]*?animation:\s*pwragent-thinking-scanner-sweep 1800ms ease-in-out infinite;[\s\S]*?animation-delay:\s*var\(--thinking-scanner-delay\);[\s\S]*?\}/
     );
   });
 });

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -138,11 +138,6 @@
 
   /* Status-error tints used inside box-shadow rings. */
   --status-error-ring-soft: color-mix(in srgb, var(--status-error) 22%, transparent);
-  --thinking-scanner-beam-width: 18px;
-  --thinking-scanner-full-offset: 0px;
-  --thinking-scanner-mini-offset: 0px;
-  --thinking-scanner-offset: var(--thinking-scanner-full-offset);
-  --thinking-scanner-progress: 0;
   /* Issue #240: max reading width for the centered chat column —
      transcript message column AND composer rows both cap here so
      the input's text-block lines up with the messages above it. The
@@ -8020,7 +8015,8 @@ textarea,
 .thinking-scanner {
   position: relative;
   --thinking-scanner-beam-width: 18px;
-  --thinking-scanner-offset: var(--thinking-scanner-full-offset);
+  --thinking-scanner-delay: 0ms;
+  --thinking-scanner-travel: 44px;
   width: 62px;
   height: 6px;
   flex: 0 0 auto;
@@ -8032,7 +8028,7 @@ textarea,
 
 .thinking-scanner--mini {
   --thinking-scanner-beam-width: 6px;
-  --thinking-scanner-offset: var(--thinking-scanner-mini-offset);
+  --thinking-scanner-travel: 10px;
   width: 16px;
   height: 6px;
 }
@@ -8053,8 +8049,10 @@ textarea,
   box-shadow:
     0 0 10px color-mix(in srgb, var(--accent) 42%, transparent),
     0 0 18px color-mix(in srgb, var(--accent) 22%, transparent);
-  opacity: calc(0.76 + (var(--thinking-scanner-progress, 0) * 0.24));
-  transform: translateX(var(--thinking-scanner-offset));
+  animation: pwragent-thinking-scanner-sweep 1800ms ease-in-out infinite;
+  animation-delay: var(--thinking-scanner-delay);
+  opacity: 0.76;
+  transform: translateX(0);
   will-change: opacity, transform;
 }
 
@@ -8062,6 +8060,19 @@ textarea,
   box-shadow:
     0 0 8px color-mix(in srgb, var(--accent) 42%, transparent),
     0 0 14px color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+@keyframes pwragent-thinking-scanner-sweep {
+  0%,
+  100% {
+    opacity: 0.76;
+    transform: translateX(0);
+  }
+
+  50% {
+    opacity: 1;
+    transform: translateX(var(--thinking-scanner-travel));
+  }
 }
 
 .transcript-activity__header {


### PR DESCRIPTION
## Summary
Thinking scanner animations no longer depend on a root-level CSS variable that React updates every frame. Each scanner now computes a synchronized negative animation delay when it mounts, then lets CSS run the sweep locally so thread-list and transcript scanners stay visually aligned without continuous DOM writes.

Dogfooding this variation showed renderer CPU mostly below 20% during active turns, with only brief spikes, after the earlier throttled version still hovered around 50-65%.

Supersedes #651 

## Testing
- `node_modules/.bin/vitest run --config vitest.workspace.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThinkingScanner.test.tsx apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
