### PR TITLE
fix(messaging): prefer transcript tail for resume repost

### DIFF
--- a/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
@@ -7,6 +7,43 @@ import type { DesktopBackendRegistry } from "../app-server/backend-registry";
 import { DesktopMessagingBackendBridge } from "../messaging/desktop-backend-bridge";
 
 describe("DesktopMessagingBackendBridge", () => {
+  it("prefers newer transcript assistant entries over stale replay messages", async () => {
+    const bridge = createBridge({
+      entries: [
+        {
+          type: "message",
+          id: "newer-entry",
+          role: "assistant",
+          text: "Actually latest bot reply.",
+          createdAt: 3_000,
+        },
+      ],
+      messages: [
+        {
+          id: "stale-message",
+          role: "assistant",
+          text: "Stale nested response item.",
+          createdAt: 1_000,
+        },
+      ],
+      lastAssistantMessage: "Stale nested response item.",
+      pagination: {
+        supportsPagination: false,
+        hasPreviousPage: false,
+      },
+    });
+
+    await expect(
+      bridge.readThreadLastAssistantReply({
+        backend: "codex",
+        threadId: "thread-1",
+      }),
+    ).resolves.toEqual({
+      text: "Actually latest bot reply.",
+      createdAt: 3_000,
+    });
+  });
+
   it("prefers the latest replay message over older transcript entries", async () => {
     const bridge = createBridge({
       entries: [

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -114,7 +114,17 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
       limit: 20,
       threadId: request.threadId,
     });
+    const entryReply = findLastAssistantEntryReply(response.replay);
     const messageReply = findLastAssistantMessageReply(response.replay);
+    if (entryReply && messageReply) {
+      if (isReplyNewer(messageReply, entryReply)) {
+        return messageReply;
+      }
+      return entryReply;
+    }
+    if (entryReply) {
+      return entryReply;
+    }
     if (messageReply) {
       return messageReply;
     }
@@ -129,7 +139,7 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
         ...(createdAt ? { createdAt } : {}),
       };
     }
-    return findLastAssistantEntryReply(response.replay);
+    return undefined;
   }
 
   async handoffThreadWorkspace(
@@ -299,4 +309,17 @@ function findLastAssistantEntryCreatedAt(
     }
   }
   return undefined;
+}
+
+function isReplyNewer(
+  candidate: MessagingLastAssistantReply,
+  current: MessagingLastAssistantReply,
+): boolean {
+  return (
+    typeof candidate.createdAt === "number" &&
+    Number.isFinite(candidate.createdAt) &&
+    typeof current.createdAt === "number" &&
+    Number.isFinite(current.createdAt) &&
+    candidate.createdAt > current.createdAt
+  );
 }


### PR DESCRIPTION
## Summary

- Messaging resume reposts now use the actual assistant transcript tail instead of letting a stale replay message win the "Last Bot Reply" card.
- This fixes cases where a resumed bound thread could show an ancient bot reply even though the thread had newer assistant output.
- Codex replay messages now inherit `startedAt` from turn records, so same-text assistant replies from newer turns are not collapsed behind older timestamped copies.
- Replay messages can still win the resume repost when they carry a strictly newer timestamp, but otherwise the chronological transcript entries are authoritative.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/codex-client.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`

## Notes

- Added a regression that fails when a newer assistant transcript entry is ignored in favor of an older replay message.
- Added a Codex replay regression for same-text assistant replies where the older copy has a timestamp and the newer turn-shaped reply only had `startedAt`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
