### PR TITLE
fix(desktop): show env run feedback

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -574,6 +574,12 @@ type EnvActionOutputState = {
   nextChunkId: number;
 };
 
+type ThreadEnvActionStartingKey = {
+  actionId: string;
+  backend: NavigationThreadSummary["source"];
+  threadId: string;
+};
+
 function buildEnvActionOutputState(
   output: string,
   nextChunkId = 1,
@@ -593,6 +599,18 @@ function trimEnvActionOutputChunks(
   const trimmed = tailLines(text, ENV_ACTION_OUTPUT_MAX_LINES);
   if (trimmed === text) return chunks;
   return [{ id: chunks.at(-1)?.id ?? 0, text: trimmed }];
+}
+
+function sameThreadEnvActionStartingKey(
+  left: ThreadEnvActionStartingKey | undefined,
+  right: ThreadEnvActionStartingKey | undefined,
+): boolean {
+  if (!left || !right) return false;
+  return (
+    left.backend === right.backend &&
+    left.threadId === right.threadId &&
+    left.actionId === right.actionId
+  );
 }
 
 function elementContainsSelection(element: HTMLElement | null): boolean {
@@ -674,22 +692,6 @@ export function EnvActionAnchorList(props: {
   runtime?: Pick<CodexThreadEnvironmentRuntime, "actionRuns" | "environmentName"> | undefined;
 }): ReactNode {
   const runs = readCodexEnvironmentActionRuns(props.runtime);
-  const hasStartedRun = useMemo(
-    () => runs.some((run) => run.status === "started"),
-    [runs],
-  );
-  const [, setElapsedTick] = useState(0);
-  useEffect(() => {
-    if (!hasStartedRun) return undefined;
-    const handle = setInterval(() => {
-      setElapsedTick((tick) => tick + 1);
-    }, 1_000);
-    return () => clearInterval(handle);
-  }, [hasStartedRun]);
-  // Bumped after dismissal to force a re-render (the dismissed-set lives
-  // outside React state).
-  const [, setDismissTick] = useState(0);
-
   const visible = runs.filter((run) => {
     if (dismissedEnvActionAnchorKeys.has(run.runId)) return false;
     const latestActivityAt = Math.max(run.exitedAt ?? 0, run.startedAt ?? 0);
@@ -707,6 +709,19 @@ export function EnvActionAnchorList(props: {
     }
     return true;
   });
+  const hasVisibleStartedRun = visible.some((run) => run.status === "started");
+  const [, setElapsedTick] = useState(0);
+  useEffect(() => {
+    if (!hasVisibleStartedRun) return undefined;
+    const handle = setInterval(() => {
+      setElapsedTick((tick) => tick + 1);
+    }, 1_000);
+    return () => clearInterval(handle);
+  }, [hasVisibleStartedRun]);
+  // Bumped after dismissal to force a re-render (the dismissed-set lives
+  // outside React state).
+  const [, setDismissTick] = useState(0);
+
   if (visible.length === 0) return null;
 
   return (
@@ -1505,7 +1520,10 @@ export function Composer(props: ComposerProps) {
   );
   const [sendError, setSendError] = useState<string>();
   const [applicationOpenError, setApplicationOpenError] = useState<string>();
-  const [threadEnvActionStarting, setThreadEnvActionStarting] = useState(false);
+  const [threadEnvActionStarting, setThreadEnvActionStartingState] =
+    useState<ThreadEnvActionStartingKey>();
+  const threadEnvActionStartingRef =
+    useRef<ThreadEnvActionStartingKey | undefined>(undefined);
   const threadEnvActionStartingTimeoutRef = useRef<number | undefined>(undefined);
   const [imageAttachments, setImageAttachments] = useState<ComposerImageAttachment[]>(
     latestDraftSnapshotRef.current.snapshot.imageAttachments
@@ -1522,35 +1540,58 @@ export function Composer(props: ComposerProps) {
   const [activeSlashIndex, setActiveSlashIndex] = useState(0);
   const [dismissedAutocompleteKey, setDismissedAutocompleteKey] = useState<string>();
 
-  const clearThreadEnvActionStarting = (): void => {
+  const setThreadEnvActionStarting = (
+    next: ThreadEnvActionStartingKey | undefined,
+  ): void => {
+    threadEnvActionStartingRef.current = next;
+    setThreadEnvActionStartingState(next);
+  };
+
+  const clearThreadEnvActionStarting = (
+    key?: ThreadEnvActionStartingKey,
+  ): void => {
+    if (key && !sameThreadEnvActionStartingKey(threadEnvActionStartingRef.current, key)) {
+      return;
+    }
     if (threadEnvActionStartingTimeoutRef.current !== undefined) {
       window.clearTimeout(threadEnvActionStartingTimeoutRef.current);
       threadEnvActionStartingTimeoutRef.current = undefined;
     }
-    setThreadEnvActionStarting(false);
+    setThreadEnvActionStarting(undefined);
   };
 
-  const showThreadEnvActionStarting = (): void => {
+  const showThreadEnvActionStarting = (
+    key: ThreadEnvActionStartingKey,
+  ): void => {
     if (threadEnvActionStartingTimeoutRef.current !== undefined) {
       window.clearTimeout(threadEnvActionStartingTimeoutRef.current);
       threadEnvActionStartingTimeoutRef.current = undefined;
     }
-    setThreadEnvActionStarting(true);
+    setThreadEnvActionStarting(key);
   };
 
-  const finishThreadEnvActionStarting = (elapsedMs: number): void => {
+  const finishThreadEnvActionStarting = (
+    key: ThreadEnvActionStartingKey,
+    elapsedMs: number,
+  ): void => {
+    if (!sameThreadEnvActionStartingKey(threadEnvActionStartingRef.current, key)) {
+      return;
+    }
     if (threadEnvActionStartingTimeoutRef.current !== undefined) {
       window.clearTimeout(threadEnvActionStartingTimeoutRef.current);
     }
     const remainingMs = Math.max(0, ENV_ACTION_RUN_CONFIRMATION_MS - elapsedMs);
     if (remainingMs === 0) {
       threadEnvActionStartingTimeoutRef.current = undefined;
-      setThreadEnvActionStarting(false);
+      setThreadEnvActionStarting(undefined);
       return;
     }
     threadEnvActionStartingTimeoutRef.current = window.setTimeout(() => {
+      if (!sameThreadEnvActionStartingKey(threadEnvActionStartingRef.current, key)) {
+        return;
+      }
       threadEnvActionStartingTimeoutRef.current = undefined;
-      setThreadEnvActionStarting(false);
+      setThreadEnvActionStarting(undefined);
     }, remainingMs);
   };
 
@@ -3778,29 +3819,34 @@ export function Composer(props: ComposerProps) {
     if (
       !props.thread ||
       !props.desktopApi?.runCodexEnvironmentAction ||
-      !selectedThreadCodexAction
+      !selectedThreadCodexAction ||
+      !currentThreadEnvActionStartingKey
     ) {
       return;
     }
 
+    const thread = props.thread;
+    const action = selectedThreadCodexAction;
+    const startingKey = currentThreadEnvActionStartingKey;
+    const cwd = workspaceOpenPath;
     setSendError(undefined);
-    props.onPendingStatusChange?.(`Starting ${selectedThreadCodexAction.name}`);
-    showThreadEnvActionStarting();
+    props.onPendingStatusChange?.(`Starting ${action.name}`);
+    showThreadEnvActionStarting(startingKey);
     const startedAt = Date.now();
     let actionStarted = false;
     try {
       await props.desktopApi.runCodexEnvironmentAction({
-        backend: props.thread.source,
-        threadId: props.thread.id,
-        actionId: selectedThreadCodexAction.id,
-        ...(workspaceOpenPath ? { cwd: workspaceOpenPath } : {}),
+        backend: thread.source,
+        threadId: thread.id,
+        actionId: action.id,
+        ...(cwd ? { cwd } : {}),
       });
       actionStarted = true;
-      finishThreadEnvActionStarting(Date.now() - startedAt);
+      finishThreadEnvActionStarting(startingKey, Date.now() - startedAt);
       await props.onRefreshNavigation?.();
     } catch (error) {
       if (!actionStarted) {
-        clearThreadEnvActionStarting();
+        clearThreadEnvActionStarting(startingKey);
       }
       setSendError(error instanceof Error ? error.message : String(error));
     } finally {
@@ -3993,6 +4039,18 @@ export function Composer(props: ComposerProps) {
     threadCodexEnvironmentActions.find(
       (action) => action.id === selectedThreadCodexActionId,
     ) ?? threadCodexEnvironmentActions[0];
+  const currentThreadEnvActionStartingKey =
+    props.thread && selectedThreadCodexAction
+      ? {
+          actionId: selectedThreadCodexAction.id,
+          backend: props.thread.source,
+          threadId: props.thread.id,
+        }
+      : undefined;
+  const currentThreadEnvActionStarting = sameThreadEnvActionStartingKey(
+    threadEnvActionStarting,
+    currentThreadEnvActionStartingKey,
+  );
   const threadWorkspace = props.thread ? getThreadWorkspace(props.thread) : undefined;
   const workspaceOpenPath = getComposerWorkspaceOpenPath({
     directory: props.directory,
@@ -5660,12 +5718,12 @@ export function Composer(props: ComposerProps) {
                 <button
                   aria-label="Run"
                   className={
-                    threadEnvActionStarting
+                    currentThreadEnvActionStarting
                       ? "composer__action-button composer__action-button--busy"
                       : "composer__action-button"
                   }
                   disabled={
-                    threadEnvActionStarting ||
+                    currentThreadEnvActionStarting ||
                     !selectedThreadCodexAction ||
                     !props.desktopApi?.runCodexEnvironmentAction
                   }
@@ -5674,7 +5732,7 @@ export function Composer(props: ComposerProps) {
                     void runThreadCodexEnvironmentAction();
                   }}
                 >
-                  {threadEnvActionStarting ? (
+                  {currentThreadEnvActionStarting ? (
                     <span
                       aria-hidden="true"
                       className="composer__action-button-spinner"

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -551,6 +551,7 @@ function QueuedImageAttachments(props: {
 }
 
 const ENV_ACTION_OUTPUT_MAX_LINES = 500;
+const ENV_ACTION_RUN_CONFIRMATION_MS = 5_000;
 
 function tailLines(text: string, maxLines: number): string {
   const lines = text.split("\n");
@@ -642,6 +643,12 @@ export function formatDurationMs(
   return remainder ? `${minutes}m ${remainder}s` : `${minutes}m`;
 }
 
+export function formatRunningDurationMs(ms?: number): string {
+  if (ms === undefined || !Number.isFinite(ms) || ms < 0) return "";
+  const totalSeconds = Math.floor(ms / 1_000);
+  return `${totalSeconds}s`;
+}
+
 /**
  * Set of run identities the user has explicitly dismissed in this session.
  * Module-level so it survives Composer remounts (thread switches), but
@@ -667,39 +674,18 @@ export function EnvActionAnchorList(props: {
   runtime?: Pick<CodexThreadEnvironmentRuntime, "actionRuns" | "environmentName"> | undefined;
 }): ReactNode {
   const runs = readCodexEnvironmentActionRuns(props.runtime);
-  // Tiered tick cadence for the per-run "running for X" meta:
-  //   < 1 min → tick every 1s   (seconds digit moves every second;
-  //                              format prints "Xs")
-  //   ≥ 1 min → tick every 30s  (display switches to coarse "Xm" with
-  //                              no seconds; we only need the tick to
-  //                              catch each minute boundary within
-  //                              ~30s, which is below user-perceived
-  //                              staleness for a minute-granularity
-  //                              display. Avoids the "distracting
-  //                              every-5s text-change" issue.)
-  // Single shared timer across all started runs on the thread; the
-  // interval re-arms when the longest-running run crosses the 1-min
-  // boundary.
-  const tickIntervalMs = useMemo(() => {
-    let maxElapsed = -1;
-    for (const run of runs) {
-      if (run.status !== "started") continue;
-      const startedAt = run.startedAt ?? Date.now();
-      const elapsed = Date.now() - startedAt;
-      if (elapsed > maxElapsed) maxElapsed = elapsed;
-    }
-    if (maxElapsed < 0) return 0; // no running runs → no timer
-    if (maxElapsed < 60_000) return 1_000;
-    return 30_000;
-  }, [runs]);
+  const hasStartedRun = useMemo(
+    () => runs.some((run) => run.status === "started"),
+    [runs],
+  );
   const [, setElapsedTick] = useState(0);
   useEffect(() => {
-    if (!tickIntervalMs) return undefined;
+    if (!hasStartedRun) return undefined;
     const handle = setInterval(() => {
       setElapsedTick((tick) => tick + 1);
-    }, tickIntervalMs);
+    }, 1_000);
     return () => clearInterval(handle);
-  }, [tickIntervalMs]);
+  }, [hasStartedRun]);
   // Bumped after dismissal to force a re-render (the dismissed-set lives
   // outside React state).
   const [, setDismissTick] = useState(0);
@@ -758,9 +744,9 @@ export function EnvActionAnchorEntry(props: {
 
   const meta: string[] = [];
   if (run.pid) meta.push(`pid ${run.pid}`);
-  if (status === "started" && run.startedAt) {
+  if (status === "started" && typeof run.startedAt === "number") {
     meta.push(
-      `running for ${formatDurationMs(Date.now() - run.startedAt, { coarseAfterMinute: true })}`,
+      `running for ${formatRunningDurationMs(Date.now() - run.startedAt)}`,
     );
   }
   if (status !== "started") {
@@ -1519,6 +1505,8 @@ export function Composer(props: ComposerProps) {
   );
   const [sendError, setSendError] = useState<string>();
   const [applicationOpenError, setApplicationOpenError] = useState<string>();
+  const [threadEnvActionStarting, setThreadEnvActionStarting] = useState(false);
+  const threadEnvActionStartingTimeoutRef = useRef<number | undefined>(undefined);
   const [imageAttachments, setImageAttachments] = useState<ComposerImageAttachment[]>(
     latestDraftSnapshotRef.current.snapshot.imageAttachments
   );
@@ -1533,6 +1521,47 @@ export function Composer(props: ComposerProps) {
   const [activeSkillIndex, setActiveSkillIndex] = useState(0);
   const [activeSlashIndex, setActiveSlashIndex] = useState(0);
   const [dismissedAutocompleteKey, setDismissedAutocompleteKey] = useState<string>();
+
+  const clearThreadEnvActionStarting = (): void => {
+    if (threadEnvActionStartingTimeoutRef.current !== undefined) {
+      window.clearTimeout(threadEnvActionStartingTimeoutRef.current);
+      threadEnvActionStartingTimeoutRef.current = undefined;
+    }
+    setThreadEnvActionStarting(false);
+  };
+
+  const showThreadEnvActionStarting = (): void => {
+    if (threadEnvActionStartingTimeoutRef.current !== undefined) {
+      window.clearTimeout(threadEnvActionStartingTimeoutRef.current);
+      threadEnvActionStartingTimeoutRef.current = undefined;
+    }
+    setThreadEnvActionStarting(true);
+  };
+
+  const finishThreadEnvActionStarting = (elapsedMs: number): void => {
+    if (threadEnvActionStartingTimeoutRef.current !== undefined) {
+      window.clearTimeout(threadEnvActionStartingTimeoutRef.current);
+    }
+    const remainingMs = Math.max(0, ENV_ACTION_RUN_CONFIRMATION_MS - elapsedMs);
+    if (remainingMs === 0) {
+      threadEnvActionStartingTimeoutRef.current = undefined;
+      setThreadEnvActionStarting(false);
+      return;
+    }
+    threadEnvActionStartingTimeoutRef.current = window.setTimeout(() => {
+      threadEnvActionStartingTimeoutRef.current = undefined;
+      setThreadEnvActionStarting(false);
+    }, remainingMs);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (threadEnvActionStartingTimeoutRef.current !== undefined) {
+        window.clearTimeout(threadEnvActionStartingTimeoutRef.current);
+        threadEnvActionStartingTimeoutRef.current = undefined;
+      }
+    };
+  }, []);
   const [fullAccessRiskDialogOpen, setFullAccessRiskDialogOpen] =
     useState(false);
   const [fullAccessRiskDontWarnAgain, setFullAccessRiskDontWarnAgain] =
@@ -3756,6 +3785,9 @@ export function Composer(props: ComposerProps) {
 
     setSendError(undefined);
     props.onPendingStatusChange?.(`Starting ${selectedThreadCodexAction.name}`);
+    showThreadEnvActionStarting();
+    const startedAt = Date.now();
+    let actionStarted = false;
     try {
       await props.desktopApi.runCodexEnvironmentAction({
         backend: props.thread.source,
@@ -3763,8 +3795,13 @@ export function Composer(props: ComposerProps) {
         actionId: selectedThreadCodexAction.id,
         ...(workspaceOpenPath ? { cwd: workspaceOpenPath } : {}),
       });
+      actionStarted = true;
+      finishThreadEnvActionStarting(Date.now() - startedAt);
       await props.onRefreshNavigation?.();
     } catch (error) {
+      if (!actionStarted) {
+        clearThreadEnvActionStarting();
+      }
       setSendError(error instanceof Error ? error.message : String(error));
     } finally {
       props.onPendingStatusChange?.(undefined);
@@ -5621,8 +5658,14 @@ export function Composer(props: ComposerProps) {
                   }}
                 />
                 <button
-                  className="composer__action-button"
+                  aria-label="Run"
+                  className={
+                    threadEnvActionStarting
+                      ? "composer__action-button composer__action-button--busy"
+                      : "composer__action-button"
+                  }
                   disabled={
+                    threadEnvActionStarting ||
                     !selectedThreadCodexAction ||
                     !props.desktopApi?.runCodexEnvironmentAction
                   }
@@ -5631,7 +5674,14 @@ export function Composer(props: ComposerProps) {
                     void runThreadCodexEnvironmentAction();
                   }}
                 >
-                  Run
+                  {threadEnvActionStarting ? (
+                    <span
+                      aria-hidden="true"
+                      className="composer__action-button-spinner"
+                    />
+                  ) : (
+                    "Run"
+                  )}
                 </button>
               </>
             ) : null}

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/EnvActionAnchorEntry.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/EnvActionAnchorEntry.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { CodexEnvironmentActionRun } from "@pwragent/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -318,6 +318,38 @@ describe("EnvActionAnchorList", () => {
       expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 1_000);
     } finally {
       setIntervalSpy.mockRestore();
+    }
+  });
+
+  it("stops ticking after the only running anchor is dismissed", async () => {
+    const setIntervalSpy = vi.spyOn(window, "setInterval");
+    const clearIntervalSpy = vi.spyOn(window, "clearInterval");
+    try {
+      render(
+        <EnvActionAnchorList
+          runtime={{
+            environmentName: "PwrAgnt",
+            actionRuns: [
+              buildRun({
+                runId: "dismissed-running-run",
+                startedAt: Date.now(),
+                status: "started",
+              }),
+            ],
+          }}
+        />,
+      );
+
+      expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 1_000);
+      fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+
+      await waitFor(() => {
+        expect(screen.queryByLabelText("Env action running")).not.toBeInTheDocument();
+        expect(clearIntervalSpy).toHaveBeenCalled();
+      });
+    } finally {
+      setIntervalSpy.mockRestore();
+      clearIntervalSpy.mockRestore();
     }
   });
 });

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/EnvActionAnchorEntry.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/EnvActionAnchorEntry.test.tsx
@@ -2,9 +2,15 @@ import "@testing-library/jest-dom/vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { CodexEnvironmentActionRun } from "@pwragent/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { EnvActionAnchorEntry, formatDurationMs } from "../Composer";
+import {
+  EnvActionAnchorList,
+  EnvActionAnchorEntry,
+  formatDurationMs,
+  formatRunningDurationMs,
+} from "../Composer";
 
 afterEach(() => {
+  vi.useRealTimers();
   cleanup();
 });
 
@@ -30,6 +36,8 @@ function buildRun(
 describe("EnvActionAnchorEntry", () => {
   describe("status branches", () => {
     it("renders the running label with always-visible Dismiss while started", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(1_700_000_000_750));
       render(
         <EnvActionAnchorEntry
           run={buildRun({ status: "started", pid: 12345 })}
@@ -48,6 +56,8 @@ describe("EnvActionAnchorEntry", () => {
       ).toBeInTheDocument();
       // The pid meta and the command echo land in the same anchor.
       expect(screen.getByText(/pid 12345/)).toBeInTheDocument();
+      expect(screen.getByText(/running for 0s/)).toBeInTheDocument();
+      expect(screen.queryByText(/750ms/)).toBeNull();
       expect(screen.getByText(/\$ pnpm test/)).toBeInTheDocument();
     });
 
@@ -287,6 +297,31 @@ describe("EnvActionAnchorEntry", () => {
   });
 });
 
+describe("EnvActionAnchorList", () => {
+  it("ticks live running duration at most once per second", () => {
+    const setIntervalSpy = vi.spyOn(window, "setInterval");
+    try {
+      render(
+        <EnvActionAnchorList
+          runtime={{
+            environmentName: "PwrAgnt",
+            actionRuns: [
+              buildRun({
+                startedAt: Date.now(),
+                status: "started",
+              }),
+            ],
+          }}
+        />,
+      );
+
+      expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 1_000);
+    } finally {
+      setIntervalSpy.mockRestore();
+    }
+  });
+});
+
 describe("formatDurationMs", () => {
   it("returns empty for falsy / non-finite inputs", () => {
     expect(formatDurationMs(undefined)).toBe("");
@@ -334,9 +369,8 @@ describe("formatDurationMs", () => {
 
   describe("coarseAfterMinute", () => {
     it("drops the seconds portion entirely past 1 minute", () => {
-      // For the live "running for X" anchor meta, we want minute-only
-      // updates past the 1-minute mark to avoid distracting the user
-      // with a ticking sub-minute display.
+      // Static one-shot duration displays can opt into a coarser
+      // minute-only suffix after the first minute.
       expect(formatDurationMs(60_500, { coarseAfterMinute: true })).toBe("1m");
       expect(formatDurationMs(118_000, { coarseAfterMinute: true })).toBe("1m");
       expect(formatDurationMs(119_499, { coarseAfterMinute: true })).toBe("1m");
@@ -357,5 +391,29 @@ describe("formatDurationMs", () => {
       expect(formatDurationMs(60_500)).toBe("1m 1s");
       expect(formatDurationMs(6 * 60_000 + 23_000)).toBe("6m 23s");
     });
+  });
+});
+
+describe("formatRunningDurationMs", () => {
+  it("returns empty for missing, invalid, or negative inputs", () => {
+    expect(formatRunningDurationMs(undefined)).toBe("");
+    expect(formatRunningDurationMs(Number.NaN)).toBe("");
+    expect(formatRunningDurationMs(Number.POSITIVE_INFINITY)).toBe("");
+    expect(formatRunningDurationMs(-1)).toBe("");
+  });
+
+  it("formats live elapsed values in seconds without milliseconds", () => {
+    expect(formatRunningDurationMs(0)).toBe("0s");
+    expect(formatRunningDurationMs(1)).toBe("0s");
+    expect(formatRunningDurationMs(750)).toBe("0s");
+    expect(formatRunningDurationMs(999)).toBe("0s");
+    expect(formatRunningDurationMs(1_000)).toBe("1s");
+    expect(formatRunningDurationMs(59_999)).toBe("59s");
+  });
+
+  it("keeps long-running live values in seconds", () => {
+    expect(formatRunningDurationMs(60_000)).toBe("60s");
+    expect(formatRunningDurationMs(119_999)).toBe("119s");
+    expect(formatRunningDurationMs(6 * 60_000 + 23_000)).toBe("383s");
   });
 });

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -86,6 +86,7 @@ function createDeferred<T>(): {
 }
 
 afterEach(async () => {
+  vi.useRealTimers();
   await flushReactUpdates();
   vi.mocked(normalizeImageFile).mockClear();
   cleanup();
@@ -634,6 +635,82 @@ describe("Composer", () => {
         actionId: undefined,
       });
     });
+  });
+
+  it("shows a disabled spinner on the environment Run button after starting", async () => {
+    vi.useFakeTimers();
+    const runCodexEnvironmentAction = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      codexEnvironmentRuntime: {
+        environmentId: "environment",
+        environmentName: "PwrAgnt",
+        executionTarget: "local" as const,
+      },
+    }));
+    const thread: NavigationThreadSummary = {
+      id: "thread-1",
+      title: "Environment commands",
+      titleSource: "explicit",
+      source: "codex",
+      executionMode: "default",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+      codexEnvironmentRuntime: {
+        environmentId: "environment",
+        environmentName: "PwrAgnt",
+        executionTarget: "local",
+        actions: [
+          {
+            id: "dev-messaging",
+            name: "Dev - Messaging",
+            command: "pnpm dev:messaging",
+          },
+        ],
+      },
+    };
+
+    render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        desktopApi={{ runCodexEnvironmentAction }}
+        disabled={false}
+        skills={[]}
+        thread={thread}
+      />,
+    );
+
+    const runButton = screen.getByRole("button", { name: "Run" });
+    expect(runButton).not.toBeDisabled();
+
+    await act(async () => {
+      fireEvent.click(runButton);
+      await Promise.resolve();
+    });
+
+    expect(runCodexEnvironmentAction).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      actionId: "dev-messaging",
+    });
+    expect(runButton).toBeDisabled();
+    expect(runButton).not.toHaveTextContent("Run");
+    expect(
+      runButton.querySelector(".composer__action-button-spinner"),
+    ).toBeInTheDocument();
+
+    await act(async () => {
+      vi.advanceTimersByTime(4_999);
+    });
+    expect(runButton).toBeDisabled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(runButton).not.toBeDisabled();
+    expect(
+      runButton.querySelector(".composer__action-button-spinner"),
+    ).not.toBeInTheDocument();
   });
 
   it("restores thread environment command selections from the per-env sticky map", () => {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -713,6 +713,87 @@ describe("Composer", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("does not leak environment Run busy state across thread changes", async () => {
+    vi.useFakeTimers();
+    const startDeferred = createDeferred<{
+      backend: "codex";
+      threadId: string;
+      codexEnvironmentRuntime: {
+        environmentId: string;
+        environmentName: string;
+        executionTarget: "local";
+      };
+    }>();
+    const runCodexEnvironmentAction = vi.fn(() => startDeferred.promise);
+    const buildThread = (id: string, actionId: string): NavigationThreadSummary => ({
+      id,
+      title: id,
+      titleSource: "explicit",
+      source: "codex",
+      executionMode: "default",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+      codexEnvironmentRuntime: {
+        environmentId: "environment",
+        environmentName: "PwrAgnt",
+        executionTarget: "local",
+        actions: [
+          {
+            id: actionId,
+            name: `Action ${actionId}`,
+            command: "pnpm test",
+          },
+        ],
+      },
+    });
+
+    const { rerender } = render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        desktopApi={{ runCodexEnvironmentAction }}
+        disabled={false}
+        skills={[]}
+        thread={buildThread("thread-a", "test-a")}
+      />,
+    );
+
+    const firstRunButton = screen.getByRole("button", { name: "Run" });
+    await act(async () => {
+      fireEvent.click(firstRunButton);
+      await Promise.resolve();
+    });
+    expect(firstRunButton).toBeDisabled();
+
+    rerender(
+      <Composer
+        backends={[backendSummary("codex")]}
+        desktopApi={{ runCodexEnvironmentAction }}
+        disabled={false}
+        skills={[]}
+        thread={buildThread("thread-b", "test-b")}
+      />,
+    );
+
+    const secondRunButton = screen.getByRole("button", { name: "Run" });
+    expect(secondRunButton).not.toBeDisabled();
+    expect(secondRunButton).toHaveTextContent("Run");
+
+    await act(async () => {
+      startDeferred.resolve({
+        backend: "codex",
+        threadId: "thread-a",
+        codexEnvironmentRuntime: {
+          environmentId: "environment",
+          environmentName: "PwrAgnt",
+          executionTarget: "local",
+        },
+      });
+      await Promise.resolve();
+    });
+
+    expect(secondRunButton).not.toBeDisabled();
+  });
+
   it("restores thread environment command selections from the per-env sticky map", () => {
     const buildThread = (
       id: string,

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -10139,6 +10139,25 @@ textarea,
   cursor: default;
 }
 
+.composer__action-button--busy {
+  min-width: 54px;
+}
+
+.composer__action-button-spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid var(--border-subtle);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: composer-action-button-spin 0.8s linear infinite;
+}
+
+@keyframes composer-action-button-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .composer__action-button--danger {
   border-color: var(--danger-border);
   background: var(--danger-soft);


### PR DESCRIPTION
## Summary

- I made the composer Env action Run button switch to a disabled spinner as soon as the action start is requested, and keep that confirmation visible for at least five seconds after a successful start.
- I changed the live Env action `running for` display to report whole seconds only, with a shared ticker that updates no more than once per second.
- I kept completed action durations on the existing static formatter and added coverage for the spinner window, second-only live durations, and ticker cadence.

## Verification

- I verified this branch is clean and exactly one commit ahead of `origin/main`.
- I ran `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/EnvActionAnchorEntry.test.tsx apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`.

## Notes

- No screenshots included; the change is a short-lived composer button state covered by focused renderer tests.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
