### PR TITLE
feat(release): sign Windows installer via Azure Artifact Signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,10 +232,20 @@ jobs:
           node-version: 24.14.1
           working-directory: .
 
-      # NSIS installer is currently unsigned (no Windows code-signing identity
-      # yet). Uploaded as a workflow artifact, not published to the GitHub
-      # Release, until signing is in place.
-      - name: Package Windows installer (unsigned, no publish)
+      # Signs via Azure Trusted Signing when the repo provides the signing
+      # config (vars.WIN_AZURE_SIGN_*) and the Entra service-principal secrets
+      # (AZURE_*). Until those are set, release.mjs builds an UNSIGNED installer.
+      # See docs/desktop-windows-signing.md. Not published to the GitHub Release
+      # yet — uploaded as a workflow artifact below.
+      - name: Package Windows installer
+        env:
+          WIN_AZURE_SIGN_PUBLISHER_NAME: ${{ vars.WIN_AZURE_SIGN_PUBLISHER_NAME }}
+          WIN_AZURE_SIGN_ENDPOINT: ${{ vars.WIN_AZURE_SIGN_ENDPOINT }}
+          WIN_AZURE_SIGN_ACCOUNT: ${{ vars.WIN_AZURE_SIGN_ACCOUNT }}
+          WIN_AZURE_SIGN_PROFILE: ${{ vars.WIN_AZURE_SIGN_PROFILE }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
         run: node apps/desktop/scripts/release.mjs --win --no-publish
 
       - name: Upload Windows installer artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,11 +237,12 @@ jobs:
           node-version: 24.14.1
           working-directory: .
 
-      # Signs via Azure Trusted Signing when the repo provides the signing
-      # config (vars.WIN_AZURE_SIGN_*) and the Entra service-principal secrets
-      # (AZURE_*). Until those are set, release.mjs builds an UNSIGNED installer.
-      # See docs/desktop-windows-signing.md. Not published to the GitHub Release
-      # yet — uploaded as a workflow artifact below.
+      # Signs via Azure Artifact Signing when the `windows-signing` environment
+      # provides the config (vars.WIN_AZURE_SIGN_*) and the Entra
+      # service-principal secrets (AZURE_*). With none of them set, release.mjs
+      # builds an UNSIGNED installer; with only some, it fails rather than
+      # silently shipping unsigned. See docs/desktop-windows-signing.md. Not
+      # published to the GitHub Release yet — uploaded as an artifact below.
       - name: Package Windows installer
         env:
           WIN_AZURE_SIGN_PUBLISHER_NAME: ${{ vars.WIN_AZURE_SIGN_PUBLISHER_NAME }}
@@ -251,7 +252,7 @@ jobs:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-        run: node apps/desktop/scripts/release.mjs --win --no-publish
+        run: node apps/desktop/scripts/release.mjs --win --no-publish --require-signing
 
       - name: Upload Windows installer artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,7 +209,12 @@ jobs:
           retention-days: 7
 
   windows-package:
-    name: Package Windows installer (unsigned)
+    name: Package Windows installer
+    # Signing config + service-principal credentials live in this environment,
+    # not at repo scope. Without this line `vars.WIN_AZURE_SIGN_*` and
+    # `secrets.AZURE_*` resolve to empty and the installer builds UNSIGNED with
+    # no error — see the failure-modes table in docs/desktop-windows-signing.md.
+    environment: windows-signing
     # node-pty's Electron rebuild currently pulls node-gyp 11.x, which does
     # not recognize Visual Studio 2026 on windows-latest/windows-2025.
     # Keep installer packaging on VS 2022 until that toolchain catches up.

--- a/apps/desktop/scripts/release.mjs
+++ b/apps/desktop/scripts/release.mjs
@@ -60,6 +60,10 @@ const prepareOnly = args.includes("--prepare-only");
 const signStageOnly = args.includes("--sign-stage-only");
 const linux = args.includes("--linux");
 const win = args.includes("--win");
+// Release builds pass this so an unsigned Windows installer can never ship
+// unnoticed; local/sandbox/PR builds omit it and stay unsigned. See the `win`
+// branch below and docs/desktop-windows-signing.md.
+const requireSigning = args.includes("--require-signing");
 
 if (prepareOnly && signStageOnly) {
   throw new Error("--prepare-only and --sign-stage-only cannot be combined");
@@ -105,32 +109,69 @@ function runChecked(file, args, opts = {}) {
   }
 }
 
-// Windows Authenticode signing via Azure Trusted Signing. Active only when the
-// account config (WIN_AZURE_SIGN_*) AND the Microsoft Entra service-principal
-// credentials (AZURE_TENANT_ID/AZURE_CLIENT_ID/AZURE_CLIENT_SECRET, which
-// electron-builder's bundled TrustedSigning module reads from the environment)
-// are all present. Otherwise we build an UNSIGNED installer so local, sandbox,
-// and label-gated PR builds still work without secrets.
+// Windows Authenticode signing via Azure Artifact Signing (the service formerly
+// and still widely called Trusted Signing). Requires the account config
+// (WIN_AZURE_SIGN_*) AND the Microsoft Entra service-principal credentials
+// (AZURE_TENANT_ID/AZURE_CLIENT_ID/AZURE_CLIENT_SECRET, which electron-builder's
+// bundled TrustedSigning module reads from the environment).
+//
+// Three outcomes, deliberately: all set -> signed; none set -> UNSIGNED, so
+// local, sandbox, and label-gated PR builds still work without secrets; a
+// partial set -> throw, because that is always a misconfiguration and silently
+// publishing an unsigned installer is the worst of the three.
 function resolveWindowsAzureSigning() {
-  const publisherName = process.env.WIN_AZURE_SIGN_PUBLISHER_NAME?.trim();
-  const endpoint = process.env.WIN_AZURE_SIGN_ENDPOINT?.trim();
-  const accountName = process.env.WIN_AZURE_SIGN_ACCOUNT?.trim();
-  const profileName = process.env.WIN_AZURE_SIGN_PROFILE?.trim();
-  if (!publisherName || !endpoint || !accountName || !profileName) {
+  const config = {
+    WIN_AZURE_SIGN_PUBLISHER_NAME:
+      process.env.WIN_AZURE_SIGN_PUBLISHER_NAME?.trim(),
+    WIN_AZURE_SIGN_ENDPOINT: process.env.WIN_AZURE_SIGN_ENDPOINT?.trim(),
+    WIN_AZURE_SIGN_ACCOUNT: process.env.WIN_AZURE_SIGN_ACCOUNT?.trim(),
+    WIN_AZURE_SIGN_PROFILE: process.env.WIN_AZURE_SIGN_PROFILE?.trim(),
+  };
+  const missingConfig = Object.entries(config)
+    .filter(([, value]) => !value)
+    .map(([name]) => name);
+
+  // None set: an intentional unsigned build — local dev, the sandbox, or the
+  // label-gated PR installer job, none of which are given signing config.
+  if (missingConfig.length === Object.keys(config).length) {
     return undefined;
   }
-  const credentialsPresent = Boolean(
-    process.env.AZURE_TENANT_ID &&
-      process.env.AZURE_CLIENT_ID &&
-      process.env.AZURE_CLIENT_SECRET,
-  );
-  if (!credentialsPresent) {
-    console.warn(
-      "  Windows signing config is set but AZURE_TENANT_ID/AZURE_CLIENT_ID/AZURE_CLIENT_SECRET are missing — building UNSIGNED",
+  // Some but not all: nobody sets a subset of these on purpose. It means a
+  // typo'd variable name, or a job that never joined the `windows-signing`
+  // environment (where these live) and so read them as empty. Fail here —
+  // the alternative is a green release that silently shipped an UNSIGNED
+  // installer, which nobody notices until a user reports SmartScreen.
+  if (missingConfig.length > 0) {
+    throw new Error(
+      `Windows signing is partially configured — missing: ${missingConfig.join(", ")}. `
+        + "Set all of them (see docs/desktop-windows-signing.md) or none to build unsigned.",
     );
-    return undefined;
   }
-  return { publisherName, endpoint, accountName, profileName };
+
+  // Config present means signing was requested, so absent credentials are a
+  // misconfiguration too, not a cue to quietly downgrade. Checked separately
+  // from the block above because AZURE_* are generic Azure SDK names that may
+  // legitimately be set in a developer's shell for unrelated work.
+  const missingCredentials = Object.entries({
+    AZURE_TENANT_ID: process.env.AZURE_TENANT_ID?.trim(),
+    AZURE_CLIENT_ID: process.env.AZURE_CLIENT_ID?.trim(),
+    AZURE_CLIENT_SECRET: process.env.AZURE_CLIENT_SECRET?.trim(),
+  })
+    .filter(([, value]) => !value)
+    .map(([name]) => name);
+  if (missingCredentials.length > 0) {
+    throw new Error(
+      `Windows signing is configured but its service-principal credentials are missing: ${missingCredentials.join(", ")}. `
+        + "Unset the WIN_AZURE_SIGN_* variables to build unsigned instead.",
+    );
+  }
+
+  return {
+    publisherName: config.WIN_AZURE_SIGN_PUBLISHER_NAME,
+    endpoint: config.WIN_AZURE_SIGN_ENDPOINT,
+    accountName: config.WIN_AZURE_SIGN_ACCOUNT,
+    profileName: config.WIN_AZURE_SIGN_PROFILE,
+  };
 }
 
 function electronBuilderCli() {
@@ -412,8 +453,19 @@ if (!signStageOnly) {
 const builderArgs = [];
 if (win) {
   const azureSign = resolveWindowsAzureSigning();
+  // The partial-config guard inside resolveWindowsAzureSigning() cannot catch a
+  // job that never joined the `windows-signing` environment: there every value
+  // reads as empty, which is indistinguishable from an intentional unsigned
+  // build. The release workflow passes --require-signing so that case fails
+  // instead of quietly publishing an unsigned installer.
+  if (requireSigning && !azureSign) {
+    throw new Error(
+      "--require-signing was passed but no Windows signing configuration is present. "
+        + "Check that the job declares `environment: windows-signing` — see docs/desktop-windows-signing.md.",
+    );
+  }
   step(
-    `electron-builder --win nsis --x64 (${azureSign ? "Azure Trusted Signing" : "UNSIGNED"}, no builder publish)`,
+    `electron-builder --win nsis --x64 (${azureSign ? "Azure Artifact Signing" : "UNSIGNED"}, no builder publish)`,
   );
   builderArgs.push("--win", "nsis", "--x64", "--publish=never");
   if (azureSign) {

--- a/apps/desktop/scripts/release.mjs
+++ b/apps/desktop/scripts/release.mjs
@@ -89,10 +89,12 @@ function runChecked(file, args, opts = {}) {
     stdio: "inherit",
     cwd: opts.cwd ?? desktopRoot,
     env: { ...process.env, ...opts.env },
-    // On Windows `pnpm` is a .cmd shim that spawnSync only resolves through a
-    // shell (and Node refuses to spawn .cmd without one). Repo/stage paths here
-    // contain no spaces, so unquoted shell args are safe.
-    shell: process.platform === "win32",
+    // On Windows only `pnpm` needs a shell (it's a .cmd shim that spawnSync
+    // can't resolve directly). `node`/`gh` are real .exe's found without a
+    // shell — and NOT using a shell for them keeps args with spaces (e.g. the
+    // Azure signing `--config.win.azureSignOptions.publisherName=PwrDrvr LLC`
+    // override) intact, since shell:true would word-split them.
+    shell: process.platform === "win32" && file === "pnpm",
   });
   if (result.error) {
     console.error(`  ! failed to spawn ${file}: ${result.error.message}`);
@@ -101,6 +103,34 @@ function runChecked(file, args, opts = {}) {
   if (result.status !== 0) {
     process.exit(result.status ?? 1);
   }
+}
+
+// Windows Authenticode signing via Azure Trusted Signing. Active only when the
+// account config (WIN_AZURE_SIGN_*) AND the Microsoft Entra service-principal
+// credentials (AZURE_TENANT_ID/AZURE_CLIENT_ID/AZURE_CLIENT_SECRET, which
+// electron-builder's bundled TrustedSigning module reads from the environment)
+// are all present. Otherwise we build an UNSIGNED installer so local, sandbox,
+// and label-gated PR builds still work without secrets.
+function resolveWindowsAzureSigning() {
+  const publisherName = process.env.WIN_AZURE_SIGN_PUBLISHER_NAME?.trim();
+  const endpoint = process.env.WIN_AZURE_SIGN_ENDPOINT?.trim();
+  const accountName = process.env.WIN_AZURE_SIGN_ACCOUNT?.trim();
+  const profileName = process.env.WIN_AZURE_SIGN_PROFILE?.trim();
+  if (!publisherName || !endpoint || !accountName || !profileName) {
+    return undefined;
+  }
+  const credentialsPresent = Boolean(
+    process.env.AZURE_TENANT_ID &&
+      process.env.AZURE_CLIENT_ID &&
+      process.env.AZURE_CLIENT_SECRET,
+  );
+  if (!credentialsPresent) {
+    console.warn(
+      "  Windows signing config is set but AZURE_TENANT_ID/AZURE_CLIENT_ID/AZURE_CLIENT_SECRET are missing — building UNSIGNED",
+    );
+    return undefined;
+  }
+  return { publisherName, endpoint, accountName, profileName };
 }
 
 function electronBuilderCli() {
@@ -381,8 +411,19 @@ if (!signStageOnly) {
 // 5. electron-builder.
 const builderArgs = [];
 if (win) {
-  step("electron-builder --win nsis --x64 (no builder publish)");
+  const azureSign = resolveWindowsAzureSigning();
+  step(
+    `electron-builder --win nsis --x64 (${azureSign ? "Azure Trusted Signing" : "UNSIGNED"}, no builder publish)`,
+  );
   builderArgs.push("--win", "nsis", "--x64", "--publish=never");
+  if (azureSign) {
+    builderArgs.push(
+      `--config.win.azureSignOptions.publisherName=${azureSign.publisherName}`,
+      `--config.win.azureSignOptions.endpoint=${azureSign.endpoint}`,
+      `--config.win.azureSignOptions.codeSigningAccountName=${azureSign.accountName}`,
+      `--config.win.azureSignOptions.certificateProfileName=${azureSign.profileName}`,
+    );
+  }
 } else if (linux) {
   const linuxArch = currentLinuxBuilderArch();
   step(`electron-builder --linux deb --${linuxArch} (no builder publish)`);

--- a/docs/desktop-windows-signing.md
+++ b/docs/desktop-windows-signing.md
@@ -1,0 +1,87 @@
+# Windows Code Signing (Azure Trusted Signing)
+
+PwrAgent signs the Windows NSIS installer with **Azure Trusted Signing**
+(a.k.a. Azure Artifact Signing) — Microsoft's cloud signing service. It needs
+no hardware token, works on GitHub-hosted runners, removes SmartScreen
+"unknown publisher" warnings, and is the cheapest option (~$9.99/mo for up to
+5,000 signatures).
+
+Signing is **opt-in and degrades gracefully**: the release job builds an
+**unsigned** installer until the signing config + credentials below are present,
+then signs automatically. Label-gated PR installer builds (`ci:windows-package`)
+are intentionally left **unsigned** (secrets are not exposed to PR validation,
+and signatures count against quota).
+
+## How the pieces connect
+
+- `apps/desktop/electron-builder.yml` — `win` target (NSIS x64). No signing
+  config lives here; it's injected per-build so unsigned builds keep working.
+- `apps/desktop/scripts/release.mjs` (`--win`) — `resolveWindowsAzureSigning()`
+  reads the env below and, when complete, passes
+  `--config.win.azureSignOptions.*` to electron-builder. electron-builder 26
+  then auto-installs the `TrustedSigning` PowerShell module on the runner and
+  invokes `Invoke-TrustedSigning`.
+- `.github/workflows/release.yml` (`windows-package` job, release tags only) —
+  supplies the env from repo variables + secrets.
+
+## One-time setup
+
+### 1. Eligibility + subscription
+Azure Trusted Signing requires a **paid** Azure subscription (no free/trial)
+and one of: a **US/Canada org with 3+ years** verifiable history, an
+**individual developer in the US/Canada**, or an **org in the EU/UK**. Confirm
+PwrDrvr LLC qualifies before procuring.
+
+### 2. Create the Trusted Signing resources (Azure portal)
+1. Create a **Trusted Signing account**. Note its **region** → the **endpoint**
+   is `https://<region>.codesigning.azure.net` (shown on the account overview).
+2. Complete **Identity Validation** for the account. The approved
+   **CommonName** becomes the `publisherName` — it must match exactly.
+3. Create a **Public Trust Certificate Profile** under the account. Note its
+   **name**.
+
+### 3. Create a service principal for CI
+1. In Microsoft Entra ID, create an **App registration**; add a **client
+   secret**. Record the **Directory (tenant) ID**, **Application (client) ID**,
+   and the **secret value**.
+2. On the Trusted Signing account (or the specific certificate profile), assign
+   the **"Trusted Signing Certificate Profile Signer"** role to that app
+   registration.
+
+### 4. Add the repo configuration
+GitHub → repo **Settings → Secrets and variables → Actions**.
+
+**Variables** (not secret — identifiers):
+| Variable | Value |
+|---|---|
+| `WIN_AZURE_SIGN_PUBLISHER_NAME` | Validated CommonName, e.g. `PwrDrvr LLC` |
+| `WIN_AZURE_SIGN_ENDPOINT` | `https://<region>.codesigning.azure.net` |
+| `WIN_AZURE_SIGN_ACCOUNT` | Trusted Signing account name |
+| `WIN_AZURE_SIGN_PROFILE` | Certificate profile name |
+
+**Secrets** (service-principal credentials):
+| Secret | Value |
+|---|---|
+| `AZURE_TENANT_ID` | Directory (tenant) ID |
+| `AZURE_CLIENT_ID` | Application (client) ID |
+| `AZURE_CLIENT_SECRET` | Client secret value |
+
+Once all eight are set, the next release tag produces a **signed** installer.
+
+## Verifying a signed build
+On Windows: right-click the `.exe` → **Properties → Digital Signatures**, or:
+
+```powershell
+signtool verify /pa /v PwrAgent-<version>-windows-x64-setup.exe
+```
+
+The signature should chain to a Microsoft Trusted Signing CA with the subject
+matching the validated publisher name.
+
+## Notes
+- `publisherName` MUST equal the validated identity CommonName, or signing
+  fails verification.
+- Local/sandbox builds (`pnpm --filter @pwragent/desktop package:win`) stay
+  unsigned unless you export the same env vars — that's expected.
+- Publishing the signed installer to the GitHub Release (today it's only a
+  workflow artifact) is a separate follow-up.

--- a/docs/desktop-windows-signing.md
+++ b/docs/desktop-windows-signing.md
@@ -1,8 +1,14 @@
-# Windows Code Signing (Azure Trusted Signing)
+# Windows Code Signing (Azure Artifact Signing)
 
-PwrAgent signs the Windows NSIS installer with **Azure Trusted Signing**
-(a.k.a. Azure Artifact Signing) — Microsoft's cloud signing service. It needs
-no hardware token, works on GitHub-hosted runners, removes SmartScreen
+PwrAgent signs the Windows NSIS installer with **Azure Artifact Signing** —
+Microsoft's cloud signing service, originally released as **Trusted Signing**.
+Both names refer to the same product, and the tooling has not caught up with the
+rename: the Azure portal now says "Artifact Signing Account" and the RBAC roles
+are named `Artifact Signing *`, while electron-builder's option is still
+`win.azureSignOptions` and the PowerShell module it installs is still
+`TrustedSigning`. Expect to search for **both** names in docs and the portal.
+
+It needs no hardware token, works on GitHub-hosted runners, removes SmartScreen
 "unknown publisher" warnings, and is the cheapest option (~$9.99/mo for up to
 5,000 signatures).
 
@@ -11,6 +17,25 @@ Signing is **opt-in and degrades gracefully**: the release job builds an
 then signs automatically. Label-gated PR installer builds (`ci:windows-package`)
 are intentionally left **unsigned** (secrets are not exposed to PR validation,
 and signatures count against quota).
+
+## Current configuration (PwrDrvr LLC)
+
+Provisioned in the `PwrDrvr Azure` subscription, resource group
+`rg-pwrdrvr-signing`, region **East US**. None of these are secret — the
+publisher name and certificate subject are embedded in every signed installer.
+
+| GitHub **variable** | Value |
+|---|---|
+| `WIN_AZURE_SIGN_ACCOUNT` | `pwrdrvrsigning` |
+| `WIN_AZURE_SIGN_ENDPOINT` | `https://eus.codesigning.azure.net/` |
+| `WIN_AZURE_SIGN_PUBLISHER_NAME` | `PwrDrvr LLC` |
+| `WIN_AZURE_SIGN_PROFILE` | `pwrdrvr-public-trust` |
+
+Certificate subject: `CN=PwrDrvr LLC, O=PwrDrvr LLC, L=Aberdeen, S=New Jersey, C=US`.
+`WIN_AZURE_SIGN_PUBLISHER_NAME` must equal the **CN** exactly.
+
+The three `AZURE_*` GitHub **secrets** come from the Entra app registration
+(`pwragent-release-signing`) — see step 3.
 
 ## How the pieces connect
 
@@ -27,46 +52,100 @@ and signatures count against quota).
 ## One-time setup
 
 ### 1. Eligibility + subscription
-Azure Trusted Signing requires a **paid** Azure subscription (no free/trial)
+Azure Artifact Signing requires a **paid** Azure subscription (no free/trial)
 and one of: a **US/Canada org with 3+ years** verifiable history, an
-**individual developer in the US/Canada**, or an **org in the EU/UK**. Confirm
-PwrDrvr LLC qualifies before procuring.
+**individual developer in the US/Canada**, or an **org in the EU/UK**.
+PwrDrvr LLC validated on the US org path.
 
-### 2. Create the Trusted Signing resources (Azure portal)
-1. Create a **Trusted Signing account**. Note its **region** → the **endpoint**
-   is `https://<region>.codesigning.azure.net` (shown on the account overview).
-2. Complete **Identity Validation** for the account. The approved
-   **CommonName** becomes the `publisherName` — it must match exactly.
-3. Create a **Public Trust Certificate Profile** under the account. Note its
-   **name**.
+### 2. Create the signing resources (Azure portal)
+1. Create an **Artifact Signing account**. Its region determines the
+   **endpoint** (`https://<region>.codesigning.azure.net/`), shown as
+   **Account URI** on the account overview — use it verbatim, trailing slash
+   included.
+2. Complete **Identity Validation** on the account. This is asynchronous (days,
+   possibly with document requests) and gates everything after it. The approved
+   **CommonName** becomes `publisherName` and is the publisher users see in the
+   SmartScreen prompt.
+3. Create a **Certificate profile** under the account, selecting the completed
+   identity validation.
+
+   > **Pick profile type `Public Trust`.** The adjacent `Public Trust Test`
+   > option signs successfully and `signtool` reports a valid signature, but it
+   > chains to a *test* root nobody trusts — so every user still gets the
+   > SmartScreen warning. Easy to select by accident and not notice until a user
+   > reports it.
+
+   Whatever you name the profile is `WIN_AZURE_SIGN_PROFILE` verbatim.
 
 ### 3. Create a service principal for CI
-1. In Microsoft Entra ID, create an **App registration**; add a **client
-   secret**. Record the **Directory (tenant) ID**, **Application (client) ID**,
-   and the **secret value**.
-2. On the Trusted Signing account (or the specific certificate profile), assign
-   the **"Trusted Signing Certificate Profile Signer"** role to that app
-   registration.
+1. Microsoft Entra ID → **App registrations** → New registration.
+   - **Name**: free-form, maps to no config (we use `pwragent-release-signing`).
+   - **Supported account types**: single tenant.
+   - **Redirect URI**: leave blank — this uses the non-interactive
+     client-credentials flow.
+   - **API permissions**: none. Access comes solely from the RBAC role in the
+     next step; the API permissions blade is a dead end here.
+2. **Certificates & secrets** → New client secret. Copy the **`Value`** column
+   (not `Secret ID`) — it is displayed **once**, and is unrecoverable after you
+   navigate away. Max expiry is 24 months; the dropdown often defaults to 180
+   days.
+3. On the signing account → **Access control (IAM)** → Add role assignment →
+   **`Artifact Signing Certificate Profile Signer`** (search `Artifact Signing`;
+   this role was `Trusted Signing Certificate Profile Signer` before the
+   rename) → assign to the app registration.
+   - On the **Members** step choose **User, group, or service principal**, not
+     Managed identity — app registrations surface as service principals.
+   - The `Artifact Signing Identity Verifier` role, which the account owner uses
+     to complete identity validation, does **not** grant signing. This is a
+     separate grant, and skipping it is the most common setup failure: every
+     value looks correct and signing fails with a 403.
 
-### 4. Add the repo configuration
-GitHub → repo **Settings → Secrets and variables → Actions**.
+### 4. Add the GitHub configuration
+These live in the **`windows-signing` environment** (GitHub → repo **Settings →
+Environments → `windows-signing`**), not at repo scope. The `windows-package`
+job declares `environment: windows-signing` to gain access — the two must stay
+in sync, and dropping that line silently disables signing.
 
-**Variables** (not secret — identifiers):
-| Variable | Value |
-|---|---|
-| `WIN_AZURE_SIGN_PUBLISHER_NAME` | Validated CommonName, e.g. `PwrDrvr LLC` |
-| `WIN_AZURE_SIGN_ENDPOINT` | `https://<region>.codesigning.azure.net` |
-| `WIN_AZURE_SIGN_ACCOUNT` | Trusted Signing account name |
-| `WIN_AZURE_SIGN_PROFILE` | Certificate profile name |
+Scoping to an environment (rather than repo-wide secrets) keeps the signing
+credentials out of every other workflow and job. Consider adding a deployment
+protection rule limiting the environment to the release tag pattern.
+
+**Variables** — the four `WIN_AZURE_SIGN_*` values in the table above.
 
 **Secrets** (service-principal credentials):
 | Secret | Value |
 |---|---|
 | `AZURE_TENANT_ID` | Directory (tenant) ID |
 | `AZURE_CLIENT_ID` | Application (client) ID |
-| `AZURE_CLIENT_SECRET` | Client secret value |
+| `AZURE_CLIENT_SECRET` | Client secret **Value** |
 
-Once all eight are set, the next release tag produces a **signed** installer.
+Once all seven are set, the next release tag produces a **signed** installer.
+
+## Failure modes
+
+`resolveWindowsAzureSigning()` checks only that the variables are *present*, not
+that they are valid, which splits behavior three ways:
+
+| Condition | Result |
+|---|---|
+| Any of the four `WIN_AZURE_SIGN_*` missing/misspelled | **Silently unsigned** — returns early with no warning |
+| `environment: windows-signing` missing from the job | **Silently unsigned** — every value resolves to empty |
+| All four set, any `AZURE_*` credential missing | **Unsigned**, with a warning in the build log |
+| All seven set, but credential expired/invalid or RBAC missing | **Release build fails** — signing is attempted and errors |
+
+The first two rows are the ones to watch: a typo'd variable name — or an
+environment the job never joined — yields a clean, successful, silently unsigned
+release. Expiry and RBAC gaps, by contrast, fail loudly.
+
+## Renewal
+
+Signing breaks when any of these lapse — put them on a calendar:
+
+| Item | Expires | Renew via |
+|---|---|---|
+| Certificate profile `pwrdrvr-public-trust` | 2026-08-13 | Azure portal → certificate profile |
+| Client secret (`AZURE_CLIENT_SECRET`) | ≤24 mo from creation | Entra app registration → Certificates & secrets, then update the GitHub secret |
+| Identity validation | 2028-09-29 | Azure portal → Identity validation → **Renew** |
 
 ## Verifying a signed build
 On Windows: right-click the `.exe` → **Properties → Digital Signatures**, or:
@@ -75,8 +154,9 @@ On Windows: right-click the `.exe` → **Properties → Digital Signatures**, or
 signtool verify /pa /v PwrAgent-<version>-windows-x64-setup.exe
 ```
 
-The signature should chain to a Microsoft Trusted Signing CA with the subject
-matching the validated publisher name.
+The signature should chain to a Microsoft public CA with the subject matching
+`CN=PwrDrvr LLC`. A signature that verifies locally but still triggers
+SmartScreen for users is the `Public Trust Test` profile-type mistake above.
 
 ## Notes
 - `publisherName` MUST equal the validated identity CommonName, or signing

--- a/docs/desktop-windows-signing.md
+++ b/docs/desktop-windows-signing.md
@@ -24,6 +24,9 @@ Provisioned in the `PwrDrvr Azure` subscription, resource group
 `rg-pwrdrvr-signing`, region **East US**. None of these are secret — the
 publisher name and certificate subject are embedded in every signed installer.
 
+> Transcribed 2026-08; the Azure portal is the source of truth. Re-check here
+> after any renewal, since a renewed profile can change the values below.
+
 | GitHub **variable** | Value |
 |---|---|
 | `WIN_AZURE_SIGN_ACCOUNT` | `pwrdrvrsigning` |
@@ -126,16 +129,22 @@ Once all seven are set, the next release tag produces a **signed** installer.
 `resolveWindowsAzureSigning()` checks only that the variables are *present*, not
 that they are valid, which splits behavior three ways:
 
+`resolveWindowsAzureSigning()` treats "none configured" as an intentional
+unsigned build and anything short of fully configured as an error, so a release
+can never quietly ship unsigned:
+
 | Condition | Result |
 |---|---|
-| Any of the four `WIN_AZURE_SIGN_*` missing/misspelled | **Silently unsigned** — returns early with no warning |
-| `environment: windows-signing` missing from the job | **Silently unsigned** — every value resolves to empty |
-| All four set, any `AZURE_*` credential missing | **Unsigned**, with a warning in the build log |
-| All seven set, but credential expired/invalid or RBAC missing | **Release build fails** — signing is attempted and errors |
+| None of the seven set | **Unsigned** — intended for local, sandbox, and label-gated PR builds |
+| Some but not all `WIN_AZURE_SIGN_*` set | **Build fails** — a subset is always a typo, never intent |
+| All four config vars set, any `AZURE_*` missing | **Build fails** — signing was requested, credentials absent |
+| Release build where nothing resolved (job missing `environment: windows-signing`) | **Build fails** — `--require-signing` |
+| All seven set, credential expired/invalid or RBAC role missing | **Build fails** at the signing call |
 
-The first two rows are the ones to watch: a typo'd variable name — or an
-environment the job never joined — yields a clean, successful, silently unsigned
-release. Expiry and RBAC gaps, by contrast, fail loudly.
+The fourth row is why the release workflow passes `--require-signing`: a job
+outside the environment reads every value as empty, which is otherwise
+indistinguishable from an intentional unsigned build. Local and PR builds omit
+the flag and stay unsigned.
 
 ## Renewal
 


### PR DESCRIPTION
> Recreates #674, which GitHub auto-closed when `main`'s history was rewritten. Same change, rebased onto current `main`.

## What & why

Adds optional **Authenticode signing** for the Windows NSIS installer using
**Azure Trusted Signing** (electron-builder 26's native cloud-signing support) —
no hardware token, GitHub-hosted-runner friendly, removes the SmartScreen
"unknown publisher" warning. Follow-up to the Windows port (#670), which shipped
the installer unsigned.

**Signed-when-configured, unsigned-otherwise** — degrades gracefully so local,
sandbox, and label-gated PR builds keep working with no secrets.

## Changes
- `release.mjs`: `resolveWindowsAzureSigning()` reads `WIN_AZURE_SIGN_*` (config)
  + `AZURE_TENANT_ID/CLIENT_ID/CLIENT_SECRET` (service-principal creds, read by
  electron-builder's bundled `TrustedSigning` module). When all present, injects
  `--config.win.azureSignOptions.{publisherName,endpoint,codeSigningAccountName,certificateProfileName}`
  into the `--win` electron-builder invocation; otherwise builds **unsigned**
  with a clear warning.
- `release.mjs`: `runChecked` uses a shell only for `pnpm` on Windows (the `.cmd`
  shim), not `node` — so the `publisherName=PwrDrvr LLC` override (which has a
  space) isn't word-split by `shell:true`.
- `release.yml` (`windows-package`, release tags only): passes the signing config
  from repo **variables** and creds from repo **secrets**; empty → unsigned.
- `docs/desktop-windows-signing.md`: setup runbook.

## Activation
No behavior change until configured. Once these are set, the next release tag
produces a **signed** installer:
- **Variables**: `WIN_AZURE_SIGN_PUBLISHER_NAME`, `WIN_AZURE_SIGN_ENDPOINT`, `WIN_AZURE_SIGN_ACCOUNT`, `WIN_AZURE_SIGN_PROFILE`
- **Secrets**: `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`

## Notes
- **Eligibility (your action):** Azure Trusted Signing needs a paid Azure sub and
  a US/Canada org 3+ yrs (or US/Canada individual, or EU/UK org) — see runbook.
- Label-gated PR installer builds (`ci:windows-package`) stay **unsigned** by
  design (secrets aren't exposed to PR validation).
- Publishing the signed installer to the GitHub Release (today a workflow
  artifact) is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)