### PR TITLE
fix(messaging): record outbound activity summaries

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-activity-log.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-activity-log.test.ts
@@ -106,9 +106,24 @@ describe("MessagingActivityLog", () => {
   });
 
   it("returns events newest-first by id", () => {
-    log.record({ platform: "telegram", kind: "outbound", summary: "first", createdAt: 1 });
-    log.record({ platform: "telegram", kind: "outbound", summary: "second", createdAt: 2 });
-    log.record({ platform: "telegram", kind: "outbound", summary: "third", createdAt: 3 });
+    log.record({
+      platform: "telegram",
+      kind: "diagnostic",
+      summary: "first",
+      createdAt: 1,
+    });
+    log.record({
+      platform: "telegram",
+      kind: "diagnostic",
+      summary: "second",
+      createdAt: 2,
+    });
+    log.record({
+      platform: "telegram",
+      kind: "diagnostic",
+      summary: "third",
+      createdAt: 3,
+    });
     expect(log.list().map((entry) => entry.summary)).toEqual([
       "third",
       "second",
@@ -119,12 +134,12 @@ describe("MessagingActivityLog", () => {
   it("respects sinceId for incremental polling", () => {
     const first = log.record({
       platform: "telegram",
-      kind: "outbound",
+      kind: "diagnostic",
       summary: "old",
     });
     const second = log.record({
       platform: "telegram",
-      kind: "outbound",
+      kind: "diagnostic",
       summary: "new",
     });
 
@@ -134,6 +149,29 @@ describe("MessagingActivityLog", () => {
     ]);
   });
 
+  it("keeps outbound response freshness out of the activity feed", () => {
+    log.record({
+      platform: "telegram",
+      kind: "outbound",
+      summary: "legacy visible outbound row",
+      createdAt: 1_500,
+    });
+    log.recordPlatformResponseActivity({
+      platform: "telegram",
+      createdAt: 2_000,
+    });
+
+    expect(log.list()).toEqual([]);
+    expect(log.getPlatformActivitySummary()).toEqual({
+      summaries: [
+        expect.objectContaining({
+          platform: "telegram",
+          lastResponseAt: 2_000,
+        }),
+      ],
+    });
+  });
+
   it("summarizes latest request and response timestamps by platform", () => {
     log.record({
       platform: "telegram",
@@ -141,10 +179,8 @@ describe("MessagingActivityLog", () => {
       summary: "telegram request",
       createdAt: 1_000,
     });
-    log.record({
+    log.recordPlatformResponseActivity({
       platform: "telegram",
-      kind: "outbound",
-      summary: "telegram response",
       createdAt: 2_000,
     });
     log.record({
@@ -153,10 +189,8 @@ describe("MessagingActivityLog", () => {
       summary: "newer telegram request",
       createdAt: 3_000,
     });
-    log.record({
+    log.recordPlatformResponseActivity({
       platform: "discord",
-      kind: "outbound",
-      summary: "discord response",
       createdAt: 4_000,
     });
     log.record({
@@ -185,7 +219,7 @@ describe("MessagingActivityLog", () => {
     for (let i = 0; i < 10; i += 1) {
       log.record({
         platform: "telegram",
-        kind: "outbound",
+        kind: "diagnostic",
         summary: `event-${i}`,
       });
     }
@@ -195,8 +229,8 @@ describe("MessagingActivityLog", () => {
 
   it("evicts to the per-platform cap on cleanupExpired", () => {
     for (let i = 0; i < 7; i += 1) {
-      log.record({ platform: "telegram", kind: "outbound", summary: `t-${i}` });
-      log.record({ platform: "discord", kind: "outbound", summary: `d-${i}` });
+      log.record({ platform: "telegram", kind: "diagnostic", summary: `t-${i}` });
+      log.record({ platform: "discord", kind: "diagnostic", summary: `d-${i}` });
     }
     // Synthetic small cap via cleanupExpired uses the file-level cap (500).
     // Verify that calling cleanup is a no-op below the cap.

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -5619,10 +5619,16 @@ describe("MessagingController", () => {
 
   it("coalesces assistant stream deltas and flushes the final turn text", async () => {
     let now = 1000;
+    const recordPlatformResponseActivity = vi.fn();
     const harness = await createHarness({
+      activityLog: () => ({
+        record: vi.fn(),
+        recordPlatformResponseActivity,
+      } as unknown as ReturnType<NonNullable<MessagingControllerOptions["activityLog"]>>),
       now: () => now,
     });
     await bindThread(harness);
+    recordPlatformResponseActivity.mockClear();
     harness.delivered.length = 0;
 
     await harness.controller.handleBackendEvent({
@@ -5651,6 +5657,7 @@ describe("MessagingController", () => {
         }),
       }),
     ]);
+    expect(recordPlatformResponseActivity).not.toHaveBeenCalled();
     const firstStream = harness.delivered[0];
     if (firstStream?.kind !== "stream_update") {
       throw new Error("expected first stream update");
@@ -5701,6 +5708,7 @@ describe("MessagingController", () => {
         sequence: 3,
       },
     });
+    expect(recordPlatformResponseActivity).not.toHaveBeenCalled();
 
     now += 100;
     await harness.controller.handleBackendEvent({
@@ -5747,6 +5755,11 @@ describe("MessagingController", () => {
         key: firstStream.stream.key,
         sequence: 4,
       },
+    });
+    expect(recordPlatformResponseActivity).toHaveBeenCalledTimes(1);
+    expect(recordPlatformResponseActivity).toHaveBeenCalledWith({
+      platform: "telegram",
+      createdAt: 1000,
     });
     expect(harness.delivered.filter((intent) => intent.kind === "message")).toEqual([]);
   });
@@ -9833,6 +9846,7 @@ async function createHarness(options?: {
   channel?: MessagingChannelKind;
   capabilityProfile?: MessagingCapabilityProfile;
   fullAccessControls?: MessagingControllerOptions["fullAccessControls"];
+  activityLog?: MessagingControllerOptions["activityLog"];
   onFullAccessPolicyViolation?: MessagingControllerOptions["onFullAccessPolicyViolation"];
   onDeliveryBudgetEvent?: MessagingControllerOptions["onDeliveryBudgetEvent"];
   resolveDeliveryScope?: MessagingAdapter["resolveDeliveryScope"];
@@ -10208,6 +10222,7 @@ async function createHarness(options?: {
     backend,
     channel: options?.channel,
     deliveryBudget: options?.deliveryBudget,
+    activityLog: options?.activityLog,
     inputDebounceMs: options?.inputDebounceMs ?? 0,
     logger: options?.logger,
     now: options?.now ?? (() => 1000),

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -453,6 +453,28 @@ describe("DesktopMessagingRuntime", () => {
       kind: "status",
       status: "waiting",
     });
+
+    const { getDesktopMessagingActivityLog } = await import(
+      "../messaging/desktop-messaging-activity-log"
+    );
+    expect(getDesktopMessagingActivityLog().getPlatformActivitySummary()).toEqual({
+      summaries: [
+        expect.objectContaining({
+          platform: "telegram",
+          lastResponseAt: 1000,
+        }),
+      ],
+    });
+
+    const { getAppStateDb } = await import("../state/app-state");
+    const outboundRowCount = getAppStateDb().raw
+      .prepare(
+        `SELECT COUNT(*) AS count
+         FROM messaging_activity_log
+         WHERE kind = ?`,
+      )
+      .get("outbound") as { count: number };
+    expect(outboundRowCount.count).toBe(0);
   });
 
   it("does not route backend requests to adapters for bindings owned by another channel", async () => {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -53,7 +53,6 @@ import type {
   MessagingInboundTextEvent,
   MessagingAdapterState,
   MessagingJsonValue,
-  MessagingMessageIntent,
   MessagingManagedConversationActionResult,
   MessagingManagedConversationOperationSupport,
   MessagingManagedTopicRecord,
@@ -93,6 +92,7 @@ import type {
   MessagingBackendBridge,
   MessagingLastAssistantReply,
 } from "./messaging-adapter.js";
+import type { MessagingActivityLog } from "../messaging-activity-log.js";
 import {
   buildActivityIntent,
   buildApprovalIntent,
@@ -487,6 +487,7 @@ export type MessagingControllerOptions = {
   toolUpdateDefaultMode?: MessagingToolUpdateDefaultModeResolver;
   fullAccessControls?: MessagingFullAccessControlsResolver;
   deliveryBudget?: MessagingDeliveryBudget;
+  activityLog?: () => MessagingActivityLog;
   onDeliveryBudgetEvent?: (event: MessagingControllerDeliveryBudgetEvent) => void;
   onFullAccessPolicyViolation?: (event: {
     actorId: string;
@@ -9271,38 +9272,24 @@ export class MessagingController {
     binding: MessagingBindingRecord | undefined,
     result: MessagingDeliveryResult,
   ): void {
-    // Only log user-visible deliveries — status/typing/dismiss are
-    // every-tick noise and would drown the activity feed.
-    if (
-      intent.kind !== "message"
-      && intent.kind !== "approval"
-      && intent.kind !== "error"
-    ) {
+    // Only update provider-visible freshness. Typing activity, dismissals, and
+    // partial stream edits are control/noisy signals; the Activity window stays
+    // focused on operator-facing inbound, binding, pairing, and diagnostic rows.
+    if (!shouldRecordOutboundActivity(intent, result)) {
       return;
     }
     const channel = binding?.channel.channel ?? result.channel;
     if (!channel) return;
-    const conversation = binding?.channel.conversation;
-    const summary = describeOutboundIntent(intent);
     try {
-      this.desktopActivityLog().record({
+      const log = this.desktopActivityLog();
+      if (!log) return;
+      log.recordPlatformResponseActivity({
         platform: channel,
-        kind: "outbound",
-        backend: binding?.backend,
-        threadId: binding?.threadId,
-        bindingId: binding?.id,
-        conversationId: conversation?.id,
-        conversationTitle: conversation?.title,
-        summary,
-        payload: {
-          intentId: intent.id,
-          intentKind: intent.kind,
-          outcome: result.outcome,
-        },
+        createdAt: result.deliveredAt,
       });
     } catch {
       // Activity log is best-effort observability; never break delivery
-      // because the log threw.
+      // because the summary write threw.
     }
   }
 
@@ -9314,6 +9301,7 @@ export class MessagingController {
     try {
       const conversation = binding.channel.conversation;
       const log = this.desktopActivityLog();
+      if (!log) return;
       log.record({
         platform: binding.channel.channel,
         kind: "binding",
@@ -9337,15 +9325,8 @@ export class MessagingController {
     }
   }
 
-  private desktopActivityLog(): import("../messaging-activity-log").MessagingActivityLog {
-    // Lazy import keeps the controller free of a top-level dep on the
-    // desktop activity-log singleton (the controller is shared with
-    // other harnesses).
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    return (require(
-      "../desktop-messaging-activity-log",
-    ) as typeof import("../desktop-messaging-activity-log"))
-      .getDesktopMessagingActivityLog();
+  private desktopActivityLog(): MessagingActivityLog | undefined {
+    return this.options.activityLog?.();
   }
 
   private async deliver(
@@ -11289,6 +11270,24 @@ function isVisibleAssistantStreamDelivery(result: MessagingDeliveryResult): bool
   );
 }
 
+function shouldRecordOutboundActivity(
+  intent: MessagingSurfaceIntent,
+  result: MessagingDeliveryResult,
+): boolean {
+  if (
+    result.outcome === "discarded" ||
+    result.outcome === "failed" ||
+    result.outcome === "unsupported" ||
+    result.outcome === "dismissed"
+  ) {
+    return false;
+  }
+  if (intent.kind === "stream_update" && !intent.stream.isFinal) {
+    return false;
+  }
+  return intent.kind !== "activity" && intent.kind !== "dismiss";
+}
+
 function assistantMessageDeliveryKey(
   event: AgentEvent,
   binding: MessagingBindingRecord,
@@ -11785,18 +11784,6 @@ function readAcpRuntimeOptionSource(
   return source === "mode" || source === "configOption" || source === "model"
     ? source
     : undefined;
-}
-
-function describeOutboundIntent(intent: MessagingSurfaceIntent): string {
-  if (intent.kind === "message") {
-    const role = (intent as MessagingMessageIntent).role ?? "assistant";
-    return role === "assistant"
-      ? "Sent assistant reply"
-      : `Sent ${role} message`;
-  }
-  if (intent.kind === "approval") return "Sent approval request";
-  if (intent.kind === "error") return "Sent error notice";
-  return `Sent ${intent.kind}`;
 }
 
 function messagingAdapterStateEqual(

--- a/apps/desktop/src/main/messaging/messaging-activity-log.ts
+++ b/apps/desktop/src/main/messaging/messaging-activity-log.ts
@@ -31,6 +31,11 @@ export type RecordMessagingActivityInput = {
   payload?: Record<string, unknown>;
 };
 
+export type RecordMessagingPlatformResponseActivityInput = {
+  platform: MessagingChannelKind;
+  createdAt?: number;
+};
+
 /**
  * Persisted messaging activity log. Rows live in the same sqlite DB as
  * other desktop state; per-platform FIFO eviction happens in
@@ -81,6 +86,28 @@ export class MessagingActivityLog {
     };
   }
 
+  recordPlatformResponseActivity(
+    entry: RecordMessagingPlatformResponseActivityInput,
+  ): void {
+    const createdAt = entry.createdAt ?? Date.now();
+    this.stateDb.raw
+      .prepare(
+        `INSERT INTO messaging_activity_summary(
+           platform, last_response_at, updated_at
+         ) VALUES (?, ?, ?)
+         ON CONFLICT(platform) DO UPDATE SET
+           last_response_at = MAX(
+             COALESCE(messaging_activity_summary.last_response_at, 0),
+             excluded.last_response_at
+           ),
+           updated_at = MAX(
+             messaging_activity_summary.updated_at,
+             excluded.updated_at
+           )`,
+      )
+      .run(entry.platform, createdAt, createdAt);
+  }
+
   list(params: {
     limit?: number;
     sinceId?: number;
@@ -96,7 +123,7 @@ export class MessagingActivityLog {
                     conversation_title, actor_id, actor_display_name, summary,
                     created_at, payload
              FROM messaging_activity_log
-             WHERE id > ?
+             WHERE id > ? AND kind <> 'outbound'
              ORDER BY id DESC
              LIMIT ?`,
           )
@@ -107,6 +134,7 @@ export class MessagingActivityLog {
                     conversation_title, actor_id, actor_display_name, summary,
                     created_at, payload
              FROM messaging_activity_log
+             WHERE kind <> 'outbound'
              ORDER BY id DESC
              LIMIT ?`,
           )
@@ -118,22 +146,45 @@ export class MessagingActivityLog {
     const rows = this.stateDb.raw
       .prepare(
         `SELECT
-           platform,
-           MAX(
-             CASE
-               WHEN kind IN ('inbound-routed', 'inbound-rejected', 'inbound-ignored')
-               THEN created_at
-             END
-           ) AS last_request_at,
-           MAX(
-             CASE
-               WHEN kind = 'outbound'
-               THEN created_at
-             END
-           ) AS last_response_at
-         FROM messaging_activity_log
-         GROUP BY platform
-         HAVING last_request_at IS NOT NULL OR last_response_at IS NOT NULL`,
+           platforms.platform,
+           inbound.last_request_at,
+           outbound.last_response_at
+         FROM (
+           SELECT platform
+           FROM messaging_activity_log
+           WHERE kind IN ('inbound-routed', 'inbound-rejected', 'inbound-ignored')
+           UNION
+           SELECT platform
+           FROM messaging_activity_summary
+           WHERE last_response_at IS NOT NULL
+           UNION
+           SELECT platform
+           FROM messaging_activity_log
+           WHERE kind = 'outbound'
+         ) AS platforms
+         LEFT JOIN (
+           SELECT platform, MAX(created_at) AS last_request_at
+           FROM messaging_activity_log
+           WHERE kind IN ('inbound-routed', 'inbound-rejected', 'inbound-ignored')
+           GROUP BY platform
+         ) AS inbound
+           ON inbound.platform = platforms.platform
+         LEFT JOIN (
+           SELECT platform, MAX(last_response_at) AS last_response_at
+           FROM (
+             SELECT platform, last_response_at
+             FROM messaging_activity_summary
+             WHERE last_response_at IS NOT NULL
+             UNION ALL
+             SELECT platform, created_at AS last_response_at
+             FROM messaging_activity_log
+             WHERE kind = 'outbound'
+           )
+           GROUP BY platform
+         ) AS outbound
+           ON outbound.platform = platforms.platform
+         WHERE inbound.last_request_at IS NOT NULL
+            OR outbound.last_response_at IS NOT NULL`,
       )
       .all() as RawActivitySummaryRow[];
     return {

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -851,6 +851,7 @@ export class DesktopMessagingRuntime {
       deliveryBudget,
       inputDebounceMs: config.inputDebounceMs,
       store,
+      activityLog: getDesktopMessagingActivityLog,
       streamingResponsesDefault: streamingResponsesDefaultForChannel(
         config,
         adapter.channel,

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -4,7 +4,7 @@ import Database from "better-sqlite3";
 import type BetterSqlite3 from "better-sqlite3";
 import { getNativeBinding } from "./native-binding.js";
 
-export const CURRENT_STATE_DB_USER_VERSION = 11;
+export const CURRENT_STATE_DB_USER_VERSION = 12;
 
 const SCHEMA_V1 = `
 CREATE TABLE meta (
@@ -385,6 +385,15 @@ CREATE INDEX IF NOT EXISTS idx_automation_run_artifacts_automation_updated
   ON automation_run_artifacts(automation_id, updated_at DESC);
 `;
 
+const MESSAGING_ACTIVITY_SUMMARY_SCHEMA = `
+CREATE TABLE IF NOT EXISTS messaging_activity_summary (
+  platform         TEXT PRIMARY KEY,
+  last_request_at  INTEGER,
+  last_response_at INTEGER,
+  updated_at       INTEGER NOT NULL
+);
+`;
+
 const DELIVERIES_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 const REVOKED_BINDINGS_RETENTION_MS = 90 * 24 * 60 * 60 * 1000;
 const APP_RUNTIME_INSTANCE_RETENTION_MS = 60 * 60 * 1000;
@@ -496,6 +505,12 @@ export class StateDb {
     if ((db.pragma("user_version", { simple: true }) as number) < 11) {
       db.transaction(() => {
         db.exec(AUTOMATION_SCHEMA);
+        db.pragma("user_version = 11");
+      })();
+    }
+    if ((db.pragma("user_version", { simple: true }) as number) < 12) {
+      db.transaction(() => {
+        db.exec(MESSAGING_ACTIVITY_SUMMARY_SCHEMA);
         db.pragma(`user_version = ${CURRENT_STATE_DB_USER_VERSION}`);
       })();
     }
@@ -643,6 +658,7 @@ function ensureCurrentSchema(db: BetterSqlite3.Database): void {
     db.exec(ACP_AGENT_SCHEMA);
     db.exec(ACP_SESSION_SCHEMA);
     db.exec(AUTOMATION_SCHEMA);
+    db.exec(MESSAGING_ACTIVITY_SUMMARY_SCHEMA);
     if ((db.pragma("user_version", { simple: true }) as number) < 4) {
       db.pragma("user_version = 4");
     }


### PR DESCRIPTION
## Summary

The messaging popover can now report recent outbound provider activity instead of showing "Last response: none yet" while status updates are actively being sent. Outbound freshness is recorded through the generic controller delivery path, so Telegram, Discord, Slack, and the other providers all feed the same persisted activity summary.

I kept typing leases, dismiss control messages, and partial streaming edits out of the freshness signal. The full Messaging Activity window also stays focused on inbound, binding, pairing, and diagnostic rows instead of showing "Sent ..." outbound rows. The controller receives the desktop activity summary writer through runtime wiring instead of using a hidden lazy require path, which makes the behavior explicit and testable.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/messaging-runtime.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
