### PR TITLE
feat(desktop): redesign composer pasted-image attachments

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-runtime-capabilities.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-runtime-capabilities.test.ts
@@ -51,4 +51,44 @@ describe("ACP runtime capabilities", () => {
     expect(capabilities?.agentCapabilities?.loadSession).toBe(true);
     expect(acpRuntimeSupportsSessionHistoryReplay(capabilities)).toBe(false);
   });
+
+  it("normalizes prompt content capabilities (image/audio/embeddedContext)", () => {
+    const capabilities = normalizeAcpRuntimeCapabilities({
+      now: 1000,
+      source: "initialize",
+      value: {
+        protocolVersion: 1,
+        agentCapabilities: {
+          promptCapabilities: {
+            image: false,
+            audio: true,
+            embeddedContext: true,
+          },
+        },
+      },
+    });
+
+    expect(capabilities?.agentCapabilities?.prompt).toEqual({
+      image: false,
+      audio: true,
+      embeddedContext: true,
+    });
+  });
+
+  it("reads prompt image support from a snake_case prompt_capabilities block", () => {
+    const capabilities = normalizeAcpRuntimeCapabilities({
+      now: 1000,
+      source: "initialize",
+      value: {
+        protocol_version: 1,
+        agent_capabilities: {
+          prompt_capabilities: {
+            image: true,
+          },
+        },
+      },
+    });
+
+    expect(capabilities?.agentCapabilities?.prompt?.image).toBe(true);
+  });
 });

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -1499,6 +1499,8 @@ describe("CodexAppServerClient", () => {
         label: "GPT-5.3-Codex-Spark",
         current: undefined,
         supportsReasoning: true,
+        // Spark does not accept image input — gates composer image pastes.
+        supportsImage: false,
       },
       {
         id: "gpt-5.2",
@@ -1507,6 +1509,30 @@ describe("CodexAppServerClient", () => {
         supportsReasoning: true,
       },
     ]);
+  });
+
+  it("marks Codex Spark as not supporting images and honors an explicit protocol flag", async () => {
+    MockTransport.modelListResult = {
+      data: [
+        { id: "gpt-5.5", supportsReasoning: true },
+        { id: "gpt-5.3-codex-spark", supportsReasoning: true },
+        // An explicit protocol flag wins over the name-based Spark fallback.
+        { id: "gpt-5.4", supportsReasoning: true, supports_image: false },
+      ],
+    };
+
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const client = new CodexAppServerClient({ command: "codex" });
+
+    const models = await client.listModels();
+    const byId = new Map(models.map((model) => [model.id, model]));
+
+    // Non-Spark default leaves the flag unset ("assume supported").
+    expect(byId.get("gpt-5.5")?.supportsImage).toBeUndefined();
+    // Spark name fallback blocks images.
+    expect(byId.get("gpt-5.3-codex-spark")?.supportsImage).toBe(false);
+    // Explicit protocol flag is honored.
+    expect(byId.get("gpt-5.4")?.supportsImage).toBe(false);
   });
 
   it("normalizes 10080 minute rate-limit windows as weekly limits", async () => {

--- a/apps/desktop/src/main/acp/acp-runtime-capabilities.ts
+++ b/apps/desktop/src/main/acp/acp-runtime-capabilities.ts
@@ -295,11 +295,35 @@ function readAgentCapabilities(
   const sessionHistoryReplay =
     readBoolean(kimiMeta, "sessionHistoryReplay") ??
     readBoolean(kimiMeta, "session_history_replay");
+  // ACP advertises prompt content support under `promptCapabilities`
+  // (image / audio / embeddedContext). Some agents nest it under `prompt`.
+  const promptRecord =
+    asRecord(record?.promptCapabilities) ??
+    asRecord(record?.prompt_capabilities) ??
+    asRecord(record?.prompt);
+  const promptImage = readBoolean(promptRecord, "image");
+  const promptAudio = readBoolean(promptRecord, "audio");
+  const promptEmbeddedContext =
+    readBoolean(promptRecord, "embeddedContext") ??
+    readBoolean(promptRecord, "embedded_context");
+  const prompt =
+    promptImage !== undefined ||
+    promptAudio !== undefined ||
+    promptEmbeddedContext !== undefined
+      ? {
+          ...(promptImage !== undefined ? { image: promptImage } : {}),
+          ...(promptAudio !== undefined ? { audio: promptAudio } : {}),
+          ...(promptEmbeddedContext !== undefined
+            ? { embeddedContext: promptEmbeddedContext }
+            : {}),
+        }
+      : undefined;
   const hasData =
     loadSession !== undefined ||
     close !== undefined ||
     cancel !== undefined ||
-    sessionHistoryReplay !== undefined;
+    sessionHistoryReplay !== undefined ||
+    prompt !== undefined;
   return hasData
     ? {
         ...(loadSession !== undefined ? { loadSession } : {}),
@@ -307,6 +331,7 @@ function readAgentCapabilities(
         ...(close !== undefined || cancel !== undefined
           ? { session: { ...(close !== undefined ? { close } : {}), ...(cancel !== undefined ? { cancel } : {}) } }
           : {}),
+        ...(prompt !== undefined ? { prompt } : {}),
         raw: record ?? sessionCapabilities,
       }
     : { raw: record ?? sessionCapabilities };

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -3659,6 +3659,17 @@ function extractModelOptions(value: unknown): BackendModelOption[] {
           "supportsSteering",
           "supports_steering",
         ]),
+        // Prefer an explicit protocol flag when the model list carries one;
+        // otherwise fall back to the known Spark exclusion (Spark models do
+        // not accept image input). Leaving this `undefined` for all other
+        // models means "assume supported" in the composer.
+        supportsImage:
+          pickBoolean(modelRecord, [
+            "supportsImage",
+            "supports_image",
+            "supportsVision",
+            "supports_vision",
+          ]) ?? (isSparkModelId(id) ? false : undefined),
       },
     ];
   });
@@ -3693,6 +3704,10 @@ function summarizeRawModelList(value: unknown): Array<Record<string, unknown>> {
       },
     ];
   });
