### PR TITLE
fix(desktop): refresh skills after catalog changes

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSkills.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSkills.test.tsx
@@ -1,6 +1,10 @@
 import "@testing-library/jest-dom/vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import type { DesktopApi } from "../desktop-api";
+import type {
+  AppServerListSkillsResponse,
+  NavigationThreadSummary,
+} from "@pwragent/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useThreadSkills } from "../useThreadSkills";
 
@@ -128,6 +132,223 @@ describe("useThreadSkills", () => {
         "skill:frontend-design",
       ]);
     });
+  });
+
+  it("refreshes cached Codex skills when the backend reports skill metadata changed", async () => {
+    const listSkills = vi
+      .fn()
+      .mockResolvedValueOnce({
+        backend: "codex" as const,
+        fetchedAt: Date.now(),
+        data: [
+          {
+            skills: [
+              {
+                name: "old-skill",
+                description: "Old skill",
+                path: "/Users/huntharo/.codex/skills/old-skill/SKILL.md",
+                scope: "user" as const,
+                enabled: true,
+              },
+            ],
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        backend: "codex" as const,
+        fetchedAt: Date.now(),
+        data: [
+          {
+            skills: [
+              {
+                name: "new-skill",
+                description: "New skill",
+                path: "/Users/huntharo/.codex/skills/new-skill/SKILL.md",
+                scope: "user" as const,
+                enabled: true,
+              },
+            ],
+          },
+        ],
+      });
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    const desktopApi: DesktopApi = {
+      listSkills,
+      onAgentEvent: (handler) => {
+        agentEventHandler = handler;
+        return () => {
+          agentEventHandler = undefined;
+        };
+      },
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSkills({
+        desktopApi,
+        thread: {
+          id: "thread-1",
+          title: "Create skill",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        },
+      })
+    );
+
+    await act(async () => {
+      await result.current.ensureLoaded();
+    });
+
+    await waitFor(() => {
+      expect(result.current.skills.map((skill) => skill.name)).toEqual([
+        "old-skill",
+      ]);
+    });
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "skills/changed",
+          params: {},
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.skills.map((skill) => skill.name)).toEqual([
+        "new-skill",
+      ]);
+    });
+    expect(listSkills).toHaveBeenCalledTimes(2);
+    expect(listSkills).toHaveBeenLastCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+  });
+
+  it("ignores stale in-flight skill responses for cache keys cleared by skills/changed", async () => {
+    const createThread = (id: string): NavigationThreadSummary => ({
+      id,
+      title: id,
+      titleSource: "explicit",
+      source: "codex",
+      executionMode: "default",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    });
+    const createResponse = (name: string): AppServerListSkillsResponse => ({
+      backend: "codex",
+      fetchedAt: Date.now(),
+      data: [
+        {
+          skills: [
+            {
+              name,
+              description: name,
+              path: `/Users/huntharo/.codex/skills/${name}/SKILL.md`,
+              scope: "user",
+              enabled: true,
+            },
+          ],
+        },
+      ],
+    });
+    let resolveThreadA:
+      | ((response: AppServerListSkillsResponse) => void)
+      | undefined;
+    let threadARequestCount = 0;
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    const listSkills = vi.fn((request) => {
+      if (request?.threadId === "thread-a") {
+        threadARequestCount += 1;
+        if (threadARequestCount === 1) {
+          return new Promise<AppServerListSkillsResponse>((resolve) => {
+            resolveThreadA = resolve;
+          });
+        }
+        return Promise.resolve(createResponse("fresh-a"));
+      }
+
+      return Promise.resolve(createResponse("thread-b"));
+    });
+    const desktopApi: DesktopApi = {
+      listSkills,
+      onAgentEvent: (handler) => {
+        agentEventHandler = handler;
+        return () => {
+          agentEventHandler = undefined;
+        };
+      },
+    };
+
+    const { result, rerender } = renderHook(
+      ({ thread }) =>
+        useThreadSkills({
+          desktopApi,
+          thread,
+        }),
+      {
+        initialProps: {
+          thread: createThread("thread-a"),
+        },
+      },
+    );
+
+    act(() => {
+      void result.current.ensureLoaded();
+    });
+
+    await waitFor(() => {
+      expect(listSkills).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-a",
+      });
+    });
+
+    rerender({ thread: createThread("thread-b") });
+    await act(async () => {
+      await result.current.ensureLoaded();
+    });
+
+    await waitFor(() => {
+      expect(result.current.skills.map((skill) => skill.name)).toEqual([
+        "thread-b",
+      ]);
+    });
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "skills/changed",
+          params: {},
+        },
+      });
+    });
+
+    await act(async () => {
+      resolveThreadA?.(createResponse("stale-a"));
+      await Promise.resolve();
+    });
+
+    rerender({ thread: createThread("thread-a") });
+    await act(async () => {
+      await result.current.ensureLoaded();
+    });
+
+    await waitFor(() => {
+      expect(result.current.skills.map((skill) => skill.name)).toEqual([
+        "fresh-a",
+      ]);
+    });
+    expect(threadARequestCount).toBe(2);
   });
 
   it("updates cached ACP provider commands when session metadata changes", async () => {

--- a/apps/desktop/src/renderer/src/lib/useThreadSkills.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSkills.ts
@@ -33,6 +33,7 @@ export function useThreadSkills(params: {
 } {
   const { desktopApi, launchpad, thread } = params;
   const requestVersionsRef = useRef<Record<string, number>>({});
+  const stateByThreadKeyRef = useRef<Record<string, SkillState>>({});
   const [stateByThreadKey, setStateByThreadKey] = useState<Record<string, SkillState>>({});
   const skillTarget = useMemo(() => {
     if (thread) {
@@ -67,14 +68,122 @@ export function useThreadSkills(params: {
   const state = skillTarget ? stateByThreadKey[skillTarget.key] : undefined;
 
   useEffect(() => {
-    if (!desktopApi?.onAgentEvent || !skillTarget?.threadId) {
+    stateByThreadKeyRef.current = stateByThreadKey;
+  }, [stateByThreadKey]);
+
+  const loadTarget = useCallback(
+    async (options: { force?: boolean } = {}): Promise<void> => {
+      if (!skillTarget) {
+        return;
+      }
+
+      if (!desktopApi?.listSkills) {
+        setStateByThreadKey((current) => ({
+          ...current,
+          [skillTarget.key]: {
+            error: "Desktop bridge is missing listSkills().",
+            loading: false,
+            response: undefined,
+          },
+        }));
+        return;
+      }
+
+      const currentState = stateByThreadKeyRef.current[skillTarget.key];
+      if (!options.force && (currentState?.loading || currentState?.response)) {
+        return;
+      }
+
+      const requestVersion =
+        (requestVersionsRef.current[skillTarget.key] ?? 0) + 1;
+      requestVersionsRef.current[skillTarget.key] = requestVersion;
+      const cwds = skillTarget.cwds;
+
+      setStateByThreadKey((current) => ({
+        ...current,
+        [skillTarget.key]: {
+          ...createEmptySkillState(),
+          loading: true,
+        },
+      }));
+
+      try {
+        const response = await desktopApi.listSkills({
+          backend: skillTarget.backend,
+          ...(cwds.length === 1 ? { cwd: cwds[0] } : {}),
+          ...(cwds.length > 0 ? { cwds } : {}),
+          ...(skillTarget.threadId ? { threadId: skillTarget.threadId } : {}),
+        });
+
+        if (requestVersionsRef.current[skillTarget.key] !== requestVersion) {
+          return;
+        }
+
+        setStateByThreadKey((current) => ({
+          ...current,
+          [skillTarget.key]: {
+            error: undefined,
+            loading: false,
+            response,
+          },
+        }));
+      } catch (error) {
+        if (requestVersionsRef.current[skillTarget.key] !== requestVersion) {
+          return;
+        }
+
+        setStateByThreadKey((current) => ({
+          ...current,
+          [skillTarget.key]: {
+            error: error instanceof Error ? error.message : String(error),
+            loading: false,
+            response: undefined,
+          },
+        }));
+      }
+    },
+    [desktopApi, skillTarget],
+  );
+
+  useEffect(() => {
+    if (!desktopApi?.onAgentEvent || !skillTarget) {
       return;
     }
 
     const { backend, key, threadId } = skillTarget;
     return desktopApi.onAgentEvent((event) => {
+      if (event.backend !== backend) {
+        return;
+      }
+
+      if (event.notification.method === "skills/changed") {
+        const currentState = stateByThreadKeyRef.current[key];
+        if (!currentState?.loading && !currentState?.response) {
+          return;
+        }
+        const staleKeyPrefixes = [`${backend}:`, `launchpad:${backend}:`];
+        const retainedEntries: Array<[string, SkillState]> = [];
+
+        for (const [cachedKey, cachedState] of Object.entries(
+          stateByThreadKeyRef.current,
+        )) {
+          if (staleKeyPrefixes.some((prefix) => cachedKey.startsWith(prefix))) {
+            requestVersionsRef.current[cachedKey] =
+              (requestVersionsRef.current[cachedKey] ?? 0) + 1;
+            continue;
+          }
+          retainedEntries.push([cachedKey, cachedState]);
+        }
+        const next = Object.fromEntries(retainedEntries);
+        stateByThreadKeyRef.current = next;
+        setStateByThreadKey(next);
+
+        void loadTarget({ force: true });
+        return;
+      }
+
       if (
-        event.backend !== backend ||
+        !threadId ||
         event.notification.method !== "thread/availableCommands/updated" ||
         event.notification.params.threadId !== threadId
       ) {
@@ -108,77 +217,11 @@ export function useThreadSkills(params: {
         },
       }));
     });
-  }, [desktopApi, skillTarget]);
+  }, [desktopApi, loadTarget, skillTarget]);
 
   const ensureLoaded = useCallback(async (): Promise<void> => {
-    if (!skillTarget) {
-      return;
-    }
-
-    if (!desktopApi?.listSkills) {
-      setStateByThreadKey((current) => ({
-        ...current,
-        [skillTarget.key]: {
-          error: "Desktop bridge is missing listSkills().",
-          loading: false,
-          response: undefined,
-        },
-      }));
-      return;
-    }
-
-    const currentState = stateByThreadKey[skillTarget.key];
-    if (currentState?.loading || currentState?.response) {
-      return;
-    }
-
-    const requestVersion = (requestVersionsRef.current[skillTarget.key] ?? 0) + 1;
-    requestVersionsRef.current[skillTarget.key] = requestVersion;
-    const cwds = skillTarget.cwds;
-
-    setStateByThreadKey((current) => ({
-      ...current,
-      [skillTarget.key]: {
-        ...createEmptySkillState(),
-        loading: true,
-      },
-    }));
-
-    try {
-      const response = await desktopApi.listSkills({
-        backend: skillTarget.backend,
-        ...(cwds.length === 1 ? { cwd: cwds[0] } : {}),
-        ...(cwds.length > 0 ? { cwds } : {}),
-        ...(skillTarget.threadId ? { threadId: skillTarget.threadId } : {}),
-      });
-
-      if (requestVersionsRef.current[skillTarget.key] !== requestVersion) {
-        return;
-      }
-
-      setStateByThreadKey((current) => ({
-        ...current,
-        [skillTarget.key]: {
-          error: undefined,
-          loading: false,
-          response,
-        },
-      }));
-    } catch (error) {
-      if (requestVersionsRef.current[skillTarget.key] !== requestVersion) {
-        return;
-      }
-
-      setStateByThreadKey((current) => ({
-        ...current,
-        [skillTarget.key]: {
-          error: error instanceof Error ? error.message : String(error),
-          loading: false,
-          response: undefined,
-        },
-      }));
-    }
-  }, [desktopApi, skillTarget, stateByThreadKey]);
+    await loadTarget();
+  }, [loadTarget]);
 
   const skills = useMemo(() => {
     const deduped = new Map<string, AppServerSkillSummary>();

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -1025,6 +1025,15 @@ export type AppServerNotification =
       };
     }
   | {
+      method: "skills/changed";
+      params: {
+        cwd?: string;
+        cwds?: string[];
+        reason?: string;
+        [key: string]: unknown;
+      };
+    }
+  | {
       method: "thread/codexEnvironment/updated";
       params: {
         threadId: string;


### PR DESCRIPTION
## Summary
- Refresh the renderer skill catalog when Codex emits `skills/changed`.
- Invalidate cached skill results for the active backend so autocomplete cannot resurrect stale skill lists.
- Add `skills/changed` to the shared normalized app-server notification contract.

## Root Cause
Codex already forwarded `skills/changed`, but `useThreadSkills` only reused its cached `skills/list` response after the first autocomplete load. New skills created during a thread stayed hidden until the renderer target remounted or otherwise lost the cache.

## Validation
- `./node_modules/.bin/vitest run --config vitest.workspace.ts apps/desktop/src/renderer/src/lib/__tests__/useThreadSkills.test.tsx`
- `./node_modules/.bin/tsc --noEmit -p apps/desktop/tsconfig.json`

Note: `pnpm` was not available in this shell, so validation used the installed repo binaries directly.
