### PR TITLE
fix(desktop): group ACP worktree threads under their repository row

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1241,6 +1241,9 @@ function createKimiAcpRegistry(options?: {
   codexClient?: MockBackendClient;
   codexEnvironmentCommandRunner?: CodexEnvironmentCommandRunner;
   gitDirectoryService?: unknown;
+  acpDirectoryEnricher?: (
+    projectKey?: string,
+  ) => Promise<{ linkedDirectories: AppServerThreadSummary["linkedDirectories"] }>;
 }) {
   const acpBackendId = options?.acpBackendId ?? ("acp:kimi" as AcpBackendId);
   const sessions = options?.sessions ?? [];
@@ -1307,6 +1310,7 @@ function createKimiAcpRegistry(options?: {
     createAcpClient: () => acpClient,
     codexEnvironmentCommandRunner: options?.codexEnvironmentCommandRunner,
     gitDirectoryService: options?.gitDirectoryService as never,
+    acpDirectoryEnricher: options?.acpDirectoryEnricher,
   });
   return {
     acpBackendId,
@@ -15302,5 +15306,96 @@ command = "pnpm dev"
 
       await registry.close();
     });
+  });
+});
+
+describe("DesktopBackendRegistry — ACP worktree directory grouping", () => {
+  const acpBackendId = "acp:kimi" as AcpBackendId;
+  const worktreeCwd = "/Users/me/.codex/worktrees/abcd/PwrAgnt";
+  const repoPath = "/Users/me/pwrdrvr/PwrAgnt";
+
+  function acpSessionWithCwd(cwd: string): AcpSessionMetadata {
+    return {
+      backendId: acpBackendId,
+      sessionId: "s1",
+      title: "ACP session",
+      cwd,
+      createdAt: 1000,
+      updatedAt: 1000,
+      executionMode: "default",
+      status: "idle",
+    };
+  }
+
+  it("resolves a managed-worktree ACP thread onto its repository checkout", async () => {
+    // ACP sessions only know their cwd; for a worktree cwd we enrich it to a
+    // repo-rooted linked directory so the thread groups under the repo row
+    // (path = repo, worktreePath = cwd) instead of getting its own folder.
+    const enricher = vi.fn(async () => ({
+      linkedDirectories: [
+        {
+          id: repoPath,
+          label: "PwrAgnt",
+          path: repoPath,
+          worktreePath: worktreeCwd,
+          kind: "worktree" as const,
+        },
+      ],
+    }));
+    const { registry } = createKimiAcpRegistry({
+      acpBackendId,
+      sessionId: "s1",
+      sessions: [acpSessionWithCwd(worktreeCwd)],
+      acpDirectoryEnricher: enricher,
+    });
+
+    const threads = await registry.listThreads({ backend: acpBackendId });
+
+    expect(enricher).toHaveBeenCalledWith(worktreeCwd);
+    expect(threads[0]?.linkedDirectories).toEqual([
+      {
+        id: repoPath,
+        label: "PwrAgnt",
+        path: repoPath,
+        worktreePath: worktreeCwd,
+        kind: "worktree",
+      },
+    ]);
+  });
+
+  it("does not enrich a plain local ACP thread's directory", async () => {
+    const enricher = vi.fn(async () => ({ linkedDirectories: [] }));
+    const { registry } = createKimiAcpRegistry({
+      acpBackendId,
+      sessionId: "s1",
+      sessions: [acpSessionWithCwd(repoPath)],
+      acpDirectoryEnricher: enricher,
+    });
+
+    const threads = await registry.listThreads({ backend: acpBackendId });
+
+    expect(enricher).not.toHaveBeenCalled();
+    expect(threads[0]?.linkedDirectories).toEqual([
+      { id: repoPath, label: "PwrAgnt", path: repoPath, kind: "local" },
+    ]);
+  });
+
+  it("keeps the session directory when worktree enrichment yields nothing", async () => {
+    // A vanished/unresolvable worktree must not drop the thread to "unlinked";
+    // fall back to the session's own cwd-rooted directory.
+    const enricher = vi.fn(async () => ({ linkedDirectories: [] }));
+    const { registry } = createKimiAcpRegistry({
+      acpBackendId,
+      sessionId: "s1",
+      sessions: [acpSessionWithCwd(worktreeCwd)],
+      acpDirectoryEnricher: enricher,
+    });
+
+    const threads = await registry.listThreads({ backend: acpBackendId });
+
+    expect(enricher).toHaveBeenCalledWith(worktreeCwd);
+    expect(threads[0]?.linkedDirectories).toEqual([
+      { id: worktreeCwd, label: "PwrAgnt", path: worktreeCwd, kind: "local" },
+    ]);
   });
 });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -21,6 +21,7 @@ import type {
   BackendAcpSessionRuntimeState,
   BackendRateLimitSummary,
   CodexThreadEnvironmentRuntime,
+  LinkedDirectorySummary,
   NavigationLaunchpadDefaults,
   NavigationLaunchpadDraft,
   ThreadExecutionMode,
@@ -218,6 +219,29 @@ function createOverlayStoreMock(params?: {
     }) => overlays.get(`${backend}:${threadId}`),
     getThreadOverlayStates: async ({ threadIds }: { threadIds: string[] }) =>
       Object.fromEntries(threadIds.map((threadId) => [threadId, overlays.get(`codex:${threadId}`)])),
+    setAcpWorktreeDirectory: async ({
+      backend,
+      threadId,
+      cwd,
+      directory,
+    }: {
+      backend: string;
+      threadId: string;
+      cwd: string;
+      directory: LinkedDirectorySummary;
+    }) => {
+      const key = `${backend}:${threadId}`;
+      const next = {
+        ...overlays.get(key),
+        backend,
+        threadId,
+        executionMode: overlays.get(key)?.executionMode ?? "default",
+        extraLinkedDirectories: overlays.get(key)?.extraLinkedDirectories ?? [],
+        acpWorktreeDirectory: { cwd, directory },
+      } as ThreadOverlayState;
+      overlays.set(key, next);
+      return next;
+    },
     persistThreadUsageActivity: async ({
       backend,
       threadId,
@@ -1241,9 +1265,9 @@ function createKimiAcpRegistry(options?: {
   codexClient?: MockBackendClient;
   codexEnvironmentCommandRunner?: CodexEnvironmentCommandRunner;
   gitDirectoryService?: unknown;
-  acpDirectoryEnricher?: (
-    projectKey?: string,
-  ) => Promise<{ linkedDirectories: AppServerThreadSummary["linkedDirectories"] }>;
+  acpWorktreeRepositoryResolver?: (
+    cwd: string,
+  ) => Promise<LinkedDirectorySummary | undefined>;
 }) {
   const acpBackendId = options?.acpBackendId ?? ("acp:kimi" as AcpBackendId);
   const sessions = options?.sessions ?? [];
@@ -1310,7 +1334,7 @@ function createKimiAcpRegistry(options?: {
     createAcpClient: () => acpClient,
     codexEnvironmentCommandRunner: options?.codexEnvironmentCommandRunner,
     gitDirectoryService: options?.gitDirectoryService as never,
-    acpDirectoryEnricher: options?.acpDirectoryEnricher,
+    acpWorktreeRepositoryResolver: options?.acpWorktreeRepositoryResolver,
   });
   return {
     acpBackendId,
@@ -15314,6 +15338,14 @@ describe("DesktopBackendRegistry — ACP worktree directory grouping", () => {
   const worktreeCwd = "/Users/me/.codex/worktrees/abcd/PwrAgnt";
   const repoPath = "/Users/me/pwrdrvr/PwrAgnt";
 
+  const resolvedDirectory: LinkedDirectorySummary = {
+    id: repoPath,
+    label: "PwrAgnt",
+    path: repoPath,
+    worktreePath: worktreeCwd,
+    kind: "worktree",
+  };
+
   function acpSessionWithCwd(cwd: string): AcpSessionMetadata {
     return {
       backendId: acpBackendId,
@@ -15327,73 +15359,101 @@ describe("DesktopBackendRegistry — ACP worktree directory grouping", () => {
     };
   }
 
-  it("resolves a managed-worktree ACP thread onto its repository checkout", async () => {
-    // ACP sessions only know their cwd; for a worktree cwd we enrich it to a
-    // repo-rooted linked directory so the thread groups under the repo row
-    // (path = repo, worktreePath = cwd) instead of getting its own folder.
-    const enricher = vi.fn(async () => ({
-      linkedDirectories: [
-        {
-          id: repoPath,
-          label: "PwrAgnt",
-          path: repoPath,
-          worktreePath: worktreeCwd,
-          kind: "worktree" as const,
-        },
-      ],
-    }));
+  it("resolves a managed-worktree ACP thread onto its repository checkout and caches it", async () => {
+    // ACP sessions only know their cwd. For a worktree cwd we follow the
+    // worktree's `.git` link (filesystem only, no git process) to a repo-rooted
+    // linked directory so the thread groups under the repo row (path = repo,
+    // worktreePath = cwd) instead of getting its own folder — then persist the
+    // result on the overlay so it is never re-resolved.
+    const resolver = vi.fn(async () => resolvedDirectory);
+    const overlayStore = createOverlayStoreMock();
+    const setSpy = vi.spyOn(overlayStore, "setAcpWorktreeDirectory");
     const { registry } = createKimiAcpRegistry({
       acpBackendId,
       sessionId: "s1",
       sessions: [acpSessionWithCwd(worktreeCwd)],
-      acpDirectoryEnricher: enricher,
+      overlayStore,
+      acpWorktreeRepositoryResolver: resolver,
     });
 
     const threads = await registry.listThreads({ backend: acpBackendId });
 
-    expect(enricher).toHaveBeenCalledWith(worktreeCwd);
-    expect(threads[0]?.linkedDirectories).toEqual([
-      {
-        id: repoPath,
-        label: "PwrAgnt",
-        path: repoPath,
-        worktreePath: worktreeCwd,
-        kind: "worktree",
-      },
-    ]);
+    expect(resolver).toHaveBeenCalledWith(worktreeCwd);
+    expect(threads[0]?.linkedDirectories).toEqual([resolvedDirectory]);
+    expect(setSpy).toHaveBeenCalledWith({
+      backend: acpBackendId,
+      threadId: "s1",
+      cwd: worktreeCwd,
+      directory: resolvedDirectory,
+    });
   });
 
-  it("does not enrich a plain local ACP thread's directory", async () => {
-    const enricher = vi.fn(async () => ({ linkedDirectories: [] }));
+  it("reuses the cached resolution from the overlay without touching the filesystem", async () => {
+    // The repo↔worktree mapping is immutable, so a thread that already carries
+    // a cached `acpWorktreeDirectory` for its cwd must short-circuit the
+    // resolver entirely.
+    const resolver = vi.fn(async () => resolvedDirectory);
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "acp:kimi:s1": {
+          backend: acpBackendId,
+          threadId: "s1",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          acpWorktreeDirectory: { cwd: worktreeCwd, directory: resolvedDirectory },
+        },
+      },
+    });
+    const { registry } = createKimiAcpRegistry({
+      acpBackendId,
+      sessionId: "s1",
+      sessions: [acpSessionWithCwd(worktreeCwd)],
+      overlayStore,
+      acpWorktreeRepositoryResolver: resolver,
+    });
+
+    const threads = await registry.listThreads({ backend: acpBackendId });
+
+    expect(resolver).not.toHaveBeenCalled();
+    expect(threads[0]?.linkedDirectories).toEqual([resolvedDirectory]);
+  });
+
+  it("does not resolve a plain local ACP thread's directory", async () => {
+    const resolver = vi.fn(async () => resolvedDirectory);
     const { registry } = createKimiAcpRegistry({
       acpBackendId,
       sessionId: "s1",
       sessions: [acpSessionWithCwd(repoPath)],
-      acpDirectoryEnricher: enricher,
+      acpWorktreeRepositoryResolver: resolver,
     });
 
     const threads = await registry.listThreads({ backend: acpBackendId });
 
-    expect(enricher).not.toHaveBeenCalled();
+    expect(resolver).not.toHaveBeenCalled();
     expect(threads[0]?.linkedDirectories).toEqual([
       { id: repoPath, label: "PwrAgnt", path: repoPath, kind: "local" },
     ]);
   });
 
-  it("keeps the session directory when worktree enrichment yields nothing", async () => {
+  it("keeps the session directory when the worktree cannot be resolved and does not cache the miss", async () => {
     // A vanished/unresolvable worktree must not drop the thread to "unlinked";
-    // fall back to the session's own cwd-rooted directory.
-    const enricher = vi.fn(async () => ({ linkedDirectories: [] }));
+    // fall back to the session's own cwd-rooted directory and leave the miss
+    // uncached so a later refresh retries cheaply.
+    const resolver = vi.fn(async () => undefined);
+    const overlayStore = createOverlayStoreMock();
+    const setSpy = vi.spyOn(overlayStore, "setAcpWorktreeDirectory");
     const { registry } = createKimiAcpRegistry({
       acpBackendId,
       sessionId: "s1",
       sessions: [acpSessionWithCwd(worktreeCwd)],
-      acpDirectoryEnricher: enricher,
+      overlayStore,
+      acpWorktreeRepositoryResolver: resolver,
     });
 
     const threads = await registry.listThreads({ backend: acpBackendId });
 
-    expect(enricher).toHaveBeenCalledWith(worktreeCwd);
+    expect(resolver).toHaveBeenCalledWith(worktreeCwd);
+    expect(setSpy).not.toHaveBeenCalled();
     expect(threads[0]?.linkedDirectories).toEqual([
       { id: worktreeCwd, label: "PwrAgnt", path: worktreeCwd, kind: "local" },
     ]);

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -156,6 +156,10 @@ import type { ProtocolCaptureStore } from "../testing/capture-store";
 import { createReplayClientsFromEnv } from "../testing/replay-runtime";
 import { GitDirectoryService } from "./git-directory-service";
 import type { DirectoryGitStatusEntry } from "./git-directory-service";
+import {
+  createThreadDirectoryEnricher,
+  type ThreadDirectoryEnrichment,
+} from "./thread-directory-enricher";
 import { GitWorkspaceHandoffService } from "./git-workspace-handoff-service";
 import { WorktreeArchiveService } from "./worktree-archive-service";
 import { getDesktopMessagingStore } from "../messaging/desktop-messaging-store";
@@ -2431,6 +2435,15 @@ export class DesktopBackendRegistry {
   private readonly gitWorkspaceHandoffService: GitWorkspaceHandoffService;
   private readonly worktreeArchiveService: WorktreeArchiveService;
   private readonly acpBackend: AcpBackendAdapter;
+  // Resolves a managed-worktree ACP cwd to its repository checkout so ACP
+  // (e.g. Grok) worktree threads group under the same directory row as their
+  // repo, exactly like Codex threads do. Codex backends carry a repo-rooted
+  // linked directory from their own enricher; ACP sessions only know their cwd,
+  // so without this every ACP worktree session lands in its own folder. Cached
+  // (per cwd, short TTL) inside the enricher. Injectable for deterministic tests.
+  private readonly acpDirectoryEnricher: (
+    projectKey?: string,
+  ) => Promise<ThreadDirectoryEnrichment>;
   private readonly messagingStore?: MessagingArchiveCleanupStore | null;
   private messagingArchiveCleaner?: MessagingArchiveCleaner | null;
   private readonly archivedMessagingCleanupInFlight = new Map<
@@ -2583,6 +2596,9 @@ export class DesktopBackendRegistry {
     threadTitleGenerationService?: ThreadTitleService | null;
     isCodexBootstrapDeferred?: () => boolean;
     isBootstrapMode?: () => boolean;
+    acpDirectoryEnricher?: (
+      projectKey?: string,
+    ) => Promise<ThreadDirectoryEnrichment>;
   }) {
     const replayClients = createReplayClientsFromEnv();
     const codexCapture = options?.codexClient
@@ -2667,6 +2683,8 @@ export class DesktopBackendRegistry {
         apiKey: grokApiKey,
         connectionObserver: grokObserver,
       });
+    this.acpDirectoryEnricher =
+      options?.acpDirectoryEnricher ?? createThreadDirectoryEnricher();
     this.overlayStore = options?.overlayStore ?? getDesktopOverlayStore();
     this.gitDirectoryService =
       options?.gitDirectoryService ??
@@ -3483,12 +3501,17 @@ export class DesktopBackendRegistry {
           thread,
           overlay?.extraLinkedDirectories ?? [],
         );
+        const linkedDirectories = await this.resolveAcpLinkedDirectories(
+          thread,
+          cwd,
+        );
         const codexEnvironmentOptions = cwd
           ? await listCodexEnvironmentOptions(cwd).catch(() => [])
           : [];
         return {
           ...thread,
           executionMode,
+          linkedDirectories,
           codexEnvironmentOptions,
         };
       }),
@@ -3499,6 +3522,46 @@ export class DesktopBackendRegistry {
         thread.title.toLowerCase().includes(normalizedFilter) ||
         thread.id.toLowerCase().includes(normalizedFilter),
     );
+  }
+
+  /**
+   * ACP sessions only know their working directory. When that cwd is a
+   * tool-managed worktree (`.codex/.../worktrees/...`, `.pwragent/.../worktrees/...`,
+   * `<repo>/.worktrees/...`), resolve the underlying repository checkout via git
+   * so the thread's linked directory is repo-rooted (`path` = repo,
+   * `worktreePath` = cwd). That makes ACP worktree threads group under the same
+   * directory row as their repo — matching Codex — instead of each worktree
+   * getting its own folder.
+   *
+   * Falls back to the session's own linked directories when the cwd is a plain
+   * local checkout (already repo-rooted), when it is not a managed worktree, or
+   * when enrichment yields nothing (e.g. the worktree was deleted). The fallback
+   * is what keeps a vanished worktree's thread grouped (or at least not dropped
+   * to "unlinked") rather than disappearing from its row.
+   */
+  private async resolveAcpLinkedDirectories(
+    thread: AppServerThreadSummary,
+    cwd: string | undefined,
+  ): Promise<AppServerThreadSummary["linkedDirectories"]> {
+    if (!cwd || !isLikelyToolManagedWorktreePath(cwd)) {
+      return thread.linkedDirectories;
+    }
+
+    try {
+      const enrichment = await this.acpDirectoryEnricher(cwd);
+      if (enrichment.linkedDirectories.length > 0) {
+        return enrichment.linkedDirectories;
+      }
+    } catch (error) {
+      backendRegistryLog.warn("ACP worktree directory enrichment failed", {
+        threadId: thread.id,
+        backend: thread.source,
+        cwd,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+
+    return thread.linkedDirectories;
   }
 
   private async readAcpThread(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -156,10 +156,7 @@ import type { ProtocolCaptureStore } from "../testing/capture-store";
 import { createReplayClientsFromEnv } from "../testing/replay-runtime";
 import { GitDirectoryService } from "./git-directory-service";
 import type { DirectoryGitStatusEntry } from "./git-directory-service";
-import {
-  createThreadDirectoryEnricher,
-  type ThreadDirectoryEnrichment,
-} from "./thread-directory-enricher";
+import { resolveWorktreeRepositoryDirectory } from "./thread-directory-enricher";
 import { GitWorkspaceHandoffService } from "./git-workspace-handoff-service";
 import { WorktreeArchiveService } from "./worktree-archive-service";
 import { getDesktopMessagingStore } from "../messaging/desktop-messaging-store";
@@ -2439,11 +2436,14 @@ export class DesktopBackendRegistry {
   // (e.g. Grok) worktree threads group under the same directory row as their
   // repo, exactly like Codex threads do. Codex backends carry a repo-rooted
   // linked directory from their own enricher; ACP sessions only know their cwd,
-  // so without this every ACP worktree session lands in its own folder. Cached
-  // (per cwd, short TTL) inside the enricher. Injectable for deterministic tests.
-  private readonly acpDirectoryEnricher: (
-    projectKey?: string,
-  ) => Promise<ThreadDirectoryEnrichment>;
+  // so without this every ACP worktree session lands in its own folder. Pure
+  // filesystem — follows the worktree's `.git` link and NEVER spawns git. The
+  // repo↔worktree mapping is immutable, so the result is cached durably on the
+  // thread overlay (`acpWorktreeDirectory`) and this resolver only runs on the
+  // first sighting of a given cwd. Injectable for deterministic tests.
+  private readonly acpWorktreeRepositoryResolver: (
+    cwd: string,
+  ) => Promise<LinkedDirectorySummary | undefined>;
   private readonly messagingStore?: MessagingArchiveCleanupStore | null;
   private messagingArchiveCleaner?: MessagingArchiveCleaner | null;
   private readonly archivedMessagingCleanupInFlight = new Map<
@@ -2596,9 +2596,9 @@ export class DesktopBackendRegistry {
     threadTitleGenerationService?: ThreadTitleService | null;
     isCodexBootstrapDeferred?: () => boolean;
     isBootstrapMode?: () => boolean;
-    acpDirectoryEnricher?: (
-      projectKey?: string,
-    ) => Promise<ThreadDirectoryEnrichment>;
+    acpWorktreeRepositoryResolver?: (
+      cwd: string,
+    ) => Promise<LinkedDirectorySummary | undefined>;
   }) {
     const replayClients = createReplayClientsFromEnv();
     const codexCapture = options?.codexClient
@@ -2683,8 +2683,9 @@ export class DesktopBackendRegistry {
         apiKey: grokApiKey,
         connectionObserver: grokObserver,
       });
-    this.acpDirectoryEnricher =
-      options?.acpDirectoryEnricher ?? createThreadDirectoryEnricher();
+    this.acpWorktreeRepositoryResolver =
+      options?.acpWorktreeRepositoryResolver ??
+      resolveWorktreeRepositoryDirectory;
     this.overlayStore = options?.overlayStore ?? getDesktopOverlayStore();
     this.gitDirectoryService =
       options?.gitDirectoryService ??
@@ -3504,6 +3505,8 @@ export class DesktopBackendRegistry {
         const linkedDirectories = await this.resolveAcpLinkedDirectories(
           thread,
           cwd,
+          overlay,
+          backendId,
         );
         const codexEnvironmentOptions = cwd
           ? await listCodexEnvironmentOptions(cwd).catch(() => [])
@@ -3527,33 +3530,54 @@ export class DesktopBackendRegistry {
   /**
    * ACP sessions only know their working directory. When that cwd is a
    * tool-managed worktree (`.codex/.../worktrees/...`, `.pwragent/.../worktrees/...`,
-   * `<repo>/.worktrees/...`), resolve the underlying repository checkout via git
-   * so the thread's linked directory is repo-rooted (`path` = repo,
+   * `<repo>/.worktrees/...`), resolve the underlying repository checkout by
+   * following the worktree's `.git` link (filesystem only — this NEVER spawns
+   * git) so the thread's linked directory is repo-rooted (`path` = repo,
    * `worktreePath` = cwd). That makes ACP worktree threads group under the same
    * directory row as their repo — matching Codex — instead of each worktree
    * getting its own folder.
    *
+   * The repo↔worktree mapping is immutable for a given worktree path, so a
+   * successful resolution is cached durably on the thread overlay
+   * (`acpWorktreeDirectory`, keyed by cwd) and reused on every later list read
+   * without touching the filesystem again. The resolver therefore runs at most
+   * once per worktree thread, not once per refresh.
+   *
    * Falls back to the session's own linked directories when the cwd is a plain
-   * local checkout (already repo-rooted), when it is not a managed worktree, or
-   * when enrichment yields nothing (e.g. the worktree was deleted). The fallback
-   * is what keeps a vanished worktree's thread grouped (or at least not dropped
-   * to "unlinked") rather than disappearing from its row.
+   * local checkout (already repo-rooted), is not a managed worktree, or resolves
+   * to nothing (e.g. the worktree was deleted). A miss is deliberately left
+   * uncached so a transient failure is retried cheaply, and a vanished
+   * worktree's thread stays on its row rather than dropping to "unlinked".
    */
   private async resolveAcpLinkedDirectories(
     thread: AppServerThreadSummary,
     cwd: string | undefined,
+    overlay: ThreadOverlayState | undefined,
+    backendId: AppServerBackendKind,
   ): Promise<AppServerThreadSummary["linkedDirectories"]> {
     if (!cwd || !isLikelyToolManagedWorktreePath(cwd)) {
       return thread.linkedDirectories;
     }
 
+    // Reuse the durably-cached resolution while the session cwd is unchanged.
+    const cached = overlay?.acpWorktreeDirectory;
+    if (cached && cached.cwd === cwd) {
+      return [cached.directory];
+    }
+
     try {
-      const enrichment = await this.acpDirectoryEnricher(cwd);
-      if (enrichment.linkedDirectories.length > 0) {
-        return enrichment.linkedDirectories;
+      const directory = await this.acpWorktreeRepositoryResolver(cwd);
+      if (directory) {
+        await this.overlayStore.setAcpWorktreeDirectory({
+          backend: backendId,
+          threadId: thread.id,
+          cwd,
+          directory,
+        });
+        return [directory];
       }
     } catch (error) {
-      backendRegistryLog.warn("ACP worktree directory enrichment failed", {
+      backendRegistryLog.warn("ACP worktree repository resolution failed", {
         threadId: thread.id,
         backend: thread.source,
         cwd,

--- a/apps/desktop/src/main/app-server/thread-directory-enricher.ts
+++ b/apps/desktop/src/main/app-server/thread-directory-enricher.ts
@@ -1,4 +1,5 @@
 export {
   createThreadDirectoryEnricher,
+  resolveWorktreeRepositoryDirectory,
   type ThreadDirectoryEnrichment,
 } from "../codex-app-server/thread-directory-enricher";

--- a/apps/desktop/src/main/codex-app-server/thread-directory-enricher.ts
+++ b/apps/desktop/src/main/codex-app-server/thread-directory-enricher.ts
@@ -151,6 +151,25 @@ async function buildLinkedDirectoryFromGitMetadata(
   };
 }
 
+/**
+ * Resolve a tool-managed worktree directory to its repository checkout by
+ * following the worktree's `.git` gitdir link. Filesystem-only — this NEVER
+ * spawns `git`. Returns a repo-rooted linked directory (`path` = repository,
+ * `worktreePath` = the worktree) when `cwd` is a git worktree, or `undefined`
+ * when it is a plain checkout (its `.git` is a real directory, not a gitdir
+ * link), a vanished worktree, or otherwise unreadable. The repo↔worktree
+ * relationship is immutable for a given worktree path, so callers can cache
+ * the result indefinitely and only re-resolve when `cwd` itself changes.
+ */
+export async function resolveWorktreeRepositoryDirectory(
+  cwd: string,
+): Promise<LinkedDirectorySummary | undefined> {
+  const { directory } = await buildLinkedDirectoryFromGitMetadata(
+    path.resolve(cwd),
+  );
+  return directory;
+}
+
 function parseGitWorktrees(output: string): string[] {
   return output
     .split("\n")

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -318,6 +318,36 @@ export class SqliteOverlayStore {
     return this.getThread(threadKey);
   }
 
+  /**
+   * Persist the immutable repository resolution for an ACP worktree thread.
+   * The mapping from a tool-managed worktree cwd to its parent repository is
+   * derived once (by following the worktree's `.git` link — no git process)
+   * and stored here so later thread-list reads reuse it instead of re-touching
+   * the filesystem. `cwd` is retained so a session rebind to a different
+   * workspace invalidates the cache. See `acpWorktreeDirectory` on
+   * `ThreadOverlayState`.
+   */
+  async setAcpWorktreeDirectory(params: {
+    backend: ThreadOverlayState["backend"];
+    threadId: string;
+    cwd: string;
+    directory: LinkedDirectorySummary;
+  }): Promise<ThreadOverlayState> {
+    const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+    const current = this.getThread(threadKey) ?? {
+      backend: params.backend,
+      threadId: params.threadId,
+      executionMode: "default" as const,
+      extraLinkedDirectories: [],
+    };
+    const nextState: ThreadOverlayState = {
+      ...current,
+      acpWorktreeDirectory: { cwd: params.cwd, directory: params.directory },
+    };
+    this.putThread(threadKey, nextState);
+    return nextState;
+  }
+
   async persistThreadUsageActivity(params: {
     backend: ThreadOverlayState["backend"];
     threadId: string;
@@ -1197,6 +1227,7 @@ export type OverlayStoreLike = Pick<
   | "getThreadExecutionMode"
   | "getThreadOverlayState"
   | "getThreadOverlayStates"
+  | "setAcpWorktreeDirectory"
   | "persistThreadUsageActivity"
   | "setThreadReaction"
   | "setThreadPin"

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -613,6 +613,24 @@ export type ThreadOverlayState = {
   extraLinkedDirectories: LinkedDirectorySummary[];
   worktreeSnapshots?: WorktreeSnapshotSummary[];
   /**
+   * Cached repository resolution for an ACP worktree thread. ACP sessions
+   * only report their working directory; mapping a tool-managed worktree cwd
+   * to its parent repository checkout requires following the worktree's `.git`
+   * gitdir link (filesystem only — we never spawn git for this). That mapping
+   * is immutable for a given worktree path, so we resolve it once and persist
+   * it here, then reuse it on every later thread-list read instead of touching
+   * the filesystem again. `cwd` records the session directory the resolution
+   * was computed for, so a session rebind to a different workspace re-resolves.
+   * `directory` is repo-rooted (`path` = repo, `worktreePath` = the worktree),
+   * which is what lets the thread group under its repository row alongside
+   * Codex threads of the same repo. Only successful resolutions are stored;
+   * a non-worktree / vanished cwd is left uncached so it is retried cheaply.
+   */
+  acpWorktreeDirectory?: {
+    cwd: string;
+    directory: LinkedDirectorySummary;
+  };
+  /**
    * Per-thread emoji reactions. Single-user model: each emoji appears at
    * most once, ordered by insertion. Used as personal status markers
    * (e.g., "needs follow-up"), not multi-user voting.


### PR DESCRIPTION
## Problem

Follow-up to #675 (the one-row-per-thread invariant). That fix stopped a single
thread from appearing under multiple folders, but ACP (Grok/Qwen/Kimi/etc.)
worktree threads still each got their **own** `<project>` folder in the
Directories lens instead of grouping under the repo.

Root cause: ACP sessions only know their working directory, so
`acpSessionToThreadSummary` produced a linked directory rooted at the cwd
(`{ path: session.cwd, kind: "local" }`). For a tool-managed worktree cwd
(`.codex/.../worktrees/...`, `.pwragent/.../worktrees/...`, `<repo>/.worktrees/...`)
that `path` is the **worktree**, not the repo — so it classifies to its own
directory row. Codex backends don't have this problem because their enricher
already resolves the repo (`path` = repo, `worktreePath` = cwd); nothing did the
equivalent for ACP.

## Fix

A git worktree's parent repository is discoverable by following its `.git`
gitdir link (`gitdir: <repo>/.git/worktrees/<name>`) — **pure filesystem, no
git subprocess** — and that mapping is **immutable** for a given worktree path.
So we resolve it once via the filesystem and cache the result durably on the
thread overlay:

- **`resolveWorktreeRepositoryDirectory(cwd)`** (wraps the existing
  `buildLinkedDirectoryFromGitMetadata`) reads the worktree's `.git` file and
  returns a repo-rooted linked directory (`path` = repo, `worktreePath` = cwd).
  It **never spawns git**.
- A new immutable **`acpWorktreeDirectory`** field on `ThreadOverlayState` (plus
  a `setAcpWorktreeDirectory` overlay setter) caches a successful resolution,
  keyed by cwd. `listInstalledAcpThreads` reuses it on every later read, so the
  resolver runs **at most once per worktree thread for its lifetime**, not once
  per refresh.
- `resolveAcpLinkedDirectories`: overlay cache-hit (cwd match) → reuse; miss →
  filesystem-resolve → persist → return; unresolvable → fall back to the
  session's cwd-rooted directory and **leave the miss uncached** so a transient
  failure is retried cheaply and a vanished worktree's thread stays on its row
  rather than dropping to \"unlinked\".
- **Plain local cwds** are left untouched (already repo-rooted) — the resolver
  isn't even called.
- **`worktreePath` is preserved**, so thread-scoped cwd resolution (turns,
  branch drift, terminal/VS Code launches) still targets the worktree, not the
  repo (`resolveLinkedDirectoryWorkspaceCwd` prefers `worktreePath`).
- The resolver is **injectable** on `DesktopBackendRegistry` so the unit suite
  stays deterministic (no real filesystem).

### Why filesystem + durable cache

The first iteration of this branch routed managed-worktree ACP cwds through the
shared git-spawning `thread-directory-enricher`, which runs 3 git subprocesses
per cold cwd. `listInstalledAcpThreads` fans those out over every ACP thread in
an unbounded `Promise.all` on a ~5s cadence, so a user with many ACP worktree
threads could spawn `3×N` concurrent git processes per list refresh. This
revision drops git entirely: **0 git processes** (was `3×N`), with at most one
`.git` read per worktree thread ever, then served from sqlite. A Codex-style
concurrency cap is unnecessary once the expensive part is gone.

## Tests

`DesktopBackendRegistry — ACP worktree directory grouping`:
- managed-worktree cwd → resolved to repo (`path` = repo, `worktreePath` = cwd,
  `kind` = worktree) **and persisted** to the overlay (`setAcpWorktreeDirectory`)
- pre-seeded overlay → **reuses the cached resolution without re-resolving**
- plain local cwd → resolver not called
- unresolvable worktree → falls back to the session directory **and the miss is
  not cached**

backend-registry suite 226 passed (222 existing + 4 new). Overlay-store + replay
suites 52 passed. Desktop + shared typecheck clean; `lint:boundaries` clean.

## Result

Combined with #675: ACP worktree threads no longer duplicate **and** now
collapse under their repository folder alongside Codex threads of the same repo
— resolved once from the filesystem, then cached, with no git processes.