### PR TITLE
fix(messaging): materialize projected launchpad options

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -299,10 +299,10 @@ describe("MessagingController", () => {
           directoryLabel: "PwrAgent",
           directoryPath: "/repo/pwragent",
           executionMode: "default",
-          fastMode: undefined,
-          model: undefined,
+          fastMode: false,
+          model: "gpt-5.3-codex",
           prompt: "",
-          reasoningEffort: undefined,
+          reasoningEffort: "low",
           serviceTier: undefined,
           workMode: "local",
         }),
@@ -3432,6 +3432,9 @@ describe("MessagingController", () => {
     };
     const harness = await createHarness({
       navigation,
+      updateDirectoryLaunchpad: async () => {
+        throw new Error("sticky update failed");
+      },
       listBackends: async (): Promise<ListBackendsResponse> => ({
         fetchedAt: 1000,
         backends: [
@@ -3491,6 +3494,20 @@ describe("MessagingController", () => {
         expect.objectContaining({ id: "browse:new:reasoning" }),
       ]),
     });
+
+    await harness.controller.handleInboundEvent(buildTextEvent("Use Kimi"));
+
+    const materializeRequest = harness.materializeDirectoryLaunchpad.mock.calls.at(-1)?.[0];
+    expect(materializeRequest).toMatchObject({
+      launchpad: expect.objectContaining({
+        backend: "acp:kimi",
+        executionMode: "default",
+        model: "kimi-code/kimi-for-coding",
+      }),
+    });
+    expect(materializeRequest?.launchpad.fastMode).toBeUndefined();
+    expect(materializeRequest?.launchpad.reasoningEffort).toBeUndefined();
+    expect(materializeRequest?.launchpad.serviceTier).toBeUndefined();
   });
 
   it("includes enabled ACP backends in the messaging new-thread provider picker", async () => {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -4971,6 +4971,7 @@ export class MessagingController {
       now: this.now(),
       workMode: options.workMode,
       branchName: options.branchName,
+      options,
       acpRuntime: options.acpRuntime,
     });
     const materialized = this.options.backend.materializeDirectoryLaunchpad
@@ -12092,6 +12093,7 @@ function launchpadForMessagingProject(params: {
   directory?: NavigationDirectorySummary;
   navigation: NavigationSnapshot;
   now: number;
+  options: NewThreadOptionsSummary;
   preferences?: MessagingBrowseSessionRecord["preferences"];
   project: NonNullable<ReturnType<typeof selectProjectFromValue>>;
   workMode: LaunchpadWorkMode;
@@ -12123,33 +12125,32 @@ function launchpadForMessagingProject(params: {
   return {
     ...base,
     backend: params.backend,
-    acpRuntime: params.acpRuntime ?? params.preferences?.acpRuntime ?? base.acpRuntime,
+    acpRuntime: params.acpRuntime ?? params.options.acpRuntime,
     codexEnvironmentId:
       params.preferences?.codexEnvironmentId === null
         ? undefined
-        : params.preferences?.codexEnvironmentId ?? base.codexEnvironmentId,
+        : params.options.codexEnvironmentId ?? undefined,
     codexEnvironmentExecutionTarget:
       params.preferences?.codexEnvironmentId === null
         ? undefined
-        : params.preferences?.codexEnvironmentExecutionTarget ??
-          base.codexEnvironmentExecutionTarget,
+        : params.options.codexEnvironmentExecutionTarget,
     codexEnvironmentSetupEnabled:
       params.preferences?.codexEnvironmentId === null
         ? false
-        : params.preferences?.codexEnvironmentSetupEnabled ??
-          base.codexEnvironmentSetupEnabled,
+        : params.options.codexEnvironmentSetupEnabled,
     codexEnvironmentActionId:
       params.preferences?.codexEnvironmentId === null
         ? undefined
         : params.preferences?.codexEnvironmentActionId === null
           ? undefined
-          : params.preferences?.codexEnvironmentActionId ??
-            base.codexEnvironmentActionId,
-    executionMode: params.preferences?.executionMode ?? base.executionMode,
-    model: params.preferences?.model ?? base.model,
-    reasoningEffort: params.preferences?.reasoningEffort ?? base.reasoningEffort,
-    serviceTier: params.preferences?.serviceTier ?? base.serviceTier,
-    fastMode: params.preferences?.fastMode ?? base.fastMode,
+          : params.options.codexEnvironmentActionId ?? undefined,
+    executionMode: params.options.executionMode,
+    model: params.options.supportsModel ? params.options.model : undefined,
+    reasoningEffort: params.options.supportsReasoning
+      ? params.options.reasoningEffort
+      : undefined,
+    serviceTier: params.preferences?.serviceTier,
+    fastMode: params.options.supportsFast ? params.options.fastMode : undefined,
     prompt: "",
     workMode: params.workMode,
     branchName: params.branchName,


### PR DESCRIPTION
## Summary

- Fix messaging `/new` materialization to use the same provider-projected launchpad options shown in the ready prompt.
- Prevent stale Codex-scoped execution/model/reasoning/fast settings from being sent when a selected ACP/Grok provider is launched before sticky defaults refresh.
- Add a regression that switches to Kimi with the sticky update failing, then verifies the materialized launchpad uses Kimi defaults.

## Verification

- pnpm --filter @pwragent/desktop exec vitest run src/main/__tests__/messaging-controller.test.ts
- pnpm --filter @pwragent/desktop typecheck
- git diff --check origin/main...HEAD
