### PR TITLE
fix(messaging): launch new threads through materialized input

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -3166,6 +3166,53 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
+  it("returns the materialized thread when the first launchpad turn fails", async () => {
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        threads: [],
+        startTurnError: new Error("invalid model"),
+      }),
+      grokClient: new MockBackendClient({ threads: [] }),
+      overlayStore: createOverlayStoreMock(),
+      gitDirectoryService: {
+        prepareLaunchpadWorkspace: vi.fn(async () => ({
+          cwd: "/repo/project",
+          workMode: "local" as const,
+        })),
+      } as never,
+    });
+
+    const response = await registry.materializeDirectoryLaunchpad({
+      directoryKey: "directory:/repo/project",
+      launchpad: {
+        directoryKey: "directory:/repo/project",
+        directoryKind: "directory",
+        directoryLabel: "project",
+        directoryPath: "/repo/project",
+        backend: "codex",
+        executionMode: "default",
+        prompt: "",
+        workMode: "local",
+        createdAt: 1000,
+        updatedAt: 2000,
+      },
+      input: [{ type: "text", text: "Fix bug" }],
+    });
+
+    expect(response).toMatchObject({
+      backend: "codex",
+      threadId: "thread-1",
+      executionMode: "default",
+      turnStartFailure: {
+        message: "invalid model",
+        phase: "turn",
+      },
+    });
+    expect(response.turnId).toBeUndefined();
+
+    await registry.close();
+  });
+
   it("auto-approves ACP permission requests for Yolo runtime sessions", async () => {
     const acpBackendId = "acp:qwen" as AcpBackendId;
     const registry = new DesktopBackendRegistry({

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -3213,6 +3213,56 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
+  it("notifies when a launchpad thread is materialized before starting input", async () => {
+    const codexClient = new MockBackendClient({ threads: [] });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({ threads: [] }),
+      overlayStore: createOverlayStoreMock(),
+      gitDirectoryService: {
+        prepareLaunchpadWorkspace: vi.fn(async () => ({
+          cwd: "/repo/project",
+          workMode: "local" as const,
+        })),
+      } as never,
+    });
+    const observed: string[] = [];
+
+    const response = await registry.materializeDirectoryLaunchpad(
+      {
+        directoryKey: "directory:/repo/project",
+        launchpad: {
+          directoryKey: "directory:/repo/project",
+          directoryKind: "directory",
+          directoryLabel: "project",
+          directoryPath: "/repo/project",
+          backend: "codex",
+          executionMode: "default",
+          prompt: "",
+          workMode: "local",
+          createdAt: 1000,
+          updatedAt: 2000,
+        },
+        input: [{ type: "text", text: "Fix bug" }],
+      },
+      {
+        onThreadMaterialized: (thread) => {
+          observed.push(`${thread.threadId}:${codexClient.startTurnCallCount}`);
+        },
+      },
+    );
+
+    expect(observed).toEqual(["thread-1:0"]);
+    expect(codexClient.startTurnCallCount).toBe(1);
+    expect(response).toMatchObject({
+      backend: "codex",
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+
+    await registry.close();
+  });
+
   it("auto-approves ACP permission requests for Yolo runtime sessions", async () => {
     const acpBackendId = "acp:qwen" as AcpBackendId;
     const registry = new DesktopBackendRegistry({

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -1006,7 +1006,7 @@ describe("MessagingController", () => {
                 status: "completed",
                 output: [
                   {
-                    type: "agentMessage",
+                    type: "text",
                     text: "Fixed it.",
                   },
                 ],

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -283,8 +283,14 @@ describe("MessagingController", () => {
 
     await harness.controller.handleInboundEvent(buildTextEvent("Fix bug"));
 
-    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith({
+    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith(expect.objectContaining({
       directoryKey: expect.stringMatching(/^messaging:browse:/),
+      input: [
+        {
+          type: "text",
+          text: "Fix bug",
+        },
+      ],
       launchpad: expect.objectContaining({
         backend: "codex",
         directoryKey: "directory:pwragent",
@@ -298,20 +304,9 @@ describe("MessagingController", () => {
         serviceTier: undefined,
         workMode: "local",
       }),
-    });
+    }));
     expect(harness.startThread).not.toHaveBeenCalled();
-    expect(harness.startTurn).toHaveBeenCalledWith(
-      expect.objectContaining({
-        backend: "codex",
-        threadId: "new-thread-1",
-        input: [
-          {
-            type: "text",
-            text: "Fix bug",
-          },
-        ],
-      }),
-    );
+    expect(harness.startTurn).not.toHaveBeenCalled();
     await expect(
       harness.store.findActiveBindingForChannel(buildCommandEvent("/resume").channel),
     ).resolves.toMatchObject({
@@ -457,8 +452,14 @@ describe("MessagingController", () => {
     await harness.controller.handleInboundEvent(buildTextEvent("Fix bug in a worktree"));
 
     expect(harness.startThread).not.toHaveBeenCalled();
-    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith({
+    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith(expect.objectContaining({
       directoryKey: expect.stringMatching(/^messaging:browse:/),
+      input: [
+        {
+          type: "text",
+          text: "Fix bug in a worktree",
+        },
+      ],
       launchpad: expect.objectContaining({
         backend: "codex",
         directoryKey: "directory:pwragent",
@@ -467,7 +468,7 @@ describe("MessagingController", () => {
         workMode: "worktree",
         branchName: "release/v2",
       }),
-    });
+    }));
   });
 
   it("keeps non-git new-thread prompts local when a worktree action is requested", async () => {
@@ -524,14 +525,20 @@ describe("MessagingController", () => {
 
     await harness.controller.handleInboundEvent(buildTextEvent("Fix bug locally"));
 
-    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith({
+    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith(expect.objectContaining({
       directoryKey: expect.stringMatching(/^messaging:browse:/),
+      input: [
+        {
+          type: "text",
+          text: "Fix bug locally",
+        },
+      ],
       launchpad: expect.objectContaining({
         directoryKey: "directory:pwragent",
         directoryPath: "/repo/pwragent",
         workMode: "local",
       }),
-    });
+    }));
   });
 
   it("paginates the new-thread base branch picker", async () => {
@@ -627,14 +634,20 @@ describe("MessagingController", () => {
     );
     await harness.controller.handleInboundEvent(buildTextEvent("Fix bug"));
 
-    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith({
+    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith(expect.objectContaining({
       directoryKey: expect.stringMatching(/^messaging:browse:/),
+      input: [
+        {
+          type: "text",
+          text: "Fix bug",
+        },
+      ],
       launchpad: expect.objectContaining({
         directoryKey: "directory:pwragent",
         directoryPath: "/repo/pwragent",
         workMode: "worktree",
       }),
-    });
+    }));
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "status",
       text: expect.stringContaining("Directory: /repo/pwragent"),
@@ -825,10 +838,8 @@ describe("MessagingController", () => {
     await vi.waitFor(() => {
       expect(harness.startThread).not.toHaveBeenCalled();
       expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledTimes(1);
-      expect(harness.startTurn).toHaveBeenCalledWith(
+      expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith(
         expect.objectContaining({
-          backend: "codex",
-          threadId: "new-thread-1",
           input: [
             {
               type: "text",
@@ -841,6 +852,7 @@ describe("MessagingController", () => {
           ],
         }),
       );
+      expect(harness.startTurn).not.toHaveBeenCalled();
     });
   });
 
@@ -920,18 +932,20 @@ describe("MessagingController", () => {
     );
     await harness.controller.handleInboundEvent(buildTextEvent("continue on the new thread"));
 
-    expect(harness.startTurn).toHaveBeenLastCalledWith(
+    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith(
       expect.objectContaining({
-        backend: "codex",
-        threadId: "new-thread-1",
         input: [
           {
             type: "text",
             text: "continue on the new thread",
           },
         ],
+        launchpad: expect.objectContaining({
+          backend: "codex",
+        }),
       }),
     );
+    expect(harness.startTurn).not.toHaveBeenCalled();
     await expect(harness.store.getBinding("binding:telegram:dm::chat-1:codex:old-thread"))
       .resolves.toMatchObject({
         revokedAt: 1000,
@@ -1155,11 +1169,17 @@ describe("MessagingController", () => {
       buildCommandEvent("/resume").channel,
     );
     expect(binding?.preferences?.streamingResponses).toBe("disabled");
-    expect(harness.startTurn).toHaveBeenCalledWith(
+    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith(
       expect.objectContaining({
-        threadId: "new-thread-1",
+        input: [
+          {
+            type: "text",
+            text: "Start with streams off",
+          },
+        ],
       }),
     );
+    expect(harness.startTurn).not.toHaveBeenCalled();
   });
 
   it("updates the resume picker and removes actions when selecting a thread", async () => {
@@ -2898,19 +2918,20 @@ describe("MessagingController", () => {
 
     await harness.controller.handleInboundEvent(buildTextEvent("Fix bug with Grok"));
 
-    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith({
+    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith(expect.objectContaining({
       directoryKey: expect.stringMatching(/^messaging:browse:/),
+      input: [
+        {
+          type: "text",
+          text: "Fix bug with Grok",
+        },
+      ],
       launchpad: expect.objectContaining({
         backend: "grok",
         directoryKey: "directory:pwragent",
       }),
-    });
-    expect(harness.startTurn).toHaveBeenCalledWith(
-      expect.objectContaining({
-        backend: "grok",
-        threadId: "new-thread-1",
-      }),
-    );
+    }));
+    expect(harness.startTurn).not.toHaveBeenCalled();
     await expect(
       harness.store.findActiveBindingForChannel(buildCommandEvent("/new").channel),
     ).resolves.toMatchObject({
@@ -2991,19 +3012,20 @@ describe("MessagingController", () => {
 
     await harness.controller.handleInboundEvent(buildTextEvent("Use Gemini"));
 
-    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith({
+    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith(expect.objectContaining({
       directoryKey: expect.stringMatching(/^messaging:browse:/),
+      input: [
+        {
+          type: "text",
+          text: "Use Gemini",
+        },
+      ],
       launchpad: expect.objectContaining({
         backend: "acp:gemini",
         directoryKey: "directory:pwragent",
       }),
-    });
-    expect(harness.startTurn).toHaveBeenCalledWith(
-      expect.objectContaining({
-        backend: "acp:gemini",
-        threadId: "new-thread-1",
-      }),
-    );
+    }));
+    expect(harness.startTurn).not.toHaveBeenCalled();
     await expect(
       harness.store.findActiveBindingForChannel(buildCommandEvent("/new").channel),
     ).resolves.toMatchObject({
@@ -3075,19 +3097,20 @@ describe("MessagingController", () => {
 
     await harness.controller.handleInboundEvent(buildTextEvent("Use Gemini"));
 
-    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith({
+    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith(expect.objectContaining({
       directoryKey: expect.stringMatching(/^messaging:browse:/),
+      input: [
+        {
+          type: "text",
+          text: "Use Gemini",
+        },
+      ],
       launchpad: expect.objectContaining({
         backend: "acp:gemini",
         executionMode: "default",
       }),
-    });
-    expect(harness.startTurn).toHaveBeenCalledWith(
-      expect.objectContaining({
-        backend: "acp:gemini",
-        threadId: "new-thread-1",
-      }),
-    );
+    }));
+    expect(harness.startTurn).not.toHaveBeenCalled();
   });
 
   it("does not label ACP model config as runtime mode in the new-thread prompt", async () => {
@@ -3227,8 +3250,14 @@ describe("MessagingController", () => {
 
     await harness.controller.handleInboundEvent(buildTextEvent("Use yolo"));
 
-    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith({
+    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith(expect.objectContaining({
       directoryKey: expect.stringMatching(/^messaging:browse:/),
+      input: [
+        {
+          type: "text",
+          text: "Use yolo",
+        },
+      ],
       launchpad: expect.objectContaining({
         backend: "acp:gemini",
         executionMode: "full-access",
@@ -3236,7 +3265,7 @@ describe("MessagingController", () => {
           currentModeId: "yolo",
         }),
       }),
-    });
+    }));
   });
 
   it("uses inherited ACP runtime state when opening the new-thread picker", async () => {
@@ -3546,6 +3575,121 @@ describe("MessagingController", () => {
       title: "Ready to start",
       body: expect.stringContaining("Model: gpt-5.3-codex"),
     });
+  });
+
+  it("lets messaging choose a Codex environment before starting a new thread", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.directories[0] = {
+      ...navigation.directories[0]!,
+      launchpad: {
+        directoryKey: "directory:pwragent",
+        directoryKind: "directory",
+        directoryLabel: "PwrAgent",
+        directoryPath: "/repo/pwragent",
+        backend: "codex",
+        executionMode: "default",
+        prompt: "",
+        workMode: "local",
+        codexEnvironmentOptions: [
+          {
+            id: "dev-env",
+            name: "Dev Environment",
+            sourcePath: "/repo/pwragent/.codex/environments/dev-env.toml",
+            setupScript: "pnpm install",
+            actions: [],
+          },
+        ],
+        createdAt: 1000,
+        updatedAt: 1000,
+      },
+    };
+    const harness = await createHarness({ navigation });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Ready to start",
+      actions: expect.arrayContaining([
+        expect.objectContaining({
+          id: "browse:new:environment",
+          label: "Env: none",
+        }),
+      ]),
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "browse:new:environment" }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Select environment",
+      actions: expect.arrayContaining([
+        expect.objectContaining({
+          id: "browse:new:set-environment",
+          label: "Dev Environment",
+          value: { environmentId: "dev-env" },
+        }),
+      ]),
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:new:set-environment",
+        value: { environmentId: "dev-env" },
+      }),
+    );
+
+    expect(harness.updateDirectoryLaunchpad).toHaveBeenCalledWith({
+      directoryKey: "directory:pwragent",
+      stickySettingsChanged: true,
+      patch: expect.objectContaining({
+        codexEnvironmentId: "dev-env",
+        codexEnvironmentExecutionTarget: "local",
+        codexEnvironmentSetupEnabled: true,
+      }),
+    });
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Ready to start",
+      body: expect.stringContaining("Environment: Dev Environment"),
+      actions: expect.arrayContaining([
+        expect.objectContaining({
+          id: "browse:new:environment",
+          label: "Env: Dev Environment",
+        }),
+      ]),
+    });
+
+    await harness.controller.handleInboundEvent(buildTextEvent("Install deps and run tests"));
+
+    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: [
+          {
+            type: "text",
+            text: "Install deps and run tests",
+          },
+        ],
+        launchpad: expect.objectContaining({
+          codexEnvironmentId: "dev-env",
+          codexEnvironmentExecutionTarget: "local",
+          codexEnvironmentSetupEnabled: true,
+        }),
+      }),
+    );
+    expect(harness.startTurn).not.toHaveBeenCalled();
   });
 
   it("clicking the New button on the help surface dispatches the new command", async () => {
@@ -7834,22 +7978,18 @@ describe("MessagingController", () => {
     );
     expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith(
       expect.objectContaining({
-        launchpad: expect.objectContaining({
-          executionMode: "full-access",
-        }),
-      }),
-    );
-    expect(harness.startTurn).toHaveBeenCalledWith(
-      expect.objectContaining({
-        executionMode: "full-access",
         input: [
           {
             type: "text",
             text: "fix bug",
           },
         ],
+        launchpad: expect.objectContaining({
+          executionMode: "full-access",
+        }),
       }),
     );
+    expect(harness.startTurn).not.toHaveBeenCalled();
   });
 
   it("starts a new thread from a directory launchpad Full Access default without a dismissable warning", async () => {
@@ -7891,16 +8031,18 @@ describe("MessagingController", () => {
     );
     expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith(
       expect.objectContaining({
+        input: [
+          {
+            type: "text",
+            text: "fix bug",
+          },
+        ],
         launchpad: expect.objectContaining({
           executionMode: "full-access",
         }),
       }),
     );
-    expect(harness.startTurn).toHaveBeenCalledWith(
-      expect.objectContaining({
-        executionMode: "full-access",
-      }),
-    );
+    expect(harness.startTurn).not.toHaveBeenCalled();
   });
 
   it("posts the first-prompt Full Access warning as a direct response when always warning", async () => {
@@ -8037,17 +8179,20 @@ describe("MessagingController", () => {
       }),
     );
 
-    expect(harness.startTurn).toHaveBeenCalledWith(
+    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith(
       expect.objectContaining({
-        executionMode: "full-access",
         input: [
           {
             type: "text",
             text: "fix bug",
           },
         ],
+        launchpad: expect.objectContaining({
+          executionMode: "full-access",
+        }),
       }),
     );
+    expect(harness.startTurn).not.toHaveBeenCalled();
     expect(harness.delivered).not.toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -8113,17 +8258,20 @@ describe("MessagingController", () => {
       }),
     );
 
-    expect(harness.startTurn).toHaveBeenCalledWith(
+    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith(
       expect.objectContaining({
-        executionMode: "full-access",
         input: [
           {
             type: "text",
             text: "new thread prompt",
           },
         ],
+        launchpad: expect.objectContaining({
+          executionMode: "full-access",
+        }),
       }),
     );
+    expect(harness.startTurn).not.toHaveBeenCalled();
   });
 
   it("delivers the normal start failure if approved Full Access prompt startup throws", async () => {
@@ -9439,6 +9587,7 @@ async function createHarness(options?: {
       ) => ({
         backend: request.launchpad?.backend ?? "codex",
         threadId: "new-thread-1",
+        ...(request.input && request.input.length > 0 ? { turnId: "turn-1" } : {}),
         executionMode: request.launchpad?.executionMode ?? "default",
         ...(request.launchpad?.workMode === "worktree"
           ? {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -907,6 +907,65 @@ describe("MessagingController", () => {
     ).resolves.toBeUndefined();
   });
 
+  it("binds a materialized thread when its first turn fails", async () => {
+    const materializeDirectoryLaunchpad = vi.fn(
+      async (
+        request: MaterializeDirectoryLaunchpadRequest,
+      ) => ({
+        backend: request.launchpad?.backend ?? "codex",
+        threadId: "new-thread-1",
+        executionMode: request.launchpad?.executionMode ?? "default",
+        workMode: request.launchpad?.workMode ?? "local",
+        turnStartFailure: {
+          message: "invalid model",
+          phase: "turn" as const,
+        },
+      }),
+    );
+    const harness = await createHarness({ materializeDirectoryLaunchpad });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/resume --new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+    await harness.controller.handleInboundEvent(buildTextEvent("Fix bug"));
+
+    expect(harness.startThread).not.toHaveBeenCalled();
+    expect(harness.startTurn).not.toHaveBeenCalled();
+    expect(materializeDirectoryLaunchpad).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: [
+          {
+            type: "text",
+            text: "Fix bug",
+          },
+        ],
+      }),
+    );
+    await expect(
+      harness.store.findActiveBindingForChannel(buildCommandEvent("/resume").channel),
+    ).resolves.toMatchObject({
+      backend: "codex",
+      threadId: "new-thread-1",
+    });
+    expect(harness.delivered.at(-2)).toMatchObject({
+      kind: "error",
+      title: "Turn could not start",
+      body: "invalid model",
+    });
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "status",
+      text: expect.stringContaining("Binding: new-thread-1"),
+    });
+  });
+
   it("routes messages to the new thread after rebinding an already-bound conversation", async () => {
     const harness = await createHarness();
     await harness.store.upsertBinding({

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -2511,6 +2511,39 @@ describe("MessagingController", () => {
     ]);
   });
 
+  it("uses the thread rename event title when the navigation snapshot is stale", async () => {
+    const staleNavigation = buildNavigationSnapshot();
+    staleNavigation.threads[0] = {
+      ...staleNavigation.threads[0]!,
+      title: "Untitled thread",
+      titleSource: "fallback",
+    };
+    const harness = await createHarness({ navigation: staleNavigation });
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "thread/name/updated",
+        params: {
+          threadId: "thread-1",
+          threadName: "What is this project",
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(harness.delivered).toEqual([
+      expect.objectContaining({
+        kind: "status",
+        text: expect.stringContaining("Binding: What is this project (codex)"),
+      }),
+    ]);
+    expect(harness.delivered.at(-1)).toMatchObject({
+      text: expect.not.stringContaining("Binding: Untitled thread (codex)"),
+    });
+  });
+
   it("does not restart typing from a stale assistant delivery after idle", async () => {
     let now = 1000;
     let resolveAssistantDelivery!: () => void;

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -11,6 +11,7 @@ import type {
   CancelThreadExecutionModeQueueRequest,
   HandoffThreadWorkspaceRequest,
   ListBackendsResponse,
+  MaterializeDirectoryLaunchpadOptions,
   MaterializeDirectoryLaunchpadRequest,
   MessagingToolUpdateMode,
   NavigationSnapshot,
@@ -283,28 +284,31 @@ describe("MessagingController", () => {
 
     await harness.controller.handleInboundEvent(buildTextEvent("Fix bug"));
 
-    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith(expect.objectContaining({
-      directoryKey: expect.stringMatching(/^messaging:browse:/),
-      input: [
-        {
-          type: "text",
-          text: "Fix bug",
-        },
-      ],
-      launchpad: expect.objectContaining({
-        backend: "codex",
-        directoryKey: "directory:pwragent",
-        directoryLabel: "PwrAgent",
-        directoryPath: "/repo/pwragent",
-        executionMode: "default",
-        fastMode: undefined,
-        model: undefined,
-        prompt: "",
-        reasoningEffort: undefined,
-        serviceTier: undefined,
-        workMode: "local",
+    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith(
+      expect.objectContaining({
+        directoryKey: expect.stringMatching(/^messaging:browse:/),
+        input: [
+          {
+            type: "text",
+            text: "Fix bug",
+          },
+        ],
+        launchpad: expect.objectContaining({
+          backend: "codex",
+          directoryKey: "directory:pwragent",
+          directoryLabel: "PwrAgent",
+          directoryPath: "/repo/pwragent",
+          executionMode: "default",
+          fastMode: undefined,
+          model: undefined,
+          prompt: "",
+          reasoningEffort: undefined,
+          serviceTier: undefined,
+          workMode: "local",
+        }),
       }),
-    }));
+      expectMaterializeOptions(),
+    );
     expect(harness.startThread).not.toHaveBeenCalled();
     expect(harness.startTurn).not.toHaveBeenCalled();
     await expect(
@@ -452,23 +456,26 @@ describe("MessagingController", () => {
     await harness.controller.handleInboundEvent(buildTextEvent("Fix bug in a worktree"));
 
     expect(harness.startThread).not.toHaveBeenCalled();
-    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith(expect.objectContaining({
-      directoryKey: expect.stringMatching(/^messaging:browse:/),
-      input: [
-        {
-          type: "text",
-          text: "Fix bug in a worktree",
-        },
-      ],
-      launchpad: expect.objectContaining({
-        backend: "codex",
-        directoryKey: "directory:pwragent",
-        directoryPath: "/repo/pwragent",
-        executionMode: "default",
-        workMode: "worktree",
-        branchName: "release/v2",
+    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith(
+      expect.objectContaining({
+        directoryKey: expect.stringMatching(/^messaging:browse:/),
+        input: [
+          {
+            type: "text",
+            text: "Fix bug in a worktree",
+          },
+        ],
+        launchpad: expect.objectContaining({
+          backend: "codex",
+          directoryKey: "directory:pwragent",
+          directoryPath: "/repo/pwragent",
+          executionMode: "default",
+          workMode: "worktree",
+          branchName: "release/v2",
+        }),
       }),
-    }));
+      expectMaterializeOptions(),
+    );
   });
 
   it("keeps non-git new-thread prompts local when a worktree action is requested", async () => {
@@ -525,20 +532,23 @@ describe("MessagingController", () => {
 
     await harness.controller.handleInboundEvent(buildTextEvent("Fix bug locally"));
 
-    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith(expect.objectContaining({
-      directoryKey: expect.stringMatching(/^messaging:browse:/),
-      input: [
-        {
-          type: "text",
-          text: "Fix bug locally",
-        },
-      ],
-      launchpad: expect.objectContaining({
-        directoryKey: "directory:pwragent",
-        directoryPath: "/repo/pwragent",
-        workMode: "local",
+    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith(
+      expect.objectContaining({
+        directoryKey: expect.stringMatching(/^messaging:browse:/),
+        input: [
+          {
+            type: "text",
+            text: "Fix bug locally",
+          },
+        ],
+        launchpad: expect.objectContaining({
+          directoryKey: "directory:pwragent",
+          directoryPath: "/repo/pwragent",
+          workMode: "local",
+        }),
       }),
-    }));
+      expectMaterializeOptions(),
+    );
   });
 
   it("paginates the new-thread base branch picker", async () => {
@@ -634,20 +644,23 @@ describe("MessagingController", () => {
     );
     await harness.controller.handleInboundEvent(buildTextEvent("Fix bug"));
 
-    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith(expect.objectContaining({
-      directoryKey: expect.stringMatching(/^messaging:browse:/),
-      input: [
-        {
-          type: "text",
-          text: "Fix bug",
-        },
-      ],
-      launchpad: expect.objectContaining({
-        directoryKey: "directory:pwragent",
-        directoryPath: "/repo/pwragent",
-        workMode: "worktree",
+    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith(
+      expect.objectContaining({
+        directoryKey: expect.stringMatching(/^messaging:browse:/),
+        input: [
+          {
+            type: "text",
+            text: "Fix bug",
+          },
+        ],
+        launchpad: expect.objectContaining({
+          directoryKey: "directory:pwragent",
+          directoryPath: "/repo/pwragent",
+          workMode: "worktree",
+        }),
       }),
-    }));
+      expectMaterializeOptions(),
+    );
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "status",
       text: expect.stringContaining("Directory: /repo/pwragent"),
@@ -851,6 +864,7 @@ describe("MessagingController", () => {
             },
           ],
         }),
+        expectMaterializeOptions(),
       );
       expect(harness.startTurn).not.toHaveBeenCalled();
     });
@@ -948,6 +962,7 @@ describe("MessagingController", () => {
           },
         ],
       }),
+      expectMaterializeOptions(),
     );
     await expect(
       harness.store.findActiveBindingForChannel(buildCommandEvent("/resume").channel),
@@ -964,6 +979,93 @@ describe("MessagingController", () => {
       kind: "status",
       text: expect.stringContaining("Binding: new-thread-1"),
     });
+  });
+
+  it("binds a materialized thread before fast first-turn terminal events", async () => {
+    let harness: Awaited<ReturnType<typeof createHarness>>;
+    const materializeDirectoryLaunchpad = vi.fn(
+      async (
+        request: MaterializeDirectoryLaunchpadRequest,
+        options?: MaterializeDirectoryLaunchpadOptions,
+      ) => {
+        await options?.onThreadMaterialized?.({
+          backend: request.launchpad?.backend ?? "codex",
+          threadId: "new-thread-1",
+          executionMode: request.launchpad?.executionMode ?? "default",
+          workMode: request.launchpad?.workMode ?? "local",
+        });
+        await harness.controller.handleBackendEvent({
+          backend: "codex",
+          notification: {
+            method: "turn/completed",
+            params: {
+              threadId: "new-thread-1",
+              turnId: "turn-1",
+              turn: {
+                id: "turn-1",
+                status: "completed",
+                output: [
+                  {
+                    type: "agentMessage",
+                    text: "Fixed it.",
+                  },
+                ],
+              },
+            },
+          },
+        } satisfies AgentEvent);
+        return {
+          backend: request.launchpad?.backend ?? "codex",
+          threadId: "new-thread-1",
+          turnId: "turn-1",
+          executionMode: request.launchpad?.executionMode ?? "default",
+          workMode: request.launchpad?.workMode ?? "local",
+        };
+      },
+    );
+    harness = await createHarness({ materializeDirectoryLaunchpad });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/resume --new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+    await harness.controller.handleInboundEvent(buildTextEvent("Fix bug"));
+
+    expect(harness.startThread).not.toHaveBeenCalled();
+    expect(harness.startTurn).not.toHaveBeenCalled();
+    await expect(
+      harness.store.findActiveBindingForChannel(buildCommandEvent("/resume").channel),
+    ).resolves.toMatchObject({
+      backend: "codex",
+      threadId: "new-thread-1",
+    });
+    expect(harness.delivered).toContainEqual(
+      expect.objectContaining({
+        kind: "message",
+        role: "assistant",
+        parts: [
+          {
+            type: "text",
+            text: "Fixed it.",
+            markdown: "markdown",
+          },
+        ],
+      }),
+    );
+    expect(harness.delivered).not.toContainEqual(
+      expect.objectContaining({
+        kind: "activity",
+        activity: "typing",
+        state: "active",
+      }),
+    );
   });
 
   it("routes messages to the new thread after rebinding an already-bound conversation", async () => {
@@ -1003,6 +1105,7 @@ describe("MessagingController", () => {
           backend: "codex",
         }),
       }),
+      expectMaterializeOptions(),
     );
     expect(harness.startTurn).not.toHaveBeenCalled();
     await expect(harness.store.getBinding("binding:telegram:dm::chat-1:codex:old-thread"))
@@ -1237,6 +1340,7 @@ describe("MessagingController", () => {
           },
         ],
       }),
+      expectMaterializeOptions(),
     );
     expect(harness.startTurn).not.toHaveBeenCalled();
   });
@@ -2977,19 +3081,22 @@ describe("MessagingController", () => {
 
     await harness.controller.handleInboundEvent(buildTextEvent("Fix bug with Grok"));
 
-    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith(expect.objectContaining({
-      directoryKey: expect.stringMatching(/^messaging:browse:/),
-      input: [
-        {
-          type: "text",
-          text: "Fix bug with Grok",
-        },
-      ],
-      launchpad: expect.objectContaining({
-        backend: "grok",
-        directoryKey: "directory:pwragent",
+    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith(
+      expect.objectContaining({
+        directoryKey: expect.stringMatching(/^messaging:browse:/),
+        input: [
+          {
+            type: "text",
+            text: "Fix bug with Grok",
+          },
+        ],
+        launchpad: expect.objectContaining({
+          backend: "grok",
+          directoryKey: "directory:pwragent",
+        }),
       }),
-    }));
+      expectMaterializeOptions(),
+    );
     expect(harness.startTurn).not.toHaveBeenCalled();
     await expect(
       harness.store.findActiveBindingForChannel(buildCommandEvent("/new").channel),
@@ -3071,19 +3178,22 @@ describe("MessagingController", () => {
 
     await harness.controller.handleInboundEvent(buildTextEvent("Use Gemini"));
 
-    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith(expect.objectContaining({
-      directoryKey: expect.stringMatching(/^messaging:browse:/),
-      input: [
-        {
-          type: "text",
-          text: "Use Gemini",
-        },
-      ],
-      launchpad: expect.objectContaining({
-        backend: "acp:gemini",
-        directoryKey: "directory:pwragent",
+    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith(
+      expect.objectContaining({
+        directoryKey: expect.stringMatching(/^messaging:browse:/),
+        input: [
+          {
+            type: "text",
+            text: "Use Gemini",
+          },
+        ],
+        launchpad: expect.objectContaining({
+          backend: "acp:gemini",
+          directoryKey: "directory:pwragent",
+        }),
       }),
-    }));
+      expectMaterializeOptions(),
+    );
     expect(harness.startTurn).not.toHaveBeenCalled();
     await expect(
       harness.store.findActiveBindingForChannel(buildCommandEvent("/new").channel),
@@ -3156,19 +3266,22 @@ describe("MessagingController", () => {
 
     await harness.controller.handleInboundEvent(buildTextEvent("Use Gemini"));
 
-    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith(expect.objectContaining({
-      directoryKey: expect.stringMatching(/^messaging:browse:/),
-      input: [
-        {
-          type: "text",
-          text: "Use Gemini",
-        },
-      ],
-      launchpad: expect.objectContaining({
-        backend: "acp:gemini",
-        executionMode: "default",
+    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith(
+      expect.objectContaining({
+        directoryKey: expect.stringMatching(/^messaging:browse:/),
+        input: [
+          {
+            type: "text",
+            text: "Use Gemini",
+          },
+        ],
+        launchpad: expect.objectContaining({
+          backend: "acp:gemini",
+          executionMode: "default",
+        }),
       }),
-    }));
+      expectMaterializeOptions(),
+    );
     expect(harness.startTurn).not.toHaveBeenCalled();
   });
 
@@ -3309,22 +3422,25 @@ describe("MessagingController", () => {
 
     await harness.controller.handleInboundEvent(buildTextEvent("Use yolo"));
 
-    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith(expect.objectContaining({
-      directoryKey: expect.stringMatching(/^messaging:browse:/),
-      input: [
-        {
-          type: "text",
-          text: "Use yolo",
-        },
-      ],
-      launchpad: expect.objectContaining({
-        backend: "acp:gemini",
-        executionMode: "full-access",
-        acpRuntime: expect.objectContaining({
-          currentModeId: "yolo",
+    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith(
+      expect.objectContaining({
+        directoryKey: expect.stringMatching(/^messaging:browse:/),
+        input: [
+          {
+            type: "text",
+            text: "Use yolo",
+          },
+        ],
+        launchpad: expect.objectContaining({
+          backend: "acp:gemini",
+          executionMode: "full-access",
+          acpRuntime: expect.objectContaining({
+            currentModeId: "yolo",
+          }),
         }),
       }),
-    }));
+      expectMaterializeOptions(),
+    );
   });
 
   it("uses inherited ACP runtime state when opening the new-thread picker", async () => {
@@ -3747,6 +3863,7 @@ describe("MessagingController", () => {
           codexEnvironmentSetupEnabled: true,
         }),
       }),
+      expectMaterializeOptions(),
     );
     expect(harness.startTurn).not.toHaveBeenCalled();
   });
@@ -8047,6 +8164,7 @@ describe("MessagingController", () => {
           executionMode: "full-access",
         }),
       }),
+      expectMaterializeOptions(),
     );
     expect(harness.startTurn).not.toHaveBeenCalled();
   });
@@ -8100,6 +8218,7 @@ describe("MessagingController", () => {
           executionMode: "full-access",
         }),
       }),
+      expectMaterializeOptions(),
     );
     expect(harness.startTurn).not.toHaveBeenCalled();
   });
@@ -8250,6 +8369,7 @@ describe("MessagingController", () => {
           executionMode: "full-access",
         }),
       }),
+      expectMaterializeOptions(),
     );
     expect(harness.startTurn).not.toHaveBeenCalled();
     expect(harness.delivered).not.toEqual(
@@ -8329,6 +8449,7 @@ describe("MessagingController", () => {
           executionMode: "full-access",
         }),
       }),
+      expectMaterializeOptions(),
     );
     expect(harness.startTurn).not.toHaveBeenCalled();
   });
@@ -10027,6 +10148,12 @@ function buildBackendSummary(overrides: Partial<BackendSummary> = {}): BackendSu
     executionModes: overrides.executionModes ?? base.executionModes,
     launchpadOptions: overrides.launchpadOptions ?? base.launchpadOptions,
   };
+}
+
+function expectMaterializeOptions() {
+  return expect.objectContaining({
+    onThreadMaterialized: expect.any(Function),
+  });
 }
 
 function buildAcpRuntimeBackendSummary(

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -981,6 +981,76 @@ describe("MessagingController", () => {
     });
   });
 
+  it("does not double-report materialized first-turn start failures that emitted backend failure events", async () => {
+    let harness: Awaited<ReturnType<typeof createHarness>>;
+    const materializeDirectoryLaunchpad = vi.fn(
+      async (
+        request: MaterializeDirectoryLaunchpadRequest,
+        options?: MaterializeDirectoryLaunchpadOptions,
+      ) => {
+        await options?.onThreadMaterialized?.({
+          backend: request.launchpad?.backend ?? "codex",
+          threadId: "new-thread-1",
+          executionMode: request.launchpad?.executionMode ?? "default",
+          workMode: request.launchpad?.workMode ?? "local",
+        });
+        await harness.controller.handleBackendEvent({
+          backend: "codex",
+          notification: {
+            method: "turn/failed",
+            params: {
+              threadId: "new-thread-1",
+              turnId: "pending:new-thread-1",
+              turn: {
+                id: "pending:new-thread-1",
+                status: "failed",
+                error: {
+                  message: "invalid model",
+                },
+              },
+            },
+          },
+        } satisfies AgentEvent);
+        return {
+          backend: request.launchpad?.backend ?? "codex",
+          threadId: "new-thread-1",
+          executionMode: request.launchpad?.executionMode ?? "default",
+          workMode: request.launchpad?.workMode ?? "local",
+          turnStartFailure: {
+            message: "invalid model",
+            phase: "turn" as const,
+          },
+        };
+      },
+    );
+    harness = await createHarness({ materializeDirectoryLaunchpad });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/resume --new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+    await harness.controller.handleInboundEvent(buildTextEvent("Fix bug"));
+
+    const turnFailedNotices = harness.delivered.filter(
+      (intent) => intent.kind === "error" && intent.title === "Turn failed",
+    );
+    const turnStartFailedNotices = harness.delivered.filter(
+      (intent) => intent.kind === "error" && intent.title === "Turn could not start",
+    );
+    expect(turnFailedNotices).toHaveLength(1);
+    expect(turnFailedNotices[0]).toMatchObject({
+      body: "invalid model",
+    });
+    expect(turnStartFailedNotices).toHaveLength(0);
+  });
+
   it("binds a materialized thread before fast first-turn terminal events", async () => {
     let harness: Awaited<ReturnType<typeof createHarness>>;
     const materializeDirectoryLaunchpad = vi.fn(
@@ -1066,6 +1136,91 @@ describe("MessagingController", () => {
         state: "active",
       }),
     );
+  });
+
+  it("routes quick follow-ups to the materialized binding while the first turn starts", async () => {
+    let harness: Awaited<ReturnType<typeof createHarness>>;
+    let resolveMaterialized!: () => void;
+    let resolveFirstTurn!: () => void;
+    const materialized = new Promise<void>((resolve) => {
+      resolveMaterialized = resolve;
+    });
+    const firstTurnStarted = new Promise<void>((resolve) => {
+      resolveFirstTurn = resolve;
+    });
+    const materializeDirectoryLaunchpad = vi.fn(
+      async (
+        request: MaterializeDirectoryLaunchpadRequest,
+        options?: MaterializeDirectoryLaunchpadOptions,
+      ) => {
+        await options?.onThreadMaterialized?.({
+          backend: request.launchpad?.backend ?? "codex",
+          threadId: "new-thread-1",
+          executionMode: request.launchpad?.executionMode ?? "default",
+          workMode: request.launchpad?.workMode ?? "local",
+        });
+        await harness.controller.handleBackendEvent({
+          backend: "codex",
+          notification: {
+            method: "turn/started",
+            params: {
+              threadId: "new-thread-1",
+              turnId: "pending:new-thread-1",
+              turn: {
+                id: "pending:new-thread-1",
+                status: "in_progress",
+              },
+            },
+          },
+        } satisfies AgentEvent);
+        resolveMaterialized();
+        await firstTurnStarted;
+        return {
+          backend: request.launchpad?.backend ?? "codex",
+          threadId: "new-thread-1",
+          turnId: "turn-1",
+          executionMode: request.launchpad?.executionMode ?? "default",
+          workMode: request.launchpad?.workMode ?? "local",
+        };
+      },
+    );
+    harness = await createHarness({ materializeDirectoryLaunchpad });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/resume --new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+    const firstPrompt = harness.controller.handleInboundEvent(buildTextEvent("Fix bug"));
+    await materialized;
+
+    await expect(
+      harness.store.findActiveBrowseSessionForChannel({
+        actorId: "user-1",
+        channel: buildTextEvent("Fix bug").channel,
+        now: 1000,
+      }),
+    ).resolves.toBeUndefined();
+
+    await harness.controller.handleInboundEvent(buildTextEvent("also check logs"));
+
+    expect(materializeDirectoryLaunchpad).toHaveBeenCalledTimes(1);
+    expect(harness.startTurn).not.toHaveBeenCalled();
+    expect(harness.delivered).toContainEqual(
+      expect.objectContaining({
+        kind: "confirmation",
+        title: "Message queued",
+      }),
+    );
+
+    resolveFirstTurn();
+    await firstPrompt;
   });
 
   it("routes messages to the new thread after rebinding an already-bound conversation", async () => {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -7550,28 +7550,45 @@ export class DesktopBackendRegistry {
         ? [{ type: "text", text: launchpad.prompt } as const]
         : []);
     let turnId: string | undefined;
+    let turnStartFailure:
+      | MaterializeDirectoryLaunchpadResponse["turnStartFailure"]
+      | undefined;
     if (codexEnvironmentStartupFailure) {
       turnId = undefined;
     } else if (request.reviewTarget) {
-      const reviewResponse = await this.startReview({
-        backend: launchpad.backend,
-        threadId: startThreadResponse.threadId,
-        target: request.reviewTarget,
-        delivery: "inline",
-      });
-      turnId = reviewResponse.turnId;
+      try {
+        const reviewResponse = await this.startReview({
+          backend: launchpad.backend,
+          threadId: startThreadResponse.threadId,
+          target: request.reviewTarget,
+          delivery: "inline",
+        });
+        turnId = reviewResponse.turnId;
+      } catch (error) {
+        turnStartFailure = {
+          message: error instanceof Error ? error.message : String(error),
+          phase: "review",
+        };
+      }
     } else if (input.length > 0) {
-      const turnResponse = await this.startTurn({
-        backend: launchpad.backend,
-        threadId: startThreadResponse.threadId,
-        input,
-        model: launchpad.model,
-        reasoningEffort: launchpad.reasoningEffort,
-        serviceTier: launchpad.serviceTier,
-        fastMode: launchpad.backend === "codex" ? launchpad.fastMode : undefined,
-        collaborationMode: request.collaborationMode,
-      });
-      turnId = turnResponse.turnId;
+      try {
+        const turnResponse = await this.startTurn({
+          backend: launchpad.backend,
+          threadId: startThreadResponse.threadId,
+          input,
+          model: launchpad.model,
+          reasoningEffort: launchpad.reasoningEffort,
+          serviceTier: launchpad.serviceTier,
+          fastMode: launchpad.backend === "codex" ? launchpad.fastMode : undefined,
+          collaborationMode: request.collaborationMode,
+        });
+        turnId = turnResponse.turnId;
+      } catch (error) {
+        turnStartFailure = {
+          message: error instanceof Error ? error.message : String(error),
+          phase: "turn",
+        };
+      }
     }
 
     await resetLaunchpadAfterMaterialize({
@@ -7592,6 +7609,7 @@ export class DesktopBackendRegistry {
       workMode: workspace.workMode,
       codexEnvironmentRuntime,
       codexEnvironmentStartupFailure,
+      turnStartFailure,
     };
   }
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -58,7 +58,9 @@ import {
   type ListBackendsResponse,
   type LinkedDirectorySummary,
   type MaterializeDirectoryLaunchpadRequest,
+  type MaterializeDirectoryLaunchpadOptions,
   type MaterializeDirectoryLaunchpadResponse,
+  type MaterializedDirectoryLaunchpadThread,
   type LaunchpadWorkMode,
   type NavigationDirectoryGitStatus,
   type NavigationDirectorySummary,
@@ -7373,11 +7375,7 @@ export class DesktopBackendRegistry {
 
   async materializeDirectoryLaunchpad(
     request: MaterializeDirectoryLaunchpadRequest,
-    options?: {
-      onCodexEnvironmentSetupProgress?: (
-        event: CodexEnvironmentSetupProgressEvent,
-      ) => void;
-    },
+    options?: MaterializeDirectoryLaunchpadOptions,
   ): Promise<MaterializeDirectoryLaunchpadResponse> {
     const launchpad =
       request.launchpad ??
@@ -7543,6 +7541,16 @@ export class DesktopBackendRegistry {
         worktreePath: workspace.cwd,
       });
     }
+    const materializedThread = {
+      backend: startThreadResponse.backend,
+      threadId: startThreadResponse.threadId,
+      executionMode: startThreadResponse.executionMode,
+      ...(linkedDirectories?.[0] ? { linkedDirectory: linkedDirectories[0] } : {}),
+      workMode: workspace.workMode,
+      codexEnvironmentRuntime,
+      codexEnvironmentStartupFailure,
+    } satisfies MaterializedDirectoryLaunchpadThread;
+    await options?.onThreadMaterialized?.(materializedThread);
 
     const input =
       request.input ??
@@ -7601,14 +7609,8 @@ export class DesktopBackendRegistry {
     });
 
     return {
-      backend: startThreadResponse.backend,
-      threadId: startThreadResponse.threadId,
+      ...materializedThread,
       turnId,
-      executionMode: startThreadResponse.executionMode,
-      ...(linkedDirectories?.[0] ? { linkedDirectory: linkedDirectories[0] } : {}),
-      workMode: workspace.workMode,
-      codexEnvironmentRuntime,
-      codexEnvironmentStartupFailure,
       turnStartFailure,
     };
   }

--- a/apps/desktop/src/main/messaging/core/messaging-adapter.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-adapter.ts
@@ -15,6 +15,7 @@ import type {
   GetNavigationSnapshotRequest,
   ListBackendsRequest,
   ListBackendsResponse,
+  MaterializeDirectoryLaunchpadOptions,
   MaterializeDirectoryLaunchpadRequest,
   MaterializeDirectoryLaunchpadResponse,
   NavigationSnapshot,
@@ -137,6 +138,7 @@ export type MessagingBackendBridge = {
   ): Promise<HandoffThreadWorkspaceResponse>;
   materializeDirectoryLaunchpad?(
     request: MaterializeDirectoryLaunchpadRequest,
+    options?: MaterializeDirectoryLaunchpadOptions,
   ): Promise<MaterializeDirectoryLaunchpadResponse>;
   updateDirectoryLaunchpad?(
     request: UpdateDirectoryLaunchpadRequest,

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -4740,6 +4740,15 @@ export class MessagingController {
           navigation: NavigationSnapshot;
         }
       | undefined;
+    let browseSessionRetired = false;
+    const retireBrowseSession = async (): Promise<void> => {
+      if (browseSessionRetired) {
+        return;
+      }
+      browseSessionRetired = true;
+      this.pendingFullAccessNewThreadPrompts.delete(session.id);
+      await this.options.store.deleteBrowseSession(session.id);
+    };
     const bindStartedThread = async (
       started: StartedLaunchpadThread,
     ): Promise<{
@@ -4753,6 +4762,7 @@ export class MessagingController {
         backend: started.backend,
         threadId: started.threadId,
       });
+      await retireBrowseSession();
       let updatedBinding = preferences
         ? await this.updateBindingPreferences(binding, preferences)
         : binding;
@@ -4833,8 +4843,7 @@ export class MessagingController {
       binding: updatedBinding,
       navigation: optimisticNavigation,
     } = await bindStartedThread(started);
-    this.pendingFullAccessNewThreadPrompts.delete(session.id);
-    await this.options.store.deleteBrowseSession(session.id);
+    await retireBrowseSession();
     if (materialized?.codexEnvironmentStartupFailure) {
       await this.deliver(
         buildErrorIntent({
@@ -4851,6 +4860,11 @@ export class MessagingController {
       return;
     }
     if (materialized?.turnStartFailure) {
+      const activeTurn = this.getActiveTurn(updatedBinding);
+      if (activeTurn?.status === "failed") {
+        await this.renderBindingStatus(updatedBinding, event, optimisticNavigation);
+        return;
+      }
       await this.deliver(
         buildErrorIntent({
           id: this.newIntentId("turn-start-failed"),

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -4794,6 +4794,21 @@ export class MessagingController {
       await this.renderBindingStatus(updatedBinding, event, optimisticNavigation);
       return;
     }
+    if (materialized?.turnStartFailure) {
+      await this.deliver(
+        buildErrorIntent({
+          id: this.newIntentId("turn-start-failed"),
+          createdAt: this.now(),
+          title: "Turn could not start",
+          body: materialized.turnStartFailure.message,
+          recoverable: true,
+        }),
+        updatedBinding,
+        event,
+      );
+      await this.renderBindingStatus(updatedBinding, event, optimisticNavigation);
+      return;
+    }
     if (materialized?.turnId) {
       this.logger.info?.("messaging materialized launchpad turn started", {
         bindingId: updatedBinding.id,

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -15,6 +15,7 @@ import type {
   BackendAcpRuntimeOptionSource,
   BackendAcpSessionRuntimeState,
   BackendSummary,
+  CodexEnvironmentOption,
   AppServerPendingRequestNotification,
   AppServerToolRequestUserInputNotification,
   DesktopAuthorizedContact,
@@ -1708,6 +1709,24 @@ export class MessagingController {
     return threadStatus === "active";
   }
 
+  private async adoptStartedTurn(params: {
+    binding: MessagingBindingRecord;
+    navigation: NavigationSnapshot;
+    turnId: string;
+  }): Promise<void> {
+    const activeTurn: MessagingActiveTurnSummary = {
+      turnId: params.turnId,
+      status: "working",
+      startedAt: this.now(),
+      updatedAt: this.now(),
+    };
+    this.setActiveTurn(params.binding, activeTurn);
+    await this.signalTurnActivity(params.binding, activeTurn, {
+      force: true,
+    });
+    await this.renderBindingStatus(params.binding, undefined, params.navigation);
+  }
+
   private async queuePreparedInput(params: {
     binding: MessagingBindingRecord;
     input: AppServerTurnInputItem[];
@@ -3309,6 +3328,14 @@ export class MessagingController {
       );
       return;
     }
+    if (actionId === "browse:new:environment") {
+      await this.presentNewThreadEnvironmentPicker(nextSession, navigation, event);
+      return;
+    }
+    if (actionId === "browse:new:set-environment") {
+      await this.setNewThreadEnvironment(nextSession, navigation, event);
+      return;
+    }
     if (actionId === "browse:new:backend") {
       await this.presentNewThreadBackendPicker(nextSession, event, navigation);
       return;
@@ -3813,6 +3840,7 @@ export class MessagingController {
       Boolean(
         selectedBackend.launchpadOptions?.models?.some((model) => model.supportsFast),
       );
+    const codexEnvironmentOptions = codexEnvironmentOptionsForDirectory(directory);
     const supportsPermissionsControls =
       !isAcpBackendId(selectedBackend.kind) ||
       options.executionMode === "full-access";
@@ -3917,6 +3945,18 @@ export class MessagingController {
           style: "secondary",
           fallbackText: "stream",
         },
+        ...(codexEnvironmentOptions.length > 0
+          ? [
+              {
+                id: "browse:new:environment",
+                label: options.codexEnvironmentName
+                  ? `Env: ${options.codexEnvironmentName}`
+                  : "Env: none",
+                style: "secondary" as const,
+                fallbackText: "environment",
+              },
+            ]
+          : []),
         ...(supportsModel
           ? [
               {
@@ -4187,6 +4227,126 @@ export class MessagingController {
         updatedAt: this.now(),
       });
     }
+  }
+
+  private async presentNewThreadEnvironmentPicker(
+    session: MessagingBrowseSessionRecord,
+    navigation: NavigationSnapshot,
+    event: MessagingInboundEvent,
+  ): Promise<void> {
+    const directory = session.selectedProject
+      ? directoryForProjectSelection(navigation, session.selectedProject)
+      : undefined;
+    const environments = codexEnvironmentOptionsForDirectory(directory);
+    if (environments.length === 0) {
+      await this.deliver(
+        buildErrorIntent({
+          id: this.newIntentId("new-thread-environments-unavailable"),
+          createdAt: this.now(),
+          title: "Environments unavailable",
+          body: "This project did not report Codex environment choices.",
+          recoverable: true,
+        }),
+        undefined,
+        event,
+      );
+      return;
+    }
+
+    const selected = selectedCodexEnvironmentForSession(session, directory);
+    const intent = buildConfirmationIntent({
+      id: this.newIntentId("new-thread-environment"),
+      capabilityProfile: this.capabilityProfile,
+      browseSessionId: session.id,
+      createdAt: this.now(),
+      delivery: session.surface
+        ? { mode: "update", replaceMarkup: true }
+        : undefined,
+      title: "Select environment",
+      body: "Choose the Codex environment for the new thread.",
+      fallbackText: "Choose an environment, or reply back.",
+      targetSurface: session.surface,
+      actions: [
+        {
+          id: "browse:new:set-environment",
+          label: selected ? "No environment" : "No environment ✓",
+          style: selected ? "secondary" as const : "primary" as const,
+          fallbackText: "0",
+          priority: 9,
+          value: { environmentId: "" },
+        },
+        ...environments.map((environment, index) => ({
+          id: "browse:new:set-environment",
+          label: `${environment.name}${environment.id === selected?.id ? " ✓" : ""}`,
+          style: environment.id === selected?.id
+            ? "primary" as const
+            : "secondary" as const,
+          fallbackText: String(index + 1),
+          priority: 10 + index,
+          value: { environmentId: environment.id },
+        })),
+        {
+          id: session.workMode === "worktree"
+            ? "browse:new:workspace:worktree"
+            : "browse:new:workspace:local",
+          label: "Back",
+          style: "secondary" as const,
+          fallbackText: "back",
+          priority: 1,
+        },
+      ],
+    });
+    await this.storePendingIntent(intent, undefined, event);
+    const result = await this.deliver(intent, undefined, event);
+    if (result.surface) {
+      await this.options.store.upsertBrowseSession({
+        ...session,
+        surface: result.surface,
+        updatedAt: this.now(),
+      });
+    }
+  }
+
+  private async setNewThreadEnvironment(
+    session: MessagingBrowseSessionRecord,
+    navigation: NavigationSnapshot,
+    event: MessagingInboundCallbackEvent,
+  ): Promise<void> {
+    const environmentId = readStringValue(event.value, "environmentId");
+    if (environmentId === undefined) {
+      await this.deliverInvalidBrowseSelection(event);
+      return;
+    }
+    const directory = session.selectedProject
+      ? directoryForProjectSelection(navigation, session.selectedProject)
+      : undefined;
+    const environments = codexEnvironmentOptionsForDirectory(directory);
+    const environment = environmentId
+      ? environments.find((candidate) => candidate.id === environmentId)
+      : undefined;
+    if (environmentId && !environment) {
+      await this.deliverInvalidBrowseSelection(event);
+      return;
+    }
+
+    await this.updateNewThreadStickySettings(session, {
+      codexEnvironmentId: environment?.id,
+      codexEnvironmentExecutionTarget: environment ? "local" : undefined,
+      codexEnvironmentSetupEnabled: Boolean(environment?.setupScript),
+      codexEnvironmentActionId: undefined,
+    });
+    await this.presentNewThreadPromptGate(
+      {
+        ...session,
+        codexEnvironmentId: environment?.id ?? null,
+        codexEnvironmentExecutionTarget: environment ? "local" : undefined,
+        codexEnvironmentSetupEnabled: Boolean(environment?.setupScript),
+        codexEnvironmentActionId: undefined,
+        updatedAt: this.now(),
+      },
+      event,
+      navigation,
+    );
   }
 
   private async presentNewThreadAcpRuntimeModePicker(
@@ -4560,11 +4720,13 @@ export class MessagingController {
             navigation,
             preferences,
             project,
+            session,
             now: this.now(),
             workMode: options.workMode,
             branchName: options.branchName,
             acpRuntime: options.acpRuntime,
           }),
+          input: prepared.input,
         })
       : undefined;
     const started = materialized ?? (await this.options.backend.startThread!({
@@ -4617,6 +4779,40 @@ export class MessagingController {
     });
     this.pendingFullAccessNewThreadPrompts.delete(session.id);
     await this.options.store.deleteBrowseSession(session.id);
+    if (materialized?.codexEnvironmentStartupFailure) {
+      await this.deliver(
+        buildErrorIntent({
+          id: this.newIntentId("environment-startup-failed"),
+          createdAt: this.now(),
+          title: "Environment startup failed",
+          body: materialized.codexEnvironmentStartupFailure.message,
+          recoverable: true,
+        }),
+        updatedBinding,
+        event,
+      );
+      await this.renderBindingStatus(updatedBinding, event, optimisticNavigation);
+      return;
+    }
+    if (materialized?.turnId) {
+      this.logger.info?.("messaging materialized launchpad turn started", {
+        bindingId: updatedBinding.id,
+        threadId: started.threadId,
+        turnId: materialized.turnId,
+      });
+      await this.adoptStartedTurn({
+        binding: updatedBinding,
+        navigation: optimisticNavigation,
+        turnId: materialized.turnId,
+      });
+      return;
+    }
+    if (materialized) {
+      this.logger.debug?.("messaging materialized launchpad without turn id", {
+        bindingId: updatedBinding.id,
+        threadId: started.threadId,
+      });
+    }
     await this.startPreparedInput({
       binding: updatedBinding,
       input: prepared.input,
@@ -10272,6 +10468,7 @@ type NewThreadOptionsSummary = {
   backend: AppServerBackendKind;
   backendLabel: string;
   branchName: string;
+  codexEnvironmentName?: string;
   executionMode: ThreadExecutionMode;
   executionModeSource: "session" | "directory-launchpad" | "launchpad-defaults";
   fastMode: boolean;
@@ -10334,11 +10531,16 @@ function newThreadOptionsForSession(
     : directory?.launchpad?.executionMode
       ? "directory-launchpad"
       : "launchpad-defaults";
+  const selectedCodexEnvironment = selectedCodexEnvironmentForSession(
+    session,
+    directory,
+  );
   return {
     backend: backend.kind,
     backendLabel: backend.label,
     acpRuntime,
     branchName: resolveNewThreadBaseBranch(session, navigation, directory),
+    codexEnvironmentName: selectedCodexEnvironment?.name,
     executionMode,
     executionModeSource,
     fastMode:
@@ -10408,6 +10610,9 @@ function newThreadPromptGateBody(
       : undefined,
     options.supportsFast ? `Fast mode: ${options.fastMode ? "on" : "off"}` : undefined,
     `Streaming: ${options.streamingResponses ? "on" : "off"}`,
+    options.codexEnvironmentName
+      ? `Environment: ${options.codexEnvironmentName}`
+      : undefined,
   ]
     .filter((line): line is string => Boolean(line))
     .join("\n");
@@ -11206,10 +11411,15 @@ function launchpadForMessagingProject(params: {
   now: number;
   preferences?: MessagingBrowseSessionRecord["preferences"];
   project: NonNullable<ReturnType<typeof selectProjectFromValue>>;
+  session: MessagingBrowseSessionRecord;
   workMode: LaunchpadWorkMode;
 }): NavigationLaunchpadDraft {
   const defaults = params.navigation.launchpadDefaults;
   const directoryPath = params.directory?.path ?? params.project.path;
+  const selectedCodexEnvironment = selectedCodexEnvironmentForSession(
+    params.session,
+    params.directory,
+  );
   const base: NavigationLaunchpadDraft = params.directory?.launchpad ?? {
     directoryKey:
       params.directory?.key ??
@@ -11244,8 +11454,44 @@ function launchpadForMessagingProject(params: {
     prompt: "",
     workMode: params.workMode,
     branchName: params.branchName,
+    codexEnvironmentId: selectedCodexEnvironment?.id,
+    codexEnvironmentExecutionTarget: selectedCodexEnvironment
+      ? params.session.codexEnvironmentExecutionTarget ??
+        base.codexEnvironmentExecutionTarget ??
+        "local"
+      : undefined,
+    codexEnvironmentSetupEnabled: selectedCodexEnvironment
+      ? params.session.codexEnvironmentSetupEnabled ??
+        base.codexEnvironmentSetupEnabled ??
+        Boolean(selectedCodexEnvironment.setupScript)
+      : false,
+    codexEnvironmentActionId: selectedCodexEnvironment
+      ? params.session.codexEnvironmentActionId ?? base.codexEnvironmentActionId
+      : undefined,
+    codexEnvironmentOptions: base.codexEnvironmentOptions,
     updatedAt: params.now,
   };
+}
+
+function codexEnvironmentOptionsForDirectory(
+  directory: NavigationDirectorySummary | undefined,
+): CodexEnvironmentOption[] {
+  return directory?.launchpad?.codexEnvironmentOptions ?? [];
+}
+
+function selectedCodexEnvironmentForSession(
+  session: MessagingBrowseSessionRecord,
+  directory: NavigationDirectorySummary | undefined,
+): CodexEnvironmentOption | undefined {
+  const environments = codexEnvironmentOptionsForDirectory(directory);
+  const selectedId =
+    session.codexEnvironmentId === null
+      ? undefined
+      : session.codexEnvironmentId ?? directory?.launchpad?.codexEnvironmentId;
+  if (!selectedId) {
+    return undefined;
+  }
+  return environments.find((environment) => environment.id === selectedId);
 }
 
 function messagingLaunchpadMaterializationKey(

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -24,6 +24,7 @@ import type {
   HandoffThreadWorkspaceResponse,
   LinkedDirectorySummary,
   LaunchpadWorkMode,
+  MaterializedDirectoryLaunchpadThread,
   MessagingToolUpdateMode,
   NavigationDirectorySummary,
   NavigationLaunchpadDraft,
@@ -1714,6 +1715,14 @@ export class MessagingController {
     navigation: NavigationSnapshot;
     turnId: string;
   }): Promise<void> {
+    const currentTurn = this.getActiveTurn(params.binding);
+    if (
+      currentTurn?.turnId === params.turnId &&
+      isTerminalTurnLifecycle(currentTurn)
+    ) {
+      await this.renderBindingStatus(params.binding, undefined, params.navigation);
+      return;
+    }
     const activeTurn: MessagingActiveTurnSummary = {
       turnId: params.turnId,
       status: "working",
@@ -4711,23 +4720,94 @@ export class MessagingController {
         return;
       }
     }
+    type StartedLaunchpadThread = Pick<
+      MaterializedDirectoryLaunchpadThread,
+      "backend" | "threadId" | "executionMode"
+    > &
+      Partial<
+        Pick<
+          MaterializedDirectoryLaunchpadThread,
+          "linkedDirectory" | "workMode"
+        >
+      >;
+    let boundThread:
+      | {
+          binding: MessagingBindingRecord;
+          navigation: NavigationSnapshot;
+        }
+      | undefined;
+    const bindStartedThread = async (
+      started: StartedLaunchpadThread,
+    ): Promise<{
+      binding: MessagingBindingRecord;
+      navigation: NavigationSnapshot;
+    }> => {
+      if (boundThread) {
+        return boundThread;
+      }
+      const binding = await this.bindChannelToThread(event, {
+        backend: started.backend,
+        threadId: started.threadId,
+      });
+      let updatedBinding = preferences
+        ? await this.updateBindingPreferences(binding, preferences)
+        : binding;
+      if (bundle.session.surface) {
+        updatedBinding = await this.options.store.upsertBinding({
+          ...updatedBinding,
+          statusSurface: bundle.session.surface,
+          updatedAt: this.now(),
+        });
+      }
+      const optimisticNavigation = navigationWithStartedThread({
+        backend: started.backend,
+        directory,
+        executionMode: started.executionMode,
+        linkedDirectory: started.linkedDirectory,
+        navigation,
+        now: this.now(),
+        model: options.supportsModel ? options.model : undefined,
+        reasoningEffort: options.supportsReasoning ? options.reasoningEffort : undefined,
+        serviceTier: preferences?.serviceTier,
+        fastMode: options.supportsFast ? options.fastMode : undefined,
+        acpRuntime: options.acpRuntime,
+        preferences,
+        project,
+        threadId: started.threadId,
+        worktreePath: started.linkedDirectory?.worktreePath,
+        workMode: started.workMode ?? options.workMode,
+      });
+      boundThread = {
+        binding: updatedBinding,
+        navigation: optimisticNavigation,
+      };
+      return boundThread;
+    };
+    const launchpad = launchpadForMessagingProject({
+      backend: selectedBackend.kind,
+      directory,
+      navigation,
+      preferences,
+      project,
+      session,
+      now: this.now(),
+      workMode: options.workMode,
+      branchName: options.branchName,
+      acpRuntime: options.acpRuntime,
+    });
     const materialized = this.options.backend.materializeDirectoryLaunchpad
-      ? await this.options.backend.materializeDirectoryLaunchpad({
-          directoryKey: messagingLaunchpadMaterializationKey(session),
-          launchpad: launchpadForMessagingProject({
-            backend: selectedBackend.kind,
-            directory,
-            navigation,
-            preferences,
-            project,
-            session,
-            now: this.now(),
-            workMode: options.workMode,
-            branchName: options.branchName,
-            acpRuntime: options.acpRuntime,
-          }),
-          input: prepared.input,
-        })
+      ? await this.options.backend.materializeDirectoryLaunchpad(
+          {
+            directoryKey: messagingLaunchpadMaterializationKey(session),
+            launchpad,
+            input: prepared.input,
+          },
+          {
+            onThreadMaterialized: async (started) => {
+              await bindStartedThread(started);
+            },
+          },
+        )
       : undefined;
     const started = materialized ?? (await this.options.backend.startThread!({
       backend: selectedBackend.kind,
@@ -4745,38 +4825,10 @@ export class MessagingController {
           }
         : {}),
     }));
-    const binding = await this.bindChannelToThread(event, {
-      backend: started.backend,
-      threadId: started.threadId,
-    });
-    let updatedBinding = preferences
-      ? await this.updateBindingPreferences(binding, preferences)
-      : binding;
-    if (bundle.session.surface) {
-      updatedBinding = await this.options.store.upsertBinding({
-        ...updatedBinding,
-        statusSurface: bundle.session.surface,
-        updatedAt: this.now(),
-      });
-    }
-    const optimisticNavigation = navigationWithStartedThread({
-      backend: started.backend,
-      directory,
-      executionMode: started.executionMode,
-      linkedDirectory: materialized?.linkedDirectory,
-      navigation,
-      now: this.now(),
-      model: options.supportsModel ? options.model : undefined,
-      reasoningEffort: options.supportsReasoning ? options.reasoningEffort : undefined,
-      serviceTier: preferences?.serviceTier,
-      fastMode: options.supportsFast ? options.fastMode : undefined,
-      acpRuntime: options.acpRuntime,
-      preferences,
-      project,
-      threadId: started.threadId,
-      worktreePath: materialized?.linkedDirectory?.worktreePath,
-      workMode: materialized?.workMode ?? options.workMode,
-    });
+    const {
+      binding: updatedBinding,
+      navigation: optimisticNavigation,
+    } = await bindStartedThread(started);
     this.pendingFullAccessNewThreadPrompts.delete(session.id);
     await this.options.store.deleteBrowseSession(session.id);
     if (materialized?.codexEnvironmentStartupFailure) {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -864,7 +864,11 @@ export class MessagingController {
       }
 
       if (isThreadNameUpdatedEvent(event)) {
-        await this.renderBindingStatus(binding);
+        await this.renderBindingStatus(
+          binding,
+          undefined,
+          await this.navigationSnapshotWithThreadNameFromEvent(event),
+        );
         continue;
       }
 
@@ -8331,6 +8335,39 @@ export class MessagingController {
       statusSurface: result.surface,
       updatedAt: this.now(),
     });
+  }
+
+  private async navigationSnapshotWithThreadNameFromEvent(
+    event: AgentEvent,
+  ): Promise<NavigationSnapshot> {
+    const snapshot = await this.options.backend.getNavigationSnapshot({
+      backend: "all",
+    });
+    const params = event.notification.params as {
+      threadId?: unknown;
+      threadName?: unknown;
+    };
+    if (
+      typeof params.threadId !== "string" ||
+      typeof params.threadName !== "string" ||
+      !params.threadName.trim()
+    ) {
+      return snapshot;
+    }
+    const threadId = params.threadId;
+    const threadName = params.threadName.trim();
+
+    return {
+      ...snapshot,
+      threads: snapshot.threads.map((thread) =>
+        thread.source === event.backend && thread.id === threadId
+          ? {
+              ...thread,
+              title: threadName,
+            }
+          : thread,
+      ),
+    };
   }
 
   private async renderMonitorStatus(

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -16,6 +16,7 @@ import type {
   InterruptTurnResponse,
   ListBackendsRequest,
   ListBackendsResponse,
+  MaterializeDirectoryLaunchpadOptions,
   MaterializeDirectoryLaunchpadRequest,
   MaterializeDirectoryLaunchpadResponse,
   NavigationSnapshot,
@@ -139,8 +140,9 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
 
   async materializeDirectoryLaunchpad(
     request: MaterializeDirectoryLaunchpadRequest,
+    options?: MaterializeDirectoryLaunchpadOptions,
   ): Promise<MaterializeDirectoryLaunchpadResponse> {
-    return await this.registry.materializeDirectoryLaunchpad(request);
+    return await this.registry.materializeDirectoryLaunchpad(request, options);
   }
 
   async updateDirectoryLaunchpad(

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -1906,6 +1906,78 @@ describe("useThreadNavigation", () => {
     );
   });
 
+  it("selects a materialized thread without optimistic input when the first turn fails", async () => {
+    const directoryKey = "directory:/Users/huntharo/github/PwrAgent";
+    const threadId = "thread-turn-failed";
+    const input = [{ type: "text" as const, text: "Fix the model setting" }];
+    const initialSnapshot = {
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [],
+      directories: [
+        {
+          key: directoryKey,
+          kind: "directory" as const,
+          label: "PwrAgent",
+          path: "/Users/huntharo/github/PwrAgent",
+          threadKeys: [],
+          needsAttentionCount: 0,
+          launchpad: {
+            directoryKey,
+            directoryKind: "directory" as const,
+            directoryLabel: "PwrAgent",
+            directoryPath: "/Users/huntharo/github/PwrAgent",
+            backend: "codex" as const,
+            executionMode: "default" as const,
+            prompt: "Fix the model setting",
+            workMode: "local" as const,
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        },
+      ],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    };
+    const getNavigationSnapshot = vi.fn().mockResolvedValue(initialSnapshot);
+    const materializeDirectoryLaunchpad = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId,
+      executionMode: "default" as const,
+      workMode: "local" as const,
+      turnStartFailure: {
+        message: "invalid model",
+        phase: "turn" as const,
+      },
+    }));
+
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      materializeDirectoryLaunchpad,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.directories[0]?.launchpad?.prompt).toBe(
+        "Fix the model setting"
+      );
+    });
+
+    await act(async () => {
+      await result.current.materializeDirectoryLaunchpad(directoryKey, input);
+    });
+
+    expect(result.current.selectedThread?.id).toBe(threadId);
+    expect(result.current.selectedThread?.optimisticUserMessage).toBeUndefined();
+    expect(result.current.launchpadError).toBe("invalid model");
+  });
+
   it("does not let a materialized thread refresh override a newer user thread selection", async () => {
     const directoryKey = "directory:/Users/huntharo/github/PwrAgent";
     const refreshedSnapshot = createDeferred<Awaited<ReturnType<NonNullable<DesktopApi["getNavigationSnapshot"]>>>>();

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -3580,7 +3580,9 @@ export function useThreadNavigation(
         executionMode: response.executionMode,
         workMode: response.workMode,
         codexEnvironmentRuntime: response.codexEnvironmentRuntime,
-        optimisticUserMessage: buildOptimisticUserMessage(input),
+        optimisticUserMessage: response.turnStartFailure
+          ? undefined
+          : buildOptimisticUserMessage(input),
         parentThreadId: materializeParentThreadId,
       });
       const nextThreadKey = buildThreadIdentityKey(response.backend, response.threadId);
@@ -3595,6 +3597,9 @@ export function useThreadNavigation(
       setOptimisticThread(optimisticMaterializedThread);
       setSelectedItemKey(nextThreadKey);
       setPendingSeenThreadKey(nextThreadKey);
+      if (response.turnStartFailure) {
+        setLaunchpadError(response.turnStartFailure.message);
+      }
       setState((current) => ({
         ...current,
         response: current.response

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -5,6 +5,7 @@ import type {
   AppServerThreadImagePart,
   AppServerThreadMessagePart,
   AppServerThreadSummary,
+  CodexEnvironmentExecutionTarget,
   MessagingDeliveryScope,
   MessagingToolUpdateMode,
   ThreadIdentifier,
@@ -1171,6 +1172,10 @@ export type MessagingBrowseSessionRecord = {
   returnTo?: MessagingBrowseReturnTarget;
   workMode?: LaunchpadWorkMode;
   branchName?: string;
+  codexEnvironmentId?: string | null;
+  codexEnvironmentExecutionTarget?: CodexEnvironmentExecutionTarget;
+  codexEnvironmentSetupEnabled?: boolean;
+  codexEnvironmentActionId?: string;
   selectedProject?: MessagingBrowseSelectedProject;
   surface?: MessagingSurfaceRef;
   textInputExpiresAt?: number;

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -472,10 +472,9 @@ export type MaterializeDirectoryLaunchpadRequest = {
   parentThreadId?: ThreadIdentifier;
 };
 
-export type MaterializeDirectoryLaunchpadResponse = {
+export type MaterializedDirectoryLaunchpadThread = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;
-  turnId?: string;
   executionMode: ThreadExecutionMode;
   linkedDirectory?: LinkedDirectorySummary;
   workMode: LaunchpadWorkMode;
@@ -485,6 +484,19 @@ export type MaterializeDirectoryLaunchpadResponse = {
     phase: "setup" | "action";
     worktreeCleanupAvailable: boolean;
   };
+};
+
+export type MaterializeDirectoryLaunchpadOptions = {
+  onCodexEnvironmentSetupProgress?: (
+    event: CodexEnvironmentSetupProgressEvent,
+  ) => void;
+  onThreadMaterialized?: (
+    thread: MaterializedDirectoryLaunchpadThread,
+  ) => void | Promise<void>;
+};
+
+export type MaterializeDirectoryLaunchpadResponse = MaterializedDirectoryLaunchpadThread & {
+  turnId?: string;
   turnStartFailure?: {
     message: string;
     phase: "turn" | "review";

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -485,6 +485,10 @@ export type MaterializeDirectoryLaunchpadResponse = {
     phase: "setup" | "action";
     worktreeCleanupAvailable: boolean;
   };
+  turnStartFailure?: {
+    message: string;
+    phase: "turn" | "review";
+  };
 };
 
 export type CodexEnvironmentSetupProgressEvent = {


### PR DESCRIPTION
## Summary

- I changed the messaging new-thread launch path so the first prompt is passed into `materializeDirectoryLaunchpad`, matching the desktop launchpad Send flow instead of creating a blank thread and starting a separate messaging turn.
- I added messaging launchpad support for selecting a Codex environment before sending the first prompt, so environment setup can run as part of normal materialization.
- I handled the partial-success case where materialization creates a thread but the first turn fails, binding the created thread to the messaging conversation and surfacing the turn-start error instead of orphaning the thread.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts -t "returns the materialized thread when the first launchpad turn fails"`
- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx -- -t "selects a materialized thread without optimistic input"`
- `pnpm --filter @pwragent/shared typecheck`
- `pnpm --filter @pwragent/messaging-interface typecheck`
- `pnpm lint:boundaries`

## Notes

- I also attempted `pnpm --filter @pwragent/desktop typecheck`, but the desktop TypeScript process stalled with no diagnostics and had to be killed.
- An accidental full `backend-registry.test.ts` run hit an unrelated existing/flaky concurrent environment-action test; the correctly filtered new backend regression passed.
