### PR TITLE
fix(messaging): clean up deleted Telegram topics

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -7901,6 +7901,53 @@ describe("MessagingController", () => {
     });
   });
 
+  it("revokes stale Telegram topic bindings when the message thread no longer exists", async () => {
+    const harness = await createHarness({
+      deliver: async () => ({
+        channel: "telegram",
+        deliveredAt: 1000,
+        outcome: "failed",
+        errorMessage: "Call to 'sendMessage' failed! (400: Bad Request: message thread not found)",
+      }),
+    });
+    await harness.store.upsertBinding({
+      id: "binding:telegram:topic:-1003659063549:405:acp:kimi:thread-1",
+      channel: {
+        channel: "telegram",
+        conversation: {
+          id: "405",
+          kind: "topic",
+          parentId: "-1003659063549",
+        },
+      },
+      backend: "acp:kimi",
+      threadId: "thread-1",
+      authorizedActorIds: ["user-1"],
+      createdAt: 1000,
+      updatedAt: 1000,
+    });
+
+    await harness.controller.handleBackendEvent({
+      backend: "acp:kimi",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+          },
+        },
+      },
+    });
+
+    await expect(
+      harness.store.getBinding("binding:telegram:topic:-1003659063549:405:acp:kimi:thread-1"),
+    ).resolves.toMatchObject({
+      revokedAt: 1000,
+    });
+  });
+
   it("does not resurrect a revoked binding after a failed status refresh returns a surface", async () => {
     const harness = await createHarness({
       deliver: async () => ({

--- a/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
@@ -2412,6 +2412,10 @@ describe("TelegramAdapter", () => {
   it("ignores Telegram forum topic rename service messages", async () => {
     const events: MessagingInboundEvent[] = [];
     const api = createApi();
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+    };
     const adapter = new TelegramAdapter({
       api: api as unknown as TelegramBotApi,
       config: {
@@ -2419,6 +2423,7 @@ describe("TelegramAdapter", () => {
         botToken: "telegram-token",
         authorizedActorIds: [{ id: "42", displayName: "" }],
       },
+      logger,
       pollOnStart: false,
     });
 
@@ -2447,6 +2452,16 @@ describe("TelegramAdapter", () => {
     });
 
     expect(events).toEqual([]);
+    expect(logger.info).toHaveBeenCalledWith(
+      "telegram inbound ignored service message",
+      {
+        chatId: -100777,
+        messageId: 106,
+        messageThreadId: 12,
+        reason: "forum_topic_edited",
+        updateId: 7,
+      },
+    );
   });
 
   it("preserves Telegram General topic id in opaque routing state", async () => {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -11839,7 +11839,11 @@ function isTurnInProgressStartError(error: unknown): boolean {
 function isPermanentMessagingTargetFailure(result: MessagingDeliveryResult): boolean {
   return (
     result.outcome === "failed" &&
-    Boolean(result.errorMessage?.match(/\bUnknown Channel\b|chat not found/i))
+    Boolean(
+      result.errorMessage?.match(
+        /\bUnknown Channel\b|chat not found|message thread not found/i,
+      ),
+    )
   );
 }
 

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -100,6 +100,7 @@ type TelegramTypingSignal = {
 
 export type TelegramProviderLogger = {
   debug(message: string, data?: Record<string, unknown>): void;
+  info?(message: string, data?: Record<string, unknown>): void;
   warn?(message: string, data?: Record<string, unknown>): void;
 };
 
@@ -1384,14 +1385,27 @@ export class TelegramAdapter implements TelegramProviderAdapter {
     }
 
     const serviceMessageReason = telegramServiceMessageReason(message);
-    if (serviceMessageReason || this.isOwnBotUser(message.from)) {
+    if (serviceMessageReason) {
       // Forum topic create/edit service messages carry the topic name
       // — capture it before the early-return so the next regular
       // message in that topic can populate `channel.conversation.title`
       // for the binding chip. Telegram has no other API to fetch this.
       this.captureForumTopicNameIfPresent(message);
+      const logServiceMessage = this.options.logger?.info ?? this.options.logger?.debug;
+      logServiceMessage?.("telegram inbound ignored service message", {
+        chatId: message.chat.id,
+        messageId: message.message_id,
+        messageThreadId: message.message_thread_id,
+        reason: serviceMessageReason,
+        updateId,
+      });
+      return;
+    }
+
+    if (this.isOwnBotUser(message.from)) {
+      this.captureForumTopicNameIfPresent(message);
       this.options.logger?.debug(
-        `telegram inbound ignored update=${updateId} message=${message.message_id} reason=${serviceMessageReason ?? "own_bot"} chat=${message.chat.id}`,
+        `telegram inbound ignored update=${updateId} message=${message.message_id} reason=own_bot chat=${message.chat.id}`,
       );
       return;
     }


### PR DESCRIPTION
## Summary

- I made Telegram topic lifecycle service messages visible in normal app logs, so `forum_topic_closed` and `forum_topic_reopened` are easy to confirm from the dev profile log without enabling debug collection.
- I fixed stale Telegram topic bindings after a topic is deleted outside PwrAgent. When Telegram returns `400: Bad Request: message thread not found`, PwrAgent now treats that as a permanent target failure and revokes the binding so the desktop chip can disappear.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/telegram-adapter.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts -t "revokes stale Telegram topic bindings when the message thread no longer exists"`
- `pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts`

## Notes

- I verified the regression test failed before the classifier change and passed afterward.
- Closed topics remain resumable when reopened; deleted topics are cleaned up after the first permanent delivery failure.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
