### PR TITLE
fix(desktop): keep live tool activity in transcript order

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -1680,6 +1680,135 @@ describe("useThreadSessionState", () => {
     ]);
   });
 
+  it("starts a new live activity bucket after assistant messages completed into the response", async () => {
+    let now = 80_000;
+    vi.spyOn(Date, "now").mockImplementation(() => now++);
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex" | "grok";
+          notification: {
+            method: string;
+            params: Record<string, unknown>;
+          };
+        }) => void)
+      | undefined;
+    const readThread = vi.fn(
+      async ({
+        backend,
+        threadId,
+      }: {
+        backend?: AppServerBackendKind;
+        threadId: string;
+      }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      })
+    );
+
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback as typeof agentEventHandler;
+        return () => undefined;
+      },
+      readThread,
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.response?.replay.entries).toEqual([]);
+    });
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/started",
+          params: {
+            threadId: "thread-1",
+            turn: { id: "turn-1", status: "inProgress" },
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/started",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: {
+              id: "read-1",
+              type: "commandExecution",
+              command: "sed -n '1,40p' src/one.ts",
+              commandActions: [{ type: "read", path: "src/one.ts" }],
+            },
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: {
+              id: "message-1",
+              type: "agentMessage",
+              phase: "commentary",
+              text: "Starting to look through the project.",
+            },
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/started",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: {
+              id: "read-2",
+              type: "commandExecution",
+              command: "rg -n transcript src",
+              commandActions: [{ type: "search", path: "src" }],
+            },
+          },
+        },
+      });
+    });
+
+    expect(
+      result.current.entries.map((entry) =>
+        entry.type === "message"
+          ? `message:${entry.text}`
+          : entry.type === "activity"
+            ? `activity:${entry.summary}:${entry.details.length}`
+            : entry.type
+      )
+    ).toEqual([
+      "activity:Explored 1 item:1",
+      "message:Starting to look through the project.",
+      "activity:Explored 1 item:1",
+    ]);
+  });
+
   it("keeps live activity between assistant messages after coarse hydration", async () => {
     let now = 30_000;
     vi.spyOn(Date, "now").mockImplementation(() => now++);

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -1939,9 +1939,14 @@ function upsertLiveActivityEntry(
   }
 
   const lastOptimisticEntry = flushed.optimisticEntries[flushed.optimisticEntries.length - 1];
+  const latestMergedEntry = mergeTranscriptEntries(
+    flushed.response?.replay.entries ?? [],
+    flushed.optimisticEntries
+  ).at(-1);
   const canMergeWithLastActivity =
     lastOptimisticEntry?.type === "activity" &&
-    lastOptimisticEntry.turn?.id === params.turn?.id;
+    lastOptimisticEntry.turn?.id === params.turn?.id &&
+    latestMergedEntry?.id === lastOptimisticEntry.id;
 
   if (canMergeWithLastActivity) {
     const updated = updateActivityEntry(


### PR DESCRIPTION
## Summary

Live transcript tool activity now stays in the same visible order that Codex events arrive. When an assistant update is completed into the hydrated response between two tool invocations from the same turn, the next tool starts a fresh activity bucket instead of merging back into the earlier bucket above that message.

This keeps later tool usages from being appended into an older activity entry above intervening assistant updates, while preserving same-turn coalescing when the activity bucket is still the latest visible transcript item. The regression test covers the `tool -> completed assistant message -> tool` stream shape that exposed the bug.

## Testing

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
