### PR TITLE
fix(desktop): suppress broken stdio log failures

### DIFF
--- a/apps/desktop/src/main/__tests__/log-stdio.test.ts
+++ b/apps/desktop/src/main/__tests__/log-stdio.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type ErrorListener = (error: Error) => void;
+
+const mocks = vi.hoisted(() => {
+  const consoleWriteFn = vi.fn();
+  const consoleTransport = Object.assign(vi.fn(), {
+    level: "silly" as string | false,
+    writeFn: consoleWriteFn,
+  });
+
+  const fileTransport = Object.assign(vi.fn(), {
+    fileName: "",
+    level: "silly" as string | false,
+    getFile: vi.fn(() => ({ path: "/tmp/profile-default.main.log" })),
+  });
+
+  const scope = Object.assign(vi.fn(), {
+    labelPadding: true,
+  });
+
+  return {
+    consoleTransport,
+    consoleWriteFn,
+    electronLog: {
+      hooks: [] as unknown[],
+      initialize: vi.fn(),
+      scope,
+      transports: {
+        console: consoleTransport,
+        file: fileTransport,
+      },
+    },
+    fileTransport,
+    scope,
+  };
+});
+
+vi.mock("electron-log/main.js", () => ({
+  default: mocks.electronLog,
+}));
+
+vi.mock("../app-logs", () => ({
+  appendAppLogEntry: vi.fn(),
+}));
+
+function makeBrokenPipeError(): Error & { code: string } {
+  return Object.assign(new Error("write EPIPE"), { code: "EPIPE" });
+}
+
+function makeMessage() {
+  return {
+    data: ["hello"],
+    date: new Date("2026-06-10T00:00:00.000Z"),
+    level: "info",
+  };
+}
+
+describe("initializeMainLogger stdio handling", () => {
+  let stdoutErrorListeners: ErrorListener[];
+  let stderrErrorListeners: ErrorListener[];
+
+  beforeEach(() => {
+    stdoutErrorListeners = process.stdout.listeners("error") as ErrorListener[];
+    stderrErrorListeners = process.stderr.listeners("error") as ErrorListener[];
+    vi.resetModules();
+    mocks.electronLog.hooks = [];
+    mocks.electronLog.initialize.mockClear();
+    mocks.scope.mockClear();
+    mocks.scope.labelPadding = true;
+    mocks.consoleWriteFn.mockReset();
+    mocks.consoleTransport.level = "silly";
+    mocks.consoleTransport.writeFn = mocks.consoleWriteFn;
+    mocks.fileTransport.fileName = "";
+    mocks.fileTransport.level = "silly";
+    mocks.fileTransport.getFile.mockClear();
+  });
+
+  afterEach(() => {
+    for (const listener of process.stdout.listeners("error") as ErrorListener[]) {
+      if (!stdoutErrorListeners.includes(listener)) {
+        process.stdout.off("error", listener);
+      }
+    }
+
+    for (const listener of process.stderr.listeners("error") as ErrorListener[]) {
+      if (!stderrErrorListeners.includes(listener)) {
+        process.stderr.off("error", listener);
+      }
+    }
+  });
+
+  it("disables console logging when the console transport hits a broken stdout pipe", async () => {
+    mocks.consoleWriteFn.mockImplementation(() => {
+      throw makeBrokenPipeError();
+    });
+
+    const { initializeMainLogger } = await import("../log");
+    initializeMainLogger();
+
+    mocks.consoleTransport.level = "silly";
+
+    expect(() => mocks.consoleTransport.writeFn(makeMessage())).not.toThrow();
+    expect(mocks.consoleWriteFn).toHaveBeenCalledTimes(1);
+    expect(mocks.consoleTransport.level).toBe(false);
+
+    mocks.consoleTransport.writeFn(makeMessage());
+    expect(mocks.consoleWriteFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables console logging when stdout emits an asynchronous broken-pipe error", async () => {
+    const { initializeMainLogger } = await import("../log");
+    initializeMainLogger();
+
+    mocks.consoleTransport.level = "silly";
+
+    expect(() => process.stdout.emit("error", makeBrokenPipeError())).not.toThrow();
+    expect(mocks.consoleTransport.level).toBe(false);
+  });
+
+  it("keeps file logging configured when console logging is disabled", async () => {
+    const { initializeMainLogger } = await import("../log");
+    initializeMainLogger();
+
+    process.stderr.emit("error", makeBrokenPipeError());
+
+    expect(mocks.consoleTransport.level).toBe(false);
+    expect(mocks.fileTransport.level).toBe("info");
+    expect(mocks.electronLog.initialize).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/main/log.ts
+++ b/apps/desktop/src/main/log.ts
@@ -3,6 +3,7 @@ import { appendAppLogEntry } from "./app-logs";
 import type { ProfileBootDecision } from "./profile";
 
 let initialized = false;
+let stdioErrorHandlersInstalled = false;
 let debugCollectionEnabled = false;
 const MAX_COMPACT_STRING_LENGTH = 320;
 const MAX_COMPACT_FIELDS = 24;
@@ -10,11 +11,74 @@ const MAX_COMPACT_DEPTH = 2;
 
 type ElectronLogHook = (typeof electronLog.hooks)[number];
 type ElectronLogMessage = Parameters<ElectronLogHook>[0];
+type StdioError = Error & {
+  code?: unknown;
+};
 
 const electronLogConsoleTransport = electronLog.transports?.console;
 
 if (process.env.VITEST === "true" && electronLogConsoleTransport) {
   electronLogConsoleTransport.level = false;
+}
+
+function isClosedStdioError(error: unknown): error is StdioError {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+
+  const code = (error as StdioError).code;
+  return code === "EPIPE" || code === "ERR_STREAM_DESTROYED";
+}
+
+function disableConsoleTransport(): void {
+  electronLog.transports.console.level = false;
+}
+
+function rethrowUnexpectedStdioError(error: unknown): void {
+  queueMicrotask(() => {
+    throw error;
+  });
+}
+
+function handleStdioError(error: unknown): void {
+  if (isClosedStdioError(error)) {
+    disableConsoleTransport();
+    return;
+  }
+
+  rethrowUnexpectedStdioError(error);
+}
+
+function installStdioErrorHandlers(): void {
+  if (stdioErrorHandlersInstalled) {
+    return;
+  }
+
+  stdioErrorHandlersInstalled = true;
+  process.stdout.on("error", handleStdioError);
+  process.stderr.on("error", handleStdioError);
+}
+
+function guardConsoleTransport(): void {
+  const transport = electronLog.transports.console;
+  const writeFn = transport.writeFn;
+
+  transport.writeFn = (options) => {
+    if (transport.level === false) {
+      return;
+    }
+
+    try {
+      writeFn(options);
+    } catch (error) {
+      if (isClosedStdioError(error)) {
+        disableConsoleTransport();
+        return;
+      }
+
+      throw error;
+    }
+  };
 }
 
 export function initializeMainLogger(options?: { profileName?: string }): void {
@@ -23,6 +87,8 @@ export function initializeMainLogger(options?: { profileName?: string }): void {
   }
 
   initialized = true;
+  installStdioErrorHandlers();
+  guardConsoleTransport();
   if (options?.profileName) {
     electronLog.transports.file.fileName = resolveMainLogFileNameForProfile(
       options.profileName,


### PR DESCRIPTION
## Summary

- I fixed the Electron main-process logging path so a closed launcher stdout/stderr no longer surfaces a JavaScript error modal when `electron-log` hits `EPIPE` or `ERR_STREAM_DESTROYED`.
- I now disable only the console transport for closed stdio errors, leaving file logging and app-log collection configured.
- I covered synchronous console transport failures and asynchronous stdout/stderr errors with a mocked logger regression test.

## Verification

- I verified `pnpm vitest run --config vitest.workspace.ts --project=desktop-main apps/desktop/src/main/__tests__/log-stdio.test.ts`.
- I verified `pnpm vitest run --config vitest.workspace.ts --project=desktop-main apps/desktop/src/main/__tests__/log.test.ts apps/desktop/src/main/__tests__/log-stdio.test.ts`.
- I verified `pnpm --filter @pwragent/desktop typecheck`.

## Notes

- This mirrors the fix from pwrdrvr/PwrSnap#231 for PwrAgent.
- No visual evidence: this is internal Electron main-process logging behavior.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
