### PR TITLE
fix(desktop): recover failed Gemini launchpads

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-local-discovery.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-local-discovery.test.ts
@@ -47,6 +47,32 @@ describe("discoverLocalAcpAgents", () => {
     ]);
   });
 
+  it("prefers a concrete Gemini executable path when it is available", async () => {
+    const probe = vi.fn<LocalAcpAgentProbe>(async (command, args) => {
+      if (command !== "/opt/homebrew/bin/gemini") {
+        throw Object.assign(new Error("missing"), { code: "ENOENT" });
+      }
+      if (args[0] === "--version") {
+        return { stdout: "0.45.0\n" };
+      }
+      if (args[0] === "--help") {
+        return { stdout: "Usage: gemini [options]\n  --acp Starts ACP mode\n" };
+      }
+      throw new Error("unexpected probe");
+    });
+
+    const agents = await discoverLocalAcpAgents({ probe, now: () => 1234 });
+
+    expect(agents[0]).toMatchObject({
+      backendId: "acp:gemini",
+      distributionSource: "/opt/homebrew/bin/gemini --acp --skip-trust",
+      launchDescriptor: {
+        command: "/opt/homebrew/bin/gemini",
+        args: ["--acp", "--skip-trust"],
+      },
+    });
+  });
+
   it("discovers Kimi Code CLI when the local command supports ACP", async () => {
     const probe = vi.fn<LocalAcpAgentProbe>(async (command, args) => {
       if (command !== "kimi") {

--- a/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
@@ -198,6 +198,94 @@ describe("AcpSessionReplayNormalizer", () => {
     expect(idleReplay.threadStatus).toBe("idle");
   });
 
+  it("shows a waiting activity for live prompts until the agent responds", () => {
+    const normalizer = new AcpSessionReplayNormalizer();
+
+    const activeReplay = normalizer.recordUserPrompt({
+      sessionId: "session-1",
+      prompt: "hello",
+      turnId: "pending:session-1",
+      receivedAt: 1000,
+      waitingForAgent: true,
+    });
+
+    expect(activeReplay.entries).toEqual([
+      expect.objectContaining({
+        type: "message",
+        role: "user",
+        text: "hello",
+      }),
+      expect.objectContaining({
+        type: "activity",
+        id: "agent-waiting:pending:session-1",
+        summary: "Waiting for agent response",
+        status: "in_progress",
+      }),
+    ]);
+
+    const respondedReplay = normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1001,
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "Hi." },
+      },
+    });
+
+    expect(respondedReplay.entries.map((entry) => entry.id)).not.toContain(
+      "agent-waiting:pending:session-1",
+    );
+    expect(respondedReplay.lastAssistantMessage).toBe("Hi.");
+  });
+
+  it("removes waiting activity when a provider finishes without a turn id", () => {
+    const normalizer = new AcpSessionReplayNormalizer();
+
+    normalizer.recordUserPrompt({
+      sessionId: "session-1",
+      prompt: "hello",
+      turnId: "pending:session-1",
+      receivedAt: 1000,
+      waitingForAgent: true,
+    });
+    const finishedReplay = normalizer.recordTurnFinished();
+
+    expect(finishedReplay.threadStatus).toBe("idle");
+    expect(finishedReplay.entries.map((entry) => entry.id)).not.toContain(
+      "agent-waiting:pending:session-1",
+    );
+  });
+
+  it("replaces waiting activity with the provider failure", () => {
+    const normalizer = new AcpSessionReplayNormalizer();
+
+    normalizer.recordUserPrompt({
+      sessionId: "session-1",
+      prompt: "hello",
+      turnId: "pending:session-1",
+      receivedAt: 1000,
+      waitingForAgent: true,
+    });
+    const failedReplay = normalizer.recordTurnFailed({
+      sessionId: "session-1",
+      turnId: "pending:session-1",
+      error: "json-rpc error (500): You have exhausted your capacity on this model.",
+      receivedAt: 1001,
+    });
+
+    expect(failedReplay.entries.map((entry) => entry.id)).not.toContain(
+      "agent-waiting:pending:session-1",
+    );
+    expect(failedReplay.entries).toContainEqual(
+      expect.objectContaining({
+        type: "activity",
+        id: "turn-failed:pending:session-1",
+        summary: "Turn failed",
+        status: "failed",
+      }),
+    );
+  });
+
   it("keeps persisted user prompt image parts out of transcript text", () => {
     const normalizer = new AcpSessionReplayNormalizer();
     const imageUrl = "data:image/png;base64,aGVsbG8=";

--- a/apps/desktop/src/main/__tests__/acp-stdio-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-stdio-transport.test.ts
@@ -63,6 +63,8 @@ describe("AcpStdioJsonRpcTransport", () => {
       cwd: "/repo",
     });
     expect(options.env).toMatchObject({ ACP_TEST: "1" });
+    expect(String(options.env?.PATH)).toContain("/opt/homebrew/bin");
+    expect(String(options.env?.PATH)).toContain("/usr/local/bin");
 
     const envelope = JSON.parse(child.writes[0]) as { id: string; method: string };
     expect(child.writes[0]).toMatch(/\n$/);

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -312,12 +312,14 @@ export class AcpAgentClient {
       parts: params.parts,
       turnId,
       receivedAt,
+      waitingForAgent: true,
     });
     this.appendHistoryUpdate(params.sessionId, receivedAt, {
       kind: "pwragent_user_prompt",
       prompt: params.prompt,
       ...(params.parts?.length ? { parts: params.parts } : {}),
       turnId,
+      waitingForAgent: true,
     });
     this.markSessionHasConversationHistory(params.sessionId, receivedAt);
     let result: unknown;
@@ -401,12 +403,14 @@ export class AcpAgentClient {
       parts: params.parts,
       turnId,
       receivedAt,
+      waitingForAgent: true,
     });
     this.appendHistoryUpdate(params.sessionId, receivedAt, {
       kind: "pwragent_user_prompt",
       prompt: params.prompt,
       ...(params.parts?.length ? { parts: params.parts } : {}),
       turnId,
+      waitingForAgent: true,
     });
     this.markSessionHasConversationHistory(params.sessionId, receivedAt);
     const protocolSessionId = this.protocolSessionIdFor(params.sessionId);

--- a/apps/desktop/src/main/acp/acp-local-discovery.ts
+++ b/apps/desktop/src/main/acp/acp-local-discovery.ts
@@ -27,6 +27,7 @@ export type LocalAcpDiscoveryOptions = {
    * if it succeeds the bare command name probe is skipped.
    */
   overrides?: {
+    gemini?: string;
     grok?: string;
     qwen?: string;
     kimi?: string;
@@ -50,58 +51,65 @@ export async function discoverLocalAcpAgents(
 async function discoverLocalGemini(options?: {
   probe?: LocalAcpAgentProbe;
   now?: () => number;
+  overrides?: {
+    gemini?: string;
+  };
 }): Promise<AcpInstalledAgentRecord | undefined> {
   const probe = options?.probe ?? defaultProbe;
-  const [versionResult, helpResult] = await Promise.all([
-    probeCommand(probe, "gemini", ["--version"]),
-    probeCommand(probe, "gemini", ["--help"]),
-  ]);
-  if (!versionResult || !helpResult) {
-    return undefined;
-  }
+  const candidates = geminiCandidatePaths(options?.overrides?.gemini);
+  for (const command of candidates) {
+    const [versionResult, helpResult] = await Promise.all([
+      probeCommand(probe, command, ["--version"]),
+      probeCommand(probe, command, ["--help"]),
+    ]);
+    if (!versionResult || !helpResult) {
+      continue;
+    }
 
-  const helpText = resultText(helpResult);
-  if (!/(^|\s)--acp(\s|,|$)/.test(helpText)) {
-    return undefined;
-  }
+    const helpText = resultText(helpResult);
+    if (!/(^|\s)--acp(\s|,|$)/.test(helpText)) {
+      continue;
+    }
 
-  const now = options?.now?.() ?? Date.now();
-  const backendId = "acp:gemini" as AcpBackendId;
-  const version = parseGeminiVersion(resultText(versionResult));
-  return {
-    backendId,
-    registryId: "gemini",
-    name: "Gemini CLI",
-    version,
-    distributionKind: "local",
-    distributionSource: "gemini --acp --skip-trust",
-    installStatus: "installed",
-    authStatus: "not-required",
-    verificationStatus: "not-applicable",
-    allowlistRuleId: "local-gemini-cli",
-    installedAt: now,
-    updatedAt: now,
-    capabilities: acpAgentCapabilitiesForRegistryId("gemini"),
-    launchDescriptor: normalizeAcpLaunchDescriptor({
+    const now = options?.now?.() ?? Date.now();
+    const backendId = "acp:gemini" as AcpBackendId;
+    const version = parseGeminiVersion(resultText(versionResult));
+    return {
       backendId,
       registryId: "gemini",
-      distributionKind: "local",
-      command: "gemini",
-      args: ["--acp"],
-      env: {},
-    }),
-    registryAgent: {
-      id: "gemini",
-      backendId,
       name: "Gemini CLI",
       version,
-      authors: ["Google"],
-      distributions: [],
-      distributionKinds: ["local"],
-      auth: { required: false, methods: ["agent-managed"] },
-      raw: { source: "local-cli" },
-    },
-  };
+      distributionKind: "local",
+      distributionSource: `${command} --acp --skip-trust`,
+      installStatus: "installed",
+      authStatus: "not-required",
+      verificationStatus: "not-applicable",
+      allowlistRuleId: "local-gemini-cli",
+      installedAt: now,
+      updatedAt: now,
+      capabilities: acpAgentCapabilitiesForRegistryId("gemini"),
+      launchDescriptor: normalizeAcpLaunchDescriptor({
+        backendId,
+        registryId: "gemini",
+        distributionKind: "local",
+        command,
+        args: ["--acp"],
+        env: {},
+      }),
+      registryAgent: {
+        id: "gemini",
+        backendId,
+        name: "Gemini CLI",
+        version,
+        authors: ["Google"],
+        distributions: [],
+        distributionKinds: ["local"],
+        auth: { required: false, methods: ["agent-managed"] },
+        raw: { source: "local-cli" },
+      },
+    };
+  }
+  return undefined;
 }
 
 async function discoverLocalKimi(
@@ -326,6 +334,19 @@ function qwenCandidatePaths(override?: string): string[] {
   candidates.push(path.join(homedir(), ".qwen", "bin", "qwen"));
   candidates.push("/opt/homebrew/bin/qwen");
   candidates.push("/usr/local/bin/qwen");
+  return Array.from(new Set(candidates));
+}
+
+function geminiCandidatePaths(override?: string): string[] {
+  const candidates: string[] = [];
+  if (override && override.trim().length > 0) {
+    candidates.push(override.trim());
+  }
+  candidates.push(path.join(homedir(), ".local", "bin", "gemini"));
+  candidates.push(path.join(homedir(), "bin", "gemini"));
+  candidates.push("/opt/homebrew/bin/gemini");
+  candidates.push("/usr/local/bin/gemini");
+  candidates.push("gemini");
   return Array.from(new Set(candidates));
 }
 

--- a/apps/desktop/src/main/acp/acp-session-normalizer.ts
+++ b/apps/desktop/src/main/acp/acp-session-normalizer.ts
@@ -41,6 +41,7 @@ export class AcpSessionReplayNormalizer {
     parts?: AppServerThreadMessagePart[];
     turnId: string;
     receivedAt?: number;
+    waitingForAgent?: boolean;
   }): AppServerThreadReplay {
     const createdAt = params.receivedAt ?? Date.now();
     const id = `user:${params.turnId}`;
@@ -55,11 +56,19 @@ export class AcpSessionReplayNormalizer {
       ...(normalizedPrompt.parts?.length ? { parts: normalizedPrompt.parts } : {}),
       createdAt,
     });
+    if (params.waitingForAgent) {
+      this.upsertAgentWaitingActivity(params.turnId, createdAt);
+    }
     this.status = "active";
     return this.replay();
   }
 
   recordTurnFinished(turnId?: string): AppServerThreadReplay {
+    if (turnId) {
+      this.removeAgentWaitingActivity(turnId);
+    } else {
+      this.removeCurrentAgentWaitingActivity();
+    }
     if (!turnId || this.currentTurnId === turnId) {
       this.currentTurnId = undefined;
     }
@@ -75,6 +84,7 @@ export class AcpSessionReplayNormalizer {
     receivedAt?: number;
   }): AppServerThreadReplay {
     const createdAt = params.receivedAt ?? Date.now();
+    this.removeAgentWaitingActivity(params.turnId);
     if (this.currentTurnId === params.turnId) {
       this.currentTurnId = undefined;
     }
@@ -113,6 +123,13 @@ export class AcpSessionReplayNormalizer {
     if (isAssistantTextUpdate) {
       // Consecutive ACP text chunks form one live bubble, but text after a tool
       // call should become a new bubble instead of overwriting earlier text.
+      const text =
+        readContentText(update.update, "content") ??
+        readString(update.update, "text") ??
+        "";
+      if (text && !isModeUpdateMarker(text) && this.currentTurnId) {
+        this.removeAgentWaitingActivity(this.currentTurnId);
+      }
       if (kind === "agent_message_chunk") {
         this.applyAgentMessageChunk(update, createdAt);
       } else {
@@ -130,10 +147,13 @@ export class AcpSessionReplayNormalizer {
     } else {
       this.activeAssistantMessageId = undefined;
       if (kind === "plan") {
+        this.removeCurrentAgentWaitingActivity();
         this.upsertPlan(update, createdAt);
       } else if (kind === "tool_call" || kind === "tool_call_update") {
+        this.removeCurrentAgentWaitingActivity();
         this.upsertActivity(toolActivity(update, kind, createdAt));
       } else if (kind === "file" || kind === "terminal") {
+        this.removeCurrentAgentWaitingActivity();
         this.upsertActivity(toolActivity(update, kind, createdAt));
       } else if (kind === "turn_started") {
         this.status = "active";
@@ -153,8 +173,10 @@ export class AcpSessionReplayNormalizer {
           parts: readMessageParts(update.update),
           turnId: readString(update.update, "turnId") ?? `pending:${update.sessionId}`,
           receivedAt: createdAt,
+          waitingForAgent: readBoolean(update.update, "waitingForAgent"),
         });
       } else {
+        this.removeCurrentAgentWaitingActivity();
         this.upsertActivity(unknownActivity(update, kind, createdAt));
       }
     }
@@ -277,6 +299,41 @@ export class AcpSessionReplayNormalizer {
     this.entries[index] = mergeActivity(
       this.entries[index] as AppServerThreadActivityEntry,
       activity,
+    );
+  }
+
+  private upsertAgentWaitingActivity(turnId: string, createdAt: number): void {
+    this.upsertActivity({
+      type: "activity",
+      id: agentWaitingActivityId(turnId),
+      createdAt,
+      summary: "Waiting for agent response",
+      status: "in_progress",
+      turn: {
+        id: turnId,
+        status: "in_progress",
+        startedAt: createdAt,
+      },
+      details: [
+        {
+          id: `${agentWaitingActivityId(turnId)}:detail`,
+          kind: "read",
+          label: "The prompt was sent. Waiting for the agent provider to respond.",
+          status: "in_progress",
+        },
+      ],
+    });
+  }
+
+  private removeCurrentAgentWaitingActivity(): void {
+    if (this.currentTurnId) {
+      this.removeAgentWaitingActivity(this.currentTurnId);
+    }
+  }
+
+  private removeAgentWaitingActivity(turnId: string): void {
+    this.entries = this.entries.filter(
+      (entry) => entry.id !== agentWaitingActivityId(turnId),
     );
   }
 
@@ -425,6 +482,18 @@ function readString(
 ): string | undefined {
   const value = record[key];
   return typeof value === "string" ? value : undefined;
+}
+
+function readBoolean(
+  record: Record<string, unknown>,
+  key: string,
+): boolean | undefined {
+  const value = record[key];
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function agentWaitingActivityId(turnId: string): string {
+  return `agent-waiting:${turnId}`;
 }
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {

--- a/apps/desktop/src/main/acp/acp-stdio-transport.ts
+++ b/apps/desktop/src/main/acp/acp-stdio-transport.ts
@@ -40,6 +40,32 @@ export type AcpStdioJsonRpcTransportOptions = {
   spawn?: AcpStdioSpawn;
 };
 
+function appendExecutableSearchPaths(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  if (process.platform === "win32") {
+    return env;
+  }
+
+  const pathKey = "PATH";
+  const pathEntries = (env[pathKey] ?? "").split(":").filter(Boolean);
+  const pathSet = new Set(pathEntries);
+  for (const candidate of [
+    "/opt/homebrew/bin",
+    "/usr/local/bin",
+    `${process.env.HOME ?? ""}/.local/bin`,
+    `${process.env.HOME ?? ""}/bin`,
+  ]) {
+    if (candidate && !pathSet.has(candidate)) {
+      pathEntries.push(candidate);
+      pathSet.add(candidate);
+    }
+  }
+
+  return {
+    ...env,
+    [pathKey]: pathEntries.join(":"),
+  };
+}
+
 export class AcpStdioJsonRpcTransport implements AcpJsonRpcTransport {
   private readonly lineTransport: AcpLineStdioTransport;
   private readonly connection: JsonRpcConnection;
@@ -155,7 +181,7 @@ class AcpLineStdioTransport implements JsonRpcTransport {
     }
 
     const descriptor = normalizeAcpLaunchDescriptor(this.options.launchDescriptor);
-    const env = { ...process.env, ...descriptor.env };
+    const env = appendExecutableSearchPaths({ ...process.env, ...descriptor.env });
     const spawnProcess = this.options.spawn ?? spawn;
     acpTransportLog.info("launch ACP agent", {
       backendId: descriptor.backendId,

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -214,6 +214,41 @@ function LaunchpadEnvironmentSetupPending(props: {
   );
 }
 
+function LaunchpadMaterializeFailure(props: {
+  directoryLabel: string;
+  error: string;
+  onClose: () => void;
+}) {
+  return (
+    <section
+      className="transcript-panel transcript-panel--pending"
+      aria-label="Thread launch failed"
+    >
+      <div className="launchpad-pending">
+        <div className="launchpad-pending__header">
+          <div>
+            <p className="eyebrow">Thread launch failed</p>
+            <h3>Could not start {props.directoryLabel}</h3>
+          </div>
+          <button
+            className="button button--ghost"
+            type="button"
+            onClick={props.onClose}
+          >
+            Close
+          </button>
+        </div>
+        <div className="launchpad-pending__output" aria-label="Launch error">
+          <div className="launchpad-pending__command-label">Error</div>
+          <pre>
+            <code>{props.error}</code>
+          </pre>
+        </div>
+      </div>
+    </section>
+  );
+}
+
 function EnvironmentSetupFailureChoice(props: {
   archiving: boolean;
   continuing: boolean;
@@ -958,6 +993,8 @@ export function ThreadView(props: ThreadViewProps) {
   const [transcriptReglueRequestKey, setTranscriptReglueRequestKey] = useState(0);
   const [contextRailWidth, setContextRailWidth] = useState(380);
   const [launchpadMaterializing, setLaunchpadMaterializing] = useState(false);
+  const [launchpadMaterializeError, setLaunchpadMaterializeError] =
+    useState<string>();
   const [setupFailureDismissedThreadKeys, setSetupFailureDismissedThreadKeys] =
     useState<Set<string>>(() => new Set());
   const [setupFailureArchiving, setSetupFailureArchiving] = useState(false);
@@ -994,6 +1031,7 @@ export function ThreadView(props: ThreadViewProps) {
     setContextRailResizing(false);
     setExpandedImage(undefined);
     setLaunchpadMaterializing(false);
+    setLaunchpadMaterializeError(undefined);
     setLaunchpadSetupProgress(undefined);
     setSetupFailureContinuing(false);
     setSetupFailureContinueError(undefined);
@@ -1919,6 +1957,7 @@ export function ThreadView(props: ThreadViewProps) {
       }
 
       setLaunchpadMaterializing(true);
+      setLaunchpadMaterializeError(undefined);
       try {
         await props.onMaterializeLaunchpad(
           directoryKey,
@@ -1927,7 +1966,9 @@ export function ThreadView(props: ThreadViewProps) {
           reviewTarget
         );
       } catch (error) {
-        setLaunchpadMaterializing(false);
+        setLaunchpadMaterializeError(
+          error instanceof Error ? error.message : String(error)
+        );
         throw error;
       }
     };
@@ -2023,7 +2064,16 @@ export function ThreadView(props: ThreadViewProps) {
         </div>
 
         <div className="thread-view__launchpad-composer">
-          {launchpadMaterializing && launchpadRunningCodexEnvironmentSetup ? (
+          {launchpadMaterializing && launchpadMaterializeError ? (
+            <LaunchpadMaterializeFailure
+              directoryLabel={selectedLaunchpad.directoryLabel}
+              error={launchpadMaterializeError}
+              onClose={() => {
+                setLaunchpadMaterializing(false);
+                setLaunchpadMaterializeError(undefined);
+              }}
+            />
+          ) : launchpadMaterializing && launchpadRunningCodexEnvironmentSetup ? (
             <LaunchpadEnvironmentSetupPending
               command={
                 launchpadSetupProgress?.command ??

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -381,6 +381,88 @@ describe("ThreadView", () => {
     expect(screen.getByRole("group", { name: "Messaging platform status" })).toBeInTheDocument();
   });
 
+  it("keeps launch failures closable from the pending setup screen", async () => {
+    const selectedDirectory = {
+      key: "directory:/repo",
+      kind: "directory",
+      label: "PwrAgent",
+      path: "/repo",
+      threadKeys: [],
+      needsAttentionCount: 0,
+    } satisfies NavigationDirectorySummary;
+    const selectedLaunchpad = {
+      backend: "acp:gemini",
+      createdAt: 1000,
+      directoryKey: selectedDirectory.key,
+      directoryKind: selectedDirectory.kind,
+      directoryLabel: selectedDirectory.label,
+      directoryPath: selectedDirectory.path,
+      executionMode: "default",
+      prompt: "Run node --version",
+      updatedAt: 1000,
+      workMode: "worktree",
+    } satisfies NavigationLaunchpadDraft;
+    const onMaterializeLaunchpad = vi.fn(async () => {
+      throw new Error("json-rpc error (500): You have exhausted your capacity on this model.");
+    });
+
+    render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[
+          {
+            kind: "acp:gemini",
+            label: "Gemini",
+            available: true,
+            methods: ["session/new", "session/prompt"],
+            capabilities: {
+              listThreads: true,
+              createThread: true,
+              resumeThread: true,
+              renameThread: true,
+              readThread: true,
+              startTurn: true,
+              interruptTurn: true,
+              steerTurn: false,
+              transcriptPagination: false,
+              toolUse: true,
+              approvalRequests: true,
+              multiDirectoryThreads: true,
+            },
+            executionModes: [],
+          },
+        ]}
+        clearPendingRequest={() => undefined}
+        composerDisabled={false}
+        loading={false}
+        loadingMore={false}
+        messageCount={0}
+        selectedDirectory={selectedDirectory}
+        selectedLaunchpad={selectedLaunchpad}
+        skills={[]}
+        transcriptEntries={[]}
+        onLoadOlder={async () => undefined}
+        onMaterializeLaunchpad={onMaterializeLaunchpad}
+        removeOptimisticMessage={(_id) => undefined}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Start thread" }));
+
+    expect(await screen.findByRole("heading", { name: "Could not start PwrAgent" }))
+      .toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "json-rpc error (500): You have exhausted your capacity on this model.",
+      ),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+
+    expect(await screen.findByRole("textbox", { name: "New thread" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Start thread" })).toBeInTheDocument();
+  });
+
   it("describes sub-thread launchpads as grouped children with empty history", () => {
     const selectedDirectory = {
       key: "subthread:codex:thread-parent:new-worktree",

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -1554,6 +1554,143 @@ describe("useThreadNavigation", () => {
     expect(result.current.directories[0]?.needsAttentionCount).toBe(1);
   });
 
+  it("rejects materialize failures after recording the launchpad error", async () => {
+    const directoryKey = "directory:/Users/huntharo/github/PwrAgent";
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [],
+      directories: [
+        {
+          key: directoryKey,
+          kind: "directory" as const,
+          label: "PwrAgent",
+          path: "/Users/huntharo/github/PwrAgent",
+          threadKeys: [],
+          needsAttentionCount: 0,
+          launchpad: {
+            directoryKey,
+            directoryKind: "directory" as const,
+            directoryLabel: "PwrAgent",
+            directoryPath: "/Users/huntharo/github/PwrAgent",
+            backend: "acp:gemini" as const,
+            executionMode: "default" as const,
+            prompt: "Investigate Gemini",
+            workMode: "worktree" as const,
+            branchName: "main",
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        },
+      ],
+      launchpadDefaults: {
+        backend: "acp:gemini" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const materializeDirectoryLaunchpad = vi.fn(async () => {
+      throw new Error("spawn gemini ENOENT");
+    });
+
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      materializeDirectoryLaunchpad,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.selectedLaunchpad?.directoryKey).toBe(directoryKey);
+    });
+
+    await act(async () => {
+      await expect(
+        result.current.materializeDirectoryLaunchpad(directoryKey)
+      ).rejects.toThrow("spawn gemini ENOENT");
+    });
+
+    expect(result.current.launchpadError).toBe("spawn gemini ENOENT");
+    expect(result.current.selectedLaunchpad?.directoryKey).toBe(directoryKey);
+    expect(result.current.selectedThread).toBeUndefined();
+  });
+
+  it("keeps the materialized thread selected when the post-create refresh fails", async () => {
+    const directoryKey = "directory:/Users/huntharo/github/PwrAgent";
+    const initialSnapshot = {
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [],
+      directories: [
+        {
+          key: directoryKey,
+          kind: "directory" as const,
+          label: "PwrAgent",
+          path: "/Users/huntharo/github/PwrAgent",
+          threadKeys: [],
+          needsAttentionCount: 0,
+          launchpad: {
+            directoryKey,
+            directoryKind: "directory" as const,
+            directoryLabel: "PwrAgent",
+            directoryPath: "/Users/huntharo/github/PwrAgent",
+            backend: "acp:gemini" as const,
+            executionMode: "default" as const,
+            prompt: "Investigate Gemini",
+            workMode: "worktree" as const,
+            branchName: "main",
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        },
+      ],
+      launchpadDefaults: {
+        backend: "acp:gemini" as const,
+        executionMode: "default" as const,
+      },
+    };
+    let snapshotCalls = 0;
+    const getNavigationSnapshot = vi.fn(async () => {
+      snapshotCalls += 1;
+      if (snapshotCalls > 1) {
+        throw new Error("refresh failed");
+      }
+      return initialSnapshot;
+    });
+    const materializeDirectoryLaunchpad = vi.fn(async () => ({
+      backend: "acp:gemini" as const,
+      threadId: "thread-new",
+      executionMode: "default" as const,
+      workMode: "worktree" as const,
+    }));
+
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      materializeDirectoryLaunchpad,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.selectedLaunchpad?.directoryKey).toBe(directoryKey);
+    });
+
+    await act(async () => {
+      await result.current.materializeDirectoryLaunchpad(directoryKey);
+    });
+
+    expect(result.current.launchpadError).toBeUndefined();
+    expect(result.current.error).toBe("refresh failed");
+    expect(result.current.selectedThread?.id).toBe("thread-new");
+    expect(result.current.selectedThread?.source).toBe("acp:gemini");
+    expect(result.current.selectedLaunchpad).toBeUndefined();
+  });
+
   it("keeps a launchpad prompt-derived title when the hydrated thread only has a fallback id title", async () => {
     const directoryKey = "directory:/Users/huntharo/github/PwrAgent";
     const threadId = "019df3a2-75b2-73d1-a273-5f94ac425966";

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -3554,10 +3554,11 @@ export function useThreadNavigation(
 
       setLaunchpadError(undefined);
 
+      const materializeParentThreadId =
+        parentThreadId ?? getParentThreadIdFromSubthreadLaunchpadKey(directoryKey);
+      let response: Awaited<ReturnType<NonNullable<DesktopApi["materializeDirectoryLaunchpad"]>>>;
       try {
-        const materializeParentThreadId =
-          parentThreadId ?? getParentThreadIdFromSubthreadLaunchpadKey(directoryKey);
-        const response = await desktopApi.materializeDirectoryLaunchpad({
+        response = await desktopApi.materializeDirectoryLaunchpad({
           directoryKey,
           launchpad,
           input,
@@ -3567,39 +3568,44 @@ export function useThreadNavigation(
             ? { parentThreadId: materializeParentThreadId }
             : {}),
         });
-        const optimisticMaterializedThread = buildOptimisticThreadFromLaunchpad({
-          directory,
-          launchpad,
-          backend: response.backend,
-          threadId: response.threadId,
-          executionMode: response.executionMode,
-          workMode: response.workMode,
-          codexEnvironmentRuntime: response.codexEnvironmentRuntime,
-          optimisticUserMessage: buildOptimisticUserMessage(input),
-          parentThreadId: materializeParentThreadId,
-        });
-        const nextThreadKey = buildThreadIdentityKey(response.backend, response.threadId);
-        setLocalLaunchpads((current) => {
-          if (!current[directoryKey]) {
-            return current;
-          }
-          const next = { ...current };
-          delete next[directoryKey];
-          return next;
-        });
-        setOptimisticThread(optimisticMaterializedThread);
-        setSelectedItemKey(nextThreadKey);
-        setPendingSeenThreadKey(nextThreadKey);
-        setState((current) => ({
-          ...current,
-          response: current.response
-            ? applyLaunchpadReset(
-                current.response,
-                directoryKey,
-                current.response.launchpadDefaults
-              )
-            : current.response,
-        }));
+      } catch (error) {
+        setLaunchpadError(error instanceof Error ? error.message : String(error));
+        throw error;
+      }
+      const optimisticMaterializedThread = buildOptimisticThreadFromLaunchpad({
+        directory,
+        launchpad,
+        backend: response.backend,
+        threadId: response.threadId,
+        executionMode: response.executionMode,
+        workMode: response.workMode,
+        codexEnvironmentRuntime: response.codexEnvironmentRuntime,
+        optimisticUserMessage: buildOptimisticUserMessage(input),
+        parentThreadId: materializeParentThreadId,
+      });
+      const nextThreadKey = buildThreadIdentityKey(response.backend, response.threadId);
+      setLocalLaunchpads((current) => {
+        if (!current[directoryKey]) {
+          return current;
+        }
+        const next = { ...current };
+        delete next[directoryKey];
+        return next;
+      });
+      setOptimisticThread(optimisticMaterializedThread);
+      setSelectedItemKey(nextThreadKey);
+      setPendingSeenThreadKey(nextThreadKey);
+      setState((current) => ({
+        ...current,
+        response: current.response
+          ? applyLaunchpadReset(
+              current.response,
+              directoryKey,
+              current.response.launchpadDefaults
+            )
+          : current.response,
+      }));
+      try {
         await refresh(nextThreadKey, optimisticMaterializedThread);
       } catch (error) {
         setLaunchpadError(error instanceof Error ? error.message : String(error));


### PR DESCRIPTION
## Summary
Gemini launchpad failures no longer trap the selected project in an opaque pending state. If environment setup or thread startup fails while the launch screen is visible, the failure stays on that screen with a Close action that returns to the same editable launchpad draft.

The Gemini process-launch issue was caused by starting ACP with a bare `gemini` command even when the installed binary lived under Homebrew. Local Gemini discovery now prefers concrete executable paths, and ACP child launches append standard Homebrew/user bin directories to PATH so stale bare-command descriptors can still resolve.

ACP turns also show an in-progress “Waiting for agent response” activity after the prompt is sent. That makes slow provider-side failures, such as Gemini capacity exhaustion, visible while the provider request is still pending and then replaces the waiting activity with the real failure when it arrives.

## Validation
- `pnpm test apps/desktop/src/main/__tests__/acp-local-discovery.test.ts apps/desktop/src/main/__tests__/acp-stdio-transport.test.ts apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx`
- `pnpm test apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts apps/desktop/src/main/__tests__/acp-client.test.ts apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
