### PR TITLE
feat(desktop): runnable Codex-on-agent-kit swap behind PWRAGENT_CODEX_KIT

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-kit-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-kit-adapter.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Unit coverage for the Phase-B kit Codex adapter's event mapping
+ * (`PWRAGENT_CODEX_KIT=1` path). Proves the kit's neutral
+ * `NormalizedThreadEvent`s convert to the `AppServerNotification` shapes the
+ * registry + renderer consume live — without spawning Codex.
+ */
+import { describe, expect, it } from "vitest";
+import type { NormalizedThreadEvent } from "@pwrdrvr/agent-core";
+import {
+  codexEventToNotifications,
+  isCodexKitFlagEnabled,
+} from "../codex-app-server/codex-kit-adapter";
+
+describe("isCodexKitFlagEnabled", () => {
+  it("is on only for an exact '1'", () => {
+    expect(isCodexKitFlagEnabled({ PWRAGENT_CODEX_KIT: "1" })).toBe(true);
+    expect(isCodexKitFlagEnabled({ PWRAGENT_CODEX_KIT: " 1 " })).toBe(true);
+    expect(isCodexKitFlagEnabled({ PWRAGENT_CODEX_KIT: "0" })).toBe(false);
+    expect(isCodexKitFlagEnabled({ PWRAGENT_CODEX_KIT: "true" })).toBe(false);
+    expect(isCodexKitFlagEnabled({})).toBe(false);
+  });
+});
+
+describe("codexEventToNotifications", () => {
+  it("maps the turn lifecycle + streaming message", () => {
+    const events: NormalizedThreadEvent[] = [
+      { kind: "turn_started", threadId: "t1", turnId: "u1" },
+      {
+        kind: "agent_message_delta",
+        threadId: "t1",
+        turnId: "u1",
+        itemId: "i1",
+        delta: "Hello",
+      },
+      {
+        kind: "agent_message",
+        threadId: "t1",
+        turnId: "u1",
+        message: { id: "i1", role: "assistant", text: "Hello world" },
+      },
+      { kind: "turn_completed", threadId: "t1", turnId: "u1", status: "completed" },
+    ];
+
+    const methods = events.flatMap((e) =>
+      codexEventToNotifications(e).map((n) => n.method),
+    );
+    expect(methods).toEqual([
+      "turn/started",
+      "item/agentMessage/delta",
+      "item/completed",
+      "turn/completed",
+    ]);
+  });
+
+  it("carries the streaming delta through verbatim", () => {
+    const [n] = codexEventToNotifications({
+      kind: "agent_message_delta",
+      threadId: "t1",
+      turnId: "u1",
+      itemId: "i1",
+      delta: "chunk",
+    });
+    expect(n).toMatchObject({
+      method: "item/agentMessage/delta",
+      params: { threadId: "t1", turnId: "u1", itemId: "i1", delta: "chunk" },
+    });
+  });
+
+  it("maps command tool calls to commandExecution items", () => {
+    const [started] = codexEventToNotifications({
+      kind: "tool_call",
+      threadId: "t1",
+      turnId: "u1",
+      toolCall: {
+        id: "c1",
+        name: "shell",
+        kind: "command",
+        label: "ls",
+        status: "in_progress",
+      },
+    });
+    expect(started).toMatchObject({
+      method: "item/started",
+      params: { item: { id: "c1", type: "commandExecution" } },
+    });
+  });
+
+  it("maps errors to turn/failed with the message", () => {
+    const [n] = codexEventToNotifications({
+      kind: "error",
+      threadId: "t1",
+      turnId: "u1",
+      message: "boom",
+    });
+    expect(n).toMatchObject({
+      method: "turn/failed",
+      params: { threadId: "t1", turnId: "u1", turn: { error: { message: "boom" } } },
+    });
+  });
+
+  it("ignores events with no live-stream notification (e.g. reasoning_delta)", () => {
+    expect(
+      codexEventToNotifications({
+        kind: "reasoning_delta",
+        threadId: "t1",
+        turnId: "u1",
+        itemId: "i1",
+        delta: "thinking",
+      }),
+    ).toEqual([]);
+  });
+});

