### PR TITLE
feat(desktop): make Skip the default messaging-safety action with a gated Continue

### DIFF
--- a/apps/desktop/e2e/onboarding-wizard.spec.ts
+++ b/apps/desktop/e2e/onboarding-wizard.spec.ts
@@ -170,6 +170,11 @@ test.describe("Onboarding wizard", () => {
         name: /Continue with messaging/i,
       });
       await expect(continueBtn).toHaveAttribute("aria-disabled", "true");
+      // Locked Continue points screen readers at the gate requirement.
+      await expect(continueBtn).toHaveAttribute(
+        "aria-describedby",
+        "onboarding-messaging-gate-hint",
+      );
       const flash = app.window.locator(".onboarding-wizard__safety-ack-flash");
       await expect(flash).toHaveCount(0);
 
@@ -184,6 +189,11 @@ test.describe("Onboarding wizard", () => {
       // Tick the acknowledgement card → Continue unlocks.
       await app.window.locator(".onboarding-wizard__safety-ack").click();
       await expect(continueBtn).not.toHaveAttribute("aria-disabled", "true");
+      // Unlocking also drops the screen-reader gate hint.
+      await expect(continueBtn).not.toHaveAttribute(
+        "aria-describedby",
+        "onboarding-messaging-gate-hint",
+      );
 
       // Now Continue advances to the provider picker.
       await continueBtn.click();
@@ -192,6 +202,57 @@ test.describe("Onboarding wizard", () => {
           name: /Pick the messaging platforms you want to connect/i,
         }),
       ).toBeVisible();
+    } finally {
+      await app.close();
+    }
+  });
+
+  test("messaging-safety flash does not replay when navigating back to the step", async () => {
+    const app = await launchElectronApp(wizardLaunchOptions);
+    try {
+      // Walk to the messaging-safety step (same Shared-mode path).
+      await app.window.getByRole("button", { name: /Get started/i }).click();
+      await app.window.getByRole("button", { name: /^Continue/i }).click();
+      await app.window
+        .locator('input[type="password"]')
+        .first()
+        .fill("xai-e2e-test-key");
+      await app.window.getByRole("button", { name: /Use this key/i }).click();
+      await app.window.getByRole("button", { name: /^Continue/i }).click();
+      await app.window
+        .getByText("Reuse your existing Codex login", { exact: false })
+        .click();
+      await app.window.getByRole("button", { name: /^Continue/i }).click();
+      await app.window
+        .getByRole("button", { name: /I.ll log in later/i })
+        .click();
+      await app.window.getByRole("button", { name: /^Continue/i }).click();
+
+      await expect(
+        app.window.getByRole("heading", { name: /Messaging is optional/i }),
+      ).toBeVisible();
+
+      const continueBtn = app.window.getByRole("button", {
+        name: /Continue with messaging/i,
+      });
+      const flash = app.window.locator(".onboarding-wizard__safety-ack-flash");
+
+      // Force a flash (box still unchecked), then leave and return.
+      await continueBtn.click({ force: true });
+      await expect(flash).toHaveCount(1);
+
+      await app.window.getByRole("button", { name: /Back/i }).click();
+      // Back lands on the shared Codex login step (login already deferred,
+      // so its Continue is live); Continue returns to messaging-safety.
+      await app.window.getByRole("button", { name: /^Continue/i }).click();
+      await expect(
+        app.window.getByRole("heading", { name: /Messaging is optional/i }),
+      ).toBeVisible();
+
+      // Re-entry must NOT replay the ring — the box is still unchecked and
+      // the operator never re-clicked the locked button.
+      await expect(flash).toHaveCount(0);
+      await expect(continueBtn).toHaveAttribute("aria-disabled", "true");
     } finally {
       await app.close();
     }

--- a/apps/desktop/e2e/onboarding-wizard.spec.ts
+++ b/apps/desktop/e2e/onboarding-wizard.spec.ts
@@ -139,6 +139,64 @@ test.describe("Onboarding wizard", () => {
     }
   });
 
+  test("messaging-safety gate: locked Continue flashes the ack card, checking it unlocks", async () => {
+    const app = await launchElectronApp(wizardLaunchOptions);
+    try {
+      // Walk to the messaging-safety step (same path as the Shared walk).
+      await app.window.getByRole("button", { name: /Get started/i }).click();
+      await app.window.getByRole("button", { name: /^Continue/i }).click();
+      await app.window
+        .locator('input[type="password"]')
+        .first()
+        .fill("xai-e2e-test-key");
+      await app.window.getByRole("button", { name: /Use this key/i }).click();
+      await app.window.getByRole("button", { name: /^Continue/i }).click();
+      await app.window
+        .getByText("Reuse your existing Codex login", { exact: false })
+        .click();
+      await app.window.getByRole("button", { name: /^Continue/i }).click();
+      await app.window
+        .getByRole("button", { name: /I.ll log in later/i })
+        .click();
+      await app.window.getByRole("button", { name: /^Continue/i }).click();
+
+      await expect(
+        app.window.getByRole("heading", { name: /Messaging is optional/i }),
+      ).toBeVisible();
+
+      // Skip is the default action; Continue starts locked (aria-disabled)
+      // and no flash ring is present yet.
+      const continueBtn = app.window.getByRole("button", {
+        name: /Continue with messaging/i,
+      });
+      await expect(continueBtn).toHaveAttribute("aria-disabled", "true");
+      const flash = app.window.locator(".onboarding-wizard__safety-ack-flash");
+      await expect(flash).toHaveCount(0);
+
+      // Force-click the locked button: it must NOT advance, and it must
+      // mount the attention flash on the acknowledgement card.
+      await continueBtn.click({ force: true });
+      await expect(
+        app.window.getByRole("heading", { name: /Messaging is optional/i }),
+      ).toBeVisible();
+      await expect(flash).toHaveCount(1);
+
+      // Tick the acknowledgement card → Continue unlocks.
+      await app.window.locator(".onboarding-wizard__safety-ack").click();
+      await expect(continueBtn).not.toHaveAttribute("aria-disabled", "true");
+
+      // Now Continue advances to the provider picker.
+      await continueBtn.click();
+      await expect(
+        app.window.getByRole("heading", {
+          name: /Pick the messaging platforms you want to connect/i,
+        }),
+      ).toBeVisible();
+    } finally {
+      await app.close();
+    }
+  });
+
   test("back navigation preserves density selection across Thread presentation ↔ Models", async () => {
     const app = await launchElectronApp(wizardLaunchOptions);
     try {

--- a/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
+++ b/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
@@ -211,6 +211,13 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
       : ["personal", "work"];
   });
   const [acknowledged, setAcknowledged] = useState(false);
+  // Nonce bumped each time the operator clicks "Continue with
+  // messaging" while the acknowledgement box is still unchecked. The
+  // messaging-safety step watches this value and, on every change,
+  // replays a one-shot orange ring around the acknowledgement card —
+  // flashing then fading over 5s — to point the operator at the
+  // checkbox they have to tick before the Continue button unlocks.
+  const [ackFlashNonce, setAckFlashNonce] = useState(0);
   // Buffered secrets (xAI API key + messaging tokens). The wizard
   // collects values in renderer memory rather than writing them
   // through `replaceSecret` on input change. At Finish, the
@@ -503,6 +510,13 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
   const skipMessaging = useCallback(() => {
     setSelectedProviders(new Set());
     setStep("done");
+  }, []);
+
+  // Fired by the footer's "Continue with messaging" button when the
+  // operator clicks it before acknowledging. Bumping the nonce replays
+  // the attention flash on the messaging-safety acknowledgement card.
+  const flashAcknowledgement = useCallback(() => {
+    setAckFlashNonce((nonce) => nonce + 1);
   }, []);
 
   /**
@@ -1050,9 +1064,7 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
             <MessagingSafetyStep
               acknowledged={acknowledged}
               onAcknowledgedChange={setAcknowledged}
-              onSkipMessaging={skipMessaging}
-              onContinue={goNext}
-              submitting={submitting}
+              flashNonce={ackFlashNonce}
               // Multi-profile context: in Multiple / Isolated modes the
               // wizard provisions N profiles and lands the operator
               // inside the first one. Messaging is configured for that
@@ -1130,6 +1142,8 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
           codexProfileModel={codexProfileModel}
           onBack={goPrev}
           onSkip={handleSkip}
+          onSkipMessaging={skipMessaging}
+          onRequestAcknowledge={flashAcknowledgement}
           onNext={goNext}
           onFinish={() => void persistAndComplete()}
         />
@@ -1378,6 +1392,12 @@ function WizardFooter(props: {
   codexProfileModel: DesktopCodexProfileModel;
   onBack: () => void;
   onSkip: () => void;
+  /** messaging-safety: clears provider selection and jumps to Done.
+   *  Distinct from `onSkip` (which exits the wizard entirely). */
+  onSkipMessaging: () => void;
+  /** messaging-safety: replay the attention flash on the
+   *  acknowledgement card when Continue is clicked while unchecked. */
+  onRequestAcknowledge: () => void;
   onNext: () => void;
   onFinish: () => void;
 }) {
@@ -1533,6 +1553,43 @@ function WizardFooter(props: {
       >
         Open my workspace →
       </button>
+    );
+  } else if (props.step === "messaging-safety") {
+    // Skip is the default action (filled accent, far right). Continue
+    // is the deliberate, non-default choice (accent outline, to its
+    // left). Continue is NOT natively `disabled` so it can still take a
+    // click while the box is unchecked — that click flashes the
+    // acknowledgement card instead of advancing, pointing the operator
+    // at the gate. Ticking the box flips it to a live outline button.
+    const continueLocked = !props.acknowledged || props.submitting;
+    primary = (
+      <>
+        <button
+          type="button"
+          className={`onboarding-wizard__btn onboarding-wizard__btn--accent-outline${
+            continueLocked ? " is-soft-disabled" : ""
+          }`}
+          aria-disabled={continueLocked || undefined}
+          onClick={() => {
+            if (props.submitting) return;
+            if (!props.acknowledged) {
+              props.onRequestAcknowledge();
+              return;
+            }
+            props.onNext();
+          }}
+        >
+          Continue with messaging →
+        </button>
+        <button
+          type="button"
+          className="onboarding-wizard__btn onboarding-wizard__btn--primary"
+          disabled={props.submitting}
+          onClick={props.onSkipMessaging}
+        >
+          Skip messaging for now
+        </button>
+      </>
     );
   }
 
@@ -2113,9 +2170,14 @@ function CodexProfileStep(props: {
 function MessagingSafetyStep(props: {
   acknowledged: boolean;
   onAcknowledgedChange: (next: boolean) => void;
-  onSkipMessaging: () => void;
-  onContinue: () => void;
-  submitting: boolean;
+  /**
+   * Counter bumped by the parent every time the operator clicks the
+   * footer's "Continue with messaging" button while still unchecked.
+   * Each change remounts the flash overlay (keyed on this value) so the
+   * one-shot orange ring replays from the top. `0` is the initial value
+   * — no flash on first render.
+   */
+  flashNonce: number;
   /**
    * In Multiple / Isolated modes, identifies the profile messaging
    * will be configured for during this wizard (always the first
@@ -2198,25 +2260,18 @@ function MessagingSafetyStep(props: {
           hold PwrDrvr LLC and all PwrAgent contributors harmless for the
           outcomes of any actions I take here.
         </span>
+        {props.flashNonce > 0 ? (
+          // Keyed on the nonce so each Continue-while-unchecked click
+          // remounts the element and restarts the one-shot flash-then-fade
+          // animation. aria-hidden + pointer-events:none keep it purely
+          // decorative — it never intercepts the checkbox click.
+          <span
+            key={props.flashNonce}
+            className="onboarding-wizard__safety-ack-flash"
+            aria-hidden
+          />
+        ) : null}
       </label>
-      <div className="onboarding-wizard__safety-fork">
-        <button
-          type="button"
-          className="onboarding-wizard__btn onboarding-wizard__btn--ghost"
-          disabled={props.submitting}
-          onClick={props.onSkipMessaging}
-        >
-          Skip messaging for now
-        </button>
-        <button
-          type="button"
-          className="onboarding-wizard__btn onboarding-wizard__btn--primary"
-          disabled={!props.acknowledged || props.submitting}
-          onClick={props.onContinue}
-        >
-          Continue to messaging setup →
-        </button>
-      </div>
       <p className="onboarding-wizard__safety-fork-hint">
         You can always add or change messaging providers later from
         Settings → Messaging.

--- a/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
+++ b/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
@@ -1360,6 +1360,17 @@ function WizardRail(props: {
   );
 }
 
+/** id of the visually-hidden hint that explains why "Continue with
+ *  messaging" is locked. The footer button points at it via
+ *  `aria-describedby` while locked so screen readers announce the gate
+ *  on focus; the messaging-safety step renders the element. */
+const MESSAGING_GATE_HINT_ID = "onboarding-messaging-gate-hint";
+/** Single source of truth for the gate-requirement sentence, shared by
+ *  the `aria-describedby` hint (announced on focus) and the assertive
+ *  live region (announced when the locked button is clicked). */
+const MESSAGING_GATE_REQUIREMENT =
+  'Select the "I understand" checkbox to continue with messaging setup.';
+
 function WizardFooter(props: {
   step: WizardStep;
   submitting: boolean;
@@ -1570,6 +1581,9 @@ function WizardFooter(props: {
             continueLocked ? " is-soft-disabled" : ""
           }`}
           aria-disabled={continueLocked || undefined}
+          aria-describedby={
+            continueLocked ? MESSAGING_GATE_HINT_ID : undefined
+          }
           onClick={() => {
             if (props.submitting) return;
             if (!props.acknowledged) {
@@ -2191,6 +2205,23 @@ function MessagingSafetyStep(props: {
    */
   multiProfileTarget?: { firstProfileName: string; otherProfileNames: readonly string[] };
 }) {
+  // Replay the attention ring ONLY when the parent's nonce actually
+  // changes during this step's lifetime — i.e. the operator clicked the
+  // locked "Continue with messaging" button (the parent bumps the nonce
+  // only while the box is unchecked). Seeding the ref from the nonce
+  // present at mount means returning to this step (Back → forward) with a
+  // stale non-zero nonce does NOT replay the flash. `flashKey` is local
+  // state, so it resets to 0 on unmount; each genuine bump increments it
+  // and remounts both the visual ring and the live-region announcement.
+  const [flashKey, setFlashKey] = useState(0);
+  const lastFlashNonce = useRef(props.flashNonce);
+  useEffect(() => {
+    if (props.flashNonce !== lastFlashNonce.current) {
+      lastFlashNonce.current = props.flashNonce;
+      setFlashKey((key) => key + 1);
+    }
+  }, [props.flashNonce]);
+
   return (
     <div className="onboarding-wizard__safety">
       <div className="onboarding-wizard__safety-icon">
@@ -2260,18 +2291,40 @@ function MessagingSafetyStep(props: {
           hold PwrDrvr LLC and all PwrAgent contributors harmless for the
           outcomes of any actions I take here.
         </span>
-        {props.flashNonce > 0 ? (
-          // Keyed on the nonce so each Continue-while-unchecked click
-          // remounts the element and restarts the one-shot flash-then-fade
-          // animation. aria-hidden + pointer-events:none keep it purely
-          // decorative — it never intercepts the checkbox click.
+        {flashKey > 0 ? (
+          // Keyed on the local flash counter so each genuine
+          // Continue-while-unchecked click remounts the element and
+          // restarts the one-shot flash-then-fade animation. aria-hidden +
+          // pointer-events:none keep it purely decorative — it never
+          // intercepts the checkbox click.
           <span
-            key={props.flashNonce}
+            key={flashKey}
             className="onboarding-wizard__safety-ack-flash"
             aria-hidden
           />
         ) : null}
       </label>
+      {/* Screen-reader affordances for the soft-locked Continue button.
+          The hint (referenced by the footer button's aria-describedby)
+          explains the gate on focus; the assertive live region mirrors the
+          visual flash by announcing the same requirement when the locked
+          button is clicked. The inner span is keyed on flashKey so a
+          repeat click replaces the text node and forces re-announcement. */}
+      <span
+        id={MESSAGING_GATE_HINT_ID}
+        className="onboarding-wizard__visually-hidden"
+      >
+        {MESSAGING_GATE_REQUIREMENT}
+      </span>
+      <span
+        role="status"
+        aria-live="assertive"
+        className="onboarding-wizard__visually-hidden"
+      >
+        {flashKey > 0 ? (
+          <span key={flashKey}>{MESSAGING_GATE_REQUIREMENT}</span>
+        ) : null}
+      </span>
       <p className="onboarding-wizard__safety-fork-hint">
         You can always add or change messaging providers later from
         Settings → Messaging.

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -11908,6 +11908,23 @@ textarea,
   border-color: var(--accent-border);
   color: var(--text-primary);
 }
+/* Non-default accent action: orange outline, transparent fill. Pairs
+   with an adjacent --primary button as the deliberate alternative. */
+.onboarding-wizard__btn--accent-outline {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: transparent;
+}
+.onboarding-wizard__btn--accent-outline:hover:not(.is-soft-disabled) {
+  background: var(--accent-soft);
+}
+/* Looks disabled but stays clickable: a click in this state replays
+   the acknowledgement flash instead of advancing. Not the native
+   `disabled` attribute, which would swallow the click. */
+.onboarding-wizard__btn--accent-outline.is-soft-disabled {
+  border-color: color-mix(in srgb, var(--accent) 40%, transparent);
+  color: color-mix(in srgb, var(--accent) 55%, var(--text-muted));
+}
 .onboarding-wizard__btn--link {
   color: var(--text-muted);
   padding: 8px 6px;
@@ -12501,6 +12518,7 @@ textarea,
   color: var(--text-primary);
 }
 .onboarding-wizard__safety-ack {
+  position: relative;
   background: var(--bg-panel-elevated);
   border: 1px solid var(--border-subtle);
   border-radius: 10px;
@@ -12511,6 +12529,47 @@ textarea,
   align-items: flex-start;
   width: 100%;
   cursor: pointer;
+}
+/* One-shot attention ring replayed when the operator clicks the
+   locked "Continue with messaging" button before ticking the box.
+   Snaps to full opacity (the flash) then eases away to nothing over
+   5s, leaving an inert opacity:0 overlay until the next replay. */
+.onboarding-wizard__safety-ack-flash {
+  position: absolute;
+  inset: -3px;
+  border-radius: 13px;
+  pointer-events: none;
+  box-shadow:
+    0 0 0 2px var(--accent),
+    0 0 14px 2px color-mix(in srgb, var(--accent) 55%, transparent);
+  opacity: 0;
+  animation: onboardingAckFlash 5s ease-out forwards;
+}
+@keyframes onboardingAckFlash {
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  /* Hold a steady ring for the same window, then drop it — no fade
+     motion, just a non-animated appear/disappear. */
+  .onboarding-wizard__safety-ack-flash {
+    animation: onboardingAckFlashReduced 5s steps(1, end) forwards;
+  }
+  @keyframes onboardingAckFlashReduced {
+    0% {
+      opacity: 1;
+    }
+    99% {
+      opacity: 1;
+    }
+    100% {
+      opacity: 0;
+    }
+  }
 }
 .onboarding-wizard__safety-ack.is-checked {
   border-color: var(--accent-border);
@@ -12547,18 +12606,6 @@ textarea,
 }
 .onboarding-wizard__safety-ack-text strong {
   color: var(--text-primary);
-}
-.onboarding-wizard__safety-fork {
-  display: flex;
-  gap: 12px;
-  width: 100%;
-  margin-top: 4px;
-  justify-content: space-between;
-  align-items: center;
-  flex-wrap: wrap;
-}
-.onboarding-wizard__safety-fork .onboarding-wizard__btn--primary {
-  margin-left: auto;
 }
 .onboarding-wizard__safety-fork-hint {
   font: 400 12px/1.5 var(--font-sans, sans-serif);

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -11918,12 +11918,14 @@ textarea,
 .onboarding-wizard__btn--accent-outline:hover:not(.is-soft-disabled) {
   background: var(--accent-soft);
 }
-/* Looks disabled but stays clickable: a click in this state replays
-   the acknowledgement flash instead of advancing. Not the native
-   `disabled` attribute, which would swallow the click. */
+/* Reads as not-yet-active but stays legible and clickable: a click in
+   this state replays the acknowledgement flash instead of advancing. Not
+   the native `disabled` attribute, which would swallow the click. Kept
+   below the full-strength outline (100% accent) so the locked vs. live
+   distinction stays visible, but dimmed only enough to signal "gated." */
 .onboarding-wizard__btn--accent-outline.is-soft-disabled {
-  border-color: color-mix(in srgb, var(--accent) 40%, transparent);
-  color: color-mix(in srgb, var(--accent) 55%, var(--text-muted));
+  border-color: color-mix(in srgb, var(--accent) 60%, transparent);
+  color: color-mix(in srgb, var(--accent) 78%, var(--text-muted));
 }
 .onboarding-wizard__btn--link {
   color: var(--text-muted);


### PR DESCRIPTION
## Summary

- Reworks the first-run wizard's **Step 4 — Messaging — Before you connect** screen so its actions live in the footer bottom row, matching the Step 3 / other-step layout instead of floating mid-page.
- **Skip messaging for now** is now the default action: filled-orange (`--primary`), far right.
- **Continue with messaging →** sits to its left as a non-default, orange-outlined button (new `--accent-outline` button variant).
- Continue is gated on the "I understand" acknowledgement checkbox. It stays *clickable* while unchecked (uses `aria-disabled` + a soft-disabled look rather than the native `disabled` attribute, which would swallow the click). Clicking it while unchecked does **not** advance — instead it flashes a one-shot orange ring around the acknowledgement card (snaps to full opacity, then fades over 5s) to draw attention to the gate. Ticking the box flips Continue to a live, full-strength outline button that advances to the provider picker.

## Verification

- `pnpm --filter @pwragent/desktop typecheck` — clean.
- `pnpm lint:colors` (renderer color lint) — passed; new CSS uses only `var(--token)` / `color-mix(...)` with tokens.
- `pnpm --filter @pwragent/desktop build` — succeeds.
- Onboarding E2E suite (`e2e/onboarding-wizard.spec.ts`) — **8/8 pass**, including a new gate test asserting: locked Continue starts `aria-disabled` with no ring; force-clicking it stays on the step and mounts the flash overlay; ticking the box clears `aria-disabled`; Continue then advances to the provider picker.
- Visually verified all four states during development (locked, flash, mid-fade, checked/unlocked) via screenshots.

## Notes

- A `prefers-reduced-motion` variant holds a static ring for the same 5s window instead of animating the fade.
- The flash overlay is keyed on a nonce so repeated locked-clicks restart the animation; it's `aria-hidden` + `pointer-events: none`, so it never intercepts the checkbox click.
- Removed the now-dead `.onboarding-wizard__safety-fork` CSS rules (the in-body button row); the `…-fork-hint` helper text is kept.
- No behavior change to "Skip messaging for now" — same label and same `skipMessaging` → Done flow, so existing E2E specs that click it still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
