### PR TITLE
fix(desktop): derive environment setup from config

### DIFF
--- a/apps/desktop/e2e/codex-environment-setup.spec.ts
+++ b/apps/desktop/e2e/codex-environment-setup.spec.ts
@@ -588,7 +588,6 @@ test("directory launchpad keeps selected environment controls after snapshot rel
           patch: {
             codexEnvironmentId: "environment",
             codexEnvironmentExecutionTarget: "local",
-            codexEnvironmentSetupEnabled: true,
             workMode: "worktree",
           },
           stickySettingsChanged: true,

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -3771,7 +3771,6 @@ script = "echo setup"
           model: "kimi-for-coding",
           codexEnvironmentId: "environment",
           codexEnvironmentExecutionTarget: "local",
-          codexEnvironmentSetupEnabled: true,
           createdAt: 1_000,
           updatedAt: 2_000,
         },
@@ -6336,7 +6335,6 @@ script = "pnpm install"
           backend: "acp:kimi" as AcpBackendId,
           codexEnvironmentId: undefined,
           codexEnvironmentExecutionTarget: undefined,
-          codexEnvironmentSetupEnabled: false,
           codexEnvironmentActionId: undefined,
         },
       });
@@ -7774,8 +7772,10 @@ command = '''node -e "require('node:fs').writeFileSync(process.argv[1], 'action-
         if (
           a?.status === "exited" &&
           b?.status === "exited" &&
-          a.output === "A-output-marker" &&
-          b.output === "B-output-marker"
+          a.output?.includes("A-output-marker") &&
+          !a.output.includes("B-output-marker") &&
+          b.output?.includes("B-output-marker") &&
+          !b.output.includes("A-output-marker")
         ) {
           // Sanity-check the runId attribution: each invocation's return
           // value's run should match the overlay's persisted entry.
@@ -8102,7 +8102,6 @@ script = "printf setup-output"
           reasoningEffort: "high",
           codexEnvironmentId: "environment",
           codexEnvironmentExecutionTarget: "local",
-          codexEnvironmentSetupEnabled: true,
           createdAt: 1_000,
           updatedAt: 2_000,
         },
@@ -8705,7 +8704,8 @@ script = "printf setup-failed && exit 42"
           model: "gpt-5.5",
           reasoningEffort: "high",
           codexEnvironmentId: "environment",
-          codexEnvironmentSetupEnabled: true,
+          // Deprecated persisted flag must not suppress config-driven setup.
+          codexEnvironmentSetupEnabled: false,
           createdAt: 1_000,
           updatedAt: 2_000,
         },

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -3802,7 +3802,6 @@ describe("MessagingController", () => {
         workMode: "local",
         codexEnvironmentId: "repo",
         codexEnvironmentExecutionTarget: "local",
-        codexEnvironmentSetupEnabled: true,
         codexEnvironmentOptions: [
           {
             id: "repo",
@@ -3896,7 +3895,6 @@ describe("MessagingController", () => {
         launchpad: expect.objectContaining({
           codexEnvironmentId: "ci",
           codexEnvironmentExecutionTarget: "local",
-          codexEnvironmentSetupEnabled: true,
         }),
       }),
       expectMaterializeOptions(),
@@ -4609,7 +4607,6 @@ describe("MessagingController", () => {
       patch: expect.objectContaining({
         codexEnvironmentId: "dev-env",
         codexEnvironmentExecutionTarget: "local",
-        codexEnvironmentSetupEnabled: true,
       }),
     });
     expect(harness.delivered.at(-1)).toMatchObject({
@@ -4637,7 +4634,6 @@ describe("MessagingController", () => {
         launchpad: expect.objectContaining({
           codexEnvironmentId: "dev-env",
           codexEnvironmentExecutionTarget: "local",
-          codexEnvironmentSetupEnabled: true,
         }),
       }),
       expectMaterializeOptions(),
@@ -4660,7 +4656,6 @@ describe("MessagingController", () => {
         workMode: "local",
         codexEnvironmentId: "repo",
         codexEnvironmentExecutionTarget: "local",
-        codexEnvironmentSetupEnabled: true,
         codexEnvironmentActionId: "repo-setup",
         codexEnvironmentOptions: [
           {
@@ -4708,7 +4703,6 @@ describe("MessagingController", () => {
       patch: expect.objectContaining({
         codexEnvironmentId: "ci",
         codexEnvironmentExecutionTarget: "local",
-        codexEnvironmentSetupEnabled: true,
         codexEnvironmentActionId: undefined,
       }),
     });
@@ -4719,7 +4713,6 @@ describe("MessagingController", () => {
     expect(materializeRequest?.launchpad).toMatchObject({
       codexEnvironmentId: "ci",
       codexEnvironmentExecutionTarget: "local",
-      codexEnvironmentSetupEnabled: true,
     });
     expect(materializeRequest?.launchpad.codexEnvironmentActionId).toBeUndefined();
   });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1798,8 +1798,6 @@ async function resetLaunchpadAfterMaterialize(params: {
     codexEnvironmentId: launchpad.codexEnvironmentId,
     codexEnvironmentExecutionTarget:
       launchpad.codexEnvironmentExecutionTarget ?? "local",
-    codexEnvironmentSetupEnabled:
-      launchpad.codexEnvironmentSetupEnabled ?? true,
     createdAt: now,
     updatedAt: now,
   });

--- a/apps/desktop/src/main/app-server/codex-environment-config.ts
+++ b/apps/desktop/src/main/app-server/codex-environment-config.ts
@@ -88,9 +88,12 @@ export function withCodexEnvironmentOptions(
   launchpad: NavigationLaunchpadDraft,
   options: CodexEnvironmentOption[],
 ): NavigationLaunchpadDraft {
+  const launchpadWithoutDeprecatedSetupFlag = { ...launchpad };
+  delete launchpadWithoutDeprecatedSetupFlag.codexEnvironmentSetupEnabled;
+
   if (options.length === 0) {
     return {
-      ...launchpad,
+      ...launchpadWithoutDeprecatedSetupFlag,
       codexEnvironmentId: undefined,
       codexEnvironmentActionId: undefined,
       codexEnvironmentOptions: [],
@@ -101,13 +104,10 @@ export function withCodexEnvironmentOptions(
     (environment) => environment.id === launchpad.codexEnvironmentId,
   );
   return {
-    ...launchpad,
+    ...launchpadWithoutDeprecatedSetupFlag,
     codexEnvironmentId: selectedEnvironment?.id,
     codexEnvironmentExecutionTarget:
       launchpad.codexEnvironmentExecutionTarget ?? "local",
-    codexEnvironmentSetupEnabled:
-      launchpad.codexEnvironmentSetupEnabled ??
-      Boolean(selectedEnvironment?.setupScript),
     codexEnvironmentActionId: undefined,
     codexEnvironmentOptions: options,
   };

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -4581,11 +4581,6 @@ export class MessagingController {
       await this.deliverInvalidBrowseSelection(event);
       return;
     }
-    const codexEnvironmentSetupEnabled = environment
-      ? directory?.launchpad?.codexEnvironmentId === environment.id
-        ? directory.launchpad.codexEnvironmentSetupEnabled ?? Boolean(environment.setupScript)
-        : Boolean(environment.setupScript)
-      : false;
     const codexEnvironmentActionId =
       environment && directory?.launchpad?.codexEnvironmentId === environment.id
         ? directory.launchpad.codexEnvironmentActionId
@@ -4593,7 +4588,6 @@ export class MessagingController {
     await this.updateNewThreadStickySettings(session, {
       codexEnvironmentId: environment?.id,
       codexEnvironmentExecutionTarget: environment ? "local" : undefined,
-      codexEnvironmentSetupEnabled,
       codexEnvironmentActionId,
     });
     await this.presentNewThreadPromptGate(
@@ -4603,7 +4597,6 @@ export class MessagingController {
           ...session.preferences,
           codexEnvironmentId: environment?.id ?? null,
           codexEnvironmentExecutionTarget: environment ? "local" : undefined,
-          codexEnvironmentSetupEnabled,
           codexEnvironmentActionId: codexEnvironmentActionId ?? null,
           updatedAt: this.now(),
         },
@@ -10973,7 +10966,6 @@ type NewThreadOptionsSummary = {
   codexEnvironmentExecutionTarget?: "local" | "remote";
   codexEnvironmentId?: string | null;
   codexEnvironmentOptions: CodexEnvironmentOption[];
-  codexEnvironmentSetupEnabled?: boolean;
   executionMode: ThreadExecutionMode;
   executionModeSource: "session" | "directory-launchpad" | "launchpad-defaults";
   fastMode: boolean;
@@ -11050,11 +11042,6 @@ function newThreadOptionsForSession(
   const selectedEnvironment = codexEnvironmentOptions.find(
     (environment) => environment.id === codexEnvironmentId,
   );
-  const codexEnvironmentSetupEnabled = selectedEnvironment
-    ? session.preferences?.codexEnvironmentSetupEnabled ??
-      directoryLaunchpad?.codexEnvironmentSetupEnabled ??
-      Boolean(selectedEnvironment.setupScript)
-    : false;
   return {
     backend: backend.kind,
     backendLabel: backend.label,
@@ -11071,7 +11058,6 @@ function newThreadOptionsForSession(
       : undefined,
     codexEnvironmentId: selectedEnvironment?.id ?? (codexEnvironmentId === null ? null : undefined),
     codexEnvironmentOptions,
-    codexEnvironmentSetupEnabled,
     executionMode,
     executionModeSource,
     fastMode:
@@ -12151,10 +12137,6 @@ function launchpadForMessagingProject(params: {
       params.preferences?.codexEnvironmentId === null
         ? undefined
         : params.options.codexEnvironmentExecutionTarget,
-    codexEnvironmentSetupEnabled:
-      params.preferences?.codexEnvironmentId === null
-        ? false
-        : params.options.codexEnvironmentSetupEnabled,
     codexEnvironmentActionId:
       params.preferences?.codexEnvironmentId === null
         ? undefined

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -137,7 +137,6 @@ type ComposerProps = {
         | "branchName"
         | "codexEnvironmentId"
         | "codexEnvironmentExecutionTarget"
-        | "codexEnvironmentSetupEnabled"
         | "codexEnvironmentActionId"
         | "directoryLabel"
         | "directoryPath"
@@ -4041,7 +4040,6 @@ export function Composer(props: ComposerProps) {
         | "branchName"
         | "codexEnvironmentId"
         | "codexEnvironmentExecutionTarget"
-        | "codexEnvironmentSetupEnabled"
         | "codexEnvironmentActionId"
       >
     >
@@ -5566,7 +5564,6 @@ export function Composer(props: ComposerProps) {
                   fastMode: undefined,
                   codexEnvironmentId: undefined,
                   codexEnvironmentExecutionTarget: undefined,
-                  codexEnvironmentSetupEnabled: false,
                   codexEnvironmentActionId: undefined,
                 });
               }}
@@ -5971,9 +5968,6 @@ export function Composer(props: ComposerProps) {
                     codexEnvironmentExecutionTarget: environment
                       ? props.launchpad?.codexEnvironmentExecutionTarget ?? "local"
                       : undefined,
-                    codexEnvironmentSetupEnabled: Boolean(
-                      environment?.setupScript,
-                    ),
                     codexEnvironmentActionId: undefined,
                   });
                 }}

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1048,7 +1048,6 @@ describe("Composer", () => {
           prompt: "",
           workMode: "local",
           codexEnvironmentId: "environment",
-          codexEnvironmentSetupEnabled: true,
           codexEnvironmentOptions: [
             {
               id: "environment",
@@ -1123,7 +1122,6 @@ describe("Composer", () => {
       expect.objectContaining({
         codexEnvironmentId: "environment",
         codexEnvironmentExecutionTarget: "local",
-        codexEnvironmentSetupEnabled: true,
       }),
       expect.any(Object),
     );

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1969,14 +1969,13 @@ export function ThreadView(props: ThreadViewProps) {
       (sameWorktreeSubthread && selectedLaunchpad.branchName
         ? "Git worktree"
         : "Directory context only");
-    const launchpadRunningCodexEnvironmentSetup = Boolean(
-      selectedLaunchpad.codexEnvironmentId &&
-        selectedLaunchpad.codexEnvironmentSetupEnabled,
-    );
     const selectedLaunchpadCodexEnvironment =
       selectedLaunchpad.codexEnvironmentOptions?.find(
         (environment) => environment.id === selectedLaunchpad.codexEnvironmentId,
       );
+    const launchpadRunningCodexEnvironmentSetup = Boolean(
+      selectedLaunchpadCodexEnvironment?.setupScript,
+    );
     const handleMaterializeLaunchpad: NonNullable<
       ThreadViewProps["onMaterializeLaunchpad"]
     > = async (directoryKey, input, collaborationMode, reviewTarget) => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -380,6 +380,99 @@ describe("ThreadView", () => {
     expect(screen.getByRole("group", { name: "Messaging platform status" })).toBeInTheDocument();
   });
 
+  it("shows environment setup details from config even when the deprecated setup flag is false", async () => {
+    const selectedDirectory = {
+      key: "directory:/repo",
+      kind: "directory",
+      label: "PwrSnap",
+      path: "/repo",
+      threadKeys: [],
+      needsAttentionCount: 0,
+    } satisfies NavigationDirectorySummary;
+    const selectedLaunchpad = {
+      backend: "codex",
+      createdAt: 1000,
+      directoryKey: selectedDirectory.key,
+      directoryKind: selectedDirectory.kind,
+      directoryLabel: selectedDirectory.label,
+      directoryPath: selectedDirectory.path,
+      executionMode: "full-access",
+      prompt: "Investigate clipboard filenames",
+      updatedAt: 1000,
+      workMode: "worktree",
+      codexEnvironmentId: "environment",
+      codexEnvironmentExecutionTarget: "local",
+      // Deprecated persisted value from older launchpad rows.
+      codexEnvironmentSetupEnabled: false,
+      codexEnvironmentOptions: [
+        {
+          id: "environment",
+          name: "PwrSnap",
+          sourcePath: "/repo/.codex/environments/environment.toml",
+          setupScript: "nvm install\ncorepack enable\npnpm install",
+          actions: [],
+        },
+      ],
+    } satisfies NavigationLaunchpadDraft;
+    const onMaterializeLaunchpad = vi.fn(() => new Promise<void>(() => {}));
+
+    render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[
+          {
+            kind: "codex",
+            label: "Codex app server",
+            available: true,
+            methods: ["thread/list", "thread/read", "turn/start", "skills/list"],
+            capabilities: {
+              listThreads: true,
+              createThread: true,
+              resumeThread: true,
+              renameThread: false,
+              readThread: true,
+              startTurn: true,
+              interruptTurn: false,
+              steerTurn: false,
+              transcriptPagination: true,
+              toolUse: false,
+              approvalRequests: false,
+              multiDirectoryThreads: true,
+            },
+            executionModes: [
+              {
+                mode: "full-access",
+                label: "Full Access",
+                available: true,
+                isDefault: true,
+              },
+            ],
+          },
+        ]}
+        clearPendingRequest={() => undefined}
+        composerDisabled={false}
+        loading={false}
+        loadingMore={false}
+        messageCount={0}
+        selectedDirectory={selectedDirectory}
+        selectedLaunchpad={selectedLaunchpad}
+        skills={[]}
+        transcriptEntries={[]}
+        onLoadOlder={async () => undefined}
+        onMaterializeLaunchpad={onMaterializeLaunchpad}
+        removeOptimisticMessage={(_id) => undefined}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Start thread" }));
+
+    expect(
+      await screen.findByRole("heading", { name: "Running environment setup" }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Setup command")).toHaveTextContent("pnpm install");
+    expect(screen.getAllByText("PwrSnap").length).toBeGreaterThan(0);
+  });
+
   it("keeps launch failures closable from the pending setup screen", async () => {
     const selectedDirectory = {
       key: "directory:/repo",

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -2529,7 +2529,6 @@ describe("useThreadNavigation", () => {
       branchName: "main",
       codexEnvironmentId: "environment",
       codexEnvironmentExecutionTarget: "local" as const,
-      codexEnvironmentSetupEnabled: true,
       codexEnvironmentOptions: [
         {
           id: "environment",
@@ -2599,7 +2598,6 @@ describe("useThreadNavigation", () => {
           prompt: "typing",
           codexEnvironmentId: undefined,
           codexEnvironmentExecutionTarget: undefined,
-          codexEnvironmentSetupEnabled: undefined,
           codexEnvironmentOptions: [],
           updatedAt: 2,
         },
@@ -2611,7 +2609,6 @@ describe("useThreadNavigation", () => {
       prompt: "typing",
       codexEnvironmentId: "environment",
       codexEnvironmentExecutionTarget: "local",
-      codexEnvironmentSetupEnabled: true,
       codexEnvironmentOptions: [
         expect.objectContaining({
           id: "environment",

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -1464,7 +1464,6 @@ function mergeLaunchpadUpdateResponse(
   preserveSetting("parentThreadTitle");
   preserveEnvironment("codexEnvironmentId");
   preserveEnvironment("codexEnvironmentExecutionTarget");
-  preserveEnvironment("codexEnvironmentSetupEnabled");
   preserveEnvironment("codexEnvironmentActionId");
   preserveEnvironment("codexEnvironmentOptions");
 

--- a/packages/agent-core/src/domain/navigation-state.ts
+++ b/packages/agent-core/src/domain/navigation-state.ts
@@ -490,8 +490,6 @@ export function buildNavigationSnapshotHash(params: {
               directory.launchpad.codexEnvironmentId ?? null,
             codexEnvironmentExecutionTarget:
               directory.launchpad.codexEnvironmentExecutionTarget ?? null,
-            codexEnvironmentSetupEnabled:
-              directory.launchpad.codexEnvironmentSetupEnabled ?? null,
             codexEnvironmentActionId:
               directory.launchpad.codexEnvironmentActionId ?? null,
             codexEnvironmentOptions: (

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -958,6 +958,11 @@ export type MessagingBindingPreferences = {
   codexEnvironmentActionId?: string | null;
   codexEnvironmentExecutionTarget?: CodexEnvironmentExecutionTarget;
   codexEnvironmentId?: string | null;
+  /**
+   * @deprecated Environment setup execution is config-driven from the selected
+   * environment's setup script. This field is kept only for old persisted
+   * messaging preference records.
+   */
   codexEnvironmentSetupEnabled?: boolean;
   executionMode?: ThreadExecutionMode;
   fastMode?: boolean;
@@ -1179,6 +1184,11 @@ export type MessagingBrowseSessionRecord = {
   branchName?: string;
   codexEnvironmentId?: string | null;
   codexEnvironmentExecutionTarget?: CodexEnvironmentExecutionTarget;
+  /**
+   * @deprecated Environment setup execution is config-driven from the selected
+   * environment's setup script. This field is kept only for old persisted
+   * browse sessions.
+   */
   codexEnvironmentSetupEnabled?: boolean;
   codexEnvironmentActionId?: string;
   selectedProject?: MessagingBrowseSelectedProject;

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -440,7 +440,6 @@ export type UpdateDirectoryLaunchpadRequest = {
       | "parentThreadTitle"
       | "codexEnvironmentId"
       | "codexEnvironmentExecutionTarget"
-      | "codexEnvironmentSetupEnabled"
       | "codexEnvironmentActionId"
       | "directoryLabel"
       | "directoryPath"

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -360,6 +360,11 @@ export type NavigationLaunchpadDraft = NavigationLaunchpadDefaults & {
   parentThreadTitle?: string;
   codexEnvironmentId?: string;
   codexEnvironmentExecutionTarget?: CodexEnvironmentExecutionTarget;
+  /**
+   * @deprecated Environment setup execution is config-driven from the selected
+   * environment's setup script. This field is kept only so old persisted
+   * launchpad rows can deserialize.
+   */
   codexEnvironmentSetupEnabled?: boolean;
   codexEnvironmentActionId?: string;
   codexEnvironmentOptions?: CodexEnvironmentOption[];


### PR DESCRIPTION
## Summary
PwrAgent now treats Codex environment setup as config-driven everywhere, so an old launchpad row with `codexEnvironmentSetupEnabled: false` can no longer hide the setup progress screen while setup still runs. The deprecated flag is stripped from hydrated launchpads, removed from new launchpad/messaging patches, and left only as compatibility shape for old persisted records.

The concurrent env-action regression test now tolerates harmless shell startup output while still proving that each detached run keeps its own output marker and does not receive the other run's marker.

## Tests
- `pnpm --filter @pwragent/desktop exec vitest run --environment jsdom src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx src/renderer/src/features/composer/__tests__/composer.test.tsx src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx`
- `pnpm --filter @pwragent/desktop exec vitest run src/main/__tests__/backend-registry.test.ts`
- `pnpm --filter @pwragent/desktop exec vitest run src/main/__tests__/messaging-controller.test.ts -t "lets messaging choose a Codex environment before starting a new thread|clears a saved Codex environment action when switching environments"`
- `pnpm --filter @pwragent/agent-core test -- navigation-state`
- `pnpm typecheck`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
