### PR TITLE
fix(desktop): quiet noisy task monitor logs

### DIFF
--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -10126,7 +10126,7 @@ export class DesktopBackendRegistry {
             "Task monitor delegations must originate from an active Codex turn.",
         });
       }
-      backendRegistryLog.info("handling task monitor dynamic tool call", {
+      backendRegistryLog.debug("handling task monitor dynamic tool call", {
         backend,
         callId: taskMonitorToolCall.callId,
         namespace: taskMonitorToolCall.namespace,

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -222,7 +222,7 @@ function logAgentEventSummary(summary: Record<string, unknown>): void {
     return;
   }
 
-  appServerLog.info("agentEventCoalesced", {
+  appServerLog.debug("agentEventCoalesced", {
     ...existing.latestSummary,
     coalescedDurationMs: existing.lastSuppressedAt - existing.firstSuppressedAt,
     suppressedCount: existing.suppressedCount,


### PR DESCRIPTION
## Summary

- I reduced log noise from two high-frequency desktop agent-server paths by moving them from info to debug.
- I changed `agentEventCoalesced` in `apps/desktop/src/main/ipc/agent-ipc.ts` from info to debug.
- I changed `handling task monitor dynamic tool call` in `apps/desktop/src/main/app-server/backend-registry.ts` from info to debug.

## Verification

- I verified the diff contains only the two targeted log-level changes and no behavioral changes.

## Notes

- I kept the branch scoped to log-noise reduction and did not change message content or payloads.
