### PR TITLE
fix(desktop): place windows on source display

### DIFF
--- a/apps/desktop/src/main/__tests__/app-bootstrap.test.ts
+++ b/apps/desktop/src/main/__tests__/app-bootstrap.test.ts
@@ -31,6 +31,10 @@ const clipboardWriteTextMock = vi.fn();
 const addWordToSpellCheckerDictionaryMock = vi.fn();
 const replaceMisspellingMock = vi.fn();
 const menuPopupMock = vi.fn();
+const getCursorScreenPointMock = vi.fn(() => ({ x: 2500, y: 200 }));
+const getDisplayNearestPointMock = vi.fn(() => ({
+  workArea: { x: 1920, y: 0, width: 1920, height: 1080 },
+}));
 const buildFromTemplateMock = vi.fn((template: MenuItemConstructorOptions[]) => ({
   popup: menuPopupMock,
   template,
@@ -160,6 +164,10 @@ vi.mock("electron", () => ({
   Menu: {
     buildFromTemplate: buildFromTemplateMock
   },
+  screen: {
+    getCursorScreenPoint: getCursorScreenPointMock,
+    getDisplayNearestPoint: getDisplayNearestPointMock,
+  },
   shell: {
     openExternal: shellOpenExternalMock
   }
@@ -219,6 +227,8 @@ describe("createMainWindow", () => {
     windowEventHandlers.clear();
     webContentsEventHandlers.clear();
     webContentsOnceHandlers.clear();
+    getCursorScreenPointMock.mockClear();
+    getDisplayNearestPointMock.mockClear();
     delete process.env.ELECTRON_RENDERER_URL;
   });
 
@@ -233,6 +243,16 @@ describe("createMainWindow", () => {
     createMainWindow();
 
     expect(BrowserWindowMock).toHaveBeenCalledTimes(1);
+    expect(browserWindowState.options).toMatchObject({
+      x: 1920 + (1920 - 1440) / 2,
+      y: (1080 - 960) / 2,
+      width: 1440,
+      height: 960,
+    });
+    expect(getDisplayNearestPointMock).toHaveBeenCalledWith({
+      x: 2500,
+      y: 200,
+    });
     expect(
       browserWindowState.options?.webPreferences?.preload?.replace(/\\/g, "/")
     ).toContain("preload/index.cjs");

--- a/apps/desktop/src/main/app-log-window.ts
+++ b/apps/desktop/src/main/app-log-window.ts
@@ -25,23 +25,31 @@ import {
   showAndFocusAuxiliaryWindow,
   showAuxiliaryWindowWhenReady,
 } from "./auxiliary-window-chrome";
+import {
+  auxiliaryWindowPlacementOptions,
+  positionAuxiliaryWindowOnSourceDisplay,
+} from "./auxiliary-window-placement";
 
 const log = getMainLogger("pwragent:app-log-window");
 const LOGS_HASH = "logs";
 const LOGS_WINDOW_TITLE = "Logs";
+const LOGS_WINDOW_WIDTH = 1040;
+const LOGS_WINDOW_HEIGHT = 760;
 
 let appLogWindow: BrowserWindow | undefined;
 
 export function showAppLogWindow(): void {
   if (appLogWindow && !appLogWindow.isDestroyed()) {
+    positionAuxiliaryWindowOnSourceDisplay(appLogWindow);
     showAndFocusAuxiliaryWindow(appLogWindow);
     return;
   }
 
   const appearance = readBootstrapAppearance();
   const window = new BrowserWindow({
-    width: 1040,
-    height: 760,
+    ...auxiliaryWindowPlacementOptions(LOGS_WINDOW_WIDTH, LOGS_WINDOW_HEIGHT),
+    width: LOGS_WINDOW_WIDTH,
+    height: LOGS_WINDOW_HEIGHT,
     minWidth: 700,
     minHeight: 500,
     show: false,

--- a/apps/desktop/src/main/auxiliary-window-placement.ts
+++ b/apps/desktop/src/main/auxiliary-window-placement.ts
@@ -1,0 +1,58 @@
+import {
+  BrowserWindow,
+  screen,
+  type Display,
+} from "electron";
+
+type WindowPositionOptions = { x: number; y: number };
+
+export function windowCenteredOnCursorDisplay(
+  width: number,
+  height: number,
+): WindowPositionOptions {
+  return centeredWindowBoundsOnDisplay(
+    width,
+    height,
+    screen.getDisplayNearestPoint(screen.getCursorScreenPoint()),
+  );
+}
+
+export function auxiliaryWindowPlacementOptions(
+  width: number,
+  height: number,
+): WindowPositionOptions {
+  return centeredWindowBoundsOnDisplay(
+    width,
+    height,
+    sourceDisplayForFocusedWindow(),
+  );
+}
+
+export function positionAuxiliaryWindowOnSourceDisplay(
+  window: BrowserWindow,
+): void {
+  const bounds = window.getBounds();
+  const position = auxiliaryWindowPlacementOptions(bounds.width, bounds.height);
+  window.setPosition(position.x, position.y, false);
+}
+
+function centeredWindowBoundsOnDisplay(
+  width: number,
+  height: number,
+  display: Display,
+): WindowPositionOptions {
+  const workArea = display.workArea;
+  return {
+    x: Math.round(workArea.x + Math.max(0, workArea.width - width) / 2),
+    y: Math.round(workArea.y + Math.max(0, workArea.height - height) / 2),
+  };
+}
+
+function sourceDisplayForFocusedWindow(): Display {
+  const focusedWindow = BrowserWindow.getFocusedWindow();
+  if (focusedWindow && !focusedWindow.isDestroyed()) {
+    return screen.getDisplayMatching(focusedWindow.getBounds());
+  }
+
+  return screen.getDisplayNearestPoint(screen.getCursorScreenPoint());
+}

--- a/apps/desktop/src/main/changelog-window.ts
+++ b/apps/desktop/src/main/changelog-window.ts
@@ -22,23 +22,34 @@ import {
   showAndFocusAuxiliaryWindow,
   showAuxiliaryWindowWhenReady,
 } from "./auxiliary-window-chrome";
+import {
+  auxiliaryWindowPlacementOptions,
+  positionAuxiliaryWindowOnSourceDisplay,
+} from "./auxiliary-window-placement";
 
 const log = getMainLogger("pwragent:changelog-window");
 const CHANGELOG_HASH = "changelog";
 const CHANGELOG_WINDOW_TITLE = "Changelog";
+const CHANGELOG_WINDOW_WIDTH = 920;
+const CHANGELOG_WINDOW_HEIGHT = 760;
 
 let changelogWindow: BrowserWindow | undefined;
 
 export function showChangelogWindow(): void {
   if (changelogWindow && !changelogWindow.isDestroyed()) {
+    positionAuxiliaryWindowOnSourceDisplay(changelogWindow);
     showAndFocusAuxiliaryWindow(changelogWindow);
     return;
   }
 
   const appearance = readBootstrapAppearance();
   const window = new BrowserWindow({
-    width: 920,
-    height: 760,
+    ...auxiliaryWindowPlacementOptions(
+      CHANGELOG_WINDOW_WIDTH,
+      CHANGELOG_WINDOW_HEIGHT,
+    ),
+    width: CHANGELOG_WINDOW_WIDTH,
+    height: CHANGELOG_WINDOW_HEIGHT,
     minWidth: 640,
     minHeight: 480,
     show: false,

--- a/apps/desktop/src/main/license-document-window.ts
+++ b/apps/desktop/src/main/license-document-window.ts
@@ -22,10 +22,16 @@ import {
   showAndFocusAuxiliaryWindow,
   showAuxiliaryWindowWhenReady,
 } from "./auxiliary-window-chrome";
+import {
+  auxiliaryWindowPlacementOptions,
+  positionAuxiliaryWindowOnSourceDisplay,
+} from "./auxiliary-window-placement";
 
 const log = getMainLogger("pwragent:license-document-window");
 const LICENSE_HASH = "license";
 const THIRD_PARTY_NOTICES_HASH = "third-party-notices";
+const LICENSE_DOCUMENT_WINDOW_WIDTH = 920;
+const LICENSE_DOCUMENT_WINDOW_HEIGHT = 760;
 
 let licenseWindow: BrowserWindow | undefined;
 let thirdPartyNoticesWindow: BrowserWindow | undefined;
@@ -60,14 +66,19 @@ function showLicenseDocumentWindow(options: {
 }): void {
   const existingWindow = options.windowRef();
   if (existingWindow && !existingWindow.isDestroyed()) {
+    positionAuxiliaryWindowOnSourceDisplay(existingWindow);
     showAndFocusAuxiliaryWindow(existingWindow);
     return;
   }
 
   const appearance = readBootstrapAppearance();
   const window = new BrowserWindow({
-    width: 920,
-    height: 760,
+    ...auxiliaryWindowPlacementOptions(
+      LICENSE_DOCUMENT_WINDOW_WIDTH,
+      LICENSE_DOCUMENT_WINDOW_HEIGHT,
+    ),
+    width: LICENSE_DOCUMENT_WINDOW_WIDTH,
+    height: LICENSE_DOCUMENT_WINDOW_HEIGHT,
     minWidth: 640,
     minHeight: 480,
     show: false,

--- a/apps/desktop/src/main/messaging-activity-window.ts
+++ b/apps/desktop/src/main/messaging-activity-window.ts
@@ -22,9 +22,15 @@ import {
   showAndFocusAuxiliaryWindow,
   showAuxiliaryWindowWhenReady,
 } from "./auxiliary-window-chrome";
+import {
+  auxiliaryWindowPlacementOptions,
+  positionAuxiliaryWindowOnSourceDisplay,
+} from "./auxiliary-window-placement";
 
 const log = getMainLogger("pwragent:activity-window");
 const ACTIVITY_WINDOW_TITLE = "Messaging Activity";
+const ACTIVITY_WINDOW_WIDTH = 980;
+const ACTIVITY_WINDOW_HEIGHT = 720;
 
 /**
  * Hash that the renderer (`main.tsx`) reads to decide whether to mount
@@ -48,14 +54,19 @@ let activityWindow: BrowserWindow | undefined;
  */
 export function showMessagingActivityWindow(): void {
   if (activityWindow && !activityWindow.isDestroyed()) {
+    positionAuxiliaryWindowOnSourceDisplay(activityWindow);
     showAndFocusAuxiliaryWindow(activityWindow);
     return;
   }
 
   const appearance = readBootstrapAppearance();
   const window = new BrowserWindow({
-    width: 980,
-    height: 720,
+    ...auxiliaryWindowPlacementOptions(
+      ACTIVITY_WINDOW_WIDTH,
+      ACTIVITY_WINDOW_HEIGHT,
+    ),
+    width: ACTIVITY_WINDOW_WIDTH,
+    height: ACTIVITY_WINDOW_HEIGHT,
     minWidth: 640,
     minHeight: 480,
     show: false,

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -43,6 +43,7 @@ import {
   navigationPreferencesAdditionalArguments,
   readBootstrapNavigationPreferences,
 } from "./navigation-browse-mode-bootstrap";
+import { windowCenteredOnCursorDisplay } from "./auxiliary-window-placement";
 
 const isDevelopment = process.env.NODE_ENV !== "production";
 const isMac = process.platform === "darwin";
@@ -294,6 +295,8 @@ export function createMainWindow(options?: {
     attachWindow: (window: BrowserWindow) => void;
   };
 }): BrowserWindow {
+  const width = 1440;
+  const height = 960;
   const preloadPath = getPreloadPath();
   const appearance = readBootstrapAppearance();
   const navigationPreferences = readBootstrapNavigationPreferences();
@@ -304,8 +307,9 @@ export function createMainWindow(options?: {
       }
     : {};
   const window = new BrowserWindow({
-    width: 1440,
-    height: 960,
+    ...windowCenteredOnCursorDisplay(width, height),
+    width,
+    height,
     minWidth: 1200,
     minHeight: 760,
     show: false,


### PR DESCRIPTION
## Summary
- center the main PwrAgent window on the current cursor display at startup
- center auxiliary windows on the display containing the focused/source window
- re-position existing Messaging Activity, Logs, Changelog, License, and Third-Party Notices windows before focusing them

## Validation
- pnpm test apps/desktop/src/main/__tests__/app-bootstrap.test.ts apps/desktop/src/main/__tests__/auxiliary-window-chrome.test.ts
- pnpm --filter @pwragent/desktop typecheck
- pnpm lint:boundaries
- pnpm dev:dev launched to ready-to-show, then cleaned up