### PR TITLE
fix(messaging): add status card pickers

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -4,7 +4,10 @@ import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
-import { buildThreadIdentityKey } from "@pwragent/shared";
+import {
+  applyNavigationLaunchpadProviderSettingsPatch,
+  buildThreadIdentityKey,
+} from "@pwragent/shared";
 import type {
   AcpBackendId,
   AgentEvent,
@@ -475,10 +478,10 @@ function createOverlayStoreMock(params?: {
     },
     getLaunchpadDefaults: async () => launchpadDefaults,
     setLaunchpadDefaults: async (patch: Partial<NavigationLaunchpadDefaults>) => {
-      launchpadDefaults = {
-        ...launchpadDefaults,
-        ...patch,
-      };
+      launchpadDefaults = applyNavigationLaunchpadProviderSettingsPatch(
+        launchpadDefaults,
+        patch,
+      );
       return launchpadDefaults;
     },
     getDirectoryLaunchpad: async ({ directoryKey }: { directoryKey: string }) =>
@@ -6155,6 +6158,91 @@ script = "echo setup"
 
     expect(updated.defaults.workMode).toBe("worktree");
     expect(next.launchpad.workMode).toBe("worktree");
+
+    await registry.close();
+  });
+
+  it("keeps sticky model and permission settings scoped to the selected provider", async () => {
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/start"] },
+        models: [
+          {
+            id: "gpt-5.3-codex",
+            label: "GPT-5.3 Codex",
+            supportsFast: true,
+            supportsReasoning: true,
+          },
+        ],
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock({
+        launchpadDefaults: {
+          backend: "codex",
+          executionMode: "full-access",
+          workMode: "local",
+          model: "gpt-5.3-codex",
+          reasoningEffort: "high",
+          fastMode: true,
+          providerSettings: {
+            codex: {
+              executionMode: "full-access",
+              model: "gpt-5.3-codex",
+              reasoningEffort: "high",
+              fastMode: true,
+            },
+          },
+        },
+      }),
+    });
+
+    await registry.ensureDirectoryLaunchpad({
+      directoryKey: "directory:/repo-a",
+      directoryKind: "directory",
+      directoryLabel: "Repo A",
+      directoryPath: "/repo-a",
+    });
+    const kimi = await registry.updateDirectoryLaunchpad({
+      directoryKey: "directory:/repo-a",
+      patch: { backend: "acp:kimi" as AcpBackendId },
+      stickySettingsChanged: true,
+    });
+
+    expect(kimi.defaults).toMatchObject({
+      backend: "acp:kimi",
+      executionMode: "default",
+    });
+    expect(kimi.defaults.fastMode).toBeUndefined();
+    expect(kimi.defaults.reasoningEffort).toBeUndefined();
+    expect(kimi.launchpad).toMatchObject({
+      backend: "acp:kimi",
+      executionMode: "default",
+    });
+    expect(kimi.launchpad.fastMode).toBeUndefined();
+    expect(kimi.launchpad.reasoningEffort).toBeUndefined();
+
+    const codex = await registry.updateDirectoryLaunchpad({
+      directoryKey: "directory:/repo-a",
+      patch: { backend: "codex" },
+      stickySettingsChanged: true,
+    });
+
+    expect(codex.defaults).toMatchObject({
+      backend: "codex",
+      executionMode: "full-access",
+      fastMode: true,
+      model: "gpt-5.3-codex",
+      reasoningEffort: "high",
+    });
+    expect(codex.launchpad).toMatchObject({
+      backend: "codex",
+      executionMode: "full-access",
+      fastMode: true,
+      model: "gpt-5.3-codex",
+      reasoningEffort: "high",
+    });
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -7820,7 +7820,9 @@ describe("MessagingController", () => {
   });
 
   it("opens a reasoning picker and stores the selected effort", async () => {
-    const harness = await createHarness();
+    const navigation = buildNavigationSnapshot();
+    navigation.launchpadDefaults.reasoningEffort = "medium";
+    const harness = await createHarness({ navigation });
     await bindThread(harness);
 
     await harness.controller.handleInboundEvent(
@@ -7829,6 +7831,11 @@ describe("MessagingController", () => {
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "single_select",
       prompt: "Select Reasoning",
+      choices: expect.arrayContaining([
+        expect.objectContaining({ label: "low" }),
+        expect.objectContaining({ label: "medium (current)" }),
+        expect.objectContaining({ label: "high" }),
+      ]),
     });
 
     await harness.controller.handleInboundEvent(
@@ -7850,6 +7857,23 @@ describe("MessagingController", () => {
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "status",
       text: expect.stringContaining("Reasoning: high"),
+      actions: expect.arrayContaining([
+        expect.objectContaining({
+          id: "status:reasoning",
+          label: "Reasoning: high",
+        }),
+      ]),
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "status:reasoning" }),
+    );
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "single_select",
+      choices: expect.arrayContaining([
+        expect.objectContaining({ label: "medium" }),
+        expect.objectContaining({ label: "high (current)" }),
+      ]),
     });
   });
 

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -9616,6 +9616,84 @@ describe("MessagingController", () => {
     });
   });
 
+  it("uses Kimi config-option permissions in the status picker", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.threads[0] = {
+      ...navigation.threads[0]!,
+      source: "acp:kimi",
+      executionMode: "default",
+      acpRuntime: {
+        configValues: { mode: "default" },
+        currentModeId: "default",
+        updatedAt: 1000,
+      },
+    };
+    const harness = await createHarness({
+      navigation,
+      listBackends: async (): Promise<ListBackendsResponse> => ({
+        fetchedAt: 1000,
+        backends: [buildKimiRuntimeBackendSummary()],
+      }),
+    });
+    await harness.store.upsertBinding({
+      id: "binding:telegram:dm::chat-1:acp:kimi:thread-1",
+      authorizedActorIds: ["user-1"],
+      backend: "acp:kimi",
+      channel: buildCommandEvent("/status").channel,
+      createdAt: 900,
+      threadId: "thread-1",
+      updatedAt: 900,
+    });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/status"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "status:permissions" }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "single_select",
+      prompt: "Select Permissions",
+      choices: expect.arrayContaining([
+        expect.objectContaining({
+          id: "status:set-runtime-mode",
+          label: "Default (current)",
+          value: {
+            optionId: "mode",
+            source: "configOption",
+            value: "default",
+          },
+        }),
+        expect.objectContaining({
+          id: "status:set-runtime-mode",
+          label: "Plan",
+          value: {
+            optionId: "mode",
+            source: "configOption",
+            value: "plan",
+          },
+        }),
+        expect.objectContaining({
+          id: "status:set-runtime-mode",
+          label: "Auto",
+          value: {
+            optionId: "mode",
+            source: "configOption",
+            value: "auto",
+          },
+        }),
+        expect.objectContaining({
+          id: "status:set-runtime-mode",
+          label: "Yolo",
+          value: {
+            optionId: "mode",
+            source: "configOption",
+            value: "yolo",
+          },
+        }),
+      ]),
+    });
+  });
+
   it("shows ACP runtime and Full Access together on the status card", async () => {
     const navigation = buildNavigationSnapshot();
     navigation.threads[0] = {
@@ -10824,6 +10902,69 @@ function buildAcpRuntimeBackendSummary(
     },
     launchpadOptions: {
       models: [{ id: "gemini-3-flash-preview", label: "Gemini 3 Flash Preview" }],
+      reasoningEfforts: [],
+      supportsFastMode: false,
+    },
+    ...overrides,
+  });
+}
+
+function buildKimiRuntimeBackendSummary(
+  overrides: Partial<BackendSummary> = {},
+): BackendSummary {
+  return buildBackendSummary({
+    kind: "acp:kimi",
+    label: "Kimi",
+    source: "acp",
+    executionModes: [],
+    acp: {
+      registryId: "kimi",
+      distributionKinds: ["local"],
+      installStatus: "installed",
+      authStatus: "authenticated",
+      verificationStatus: "not-applicable",
+      runtime: {
+        schemaVersion: 1,
+        status: "discovered",
+        configOptions: [
+          {
+            id: "mode",
+            label: "Mode",
+            type: "select",
+            category: "mode",
+            currentValue: "default",
+            values: [
+              {
+                value: "default",
+                label: "Default",
+                description: "Manual approvals; tools execute normally.",
+              },
+              {
+                value: "plan",
+                label: "Plan",
+                description: "Read-only planning; no tool execution.",
+              },
+              {
+                value: "auto",
+                label: "Auto",
+                description: "Auto-approve safe operations.",
+              },
+              {
+                value: "yolo",
+                label: "YOLO",
+                description: "Auto-approve everything.",
+              },
+            ],
+          },
+        ],
+        modes: {
+          currentModeId: "default",
+          availableModes: [{ id: "default", label: "Default" }],
+        },
+      },
+    },
+    launchpadOptions: {
+      models: [{ id: "kimi-code/kimi-for-coding", label: "Kimi for Coding" }],
       reasoningEfforts: [],
       supportsFastMode: false,
     },

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -3641,11 +3641,11 @@ describe("MessagingController", () => {
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "confirmation",
       title: "Ready to start",
-      body: expect.stringContaining("Permissions: Agent default"),
+      body: expect.stringContaining("Permissions: Agent default + Full Access"),
       actions: expect.arrayContaining([
         expect.objectContaining({
           id: "browse:new:permissions",
-          label: "Permissions: Agent default",
+          label: "Permissions: Agent default + Full Access",
         }),
       ]),
     });
@@ -3961,11 +3961,11 @@ describe("MessagingController", () => {
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "confirmation",
       title: "Ready to start",
-      body: expect.stringContaining("Permissions: Default"),
+      body: expect.stringContaining("Permissions: Default + Full Access"),
       actions: expect.arrayContaining([
         expect.objectContaining({
           id: "browse:new:permissions",
-          label: "Permissions: Default",
+          label: "Permissions: Default + Full Access",
         }),
       ]),
     });
@@ -4273,6 +4273,85 @@ describe("MessagingController", () => {
       expectMaterializeOptions(),
     );
     expect(harness.startTurn).not.toHaveBeenCalled();
+  });
+
+  it("clears a saved Codex environment action when switching environments", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.directories[0] = {
+      ...navigation.directories[0]!,
+      launchpad: {
+        directoryKey: "directory:pwragent",
+        directoryKind: "directory",
+        directoryLabel: "PwrAgent",
+        directoryPath: "/repo/pwragent",
+        backend: "codex",
+        executionMode: "default",
+        prompt: "",
+        workMode: "local",
+        codexEnvironmentId: "repo",
+        codexEnvironmentExecutionTarget: "local",
+        codexEnvironmentSetupEnabled: true,
+        codexEnvironmentActionId: "repo-setup",
+        codexEnvironmentOptions: [
+          {
+            id: "repo",
+            name: "Repo Env",
+            sourcePath: "/repo/pwragent/.codex/environments/repo.toml",
+            setupScript: "pnpm install",
+            actions: [{ id: "repo-setup", name: "Repo Setup", command: "pnpm install" }],
+          },
+          {
+            id: "ci",
+            name: "CI Env",
+            sourcePath: "/repo/pwragent/.codex/environments/ci.toml",
+            setupScript: "pnpm test",
+            actions: [{ id: "ci-setup", name: "CI Setup", command: "pnpm test" }],
+          },
+        ],
+        createdAt: 1000,
+        updatedAt: 1000,
+      },
+    };
+    const harness = await createHarness({ navigation });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:new:set-environment",
+        value: { environmentId: "ci" },
+      }),
+    );
+
+    expect(harness.updateDirectoryLaunchpad).toHaveBeenCalledWith({
+      directoryKey: "directory:pwragent",
+      stickySettingsChanged: true,
+      patch: expect.objectContaining({
+        codexEnvironmentId: "ci",
+        codexEnvironmentExecutionTarget: "local",
+        codexEnvironmentSetupEnabled: true,
+        codexEnvironmentActionId: undefined,
+      }),
+    });
+
+    await harness.controller.handleInboundEvent(buildTextEvent("Use CI environment"));
+
+    const materializeRequest = harness.materializeDirectoryLaunchpad.mock.calls.at(-1)?.[0];
+    expect(materializeRequest?.launchpad).toMatchObject({
+      codexEnvironmentId: "ci",
+      codexEnvironmentExecutionTarget: "local",
+      codexEnvironmentSetupEnabled: true,
+    });
+    expect(materializeRequest?.launchpad.codexEnvironmentActionId).toBeUndefined();
   });
 
   it("clicking the New button on the help surface dispatches the new command", async () => {
@@ -9534,6 +9613,48 @@ describe("MessagingController", () => {
       source: "mode",
       optionId: "mode",
       value: "yolo",
+    });
+  });
+
+  it("shows ACP runtime and Full Access together on the status card", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.threads[0] = {
+      ...navigation.threads[0]!,
+      source: "acp:gemini",
+      executionMode: "full-access",
+      acpRuntime: {
+        currentModeId: "default",
+        updatedAt: 1000,
+      },
+    };
+    const harness = await createHarness({
+      navigation,
+      listBackends: async (): Promise<ListBackendsResponse> => ({
+        fetchedAt: 1000,
+        backends: [buildAcpRuntimeBackendSummary()],
+      }),
+    });
+    await harness.store.upsertBinding({
+      id: "binding:telegram:dm::chat-1:acp:gemini:thread-1",
+      authorizedActorIds: ["user-1"],
+      backend: "acp:gemini",
+      channel: buildCommandEvent("/status").channel,
+      createdAt: 900,
+      threadId: "thread-1",
+      updatedAt: 900,
+    });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/status"));
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "status",
+      text: expect.stringContaining("Permissions: Default + Full Access"),
+      actions: expect.arrayContaining([
+        expect.objectContaining({
+          id: "status:permissions",
+          label: "Permissions: Default + Full Access",
+        }),
+      ]),
     });
   });
 

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -3693,6 +3693,72 @@ describe("MessagingController", () => {
     expect(harness.startTurn).not.toHaveBeenCalled();
   });
 
+  it("treats selecting the current new-thread Full Access permission as a no-op", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.launchpadDefaults = {
+      ...navigation.launchpadDefaults,
+      executionMode: "full-access",
+    };
+    const onFullAccessPolicyViolation = vi.fn();
+    const harness = await createHarness({
+      navigation,
+      fullAccessControls: {
+        allowEscalation: false,
+        allowThreadResume: true,
+        warningPolicy: "never",
+      },
+      onFullAccessPolicyViolation,
+    });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "browse:new:permissions" }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Select permissions",
+      actions: expect.arrayContaining([
+        expect.objectContaining({
+          id: "browse:new:set-permissions",
+          label: "Full Access (current)",
+          value: { executionMode: "full-access" },
+        }),
+      ]),
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:new:set-permissions",
+        value: { executionMode: "full-access" },
+      }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Ready to start",
+      body: expect.stringContaining("Permissions: Full"),
+    });
+    expect(onFullAccessPolicyViolation).not.toHaveBeenCalled();
+    expect(harness.updateDirectoryLaunchpad).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        patch: expect.objectContaining({
+          executionMode: "full-access",
+        }),
+      }),
+    );
+  });
+
   it("does not label ACP model config as permissions in the new-thread prompt", async () => {
     const navigation = buildNavigationSnapshot();
     navigation.launchpadDefaults = {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -9851,6 +9851,80 @@ describe("MessagingController", () => {
     });
   });
 
+  it("does not show or apply Fast and Reasoning controls for Kimi status cards", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.launchpadDefaults.fastMode = true;
+    navigation.launchpadDefaults.reasoningEffort = "high";
+    navigation.threads[0] = {
+      ...navigation.threads[0]!,
+      source: "acp:kimi",
+      model: "kimi-code/kimi-for-coding,thinking",
+      acpRuntime: {
+        configValues: { mode: "default" },
+        currentModeId: "default",
+        updatedAt: 1000,
+      },
+    };
+    const harness = await createHarness({
+      navigation,
+      listBackends: async (): Promise<ListBackendsResponse> => ({
+        fetchedAt: 1000,
+        backends: [buildKimiRuntimeBackendSummary()],
+      }),
+    });
+    await harness.store.upsertBinding({
+      id: "binding:telegram:dm::chat-1:acp:kimi:thread-1",
+      authorizedActorIds: ["user-1"],
+      backend: "acp:kimi",
+      channel: buildCommandEvent("/status").channel,
+      createdAt: 900,
+      threadId: "thread-1",
+      updatedAt: 900,
+    });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/status"));
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "status",
+      text: expect.not.stringContaining("Fast mode:"),
+      actions: expect.not.arrayContaining([
+        expect.objectContaining({ id: "status:fast" }),
+        expect.objectContaining({ id: "status:reasoning" }),
+      ]),
+    });
+    expect(harness.delivered.at(-1)).toMatchObject({
+      text: expect.not.stringContaining("Reasoning:"),
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "status:fast" }),
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "status:reasoning" }),
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "status:set-reasoning",
+        value: { reasoningEffort: "high" },
+      }),
+    );
+
+    expect(harness.setThreadModelSettings).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: "acp:kimi",
+        threadId: "thread-1",
+        fastMode: expect.any(Boolean),
+      }),
+    );
+    expect(harness.setThreadModelSettings).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: "acp:kimi",
+        threadId: "thread-1",
+        reasoningEffort: "high",
+      }),
+    );
+  });
+
   it("shows ACP runtime and Full Access together on the status card", async () => {
     const navigation = buildNavigationSnapshot();
     navigation.threads[0] = {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -9614,6 +9614,16 @@ describe("MessagingController", () => {
       optionId: "mode",
       value: "yolo",
     });
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "status",
+      text: expect.stringContaining("Permissions: Yolo"),
+      actions: expect.arrayContaining([
+        expect.objectContaining({
+          id: "status:permissions",
+          label: "Permissions: Yolo",
+        }),
+      ]),
+    });
   });
 
   it("uses Kimi config-option permissions in the status picker", async () => {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -7735,7 +7735,23 @@ describe("MessagingController", () => {
   });
 
   it("opens a model picker and stores the selected model", async () => {
-    const harness = await createHarness();
+    const harness = await createHarness({
+      listBackends: async () => ({
+        fetchedAt: 1000,
+        backends: [
+          buildBackendSummary({
+            launchpadOptions: {
+              models: [
+                { id: "gpt-5.2-codex", label: "GPT-5.2 Codex", current: true },
+                { id: "gpt-5.3-codex", label: "GPT-5.3 Codex" },
+              ],
+              reasoningEfforts: ["low", "medium", "high"],
+              supportsFastMode: true,
+            },
+          }),
+        ],
+      }),
+    });
     await bindThread(harness);
 
     await harness.controller.handleInboundEvent(buildCallbackEvent({ actionId: "status:model" }));
@@ -7749,6 +7765,12 @@ describe("MessagingController", () => {
             model: "gpt-5.3-codex",
           },
         }),
+      ]),
+    });
+    expect(harness.delivered.at(-1)).toMatchObject({
+      choices: expect.arrayContaining([
+        expect.objectContaining({ label: "GPT-5.2 Codex (current)" }),
+        expect.objectContaining({ label: "GPT-5.3 Codex" }),
       ]),
     });
 
@@ -7768,6 +7790,16 @@ describe("MessagingController", () => {
         model: "gpt-5.3-codex",
       }),
     );
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "status",
+      text: expect.stringContaining("Model: gpt-5.3-codex"),
+      actions: expect.arrayContaining([
+        expect.objectContaining({
+          id: "status:model",
+          label: "Model",
+        }),
+      ]),
+    });
     expect(harness.updateDirectoryLaunchpad).not.toHaveBeenCalled();
     await expect(
       harness.store.findActiveBindingForChannel(buildCommandEvent("/status").channel),
@@ -7775,6 +7807,15 @@ describe("MessagingController", () => {
       preferences: {
         model: "gpt-5.3-codex",
       },
+    });
+
+    await harness.controller.handleInboundEvent(buildCallbackEvent({ actionId: "status:model" }));
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "single_select",
+      choices: expect.arrayContaining([
+        expect.objectContaining({ label: "GPT-5.2 Codex" }),
+        expect.objectContaining({ label: "GPT-5.3 Codex (current)" }),
+      ]),
     });
   });
 

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -9691,6 +9691,88 @@ describe("MessagingController", () => {
     });
   });
 
