### PR TITLE
feat(messaging): surface Markdown artifacts via attachments and previews

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-artifact-renderer.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-artifact-renderer.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import type { MessagingCapabilityProfile } from "@pwragent/messaging-interface";
+import { PERMISSIVE_CAPABILITY_PROFILE } from "@pwragent/messaging-interface/testing";
+import {
+  buildArtifactDeliveryIntent,
+  buildPlanArtifactIntent,
+} from "../messaging/core/messaging-artifact-renderer";
+
+describe("messaging artifact renderer", () => {
+  it("renders short plans inline without a file part", () => {
+    const intent = buildPlanArtifactIntent({
+      capabilityProfile: PERMISSIVE_CAPABILITY_PROFILE,
+      createdAt: 1000,
+      id: "plan-short",
+      plan: {
+        type: "plan",
+        id: "plan-1",
+        steps: [{ step: "Write the test", status: "pending" }],
+      },
+    });
+
+    expect(intent.artifactDelivery).toEqual({
+      kind: "plan",
+      mode: "inline_only",
+    });
+    expect(intent.parts).toHaveLength(1);
+    expect(intent.parts[0]).toMatchObject({
+      type: "text",
+      text: expect.stringContaining("Write the test"),
+    });
+  });
+
+  it("adds a markdown attachment and bounded preview for long artifacts when upload is supported", () => {
+    const markdown = longMarkdown();
+    const intent = buildArtifactDeliveryIntent({
+      artifact: {
+        kind: "review",
+        title: "Review artifact",
+        summary: "Review completed",
+        markdown,
+      },
+      capabilityProfile: PERMISSIVE_CAPABILITY_PROFILE,
+      createdAt: 1000,
+      id: "review-long",
+    });
+
+    expect(intent.artifactDelivery.mode).toBe("attachment_summary");
+    expect(intent.parts).toHaveLength(2);
+    expect(intent.parts[0]).toMatchObject({
+      type: "text",
+      text: expect.stringContaining("Open the attachment"),
+    });
+    expect(intent.parts[1]).toMatchObject({
+      type: "file",
+      mimeType: "text/markdown",
+      name: expect.stringMatching(/^review-[a-f0-9]{10}\.md$/),
+      sizeBytes: new TextEncoder().encode(markdown.trim()).byteLength,
+    });
+  });
+
+  it("falls back to inline preview when provider cannot upload files", () => {
+    const textOnlyProfileWithUndefinedOutbound: MessagingCapabilityProfile = {
+      ...PERMISSIVE_CAPABILITY_PROFILE,
+      text: {
+        ...PERMISSIVE_CAPABILITY_PROFILE.text,
+        maxLength: 4096,
+        encoding: "characters",
+        markdownDialect: "plain",
+      },
+    };
+    const {
+      outboundAttachments: _outboundAttachments,
+      ...textOnlyProfile
+    } = textOnlyProfileWithUndefinedOutbound;
+
+    const intent = buildArtifactDeliveryIntent({
+      artifact: {
+        kind: "plan",
+        title: "Plan artifact",
+        markdown: longMarkdown(),
+      },
+      capabilityProfile: textOnlyProfile,
+      createdAt: 1000,
+      id: "plan-fallback",
+    });
+
+    expect(intent.artifactDelivery.mode).toBe("inline_fallback");
+    expect(intent.parts).toHaveLength(1);
+    expect(intent.parts[0]).toMatchObject({
+      type: "text",
+      text: expect.stringContaining("Attachment delivery is unavailable"),
+    });
+  });
+
+  it("falls back to inline preview when upload size exceeds the capability limit", () => {
+    const tinyUploadProfile: MessagingCapabilityProfile = {
+      ...PERMISSIVE_CAPABILITY_PROFILE,
+      outboundAttachments: {
+        ...PERMISSIVE_CAPABILITY_PROFILE.outboundAttachments!,
+        maxUploadBytes: 32,
+      },
+    };
+
+    const intent = buildArtifactDeliveryIntent({
+      artifact: {
+        kind: "plan",
+        title: "Plan artifact",
+        markdown: longMarkdown(),
+      },
+      capabilityProfile: tinyUploadProfile,
+      createdAt: 1000,
+      id: "plan-too-large",
+    });
+
+    expect(intent.artifactDelivery.mode).toBe("inline_fallback");
+    expect(intent.parts.every((part) => part.type !== "file")).toBe(true);
+  });
+});
+
+function longMarkdown(): string {
+  return [
+    "# Artifact",
+    "",
+    ...Array.from({ length: 120 }, (_, index) => (
+      `- Item ${index + 1}: ${"Detailed artifact content ".repeat(4)}`
+    )),
+  ].join("\n");
+}

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -2889,6 +2889,172 @@ describe("MessagingController", () => {
     expect(errorNotices).toHaveLength(1);
   });
 
