### PR TITLE
fix(desktop): tighten title reference detection

### DIFF
--- a/apps/desktop/src/main/__tests__/thread-title-generation-service.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-title-generation-service.test.ts
@@ -148,6 +148,25 @@ describe("ThreadTitleGenerationService", () => {
     });
   });
 
+  it("accepts first-turn handoff titles with non-ticket task markers", async () => {
+    const service = new ThreadTitleGenerationService({
+      generators: {
+        codex: makeGenerator({ title: "Dynamic subagent monitoring" }),
+      },
+    });
+
+    await expect(
+      service.generateTitle({
+        backend: "codex",
+        userPrompt:
+          "**Handoff Message: Dynamic Subagent Monitoring for Long-Running Tasks**\n\nTask #1: monitor the spawned agents.\nTask #2: report long-running tool calls.",
+      })
+    ).resolves.toMatchObject({
+      status: "generated",
+      title: "Dynamic subagent monitoring",
+    });
+  });
+
   it("cleans wrapper quotes and trailing punctuation", async () => {
     const service = new ThreadTitleGenerationService({
       generators: {

--- a/apps/desktop/src/main/app-server/thread-title-generation-service.ts
+++ b/apps/desktop/src/main/app-server/thread-title-generation-service.ts
@@ -252,19 +252,30 @@ function preservesTicketReferences(userPrompt: string, title: string): boolean {
 
 function extractTicketReferences(value: string): string[] {
   const references: string[] = [];
-  const patterns = [
+  const contextualPatterns = [
     /\b[A-Z][A-Z0-9]+-\d+\b/g,
-    /#\d+\b/g,
     /\b(?:issue|pr|pull request)\s+#?\d+\b/gi,
   ];
 
-  for (const pattern of patterns) {
+  for (const pattern of contextualPatterns) {
     for (const match of value.matchAll(pattern)) {
       references.push(match[0]);
     }
   }
 
+  for (const match of value.matchAll(/#\d+\b/g)) {
+    const index = match.index;
+    if (typeof index !== "number" || isBareHashTicketReference(value, index)) {
+      references.push(match[0]);
+    }
+  }
+
   return references;
+}
+
+function isBareHashTicketReference(value: string, index: number): boolean {
+  const context = value.slice(Math.max(0, index - 32), index).toLowerCase();
+  return !/\b(?:agent|item|option|step|subagent|task|turn)\s*$/.test(context);
 }
 
 function normalizeReferenceText(value: string): string {


### PR DESCRIPTION
## Summary

- I tightened thread title ticket-reference detection so task markers like `Task #1` and `Task #2` no longer look like GitHub issue references.
- I kept the existing prompt and the hard preservation check for real ticket/work-item references such as `PROJECT-123`, `issue 123`, `PR 456`, and bare `#123`.
- I added a first-turn handoff regression test for non-ticket task markers so generated titles do not get rejected with `ticket_reference_missing`.

## Verification

- I ran `pnpm test apps/desktop/src/main/__tests__/thread-title-generation-service.test.ts apps/desktop/src/main/__tests__/thread-title-prompt.test.ts`.
- I verified the focused suite passes: 2 test files, 15 tests.

## Notes

- Root cause: the previous bare `#number` heuristic treated non-ticket task markers in handoff prompts as ticket references, so a title like `Dynamic subagent monitoring` could be rejected with `ticket_reference_missing`.