+  it("falls back to legacy permissions for ACP threads without runtime choices", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.threads[0] = {
+      ...navigation.threads[0]!,
+      source: "acp:gemini",
+      executionMode: "full-access",
+    };
+    const harness = await createHarness({
+      navigation,
+      listBackends: async (): Promise<ListBackendsResponse> => ({
+        fetchedAt: 1000,
+        backends: [
+          buildAcpRuntimeBackendSummary({
+            acp: {
+              registryId: "gemini",
+              distributionKinds: ["local"],
+              installStatus: "installed",
+              authStatus: "authenticated",
+              verificationStatus: "not-applicable",
+            },
+          }),
+        ],
+      }),
+    });
+    await harness.store.upsertBinding({
+      id: "binding:telegram:dm::chat-1:acp:gemini:thread-1",
+      authorizedActorIds: ["user-1"],
+      backend: "acp:gemini",
+      channel: buildCommandEvent("/status").channel,
+      createdAt: 900,
+      threadId: "thread-1",
+      updatedAt: 900,
+    });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/status"));
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "status",
+      text: expect.stringContaining("Full Access"),
+      actions: expect.arrayContaining([
+        expect.objectContaining({
+          id: "status:permissions",
+          label: expect.stringContaining("Full Access"),
+        }),
+      ]),
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "status:permissions" }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "single_select",
+      prompt: "Select Permissions",
+      choices: expect.arrayContaining([
+        expect.objectContaining({
+          id: "status:set-permissions",
+          label: "Default",
+          value: { executionMode: "default" },
+        }),
+        expect.objectContaining({
+          id: "status:set-permissions",
+          label: "Full Access (current)",
+          value: { executionMode: "full-access" },
+        }),
+      ]),
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "status:set-permissions",
+        value: { executionMode: "default" },
+      }),
+    );
+
+    expect(harness.setThreadExecutionMode).toHaveBeenCalledWith({
+      backend: "acp:gemini",
+      threadId: "thread-1",
+      executionMode: "default",
+    });
+  });
+
   it("uses Kimi config-option permissions in the status picker", async () => {
     const navigation = buildNavigationSnapshot();
     navigation.threads[0] = {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -3392,6 +3392,87 @@ describe("MessagingController", () => {
     });
   });
 
+  it("does not leak Codex sticky permissions and speed settings into Kimi new-thread prompts", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.launchpadDefaults = {
+      ...navigation.launchpadDefaults,
+      backend: "codex",
+      executionMode: "full-access",
+      fastMode: true,
+      model: "gpt-5.3-codex",
+      reasoningEffort: "high",
+      providerSettings: {
+        codex: {
+          executionMode: "full-access",
+          fastMode: true,
+          model: "gpt-5.3-codex",
+          reasoningEffort: "high",
+        },
+      },
+    };
+    const harness = await createHarness({
+      navigation,
+      listBackends: async (): Promise<ListBackendsResponse> => ({
+        fetchedAt: 1000,
+        backends: [
+          buildBackendSummary({
+            kind: "codex",
+            label: "Codex",
+            launchpadOptions: {
+              models: [
+                {
+                  id: "gpt-5.3-codex",
+                  label: "GPT-5.3 Codex",
+                  supportsFast: true,
+                  supportsReasoning: true,
+                },
+              ],
+              reasoningEfforts: ["low", "medium", "high"],
+              supportsFastMode: true,
+            },
+          }),
+          buildKimiRuntimeBackendSummary(),
+        ],
+      }),
+    });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:new:set-backend",
+        value: { backend: "acp:kimi" },
+      }),
+    );
+
+    const readyIntent = harness.delivered.at(-1);
+    const body = readyIntent && "body" in readyIntent ? String(readyIntent.body) : "";
+    expect(readyIntent).toMatchObject({
+      kind: "confirmation",
+      title: "Ready to start",
+      body: expect.stringContaining("Provider: Kimi"),
+    });
+    expect(body).toContain("Permissions: Default");
+    expect(body).not.toContain("Full Access");
+    expect(body).not.toContain("Fast mode:");
+    expect(body).not.toContain("Reasoning:");
+    expect(readyIntent).toMatchObject({
+      actions: expect.not.arrayContaining([
+        expect.objectContaining({ id: "browse:new:fast" }),
+        expect.objectContaining({ id: "browse:new:reasoning" }),
+      ]),
+    });
+  });
+
   it("includes enabled ACP backends in the messaging new-thread provider picker", async () => {
     const harness = await createHarness({
       listBackends: async (): Promise<ListBackendsResponse> => ({
@@ -3609,7 +3690,13 @@ describe("MessagingController", () => {
     const navigation = buildNavigationSnapshot();
     navigation.launchpadDefaults = {
       ...navigation.launchpadDefaults,
+      backend: "acp:gemini",
       executionMode: "full-access",
+      providerSettings: {
+        "acp:gemini": {
+          executionMode: "full-access",
+        },
+      },
     };
     const harness = await createHarness({
       navigation,

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -1337,11 +1337,11 @@ describe("MessagingController", () => {
       text: expect.stringContaining("Binding: Thread one"),
     });
     expect(harness.delivered.at(-1)).toMatchObject({
-      text: expect.stringContaining("Tool updates: Show Some"),
+      text: expect.stringContaining("Tool updates: Some"),
       actions: expect.arrayContaining([
         expect.objectContaining({
           id: "status:tool-updates",
-          label: "Tools: Show Some",
+          label: "Tools: Some",
           fallbackText: "tools",
         }),
         expect.objectContaining({
@@ -3489,6 +3489,122 @@ describe("MessagingController", () => {
     });
   });
 
+  it("lets messaging choose a Codex environment before starting a new thread", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.directories[0] = {
+      ...navigation.directories[0]!,
+      launchpad: {
+        directoryKey: "directory:pwragent",
+        directoryKind: "directory",
+        directoryLabel: "PwrAgent",
+        directoryPath: "/repo/pwragent",
+        backend: "codex",
+        executionMode: "default",
+        prompt: "",
+        workMode: "local",
+        codexEnvironmentId: "repo",
+        codexEnvironmentExecutionTarget: "local",
+        codexEnvironmentSetupEnabled: true,
+        codexEnvironmentOptions: [
+          {
+            id: "repo",
+            name: "Repo Env",
+            sourcePath: "/repo/pwragent/.codex/environments/repo.toml",
+            setupScript: "pnpm install",
+            actions: [],
+          },
+          {
+            id: "ci",
+            name: "CI Env",
+            sourcePath: "/repo/pwragent/.codex/environments/ci.toml",
+            setupScript: "pnpm test",
+            actions: [],
+          },
+        ],
+        createdAt: 1000,
+        updatedAt: 1000,
+      },
+    };
+    const harness = await createHarness({ navigation });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Ready to start",
+      body: expect.stringContaining("Environment: Repo Env"),
+      actions: expect.arrayContaining([
+        expect.objectContaining({
+          id: "browse:new:environment",
+          label: "Environment: Repo Env",
+        }),
+      ]),
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "browse:new:environment" }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "single_select",
+      prompt: "Select Environment",
+      choices: expect.arrayContaining([
+        expect.objectContaining({
+          id: "browse:new:set-environment",
+          label: "None",
+          value: { environmentId: null },
+        }),
+        expect.objectContaining({
+          id: "browse:new:set-environment",
+          label: "Repo Env (current)",
+          value: { environmentId: "repo" },
+        }),
+        expect.objectContaining({
+          id: "browse:new:set-environment",
+          label: "CI Env",
+          value: { environmentId: "ci" },
+        }),
+      ]),
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:new:set-environment",
+        value: { environmentId: "ci" },
+      }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Ready to start",
+      body: expect.stringContaining("Environment: CI Env"),
+    });
+
+    await harness.controller.handleInboundEvent(buildTextEvent("Use CI env"));
+
+    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith(
+      expect.objectContaining({
+        directoryKey: expect.stringMatching(/^messaging:browse:/),
+        launchpad: expect.objectContaining({
+          codexEnvironmentId: "ci",
+          codexEnvironmentExecutionTarget: "local",
+          codexEnvironmentSetupEnabled: true,
+        }),
+      }),
+      expectMaterializeOptions(),
+    );
+  });
+
   it("lets ACP messaging clear an inherited Full Access launchpad default", async () => {
     const navigation = buildNavigationSnapshot();
     navigation.launchpadDefaults = {
@@ -3525,17 +3641,23 @@ describe("MessagingController", () => {
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "confirmation",
       title: "Ready to start",
-      body: expect.stringContaining("Permissions: Full"),
+      body: expect.stringContaining("Permissions: Agent default"),
       actions: expect.arrayContaining([
         expect.objectContaining({
           id: "browse:new:permissions",
-          label: "Permissions: Full",
+          label: "Permissions: Agent default",
         }),
       ]),
     });
 
     await harness.controller.handleInboundEvent(
       buildCallbackEvent({ actionId: "browse:new:permissions" }),
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:new:set-permissions",
+        value: { executionMode: "default" },
+      }),
     );
 
     const defaultReadyIntent = harness.delivered.at(-1);
@@ -3571,7 +3693,7 @@ describe("MessagingController", () => {
     expect(harness.startTurn).not.toHaveBeenCalled();
   });
 
-  it("does not label ACP model config as runtime mode in the new-thread prompt", async () => {
+  it("does not label ACP model config as permissions in the new-thread prompt", async () => {
     const navigation = buildNavigationSnapshot();
     navigation.launchpadDefaults = {
       ...navigation.launchpadDefaults,
@@ -3615,17 +3737,17 @@ describe("MessagingController", () => {
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "confirmation",
       title: "Ready to start",
-      body: expect.stringContaining("Runtime mode: Agent default"),
+      body: expect.stringContaining("Permissions: Agent default"),
     });
     expect(harness.delivered.at(-1)).toMatchObject({
       body: expect.stringContaining("Model: gemini-3-flash-preview"),
     });
     expect(harness.delivered.at(-1)).toMatchObject({
-      body: expect.not.stringContaining("Runtime mode: Gemini 3 Flash Preview"),
+      body: expect.not.stringContaining("Permissions: Gemini 3 Flash Preview"),
     });
   });
 
-  it("lets ACP messaging choose a runtime mode before starting a new thread", async () => {
+  it("lets ACP messaging choose a permissions before starting a new thread", async () => {
     const navigation = buildNavigationSnapshot();
     navigation.launchpadDefaults = {
       ...navigation.launchpadDefaults,
@@ -3658,22 +3780,22 @@ describe("MessagingController", () => {
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "confirmation",
       title: "Ready to start",
-      body: expect.stringContaining("Runtime mode: Default"),
+      body: expect.stringContaining("Permissions: Default"),
       actions: expect.arrayContaining([
         expect.objectContaining({
-          id: "browse:new:runtime-mode",
-          label: "Runtime: Default",
+          id: "browse:new:permissions",
+          label: "Permissions: Default",
         }),
       ]),
     });
 
     await harness.controller.handleInboundEvent(
-      buildCallbackEvent({ actionId: "browse:new:runtime-mode" }),
+      buildCallbackEvent({ actionId: "browse:new:permissions" }),
     );
 
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "confirmation",
-      title: "Select runtime mode",
+      title: "Select permissions",
       actions: expect.arrayContaining([
         expect.objectContaining({
           id: "browse:new:set-runtime-mode",
@@ -3702,7 +3824,7 @@ describe("MessagingController", () => {
       kind: "confirmation",
       title: "Ready to start",
       body: expect.stringMatching(
-        /Permissions: Full[\s\S]*Runtime mode: Yolo|Runtime mode: Yolo[\s\S]*Permissions: Full/,
+        /Permissions: Yolo/,
       ),
     });
 
@@ -3781,16 +3903,16 @@ describe("MessagingController", () => {
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "confirmation",
       title: "Ready to start",
-      body: expect.stringContaining("Runtime mode: Yolo"),
+      body: expect.stringContaining("Permissions: Yolo"),
     });
 
     await harness.controller.handleInboundEvent(
-      buildCallbackEvent({ actionId: "browse:new:runtime-mode" }),
+      buildCallbackEvent({ actionId: "browse:new:permissions" }),
     );
 
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "confirmation",
-      title: "Select runtime mode",
+      title: "Select permissions",
       actions: expect.arrayContaining([
         expect.objectContaining({
           id: "browse:new:set-runtime-mode",
@@ -3839,11 +3961,11 @@ describe("MessagingController", () => {
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "confirmation",
       title: "Ready to start",
-      body: expect.stringContaining("Permissions: Full"),
+      body: expect.stringContaining("Permissions: Default"),
       actions: expect.arrayContaining([
         expect.objectContaining({
           id: "browse:new:permissions",
-          label: "Permissions: Full",
+          label: "Permissions: Default",
         }),
       ]),
     });
@@ -3854,18 +3976,17 @@ describe("MessagingController", () => {
 
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "confirmation",
-      title: "Ready to start",
-      body: expect.not.stringContaining("Permissions: Full"),
-      actions: expect.not.arrayContaining([
+      title: "Select permissions",
+      actions: expect.arrayContaining([
         expect.objectContaining({
-          id: "browse:new:permissions",
-          label: "Permissions: Full",
+          id: "browse:new:set-runtime-mode",
+          label: "Yolo",
         }),
       ]),
     });
   });
 
-  it("warning-gates risky ACP runtime modes from messaging", async () => {
+  it("warning-gates risky ACP permissions from messaging", async () => {
     const navigation = buildNavigationSnapshot();
     navigation.launchpadDefaults = {
       ...navigation.launchpadDefaults,
@@ -3937,7 +4058,7 @@ describe("MessagingController", () => {
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "confirmation",
       title: "Ready to start",
-      body: expect.stringContaining("Runtime mode: Yolo"),
+      body: expect.stringContaining("Permissions: Yolo"),
     });
   });
 
@@ -4084,7 +4205,7 @@ describe("MessagingController", () => {
       actions: expect.arrayContaining([
         expect.objectContaining({
           id: "browse:new:environment",
-          label: "Env: none",
+          label: "Environment: None",
         }),
       ]),
     });
@@ -4094,9 +4215,9 @@ describe("MessagingController", () => {
     );
 
     expect(harness.delivered.at(-1)).toMatchObject({
-      kind: "confirmation",
-      title: "Select environment",
-      actions: expect.arrayContaining([
+      kind: "single_select",
+      prompt: "Select Environment",
+      choices: expect.arrayContaining([
         expect.objectContaining({
           id: "browse:new:set-environment",
           label: "Dev Environment",
@@ -4128,7 +4249,7 @@ describe("MessagingController", () => {
       actions: expect.arrayContaining([
         expect.objectContaining({
           id: "browse:new:environment",
-          label: "Env: Dev Environment",
+          label: "Environment: Dev Environment",
         }),
       ]),
     });
@@ -8025,6 +8146,24 @@ describe("MessagingController", () => {
       buildCallbackEvent({ actionId: "status:permissions" }),
     );
 
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "single_select",
+      prompt: "Select Permissions",
+      choices: expect.arrayContaining([
+        expect.objectContaining({
+          id: "status:set-permissions",
+          label: "Full Access",
+          value: { executionMode: "full-access" },
+        }),
+      ]),
+    });
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "status:set-permissions",
+        value: { executionMode: "full-access" },
+      }),
+    );
+
     expect(harness.setThreadExecutionMode).toHaveBeenCalledWith({
       backend: "codex",
       threadId: "thread-1",
@@ -8060,6 +8199,12 @@ describe("MessagingController", () => {
 
     await harness.controller.handleInboundEvent(
       buildCallbackEvent({ actionId: "status:permissions" }),
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "status:set-permissions",
+        value: { executionMode: "full-access" },
+      }),
     );
 
     expect(harness.setThreadExecutionMode).not.toHaveBeenCalled();
@@ -8100,6 +8245,12 @@ describe("MessagingController", () => {
     await harness.controller.handleInboundEvent(
       buildCallbackEvent({ actionId: "status:permissions" }),
     );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "status:set-permissions",
+        value: { executionMode: "full-access" },
+      }),
+    );
 
     expect(harness.setThreadExecutionMode).not.toHaveBeenCalled();
     const warning = harness.delivered.at(-1);
@@ -8111,7 +8262,9 @@ describe("MessagingController", () => {
         mode: "update",
         replaceMarkup: true,
       },
-      targetSurface: binding?.statusSurface,
+      targetSurface: expect.objectContaining({
+        channel: "telegram",
+      }),
       actions: expect.arrayContaining([
         expect.objectContaining({ id: "full-access-risk:accept", label: "Yes" }),
         expect.objectContaining({
@@ -8160,6 +8313,12 @@ describe("MessagingController", () => {
     await harness.controller.handleInboundEvent(
       buildCallbackEvent({ actionId: "status:permissions" }),
     );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "status:set-permissions",
+        value: { executionMode: "full-access" },
+      }),
+    );
 
     const warning = harness.delivered.at(-1);
     expect(warning).toMatchObject({
@@ -8191,6 +8350,12 @@ describe("MessagingController", () => {
 
     await harness.controller.handleInboundEvent(
       buildCallbackEvent({ actionId: "status:permissions" }),
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "status:set-permissions",
+        value: { executionMode: "full-access" },
+      }),
     );
     const warning = harness.delivered.at(-1);
     allowEscalation = false;
@@ -8236,6 +8401,12 @@ describe("MessagingController", () => {
     await harness.controller.handleInboundEvent(
       buildCallbackEvent({ actionId: "status:permissions" }),
     );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "status:set-permissions",
+        value: { executionMode: "full-access" },
+      }),
+    );
 
     const warning = harness.delivered.at(-1);
     expect(warning).toMatchObject({
@@ -8245,7 +8416,9 @@ describe("MessagingController", () => {
         mode: "update",
         replaceMarkup: true,
       },
-      targetSurface: binding?.statusSurface,
+      targetSurface: expect.objectContaining({
+        channel: "telegram",
+      }),
     });
 
     await harness.controller.handleInboundEvent(
@@ -8260,7 +8433,9 @@ describe("MessagingController", () => {
       delivery: expect.objectContaining({
         mode: "update",
       }),
-      targetSurface: binding?.statusSurface,
+      targetSurface: warning && "targetSurface" in warning
+        ? warning.targetSurface
+        : undefined,
       text: expect.stringContaining("Permissions: Full Access"),
     });
   });
@@ -8284,6 +8459,12 @@ describe("MessagingController", () => {
     await harness.controller.handleInboundEvent(
       buildCallbackEvent({ actionId: "status:permissions" }),
     );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "status:set-permissions",
+        value: { executionMode: "full-access" },
+      }),
+    );
 
     const warning = harness.delivered.at(-1);
     await harness.controller.handleInboundEvent(
@@ -8299,7 +8480,9 @@ describe("MessagingController", () => {
       delivery: expect.objectContaining({
         mode: "update",
       }),
-      targetSurface: binding?.statusSurface,
+      targetSurface: warning && "targetSurface" in warning
+        ? warning.targetSurface
+        : undefined,
       text: expect.stringContaining("Permissions: Default"),
     });
   });
@@ -8376,6 +8559,12 @@ describe("MessagingController", () => {
     await harness.controller.handleInboundEvent(
       buildCallbackEvent({ actionId: "browse:new:permissions" }),
     );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:new:set-permissions",
+        value: { executionMode: "full-access" },
+      }),
+    );
 
     const warning = harness.delivered.at(-1);
     expect(warning).toMatchObject({
@@ -8385,9 +8574,9 @@ describe("MessagingController", () => {
         mode: "update",
         replaceMarkup: true,
       },
-      targetSurface: {
-        id: `surface:${readyIntent?.id}`,
-      },
+      targetSurface: expect.objectContaining({
+        id: expect.stringMatching(/^surface:new-thread-permissions:/),
+      }),
     });
 
     await harness.controller.handleInboundEvent(
@@ -8404,9 +8593,9 @@ describe("MessagingController", () => {
       delivery: expect.objectContaining({
         mode: "update",
       }),
-      targetSurface: {
-        id: `surface:${readyIntent?.id}`,
-      },
+      targetSurface: warning && "targetSurface" in warning
+        ? warning.targetSurface
+        : undefined,
     });
   });
 
@@ -9267,7 +9456,7 @@ describe("MessagingController", () => {
     );
   });
 
-  it("lets ACP messaging change runtime mode from the status card", async () => {
+  it("lets ACP messaging change permissions from the status card", async () => {
     const navigation = buildNavigationSnapshot();
     navigation.threads[0] = {
       ...navigation.threads[0]!,
@@ -9299,22 +9488,22 @@ describe("MessagingController", () => {
 
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "status",
-      text: expect.stringContaining("Runtime mode: Default"),
+      text: expect.stringContaining("Permissions: Default"),
       actions: expect.arrayContaining([
         expect.objectContaining({
-          id: "status:runtime-mode",
-          label: "Runtime: Default",
+          id: "status:permissions",
+          label: "Permissions: Default",
         }),
       ]),
     });
 
     await harness.controller.handleInboundEvent(
-      buildCallbackEvent({ actionId: "status:runtime-mode" }),
+      buildCallbackEvent({ actionId: "status:permissions" }),
     );
 
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "single_select",
-      prompt: "Select Runtime Mode",
+      prompt: "Select Permissions",
       choices: expect.arrayContaining([
         expect.objectContaining({
           id: "status:set-runtime-mode",
@@ -9392,7 +9581,7 @@ describe("MessagingController", () => {
 
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "status",
-      text: expect.stringContaining("Tool updates: Show Less"),
+      text: expect.stringContaining("Tool updates: Few"),
     });
 
     await harness.controller.handleInboundEvent(
@@ -9400,8 +9589,26 @@ describe("MessagingController", () => {
     );
 
     expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "single_select",
+      prompt: "Select Tools",
+      choices: expect.arrayContaining([
+        expect.objectContaining({
+          id: "status:set-tool-updates",
+          label: "Some",
+          value: { toolUpdateMode: "show_some" },
+        }),
+      ]),
+    });
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "status:set-tool-updates",
+        value: { toolUpdateMode: "show_some" },
+      }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
       kind: "status",
-      text: expect.stringContaining("Tool updates: Show Some"),
+      text: expect.stringContaining("Tool updates: Some"),
     });
     await expect(
       harness.store.findActiveBindingForChannel(buildCommandEvent("/status").channel),
@@ -9412,20 +9619,30 @@ describe("MessagingController", () => {
     });
   });
 
-  it("cycles the tool update status action through all modes and wraps", async () => {
+  it("sets the tool update status action through the picker", async () => {
     const harness = await createHarness();
     await bindThread(harness);
     harness.delivered.length = 0;
 
-    for (const expected of [
-      "Show More",
-      "Show All",
-      "Show None",
-      "Show Less",
-      "Show Some",
-    ]) {
+    for (const [toolUpdateMode, expected] of [
+      ["show_more", "More"],
+      ["show_all", "All"],
+      ["show_none", "None"],
+      ["show_less", "Few"],
+      ["show_some", "Some"],
+    ] as const) {
       await harness.controller.handleInboundEvent(
         buildCallbackEvent({ actionId: "status:tool-updates" }),
+      );
+      expect(harness.delivered.at(-1)).toMatchObject({
+        kind: "single_select",
+        prompt: "Select Tools",
+      });
+      await harness.controller.handleInboundEvent(
+        buildCallbackEvent({
+          actionId: "status:set-tool-updates",
+          value: { toolUpdateMode },
+        }),
       );
       expect(harness.delivered.at(-1)).toMatchObject({
         kind: "status",

--- a/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
@@ -539,7 +539,7 @@ describe("buildBindingStatusIntent", () => {
     );
   });
 
-  it("renders ACP runtime mode instead of Codex permission controls", () => {
+  it("renders ACP permissions instead of Codex permission controls", () => {
     const navigation = buildNavigationSnapshot();
     navigation.launchpadDefaults.acpRuntime = {
       currentModeId: "default",
@@ -567,22 +567,16 @@ describe("buildBindingStatusIntent", () => {
     });
 
     expect(intent.text).toContain("Binding: Thread one (acp:gemini)");
-    expect(intent.text).toContain("Runtime mode: Yolo");
-    expect(intent.text).not.toContain("Permissions:");
+    expect(intent.text).toContain("Permissions: Yolo");
     expect(intent.actions).toContainEqual(
       expect.objectContaining({
-        id: "status:runtime-mode",
-        label: "Runtime: Yolo",
-      }),
-    );
-    expect(intent.actions).not.toContainEqual(
-      expect.objectContaining({
         id: "status:permissions",
+        label: "Permissions: Yolo",
       }),
     );
   });
 
-  it("does not treat ACP model config values as runtime modes", () => {
+  it("does not treat ACP model config values as permissions", () => {
     const navigation = buildNavigationSnapshot();
     navigation.threads[0] = {
       ...navigation.threads[0]!,
@@ -630,11 +624,11 @@ describe("buildBindingStatusIntent", () => {
       threadState: resolveMessagingThreadState({ binding, navigation }),
     });
 
-    expect(intent.text).toContain("Runtime mode: Agent default");
-    expect(intent.text).not.toContain("Runtime mode: Gemini 3 Flash Preview");
+    expect(intent.text).toContain("Permissions: Agent default");
+    expect(intent.text).not.toContain("Permissions: Gemini 3 Flash Preview");
     expect(intent.actions).not.toContainEqual(
       expect.objectContaining({
-        id: "status:runtime-mode",
+        id: "status:permissions",
       }),
     );
   });

--- a/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
@@ -81,6 +81,7 @@ describe("buildBindingStatusIntent", () => {
         },
         executionModes: [],
         launchpadOptions: {
+          reasoningEfforts: ["low", "medium", "high"],
           supportsFastMode: true,
         },
       },
@@ -283,10 +284,10 @@ describe("buildBindingStatusIntent", () => {
     expect(intent.text).not.toContain("95 remaining");
   });
 
-  it("reports Fast mode as unsupported when the backend says it is not available", () => {
+  it("hides Fast mode when the backend says it is not available", () => {
     const binding = buildBinding();
     const navigation = buildNavigationSnapshot();
-    delete navigation.launchpadDefaults.fastMode;
+    navigation.launchpadDefaults.fastMode = true;
     const intent = buildBindingStatusIntent({
       id: "status-fast-unsupported",
       backendSummary: {
@@ -336,7 +337,69 @@ describe("buildBindingStatusIntent", () => {
       }),
     });
 
-    expect(intent.text).toContain("Fast mode: unsupported");
+    expect(intent.text).not.toContain("Fast mode:");
+    expect(intent.actions).not.toContainEqual(
+      expect.objectContaining({ id: "status:fast" }),
+    );
+  });
+
+  it("does not leak launchpad Fast or Reasoning defaults into ACP status cards", () => {
+    const binding = {
+      ...buildBinding(),
+      backend: "acp:kimi",
+    } satisfies MessagingBindingRecord;
+    const navigation = buildNavigationSnapshot();
+    navigation.launchpadDefaults.fastMode = true;
+    navigation.launchpadDefaults.reasoningEffort = "high";
+    navigation.threads[0] = {
+      ...navigation.threads[0]!,
+      source: "acp:kimi",
+      fastMode: undefined,
+      reasoningEffort: undefined,
+    };
+
+    const intent = buildBindingStatusIntent({
+      id: "status-acp-no-fast",
+      backendSummary: {
+        kind: "acp:kimi",
+        source: "acp",
+        label: "Kimi",
+        available: true,
+        methods: [],
+        capabilities: {
+          listThreads: true,
+          createThread: true,
+          resumeThread: true,
+          renameThread: true,
+          readThread: true,
+          startTurn: true,
+          interruptTurn: true,
+          steerTurn: false,
+          transcriptPagination: false,
+          toolUse: true,
+          approvalRequests: true,
+          multiDirectoryThreads: true,
+        },
+        executionModes: [],
+        launchpadOptions: {
+          models: [{ id: "kimi-code/kimi-for-coding", label: "Kimi for Coding" }],
+          reasoningEfforts: [],
+          supportsFastMode: false,
+        },
+      },
+      createdAt: 1000,
+      binding,
+      threadState: resolveMessagingThreadState({ binding, navigation }),
+    });
+
+    expect(intent.text).not.toContain("Fast mode:");
+    expect(intent.text).not.toContain("Reasoning:");
+    expect(intent.actions).not.toContainEqual(
+      expect.objectContaining({ id: "status:fast" }),
+    );
+    expect(intent.actions).not.toContainEqual(
+      expect.objectContaining({ id: "status:reasoning" }),
+    );
   });
 
   it("renders a pending skill selection on the status card", () => {

--- a/apps/desktop/src/main/__tests__/overlay-store-launchpad-defaults.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-launchpad-defaults.test.ts
@@ -104,7 +104,18 @@ describe("SqliteOverlayStore - launchpad defaults", () => {
 
     await store.setLaunchpadDefaults({ fastMode: false, serviceTier: undefined });
 
-    expect(listDefaultKeys()).toEqual(["backend", "executionMode", "fastMode"]);
+    expect(listDefaultKeys()).toEqual([
+      "backend",
+      "executionMode",
+      "fastMode",
+      "providerSettings",
+    ]);
+    expect(readDefaultValue("providerSettings")).toEqual({
+      codex: {
+        executionMode: "default",
+        fastMode: false,
+      },
+    });
   });
 
   it("preserves unknown launchpad default keys while clearing owned keys", async () => {

--- a/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
@@ -301,6 +301,55 @@ describe("TelegramAdapter", () => {
     });
   });
 
+  it("stores browse session ids for single-select callback handles", async () => {
+    const harness = await createControllerHarness();
+
+    await harness.adapter.deliver({
+      id: "environment-picker",
+      kind: "single_select",
+      browseSessionId: "browse-env-1",
+      createdAt: 1000,
+      fallbackText: "Pick an environment.",
+      prompt: "Select Environment",
+      choices: [
+        {
+          id: "browse:new:set-environment",
+          label: "Dev",
+          value: { environmentId: "dev" },
+        },
+      ],
+      audit: {
+        actor: { platformUserId: "42" },
+        channel: {
+          channel: "telegram",
+          conversation: { id: "777", kind: "dm" },
+        },
+        occurredAt: 1000,
+      },
+    });
+
+    const request = harness.api.sendMessage.mock.calls.at(-1)?.[0];
+    const callbackData = request?.reply_markup?.inline_keyboard[0]?.[0]?.callback_data;
+    await expect(
+      harness.store.resolveCallbackHandle({
+        actorId: "42",
+        channel: {
+          channel: "telegram",
+          conversation: {
+            id: "777",
+            kind: "dm",
+          },
+        },
+        handle: callbackData ?? "",
+        now: 1000,
+      }),
+    ).resolves.toMatchObject({
+      actionId: "browse:new:set-environment",
+      browseSessionId: "browse-env-1",
+      value: { environmentId: "dev" },
+    });
+  });
+
   it("treats `@PwrAgentBot resume` as the /resume command", async () => {
     const harness = await createControllerHarness();
     await harness.adapter.start((event) => harness.controller.handleInboundEvent(event));

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -78,6 +78,8 @@ import {
   type SetAcpSessionRuntimeOptionResponse,
   type RenameThreadRequest,
   type RenameThreadResponse,
+  applyNavigationLaunchpadProviderSettingsPatch,
+  projectNavigationLaunchpadProviderSettings,
   type RestoreWorktreeRequest,
   type RestoreWorktreeResponse,
   type RestoreThreadRequest,
@@ -6849,17 +6851,18 @@ export class DesktopBackendRegistry {
     );
     if (existing) {
       const registeredAt = existing.registeredAt ?? request.registeredAt;
-      const backend = await this.resolveLaunchpadBackend(existing.backend);
+      const existingLaunchpad = projectNavigationLaunchpadProviderSettings(existing);
+      const backend = await this.resolveLaunchpadBackend(existingLaunchpad.backend);
       const modelSettings = await this.resolveLaunchpadModelSettings(
         backend,
-        existing,
+        existingLaunchpad,
       );
       const executionMode = getAvailableExecutionMode(
         backend,
-        existing.executionMode,
+        existingLaunchpad.executionMode,
       );
       const normalizedExisting: NavigationLaunchpadDraft = {
-        ...existing,
+        ...existingLaunchpad,
         backend: backend.kind,
         executionMode,
         ...modelSettings,
@@ -6889,6 +6892,8 @@ export class DesktopBackendRegistry {
           reasoningEffort: defaults.reasoningEffort,
           serviceTier: defaults.serviceTier,
           fastMode: defaults.fastMode,
+          acpRuntime: defaults.acpRuntime,
+          providerSettings: defaults.providerSettings,
           workMode: defaultLaunchpadWorkMode(request, defaults),
           branchName: existing.branchName ?? request.currentBranch,
           parentThreadId: requestParentThreadId,
@@ -6951,6 +6956,8 @@ export class DesktopBackendRegistry {
       reasoningEffort: defaults.reasoningEffort,
       serviceTier: defaults.serviceTier,
       fastMode: defaults.fastMode,
+      acpRuntime: defaults.acpRuntime,
+      providerSettings: defaults.providerSettings,
       prompt: "",
       registeredAt: request.registeredAt,
       workMode: defaultLaunchpadWorkMode(request, defaults),
@@ -6982,12 +6989,12 @@ export class DesktopBackendRegistry {
         directoryLabel: request.directoryKey,
       })).launchpad;
 
-    const nextLaunchpad: NavigationLaunchpadDraft = {
-      ...current,
+    const patch = {
       ...request.patch,
-      ...("fastMode" in request.patch
-        ? { serviceTier: undefined }
-        : {}),
+      ...("fastMode" in request.patch ? { serviceTier: undefined } : {}),
+    };
+    const nextLaunchpad: NavigationLaunchpadDraft = {
+      ...applyNavigationLaunchpadProviderSettingsPatch(current, patch),
       directoryKey: request.directoryKey,
       settingsTouchedAt: request.stickySettingsChanged
         ? Date.now()
@@ -7000,21 +7007,24 @@ export class DesktopBackendRegistry {
     if (request.stickySettingsChanged && request.patch.backend) {
       stickyPatch.backend = request.patch.backend;
     }
-    if (request.stickySettingsChanged && request.patch.executionMode) {
-      stickyPatch.executionMode = request.patch.executionMode;
+    if (request.stickySettingsChanged && patch.executionMode) {
+      stickyPatch.executionMode = patch.executionMode;
     }
-    if (request.stickySettingsChanged && "model" in request.patch) {
-      stickyPatch.model = request.patch.model;
+    if (request.stickySettingsChanged && "model" in patch) {
+      stickyPatch.model = patch.model;
     }
-    if (request.stickySettingsChanged && "reasoningEffort" in request.patch) {
-      stickyPatch.reasoningEffort = request.patch.reasoningEffort;
+    if (request.stickySettingsChanged && "reasoningEffort" in patch) {
+      stickyPatch.reasoningEffort = patch.reasoningEffort;
     }
-    if (request.stickySettingsChanged && "serviceTier" in request.patch) {
-      stickyPatch.serviceTier = request.patch.serviceTier;
+    if (request.stickySettingsChanged && "serviceTier" in patch) {
+      stickyPatch.serviceTier = patch.serviceTier;
     }
-    if (request.stickySettingsChanged && "fastMode" in request.patch) {
-      stickyPatch.fastMode = request.patch.fastMode;
+    if (request.stickySettingsChanged && "fastMode" in patch) {
+      stickyPatch.fastMode = patch.fastMode;
       stickyPatch.serviceTier = undefined;
+    }
+    if (request.stickySettingsChanged && "acpRuntime" in patch) {
+      stickyPatch.acpRuntime = patch.acpRuntime;
     }
     if (request.stickySettingsChanged && request.patch.workMode) {
       stickyPatch.workMode = request.patch.workMode;
@@ -7767,19 +7777,34 @@ export class DesktopBackendRegistry {
     storedDefaults: NavigationLaunchpadDefaults,
     preferredBackend?: AppServerBackendKind,
   ): Promise<NavigationLaunchpadDefaults> {
+    const projectedDefaults =
+      projectNavigationLaunchpadProviderSettings(storedDefaults);
     const backend = await this.resolveLaunchpadBackend(
-      preferredBackend ?? storedDefaults.backend,
+      preferredBackend ?? projectedDefaults.backend,
     );
+    const backendDefaults =
+      backend.kind === projectedDefaults.backend
+        ? projectedDefaults
+        : projectNavigationLaunchpadProviderSettings({
+            ...projectedDefaults,
+            backend: backend.kind,
+            executionMode: "default",
+            model: undefined,
+            reasoningEffort: undefined,
+            serviceTier: undefined,
+            fastMode: undefined,
+            acpRuntime: undefined,
+          });
     const modelSettings = await this.resolveLaunchpadModelSettings(
       backend,
-      storedDefaults,
+      backendDefaults,
     );
     const resolvedDefaults: NavigationLaunchpadDefaults = {
-      ...storedDefaults,
+      ...backendDefaults,
       backend: backend.kind,
       executionMode: getAvailableExecutionMode(
         backend,
-        storedDefaults.executionMode,
+        backendDefaults.executionMode,
       ),
       ...modelSettings,
     };
@@ -7791,8 +7816,8 @@ export class DesktopBackendRegistry {
       delete resolvedDefaults.serviceTier;
     }
 
-    if (launchpadDefaultsEqual(storedDefaults, resolvedDefaults)) {
-      return storedDefaults;
+    if (launchpadDefaultsEqual(projectedDefaults, resolvedDefaults)) {
+      return projectedDefaults;
     }
 
     return await this.overlayStore.setLaunchpadDefaults(resolvedDefaults);

--- a/apps/desktop/src/main/messaging/core/messaging-acp-runtime.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-acp-runtime.ts
@@ -35,6 +35,38 @@ export function buildMessagingAcpRuntimeModeSummary(params: {
   }
 
   const runtimeCapabilities = backend.acp?.runtime;
+  const modeConfigOptions =
+    runtimeCapabilities?.configOptions?.filter(isRuntimeModeConfigOption) ?? [];
+  const configChoices = modeConfigOptions.flatMap((option) => {
+    const currentModeValue =
+      params.runtime?.currentModeId &&
+      option.values.some((value) => value.value === params.runtime?.currentModeId)
+        ? params.runtime.currentModeId
+        : undefined;
+    const currentValue =
+      currentModeValue ??
+      params.runtime?.configValues?.[option.id] ??
+      option.currentValue ??
+      defaultConfigOptionValue(option);
+    return option.values.map((value) => ({
+      description: value.description,
+      label: formatMessagingAcpRuntimeModeLabel(value.label || value.value),
+      optionId: option.id,
+      privileged: messagingAcpRuntimeValueLooksPrivileged(value.value),
+      selected: value.value === currentValue,
+      source: "configOption" as const,
+      value: value.value,
+    }));
+  });
+  if (configChoices.length > 0) {
+    const selected = configChoices.find((choice) => choice.selected);
+    return {
+      choices: configChoices,
+      currentLabel: selected?.label ?? "Agent default",
+      currentValue: selected?.value,
+    };
+  }
+
   const modeChoices =
     runtimeCapabilities?.modes?.availableModes.map((mode) => ({
       description: mode.description,
@@ -58,32 +90,6 @@ export function buildMessagingAcpRuntimeModeSummary(params: {
       choices,
       currentLabel: labelForRuntimeValue(choices, currentValue),
       currentValue,
-    };
-  }
-
-  const modeConfigOptions =
-    runtimeCapabilities?.configOptions?.filter(isRuntimeModeConfigOption) ?? [];
-  const configChoices = modeConfigOptions.flatMap((option) => {
-    const currentValue =
-      params.runtime?.configValues?.[option.id] ??
-      option.currentValue ??
-      defaultConfigOptionValue(option);
-    return option.values.map((value) => ({
-      description: value.description,
-      label: formatMessagingAcpRuntimeModeLabel(value.label || value.value),
-      optionId: option.id,
-      privileged: messagingAcpRuntimeValueLooksPrivileged(value.value),
-      selected: value.value === currentValue,
-      source: "configOption" as const,
-      value: value.value,
-    }));
-  });
-  if (configChoices.length > 0) {
-    const selected = configChoices.find((choice) => choice.selected);
-    return {
-      choices: configChoices,
-      currentLabel: selected?.label ?? "Agent default",
-      currentValue: selected?.value,
     };
   }
 

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -6876,12 +6876,22 @@ export class MessagingController {
       "medium",
       "high",
     ];
+    const navigation = await this.options.backend.getNavigationSnapshot({
+      backend: "all",
+    });
+    const thread = findThreadForBinding(navigation, binding);
+    const currentReasoningEffort =
+      thread?.reasoningEffort ??
+      binding.preferences?.reasoningEffort ??
+      navigation.launchpadDefaults.reasoningEffort;
+
     await this.deliver(
       buildStatusReasoningPickerIntent({
         id: this.newIntentId("status-reasoning-picker"),
         capabilityProfile: this.capabilityProfile,
         binding,
         createdAt: this.now(),
+        currentReasoningEffort,
         efforts,
       }),
       binding,
@@ -7023,6 +7033,9 @@ export class MessagingController {
       return;
     }
 
+    const navigation = await this.options.backend.getNavigationSnapshot({
+      backend: "all",
+    });
     const updatedBinding = await this.updateBindingPreferences(binding, {
       reasoningEffort,
     });
@@ -7034,8 +7047,16 @@ export class MessagingController {
       reasoningEffort,
       serviceTier: updatedBinding.preferences?.serviceTier,
     });
-    // Refresh handled by the thread-state update bus on
-    // thread/modelSettings/updated — see refreshStatusSurfacesForThread.
+    const optimisticNavigation: NavigationSnapshot = {
+      ...navigation,
+      threads: navigation.threads.map((candidate) =>
+        candidate.source === binding.backend && candidate.id === binding.threadId
+          ? { ...candidate, reasoningEffort }
+          : candidate,
+      ),
+    };
+    await this.clearActiveBindingSubmodeIntent(event, updatedBinding);
+    await this.renderBindingStatus(updatedBinding, event, optimisticNavigation);
   }
 
   private async setBindingAcpRuntimeMode(

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -6889,6 +6889,10 @@ export class MessagingController {
       "medium",
       "high",
     ];
+    if (summary && efforts.length === 0) {
+      await this.renderBindingStatus(binding, event);
+      return;
+    }
     const navigation = await this.options.backend.getNavigationSnapshot({
       backend: "all",
     });
@@ -7045,6 +7049,16 @@ export class MessagingController {
       await this.deliverInvalidStatusSelection(event);
       return;
     }
+    const summary = await this.getBackendSummary(binding.backend);
+    const efforts = summary?.launchpadOptions?.reasoningEfforts ?? [
+      "low",
+      "medium",
+      "high",
+    ];
+    if (summary && !efforts.includes(reasoningEffort)) {
+      await this.renderBindingStatus(binding, event);
+      return;
+    }
 
     const navigation = await this.options.backend.getNavigationSnapshot({
       backend: "all",
@@ -7188,6 +7202,14 @@ export class MessagingController {
     binding: MessagingBindingRecord,
     event: MessagingInboundEvent,
   ): Promise<void> {
+    const summary = await this.getBackendSummary(binding.backend);
+    if (
+      summary &&
+      (summary.kind !== "codex" || summary.launchpadOptions?.supportsFastMode === false)
+    ) {
+      await this.renderBindingStatus(binding, event);
+      return;
+    }
     const fastMode = !binding.preferences?.fastMode;
     const updatedBinding = await this.updateBindingPreferences(binding, {
       fastMode,

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -6166,7 +6166,20 @@ export class MessagingController {
     }
     if (actionId === "status:permissions") {
       if (isAcpBackendId(binding.backend)) {
-        await this.presentStatusAcpRuntimeModePicker(binding, event);
+        const summary = await this.getBackendSummary(binding.backend);
+        const navigation = await this.options.backend.getNavigationSnapshot({
+          backend: "all",
+        });
+        const thread = findThreadForBinding(navigation, binding);
+        const runtimeMode = buildMessagingAcpRuntimeModeSummary({
+          backend: summary,
+          runtime: thread?.acpRuntime ?? binding.preferences?.acpRuntime,
+        });
+        if (runtimeMode.choices.length > 0) {
+          await this.presentStatusAcpRuntimeModePicker(binding, event);
+        } else {
+          await this.presentPermissionsPicker(binding, event);
+        }
       } else {
         await this.presentPermissionsPicker(binding, event);
       }
@@ -7252,10 +7265,6 @@ export class MessagingController {
     binding: MessagingBindingRecord,
     event: MessagingInboundCallbackEvent,
   ): Promise<void> {
-    if (isAcpBackendId(binding.backend)) {
-      await this.renderBindingStatus(binding, event);
-      return;
-    }
     const executionMode = readThreadExecutionModeValue(event.value);
     if (!executionMode) {
       await this.deliverInvalidStatusSelection(event);

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -6842,12 +6842,23 @@ export class MessagingController {
       return;
     }
 
+    const navigation = await this.options.backend.getNavigationSnapshot({
+      backend: "all",
+    });
+    const thread = findThreadForBinding(navigation, binding);
+    const currentModelId =
+      thread?.model ??
+      binding.preferences?.model ??
+      navigation.launchpadDefaults.model ??
+      models.find((model) => model.current)?.id;
+
     await this.deliver(
       buildStatusModelPickerIntent({
         id: this.newIntentId("status-model-picker"),
         capabilityProfile: this.capabilityProfile,
         binding,
         createdAt: this.now(),
+        currentModelId,
         models,
       }),
       binding,
@@ -6976,6 +6987,9 @@ export class MessagingController {
       return;
     }
 
+    const navigation = await this.options.backend.getNavigationSnapshot({
+      backend: "all",
+    });
     const updatedBinding = await this.updateBindingPreferences(binding, {
       model,
     });
@@ -6987,9 +7001,16 @@ export class MessagingController {
       reasoningEffort: updatedBinding.preferences?.reasoningEffort,
       serviceTier: updatedBinding.preferences?.serviceTier,
     });
-    // Bus-driven refresh: setThreadModelSettings emits thread/modelSettings/updated
-    // which fans out to refreshStatusSurfacesForThread for every controller —
-    // including this one — so we don't need an inline render here.
+    const optimisticNavigation: NavigationSnapshot = {
+      ...navigation,
+      threads: navigation.threads.map((candidate) =>
+        candidate.source === binding.backend && candidate.id === binding.threadId
+          ? { ...candidate, model }
+          : candidate,
+      ),
+    };
+    await this.clearActiveBindingSubmodeIntent(event, updatedBinding);
+    await this.renderBindingStatus(updatedBinding, event, optimisticNavigation);
   }
 
   private async setBindingReasoning(

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -12,10 +12,10 @@ import type {
   AppServerTurnInputItem,
   AppServerBackendKind,
   AutomationRunOutputDecision,
+  CodexEnvironmentOption,
   BackendAcpRuntimeOptionSource,
   BackendAcpSessionRuntimeState,
   BackendSummary,
-  CodexEnvironmentOption,
   AppServerPendingRequestNotification,
   AppServerToolRequestUserInputNotification,
   DesktopAuthorizedContact,
@@ -119,17 +119,20 @@ import {
 } from "./messaging-resume-browser.js";
 import {
   buildBindingStatusIntent,
+  buildNewThreadEnvironmentPickerIntent,
   buildStatusAcpRuntimeModePickerIntent,
   buildBranchPickerPage,
   buildHandoffBranchPickerIntent,
   buildHandoffConfirmationIntent,
   buildHandoffOverviewIntent,
   buildStatusModelPickerIntent,
+  buildStatusPermissionsPickerIntent,
   buildStatusReasoningPickerIntent,
+  buildStatusToolUpdateModePickerIntent,
   formatExecutionModeLabel,
   handoffRequestFromValue,
+  messagingToolUpdateModeChoices,
   nextMessagingStreamingResponseMode,
-  nextMessagingToolUpdateMode,
   resolveMessagingStreamingResponseMode,
   resolveMessagingToolUpdateMode,
   type MessagingWorkspaceHandoffContext,
@@ -3300,47 +3303,65 @@ export class MessagingController {
       return;
     }
     if (actionId === "browse:new:permissions") {
-      const directory = nextSession.selectedProject
-        ? directoryForProjectSelection(navigation, nextSession.selectedProject)
-        : undefined;
-      const currentMode =
-        nextSession.preferences?.executionMode ??
-        directory?.launchpad?.executionMode ??
-        navigation.launchpadDefaults.executionMode;
-      const executionMode = currentMode === "full-access" ? "default" : "full-access";
-      if (
-        nextSession.backend &&
-        isAcpBackendId(nextSession.backend) &&
-        executionMode === "full-access"
-      ) {
-        await this.presentNewThreadPromptGate(nextSession, event, navigation);
+      if (nextSession.backend && isAcpBackendId(nextSession.backend)) {
+        const summary = await this.getBackendSummary(nextSession.backend);
+        const directory = nextSession.selectedProject
+          ? directoryForProjectSelection(navigation, nextSession.selectedProject)
+          : undefined;
+        const runtimeChoices = summary
+          ? buildMessagingAcpRuntimeModeSummary({
+              backend: summary,
+              runtime: newThreadOptionsForSession(
+                nextSession,
+                navigation,
+                directory,
+                this.streamingResponsesDefault,
+                summary,
+              ).acpRuntime,
+            }).choices
+          : [];
+        if (runtimeChoices.length > 0) {
+          await this.presentNewThreadAcpRuntimeModePicker(
+            nextSession,
+            event,
+            nextSession.backend,
+            navigation,
+          );
+        } else {
+          await this.presentNewThreadPermissionsPicker(nextSession, event, navigation);
+        }
         return;
       }
-      if (executionMode === "full-access") {
-        const allowed = await this.ensureFullAccessEscalationAllowed(
-          { kind: "new-thread", session: nextSession },
-          event,
-        );
-        if (!allowed) {
-          return;
-        }
-      }
-      await this.updateNewThreadStickySettings(nextSession, {
-        executionMode,
-      });
-      await this.presentNewThreadPromptGate(
-        {
-          ...nextSession,
-          preferences: {
-            ...nextSession.preferences,
-            executionMode,
-            permissionsMode: executionMode,
-            updatedAt: this.now(),
-          },
-        },
+      await this.presentNewThreadPermissionsPicker(nextSession, event, navigation);
+      return;
+    }
+    if (actionId === "browse:new:set-permissions") {
+      await this.setNewThreadPermissions(nextSession, event, navigation);
+      return;
+    }
+    if (actionId === "browse:new:environment") {
+      await this.presentNewThreadEnvironmentPicker(nextSession, event, navigation);
+      return;
+    }
+    if (actionId === "browse:new:environment:back") {
+      await this.presentNewThreadPromptGate(nextSession, event, navigation);
+      return;
+    }
+    if (actionId === "browse:new:set-environment") {
+      await this.setNewThreadEnvironment(nextSession, event, navigation);
+      return;
+    }
+    if (actionId === "browse:new:runtime-mode") {
+      await this.presentNewThreadAcpRuntimeModePicker(
+        nextSession,
         event,
+        nextSession.backend ?? navigation.launchpadDefaults.backend,
         navigation,
       );
+      return;
+    }
+    if (actionId === "browse:new:set-runtime-mode") {
+      await this.setNewThreadAcpRuntimeMode(nextSession, event, navigation);
       return;
     }
     if (actionId === "browse:new:fast") {
@@ -3385,29 +3406,8 @@ export class MessagingController {
       );
       return;
     }
-    if (actionId === "browse:new:environment") {
-      await this.presentNewThreadEnvironmentPicker(nextSession, navigation, event);
-      return;
-    }
-    if (actionId === "browse:new:set-environment") {
-      await this.setNewThreadEnvironment(nextSession, navigation, event);
-      return;
-    }
     if (actionId === "browse:new:backend") {
       await this.presentNewThreadBackendPicker(nextSession, event, navigation);
-      return;
-    }
-    if (actionId === "browse:new:runtime-mode") {
-      await this.presentNewThreadAcpRuntimeModePicker(
-        nextSession,
-        event,
-        nextSession.backend ?? navigation.launchpadDefaults.backend,
-        navigation,
-      );
-      return;
-    }
-    if (actionId === "browse:new:set-runtime-mode") {
-      await this.setNewThreadAcpRuntimeMode(nextSession, event, navigation);
       return;
     }
     if (actionId === "browse:new:set-backend") {
@@ -3897,7 +3897,6 @@ export class MessagingController {
       Boolean(
         selectedBackend.launchpadOptions?.models?.some((model) => model.supportsFast),
       );
-    const codexEnvironmentOptions = codexEnvironmentOptionsForDirectory(directory);
     const supportsPermissionsControls =
       !isAcpBackendId(selectedBackend.kind) ||
       options.executionMode === "full-access";
@@ -3907,6 +3906,10 @@ export class MessagingController {
           runtime: options.acpRuntime,
         })
       : undefined;
+    const environmentLabel = formatNewThreadEnvironmentLabel(options);
+    const supportsEnvironment =
+      options.codexEnvironmentOptions.length > 0 ||
+      Boolean(options.codexEnvironmentId);
     await this.options.store.upsertBrowseSession(effectiveSession);
     const intent = buildConfirmationIntent({
       id: this.newIntentId("new-thread-ready"),
@@ -3964,25 +3967,29 @@ export class MessagingController {
               },
             ]
           : []),
-        ...((supportsPermissionsControls &&
-        (options.executionMode === "full-access" ||
-        fullAccessControls.allowEscalation))
+        ...(((supportsPermissionsControls &&
+          (options.executionMode === "full-access" ||
+            fullAccessControls.allowEscalation)) ||
+          (acpRuntimeMode && acpRuntimeMode.choices.length > 0))
           ? [
               {
                 id: "browse:new:permissions",
-                label: `Permissions: ${formatPermissionsShortLabel(options.executionMode)}`,
+                label: `Permissions: ${
+                  acpRuntimeMode?.currentLabel ??
+                  formatPermissionsShortLabel(options.executionMode)
+                }`,
                 style: "secondary" as const,
                 fallbackText: "permissions",
               },
             ]
           : []),
-        ...(acpRuntimeMode && acpRuntimeMode.choices.length > 0
+        ...(supportsEnvironment
           ? [
               {
-                id: "browse:new:runtime-mode",
-                label: `Runtime: ${acpRuntimeMode.currentLabel}`,
+                id: "browse:new:environment",
+                label: `Environment: ${environmentLabel}`,
                 style: "secondary" as const,
-                fallbackText: "runtime",
+                fallbackText: "environment",
               },
             ]
           : []),
@@ -4002,18 +4009,6 @@ export class MessagingController {
           style: "secondary",
           fallbackText: "stream",
         },
-        ...(codexEnvironmentOptions.length > 0
-          ? [
-              {
-                id: "browse:new:environment",
-                label: options.codexEnvironmentName
-                  ? `Env: ${options.codexEnvironmentName}`
-                  : "Env: none",
-                style: "secondary" as const,
-                fallbackText: "environment",
-              },
-            ]
-          : []),
         ...(supportsModel
           ? [
               {
@@ -4286,126 +4281,6 @@ export class MessagingController {
     }
   }
 
-  private async presentNewThreadEnvironmentPicker(
-    session: MessagingBrowseSessionRecord,
-    navigation: NavigationSnapshot,
-    event: MessagingInboundEvent,
-  ): Promise<void> {
-    const directory = session.selectedProject
-      ? directoryForProjectSelection(navigation, session.selectedProject)
-      : undefined;
-    const environments = codexEnvironmentOptionsForDirectory(directory);
-    if (environments.length === 0) {
-      await this.deliver(
-        buildErrorIntent({
-          id: this.newIntentId("new-thread-environments-unavailable"),
-          createdAt: this.now(),
-          title: "Environments unavailable",
-          body: "This project did not report Codex environment choices.",
-          recoverable: true,
-        }),
-        undefined,
-        event,
-      );
-      return;
-    }
-
-    const selected = selectedCodexEnvironmentForSession(session, directory);
-    const intent = buildConfirmationIntent({
-      id: this.newIntentId("new-thread-environment"),
-      capabilityProfile: this.capabilityProfile,
-      browseSessionId: session.id,
-      createdAt: this.now(),
-      delivery: session.surface
-        ? { mode: "update", replaceMarkup: true }
-        : undefined,
-      title: "Select environment",
-      body: "Choose the Codex environment for the new thread.",
-      fallbackText: "Choose an environment, or reply back.",
-      targetSurface: session.surface,
-      actions: [
-        {
-          id: "browse:new:set-environment",
-          label: selected ? "No environment" : "No environment ✓",
-          style: selected ? "secondary" as const : "primary" as const,
-          fallbackText: "0",
-          priority: 9,
-          value: { environmentId: "" },
-        },
-        ...environments.map((environment, index) => ({
-          id: "browse:new:set-environment",
-          label: `${environment.name}${environment.id === selected?.id ? " ✓" : ""}`,
-          style: environment.id === selected?.id
-            ? "primary" as const
-            : "secondary" as const,
-          fallbackText: String(index + 1),
-          priority: 10 + index,
-          value: { environmentId: environment.id },
-        })),
-        {
-          id: session.workMode === "worktree"
-            ? "browse:new:workspace:worktree"
-            : "browse:new:workspace:local",
-          label: "Back",
-          style: "secondary" as const,
-          fallbackText: "back",
-          priority: 1,
-        },
-      ],
-    });
-    await this.storePendingIntent(intent, undefined, event);
-    const result = await this.deliver(intent, undefined, event);
-    if (result.surface) {
-      await this.options.store.upsertBrowseSession({
-        ...session,
-        surface: result.surface,
-        updatedAt: this.now(),
-      });
-    }
-  }
-
-  private async setNewThreadEnvironment(
-    session: MessagingBrowseSessionRecord,
-    navigation: NavigationSnapshot,
-    event: MessagingInboundCallbackEvent,
-  ): Promise<void> {
-    const environmentId = readStringValue(event.value, "environmentId");
-    if (environmentId === undefined) {
-      await this.deliverInvalidBrowseSelection(event);
-      return;
-    }
-    const directory = session.selectedProject
-      ? directoryForProjectSelection(navigation, session.selectedProject)
-      : undefined;
-    const environments = codexEnvironmentOptionsForDirectory(directory);
-    const environment = environmentId
-      ? environments.find((candidate) => candidate.id === environmentId)
-      : undefined;
-    if (environmentId && !environment) {
-      await this.deliverInvalidBrowseSelection(event);
-      return;
-    }
-
-    await this.updateNewThreadStickySettings(session, {
-      codexEnvironmentId: environment?.id,
-      codexEnvironmentExecutionTarget: environment ? "local" : undefined,
-      codexEnvironmentSetupEnabled: Boolean(environment?.setupScript),
-      codexEnvironmentActionId: undefined,
-    });
-    await this.presentNewThreadPromptGate(
-      {
-        ...session,
-        codexEnvironmentId: environment?.id ?? null,
-        codexEnvironmentExecutionTarget: environment ? "local" : undefined,
-        codexEnvironmentSetupEnabled: Boolean(environment?.setupScript),
-        codexEnvironmentActionId: undefined,
-        updatedAt: this.now(),
-      },
-      event,
-      navigation,
-    );
-  }
-
   private async presentNewThreadAcpRuntimeModePicker(
     session: MessagingBrowseSessionRecord,
     event: MessagingInboundEvent,
@@ -4418,8 +4293,8 @@ export class MessagingController {
         buildErrorIntent({
           id: this.newIntentId("new-thread-runtime-unavailable"),
           createdAt: this.now(),
-          title: "Runtime modes unavailable",
-          body: "This ACP backend did not report runtime mode choices.",
+          title: "Permissions unavailable",
+          body: "This ACP backend did not report permissions choices.",
           recoverable: true,
         }),
         undefined,
@@ -4446,8 +4321,8 @@ export class MessagingController {
         buildErrorIntent({
           id: this.newIntentId("new-thread-runtime-unavailable"),
           createdAt: this.now(),
-          title: "Runtime modes unavailable",
-          body: "This ACP backend did not report runtime mode choices.",
+          title: "Permissions unavailable",
+          body: "This ACP backend did not report permissions choices.",
           recoverable: true,
         }),
         undefined,
@@ -4464,9 +4339,9 @@ export class MessagingController {
       delivery: session.surface
         ? { mode: "update", replaceMarkup: true }
         : undefined,
-      title: "Select runtime mode",
-      body: "Choose the runtime mode for the new thread.",
-      fallbackText: "Choose a runtime mode, or reply back.",
+      title: "Select permissions",
+      body: "Choose the permissions mode for the new thread.",
+      fallbackText: "Choose a permissions option, or reply back.",
       targetSurface: session.surface,
       actions: [
         ...runtimeMode.choices.map((choice, index) => ({
@@ -4501,6 +4376,193 @@ export class MessagingController {
         updatedAt: this.now(),
       });
     }
+  }
+
+  private async presentNewThreadPermissionsPicker(
+    session: MessagingBrowseSessionRecord,
+    event: MessagingInboundEvent,
+    navigation: NavigationSnapshot,
+  ): Promise<void> {
+    const directory = session.selectedProject
+      ? directoryForProjectSelection(navigation, session.selectedProject)
+      : undefined;
+    const currentMode =
+      session.preferences?.executionMode ??
+      directory?.launchpad?.executionMode ??
+      navigation.launchpadDefaults.executionMode;
+    const choices: Array<{ label: string; mode: ThreadExecutionMode }> = [
+      { label: "Default", mode: "default" },
+      { label: "Full Access", mode: "full-access" },
+    ];
+    const intent = buildConfirmationIntent({
+      id: this.newIntentId("new-thread-permissions"),
+      capabilityProfile: this.capabilityProfile,
+      browseSessionId: session.id,
+      createdAt: this.now(),
+      delivery: session.surface
+        ? { mode: "update", replaceMarkup: true }
+        : undefined,
+      title: "Select permissions",
+      body: "Choose the permissions mode for the new thread.",
+      fallbackText: "Choose a permissions option, or reply back.",
+      targetSurface: session.surface,
+      actions: [
+        ...choices.map((choice, index) => ({
+          id: "browse:new:set-permissions",
+          label: `${choice.label}${choice.mode === currentMode ? " (current)" : ""}`,
+          style: "secondary" as const,
+          fallbackText: String(index + 1),
+          priority: 10 + index,
+          value: { executionMode: choice.mode },
+        })),
+        {
+          id: session.workMode === "worktree"
+            ? "browse:new:workspace:worktree"
+            : "browse:new:workspace:local",
+          label: "Back",
+          style: "secondary" as const,
+          fallbackText: "back",
+          priority: 1,
+        },
+      ],
+    });
+    await this.storePendingIntent(intent, undefined, event);
+    const result = await this.deliver(intent, undefined, event);
+    if (result.surface) {
+      await this.options.store.upsertBrowseSession({
+        ...session,
+        surface: result.surface,
+        updatedAt: this.now(),
+      });
+    }
+  }
+
+  private async setNewThreadPermissions(
+    session: MessagingBrowseSessionRecord,
+    event: MessagingInboundCallbackEvent,
+    navigation: NavigationSnapshot,
+  ): Promise<void> {
+    const executionMode = readThreadExecutionModeValue(event.value);
+    if (!executionMode) {
+      await this.deliverInvalidBrowseSelection(event);
+      return;
+    }
+    if (executionMode === "full-access") {
+      const allowed = await this.ensureFullAccessEscalationAllowed(
+        { kind: "new-thread", session },
+        event,
+      );
+      if (!allowed) {
+        return;
+      }
+    }
+    await this.updateNewThreadStickySettings(session, {
+      executionMode,
+    });
+    await this.presentNewThreadPromptGate(
+      {
+        ...session,
+        preferences: {
+          ...session.preferences,
+          executionMode,
+          permissionsMode: executionMode,
+          updatedAt: this.now(),
+        },
+      },
+      event,
+      navigation,
+    );
+  }
+
+  private async presentNewThreadEnvironmentPicker(
+    session: MessagingBrowseSessionRecord,
+    event: MessagingInboundEvent,
+    navigation: NavigationSnapshot,
+  ): Promise<void> {
+    const directory = session.selectedProject
+      ? directoryForProjectSelection(navigation, session.selectedProject)
+      : undefined;
+    const options = directory?.launchpad?.codexEnvironmentOptions ?? [];
+    const currentEnvironmentId = resolveNewThreadCodexEnvironmentId(
+      session,
+      directory,
+    );
+    if (options.length === 0 && !currentEnvironmentId) {
+      await this.presentNewThreadPromptGate(session, event, navigation);
+      return;
+    }
+    const intent = buildNewThreadEnvironmentPickerIntent({
+      id: this.newIntentId("new-thread-environment"),
+      browseSessionId: session.id,
+      capabilityProfile: this.capabilityProfile,
+      createdAt: this.now(),
+      currentEnvironmentId,
+      options,
+      targetSurface: session.surface,
+    });
+    await this.storePendingIntent(intent, undefined, event);
+    const result = await this.deliver(intent, undefined, event);
+    if (result.surface) {
+      await this.options.store.upsertBrowseSession({
+        ...session,
+        surface: result.surface,
+        updatedAt: this.now(),
+      });
+    }
+  }
+
+  private async setNewThreadEnvironment(
+    session: MessagingBrowseSessionRecord,
+    event: MessagingInboundCallbackEvent,
+    navigation: NavigationSnapshot,
+  ): Promise<void> {
+    const directory = session.selectedProject
+      ? directoryForProjectSelection(navigation, session.selectedProject)
+      : undefined;
+    const environmentId = readNullableStringValue(event.value, "environmentId");
+    if (environmentId === undefined) {
+      await this.deliverInvalidBrowseSelection(event);
+      return;
+    }
+    const environment = environmentId === null
+      ? undefined
+      : directory?.launchpad?.codexEnvironmentOptions?.find(
+          (candidate) => candidate.id === environmentId,
+        );
+    if (environmentId !== null && !environment) {
+      await this.deliverInvalidBrowseSelection(event);
+      return;
+    }
+    const codexEnvironmentSetupEnabled = environment
+      ? directory?.launchpad?.codexEnvironmentId === environment.id
+        ? directory.launchpad.codexEnvironmentSetupEnabled ?? Boolean(environment.setupScript)
+        : Boolean(environment.setupScript)
+      : false;
+    await this.updateNewThreadStickySettings(session, {
+      codexEnvironmentId: environment?.id,
+      codexEnvironmentExecutionTarget: environment ? "local" : undefined,
+      codexEnvironmentSetupEnabled,
+      codexEnvironmentActionId: environment
+        ? directory?.launchpad?.codexEnvironmentActionId
+        : undefined,
+    });
+    await this.presentNewThreadPromptGate(
+      {
+        ...session,
+        preferences: {
+          ...session.preferences,
+          codexEnvironmentId: environment?.id ?? null,
+          codexEnvironmentExecutionTarget: environment ? "local" : undefined,
+          codexEnvironmentSetupEnabled,
+          codexEnvironmentActionId: environment
+            ? directory?.launchpad?.codexEnvironmentActionId ?? null
+            : null,
+          updatedAt: this.now(),
+        },
+      },
+      event,
+      navigation,
+    );
   }
 
   private async setNewThreadAcpRuntimeMode(
@@ -4775,7 +4837,7 @@ export class MessagingController {
       Partial<
         Pick<
           MaterializedDirectoryLaunchpadThread,
-          "linkedDirectory" | "workMode"
+          "codexEnvironmentRuntime" | "linkedDirectory" | "workMode"
         >
       >;
     let boundThread:
@@ -4829,6 +4891,7 @@ export class MessagingController {
         serviceTier: preferences?.serviceTier,
         fastMode: options.supportsFast ? options.fastMode : undefined,
         acpRuntime: options.acpRuntime,
+        codexEnvironmentRuntime: started.codexEnvironmentRuntime,
         preferences,
         project,
         threadId: started.threadId,
@@ -4847,7 +4910,6 @@ export class MessagingController {
       navigation,
       preferences,
       project,
-      session,
       now: this.now(),
       workMode: options.workMode,
       branchName: options.branchName,
@@ -6087,16 +6149,28 @@ export class MessagingController {
       await this.setBindingAcpRuntimeMode(binding, event);
       return;
     }
+    if (actionId === "status:set-permissions") {
+      await this.setBindingPermissionsMode(binding, event);
+      return;
+    }
+    if (actionId === "status:set-tool-updates") {
+      await this.setToolUpdateMode(binding, event);
+      return;
+    }
     if (actionId === "status:fast") {
       await this.toggleFastMode(binding, event);
       return;
     }
     if (actionId === "status:permissions") {
-      await this.togglePermissionsMode(binding, event);
+      if (isAcpBackendId(binding.backend)) {
+        await this.presentStatusAcpRuntimeModePicker(binding, event);
+      } else {
+        await this.presentPermissionsPicker(binding, event);
+      }
       return;
     }
     if (actionId === "status:tool-updates") {
-      await this.cycleToolUpdateMode(binding, event);
+      await this.presentToolUpdateModePicker(binding, event);
       return;
     }
     if (actionId === "status:streaming") {
@@ -6819,8 +6893,8 @@ export class MessagingController {
         buildErrorIntent({
           id: this.newIntentId("status-runtime-unavailable"),
           createdAt: this.now(),
-          title: "Runtime modes unavailable",
-          body: "This ACP backend did not report runtime mode choices. Use /status to refresh.",
+          title: "Permissions unavailable",
+          body: "This ACP backend did not report permissions choices. Use /status to refresh.",
           recoverable: true,
         }),
         binding,
@@ -6829,12 +6903,59 @@ export class MessagingController {
       return;
     }
 
-    await this.deliver(
+    await this.deliverAndStoreStatusSubmode(
       buildStatusAcpRuntimeModePickerIntent({
         id: this.newIntentId("status-runtime-picker"),
         capabilityProfile: this.capabilityProfile,
         binding,
         choices: runtimeMode.choices,
+        createdAt: this.now(),
+        prompt: "Select Permissions",
+      }),
+      binding,
+      event,
+    );
+  }
+
+  private async presentPermissionsPicker(
+    binding: MessagingBindingRecord,
+    event: MessagingInboundEvent,
+  ): Promise<void> {
+    const navigation = await this.options.backend.getNavigationSnapshot({
+      backend: "all",
+    });
+    const thread = findThreadForBinding(navigation, binding);
+    const currentMode =
+      thread?.queuedExecutionMode ??
+      executionModeForBinding(binding, navigation) ??
+      "default";
+    await this.deliverAndStoreStatusSubmode(
+      buildStatusPermissionsPickerIntent({
+        id: this.newIntentId("status-permissions-picker"),
+        capabilityProfile: this.capabilityProfile,
+        binding,
+        createdAt: this.now(),
+        currentMode,
+      }),
+      binding,
+      event,
+    );
+  }
+
+  private async presentToolUpdateModePicker(
+    binding: MessagingBindingRecord,
+    event: MessagingInboundEvent,
+  ): Promise<void> {
+    const currentMode = resolveMessagingToolUpdateMode(
+      binding,
+      await this.resolveToolUpdateDefaultMode(),
+    );
+    await this.deliverAndStoreStatusSubmode(
+      buildStatusToolUpdateModePickerIntent({
+        id: this.newIntentId("status-tools-picker"),
+        capabilityProfile: this.capabilityProfile,
+        binding,
+        choices: messagingToolUpdateModeChoices(currentMode),
         createdAt: this.now(),
       }),
       binding,
@@ -7073,6 +7194,58 @@ export class MessagingController {
     // thread/executionMode/updated — see refreshStatusSurfacesForThread.
   }
 
+  private async setBindingPermissionsMode(
+    binding: MessagingBindingRecord,
+    event: MessagingInboundCallbackEvent,
+  ): Promise<void> {
+    if (isAcpBackendId(binding.backend)) {
+      await this.renderBindingStatus(binding, event);
+      return;
+    }
+    const executionMode = readThreadExecutionModeValue(event.value);
+    if (!executionMode) {
+      await this.deliverInvalidStatusSelection(event);
+      return;
+    }
+    const navigation = await this.options.backend.getNavigationSnapshot({
+      backend: "all",
+    });
+    const thread = findThreadForBinding(navigation, binding);
+    const currentMode =
+      thread?.queuedExecutionMode ??
+      executionModeForBinding(binding, navigation) ??
+      "default";
+    if (executionMode === currentMode) {
+      await this.clearActiveBindingSubmodeIntent(event, binding);
+      await this.renderBindingStatus(binding, event, navigation);
+      return;
+    }
+    if (executionMode === "full-access") {
+      const allowed = await this.ensureFullAccessEscalationAllowed(
+        {
+          backend: binding.backend,
+          binding,
+          kind: "thread",
+          threadId: binding.threadId,
+        },
+        event,
+      );
+      if (!allowed) {
+        return;
+      }
+    }
+    await this.updateBindingPreferences(binding, {
+      executionMode,
+      permissionsMode: executionMode,
+    });
+    await this.clearActiveBindingSubmodeIntent(event, binding);
+    await this.options.backend.setThreadExecutionMode?.({
+      backend: binding.backend,
+      threadId: binding.threadId,
+      executionMode,
+    });
+  }
+
   private async ensureAcpRuntimeModeAllowed(
     context: AcpRuntimeRiskWarningContext,
     event: MessagingInboundEvent,
@@ -7084,7 +7257,7 @@ export class MessagingController {
           ? await this.options.store.getBinding(context.bindingId)
           : undefined,
         event,
-        `Runtime mode ${context.label} is disabled from messaging by Full Access settings.`,
+        `Permissions mode ${context.label} is disabled from messaging by Full Access settings.`,
       );
       return false;
     }
@@ -7591,7 +7764,7 @@ export class MessagingController {
         ? await this.options.store.getBinding(context.bindingId)
         : undefined,
       event,
-      `Runtime mode ${context.label} is disabled from messaging by Full Access settings.`,
+        `Permissions mode ${context.label} is disabled from messaging by Full Access settings.`,
     );
     return false;
   }
@@ -8040,13 +8213,22 @@ export class MessagingController {
     binding: MessagingBindingRecord,
     event: MessagingInboundEvent,
   ): Promise<void> {
-    const currentMode = resolveMessagingToolUpdateMode(
-      binding,
-      await this.resolveToolUpdateDefaultMode(),
-    );
+    await this.presentToolUpdateModePicker(binding, event);
+  }
+
+  private async setToolUpdateMode(
+    binding: MessagingBindingRecord,
+    event: MessagingInboundCallbackEvent,
+  ): Promise<void> {
+    const toolUpdateMode = readMessagingToolUpdateModeValue(event.value);
+    if (!toolUpdateMode) {
+      await this.deliverInvalidStatusSelection(event);
+      return;
+    }
     const updatedBinding = await this.updateBindingPreferences(binding, {
-      toolUpdateMode: nextMessagingToolUpdateMode(currentMode),
+      toolUpdateMode,
     });
+    await this.clearActiveBindingSubmodeIntent(event, updatedBinding);
     await this.renderBindingStatus(updatedBinding, event);
   }
 
@@ -10636,7 +10818,11 @@ type NewThreadOptionsSummary = {
   backend: AppServerBackendKind;
   backendLabel: string;
   branchName: string;
-  codexEnvironmentName?: string;
+  codexEnvironmentActionId?: string | null;
+  codexEnvironmentExecutionTarget?: "local" | "remote";
+  codexEnvironmentId?: string | null;
+  codexEnvironmentOptions: CodexEnvironmentOption[];
+  codexEnvironmentSetupEnabled?: boolean;
   executionMode: ThreadExecutionMode;
   executionModeSource: "session" | "directory-launchpad" | "launchpad-defaults";
   fastMode: boolean;
@@ -10699,16 +10885,33 @@ function newThreadOptionsForSession(
     : directory?.launchpad?.executionMode
       ? "directory-launchpad"
       : "launchpad-defaults";
-  const selectedCodexEnvironment = selectedCodexEnvironmentForSession(
-    session,
-    directory,
+  const codexEnvironmentOptions = directory?.launchpad?.codexEnvironmentOptions ?? [];
+  const codexEnvironmentId = resolveNewThreadCodexEnvironmentId(session, directory);
+  const selectedEnvironment = codexEnvironmentOptions.find(
+    (environment) => environment.id === codexEnvironmentId,
   );
+  const codexEnvironmentSetupEnabled = selectedEnvironment
+    ? session.preferences?.codexEnvironmentSetupEnabled ??
+      directory?.launchpad?.codexEnvironmentSetupEnabled ??
+      Boolean(selectedEnvironment.setupScript)
+    : false;
   return {
     backend: backend.kind,
     backendLabel: backend.label,
     acpRuntime,
     branchName: resolveNewThreadBaseBranch(session, navigation, directory),
-    codexEnvironmentName: selectedCodexEnvironment?.name,
+    codexEnvironmentActionId: selectedEnvironment
+      ? session.preferences?.codexEnvironmentActionId ??
+        directory?.launchpad?.codexEnvironmentActionId
+      : undefined,
+    codexEnvironmentExecutionTarget: selectedEnvironment
+      ? session.preferences?.codexEnvironmentExecutionTarget ??
+        directory?.launchpad?.codexEnvironmentExecutionTarget ??
+        "local"
+      : undefined,
+    codexEnvironmentId: selectedEnvironment?.id ?? (codexEnvironmentId === null ? null : undefined),
+    codexEnvironmentOptions,
+    codexEnvironmentSetupEnabled,
     executionMode,
     executionModeSource,
     fastMode:
@@ -10766,11 +10969,13 @@ function newThreadPromptGateBody(
     `Provider: ${backend.label}`,
     `Workspace: ${options.workMode === "worktree" ? "New Worktree" : "Local"}`,
     options.workMode === "worktree" ? `Base branch: ${options.branchName}` : undefined,
-    !isAcpBackendId(options.backend) || options.executionMode === "full-access"
-      ? `Permissions: ${formatPermissionsShortLabel(options.executionMode)}`
-      : undefined,
     acpRuntimeMode
-      ? `Runtime mode: ${acpRuntimeMode.currentLabel}`
+      ? `Permissions: ${acpRuntimeMode.currentLabel}`
+      : !isAcpBackendId(options.backend) || options.executionMode === "full-access"
+        ? `Permissions: ${formatPermissionsShortLabel(options.executionMode)}`
+        : undefined,
+    options.codexEnvironmentOptions.length > 0 || options.codexEnvironmentId
+      ? `Environment: ${formatNewThreadEnvironmentLabel(options)}`
       : undefined,
     options.supportsModel ? `Model: ${options.model}` : undefined,
     options.supportsReasoning && options.reasoningEffort
@@ -10778,9 +10983,6 @@ function newThreadPromptGateBody(
       : undefined,
     options.supportsFast ? `Fast mode: ${options.fastMode ? "on" : "off"}` : undefined,
     `Streaming: ${options.streamingResponses ? "on" : "off"}`,
-    options.codexEnvironmentName
-      ? `Environment: ${options.codexEnvironmentName}`
-      : undefined,
   ]
     .filter((line): line is string => Boolean(line))
     .join("\n");
@@ -10788,6 +10990,35 @@ function newThreadPromptGateBody(
 
 function formatPermissionsShortLabel(mode: ThreadExecutionMode): string {
   return mode === "full-access" ? "Full" : "Default";
+}
+
+function resolveNewThreadCodexEnvironmentId(
+  session: MessagingBrowseSessionRecord,
+  directory: NavigationDirectorySummary | undefined,
+): string | null | undefined {
+  if (session.preferences?.codexEnvironmentId === null) {
+    return null;
+  }
+  return (
+    session.preferences?.codexEnvironmentId ??
+    directory?.launchpad?.codexEnvironmentId
+  );
+}
+
+function formatNewThreadEnvironmentLabel(
+  options: Pick<
+    NewThreadOptionsSummary,
+    "codexEnvironmentId" | "codexEnvironmentOptions"
+  >,
+): string {
+  if (!options.codexEnvironmentId) {
+    return "None";
+  }
+  return (
+    options.codexEnvironmentOptions.find(
+      (environment) => environment.id === options.codexEnvironmentId,
+    )?.name ?? options.codexEnvironmentId
+  );
 }
 
 function resolveNewThreadBaseBranch(
@@ -11621,6 +11852,7 @@ type TurnLifecycleParams = {
 function navigationWithStartedThread(params: {
   acpRuntime?: BackendAcpSessionRuntimeState;
   backend: AppServerBackendKind;
+  codexEnvironmentRuntime?: NavigationThreadSummary["codexEnvironmentRuntime"];
   directory?: NavigationDirectorySummary;
   executionMode?: ThreadExecutionMode;
   linkedDirectory?: LinkedDirectorySummary;
@@ -11670,6 +11902,7 @@ function navigationWithStartedThread(params: {
         updatedAt: params.now,
         executionMode: params.executionMode,
         acpRuntime: params.acpRuntime,
+        codexEnvironmentRuntime: params.codexEnvironmentRuntime,
         model: params.model,
         reasoningEffort: params.reasoningEffort,
         serviceTier: params.serviceTier,
@@ -11708,15 +11941,10 @@ function launchpadForMessagingProject(params: {
   now: number;
   preferences?: MessagingBrowseSessionRecord["preferences"];
   project: NonNullable<ReturnType<typeof selectProjectFromValue>>;
-  session: MessagingBrowseSessionRecord;
   workMode: LaunchpadWorkMode;
 }): NavigationLaunchpadDraft {
   const defaults = params.navigation.launchpadDefaults;
   const directoryPath = params.directory?.path ?? params.project.path;
-  const selectedCodexEnvironment = selectedCodexEnvironmentForSession(
-    params.session,
-    params.directory,
-  );
   const base: NavigationLaunchpadDraft = params.directory?.launchpad ?? {
     directoryKey:
       params.directory?.key ??
@@ -11743,6 +11971,27 @@ function launchpadForMessagingProject(params: {
     ...base,
     backend: params.backend,
     acpRuntime: params.acpRuntime ?? params.preferences?.acpRuntime ?? base.acpRuntime,
+    codexEnvironmentId:
+      params.preferences?.codexEnvironmentId === null
+        ? undefined
+        : params.preferences?.codexEnvironmentId ?? base.codexEnvironmentId,
+    codexEnvironmentExecutionTarget:
+      params.preferences?.codexEnvironmentId === null
+        ? undefined
+        : params.preferences?.codexEnvironmentExecutionTarget ??
+          base.codexEnvironmentExecutionTarget,
+    codexEnvironmentSetupEnabled:
+      params.preferences?.codexEnvironmentId === null
+        ? false
+        : params.preferences?.codexEnvironmentSetupEnabled ??
+          base.codexEnvironmentSetupEnabled,
+    codexEnvironmentActionId:
+      params.preferences?.codexEnvironmentId === null
+        ? undefined
+        : params.preferences?.codexEnvironmentActionId === null
+          ? undefined
+          : params.preferences?.codexEnvironmentActionId ??
+            base.codexEnvironmentActionId,
     executionMode: params.preferences?.executionMode ?? base.executionMode,
     model: params.preferences?.model ?? base.model,
     reasoningEffort: params.preferences?.reasoningEffort ?? base.reasoningEffort,
@@ -11751,44 +12000,9 @@ function launchpadForMessagingProject(params: {
     prompt: "",
     workMode: params.workMode,
     branchName: params.branchName,
-    codexEnvironmentId: selectedCodexEnvironment?.id,
-    codexEnvironmentExecutionTarget: selectedCodexEnvironment
-      ? params.session.codexEnvironmentExecutionTarget ??
-        base.codexEnvironmentExecutionTarget ??
-        "local"
-      : undefined,
-    codexEnvironmentSetupEnabled: selectedCodexEnvironment
-      ? params.session.codexEnvironmentSetupEnabled ??
-        base.codexEnvironmentSetupEnabled ??
-        Boolean(selectedCodexEnvironment.setupScript)
-      : false,
-    codexEnvironmentActionId: selectedCodexEnvironment
-      ? params.session.codexEnvironmentActionId ?? base.codexEnvironmentActionId
-      : undefined,
     codexEnvironmentOptions: base.codexEnvironmentOptions,
     updatedAt: params.now,
   };
-}
-
-function codexEnvironmentOptionsForDirectory(
-  directory: NavigationDirectorySummary | undefined,
-): CodexEnvironmentOption[] {
-  return directory?.launchpad?.codexEnvironmentOptions ?? [];
-}
-
-function selectedCodexEnvironmentForSession(
-  session: MessagingBrowseSessionRecord,
-  directory: NavigationDirectorySummary | undefined,
-): CodexEnvironmentOption | undefined {
-  const environments = codexEnvironmentOptionsForDirectory(directory);
-  const selectedId =
-    session.codexEnvironmentId === null
-      ? undefined
-      : session.codexEnvironmentId ?? directory?.launchpad?.codexEnvironmentId;
-  if (!selectedId) {
-    return undefined;
-  }
-  return environments.find((environment) => environment.id === selectedId);
 }
 
 function messagingLaunchpadMaterializationKey(
@@ -11955,6 +12169,45 @@ function readStringValue(
 
   const result = value[key];
   return typeof result === "string" ? result : undefined;
+}
+
+function readNullableStringValue(
+  value: MessagingJsonValue | undefined,
+  key: string,
+): string | null | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+
+  const result = value[key];
+  if (result === null) {
+    return null;
+  }
+  return typeof result === "string" ? result : undefined;
+}
+
+function readThreadExecutionModeValue(
+  value: MessagingJsonValue | undefined,
+): ThreadExecutionMode | undefined {
+  const executionMode = readStringValue(value, "executionMode");
+  return executionMode === "default" || executionMode === "full-access"
+    ? executionMode
+    : undefined;
+}
+
+function readMessagingToolUpdateModeValue(
+  value: MessagingJsonValue | undefined,
+): MessagingToolUpdateMode | undefined {
+  const toolUpdateMode = readStringValue(value, "toolUpdateMode");
+  return (
+    toolUpdateMode === "show_none" ||
+      toolUpdateMode === "show_less" ||
+      toolUpdateMode === "show_some" ||
+      toolUpdateMode === "show_more" ||
+      toolUpdateMode === "show_all"
+  )
+    ? toolUpdateMode
+    : undefined;
 }
 
 function readAcpRuntimeOptionSource(

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -4450,6 +4450,17 @@ export class MessagingController {
       await this.deliverInvalidBrowseSelection(event);
       return;
     }
+    const directory = session.selectedProject
+      ? directoryForProjectSelection(navigation, session.selectedProject)
+      : undefined;
+    const currentMode =
+      session.preferences?.executionMode ??
+      directory?.launchpad?.executionMode ??
+      navigation.launchpadDefaults.executionMode;
+    if (executionMode === currentMode) {
+      await this.presentNewThreadPromptGate(session, event, navigation);
+      return;
+    }
     if (executionMode === "full-access") {
       const allowed = await this.ensureFullAccessEscalationAllowed(
         { kind: "new-thread", session },

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -1,5 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
 import {
+  applyNavigationLaunchpadProviderSettingsPatch,
   buildThreadIdentityKey,
   isAcpBackendId,
   isAppServerBackendKind,
@@ -4389,10 +4390,23 @@ export class MessagingController {
     const directory = session.selectedProject
       ? directoryForProjectSelection(navigation, session.selectedProject)
       : undefined;
-    const currentMode =
-      session.preferences?.executionMode ??
-      directory?.launchpad?.executionMode ??
-      navigation.launchpadDefaults.executionMode;
+    const backend = await this.resolveNewThreadBackendForSession(
+      {
+        launchpadBackend: navigation.launchpadDefaults.backend,
+        preferredBackend: session.backend,
+        session,
+      },
+      event,
+    );
+    const currentMode = backend
+      ? newThreadOptionsForSession(
+          session,
+          navigation,
+          directory,
+          this.streamingResponsesDefault,
+          backend,
+        ).executionMode
+      : session.preferences?.executionMode ?? "default";
     const choices: Array<{ label: string; mode: ThreadExecutionMode }> = [
       { label: "Default", mode: "default" },
       { label: "Full Access", mode: "full-access" },
@@ -4654,9 +4668,20 @@ export class MessagingController {
     navigation: NavigationSnapshot,
     selection: AcpRuntimeRiskWarningContext & { kind: "new-thread" },
   ): Promise<void> {
-    const currentRuntime =
-      session.preferences?.acpRuntime ??
-      navigation.launchpadDefaults.acpRuntime;
+    const backend = session.backend ?? navigation.launchpadDefaults.backend;
+    const summary = await this.getBackendSummary(backend);
+    const directory = session.selectedProject
+      ? directoryForProjectSelection(navigation, session.selectedProject)
+      : undefined;
+    const currentRuntime = summary
+      ? newThreadOptionsForSession(
+          session,
+          navigation,
+          directory,
+          this.streamingResponsesDefault,
+          summary,
+        ).acpRuntime
+      : session.preferences?.acpRuntime;
     const acpRuntime: BackendAcpSessionRuntimeState = {
       ...currentRuntime,
       configValues:
@@ -10938,11 +10963,20 @@ function newThreadOptionsForSession(
   streamingResponsesDefault: boolean,
   backend: BackendSummary,
 ): NewThreadOptionsSummary {
+  const launchpadDefaults = applyNavigationLaunchpadProviderSettingsPatch(
+    navigation.launchpadDefaults,
+    { backend: backend.kind },
+  );
+  const directoryLaunchpad = directory?.launchpad
+    ? applyNavigationLaunchpadProviderSettingsPatch(directory.launchpad, {
+        backend: backend.kind,
+      })
+    : undefined;
   const workMode = resolveNewThreadWorkMode({
     requestedWorkMode:
       session.workMode ??
-      directory?.launchpad?.workMode ??
-      navigation.launchpadDefaults.workMode ??
+      directoryLaunchpad?.workMode ??
+      launchpadDefaults.workMode ??
       "local",
     directory,
   });
@@ -10950,7 +10984,7 @@ function newThreadOptionsForSession(
   const models = backend.launchpadOptions?.models ?? [];
   const modelOption =
     models.find((model) => model.id === session.preferences?.model) ??
-    models.find((model) => model.id === navigation.launchpadDefaults.model) ??
+    models.find((model) => model.id === launchpadDefaults.model) ??
     models.find((model) => model.current) ??
     models[0];
   const reasoningEfforts = backend.launchpadOptions?.reasoningEfforts ?? [];
@@ -10958,9 +10992,9 @@ function newThreadOptionsForSession(
     session.preferences?.reasoningEffort &&
     reasoningEfforts.includes(session.preferences.reasoningEffort)
       ? session.preferences.reasoningEffort
-      : navigation.launchpadDefaults.reasoningEffort &&
-          reasoningEfforts.includes(navigation.launchpadDefaults.reasoningEffort)
-        ? navigation.launchpadDefaults.reasoningEffort
+      : launchpadDefaults.reasoningEffort &&
+          reasoningEfforts.includes(launchpadDefaults.reasoningEffort)
+        ? launchpadDefaults.reasoningEffort
         : reasoningEfforts[0];
   const supportsFast =
     Boolean(backend.launchpadOptions?.supportsFastMode) ||
@@ -10969,26 +11003,26 @@ function newThreadOptionsForSession(
     reasoningEfforts.length > 0 || Boolean(modelOption?.supportsReasoning);
   const acpRuntime = isAcpBackendId(backend.kind)
     ? session.preferences?.acpRuntime ??
-      directory?.launchpad?.acpRuntime ??
-      navigation.launchpadDefaults.acpRuntime
+      directoryLaunchpad?.acpRuntime ??
+      launchpadDefaults.acpRuntime
     : undefined;
   const executionMode =
     session.preferences?.executionMode ??
-    directory?.launchpad?.executionMode ??
-    navigation.launchpadDefaults.executionMode;
+    directoryLaunchpad?.executionMode ??
+    launchpadDefaults.executionMode;
   const executionModeSource = session.preferences?.executionMode
     ? "session"
-    : directory?.launchpad?.executionMode
+    : directoryLaunchpad?.executionMode
       ? "directory-launchpad"
       : "launchpad-defaults";
-  const codexEnvironmentOptions = directory?.launchpad?.codexEnvironmentOptions ?? [];
+  const codexEnvironmentOptions = directoryLaunchpad?.codexEnvironmentOptions ?? [];
   const codexEnvironmentId = resolveNewThreadCodexEnvironmentId(session, directory);
   const selectedEnvironment = codexEnvironmentOptions.find(
     (environment) => environment.id === codexEnvironmentId,
   );
   const codexEnvironmentSetupEnabled = selectedEnvironment
     ? session.preferences?.codexEnvironmentSetupEnabled ??
-      directory?.launchpad?.codexEnvironmentSetupEnabled ??
+      directoryLaunchpad?.codexEnvironmentSetupEnabled ??
       Boolean(selectedEnvironment.setupScript)
     : false;
   return {
@@ -10998,11 +11032,11 @@ function newThreadOptionsForSession(
     branchName: resolveNewThreadBaseBranch(session, navigation, directory),
     codexEnvironmentActionId: selectedEnvironment
       ? session.preferences?.codexEnvironmentActionId ??
-        directory?.launchpad?.codexEnvironmentActionId
+        directoryLaunchpad?.codexEnvironmentActionId
       : undefined,
     codexEnvironmentExecutionTarget: selectedEnvironment
       ? session.preferences?.codexEnvironmentExecutionTarget ??
-        directory?.launchpad?.codexEnvironmentExecutionTarget ??
+        directoryLaunchpad?.codexEnvironmentExecutionTarget ??
         "local"
       : undefined,
     codexEnvironmentId: selectedEnvironment?.id ?? (codexEnvironmentId === null ? null : undefined),
@@ -11012,7 +11046,7 @@ function newThreadOptionsForSession(
     executionModeSource,
     fastMode:
       supportsFast
-        ? session.preferences?.fastMode ?? navigation.launchpadDefaults.fastMode ?? false
+        ? session.preferences?.fastMode ?? launchpadDefaults.fastMode ?? false
         : false,
     model: session.preferences?.model ?? modelOption?.id ?? "default",
     reasoningEffort,

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -7107,7 +7107,7 @@ export class MessagingController {
         : currentRuntime?.currentModeId,
       updatedAt: this.now(),
     };
-    await this.updateBindingPreferences(binding, {
+    const updatedBinding = await this.updateBindingPreferences(binding, {
       acpRuntime,
     });
     await this.options.backend.setAcpSessionRuntimeOption({
@@ -7117,7 +7117,16 @@ export class MessagingController {
       optionId: selection.optionId,
       value: selection.value,
     });
-    // Refresh handled by thread/acpRuntime/updated or queue audit refresh.
+    const optimisticNavigation: NavigationSnapshot = {
+      ...navigation,
+      threads: navigation.threads.map((candidate) =>
+        candidate.source === binding.backend && candidate.id === binding.threadId
+          ? { ...candidate, acpRuntime }
+          : candidate,
+      ),
+    };
+    await this.clearActiveBindingSubmodeIntent(event, updatedBinding);
+    await this.renderBindingStatus(updatedBinding, event, optimisticNavigation);
   }
 
   private async toggleFastMode(

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -130,6 +130,8 @@ import {
   buildStatusReasoningPickerIntent,
   buildStatusToolUpdateModePickerIntent,
   formatExecutionModeLabel,
+  formatPermissionsActionDisplayLabel,
+  formatPermissionsLineDisplayLabel,
   handoffRequestFromValue,
   messagingToolUpdateModeChoices,
   nextMessagingStreamingResponseMode,
@@ -3906,6 +3908,10 @@ export class MessagingController {
           runtime: options.acpRuntime,
         })
       : undefined;
+    const permissionsLabel = formatPermissionsActionDisplayLabel({
+      acpRuntimeLabel: acpRuntimeMode?.currentLabel,
+      current: options.executionMode,
+    });
     const environmentLabel = formatNewThreadEnvironmentLabel(options);
     const supportsEnvironment =
       options.codexEnvironmentOptions.length > 0 ||
@@ -3974,10 +3980,7 @@ export class MessagingController {
           ? [
               {
                 id: "browse:new:permissions",
-                label: `Permissions: ${
-                  acpRuntimeMode?.currentLabel ??
-                  formatPermissionsShortLabel(options.executionMode)
-                }`,
+                label: `Permissions: ${permissionsLabel}`,
                 style: "secondary" as const,
                 fallbackText: "permissions",
               },
@@ -4538,13 +4541,15 @@ export class MessagingController {
         ? directory.launchpad.codexEnvironmentSetupEnabled ?? Boolean(environment.setupScript)
         : Boolean(environment.setupScript)
       : false;
+    const codexEnvironmentActionId =
+      environment && directory?.launchpad?.codexEnvironmentId === environment.id
+        ? directory.launchpad.codexEnvironmentActionId
+        : undefined;
     await this.updateNewThreadStickySettings(session, {
       codexEnvironmentId: environment?.id,
       codexEnvironmentExecutionTarget: environment ? "local" : undefined,
       codexEnvironmentSetupEnabled,
-      codexEnvironmentActionId: environment
-        ? directory?.launchpad?.codexEnvironmentActionId
-        : undefined,
+      codexEnvironmentActionId,
     });
     await this.presentNewThreadPromptGate(
       {
@@ -4554,9 +4559,7 @@ export class MessagingController {
           codexEnvironmentId: environment?.id ?? null,
           codexEnvironmentExecutionTarget: environment ? "local" : undefined,
           codexEnvironmentSetupEnabled,
-          codexEnvironmentActionId: environment
-            ? directory?.launchpad?.codexEnvironmentActionId ?? null
-            : null,
+          codexEnvironmentActionId: codexEnvironmentActionId ?? null,
           updatedAt: this.now(),
         },
       },
@@ -10963,17 +10966,19 @@ function newThreadPromptGateBody(
         runtime: options.acpRuntime,
       })
     : undefined;
+  const permissionsLabel = formatPermissionsLineDisplayLabel({
+    acpRuntimeLabel: acpRuntimeMode?.currentLabel,
+    current: options.executionMode,
+  });
   return [
     `Send the first instruction for ${session.selectedProject?.label ?? "this project"}.`,
     "The thread will be created when that message arrives.",
     `Provider: ${backend.label}`,
     `Workspace: ${options.workMode === "worktree" ? "New Worktree" : "Local"}`,
     options.workMode === "worktree" ? `Base branch: ${options.branchName}` : undefined,
-    acpRuntimeMode
-      ? `Permissions: ${acpRuntimeMode.currentLabel}`
-      : !isAcpBackendId(options.backend) || options.executionMode === "full-access"
-        ? `Permissions: ${formatPermissionsShortLabel(options.executionMode)}`
-        : undefined,
+    acpRuntimeMode || !isAcpBackendId(options.backend) || options.executionMode === "full-access"
+      ? `Permissions: ${permissionsLabel}`
+      : undefined,
     options.codexEnvironmentOptions.length > 0 || options.codexEnvironmentId
       ? `Environment: ${formatNewThreadEnvironmentLabel(options)}`
       : undefined,
@@ -10986,10 +10991,6 @@ function newThreadPromptGateBody(
   ]
     .filter((line): line is string => Boolean(line))
     .join("\n");
-}
-
-function formatPermissionsShortLabel(mode: ThreadExecutionMode): string {
-  return mode === "full-access" ? "Full" : "Default";
 }
 
 function resolveNewThreadCodexEnvironmentId(

--- a/apps/desktop/src/main/messaging/core/messaging-status-card.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-status-card.ts
@@ -1058,6 +1058,7 @@ export function buildStatusModelPickerIntent(params: {
   binding: MessagingBindingRecord;
   capabilityProfile?: MessagingCapabilityProfile;
   createdAt: number;
+  currentModelId?: string;
   id: string;
   models: Array<{ id: string; label?: string; current?: boolean }>;
 }): MessagingSingleSelectIntent {
@@ -1081,7 +1082,11 @@ export function buildStatusModelPickerIntent(params: {
       [
         ...params.models.map((model, index) => ({
           id: "status:set-model",
-          label: `${model.label ?? model.id}${model.current ? " (current)" : ""}`,
+          label: `${model.label ?? model.id}${
+            (params.currentModelId ? model.id === params.currentModelId : model.current)
+              ? " (current)"
+              : ""
+          }`,
           fallbackText: String(index + 1),
           style: "secondary" as const,
           priority: 10 + index,

--- a/apps/desktop/src/main/messaging/core/messaging-status-card.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-status-card.ts
@@ -115,6 +115,16 @@ export function buildBindingStatusIntent(params: {
     : undefined;
   const acpRuntimeLabel = acpRuntimeMode?.currentLabel;
   const acpRuntimeChoices = acpRuntimeMode?.choices ?? [];
+  const permissionsLineLabel = formatPermissionsLineDisplayLabel({
+    acpRuntimeLabel,
+    current: permissionsMode,
+    queued: queuedExecutionMode,
+  });
+  const permissionsActionLabel = formatPermissionsActionDisplayLabel({
+    acpRuntimeLabel,
+    current: permissionsMode,
+    queued: queuedExecutionMode,
+  });
 
   return {
     id: params.id,
@@ -139,10 +149,7 @@ export function buildBindingStatusIntent(params: {
       `Model: ${model}`,
       `Reasoning: ${reasoning}`,
       `Fast mode: ${fastModeLabel}`,
-      `Permissions: ${
-        acpRuntimeLabel ??
-        formatPermissionsLineLabel(permissionsMode, queuedExecutionMode)
-      }`,
+      `Permissions: ${permissionsLineLabel}`,
       `Tool updates: ${formatMessagingToolUpdateModeLabel(toolUpdateMode)}`,
       `Streaming: ${streamingLabel}`,
       params.binding.pendingSkillSelection
@@ -162,6 +169,7 @@ export function buildBindingStatusIntent(params: {
       fastMode,
       handoff: params.handoff,
       permissionsMode,
+      permissionsActionLabel,
       permissionsChoices: acpRuntimeChoices,
       supportsLegacyPermissionsAction:
         !isAcpBackendId(params.binding.backend) ||
@@ -384,6 +392,7 @@ function buildStatusActions(params: {
   fastMode: boolean | undefined;
   handoff?: MessagingWorkspaceHandoffContext;
   permissionsMode: string;
+  permissionsActionLabel: string;
   permissionsChoices?: MessagingAcpRuntimeModeChoice[];
   supportsLegacyPermissionsAction?: boolean;
   queuedExecutionMode?: ThreadExecutionMode;
@@ -406,15 +415,7 @@ function buildStatusActions(params: {
         params.allowFullAccessEscalation !== false))
       ? {
           id: "status:permissions",
-          label: params.permissionsChoices?.length
-            ? `Permissions: ${
-                params.permissionsChoices.find((choice) => choice.selected)?.label ??
-                "Agent default"
-              }`
-            : formatPermissionsActionLabel(
-                params.permissionsMode,
-                params.queuedExecutionMode,
-              ),
+          label: `Permissions: ${params.permissionsActionLabel}`,
           style: "secondary",
           fallbackText: "permissions",
           priority: 7,
@@ -1427,6 +1428,50 @@ export function formatPermissionsActionLabel(
   }
   const queuedLabel = queued === "full-access" ? "Full Access" : "Default";
   return `Permissions: ${currentLabel} → ${queuedLabel} (queued)`;
+}
+
+export function formatPermissionsActionDisplayLabel(params: {
+  acpRuntimeLabel?: string;
+  current: string;
+  queued?: ThreadExecutionMode;
+}): string {
+  return formatPermissionsDisplayLabel({
+    acpRuntimeLabel: params.acpRuntimeLabel,
+    executionLabel: formatPermissionsActionLabel(params.current, params.queued).replace(
+      /^Permissions:\s*/,
+      "",
+    ),
+    current: params.current,
+    queued: params.queued,
+  });
+}
+
+export function formatPermissionsLineDisplayLabel(params: {
+  acpRuntimeLabel?: string;
+  current: string;
+  queued?: ThreadExecutionMode;
+}): string {
+  return formatPermissionsDisplayLabel({
+    acpRuntimeLabel: params.acpRuntimeLabel,
+    executionLabel: formatPermissionsLineLabel(params.current, params.queued),
+    current: params.current,
+    queued: params.queued,
+  });
+}
+
+function formatPermissionsDisplayLabel(params: {
+  acpRuntimeLabel?: string;
+  executionLabel: string;
+  current: string;
+  queued?: ThreadExecutionMode;
+}): string {
+  if (!params.acpRuntimeLabel) {
+    return params.executionLabel;
+  }
+  if (params.current === "default" && !params.queued) {
+    return params.acpRuntimeLabel;
+  }
+  return `${params.acpRuntimeLabel} + ${params.executionLabel}`;
 }
 
 /**

--- a/apps/desktop/src/main/messaging/core/messaging-status-card.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-status-card.ts
@@ -1111,6 +1111,7 @@ export function buildStatusReasoningPickerIntent(params: {
   binding: MessagingBindingRecord;
   capabilityProfile?: MessagingCapabilityProfile;
   createdAt: number;
+  currentReasoningEffort?: string;
   id: string;
   efforts: string[];
 }): MessagingSingleSelectIntent {
@@ -1130,7 +1131,7 @@ export function buildStatusReasoningPickerIntent(params: {
       [
         ...params.efforts.map((effort, index) => ({
           id: "status:set-reasoning",
-          label: effort,
+          label: `${effort}${effort === params.currentReasoningEffort ? " (current)" : ""}`,
           fallbackText: String(index + 1),
           style: "secondary" as const,
           priority: 10 + index,

--- a/apps/desktop/src/main/messaging/core/messaging-status-card.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-status-card.ts
@@ -1,6 +1,7 @@
 import type {
   AppServerBackendKind,
   BackendSummary,
+  CodexEnvironmentOption,
   HandoffThreadWorkspaceRequest,
   MessagingToolUpdateMode,
   ThreadExecutionMode,
@@ -106,18 +107,14 @@ export function buildBindingStatusIntent(params: {
     streamingMode,
     params.streamingResponsesDefault,
   );
-  const acpRuntimeLabel = isAcpBackendId(params.binding.backend)
+  const acpRuntimeMode = isAcpBackendId(params.binding.backend)
     ? buildMessagingAcpRuntimeModeSummary({
         backend: params.backendSummary,
         runtime: params.threadState.acpRuntime,
-      }).currentLabel
+      })
     : undefined;
-  const acpRuntimeChoices = isAcpBackendId(params.binding.backend)
-    ? buildMessagingAcpRuntimeModeSummary({
-        backend: params.backendSummary,
-        runtime: params.threadState.acpRuntime,
-      }).choices
-    : [];
+  const acpRuntimeLabel = acpRuntimeMode?.currentLabel;
+  const acpRuntimeChoices = acpRuntimeMode?.choices ?? [];
 
   return {
     id: params.id,
@@ -142,9 +139,10 @@ export function buildBindingStatusIntent(params: {
       `Model: ${model}`,
       `Reasoning: ${reasoning}`,
       `Fast mode: ${fastModeLabel}`,
-      acpRuntimeLabel
-        ? `Runtime mode: ${acpRuntimeLabel}`
-        : `Permissions: ${formatPermissionsLineLabel(permissionsMode, queuedExecutionMode)}`,
+      `Permissions: ${
+        acpRuntimeLabel ??
+        formatPermissionsLineLabel(permissionsMode, queuedExecutionMode)
+      }`,
       `Tool updates: ${formatMessagingToolUpdateModeLabel(toolUpdateMode)}`,
       `Streaming: ${streamingLabel}`,
       params.binding.pendingSkillSelection
@@ -164,8 +162,10 @@ export function buildBindingStatusIntent(params: {
       fastMode,
       handoff: params.handoff,
       permissionsMode,
-      runtimeChoices: acpRuntimeChoices,
-      supportsPermissionsAction: !acpRuntimeLabel,
+      permissionsChoices: acpRuntimeChoices,
+      supportsLegacyPermissionsAction:
+        !isAcpBackendId(params.binding.backend) ||
+        permissionsMode === "full-access",
       queuedExecutionMode,
       reasoning,
       streamingMode,
@@ -384,8 +384,8 @@ function buildStatusActions(params: {
   fastMode: boolean | undefined;
   handoff?: MessagingWorkspaceHandoffContext;
   permissionsMode: string;
-  runtimeChoices?: MessagingAcpRuntimeModeChoice[];
-  supportsPermissionsAction?: boolean;
+  permissionsChoices?: MessagingAcpRuntimeModeChoice[];
+  supportsLegacyPermissionsAction?: boolean;
   queuedExecutionMode?: ThreadExecutionMode;
   reasoning: string;
   streamingMode: MessagingStreamingResponseMode;
@@ -400,31 +400,23 @@ function buildStatusActions(params: {
   const permissionsAction:
     | MessagingSurfaceAction
     | undefined =
-    params.supportsPermissionsAction !== false &&
-    (params.permissionsMode === "full-access" || params.allowFullAccessEscalation !== false)
+    params.permissionsChoices?.length ||
+    (params.supportsLegacyPermissionsAction !== false &&
+      (params.permissionsMode === "full-access" ||
+        params.allowFullAccessEscalation !== false))
       ? {
           id: "status:permissions",
-          label: formatPermissionsActionLabel(
-            params.permissionsMode,
-            params.queuedExecutionMode,
-          ),
+          label: params.permissionsChoices?.length
+            ? `Permissions: ${
+                params.permissionsChoices.find((choice) => choice.selected)?.label ??
+                "Agent default"
+              }`
+            : formatPermissionsActionLabel(
+                params.permissionsMode,
+                params.queuedExecutionMode,
+              ),
           style: "secondary",
           fallbackText: "permissions",
-          priority: 7,
-        }
-      : undefined;
-  const runtimeAction:
-    | MessagingSurfaceAction
-    | undefined =
-    params.runtimeChoices && params.runtimeChoices.length > 0
-      ? {
-          id: "status:runtime-mode",
-          label: `Runtime: ${
-            params.runtimeChoices.find((choice) => choice.selected)?.label ??
-            "Agent default"
-          }`,
-          style: "secondary",
-          fallbackText: "runtime",
           priority: 7,
         }
       : undefined;
@@ -451,7 +443,6 @@ function buildStatusActions(params: {
       priority: 6,
     },
     ...(permissionsAction ? [permissionsAction] : []),
-    ...(runtimeAction ? [runtimeAction] : []),
     ...(params.handoff
       ? [
           {
@@ -622,16 +613,32 @@ export function formatMessagingToolUpdateModeLabel(
 ): string {
   switch (mode) {
     case "show_none":
-      return "Show None";
+      return "None";
     case "show_less":
-      return "Show Less";
+      return "Few";
     case "show_some":
-      return "Show Some";
+      return "Some";
     case "show_more":
-      return "Show More";
+      return "More";
     case "show_all":
-      return "Show All";
+      return "All";
   }
+}
+
+export type MessagingToolUpdateModeChoice = {
+  current?: boolean;
+  label: string;
+  mode: MessagingToolUpdateMode;
+};
+
+export function messagingToolUpdateModeChoices(
+  currentMode: MessagingToolUpdateMode,
+): MessagingToolUpdateModeChoice[] {
+  return TOOL_UPDATE_MODE_ORDER.map((mode) => ({
+    current: mode === currentMode,
+    label: formatMessagingToolUpdateModeLabel(mode),
+    mode,
+  }));
 }
 
 export function buildHandoffOverviewIntent(params: {
@@ -1144,6 +1151,7 @@ export function buildStatusAcpRuntimeModePickerIntent(params: {
   choices: MessagingAcpRuntimeModeChoice[];
   createdAt: number;
   id: string;
+  prompt?: string;
 }): MessagingSingleSelectIntent {
   return {
     id: params.id,
@@ -1155,8 +1163,8 @@ export function buildStatusAcpRuntimeModePickerIntent(params: {
       fallback: "present_new",
     },
     targetSurface: params.binding.statusSurface,
-    fallbackText: "Reply with a runtime mode number, Refresh, or Detach.",
-    prompt: "Select Runtime Mode",
+    fallbackText: "Reply with a permissions option number, Back, or Cancel.",
+    prompt: params.prompt ?? "Select Permissions",
     choices: applyActionCapabilityLimits(
       [
         ...params.choices.map((choice, index) => ({
@@ -1173,6 +1181,153 @@ export function buildStatusAcpRuntimeModePickerIntent(params: {
         })),
         {
           id: "status:refresh",
+          label: "Back",
+          fallbackText: "back",
+          style: "secondary" as const,
+          priority: 1,
+        },
+      ],
+      params.capabilityProfile,
+    ),
+  };
+}
+
+export function buildStatusPermissionsPickerIntent(params: {
+  binding: MessagingBindingRecord;
+  capabilityProfile?: MessagingCapabilityProfile;
+  createdAt: number;
+  currentMode: ThreadExecutionMode;
+  id: string;
+}): MessagingSingleSelectIntent {
+  const choices: Array<{ label: string; mode: ThreadExecutionMode }> = [
+    { label: "Default", mode: "default" },
+    { label: "Full Access", mode: "full-access" },
+  ];
+  return {
+    id: params.id,
+    kind: "single_select",
+    bindingId: params.binding.id,
+    createdAt: params.createdAt,
+    delivery: {
+      mode: params.binding.statusSurface ? "update" : "present",
+      fallback: "present_new",
+    },
+    targetSurface: params.binding.statusSurface,
+    fallbackText: "Reply with a permissions option number, Back, or Cancel.",
+    prompt: "Select Permissions",
+    choices: applyActionCapabilityLimits(
+      [
+        ...choices.map((choice, index) => ({
+          id: "status:set-permissions",
+          label: `${choice.label}${choice.mode === params.currentMode ? " (current)" : ""}`,
+          fallbackText: String(index + 1),
+          style: "secondary" as const,
+          priority: 10 + index,
+          value: {
+            executionMode: choice.mode,
+          },
+        })),
+        {
+          id: "status:refresh",
+          label: "Back",
+          fallbackText: "back",
+          style: "secondary" as const,
+          priority: 1,
+        },
+      ],
+      params.capabilityProfile,
+    ),
+  };
+}
+
+export function buildStatusToolUpdateModePickerIntent(params: {
+  binding: MessagingBindingRecord;
+  capabilityProfile?: MessagingCapabilityProfile;
+  choices: MessagingToolUpdateModeChoice[];
+  createdAt: number;
+  id: string;
+}): MessagingSingleSelectIntent {
+  return {
+    id: params.id,
+    kind: "single_select",
+    bindingId: params.binding.id,
+    createdAt: params.createdAt,
+    delivery: {
+      mode: params.binding.statusSurface ? "update" : "present",
+      fallback: "present_new",
+    },
+    targetSurface: params.binding.statusSurface,
+    fallbackText: "Reply with a tools option number, Back, or Cancel.",
+    prompt: "Select Tools",
+    choices: applyActionCapabilityLimits(
+      [
+        ...params.choices.map((choice, index) => ({
+          id: "status:set-tool-updates",
+          label: `${choice.label}${choice.current ? " (current)" : ""}`,
+          fallbackText: String(index + 1),
+          style: "secondary" as const,
+          priority: 10 + index,
+          value: {
+            toolUpdateMode: choice.mode,
+          },
+        })),
+        {
+          id: "status:refresh",
+          label: "Back",
+          fallbackText: "back",
+          style: "secondary" as const,
+          priority: 1,
+        },
+      ],
+      params.capabilityProfile,
+    ),
+  };
+}
+
+export function buildNewThreadEnvironmentPickerIntent(params: {
+  browseSessionId: string;
+  capabilityProfile?: MessagingCapabilityProfile;
+  createdAt: number;
+  currentEnvironmentId?: string | null;
+  id: string;
+  options: CodexEnvironmentOption[];
+  targetSurface?: MessagingStatusIntent["targetSurface"];
+}): MessagingSingleSelectIntent {
+  return {
+    id: params.id,
+    kind: "single_select",
+    browseSessionId: params.browseSessionId,
+    createdAt: params.createdAt,
+    delivery: params.targetSurface
+      ? { mode: "update", replaceMarkup: true }
+      : undefined,
+    targetSurface: params.targetSurface,
+    fallbackText: "Reply with an environment number, Back, or Cancel.",
+    prompt: "Select Environment",
+    choices: applyActionCapabilityLimits(
+      [
+        {
+          id: "browse:new:set-environment",
+          label: `None${params.currentEnvironmentId ? "" : " (current)"}`,
+          fallbackText: "none",
+          style: "secondary" as const,
+          priority: 10,
+          value: {
+            environmentId: null,
+          },
+        },
+        ...params.options.map((option, index) => ({
+          id: "browse:new:set-environment",
+          label: `${option.name}${option.id === params.currentEnvironmentId ? " (current)" : ""}`,
+          fallbackText: String(index + 1),
+          style: "secondary" as const,
+          priority: 20 + index,
+          value: {
+            environmentId: option.id,
+          },
+        })),
+        {
+          id: "browse:new:environment:back",
           label: "Back",
           fallbackText: "back",
           style: "secondary" as const,

--- a/apps/desktop/src/main/messaging/core/messaging-status-card.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-status-card.ts
@@ -73,14 +73,25 @@ export function buildBindingStatusIntent(params: {
     preferences?.model ??
     defaults?.model ??
     unavailable();
-  const reasoning =
-    params.threadState.reasoningEffort ??
-    preferences?.reasoningEffort ??
-    defaults?.reasoningEffort ??
-    unavailable();
-  const fastMode =
-    params.threadState.fastMode ?? preferences?.fastMode ?? defaults?.fastMode;
-  const fastModeLabel = formatFastModeStatus(fastMode, params.backendSummary);
+  const modelOption = params.backendSummary?.launchpadOptions?.models?.find(
+    (option) => option.id === model,
+  );
+  const supportsReasoning =
+    !params.backendSummary ||
+    Boolean(params.backendSummary.launchpadOptions?.reasoningEfforts?.length);
+  const reasoning = supportsReasoning
+    ? params.threadState.reasoningEffort ??
+      preferences?.reasoningEffort ??
+      defaults?.reasoningEffort ??
+      unavailable()
+    : undefined;
+  const supportsFastMode = backendSupportsFastMode(
+    params.backendSummary,
+    modelOption,
+  );
+  const fastMode = supportsFastMode
+    ? params.threadState.fastMode ?? preferences?.fastMode ?? defaults?.fastMode
+    : undefined;
   const contextUsageLine = formatContextUsageLine(params.contextUsageSummary);
   const accountLine = formatBackendAccountLine(params.backendSummary, params.binding);
   const rateLimitsLine = formatBackendRateLimitsLine(params.backendSummary);
@@ -147,8 +158,8 @@ export function buildBindingStatusIntent(params: {
       params.threadState.missing ? "Thread state: unavailable" : undefined,
       mentionRequiredLine(params.binding, params.capabilityProfile),
       `Model: ${model}`,
-      `Reasoning: ${reasoning}`,
-      `Fast mode: ${fastModeLabel}`,
+      reasoning ? `Reasoning: ${reasoning}` : undefined,
+      supportsFastMode ? `Fast mode: ${fastMode ? "on" : "off"}` : undefined,
       `Permissions: ${permissionsLineLabel}`,
       `Tool updates: ${formatMessagingToolUpdateModeLabel(toolUpdateMode)}`,
       `Streaming: ${streamingLabel}`,
@@ -176,6 +187,8 @@ export function buildBindingStatusIntent(params: {
         permissionsMode === "full-access",
       queuedExecutionMode,
       reasoning,
+      supportsFastMode,
+      supportsReasoning,
       streamingMode,
       streamingResponsesDefault: params.streamingResponsesDefault,
       toolUpdateMode,
@@ -183,17 +196,17 @@ export function buildBindingStatusIntent(params: {
   };
 }
 
-function formatFastModeStatus(
-  fastMode: boolean | undefined,
+function backendSupportsFastMode(
   backendSummary: BackendSummary | undefined,
-): string {
-  if (fastMode !== undefined) {
-    return fastMode ? "on" : "off";
+  modelOption: { supportsFast?: boolean } | undefined,
+): boolean {
+  if (!backendSummary) {
+    return true;
   }
-  if (backendSummary?.launchpadOptions?.supportsFastMode === false) {
-    return "unsupported";
+  if (backendSummary.kind !== "codex") {
+    return false;
   }
-  return unavailable();
+  return modelOption?.supportsFast ?? backendSummary.launchpadOptions?.supportsFastMode ?? false;
 }
 
 function formatContextUsageLine(summary: string | undefined): string | undefined {
@@ -396,7 +409,9 @@ function buildStatusActions(params: {
   permissionsChoices?: MessagingAcpRuntimeModeChoice[];
   supportsLegacyPermissionsAction?: boolean;
   queuedExecutionMode?: ThreadExecutionMode;
-  reasoning: string;
+  reasoning?: string;
+  supportsFastMode: boolean;
+  supportsReasoning: boolean;
   streamingMode: MessagingStreamingResponseMode;
   streamingResponsesDefault?: boolean;
   toolUpdateMode: MessagingToolUpdateMode;
@@ -429,20 +444,28 @@ function buildStatusActions(params: {
       fallbackText: "model",
       priority: 4,
     },
-    {
-      id: "status:reasoning",
-      label: `Reasoning: ${params.reasoning}`,
-      style: "secondary",
-      fallbackText: "reasoning",
-      priority: 5,
-    },
-    {
-      id: "status:fast",
-      label: params.fastMode ? "Fast: on" : "Fast: off",
-      style: "secondary",
-      fallbackText: "fast",
-      priority: 6,
-    },
+    ...(params.supportsReasoning && params.reasoning
+      ? [
+          {
+            id: "status:reasoning",
+            label: `Reasoning: ${params.reasoning}`,
+            style: "secondary" as const,
+            fallbackText: "reasoning",
+            priority: 5,
+          },
+        ]
+      : []),
+    ...(params.supportsFastMode
+      ? [
+          {
+            id: "status:fast",
+            label: params.fastMode ? "Fast: on" : "Fast: off",
+            style: "secondary" as const,
+            fallbackText: "fast",
+            priority: 6,
+          },
+        ]
+      : []),
     ...(permissionsAction ? [permissionsAction] : []),
     ...(params.handoff
       ? [

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -24,7 +24,9 @@ import {
   MAX_IMMUTABLE_USAGE_ACTIVITY_ENTRIES,
   MAX_PERMISSION_TRANSITION_LOG_ENTRIES,
   buildThreadIdentityKey,
+  applyNavigationLaunchpadProviderSettingsPatch,
   parseThreadIdentityKey,
+  projectNavigationLaunchpadProviderSettings,
 } from "@pwragent/shared";
 import {
   buildNavigationSnapshot,
@@ -57,7 +59,8 @@ function parseDirectoryGitStatusCachePayload(
 function normalizeLaunchpadDefaults(
   defaults: NavigationLaunchpadDefaults,
 ): NavigationLaunchpadDefaults {
-  const next: NavigationLaunchpadDefaults = { ...defaults };
+  const next: NavigationLaunchpadDefaults =
+    projectNavigationLaunchpadProviderSettings(defaults);
   if (
     next.backend === "codex" &&
     (next.serviceTier === "fast" || next.serviceTier === "priority")
@@ -911,7 +914,9 @@ export class SqliteOverlayStore {
     patch: Partial<NavigationLaunchpadDefaults>,
   ): Promise<NavigationLaunchpadDefaults> {
     const current = this.readLaunchpadDefaults();
-    const next = normalizeLaunchpadDefaults({ ...current, ...patch });
+    const next = normalizeLaunchpadDefaults(
+      applyNavigationLaunchpadProviderSettingsPatch(current, patch),
+    );
     this.writeLaunchpadDefaults(next);
     return next;
   }
@@ -940,14 +945,22 @@ export class SqliteOverlayStore {
     const row = this.stateDb.raw
       .prepare("SELECT payload FROM directory_launchpads WHERE directory_path = ?")
       .get(params.directoryKey) as { payload: string } | undefined;
-    return row ? JSON.parse(row.payload) : undefined;
+    return row
+      ? projectNavigationLaunchpadProviderSettings(
+          JSON.parse(row.payload) as DirectoryLaunchpadOverlayState,
+        )
+      : undefined;
   }
 
   async listDirectoryLaunchpads(): Promise<DirectoryLaunchpadOverlayState[]> {
     const rows = this.stateDb.raw
       .prepare("SELECT payload FROM directory_launchpads")
       .all() as { payload: string }[];
-    return rows.map((r) => JSON.parse(r.payload));
+    return rows.map((r) =>
+      projectNavigationLaunchpadProviderSettings(
+        JSON.parse(r.payload) as DirectoryLaunchpadOverlayState,
+      ),
+    );
   }
 
   async upsertDirectoryLaunchpad(
@@ -1160,7 +1173,12 @@ export class SqliteOverlayStore {
       .prepare("SELECT directory_path, payload FROM directory_launchpads")
       .all() as { directory_path: string; payload: string }[];
     return Object.fromEntries(
-      rows.map((r) => [r.directory_path, JSON.parse(r.payload)]),
+      rows.map((r) => [
+        r.directory_path,
+        projectNavigationLaunchpadProviderSettings(
+          JSON.parse(r.payload) as DirectoryLaunchpadOverlayState,
+        ),
+      ]),
     );
   }
 

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -1,11 +1,11 @@
 import type {
   AppServerBackendKind,
   BackendAcpSessionRuntimeState,
+  CodexEnvironmentExecutionTarget,
   LaunchpadWorkMode,
   AppServerThreadImagePart,
   AppServerThreadMessagePart,
   AppServerThreadSummary,
-  CodexEnvironmentExecutionTarget,
   MessagingDeliveryScope,
   MessagingToolUpdateMode,
   ThreadIdentifier,
@@ -747,6 +747,7 @@ export type MessagingProjectPickerIntent = MessagingBaseSurfaceIntent & {
 
 export type MessagingSingleSelectIntent = MessagingBaseSurfaceIntent & {
   kind: "single_select";
+  browseSessionId?: string;
   prompt: string;
   choices: MessagingChoice[];
 };
@@ -954,6 +955,10 @@ export type MessagingPermissionsMode = "default" | "full-access";
 
 export type MessagingBindingPreferences = {
   acpRuntime?: BackendAcpSessionRuntimeState;
+  codexEnvironmentActionId?: string | null;
+  codexEnvironmentExecutionTarget?: CodexEnvironmentExecutionTarget;
+  codexEnvironmentId?: string | null;
+  codexEnvironmentSetupEnabled?: boolean;
   executionMode?: ThreadExecutionMode;
   fastMode?: boolean;
   model?: string;

--- a/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
+++ b/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
@@ -530,6 +530,55 @@ describe("discord adapter", () => {
     await restartedAdapter.stop();
   });
 
+  it("stores browse session ids for single-select component handles", async () => {
+    const store = createCallbackHandleStore();
+    let createdRequest: Parameters<DiscordApi["createMessage"]>[1] | undefined;
+    const createMessage = vi.fn(async (channelId: string, request) => {
+      createdRequest = request;
+      return {
+        channel_id: channelId,
+        id: "message-2",
+      };
+    });
+    const adapter = new DiscordAdapter({
+      api: createApi({ createMessage }),
+      config: {
+        authorizedActorIds: [{ id: TEST_USER_ID, displayName: "" }],
+        botToken: "token",
+        channel: "discord",
+      },
+      now: () => 1234,
+      store,
+    });
+
+    await adapter.deliver({
+      audit: discordAudit(),
+      browseSessionId: "browse-env-1",
+      choices: [
+        {
+          id: "browse:new:set-environment",
+          label: "Dev",
+          value: { environmentId: "dev" },
+        },
+      ],
+      createdAt: 1234,
+      fallbackText: "Pick an environment.",
+      id: "environment-picker",
+      kind: "single_select",
+      prompt: "Select Environment",
+    });
+
+    const customId = createdRequest?.components?.[0]?.components[0]?.custom_id;
+    expect(store.upsertCallbackHandle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionId: "browse:new:set-environment",
+        browseSessionId: "browse-env-1",
+        handle: customId,
+        value: { environmentId: "dev" },
+      }),
+    );
+  });
+
   it("validates live component clicks against persisted callback actor scope", async () => {
     const store = createCallbackHandleStore();
     let createdRequest: Parameters<DiscordApi["createMessage"]>[1] | undefined;

--- a/packages/messaging/providers/discord/src/discord-adapter.ts
+++ b/packages/messaging/providers/discord/src/discord-adapter.ts
@@ -2367,6 +2367,7 @@ function sanitizeDiscordThreadName(title: string): string {
 function browseSessionIdForIntent(intent: MessagingSurfaceIntent): string | undefined {
   return intent.kind === "thread_picker" ||
     intent.kind === "project_picker" ||
+    intent.kind === "single_select" ||
     intent.kind === "confirmation"
     ? intent.browseSessionId
     : undefined;

--- a/packages/messaging/providers/feishu/src/__tests__/feishu-adapter.test.ts
+++ b/packages/messaging/providers/feishu/src/__tests__/feishu-adapter.test.ts
@@ -261,6 +261,49 @@ describe("FeishuAdapter", () => {
     });
   });
 
+  it("stores browse session ids for single-select callback handles", async () => {
+    const store = fakeStore();
+    const spies: { sent: unknown[] } = { sent: [] };
+    const adapter = new FeishuAdapter({
+      config: baseConfig,
+      callbackHandleStore: store,
+      api: fakeApi(spies),
+      now: () => 1_700_000_000_000,
+    });
+
+    await adapter.deliver({
+      id: "environment-picker",
+      kind: "single_select",
+      browseSessionId: "browse-env-1",
+      createdAt: 1,
+      fallbackText: "Pick an environment.",
+      prompt: "Select Environment",
+      choices: [
+        {
+          id: "browse:new:set-environment",
+          label: "Dev",
+          value: { environmentId: "dev" },
+        },
+      ],
+      audit: {
+        actor: { platformUserId: "ou_user" },
+        channel: {
+          channel: "feishu",
+          conversation: { id: "ou_user", kind: "dm" },
+        },
+        occurredAt: 1,
+      },
+    });
+
+    expect(store.records).toHaveLength(1);
+    expect(store.records[0]).toMatchObject({
+      actionId: "browse:new:set-environment",
+      browseSessionId: "browse-env-1",
+      pendingIntentId: "environment-picker",
+      value: { environmentId: "dev" },
+    });
+  });
+
   it("normalizes authorized webhook text events", async () => {
     const adapter = new FeishuAdapter({
       config: baseConfig,

--- a/packages/messaging/providers/feishu/src/feishu-adapter.ts
+++ b/packages/messaging/providers/feishu/src/feishu-adapter.ts
@@ -2272,6 +2272,7 @@ function callbackBindingId(intent: MessagingSurfaceIntent): string | undefined {
 function browseSessionIdForIntent(intent: MessagingSurfaceIntent): string | undefined {
   return intent.kind === "thread_picker" ||
     intent.kind === "project_picker" ||
+    intent.kind === "single_select" ||
     intent.kind === "confirmation"
     ? intent.browseSessionId
     : undefined;

--- a/packages/messaging/providers/line/src/__tests__/line-adapter.test.ts
+++ b/packages/messaging/providers/line/src/__tests__/line-adapter.test.ts
@@ -240,6 +240,43 @@ describe("LineAdapter", () => {
     );
   });
 
+  it("stores browse session ids for single-select callback handles", async () => {
+    const api = createApi();
+    const store = createCallbackStore();
+    const adapter = new LineAdapter({
+      api,
+      callbackHandleStore: store,
+      config: createConfig(),
+      now: () => 1234,
+    });
+    adapters.push(adapter);
+
+    await adapter.deliver({
+      id: "environment-picker",
+      kind: "single_select",
+      browseSessionId: "browse-env-1",
+      createdAt: 1234,
+      fallbackText: "Pick an environment.",
+      prompt: "Select Environment",
+      choices: [
+        {
+          id: "browse:new:set-environment",
+          label: "Dev",
+          value: { environmentId: "dev" },
+        },
+      ],
+      audit: lineDmAudit(),
+    });
+
+    expect(store.upsertCallbackHandle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionId: "browse:new:set-environment",
+        browseSessionId: "browse-env-1",
+        value: { environmentId: "dev" },
+      }),
+    );
+  });
+
   it("uses concise LINE flex titles instead of repeating full picker fallback text", async () => {
     const api = createApi();
     const adapter = new LineAdapter({

--- a/packages/messaging/providers/line/src/line-adapter.ts
+++ b/packages/messaging/providers/line/src/line-adapter.ts
@@ -1250,6 +1250,7 @@ function callbackBindingId(intent: MessagingSurfaceIntent): string | undefined {
 function browseSessionIdForIntent(intent: MessagingSurfaceIntent): string | undefined {
   return intent.kind === "thread_picker" ||
     intent.kind === "project_picker" ||
+    intent.kind === "single_select" ||
     intent.kind === "confirmation"
     ? intent.browseSessionId
     : undefined;

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -2794,6 +2794,7 @@ function parseTelegramIdentifier(value: string): number | string {
 function browseSessionIdForIntent(intent: MessagingSurfaceIntent): string | undefined {
   return intent.kind === "thread_picker" ||
     intent.kind === "project_picker" ||
+    intent.kind === "single_select" ||
     intent.kind === "confirmation"
     ? intent.browseSessionId
     : undefined;

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -193,7 +193,144 @@ export type NavigationLaunchpadDefaults = {
   serviceTier?: string;
   fastMode?: boolean;
   acpRuntime?: BackendAcpSessionRuntimeState;
+  providerSettings?: Partial<
+    Record<AppServerBackendKind, NavigationLaunchpadProviderSettings>
+  >;
 };
+
+export type NavigationLaunchpadProviderSettings = {
+  executionMode?: ThreadExecutionMode;
+  model?: string;
+  reasoningEffort?: string;
+  serviceTier?: string;
+  fastMode?: boolean;
+  acpRuntime?: BackendAcpSessionRuntimeState;
+};
+
+const NAVIGATION_LAUNCHPAD_PROVIDER_SETTING_KEYS = [
+  "executionMode",
+  "model",
+  "reasoningEffort",
+  "serviceTier",
+  "fastMode",
+  "acpRuntime",
+] as const satisfies readonly (keyof NavigationLaunchpadProviderSettings)[];
+
+export function extractNavigationLaunchpadProviderSettings(
+  source: Partial<NavigationLaunchpadDefaults>,
+): NavigationLaunchpadProviderSettings {
+  const settings: NavigationLaunchpadProviderSettings = {};
+  for (const key of NAVIGATION_LAUNCHPAD_PROVIDER_SETTING_KEYS) {
+    if (key in source) {
+      settings[key] = source[key] as never;
+    }
+  }
+  return settings;
+}
+
+function hasNavigationLaunchpadProviderSettingPatch(
+  patch: Partial<NavigationLaunchpadDefaults>,
+): boolean {
+  return NAVIGATION_LAUNCHPAD_PROVIDER_SETTING_KEYS.some((key) => key in patch);
+}
+
+function mergeNavigationLaunchpadProviderSettings(
+  current: NavigationLaunchpadProviderSettings,
+  patch: NavigationLaunchpadProviderSettings,
+): NavigationLaunchpadProviderSettings {
+  const next: NavigationLaunchpadProviderSettings = { ...current };
+  for (const key of NAVIGATION_LAUNCHPAD_PROVIDER_SETTING_KEYS) {
+    if (key in patch) {
+      const value = patch[key];
+      if (value === undefined) {
+        delete next[key];
+      } else {
+        next[key] = value as never;
+      }
+    }
+  }
+  return next;
+}
+
+function isEmptyNavigationLaunchpadProviderSettings(
+  settings: NavigationLaunchpadProviderSettings | undefined,
+): boolean {
+  return !settings || Object.keys(settings).length === 0;
+}
+
+function seedNavigationLaunchpadProviderSettings<T extends NavigationLaunchpadDefaults>(
+  launchpad: T,
+): Partial<Record<AppServerBackendKind, NavigationLaunchpadProviderSettings>> {
+  const providerSettings = { ...(launchpad.providerSettings ?? {}) };
+  providerSettings[launchpad.backend] = mergeNavigationLaunchpadProviderSettings(
+    providerSettings[launchpad.backend] ?? {},
+    extractNavigationLaunchpadProviderSettings(launchpad),
+  );
+  return providerSettings;
+}
+
+function clearNavigationLaunchpadProviderFields<T extends NavigationLaunchpadDefaults>(
+  launchpad: T,
+): T {
+  return {
+    ...launchpad,
+    executionMode: "default",
+    model: undefined,
+    reasoningEffort: undefined,
+    serviceTier: undefined,
+    fastMode: undefined,
+    acpRuntime: undefined,
+  };
+}
+
+export function projectNavigationLaunchpadProviderSettings<
+  T extends NavigationLaunchpadDefaults,
+>(launchpad: T): T {
+  const legacySettings = extractNavigationLaunchpadProviderSettings(launchpad);
+  const providerSettings = launchpad.providerSettings?.[launchpad.backend];
+  const settings = {
+    ...legacySettings,
+    ...(providerSettings ?? {}),
+  };
+  return {
+    ...launchpad,
+    executionMode: settings.executionMode ?? "default",
+    model: settings.model,
+    reasoningEffort: settings.reasoningEffort,
+    serviceTier: settings.serviceTier,
+    fastMode: settings.fastMode,
+    acpRuntime: settings.acpRuntime,
+  };
+}
+
+export function applyNavigationLaunchpadProviderSettingsPatch<
+  T extends NavigationLaunchpadDefaults,
+>(launchpad: T, patch: Partial<T>): T {
+  const providerPatch = extractNavigationLaunchpadProviderSettings(patch);
+  const backend = patch.backend ?? launchpad.backend;
+  const providerSettings = seedNavigationLaunchpadProviderSettings(launchpad);
+
+  if (hasNavigationLaunchpadProviderSettingPatch(patch)) {
+    providerSettings[backend] = mergeNavigationLaunchpadProviderSettings(
+      providerSettings[backend] ?? {},
+      providerPatch,
+    );
+    if (isEmptyNavigationLaunchpadProviderSettings(providerSettings[backend])) {
+      delete providerSettings[backend];
+    }
+  }
+
+  const base =
+    backend === launchpad.backend
+      ? { ...launchpad, ...patch, providerSettings }
+      : {
+          ...clearNavigationLaunchpadProviderFields(launchpad),
+          ...patch,
+          backend,
+          providerSettings,
+        };
+  return projectNavigationLaunchpadProviderSettings(base as T);
+}
 
 export type NavigationLaunchpadDraft = NavigationLaunchpadDefaults & {
   directoryKey: string;


### PR DESCRIPTION
## Summary

- I changed messaging status-card Tools and Permissions controls from click-to-cycle buttons into single-select pickers that show the current checked value.
- I aligned ACP permissions handling so runtime choices are represented through the Permissions picker instead of leaking as a confusing Runtime control.
- I added messaging new-thread Environment selection backed by Codex environment options, including `None`, and carried the selected environment into launchpad materialization.
- I added Provider and Environment details to the new-thread status text/buttons so the messaging setup view matches the provider/environment selected from launchpad defaults or picker choices.

## Verification

- I verified this branch is a single commit over the rewritten `origin/main`.
- `pnpm --filter @pwragent/desktop exec vitest run src/main/__tests__/messaging-controller.test.ts src/main/__tests__/messaging-status-card.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm --filter @pwragent/messaging-interface typecheck`
- `pnpm --filter @pwragent/messaging-interface test`
- `pnpm lint:boundaries`
- `git diff --check`

## Notes

- The only untracked local file is `foo.out`; I did not include it in this PR.