+  it("delivers a completed plan artifact as markdown attachment plus inline preview", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/plan/updated",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          plan: {
+            explanation: "Implementation plan",
+            steps: Array.from({ length: 80 }, (_, index) => ({
+              step: `Complete implementation step ${index + 1}`,
+              status: "pending" as const,
+            })),
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            output: [],
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    const artifactIntent = harness.delivered.find(
+      (intent): intent is MessagingSurfaceIntent & {
+        artifactDelivery: { kind: "plan"; mode: string };
+      } => intent.kind === "message" && "artifactDelivery" in intent,
+    );
+    expect(artifactIntent).toMatchObject({
+      kind: "message",
+      artifactDelivery: {
+        kind: "plan",
+        mode: "attachment_summary",
+      },
+      parts: [
+        expect.objectContaining({
+          type: "text",
+          text: expect.stringContaining("Open the attachment"),
+        }),
+        expect.objectContaining({
+          type: "file",
+          mimeType: "text/markdown",
+          name: expect.stringMatching(/^plan-[a-f0-9]{10}\.md$/),
+        }),
+      ],
+    });
+  });
+
+  it("retries plan artifact delivery as inline preview when attachment delivery fails", async () => {
+    const attempts: MessagingSurfaceIntent[] = [];
+    const harness = await createHarness({
+      deliver: async (intent) => {
+        attempts.push(intent);
+        const hasFile = intent.kind === "message" && intent.parts.some((part) => part.type === "file");
+        return {
+          channel: "telegram",
+          deliveredAt: 1000,
+          outcome: hasFile ? "failed" : "presented",
+          ...(hasFile ? { errorMessage: "file upload failed" } : {}),
+        };
+      },
+    });
+    await bindThread(harness);
+    attempts.length = 0;
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/plan/updated",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          plan: {
+            steps: Array.from({ length: 80 }, (_, index) => ({
+              step: `Complete implementation step ${index + 1}`,
+              status: "pending" as const,
+            })),
+          },
+        },
+      },
+    } satisfies AgentEvent);
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            output: [],
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    const artifactAttempts = attempts.filter(
+      (intent): intent is MessagingSurfaceIntent & {
+        artifactDelivery: { kind: "plan"; mode: string };
+      } => intent.kind === "message" && "artifactDelivery" in intent,
+    );
+    expect(artifactAttempts.map((intent) => intent.artifactDelivery.mode)).toEqual([
+      "attachment_summary",
+      "inline_fallback",
+    ]);
+    expect(artifactAttempts[1]?.kind === "message" ? artifactAttempts[1].parts : []).toHaveLength(1);
+  });
+
+  it("delivers review artifacts for standard exited_review_mode items", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "review-1",
+            type: "exited_review_mode",
+            review: "Review found no blocking issues.",
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(
+      harness.delivered.find(
+        (intent): intent is MessagingSurfaceIntent & {
+          artifactDelivery: { kind: "review"; mode: string };
+        } => intent.kind === "message" && "artifactDelivery" in intent,
+      ),
+    ).toMatchObject({
+      kind: "message",
+      artifactDelivery: {
+        kind: "review",
+      },
+      parts: [
+        expect.objectContaining({
+          type: "text",
+          text: expect.stringContaining("Review found no blocking issues."),
+        }),
+      ],
+    });
+  });
+
   it("posts a durable start notice for automation turns", async () => {
     const harness = await createHarness();
     await bindThread(harness);
@@ -3006,6 +3172,22 @@ describe("MessagingController", () => {
     await harness.controller.handleBackendEvent({
       backend: "codex",
       notification: {
+        method: "turn/plan/updated",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          plan: {
+            steps: Array.from({ length: 80 }, (_, index) => ({
+              step: `Automation plan step ${index + 1}`,
+              status: "pending" as const,
+            })),
+          },
+        },
+      },
+    } satisfies AgentEvent);
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
         method: "turn/completed",
         params: {
           threadId: "thread-1",
@@ -3028,6 +3210,11 @@ describe("MessagingController", () => {
     ).toEqual([]);
     expect(JSON.stringify(harness.delivered)).not.toContain("Intermediate thinking");
     expect(JSON.stringify(harness.delivered)).not.toContain("Intermediate commentary");
+    expect(
+      harness.delivered.filter(
+        (intent) => intent.kind === "message" && "artifactDelivery" in intent,
+      ),
+    ).toEqual([]);
     expect(harness.delivered).toContainEqual(
       expect.objectContaining({
         kind: "message",

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -3055,6 +3055,71 @@ describe("MessagingController", () => {
     });
   });
 
+  it("delivers a single added markdown file as attachment plus bounded preview", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    const markdown = `# Release notes\n\n${"x".repeat(1_200)}\n\nDo not include this tail in the preview.`;
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "file-1",
+            type: "fileChange",
+            changes: [
+              {
+                path: "/repo/docs/release-notes.md",
+                kind: {
+                  type: "add",
+                  content: markdown,
+                },
+              },
+            ],
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    const artifactIntent = harness.delivered.find(
+      (intent): intent is MessagingSurfaceIntent & {
+        artifactDelivery: { kind: "markdown_file"; mode: string };
+      } => intent.kind === "message" && "artifactDelivery" in intent,
+    );
+    expect(artifactIntent).toMatchObject({
+      kind: "message",
+      artifactDelivery: {
+        kind: "markdown_file",
+        mode: "attachment_summary",
+      },
+      parts: [
+        expect.objectContaining({
+          type: "text",
+          text: expect.stringContaining("Added /repo/docs/release-notes.md"),
+        }),
+        expect.objectContaining({
+          type: "file",
+          mimeType: "text/markdown",
+          name: "release-notes.md",
+          sizeBytes: new TextEncoder().encode(markdown).byteLength,
+        }),
+      ],
+    });
+    const textPart = artifactIntent?.kind === "message" ? artifactIntent.parts[0] : undefined;
+    const filePart = artifactIntent?.kind === "message" ? artifactIntent.parts[1] : undefined;
+    expect(textPart?.type === "text" ? textPart.text : "").toContain("Open the attachment");
+    expect(textPart?.type === "text" ? textPart.text : "").not.toContain(
+      "Do not include this tail",
+    );
+    expect(filePart?.type === "file" ? new TextDecoder().decode(filePart.data) : "").toBe(
+      markdown,
+    );
+  });
+
   it("posts a durable start notice for automation turns", async () => {
     const harness = await createHarness();
     await bindThread(harness);

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -3055,6 +3055,71 @@ describe("MessagingController", () => {
     });
   });
 
+  it("delivers review artifacts from structured review output", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "review-structured-1",
+            type: "exited_review_mode",
+            data: {
+              reviewOutput: {
+                findings: [
+                  {
+                    title: "Missing validation",
+                    body: "The input is not validated.",
+                    confidence_score: 0.91,
+                    priority: 1,
+                    code_location: {
+                      absolute_file_path: "/repo/src/index.ts",
+                      line_range: {
+                        start: 12,
+                        end: 12,
+                      },
+                    },
+                  },
+                ],
+                overall_correctness: "patch is incorrect",
+                overall_explanation: "The patch has one validation issue.",
+                overall_confidence_score: 0.87,
+              },
+            },
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    const artifactIntent = harness.delivered.find(
+      (intent): intent is MessagingSurfaceIntent & {
+        artifactDelivery: { kind: "review"; mode: string };
+      } => intent.kind === "message" && "artifactDelivery" in intent,
+    );
+    expect(artifactIntent).toMatchObject({
+      kind: "message",
+      artifactDelivery: {
+        kind: "review",
+      },
+      parts: [
+        expect.objectContaining({
+          type: "text",
+          text: expect.stringContaining("The patch has one validation issue."),
+        }),
+      ],
+    });
+    const textPart = artifactIntent?.kind === "message" ? artifactIntent.parts[0] : undefined;
+    expect(textPart).toEqual(expect.objectContaining({
+      text: expect.stringContaining("Missing validation"),
+    }));
+  });
+
   it("delivers a single added markdown file as attachment plus bounded preview", async () => {
     const harness = await createHarness();
     await bindThread(harness);

--- a/apps/desktop/src/main/__tests__/messaging-markdown-file-attachment-selector.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-markdown-file-attachment-selector.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import { MessagingMarkdownFileAttachmentSelector } from "../messaging/core/messaging-markdown-file-attachment-selector.js";
+
+describe("MessagingMarkdownFileAttachmentSelector", () => {
+  it("selects one added markdown file under the size limit", () => {
+    const selector = new MessagingMarkdownFileAttachmentSelector();
+    const selection = selector.selectFromCompletedItem({
+      type: "fileChange",
+      changes: [
+        {
+          path: "/repo/docs/plan.md",
+          kind: {
+            type: "add",
+            content: "# Plan\n\nShip the feature.\n",
+          },
+        },
+      ],
+    });
+
+    expect(selection).toMatchObject({
+      attachmentName: "plan.md",
+      markdown: "# Plan\n\nShip the feature.\n",
+      path: "/repo/docs/plan.md",
+      previewMarkdown: "# Plan\n\nShip the feature.",
+      previewTruncated: false,
+    });
+  });
+
+  it("caps previews by both line count and character count", () => {
+    const selector = new MessagingMarkdownFileAttachmentSelector({
+      maxPreviewChars: 1_000,
+      maxPreviewLines: 20,
+    });
+    const longLine = "x".repeat(1_200);
+    const manyLines = Array.from({ length: 25 }, (_, index) => `line ${index + 1}`).join("\n");
+
+    const longLineSelection = selector.selectFromCompletedItem({
+      type: "fileChange",
+      changes: [
+        {
+          path: "LONG.md",
+          kind: {
+            type: "add",
+            content: longLine,
+          },
+        },
+      ],
+    });
+    const manyLinesSelection = selector.selectFromCompletedItem({
+      type: "fileChange",
+      changes: [
+        {
+          path: "LINES.md",
+          kind: {
+            type: "add",
+            content: manyLines,
+          },
+        },
+      ],
+    });
+
+    expect(longLineSelection?.previewMarkdown).toHaveLength(1_000);
+    expect(longLineSelection?.previewTruncated).toBe(true);
+    expect(manyLinesSelection?.previewMarkdown.split("\n")).toHaveLength(20);
+    expect(manyLinesSelection?.previewMarkdown).not.toContain("line 21");
+    expect(manyLinesSelection?.previewTruncated).toBe(true);
+  });
+
+  it("skips multiple changes, non-markdown files, updates, and oversized files", () => {
+    const selector = new MessagingMarkdownFileAttachmentSelector();
+
+    expect(
+      selector.selectFromCompletedItem({
+        type: "fileChange",
+        changes: [
+          { path: "one.md", kind: { type: "add", content: "one" } },
+          { path: "two.md", kind: { type: "add", content: "two" } },
+        ],
+      }),
+    ).toBeUndefined();
+    expect(
+      selector.selectFromCompletedItem({
+        type: "fileChange",
+        changes: [{ path: "notes.txt", kind: { type: "add", content: "notes" } }],
+      }),
+    ).toBeUndefined();
+    expect(
+      selector.selectFromCompletedItem({
+        type: "fileChange",
+        changes: [{ path: "notes.md", kind: { type: "update", content: "notes" } }],
+      }),
+    ).toBeUndefined();
+    expect(
+      selector.selectFromCompletedItem({
+        type: "fileChange",
+        changes: [
+          {
+            path: "large.md",
+            kind: { type: "add", content: "x".repeat(50 * 1024) },
+          },
+        ],
+      }),
+    ).toBeUndefined();
+  });
+
+  it("reconstructs added markdown from a unified diff", () => {
+    const selector = new MessagingMarkdownFileAttachmentSelector();
+    const selection = selector.selectFromCompletedItem({
+      type: "fileChange",
+      changes: [
+        {
+          path: "docs/result.md",
+          kind: { type: "add" },
+          diff: [
+            "new file mode 100644",
+            "--- /dev/null",
+            "+++ b/docs/result.md",
+            "@@ -0,0 +1,3 @@",
+            "+# Result",
+            "+",
+            "+Done.",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(selection?.markdown).toBe("# Result\n\nDone.");
+    expect(selection?.previewMarkdown).toBe("# Result\n\nDone.");
+  });
+});

--- a/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
@@ -112,6 +112,7 @@ describe("buildBindingStatusIntent", () => {
     expect(intent.text).toContain("Model: gpt-5.3-codex");
     expect(intent.text).toContain("Reasoning: high");
     expect(intent.text).toContain("Fast mode: on");
+    expect(intent.text).toContain("Plan delivery: inline preview");
     expect(intent.text).not.toContain("Plan mode:");
     expect(intent.text).toContain("Permissions: Full Access");
     expect(intent.text).toContain("Streaming: Off");

--- a/apps/desktop/src/main/messaging/core/messaging-artifact-renderer.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-artifact-renderer.ts
@@ -17,10 +17,16 @@ const TRUNCATED_WITH_ATTACHMENT =
 const TRUNCATED_INLINE_ONLY =
   "[Preview truncated. Attachment delivery is unavailable for this provider.]";
 
-export type MessagingArtifactKind = "plan" | "review";
+export type MessagingArtifactKind = "plan" | "review" | "markdown_file";
 
 export type MessagingArtifact = {
+  attachmentDescription?: string;
+  attachmentName?: string;
   kind: MessagingArtifactKind;
+  preferAttachment?: boolean;
+  preserveMarkdown?: boolean;
+  previewMarkdown?: string;
+  previewTruncated?: boolean;
   title: string;
   summary?: string;
   markdown: string;
@@ -91,7 +97,9 @@ export function buildArtifactDeliveryIntent(params: {
   createdAt: number;
   id: string;
 }): MessagingArtifactMessageIntent {
-  const markdown = normalizeMarkdown(params.artifact.markdown);
+  const markdown = params.artifact.preserveMarkdown
+    ? params.artifact.markdown
+    : normalizeMarkdown(params.artifact.markdown);
   const inlineLimit = clampTextLimit(params.capabilityProfile, INLINE_ONLY_THRESHOLD);
   const canSendInlineOnly = markdown.length <= inlineLimit;
   const fileData = new TextEncoder().encode(markdown);
@@ -99,11 +107,15 @@ export function buildArtifactDeliveryIntent(params: {
   const canAttach =
     params.capabilityProfile.outboundAttachments?.supportsFileUpload === true &&
     (uploadLimit === undefined || fileData.byteLength <= uploadLimit);
-  const mode: MessagingArtifactDeliveryMode = canSendInlineOnly
-    ? "inline_only"
-    : canAttach
+  const mode: MessagingArtifactDeliveryMode = params.artifact.preferAttachment
+    ? canAttach
       ? "attachment_summary"
-      : "inline_fallback";
+      : "inline_fallback"
+    : canSendInlineOnly
+      ? "inline_only"
+      : canAttach
+        ? "attachment_summary"
+        : "inline_fallback";
   const text = mode === "inline_only"
     ? markdown
     : mode === "attachment_summary"
@@ -144,11 +156,13 @@ export function buildArtifactDeliveryIntent(params: {
         ? [
             {
               type: "file" as const,
-              name: artifactFileName(params.artifact.kind, markdown),
+              name: artifactFileName(params.artifact, markdown),
               data: fileData,
               mimeType: "text/markdown",
               sizeBytes: fileData.byteLength,
-              description: `Full ${params.artifact.kind} artifact`,
+              description:
+                params.artifact.attachmentDescription ??
+                `Full ${params.artifact.kind} artifact`,
             },
           ]
         : []),
@@ -273,13 +287,19 @@ function formatAttachmentSummary(params: {
   markdown: string;
   maxChars: number;
 }): string {
+  const preview = formatArtifactPreview({
+    artifact: params.artifact,
+    markdown: params.markdown,
+    maxChars: params.maxChars,
+    marker: TRUNCATED_WITH_ATTACHMENT,
+  });
   return boundedText(
     [
       `# ${params.artifact.title}`,
       params.artifact.summary,
       stepSummary(params.artifact.steps),
       "",
-      truncateMarkdown(params.markdown, params.maxChars, TRUNCATED_WITH_ATTACHMENT),
+      preview,
     ],
     params.maxChars,
     TRUNCATED_WITH_ATTACHMENT,
@@ -291,17 +311,43 @@ function formatInlineFallback(params: {
   markdown: string;
   maxChars: number;
 }): string {
+  const preview = formatArtifactPreview({
+    artifact: params.artifact,
+    markdown: params.markdown,
+    maxChars: params.maxChars,
+    marker: TRUNCATED_INLINE_ONLY,
+  });
   return boundedText(
     [
       `# ${params.artifact.title}`,
       params.artifact.summary,
       stepSummary(params.artifact.steps),
       "",
-      truncateMarkdown(params.markdown, params.maxChars, TRUNCATED_INLINE_ONLY),
+      preview,
     ],
     params.maxChars,
     TRUNCATED_INLINE_ONLY,
   );
+}
+
+function formatArtifactPreview(params: {
+  artifact: MessagingArtifact;
+  markdown: string;
+  maxChars: number;
+  marker: string;
+}): string {
+  if (params.artifact.previewMarkdown === undefined) {
+    return truncateMarkdown(params.markdown, params.maxChars, params.marker);
+  }
+  const preview = truncateMarkdown(
+    params.artifact.previewMarkdown,
+    params.maxChars,
+    params.marker,
+  );
+  if (!params.artifact.previewTruncated || preview.includes(params.marker)) {
+    return preview;
+  }
+  return `${preview.trimEnd()}\n\n${params.marker}`;
 }
 
 function truncateMarkdown(markdown: string, maxChars: number, marker: string): string {
@@ -337,9 +383,12 @@ function clampTextLimit(
   return Math.max(200, Math.min(preferred, capabilityProfile.text.maxLength));
 }
 
-function artifactFileName(kind: MessagingArtifactKind, markdown: string): string {
+function artifactFileName(artifact: MessagingArtifact, markdown: string): string {
+  if (artifact.attachmentName?.trim()) {
+    return artifact.attachmentName.trim();
+  }
   const digest = createHash("sha256").update(markdown).digest("hex").slice(0, 10);
-  return `${kind}-${digest}.md`;
+  return `${artifact.kind}-${digest}.md`;
 }
 
 function statusCheckbox(status: AppServerThreadPlanStep["status"]): string {

--- a/apps/desktop/src/main/messaging/core/messaging-artifact-renderer.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-artifact-renderer.ts
@@ -1,0 +1,351 @@
+import { createHash } from "node:crypto";
+import type {
+  AppServerThreadPlanEntry,
+  AppServerThreadPlanStep,
+  AppServerThreadReviewEntry,
+} from "@pwragent/shared";
+import type {
+  MessagingCapabilityProfile,
+  MessagingMessageIntent,
+} from "@pwragent/messaging-interface";
+
+const INLINE_ONLY_THRESHOLD = 1_400;
+const ATTACHMENT_SUMMARY_PREVIEW_CHARS = 1_400;
+const INLINE_FALLBACK_PREVIEW_CHARS = 1_800;
+const TRUNCATED_WITH_ATTACHMENT =
+  "[Preview truncated. Open the attachment for the full artifact.]";
+const TRUNCATED_INLINE_ONLY =
+  "[Preview truncated. Attachment delivery is unavailable for this provider.]";
+
+export type MessagingArtifactKind = "plan" | "review";
+
+export type MessagingArtifact = {
+  kind: MessagingArtifactKind;
+  title: string;
+  summary?: string;
+  markdown: string;
+  steps?: AppServerThreadPlanStep[];
+};
+
+export type MessagingArtifactDeliveryMode =
+  | "inline_only"
+  | "attachment_summary"
+  | "inline_fallback";
+
+export type MessagingArtifactMessageIntent = MessagingMessageIntent & {
+  artifactDelivery: {
+    kind: MessagingArtifactKind;
+    mode: MessagingArtifactDeliveryMode;
+  };
+};
+
+export function buildPlanArtifactIntent(params: {
+  bindingId?: string;
+  capabilityProfile: MessagingCapabilityProfile;
+  createdAt: number;
+  id: string;
+  plan: AppServerThreadPlanEntry;
+}): MessagingArtifactMessageIntent {
+  const markdown = params.plan.markdown?.trim() || renderPlanMarkdown(params.plan);
+  return buildArtifactDeliveryIntent({
+    artifact: {
+      kind: "plan",
+      title: "Plan artifact",
+      summary: params.plan.explanation,
+      steps: params.plan.steps,
+      markdown,
+    },
+    bindingId: params.bindingId,
+    capabilityProfile: params.capabilityProfile,
+    createdAt: params.createdAt,
+    id: params.id,
+  });
+}
+
+export function buildReviewArtifactIntent(params: {
+  bindingId?: string;
+  capabilityProfile: MessagingCapabilityProfile;
+  createdAt: number;
+  id: string;
+  review: AppServerThreadReviewEntry;
+}): MessagingArtifactMessageIntent {
+  const markdown = renderReviewMarkdown(params.review);
+  return buildArtifactDeliveryIntent({
+    artifact: {
+      kind: "review",
+      title: "Review artifact",
+      summary: params.review.displayText,
+      markdown,
+    },
+    bindingId: params.bindingId,
+    capabilityProfile: params.capabilityProfile,
+    createdAt: params.createdAt,
+    id: params.id,
+  });
+}
+
+export function buildArtifactDeliveryIntent(params: {
+  artifact: MessagingArtifact;
+  bindingId?: string;
+  capabilityProfile: MessagingCapabilityProfile;
+  createdAt: number;
+  id: string;
+}): MessagingArtifactMessageIntent {
+  const markdown = normalizeMarkdown(params.artifact.markdown);
+  const inlineLimit = clampTextLimit(params.capabilityProfile, INLINE_ONLY_THRESHOLD);
+  const canSendInlineOnly = markdown.length <= inlineLimit;
+  const fileData = new TextEncoder().encode(markdown);
+  const uploadLimit = params.capabilityProfile.outboundAttachments?.maxUploadBytes;
+  const canAttach =
+    params.capabilityProfile.outboundAttachments?.supportsFileUpload === true &&
+    (uploadLimit === undefined || fileData.byteLength <= uploadLimit);
+  const mode: MessagingArtifactDeliveryMode = canSendInlineOnly
+    ? "inline_only"
+    : canAttach
+      ? "attachment_summary"
+      : "inline_fallback";
+  const text = mode === "inline_only"
+    ? markdown
+    : mode === "attachment_summary"
+      ? formatAttachmentSummary({
+          artifact: params.artifact,
+          markdown,
+          maxChars: clampTextLimit(
+            params.capabilityProfile,
+            ATTACHMENT_SUMMARY_PREVIEW_CHARS,
+          ),
+        })
+      : formatInlineFallback({
+          artifact: params.artifact,
+          markdown,
+          maxChars: clampTextLimit(
+            params.capabilityProfile,
+            INLINE_FALLBACK_PREVIEW_CHARS,
+          ),
+        });
+
+  return {
+    id: params.id,
+    kind: "message",
+    artifactDelivery: {
+      kind: params.artifact.kind,
+      mode,
+    },
+    bindingId: params.bindingId,
+    createdAt: params.createdAt,
+    role: "system",
+    parts: [
+      {
+        type: "text",
+        text,
+        markdown: "markdown",
+      },
+      ...(mode === "attachment_summary"
+        ? [
+            {
+              type: "file" as const,
+              name: artifactFileName(params.artifact.kind, markdown),
+              data: fileData,
+              mimeType: "text/markdown",
+              sizeBytes: fileData.byteLength,
+              description: `Full ${params.artifact.kind} artifact`,
+            },
+          ]
+        : []),
+    ],
+  };
+}
+
+export function buildArtifactInlineFallbackIntent(params: {
+  artifact: MessagingArtifact;
+  bindingId?: string;
+  capabilityProfile: MessagingCapabilityProfile;
+  createdAt: number;
+  id: string;
+}): MessagingArtifactMessageIntent {
+  const markdown = normalizeMarkdown(params.artifact.markdown);
+  return {
+    id: params.id,
+    kind: "message",
+    artifactDelivery: {
+      kind: params.artifact.kind,
+      mode: "inline_fallback",
+    },
+    bindingId: params.bindingId,
+    createdAt: params.createdAt,
+    role: "system",
+    parts: [
+      {
+        type: "text",
+        text: formatInlineFallback({
+          artifact: params.artifact,
+          markdown,
+          maxChars: clampTextLimit(
+            params.capabilityProfile,
+            INLINE_FALLBACK_PREVIEW_CHARS,
+          ),
+        }),
+        markdown: "markdown",
+      },
+    ],
+  };
+}
+
+export function planEntryFromUpdate(params: {
+  createdAt: number;
+  explanation?: string;
+  id: string;
+  markdown?: string;
+  steps: AppServerThreadPlanStep[];
+  turnId: string;
+}): AppServerThreadPlanEntry {
+  return {
+    type: "plan",
+    id: params.id,
+    createdAt: params.createdAt,
+    ...(params.explanation ? { explanation: params.explanation } : {}),
+    ...(params.markdown ? { markdown: params.markdown } : {}),
+    steps: params.steps,
+    turn: {
+      id: params.turnId,
+    },
+  };
+}
+
+export function artifactFromPlanEntry(plan: AppServerThreadPlanEntry): MessagingArtifact {
+  return {
+    kind: "plan",
+    title: "Plan artifact",
+    summary: plan.explanation,
+    steps: plan.steps,
+    markdown: plan.markdown?.trim() || renderPlanMarkdown(plan),
+  };
+}
+
+export function artifactFromReviewEntry(review: AppServerThreadReviewEntry): MessagingArtifact {
+  return {
+    kind: "review",
+    title: "Review artifact",
+    summary: review.displayText,
+    markdown: renderReviewMarkdown(review),
+  };
+}
+
+function renderPlanMarkdown(plan: AppServerThreadPlanEntry): string {
+  const lines = ["# Plan"];
+  if (plan.explanation?.trim()) {
+    lines.push("", plan.explanation.trim());
+  }
+  if (plan.steps.length > 0) {
+    lines.push("", "## Steps");
+    for (const step of plan.steps) {
+      lines.push(`- [${statusCheckbox(step.status)}] ${step.step.trim()}`);
+    }
+  }
+  return lines.join("\n").trim();
+}
+
+function renderReviewMarkdown(review: AppServerThreadReviewEntry): string {
+  const lines = ["# Review"];
+  if (review.displayText?.trim()) {
+    lines.push("", review.displayText.trim());
+  }
+  if (review.review.trim()) {
+    lines.push("", review.review.trim());
+  }
+  if (review.output) {
+    lines.push("", "## Summary");
+    lines.push(`- Correctness: ${review.output.overall_correctness}`);
+    lines.push(`- Confidence: ${review.output.overall_confidence_score}`);
+    lines.push(`- Explanation: ${review.output.overall_explanation}`);
+    if (review.output.findings.length > 0) {
+      lines.push("", "## Findings");
+      for (const finding of review.output.findings) {
+        lines.push(`- ${finding.title}: ${finding.body}`);
+      }
+    }
+  }
+  return lines.join("\n").trim();
+}
+
+function formatAttachmentSummary(params: {
+  artifact: MessagingArtifact;
+  markdown: string;
+  maxChars: number;
+}): string {
+  return boundedText(
+    [
+      `# ${params.artifact.title}`,
+      params.artifact.summary,
+      stepSummary(params.artifact.steps),
+      "",
+      truncateMarkdown(params.markdown, params.maxChars, TRUNCATED_WITH_ATTACHMENT),
+    ],
+    params.maxChars,
+    TRUNCATED_WITH_ATTACHMENT,
+  );
+}
+
+function formatInlineFallback(params: {
+  artifact: MessagingArtifact;
+  markdown: string;
+  maxChars: number;
+}): string {
+  return boundedText(
+    [
+      `# ${params.artifact.title}`,
+      params.artifact.summary,
+      stepSummary(params.artifact.steps),
+      "",
+      truncateMarkdown(params.markdown, params.maxChars, TRUNCATED_INLINE_ONLY),
+    ],
+    params.maxChars,
+    TRUNCATED_INLINE_ONLY,
+  );
+}
+
+function truncateMarkdown(markdown: string, maxChars: number, marker: string): string {
+  if (markdown.length <= maxChars) {
+    return markdown;
+  }
+  const available = Math.max(0, maxChars - marker.length - 2);
+  const headingBreak = markdown.lastIndexOf("\n## ", available);
+  const lineBreak = markdown.lastIndexOf("\n", available);
+  const cutAt = headingBreak > 120 ? headingBreak : lineBreak > 120 ? lineBreak : available;
+  return `${markdown.slice(0, cutAt).trimEnd()}\n\n${marker}`;
+}
+
+function boundedText(parts: Array<string | undefined>, maxChars: number, marker: string): string {
+  const text = parts.filter((part): part is string => Boolean(part?.trim())).join("\n");
+  return truncateMarkdown(text, maxChars, marker);
+}
+
+function stepSummary(steps: AppServerThreadPlanStep[] | undefined): string | undefined {
+  if (!steps || steps.length === 0) {
+    return undefined;
+  }
+  const pending = steps.filter((step) => step.status === "pending").length;
+  const inProgress = steps.filter((step) => step.status === "in_progress").length;
+  const completed = steps.filter((step) => step.status === "completed").length;
+  return `Steps: ${completed} completed, ${inProgress} in progress, ${pending} pending`;
+}
+
+function clampTextLimit(
+  capabilityProfile: MessagingCapabilityProfile,
+  preferred: number,
+): number {
+  return Math.max(200, Math.min(preferred, capabilityProfile.text.maxLength));
+}
+
+function artifactFileName(kind: MessagingArtifactKind, markdown: string): string {
+  const digest = createHash("sha256").update(markdown).digest("hex").slice(0, 10);
+  return `${kind}-${digest}.md`;
+}
+
+function statusCheckbox(status: AppServerThreadPlanStep["status"]): string {
+  return status === "completed" ? "x" : status === "in_progress" ? "-" : " ";
+}
+
+function normalizeMarkdown(markdown: string): string {
+  return markdown.trim() || "# Artifact\n\nNo artifact content was provided.";
+}

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -12149,8 +12149,11 @@ function reviewArtifactForBackendEvent(
     return undefined;
   }
   const item = params.item as {
+    data?: unknown;
     id?: unknown;
     review?: unknown;
+    review_output?: unknown;
+    reviewOutput?: unknown;
     text?: unknown;
     type?: unknown;
   };
@@ -12165,8 +12168,11 @@ function reviewArtifactForBackendEvent(
   ) {
     return undefined;
   }
+  const reviewOutput = normalizeStructuredReviewOutput(item as Record<string, unknown>);
   const review = (typeof item.review === "string" ? item.review.trim() : "") ||
-    (typeof item.text === "string" ? item.text.trim() : "");
+    (typeof item.text === "string" ? item.text.trim() : "") ||
+    reviewOutput?.overall_explanation.trim() ||
+    "";
   if (!review) {
     return undefined;
   }
@@ -12176,6 +12182,7 @@ function reviewArtifactForBackendEvent(
     createdAt,
     review,
     displayText: "Code review completed",
+    ...(reviewOutput ? { output: reviewOutput } : {}),
     ...(typeof params.turnId === "string"
       ? {
           turn: {
@@ -12183,6 +12190,38 @@ function reviewArtifactForBackendEvent(
           },
         }
       : {}),
+  };
+}
+
+function normalizeStructuredReviewOutput(
+  item: Record<string, unknown>,
+): AppServerThreadReviewEntry["output"] | undefined {
+  const data = asPlainRecord(item.data);
+  const reviewOutput =
+    asPlainRecord(data?.reviewOutput) ??
+    asPlainRecord(data?.review_output) ??
+    asPlainRecord(item.reviewOutput) ??
+    asPlainRecord(item.review_output);
+  const findings = Array.isArray(reviewOutput?.findings)
+    ? reviewOutput.findings
+    : undefined;
+
+  if (
+    !reviewOutput ||
+    !findings ||
+    (reviewOutput.overall_correctness !== "patch is correct" &&
+      reviewOutput.overall_correctness !== "patch is incorrect") ||
+    typeof reviewOutput.overall_explanation !== "string" ||
+    typeof reviewOutput.overall_confidence_score !== "number"
+  ) {
+    return undefined;
+  }
+
+  return {
+    findings: findings as NonNullable<AppServerThreadReviewEntry["output"]>["findings"],
+    overall_correctness: reviewOutput.overall_correctness,
+    overall_explanation: reviewOutput.overall_explanation,
+    overall_confidence_score: reviewOutput.overall_confidence_score,
   };
 }
 

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -13,6 +13,8 @@ import type {
   AgentEvent,
   AppServerTurnInputItem,
   AppServerBackendKind,
+  AppServerThreadPlanEntry,
+  AppServerThreadReviewEntry,
   AutomationRunOutputDecision,
   CodexEnvironmentOption,
   BackendAcpRuntimeOptionSource,
@@ -109,6 +111,15 @@ import {
   buildToolUpdateBatchMessageIntent,
   buildToolUpdateMessageIntent,
 } from "./messaging-renderer.js";
+import {
+  artifactFromPlanEntry,
+  artifactFromReviewEntry,
+  buildArtifactDeliveryIntent,
+  buildArtifactInlineFallbackIntent,
+  planEntryFromUpdate,
+  type MessagingArtifact,
+  type MessagingArtifactMessageIntent,
+} from "./messaging-artifact-renderer.js";
 import { buildMessagingAuditContext } from "./messaging-audit.js";
 import { getMainLogger } from "../../log.js";
 import { DeterministicInteractionMapper } from "./deterministic-interaction-mapper.js";
@@ -559,6 +570,7 @@ export class MessagingController {
   private readonly interactionMapper: MessagingInteractionMapper;
   private readonly activeTurnsByThreadKey = new Map<string, MessagingActiveTurnSummary>();
   private readonly contextUsageSummariesByThreadKey = new Map<string, string>();
+  private readonly planArtifactsByTurnKey = new Map<string, AppServerThreadPlanEntry>();
   private readonly typingActivityLastSignaledAt = new Map<string, number>();
   private readonly logger: MessagingControllerLogger;
   private readonly streamingResponsesDefault: boolean;
@@ -840,7 +852,18 @@ export class MessagingController {
       }
       return;
     }
+    const planUpdate = planEntryForBackendEvent(event, this.now());
+    if (planUpdate) {
+      this.planArtifactsByTurnKey.set(
+        artifactTurnKey(event.backend, threadId, planUpdate.turn?.id ?? planUpdate.id),
+        planUpdate,
+      );
+    }
+    const reviewArtifact = reviewArtifactForBackendEvent(event, this.now());
     const lifecycle = turnLifecycleForBackendEvent(event, this.now());
+    const completedPlan = lifecycle && isTerminalTurnLifecycle(lifecycle)
+      ? this.planArtifactsByTurnKey.get(artifactTurnKey(event.backend, threadId, lifecycle.turnId))
+      : undefined;
     for (const binding of bindings) {
       let activeTurn = this.getActiveTurn(binding);
       let turnStateChanged = false;
@@ -936,6 +959,22 @@ export class MessagingController {
         }
       }
 
+      if (completedPlan && !automationTurnEvent) {
+        await this.deliverArtifactForBinding({
+          artifact: artifactFromPlanEntry(completedPlan),
+          binding,
+          intentId: `artifact:plan:${completedPlan.turn?.id ?? completedPlan.id}:${binding.id}`,
+        });
+      }
+
+      if (reviewArtifact && !automationTurnEvent) {
+        await this.deliverArtifactForBinding({
+          artifact: artifactFromReviewEntry(reviewArtifact),
+          binding,
+          intentId: `artifact:review:${reviewArtifact.id}:${binding.id}`,
+        });
+      }
+
       if (isThreadNameUpdatedEvent(event)) {
         await this.renderBindingStatus(
           binding,
@@ -989,6 +1028,7 @@ export class MessagingController {
     if (lifecycle && isTerminalTurnLifecycle(lifecycle)) {
       this.forgetAutomationTurn(event.backend, threadId, lifecycle.turnId);
       this.forgetAgentMessagingOrigin(event.backend, threadId, lifecycle.turnId);
+      this.planArtifactsByTurnKey.delete(artifactTurnKey(event.backend, threadId, lifecycle.turnId));
     }
   }
 
@@ -10156,6 +10196,42 @@ export class MessagingController {
     }
   }
 
+  private async deliverArtifactForBinding(params: {
+    artifact: MessagingArtifact;
+    binding: MessagingBindingRecord;
+    intentId: string;
+  }): Promise<void> {
+    const intent = buildArtifactDeliveryIntent({
+      artifact: params.artifact,
+      bindingId: params.binding.id,
+      capabilityProfile: this.capabilityProfile,
+      createdAt: this.now(),
+      id: params.intentId,
+    });
+    const result = await this.deliver(intent, params.binding);
+    if (!shouldRetryArtifactInline(intent, result)) {
+      return;
+    }
+    this.logger.debug?.("messaging artifact attachment delivery failed; retrying inline fallback", {
+      bindingId: params.binding.id,
+      errorMessage: result.errorMessage,
+      intentId: intent.id,
+      kind: params.artifact.kind,
+      outcome: result.outcome,
+      threadId: params.binding.threadId,
+    });
+    await this.deliver(
+      buildArtifactInlineFallbackIntent({
+        artifact: params.artifact,
+        bindingId: params.binding.id,
+        capabilityProfile: this.capabilityProfile,
+        createdAt: this.now(),
+        id: `${params.intentId}:inline-fallback`,
+      }),
+      params.binding,
+    );
+  }
+
   private logDeliveryResult(
     intent: MessagingSurfaceIntent,
     binding: MessagingBindingRecord | undefined,
@@ -11996,6 +12072,120 @@ function formatContextUsageNumber(value: number): string {
   return Math.round(value).toLocaleString();
 }
 
+function planEntryForBackendEvent(
+  event: AgentEvent,
+  createdAt: number,
+): AppServerThreadPlanEntry | undefined {
+  if (event.notification.method !== "turn/plan/updated") {
+    return undefined;
+  }
+  const params = event.notification.params as {
+    plan?: {
+      explanation?: unknown;
+      steps?: unknown;
+    };
+    turnId?: unknown;
+  };
+  if (typeof params.turnId !== "string" || !Array.isArray(params.plan?.steps)) {
+    return undefined;
+  }
+  const explanation = typeof params.plan.explanation === "string"
+    ? params.plan.explanation.trim()
+    : undefined;
+  const steps = params.plan.steps.flatMap((step): AppServerThreadPlanEntry["steps"] => {
+    if (!step || typeof step !== "object") {
+      return [];
+    }
+    const record = step as { status?: unknown; step?: unknown };
+    if (
+      typeof record.step !== "string" ||
+      !isPlanStepStatus(record.status) ||
+      !record.step.trim()
+    ) {
+      return [];
+    }
+    return [{ step: record.step.trim(), status: record.status }];
+  });
+  if (!explanation && steps.length === 0) {
+    return undefined;
+  }
+  return planEntryFromUpdate({
+    createdAt,
+    id: `plan:${params.turnId}`,
+    ...(explanation ? { explanation } : {}),
+    steps,
+    turnId: params.turnId,
+  });
+}
+
+function reviewArtifactForBackendEvent(
+  event: AgentEvent,
+  createdAt: number,
+): AppServerThreadReviewEntry | undefined {
+  if (event.notification.method !== "item/completed") {
+    return undefined;
+  }
+  const params = event.notification.params as {
+    item?: unknown;
+    turnId?: unknown;
+  };
+  if (!params.item || typeof params.item !== "object") {
+    return undefined;
+  }
+  const item = params.item as {
+    id?: unknown;
+    review?: unknown;
+    text?: unknown;
+    type?: unknown;
+  };
+  if (typeof item.id !== "string" || typeof item.type !== "string") {
+    return undefined;
+  }
+  const normalizedType = normalizeReviewItemType(item.type);
+  if (
+    normalizedType !== "exitedreviewmode" &&
+    normalizedType !== "review" &&
+    normalizedType !== "reviewartifact"
+  ) {
+    return undefined;
+  }
+  const review = (typeof item.review === "string" ? item.review.trim() : "") ||
+    (typeof item.text === "string" ? item.text.trim() : "");
+  if (!review) {
+    return undefined;
+  }
+  return {
+    type: "review",
+    id: item.id,
+    createdAt,
+    review,
+    displayText: "Code review completed",
+    ...(typeof params.turnId === "string"
+      ? {
+          turn: {
+            id: params.turnId,
+          },
+        }
+      : {}),
+  };
+}
+
+function isPlanStepStatus(value: unknown): value is AppServerThreadPlanEntry["steps"][number]["status"] {
+  return value === "pending" || value === "in_progress" || value === "completed";
+}
+
+function normalizeReviewItemType(type: string): string {
+  return type.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+function artifactTurnKey(
+  backend: AppServerBackendKind,
+  threadId: ThreadIdentifier,
+  turnId: string,
+): string {
+  return `${backend}:${threadId}:${turnId}`;
+}
+
 function turnIdForBackendEvent(event: AgentEvent): string | undefined {
   const params = event.notification.params as {
     turn?: { id?: unknown };
@@ -12552,6 +12742,16 @@ function isPermanentMessagingTargetFailure(result: MessagingDeliveryResult): boo
         /\bUnknown Channel\b|chat not found|message thread not found/i,
       ),
     )
+  );
+}
+
+function shouldRetryArtifactInline(
+  intent: MessagingArtifactMessageIntent,
+  result: MessagingDeliveryResult,
+): boolean {
+  return (
+    intent.artifactDelivery.mode === "attachment_summary" &&
+    (result.outcome === "failed" || result.outcome === "unsupported")
   );
 }
 

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -120,6 +120,10 @@ import {
   type MessagingArtifact,
   type MessagingArtifactMessageIntent,
 } from "./messaging-artifact-renderer.js";
+import {
+  artifactFromMarkdownFileSelection,
+  MessagingMarkdownFileAttachmentSelector,
+} from "./messaging-markdown-file-attachment-selector.js";
 import { buildMessagingAuditContext } from "./messaging-audit.js";
 import { getMainLogger } from "../../log.js";
 import { DeterministicInteractionMapper } from "./deterministic-interaction-mapper.js";
@@ -571,6 +575,8 @@ export class MessagingController {
   private readonly activeTurnsByThreadKey = new Map<string, MessagingActiveTurnSummary>();
   private readonly contextUsageSummariesByThreadKey = new Map<string, string>();
   private readonly planArtifactsByTurnKey = new Map<string, AppServerThreadPlanEntry>();
+  private readonly markdownFileAttachmentSelector =
+    new MessagingMarkdownFileAttachmentSelector();
   private readonly typingActivityLastSignaledAt = new Map<string, number>();
   private readonly logger: MessagingControllerLogger;
   private readonly streamingResponsesDefault: boolean;
@@ -860,6 +866,8 @@ export class MessagingController {
       );
     }
     const reviewArtifact = reviewArtifactForBackendEvent(event, this.now());
+    const markdownFileArtifactSelection =
+      this.markdownFileAttachmentSelector.selectFromBackendEvent(event);
     const lifecycle = turnLifecycleForBackendEvent(event, this.now());
     const completedPlan = lifecycle && isTerminalTurnLifecycle(lifecycle)
       ? this.planArtifactsByTurnKey.get(artifactTurnKey(event.backend, threadId, lifecycle.turnId))
@@ -972,6 +980,14 @@ export class MessagingController {
           artifact: artifactFromReviewEntry(reviewArtifact),
           binding,
           intentId: `artifact:review:${reviewArtifact.id}:${binding.id}`,
+        });
+      }
+
+      if (markdownFileArtifactSelection && !automationTurnEvent) {
+        await this.deliverArtifactForBinding({
+          artifact: artifactFromMarkdownFileSelection(markdownFileArtifactSelection),
+          binding,
+          intentId: `artifact:markdown-file:${markdownFileArtifactSelection.path}:${binding.id}`,
         });
       }
 

--- a/apps/desktop/src/main/messaging/core/messaging-markdown-file-attachment-selector.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-markdown-file-attachment-selector.ts
@@ -1,0 +1,267 @@
+import path from "node:path";
+import type { AgentEvent } from "@pwragent/shared";
+import type { MessagingArtifact } from "./messaging-artifact-renderer.js";
+
+const DEFAULT_MAX_MARKDOWN_FILE_BYTES = 50 * 1024;
+const DEFAULT_MAX_PREVIEW_CHARS = 1_000;
+const DEFAULT_MAX_PREVIEW_LINES = 20;
+
+export type MessagingMarkdownFileAttachmentSelection = {
+  attachmentName: string;
+  markdown: string;
+  path: string;
+  previewMarkdown: string;
+  previewTruncated: boolean;
+  sizeBytes: number;
+};
+
+export type MessagingMarkdownFileAttachmentSelectorOptions = {
+  maxBytes?: number;
+  maxPreviewChars?: number;
+  maxPreviewLines?: number;
+};
+
+type PreviewSelection = {
+  text: string;
+  truncated: boolean;
+};
+
+export class MessagingMarkdownFileAttachmentSelector {
+  private readonly maxBytes: number;
+  private readonly maxPreviewChars: number;
+  private readonly maxPreviewLines: number;
+
+  constructor(options: MessagingMarkdownFileAttachmentSelectorOptions = {}) {
+    this.maxBytes = options.maxBytes ?? DEFAULT_MAX_MARKDOWN_FILE_BYTES;
+    this.maxPreviewChars = options.maxPreviewChars ?? DEFAULT_MAX_PREVIEW_CHARS;
+    this.maxPreviewLines = options.maxPreviewLines ?? DEFAULT_MAX_PREVIEW_LINES;
+  }
+
+  selectFromBackendEvent(
+    event: AgentEvent,
+  ): MessagingMarkdownFileAttachmentSelection | undefined {
+    if (event.notification.method !== "item/completed") {
+      return undefined;
+    }
+    const params = event.notification.params as { item?: unknown };
+    return this.selectFromCompletedItem(params.item);
+  }
+
+  selectFromCompletedItem(
+    item: unknown,
+  ): MessagingMarkdownFileAttachmentSelection | undefined {
+    const itemRecord = readRecord(item);
+    if (!itemRecord) {
+      return undefined;
+    }
+    if (normalizeToken(readString(itemRecord, "type")) !== "filechange") {
+      return undefined;
+    }
+    if (readString(itemRecord, "status") === "failed" || itemRecord.success === false) {
+      return undefined;
+    }
+
+    const changes = Array.isArray(itemRecord.changes)
+      ? itemRecord.changes
+          .map((entry) => readRecord(entry))
+          .filter((entry): entry is Record<string, unknown> => Boolean(entry))
+      : [];
+    if (changes.length !== 1) {
+      return undefined;
+    }
+
+    const change = changes[0]!;
+    const changeKind = readRecord(change.kind);
+    if (normalizeFileChangeKind(changeKind ?? change) !== "add") {
+      return undefined;
+    }
+
+    const markdownPath = readString(change, "path");
+    if (!markdownPath || !isMarkdownFilePath(markdownPath)) {
+      return undefined;
+    }
+
+    const markdown = extractAddedMarkdown(change, changeKind);
+    if (markdown === undefined) {
+      return undefined;
+    }
+
+    const sizeBytes = new TextEncoder().encode(markdown).byteLength;
+    if (sizeBytes >= this.maxBytes) {
+      return undefined;
+    }
+
+    const preview = selectMarkdownPreview(markdown, {
+      maxChars: this.maxPreviewChars,
+      maxLines: this.maxPreviewLines,
+    });
+    return {
+      attachmentName: markdownAttachmentName(markdownPath),
+      markdown,
+      path: markdownPath,
+      previewMarkdown: preview.text,
+      previewTruncated: preview.truncated,
+      sizeBytes,
+    };
+  }
+}
+
+export function artifactFromMarkdownFileSelection(
+  selection: MessagingMarkdownFileAttachmentSelection,
+): MessagingArtifact {
+  return {
+    attachmentDescription: `Full Markdown file: ${selection.path}`,
+    attachmentName: selection.attachmentName,
+    kind: "markdown_file",
+    markdown: selection.markdown,
+    preferAttachment: true,
+    preserveMarkdown: true,
+    previewMarkdown: selection.previewMarkdown,
+    previewTruncated: selection.previewTruncated,
+    summary: `Added ${selection.path} (${formatByteSize(selection.sizeBytes)})`,
+    title: "Markdown file added",
+  };
+}
+
+export function selectMarkdownPreview(
+  markdown: string,
+  params: { maxChars: number; maxLines: number },
+): PreviewSelection {
+  const maxChars = Math.max(0, Math.trunc(params.maxChars));
+  const maxLines = Math.max(0, Math.trunc(params.maxLines));
+  if (markdown.length === 0 || maxChars === 0 || maxLines === 0) {
+    return {
+      text: "",
+      truncated: markdown.length > 0,
+    };
+  }
+
+  let index = 0;
+  let lines = 0;
+  while (index < markdown.length && index < maxChars && lines < maxLines) {
+    const nextNewline = markdown.indexOf("\n", index);
+    const lineEnd = nextNewline === -1 ? markdown.length : nextNewline + 1;
+    const nextIndex = Math.min(lineEnd, maxChars);
+    if (nextIndex <= index) {
+      break;
+    }
+    index = nextIndex;
+    if (nextNewline !== -1 && nextNewline + 1 <= nextIndex) {
+      lines += 1;
+    } else if (nextNewline === -1 || nextIndex < lineEnd) {
+      break;
+    }
+  }
+
+  if (index === 0 && markdown.length > 0) {
+    index = Math.min(markdown.length, maxChars);
+  }
+
+  return {
+    text: markdown.slice(0, index).trimEnd(),
+    truncated: index < markdown.length,
+  };
+}
+
+function extractAddedMarkdown(
+  change: Record<string, unknown>,
+  changeKind: Record<string, unknown> | undefined,
+): string | undefined {
+  const content =
+    readStringAllowEmpty(changeKind, "content") ??
+    readStringAllowEmpty(change, "content");
+  if (content !== undefined) {
+    return content;
+  }
+
+  const diff = readStringAllowEmpty(changeKind, "unified_diff") ??
+    readStringAllowEmpty(changeKind, "unifiedDiff") ??
+    readStringAllowEmpty(change, "diff") ??
+    readStringAllowEmpty(change, "patch") ??
+    readStringAllowEmpty(change, "unifiedDiff") ??
+    readStringAllowEmpty(change, "unified_diff");
+  if (diff === undefined) {
+    return undefined;
+  }
+  return looksLikeUnifiedDiff(diff) ? addedContentFromUnifiedDiff(diff) : diff;
+}
+
+function addedContentFromUnifiedDiff(diff: string): string {
+  const lines: string[] = [];
+  for (const line of diff.split("\n")) {
+    if (
+      line.startsWith("+++") ||
+      line.startsWith("diff --git ") ||
+      line.startsWith("index ") ||
+      line.startsWith("new file mode ") ||
+      line.startsWith("@@ ") ||
+      line.startsWith("\\")
+    ) {
+      continue;
+    }
+    if (line.startsWith("+")) {
+      lines.push(line.slice(1));
+    }
+  }
+  return lines.join("\n");
+}
+
+function looksLikeUnifiedDiff(text: string): boolean {
+  return /(^|\n)(diff --git |--- |\+\+\+ |@@ )/.test(text);
+}
+
+function normalizeFileChangeKind(
+  record: Record<string, unknown>,
+): "add" | "delete" | "update" {
+  const raw =
+    readString(record, "type") ??
+    readString(record, "kind");
+  const normalized = raw?.trim().toLowerCase();
+  return normalized === "add" || normalized === "delete" || normalized === "update"
+    ? normalized
+    : "update";
+}
+
+function isMarkdownFilePath(filePath: string): boolean {
+  return filePath.trim().toLowerCase().endsWith(".md");
+}
+
+function markdownAttachmentName(filePath: string): string {
+  const normalized = filePath.replace(/\\/g, "/");
+  const basename = path.posix.basename(normalized) || "artifact.md";
+  const safe = basename.replace(/[\x00-\x1f\x7f/\\]/g, "_").trim();
+  return safe.toLowerCase().endsWith(".md") ? safe : `${safe || "artifact"}.md`;
+}
+
+function readRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function readString(
+  record: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
+  const value = record?.[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function readStringAllowEmpty(
+  record: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
+  const value = record?.[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function normalizeToken(value: string | undefined): string {
+  return value?.toLowerCase().replace(/[^a-z0-9]/g, "") ?? "";
+}
+
+function formatByteSize(bytes: number): string {
+  if (bytes >= 1024) {
+    return `${Math.round(bytes / 1024)} KB`;
+  }
+  return `${bytes} B`;
+}

--- a/apps/desktop/src/main/messaging/core/messaging-status-card.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-status-card.ts
@@ -163,6 +163,7 @@ export function buildBindingStatusIntent(params: {
       `Model: ${model}`,
       reasoning ? `Reasoning: ${reasoning}` : undefined,
       supportsFastMode ? `Fast mode: ${fastMode ? "on" : "off"}` : undefined,
+      planDeliveryLine(params.capabilityProfile),
       `Permissions: ${permissionsLineLabel}`,
       `Tool updates: ${formatMessagingToolUpdateModeLabel(toolUpdateMode)}`,
       `Streaming: ${streamingLabel}`,
@@ -386,6 +387,14 @@ function formatRateLimitReset(resetAt: number | undefined): string | undefined {
 
 function formatWholeNumber(value: number): string {
   return Math.round(value).toLocaleString();
+}
+
+function planDeliveryLine(
+  capabilityProfile: MessagingCapabilityProfile | undefined,
+): string {
+  return capabilityProfile?.outboundAttachments?.supportsFileUpload
+    ? "Plan delivery: Markdown attachment + inline preview"
+    : "Plan delivery: inline preview";
 }
 
 function mentionRequiredLine(

--- a/docs/messaging-adapter-contract.md
+++ b/docs/messaging-adapter-contract.md
@@ -233,9 +233,9 @@ dimensions:
 - **inboundAttachments** — what we accept from the user (size caps, count
   caps, download support).
 - **outboundAttachments** — what we can deliver to the user (file upload size,
-  image upload, remote URL support). Reserved for the forthcoming Plan/Review
-  surface delivery (see the plan-review attachment delivery plan in
-  `docs/plans/`).
+  image upload, remote URL support). Plan/Review artifact producers read this
+  to choose between inline-only text and inline preview plus Markdown
+  attachment.
 
 Existing examples in the tree:
 

--- a/docs/messaging-architecture.md
+++ b/docs/messaging-architecture.md
@@ -196,7 +196,7 @@ type MessagingCapabilityProfile = {
     supportsMessageEdit: boolean;
   };
   inboundAttachments?: { /* user-upload limits */ };
-  outboundAttachments?: { /* file-delivery limits — see Plan/Review delivery issue */ };
+  outboundAttachments?: { /* file-delivery limits for artifacts and media */ };
 };
 ```
 
@@ -437,5 +437,5 @@ The full hands-on walkthrough — including a capability-profile workshop, the i
 - [`docs/messaging-adapter-contract.md`](messaging-adapter-contract.md) — the formal contract for new platform adapters
 - [`packages/messaging/AGENTS.md`](../packages/messaging/AGENTS.md) — package boundary rules and enforcement
 - [`docs/plans/2026-05-04-002-feat-messaging-capability-discovery-plan.md`](plans/2026-05-04-002-feat-messaging-capability-discovery-plan.md) — the design plan that introduced the capability profile system
-- [`docs/plans/2026-05-05-002-feat-messaging-plan-review-attachment-delivery-plan.md`](plans/2026-05-05-002-feat-messaging-plan-review-attachment-delivery-plan.md) — planned consumer of `outboundAttachments` for plan/review surface delivery
+- [`docs/plans/2026-05-05-002-feat-messaging-plan-review-attachment-delivery-plan.md`](plans/2026-05-05-002-feat-messaging-plan-review-attachment-delivery-plan.md) — decision artifact for `outboundAttachments` consumption by plan/review surface delivery
 - [`docs/plans/2026-05-06-001-feat-messaging-mattermost-adapter-and-provider-guide-plan.md`](plans/2026-05-06-001-feat-messaging-mattermost-adapter-and-provider-guide-plan.md) — the Mattermost adapter implementation plan

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -1280,13 +1280,10 @@ export type MessagingAttachmentCapabilities = {
 /**
  * Outbound attachment capabilities — what we can deliver to the user.
  *
- * Reserved for forthcoming Plan/Review surface delivery: the agent's plan
- * artifact (and code-review artifact) is intended to ride out as a
- * Markdown file attachment with a truncated inline preview, mirroring the
- * pattern proven in openclaw-app-server (`buildCodexPlanMarkdownPreview` +
- * `formatCodexPlanAttachmentSummary` + `formatCodexPlanAttachmentFallback`).
- * Producers will read `supportsFileUpload` and `maxUploadBytes` to decide
- * between attachment-with-preview and inline-only fallback.
+ * Read by generic artifact producers such as Plan/Review surface delivery:
+ * the agent artifact can ride out as a Markdown file attachment with a
+ * truncated inline preview when the provider supports upload, or as an
+ * inline-only fallback for text-only providers and oversized artifacts.
  *
  * Tracked in: docs/plans/2026-05-05-002-feat-messaging-plan-review-attachment-delivery-plan.md
  */
@@ -1315,8 +1312,8 @@ export type MessagingCapabilityProfile = {
   /** Inbound attachment limits — read by the desktop attachment processor. */
   inboundAttachments?: MessagingAttachmentCapabilities;
   /**
-   * Outbound attachment limits — reserved for Plan/Review surface delivery.
-   * See `MessagingOutboundAttachmentCapabilities` for the planned consumer.
+   * Outbound attachment limits — read by Plan/Review artifact producers and
+   * any future generic surfaces that can choose between file upload and text.
    */
   outboundAttachments?: MessagingOutboundAttachmentCapabilities;
 };

--- a/packages/messaging/interface/src/testing.ts
+++ b/packages/messaging/interface/src/testing.ts
@@ -34,4 +34,10 @@ export const PERMISSIVE_CAPABILITY_PROFILE: MessagingCapabilityProfile = {
     supportsInlineCode: true,
     supportsMessageEdit: true,
   },
+  outboundAttachments: {
+    maxUploadBytes: 100 * 1024 * 1024,
+    supportsFileUpload: true,
+    supportsImageUpload: true,
+    supportsRemoteImageUrl: true,
+  },
 };

--- a/packages/messaging/providers/mattermost/src/__tests__/mattermost-adapter.test.ts
+++ b/packages/messaging/providers/mattermost/src/__tests__/mattermost-adapter.test.ts
@@ -96,6 +96,8 @@ function fakeClient4(spies: {
     root_id?: string;
     create_at: number;
   }>;
+  uploadFile?: (formData: FormData) => Promise<{ file_infos?: Array<{ id?: string }> }>;
+  uploadedFiles?: FormData[];
 }): Client4 {
   return {
     setUrl: () => {},
@@ -117,6 +119,13 @@ function fakeClient4(spies: {
       ),
       order: (spies.postsSinceResults ?? []).map((p) => p.id),
     }),
+    uploadFile: async (formData: FormData) => {
+      spies.uploadedFiles?.push(formData);
+      if (spies.uploadFile) {
+        return await spies.uploadFile(formData);
+      }
+      return { file_infos: [{ id: `file-${(spies.uploadedFiles?.length ?? 1)}` }] };
+    },
     // Stubs sufficient for `adapter.start()` to complete without
     // throwing — slash-command reconciliation runs against an empty
     // team list, the WS init is no-op'd by the websocket fake.
@@ -372,6 +381,8 @@ describe("MattermostAdapter — outbound deliver", () => {
   function makeAdapter(spies: {
     createdPosts: CreatedPost[];
     patchedPosts: PatchedPost[];
+    uploadFile?: (formData: FormData) => Promise<{ file_infos?: Array<{ id?: string }> }>;
+    uploadedFiles?: FormData[];
   }) {
     return new MattermostAdapter({
       callbackHandleStore: fakeStore,
@@ -461,6 +472,45 @@ describe("MattermostAdapter — outbound deliver", () => {
 
     expect(spies.createdPosts[0].channel_id).toBe("channel-id");
     expect(spies.createdPosts[0].root_id).toBe("root-post-id");
+  });
+
+  it("fails artifact delivery when file upload returns no file id", async () => {
+    const spies = {
+      createdPosts: [] as CreatedPost[],
+      patchedPosts: [] as PatchedPost[],
+      uploadedFiles: [] as FormData[],
+      uploadFile: async () => ({ file_infos: [] }),
+    };
+    const adapter = makeAdapter(spies);
+
+    const result = await adapter.deliver({
+      id: "artifact-1",
+      kind: "message",
+      artifactDelivery: {
+        kind: "plan",
+        mode: "attachment_summary",
+      },
+      createdAt: 1_700_000_000_000,
+      parts: [
+        { type: "text", text: "Open the attachment for the full artifact." },
+        {
+          type: "file",
+          name: "plan.md",
+          data: new TextEncoder().encode("# Plan\n\nFull content"),
+          mimeType: "text/markdown",
+          sizeBytes: 20,
+        },
+      ],
+      audit: {
+        channel: dmChannel("dm-1"),
+        actor: { platformUserId: "user-1" },
+      },
+    } as unknown as MessagingSurfaceIntent);
+
+    expect(result.outcome).toBe("failed");
+    expect(result.errorMessage).toContain("uploaded 0/1 artifact files");
+    expect(spies.uploadedFiles).toHaveLength(1);
+    expect(spies.createdPosts).toHaveLength(0);
   });
 
   it("clears attachments on patchPost when delivery.replaceMarkup is true and intent has no buttons", async () => {

--- a/packages/messaging/providers/mattermost/src/mattermost-adapter.ts
+++ b/packages/messaging/providers/mattermost/src/mattermost-adapter.ts
@@ -2282,12 +2282,16 @@ export class MattermostAdapter implements MattermostProviderAdapter {
     if (fileParts.length === 0) {
       return [];
     }
+    const requiresAllFiles = isArtifactFileDelivery(params.intent);
     const maxBytes =
       this.capabilityProfile.outboundAttachments?.maxUploadBytes ?? Infinity;
     const ids: string[] = [];
     for (const part of fileParts) {
       try {
         if (!part.data && !part.url) {
+          if (requiresAllFiles) {
+            throw new Error(`artifact file ${part.name} has no upload data`);
+          }
           continue;
         }
         const bytes = part.data ?? (await fetchRemoteBytes(part.url!));
@@ -2297,6 +2301,11 @@ export class MattermostAdapter implements MattermostProviderAdapter {
             sizeBytes: bytes.byteLength,
             maxBytes,
           });
+          if (requiresAllFiles) {
+            throw new Error(
+              `artifact file ${part.name} exceeds Mattermost upload size cap`,
+            );
+          }
           continue;
         }
         const formData = new FormData();
@@ -2322,7 +2331,15 @@ export class MattermostAdapter implements MattermostProviderAdapter {
           name: part.name,
           error: error instanceof Error ? error.message : String(error),
         });
+        if (requiresAllFiles) {
+          throw error;
+        }
       }
+    }
+    if (requiresAllFiles && ids.length !== fileParts.length) {
+      throw new Error(
+        `Mattermost uploaded ${ids.length}/${fileParts.length} artifact files`,
+      );
     }
     return ids;
   }
@@ -2524,6 +2541,14 @@ export function summarizeThreadRoot(text: string): string {
   }
   // -1 to leave room for the ellipsis without overshooting `max`.
   return `${single.slice(0, max - 1)}…`;
+}
+
+function isArtifactFileDelivery(intent: MessagingSurfaceIntent): boolean {
+  return (
+    intent.kind === "message" &&
+    "artifactDelivery" in intent &&
+    intent.parts.some((part) => part.type === "file")
+  );
 }
 
 function parseEmbeddedPost(

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -480,7 +480,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
     },
     outboundAttachments: {
       maxUploadBytes: 50 * 1024 * 1024,
-      supportsFileUpload: false,
+      supportsFileUpload: true,
       supportsImageUpload: true,
       supportsRemoteImageUrl: true,
     },


### PR DESCRIPTION
## Summary

Replaces closed #602. Closes #193.

This adds a generic Markdown artifact delivery path for messaging providers. Plan/Review artifacts and small newly-added `.md` files now render through capability-driven intent generation instead of provider branches:

- short plan/review artifacts can send inline
- longer artifacts send a bounded inline preview plus a Markdown attachment when `outboundAttachments.supportsFileUpload` and `maxUploadBytes` allow it
- a single newly-added `.md` file under 50 KB is sent as a Markdown attachment with a preview capped at about 1,000 chars and 20 lines
- text-only providers and oversized artifacts get an inline fallback preview
- failed attachment delivery retries once as inline fallback

## Changes

- Adds `messaging-artifact-renderer` with shared artifact formatting, attachment selection, and inline fallback behavior.
- Caches `turn/plan/updated` by turn in `MessagingController` and delivers the artifact on terminal turn completion.
- Adds generic review artifact delivery for completed review items using the same renderer.
- Adds `MessagingMarkdownFileAttachmentSelector`, an isolated selector for exactly one added `.md` file under 50 KB, including bounded preview selection.
- Keeps automation turns quiet until their automation output/decision path posts.
- Replaces the status-card `Plan mode: unavailable` stub with capability-based plan delivery status.
- Marks Telegram as supporting outbound file upload, matching its existing `sendDocument` delivery path.
- Updates messaging capability docs now that `outboundAttachments` has producer consumers.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/messaging-markdown-file-attachment-selector.test.ts apps/desktop/src/main/__tests__/messaging-artifact-renderer.test.ts apps/desktop/src/main/__tests__/messaging-controller.test.ts apps/desktop/src/main/__tests__/messaging-status-card.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`

## Notes

Manual real-bot validation for Discord and Telegram attachment delivery is still worth doing before considering #193 fully closed.