### PR TITLE
feat(desktop): custom frameless window chrome for Windows

### DIFF
--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -172,6 +172,10 @@ vi.mock("../window", () => ({
   syncHotCpuProfilersFromSettings: vi.fn(),
 }));
 
+vi.mock("../app-menu-bridge", () => ({
+  wireAppMenuBridge: vi.fn(),
+}));
+
 vi.mock("../window-open-settings", () => ({
   requestOpenSettings: requestOpenSettingsMock,
 }));

--- a/apps/desktop/src/main/app-menu-bridge.ts
+++ b/apps/desktop/src/main/app-menu-bridge.ts
@@ -1,0 +1,77 @@
+// Renderer <-> main bridge for the Windows custom title-bar menu bar.
+//
+// On Windows we hide the native title bar (titleBarStyle: "hidden") to draw our
+// own chrome, which ALSO removes the native menu bar (the menu lives in the
+// title bar Windows just hid). So the renderer paints its own always-visible
+// top-level menu buttons (File / View / Profiles / Window / Help) and, on click
+// or Alt-mnemonic, asks main to pop the REAL native submenu at that spot via
+// `Menu.popup()`. The submenus — roles (Undo/Copy/Paste), accelerators,
+// dynamic enable/disable, click handlers — are exactly the ones
+// `installApplicationMenu` already builds, so there is a single source of truth
+// for menu behavior; the renderer only owns the top-level bar's looks.
+//
+// macOS/Linux never reach the renderer path — they keep their native menu bar.
+
+import { BrowserWindow, ipcMain, Menu } from "electron";
+import {
+  APP_MENU_MODEL_CHANNEL,
+  APP_MENU_POPUP_CHANNEL,
+} from "../shared/ipc";
+import type { AppMenuTopLevel } from "../shared/app-menu";
+
+/**
+ * Top-level entries of the current application menu, for the renderer's custom
+ * menu bar. `buildFromTemplate` has already expanded roles, so labels like
+ * "View" / "Window" are concrete. The macOS app menu (role: "appMenu") is
+ * excluded — it never appears on Windows, where this bridge is used.
+ */
+function appMenuTopLevel(): AppMenuTopLevel[] {
+  const menu = Menu.getApplicationMenu();
+  if (menu === null) return [];
+  const out: AppMenuTopLevel[] = [];
+  menu.items.forEach((item, index) => {
+    if (item.role === "appMenu") return;
+    if (item.visible === false) return;
+    if (typeof item.label !== "string" || item.label.length === 0) return;
+    if (item.submenu === undefined) return;
+    out.push({ index, label: item.label });
+  });
+  return out;
+}
+
+let wired = false;
+
+/**
+ * Register the menu-bar bridge. Idempotent — call once after the first
+ * `installApplicationMenu()`. The handlers read `Menu.getApplicationMenu()`
+ * live on each call, so they always reflect the latest menu (developer-mode
+ * rebuilds, profile/window submenu changes, dynamic enable state) without
+ * re-registration.
+ */
+export function wireAppMenuBridge(): void {
+  if (wired) return;
+  wired = true;
+
+  ipcMain.handle(APP_MENU_MODEL_CHANNEL, () => appMenuTopLevel());
+
+  ipcMain.on(APP_MENU_POPUP_CHANNEL, (event, payload: unknown) => {
+    if (payload === null || typeof payload !== "object") return;
+    const { index, x, y } = payload as {
+      index?: unknown;
+      x?: unknown;
+      y?: unknown;
+    };
+    if (typeof index !== "number") return;
+    const menu = Menu.getApplicationMenu();
+    const submenu = menu?.items[index]?.submenu;
+    if (submenu === undefined) return;
+    const win = BrowserWindow.fromWebContents(event.sender);
+    if (win === null) return;
+    // x/y are window-relative DIP (the button's bottom-left). Round to whole
+    // pixels; omit when absent so Electron falls back to the cursor position.
+    const popupOptions: Electron.PopupOptions = { window: win };
+    if (typeof x === "number" && Number.isFinite(x)) popupOptions.x = Math.round(x);
+    if (typeof y === "number" && Number.isFinite(y)) popupOptions.y = Math.round(y);
+    submenu.popup(popupOptions);
+  });
+}

--- a/apps/desktop/src/main/appearance-broadcast.ts
+++ b/apps/desktop/src/main/appearance-broadcast.ts
@@ -11,16 +11,35 @@
  * bootstrapped with at window creation.
  */
 
+import { BrowserWindow } from "electron";
 import type { BootstrapAppearance } from "./settings/appearance-bootstrap";
+import { themedTitleBarOverlay } from "./settings/appearance-bootstrap";
 import { APPEARANCE_CHANGED_EVENT_CHANNEL } from "../shared/ipc";
 import { subscribersForChannel } from "./window-channels";
+
+const isWindows = process.platform === "win32";
 
 export function broadcastAppearanceChange(
   appearance: BootstrapAppearance,
 ): void {
+  const overlay = isWindows ? themedTitleBarOverlay(appearance) : undefined;
   for (const webContents of subscribersForChannel(
     APPEARANCE_CHANGED_EVENT_CHANNEL,
   )) {
     webContents.send(APPEARANCE_CHANGED_EVENT_CHANNEL, appearance);
+    // On Windows, re-color the OS caption-button overlay so min/max/close
+    // match the new theme. Only windows created with `titleBarOverlay` accept
+    // this; for any that weren't, setTitleBarOverlay throws — ignore those.
+    if (overlay) {
+      const window = BrowserWindow.fromWebContents(webContents);
+      try {
+        window?.setTitleBarOverlay({
+          color: overlay.color,
+          symbolColor: overlay.symbolColor,
+        });
+      } catch {
+        // Window has no Window Controls Overlay (e.g. not yet converted).
+      }
+    }
   }
 }

--- a/apps/desktop/src/main/auxiliary-window-chrome.ts
+++ b/apps/desktop/src/main/auxiliary-window-chrome.ts
@@ -2,6 +2,10 @@ import type {
   BrowserWindow,
   BrowserWindowConstructorOptions,
 } from "electron";
+import {
+  readBootstrapAppearance,
+  themedTitleBarOverlay,
+} from "./settings/appearance-bootstrap";
 
 const supportsPerWindowMenuBar =
   process.platform === "linux" || process.platform === "win32";
@@ -19,12 +23,29 @@ const auxiliaryWindowRaiseRetryTimers = new Map<
 
 export function auxiliaryWindowChromeOptions(): Pick<
   BrowserWindowConstructorOptions,
