### PR TITLE
fix(desktop): keep the pinned context rail from covering the chat + MSG

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -5,7 +5,6 @@ import {
   useRef,
   useState,
   type ComponentType,
-  type CSSProperties,
   type FocusEvent,
   type KeyboardEvent,
   type MouseEvent,
@@ -61,6 +60,18 @@ type ThreadContextPanelProps = {
   onRefreshNavigation?: () => Promise<void>;
   onResizingChange?: (resizing: boolean) => void;
   onWidthChange?: (width: number) => void;
+  /**
+   * Current rail width in px, owned by `ThreadView`. The panel is a
+   * controlled component: `ThreadView` publishes this as `--context-rail-width`
+   * on `.thread-view`, the panel renders at the derived
+   * `--context-rail-effective` (sidebar-capped) that the chat column + header
+   * also reserve, and resizes report back through `onWidthChange`. Keeping a
+   * single width source — instead of a second local copy here — is what
+   * guarantees the panel and its reserved gutter can never disagree (the bug
+   * where a widened rail slid under the MSG cluster on a freshly-created
+   * subthread).
+   */
+  width?: number;
   pinned: boolean;
   platform?: string;
   thread: NavigationThreadSummary;
@@ -78,7 +89,10 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
   const railRef = useRef<HTMLElement>(null);
   const tooltipRef = useRef<HTMLDivElement>(null);
   const [revealed, setRevealed] = useState(false);
-  const [railWidth, setRailWidth] = useState(380);
+  // Width is owned by ThreadView (single source of truth). Used only for the
+  // resize delta math here; the rendered width comes from the inherited
+  // `--context-rail-effective` custom property. No local copy → no desync.
+  const railWidth = props.width ?? 380;
   const [resizing, setResizing] = useState(false);
   const [tooltip, setTooltip] = useState<{
     left?: number;
@@ -348,7 +362,6 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
 
   const resizeRail = (nextWidth: number): void => {
     const clampedWidth = Math.min(560, Math.max(300, nextWidth));
-    setRailWidth(clampedWidth);
     props.onWidthChange?.(clampedWidth);
   };
   const startRailResize = (event: PointerEvent<HTMLElement>): void => {
@@ -386,7 +399,6 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
       className={`context-rail${open ? " is-open" : " is-collapsed"}${
         pinned ? " is-pinned" : ""
       }${resizing ? " is-resizing" : ""}`}
-      style={{ "--context-rail-width": `${railWidth}px` } as CSSProperties}
       onMouseEnter={(event) => {
         rememberMousePosition(event);
         if (!pinned) {

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -2168,9 +2168,7 @@ export function ThreadView(props: ThreadViewProps) {
 
   return (
     <section
-      className={`thread-view${
-        contextRailPinned ? " has-pinned-context-rail" : ""
-      }`}
+      className="thread-view"
       style={
         {
           "--context-rail-width": `${contextRailWidth}px`,

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -2168,7 +2168,9 @@ export function ThreadView(props: ThreadViewProps) {
 
   return (
     <section
-      className="thread-view"
+      className={`thread-view${
+        contextRailPinned ? " has-pinned-context-rail" : ""
+      }`}
       style={
         {
           "--context-rail-width": `${contextRailWidth}px`,
@@ -2399,6 +2401,7 @@ export function ThreadView(props: ThreadViewProps) {
           onRefreshNavigation={props.onRefreshNavigation}
           onResizingChange={setContextRailResizing}
           onWidthChange={setContextRailWidth}
+          width={contextRailWidth}
           pinned={contextRailPinned}
           platform={props.platform}
           thread={selectedThread!}

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -350,6 +350,17 @@ describe("Tangerine Terminal theme contract", () => {
     );
   });
 
+  it("keeps the above-docked live work rail inset to match the chat column", () => {
+    // The bar carries 16px side margins, so its width must leave room for
+    // them (`100% - 32px`). A bare `100%` plus the margins overflows once the
+    // chat column is narrower than --chat-column-max (sidebar + context rail
+    // both open), ramming the bar flush against both edges while the
+    // composer/transcript stay inset.
+    const rule = extractRuleBody(css, ".live-work-rail--dock-above");
+    expect(rule).toContain("width: min(100% - 32px, var(--chat-column-max));");
+    expect(rule).toContain("margin: 0 16px 8px;");
+  });
+
   it("keeps hidden thread row actions from stealing row clicks", () => {
     const actionsRule = extractRuleBody(css, ".thread-row__actions");
 

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -307,33 +307,32 @@ describe("Tangerine Terminal theme contract", () => {
     expect(copyButtonRule).toContain("opacity: 1;");
   });
 
-  it("derives the pinned rail width, gutter, and header reserve from one shared var", () => {
-    // Single source of truth: `--context-rail-effective` is computed once on
-    // `.thread-view`, and the panel renders at it while the chat column +
-    // header reserve that same width (+ spine). Computing it once is what
-    // stops the position:fixed panel from ever rendering wider than its
-    // reserved gutter — the bug where a widened rail slid over the chat +
-    // MSG cluster on a freshly-created subthread. The cap is sidebar-aware
-    // (not a bare `vw`), so a wide rail can't starve the chat on a narrow
-    // window and push the MSG indicators under the rail.
+  it("anchors the context rail below the header and reserves one shared width for the chat", () => {
+    // The rail is anchored to `.thread-view__layout` (absolute), NOT the
+    // window, so it starts below the thread header. The header therefore owns
+    // its full width — it must NOT carry a rail-width gutter (the old
+    // `position: fixed; top: 0` rail overlapped the header and forced the
+    // toggles/MSG to squash, then slide under the rail).
+    expect(extractRuleBody(css, ".context-rail")).toContain(
+      "position: absolute;"
+    );
+    expect(css).not.toMatch(
+      /\.thread-header[^{]*\{[^}]*padding-right:\s*calc\(var\(--context-rail-effective/
+    );
+    // Single source of truth for the chat-side gutter: `--context-rail-effective`
+    // is computed once on `.thread-view`, sidebar-aware (not a bare `vw`) so a
+    // wide rail can't starve the chat on a narrow window. The panel renders at
+    // it and the chat column reserves it (+ the 48px spine) — same value, so
+    // the panel can never render wider than its reserved gutter.
     expect(css).toMatch(
       /--context-rail-effective:\s*min\(\s*var\(--context-rail-width, 380px\),\s*max\(240px, calc\(100vw - var\(--sidebar-width, 408px\) - 448px\)\)\s*\);/
     );
-    // Header status area: explicit `.has-pinned-context-rail` class (robust
-    // across every render branch, even before the fixed panel mounts) plus a
-    // `:has(.context-rail.is-open)` fallback for the hover-reveal overlay.
-    // +60 = effective width + the 48px spine + a small gap.
-    expect(css).toMatch(
-      /\.thread-view\.has-pinned-context-rail \.thread-header,\s*\.thread-view:has\(\.context-rail\.is-open\) \.thread-header\s*\{[\s\S]*?padding-right:\s*calc\(var\(--context-rail-effective, 380px\) \+ 60px\);[\s\S]*?\}/
-    );
-    // Chat column + panel read the exact same effective width.
     expect(css).toContain(
       "padding-right: calc(var(--context-rail-effective, 380px) + 48px);"
     );
     expect(css).toContain("width: var(--context-rail-effective, 380px);");
     // The narrow-width media query must NOT zero the rail gutter or drop the
-    // header reserve to a fixed 56px anymore — doing so left the fixed panel
-    // covering the chat + MSG cluster on narrow windows.
+    // header reserve to a fixed 56px anymore.
     expect(css).not.toMatch(
       /@media \(max-width: 1100px\)[\s\S]*?\.thread-header,[\s\S]*?padding-right:\s*56px;/
     );

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -307,18 +307,35 @@ describe("Tangerine Terminal theme contract", () => {
     expect(copyButtonRule).toContain("opacity: 1;");
   });
 
-  it("reserves opened context rail width for the thread header status area", () => {
-    // + 60px = panel width + the always-visible 48px tab rail (spine) +
-    // a small gap, so the header status area clears both the panel and
-    // the spine when the rail is open/pinned.
+  it("derives the pinned rail width, gutter, and header reserve from one shared var", () => {
+    // Single source of truth: `--context-rail-effective` is computed once on
+    // `.thread-view`, and the panel renders at it while the chat column +
+    // header reserve that same width (+ spine). Computing it once is what
+    // stops the position:fixed panel from ever rendering wider than its
+    // reserved gutter — the bug where a widened rail slid over the chat +
+    // MSG cluster on a freshly-created subthread. The cap is sidebar-aware
+    // (not a bare `vw`), so a wide rail can't starve the chat on a narrow
+    // window and push the MSG indicators under the rail.
     expect(css).toMatch(
-      /\.thread-view:has\(\.context-rail\.is-open\) \.thread-header\s*\{[\s\S]*?padding-right:\s*calc\(min\(var\(--context-rail-width, 380px\), calc\(100% - 32px\)\) \+ 60px\);[\s\S]*?\}/
+      /--context-rail-effective:\s*min\(\s*var\(--context-rail-width, 380px\),\s*max\(240px, calc\(100vw - var\(--sidebar-width, 408px\) - 448px\)\)\s*\);/
     );
+    // Header status area: explicit `.has-pinned-context-rail` class (robust
+    // across every render branch, even before the fixed panel mounts) plus a
+    // `:has(.context-rail.is-open)` fallback for the hover-reveal overlay.
+    // +60 = effective width + the 48px spine + a small gap.
     expect(css).toMatch(
-      /\.thread-view:has\(\.context-rail\.is-pinned\) \.thread-header,\s*\.thread-view:has\(\.thread-view__layout\.has-pinned-context-rail\) \.thread-header\s*\{[\s\S]*?padding-right:\s*calc\(min\(var\(--context-rail-width, 380px\), 42vw\) \+ 60px\);[\s\S]*?\}/
+      /\.thread-view\.has-pinned-context-rail \.thread-header,\s*\.thread-view:has\(\.context-rail\.is-open\) \.thread-header\s*\{[\s\S]*?padding-right:\s*calc\(var\(--context-rail-effective, 380px\) \+ 60px\);[\s\S]*?\}/
     );
-    expect(css).toMatch(
-      /@media \(max-width: 1100px\)\s*\{[\s\S]*?\.thread-view:has\(\.context-rail\.is-open\) \.thread-header,[\s\S]*?padding-right:\s*56px;[\s\S]*?\}/
+    // Chat column + panel read the exact same effective width.
+    expect(css).toContain(
+      "padding-right: calc(var(--context-rail-effective, 380px) + 48px);"
+    );
+    expect(css).toContain("width: var(--context-rail-effective, 380px);");
+    // The narrow-width media query must NOT zero the rail gutter or drop the
+    // header reserve to a fixed 56px anymore — doing so left the fixed panel
+    // covering the chat + MSG cluster on narrow windows.
+    expect(css).not.toMatch(
+      /@media \(max-width: 1100px\)[\s\S]*?\.thread-header,[\s\S]*?padding-right:\s*56px;/
     );
     expect(css).not.toContain("the header reclaims the space");
   });

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -316,6 +316,12 @@ describe("Tangerine Terminal theme contract", () => {
     expect(extractRuleBody(css, ".context-rail")).toContain(
       "position: absolute;"
     );
+    // A media query must NOT flip the rail back to `position: static` (the
+    // old "stack the rail below the chat" narrow-width design) — anchored
+    // absolute, an in-flow full-width rail collapses the chat to zero width.
+    expect(css).not.toMatch(
+      /@media[^{]*\{[\s\S]*?\.context-rail[^{]*\{[^}]*position:\s*static/
+    );
     expect(css).not.toMatch(
       /\.thread-header[^{]*\{[^}]*padding-right:\s*calc\(var\(--context-rail-effective/
     );

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -331,7 +331,7 @@ describe("Tangerine Terminal theme contract", () => {
     // it and the chat column reserves it (+ the 48px spine) — same value, so
     // the panel can never render wider than its reserved gutter.
     expect(css).toMatch(
-      /--context-rail-effective:\s*min\(\s*var\(--context-rail-width, 380px\),\s*max\(240px, calc\(100vw - var\(--sidebar-width, 408px\) - 448px\)\)\s*\);/
+      /--context-rail-effective:\s*min\(\s*var\(--context-rail-width, 380px\),\s*max\(240px, calc\(100vw - var\(--sidebar-reserve, 408px\) - 448px\)\)\s*\);/
     );
     expect(css).toContain(
       "padding-right: calc(var(--context-rail-effective, 380px) + 48px);"
@@ -343,6 +343,11 @@ describe("Tangerine Terminal theme contract", () => {
       /@media \(max-width: 1100px\)[\s\S]*?\.thread-header,[\s\S]*?padding-right:\s*56px;/
     );
     expect(css).not.toContain("the header reclaims the space");
+    // The sidebar-hidden override must zero the reserve so the rail reclaims
+    // the freed space instead of subtracting a sidebar that isn't on screen.
+    expect(css).toMatch(
+      /\.app-shell\[data-sidebar-hidden="true"\][^{]*\{[^}]*--sidebar-reserve:\s*0px;/
+    );
   });
 
   it("keeps hidden thread row actions from stealing row clicks", () => {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -7515,8 +7515,13 @@ textarea,
 .live-work-rail--dock-above {
   /* Cap at the same width as the composer + transcript reading
      column (--chat-column-max) so the rail lines up visually with
-     the composer's input. Issue #495 follow-up. */
-  width: min(100%, var(--chat-column-max));
+     the composer's input. Issue #495 follow-up.
+     Subtract the 16px side margins from the 100% term: when the chat
+     column is narrower than --chat-column-max (the usual case once the
+     sidebar + context rail are both open), a bare `100%` plus the margins
+     overflows the column and rams the bar flush against the sidebar +
+     context rail while the composer/transcript stay inset 16px. */
+  width: min(100% - 32px, var(--chat-column-max));
   align-self: center;
   margin: 0 16px 8px;
   /* Bounded height: composer + transcript should still own the

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -755,20 +755,22 @@ textarea,
   padding-right: 56px;
 }
 
-.thread-view:has(.context-rail.is-open) .thread-header {
-  /* The header sits above `.thread-view__layout`, so the layout's
-     pinned-rail padding does not protect the right-aligned messaging
-     indicators. Reserve the opened rail width here as well; the
-     title/chips shrink first and the status indicators keep their
-     visible slot. */
-  /* + 48px reserves the always-visible tab rail (spine) that now sits at
-     the window edge to the right of the panel. */
-  padding-right: calc(min(var(--context-rail-width, 380px), calc(100% - 32px)) + 60px);
-}
+/* Reserve the rail's gutter on the header so the right-aligned messaging
+   indicators never slide under the fixed rail. Two selectors, identical
+   value: the explicit `.has-pinned-context-rail` class is the robust path
+   (set by `ThreadView` straight from the pinned state, so the reserve is
+   correct in every render branch — even before the position:fixed panel
+   mounts, which a freshly-created subthread passes through), and the
+   `:has(.context-rail.is-open)` path covers the transient hover-reveal
+   overlay while unpinned.
 
-.thread-view:has(.context-rail.is-pinned) .thread-header,
-.thread-view:has(.thread-view__layout.has-pinned-context-rail) .thread-header {
-  padding-right: calc(min(var(--context-rail-width, 380px), 42vw) + 60px);
+   The reserve is the panel's shared effective width (see `.thread-view`)
+   plus the 48px spine, or the panel renders wider than the gutter and
+   covers the chat + MSG cluster. The extra 12px (60 vs the layout's 48)
+   keeps the status indicators a hair clear of the rail edge. */
+.thread-view.has-pinned-context-rail .thread-header,
+.thread-view:has(.context-rail.is-open) .thread-header {
+  padding-right: calc(var(--context-rail-effective, 380px) + 60px);
 }
 
 .thread-header button,
@@ -3879,6 +3881,21 @@ textarea,
   gap: 0;
   min-height: 0;
   overflow: hidden;
+  /* The single source of truth for the pinned rail's rendered width.
+     `.context-panel` renders at exactly this, and `.thread-view__layout`
+     + `.thread-header` reserve exactly this (+ spine) — computed ONCE so
+     the panel and its gutter can never disagree (which is what slid the
+     panel over the chat + MSG cluster).
+
+     The width is the user's chosen `--context-rail-width`, but never wider
+     than what leaves the chat column ~400px after the sidebar + spine. A
+     plain `42vw` cap ignored the sidebar, so on a narrow window a wide rail
+     still starved the chat and the fixed-width MSG cluster overflowed under
+     the rail. `max(240px, …)` keeps the panel usable on tiny windows. */
+  --context-rail-effective: min(
+    var(--context-rail-width, 380px),
+    max(240px, calc(100vw - var(--sidebar-width, 408px) - 448px))
+  );
 }
 
 .settings-screen {
@@ -6494,8 +6511,10 @@ textarea,
      `.composer > *`), so the visual breathing room between the message
      column and the rail comes from the centered chat column's right
      margin. + 48px reserves the always-visible tab rail (spine) that
-     sits at the window edge to the right of the panel. */
-  padding-right: calc(min(var(--context-rail-width, 380px), 42vw) + 48px);
+     sits at the window edge to the right of the panel. Reserve exactly the
+     panel's shared effective width (see `.thread-view`) so the gutter and
+     the panel can never disagree. */
+  padding-right: calc(var(--context-rail-effective, 380px) + 48px);
 }
 
 .thread-view__layout.is-resizing-context-rail {
@@ -9120,8 +9139,12 @@ textarea,
   order: 1;
   display: flex;
   flex-direction: column;
-  flex: 0 0 min(var(--context-rail-width, 380px), calc(100vw - 96px));
-  width: min(var(--context-rail-width, 380px), calc(100vw - 96px));
+  /* Render at the shared effective width (see `.thread-view`). The gutter
+     reserved by `.thread-view__layout` + `.thread-header` is this same var
+     (+ spine), so this position:fixed surface can never be wider than its
+     reserved gutter — which is what slid it over the chat + MSG cluster. */
+  flex: 0 0 var(--context-rail-effective, 380px);
+  width: var(--context-rail-effective, 380px);
   min-width: 0;
   min-height: 0;
   overflow: hidden;
@@ -11894,15 +11917,14 @@ textarea,
     grid-template-columns: minmax(280px, min(var(--sidebar-width, 360px), 360px)) minmax(0, 1fr);
   }
 
-  .thread-view__layout {
-    flex-direction: column;
-    padding-right: 0;
-  }
-
-  .thread-view:has(.context-rail.is-open) .thread-header,
-  .thread-view:has(.thread-view__layout.has-pinned-context-rail) .thread-header {
-    padding-right: 56px;
-  }
+  /* No rail-gutter overrides here. The context rail is `position: fixed`,
+     so its gutter is reserved by `.thread-view__layout` /
+     `.thread-header` from the shared `--context-rail-effective` width,
+     which already scales down with the viewport (it leaves the chat ~400px
+     after the sidebar). Zeroing the reserve at narrow widths (as this
+     block used to) only removed the gutter while the fixed panel kept
+     rendering — covering the chat + MSG cluster. Let the capped reserve
+     ride the window down instead. */
 
   .transcript-list__scroll-bottom {
     left: 50%;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -11927,51 +11927,15 @@ textarea,
     border-bottom: 1px solid var(--border-subtle);
   }
 
-  /* At narrow widths the rail stops floating and stacks below the chat:
-     the tab strip becomes a horizontal row and the open panel sits under
-     it, full width. */
-  .context-rail,
-  .context-rail.is-open,
-  .context-rail.is-pinned {
-    position: static;
-    width: 100%;
-    max-width: none;
-    min-width: 0;
-    flex-basis: auto;
-    flex-direction: column;
-    margin-left: 0;
-    box-shadow: none;
-  }
-
-  .context-rail__spine {
-    order: 0;
-    width: 100%;
-    flex: 0 0 auto;
-    flex-direction: row;
-    align-items: center;
-    padding: 8px;
-    border-left: 0;
-    border-bottom: 1px solid var(--border-subtle);
-  }
-
-  .context-rail__tablist {
-    flex: 0 0 auto;
-    flex-direction: row;
-    width: auto;
-  }
-
-  .context-rail__tablist-spacer {
-    display: none;
-  }
-
-  .context-panel {
-    order: 1;
-    width: 100%;
-    flex-basis: auto;
-    border-left: 0;
-    max-height: 60vh;
-    animation: none;
-  }
+  /* No rail overrides at narrow widths. The rail is anchored to
+     `.thread-view__layout` (position: absolute) and its width is the
+     sidebar-aware `--context-rail-effective`, which already shrinks the
+     panel as the window narrows. The old narrow-width design flipped the
+     rail to `position: static; width: 100%` to stack it below the chat as a
+     horizontal strip — but that only worked while `.thread-view__layout`
+     was `flex-direction: column`. Anchored absolute, a static full-width
+     rail would instead sit in-flow beside the chat and collapse it to zero
+     width, so the rail stays vertical + floating at every width. */
 }
 
 @media (max-width: 820px) {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -748,29 +748,12 @@ textarea,
      22px matches the v2 design's `.pa-thread__header { padding:
      14px 22px }`. */
   padding-left: 22px;
-  /* Reserve space for the position:fixed context-rail spine (48px wide,
-     pinned top-right). Without this padding, anything we render in the
-     header's right-aligned region (messaging status icons, on/off
-     toggle) gets covered by the spine's hamburger button. */
-  padding-right: 56px;
-}
-
-/* Reserve the rail's gutter on the header so the right-aligned messaging
-   indicators never slide under the fixed rail. Two selectors, identical
-   value: the explicit `.has-pinned-context-rail` class is the robust path
-   (set by `ThreadView` straight from the pinned state, so the reserve is
-   correct in every render branch — even before the position:fixed panel
-   mounts, which a freshly-created subthread passes through), and the
-   `:has(.context-rail.is-open)` path covers the transient hover-reveal
-   overlay while unpinned.
-
-   The reserve is the panel's shared effective width (see `.thread-view`)
-   plus the 48px spine, or the panel renders wider than the gutter and
-   covers the chat + MSG cluster. The extra 12px (60 vs the layout's 48)
-   keeps the status indicators a hair clear of the rail edge. */
-.thread-view.has-pinned-context-rail .thread-header,
-.thread-view:has(.context-rail.is-open) .thread-header {
-  padding-right: calc(var(--context-rail-effective, 380px) + 60px);
+  /* The context rail now lives BELOW the header (anchored to
+     `.thread-view__layout`, not the window), so the header owns its full
+     width — no rail gutter to reserve and nothing to squash the toggles /
+     MSG against. Just a small right inset so they don't sit flush to the
+     window edge. */
+  padding-right: 16px;
 }
 
 .thread-header button,
@@ -8970,14 +8953,21 @@ textarea,
 
 .context-rail {
   display: flex;
-  position: fixed;
+  /* Anchored to `.thread-view__layout` (position: relative), NOT the window,
+     so the rail starts BELOW the thread header and spans only the chat area.
+     The header then keeps its full width and never has to reserve a gutter
+     or squash its toggles/MSG to clear a rail that overlaps the title line.
+     `right: 0` lands on the layout's padding edge = the window's right edge;
+     the layout's padding-right reserves the gutter so the transcript /
+     composer sit flush against the rail's left border when pinned. */
+  position: absolute;
   top: 0;
   right: 0;
   bottom: 0;
   z-index: 10;
   flex: 0 0 auto;
   width: max-content;
-  max-width: calc(100vw - 32px);
+  max-width: calc(100% - 32px);
   min-width: 0;
   min-height: 0;
   overflow: visible;
@@ -9002,13 +8992,6 @@ textarea,
 .context-rail.is-pinned {
   z-index: 10;
   box-shadow: none;
-}
-
-/* On Windows the context-rail is position:fixed top:0 — it would slide under
-   the custom title strip (and its tabs under the OS caption buttons). Pin it
-   below the strip instead. */
-:root[data-platform="win32"] .context-rail {
-  top: var(--win-titlebar-h);
 }
 
 /* Vertical tab rail pinned to the window's right edge — always visible. Tool
@@ -11917,13 +11900,12 @@ textarea,
     grid-template-columns: minmax(280px, min(var(--sidebar-width, 360px), 360px)) minmax(0, 1fr);
   }
 
-  /* No rail-gutter overrides here. The context rail is `position: fixed`,
-     so its gutter is reserved by `.thread-view__layout` /
-     `.thread-header` from the shared `--context-rail-effective` width,
-     which already scales down with the viewport (it leaves the chat ~400px
-     after the sidebar). Zeroing the reserve at narrow widths (as this
-     block used to) only removed the gutter while the fixed panel kept
-     rendering — covering the chat + MSG cluster. Let the capped reserve
+  /* No rail-gutter override here. The context rail is anchored to
+     `.thread-view__layout`, which reserves its gutter from the shared
+     `--context-rail-effective` width — already sidebar-aware and scaling
+     down with the viewport (it leaves the chat ~400px). Zeroing the reserve
+     at narrow widths (as this block used to) only removed the gutter while
+     the panel kept rendering, covering the chat. Let the capped reserve
      ride the window down instead. */
 
   .transcript-list__scroll-bottom {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -383,6 +383,11 @@ textarea,
   display: grid;
   position: relative;
   grid-template-columns: var(--sidebar-width, 408px) minmax(0, 1fr);
+  /* The sidebar's actual horizontal footprint. Mirrors `--sidebar-width`
+     while the sidebar is shown; the hidden override below drops it to 0 so
+     downstream reserves (e.g. `--context-rail-effective`) stop subtracting a
+     sidebar that isn't on screen. */
+  --sidebar-reserve: var(--sidebar-width, 408px);
   align-items: stretch;
   height: 100vh;
   height: 100dvh;
@@ -403,6 +408,9 @@ textarea,
    0-width first track and the whole content area collapses to nothing. */
 .app-shell[data-sidebar-hidden="true"] {
   grid-template-columns: minmax(0, 1fr);
+  /* No sidebar on screen — free its footprint so reserves computed from it
+     (the context rail's effective width) reclaim the space. */
+  --sidebar-reserve: 0px;
 }
 
 .app-shell[data-sidebar-hidden="true"] .sidebar {
@@ -3866,18 +3874,22 @@ textarea,
   overflow: hidden;
   /* The single source of truth for the pinned rail's rendered width.
      `.context-panel` renders at exactly this, and `.thread-view__layout`
-     + `.thread-header` reserve exactly this (+ spine) — computed ONCE so
-     the panel and its gutter can never disagree (which is what slid the
-     panel over the chat + MSG cluster).
+     reserves exactly this (+ spine) — computed ONCE so the panel and its
+     gutter can never disagree (which is what slid the panel over the chat
+     + MSG cluster). The header no longer reserves a gutter at all: the rail
+     is anchored below it (see `.context-rail`).
 
      The width is the user's chosen `--context-rail-width`, but never wider
      than what leaves the chat column ~400px after the sidebar + spine. A
      plain `42vw` cap ignored the sidebar, so on a narrow window a wide rail
      still starved the chat and the fixed-width MSG cluster overflowed under
-     the rail. `max(240px, …)` keeps the panel usable on tiny windows. */
+     the rail. `--sidebar-reserve` is the sidebar's real footprint (0px when
+     the sidebar is hidden), so a hidden sidebar hands the freed space to the
+     rail instead of reserving for a sidebar that isn't there. `max(240px, …)`
+     keeps the panel usable on tiny windows. */
   --context-rail-effective: min(
     var(--context-rail-width, 380px),
-    max(240px, calc(100vw - var(--sidebar-width, 408px) - 448px))
+    max(240px, calc(100vw - var(--sidebar-reserve, 408px) - 448px))
   );
 }
 
@@ -9123,9 +9135,9 @@ textarea,
   display: flex;
   flex-direction: column;
   /* Render at the shared effective width (see `.thread-view`). The gutter
-     reserved by `.thread-view__layout` + `.thread-header` is this same var
-     (+ spine), so this position:fixed surface can never be wider than its
-     reserved gutter — which is what slid it over the chat + MSG cluster. */
+     reserved by `.thread-view__layout` is this same var (+ spine), so this
+     absolutely-positioned surface can never be wider than its reserved
+     gutter — which is what slid it over the chat + MSG cluster. */
   flex: 0 0 var(--context-rail-effective, 380px);
   width: var(--context-rail-effective, 380px);
   min-width: 0;


### PR DESCRIPTION
## Summary

The right-side context rail could render wider than the gutter the chat column and thread header reserved for it, so a pinned (or auto-hide) rail slid over the chat's right edge and covered the header's MSG status cluster — most visibly after creating a subthread with the rail pinned. This PR makes the rail's width a single sidebar-aware source of truth, re-anchors the rail **below** the header, removes narrow-width overrides that broke once the rail moved, and fixes an adjacent layout bug spotted in review.

Left sidebar and the app title bar are untouched.

## What changed

**1. Single, sidebar-aware width source.** One `--context-rail-effective` var, computed once on `.thread-view`, drives both the panel width **and** the chat-column reserve, so they can never disagree (the desync was the original slide-over bug). The cap is sidebar-aware — `min(width, max(240px, 100vw − sidebar − 448px))` instead of a bare `42vw` — so a wide rail can't starve the chat on a narrow window. `ThreadContextPanel` is now width-controlled (no second local copy). The reserve is also **sidebar-hidden aware**: a new `--sidebar-reserve` mirrors the sidebar width but drops to `0px` under `[data-sidebar-hidden]`, so hiding the sidebar hands the freed space to the rail instead of reserving for a sidebar that isn't on screen.

**2. Anchor the rail below the thread header.** The rail re-anchors to `.thread-view__layout` (`position: absolute`) so it starts **below** the header instead of overlapping it at `top: 0`. The header reclaims its full width — no rail gutter to reserve, nothing to squash, and the breadcrumb shows the full thread title again. The chat column still reserves the rail's gutter (same shared width) so the transcript/composer stay flush when pinned; hover-reveal still overlays.

**3. Drop the narrow-width rail-stacking overrides.** A `@media (max-width: 1100px)` block used to flip the rail to `position: static; width: 100%` to stack it below the chat as a horizontal strip — but that only worked while `.thread-view__layout` was `flex-direction: column`, the sibling override removed in step 2. Anchored absolute, the static full-width rail instead sat in-flow beside the chat and collapsed `.thread-view__primary` to zero width, so narrow-viewport Desktop E2E specs (review-path wrapping @900, tangerine narrow layout @980, live streaming @900) rendered the transcript at 0px. The overrides are gone; the rail stays vertical + floating at every width and its `--context-rail-effective` width already shrinks the panel as the window narrows.

**4. Inset the above-docked Live Work rail (adjacent pre-existing bug).** `.live-work-rail--dock-above` used `width: min(100%, --chat-column-max)` together with `margin: 0 16px`. Once the chat column is narrower than `--chat-column-max` — the usual case with the sidebar + context rail both open — the `100%` term wins and the 16px margins push the bar's border box out to the container edges, ramming the "Edited files" strip flush against the sidebar and the rail while the composer/transcript stay inset. Capping at `min(100% - 32px, --chat-column-max)` leaves room for the margins so it lines up with the composer. Unrelated to the rail-covering fix; kept as its own commit.

## Verification

- Original slide-over reproduced + diagnosed live with a temporary on-screen overlay reading the real computed widths (panel rect vs. MSG rect, `:has` match, header padding). After the fix, verified live on macOS: rail sits below the header; header is full-width with the MSG cluster + toggles never clipped; pin/unpin and hover-reveal all work; resizing moves the panel and its gutter together (single source); the 1200px max-width-rail case that previously clipped is now clear.
- `pnpm --filter @pwragent/desktop typecheck` ✓
- `pnpm lint:boundaries` ✓ (renderer still imports only `@pwragent/shared`)
- `theme-contract` (37) + `ThreadContextPanel` (15) renderer unit tests ✓. `theme-contract` now locks: rail anchored below the header; header carries no rail gutter; panel + chat reserve derive from one shared var; no media query flips the rail back to `position: static`; the sidebar-hidden override zeroes the reserve; and the dock-above Live Work rail stays inset.
- Narrow-viewport behavior (the @900 / @980 specs that regressed in step 3) is covered by the desktop E2E suite in CI.

## Commits

1. `fix(desktop): stop the pinned context rail covering chat + MSG` — single shared width var + controlled panel.
2. `fix(desktop): anchor the context rail below the thread header` — `position: absolute` below the header.
3. `fix(desktop): drop the narrow-width rail-stacking override` — fixes the zero-width-chat E2E regression introduced by step 2.
4. `fix(desktop): make context rail width sidebar-hidden aware` — adds `--sidebar-reserve`; refreshes two stale comments left by step 2.
5. `fix(desktop): inset the above-docked live work rail` — adjacent pre-existing margin/width overflow.

## Notes

- Step 2 makes step 1's header-reserve robustness moot (the rail no longer touches the header), but step 1's chat-side reservation is still load-bearing for a pinned/widened rail vs. the transcript/composer, so both are kept.
- Net diff is renderer CSS + two small component changes (`ThreadContextPanel` controlled width, `ThreadView` width prop) + test updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
