### PR TITLE
fix(desktop): open windows on source display

### DIFF
--- a/apps/desktop/src/main/__tests__/app-bootstrap.test.ts
+++ b/apps/desktop/src/main/__tests__/app-bootstrap.test.ts
@@ -35,6 +35,10 @@ const buildFromTemplateMock = vi.fn((template: MenuItemConstructorOptions[]) => 
   popup: menuPopupMock,
   template,
 }));
+const getCursorScreenPointMock = vi.fn(() => ({ x: 100, y: 100 }));
+const getDisplayNearestPointMock = vi.fn(() => ({
+  workArea: { x: 0, y: 0, width: 1920, height: 1080 },
+}));
 const RendererHeapMonitorMock = vi.fn(function RendererHeapMonitor(this: unknown) {
   return {
     start: rendererMonitorStartMock,
@@ -162,6 +166,10 @@ vi.mock("electron", () => ({
   },
   shell: {
     openExternal: shellOpenExternalMock
+  },
+  screen: {
+    getCursorScreenPoint: getCursorScreenPointMock,
+    getDisplayNearestPoint: getDisplayNearestPointMock
   }
 }));
 
@@ -209,6 +217,12 @@ describe("createMainWindow", () => {
     mainMonitorStartMock.mockReset();
     mainMonitorStopMock.mockReset();
     shellOpenExternalMock.mockReset();
+    getCursorScreenPointMock.mockClear();
+    getCursorScreenPointMock.mockReturnValue({ x: 100, y: 100 });
+    getDisplayNearestPointMock.mockClear();
+    getDisplayNearestPointMock.mockReturnValue({
+      workArea: { x: 0, y: 0, width: 1920, height: 1080 },
+    });
     clipboardWriteTextMock.mockReset();
     addWordToSpellCheckerDictionaryMock.mockReset();
     replaceMisspellingMock.mockReset();
@@ -233,6 +247,12 @@ describe("createMainWindow", () => {
     createMainWindow();
 
     expect(BrowserWindowMock).toHaveBeenCalledTimes(1);
+    expect(browserWindowState.options).toMatchObject({
+      x: 240,
+      y: 60,
+      width: 1440,
+      height: 960,
+    });
     expect(
       browserWindowState.options?.webPreferences?.preload?.replace(/\\/g, "/")
     ).toContain("preload/index.cjs");

--- a/apps/desktop/src/main/__tests__/messaging-status-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-ipc.test.ts
@@ -51,6 +51,9 @@ const leaseCoordinatorMock = vi.hoisted(() => ({
 }));
 
 vi.mock("electron", () => ({
+  BrowserWindow: {
+    fromWebContents: vi.fn(),
+  },
   ipcMain: {
     handle: vi.fn(
       (channel: string, handler: (...args: unknown[]) => Promise<unknown>) => {

--- a/apps/desktop/src/main/__tests__/window-placement.test.ts
+++ b/apps/desktop/src/main/__tests__/window-placement.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { BrowserWindow } from "electron";
+
+const electronMock = vi.hoisted(() => ({
+  fromId: vi.fn(),
+  getCursorScreenPoint: vi.fn(),
+  getDisplayMatching: vi.fn(),
+  getDisplayNearestPoint: vi.fn(),
+  getFocusedWindow: vi.fn(),
+  getPrimaryDisplay: vi.fn(),
+}));
+
+vi.mock("electron", () => ({
+  BrowserWindow: {
+    fromId: electronMock.fromId,
+    getFocusedWindow: electronMock.getFocusedWindow,
+  },
+  screen: {
+    getCursorScreenPoint: electronMock.getCursorScreenPoint,
+    getDisplayMatching: electronMock.getDisplayMatching,
+    getDisplayNearestPoint: electronMock.getDisplayNearestPoint,
+    getPrimaryDisplay: electronMock.getPrimaryDisplay,
+  },
+}));
+
+describe("window placement", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    electronMock.fromId.mockReset();
+    electronMock.getCursorScreenPoint.mockReset();
+    electronMock.getDisplayMatching.mockReset();
+    electronMock.getDisplayNearestPoint.mockReset();
+    electronMock.getFocusedWindow.mockReset();
+    electronMock.getPrimaryDisplay.mockReset();
+  });
+
+  it("centers a new window on the explicit source bounds display", async () => {
+    const sourceBounds = { x: 2200, y: 100, width: 900, height: 700 };
+    electronMock.getDisplayMatching.mockReturnValue({
+      workArea: { x: 1920, y: 0, width: 1920, height: 1080 },
+    });
+
+    const { placementForSourceDisplay } = await import("../window-placement");
+
+    expect(
+      placementForSourceDisplay(920, 760, { sourceBounds }),
+    ).toEqual({
+      x: 2420,
+      y: 160,
+    });
+    expect(electronMock.getDisplayMatching).toHaveBeenCalledWith(sourceBounds);
+  });
+
+  it("centers a new window on the source window display", async () => {
+    const sourceWindow = {
+      getBounds: vi.fn(() => ({ x: 3840, y: 0, width: 1200, height: 800 })),
+      isDestroyed: vi.fn(() => false),
+    };
+    electronMock.fromId.mockReturnValue(sourceWindow);
+    electronMock.getDisplayMatching.mockReturnValue({
+      workArea: { x: 3840, y: 0, width: 1920, height: 1080 },
+    });
+
+    const { placementForSourceDisplay } = await import("../window-placement");
+
+    expect(
+      placementForSourceDisplay(1040, 760, { sourceWindowId: 41 }),
+    ).toEqual({
+      x: 4280,
+      y: 160,
+    });
+    expect(electronMock.getDisplayMatching).toHaveBeenCalledWith({
+      x: 3840,
+      y: 0,
+      width: 1200,
+      height: 800,
+    });
+  });
+
+  it("repositions an existing window onto the source display before focusing", async () => {
+    const sourceWindow = {
+      getBounds: vi.fn(() => ({ x: 2200, y: 100, width: 900, height: 700 })),
+      isDestroyed: vi.fn(() => false),
+    };
+    const targetWindow = {
+      getBounds: vi.fn(() => ({ x: 0, y: 0, width: 980, height: 720 })),
+      setPosition: vi.fn(),
+    };
+    electronMock.getDisplayMatching.mockReturnValue({
+      workArea: { x: 1920, y: 0, width: 1920, height: 1080 },
+    });
+
+    const { positionWindowForSourceDisplay } = await import("../window-placement");
+    positionWindowForSourceDisplay(targetWindow as unknown as BrowserWindow, {
+      sourceWindow: sourceWindow as unknown as BrowserWindow,
+    });
+
+    expect(targetWindow.setPosition).toHaveBeenCalledWith(2390, 180, false);
+  });
+
+  it("centers the main window on the cursor display at launch", async () => {
+    const cursor = { x: 4000, y: 300 };
+    electronMock.getCursorScreenPoint.mockReturnValue(cursor);
+    electronMock.getDisplayNearestPoint.mockReturnValue({
+      workArea: { x: 3840, y: 0, width: 1920, height: 1080 },
+    });
+
+    const { placementForCursorDisplay } = await import("../window-placement");
+
+    expect(placementForCursorDisplay(1440, 960)).toEqual({
+      x: 4080,
+      y: 60,
+    });
+    expect(electronMock.getDisplayNearestPoint).toHaveBeenCalledWith(cursor);
+  });
+});

--- a/apps/desktop/src/main/app-log-window.ts
+++ b/apps/desktop/src/main/app-log-window.ts
@@ -25,23 +25,32 @@ import {
   showAndFocusAuxiliaryWindow,
   showAuxiliaryWindowWhenReady,
 } from "./auxiliary-window-chrome";
+import {
+  placementForSourceDisplay,
+  positionWindowForSourceDisplay,
+  type WindowPlacementSource,
+} from "./window-placement";
 
 const log = getMainLogger("pwragent:app-log-window");
 const LOGS_HASH = "logs";
 const LOGS_WINDOW_TITLE = "Logs";
+const LOGS_WINDOW_WIDTH = 1040;
+const LOGS_WINDOW_HEIGHT = 760;
 
 let appLogWindow: BrowserWindow | undefined;
 
-export function showAppLogWindow(): void {
+export function showAppLogWindow(source: WindowPlacementSource = {}): void {
   if (appLogWindow && !appLogWindow.isDestroyed()) {
+    positionWindowForSourceDisplay(appLogWindow, source);
     showAndFocusAuxiliaryWindow(appLogWindow);
     return;
   }
 
   const appearance = readBootstrapAppearance();
   const window = new BrowserWindow({
-    width: 1040,
-    height: 760,
+    ...placementForSourceDisplay(LOGS_WINDOW_WIDTH, LOGS_WINDOW_HEIGHT, source),
+    width: LOGS_WINDOW_WIDTH,
+    height: LOGS_WINDOW_HEIGHT,
     minWidth: 700,
     minHeight: 500,
     show: false,

--- a/apps/desktop/src/main/changelog-window.ts
+++ b/apps/desktop/src/main/changelog-window.ts
@@ -22,23 +22,36 @@ import {
   showAndFocusAuxiliaryWindow,
   showAuxiliaryWindowWhenReady,
 } from "./auxiliary-window-chrome";
+import {
+  placementForSourceDisplay,
+  positionWindowForSourceDisplay,
+  type WindowPlacementSource,
+} from "./window-placement";
 
 const log = getMainLogger("pwragent:changelog-window");
 const CHANGELOG_HASH = "changelog";
 const CHANGELOG_WINDOW_TITLE = "Changelog";
+const CHANGELOG_WINDOW_WIDTH = 920;
+const CHANGELOG_WINDOW_HEIGHT = 760;
 
 let changelogWindow: BrowserWindow | undefined;
 
-export function showChangelogWindow(): void {
+export function showChangelogWindow(source: WindowPlacementSource = {}): void {
   if (changelogWindow && !changelogWindow.isDestroyed()) {
+    positionWindowForSourceDisplay(changelogWindow, source);
     showAndFocusAuxiliaryWindow(changelogWindow);
     return;
   }
 
   const appearance = readBootstrapAppearance();
   const window = new BrowserWindow({
-    width: 920,
-    height: 760,
+    ...placementForSourceDisplay(
+      CHANGELOG_WINDOW_WIDTH,
+      CHANGELOG_WINDOW_HEIGHT,
+      source,
+    ),
+    width: CHANGELOG_WINDOW_WIDTH,
+    height: CHANGELOG_WINDOW_HEIGHT,
     minWidth: 640,
     minHeight: 480,
     show: false,

--- a/apps/desktop/src/main/ipc/app-metadata.ts
+++ b/apps/desktop/src/main/ipc/app-metadata.ts
@@ -1,7 +1,7 @@
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
-import { app, ipcMain } from "electron";
+import { app, BrowserWindow, ipcMain } from "electron";
 import {
   APP_CHANGELOG_DOCUMENT_READ_CHANNEL,
   APP_CHANGELOG_WINDOW_OPEN_CHANNEL,
@@ -133,13 +133,17 @@ export function registerAppMetadataIpcHandlers(): void {
     APP_CHANGELOG_DOCUMENT_READ_CHANNEL,
     async (): Promise<AppChangelogDocument> => readAppChangelogDocument(),
   );
-  ipcMain.handle(APP_CHANGELOG_WINDOW_OPEN_CHANNEL, async (): Promise<void> => {
-    showChangelogWindow();
+  ipcMain.handle(APP_CHANGELOG_WINDOW_OPEN_CHANNEL, async (event): Promise<void> => {
+    showChangelogWindow({
+      sourceWindow: BrowserWindow.fromWebContents(event.sender),
+    });
   });
   ipcMain.handle(
     APP_THIRD_PARTY_NOTICES_WINDOW_OPEN_CHANNEL,
-    async (): Promise<void> => {
-      showThirdPartyNoticesWindow();
+    async (event): Promise<void> => {
+      showThirdPartyNoticesWindow({
+        sourceWindow: BrowserWindow.fromWebContents(event.sender),
+      });
     },
   );
   ipcMain.handle(
@@ -153,8 +157,10 @@ export function registerAppMetadataIpcHandlers(): void {
       return readDecoratedAppLogSnapshot();
     },
   );
-  ipcMain.handle(APP_LOG_WINDOW_OPEN_CHANNEL, async (): Promise<void> => {
-    showAppLogWindow();
+  ipcMain.handle(APP_LOG_WINDOW_OPEN_CHANNEL, async (event): Promise<void> => {
+    showAppLogWindow({
+      sourceWindow: BrowserWindow.fromWebContents(event.sender),
+    });
   });
 }
 

--- a/apps/desktop/src/main/ipc/messaging-status.ts
+++ b/apps/desktop/src/main/ipc/messaging-status.ts
@@ -1,4 +1,4 @@
-import { ipcMain } from "electron";
+import { BrowserWindow, ipcMain } from "electron";
 import type {
   ApproveMessagingPairingRequest,
   ApproveMessagingPairingResponse,
@@ -484,9 +484,14 @@ export function registerMessagingStatusIpcHandlers(): void {
   );
 
   ipcMain.removeHandler(MESSAGING_OPEN_ACTIVITY_WINDOW_CHANNEL);
-  ipcMain.handle(MESSAGING_OPEN_ACTIVITY_WINDOW_CHANNEL, async (): Promise<void> => {
-    showMessagingActivityWindow();
-  });
+  ipcMain.handle(
+    MESSAGING_OPEN_ACTIVITY_WINDOW_CHANNEL,
+    async (event): Promise<void> => {
+      showMessagingActivityWindow({
+        sourceWindow: BrowserWindow.fromWebContents(event.sender),
+      });
+    },
+  );
 
   ipcMain.removeHandler(MESSAGING_SHUTDOWN_RUNTIME_CHANNEL);
   ipcMain.handle(MESSAGING_SHUTDOWN_RUNTIME_CHANNEL, async (): Promise<void> => {

--- a/apps/desktop/src/main/license-document-window.ts
+++ b/apps/desktop/src/main/license-document-window.ts
@@ -22,17 +22,25 @@ import {
   showAndFocusAuxiliaryWindow,
   showAuxiliaryWindowWhenReady,
 } from "./auxiliary-window-chrome";
+import {
+  placementForSourceDisplay,
+  positionWindowForSourceDisplay,
+  type WindowPlacementSource,
+} from "./window-placement";
 
 const log = getMainLogger("pwragent:license-document-window");
 const LICENSE_HASH = "license";
 const THIRD_PARTY_NOTICES_HASH = "third-party-notices";
+const LICENSE_DOCUMENT_WINDOW_WIDTH = 920;
+const LICENSE_DOCUMENT_WINDOW_HEIGHT = 760;
 
 let licenseWindow: BrowserWindow | undefined;
 let thirdPartyNoticesWindow: BrowserWindow | undefined;
 
-export function showLicenseWindow(): void {
+export function showLicenseWindow(source: WindowPlacementSource = {}): void {
   showLicenseDocumentWindow({
     hash: LICENSE_HASH,
+    source,
     title: "License",
     windowRef: () => licenseWindow,
     setWindowRef: (window) => {
@@ -41,9 +49,12 @@ export function showLicenseWindow(): void {
   });
 }
 
-export function showThirdPartyNoticesWindow(): void {
+export function showThirdPartyNoticesWindow(
+  source: WindowPlacementSource = {},
+): void {
   showLicenseDocumentWindow({
     hash: THIRD_PARTY_NOTICES_HASH,
+    source,
     title: "Third-Party Notices",
     windowRef: () => thirdPartyNoticesWindow,
     setWindowRef: (window) => {
@@ -54,20 +65,27 @@ export function showThirdPartyNoticesWindow(): void {
 
 function showLicenseDocumentWindow(options: {
   hash: string;
+  source: WindowPlacementSource;
   title: string;
   windowRef: () => BrowserWindow | undefined;
   setWindowRef: (window: BrowserWindow | undefined) => void;
 }): void {
   const existingWindow = options.windowRef();
   if (existingWindow && !existingWindow.isDestroyed()) {
+    positionWindowForSourceDisplay(existingWindow, options.source);
     showAndFocusAuxiliaryWindow(existingWindow);
     return;
   }
 
   const appearance = readBootstrapAppearance();
   const window = new BrowserWindow({
-    width: 920,
-    height: 760,
+    ...placementForSourceDisplay(
+      LICENSE_DOCUMENT_WINDOW_WIDTH,
+      LICENSE_DOCUMENT_WINDOW_HEIGHT,
+      options.source,
+    ),
+    width: LICENSE_DOCUMENT_WINDOW_WIDTH,
+    height: LICENSE_DOCUMENT_WINDOW_HEIGHT,
     minWidth: 640,
     minHeight: 480,
     show: false,

--- a/apps/desktop/src/main/messaging-activity-window.ts
+++ b/apps/desktop/src/main/messaging-activity-window.ts
@@ -22,9 +22,16 @@ import {
   showAndFocusAuxiliaryWindow,
   showAuxiliaryWindowWhenReady,
 } from "./auxiliary-window-chrome";
+import {
+  placementForSourceDisplay,
+  positionWindowForSourceDisplay,
+  type WindowPlacementSource,
+} from "./window-placement";
 
 const log = getMainLogger("pwragent:activity-window");
 const ACTIVITY_WINDOW_TITLE = "Messaging Activity";
+const ACTIVITY_WINDOW_WIDTH = 980;
+const ACTIVITY_WINDOW_HEIGHT = 720;
 
 /**
  * Hash that the renderer (`main.tsx`) reads to decide whether to mount
@@ -46,16 +53,24 @@ let activityWindow: BrowserWindow | undefined;
  * Closing the window does NOT affect the main window. Reopening
  * focuses the existing window when one is already open.
  */
-export function showMessagingActivityWindow(): void {
+export function showMessagingActivityWindow(
+  source: WindowPlacementSource = {},
+): void {
   if (activityWindow && !activityWindow.isDestroyed()) {
+    positionWindowForSourceDisplay(activityWindow, source);
     showAndFocusAuxiliaryWindow(activityWindow);
     return;
   }
 
   const appearance = readBootstrapAppearance();
   const window = new BrowserWindow({
-    width: 980,
-    height: 720,
+    ...placementForSourceDisplay(
+      ACTIVITY_WINDOW_WIDTH,
+      ACTIVITY_WINDOW_HEIGHT,
+      source,
+    ),
+    width: ACTIVITY_WINDOW_WIDTH,
+    height: ACTIVITY_WINDOW_HEIGHT,
     minWidth: 640,
     minHeight: 480,
     show: false,

--- a/apps/desktop/src/main/window-placement.ts
+++ b/apps/desktop/src/main/window-placement.ts
@@ -1,0 +1,77 @@
+import {
+  BrowserWindow,
+  screen,
+  type Rectangle,
+} from "electron";
+
+type WindowPosition = {
+  x: number;
+  y: number;
+};
+
+export type WindowPlacementSource = {
+  sourceBounds?: Rectangle | undefined;
+  sourceWindow?: BrowserWindow | null | undefined;
+  sourceWindowId?: number | undefined;
+};
+
+export function centerWindowOnDisplay(
+  width: number,
+  height: number,
+  display: Electron.Display,
+): WindowPosition {
+  const { workArea } = display;
+  return {
+    x: Math.round(workArea.x + Math.max(0, workArea.width - width) / 2),
+    y: Math.round(workArea.y + Math.max(0, workArea.height - height) / 2),
+  };
+}
+
+export function placementForSourceDisplay(
+  width: number,
+  height: number,
+  source: WindowPlacementSource = {},
+): WindowPosition {
+  return centerWindowOnDisplay(width, height, displayForPlacementSource(source));
+}
+
+export function placementForCursorDisplay(
+  width: number,
+  height: number,
+): WindowPosition {
+  return centerWindowOnDisplay(
+    width,
+    height,
+    screen.getDisplayNearestPoint(screen.getCursorScreenPoint()),
+  );
+}
+
+export function positionWindowForSourceDisplay(
+  window: BrowserWindow,
+  source: WindowPlacementSource = {},
+): void {
+  const bounds = window.getBounds();
+  const position = placementForSourceDisplay(bounds.width, bounds.height, source);
+  window.setPosition(position.x, position.y, false);
+}
+
+export function displayForPlacementSource(
+  source: WindowPlacementSource = {},
+): Electron.Display {
+  if (source.sourceBounds) {
+    return screen.getDisplayMatching(source.sourceBounds);
+  }
+
+  const sourceWindow =
+    source.sourceWindow && !source.sourceWindow.isDestroyed()
+      ? source.sourceWindow
+      : source.sourceWindowId !== undefined
+        ? BrowserWindow.fromId(source.sourceWindowId)
+        : BrowserWindow.getFocusedWindow();
+
+  if (sourceWindow && !sourceWindow.isDestroyed()) {
+    return screen.getDisplayMatching(sourceWindow.getBounds());
+  }
+
+  return screen.getPrimaryDisplay();
+}

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -44,10 +44,13 @@ import {
   navigationPreferencesAdditionalArguments,
   readBootstrapNavigationPreferences,
 } from "./navigation-browse-mode-bootstrap";
+import { placementForCursorDisplay } from "./window-placement";
 
 const isDevelopment = process.env.NODE_ENV !== "production";
 const isMac = process.platform === "darwin";
 const isWindows = process.platform === "win32";
+const MAIN_WINDOW_WIDTH = 1440;
+const MAIN_WINDOW_HEIGHT = 960;
 const mainLog = getMainLogger("pwragent:main");
 const heapLog = getMainLogger("pwragent:heap");
 const hotCpuLog = getMainLogger("pwragent:hot-cpu");
@@ -320,8 +323,9 @@ export function createMainWindow(options?: {
         }
       : {};
   const window = new BrowserWindow({
-    width: 1440,
-    height: 960,
+    ...placementForCursorDisplay(MAIN_WINDOW_WIDTH, MAIN_WINDOW_HEIGHT),
+    width: MAIN_WINDOW_WIDTH,
+    height: MAIN_WINDOW_HEIGHT,
     minWidth: 1200,
     minHeight: 760,
     show: false,


### PR DESCRIPTION
## Summary
PwrAgent windows now open on the display where the user is working instead of defaulting to the built-in laptop monitor. The dev-profile main window is centered on the cursor's display at launch, and secondary windows opened from the app now use the display of the window that triggered them.

The fix adds one main-process placement helper and routes renderer-initiated opens through the sender `BrowserWindow`, so Messaging Activity, Logs, Changelog, License, and Third-Party Notices all share the same source-display behavior. Existing singleton auxiliary windows are also repositioned before being raised, which keeps reopen/focus behavior consistent after moving between monitors.

## Verification
- `pnpm test apps/desktop/src/main/__tests__/window-placement.test.ts apps/desktop/src/main/__tests__/app-bootstrap.test.ts apps/desktop/src/main/__tests__/messaging-status-ipc.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm dev:dev` booted to `ready-to-show`, then the dev process was cleaned up

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