-  "autoHideMenuBar" | "titleBarStyle" | "trafficLightPosition"
+  | "autoHideMenuBar"
+  | "titleBarStyle"
+  | "trafficLightPosition"
+  | "titleBarOverlay"
 > {
   if (process.platform === "darwin") {
     return {
       titleBarStyle: "hiddenInset",
       trafficLightPosition: { x: 20, y: 18 },
+    };
+  }
+
+  if (process.platform === "win32") {
+    // Frameless + Window Controls Overlay, like the main window — the native
+    // title bar (and the white system band) is gone; the OS draws themed
+    // min/max/close at the top-right, blended into the renderer's
+    // `.activity-titlebar` header. Aux windows have NO application menu, so
+    // there's no painted menu bar here — just the seamless caption buttons.
+    // autoHideMenuBar stays true so no phantom native bar can appear.
+    return {
+      titleBarStyle: "hidden",
+      titleBarOverlay: themedTitleBarOverlay(readBootstrapAppearance()),
+      autoHideMenuBar: true,
     };
   }
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -100,6 +100,7 @@ import { requestOpenNewThread } from "./window-open-new-thread";
 import { requestOpenSettings } from "./window-open-settings";
 import { requestReplayOnboarding } from "./window-replay-onboarding";
 import { buildApplicationMenuTemplate } from "./menu";
+import { wireAppMenuBridge } from "./app-menu-bridge";
 import { appQuitManager, requestQuit } from "./quit-manager";
 import {
   installTranscriptImageProtocol,
@@ -512,6 +513,9 @@ export function bootstrapApp(): void {
       installProfileFocusRequestWatcher();
     }
     installApplicationMenu();
+    // Windows: serve the painted title-bar menu bar from the live application
+    // menu (idempotent; the renderer mounts the bar only on win32).
+    wireAppMenuBridge();
     installWindowMenuRefreshHandlers();
     registerAppServerIpcHandlers();
     registerAgentIpcHandlers();

--- a/apps/desktop/src/main/settings/appearance-bootstrap.ts
+++ b/apps/desktop/src/main/settings/appearance-bootstrap.ts
@@ -56,13 +56,26 @@ export function themedWindowBackgroundColor(
 }
 
 /**
+ * Title-bar (caption-button strip) background. This MUST match the renderer's
+ * painted title strip — `.app-titlebar`, which fills `var(--bg-sidebar)`, NOT
+ * the page background — so the native min/max/close buttons blend seamlessly
+ * into our chrome instead of sitting on a slightly-off rectangle (most visible
+ * in light theme: pure white behind cream). GitHub Desktop does the same: point
+ * the overlay at the title-bar color. Keep in sync with `--bg-sidebar` in
+ * `app.css` (`:root` and `:root[data-theme="light"]`).
+ */
+export const TITLE_BAR_BG_DARK = "#050505";
+export const TITLE_BAR_BG_LIGHT = "#f7f4ef";
+
+/**
  * Window Controls Overlay (Windows) styling for the frameless title bar.
  *
  * `color` is the background behind the OS-drawn min/max/close caption buttons
- * (matched to the window fill so there's no seam); `symbolColor` is the caption
- * glyph color; `height` sets the caption strip height so the buttons align with
- * the app's title-bar row (the sidebar masthead / content title row). Re-apply
- * via `window.setTitleBarOverlay(...)` when the theme flips. macOS uses
+ * (matched to the painted `.app-titlebar` strip so there's no seam);
+ * `symbolColor` is the caption glyph color; `height` sets the caption strip
+ * height so the buttons align with the painted menu bar. Re-apply via
+ * `window.setTitleBarOverlay(...)` when the theme flips — Electron restyles the
+ * existing overlay in place, so NO window recreation is needed. macOS uses
  * `trafficLightPosition` instead; Linux gets a normal frame.
  */
 // Keep in sync with `--win-titlebar-h` in app.css so the OS caption buttons
@@ -76,7 +89,7 @@ export function themedTitleBarOverlay(appearance: BootstrapAppearance): {
 } {
   const light = appearance.theme === "light";
   return {
-    color: light ? WINDOW_BG_LIGHT : WINDOW_BG_DARK,
+    color: light ? TITLE_BAR_BG_LIGHT : TITLE_BAR_BG_DARK,
     symbolColor: light ? "#3a3a3a" : "#c8ccd4",
     height: TITLE_BAR_OVERLAY_HEIGHT,
   };

--- a/apps/desktop/src/main/settings/appearance-bootstrap.ts
+++ b/apps/desktop/src/main/settings/appearance-bootstrap.ts
@@ -55,6 +55,31 @@ export function themedWindowBackgroundColor(
   return appearance.theme === "light" ? WINDOW_BG_LIGHT : WINDOW_BG_DARK;
 }
 
+/**
+ * Window Controls Overlay (Windows) styling for the frameless title bar.
+ *
+ * `color` is the background behind the OS-drawn min/max/close caption buttons
+ * (matched to the window fill so there's no seam); `symbolColor` is the caption
+ * glyph color; `height` sets the caption strip height so the buttons align with
+ * the app's title-bar row (the sidebar masthead / content title row). Re-apply
+ * via `window.setTitleBarOverlay(...)` when the theme flips. macOS uses
+ * `trafficLightPosition` instead; Linux gets a normal frame.
+ */
+export const TITLE_BAR_OVERLAY_HEIGHT = 48;
+
+export function themedTitleBarOverlay(appearance: BootstrapAppearance): {
+  color: string;
+  symbolColor: string;
+  height: number;
+} {
+  const light = appearance.theme === "light";
+  return {
+    color: light ? WINDOW_BG_LIGHT : WINDOW_BG_DARK,
+    symbolColor: light ? "#3a3a3a" : "#c8ccd4",
+    height: TITLE_BAR_OVERLAY_HEIGHT,
+  };
+}
+
 /** Build the `webPreferences.additionalArguments` array that surfaces
  *  the appearance to the preload script. Every BrowserWindow that
  *  loads the renderer needs this — without it, the preload's

--- a/apps/desktop/src/main/settings/appearance-bootstrap.ts
+++ b/apps/desktop/src/main/settings/appearance-bootstrap.ts
@@ -65,7 +65,9 @@ export function themedWindowBackgroundColor(
  * via `window.setTitleBarOverlay(...)` when the theme flips. macOS uses
  * `trafficLightPosition` instead; Linux gets a normal frame.
  */
-export const TITLE_BAR_OVERLAY_HEIGHT = 48;
+// Keep in sync with `--win-titlebar-h` in app.css so the OS caption buttons
+// and the painted menu bar share one line.
+export const TITLE_BAR_OVERLAY_HEIGHT = 40;
 
 export function themedTitleBarOverlay(appearance: BootstrapAppearance): {
   color: string;

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -307,12 +307,14 @@ export function createMainWindow(options?: {
     : isWindows
       ? {
           // Frameless + Window Controls Overlay: the OS draws min/max/close in
-          // a reserved region at the top-right; the rest of the bar (our
-          // sidebar masthead) is ours and draggable. autoHideMenuBar tucks the
-          // File/Edit/View menu away (Alt reveals it), like GitHub Desktop.
+          // a reserved region at the top-right; the menu bar (File/Edit/View/
+          // Help) renders to its left and the rest of the strip is draggable —
+          // GitHub-Desktop style. autoHideMenuBar:false keeps the menu always
+          // visible; Alt focuses it and Alt+F etc. open the menus (it does NOT
+          // toggle visibility the way autoHideMenuBar:true would).
           titleBarStyle: "hidden" as const,
           titleBarOverlay: themedTitleBarOverlay(appearance),
-          autoHideMenuBar: true,
+          autoHideMenuBar: false,
         }
       : {};
   const window = new BrowserWindow({

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -36,6 +36,7 @@ import {
 } from "../shared/ipc";
 import {
   readBootstrapAppearance,
+  themedTitleBarOverlay,
   themedWindowAdditionalArguments,
   themedWindowBackgroundColor,
 } from "./settings/appearance-bootstrap";
@@ -46,6 +47,7 @@ import {
 
 const isDevelopment = process.env.NODE_ENV !== "production";
 const isMac = process.platform === "darwin";
+const isWindows = process.platform === "win32";
 const mainLog = getMainLogger("pwragent:main");
 const heapLog = getMainLogger("pwragent:heap");
 const hotCpuLog = getMainLogger("pwragent:hot-cpu");
@@ -297,12 +299,22 @@ export function createMainWindow(options?: {
   const preloadPath = getPreloadPath();
   const appearance = readBootstrapAppearance();
   const navigationPreferences = readBootstrapNavigationPreferences();
-  const macWindowChrome = isMac
+  const windowChrome = isMac
     ? {
         titleBarStyle: "hiddenInset" as const,
         trafficLightPosition: { x: 20, y: 18 },
       }
-    : {};
+    : isWindows
+      ? {
+          // Frameless + Window Controls Overlay: the OS draws min/max/close in
+          // a reserved region at the top-right; the rest of the bar (our
+          // sidebar masthead) is ours and draggable. autoHideMenuBar tucks the
+          // File/Edit/View menu away (Alt reveals it), like GitHub Desktop.
+          titleBarStyle: "hidden" as const,
+          titleBarOverlay: themedTitleBarOverlay(appearance),
+          autoHideMenuBar: true,
+        }
+      : {};
   const window = new BrowserWindow({
     width: 1440,
     height: 960,
@@ -310,7 +322,7 @@ export function createMainWindow(options?: {
     minHeight: 760,
     show: false,
     title: "PwrAgent",
-    ...macWindowChrome,
+    ...windowChrome,
     // Pre-tinted so the OS window fill matches the renderer's first
     // paint and we don't flash dark before a light renderer mounts.
     //

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -307,14 +307,16 @@ export function createMainWindow(options?: {
     : isWindows
       ? {
           // Frameless + Window Controls Overlay: the OS draws min/max/close in
-          // a reserved region at the top-right; the menu bar (File/Edit/View/
-          // Help) renders to its left and the rest of the strip is draggable —
-          // GitHub-Desktop style. autoHideMenuBar:false keeps the menu always
-          // visible; Alt focuses it and Alt+F etc. open the menus (it does NOT
-          // toggle visibility the way autoHideMenuBar:true would).
+          // a reserved region at the top-right. titleBarStyle:"hidden" ALSO
+          // removes the native menu bar on Windows (it lived in the title bar
+          // we hid), so the renderer paints its own always-visible menu bar
+          // (File/View/Profiles/Window/Help) in the strip and pops the real
+          // native submenus via the app-menu bridge — GitHub-Desktop style.
+          // autoHideMenuBar is moot here (no native bar to toggle); keep it
+          // true so no phantom native bar can ever appear above our painted one.
           titleBarStyle: "hidden" as const,
           titleBarOverlay: themedTitleBarOverlay(appearance),
-          autoHideMenuBar: false,
+          autoHideMenuBar: true,
         }
       : {};
   const window = new BrowserWindow({

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1108,6 +1108,11 @@ const bootstrapNavigationPreferences = readBootstrapNavigationPreferences();
 if (process.contextIsolated) {
   contextBridge.exposeInMainWorld("pwragent", desktopApi);
   contextBridge.exposeInMainWorld("__pwragentAppearance", bootstrapAppearance);
+  // Surface the OS platform synchronously so the index.html bootstrap can set
+  // `<html data-platform>` before first paint. This drives platform-specific
+  // window chrome in app.css (e.g. zeroing the macOS stoplight reservation on
+  // Windows, where the caption buttons live in the Window Controls Overlay).
+  contextBridge.exposeInMainWorld("__pwragentPlatform", process.platform);
   contextBridge.exposeInMainWorld(
     "__pwragentNavigationPreferences",
     bootstrapNavigationPreferences,

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -347,7 +347,10 @@ import {
   WINDOW_POINTER_SNAPSHOT_CHANNEL,
   WINDOW_REPLAY_ONBOARDING_CHANNEL,
   WINDOW_SHOW_THREAD_CHANNEL,
+  APP_MENU_MODEL_CHANNEL,
+  APP_MENU_POPUP_CHANNEL,
 } from "../shared/ipc";
+import type { AppMenuTopLevel, AppMenuPopupRequest } from "../shared/app-menu";
 import type { RuntimeIdentity } from "../shared/runtime-identity";
 import type { WindowPointerSnapshot } from "../shared/window-pointer";
 import type { WindowShowThreadRequest } from "../shared/window-show-thread";
@@ -1036,6 +1039,14 @@ const desktopApi = Object.freeze({
     return () => {
       ipcRenderer.off(MESSAGING_PAIRING_CHANGED_EVENT_CHANNEL, listener);
     };
+  },
+  // Windows custom title-bar menu bar (see shared/app-menu.ts). The renderer
+  // reads the top-level model once on mount and pops the live native submenu on
+  // click / Alt-mnemonic. No-op surface on macOS/Linux (the bar isn't mounted).
+  getAppMenuModel: async (): Promise<AppMenuTopLevel[]> =>
+    await ipcRenderer.invoke(APP_MENU_MODEL_CHANNEL),
+  popupAppMenu: (request: AppMenuPopupRequest): void => {
+    ipcRenderer.send(APP_MENU_POPUP_CHANNEL, request);
   },
   platform: process.platform,
   versions: {

--- a/apps/desktop/src/renderer/index.html
+++ b/apps/desktop/src/renderer/index.html
@@ -28,6 +28,13 @@
       // — no reload needed.
       (function () {
         try {
+          // Tag the OS platform so platform-specific window chrome (e.g. the
+          // Windows title bar / caption-button reservation) applies on first
+          // paint. Exposed synchronously by the preload as __pwragentPlatform.
+          var platform = window.__pwragentPlatform;
+          if (platform) {
+            document.documentElement.setAttribute("data-platform", platform);
+          }
           var bridged = window.__pwragentAppearance || {};
           var theme = bridged.theme || "system";
           var density = bridged.density || "mission-control";

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -538,221 +538,221 @@ function DesktopAppShell(props: {
       >
         <Sidebar
           backends={backendSummaries.backends}
-        browseMode={navigation.browseMode}
-        createThreadError={navigation.createThreadError}
-        creatingThread={navigation.creatingThread}
-        directories={navigation.directories}
-        error={navigation.error}
-        inboxThreads={navigation.inboxThreads}
-        recentThreads={navigation.recentThreads}
-        archiveThreadError={navigation.archiveThreadError}
-        renameThreadError={navigation.renameThreadError}
-        runtimeIdentity={runtimeIdentity}
-        activeProfile={profiles.activeProfile}
-        profiles={profiles.profiles}
-        launchpadError={navigation.launchpadError}
-        loading={navigation.loading}
-        approvalRequestThreadKeys={session.approvalRequestThreadKeys}
-        selectedItemKey={navigation.selectedItemKey}
-        thinkingThreadKeys={session.thinkingThreadKeys}
-        threads={navigation.threads}
-        automationsActive={mainView === "automations"}
-        settingsActive={mainView === "settings"}
-        onBrowseModeChange={navigation.setBrowseMode}
-        onCreateThread={async () => {
-          setMainView("thread");
-          await navigation.createThread();
-        }}
-        onCreateSubthread={async (thread, mode) => {
-          setMainView("thread");
-          await navigation.createSubthread(thread, mode);
-        }}
-        onForkThread={async (thread, mode) => {
-          setMainView("thread");
-          await navigation.forkThread(thread, mode);
-        }}
-        onOpenAutomations={() => {
-          setMainView("automations");
-        }}
-        onOpenLaunchpad={async (directory, preferredBackend) => {
-          setMainView("thread");
-          await navigation.openDirectoryLaunchpad(directory, preferredBackend);
-        }}
-        onOpenSettings={() => {
-          setSettingsInitialSection(undefined);
-          setMainView("settings");
-        }}
-        onOpenProfile={profiles.openProfile}
-        onSelectThread={(thread) => {
-          setMainView("thread");
-          navigation.selectThread(thread);
-        }}
-        onArchiveThread={navigation.archiveThread}
-        onRenameThread={navigation.renameThread}
-        onSetThreadReaction={navigation.setThreadReaction}
-        onSetThreadPin={navigation.setThreadPin}
-        onReorderThreadPins={navigation.reorderThreadPins}
-        onSetThreadParent={navigation.setThreadParent}
-        onUpdateSubthreadOrder={navigation.updateSubthreadOrder}
-        onSetSubthreadsCollapsed={navigation.setSubthreadsCollapsed}
-        onSetDirectoryPin={navigation.setDirectoryPin}
-        onReorderDirectoryPins={navigation.reorderDirectoryPins}
-        onPrefetchPullRequests={pullRequests.prefetch}
-        onUnbindMessagingBinding={async (_thread, binding) => {
-          if (!desktopApi?.unbindMessagingThread) return;
-          await desktopApi.unbindMessagingThread({ bindingId: binding.bindingId });
-          await navigation.refresh?.();
-        }}
-        onResizeStart={startSidebarResize}
-        onResizeByKeyboard={(delta) => resizeSidebar(sidebarWidth + delta)}
-        sidebarWidth={sidebarWidth}
-        sidebarMinWidth={sidebarMinWidth}
-        sidebarMaxWidth={sidebarMaxWidth}
-      />
+          browseMode={navigation.browseMode}
+          createThreadError={navigation.createThreadError}
+          creatingThread={navigation.creatingThread}
+          directories={navigation.directories}
+          error={navigation.error}
+          inboxThreads={navigation.inboxThreads}
+          recentThreads={navigation.recentThreads}
+          archiveThreadError={navigation.archiveThreadError}
+          renameThreadError={navigation.renameThreadError}
+          runtimeIdentity={runtimeIdentity}
+          activeProfile={profiles.activeProfile}
+          profiles={profiles.profiles}
+          launchpadError={navigation.launchpadError}
+          loading={navigation.loading}
+          approvalRequestThreadKeys={session.approvalRequestThreadKeys}
+          selectedItemKey={navigation.selectedItemKey}
+          thinkingThreadKeys={session.thinkingThreadKeys}
+          threads={navigation.threads}
+          automationsActive={mainView === "automations"}
+          settingsActive={mainView === "settings"}
+          onBrowseModeChange={navigation.setBrowseMode}
+          onCreateThread={async () => {
+            setMainView("thread");
+            await navigation.createThread();
+          }}
+          onCreateSubthread={async (thread, mode) => {
+            setMainView("thread");
+            await navigation.createSubthread(thread, mode);
+          }}
+          onForkThread={async (thread, mode) => {
+            setMainView("thread");
+            await navigation.forkThread(thread, mode);
+          }}
+          onOpenAutomations={() => {
+            setMainView("automations");
+          }}
+          onOpenLaunchpad={async (directory, preferredBackend) => {
+            setMainView("thread");
+            await navigation.openDirectoryLaunchpad(directory, preferredBackend);
+          }}
+          onOpenSettings={() => {
+            setSettingsInitialSection(undefined);
+            setMainView("settings");
+          }}
+          onOpenProfile={profiles.openProfile}
+          onSelectThread={(thread) => {
+            setMainView("thread");
+            navigation.selectThread(thread);
+          }}
+          onArchiveThread={navigation.archiveThread}
+          onRenameThread={navigation.renameThread}
+          onSetThreadReaction={navigation.setThreadReaction}
+          onSetThreadPin={navigation.setThreadPin}
+          onReorderThreadPins={navigation.reorderThreadPins}
+          onSetThreadParent={navigation.setThreadParent}
+          onUpdateSubthreadOrder={navigation.updateSubthreadOrder}
+          onSetSubthreadsCollapsed={navigation.setSubthreadsCollapsed}
+          onSetDirectoryPin={navigation.setDirectoryPin}
+          onReorderDirectoryPins={navigation.reorderDirectoryPins}
+          onPrefetchPullRequests={pullRequests.prefetch}
+          onUnbindMessagingBinding={async (_thread, binding) => {
+            if (!desktopApi?.unbindMessagingThread) return;
+            await desktopApi.unbindMessagingThread({ bindingId: binding.bindingId });
+            await navigation.refresh?.();
+          }}
+          onResizeStart={startSidebarResize}
+          onResizeByKeyboard={(delta) => resizeSidebar(sidebarWidth + delta)}
+          sidebarWidth={sidebarWidth}
+          sidebarMinWidth={sidebarMinWidth}
+          sidebarMaxWidth={sidebarMaxWidth}
+        />
 
-      <main
-        className={`app-main${
-          threadDetailPending ? " app-main--thread-detail-pending" : ""
-        }`}
-      >
-        {threadDetailPending ? (
-          <section className="thread-view thread-view--pending">
-            <ThreadPlaceholderHeader
-              desktopApi={desktopApi}
-              title="Loading..."
-              onOpenMessagingActivity={openMessagingActivityWindow}
-            />
-          </section>
-        ) : ThreadViewComponent ? (
-          <ThreadViewComponent {...threadViewProps} />
+        <main
+          className={`app-main${
+            threadDetailPending ? " app-main--thread-detail-pending" : ""
+          }`}
+        >
+          {threadDetailPending ? (
+            <section className="thread-view thread-view--pending">
+              <ThreadPlaceholderHeader
+                desktopApi={desktopApi}
+                title="Loading..."
+                onOpenMessagingActivity={openMessagingActivityWindow}
+              />
+            </section>
+          ) : ThreadViewComponent ? (
+            <ThreadViewComponent {...threadViewProps} />
+          ) : null}
+        </main>
+
+        {mainView === "settings" ? (
+          <div className="app-shell__settings-layer">
+            <Suspense fallback={null}>
+              <LazySettingsScreen
+                appearanceController={props.appearanceController}
+                desktopApi={desktopApi}
+                initialSection={settingsInitialSection}
+                profiles={profiles}
+                settings={settings}
+                onClose={() => setMainView("thread")}
+                onOpenMessagingActivity={openMessagingActivityWindow}
+              />
+            </Suspense>
+          </div>
         ) : null}
-      </main>
 
-      {mainView === "settings" ? (
-        <div className="app-shell__settings-layer">
-          <Suspense fallback={null}>
-            <LazySettingsScreen
-              appearanceController={props.appearanceController}
+        {mainView === "automations" ? (
+          <div className="app-shell__settings-layer">
+            <AutomationsScreen
               desktopApi={desktopApi}
-              initialSection={settingsInitialSection}
-              profiles={profiles}
-              settings={settings}
+              threads={navigation.threads}
               onClose={() => setMainView("thread")}
               onOpenMessagingActivity={openMessagingActivityWindow}
+              onRefreshNavigation={navigation.refresh}
+              onSelectThread={(thread) => {
+                setMainView("thread");
+                navigation.selectThread(thread);
+              }}
+            />
+          </div>
+        ) : null}
+
+        {onboardingOpen !== null && settings.snapshot ? (
+          <Suspense fallback={null}>
+            <LazyOnboardingWizard
+              isReplay={onboardingOpen === "replay"}
+              bootInfo={bootInfo}
+              initialDensity={settings.snapshot.general.appearance.density.value}
+              initialTheme={settings.snapshot.general.appearance.theme.value}
+              initialCodexProfileModel={
+                onboardingOpen === "replay" && replayCodexProfileSetup
+                  ? replayCodexProfileSetup.model
+                  : settings.snapshot.general.codexProfileModel.value
+              }
+              initialCodexProfileNames={
+                onboardingOpen === "replay"
+                  ? replayCodexProfileSetup?.profileNames
+                  : undefined
+              }
+              appearanceController={props.appearanceController}
+              settings={settings}
+              desktopApi={desktopApi}
+              onComplete={async (patch) => {
+                await settings.writeConfig(patch);
+                // The wizard already flips theme + density live via
+                // appearanceController as the operator clicks — the
+                // explicit setters below are a belt-and-suspenders to keep
+                // the controller's React state aligned with whatever the
+                // final patch holds, even if persistAndComplete adjusts.
+                if (patch.general?.appearance?.density) {
+                  props.appearanceController.setDensity(
+                    patch.general.appearance.density,
+                  );
+                }
+                if (patch.general?.appearance?.theme) {
+                  props.appearanceController.setTheme(
+                    patch.general.appearance.theme,
+                  );
+                }
+                // Mark onboarding complete AND kick off the deferred Codex
+                // `listThreads` prefetch in one IPC call (#500). On replay,
+                // skip the call entirely — replays don't touch onboarding.
+                //
+                // In bootstrap mode (#524), skip this too. The bootstrap
+                // window is about to quit; firing
+                // `completeOnboardingCodexBootstrap` here would (a) write
+                // `[onboarding] completed = true` to `.bootstrap/config.toml`
+                // (which we're about to delete) and (b) trigger a Codex
+                // `listThreads` against the system default Codex install,
+                // contaminating the soon-to-quit window with the operator's
+                // real Codex Desktop threads. The new profile's window
+                // handles its own completion + prefetch on launch.
+                if (!onboardingOpen) return;
+                if (
+                  onboardingOpen !== "replay" &&
+                  bootInfo?.mode !== "bootstrap" &&
+                  desktopApi?.completeOnboardingCodexBootstrap
+                ) {
+                  await desktopApi.completeOnboardingCodexBootstrap({
+                    connect: true,
+                  });
+                  await settings.refresh();
+                }
+                setOnboardingOpen(null);
+              }}
+              onDismiss={(persistCompleted) => {
+                if (persistCompleted) {
+                  // Skip path: persist `completed = true` so the wizard
+                  // doesn't auto-fire again, but pass `connect: false` so
+                  // we don't auto-load Codex threads under an unverified
+                  // identity. The renderer's next explicit refresh (or app
+                  // restart) will surface them.
+                  void desktopApi?.completeOnboardingCodexBootstrap?.({
+                    connect: false,
+                  }).then(() => settings.refresh());
+                }
+                setOnboardingOpen(null);
+              }}
+              onOpenMessagingSettings={() => {
+                setSettingsInitialSection("messaging");
+                setMainView("settings");
+              }}
             />
           </Suspense>
-        </div>
-      ) : null}
+        ) : null}
 
-      {mainView === "automations" ? (
-        <div className="app-shell__settings-layer">
-          <AutomationsScreen
+        <CodexConfigWarningBanner desktopApi={desktopApi} />
+        <div className="app-toast-stack" aria-live="polite">
+          <AppNoticeToast
             desktopApi={desktopApi}
-            threads={navigation.threads}
-            onClose={() => setMainView("thread")}
-            onOpenMessagingActivity={openMessagingActivityWindow}
-            onRefreshNavigation={navigation.refresh}
-            onSelectThread={(thread) => {
-              setMainView("thread");
-              navigation.selectThread(thread);
-            }}
+            notice={navigation.archiveThreadNotice}
+            onDismiss={navigation.dismissArchiveThreadNotice}
           />
+          <AppUpdateBanner desktopApi={desktopApi} />
         </div>
-      ) : null}
-
-      {onboardingOpen !== null && settings.snapshot ? (
-        <Suspense fallback={null}>
-          <LazyOnboardingWizard
-            isReplay={onboardingOpen === "replay"}
-            bootInfo={bootInfo}
-            initialDensity={settings.snapshot.general.appearance.density.value}
-            initialTheme={settings.snapshot.general.appearance.theme.value}
-            initialCodexProfileModel={
-              onboardingOpen === "replay" && replayCodexProfileSetup
-                ? replayCodexProfileSetup.model
-                : settings.snapshot.general.codexProfileModel.value
-            }
-            initialCodexProfileNames={
-              onboardingOpen === "replay"
-                ? replayCodexProfileSetup?.profileNames
-                : undefined
-            }
-            appearanceController={props.appearanceController}
-            settings={settings}
-            desktopApi={desktopApi}
-            onComplete={async (patch) => {
-              await settings.writeConfig(patch);
-              // The wizard already flips theme + density live via
-              // appearanceController as the operator clicks — the
-              // explicit setters below are a belt-and-suspenders to keep
-              // the controller's React state aligned with whatever the
-              // final patch holds, even if persistAndComplete adjusts.
-              if (patch.general?.appearance?.density) {
-                props.appearanceController.setDensity(
-                  patch.general.appearance.density,
-                );
-              }
-              if (patch.general?.appearance?.theme) {
-                props.appearanceController.setTheme(
-                  patch.general.appearance.theme,
-                );
-              }
-              // Mark onboarding complete AND kick off the deferred Codex
-              // `listThreads` prefetch in one IPC call (#500). On replay,
-              // skip the call entirely — replays don't touch onboarding.
-              //
-              // In bootstrap mode (#524), skip this too. The bootstrap
-              // window is about to quit; firing
-              // `completeOnboardingCodexBootstrap` here would (a) write
-              // `[onboarding] completed = true` to `.bootstrap/config.toml`
-              // (which we're about to delete) and (b) trigger a Codex
-              // `listThreads` against the system default Codex install,
-              // contaminating the soon-to-quit window with the operator's
-              // real Codex Desktop threads. The new profile's window
-              // handles its own completion + prefetch on launch.
-              if (!onboardingOpen) return;
-              if (
-                onboardingOpen !== "replay" &&
-                bootInfo?.mode !== "bootstrap" &&
-                desktopApi?.completeOnboardingCodexBootstrap
-              ) {
-                await desktopApi.completeOnboardingCodexBootstrap({
-                  connect: true,
-                });
-                await settings.refresh();
-              }
-              setOnboardingOpen(null);
-            }}
-            onDismiss={(persistCompleted) => {
-              if (persistCompleted) {
-                // Skip path: persist `completed = true` so the wizard
-                // doesn't auto-fire again, but pass `connect: false` so
-                // we don't auto-load Codex threads under an unverified
-                // identity. The renderer's next explicit refresh (or app
-                // restart) will surface them.
-                void desktopApi?.completeOnboardingCodexBootstrap?.({
-                  connect: false,
-                }).then(() => settings.refresh());
-              }
-              setOnboardingOpen(null);
-            }}
-            onOpenMessagingSettings={() => {
-              setSettingsInitialSection("messaging");
-              setMainView("settings");
-            }}
-          />
-        </Suspense>
-      ) : null}
-
-      <CodexConfigWarningBanner desktopApi={desktopApi} />
-      <div className="app-toast-stack" aria-live="polite">
-        <AppNoticeToast
-          desktopApi={desktopApi}
-          notice={navigation.archiveThreadNotice}
-          onDismiss={navigation.dismissArchiveThreadNotice}
-        />
-        <AppUpdateBanner desktopApi={desktopApi} />
-      </div>
       </div>
     </>
   );

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -14,6 +14,7 @@ import type {
   DesktopPwrAgentProfileSummary,
 } from "@pwragent/shared";
 import { Sidebar } from "./features/navigation/Sidebar";
+import { AppTitleBar } from "./features/chrome/AppTitleBar";
 import type { SettingsSection } from "./features/settings/SettingsScreen";
 import {
   useDesktopSettings,
@@ -81,33 +82,39 @@ export function App() {
 
   if (desktopApi?.readSettings && !settings.snapshot && settings.error) {
     return (
-      <div className="app-shell app-shell--fatal-settings">
-        <main className="app-main">
-          <Suspense fallback={null}>
-            <LazySettingsScreen
-              appearanceController={appearanceController}
-              desktopApi={desktopApi}
-              settings={settings}
-            />
-          </Suspense>
-        </main>
-      </div>
+      <>
+        <AppTitleBar />
+        <div className="app-shell app-shell--fatal-settings">
+          <main className="app-main">
+            <Suspense fallback={null}>
+              <LazySettingsScreen
+                appearanceController={appearanceController}
+                desktopApi={desktopApi}
+                settings={settings}
+              />
+            </Suspense>
+          </main>
+        </div>
+      </>
     );
   }
 
   if (settings.snapshot?.configError) {
     return (
-      <div className="app-shell app-shell--fatal-settings">
-        <main className="app-main">
-          <Suspense fallback={null}>
-            <LazySettingsScreen
-              appearanceController={appearanceController}
-              desktopApi={desktopApi}
-              settings={settings}
-            />
-          </Suspense>
-        </main>
-      </div>
+      <>
+        <AppTitleBar />
+        <div className="app-shell app-shell--fatal-settings">
+          <main className="app-main">
+            <Suspense fallback={null}>
+              <LazySettingsScreen
+                appearanceController={appearanceController}
+                desktopApi={desktopApi}
+                settings={settings}
+              />
+            </Suspense>
+          </main>
+        </div>
+      </>
     );
   }
 
@@ -504,12 +511,33 @@ function DesktopAppShell(props: {
   };
 
   return (
-    <div
-      className="app-shell"
-      style={{ "--sidebar-width": `${sidebarWidth}px` } as CSSProperties}
-    >
-      <Sidebar
-        backends={backendSummaries.backends}
+    <>
+      <AppTitleBar
+        desktopApi={desktopApi}
+        onOpenMessagingActivity={openMessagingActivityWindow}
+        actions={{
+          automationsActive: mainView === "automations",
+          settingsActive: mainView === "settings",
+          creatingThread: Boolean(navigation.creatingThread),
+          onOpenAutomations: () => {
+            setMainView("automations");
+          },
+          onOpenSettings: () => {
+            setSettingsInitialSection(undefined);
+            setMainView("settings");
+          },
+          onCreateThread: async () => {
+            setMainView("thread");
+            await navigation.createThread();
+          },
+        }}
+      />
+      <div
+        className="app-shell"
+        style={{ "--sidebar-width": `${sidebarWidth}px` } as CSSProperties}
+      >
+        <Sidebar
+          backends={backendSummaries.backends}
         browseMode={navigation.browseMode}
         createThreadError={navigation.createThreadError}
         creatingThread={navigation.creatingThread}
@@ -725,7 +753,8 @@ function DesktopAppShell(props: {
         />
         <AppUpdateBanner desktopApi={desktopApi} />
       </div>
-    </div>
+      </div>
+    </>
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/chrome/AppMenuBar.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/AppMenuBar.tsx
@@ -1,0 +1,131 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactElement,
+} from "react";
+import { getDesktopApi } from "../../lib/desktop-api";
+import type { AppMenuTopLevel } from "../../../../shared/app-menu";
+
+/**
+ * Windows-only custom application menu bar, painted into our frameless title
+ * strip.
+ *
+ * Under `titleBarStyle: "hidden"` (our custom chrome) the native Windows menu
+ * bar is gone — the menu lived in the title bar we hid. So we paint the
+ * top-level entries (File / View / Profiles / Window / Help) as buttons and, on
+ * click or Alt-mnemonic, ask main to pop the REAL native submenu at the button
+ * (`popupAppMenu`). Roles, accelerators, dynamic enable/disable, and click
+ * handlers all live in the application menu main already builds — this
+ * component owns only the bar's looks + keyboard entry.
+ *
+ * Renders nothing off win32. The strip (drag region) renders on win32 even
+ * before the model loads so the window stays draggable and the content offset
+ * (`--win-titlebar-h`) is consistent.
+ */
+export function AppMenuBar(): ReactElement | null {
+  const isWindows = getDesktopApi()?.platform === "win32";
+  const [items, setItems] = useState<AppMenuTopLevel[]>([]);
+  // Array position (not menu index) of the keyboard-focused entry, or null.
+  const [focusedPos, setFocusedPos] = useState<number | null>(null);
+  const btnRefs = useRef(new Map<number, HTMLButtonElement>());
+
+  useEffect(() => {
+    if (!isWindows) return;
+    const api = getDesktopApi();
+    if (api?.getAppMenuModel === undefined) return;
+    let alive = true;
+    void api.getAppMenuModel().then((model) => {
+      if (alive) setItems(Array.isArray(model) ? model : []);
+    });
+    return () => {
+      alive = false;
+    };
+  }, [isWindows]);
+
+  const openMenu = useCallback((index: number): void => {
+    const btn = btnRefs.current.get(index);
+    const api = getDesktopApi();
+    if (btn === undefined || api?.popupAppMenu === undefined) return;
+    const rect = btn.getBoundingClientRect();
+    // Window-relative bottom-left of the button → native submenu anchors there.
+    api.popupAppMenu({
+      index,
+      x: Math.round(rect.left),
+      y: Math.round(rect.bottom),
+    });
+    setFocusedPos(null);
+  }, []);
+
+  useEffect(() => {
+    if (!isWindows || items.length === 0) return;
+    const onKeyDown = (event: KeyboardEvent): void => {
+      // Plain Alt: toggle the keyboard-focus highlight on the bar (Windows
+      // convention — Alt then arrows/Enter, or Alt+<letter> below).
+      if (event.key === "Alt") {
+        event.preventDefault();
+        setFocusedPos((cur) => (cur === null ? 0 : null));
+        return;
+      }
+      // Alt + first-letter mnemonic (e.g. Alt+F → File). Alt is held, so this
+      // never collides with typing in an input.
+      if (event.altKey && event.key.length === 1) {
+        const ch = event.key.toLowerCase();
+        const match = items.find((it) => it.label.toLowerCase().startsWith(ch));
+        if (match !== undefined) {
+          event.preventDefault();
+          openMenu(match.index);
+        }
+        return;
+      }
+      // Bar-focused navigation (after a plain Alt).
+      if (focusedPos === null) return;
+      if (event.key === "ArrowRight") {
+        event.preventDefault();
+        setFocusedPos((cur) => ((cur ?? -1) + 1) % items.length);
+      } else if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        setFocusedPos((cur) => ((cur ?? 0) - 1 + items.length) % items.length);
+      } else if (
+        event.key === "Enter" ||
+        event.key === "ArrowDown" ||
+        event.key === " "
+      ) {
+        event.preventDefault();
+        const it = items[focusedPos];
+        if (it !== undefined) openMenu(it.index);
+      } else if (event.key === "Escape") {
+        event.preventDefault();
+        setFocusedPos(null);
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [isWindows, items, focusedPos, openMenu]);
+
+  if (!isWindows) return null;
+  return (
+    <div className="app-titlebar">
+      <nav className="app-titlebar__menubar" aria-label="Application menu">
+        {items.map((it, pos) => (
+          <button
+            key={it.index}
+            type="button"
+            ref={(el) => {
+              if (el === null) btnRefs.current.delete(it.index);
+              else btnRefs.current.set(it.index, el);
+            }}
+            className={
+              "app-titlebar__menu-item" +
+              (focusedPos === pos ? " is-focused" : "")
+            }
+            onClick={() => openMenu(it.index)}
+          >
+            {it.label}
+          </button>
+        ))}
+      </nav>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/chrome/AppMenuBar.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/AppMenuBar.tsx
@@ -4,6 +4,8 @@ import {
   useRef,
   useState,
   type ReactElement,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type FocusEvent as ReactFocusEvent,
 } from "react";
 import { getDesktopApi } from "../../lib/desktop-api";
 import type { AppMenuTopLevel } from "../../../../shared/app-menu";
@@ -29,17 +31,39 @@ export function AppMenuBar(): ReactElement | null {
   const [focusedPos, setFocusedPos] = useState<number | null>(null);
   const btnRefs = useRef(new Map<number, HTMLButtonElement>());
 
+  // Load the top-level model on mount AND whenever this window regains focus.
+  // The native application menu is rebuilt in main on profile switches,
+  // dev-mode menu rebuilds, and Window-menu refreshes; re-reading on focus
+  // keeps the painted bar's labels/visibility in sync without a dedicated
+  // change event. (The popup path always reads the live submenu, so only the
+  // top-level entries can go stale.) A single `cancelled` flag guards every
+  // in-flight fetch — the initial one and each focus-triggered refresh.
   useEffect(() => {
     const api = getDesktopApi();
     if (api?.getAppMenuModel === undefined) return;
-    let alive = true;
-    void api.getAppMenuModel().then((model) => {
-      if (alive) setItems(Array.isArray(model) ? model : []);
-    });
+    let cancelled = false;
+    const load = (): void => {
+      void api.getAppMenuModel?.().then((model) => {
+        if (!cancelled) setItems(Array.isArray(model) ? model : []);
+      });
+    };
+    load();
+    const onFocus = (): void => load();
+    window.addEventListener("focus", onFocus);
     return () => {
-      alive = false;
+      cancelled = true;
+      window.removeEventListener("focus", onFocus);
     };
   }, []);
+
+  // Move real DOM focus to the active entry so screen readers announce it and
+  // the OS focus ring tracks keyboard navigation. Never steals focus on mount
+  // (focusedPos starts null); only runs once a position is active.
+  useEffect(() => {
+    if (focusedPos === null) return;
+    const it = items[focusedPos];
+    if (it !== undefined) btnRefs.current.get(it.index)?.focus();
+  }, [focusedPos, items]);
 
   const openMenu = useCallback((index: number): void => {
     const btn = btnRefs.current.get(index);
@@ -55,12 +79,17 @@ export function AppMenuBar(): ReactElement | null {
     setFocusedPos(null);
   }, []);
 
+  // Global: Alt enters the bar; Alt+<letter> opens by mnemonic. These must be
+  // global because focus isn't on the bar yet. In-bar navigation (arrows,
+  // Enter/Space, Escape) is handled on the <nav> once it actually holds focus.
   useEffect(() => {
     if (items.length === 0) return;
     const onKeyDown = (event: KeyboardEvent): void => {
       // Plain Alt: toggle the keyboard-focus highlight on the bar (Windows
-      // convention — Alt then arrows/Enter, or Alt+<letter> below).
+      // convention — Alt then arrows/Enter, or Alt+<letter> below). Ignore
+      // auto-repeat so holding Alt doesn't flicker the highlight on/off.
       if (event.key === "Alt") {
+        if (event.repeat) return;
         event.preventDefault();
         setFocusedPos((cur) => (cur === null ? 0 : null));
         return;
@@ -74,40 +103,70 @@ export function AppMenuBar(): ReactElement | null {
           event.preventDefault();
           openMenu(match.index);
         }
-        return;
       }
-      // Bar-focused navigation (after a plain Alt).
-      if (focusedPos === null) return;
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [items, openMenu]);
+
+  // In-bar navigation, handled only while the menubar actually holds focus.
+  // Enter/Space fall through to the native button activation (onClick) so the
+  // submenu isn't popped twice; we own arrows + Escape (and ArrowDown-to-open).
+  const onMenuKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLElement>): void => {
+      if (items.length === 0) return;
       if (event.key === "ArrowRight") {
         event.preventDefault();
         setFocusedPos((cur) => ((cur ?? -1) + 1) % items.length);
       } else if (event.key === "ArrowLeft") {
         event.preventDefault();
         setFocusedPos((cur) => ((cur ?? 0) - 1 + items.length) % items.length);
-      } else if (
-        event.key === "Enter" ||
-        event.key === "ArrowDown" ||
-        event.key === " "
-      ) {
+      } else if (event.key === "ArrowDown") {
         event.preventDefault();
-        const it = items[focusedPos];
+        const it = focusedPos !== null ? items[focusedPos] : undefined;
         if (it !== undefined) openMenu(it.index);
       } else if (event.key === "Escape") {
         event.preventDefault();
         setFocusedPos(null);
+        // Return focus out of the bar so the highlight + focus ring both clear.
+        if (event.target instanceof HTMLElement) event.target.blur();
       }
-    };
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [items, focusedPos, openMenu]);
+    },
+    [items, focusedPos, openMenu],
+  );
+
+  // Clear the keyboard-focus state when focus leaves the bar entirely (click
+  // elsewhere, Tab away) so the highlight never sticks. Moving focus between
+  // two entries keeps relatedTarget inside the <nav>, so navigation doesn't
+  // trip this.
+  const onMenuBlur = useCallback(
+    (event: ReactFocusEvent<HTMLElement>): void => {
+      if (!event.currentTarget.contains(event.relatedTarget)) {
+        setFocusedPos(null);
+      }
+    },
+    [],
+  );
 
   if (items.length === 0) return null;
   return (
-    <nav className="app-titlebar__menubar" aria-label="Application menu">
+    <nav
+      className="app-titlebar__menubar"
+      aria-label="Application menu"
+      role="menubar"
+      onKeyDown={onMenuKeyDown}
+      onBlur={onMenuBlur}
+    >
       {items.map((it, pos) => (
         <button
           key={it.index}
           type="button"
+          role="menuitem"
+          aria-haspopup="true"
+          // Roving tabindex: the active entry is the bar's single tab stop;
+          // when nothing is active the bar stays out of the Tab order (Windows
+          // menu bars are reached via Alt, not Tab).
+          tabIndex={focusedPos === pos ? 0 : -1}
           ref={(el) => {
             if (el === null) btnRefs.current.delete(it.index);
             else btnRefs.current.set(it.index, el);

--- a/apps/desktop/src/renderer/src/features/chrome/AppMenuBar.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/AppMenuBar.tsx
@@ -9,30 +9,27 @@ import { getDesktopApi } from "../../lib/desktop-api";
 import type { AppMenuTopLevel } from "../../../../shared/app-menu";
 
 /**
- * Windows-only custom application menu bar, painted into our frameless title
- * strip.
+ * The painted application menu bar (File / Edit / View / Profiles / Window /
+ * Help), rendered inside the Windows title strip by `AppTitleBar`.
  *
- * Under `titleBarStyle: "hidden"` (our custom chrome) the native Windows menu
- * bar is gone — the menu lived in the title bar we hid. So we paint the
- * top-level entries (File / View / Profiles / Window / Help) as buttons and, on
- * click or Alt-mnemonic, ask main to pop the REAL native submenu at the button
- * (`popupAppMenu`). Roles, accelerators, dynamic enable/disable, and click
- * handlers all live in the application menu main already builds — this
- * component owns only the bar's looks + keyboard entry.
+ * Under `titleBarStyle: "hidden"` the native Windows menu bar is gone — the
+ * menu lived in the title bar we hid. So we paint the top-level entries as
+ * buttons and, on click or Alt-mnemonic, ask main to pop the REAL native
+ * submenu at the button (`popupAppMenu`). Roles, accelerators, dynamic
+ * enable/disable, and click handlers all live in the application menu main
+ * already builds — this component owns only the bar's looks + keyboard entry.
  *
- * Renders nothing off win32. The strip (drag region) renders on win32 even
- * before the model loads so the window stays draggable and the content offset
- * (`--win-titlebar-h`) is consistent.
+ * Renders the `<nav>` only (no strip chrome — `AppTitleBar` owns that) and
+ * nothing until the model loads. `AppTitleBar` gates on win32, so this is only
+ * ever mounted there.
  */
 export function AppMenuBar(): ReactElement | null {
-  const isWindows = getDesktopApi()?.platform === "win32";
   const [items, setItems] = useState<AppMenuTopLevel[]>([]);
   // Array position (not menu index) of the keyboard-focused entry, or null.
   const [focusedPos, setFocusedPos] = useState<number | null>(null);
   const btnRefs = useRef(new Map<number, HTMLButtonElement>());
 
   useEffect(() => {
-    if (!isWindows) return;
     const api = getDesktopApi();
     if (api?.getAppMenuModel === undefined) return;
     let alive = true;
@@ -42,7 +39,7 @@ export function AppMenuBar(): ReactElement | null {
     return () => {
       alive = false;
     };
-  }, [isWindows]);
+  }, []);
 
   const openMenu = useCallback((index: number): void => {
     const btn = btnRefs.current.get(index);
@@ -59,7 +56,7 @@ export function AppMenuBar(): ReactElement | null {
   }, []);
 
   useEffect(() => {
-    if (!isWindows || items.length === 0) return;
+    if (items.length === 0) return;
     const onKeyDown = (event: KeyboardEvent): void => {
       // Plain Alt: toggle the keyboard-focus highlight on the bar (Windows
       // convention — Alt then arrows/Enter, or Alt+<letter> below).
@@ -102,30 +99,28 @@ export function AppMenuBar(): ReactElement | null {
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [isWindows, items, focusedPos, openMenu]);
+  }, [items, focusedPos, openMenu]);
 
-  if (!isWindows) return null;
+  if (items.length === 0) return null;
   return (
-    <div className="app-titlebar">
-      <nav className="app-titlebar__menubar" aria-label="Application menu">
-        {items.map((it, pos) => (
-          <button
-            key={it.index}
-            type="button"
-            ref={(el) => {
-              if (el === null) btnRefs.current.delete(it.index);
-              else btnRefs.current.set(it.index, el);
-            }}
-            className={
-              "app-titlebar__menu-item" +
-              (focusedPos === pos ? " is-focused" : "")
-            }
-            onClick={() => openMenu(it.index)}
-          >
-            {it.label}
-          </button>
-        ))}
-      </nav>
-    </div>
+    <nav className="app-titlebar__menubar" aria-label="Application menu">
+      {items.map((it, pos) => (
+        <button
+          key={it.index}
+          type="button"
+          ref={(el) => {
+            if (el === null) btnRefs.current.delete(it.index);
+            else btnRefs.current.set(it.index, el);
+          }}
+          className={
+            "app-titlebar__menu-item" +
+            (focusedPos === pos ? " is-focused" : "")
+          }
+          onClick={() => openMenu(it.index)}
+        >
+          {it.label}
+        </button>
+      ))}
+    </nav>
   );
 }

--- a/apps/desktop/src/renderer/src/features/chrome/AppTitleBar.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/AppTitleBar.tsx
@@ -1,0 +1,89 @@
+import type { ReactElement } from "react";
+import { getDesktopApi, type DesktopApi } from "../../lib/desktop-api";
+import { MessagingStatusBar } from "../messaging-status/MessagingStatusBar";
+import { AppMenuBar } from "./AppMenuBar";
+
+/**
+ * Windows-only custom title bar (GitHub-Desktop style). Consolidates the chrome
+ * the native title bar would otherwise own into one frameless strip:
+ *
+ *   [PwrAgent] File … Help  [automations][settings][new]  …drag…  [MSG]   — ▢ ✕
+ *
+ * The OS caption buttons (min/max/close) are drawn by the Window Controls
+ * Overlay at the far right; this strip fills the rest of the line. On Windows
+ * the sidebar masthead (wordmark + action buttons) and the per-screen MSG
+ * button are hidden (app.css), so these are their single home.
+ *
+ * Renders nothing off win32 — macOS keeps `hiddenInset`, the sidebar masthead,
+ * and the per-screen MSG button unchanged. `actions`/`desktopApi` are absent in
+ * the fatal/startup app states, where only the wordmark + menu render.
+ */
+export function AppTitleBar(props: {
+  desktopApi?: DesktopApi;
+  onOpenMessagingActivity?: () => void;
+  actions?: {
+    automationsActive: boolean;
+    settingsActive: boolean;
+    creatingThread: boolean;
+    onOpenAutomations: () => void;
+    onOpenSettings: () => void;
+    onCreateThread: () => void | Promise<void>;
+  };
+}): ReactElement | null {
+  const isWindows = getDesktopApi()?.platform === "win32";
+  if (!isWindows) return null;
+
+  const actions = props.actions;
+  return (
+    <div className="app-titlebar">
+      <div className="app-titlebar__left">
+        <p className="app-titlebar__brand">
+          Pwr<span className="app-titlebar__brand-accent">Agent</span>
+        </p>
+        <AppMenuBar />
+        {actions ? (
+          <div className="app-titlebar__actions">
+            <button
+              type="button"
+              aria-label="Open automations"
+              aria-pressed={actions.automationsActive}
+              className={`sidebar__icon-button${actions.automationsActive ? " is-active" : ""}`}
+              onClick={actions.onOpenAutomations}
+            >
+              <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><path d="M8 2v4"/><path d="M16 2v4"/><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M3 10h18"/><path d="M8 14h.01"/><path d="M12 14h.01"/><path d="M16 14h.01"/><path d="M8 18h.01"/><path d="M12 18h.01"/></svg>
+            </button>
+            <button
+              type="button"
+              aria-label="Open settings"
+              aria-pressed={actions.settingsActive}
+              className={`sidebar__icon-button${actions.settingsActive ? " is-active" : ""}`}
+              onClick={actions.onOpenSettings}
+            >
+              <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/></svg>
+            </button>
+            <button
+              type="button"
+              aria-label="New thread"
+              className="sidebar__icon-button"
+              disabled={actions.creatingThread}
+              onClick={() => {
+                void actions.onCreateThread();
+              }}
+            >
+              <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/><line x1="12" y1="18" x2="12" y2="12"/><line x1="9" y1="15" x2="15" y2="15"/></svg>
+            </button>
+          </div>
+        ) : null}
+      </div>
+      <div className="app-titlebar__spacer" />
+      {props.desktopApi ? (
+        <div className="app-titlebar__right">
+          <MessagingStatusBar
+            desktopApi={props.desktopApi}
+            onOpenActivity={props.onOpenMessagingActivity}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -207,6 +207,7 @@ import type {
 import type { RuntimeIdentity } from "../../../shared/runtime-identity";
 import type { WindowPointerSnapshot } from "../../../shared/window-pointer";
 import type { WindowShowThreadRequest } from "../../../shared/window-show-thread";
+import type { AppMenuTopLevel, AppMenuPopupRequest } from "../../../shared/app-menu";
 import type {
   AppChangelogDocument,
   AppLogEntry,
@@ -663,6 +664,14 @@ export type DesktopApi = {
    */
   onReplayOnboardingRequested?: (callback: () => void) => () => void;
   getWindowPointerSnapshot?: () => Promise<WindowPointerSnapshot>;
+  /**
+   * Windows custom title-bar menu bar (win32 only). `getAppMenuModel`
+   * returns the top-level entries for the painted bar; `popupAppMenu`
+   * pops the real native submenu at a button's bottom-left. The native
+   * menu (`installApplicationMenu`) stays the single source of truth.
+   */
+  getAppMenuModel?: () => Promise<AppMenuTopLevel[]>;
+  popupAppMenu?: (request: AppMenuPopupRequest) => void;
   platform?: string;
   versions?: {
     chrome?: string;

--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -5,6 +5,7 @@ import type {
   DesktopAppearanceTheme,
 } from "@pwragent/shared";
 import { App } from "./App";
+import { AppMenuBar } from "./features/chrome/AppMenuBar";
 import { RendererErrorBoundary } from "./features/diagnostics/RendererErrorBoundary";
 import { applyAppearanceAttributes, resolveTheme } from "./lib/appearance";
 import { installGlobalRendererErrorHandlers } from "./lib/renderer-error-reporting";
@@ -121,7 +122,17 @@ const routes: Array<{
 
 function chooseRoot(): ReactElement {
   const hash = window.location.hash.replace(/^#/, "");
-  return routes.find((route) => route.match(hash))?.render() ?? <App />;
+  const matched = routes.find((route) => route.match(hash))?.render();
+  if (matched) return matched;
+  // Main shell. On Windows, the painted title-bar menu bar mounts above it
+  // (AppMenuBar renders null off win32). Aux windows above keep their own
+  // chrome and never get the bar.
+  return (
+    <>
+      <AppMenuBar />
+      <App />
+    </>
+  );
 }
 
 ReactDOM.createRoot(document.getElementById("root")!).render(

--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -5,7 +5,6 @@ import type {
   DesktopAppearanceTheme,
 } from "@pwragent/shared";
 import { App } from "./App";
-import { AppMenuBar } from "./features/chrome/AppMenuBar";
 import { RendererErrorBoundary } from "./features/diagnostics/RendererErrorBoundary";
 import { applyAppearanceAttributes, resolveTheme } from "./lib/appearance";
 import { installGlobalRendererErrorHandlers } from "./lib/renderer-error-reporting";
@@ -122,17 +121,10 @@ const routes: Array<{
 
 function chooseRoot(): ReactElement {
   const hash = window.location.hash.replace(/^#/, "");
-  const matched = routes.find((route) => route.match(hash))?.render();
-  if (matched) return matched;
-  // Main shell. On Windows, the painted title-bar menu bar mounts above it
-  // (AppMenuBar renders null off win32). Aux windows above keep their own
-  // chrome and never get the bar.
-  return (
-    <>
-      <AppMenuBar />
-      <App />
-    </>
-  );
+  // The Windows custom title bar (AppTitleBar) is rendered inside <App/> —
+  // it needs App's handlers + messaging state, and aux windows (matched
+  // routes) keep their own chrome.
+  return routes.find((route) => route.match(hash))?.render() ?? <App />;
 }
 
 ReactDOM.createRoot(document.getElementById("root")!).render(

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -581,6 +581,12 @@ describe("Tangerine Terminal theme contract", () => {
     expect(css).toMatch(
       /:root\[data-platform\]:not\(\[data-platform="darwin"\]\):not\(\[data-platform="win32"\]\)\s*\.activity-titlebar\s*\{[\s\S]*?padding-left:\s*14px;[\s\S]*?\}/,
     );
+    // On Windows the aux windows are frameless with the OS caption buttons at
+    // the top-right, so .activity-titlebar drops the left stoplight gutter and
+    // instead reserves the caption-button width on the right.
+    expect(css).toMatch(
+      /:root\[data-platform="win32"\]\s*\.activity-titlebar\s*\{[\s\S]*?padding-left:\s*14px;[\s\S]*?padding-right:\s*var\(--win-caption-w[\s\S]*?\}/,
+    );
     // The main sidebar masthead drops the stoplight gutter on every non-macOS
     // platform now: Linux has a normal frame, and on Windows the masthead is
     // hidden entirely (its wordmark + action buttons moved into the custom

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -581,8 +581,15 @@ describe("Tangerine Terminal theme contract", () => {
     expect(css).toMatch(
       /:root\[data-platform\]:not\(\[data-platform="darwin"\]\):not\(\[data-platform="win32"\]\)\s*\.activity-titlebar\s*\{[\s\S]*?padding-left:\s*14px;[\s\S]*?\}/,
     );
+    // The main sidebar masthead drops the stoplight gutter on every non-macOS
+    // platform now: Linux has a normal frame, and on Windows the masthead is
+    // hidden entirely (its wordmark + action buttons moved into the custom
+    // .app-titlebar strip), so there is no left reservation to keep.
     expect(css).toMatch(
-      /:root\[data-platform\]:not\(\[data-platform="darwin"\]\):not\(\[data-platform="win32"\]\)\s*\.sidebar__masthead\s*\{[\s\S]*?padding-left:\s*0;[\s\S]*?\}/,
+      /:root\[data-platform\]:not\(\[data-platform="darwin"\]\)\s*\.sidebar__masthead\s*\{[\s\S]*?padding-left:\s*0;[\s\S]*?\}/,
+    );
+    expect(css).toMatch(
+      /:root\[data-platform="win32"\]\s*\.sidebar__masthead\s*\{[\s\S]*?display:\s*none;[\s\S]*?\}/,
     );
     expect(css).toMatch(
       /:root\[data-platform\]:not\(\[data-platform="darwin"\]\):not\(\[data-platform="win32"\]\)\s*\.settings-nav__masthead\s*\{[\s\S]*?padding-left:\s*0;[\s\S]*?\}/,

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1049,6 +1049,18 @@ textarea,
   padding-left: 14px;
 }
 
+/* On Windows the aux windows (Changelog / License / Logs / Activity) are
+   frameless with the OS caption buttons at the top-right, so the
+   .activity-titlebar header IS the title strip: drop the macOS stoplight
+   reservation on the left, reserve the caption-button width on the right, and
+   match the WCO overlay color (--bg-sidebar) so the buttons blend in. It's
+   already draggable + min-height 44px from the base rule. */
+:root[data-platform="win32"] .activity-titlebar {
+  padding-left: 14px;
+  padding-right: var(--win-caption-w, 140px);
+  background: var(--bg-sidebar);
+}
+
 .activity-titlebar button,
 .activity-titlebar [role="button"] {
   -webkit-app-region: no-drag;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -8700,6 +8700,15 @@ textarea,
   background: var(--bg-panel-elevated);
 }
 
+/* On Windows the OS draws the min/max/close caption buttons in a reserved
+   overlay at the window's top-right — exactly where this fixed spine pins its
+   hamburger. Drop the spine's top content below the caption strip so the
+   hamburger never sits under the close button. env(titlebar-area-height) is
+   the overlay height (TITLE_BAR_OVERLAY_HEIGHT); falls back to 48px. */
+:root[data-platform="win32"] .context-rail__spine {
+  padding-top: calc(8px + env(titlebar-area-height, 48px));
+}
+
 .context-rail.is-open .context-rail__spine {
   display: none;
 }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -7,6 +7,9 @@
      buttons sit on the same line. Only consumed under [data-platform="win32"];
      zero contribution elsewhere. */
   --win-titlebar-h: 40px;
+  /* Width reserved at the strip's right edge for the OS caption buttons
+     (min/max/close) so title-bar content never sits under them. */
+  --win-caption-w: 140px;
   --bg-app: #000000;
   --bg-sidebar: #050505;
   --bg-panel: #0a0a0a;
@@ -404,13 +407,62 @@ textarea,
   z-index: 40;
   display: flex;
   align-items: center;
+  gap: 10px;
   height: var(--win-titlebar-h);
-  padding-left: 8px;
+  /* Right padding reserves room for the OS caption buttons (min/max/close) so
+     the MSG cluster never sits under them; the draggable spacer absorbs the
+     slack. ~3 caption buttons at default DPI. */
+  padding: 0 var(--win-caption-w, 140px) 0 10px;
   /* Match the OS caption-button overlay color (TITLE_BAR_BG_* in
      appearance-bootstrap.ts mirrors --bg-sidebar) so the painted strip and the
      native min/max/close buttons read as one continuous title bar. */
   background: var(--bg-sidebar);
   -webkit-app-region: drag;
+}
+
+/* Left cluster: wordmark + menu + action buttons (all interactive → no-drag).
+   The spacer between left and right clusters stays draggable. */
+.app-titlebar__left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  -webkit-app-region: no-drag;
+}
+
+.app-titlebar__spacer {
+  flex: 1 1 auto;
+  align-self: stretch;
+  -webkit-app-region: drag;
+}
+
+.app-titlebar__right {
+  display: flex;
+  align-items: center;
+  -webkit-app-region: no-drag;
+}
+
+/* Wordmark — reuse the sidebar brand tokens (--text-primary / --accent), sized
+   for the title strip. The sidebar masthead is hidden on win32 so this is the
+   only wordmark. */
+.app-titlebar__brand {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: -0.01em;
+  white-space: nowrap;
+}
+
+.app-titlebar__brand-accent {
+  color: var(--accent);
+}
+
+.app-titlebar__actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
 }
 
 .app-titlebar__menubar {
@@ -451,6 +503,23 @@ textarea,
   margin-top: var(--win-titlebar-h);
   height: calc(100vh - var(--win-titlebar-h));
   height: calc(100dvh - var(--win-titlebar-h));
+}
+
+/* On Windows the wordmark + masthead action buttons (Automations/Settings/New
+   Thread) live in the title strip instead, so hide the sidebar masthead. */
+:root[data-platform="win32"] .sidebar__masthead {
+  display: none;
+}
+
+/* On Windows the MSG status indicator lives in the title strip (one global
+   control), so hide the per-screen copies in every header but restore the one
+   inside the title bar. */
+:root[data-platform="win32"] .messaging-status-bar {
+  display: none;
+}
+
+:root[data-platform="win32"] .app-titlebar .messaging-status-bar {
+  display: flex;
 }
 
 .app-shell--fatal-settings {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -498,8 +498,10 @@ textarea,
   border-bottom: none;
 }
 
-:root[data-platform]:not([data-platform="darwin"]):not([data-platform="win32"])
-  .sidebar__masthead {
+/* macOS reserves 80px for the traffic-light stoplights. Every other
+   platform (Linux normal frame; Windows frameless with caption buttons on
+   the right, never the left) starts the brand at the left edge. */
+:root[data-platform]:not([data-platform="darwin"]) .sidebar__masthead {
   padding-left: 0;
 }
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2,6 +2,11 @@
   color-scheme: dark;
   font-family: "Geist", "IBM Plex Sans", "SF Pro Text", "Inter", system-ui, sans-serif;
   --font-mono: "IBM Plex Mono", "SFMono-Regular", "SF Mono", Consolas, monospace;
+  /* Windows custom title-bar strip height. Matches TITLE_BAR_OVERLAY_HEIGHT
+     (appearance-bootstrap.ts) so the painted menu bar and the OS caption
+     buttons sit on the same line. Only consumed under [data-platform="win32"];
+     zero contribution elsewhere. */
+  --win-titlebar-h: 40px;
   --bg-app: #000000;
   --bg-sidebar: #050505;
   --bg-panel: #0a0a0a;
@@ -383,6 +388,66 @@ textarea,
   color: var(--text-primary);
   -webkit-user-select: none;
   user-select: none;
+}
+
+/* Windows custom title-bar strip (File / View / Profiles / Window / Help).
+   Frameless WCO draws the OS caption buttons at the top-right; this strip
+   fills the rest of that line with the painted menu bar (left) and a draggable
+   remainder. The whole app shell is pushed below it so nothing renders under
+   the caption buttons. macOS/Linux never set data-platform="win32", so the
+   strip isn't mounted and these offsets don't apply. */
+.app-titlebar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 40;
+  display: flex;
+  align-items: center;
+  height: var(--win-titlebar-h);
+  padding-left: 8px;
+  background: var(--bg-app);
+  -webkit-app-region: drag;
+}
+
+.app-titlebar__menubar {
+  display: flex;
+  align-items: center;
+  gap: 1px;
+  -webkit-app-region: no-drag;
+}
+
+.app-titlebar__menu-item {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 12.5px;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  padding: 5px 9px;
+  border-radius: 6px;
+  cursor: default;
+  white-space: nowrap;
+}
+
+.app-titlebar__menu-item:hover {
+  background: var(--bg-row-active);
+  color: var(--text-primary);
+}
+
+.app-titlebar__menu-item.is-focused {
+  background: var(--bg-row-active);
+  color: var(--text-primary);
+  box-shadow: inset 0 0 0 1px var(--accent);
+}
+
+/* Push the entire shell (main, startup, and fatal variants all carry the
+   .app-shell base) below the fixed title strip on Windows. */
+:root[data-platform="win32"] .app-shell {
+  margin-top: var(--win-titlebar-h);
+  height: calc(100vh - var(--win-titlebar-h));
+  height: calc(100dvh - var(--win-titlebar-h));
 }
 
 .app-shell--fatal-settings {
@@ -8700,13 +8765,13 @@ textarea,
   background: var(--bg-panel-elevated);
 }
 
-/* On Windows the OS draws the min/max/close caption buttons in a reserved
-   overlay at the window's top-right — exactly where this fixed spine pins its
-   hamburger. Drop the spine's top content below the caption strip so the
-   hamburger never sits under the close button. env(titlebar-area-height) is
-   the overlay height (TITLE_BAR_OVERLAY_HEIGHT); falls back to 48px. */
-:root[data-platform="win32"] .context-rail__spine {
-  padding-top: calc(8px + env(titlebar-area-height, 48px));
+/* On Windows the context-rail is position:fixed top:0 — it would slide under
+   the custom title strip (and its hamburger under the OS caption buttons). Pin
+   it below the strip instead. Both the collapsed and pinned states inherit
+   top:0, so offset both. */
+:root[data-platform="win32"] .context-rail,
+:root[data-platform="win32"] .context-rail.is-pinned {
+  top: var(--win-titlebar-h);
 }
 
 .context-rail.is-open .context-rail__spine {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -406,7 +406,10 @@ textarea,
   align-items: center;
   height: var(--win-titlebar-h);
   padding-left: 8px;
-  background: var(--bg-app);
+  /* Match the OS caption-button overlay color (TITLE_BAR_BG_* in
+     appearance-bootstrap.ts mirrors --bg-sidebar) so the painted strip and the
+     native min/max/close buttons read as one continuous title bar. */
+  background: var(--bg-sidebar);
   -webkit-app-region: drag;
 }
 

--- a/apps/desktop/src/shared/app-menu.ts
+++ b/apps/desktop/src/shared/app-menu.ts
@@ -1,0 +1,24 @@
+/**
+ * Shapes for the Windows custom title-bar menu bar bridge.
+ *
+ * On Windows the native title bar is hidden (`titleBarStyle: "hidden"`), which
+ * also removes the native menu bar — on Windows the menu lives in the title bar
+ * the OS just hid. So the renderer paints its own top-level entries (File /
+ * View / Profiles / Window / Help) and, on click or Alt-mnemonic, asks main to
+ * pop the REAL native submenu at the button. The submenu behavior (roles,
+ * accelerators, enable state, click handlers) stays the single source of truth
+ * in the application menu `installApplicationMenu` already builds.
+ *
+ * macOS keeps its system menu bar; Linux keeps the native frame's menu bar.
+ * Neither uses this bridge.
+ */
+
+/** One top-level application-menu entry, for the renderer's custom menu bar. */
+export type AppMenuTopLevel = { index: number; label: string };
+
+/**
+ * Request to pop a top-level submenu. `index` is the menu-model index;
+ * `x`/`y` are window-relative DIP (the menu button's bottom-left). When
+ * absent, Electron falls back to the cursor position.
+ */
+export type AppMenuPopupRequest = { index: number; x?: number; y?: number };

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -285,3 +285,8 @@ export const APP_GET_BOOT_INFO_CHANNEL = "app:get-boot-info";
 export const APP_QUIT_CHANNEL = "app:quit";
 export const APP_WAIT_FOR_PROFILE_ALIVE_CHANNEL = "app:wait-for-profile-alive";
 export const PROFILES_WRITE_SECRETS_CHANNEL = "profiles:write-secrets";
+// Windows custom title-bar menu bar (see shared/app-menu.ts). `model` returns
+// the top-level entries for the renderer's painted bar; `popup` pops the real
+// native submenu at a button. Unused on macOS/Linux.
+export const APP_MENU_MODEL_CHANNEL = "app-menu:model";
+export const APP_MENU_POPUP_CHANNEL = "app-menu:popup";


### PR DESCRIPTION
## What

Gives the Windows desktop app custom, GitHub-Desktop-style window chrome. The native title bar is replaced by a frameless window with a Window Controls Overlay (OS-drawn min/max/close), and the chrome the native title bar used to own is consolidated into a single painted title strip.

**Main window**
```
[PwrAgent] File Edit View Profiles Window Help  [📅][⚙️][＋]  ……drag……  [MSG ▾]   — ▢ ✕
```
- Brand wordmark, the application menu, the Automations/Settings/New-Thread action buttons, and a single MSG status indicator all live on one strip.
- The menu is a **custom-painted bar that pops the real native submenus** (`Menu.popup` over IPC) — `titleBarStyle: 'hidden'` removes the native Windows menu bar entirely, so this is the GitHub-Desktop / VSCode pattern. Click opens; `Alt` focuses the bar; `Alt+F` etc. open by mnemonic; arrows/Enter/Esc navigate. The application menu (`installApplicationMenu`) stays the single source of truth for roles, accelerators, enable-state, and handlers.
- The sidebar masthead and the per-screen MSG button are hidden on Windows (their contents moved into the strip).

**Aux windows** (Changelog / License / Third-Party Notices / Logs / Messaging Activity)
- Same frameless WCO treatment, **minus the menu** (they have no application menu). The existing `.activity-titlebar` breadcrumb header becomes the draggable title strip.

**Color + theme**
- The OS caption-button overlay color is matched to the title bar's real background (`--bg-sidebar`), so the buttons blend instead of sitting on an off-color rectangle (most visible in light theme).
- Theme flips re-color the caption buttons live via `setTitleBarOverlay` (no window recreation).

## Platform scope

**Windows-only.** Everything gates on `data-platform="win32"`. macOS is untouched (`hiddenInset` + traffic lights, sidebar masthead, per-screen MSG, system menu bar all unchanged); Linux keeps the native frame + menu bar.

## Key files

- `main/window.ts` — frameless + themed WCO for the main window.
- `main/app-menu-bridge.ts` (new) — `app-menu:model` / `app-menu:popup` IPC; reads the live application menu.
- `main/auxiliary-window-chrome.ts` — win32 frameless WCO branch for aux windows.
- `main/settings/appearance-bootstrap.ts` — `themedTitleBarOverlay` + `TITLE_BAR_BG_*` (mirror `--bg-sidebar`).
- `main/appearance-broadcast.ts` — live `setTitleBarOverlay` re-color on theme change.
- `renderer/features/chrome/AppTitleBar.tsx` + `AppMenuBar.tsx` (new) — the painted strip + menu.
- `renderer/styles/app.css` — `.app-titlebar` strip, win32 offsets, masthead/MSG hide rules, aux `.activity-titlebar` title strip.
- `shared/app-menu.ts` + `shared/ipc.ts` — menu-bridge types + channels.

## Testing

Validated on a Windows Server 2022 box (Electron run): `typecheck`, `build`, and the affected unit tests all green — `theme-contract` (36/36, updated for the new masthead + aux-titlebar contract), `index`/startup, and `app-bootstrap`. Full Linux + Windows CI runs here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
