### PR TITLE
fix(tests): harden Windows-flaky env-action cleanup and messaging-runtime timeout

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -614,6 +614,38 @@ function createOverlayStoreMock(params?: {
   } as unknown as OverlayStoreLike;
 }
 
+/**
+ * Detach-mode env actions resolve on spawn and `unref()` the child, so the
+ * spawned process (the shell plus any grandchild it launches) keeps holding
+ * its `cwd` directory handle after `runCodexEnvironmentAction` returns. On
+ * Windows that open handle blocks the temp-dir cleanup with
+ * `EBUSY: resource busy or locked, rmdir` until the process fully exits —
+ * POSIX can unlink a directory that still has open handles, Windows cannot.
+ *
+ * Waiting for the action's output *file* is not sufficient: it is written
+ * while the child is still alive. The detached-exit handler flips the run's
+ * status to a terminal value ("exited"/"failed") once the child's `close`
+ * event fires, so gate temp-dir cleanup on that terminal status — the same
+ * pattern the concurrent-runs test uses — to guarantee the process is gone
+ * before we remove its working directory. The `rm` retry options remain as a
+ * backstop for Windows' lazy post-exit handle release.
+ */
+async function waitForDetachedActionRunToExit(
+  overlayStore: OverlayStoreLike,
+  params: { backend: "codex" | "grok"; threadId: string; actionId: string },
+): Promise<void> {
+  await expectEventually(async () => {
+    const overlay = await overlayStore.getThreadOverlayState({
+      backend: params.backend,
+      threadId: params.threadId,
+    });
+    const run = overlay?.codexEnvironmentRuntime?.actionRuns?.find(
+      (candidate) => candidate.actionId === params.actionId,
+    );
+    return run?.status === "exited" || run?.status === "failed";
+  }, true);
+}
+
 class MockBackendClient {
   private readonly listeners = new Set<
     (notification: AppServerNotification) => void | Promise<void>
@@ -7161,6 +7193,13 @@ command = '''printf action-ran > ${shellOutputPath}'''
         },
       });
       await expectEventually(async () => await readFile(outputPath, "utf8"), "action-ran");
+      // Gate cleanup on the detached child fully exiting (see helper) so the
+      // temp dir it spawned into is no longer locked when we remove it.
+      await waitForDetachedActionRunToExit(overlayStore, {
+        backend: "codex",
+        threadId: "thread-1",
+        actionId: "dev-messaging",
+      });
     } finally {
       await registry.close();
       await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
@@ -7258,6 +7297,13 @@ command = '''printf action-ran > ${shellOutputPath}'''
           cwd: worktreePath,
         },
       });
+      // Gate cleanup on the detached child fully exiting (see helper) so the
+      // worktree dir it ran in is no longer locked when we remove it.
+      await waitForDetachedActionRunToExit(overlayStore, {
+        backend: "codex",
+        threadId: "thread-1",
+        actionId: "capture-cwd",
+      });
     } finally {
       await registry.close();
       await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
@@ -7343,6 +7389,13 @@ command = '''printf action-ran > ${shellOutputPath}'''
           ),
         (await realpath(localPath)).replace(/\\/g, "/"),
       );
