### PR TITLE
fix(messaging): reduce status refresh slow-mode noise

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -7176,6 +7176,60 @@ describe("MessagingController", () => {
     });
   });
 
+  it("does not resurrect a revoked binding after a failed status refresh returns a surface", async () => {
+    const harness = await createHarness({
+      deliver: async () => ({
+        channel: "telegram",
+        deliveredAt: 1000,
+        outcome: "failed",
+        errorMessage: "Bad Request: chat not found",
+        surface: {
+          channel: "telegram",
+          id: "stale-status-surface",
+        },
+      }),
+    });
+    await harness.store.upsertBinding({
+      id: "binding:telegram:dm::chat-1:codex:thread-1",
+      channel: {
+        channel: "telegram",
+        conversation: {
+          id: "chat-1",
+          kind: "dm",
+        },
+      },
+      backend: "codex",
+      threadId: "thread-1",
+      authorizedActorIds: ["user-1"],
+      createdAt: 1000,
+      updatedAt: 1000,
+      statusSurface: {
+        channel: "telegram",
+        id: "existing-status-surface",
+      },
+    });
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+          },
+        },
+      },
+    });
+
+    await expect(
+      harness.store.getBinding("binding:telegram:dm::chat-1:codex:thread-1"),
+    ).resolves.toMatchObject({
+      revokedAt: 1000,
+    });
+  });
+
   it("does not revoke a binding from a failure result for another channel", async () => {
     const harness = await createHarness({
       deliver: async () => ({

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -4643,6 +4643,77 @@ describe("MessagingController", () => {
     });
   });
 
+  it("hydrates a bound Telegram topic title from managed topic metadata", async () => {
+    const harness = await createHarness();
+    await harness.store.upsertManagedTopic({
+      id: "topic:telegram:-1001:56",
+      authorizedActorIds: ["user-1"],
+      channel: "telegram",
+      conversation: {
+        id: "56",
+        kind: "topic",
+        parentId: "-1001",
+        parentTitle: "Ops",
+        title: "Test Thread",
+      },
+      createdAt: 1000,
+      lastObservedAt: 1000,
+      lifecycle: "open",
+      source: "observed",
+      supergroupId: "-1001",
+      title: "Test Thread",
+      topicId: "56",
+      updatedAt: 1000,
+    });
+    await harness.store.upsertBinding({
+      id: "binding:telegram:topic:-1001:56:codex:thread-1",
+      channel: {
+        channel: "telegram",
+        conversation: {
+          id: "56",
+          kind: "topic",
+          parentId: "-1001",
+          parentTitle: "Ops",
+        },
+      },
+      backend: "codex",
+      threadId: "thread-1",
+      authorizedActorIds: ["user-1"],
+      createdAt: 1000,
+      updatedAt: 1000,
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildTextEvent("hello", {
+        channel: {
+          channel: "telegram",
+          conversation: {
+            id: "56",
+            kind: "topic",
+            parentId: "-1001",
+            parentTitle: "Ops",
+          },
+        },
+        routingState: {
+          opaque: {
+            chatId: -1001,
+            messageThreadId: 56,
+          },
+        },
+      }),
+    );
+
+    await expect(
+      harness.store.getBinding("binding:telegram:topic:-1001:56:codex:thread-1"),
+    ).resolves.toMatchObject({
+      channel: {
+        conversation: {
+          title: "Test Thread",
+        },
+      },
+    });
+  });
+
   it("renders Telegram topic cleanup as dry-run proposals", async () => {
     const closeManagedConversation = vi.fn(async () => ({
       channel: "telegram" as const,

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -2666,6 +2666,26 @@ describe("MessagingController", () => {
     ]);
   });
 
+  it("does not refresh every bound status surface for backend rate-limit metadata", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+    harness.delivered.length = 0;
+    harness.getNavigationSnapshot.mockClear();
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "account/rateLimits/updated",
+        params: {
+          rateLimits: [],
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(harness.delivered).toEqual([]);
+    expect(harness.getNavigationSnapshot).not.toHaveBeenCalled();
+  });
+
   it("uses the thread rename event title when the navigation snapshot is stale", async () => {
     const staleNavigation = buildNavigationSnapshot();
     staleNavigation.threads[0] = {

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -1498,6 +1498,13 @@ describe("DesktopMessagingRuntime", () => {
       backend: "codex",
       bindingId: "binding:telegram:topic:-1003841603622:10345:codex:thread-1",
       channel: "telegram",
+      conversation: {
+        id: "10345",
+        kind: "topic",
+        parentId: "-1003841603622",
+        parentTitle: "PwrAgent Mini Dev Group",
+        title: "Test Thread",
+      },
       intentId: "status:1",
       intentKind: "status",
       outcome: "dropped",
@@ -1516,15 +1523,22 @@ describe("DesktopMessagingRuntime", () => {
       runtime as unknown as {
         handleDeliveryBudgetEvent: (
           event: MessagingControllerDeliveryBudgetEvent,
-        ) => void;
+        ) => Promise<void>;
       }
     ).handleDeliveryBudgetEvent.bind(runtime);
 
-    handleDeliveryBudgetEvent(event);
-    handleDeliveryBudgetEvent({
+    await handleDeliveryBudgetEvent(event);
+    await handleDeliveryBudgetEvent({
       ...event,
       at: event.at + 1000,
       bindingId: "binding:telegram:topic:-1003841603622:9387:codex:thread-2",
+      conversation: {
+        id: "9387",
+        kind: "topic",
+        parentId: "-1003841603622",
+        parentTitle: "PwrAgent Mini Dev Group",
+        title: "Release Thread",
+      },
       intentId: "status:2",
       threadId: "thread-2",
     });
@@ -1534,13 +1548,13 @@ describe("DesktopMessagingRuntime", () => {
         health: "degraded",
         degradationReasons: expect.arrayContaining([
           expect.objectContaining({
-            message: expect.stringContaining("binding binding:te...thread-1"),
+            message: expect.stringContaining("conversation PwrAgent Mini Dev Group / Test Thread"),
             scope: expect.objectContaining({
               id: "telegram:group:-1003841603622",
             }),
           }),
           expect.objectContaining({
-            message: expect.stringContaining("binding binding:te...thread-2"),
+            message: expect.stringContaining("conversation PwrAgent Mini Dev Group / Release Thread"),
             scope: expect.objectContaining({
               id: "telegram:group:-1003841603622",
             }),
@@ -1553,7 +1567,7 @@ describe("DesktopMessagingRuntime", () => {
     const { getAppStateDb } = await import("../state/app-state");
     const rows = getAppStateDb().raw
       .prepare(
-        `SELECT binding_id, thread_id, summary, payload
+        `SELECT binding_id, conversation_id, conversation_title, thread_id, summary, payload
          FROM messaging_activity_log
          WHERE kind = ?
          ORDER BY id DESC
@@ -1562,6 +1576,8 @@ describe("DesktopMessagingRuntime", () => {
       .all("diagnostic") as
         {
             binding_id: string;
+            conversation_id: string | null;
+            conversation_title: string | null;
             payload: string;
             summary: string;
             thread_id: string;
@@ -1570,16 +1586,22 @@ describe("DesktopMessagingRuntime", () => {
     expect(rows).toHaveLength(2);
     expect(rows[0]).toMatchObject({
       binding_id: "binding:telegram:topic:-1003841603622:9387:codex:thread-2",
-      summary: expect.stringContaining("binding binding:te...thread-2"),
+      summary: expect.stringContaining("conversation PwrAgent Mini Dev Group / Release Thread"),
       thread_id: "thread-2",
     });
     expect(rows[1]).toMatchObject({
       binding_id: event.bindingId,
-      summary: expect.stringContaining("binding binding:te...thread-1"),
+      conversation_id: "10345",
+      conversation_title: "PwrAgent Mini Dev Group / Test Thread",
+      summary: expect.stringContaining("conversation PwrAgent Mini Dev Group / Test Thread"),
       thread_id: "thread-1",
     });
     expect(JSON.parse(rows[1]?.payload ?? "{}")).toMatchObject({
       bindingId: event.bindingId,
+      conversationKind: "topic",
+      conversationParentId: "-1003841603622",
+      conversationTitle: "PwrAgent Mini Dev Group / Test Thread",
+      localThreadTitle: "Thread one",
       scopeId: "telegram:group:-1003841603622",
       scopeKind: "group",
       threadId: "thread-1",

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -1512,53 +1512,73 @@ describe("DesktopMessagingRuntime", () => {
       slowMode: true,
       threadId: "thread-1",
     };
-
-    (
+    const handleDeliveryBudgetEvent = (
       runtime as unknown as {
         handleDeliveryBudgetEvent: (
           event: MessagingControllerDeliveryBudgetEvent,
         ) => void;
       }
-    ).handleDeliveryBudgetEvent(event);
+    ).handleDeliveryBudgetEvent.bind(runtime);
+
+    handleDeliveryBudgetEvent(event);
+    handleDeliveryBudgetEvent({
+      ...event,
+      at: event.at + 1000,
+      bindingId: "binding:telegram:topic:-1003841603622:9387:codex:thread-2",
+      intentId: "status:2",
+      threadId: "thread-2",
+    });
 
     expect(runtime.getPlatformStatuses()).toEqual([
       expect.objectContaining({
         health: "degraded",
-        degradationReasons: [
+        degradationReasons: expect.arrayContaining([
           expect.objectContaining({
             message: expect.stringContaining("binding binding:te...thread-1"),
             scope: expect.objectContaining({
               id: "telegram:group:-1003841603622",
             }),
           }),
-        ],
+          expect.objectContaining({
+            message: expect.stringContaining("binding binding:te...thread-2"),
+            scope: expect.objectContaining({
+              id: "telegram:group:-1003841603622",
+            }),
+          }),
+        ]),
       }),
     ]);
+    expect(runtime.getPlatformStatuses()[0]?.degradationReasons).toHaveLength(2);
 
     const { getAppStateDb } = await import("../state/app-state");
-    const row = getAppStateDb().raw
+    const rows = getAppStateDb().raw
       .prepare(
         `SELECT binding_id, thread_id, summary, payload
          FROM messaging_activity_log
          WHERE kind = ?
          ORDER BY id DESC
-         LIMIT 1`,
+         LIMIT 2`,
       )
-      .get("diagnostic") as
-        | {
+      .all("diagnostic") as
+        {
             binding_id: string;
             payload: string;
             summary: string;
             thread_id: string;
-          }
-        | undefined;
+          }[];
 
-    expect(row).toMatchObject({
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({
+      binding_id: "binding:telegram:topic:-1003841603622:9387:codex:thread-2",
+      summary: expect.stringContaining("binding binding:te...thread-2"),
+      thread_id: "thread-2",
+    });
+    expect(rows[1]).toMatchObject({
       binding_id: event.bindingId,
       summary: expect.stringContaining("binding binding:te...thread-1"),
       thread_id: "thread-1",
     });
-    expect(JSON.parse(row?.payload ?? "{}")).toMatchObject({
+    expect(JSON.parse(rows[1]?.payload ?? "{}")).toMatchObject({
       bindingId: event.bindingId,
       scopeId: "telegram:group:-1003841603622",
       scopeKind: "group",

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -21,6 +21,7 @@ import type {
 } from "@pwragent/messaging-interface";
 import { PERMISSIVE_CAPABILITY_PROFILE } from "@pwragent/messaging-interface/testing";
 import type { MessagingBackendBridge } from "../messaging/core/messaging-adapter";
+import type { MessagingControllerDeliveryBudgetEvent } from "../messaging/core/messaging-controller";
 import type {
   DesktopMessagingAdapter,
   DesktopMessagingAdapterFactory,
@@ -1485,6 +1486,83 @@ describe("DesktopMessagingRuntime", () => {
     expect(JSON.parse(row?.payload ?? "{}")).toMatchObject({
       eventId: "evt_entered",
       eventType: "im.chat.access_event.bot_p2p_chat_entered_v1",
+    });
+  });
+
+  it("names the constrained binding in delivery budget diagnostics", async () => {
+    const { runtime } = await createRuntimeHarness();
+    await runtime.start();
+
+    const event: MessagingControllerDeliveryBudgetEvent = {
+      at: Date.now(),
+      backend: "codex",
+      bindingId: "binding:telegram:topic:-1003841603622:10345:codex:thread-1",
+      channel: "telegram",
+      intentId: "status:1",
+      intentKind: "status",
+      outcome: "dropped",
+      priority: "routine_status",
+      reason: "budget-exhausted",
+      scope: {
+        platform: "telegram",
+        id: "telegram:group:-1003841603622",
+        kind: "group",
+        label: "PwrAgent Mini Dev",
+      },
+      slowMode: true,
+      threadId: "thread-1",
+    };
+
+    (
+      runtime as unknown as {
+        handleDeliveryBudgetEvent: (
+          event: MessagingControllerDeliveryBudgetEvent,
+        ) => void;
+      }
+    ).handleDeliveryBudgetEvent(event);
+
+    expect(runtime.getPlatformStatuses()).toEqual([
+      expect.objectContaining({
+        health: "degraded",
+        degradationReasons: [
+          expect.objectContaining({
+            message: expect.stringContaining("binding binding:te...thread-1"),
+            scope: expect.objectContaining({
+              id: "telegram:group:-1003841603622",
+            }),
+          }),
+        ],
+      }),
+    ]);
+
+    const { getAppStateDb } = await import("../state/app-state");
+    const row = getAppStateDb().raw
+      .prepare(
+        `SELECT binding_id, thread_id, summary, payload
+         FROM messaging_activity_log
+         WHERE kind = ?
+         ORDER BY id DESC
+         LIMIT 1`,
+      )
+      .get("diagnostic") as
+        | {
+            binding_id: string;
+            payload: string;
+            summary: string;
+            thread_id: string;
+          }
+        | undefined;
+
+    expect(row).toMatchObject({
+      binding_id: event.bindingId,
+      summary: expect.stringContaining("binding binding:te...thread-1"),
+      thread_id: "thread-1",
+    });
+    expect(JSON.parse(row?.payload ?? "{}")).toMatchObject({
+      bindingId: event.bindingId,
+      scopeId: "telegram:group:-1003841603622",
+      scopeKind: "group",
+      threadId: "thread-1",
     });
   });
 

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -8414,16 +8414,21 @@ export class MessagingController {
       toolUpdateMode: await this.resolveToolUpdateDefaultMode(),
     });
     const result = await this.deliver(intent, binding, event);
+    const latestBinding = await this.options.store.getBinding(binding.id);
+    if (latestBinding?.revokedAt) {
+      return latestBinding;
+    }
     if (!result.surface) {
-      return binding;
+      return latestBinding ?? binding;
     }
 
+    const currentBinding = latestBinding ?? binding;
     return await this.options.store.upsertBinding({
-      ...binding,
+      ...currentBinding,
       pinnedStatusSurface:
         result.outcome === "pinned"
           ? result.surface
-          : binding.pinnedStatusSurface,
+          : currentBinding.pinnedStatusSurface,
       statusSurface: result.surface,
       updatedAt: this.now(),
     });

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -421,6 +421,7 @@ export type MessagingControllerDeliveryBudgetEvent = {
   backend?: AppServerBackendKind;
   bindingId?: string;
   channel: MessagingChannelKind;
+  conversation?: MessagingChannelRef["conversation"];
   intentId: string;
   intentKind: MessagingSurfaceIntent["kind"];
   outcome: "deferred" | "dropped";
@@ -9434,6 +9435,7 @@ export class MessagingController {
             backend: binding?.backend,
             bindingId: binding?.id ?? intent.bindingId,
             channel: budgetChannel,
+            conversation: binding?.channel.conversation,
             intentId: routedIntent.id,
             intentKind: routedIntent.kind,
             outcome: "deferred",
@@ -9468,6 +9470,7 @@ export class MessagingController {
             backend: binding?.backend,
             bindingId: binding?.id ?? intent.bindingId,
             channel: budgetChannel,
+            conversation: binding?.channel.conversation,
             intentId: routedIntent.id,
             intentKind: routedIntent.kind,
             outcome: "dropped",

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -674,11 +674,18 @@ export class MessagingController {
 
   async handleBackendEvent(event: AgentEvent): Promise<void> {
     const threadId = threadIdForBackendEvent(event);
-    if (!threadId && isBackendAccountMetadataEvent(event)) {
+    if (!threadId && event.notification.method === "account/updated") {
       await this.refreshStatusSurfacesForBackend(
         event.backend,
         event.notification.method,
       );
+      return;
+    }
+    if (!threadId && event.notification.method === "account/rateLimits/updated") {
+      this.logger.debug?.("messaging skipped bound status refresh for backend rate limits", {
+        backend: event.backend,
+        method: event.notification.method,
+      });
       return;
     }
     if (!threadId) {
@@ -10889,11 +10896,6 @@ function threadIdForBackendEvent(event: AgentEvent): ThreadIdentifier | undefine
     return params.threadId;
   }
   return typeof params.parentThreadId === "string" ? params.parentThreadId : undefined;
-}
-
-function isBackendAccountMetadataEvent(event: AgentEvent): boolean {
-  return event.notification.method === "account/updated" ||
-    event.notification.method === "account/rateLimits/updated";
 }
 
 function contextUsageSummaryFromValue(value: unknown): string | undefined {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -1065,11 +1065,22 @@ export class MessagingController {
     // broadcast — so the gateway echo of our own `editForumTopic`
     // call (which carries the same name we just wrote in
     // `syncConversationName`) is a no-op, not a refresh storm.
+    const managedTopic =
+      incoming.kind === "topic" && incoming.parentId
+        ? await this.options.store.findManagedTopicByConversation({
+            channel: event.channel.channel,
+            supergroupId: incoming.parentId,
+            topicId: incoming.id,
+          })
+        : undefined;
+    const managedConversation = managedTopic?.conversation;
     const merged = {
       ...stored,
-      title: incoming.title ?? stored.title,
-      parentTitle: incoming.parentTitle ?? stored.parentTitle,
-      ancestorTitle: incoming.ancestorTitle ?? stored.ancestorTitle,
+      title: incoming.title ?? stored.title ?? managedConversation?.title,
+      parentTitle:
+        incoming.parentTitle ?? stored.parentTitle ?? managedConversation?.parentTitle,
+      ancestorTitle:
+        incoming.ancestorTitle ?? stored.ancestorTitle ?? managedConversation?.ancestorTitle,
     };
     const routingState = event.routingState ?? binding.routingState;
     const changed =

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -1348,6 +1348,7 @@ export class DesktopMessagingRuntime {
       : undefined;
     const isCoolOff = reason === "cool-off";
     const modeLabel = isCoolOff ? "Cool Off" : "Slow Mode";
+    const targetPhrase = describeDeliveryBudgetTarget(event);
 
     const diagnosticKey = [
       event.channel,
@@ -1389,8 +1390,8 @@ export class DesktopMessagingRuntime {
       kind: "warning",
       key,
       message: event.outcome === "deferred"
-        ? `${modeLabel} active; holding ${event.priority} for ${formatDurationForStatus(retryDelayMs ?? 0)}.`
-        : `${modeLabel} active; dropped ${event.priority} (${reason}).`,
+        ? `${modeLabel} active; holding ${event.priority} for ${formatDurationForStatus(retryDelayMs ?? 0)}${targetPhrase}.`
+        : `${modeLabel} active; dropped ${event.priority} (${reason})${targetPhrase}.`,
       scope: event.scope ? sanitizeDeliveryScope(event.scope) : undefined,
       startedAt: event.at,
       expiresAt,
@@ -1401,11 +1402,12 @@ export class DesktopMessagingRuntime {
       threadId: event.threadId,
       bindingId: event.bindingId,
       summary: event.outcome === "deferred"
-        ? `${modeLabel} held ${event.priority} for ${formatDurationForStatus(retryDelayMs ?? 0)}`
-        : `${modeLabel} dropped ${event.priority}: ${reason}`,
+        ? `${modeLabel} held ${event.priority} for ${formatDurationForStatus(retryDelayMs ?? 0)}${targetPhrase}`
+        : `${modeLabel} dropped ${event.priority}: ${reason}${targetPhrase}`,
       createdAt: event.at,
       payload: {
         type: isCoolOff ? "cool-off" : "slow-mode",
+        bindingId: event.bindingId,
         intentId: event.intentId,
         intentKind: event.intentKind,
         outcome: event.outcome,
@@ -1414,7 +1416,10 @@ export class DesktopMessagingRuntime {
         retryAt: event.retryAt,
         retryDelayMs,
         scope: event.scope ? sanitizeDeliveryScope(event.scope) : undefined,
+        scopeId,
+        scopeKind: event.scope?.kind,
         slowModeActive: event.slowMode,
+        threadId: event.threadId,
       },
     });
   }
@@ -2157,6 +2162,30 @@ function sanitizeDeliveryScope(
     label: clipStatusText(scope.label),
     bucketId: clipStatusText(scope.bucketId),
   };
+}
+
+function describeDeliveryBudgetTarget(
+  event: MessagingControllerDeliveryBudgetEvent,
+): string {
+  const pieces: string[] = [];
+  if (event.bindingId) {
+    pieces.push(`binding ${shortIdentifier(event.bindingId)}`);
+  }
+  if (event.threadId) {
+    pieces.push(`thread ${shortIdentifier(event.threadId)}`);
+  }
+  if (event.scope) {
+    pieces.push(`${event.scope.kind} ${shortIdentifier(event.scope.label ?? event.scope.id)}`);
+  }
+  return pieces.length > 0 ? ` for ${pieces.join(", ")}` : "";
+}
+
+function shortIdentifier(value: string): string {
+  const normalized = clipStatusText(value) ?? value;
+  if (normalized.length <= 24) {
+    return normalized;
+  }
+  return `${normalized.slice(0, 10)}...${normalized.slice(-8)}`;
 }
 
 function clipStatusText(value: string | undefined): string | undefined {

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -1349,10 +1349,12 @@ export class DesktopMessagingRuntime {
     const isCoolOff = reason === "cool-off";
     const modeLabel = isCoolOff ? "Cool Off" : "Slow Mode";
     const targetPhrase = describeDeliveryBudgetTarget(event);
+    const targetKey = deliveryBudgetTargetKey(event);
 
     const diagnosticKey = [
       event.channel,
       scopeId,
+      targetKey,
       event.outcome,
       event.reason ?? "deferred",
       event.priority,
@@ -1385,7 +1387,11 @@ export class DesktopMessagingRuntime {
     const expiresAt = event.outcome === "deferred"
       ? event.retryAt
       : event.at + DELIVERY_BUDGET_WARNING_TTL_MS;
-    const key = degradationKey(event.channel, "warning", `delivery-budget:${scopeId}`);
+    const key = degradationKey(
+      event.channel,
+      "warning",
+      `delivery-budget:${scopeId}:${targetKey}`,
+    );
     this.addPlatformDegradationReason(event.channel, {
       kind: "warning",
       key,
@@ -2178,6 +2184,19 @@ function describeDeliveryBudgetTarget(
     pieces.push(`${event.scope.kind} ${shortIdentifier(event.scope.label ?? event.scope.id)}`);
   }
   return pieces.length > 0 ? ` for ${pieces.join(", ")}` : "";
+}
+
+function deliveryBudgetTargetKey(
+  event: MessagingControllerDeliveryBudgetEvent,
+): string {
+  const pieces: string[] = [];
+  if (event.bindingId) {
+    pieces.push(`binding:${encodeURIComponent(event.bindingId)}`);
+  }
+  if (event.threadId) {
+    pieces.push(`thread:${encodeURIComponent(event.threadId)}`);
+  }
+  return pieces.length > 0 ? pieces.join("|") : "scope";
 }
 
 function shortIdentifier(value: string): string {

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -861,7 +861,9 @@ export class DesktopMessagingRuntime {
       fullAccessControls: async () =>
         (await this.loadConfig()).fullAccessControls,
       onBindingChanged: () => this.broadcastBindingsChanged(),
-      onDeliveryBudgetEvent: (event) => this.handleDeliveryBudgetEvent(event),
+      onDeliveryBudgetEvent: (event) => {
+        void this.handleDeliveryBudgetEvent(event);
+      },
       onFullAccessPolicyViolation: (event) =>
         this.recordFullAccessPolicyViolation(adapter.channel, event),
     });
@@ -1338,9 +1340,9 @@ export class DesktopMessagingRuntime {
     });
   }
 
-  private handleDeliveryBudgetEvent(
+  private async handleDeliveryBudgetEvent(
     event: MessagingControllerDeliveryBudgetEvent,
-  ): void {
+  ): Promise<void> {
     const scopeId = event.scope?.id ?? "unknown";
     const reason = event.reason ?? (event.outcome === "deferred" ? "deferred" : "dropped");
     const retryDelayMs = event.retryAt !== undefined
@@ -1348,7 +1350,6 @@ export class DesktopMessagingRuntime {
       : undefined;
     const isCoolOff = reason === "cool-off";
     const modeLabel = isCoolOff ? "Cool Off" : "Slow Mode";
-    const targetPhrase = describeDeliveryBudgetTarget(event);
     const targetKey = deliveryBudgetTargetKey(event);
 
     const diagnosticKey = [
@@ -1368,6 +1369,8 @@ export class DesktopMessagingRuntime {
       return;
     }
     this.deliveryBudgetDiagnosticLastLoggedAt.set(diagnosticKey, event.at);
+    const localThreadTitle = await this.resolveDeliveryBudgetThreadTitle(event);
+    const targetPhrase = describeDeliveryBudgetTarget(event, localThreadTitle);
 
     messagingLog.info("messaging delivery budget constrained", {
       bindingId: event.bindingId,
@@ -1407,6 +1410,7 @@ export class DesktopMessagingRuntime {
       backend: event.backend,
       threadId: event.threadId,
       bindingId: event.bindingId,
+      conversation: event.conversation,
       summary: event.outcome === "deferred"
         ? `${modeLabel} held ${event.priority} for ${formatDurationForStatus(retryDelayMs ?? 0)}${targetPhrase}`
         : `${modeLabel} dropped ${event.priority}: ${reason}${targetPhrase}`,
@@ -1414,8 +1418,14 @@ export class DesktopMessagingRuntime {
       payload: {
         type: isCoolOff ? "cool-off" : "slow-mode",
         bindingId: event.bindingId,
+        conversationKind: event.conversation?.kind,
+        conversationParentId: event.conversation?.parentId,
+        conversationTitle: event.conversation
+          ? describeConversation(event.conversation)
+          : undefined,
         intentId: event.intentId,
         intentKind: event.intentKind,
+        localThreadTitle,
         outcome: event.outcome,
         priority: event.priority,
         reason,
@@ -1446,6 +1456,31 @@ export class DesktopMessagingRuntime {
       lastFailureReason: clipStatusText(info.lastFailureReason),
       startedAt: info.observedAt ?? Date.now(),
     });
+  }
+
+  private async resolveDeliveryBudgetThreadTitle(
+    event: MessagingControllerDeliveryBudgetEvent,
+  ): Promise<string | undefined> {
+    if (!event.backend || !event.threadId) {
+      return undefined;
+    }
+    try {
+      const snapshot = await this.options.backendBridge.getNavigationSnapshot({
+        backend: "all",
+      });
+      const thread = snapshot.threads.find(
+        (candidate) =>
+          candidate.source === event.backend && candidate.id === event.threadId,
+      );
+      return clipStatusText(thread?.title);
+    } catch (error) {
+      messagingLog.debug("messaging budget diagnostic thread-title lookup failed", {
+        backend: event.backend,
+        error: error instanceof Error ? error.message : String(error),
+        threadId: event.threadId,
+      });
+      return undefined;
+    }
   }
 
   private addPlatformDegradationReason(
@@ -1784,7 +1819,9 @@ export class DesktopMessagingRuntime {
         threadId: params.threadId,
         bindingId: params.bindingId,
         conversationId: params.conversation?.id,
-        conversationTitle: params.conversation?.title,
+        conversationTitle: params.conversation
+          ? describeConversation(params.conversation)
+          : undefined,
         actorId: params.actor?.platformUserId,
         actorDisplayName: params.actor?.displayName,
         summary: params.summary,
@@ -2172,16 +2209,21 @@ function sanitizeDeliveryScope(
 
 function describeDeliveryBudgetTarget(
   event: MessagingControllerDeliveryBudgetEvent,
+  localThreadTitle?: string,
 ): string {
   const pieces: string[] = [];
-  if (event.bindingId) {
+  if (event.conversation) {
+    pieces.push(`conversation ${shortIdentifier(describeConversation(event.conversation), 80)}`);
+  } else if (event.bindingId) {
     pieces.push(`binding ${shortIdentifier(event.bindingId)}`);
   }
-  if (event.threadId) {
+  if (localThreadTitle) {
+    pieces.push(`thread ${shortIdentifier(localThreadTitle, 48)}`);
+  } else if (event.threadId) {
     pieces.push(`thread ${shortIdentifier(event.threadId)}`);
   }
-  if (event.scope) {
-    pieces.push(`${event.scope.kind} ${shortIdentifier(event.scope.label ?? event.scope.id)}`);
+  if (event.scope && !event.conversation) {
+    pieces.push(`${event.scope.kind} ${shortIdentifier(event.scope.label ?? event.scope.id, 48)}`);
   }
   return pieces.length > 0 ? ` for ${pieces.join(", ")}` : "";
 }
@@ -2199,12 +2241,14 @@ function deliveryBudgetTargetKey(
   return pieces.length > 0 ? pieces.join("|") : "scope";
 }
 
-function shortIdentifier(value: string): string {
+function shortIdentifier(value: string, maxLength = 24): string {
   const normalized = clipStatusText(value) ?? value;
-  if (normalized.length <= 24) {
+  if (normalized.length <= maxLength) {
     return normalized;
   }
-  return `${normalized.slice(0, 10)}...${normalized.slice(-8)}`;
+  const prefixLength = Math.max(10, Math.ceil((maxLength - 3) * 0.6));
+  const suffixLength = Math.max(8, maxLength - 3 - prefixLength);
+  return `${normalized.slice(0, prefixLength)}...${normalized.slice(-suffixLength)}`;
 }
 
 function clipStatusText(value: string | undefined): string | undefined {
@@ -2216,7 +2260,7 @@ function clipStatusText(value: string | undefined): string | undefined {
 }
 
 function describeConversation(
-  conversation: MessagingBindingRecord["channel"]["conversation"],
+  conversation: MessagingChannelRef["conversation"],
 ): string {
   const pieces = [
     conversation.ancestorTitle,

--- a/apps/desktop/src/renderer/src/features/messaging-activity/MessagingActivityScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/messaging-activity/MessagingActivityScreen.tsx
@@ -221,6 +221,22 @@ function copyFieldsForEntry(
       value: entry.actorId,
     });
   }
+  if (entry.kind === "diagnostic") {
+    if (entry.bindingId) {
+      fields.push({
+        key: "binding",
+        label: "Binding ID",
+        value: entry.bindingId,
+      });
+    }
+    if (entry.threadId) {
+      fields.push({
+        key: "thread",
+        label: "Thread ID",
+        value: entry.threadId,
+      });
+    }
+  }
 
   const conversationKind =
     typeof entry.payload?.conversationKind === "string"

--- a/apps/desktop/src/renderer/src/features/messaging-activity/MessagingActivityScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/messaging-activity/MessagingActivityScreen.tsx
@@ -5,7 +5,10 @@ import type {
 } from "@pwragent/shared";
 import { copyText } from "../../lib/copy-text";
 import type { DesktopApi } from "../../lib/desktop-api";
-import { MESSAGING_PLATFORM_ICONS } from "../../lib/messaging-platform-branding";
+import {
+  formatMessagingPlatformName,
+  MESSAGING_PLATFORM_ICONS,
+} from "../../lib/messaging-platform-branding";
 
 const REFRESH_INTERVAL_MS = 5_000;
 const KIND_LABEL: Record<MessagingActivityKind, string> = {
@@ -214,6 +217,48 @@ function copyFieldsForEntry(
   entry: MessagingActivityEntry,
 ): Array<{ key: string; label: string; value: string }> {
   const fields: Array<{ key: string; label: string; value: string }> = [];
+  const conversationKind =
+    typeof entry.payload?.conversationKind === "string"
+      ? entry.payload.conversationKind
+      : undefined;
+  const parentId =
+    typeof entry.payload?.conversationParentId === "string"
+      ? entry.payload.conversationParentId
+      : undefined;
+  const bucketId =
+    typeof entry.payload?.conversationBucketId === "string"
+      ? entry.payload.conversationBucketId
+      : undefined;
+  const conversationTitle =
+    typeof entry.payload?.conversationTitle === "string"
+      ? entry.payload.conversationTitle
+      : entry.conversationTitle;
+  const localThreadTitle =
+    typeof entry.payload?.localThreadTitle === "string"
+      ? entry.payload.localThreadTitle
+      : undefined;
+
+  if (entry.kind === "diagnostic") {
+    fields.push({
+      key: "provider",
+      label: "Provider",
+      value: formatMessagingPlatformName(entry.platform),
+    });
+    if (conversationTitle) {
+      fields.push({
+        key: "conversation-title",
+        label: "Conversation",
+        value: conversationTitle,
+      });
+    }
+    if (localThreadTitle) {
+      fields.push({
+        key: "local-thread-title",
+        label: "Thread",
+        value: localThreadTitle,
+      });
+    }
+  }
   if (entry.actorId) {
     fields.push({
       key: "actor",
@@ -237,19 +282,6 @@ function copyFieldsForEntry(
       });
     }
   }
-
-  const conversationKind =
-    typeof entry.payload?.conversationKind === "string"
-      ? entry.payload.conversationKind
-      : undefined;
-  const parentId =
-    typeof entry.payload?.conversationParentId === "string"
-      ? entry.payload.conversationParentId
-      : undefined;
-  const bucketId =
-    typeof entry.payload?.conversationBucketId === "string"
-      ? entry.payload.conversationBucketId
-      : undefined;
 
   if (parentId) {
     fields.push({

--- a/apps/desktop/src/renderer/src/features/messaging-activity/__tests__/messaging-activity-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/messaging-activity/__tests__/messaging-activity-screen.test.tsx
@@ -80,6 +80,51 @@ describe("MessagingActivityScreen", () => {
       .toHaveTextContent("Topic ID");
   });
 
+  it("shows friendly provider, conversation, and thread chips for diagnostics", async () => {
+    const desktopApi = {
+      listMessagingActivity: vi.fn(async () => ({
+        entries: [
+          {
+            id: 1,
+            platform: "telegram",
+            kind: "diagnostic",
+            backend: "codex",
+            bindingId:
+              "binding:telegram:topic:-1003841603622:56:codex:019ead15-b0bf-7f43-bfff-eb70c8cc1250",
+            conversationId: "56",
+            conversationTitle: "PwrAgent Mini Dev Group / Test Thread",
+            summary:
+              "Slow Mode dropped stream_partial: slow-mode for conversation PwrAgent Mini Dev Group / Test Thread, thread Rate Limit Test",
+            threadId: "019ead15-b0bf-7f43-bfff-eb70c8cc1250",
+            createdAt: Date.now(),
+            payload: {
+              conversationKind: "topic",
+              conversationParentId: "-1003841603622",
+              conversationTitle: "PwrAgent Mini Dev Group / Test Thread",
+              localThreadTitle: "Rate Limit Test",
+            },
+          },
+        ],
+      })),
+    } as unknown as DesktopApi;
+
+    render(<MessagingActivityScreen desktopApi={desktopApi} />);
+
+    await waitFor(() => {
+      expect(desktopApi.listMessagingActivity).toHaveBeenCalledWith({ limit: 200 });
+    });
+    expect((await screen.findByText("Telegram")).closest("button"))
+      .toHaveTextContent("Provider");
+    expect(screen.getByText("PwrAgent Mini Dev Group / Test Thread").closest("button"))
+      .toHaveTextContent("Conversation");
+    expect(screen.getByText("Rate Limit Test").closest("button"))
+      .toHaveTextContent("Thread");
+    expect(screen.getByText("-1003841603622").closest("button"))
+      .toHaveTextContent("Supergroup ID");
+    expect(screen.getByText("56").closest("button"))
+      .toHaveTextContent("Topic ID");
+  });
+
   it("shows Slack workspace IDs from bucket metadata", async () => {
     const desktopApi = {
       listMessagingActivity: vi.fn(async () => ({


### PR DESCRIPTION
## Summary

- I stopped backend rate-limit metadata events from re-rendering every bound messaging status surface.
- I added binding/thread/scope context to Slow Mode and budget-exhausted diagnostics so the popover and Activity window point at the binding that tripped the budget.
- I exposed copyable binding and thread IDs on diagnostic rows in the Messaging Activity window.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts apps/desktop/src/main/__tests__/messaging-runtime.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`

## Notes

- `account/updated` still refreshes bound status cards because account identity details are rendered there.
- `account/rateLimits/updated` no longer fans out to all status surfaces; that was the noisy path that could trip provider Slow Mode with routine status updates.
