### PR TITLE
feat(desktop): add hot CPU capture presets

### DIFF
--- a/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
@@ -23,6 +23,9 @@ describe("desktopSettingsPatchToEdits — general", () => {
     const edits = desktopSettingsPatchToEdits({
       general: {
         hotCpuProfilingEnabled: true,
+        hotCpuProfilingStartDelayMs: 5000,
+        hotCpuProfilingTriggerMode: "slowburn",
+        hotCpuProfilingSlowburnThresholdPercent: 15,
       },
     });
 
@@ -31,6 +34,21 @@ describe("desktopSettingsPatchToEdits — general", () => {
         op: "set",
         path: ["general", "hot_cpu_profiling_enabled"],
         value: true,
+      },
+      {
+        op: "set",
+        path: ["general", "hot_cpu_profiling_start_delay_ms"],
+        value: 5000,
+      },
+      {
+        op: "set",
+        path: ["general", "hot_cpu_profiling_trigger_mode"],
+        value: "slowburn",
+      },
+      {
+        op: "set",
+        path: ["general", "hot_cpu_profiling_slowburn_threshold_percent"],
+        value: 15,
       },
     ]);
   });

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -283,6 +283,18 @@ describe("DesktopSettingsService", () => {
       value: false,
       source: "default",
     });