+      // Gate cleanup on the detached child fully exiting (see helper) so the
+      // dir it ran in is no longer locked when we remove it.
+      await waitForDetachedActionRunToExit(overlayStore, {
+        backend: "codex",
+        threadId: "thread-1",
+        actionId: "capture-cwd",
+      });
     } finally {
       await registry.close();
       await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -86,7 +86,14 @@ describe("DesktopMessagingRuntime", () => {
     expect(adapter.delivered.at(-1)).toMatchObject({
       kind: "thread_picker",
     });
-  }, 15_000);
+    // This integration-style startup test imports the runtime module graph and
+    // exercises the full adapter-start + inbound-routing path. On the slow
+    // shared Windows CI runner that cold path can exceed 15s — not a hang, just
+    // slow. An explicit per-test timeout overrides the workspace default
+    // (30_000 on Windows; see vitest.workspace.ts), so the previous 15_000 was
+    // actively capping the budget below that default. Match the Windows default
+    // so the test gets the same headroom every other desktop-main test has.
+  }, 30_000);
 
   it("rehydrates enabled Monitor bindings after adapter startup", async () => {
     const { runtime, adapter } = await createRuntimeHarness();

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -89,11 +89,11 @@ describe("DesktopMessagingRuntime", () => {
     // This integration-style startup test imports the runtime module graph and
     // exercises the full adapter-start + inbound-routing path. On the slow
     // shared Windows CI runner that cold path can exceed 15s — not a hang, just
-    // slow. An explicit per-test timeout overrides the workspace default
-    // (30_000 on Windows; see vitest.workspace.ts), so the previous 15_000 was
-    // actively capping the budget below that default. Match the Windows default
-    // so the test gets the same headroom every other desktop-main test has.
-  }, 30_000);
+    // slow — so Windows gets the workspace default headroom (30_000; see
+    // vitest.workspace.ts). Other platforms keep the original tighter 15_000
+    // budget where the cold path is comfortably fast, so a genuine hang or
+    // regression there still fails fast instead of idling for the full 30s.
+  }, process.platform === "win32" ? 30_000 : 15_000);
 
   it("rehydrates enabled Monitor bindings after adapter startup", async () => {
     const { runtime, adapter } = await createRuntimeHarness();

--- a/packages/agent-core/src/testing/test-harness.ts
+++ b/packages/agent-core/src/testing/test-harness.ts
@@ -129,7 +129,21 @@ export async function createTemporaryTestDirectory(): Promise<{
   return {
     path: tempPath,
     cleanup: async () => {
-      await fs.rm(tempPath, { recursive: true, force: true });
+      // Tests that start a thread with a cwd inside this temp dir spawn
+      // short-lived git/shell subprocesses (e.g. the directory enricher) whose
+      // working-directory handle Windows releases lazily — a few milliseconds
+      // *after* the process has already exited. The awaited operations
+      // guarantee the process is gone by the time we clean up, but on Windows
+      // that lingering handle still blocks `rmdir` with `EBUSY` on the first
+      // attempt. POSIX can unlink a directory with open handles; Windows
+      // cannot. The retry/backoff is the backstop for that post-exit window —
+      // a no-op on POSIX, where the first `rm` already succeeds.
+      await fs.rm(tempPath, {
+        recursive: true,
+        force: true,
+        maxRetries: 5,
+        retryDelay: 100,
+      });
     },
   };
 }


### PR DESCRIPTION
## Problem

The **Windows (build + test)** job in `.github/workflows/ci.yml` intermittently failed on three `desktop-main` tests. They pass on macOS/Linux and pass on Windows re-run, so they were environmental (file-lock races + a too-tight per-test timeout), not logic bugs — but they forced manual re-runs.

Observed failures (CI run 27132776394):

- `backend-registry.test.ts › "refreshes stale thread environment actions before running a command"` — `EBUSY: resource busy or locked, rmdir '…\pwragent-thread-env-run-XXXX'`
- `backend-registry.test.ts › "runs existing-thread environment actions from the current worktree directory"` — `EBUSY: … rmdir '…\pwragent-thread-env-worktree-XXXX\worktree'`
- `messaging-runtime.test.ts › "starts configured adapters and routes inbound events through channel controllers"` — `Test timed out in 15000ms.`

## Root cause

**EBUSY (#1/#2).** Detach-mode env actions resolve on `spawn` and `unref()` the child, so the spawned process (the shell + any grandchild) keeps holding its `cwd` directory handle after `runCodexEnvironmentAction` returns. These tests only waited for the action's output *file* — which is written **while the child is still alive** — then removed the temp dir. On Windows the open `cwd` handle blocks `rmdir` with `EBUSY` (POSIX can unlink a directory with open handles; Windows cannot). The `rm` retry options (`maxRetries`/`retryDelay`) already present in these tests cannot cover a child that is genuinely *still running*.

**Timeout (#3).** The `desktop-main` vitest project already grants `testTimeout: 30_000` on Windows (`vitest.workspace.ts`), but this test carried an explicit `}, 15_000)` per-test timeout that overrode the workspace default **downward** — hence the failure at exactly 15000ms. It's slow (cold module-graph import + full adapter-start path on the slow shared runner), not hung.

## Fix

- **Deterministic child-exit gate.** Added a shared `waitForDetachedActionRunToExit` helper that polls the overlay until the run reaches a terminal status (`exited`/`failed`) — which the detached-exit handler sets once the child's `close` event fires (process fully exited). This is the same pattern the existing concurrent-runs test already uses. Applied it before temp-dir cleanup in **all three** detached-action temp-dir tests: the two reported, plus the latent `local after worktree handoff back` twin that shares the identical race. The existing `rm({ …, maxRetries: 5, retryDelay: 100 })` stays as a backstop for Windows' lazy *post-exit* handle release.
- **Timeout.** Raised the messaging-runtime startup test's explicit timeout `15_000 → 30_000` to match the Windows workspace default.

No assertions weakened, no tests skipped, no `severity: ignore` added. Test-only change.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/main/__tests__/messaging-runtime.test.ts` → **264 passed**. The new gates would time out and fail if the run status never reached `exited`, so the green run confirms the deterministic signal works.
- `pnpm --filter @pwragent/desktop typecheck` → clean.
- The `EBUSY` path only reproduces on the Windows CI runner — the real signal is the **Windows (build + test)** job on this PR.

Refs: `docs/plans/AGENTS.md` (plan-doc rules — no plan files touched), `.github/workflows/README.md` (no CI label needed; the Windows build+test job runs by default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)