--- a/apps/desktop/src/main/__tests__/codex-kit-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-kit-adapter.test.ts
@@ -49,7 +49,33 @@ describe("codexEventToNotifications", () => {
       "item/agentMessage/delta",
       "item/completed",
       "turn/completed",
+      // idle status at turn end — sweeps the registry's synthetic pending turn
+      "thread/status/changed",
     ]);
+  });
+
+  it("emits an idle thread/status/changed at turn end (clears the pending placeholder)", () => {
+    const [completed, status] = codexEventToNotifications({
+      kind: "turn_completed",
+      threadId: "t1",
+      turnId: "u1",
+      status: "completed",
+    });
+    expect(completed?.method).toBe("turn/completed");
+    expect(status).toMatchObject({
+      method: "thread/status/changed",
+      params: { threadId: "t1", status: { type: "idle" } },
+    });
+  });
+
+  it("emits idle status after a turn error too", () => {
+    const methods = codexEventToNotifications({
+      kind: "error",
+      threadId: "t1",
+      turnId: "u1",
+      message: "boom",
+    }).map((n) => n.method);
+    expect(methods).toEqual(["turn/failed", "thread/status/changed"]);
   });
 
   it("carries the streaming delta through verbatim", () => {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -142,6 +142,10 @@ import {
   type LocalAcpDiscovery,
 } from "./acp-backend-adapter";
 import { CodexAppServerClient } from "../codex-app-server/client";
+import {
+  CodexKitBackendClient,
+  isCodexKitFlagEnabled,
+} from "../codex-app-server/codex-kit-adapter";
 import { GrokAppServerClient } from "../grok-app-server/client";
 import {
   buildAutomationInspectionDynamicToolErrorResponse,
@@ -2661,7 +2665,17 @@ export class DesktopBackendRegistry {
     this.codexClient =
       options?.codexClient ??
       replayClients?.codexClient ??
-      new CodexAppServerClient({
+      // Phase B swap (v1): when PWRAGENT_CODEX_KIT=1, drive Codex through the
+      // kit's CodexThreadClient instead of the in-tree client. Core path only
+      // (start thread/turn, stream, read, interrupt); the rich features stay
+      // unavailable under the flag. Flag-off = the full in-tree client, unchanged.
+      (isCodexKitFlagEnabled()
+        ? (new CodexKitBackendClient({
+            command: codexCommand,
+            env: codexEnv,
+            clientVersion,
+          }) as unknown as BackendClient)
+        : new CodexAppServerClient({
         args: buildCodexClientArgs(codexEnv),
         command: codexCommand,
         connectionObserver: codexObserver,
@@ -2677,7 +2691,7 @@ export class DesktopBackendRegistry {
         // `describeCodexBackend` catches via `Promise.allSettled` and
         // surfaces as `available: false` with a clean reason.
         isCodexBootstrapDeferred: () => this.isCodexBootstrapDeferredFn(),
-      });
+      }));
     this.grokClient =
       options?.grokClient ??
       replayClients?.grokClient ??

--- a/apps/desktop/src/main/codex-app-server/codex-kit-adapter.ts
+++ b/apps/desktop/src/main/codex-app-server/codex-kit-adapter.ts
@@ -22,6 +22,7 @@ import {
   type Unsubscribe,
 } from "@pwrdrvr/agent-client";
 import type { NormalizedThreadEvent } from "@pwrdrvr/agent-core";
+import type { UserInput } from "@pwrdrvr/codex-app-server-protocol/v2";
 import type {
   AppServerNotification,
   AppServerThreadSummary,
@@ -139,6 +140,84 @@ export class CodexKitBackendClient {
   }): Promise<{ threadId: string; turnId: string }> {
     await this.client.interruptTurn(params.threadId);
     return params;
+  }
+
+  // ── BackendClient: rich Codex features (ported into the kit) ──────────────
+  /** Inject input into the in-flight turn (kit `turn/steer`). */
+  async steerTurn(params: {
+    threadId: string;
+    input: AppServerTurnInputItem[];
+    expectedTurnId: string;
+  }): Promise<{ threadId: string; turnId: string }> {
+    return this.client.steerTurn({
+      threadId: params.threadId,
+      input: params.input.map(toKitUserInput),
+      expectedTurnId: params.expectedTurnId,
+    });
+  }
+
+  /** Summarize thread history (kit `thread/compact/start`). */
+  async compactThread(params: {
+    threadId: string;
+  }): Promise<{ threadId: string; turnId: string; itemId?: string }> {
+    return this.client.compactThread(params.threadId);
+  }
+
+  /** Start a code review (kit `review/start`). */
+  async startReview(params: {
+    threadId: string;
+    target: unknown;
+    delivery?: unknown;
+    cwd?: string;
+  }): Promise<{ threadId: string; reviewThreadId: string; turnId: string }> {
+    return this.client.startReview({
+      threadId: params.threadId,
+      target: params.target as Parameters<CodexThreadClient["startReview"]>[0]["target"],
+      ...(params.delivery !== undefined
+        ? {
+            delivery: params.delivery as Parameters<
+              CodexThreadClient["startReview"]
+            >[0]["delivery"],
+          }
+        : {}),
+      ...(params.cwd !== undefined ? { cwd: params.cwd } : {}),
+    });
+  }
+
+  /** Re-apply per-thread permissions via resume overlay (kit `thread/resume`). */
+  async setThreadPermissions(params: {
+    threadId: string;
+    cwd?: string;
+    model?: string;
+    approvalPolicy?: string;
+    sandbox?: string;
+    serviceTier?: string;
+    reasoningEffort?: string;
+  }): Promise<{ threadId: string }> {
+    return this.client.setThreadPermissions({
+      threadId: params.threadId,
+      ...(params.cwd !== undefined ? { cwd: params.cwd } : {}),
+      ...(params.model !== undefined ? { model: params.model } : {}),
+      ...(params.approvalPolicy !== undefined
+        ? { approvalPolicy: params.approvalPolicy }
+        : {}),
+      ...(params.sandbox !== undefined ? { sandbox: params.sandbox } : {}),
+      ...(params.serviceTier !== undefined ? { serviceTier: params.serviceTier } : {}),
+      ...(params.reasoningEffort !== undefined
+        ? { reasoningEffort: params.reasoningEffort }
+        : {}),
+    });
+  }
+
+  /** Mark a project directory trusted (kit `config/value/write`). */
+  async trustProject(params: {
+    projectPath: string;
+    configPath?: string;
+  }): Promise<{ projectPath: string; configPath?: string }> {
+    return this.client.trustProject({
+      projectPath: params.projectPath,
+      ...(params.configPath !== undefined ? { configPath: params.configPath } : {}),
+    });
   }
 
   async close(): Promise<void> {
@@ -288,4 +367,12 @@ export function codexEventToNotifications(
 
 function codexItemType(kind: string): string {
   return kind === "command" ? "commandExecution" : "fileChange";
+}
+
+/** Map a PwrAgent turn-input item onto the kit's Codex `UserInput` shape. */
+function toKitUserInput(item: AppServerTurnInputItem): UserInput {
+  if (item.type === "text") {
+    return { type: "text", text: item.text, text_elements: [] };
+  }
+  return item as unknown as UserInput;
 }

--- a/apps/desktop/src/main/codex-app-server/codex-kit-adapter.ts
+++ b/apps/desktop/src/main/codex-app-server/codex-kit-adapter.ts
@@ -1,0 +1,291 @@
+/**
+ * KIT-BACKED Codex client (Phase B swap, v1, behind `PWRAGENT_CODEX_KIT=1`).
+ *
+ * Implements the registry's `BackendClient` surface but drives the kit's
+ * `CodexThreadClient` (@pwrdrvr/agent-client) instead of PwrAgent's in-tree
+ * `CodexAppServerClient`. The kit emits neutral `NormalizedThreadEvent`s; this
+ * adapter maps them to the `AppServerNotification` shapes the registry + renderer
+ * already consume, and accumulates a per-thread `NormalizedThread` (via the B1
+ * reducer) so `readThread` can return a transcript.
+ *
+ * SCOPE (v1 — runnable core path): start thread, start turn, stream the
+ * assistant message + tool activity, complete the turn, read the transcript,
+ * interrupt. The rich Codex features (steering, compaction, review, model/skill/
+ * account queries, environments) are intentionally NOT implemented here — they're
+ * declared optional on `BackendClient`, so omitting them makes them simply
+ * unavailable under the flag. The default (flag-off) path keeps the full in-tree
+ * client untouched. This is the first thing you can launch and actually run on
+ * the kit; the feature port + full swap follow.
+ */
+import {
+  CodexThreadClient,
+  type Unsubscribe,
+} from "@pwrdrvr/agent-client";
+import type { NormalizedThreadEvent } from "@pwrdrvr/agent-core";
+import type {
+  AppServerNotification,
+  AppServerThreadSummary,
+  AppServerTurnInputItem,
+} from "@pwragent/shared";
+import { reduceNormalizedThread } from "../acp/normalized-thread-reducer";
+import { normalizedThreadToReplay } from "../acp/normalized-thread-to-replay";
+
+export const CODEX_KIT_FLAG_ENV = "PWRAGENT_CODEX_KIT";
+
+export function isCodexKitFlagEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env[CODEX_KIT_FLAG_ENV]?.trim() === "1";
+}
+
+type NotificationListener = (
+  notification: AppServerNotification,
+) => void | Promise<void>;
+
+export type CodexKitBackendClientOptions = {
+  command?: string;
+  env?: NodeJS.ProcessEnv;
+  clientVersion?: string;
+};
+
+/**
+ * Adapter satisfying the registry's `BackendClient` surface (the optional rich
+ * methods are deliberately omitted in v1). Only the core methods are typed
+ * structurally — the registry consumes this through the `BackendClient` type.
+ */
+export class CodexKitBackendClient {
+  private readonly client: CodexThreadClient;
+  private readonly listeners = new Set<NotificationListener>();
+  /** Per-thread accumulated kit events, replayed through the reducer on read. */
+  private readonly eventsByThread = new Map<string, NormalizedThreadEvent[]>();
+  private unsubscribe: Unsubscribe | undefined;
+
+  constructor(options: CodexKitBackendClientOptions = {}) {
+    this.client = new CodexThreadClient({
+      ...(options.command !== undefined ? { command: options.command } : {}),
+      ...(options.env !== undefined ? { env: options.env } : {}),
+      clientName: "pwragent",
+      clientVersion: options.clientVersion ?? "0.0.0",
+    });
+    this.unsubscribe = this.client.onEvent((event) => {
+      void this.handleEvent(event);
+    });
+  }
+
+  // ── BackendClient: event subscription ────────────────────────────────────
+  onNotification(listener: NotificationListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  // ── BackendClient: lifecycle ─────────────────────────────────────────────
+  async getInitializeResult(): Promise<Record<string, unknown>> {
+    // Minimal: the kit handles initialize internally on first use. The registry
+    // only needs this to not throw so Codex reports available under the flag.
+    return {};
+  }
+
+  async listThreads(): Promise<AppServerThreadSummary[]> {
+    // v1 doesn't surface the historical thread list through the kit; new threads
+    // created in-session still render live. (Full list = a later increment.)
+    return [];
+  }
+
+  async listSkills(): Promise<unknown[]> {
+    return [];
+  }
+
+  async readThread(params: {
+    threadId: string;
+  }): Promise<ReturnType<typeof normalizedThreadToReplay>> {
+    const events = this.eventsByThread.get(params.threadId) ?? [];
+    return normalizedThreadToReplay(reduceNormalizedThread(events, params.threadId));
+  }
+
+  // ── BackendClient: thread + turn ─────────────────────────────────────────
+  async startThread(params: {
+    cwd?: string;
+    model?: string;
+    reasoningEffort?: string;
+  }): Promise<{ threadId: string }> {
+    const result = await this.client.startThread({
+      ...(params.cwd !== undefined ? { cwd: params.cwd } : {}),
+      ...(params.model !== undefined ? { model: params.model } : {}),
+    });
+    this.eventsByThread.set(result.threadId, []);
+    return { threadId: result.threadId };
+  }
+
+  async startTurn(params: {
+    threadId: string;
+    input: AppServerTurnInputItem[];
+    model?: string;
+    reasoningEffort?: string;
+  }): Promise<{ threadId: string; turnId: string }> {
+    const text = params.input
+      .map((item) => (item.type === "text" ? item.text : ""))
+      .join("");
+    const turn = await this.client.startTurn({
+      threadId: params.threadId,
+      input: { text },
+      ...(params.reasoningEffort !== undefined
+        ? { reasoning: params.reasoningEffort }
+        : {}),
+    });
+    return { threadId: params.threadId, turnId: turn.turnId };
+  }
+
+  async interruptTurn(params: {
+    threadId: string;
+    turnId: string;
+  }): Promise<{ threadId: string; turnId: string }> {
+    await this.client.interruptTurn(params.threadId);
+    return params;
+  }
+
+  async close(): Promise<void> {
+    this.unsubscribe?.();
+    this.unsubscribe = undefined;
+    this.listeners.clear();
+    await this.client.close();
+  }
+
+  // ── kit event → AppServerNotification mapping ────────────────────────────
+  private async handleEvent(event: NormalizedThreadEvent): Promise<void> {
+    const threadId = "threadId" in event ? (event.threadId as string) : undefined;
+    if (threadId) {
+      const bucket = this.eventsByThread.get(threadId) ?? [];
+      bucket.push(event);
+      this.eventsByThread.set(threadId, bucket);
+    }
+    for (const notification of codexEventToNotifications(event)) {
+      await this.fanout(notification);
+    }
+  }
+
+  private async fanout(notification: AppServerNotification): Promise<void> {
+    for (const listener of this.listeners) {
+      try {
+        await listener(notification);
+      } catch {
+        // a single renderer listener failing must not break the stream
+      }
+    }
+  }
+}
+
+/**
+ * Pure mapping: one neutral kit `NormalizedThreadEvent` → zero+
+ * `AppServerNotification`s in the shapes the registry + renderer consume live.
+ * Exported standalone so it's unit-testable without spawning Codex.
+ */
+export function codexEventToNotifications(
+  event: NormalizedThreadEvent,
+): AppServerNotification[] {
+  switch (event.kind) {
+    case "turn_started":
+      return [
+        {
+          method: "turn/started",
+          params: {
+            threadId: event.threadId,
+            turnId: event.turnId,
+            turn: { id: event.turnId, status: "inProgress" },
+          },
+        } as AppServerNotification,
+      ];
+    case "agent_message_delta":
+      return [
+        {
+          method: "item/agentMessage/delta",
+          params: {
+            threadId: event.threadId,
+            turnId: event.turnId,
+            itemId: event.itemId,
+            delta: event.delta,
+          },
+        } as AppServerNotification,
+      ];
+    case "agent_message":
+      return [
+        {
+          method: "item/completed",
+          params: {
+            threadId: event.threadId,
+            turnId: event.turnId,
+            item: {
+              id: event.message.id,
+              type: "agentMessage",
+              text: event.message.text,
+            },
+          },
+        } as AppServerNotification,
+      ];
+    case "tool_call":
+      return [
+        {
+          method: "item/started",
+          params: {
+            threadId: event.threadId,
+            turnId: event.turnId,
+            item: { id: event.toolCall.id, type: codexItemType(event.toolCall.kind) },
+          },
+        } as AppServerNotification,
+      ];
+    case "tool_call_update":
+      return [
+        {
+          method: "item/completed",
+          params: {
+            threadId: event.threadId,
+            turnId: event.turnId,
+            item: {
+              id: event.toolCall.id,
+              type: codexItemType(event.toolCall.kind ?? "command"),
+            },
+          },
+        } as AppServerNotification,
+      ];
+    case "token_usage":
+      return [
+        {
+          method: "thread/tokenUsage/updated",
+          params: {
+            threadId: event.threadId,
+            turnId: event.turnId,
+            tokenUsage: event.usage,
+          },
+        } as AppServerNotification,
+      ];
+    case "turn_completed":
+      return [
+        {
+          method: "turn/completed",
+          params: {
+            threadId: event.threadId,
+            turnId: event.turnId,
+            turn: { id: event.turnId, status: "completed", output: [] },
+          },
+        } as AppServerNotification,
+      ];
+    case "error":
+      return [
+        {
+          method: "turn/failed",
+          params: {
+            threadId: event.threadId ?? "",
+            turnId: event.turnId ?? "",
+            turn: {
+              id: event.turnId ?? "",
+              status: "failed",
+              error: { message: event.message },
+            },
+          },
+        } as AppServerNotification,
+      ];
+    default:
+      return [];
+  }
+}
+
+function codexItemType(kind: string): string {
+  return kind === "command" ? "commandExecution" : "fileChange";
+}

--- a/apps/desktop/src/main/codex-app-server/codex-kit-adapter.ts
+++ b/apps/desktop/src/main/codex-app-server/codex-kit-adapter.ts
@@ -344,6 +344,14 @@ export function codexEventToNotifications(
             turn: { id: event.turnId, status: "completed", output: [] },
           },
         } as AppServerNotification,
+        // The kit's neutral event stream has no thread-status event, so Codex's
+        // `thread/status/changed` notifications are dropped at the kit boundary.
+        // The registry relies on a non-"active" status to sweep its synthetic
+        // `pending:<threadId>` turn/started placeholder out of `activeTurnKeys`
+        // (the thread-list "thinking" driver) — without this, that placeholder
+        // leaks and the list stays stuck "thinking" while the transcript (which
+        // reads threadStatus=idle) does not. Synthesize idle at turn end.
+        idleStatusNotification(event.threadId),
       ];
     case "error":
       return [
@@ -359,6 +367,9 @@ export function codexEventToNotifications(
             },
           },
         } as AppServerNotification,
+        ...(event.threadId !== undefined
+          ? [idleStatusNotification(event.threadId)]
+          : []),
       ];
     default:
       return [];
@@ -367,6 +378,18 @@ export function codexEventToNotifications(
 
 function codexItemType(kind: string): string {
   return kind === "command" ? "commandExecution" : "fileChange";
+}
+
+/**
+ * A `thread/status/changed` → idle notification. Emitted at turn end so the
+ * registry sweeps its synthetic `pending:<threadId>` placeholder from
+ * `activeTurnKeys` (the wholesale sweep only fires for a non-"active" status).
+ */
+function idleStatusNotification(threadId: string): AppServerNotification {
+  return {
+    method: "thread/status/changed",
+    params: { threadId, status: { type: "idle" } },
+  } as AppServerNotification;
 }
 
 /** Map a PwrAgent turn-input item onto the kit's Codex `UserInput` shape. */

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "pnpm": {
     "overrides": {
       "@types/node": "^24.12.4",
+      "@pwrdrvr/agent-client": "file:/Users/huntharo/pwrdrvr/agent-kit/.worktrees/codex-port/.pack/pwrdrvr-agent-client-0.6.1.tgz",
       "axios": "^1.16.0",
       "protobufjs": "7.5.8",
       "qs": "6.15.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   '@types/node': ^24.12.4
+  '@pwrdrvr/agent-client': file:/Users/huntharo/pwrdrvr/agent-kit/.worktrees/codex-port/.pack/pwrdrvr-agent-client-0.6.1.tgz
   axios: ^1.16.0
   protobufjs: 7.5.8
   qs: 6.15.2
@@ -67,8 +68,8 @@ importers:
         specifier: ^0.12.0
         version: 0.12.0
       '@pwrdrvr/agent-client':
-        specifier: ^0.6.1
-        version: 0.6.1
+        specifier: file:/Users/huntharo/pwrdrvr/agent-kit/.worktrees/codex-port/.pack/pwrdrvr-agent-client-0.6.1.tgz
+        version: file:../../../../agent-kit/.worktrees/codex-port/.pack/pwrdrvr-agent-client-0.6.1.tgz
       '@pwrdrvr/agent-core':
         specifier: ^0.2.0
         version: 0.2.0
@@ -1188,8 +1189,9 @@ packages:
   '@pwrdrvr/agent-acp@0.12.0':
     resolution: {integrity: sha512-79B0dhU6XTitgYEkQjY0t8bEcOTjfvD2wcjoArVB/uxFr9hvUz3KCb4Y7BHOHtOcIC36P6UUfarwlFh+gahDsw==}
 
-  '@pwrdrvr/agent-client@0.6.1':
-    resolution: {integrity: sha512-Q8jyGN9c3BfGTW1ba3baFliaF0bWpabV2rYgKmgwZypB3BoPiraZ3qv4X4piHNKVHJ+XK8PdNtyGC78c6sLHNA==}
+  '@pwrdrvr/agent-client@file:../../../../agent-kit/.worktrees/codex-port/.pack/pwrdrvr-agent-client-0.6.1.tgz':
+    resolution: {integrity: sha512-D99LUkZ5UlXEs2b4w34SDrZBXlaGGm4i22xASv8WbHbxlvoS5FIC3TzfXcHTfFX4smv6xXv5hDWKCn5G6YFz7g==, tarball: file:../../../../agent-kit/.worktrees/codex-port/.pack/pwrdrvr-agent-client-0.6.1.tgz}
+    version: 0.6.1
 
   '@pwrdrvr/agent-core@0.1.3':
     resolution: {integrity: sha512-4yN246yJvMvupOd1R3Z/wo2QfpfpP7WWX3RvATklZVWthrjJgmVSoHn0J8emvJdySJAvvG0eE6TkQB7VNAnqVw==}
@@ -5097,7 +5099,7 @@ snapshots:
       '@pwrdrvr/agent-transport': 0.1.6
       '@zed-industries/agent-client-protocol': 0.4.5
 
-  '@pwrdrvr/agent-client@0.6.1':
+  '@pwrdrvr/agent-client@file:../../../../agent-kit/.worktrees/codex-port/.pack/pwrdrvr-agent-client-0.6.1.tgz':
     dependencies:
       '@pwrdrvr/agent-core': 0.2.0
       '@pwrdrvr/agent-transport': 0.1.6


### PR DESCRIPTION
**Draft / WIP tracker** — recreated after #679 was auto-closed by a history rewrite on `main`; rebased clean onto the new main (2 commits, no conflicts). The Phase-B Codex swap: PwrAgent's live Codex thread driven through the kit's `CodexThreadClient` (`@pwrdrvr/agent-client`) behind **`PWRAGENT_CODEX_KIT=1`**, instead of the in-tree `CodexAppServerClient`. Flag-off keeps the in-tree client byte-for-byte unchanged (A/B-able).

## What runs through the kit now
- **Core path:** start thread, start turn, stream assistant message + tool activity, complete, read transcript, interrupt.
- **Rich features (wired, not stubbed):** steer, compact, review, set-permissions, trust-project — via methods ported into the kit's `CodexThreadClient` (agent-kit PR pwrdrvr/agent-kit#7).

`CodexKitBackendClient` (`codex-kit-adapter.ts`) implements the registry's `BackendClient` surface over `CodexThreadClient`; `codexEventToNotifications` maps the kit's neutral `NormalizedThreadEvent`s → the `AppServerNotification` shapes the registry + renderer consume live. Gated at one seam (the `codexClient` construction in `backend-registry.ts`); downstream wiring untouched.

## Depends on: pwrdrvr/agent-kit#7
The ported kit methods aren't published yet, so this branch uses a **local bridge**: a root `pnpm` override points `@pwrdrvr/agent-client` at a tarball built from the agent-kit feature-port branch. **CI is red until** agent-kit#7 lands, a version is published, the `apps/desktop` pin is bumped, and the override is dropped. Expected for the draft.

## Run it (local bridge in place)
```bash
PWRAGENT_CODEX_KIT=1 pnpm --filter @pwragent/desktop dev
```

## Status
Rebased onto new `main`, built green locally against the linked kit build: desktop typecheck · build · 6 adapter tests · 230 backend-registry tests (242 desktop-main total). Agent-kit side (#7): 46 tests (6 new), CI green.

**Not yet validated end-to-end with a live GUI + real Codex** — that's the launch test. Relationship to #672: independent; #672 is the parity gate (normalizer fidelity), this is the runtime wiring + feature port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
