### PR TITLE
fix(desktop): single access-mode selector for Kimi (#658)

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -49,6 +49,119 @@ describe("describeInstalledAcpBackend", () => {
 
     expect(backend.methods).toContain("session/load");
   });
+
+  it("suppresses hardcoded execution modes for Kimi once it advertises runtime modes (#658)", () => {
+    // Kimi exposes its own Default/Plan/Auto/Yolo runtime modes. Surfacing the
+    // hardcoded Default/Full Access modes too produced a second, overlapping
+    // dropdown — and the legacy /yolo path they drove is rejected by current
+    // kimi. The runtime modes must be the single source.
+    const backend = describeInstalledAcpBackend({
+      ...buildInstalledAgent(),
+      backendId: "acp:kimi" as AcpBackendId,
+      registryId: "kimi",
+      name: "Kimi Code CLI",
+      runtimeCapabilities: {
+        schemaVersion: 1,
+        status: "discovered",
+        checkedAt: 1000,
+        configOptions: [
+          {
+            id: "approval-mode",
+            label: "Permission mode",
+            type: "select",
+            category: "mode",
+            currentValue: "default",
+            values: [
+              { value: "default", label: "Default" },
+              { value: "yolo", label: "Yolo" },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(backend.executionModes).toEqual([]);
+  });
+
+  it("suppresses hardcoded execution modes when Kimi advertises modes via SessionModeState (#658)", () => {
+    // Kimi's real shape: modes arrive as an ACP SessionModeState
+    // (runtimeCapabilities.modes.availableModes), NOT as a configOptions entry.
+    // The suppression must cover this form too, or the duplicate dropdown
+    // survives on actual kimi.
+    const backend = describeInstalledAcpBackend({
+      ...buildInstalledAgent(),
+      backendId: "acp:kimi" as AcpBackendId,
+      registryId: "kimi",
+      name: "Kimi Code CLI",
+      runtimeCapabilities: {
+        schemaVersion: 1,
+        status: "discovered",
+        checkedAt: 1000,
+        modes: {
+          currentModeId: "default",
+          availableModes: [
+            { id: "default", label: "Default" },
+            { id: "yolo", label: "Yolo" },
+          ],
+        },
+      },
+    });
+
+    expect(backend.executionModes).toEqual([]);
+  });
+
+  it("keeps execution modes when only a single runtime mode is advertised", () => {
+    // Mainline kimi advertises ONLY "default" (a single mode = no real
+    // selector), so there's no runtime dropdown to defer to.
+    const backend = describeInstalledAcpBackend({
+      ...buildInstalledAgent(),
+      backendId: "acp:kimi" as AcpBackendId,
+      registryId: "kimi",
+      name: "Kimi Code CLI",
+      runtimeCapabilities: {
+        schemaVersion: 1,
+        status: "discovered",
+        checkedAt: 1000,
+        modes: {
+          currentModeId: "default",
+          availableModes: [{ id: "default", label: "Default" }],
+        },
+      },
+    });
+
+    expect(backend.executionModes.map((mode) => mode.mode)).toEqual([
+      "default",
+      "full-access",
+    ]);
+  });
+
+  it("falls back to hardcoded execution modes for Kimi with no runtime mode selector", () => {
+    const backend = describeInstalledAcpBackend({
+      ...buildInstalledAgent(),
+      backendId: "acp:kimi" as AcpBackendId,
+      registryId: "kimi",
+      name: "Kimi Code CLI",
+    });
+
+    expect(backend.executionModes.map((mode) => mode.mode)).toEqual([
+      "default",
+      "full-access",
+    ]);
+  });
+
+  it("keeps hardcoded execution modes for Grok (no runtime mode selector)", () => {
+    const backend = describeInstalledAcpBackend({
+      ...buildInstalledAgent(),
+      backendId: "acp:grok" as AcpBackendId,
+      registryId: "grok",
+      name: "Grok CLI",
+    });
+
+    expect(backend.executionModes.map((mode) => mode.mode)).toEqual([
+      "default",
+      "full-access",
+    ]);
+  });
 });
 
 describe("AcpBackendAdapter", () => {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2657,6 +2657,123 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
+  it("does not send /yolo for Kimi once it advertises runtime modes (#658)", async () => {
+    // The #658 fix: when kimi exposes its own runtime modes, approval policy is
+    // controlled via the runtime "yolo" mode (session/set_mode), NOT the legacy
+    // /yolo slash command (which current kimi rejects). So the registry must
+    // suppress the hardcoded execution modes AND never send /yolo.
+    const sessions: AcpSessionMetadata[] = [];
+    const acpBackendId = "acp:kimi" as AcpBackendId;
+    const sendControlPrompt = vi.fn(async () => ({ text: "" }));
+    const acpClient = {
+      initialize: vi.fn(async () => undefined),
+      dispose: vi.fn(),
+      startSession: vi.fn(async (params: { cwd?: string; executionMode: "default" | "full-access" }) => {
+        const metadata: AcpSessionMetadata = {
+          backendId: acpBackendId,
+          sessionId: "kimi-session-1",
+          title: "ACP session",
+          cwd: params.cwd,
+          createdAt: 1000,
+          updatedAt: 1000,
+          executionMode: params.executionMode,
+          status: "idle",
+        };
+        sessions.push(metadata);
+        return metadata;
+      }),
+      startPrompt: vi.fn(),
+      sendControlPrompt,
+      ensureSession: vi.fn(async () => undefined),
+      loadSession: vi.fn(async (): Promise<AppServerThreadReplay> => ({
+        entries: [],
+        messages: [],
+        pagination: { supportsPagination: false, hasPreviousPage: false },
+        threadStatus: "idle",
+      })),
+      refreshSession: vi.fn(async () => undefined),
+      cancelSession: vi.fn(),
+      readReplay: vi.fn((): AppServerThreadReplay => ({
+        entries: [],
+        messages: [],
+        pagination: { supportsPagination: false, hasPreviousPage: false },
+        threadStatus: "idle",
+      })),
+    };
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      grokClient: new MockBackendClient({ threads: [] }),
+      overlayStore: createOverlayStoreMock(),
+      acpAgentStore: createAcpAgentStoreMock([
+        {
+          backendId: acpBackendId,
+          registryId: "kimi",
+          name: "Kimi Code CLI",
+          version: "1.44.0",
+          distributionKind: "local",
+          distributionSource: "kimi acp",
+          installStatus: "installed",
+          authStatus: "not-required",
+          verificationStatus: "not-applicable",
+          allowlistRuleId: "local-kimi-cli",
+          installedAt: 1000,
+          updatedAt: 2000,
+          runtimeCapabilities: {
+            schemaVersion: 1,
+            status: "discovered",
+            checkedAt: 1000,
+            configOptions: [
+              {
+                id: "approval-mode",
+                label: "Permission mode",
+                type: "select",
+                category: "mode",
+                currentValue: "default",
+                values: [
+                  { value: "default", label: "Default" },
+                  { value: "yolo", label: "Yolo" },
+                ],
+              },
+            ],
+          },
+          launchDescriptor: {
+            backendId: acpBackendId,
+            registryId: "kimi",
+            distributionKind: "local",
+            command: "kimi",
+            args: ["acp"],
+            env: {},
+          },
+        },
+      ]),
+      acpSessionStore: createAcpSessionStoreMock(sessions),
+      createAcpClient: () => acpClient,
+    });
+
+    // The hardcoded Default/Full Access modes are gone — only the runtime
+    // modes remain (one dropdown in the UI).
+    const backends = await registry.listBackends({ includeUnavailable: true });
+    expect(
+      backends.backends.find((backend) => backend.kind === acpBackendId)
+        ?.executionModes,
+    ).toEqual([]);
+
+    // Even a full-access thread + an execution-mode change must NOT send /yolo.
+    await registry.startThread({
+      backend: acpBackendId,
+      cwd: "/repo/project",
+      executionMode: "full-access",
+    });
+    await registry.setThreadExecutionMode({
+      backend: acpBackendId,
+      threadId: "kimi-session-1",
+      executionMode: "default",
+    });
+    expect(sendControlPrompt).not.toHaveBeenCalled();
+
+    await registry.close();
+  });
+
   it("runs Grok ACP execution mode changes through /always-approve slash control prompts", async () => {
     // Regression test for the Grok-ACP Full Access bug: creating a Grok
     // thread with executionMode="full-access" must persist that mode to

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -335,6 +335,27 @@ function resolveDefaultAcpRolloutRoot(): string {
     : resolveActiveProfilePath("state/acp-rollouts");
 }
 
+/**
+ * Whether the agent advertises its OWN runtime mode selector that the renderer
+ * will surface as a dropdown. Mirrors the renderer's `getAcpRuntimeModeControl`
+ * gating EXACTLY so the two never disagree (which is what produced the #658
+ * double-dropdown): a `configOptions` entry of category "mode" with ≥2 values,
+ * or an ACP `SessionModeState` (`modes.availableModes`) with ≥2 modes. Kimi's
+ * Default/Plan/Auto/Yolo arrive via the latter, so checking only configOptions
+ * would miss it.
+ */
+export function acpAdvertisesRuntimeModeSelector(
+  runtimeCapabilities: BackendAcpRuntimeCapabilities | undefined,
+): boolean {
+  const modeConfigOption = runtimeCapabilities?.configOptions?.find(
+    (option) => option.category === "mode" && option.values.length > 0,
+  );
+  if (modeConfigOption) {
+    return modeConfigOption.values.length >= 2;
+  }
+  return (runtimeCapabilities?.modes?.availableModes?.length ?? 0) >= 2;
+}
+
 function buildAcpExecutionModes(
   agent: AcpInstalledAgentRecord,
   available: boolean,
@@ -345,6 +366,18 @@ function buildAcpExecutionModes(
   // identically at this layer (the per-agent slash command text + response
   // parsing lives in backend-registry.ts).
   if (agent.registryId !== "kimi" && agent.registryId !== "grok") {
+    return [];
+  }
+  // If the agent advertises its OWN runtime "mode" selector (kimi surfaces
+  // Default/Plan/Auto/Yolo via session capabilities), that is the single
+  // source of truth for approval policy. Surfacing these hardcoded
+  // Default/Full Access modes on top produced TWO overlapping mode dropdowns
+  // (#658) that mirror each other — and the legacy slash-command path they
+  // drive (kimi `/yolo`) is rejected by current kimi, failing the launch.
+  // Defer entirely to the runtime modes whenever the agent advertises a
+  // selector; only fall back to these hardcoded modes for agents (e.g. grok)
+  // that expose no runtime mode selector of their own.
+  if (acpAdvertisesRuntimeModeSelector(agent.runtimeCapabilities)) {
     return [];
   }
   return [

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -127,6 +127,7 @@ import {
   acpSessionToThreadSummary,
   formatAcpRuntimeLabel,
   inputToAcpPrompt,
+  acpAdvertisesRuntimeModeSelector,
   isAcpSessionMissingForProjectError,
   mergeAcpRuntimeState,
   readKimiYoloExecutionModeFromText,
@@ -5761,10 +5762,21 @@ export class DesktopBackendRegistry {
   private usesKimiSlashExecutionModes(
     backend: AppServerBackendKind,
   ): backend is AcpBackendId {
-    return (
-      isAcpBackendId(backend) &&
-      this.acpBackend.getInstalledAgent(backend)?.registryId === "kimi"
-    );
+    if (!isAcpBackendId(backend)) {
+      return false;
+    }
+    const agent = this.acpBackend.getInstalledAgent(backend);
+    if (agent?.registryId !== "kimi") {
+      return false;
+    }
+    // Once kimi advertises its own runtime mode selector (Default/Plan/Auto/
+    // Yolo via session capabilities), the legacy `/yolo` slash command is both
+    // obsolete and rejected by current kimi (#658). The runtime "yolo" mode —
+    // set over the standard `session/set_mode` protocol method — is the
+    // approval-policy control instead, so never drive kimi through the slash
+    // path in that case. Falls back to `/yolo` only for a kimi build that
+    // exposes no runtime mode selector of its own.
+    return !acpAdvertisesRuntimeModeSelector(agent.runtimeCapabilities);
   }
 
   private usesGrokSlashExecutionModes(


### PR DESCRIPTION
Fixes #658.

## Part 1 — duplicate access-mode dropdowns (fixed)

Kimi surfaced **two** overlapping access-mode selectors:
- the hardcoded **Default / Full Access** execution modes (`buildAcpExecutionModes`, kimi + grok only), and
- Kimi's **own advertised runtime modes** (Default / Plan / Auto / Yolo).

They mirrored each other (picking *Yolo* flipped the other to *Full Access*), and the legacy `/yolo` slash command the hardcoded modes drive is rejected by current Kimi.

**Fix:** when an agent advertises its own runtime mode selector, defer to it as the single source of truth and suppress the hardcoded execution modes — exactly how Gemini already behaves (one dropdown).

- New `acpAdvertisesRuntimeModeSelector()` mirrors the renderer's `getAcpRuntimeModeControl` gating **exactly**: a `configOptions` entry of category `mode` with ≥2 values, **or** an ACP `SessionModeState` (`modes.availableModes`) with ≥2 modes. Kimi Code advertises its modes via the `configOptions` form, so a `SessionModeState`-only check would have missed them and left the duplicate.
- `buildAcpExecutionModes()` returns `[]` when a runtime mode selector exists.
- `usesKimiSlashExecutionModes()` returns `false` in that case → kimi never sends the rejected `/yolo`; approval policy is the runtime mode set over the standard ACP `session/set_config_option` / `session/set_mode` protocol methods.
- grok (no runtime mode selector) keeps its `/always-approve` execution modes — unchanged.

## Part 2 — which Kimi is this, and do we need the yolo PR? (No)

**We integrate with [`kimi-code`](https://github.com/MoonshotAI/kimi-code), not [`kimi-cli`](https://github.com/MoonshotAI/kimi-cli).** These are two different MoonshotAI products, both named "Kimi Code CLI":

| | **`kimi-code`** (what PwrAgent runs) | **`kimi-cli`** |
|---|---|---|
| Language | **TypeScript** | Python |
| License | **MIT** | Apache-2.0 |
| Package / install | `@moonshot-ai/kimi-code` → `~/.kimi-code/bin/kimi` | `pip` / `uv` |
| Version (current) | **0.11.0** (born May 2026) | 1.47.0 (born Oct 2025) |
| ACP modes | **default / plan / auto / yolo**, native (`configOptions` + `setSessionMode`) | only `default` on `main` |

`kimi-code` is the newer TypeScript rewrite ("The Starting Point for Next-Gen Agents"). PwrAgent's discovery targets `~/.kimi-code/bin`, so the agent we speak to over ACP is `kimi-code`. Confirmed from its source (`packages/acp-adapter/src/modes.ts`): *"The 4 modes (`default`, `plan`, `auto`, `yolo`) are the locked..."*, exposed via the `configOptions` channel, with a `YoloModeApprovePermissionPolicy`.

**Implications:**
- `kimi-code` **already** supports ACP permission-mode switching (including yolo) natively — so **no upstream PR is required** for yolo to work. (Earlier drafts of this PR referenced a yolo PR against the Python `kimi-cli`; that repo is *not* what PwrAgent runs, so it's irrelevant here.)
- The legacy `/yolo` slash command in PwrAgent was modeled on the **old Python `kimi-cli`** pre-ACP toggle. `kimi-code` doesn't use `/yolo` at all — it uses the proper ACP `configOptions` / `setSessionMode` path. So suppressing it (this PR) is safe, and fully removing the bespoke `/yolo` slash machinery is a good follow-up cleanup (Phase B).

## What each mode does (all kimi-code's, set agent-side)
- **Default** — Kimi asks for approval on tool calls → PwrAgent shows the prompt.
- **Plan** — read-only planning.
- **Auto** — Kimi auto-approves *safe* tool calls itself (e.g. read-only bash), escalates riskier ones → PwrAgent prompts for those.
- **Yolo** — Kimi auto-approves **all** tool calls. PwrAgent additionally auto-approves any escalated `session/request_permission` while the runtime mode is yolo (scoped to tool-call permissions — `AskUserQuestion` still prompts).

## Tests
- Execution modes suppressed for kimi advertising runtime modes via **either** `configOptions` or `SessionModeState`.
- Execution modes kept for single-mode / no-mode kimi and for grok.
- Registry no longer sends `/yolo` once kimi advertises runtime modes; still does for the no-runtime-mode fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
