### PR TITLE
fix(desktop): dispatch queued turns after branch drift

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -2970,7 +2970,7 @@ export function Composer(props: ComposerProps) {
           } satisfies AppServerCollaborationModeRequest)
         : undefined;
 
-    if (props.onBeforeStartTurn && !(await props.onBeforeStartTurn())) {
+    if (!queued && props.onBeforeStartTurn && !(await props.onBeforeStartTurn())) {
       updateSending(false);
       restoreQueuedTurnIfClaimed(queued, options?.queueClaimed);
       if (queued && options?.queueClaimed) {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -3720,7 +3720,7 @@ describe("Composer", () => {
     expect(startTurn).not.toHaveBeenCalled();
   });
 
-  it("restores a claimed queued turn when preflight blocks sending", async () => {
+  it("dispatches a queued turn even when selected-thread preflight would block a new send", async () => {
     const draftStore = createComposerDraftStore();
     const startTurn = vi.fn(async (request: StartTurnRequest) => ({
       backend: request.backend,
@@ -3769,16 +3769,21 @@ describe("Composer", () => {
     );
 
     await waitFor(() => {
-      expect(onBeforeStartTurn).toHaveBeenCalled();
+      expect(startTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          backend: "codex",
+          threadId: "thread-1",
+          input: [{ type: "text", text: "Queued preflight block" }],
+        })
+      );
     });
     await waitFor(() => {
-      expect(screen.getByText("Queued preflight block")).toBeInTheDocument();
+      expect(screen.queryByText("Queued preflight block")).not.toBeInTheDocument();
     });
     expect(
-      draftStore.getQueuedTurn("thread:codex:thread-1")?.text,
-    ).toBe("Queued preflight block");
-    expect(onBeforeStartTurn).toHaveBeenCalledTimes(1);
-    expect(startTurn).not.toHaveBeenCalled();
+      draftStore.getQueuedTurn("thread:codex:thread-1"),
+    ).toBeUndefined();
+    expect(onBeforeStartTurn).not.toHaveBeenCalled();
   });
 
   it("updates model settings without crashing when fast-mode support changes", async () => {


### PR DESCRIPTION
## Summary
Queued replies now dispatch when an active turn finishes, even if the finished turn changed the thread worktree branch. Fresh sends still run the selected-thread branch drift preflight, but already-queued work is treated as user intent that should proceed at the release boundary instead of getting stuck behind the branch warning.

## Test Plan
- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx -t "dispatches a queued turn"`
- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
