### PR TITLE
fix(desktop): show Kimi approval commands

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -418,6 +418,66 @@ describe("AcpAgentClient", () => {
     });
   });
 
+  it("extracts Kimi shell commands from nested ACP permission content", async () => {
+    const transport = new FakeAcpAgentTransport();
+    const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+    const client = new AcpAgentClient({
+      backendId: "acp:kimi",
+      agentDisplayName: "Kimi Code CLI",
+      store,
+      transport,
+      now: () => 1000,
+      onRequest: (request) => {
+        requests.push(request);
+        return { decision: "accept" };
+      },
+    });
+
+    await client.initialize();
+    const session = await client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+    });
+    client.startPrompt({
+      sessionId: session.sessionId,
+      prompt: "Check versions",
+      turnId: "turn-1",
+    });
+
+    await transport.emitRequest(
+      "session/request_permission",
+      {
+        sessionId: session.sessionId,
+        toolCall: {
+          toolCallId: "run_shell_command_1",
+          kind: "execute",
+          title: "Bash",
+          content: [
+            {
+              type: "content",
+              content: {
+                type: "text",
+                text: "{\"command\": \"node --version && pnpm --version\"}",
+              },
+            },
+          ],
+        },
+        options: [{ optionId: "proceed_once", kind: "allow_once" }],
+      },
+      0,
+    );
+
+    expect(requests[0]).toMatchObject({
+      method: "item/commandExecution/requestApproval",
+      params: {
+        prompt: "Kimi Code CLI wants to run execute: Bash",
+        reason: "Kimi Code CLI wants to run execute: Bash",
+        command: "node --version && pnpm --version",
+        displayCommand: "node --version && pnpm --version",
+      },
+    });
+  });
+
   it("captures ACP runtime modes and models from session setup", async () => {
     const runtimeEvents: unknown[] = [];
     const transport = new FakeAcpAgentTransport({

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -478,6 +478,59 @@ describe("AcpAgentClient", () => {
     });
   });
 
+  it("extracts Kimi shell commands from approval prompt text", async () => {
+    const transport = new FakeAcpAgentTransport();
+    const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+    const client = new AcpAgentClient({
+      backendId: "acp:kimi",
+      agentDisplayName: "Kimi Code CLI",
+      store,
+      transport,
+      now: () => 1000,
+      onRequest: (request) => {
+        requests.push(request);
+        return { decision: "accept" };
+      },
+    });
+
+    await client.initialize();
+    const session = await client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+    });
+
+    await transport.emitRequest(
+      "session/request_permission",
+      {
+        sessionId: session.sessionId,
+        toolCall: {
+          toolCallId: "run_shell_command_1",
+          kind: "execute",
+          title: "Bash",
+          content: [
+            {
+              type: "content",
+              content: {
+                type: "text",
+                text: "Requesting approval to Running: npm view pnpm",
+              },
+            },
+          ],
+        },
+        options: [{ optionId: "proceed_once", kind: "allow_once" }],
+      },
+      0,
+    );
+
+    expect(requests[0]).toMatchObject({
+      params: {
+        prompt: "Requesting approval to Running: npm view pnpm",
+        command: "npm view pnpm",
+        displayCommand: "npm view pnpm",
+      },
+    });
+  });
+
   it("captures ACP runtime modes and models from session setup", async () => {
     const runtimeEvents: unknown[] = [];
     const transport = new FakeAcpAgentTransport({

--- a/apps/desktop/src/main/__tests__/acp-live-notifications.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-live-notifications.test.ts
@@ -86,6 +86,46 @@ describe("acpToolUpdateNotifications", () => {
     ]);
   });
 
+  it("keeps non-shell ACP content with command fields as live output", () => {
+    const output = "{\"command\":\"npm view pnpm\",\"result\":\"found text\"}";
+    const notifications = acpToolUpdateNotifications({
+      threadId: "session-1",
+      turnId: "turn-1",
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "search-1",
+        kind: "search",
+        title: "Search package metadata",
+        status: "completed",
+        content: {
+          type: "text",
+          text: output,
+        },
+      },
+    });
+
+    expect(notifications).toEqual([
+      expect.objectContaining({
+        method: "item/completed",
+        params: expect.objectContaining({
+          item: expect.objectContaining({
+            id: "search-1",
+            command: "Search package metadata",
+            data: {
+              output,
+            },
+            commandActions: [
+              {
+                type: "search",
+                name: "Search package metadata",
+              },
+            ],
+          }),
+        }),
+      }),
+    ]);
+  });
+
   it("maps Kimi snake_case ACP tool updates to stable live item ids", () => {
     const notifications = acpToolUpdateNotifications({
       threadId: "session-1",

--- a/apps/desktop/src/main/__tests__/acp-live-notifications.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-live-notifications.test.ts
@@ -113,6 +113,37 @@ describe("acpToolUpdateNotifications", () => {
     ]);
   });
 
+  it("extracts Kimi shell commands from raw input and command JSON content", () => {
+    const notifications = acpToolUpdateNotifications({
+      threadId: "session-1",
+      turnId: "turn-1",
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "2:tool_FepVvUHmSL1YkNrQrdMD9alt",
+        kind: "execute",
+        title: "Bash",
+        status: "in_progress",
+        rawInput: { command: "npm view pnpm" },
+        content: [
+          {
+            type: "content",
+            content: {
+              type: "text",
+              text: "{\"command\":\"npm view pnpm\"}",
+            },
+          },
+        ],
+      },
+    });
+
+    const item = notifications[0]?.params.item as Record<string, unknown> | undefined;
+    expect(item).toMatchObject({
+      id: "2:tool_FepVvUHmSL1YkNrQrdMD9alt",
+      command: "npm view pnpm",
+    });
+    expect(item?.data).toBeUndefined();
+  });
+
   it("does not render ACP topic updates as live tool activity", () => {
     expect(
       acpToolUpdateNotifications({

--- a/apps/desktop/src/main/__tests__/acp-live-notifications.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-live-notifications.test.ts
@@ -136,7 +136,10 @@ describe("acpToolUpdateNotifications", () => {
       },
     });
 
-    const item = notifications[0]?.params.item as Record<string, unknown> | undefined;
+    const params = notifications[0]?.params as
+      | { item?: Record<string, unknown> }
+      | undefined;
+    const item = params?.item;
     expect(item).toMatchObject({
       id: "2:tool_FepVvUHmSL1YkNrQrdMD9alt",
       command: "npm view pnpm",

--- a/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
@@ -667,6 +667,53 @@ describe("AcpSessionReplayNormalizer", () => {
     ]);
   });
 
+  it("keeps non-shell ACP content with command fields as transcript output", () => {
+    const normalizer = new AcpSessionReplayNormalizer();
+    const output = "{\"command\":\"npm view pnpm\",\"result\":\"found text\"}";
+
+    const replay = normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1000,
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "read-file-1",
+        kind: "read",
+        title: "package.json",
+        status: "completed",
+        locations: [{ path: "/repo/package.json" }],
+        content: {
+          type: "text",
+          text: output,
+        },
+      },
+    });
+
+    expect(replay.entries).toEqual([
+      expect.objectContaining({
+        type: "activity",
+        id: "read-file-1",
+        summary: "package.json",
+        status: "completed",
+        details: [
+          expect.objectContaining({
+            kind: "read",
+            label: "package.json",
+            path: "/repo/package.json",
+            command: expect.objectContaining({
+              displayCommand: "package.json",
+              output,
+            }),
+          }),
+        ],
+      }),
+    ]);
+    const activity = replay.entries[0] as
+      | { details?: Array<{ command?: { rawCommand?: string } }> }
+      | undefined;
+    const detail = activity?.details?.[0];
+    expect(detail?.command?.rawCommand).toBeUndefined();
+  });
+
   it("extracts Kimi shell commands from raw input and command JSON content", () => {
     const normalizer = new AcpSessionReplayNormalizer();
 

--- a/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
@@ -667,6 +667,62 @@ describe("AcpSessionReplayNormalizer", () => {
     ]);
   });
 
+  it("extracts Kimi shell commands from raw input and command JSON content", () => {
+    const normalizer = new AcpSessionReplayNormalizer();
+
+    normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1000,
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "2:tool_FepVvUHmSL1YkNrQrdMD9alt",
+        kind: "execute",
+        title: "Bash",
+        status: "pending",
+      },
+    });
+    const replay = normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1001,
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "2:tool_FepVvUHmSL1YkNrQrdMD9alt",
+        kind: "execute",
+        title: "Bash",
+        status: "in_progress",
+        rawInput: { command: "npm view pnpm" },
+        content: [
+          {
+            type: "content",
+            content: {
+              type: "text",
+              text: "{\"command\":\"npm view pnpm\"}",
+            },
+          },
+        ],
+      },
+    });
+
+    expect(replay.entries).toEqual([
+      expect.objectContaining({
+        type: "activity",
+        id: "2:tool_FepVvUHmSL1YkNrQrdMD9alt",
+        summary: "npm view pnpm",
+        details: [
+          expect.objectContaining({
+            label: "npm view pnpm",
+            command: {
+              displayCommand: "npm view pnpm",
+              rawCommand: "npm view pnpm",
+              output: undefined,
+              exitCode: undefined,
+            },
+          }),
+        ],
+      }),
+    ]);
+  });
+
   it("ignores available command updates in transcripts", () => {
     const normalizer = new AcpSessionReplayNormalizer();
 

--- a/apps/desktop/src/main/__tests__/messaging-approval-renderer.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-approval-renderer.test.ts
@@ -36,6 +36,28 @@ describe("buildApprovalIntent", () => {
     expect(intent.body).toContain("```shell\npnpm test -- messaging-controller\n```");
   });
 
+  it("renders normalized Kimi shell approvals with the actual command", () => {
+    const intent = buildApprovalIntent({
+      id: "approval-kimi",
+      createdAt: 1000,
+      request: {
+        method: "item/commandExecution/requestApproval",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          requestId: "request-1",
+          prompt: "Kimi Code CLI wants to run Bash",
+          command: "node --version && pnpm --version",
+          displayCommand: "node --version && pnpm --version",
+        },
+      },
+    });
+
+    expect(intent.body).toContain("Kimi Code CLI wants to run Bash");
+    expect(intent.body).toContain("```shell\nnode --version && pnpm --version\n```");
+    expect(intent.body).not.toContain("```shell\nBash\n```");
+  });
+
   it("preserves backend-provided decision labels when they map to known decisions", () => {
     const intent = buildApprovalIntent({
       id: "approval-2",

--- a/apps/desktop/src/main/__tests__/messaging-approval-renderer.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-approval-renderer.test.ts
@@ -58,6 +58,27 @@ describe("buildApprovalIntent", () => {
     expect(intent.body).not.toContain("```shell\nBash\n```");
   });
 
+  it("derives Kimi approval commands from prompt text when command is a shell title", () => {
+    const intent = buildApprovalIntent({
+      id: "approval-kimi-running",
+      createdAt: 1000,
+      request: {
+        method: "item/commandExecution/requestApproval",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          requestId: "request-1",
+          prompt: "Requesting approval to Running: npm view pnpm",
+          command: "Bash",
+        },
+      },
+    });
+
+    expect(intent.body).toContain("Requesting approval to Running: npm view pnpm");
+    expect(intent.body).toContain("```shell\nnpm view pnpm\n```");
+    expect(intent.body).not.toContain("```shell\nBash\n```");
+  });
+
   it("preserves backend-provided decision labels when they map to known decisions", () => {
     const intent = buildApprovalIntent({
       id: "approval-2",

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -24,8 +24,8 @@ import {
   normalizeAcpRuntimeCapabilities,
 } from "./acp-runtime-capabilities.js";
 import {
-  extractCommandFromText,
   readAcpToolCommand,
+  readAcpToolContentCommand,
   readAcpToolText,
 } from "./acp-command-extraction.js";
 import type {
@@ -1225,7 +1225,7 @@ function permissionPrompt(
   const contentText = readToolCallText(toolCall.content);
   if (
     contentText &&
-    (!extractCommandFromText(contentText) || isApprovalPromptText(contentText))
+    (!readAcpToolContentCommand(toolCall) || isApprovalPromptText(contentText))
   ) {
     return contentText;
   }

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -23,6 +23,11 @@ import {
   acpSessionRuntimeStateFromUpdate,
   normalizeAcpRuntimeCapabilities,
 } from "./acp-runtime-capabilities.js";
+import {
+  extractCommandFromText,
+  readAcpToolCommand,
+  readAcpToolText,
+} from "./acp-command-extraction.js";
 import type {
   AcpSessionMetadata,
   AcpSessionStore,
@@ -1218,7 +1223,10 @@ function permissionPrompt(
   toolCall: Record<string, unknown>,
 ): string {
   const contentText = readToolCallText(toolCall.content);
-  if (contentText && !extractCommandFromText(contentText)) {
+  if (
+    contentText &&
+    (!extractCommandFromText(contentText) || isApprovalPromptText(contentText))
+  ) {
     return contentText;
   }
   const kind = typeof toolCall.kind === "string" ? toolCall.kind : undefined;
@@ -1227,84 +1235,19 @@ function permissionPrompt(
     : `${requesterName} wants to run ${title}`;
 }
 
+function isApprovalPromptText(text: string): boolean {
+  return /^Requesting approval to Running:\s*/imu.test(text);
+}
+
 function readToolCallText(value: unknown): string | undefined {
-  return readAcpContentText(value)?.trim() || undefined;
+  return readAcpToolText(value);
 }
 
 function permissionCommand(
   title: string,
   toolCall: Record<string, unknown>,
 ): string {
-  return (
-    readDirectToolCommand(toolCall) ??
-    extractCommandFromText(readToolCallText(toolCall.content)) ??
-    title
-  );
-}
-
-function readDirectToolCommand(
-  toolCall: Record<string, unknown>,
-): string | undefined {
-  for (const key of [
-    "command",
-    "cmd",
-    "displayCommand",
-    "shellCommand",
-    "commandText",
-  ]) {
-    const value = toolCall[key];
-    if (typeof value === "string" && value.trim()) {
-      return value.trim();
-    }
-  }
-  return undefined;
-}
-
-function extractCommandFromText(text: string | undefined): string | undefined {
-  if (!text) {
-    return undefined;
-  }
-  const trimmed = text.trim();
-  const parsedCommand = extractCommandFromJsonText(trimmed);
-  if (parsedCommand) {
-    return parsedCommand;
-  }
-  const match = /"command"\s*:\s*"((?:\\.|[^"\\])*)"/.exec(trimmed);
-  if (!match?.[1]) {
-    return undefined;
-  }
-  try {
-    return JSON.parse(`"${match[1]}"`);
-  } catch {
-    return (
-      match[1].replace(/\\"/g, '"').replace(/\\\\/g, "\\").trim() || undefined
-    );
-  }
-}
-
-function extractCommandFromJsonText(text: string): string | undefined {
-  try {
-    const parsed = JSON.parse(text) as unknown;
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-      return undefined;
-    }
-    const record = parsed as Record<string, unknown>;
-    for (const key of [
-      "command",
-      "cmd",
-      "displayCommand",
-      "shellCommand",
-      "commandText",
-    ]) {
-      const value = record[key];
-      if (typeof value === "string" && value.trim()) {
-        return value.trim();
-      }
-    }
-  } catch {
-    return undefined;
-  }
-  return undefined;
+  return readAcpToolCommand(toolCall) ?? title;
 }
 
 function permissionOutcomeFromResponse(

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -696,6 +696,7 @@ export class AcpAgentClient {
           : undefined;
     const requestId = id == null ? toolCallId ?? `acp:${this.now()}` : String(id);
     const activeTurn = this.activeTurns.get(sessionId);
+    const command = permissionCommand(title, toolCall);
 
     return {
       method: "item/commandExecution/requestApproval",
@@ -705,8 +706,8 @@ export class AcpAgentClient {
         requestId,
         prompt: permissionPrompt(this.approvalRequesterName, title, toolCall),
         reason: permissionPrompt(this.approvalRequesterName, title, toolCall),
-        command: title,
-        displayCommand: title,
+        command,
+        displayCommand: command,
         acpMethod: "session/request_permission",
         acpToolCallId: toolCallId,
         acpToolKind: typeof toolCall.kind === "string" ? toolCall.kind : undefined,
@@ -1217,7 +1218,7 @@ function permissionPrompt(
   toolCall: Record<string, unknown>,
 ): string {
   const contentText = readToolCallText(toolCall.content);
-  if (contentText) {
+  if (contentText && !extractCommandFromText(contentText)) {
     return contentText;
   }
   const kind = typeof toolCall.kind === "string" ? toolCall.kind : undefined;
@@ -1227,19 +1228,83 @@ function permissionPrompt(
 }
 
 function readToolCallText(value: unknown): string | undefined {
-  if (!Array.isArray(value)) {
+  return readAcpContentText(value)?.trim() || undefined;
+}
+
+function permissionCommand(
+  title: string,
+  toolCall: Record<string, unknown>,
+): string {
+  return (
+    readDirectToolCommand(toolCall) ??
+    extractCommandFromText(readToolCallText(toolCall.content)) ??
+    title
+  );
+}
+
+function readDirectToolCommand(
+  toolCall: Record<string, unknown>,
+): string | undefined {
+  for (const key of [
+    "command",
+    "cmd",
+    "displayCommand",
+    "shellCommand",
+    "commandText",
+  ]) {
+    const value = toolCall[key];
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+function extractCommandFromText(text: string | undefined): string | undefined {
+  if (!text) {
     return undefined;
   }
-  const text = value
-    .flatMap((item) => {
-      const record = asRecord(item);
-      return record?.type === "text" && typeof record.text === "string"
-        ? [record.text.trim()]
-        : [];
-    })
-    .filter(Boolean)
-    .join("\n\n");
-  return text || undefined;
+  const trimmed = text.trim();
+  const parsedCommand = extractCommandFromJsonText(trimmed);
+  if (parsedCommand) {
+    return parsedCommand;
+  }
+  const match = /"command"\s*:\s*"((?:\\.|[^"\\])*)"/.exec(trimmed);
+  if (!match?.[1]) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(`"${match[1]}"`);
+  } catch {
+    return (
+      match[1].replace(/\\"/g, '"').replace(/\\\\/g, "\\").trim() || undefined
+    );
+  }
+}
+
+function extractCommandFromJsonText(text: string): string | undefined {
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return undefined;
+    }
+    const record = parsed as Record<string, unknown>;
+    for (const key of [
+      "command",
+      "cmd",
+      "displayCommand",
+      "shellCommand",
+      "commandText",
+    ]) {
+      const value = record[key];
+      if (typeof value === "string" && value.trim()) {
+        return value.trim();
+      }
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
 }
 
 function permissionOutcomeFromResponse(

--- a/apps/desktop/src/main/acp/acp-command-extraction.ts
+++ b/apps/desktop/src/main/acp/acp-command-extraction.ts
@@ -4,8 +4,16 @@ export function readAcpToolCommand(
   return (
     readDirectCommand(record) ??
     readDirectCommand(asRecord(record.rawInput)) ??
-    extractCommandFromText(readAcpToolText(record.content))
+    readAcpToolContentCommand(record)
   );
+}
+
+export function readAcpToolContentCommand(
+  record: Record<string, unknown>,
+): string | undefined {
+  return isShellLikeAcpTool(record)
+    ? extractCommandFromText(readAcpToolText(record.content))
+    : undefined;
 }
 
 export function readAcpToolText(value: unknown): string | undefined {
@@ -63,6 +71,26 @@ export function isGenericShellToolTitle(value: string | undefined): boolean {
   return /^(?:bash|shell|sh|zsh|terminal|tool)$/i.test(value?.trim() ?? "");
 }
 
+function isShellLikeAcpTool(record: Record<string, unknown>): boolean {
+  return (
+    isShellLikeToolKind(readString(record, "kind")) ||
+    isShellLikeToolKind(readString(record, "toolKind")) ||
+    isShellLikeToolKind(readString(record, "toolName")) ||
+    isShellLikeToolKind(readString(record, "name")) ||
+    isShellToolTitle(readString(record, "title"))
+  );
+}
+
+function isShellLikeToolKind(value: string | undefined): boolean {
+  return /^(?:execute|exec|command|commandexecution|command_execution|shell|bash|sh|zsh|terminal)$/i.test(
+    value?.trim() ?? "",
+  );
+}
+
+function isShellToolTitle(value: string | undefined): boolean {
+  return /^(?:bash|shell|sh|zsh|terminal)$/i.test(value?.trim() ?? "");
+}
+
 function readDirectCommand(
   record: Record<string, unknown> | undefined,
 ): string | undefined {
@@ -82,6 +110,14 @@ function readDirectCommand(
     }
   }
   return undefined;
+}
+
+function readString(
+  record: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const value = record[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
 function extractCommandFromJsonText(text: string): string | undefined {

--- a/apps/desktop/src/main/acp/acp-command-extraction.ts
+++ b/apps/desktop/src/main/acp/acp-command-extraction.ts
@@ -1,0 +1,101 @@
+export function readAcpToolCommand(
+  record: Record<string, unknown>,
+): string | undefined {
+  return (
+    readDirectCommand(record) ??
+    readDirectCommand(asRecord(record.rawInput)) ??
+    extractCommandFromText(readAcpToolText(record.content))
+  );
+}
+
+export function readAcpToolText(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return value.trim() || undefined;
+  }
+
+  if (Array.isArray(value)) {
+    const parts = value
+      .map((item) => readAcpToolText(item))
+      .filter((item): item is string => Boolean(item));
+    return parts.length > 0 ? parts.join("\n").trim() : undefined;
+  }
+
+  const record = asRecord(value);
+  if (!record) {
+    return undefined;
+  }
+
+  return (
+    readAcpToolText(record.text) ??
+    readAcpToolText(record.content) ??
+    readAcpToolText(record.output) ??
+    readAcpToolText(record.result)
+  );
+}
+
+export function extractCommandFromText(text: string | undefined): string | undefined {
+  if (!text) {
+    return undefined;
+  }
+  const trimmed = text.trim();
+  const parsedCommand = extractCommandFromJsonText(trimmed);
+  if (parsedCommand) {
+    return parsedCommand;
+  }
+
+  const quotedMatch = /"command"\s*:\s*"((?:\\.|[^"\\])*)"/.exec(trimmed);
+  if (quotedMatch?.[1]) {
+    try {
+      return JSON.parse(`"${quotedMatch[1]}"`);
+    } catch {
+      return (
+        quotedMatch[1].replace(/\\"/g, '"').replace(/\\\\/g, "\\").trim() ||
+        undefined
+      );
+    }
+  }
+
+  const runningMatch = /^Requesting approval to Running:\s*(.+)$/imu.exec(trimmed);
+  return runningMatch?.[1]?.trim() || undefined;
+}
+
+export function isGenericShellToolTitle(value: string | undefined): boolean {
+  return /^(?:bash|shell|sh|zsh|terminal|tool)$/i.test(value?.trim() ?? "");
+}
+
+function readDirectCommand(
+  record: Record<string, unknown> | undefined,
+): string | undefined {
+  if (!record) {
+    return undefined;
+  }
+  for (const key of [
+    "command",
+    "cmd",
+    "displayCommand",
+    "shellCommand",
+    "commandText",
+  ]) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+function extractCommandFromJsonText(text: string): string | undefined {
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    const record = asRecord(parsed);
+    return readDirectCommand(record);
+  } catch {
+    return undefined;
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}

--- a/apps/desktop/src/main/acp/acp-live-notifications.ts
+++ b/apps/desktop/src/main/acp/acp-live-notifications.ts
@@ -1,9 +1,9 @@
 import type { AppServerNotification } from "@pwragent/shared";
 import { readAcpContentText, readAcpTopicTitle } from "./acp-session-normalizer";
 import {
-  extractCommandFromText,
   isGenericShellToolTitle,
   readAcpToolCommand,
+  readAcpToolContentCommand,
 } from "./acp-command-extraction.js";
 
 export function acpToolUpdateNotifications(params: {
@@ -133,7 +133,7 @@ function readAcpToolOutput(record: Record<string, unknown>): string | undefined 
     readString(record, "stdout") ??
     readString(record, "stderr") ??
     readString(record, "result") ??
-    (extractCommandFromText(contentText) ? undefined : contentText)
+    (readAcpToolContentCommand(record) ? undefined : contentText)
   );
 }
 

--- a/apps/desktop/src/main/acp/acp-live-notifications.ts
+++ b/apps/desktop/src/main/acp/acp-live-notifications.ts
@@ -1,5 +1,10 @@
 import type { AppServerNotification } from "@pwragent/shared";
 import { readAcpContentText, readAcpTopicTitle } from "./acp-session-normalizer";
+import {
+  extractCommandFromText,
+  isGenericShellToolTitle,
+  readAcpToolCommand,
+} from "./acp-command-extraction.js";
 
 export function acpToolUpdateNotifications(params: {
   threadId: string;
@@ -55,8 +60,12 @@ function liveItemForAcpToolUpdate(
   const path = readString(update, "path") ?? readFirstLocationPath(update);
   const status = normalizeAcpToolStatus(readString(update, "status"));
   const output = readAcpToolOutput(update);
-  const command = readString(update, "command") ?? title;
-  const commandActions = acpCommandActions({ kind: toolKind, path, title });
+  const command = readAcpToolCommand(update) ?? title;
+  const commandActions = acpCommandActions({
+    kind: toolKind,
+    path,
+    title: isGenericShellToolTitle(title) ? command : title,
+  });
   const item: Record<string, unknown> = {
     id: id ?? `${toolKind}:${title}`,
     type: "commandExecution",
@@ -118,12 +127,13 @@ function isTerminalToolStatus(status: unknown): boolean {
 }
 
 function readAcpToolOutput(record: Record<string, unknown>): string | undefined {
+  const contentText = readAcpContentText(record.content);
   return (
     readString(record, "output") ??
     readString(record, "stdout") ??
     readString(record, "stderr") ??
     readString(record, "result") ??
-    readAcpContentText(record.content)
+    (extractCommandFromText(contentText) ? undefined : contentText)
   );
 }
 

--- a/apps/desktop/src/main/acp/acp-session-normalizer.ts
+++ b/apps/desktop/src/main/acp/acp-session-normalizer.ts
@@ -10,9 +10,9 @@ import type {
   AppServerTranscriptPhase,
 } from "@pwragent/shared";
 import {
-  extractCommandFromText,
   isGenericShellToolTitle,
   readAcpToolCommand,
+  readAcpToolContentCommand,
 } from "./acp-command-extraction.js";
 
 export type AcpSessionUpdate = {
@@ -596,7 +596,7 @@ function readToolOutput(record: Record<string, unknown>): string | undefined {
     readString(record, "stdout") ??
     readString(record, "stderr") ??
     readString(record, "result") ??
-    (extractCommandFromText(contentText) ? undefined : contentText)
+    (readAcpToolContentCommand(record) ? undefined : contentText)
   );
 }
 

--- a/apps/desktop/src/main/acp/acp-session-normalizer.ts
+++ b/apps/desktop/src/main/acp/acp-session-normalizer.ts
@@ -9,6 +9,11 @@ import type {
   AppServerThreadStatus,
   AppServerTranscriptPhase,
 } from "@pwragent/shared";
+import {
+  extractCommandFromText,
+  isGenericShellToolTitle,
+  readAcpToolCommand,
+} from "./acp-command-extraction.js";
 
 export type AcpSessionUpdate = {
   sessionId: string;
@@ -585,12 +590,13 @@ function normalizeUserPrompt(
 }
 
 function readToolOutput(record: Record<string, unknown>): string | undefined {
+  const contentText = readContentText(record, "content");
   return (
     readString(record, "output") ??
     readString(record, "stdout") ??
     readString(record, "stderr") ??
     readString(record, "result") ??
-    readContentText(record, "content")
+    (extractCommandFromText(contentText) ? undefined : contentText)
   );
 }
 
@@ -683,14 +689,16 @@ function toolActivity(
     readString(update.update, "itemId") ??
     readString(update.update, "item_id") ??
     `${kind}:${update.sessionId}`;
-  const label =
+  const command = readAcpToolCommand(update.update);
+  const labelCandidate =
     readString(update.update, "title") ??
     readString(update.update, "name") ??
     readString(update.update, "kind") ??
     kind.replaceAll("_", " ");
+  const label =
+    command && isGenericShellToolTitle(labelCandidate) ? command : labelCandidate;
   const status = readString(update.update, "status");
   const path = readString(update.update, "path") ?? readFirstLocationPath(update.update);
-  const command = readString(update.update, "command");
   const output = readToolOutput(update.update);
   const exitCode = readNumber(update.update, "exitCode");
   const detailKind = command
@@ -755,12 +763,16 @@ function mergeActivity(
                 existingDetail.command || incomingDetail.command
                   ? {
                       displayCommand:
-                        existingDetail.command?.displayCommand ??
-                        incomingDetail.command?.displayCommand ??
+                        preferSpecificCommand(
+                          existingDetail.command?.displayCommand,
+                          incomingDetail.command?.displayCommand,
+                        ) ??
                         preferSpecificLabel(existingDetail.label, incomingDetail.label),
                       rawCommand:
-                        existingDetail.command?.rawCommand ??
-                        incomingDetail.command?.rawCommand,
+                        preferSpecificCommand(
+                          existingDetail.command?.rawCommand,
+                          incomingDetail.command?.rawCommand,
+                        ),
                       output:
                         incomingDetail.command?.output ??
                         existingDetail.command?.output,
@@ -786,6 +798,10 @@ function mergeActivity(
 
 function preferSpecificLabel(existing: string, incoming: string): string {
   const generic = new Set([
+    "bash",
+    "shell",
+    "sh",
+    "zsh",
     "execute",
     "read",
     "write",
@@ -799,6 +815,16 @@ function preferSpecificLabel(existing: string, incoming: string): string {
   return generic.has(existing.toLowerCase()) && incoming
     ? incoming
     : existing || incoming;
+}
+
+function preferSpecificCommand(
+  existing: string | undefined,
+  incoming: string | undefined,
+): string | undefined {
+  if (!existing || isGenericShellToolTitle(existing)) {
+    return incoming ?? existing;
+  }
+  return existing;
 }
 
 function toolDetailKind(

--- a/apps/desktop/src/main/messaging/core/messaging-approval-renderer.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-approval-renderer.ts
@@ -127,10 +127,19 @@ function decisionFromOption(
 }
 
 function extractCommand(params: AppServerPendingRequestNotification["params"]): string | undefined {
+  const promptCommand =
+    commandFromApprovalText(stringField(params.prompt)) ??
+    commandFromApprovalText(stringField(params.reason));
   const direct =
     stringField(params.command) ??
     stringField(params.shellCommand) ??
     stringField(params.commandText);
+  if (direct && !isGenericShellToolTitle(direct)) {
+    return direct;
+  }
+  if (promptCommand) {
+    return promptCommand;
+  }
   if (direct) {
     return direct;
   }
@@ -138,10 +147,23 @@ function extractCommand(params: AppServerPendingRequestNotification["params"]): 
   const command = params.command;
   if (command && typeof command === "object" && !Array.isArray(command)) {
     const record = command as Record<string, unknown>;
-    return stringField(record.command) ?? stringField(record.cmd) ?? stringField(record.text);
+    return (
+      stringField(record.command) ??
+      stringField(record.cmd) ??
+      stringField(record.text)
+    );
   }
 
   return undefined;
+}
+
+function commandFromApprovalText(text: string | undefined): string | undefined {
+  const match = /^Requesting approval to Running:\s*(.+)$/imu.exec(text ?? "");
+  return match?.[1]?.trim() || undefined;
+}
+
+function isGenericShellToolTitle(command: string): boolean {
+  return /^(?:bash|shell|sh|zsh|terminal|tool)$/i.test(command.trim());
 }
 
 function extractFileContext(

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -281,6 +281,9 @@ function approvalDisplayCommand(params: Record<string, unknown>): string {
     return parsedCommand;
   }
 
+  const promptCommand =
+    commandFromApprovalText(firstStringByKeys(params, ["prompt"])) ||
+    commandFromApprovalText(firstStringByKeys(params, ["reason"]));
   const rawCommand = firstStringByKeys(params, [
     "command",
     "cmd",
@@ -289,7 +292,19 @@ function approvalDisplayCommand(params: Record<string, unknown>): string {
     "shellCommand",
   ]);
 
+  if (promptCommand && (!rawCommand || isGenericShellToolTitle(rawCommand))) {
+    return promptCommand;
+  }
   return rawCommand ? stripShellLauncher(rawCommand) : "";
+}
+
+function commandFromApprovalText(text: string): string {
+  const match = /^Requesting approval to Running:\s*(.+)$/imu.exec(text);
+  return match?.[1]?.trim() || "";
+}
+
+function isGenericShellToolTitle(command: string): boolean {
+  return /^(?:bash|shell|sh|zsh|terminal|tool)$/i.test(command.trim());
 }
 
 function pendingRequestPrompt(request: AppServerPendingRequestNotification): string {

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -293,14 +293,18 @@ function approvalDisplayCommand(params: Record<string, unknown>): string {
 }
 
 function pendingRequestPrompt(request: AppServerPendingRequestNotification): string {
-  if (typeof request.params.prompt === "string" && request.params.prompt.trim()) {
-    return request.params.prompt.trim();
-  }
-
+  const prompt =
+    typeof request.params.prompt === "string" ? request.params.prompt.trim() : "";
   const reason = typeof request.params.reason === "string" ? request.params.reason.trim() : "";
   const command = approvalDisplayCommand(request.params);
   const commandBlock = command ? `Command:\n\n${markdownCodeBlock(command, "sh")}` : "";
 
+  if (prompt && commandBlock) {
+    return `${prompt}\n\n${commandBlock}`;
+  }
+  if (prompt) {
+    return prompt;
+  }
   if (reason && commandBlock) {
     return `${reason}\n\n${commandBlock}`;
   }

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -2958,6 +2958,34 @@ describe("TranscriptList", () => {
     expect(screen.queryByText(/\/bin\/zsh -lc/)).not.toBeInTheDocument();
   });
 
+  it("shows command approval prompt and command when both are provided", () => {
+    const { container } = render(
+      <TranscriptList
+        entries={[]}
+        loading={false}
+        loadingMore={false}
+        pendingRequest={{
+          method: "item/commandExecution/requestApproval",
+          params: {
+            threadId: "thread-1",
+            requestId: "approval-1",
+            prompt: "Kimi Code CLI wants to run Bash",
+            command: "node --version && pnpm --version",
+          },
+        }}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(screen.getByRole("group", { name: "Pending approval" })).toBeInTheDocument();
+    expect(screen.getByText(/Kimi Code CLI wants to run Bash/)).toBeInTheDocument();
+    expect(screen.getByText("Command:")).toBeInTheDocument();
+    expect(container.querySelector(".transcript-request pre code")).toHaveTextContent(
+      "node --version && pnpm --version"
+    );
+  });
+
   it("prefers parsed command actions for command approval display", () => {
     const { container } = render(
       <TranscriptList

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -2986,6 +2986,36 @@ describe("TranscriptList", () => {
     );
   });
 
+  it("derives Kimi approval commands from prompt text when command is a shell title", () => {
+    const { container } = render(
+      <TranscriptList
+        entries={[]}
+        loading={false}
+        loadingMore={false}
+        pendingRequest={{
+          method: "item/commandExecution/requestApproval",
+          params: {
+            threadId: "thread-1",
+            requestId: "approval-1",
+            prompt: "Requesting approval to Running: npm view pnpm",
+            command: "Bash",
+          },
+        }}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(screen.getByRole("group", { name: "Pending approval" })).toBeInTheDocument();
+    expect(screen.getByText(/Requesting approval to Running: npm view pnpm/)).toBeInTheDocument();
+    expect(container.querySelector(".transcript-request pre code")).toHaveTextContent(
+      "npm view pnpm"
+    );
+    expect(container.querySelector(".transcript-request pre code")).not.toHaveTextContent(
+      "Bash"
+    );
+  });
+
   it("prefers parsed command actions for command approval display", () => {
     const { container } = render(
       <TranscriptList


### PR DESCRIPTION
## Summary

- I fixed ACP permission normalization so Kimi shell approvals use the actual command extracted from nested tool content instead of the tool title `Bash`.
- I kept the desktop pending approval transcript command block visible when a prompt is also present.
- I added focused regression tests for ACP normalization, messaging approval rendering, and transcript display.

## Verification

- I ran `pnpm test apps/desktop/src/main/__tests__/acp-client.test.ts apps/desktop/src/main/__tests__/messaging-approval-renderer.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx`; all 3 test files passed, 96 tests total.
- I ran `git diff --check`.

## Notes

- I attempted `pnpm --filter @pwragent/desktop typecheck`; it produced no diagnostics but did not complete in a reasonable time, so I terminated the stuck `tsc` process.
