### PR TITLE
fix(desktop): place windows on active display

### DIFF
--- a/apps/desktop/src/main/__tests__/window-placement.test.ts
+++ b/apps/desktop/src/main/__tests__/window-placement.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const electronMock = vi.hoisted(() => {
+  const primaryDisplay = {
+    id: 1,
+    workArea: { x: 0, y: 0, width: 1440, height: 900 },
+  };
+  const externalDisplay = {
+    id: 2,
+    workArea: { x: 1440, y: -180, width: 2560, height: 1440 },
+  };
+
+  return {
+    externalDisplay,
+    fromId: vi.fn(),
+    getCursorScreenPoint: vi.fn(),
+    getDisplayMatching: vi.fn(),
+    getDisplayNearestPoint: vi.fn(),
+    getFocusedWindow: vi.fn(),
+    primaryDisplay,
+  };
+});
+
+vi.mock("electron", () => ({
+  BrowserWindow: {
+    fromId: electronMock.fromId,
+    getFocusedWindow: electronMock.getFocusedWindow,
+  },
+  screen: {
+    getCursorScreenPoint: electronMock.getCursorScreenPoint,
+    getDisplayMatching: electronMock.getDisplayMatching,
+    getDisplayNearestPoint: electronMock.getDisplayNearestPoint,
+  },
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("window placement", () => {
+  it("centers windows on the focused window display", async () => {
+    electronMock.getFocusedWindow.mockReturnValue({
+      getBounds: () => ({ x: 1600, y: 0, width: 900, height: 700 }),
+      isDestroyed: () => false,
+    });
+    electronMock.getDisplayMatching.mockReturnValue(electronMock.externalDisplay);
+
+    const { centeredWindowPlacementOptions } = await import(
+      "../window-placement"
+    );
+
+    expect(centeredWindowPlacementOptions(1000, 500)).toEqual({
+      x: 2220,
+      y: 290,
+    });
+  });
+
+  it("falls back to the cursor display when there is no source window", async () => {
+    electronMock.getFocusedWindow.mockReturnValue(null);
+    electronMock.getCursorScreenPoint.mockReturnValue({ x: 1700, y: 100 });
+    electronMock.getDisplayNearestPoint.mockReturnValue(
+      electronMock.externalDisplay,
+    );
+
+    const { centeredWindowPlacementOptions } = await import(
+      "../window-placement"
+    );
+
+    expect(centeredWindowPlacementOptions(1440, 960)).toEqual({
+      x: 2000,
+      y: 60,
+    });
+    expect(electronMock.getDisplayNearestPoint).toHaveBeenCalledWith({
+      x: 1700,
+      y: 100,
+    });
+  });
+
+  it("can skip focused-window placement for first launch", async () => {
+    electronMock.getFocusedWindow.mockReturnValue({
+      getBounds: () => ({ x: 0, y: 0, width: 900, height: 700 }),
+      isDestroyed: () => false,
+    });
+    electronMock.getCursorScreenPoint.mockReturnValue({ x: 1700, y: 100 });
+    electronMock.getDisplayNearestPoint.mockReturnValue(
+      electronMock.externalDisplay,
+    );
+
+    const { centeredWindowPlacementOptions } = await import(
+      "../window-placement"
+    );
+
+    expect(
+      centeredWindowPlacementOptions(1440, 960, {
+        preferFocusedWindow: false,
+      }),
+    ).toEqual({
+      x: 2000,
+      y: 60,
+    });
+    expect(electronMock.getFocusedWindow).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/app-log-window.ts
+++ b/apps/desktop/src/main/app-log-window.ts
@@ -25,6 +25,7 @@ import {
   showAndFocusAuxiliaryWindow,
   showAuxiliaryWindowWhenReady,
 } from "./auxiliary-window-chrome";
+import { centeredWindowPlacementOptions } from "./window-placement";
 
 const log = getMainLogger("pwragent:app-log-window");
 const LOGS_HASH = "logs";
@@ -46,6 +47,7 @@ export function showAppLogWindow(): void {
     minHeight: 500,
     show: false,
     title: LOGS_WINDOW_TITLE,
+    ...centeredWindowPlacementOptions(1040, 760),
     ...auxiliaryWindowChromeOptions(),
     backgroundColor: themedWindowBackgroundColor(appearance),
     webPreferences: {

--- a/apps/desktop/src/main/changelog-window.ts
+++ b/apps/desktop/src/main/changelog-window.ts
@@ -22,6 +22,7 @@ import {
   showAndFocusAuxiliaryWindow,
   showAuxiliaryWindowWhenReady,
 } from "./auxiliary-window-chrome";
+import { centeredWindowPlacementOptions } from "./window-placement";
 
 const log = getMainLogger("pwragent:changelog-window");
 const CHANGELOG_HASH = "changelog";
@@ -43,6 +44,7 @@ export function showChangelogWindow(): void {
     minHeight: 480,
     show: false,
     title: CHANGELOG_WINDOW_TITLE,
+    ...centeredWindowPlacementOptions(920, 760),
     ...auxiliaryWindowChromeOptions(),
     backgroundColor: themedWindowBackgroundColor(appearance),
     webPreferences: {

--- a/apps/desktop/src/main/license-document-window.ts
+++ b/apps/desktop/src/main/license-document-window.ts
@@ -22,6 +22,7 @@ import {
   showAndFocusAuxiliaryWindow,
   showAuxiliaryWindowWhenReady,
 } from "./auxiliary-window-chrome";
+import { centeredWindowPlacementOptions } from "./window-placement";
 
 const log = getMainLogger("pwragent:license-document-window");
 const LICENSE_HASH = "license";
@@ -72,6 +73,7 @@ function showLicenseDocumentWindow(options: {
     minHeight: 480,
     show: false,
     title: options.title,
+    ...centeredWindowPlacementOptions(920, 760),
     ...auxiliaryWindowChromeOptions(),
     backgroundColor: themedWindowBackgroundColor(appearance),
     webPreferences: {

--- a/apps/desktop/src/main/messaging-activity-window.ts
+++ b/apps/desktop/src/main/messaging-activity-window.ts
@@ -22,6 +22,7 @@ import {
   showAndFocusAuxiliaryWindow,
   showAuxiliaryWindowWhenReady,
 } from "./auxiliary-window-chrome";
+import { centeredWindowPlacementOptions } from "./window-placement";
 
 const log = getMainLogger("pwragent:activity-window");
 const ACTIVITY_WINDOW_TITLE = "Messaging Activity";
@@ -60,6 +61,7 @@ export function showMessagingActivityWindow(): void {
     minHeight: 480,
     show: false,
     title: ACTIVITY_WINDOW_TITLE,
+    ...centeredWindowPlacementOptions(980, 720),
     ...auxiliaryWindowChromeOptions(),
     backgroundColor: themedWindowBackgroundColor(appearance),
     webPreferences: {

--- a/apps/desktop/src/main/window-placement.ts
+++ b/apps/desktop/src/main/window-placement.ts
@@ -1,0 +1,53 @@
+import {
+  BrowserWindow,
+  screen,
+  type BrowserWindowConstructorOptions,
+  type Display,
+  type Rectangle,
+} from "electron";
+
+type PlacementSource = {
+  sourceBounds?: Rectangle;
+  sourceWindowId?: number;
+  preferFocusedWindow?: boolean;
+};
+
+export function centeredWindowPlacementOptions(
+  width: number,
+  height: number,
+  source: PlacementSource = {},
+): Pick<BrowserWindowConstructorOptions, "x" | "y"> {
+  const display = resolvePlacementDisplay(source);
+  const { x, y } = centeredWindowBoundsOnDisplay(width, height, display);
+  return { x, y };
+}
+
+export function centeredWindowBoundsOnDisplay(
+  width: number,
+  height: number,
+  display: Display,
+): { x: number; y: number } {
+  const wa = display.workArea;
+  return {
+    x: Math.round(wa.x + Math.max(0, wa.width - width) / 2),
+    y: Math.round(wa.y + Math.max(0, wa.height - height) / 2),
+  };
+}
+
+function resolvePlacementDisplay(source: PlacementSource): Display {
+  if (source.sourceBounds !== undefined) {
+    return screen.getDisplayMatching(source.sourceBounds);
+  }
+
+  const sourceWindow =
+    source.sourceWindowId !== undefined
+      ? BrowserWindow.fromId(source.sourceWindowId)
+      : source.preferFocusedWindow === false
+        ? undefined
+        : BrowserWindow.getFocusedWindow();
+  if (sourceWindow && !sourceWindow.isDestroyed()) {
+    return screen.getDisplayMatching(sourceWindow.getBounds());
+  }
+
+  return screen.getDisplayNearestPoint(screen.getCursorScreenPoint());
+}

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -43,6 +43,7 @@ import {
   navigationPreferencesAdditionalArguments,
   readBootstrapNavigationPreferences,
 } from "./navigation-browse-mode-bootstrap";
+import { centeredWindowPlacementOptions } from "./window-placement";
 
 const isDevelopment = process.env.NODE_ENV !== "production";
 const isMac = process.platform === "darwin";
@@ -310,6 +311,9 @@ export function createMainWindow(options?: {
     minHeight: 760,
     show: false,
     title: "PwrAgent",
+    ...centeredWindowPlacementOptions(1440, 960, {
+      preferFocusedWindow: false,
+    }),
     ...macWindowChrome,
     // Pre-tinted so the OS window fill matches the renderer's first
     // paint and we don't flash dark before a light renderer mounts.


### PR DESCRIPTION
## Summary

- Add a main-process placement helper that centers new windows on the focused window display, falling back to the cursor display.
- Center the first main window on the cursor display during startup.
- Apply focused-window placement to Messaging Activity, Logs, Changelog, License, and Third-Party Notices windows.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/window-placement.test.ts`
- `pnpm dev:dev` launched successfully and showed the main window, then was stopped
- `pnpm --filter @pwragent/desktop typecheck` was started but terminated after running silently for over a minute
