### PR TITLE
fix(desktop): share PR status across threads

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -243,8 +243,43 @@ const getAuthStatus = vi.fn(async () => ({
 }));
 const detectPullRequestsForThread = vi.fn(async (): Promise<PrSummary[]> => []);
 
-function githubPr(pr: Omit<PrSummary, "provider">): PrSummary {
-  return { provider: "github.com", ...pr };
+function githubPr(
+  pr: Omit<PrSummary, "provider" | "checkState" | "lifecycleState" | "reviewState" | "mergeState">
+    & Partial<Pick<PrSummary, "checkState" | "lifecycleState" | "reviewState" | "mergeState">>,
+): PrSummary {
+  const checkState = pr.checkState ?? normalizeTestCheckState(pr.state);
+  return {
+    provider: "github.com",
+    ...pr,
+    state: checkState,
+    checkState,
+    lifecycleState: pr.lifecycleState ?? legacyTestLifecycleState(pr.state),
+    reviewState: pr.reviewState ?? legacyTestReviewState(pr.state),
+    mergeState: pr.mergeState ?? "unknown",
+  };
+}
+
+function normalizeTestCheckState(state: PrSummary["state"]): NonNullable<PrSummary["checkState"]> {
+  if (
+    state === "passing"
+    || state === "failing"
+    || state === "pending"
+    || state === "unknown"
+  ) {
+    return state;
+  }
+  return "unknown";
+}
+
+function legacyTestLifecycleState(state: PrSummary["state"]): NonNullable<PrSummary["lifecycleState"]> {
+  if (state === "merged" || state === "closed") {
+    return state;
+  }
+  return "open";
+}
+
+function legacyTestReviewState(state: PrSummary["state"]): NonNullable<PrSummary["reviewState"]> {
+  return state === "draft" ? "draft" : "ready_for_review";
 }
 
 function buildThreadPrRequestKey(params: {
@@ -820,7 +855,13 @@ describe("app server ipc", () => {
       url: "https://github.com/pwrdrvr/PwrAgent/pull/430",
     });
     const refreshedPrs: PrSummary[] = [
-      { ...stalePassingPr, state: "merged" },
+      githubPr({
+        number: stalePassingPr.number,
+        org: stalePassingPr.org,
+        repo: stalePassingPr.repo,
+        state: "merged",
+        url: stalePassingPr.url,
+      }),
       mergedPr,
     ];
     getThreadOverlayState.mockResolvedValueOnce({
@@ -901,10 +942,13 @@ describe("app server ipc", () => {
       state: "pending",
       url: "https://github.com/OpenAI/codex/pull/727",
     });
-    const passingPr: PrSummary = {
-      ...stalePr,
+    const passingPr = githubPr({
+      number: stalePr.number,
+      org: stalePr.org,
+      repo: stalePr.repo,
       state: "passing",
-    };
+      url: stalePr.url,
+    });
     const baseRequest = {
       backend: "codex",
       branch: "hot-cpu-capture-presets",
@@ -992,10 +1036,13 @@ describe("app server ipc", () => {
       state: "pending",
       url: "https://github.com/OpenAI/codex/pull/727",
     });
-    const cachedPr: PrSummary = {
-      ...stalePr,
+    const cachedPr = githubPr({
+      number: stalePr.number,
+      org: stalePr.org,
+      repo: stalePr.repo,
       state: "passing",
-    };
+      url: stalePr.url,
+    });
     const request = {
       backend: "codex",
       threadId: "thread-1",
@@ -1826,10 +1873,13 @@ describe("app server ipc", () => {
       state: "pending",
       url: "https://github.com/OpenAI/codex/pull/727",
     });
-    const cachedPr: PrSummary = {
-      ...stalePr,
+    const cachedPr = githubPr({
+      number: stalePr.number,
+      org: stalePr.org,
+      repo: stalePr.repo,
       state: "passing",
-    };
+      url: stalePr.url,
+    });
     readPrStatusCache.mockResolvedValueOnce({
       "github.com/openai/codex#727": {
         provider: "github.com",

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -874,6 +874,20 @@ describe("app server ipc", () => {
       ...baseRequest,
       threadId: "019eb2e4-840b-7fb1-979c-af66091712c0",
     } satisfies RefreshThreadPullRequestsRequest;
+    const threadOneRequestKey = JSON.stringify({
+      lookupVersion: 2,
+      backend: "codex",
+      threadId: threadOneRequest.threadId,
+      branch: baseRequest.branch,
+      directoryPaths: baseRequest.directoryPaths,
+    });
+    const threadTwoRequestKey = JSON.stringify({
+      lookupVersion: 2,
+      backend: "codex",
+      threadId: threadTwoRequest.threadId,
+      branch: baseRequest.branch,
+      directoryPaths: baseRequest.directoryPaths,
+    });
     getThreadOverlayState
       .mockResolvedValueOnce({
         backend: "codex",
@@ -882,7 +896,7 @@ describe("app server ipc", () => {
         extraLinkedDirectories: [],
         prs: [stalePr],
         prsFetchedAt: Date.now() - 120_000,
-        prsRefreshKey: "thread-one-key",
+        prsRefreshKey: threadOneRequestKey,
       })
       .mockResolvedValueOnce({
         backend: "codex",
@@ -891,7 +905,7 @@ describe("app server ipc", () => {
         extraLinkedDirectories: [],
         prs: [stalePr],
         prsFetchedAt: Date.now() - 120_000,
-        prsRefreshKey: "thread-two-key",
+        prsRefreshKey: threadTwoRequestKey,
       });
     detectPullRequestsForThread.mockResolvedValueOnce([passingPr]);
 
@@ -938,6 +952,20 @@ describe("app server ipc", () => {
       ...stalePr,
       state: "passing",
     };
+    const request = {
+      backend: "codex",
+      threadId: "thread-1",
+      trigger: "scheduled",
+      branch: "hot-cpu-capture-presets",
+      directoryPaths: ["/repo"],
+    } satisfies RefreshThreadPullRequestsRequest;
+    const requestKey = JSON.stringify({
+      lookupVersion: 2,
+      backend: "codex",
+      threadId: "thread-1",
+      branch: "hot-cpu-capture-presets",
+      directoryPaths: ["/repo"],
+    });
     readPrStatusCache.mockResolvedValueOnce({
       "openai/codex#727": {
         prKey: "openai/codex#727",
@@ -952,20 +980,14 @@ describe("app server ipc", () => {
       extraLinkedDirectories: [],
       prs: [stalePr],
       prsFetchedAt: Date.now() - 300_000,
-      prsRefreshKey: "thread-key",
+      prsRefreshKey: requestKey,
     });
 
     registerAppServerIpcHandlers();
 
     const response = await handlers.get(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL)?.(
       {},
-      {
-        backend: "codex",
-        threadId: "thread-1",
-        trigger: "scheduled",
-        branch: "hot-cpu-capture-presets",
-        directoryPaths: ["/repo"],
-      } satisfies RefreshThreadPullRequestsRequest,
+      request,
     );
 
     expect(response).toEqual({
@@ -987,6 +1009,20 @@ describe("app server ipc", () => {
       state: "passing",
       url: "https://github.com/OpenAI/codex/pull/727",
     };
+    const request = {
+      backend: "codex",
+      threadId: "thread-1",
+      trigger: "user",
+      branch: "hot-cpu-capture-presets",
+      directoryPaths: ["/repo"],
+    } satisfies RefreshThreadPullRequestsRequest;
+    const requestKey = JSON.stringify({
+      lookupVersion: 2,
+      backend: "codex",
+      threadId: "thread-1",
+      branch: "hot-cpu-capture-presets",
+      directoryPaths: ["/repo"],
+    });
     readPrStatusCache.mockResolvedValueOnce({
       "openai/codex#727": {
         prKey: "openai/codex#727",
@@ -1001,20 +1037,14 @@ describe("app server ipc", () => {
       extraLinkedDirectories: [],
       prs: [cachedPr],
       prsFetchedAt: Date.now(),
-      prsRefreshKey: "thread-key",
+      prsRefreshKey: requestKey,
     });
 
     registerAppServerIpcHandlers();
 
     const response = await handlers.get(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL)?.(
       {},
-      {
-        backend: "codex",
-        threadId: "thread-1",
-        trigger: "user",
-        branch: "hot-cpu-capture-presets",
-        directoryPaths: ["/repo"],
-      } satisfies RefreshThreadPullRequestsRequest,
+      request,
     );
 
     expect(response).toEqual({
@@ -1076,6 +1106,127 @@ describe("app server ipc", () => {
       },
     ]);
     expect(setThreadPullRequests).toHaveBeenCalledOnce();
+  });
+
+  it("honors cached empty PR lookups for the same branch and directories", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_REFRESH_THREAD_PRS_CHANNEL } = await import("../../shared/ipc");
+    const request = {
+      backend: "codex",
+      threadId: "thread-1",
+      branch: "feat/no-pr-yet",
+      directoryPaths: ["/repo"],
+    } satisfies RefreshThreadPullRequestsRequest;
+    const requestKey = JSON.stringify({
+      lookupVersion: 2,
+      backend: "codex",
+      threadId: "thread-1",
+      branch: "feat/no-pr-yet",
+      directoryPaths: ["/repo"],
+    });
+    getThreadOverlayState.mockResolvedValueOnce({
+      backend: "codex",
+      threadId: "thread-1",
+      executionMode: "default",
+      extraLinkedDirectories: [],
+      prs: [],
+      prsFetchedAt: Date.now() - 120_000,
+      prsRefreshKey: requestKey,
+    });
+
+    registerAppServerIpcHandlers();
+
+    const response = await handlers.get(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL)?.(
+      {},
+      request,
+    );
+
+    expect(detectPullRequestsForThread).not.toHaveBeenCalled();
+    expect(setThreadPullRequests).not.toHaveBeenCalled();
+    expect(response).toEqual({
+      backend: "codex",
+      threadId: "thread-1",
+      ghAvailable: true,
+      prs: [],
+    });
+  });
+
+  it("rechecks PRs when cached PRs belong to a different lookup key", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_REFRESH_THREAD_PRS_CHANNEL } = await import("../../shared/ipc");
+    const request = {
+      backend: "codex",
+      threadId: "thread-1",
+      branch: "fix/new-branch",
+      directoryPaths: ["/repo"],
+    } satisfies RefreshThreadPullRequestsRequest;
+    const requestKey = JSON.stringify({
+      lookupVersion: 2,
+      backend: "codex",
+      threadId: "thread-1",
+      branch: "fix/new-branch",
+      directoryPaths: ["/repo"],
+    });
+    const terminalPrs: PrSummary[] = [
+      {
+        number: 433,
+        org: "pwrdrvr",
+        repo: "PwrAgent",
+        state: "merged",
+        url: "https://github.com/pwrdrvr/PwrAgent/pull/433",
+      },
+    ];
+    const newBranchPrs: PrSummary[] = [
+      {
+        number: 438,
+        org: "pwrdrvr",
+        repo: "PwrAgent",
+        state: "pending",
+        url: "https://github.com/pwrdrvr/PwrAgent/pull/438",
+      },
+    ];
+    getThreadOverlayState.mockResolvedValueOnce({
+      backend: "codex",
+      threadId: "thread-1",
+      executionMode: "default",
+      extraLinkedDirectories: [],
+      prs: terminalPrs,
+      prsFetchedAt: Date.now() - 120_000,
+      prsRefreshKey: JSON.stringify({
+        lookupVersion: 2,
+        backend: "codex",
+        threadId: "thread-1",
+        branch: "fix/old-branch",
+        directoryPaths: ["/repo"],
+      }),
+    });
+    detectPullRequestsForThread.mockResolvedValueOnce(newBranchPrs);
+
+    registerAppServerIpcHandlers();
+
+    const response = await handlers.get(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL)?.(
+      {},
+      request,
+    );
+
+    expect(detectPullRequestsForThread).toHaveBeenCalledWith({
+      fetcher: expect.any(Object),
+      branch: "fix/new-branch",
+      directoryPaths: ["/repo"],
+    });
+    expect(setThreadPullRequests).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      prs: newBranchPrs,
+      fetchedAt: expect.any(Number),
+      refreshKey: requestKey,
+    });
+    expect(response).toEqual({
+      backend: "codex",
+      threadId: "thread-1",
+      ghAvailable: true,
+      prs: newBranchPrs,
+    });
   });
 
   it("short-circuits PR refresh when all cached PRs are terminal for the same lookup", async () => {

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -741,7 +741,7 @@ describe("app server ipc", () => {
     });
   });
 
-  it("refreshes mixed terminal and non-terminal PR chips instead of short-circuiting", async () => {
+  it("returns known PR chips immediately and refreshes mixed terminal/non-terminal state in the background", async () => {
     const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
     const { NAVIGATION_REFRESH_THREAD_PRS_CHANNEL } = await import("../../shared/ipc");
     const request = {
@@ -793,23 +793,166 @@ describe("app server ipc", () => {
       request,
     );
 
-    expect(detectPullRequestsForThread).toHaveBeenCalledWith({
-      fetcher: expect.any(Object),
-      branch: "fix/desktop-source-link-goto",
-      directoryPaths: ["/repo"],
+    expect(response).toEqual({
+      backend: "codex",
+      threadId: "thread-1",
+      ghAvailable: true,
+      prs: [stalePassingPr, mergedPr],
+    });
+
+    await vi.waitFor(() => {
+      expect(detectPullRequestsForThread).toHaveBeenCalledWith({
+        fetcher: expect.any(Object),
+        branch: "fix/desktop-source-link-goto",
+        directoryPaths: ["/repo"],
+      });
     });
     expect(setThreadPullRequests).toHaveBeenCalledWith({
       backend: "codex",
       threadId: "thread-1",
       prs: refreshedPrs,
+      fetchedAt: expect.any(Number),
       refreshKey: requestKey,
     });
+    expect(publishLocalEvent).toHaveBeenCalledWith({
+      backend: "codex",
+      notification: {
+        method: "thread/pullRequests/updated",
+        params: {
+          threadId: "thread-1",
+          prs: refreshedPrs,
+        },
+      },
+    });
+  });
+
+  it("serves the same canonical PR state across different thread overlays", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_REFRESH_THREAD_PRS_CHANNEL } = await import("../../shared/ipc");
+    const stalePr: PrSummary = {
+      number: 727,
+      org: "OpenAI",
+      repo: "codex",
+      state: "pending",
+      url: "https://github.com/OpenAI/codex/pull/727",
+    };
+    const passingPr: PrSummary = {
+      ...stalePr,
+      state: "passing",
+    };
+    const baseRequest = {
+      backend: "codex",
+      branch: "hot-cpu-capture-presets",
+      directoryPaths: ["/repo"],
+    } satisfies Omit<RefreshThreadPullRequestsRequest, "threadId">;
+    const threadOneRequest = {
+      ...baseRequest,
+      threadId: "019eb2a0-734b-7503-b0b8-9d3fa56203ba",
+    } satisfies RefreshThreadPullRequestsRequest;
+    const threadTwoRequest = {
+      ...baseRequest,
+      threadId: "019eb2e4-840b-7fb1-979c-af66091712c0",
+    } satisfies RefreshThreadPullRequestsRequest;
+    getThreadOverlayState
+      .mockResolvedValueOnce({
+        backend: "codex",
+        threadId: threadOneRequest.threadId,
+        executionMode: "default",
+        extraLinkedDirectories: [],
+        prs: [stalePr],
+        prsFetchedAt: Date.now() - 120_000,
+        prsRefreshKey: "thread-one-key",
+      })
+      .mockResolvedValueOnce({
+        backend: "codex",
+        threadId: threadTwoRequest.threadId,
+        executionMode: "default",
+        extraLinkedDirectories: [],
+        prs: [stalePr],
+        prsFetchedAt: Date.now() - 120_000,
+        prsRefreshKey: "thread-two-key",
+      });
+    detectPullRequestsForThread.mockResolvedValueOnce([passingPr]);
+
+    registerAppServerIpcHandlers();
+
+    await handlers.get(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL)?.(
+      {},
+      threadOneRequest,
+    );
+    await vi.waitFor(() => {
+      expect(setThreadPullRequests).toHaveBeenCalledWith(
+        expect.objectContaining({
+          threadId: threadOneRequest.threadId,
+          prs: [passingPr],
+        }),
+      );
+    });
+
+    const response = await handlers.get(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL)?.(
+      {},
+      threadTwoRequest,
+    );
+
     expect(response).toEqual({
       backend: "codex",
-      threadId: "thread-1",
+      threadId: threadTwoRequest.threadId,
       ghAvailable: true,
-      prs: refreshedPrs,
+      prs: [passingPr],
     });
+    expect(detectPullRequestsForThread).toHaveBeenCalledOnce();
+  });
+
+  it("coalesces concurrent first-time PR lookups for the same thread request", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_REFRESH_THREAD_PRS_CHANNEL } = await import("../../shared/ipc");
+    const request = {
+      backend: "codex",
+      threadId: "thread-1",
+      branch: "feat/pr-chip",
+      directoryPaths: ["/repo"],
+    } satisfies RefreshThreadPullRequestsRequest;
+    const fetchedPrs: PrSummary[] = [
+      {
+        number: 249,
+        org: "pwrdrvr",
+        repo: "PwrAgent",
+        state: "passing",
+        url: "https://github.com/pwrdrvr/PwrAgent/pull/249",
+      },
+    ];
+    let resolveFetch: ((prs: PrSummary[]) => void) | undefined;
+    detectPullRequestsForThread.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveFetch = resolve;
+      }),
+    );
+
+    registerAppServerIpcHandlers();
+
+    const handler = handlers.get(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL)!;
+    const first = handler({}, request);
+    const second = handler({}, request);
+    await vi.waitFor(() => {
+      expect(detectPullRequestsForThread).toHaveBeenCalledOnce();
+    });
+    resolveFetch?.(fetchedPrs);
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      {
+        backend: "codex",
+        threadId: "thread-1",
+        ghAvailable: true,
+        prs: fetchedPrs,
+      },
+      {
+        backend: "codex",
+        threadId: "thread-1",
+        ghAvailable: true,
+        prs: fetchedPrs,
+      },
+    ]);
+    expect(setThreadPullRequests).toHaveBeenCalledOnce();
   });
 
   it("short-circuits PR refresh when all cached PRs are terminal for the same lookup", async () => {

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -230,6 +230,8 @@ const setThreadPullRequests = vi.fn(async (request: {
   prsFetchedAt: Date.now(),
   prsRefreshKey: request.refreshKey,
 }));
+const readPrStatusCache = vi.fn(async () => ({}));
+const writePrStatusCacheEntries = vi.fn(async () => undefined);
 const isGhAvailable = vi.fn(async () => true);
 const getAuthStatus = vi.fn(async () => ({
   installed: true,
@@ -260,6 +262,8 @@ vi.mock("../app-server/desktop-overlay-store", () => ({
     getThreadOverlayState,
     getThreadOverlayStates,
     setThreadPullRequests,
+    readPrStatusCache,
+    writePrStatusCacheEntries,
     readDirectoryGitStatusCache,
     writeDirectoryGitStatusCacheEntry,
   }),
@@ -322,6 +326,9 @@ describe("app server ipc", () => {
     getThreadOverlayStates.mockReset();
     getThreadOverlayStates.mockResolvedValue({});
     setThreadPullRequests.mockClear();
+    readPrStatusCache.mockReset();
+    readPrStatusCache.mockResolvedValue({});
+    writePrStatusCacheEntries.mockClear();
     isGhAvailable.mockClear();
     isGhAvailable.mockResolvedValue(true);
     getAuthStatus.mockClear();
@@ -747,6 +754,7 @@ describe("app server ipc", () => {
     const request = {
       backend: "codex",
       threadId: "thread-1",
+      trigger: "user",
       branch: "fix/desktop-source-link-goto",
       directoryPaths: ["/repo"],
     } satisfies RefreshThreadPullRequestsRequest;
@@ -824,6 +832,18 @@ describe("app server ipc", () => {
         },
       },
     });
+    expect(writePrStatusCacheEntries).toHaveBeenCalledWith([
+      {
+        prKey: "pwrdrvr/pwragent#433",
+        fetchedAt: expect.any(Number),
+        pr: refreshedPrs[0],
+      },
+      {
+        prKey: "pwrdrvr/pwragent#430",
+        fetchedAt: expect.any(Number),
+        pr: refreshedPrs[1],
+      },
+    ]);
   });
 
   it("serves the same canonical PR state across different thread overlays", async () => {
@@ -847,6 +867,7 @@ describe("app server ipc", () => {
     } satisfies Omit<RefreshThreadPullRequestsRequest, "threadId">;
     const threadOneRequest = {
       ...baseRequest,
+      trigger: "user",
       threadId: "019eb2a0-734b-7503-b0b8-9d3fa56203ba",
     } satisfies RefreshThreadPullRequestsRequest;
     const threadTwoRequest = {
@@ -901,6 +922,108 @@ describe("app server ipc", () => {
       prs: [passingPr],
     });
     expect(detectPullRequestsForThread).toHaveBeenCalledOnce();
+  });
+
+  it("hydrates canonical PR state from persisted cache without scheduled GitHub refresh", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_REFRESH_THREAD_PRS_CHANNEL } = await import("../../shared/ipc");
+    const stalePr: PrSummary = {
+      number: 727,
+      org: "OpenAI",
+      repo: "codex",
+      state: "pending",
+      url: "https://github.com/OpenAI/codex/pull/727",
+    };
+    const cachedPr: PrSummary = {
+      ...stalePr,
+      state: "passing",
+    };
+    readPrStatusCache.mockResolvedValueOnce({
+      "openai/codex#727": {
+        prKey: "openai/codex#727",
+        fetchedAt: Date.now() - 120_000,
+        pr: cachedPr,
+      },
+    });
+    getThreadOverlayState.mockResolvedValueOnce({
+      backend: "codex",
+      threadId: "thread-1",
+      executionMode: "default",
+      extraLinkedDirectories: [],
+      prs: [stalePr],
+      prsFetchedAt: Date.now() - 300_000,
+      prsRefreshKey: "thread-key",
+    });
+
+    registerAppServerIpcHandlers();
+
+    const response = await handlers.get(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL)?.(
+      {},
+      {
+        backend: "codex",
+        threadId: "thread-1",
+        trigger: "scheduled",
+        branch: "hot-cpu-capture-presets",
+        directoryPaths: ["/repo"],
+      } satisfies RefreshThreadPullRequestsRequest,
+    );
+
+    expect(response).toEqual({
+      backend: "codex",
+      threadId: "thread-1",
+      ghAvailable: true,
+      prs: [cachedPr],
+    });
+    expect(detectPullRequestsForThread).not.toHaveBeenCalled();
+  });
+
+  it("skips user-triggered PR refresh when the persisted cache was fetched recently", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_REFRESH_THREAD_PRS_CHANNEL } = await import("../../shared/ipc");
+    const cachedPr: PrSummary = {
+      number: 727,
+      org: "OpenAI",
+      repo: "codex",
+      state: "passing",
+      url: "https://github.com/OpenAI/codex/pull/727",
+    };
+    readPrStatusCache.mockResolvedValueOnce({
+      "openai/codex#727": {
+        prKey: "openai/codex#727",
+        fetchedAt: Date.now(),
+        pr: cachedPr,
+      },
+    });
+    getThreadOverlayState.mockResolvedValueOnce({
+      backend: "codex",
+      threadId: "thread-1",
+      executionMode: "default",
+      extraLinkedDirectories: [],
+      prs: [cachedPr],
+      prsFetchedAt: Date.now(),
+      prsRefreshKey: "thread-key",
+    });
+
+    registerAppServerIpcHandlers();
+
+    const response = await handlers.get(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL)?.(
+      {},
+      {
+        backend: "codex",
+        threadId: "thread-1",
+        trigger: "user",
+        branch: "hot-cpu-capture-presets",
+        directoryPaths: ["/repo"],
+      } satisfies RefreshThreadPullRequestsRequest,
+    );
+
+    expect(response).toEqual({
+      backend: "codex",
+      threadId: "thread-1",
+      ghAvailable: true,
+      prs: [cachedPr],
+    });
+    expect(detectPullRequestsForThread).not.toHaveBeenCalled();
   });
 
   it("coalesces concurrent first-time PR lookups for the same thread request", async () => {

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -1393,6 +1393,82 @@ describe("app server ipc", () => {
     });
   });
 
+  it("appends newly discovered PRs to the thread PR history", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_REFRESH_THREAD_PRS_CHANNEL } = await import("../../shared/ipc");
+    const request = {
+      backend: "codex",
+      threadId: "thread-1",
+      trigger: "user",
+      branch: "feat/reused-branch",
+      directoryPaths: ["/repo"],
+    } satisfies RefreshThreadPullRequestsRequest;
+    const requestKey = buildThreadPrRequestKey({
+      backend: "codex",
+      threadId: "thread-1",
+      branch: "feat/reused-branch",
+      directoryPaths: ["/repo"],
+    });
+    const previousPr = githubPr({
+      number: 720,
+      org: "pwrdrvr",
+      repo: "PwrAgent",
+      state: "merged",
+      url: "https://github.com/pwrdrvr/PwrAgent/pull/720",
+    });
+    const discoveredPr = githubPr({
+      number: 737,
+      org: "pwrdrvr",
+      repo: "PwrAgent",
+      state: "passing",
+      url: "https://github.com/pwrdrvr/PwrAgent/pull/737",
+    });
+    getThreadOverlayState.mockResolvedValueOnce({
+      backend: "codex",
+      threadId: "thread-1",
+      executionMode: "default",
+      extraLinkedDirectories: [],
+      prs: [previousPr],
+      prsFetchedAt: Date.now() - 120_000,
+      prsRefreshKey: requestKey,
+    });
+    detectPullRequestsForThread.mockResolvedValueOnce([discoveredPr]);
+
+    registerAppServerIpcHandlers();
+
+    const response = await handlers.get(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL)?.(
+      {},
+      request,
+    );
+
+    expect(response).toEqual({
+      backend: "codex",
+      threadId: "thread-1",
+      provider: "github.com",
+      ghAvailable: true,
+      prs: [previousPr],
+    });
+    await vi.waitFor(() => {
+      expect(setThreadPullRequests).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        prs: [previousPr, discoveredPr],
+        fetchedAt: expect.any(Number),
+        refreshKey: requestKey,
+      });
+    });
+    expect(publishLocalEvent).toHaveBeenCalledWith({
+      backend: "codex",
+      notification: {
+        method: "thread/pullRequests/updated",
+        params: {
+          threadId: "thread-1",
+          prs: [previousPr, discoveredPr],
+        },
+      },
+    });
+  });
+
   it("rechecks PRs when cached PRs belong to a different lookup key", async () => {
     const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
     const { NAVIGATION_REFRESH_THREAD_PRS_CHANNEL } = await import("../../shared/ipc");
@@ -1454,7 +1530,7 @@ describe("app server ipc", () => {
       threadId: "thread-1",
       provider: "github.com",
       ghAvailable: true,
-      prs: [],
+      prs: terminalPrs,
     });
     await vi.waitFor(() => {
       expect(detectPullRequestsForThread).toHaveBeenCalledWith({
@@ -1467,7 +1543,7 @@ describe("app server ipc", () => {
       expect(setThreadPullRequests).toHaveBeenCalledWith({
         backend: "codex",
         threadId: "thread-1",
-        prs: newBranchPrs,
+        prs: [...terminalPrs, ...newBranchPrs],
         fetchedAt: expect.any(Number),
         refreshKey: requestKey,
       });

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -1420,6 +1420,7 @@ describe("app server ipc", () => {
       number: 737,
       org: "pwrdrvr",
       repo: "PwrAgent",
+      title: "Retain thread pull request history",
       state: "passing",
       url: "https://github.com/pwrdrvr/PwrAgent/pull/737",
     });
@@ -1464,6 +1465,69 @@ describe("app server ipc", () => {
         params: {
           threadId: "thread-1",
           prs: [previousPr, discoveredPr],
+        },
+      },
+    });
+  });
+
+  it("persists and publishes title-only PR updates", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_REFRESH_THREAD_PRS_CHANNEL } = await import("../../shared/ipc");
+    const request = {
+      backend: "codex",
+      threadId: "thread-1",
+      trigger: "user",
+      branch: "feat/title-update",
+      directoryPaths: ["/repo"],
+    } satisfies RefreshThreadPullRequestsRequest;
+    const requestKey = buildThreadPrRequestKey({
+      backend: "codex",
+      threadId: "thread-1",
+      branch: "feat/title-update",
+      directoryPaths: ["/repo"],
+    });
+    const previousPr = githubPr({
+      number: 737,
+      org: "pwrdrvr",
+      repo: "PwrAgent",
+      state: "passing",
+      url: "https://github.com/pwrdrvr/PwrAgent/pull/737",
+    });
+    const titledPr = {
+      ...previousPr,
+      title: "Retain thread pull request history",
+    };
+    getThreadOverlayState.mockResolvedValueOnce({
+      backend: "codex",
+      threadId: "thread-1",
+      executionMode: "default",
+      extraLinkedDirectories: [],
+      prs: [previousPr],
+      prsFetchedAt: Date.now() - 120_000,
+      prsRefreshKey: requestKey,
+    });
+    detectPullRequestsForThread.mockResolvedValueOnce([titledPr]);
+
+    registerAppServerIpcHandlers();
+
+    await handlers.get(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL)?.({}, request);
+
+    await vi.waitFor(() => {
+      expect(setThreadPullRequests).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        prs: [titledPr],
+        fetchedAt: expect.any(Number),
+        refreshKey: requestKey,
+      });
+    });
+    expect(publishLocalEvent).toHaveBeenCalledWith({
+      backend: "codex",
+      notification: {
+        method: "thread/pullRequests/updated",
+        params: {
+          threadId: "thread-1",
+          prs: [titledPr],
         },
       },
     });

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -232,6 +232,8 @@ const setThreadPullRequests = vi.fn(async (request: {
 }));
 const readPrStatusCache = vi.fn(async () => ({}));
 const writePrStatusCacheEntries = vi.fn(async () => undefined);
+const readPrLookupCache = vi.fn(async () => ({}));
+const writePrLookupCacheEntry = vi.fn(async () => undefined);
 const isGhAvailable = vi.fn(async () => true);
 const getAuthStatus = vi.fn(async () => ({
   installed: true,
@@ -264,6 +266,8 @@ vi.mock("../app-server/desktop-overlay-store", () => ({
     setThreadPullRequests,
     readPrStatusCache,
     writePrStatusCacheEntries,
+    readPrLookupCache,
+    writePrLookupCacheEntry,
     readDirectoryGitStatusCache,
     writeDirectoryGitStatusCacheEntry,
   }),
@@ -329,6 +333,9 @@ describe("app server ipc", () => {
     readPrStatusCache.mockReset();
     readPrStatusCache.mockResolvedValue({});
     writePrStatusCacheEntries.mockClear();
+    readPrLookupCache.mockReset();
+    readPrLookupCache.mockResolvedValue({});
+    writePrLookupCacheEntry.mockClear();
     isGhAvailable.mockClear();
     isGhAvailable.mockResolvedValue(true);
     getAuthStatus.mockClear();
@@ -815,12 +822,14 @@ describe("app server ipc", () => {
         directoryPaths: ["/repo"],
       });
     });
-    expect(setThreadPullRequests).toHaveBeenCalledWith({
-      backend: "codex",
-      threadId: "thread-1",
-      prs: refreshedPrs,
-      fetchedAt: expect.any(Number),
-      refreshKey: requestKey,
+    await vi.waitFor(() => {
+      expect(setThreadPullRequests).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        prs: refreshedPrs,
+        fetchedAt: expect.any(Number),
+        refreshKey: requestKey,
+      });
     });
     expect(publishLocalEvent).toHaveBeenCalledWith({
       backend: "codex",
@@ -966,11 +975,25 @@ describe("app server ipc", () => {
       branch: "hot-cpu-capture-presets",
       directoryPaths: ["/repo"],
     });
+    const lookupKey = JSON.stringify({
+      lookupVersion: 1,
+      branch: "hot-cpu-capture-presets",
+      directoryPaths: ["/repo"],
+    });
     readPrStatusCache.mockResolvedValueOnce({
       "openai/codex#727": {
         prKey: "openai/codex#727",
         fetchedAt: Date.now() - 120_000,
         pr: cachedPr,
+      },
+    });
+    readPrLookupCache.mockResolvedValueOnce({
+      [lookupKey]: {
+        lookupKey,
+        branch: "hot-cpu-capture-presets",
+        directoryPaths: ["/repo"],
+        fetchedAt: Date.now(),
+        prs: [cachedPr],
       },
     });
     getThreadOverlayState.mockResolvedValueOnce({
@@ -1023,11 +1046,25 @@ describe("app server ipc", () => {
       branch: "hot-cpu-capture-presets",
       directoryPaths: ["/repo"],
     });
+    const lookupKey = JSON.stringify({
+      lookupVersion: 1,
+      branch: "hot-cpu-capture-presets",
+      directoryPaths: ["/repo"],
+    });
     readPrStatusCache.mockResolvedValueOnce({
       "openai/codex#727": {
         prKey: "openai/codex#727",
         fetchedAt: Date.now(),
         pr: cachedPr,
+      },
+    });
+    readPrLookupCache.mockResolvedValueOnce({
+      [lookupKey]: {
+        lookupKey,
+        branch: "hot-cpu-capture-presets",
+        directoryPaths: ["/repo"],
+        fetchedAt: Date.now(),
+        prs: [cachedPr],
       },
     });
     getThreadOverlayState.mockResolvedValueOnce({
@@ -1056,14 +1093,18 @@ describe("app server ipc", () => {
     expect(detectPullRequestsForThread).not.toHaveBeenCalled();
   });
 
-  it("coalesces concurrent first-time PR lookups for the same thread request", async () => {
+  it("coalesces concurrent first-time PR lookups for the same branch and directories", async () => {
     const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
     const { NAVIGATION_REFRESH_THREAD_PRS_CHANNEL } = await import("../../shared/ipc");
-    const request = {
+    const firstRequest = {
       backend: "codex",
       threadId: "thread-1",
       branch: "feat/pr-chip",
       directoryPaths: ["/repo"],
+    } satisfies RefreshThreadPullRequestsRequest;
+    const secondRequest = {
+      ...firstRequest,
+      threadId: "thread-2",
     } satisfies RefreshThreadPullRequestsRequest;
     const fetchedPrs: PrSummary[] = [
       {
@@ -1084,31 +1125,45 @@ describe("app server ipc", () => {
     registerAppServerIpcHandlers();
 
     const handler = handlers.get(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL)!;
-    const first = handler({}, request);
-    const second = handler({}, request);
-    await vi.waitFor(() => {
-      expect(detectPullRequestsForThread).toHaveBeenCalledOnce();
-    });
-    resolveFetch?.(fetchedPrs);
-
+    const first = handler({}, firstRequest);
+    const second = handler({}, secondRequest);
     await expect(Promise.all([first, second])).resolves.toEqual([
       {
         backend: "codex",
         threadId: "thread-1",
         ghAvailable: true,
-        prs: fetchedPrs,
+        prs: [],
       },
       {
         backend: "codex",
-        threadId: "thread-1",
+        threadId: "thread-2",
         ghAvailable: true,
-        prs: fetchedPrs,
+        prs: [],
       },
     ]);
-    expect(setThreadPullRequests).toHaveBeenCalledOnce();
+    await vi.waitFor(() => {
+      expect(detectPullRequestsForThread).toHaveBeenCalledOnce();
+    });
+    resolveFetch?.(fetchedPrs);
+
+    await vi.waitFor(() => {
+      expect(setThreadPullRequests).toHaveBeenCalledTimes(2);
+    });
+    expect(setThreadPullRequests).toHaveBeenCalledWith(
+      expect.objectContaining({
+        threadId: "thread-1",
+        prs: fetchedPrs,
+      }),
+    );
+    expect(setThreadPullRequests).toHaveBeenCalledWith(
+      expect.objectContaining({
+        threadId: "thread-2",
+        prs: fetchedPrs,
+      }),
+    );
   });
 
-  it("honors cached empty PR lookups for the same branch and directories", async () => {
+  it("returns recent cached empty PR lookups without hitting GitHub", async () => {
     const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
     const { NAVIGATION_REFRESH_THREAD_PRS_CHANNEL } = await import("../../shared/ipc");
     const request = {
@@ -1130,7 +1185,7 @@ describe("app server ipc", () => {
       executionMode: "default",
       extraLinkedDirectories: [],
       prs: [],
-      prsFetchedAt: Date.now() - 120_000,
+      prsFetchedAt: Date.now(),
       prsRefreshKey: requestKey,
     });
 
@@ -1148,6 +1203,75 @@ describe("app server ipc", () => {
       threadId: "thread-1",
       ghAvailable: true,
       prs: [],
+    });
+  });
+
+  it("returns stale cached empty PR lookups immediately and refreshes them in the background", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_REFRESH_THREAD_PRS_CHANNEL } = await import("../../shared/ipc");
+    const request = {
+      backend: "codex",
+      threadId: "thread-1",
+      branch: "feat/no-pr-yet",
+      directoryPaths: ["/repo"],
+    } satisfies RefreshThreadPullRequestsRequest;
+    const requestKey = JSON.stringify({
+      lookupVersion: 2,
+      backend: "codex",
+      threadId: "thread-1",
+      branch: "feat/no-pr-yet",
+      directoryPaths: ["/repo"],
+    });
+    const fetchedPrs: PrSummary[] = [
+      {
+        number: 438,
+        org: "pwrdrvr",
+        repo: "PwrAgent",
+        state: "pending",
+        url: "https://github.com/pwrdrvr/PwrAgent/pull/438",
+      },
+    ];
+    getThreadOverlayState.mockResolvedValueOnce({
+      backend: "codex",
+      threadId: "thread-1",
+      executionMode: "default",
+      extraLinkedDirectories: [],
+      prs: [],
+      prsFetchedAt: Date.now() - 120_000,
+      prsRefreshKey: requestKey,
+    });
+    detectPullRequestsForThread.mockResolvedValueOnce(fetchedPrs);
+
+    registerAppServerIpcHandlers();
+
+    const response = await handlers.get(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL)?.(
+      {},
+      request,
+    );
+
+    expect(response).toEqual({
+      backend: "codex",
+      threadId: "thread-1",
+      ghAvailable: true,
+      prs: [],
+    });
+    await vi.waitFor(() => {
+      expect(setThreadPullRequests).toHaveBeenCalledWith(
+        expect.objectContaining({
+          threadId: "thread-1",
+          prs: fetchedPrs,
+        }),
+      );
+    });
+    expect(publishLocalEvent).toHaveBeenCalledWith({
+      backend: "codex",
+      notification: {
+        method: "thread/pullRequests/updated",
+        params: {
+          threadId: "thread-1",
+          prs: fetchedPrs,
+        },
+      },
     });
   });
 
@@ -1209,23 +1333,27 @@ describe("app server ipc", () => {
       request,
     );
 
-    expect(detectPullRequestsForThread).toHaveBeenCalledWith({
-      fetcher: expect.any(Object),
-      branch: "fix/new-branch",
-      directoryPaths: ["/repo"],
-    });
-    expect(setThreadPullRequests).toHaveBeenCalledWith({
-      backend: "codex",
-      threadId: "thread-1",
-      prs: newBranchPrs,
-      fetchedAt: expect.any(Number),
-      refreshKey: requestKey,
-    });
     expect(response).toEqual({
       backend: "codex",
       threadId: "thread-1",
       ghAvailable: true,
-      prs: newBranchPrs,
+      prs: [],
+    });
+    await vi.waitFor(() => {
+      expect(detectPullRequestsForThread).toHaveBeenCalledWith({
+        fetcher: expect.any(Object),
+        branch: "fix/new-branch",
+        directoryPaths: ["/repo"],
+      });
+    });
+    await vi.waitFor(() => {
+      expect(setThreadPullRequests).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        prs: newBranchPrs,
+        fetchedAt: expect.any(Number),
+        refreshKey: requestKey,
+      });
     });
   });
 

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -243,6 +243,40 @@ const getAuthStatus = vi.fn(async () => ({
 }));
 const detectPullRequestsForThread = vi.fn(async (): Promise<PrSummary[]> => []);
 
+function githubPr(pr: Omit<PrSummary, "provider">): PrSummary {
+  return { provider: "github.com", ...pr };
+}
+
+function buildThreadPrRequestKey(params: {
+  backend: string;
+  threadId: string;
+  branch: string;
+  directoryPaths: string[];
+  provider?: string;
+}): string {
+  return JSON.stringify({
+    lookupVersion: 3,
+    backend: params.backend,
+    threadId: params.threadId,
+    provider: params.provider ?? "github.com",
+    branch: params.branch,
+    directoryPaths: params.directoryPaths,
+  });
+}
+
+function buildPrLookupKey(params: {
+  branch: string;
+  directoryPaths: string[];
+  provider?: string;
+}): string {
+  return JSON.stringify({
+    lookupVersion: 2,
+    provider: params.provider ?? "github.com",
+    branch: params.branch,
+    directoryPaths: params.directoryPaths,
+  });
+}
+
 vi.mock("electron", () => ({
   app: {
     getPath: vi.fn(() => "/tmp/pwragent-userdata"),
@@ -765,27 +799,26 @@ describe("app server ipc", () => {
       branch: "fix/desktop-source-link-goto",
       directoryPaths: ["/repo"],
     } satisfies RefreshThreadPullRequestsRequest;
-    const requestKey = JSON.stringify({
-      lookupVersion: 2,
+    const requestKey = buildThreadPrRequestKey({
       backend: "codex",
       threadId: "thread-1",
       branch: "fix/desktop-source-link-goto",
       directoryPaths: ["/repo"],
     });
-    const stalePassingPr: PrSummary = {
+    const stalePassingPr = githubPr({
       number: 433,
       org: "pwrdrvr",
       repo: "PwrAgent",
       state: "passing",
       url: "https://github.com/pwrdrvr/PwrAgent/pull/433",
-    };
-    const mergedPr: PrSummary = {
+    });
+    const mergedPr = githubPr({
       number: 430,
       org: "pwrdrvr",
       repo: "PwrAgent",
       state: "merged",
       url: "https://github.com/pwrdrvr/PwrAgent/pull/430",
-    };
+    });
     const refreshedPrs: PrSummary[] = [
       { ...stalePassingPr, state: "merged" },
       mergedPr,
@@ -811,6 +844,7 @@ describe("app server ipc", () => {
     expect(response).toEqual({
       backend: "codex",
       threadId: "thread-1",
+      provider: "github.com",
       ghAvailable: true,
       prs: [stalePassingPr, mergedPr],
     });
@@ -843,12 +877,14 @@ describe("app server ipc", () => {
     });
     expect(writePrStatusCacheEntries).toHaveBeenCalledWith([
       {
-        prKey: "pwrdrvr/pwragent#433",
+        provider: "github.com",
+        prKey: "github.com/pwrdrvr/pwragent#433",
         fetchedAt: expect.any(Number),
         pr: refreshedPrs[0],
       },
       {
-        prKey: "pwrdrvr/pwragent#430",
+        provider: "github.com",
+        prKey: "github.com/pwrdrvr/pwragent#430",
         fetchedAt: expect.any(Number),
         pr: refreshedPrs[1],
       },
@@ -858,13 +894,13 @@ describe("app server ipc", () => {
   it("serves the same canonical PR state across different thread overlays", async () => {
     const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
     const { NAVIGATION_REFRESH_THREAD_PRS_CHANNEL } = await import("../../shared/ipc");
-    const stalePr: PrSummary = {
+    const stalePr = githubPr({
       number: 727,
       org: "OpenAI",
       repo: "codex",
       state: "pending",
       url: "https://github.com/OpenAI/codex/pull/727",
-    };
+    });
     const passingPr: PrSummary = {
       ...stalePr,
       state: "passing",
@@ -883,15 +919,13 @@ describe("app server ipc", () => {
       ...baseRequest,
       threadId: "019eb2e4-840b-7fb1-979c-af66091712c0",
     } satisfies RefreshThreadPullRequestsRequest;
-    const threadOneRequestKey = JSON.stringify({
-      lookupVersion: 2,
+    const threadOneRequestKey = buildThreadPrRequestKey({
       backend: "codex",
       threadId: threadOneRequest.threadId,
       branch: baseRequest.branch,
       directoryPaths: baseRequest.directoryPaths,
     });
-    const threadTwoRequestKey = JSON.stringify({
-      lookupVersion: 2,
+    const threadTwoRequestKey = buildThreadPrRequestKey({
       backend: "codex",
       threadId: threadTwoRequest.threadId,
       branch: baseRequest.branch,
@@ -941,6 +975,7 @@ describe("app server ipc", () => {
     expect(response).toEqual({
       backend: "codex",
       threadId: threadTwoRequest.threadId,
+      provider: "github.com",
       ghAvailable: true,
       prs: [passingPr],
     });
@@ -950,13 +985,13 @@ describe("app server ipc", () => {
   it("hydrates canonical PR state from persisted cache without scheduled GitHub refresh", async () => {
     const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
     const { NAVIGATION_REFRESH_THREAD_PRS_CHANNEL } = await import("../../shared/ipc");
-    const stalePr: PrSummary = {
+    const stalePr = githubPr({
       number: 727,
       org: "OpenAI",
       repo: "codex",
       state: "pending",
       url: "https://github.com/OpenAI/codex/pull/727",
-    };
+    });
     const cachedPr: PrSummary = {
       ...stalePr,
       state: "passing",
@@ -968,21 +1003,20 @@ describe("app server ipc", () => {
       branch: "hot-cpu-capture-presets",
       directoryPaths: ["/repo"],
     } satisfies RefreshThreadPullRequestsRequest;
-    const requestKey = JSON.stringify({
-      lookupVersion: 2,
+    const requestKey = buildThreadPrRequestKey({
       backend: "codex",
       threadId: "thread-1",
       branch: "hot-cpu-capture-presets",
       directoryPaths: ["/repo"],
     });
-    const lookupKey = JSON.stringify({
-      lookupVersion: 1,
+    const lookupKey = buildPrLookupKey({
       branch: "hot-cpu-capture-presets",
       directoryPaths: ["/repo"],
     });
     readPrStatusCache.mockResolvedValueOnce({
-      "openai/codex#727": {
-        prKey: "openai/codex#727",
+      "github.com/openai/codex#727": {
+        provider: "github.com",
+        prKey: "github.com/openai/codex#727",
         fetchedAt: Date.now() - 120_000,
         pr: cachedPr,
       },
@@ -990,6 +1024,7 @@ describe("app server ipc", () => {
     readPrLookupCache.mockResolvedValueOnce({
       [lookupKey]: {
         lookupKey,
+        provider: "github.com",
         branch: "hot-cpu-capture-presets",
         directoryPaths: ["/repo"],
         fetchedAt: Date.now(),
@@ -1016,6 +1051,7 @@ describe("app server ipc", () => {
     expect(response).toEqual({
       backend: "codex",
       threadId: "thread-1",
+      provider: "github.com",
       ghAvailable: true,
       prs: [cachedPr],
     });
@@ -1025,13 +1061,13 @@ describe("app server ipc", () => {
   it("skips user-triggered PR refresh when the persisted cache was fetched recently", async () => {
     const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
     const { NAVIGATION_REFRESH_THREAD_PRS_CHANNEL } = await import("../../shared/ipc");
-    const cachedPr: PrSummary = {
+    const cachedPr = githubPr({
       number: 727,
       org: "OpenAI",
       repo: "codex",
       state: "passing",
       url: "https://github.com/OpenAI/codex/pull/727",
-    };
+    });
     const request = {
       backend: "codex",
       threadId: "thread-1",
@@ -1039,21 +1075,20 @@ describe("app server ipc", () => {
       branch: "hot-cpu-capture-presets",
       directoryPaths: ["/repo"],
     } satisfies RefreshThreadPullRequestsRequest;
-    const requestKey = JSON.stringify({
-      lookupVersion: 2,
+    const requestKey = buildThreadPrRequestKey({
       backend: "codex",
       threadId: "thread-1",
       branch: "hot-cpu-capture-presets",
       directoryPaths: ["/repo"],
     });
-    const lookupKey = JSON.stringify({
-      lookupVersion: 1,
+    const lookupKey = buildPrLookupKey({
       branch: "hot-cpu-capture-presets",
       directoryPaths: ["/repo"],
     });
     readPrStatusCache.mockResolvedValueOnce({
-      "openai/codex#727": {
-        prKey: "openai/codex#727",
+      "github.com/openai/codex#727": {
+        provider: "github.com",
+        prKey: "github.com/openai/codex#727",
         fetchedAt: Date.now(),
         pr: cachedPr,
       },
@@ -1061,6 +1096,7 @@ describe("app server ipc", () => {
     readPrLookupCache.mockResolvedValueOnce({
       [lookupKey]: {
         lookupKey,
+        provider: "github.com",
         branch: "hot-cpu-capture-presets",
         directoryPaths: ["/repo"],
         fetchedAt: Date.now(),
@@ -1087,6 +1123,7 @@ describe("app server ipc", () => {
     expect(response).toEqual({
       backend: "codex",
       threadId: "thread-1",
+      provider: "github.com",
       ghAvailable: true,
       prs: [cachedPr],
     });
@@ -1096,13 +1133,13 @@ describe("app server ipc", () => {
   it("persists fresh lookup-cache hits to the requesting thread overlay", async () => {
     const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
     const { NAVIGATION_REFRESH_THREAD_PRS_CHANNEL } = await import("../../shared/ipc");
-    const cachedPr: PrSummary = {
+    const cachedPr = githubPr({
       number: 727,
       org: "OpenAI",
       repo: "codex",
       state: "passing",
       url: "https://github.com/OpenAI/codex/pull/727",
-    };
+    });
     const request = {
       backend: "codex",
       threadId: "thread-1",
@@ -1110,22 +1147,21 @@ describe("app server ipc", () => {
       branch: "hot-cpu-capture-presets",
       directoryPaths: ["/repo"],
     } satisfies RefreshThreadPullRequestsRequest;
-    const requestKey = JSON.stringify({
-      lookupVersion: 2,
+    const requestKey = buildThreadPrRequestKey({
       backend: "codex",
       threadId: "thread-1",
       branch: "hot-cpu-capture-presets",
       directoryPaths: ["/repo"],
     });
     const fetchedAt = Date.now();
-    const lookupKey = JSON.stringify({
-      lookupVersion: 1,
+    const lookupKey = buildPrLookupKey({
       branch: "hot-cpu-capture-presets",
       directoryPaths: ["/repo"],
     });
     readPrLookupCache.mockResolvedValueOnce({
       [lookupKey]: {
         lookupKey,
+        provider: "github.com",
         branch: "hot-cpu-capture-presets",
         directoryPaths: ["/repo"],
         fetchedAt,
@@ -1140,9 +1176,10 @@ describe("app server ipc", () => {
       prs: [],
       prsFetchedAt: Date.now() - 300_000,
       prsRefreshKey: JSON.stringify({
-        lookupVersion: 2,
+        lookupVersion: 3,
         backend: "codex",
         threadId: "thread-1",
+        provider: "github.com",
         branch: "old-branch",
         directoryPaths: ["/repo"],
       }),
@@ -1158,6 +1195,7 @@ describe("app server ipc", () => {
     expect(response).toEqual({
       backend: "codex",
       threadId: "thread-1",
+      provider: "github.com",
       ghAvailable: true,
       prs: [cachedPr],
     });
@@ -1185,13 +1223,13 @@ describe("app server ipc", () => {
       threadId: "thread-2",
     } satisfies RefreshThreadPullRequestsRequest;
     const fetchedPrs: PrSummary[] = [
-      {
+      githubPr({
         number: 249,
         org: "pwrdrvr",
         repo: "PwrAgent",
         state: "passing",
         url: "https://github.com/pwrdrvr/PwrAgent/pull/249",
-      },
+      }),
     ];
     let resolveFetch: ((prs: PrSummary[]) => void) | undefined;
     detectPullRequestsForThread.mockReturnValueOnce(
@@ -1209,12 +1247,14 @@ describe("app server ipc", () => {
       {
         backend: "codex",
         threadId: "thread-1",
+        provider: "github.com",
         ghAvailable: true,
         prs: [],
       },
       {
         backend: "codex",
         threadId: "thread-2",
+        provider: "github.com",
         ghAvailable: true,
         prs: [],
       },
@@ -1250,8 +1290,7 @@ describe("app server ipc", () => {
       branch: "feat/no-pr-yet",
       directoryPaths: ["/repo"],
     } satisfies RefreshThreadPullRequestsRequest;
-    const requestKey = JSON.stringify({
-      lookupVersion: 2,
+    const requestKey = buildThreadPrRequestKey({
       backend: "codex",
       threadId: "thread-1",
       branch: "feat/no-pr-yet",
@@ -1279,6 +1318,7 @@ describe("app server ipc", () => {
     expect(response).toEqual({
       backend: "codex",
       threadId: "thread-1",
+      provider: "github.com",
       ghAvailable: true,
       prs: [],
     });
@@ -1293,21 +1333,20 @@ describe("app server ipc", () => {
       branch: "feat/no-pr-yet",
       directoryPaths: ["/repo"],
     } satisfies RefreshThreadPullRequestsRequest;
-    const requestKey = JSON.stringify({
-      lookupVersion: 2,
+    const requestKey = buildThreadPrRequestKey({
       backend: "codex",
       threadId: "thread-1",
       branch: "feat/no-pr-yet",
       directoryPaths: ["/repo"],
     });
     const fetchedPrs: PrSummary[] = [
-      {
+      githubPr({
         number: 438,
         org: "pwrdrvr",
         repo: "PwrAgent",
         state: "pending",
         url: "https://github.com/pwrdrvr/PwrAgent/pull/438",
-      },
+      }),
     ];
     getThreadOverlayState.mockResolvedValueOnce({
       backend: "codex",
@@ -1330,6 +1369,7 @@ describe("app server ipc", () => {
     expect(response).toEqual({
       backend: "codex",
       threadId: "thread-1",
+      provider: "github.com",
       ghAvailable: true,
       prs: [],
     });
@@ -1362,30 +1402,29 @@ describe("app server ipc", () => {
       branch: "fix/new-branch",
       directoryPaths: ["/repo"],
     } satisfies RefreshThreadPullRequestsRequest;
-    const requestKey = JSON.stringify({
-      lookupVersion: 2,
+    const requestKey = buildThreadPrRequestKey({
       backend: "codex",
       threadId: "thread-1",
       branch: "fix/new-branch",
       directoryPaths: ["/repo"],
     });
     const terminalPrs: PrSummary[] = [
-      {
+      githubPr({
         number: 433,
         org: "pwrdrvr",
         repo: "PwrAgent",
         state: "merged",
         url: "https://github.com/pwrdrvr/PwrAgent/pull/433",
-      },
+      }),
     ];
     const newBranchPrs: PrSummary[] = [
-      {
+      githubPr({
         number: 438,
         org: "pwrdrvr",
         repo: "PwrAgent",
         state: "pending",
         url: "https://github.com/pwrdrvr/PwrAgent/pull/438",
-      },
+      }),
     ];
     getThreadOverlayState.mockResolvedValueOnce({
       backend: "codex",
@@ -1394,8 +1433,7 @@ describe("app server ipc", () => {
       extraLinkedDirectories: [],
       prs: terminalPrs,
       prsFetchedAt: Date.now() - 120_000,
-      prsRefreshKey: JSON.stringify({
-        lookupVersion: 2,
+      prsRefreshKey: buildThreadPrRequestKey({
         backend: "codex",
         threadId: "thread-1",
         branch: "fix/old-branch",
@@ -1414,6 +1452,7 @@ describe("app server ipc", () => {
     expect(response).toEqual({
       backend: "codex",
       threadId: "thread-1",
+      provider: "github.com",
       ghAvailable: true,
       prs: [],
     });
@@ -1444,28 +1483,27 @@ describe("app server ipc", () => {
       branch: "fix/done",
       directoryPaths: ["/repo"],
     } satisfies RefreshThreadPullRequestsRequest;
-    const requestKey = JSON.stringify({
-      lookupVersion: 2,
+    const requestKey = buildThreadPrRequestKey({
       backend: "codex",
       threadId: "thread-1",
       branch: "fix/done",
       directoryPaths: ["/repo"],
     });
     const terminalPrs: PrSummary[] = [
-      {
+      githubPr({
         number: 433,
         org: "pwrdrvr",
         repo: "PwrAgent",
         state: "merged",
         url: "https://github.com/pwrdrvr/PwrAgent/pull/433",
-      },
-      {
+      }),
+      githubPr({
         number: 430,
         org: "pwrdrvr",
         repo: "PwrAgent",
         state: "closed",
         url: "https://github.com/pwrdrvr/PwrAgent/pull/430",
-      },
+      }),
     ];
     getThreadOverlayState.mockResolvedValueOnce({
       backend: "codex",
@@ -1489,6 +1527,7 @@ describe("app server ipc", () => {
     expect(response).toEqual({
       backend: "codex",
       threadId: "thread-1",
+      provider: "github.com",
       ghAvailable: true,
       prs: terminalPrs,
       shortCircuited: true,
@@ -1640,20 +1679,21 @@ describe("app server ipc", () => {
   it("marks snapshots changed when canonical PR statuses update thread PRs", async () => {
     const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
     const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
-    const stalePr: PrSummary = {
+    const stalePr = githubPr({
       number: 727,
       org: "OpenAI",
       repo: "codex",
       state: "pending",
       url: "https://github.com/OpenAI/codex/pull/727",
-    };
+    });
     const cachedPr: PrSummary = {
       ...stalePr,
       state: "passing",
     };
     readPrStatusCache.mockResolvedValueOnce({
-      "openai/codex#727": {
-        prKey: "openai/codex#727",
+      "github.com/openai/codex#727": {
+        provider: "github.com",
+        prKey: "github.com/openai/codex#727",
         fetchedAt: Date.now(),
         pr: cachedPr,
       },

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -1721,6 +1721,130 @@ describe("app server ipc", () => {
     });
   });
 
+  it("rate-limits user-triggered terminal PR lookups to once per minute", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(1_000_000);
+      const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+      const { NAVIGATION_REFRESH_THREAD_PRS_CHANNEL } = await import("../../shared/ipc");
+      const request = {
+        backend: "codex",
+        threadId: "thread-1",
+        trigger: "user",
+        branch: "fix/done",
+        directoryPaths: ["/repo"],
+      } satisfies RefreshThreadPullRequestsRequest;
+      const requestKey = buildThreadPrRequestKey({
+        backend: "codex",
+        threadId: "thread-1",
+        branch: "fix/done",
+        directoryPaths: ["/repo"],
+      });
+      const terminalPrs: PrSummary[] = [
+        githubPr({
+          number: 433,
+          org: "pwrdrvr",
+          repo: "PwrAgent",
+          state: "merged",
+          url: "https://github.com/pwrdrvr/PwrAgent/pull/433",
+        }),
+      ];
+
+      getThreadOverlayState.mockResolvedValue({
+        backend: "codex",
+        threadId: "thread-1",
+        executionMode: "default",
+        extraLinkedDirectories: [],
+        prs: terminalPrs,
+        prsFetchedAt: 1_000_000 - 120_000,
+        prsRefreshKey: requestKey,
+      });
+      detectPullRequestsForThread.mockResolvedValue(terminalPrs);
+
+      registerAppServerIpcHandlers();
+
+      await handlers.get(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL)?.({}, request);
+      await vi.waitFor(() => {
+        expect(detectPullRequestsForThread).toHaveBeenCalledTimes(1);
+      });
+
+      vi.setSystemTime(1_000_000 + 30_000);
+      await handlers.get(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL)?.({}, request);
+      await Promise.resolve();
+      expect(detectPullRequestsForThread).toHaveBeenCalledTimes(1);
+
+      vi.setSystemTime(1_000_000 + 60_000);
+      await handlers.get(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL)?.({}, request);
+      await vi.waitFor(() => {
+        expect(detectPullRequestsForThread).toHaveBeenCalledTimes(2);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps the shorter user cooldown for non-terminal PR lookups", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(2_000_000);
+      const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+      const { NAVIGATION_REFRESH_THREAD_PRS_CHANNEL } = await import("../../shared/ipc");
+      const request = {
+        backend: "codex",
+        threadId: "thread-1",
+        trigger: "user",
+        branch: "fix/open",
+        directoryPaths: ["/repo"],
+      } satisfies RefreshThreadPullRequestsRequest;
+      const requestKey = buildThreadPrRequestKey({
+        backend: "codex",
+        threadId: "thread-1",
+        branch: "fix/open",
+        directoryPaths: ["/repo"],
+      });
+      const pendingPrs: PrSummary[] = [
+        githubPr({
+          number: 434,
+          org: "pwrdrvr",
+          repo: "PwrAgent",
+          state: "pending",
+          url: "https://github.com/pwrdrvr/PwrAgent/pull/434",
+        }),
+      ];
+
+      getThreadOverlayState.mockResolvedValue({
+        backend: "codex",
+        threadId: "thread-1",
+        executionMode: "default",
+        extraLinkedDirectories: [],
+        prs: pendingPrs,
+        prsFetchedAt: 2_000_000 - 120_000,
+        prsRefreshKey: requestKey,
+      });
+      detectPullRequestsForThread.mockResolvedValue(pendingPrs);
+
+      registerAppServerIpcHandlers();
+
+      await handlers.get(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL)?.({}, request);
+      await vi.waitFor(() => {
+        expect(detectPullRequestsForThread).toHaveBeenCalledTimes(1);
+      });
+
+      vi.setSystemTime(2_000_000 + 9_000);
+      await handlers.get(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL)?.({}, request);
+      await Promise.resolve();
+      expect(detectPullRequestsForThread).toHaveBeenCalledTimes(1);
+
+      vi.setSystemTime(2_000_000 + 10_000);
+      await handlers.get(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL)?.({}, request);
+      await vi.waitFor(() => {
+        expect(detectPullRequestsForThread).toHaveBeenCalledTimes(2);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("preserves unchanged snapshots when directory statuses are unchanged", async () => {
     const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
     const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -1093,6 +1093,84 @@ describe("app server ipc", () => {
     expect(detectPullRequestsForThread).not.toHaveBeenCalled();
   });
 
+  it("persists fresh lookup-cache hits to the requesting thread overlay", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_REFRESH_THREAD_PRS_CHANNEL } = await import("../../shared/ipc");
+    const cachedPr: PrSummary = {
+      number: 727,
+      org: "OpenAI",
+      repo: "codex",
+      state: "passing",
+      url: "https://github.com/OpenAI/codex/pull/727",
+    };
+    const request = {
+      backend: "codex",
+      threadId: "thread-1",
+      trigger: "scheduled",
+      branch: "hot-cpu-capture-presets",
+      directoryPaths: ["/repo"],
+    } satisfies RefreshThreadPullRequestsRequest;
+    const requestKey = JSON.stringify({
+      lookupVersion: 2,
+      backend: "codex",
+      threadId: "thread-1",
+      branch: "hot-cpu-capture-presets",
+      directoryPaths: ["/repo"],
+    });
+    const fetchedAt = Date.now();
+    const lookupKey = JSON.stringify({
+      lookupVersion: 1,
+      branch: "hot-cpu-capture-presets",
+      directoryPaths: ["/repo"],
+    });
+    readPrLookupCache.mockResolvedValueOnce({
+      [lookupKey]: {
+        lookupKey,
+        branch: "hot-cpu-capture-presets",
+        directoryPaths: ["/repo"],
+        fetchedAt,
+        prs: [cachedPr],
+      },
+    });
+    getThreadOverlayState.mockResolvedValueOnce({
+      backend: "codex",
+      threadId: "thread-1",
+      executionMode: "default",
+      extraLinkedDirectories: [],
+      prs: [],
+      prsFetchedAt: Date.now() - 300_000,
+      prsRefreshKey: JSON.stringify({
+        lookupVersion: 2,
+        backend: "codex",
+        threadId: "thread-1",
+        branch: "old-branch",
+        directoryPaths: ["/repo"],
+      }),
+    });
+
+    registerAppServerIpcHandlers();
+
+    const response = await handlers.get(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL)?.(
+      {},
+      request,
+    );
+
+    expect(response).toEqual({
+      backend: "codex",
+      threadId: "thread-1",
+      ghAvailable: true,
+      prs: [cachedPr],
+    });
+    expect(detectPullRequestsForThread).not.toHaveBeenCalled();
+    expect(setThreadPullRequests).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      prs: [cachedPr],
+      fetchedAt,
+      refreshKey: requestKey,
+    });
+  });
+
   it("coalesces concurrent first-time PR lookups for the same branch and directories", async () => {
     const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
     const { NAVIGATION_REFRESH_THREAD_PRS_CHANNEL } = await import("../../shared/ipc");
@@ -1556,6 +1634,89 @@ describe("app server ipc", () => {
         backend: "codex",
         executionMode: "default",
       },
+    });
+  });
+
+  it("marks snapshots changed when canonical PR statuses update thread PRs", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+    const stalePr: PrSummary = {
+      number: 727,
+      org: "OpenAI",
+      repo: "codex",
+      state: "pending",
+      url: "https://github.com/OpenAI/codex/pull/727",
+    };
+    const cachedPr: PrSummary = {
+      ...stalePr,
+      state: "passing",
+    };
+    readPrStatusCache.mockResolvedValueOnce({
+      "openai/codex#727": {
+        prKey: "openai/codex#727",
+        fetchedAt: Date.now(),
+        pr: cachedPr,
+      },
+    });
+    reconcileNavigationSnapshot
+      .mockResolvedValueOnce({
+        backend: "all",
+        fetchedAt: 1234,
+        unchanged: false,
+        threads: [
+          {
+            id: "thread-1",
+            title: "Thread one",
+            titleSource: "explicit" as const,
+            source: "codex" as const,
+            linkedDirectories: [],
+            updatedAt: 2000,
+            prs: [stalePr],
+          },
+        ],
+        inboxThreadKeys: ["codex:thread-1"],
+        directories: [],
+        launchpadDefaults: {
+          backend: "codex" as const,
+          executionMode: "default" as const,
+        },
+      })
+      .mockResolvedValueOnce({
+        backend: "all",
+        fetchedAt: 5678,
+        unchanged: true,
+        threads: [
+          {
+            id: "thread-1",
+            title: "Thread one",
+            titleSource: "explicit" as const,
+            source: "codex" as const,
+            linkedDirectories: [],
+            updatedAt: 2000,
+            prs: [stalePr],
+          },
+        ],
+        inboxThreadKeys: ["codex:thread-1"],
+        directories: [],
+        launchpadDefaults: {
+          backend: "codex" as const,
+          executionMode: "default" as const,
+        },
+      });
+
+    registerAppServerIpcHandlers();
+
+    await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
+    const response = await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
+
+    expect(response).toMatchObject({
+      unchanged: false,
+      threads: [
+        {
+          id: "thread-1",
+          prs: [cachedPr],
+        },
+      ],
     });
   });
 

--- a/apps/desktop/src/main/__tests__/github-pr-fetcher.test.ts
+++ b/apps/desktop/src/main/__tests__/github-pr-fetcher.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it, vi } from "vitest";
 import {
   GithubPrFetcher,
   deriveChipState,
+  deriveLifecycleState,
+  deriveMergeState,
+  deriveReviewState,
   parseGhAuthStatus,
   parseGhPrPayload,
 } from "../pr-status/github-pr-fetcher";
@@ -16,6 +19,8 @@ function rawMergedPr() {
     url: "https://github.com/pwrdrvr/PwrAgent/pull/178",
     state: "MERGED",
     isDraft: false,
+    mergeable: "MERGEABLE",
+    mergeStateStatus: "CLEAN",
     mergedAt: "2026-05-05T00:06:31Z",
     headRefName: "feat/desktop-thread-reactions-and-pr-chips",
     headRepository: { name: "PwrAgent" },
@@ -39,7 +44,11 @@ describe("parseGhPrPayload", () => {
       org: "pwrdrvr",
       repo: "PwrAgent",
       title: "Retain thread pull request history",
-      state: "merged",
+      state: "passing",
+      checkState: "passing",
+      lifecycleState: "merged",
+      reviewState: "ready_for_review",
+      mergeState: "unknown",
       url: "https://github.com/pwrdrvr/PwrAgent/pull/178",
     });
   });
@@ -61,31 +70,42 @@ describe("parseGhPrPayload", () => {
   });
 });
 
-describe("deriveChipState", () => {
-  it("returns merged for MERGED state regardless of checks", () => {
-    expect(deriveChipState({ ...rawMergedPr(), state: "MERGED" })).toBe(
-      "merged",
-    );
+describe("derive PR states", () => {
+  it("keeps lifecycle separate from check state", () => {
+    const row = { ...rawMergedPr(), state: "MERGED" };
+    expect(deriveLifecycleState(row)).toBe("merged");
+    expect(deriveChipState(row)).toBe("passing");
   });
 
-  it("returns closed for CLOSED state without merge", () => {
-    expect(
-      deriveChipState({
-        ...rawMergedPr(),
-        state: "CLOSED",
-        mergedAt: null,
-      }),
-    ).toBe("closed");
+  it("keeps closed lifecycle separate from check state", () => {
+    const row = {
+      ...rawMergedPr(),
+      state: "CLOSED",
+      mergedAt: null,
+    };
+    expect(deriveLifecycleState(row)).toBe("closed");
+    expect(deriveChipState(row)).toBe("passing");
   });
 
-  it("returns draft for OPEN + isDraft", () => {
-    expect(
-      deriveChipState({
-        ...rawMergedPr(),
-        state: "OPEN",
-        isDraft: true,
-      }),
-    ).toBe("draft");
+  it("keeps draft review state separate from check state", () => {
+    const row = {
+      ...rawMergedPr(),
+      state: "OPEN",
+      isDraft: true,
+    };
+    expect(deriveReviewState(row)).toBe("draft");
+    expect(deriveChipState(row)).toBe("passing");
+  });
+
+  it("detects merge conflicts separately from check state", () => {
+    const row = {
+      ...rawMergedPr(),
+      state: "OPEN",
+      mergeable: "CONFLICTING",
+      mergeStateStatus: "DIRTY",
+    };
+    expect(deriveMergeState(row)).toBe("conflicting");
+    expect(deriveChipState(row)).toBe("passing");
   });
 
   it("returns passing when all checks SUCCEEDED", () => {
@@ -369,7 +389,11 @@ describe("GithubPrFetcher", () => {
           org: "pwrdrvr",
           repo: "PwrAgent",
           title: "Retain thread pull request history",
-          state: "merged",
+          state: "passing",
+          checkState: "passing",
+          lifecycleState: "merged",
+          reviewState: "ready_for_review",
+          mergeState: "unknown",
           url: "https://github.com/pwrdrvr/PwrAgent/pull/178",
         },
       ]);

--- a/apps/desktop/src/main/__tests__/github-pr-fetcher.test.ts
+++ b/apps/desktop/src/main/__tests__/github-pr-fetcher.test.ts
@@ -12,6 +12,7 @@ import {
 function rawMergedPr() {
   return {
     number: 178,
+    title: "Retain thread pull request history",
     url: "https://github.com/pwrdrvr/PwrAgent/pull/178",
     state: "MERGED",
     isDraft: false,
@@ -37,9 +38,16 @@ describe("parseGhPrPayload", () => {
       number: 178,
       org: "pwrdrvr",
       repo: "PwrAgent",
+      title: "Retain thread pull request history",
       state: "merged",
       url: "https://github.com/pwrdrvr/PwrAgent/pull/178",
     });
+  });
+
+  it("omits blank titles from PrSummary", () => {
+    expect(parseGhPrPayload({ ...rawMergedPr(), title: " " })).not.toHaveProperty(
+      "title",
+    );
   });
 
   it("falls back to empty strings for missing repo/owner", () => {
@@ -360,6 +368,7 @@ describe("GithubPrFetcher", () => {
           number: 178,
           org: "pwrdrvr",
           repo: "PwrAgent",
+          title: "Retain thread pull request history",
           state: "merged",
           url: "https://github.com/pwrdrvr/PwrAgent/pull/178",
         },
@@ -377,6 +386,7 @@ describe("GithubPrFetcher", () => {
         "--limit",
         "5",
       ]);
+      expect(args[args.indexOf("--json") + 1]).toContain("title");
     });
 
     it("returns [] on subprocess failure", async () => {

--- a/apps/desktop/src/main/__tests__/github-pr-fetcher.test.ts
+++ b/apps/desktop/src/main/__tests__/github-pr-fetcher.test.ts
@@ -33,6 +33,7 @@ function rawMergedPr() {
 describe("parseGhPrPayload", () => {
   it("maps the pinned JSON shape into a PrSummary", () => {
     expect(parseGhPrPayload(rawMergedPr())).toEqual({
+      provider: "github.com",
       number: 178,
       org: "pwrdrvr",
       repo: "PwrAgent",
@@ -355,6 +356,7 @@ describe("GithubPrFetcher", () => {
       });
       expect(result).toEqual([
         {
+          provider: "github.com",
           number: 178,
           org: "pwrdrvr",
           repo: "PwrAgent",

--- a/apps/desktop/src/main/__tests__/overlay-store-prs.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-prs.test.ts
@@ -144,4 +144,31 @@ describe("SqliteOverlayStore — thread PRs", () => {
     });
     expect(next.prs).toEqual([]);
   });
+
+  it("persists canonical PR status cache rows across reopen", async () => {
+    await store.writePrStatusCacheEntries([
+      {
+        prKey: "pwrdrvr/pwragent#179",
+        fetchedAt: 1234,
+        pr: prPassing,
+      },
+    ]);
+
+    const dbPath = path.join(tempDir, "state.db");
+    stateDb.close();
+
+    const reopened = StateDb.open(dbPath);
+    const reopenedStore = new SqliteOverlayStore(reopened);
+    await expect(reopenedStore.readPrStatusCache()).resolves.toEqual({
+      "pwrdrvr/pwragent#179": {
+        prKey: "pwrdrvr/pwragent#179",
+        fetchedAt: 1234,
+        pr: prPassing,
+      },
+    });
+    reopened.close();
+
+    stateDb = StateDb.open(dbPath);
+    store = new SqliteOverlayStore(stateDb);
+  });
 });

--- a/apps/desktop/src/main/__tests__/overlay-store-prs.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-prs.test.ts
@@ -171,4 +171,33 @@ describe("SqliteOverlayStore — thread PRs", () => {
     stateDb = StateDb.open(dbPath);
     store = new SqliteOverlayStore(stateDb);
   });
+
+  it("persists branch lookup cache rows across reopen", async () => {
+    await store.writePrLookupCacheEntry({
+      lookupKey: "lookup:repo:branch",
+      branch: "feat/pr-chip",
+      directoryPaths: ["/repo"],
+      fetchedAt: 2345,
+      prs: [prPassing],
+    });
+
+    const dbPath = path.join(tempDir, "state.db");
+    stateDb.close();
+
+    const reopened = StateDb.open(dbPath);
+    const reopenedStore = new SqliteOverlayStore(reopened);
+    await expect(reopenedStore.readPrLookupCache()).resolves.toEqual({
+      "lookup:repo:branch": {
+        lookupKey: "lookup:repo:branch",
+        branch: "feat/pr-chip",
+        directoryPaths: ["/repo"],
+        fetchedAt: 2345,
+        prs: [prPassing],
+      },
+    });
+    reopened.close();
+
+    stateDb = StateDb.open(dbPath);
+    store = new SqliteOverlayStore(stateDb);
+  });
 });

--- a/apps/desktop/src/main/__tests__/overlay-store-prs.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-prs.test.ts
@@ -21,32 +21,66 @@ afterEach(() => {
   rmSync(tempDir, { recursive: true, force: true });
 });
 
-const prMerged: PrSummary = {
+const prMerged: PrSummary = pr({
   provider: "github.com",
   number: 178,
   org: "pwrdrvr",
   repo: "PwrAgent",
   state: "merged",
   url: "https://github.com/pwrdrvr/PwrAgent/pull/178",
-};
+});
 
-const prPassing: PrSummary = {
+const prPassing: PrSummary = pr({
   provider: "github.com",
   number: 179,
   org: "pwrdrvr",
   repo: "PwrAgent",
   state: "passing",
   url: "https://github.com/pwrdrvr/PwrAgent/pull/179",
-};
+});
 
-const enterprisePrPassing: PrSummary = {
+const enterprisePrPassing: PrSummary = pr({
   provider: "ghe.pwrdrvr.test",
   number: 179,
   org: "pwrdrvr",
   repo: "PwrAgent",
   state: "passing",
   url: "https://ghe.pwrdrvr.test/pwrdrvr/PwrAgent/pull/179",
-};
+});
+
+function pr(
+  value: Omit<PrSummary, "checkState" | "lifecycleState" | "reviewState" | "mergeState">
+    & Partial<Pick<PrSummary, "checkState" | "lifecycleState" | "reviewState" | "mergeState">>,
+): PrSummary {
+  const checkState = value.checkState ?? normalizeCheckState(value.state);
+  return {
+    ...value,
+    state: checkState,
+    checkState,
+    lifecycleState: value.lifecycleState ?? legacyLifecycleState(value.state),
+    reviewState: value.reviewState ?? (value.state === "draft" ? "draft" : "ready_for_review"),
+    mergeState: value.mergeState ?? "unknown",
+  };
+}
+
+function normalizeCheckState(state: PrSummary["state"]): NonNullable<PrSummary["checkState"]> {
+  if (
+    state === "passing"
+    || state === "failing"
+    || state === "pending"
+    || state === "unknown"
+  ) {
+    return state;
+  }
+  return "unknown";
+}
+
+function legacyLifecycleState(state: PrSummary["state"]): NonNullable<PrSummary["lifecycleState"]> {
+  if (state === "merged" || state === "closed") {
+    return state;
+  }
+  return "open";
+}
 
 describe("SqliteOverlayStore — thread PRs", () => {
   it("starts with no prs on a thread that has never been touched", async () => {
@@ -79,12 +113,12 @@ describe("SqliteOverlayStore — thread PRs", () => {
     await store.setThreadPullRequests({
       backend: "codex",
       threadId: "thread-1",
-      prs: [{ ...prPassing, state: "pending" }],
+      prs: [pr({ ...prPassing, state: "pending", checkState: "pending" })],
     });
     await store.setThreadPullRequests({
       backend: "codex",
       threadId: "thread-1",
-      prs: [{ ...prPassing, state: "failing" }],
+      prs: [pr({ ...prPassing, state: "failing", checkState: "failing" })],
     });
 
     const overlay = await store.getThreadOverlayState({

--- a/apps/desktop/src/main/__tests__/overlay-store-prs.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-prs.test.ts
@@ -22,6 +22,7 @@ afterEach(() => {
 });
 
 const prMerged: PrSummary = {
+  provider: "github.com",
   number: 178,
   org: "pwrdrvr",
   repo: "PwrAgent",
@@ -30,6 +31,7 @@ const prMerged: PrSummary = {
 };
 
 const prPassing: PrSummary = {
+  provider: "github.com",
   number: 179,
   org: "pwrdrvr",
   repo: "PwrAgent",
@@ -148,7 +150,8 @@ describe("SqliteOverlayStore — thread PRs", () => {
   it("persists canonical PR status cache rows across reopen", async () => {
     await store.writePrStatusCacheEntries([
       {
-        prKey: "pwrdrvr/pwragent#179",
+        provider: "github.com",
+        prKey: "github.com/pwrdrvr/pwragent#179",
         fetchedAt: 1234,
         pr: prPassing,
       },
@@ -160,8 +163,9 @@ describe("SqliteOverlayStore — thread PRs", () => {
     const reopened = StateDb.open(dbPath);
     const reopenedStore = new SqliteOverlayStore(reopened);
     await expect(reopenedStore.readPrStatusCache()).resolves.toEqual({
-      "pwrdrvr/pwragent#179": {
-        prKey: "pwrdrvr/pwragent#179",
+      "github.com/pwrdrvr/pwragent#179": {
+        provider: "github.com",
+        prKey: "github.com/pwrdrvr/pwragent#179",
         fetchedAt: 1234,
         pr: prPassing,
       },
@@ -174,7 +178,8 @@ describe("SqliteOverlayStore — thread PRs", () => {
 
   it("persists branch lookup cache rows across reopen", async () => {
     await store.writePrLookupCacheEntry({
-      lookupKey: "lookup:repo:branch",
+      lookupKey: "{\"lookupVersion\":2,\"provider\":\"github.com\",\"branch\":\"feat/pr-chip\",\"directoryPaths\":[\"/repo\"]}",
+      provider: "github.com",
       branch: "feat/pr-chip",
       directoryPaths: ["/repo"],
       fetchedAt: 2345,
@@ -187,8 +192,9 @@ describe("SqliteOverlayStore — thread PRs", () => {
     const reopened = StateDb.open(dbPath);
     const reopenedStore = new SqliteOverlayStore(reopened);
     await expect(reopenedStore.readPrLookupCache()).resolves.toEqual({
-      "lookup:repo:branch": {
-        lookupKey: "lookup:repo:branch",
+      "{\"lookupVersion\":2,\"provider\":\"github.com\",\"branch\":\"feat/pr-chip\",\"directoryPaths\":[\"/repo\"]}": {
+        lookupKey: "{\"lookupVersion\":2,\"provider\":\"github.com\",\"branch\":\"feat/pr-chip\",\"directoryPaths\":[\"/repo\"]}",
+        provider: "github.com",
         branch: "feat/pr-chip",
         directoryPaths: ["/repo"],
         fetchedAt: 2345,

--- a/apps/desktop/src/main/__tests__/overlay-store-prs.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-prs.test.ts
@@ -39,6 +39,15 @@ const prPassing: PrSummary = {
   url: "https://github.com/pwrdrvr/PwrAgent/pull/179",
 };
 
+const enterprisePrPassing: PrSummary = {
+  provider: "ghe.pwrdrvr.test",
+  number: 179,
+  org: "pwrdrvr",
+  repo: "PwrAgent",
+  state: "passing",
+  url: "https://ghe.pwrdrvr.test/pwrdrvr/PwrAgent/pull/179",
+};
+
 describe("SqliteOverlayStore — thread PRs", () => {
   it("starts with no prs on a thread that has never been touched", async () => {
     const overlay = await store.getThreadOverlayState({
@@ -205,5 +214,29 @@ describe("SqliteOverlayStore — thread PRs", () => {
 
     stateDb = StateDb.open(dbPath);
     store = new SqliteOverlayStore(stateDb);
+  });
+
+  it("preserves PR providers inside branch lookup cache payloads", async () => {
+    await store.writePrLookupCacheEntry({
+      lookupKey: "{\"lookupVersion\":2,\"provider\":\"github.com\",\"branch\":\"feat/pr-chip\",\"directoryPaths\":[\"/repo\"]}",
+      provider: "github.com",
+      branch: "feat/pr-chip",
+      directoryPaths: ["/repo"],
+      fetchedAt: 2345,
+      prs: [enterprisePrPassing],
+    });
+
+    const entries = await store.readPrLookupCache();
+
+    expect(entries).toEqual({
+      "{\"lookupVersion\":2,\"provider\":\"github.com\",\"branch\":\"feat/pr-chip\",\"directoryPaths\":[\"/repo\"]}": {
+        lookupKey: "{\"lookupVersion\":2,\"provider\":\"github.com\",\"branch\":\"feat/pr-chip\",\"directoryPaths\":[\"/repo\"]}",
+        provider: "github.com",
+        branch: "feat/pr-chip",
+        directoryPaths: ["/repo"],
+        fetchedAt: 2345,
+        prs: [enterprisePrPassing],
+      },
+    });
   });
 });

--- a/apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts
@@ -980,6 +980,82 @@ describe("RendererHotCpuProfiler", () => {
     ).toHaveLength(1);
   });
 
+  it("waits for an in-flight duration stop before detaching", async () => {
+    const workspace = await createTemporaryTestDirectory();
+    cleanups.push(workspace.cleanup);
+
+    const config = createEnabledConfig(workspace.path);
+    const sessionResult = await createHotCpuProfileSession({
+      config,
+      createdAt: new Date(2026, 5, 1, 15, 30, 0),
+      sessionId: "abc123",
+      versions: {
+        appVersion: "1.0.0",
+        electronVersion: "41.2.1",
+        chromeVersion: "146.0.0.0",
+        nodeVersion: "24.0.0",
+      },
+    });
+    expect(sessionResult.ok).toBe(true);
+    if (!sessionResult.ok) return;
+
+    vi.useFakeTimers();
+
+    const stopCommand = deferred<{ profile: { nodes: Array<{ id: number }> } }>();
+    const { target, debuggerApi } = createTarget();
+    debuggerApi.sendCommand.mockImplementation(async (method: string) => {
+      if (method === "Profiler.stop") {
+        return stopCommand.promise;
+      }
+
+      return {};
+    });
+    const profiler = new RendererHotCpuProfiler({
+      config,
+      getAppMetrics: () => [createMetric(89)],
+      session: sessionResult.session,
+      target,
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+    });
+
+    await (
+      profiler as unknown as {
+        startProfile: (options: {
+          capturedAt: string;
+          cpuPercent: number;
+          pid: number;
+        }) => Promise<void>;
+      }
+    ).startProfile({
+      capturedAt: new Date().toISOString(),
+      cpuPercent: 89,
+      pid: 1234,
+    });
+
+    await vi.advanceTimersByTimeAsync(config.profileDurationMs);
+    await vi.waitFor(() => {
+      expect(
+        debuggerApi.sendCommand.mock.calls.filter(
+          ([method]) => method === "Profiler.stop",
+        ),
+      ).toHaveLength(1);
+    });
+
+    const stopPromise = profiler.stop("test-complete");
+    await Promise.resolve();
+
+    expect(debuggerApi.detach).not.toHaveBeenCalled();
+
+    stopCommand.resolve({ profile: { nodes: [{ id: 1 }] } });
+    await stopPromise;
+
+    expect(debuggerApi.detach).toHaveBeenCalled();
+  });
+
   it("does not query debugger attachment when the renderer is destroyed", async () => {
     const workspace = await createTemporaryTestDirectory();
     cleanups.push(workspace.cleanup);

--- a/apps/desktop/src/main/__tests__/state-db.test.ts
+++ b/apps/desktop/src/main/__tests__/state-db.test.ts
@@ -21,12 +21,13 @@ describe("StateDb", () => {
   it("creates additive runtime cache tables", () => {
     const tables = stateDb.raw
       .prepare(
-        `SELECT name FROM sqlite_master WHERE type = 'table' AND name IN (?, ?, ?, ?) ORDER BY name`,
+        `SELECT name FROM sqlite_master WHERE type = 'table' AND name IN (?, ?, ?, ?, ?) ORDER BY name`,
       )
       .all(
         "acp_installed_agents",
         "acp_registry_cache",
         "acp_sessions",
+        "pr_lookup_cache",
         "pr_status_cache",
       ) as Array<{ name: string }>;
 
@@ -34,6 +35,7 @@ describe("StateDb", () => {
       "acp_installed_agents",
       "acp_registry_cache",
       "acp_sessions",
+      "pr_lookup_cache",
       "pr_status_cache",
     ]);
     expect(stateDb.raw.pragma("user_version", { simple: true })).toBe(

--- a/apps/desktop/src/main/__tests__/state-db.test.ts
+++ b/apps/desktop/src/main/__tests__/state-db.test.ts
@@ -42,4 +42,16 @@ describe("StateDb", () => {
       CURRENT_STATE_DB_USER_VERSION,
     );
   });
+
+  it("creates provider-aware pull request cache columns", () => {
+    const prStatusColumns = stateDb.raw
+      .prepare("PRAGMA table_info(pr_status_cache)")
+      .all() as Array<{ name: string }>;
+    const prLookupColumns = stateDb.raw
+      .prepare("PRAGMA table_info(pr_lookup_cache)")
+      .all() as Array<{ name: string }>;
+
+    expect(prStatusColumns.map((column) => column.name)).toContain("provider");
+    expect(prLookupColumns.map((column) => column.name)).toContain("provider");
+  });
 });

--- a/apps/desktop/src/main/__tests__/state-db.test.ts
+++ b/apps/desktop/src/main/__tests__/state-db.test.ts
@@ -1,7 +1,10 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import Database from "better-sqlite3";
+import type BetterSqlite3 from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getNativeBinding } from "../state/native-binding";
 import { CURRENT_STATE_DB_USER_VERSION, StateDb } from "../state/state-db";
 
 let stateDb: StateDb;
@@ -54,4 +57,136 @@ describe("StateDb", () => {
     expect(prStatusColumns.map((column) => column.name)).toContain("provider");
     expect(prLookupColumns.map((column) => column.name)).toContain("provider");
   });
+
+  it("repairs databases that used version 13 for the old PR cache migration", () => {
+    stateDb.close();
+
+    const dbPath = path.join(tempDir, "legacy-pr-cache-state.db");
+    const raw = openRawDb(dbPath);
+    raw.exec(`
+      PRAGMA user_version = 13;
+      CREATE TABLE pr_status_cache (
+        pr_key     TEXT PRIMARY KEY,
+        org        TEXT NOT NULL,
+        repo       TEXT NOT NULL,
+        number     INTEGER NOT NULL,
+        fetched_at INTEGER NOT NULL,
+        payload    TEXT NOT NULL
+      );
+    `);
+    raw.close();
+
+    stateDb = StateDb.open(dbPath);
+
+    expect(existingTables()).toEqual([
+      "pr_lookup_cache",
+      "pr_status_cache",
+      "thread_search_documents",
+      "thread_search_fts",
+    ]);
+    expect(columnNames("pr_status_cache")).toContain("provider");
+    expect(columnNames("pr_lookup_cache")).toContain("provider");
+    expect(stateDb.raw.pragma("user_version", { simple: true })).toBe(
+      CURRENT_STATE_DB_USER_VERSION,
+    );
+  });
+
+  it("repairs version 13 databases that only have thread search", () => {
+    stateDb.close();
+
+    const dbPath = path.join(tempDir, "legacy-thread-search-state.db");
+    const raw = openRawDb(dbPath);
+    raw.exec(`
+      PRAGMA user_version = 13;
+      CREATE TABLE thread_search_documents (
+        identity_key            TEXT PRIMARY KEY,
+        backend                 TEXT NOT NULL,
+        thread_id               TEXT NOT NULL,
+        title                   TEXT NOT NULL,
+        title_source            TEXT,
+        summary                 TEXT,
+        project_key             TEXT,
+        created_at              INTEGER,
+        updated_at              INTEGER,
+        archived_at             INTEGER,
+        git_branch              TEXT,
+        git_origin_url          TEXT,
+        model                   TEXT,
+        linked_directories_json TEXT NOT NULL,
+        display_json            TEXT NOT NULL,
+        indexed_at              INTEGER NOT NULL
+      );
+      CREATE INDEX idx_thread_search_documents_backend_updated
+        ON thread_search_documents(backend, updated_at DESC);
+      CREATE INDEX idx_thread_search_documents_project_updated
+        ON thread_search_documents(project_key, updated_at DESC);
+      CREATE INDEX idx_thread_search_documents_archived
+        ON thread_search_documents(archived_at);
+      CREATE VIRTUAL TABLE thread_search_fts USING fts5(
+        identity_key UNINDEXED,
+        title,
+        summary,
+        project_key,
+        directory_labels,
+        directory_paths,
+        git_branch,
+        git_origin_url,
+        model,
+        backend,
+        tokenize = "unicode61 remove_diacritics 2 tokenchars '-_./:'"
+      );
+    `);
+    raw.close();
+
+    stateDb = StateDb.open(dbPath);
+
+    expect(existingTables()).toEqual([
+      "pr_lookup_cache",
+      "pr_status_cache",
+      "thread_search_documents",
+      "thread_search_fts",
+    ]);
+    expect(stateDb.raw.pragma("user_version", { simple: true })).toBe(
+      CURRENT_STATE_DB_USER_VERSION,
+    );
+  });
 });
+
+function openRawDb(dbPath: string): BetterSqlite3.Database {
+  const nativeBinding = getNativeBinding();
+  return new Database(dbPath, nativeBinding ? { nativeBinding } : {});
+}
+
+function existingTables(): string[] {
+  const rows = stateDb.raw
+    .prepare(
+      `SELECT name FROM sqlite_master WHERE type = 'table' AND name IN (?, ?, ?, ?) ORDER BY name`,
+    )
+    .all(
+      "pr_lookup_cache",
+      "pr_status_cache",
+      "thread_search_documents",
+      "thread_search_fts",
+    ) as Array<{ name: string }>;
+  return rows.map((row) => row.name);
+}
+
+function columnNames(tableName: "pr_lookup_cache" | "pr_status_cache"): string[] {
+  const rows = readTableInfo(tableName);
+  return rows.map((row) => row.name);
+}
+
+function readTableInfo(
+  tableName: "pr_lookup_cache" | "pr_status_cache",
+): Array<{ name: string }> {
+  switch (tableName) {
+    case "pr_lookup_cache":
+      return stateDb.raw.prepare("PRAGMA table_info(pr_lookup_cache)").all() as Array<{
+        name: string;
+      }>;
+    case "pr_status_cache":
+      return stateDb.raw.prepare("PRAGMA table_info(pr_status_cache)").all() as Array<{
+        name: string;
+      }>;
+  }
+}

--- a/apps/desktop/src/main/__tests__/state-db.test.ts
+++ b/apps/desktop/src/main/__tests__/state-db.test.ts
@@ -18,19 +18,23 @@ afterEach(() => {
 });
 
 describe("StateDb", () => {
-  it("creates ACP registry, installed-agent, and session tables", () => {
+  it("creates additive runtime cache tables", () => {
     const tables = stateDb.raw
       .prepare(
-        `SELECT name FROM sqlite_master WHERE type = 'table' AND name IN (?, ?, ?) ORDER BY name`,
+        `SELECT name FROM sqlite_master WHERE type = 'table' AND name IN (?, ?, ?, ?) ORDER BY name`,
       )
-      .all("acp_installed_agents", "acp_registry_cache", "acp_sessions") as Array<{
-      name: string;
-    }>;
+      .all(
+        "acp_installed_agents",
+        "acp_registry_cache",
+        "acp_sessions",
+        "pr_status_cache",
+      ) as Array<{ name: string }>;
 
     expect(tables.map((table) => table.name)).toEqual([
       "acp_installed_agents",
       "acp_registry_cache",
       "acp_sessions",
+      "pr_status_cache",
     ]);
     expect(stateDb.raw.pragma("user_version", { simple: true })).toBe(
       CURRENT_STATE_DB_USER_VERSION,

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -376,10 +376,41 @@ function normalizePullRequestProvider(provider: string | undefined): string {
 }
 
 function normalizePrSummary(pr: PrSummary): PrSummary {
+  const checkState = normalizePrCheckState(pr.checkState ?? pr.state);
   return {
     ...pr,
     provider: normalizePullRequestProvider(pr.provider),
+    state: checkState,
+    checkState,
+    lifecycleState: pr.lifecycleState ?? legacyPrLifecycleState(pr.state),
+    reviewState: pr.reviewState ?? legacyPrReviewState(pr.state),
+    mergeState: pr.mergeState ?? "unknown",
   };
+}
+
+function normalizePrCheckState(
+  state: string | undefined,
+): NonNullable<PrSummary["checkState"]> {
+  if (
+    state === "passing"
+    || state === "failing"
+    || state === "pending"
+    || state === "unknown"
+  ) {
+    return state;
+  }
+  return "unknown";
+}
+
+function legacyPrLifecycleState(state: string | undefined): PrSummary["lifecycleState"] {
+  if (state === "merged" || state === "closed") {
+    return state;
+  }
+  return "open";
+}
+
+function legacyPrReviewState(state: string | undefined): PrSummary["reviewState"] {
+  return state === "draft" ? "draft" : "ready_for_review";
 }
 
 function getPrStatusKey(
@@ -403,6 +434,10 @@ function prSummariesEqual(left: PrSummary[], right: PrSummary[]): boolean {
       candidate.repo === pr.repo &&
       candidate.title === pr.title &&
       candidate.state === pr.state &&
+      candidate.checkState === pr.checkState &&
+      candidate.lifecycleState === pr.lifecycleState &&
+      candidate.reviewState === pr.reviewState &&
+      candidate.mergeState === pr.mergeState &&
       candidate.url === pr.url
     );
   });
@@ -1205,7 +1240,7 @@ class DesktopAppServerService {
     const allExistingPrsTerminal =
       currentLookupPrs.length > 0
       && currentLookupPrs.every(
-        (pr) => pr.state === "merged" || pr.state === "closed",
+        (pr) => pr.lifecycleState === "merged" || pr.lifecycleState === "closed",
       );
     if (
       allExistingPrsTerminal

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import type {
   DirectoryGitStatusCacheEntry,
   OverlayStoreLike,
+  PrLookupCacheEntry,
   PrStatusCacheEntry,
   SqliteOverlayStore,
 } from "../state/overlay-store-sqlite";
@@ -88,6 +89,7 @@ import {
   type UpdateSubthreadOrderRequest,
   type UpdateSubthreadOrderResponse,
 } from "@pwragent/shared";
+import { buildThreadIdentityKey } from "@pwragent/shared";
 import { registerDirectoryFromDisk } from "../app-server/directory-registration-service";
 import {
   disposeDesktopBackendRegistry,
@@ -345,6 +347,21 @@ function getThreadPullRequestsRequestKey(
   });
 }
 
+function normalizePrLookupDirectoryPaths(directoryPaths: string[]): string[] {
+  return [...new Set(directoryPaths.map((path) => path.trim()).filter(Boolean))]
+    .sort((left, right) => left.localeCompare(right));
+}
+
+function getPullRequestLookupKey(
+  request: Pick<RefreshThreadPullRequestsRequest, "branch" | "directoryPaths">,
+): string {
+  return JSON.stringify({
+    lookupVersion: 1,
+    branch: request.branch.trim(),
+    directoryPaths: normalizePrLookupDirectoryPaths(request.directoryPaths),
+  });
+}
+
 function getPrStatusKey(pr: Pick<PrSummary, "org" | "repo" | "number">): string {
   return `${pr.org.toLowerCase()}/${pr.repo.toLowerCase()}#${pr.number}`;
 }
@@ -371,6 +388,22 @@ type PrStatusRegistryEntry = {
   fetchedAt: number;
   lastScheduledRefreshRequestedAt?: number;
   lastUserRefreshRequestedAt?: number;
+};
+
+type PrLookupRegistryEntry = {
+  prs: PrSummary[];
+  fetchedAt: number;
+  branch: string;
+  directoryPaths: string[];
+  lastScheduledRefreshRequestedAt?: number;
+  lastUserRefreshRequestedAt?: number;
+};
+
+type PrLookupSubscriber = {
+  backend: AppServerBackendKind;
+  threadId: string;
+  requestKey: string;
+  previousPrs: PrSummary[];
 };
 
 class PrStatusTokenBucket {
@@ -409,9 +442,15 @@ class DesktopAppServerService {
     Promise<RefreshThreadPullRequestsResponse>
   >();
   private readonly prStatusRegistry = new Map<string, PrStatusRegistryEntry>();
-  private readonly pendingPrStatusRefreshes = new Map<string, Promise<void>>();
+  private readonly prLookupRegistry = new Map<string, PrLookupRegistryEntry>();
+  private readonly pendingPrLookupRefreshes = new Map<string, Promise<void>>();
+  private readonly prLookupSubscribers = new Map<
+    string,
+    Map<string, PrLookupSubscriber>
+  >();
   private readonly prStatusTokenBucket = new PrStatusTokenBucket();
   private prStatusRegistryLoaded = false;
+  private prLookupRegistryLoaded = false;
   private readonly previousDirectoriesByBackend = new Map<
     AppServerBackendScope,
     NavigationSnapshot["directories"]
@@ -750,6 +789,7 @@ class DesktopAppServerService {
       workspaceRoots: resolveScratchProjectsRoots(),
     });
     await this.loadPrStatusRegistry();
+    await this.loadPrLookupRegistry();
     this.seedPrStatusRegistryFromThreads(snapshot.threads);
     const snapshotThreads = this.applyCanonicalPrStatuses(snapshot.threads);
     await this.loadDirectoryGitStatusCache();
@@ -1082,11 +1122,31 @@ class DesktopAppServerService {
       threadId: request.threadId,
     });
     await this.loadPrStatusRegistry();
+    await this.loadPrLookupRegistry();
     const persistedPrs = existing?.prs ?? [];
     this.rememberPrStatuses(persistedPrs, existing?.prsFetchedAt ?? 0);
     const existingPrs = this.canonicalizePrs(persistedPrs);
     const branch = request.branch.trim();
+    const lookupKey = getPullRequestLookupKey(request);
+    const lookupDirectoryPaths = normalizePrLookupDirectoryPaths(
+      request.directoryPaths,
+    );
     const existingLookupMatches = existing?.prsRefreshKey === requestKey;
+    if (existingLookupMatches) {
+      this.rememberPrLookup({
+        lookupKey,
+        branch,
+        directoryPaths: lookupDirectoryPaths,
+        prs: existingPrs,
+        fetchedAt: existing?.prsFetchedAt ?? 0,
+      });
+    }
+    const lookupEntry = this.prLookupRegistry.get(lookupKey);
+    const currentLookupPrs = lookupEntry
+      ? this.canonicalizePrs(lookupEntry.prs)
+      : existingLookupMatches
+        ? existingPrs
+        : [];
     // Terminal-state short-circuit: once every cached PR for a lookup is
     // merged or closed, we do not need to re-query gh for the same
     // branch/directory lookup.
@@ -1101,17 +1161,18 @@ class DesktopAppServerService {
     // programmatically can read `shortCircuited: true` off the
     // response.
     const allExistingPrsTerminal =
-      existingPrs.length > 0
-      && existingPrs.every((pr) => pr.state === "merged" || pr.state === "closed");
+      currentLookupPrs.length > 0
+      && currentLookupPrs.every(
+        (pr) => pr.state === "merged" || pr.state === "closed",
+      );
     if (
       allExistingPrsTerminal
       && branch !== "HEAD"
-      && existingLookupMatches
     ) {
       return {
         backend,
         threadId: request.threadId,
-        prs: existingPrs,
+        prs: currentLookupPrs,
         ghAvailable: true,
         shortCircuited: true,
       };
@@ -1121,52 +1182,33 @@ class DesktopAppServerService {
       return {
         backend,
         threadId: request.threadId,
-        prs: existingPrs,
+        prs: currentLookupPrs,
         ghAvailable: true,
       };
     }
 
-    if (existingLookupMatches) {
-      if ((request.trigger ?? "scheduled") === "user") {
-        this.startCanonicalPullRequestRefresh({
-          backend,
-          request,
-          requestKey,
-          previousPrs: existingPrs,
-        });
-      }
-      return {
-        backend,
-        threadId: request.threadId,
-        prs: existingPrs,
-        ghAvailable: true,
-      };
-    }
-
-    if (!this.tryClaimLookupRefresh(request.trigger ?? "scheduled")) {
-      return {
-        backend,
-        threadId: request.threadId,
-        prs: existingPrs,
-        ghAvailable: true,
-      };
-    }
-
-    const refreshPromise = this.fetchAndPersistThreadPullRequests({
+    this.startPullRequestLookupRefresh({
       backend,
       request,
       requestKey,
-      previousPrs: existingPrs,
+      lookupKey,
+      lookupDirectoryPaths,
+      previousPrs: currentLookupPrs,
     });
-    return await refreshPromise;
+
+    return {
+      backend,
+      threadId: request.threadId,
+      prs: currentLookupPrs,
+      ghAvailable: true,
+    };
   }
 
-  private async fetchAndPersistThreadPullRequests(params: {
-    backend: AppServerBackendKind;
+  private async fetchPullRequestLookup(params: {
     request: RefreshThreadPullRequestsRequest;
-    requestKey: string;
-    previousPrs: PrSummary[];
-  }): Promise<RefreshThreadPullRequestsResponse> {
+    lookupKey: string;
+    lookupDirectoryPaths: string[];
+  }): Promise<{ prs: PrSummary[]; fetchedAt: number }> {
     const prs = await detectPullRequestsForThread({
       fetcher: this.getPrFetcher(),
       branch: params.request.branch.trim(),
@@ -1175,75 +1217,130 @@ class DesktopAppServerService {
     const fetchedAt = Date.now();
     this.rememberPrStatuses(prs, fetchedAt);
     await this.writePrStatusesToCache(prs, fetchedAt);
-
-    // Persist even an empty result so we don't refetch unchanged state on
-    // every renderer trigger. The fetchedAt timestamp lets a future TTL
-    // policy (if we add one) reason about staleness without any extra
-    // bookkeeping.
-    await this.getOverlayStore().setThreadPullRequests({
-      backend: params.backend,
-      threadId: params.request.threadId,
+    this.rememberPrLookup({
+      lookupKey: params.lookupKey,
+      branch: params.request.branch.trim(),
+      directoryPaths: params.lookupDirectoryPaths,
       prs,
       fetchedAt,
-      refreshKey: params.requestKey,
+    });
+    await this.writePrLookupToCache({
+      lookupKey: params.lookupKey,
+      branch: params.request.branch.trim(),
+      directoryPaths: params.lookupDirectoryPaths,
+      prs,
+      fetchedAt,
     });
 
-    if (!prSummariesEqual(params.previousPrs, prs)) {
-      await this.publishThreadPullRequestsUpdated({
-        backend: params.backend,
-        threadId: params.request.threadId,
-        prs,
-      });
-    }
-
-    return {
-      backend: params.backend,
-      threadId: params.request.threadId,
-      prs,
-      ghAvailable: true,
-    };
+    return { prs, fetchedAt };
   }
 
-  private startCanonicalPullRequestRefresh(params: {
+  private startPullRequestLookupRefresh(params: {
     backend: AppServerBackendKind;
     request: RefreshThreadPullRequestsRequest;
     requestKey: string;
+    lookupKey: string;
+    lookupDirectoryPaths: string[];
     previousPrs: PrSummary[];
   }): void {
-    const refreshKey = this.claimCanonicalRefreshKey(
-      params.previousPrs,
-      params.request.trigger ?? "scheduled",
-    );
-    if (!refreshKey || this.pendingPrStatusRefreshes.has(refreshKey)) {
+    const pending = this.pendingPrLookupRefreshes.get(params.lookupKey);
+    if (pending) {
+      this.addPullRequestLookupSubscriber(params.lookupKey, params);
       return;
     }
 
-    const promise = this.fetchAndPersistThreadPullRequests(params)
-      .then(() => undefined)
+    const refreshKey = this.claimPullRequestLookupRefreshKey(
+      params.lookupKey,
+      params.request.trigger ?? "scheduled",
+    );
+    if (!refreshKey) {
+      return;
+    }
+
+    this.addPullRequestLookupSubscriber(params.lookupKey, params);
+    const promise = this.fetchPullRequestLookup(params)
+      .then(async ({ prs, fetchedAt }) => {
+        await this.persistPullRequestLookupSubscribers({
+          lookupKey: params.lookupKey,
+          prs,
+          fetchedAt,
+        });
+      })
       .catch((error) => {
-        appServerLog.warn("background PR status refresh failed", {
+        appServerLog.warn("background PR lookup refresh failed", {
           threadId: params.request.threadId,
           refreshKey,
           error: error instanceof Error ? error.message : String(error),
         });
       })
       .finally(() => {
-        if (this.pendingPrStatusRefreshes.get(refreshKey) === promise) {
-          this.pendingPrStatusRefreshes.delete(refreshKey);
+        if (this.pendingPrLookupRefreshes.get(params.lookupKey) === promise) {
+          this.pendingPrLookupRefreshes.delete(params.lookupKey);
+          this.prLookupSubscribers.delete(params.lookupKey);
         }
       });
-    this.pendingPrStatusRefreshes.set(refreshKey, promise);
+    this.pendingPrLookupRefreshes.set(params.lookupKey, promise);
   }
 
-  private claimCanonicalRefreshKey(
-    prs: PrSummary[],
-    trigger: NonNullable<RefreshThreadPullRequestsRequest["trigger"]>,
-  ): string | undefined {
-    const keys = [...new Set(prs.map(getPrStatusKey))].sort();
-    if (keys.length === 0) {
-      return undefined;
+  private addPullRequestLookupSubscriber(
+    lookupKey: string,
+    params: {
+      backend: AppServerBackendKind;
+      request: RefreshThreadPullRequestsRequest;
+      requestKey: string;
+      previousPrs: PrSummary[];
+    },
+  ): void {
+    const subscribers =
+      this.prLookupSubscribers.get(lookupKey) ?? new Map<string, PrLookupSubscriber>();
+    const threadKey = buildThreadIdentityKey(
+      params.backend,
+      params.request.threadId,
+    );
+    subscribers.set(threadKey, {
+      backend: params.backend,
+      threadId: params.request.threadId,
+      requestKey: params.requestKey,
+      previousPrs: params.previousPrs,
+    });
+    this.prLookupSubscribers.set(lookupKey, subscribers);
+  }
+
+  private async persistPullRequestLookupSubscribers(params: {
+    lookupKey: string;
+    prs: PrSummary[];
+    fetchedAt: number;
+  }): Promise<void> {
+    const subscribers = this.prLookupSubscribers.get(params.lookupKey);
+    if (!subscribers?.size) {
+      return;
     }
 
+    await Promise.all(
+      [...subscribers.values()].map(async (subscriber) => {
+        await this.getOverlayStore().setThreadPullRequests({
+          backend: subscriber.backend,
+          threadId: subscriber.threadId,
+          prs: params.prs,
+          fetchedAt: params.fetchedAt,
+          refreshKey: subscriber.requestKey,
+        });
+
+        if (!prSummariesEqual(subscriber.previousPrs, params.prs)) {
+          await this.publishThreadPullRequestsUpdated({
+            backend: subscriber.backend,
+            threadId: subscriber.threadId,
+            prs: params.prs,
+          });
+        }
+      }),
+    );
+  }
+
+  private claimPullRequestLookupRefreshKey(
+    lookupKey: string,
+    trigger: NonNullable<RefreshThreadPullRequestsRequest["trigger"]>,
+  ): string | undefined {
     const now = Date.now();
     const minInterval =
       trigger === "user"
@@ -1253,16 +1350,12 @@ class DesktopAppServerService {
       trigger === "user"
         ? "lastUserRefreshRequestedAt"
         : "lastScheduledRefreshRequestedAt";
-    const due = keys.some((key) => {
-      const entry = this.prStatusRegistry.get(key);
-      const lastRequestedAt = Math.max(
-        entry?.[timestampField] ?? 0,
-        entry?.fetchedAt ?? 0,
-      );
-      return (
-        now - lastRequestedAt >= minInterval
-      );
-    });
+    const entry = this.prLookupRegistry.get(lookupKey);
+    const lastRequestedAt = Math.max(
+      entry?.[timestampField] ?? 0,
+      entry?.fetchedAt ?? 0,
+    );
+    const due = now - lastRequestedAt >= minInterval;
     if (!due) {
       return undefined;
     }
@@ -1270,20 +1363,19 @@ class DesktopAppServerService {
       return undefined;
     }
 
-    for (const key of keys) {
-      const entry = this.prStatusRegistry.get(key);
-      if (entry) {
-        entry[timestampField] = now;
-      }
+    if (entry) {
+      entry[timestampField] = now;
+    } else {
+      this.prLookupRegistry.set(lookupKey, {
+        prs: [],
+        fetchedAt: 0,
+        branch: "",
+        directoryPaths: [],
+        [timestampField]: now,
+      });
     }
 
-    return keys.join("|");
-  }
-
-  private tryClaimLookupRefresh(
-    trigger: NonNullable<RefreshThreadPullRequestsRequest["trigger"]>,
-  ): boolean {
-    return trigger === "user" || this.prStatusTokenBucket.tryTake();
+    return lookupKey;
   }
 
   private rememberPrStatuses(prs: PrSummary[], fetchedAt: number): void {
@@ -1301,6 +1393,26 @@ class DesktopAppServerService {
     }
   }
 
+  private rememberPrLookup(entry: {
+    lookupKey: string;
+    branch: string;
+    directoryPaths: string[];
+    prs: PrSummary[];
+    fetchedAt: number;
+  }): void {
+    const current = this.prLookupRegistry.get(entry.lookupKey);
+    if (current && current.fetchedAt > entry.fetchedAt) {
+      return;
+    }
+    this.prLookupRegistry.set(entry.lookupKey, {
+      ...current,
+      branch: entry.branch,
+      directoryPaths: entry.directoryPaths,
+      prs: entry.prs,
+      fetchedAt: entry.fetchedAt,
+    });
+  }
+
   private async loadPrStatusRegistry(): Promise<void> {
     if (this.prStatusRegistryLoaded) {
       return;
@@ -1309,6 +1421,18 @@ class DesktopAppServerService {
     const entries = await this.getOverlayStore().readPrStatusCache();
     for (const entry of Object.values(entries)) {
       this.rememberPrStatuses([entry.pr], entry.fetchedAt);
+    }
+  }
+
+  private async loadPrLookupRegistry(): Promise<void> {
+    if (this.prLookupRegistryLoaded) {
+      return;
+    }
+    this.prLookupRegistryLoaded = true;
+    const entries = await this.getOverlayStore().readPrLookupCache();
+    for (const entry of Object.values(entries)) {
+      this.rememberPrLookup(entry);
+      this.rememberPrStatuses(entry.prs, entry.fetchedAt);
     }
   }
 
@@ -1322,6 +1446,10 @@ class DesktopAppServerService {
       pr,
     }));
     await this.getOverlayStore().writePrStatusCacheEntries(entries);
+  }
+
+  private async writePrLookupToCache(entry: PrLookupCacheEntry): Promise<void> {
+    await this.getOverlayStore().writePrLookupCacheEntry(entry);
   }
 
   private canonicalizePrs(prs: PrSummary[]): PrSummary[] {
@@ -1843,8 +1971,11 @@ class DesktopAppServerService {
     this.pendingNavigationSnapshots.clear();
     this.pendingThreadPullRequestRefreshes.clear();
     this.prStatusRegistry.clear();
-    this.pendingPrStatusRefreshes.clear();
+    this.prLookupRegistry.clear();
+    this.pendingPrLookupRefreshes.clear();
+    this.prLookupSubscribers.clear();
     this.prStatusRegistryLoaded = false;
+    this.prLookupRegistryLoaded = false;
     this.pendingDirectoryGitStatusRefreshes.clear();
     this.pendingDirectoryGitStatusKeys.clear();
     this.previousDirectoriesByBackend.clear();

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -401,6 +401,7 @@ function prSummariesEqual(left: PrSummary[], right: PrSummary[]): boolean {
         === normalizePullRequestProvider(pr.provider) &&
       candidate.org === pr.org &&
       candidate.repo === pr.repo &&
+      candidate.title === pr.title &&
       candidate.state === pr.state &&
       candidate.url === pr.url
     );

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -156,6 +156,7 @@ import { ThreadSearchStore } from "../thread-search/thread-search-store";
 const isDevelopment = process.env.NODE_ENV !== "production";
 const THREAD_PR_REFRESH_MIN_INTERVAL_MS = 60_000;
 const USER_THREAD_PR_REFRESH_MIN_INTERVAL_MS = 10_000;
+const TERMINAL_USER_THREAD_PR_REFRESH_MIN_INTERVAL_MS = 60_000;
 const PR_STATUS_TOKEN_BUCKET_CAPACITY = 20;
 const PR_STATUS_TOKEN_BUCKET_REFILL_PER_MINUTE = 20;
 const STARTUP_DIRECTORY_GIT_STATUS_REFRESH_LIMIT = 4;
@@ -1336,6 +1337,10 @@ class DesktopAppServerService {
       params.lookupKey,
       params.request.trigger ?? "scheduled",
       normalizePullRequestProvider(params.request.provider),
+      params.previousPrs.length > 0
+        && params.previousPrs.every(
+          (pr) => pr.lifecycleState === "merged" || pr.lifecycleState === "closed",
+        ),
     );
     if (!refreshKey) {
       return;
@@ -1460,11 +1465,14 @@ class DesktopAppServerService {
     lookupKey: string,
     trigger: NonNullable<RefreshThreadPullRequestsRequest["trigger"]>,
     provider: string,
+    terminalOnly: boolean,
   ): string | undefined {
     const now = Date.now();
     const minInterval =
       trigger === "user"
-        ? USER_THREAD_PR_REFRESH_MIN_INTERVAL_MS
+        ? terminalOnly
+          ? TERMINAL_USER_THREAD_PR_REFRESH_MIN_INTERVAL_MS
+          : USER_THREAD_PR_REFRESH_MIN_INTERVAL_MS
         : THREAD_PR_REFRESH_MIN_INTERVAL_MS;
     const timestampField =
       trigger === "user"

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import type {
   DirectoryGitStatusCacheEntry,
   OverlayStoreLike,
+  PrStatusCacheEntry,
   SqliteOverlayStore,
 } from "../state/overlay-store-sqlite";
 import {
@@ -410,6 +411,7 @@ class DesktopAppServerService {
   private readonly prStatusRegistry = new Map<string, PrStatusRegistryEntry>();
   private readonly pendingPrStatusRefreshes = new Map<string, Promise<void>>();
   private readonly prStatusTokenBucket = new PrStatusTokenBucket();
+  private prStatusRegistryLoaded = false;
   private readonly previousDirectoriesByBackend = new Map<
     AppServerBackendScope,
     NavigationSnapshot["directories"]
@@ -747,6 +749,7 @@ class DesktopAppServerService {
       threads,
       workspaceRoots: resolveScratchProjectsRoots(),
     });
+    await this.loadPrStatusRegistry();
     this.seedPrStatusRegistryFromThreads(snapshot.threads);
     const snapshotThreads = this.applyCanonicalPrStatuses(snapshot.threads);
     await this.loadDirectoryGitStatusCache();
@@ -1078,6 +1081,7 @@ class DesktopAppServerService {
       backend,
       threadId: request.threadId,
     });
+    await this.loadPrStatusRegistry();
     const persistedPrs = existing?.prs ?? [];
     this.rememberPrStatuses(persistedPrs, existing?.prsFetchedAt ?? 0);
     const existingPrs = this.canonicalizePrs(persistedPrs);
@@ -1122,12 +1126,14 @@ class DesktopAppServerService {
     }
 
     if (existingPrs.length > 0) {
-      this.startCanonicalPullRequestRefresh({
-        backend,
-        request,
-        requestKey,
-        previousPrs: existingPrs,
-      });
+      if ((request.trigger ?? "scheduled") === "user") {
+        this.startCanonicalPullRequestRefresh({
+          backend,
+          request,
+          requestKey,
+          previousPrs: existingPrs,
+        });
+      }
       return {
         backend,
         threadId: request.threadId,
@@ -1167,6 +1173,7 @@ class DesktopAppServerService {
     });
     const fetchedAt = Date.now();
     this.rememberPrStatuses(prs, fetchedAt);
+    await this.writePrStatusesToCache(prs, fetchedAt);
 
     // Persist even an empty result so we don't refetch unchanged state on
     // every renderer trigger. The fetchedAt timestamp lets a future TTL
@@ -1247,9 +1254,11 @@ class DesktopAppServerService {
         : "lastScheduledRefreshRequestedAt";
     const due = keys.some((key) => {
       const entry = this.prStatusRegistry.get(key);
-      const lastRequestedAt = entry?.[timestampField];
+      const lastRequestedAt = Math.max(
+        entry?.[timestampField] ?? 0,
+        entry?.fetchedAt ?? 0,
+      );
       return (
-        typeof lastRequestedAt !== "number" ||
         now - lastRequestedAt >= minInterval
       );
     });
@@ -1289,6 +1298,29 @@ class DesktopAppServerService {
         fetchedAt,
       });
     }
+  }
+
+  private async loadPrStatusRegistry(): Promise<void> {
+    if (this.prStatusRegistryLoaded) {
+      return;
+    }
+    this.prStatusRegistryLoaded = true;
+    const entries = await this.getOverlayStore().readPrStatusCache();
+    for (const entry of Object.values(entries)) {
+      this.rememberPrStatuses([entry.pr], entry.fetchedAt);
+    }
+  }
+
+  private async writePrStatusesToCache(
+    prs: PrSummary[],
+    fetchedAt: number,
+  ): Promise<void> {
+    const entries: PrStatusCacheEntry[] = prs.map((pr) => ({
+      prKey: getPrStatusKey(pr),
+      fetchedAt,
+      pr,
+    }));
+    await this.getOverlayStore().writePrStatusCacheEntries(entries);
   }
 
   private canonicalizePrs(prs: PrSummary[]): PrSummary[] {
@@ -1811,6 +1843,7 @@ class DesktopAppServerService {
     this.pendingThreadPullRequestRefreshes.clear();
     this.prStatusRegistry.clear();
     this.pendingPrStatusRefreshes.clear();
+    this.prStatusRegistryLoaded = false;
     this.pendingDirectoryGitStatusRefreshes.clear();
     this.pendingDirectoryGitStatusKeys.clear();
     this.previousDirectoriesByBackend.clear();

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -48,6 +48,7 @@ import {
   type NavigationDirectoryGitStatusUpdatedNotification,
   type NavigationSnapshot,
   type AutomationThreadSummary,
+  type PrSummary,
   type ReorderDirectoryPinsRequest,
   type ReorderDirectoryPinsResponse,
   type ReorderThreadPinsRequest,
@@ -148,6 +149,9 @@ import { ThreadSearchStore } from "../thread-search/thread-search-store";
 
 const isDevelopment = process.env.NODE_ENV !== "production";
 const THREAD_PR_REFRESH_MIN_INTERVAL_MS = 60_000;
+const USER_THREAD_PR_REFRESH_MIN_INTERVAL_MS = 10_000;
+const PR_STATUS_TOKEN_BUCKET_CAPACITY = 20;
+const PR_STATUS_TOKEN_BUCKET_REFILL_PER_MINUTE = 20;
 const STARTUP_DIRECTORY_GIT_STATUS_REFRESH_LIMIT = 4;
 const DIRECTORY_GIT_STATUS_CACHE_MAX_AGE_MS = 5 * 60_000;
 
@@ -340,6 +344,56 @@ function getThreadPullRequestsRequestKey(
   });
 }
 
+function getPrStatusKey(pr: Pick<PrSummary, "org" | "repo" | "number">): string {
+  return `${pr.org.toLowerCase()}/${pr.repo.toLowerCase()}#${pr.number}`;
+}
+
+function prSummariesEqual(left: PrSummary[], right: PrSummary[]): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  return left.every((pr, index) => {
+    const candidate = right[index];
+    return (
+      candidate?.number === pr.number &&
+      candidate.org === pr.org &&
+      candidate.repo === pr.repo &&
+      candidate.state === pr.state &&
+      candidate.url === pr.url
+    );
+  });
+}
+
+type PrStatusRegistryEntry = {
+  pr: PrSummary;
+  fetchedAt: number;
+  lastScheduledRefreshRequestedAt?: number;
+  lastUserRefreshRequestedAt?: number;
+};
+
+class PrStatusTokenBucket {
+  private tokens = PR_STATUS_TOKEN_BUCKET_CAPACITY;
+  private updatedAt = Date.now();
+
+  tryTake(now = Date.now()): boolean {
+    const elapsedMs = Math.max(0, now - this.updatedAt);
+    this.tokens = Math.min(
+      PR_STATUS_TOKEN_BUCKET_CAPACITY,
+      this.tokens +
+        (elapsedMs * PR_STATUS_TOKEN_BUCKET_REFILL_PER_MINUTE) / 60_000,
+    );
+    this.updatedAt = now;
+
+    if (this.tokens < 1) {
+      return false;
+    }
+
+    this.tokens -= 1;
+    return true;
+  }
+}
+
 class DesktopAppServerService {
   private focusedDiffService: FocusedDiffService | null = null;
   private focusedDiffServiceApiKey: string | undefined;
@@ -353,6 +407,9 @@ class DesktopAppServerService {
     string,
     Promise<RefreshThreadPullRequestsResponse>
   >();
+  private readonly prStatusRegistry = new Map<string, PrStatusRegistryEntry>();
+  private readonly pendingPrStatusRefreshes = new Map<string, Promise<void>>();
+  private readonly prStatusTokenBucket = new PrStatusTokenBucket();
   private readonly previousDirectoriesByBackend = new Map<
     AppServerBackendScope,
     NavigationSnapshot["directories"]
@@ -690,6 +747,8 @@ class DesktopAppServerService {
       threads,
       workspaceRoots: resolveScratchProjectsRoots(),
     });
+    this.seedPrStatusRegistryFromThreads(snapshot.threads);
+    const snapshotThreads = this.applyCanonicalPrStatuses(snapshot.threads);
     await this.loadDirectoryGitStatusCache();
     for (const directory of snapshot.directories) {
       this.lastDirectoriesByKey.set(directory.key, directory);
@@ -716,6 +775,7 @@ class DesktopAppServerService {
 
     return {
       ...snapshot,
+      threads: snapshotThreads,
       directories,
       unchanged: snapshot.unchanged && directoriesUnchanged,
     };
@@ -1018,7 +1078,9 @@ class DesktopAppServerService {
       backend,
       threadId: request.threadId,
     });
-    const existingPrs = existing?.prs ?? [];
+    const persistedPrs = existing?.prs ?? [];
+    this.rememberPrStatuses(persistedPrs, existing?.prsFetchedAt ?? 0);
+    const existingPrs = this.canonicalizePrs(persistedPrs);
     const branch = request.branch.trim();
     // Terminal-state short-circuit: once every cached PR for a lookup is
     // merged or closed, we do not need to re-query gh for the same
@@ -1059,12 +1121,13 @@ class DesktopAppServerService {
       };
     }
 
-    const lastFetchedAt = existing?.prsFetchedAt;
-    if (
-      typeof lastFetchedAt === "number" &&
-      Date.now() - lastFetchedAt < THREAD_PR_REFRESH_MIN_INTERVAL_MS &&
-      existing?.prsRefreshKey === requestKey
-    ) {
+    if (existingPrs.length > 0) {
+      this.startCanonicalPullRequestRefresh({
+        backend,
+        request,
+        requestKey,
+        previousPrs: existingPrs,
+      });
       return {
         backend,
         threadId: request.threadId,
@@ -1073,24 +1136,203 @@ class DesktopAppServerService {
       };
     }
 
-    const prs = await detectPullRequestsForThread({
-      fetcher,
-      branch,
-      directoryPaths: request.directoryPaths,
+    if (!this.tryClaimLookupRefresh(request.trigger ?? "scheduled")) {
+      return {
+        backend,
+        threadId: request.threadId,
+        prs: existingPrs,
+        ghAvailable: true,
+      };
+    }
+
+    const refreshPromise = this.fetchAndPersistThreadPullRequests({
+      backend,
+      request,
+      requestKey,
+      previousPrs: existingPrs,
     });
+    return await refreshPromise;
+  }
+
+  private async fetchAndPersistThreadPullRequests(params: {
+    backend: AppServerBackendKind;
+    request: RefreshThreadPullRequestsRequest;
+    requestKey: string;
+    previousPrs: PrSummary[];
+  }): Promise<RefreshThreadPullRequestsResponse> {
+    const prs = await detectPullRequestsForThread({
+      fetcher: this.getPrFetcher(),
+      branch: params.request.branch.trim(),
+      directoryPaths: params.request.directoryPaths,
+    });
+    const fetchedAt = Date.now();
+    this.rememberPrStatuses(prs, fetchedAt);
 
     // Persist even an empty result so we don't refetch unchanged state on
     // every renderer trigger. The fetchedAt timestamp lets a future TTL
     // policy (if we add one) reason about staleness without any extra
     // bookkeeping.
-    await overlay.setThreadPullRequests({
-      backend,
-      threadId: request.threadId,
+    await this.getOverlayStore().setThreadPullRequests({
+      backend: params.backend,
+      threadId: params.request.threadId,
       prs,
-      refreshKey: requestKey,
+      fetchedAt,
+      refreshKey: params.requestKey,
     });
 
-    return { backend, threadId: request.threadId, prs, ghAvailable: true };
+    if (!prSummariesEqual(params.previousPrs, prs)) {
+      await this.publishThreadPullRequestsUpdated({
+        backend: params.backend,
+        threadId: params.request.threadId,
+        prs,
+      });
+    }
+
+    return {
+      backend: params.backend,
+      threadId: params.request.threadId,
+      prs,
+      ghAvailable: true,
+    };
+  }
+
+  private startCanonicalPullRequestRefresh(params: {
+    backend: AppServerBackendKind;
+    request: RefreshThreadPullRequestsRequest;
+    requestKey: string;
+    previousPrs: PrSummary[];
+  }): void {
+    const refreshKey = this.claimCanonicalRefreshKey(
+      params.previousPrs,
+      params.request.trigger ?? "scheduled",
+    );
+    if (!refreshKey || this.pendingPrStatusRefreshes.has(refreshKey)) {
+      return;
+    }
+
+    const promise = this.fetchAndPersistThreadPullRequests(params)
+      .then(() => undefined)
+      .catch((error) => {
+        appServerLog.warn("background PR status refresh failed", {
+          threadId: params.request.threadId,
+          refreshKey,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      })
+      .finally(() => {
+        if (this.pendingPrStatusRefreshes.get(refreshKey) === promise) {
+          this.pendingPrStatusRefreshes.delete(refreshKey);
+        }
+      });
+    this.pendingPrStatusRefreshes.set(refreshKey, promise);
+  }
+
+  private claimCanonicalRefreshKey(
+    prs: PrSummary[],
+    trigger: NonNullable<RefreshThreadPullRequestsRequest["trigger"]>,
+  ): string | undefined {
+    const keys = [...new Set(prs.map(getPrStatusKey))].sort();
+    if (keys.length === 0) {
+      return undefined;
+    }
+
+    const now = Date.now();
+    const minInterval =
+      trigger === "user"
+        ? USER_THREAD_PR_REFRESH_MIN_INTERVAL_MS
+        : THREAD_PR_REFRESH_MIN_INTERVAL_MS;
+    const timestampField =
+      trigger === "user"
+        ? "lastUserRefreshRequestedAt"
+        : "lastScheduledRefreshRequestedAt";
+    const due = keys.some((key) => {
+      const entry = this.prStatusRegistry.get(key);
+      const lastRequestedAt = entry?.[timestampField];
+      return (
+        typeof lastRequestedAt !== "number" ||
+        now - lastRequestedAt >= minInterval
+      );
+    });
+    if (!due) {
+      return undefined;
+    }
+    if (trigger === "scheduled" && !this.prStatusTokenBucket.tryTake(now)) {
+      return undefined;
+    }
+
+    for (const key of keys) {
+      const entry = this.prStatusRegistry.get(key);
+      if (entry) {
+        entry[timestampField] = now;
+      }
+    }
+
+    return keys.join("|");
+  }
+
+  private tryClaimLookupRefresh(
+    trigger: NonNullable<RefreshThreadPullRequestsRequest["trigger"]>,
+  ): boolean {
+    return trigger === "user" || this.prStatusTokenBucket.tryTake();
+  }
+
+  private rememberPrStatuses(prs: PrSummary[], fetchedAt: number): void {
+    for (const pr of prs) {
+      const key = getPrStatusKey(pr);
+      const current = this.prStatusRegistry.get(key);
+      if (current && current.fetchedAt > fetchedAt) {
+        continue;
+      }
+      this.prStatusRegistry.set(key, {
+        ...current,
+        pr,
+        fetchedAt,
+      });
+    }
+  }
+
+  private canonicalizePrs(prs: PrSummary[]): PrSummary[] {
+    return prs.map((pr) => this.prStatusRegistry.get(getPrStatusKey(pr))?.pr ?? pr);
+  }
+
+  private seedPrStatusRegistryFromThreads(
+    threads: NavigationSnapshot["threads"],
+  ): void {
+    for (const thread of threads) {
+      if (!thread.prs?.length) {
+        continue;
+      }
+      this.rememberPrStatuses(thread.prs, 0);
+    }
+  }
+
+  private applyCanonicalPrStatuses(
+    threads: NavigationSnapshot["threads"],
+  ): NavigationSnapshot["threads"] {
+    return threads.map((thread) => {
+      if (!thread.prs?.length) {
+        return thread;
+      }
+      const prs = this.canonicalizePrs(thread.prs);
+      return prSummariesEqual(thread.prs, prs) ? thread : { ...thread, prs };
+    });
+  }
+
+  private async publishThreadPullRequestsUpdated(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    prs: PrSummary[];
+  }): Promise<void> {
+    await getDesktopBackendRegistry().publishLocalEvent({
+      backend: params.backend,
+      notification: {
+        method: "thread/pullRequests/updated",
+        params: {
+          threadId: params.threadId,
+          prs: params.prs,
+        },
+      },
+    });
   }
 
   async getGhStatus(request: GetGhStatusRequest): Promise<GhStatus> {
@@ -1566,6 +1808,9 @@ class DesktopAppServerService {
     this.focusedDiffServiceModel = undefined;
     this.prFetcher = undefined;
     this.pendingNavigationSnapshots.clear();
+    this.pendingThreadPullRequestRefreshes.clear();
+    this.prStatusRegistry.clear();
+    this.pendingPrStatusRefreshes.clear();
     this.pendingDirectoryGitStatusRefreshes.clear();
     this.pendingDirectoryGitStatusKeys.clear();
     this.previousDirectoriesByBackend.clear();

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -791,7 +791,7 @@ class DesktopAppServerService {
     await this.loadPrStatusRegistry();
     await this.loadPrLookupRegistry();
     this.seedPrStatusRegistryFromThreads(snapshot.threads);
-    const snapshotThreads = this.applyCanonicalPrStatuses(snapshot.threads);
+    const canonicalSnapshot = this.applyCanonicalPrStatuses(snapshot.threads);
     await this.loadDirectoryGitStatusCache();
     for (const directory of snapshot.directories) {
       this.lastDirectoriesByKey.set(directory.key, directory);
@@ -818,9 +818,10 @@ class DesktopAppServerService {
 
     return {
       ...snapshot,
-      threads: snapshotThreads,
+      threads: canonicalSnapshot.threads,
       directories,
-      unchanged: snapshot.unchanged && directoriesUnchanged,
+      unchanged:
+        snapshot.unchanged && directoriesUnchanged && !canonicalSnapshot.changed,
     };
   }
 
@@ -1147,6 +1148,17 @@ class DesktopAppServerService {
       : existingLookupMatches
         ? existingPrs
         : [];
+    if (lookupEntry && lookupEntry.fetchedAt > 0) {
+      await this.persistPullRequestLookupHit({
+        backend,
+        request,
+        requestKey,
+        persistedPrs,
+        persistedRefreshKey: existing?.prsRefreshKey,
+        prs: currentLookupPrs,
+        fetchedAt: lookupEntry.fetchedAt,
+      });
+    }
     // Terminal-state short-circuit: once every cached PR for a lookup is
     // merged or closed, we do not need to re-query gh for the same
     // branch/directory lookup.
@@ -1337,6 +1349,39 @@ class DesktopAppServerService {
     );
   }
 
+  private async persistPullRequestLookupHit(params: {
+    backend: AppServerBackendKind;
+    request: RefreshThreadPullRequestsRequest;
+    requestKey: string;
+    persistedPrs: PrSummary[];
+    persistedRefreshKey?: string;
+    prs: PrSummary[];
+    fetchedAt: number;
+  }): Promise<void> {
+    if (
+      params.persistedRefreshKey === params.requestKey
+      && prSummariesEqual(params.persistedPrs, params.prs)
+    ) {
+      return;
+    }
+
+    await this.getOverlayStore().setThreadPullRequests({
+      backend: params.backend,
+      threadId: params.request.threadId,
+      prs: params.prs,
+      fetchedAt: params.fetchedAt,
+      refreshKey: params.requestKey,
+    });
+
+    if (!prSummariesEqual(params.persistedPrs, params.prs)) {
+      await this.publishThreadPullRequestsUpdated({
+        backend: params.backend,
+        threadId: params.request.threadId,
+        prs: params.prs,
+      });
+    }
+  }
+
   private claimPullRequestLookupRefreshKey(
     lookupKey: string,
     trigger: NonNullable<RefreshThreadPullRequestsRequest["trigger"]>,
@@ -1469,14 +1514,21 @@ class DesktopAppServerService {
 
   private applyCanonicalPrStatuses(
     threads: NavigationSnapshot["threads"],
-  ): NavigationSnapshot["threads"] {
-    return threads.map((thread) => {
+  ): { threads: NavigationSnapshot["threads"]; changed: boolean } {
+    let changed = false;
+    const canonicalThreads = threads.map((thread) => {
       if (!thread.prs?.length) {
         return thread;
       }
       const prs = this.canonicalizePrs(thread.prs);
-      return prSummariesEqual(thread.prs, prs) ? thread : { ...thread, prs };
+      if (prSummariesEqual(thread.prs, prs)) {
+        return thread;
+      }
+      changed = true;
+      return { ...thread, prs };
     });
+
+    return { threads: canonicalThreads, changed };
   }
 
   private async publishThreadPullRequestsUpdated(params: {

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1086,6 +1086,7 @@ class DesktopAppServerService {
     this.rememberPrStatuses(persistedPrs, existing?.prsFetchedAt ?? 0);
     const existingPrs = this.canonicalizePrs(persistedPrs);
     const branch = request.branch.trim();
+    const existingLookupMatches = existing?.prsRefreshKey === requestKey;
     // Terminal-state short-circuit: once every cached PR for a lookup is
     // merged or closed, we do not need to re-query gh for the same
     // branch/directory lookup.
@@ -1105,7 +1106,7 @@ class DesktopAppServerService {
     if (
       allExistingPrsTerminal
       && branch !== "HEAD"
-      && existing?.prsRefreshKey === requestKey
+      && existingLookupMatches
     ) {
       return {
         backend,
@@ -1125,7 +1126,7 @@ class DesktopAppServerService {
       };
     }
 
-    if (existingPrs.length > 0) {
+    if (existingLookupMatches) {
       if ((request.trigger ?? "scheduled") === "user") {
         this.startCanonicalPullRequestRefresh({
           backend,

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -89,7 +89,10 @@ import {
   type UpdateSubthreadOrderRequest,
   type UpdateSubthreadOrderResponse,
 } from "@pwragent/shared";
-import { buildThreadIdentityKey } from "@pwragent/shared";
+import {
+  DEFAULT_PULL_REQUEST_PROVIDER,
+  buildThreadIdentityKey,
+} from "@pwragent/shared";
 import { registerDirectoryFromDisk } from "../app-server/directory-registration-service";
 import {
   disposeDesktopBackendRegistry,
@@ -339,9 +342,10 @@ function getThreadPullRequestsRequestKey(
   request: RefreshThreadPullRequestsRequest,
 ): string {
   return JSON.stringify({
-    lookupVersion: 2,
+    lookupVersion: 3,
     backend,
     threadId: request.threadId,
+    provider: normalizePullRequestProvider(request.provider),
     branch: request.branch.trim(),
     directoryPaths: request.directoryPaths,
   });
@@ -353,17 +357,35 @@ function normalizePrLookupDirectoryPaths(directoryPaths: string[]): string[] {
 }
 
 function getPullRequestLookupKey(
-  request: Pick<RefreshThreadPullRequestsRequest, "branch" | "directoryPaths">,
+  request: Pick<
+    RefreshThreadPullRequestsRequest,
+    "provider" | "branch" | "directoryPaths"
+  >,
 ): string {
   return JSON.stringify({
-    lookupVersion: 1,
+    lookupVersion: 2,
+    provider: normalizePullRequestProvider(request.provider),
     branch: request.branch.trim(),
     directoryPaths: normalizePrLookupDirectoryPaths(request.directoryPaths),
   });
 }
 
-function getPrStatusKey(pr: Pick<PrSummary, "org" | "repo" | "number">): string {
-  return `${pr.org.toLowerCase()}/${pr.repo.toLowerCase()}#${pr.number}`;
+function normalizePullRequestProvider(provider: string | undefined): string {
+  return (provider ?? DEFAULT_PULL_REQUEST_PROVIDER).trim().toLowerCase()
+    || DEFAULT_PULL_REQUEST_PROVIDER;
+}
+
+function normalizePrSummary(pr: PrSummary): PrSummary {
+  return {
+    ...pr,
+    provider: normalizePullRequestProvider(pr.provider),
+  };
+}
+
+function getPrStatusKey(
+  pr: Pick<PrSummary, "provider" | "org" | "repo" | "number">,
+): string {
+  return `${normalizePullRequestProvider(pr.provider)}/${pr.org.toLowerCase()}/${pr.repo.toLowerCase()}#${pr.number}`;
 }
 
 function prSummariesEqual(left: PrSummary[], right: PrSummary[]): boolean {
@@ -375,6 +397,8 @@ function prSummariesEqual(left: PrSummary[], right: PrSummary[]): boolean {
     const candidate = right[index];
     return (
       candidate?.number === pr.number &&
+      normalizePullRequestProvider(candidate.provider)
+        === normalizePullRequestProvider(pr.provider) &&
       candidate.org === pr.org &&
       candidate.repo === pr.repo &&
       candidate.state === pr.state &&
@@ -393,6 +417,7 @@ type PrStatusRegistryEntry = {
 type PrLookupRegistryEntry = {
   prs: PrSummary[];
   fetchedAt: number;
+  provider: string;
   branch: string;
   directoryPaths: string[];
   lastScheduledRefreshRequestedAt?: number;
@@ -1106,12 +1131,14 @@ class DesktopAppServerService {
     request: RefreshThreadPullRequestsRequest,
     requestKey: string,
   ): Promise<RefreshThreadPullRequestsResponse> {
+    const provider = normalizePullRequestProvider(request.provider);
     const fetcher = this.getPrFetcher();
     const ghAvailable = await fetcher.isGhAvailable();
     if (!ghAvailable) {
       return {
         backend,
         threadId: request.threadId,
+        provider,
         prs: [],
         ghAvailable: false,
       };
@@ -1136,6 +1163,7 @@ class DesktopAppServerService {
     if (existingLookupMatches) {
       this.rememberPrLookup({
         lookupKey,
+        provider,
         branch,
         directoryPaths: lookupDirectoryPaths,
         prs: existingPrs,
@@ -1184,6 +1212,7 @@ class DesktopAppServerService {
       return {
         backend,
         threadId: request.threadId,
+        provider,
         prs: currentLookupPrs,
         ghAvailable: true,
         shortCircuited: true,
@@ -1194,6 +1223,7 @@ class DesktopAppServerService {
       return {
         backend,
         threadId: request.threadId,
+        provider,
         prs: currentLookupPrs,
         ghAvailable: true,
       };
@@ -1211,6 +1241,7 @@ class DesktopAppServerService {
     return {
       backend,
       threadId: request.threadId,
+      provider,
       prs: currentLookupPrs,
       ghAvailable: true,
     };
@@ -1221,16 +1252,17 @@ class DesktopAppServerService {
     lookupKey: string;
     lookupDirectoryPaths: string[];
   }): Promise<{ prs: PrSummary[]; fetchedAt: number }> {
-    const prs = await detectPullRequestsForThread({
+    const prs = (await detectPullRequestsForThread({
       fetcher: this.getPrFetcher(),
       branch: params.request.branch.trim(),
       directoryPaths: params.request.directoryPaths,
-    });
+    })).map(normalizePrSummary);
     const fetchedAt = Date.now();
     this.rememberPrStatuses(prs, fetchedAt);
     await this.writePrStatusesToCache(prs, fetchedAt);
     this.rememberPrLookup({
       lookupKey: params.lookupKey,
+      provider: normalizePullRequestProvider(params.request.provider),
       branch: params.request.branch.trim(),
       directoryPaths: params.lookupDirectoryPaths,
       prs,
@@ -1238,6 +1270,7 @@ class DesktopAppServerService {
     });
     await this.writePrLookupToCache({
       lookupKey: params.lookupKey,
+      provider: normalizePullRequestProvider(params.request.provider),
       branch: params.request.branch.trim(),
       directoryPaths: params.lookupDirectoryPaths,
       prs,
@@ -1264,6 +1297,7 @@ class DesktopAppServerService {
     const refreshKey = this.claimPullRequestLookupRefreshKey(
       params.lookupKey,
       params.request.trigger ?? "scheduled",
+      normalizePullRequestProvider(params.request.provider),
     );
     if (!refreshKey) {
       return;
@@ -1385,6 +1419,7 @@ class DesktopAppServerService {
   private claimPullRequestLookupRefreshKey(
     lookupKey: string,
     trigger: NonNullable<RefreshThreadPullRequestsRequest["trigger"]>,
+    provider: string,
   ): string | undefined {
     const now = Date.now();
     const minInterval =
@@ -1414,6 +1449,7 @@ class DesktopAppServerService {
       this.prLookupRegistry.set(lookupKey, {
         prs: [],
         fetchedAt: 0,
+        provider: normalizePullRequestProvider(provider),
         branch: "",
         directoryPaths: [],
         [timestampField]: now,
@@ -1424,7 +1460,7 @@ class DesktopAppServerService {
   }
 
   private rememberPrStatuses(prs: PrSummary[], fetchedAt: number): void {
-    for (const pr of prs) {
+    for (const pr of prs.map(normalizePrSummary)) {
       const key = getPrStatusKey(pr);
       const current = this.prStatusRegistry.get(key);
       if (current && current.fetchedAt > fetchedAt) {
@@ -1440,6 +1476,7 @@ class DesktopAppServerService {
 
   private rememberPrLookup(entry: {
     lookupKey: string;
+    provider: string;
     branch: string;
     directoryPaths: string[];
     prs: PrSummary[];
@@ -1451,9 +1488,10 @@ class DesktopAppServerService {
     }
     this.prLookupRegistry.set(entry.lookupKey, {
       ...current,
+      provider: normalizePullRequestProvider(entry.provider),
       branch: entry.branch,
       directoryPaths: entry.directoryPaths,
-      prs: entry.prs,
+      prs: entry.prs.map(normalizePrSummary),
       fetchedAt: entry.fetchedAt,
     });
   }
@@ -1485,7 +1523,8 @@ class DesktopAppServerService {
     prs: PrSummary[],
     fetchedAt: number,
   ): Promise<void> {
-    const entries: PrStatusCacheEntry[] = prs.map((pr) => ({
+    const entries: PrStatusCacheEntry[] = prs.map(normalizePrSummary).map((pr) => ({
+      provider: normalizePullRequestProvider(pr.provider),
       prKey: getPrStatusKey(pr),
       fetchedAt,
       pr,
@@ -1498,7 +1537,10 @@ class DesktopAppServerService {
   }
 
   private canonicalizePrs(prs: PrSummary[]): PrSummary[] {
-    return prs.map((pr) => this.prStatusRegistry.get(getPrStatusKey(pr))?.pr ?? pr);
+    return prs.map((pr) => {
+      const normalized = normalizePrSummary(pr);
+      return this.prStatusRegistry.get(getPrStatusKey(normalized))?.pr ?? normalized;
+    });
   }
 
   private seedPrStatusRegistryFromThreads(

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1176,6 +1176,7 @@ class DesktopAppServerService {
       : existingLookupMatches
         ? existingPrs
         : [];
+    const knownPrs = this.mergePrHistory(existingPrs, currentLookupPrs);
     if (lookupEntry && lookupEntry.fetchedAt > 0) {
       await this.persistPullRequestLookupHit({
         backend,
@@ -1208,12 +1209,13 @@ class DesktopAppServerService {
     if (
       allExistingPrsTerminal
       && branch !== "HEAD"
+      && request.trigger !== "user"
     ) {
       return {
         backend,
         threadId: request.threadId,
         provider,
-        prs: currentLookupPrs,
+        prs: knownPrs,
         ghAvailable: true,
         shortCircuited: true,
       };
@@ -1224,7 +1226,7 @@ class DesktopAppServerService {
         backend,
         threadId: request.threadId,
         provider,
-        prs: currentLookupPrs,
+        prs: knownPrs,
         ghAvailable: true,
       };
     }
@@ -1235,14 +1237,14 @@ class DesktopAppServerService {
       requestKey,
       lookupKey,
       lookupDirectoryPaths,
-      previousPrs: currentLookupPrs,
+      previousPrs: knownPrs,
     });
 
     return {
       backend,
       threadId: request.threadId,
       provider,
-      prs: currentLookupPrs,
+      prs: knownPrs,
       ghAvailable: true,
     };
   }
@@ -1364,19 +1366,20 @@ class DesktopAppServerService {
 
     await Promise.all(
       [...subscribers.values()].map(async (subscriber) => {
+        const nextPrs = this.mergePrHistory(subscriber.previousPrs, params.prs);
         await this.getOverlayStore().setThreadPullRequests({
           backend: subscriber.backend,
           threadId: subscriber.threadId,
-          prs: params.prs,
+          prs: nextPrs,
           fetchedAt: params.fetchedAt,
           refreshKey: subscriber.requestKey,
         });
 
-        if (!prSummariesEqual(subscriber.previousPrs, params.prs)) {
+        if (!prSummariesEqual(subscriber.previousPrs, nextPrs)) {
           await this.publishThreadPullRequestsUpdated({
             backend: subscriber.backend,
             threadId: subscriber.threadId,
-            prs: params.prs,
+            prs: nextPrs,
           });
         }
       }),
@@ -1392,9 +1395,10 @@ class DesktopAppServerService {
     prs: PrSummary[];
     fetchedAt: number;
   }): Promise<void> {
+    const nextPrs = this.mergePrHistory(params.persistedPrs, params.prs);
     if (
       params.persistedRefreshKey === params.requestKey
-      && prSummariesEqual(params.persistedPrs, params.prs)
+      && prSummariesEqual(params.persistedPrs, nextPrs)
     ) {
       return;
     }
@@ -1402,16 +1406,16 @@ class DesktopAppServerService {
     await this.getOverlayStore().setThreadPullRequests({
       backend: params.backend,
       threadId: params.request.threadId,
-      prs: params.prs,
+      prs: nextPrs,
       fetchedAt: params.fetchedAt,
       refreshKey: params.requestKey,
     });
 
-    if (!prSummariesEqual(params.persistedPrs, params.prs)) {
+    if (!prSummariesEqual(params.persistedPrs, nextPrs)) {
       await this.publishThreadPullRequestsUpdated({
         backend: params.backend,
         threadId: params.request.threadId,
-        prs: params.prs,
+        prs: nextPrs,
       });
     }
   }
@@ -1541,6 +1545,30 @@ class DesktopAppServerService {
       const normalized = normalizePrSummary(pr);
       return this.prStatusRegistry.get(getPrStatusKey(normalized))?.pr ?? normalized;
     });
+  }
+
+  private mergePrHistory(
+    existingPrs: PrSummary[],
+    discoveredPrs: PrSummary[],
+  ): PrSummary[] {
+    const merged = this.canonicalizePrs(existingPrs);
+    const indexes = new Map<string, number>();
+    merged.forEach((pr, index) => {
+      indexes.set(getPrStatusKey(pr), index);
+    });
+
+    for (const pr of this.canonicalizePrs(discoveredPrs)) {
+      const key = getPrStatusKey(pr);
+      const existingIndex = indexes.get(key);
+      if (existingIndex === undefined) {
+        indexes.set(key, merged.length);
+        merged.push(pr);
+      } else {
+        merged[existingIndex] = pr;
+      }
+    }
+
+    return merged;
   }
 
   private seedPrStatusRegistryFromThreads(

--- a/apps/desktop/src/main/pr-status/github-pr-fetcher.ts
+++ b/apps/desktop/src/main/pr-status/github-pr-fetcher.ts
@@ -6,6 +6,7 @@ import type {
   PrChipState,
   PrSummary,
 } from "@pwragent/shared";
+import { DEFAULT_PULL_REQUEST_PROVIDER } from "@pwragent/shared";
 import { getMainLogger } from "../log";
 import { discoverGhCommands } from "../settings/gh-discovery";
 import { getDesktopSettingsService } from "../settings/desktop-settings-singleton";
@@ -374,12 +375,21 @@ export class GithubPrFetcher {
  */
 export function parseGhPrPayload(row: GhPrPayload): PrSummary {
   return {
+    provider: parsePullRequestProvider(row.url),
     number: row.number,
     org: row.headRepositoryOwner?.login ?? "",
     repo: row.headRepository?.name ?? "",
     state: deriveChipState(row),
     url: row.url,
   };
+}
+
+function parsePullRequestProvider(url: string): string {
+  try {
+    return new URL(url).hostname.toLowerCase() || DEFAULT_PULL_REQUEST_PROVIDER;
+  } catch {
+    return DEFAULT_PULL_REQUEST_PROVIDER;
+  }
 }
 
 export function deriveChipState(row: GhPrPayload): PrChipState {

--- a/apps/desktop/src/main/pr-status/github-pr-fetcher.ts
+++ b/apps/desktop/src/main/pr-status/github-pr-fetcher.ts
@@ -4,6 +4,9 @@ import type {
   DesktopGhDiscoverySnapshot,
   GhStatus,
   PrChipState,
+  PrLifecycleState,
+  PrMergeState,
+  PrReviewState,
   PrSummary,
 } from "@pwragent/shared";
 import { DEFAULT_PULL_REQUEST_PROVIDER } from "@pwragent/shared";
@@ -22,6 +25,8 @@ const GH_FIELDS = [
   "url",
   "state",
   "isDraft",
+  "mergeable",
+  "mergeStateStatus",
   "mergedAt",
   "headRefName",
   "headRepository",
@@ -56,6 +61,8 @@ type GhPrPayload = {
   url: string;
   state: string;
   isDraft: boolean;
+  mergeable?: string | null;
+  mergeStateStatus?: string | null;
   mergedAt: string | null;
   headRefName: string;
   headRepository: { name?: string } | null;
@@ -173,9 +180,10 @@ export class GithubPrFetcher {
    * Fetch all open PRs for the given branches in a single `gh pr list` call.
    * Caller batches by cwd (each cwd is a separate repo from gh's POV).
    *
-   * Why open-only: merged/closed PRs are terminal states. Once we've stored
-   * a `merged` chip on the overlay, we never re-fetch — so this call only
-   * needs to surface non-terminal PRs we might want to refresh.
+   * Why open-only: merged/closed PRs are terminal lifecycle states. Once we've
+   * stored a terminal lifecycle on the overlay, we never re-fetch through this
+   * open-only path — it only needs to surface non-terminal PRs we might want
+   * to refresh.
    *
    * Filter by headRefName client-side: gh's `--head` flag accepts only one
    * branch, but `--state open --json …` over the whole repo returns at most
@@ -376,13 +384,18 @@ export class GithubPrFetcher {
  * without invoking the subprocess.
  */
 export function parseGhPrPayload(row: GhPrPayload): PrSummary {
+  const checkState = deriveChipState(row);
   return {
     provider: parsePullRequestProvider(row.url),
     number: row.number,
     org: row.headRepositoryOwner?.login ?? "",
     repo: row.headRepository?.name ?? "",
     ...(row.title?.trim() ? { title: row.title.trim() } : {}),
-    state: deriveChipState(row),
+    state: checkState,
+    checkState,
+    lifecycleState: deriveLifecycleState(row),
+    reviewState: deriveReviewState(row),
+    mergeState: deriveMergeState(row),
     url: row.url,
   };
 }
@@ -396,11 +409,6 @@ function parsePullRequestProvider(url: string): string {
 }
 
 export function deriveChipState(row: GhPrPayload): PrChipState {
-  if (row.state === "MERGED") return "merged";
-  if (row.state === "CLOSED") return "closed";
-  // OPEN past this point.
-  if (row.isDraft) return "draft";
-
   const checks = row.statusCheckRollup ?? [];
   if (checks.length === 0) return "unknown";
 
@@ -439,6 +447,31 @@ export function deriveChipState(row: GhPrPayload): PrChipState {
   }
   if (pendingCount > 0) return "pending";
   return "passing";
+}
+
+export function deriveLifecycleState(row: Pick<GhPrPayload, "state">): PrLifecycleState {
+  if (row.state === "MERGED") return "merged";
+  if (row.state === "CLOSED") return "closed";
+  return "open";
+}
+
+export function deriveReviewState(row: Pick<GhPrPayload, "isDraft">): PrReviewState {
+  return row.isDraft ? "draft" : "ready_for_review";
+}
+
+export function deriveMergeState(
+  row: Pick<GhPrPayload, "mergeable" | "mergeStateStatus" | "state">,
+): PrMergeState {
+  if (deriveLifecycleState(row) !== "open") {
+    return "unknown";
+  }
+  if (row.mergeStateStatus === "DIRTY" || row.mergeable === "CONFLICTING") {
+    return "conflicting";
+  }
+  if (row.mergeStateStatus === "CLEAN" || row.mergeable === "MERGEABLE") {
+    return "mergeable";
+  }
+  return "unknown";
 }
 
 /**

--- a/apps/desktop/src/main/pr-status/github-pr-fetcher.ts
+++ b/apps/desktop/src/main/pr-status/github-pr-fetcher.ts
@@ -18,6 +18,7 @@ const fetcherLog = getMainLogger("pwragent:pr-fetcher");
  *  against `gh 2.88.1` against pwrdrvr/PwrAgent on 2026-05-04. */
 const GH_FIELDS = [
   "number",
+  "title",
   "url",
   "state",
   "isDraft",
@@ -51,6 +52,7 @@ const DEFAULT_GH_AUTH_STATUS_CACHE_TTL_MS = 5 * 60_000;
 /** Subset of fields returned by `gh pr list --json …` that we actually read. */
 type GhPrPayload = {
   number: number;
+  title?: string;
   url: string;
   state: string;
   isDraft: boolean;
@@ -379,6 +381,7 @@ export function parseGhPrPayload(row: GhPrPayload): PrSummary {
     number: row.number,
     org: row.headRepositoryOwner?.login ?? "",
     repo: row.headRepository?.name ?? "",
+    ...(row.title?.trim() ? { title: row.title.trim() } : {}),
     state: deriveChipState(row),
     url: row.url,
   };

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -66,10 +66,41 @@ function normalizePullRequestProvider(provider: string | undefined): string {
 }
 
 function normalizePrSummary(pr: PrSummary): PrSummary {
+  const checkState = normalizePrCheckState(pr.checkState ?? pr.state);
   return {
     ...pr,
     provider: normalizePullRequestProvider(pr.provider),
+    state: checkState,
+    checkState,
+    lifecycleState: pr.lifecycleState ?? legacyPrLifecycleState(pr.state),
+    reviewState: pr.reviewState ?? legacyPrReviewState(pr.state),
+    mergeState: pr.mergeState ?? "unknown",
   };
+}
+
+function normalizePrCheckState(
+  state: string | undefined,
+): NonNullable<PrSummary["checkState"]> {
+  if (
+    state === "passing"
+    || state === "failing"
+    || state === "pending"
+    || state === "unknown"
+  ) {
+    return state;
+  }
+  return "unknown";
+}
+
+function legacyPrLifecycleState(state: string | undefined): PrSummary["lifecycleState"] {
+  if (state === "merged" || state === "closed") {
+    return state;
+  }
+  return "open";
+}
+
+function legacyPrReviewState(state: string | undefined): PrSummary["reviewState"] {
+  return state === "draft" ? "draft" : "ready_for_review";
 }
 
 function getPrStatusCacheKey(pr: PrSummary): string {

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -824,7 +824,7 @@ export class SqliteOverlayStore {
           directoryPaths,
           fetchedAt: row.fetched_at,
           prs: (JSON.parse(row.payload) as PrSummary[]).map((pr) =>
-            normalizePrSummary({ ...pr, provider }),
+            normalizePrSummary({ ...pr, provider: pr.provider ?? provider }),
           ),
         };
       } catch {

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -20,6 +20,7 @@ import type {
   WorktreeSnapshotSummary,
 } from "@pwragent/shared";
 import {
+  DEFAULT_PULL_REQUEST_PROVIDER,
   AGENT_PERSONA_INSTRUCTIONS_LINE_GUIDANCE,
   MAX_MESSAGING_BINDING_TRANSITION_LOG_ENTRIES,
   MAX_IMMUTABLE_USAGE_ACTIVITY_ENTRIES,
@@ -45,17 +46,49 @@ export type DirectoryGitStatusCacheEntry = {
 
 export type PrStatusCacheEntry = {
   prKey: string;
+  provider: string;
   fetchedAt: number;
   pr: PrSummary;
 };
 
 export type PrLookupCacheEntry = {
   lookupKey: string;
+  provider: string;
   branch: string;
   directoryPaths: string[];
   fetchedAt: number;
   prs: PrSummary[];
 };
+
+function normalizePullRequestProvider(provider: string | undefined): string {
+  return (provider ?? DEFAULT_PULL_REQUEST_PROVIDER).trim().toLowerCase()
+    || DEFAULT_PULL_REQUEST_PROVIDER;
+}
+
+function normalizePrSummary(pr: PrSummary): PrSummary {
+  return {
+    ...pr,
+    provider: normalizePullRequestProvider(pr.provider),
+  };
+}
+
+function getPrStatusCacheKey(pr: PrSummary): string {
+  return `${normalizePullRequestProvider(pr.provider)}/${pr.org.toLowerCase()}/${pr.repo.toLowerCase()}#${pr.number}`;
+}
+
+function getPrLookupCacheKey(entry: {
+  provider: string;
+  branch: string;
+  directoryPaths: string[];
+}): string {
+  return JSON.stringify({
+    lookupVersion: 2,
+    provider: normalizePullRequestProvider(entry.provider),
+    branch: entry.branch.trim(),
+    directoryPaths: [...new Set(entry.directoryPaths.map((path) => path.trim()).filter(Boolean))]
+      .sort((left, right) => left.localeCompare(right)),
+  });
+}
 
 function parseDirectoryGitStatusCachePayload(
   payload: string | null,
@@ -685,7 +718,7 @@ export class SqliteOverlayStore {
     };
     const nextState: ThreadOverlayState = {
       ...current,
-      prs: params.prs,
+      prs: params.prs.map(normalizePrSummary),
       prsFetchedAt: params.fetchedAt ?? Date.now(),
       prsRefreshKey: params.refreshKey,
     };
@@ -696,11 +729,12 @@ export class SqliteOverlayStore {
   async readPrStatusCache(): Promise<Record<string, PrStatusCacheEntry>> {
     const rows = this.stateDb.raw
       .prepare(
-        `SELECT pr_key, fetched_at, payload
+        `SELECT pr_key, provider, fetched_at, payload
          FROM pr_status_cache`,
       )
       .all() as Array<{
         pr_key: string;
+        provider: string | null;
         fetched_at: number;
         payload: string;
       }>;
@@ -708,10 +742,17 @@ export class SqliteOverlayStore {
     const entries: Record<string, PrStatusCacheEntry> = {};
     for (const row of rows) {
       try {
-        entries[row.pr_key] = {
-          prKey: row.pr_key,
+        const provider = normalizePullRequestProvider(row.provider ?? undefined);
+        const pr = normalizePrSummary({
+          ...(JSON.parse(row.payload) as PrSummary),
+          provider,
+        });
+        const prKey = getPrStatusCacheKey(pr);
+        entries[prKey] = {
+          prKey,
+          provider,
           fetchedAt: row.fetched_at,
-          pr: JSON.parse(row.payload) as PrSummary,
+          pr,
         };
       } catch {
         // Ignore malformed cache rows. A future refresh rewrites the row.
@@ -727,22 +768,24 @@ export class SqliteOverlayStore {
     const insert = this.stateDb.raw.prepare(
       `INSERT OR REPLACE INTO pr_status_cache(
          pr_key,
+         provider,
          org,
          repo,
          number,
          fetched_at,
          payload
-       ) VALUES (?, ?, ?, ?, ?, ?)`,
+       ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
     );
     const write = this.stateDb.raw.transaction(() => {
       for (const entry of entries) {
         insert.run(
           entry.prKey,
+          normalizePullRequestProvider(entry.provider),
           entry.pr.org,
           entry.pr.repo,
           entry.pr.number,
           entry.fetchedAt,
-          JSON.stringify(entry.pr),
+          JSON.stringify(normalizePrSummary(entry.pr)),
         );
       }
     });
@@ -752,11 +795,12 @@ export class SqliteOverlayStore {
   async readPrLookupCache(): Promise<Record<string, PrLookupCacheEntry>> {
     const rows = this.stateDb.raw
       .prepare(
-        `SELECT lookup_key, branch, directory_paths, fetched_at, payload
+        `SELECT lookup_key, provider, branch, directory_paths, fetched_at, payload
          FROM pr_lookup_cache`,
       )
       .all() as Array<{
         lookup_key: string;
+        provider: string | null;
         branch: string;
         directory_paths: string;
         fetched_at: number;
@@ -766,12 +810,22 @@ export class SqliteOverlayStore {
     const entries: Record<string, PrLookupCacheEntry> = {};
     for (const row of rows) {
       try {
-        entries[row.lookup_key] = {
-          lookupKey: row.lookup_key,
+        const provider = normalizePullRequestProvider(row.provider ?? undefined);
+        const directoryPaths = JSON.parse(row.directory_paths) as string[];
+        const lookupKey = getPrLookupCacheKey({
+          provider,
           branch: row.branch,
-          directoryPaths: JSON.parse(row.directory_paths) as string[],
+          directoryPaths,
+        });
+        entries[lookupKey] = {
+          lookupKey,
+          provider,
+          branch: row.branch,
+          directoryPaths,
           fetchedAt: row.fetched_at,
-          prs: JSON.parse(row.payload) as PrSummary[],
+          prs: (JSON.parse(row.payload) as PrSummary[]).map((pr) =>
+            normalizePrSummary({ ...pr, provider }),
+          ),
         };
       } catch {
         // Ignore malformed cache rows. A future refresh rewrites the row.
@@ -785,18 +839,20 @@ export class SqliteOverlayStore {
       .prepare(
         `INSERT OR REPLACE INTO pr_lookup_cache(
            lookup_key,
+           provider,
            branch,
            directory_paths,
            fetched_at,
            payload
-         ) VALUES (?, ?, ?, ?, ?)`,
+         ) VALUES (?, ?, ?, ?, ?, ?)`,
       )
       .run(
         entry.lookupKey,
+        normalizePullRequestProvider(entry.provider),
         entry.branch,
         JSON.stringify(entry.directoryPaths),
         entry.fetchedAt,
-        JSON.stringify(entry.prs),
+        JSON.stringify(entry.prs.map(normalizePrSummary)),
       );
   }
 

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -43,6 +43,12 @@ export type DirectoryGitStatusCacheEntry = {
   gitStatus?: NavigationDirectoryGitStatus;
 };
 
+export type PrStatusCacheEntry = {
+  prKey: string;
+  fetchedAt: number;
+  pr: PrSummary;
+};
+
 function parseDirectoryGitStatusCachePayload(
   payload: string | null,
 ): NavigationDirectoryGitStatus | undefined {
@@ -679,6 +685,62 @@ export class SqliteOverlayStore {
     return nextState;
   }
 
+  async readPrStatusCache(): Promise<Record<string, PrStatusCacheEntry>> {
+    const rows = this.stateDb.raw
+      .prepare(
+        `SELECT pr_key, fetched_at, payload
+         FROM pr_status_cache`,
+      )
+      .all() as Array<{
+        pr_key: string;
+        fetched_at: number;
+        payload: string;
+      }>;
+
+    const entries: Record<string, PrStatusCacheEntry> = {};
+    for (const row of rows) {
+      try {
+        entries[row.pr_key] = {
+          prKey: row.pr_key,
+          fetchedAt: row.fetched_at,
+          pr: JSON.parse(row.payload) as PrSummary,
+        };
+      } catch {
+        // Ignore malformed cache rows. A future refresh rewrites the row.
+      }
+    }
+    return entries;
+  }
+
+  async writePrStatusCacheEntries(entries: PrStatusCacheEntry[]): Promise<void> {
+    if (entries.length === 0) {
+      return;
+    }
+    const insert = this.stateDb.raw.prepare(
+      `INSERT OR REPLACE INTO pr_status_cache(
+         pr_key,
+         org,
+         repo,
+         number,
+         fetched_at,
+         payload
+       ) VALUES (?, ?, ?, ?, ?, ?)`,
+    );
+    const write = this.stateDb.raw.transaction(() => {
+      for (const entry of entries) {
+        insert.run(
+          entry.prKey,
+          entry.pr.org,
+          entry.pr.repo,
+          entry.pr.number,
+          entry.fetchedAt,
+          JSON.stringify(entry.pr),
+        );
+      }
+    });
+    write();
+  }
+
   async getThreadOverlayStates(params: {
     backend: ThreadOverlayState["backend"];
     threadIds: string[];
@@ -1300,6 +1362,8 @@ export type OverlayStoreLike = Pick<
   | "getDirectoryOverlayState"
   | "readAllDirectoryOverlays"
   | "setThreadPullRequests"
+  | "readPrStatusCache"
+  | "writePrStatusCacheEntries"
   | "upsertWorktreeSnapshot"
   | "setThreadExecutionMode"
   | "setThreadModelSettings"

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -49,6 +49,14 @@ export type PrStatusCacheEntry = {
   pr: PrSummary;
 };
 
+export type PrLookupCacheEntry = {
+  lookupKey: string;
+  branch: string;
+  directoryPaths: string[];
+  fetchedAt: number;
+  prs: PrSummary[];
+};
+
 function parseDirectoryGitStatusCachePayload(
   payload: string | null,
 ): NavigationDirectoryGitStatus | undefined {
@@ -741,6 +749,57 @@ export class SqliteOverlayStore {
     write();
   }
 
+  async readPrLookupCache(): Promise<Record<string, PrLookupCacheEntry>> {
+    const rows = this.stateDb.raw
+      .prepare(
+        `SELECT lookup_key, branch, directory_paths, fetched_at, payload
+         FROM pr_lookup_cache`,
+      )
+      .all() as Array<{
+        lookup_key: string;
+        branch: string;
+        directory_paths: string;
+        fetched_at: number;
+        payload: string;
+      }>;
+
+    const entries: Record<string, PrLookupCacheEntry> = {};
+    for (const row of rows) {
+      try {
+        entries[row.lookup_key] = {
+          lookupKey: row.lookup_key,
+          branch: row.branch,
+          directoryPaths: JSON.parse(row.directory_paths) as string[],
+          fetchedAt: row.fetched_at,
+          prs: JSON.parse(row.payload) as PrSummary[],
+        };
+      } catch {
+        // Ignore malformed cache rows. A future refresh rewrites the row.
+      }
+    }
+    return entries;
+  }
+
+  async writePrLookupCacheEntry(entry: PrLookupCacheEntry): Promise<void> {
+    this.stateDb.raw
+      .prepare(
+        `INSERT OR REPLACE INTO pr_lookup_cache(
+           lookup_key,
+           branch,
+           directory_paths,
+           fetched_at,
+           payload
+         ) VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run(
+        entry.lookupKey,
+        entry.branch,
+        JSON.stringify(entry.directoryPaths),
+        entry.fetchedAt,
+        JSON.stringify(entry.prs),
+      );
+  }
+
   async getThreadOverlayStates(params: {
     backend: ThreadOverlayState["backend"];
     threadIds: string[];
@@ -1364,6 +1423,8 @@ export type OverlayStoreLike = Pick<
   | "setThreadPullRequests"
   | "readPrStatusCache"
   | "writePrStatusCacheEntries"
+  | "readPrLookupCache"
+  | "writePrLookupCacheEntry"
   | "upsertWorktreeSnapshot"
   | "setThreadExecutionMode"
   | "setThreadModelSettings"

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -591,11 +591,6 @@ export class StateDb {
     if ((db.pragma("user_version", { simple: true }) as number) < 14) {
       db.transaction(() => {
         db.exec(PR_STATUS_CACHE_SCHEMA);
-        db.pragma("user_version = 13");
-      })();
-    }
-    if ((db.pragma("user_version", { simple: true }) as number) < 14) {
-      db.transaction(() => {
         db.exec(PR_LOOKUP_CACHE_SCHEMA);
         db.pragma("user_version = 14");
       })();

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -4,7 +4,7 @@ import Database from "better-sqlite3";
 import type BetterSqlite3 from "better-sqlite3";
 import { getNativeBinding } from "./native-binding.js";
 
-export const CURRENT_STATE_DB_USER_VERSION = 14;
+export const CURRENT_STATE_DB_USER_VERSION = 15;
 
 const SCHEMA_V1 = `
 CREATE TABLE meta (
@@ -438,6 +438,7 @@ CREATE VIRTUAL TABLE IF NOT EXISTS thread_search_fts USING fts5(
 const PR_STATUS_CACHE_SCHEMA = `
 CREATE TABLE IF NOT EXISTS pr_status_cache (
   pr_key     TEXT PRIMARY KEY,
+  provider   TEXT NOT NULL DEFAULT 'github.com',
   org        TEXT NOT NULL,
   repo       TEXT NOT NULL,
   number     INTEGER NOT NULL,
@@ -451,6 +452,7 @@ CREATE INDEX IF NOT EXISTS idx_pr_status_cache_fetched
 const PR_LOOKUP_CACHE_SCHEMA = `
 CREATE TABLE IF NOT EXISTS pr_lookup_cache (
   lookup_key      TEXT PRIMARY KEY,
+  provider        TEXT NOT NULL DEFAULT 'github.com',
   branch          TEXT NOT NULL,
   directory_paths TEXT NOT NULL,
   fetched_at      INTEGER NOT NULL,
@@ -595,6 +597,12 @@ export class StateDb {
     if ((db.pragma("user_version", { simple: true }) as number) < 14) {
       db.transaction(() => {
         db.exec(PR_LOOKUP_CACHE_SCHEMA);
+        db.pragma("user_version = 14");
+      })();
+    }
+    if ((db.pragma("user_version", { simple: true }) as number) < 15) {
+      db.transaction(() => {
+        ensurePullRequestProviderColumns(db);
         db.pragma(`user_version = ${CURRENT_STATE_DB_USER_VERSION}`);
       })();
     }
@@ -746,12 +754,13 @@ function ensureCurrentSchema(db: BetterSqlite3.Database): void {
     db.exec(THREAD_SEARCH_SCHEMA);
     db.exec(PR_STATUS_CACHE_SCHEMA);
     db.exec(PR_LOOKUP_CACHE_SCHEMA);
+    ensurePullRequestProviderColumns(db);
     if ((db.pragma("user_version", { simple: true }) as number) < 4) {
       db.pragma("user_version = 4");
     }
   })();
 
-  if (!appRuntimeInstancesColumnExists(db, "cwd_hash")) {
+  if (!tableColumnExists(db, "app_runtime_instances", "cwd_hash")) {
     db.exec("ALTER TABLE app_runtime_instances ADD COLUMN cwd_hash TEXT");
   }
   db.exec(`
@@ -760,11 +769,42 @@ CREATE INDEX IF NOT EXISTS idx_app_runtime_instances_profile_cwd_hash
 `);
 }
 
-function appRuntimeInstancesColumnExists(
+function ensurePullRequestProviderColumns(db: BetterSqlite3.Database): void {
+  if (!tableColumnExists(db, "pr_status_cache", "provider")) {
+    db.exec(
+      "ALTER TABLE pr_status_cache ADD COLUMN provider TEXT NOT NULL DEFAULT 'github.com'",
+    );
+  }
+  db.exec(`
+UPDATE pr_status_cache
+SET
+  provider = COALESCE(NULLIF(provider, ''), 'github.com'),
+  pr_key = COALESCE(NULLIF(provider, ''), 'github.com')
+    || '/'
+    || lower(org)
+    || '/'
+    || lower(repo)
+    || '#'
+    || number
+`);
+
+  if (!tableColumnExists(db, "pr_lookup_cache", "provider")) {
+    db.exec(
+      "ALTER TABLE pr_lookup_cache ADD COLUMN provider TEXT NOT NULL DEFAULT 'github.com'",
+    );
+  }
+  db.exec(`
+UPDATE pr_lookup_cache
+SET provider = COALESCE(NULLIF(provider, ''), 'github.com')
+`);
+}
+
+function tableColumnExists(
   db: BetterSqlite3.Database,
+  tableName: string,
   columnName: string,
 ): boolean {
-  const rows = db.prepare("PRAGMA table_info(app_runtime_instances)").all() as Array<{
+  const rows = db.prepare(`PRAGMA table_info(${tableName})`).all() as Array<{
     name: string;
   }>;
   return rows.some((row) => row.name === columnName);

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -4,7 +4,7 @@ import Database from "better-sqlite3";
 import type BetterSqlite3 from "better-sqlite3";
 import { getNativeBinding } from "./native-binding.js";
 
-export const CURRENT_STATE_DB_USER_VERSION = 13;
+export const CURRENT_STATE_DB_USER_VERSION = 14;
 
 const SCHEMA_V1 = `
 CREATE TABLE meta (
@@ -435,6 +435,19 @@ CREATE VIRTUAL TABLE IF NOT EXISTS thread_search_fts USING fts5(
 );
 `;
 
+const PR_STATUS_CACHE_SCHEMA = `
+CREATE TABLE IF NOT EXISTS pr_status_cache (
+  pr_key     TEXT PRIMARY KEY,
+  org        TEXT NOT NULL,
+  repo       TEXT NOT NULL,
+  number     INTEGER NOT NULL,
+  fetched_at INTEGER NOT NULL,
+  payload    TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_pr_status_cache_fetched
+  ON pr_status_cache(fetched_at DESC);
+`;
+
 const DELIVERIES_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 const REVOKED_BINDINGS_RETENTION_MS = 90 * 24 * 60 * 60 * 1000;
 const APP_RUNTIME_INSTANCE_RETENTION_MS = 60 * 60 * 1000;
@@ -558,6 +571,12 @@ export class StateDb {
     if ((db.pragma("user_version", { simple: true }) as number) < 13) {
       db.transaction(() => {
         db.exec(THREAD_SEARCH_SCHEMA);
+        db.pragma("user_version = 13");
+      })();
+    }
+    if ((db.pragma("user_version", { simple: true }) as number) < 14) {
+      db.transaction(() => {
+        db.exec(PR_STATUS_CACHE_SCHEMA);
         db.pragma(`user_version = ${CURRENT_STATE_DB_USER_VERSION}`);
       })();
     }
@@ -707,6 +726,7 @@ function ensureCurrentSchema(db: BetterSqlite3.Database): void {
     db.exec(AUTOMATION_SCHEMA);
     db.exec(MESSAGING_ACTIVITY_SUMMARY_SCHEMA);
     db.exec(THREAD_SEARCH_SCHEMA);
+    db.exec(PR_STATUS_CACHE_SCHEMA);
     if ((db.pragma("user_version", { simple: true }) as number) < 4) {
       db.pragma("user_version = 4");
     }

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -448,6 +448,18 @@ CREATE INDEX IF NOT EXISTS idx_pr_status_cache_fetched
   ON pr_status_cache(fetched_at DESC);
 `;
 
+const PR_LOOKUP_CACHE_SCHEMA = `
+CREATE TABLE IF NOT EXISTS pr_lookup_cache (
+  lookup_key      TEXT PRIMARY KEY,
+  branch          TEXT NOT NULL,
+  directory_paths TEXT NOT NULL,
+  fetched_at      INTEGER NOT NULL,
+  payload         TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_pr_lookup_cache_fetched
+  ON pr_lookup_cache(fetched_at DESC);
+`;
+
 const DELIVERIES_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 const REVOKED_BINDINGS_RETENTION_MS = 90 * 24 * 60 * 60 * 1000;
 const APP_RUNTIME_INSTANCE_RETENTION_MS = 60 * 60 * 1000;
@@ -577,6 +589,12 @@ export class StateDb {
     if ((db.pragma("user_version", { simple: true }) as number) < 14) {
       db.transaction(() => {
         db.exec(PR_STATUS_CACHE_SCHEMA);
+        db.pragma("user_version = 13");
+      })();
+    }
+    if ((db.pragma("user_version", { simple: true }) as number) < 14) {
+      db.transaction(() => {
+        db.exec(PR_LOOKUP_CACHE_SCHEMA);
         db.pragma(`user_version = ${CURRENT_STATE_DB_USER_VERSION}`);
       })();
     }
@@ -727,6 +745,7 @@ function ensureCurrentSchema(db: BetterSqlite3.Database): void {
     db.exec(MESSAGING_ACTIVITY_SUMMARY_SCHEMA);
     db.exec(THREAD_SEARCH_SCHEMA);
     db.exec(PR_STATUS_CACHE_SCHEMA);
+    db.exec(PR_LOOKUP_CACHE_SCHEMA);
     if ((db.pragma("user_version", { simple: true }) as number) < 4) {
       db.pragma("user_version = 4");
     }

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -801,11 +801,29 @@ SET provider = COALESCE(NULLIF(provider, ''), 'github.com')
 
 function tableColumnExists(
   db: BetterSqlite3.Database,
-  tableName: string,
+  tableName: "app_runtime_instances" | "pr_lookup_cache" | "pr_status_cache",
   columnName: string,
 ): boolean {
-  const rows = db.prepare(`PRAGMA table_info(${tableName})`).all() as Array<{
-    name: string;
-  }>;
+  const rows = readTableInfo(db, tableName);
   return rows.some((row) => row.name === columnName);
+}
+
+function readTableInfo(
+  db: BetterSqlite3.Database,
+  tableName: "app_runtime_instances" | "pr_lookup_cache" | "pr_status_cache",
+): Array<{ name: string }> {
+  switch (tableName) {
+    case "app_runtime_instances":
+      return db.prepare("PRAGMA table_info(app_runtime_instances)").all() as Array<{
+        name: string;
+      }>;
+    case "pr_lookup_cache":
+      return db.prepare("PRAGMA table_info(pr_lookup_cache)").all() as Array<{
+        name: string;
+      }>;
+    case "pr_status_cache":
+      return db.prepare("PRAGMA table_info(pr_status_cache)").all() as Array<{
+        name: string;
+      }>;
+  }
 }

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -104,7 +104,8 @@ export function ThreadRow(props: ThreadRowProps) {
   const showRepoPrefix = needsRepoPrefix(prs);
   const openPr = props.onOpenPullRequest ?? defaultOpenPullRequest;
   const hasNonTerminalPr = prs.some(
-    (pr) => pr.state !== "merged" && pr.state !== "closed",
+    (pr) => (pr.lifecycleState ?? pr.state) !== "merged"
+      && (pr.lifecycleState ?? pr.state) !== "closed",
   );
   // Hover prefetch: 750ms intent timer — long enough that simply scrolling
   // past doesn't fire, short enough that a deliberate hover beats the

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -103,13 +103,10 @@ export function ThreadRow(props: ThreadRowProps) {
   const prs = props.thread.prs ?? [];
   const showRepoPrefix = needsRepoPrefix(prs);
   const openPr = props.onOpenPullRequest ?? defaultOpenPullRequest;
-  const hasNonTerminalPr = prs.some(
-    (pr) => (pr.lifecycleState ?? pr.state) !== "merged"
-      && (pr.lifecycleState ?? pr.state) !== "closed",
-  );
   // Hover prefetch: 750ms intent timer — long enough that simply scrolling
   // past doesn't fire, short enough that a deliberate hover beats the
-  // user's first click.
+  // user's first click. Terminal-only PR sets still request a user
+  // refresh; main owns the longer terminal-state rate limit.
   const hoverTimerRef = useRef<number | undefined>(undefined);
   useEffect(() => () => {
     if (hoverTimerRef.current !== undefined) {
@@ -119,7 +116,6 @@ export function ThreadRow(props: ThreadRowProps) {
   }, []);
   const armHoverPrefetch = (): void => {
     if (!props.onPrefetchPullRequests) return;
-    if (!hasNonTerminalPr) return;
     if (hoverTimerRef.current !== undefined) return;
     hoverTimerRef.current = window.setTimeout(() => {
       hoverTimerRef.current = undefined;

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -120,6 +120,7 @@ const pullRequestThread: NavigationThreadSummary = {
   ...sharedThread,
   prs: [
     {
+      provider: "github.com",
       number: 202,
       org: "Giphy",
       repo: "GifGrabber",

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -2214,7 +2214,7 @@ describe("Sidebar", () => {
     );
 
     const prChip = screen.getByRole("button", {
-      name: "Open Giphy/GifGrabber#202 (passing) in browser",
+      name: "Open Giphy/GifGrabber#202 (ready for review · checks passing) in browser",
     });
     fireEvent.contextMenu(prChip, { clientX: 48, clientY: 64 });
     await clickElement(

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
@@ -306,6 +306,7 @@ describe("ThreadRow chip flow", () => {
       reactions: ["🙂"],
       prs: [
         {
+          provider: "github.com",
           number: 123,
           org: "pwrdrvr",
           repo: "PwrAgent",

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
@@ -363,4 +363,37 @@ describe("ThreadRow chip flow", () => {
       "pwrdrvr/PwrAgent#123 — ready for review · checks passing",
     );
   });
+
+  it("renders merged PRs as terminal purple chips without unknown check status", () => {
+    renderRow({
+      thread: {
+        ...baseThread,
+        prs: [
+          {
+            provider: "github.com",
+            number: 542,
+            org: "pwrdrvr",
+            repo: "PwrAgent",
+            lifecycleState: "merged",
+            checkState: "unknown",
+            state: "unknown",
+            url: "https://github.com/pwrdrvr/PwrAgent/pull/542",
+          },
+        ],
+      },
+    });
+
+    const prChip = screen.getByRole("button", {
+      name: "Open pwrdrvr/PwrAgent#542 (merged) in browser",
+    });
+    expect(prChip).toHaveClass("pr-chip--merged");
+    expect(prChip).not.toHaveClass("pr-chip--unknown");
+
+    fireEvent.mouseEnter(prChip);
+
+    expect(screen.getByRole("tooltip")).toHaveTextContent(
+      "pwrdrvr/PwrAgent#542 — merged",
+    );
+    expect(screen.getByRole("tooltip")).not.toHaveTextContent("status unknown");
+  });
 });

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
@@ -233,6 +233,43 @@ describe("ThreadRow chip flow", () => {
     expect(addReaction?.textContent ?? "").not.toContain("+");
   });
 
+  it("prefetches terminal-only PR chip sets after hover dwell", () => {
+    vi.useFakeTimers();
+    try {
+      const onPrefetchPullRequests = vi.fn();
+      const thread: NavigationThreadSummary = {
+        ...baseThread,
+        prs: [
+          {
+            provider: "github.com",
+            number: 542,
+            org: "pwrdrvr",
+            repo: "PwrAgent",
+            state: "unknown",
+            lifecycleState: "merged",
+            checkState: "unknown",
+            reviewState: "ready_for_review",
+            mergeState: "unknown",
+            url: "https://github.com/pwrdrvr/PwrAgent/pull/542",
+          },
+        ],
+      };
+      const { container } = renderRow({
+        thread,
+        onPrefetchPullRequests,
+      });
+
+      fireEvent.mouseEnter(container.querySelector(".thread-row__chips")!);
+      vi.advanceTimersByTime(749);
+      expect(onPrefetchPullRequests).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(1);
+      expect(onPrefetchPullRequests).toHaveBeenCalledWith(thread);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("uses a full card without action controls for the drag preview", () => {
     vi.useFakeTimers();
     try {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
@@ -330,4 +330,29 @@ describe("ThreadRow chip flow", () => {
     if (prIdx >= 0 && bindingIdx >= 0) expect(prIdx).toBeLessThan(bindingIdx);
     if (bindingIdx >= 0 && reactionIdx >= 0) expect(bindingIdx).toBeLessThan(reactionIdx);
   });
+
+  it("shows the PR title and status on separate tooltip lines", () => {
+    renderRow({
+      thread: {
+        ...baseThread,
+        prs: [
+          {
+            provider: "github.com",
+            number: 123,
+            org: "pwrdrvr",
+            repo: "PwrAgent",
+            title: "Retain thread pull request history",
+            state: "passing",
+            url: "https://github.com/pwrdrvr/PwrAgent/pull/123",
+          },
+        ],
+      },
+    });
+
+    expect(screen.getByRole("button", { name: /Open pwrdrvr\/PwrAgent#123/ }))
+      .toHaveAttribute(
+        "title",
+        "Retain thread pull request history\npwrdrvr/PwrAgent#123 — all checks passing",
+      );
+  });
 });

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
@@ -331,7 +331,7 @@ describe("ThreadRow chip flow", () => {
     if (bindingIdx >= 0 && reactionIdx >= 0) expect(bindingIdx).toBeLessThan(reactionIdx);
   });
 
-  it("shows the PR title and status on separate tooltip lines", () => {
+  it("shows the PR title and status in the shared viewport tooltip", () => {
     renderRow({
       thread: {
         ...baseThread,
@@ -349,10 +349,18 @@ describe("ThreadRow chip flow", () => {
       },
     });
 
-    expect(screen.getByRole("button", { name: /Open pwrdrvr\/PwrAgent#123/ }))
-      .toHaveAttribute(
-        "title",
-        "Retain thread pull request history\npwrdrvr/PwrAgent#123 — ready for review · checks passing",
-      );
+    const prChip = screen.getByRole("button", {
+      name: /Open pwrdrvr\/PwrAgent#123/,
+    });
+    expect(prChip).not.toHaveAttribute("title");
+
+    fireEvent.mouseEnter(prChip);
+
+    const tooltip = screen.getByRole("tooltip");
+    expect(tooltip).toHaveClass("viewport-tooltip");
+    expect(tooltip).toHaveTextContent("Retain thread pull request history");
+    expect(tooltip).toHaveTextContent(
+      "pwrdrvr/PwrAgent#123 — ready for review · checks passing",
+    );
   });
 });

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
@@ -352,7 +352,7 @@ describe("ThreadRow chip flow", () => {
     expect(screen.getByRole("button", { name: /Open pwrdrvr\/PwrAgent#123/ }))
       .toHaveAttribute(
         "title",
-        "Retain thread pull request history\npwrdrvr/PwrAgent#123 — all checks passing",
+        "Retain thread pull request history\npwrdrvr/PwrAgent#123 — ready for review · checks passing",
       );
   });
 });

--- a/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
@@ -17,7 +17,11 @@ export function PrChip(props: PrChipProps) {
   const label = props.showRepoPrefix
     ? `${pr.org}/${pr.repo}#${pr.number}`
     : `#${pr.number}`;
-  const tooltip = `${pr.org}/${pr.repo}#${pr.number} — ${stateTooltipLabel(pr.state)}`;
+  const identity = `${pr.org}/${pr.repo}#${pr.number}`;
+  const title = pr.title?.trim();
+  const tooltip = title
+    ? `${title}\n${identity} — ${stateTooltipLabel(pr.state)}`
+    : `${identity} — ${stateTooltipLabel(pr.state)}`;
 
   // role="button" span (not a real <button>) so the chip is legal HTML
   // inside the row's main <button>. stopPropagation prevents the row's

--- a/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
@@ -23,7 +23,7 @@ export function PrChip(props: PrChipProps) {
     : `#${pr.number}`;
   const identity = `${pr.org}/${pr.repo}#${pr.number}`;
   const title = pr.title?.trim();
-  const checkState = resolveCheckState(pr);
+  const chipState = resolveChipState(pr);
   const status = prStatusLabel(pr);
   const tooltip = title
     ? `${title}\n${identity} — ${status}`
@@ -46,7 +46,7 @@ export function PrChip(props: PrChipProps) {
         role="button"
         tabIndex={0}
         aria-label={`Open ${pr.org}/${pr.repo}#${pr.number} (${status}) in browser`}
-        className={`pr-chip pr-chip--${checkState}`}
+        className={`pr-chip pr-chip--${chipState}`}
         data-pr-chip=""
         onBlur={tooltipController.hide}
         onClick={handleActivate}
@@ -81,11 +81,14 @@ export function PrChip(props: PrChipProps) {
 }
 
 function prStatusLabel(pr: PrSummary): string {
+  const lifecycleState = resolveLifecycleState(pr);
   const parts: string[] = [];
-  if (pr.lifecycleState === "merged") {
+  if (lifecycleState === "merged") {
     parts.push("merged");
-  } else if (pr.lifecycleState === "closed") {
+    return parts.join(" · ");
+  } else if (lifecycleState === "closed") {
     parts.push("closed without merge");
+    return parts.join(" · ");
   } else if (pr.reviewState === "draft") {
     parts.push("draft");
   } else {
@@ -98,6 +101,26 @@ function prStatusLabel(pr: PrSummary): string {
 
   parts.push(checkStateTooltipLabel(resolveCheckState(pr)));
   return parts.join(" · ");
+}
+
+function resolveChipState(
+  pr: PrSummary,
+): NonNullable<PrSummary["checkState"]> | "merged" | "closed" {
+  const lifecycleState = resolveLifecycleState(pr);
+  if (lifecycleState === "merged" || lifecycleState === "closed") {
+    return lifecycleState;
+  }
+  return resolveCheckState(pr);
+}
+
+function resolveLifecycleState(pr: PrSummary): NonNullable<PrSummary["lifecycleState"]> {
+  if (pr.lifecycleState) {
+    return pr.lifecycleState;
+  }
+  if (pr.state === "merged" || pr.state === "closed") {
+    return pr.state;
+  }
+  return "open";
 }
 
 function resolveCheckState(pr: PrSummary): NonNullable<PrSummary["checkState"]> {

--- a/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
@@ -1,5 +1,6 @@
 import type { KeyboardEvent, MouseEvent } from "react";
 import type { PrSummary } from "@pwragent/shared";
+import { useViewportTooltip } from "../../lib/useViewportTooltip";
 
 type PrChipProps = {
   pr: PrSummary;
@@ -14,6 +15,9 @@ type PrChipProps = {
 
 export function PrChip(props: PrChipProps) {
   const { pr } = props;
+  const tooltipController = useViewportTooltip({
+    className: "viewport-tooltip",
+  });
   const label = props.showRepoPrefix
     ? `${pr.org}/${pr.repo}#${pr.number}`
     : `#${pr.number}`;
@@ -37,35 +41,42 @@ export function PrChip(props: PrChipProps) {
   };
 
   return (
-    <span
-      role="button"
-      tabIndex={0}
-      aria-label={`Open ${pr.org}/${pr.repo}#${pr.number} (${status}) in browser`}
-      title={tooltip}
-      className={`pr-chip pr-chip--${checkState}`}
-      onClick={handleActivate}
-      onContextMenu={(event) => {
-        if (!props.onOpenContextMenu) {
-          return;
-        }
-        event.preventDefault();
-        event.stopPropagation();
-        const rect = event.currentTarget.getBoundingClientRect();
-        props.onOpenContextMenu(pr, {
-          x: event.clientX,
-          y: event.clientY,
-          anchorTop: rect.top,
-        });
-      }}
-      onKeyDown={(event) => {
-        if (event.key === "Enter" || event.key === " ") {
-          handleActivate(event);
-        }
-      }}
-    >
-      <span className="pr-chip__dot" aria-hidden="true" />
-      <span className="pr-chip__label">{label}</span>
-    </span>
+    <>
+      <span
+        role="button"
+        tabIndex={0}
+        aria-label={`Open ${pr.org}/${pr.repo}#${pr.number} (${status}) in browser`}
+        className={`pr-chip pr-chip--${checkState}`}
+        data-pr-chip=""
+        onBlur={tooltipController.hide}
+        onClick={handleActivate}
+        onContextMenu={(event) => {
+          if (!props.onOpenContextMenu) {
+            return;
+          }
+          event.preventDefault();
+          event.stopPropagation();
+          const rect = event.currentTarget.getBoundingClientRect();
+          props.onOpenContextMenu(pr, {
+            x: event.clientX,
+            y: event.clientY,
+            anchorTop: rect.top,
+          });
+        }}
+        onFocus={(event) => tooltipController.show(event.currentTarget, tooltip)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            handleActivate(event);
+          }
+        }}
+        onMouseEnter={(event) => tooltipController.show(event.currentTarget, tooltip)}
+        onMouseLeave={tooltipController.hide}
+      >
+        <span className="pr-chip__dot" aria-hidden="true" />
+        <span className="pr-chip__label">{label}</span>
+      </span>
+      {tooltipController.tooltipNode}
+    </>
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
@@ -19,9 +19,11 @@ export function PrChip(props: PrChipProps) {
     : `#${pr.number}`;
   const identity = `${pr.org}/${pr.repo}#${pr.number}`;
   const title = pr.title?.trim();
+  const checkState = resolveCheckState(pr);
+  const status = prStatusLabel(pr);
   const tooltip = title
-    ? `${title}\n${identity} — ${stateTooltipLabel(pr.state)}`
-    : `${identity} — ${stateTooltipLabel(pr.state)}`;
+    ? `${title}\n${identity} — ${status}`
+    : `${identity} — ${status}`;
 
   // role="button" span (not a real <button>) so the chip is legal HTML
   // inside the row's main <button>. stopPropagation prevents the row's
@@ -38,9 +40,9 @@ export function PrChip(props: PrChipProps) {
     <span
       role="button"
       tabIndex={0}
-      aria-label={`Open ${pr.org}/${pr.repo}#${pr.number} (${pr.state}) in browser`}
+      aria-label={`Open ${pr.org}/${pr.repo}#${pr.number} (${status}) in browser`}
       title={tooltip}
-      className={`pr-chip pr-chip--${pr.state}`}
+      className={`pr-chip pr-chip--${checkState}`}
       onClick={handleActivate}
       onContextMenu={(event) => {
         if (!props.onOpenContextMenu) {
@@ -67,20 +69,50 @@ export function PrChip(props: PrChipProps) {
   );
 }
 
-function stateTooltipLabel(state: PrSummary["state"]): string {
+function prStatusLabel(pr: PrSummary): string {
+  const parts: string[] = [];
+  if (pr.lifecycleState === "merged") {
+    parts.push("merged");
+  } else if (pr.lifecycleState === "closed") {
+    parts.push("closed without merge");
+  } else if (pr.reviewState === "draft") {
+    parts.push("draft");
+  } else {
+    parts.push("ready for review");
+  }
+
+  if (pr.mergeState === "conflicting") {
+    parts.push("merge conflict");
+  }
+
+  parts.push(checkStateTooltipLabel(resolveCheckState(pr)));
+  return parts.join(" · ");
+}
+
+function resolveCheckState(pr: PrSummary): NonNullable<PrSummary["checkState"]> {
+  return pr.checkState ?? normalizeLegacyCheckState(pr.state);
+}
+
+function normalizeLegacyCheckState(state: PrSummary["state"]): NonNullable<PrSummary["checkState"]> {
+  if (
+    state === "passing"
+    || state === "failing"
+    || state === "pending"
+    || state === "unknown"
+  ) {
+    return state;
+  }
+  return "unknown";
+}
+
+function checkStateTooltipLabel(state: NonNullable<PrSummary["checkState"]>): string {
   switch (state) {
-    case "merged":
-      return "merged";
     case "passing":
-      return "all checks passing";
+      return "checks passing";
     case "failing":
       return "checks failing";
-    case "draft":
-      return "draft";
     case "pending":
       return "checks pending";
-    case "closed":
-      return "closed without merge";
     case "unknown":
       return "status unknown";
   }

--- a/apps/desktop/src/renderer/src/features/pr-status/__tests__/usePullRequestRefresh.test.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/__tests__/usePullRequestRefresh.test.tsx
@@ -37,9 +37,11 @@ function buildResponse(
   return {
     backend: "codex",
     threadId: "thread-1",
+    provider: "github.com",
     ghAvailable: true,
     prs: [
       {
+        provider: "github.com",
         number: 249,
         org: "pwrdrvr",
         repo: "PwrAgent",

--- a/apps/desktop/src/renderer/src/features/pr-status/__tests__/usePullRequestRefresh.test.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/__tests__/usePullRequestRefresh.test.tsx
@@ -71,6 +71,7 @@ describe("usePullRequestRefresh", () => {
       expect(refreshThreadPullRequests).toHaveBeenCalledWith({
         backend: "codex",
         threadId: "thread-1",
+        trigger: "scheduled",
         branch: "feat/pr-chip",
         directoryPaths: ["/repo"],
       });
@@ -201,6 +202,7 @@ describe("usePullRequestRefresh", () => {
     expect(refreshThreadPullRequests).toHaveBeenLastCalledWith({
       backend: "codex",
       threadId: "thread-1",
+      trigger: "scheduled",
       branch: "feat/next",
       directoryPaths: ["/repo"],
     });
@@ -227,7 +229,33 @@ describe("usePullRequestRefresh", () => {
       expect(refreshThreadPullRequests).toHaveBeenCalledWith({
         backend: "codex",
         threadId: "thread-1",
+        trigger: "scheduled",
         branch: "fix/new-pr",
+        directoryPaths: ["/repo"],
+      });
+    });
+  });
+
+  it("marks hover prefetches as user-triggered refreshes", async () => {
+    const refreshThreadPullRequests = vi.fn(async () => buildResponse({ prs: [] }));
+    const desktopApi = {
+      refreshThreadPullRequests,
+    } satisfies DesktopApi;
+
+    const { result } = renderHook(() =>
+      usePullRequestRefresh({
+        desktopApi,
+      }),
+    );
+
+    result.current.prefetch(buildThread());
+
+    await waitFor(() => {
+      expect(refreshThreadPullRequests).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        trigger: "user",
+        branch: "feat/pr-chip",
         directoryPaths: ["/repo"],
       });
     });

--- a/apps/desktop/src/renderer/src/features/pr-status/usePullRequestRefresh.ts
+++ b/apps/desktop/src/renderer/src/features/pr-status/usePullRequestRefresh.ts
@@ -159,6 +159,7 @@ function prSummariesEqual(
     const candidate = right[index];
     return (
       candidate?.number === pr.number &&
+      candidate.provider === pr.provider &&
       candidate.org === pr.org &&
       candidate.repo === pr.repo &&
       candidate.state === pr.state &&

--- a/apps/desktop/src/renderer/src/features/pr-status/usePullRequestRefresh.ts
+++ b/apps/desktop/src/renderer/src/features/pr-status/usePullRequestRefresh.ts
@@ -35,7 +35,10 @@ export function usePullRequestRefresh(params: {
   }, [onRefreshNavigation]);
 
   const refresh = useCallback(
-    (thread: NavigationThreadSummary): void => {
+    (
+      thread: NavigationThreadSummary,
+      trigger: "scheduled" | "user" = "scheduled",
+    ): void => {
       if (!desktopApi?.refreshThreadPullRequests) return;
       const branch = resolvePullRequestLookupBranch(thread);
       if (!branch) return;
@@ -45,6 +48,7 @@ export function usePullRequestRefresh(params: {
         .refreshThreadPullRequests({
           backend: thread.source,
           threadId: thread.id,
+          trigger,
           branch,
           directoryPaths,
         })
@@ -83,7 +87,7 @@ export function usePullRequestRefresh(params: {
       const currentSelected = selectedRef.current;
       if (!currentSelected) return;
       if (buildRefreshRequestKey(currentSelected) !== selectedRefreshKey) return;
-      refresh(currentSelected);
+      refresh(currentSelected, "scheduled");
     };
 
     refreshSelected();
@@ -96,7 +100,8 @@ export function usePullRequestRefresh(params: {
   }, [selectedRefreshKey, refresh]);
 
   // Hover prefetch: dedupe so a flood of mouseenter events for the same
-  // thread doesn't trigger a flood of gh subprocesses.
+  // thread doesn't trigger a flood of gh subprocesses. User-triggered
+  // prefetches intentionally use a shorter cooldown in main.
   const inflightKeysRef = useRef<Set<string>>(new Set());
   const prefetch = useCallback(
     (thread: NavigationThreadSummary): void => {
@@ -104,14 +109,15 @@ export function usePullRequestRefresh(params: {
       if (inflightKeysRef.current.has(key)) return;
       inflightKeysRef.current.add(key);
       try {
-        refresh(thread);
+        refresh(thread, "user");
       } finally {
-        // Allow another prefetch attempt after the typical 60s tick window.
+        // Allow deliberate leave/re-enter chip hovers to refresh more often
+        // than the scheduled 60s tick. Main still coalesces these per PR.
         // We don't wait for the IPC to resolve — main absorbs the duplicate
-        // call cost via the cached gh-version probe + terminal short-circuit.
+        // call cost via the registry and in-flight coalescing.
         window.setTimeout(() => {
           inflightKeysRef.current.delete(key);
-        }, SELECTED_REFRESH_INTERVAL_MS);
+        }, 10_000);
       }
     },
     [refresh],

--- a/apps/desktop/src/renderer/src/features/pr-status/usePullRequestRefresh.ts
+++ b/apps/desktop/src/renderer/src/features/pr-status/usePullRequestRefresh.ts
@@ -164,6 +164,10 @@ function prSummariesEqual(
       candidate.repo === pr.repo &&
       candidate.title === pr.title &&
       candidate.state === pr.state &&
+      candidate.checkState === pr.checkState &&
+      candidate.lifecycleState === pr.lifecycleState &&
+      candidate.reviewState === pr.reviewState &&
+      candidate.mergeState === pr.mergeState &&
       candidate.url === pr.url
     );
   });

--- a/apps/desktop/src/renderer/src/features/pr-status/usePullRequestRefresh.ts
+++ b/apps/desktop/src/renderer/src/features/pr-status/usePullRequestRefresh.ts
@@ -162,6 +162,7 @@ function prSummariesEqual(
       candidate.provider === pr.provider &&
       candidate.org === pr.org &&
       candidate.repo === pr.repo &&
+      candidate.title === pr.title &&
       candidate.state === pr.state &&
       candidate.url === pr.url
     );

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/LinkedProjectsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/LinkedProjectsPanel.tsx
@@ -92,8 +92,13 @@ export function LinkedProjectsPanel(props: LinkedProjectsPanelProps) {
               <li key={`${pr.provider}/${pr.org}/${pr.repo}#${pr.number}`} className="pr-panel-row">
                 <div className="pr-panel-row__main">
                   <PrChip pr={pr} showRepoPrefix={false} onOpen={openExternalUrl} />
-                  <span className="pr-panel-row__repo">
-                    {pr.provider}/{pr.org}/{pr.repo}
+                  <span className="pr-panel-row__details">
+                    {pr.title?.trim() ? (
+                      <span className="pr-panel-row__title">{pr.title.trim()}</span>
+                    ) : null}
+                    <span className="pr-panel-row__repo">
+                      {pr.provider}/{pr.org}/{pr.repo}
+                    </span>
                   </span>
                 </div>
               </li>

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/LinkedProjectsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/LinkedProjectsPanel.tsx
@@ -26,7 +26,6 @@ export function LinkedProjectsPanel(props: LinkedProjectsPanelProps) {
   const directories = props.thread.linkedDirectories;
   const prs = props.thread.prs ?? [];
   const branch = props.thread.gitBranch;
-  const multiRepo = new Set(prs.map((pr) => `${pr.org}/${pr.repo}`)).size > 1;
 
   return (
     <section className="context-panel__section">
@@ -90,8 +89,13 @@ export function LinkedProjectsPanel(props: LinkedProjectsPanelProps) {
           <h4 className="context-subheading">Linked pull requests</h4>
           <ul className="context-list pr-panel-list">
             {prs.map((pr) => (
-              <li key={`${pr.org}/${pr.repo}#${pr.number}`} className="pr-panel-row">
-                <PrChip pr={pr} showRepoPrefix={multiRepo} onOpen={openExternalUrl} />
+              <li key={`${pr.provider}/${pr.org}/${pr.repo}#${pr.number}`} className="pr-panel-row">
+                <div className="pr-panel-row__main">
+                  <PrChip pr={pr} showRepoPrefix={false} onOpen={openExternalUrl} />
+                  <span className="pr-panel-row__repo">
+                    {pr.provider}/{pr.org}/{pr.repo}
+                  </span>
+                </div>
               </li>
             ))}
           </ul>

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PullRequestsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PullRequestsPanel.tsx
@@ -54,11 +54,14 @@ function repositoryLabel(pr: PrSummary): string {
 }
 
 function statusLabel(pr: PrSummary): string {
+  const lifecycleState = resolveLifecycleState(pr);
   const parts: string[] = [];
-  if (pr.lifecycleState === "merged") {
+  if (lifecycleState === "merged") {
     parts.push("Merged");
-  } else if (pr.lifecycleState === "closed") {
+    return parts.join(" · ");
+  } else if (lifecycleState === "closed") {
     parts.push("Closed");
+    return parts.join(" · ");
   } else if (pr.reviewState === "draft") {
     parts.push("Draft");
   } else {
@@ -69,6 +72,16 @@ function statusLabel(pr: PrSummary): string {
   }
   parts.push(checkStateLabel(resolveCheckState(pr)));
   return parts.join(" · ");
+}
+
+function resolveLifecycleState(pr: PrSummary): NonNullable<PrSummary["lifecycleState"]> {
+  if (pr.lifecycleState) {
+    return pr.lifecycleState;
+  }
+  if (pr.state === "merged" || pr.state === "closed") {
+    return pr.state;
+  }
+  return "open";
 }
 
 function resolveCheckState(pr: PrSummary): NonNullable<PrSummary["checkState"]> {

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PullRequestsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PullRequestsPanel.tsx
@@ -25,7 +25,12 @@ export function PullRequestsPanel(props: PullRequestsPanelProps) {
             <li key={prKey(pr)} className="pr-panel-row">
               <div className="pr-panel-row__main">
                 <PrChip pr={pr} showRepoPrefix={false} onOpen={openExternalUrl} />
-                <span className="pr-panel-row__repo">{repositoryLabel(pr)}</span>
+                <span className="pr-panel-row__details">
+                  {pr.title?.trim() ? (
+                    <span className="pr-panel-row__title">{pr.title.trim()}</span>
+                  ) : null}
+                  <span className="pr-panel-row__repo">{repositoryLabel(pr)}</span>
+                </span>
               </div>
               <span className="pr-panel-row__state">{stateLabel(pr.state)}</span>
             </li>

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PullRequestsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PullRequestsPanel.tsx
@@ -32,7 +32,7 @@ export function PullRequestsPanel(props: PullRequestsPanelProps) {
                   <span className="pr-panel-row__repo">{repositoryLabel(pr)}</span>
                 </span>
               </div>
-              <span className="pr-panel-row__state">{stateLabel(pr.state)}</span>
+              <span className="pr-panel-row__state">{statusLabel(pr)}</span>
             </li>
           ))}
         </ul>
@@ -53,20 +53,45 @@ function repositoryLabel(pr: PrSummary): string {
   return `${pr.provider}/${pr.org}/${pr.repo}`;
 }
 
-function stateLabel(state: PrSummary["state"]): string {
+function statusLabel(pr: PrSummary): string {
+  const parts: string[] = [];
+  if (pr.lifecycleState === "merged") {
+    parts.push("Merged");
+  } else if (pr.lifecycleState === "closed") {
+    parts.push("Closed");
+  } else if (pr.reviewState === "draft") {
+    parts.push("Draft");
+  } else {
+    parts.push("Ready for review");
+  }
+  if (pr.mergeState === "conflicting") {
+    parts.push("Merge conflict");
+  }
+  parts.push(checkStateLabel(resolveCheckState(pr)));
+  return parts.join(" · ");
+}
+
+function resolveCheckState(pr: PrSummary): NonNullable<PrSummary["checkState"]> {
+  const state = pr.checkState ?? pr.state;
+  if (
+    state === "passing"
+    || state === "failing"
+    || state === "pending"
+    || state === "unknown"
+  ) {
+    return state;
+  }
+  return "unknown";
+}
+
+function checkStateLabel(state: NonNullable<PrSummary["checkState"]>): string {
   switch (state) {
-    case "merged":
-      return "Merged";
     case "passing":
       return "Checks passing";
     case "failing":
       return "Checks failing";
-    case "draft":
-      return "Draft";
     case "pending":
       return "Checks pending";
-    case "closed":
-      return "Closed";
     case "unknown":
       return "Status unknown";
   }

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PullRequestsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PullRequestsPanel.tsx
@@ -15,8 +15,6 @@ type PullRequestsPanelProps = {
  */
 export function PullRequestsPanel(props: PullRequestsPanelProps) {
   const prs = props.thread.prs ?? [];
-  const multiRepo =
-    new Set(prs.map((pr) => `${pr.org}/${pr.repo}`)).size > 1;
 
   return (
     <section className="context-panel__section">
@@ -25,7 +23,10 @@ export function PullRequestsPanel(props: PullRequestsPanelProps) {
         <ul className="context-list pr-panel-list">
           {prs.map((pr) => (
             <li key={prKey(pr)} className="pr-panel-row">
-              <PrChip pr={pr} showRepoPrefix={multiRepo} onOpen={openExternalUrl} />
+              <div className="pr-panel-row__main">
+                <PrChip pr={pr} showRepoPrefix={false} onOpen={openExternalUrl} />
+                <span className="pr-panel-row__repo">{repositoryLabel(pr)}</span>
+              </div>
               <span className="pr-panel-row__state">{stateLabel(pr.state)}</span>
             </li>
           ))}
@@ -40,7 +41,11 @@ export function PullRequestsPanel(props: PullRequestsPanelProps) {
 }
 
 function prKey(pr: PrSummary): string {
-  return `${pr.org}/${pr.repo}#${pr.number}`;
+  return `${pr.provider}/${pr.org}/${pr.repo}#${pr.number}`;
+}
+
+function repositoryLabel(pr: PrSummary): string {
+  return `${pr.provider}/${pr.org}/${pr.repo}`;
 }
 
 function stateLabel(state: PrSummary["state"]): string {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -3305,6 +3305,7 @@ describe("useThreadNavigation", () => {
       ],
       prs: [
         {
+          provider: "github.com",
           number: 123,
           org: "pwrdrvr",
           repo: "PwrAgent",

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -5,6 +5,7 @@ import type {
   NavigationLaunchpadDefaults,
   NavigationLaunchpadDraft,
   NavigationSnapshot,
+  PrSummary,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../desktop-api";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -4112,6 +4113,94 @@ describe("useThreadNavigation", () => {
     // renderer for transcript rendering.
     await waitFor(() => {
       expect(getNavigationSnapshot).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("applies pull request update notification payloads before unchanged refreshes", async () => {
+    const listeners = new Set<(event: any) => void>();
+    const initialPr: PrSummary = {
+      provider: "github.com",
+      number: 123,
+      org: "pwrdrvr",
+      repo: "PwrAgent",
+      state: "passing",
+      url: "https://github.com/pwrdrvr/PwrAgent/pull/123",
+    };
+    const updatedPr: PrSummary = {
+      ...initialPr,
+      title: "Preserve PR title updates",
+    };
+    const getNavigationSnapshot = vi
+      .fn()
+      .mockResolvedValueOnce({
+        backend: "all" as const,
+        fetchedAt: Date.now(),
+        unchanged: false,
+        inboxThreadKeys: ["codex:thread-1"],
+        threads: [
+          {
+            id: "thread-1",
+            title: "First thread",
+            titleSource: "explicit" as const,
+            source: "codex" as const,
+            linkedDirectories: [],
+            prs: [initialPr],
+            inbox: { inInbox: true, reason: "new-thread" as const },
+            updatedAt: 1_000,
+          },
+        ],
+        directories: [],
+        launchpadDefaults: {
+          backend: "codex" as const,
+          executionMode: "default" as const,
+        },
+      })
+      .mockResolvedValue({
+        backend: "all" as const,
+        fetchedAt: Date.now(),
+        unchanged: true,
+        inboxThreadKeys: ["codex:thread-1"],
+        threads: [],
+        directories: [],
+        launchpadDefaults: {
+          backend: "codex" as const,
+          executionMode: "default" as const,
+        },
+      });
+
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: (callback) => {
+        listeners.add(callback);
+        return () => {
+          listeners.delete(callback);
+        };
+      },
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.prs?.[0]?.title).toBeUndefined();
+    });
+
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "thread/pullRequests/updated",
+            params: {
+              threadId: "thread-1",
+              prs: [updatedPr],
+            },
+          },
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.prs).toEqual([updatedPr]);
     });
   });
 

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -2298,6 +2298,11 @@ export function useThreadNavigation(
         return;
       }
 
+      if (method === "thread/pullRequests/updated") {
+        scheduleRefresh();
+        return;
+      }
+
       if (method === "thread/name/updated") {
         const { threadId, threadName } = event.notification.params as {
           threadId: string;

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -15,6 +15,7 @@ import type {
   NavigationLaunchpadDraft,
   NavigationSnapshot,
   NavigationThreadSummary,
+  PrSummary,
   ThreadAgentMetadata,
   ThreadExecutionMode,
 } from "@pwragent/shared";
@@ -431,9 +432,15 @@ function prSummariesEqual(
     const candidate = rightPrs[index];
     return (
       candidate?.number === pr.number &&
+      candidate.provider === pr.provider &&
       candidate.org === pr.org &&
       candidate.repo === pr.repo &&
+      candidate.title === pr.title &&
       candidate.state === pr.state &&
+      candidate.checkState === pr.checkState &&
+      candidate.lifecycleState === pr.lifecycleState &&
+      candidate.reviewState === pr.reviewState &&
+      candidate.mergeState === pr.mergeState &&
       candidate.url === pr.url
     );
   });
@@ -1166,7 +1173,40 @@ function applyThreadNameUpdate(
         ...snapshot,
         threads,
       }
-      : snapshot;
+    : snapshot;
+}
+
+function applyThreadPullRequestsUpdate(
+  snapshot: NavigationSnapshot | undefined,
+  params: { backend: AppServerBackendKind; threadId: string; prs: PrSummary[] }
+): NavigationSnapshot | undefined {
+  if (!snapshot) {
+    return snapshot;
+  }
+
+  let changed = false;
+  const threads = snapshot.threads.map((thread) => {
+    if (thread.source !== params.backend || thread.id !== params.threadId) {
+      return thread;
+    }
+
+    if (prSummariesEqual(thread.prs, params.prs)) {
+      return thread;
+    }
+
+    changed = true;
+    return {
+      ...thread,
+      prs: params.prs,
+    };
+  });
+
+  return changed
+    ? {
+        ...snapshot,
+        threads,
+      }
+    : snapshot;
 }
 
 function applyThreadModelSettingsUpdate(
@@ -2299,6 +2339,18 @@ export function useThreadNavigation(
       }
 
       if (method === "thread/pullRequests/updated") {
+        const { threadId, prs } = event.notification.params as {
+          threadId: string;
+          prs: PrSummary[];
+        };
+        setState((current) => ({
+          ...current,
+          response: applyThreadPullRequestsUpdate(current.response, {
+            backend: event.backend,
+            threadId,
+            prs,
+          }),
+        }));
         scheduleRefresh();
         return;
       }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -10103,9 +10103,24 @@ textarea,
 
 .pr-panel-row {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 10px;
+}
+
+.pr-panel-row__main {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+}
+
+.pr-panel-row__repo {
+  min-width: 0;
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
 }
 
 .pr-panel-row__state {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -10111,8 +10111,25 @@ textarea,
 .pr-panel-row__main {
   display: flex;
   min-width: 0;
-  align-items: center;
+  align-items: flex-start;
   gap: 8px;
+}
+
+.pr-panel-row__details {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.pr-panel-row__title {
+  min-width: 0;
+  color: var(--text-primary);
+  font-size: 12px;
+  line-height: 1.25;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .pr-panel-row__repo {

--- a/packages/agent-core/src/__tests__/navigation-state.test.ts
+++ b/packages/agent-core/src/__tests__/navigation-state.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type {
   AppServerThreadSummary,
   AutomationThreadSummary,
+  PrSummary,
 } from "@pwragent/shared";
 
 import {
@@ -112,6 +113,61 @@ describe("navigation automation summaries", () => {
       buildNavigationSnapshotHash({
         backend: "codex",
         threads: [threadWithAutomation!],
+      }),
+    );
+  });
+
+  it("includes PR titles in the navigation snapshot hash", () => {
+    const prWithoutTitle: PrSummary = {
+      provider: "github.com",
+      number: 727,
+      org: "OpenAI",
+      repo: "codex",
+      state: "passing",
+      url: "https://github.com/OpenAI/codex/pull/727",
+    };
+    const prWithTitle: PrSummary = {
+      ...prWithoutTitle,
+      title: "Preserve PR titles",
+    };
+    const [threadWithoutTitle] = materializeNavigationThreads({
+      firstSnapshot: false,
+      overlayByThreadKey: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          prs: [prWithoutTitle],
+        },
+      },
+      previousKnownThreadKeys: ["codex:thread-1"],
+      threads: [buildThread()],
+    });
+    const [threadWithTitle] = materializeNavigationThreads({
+      firstSnapshot: false,
+      overlayByThreadKey: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          prs: [prWithTitle],
+        },
+      },
+      previousKnownThreadKeys: ["codex:thread-1"],
+      threads: [buildThread()],
+    });
+
+    expect(
+      buildNavigationSnapshotHash({
+        backend: "codex",
+        threads: [threadWithoutTitle!],
+      }),
+    ).not.toBe(
+      buildNavigationSnapshotHash({
+        backend: "codex",
+        threads: [threadWithTitle!],
       }),
     );
   });

--- a/packages/agent-core/src/domain/navigation-state.ts
+++ b/packages/agent-core/src/domain/navigation-state.ts
@@ -429,10 +429,16 @@ export function buildNavigationSnapshotHash(params: {
       // the next snapshot tick computes an identical hash, gets marked
       // unchanged, and the renderer keeps the stale empty thread.prs.
       prs: (thread.prs ?? []).map((pr) => ({
+        provider: pr.provider,
         number: pr.number,
         org: pr.org,
         repo: pr.repo,
+        title: pr.title ?? null,
         state: pr.state,
+        checkState: pr.checkState ?? null,
+        lifecycleState: pr.lifecycleState ?? null,
+        reviewState: pr.reviewState ?? null,
+        mergeState: pr.mergeState ?? null,
         url: pr.url,
       })),
       // Include the breadcrumb fields (parentTitle / ancestorTitle) in

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -98,7 +98,7 @@ export type NavigationThreadSummary = AppServerThreadSummary & {
   };
   /** Per-thread emoji reactions, ordered by insertion. */
   reactions?: string[];
-  /** GitHub pull requests detected for this thread's linked directories + branch. */
+  /** Pull requests known for this thread's linked directories + branch history. */
   prs?: PrSummary[];
   /** Codex environments discovered from the active thread workspace. */
   codexEnvironmentOptions?: CodexEnvironmentOption[];
@@ -857,10 +857,9 @@ export type ThreadOverlayState = {
   /** Persisted disclosure state for the parent's child section. */
   subthreadsCollapsed?: boolean;
   /**
-   * GitHub pull requests detected for this thread, persisted across
-   * restarts so chips appear instantly on relaunch and so we can
-   * short-circuit re-fetching once a PR reaches a terminal state
-   * (`merged` / `closed`).
+   * Pull requests known for this thread, persisted across restarts so chips
+   * appear instantly on relaunch. The list is append-only by PR identity for
+   * sidebar/history purposes; status refreshes replace matching entries.
    */
   prs?: PrSummary[];
   /** Wall-clock ms when `prs` was last refreshed via gh. */

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -221,6 +221,8 @@ export type PrSummary = {
   org: string;
   /** Repo name, e.g. "PwrAgent". */
   repo: string;
+  /** Last observed pull request title, when the provider returns one. */
+  title?: string;
   state: PrChipState;
   url: string;
 };

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -187,24 +187,18 @@ export type MessagingThreadBindingSummary = {
   activeAt?: number;
 };
 
-/**
- * Color states map directly to GitHub PR + check status:
- *   - merged   → state === MERGED              (purple chip)
- *   - failing  → any check FAILURE/CANCELLED/TIMED_OUT/STARTUP_FAILURE (red)
- *   - passing  → all checks SUCCESS, !isDraft  (green)
- *   - draft    → isDraft on an OPEN PR         (gray)
- *   - pending  → checks still running          (yellow)
- *   - closed   → CLOSED without merge          (gray)
- *   - unknown  → no checks reported yet, or shape we don't recognize (gray)
- */
+/** Check states drive the PR chip dot color only. */
 export type PrChipState =
-  | "merged"
   | "failing"
   | "passing"
-  | "draft"
   | "pending"
-  | "closed"
   | "unknown";
+
+export type PrLegacyChipState = "merged" | "draft" | "closed";
+
+export type PrLifecycleState = "open" | "merged" | "closed";
+export type PrReviewState = "draft" | "ready_for_review";
+export type PrMergeState = "mergeable" | "conflicting" | "unknown";
 
 export const DEFAULT_PULL_REQUEST_PROVIDER = "github.com";
 export type PullRequestProvider = string;
@@ -223,7 +217,15 @@ export type PrSummary = {
   repo: string;
   /** Last observed pull request title, when the provider returns one. */
   title?: string;
-  state: PrChipState;
+  /**
+   * Deprecated compatibility alias for `checkState`. New writers keep this
+   * check-only so review/lifecycle/mergeability never collide with checks.
+   */
+  state: PrChipState | PrLegacyChipState;
+  checkState?: PrChipState;
+  lifecycleState?: PrLifecycleState;
+  reviewState?: PrReviewState;
+  mergeState?: PrMergeState;
   url: string;
 };
 
@@ -748,8 +750,8 @@ export type RefreshThreadPullRequestsResponse = {
   /** True when the host doesn't have `gh` installed; degrade silently. */
   ghAvailable: boolean;
   /**
-   * True when main short-circuited the gh fetch because at least one
-   * PR for this thread is already in a terminal state (`merged` or
+   * True when main short-circuited the gh fetch because the lookup's
+   * known PRs are already in terminal lifecycle states (`merged` or
    * `closed`). Returned PRs are the persisted overlay snapshot.
    */
   shortCircuited?: boolean;

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -711,6 +711,12 @@ export type ReorderDirectoryPinsResponse = {
 export type RefreshThreadPullRequestsRequest = {
   backend?: AppServerBackendKind;
   threadId: ThreadIdentifier;
+  /**
+   * Refresh intent controls main-process coalescing. Scheduled polling is
+   * rate-limited globally and per PR; direct user interaction gets a much
+   * shorter per-PR cooldown and bypasses the global GitHub token bucket.
+   */
+  trigger?: "scheduled" | "user";
   /** Branch the renderer believes the thread is on. */
   branch: string;
   /**

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -206,7 +206,16 @@ export type PrChipState =
   | "closed"
   | "unknown";
 
+export const DEFAULT_PULL_REQUEST_PROVIDER = "github.com";
+export type PullRequestProvider = string;
+
 export type PrSummary = {
+  /**
+   * Forge host that owns the PR namespace, e.g. "github.com" or a future
+   * GitHub Enterprise/GitLab host. Owner/repo/number are only unique inside
+   * this provider.
+   */
+  provider: PullRequestProvider;
   number: number;
   /** Repo owner login, e.g. "pwrdrvr". */
   org: string;
@@ -711,6 +720,8 @@ export type ReorderDirectoryPinsResponse = {
 export type RefreshThreadPullRequestsRequest = {
   backend?: AppServerBackendKind;
   threadId: ThreadIdentifier;
+  /** Forge host for this lookup. Defaults to github.com while GitHub is the only provider. */
+  provider?: PullRequestProvider;
   /**
    * Refresh intent controls main-process coalescing. Scheduled polling is
    * rate-limited globally and per PR; direct user interaction gets a much
@@ -730,6 +741,7 @@ export type RefreshThreadPullRequestsRequest = {
 export type RefreshThreadPullRequestsResponse = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;
+  provider: PullRequestProvider;
   prs: PrSummary[];
   /** True when the host doesn't have `gh` installed; degrade silently. */
   ghAvailable: boolean;

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -1159,6 +1159,26 @@ export type AppServerNotification =
         collapsed: boolean;
       };
     }
+  | {
+      method: "thread/pullRequests/updated";
+      params: {
+        threadId: string;
+        prs: Array<{
+          number: number;
+          org: string;
+          repo: string;
+          state:
+            | "merged"
+            | "failing"
+            | "passing"
+            | "draft"
+            | "pending"
+            | "closed"
+            | "unknown";
+          url: string;
+        }>;
+      };
+    }
   /**
    * Directory pin lifecycle — mirror of `thread/pin/*` minus the
    * implicit per-backend dimension (directories are

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -1,4 +1,5 @@
 import type { AutomationRunOutputDecision } from "./automations";
+import type { PullRequestProvider } from "./navigation";
 
 export type AppServerBuiltinBackendKind = "codex" | "grok";
 export type AcpBackendId = `acp:${string}`;
@@ -1164,6 +1165,7 @@ export type AppServerNotification =
       params: {
         threadId: string;
         prs: Array<{
+          provider: PullRequestProvider;
           number: number;
           org: string;
           repo: string;

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -1,5 +1,5 @@
 import type { AutomationRunOutputDecision } from "./automations";
-import type { PullRequestProvider } from "./navigation";
+import type { PrSummary } from "./navigation";
 
 export type AppServerBuiltinBackendKind = "codex" | "grok";
 export type AcpBackendId = `acp:${string}`;
@@ -1164,21 +1164,7 @@ export type AppServerNotification =
       method: "thread/pullRequests/updated";
       params: {
         threadId: string;
-        prs: Array<{
-          provider: PullRequestProvider;
-          number: number;
-          org: string;
-          repo: string;
-          state:
-            | "merged"
-            | "failing"
-            | "passing"
-            | "draft"
-            | "pending"
-            | "closed"
-            | "unknown";
-          url: string;
-        }>;
+        prs: PrSummary[];
       };
     }
   /**


### PR DESCRIPTION
## Summary

- I fixed PR chips so every surface showing the same provider/org/repo#number reads from one canonical status registry instead of independent per-thread snapshots.
- I added a durable branch/directory lookup registry, so provider + branch + repo paths -> PRs requests return the current cached answer immediately, coalesce stampedes, obey the scheduled/user refresh gates, and notify subscribed thread surfaces when GitHub returns a changed result.
- I persisted both layers across restarts: known PR status lives in `pr_status_cache`, and branch lookup results, including empty results, live in `pr_lookup_cache` with fetch timestamps.
- I made the PR protocol and cache schema provider-aware now (`github.com` today, future forge hosts later), so later GitLab/GHES support will not collide on identical owner/repo/number values.

## Verification

- I ran `pnpm test apps/desktop/src/main/__tests__/app-server-ipc.test.ts`.
- I ran `pnpm test apps/desktop/src/main/__tests__/overlay-store-prs.test.ts apps/desktop/src/main/__tests__/state-db.test.ts`.
- I ran `pnpm test apps/desktop/src/renderer/src/features/pr-status/__tests__/usePullRequestRefresh.test.tsx`.
- I ran `pnpm test apps/desktop/src/main/__tests__/app-server-ipc.test.ts apps/desktop/src/main/__tests__/overlay-store-prs.test.ts apps/desktop/src/main/__tests__/state-db.test.ts apps/desktop/src/main/__tests__/github-pr-fetcher.test.ts apps/desktop/src/renderer/src/features/pr-status/__tests__/usePullRequestRefresh.test.tsx apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx`.
- I ran `pnpm --filter @pwragent/desktop typecheck`.
- I ran `pnpm lint:boundaries`.

## Notes

- This PR intentionally changes the state DB user version from `12` to `15` with additive `pr_status_cache` and `pr_lookup_cache` tables plus provider columns.
- I did not add visual evidence because the change is background refresh/cache behavior rather than a new UI surface.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