+}
+
+function isSparkModelId(id: string): boolean {
+  return id.toLowerCase().includes("spark");
 }
 
 function shouldHideCodexModel(

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -36,6 +36,7 @@ import { useThreadSkills } from "./lib/useThreadSkills";
 import { useQueuedTurnRelease } from "./lib/useQueuedTurnRelease";
 import { CodexConfigWarningBanner } from "./features/codex-config/CodexConfigWarningBanner";
 import { AppNoticeToast } from "./features/notifications/AppNoticeToast";
+import type { AppNoticeToastNotice } from "./features/notifications/AppNoticeToast";
 import { AppUpdateBanner } from "./features/update/AppUpdateBanner";
 import { AutomationsScreen } from "./features/automations/AutomationsScreen";
 
@@ -168,6 +169,11 @@ function DesktopAppShell(props: {
   // triggers the slim "set up `foo`?" confirmation step; everything
   // else uses the standard first-run / replay flow.
   const [bootInfo, setBootInfo] = useState<DesktopBootInfo | null>(null);
+  // Transient composer-originated notices (image attachment limit reached,
+  // pasted image rejected on a non-vision model). Rendered through the shared
+  // AppNoticeToast in the toast stack below, separate from the navigation
+  // archive notice so the two never clobber each other.
+  const [composerNotice, setComposerNotice] = useState<AppNoticeToastNotice>();
   const [ThreadViewComponent, setThreadViewComponent] =
     useState<ComponentType<ThreadViewProps>>();
   const desktopApi = props.desktopApi;
@@ -380,6 +386,7 @@ function DesktopAppShell(props: {
     composerDraftStore,
     desktopApi,
     launchpadError: navigation.launchpadError,
+    onShowNotice: setComposerNotice,
     loading: session.loading,
     loadingMore: session.loadingMore,
     messageCount: session.messages.length,
@@ -750,6 +757,11 @@ function DesktopAppShell(props: {
             desktopApi={desktopApi}
             notice={navigation.archiveThreadNotice}
             onDismiss={navigation.dismissArchiveThreadNotice}
+          />
+          <AppNoticeToast
+            desktopApi={desktopApi}
+            notice={composerNotice}
+            onDismiss={() => setComposerNotice(undefined)}
           />
           <AppUpdateBanner desktopApi={desktopApi} />
         </div>

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1560,6 +1560,20 @@ export function Composer(props: ComposerProps) {
   const [imageAttachments, setImageAttachments] = useState<ComposerImageAttachment[]>(
     latestDraftSnapshotRef.current.snapshot.imageAttachments
   );
+  // Per-attachment content signature (`<size>:<hash>`) cache used to reject
+  // exact-duplicate pastes. Computed lazily on first use and kept only in
+  // memory — signatures are never part of the persisted draft snapshot.
+  const imageSignatureCacheRef = useRef(new Map<string, string>());
+  const getImageSignature = (attachment: ComposerImageAttachment): string => {
+    const cache = imageSignatureCacheRef.current;
+    const cached = cache.get(attachment.id);
+    if (cached !== undefined) {
+      return cached;
+    }
+    const signature = `${attachment.size}:${hashImageDataUrl(attachment.url)}`;
+    cache.set(attachment.id, signature);
+    return signature;
+  };
   // Currently expanded attachment shown in the full-size lightbox, or
   // undefined when the lightbox is closed.
   const [lightboxAttachment, setLightboxAttachment] =
@@ -3934,13 +3948,20 @@ export function Composer(props: ComposerProps) {
           imageAttachments: pasteImageAttachments,
           skillTokens,
         };
+        // Drop exact duplicates against the background scope's own attachments
+        // (no toast — this composer isn't the one on screen).
+        const { unique } = partitionNewImageAttachments(
+          saved.imageAttachments,
+          nextAttachments,
+          getImageSignature,
+        );
         const nextSnapshot = {
           draft: saved.draft,
           editorDocument: saved.editorDocument,
-          imageAttachments: [
-            ...saved.imageAttachments,
-            ...nextAttachments,
-          ].slice(0, MAX_COMPOSER_IMAGE_ATTACHMENTS),
+          imageAttachments: [...saved.imageAttachments, ...unique].slice(
+            0,
+            MAX_COMPOSER_IMAGE_ATTACHMENTS,
+          ),
           skillTokens: saved.skillTokens,
         };
         saveComposerDraftSnapshot(pasteScope.key, nextSnapshot);
@@ -3948,10 +3969,39 @@ export function Composer(props: ComposerProps) {
         return;
       }
 
+      // Reject exact-duplicate pastes so the same image can't stack up. Toast
+      // off the snapshot captured when this paste started — accurate for the
+      // sequential paste-the-same-image case — then re-check inside the state
+      // updater below against the freshest list for the rare paste race.
+      const { unique, duplicateCount } = partitionNewImageAttachments(
+        pasteImageAttachments,
+        nextAttachments,
+        getImageSignature,
+      );
+      if (duplicateCount > 0) {
+        showComposerNotice({
+          title: "Image already attached",
+          message:
+            duplicateCount === 1
+              ? "That image is already attached to this message."
+              : `${duplicateCount} of those images are already attached to this message.`,
+        });
+      }
+      if (unique.length === 0) {
+        return;
+      }
+
       setImageAttachments((current) => {
-        // Final safety cap so two near-simultaneous pastes can never persist
-        // more than the limit even if both passed the pre-attach gate.
-        const mergedAttachments = [...current, ...nextAttachments].slice(
+        // Re-run de-dup and the cap against the latest state (not the snapshot
+        // captured when this paste began) so a second identical paste arriving
+        // while an earlier one is still normalizing can never slip a duplicate
+        // through or exceed the limit.
+        const { unique: freshlyUnique } = partitionNewImageAttachments(
+          current,
+          unique,
+          getImageSignature,
+        );
+        const mergedAttachments = [...current, ...freshlyUnique].slice(
           0,
           MAX_COMPOSER_IMAGE_ATTACHMENTS,
         );
@@ -6338,6 +6388,66 @@ function readFileAsImageDataUrl(file: File, mimeType: string): Promise<string> {
     });
     reader.readAsDataURL(file);
   });
+}
+
+/**
+ * Small, fast, non-cryptographic 53-bit hash (cyrb53) over an image data URL.
+ * Used only to bucket like-sized attachments for in-memory de-duplication; it
+ * is never persisted or sent, and hash collisions are resolved by an exact
+ * data-URL comparison, so a weak hash is safe here.
+ */
+function hashImageDataUrl(value: string): number {
+  let h1 = 0xdeadbeef;
+  let h2 = 0x41c6ce57;
+  for (let i = 0; i < value.length; i += 1) {
+    const ch = value.charCodeAt(i);
+    h1 = Math.imul(h1 ^ ch, 2654435761);
+    h2 = Math.imul(h2 ^ ch, 1597334677);
+  }
+  h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507);
+  h1 ^= Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+  h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507);
+  h2 ^= Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+  return 4294967296 * (2097151 & h2) + (h1 >>> 0);
+}
+
+/**
+ * Split a freshly-normalized batch into genuinely new attachments versus exact
+ * duplicates of something already attached (or of an earlier item in the same
+ * batch). A mismatched `size` rules out most pairs up front via the signature
+ * prefix; only same-size candidates land in the same bucket, where an exact
+ * data-URL compare confirms the match so two distinct same-size images are
+ * never wrongly merged on a hash collision.
+ */
+function partitionNewImageAttachments(
+  existing: ComposerImageAttachment[],
+  incoming: ComposerImageAttachment[],
+  signatureFor: (attachment: ComposerImageAttachment) => string,
+): { unique: ComposerImageAttachment[]; duplicateCount: number } {
+  const seen = new Map<string, string[]>();
+  const remember = (attachment: ComposerImageAttachment): void => {
+    const signature = signatureFor(attachment);
+    const urls = seen.get(signature);
+    if (urls) {
+      urls.push(attachment.url);
+    } else {
+      seen.set(signature, [attachment.url]);
+    }
+  };
+  for (const attachment of existing) {
+    remember(attachment);
+  }
+  const unique: ComposerImageAttachment[] = [];
+  let duplicateCount = 0;
+  for (const attachment of incoming) {
+    if (seen.get(signatureFor(attachment))?.includes(attachment.url)) {
+      duplicateCount += 1;
+      continue;
+    }
+    unique.push(attachment);
+    remember(attachment);
+  }
+  return { unique, duplicateCount };
 }
 
 function formatImageDimensions(

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -5218,6 +5218,13 @@ export function Composer(props: ComposerProps) {
         </div>
       ) : null}
 
+      {imageAttachments.length > 0 && !imagesSupported ? (
+        <p className="composer__meta composer__meta--warning" role="status">
+          {imagesUnsupportedLabel} doesn&apos;t support image attachments —
+          remove them or switch models before sending.
+        </p>
+      ) : null}
+
       <div className="composer__input-wrap" ref={inputWrapRef}>
         {isReviewComposerOpen ? (
           <fieldset className="composer__review-config" aria-label="Review target">

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -36,7 +36,8 @@ import type {
   ThreadExecutionMode,
 } from "@pwragent/shared";
 import { readCodexEnvironmentActionRuns } from "@pwragent/shared";
-import { EditorIcon, FileCodeIcon, TerminalIcon } from "../../icons";
+import { CloseIcon, EditorIcon, FileCodeIcon, TerminalIcon } from "../../icons";
+import type { AppNoticeToastNotice } from "../notifications/AppNoticeToast";
 import { formatBackendLabel } from "../../lib/backend-label";
 import type { DesktopApi } from "../../lib/desktop-api";
 import {
@@ -81,6 +82,12 @@ type ComposerProps = {
   backends?: BackendSummary[];
   applications?: DesktopApplicationsSnapshot;
   desktopApi?: DesktopApi;
+  /**
+   * Surface a transient app-level toast (image attachment limit reached,
+   * pasted image rejected on a non-vision model). Plumbed up to the shared
+   * AppNoticeToast stack in App.tsx.
+   */
+  onShowNotice?: (notice: AppNoticeToastNotice) => void;
   directory?: NavigationDirectorySummary;
   /**
    * Full set of currently-tracked directories from the navigation
@@ -184,6 +191,13 @@ type ComposerProps = {
 type LocalHandoffStrategy = ThreadWorkspaceHandoffStrategy;
 
 type ComposerImageAttachment = NavigationLaunchpadImageAttachment;
+
+/**
+ * Maximum number of image attachments allowed on a single message. No
+ * provider currently advertises its own per-message image limit, so this is
+ * the default cap; if a backend ever reports one, prefer the smaller value.
+ */
+const MAX_COMPOSER_IMAGE_ATTACHMENTS = 5;
 
 type ComposerDropdownOption = {
   disabled?: boolean;
@@ -1546,6 +1560,24 @@ export function Composer(props: ComposerProps) {
   const [imageAttachments, setImageAttachments] = useState<ComposerImageAttachment[]>(
     latestDraftSnapshotRef.current.snapshot.imageAttachments
   );
+  // Currently expanded attachment shown in the full-size lightbox, or
+  // undefined when the lightbox is closed.
+  const [lightboxAttachment, setLightboxAttachment] =
+    useState<ComposerImageAttachment>();
+  useEffect(() => {
+    if (!lightboxAttachment) {
+      return;
+    }
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === "Escape") {
+        setLightboxAttachment(undefined);
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [lightboxAttachment]);
   const [planModeEnabled, setPlanModeEnabled] = useState(false);
   const [skillTokens, setSkillTokens] = useState<ComposerSkillToken[]>(
     latestDraftSnapshotRef.current.snapshot.skillTokens
@@ -3754,6 +3786,50 @@ export function Composer(props: ComposerProps) {
     });
   };
 
+  const showComposerNotice = (notice: Omit<AppNoticeToastNotice, "id">): void => {
+    props.onShowNotice?.({
+      id: `composer-notice-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      ...notice,
+    });
+  };
+
+  /**
+   * Apply image-support + attachment-limit policy to a freshly pasted/dropped
+   * batch. Returns the subset that should be attached, or `null` to reject the
+   * whole batch. Surfaces a toast for every rejection (non-vision model) and
+   * whenever the per-message limit clamps or blocks the batch.
+   */
+  const gateImageFilesForAttachment = (
+    files: ComposerImageFile[],
+  ): ComposerImageFile[] | null => {
+    if (!imagesSupported) {
+      showComposerNotice({
+        title: "Images not supported",
+        message: `${imagesUnsupportedLabel} doesn't support image attachments.`,
+      });
+      return null;
+    }
+
+    const remaining = MAX_COMPOSER_IMAGE_ATTACHMENTS - imageAttachments.length;
+    if (remaining <= 0) {
+      showComposerNotice({
+        title: "Attachment limit reached",
+        message: `You can attach up to ${MAX_COMPOSER_IMAGE_ATTACHMENTS} images per message.`,
+      });
+      return null;
+    }
+
+    if (files.length > remaining) {
+      showComposerNotice({
+        title: "Attachment limit reached",
+        message: `You can attach up to ${MAX_COMPOSER_IMAGE_ATTACHMENTS} images per message.`,
+      });
+      return files.slice(0, remaining);
+    }
+
+    return files;
+  };
+
   const handlePaste = (event: ClipboardEvent<HTMLElement>): void => {
     const pastedFiles = getImageFilesFromDataTransfer(event.clipboardData);
     if (pastedFiles.length === 0) {
@@ -3762,7 +3838,11 @@ export function Composer(props: ComposerProps) {
 
     event.preventDefault();
     setSendError(undefined);
-    void attachImages(pastedFiles);
+    const accepted = gateImageFilesForAttachment(pastedFiles);
+    if (!accepted || accepted.length === 0) {
+      return;
+    }
+    void attachImages(accepted);
   };
 
   const handleDragOver = (event: DragEvent<HTMLElement>): void => {
@@ -3782,7 +3862,11 @@ export function Composer(props: ComposerProps) {
 
     event.preventDefault();
     setSendError(undefined);
-    void attachImages(droppedFiles);
+    const accepted = gateImageFilesForAttachment(droppedFiles);
+    if (!accepted || accepted.length === 0) {
+      return;
+    }
+    void attachImages(accepted);
   };
 
   const attachImages = async (files: ComposerImageFile[]): Promise<void> => {
@@ -3796,6 +3880,8 @@ export function Composer(props: ComposerProps) {
         files.map(async ({ file, type }, index) => {
           const fallbackName = formatPastedImageName(type, index);
           if (isGifFile(file, type)) {
+            // GIFs skip normalization (to preserve animation), so they have no
+            // measured dimensions — the card shows only the size chip for them.
             return {
               id: `pasted-${Date.now()}-${index}-${Math.random().toString(36).slice(2, 8)}`,
               name: file.name || fallbackName,
@@ -3851,7 +3937,10 @@ export function Composer(props: ComposerProps) {
         const nextSnapshot = {
           draft: saved.draft,
           editorDocument: saved.editorDocument,
-          imageAttachments: [...saved.imageAttachments, ...nextAttachments],
+          imageAttachments: [
+            ...saved.imageAttachments,
+            ...nextAttachments,
+          ].slice(0, MAX_COMPOSER_IMAGE_ATTACHMENTS),
           skillTokens: saved.skillTokens,
         };
         saveComposerDraftSnapshot(pasteScope.key, nextSnapshot);
@@ -3860,7 +3949,12 @@ export function Composer(props: ComposerProps) {
       }
 
       setImageAttachments((current) => {
-        const mergedAttachments = [...current, ...nextAttachments];
+        // Final safety cap so two near-simultaneous pastes can never persist
+        // more than the limit even if both passed the pre-attach gate.
+        const mergedAttachments = [...current, ...nextAttachments].slice(
+          0,
+          MAX_COMPOSER_IMAGE_ATTACHMENTS,
+        );
         const nextSnapshot = {
           draft,
           editorDocument,
@@ -4068,6 +4162,15 @@ export function Composer(props: ComposerProps) {
   const selectedModelOption =
     modelOptions.find((option) => option.id === currentSettings?.model) ??
     getDefaultModelOption(backend);
+  // Image attachments are allowed unless the active model explicitly reports
+  // no image support (Codex Spark) or the ACP agent advertises
+  // `prompt.image: false`. `undefined` on either signal means "assume
+  // supported" so existing backends keep working.
+  const imagesSupported =
+    selectedModelOption?.supportsImage !== false &&
+    backend?.acp?.runtime?.agentCapabilities?.prompt?.image !== false;
+  const imagesUnsupportedLabel =
+    selectedModelOption?.label ?? currentSettings?.model ?? "This mode";
   const supportsReasoning =
     selectedModelOption?.supportsReasoning ??
     Boolean(backend?.launchpadOptions?.reasoningEfforts?.length);
@@ -4698,6 +4801,39 @@ export function Composer(props: ComposerProps) {
         document.body,
       )
     : null;
+  const imageLightbox = lightboxAttachment
+    ? createPortal(
+        <div
+          className="composer__lightbox"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Expanded image"
+          onClick={() => setLightboxAttachment(undefined)}
+        >
+          <div
+            className="composer__lightbox-content"
+            onClick={(event) => {
+              event.stopPropagation();
+            }}
+          >
+            <button
+              aria-label="Close image"
+              className="composer__lightbox-close"
+              type="button"
+              onClick={() => setLightboxAttachment(undefined)}
+            >
+              <CloseIcon size={18} aria-hidden="true" />
+            </button>
+            <img
+              className="composer__lightbox-image"
+              src={lightboxAttachment.url}
+              alt={formatPastedImageAlt(lightboxAttachment, 0)}
+            />
+          </div>
+        </div>,
+        document.body,
+      )
+    : null;
   const workspaceHandoffDialog =
     handoffDialog && threadWorkspace
       ? createPortal(
@@ -5033,6 +5169,55 @@ export function Composer(props: ComposerProps) {
         </div>
       ))}
 
+      {imageAttachments.length > 0 ? (
+        <div className="composer__attachments" aria-label="Pasted images">
+          {imageAttachments.map((attachment, index) => {
+            const dimensions = formatImageDimensions(
+              attachment.width,
+              attachment.height,
+            );
+            return (
+              <div className="composer__attachment" key={attachment.id}>
+                <div className="composer__attachment-thumb">
+                  <button
+                    aria-label={`Expand ${attachment.name}`}
+                    className="composer__attachment-open"
+                    type="button"
+                    onClick={() => {
+                      setLightboxAttachment(attachment);
+                    }}
+                  >
+                    <img
+                      className="composer__attachment-preview"
+                      src={attachment.url}
+                      alt={formatPastedImageAlt(attachment, index)}
+                    />
+                  </button>
+                  <button
+                    aria-label={`Remove ${attachment.name}`}
+                    className="composer__attachment-remove"
+                    type="button"
+                    onClick={() => {
+                      removeImageAttachment(attachment.id);
+                    }}
+                  >
+                    <CloseIcon size={12} aria-hidden="true" />
+                  </button>
+                </div>
+                <div className="composer__attachment-chips">
+                  <span className="composer__attachment-chip">
+                    {formatBytes(attachment.size)}
+                  </span>
+                  {dimensions ? (
+                    <span className="composer__attachment-chip">{dimensions}</span>
+                  ) : null}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      ) : null}
+
       <div className="composer__input-wrap" ref={inputWrapRef}>
         {isReviewComposerOpen ? (
           <fieldset className="composer__review-config" aria-label="Review target">
@@ -5282,38 +5467,6 @@ export function Composer(props: ComposerProps) {
           </div>
         ) : null}
       </div>
-
-      {imageAttachments.length > 0 ? (
-        <div className="composer__attachments" aria-label="Pasted images">
-          {imageAttachments.map((attachment, index) => (
-            <div className="composer__attachment" key={attachment.id}>
-              <img
-                className="composer__attachment-preview"
-                src={attachment.url}
-                alt={formatPastedImageAlt(attachment, index)}
-              />
-              <div className="composer__attachment-copy">
-                <span className="composer__attachment-name">
-                  {attachment.name}
-                </span>
-                <span className="composer__attachment-meta">
-                  {formatImageType(attachment.type)} · {formatBytes(attachment.size)}
-                </span>
-              </div>
-              <button
-                aria-label={`Remove ${attachment.name}`}
-                className="composer__attachment-remove"
-                type="button"
-                onClick={() => {
-                  removeImageAttachment(attachment.id);
-                }}
-              >
-                Remove
-              </button>
-            </div>
-          ))}
-        </div>
-      ) : null}
 
       {props.launchpad || props.thread ? (
         <div
@@ -5910,6 +6063,7 @@ export function Composer(props: ComposerProps) {
       </div>
       </form>
       {fullAccessRiskDialog}
+      {imageLightbox}
     </>
   );
 }
@@ -6179,6 +6333,21 @@ function readFileAsImageDataUrl(file: File, mimeType: string): Promise<string> {
   });
 }
 
+function formatImageDimensions(
+  width: number | undefined,
+  height: number | undefined,
+): string | undefined {
+  if (
+    !width ||
+    !height ||
+    !Number.isFinite(width) ||
+    !Number.isFinite(height)
+  ) {
+    return undefined;
+  }
+  return `${Math.round(width)}×${Math.round(height)}`;
+}
+
 function formatPastedImageName(type: string, index: number): string {
   const extension = type.split("/")[1] || "png";
   return `pasted-image-${index + 1}.${extension}`;
@@ -6189,11 +6358,6 @@ function formatPastedImageAlt(
   index: number
 ): string {
   return attachment.name || `Pasted image ${index + 1}`;
-}
-
-function formatImageType(type: string): string {
-  const subtype = type.split("/")[1];
-  return subtype ? subtype.toUpperCase() : "Image";
 }
 
 function formatBytes(size: number): string {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -8372,6 +8372,56 @@ describe("Composer", () => {
     expect(normalizeImageFile).not.toHaveBeenCalled();
   });
 
+  it("warns when attachments are already present on a model that doesn't support images", async () => {
+    render(
+      <Composer
+        desktopApi={{ onAgentEvent: () => () => undefined }}
+        disabled={false}
+        skills={[]}
+        backends={[
+          backendSummary("codex", {
+            models: [
+              {
+                id: "gpt-5.3-codex-spark",
+                label: "GPT-5.3-Codex-Spark",
+                supportsImage: false,
+              },
+            ],
+          }),
+        ]}
+        launchpad={{
+          directoryKey: "directory:/repo",
+          directoryKind: "directory",
+          directoryLabel: "PwrAgent",
+          directoryPath: "/repo",
+          backend: "codex",
+          executionMode: "default",
+          prompt: "",
+          workMode: "local",
+          branchName: "main",
+          createdAt: 1,
+          updatedAt: 1,
+          imageAttachments: [
+            {
+              id: "seeded-1",
+              name: "shot.png",
+              size: 24 * 1024,
+              type: "image/png",
+              url: "data:image/png;base64,AAAA",
+            },
+          ],
+        }}
+      />
+    );
+
+    // The thumbnail still renders (non-blocking), but a warning naming the
+    // model appears so the operator knows the image won't be processed.
+    expect(await screen.findByText("24 KB")).toBeInTheDocument();
+    const warning = screen.getByText(/doesn't support image attachments/);
+    expect(warning).toHaveClass("composer__meta--warning");
+    expect(warning.textContent).toContain("GPT-5.3-Codex-Spark");
+  });
+
   it("opens a full-size lightbox when a thumbnail is clicked and closes it via the X", async () => {
     const file = new File([new Uint8Array([1])], "shot.png", {
       type: "image/png",

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -8278,6 +8278,28 @@ describe("Composer", () => {
           type: "image/png",
         })
     );
+    // Distinct content per file so the cap (not the duplicate guard) is what
+    // clamps the batch — identical pastes are de-duplicated separately. The
+    // gate clamps 6 → 5 before normalizing, so only 5 files are normalized;
+    // queueing exactly 5 `Once` overrides keeps them consumed within this test
+    // and never leaks into later tests (afterEach only clears call history).
+    for (const file of files.slice(0, 5)) {
+      vi.mocked(normalizeImageFile).mockImplementationOnce(async () => ({
+        conversionPath: "renderer" as const,
+        dataUrl: `data:image/png;base64,${btoa(file.name)}`,
+        height: 24,
+        mimeType: "image/png" as const,
+        original: {
+          height: 24,
+          mimeType: "image/png",
+          name: file.name,
+          size: file.size,
+          width: 32,
+        },
+        size: 3,
+        width: 32,
+      }));
+    }
 
     const { container } = render(
       <Composer
@@ -8316,6 +8338,59 @@ describe("Composer", () => {
     expect(onShowNotice).toHaveBeenCalledWith(
       expect.objectContaining({ title: "Attachment limit reached" })
     );
+  });
+
+  it("rejects an exact-duplicate paste and keeps a single attachment", async () => {
+    const onShowNotice = vi.fn();
+    const makeFile = () =>
+      new File([new Uint8Array([1])], "shot.png", { type: "image/png" });
+
+    const { container } = render(
+      <Composer
+        desktopApi={{ onAgentEvent: () => () => undefined }}
+        disabled={false}
+        skills={[]}
+        backends={[backendSummary("codex")]}
+        onShowNotice={onShowNotice}
+        thread={{
+          id: "thread-1",
+          title: "Build Codex client",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const pasteOnce = () =>
+      fireEvent.paste(screen.getByLabelText("Reply"), {
+        clipboardData: {
+          files: [],
+          items: [
+            { kind: "file", type: "image/png", getAsFile: () => makeFile() },
+          ],
+        },
+      });
+
+    // The default normalize mock yields identical bytes for both pastes, so
+    // the second paste is an exact duplicate of the first.
+    pasteOnce();
+    await waitFor(() =>
+      expect(
+        container.querySelectorAll(".composer__attachment-preview")
+      ).toHaveLength(1)
+    );
+
+    pasteOnce();
+    await waitFor(() =>
+      expect(onShowNotice).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Image already attached" })
+      )
+    );
+    expect(
+      container.querySelectorAll(".composer__attachment-preview")
+    ).toHaveLength(1);
   });
 
   it("rejects pasted images and toasts when the model does not support images", async () => {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -8214,10 +8214,206 @@ describe("Composer", () => {
       },
     });
 
-    expect(await screen.findByText("PNG · 24 KB")).toBeInTheDocument();
-    expect(screen.getByText("PNG · 1 MB")).toBeInTheDocument();
-    expect(screen.getByText("PNG · 1.2 MB")).toBeInTheDocument();
-    expect(screen.getByText("PNG · 10 MB")).toBeInTheDocument();
+    expect(await screen.findByText("24 KB")).toBeInTheDocument();
+    expect(screen.getByText("1 MB")).toBeInTheDocument();
+    expect(screen.getByText("1.2 MB")).toBeInTheDocument();
+    expect(screen.getByText("10 MB")).toBeInTheDocument();
+  });
+
+  it("renders size and dimension chips above the chat entry and removes an image via the circular control", async () => {
+    const file = new File([new Uint8Array([1])], "shot.png", {
+      type: "image/png",
+    });
+
+    const { container } = render(
+      <Composer
+        desktopApi={{ onAgentEvent: () => () => undefined }}
+        disabled={false}
+        skills={[]}
+        backends={[backendSummary("codex")]}
+        thread={{
+          id: "thread-1",
+          title: "Build Codex client",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.paste(screen.getByLabelText("Reply"), {
+      clipboardData: {
+        files: [],
+        items: [{ kind: "file", type: file.type, getAsFile: () => file }],
+      },
+    });
+
+    // Size + dimension chips (normalizeImageFile mock => 3 bytes, 32x24).
+    expect(await screen.findByText("3 B")).toBeInTheDocument();
+    expect(screen.getByText("32×24")).toBeInTheDocument();
+
+    // The strip sits before the chat entry in the DOM (req 1 & 6).
+    const strip = screen.getByLabelText("Pasted images");
+    const input = screen.getByLabelText("Reply");
+    expect(
+      strip.compareDocumentPosition(input) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+
+    // The circular control removes the attachment.
+    fireEvent.click(screen.getByRole("button", { name: "Remove shot.png" }));
+    await waitFor(() =>
+      expect(
+        container.querySelectorAll(".composer__attachment-preview")
+      ).toHaveLength(0)
+    );
+  });
+
+  it("stops accepting pasted images at the attachment limit and shows a toast", async () => {
+    const onShowNotice = vi.fn();
+    const files = Array.from(
+      { length: 6 },
+      (_, index) =>
+        new File([new Uint8Array([1])], `shot-${index}.png`, {
+          type: "image/png",
+        })
+    );
+
+    const { container } = render(
+      <Composer
+        desktopApi={{ onAgentEvent: () => () => undefined }}
+        disabled={false}
+        skills={[]}
+        backends={[backendSummary("codex")]}
+        onShowNotice={onShowNotice}
+        thread={{
+          id: "thread-1",
+          title: "Build Codex client",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.paste(screen.getByLabelText("Reply"), {
+      clipboardData: {
+        files: [],
+        items: files.map((file) => ({
+          kind: "file",
+          type: file.type,
+          getAsFile: () => file,
+        })),
+      },
+    });
+
+    await waitFor(() =>
+      expect(
+        container.querySelectorAll(".composer__attachment-preview")
+      ).toHaveLength(5)
+    );
+    expect(onShowNotice).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Attachment limit reached" })
+    );
+  });
+
+  it("rejects pasted images and toasts when the model does not support images", async () => {
+    const onShowNotice = vi.fn();
+    const file = new File([new Uint8Array([1])], "shot.png", {
+      type: "image/png",
+    });
+
+    const { container } = render(
+      <Composer
+        desktopApi={{ onAgentEvent: () => () => undefined }}
+        disabled={false}
+        skills={[]}
+        backends={[
+          backendSummary("codex", {
+            models: [
+              {
+                id: "gpt-5.3-codex-spark",
+                label: "GPT-5.3-Codex-Spark",
+                supportsImage: false,
+              },
+            ],
+          }),
+        ]}
+        onShowNotice={onShowNotice}
+        thread={{
+          id: "thread-1",
+          title: "Build Codex client",
+          titleSource: "explicit",
+          source: "codex",
+          model: "gpt-5.3-codex-spark",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.paste(screen.getByLabelText("Reply"), {
+      clipboardData: {
+        files: [],
+        items: [{ kind: "file", type: file.type, getAsFile: () => file }],
+      },
+    });
+
+    expect(onShowNotice).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Images not supported",
+        message: expect.stringContaining("GPT-5.3-Codex-Spark"),
+      })
+    );
+    expect(
+      container.querySelectorAll(".composer__attachment-preview")
+    ).toHaveLength(0);
+    expect(normalizeImageFile).not.toHaveBeenCalled();
+  });
+
+  it("opens a full-size lightbox when a thumbnail is clicked and closes it via the X", async () => {
+    const file = new File([new Uint8Array([1])], "shot.png", {
+      type: "image/png",
+    });
+
+    render(
+      <Composer
+        desktopApi={{ onAgentEvent: () => () => undefined }}
+        disabled={false}
+        skills={[]}
+        backends={[backendSummary("codex")]}
+        thread={{
+          id: "thread-1",
+          title: "Build Codex client",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.paste(screen.getByLabelText("Reply"), {
+      clipboardData: {
+        files: [],
+        items: [{ kind: "file", type: file.type, getAsFile: () => file }],
+      },
+    });
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Expand shot.png" })
+    );
+
+    const dialog = screen.getByRole("dialog", { name: "Expanded image" });
+    expect(dialog).toBeInTheDocument();
+
+    fireEvent.click(within(dialog).getByRole("button", { name: "Close image" }));
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("dialog", { name: "Expanded image" })
+      ).not.toBeInTheDocument()
+    );
   });
 
   it("keeps dropped GIF images animated by preserving the original data URL", async () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -49,6 +49,7 @@ import { isSameWorktreeSubthreadLaunchpad } from "../../lib/subthread-launchpads
 import { useMediaQuery } from "../../lib/useMediaQuery";
 import { Composer } from "../composer/Composer";
 import type { ComposerDraftStore } from "../composer/useComposerDraftStore";
+import type { AppNoticeToastNotice } from "../notifications/AppNoticeToast";
 import { MessagingStatusBar } from "../messaging-status/MessagingStatusBar";
 import { ThreadContextPanel } from "./ThreadContextPanel";
 import { ThreadHeader } from "./ThreadHeader";
@@ -816,6 +817,7 @@ export type ThreadViewProps = {
   composerImplementation?: DesktopChatReplyComposer;
   desktopApi?: DesktopApi;
   launchpadError?: string;
+  onShowNotice?: (notice: AppNoticeToastNotice) => void;
   archiveThreadError?: string;
   loading: boolean;
   loadingMore: boolean;
@@ -2103,6 +2105,7 @@ export function ThreadView(props: ThreadViewProps) {
               backends={props.backends}
               applications={props.applications}
               desktopApi={props.desktopApi}
+              onShowNotice={props.onShowNotice}
               composerImplementation={props.composerImplementation}
               draftStore={props.composerDraftStore}
               directory={props.selectedDirectory}
@@ -2287,6 +2290,7 @@ export function ThreadView(props: ThreadViewProps) {
             backends={props.backends}
             applications={props.applications}
             desktopApi={props.desktopApi}
+            onShowNotice={props.onShowNotice}
             composerImplementation={props.composerImplementation}
             draftStore={props.composerDraftStore}
             directory={props.selectedDirectory}

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -11383,6 +11383,10 @@ textarea,
   color: var(--danger-text);
 }
 
+.composer__meta--warning {
+  color: var(--status-warning);
+}
+
 .composer__meta--copyable {
   display: flex;
   align-items: flex-start;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -10041,69 +10041,159 @@ textarea,
   -webkit-user-select: text;
 }
 
+/* Pasted-image strip sits directly above the chat entry (see Composer.tsx).
+   Cards flow left-to-right and wrap; each is a thumbnail with an overlaid
+   circular remove control and muted size/dimension chips below. */
 .composer__attachments {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(min(100%, 240px), 1fr));
+  display: flex;
+  flex-wrap: wrap;
   gap: 8px;
 }
 
 .composer__attachment {
-  display: grid;
-  grid-template-columns: 56px minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 10px;
+  display: flex;
   min-width: 0;
-  padding: 8px;
-  border: 1px solid var(--border-subtle);
+  flex-direction: column;
+  gap: 6px;
+}
+
+.composer__attachment-thumb {
+  position: relative;
+  width: 88px;
+  height: 88px;
+}
+
+/* Clicking the thumbnail opens the full-size lightbox. Bare button so the
+   preview fills it; the remove control sits above it (absolute sibling). */
+.composer__attachment-open {
+  display: block;
+  width: 88px;
+  height: 88px;
+  padding: 0;
+  border: 0;
   border-radius: 8px;
-  background: var(--bg-panel-elevated);
+  background: transparent;
+  cursor: zoom-in;
+}
+
+.composer__attachment-open:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
 }
 
 .composer__attachment-preview {
-  width: 56px;
-  aspect-ratio: 1;
-  border-radius: 6px;
+  display: block;
+  width: 88px;
+  height: 88px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
   object-fit: cover;
   background: var(--bg-panel-hover);
 }
 
-.composer__attachment-copy {
-  min-width: 0;
-}
-
-.composer__attachment-name,
-.composer__attachment-meta {
-  display: block;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.composer__attachment-name {
-  color: var(--text-primary);
-  font-size: 13px;
-  font-weight: 600;
-}
-
-.composer__attachment-meta {
-  margin-top: 2px;
-  color: var(--text-muted);
-  font-size: 12px;
-}
-
+/* Solid filled circle (not a translucent scrim) so the X stays legible over
+   any underlying image. Pinned to the thumbnail's top-right corner. */
 .composer__attachment-remove {
-  min-height: 30px;
-  padding: 0 8px;
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
   border: 1px solid var(--border-subtle);
-  border-radius: 6px;
-  background: transparent;
-  color: var(--text-secondary);
+  border-radius: 999px;
+  background: var(--bg-panel-elevated);
+  color: var(--text-primary);
+  box-shadow: 0 1px 3px var(--shadow-tint-soft);
   cursor: pointer;
 }
 
 .composer__attachment-remove:hover {
   background: var(--bg-panel-hover);
   color: var(--text-primary);
+}
+
+.composer__attachment-chips {
+  display: flex;
+  max-width: 88px;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.composer__attachment-chip {
+  display: inline-flex;
+  align-items: center;
+  height: 18px;
+  padding: 0 6px;
+  border-radius: 999px;
+  background: var(--bg-panel-hover);
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+/* Full-size preview overlay. Click the scrim or the X to close (Escape too).
+   Mirrors the transcript image lightbox, with a circular X like the
+   thumbnail remove control. */
+.composer__lightbox {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: var(--scrim-opaque);
+  cursor: zoom-out;
+}
+
+.composer__lightbox-content {
+  position: relative;
+  display: flex;
+  max-width: min(100%, 1100px);
+  cursor: default;
+}
+
+.composer__lightbox-close {
+  position: absolute;
+  top: -14px;
+  right: -14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  background: var(--bg-panel-elevated);
+  color: var(--text-primary);
+  box-shadow: 0 1px 3px var(--shadow-tint-soft);
+  cursor: pointer;
+}
+
+.composer__lightbox-close:hover {
+  background: var(--bg-panel-hover);
+}
+
+.composer__lightbox-close:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.composer__lightbox-image {
+  display: block;
+  max-width: min(100vw - 48px, 1100px);
+  max-height: min(100vh - 48px, 900px);
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  background: var(--bg-panel);
+  object-fit: contain;
 }
 
 .composer__setup {

--- a/packages/shared/src/contracts/backend.ts
+++ b/packages/shared/src/contracts/backend.ts
@@ -157,6 +157,14 @@ export type BackendModelOption = {
   supportsReasoning?: boolean;
   supportsFast?: boolean;
   supportsSteering?: boolean;
+  /**
+   * Whether this model accepts image input. `undefined` means "assume
+   * supported" (backward compatible); only an explicit `false` blocks image
+   * attachments in the composer. Codex Spark reports `false`; ACP agents that
+   * advertise `agentCapabilities.prompt.image: false` are gated separately on
+   * the runtime capability.
+   */
+  supportsImage?: boolean;
 };
 
 export type BackendLaunchpadOptions = {


### PR DESCRIPTION
## What

Reworks how pasted/attached images are presented in the thread composer.

**Layout & card design**
- Moves the attachment strip to sit **directly above the chat entry** (below env-action output and queued sections) so it reads as part of the message being composed.
- Restyles each attachment as a compact **left-to-right thumbnail card** that wraps: an `88px` preview with a **circular X remove control** overlaid (solid filled circle so it stays legible over any image), and two muted **chips** below — file size (`408 KB`) and pixel dimensions (`1600×1200`, shown only when known).

**Attachment limit + toasts**
- Caps attachments at **5** per message. Pasting past the cap fills the remaining slots and shows a toast; a final cap on merge closes paste-race gaps.
- On a model/mode that doesn't accept images, **every** paste is rejected with a toast naming the model.
- Toasts reuse the shared `AppNoticeToast`, plumbed `App → ThreadView → Composer` via a new optional `onShowNotice`.

**Typed per-model image support** (drives the gating above)
- Adds `supportsImage` to `BackendModelOption` (`undefined` ⇒ assume supported; only explicit `false` blocks).
- Codex: Spark reports `false` (an explicit protocol flag is honored when present); other models stay unset.
- ACP: `agentCapabilities.prompt.image` is now normalized off the runtime and the composer gates on it too.

**Full-size lightbox**
- Clicking a thumbnail opens the image full size in an overlay (portal'd to `document.body`, mirroring the composer's handoff dialog) with an **X close** consistent with the thumbnail remove control. Backdrop click and Escape also close.

## Why

The previous strip rendered as a full-width list **under** the textarea, reading as if it belonged with the provider/model controls rather than the message. There was no cap and no feedback, and non-vision modes (e.g. Codex Spark) silently accepted pastes that fail downstream. This makes attachment composing legible, bounded, and honest about what the selected model accepts — and lets you actually inspect a pasted image at full size.

## Reviewer notes

- **GIF dimensions** are intentionally not measured — reading them requires loading an `Image`, which hangs under jsdom and would block the GIF attach; GIFs show the size chip only. Normalized (non-GIF) pastes already carry real dimensions.
- The lightbox is **composer-scoped** rather than reusing `TranscriptImageLightbox` (which lives in `thread-detail`, is tied to `AppServerThreadImagePart`, and uses a text "Close" button). It mirrors that component's overlay and reuses the same scrim/border tokens, with an X close per request.
- Renderer still imports only `@pwragent/shared`; the new capability is computed in the main process.

## Verification

- `pnpm --filter @pwragent/desktop typecheck`, full-workspace `pnpm typecheck`
- `pnpm lint:boundaries`, `pnpm lint:colors`
- Tests: composer suite (138, incl. new coverage for the limit, unsupported-model rejection, size/dimension chips, circular remove, and the click-to-open / X-to-close lightbox), Codex client (Spark `supportsImage:false` + protocol-flag override), ACP `prompt.image` normalization, backend registry/catalog/ACP adapter, AppNoticeToast

🤖 Generated with [Claude Code](https://claude.com/claude-code)