+    expect(initial.general.hotCpuProfilingStartDelayMs).toEqual({
+      value: 0,
+      source: "default",
+    });
+    expect(initial.general.hotCpuProfilingTriggerMode).toEqual({
+      value: "sustained",
+      source: "default",
+    });
+    expect(initial.general.hotCpuProfilingSlowburnThresholdPercent).toEqual({
+      value: 15,
+      source: "default",
+    });
     expect(initial.general.hotCpuProfilingCaptureHeapSnapshot).toEqual({
       value: false,
       source: "default",
@@ -292,12 +304,18 @@ describe("DesktopSettingsService", () => {
       source: "default",
     });
     expect(service.resolveHotCpuProfilingEnabled()).toBe(false);
+    expect(service.resolveHotCpuProfilingStartDelayMs()).toBe(0);
+    expect(service.resolveHotCpuProfilingTriggerMode()).toBe("sustained");
+    expect(service.resolveHotCpuProfilingSlowburnThresholdPercent()).toBe(15);
     expect(service.resolveHotCpuProfilingCaptureHeapSnapshot()).toBe(false);
     expect(service.resolveHotCpuProfilingHeapSnapshotLimit()).toBe(2);
 
     await service.writeConfigPatch({
       general: {
         hotCpuProfilingEnabled: true,
+        hotCpuProfilingStartDelayMs: 5000,
+        hotCpuProfilingTriggerMode: "slowburn",
+        hotCpuProfilingSlowburnThresholdPercent: 20,
         hotCpuProfilingCaptureHeapSnapshot: true,
         hotCpuProfilingHeapSnapshotLimit: 3,
       },
@@ -306,10 +324,31 @@ describe("DesktopSettingsService", () => {
     const saved = fs.readFileSync(configPath, "utf8");
     expect(saved).toContain("[general]");
     expect(saved).toContain("hot_cpu_profiling_enabled = true");
+    expect(saved).toContain("hot_cpu_profiling_start_delay_ms = 5000");
+    expect(saved).toContain('hot_cpu_profiling_trigger_mode = "slowburn"');
+    expect(saved).toContain("hot_cpu_profiling_slowburn_threshold_percent = 20");
     expect(saved).toContain("hot_cpu_profiling_capture_heap_snapshot = true");
     expect(saved).toContain("hot_cpu_profiling_heap_snapshot_limit = 3");
     expect((await service.readSettings()).general.hotCpuProfilingEnabled).toEqual({
       value: true,
+      source: "config",
+    });
+    expect(
+      (await service.readSettings()).general.hotCpuProfilingStartDelayMs,
+    ).toEqual({
+      value: 5000,
+      source: "config",
+    });
+    expect(
+      (await service.readSettings()).general.hotCpuProfilingTriggerMode,
+    ).toEqual({
+      value: "slowburn",
+      source: "config",
+    });
+    expect(
+      (await service.readSettings()).general.hotCpuProfilingSlowburnThresholdPercent,
+    ).toEqual({
+      value: 20,
       source: "config",
     });
     expect(
@@ -325,6 +364,9 @@ describe("DesktopSettingsService", () => {
       source: "config",
     });
     expect(service.resolveHotCpuProfilingEnabled()).toBe(true);
+    expect(service.resolveHotCpuProfilingStartDelayMs()).toBe(5000);
+    expect(service.resolveHotCpuProfilingTriggerMode()).toBe("slowburn");
+    expect(service.resolveHotCpuProfilingSlowburnThresholdPercent()).toBe(20);
     expect(service.resolveHotCpuProfilingCaptureHeapSnapshot()).toBe(true);
     expect(service.resolveHotCpuProfilingHeapSnapshotLimit()).toBe(3);
   });

--- a/apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts
@@ -211,6 +211,182 @@ describe("RendererHotCpuProfiler", () => {
     );
   });
 
+  it("waits for the configured delay before sampling", async () => {
+    const workspace = await createTemporaryTestDirectory();
+    cleanups.push(workspace.cleanup);
+
+    const config = createEnabledConfig(workspace.path, {
+      PWRAGENT_HOT_CPU_PROFILING_START_DELAY_MS: "100",
+    });
+    const sessionResult = await createHotCpuProfileSession({
+      config,
+      createdAt: new Date(2026, 5, 1, 15, 30, 0),
+      sessionId: "abc123",
+      versions: {
+        appVersion: "1.0.0",
+        electronVersion: "41.2.1",
+        chromeVersion: "146.0.0.0",
+        nodeVersion: "24.0.0",
+      },
+    });
+    expect(sessionResult.ok).toBe(true);
+    if (!sessionResult.ok) return;
+
+    vi.useFakeTimers();
+
+    const { target } = createTarget();
+    const getAppMetrics = vi.fn(() => [createMetric(0, 100)]);
+    const profiler = new RendererHotCpuProfiler({
+      config,
+      getAppMetrics,
+      session: sessionResult.session,
+      target,
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+    });
+
+    await profiler.start();
+    await vi.advanceTimersByTimeAsync(99);
+    expect(getAppMetrics).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(getAppMetrics).toHaveBeenCalledTimes(1);
+
+    await profiler.stop("test-complete");
+  });
+
+  it("starts a profile after one hot sample in spike mode", async () => {
+    const workspace = await createTemporaryTestDirectory();
+    cleanups.push(workspace.cleanup);
+
+    const config = createEnabledConfig(workspace.path, {
+      PWRAGENT_HOT_CPU_PROFILING_TRIGGER_MODE: "spike",
+    });
+    const sessionResult = await createHotCpuProfileSession({
+      config,
+      createdAt: new Date(2026, 5, 1, 15, 30, 0),
+      sessionId: "abc123",
+      versions: {
+        appVersion: "1.0.0",
+        electronVersion: "41.2.1",
+        chromeVersion: "146.0.0.0",
+        nodeVersion: "24.0.0",
+      },
+    });
+    expect(sessionResult.ok).toBe(true);
+    if (!sessionResult.ok) return;
+
+    const { target, debuggerApi } = createTarget();
+    let nowCallCount = 0;
+    const metrics = [
+      createMetric(0, 100),
+      createMetric(4, 101.2),
+    ];
+    const profiler = new RendererHotCpuProfiler({
+      config,
+      getAppMetrics: () => [metrics.shift() ?? createMetric(0)],
+      session: sessionResult.session,
+      target,
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+      now: () => new Date(1_780_000_000_000 + nowCallCount++ * 2_000),
+    });
+
+    await profiler.start();
+    await vi.waitFor(() => {
+      expect(debuggerApi.attach).toHaveBeenCalledWith("1.3");
+    });
+    await profiler.stop("test-complete");
+
+    const events = (await fs.readFile(sessionResult.session.eventsPath, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "profile-started",
+          detail: expect.objectContaining({
+            triggerMode: "spike",
+            triggerConsecutiveSamples: 1,
+          }),
+        }),
+      ]),
+    );
+  });
+
+  it("starts a profile after consecutive slowburn samples", async () => {
+    const workspace = await createTemporaryTestDirectory();
+    cleanups.push(workspace.cleanup);
+
+    const config = createEnabledConfig(workspace.path, {
+      PWRAGENT_HOT_CPU_PROFILING_TRIGGER_MODE: "slowburn",
+      PWRAGENT_HOT_CPU_PROFILING_SLOWBURN_THRESHOLD_PERCENT: "15",
+    });
+    const sessionResult = await createHotCpuProfileSession({
+      config,
+      createdAt: new Date(2026, 5, 1, 15, 30, 0),
+      sessionId: "abc123",
+      versions: {
+        appVersion: "1.0.0",
+        electronVersion: "41.2.1",
+        chromeVersion: "146.0.0.0",
+        nodeVersion: "24.0.0",
+      },
+    });
+    expect(sessionResult.ok).toBe(true);
+    if (!sessionResult.ok) return;
+
+    const { target, debuggerApi } = createTarget();
+    let nowCallCount = 0;
+    const metrics = [
+      createMetric(0, 100),
+      createMetric(2, 100.4),
+      createMetric(2, 100.8),
+    ];
+    const profiler = new RendererHotCpuProfiler({
+      config,
+      getAppMetrics: () => [metrics.shift() ?? createMetric(0)],
+      session: sessionResult.session,
+      target,
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+      now: () => new Date(1_780_000_000_000 + nowCallCount++ * 2_000),
+    });
+
+    await profiler.start();
+    await vi.waitFor(() => {
+      expect(debuggerApi.attach).toHaveBeenCalledWith("1.3");
+    });
+    await profiler.stop("test-complete");
+
+    const events = (await fs.readFile(sessionResult.session.eventsPath, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "profile-started",
+          detail: expect.objectContaining({
+            triggerMode: "slowburn",
+            triggerThresholdPercent: 15,
+            triggerConsecutiveSamples: 2,
+          }),
+        }),
+      ]),
+    );
+  });
+
   it("captures bounded heap snapshots around a hot CPU profile", async () => {
     const workspace = await createTemporaryTestDirectory();
     cleanups.push(workspace.cleanup);

--- a/apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts
@@ -184,6 +184,10 @@ describe("RendererHotCpuProfiler", () => {
         profilePath: sessionResult.session.createProfilePath(1),
         sessionDirectory: sessionResult.session.directoryPath,
         sessionDirectoryName: sessionResult.session.directoryName,
+        triggerConsecutiveSamples: 2,
+        triggerCpuPercent: 75,
+        triggerMode: "sustained",
+        triggerThresholdPercent: 50,
       }),
     );
 

--- a/apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts
@@ -135,6 +135,7 @@ describe("RendererHotCpuProfiler", () => {
     if (!sessionResult.ok) return;
 
     const { target, debuggerApi } = createTarget();
+    const onProfileWritten = vi.fn(async () => undefined);
     let nowCallCount = 0;
     const metrics = [
       createMetric(0, 100),
@@ -152,6 +153,7 @@ describe("RendererHotCpuProfiler", () => {
         error: vi.fn(),
       },
       now: () => new Date(1_780_000_000_000 + nowCallCount++ * 2_000),
+      onProfileWritten,
     });
 
     await profiler.start();
@@ -176,6 +178,14 @@ describe("RendererHotCpuProfiler", () => {
 
     expect(debuggerApi.sendCommand).toHaveBeenCalledWith("Profiler.stop");
     expect(debuggerApi.detach).toHaveBeenCalled();
+    expect(onProfileWritten).toHaveBeenCalledWith(
+      expect.objectContaining({
+        profileFilename: "renderer-hot-0001.cpuprofile",
+        profilePath: sessionResult.session.createProfilePath(1),
+        sessionDirectory: sessionResult.session.directoryPath,
+        sessionDirectoryName: sessionResult.session.directoryName,
+      }),
+    );
 
     const profile = JSON.parse(
       await fs.readFile(

--- a/apps/desktop/src/main/diagnostics/hot-cpu-profile-config.ts
+++ b/apps/desktop/src/main/diagnostics/hot-cpu-profile-config.ts
@@ -1,4 +1,11 @@
 import path from "node:path";
+import type { DesktopHotCpuProfileTriggerMode } from "@pwragent/shared";
+import {
+  DESKTOP_HOT_CPU_PROFILE_SLOWBURN_THRESHOLD_DEFAULT_PERCENT,
+  DESKTOP_HOT_CPU_PROFILE_START_DELAY_DEFAULT_MS,
+  DESKTOP_HOT_CPU_PROFILE_TRIGGER_MODE_DEFAULT,
+  isDesktopHotCpuProfileTriggerMode,
+} from "@pwragent/shared";
 
 const DEFAULT_INTERVAL_MS = 2_000;
 const DEFAULT_THRESHOLD_PERCENT = 50;
@@ -16,8 +23,11 @@ export type HotCpuProfileConfig =
       enabled: true;
       repoRoot: string;
       outputRoot: string;
+      startDelayMs: number;
+      triggerMode: DesktopHotCpuProfileTriggerMode;
       intervalMs: number;
       thresholdPercent: number;
+      slowburnThresholdPercent: number;
       consecutiveSamples: number;
       profileDurationMs: number;
       cooldownMs: number;
@@ -41,6 +51,16 @@ function parsePositiveInteger(
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
+function parseNonNegativeInteger(
+  value: string | undefined,
+  fallback: number,
+): number {
+  if (!value) return fallback;
+
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
 function parsePositiveNumber(
   value: string | undefined,
   fallback: number,
@@ -55,6 +75,19 @@ function clampHeapSnapshotLimit(value: number): number {
   return Math.min(Math.max(Math.round(value), 1), MAX_HEAP_SNAPSHOT_LIMIT);
 }
 
+function clampPercent(value: number): number {
+  return Math.min(Math.max(value, 1), 100);
+}
+
+function parseTriggerMode(
+  value: string | undefined,
+  fallback: DesktopHotCpuProfileTriggerMode,
+): DesktopHotCpuProfileTriggerMode {
+  if (!value) return fallback;
+  const normalized = value.trim().toLowerCase();
+  return isDesktopHotCpuProfileTriggerMode(normalized) ? normalized : fallback;
+}
+
 export function resolveHotCpuProfileConfig(options?: {
   captureHeapSnapshot?: boolean;
   enabled?: boolean;
@@ -62,6 +95,9 @@ export function resolveHotCpuProfileConfig(options?: {
   heapSnapshotLimit?: number;
   outputRoot?: string;
   repoRoot?: string;
+  slowburnThresholdPercent?: number;
+  startDelayMs?: number;
+  triggerMode?: DesktopHotCpuProfileTriggerMode;
 }): HotCpuProfileConfig {
   const env = options?.env ?? process.env;
   if (!options?.enabled && !isEnabled(env.PWRAGENT_HOT_CPU_PROFILING)) {
@@ -77,6 +113,14 @@ export function resolveHotCpuProfileConfig(options?: {
     enabled: true,
     repoRoot,
     outputRoot,
+    startDelayMs: parseNonNegativeInteger(
+      env.PWRAGENT_HOT_CPU_PROFILING_START_DELAY_MS,
+      options?.startDelayMs ?? DESKTOP_HOT_CPU_PROFILE_START_DELAY_DEFAULT_MS,
+    ),
+    triggerMode: parseTriggerMode(
+      env.PWRAGENT_HOT_CPU_PROFILING_TRIGGER_MODE,
+      options?.triggerMode ?? DESKTOP_HOT_CPU_PROFILE_TRIGGER_MODE_DEFAULT,
+    ),
     intervalMs: parsePositiveInteger(
       env.PWRAGENT_HOT_CPU_PROFILING_INTERVAL_MS,
       DEFAULT_INTERVAL_MS,
@@ -84,6 +128,13 @@ export function resolveHotCpuProfileConfig(options?: {
     thresholdPercent: parsePositiveNumber(
       env.PWRAGENT_HOT_CPU_PROFILING_THRESHOLD_PERCENT,
       DEFAULT_THRESHOLD_PERCENT,
+    ),
+    slowburnThresholdPercent: clampPercent(
+      parsePositiveNumber(
+        env.PWRAGENT_HOT_CPU_PROFILING_SLOWBURN_THRESHOLD_PERCENT,
+        options?.slowburnThresholdPercent ??
+          DESKTOP_HOT_CPU_PROFILE_SLOWBURN_THRESHOLD_DEFAULT_PERCENT,
+      ),
     ),
     consecutiveSamples: parsePositiveInteger(
       env.PWRAGENT_HOT_CPU_PROFILING_CONSECUTIVE_SAMPLES,

--- a/apps/desktop/src/main/diagnostics/hot-cpu-profile-session.ts
+++ b/apps/desktop/src/main/diagnostics/hot-cpu-profile-session.ts
@@ -47,8 +47,11 @@ type HotCpuProfileSessionManifest = {
   outputRoot: string;
   artifacts: string[];
   config: {
+    startDelayMs: number;
+    triggerMode: string;
     intervalMs: number;
     thresholdPercent: number;
+    slowburnThresholdPercent: number;
     consecutiveSamples: number;
     profileDurationMs: number;
     cooldownMs: number;
@@ -106,8 +109,11 @@ export async function createHotCpuProfileSession(options: {
     outputRoot: options.config.outputRoot,
     artifacts,
     config: {
+      startDelayMs: options.config.startDelayMs,
+      triggerMode: options.config.triggerMode,
       intervalMs: options.config.intervalMs,
       thresholdPercent: options.config.thresholdPercent,
+      slowburnThresholdPercent: options.config.slowburnThresholdPercent,
       consecutiveSamples: options.config.consecutiveSamples,
       profileDurationMs: options.config.profileDurationMs,
       cooldownMs: options.config.cooldownMs,

--- a/apps/desktop/src/main/diagnostics/renderer-hot-cpu-profiler.ts
+++ b/apps/desktop/src/main/diagnostics/renderer-hot-cpu-profiler.ts
@@ -104,7 +104,10 @@ export class RendererHotCpuProfiler {
       type: "monitor-started",
       detail: {
         intervalMs: this.config.intervalMs,
+        startDelayMs: this.config.startDelayMs,
+        triggerMode: this.config.triggerMode,
         thresholdPercent: this.config.thresholdPercent,
+        slowburnThresholdPercent: this.config.slowburnThresholdPercent,
         consecutiveSamples: this.config.consecutiveSamples,
         profileDurationMs: this.config.profileDurationMs,
         captureHeapSnapshot: this.config.captureHeapSnapshot,
@@ -113,10 +116,13 @@ export class RendererHotCpuProfiler {
     });
     this.logger.info("[pwragent:hot-cpu] monitoring started", {
       sessionDirectory: this.session.directoryPath,
+      startDelayMs: this.config.startDelayMs,
+      triggerMode: this.config.triggerMode,
       thresholdPercent: this.config.thresholdPercent,
+      slowburnThresholdPercent: this.config.slowburnThresholdPercent,
       profileDurationMs: this.config.profileDurationMs,
     });
-    this.scheduleNextSample();
+    this.scheduleNextSample(this.config.startDelayMs);
   }
 
   async stop(reason = "stopped"): Promise<void> {
@@ -144,12 +150,12 @@ export class RendererHotCpuProfiler {
     });
   }
 
-  private scheduleNextSample(): void {
+  private scheduleNextSample(delayMs = this.config.intervalMs): void {
     if (this.stopped) {
       return;
     }
 
-    this.intervalTimer = setTimeout(() => this.captureSample(), this.config.intervalMs);
+    this.intervalTimer = setTimeout(() => this.captureSample(), delayMs);
   }
 
   private async captureSample(): Promise<void> {
@@ -182,8 +188,9 @@ export class RendererHotCpuProfiler {
         electronCpuPercent: metric.cpu.percentCPUUsage,
       });
       const cpuPercent = cpuUsage.cpuPercent;
+      const triggerThresholdPercent = this.triggerThresholdPercent();
       this.consecutiveHotSamples =
-        cpuPercent >= this.config.thresholdPercent
+        cpuPercent >= triggerThresholdPercent
           ? this.consecutiveHotSamples + 1
           : 0;
 
@@ -271,11 +278,11 @@ export class RendererHotCpuProfiler {
   }
 
   private shouldStartProfile(cpuPercent: number, capturedAt: string): boolean {
-    if (this.profiling || cpuPercent < this.config.thresholdPercent) {
+    if (this.profiling || cpuPercent < this.triggerThresholdPercent()) {
       return false;
     }
 
-    if (this.consecutiveHotSamples < this.config.consecutiveSamples) {
+    if (this.consecutiveHotSamples < this.triggerConsecutiveSamples()) {
       return false;
     }
 
@@ -288,6 +295,16 @@ export class RendererHotCpuProfiler {
       this.lastProfileAtMs === null ||
       capturedAtMs - this.lastProfileAtMs >= this.config.cooldownMs
     );
+  }
+
+  private triggerThresholdPercent(): number {
+    return this.config.triggerMode === "slowburn"
+      ? this.config.slowburnThresholdPercent
+      : this.config.thresholdPercent;
+  }
+
+  private triggerConsecutiveSamples(): number {
+    return this.config.triggerMode === "spike" ? 1 : this.config.consecutiveSamples;
   }
 
   private async startProfile(options: {
@@ -324,6 +341,9 @@ export class RendererHotCpuProfiler {
         detail: {
           index,
           cpuPercent: options.cpuPercent,
+          triggerMode: this.config.triggerMode,
+          triggerThresholdPercent: this.triggerThresholdPercent(),
+          triggerConsecutiveSamples: this.triggerConsecutiveSamples(),
           pid: options.pid,
           durationMs: this.config.profileDurationMs,
         },

--- a/apps/desktop/src/main/diagnostics/renderer-hot-cpu-profiler.ts
+++ b/apps/desktop/src/main/diagnostics/renderer-hot-cpu-profiler.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { ProcessMetric } from "electron";
+import type { HotCpuProfileCapturedEvent } from "../../shared/hot-cpu-profile";
 import type { HotCpuProfileConfig } from "./hot-cpu-profile-config";
 import type { HotCpuProfileSession } from "./hot-cpu-profile-session";
 import { getMainLogger } from "../log";
@@ -59,6 +60,9 @@ export class RendererHotCpuProfiler {
   private readonly logger: Logger;
   private readonly now: () => Date;
   private readonly onHeapSnapshotLimitReached?: () => void | Promise<void>;
+  private readonly onProfileWritten?: (
+    event: HotCpuProfileCapturedEvent,
+  ) => void | Promise<void>;
   private readonly session: HotCpuProfileSession;
   private readonly target: RendererHotCpuTarget;
 
@@ -84,12 +88,14 @@ export class RendererHotCpuProfiler {
     logger?: Logger;
     now?: () => Date;
     onHeapSnapshotLimitReached?: () => void | Promise<void>;
+    onProfileWritten?: (event: HotCpuProfileCapturedEvent) => void | Promise<void>;
   }) {
     this.config = options.config;
     this.getAppMetrics = options.getAppMetrics;
     this.logger = options.logger ?? getMainLogger("pwragent:hot-cpu");
     this.now = options.now ?? (() => new Date());
     this.onHeapSnapshotLimitReached = options.onHeapSnapshotLimitReached;
+    this.onProfileWritten = options.onProfileWritten;
     this.session = options.session;
     this.target = options.target;
   }
@@ -418,6 +424,13 @@ export class RendererHotCpuProfiler {
       ) {
         await this.captureHeapSnapshot(index, "stop");
       }
+      await this.onProfileWritten?.({
+        capturedAt: this.now().toISOString(),
+        profileFilename,
+        profilePath,
+        sessionDirectory: this.session.directoryPath,
+        sessionDirectoryName: this.session.directoryName,
+      });
     } catch (error) {
       await this.session.appendEvent({
         capturedAt: this.now().toISOString(),

--- a/apps/desktop/src/main/diagnostics/renderer-hot-cpu-profiler.ts
+++ b/apps/desktop/src/main/diagnostics/renderer-hot-cpu-profiler.ts
@@ -33,6 +33,14 @@ type CpuUsageReading = {
   wallDeltaSeconds?: number;
 };
 
+type ActiveProfileTrigger = Pick<
+  HotCpuProfileCapturedEvent,
+  | "triggerConsecutiveSamples"
+  | "triggerCpuPercent"
+  | "triggerMode"
+  | "triggerThresholdPercent"
+>;
+
 function serializeError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
@@ -78,6 +86,7 @@ export class RendererHotCpuProfiler {
   private profileDurationTimer: ReturnType<typeof setTimeout> | null = null;
   private profileCount = 0;
   private profiling = false;
+  private activeProfileTrigger: ActiveProfileTrigger | null = null;
   private stopped = false;
 
   constructor(options: {
@@ -338,6 +347,12 @@ export class RendererHotCpuProfiler {
       await this.target.debugger.sendCommand("Profiler.enable");
       await this.target.debugger.sendCommand("Profiler.start");
       this.profiling = true;
+      this.activeProfileTrigger = {
+        triggerConsecutiveSamples: this.triggerConsecutiveSamples(),
+        triggerCpuPercent: options.cpuPercent,
+        triggerMode: this.config.triggerMode,
+        triggerThresholdPercent: this.triggerThresholdPercent(),
+      };
       this.profileCount += 1;
       const index = this.profileCount;
       this.lastProfileAtMs = Date.parse(options.capturedAt);
@@ -376,6 +391,8 @@ export class RendererHotCpuProfiler {
         this.config.profileDurationMs,
       );
     } catch (error) {
+      this.activeProfileTrigger = null;
+      this.profiling = false;
       await this.session.appendEvent({
         capturedAt: this.now().toISOString(),
         type: "profile-start-failed",
@@ -397,6 +414,13 @@ export class RendererHotCpuProfiler {
     const index = this.profileCount;
     const profilePath = this.session.createProfilePath(index);
     const profileFilename = artifactFilename(profilePath);
+    const activeProfileTrigger =
+      this.activeProfileTrigger ?? {
+        triggerConsecutiveSamples: this.triggerConsecutiveSamples(),
+        triggerCpuPercent: 0,
+        triggerMode: this.config.triggerMode,
+        triggerThresholdPercent: this.triggerThresholdPercent(),
+      };
 
     try {
       const result = (await this.target.debugger.sendCommand("Profiler.stop")) as {
@@ -430,6 +454,7 @@ export class RendererHotCpuProfiler {
         profilePath,
         sessionDirectory: this.session.directoryPath,
         sessionDirectoryName: this.session.directoryName,
+        ...activeProfileTrigger,
       });
     } catch (error) {
       await this.session.appendEvent({
@@ -443,6 +468,7 @@ export class RendererHotCpuProfiler {
       });
       this.logger.error("[pwragent:hot-cpu] CPU profile failed to stop", error);
     } finally {
+      this.activeProfileTrigger = null;
       this.detachDebugger();
     }
   }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -596,6 +596,9 @@ export function bootstrapApp(): void {
         if (
           patch.general?.developerMode !== undefined ||
           patch.general?.hotCpuProfilingEnabled !== undefined ||
+          patch.general?.hotCpuProfilingStartDelayMs !== undefined ||
+          patch.general?.hotCpuProfilingTriggerMode !== undefined ||
+          patch.general?.hotCpuProfilingSlowburnThresholdPercent !== undefined ||
           patch.general?.hotCpuProfilingCaptureHeapSnapshot !== undefined ||
           patch.general?.hotCpuProfilingHeapSnapshotLimit !== undefined
         ) {

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -7,6 +7,8 @@ import type {
   DesktopChatReplyComposer,
   DesktopAuthorizedContact,
   DesktopCodexProfileModel,
+  DesktopHotCpuProfileStartDelayMs,
+  DesktopHotCpuProfileTriggerMode,
   DesktopMessagingAcknowledgment,
   DesktopMessagingFullAccessWarningGlobalPolicy,
   DesktopMessagingFullAccessWarningUserPolicy,
@@ -25,6 +27,8 @@ import {
   isDesktopAppearanceDensity,
   isDesktopAppearanceTheme,
   isDesktopCodexProfileModel,
+  isDesktopHotCpuProfileStartDelayMs,
+  isDesktopHotCpuProfileTriggerMode,
   isDesktopOnboardingCompletedSource,
   isDesktopWorktreeStorageLocation,
   isDesktopUpdateChannel,
@@ -69,6 +73,9 @@ export type DesktopSettingsConfig = {
     confirmQuitWithInProgressThreads?: boolean;
     developerMode?: boolean;
     hotCpuProfilingEnabled?: boolean;
+    hotCpuProfilingStartDelayMs?: DesktopHotCpuProfileStartDelayMs;
+    hotCpuProfilingTriggerMode?: DesktopHotCpuProfileTriggerMode;
+    hotCpuProfilingSlowburnThresholdPercent?: number;
     hotCpuProfilingCaptureHeapSnapshot?: boolean;
     hotCpuProfilingHeapSnapshotLimit?: number;
     notificationsEnabled?: boolean;
@@ -554,6 +561,24 @@ export function desktopSettingsPatchToEdits(
     set(
       ["general", "hot_cpu_profiling_enabled"],
       patch.general.hotCpuProfilingEnabled,
+    );
+  }
+  if (patch.general?.hotCpuProfilingStartDelayMs !== undefined) {
+    set(
+      ["general", "hot_cpu_profiling_start_delay_ms"],
+      patch.general.hotCpuProfilingStartDelayMs,
+    );
+  }
+  if (patch.general?.hotCpuProfilingTriggerMode !== undefined) {
+    set(
+      ["general", "hot_cpu_profiling_trigger_mode"],
+      patch.general.hotCpuProfilingTriggerMode,
+    );
+  }
+  if (patch.general?.hotCpuProfilingSlowburnThresholdPercent !== undefined) {
+    set(
+      ["general", "hot_cpu_profiling_slowburn_threshold_percent"],
+      patch.general.hotCpuProfilingSlowburnThresholdPercent,
     );
   }
   if (patch.general?.hotCpuProfilingCaptureHeapSnapshot !== undefined) {
@@ -1115,6 +1140,15 @@ function normalizeDesktopConfig(
       ),
       developerMode: readBoolean(general?.developer_mode),
       hotCpuProfilingEnabled: readBoolean(general?.hot_cpu_profiling_enabled),
+      hotCpuProfilingStartDelayMs: readHotCpuProfileStartDelayMs(
+        general?.hot_cpu_profiling_start_delay_ms,
+      ),
+      hotCpuProfilingTriggerMode: readHotCpuProfileTriggerMode(
+        general?.hot_cpu_profiling_trigger_mode,
+      ),
+      hotCpuProfilingSlowburnThresholdPercent: readNumber(
+        general?.hot_cpu_profiling_slowburn_threshold_percent,
+      ),
       hotCpuProfilingCaptureHeapSnapshot: readBoolean(
         general?.hot_cpu_profiling_capture_heap_snapshot,
       ),
@@ -1341,6 +1375,12 @@ function pruneEmptyConfig(config: DesktopSettingsConfig): DesktopSettingsConfig 
 
   const developerMode = config.general?.developerMode;
   const hotCpuProfilingEnabled = config.general?.hotCpuProfilingEnabled;
+  const hotCpuProfilingStartDelayMs =
+    config.general?.hotCpuProfilingStartDelayMs;
+  const hotCpuProfilingTriggerMode =
+    config.general?.hotCpuProfilingTriggerMode;
+  const hotCpuProfilingSlowburnThresholdPercent =
+    config.general?.hotCpuProfilingSlowburnThresholdPercent;
   const hotCpuProfilingCaptureHeapSnapshot =
     config.general?.hotCpuProfilingCaptureHeapSnapshot;
   const hotCpuProfilingHeapSnapshotLimit =
@@ -1355,6 +1395,9 @@ function pruneEmptyConfig(config: DesktopSettingsConfig): DesktopSettingsConfig 
   if (
     developerMode !== undefined ||
     hotCpuProfilingEnabled !== undefined ||
+    hotCpuProfilingStartDelayMs !== undefined ||
+    hotCpuProfilingTriggerMode !== undefined ||
+    hotCpuProfilingSlowburnThresholdPercent !== undefined ||
     hotCpuProfilingCaptureHeapSnapshot !== undefined ||
     hotCpuProfilingHeapSnapshotLimit !== undefined ||
     confirmQuitWithInProgressThreads !== undefined ||
@@ -1369,6 +1412,16 @@ function pruneEmptyConfig(config: DesktopSettingsConfig): DesktopSettingsConfig 
     }
     if (hotCpuProfilingEnabled !== undefined) {
       pruned.general.hotCpuProfilingEnabled = hotCpuProfilingEnabled;
+    }
+    if (hotCpuProfilingStartDelayMs !== undefined) {
+      pruned.general.hotCpuProfilingStartDelayMs = hotCpuProfilingStartDelayMs;
+    }
+    if (hotCpuProfilingTriggerMode !== undefined) {
+      pruned.general.hotCpuProfilingTriggerMode = hotCpuProfilingTriggerMode;
+    }
+    if (hotCpuProfilingSlowburnThresholdPercent !== undefined) {
+      pruned.general.hotCpuProfilingSlowburnThresholdPercent =
+        hotCpuProfilingSlowburnThresholdPercent;
     }
     if (hotCpuProfilingCaptureHeapSnapshot !== undefined) {
       pruned.general.hotCpuProfilingCaptureHeapSnapshot =
@@ -1621,6 +1674,22 @@ function readCodexProfileModel(
   value: TomlScalar | undefined,
 ): DesktopCodexProfileModel | undefined {
   return typeof value === "string" && isDesktopCodexProfileModel(value)
+    ? value
+    : undefined;
+}
+
+function readHotCpuProfileStartDelayMs(
+  value: TomlScalar | undefined,
+): DesktopHotCpuProfileStartDelayMs | undefined {
+  return typeof value === "number" && isDesktopHotCpuProfileStartDelayMs(value)
+    ? value
+    : undefined;
+}
+
+function readHotCpuProfileTriggerMode(
+  value: TomlScalar | undefined,
+): DesktopHotCpuProfileTriggerMode | undefined {
+  return typeof value === "string" && isDesktopHotCpuProfileTriggerMode(value)
     ? value
     : undefined;
 }

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -7,6 +7,8 @@ import type {
   DesktopCodexAuthProfileDiscoverySnapshot,
   DesktopCodexProfileModel,
   DesktopGitDiscoverySnapshot,
+  DesktopHotCpuProfileStartDelayMs,
+  DesktopHotCpuProfileTriggerMode,
   DesktopMessagingFullAccessWarningGlobalPolicy,
   DesktopMessagingImageProfile,
   DesktopOnboardingCompletedSource,
@@ -25,6 +27,9 @@ import {
   DESKTOP_APPEARANCE_THEME_DEFAULT,
   DESKTOP_CHAT_REPLY_COMPOSER_DEFAULT,
   DESKTOP_CODEX_PROFILE_MODEL_DEFAULT,
+  DESKTOP_HOT_CPU_PROFILE_SLOWBURN_THRESHOLD_DEFAULT_PERCENT,
+  DESKTOP_HOT_CPU_PROFILE_START_DELAY_DEFAULT_MS,
+  DESKTOP_HOT_CPU_PROFILE_TRIGGER_MODE_DEFAULT,
   DESKTOP_UPDATE_CHANNEL_DEFAULT,
   DESKTOP_WORKTREE_STORAGE_DEFAULT,
 } from "@pwragent/shared";
@@ -403,6 +408,15 @@ export class DesktopSettingsService {
         hotCpuProfilingEnabled: this.resolveConfigBoolean(
           config.general?.hotCpuProfilingEnabled,
           false,
+        ),
+        hotCpuProfilingStartDelayMs: this.resolveHotCpuProfileStartDelayMs(
+          config.general?.hotCpuProfilingStartDelayMs,
+        ),
+        hotCpuProfilingTriggerMode: this.resolveHotCpuProfileTriggerMode(
+          config.general?.hotCpuProfilingTriggerMode,
+        ),
+        hotCpuProfilingSlowburnThresholdPercent: this.resolveHotCpuSlowburnThresholdPercent(
+          config.general?.hotCpuProfilingSlowburnThresholdPercent,
         ),
         hotCpuProfilingCaptureHeapSnapshot: this.resolveConfigBoolean(
           config.general?.hotCpuProfilingCaptureHeapSnapshot,
@@ -870,6 +884,24 @@ export class DesktopSettingsService {
     return this.resolveConfigBoolean(
       this.readConfig().config.general?.hotCpuProfilingCaptureHeapSnapshot,
       false,
+    ).value;
+  }
+
+  resolveHotCpuProfilingStartDelayMs(): DesktopHotCpuProfileStartDelayMs {
+    return this.resolveHotCpuProfileStartDelayMs(
+      this.readConfig().config.general?.hotCpuProfilingStartDelayMs,
+    ).value;
+  }
+
+  resolveHotCpuProfilingTriggerMode(): DesktopHotCpuProfileTriggerMode {
+    return this.resolveHotCpuProfileTriggerMode(
+      this.readConfig().config.general?.hotCpuProfilingTriggerMode,
+    ).value;
+  }
+
+  resolveHotCpuProfilingSlowburnThresholdPercent(): number {
+    return this.resolveHotCpuSlowburnThresholdPercent(
+      this.readConfig().config.general?.hotCpuProfilingSlowburnThresholdPercent,
     ).value;
   }
 
@@ -1341,6 +1373,37 @@ export class DesktopSettingsService {
         Math.max(rounded, MIN_HOT_CPU_HEAP_SNAPSHOT_LIMIT),
         MAX_HOT_CPU_HEAP_SNAPSHOT_LIMIT,
       ),
+      source: configValue === undefined ? "default" : "config",
+    };
+  }
+
+  private resolveHotCpuProfileStartDelayMs(
+    configValue: DesktopHotCpuProfileStartDelayMs | undefined,
+  ): DesktopSettingsValue<DesktopHotCpuProfileStartDelayMs> {
+    return {
+      value: configValue ?? DESKTOP_HOT_CPU_PROFILE_START_DELAY_DEFAULT_MS,
+      source: configValue === undefined ? "default" : "config",
+    };
+  }
+
+  private resolveHotCpuProfileTriggerMode(
+    configValue: DesktopHotCpuProfileTriggerMode | undefined,
+  ): DesktopSettingsValue<DesktopHotCpuProfileTriggerMode> {
+    return {
+      value: configValue ?? DESKTOP_HOT_CPU_PROFILE_TRIGGER_MODE_DEFAULT,
+      source: configValue === undefined ? "default" : "config",
+    };
+  }
+
+  private resolveHotCpuSlowburnThresholdPercent(
+    configValue: number | undefined,
+  ): DesktopSettingsValue<number> {
+    const rounded =
+      configValue === undefined
+        ? DESKTOP_HOT_CPU_PROFILE_SLOWBURN_THRESHOLD_DEFAULT_PERCENT
+        : Math.round(configValue);
+    return {
+      value: Math.min(Math.max(rounded, 1), 100),
       source: configValue === undefined ? "default" : "config",
     };
   }

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -22,10 +22,12 @@ import { attachWindowFocusSync } from "./window-focus-sync";
 import {
   WINDOW_KIND_MAIN,
   registerWindowChannels,
+  subscribersForChannel,
 } from "./window-channels";
 import {
   AGENT_EVENT_CHANNEL,
   APPEARANCE_CHANGED_EVENT_CHANNEL,
+  HOT_CPU_PROFILE_CAPTURED_EVENT_CHANNEL,
   MESSAGING_BINDINGS_CHANGED_EVENT_CHANNEL,
   MESSAGING_PAIRING_CHANGED_EVENT_CHANNEL,
   MESSAGING_PLATFORM_STATUS_EVENT_CHANNEL,
@@ -439,6 +441,13 @@ export function createMainWindow(options?: {
         });
         syncHotCpuProfilersFromSettings("heap-snapshot-limit-reached");
       },
+      onProfileWritten: (event) => {
+        for (const subscriber of subscribersForChannel(
+          HOT_CPU_PROFILE_CAPTURED_EVENT_CHANNEL,
+        )) {
+          subscriber.send(HOT_CPU_PROFILE_CAPTURED_EVENT_CHANNEL, event);
+        }
+      },
       session: created.session,
       target: webContents,
     });
@@ -681,6 +690,7 @@ export function createMainWindow(options?: {
   registerWindowChannels(window, WINDOW_KIND_MAIN, [
     AGENT_EVENT_CHANNEL,
     APPEARANCE_CHANGED_EVENT_CHANNEL,
+    HOT_CPU_PROFILE_CAPTURED_EVENT_CHANNEL,
     MESSAGING_BINDINGS_CHANGED_EVENT_CHANNEL,
     MESSAGING_PAIRING_CHANGED_EVENT_CHANNEL,
     MESSAGING_PLATFORM_STATUS_EVENT_CHANNEL,

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -468,8 +468,11 @@ export function createMainWindow(options?: {
     hotCpuConfig: Extract<ReturnType<typeof resolveHotCpuProfileConfig>, { enabled: true }>,
   ): string => {
     return JSON.stringify({
+      startDelayMs: hotCpuConfig.startDelayMs,
+      triggerMode: hotCpuConfig.triggerMode,
       intervalMs: hotCpuConfig.intervalMs,
       thresholdPercent: hotCpuConfig.thresholdPercent,
+      slowburnThresholdPercent: hotCpuConfig.slowburnThresholdPercent,
       consecutiveSamples: hotCpuConfig.consecutiveSamples,
       profileDurationMs: hotCpuConfig.profileDurationMs,
       cooldownMs: hotCpuConfig.cooldownMs,
@@ -497,6 +500,10 @@ export function createMainWindow(options?: {
           settingsService.resolveHotCpuProfilingHeapSnapshotLimit(),
         outputRoot: resolveHotCpuProfileOutputRoot(),
         repoRoot: resolveRepoRoot(),
+        slowburnThresholdPercent:
+          settingsService.resolveHotCpuProfilingSlowburnThresholdPercent(),
+        startDelayMs: settingsService.resolveHotCpuProfilingStartDelayMs(),
+        triggerMode: settingsService.resolveHotCpuProfilingTriggerMode(),
       });
 
       if (!hotCpuConfig.enabled) {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -206,6 +206,7 @@ import type {
   ImageUploadFallbackResponse,
   ImageUploadNormalizationLogRequest,
 } from "../shared/image-normalization";
+import type { HotCpuProfileCapturedEvent } from "../shared/hot-cpu-profile";
 import {
   AGENT_CANCEL_THREAD_EXECUTION_MODE_QUEUE_CHANNEL,
   AGENT_EVENT_CHANNEL,
@@ -275,6 +276,7 @@ import {
   COMPOSER_DRAFT_SAVE_CHANNEL,
   NAVIGATION_ENSURE_DIRECTORY_LAUNCHPAD_CHANNEL,
   FOCUSED_DIFF_ANALYZE_CHANNEL,
+  HOT_CPU_PROFILE_CAPTURED_EVENT_CHANNEL,
   IMAGE_UPLOAD_FALLBACK_CHANNEL,
   IMAGE_UPLOAD_NORMALIZATION_LOG_CHANNEL,
   MESSAGING_BINDINGS_CHANGED_EVENT_CHANNEL,
@@ -439,6 +441,18 @@ const desktopApi = Object.freeze({
     ipcRenderer.on(APP_UPDATE_STATUS_EVENT_CHANNEL, listener);
     return () => {
       ipcRenderer.off(APP_UPDATE_STATUS_EVENT_CHANNEL, listener);
+    };
+  },
+  onHotCpuProfileCaptured: (
+    callback: (event: HotCpuProfileCapturedEvent) => void,
+  ): (() => void) => {
+    const listener = (
+      _event: Electron.IpcRendererEvent,
+      payload: HotCpuProfileCapturedEvent,
+    ) => callback(payload);
+    ipcRenderer.on(HOT_CPU_PROFILE_CAPTURED_EVENT_CHANNEL, listener);
+    return () => {
+      ipcRenderer.off(HOT_CPU_PROFILE_CAPTURED_EVENT_CHANNEL, listener);
     };
   },
   installAppUpdate: async (): Promise<AppUpdateInstallResult> =>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -43,7 +43,10 @@ import { useQueuedTurnRelease } from "./lib/useQueuedTurnRelease";
 import { CodexConfigWarningBanner } from "./features/codex-config/CodexConfigWarningBanner";
 import { AppNoticeToast } from "./features/notifications/AppNoticeToast";
 import type { AppNoticeToastNotice } from "./features/notifications/AppNoticeToast";
-import { buildHotCpuProfileHandoffMessage } from "../../shared/hot-cpu-profile";
+import {
+  buildHotCpuProfileHandoffMessage,
+  formatHotCpuProfileTriggerSummary,
+} from "../../shared/hot-cpu-profile";
 import { AppUpdateBanner } from "./features/update/AppUpdateBanner";
 import { AutomationsScreen } from "./features/automations/AutomationsScreen";
 
@@ -205,9 +208,13 @@ function DesktopAppShell(props: {
   useEffect(() => {
     return desktopApi?.onHotCpuProfileCaptured?.((event) => {
       setHotCpuProfileNotice({
+        autoDismiss: false,
         id: `hot-cpu-profile:${event.capturedAt}:${event.profileFilename}`,
         title: "CPU profile captured",
-        message: `Saved ${event.profileFilename}. Copy this notice to hand off the profile path.`,
+        message: [
+          `${formatHotCpuProfileTriggerSummary(event)} saved ${event.profileFilename}.`,
+          "Copy this notice to hand off the profile path.",
+        ].join(" "),
         detail: buildHotCpuProfileHandoffMessage(event),
       });
     });

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -43,6 +43,7 @@ import { useQueuedTurnRelease } from "./lib/useQueuedTurnRelease";
 import { CodexConfigWarningBanner } from "./features/codex-config/CodexConfigWarningBanner";
 import { AppNoticeToast } from "./features/notifications/AppNoticeToast";
 import type { AppNoticeToastNotice } from "./features/notifications/AppNoticeToast";
+import { buildHotCpuProfileHandoffMessage } from "../../shared/hot-cpu-profile";
 import { AppUpdateBanner } from "./features/update/AppUpdateBanner";
 import { AutomationsScreen } from "./features/automations/AutomationsScreen";
 
@@ -188,6 +189,8 @@ function DesktopAppShell(props: {
   // AppNoticeToast in the toast stack below, separate from the navigation
   // archive notice so the two never clobber each other.
   const [composerNotice, setComposerNotice] = useState<AppNoticeToastNotice>();
+  const [hotCpuProfileNotice, setHotCpuProfileNotice] =
+    useState<AppNoticeToastNotice>();
   const [ThreadViewComponent, setThreadViewComponent] =
     useState<ComponentType<ThreadViewProps>>();
   const desktopApi = props.desktopApi;
@@ -197,6 +200,17 @@ function DesktopAppShell(props: {
   // OS window with its own lifecycle.
   const openMessagingActivityWindow = useCallback(() => {
     void desktopApi?.openMessagingActivityWindow?.();
+  }, [desktopApi]);
+
+  useEffect(() => {
+    return desktopApi?.onHotCpuProfileCaptured?.((event) => {
+      setHotCpuProfileNotice({
+        id: `hot-cpu-profile:${event.capturedAt}:${event.profileFilename}`,
+        title: "CPU profile captured",
+        message: `Saved ${event.profileFilename}. Copy this notice to hand off the profile path.`,
+        detail: buildHotCpuProfileHandoffMessage(event),
+      });
+    });
   }, [desktopApi]);
   const revealSelectedThreadInList = useCallback(() => {
     const selectedRow = document.querySelector<HTMLElement>(
@@ -845,6 +859,11 @@ function DesktopAppShell(props: {
             desktopApi={desktopApi}
             notice={composerNotice}
             onDismiss={() => setComposerNotice(undefined)}
+          />
+          <AppNoticeToast
+            desktopApi={desktopApi}
+            notice={hotCpuProfileNotice}
+            onDismiss={() => setHotCpuProfileNotice(undefined)}
           />
           <AppUpdateBanner desktopApi={desktopApi} />
         </div>

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -394,6 +394,18 @@ describe("App", () => {
           value: false,
           source: "default",
         },
+        hotCpuProfilingStartDelayMs: {
+          value: 0,
+          source: "default",
+        },
+        hotCpuProfilingTriggerMode: {
+          value: "sustained",
+          source: "default",
+        },
+        hotCpuProfilingSlowburnThresholdPercent: {
+          value: 15,
+          source: "default",
+        },
         hotCpuProfilingCaptureHeapSnapshot: {
           value: false,
           source: "default",

--- a/apps/desktop/src/renderer/src/features/notifications/AppNoticeToast.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/AppNoticeToast.tsx
@@ -6,6 +6,7 @@ import type { DesktopApi } from "../../lib/desktop-api";
 const AUTO_DISMISS_MS = 9_000;
 
 export type AppNoticeToastNotice = {
+  autoDismiss?: boolean;
   id: string;
   title: string;
   message: string;
@@ -20,6 +21,7 @@ export function AppNoticeToast(props: {
   const [paused, setPaused] = useState(false);
   const timeoutRef = useRef<number | undefined>(undefined);
   const onDismissRef = useRef(props.onDismiss);
+  const autoDismiss = props.notice?.autoDismiss !== false;
 
   useEffect(() => {
     onDismissRef.current = props.onDismiss;
@@ -34,7 +36,7 @@ export function AppNoticeToast(props: {
   }, [props.notice?.id]);
 
   useEffect(() => {
-    if (!props.notice || paused) {
+    if (!props.notice || !autoDismiss || paused) {
       return;
     }
 
@@ -49,7 +51,7 @@ export function AppNoticeToast(props: {
         timeoutRef.current = undefined;
       }
     };
-  }, [paused, props.notice?.id]);
+  }, [autoDismiss, paused, props.notice?.id]);
 
   if (!props.notice) {
     return null;
@@ -102,11 +104,13 @@ export function AppNoticeToast(props: {
           <CloseIcon size={14} aria-hidden="true" />
         </button>
       </div>
-      <span
-        className="app-notice-toast__timer"
-        aria-hidden="true"
-        data-paused={paused ? "true" : undefined}
-      />
+      {autoDismiss ? (
+        <span
+          className="app-notice-toast__timer"
+          aria-hidden="true"
+          data-paused={paused ? "true" : undefined}
+        />
+      ) : null}
     </aside>
   );
 }

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeToast.test.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeToast.test.tsx
@@ -60,4 +60,26 @@ describe("AppNoticeToast", () => {
     });
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });
+
+  it("stays visible without a countdown when auto-dismiss is disabled", () => {
+    vi.useFakeTimers();
+    const onDismiss = vi.fn();
+
+    const { container } = render(
+      <AppNoticeToast
+        notice={{ ...notice, autoDismiss: false }}
+        onDismiss={onDismiss}
+      />,
+    );
+
+    expect(container.querySelector(".app-notice-toast__timer")).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss notice" }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
@@ -148,6 +148,10 @@ function updateResultText(result: AppUpdateCheckResult): string {
   return `Update available: v${result.version}. Downloading in the background.`;
 }
 
+function formatHotCpuStartDelay(delayMs: DesktopHotCpuProfileStartDelayMs): string {
+  return delayMs === 0 ? "Immediate" : `Delay ${Math.round(delayMs / 1_000)}s`;
+}
+
 export function GeneralSettings(props: {
   appearanceController?: AppearanceController;
   desktopApi?: DesktopApi;
@@ -183,6 +187,11 @@ export function GeneralSettings(props: {
   const [updateRestartError, setUpdateRestartError] = useState<
     string | undefined
   >();
+  const [hotCpuCountdownEndsAt, setHotCpuCountdownEndsAt] = useState<
+    number | null
+  >(null);
+  const [hotCpuCountdownRemainingMs, setHotCpuCountdownRemainingMs] =
+    useState(0);
   const pastedImageMaxPatches =
     props.snapshot.imageUploads.pastedImageMaxPatches;
   const confirmQuitWithInProgressThreads =
@@ -207,6 +216,49 @@ export function GeneralSettings(props: {
   const activeOption = PASTED_IMAGE_PATCH_OPTIONS.find(
     (option) => option.value === pastedImageMaxPatches.value,
   );
+  const hotCpuCountdownActive = hotCpuCountdownRemainingMs > 0;
+  const hotCpuCountdownSeconds = Math.ceil(hotCpuCountdownRemainingMs / 1_000);
+  const hotCpuStartDelayText = formatHotCpuStartDelay(
+    hotCpuProfilingStartDelayMs.value,
+  );
+
+  useEffect(() => {
+    if (hotCpuCountdownEndsAt === null) {
+      return;
+    }
+
+    const updateCountdown = () => {
+      const remainingMs = Math.max(0, hotCpuCountdownEndsAt - Date.now());
+      setHotCpuCountdownRemainingMs(remainingMs);
+      if (remainingMs === 0) {
+        setHotCpuCountdownEndsAt(null);
+      }
+    };
+
+    updateCountdown();
+    const interval = window.setInterval(updateCountdown, 250);
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, [hotCpuCountdownEndsAt]);
+
+  const startHotCpuCapture = async () => {
+    await props.onHotCpuProfilingEnabledChange(true);
+    if (hotCpuProfilingStartDelayMs.value > 0) {
+      const endsAt = Date.now() + hotCpuProfilingStartDelayMs.value;
+      setHotCpuCountdownEndsAt(endsAt);
+      setHotCpuCountdownRemainingMs(hotCpuProfilingStartDelayMs.value);
+    } else {
+      setHotCpuCountdownEndsAt(null);
+      setHotCpuCountdownRemainingMs(0);
+    }
+  };
+
+  const stopHotCpuCapture = async () => {
+    setHotCpuCountdownEndsAt(null);
+    setHotCpuCountdownRemainingMs(0);
+    await props.onHotCpuProfilingEnabledChange(false);
+  };
 
   useEffect(() => {
     let canceled = false;
@@ -642,17 +694,41 @@ export function GeneralSettings(props: {
           />
           <SettingsField
             label="Hot renderer CPU profiling"
-            sub="Capture a short Chrome CPU profile when the renderer stays hot."
+            sub="Start an armed capture only after the presets below are ready."
             source={sourceBadge(hotCpuProfilingEnabled)}
             control={
-              <SettingsSwitch
-                checked={hotCpuProfilingEnabled.value}
-                disabled={props.saving}
-                label="Hot renderer CPU profiling"
-                onChange={(next) => {
-                  void props.onHotCpuProfilingEnabledChange(next);
-                }}
-              />
+              <div className="settings-hot-cpu-capture">
+                {hotCpuProfilingEnabled.value || hotCpuCountdownActive ? (
+                  <button
+                    type="button"
+                    className="button button--secondary"
+                    disabled={props.saving}
+                    onClick={() => {
+                      void stopHotCpuCapture();
+                    }}
+                  >
+                    Stop Capture
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    className="button button--primary"
+                    disabled={props.saving}
+                    onClick={() => {
+                      void startHotCpuCapture();
+                    }}
+                  >
+                    Start Capture ({hotCpuStartDelayText})
+                  </button>
+                )}
+                <span className="settings-hot-cpu-capture__status" aria-live="polite">
+                  {hotCpuCountdownActive
+                    ? `Starting in ${hotCpuCountdownSeconds}s`
+                    : hotCpuProfilingEnabled.value
+                      ? "Monitoring"
+                      : "Not armed"}
+                </span>
+              </div>
             }
           />
           <SettingsField
@@ -676,7 +752,7 @@ export function GeneralSettings(props: {
                         ? " is-active"
                         : ""
                     }`}
-                    disabled={props.saving || !hotCpuProfilingEnabled.value}
+                    disabled={props.saving}
                     role="radio"
                     type="button"
                     onClick={() => {
@@ -716,7 +792,7 @@ export function GeneralSettings(props: {
                         ? " is-active"
                         : ""
                     }`}
-                    disabled={props.saving || !hotCpuProfilingEnabled.value}
+                    disabled={props.saving}
                     role="radio"
                     type="button"
                     onClick={() => {
@@ -737,7 +813,7 @@ export function GeneralSettings(props: {
           <SettingsField
             label="Smart heap snapshots"
             sub="Capture bounded heap snapshots around the next hot CPU trigger, then turn this option back off."
-            help="This also enables hot renderer CPU profiling so it can arm immediately while the current instance keeps running."
+            help="Arms heap snapshots for the next explicit CPU capture start."
             source={sourceBadge(hotCpuProfilingCaptureHeapSnapshot)}
             control={
               <SettingsSwitch

--- a/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
 import type {
+  DesktopHotCpuProfileStartDelayMs,
+  DesktopHotCpuProfileTriggerMode,
   DesktopSettingsSnapshot,
   DesktopUpdateChannel,
 } from "@pwragent/shared";
@@ -94,6 +96,26 @@ const HOT_CPU_HEAP_SNAPSHOT_LIMIT_OPTIONS: Array<{
   { label: "3 snapshots", meta: "Extra sample", value: 3 },
 ];
 
+const HOT_CPU_START_DELAY_OPTIONS: Array<{
+  label: string;
+  meta: string;
+  value: DesktopHotCpuProfileStartDelayMs;
+}> = [
+  { label: "Immediate", meta: "Arm now", value: 0 },
+  { label: "5 seconds", meta: "Short setup", value: 5_000 },
+  { label: "10 seconds", meta: "Long setup", value: 10_000 },
+];
+
+const HOT_CPU_TRIGGER_MODE_OPTIONS: Array<{
+  label: string;
+  meta: string;
+  value: DesktopHotCpuProfileTriggerMode;
+}> = [
+  { label: "Spike", meta: "> 50%", value: "spike" },
+  { label: "Sustained", meta: "2x > 50%", value: "sustained" },
+  { label: "Slowburn", meta: "2x > 15%", value: "slowburn" },
+];
+
 function releaseVersionText(release: AppUpdateReleaseInfo | undefined): string {
   return release?.version ?? "Unavailable";
 }
@@ -133,6 +155,12 @@ export function GeneralSettings(props: {
   snapshot: DesktopSettingsSnapshot;
   onDeveloperModeChange: (value: boolean) => Promise<void>;
   onHotCpuProfilingEnabledChange: (value: boolean) => Promise<void>;
+  onHotCpuProfilingStartDelayMsChange: (
+    value: DesktopHotCpuProfileStartDelayMs,
+  ) => Promise<void>;
+  onHotCpuProfilingTriggerModeChange: (
+    value: DesktopHotCpuProfileTriggerMode,
+  ) => Promise<void>;
   onHotCpuProfilingCaptureHeapSnapshotChange: (value: boolean) => Promise<void>;
   onHotCpuProfilingHeapSnapshotLimitChange: (value: number) => Promise<void>;
   onConfirmQuitWithInProgressThreadsChange: (value: boolean) => Promise<void>;
@@ -162,6 +190,12 @@ export function GeneralSettings(props: {
   const developerMode = props.snapshot.general.developerMode;
   const hotCpuProfilingEnabled =
     props.snapshot.general.hotCpuProfilingEnabled;
+  const hotCpuProfilingStartDelayMs =
+    props.snapshot.general.hotCpuProfilingStartDelayMs;
+  const hotCpuProfilingTriggerMode =
+    props.snapshot.general.hotCpuProfilingTriggerMode;
+  const hotCpuProfilingSlowburnThresholdPercent =
+    props.snapshot.general.hotCpuProfilingSlowburnThresholdPercent;
   const hotCpuProfilingCaptureHeapSnapshot =
     props.snapshot.general.hotCpuProfilingCaptureHeapSnapshot;
   const hotCpuProfilingHeapSnapshotLimit =
@@ -619,6 +653,85 @@ export function GeneralSettings(props: {
                   void props.onHotCpuProfilingEnabledChange(next);
                 }}
               />
+            }
+          />
+          <SettingsField
+            label="Profiling start delay"
+            sub="Wait before the monitor starts sampling so you can trigger the scenario."
+            source={sourceBadge(hotCpuProfilingStartDelayMs)}
+            control={
+              <div
+                className="settings-segmented"
+                role="radiogroup"
+                aria-label="Profiling start delay"
+              >
+                {HOT_CPU_START_DELAY_OPTIONS.map((option) => (
+                  <button
+                    key={option.value}
+                    aria-checked={
+                      hotCpuProfilingStartDelayMs.value === option.value
+                    }
+                    className={`settings-segmented__button settings-segmented__button--stacked${
+                      hotCpuProfilingStartDelayMs.value === option.value
+                        ? " is-active"
+                        : ""
+                    }`}
+                    disabled={props.saving || !hotCpuProfilingEnabled.value}
+                    role="radio"
+                    type="button"
+                    onClick={() => {
+                      void props.onHotCpuProfilingStartDelayMsChange(
+                        option.value,
+                      );
+                    }}
+                  >
+                    <span>{option.label}</span>
+                    <span className="settings-segmented__meta">
+                      {option.meta}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            }
+          />
+          <SettingsField
+            label="CPU profile trigger"
+            sub="Choose whether one spike, two hot samples, or a lower slowburn starts the capture."
+            help={`Slowburn currently uses ${hotCpuProfilingSlowburnThresholdPercent.value}% across the same consecutive-sample window.`}
+            source={sourceBadge(hotCpuProfilingTriggerMode)}
+            control={
+              <div
+                className="settings-segmented"
+                role="radiogroup"
+                aria-label="CPU profile trigger"
+              >
+                {HOT_CPU_TRIGGER_MODE_OPTIONS.map((option) => (
+                  <button
+                    key={option.value}
+                    aria-checked={
+                      hotCpuProfilingTriggerMode.value === option.value
+                    }
+                    className={`settings-segmented__button settings-segmented__button--stacked${
+                      hotCpuProfilingTriggerMode.value === option.value
+                        ? " is-active"
+                        : ""
+                    }`}
+                    disabled={props.saving || !hotCpuProfilingEnabled.value}
+                    role="radio"
+                    type="button"
+                    onClick={() => {
+                      void props.onHotCpuProfilingTriggerModeChange(
+                        option.value,
+                      );
+                    }}
+                  >
+                    <span>{option.label}</span>
+                    <span className="settings-segmented__meta">
+                      {option.meta}
+                    </span>
+                  </button>
+                ))}
+              </div>
             }
           />
           <SettingsField

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -1,4 +1,6 @@
 import type {
+  DesktopHotCpuProfileStartDelayMs,
+  DesktopHotCpuProfileTriggerMode,
   DesktopSettingsConfigPatch,
   DesktopSettingsSnapshot,
   DesktopMessagingImageProfile,
@@ -322,6 +324,20 @@ function SettingsSectionBody(props: {
         ) => {
           await props.settings.writeConfig({
             general: { hotCpuProfilingEnabled },
+          });
+        }}
+        onHotCpuProfilingStartDelayMsChange={async (
+          hotCpuProfilingStartDelayMs: DesktopHotCpuProfileStartDelayMs,
+        ) => {
+          await props.settings.writeConfig({
+            general: { hotCpuProfilingStartDelayMs },
+          });
+        }}
+        onHotCpuProfilingTriggerModeChange={async (
+          hotCpuProfilingTriggerMode: DesktopHotCpuProfileTriggerMode,
+        ) => {
+          await props.settings.writeConfig({
+            general: { hotCpuProfilingTriggerMode },
           });
         }}
         onHotCpuProfilingCaptureHeapSnapshotChange={async (

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -346,9 +346,6 @@ function SettingsSectionBody(props: {
           await props.settings.writeConfig({
             general: {
               hotCpuProfilingCaptureHeapSnapshot,
-              ...(hotCpuProfilingCaptureHeapSnapshot
-                ? { hotCpuProfilingEnabled: true }
-                : {}),
             },
           });
         }}

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -459,8 +459,8 @@ describe("SettingsScreen", () => {
       "false",
     );
     expect(
-      screen.getByRole("switch", { name: "Hot renderer CPU profiling" }),
-    ).toHaveAttribute("aria-checked", "false");
+      screen.getByRole("button", { name: "Start Capture (Immediate)" }),
+    ).toBeInTheDocument();
     expect(
       screen.getByRole("switch", {
         name: "Confirm quit when threads are in progress",
@@ -488,9 +488,7 @@ describe("SettingsScreen", () => {
       });
     });
 
-    fireEvent.click(
-      screen.getByRole("switch", { name: "Hot renderer CPU profiling" }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: "Start Capture (Immediate)" }));
     await waitFor(() => {
       expect(settings.writeConfig).toHaveBeenCalledWith({
         general: {
@@ -499,6 +497,8 @@ describe("SettingsScreen", () => {
       });
     });
 
+    expect(screen.getByRole("radio", { name: /5 seconds/ })).not.toBeDisabled();
+    expect(screen.getByRole("radio", { name: /Slowburn/ })).not.toBeDisabled();
     expect(
       screen.getByRole("switch", { name: "Smart heap snapshots" }),
     ).toHaveAttribute("aria-checked", "false");
@@ -512,7 +512,6 @@ describe("SettingsScreen", () => {
       expect(settings.writeConfig).toHaveBeenCalledWith({
         general: {
           hotCpuProfilingCaptureHeapSnapshot: true,
-          hotCpuProfilingEnabled: true,
         },
       });
     });

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -76,6 +76,18 @@ function createSnapshot(
         value: false,
         source: "default",
       },
+      hotCpuProfilingStartDelayMs: {
+        value: 0,
+        source: "default",
+      },
+      hotCpuProfilingTriggerMode: {
+        value: "sustained",
+        source: "default",
+      },
+      hotCpuProfilingSlowburnThresholdPercent: {
+        value: 15,
+        source: "default",
+      },
       hotCpuProfilingCaptureHeapSnapshot: {
         value: false,
         source: "default",
@@ -753,6 +765,38 @@ describe("SettingsScreen", () => {
       expect(settings.writeConfig).toHaveBeenCalledWith({
         general: {
           hotCpuProfilingHeapSnapshotLimit: 3,
+        },
+      });
+    });
+  });
+
+  it("saves hot CPU profiling delay and trigger mode presets", async () => {
+    const baseSnapshot = createSnapshot();
+    const settings = createSettingsState(
+      createSnapshot({
+        general: {
+          ...baseSnapshot.general,
+          hotCpuProfilingEnabled: { value: true, source: "config" },
+        },
+      }),
+    );
+
+    render(<SettingsScreen settings={settings} onClose={() => undefined} />);
+
+    fireEvent.click(screen.getByRole("radio", { name: /5 seconds/ }));
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        general: {
+          hotCpuProfilingStartDelayMs: 5000,
+        },
+      });
+    });
+
+    fireEvent.click(screen.getByRole("radio", { name: /Slowburn/ }));
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        general: {
+          hotCpuProfilingTriggerMode: "slowburn",
         },
       });
     });

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -6,6 +6,7 @@ import type {
   ImageUploadFallbackResponse,
   ImageUploadNormalizationLogRequest,
 } from "../../../shared/image-normalization";
+import type { HotCpuProfileCapturedEvent } from "../../../shared/hot-cpu-profile";
 import type {
   AgentEvent,
   AutomationIdRequest,
@@ -241,6 +242,9 @@ export type DesktopApi = {
   readAppUpdateStatus?: () => Promise<AppUpdateStatus>;
   readAppUpdateReleaseVersions?: () => Promise<AppUpdateReleaseVersions>;
   onAppUpdateStatus?: (callback: (status: AppUpdateStatus) => void) => () => void;
+  onHotCpuProfileCaptured?: (
+    callback: (event: HotCpuProfileCapturedEvent) => void,
+  ) => () => void;
   installAppUpdate?: () => Promise<AppUpdateInstallResult>;
   listAutomations?: (
     request?: ListAutomationsRequest,

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5016,6 +5016,19 @@ textarea,
   white-space: nowrap;
 }
 
+.settings-hot-cpu-capture {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.settings-hot-cpu-capture__status {
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 600;
+}
+
 .settings-segmented__button:hover,
 .settings-segmented__button:focus-visible {
   color: var(--text-primary);

--- a/apps/desktop/src/shared/__tests__/hot-cpu-profile.test.ts
+++ b/apps/desktop/src/shared/__tests__/hot-cpu-profile.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { buildHotCpuProfileHandoffMessage } from "../hot-cpu-profile";
+
+describe("hot CPU profile handoff message", () => {
+  it("includes copyable basenames and absolute paths", () => {
+    expect(
+      buildHotCpuProfileHandoffMessage({
+        capturedAt: "2026-06-10T12:00:00.000Z",
+        profileFilename: "renderer-hot-0001.cpuprofile",
+        profilePath:
+          "/Users/test/.pwragent/profiles/dev/diagnostics/hot-cpu/20260610T120000Z/renderer-hot-0001.cpuprofile",
+        sessionDirectory:
+          "/Users/test/.pwragent/profiles/dev/diagnostics/hot-cpu/20260610T120000Z",
+        sessionDirectoryName: "20260610T120000Z",
+      }),
+    ).toBe(
+      [
+        "PwrAgent captured a renderer CPU profile.",
+        "Session basename: 20260610T120000Z",
+        "Session directory path: /Users/test/.pwragent/profiles/dev/diagnostics/hot-cpu/20260610T120000Z",
+        "CPU profile basename: renderer-hot-0001.cpuprofile",
+        "CPU profile path: /Users/test/.pwragent/profiles/dev/diagnostics/hot-cpu/20260610T120000Z/renderer-hot-0001.cpuprofile",
+        "Open the .cpuprofile in Chrome DevTools Performance, or inspect the full session directory for samples, events, and optional heap snapshots.",
+      ].join("\n"),
+    );
+  });
+});

--- a/apps/desktop/src/shared/__tests__/hot-cpu-profile.test.ts
+++ b/apps/desktop/src/shared/__tests__/hot-cpu-profile.test.ts
@@ -12,10 +12,15 @@ describe("hot CPU profile handoff message", () => {
         sessionDirectory:
           "/Users/test/.pwragent/profiles/dev/diagnostics/hot-cpu/20260610T120000Z",
         sessionDirectoryName: "20260610T120000Z",
+        triggerConsecutiveSamples: 2,
+        triggerCpuPercent: 24.25,
+        triggerMode: "slowburn",
+        triggerThresholdPercent: 15,
       }),
     ).toBe(
       [
         "PwrAgent captured a renderer CPU profile.",
+        "Trigger: Slowburn (2 consecutive samples >= 15%; trigger sample 24.3%)",
         "Session basename: 20260610T120000Z",
         "Session directory path: /Users/test/.pwragent/profiles/dev/diagnostics/hot-cpu/20260610T120000Z",
         "CPU profile basename: renderer-hot-0001.cpuprofile",

--- a/apps/desktop/src/shared/hot-cpu-profile.ts
+++ b/apps/desktop/src/shared/hot-cpu-profile.ts
@@ -1,16 +1,60 @@
+export type HotCpuProfileTriggerMode = "spike" | "sustained" | "slowburn";
+
 export type HotCpuProfileCapturedEvent = {
   capturedAt: string;
   profileFilename: string;
   profilePath: string;
   sessionDirectory: string;
   sessionDirectoryName: string;
+  triggerConsecutiveSamples: number;
+  triggerCpuPercent: number;
+  triggerMode: HotCpuProfileTriggerMode;
+  triggerThresholdPercent: number;
 };
+
+function formatPercent(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1);
+}
+
+export function formatHotCpuProfileTriggerMode(
+  mode: HotCpuProfileTriggerMode,
+): string {
+  switch (mode) {
+    case "spike":
+      return "Spike";
+    case "sustained":
+      return "Sustained";
+    case "slowburn":
+      return "Slowburn";
+  }
+}
+
+export function formatHotCpuProfileTriggerSummary(
+  event: Pick<
+    HotCpuProfileCapturedEvent,
+    | "triggerConsecutiveSamples"
+    | "triggerCpuPercent"
+    | "triggerMode"
+    | "triggerThresholdPercent"
+  >,
+): string {
+  const sampleLabel =
+    event.triggerConsecutiveSamples === 1
+      ? "1 sample"
+      : `${event.triggerConsecutiveSamples} consecutive samples`;
+  return [
+    `${formatHotCpuProfileTriggerMode(event.triggerMode)} (`,
+    `${sampleLabel} >= ${formatPercent(event.triggerThresholdPercent)}%; `,
+    `trigger sample ${formatPercent(event.triggerCpuPercent)}%)`,
+  ].join("");
+}
 
 export function buildHotCpuProfileHandoffMessage(
   event: HotCpuProfileCapturedEvent,
 ): string {
   return [
     "PwrAgent captured a renderer CPU profile.",
+    `Trigger: ${formatHotCpuProfileTriggerSummary(event)}`,
     `Session basename: ${event.sessionDirectoryName}`,
     `Session directory path: ${event.sessionDirectory}`,
     `CPU profile basename: ${event.profileFilename}`,

--- a/apps/desktop/src/shared/hot-cpu-profile.ts
+++ b/apps/desktop/src/shared/hot-cpu-profile.ts
@@ -1,0 +1,20 @@
+export type HotCpuProfileCapturedEvent = {
+  capturedAt: string;
+  profileFilename: string;
+  profilePath: string;
+  sessionDirectory: string;
+  sessionDirectoryName: string;
+};
+
+export function buildHotCpuProfileHandoffMessage(
+  event: HotCpuProfileCapturedEvent,
+): string {
+  return [
+    "PwrAgent captured a renderer CPU profile.",
+    `Session basename: ${event.sessionDirectoryName}`,
+    `Session directory path: ${event.sessionDirectory}`,
+    `CPU profile basename: ${event.profileFilename}`,
+    `CPU profile path: ${event.profilePath}`,
+    "Open the .cpuprofile in Chrome DevTools Performance, or inspect the full session directory for samples, events, and optional heap snapshots.",
+  ].join("\n");
+}

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -264,6 +264,8 @@ export const APP_LOG_WINDOW_OPEN_CHANNEL = "app:open-log-window";
 export const APP_UPDATE_CHECK_CHANNEL = "app:check-for-updates";
 export const APP_UPDATE_STATUS_READ_CHANNEL = "app:read-update-status";
 export const APP_UPDATE_STATUS_EVENT_CHANNEL = "app:update-status-event";
+export const HOT_CPU_PROFILE_CAPTURED_EVENT_CHANNEL =
+  "hot-cpu-profile:captured";
 /** Main → renderer push: appearance (theme + density) was written to
  *  the per-profile config.toml by a settings update. Every BrowserWindow
  *  subscribes so secondary windows (changelog, app-log, license,

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -31,6 +31,18 @@ describe("desktop settings contracts", () => {
           value: false,
           source: "default",
         },
+        hotCpuProfilingStartDelayMs: {
+          value: 0,
+          source: "default",
+        },
+        hotCpuProfilingTriggerMode: {
+          value: "sustained",
+          source: "default",
+        },
+        hotCpuProfilingSlowburnThresholdPercent: {
+          value: 15,
+          source: "default",
+        },
         hotCpuProfilingCaptureHeapSnapshot: {
           value: false,
           source: "default",

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -50,6 +50,23 @@ export type DesktopCodexProfileModel =
 export const DESKTOP_CODEX_PROFILE_MODEL_DEFAULT: DesktopCodexProfileModel =
   "shared";
 
+export const DESKTOP_HOT_CPU_PROFILE_START_DELAYS_MS = [0, 5_000, 10_000] as const;
+export type DesktopHotCpuProfileStartDelayMs =
+  (typeof DESKTOP_HOT_CPU_PROFILE_START_DELAYS_MS)[number];
+export const DESKTOP_HOT_CPU_PROFILE_START_DELAY_DEFAULT_MS: DesktopHotCpuProfileStartDelayMs =
+  0;
+
+export const DESKTOP_HOT_CPU_PROFILE_TRIGGER_MODES = [
+  "spike",
+  "sustained",
+  "slowburn",
+] as const;
+export type DesktopHotCpuProfileTriggerMode =
+  (typeof DESKTOP_HOT_CPU_PROFILE_TRIGGER_MODES)[number];
+export const DESKTOP_HOT_CPU_PROFILE_TRIGGER_MODE_DEFAULT: DesktopHotCpuProfileTriggerMode =
+  "sustained";
+export const DESKTOP_HOT_CPU_PROFILE_SLOWBURN_THRESHOLD_DEFAULT_PERCENT = 15;
+
 /**
  * Persisted record that the operator acknowledged the messaging-safety
  * preamble in the first-run wizard. Audit-trail oriented: timestamp + the
@@ -226,6 +243,9 @@ export type DesktopGeneralSettingsSnapshot = {
   confirmQuitWithInProgressThreads: DesktopSettingsValue<boolean>;
   developerMode: DesktopSettingsValue<boolean>;
   hotCpuProfilingEnabled: DesktopSettingsValue<boolean>;
+  hotCpuProfilingStartDelayMs: DesktopSettingsValue<DesktopHotCpuProfileStartDelayMs>;
+  hotCpuProfilingTriggerMode: DesktopSettingsValue<DesktopHotCpuProfileTriggerMode>;
+  hotCpuProfilingSlowburnThresholdPercent: DesktopSettingsValue<number>;
   hotCpuProfilingCaptureHeapSnapshot: DesktopSettingsValue<boolean>;
   hotCpuProfilingHeapSnapshotLimit: DesktopSettingsValue<number>;
   notificationsEnabled: DesktopSettingsValue<boolean>;
@@ -619,6 +639,9 @@ export type DesktopSettingsConfigPatch = {
     confirmQuitWithInProgressThreads?: boolean;
     developerMode?: boolean;
     hotCpuProfilingEnabled?: boolean;
+    hotCpuProfilingStartDelayMs?: DesktopHotCpuProfileStartDelayMs;
+    hotCpuProfilingTriggerMode?: DesktopHotCpuProfileTriggerMode;
+    hotCpuProfilingSlowburnThresholdPercent?: number;
     hotCpuProfilingCaptureHeapSnapshot?: boolean;
     hotCpuProfilingHeapSnapshotLimit?: number;
     notificationsEnabled?: boolean;
@@ -1132,6 +1155,22 @@ export function isDesktopCodexProfileModel(
 ): value is DesktopCodexProfileModel {
   return DESKTOP_CODEX_PROFILE_MODELS.includes(
     value as DesktopCodexProfileModel,
+  );
+}
+
+export function isDesktopHotCpuProfileStartDelayMs(
+  value: number,
+): value is DesktopHotCpuProfileStartDelayMs {
+  return DESKTOP_HOT_CPU_PROFILE_START_DELAYS_MS.includes(
+    value as DesktopHotCpuProfileStartDelayMs,
+  );
+}
+
+export function isDesktopHotCpuProfileTriggerMode(
+  value: string,
+): value is DesktopHotCpuProfileTriggerMode {
+  return DESKTOP_HOT_CPU_PROFILE_TRIGGER_MODES.includes(
+    value as DesktopHotCpuProfileTriggerMode,
   );
 }
 


### PR DESCRIPTION
## Summary

- I replaced the hot renderer CPU profiling toggle with explicit Start/Stop capture actions, so editing diagnostics presets no longer arms the profiler or starts the delay countdown.
- I added Settings presets for hot renderer CPU profiling so an operator can start capture immediately, after 5 seconds, or after 10 seconds before sampling starts.
- I added trigger modes for one-sample spikes over 50%, the existing sustained two-sample threshold over 50%, and slowburn captures over 15% so the profiler can catch continuous moderate CPU usage.
- I persisted the new options in the profile TOML config, included them in hot CPU session manifests/events, and restart the live monitor when armed settings change.
- I added a capture-complete toast that stays visible until manually dismissed and can copy a handoff message containing trigger context, the session basename, session directory path, CPU profile basename, and CPU profile path.

## Verification

- I ran focused Vitest coverage for the shared settings contract, desktop settings service, TOML patch translator, renderer hot CPU profiler, and Settings screen: 123 tests passed.
- I reran focused Settings/profiler tests after the Start/Stop capture change: 105 tests passed.
- I ran focused coverage for the handoff formatter, profiler capture callback, capture toast copy behavior, and Settings screen: 62 tests passed.
- I reran focused coverage for sticky capture toasts, trigger-context formatting, and profiler capture metadata: 13 tests passed.
- I ran `pnpm typecheck`.
- I ran `pnpm lint:boundaries`.
- I ran `git diff --check`.

## Notes

- I did not restart the live Electron dev app for a screenshot because this thread is running through the active PwrAgent instance.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex_GPT--5.5](https://img.shields.io/badge/Codex_GPT--5.5-000000)
