### PR TITLE
fix(desktop): seed launchpad review turn state

### DIFF
--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -1200,7 +1200,6 @@ describe("App", () => {
           threadId: string;
           executionMode: "default";
           workMode: "local";
-          turnId: string;
         }>((resolve) => {
           resolveMaterializeLaunchpad = () => {
             resolve({
@@ -1208,7 +1207,6 @@ describe("App", () => {
               threadId: "thread-2",
               executionMode: "default" as const,
               workMode: "local" as const,
-              turnId: "turn-1",
             });
           };
         })

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -2254,7 +2254,6 @@ describe("App", () => {
       threadId: "thread-new",
       executionMode: "default" as const,
       workMode: "local" as const,
-      turnId: "turn-1",
     }));
     const agentEventListeners = new Set<
       (event: {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -1554,6 +1554,91 @@ describe("useThreadNavigation", () => {
     expect(result.current.directories[0]?.needsAttentionCount).toBe(1);
   });
 
+  it("carries the started review turn from launchpad materialization", async () => {
+    const directoryKey = "directory:/Users/huntharo/github/PwrAgent";
+    const getNavigationSnapshot = vi.fn(async (): Promise<NavigationSnapshot> => ({
+      backend: "all",
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [],
+      directories: [
+        {
+          key: directoryKey,
+          kind: "directory",
+          label: "PwrAgent",
+          path: "/Users/huntharo/github/PwrAgent",
+          threadKeys: [],
+          needsAttentionCount: 0,
+          launchpad: {
+            directoryKey,
+            directoryKind: "directory",
+            directoryLabel: "PwrAgent",
+            directoryPath: "/Users/huntharo/github/PwrAgent",
+            backend: "codex",
+            executionMode: "default",
+            prompt: "/review main",
+            workMode: "worktree",
+            branchName: "main",
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        },
+      ],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+    }));
+    const materializeDirectoryLaunchpad = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-review",
+      executionMode: "default" as const,
+      workMode: "worktree" as const,
+      turnId: "turn-review",
+    }));
+
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      materializeDirectoryLaunchpad,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.directories[0]?.launchpad?.prompt).toBe("/review main");
+    });
+
+    await act(async () => {
+      await result.current.materializeDirectoryLaunchpad(
+        directoryKey,
+        undefined,
+        undefined,
+        { type: "baseBranch", branch: "main" }
+      );
+    });
+
+    expect(materializeDirectoryLaunchpad).toHaveBeenCalledWith({
+      directoryKey,
+      launchpad: expect.objectContaining({
+        prompt: "/review main",
+      }),
+      input: undefined,
+      collaborationMode: undefined,
+      reviewTarget: { type: "baseBranch", branch: "main" },
+    });
+    expect(result.current.selectedThread).toMatchObject({
+      id: "thread-review",
+      optimisticActiveTurn: {
+        id: "turn-review",
+        statusText: "Reviewing",
+        reviewDisplayText: "Review changes against main",
+      },
+    });
+    expect(result.current.selectedThread?.optimisticUserMessage).toBeUndefined();
+  });
+
   it("rejects materialize failures after recording the launchpad error", async () => {
     const directoryKey = "directory:/Users/huntharo/github/PwrAgent";
     const getNavigationSnapshot = vi.fn(async () => ({

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -1639,6 +1639,109 @@ describe("useThreadNavigation", () => {
     expect(result.current.selectedThread?.optimisticUserMessage).toBeUndefined();
   });
 
+  it("keeps launchpad review turn metadata when hydration races materialization", async () => {
+    const directoryKey = "directory:/Users/huntharo/github/PwrAgent";
+    const initialSnapshot: NavigationSnapshot = {
+      backend: "all",
+      fetchedAt: 1_000,
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [],
+      directories: [
+        {
+          key: directoryKey,
+          kind: "directory",
+          label: "PwrAgent",
+          path: "/Users/huntharo/github/PwrAgent",
+          threadKeys: [],
+          needsAttentionCount: 0,
+          launchpad: {
+            directoryKey,
+            directoryKind: "directory",
+            directoryLabel: "PwrAgent",
+            directoryPath: "/Users/huntharo/github/PwrAgent",
+            backend: "codex",
+            executionMode: "default",
+            prompt: "/review main",
+            workMode: "worktree",
+            branchName: "main",
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        },
+      ],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+    };
+    const hydratedSnapshot: NavigationSnapshot = {
+      ...initialSnapshot,
+      fetchedAt: 1_100,
+      inboxThreadKeys: ["codex:thread-review"],
+      threads: [
+        {
+          id: "thread-review",
+          title: "Untitled thread",
+          titleSource: "fallback",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: {
+            inInbox: true,
+            reason: "new-thread",
+          },
+          updatedAt: 1_050,
+        },
+      ],
+    };
+    const getNavigationSnapshot = vi
+      .fn()
+      .mockResolvedValueOnce(initialSnapshot)
+      .mockResolvedValueOnce(hydratedSnapshot)
+      .mockResolvedValue(hydratedSnapshot);
+    const materializeDirectoryLaunchpad = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-review",
+      executionMode: "default" as const,
+      workMode: "worktree" as const,
+      turnId: "turn-review",
+    }));
+
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      materializeDirectoryLaunchpad,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.directories[0]?.launchpad?.prompt).toBe("/review main");
+    });
+
+    await act(async () => {
+      await result.current.materializeDirectoryLaunchpad(
+        directoryKey,
+        undefined,
+        undefined,
+        { type: "baseBranch", branch: "main" }
+      );
+    });
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(result.current.selectedThread).toMatchObject({
+      id: "thread-review",
+      title: "/review main",
+      optimisticActiveTurn: {
+        id: "turn-review",
+        statusText: "Reviewing",
+      },
+    });
+  });
+
   it("rejects materialize failures after recording the launchpad error", async () => {
     const directoryKey = "directory:/Users/huntharo/github/PwrAgent";
     const getNavigationSnapshot = vi.fn(async () => ({

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -6236,6 +6236,28 @@ describe("useThreadSessionState", () => {
       agentEventHandler?.({
         backend: "codex",
         notification: {
+          method: "item/commandExecution/requestApproval",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-review",
+            itemId: "call-1",
+            requestId: "approval-1",
+            reason: "Network access is required.",
+            command: "npm view dive",
+          },
+        } as any,
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.activeTurnId).toBe("turn-review");
+      expect(result.current.pendingStatusText).toBe("Waiting for approval");
+    });
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
           method: "turn/started",
           params: {
             threadId: "thread-1",
@@ -6262,6 +6284,7 @@ describe("useThreadSessionState", () => {
             turn: {
               id: "turn-review",
               status: "completed",
+              output: [],
             },
           },
         },

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -6297,6 +6297,103 @@ describe("useThreadSessionState", () => {
     });
   });
 
+  it("repairs a stray launchpad start when optimistic review metadata arrives after events", async () => {
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback;
+        return () => undefined;
+      },
+      readThread: async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }),
+    };
+
+    const { result, rerender } = renderHook(
+      ({ includeOptimisticReview }: { includeOptimisticReview: boolean }) =>
+        useThreadSessionState({
+          desktopApi,
+          thread: {
+            ...buildThread({ id: "thread-1", updatedAt: 1_000 }),
+            ...(includeOptimisticReview
+              ? {
+                  optimisticActiveTurn: {
+                    id: "turn-review",
+                    statusText: "Reviewing",
+                    startedAt: 1_500,
+                    reviewDisplayText: "Review changes against main",
+                  },
+                }
+              : {}),
+          },
+        }),
+      { initialProps: { includeOptimisticReview: false } }
+    );
+
+    await waitForThreadHydration(result);
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/started",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-stray",
+            turn: {
+              id: "turn-stray",
+              status: "inProgress",
+            },
+          },
+        },
+      });
+    });
+
+    expect(result.current.activeTurnId).toBe("turn-stray");
+
+    rerender({ includeOptimisticReview: true });
+
+    await waitFor(() => {
+      expect(result.current.activeTurnId).toBe("turn-review");
+      expect(result.current.pendingStatusText).toBe("Reviewing");
+    });
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-review",
+            turn: {
+              id: "turn-review",
+              status: "completed",
+              output: [],
+            },
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.activeTurnId).toBeUndefined();
+      expect(result.current.pendingStatusText).toBeUndefined();
+    });
+  });
+
   it("seeds launchpad active turns alongside optimistic user messages", async () => {
     const desktopApi: DesktopApi = {
       onAgentEvent: () => () => undefined,

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -6394,6 +6394,78 @@ describe("useThreadSessionState", () => {
     });
   });
 
+  it("does not reseed a launchpad active turn after idle hydration clears it", async () => {
+    const readThread = vi.fn(async ({ backend, threadId }) => ({
+      backend: backend ?? "codex",
+      fetchedAt: Date.now(),
+      threadId,
+      threadStatus: "idle" as const,
+      replay: {
+        entries: [
+          {
+            type: "review" as const,
+            id: "review-1",
+            review: "Code review",
+            displayText: "Code review",
+            createdAt: 2_000,
+            turn: {
+              id: "turn-review",
+              status: "completed" as const,
+              startedAt: 1_500,
+              completedAt: 2_500,
+            },
+          },
+        ],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+      },
+    }));
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread,
+    };
+    const optimisticThread = {
+      ...buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      optimisticActiveTurn: {
+        id: "turn-review",
+        statusText: "Reviewing",
+        startedAt: 1_500,
+        reviewDisplayText: "Review changes against main",
+      },
+    };
+
+    const { result, rerender } = renderHook(
+      ({ currentThread }) =>
+        useThreadSessionState({
+          desktopApi,
+          thread: currentThread,
+        }),
+      {
+        initialProps: {
+          currentThread: optimisticThread,
+        },
+      }
+    );
+
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(result.current.activeTurnId).toBeUndefined();
+      expect(result.current.pendingStatusText).toBeUndefined();
+    });
+
+    rerender({ currentThread: { ...optimisticThread } });
+    await flushReactUpdates();
+
+    expect(result.current.activeTurnId).toBeUndefined();
+    expect(result.current.pendingStatusText).toBeUndefined();
+    expect(result.current.threadBusy).toBe(false);
+  });
+
   it("seeds launchpad active turns alongside optimistic user messages", async () => {
     const desktopApi: DesktopApi = {
       onAgentEvent: () => () => undefined,

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -6178,6 +6178,151 @@ describe("useThreadSessionState", () => {
     });
   });
 
+  it("seeds launchpad review turns before stray turn starts arrive", async () => {
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback;
+        return () => undefined;
+      },
+      readThread: async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: {
+          ...buildThread({ id: "thread-1", updatedAt: 1_000 }),
+          optimisticActiveTurn: {
+            id: "turn-review",
+            statusText: "Reviewing",
+            startedAt: 1_500,
+            reviewDisplayText: "Review changes against main",
+          },
+        },
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.activeTurnId).toBe("turn-review");
+      expect(result.current.pendingStatusText).toBe("Reviewing");
+      expect(result.current.entries).toEqual([
+        expect.objectContaining({
+          type: "review",
+          review: "Review changes against main",
+          turn: expect.objectContaining({
+            id: "turn-review",
+            status: "in_progress",
+          }),
+        }),
+      ]);
+    });
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/started",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-stray",
+            turn: {
+              id: "turn-stray",
+              status: "inProgress",
+            },
+          },
+        },
+      });
+    });
+
+    expect(result.current.activeTurnId).toBe("turn-review");
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-review",
+            turn: {
+              id: "turn-review",
+              status: "completed",
+            },
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.activeTurnId).toBeUndefined();
+      expect(result.current.pendingStatusText).toBeUndefined();
+    });
+  });
+
+  it("seeds launchpad active turns alongside optimistic user messages", async () => {
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread: async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: {
+          ...buildThread({ id: "thread-1", updatedAt: 1_000 }),
+          optimisticUserMessage: {
+            text: "Start from launchpad",
+            createdAt: 1_500,
+          },
+          optimisticActiveTurn: {
+            id: "turn-1",
+            statusText: "Thinking",
+            startedAt: 1_500,
+          },
+        },
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.activeTurnId).toBe("turn-1");
+      expect(result.current.pendingStatusText).toBe("Thinking");
+      expect(result.current.entries).toEqual([
+        expect.objectContaining({
+          type: "message",
+          role: "user",
+          text: "Start from launchpad",
+        }),
+      ]);
+    });
+  });
+
   it("stores context window usage from token usage notifications", async () => {
     let agentEventHandler: Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0] | undefined;
     const desktopApi: DesktopApi = {

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -2744,6 +2744,8 @@ export function useThreadNavigation(
         buildThreadIdentityKey(thread.source, thread.id) === optimisticThreadKey
           ? {
               ...mergeHydratedThreadWithOptimisticTitle(thread, optimisticThread),
+              optimisticActiveTurn:
+                thread.optimisticActiveTurn ?? optimisticThread.optimisticActiveTurn,
               optimisticUserMessage:
                 thread.optimisticUserMessage ?? optimisticThread.optimisticUserMessage,
             }

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -1620,6 +1620,7 @@ function buildOptimisticThreadFromLaunchpad(params: {
   workMode: NavigationLaunchpadDraft["workMode"];
   codexEnvironmentRuntime?: NavigationThreadSummary["codexEnvironmentRuntime"];
   optimisticUserMessage?: NavigationThreadSummary["optimisticUserMessage"];
+  optimisticActiveTurn?: NavigationThreadSummary["optimisticActiveTurn"];
   parentThreadId?: string;
 }): NavigationThreadSummary {
   const titlePrompt =
@@ -1642,6 +1643,7 @@ function buildOptimisticThreadFromLaunchpad(params: {
     acpRuntime: params.launchpad.acpRuntime,
     codexEnvironmentRuntime: params.codexEnvironmentRuntime,
     optimisticUserMessage: params.optimisticUserMessage,
+    optimisticActiveTurn: params.optimisticActiveTurn,
     linkedDirectories:
       params.launchpad.directoryPath && params.launchpad.directoryKind !== "workspace"
         ? [
@@ -1718,6 +1720,25 @@ function buildOptimisticUserMessage(
     ...(imageParts.length > 0 ? { imageParts } : {}),
     createdAt: Date.now(),
   };
+}
+
+function reviewDisplayTextFromTarget(
+  target: AppServerReviewTarget | undefined
+): string | undefined {
+  if (!target) {
+    return undefined;
+  }
+
+  switch (target.type) {
+    case "uncommittedChanges":
+      return "Review current changes";
+    case "baseBranch":
+      return `Review changes against ${target.branch}`;
+    case "commit":
+      return `Review commit ${target.sha}`;
+    case "custom":
+      return "Review custom instructions";
+  }
 }
 
 type UseThreadNavigationOptions = {
@@ -3583,6 +3604,20 @@ export function useThreadNavigation(
         optimisticUserMessage: response.turnStartFailure
           ? undefined
           : buildOptimisticUserMessage(input),
+        optimisticActiveTurn: response.turnId && !response.turnStartFailure
+          ? {
+              id: response.turnId,
+              statusText: reviewTarget
+                ? "Reviewing"
+                : collaborationMode
+                  ? "Planning"
+                  : "Thinking",
+              startedAt: Date.now(),
+              ...(reviewTarget
+                ? { reviewDisplayText: reviewDisplayTextFromTarget(reviewTarget) }
+                : {}),
+            }
+          : undefined,
         parentThreadId: materializeParentThreadId,
       });
       const nextThreadKey = buildThreadIdentityKey(response.backend, response.threadId);

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -2618,6 +2618,7 @@ export function useThreadSessionState(params: {
     ? buildThreadIdentityKey(thread.source, thread.id)
     : undefined;
   const selectedThreadKeyRef = useRef<string | undefined>(undefined);
+  const consumedOptimisticActiveTurnKeysRef = useRef<Set<string>>(new Set());
   const lastLiveActivitySignatureRef = useRef<Record<string, string>>({});
   const requestVersionsRef = useRef<Record<string, number>>({});
   const staleThinkingLogKeysRef = useRef<Set<string>>(new Set());
@@ -2915,6 +2916,75 @@ export function useThreadSessionState(params: {
             ...current.optimisticEntries,
             optimisticEntry,
           ],
+        };
+      });
+    }
+
+    const optimisticActiveTurn = thread.optimisticActiveTurn;
+    if (optimisticActiveTurn) {
+      updateSession(threadKey, (current) => {
+        const optimisticActiveTurnKey = `${threadKey}:${optimisticActiveTurn.id}`;
+        if (consumedOptimisticActiveTurnKeysRef.current.has(optimisticActiveTurnKey)) {
+          return current;
+        }
+
+        const activeTurnStartedAt =
+          optimisticActiveTurn.startedAt ?? current.activeTurnStartedAt ?? Date.now();
+        const optimisticReviewEntry: AppServerThreadReviewEntry | undefined =
+          optimisticActiveTurn.reviewDisplayText
+            ? {
+                type: "review",
+                id: `optimistic-launchpad-review-${threadKey}`,
+                review: optimisticActiveTurn.reviewDisplayText,
+                displayText: optimisticActiveTurn.reviewDisplayText,
+                createdAt: activeTurnStartedAt,
+                turn: {
+                  id: optimisticActiveTurn.id,
+                  status: "in_progress",
+                  startedAt: activeTurnStartedAt,
+                },
+              }
+            : undefined;
+        const responseReviewExists =
+          optimisticReviewEntry &&
+          current.response?.replay.entries.some(
+            (entry) =>
+              entry.type === "review" &&
+              reviewEntriesMatch(entry, optimisticReviewEntry)
+          );
+        const optimisticReviewExists =
+          optimisticReviewEntry &&
+          current.optimisticEntries.some(
+            (entry) =>
+              entry.type === "review" &&
+              reviewEntriesMatch(entry, optimisticReviewEntry)
+          );
+        const nextOptimisticEntries =
+          optimisticReviewEntry &&
+          !responseReviewExists &&
+          !optimisticReviewExists
+            ? [...current.optimisticEntries, optimisticReviewEntry]
+            : current.optimisticEntries;
+
+        if (
+          current.activeTurnId === optimisticActiveTurn.id &&
+          current.pendingStatusText === optimisticActiveTurn.statusText &&
+          nextOptimisticEntries === current.optimisticEntries
+        ) {
+          return current;
+        }
+
+        return {
+          ...current,
+          activeTurnId: optimisticActiveTurn.id,
+          activeTurnStartedAt,
+          expectOwnUpdate: true,
+          interacted: true,
+          lastTouchedAt: Date.now(),
+          optimisticEntries: nextOptimisticEntries,
+          pendingStatusText:
+            optimisticActiveTurn.statusText ?? current.pendingStatusText,
+          pendingTurnUsage: undefined,
         };
       });
     }
@@ -3466,6 +3536,11 @@ export function useThreadSessionState(params: {
             current,
             completedTurn?.id,
           );
+          if (completedTurnMatchesActive && completedTurn?.id) {
+            consumedOptimisticActiveTurnKeysRef.current.add(
+              `${targetThreadKey}:${completedTurn.id}`
+            );
+          }
           if (liveTranscriptEventFiltering && isUnfocusedThread) {
             return {
               ...current,
@@ -3682,6 +3757,11 @@ export function useThreadSessionState(params: {
           ) {
             return current;
           }
+          if (event.notification.params.turnId) {
+            consumedOptimisticActiveTurnKeysRef.current.add(
+              `${targetThreadKey}:${event.notification.params.turnId}`
+            );
+          }
 
           const errorMessage =
             typeof event.notification.params.turn.error?.message === "string" &&
@@ -3716,6 +3796,11 @@ export function useThreadSessionState(params: {
             )
           ) {
             return current;
+          }
+          if (event.notification.params.turnId) {
+            consumedOptimisticActiveTurnKeysRef.current.add(
+              `${targetThreadKey}:${event.notification.params.turnId}`
+            );
           }
 
           return {

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -2782,6 +2782,11 @@ export function useThreadSessionState(params: {
             !hasPendingInteraction(current);
 
           if (shouldClearStaleThinking) {
+            if (targetThread.optimisticActiveTurn) {
+              consumedOptimisticActiveTurnKeysRef.current.add(
+                `${targetThreadKey}:${targetThread.optimisticActiveTurn.id}`
+              );
+            }
             logStaleThinkingState({
               current,
               reasons: thinkingReasons,

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -2965,10 +2965,12 @@ export function useThreadSessionState(params: {
           !optimisticReviewExists
             ? [...current.optimisticEntries, optimisticReviewEntry]
             : current.optimisticEntries;
+        const nextPendingStatusText =
+          current.pendingStatusText ?? optimisticActiveTurn.statusText;
 
         if (
           current.activeTurnId === optimisticActiveTurn.id &&
-          current.pendingStatusText === optimisticActiveTurn.statusText &&
+          current.pendingStatusText === nextPendingStatusText &&
           nextOptimisticEntries === current.optimisticEntries
         ) {
           return current;
@@ -2982,8 +2984,7 @@ export function useThreadSessionState(params: {
           interacted: true,
           lastTouchedAt: Date.now(),
           optimisticEntries: nextOptimisticEntries,
-          pendingStatusText:
-            optimisticActiveTurn.statusText ?? current.pendingStatusText,
+          pendingStatusText: nextPendingStatusText,
           pendingTurnUsage: undefined,
         };
       });

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -86,6 +86,12 @@ export type NavigationThreadSummary = AppServerThreadSummary & {
     imageParts?: AppServerThreadImagePart[];
     createdAt?: number;
   };
+  optimisticActiveTurn?: {
+    id: ThreadIdentifier;
+    statusText?: string;
+    startedAt?: number;
+    reviewDisplayText?: string;
+  };
   /** Per-thread emoji reactions, ordered by insertion. */
   reactions?: string[];
   /** GitHub pull requests detected for this thread's linked directories + branch. */


### PR DESCRIPTION
## Summary

Launchpad-created `/review` subthreads now keep the real review turn lifecycle in the renderer. Previously the main process returned the `review/start` turn id, but navigation dropped it, so the transcript could render the review result while the surrounding thread stayed stuck on a mismatched Thinking turn.

The materialized thread now carries a transient optimistic active turn, and session state seeds that turn before stray `turn/started` events can take over. Review launchpads also get the same optimistic review placeholder as composer-started reviews until the durable review-mode item arrives.

## Verification

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx -t "started review turn"`
- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx -t "launchpad review turns|review turn active|launchpad active turns"`
- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx`
- `pnpm --filter @pwragent/shared typecheck`
- `git diff --check`

Note: `pnpm --filter @pwragent/desktop typecheck` stalled with no diagnostics and was terminated with `SIGTERM`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5.5_%28high%29](https://img.shields.io/badge/GPT--5.5_%28high%29-000000)
