### PR TITLE
fix(desktop): preserve codex turn message timestamps

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -2191,7 +2191,7 @@ describe("CodexAppServerClient", () => {
           id: "item-1",
           role: "user",
           text: "Show me the current desktop thread shell",
-          createdAt: undefined,
+          createdAt: 1_763_500_100_000,
           parts: [
             {
               type: "text",
@@ -2203,13 +2203,13 @@ describe("CodexAppServerClient", () => {
           id: "item-2",
           role: "assistant",
           text: "I’m tracing the transcript scroll container.",
-          createdAt: undefined
+          createdAt: 1_763_500_100_000
         },
         {
           id: "item-6",
           role: "assistant",
           text: "The desktop shell is live and listing Codex threads.",
-          createdAt: undefined
+          createdAt: 1_763_500_100_000
         }
       ],
       lastUserMessage: "Show me the current desktop thread shell",
@@ -2338,6 +2338,74 @@ describe("CodexAppServerClient", () => {
         },
       },
     ]);
+
+    await client.close();
+  });
+
+  it("does not let an older same-text assistant message hide a newer turn reply", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.readThreadResultByThreadId.set("thread-repeated-assistant-text", {
+      events: [
+        {
+          type: "response_item",
+          timestamp: "2026-06-09T15:01:00.000Z",
+          payload: {
+            id: "old-response-item",
+            role: "assistant",
+            content: [
+              {
+                type: "output_text",
+                text: "Same final answer.",
+              },
+            ],
+          },
+        },
+      ],
+      thread: {
+        turns: [
+          {
+            id: "newer-turn",
+            status: "completed",
+            startedAt: 1_781_112_452,
+            items: [
+              {
+                type: "agentMessage",
+                id: "new-final-answer",
+                phase: "final_answer",
+                text: "Same final answer.",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    const replay = await client.readThread({
+      threadId: "thread-repeated-assistant-text",
+    });
+
+    expect(replay.entries).toEqual([
+      expect.objectContaining({
+        id: "new-final-answer",
+        role: "assistant",
+        text: "Same final answer.",
+        createdAt: 1_781_112_452_000,
+      }),
+    ]);
+    expect(replay.messages.at(-1)).toEqual(
+      expect.objectContaining({
+        id: "new-final-answer",
+        role: "assistant",
+        text: "Same final answer.",
+        createdAt: 1_781_112_452_000,
+      }),
+    );
+    expect(replay.lastAssistantMessage).toBe("Same final answer.");
 
     await client.close();
   });
@@ -2769,7 +2837,7 @@ describe("CodexAppServerClient", () => {
         id: "item-image-1",
         role: "user",
         text: "Describe this image",
-        createdAt: undefined,
+        createdAt: 1_763_500_150_000,
         parts: [
           {
             type: "text",
@@ -2785,7 +2853,7 @@ describe("CodexAppServerClient", () => {
         id: "item-image-2",
         role: "user",
         text: "",
-        createdAt: undefined,
+        createdAt: 1_763_500_150_000,
         parts: [
           {
             type: "image",

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -1754,7 +1754,14 @@ function appendConversationMessage(
 function extractConversationMessages(value: unknown): AppServerThreadReplay["messages"] {
   const output: AppServerThreadReplay["messages"] = [];
   const suppressedAssistantTexts = collectReviewSuppressionTexts(value);
-  const timestampKeys = ["createdAt", "created_at", "timestamp", "time"];
+  const timestampKeys = [
+    "createdAt",
+    "created_at",
+    "startedAt",
+    "started_at",
+    "timestamp",
+    "time",
+  ];
 
   const visit = (node: unknown, inheritedCreatedAt?: number): void => {
     if (Array.isArray(node)) {


### PR DESCRIPTION
## Summary

- Codex replay messages now inherit turn `startedAt` timestamps, so the flat message view no longer treats newer turn-shaped assistant replies as timestampless.
- This closes the case where an older same-text assistant message could hide a newer turn reply in `replay.messages` and stale the derived `lastAssistantMessage`.
- Existing completed-final behavior from main still uses `completedAt` for final transcript entries; this patch covers the flat replay message side.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/codex-client.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`

## Notes

- Added a regression for same-text assistant replies where an older timestamped protocol event and a newer turn item both contain the same final answer.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
