### PR TITLE
fix(desktop): restore env action elapsed formatting

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -664,7 +664,8 @@ export function formatDurationMs(
 export function formatRunningDurationMs(ms?: number): string {
   if (ms === undefined || !Number.isFinite(ms) || ms < 0) return "";
   const totalSeconds = Math.floor(ms / 1_000);
-  return `${totalSeconds}s`;
+  if (totalSeconds < 1) return "0s";
+  return formatDurationMs(totalSeconds * 1_000);
 }
 
 /**

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/EnvActionAnchorEntry.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/EnvActionAnchorEntry.test.tsx
@@ -443,9 +443,10 @@ describe("formatRunningDurationMs", () => {
     expect(formatRunningDurationMs(59_999)).toBe("59s");
   });
 
-  it("keeps long-running live values in seconds", () => {
-    expect(formatRunningDurationMs(60_000)).toBe("60s");
-    expect(formatRunningDurationMs(119_999)).toBe("119s");
-    expect(formatRunningDurationMs(6 * 60_000 + 23_000)).toBe("383s");
+  it("formats minute-plus live elapsed values as minutes and seconds", () => {
+    expect(formatRunningDurationMs(60_000)).toBe("1m");
+    expect(formatRunningDurationMs(119_999)).toBe("1m 59s");
+    expect(formatRunningDurationMs(323_000)).toBe("5m 23s");
+    expect(formatRunningDurationMs(6 * 60_000 + 23_000)).toBe("6m 23s");
   });
 });


### PR DESCRIPTION
## Summary

- I restored minute-and-second formatting for the live Env Action Running elapsed label so values like `323s` render as `5m 23s`.
- I kept the recent live-counter cleanup that shows `0s` before one full second has elapsed instead of surfacing milliseconds.
- I added a regression assertion for the `323_000ms -> 5m 23s` case.

## Verification

- I ran `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/EnvActionAnchorEntry.test.tsx`.

## Notes

- The regression came from the newer live running-duration helper returning raw seconds for all elapsed values instead of reusing the existing duration formatter once the counter reached whole seconds.
