### PR TITLE
feat(desktop): clarify settings update actions

### DIFF
--- a/apps/desktop/src/main/__tests__/auto-updater.test.ts
+++ b/apps/desktop/src/main/__tests__/auto-updater.test.ts
@@ -168,10 +168,43 @@ describe("auto updater", () => {
     const manualResult = await updater.checkForAppUpdatesNow("manual");
 
     expect(manualResult).toEqual({
-      status: "downloaded",
+      status: "available",
       version: "1.0.0-beta.8",
     });
     expect(checkForUpdatesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("binds a downloaded update to the channel that found it", async () => {
+    resolveUpdateChannelMock.mockReturnValue("prerelease");
+    checkForUpdatesMock
+      .mockResolvedValueOnce({ updateInfo: { version: "1.0.0-beta.8" } })
+      .mockResolvedValue({ updateInfo: { version: "1.0.0-beta.7" } });
+    const updater = await importAutoUpdater();
+
+    updater.initAutoUpdater();
+    await Promise.resolve();
+
+    resolveUpdateChannelMock.mockReturnValue("latest");
+    await expect(updater.checkForAppUpdatesNow("manual")).resolves.toEqual({
+      status: "no-update",
+      version: "1.0.0-beta.7",
+    });
+    updateEventHandlers.get("update-downloaded")?.({ version: "1.0.0-beta.8" });
+
+    checkForUpdatesMock.mockClear();
+    await expect(updater.checkForAppUpdatesNow("manual")).resolves.toEqual({
+      status: "no-update",
+      version: "1.0.0-beta.7",
+    });
+    expect(checkForUpdatesMock).toHaveBeenCalledTimes(1);
+
+    resolveUpdateChannelMock.mockReturnValue("prerelease");
+    checkForUpdatesMock.mockClear();
+    await expect(updater.checkForAppUpdatesNow("manual")).resolves.toEqual({
+      status: "downloaded",
+      version: "1.0.0-beta.8",
+    });
+    expect(checkForUpdatesMock).not.toHaveBeenCalled();
   });
 
   it("skips electron-updater on Linux package builds", async () => {

--- a/apps/desktop/src/main/__tests__/auto-updater.test.ts
+++ b/apps/desktop/src/main/__tests__/auto-updater.test.ts
@@ -139,6 +139,41 @@ describe("auto updater", () => {
     expect(windowSendMock).not.toHaveBeenCalled();
   });
 
+  it("does not check again when an update is already downloaded for the selected channel", async () => {
+    const updater = await importAutoUpdater();
+
+    updater.initAutoUpdater();
+    await Promise.resolve();
+    updateEventHandlers.get("update-downloaded")?.({ version: "1.0.0-beta.8" });
+    checkForUpdatesMock.mockClear();
+
+    const manualResult = await updater.checkForAppUpdatesNow("manual");
+
+    expect(manualResult).toEqual({
+      status: "downloaded",
+      version: "1.0.0-beta.8",
+    });
+    expect(checkForUpdatesMock).not.toHaveBeenCalled();
+  });
+
+  it("checks again when the selected channel changes after an update is downloaded", async () => {
+    const updater = await importAutoUpdater();
+
+    updater.initAutoUpdater();
+    await Promise.resolve();
+    updateEventHandlers.get("update-downloaded")?.({ version: "1.0.0-beta.8" });
+    resolveUpdateChannelMock.mockReturnValue("prerelease");
+    checkForUpdatesMock.mockClear();
+
+    const manualResult = await updater.checkForAppUpdatesNow("manual");
+
+    expect(manualResult).toEqual({
+      status: "downloaded",
+      version: "1.0.0-beta.8",
+    });
+    expect(checkForUpdatesMock).toHaveBeenCalledTimes(1);
+  });
+
   it("skips electron-updater on Linux package builds", async () => {
     setPlatform("linux");
     const updater = await importAutoUpdater();

--- a/apps/desktop/src/main/auto-updater.ts
+++ b/apps/desktop/src/main/auto-updater.ts
@@ -28,8 +28,12 @@ let initialized = false;
 let updateStatus: AppUpdateStatus = { status: "idle" };
 let periodicUpdateCheckTimer: ReturnType<typeof setInterval> | undefined;
 let updateCheckInFlight: Promise<AppUpdateCheckResult> | undefined;
-let configuredUpdateChannel: "latest" | "prerelease" | undefined;
+let updateCheckChannelInFlight: "latest" | "prerelease" | undefined;
 let downloadedUpdateChannel: "latest" | "prerelease" | undefined;
+const pendingDownloadChannelsByVersion = new Map<
+  string,
+  "latest" | "prerelease"
+>();
 
 type GitHubRelease = {
   draft?: boolean;
@@ -71,7 +75,6 @@ function currentUpdateChannel(): "latest" | "prerelease" {
 function configureAutoUpdaterChannel(
   updateChannel: "latest" | "prerelease" = currentUpdateChannel(),
 ): void {
-  configuredUpdateChannel = updateChannel;
   autoUpdater.allowPrerelease = updateChannel === "prerelease";
   log.info("configured auto-update channel", {
     allowPrerelease: autoUpdater.allowPrerelease,
@@ -139,6 +142,16 @@ function downloadedUpdateMatchesChannel(
   return { status: "downloaded", version: updateStatus.version };
 }
 
+function recordPendingDownloadChannel(
+  version: string | undefined,
+  updateChannel: "latest" | "prerelease" | undefined,
+): void {
+  if (!version || !updateChannel) {
+    return;
+  }
+  pendingDownloadChannelsByVersion.set(version, updateChannel);
+}
+
 export async function checkForAppUpdatesNow(
   trigger: "startup" | "periodic" | "manual" | "menu" = "manual",
 ): Promise<AppUpdateCheckResult> {
@@ -173,9 +186,15 @@ export async function checkForAppUpdatesNow(
       }
       log.info("checking for app updates", { trigger });
       configureAutoUpdaterChannel(updateChannel);
+      updateCheckChannelInFlight = updateChannel;
       const result = await autoUpdater.checkForUpdates();
-      if (updateStatus.status === "downloaded") {
-        return { status: "downloaded", version: updateStatus.version };
+      const currentVersion = autoUpdater.currentVersion?.version ?? "unknown";
+      if (result?.updateInfo?.version !== currentVersion) {
+        recordPendingDownloadChannel(result?.updateInfo?.version, updateChannel);
+      }
+      const matchingDownloadedResult = downloadedUpdateMatchesChannel(updateChannel);
+      if (matchingDownloadedResult) {
+        return matchingDownloadedResult;
       }
       if (!result || !result.updateInfo) {
         return {
@@ -183,7 +202,6 @@ export async function checkForAppUpdatesNow(
           version: result?.updateInfo?.version ?? "unknown",
         };
       }
-      const currentVersion = autoUpdater.currentVersion?.version ?? "unknown";
       if (result.updateInfo.version === currentVersion) {
         return { status: "no-update", version: currentVersion };
       }
@@ -200,6 +218,7 @@ export async function checkForAppUpdatesNow(
       });
       return result;
     } finally {
+      updateCheckChannelInFlight = undefined;
       updateCheckInFlight = undefined;
     }
   })();
@@ -392,6 +411,7 @@ export function initAutoUpdater(): void {
   });
   autoUpdater.on("update-available", (info) => {
     log.info("update-available", { version: info.version });
+    recordPendingDownloadChannel(info.version, updateCheckChannelInFlight);
     setUpdateStatus({ status: "available", version: info.version });
   });
   autoUpdater.on("update-not-available", (info) => {
@@ -416,7 +436,12 @@ export function initAutoUpdater(): void {
   });
   autoUpdater.on("update-downloaded", (info) => {
     log.info("update-downloaded", { version: info.version });
-    downloadedUpdateChannel = configuredUpdateChannel;
+    downloadedUpdateChannel = info.version
+      ? pendingDownloadChannelsByVersion.get(info.version)
+      : undefined;
+    if (info.version) {
+      pendingDownloadChannelsByVersion.delete(info.version);
+    }
     setUpdateStatus({ status: "downloaded", version: info.version });
   });
   autoUpdater.on("error", (err: Error) => {

--- a/apps/desktop/src/main/auto-updater.ts
+++ b/apps/desktop/src/main/auto-updater.ts
@@ -28,6 +28,8 @@ let initialized = false;
 let updateStatus: AppUpdateStatus = { status: "idle" };
 let periodicUpdateCheckTimer: ReturnType<typeof setInterval> | undefined;
 let updateCheckInFlight: Promise<AppUpdateCheckResult> | undefined;
+let configuredUpdateChannel: "latest" | "prerelease" | undefined;
+let downloadedUpdateChannel: "latest" | "prerelease" | undefined;
 
 type GitHubRelease = {
   draft?: boolean;
@@ -39,6 +41,9 @@ type GitHubRelease = {
 };
 
 function setUpdateStatus(nextStatus: AppUpdateStatus): void {
+  if (nextStatus.status !== "downloaded") {
+    downloadedUpdateChannel = undefined;
+  }
   updateStatus = nextStatus;
   for (const window of BrowserWindow.getAllWindows()) {
     if (window.isDestroyed()) {
@@ -63,8 +68,10 @@ function currentUpdateChannel(): "latest" | "prerelease" {
   }
 }
 
-function configureAutoUpdaterChannel(): void {
-  const updateChannel = currentUpdateChannel();
+function configureAutoUpdaterChannel(
+  updateChannel: "latest" | "prerelease" = currentUpdateChannel(),
+): void {
+  configuredUpdateChannel = updateChannel;
   autoUpdater.allowPrerelease = updateChannel === "prerelease";
   log.info("configured auto-update channel", {
     allowPrerelease: autoUpdater.allowPrerelease,
@@ -120,6 +127,18 @@ function setUpdateStatusUnlessDownloaded(nextStatus: AppUpdateStatus): void {
   setUpdateStatus(nextStatus);
 }
 
+function downloadedUpdateMatchesChannel(
+  updateChannel: "latest" | "prerelease",
+): Extract<AppUpdateCheckResult, { status: "downloaded" }> | undefined {
+  if (
+    updateStatus.status !== "downloaded" ||
+    downloadedUpdateChannel !== updateChannel
+  ) {
+    return undefined;
+  }
+  return { status: "downloaded", version: updateStatus.version };
+}
+
 export async function checkForAppUpdatesNow(
   trigger: "startup" | "periodic" | "manual" | "menu" = "manual",
 ): Promise<AppUpdateCheckResult> {
@@ -142,8 +161,18 @@ export async function checkForAppUpdatesNow(
 
   updateCheckInFlight = (async () => {
     try {
+      const updateChannel = currentUpdateChannel();
+      const downloadedResult = downloadedUpdateMatchesChannel(updateChannel);
+      if (downloadedResult) {
+        log.info("skipping app update check; update already downloaded", {
+          trigger,
+          updateChannel,
+          version: downloadedResult.version,
+        });
+        return downloadedResult;
+      }
       log.info("checking for app updates", { trigger });
-      configureAutoUpdaterChannel();
+      configureAutoUpdaterChannel(updateChannel);
       const result = await autoUpdater.checkForUpdates();
       if (updateStatus.status === "downloaded") {
         return { status: "downloaded", version: updateStatus.version };
@@ -387,6 +416,7 @@ export function initAutoUpdater(): void {
   });
   autoUpdater.on("update-downloaded", (info) => {
     log.info("update-downloaded", { version: info.version });
+    downloadedUpdateChannel = configuredUpdateChannel;
     setUpdateStatus({ status: "downloaded", version: info.version });
   });
   autoUpdater.on("error", (err: Error) => {

--- a/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
@@ -98,23 +98,6 @@ function releaseVersionText(release: AppUpdateReleaseInfo | undefined): string {
   return release?.version ?? "Unavailable";
 }
 
-function normalizedUpdateVersion(version: string | undefined): string | undefined {
-  return version?.trim().replace(/^v/i, "");
-}
-
-function downloadedVersionMatchesRelease(
-  status: AppUpdateStatus | undefined,
-  release: AppUpdateReleaseInfo | undefined,
-): status is Extract<AppUpdateStatus, { status: "downloaded" }> {
-  if (status?.status !== "downloaded" || !release?.version) {
-    return false;
-  }
-  return (
-    normalizedUpdateVersion(status.version) ===
-    normalizedUpdateVersion(release.version)
-  );
-}
-
 function releaseHelpText(
   releases: AppUpdateReleaseVersions | undefined,
 ): string {
@@ -165,6 +148,13 @@ export function GeneralSettings(props: {
   const [updateResult, setUpdateResult] = useState<
     AppUpdateCheckResult | undefined
   >();
+  const [updateStatus, setUpdateStatus] = useState<AppUpdateStatus>({
+    status: "idle",
+  });
+  const [updateRestarting, setUpdateRestarting] = useState(false);
+  const [updateRestartError, setUpdateRestartError] = useState<
+    string | undefined
+  >();
   const pastedImageMaxPatches =
     props.snapshot.imageUploads.pastedImageMaxPatches;
   const confirmQuitWithInProgressThreads =
@@ -196,29 +186,41 @@ export function GeneralSettings(props: {
     };
   }, [props.desktopApi]);
 
+  useEffect(() => {
+    let canceled = false;
+    let receivedEvent = false;
+    const unsubscribe = props.desktopApi?.onAppUpdateStatus?.((status) => {
+      receivedEvent = true;
+      setUpdateStatus(status);
+      if (status.status === "downloaded") {
+        setUpdateRestartError(undefined);
+        setUpdateRestarting(false);
+      }
+    });
+    void props.desktopApi?.readAppUpdateStatus?.().then((status) => {
+      if (!canceled && !receivedEvent) {
+        setUpdateStatus(status);
+      }
+    });
+    return () => {
+      canceled = true;
+      unsubscribe?.();
+    };
+  }, [props.desktopApi]);
+
   const checkForUpdates = props.desktopApi?.checkForAppUpdates;
-  const handleUpdateNow = async () => {
+  const downloadedVersion =
+    updateStatus.status === "downloaded" ? updateStatus.version : undefined;
+  const handleCheckForUpdate = async () => {
     if (!checkForUpdates) {
       return;
     }
     setUpdateChecking(true);
     setUpdateResult(undefined);
     try {
-      let currentStatus: AppUpdateStatus | undefined;
-      try {
-        currentStatus = await props.desktopApi?.readAppUpdateStatus?.();
-      } catch {
-        currentStatus = undefined;
-      }
-      const selectedRelease = releaseVersions?.[updateChannel.value];
-      if (downloadedVersionMatchesRelease(currentStatus, selectedRelease)) {
-        setUpdateResult({
-          status: "downloaded",
-          version: currentStatus.version,
-        });
-        return;
-      }
-      setUpdateResult(await checkForUpdates());
+      const result = await checkForUpdates();
+      setUpdateResult(result);
+      setUpdateStatus(result);
     } catch (err) {
       setUpdateResult({
         status: "error",
@@ -226,6 +228,19 @@ export function GeneralSettings(props: {
       });
     } finally {
       setUpdateChecking(false);
+    }
+  };
+  const handleRestartUpdate = async () => {
+    if (!props.desktopApi?.installAppUpdate) {
+      setUpdateRestartError("Restart is not available in this build.");
+      return;
+    }
+    setUpdateRestarting(true);
+    setUpdateRestartError(undefined);
+    const result = await props.desktopApi.installAppUpdate();
+    if (result.status === "error") {
+      setUpdateRestartError(result.message);
+      setUpdateRestarting(false);
     }
   };
 
@@ -519,15 +534,46 @@ export function GeneralSettings(props: {
                     </button>
                   ))}
                 </div>
+                {downloadedVersion ? (
+                  <div className="settings-update-channel__restart">
+                    <button
+                      aria-label={`Restart to Update (${downloadedVersion})`}
+                      className="button button--primary settings-update-channel__restart-button"
+                      type="button"
+                      disabled={
+                        updateRestarting || !props.desktopApi?.installAppUpdate
+                      }
+                      onClick={() => {
+                        void handleRestartUpdate();
+                      }}
+                    >
+                      <span>Restart to Update</span>
+                      <span className="settings-update-channel__restart-version">
+                        ({downloadedVersion})
+                      </span>
+                    </button>
+                    <span className="settings-update-channel__downloaded">
+                      Downloaded version: {downloadedVersion}
+                    </span>
+                    {updateRestartError ? (
+                      <span
+                        className="settings-update-channel__result settings-update-channel__result--error"
+                        role="alert"
+                      >
+                        {updateRestartError}
+                      </span>
+                    ) : null}
+                  </div>
+                ) : null}
                 <button
                   className="button button--secondary settings-update-channel__button"
                   type="button"
                   disabled={!checkForUpdates || props.saving || updateChecking}
                   onClick={() => {
-                    void handleUpdateNow();
+                    void handleCheckForUpdate();
                   }}
                 >
-                  {updateChecking ? "Checking..." : "Update"}
+                  {updateChecking ? "Checking..." : "Check for Update"}
                 </button>
               </div>
             }

--- a/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
@@ -7,6 +7,7 @@ import type {
   AppUpdateCheckResult,
   AppUpdateReleaseInfo,
   AppUpdateReleaseVersions,
+  AppUpdateStatus,
 } from "../../../../shared/app-metadata";
 import type { DesktopApi } from "../../lib/desktop-api";
 import type {
@@ -95,6 +96,23 @@ const HOT_CPU_HEAP_SNAPSHOT_LIMIT_OPTIONS: Array<{
 
 function releaseVersionText(release: AppUpdateReleaseInfo | undefined): string {
   return release?.version ?? "Unavailable";
+}
+
+function normalizedUpdateVersion(version: string | undefined): string | undefined {
+  return version?.trim().replace(/^v/i, "");
+}
+
+function downloadedVersionMatchesRelease(
+  status: AppUpdateStatus | undefined,
+  release: AppUpdateReleaseInfo | undefined,
+): status is Extract<AppUpdateStatus, { status: "downloaded" }> {
+  if (status?.status !== "downloaded" || !release?.version) {
+    return false;
+  }
+  return (
+    normalizedUpdateVersion(status.version) ===
+    normalizedUpdateVersion(release.version)
+  );
 }
 
 function releaseHelpText(
@@ -186,6 +204,20 @@ export function GeneralSettings(props: {
     setUpdateChecking(true);
     setUpdateResult(undefined);
     try {
+      let currentStatus: AppUpdateStatus | undefined;
+      try {
+        currentStatus = await props.desktopApi?.readAppUpdateStatus?.();
+      } catch {
+        currentStatus = undefined;
+      }
+      const selectedRelease = releaseVersions?.[updateChannel.value];
+      if (downloadedVersionMatchesRelease(currentStatus, selectedRelease)) {
+        setUpdateResult({
+          status: "downloaded",
+          version: currentStatus.version,
+        });
+        return;
+      }
       setUpdateResult(await checkForUpdates());
     } catch (err) {
       setUpdateResult({

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -2883,6 +2883,48 @@ describe("SettingsScreen", () => {
     expect(settings.replaceSecret).not.toHaveBeenCalled();
   });
 
+  it("does not check for updates again when the selected channel version is already downloaded", async () => {
+    const settings = createSettingsState(
+      createSnapshot({
+        updates: {
+          channel: { value: "prerelease", source: "config" },
+        },
+      }),
+    );
+    const desktopApi = {
+      checkForAppUpdates: vi.fn(async () => ({
+        status: "available" as const,
+        version: "1.0.0-beta.8",
+      })),
+      readAppUpdateReleaseVersions: vi.fn(async () => ({
+        fetchedAt: 1,
+        latest: { version: "v1.0.0" },
+        prerelease: { version: "v1.0.0-beta.7" },
+      })),
+      readAppUpdateStatus: vi.fn(async () => ({
+        status: "downloaded" as const,
+        version: "1.0.0-beta.7",
+      })),
+    };
+
+    render(
+      <SettingsScreen
+        desktopApi={desktopApi}
+        settings={settings}
+        onClose={() => undefined}
+      />,
+    );
+
+    expect(await screen.findByText("v1.0.0-beta.7")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Update" }));
+
+    expect(
+      await screen.findByText("Update ready: v1.0.0-beta.7. Restart to install."),
+    ).toBeInTheDocument();
+    expect(desktopApi.readAppUpdateStatus).toHaveBeenCalledTimes(1);
+    expect(desktopApi.checkForAppUpdates).not.toHaveBeenCalled();
+  });
+
   it("blocks settings edits when the config file cannot be parsed", () => {
     render(
       <SettingsScreen

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -521,7 +521,7 @@ describe("SettingsScreen", () => {
         },
       });
     });
-    fireEvent.click(screen.getByRole("button", { name: "Update" }));
+    fireEvent.click(screen.getByRole("button", { name: "Check for Update" }));
     await waitFor(() => {
       expect(desktopApi.checkForAppUpdates).toHaveBeenCalledTimes(1);
     });
@@ -2883,7 +2883,7 @@ describe("SettingsScreen", () => {
     expect(settings.replaceSecret).not.toHaveBeenCalled();
   });
 
-  it("does not check for updates again when the selected channel version is already downloaded", async () => {
+  it("shows a restart action when the selected channel version is already downloaded", async () => {
     const settings = createSettingsState(
       createSnapshot({
         updates: {
@@ -2905,6 +2905,7 @@ describe("SettingsScreen", () => {
         status: "downloaded" as const,
         version: "1.0.0-beta.7",
       })),
+      installAppUpdate: vi.fn(async () => ({ status: "restarting" as const })),
     };
 
     render(
@@ -2916,13 +2917,31 @@ describe("SettingsScreen", () => {
     );
 
     expect(await screen.findByText("v1.0.0-beta.7")).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Update" }));
-
     expect(
-      await screen.findByText("Update ready: v1.0.0-beta.7. Restart to install."),
+      await screen.findByRole("button", {
+        name: "Restart to Update (1.0.0-beta.7)",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Downloaded version: 1.0.0-beta.7"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Restart to Update (1.0.0-beta.7)",
+      }),
+    );
+    await waitFor(() => {
+      expect(desktopApi.installAppUpdate).toHaveBeenCalledTimes(1);
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Check for Update" }));
+    await waitFor(() => {
+      expect(desktopApi.checkForAppUpdates).toHaveBeenCalledTimes(1);
+    });
+    expect(
+      await screen.findByText(/Update available: v1.0.0-beta.8/),
     ).toBeInTheDocument();
     expect(desktopApi.readAppUpdateStatus).toHaveBeenCalledTimes(1);
-    expect(desktopApi.checkForAppUpdates).not.toHaveBeenCalled();
   });
 
   it("blocks settings edits when the config file cannot be parsed", () => {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -4293,6 +4293,33 @@ textarea,
   min-height: 0;
 }
 
+.settings-update-channel__restart {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 5px;
+}
+
+.settings-update-channel__restart-button {
+  display: inline-flex;
+  min-height: 0;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  gap: 3px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+  line-height: 1.1;
+}
+
+.settings-update-channel__restart-version,
+.settings-update-channel__downloaded {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 500;
+}
+
 .settings-update-channel__result {
   color: var(--text-secondary);
 }


### PR DESCRIPTION
## Summary

- Shows a Settings restart action when an app update is already downloaded, with the downloaded version visible in the button and below it.
- Keeps a separate Check for Update button so the operator can explicitly re-run the update check.
- Avoids duplicate same-channel update checks once an update is already downloaded while still allowing a check after changing channels.

## Verification

- I ran `pnpm test apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx apps/desktop/src/main/__tests__/auto-updater.test.ts`.
- I ran `pnpm --filter @pwragent/desktop typecheck`.
- I ran `pnpm lint:colors`.
- I ran `git diff --check`.

## Notes

- Restart from Settings uses the same `installAppUpdate` IPC path as the update toast, so it still goes through the busy-thread quit confirmation before `quitAndInstall()`.
