### PR TITLE
fix(messaging): prevent ACP replay leaks

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -459,6 +459,79 @@ describe("AcpBackendAdapter", () => {
     await adapter.close();
   });
 
+  it("does not emit replayed ACP assistant text without a live turn", async () => {
+    const backendId = "acp:kimi" as AcpBackendId;
+    const transport = new FakeAcpAgentTransport();
+    const events: AgentEvent[] = [];
+    const sessions: AcpSessionMetadata[] = [];
+    const agent: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      backendId,
+      registryId: "kimi",
+      name: "Kimi Code CLI",
+      launchDescriptor: {
+        backendId,
+        registryId: "kimi",
+        distributionKind: "local",
+        command: "kimi",
+        args: ["acp"],
+        env: {},
+      },
+    };
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => agent,
+        listInstalledAgents: () => [agent],
+        upsertInstalledAgent: vi.fn(),
+      },
+      acpSessionStore: {
+        listSessions: () => sessions,
+        getSession: (_backendId, sessionId) =>
+          sessions.find((session) => session.sessionId === sessionId),
+        upsertSession: (metadata) => {
+          const index = sessions.findIndex(
+            (session) => session.sessionId === metadata.sessionId,
+          );
+          if (index >= 0) {
+            sessions[index] = metadata;
+          } else {
+            sessions.push(metadata);
+          }
+        },
+      },
+      captureStores: [],
+      createAcpTransport: () => transport,
+      emit: async (event) => {
+        events.push(event);
+      },
+      handleServerRequest: async () => ({ decision: "accept" }),
+    });
+
+    const client = await adapter.getClient(backendId);
+    const session = await client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+    });
+
+    transport.emitSessionUpdate(session.sessionId, {
+      session_update: "agent_thought_chunk",
+      content: { type: "text", text: "This is prior turn thinking." },
+    });
+    transport.emitSessionUpdate(session.sessionId, {
+      session_update: "agent_message_chunk",
+      content: { type: "text", text: "This is a prior turn answer." },
+    });
+    await Promise.resolve();
+
+    expect(
+      events.filter(
+        (event) => event.notification.method === "item/agentMessage/delta",
+      ),
+    ).toEqual([]);
+
+    await adapter.close();
+  });
+
   it("does not emit Qwen thought chunks as live assistant response text", async () => {
     const backendId = "acp:qwen" as AcpBackendId;
     const transport = new FakeAcpAgentTransport();

--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -377,7 +377,7 @@ describe("AcpBackendAdapter", () => {
     await adapter.close();
   });
 
-  it("emits ACP thought chunks as live assistant response text", async () => {
+  it("emits ACP thought chunks with the same commentary phase used in replay", async () => {
     const backendId = "acp:kimi" as AcpBackendId;
     const transport = new FakeAcpAgentTransport();
     const events: AgentEvent[] = [];
@@ -440,20 +440,61 @@ describe("AcpBackendAdapter", () => {
       session_update: "agent_thought_chunk",
       content: { type: "text", text: "I should inspect the build setup." },
     });
+    transport.emitSessionUpdate(session.sessionId, {
+      session_update: "agent_message_chunk",
+      content: { type: "text", text: "The build setup is straightforward." },
+    });
 
     await vi.waitFor(() => {
-      expect(events).toContainEqual({
-        backend: backendId,
-        notification: {
-          method: "item/agentMessage/delta",
-          params: {
-            threadId: session.sessionId,
-            turnId: "turn-1",
-            itemId: "assistant:turn-1:0",
-            delta: "I should inspect the build setup.",
-          },
+      expect(
+        events
+          .filter(
+            (event) => event.notification.method === "item/agentMessage/delta",
+          )
+          .map((event) =>
+            event.notification.method === "item/agentMessage/delta"
+              ? event.notification.params
+              : undefined,
+          ),
+      ).toEqual([
+        {
+          threadId: session.sessionId,
+          turnId: "turn-1",
+          itemId: "assistant:turn-1:0",
+          delta: "I should inspect the build setup.",
+          phase: "commentary",
         },
-      });
+        {
+          threadId: session.sessionId,
+          turnId: "turn-1",
+          itemId: "assistant:turn-1:1",
+          delta: "The build setup is straightforward.",
+          phase: "final",
+        },
+      ]);
+    });
+    await expect(
+      adapter.readReplay(backendId, session.sessionId),
+    ).resolves.toMatchObject({
+      entries: [
+        expect.objectContaining({
+          id: "user:turn-1",
+          role: "user",
+          text: "Inspect this",
+        }),
+        expect.objectContaining({
+          id: "assistant:turn-1:0",
+          role: "assistant",
+          phase: "commentary",
+          text: "I should inspect the build setup.",
+        }),
+        expect.objectContaining({
+          id: "assistant:turn-1:1",
+          role: "assistant",
+          phase: "final",
+          text: "The build setup is straightforward.",
+        }),
+      ],
     });
 
     await adapter.close();
@@ -610,6 +651,7 @@ describe("AcpBackendAdapter", () => {
             turnId: "turn-1",
             itemId: "assistant:turn-1:0",
             delta: "Yes, it builds.",
+            phase: "final",
           },
         },
       });
@@ -712,6 +754,17 @@ describe("AcpBackendAdapter", () => {
           ),
       ).toEqual(["assistant:turn-1:0", "assistant:turn-1:1"]);
     });
+    expect(
+      events
+        .filter(
+          (event) => event.notification.method === "item/agentMessage/delta",
+        )
+        .map((event) =>
+          event.notification.method === "item/agentMessage/delta"
+            ? event.notification.params.phase
+            : undefined,
+        ),
+    ).toEqual(["commentary", "commentary"]);
 
     await adapter.close();
   });

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -904,6 +904,72 @@ describe("AcpAgentClient", () => {
     ).toBeUndefined();
   });
 
