### PR TITLE
fix(desktop): reduce log viewer noise

### DIFF
--- a/apps/desktop/src/main/__tests__/app-logs.test.ts
+++ b/apps/desktop/src/main/__tests__/app-logs.test.ts
@@ -21,6 +21,7 @@ describe("app log snapshots", () => {
 
     expect(readAppLogSnapshot()).toMatchObject({
       kind: "log-snapshot",
+      debugCollectionEnabled: false,
       entries: [
         {
           sequence: 1,

--- a/apps/desktop/src/main/__tests__/log.test.ts
+++ b/apps/desktop/src/main/__tests__/log.test.ts
@@ -2,13 +2,29 @@ import { describe, expect, it } from "vitest";
 import electronLog from "electron-log/main.js";
 import {
   compactStructuredLogData,
+  isMainLogDebugCollectionEnabled,
   resolveMainLogFileNameForProfile,
   resolveMainLogProfileName,
+  setMainLogDebugCollectionEnabled,
 } from "../log";
 
 describe("main logger compact formatting", () => {
   it("suppresses the electron-log console transport during unit tests", () => {
     expect(electronLog.transports.console.level).toBe(false);
+  });
+
+  it("keeps app-log debug collection disabled unless explicitly enabled", () => {
+    setMainLogDebugCollectionEnabled(false);
+
+    expect(isMainLogDebugCollectionEnabled()).toBe(false);
+    expect(electronLog.transports.file.level).toBe("info");
+
+    setMainLogDebugCollectionEnabled(true);
+
+    expect(isMainLogDebugCollectionEnabled()).toBe(true);
+    expect(electronLog.transports.file.level).toBe("debug");
+
+    setMainLogDebugCollectionEnabled(false);
   });
 
   it("omits undefined object fields from compact log output", () => {

--- a/apps/desktop/src/main/app-logs.ts
+++ b/apps/desktop/src/main/app-logs.ts
@@ -35,10 +35,13 @@ export function appendAppLogEntry(entry: Omit<AppLogEntry, "sequence">): AppLogE
   return stored;
 }
 
-export function readAppLogSnapshot(): AppLogSnapshot {
+export function readAppLogSnapshot(options?: {
+  debugCollectionEnabled?: boolean;
+}): AppLogSnapshot {
   return {
     kind: "log-snapshot",
     title: "Logs",
+    debugCollectionEnabled: options?.debugCollectionEnabled ?? false,
     entries: orderedEntries(),
     readAt: Date.now(),
     truncated: droppedEntries > 0,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -8951,7 +8951,7 @@ export class DesktopBackendRegistry {
         source = "default-fallback";
       }
     }
-    backendRegistryLog.info("codex thread client routing", {
+    backendRegistryLog.debug("codex thread client routing", {
       threadId,
       requestedMode,
       resolvedMode: mode,

--- a/apps/desktop/src/main/ipc/app-metadata.ts
+++ b/apps/desktop/src/main/ipc/app-metadata.ts
@@ -5,6 +5,7 @@ import { app, ipcMain } from "electron";
 import {
   APP_CHANGELOG_DOCUMENT_READ_CHANNEL,
   APP_CHANGELOG_WINDOW_OPEN_CHANNEL,
+  APP_LOG_DEBUG_COLLECTION_SET_CHANNEL,
   APP_LOG_ENTRY_EVENT_CHANNEL,
   APP_LOG_SNAPSHOT_READ_CHANNEL,
   APP_LOG_WINDOW_OPEN_CHANNEL,
@@ -25,12 +26,24 @@ import { readAppLogSnapshot, subscribeAppLogEntries } from "../app-logs";
 import { showAppLogWindow } from "../app-log-window";
 import { showChangelogWindow } from "../changelog-window";
 import { showThirdPartyNoticesWindow } from "../license-document-window";
-import { getMainLogFilePath } from "../log";
+import {
+  getMainLogFilePath,
+  isMainLogDebugCollectionEnabled,
+  setMainLogDebugCollectionEnabled,
+} from "../log";
 import { subscribersForChannel } from "../window-channels";
 
 const APP_COPYRIGHT = "Copyright © 2026 PwrDrvr LLC.";
 
 let unsubscribeAppLogEntries: (() => void) | undefined;
+
+function readDecoratedAppLogSnapshot(): AppLogSnapshot {
+  const snapshot = readAppLogSnapshot({
+    debugCollectionEnabled: isMainLogDebugCollectionEnabled(),
+  });
+  const logFilePath = getMainLogFilePath();
+  return logFilePath ? { ...snapshot, logFilePath } : snapshot;
+}
 
 export function resolveAppMetadata(): AppMetadata {
   return {
@@ -104,6 +117,7 @@ export function registerAppMetadataIpcHandlers(): void {
   ipcMain.removeHandler(APP_CHANGELOG_WINDOW_OPEN_CHANNEL);
   ipcMain.removeHandler(APP_THIRD_PARTY_NOTICES_WINDOW_OPEN_CHANNEL);
   ipcMain.removeHandler(APP_LOG_SNAPSHOT_READ_CHANNEL);
+  ipcMain.removeHandler(APP_LOG_DEBUG_COLLECTION_SET_CHANNEL);
   ipcMain.removeHandler(APP_LOG_WINDOW_OPEN_CHANNEL);
   ipcMain.handle(APP_METADATA_READ_CHANNEL, async (): Promise<AppMetadata> =>
     resolveAppMetadata(),
@@ -130,10 +144,13 @@ export function registerAppMetadataIpcHandlers(): void {
   );
   ipcMain.handle(
     APP_LOG_SNAPSHOT_READ_CHANNEL,
-    async (): Promise<AppLogSnapshot> => {
-      const snapshot = readAppLogSnapshot();
-      const logFilePath = getMainLogFilePath();
-      return logFilePath ? { ...snapshot, logFilePath } : snapshot;
+    async (): Promise<AppLogSnapshot> => readDecoratedAppLogSnapshot(),
+  );
+  ipcMain.handle(
+    APP_LOG_DEBUG_COLLECTION_SET_CHANNEL,
+    async (_event, enabled: boolean): Promise<AppLogSnapshot> => {
+      setMainLogDebugCollectionEnabled(enabled);
+      return readDecoratedAppLogSnapshot();
     },
   );
   ipcMain.handle(APP_LOG_WINDOW_OPEN_CHANNEL, async (): Promise<void> => {
@@ -150,5 +167,6 @@ export function disposeAppMetadataIpcHandlers(): void {
   ipcMain.removeHandler(APP_CHANGELOG_WINDOW_OPEN_CHANNEL);
   ipcMain.removeHandler(APP_THIRD_PARTY_NOTICES_WINDOW_OPEN_CHANNEL);
   ipcMain.removeHandler(APP_LOG_SNAPSHOT_READ_CHANNEL);
+  ipcMain.removeHandler(APP_LOG_DEBUG_COLLECTION_SET_CHANNEL);
   ipcMain.removeHandler(APP_LOG_WINDOW_OPEN_CHANNEL);
 }

--- a/apps/desktop/src/main/log.ts
+++ b/apps/desktop/src/main/log.ts
@@ -3,6 +3,7 @@ import { appendAppLogEntry } from "./app-logs";
 import type { ProfileBootDecision } from "./profile";
 
 let initialized = false;
+let debugCollectionEnabled = false;
 const MAX_COMPACT_STRING_LENGTH = 320;
 const MAX_COMPACT_FIELDS = 24;
 const MAX_COMPACT_DEPTH = 2;
@@ -27,6 +28,7 @@ export function initializeMainLogger(options?: { profileName?: string }): void {
       options.profileName,
     );
   }
+  electronLog.transports.file.level = debugCollectionEnabled ? "debug" : "info";
   electronLog.initialize();
   electronLog.scope.labelPadding = false;
   electronLog.hooks.push((
@@ -79,6 +81,15 @@ export function getMainLogFilePath(): string | undefined {
   } catch {
     return undefined;
   }
+}
+
+export function isMainLogDebugCollectionEnabled(): boolean {
+  return debugCollectionEnabled;
+}
+
+export function setMainLogDebugCollectionEnabled(enabled: boolean): void {
+  debugCollectionEnabled = enabled;
+  electronLog.transports.file.level = enabled ? "debug" : "info";
 }
 
 type CompactField = {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -1646,10 +1646,10 @@ export class MessagingController {
       // a silent security bug — the user thinks they're sandboxed but
       // commands like `npm view` succeed because the full-access client
       // skipped the network sandbox. We log the resolved mode + where
-      // it came from here at the messaging layer; the registry's
-      // `codex thread client routing` log shows which client actually
-      // received the turn. Cross-reference both lines by threadId to
-      // verify the routing matched intent. `executionModeSource` of
+      // it came from here at the messaging layer; with Debug log collection
+      // enabled, the registry's `codex thread client routing` log shows which
+      // client actually received the turn. Cross-reference both lines by
+      // threadId to verify the routing matched intent. `executionModeSource` of
       // anything other than `thread` is suspicious for a thread the UI
       // claims has been explicitly toggled.
       this.logger.info?.("messaging starting turn", {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -243,6 +243,7 @@ import {
   AUTOMATIONS_UPDATE_CHANNEL,
   APP_CHANGELOG_DOCUMENT_READ_CHANNEL,
   APP_CHANGELOG_WINDOW_OPEN_CHANNEL,
+  APP_LOG_DEBUG_COLLECTION_SET_CHANNEL,
   APP_LOG_ENTRY_EVENT_CHANNEL,
   APP_LOG_SNAPSHOT_READ_CHANNEL,
   APP_LOG_WINDOW_OPEN_CHANNEL,
@@ -404,6 +405,10 @@ const desktopApi = Object.freeze({
   },
   readAppLogSnapshot: async (): Promise<AppLogSnapshot> =>
     await ipcRenderer.invoke(APP_LOG_SNAPSHOT_READ_CHANNEL),
+  setAppLogDebugCollectionEnabled: async (
+    enabled: boolean,
+  ): Promise<AppLogSnapshot> =>
+    await ipcRenderer.invoke(APP_LOG_DEBUG_COLLECTION_SET_CHANNEL, enabled),
   openAppLogWindow: async (): Promise<void> => {
     await ipcRenderer.invoke(APP_LOG_WINDOW_OPEN_CHANNEL);
   },

--- a/apps/desktop/src/renderer/src/features/logs/LogsWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/logs/LogsWindow.tsx
@@ -14,7 +14,7 @@ import { useDesktopApi } from "../../lib/desktop-api";
 
 const BOTTOM_THRESHOLD_PX = 32;
 export const MAX_RENDERED_LOG_ENTRIES = 5000;
-const DEFAULT_MINIMUM_LOG_LEVEL: LogLevelFilter = "info";
+const DEFAULT_SELECTED_LOG_LEVELS: LogLevelFilter[] = ["error", "warn", "info"];
 const LOG_LEVEL_FILTERS: Array<{ value: LogLevelFilter; label: string }> = [
   { value: "error", label: "Error" },
   { value: "warn", label: "Warning" },
@@ -71,8 +71,8 @@ export function LogsWindow() {
   const [query, setQuery] = useState("");
   const [activeMatchIndex, setActiveMatchIndex] = useState(0);
   const [following, setFollowing] = useState(true);
-  const [minimumLevel, setMinimumLevel] = useState<LogLevelFilter>(
-    DEFAULT_MINIMUM_LOG_LEVEL,
+  const [selectedLevels, setSelectedLevels] = useState<LogLevelFilter[]>(
+    DEFAULT_SELECTED_LOG_LEVELS,
   );
   const [debugCollectionEnabled, setDebugCollectionEnabled] = useState(false);
 
@@ -209,13 +209,13 @@ export function LogsWindow() {
   const rendered = useMemo(() => {
     const entries = orderedRenderedLogEntries(entryBufferRef.current);
     const visibleEntries = entries.filter((entry) =>
-      shouldShowLogEntry(entry, minimumLevel),
+      shouldShowLogEntry(entry, selectedLevels),
     );
     return buildRenderedLogLines(
       visibleEntries.map((entry) => entry.line).join("\n"),
       query,
     );
-  }, [minimumLevel, query, renderVersion]);
+  }, [query, renderVersion, selectedLevels]);
 
   useEffect(() => {
     setActiveMatchIndex(0);
@@ -288,10 +288,14 @@ export function LogsWindow() {
     }
   }, [setFollowingMode]);
 
-  const handleMinimumLevelChange = useCallback(
+  const handleLogLevelToggle = useCallback(
     (value: LogLevelFilter) => {
-      setMinimumLevel(value);
-      const nextDebugCollectionEnabled = value === "debug";
+      const nextLevels = selectedLevels.includes(value)
+        ? selectedLevels.filter((level) => level !== value)
+        : [...selectedLevels, value];
+      setSelectedLevels(nextLevels);
+
+      const nextDebugCollectionEnabled = nextLevels.includes("debug");
       if (desiredDebugCollectionRef.current === nextDebugCollectionEnabled) {
         return;
       }
@@ -299,7 +303,7 @@ export function LogsWindow() {
       desiredDebugCollectionRef.current = nextDebugCollectionEnabled;
       syncDebugCollection();
     },
-    [syncDebugCollection],
+    [selectedLevels, syncDebugCollection],
   );
 
   const handleCopyLogFilePath = useCallback(() => {
@@ -355,22 +359,24 @@ export function LogsWindow() {
               />
             </label>
             <div
-              aria-label="Minimum log level"
+              aria-label="Log levels"
               className="log-window__level-filter"
               role="group"
             >
               {LOG_LEVEL_FILTERS.map((option) => (
                 <button
                   key={option.value}
-                  aria-pressed={minimumLevel === option.value}
+                  aria-pressed={selectedLevels.includes(option.value)}
                   className="log-window__level-option"
                   data-debug-collection={
-                    option.value === "debug" && !debugCollectionEnabled
+                    option.value === "debug" &&
+                    selectedLevels.includes("debug") &&
+                    !debugCollectionEnabled
                       ? "off"
                       : undefined
                   }
                   type="button"
-                  onClick={() => handleMinimumLevelChange(option.value)}
+                  onClick={() => handleLogLevelToggle(option.value)}
                 >
                   {option.label}
                 </button>
@@ -524,12 +530,18 @@ export function orderedRenderedLogEntries(
   return ordered;
 }
 
-function shouldShowLogEntry(entry: AppLogEntry, minimumLevel: LogLevelFilter): boolean {
+function shouldShowLogEntry(
+  entry: AppLogEntry,
+  selectedLevels: LogLevelFilter[],
+): boolean {
   const level = normalizeLogLevel(entry.level);
   if (!level) {
-    return minimumLevel === "debug" || minimumLevel === "info";
+    return selectedLevels.includes("info");
   }
-  return severityForLogLevel(level) <= severityForLogLevel(minimumLevel);
+  if (level === "trace" || level === "verbose") {
+    return selectedLevels.includes("debug");
+  }
+  return selectedLevels.includes(level);
 }
 
 function LogLine(props: {
@@ -690,13 +702,6 @@ function normalizeLogLevel(levelToken: string): LogLevel | undefined {
     return value;
   }
   return undefined;
-}
-
-function severityForLogLevel(level: LogLevel): number {
-  if (level === "error") return 0;
-  if (level === "warn") return 1;
-  if (level === "info") return 2;
-  return 3;
 }
 
 function toneForLogLevel(level: LogLevel | undefined): LogLinePartTone | undefined {

--- a/apps/desktop/src/renderer/src/features/logs/LogsWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/logs/LogsWindow.tsx
@@ -7,13 +7,20 @@ import {
   type MutableRefObject,
   type ReactNode,
 } from "react";
-import type { AppLogEntry } from "../../../../shared/app-metadata";
+import type { AppLogEntry, AppLogSnapshot } from "../../../../shared/app-metadata";
 import { CopyIcon } from "../../icons";
 import { copyText } from "../../lib/copy-text";
 import { useDesktopApi } from "../../lib/desktop-api";
 
 const BOTTOM_THRESHOLD_PX = 32;
 export const MAX_RENDERED_LOG_ENTRIES = 5000;
+const DEFAULT_MINIMUM_LOG_LEVEL: LogLevelFilter = "info";
+const LOG_LEVEL_FILTERS: Array<{ value: LogLevelFilter; label: string }> = [
+  { value: "error", label: "Error" },
+  { value: "warn", label: "Warning" },
+  { value: "info", label: "Info" },
+  { value: "debug", label: "Debug" },
+];
 
 type RenderedLogEntryBuffer = {
   slots: Array<AppLogEntry | undefined>;
@@ -34,6 +41,7 @@ type RenderedLogLine = {
 };
 
 type LogLevel = "error" | "warn" | "info" | "debug" | "trace" | "verbose";
+type LogLevelFilter = "error" | "warn" | "info" | "debug";
 
 type LogLinePartTone =
   | "timestamp"
@@ -59,10 +67,23 @@ export function LogsWindow() {
   const [query, setQuery] = useState("");
   const [activeMatchIndex, setActiveMatchIndex] = useState(0);
   const [following, setFollowing] = useState(true);
+  const [minimumLevel, setMinimumLevel] = useState<LogLevelFilter>(
+    DEFAULT_MINIMUM_LOG_LEVEL,
+  );
+  const [debugCollectionEnabled, setDebugCollectionEnabled] = useState(false);
 
   const setFollowingMode = useCallback((value: boolean) => {
     followingRef.current = value;
     setFollowing(value);
+  }, []);
+
+  const applySnapshot = useCallback((value: AppLogSnapshot) => {
+    entryBufferRef.current = createRenderedLogEntryBuffer(value.entries);
+    setRenderVersion((version) => version + 1);
+    setLogFilePath(value.logFilePath);
+    setDebugCollectionEnabled(value.debugCollectionEnabled);
+    setTruncated(value.truncated || value.entries.length > MAX_RENDERED_LOG_ENTRIES);
+    setError(undefined);
   }, []);
 
   useEffect(() => {
@@ -86,17 +107,13 @@ export function LogsWindow() {
     setLoading(true);
     try {
       const value = await reader();
-      entryBufferRef.current = createRenderedLogEntryBuffer(value.entries);
-      setRenderVersion((version) => version + 1);
-      setLogFilePath(value.logFilePath);
-      setTruncated(value.truncated || value.entries.length > MAX_RENDERED_LOG_ENTRIES);
-      setError(undefined);
+      applySnapshot(value);
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
       setLoading(false);
     }
-  }, [desktopApi]);
+  }, [applySnapshot, desktopApi]);
 
   useEffect(() => {
     void loadSnapshot();
@@ -149,8 +166,14 @@ export function LogsWindow() {
 
   const rendered = useMemo(() => {
     const entries = orderedRenderedLogEntries(entryBufferRef.current);
-    return buildRenderedLogLines(entries.map((entry) => entry.line).join("\n"), query);
-  }, [query, renderVersion]);
+    const visibleEntries = entries.filter((entry) =>
+      shouldShowLogEntry(entry, minimumLevel),
+    );
+    return buildRenderedLogLines(
+      visibleEntries.map((entry) => entry.line).join("\n"),
+      query,
+    );
+  }, [minimumLevel, query, renderVersion]);
 
   useEffect(() => {
     setActiveMatchIndex(0);
@@ -223,6 +246,30 @@ export function LogsWindow() {
     }
   }, [setFollowingMode]);
 
+  const handleMinimumLevelChange = useCallback(
+    (value: LogLevelFilter) => {
+      setMinimumLevel(value);
+      const nextDebugCollectionEnabled = value === "debug";
+      const setter = desktopApi?.setAppLogDebugCollectionEnabled;
+      if (!setter || nextDebugCollectionEnabled === debugCollectionEnabled) {
+        return;
+      }
+
+      setLoading(true);
+      void setter(nextDebugCollectionEnabled)
+        .then((snapshot) => {
+          applySnapshot(snapshot);
+        })
+        .catch((err: unknown) => {
+          setError(err instanceof Error ? err.message : String(err));
+        })
+        .finally(() => {
+          setLoading(false);
+        });
+    },
+    [applySnapshot, debugCollectionEnabled, desktopApi],
+  );
+
   const handleCopyLogFilePath = useCallback(() => {
     if (!logFilePath) {
       return;
@@ -275,6 +322,28 @@ export function LogsWindow() {
                 spellCheck={false}
               />
             </label>
+            <div
+              aria-label="Minimum log level"
+              className="log-window__level-filter"
+              role="group"
+            >
+              {LOG_LEVEL_FILTERS.map((option) => (
+                <button
+                  key={option.value}
+                  aria-pressed={minimumLevel === option.value}
+                  className="log-window__level-option"
+                  data-debug-collection={
+                    option.value === "debug" && !debugCollectionEnabled
+                      ? "off"
+                      : undefined
+                  }
+                  type="button"
+                  onClick={() => handleMinimumLevelChange(option.value)}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
             <span className="log-window__match-count" aria-live="polite">
               {activeMatchLabel}
             </span>
@@ -336,6 +405,9 @@ export function LogsWindow() {
             </span>
             {truncated ? (
               <span className="log-window__status-note">Showing tail</span>
+            ) : null}
+            {debugCollectionEnabled ? (
+              <span className="log-window__status-note">Debug collection on</span>
             ) : null}
           </div>
 
@@ -418,6 +490,14 @@ export function orderedRenderedLogEntries(
     }
   }
   return ordered;
+}
+
+function shouldShowLogEntry(entry: AppLogEntry, minimumLevel: LogLevelFilter): boolean {
+  const level = normalizeLogLevel(entry.level);
+  if (!level) {
+    return minimumLevel === "debug" || minimumLevel === "info";
+  }
+  return severityForLogLevel(level) <= severityForLogLevel(minimumLevel);
 }
 
 function LogLine(props: {
@@ -578,6 +658,13 @@ function normalizeLogLevel(levelToken: string): LogLevel | undefined {
     return value;
   }
   return undefined;
+}
+
+function severityForLogLevel(level: LogLevel): number {
+  if (level === "error") return 0;
+  if (level === "warn") return 1;
+  if (level === "info") return 2;
+  return 3;
 }
 
 function toneForLogLevel(level: LogLevel | undefined): LogLinePartTone | undefined {

--- a/apps/desktop/src/renderer/src/features/logs/LogsWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/logs/LogsWindow.tsx
@@ -56,6 +56,10 @@ export function LogsWindow() {
   const logViewportRef = useRef<HTMLDivElement | null>(null);
   const activeMatchRef = useRef<HTMLElement | null>(null);
   const followingRef = useRef(true);
+  const confirmedDebugCollectionRef = useRef(false);
+  const desiredDebugCollectionRef = useRef(false);
+  const debugCollectionSyncInFlightRef = useRef(false);
+  const syncDebugCollectionRef = useRef<() => void>(() => undefined);
   const entryBufferRef = useRef(createRenderedLogEntryBuffer());
   const copyResetTimerRef = useRef<number | undefined>(undefined);
   const [renderVersion, setRenderVersion] = useState(0);
@@ -81,10 +85,48 @@ export function LogsWindow() {
     entryBufferRef.current = createRenderedLogEntryBuffer(value.entries);
     setRenderVersion((version) => version + 1);
     setLogFilePath(value.logFilePath);
+    confirmedDebugCollectionRef.current = value.debugCollectionEnabled;
     setDebugCollectionEnabled(value.debugCollectionEnabled);
     setTruncated(value.truncated || value.entries.length > MAX_RENDERED_LOG_ENTRIES);
     setError(undefined);
   }, []);
+
+  const syncDebugCollection = useCallback(() => {
+    const setter = desktopApi?.setAppLogDebugCollectionEnabled;
+    if (!setter || debugCollectionSyncInFlightRef.current) {
+      return;
+    }
+
+    const desiredDebugCollectionEnabled = desiredDebugCollectionRef.current;
+    if (
+      confirmedDebugCollectionRef.current === desiredDebugCollectionEnabled
+    ) {
+      return;
+    }
+
+    debugCollectionSyncInFlightRef.current = true;
+    let requestFailed = false;
+    setLoading(true);
+    void setter(desiredDebugCollectionEnabled)
+      .then((snapshot) => {
+        applySnapshot(snapshot);
+      })
+      .catch((err: unknown) => {
+        requestFailed = true;
+        setError(err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => {
+        debugCollectionSyncInFlightRef.current = false;
+        setLoading(false);
+        if (!requestFailed) {
+          syncDebugCollectionRef.current();
+        }
+      });
+  }, [applySnapshot, desktopApi]);
+
+  useEffect(() => {
+    syncDebugCollectionRef.current = syncDebugCollection;
+  }, [syncDebugCollection]);
 
   useEffect(() => {
     document.title = "Logs";
@@ -250,24 +292,14 @@ export function LogsWindow() {
     (value: LogLevelFilter) => {
       setMinimumLevel(value);
       const nextDebugCollectionEnabled = value === "debug";
-      const setter = desktopApi?.setAppLogDebugCollectionEnabled;
-      if (!setter || nextDebugCollectionEnabled === debugCollectionEnabled) {
+      if (desiredDebugCollectionRef.current === nextDebugCollectionEnabled) {
         return;
       }
 
-      setLoading(true);
-      void setter(nextDebugCollectionEnabled)
-        .then((snapshot) => {
-          applySnapshot(snapshot);
-        })
-        .catch((err: unknown) => {
-          setError(err instanceof Error ? err.message : String(err));
-        })
-        .finally(() => {
-          setLoading(false);
-        });
+      desiredDebugCollectionRef.current = nextDebugCollectionEnabled;
+      syncDebugCollection();
     },
-    [applySnapshot, debugCollectionEnabled, desktopApi],
+    [syncDebugCollection],
   );
 
   const handleCopyLogFilePath = useCallback(() => {

--- a/apps/desktop/src/renderer/src/features/logs/__tests__/logs-window.test.tsx
+++ b/apps/desktop/src/renderer/src/features/logs/__tests__/logs-window.test.tsx
@@ -11,6 +11,7 @@ import {
   tokenizeLogLine,
 } from "../LogsWindow";
 import type { DesktopApi } from "../../../lib/desktop-api";
+import type { AppLogSnapshot } from "../../../../../shared/app-metadata";
 
 afterEach(() => {
   cleanup();
@@ -248,6 +249,89 @@ describe("LogsWindow", () => {
 
     await waitFor(() => {
       expect(desktopApi.setAppLogDebugCollectionEnabled).toHaveBeenCalledWith(false);
+    });
+    expect(screen.queryByText(/hidden debug line/)).not.toBeInTheDocument();
+  });
+
+  it("disables debug collection after a rapid Debug to Info toggle", async () => {
+    const entries = [
+      {
+        sequence: 1,
+        timestamp: Date.now(),
+        level: "info",
+        line: "[2026-05-12 20:06:28.722] [info] (pwragent:main) visible info line",
+      },
+      {
+        sequence: 2,
+        timestamp: Date.now(),
+        level: "debug",
+        line: "[2026-05-12 20:06:29.000] [debug] (pwragent:main) hidden debug line",
+      },
+    ];
+    let resolveEnable: ((snapshot: AppLogSnapshot) => void) | undefined;
+    let resolveDisable: ((snapshot: AppLogSnapshot) => void) | undefined;
+    const desktopApi = {
+      readAppLogSnapshot: vi.fn(async () => ({
+        kind: "log-snapshot",
+        title: "Logs",
+        debugCollectionEnabled: false,
+        entries,
+        readAt: Date.now(),
+        truncated: false,
+      })),
+      setAppLogDebugCollectionEnabled: vi.fn(
+        (enabled: boolean) =>
+          new Promise<AppLogSnapshot>((resolve) => {
+            if (enabled) {
+              resolveEnable = resolve;
+            } else {
+              resolveDisable = resolve;
+            }
+          }),
+      ),
+      onAppLogEntry: vi.fn(() => () => undefined),
+    } as unknown as DesktopApi;
+    (window as Window & { pwragent?: DesktopApi }).pwragent = desktopApi;
+
+    render(<LogsWindow />);
+
+    expect(await screen.findByText(/visible info line/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Debug" }));
+    await waitFor(() => {
+      expect(desktopApi.setAppLogDebugCollectionEnabled).toHaveBeenCalledWith(true);
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Info" }));
+    expect(desktopApi.setAppLogDebugCollectionEnabled).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveEnable?.({
+        kind: "log-snapshot",
+        title: "Logs",
+        debugCollectionEnabled: true,
+        entries,
+        readAt: Date.now(),
+        truncated: false,
+      });
+    });
+
+    await waitFor(() => {
+      expect(desktopApi.setAppLogDebugCollectionEnabled).toHaveBeenCalledWith(false);
+    });
+
+    await act(async () => {
+      resolveDisable?.({
+        kind: "log-snapshot",
+        title: "Logs",
+        debugCollectionEnabled: false,
+        entries,
+        readAt: Date.now(),
+        truncated: false,
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText("Debug collection on")).not.toBeInTheDocument();
     });
     expect(screen.queryByText(/hidden debug line/)).not.toBeInTheDocument();
   });

--- a/apps/desktop/src/renderer/src/features/logs/__tests__/logs-window.test.tsx
+++ b/apps/desktop/src/renderer/src/features/logs/__tests__/logs-window.test.tsx
@@ -196,16 +196,28 @@ describe("LogsWindow", () => {
     });
   });
 
-  it("defaults to Info logs and enables debug collection from the Debug filter", async () => {
+  it("defaults to Error, Warning, and Info toggles with Debug off", async () => {
     const entries = [
       {
         sequence: 1,
+        timestamp: Date.now(),
+        level: "error",
+        line: "[2026-05-12 20:06:26.000] [error] (pwragent:main) visible error line",
+      },
+      {
+        sequence: 2,
+        timestamp: Date.now(),
+        level: "warn",
+        line: "[2026-05-12 20:06:27.000] [warn] (pwragent:main) visible warn line",
+      },
+      {
+        sequence: 3,
         timestamp: Date.now(),
         level: "info",
         line: "[2026-05-12 20:06:28.722] [info] (pwragent:main) visible info line",
       },
       {
-        sequence: 2,
+        sequence: 4,
         timestamp: Date.now(),
         level: "debug",
         line: "[2026-05-12 20:06:29.000] [debug] (pwragent:main) hidden debug line",
@@ -234,8 +246,22 @@ describe("LogsWindow", () => {
 
     render(<LogsWindow />);
 
+    expect(await screen.findByText(/visible error line/)).toBeInTheDocument();
+    expect(screen.getByText(/visible warn line/)).toBeInTheDocument();
     expect(await screen.findByText(/visible info line/)).toBeInTheDocument();
     expect(screen.queryByText(/hidden debug line/)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Info" }));
+
+    expect(screen.getByText(/visible error line/)).toBeInTheDocument();
+    expect(screen.getByText(/visible warn line/)).toBeInTheDocument();
+    expect(screen.queryByText(/visible info line/)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Error" }));
+
+    expect(screen.queryByText(/visible error line/)).not.toBeInTheDocument();
+    expect(screen.getByText(/visible warn line/)).toBeInTheDocument();
+    expect(screen.queryByText(/visible info line/)).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Debug" }));
 
@@ -245,7 +271,7 @@ describe("LogsWindow", () => {
     expect(await screen.findByText(/hidden debug line/)).toBeInTheDocument();
     expect(screen.getByText("Debug collection on")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Info" }));
+    fireEvent.click(screen.getByRole("button", { name: "Debug" }));
 
     await waitFor(() => {
       expect(desktopApi.setAppLogDebugCollectionEnabled).toHaveBeenCalledWith(false);
@@ -253,7 +279,7 @@ describe("LogsWindow", () => {
     expect(screen.queryByText(/hidden debug line/)).not.toBeInTheDocument();
   });
 
-  it("disables debug collection after a rapid Debug to Info toggle", async () => {
+  it("disables debug collection after a rapid Debug toggle off", async () => {
     const entries = [
       {
         sequence: 1,
@@ -301,7 +327,7 @@ describe("LogsWindow", () => {
     await waitFor(() => {
       expect(desktopApi.setAppLogDebugCollectionEnabled).toHaveBeenCalledWith(true);
     });
-    fireEvent.click(screen.getByRole("button", { name: "Info" }));
+    fireEvent.click(screen.getByRole("button", { name: "Debug" }));
     expect(desktopApi.setAppLogDebugCollectionEnabled).toHaveBeenCalledTimes(1);
 
     await act(async () => {

--- a/apps/desktop/src/renderer/src/features/logs/__tests__/logs-window.test.tsx
+++ b/apps/desktop/src/renderer/src/features/logs/__tests__/logs-window.test.tsx
@@ -151,6 +151,7 @@ describe("LogsWindow", () => {
         kind: "log-snapshot",
         title: "Logs",
         logFilePath: "/Users/example/Library/Logs/PwrAgent/main.log",
+        debugCollectionEnabled: false,
         entries: [
           {
             sequence: 1,
@@ -194,12 +195,70 @@ describe("LogsWindow", () => {
     });
   });
 
+  it("defaults to Info logs and enables debug collection from the Debug filter", async () => {
+    const entries = [
+      {
+        sequence: 1,
+        timestamp: Date.now(),
+        level: "info",
+        line: "[2026-05-12 20:06:28.722] [info] (pwragent:main) visible info line",
+      },
+      {
+        sequence: 2,
+        timestamp: Date.now(),
+        level: "debug",
+        line: "[2026-05-12 20:06:29.000] [debug] (pwragent:main) hidden debug line",
+      },
+    ];
+    const desktopApi = {
+      readAppLogSnapshot: vi.fn(async () => ({
+        kind: "log-snapshot",
+        title: "Logs",
+        debugCollectionEnabled: false,
+        entries,
+        readAt: Date.now(),
+        truncated: false,
+      })),
+      setAppLogDebugCollectionEnabled: vi.fn(async (enabled: boolean) => ({
+        kind: "log-snapshot",
+        title: "Logs",
+        debugCollectionEnabled: enabled,
+        entries,
+        readAt: Date.now(),
+        truncated: false,
+      })),
+      onAppLogEntry: vi.fn(() => () => undefined),
+    } as unknown as DesktopApi;
+    (window as Window & { pwragent?: DesktopApi }).pwragent = desktopApi;
+
+    render(<LogsWindow />);
+
+    expect(await screen.findByText(/visible info line/)).toBeInTheDocument();
+    expect(screen.queryByText(/hidden debug line/)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Debug" }));
+
+    await waitFor(() => {
+      expect(desktopApi.setAppLogDebugCollectionEnabled).toHaveBeenCalledWith(true);
+    });
+    expect(await screen.findByText(/hidden debug line/)).toBeInTheDocument();
+    expect(screen.getByText("Debug collection on")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Info" }));
+
+    await waitFor(() => {
+      expect(desktopApi.setAppLogDebugCollectionEnabled).toHaveBeenCalledWith(false);
+    });
+    expect(screen.queryByText(/hidden debug line/)).not.toBeInTheDocument();
+  });
+
   it("appends streamed log entries while following", async () => {
     let listener: Parameters<NonNullable<DesktopApi["onAppLogEntry"]>>[0] | undefined;
     const desktopApi = {
       readAppLogSnapshot: vi.fn(async () => ({
         kind: "log-snapshot",
         title: "Logs",
+        debugCollectionEnabled: false,
         entries: [],
         readAt: Date.now(),
         truncated: false,
@@ -232,6 +291,7 @@ describe("LogsWindow", () => {
       readAppLogSnapshot: vi.fn(async () => ({
         kind: "log-snapshot",
         title: "Logs",
+        debugCollectionEnabled: false,
         entries: [
           {
             sequence: 1,
@@ -273,6 +333,7 @@ describe("LogsWindow", () => {
       readAppLogSnapshot: vi.fn(async () => ({
         kind: "log-snapshot",
         title: "Logs",
+        debugCollectionEnabled: false,
         entries: [
           {
             sequence: 1,
@@ -319,6 +380,7 @@ describe("LogsWindow", () => {
         .mockResolvedValueOnce({
           kind: "log-snapshot",
           title: "Logs",
+          debugCollectionEnabled: false,
           entries: [
             {
               sequence: 1,
@@ -333,6 +395,7 @@ describe("LogsWindow", () => {
         .mockResolvedValueOnce({
           kind: "log-snapshot",
           title: "Logs",
+          debugCollectionEnabled: false,
           entries: [
             {
               sequence: 7,
@@ -396,6 +459,7 @@ describe("LogsWindow", () => {
         readAppLogSnapshot: vi.fn(async () => ({
           kind: "log-snapshot",
           title: "Logs",
+          debugCollectionEnabled: false,
           entries: Array.from(
             { length: MAX_RENDERED_LOG_ENTRIES },
             (_, index) => ({

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -231,6 +231,9 @@ export type DesktopApi = {
   openChangelogWindow?: () => Promise<void>;
   openThirdPartyNoticesWindow?: () => Promise<void>;
   readAppLogSnapshot?: () => Promise<AppLogSnapshot>;
+  setAppLogDebugCollectionEnabled?: (
+    enabled: boolean,
+  ) => Promise<AppLogSnapshot>;
   openAppLogWindow?: () => Promise<void>;
   onAppLogEntry?: (callback: (entry: AppLogEntry) => void) => () => void;
   checkForAppUpdates?: () => Promise<AppUpdateCheckResult>;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1118,6 +1118,55 @@ textarea,
   color: var(--text-subtle);
 }
 
+.log-window__level-filter {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  height: 34px;
+  overflow: hidden;
+  border: 1px solid var(--border-subtle);
+  border-radius: 7px;
+  background: var(--bg-panel-elevated);
+}
+
+.log-window__level-option {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 58px;
+  height: 100%;
+  padding: 0 10px;
+  border: 0;
+  border-right: 1px solid var(--border-subtle);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.log-window__level-option:last-child {
+  border-right: 0;
+}
+
+.log-window__level-option:hover {
+  color: var(--text-primary);
+}
+
+.log-window__level-option:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: -2px;
+}
+
+.log-window__level-option[aria-pressed="true"] {
+  background: var(--accent-soft);
+  color: var(--accent-bright);
+}
+
+.log-window__level-option[data-debug-collection="off"] {
+  color: var(--text-muted);
+}
+
 .log-window__match-count {
   flex: 0 0 auto;
   min-width: 58px;

--- a/apps/desktop/src/shared/app-metadata.ts
+++ b/apps/desktop/src/shared/app-metadata.ts
@@ -30,6 +30,7 @@ export type AppLogSnapshot = {
   kind: "log-snapshot";
   title: string;
   logFilePath?: string;
+  debugCollectionEnabled: boolean;
   entries: AppLogEntry[];
   readAt: number;
   truncated: boolean;

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -258,6 +258,8 @@ export const APP_THIRD_PARTY_NOTICES_WINDOW_OPEN_CHANNEL =
   "app:open-third-party-notices-window";
 export const APP_LOG_SNAPSHOT_READ_CHANNEL = "app:read-log-snapshot";
 export const APP_LOG_ENTRY_EVENT_CHANNEL = "app:log-entry-event";
+export const APP_LOG_DEBUG_COLLECTION_SET_CHANNEL =
+  "app:set-log-debug-collection";
 export const APP_LOG_WINDOW_OPEN_CHANNEL = "app:open-log-window";
 export const APP_UPDATE_CHECK_CHANNEL = "app:check-for-updates";
 export const APP_UPDATE_STATUS_READ_CHANNEL = "app:read-update-status";


### PR DESCRIPTION
## Summary

- I reduced overnight app-log noise by moving the repeated Codex thread-routing breadcrumb out of normal Info collection and into Debug.
- I defaulted app-log file collection to Info, then added an Error / Warning / Info / Debug selector in the Logs window.
- I made the Debug selector enable debug file collection while selected and turn it back off when returning to a lower level.

## Verification

- `pnpm test apps/desktop/src/renderer/src/features/logs/__tests__/logs-window.test.tsx apps/desktop/src/main/__tests__/app-logs.test.ts apps/desktop/src/main/__tests__/log.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`
- `git diff --check`

## Notes

- Debug collection affects future entries while enabled; it does not backfill debug rows from periods where debug collection was off.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
