### PR TITLE
fix(messaging): show real backend status metadata

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -2518,7 +2518,7 @@ describe("MessagingController", () => {
     );
     expect(statusText).toContain("Account: operator@example.com (ChatGPT team)");
     expect(statusText).toContain(
-      "Rate limits: gpt-5.3-codex primary: 76/100 remaining (24% used)",
+      "Rate limits: gpt-5.3-codex primary: 76% left",
     );
   });
 

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -2468,6 +2468,104 @@ describe("MessagingController", () => {
     });
   });
 
+  it("passes Codex backend metadata through to rendered status cards", async () => {
+    const harness = await createHarness({
+      listBackends: async () => ({
+        fetchedAt: 1000,
+        backends: [
+          buildBackendSummary({
+            account: {
+              type: "chatgpt",
+              email: "operator@example.com",
+              planType: "team",
+            },
+            rateLimits: [
+              {
+                name: "gpt-5.3-codex primary",
+                remaining: 76,
+                limit: 100,
+                usedPercent: 24,
+              },
+            ],
+          }),
+        ],
+      }),
+    });
+    await bindThread(harness);
+    harness.delivered.splice(0);
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "thread/tokenUsage/updated",
+        params: {
+          threadId: "thread-1",
+          tokenUsage: {
+            last: {
+              inputTokens: 16_000,
+              cachedInputTokens: 4_000,
+              outputTokens: 2_000,
+            },
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/status"));
+
+    const statusText = readDeliveredStatusText(harness.delivered.at(-1));
+    expect(statusText).toContain(
+      "Context usage: Latest request usage: 12,000 uncached in · 4,000 cached · 2,000 out",
+    );
+    expect(statusText).toContain("Account: operator@example.com (ChatGPT team)");
+    expect(statusText).toContain(
+      "Rate limits: gpt-5.3-codex primary: 76/100 remaining (24% used)",
+    );
+  });
+
+  it("refreshes pinned status cards when backend account metadata changes", async () => {
+    const harness = await createHarness({
+      listBackends: async () => ({
+        fetchedAt: 1000,
+        backends: [
+          buildBackendSummary({
+            account: {
+              type: "chatgpt",
+              email: "operator@example.com",
+              planType: "team",
+            },
+          }),
+        ],
+      }),
+    });
+    await bindThread(harness);
+    const binding = await harness.store.findActiveBindingForChannel(
+      buildCommandEvent("/status").channel,
+    );
+    harness.delivered.splice(0);
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "account/updated",
+        params: {
+          account: {
+            email: "operator@example.com",
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(harness.delivered).toHaveLength(1);
+    expect(harness.delivered[0]).toMatchObject({
+      kind: "status",
+      delivery: {
+        mode: "update",
+      },
+      targetSurface: binding?.statusSurface,
+      text: expect.stringContaining("Account: operator@example.com (ChatGPT team)"),
+    });
+  });
+
   it("detaches a bound conversation, clears status actions, and unpins the status surface", async () => {
     const harness = await createHarness();
     await harness.controller.handleInboundEvent(

--- a/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
@@ -17,7 +17,7 @@ import {
 import { resolveMessagingThreadState } from "../messaging/core/messaging-thread-state";
 
 describe("buildBindingStatusIntent", () => {
-  it("renders binding, preference, project, and unavailable status fields", () => {
+  it("renders binding, preference, project, and available backend status fields", () => {
     const binding = {
       id: "binding-1",
       authorizedActorIds: ["user-1"],
@@ -43,7 +43,46 @@ describe("buildBindingStatusIntent", () => {
     const navigation = buildNavigationSnapshot();
     const intent = buildBindingStatusIntent({
       id: "status-1",
+      backendSummary: {
+        kind: "codex",
+        label: "Codex",
+        available: true,
+        account: {
+          type: "chatgpt",
+          email: "operator@example.com",
+          planType: "pro",
+        },
+        rateLimits: [
+          {
+            name: "gpt-5.3-codex primary",
+            remaining: 76,
+            limit: 100,
+            usedPercent: 24,
+          },
+        ],
+        methods: [],
+        capabilities: {
+          listThreads: true,
+          createThread: true,
+          resumeThread: true,
+          renameThread: true,
+          readThread: true,
+          startTurn: true,
+          interruptTurn: true,
+          steerTurn: false,
+          transcriptPagination: false,
+          toolUse: true,
+          approvalRequests: true,
+          multiDirectoryThreads: true,
+        },
+        executionModes: [],
+        launchpadOptions: {
+          supportsFastMode: true,
+        },
+      },
       createdAt: 1000,
+      contextUsageSummary:
+        "Latest request usage: 12,000 uncached in · 4,000 cached · 2,000 out",
       binding,
       threadState: resolveMessagingThreadState({ binding, navigation }),
     });
@@ -68,9 +107,16 @@ describe("buildBindingStatusIntent", () => {
     expect(intent.text).toContain("Model: gpt-5.3-codex");
     expect(intent.text).toContain("Reasoning: high");
     expect(intent.text).toContain("Fast mode: on");
+    expect(intent.text).not.toContain("Plan mode:");
     expect(intent.text).toContain("Permissions: Full Access");
     expect(intent.text).toContain("Streaming: Off");
-    expect(intent.text).toContain("Context usage: unavailable");
+    expect(intent.text).toContain(
+      "Context usage: Latest request usage: 12,000 uncached in · 4,000 cached · 2,000 out",
+    );
+    expect(intent.text).toContain("Account: operator@example.com (ChatGPT pro)");
+    expect(intent.text).toContain(
+      "Rate limits: gpt-5.3-codex primary: 76/100 remaining (24% used)",
+    );
     expect(intent.actions).toContainEqual(
       expect.objectContaining({
         id: "status:streaming",
@@ -78,6 +124,99 @@ describe("buildBindingStatusIntent", () => {
         fallbackText: "stream",
       }),
     );
+  });
+
+  it("omits unavailable-only backend metadata rows when no data exists", () => {
+    const binding = buildBinding();
+    const navigation = buildNavigationSnapshot();
+    const intent = buildBindingStatusIntent({
+      id: "status-no-backend-metadata",
+      backendSummary: {
+        kind: "codex",
+        label: "Codex",
+        available: true,
+        methods: [],
+        capabilities: {
+          listThreads: true,
+          createThread: true,
+          resumeThread: true,
+          renameThread: true,
+          readThread: true,
+          startTurn: true,
+          interruptTurn: true,
+          steerTurn: false,
+          transcriptPagination: false,
+          toolUse: true,
+          approvalRequests: true,
+          multiDirectoryThreads: true,
+        },
+        executionModes: [],
+      },
+      createdAt: 1000,
+      binding,
+      threadState: resolveMessagingThreadState({ binding, navigation }),
+    });
+
+    expect(intent.text).not.toContain("Plan mode:");
+    expect(intent.text).not.toContain("Context usage:");
+    expect(intent.text).not.toContain("Account:");
+    expect(intent.text).not.toContain("Rate limits:");
+  });
+
+  it("reports Fast mode as unsupported when the backend says it is not available", () => {
+    const binding = buildBinding();
+    const navigation = buildNavigationSnapshot();
+    delete navigation.launchpadDefaults.fastMode;
+    const intent = buildBindingStatusIntent({
+      id: "status-fast-unsupported",
+      backendSummary: {
+        kind: "acp:gemini",
+        source: "acp",
+        label: "Gemini CLI",
+        available: true,
+        methods: [],
+        capabilities: {
+          listThreads: true,
+          createThread: true,
+          resumeThread: true,
+          renameThread: true,
+          readThread: true,
+          startTurn: true,
+          interruptTurn: true,
+          steerTurn: false,
+          transcriptPagination: false,
+          toolUse: true,
+          approvalRequests: true,
+          multiDirectoryThreads: true,
+        },
+        executionModes: [],
+        launchpadOptions: {
+          supportsFastMode: false,
+        },
+      },
+      createdAt: 1000,
+      binding: {
+        ...binding,
+        backend: "acp:gemini",
+      },
+      threadState: resolveMessagingThreadState({
+        binding: {
+          ...binding,
+          backend: "acp:gemini",
+        },
+        navigation: {
+          ...navigation,
+          threads: [
+            {
+              ...navigation.threads[0]!,
+              source: "acp:gemini",
+            },
+          ],
+        },
+      }),
+    });
+
+    expect(intent.text).toContain("Fast mode: unsupported");
   });
 
   it("renders a pending skill selection on the status card", () => {

--- a/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
   BackendSummary,
   NavigationSnapshot,
@@ -15,6 +15,10 @@ import {
   type MessagingWorkspaceHandoffContext,
 } from "../messaging/core/messaging-status-card";
 import { resolveMessagingThreadState } from "../messaging/core/messaging-thread-state";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe("buildBindingStatusIntent", () => {
   it("renders binding, preference, project, and available backend status fields", () => {
@@ -115,7 +119,7 @@ describe("buildBindingStatusIntent", () => {
     );
     expect(intent.text).toContain("Account: operator@example.com (ChatGPT pro)");
     expect(intent.text).toContain(
-      "Rate limits: gpt-5.3-codex primary: 76/100 remaining (24% used)",
+      "Rate limits: gpt-5.3-codex primary: 76% left",
     );
     expect(intent.actions).toContainEqual(
       expect.objectContaining({
@@ -161,6 +165,73 @@ describe("buildBindingStatusIntent", () => {
     expect(intent.text).not.toContain("Context usage:");
     expect(intent.text).not.toContain("Account:");
     expect(intent.text).not.toContain("Rate limits:");
+  });
+
+  it("formats Codex and Spark rate limits with normalized labels and reset text", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 5, 8, 14, 0, 0));
+
+    const binding = buildBinding();
+    const navigation = buildNavigationSnapshot();
+    const intent = buildBindingStatusIntent({
+      id: "status-rate-limits",
+      backendSummary: {
+        kind: "codex",
+        label: "Codex",
+        available: true,
+        methods: [],
+        capabilities: {
+          listThreads: true,
+          createThread: true,
+          resumeThread: true,
+          renameThread: true,
+          readThread: true,
+          startTurn: true,
+          interruptTurn: true,
+          steerTurn: false,
+          transcriptPagination: false,
+          toolUse: true,
+          approvalRequests: true,
+          multiDirectoryThreads: true,
+        },
+        executionModes: [],
+        rateLimits: [
+          {
+            name: "GPT-5.3-Codex-Spark 5h limit",
+            remaining: 100,
+            usedPercent: 0,
+            resetAt: new Date(2026, 5, 8, 19, 20, 0).getTime(),
+          },
+          {
+            name: "5h limit",
+            remaining: 95,
+            usedPercent: 5,
+            resetAt: new Date(2026, 5, 8, 18, 2, 0).getTime(),
+          },
+          {
+            name: "GPT-5.3-Codex-Spark Weekly limit",
+            remaining: 100,
+            usedPercent: 0,
+            resetAt: new Date(2026, 5, 12, 0, 0, 0).getTime(),
+          },
+          {
+            name: "Weekly limit",
+            remaining: 73,
+            usedPercent: 27,
+            resetAt: new Date(2026, 5, 10, 0, 0, 0).getTime(),
+          },
+        ],
+      },
+      createdAt: 1000,
+      binding,
+      threadState: resolveMessagingThreadState({ binding, navigation }),
+    });
+
+    expect(intent.text).toContain(
+      "Rate limits: 5h limit: 95% left, resets 6:02 PM; Weekly limit: 73% left, resets Jun 10; Spark 5h limit: 100% left, resets 7:20 PM; Spark Weekly limit: 100% left, resets Jun 12",
+    );
+    expect(intent.text).not.toContain("GPT-5.3-Codex-Spark");
+    expect(intent.text).not.toContain("95 remaining");
   });
 
   it("reports Fast mode as unsupported when the backend says it is not available", () => {

--- a/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
@@ -167,6 +167,55 @@ describe("buildBindingStatusIntent", () => {
     expect(intent.text).not.toContain("Rate limits:");
   });
 
+  it("redacts backend account email in shared conversations", () => {
+    const binding = {
+      ...buildBinding(),
+      channel: {
+        channel: "telegram",
+        conversation: {
+          id: "chat-1",
+          kind: "channel",
+        },
+      },
+    } satisfies MessagingBindingRecord;
+    const navigation = buildNavigationSnapshot();
+    const intent = buildBindingStatusIntent({
+      id: "status-shared-account",
+      backendSummary: {
+        kind: "codex",
+        label: "Codex",
+        available: true,
+        account: {
+          type: "chatgpt",
+          email: "operator@example.com",
+          planType: "pro",
+        },
+        methods: [],
+        capabilities: {
+          listThreads: true,
+          createThread: true,
+          resumeThread: true,
+          renameThread: true,
+          readThread: true,
+          startTurn: true,
+          interruptTurn: true,
+          steerTurn: false,
+          transcriptPagination: false,
+          toolUse: true,
+          approvalRequests: true,
+          multiDirectoryThreads: true,
+        },
+        executionModes: [],
+      },
+      createdAt: 1000,
+      binding,
+      threadState: resolveMessagingThreadState({ binding, navigation }),
+    });
+
+    expect(intent.text).toContain("Account: ChatGPT pro");
+    expect(intent.text).not.toContain("operator@example.com");
+  });
+
   it("formats Codex and Spark rate limits with normalized labels and reset text", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(2026, 5, 8, 14, 0, 0));

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -523,6 +523,7 @@ export class MessagingController {
   private readonly pendingIntentTtlMs: number;
   private readonly interactionMapper: MessagingInteractionMapper;
   private readonly activeTurnsByThreadKey = new Map<string, MessagingActiveTurnSummary>();
+  private readonly contextUsageSummariesByThreadKey = new Map<string, string>();
   private readonly typingActivityLastSignaledAt = new Map<string, number>();
   private readonly logger: MessagingControllerLogger;
   private readonly streamingResponsesDefault: boolean;
@@ -670,8 +671,18 @@ export class MessagingController {
 
   async handleBackendEvent(event: AgentEvent): Promise<void> {
     const threadId = threadIdForBackendEvent(event);
+    if (!threadId && isBackendAccountMetadataEvent(event)) {
+      await this.refreshStatusSurfacesForBackend(
+        event.backend,
+        event.notification.method,
+      );
+      return;
+    }
     if (!threadId) {
       return;
+    }
+    if (event.notification.method === "thread/tokenUsage/updated") {
+      this.rememberContextUsageSummary(event);
     }
     if (event.notification.method === "serverRequest/resolved") {
       await this.handleBackendRequestResolved(event);
@@ -701,6 +712,7 @@ export class MessagingController {
       event.notification.method === "thread/executionMode/updated" ||
       event.notification.method === "thread/modelSettings/updated" ||
       event.notification.method === "thread/codexEnvironment/updated" ||
+      event.notification.method === "thread/tokenUsage/updated" ||
       event.notification.method === "thread/parent/set" ||
       event.notification.method === "thread/parent/cleared" ||
       event.notification.method === "thread/subthreadOrder/updated" ||
@@ -909,6 +921,37 @@ export class MessagingController {
     }
     if (lifecycle && isTerminalTurnLifecycle(lifecycle)) {
       this.forgetAutomationTurn(event.backend, threadId, lifecycle.turnId);
+    }
+  }
+
+  private async refreshStatusSurfacesForBackend(
+    backend: AppServerBackendKind,
+    reason: string,
+  ): Promise<void> {
+    const bindings = this.filterBindingsForChannel(
+      await this.options.store.findActiveBindingsForBackend({ backend }),
+    );
+    const renderableBindings = bindings.filter(
+      (binding) => binding.statusSurface || binding.pinnedStatusSurface,
+    );
+    if (renderableBindings.length === 0) {
+      return;
+    }
+    const navigation = await this.options.backend.getNavigationSnapshot({
+      backend: "all",
+    });
+    for (const binding of renderableBindings) {
+      try {
+        await this.renderBindingStatus(binding, undefined, navigation);
+      } catch (error) {
+        this.logger.debug?.("messaging backend status refresh failed", {
+          backend,
+          bindingId: binding.id,
+          error: error instanceof Error ? error.message : String(error),
+          reason,
+          threadId: binding.threadId,
+        });
+      }
     }
   }
 
@@ -7761,6 +7804,32 @@ export class MessagingController {
     return response?.backends.find((candidate) => candidate.kind === backend);
   }
 
+  private rememberContextUsageSummary(event: AgentEvent): void {
+    const params = event.notification.params as {
+      threadId?: unknown;
+      tokenUsage?: unknown;
+    };
+    if (typeof params.threadId !== "string") {
+      return;
+    }
+    const summary = contextUsageSummaryFromValue(params.tokenUsage);
+    if (!summary) {
+      return;
+    }
+    this.contextUsageSummariesByThreadKey.set(
+      buildThreadIdentityKey(event.backend, params.threadId),
+      summary,
+    );
+  }
+
+  private contextUsageSummaryForBinding(
+    binding: MessagingBindingRecord,
+  ): string | undefined {
+    return this.contextUsageSummariesByThreadKey.get(
+      buildThreadIdentityKey(binding.backend, binding.threadId),
+    );
+  }
+
   private async deliverInvalidStatusSelection(
     event: MessagingInboundEvent,
   ): Promise<void> {
@@ -7956,6 +8025,7 @@ export class MessagingController {
             id: this.newIntentId("status-retire"),
             binding,
             capabilityProfile: this.capabilityProfile,
+            contextUsageSummary: this.contextUsageSummaryForBinding(binding),
             createdAt: this.now(),
             threadState: resolveMessagingThreadState({
               activeTurn: this.getActiveTurn(binding),
@@ -8032,9 +8102,7 @@ export class MessagingController {
       binding,
       "status_refresh",
     );
-    const backendSummary = isAcpBackendId(binding.backend)
-      ? await this.getBackendSummary(binding.backend)
-      : undefined;
+    const backendSummary = await this.getBackendSummary(binding.backend);
     const intent = buildBindingStatusIntent({
       id: this.newIntentId("status"),
       allowFullAccessEscalation: (await this.resolveFullAccessControls())
@@ -8042,6 +8110,7 @@ export class MessagingController {
       backendSummary,
       binding,
       capabilityProfile: this.capabilityProfile,
+      contextUsageSummary: this.contextUsageSummaryForBinding(binding),
       createdAt: this.now(),
       handoff: this.options.backend.handoffThreadWorkspace
         ? handoffContextForBinding(binding, snapshot)
@@ -10516,6 +10585,117 @@ function threadIdForBackendEvent(event: AgentEvent): ThreadIdentifier | undefine
     return params.threadId;
   }
   return typeof params.parentThreadId === "string" ? params.parentThreadId : undefined;
+}
+
+function isBackendAccountMetadataEvent(event: AgentEvent): boolean {
+  return event.notification.method === "account/updated" ||
+    event.notification.method === "account/rateLimits/updated";
+}
+
+function contextUsageSummaryFromValue(value: unknown): string | undefined {
+  const explicitSummary = findStringField(value, "summary");
+  if (explicitSummary) {
+    return explicitSummary;
+  }
+
+  const usage = findTokenUsageRecord(value);
+  if (!usage) {
+    return undefined;
+  }
+
+  const cachedInputTokens = Math.max(
+    0,
+    readNumberField(usage, "cachedInputTokens", "cached_input_tokens") ?? 0,
+  );
+  const inputTokens = Math.max(
+    0,
+    readNumberField(usage, "inputTokens", "input_tokens") ?? 0,
+  );
+  const uncachedInputTokens = Math.max(0, inputTokens - cachedInputTokens);
+  const outputTokens = Math.max(
+    0,
+    readNumberField(usage, "outputTokens", "output_tokens") ?? 0,
+  );
+  const reasoningOutputTokens = Math.max(
+    0,
+    readNumberField(usage, "reasoningOutputTokens", "reasoning_output_tokens") ?? 0,
+  );
+  const outputLabel = reasoningOutputTokens > 0
+    ? `${formatContextUsageNumber(outputTokens)} out (${formatContextUsageNumber(
+        reasoningOutputTokens,
+      )} reasoning)`
+    : `${formatContextUsageNumber(outputTokens)} out`;
+
+  return [
+    `Latest request usage: ${formatContextUsageNumber(uncachedInputTokens)} uncached in`,
+    `${formatContextUsageNumber(cachedInputTokens)} cached`,
+    outputLabel,
+  ].join(" · ");
+}
+
+function findTokenUsageRecord(value: unknown): Record<string, unknown> | undefined {
+  const root = asPlainRecord(value);
+  if (!root) {
+    return undefined;
+  }
+  const container =
+    asPlainRecord(root.tokenUsage) ??
+    asPlainRecord(root.token_usage) ??
+    root;
+  const direct =
+    asPlainRecord(container.last) ??
+    asPlainRecord(container.last_token_usage) ??
+    asPlainRecord(container.total) ??
+    asPlainRecord(container.total_token_usage) ??
+    container;
+  if (
+    readNumberField(direct, "inputTokens", "input_tokens") !== undefined ||
+    readNumberField(direct, "cachedInputTokens", "cached_input_tokens") !== undefined ||
+    readNumberField(direct, "outputTokens", "output_tokens") !== undefined ||
+    readNumberField(
+      direct,
+      "reasoningOutputTokens",
+      "reasoning_output_tokens",
+    ) !== undefined
+  ) {
+    return direct;
+  }
+  for (const key of ["data", "payload", "info", "usage", "result"]) {
+    const nested = findTokenUsageRecord(root[key]);
+    if (nested) {
+      return nested;
+    }
+  }
+  return undefined;
+}
+
+function findStringField(value: unknown, key: string): string | undefined {
+  const record = asPlainRecord(value);
+  const direct = record?.[key];
+  return typeof direct === "string" && direct.trim() ? direct.trim() : undefined;
+}
+
+function readNumberField(
+  record: Record<string, unknown>,
+  ...keys: string[]
+): number | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function asPlainRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function formatContextUsageNumber(value: number): string {
+  return Math.round(value).toLocaleString();
 }
 
 function turnIdForBackendEvent(event: AgentEvent): string | undefined {

--- a/apps/desktop/src/main/messaging/core/messaging-status-card.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-status-card.ts
@@ -81,7 +81,7 @@ export function buildBindingStatusIntent(params: {
     params.threadState.fastMode ?? preferences?.fastMode ?? defaults?.fastMode;
   const fastModeLabel = formatFastModeStatus(fastMode, params.backendSummary);
   const contextUsageLine = formatContextUsageLine(params.contextUsageSummary);
-  const accountLine = formatBackendAccountLine(params.backendSummary);
+  const accountLine = formatBackendAccountLine(params.backendSummary, params.binding);
   const rateLimitsLine = formatBackendRateLimitsLine(params.backendSummary);
   const permissionsMode =
     params.threadState.executionMode ??
@@ -197,6 +197,7 @@ function formatContextUsageLine(summary: string | undefined): string | undefined
 
 function formatBackendAccountLine(
   backendSummary: BackendSummary | undefined,
+  binding: MessagingBindingRecord,
 ): string | undefined {
   const account = backendSummary?.account;
   if (!account) {
@@ -210,6 +211,18 @@ function formatBackendAccountLine(
         ? "API key"
         : undefined;
   const detail = [kind, account.planType].filter(Boolean).join(" ");
+  if (binding.channel.conversation.kind !== "dm") {
+    if (detail) {
+      return `Account: ${detail}`;
+    }
+    if (kind) {
+      return `Account: ${kind}`;
+    }
+    if (account.requiresOpenaiAuth) {
+      return "Account: OpenAI auth required";
+    }
+    return undefined;
+  }
   if (account.email && detail) {
     return `Account: ${account.email} (${detail})`;
   }

--- a/apps/desktop/src/main/messaging/core/messaging-status-card.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-status-card.ts
@@ -228,64 +228,127 @@ function formatBackendAccountLine(
 function formatBackendRateLimitsLine(
   backendSummary: BackendSummary | undefined,
 ): string | undefined {
-  const rateLimits = backendSummary?.rateLimits?.filter((rateLimit) =>
-    Boolean(formatBackendRateLimit(rateLimit)),
-  );
+  const rateLimits = selectStatusRateLimits(backendSummary);
   if (!rateLimits || rateLimits.length === 0) {
     return undefined;
   }
 
   return `Rate limits: ${rateLimits
-    .slice(0, 3)
     .map((rateLimit) => formatBackendRateLimit(rateLimit))
     .filter((line): line is string => Boolean(line))
     .join("; ")}`;
 }
 
+function selectStatusRateLimits(
+  backendSummary: BackendSummary | undefined,
+): NonNullable<BackendSummary["rateLimits"]> | undefined {
+  const limits = backendSummary?.rateLimits;
+  if (!limits || limits.length === 0) {
+    return undefined;
+  }
+  return [...limits].sort((left, right) => {
+    const leftName = splitRateLimitName(left.name);
+    const rightName = splitRateLimitName(right.name);
+    const leftFamilyOrder = isSparkRateLimit(left) ? 1 : 0;
+    const rightFamilyOrder = isSparkRateLimit(right) ? 1 : 0;
+    if (leftFamilyOrder !== rightFamilyOrder) {
+      return leftFamilyOrder - rightFamilyOrder;
+    }
+    if (leftName.labelOrder !== rightName.labelOrder) {
+      return leftName.labelOrder - rightName.labelOrder;
+    }
+    return left.name.localeCompare(right.name);
+  });
+}
+
 function formatBackendRateLimit(
   rateLimit: NonNullable<BackendSummary["rateLimits"]>[number],
 ): string | undefined {
-  const parts: string[] = [];
+  const { label } = splitRateLimitName(rateLimit.name);
+  const displayLabel = isSparkRateLimit(rateLimit) ? `Spark ${label}` : label;
+  const resetText = formatRateLimitReset(rateLimit.resetAt);
+  const suffix = resetText ? `, resets ${resetText}` : "";
+
+  if (rateLimit.usedPercent !== undefined) {
+    return `${displayLabel}: ${Math.max(
+      0,
+      Math.round(100 - rateLimit.usedPercent),
+    )}% left${suffix}`;
+  }
   if (rateLimit.remaining !== undefined && rateLimit.limit !== undefined) {
-    parts.push(
-      `${formatWholeNumber(rateLimit.remaining)}/${formatWholeNumber(
-        rateLimit.limit,
-      )} remaining`,
-    );
+    if (rateLimit.limit === 100) {
+      return `${displayLabel}: ${Math.max(
+        0,
+        Math.round(rateLimit.remaining),
+      )}% left${suffix}`;
+    }
+    return `${displayLabel}: ${formatWholeNumber(
+      rateLimit.remaining,
+    )}/${formatWholeNumber(rateLimit.limit)} left${suffix}`;
   } else if (rateLimit.remaining !== undefined) {
-    parts.push(`${formatWholeNumber(rateLimit.remaining)} remaining`);
+    return `${displayLabel}: ${Math.max(
+      0,
+      Math.round(rateLimit.remaining),
+    )}% left${suffix}`;
   } else if (rateLimit.used !== undefined && rateLimit.limit !== undefined) {
-    parts.push(
-      `${formatWholeNumber(rateLimit.used)}/${formatWholeNumber(
-        rateLimit.limit,
-      )} used`,
-    );
-  } else if (rateLimit.usedPercent !== undefined) {
-    parts.push(`${formatPercent(rateLimit.usedPercent)} used`);
+    return `${displayLabel}: ${formatWholeNumber(rateLimit.used)}/${formatWholeNumber(
+      rateLimit.limit,
+    )} used${suffix}`;
   }
 
-  if (
-    rateLimit.usedPercent !== undefined &&
-    !parts.some((part) => part.includes("used"))
-  ) {
-    parts.push(`${formatPercent(rateLimit.usedPercent)} used`);
-  }
+  return undefined;
+}
 
-  if (parts.length === 0) {
+function splitRateLimitName(name: string): {
+  label: string;
+  labelOrder: number;
+} {
+  const trimmed = name.trim();
+  const lower = trimmed.toLowerCase();
+  if (lower.endsWith("5h limit")) {
+    return { label: "5h limit", labelOrder: 0 };
+  }
+  if (lower.endsWith("weekly limit")) {
+    return { label: "Weekly limit", labelOrder: 1 };
+  }
+  return { label: trimmed, labelOrder: 99 };
+}
+
+function isSparkRateLimit(
+  rateLimit: NonNullable<BackendSummary["rateLimits"]>[number],
+): boolean {
+  return isSparkRateLimitName(rateLimit.limitId) ||
+    isSparkRateLimitName(rateLimit.name);
+}
+
+function isSparkRateLimitName(value: string | undefined): boolean {
+  return value?.toLowerCase().includes("spark") ?? false;
+}
+
+function formatRateLimitReset(resetAt: number | undefined): string | undefined {
+  if (typeof resetAt !== "number" || !Number.isFinite(resetAt)) {
     return undefined;
   }
-  if (parts.length === 1) {
-    return `${rateLimit.name}: ${parts[0]}`;
+  const date = new Date(resetAt);
+  if (Number.isNaN(date.getTime())) {
+    return undefined;
   }
-  return `${rateLimit.name}: ${parts[0]} (${parts.slice(1).join(", ")})`;
+  const now = Date.now();
+  const oneDayMs = 24 * 60 * 60 * 1000;
+  if (resetAt >= now && resetAt - now < oneDayMs) {
+    return new Intl.DateTimeFormat(undefined, {
+      hour: "numeric",
+      minute: "2-digit",
+    }).format(date);
+  }
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+  }).format(date);
 }
 
 function formatWholeNumber(value: number): string {
   return Math.round(value).toLocaleString();
-}
-
-function formatPercent(value: number): string {
-  return `${Math.round(value)}%`;
 }
 
 function mentionRequiredLine(

--- a/apps/desktop/src/main/messaging/core/messaging-status-card.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-status-card.ts
@@ -55,6 +55,7 @@ export function buildBindingStatusIntent(params: {
   backendSummary?: BackendSummary;
   binding: MessagingBindingRecord;
   capabilityProfile?: MessagingCapabilityProfile;
+  contextUsageSummary?: string;
   createdAt: number;
   handoff?: MessagingWorkspaceHandoffContext;
   id: string;
@@ -78,6 +79,10 @@ export function buildBindingStatusIntent(params: {
     unavailable();
   const fastMode =
     params.threadState.fastMode ?? preferences?.fastMode ?? defaults?.fastMode;
+  const fastModeLabel = formatFastModeStatus(fastMode, params.backendSummary);
+  const contextUsageLine = formatContextUsageLine(params.contextUsageSummary);
+  const accountLine = formatBackendAccountLine(params.backendSummary);
+  const rateLimitsLine = formatBackendRateLimitsLine(params.backendSummary);
   const permissionsMode =
     params.threadState.executionMode ??
     preferences?.permissionsMode ??
@@ -136,8 +141,7 @@ export function buildBindingStatusIntent(params: {
       mentionRequiredLine(params.binding, params.capabilityProfile),
       `Model: ${model}`,
       `Reasoning: ${reasoning}`,
-      `Fast mode: ${fastMode === undefined ? unavailable() : fastMode ? "on" : "off"}`,
-      "Plan mode: unavailable",
+      `Fast mode: ${fastModeLabel}`,
       acpRuntimeLabel
         ? `Runtime mode: ${acpRuntimeLabel}`
         : `Permissions: ${formatPermissionsLineLabel(permissionsMode, queuedExecutionMode)}`,
@@ -146,9 +150,9 @@ export function buildBindingStatusIntent(params: {
       params.binding.pendingSkillSelection
         ? `Pending skill: $${params.binding.pendingSkillSelection.name}`
         : undefined,
-      "Context usage: unavailable",
-      "Account: unavailable",
-      "Rate limits: unavailable",
+      contextUsageLine,
+      accountLine,
+      rateLimitsLine,
       `Thread: ${params.binding.threadId}`,
       activeTurn ? `Turn: ${activeTurn.status} (${activeTurn.turnId})` : "Turn: idle",
     ]
@@ -169,6 +173,119 @@ export function buildBindingStatusIntent(params: {
       toolUpdateMode,
     }),
   };
+}
+
+function formatFastModeStatus(
+  fastMode: boolean | undefined,
+  backendSummary: BackendSummary | undefined,
+): string {
+  if (fastMode !== undefined) {
+    return fastMode ? "on" : "off";
+  }
+  if (backendSummary?.launchpadOptions?.supportsFastMode === false) {
+    return "unsupported";
+  }
+  return unavailable();
+}
+
+function formatContextUsageLine(summary: string | undefined): string | undefined {
+  if (!summary) {
+    return undefined;
+  }
+  return `Context usage: ${summary}`;
+}
+
+function formatBackendAccountLine(
+  backendSummary: BackendSummary | undefined,
+): string | undefined {
+  const account = backendSummary?.account;
+  if (!account) {
+    return undefined;
+  }
+
+  const kind =
+    account.type === "chatgpt"
+      ? "ChatGPT"
+      : account.type === "apiKey"
+        ? "API key"
+        : undefined;
+  const detail = [kind, account.planType].filter(Boolean).join(" ");
+  if (account.email && detail) {
+    return `Account: ${account.email} (${detail})`;
+  }
+  if (account.email) {
+    return `Account: ${account.email}`;
+  }
+  if (detail) {
+    return `Account: ${detail}`;
+  }
+  if (account.requiresOpenaiAuth) {
+    return "Account: OpenAI auth required";
+  }
+  return undefined;
+}
+
+function formatBackendRateLimitsLine(
+  backendSummary: BackendSummary | undefined,
+): string | undefined {
+  const rateLimits = backendSummary?.rateLimits?.filter((rateLimit) =>
+    Boolean(formatBackendRateLimit(rateLimit)),
+  );
+  if (!rateLimits || rateLimits.length === 0) {
+    return undefined;
+  }
+
+  return `Rate limits: ${rateLimits
+    .slice(0, 3)
+    .map((rateLimit) => formatBackendRateLimit(rateLimit))
+    .filter((line): line is string => Boolean(line))
+    .join("; ")}`;
+}
+
+function formatBackendRateLimit(
+  rateLimit: NonNullable<BackendSummary["rateLimits"]>[number],
+): string | undefined {
+  const parts: string[] = [];
+  if (rateLimit.remaining !== undefined && rateLimit.limit !== undefined) {
+    parts.push(
+      `${formatWholeNumber(rateLimit.remaining)}/${formatWholeNumber(
+        rateLimit.limit,
+      )} remaining`,
+    );
+  } else if (rateLimit.remaining !== undefined) {
+    parts.push(`${formatWholeNumber(rateLimit.remaining)} remaining`);
+  } else if (rateLimit.used !== undefined && rateLimit.limit !== undefined) {
+    parts.push(
+      `${formatWholeNumber(rateLimit.used)}/${formatWholeNumber(
+        rateLimit.limit,
+      )} used`,
+    );
+  } else if (rateLimit.usedPercent !== undefined) {
+    parts.push(`${formatPercent(rateLimit.usedPercent)} used`);
+  }
+
+  if (
+    rateLimit.usedPercent !== undefined &&
+    !parts.some((part) => part.includes("used"))
+  ) {
+    parts.push(`${formatPercent(rateLimit.usedPercent)} used`);
+  }
+
+  if (parts.length === 0) {
+    return undefined;
+  }
+  if (parts.length === 1) {
+    return `${rateLimit.name}: ${parts[0]}`;
+  }
+  return `${rateLimit.name}: ${parts[0]} (${parts.slice(1).join(", ")})`;
+}
+
+function formatWholeNumber(value: number): string {
+  return Math.round(value).toLocaleString();
+}
+
+function formatPercent(value: number): string {
+  return `${Math.round(value)}%`;
 }
 
 function mentionRequiredLine(


### PR DESCRIPTION
## Summary

- I fixed messaging status cards so they use the existing backend metadata bus for real context usage, account, and rate-limit details instead of hardcoded unavailable rows.
- I normalized Codex rate-limit display to match the profile tooltip shape, including regular and Spark 5h/weekly limits, percent-left wording, and reset times.
- I redacted the OpenAI account email outside DM conversations while still showing non-PII account type and plan details.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/messaging-status-card.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `git diff --check`

## Notes

- `Plan mode` is no longer shown as an unavailable placeholder because the status card still does not have a real protocol field for it.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
