### PR TITLE
fix(desktop): dedupe pending review submits

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1695,6 +1695,23 @@ export function Composer(props: ComposerProps) {
     setDraft("");
     setSkillTokens([]);
   };
+  const createEmptyComposerDraftSnapshot = (): ComposerDraftSnapshot => ({
+    draft: "",
+    editorDocument: undefined,
+    imageAttachments: [],
+    skillTokens: [],
+  });
+  const clearSubmittedComposerDraftForStart = (
+    scopeKey: string,
+  ): void => {
+    clearComposerDraftSnapshot(scopeKey);
+    latestDraftSnapshotRef.current = {
+      scopeKey,
+      snapshot: createEmptyComposerDraftSnapshot(),
+    };
+    clearComposerDraft();
+    setImageAttachments([]);
+  };
   const hasLiveComposerContent = (): boolean => {
     const latest = latestDraftSnapshotRef.current;
     return Boolean(
@@ -1827,6 +1844,47 @@ export function Composer(props: ComposerProps) {
         inputRef.current?.setSelectionRange(0, 0);
       });
     });
+  };
+  const hasNewLiveComposerContentSinceSubmittedClear = (
+    submittedSnapshot: ComposerDraftSnapshot,
+  ): boolean => {
+    const latest = latestDraftSnapshotRef.current;
+    const latestSnapshot =
+      latest.scopeKey === composerScopeKey
+        ? latest.snapshot
+        : createEmptyComposerDraftSnapshot();
+    const liveDraft = inputRef.current?.value ?? latestSnapshot.draft;
+    const liveSkillTokenCount =
+      inputRef.current?.skillTokenCount ?? latestSnapshot.skillTokens.length;
+    const latestSnapshotIsCleared =
+      !latestSnapshot.draft.trim() &&
+      latestSnapshot.skillTokens.length === 0 &&
+      latestSnapshot.imageAttachments.length === 0;
+
+    if (
+      latestSnapshotIsCleared &&
+      liveDraft === submittedSnapshot.draft &&
+      liveSkillTokenCount === submittedSnapshot.skillTokens.length
+    ) {
+      return false;
+    }
+
+    return Boolean(
+      liveDraft.trim() ||
+        liveSkillTokenCount > 0 ||
+        latestSnapshot.imageAttachments.length > 0,
+    );
+  };
+  const recoverSubmittedComposerDraft = (
+    snapshot: ComposerDraftSnapshot,
+  ): boolean => {
+    if (hasNewLiveComposerContentSinceSubmittedClear(snapshot)) {
+      recordComposerDraftHistory(composerScopeKey, snapshot, "unsent");
+      return false;
+    }
+
+    applyRecoveredComposerDraft(snapshot);
+    return true;
   };
   const clearRecoveredComposerDraft = (): void => {
     recoveryCycleRef.current = undefined;
@@ -2873,8 +2931,7 @@ export function Composer(props: ComposerProps) {
     setActiveOptimisticMessageId(optimisticReviewId);
     const submittedSnapshot = latestDraftSnapshotRef.current.snapshot;
     if (!options?.queued) {
-      clearComposerDraftSnapshot(composerScopeKey);
-      clearComposerDraft();
+      clearSubmittedComposerDraftForStart(composerScopeKey);
       setReviewConfig(undefined);
     }
     try {
@@ -2884,6 +2941,7 @@ export function Composer(props: ComposerProps) {
         target: reviewCommand.target,
         delivery: "inline",
       });
+      inFlightReviewSubmissionKeyRef.current = undefined;
       updateActiveTurnId(response.turnId, { review: true });
       props.onActiveTurnIdChange?.(response.turnId);
       if (options?.queued) {
@@ -2903,7 +2961,7 @@ export function Composer(props: ComposerProps) {
       }
       inFlightReviewSubmissionKeyRef.current = undefined;
       if (!options?.queued) {
-        applyRecoveredComposerDraft(submittedSnapshot);
+        recoverSubmittedComposerDraft(submittedSnapshot);
       }
       props.onPendingStatusChange?.(undefined);
       updateSending(false);
@@ -3093,9 +3151,7 @@ export function Composer(props: ComposerProps) {
     setActiveOptimisticMessageId(optimisticMessageId);
     const submittedSnapshot = latestDraftSnapshotRef.current.snapshot;
     if (!queued) {
-      clearComposerDraftSnapshot(composerScopeKey);
-      clearComposerDraft();
-      setImageAttachments([]);
+      clearSubmittedComposerDraftForStart(composerScopeKey);
       if (collaborationMode) {
         setPlanModeEnabled(false);
       }
@@ -3137,8 +3193,9 @@ export function Composer(props: ComposerProps) {
         props.removeOptimisticMessage?.(optimisticMessageId);
       }
       if (!queued) {
-        applyRecoveredComposerDraft(submittedSnapshot);
-        if (collaborationMode) {
+        const recoveredSubmittedDraft =
+          recoverSubmittedComposerDraft(submittedSnapshot);
+        if (collaborationMode && recoveredSubmittedDraft) {
           setPlanModeEnabled(true);
         }
       }

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -2871,6 +2871,12 @@ export function Composer(props: ComposerProps) {
       reviewCommand.displayText
     );
     setActiveOptimisticMessageId(optimisticReviewId);
+    const submittedSnapshot = latestDraftSnapshotRef.current.snapshot;
+    if (!options?.queued) {
+      clearComposerDraftSnapshot(composerScopeKey);
+      clearComposerDraft();
+      setReviewConfig(undefined);
+    }
     try {
       const response = await props.desktopApi.startReview({
         backend: props.thread.source,
@@ -2887,18 +2893,18 @@ export function Composer(props: ComposerProps) {
       } else {
         recordComposerDraftHistory(
           composerScopeKey,
-          latestDraftSnapshotRef.current.snapshot,
+          submittedSnapshot,
           "sent",
         );
-        clearComposerDraftSnapshot(composerScopeKey);
-        clearComposerDraft();
-        setReviewConfig(undefined);
       }
     } catch (error) {
       if (optimisticReviewId) {
         props.removeOptimisticMessage?.(optimisticReviewId);
       }
       inFlightReviewSubmissionKeyRef.current = undefined;
+      if (!options?.queued) {
+        applyRecoveredComposerDraft(submittedSnapshot);
+      }
       props.onPendingStatusChange?.(undefined);
       updateSending(false);
       setInterrupting(false);
@@ -3085,6 +3091,15 @@ export function Composer(props: ComposerProps) {
       payload.imageParts
     );
     setActiveOptimisticMessageId(optimisticMessageId);
+    const submittedSnapshot = latestDraftSnapshotRef.current.snapshot;
+    if (!queued) {
+      clearComposerDraftSnapshot(composerScopeKey);
+      clearComposerDraft();
+      setImageAttachments([]);
+      if (collaborationMode) {
+        setPlanModeEnabled(false);
+      }
+    }
 
     try {
       const response = await props.desktopApi.startTurn({
@@ -3113,19 +3128,19 @@ export function Composer(props: ComposerProps) {
       } else {
         recordComposerDraftHistory(
           composerScopeKey,
-          latestDraftSnapshotRef.current.snapshot,
+          submittedSnapshot,
           "sent",
         );
-        clearComposerDraftSnapshot(composerScopeKey);
-        clearComposerDraft();
-        setImageAttachments([]);
-        if (collaborationMode) {
-          setPlanModeEnabled(false);
-        }
       }
     } catch (error) {
       if (optimisticMessageId) {
         props.removeOptimisticMessage?.(optimisticMessageId);
+      }
+      if (!queued) {
+        applyRecoveredComposerDraft(submittedSnapshot);
+        if (collaborationMode) {
+          setPlanModeEnabled(true);
+        }
       }
       props.onPendingStatusChange?.(undefined);
       updateSending(false);

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1020,6 +1020,22 @@ function reviewCommandToDraftText(command: {
   return `/review --custom ${target.instructions}`;
 }
 
+function reviewSubmissionKey(command: {
+  target: AppServerReviewTarget;
+}): string {
+  const target = command.target;
+  switch (target.type) {
+    case "baseBranch":
+      return `review:baseBranch:${target.branch}`;
+    case "commit":
+      return `review:commit:${target.sha}:${target.title ?? ""}`;
+    case "custom":
+      return `review:custom:${target.instructions}`;
+    default:
+      return `review:${JSON.stringify(target)}`;
+  }
+}
+
 function HighlightedAutocompleteLabel(props: {
   label: string;
   query: string;
@@ -1403,6 +1419,7 @@ export function Composer(props: ComposerProps) {
   const autocompleteListRef = useRef<HTMLDivElement>(null);
   const activeTurnIdRef = useRef<string | undefined>(props.activeTurnId);
   const activeReviewTurnIdRef = useRef<string | undefined>(undefined);
+  const inFlightReviewSubmissionKeyRef = useRef<string | undefined>(undefined);
   const autocompleteOptionRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const skillListboxId = useId();
   const slashListboxId = useId();
@@ -2777,6 +2794,15 @@ export function Composer(props: ComposerProps) {
     queueClaimed?: boolean;
     queued?: QueuedTurnDraft;
   }): Promise<void> => {
+    const submissionKey = reviewSubmissionKey(reviewCommand);
+    if (
+      sendingRef.current &&
+      inFlightReviewSubmissionKeyRef.current === submissionKey
+    ) {
+      restoreQueuedTurnIfClaimed(options?.queued, options?.queueClaimed);
+      releaseQueuedTurnScopeLockIfClaimed(options?.queued, options?.queueClaimed);
+      return;
+    }
     if (props.disabled) {
       restoreQueuedTurnIfClaimed(options?.queued, options?.queueClaimed);
       releaseQueuedTurnScopeLockIfClaimed(options?.queued, options?.queueClaimed);
@@ -2798,6 +2824,7 @@ export function Composer(props: ComposerProps) {
     }
 
     setSendError(undefined);
+    inFlightReviewSubmissionKeyRef.current = submissionKey;
     updateSending(true);
     props.onPendingStatusChange?.("Reviewing");
 
@@ -2821,6 +2848,7 @@ export function Composer(props: ComposerProps) {
         setReviewConfig(undefined);
       } catch (error) {
         unmarkComposerDraftSubmitted(submittedScopeKey);
+        inFlightReviewSubmissionKeyRef.current = undefined;
         props.onPendingStatusChange?.(undefined);
         restoreQueuedTurnIfClaimed(options?.queued, options?.queueClaimed);
         releaseQueuedTurnScopeLockIfClaimed(options?.queued, options?.queueClaimed);
@@ -2870,6 +2898,7 @@ export function Composer(props: ComposerProps) {
       if (optimisticReviewId) {
         props.removeOptimisticMessage?.(optimisticReviewId);
       }
+      inFlightReviewSubmissionKeyRef.current = undefined;
       props.onPendingStatusChange?.(undefined);
       updateSending(false);
       setInterrupting(false);
@@ -3376,6 +3405,13 @@ export function Composer(props: ComposerProps) {
 
   const submitTurn = async (mode: "default" | "steer" = "default"): Promise<void> => {
     const reviewCommand = supportsReview ? parseReviewCommand(draft) : undefined;
+    if (
+      reviewCommand &&
+      sendingRef.current &&
+      inFlightReviewSubmissionKeyRef.current === reviewSubmissionKey(reviewCommand)
+    ) {
+      return;
+    }
     if (isCompactCommand) {
       await submitCompactThread();
       return;

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -4049,6 +4049,68 @@ describe("Composer", () => {
     expect(startTurn).not.toHaveBeenCalled();
   });
 
+  it("ignores a duplicate slash review submit while the review start is pending", async () => {
+    const startTurn = vi.fn();
+    const addOptimisticReviewEntry = vi.fn(() => "review-optimistic-1");
+    const startReviewDeferred = createDeferred<{
+      backend: "codex";
+      threadId: string;
+      reviewThreadId: string;
+      turnId: string;
+    }>();
+    const startReview = vi.fn(() => startReviewDeferred.promise);
+
+    render(
+      <Composer
+        addOptimisticReviewEntry={addOptimisticReviewEntry}
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview,
+          startTurn,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Review thread",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    const form = textarea.closest("form");
+    expect(form).not.toBeNull();
+
+    fireEvent.change(textarea, {
+      target: { value: "/review main" },
+    });
+
+    await act(async () => {
+      fireEvent.submit(form!);
+      fireEvent.submit(form!);
+      await Promise.resolve();
+    });
+
+    expect(startReview).toHaveBeenCalledTimes(1);
+    expect(addOptimisticReviewEntry).toHaveBeenCalledTimes(1);
+    expect(startTurn).not.toHaveBeenCalled();
+    expect(screen.queryByLabelText("Queued message")).not.toBeInTheDocument();
+
+    await act(async () => {
+      startReviewDeferred.resolve({
+        backend: "codex",
+        threadId: "thread-1",
+        reviewThreadId: "thread-1",
+        turnId: "turn-review-1",
+      });
+    });
+  });
+
   it("keeps review completion tied to the review/start turn id", async () => {
     let agentEventHandler: ((event: {
       backend: "codex";

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1440,6 +1440,7 @@ describe("Composer", () => {
 
     expect(screen.getByRole("button", { name: "Sending…" })).toBeDisabled();
     expect(textarea).toBeEnabled();
+    expect(textarea).toHaveValue("");
 
     await act(async () => {
       resolveStartTurn?.({
@@ -1447,6 +1448,41 @@ describe("Composer", () => {
         threadId: "thread-1",
         turnId: "turn-1",
       });
+    });
+  });
+
+  it("restores the reply draft when starting a turn fails after clearing", async () => {
+    const startTurn = vi.fn(async () => {
+      throw new Error("Start failed");
+    });
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Failed send",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "Restore this draft" } });
+    await clickButton("Send");
+
+    await waitFor(() => {
+      expect(textarea).toHaveValue("Restore this draft");
+      expect(screen.getByText("Start failed")).toBeInTheDocument();
     });
   });
 
@@ -4099,6 +4135,7 @@ describe("Composer", () => {
     expect(startReview).toHaveBeenCalledTimes(1);
     expect(addOptimisticReviewEntry).toHaveBeenCalledTimes(1);
     expect(startTurn).not.toHaveBeenCalled();
+    expect(textarea).toHaveValue("");
     expect(screen.queryByLabelText("Queued message")).not.toBeInTheDocument();
 
     await act(async () => {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1486,6 +1486,46 @@ describe("Composer", () => {
     });
   });
 
+  it("preserves newer reply edits when starting a turn fails after clearing", async () => {
+    const startTurnDeferred = createDeferred<StartTurnResponse>();
+    const startTurn = vi.fn(() => startTurnDeferred.promise);
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Failed send",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "Submitted draft" } });
+    await clickButton("Send");
+    expect(textarea).toHaveValue("");
+
+    fireEvent.change(textarea, { target: { value: "Next draft" } });
+    await act(async () => {
+      startTurnDeferred.reject(new Error("Start failed"));
+    });
+
+    await waitFor(() => {
+      expect(textarea).toHaveValue("Next draft");
+      expect(screen.getByText("Start failed")).toBeInTheDocument();
+    });
+  });
+
   it("queues submits while a turn start is pending", async () => {
     let resolveStartTurn: ((value: StartTurnResponse) => void) | undefined;
     const startTurn = vi.fn(
@@ -4146,6 +4186,114 @@ describe("Composer", () => {
         turnId: "turn-review-1",
       });
     });
+  });
+
+  it("preserves newer reply edits when starting a review fails after clearing", async () => {
+    const startReviewDeferred = createDeferred<{
+      backend: "codex";
+      threadId: string;
+      reviewThreadId: string;
+      turnId: string;
+    }>();
+    const startReview = vi.fn(() => startReviewDeferred.promise);
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview,
+          startTurn: vi.fn(),
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Review thread",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, {
+      target: { value: "/review main" },
+    });
+    await clickButton("Send");
+    expect(textarea).toHaveValue("");
+
+    fireEvent.change(textarea, { target: { value: "Next draft" } });
+    await act(async () => {
+      startReviewDeferred.reject(new Error("Review failed"));
+    });
+
+    await waitFor(() => {
+      expect(textarea).toHaveValue("Next draft");
+      expect(screen.getByText("Review failed")).toBeInTheDocument();
+    });
+  });
+
+  it("queues an identical slash review after the previous review start is accepted", async () => {
+    const startTurn = vi.fn();
+    const addOptimisticReviewEntry = vi.fn(() => "review-optimistic-1");
+    const startReviewDeferred = createDeferred<{
+      backend: "codex";
+      threadId: string;
+      reviewThreadId: string;
+      turnId: string;
+    }>();
+    const startReview = vi.fn(() => startReviewDeferred.promise);
+
+    render(
+      <Composer
+        addOptimisticReviewEntry={addOptimisticReviewEntry}
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview,
+          startTurn,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Review thread",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, {
+      target: { value: "/review main" },
+    });
+    await clickButton("Send");
+
+    await act(async () => {
+      startReviewDeferred.resolve({
+        backend: "codex",
+        threadId: "thread-1",
+        reviewThreadId: "thread-1",
+        turnId: "turn-review-1",
+      });
+    });
+
+    fireEvent.change(textarea, {
+      target: { value: "/review main" },
+    });
+    await clickButton("Queue");
+
+    expect(startReview).toHaveBeenCalledTimes(1);
+    expect(addOptimisticReviewEntry).toHaveBeenCalledTimes(1);
+    expect(startTurn).not.toHaveBeenCalled();
+    expect(screen.getByText("Queued next")).toBeInTheDocument();
+    expect(screen.getByText("Review changes against main")).toBeInTheDocument();
   });
 
   it("keeps review completion tied to the review/start turn id", async () => {


### PR DESCRIPTION
## Summary

Duplicate `/review` submits no longer start or queue a second identical review while the first review request is still pending. The composer now keys an in-flight review by target, ignores same-target re-entry, and keeps intentional different follow-ups eligible for the existing queue behavior.

Accepted sends now also clear the composer immediately instead of leaving the submitted draft visible until the app-server call returns. If `startTurn` or `startReview` fails, the submitted draft is restored so the user gets fast feedback without losing their text.

## Verification

- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx -t "duplicate slash review"`
- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx -t "keeps the reply input focusable|restores the reply draft|duplicate slash review"`
- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx -t "review turn"`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5.5_%28high%29](https://img.shields.io/badge/GPT--5.5_%28high%29-000000)
