### PR TITLE
fix(desktop): timestamp completed assistant responses

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -2290,6 +2290,58 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("uses turn completion time for final assistant entries without item timestamps", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.readThreadResultByThreadId.set("thread-final-completed-at", {
+      thread: {
+        turns: [
+          {
+            id: "turn-final",
+            status: "completed",
+            startedAt: 1_763_500_100,
+            completedAt: 1_763_500_520,
+            items: [
+              {
+                type: "agentMessage",
+                id: "final-response",
+                phase: "final",
+                text: "Done at completion.",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    const replay = await client.readThread({
+      threadId: "thread-final-completed-at",
+    });
+
+    expect(replay.entries).toEqual([
+      {
+        type: "message",
+        id: "final-response",
+        role: "assistant",
+        text: "Done at completion.",
+        createdAt: 1_763_500_520_000,
+        phase: "final",
+        turn: {
+          id: "turn-final",
+          status: "completed",
+          startedAt: 1_763_500_100_000,
+          completedAt: 1_763_500_520_000,
+        },
+      },
+    ]);
+
+    await client.close();
+  });
+
   it("counts added, removed, and updated FileChange variants from thread/read", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
     MockTransport.readThreadResultByThreadId.set("thread-file-change-counts", {

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -1297,7 +1297,7 @@ function normalizeAgentMessagePhase(
   if (value === "commentary") {
     return "commentary";
   }
-  if (value === "final_answer") {
+  if (value === "final" || value === "final_answer") {
     return "final";
   }
   return undefined;
@@ -3290,6 +3290,12 @@ function sortEntriesByCreatedAt(entries: AppServerThreadEntry[]): AppServerThrea
     .map((item) => item.entry);
 }
 
+function timestampFromRecord(record: Record<string, unknown>): number | undefined {
+  return normalizeEpochTimestamp(
+    pickNumber(record, ["createdAt", "created_at", "timestamp", "time"])
+  );
+}
+
 function extractThreadEntries(value: unknown): AppServerThreadEntry[] {
   const record = asRecord(value);
   const thread = asRecord(record?.thread);
@@ -3343,6 +3349,7 @@ function extractThreadEntries(value: unknown): AppServerThreadEntry[] {
     };
 
     for (const item of rawItems) {
+      const itemCreatedAt = timestampFromRecord(item);
       const itemType = pickString(item, ["type"]);
       const role = normalizeConversationRole(itemType);
       if (role) {
@@ -3355,6 +3362,12 @@ function extractThreadEntries(value: unknown): AppServerThreadEntry[] {
           continue;
         }
         const phase = normalizeAgentMessagePhase(pickString(item, ["phase"]));
+        const messageCreatedAt =
+          itemCreatedAt ??
+          (role === "assistant" && phase === "final"
+            ? turnMetadata?.completedAt
+            : undefined) ??
+          createdAt;
         entries.push({
           type: "message",
           id:
@@ -3363,7 +3376,7 @@ function extractThreadEntries(value: unknown): AppServerThreadEntry[] {
           role,
           text: content.text,
           ...(content.parts ? { parts: content.parts } : {}),
-          createdAt,
+          createdAt: messageCreatedAt,
           ...(turnMetadata ? { turn: turnMetadata } : {}),
           ...(phase ? { phase } : {})
         });
@@ -3400,7 +3413,11 @@ function extractThreadEntries(value: unknown): AppServerThreadEntry[] {
         continue;
       }
 
-      const tokenUsageActivity = summarizeTokenUsageActivity(item, createdAt, turnMetadata);
+      const tokenUsageActivity = summarizeTokenUsageActivity(
+        item,
+        itemCreatedAt ?? turnMetadata?.completedAt ?? createdAt,
+        turnMetadata
+      );
       if (tokenUsageActivity) {
         flushActivityItems();
         entries.push(tokenUsageActivity);

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -1239,6 +1239,130 @@ describe("useThreadSessionState", () => {
     expect(result.current.pendingAssistantMessage).toBeUndefined();
   });
 
+  it("retimestamps streamed final assistant messages when the turn completes", async () => {
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex" | "grok";
+          notification: {
+            method: string;
+            params: Record<string, unknown>;
+          };
+        }) => void)
+      | undefined;
+    const readThread = vi.fn(
+      async ({
+        backend,
+        threadId,
+      }: {
+        backend?: AppServerBackendKind;
+        threadId: string;
+      }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      })
+    );
+
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback as typeof agentEventHandler;
+        return () => undefined;
+      },
+      readThread,
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.response?.replay.entries).toEqual([]);
+    });
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/started",
+          params: {
+            threadId: "thread-1",
+            turn: {
+              id: "turn-1",
+              status: "inProgress",
+              startedAt: 1_763_500_100_000,
+            },
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/agentMessage/delta",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            itemId: "final-message",
+            delta: "Final answer.",
+            phase: "final",
+          },
+        },
+      });
+    });
+
+    const pendingCreatedAt = result.current.pendingAssistantMessage?.createdAt;
+    expect(pendingCreatedAt).toEqual(expect.any(Number));
+    expect(pendingCreatedAt).not.toBe(1_763_500_520_000);
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            turn: {
+              id: "turn-1",
+              status: "completed",
+              startedAt: 1_763_500_100_000,
+              completedAt: 1_763_500_520_000,
+              output: [{ type: "text", text: "Final answer." }],
+            },
+          },
+        },
+      });
+    });
+
+    expect(result.current.entries).toEqual([
+      expect.objectContaining({
+        type: "message",
+        id: "final-message",
+        role: "assistant",
+        phase: "final",
+        text: "Final answer.",
+        createdAt: 1_763_500_520_000,
+        turn: expect.objectContaining({
+          id: "turn-1",
+          status: "completed",
+          startedAt: 1_763_500_100_000,
+          completedAt: 1_763_500_520_000,
+        }),
+      }),
+    ]);
+    expect(result.current.pendingAssistantMessage).toBeUndefined();
+  });
+
   it("renders completed assistant message items without waiting for a transcript reread", async () => {
     let agentEventHandler:
       | ((event: {

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -1706,6 +1706,26 @@ function withTurnMetadataAndPhase(
   };
 }
 
+function withCompletedAssistantTimestamp(
+  entry: AppServerThreadMessageEntry,
+  params: {
+    completedAt: number;
+    phase: AppServerThreadMessageEntry["phase"] | undefined;
+  }
+): AppServerThreadMessageEntry {
+  if (
+    entry.role !== "assistant" ||
+    (params.phase && params.phase !== "final")
+  ) {
+    return entry;
+  }
+
+  return {
+    ...entry,
+    createdAt: params.completedAt,
+  };
+}
+
 function withCompletedResponseTurnMetadata(
   response: AppServerReadThreadResponse | undefined,
   turn: AppServerThreadTurnMetadata | undefined,
@@ -3604,23 +3624,40 @@ export function useThreadSessionState(params: {
           const nextEntries = [
             ...current.optimisticEntries
               .filter((entry): entry is AppServerThreadMessageEntry => entry.type === "message")
-              .map((entry) =>
-                entry.turn?.id === completedTurn?.id
-                  ? withTurnMetadataAndPhase(
+              .map((entry) => {
+                if (entry.turn?.id !== completedTurn?.id) {
+                  return entry;
+                }
+
+                const phase = unphasedAssistantCompletionPhase ?? entry.phase;
+                return withCompletedAssistantTimestamp(
+                  withTurnMetadataAndPhase(
                     entry,
                     completedTurn,
                     unphasedAssistantCompletionPhase
-                  )
-                  : entry
-              ),
+                  ),
+                  {
+                    completedAt: completedTurn?.completedAt ?? nextLastTouchedAt,
+                    phase,
+                  }
+                );
+              }),
             ...(current.pendingAssistantMessage && completedTurnMatchesActive
               ? completedTurnHasReview
                 ? []
                 : [
-                  withTurnMetadataAndPhase(
-                    current.pendingAssistantMessage,
-                    completedTurn,
-                    unphasedAssistantCompletionPhase
+                  withCompletedAssistantTimestamp(
+                    withTurnMetadataAndPhase(
+                      current.pendingAssistantMessage,
+                      completedTurn,
+                      unphasedAssistantCompletionPhase
+                    ),
+                    {
+                      completedAt: completedTurn?.completedAt ?? nextLastTouchedAt,
+                      phase:
+                        unphasedAssistantCompletionPhase ??
+                        current.pendingAssistantMessage.phase,
+                    }
                   ),
                 ]
               : []),
@@ -3637,7 +3674,7 @@ export function useThreadSessionState(params: {
                   phase: "final",
                   ...(completedTurn ? { turn: completedTurn } : {}),
                   text: completedText,
-                  createdAt: Date.now(),
+                  createdAt: completedTurn?.completedAt ?? nextLastTouchedAt,
                 },
                 syntheticFinalSequence
               )


### PR DESCRIPTION
## Summary

- Final assistant messages in the desktop transcript now show completion time instead of the time the response first started streaming.
- Reloaded Codex transcripts now preserve the same behavior by using item timestamps when present and turn completion time for final assistant entries that do not carry their own timestamp.
- The Codex normalizer now recognizes both `final` and `final_answer` assistant phases, matching the live renderer path.

## Verification

- I verified `pnpm test apps/desktop/src/main/__tests__/codex-client.test.ts` passes.
- I verified `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx` passes.
- I verified `pnpm --filter @pwragent/desktop typecheck` passes.
- I verified `git diff --check` passes.

## Notes

- This fixes the case where Telegram showed the final response at delivery time while PwrAgent’s transcript card showed the earlier first-delta time for the same assistant response.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
