### PR TITLE
feat(desktop): order pinned threads globally across backends

### DIFF
--- a/apps/desktop/src/main/__tests__/overlay-store-pins.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-pins.test.ts
@@ -50,17 +50,48 @@ describe("SqliteOverlayStore — thread pins", () => {
     });
 
     const ranks = await store.reorderThreadPins({
-      backend: "codex",
-      threadIds: ["thread-2", "thread-1"],
+      threadKeys: ["codex:thread-2", "codex:thread-1"],
     });
 
     expect(ranks).toEqual({
-      "thread-2": "1024",
-      "thread-1": "2048",
+      "codex:thread-2": "1024",
+      "codex:thread-1": "2048",
     });
     await expect(
       store.getThreadOverlayState({ backend: "codex", threadId: "thread-2" }),
     ).resolves.toMatchObject({ pinnedRank: "1024" });
+  });
+
+  it("orders pins globally across backends (interleaving Codex and ACP)", async () => {
+    // The whole point of global pin order: a Codex pin and an ACP pin can be
+    // interleaved in any order, with strictly increasing ranks assigned by the
+    // single global position — no per-backend rank collisions.
+    const ranks = await store.reorderThreadPins({
+      threadKeys: ["codex:c1", "acp%3Agemini:g1", "codex:c2"],
+    });
+
+    expect(ranks).toEqual({
+      "codex:c1": "1024",
+      "acp%3Agemini:g1": "2048",
+      "codex:c2": "3072",
+    });
+    await expect(
+      store.getThreadOverlayState({ backend: "acp:gemini", threadId: "g1" }),
+    ).resolves.toMatchObject({ backend: "acp:gemini", pinnedRank: "2048" });
+    await expect(
+      store.getThreadOverlayState({ backend: "codex", threadId: "c2" }),
+    ).resolves.toMatchObject({ backend: "codex", pinnedRank: "3072" });
+  });
+
+  it("skips unparseable thread keys without consuming a rank", async () => {
+    const ranks = await store.reorderThreadPins({
+      threadKeys: ["codex:c1", "not-a-valid-key-no-separator", "codex:c2"],
+    });
+
+    expect(ranks).toEqual({
+      "codex:c1": "1024",
+      "codex:c2": "2048",
+    });
   });
 
   it("persists pin state across sqlite handles", async () => {

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1171,20 +1171,19 @@ class DesktopAppServerService {
   async reorderThreadPins(
     request: ReorderThreadPinsRequest,
   ): Promise<ReorderThreadPinsResponse> {
-    const backend = request.backend ?? "codex";
-
     const pinnedRanks = await this.getOverlayStore().reorderThreadPins({
-      backend,
-      threadIds: request.threadIds,
+      threadKeys: request.threadKeys,
     });
 
     logDebug("reorderThreadPins", {
-      backend,
-      pinCount: request.threadIds.length,
+      pinCount: request.threadKeys.length,
     });
 
+    // Pin order is global across backends, so this is a global notification.
+    // `backend` is required by publishLocalEvent but irrelevant here — use a
+    // fixed value (matches the directory/pin/reordered handler).
     await getDesktopBackendRegistry().publishLocalEvent({
-      backend,
+      backend: "codex",
       notification: {
         method: "thread/pin/reordered",
         params: {
@@ -1193,7 +1192,7 @@ class DesktopAppServerService {
       },
     });
 
-    return { backend, pinnedRanks };
+    return { pinnedRanks };
   }
 
   async setThreadParent(

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -24,6 +24,7 @@ import {
   MAX_IMMUTABLE_USAGE_ACTIVITY_ENTRIES,
   MAX_PERMISSION_TRANSITION_LOG_ENTRIES,
   buildThreadIdentityKey,
+  parseThreadIdentityKey,
 } from "@pwragent/shared";
 import {
   buildNavigationSnapshot,
@@ -449,27 +450,37 @@ export class SqliteOverlayStore {
     return nextState;
   }
 
+  /**
+   * Reorder pinned threads globally across backends. `threadKeys` is the
+   * complete pinned order (thread identity keys); ranks are assigned by global
+   * index so Codex and ACP pins interleave in any order. Unparseable keys are
+   * skipped without consuming a rank.
+   */
   async reorderThreadPins(params: {
-    backend: ThreadOverlayState["backend"];
-    threadIds: string[];
+    threadKeys: string[];
   }): Promise<Record<string, string>> {
     const pinnedRanks: Record<string, string> = {};
     const write = this.stateDb.raw.transaction(() => {
-      params.threadIds.forEach((threadId, index) => {
-        const threadKey = buildThreadIdentityKey(params.backend, threadId);
+      let rankIndex = 0;
+      for (const threadKey of params.threadKeys) {
+        const parts = parseThreadIdentityKey(threadKey);
+        if (!parts) {
+          continue;
+        }
         const current = this.getThread(threadKey) ?? {
-          backend: params.backend,
-          threadId,
+          backend: parts.backend,
+          threadId: parts.threadId,
           executionMode: "default" as const,
           extraLinkedDirectories: [],
         };
-        const pinnedRank = String((index + 1) * 1024);
-        pinnedRanks[threadId] = pinnedRank;
+        rankIndex += 1;
+        const pinnedRank = String(rankIndex * 1024);
+        pinnedRanks[threadKey] = pinnedRank;
         this.putThread(threadKey, {
           ...current,
           pinnedRank,
         });
-      });
+      }
     });
     write();
     return pinnedRanks;

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -56,10 +56,7 @@ type DirectoriesListProps = {
   ) => Promise<void>;
   onSelectThread: (thread: NavigationThreadSummary) => void;
   onPrefetchPullRequests?: (thread: NavigationThreadSummary) => void;
-  onReorderThreadPins?: (
-    backend: AppServerBackendKind,
-    threadIds: string[],
-  ) => Promise<void>;
+  onReorderThreadPins?: (orderedThreadKeys: string[]) => Promise<void>;
   onUpdateSubthreadOrder?: (
     parent: NavigationThreadSummary,
     threadIds: string[],
@@ -257,30 +254,18 @@ export function DirectoriesList(props: DirectoriesListProps) {
     );
   };
 
-  const pinnedThreadKeysForBackend = (backend: AppServerBackendKind): string[] =>
-    pinnedThreads
-      .filter((thread) => thread.source === backend)
-      .map((thread) => buildThreadIdentityKey(thread.source, thread.id));
-
-  const reorderPins = (
-    backend: AppServerBackendKind,
-    nextThreadKeys: string[],
-  ): void => {
-    const ids = nextThreadKeys
-      .filter((threadKey) => threadsByKey.get(threadKey)?.source === backend)
-      .map((threadKey) => threadsByKey.get(threadKey)?.id)
-      .filter((threadId): threadId is string => Boolean(threadId));
-    void props.onReorderThreadPins?.(backend, ids);
+  // Pin order is global across backends, so reorder submits the complete new
+  // order of pinned-thread keys (not a per-backend slice).
+  const reorderPins = (nextThreadKeys: string[]): void => {
+    void props.onReorderThreadPins?.(nextThreadKeys);
   };
 
+  // The directory's pinned thread keys (any backend), in global rank order.
   const buildDirectoryPinnedKeys = (
     directory: NavigationDirectorySummary,
-    backend: AppServerBackendKind,
   ): string[] =>
-    pinnedThreadKeys.filter(
-      (threadKey) =>
-        directory.threadKeys.includes(threadKey) &&
-        threadsByKey.get(threadKey)?.source === backend,
+    pinnedThreadKeys.filter((threadKey) =>
+      directory.threadKeys.includes(threadKey),
     );
 
   const moveDirectoryPin = (
@@ -293,18 +278,16 @@ export function DirectoriesList(props: DirectoriesListProps) {
 
     const draggedThread = threadsByKey.get(draggedKey);
     const targetThread = threadsByKey.get(targetKey);
-    if (!draggedThread || !targetThread || draggedThread.source !== targetThread.source) {
+    if (!draggedThread || !targetThread) {
       return;
     }
 
-    const backendPinnedThreadKeys = pinnedThreadKeysForBackend(draggedThread.source);
-    const sourceKeys = backendPinnedThreadKeys.includes(draggedKey)
-      ? backendPinnedThreadKeys
-      : [...backendPinnedThreadKeys, draggedKey];
-    reorderPins(
-      draggedThread.source,
-      moveThreadKey(sourceKeys, draggedKey, targetKey, position),
-    );
+    // Reposition within the full pinned list (cross-backend allowed) and submit
+    // the complete new order.
+    const sourceKeys = pinnedThreadKeys.includes(draggedKey)
+      ? pinnedThreadKeys
+      : [...pinnedThreadKeys, draggedKey];
+    reorderPins(moveThreadKey(sourceKeys, draggedKey, targetKey, position));
   };
 
   const dropThreadAfterDirectoryPins = (
@@ -316,25 +299,17 @@ export function DirectoriesList(props: DirectoriesListProps) {
     const draggedThread = threadsByKey.get(draggedKey);
     if (!draggedThread) return;
 
-    const backendPinnedThreadKeys = pinnedThreadKeysForBackend(draggedThread.source);
-    const directoryPinnedThreadKeys = buildDirectoryPinnedKeys(
-      directory,
-      draggedThread.source,
-    );
-    const targetKey = directoryPinnedThreadKeys[directoryPinnedThreadKeys.length - 1];
+    const directoryPinnedThreadKeys = buildDirectoryPinnedKeys(directory);
+    const targetKey =
+      directoryPinnedThreadKeys[directoryPinnedThreadKeys.length - 1];
 
     if (!targetKey) {
-      if (backendPinnedThreadKeys.includes(draggedKey)) return;
-      reorderPins(draggedThread.source, [...backendPinnedThreadKeys, draggedKey]);
+      if (pinnedThreadKeys.includes(draggedKey)) return;
+      reorderPins([...pinnedThreadKeys, draggedKey]);
       return;
     }
 
-    moveDirectoryPin(
-      directory,
-      draggedKey,
-      targetKey,
-      "after",
-    );
+    moveDirectoryPin(directory, draggedKey, targetKey, "after");
   };
 
   const movePinnedThreadByKeyboard = (
@@ -343,10 +318,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
     direction: "up" | "down",
   ): void => {
     const threadKey = buildThreadIdentityKey(thread.source, thread.id);
-    const directoryPinnedThreadKeys = buildDirectoryPinnedKeys(
-      directory,
-      thread.source,
-    );
+    const directoryPinnedThreadKeys = buildDirectoryPinnedKeys(directory);
     const currentIndex = directoryPinnedThreadKeys.indexOf(threadKey);
     if (currentIndex === -1) return;
 
@@ -798,8 +770,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
                             if (
                               !draggedThreadKey ||
                               !draggedThread ||
-                              !directory.threadKeys.includes(draggedThreadKey) ||
-                              draggedThread.source !== thread.source
+                              !directory.threadKeys.includes(draggedThreadKey)
                             ) {
                               event.dataTransfer.dropEffect = "none";
                               setDropIndicator(undefined);

--- a/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import type {
-  AppServerBackendKind,
   MessagingThreadBindingSummary,
   NavigationThreadSummary,
   PrSummary,
@@ -34,10 +33,7 @@ type RecentsListProps = {
     position: { x: number; y: number; anchorTop?: number }
   ) => void;
   onPrefetchPullRequests?: (thread: NavigationThreadSummary) => void;
-  onReorderThreadPins?: (
-    backend: AppServerBackendKind,
-    threadIds: string[],
-  ) => Promise<void>;
+  onReorderThreadPins?: (orderedThreadKeys: string[]) => Promise<void>;
   onUpdateSubthreadOrder?: (
     parent: NavigationThreadSummary,
     threadIds: string[],
@@ -109,20 +105,10 @@ export function RecentsList(props: RecentsListProps) {
   );
   const unpinnedThreads = topLevelThreads.filter((thread) => !isPinnedThread(thread));
 
-  const pinnedThreadKeysForBackend = (backend: AppServerBackendKind): string[] =>
-    pinnedThreads
-      .filter((thread) => thread.source === backend)
-      .map((thread) => buildThreadIdentityKey(thread.source, thread.id));
-
-  const reorderPins = (
-    backend: AppServerBackendKind,
-    nextThreadKeys: string[],
-  ): void => {
-    const ids = nextThreadKeys
-      .filter((threadKey) => threadByKey.get(threadKey)?.source === backend)
-      .map((threadKey) => parseThreadIdentityKey(threadKey)?.threadId)
-      .filter((threadId): threadId is string => Boolean(threadId));
-    void props.onReorderThreadPins?.(backend, ids);
+  // Pin order is global across backends, so reorder operates on the full
+  // pinned-thread key list and passes the complete new order through.
+  const reorderPins = (nextThreadKeys: string[]): void => {
+    void props.onReorderThreadPins?.(nextThreadKeys);
   };
 
   const movePinnedThreadByKeyboard = (
@@ -130,18 +116,16 @@ export function RecentsList(props: RecentsListProps) {
     direction: "up" | "down",
   ): void => {
     const threadKey = buildThreadIdentityKey(thread.source, thread.id);
-    const backendPinnedThreadKeys = pinnedThreadKeysForBackend(thread.source);
-    const currentIndex = backendPinnedThreadKeys.indexOf(threadKey);
+    const currentIndex = pinnedThreadKeys.indexOf(threadKey);
     if (currentIndex === -1) return;
 
     const targetIndex = direction === "up" ? currentIndex - 1 : currentIndex + 1;
-    const targetKey = backendPinnedThreadKeys[targetIndex];
+    const targetKey = pinnedThreadKeys[targetIndex];
     if (!targetKey) return;
 
     reorderPins(
-      thread.source,
       moveThreadKey(
-        backendPinnedThreadKeys,
+        pinnedThreadKeys,
         threadKey,
         targetKey,
         direction === "up" ? "before" : "after",
@@ -326,22 +310,17 @@ export function RecentsList(props: RecentsListProps) {
                   const draggedKey = event.dataTransfer.getData("text/plain");
                   if (!draggedKey) return;
                   const draggedThread = threadByKey.get(draggedKey);
-                  if (
-                    !draggedThread ||
-                    draggedThread.source !== thread.source ||
-                    draggedThread.parentThreadId
-                  ) return;
-                  const backendPinnedThreadKeys = pinnedThreadKeysForBackend(thread.source);
+                  if (!draggedThread || draggedThread.parentThreadId) return;
                   const position = getDropIndicatorPosition(event);
-                  const nextKeys = backendPinnedThreadKeys.includes(draggedKey)
-                    ? moveThreadKey(backendPinnedThreadKeys, draggedKey, key, position)
+                  const nextKeys = pinnedThreadKeys.includes(draggedKey)
+                    ? moveThreadKey(pinnedThreadKeys, draggedKey, key, position)
                     : moveThreadKey(
-                        [...backendPinnedThreadKeys, draggedKey],
+                        [...pinnedThreadKeys, draggedKey],
                         draggedKey,
                         key,
                         position,
                       );
-                  reorderPins(thread.source, nextKeys);
+                  reorderPins(nextKeys);
                 }
               : undefined
           }
@@ -400,10 +379,7 @@ export function RecentsList(props: RecentsListProps) {
             const draggedKey = event.dataTransfer.getData("text/plain");
             const draggedThread = threadByKey.get(draggedKey);
             if (!draggedThread || draggedThread.parentThreadId || pinnedThreadKeys.includes(draggedKey)) return;
-            reorderPins(draggedThread.source, [
-              ...pinnedThreadKeysForBackend(draggedThread.source),
-              draggedKey,
-            ]);
+            reorderPins([...pinnedThreadKeys, draggedKey]);
           }}
         >
           <span>Recent threads</span>

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -16,6 +16,7 @@ import type {
   ThreadExecutionMode,
 } from "@pwragent/shared";
 import {
+  buildThreadIdentityKey,
   comparePinnedDirectories,
   comparePinnedThreads,
   isPinnedDirectory,
@@ -107,10 +108,7 @@ type SidebarProps = {
     thread: NavigationThreadSummary,
     pinned: boolean,
   ) => Promise<void>;
-  onReorderThreadPins?: (
-    backend: AppServerBackendKind,
-    threadIds: string[],
-  ) => Promise<void>;
+  onReorderThreadPins?: (orderedThreadKeys: string[]) => Promise<void>;
   onSetThreadParent?: (
     thread: NavigationThreadSummary,
     parentThreadId?: string,
@@ -492,23 +490,18 @@ export function Sidebar(props: SidebarProps) {
   };
 
   /**
-   * Pinned-thread order, grouped by backend. The thread reorder
-   * IPC is per-backend (mirrors per-backend pin ranks), so the
-   * "Move Up / Move Down" menu items have to compute per-backend
-   * adjacency to figure out whether the target row is at the top
-   * or bottom of its backend's pinned section.
+   * Pinned-thread identity keys in stable global order. Pin order is global
+   * across backends (mirrors directory pinning), so a single sorted array is
+   * enough to compute Move Up / Move Down adjacency for the context menu.
    */
-  const pinnedThreadIdsByBackend = useMemo(() => {
-    const byBackend = new Map<AppServerBackendKind, string[]>();
-    for (const thread of [...props.threads]
-      .filter(isPinnedThread)
-      .sort(comparePinnedThreads)) {
-      const list = byBackend.get(thread.source) ?? [];
-      list.push(thread.id);
-      byBackend.set(thread.source, list);
-    }
-    return byBackend;
-  }, [props.threads]);
+  const pinnedThreadKeysInOrder = useMemo(
+    () =>
+      [...props.threads]
+        .filter(isPinnedThread)
+        .sort(comparePinnedThreads)
+        .map((thread) => buildThreadIdentityKey(thread.source, thread.id)),
+    [props.threads],
+  );
 
   /**
    * Pinned-directory keys in stable user-curated order. Directory
@@ -529,17 +522,18 @@ export function Sidebar(props: SidebarProps) {
     thread: NavigationThreadSummary,
     direction: "up" | "down",
   ): void => {
-    const ordered = pinnedThreadIdsByBackend.get(thread.source) ?? [];
-    const currentIndex = ordered.indexOf(thread.id);
+    const ordered = pinnedThreadKeysInOrder;
+    const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+    const currentIndex = ordered.indexOf(threadKey);
     if (currentIndex === -1) return;
     const targetIndex =
       direction === "up" ? currentIndex - 1 : currentIndex + 1;
     if (targetIndex < 0 || targetIndex >= ordered.length) return;
-    const targetId = ordered[targetIndex]!;
-    const nextIds = moveThreadKey(
+    const targetKey = ordered[targetIndex]!;
+    const nextKeys = moveThreadKey(
       ordered,
-      thread.id,
-      targetId,
+      threadKey,
+      targetKey,
       direction === "up" ? "before" : "after",
     );
     // Intentionally do NOT dismiss the menu after a Move — the
@@ -550,7 +544,7 @@ export function Sidebar(props: SidebarProps) {
     // tick, so subsequent Move clicks see updated adjacency.
     // Pin / Unpin / Rename / Archive are terminal actions and
     // still dismiss the menu.
-    void props.onReorderThreadPins?.(thread.source, nextIds);
+    void props.onReorderThreadPins?.(nextKeys);
   };
 
   const moveDirectoryFromContextMenu = (
@@ -650,21 +644,19 @@ export function Sidebar(props: SidebarProps) {
    * Move Up / Move Down show as menu items only when the target
    * thread is pinned (reorder only applies inside the pinned
    * section) AND the reorder IPC is wired. Each item is then
-   * disabled when the thread is at the top / bottom of its
-   * backend's pinned slice. We render the items even when disabled
+   * disabled when the thread is at the top / bottom of the global
+   * pinned section. We render the items even when disabled
    * so the menu layout doesn't jump as the user walks the list.
    */
   const contextMenuShowMoveItems = Boolean(
     contextMenu?.thread.pinnedRank && props.onReorderThreadPins,
   );
   const contextMenuPinnedThreadIndex = contextMenu
-    ? (pinnedThreadIdsByBackend.get(contextMenu.thread.source) ?? []).indexOf(
-        contextMenu.thread.id,
+    ? pinnedThreadKeysInOrder.indexOf(
+        buildThreadIdentityKey(contextMenu.thread.source, contextMenu.thread.id),
       )
     : -1;
-  const contextMenuPinnedThreadCount = contextMenu
-    ? (pinnedThreadIdsByBackend.get(contextMenu.thread.source) ?? []).length
-    : 0;
+  const contextMenuPinnedThreadCount = pinnedThreadKeysInOrder.length;
   const contextMenuCanMoveUp =
     contextMenuShowMoveItems && contextMenuPinnedThreadIndex > 0;
   const contextMenuCanMoveDown =

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -1308,9 +1308,9 @@ describe("Sidebar", () => {
 
     // Click Move Down on the top thread → swap order.
     await clickElement(moveDown);
-    expect(onReorderThreadPins).toHaveBeenCalledWith("codex", [
-      pinnedBottom.id,
-      pinnedTop.id,
+    expect(onReorderThreadPins).toHaveBeenCalledWith([
+      `codex:${pinnedBottom.id}`,
+      `codex:${pinnedTop.id}`,
     ]);
   });
 
@@ -1466,9 +1466,9 @@ describe("Sidebar", () => {
       { dataTransfer: createDataTransfer("codex:thread-1") },
     );
 
-    expect(onReorderThreadPins).toHaveBeenCalledWith("codex", [
-      "thread-updated",
-      "thread-1",
+    expect(onReorderThreadPins).toHaveBeenCalledWith([
+      "codex:thread-updated",
+      "codex:thread-1",
     ]);
   });
 
@@ -3076,32 +3076,32 @@ describe("Sidebar directory pinning", () => {
 });
 
 describe("Sidebar thread pinning Move items", () => {
-  it("disables Move Down on backend A's bottom pinned thread regardless of backend B's pinned count", async () => {
-    // Per-backend pin-rank invariant: reorder IPC is scoped to
-    // (backend, [threadId, threadId, ...]). Move Down on backend
-    // A's bottom thread must NOT promote into backend B's pinned
-    // slice. Lock the boundary so a future refactor that
-    // accidentally globalizes the sort can't slip past review.
-    const codexOnly = {
+  it("moves a pin across backends — pin order is global, not per-backend", async () => {
+    // Pin order is global across backends (mirrors directory pinning). The
+    // top global pin can Move Down past another backend's pins, producing an
+    // interleaved cross-backend order. This is exactly the behavior the old
+    // per-backend slice blocked.
+    const onReorderThreadPins = vi.fn(async () => undefined);
+    const codexTop = {
       ...sharedThread,
-      id: "codex-pinned-only",
-      title: "Codex sole pin",
+      id: "codex-top",
+      title: "Codex top pin",
       source: "codex" as const,
       pinnedRank: "1024",
     };
-    const grokTop = {
+    const grokMiddle = {
       ...sharedThread,
-      id: "grok-top",
-      title: "Grok top pin",
+      id: "grok-middle",
+      title: "Grok middle pin",
       source: "grok" as const,
-      pinnedRank: "1024",
+      pinnedRank: "2048",
     };
     const grokBottom = {
       ...sharedThread,
       id: "grok-bottom",
       title: "Grok bottom pin",
       source: "grok" as const,
-      pinnedRank: "2048",
+      pinnedRank: "3072",
     };
 
     render(
@@ -3115,20 +3115,20 @@ describe("Sidebar thread pinning Move items", () => {
         loading={false}
         creatingThread={undefined}
         selectedItemKey={undefined}
-        threads={[codexOnly, grokTop, grokBottom]}
+        threads={[codexTop, grokMiddle, grokBottom]}
         onBrowseModeChange={() => undefined}
         onCreateThread={async () => undefined}
         onOpenLaunchpad={async () => undefined}
-        onReorderThreadPins={async () => undefined}
+        onReorderThreadPins={onReorderThreadPins}
         onSelectThread={() => undefined}
         onSetThreadPin={async () => undefined}
       />,
     );
 
-    // Open menu on codex's sole pin (it's at both top AND bottom
-    // of its backend's slice — but grok has TWO pins below).
+    // Codex's pin is the GLOBAL top (rank 1024). Move Up is disabled (nothing
+    // above it), but Move Down is enabled and crosses into grok's pins.
     const codexRow = screen
-      .getByRole("button", { name: /Codex sole pin/i })
+      .getByRole("button", { name: /Codex top pin/i })
       .closest(".thread-row-shell") as HTMLElement;
     fireEvent.click(
       codexRow.querySelector(".thread-row__overflow-button") as HTMLButtonElement,
@@ -3138,10 +3138,16 @@ describe("Sidebar thread pinning Move items", () => {
     const moveDown = await screen.findByRole("menuitem", {
       name: /Move Down/i,
     });
-    // Per-backend slice has length 1 → both Up and Down disabled
-    // even though the global pin count is 3.
     expect(moveUp).toBeDisabled();
-    expect(moveDown).toBeDisabled();
+    expect(moveDown).toBeEnabled();
+
+    fireEvent.click(moveDown);
+    // Global, interleaved new order: grok-middle now above the codex pin.
+    expect(onReorderThreadPins).toHaveBeenCalledWith([
+      "grok:grok-middle",
+      "codex:codex-top",
+      "grok:grok-bottom",
+    ]);
   });
 
   it("invokes the reorder IPC on Cmd+Shift+ArrowDown on a focused pinned thread row", () => {
@@ -3197,9 +3203,9 @@ describe("Sidebar thread pinning Move items", () => {
       metaKey: true,
       shiftKey: true,
     });
-    expect(onReorderThreadPins).toHaveBeenCalledWith("codex", [
-      pinnedBottom.id,
-      pinnedTop.id,
+    expect(onReorderThreadPins).toHaveBeenCalledWith([
+      `codex:${pinnedBottom.id}`,
+      `codex:${pinnedTop.id}`,
     ]);
   });
 });

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -733,8 +733,8 @@ function updateThreadAgentInSnapshot(
 function updateThreadPinsInSnapshot(
   snapshot: NavigationSnapshot | undefined,
   params: {
-    backend: AppServerBackendKind;
-    pinnedRanks: Record<string, string>;
+    /** Thread identity key -> pin rank. Pin order is global across backends. */
+    pinnedRanksByThreadKey: Record<string, string>;
   },
 ): NavigationSnapshot | undefined {
   if (!snapshot) {
@@ -743,10 +743,10 @@ function updateThreadPinsInSnapshot(
 
   let changed = false;
   const threads = snapshot.threads.map((thread) => {
-    if (thread.source !== params.backend) {
-      return thread;
-    }
-    const pinnedRank = params.pinnedRanks[thread.id];
+    const pinnedRank =
+      params.pinnedRanksByThreadKey[
+        buildThreadIdentityKey(thread.source, thread.id)
+      ];
     if (!pinnedRank || thread.pinnedRank === pinnedRank) {
       return thread;
     }
@@ -1853,10 +1853,11 @@ export function useThreadNavigation(
     thread: NavigationThreadSummary,
     agent: Parameters<NonNullable<DesktopApi["setThreadAgent"]>>[0]["agent"],
   ) => Promise<void>;
-  reorderThreadPins: (
-    backend: AppServerBackendKind,
-    threadIds: string[],
-  ) => Promise<void>;
+  /**
+   * Reorder pinned threads globally. `orderedThreadKeys` is the complete
+   * pinned order across all backends (thread identity keys), top first.
+   */
+  reorderThreadPins: (orderedThreadKeys: string[]) => Promise<void>;
   setThreadParent: (
     thread: NavigationThreadSummary,
     parentThreadId?: string,
@@ -2546,8 +2547,7 @@ export function useThreadNavigation(
         setState((current) => ({
           ...current,
           response: updateThreadPinsInSnapshot(current.response, {
-            backend: event.backend,
-            pinnedRanks,
+            pinnedRanksByThreadKey: pinnedRanks,
           }),
         }));
         return;
@@ -3921,11 +3921,13 @@ export function useThreadNavigation(
         return;
       }
 
+      // Append above ALL existing pins (across backends), not just this
+      // thread's backend — pin order is global.
       const pinnedRank = pinned
         ? thread.pinnedRank ?? buildAppendPinRank(
-            (state.response?.threads ?? [])
-              .filter((candidate) => candidate.source === thread.source)
-              .map((candidate) => candidate.pinnedRank),
+            (state.response?.threads ?? []).map(
+              (candidate) => candidate.pinnedRank,
+            ),
           )
         : undefined;
 
@@ -3960,33 +3962,27 @@ export function useThreadNavigation(
   );
 
   const reorderThreadPins = useCallback(
-    async (
-      backend: AppServerBackendKind,
-      threadIds: string[],
-    ): Promise<void> => {
+    async (orderedThreadKeys: string[]): Promise<void> => {
       if (!reorderThreadPinsRequest) {
         return;
       }
 
-      const pinnedRanks = buildPinnedRanks(threadIds);
+      const pinnedRanksByThreadKey = buildPinnedRanks(orderedThreadKeys);
       setState((current) => ({
         ...current,
         response: updateThreadPinsInSnapshot(current.response, {
-          backend,
-          pinnedRanks,
+          pinnedRanksByThreadKey,
         }),
       }));
 
       try {
         const result = await reorderThreadPinsRequest({
-          backend,
-          threadIds,
+          threadKeys: orderedThreadKeys,
         });
         setState((current) => ({
           ...current,
           response: updateThreadPinsInSnapshot(current.response, {
-            backend: result.backend,
-            pinnedRanks: result.pinnedRanks,
+            pinnedRanksByThreadKey: result.pinnedRanks,
           }),
         }));
       } catch {

--- a/packages/agent-core/src/persistence/overlay-store.ts
+++ b/packages/agent-core/src/persistence/overlay-store.ts
@@ -22,6 +22,7 @@ import {
   MAX_MESSAGING_BINDING_TRANSITION_LOG_ENTRIES,
   MAX_PERMISSION_TRANSITION_LOG_ENTRIES,
   buildThreadIdentityKey,
+  parseThreadIdentityKey,
 } from "@pwragent/shared";
 import {
   buildNavigationSnapshot,
@@ -491,27 +492,37 @@ export class OverlayStore {
     });
   }
 
+  /**
+   * Reorder pinned threads globally across backends. `threadKeys` is the
+   * complete pinned order (thread identity keys); ranks are assigned by global
+   * index so a Codex pin and an ACP pin can be interleaved in any order. Keys
+   * that don't parse to a known backend are skipped without consuming a rank.
+   */
   async reorderThreadPins(params: {
-    backend: ThreadOverlayState["backend"];
-    threadIds: string[];
+    threadKeys: string[];
   }): Promise<Record<string, string>> {
     return await this.withData(async (data) => {
       const pinnedRanks: Record<string, string> = {};
-      params.threadIds.forEach((threadId, index) => {
-        const threadKey = buildThreadIdentityKey(params.backend, threadId);
+      let rankIndex = 0;
+      for (const threadKey of params.threadKeys) {
+        const parts = parseThreadIdentityKey(threadKey);
+        if (!parts) {
+          continue;
+        }
         const current = data.threads[threadKey] ?? {
-          backend: params.backend,
-          threadId,
+          backend: parts.backend,
+          threadId: parts.threadId,
           executionMode: "default" as const,
           extraLinkedDirectories: [],
         };
-        const pinnedRank = String((index + 1) * 1024);
-        pinnedRanks[threadId] = pinnedRank;
+        rankIndex += 1;
+        const pinnedRank = String(rankIndex * 1024);
+        pinnedRanks[threadKey] = pinnedRank;
         data.threads[threadKey] = {
           ...current,
           pinnedRank,
         };
-      });
+      }
       return pinnedRanks;
     });
   }

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -443,14 +443,18 @@ export type SetThreadAgentResponse = {
 };
 
 export type ReorderThreadPinsRequest = {
-  backend?: AppServerBackendKind;
-  /** Complete pinned order for this backend, first item at the top. */
-  threadIds: ThreadIdentifier[];
+  /**
+   * Complete pinned order across ALL backends, first item at the top.
+   * Entries are thread identity keys (`buildThreadIdentityKey`), so a Codex
+   * pin and an ACP pin can be interleaved in any order — pin order is global,
+   * not per-backend (mirrors directory pinning).
+   */
+  threadKeys: string[];
 };
 
 export type ReorderThreadPinsResponse = {
-  backend: AppServerBackendKind;
-  pinnedRanks: Record<ThreadIdentifier, string>;
+  /** Thread identity key -> pin rank. */
+  pinnedRanks: Record<string, string>;
 };
 
 export type SetThreadParentRequest = {


### PR DESCRIPTION
## Problem

Pinned threads could only be sorted **within a single backend** — you couldn't
drag a Codex pin between two ACP (Grok/Qwen) pins, and the pin order had
"invisible boundaries" between backends.

Root cause: the reorder path was per-backend. `reorderThreadPins({ backend, threadIds })`
assigned `pinnedRank = (index+1)*1024` scoped to one backend, so Codex and ACP
pins got **colliding** ranks (1024/2048/…). `comparePinnedThreads` then fell
back to `updatedAt`, interleaving backends by recency instead of user intent.
The nav lists reinforced it by **rejecting cross-backend pin drops**
(`draggedThread.source !== thread.source`) and reordering only within one
backend's slice.

Directory pins already solved exactly this by dropping the backend dimension
("directory keys are globally unique so pin order is global"). Thread identity
keys (`buildThreadIdentityKey`) are globally unique too — so thread pins now work
the same way.

## Change

Pin order is now **global across backends**, mirroring directory pinning:

- **Contract** (`ReorderThreadPinsRequest`): a single `threadKeys` list — the
  complete pinned order across all backends, top first. Response keyed by thread
  identity key.
- **Stores** (agent-core in-memory + sqlite): assign global ranks by index;
  parse each key with `parseThreadIdentityKey` and write each thread's overlay by
  its own `(backend, threadId)`. Unparseable keys are skipped without consuming a
  rank.
- **IPC**: global `thread/pin/reordered` notification (key→rank map).
- **`useThreadNavigation`**: snapshot patch keyed by thread key; reorder callback
  takes the global ordered key list; `setThreadPin` appends above **all** pins,
  not just the same backend's.
- **Nav lists** (Recents, Directories, Sidebar): operate on the global
  pinned-key list, **allow cross-backend drag** (removed the `source !== source`
  gates), keyboard Move + context-menu Move + divider-append all use the global
  list. In the Directories lens, reordering a directory's pins repositions within
  the full pinned set (so a single global rank per thread stays consistent).

`desktop-api`/preload needed no changes — they pass the contract types through.

## Tests

- Store: cross-backend interleave (`codex:c1`, `acp%3Agemini:g1`, `codex:c2` →
  1024/2048/3072) + skip-unparseable-key case.
- Sidebar: new cross-backend Move test (top global pin Moves Down past another
  backend's pins → interleaved order). The old per-backend-boundary assertion
  ("disables Move Down … regardless of backend B") is **inverted** to the new
  global behavior.
- Directory-pin tests unchanged and green. Full `pnpm lint` (typecheck all
  packages + dependency boundaries) passes; 147 pin tests + agent-core suite (196) green.

## Migration note

Existing pins carry colliding per-backend ranks; they'll look unsorted until the
first cross-backend drag re-ranks them globally. No data migration is included —
the first reorder normalizes the affected pins. Called out here in case we want a
one-time normalization follow-up.