### PR TITLE
test(desktop): isolate settings IPC from network

### DIFF
--- a/apps/desktop/src/main/__tests__/settings-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-ipc.test.ts
@@ -219,6 +219,12 @@ describe("settings ipc", () => {
     childProcessMocks.spawn.mockImplementation(() => {
       throw new Error("unexpected spawn");
     });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("unexpected network fetch in settings IPC test");
+      }),
+    );
   });
 
   it("registers redacted read and write handlers", async () => {


### PR DESCRIPTION
Settings IPC ACP refresh tests now fail fast if they accidentally touch the network. The ACP list path intentionally falls back when registry fetch fails, but the test previously left `globalThis.fetch` real, so CI could spend most of the 5s test timeout waiting on an external registry request before exercising that fallback.

The test setup now stubs `fetch` to reject immediately, keeping the suite offline and making the fallback path deterministic.

## Test Plan

- `pnpm test apps/desktop/src/main/__tests__/settings-ipc.test.ts`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
