### PR TITLE
fix(agent-core): never list a thread under more than one directory row

### DIFF
--- a/packages/agent-core/src/__tests__/directory-navigation.test.ts
+++ b/packages/agent-core/src/__tests__/directory-navigation.test.ts
@@ -1074,6 +1074,137 @@ describe("buildDirectorySummaries", () => {
       }),
     ]);
   });
+
+  // The one-row-per-thread invariant. This is platform-independent: on macOS
+  // (all forward slashes) the same thread was surfacing under two/three
+  // "PwrAgnt" parent folders at once, all highlighting as selected. A thread
+  // must appear under exactly one parent directory row no matter how many
+  // distinct rows its linked directories resolve to.
+  it("never lists the same thread under more than one parent directory row", () => {
+    const directories = buildDirectorySummaries({
+      threads: [
+        buildThread({
+          id: "thread-1",
+          createdAt: 1_000,
+          // Two managed worktrees of the same project, different hashes, no
+          // canonical repo path and no shared git origin to remap onto — so
+          // they classify to two distinct rows that cannot be collapsed.
+          linkedDirectories: [
+            {
+              id: "wt-a",
+              label: "PwrAgnt",
+              path: "/Users/huntharo/.codex/worktrees/aaaa/PwrAgnt",
+              kind: "worktree",
+            },
+            {
+              id: "wt-b",
+              label: "PwrAgnt",
+              path: "/Users/huntharo/.codex/worktrees/bbbb/PwrAgnt",
+              kind: "worktree",
+            },
+          ],
+        }),
+      ],
+    });
+
+    const rowsWithThread = directories.filter((directory) =>
+      directory.threadKeys.includes("codex:thread-1"),
+    );
+    expect(rowsWithThread).toHaveLength(1);
+    // Deterministic home: lexicographically smallest key when no row is more
+    // canonical than another.
+    expect(rowsWithThread[0]?.key).toBe(
+      "directory:/Users/huntharo/.codex/worktrees/aaaa/PwrAgnt",
+    );
+  });
+
+  it("homes a thread on its repo row, not an unrelated worktree row", () => {
+    const directories = buildDirectorySummaries({
+      threads: [
+        buildThread({
+          id: "thread-1",
+          createdAt: 1_000,
+          linkedDirectories: [
+            {
+              id: "repo",
+              label: "PwrAgnt",
+              path: "/Users/huntharo/pwrdrvr/PwrAgnt",
+              kind: "local",
+            },
+            {
+              id: "stray-worktree",
+              label: "Other",
+              path: "/Users/huntharo/.codex/worktrees/zzzz/Other",
+              kind: "worktree",
+            },
+          ],
+        }),
+      ],
+    });
+
+    const rowsWithThread = directories.filter((directory) =>
+      directory.threadKeys.includes("codex:thread-1"),
+    );
+    expect(rowsWithThread).toHaveLength(1);
+    expect(rowsWithThread[0]).toEqual(
+      expect.objectContaining({
+        key: "directory:/Users/huntharo/pwrdrvr/PwrAgnt",
+        path: "/Users/huntharo/pwrdrvr/PwrAgnt",
+      }),
+    );
+  });
+
+  it("does not duplicate a worktree thread when the same-label stable repo path is ambiguous", () => {
+    // Reproduces the macOS report (thread surfacing under two parent folders at
+    // once). thread-1 carries a live worktree-rooted directory plus a backfilled
+    // repo relationship. A sibling thread checked out the same project under a
+    // different absolute path, so the per-label stable path is ambiguous and the
+    // worktree descriptor can no longer remap onto the repo — leaving thread-1
+    // with two distinct rows. The invariant must still home it on exactly one.
+    const directories = buildDirectorySummaries({
+      threads: [
+        buildThread({
+          id: "019ea569-b29b-78c3-8b2a-3fc135e4af1f",
+          createdAt: 2_000,
+          linkedDirectories: [
+            {
+              id: "live",
+              label: "PwrAgnt",
+              path: "/Users/huntharo/.codex/worktrees/mq4ow4zb/PwrAgnt",
+              kind: "worktree",
+            },
+            {
+              id: "backfill",
+              label: "PwrAgnt",
+              path: "/Users/huntharo/pwrdrvr/PwrAgnt",
+              worktreePath: "/Users/huntharo/.codex/worktrees/mq4ow4zb/PwrAgnt",
+              kind: "worktree",
+            },
+          ],
+        }),
+        buildThread({
+          id: "sibling",
+          createdAt: 1_000,
+          linkedDirectories: [
+            {
+              id: "sibling-repo",
+              label: "PwrAgnt",
+              path: "/Users/huntharo/pwrdrvr-old/PwrAgnt",
+              kind: "local",
+            },
+          ],
+        }),
+      ],
+    });
+
+    const threadKey = "codex:019ea569-b29b-78c3-8b2a-3fc135e4af1f";
+    const rowsWithThread = directories.filter((directory) =>
+      directory.threadKeys.includes(threadKey),
+    );
+    expect(rowsWithThread).toHaveLength(1);
+    // The repo row (a real checkout) wins over the worktree row.
+    expect(rowsWithThread[0]?.key).toBe("directory:/Users/huntharo/pwrdrvr/PwrAgnt");
+  });
 });
 
 describe("materializeNavigationThreads", () => {

--- a/packages/agent-core/src/__tests__/directory-navigation.test.ts
+++ b/packages/agent-core/src/__tests__/directory-navigation.test.ts
@@ -1118,6 +1118,43 @@ describe("buildDirectorySummaries", () => {
     );
   });
 
+  it("never lists the same thread under more than one parent directory row (Windows paths)", () => {
+    // Same invariant as above, but the linked directories arrive with native
+    // Windows backslashes + a drive letter. classifyDirectory canonicalizes
+    // separators first, so the home selection that follows behaves identically
+    // to POSIX — the thread still lands in exactly one row.
+    const directories = buildDirectorySummaries({
+      threads: [
+        buildThread({
+          id: "thread-1",
+          createdAt: 1_000,
+          linkedDirectories: [
+            {
+              id: "wt-a",
+              label: "PwrAgnt",
+              path: "C:\\Users\\Administrator\\.codex\\worktrees\\aaaa\\PwrAgnt",
+              kind: "worktree",
+            },
+            {
+              id: "wt-b",
+              label: "PwrAgnt",
+              path: "C:\\Users\\Administrator\\.codex\\worktrees\\bbbb\\PwrAgnt",
+              kind: "worktree",
+            },
+          ],
+        }),
+      ],
+    });
+
+    const rowsWithThread = directories.filter((directory) =>
+      directory.threadKeys.includes("codex:thread-1"),
+    );
+    expect(rowsWithThread).toHaveLength(1);
+    expect(rowsWithThread[0]?.key).toBe(
+      "directory:C:/Users/Administrator/.codex/worktrees/aaaa/PwrAgnt",
+    );
+  });
+
   it("homes a thread on its repo row, not an unrelated worktree row", () => {
     const directories = buildDirectorySummaries({
       threads: [

--- a/packages/agent-core/src/__tests__/directory-navigation.test.ts
+++ b/packages/agent-core/src/__tests__/directory-navigation.test.ts
@@ -908,6 +908,99 @@ describe("buildDirectorySummaries", () => {
     ]);
   });
 
+  it("collapses a Windows repo into one row across path-separator representations", () => {
+    // Reproduces the Windows bug where one project surfaced as three "PwrAgent"
+    // rows: the main checkout linked once with forward slashes (how we normalize
+    // codex/git paths) and once with native backslashes, plus a codex worktree
+    // that then couldn't remap onto a now-ambiguous canonical repo path.
+    const directories = buildDirectorySummaries({
+      threads: [
+        buildThread({
+          id: "main-fwd",
+          createdAt: 3_000,
+          linkedDirectories: [
+            {
+              id: "d1",
+              label: "PwrAgent",
+              path: "C:/Users/Administrator/PwrAgent",
+              kind: "local",
+            },
+          ],
+        }),
+        buildThread({
+          id: "main-bak",
+          createdAt: 2_000,
+          linkedDirectories: [
+            {
+              id: "d2",
+              label: "PwrAgent",
+              path: "C:\\Users\\Administrator\\PwrAgent",
+              kind: "local",
+            },
+          ],
+        }),
+        buildThread({
+          id: "worktree",
+          createdAt: 1_000,
+          linkedDirectories: [
+            {
+              id: "d3",
+              label: "PwrAgent",
+              path: "C:\\Users\\Administrator\\.codex\\worktrees\\mq4ow4zb\\PwrAgent",
+              kind: "worktree",
+            },
+          ],
+        }),
+      ],
+    });
+
+    expect(directories).toHaveLength(1);
+    expect(directories[0]).toEqual(
+      expect.objectContaining({
+        key: "directory:C:/Users/Administrator/PwrAgent",
+        label: "PwrAgent",
+        path: "C:/Users/Administrator/PwrAgent",
+      }),
+    );
+    expect(directories[0]?.threadKeys).toHaveLength(3);
+  });
+
+  it("does not duplicate a Windows codex worktree row across separator representations", () => {
+    // One thread linked to the same codex worktree via both forward and back
+    // slashes must surface as a single row, not appear twice.
+    const directories = buildDirectorySummaries({
+      threads: [
+        buildThread({
+          id: "thread-1",
+          createdAt: 1_000,
+          linkedDirectories: [
+            {
+              id: "d-fwd",
+              label: "PwrAgent",
+              path: "C:/Users/Administrator/.codex/worktrees/mq4ow4zb/PwrAgent",
+              kind: "worktree",
+            },
+            {
+              id: "d-bak",
+              label: "PwrAgent",
+              path: "C:\\Users\\Administrator\\.codex\\worktrees\\mq4ow4zb\\PwrAgent",
+              kind: "worktree",
+            },
+          ],
+        }),
+      ],
+    });
+
+    expect(directories).toHaveLength(1);
+    expect(directories[0]).toEqual(
+      expect.objectContaining({
+        key: "directory:C:/Users/Administrator/.codex/worktrees/mq4ow4zb/PwrAgent",
+        label: "PwrAgent",
+      }),
+    );
+    expect(directories[0]?.threadKeys).toEqual(["codex:thread-1"]);
+  });
+
   it("groups PwrAgent-managed worktree paths under the stable same-label home repo row", () => {
     const directories = buildDirectorySummaries({
       threads: [

--- a/packages/agent-core/src/domain/directory-navigation.ts
+++ b/packages/agent-core/src/domain/directory-navigation.ts
@@ -27,9 +27,20 @@ function pathBaseName(value?: string): string {
   return parts.at(-1) ?? normalized;
 }
 
+// Canonicalize a filesystem path for use as a stable navigation identity:
+// forward slashes and no trailing separator. This is what collapses a single
+// logical directory keyed via different representations into ONE row — on
+// Windows the same repo/worktree can arrive as `C:\…` (codex/git native) and as
+// `C:/…` (the forward slashes we normalize codex/git paths to elsewhere), and
+// without this they produce two `directory:` keys → duplicate folders. No-op on
+// already-POSIX paths (no backslashes, no trailing slash).
+function canonicalizeNavigationPath(value: string): string {
+  return value.replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
 function normalizeComparablePath(value?: string): string | undefined {
-  const normalized = value?.trim().replace(/[\\/]+$/, "");
-  return normalized || undefined;
+  const normalized = value?.trim();
+  return normalized ? canonicalizeNavigationPath(normalized) || undefined : undefined;
 }
 
 function normalizeGitOriginUrl(value?: string): string | undefined {
@@ -104,9 +115,14 @@ function matchCodexChatsRoot(value: string): string | undefined {
 }
 
 function classifyDirectory(directory: LinkedDirectorySummary): DirectoryDescriptor {
+  // Canonicalize separators up front so a directory keyed via different path
+  // representations (Windows `C:\…` vs the forward-slashed `C:/…` we normalize
+  // codex/git paths to) collapses to ONE directory row instead of duplicating.
+  const path = canonicalizeNavigationPath(directory.path);
+
   // Match both current ".pwragent" and legacy ".pwragnt" home directory names
   // so pre-rebrand thread data classifies correctly.
-  const scratchProjectsRoot = matchScratchProjectsRoot(directory.path);
+  const scratchProjectsRoot = matchScratchProjectsRoot(path);
   if (scratchProjectsRoot) {
     return {
       key: `workspace:${scratchProjectsRoot}`,
@@ -116,7 +132,7 @@ function classifyDirectory(directory: LinkedDirectorySummary): DirectoryDescript
     };
   }
 
-  const codexChatsRoot = matchCodexChatsRoot(directory.path);
+  const codexChatsRoot = matchCodexChatsRoot(path);
   if (codexChatsRoot) {
     return {
       key: `directory:${codexChatsRoot}`,
@@ -126,7 +142,7 @@ function classifyDirectory(directory: LinkedDirectorySummary): DirectoryDescript
     };
   }
 
-  const repoWorktreeMatch = directory.path.match(
+  const repoWorktreeMatch = path.match(
     /^(.*)[\\/]\.worktrees[\\/][^\\/]+(?:[\\/].*)?$/,
   );
   if (repoWorktreeMatch) {
@@ -139,28 +155,31 @@ function classifyDirectory(directory: LinkedDirectorySummary): DirectoryDescript
     };
   }
 
-  const codexWorktreeMatch = directory.path.match(
-    /^[\\/].*[\\/]\.codex(?:[\\/]profiles[\\/][^\\/]+)?[\\/]worktrees[\\/][^\\/]+[\\/]([^\\/]+)(?:[\\/].*)?$/,
+  // Leading `(?:[A-Za-z]:)?` accepts a Windows drive prefix (C:/…); without it
+  // the `^[\\/]` anchor only matched POSIX-absolute paths and codex worktrees
+  // on Windows fell through to the generic fallback (wrong label, and no
+  // chance to group by project name).
+  const codexWorktreeMatch = path.match(
+    /^(?:[A-Za-z]:)?[\\/].*[\\/]\.codex(?:[\\/]profiles[\\/][^\\/]+)?[\\/]worktrees[\\/][^\\/]+[\\/]([^\\/]+)(?:[\\/].*)?$/,
   );
   if (codexWorktreeMatch) {
-    const canonicalPath = directory.path.replace(/[\\/]+$/, "");
     return {
-      key: `directory:${canonicalPath}`,
+      key: `directory:${path}`,
       kind: "directory",
       label: codexWorktreeMatch[1],
-      path: canonicalPath,
+      path,
     };
   }
 
   return {
-    key: `directory:${directory.path}`,
+    key: `directory:${path}`,
     kind: "directory",
     label: displayDirectoryLabel({
       kind: "directory",
       label: directory.label,
-      path: directory.path,
+      path,
     }),
-    path: directory.path,
+    path,
   };
 }
 

--- a/packages/agent-core/src/domain/directory-navigation.ts
+++ b/packages/agent-core/src/domain/directory-navigation.ts
@@ -266,6 +266,42 @@ function normalizeDirectoryDescriptor(
   };
 }
 
+// INVARIANT: a thread is listed under exactly ONE parent directory row.
+// When a thread's linked directories resolve to multiple distinct rows — e.g.
+// a tool-managed worktree that couldn't be remapped onto its repo (no stable
+// path, no shared git origin), a thread linked to genuinely different repos, or
+// a stale backfilled relationship whose path drifted from the live one — we must
+// NOT add the thread to every row. Doing so makes the same thread appear (and
+// highlight as "selected") under two/three parent folders at once, which the
+// product forbids. Pick a single canonical "home" row instead.
+//
+// Preference order:
+//   1. A stable repo/local/workspace row over an ephemeral tool-managed
+//      worktree row, so the thread groups under its project (the main checkout)
+//      rather than a throwaway worktree folder.
+//   2. Deterministic tiebreak by key, so the choice is stable across snapshots,
+//      backends, and platforms (no flicker between rows on re-render).
+function pickHomeDirectory(
+  descriptors: DirectoryDescriptor[],
+): DirectoryDescriptor | undefined {
+  if (descriptors.length <= 1) {
+    return descriptors[0];
+  }
+
+  return [...descriptors].sort((left, right) => {
+    const leftIsWorktree = left.path
+      ? isToolManagedWorktreePath(left.path)
+      : false;
+    const rightIsWorktree = right.path
+      ? isToolManagedWorktreePath(right.path)
+      : false;
+    if (leftIsWorktree !== rightIsWorktree) {
+      return leftIsWorktree ? 1 : -1;
+    }
+    return left.key.localeCompare(right.key);
+  })[0];
+}
+
 function ensureSummary(
   summaries: Map<string, NavigationDirectorySummary>,
   descriptor: DirectoryDescriptor,
@@ -491,7 +527,11 @@ export function buildDirectorySummaries(params: {
       continue;
     }
 
-    const seenDescriptors = new Set<string>();
+    // Resolve every linked directory to its normalized row descriptor, deduped
+    // by key. A thread linked to the same row via several representations
+    // (repo + its own worktree, forward/back slashes, stale backfill) collapses
+    // to one entry here.
+    const descriptorsByKey = new Map<string, DirectoryDescriptor>();
     for (const directory of thread.linkedDirectories) {
       const descriptor = classifyDirectory(directory);
       const stablePath = stablePathByLabel.get(descriptor.label);
@@ -507,19 +547,28 @@ export function buildDirectorySummaries(params: {
       if (!isAllowedWorkspaceRoot(normalizedDescriptor, allowedWorkspaceRoots)) {
         continue;
       }
-      if (seenDescriptors.has(normalizedDescriptor.key)) {
-        continue;
+      if (!descriptorsByKey.has(normalizedDescriptor.key)) {
+        descriptorsByKey.set(normalizedDescriptor.key, normalizedDescriptor);
       }
-      seenDescriptors.add(normalizedDescriptor.key);
-      const summary = ensureSummary(summaries, normalizedDescriptor);
-      if (!summary.threadKeys.includes(threadKey)) {
-        summary.threadKeys.push(threadKey);
-      }
-      if (thread.inbox.inInbox) {
-        summary.needsAttentionCount += 1;
-      }
-      summary.latestUpdatedAt = Math.max(summary.latestUpdatedAt ?? 0, thread.updatedAt ?? 0);
     }
+
+    // Enforce the one-row-per-thread invariant: even when the descriptors above
+    // resolve to multiple distinct rows, the thread is added to exactly one.
+    const homeDescriptor = pickHomeDirectory([...descriptorsByKey.values()]);
+    if (!homeDescriptor) {
+      continue;
+    }
+    const summary = ensureSummary(summaries, homeDescriptor);
+    if (!summary.threadKeys.includes(threadKey)) {
+      summary.threadKeys.push(threadKey);
+    }
+    if (thread.inbox.inInbox) {
+      summary.needsAttentionCount += 1;
+    }
+    summary.latestUpdatedAt = Math.max(
+      summary.latestUpdatedAt ?? 0,
+      thread.updatedAt ?? 0,
+    );
   }
 
   for (const [directoryKey, launchpad] of Object.entries(params.launchpadsByKey ?? {})) {


### PR DESCRIPTION
## Problem

In the Directories lens, a single thread was showing up under two or three
parent \`PwrAgnt\` folders **at the same time** — all of them highlighting as
"selected", which the user correctly flagged as impossible. First seen on
Windows (a Telegram-started codex worktree thread, id \`019ea569…\`, surfaced in
3 folders), then confirmed on **macOS** too — so it is not a Windows
path-separator quirk.

Invariant being restored (user's words): *we should never list the same thread
twice under different parent directories.*

## Root cause

\`buildDirectorySummaries\` added a thread to **every** distinct directory row its
linked directories resolved to. That's fine when all of a thread's directory
descriptors collapse to one key, but they don't when:

- a tool-managed worktree can't be remapped onto its repo (no per-label stable
  path, no shared git origin), or
- the per-label stable path is **ambiguous** (same project checked out under two
  absolute paths), or
- a backfilled repo relationship drifts from the live worktree-rooted directory, or
- (Windows) the same path arrives as both \`C:\\…\` and \`C:/…\`.

In all of these, the thread got pushed into multiple rows.

## Fix

Two complementary changes in the pure \`agent-core\` navigation domain:

1. **One-row-per-thread invariant (cross-platform).** A thread is now added to
   exactly one "home" directory row. Home selection prefers a stable
   repo/local/workspace row over an ephemeral worktree row (so the thread groups
   under its project, not a throwaway worktree folder) and breaks ties
   deterministically by key (stable across snapshots, backends, platforms). This
   holds no matter which backend/adapter produced the linked directories.
2. **Canonicalize path separators** so a directory keyed via \`C:\\…\` vs \`C:/…\`
   (and trailing-slash variants) collapses to one row instead of duplicating.

## Tests

- New: two same-label worktrees with no canonical repo → one row; repo +
  unrelated worktree → homes on the repo; ambiguous stable path → one row.
  (Each fails on the pre-fix loop.)
- Existing 35 directory-navigation tests still pass (incl. "keeps same-named
  Codex worktrees as separate rows" — different *threads* in separate rows is
  still allowed; only the *same thread* in multiple rows is forbidden).
- Full agent-core suite (195) + desktop navigation tests green.

## Known follow-up (not in this PR)

ACP backends (\`acpSessionToThreadSummary\`) set a linked directory of
\`{ path: session.cwd, kind: "local" }\` — i.e. the **worktree** path, not the
repo, violating the \`LinkedDirectorySummary\` contract. With this PR an ACP
worktree thread is no longer duplicated, but it can still appear in its own
worktree folder rather than grouped under the repo when no other thread supplies
an unambiguous repo path for that label. Resolving the repo for ACP worktree
threads (as the codex enricher already does) is a separate grouping improvement.