### PR TITLE
fix(desktop): onboarding profile graduation — pin requested name + dev-safe exit

### DIFF
--- a/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
+++ b/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
@@ -130,6 +130,26 @@ export type OnboardingWizardProps = {
   desktopApi?: DesktopApi;
 };
 
+/**
+ * The profile name the wizard provisions for its single-profile bootstrap
+ * paths — Shared mode and "Skip and use default". When the operator pinned a
+ * profile via `PWRAGENT_PROFILE` / `--profile`, boot resolves that env/CLI name
+ * FIRST on every launch (before the registry default), so the provisioned
+ * profile MUST carry that exact name. Otherwise the next boot looks for the
+ * pinned name, doesn't find it (we created `default` instead), and re-fires the
+ * wizard forever. Falls back to `default` for the unnamed first-run case
+ * (`no-profile-configured`), where no name was requested.
+ */
+export function bootstrapProvisionProfileName(
+  bootInfo: DesktopBootInfo | null,
+): string {
+  const requested =
+    bootInfo?.decisionKind === "missing-named-profile"
+      ? bootInfo.requestedProfileName?.trim()
+      : undefined;
+  return requested || "default";
+}
+
 export function OnboardingWizard(props: OnboardingWizardProps) {
   // Initial step:
   //   - bootstrap with a CLI/env-named missing profile →
@@ -755,12 +775,16 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
           if (activeProfile) {
             await writeBufferedSecretsIfAny(activeProfile, bufferedSecrets);
           } else if (props.desktopApi?.createPwrAgentProfile) {
-            // Bootstrap + Shared. Provision the default profile
-            // with the system-default Codex pairing implied (we
-            // skip `setPwrAgentProfileCodexProfile`; an unset
-            // codex.profile in the new profile's config.toml means
-            // "use ~/.codex/" — i.e. Shared).
-            const defaultName = "default";
+            // Bootstrap + Shared. Provision the profile with the
+            // system-default Codex pairing implied (we skip
+            // `setPwrAgentProfileCodexProfile`; an unset codex.profile
+            // in the new profile's config.toml means "use ~/.codex/"
+            // — i.e. Shared).
+            //
+            // Name it after the boot-requested profile when one was
+            // pinned (PWRAGENT_PROFILE=test / --profile test) so the next
+            // boot opens straight in instead of re-firing the wizard.
+            const defaultName = bootstrapProvisionProfileName(props.bootInfo);
             try {
               await props.desktopApi.createPwrAgentProfile({
                 profile: defaultName,
@@ -835,7 +859,11 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
     if (submitting) return;
     setSubmitting(true);
     try {
-      const defaultName = "default";
+      // Honor a boot-requested profile name (PWRAGENT_PROFILE / --profile)
+      // here too — otherwise "Skip and use default" provisions `default`
+      // while the next boot still looks for the pinned name and re-fires
+      // the wizard.
+      const defaultName = bootstrapProvisionProfileName(props.bootInfo);
       if (!props.desktopApi?.createPwrAgentProfile) {
         props.onDismiss(false);
         return;

--- a/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
+++ b/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
@@ -587,6 +587,39 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
           );
         }
       }
+      // Dev mode (`pnpm dev`) can't spawn a working second Electron
+      // instance: a detached child process can't re-attach to
+      // electron-vite's single Vite dev server, so the auto-switch-into-
+      // profile window never comes up (it lands at chrome-error://) and
+      // `waitForProfileAlive` just times out. Graduation has already
+      // persisted the profile AND set it as the registry default, so
+      // there's nothing left to do but tell the operator how to open it
+      // and exit. The next launch — `pnpm dev` (the graduated profile is
+      // now the default) or `PWRAGENT_PROFILE=<name> pnpm dev` — boots
+      // straight into it. Production builds relaunch reliably, so they
+      // keep the spawn-and-switch path below.
+      if (import.meta.env.DEV && props.bootInfo?.mode === "bootstrap") {
+        // eslint-disable-next-line no-console
+        console.info(
+          `Onboarding: profile "${targetProfile}" is set up and ready. Dev mode `
+            + "can't open a second app instance, so PwrAgent will exit now — "
+            + `relaunch with \`PWRAGENT_PROFILE=${targetProfile} pnpm dev\` `
+            + `(or just \`pnpm dev\`, since "${targetProfile}" is now the default `
+            + "profile) to open it.",
+        );
+        if (api.quitApp) {
+          try {
+            await api.quitApp();
+          } catch (caught) {
+            // eslint-disable-next-line no-console
+            console.warn(
+              "Onboarding: quitApp after graduation (dev) failed",
+              caught,
+            );
+          }
+        }
+        return;
+      }
       try {
         await api.openPwrAgentProfile({ profile: targetProfile });
       } catch (caught) {

--- a/apps/desktop/src/renderer/src/features/onboarding/__tests__/bootstrapProvisionProfileName.test.ts
+++ b/apps/desktop/src/renderer/src/features/onboarding/__tests__/bootstrapProvisionProfileName.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import type { DesktopBootInfo } from "@pwragent/shared";
+import { bootstrapProvisionProfileName } from "../OnboardingWizard";
+
+/**
+ * Regression guard for the "wizard re-fires forever under PWRAGENT_PROFILE=test"
+ * bug. The single-profile bootstrap finish paths (Shared mode + "Skip and use
+ * default") used to hardcode `default` as the provisioned profile name. But
+ * boot resolves the pinned env/CLI name FIRST (before the registry default), so
+ * provisioning `default` meant the next boot looked for `test`, didn't find it,
+ * and showed the wizard again — every launch. The provisioned name must equal
+ * the requested name whenever one was pinned.
+ */
+describe("bootstrapProvisionProfileName", () => {
+  it("provisions the boot-requested profile name (the re-fire bug)", () => {
+    const bootInfo: DesktopBootInfo = {
+      mode: "bootstrap",
+      decisionKind: "missing-named-profile",
+      requestedProfileName: "test",
+    };
+    // MUST be "test", not "default" — otherwise the next boot with
+    // PWRAGENT_PROFILE=test re-fires the wizard forever.
+    expect(bootstrapProvisionProfileName(bootInfo)).toBe("test");
+  });
+
+  it("trims surrounding whitespace on the requested name", () => {
+    const bootInfo: DesktopBootInfo = {
+      mode: "bootstrap",
+      decisionKind: "missing-named-profile",
+      requestedProfileName: "  test  ",
+    };
+    expect(bootstrapProvisionProfileName(bootInfo)).toBe("test");
+  });
+
+  it("falls back to 'default' for an unnamed first run", () => {
+    const bootInfo: DesktopBootInfo = {
+      mode: "bootstrap",
+      decisionKind: "no-profile-configured",
+    };
+    expect(bootstrapProvisionProfileName(bootInfo)).toBe("default");
+  });
+
+  it("falls back to 'default' when no boot info is available", () => {
+    expect(bootstrapProvisionProfileName(null)).toBe("default");
+  });
+
+  it("ignores a stray requestedProfileName outside the missing-named-profile decision", () => {
+    // requestedProfileName is only meaningful for missing-named-profile; a
+    // value carried on any other decision kind must not steer provisioning.
+    const bootInfo = {
+      mode: "bootstrap",
+      decisionKind: "no-profile-configured",
+      requestedProfileName: "stray",
+    } as DesktopBootInfo;
+    expect(bootstrapProvisionProfileName(bootInfo)).toBe("default");
+  });
+});

--- a/apps/desktop/src/renderer/src/vite-env.d.ts
+++ b/apps/desktop/src/renderer/src/vite-env.d.ts
@@ -1,3 +1,15 @@
+// Minimal typing for Vite's compile-time env constants (the renderer doesn't
+// pull in the full `vite/client` types). `import.meta.env.DEV` is `true` under
+// `pnpm dev` and `false` in production builds.
+interface ImportMetaEnv {
+  readonly DEV: boolean;
+  readonly PROD: boolean;
+  readonly MODE: string;
+}
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}
+
 declare module "*.css";
 
 declare module "*.svg" {


### PR DESCRIPTION
Two related fixes to the onboarding → profile graduation flow when booting with a pinned profile (`PWRAGENT_PROFILE=test` / `--profile test`).

## 1. Provision the boot-requested profile name (the re-fire bug)

**Problem:** booting with `PWRAGENT_PROFILE=test`, completing onboarding in **Shared** mode, then relaunching **re-fires the wizard every time** — the `test` profile never sticks.

**Root cause:** the single-profile bootstrap finish paths — Shared mode and "Skip and use default" — hardcoded the provisioned profile name to `"default"`, ignoring the pinned name. Boot resolves the pinned env/CLI name **first**, before the registry default (`resolveProfileBootDecision` step 2 beats step 3), so the next launch looks for a `test/` dir, finds only `default/`, and falls back to `missing-named-profile` → wizard. Forever. Nothing failed to save — graduation just used the wrong **name**.

**Fix:** name the provisioned profile after the boot-requested name when one was pinned, via a new exported helper `bootstrapProvisionProfileName(bootInfo)` used by both paths. Falls back to `default` only for the unnamed first-run (`no-profile-configured`) case. The Isolated/Multiple paths already seeded the requested name as their naming default — only Shared/skip had the gap.

Guarded by `bootstrapProvisionProfileName.test.ts` (5 cases).

## 2. Exit with a clear hint after graduation in dev (cosmetic, dev-only)

**Problem:** after graduation, the wizard spawns a *second* Electron instance for the new profile and waits up to 10s for it to report alive. Under `pnpm dev`, that detached child can't re-attach to electron-vite's single Vite dev server, so it never comes up — `waitForProfileAlive` times out and the bootstrap window is left open, looking broken:

```
waitForProfileAlive timeout profile=test timeoutMs=10000
Onboarding: spawned "test" didn't report alive within timeout; keeping bootstrap window open
```

Verified this is **not** a DB lock: `StateDb.open` makes a fresh connection (WAL, `busy_timeout=5000`) and `writeDesktopSecretsToProfile` closes it in `finally`; create/graduate only write TOML; and the alive marker is a filesystem heartbeat, not gated on the DB.

**Fix:** in dev + bootstrap mode, skip the doomed spawn-and-wait. The profile + secrets + config are already graduated (and it's now the registry default), so log a clear message telling the operator how to open it and quit. Next launch boots straight into it. Production builds relaunch reliably and keep the spawn-and-switch path. Adds minimal `import.meta.env` typing to the renderer's `vite-env.d.ts`.

---

Both are pre-existing on `main`; unrelated to the ACP settings work in #659.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
