### PR TITLE
feat(desktop): add settings update button

### DIFF
--- a/apps/desktop/src/main/__tests__/auto-updater.test.ts
+++ b/apps/desktop/src/main/__tests__/auto-updater.test.ts
@@ -158,6 +158,20 @@ describe("auto updater", () => {
     );
   });
 
+  it("uses the selected update channel for manual checks", async () => {
+    resolveUpdateChannelMock.mockReturnValue("prerelease");
+    const updater = await importAutoUpdater();
+
+    const manualResult = await updater.checkForAppUpdatesNow("manual");
+
+    expect(manualResult).toEqual({
+      status: "available",
+      version: "1.0.0-beta.8",
+    });
+    expect(resolveUpdateChannelMock).toHaveBeenCalledTimes(1);
+    expect(autoUpdaterMock.allowPrerelease).toBe(true);
+  });
+
   it("routes downloaded update installs through requestQuit", async () => {
     const updater = await importAutoUpdater();
     const requestQuit = vi.fn(async (performQuit: () => void) => {

--- a/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
@@ -4,6 +4,7 @@ import type {
   DesktopUpdateChannel,
 } from "@pwragent/shared";
 import type {
+  AppUpdateCheckResult,
   AppUpdateReleaseInfo,
   AppUpdateReleaseVersions,
 } from "../../../../shared/app-metadata";
@@ -105,6 +106,25 @@ function releaseHelpText(
   return `Latest: ${releaseVersionText(releases.latest)}. Prerelease: ${releaseVersionText(releases.prerelease)}.`;
 }
 
+function updateResultText(result: AppUpdateCheckResult): string {
+  if (result.status === "skipped") {
+    return result.reason;
+  }
+  if (result.status === "error") {
+    return `Update check failed: ${result.message}`;
+  }
+  if (result.status === "checking") {
+    return "Checking for updates...";
+  }
+  if (result.status === "no-update") {
+    return `You're up to date (v${result.version}).`;
+  }
+  if (result.status === "downloaded") {
+    return `Update ready: v${result.version}. Restart to install.`;
+  }
+  return `Update available: v${result.version}. Downloading in the background.`;
+}
+
 export function GeneralSettings(props: {
   appearanceController?: AppearanceController;
   desktopApi?: DesktopApi;
@@ -122,6 +142,10 @@ export function GeneralSettings(props: {
 }) {
   const [releaseVersions, setReleaseVersions] = useState<
     AppUpdateReleaseVersions | undefined
+  >();
+  const [updateChecking, setUpdateChecking] = useState(false);
+  const [updateResult, setUpdateResult] = useState<
+    AppUpdateCheckResult | undefined
   >();
   const pastedImageMaxPatches =
     props.snapshot.imageUploads.pastedImageMaxPatches;
@@ -153,6 +177,25 @@ export function GeneralSettings(props: {
       canceled = true;
     };
   }, [props.desktopApi]);
+
+  const checkForUpdates = props.desktopApi?.checkForAppUpdates;
+  const handleUpdateNow = async () => {
+    if (!checkForUpdates) {
+      return;
+    }
+    setUpdateChecking(true);
+    setUpdateResult(undefined);
+    try {
+      setUpdateResult(await checkForUpdates());
+    } catch (err) {
+      setUpdateResult({
+        status: "error",
+        message: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setUpdateChecking(false);
+    }
+  };
 
   const appearance = props.appearanceController?.appearance;
 
@@ -392,35 +435,68 @@ export function GeneralSettings(props: {
           <SettingsField
             label="Update channel"
             sub="Choose which GitHub release stream the updater follows."
-            help={releaseHelpText(releaseVersions)}
+            help={
+              <>
+                {releaseHelpText(releaseVersions)}
+                {updateResult ? (
+                  <>
+                    {" "}
+                    <span
+                      className={
+                        updateResult.status === "error"
+                          ? "settings-update-channel__result settings-update-channel__result--error"
+                          : "settings-update-channel__result"
+                      }
+                      role={
+                        updateResult.status === "error" ? "alert" : undefined
+                      }
+                    >
+                      {updateResultText(updateResult)}
+                    </span>
+                  </>
+                ) : null}
+              </>
+            }
             error={updateChannel.error}
             source={sourceBadge(updateChannel)}
             control={
-              <div
-                className="settings-segmented"
-                role="radiogroup"
-                aria-label="Update channel"
-              >
-                {UPDATE_CHANNEL_OPTIONS.map((option) => (
-                  <button
-                    key={option.value}
-                    aria-checked={updateChannel.value === option.value}
-                    className={`settings-segmented__button settings-segmented__button--stacked${
-                      updateChannel.value === option.value ? " is-active" : ""
-                    }`}
-                    disabled={props.saving}
-                    role="radio"
-                    type="button"
-                    onClick={() => {
-                      void props.onUpdateChannelChange(option.value);
-                    }}
-                  >
-                    <span>{option.label}</span>
-                    <span className="settings-segmented__meta">
-                      {releaseVersionText(releaseVersions?.[option.value])}
-                    </span>
-                  </button>
-                ))}
+              <div className="settings-update-channel">
+                <div
+                  className="settings-segmented"
+                  role="radiogroup"
+                  aria-label="Update channel"
+                >
+                  {UPDATE_CHANNEL_OPTIONS.map((option) => (
+                    <button
+                      key={option.value}
+                      aria-checked={updateChannel.value === option.value}
+                      className={`settings-segmented__button settings-segmented__button--stacked${
+                        updateChannel.value === option.value ? " is-active" : ""
+                      }`}
+                      disabled={props.saving}
+                      role="radio"
+                      type="button"
+                      onClick={() => {
+                        void props.onUpdateChannelChange(option.value);
+                      }}
+                    >
+                      <span>{option.label}</span>
+                      <span className="settings-segmented__meta">
+                        {releaseVersionText(releaseVersions?.[option.value])}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+                <button
+                  className="button button--secondary settings-update-channel__button"
+                  type="button"
+                  disabled={!checkForUpdates || props.saving || updateChecking}
+                  onClick={() => {
+                    void handleUpdateNow();
+                  }}
+                >
+                  {updateChecking ? "Checking..." : "Update"}
+                </button>
               </div>
             }
           />

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -408,6 +408,10 @@ describe("SettingsScreen", () => {
   it("switches sections and saves settings", async () => {
     const settings = createSettingsState();
     const desktopApi = {
+      checkForAppUpdates: vi.fn(async () => ({
+        status: "available" as const,
+        version: "1.0.0-beta.8",
+      })),
       readAppUpdateReleaseVersions: vi.fn(async () => ({
         fetchedAt: 1,
         latest: { version: "v1.0.0" },
@@ -517,6 +521,13 @@ describe("SettingsScreen", () => {
         },
       });
     });
+    fireEvent.click(screen.getByRole("button", { name: "Update" }));
+    await waitFor(() => {
+      expect(desktopApi.checkForAppUpdates).toHaveBeenCalledTimes(1);
+    });
+    expect(
+      await screen.findByText(/Update available: v1.0.0-beta.8/),
+    ).toBeInTheDocument();
 
     expect(screen.getByRole("heading", { name: "Pasted images" })).toBeInTheDocument();
     expect(screen.getByRole("radio", { name: "1536 patches" })).toHaveAttribute(

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -4233,6 +4233,25 @@ textarea,
   line-height: 1.45;
 }
 
+.settings-update-channel {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  gap: 8px;
+}
+
+.settings-update-channel__button {
+  min-height: 0;
+}
+
+.settings-update-channel__result {
+  color: var(--text-secondary);
+}
+
+.settings-update-channel__result--error {
+  color: var(--danger-text);
+}
+
 .settings-section__description {
   margin: 6px 0 0;
   color: var(--text-secondary);


### PR DESCRIPTION
## Summary

- Added an Update button next to Settings -> General -> Updates -> Update channel.
- Reused the existing manual app-update check IPC so the updater checks the currently selected release channel.
- Added coverage for the settings button and for the main updater honoring the selected channel on manual checks.

## Verification

- I ran `pnpm test apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx apps/desktop/src/main/__tests__/auto-updater.test.ts`.
- I ran `pnpm --filter @pwragent/desktop typecheck`.
- I ran `pnpm lint:colors`.
- I ran `git diff --check`.

## Notes

- The Update button starts a check/download for the selected channel; the existing update-ready banner still handles restart/install once a download is ready.
