### PR TITLE
feat(desktop): quit the app when the main window is closed

### DIFF
--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -668,6 +668,42 @@ describe("bootstrapApp", () => {
     expect(requestQuitMock).not.toHaveBeenCalled();
   });
 
+  it("releases the quit hold when the close-triggered quit request rejects", async () => {
+    startupProfilerInstance.start.mockResolvedValue();
+
+    await import("../index");
+    await flushMicrotasks();
+
+    const closeHandler = mainWindowHandlers.get("close");
+    expect(closeHandler).toBeTypeOf("function");
+    if (!closeHandler) {
+      return;
+    }
+
+    // A rejected quit request (e.g. the confirmation dialog throws) must not
+    // wedge the app: we log it and clear the in-progress hold. Proof the hold
+    // released — a later window-all-closed is NOT swallowed as "already
+    // quitting" but routes through the quit flow again.
+    isQuitAllowedMock.mockReturnValue(false);
+    requestQuitMock.mockRejectedValueOnce(new Error("quit dialog boom"));
+    const event = { preventDefault: vi.fn() };
+    closeHandler(event);
+    await flushMicrotasks();
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(mainLogErrorMock).toHaveBeenCalledWith(
+      "quit request failed; releasing quit hold",
+      expect.objectContaining({ source: "main-window-closed" }),
+    );
+
+    appEventHandlers.get("window-all-closed")?.();
+    await flushMicrotasks();
+
+    expect(requestQuitMock).toHaveBeenLastCalledWith({
+      source: "window-all-closed",
+    });
+  });
+
   it("creates a main window when a profile focus request arrives without one", async () => {
     startupProfilerInstance.start.mockResolvedValue();
 

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -2,6 +2,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const appEventHandlers = new Map<string, (...args: unknown[]) => void>();
 const processEventHandlers = new Map<string, (...args: unknown[]) => void>();
+// Captures the listeners createMainWindow's return value registers via
+// `window.on(...)` — lets tests drive the main window's "close" handler
+// (quit-on-main-window-close).
+const mainWindowHandlers = new Map<string, (...args: unknown[]) => void>();
 const createMainWindowMock = vi.fn();
 const registerAppServerIpcHandlersMock = vi.fn();
 const disposeAppServerIpcHandlersMock = vi.fn();
@@ -364,7 +368,16 @@ describe("bootstrapApp", () => {
         return process;
       },
     );
+    mainWindowHandlers.clear();
     createMainWindowMock.mockReset();
+    // createMainWindow returns the BrowserWindow; index.ts wraps each call in
+    // quitAppOnMainWindowClose(window), which calls window.on("close", …).
+    // Return a stub that records its listeners so tests can invoke them.
+    createMainWindowMock.mockImplementation(() => ({
+      on: (event: string, handler: (...args: unknown[]) => void) => {
+        mainWindowHandlers.set(event, handler);
+      },
+    }));
     registerAppServerIpcHandlersMock.mockReset();
     disposeAppServerIpcHandlersMock.mockReset();
     registerAgentIpcHandlersMock.mockReset();
@@ -602,6 +615,57 @@ describe("bootstrapApp", () => {
     expect(createMainWindowMock).toHaveBeenCalledWith({
       startupCpuProfiler: startupProfilerInstance,
     });
+  });
+
+  it("quits the app when the main window is closed", async () => {
+    startupProfilerInstance.start.mockResolvedValue();
+
+    await import("../index");
+    await flushMicrotasks();
+
+    const closeHandler = mainWindowHandlers.get("close");
+    expect(closeHandler).toBeTypeOf("function");
+    if (!closeHandler) {
+      return;
+    }
+
+    // User clicks the main window's X with a quit not yet allowed: hold the
+    // window (preventDefault) and request an app-wide quit so aux windows can't
+    // keep a headless, unreachable app alive.
+    isQuitAllowedMock.mockReturnValue(false);
+    requestQuitMock.mockClear();
+    const event = { preventDefault: vi.fn() };
+    closeHandler(event);
+    await flushMicrotasks();
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(requestQuitMock).toHaveBeenCalledWith({
+      source: "main-window-closed",
+    });
+  });
+
+  it("lets the main window close once a quit is already allowed", async () => {
+    startupProfilerInstance.start.mockResolvedValue();
+
+    await import("../index");
+    await flushMicrotasks();
+
+    const closeHandler = mainWindowHandlers.get("close");
+    expect(closeHandler).toBeTypeOf("function");
+    if (!closeHandler) {
+      return;
+    }
+
+    // app.quit() teardown re-closes the window; with the quit already allowed
+    // we must NOT preventDefault or re-request — that would loop.
+    isQuitAllowedMock.mockReturnValue(true);
+    requestQuitMock.mockClear();
+    const event = { preventDefault: vi.fn() };
+    closeHandler(event);
+    await flushMicrotasks();
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(requestQuitMock).not.toHaveBeenCalled();
   });
 
   it("creates a main window when a profile focus request arrives without one", async () => {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -101,7 +101,11 @@ import { requestOpenSettings } from "./window-open-settings";
 import { requestReplayOnboarding } from "./window-replay-onboarding";
 import { buildApplicationMenuTemplate } from "./menu";
 import { wireAppMenuBridge } from "./app-menu-bridge";
-import { appQuitManager, requestQuit } from "./quit-manager";
+import {
+  appQuitManager,
+  requestQuit,
+  type QuitRequestSource,
+} from "./quit-manager";
 import {
   installTranscriptImageProtocol,
   registerTranscriptImageProtocolScheme,
@@ -250,6 +254,33 @@ function cancelQuitInProgress(source: string): void {
   mainLog.info("quit cancelled", { source });
 }
 
+/**
+ * Begin an app-wide quit for `source`, then release the hold if it doesn't
+ * take. Shared by every entry point that holds a window/quit open while the
+ * quit manager confirms (main-window close, window-all-closed, before-quit):
+ * mark the quit in progress, ask the manager to confirm, and clear
+ * `quitInProgress` again if the user declines the in-progress-thread prompt
+ * (`didQuit === false`) — or if the request rejects unexpectedly. Without that
+ * release the app wedges: the window stays held open (preventDefault) and
+ * window creation stays blocked, with no path back.
+ */
+function beginQuitWithRelease(source: QuitRequestSource): void {
+  beginQuitInProgress(source);
+  void requestQuit({ source })
+    .then((didQuit) => {
+      if (!didQuit) {
+        cancelQuitInProgress(source);
+      }
+    })
+    .catch((error: unknown) => {
+      mainLog.error("quit request failed; releasing quit hold", {
+        error,
+        source,
+      });
+      cancelQuitInProgress(source);
+    });
+}
+
 function isWindowCreationBlocked(): boolean {
   return quitInProgress || mainProcessResourcesDisposed;
 }
@@ -271,12 +302,7 @@ function quitAppOnMainWindowClose(window: BrowserWindow): void {
       return;
     }
     event.preventDefault();
-    beginQuitInProgress("main-window-closed");
-    void requestQuit({ source: "main-window-closed" }).then((didQuit) => {
-      if (!didQuit) {
-        cancelQuitInProgress("main-window-closed");
-      }
-    });
+    beginQuitWithRelease("main-window-closed");
   });
 }
 
@@ -667,23 +693,13 @@ export function bootstrapApp(): void {
       mainLog.info("ignoring window-all-closed during shutdown");
       return;
     }
-    beginQuitInProgress("window-all-closed");
-    void requestQuit({ source: "window-all-closed" }).then((didQuit) => {
-      if (!didQuit) {
-        cancelQuitInProgress("window-all-closed");
-      }
-    });
+    beginQuitWithRelease("window-all-closed");
   });
 
   app.on("before-quit", (event) => {
     if (!appQuitManager.isQuitAllowed()) {
       event?.preventDefault();
-      beginQuitInProgress("before-quit");
-      void requestQuit({ source: "before-quit" }).then((didQuit) => {
-        if (!didQuit) {
-          cancelQuitInProgress("before-quit");
-        }
-      });
+      beginQuitWithRelease("before-quit");
       return;
     }
     beginQuitInProgress("before-quit");

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -254,6 +254,32 @@ function isWindowCreationBlocked(): boolean {
   return quitInProgress || mainProcessResourcesDisposed;
 }
 
+/**
+ * Closing the primary window quits the whole app. PwrAgent has no tray and no
+ * dock/reopen path we want to support, so once the main window is gone there's
+ * no way back to it — and any still-open aux windows (Changelog / Logs /
+ * License / Messaging Activity) must not keep a headless, unreachable app
+ * alive. Mirror the before-quit / window-all-closed flow: hold the window open
+ * until an in-progress-thread quit is confirmed, then let app.quit() tear
+ * everything (incl. aux windows) down. Once a quit is allowed/underway,
+ * isQuitAllowed() is true and we let the close proceed — that also covers
+ * app.quit() re-closing this window during teardown, so there's no loop.
+ */
+function quitAppOnMainWindowClose(window: BrowserWindow): void {
+  window.on("close", (event) => {
+    if (appQuitManager.isQuitAllowed()) {
+      return;
+    }
+    event.preventDefault();
+    beginQuitInProgress("main-window-closed");
+    void requestQuit({ source: "main-window-closed" }).then((didQuit) => {
+      if (!didQuit) {
+        cancelQuitInProgress("main-window-closed");
+      }
+    });
+  });
+}
+
 function installProcessShutdownHandlers(): void {
   const handleSignal = (signal: NodeJS.Signals): void => {
     mainLog.info("main process shutdown signal received", { signal });
@@ -296,10 +322,12 @@ function focusPwrAgentWindows(): void {
       Boolean(window && !window.isDestroyed()),
   );
   if (windows.length === 0) {
-    createMainWindow(
-      startupCpuProfilerForNewWindows
-        ? { startupCpuProfiler: startupCpuProfilerForNewWindows }
-        : undefined,
+    quitAppOnMainWindowClose(
+      createMainWindow(
+        startupCpuProfilerForNewWindows
+          ? { startupCpuProfiler: startupCpuProfilerForNewWindows }
+          : undefined,
+      ),
     );
     app.focus({ steal: true });
     return;
@@ -603,9 +631,11 @@ export function bootstrapApp(): void {
     // current snapshot. When messaging is disabled the runtime singleton
     // still exists (default config); status returns []  / never emits.
     registerMessagingStatusIpcHandlers();
-    createMainWindow({
-      startupCpuProfiler,
-    });
+    quitAppOnMainWindowClose(
+      createMainWindow({
+        startupCpuProfiler,
+      }),
+    );
     prewarmInitialThreadList();
 
     // Wire up auto-update *after* the window is created so a slow update
@@ -618,9 +648,11 @@ export function bootstrapApp(): void {
         return;
       }
       if (BrowserWindow.getAllWindows().length === 0) {
-        createMainWindow({
-          startupCpuProfiler,
-        });
+        quitAppOnMainWindowClose(
+          createMainWindow({
+            startupCpuProfiler,
+          }),
+        );
       }
     });
   });

--- a/apps/desktop/src/main/quit-manager.ts
+++ b/apps/desktop/src/main/quit-manager.ts
@@ -12,6 +12,7 @@ export const QUIT_CONFIRMATION_COUNTDOWN_SECONDS = 10;
 export type QuitRequestSource =
   | "before-quit"
   | "ipc"
+  | "main-window-closed"
   | "menu"
   | "signal"
   | "update-install"


### PR DESCRIPTION
## What

Closing the main window's **X** now quits the whole app (Windows **and** macOS).

## Why

PwrAgent has no tray and no dock/reopen path we want to support, so once the main window is gone there's no way back to it. Today the app only quits on `window-all-closed` — which fires when the *last* window closes. So closing the main window while an **aux window** (Changelog / Logs / License / Messaging Activity) is still open left the app running **headless with no main window and no way to recover it**. (Easy to hit: open a couple of those windows, then close the main one.)

## How

`quitAppOnMainWindowClose(window)` wires a `close` handler on every main window — initial boot, profile-focus re-create, and the macOS `activate` re-create. It mirrors the existing `before-quit` flow:

- Hold the window open (`preventDefault`) until an in-progress-thread quit is **confirmed**, then let `app.quit()` tear everything down (including aux windows).
- Once a quit is allowed/underway, `appQuitManager.isQuitAllowed()` is `true` and the close proceeds — which also covers `app.quit()` re-closing this window during teardown, so there's **no loop**.

Lives in `index.ts` (app-lifecycle policy, alongside `window-all-closed` / `before-quit` / `activate`) rather than `window.ts` — that also avoids dragging `quit-manager`'s backend-registry deps into the window unit test.

## Scope

Applies on macOS too (per the request — we don't want the dock-reopen behavior). The `activate` re-create handler stays as a harmless safety net for any 0-window state.

## Testing

On a Windows box: `typecheck` ✅ and the affected unit tests ✅ (42/42 — `index` incl. two new cases: request-quit-and-hold on close, and the already-allowed no-op that prevents a teardown loop; plus `quit-manager` and `app-bootstrap`). Full Linux + Windows CI runs here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