+  it("filters ACP system reminders when rehydrating provider session/load replay", async () => {
+    const transport = new FakeAcpAgentTransport();
+    const client = new AcpAgentClient({
+      backendId: "acp:kimi",
+      store,
+      transport: {
+        request: async (method, params) => {
+          const result = await transport.request(method, params);
+          if (method === "session/load") {
+            transport.emitSessionUpdate("session-1", {
+              session_update: "user_message_chunk",
+              content: { type: "text", text: "Run npm view pwrdrvr" },
+            });
+            transport.emitSessionUpdate("session-1", {
+              session_update: "user_message_chunk",
+              content: {
+                type: "text",
+                text: "<system-reminder> Auto permission mode is no longer active. Tool approvals and permission checks are back to the current mode. </system-reminder>",
+              },
+            });
+            transport.emitSessionUpdate("session-1", {
+              session_update: "agent_message_chunk",
+              content: { type: "text", text: "pwrdrvr exists on npm." },
+            });
+          }
+          return result;
+        },
+        notify: (method, params) => transport.notify(method, params),
+        close: () => transport.close(),
+        onNotification: (listener) => transport.onNotification(listener),
+      },
+      now: () => 2000,
+    });
+    store.upsertSession({
+      backendId: "acp:kimi",
+      sessionId: "session-1",
+      title: "Kimi session",
+      cwd: "/repo",
+      createdAt: 1000,
+      updatedAt: 1000,
+      executionMode: "default",
+      status: "idle",
+      hasConversationHistory: true,
+    });
+
+    await client.initialize();
+    const replay = await client.loadSession(
+      store.getSession("acp:kimi", "session-1")!,
+    );
+
+    expect(replay.messages.map((message) => message.text)).toEqual([
+      "Run npm view pwrdrvr",
+      "pwrdrvr exists on npm.",
+    ]);
+    expect(
+      replay.entries.some(
+        (entry) =>
+          entry.type === "message" && entry.text.includes("system-reminder"),
+      ),
+    ).toBe(false);
+    expect(transport.requests.map((request) => request.method)).toEqual([
+      "initialize",
+      "session/load",
+    ]);
+  });
+
   it("returns empty replay when no provider session/load support is advertised", async () => {
     const transport = new FakeAcpAgentTransport({
       initialize: {

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -1001,6 +1001,24 @@ describe("AcpAgentClient", () => {
         turnId: "turn-2",
       },
     });
+    rolloutStore.appendUpdate({
+      backendId: "acp:kimi",
+      sessionId: "session-1",
+      receivedAt: 1950,
+      update: {
+        session_update: "agent_message_chunk",
+        content: { type: "text", text: "It's 10:57 PM." },
+      },
+    });
+    rolloutStore.appendUpdate({
+      backendId: "acp:kimi",
+      sessionId: "session-1",
+      receivedAt: 1960,
+      update: {
+        session_update: "turn_finished",
+        turnId: "turn-2",
+      },
+    });
     const transport = new FakeAcpAgentTransport();
     const client = new AcpAgentClient({
       backendId: "acp:kimi",
@@ -1021,6 +1039,14 @@ describe("AcpAgentClient", () => {
             transport.emitSessionUpdate("session-1", {
               session_update: "user_message_chunk",
               content: { type: "text", text: "what time is it?" },
+            });
+            transport.emitSessionUpdate("session-1", {
+              session_update: "agent_message_chunk",
+              content: { type: "text", text: "It's 10:57 PM." },
+            });
+            transport.emitSessionUpdate("session-1", {
+              session_update: "turn_finished",
+              turnId: "turn-2",
             });
           }
           return result;
@@ -1057,13 +1083,91 @@ describe("AcpAgentClient", () => {
       { createdAt: 1100, text: "What have we here?" },
       { createdAt: 1200, text: "This is PwrAgent." },
       { createdAt: 1900, text: "what time is it?" },
+      { createdAt: 1950, text: "It's 10:57 PM." },
     ]);
     expect(
       rolloutStore.readUpdates({
         backendId: "acp:kimi",
         sessionId: "session-1",
       }),
-    ).toHaveLength(3);
+    ).toHaveLength(5);
+  });
+
+  it("merges provider session/load replay when local rollout history is incomplete", async () => {
+    const rolloutStore = new AcpRolloutStore(path.join(tempDir, "rollouts"));
+    rolloutStore.appendUpdate({
+      backendId: "acp:kimi",
+      sessionId: "session-1",
+      receivedAt: 1100,
+      update: {
+        kind: "pwragent_user_prompt",
+        prompt: "what time is it?",
+        turnId: "turn-1",
+      },
+    });
+    const transport = new FakeAcpAgentTransport();
+    const client = new AcpAgentClient({
+      backendId: "acp:kimi",
+      rolloutStore,
+      store,
+      transport: {
+        request: async (method, params) => {
+          const result = await transport.request(method, params);
+          if (method === "session/load") {
+            transport.emitSessionUpdate("session-1", {
+              session_update: "user_message_chunk",
+              content: { type: "text", text: "what time is it?" },
+            });
+            transport.emitSessionUpdate("session-1", {
+              session_update: "agent_message_chunk",
+              content: { type: "text", text: "It's 10:57 PM." },
+            });
+            transport.emitSessionUpdate("session-1", {
+              session_update: "turn_finished",
+              turnId: "turn-1",
+            });
+          }
+          return result;
+        },
+        notify: (method, params) => transport.notify(method, params),
+        close: () => transport.close(),
+        onNotification: (listener) => transport.onNotification(listener),
+      },
+      now: () => 2000,
+    });
+    store.upsertSession({
+      backendId: "acp:kimi",
+      sessionId: "session-1",
+      title: "Kimi session",
+      cwd: "/repo",
+      createdAt: 1000,
+      updatedAt: 1100,
+      executionMode: "default",
+      status: "active",
+      hasConversationHistory: true,
+    });
+
+    await client.initialize();
+    const replay = await client.loadSession(
+      store.getSession("acp:kimi", "session-1")!,
+    );
+
+    expect(
+      replay.messages.map((message) => ({
+        createdAt: message.createdAt,
+        text: message.text,
+      })),
+    ).toEqual([
+      { createdAt: 1100, text: "what time is it?" },
+      { createdAt: 2000, text: "It's 10:57 PM." },
+    ]);
+    expect(replay.threadStatus).toBe("idle");
+    expect(
+      rolloutStore.readUpdates({
+        backendId: "acp:kimi",
+        sessionId: "session-1",
+      }),
+    ).toHaveLength(1);
   });
 
   it("returns empty replay when no provider session/load support is advertised", async () => {
@@ -1971,6 +2075,65 @@ describe("AcpAgentClient", () => {
     promptResponse.resolve({ turnId: "turn-1" });
     await Promise.resolve();
     await client.dispose();
+  });
+
+  it("preserves a visible assistant stream across hidden ACP thought chunks", async () => {
+    const assistantMessageItemIds: Array<string | undefined> = [];
+    const transport = new FakeAcpAgentTransport();
+    const client = new AcpAgentClient({
+      backendId: "acp:qwen",
+      store,
+      transport,
+      now: () => 1000,
+      onSessionUpdate: ({ assistantMessageItemId, update }) => {
+        if (
+          (update.sessionUpdate ?? update.session_update ?? update.kind) ===
+          "agent_message_chunk"
+        ) {
+          assistantMessageItemIds.push(assistantMessageItemId);
+        }
+      },
+    });
+
+    await client.initialize();
+    const session = await client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+    });
+    client.startPrompt({
+      sessionId: session.sessionId,
+      prompt: "hello",
+      turnId: "turn-1",
+    });
+
+    transport.emitSessionUpdate(session.sessionId, {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "Visible " },
+    });
+    transport.emitSessionUpdate(session.sessionId, {
+      sessionUpdate: "agent_thought_chunk",
+      content: { type: "text", text: "hidden reasoning" },
+    });
+    transport.emitSessionUpdate(session.sessionId, {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "answer." },
+    });
+
+    expect(assistantMessageItemIds).toEqual([
+      "assistant:turn-1:0",
+      "assistant:turn-1:0",
+    ]);
+    expect(client.readReplay(session.sessionId).lastAssistantMessage).toBe(
+      "Visible answer.",
+    );
+    expect(
+      client
+        .readReplay(session.sessionId)
+        .entries.some(
+          (entry) =>
+            entry.type === "message" && entry.text.includes("hidden reasoning"),
+        ),
+    ).toBe(false);
   });
 
   it("strips legacy transcript updates when upserting stored sessions", () => {

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -970,6 +970,102 @@ describe("AcpAgentClient", () => {
     ]);
   });
 
+  it("preserves local rollout timestamps when provider session/load replays old messages", async () => {
+    const rolloutStore = new AcpRolloutStore(path.join(tempDir, "rollouts"));
+    rolloutStore.appendUpdate({
+      backendId: "acp:kimi",
+      sessionId: "session-1",
+      receivedAt: 1100,
+      update: {
+        kind: "pwragent_user_prompt",
+        prompt: "What have we here?",
+        turnId: "turn-1",
+      },
+    });
+    rolloutStore.appendUpdate({
+      backendId: "acp:kimi",
+      sessionId: "session-1",
+      receivedAt: 1200,
+      update: {
+        session_update: "agent_message_chunk",
+        content: { type: "text", text: "This is PwrAgent." },
+      },
+    });
+    rolloutStore.appendUpdate({
+      backendId: "acp:kimi",
+      sessionId: "session-1",
+      receivedAt: 1900,
+      update: {
+        kind: "pwragent_user_prompt",
+        prompt: "what time is it?",
+        turnId: "turn-2",
+      },
+    });
+    const transport = new FakeAcpAgentTransport();
+    const client = new AcpAgentClient({
+      backendId: "acp:kimi",
+      rolloutStore,
+      store,
+      transport: {
+        request: async (method, params) => {
+          const result = await transport.request(method, params);
+          if (method === "session/load") {
+            transport.emitSessionUpdate("session-1", {
+              session_update: "user_message_chunk",
+              content: { type: "text", text: "What have we here?" },
+            });
+            transport.emitSessionUpdate("session-1", {
+              session_update: "agent_message_chunk",
+              content: { type: "text", text: "This is PwrAgent." },
+            });
+            transport.emitSessionUpdate("session-1", {
+              session_update: "user_message_chunk",
+              content: { type: "text", text: "what time is it?" },
+            });
+          }
+          return result;
+        },
+        notify: (method, params) => transport.notify(method, params),
+        close: () => transport.close(),
+        onNotification: (listener) => transport.onNotification(listener),
+      },
+      now: () => 2000,
+    });
+    store.upsertSession({
+      backendId: "acp:kimi",
+      sessionId: "session-1",
+      title: "Kimi session",
+      cwd: "/repo",
+      createdAt: 1000,
+      updatedAt: 1950,
+      executionMode: "default",
+      status: "idle",
+      hasConversationHistory: true,
+    });
+
+    await client.initialize();
+    const replay = await client.loadSession(
+      store.getSession("acp:kimi", "session-1")!,
+    );
+
+    expect(
+      replay.messages.map((message) => ({
+        createdAt: message.createdAt,
+        text: message.text,
+      })),
+    ).toEqual([
+      { createdAt: 1100, text: "What have we here?" },
+      { createdAt: 1200, text: "This is PwrAgent." },
+      { createdAt: 1900, text: "what time is it?" },
+    ]);
+    expect(
+      rolloutStore.readUpdates({
+        backendId: "acp:kimi",
+        sessionId: "session-1",
+      }),
+    ).toHaveLength(3);
+  });
+
   it("returns empty replay when no provider session/load support is advertised", async () => {
     const transport = new FakeAcpAgentTransport({
       initialize: {

--- a/apps/desktop/src/main/__tests__/acp-rollout-store.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-rollout-store.test.ts
@@ -199,4 +199,59 @@ describe("AcpRolloutStore", () => {
       expect.objectContaining({ role: "assistant", text: "It is PwrAgent." }),
     ]);
   });
+
+  it("does not persist ACP <system-reminder> boilerplate (no reload pollution)", () => {
+    const store = new AcpRolloutStore(tempDir);
+    const backendId = "acp:kimi" as AcpBackendId;
+
+    store.appendUpdate({
+      backendId,
+      sessionId: "session-1",
+      receivedAt: 1000,
+      update: {
+        kind: "pwragent_user_prompt",
+        prompt: "Run npm view pwrdrvr",
+        turnId: "turn-1",
+      },
+    });
+    store.appendUpdate({
+      backendId,
+      sessionId: "session-1",
+      receivedAt: 1001,
+      update: {
+        session_update: "agent_message_chunk",
+        content: { type: "text", text: "pwrdrvr exists on npm." },
+      },
+    });
+    store.appendUpdate({
+      backendId,
+      sessionId: "session-1",
+      receivedAt: 2000,
+      update: {
+        session_update: "user_message_chunk",
+        content: {
+          type: "text",
+          text: "<system-reminder> Auto permission mode is no longer active. Tool approvals and permission checks are back to the current mode. </system-reminder>",
+        },
+      },
+    });
+
+    const updates = store.readUpdates({ backendId, sessionId: "session-1" });
+    expect(
+      updates.some(
+        (record) =>
+          (record.update.kind ?? record.update.session_update) ===
+          "user_message_chunk",
+      ),
+    ).toBe(false);
+
+    const replay = store.readReplay({ backendId, sessionId: "session-1" });
+    expect(replay.messages.map((message) => message.text)).toEqual([
+      "Run npm view pwrdrvr",
+      "pwrdrvr exists on npm.",
+    ]);
+    expect(
+      replay.messages.some((message) => message.text.includes("system-reminder")),
+    ).toBe(false);
+  });
 });

--- a/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
@@ -59,6 +59,49 @@ describe("AcpSessionReplayNormalizer", () => {
     ).toBe(false);
   });
 
+  it("drops ACP <system-reminder> boilerplate user_message_chunk", () => {
+    const normalizer = new AcpSessionReplayNormalizer();
+
+    normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1000,
+      update: {
+        session_update: "user_message_chunk",
+        content: { type: "text", text: "Run npm view pwrdrvr" },
+      },
+    });
+    normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1001,
+      update: {
+        session_update: "user_message_chunk",
+        content: {
+          type: "text",
+          text: "<system-reminder> Auto permission mode is no longer active. Tool approvals and permission checks are back to the current mode. </system-reminder>",
+        },
+      },
+    });
+    const replay = normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1002,
+      update: {
+        session_update: "agent_message_chunk",
+        content: { type: "text", text: "pwrdrvr exists on npm." },
+      },
+    });
+
+    expect(replay.messages).toEqual([
+      expect.objectContaining({ role: "user", text: "Run npm view pwrdrvr" }),
+      expect.objectContaining({
+        role: "assistant",
+        text: "pwrdrvr exists on npm.",
+      }),
+    ]);
+    expect(
+      replay.messages.some((message) => message.text.includes("system-reminder")),
+    ).toBe(false);
+  });
+
   it("reads ACP text content blocks from assistant chunks", () => {
     const normalizer = new AcpSessionReplayNormalizer();
 

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -9818,6 +9818,82 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("does not replace an existing ACP prompt-derived fallback title with a later prompt", async () => {
+    const acpBackendId = "acp:qwen" as AcpBackendId;
+    const sessions: AcpSessionMetadata[] = [
+      {
+        backendId: acpBackendId,
+        sessionId: "qwen-session-1",
+        title: "Run npm view openclaw",
+        titleSource: "fallback",
+        cwd: "/repo/project",
+        createdAt: 1000,
+        updatedAt: 1000,
+        executionMode: "default",
+        status: "idle",
+      },
+    ];
+    const titleService = {
+      generateTitle: vi.fn(async () => ({
+        status: "unavailable" as const,
+        reason: "acp:qwen_title_generator_unavailable",
+      })),
+    };
+    const acpClient = {
+      initialize: vi.fn(async () => undefined),
+      dispose: vi.fn(),
+      startSession: vi.fn(async () => sessions[0]!),
+      ensureSession: vi.fn(async () => undefined),
+      loadSession: vi.fn(),
+      refreshSession: vi.fn(async () => undefined),
+      cancelSession: vi.fn(),
+      startPrompt: vi.fn(() => ({
+        sessionId: "qwen-session-1",
+        turnId: "turn-1",
+      })),
+      readReplay: vi.fn((): AppServerThreadReplay => ({
+        entries: [],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+        threadStatus: "idle",
+      })),
+    };
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      grokClient: new MockBackendClient({ threads: [] }),
+      overlayStore: createOverlayStoreMock(),
+      acpAgentStore: createAcpAgentStoreMock([
+        {
+          ...createKimiAgentRecord(acpBackendId),
+          registryId: "qwen",
+          name: "Qwen Code",
+        },
+      ]),
+      acpSessionStore: createAcpSessionStoreMock(sessions),
+      createAcpClient: () => acpClient,
+      threadTitleGenerationService: titleService,
+    });
+
+    await registry.startTurn({
+      backend: acpBackendId,
+      threadId: "qwen-session-1",
+      input: [{ type: "text", text: "what time is it?" }],
+    });
+    await flushAsync();
+    await flushAsync();
+
+    expect(titleService.generateTitle).not.toHaveBeenCalled();
+    expect(sessions[0]).toMatchObject({
+      title: "Run npm view openclaw",
+      titleSource: "fallback",
+    });
+
+    await registry.close();
+  });
+
   it("skips generated titles when the thread already has an explicit name", async () => {
     const titleService = {
       generateTitle: vi.fn(async () => ({

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -9594,6 +9594,53 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("keeps forked fallback placeholder titles eligible for title generation", async () => {
+    const titleService = {
+      generateTitle: vi.fn(async () => ({
+        status: "generated" as const,
+        title: "Forked sidebar followup",
+      })),
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start", "thread/name/set"] },
+      threads: [
+        {
+          id: "forked-thread-title",
+          title: "Forked thread",
+          titleSource: "fallback",
+          linkedDirectories: [],
+          source: "codex",
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok unavailable"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: titleService,
+    });
+
+    await registry.startTurn({
+      backend: "codex",
+      threadId: "forked-thread-title",
+      input: [{ type: "text", text: "Improve the sidebar followup" }],
+    });
+    await waitForCondition(() => codexClient.lastRenameThreadParams !== undefined);
+
+    expect(titleService.generateTitle).toHaveBeenCalledWith({
+      backend: "codex",
+      userPrompt: "Improve the sidebar followup",
+    });
+    expect(codexClient.lastRenameThreadParams).toEqual({
+      threadId: "forked-thread-title",
+      name: "Forked sidebar followup",
+    });
+
+    await registry.close();
+  });
+
   it("applies generated titles when Codex exposes the prompt as an explicit title", async () => {
     const titleService = {
       generateTitle: vi.fn(async () => ({

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -5894,6 +5894,63 @@ describe("MessagingController", () => {
     expect(harness.delivered).toEqual([]);
   });
 
+  it("keeps commentary assistant deltas off messaging providers while delivering the final response", async () => {
+    const harness = await createHarness();
+    await bindThreadToBackend(harness, "acp:kimi");
+    harness.delivered.length = 0;
+
+    await harness.controller.handleBackendEvent({
+      backend: "acp:kimi",
+      notification: {
+        method: "item/agentMessage/delta",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: "assistant:turn-1:0",
+          delta: "I should inspect prior context before answering.",
+          phase: "commentary",
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(harness.delivered).toEqual([]);
+
+    await harness.controller.handleBackendEvent({
+      backend: "acp:kimi",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            output: [
+              {
+                type: "text",
+                text: "It is 10:57 PM.",
+              },
+            ],
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(
+      harness.delivered.filter((intent) => intent.kind === "message"),
+    ).toEqual([
+      expect.objectContaining({
+        kind: "message",
+        role: "assistant",
+        parts: [
+          expect.objectContaining({
+            text: "It is 10:57 PM.",
+          }),
+        ],
+      }),
+    ]);
+  });
+
   it("falls back with a final assistant message per binding", async () => {
     const delivered: MessagingSurfaceIntent[] = [];
     const harness = await createHarness({

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -5862,6 +5862,38 @@ describe("MessagingController", () => {
     expect(harness.delivered.filter((intent) => intent.kind === "message")).toEqual([]);
   });
 
+  it("ignores assistant stream deltas that are not tied to a turn", async () => {
+    const harness = await createHarness();
+    await bindThreadToBackend(harness, "acp:kimi");
+    harness.delivered.length = 0;
+
+    await harness.controller.handleBackendEvent({
+      backend: "acp:kimi",
+      notification: {
+        method: "item/agentMessage/delta",
+        params: {
+          threadId: "thread-1",
+          itemId: "assistant:thread-1",
+          delta: "Prior turn replay should not be delivered.",
+        },
+      },
+    } satisfies AgentEvent);
+    await harness.controller.handleBackendEvent({
+      backend: "acp:kimi",
+      notification: {
+        method: "thread/status/changed",
+        params: {
+          threadId: "thread-1",
+          status: {
+            type: "idle",
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(harness.delivered).toEqual([]);
+  });
+
   it("falls back with a final assistant message per binding", async () => {
     const delivered: MessagingSurfaceIntent[] = [];
     const harness = await createHarness({

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -93,6 +93,10 @@ type AcpActiveTurn = {
   turnId: string;
 };
 
+type AcpSessionLoadState = {
+  suppressTranscriptReplay: boolean;
+};
+
 export type AcpAgentClientOptions = {
   backendId: AcpBackendId;
   agentDisplayName?: string;
@@ -141,6 +145,7 @@ export class AcpAgentClient {
     string,
     { textChunks: string[] }
   >();
+  private readonly loadingSessions = new Map<string, AcpSessionLoadState>();
   private readonly agentSessionIdsByAppSessionId = new Map<string, string>();
   private readonly appSessionIdsByAgentSessionId = new Map<string, string>();
   private readonly now: () => number;
@@ -360,10 +365,11 @@ export class AcpAgentClient {
   async loadSession(metadata: AcpSessionMetadata): Promise<AppServerThreadReplay> {
     this.options.store.upsertSession(metadata);
     this.rememberSessionIds(metadata);
+    const hasLocalHistory = this.hydrateSessionFromHistory(metadata);
     if (this.supportsSessionLoad()) {
-      await this.ensureSession(metadata);
-    } else {
-      this.hydrateSessionFromHistory(metadata);
+      await this.ensureSession(metadata, {
+        suppressTranscriptReplay: hasLocalHistory,
+      });
     }
     return this.replayForSessionMetadata(metadata);
   }
@@ -372,7 +378,10 @@ export class AcpAgentClient {
     await this.ensureSession(metadata);
   }
 
-  async ensureSession(metadata: AcpSessionMetadata): Promise<void> {
+  async ensureSession(
+    metadata: AcpSessionMetadata,
+    options: { suppressTranscriptReplay?: boolean } = {},
+  ): Promise<void> {
     this.options.store.upsertSession(metadata);
     this.rememberSessionIds(metadata);
     if (!this.supportsSessionLoad()) {
@@ -386,7 +395,7 @@ export class AcpAgentClient {
     ) {
       return;
     }
-    await this.loadSessionFromAgent(metadata);
+    await this.loadSessionFromAgent(metadata, options);
   }
 
   startPrompt(params: {
@@ -616,6 +625,10 @@ export class AcpAgentClient {
       ).catch(() => undefined);
       return;
     }
+    const loadState = this.loadingSessions.get(protocolSessionId);
+    if (loadState?.suppressTranscriptReplay && isTranscriptReplayUpdate(update)) {
+      return;
+    }
     if (updateKind === "available_commands_update") {
       this.updateSessionAvailableCommands(sessionId, update, receivedAt);
     }
@@ -623,7 +636,9 @@ export class AcpAgentClient {
     if (isConversationHistoryUpdate(update)) {
       this.markSessionHasConversationHistory(sessionId, receivedAt);
     }
-    this.appendHistoryUpdate(sessionId, receivedAt, update);
+    if (!loadState) {
+      this.appendHistoryUpdate(sessionId, receivedAt, update);
+    }
     const isAssistantTextUpdate =
       updateKind === "agent_message_chunk" || updateKind === "agent_thought_chunk";
     const shouldTrackAssistantTextUpdate =
@@ -749,17 +764,18 @@ export class AcpAgentClient {
     };
   }
 
-  private hydrateSessionFromHistory(metadata: AcpSessionMetadata): void {
+  private hydrateSessionFromHistory(metadata: AcpSessionMetadata): boolean {
     if (!this.options.rolloutStore) {
-      return;
+      return false;
     }
     const normalizer = new AcpSessionReplayNormalizer({
       surfaceThoughtsAsMessages: this.surfaceThoughtsAsMessages,
     });
-    for (const record of this.options.rolloutStore.readUpdates({
+    const records = this.options.rolloutStore.readUpdates({
       backendId: this.options.backendId,
       sessionId: metadata.sessionId,
-    })) {
+    });
+    for (const record of records) {
       normalizer.apply({
         sessionId: metadata.sessionId,
         receivedAt: record.receivedAt,
@@ -767,6 +783,8 @@ export class AcpAgentClient {
       });
     }
     this.normalizers.set(metadata.sessionId, normalizer);
+    const replay = normalizer.replay();
+    return replay.messages.length > 0 || replay.entries.length > 0;
   }
 
   private markSessionHasConversationHistory(
@@ -864,7 +882,10 @@ export class AcpAgentClient {
     );
   }
 
-  private async loadSessionFromAgent(metadata: AcpSessionMetadata): Promise<unknown> {
+  private async loadSessionFromAgent(
+    metadata: AcpSessionMetadata,
+    options: { suppressTranscriptReplay?: boolean } = {},
+  ): Promise<unknown> {
     if (!this.supportsSessionLoad()) {
       return undefined;
     }
@@ -874,11 +895,19 @@ export class AcpAgentClient {
       cwd,
       sessionId: metadata.sessionId,
     });
-    const result = await this.options.transport.request("session/load", {
-      cwd,
-      mcpServers,
-      sessionId: protocolSessionId,
+    this.loadingSessions.set(protocolSessionId, {
+      suppressTranscriptReplay: options.suppressTranscriptReplay === true,
     });
+    let result: unknown;
+    try {
+      result = await this.options.transport.request("session/load", {
+        cwd,
+        mcpServers,
+        sessionId: protocolSessionId,
+      });
+    } finally {
+      this.loadingSessions.delete(protocolSessionId);
+    }
     const runtimeCapabilities = this.captureRuntimeCapabilities({
       source: "session-load",
       result,
@@ -1077,7 +1106,22 @@ function isConversationHistoryUpdate(update: Record<string, unknown>): boolean {
   return (
     kind === "pwragent_user_prompt" ||
     kind === "user_message_chunk" ||
-    kind === "agent_message_chunk"
+    kind === "agent_message_chunk" ||
+    kind === "agent_thought_chunk"
+  );
+}
+
+function isTranscriptReplayUpdate(update: Record<string, unknown>): boolean {
+  const kind = readUpdateKind(update);
+  return (
+    isConversationHistoryUpdate(update) ||
+    kind === "plan" ||
+    kind === "tool_call" ||
+    kind === "tool_call_update" ||
+    kind === "file" ||
+    kind === "terminal" ||
+    kind === "turn_finished" ||
+    kind === "pwragent_turn_failed"
   );
 }
 

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -97,6 +97,10 @@ type AcpSessionLoadState = {
   suppressTranscriptReplay: boolean;
 };
 
+type AcpHydratedSessionHistory = {
+  isComplete: boolean;
+};
+
 export type AcpAgentClientOptions = {
   backendId: AcpBackendId;
   agentDisplayName?: string;
@@ -365,13 +369,16 @@ export class AcpAgentClient {
   async loadSession(metadata: AcpSessionMetadata): Promise<AppServerThreadReplay> {
     this.options.store.upsertSession(metadata);
     this.rememberSessionIds(metadata);
-    const hasLocalHistory = this.hydrateSessionFromHistory(metadata);
+    const localHistory = this.hydrateSessionFromHistory(metadata);
     if (this.supportsSessionLoad()) {
       await this.ensureSession(metadata, {
-        suppressTranscriptReplay: hasLocalHistory,
+        suppressTranscriptReplay: localHistory.isComplete,
       });
     }
-    return this.replayForSessionMetadata(metadata);
+    return this.replayForSessionMetadata(
+      this.options.store.getSession(this.options.backendId, metadata.sessionId) ??
+        metadata,
+    );
   }
 
   async refreshSession(metadata: AcpSessionMetadata): Promise<void> {
@@ -632,6 +639,14 @@ export class AcpAgentClient {
     if (updateKind === "available_commands_update") {
       this.updateSessionAvailableCommands(sessionId, update, receivedAt);
     }
+    if (updateKind === "turn_started") {
+      this.updateSessionStatus(sessionId, "active");
+    } else if (
+      updateKind === "turn_finished" ||
+      updateKind === "pwragent_turn_failed"
+    ) {
+      this.updateSessionStatus(sessionId, "idle");
+    }
     const title = this.updateSessionTitleFromAcpUpdate(sessionId, update, receivedAt);
     if (isConversationHistoryUpdate(update)) {
       this.markSessionHasConversationHistory(sessionId, receivedAt);
@@ -657,10 +672,7 @@ export class AcpAgentClient {
       if (updateKind === "agent_message_chunk") {
         activeTurn.assistantText += text;
       }
-    } else if (
-      (!isAssistantTextUpdate || !shouldTrackAssistantTextUpdate) &&
-      activeTurn
-    ) {
+    } else if (!isAssistantTextUpdate && activeTurn) {
       activeTurn.activeAssistantMessageItemId = undefined;
       activeTurn.activeAssistantMessagePhase = undefined;
     }
@@ -764,18 +776,24 @@ export class AcpAgentClient {
     };
   }
 
-  private hydrateSessionFromHistory(metadata: AcpSessionMetadata): boolean {
+  private hydrateSessionFromHistory(
+    metadata: AcpSessionMetadata,
+  ): AcpHydratedSessionHistory {
     if (!this.options.rolloutStore) {
-      return false;
+      return { isComplete: false };
     }
     const normalizer = new AcpSessionReplayNormalizer({
       surfaceThoughtsAsMessages: this.surfaceThoughtsAsMessages,
     });
+    let hasTranscriptHistory = false;
     const records = this.options.rolloutStore.readUpdates({
       backendId: this.options.backendId,
       sessionId: metadata.sessionId,
     });
     for (const record of records) {
+      if (isTranscriptReplayUpdate(record.update)) {
+        hasTranscriptHistory = true;
+      }
       normalizer.apply({
         sessionId: metadata.sessionId,
         receivedAt: record.receivedAt,
@@ -784,7 +802,10 @@ export class AcpAgentClient {
     }
     this.normalizers.set(metadata.sessionId, normalizer);
     const replay = normalizer.replay();
-    return replay.messages.length > 0 || replay.entries.length > 0;
+    const hasReplay = replay.messages.length > 0 || replay.entries.length > 0;
+    return {
+      isComplete: (hasTranscriptHistory || hasReplay) && replay.threadStatus === "idle",
+    };
   }
 
   private markSessionHasConversationHistory(

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -2,6 +2,7 @@ import type {
   AcpBackendId,
   AppServerAvailableCommandSummary,
   AppServerPendingRequestNotification,
+  AppServerTranscriptPhase,
   AppServerThreadReplay,
   AppServerThreadMessagePart,
   BackendAcpRuntimeCapabilities,
@@ -86,6 +87,7 @@ type AcpRolloutStoreLike = {
 
 type AcpActiveTurn = {
   activeAssistantMessageItemId?: string;
+  activeAssistantMessagePhase?: AppServerTranscriptPhase;
   assistantText: string;
   assistantMessageSequence: number;
   turnId: string;
@@ -624,18 +626,28 @@ export class AcpAgentClient {
     this.appendHistoryUpdate(sessionId, receivedAt, update);
     const isAssistantTextUpdate =
       updateKind === "agent_message_chunk" || updateKind === "agent_thought_chunk";
+    const shouldTrackAssistantTextUpdate =
+      updateKind === "agent_message_chunk" ||
+      (updateKind === "agent_thought_chunk" && this.surfaceThoughtsAsMessages);
     const text = readUpdateText(update);
     let assistantMessageItemId: string | undefined;
-    if (isAssistantTextUpdate && activeTurn && text) {
+    if (shouldTrackAssistantTextUpdate && activeTurn && text) {
+      const phase: AppServerTranscriptPhase =
+        updateKind === "agent_thought_chunk" ? "commentary" : "final";
       assistantMessageItemId = assistantMessageItemIdForUpdate({
         activeTurn,
+        phase,
         update,
       });
       if (updateKind === "agent_message_chunk") {
         activeTurn.assistantText += text;
       }
-    } else if (!isAssistantTextUpdate && activeTurn) {
+    } else if (
+      (!isAssistantTextUpdate || !shouldTrackAssistantTextUpdate) &&
+      activeTurn
+    ) {
       activeTurn.activeAssistantMessageItemId = undefined;
+      activeTurn.activeAssistantMessagePhase = undefined;
     }
     const replay = this.normalizerFor(sessionId).apply({
       sessionId,
@@ -1309,8 +1321,13 @@ function textPrompt(text: string): AcpPromptContentBlock[] {
 
 function assistantMessageItemIdForUpdate(params: {
   activeTurn: AcpActiveTurn;
+  phase: AppServerTranscriptPhase;
   update: Record<string, unknown>;
 }): string {
+  if (params.activeTurn.activeAssistantMessagePhase !== params.phase) {
+    params.activeTurn.activeAssistantMessageItemId = undefined;
+    params.activeTurn.activeAssistantMessagePhase = params.phase;
+  }
   const explicitId =
     typeof params.update.messageId === "string"
       ? params.update.messageId

--- a/apps/desktop/src/main/acp/acp-rollout-store.ts
+++ b/apps/desktop/src/main/acp/acp-rollout-store.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import type { AcpBackendId, AppServerThreadReplay } from "@pwragent/shared";
 import {
   AcpSessionReplayNormalizer,
-  isAcpSessionContextBoilerplate,
+  isAcpUserBoilerplateMessage,
   readAcpContentText,
   readAcpTopicTitle,
   shouldSurfaceAcpThoughtsAsMessages,
@@ -196,13 +196,12 @@ function shouldPersistUpdate(update: Record<string, unknown>): boolean {
   if (readAcpTopicTitle(update)) {
     return false;
   }
-  // Don't persist Gemini's <session_context> boilerplate. It arrives as a
-  // user_message_chunk during session/load replay, so without this guard every
-  // reload appends another copy to the rollout — permanently polluting the
-  // durable history with environment setup text.
+  // Don't persist ACP user boilerplate. These chunks arrive during session/load
+  // replay, so without this guard every reload appends another copy to the
+  // rollout and permanently pollutes durable history with setup/control text.
   if (
     kind === "user_message_chunk" &&
-    isAcpSessionContextBoilerplate(readUpdateText(update))
+    isAcpUserBoilerplateMessage(readUpdateText(update))
   ) {
     return false;
   }

--- a/apps/desktop/src/main/acp/acp-session-normalizer.ts
+++ b/apps/desktop/src/main/acp/acp-session-normalizer.ts
@@ -121,6 +121,12 @@ export class AcpSessionReplayNormalizer {
   apply(update: AcpSessionUpdate): AppServerThreadReplay {
     const kind = readKind(update.update);
     const createdAt = update.receivedAt ?? Date.now();
+    if (
+      kind === "agent_thought_chunk" &&
+      this.options.surfaceThoughtsAsMessages === false
+    ) {
+      return this.replay();
+    }
     const isAssistantTextUpdate =
       kind === "agent_message_chunk" || kind === "agent_thought_chunk";
 

--- a/apps/desktop/src/main/acp/acp-session-normalizer.ts
+++ b/apps/desktop/src/main/acp/acp-session-normalizer.ts
@@ -215,7 +215,7 @@ export class AcpSessionReplayNormalizer {
       readContentText(update.update, "content") ??
       readString(update.update, "text") ??
       "";
-    if (isModeUpdateMarker(text)) {
+    if (!text || isModeUpdateMarker(text)) {
       return;
     }
     const id = this.assistantMessageIdForChunk(update);
@@ -233,12 +233,11 @@ export class AcpSessionReplayNormalizer {
       readContentText(update.update, "content") ??
       readString(update.update, "text") ??
       "";
-    if (isAcpSessionContextBoilerplate(text)) {
+    if (isAcpUserBoilerplateMessage(text)) {
       // Gemini re-emits its <session_context> environment block (date, OS,
       // workspace dir, directory tree) as a user_message_chunk on session/load.
-      // It's setup boilerplate the agent injects, not a turn the user typed —
-      // surfacing it makes a reloaded thread look like the human pasted a file
-      // listing. Drop it from the transcript entirely.
+      // ACP agents can also replay synthetic <system-reminder> prompts. These
+      // are setup/control text the agent saw, not user-authored turns.
       return;
     }
     if (this.currentTurnId) {
@@ -639,6 +638,17 @@ function readContentText(
  */
 export function isAcpSessionContextBoilerplate(text: string | undefined): boolean {
   return text !== undefined && text.trimStart().startsWith("<session_context>");
+}
+
+export function isAcpSystemReminderBoilerplate(text: string | undefined): boolean {
+  return text !== undefined && text.trimStart().startsWith("<system-reminder>");
+}
+
+export function isAcpUserBoilerplateMessage(text: string | undefined): boolean {
+  return (
+    isAcpSessionContextBoilerplate(text) ||
+    isAcpSystemReminderBoilerplate(text)
+  );
 }
 
 export function readAcpContentText(value: unknown): string | undefined {

--- a/apps/desktop/src/main/acp/acp-session-normalizer.ts
+++ b/apps/desktop/src/main/acp/acp-session-normalizer.ts
@@ -30,6 +30,7 @@ export class AcpSessionReplayNormalizer {
   private status: AppServerThreadStatus = "idle";
   private currentTurnId?: string;
   private activeAssistantMessageId?: string;
+  private activeAssistantMessagePhase?: AppServerTranscriptPhase;
   private assistantMessageSequence = 0;
   private generatedMessageSequence = 0;
 
@@ -48,6 +49,7 @@ export class AcpSessionReplayNormalizer {
     const normalizedPrompt = normalizeUserPrompt(params.prompt, params.parts);
     this.currentTurnId = params.turnId;
     this.activeAssistantMessageId = undefined;
+    this.activeAssistantMessagePhase = undefined;
     this.assistantMessageSequence = 0;
     this.upsertMessage({
       id,
@@ -73,6 +75,7 @@ export class AcpSessionReplayNormalizer {
       this.currentTurnId = undefined;
     }
     this.activeAssistantMessageId = undefined;
+    this.activeAssistantMessagePhase = undefined;
     this.status = "idle";
     return this.replay();
   }
@@ -89,6 +92,7 @@ export class AcpSessionReplayNormalizer {
       this.currentTurnId = undefined;
     }
     this.activeAssistantMessageId = undefined;
+    this.activeAssistantMessagePhase = undefined;
     this.status = "idle";
     this.upsertActivity({
       type: "activity",
@@ -131,12 +135,15 @@ export class AcpSessionReplayNormalizer {
         this.removeAgentWaitingActivity(this.currentTurnId);
       }
       if (kind === "agent_message_chunk") {
+        this.resetAssistantMessageIfPhaseChanged("final");
         this.applyAgentMessageChunk(update, createdAt);
       } else {
+        this.resetAssistantMessageIfPhaseChanged("commentary");
         this.applyAgentThoughtChunk(update, createdAt);
       }
     } else if (kind === "user_message_chunk") {
       this.activeAssistantMessageId = undefined;
+      this.activeAssistantMessagePhase = undefined;
       this.applyUserMessageChunk(update, createdAt);
     } else if (kind === "available_commands_update") {
       // Command metadata belongs in provider capabilities, not the transcript.
@@ -146,6 +153,7 @@ export class AcpSessionReplayNormalizer {
       // Topic updates are thread metadata, not transcript entries.
     } else {
       this.activeAssistantMessageId = undefined;
+      this.activeAssistantMessagePhase = undefined;
       if (kind === "plan") {
         this.removeCurrentAgentWaitingActivity();
         this.upsertPlan(update, createdAt);
@@ -211,7 +219,13 @@ export class AcpSessionReplayNormalizer {
       return;
     }
     const id = this.assistantMessageIdForChunk(update);
-    this.appendMessageChunk({ id, role: "assistant", text, createdAt });
+    this.appendMessageChunk({
+      id,
+      phase: "final",
+      role: "assistant",
+      text,
+      createdAt,
+    });
   }
 
   private applyUserMessageChunk(update: AcpSessionUpdate, createdAt: number): void {
@@ -260,6 +274,7 @@ export class AcpSessionReplayNormalizer {
     const id = this.assistantMessageIdForChunk(update);
     this.appendMessageChunk({
       id,
+      phase: "commentary",
       role: "assistant",
       text,
       createdAt,
@@ -279,6 +294,16 @@ export class AcpSessionReplayNormalizer {
         `assistant:${this.currentTurnId ?? update.sessionId}:${this.assistantMessageSequence++}`;
     }
     return this.activeAssistantMessageId;
+  }
+
+  private resetAssistantMessageIfPhaseChanged(
+    phase: AppServerTranscriptPhase
+  ): void {
+    if (this.activeAssistantMessagePhase === phase) {
+      return;
+    }
+    this.activeAssistantMessageId = undefined;
+    this.activeAssistantMessagePhase = phase;
   }
 
   private upsertPlan(update: AcpSessionUpdate, createdAt: number): void {

--- a/apps/desktop/src/main/acp/normalized-thread-reducer.ts
+++ b/apps/desktop/src/main/acp/normalized-thread-reducer.ts
@@ -64,13 +64,13 @@ class NormalizedThreadReducer {
         this.status = "active";
         break;
       case "agent_message_delta":
-        this.appendAssistantDelta(event.itemId, event.delta);
+        this.appendAssistantDelta("final", event.itemId, event.delta);
         break;
       case "reasoning_delta":
         // Reasoning is surfaced as assistant text when the agent's quirk says
         // so; the kit already gates this (it only emits reasoning_delta when
         // surfaceThoughts is true), so treat it like an assistant delta.
-        this.appendAssistantDelta(event.itemId, event.delta);
+        this.appendAssistantDelta("reasoning", event.itemId, event.delta);
         break;
       case "agent_message":
         this.setAssistantMessage(event.message);
@@ -118,8 +118,13 @@ class NormalizedThreadReducer {
     };
   }
 
-  private appendAssistantDelta(itemId: string, delta: string): void {
-    const existingIndex = this.messageEntryByItem.get(itemId);
+  private appendAssistantDelta(
+    phase: "final" | "reasoning",
+    itemId: string,
+    delta: string,
+  ): void {
+    const messageKey = `${phase}:${itemId}`;
+    const existingIndex = this.messageEntryByItem.get(messageKey);
     if (existingIndex !== undefined) {
       const entry = this.entries[existingIndex] as NormalizedMessageEntry;
       entry.text += delta;
@@ -131,18 +136,28 @@ class NormalizedThreadReducer {
       role: "assistant",
       text: delta,
     };
-    this.messageEntryByItem.set(itemId, this.entries.length);
+    this.messageEntryByItem.set(messageKey, this.entries.length);
     this.entries.push(entry);
   }
 
   private setAssistantMessage(message: NormalizedMessage): void {
-    const existingIndex = this.messageEntryByItem.get(message.id);
+    const messageKey = `final:${message.id}`;
+    const existingIndex = this.messageEntryByItem.get(messageKey);
     const entry: NormalizedMessageEntry = { type: "message", ...message };
     if (existingIndex !== undefined) {
-      this.entries[existingIndex] = entry;
+      // Some ACP normalizers finalize with reasoning+final text combined after
+      // emitting final deltas. The in-tree replay keeps the final answer lane
+      // separate, so preserve the streamed final entry.
       return;
     }
-    this.messageEntryByItem.set(message.id, this.entries.length);
+    const reasoningIndex = this.messageEntryByItem.get(`reasoning:${message.id}`);
+    if (reasoningIndex !== undefined) {
+      const reasoningEntry = this.entries[reasoningIndex] as NormalizedMessageEntry;
+      if (reasoningEntry.text === message.text) {
+        return;
+      }
+    }
+    this.messageEntryByItem.set(messageKey, this.entries.length);
     this.entries.push(entry);
   }
 

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -1282,6 +1282,8 @@ export class AcpBackendAdapter {
         ) {
           const delta = readAcpUpdateText(update);
           if (delta) {
+            const phase =
+              updateKind === "agent_thought_chunk" ? "commentary" : "final";
             await this.emit({
               backend: agent.backendId,
               notification: {
@@ -1292,6 +1294,7 @@ export class AcpBackendAdapter {
                   itemId:
                     assistantMessageItemId ?? `assistant:${turnId ?? sessionId}`,
                   delta,
+                  phase,
                 },
               },
             });

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -1275,9 +1275,10 @@ export class AcpBackendAdapter {
           }
         }
         if (
-          updateKind === "agent_message_chunk" ||
-          (updateKind === "agent_thought_chunk" &&
-            shouldSurfaceAcpThoughtsAsMessages(agent.backendId))
+          turnId &&
+          (updateKind === "agent_message_chunk" ||
+            (updateKind === "agent_thought_chunk" &&
+              shouldSurfaceAcpThoughtsAsMessages(agent.backendId)))
         ) {
           const delta = readAcpUpdateText(update);
           if (delta) {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -2084,7 +2084,13 @@ function isEligibleForGeneratedTitle(
   if (isInjectedContextPlaceholderTitle(thread.title)) {
     return true;
   }
-  if (isFallbackPlaceholderTitle(thread.title)) {
+  if (thread.titleSource === "fallback") {
+    return (
+      !isAcpBackendId(thread.source) ||
+      isAcpFallbackPlaceholderTitle(thread.title)
+    );
+  }
+  if (isGenericPlaceholderTitle(thread.title)) {
     return true;
   }
 
@@ -2114,12 +2120,14 @@ function isInjectedContextPlaceholderTitle(title: string): boolean {
   );
 }
 
-function isFallbackPlaceholderTitle(title: string): boolean {
+function isAcpFallbackPlaceholderTitle(title: string): boolean {
   const normalizedTitle = normalizeTitleForComparison(title);
-  return (
-    normalizedTitle === "untitled thread" ||
-    normalizedTitle === "acp session"
-  );
+  return normalizedTitle === "acp session";
+}
+
+function isGenericPlaceholderTitle(title: string): boolean {
+  const normalizedTitle = normalizeTitleForComparison(title);
+  return normalizedTitle === "untitled thread";
 }
 
 function truncateLogValue(value: string | undefined): string | null {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -2084,7 +2084,7 @@ function isEligibleForGeneratedTitle(
   if (isInjectedContextPlaceholderTitle(thread.title)) {
     return true;
   }
-  if (thread.titleSource === "fallback" || thread.title === "Untitled thread") {
+  if (isFallbackPlaceholderTitle(thread.title)) {
     return true;
   }
 
@@ -2111,6 +2111,14 @@ function isInjectedContextPlaceholderTitle(title: string): boolean {
   return (
     normalizedTitle.startsWith("# agents.md instructions") ||
     normalizedTitle.startsWith("agents.md instructions for")
+  );
+}
+
+function isFallbackPlaceholderTitle(title: string): boolean {
+  const normalizedTitle = normalizeTitleForComparison(title);
+  return (
+    normalizedTitle === "untitled thread" ||
+    normalizedTitle === "acp session"
   );
 }
 

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -229,7 +229,7 @@ type AssistantStreamDelta = {
   itemId: string;
   streamKey: string;
   threadId: ThreadIdentifier;
-  turnId?: string;
+  turnId: string;
 };
 
 type AssistantStreamBuffer = AssistantStreamDelta & {
@@ -11318,23 +11318,23 @@ function assistantDeltaForBackendEvent(
   };
   if (
     typeof params.threadId !== "string" ||
+    typeof params.turnId !== "string" ||
     typeof params.itemId !== "string" ||
     typeof params.delta !== "string" ||
     params.delta.length === 0
   ) {
     return undefined;
   }
-  const turnId = typeof params.turnId === "string" ? params.turnId : undefined;
   return {
     delta: params.delta,
     itemId: params.itemId,
     streamKey: assistantStreamKey({
       backend: event.backend,
       threadId: params.threadId,
-      turnId,
+      turnId: params.turnId,
     }),
     threadId: params.threadId,
-    turnId,
+    turnId: params.turnId,
   };
 }
 

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -11313,9 +11313,13 @@ function assistantDeltaForBackendEvent(
   const params = event.notification.params as {
     delta?: unknown;
     itemId?: unknown;
+    phase?: unknown;
     threadId?: unknown;
     turnId?: unknown;
   };
+  if (params.phase === "commentary") {
+    return undefined;
+  }
   if (
     typeof params.threadId !== "string" ||
     typeof params.turnId !== "string" ||


### PR DESCRIPTION
## Summary

I fixed the ACP messaging path so replayed/hydrated assistant chunks cannot be treated as live outbound replies. Before this, prior Kimi turn thinking and answers could leak into Telegram after the real response; now live assistant stream updates must carry a turn id at both the ACP adapter boundary and the generic messaging controller boundary.

I also tightened ACP fallback title generation so an existing prompt-derived fallback title is not treated like a brand-new unnamed thread on a later prompt. Placeholder titles such as `ACP session` and `Untitled thread` can still get a first prompt-derived name.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts apps/desktop/src/main/__tests__/messaging-controller.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts`
- `pnpm lint:boundaries`
- `pnpm --filter @pwragent/desktop typecheck`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
