### PR TITLE
feat(federation): complete remote instance federation

### DIFF
--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -404,6 +404,7 @@ MIT
 - w3c-keyname@2.2.8 | https://github.com/marijnh/w3c-keyname
 - web-namespaces@2.0.1 | wooorm/web-namespaces
 - whatwg-url@5.0.0 | jsdom/whatwg-url
+- ws@8.20.1 | https://github.com/websockets/ws
 - zod@3.25.76 | https://github.com/colinhacks/zod
 - zod@4.3.6 | https://github.com/colinhacks/zod
 - zwitch@2.0.4 | wooorm/zwitch
@@ -6643,6 +6644,35 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+ws@8.20.1 (MIT)
+---------------
+
+Applies to:
+- ws@8.20.1 (MIT)
+
+Representative file: ws@8.20.1/LICENSE
+
+Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
+Copyright (c) 2013 Arnout Kazemier and contributors
+Copyright (c) 2016 Luigi Pinca and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 zod@3.25.76 (MIT)
 -----------------

--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -404,7 +404,7 @@ MIT
 - w3c-keyname@2.2.8 | https://github.com/marijnh/w3c-keyname
 - web-namespaces@2.0.1 | wooorm/web-namespaces
 - whatwg-url@5.0.0 | jsdom/whatwg-url
-- ws@8.20.1 | https://github.com/websockets/ws
+- ws@8.21.0 | https://github.com/websockets/ws
 - zod@3.25.76 | https://github.com/colinhacks/zod
 - zod@4.3.6 | https://github.com/colinhacks/zod
 - zwitch@2.0.4 | wooorm/zwitch
@@ -6645,13 +6645,13 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
-ws@8.20.1 (MIT)
+ws@8.21.0 (MIT)
 ---------------
 
 Applies to:
-- ws@8.20.1 (MIT)
+- ws@8.21.0 (MIT)
 
-Representative file: ws@8.20.1/LICENSE
+Representative file: ws@8.21.0/LICENSE
 
 Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
 Copyright (c) 2013 Arnout Kazemier and contributors

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -92,7 +92,7 @@
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
-    "ws": "8.20.1"
+    "ws": "8.21.0"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.3",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -91,7 +91,8 @@
     "rehype-katex": "^7.0.1",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
-    "remark-math": "^6.0.0"
+    "remark-math": "^6.0.0",
+    "ws": "8.20.1"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.3",
@@ -102,6 +103,7 @@
     "@types/better-sqlite3": "^7.6.13",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@types/ws": "8.18.1",
     "@vitejs/plugin-react": "^5.2.0",
     "axe-core": "^4.11.4",
     "electron": "^41.10.3",

--- a/apps/desktop/src/main/__tests__/agent-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-ipc.test.ts
@@ -3,11 +3,13 @@ import type {
   AgentEvent,
   CancelThreadExecutionModeQueueRequest,
   CompactThreadRequest,
+  ForkThreadRequest,
   InterruptTurnRequest,
   ListBackendsRequest,
   MaterializeDirectoryLaunchpadRequest,
   QueueThreadExecutionModeRequest,
   RunCodexEnvironmentActionRequest,
+  StopCodexEnvironmentActionRequest,
   SetAcpSessionRuntimeOptionRequest,
   SetCodexThreadEnvironmentRequest,
   SetThreadExecutionModeRequest,
@@ -92,11 +94,29 @@ const registry = {
 
 const federationMock = vi.hoisted(() => {
   const remoteBackend = {
+    startThread: vi.fn(async (request: StartThreadRequest) => ({
+      backend: request.backend,
+      threadId: "remote-thread-1",
+      executionMode: "default" as const,
+    })),
+    forkThread: vi.fn(async (request: ForkThreadRequest) => ({
+      backend: request.backend,
+      sourceThreadId: request.sourceThreadId,
+      threadId: "remote-fork-1",
+      executionMode: "default" as const,
+      workMode: "local" as const,
+    })),
     startTurn: vi.fn(async (request: StartTurnRequest) => ({
       backend: request.backend,
       threadId: request.threadId,
       turnId: "remote-turn-1",
       queueStatus: "started" as const,
+    })),
+    startReview: vi.fn(async (request: StartReviewRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      reviewThreadId: request.threadId,
+      turnId: "remote-review-1",
     })),
     compactThread: vi.fn(async (request: CompactThreadRequest) => ({
       backend: request.backend,
@@ -155,6 +175,17 @@ const federationMock = vi.hoisted(() => {
         },
       }),
     ),
+    stopCodexEnvironmentAction: vi.fn(
+      async (request: StopCodexEnvironmentActionRequest) => ({
+        backend: request.backend,
+        threadId: request.threadId,
+        codexEnvironmentRuntime: {
+          environmentId: "node",
+          environmentName: "Node",
+          executionTarget: "local" as const,
+        },
+      }),
+    ),
     setCodexThreadEnvironment: vi.fn(
       async (request: SetCodexThreadEnvironmentRequest) => ({
         backend: request.backend,
@@ -166,6 +197,14 @@ const federationMock = vi.hoisted(() => {
               executionTarget: "local" as const,
             }
           : undefined,
+      }),
+    ),
+    materializeDirectoryLaunchpad: vi.fn(
+      async (request: MaterializeDirectoryLaunchpadRequest) => ({
+        backend: "codex" as const,
+        threadId: `remote:${request.directoryKey}`,
+        executionMode: "default" as const,
+        workMode: "local" as const,
       }),
     ),
     submitServerRequest: vi.fn(async (request: SubmitServerRequestRequest) => ({
@@ -180,6 +219,7 @@ const federationMock = vi.hoisted(() => {
     runtime: {
       remoteBackend: vi.fn(() => remoteBackend),
       setAgentEventPublisher: vi.fn(),
+      setEnvironmentSetupProgressPublisher: vi.fn(),
     },
   };
 });
@@ -242,6 +282,7 @@ describe("agent ipc", () => {
     registry.materializeDirectoryLaunchpad.mockClear();
     federationMock.runtime.remoteBackend.mockClear();
     federationMock.runtime.setAgentEventPublisher.mockClear();
+    federationMock.runtime.setEnvironmentSetupProgressPublisher.mockClear();
     for (const method of Object.values(federationMock.remoteBackend)) {
       method.mockClear();
     }
@@ -255,14 +296,19 @@ describe("agent ipc", () => {
     const {
       AGENT_CANCEL_THREAD_EXECUTION_MODE_QUEUE_CHANNEL,
       AGENT_COMPACT_THREAD_CHANNEL,
+      AGENT_FORK_THREAD_CHANNEL,
       AGENT_INTERRUPT_TURN_CHANNEL,
+      AGENT_MATERIALIZE_DIRECTORY_LAUNCHPAD_CHANNEL,
       AGENT_QUEUE_THREAD_EXECUTION_MODE_CHANNEL,
       AGENT_RUN_CODEX_ENVIRONMENT_ACTION_CHANNEL,
+      AGENT_STOP_CODEX_ENVIRONMENT_ACTION_CHANNEL,
       AGENT_SET_ACP_SESSION_RUNTIME_OPTION_CHANNEL,
       AGENT_SET_CODEX_THREAD_ENVIRONMENT_CHANNEL,
       AGENT_SET_THREAD_EXECUTION_MODE_CHANNEL,
       AGENT_SET_THREAD_MODEL_SETTINGS_CHANNEL,
       AGENT_START_TURN_CHANNEL,
+      AGENT_START_REVIEW_CHANNEL,
+      AGENT_START_THREAD_CHANNEL,
       AGENT_STEER_TURN_CHANNEL,
       AGENT_SUBMIT_SERVER_REQUEST_CHANNEL,
     } = await import("../../shared/ipc");
@@ -273,11 +319,27 @@ describe("agent ipc", () => {
 
     registerAgentIpcHandlers();
 
+    await handlers.get(AGENT_START_THREAD_CHANNEL)?.({}, {
+      backend: "codex",
+      federationTarget,
+      cwd: "/repo/app",
+    });
+    await handlers.get(AGENT_FORK_THREAD_CHANNEL)?.({}, {
+      backend: "codex",
+      federationTarget,
+      sourceThreadId: "thread-1",
+    });
     await handlers.get(AGENT_START_TURN_CHANNEL)?.({}, {
       backend: "codex",
       federationTarget,
       threadId: "thread-1",
       input: [{ type: "text", text: "Ship it" }],
+    });
+    await handlers.get(AGENT_START_REVIEW_CHANNEL)?.({}, {
+      backend: "codex",
+      federationTarget,
+      threadId: "thread-1",
+      target: { type: "uncommittedChanges" },
     });
     await handlers.get(AGENT_COMPACT_THREAD_CHANNEL)?.({}, {
       backend: "codex",
@@ -335,6 +397,13 @@ describe("agent ipc", () => {
       actionId: "setup",
       cwd: "/repo/app",
     });
+    await handlers.get(AGENT_STOP_CODEX_ENVIRONMENT_ACTION_CHANNEL)?.({}, {
+      backend: "codex",
+      federationTarget,
+      threadId: "thread-1",
+      runId: "run-1",
+      mode: "stop",
+    });
     await handlers.get(AGENT_SET_CODEX_THREAD_ENVIRONMENT_CHANNEL)?.({}, {
       backend: "codex",
       federationTarget,
@@ -350,12 +419,29 @@ describe("agent ipc", () => {
       requestId: "approval-1",
       response: { decision: "approve" },
     });
+    await handlers.get(AGENT_MATERIALIZE_DIRECTORY_LAUNCHPAD_CHANNEL)?.({}, {
+      directoryKey: "directory:/repo/app",
+      federationTarget,
+    });
 
     expect(federationMock.runtime.remoteBackend).toHaveBeenCalledWith(federationTarget);
+    expect(federationMock.remoteBackend.startThread).toHaveBeenCalledWith({
+      backend: "codex",
+      cwd: "/repo/app",
+    });
+    expect(federationMock.remoteBackend.forkThread).toHaveBeenCalledWith({
+      backend: "codex",
+      sourceThreadId: "thread-1",
+    });
     expect(federationMock.remoteBackend.startTurn).toHaveBeenCalledWith({
       backend: "codex",
       threadId: "thread-1",
       input: [{ type: "text", text: "Ship it" }],
+    });
+    expect(federationMock.remoteBackend.startReview).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      target: { type: "uncommittedChanges" },
     });
     expect(federationMock.remoteBackend.compactThread).toHaveBeenCalledWith({
       backend: "codex",
@@ -406,6 +492,12 @@ describe("agent ipc", () => {
       actionId: "setup",
       cwd: "/repo/app",
     });
+    expect(federationMock.remoteBackend.stopCodexEnvironmentAction).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      runId: "run-1",
+      mode: "stop",
+    });
     expect(federationMock.remoteBackend.setCodexThreadEnvironment).toHaveBeenCalledWith({
       backend: "codex",
       threadId: "thread-1",
@@ -418,6 +510,11 @@ describe("agent ipc", () => {
       turnId: "turn-1",
       requestId: "approval-1",
       response: { decision: "approve" },
+    });
+    expect(
+      federationMock.remoteBackend.materializeDirectoryLaunchpad,
+    ).toHaveBeenCalledWith({
+      directoryKey: "directory:/repo/app",
     });
 
     disposeAgentIpcHandlers();

--- a/apps/desktop/src/main/__tests__/agent-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-ipc.test.ts
@@ -100,6 +100,7 @@ const registry = {
 
 const federationMock = vi.hoisted(() => {
   const remoteBackend = {
+    listBackends: vi.fn(async () => ({ fetchedAt: 1, backends: [] })),
     startThread: vi.fn(async (request: StartThreadRequest) => ({
       backend: request.backend,
       threadId: "remote-thread-1",
@@ -537,6 +538,32 @@ describe("agent ipc", () => {
       directoryKey: "directory:/repo/app",
     });
 
+    disposeAgentIpcHandlers();
+  });
+
+  it("loads backend summaries from the selected federation peer", async () => {
+    const { registerAgentIpcHandlers, disposeAgentIpcHandlers } = await import(
+      "../ipc/agent-ipc"
+    );
+    const { BACKEND_LIST_CHANNEL } = await import("../../shared/ipc");
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "client_one",
+    };
+    registerAgentIpcHandlers();
+
+    await handlers.get(BACKEND_LIST_CHANNEL)?.({}, {
+      includeUnavailable: true,
+      federationTarget,
+    });
+
+    expect(federationMock.runtime.remoteBackend).toHaveBeenCalledWith(
+      federationTarget,
+    );
+    expect(federationMock.remoteBackend.listBackends).toHaveBeenCalledWith({
+      includeUnavailable: true,
+    });
+    expect(registry.listBackends).not.toHaveBeenCalled();
     disposeAgentIpcHandlers();
   });
 

--- a/apps/desktop/src/main/__tests__/agent-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-ipc.test.ts
@@ -20,6 +20,7 @@ import type {
   StartTurnRequest,
   SteerTurnRequest,
   SubmitServerRequestRequest,
+  TrustCodexProjectRequest,
 } from "@pwragent/shared";
 
 const handlers = new Map<string, (...args: unknown[]) => Promise<unknown>>();
@@ -90,6 +91,11 @@ const registry = {
       turnId: "turn-2",
     }),
   ),
+  trustCodexProject: vi.fn(async (request: TrustCodexProjectRequest) => ({
+    ...request,
+    trusted: true,
+  })),
+  getLatestCodexConfigWarning: vi.fn(() => ({})),
 };
 
 const federationMock = vi.hoisted(() => {
@@ -213,6 +219,10 @@ const federationMock = vi.hoisted(() => {
       turnId: request.turnId,
       requestId: request.requestId,
     })),
+    trustCodexProject: vi.fn(async (request: TrustCodexProjectRequest) => ({
+      ...request,
+      trusted: true,
+    })),
   };
   return {
     remoteBackend,
@@ -311,6 +321,7 @@ describe("agent ipc", () => {
       AGENT_START_THREAD_CHANNEL,
       AGENT_STEER_TURN_CHANNEL,
       AGENT_SUBMIT_SERVER_REQUEST_CHANNEL,
+      AGENT_TRUST_CODEX_PROJECT_CHANNEL,
     } = await import("../../shared/ipc");
     const federationTarget = {
       scope: "remote" as const,
@@ -323,6 +334,11 @@ describe("agent ipc", () => {
       backend: "codex",
       federationTarget,
       cwd: "/repo/app",
+    });
+    await handlers.get(AGENT_TRUST_CODEX_PROJECT_CHANNEL)?.({}, {
+      federationTarget,
+      projectPath: "/repo/app",
+      configPath: "/remote/.codex/config.toml",
     });
     await handlers.get(AGENT_FORK_THREAD_CHANNEL)?.({}, {
       backend: "codex",
@@ -510,6 +526,10 @@ describe("agent ipc", () => {
       turnId: "turn-1",
       requestId: "approval-1",
       response: { decision: "approve" },
+    });
+    expect(federationMock.remoteBackend.trustCodexProject).toHaveBeenCalledWith({
+      projectPath: "/repo/app",
+      configPath: "/remote/.codex/config.toml",
     });
     expect(
       federationMock.remoteBackend.materializeDirectoryLaunchpad,

--- a/apps/desktop/src/main/__tests__/agent-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-ipc.test.ts
@@ -1,14 +1,23 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   AgentEvent,
+  CancelThreadExecutionModeQueueRequest,
+  CompactThreadRequest,
   InterruptTurnRequest,
   ListBackendsRequest,
   MaterializeDirectoryLaunchpadRequest,
+  QueueThreadExecutionModeRequest,
+  RunCodexEnvironmentActionRequest,
+  SetAcpSessionRuntimeOptionRequest,
+  SetCodexThreadEnvironmentRequest,
+  SetThreadExecutionModeRequest,
+  SetThreadModelSettingsRequest,
   StopSubAgentRequest,
   StartReviewRequest,
   StartThreadRequest,
   StartTurnRequest,
   SteerTurnRequest,
+  SubmitServerRequestRequest,
 } from "@pwragent/shared";
 
 const handlers = new Map<string, (...args: unknown[]) => Promise<unknown>>();
@@ -81,6 +90,100 @@ const registry = {
   ),
 };
 
+const federationMock = vi.hoisted(() => {
+  const remoteBackend = {
+    startTurn: vi.fn(async (request: StartTurnRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      turnId: "remote-turn-1",
+      queueStatus: "started" as const,
+    })),
+    compactThread: vi.fn(async (request: CompactThreadRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      turnId: "remote-compact-1",
+    })),
+    interruptTurn: vi.fn(async (request: InterruptTurnRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      turnId: request.turnId,
+    })),
+    steerTurn: vi.fn(async (request: SteerTurnRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      turnId: request.expectedTurnId,
+    })),
+    setThreadExecutionMode: vi.fn(
+      async (request: SetThreadExecutionModeRequest) => ({
+        backend: request.backend,
+        threadId: request.threadId,
+        executionMode: request.executionMode,
+      }),
+    ),
+    queueThreadExecutionMode: vi.fn(
+      async (request: QueueThreadExecutionModeRequest) => ({
+        backend: request.backend,
+        threadId: request.threadId,
+        queuedExecutionMode: request.executionMode,
+        queuedAt: 1_000,
+      }),
+    ),
+    cancelThreadExecutionModeQueue: vi.fn(
+      async (request: CancelThreadExecutionModeQueueRequest) => ({
+        backend: request.backend,
+        threadId: request.threadId,
+        executionMode: "default" as const,
+      }),
+    ),
+    setAcpSessionRuntimeOption: vi.fn(
+      async (request: SetAcpSessionRuntimeOptionRequest) => ({
+        backend: request.backend,
+        threadId: request.threadId,
+      }),
+    ),
+    setThreadModelSettings: vi.fn(
+      async (request: SetThreadModelSettingsRequest) => request,
+    ),
+    runCodexEnvironmentAction: vi.fn(
+      async (request: RunCodexEnvironmentActionRequest) => ({
+        backend: request.backend,
+        threadId: request.threadId,
+        codexEnvironmentRuntime: {
+          environmentId: "node",
+          environmentName: "Node",
+          executionTarget: "local" as const,
+        },
+      }),
+    ),
+    setCodexThreadEnvironment: vi.fn(
+      async (request: SetCodexThreadEnvironmentRequest) => ({
+        backend: request.backend,
+        threadId: request.threadId,
+        codexEnvironmentRuntime: request.environmentId
+          ? {
+              environmentId: request.environmentId,
+              environmentName: request.environmentId,
+              executionTarget: "local" as const,
+            }
+          : undefined,
+      }),
+    ),
+    submitServerRequest: vi.fn(async (request: SubmitServerRequestRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      turnId: request.turnId,
+      requestId: request.requestId,
+    })),
+  };
+  return {
+    remoteBackend,
+    runtime: {
+      remoteBackend: vi.fn(() => remoteBackend),
+      setAgentEventPublisher: vi.fn(),
+    },
+  };
+});
+
 vi.mock("electron", () => ({
   BrowserWindow: {
     getAllWindows: () => [
@@ -118,6 +221,10 @@ vi.mock("../app-server/backend-registry", () => ({
   getDesktopBackendRegistry: () => registry,
 }));
 
+vi.mock("../federation/federation-runtime", () => ({
+  getDesktopFederationRuntime: () => federationMock.runtime,
+}));
+
 describe("agent ipc", () => {
   beforeEach(() => {
     handlers.clear();
@@ -133,7 +240,187 @@ describe("agent ipc", () => {
     registry.stopSubAgent.mockClear();
     registry.steerTurn.mockClear();
     registry.materializeDirectoryLaunchpad.mockClear();
+    federationMock.runtime.remoteBackend.mockClear();
+    federationMock.runtime.setAgentEventPublisher.mockClear();
+    for (const method of Object.values(federationMock.remoteBackend)) {
+      method.mockClear();
+    }
     registryListener = undefined;
+  });
+
+  it("routes remote thread controls through federation without leaking the target", async () => {
+    const { registerAgentIpcHandlers, disposeAgentIpcHandlers } = await import(
+      "../ipc/agent-ipc"
+    );
+    const {
+      AGENT_CANCEL_THREAD_EXECUTION_MODE_QUEUE_CHANNEL,
+      AGENT_COMPACT_THREAD_CHANNEL,
+      AGENT_INTERRUPT_TURN_CHANNEL,
+      AGENT_QUEUE_THREAD_EXECUTION_MODE_CHANNEL,
+      AGENT_RUN_CODEX_ENVIRONMENT_ACTION_CHANNEL,
+      AGENT_SET_ACP_SESSION_RUNTIME_OPTION_CHANNEL,
+      AGENT_SET_CODEX_THREAD_ENVIRONMENT_CHANNEL,
+      AGENT_SET_THREAD_EXECUTION_MODE_CHANNEL,
+      AGENT_SET_THREAD_MODEL_SETTINGS_CHANNEL,
+      AGENT_START_TURN_CHANNEL,
+      AGENT_STEER_TURN_CHANNEL,
+      AGENT_SUBMIT_SERVER_REQUEST_CHANNEL,
+    } = await import("../../shared/ipc");
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "client_one",
+    };
+
+    registerAgentIpcHandlers();
+
+    await handlers.get(AGENT_START_TURN_CHANNEL)?.({}, {
+      backend: "codex",
+      federationTarget,
+      threadId: "thread-1",
+      input: [{ type: "text", text: "Ship it" }],
+    });
+    await handlers.get(AGENT_COMPACT_THREAD_CHANNEL)?.({}, {
+      backend: "codex",
+      federationTarget,
+      threadId: "thread-1",
+    });
+    await handlers.get(AGENT_INTERRUPT_TURN_CHANNEL)?.({}, {
+      backend: "codex",
+      federationTarget,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await handlers.get(AGENT_STEER_TURN_CHANNEL)?.({}, {
+      backend: "codex",
+      federationTarget,
+      threadId: "thread-1",
+      expectedTurnId: "turn-1",
+      input: [{ type: "text", text: "Actually do this" }],
+    });
+    await handlers.get(AGENT_SET_THREAD_EXECUTION_MODE_CHANNEL)?.({}, {
+      backend: "codex",
+      federationTarget,
+      threadId: "thread-1",
+      executionMode: "plan",
+    });
+    await handlers.get(AGENT_QUEUE_THREAD_EXECUTION_MODE_CHANNEL)?.({}, {
+      backend: "codex",
+      federationTarget,
+      threadId: "thread-1",
+      executionMode: "default",
+    });
+    await handlers.get(AGENT_CANCEL_THREAD_EXECUTION_MODE_QUEUE_CHANNEL)?.({}, {
+      backend: "codex",
+      federationTarget,
+      threadId: "thread-1",
+    });
+    await handlers.get(AGENT_SET_ACP_SESSION_RUNTIME_OPTION_CHANNEL)?.({}, {
+      backend: "acp:gemini",
+      federationTarget,
+      threadId: "thread-1",
+      source: "model",
+      optionId: "model",
+      value: "gemini-pro",
+    });
+    await handlers.get(AGENT_SET_THREAD_MODEL_SETTINGS_CHANNEL)?.({}, {
+      backend: "codex",
+      federationTarget,
+      threadId: "thread-1",
+      model: "gpt-5-codex",
+    });
+    await handlers.get(AGENT_RUN_CODEX_ENVIRONMENT_ACTION_CHANNEL)?.({}, {
+      backend: "codex",
+      federationTarget,
+      threadId: "thread-1",
+      actionId: "setup",
+      cwd: "/repo/app",
+    });
+    await handlers.get(AGENT_SET_CODEX_THREAD_ENVIRONMENT_CHANNEL)?.({}, {
+      backend: "codex",
+      federationTarget,
+      threadId: "thread-1",
+      environmentId: "node",
+      actionId: "setup",
+    });
+    await handlers.get(AGENT_SUBMIT_SERVER_REQUEST_CHANNEL)?.({}, {
+      backend: "codex",
+      federationTarget,
+      threadId: "thread-1",
+      turnId: "turn-1",
+      requestId: "approval-1",
+      response: { decision: "approve" },
+    });
+
+    expect(federationMock.runtime.remoteBackend).toHaveBeenCalledWith(federationTarget);
+    expect(federationMock.remoteBackend.startTurn).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      input: [{ type: "text", text: "Ship it" }],
+    });
+    expect(federationMock.remoteBackend.compactThread).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(federationMock.remoteBackend.interruptTurn).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    expect(federationMock.remoteBackend.steerTurn).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      expectedTurnId: "turn-1",
+      input: [{ type: "text", text: "Actually do this" }],
+    });
+    expect(federationMock.remoteBackend.setThreadExecutionMode).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      executionMode: "plan",
+    });
+    expect(federationMock.remoteBackend.queueThreadExecutionMode).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      executionMode: "default",
+    });
+    expect(
+      federationMock.remoteBackend.cancelThreadExecutionModeQueue,
+    ).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(federationMock.remoteBackend.setAcpSessionRuntimeOption).toHaveBeenCalledWith({
+      backend: "acp:gemini",
+      threadId: "thread-1",
+      source: "model",
+      optionId: "model",
+      value: "gemini-pro",
+    });
+    expect(federationMock.remoteBackend.setThreadModelSettings).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      model: "gpt-5-codex",
+    });
+    expect(federationMock.remoteBackend.runCodexEnvironmentAction).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      actionId: "setup",
+      cwd: "/repo/app",
+    });
+    expect(federationMock.remoteBackend.setCodexThreadEnvironment).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      environmentId: "node",
+      actionId: "setup",
+    });
+    expect(federationMock.remoteBackend.submitServerRequest).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      turnId: "turn-1",
+      requestId: "approval-1",
+      response: { decision: "approve" },
+    });
+
+    disposeAgentIpcHandlers();
   });
 
   it("registers backend and agent handlers and broadcasts backend-tagged events", async () => {

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -30,6 +30,12 @@ const backendRegistryLifecycle = vi.hoisted(() => ({
 }));
 const federationMock = vi.hoisted(() => {
   const remoteBackend = {
+    archiveThread: vi.fn(async (request: ArchiveThreadRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      archivedAt: 6_000,
+      cleanup: [],
+    })),
     renameThread: vi.fn(async (request: RenameThreadRequest) => ({
       backend: request.backend,
       threadId: request.threadId,
@@ -751,6 +757,7 @@ describe("app server ipc", () => {
     handoffThreadWorkspace.mockClear();
     renameThread.mockClear();
     federationMock.remoteBackend.renameThread.mockClear();
+    federationMock.remoteBackend.archiveThread.mockClear();
     federationMock.runtime.remoteBackend.mockClear();
     listThreads.mockClear();
     readThread.mockClear();
@@ -1990,6 +1997,37 @@ describe("app server ipc", () => {
       backend: "codex",
       threadId: "thread-1",
       archivedAt: 3000,
+      cleanup: [],
+    });
+  });
+
+  it("archives remote threads on the selected federation peer", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { APP_SERVER_ARCHIVE_THREAD_CHANNEL } = await import("../../shared/ipc");
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "remote-instance",
+    };
+    registerAppServerIpcHandlers();
+
+    const response = await handlers.get(APP_SERVER_ARCHIVE_THREAD_CHANNEL)?.({}, {
+      backend: "codex",
+      federationTarget,
+      threadId: "thread-remote",
+    } satisfies ArchiveThreadRequest);
+
+    expect(federationMock.runtime.remoteBackend).toHaveBeenCalledWith(
+      federationTarget,
+    );
+    expect(federationMock.remoteBackend.archiveThread).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-remote",
+    });
+    expect(archiveThread).not.toHaveBeenCalled();
+    expect(response).toEqual({
+      backend: "codex",
+      threadId: "thread-remote",
+      archivedAt: 6_000,
       cleanup: [],
     });
   });

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -28,6 +28,21 @@ const backendRegistryLifecycle = vi.hoisted(() => ({
   existing: true,
   get: vi.fn(),
 }));
+const federationMock = vi.hoisted(() => {
+  const remoteBackend = {
+    renameThread: vi.fn(async (request: RenameThreadRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      renamedAt: 6_000,
+    })),
+  };
+  return {
+    remoteBackend,
+    runtime: {
+      remoteBackend: vi.fn(() => remoteBackend),
+    },
+  };
+});
 
 const prAutoDispatchBudgetStatusSend = vi.hoisted(() => vi.fn());
 
@@ -686,6 +701,10 @@ vi.mock("../app-server/backend-registry", () => {
   };
 });
 
+vi.mock("../federation/federation-runtime", () => ({
+  getDesktopFederationRuntime: () => federationMock.runtime,
+}));
+
 vi.mock("../pr-status/github-pr-fetcher", () => ({
   GithubPrFetcher: vi.fn(function GithubPrFetcher() {
     return {
@@ -731,6 +750,8 @@ describe("app server ipc", () => {
     restoreWorktree.mockClear();
     handoffThreadWorkspace.mockClear();
     renameThread.mockClear();
+    federationMock.remoteBackend.renameThread.mockClear();
+    federationMock.runtime.remoteBackend.mockClear();
     listThreads.mockClear();
     readThread.mockClear();
     getThreadTranscriptImageRoots.mockClear();
@@ -2117,6 +2138,39 @@ describe("app server ipc", () => {
       backend: "grok",
       threadId: "thread-1",
       renamedAt: 3000,
+    });
+  });
+
+  it("renames remote threads on the selected federation peer", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { APP_SERVER_RENAME_THREAD_CHANNEL } = await import("../../shared/ipc");
+
+    registerAppServerIpcHandlers();
+
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "remote-instance",
+    };
+    const response = await handlers.get(APP_SERVER_RENAME_THREAD_CHANNEL)?.({}, {
+      backend: "codex",
+      federationTarget,
+      threadId: "thread-remote",
+      name: "Remote title",
+    } satisfies RenameThreadRequest);
+
+    expect(federationMock.runtime.remoteBackend).toHaveBeenCalledWith(
+      federationTarget,
+    );
+    expect(federationMock.remoteBackend.renameThread).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-remote",
+      name: "Remote title",
+    });
+    expect(renameThread).not.toHaveBeenCalled();
+    expect(response).toEqual({
+      backend: "codex",
+      threadId: "thread-remote",
+      renamedAt: 6_000,
     });
   });
 

--- a/apps/desktop/src/main/__tests__/applications-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/applications-ipc.test.ts
@@ -1,8 +1,29 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
+  DesktopApplicationsSnapshot,
   OpenDesktopApplicationRequest,
   OpenDesktopApplicationResponse,
+  ReadDesktopApplicationsRequest,
 } from "@pwragent/shared";
+
+const remoteApplications: DesktopApplicationsSnapshot = {
+  editors: [],
+  terminals: [{
+    id: "terminal",
+    kind: "terminal",
+    name: "Terminal",
+    source: "application",
+    appPath: "/System/Applications/Utilities/Terminal.app",
+    canOpenWorkspace: true,
+  }],
+  preferredEditorId: { value: "", source: "default" },
+  preferredTerminalId: { value: "", source: "default" },
+  gh: {
+    path: { value: "", source: "default" },
+    discovery: { candidates: [] },
+  },
+  git: { discovery: { candidates: [] } },
+};
 
 const mocks = vi.hoisted(() => {
   const handlers = new Map<
@@ -12,10 +33,13 @@ const mocks = vi.hoisted(() => {
   const openApplication = vi.fn(
     async (): Promise<OpenDesktopApplicationResponse> => ({ opened: true }),
   );
-  const remoteBackend = { openApplication };
+  const readApplications = vi.fn(async () => remoteApplications);
+  const remoteBackend = { openApplication, readApplications };
   return {
     handlers,
     openApplication,
+    readApplications,
+    discoverDesktopApplications: vi.fn(async () => remoteApplications),
     openDesktopApplication: vi.fn(
       async (): Promise<OpenDesktopApplicationResponse> => ({ opened: true }),
     ),
@@ -43,6 +67,7 @@ vi.mock("electron", () => ({
 }));
 
 vi.mock("../settings/application-discovery", () => ({
+  discoverDesktopApplications: mocks.discoverDesktopApplications,
   openDesktopApplication: mocks.openDesktopApplication,
 }));
 
@@ -65,6 +90,8 @@ describe("application IPC", () => {
   beforeEach(() => {
     mocks.handlers.clear();
     mocks.openApplication.mockClear();
+    mocks.readApplications.mockClear();
+    mocks.discoverDesktopApplications.mockClear();
     mocks.openDesktopApplication.mockClear();
     mocks.remoteBackendForTarget.mockClear();
   });
@@ -93,5 +120,24 @@ describe("application IPC", () => {
     });
     expect(mocks.openDesktopApplication).not.toHaveBeenCalled();
     expect(response).toEqual({ opened: true });
+  });
+
+  it("reads application candidates from the selected federation peer", async () => {
+    const { registerApplicationIpcHandlers } = await import("../ipc/applications");
+    const { APPLICATIONS_READ_CHANNEL } = await import("../../shared/ipc");
+    registerApplicationIpcHandlers();
+
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "remote-instance",
+    };
+    const response = await mocks.handlers.get(APPLICATIONS_READ_CHANNEL)?.({}, {
+      federationTarget,
+    } satisfies ReadDesktopApplicationsRequest);
+
+    expect(mocks.remoteBackendForTarget).toHaveBeenCalledWith(federationTarget);
+    expect(mocks.readApplications).toHaveBeenCalledTimes(1);
+    expect(mocks.discoverDesktopApplications).not.toHaveBeenCalled();
+    expect(response).toEqual({ applications: remoteApplications });
   });
 });

--- a/apps/desktop/src/main/__tests__/applications-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/applications-ipc.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  OpenDesktopApplicationRequest,
+  OpenDesktopApplicationResponse,
+} from "@pwragent/shared";
+
+const mocks = vi.hoisted(() => {
+  const handlers = new Map<
+    string,
+    (...args: unknown[]) => Promise<unknown>
+  >();
+  const openApplication = vi.fn(
+    async (): Promise<OpenDesktopApplicationResponse> => ({ opened: true }),
+  );
+  const remoteBackend = { openApplication };
+  return {
+    handlers,
+    openApplication,
+    openDesktopApplication: vi.fn(
+      async (): Promise<OpenDesktopApplicationResponse> => ({ opened: true }),
+    ),
+    remoteBackend,
+    remoteBackendForTarget: vi.fn(() => remoteBackend),
+  };
+});
+
+vi.mock("electron", () => ({
+  BrowserWindow: { fromWebContents: vi.fn() },
+  ipcMain: {
+    handle: vi.fn(
+      (channel: string, handler: (...args: unknown[]) => Promise<unknown>) => {
+        mocks.handlers.set(channel, handler);
+      },
+    ),
+    removeHandler: vi.fn((channel: string) => {
+      mocks.handlers.delete(channel);
+    }),
+  },
+  shell: {
+    openPath: vi.fn(async () => ""),
+    showItemInFolder: vi.fn(),
+  },
+}));
+
+vi.mock("../settings/application-discovery", () => ({
+  openDesktopApplication: mocks.openDesktopApplication,
+}));
+
+vi.mock("../federation/federation-runtime", () => ({
+  getDesktopFederationRuntime: () => ({
+    remoteBackend: mocks.remoteBackendForTarget,
+  }),
+}));
+
+vi.mock("../markdown-files-window", () => ({
+  readMarkdownFileViewerSnapshot: vi.fn(),
+  showMarkdownFileViewerWindow: vi.fn(),
+}));
+
+vi.mock("../subagent-transcript-window", () => ({
+  showSubAgentTranscriptWindow: vi.fn(),
+}));
+
+describe("application IPC", () => {
+  beforeEach(() => {
+    mocks.handlers.clear();
+    mocks.openApplication.mockClear();
+    mocks.openDesktopApplication.mockClear();
+    mocks.remoteBackendForTarget.mockClear();
+  });
+
+  it("opens applications on the selected federation peer", async () => {
+    const { registerApplicationIpcHandlers } = await import("../ipc/applications");
+    const { APPLICATION_OPEN_CHANNEL } = await import("../../shared/ipc");
+    registerApplicationIpcHandlers();
+
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "remote-instance",
+    };
+    const response = await mocks.handlers.get(APPLICATION_OPEN_CHANNEL)?.({}, {
+      applicationId: "terminal",
+      federationTarget,
+      kind: "terminal",
+      targetPath: "/remote/repo",
+    } satisfies OpenDesktopApplicationRequest);
+
+    expect(mocks.remoteBackendForTarget).toHaveBeenCalledWith(federationTarget);
+    expect(mocks.openApplication).toHaveBeenCalledWith({
+      applicationId: "terminal",
+      kind: "terminal",
+      targetPath: "/remote/repo",
+    });
+    expect(mocks.openDesktopApplication).not.toHaveBeenCalled();
+    expect(response).toEqual({ opened: true });
+  });
+});

--- a/apps/desktop/src/main/__tests__/desktop-config-federation.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-config-federation.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  desktopSettingsPatchToEdits,
+  parseDesktopSettingsToml,
+} from "../settings/desktop-config";
+import { applyTomlEdits, parseTomlTables } from "../settings/toml-editor";
+
+describe("desktop config [federation] section", () => {
+  it("reads federation settings from TOML", () => {
+    const src = [
+      "[federation]",
+      'mode = "gateway"',
+      'listen_host = "127.0.0.1"',
+      "listen_port = 47830",
+      'public_url = "https://pwragent.example.com"',
+      'gateway_url = "https://pwragent.example.com"',
+      "cloudflare_mtls_enabled = true",
+      "cloudflare_access_service_auth_enabled = true",
+      "",
+    ].join("\n");
+
+    const config = parseDesktopSettingsToml(src, "test.toml");
+
+    expect(config.federation).toEqual({
+      mode: "gateway",
+      listenHost: "127.0.0.1",
+      listenPort: 47830,
+      publicUrl: "https://pwragent.example.com",
+      gatewayUrl: "https://pwragent.example.com",
+      cloudflareMtlsEnabled: true,
+      cloudflareAccessServiceAuthEnabled: true,
+    });
+  });
+
+  it("round-trips federation writes through TOML edits", () => {
+    const edits = desktopSettingsPatchToEdits({
+      federation: {
+        mode: "dual",
+        listenHost: "0.0.0.0",
+        listenPort: 47831,
+        publicUrl: "https://gateway.example.com",
+        gatewayUrl: "https://gateway.example.com",
+        cloudflareMtlsEnabled: true,
+        cloudflareAccessServiceAuthEnabled: true,
+      },
+    });
+    const written = applyTomlEdits("", edits);
+    const config = parseDesktopSettingsToml(written, "test.toml");
+
+    expect(config.federation).toEqual({
+      mode: "dual",
+      listenHost: "0.0.0.0",
+      listenPort: 47831,
+      publicUrl: "https://gateway.example.com",
+      gatewayUrl: "https://gateway.example.com",
+      cloudflareMtlsEnabled: true,
+      cloudflareAccessServiceAuthEnabled: true,
+    });
+  });
+
+  it("deletes federation defaults on write", () => {
+    const existing = [
+      "[federation]",
+      'mode = "gateway"',
+      'listen_host = "127.0.0.1"',
+      "listen_port = 47830",
+      'public_url = "https://gateway.example.com"',
+      'gateway_url = "https://gateway.example.com"',
+      "cloudflare_mtls_enabled = true",
+      "cloudflare_access_service_auth_enabled = true",
+      "",
+    ].join("\n");
+    const edits = desktopSettingsPatchToEdits(
+      {
+        federation: {
+          mode: "disabled",
+          listenHost: "",
+          listenPort: 0,
+          publicUrl: "",
+          gatewayUrl: "",
+          cloudflareMtlsEnabled: false,
+          cloudflareAccessServiceAuthEnabled: false,
+        },
+      },
+      parseTomlTables(existing, "test.toml"),
+    );
+    const written = applyTomlEdits(existing, edits);
+    const config = parseDesktopSettingsToml(written, "test.toml");
+
+    expect(config.federation).toBeUndefined();
+  });
+
+  it("ignores unknown federation modes", () => {
+    const config = parseDesktopSettingsToml(
+      '[federation]\nmode = "master"\n',
+      "test.toml",
+    );
+
+    expect(config.federation).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/main/__tests__/desktop-config-federation.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-config-federation.test.ts
@@ -92,10 +92,19 @@ describe("desktop config [federation] section", () => {
 
   it("ignores unknown federation modes", () => {
     const config = parseDesktopSettingsToml(
-      '[federation]\nmode = "master"\n',
+      '[federation]\nmode = "coordinator"\n',
       "test.toml",
     );
 
     expect(config.federation).toBeUndefined();
+  });
+
+  it("maps the legacy child federation mode to client", () => {
+    const config = parseDesktopSettingsToml(
+      '[federation]\nmode = "child"\n',
+      "test.toml",
+    );
+
+    expect(config.federation?.mode).toBe("client");
   });
 });

--- a/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, it, vi } from "vitest";
 import type {
+  AgentEvent,
   AppServerReadThreadResponse,
   AppServerThreadReplay,
+  NavigationSnapshot,
 } from "@pwragent/shared";
 import type { DesktopBackendRegistry } from "../app-server/backend-registry";
-import { DesktopMessagingBackendBridge } from "../messaging/desktop-backend-bridge";
+import type { FederationBackendOperations } from "../federation/federation-backend-bridge";
+import {
+  DesktopMessagingBackendBridge,
+  type DesktopMessagingFederationBridge,
+} from "../messaging/desktop-backend-bridge";
 
 describe("DesktopMessagingBackendBridge", () => {
   it("preserves enriched messaging provenance when starting a turn", async () => {
@@ -377,6 +383,151 @@ describe("DesktopMessagingBackendBridge", () => {
         url: "https://example.com/current.png",
       }),
     ]);
+  });
+
+  it("routes targeted messaging turns and navigation to the remote backend", async () => {
+    const startTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      turnId: "turn-remote",
+      queueStatus: "started" as const,
+    }));
+    const remoteNavigation: NavigationSnapshot = {
+      backend: "all",
+      fetchedAt: 2_000,
+      unchanged: false,
+      threads: [],
+      inboxThreadKeys: [],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+    };
+    const remoteNavigationSnapshot = vi.fn(async () => remoteNavigation);
+    const listBackends = vi.fn(async () => ({
+      fetchedAt: 2_000,
+      backends: [
+        {
+          kind: "codex" as const,
+          label: "Remote Codex",
+          available: true,
+          methods: [],
+          capabilities: {},
+          executionModes: [],
+        },
+      ],
+    }));
+    const federation = {
+      connectedPeerTargets: () => [],
+      onRemoteBackendEvent: () => () => undefined,
+      remoteBackend: () => ({
+        listBackends,
+        startTurn,
+      } as unknown as FederationBackendOperations),
+      remoteNavigationSnapshot,
+    } satisfies DesktopMessagingFederationBridge;
+    const registry = {
+      submitTurn: vi.fn(() => {
+        throw new Error("local turn should not run");
+      }),
+    } as unknown as DesktopBackendRegistry;
+    const bridge = new DesktopMessagingBackendBridge(registry, federation);
+    const target = { scope: "remote" as const, instanceId: "client_one" };
+
+    await expect(
+      bridge.startTurn({
+        backend: "codex",
+        federationTarget: target,
+        threadId: "thread-1",
+        input: [{ type: "text", text: "ship it" }],
+      }),
+    ).resolves.toMatchObject({ turnId: "turn-remote" });
+    await expect(
+      bridge.getNavigationSnapshot({
+        backend: "all",
+        federationTarget: target,
+      }),
+    ).resolves.toBe(remoteNavigation);
+    await expect(
+      bridge.listBackends({
+        includeUnavailable: true,
+        federationTarget: target,
+      }),
+    ).resolves.toMatchObject({
+      backends: [{ label: "Remote Codex" }],
+    });
+
+    expect(startTurn).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      input: [{ type: "text", text: "ship it" }],
+    });
+    expect(remoteNavigationSnapshot).toHaveBeenCalledWith(target, {
+      backend: "all",
+      federationTarget: target,
+    });
+    expect(listBackends).toHaveBeenCalledWith({
+      includeUnavailable: true,
+    });
+  });
+
+  it("subscribes messaging controllers to local and remote backend events", async () => {
+    let localListener: ((event: AgentEvent) => void | Promise<void>) | undefined;
+    let remoteListener: ((event: AgentEvent) => void | Promise<void>) | undefined;
+    const unsubscribeLocal = vi.fn();
+    const unsubscribeRemote = vi.fn();
+    const registry = {
+      onEvent: vi.fn(
+        (listener: (event: AgentEvent) => void | Promise<void>) => {
+          localListener = listener;
+          return unsubscribeLocal;
+        },
+      ),
+    } as unknown as DesktopBackendRegistry;
+    const federation = {
+      connectedPeerTargets: () => [],
+      onRemoteBackendEvent: (
+        listener: (event: AgentEvent) => void | Promise<void>,
+      ) => {
+        remoteListener = listener;
+        return unsubscribeRemote;
+      },
+      remoteBackend: vi.fn(),
+      remoteNavigationSnapshot: vi.fn(),
+    } as unknown as DesktopMessagingFederationBridge;
+    const bridge = new DesktopMessagingBackendBridge(registry, federation);
+    const listener = vi.fn();
+
+    const unsubscribe = bridge.onEvent(listener);
+    await remoteListener?.({
+      backend: "codex",
+      federationTarget: { scope: "remote", instanceId: "client_one" },
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+    await localListener?.({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "thread-2",
+          turnId: "turn-2",
+          turn: { id: "turn-2" },
+        },
+      },
+    });
+    unsubscribe();
+
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(unsubscribeLocal).toHaveBeenCalledOnce();
+    expect(unsubscribeRemote).toHaveBeenCalledOnce();
   });
 });
 

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -101,6 +101,15 @@ describe("DesktopSettingsService", () => {
         "[updates]",
         'channel = "prerelease"',
         "",
+        "[federation]",
+        'mode = "gateway"',
+        'listen_host = "127.0.0.1"',
+        "listen_port = 47830",
+        'public_url = "https://pwragent.example.com"',
+        'gateway_url = "https://pwragent.example.com"',
+        "cloudflare_mtls_enabled = true",
+        "cloudflare_access_service_auth_enabled = true",
+        "",
         "[messaging.attachments]",
         'image_profile = "high"',
         "",
@@ -192,6 +201,42 @@ describe("DesktopSettingsService", () => {
     expect(snapshot.updates.channel).toEqual({
       value: "prerelease",
       source: "config",
+    });
+    expect(snapshot.federation).toMatchObject({
+      mode: { value: "gateway", source: "config" },
+      listenHost: { value: "127.0.0.1", source: "config" },
+      listenPort: { value: 47830, source: "config" },
+      publicUrl: {
+        value: "https://pwragent.example.com",
+        source: "config",
+      },
+      gatewayUrl: {
+        value: "https://pwragent.example.com",
+        source: "config",
+      },
+      cloudflareMtlsEnabled: { value: true, source: "config" },
+      cloudflareAccessServiceAuthEnabled: { value: true, source: "config" },
+      instancePrivateKey: { configured: false, source: "unset", writable: true },
+      cloudflareClientCertificate: {
+        configured: false,
+        source: "unset",
+        writable: true,
+      },
+      cloudflareClientPrivateKey: {
+        configured: false,
+        source: "unset",
+        writable: true,
+      },
+      cloudflareAccessClientId: {
+        configured: false,
+        source: "unset",
+        writable: true,
+      },
+      cloudflareAccessClientSecret: {
+        configured: false,
+        source: "unset",
+        writable: true,
+      },
     });
     expect(snapshot.messaging.attachments.imageProfile).toEqual({
       value: "high",
@@ -294,6 +339,54 @@ describe("DesktopSettingsService", () => {
     expect((await service.readSettings()).updates.channel).toEqual({
       value: "latest",
       source: "default",
+    });
+  });
+
+  it("defaults federation settings and exposes stored federation secrets", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    const secretStore = new MemoryDesktopSecretStore();
+    const service = new DesktopSettingsService({
+      configPath,
+      env: {},
+      secretStore,
+    });
+
+    const initial = await service.readSettings();
+    expect(initial.federation).toMatchObject({
+      mode: { value: "disabled", source: "default" },
+      listenHost: { value: "127.0.0.1", source: "default" },
+      listenPort: { value: 47830, source: "default" },
+      publicUrl: { value: "", source: "default" },
+      gatewayUrl: { value: "", source: "default" },
+      cloudflareMtlsEnabled: { value: false, source: "default" },
+      cloudflareAccessServiceAuthEnabled: {
+        value: false,
+        source: "default",
+      },
+      instancePrivateKey: { configured: false, source: "unset", writable: true },
+    });
+
+    await service.writeConfigPatch({
+      federation: {
+        mode: "child",
+        gatewayUrl: "https://pwragent.example.com",
+      },
+    });
+    await service.replaceSecret("federationInstancePrivateKey", "private-key");
+
+    const snapshot = await service.readSettings();
+    expect(snapshot.federation).toMatchObject({
+      mode: { value: "child", source: "config" },
+      gatewayUrl: {
+        value: "https://pwragent.example.com",
+        source: "config",
+      },
+      instancePrivateKey: {
+        configured: true,
+        source: "keychain",
+        writable: true,
+      },
     });
   });
 

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -369,7 +369,7 @@ describe("DesktopSettingsService", () => {
 
     await service.writeConfigPatch({
       federation: {
-        mode: "child",
+        mode: "client",
         gatewayUrl: "https://pwragent.example.com",
       },
     });
@@ -377,7 +377,7 @@ describe("DesktopSettingsService", () => {
 
     const snapshot = await service.readSettings();
     expect(snapshot.federation).toMatchObject({
-      mode: { value: "child", source: "config" },
+      mode: { value: "client", source: "config" },
       gatewayUrl: {
         value: "https://pwragent.example.com",
         source: "config",

--- a/apps/desktop/src/main/__tests__/federated-search-service.test.ts
+++ b/apps/desktop/src/main/__tests__/federated-search-service.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AppServerThreadSummary } from "@pwragent/shared";
+import { FederatedSearchService } from "../federation/federated-search-service";
+
+function thread(
+  id: string,
+  title: string,
+  updatedAt: number,
+): AppServerThreadSummary {
+  return {
+    id,
+    title,
+    titleSource: "explicit",
+    updatedAt,
+    linkedDirectories: [],
+    source: "codex",
+  };
+}
+
+describe("FederatedSearchService", () => {
+  it("fans out to local and remote peers and preserves source identity", async () => {
+    const service = new FederatedSearchService({
+      now: () => 10_000,
+      local: {
+        listThreads: vi.fn(async () => ({
+          backend: "codex" as const,
+          fetchedAt: 1_000,
+          threads: [thread("local-1", "Build remote control", 1_000)],
+        })),
+      },
+      peers: () => [
+        {
+          instanceId: "child_one",
+          label: "Laptop",
+          status: "connected",
+          backend: {
+            listThreads: vi.fn(async () => ({
+              backend: "codex" as const,
+              fetchedAt: 1_000,
+              threads: [thread("remote-1", "Remote control design", 2_000)],
+            })),
+          },
+        },
+      ],
+    });
+
+    await expect(
+      service.search({ query: "remote", limit: 10 }),
+    ).resolves.toMatchObject({
+      query: "remote",
+      searchedAt: 10_000,
+      failures: [],
+      results: [
+        {
+          ref: {
+            backend: "codex",
+            target: { scope: "remote", instanceId: "child_one" },
+            threadId: "remote-1",
+          },
+          instanceLabel: "Laptop",
+          peerStatus: "connected",
+        },
+        {
+          ref: {
+            backend: "codex",
+            target: { scope: "local" },
+            threadId: "local-1",
+          },
+          instanceLabel: "This Mac",
+        },
+      ],
+    });
+  });
+
+  it("returns successful peers when another peer fails", async () => {
+    const service = new FederatedSearchService({
+      local: {
+        listThreads: vi.fn(async () => ({
+          backend: "codex" as const,
+          fetchedAt: 1_000,
+          threads: [],
+        })),
+      },
+      peers: () => [
+        {
+          instanceId: "child_one",
+          label: "Laptop",
+          backend: {
+            listThreads: vi.fn(async () => {
+              throw new Error("offline");
+            }),
+          },
+        },
+        {
+          instanceId: "child_two",
+          label: "Desktop",
+          backend: {
+            listThreads: vi.fn(async () => ({
+              backend: "codex" as const,
+              fetchedAt: 1_000,
+              threads: [thread("remote-2", "Search survives failure", 3_000)],
+            })),
+          },
+        },
+      ],
+    });
+
+    await expect(service.search({ query: "search" })).resolves.toMatchObject({
+      results: [
+        {
+          ref: {
+            target: { scope: "remote", instanceId: "child_two" },
+            threadId: "remote-2",
+          },
+          instanceLabel: "Desktop",
+        },
+      ],
+      failures: [
+        {
+          instanceId: "child_one",
+          instanceLabel: "Laptop",
+          error: "offline",
+        },
+      ],
+    });
+  });
+});

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -204,4 +204,207 @@ describe("federation backend bridge", () => {
       },
     ]);
   });
+
+  it("maps expanded remote control operations to capability-guarded handlers", async () => {
+    const backend: FederationBackendOperations = {
+      listThreads: vi.fn(),
+      readThread: vi.fn(),
+      listSkills: vi.fn(),
+      startTurn: vi.fn(),
+      compactThread: vi.fn(async () => ({
+        backend: "codex" as const,
+        threadId: "thread-1",
+        turnId: "compact-1",
+      })),
+      interruptTurn: vi.fn(),
+      steerTurn: vi.fn(),
+      setThreadExecutionMode: vi.fn(),
+      queueThreadExecutionMode: vi.fn(),
+      cancelThreadExecutionModeQueue: vi.fn(),
+      setAcpSessionRuntimeOption: vi.fn(),
+      setThreadModelSettings: vi.fn(),
+      submitServerRequest: vi.fn(async () => ({
+        backend: "codex" as const,
+        threadId: "thread-1",
+        requestId: "approval-1",
+      })),
+      runCodexEnvironmentAction: vi.fn(async () => ({
+        backend: "codex" as const,
+        threadId: "thread-1",
+        codexEnvironmentRuntime: {
+          environmentId: "node",
+          environmentName: "Node",
+          executionTarget: "local" as const,
+        },
+      })),
+      setCodexThreadEnvironment: vi.fn(),
+      handoffThreadWorkspace: vi.fn(),
+    };
+    const replies: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({
+      localInstanceId: "client_one",
+      methodCapabilities: FEDERATION_BACKEND_METHOD_CAPABILITIES,
+      now: () => 2_000,
+    });
+    router.registerConnection({
+      peerId: "gateway_one",
+      capabilities: [
+        "turn_control",
+        "pending_request_control",
+        "environment_actions",
+      ],
+      sendEnvelope: (envelope) => replies.push(envelope),
+    });
+    registerFederationBackendHandlers({ router, backend });
+
+    await router.routeEnvelope({
+      sourcePeerId: "gateway_one",
+      envelope: {
+        id: "compact-request",
+        kind: "request",
+        method: FEDERATION_BACKEND_METHODS.compactThread,
+        params: { backend: "codex", threadId: "thread-1" },
+        protocolVersion: 1,
+        sourceInstanceId: "gateway_one",
+        targetInstanceId: "client_one",
+        createdAt: 1_000,
+      },
+    });
+    await router.routeEnvelope({
+      sourcePeerId: "gateway_one",
+      envelope: {
+        id: "approval-request",
+        kind: "request",
+        method: FEDERATION_BACKEND_METHODS.submitServerRequest,
+        params: {
+          backend: "codex",
+          threadId: "thread-1",
+          requestId: "approval-1",
+          response: { decision: "approve" },
+        },
+        protocolVersion: 1,
+        sourceInstanceId: "gateway_one",
+        targetInstanceId: "client_one",
+        createdAt: 1_100,
+      },
+    });
+    await router.routeEnvelope({
+      sourcePeerId: "gateway_one",
+      envelope: {
+        id: "env-request",
+        kind: "request",
+        method: FEDERATION_BACKEND_METHODS.runCodexEnvironmentAction,
+        params: {
+          actionId: "start",
+          backend: "codex",
+          threadId: "thread-1",
+        },
+        protocolVersion: 1,
+        sourceInstanceId: "gateway_one",
+        targetInstanceId: "client_one",
+        createdAt: 1_200,
+      },
+    });
+
+    expect(backend.compactThread).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(backend.submitServerRequest).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      requestId: "approval-1",
+      response: { decision: "approve" },
+    });
+    expect(backend.runCodexEnvironmentAction).toHaveBeenCalledWith({
+      actionId: "start",
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(replies).toMatchObject([
+      {
+        kind: "response",
+        requestId: "compact-request",
+        result: { turnId: "compact-1" },
+      },
+      {
+        kind: "response",
+        requestId: "approval-request",
+        result: { requestId: "approval-1" },
+      },
+      {
+        kind: "response",
+        requestId: "env-request",
+        result: {
+          codexEnvironmentRuntime: {
+            environmentId: "node",
+          },
+        },
+      },
+    ]);
+  });
+
+  it("requires environment_actions for remote environment mutations", async () => {
+    const replies: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({
+      localInstanceId: "client_one",
+      methodCapabilities: FEDERATION_BACKEND_METHOD_CAPABILITIES,
+    });
+    router.registerConnection({
+      peerId: "gateway_one",
+      capabilities: ["turn_control"],
+      sendEnvelope: (envelope) => replies.push(envelope),
+    });
+    registerFederationBackendHandlers({
+      router,
+      backend: {
+        listThreads: vi.fn(),
+        readThread: vi.fn(),
+        listSkills: vi.fn(),
+        startTurn: vi.fn(),
+        compactThread: vi.fn(),
+        interruptTurn: vi.fn(),
+        steerTurn: vi.fn(),
+        setThreadExecutionMode: vi.fn(),
+        queueThreadExecutionMode: vi.fn(),
+        cancelThreadExecutionModeQueue: vi.fn(),
+        setAcpSessionRuntimeOption: vi.fn(),
+        setThreadModelSettings: vi.fn(),
+        submitServerRequest: vi.fn(),
+        runCodexEnvironmentAction: vi.fn(),
+        setCodexThreadEnvironment: vi.fn(),
+        handoffThreadWorkspace: vi.fn(),
+      } as FederationBackendOperations,
+    });
+
+    await expect(
+      router.routeEnvelope({
+        sourcePeerId: "gateway_one",
+        envelope: {
+          id: "env-request",
+          kind: "request",
+          method: FEDERATION_BACKEND_METHODS.setCodexThreadEnvironment,
+          params: {
+            backend: "codex",
+            environmentId: "node",
+            threadId: "thread-1",
+          },
+          protocolVersion: 1,
+          sourceInstanceId: "gateway_one",
+          targetInstanceId: "client_one",
+          createdAt: 1_000,
+        },
+      }),
+    ).resolves.toMatchObject({
+      status: "rejected",
+      code: "capability_denied",
+    });
+    expect(replies).toMatchObject([
+      {
+        kind: "error",
+        requestId: "env-request",
+        error: { code: "capability_denied" },
+      },
+    ]);
+  });
 });

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -29,21 +29,21 @@ describe("federation backend bridge", () => {
       now: () => 2_000,
     });
     router.registerConnection({
-      peerId: "child_one",
+      peerId: "client_one",
       capabilities: ["thread_navigation"],
       sendEnvelope: (envelope) => replies.push(envelope),
     });
     registerFederationBackendHandlers({ router, backend });
 
     await router.routeEnvelope({
-      sourcePeerId: "child_one",
+      sourcePeerId: "client_one",
       envelope: {
         id: "request-1",
         kind: "request",
         method: FEDERATION_BACKEND_METHODS.listThreads,
         params: { backend: "codex" },
         protocolVersion: 1,
-        sourceInstanceId: "child_one",
+        sourceInstanceId: "client_one",
         targetInstanceId: "gateway_one",
         createdAt: 1_000,
       },
@@ -66,7 +66,7 @@ describe("federation backend bridge", () => {
     const sent: FederationProtocolEnvelope[] = [];
     const rpc = new FederationRpcEndpoint({
       localInstanceId: "gateway_one",
-      remoteInstanceId: "child_one",
+      remoteInstanceId: "client_one",
       sendEnvelope: (envelope) => sent.push(envelope),
       now: () => 1_000,
     });
@@ -79,7 +79,7 @@ describe("federation backend bridge", () => {
         method: FEDERATION_BACKEND_METHODS.listThreads,
         params: { backend: "codex" },
         sourceInstanceId: "gateway_one",
-        targetInstanceId: "child_one",
+        targetInstanceId: "client_one",
       },
     ]);
 
@@ -88,7 +88,7 @@ describe("federation backend bridge", () => {
       kind: "response",
       requestId: sent[0]!.id,
       protocolVersion: 1,
-      sourceInstanceId: "child_one",
+      sourceInstanceId: "client_one",
       targetInstanceId: "gateway_one",
       createdAt: 1_100,
       result: {
@@ -111,7 +111,7 @@ describe("federation backend bridge", () => {
       methodCapabilities: FEDERATION_BACKEND_METHOD_CAPABILITIES,
     });
     router.registerConnection({
-      peerId: "child_one",
+      peerId: "client_one",
       capabilities: ["thread_navigation"],
       sendEnvelope: (envelope) => replies.push(envelope),
     });
@@ -127,14 +127,14 @@ describe("federation backend bridge", () => {
 
     await expect(
       router.routeEnvelope({
-        sourcePeerId: "child_one",
+        sourcePeerId: "client_one",
         envelope: {
           id: "request-1",
           kind: "request",
           method: FEDERATION_BACKEND_METHODS.readThread,
           params: { backend: "codex", threadId: "thread-1" },
           protocolVersion: 1,
-          sourceInstanceId: "child_one",
+          sourceInstanceId: "client_one",
           targetInstanceId: "gateway_one",
           createdAt: 1_000,
         },
@@ -159,7 +159,7 @@ describe("federation backend bridge", () => {
     } as unknown as FederationBackendOperations;
     const replies: FederationProtocolEnvelope[] = [];
     const router = new FederationRouter({
-      localInstanceId: "child_one",
+      localInstanceId: "client_one",
       methodCapabilities: FEDERATION_BACKEND_METHOD_CAPABILITIES,
     });
     router.registerConnection({
@@ -182,7 +182,7 @@ describe("federation backend bridge", () => {
         },
         protocolVersion: 1,
         sourceInstanceId: "gateway_one",
-        targetInstanceId: "child_one",
+        targetInstanceId: "client_one",
         createdAt: 1_000,
       },
     });

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -20,6 +20,7 @@ describe("federation backend bridge", () => {
       })),
       readThread: vi.fn(),
       listSkills: vi.fn(),
+      startTurn: vi.fn(),
     } as unknown as FederationBackendOperations;
     const replies: FederationProtocolEnvelope[] = [];
     const router = new FederationRouter({
@@ -120,6 +121,7 @@ describe("federation backend bridge", () => {
         listThreads: vi.fn(),
         readThread: vi.fn(),
         listSkills: vi.fn(),
+        startTurn: vi.fn(),
       } as unknown as FederationBackendOperations,
     });
 
@@ -141,5 +143,65 @@ describe("federation backend bridge", () => {
       status: "rejected",
       code: "capability_denied",
     });
+  });
+
+  it("maps remote turn submission to a turn-control guarded handler", async () => {
+    const backend: FederationBackendOperations = {
+      listThreads: vi.fn(),
+      readThread: vi.fn(),
+      listSkills: vi.fn(),
+      startTurn: vi.fn(async () => ({
+        backend: "codex",
+        threadId: "thread-1",
+        turnId: "turn-1",
+        queueStatus: "started",
+      })),
+    } as unknown as FederationBackendOperations;
+    const replies: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({
+      localInstanceId: "child_one",
+      methodCapabilities: FEDERATION_BACKEND_METHOD_CAPABILITIES,
+    });
+    router.registerConnection({
+      peerId: "gateway_one",
+      capabilities: ["turn_control"],
+      sendEnvelope: (envelope) => replies.push(envelope),
+    });
+    registerFederationBackendHandlers({ router, backend });
+
+    await router.routeEnvelope({
+      sourcePeerId: "gateway_one",
+      envelope: {
+        id: "request-1",
+        kind: "request",
+        method: FEDERATION_BACKEND_METHODS.startTurn,
+        params: {
+          backend: "codex",
+          threadId: "thread-1",
+          input: [{ type: "text", text: "ship it" }],
+        },
+        protocolVersion: 1,
+        sourceInstanceId: "gateway_one",
+        targetInstanceId: "child_one",
+        createdAt: 1_000,
+      },
+    });
+
+    expect(backend.startTurn).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      input: [{ type: "text", text: "ship it" }],
+    });
+    expect(replies).toMatchObject([
+      {
+        kind: "response",
+        requestId: "request-1",
+        result: {
+          backend: "codex",
+          threadId: "thread-1",
+          turnId: "turn-1",
+        },
+      },
+    ]);
   });
 });

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from "vitest";
+import type { FederationProtocolEnvelope } from "@pwragent/shared";
+import {
+  FEDERATION_BACKEND_METHODS,
+  FEDERATION_BACKEND_METHOD_CAPABILITIES,
+  FederationRemoteBackendClient,
+  registerFederationBackendHandlers,
+  type FederationBackendOperations,
+} from "../federation/federation-backend-bridge";
+import { FederationRouter } from "../federation/federation-router";
+import { FederationRpcEndpoint } from "../federation/federation-rpc";
+
+describe("federation backend bridge", () => {
+  it("maps federation backend methods to local app-server operations", async () => {
+    const backend: FederationBackendOperations = {
+      listThreads: vi.fn(async () => ({
+        backend: "codex",
+        fetchedAt: 1_000,
+        threads: [],
+      })),
+      readThread: vi.fn(),
+      listSkills: vi.fn(),
+    } as unknown as FederationBackendOperations;
+    const replies: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({
+      localInstanceId: "gateway_one",
+      methodCapabilities: FEDERATION_BACKEND_METHOD_CAPABILITIES,
+      now: () => 2_000,
+    });
+    router.registerConnection({
+      peerId: "child_one",
+      capabilities: ["thread_navigation"],
+      sendEnvelope: (envelope) => replies.push(envelope),
+    });
+    registerFederationBackendHandlers({ router, backend });
+
+    await router.routeEnvelope({
+      sourcePeerId: "child_one",
+      envelope: {
+        id: "request-1",
+        kind: "request",
+        method: FEDERATION_BACKEND_METHODS.listThreads,
+        params: { backend: "codex" },
+        protocolVersion: 1,
+        sourceInstanceId: "child_one",
+        targetInstanceId: "gateway_one",
+        createdAt: 1_000,
+      },
+    });
+
+    expect(backend.listThreads).toHaveBeenCalledWith({ backend: "codex" });
+    expect(replies).toMatchObject([
+      {
+        kind: "response",
+        requestId: "request-1",
+        result: {
+          backend: "codex",
+          threads: [],
+        },
+      },
+    ]);
+  });
+
+  it("serializes remote backend requests over RPC envelopes", async () => {
+    const sent: FederationProtocolEnvelope[] = [];
+    const rpc = new FederationRpcEndpoint({
+      localInstanceId: "gateway_one",
+      remoteInstanceId: "child_one",
+      sendEnvelope: (envelope) => sent.push(envelope),
+      now: () => 1_000,
+    });
+    const client = new FederationRemoteBackendClient(rpc);
+    const pending = client.listThreads({ backend: "codex" });
+
+    expect(sent).toMatchObject([
+      {
+        kind: "request",
+        method: FEDERATION_BACKEND_METHODS.listThreads,
+        params: { backend: "codex" },
+        sourceInstanceId: "gateway_one",
+        targetInstanceId: "child_one",
+      },
+    ]);
+
+    rpc.receiveEnvelope({
+      id: "response-1",
+      kind: "response",
+      requestId: sent[0]!.id,
+      protocolVersion: 1,
+      sourceInstanceId: "child_one",
+      targetInstanceId: "gateway_one",
+      createdAt: 1_100,
+      result: {
+        backend: "codex",
+        fetchedAt: 1_100,
+        threads: [],
+      },
+    });
+
+    await expect(pending).resolves.toMatchObject({
+      backend: "codex",
+      threads: [],
+    });
+  });
+
+  it("requires thread-detail capability for remote thread reads", async () => {
+    const replies: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({
+      localInstanceId: "gateway_one",
+      methodCapabilities: FEDERATION_BACKEND_METHOD_CAPABILITIES,
+    });
+    router.registerConnection({
+      peerId: "child_one",
+      capabilities: ["thread_navigation"],
+      sendEnvelope: (envelope) => replies.push(envelope),
+    });
+    registerFederationBackendHandlers({
+      router,
+      backend: {
+        listThreads: vi.fn(),
+        readThread: vi.fn(),
+        listSkills: vi.fn(),
+      } as unknown as FederationBackendOperations,
+    });
+
+    await expect(
+      router.routeEnvelope({
+        sourcePeerId: "child_one",
+        envelope: {
+          id: "request-1",
+          kind: "request",
+          method: FEDERATION_BACKEND_METHODS.readThread,
+          params: { backend: "codex", threadId: "thread-1" },
+          protocolVersion: 1,
+          sourceInstanceId: "child_one",
+          targetInstanceId: "gateway_one",
+          createdAt: 1_000,
+        },
+      }),
+    ).resolves.toMatchObject({
+      status: "rejected",
+      code: "capability_denied",
+    });
+  });
+});

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -24,6 +24,12 @@ describe("federation backend bridge", () => {
       readThread: vi.fn(),
       listSkills: vi.fn(),
       listBackends: vi.fn(),
+      archiveThread: vi.fn(async () => ({
+        backend: "codex",
+        threadId: "thread-1",
+        archivedAt: 2_000,
+        cleanup: [],
+      })),
       startTurn: vi.fn(),
     } as unknown as FederationBackendOperations;
     const replies: FederationProtocolEnvelope[] = [];
@@ -34,7 +40,7 @@ describe("federation backend bridge", () => {
     });
     router.registerConnection({
       peerId: "client_one",
-      capabilities: ["thread_navigation"],
+      capabilities: ["thread_navigation", "turn_control"],
       sendEnvelope: (envelope) => replies.push(envelope),
     });
     registerFederationBackendHandlers({ router, backend });
@@ -52,8 +58,25 @@ describe("federation backend bridge", () => {
         createdAt: 1_000,
       },
     });
+    await router.routeEnvelope({
+      sourcePeerId: "client_one",
+      envelope: {
+        id: "request-2",
+        kind: "request",
+        method: FEDERATION_BACKEND_METHODS.archiveThread,
+        params: { backend: "codex", threadId: "thread-1" },
+        protocolVersion: 1,
+        sourceInstanceId: "client_one",
+        targetInstanceId: "gateway_one",
+        createdAt: 1_100,
+      },
+    });
 
     expect(backend.listThreads).toHaveBeenCalledWith({ backend: "codex" });
+    expect(backend.archiveThread).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+    });
     expect(replies).toMatchObject([
       {
         kind: "response",
@@ -61,6 +84,14 @@ describe("federation backend bridge", () => {
         result: {
           backend: "codex",
           threads: [],
+        },
+      },
+      {
+        kind: "response",
+        requestId: "request-2",
+        result: {
+          backend: "codex",
+          threadId: "thread-1",
         },
       },
     ]);
@@ -105,6 +136,36 @@ describe("federation backend bridge", () => {
     await expect(pending).resolves.toMatchObject({
       backend: "codex",
       threads: [],
+    });
+
+    const archivePending = client.archiveThread({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    const archiveRequest = sent.at(-1)!;
+    expect(archiveRequest).toMatchObject({
+      kind: "request",
+      method: FEDERATION_BACKEND_METHODS.archiveThread,
+      params: { backend: "codex", threadId: "thread-1" },
+    });
+    rpc.receiveEnvelope({
+      id: "response-2",
+      kind: "response",
+      requestId: archiveRequest.id,
+      protocolVersion: 1,
+      sourceInstanceId: "client_one",
+      targetInstanceId: "gateway_one",
+      createdAt: 1_200,
+      result: {
+        backend: "codex",
+        threadId: "thread-1",
+        archivedAt: 1_200,
+        cleanup: [],
+      },
+    });
+    await expect(archivePending).resolves.toMatchObject({
+      threadId: "thread-1",
+      cleanup: [],
     });
   });
 
@@ -217,6 +278,7 @@ describe("federation backend bridge", () => {
       readThread: vi.fn(),
       listSkills: vi.fn(),
       listBackends: vi.fn(),
+      archiveThread: vi.fn(),
       startThread: vi.fn(),
       forkThread: vi.fn(),
       startTurn: vi.fn(),
@@ -379,6 +441,7 @@ describe("federation backend bridge", () => {
         readThread: vi.fn(),
         listSkills: vi.fn(),
         listBackends: vi.fn(),
+        archiveThread: vi.fn(),
         startThread: vi.fn(),
         forkThread: vi.fn(),
         startTurn: vi.fn(),

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -252,6 +252,7 @@ describe("federation backend bridge", () => {
       materializeDirectoryLaunchpad: vi.fn(),
       handoffThreadWorkspace: vi.fn(),
       renameThread: vi.fn(),
+      readApplications: vi.fn(),
       openApplication: vi.fn(),
       trustCodexProject: vi.fn(),
     };
@@ -397,6 +398,7 @@ describe("federation backend bridge", () => {
         materializeDirectoryLaunchpad: vi.fn(),
         handoffThreadWorkspace: vi.fn(),
         renameThread: vi.fn(),
+        readApplications: vi.fn(),
         openApplication: vi.fn(),
         trustCodexProject: vi.fn(),
       } as FederationBackendOperations,
@@ -433,12 +435,29 @@ describe("federation backend bridge", () => {
     ]);
   });
 
-  it("routes remote thread renames and application opens to the target instance", async () => {
+  it("routes remote thread renames and application operations to the target instance", async () => {
     const backend = {
       renameThread: vi.fn(async () => ({
         backend: "codex" as const,
         threadId: "thread-1",
         renamedAt: 2_000,
+      })),
+      readApplications: vi.fn(async () => ({
+        editors: [],
+        terminals: [{
+          id: "terminal",
+          kind: "terminal" as const,
+          name: "Terminal",
+          source: "application" as const,
+          canOpenWorkspace: true,
+        }],
+        preferredEditorId: { value: "", source: "default" as const },
+        preferredTerminalId: { value: "", source: "default" as const },
+        gh: {
+          path: { value: "", source: "default" as const },
+          discovery: { candidates: [] },
+        },
+        git: { discovery: { candidates: [] } },
       })),
       openApplication: vi.fn(async () => ({ opened: true as const })),
       trustCodexProject: vi.fn(async (request: TrustCodexProjectRequest) => ({
@@ -482,6 +501,19 @@ describe("federation backend bridge", () => {
     await router.routeEnvelope({
       sourcePeerId: "gateway_one",
       envelope: {
+        id: "applications-read-request",
+        kind: "request",
+        method: FEDERATION_BACKEND_METHODS.readApplications,
+        params: {},
+        protocolVersion: 1,
+        sourceInstanceId: "gateway_one",
+        targetInstanceId: "client_one",
+        createdAt: 1_050,
+      },
+    });
+    await router.routeEnvelope({
+      sourcePeerId: "gateway_one",
+      envelope: {
         id: "application-request",
         kind: "request",
         method: FEDERATION_BACKEND_METHODS.openApplication,
@@ -518,6 +550,7 @@ describe("federation backend bridge", () => {
       threadId: "thread-1",
       name: "Remote title",
     });
+    expect(backend.readApplications).toHaveBeenCalledTimes(1);
     expect(backend.openApplication).toHaveBeenCalledWith({
       applicationId: "terminal",
       kind: "terminal",
@@ -532,6 +565,13 @@ describe("federation backend bridge", () => {
         kind: "response",
         requestId: "rename-request",
         result: { renamedAt: 2_000 },
+      },
+      {
+        kind: "response",
+        requestId: "applications-read-request",
+        result: {
+          terminals: [{ id: "terminal" }],
+        },
       },
       {
         kind: "response",

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -20,6 +20,7 @@ describe("federation backend bridge", () => {
       })),
       readThread: vi.fn(),
       listSkills: vi.fn(),
+      listBackends: vi.fn(),
       startTurn: vi.fn(),
     } as unknown as FederationBackendOperations;
     const replies: FederationProtocolEnvelope[] = [];
@@ -121,6 +122,7 @@ describe("federation backend bridge", () => {
         listThreads: vi.fn(),
         readThread: vi.fn(),
         listSkills: vi.fn(),
+        listBackends: vi.fn(),
         startTurn: vi.fn(),
       } as unknown as FederationBackendOperations,
     });
@@ -207,10 +209,15 @@ describe("federation backend bridge", () => {
 
   it("maps expanded remote control operations to capability-guarded handlers", async () => {
     const backend: FederationBackendOperations = {
+      getNavigationSnapshot: vi.fn(),
       listThreads: vi.fn(),
       readThread: vi.fn(),
       listSkills: vi.fn(),
+      listBackends: vi.fn(),
+      startThread: vi.fn(),
+      forkThread: vi.fn(),
       startTurn: vi.fn(),
+      startReview: vi.fn(),
       compactThread: vi.fn(async () => ({
         backend: "codex" as const,
         threadId: "thread-1",
@@ -237,7 +244,9 @@ describe("federation backend bridge", () => {
           executionTarget: "local" as const,
         },
       })),
+      stopCodexEnvironmentAction: vi.fn(),
       setCodexThreadEnvironment: vi.fn(),
+      materializeDirectoryLaunchpad: vi.fn(),
       handoffThreadWorkspace: vi.fn(),
     };
     const replies: FederationProtocolEnvelope[] = [];
@@ -358,10 +367,15 @@ describe("federation backend bridge", () => {
     registerFederationBackendHandlers({
       router,
       backend: {
+        getNavigationSnapshot: vi.fn(),
         listThreads: vi.fn(),
         readThread: vi.fn(),
         listSkills: vi.fn(),
+        listBackends: vi.fn(),
+        startThread: vi.fn(),
+        forkThread: vi.fn(),
         startTurn: vi.fn(),
+        startReview: vi.fn(),
         compactThread: vi.fn(),
         interruptTurn: vi.fn(),
         steerTurn: vi.fn(),
@@ -372,7 +386,9 @@ describe("federation backend bridge", () => {
         setThreadModelSettings: vi.fn(),
         submitServerRequest: vi.fn(),
         runCodexEnvironmentAction: vi.fn(),
+        stopCodexEnvironmentAction: vi.fn(),
         setCodexThreadEnvironment: vi.fn(),
+        materializeDirectoryLaunchpad: vi.fn(),
         handoffThreadWorkspace: vi.fn(),
       } as FederationBackendOperations,
     });

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import type { FederationProtocolEnvelope } from "@pwragent/shared";
+import type {
+  FederationProtocolEnvelope,
+  TrustCodexProjectRequest,
+} from "@pwragent/shared";
 import {
   FEDERATION_BACKEND_METHODS,
   FEDERATION_BACKEND_METHOD_CAPABILITIES,
@@ -248,6 +251,9 @@ describe("federation backend bridge", () => {
       setCodexThreadEnvironment: vi.fn(),
       materializeDirectoryLaunchpad: vi.fn(),
       handoffThreadWorkspace: vi.fn(),
+      renameThread: vi.fn(),
+      openApplication: vi.fn(),
+      trustCodexProject: vi.fn(),
     };
     const replies: FederationProtocolEnvelope[] = [];
     const router = new FederationRouter({
@@ -390,6 +396,9 @@ describe("federation backend bridge", () => {
         setCodexThreadEnvironment: vi.fn(),
         materializeDirectoryLaunchpad: vi.fn(),
         handoffThreadWorkspace: vi.fn(),
+        renameThread: vi.fn(),
+        openApplication: vi.fn(),
+        trustCodexProject: vi.fn(),
       } as FederationBackendOperations,
     });
 
@@ -420,6 +429,119 @@ describe("federation backend bridge", () => {
         kind: "error",
         requestId: "env-request",
         error: { code: "capability_denied" },
+      },
+    ]);
+  });
+
+  it("routes remote thread renames and application opens to the target instance", async () => {
+    const backend = {
+      renameThread: vi.fn(async () => ({
+        backend: "codex" as const,
+        threadId: "thread-1",
+        renamedAt: 2_000,
+      })),
+      openApplication: vi.fn(async () => ({ opened: true as const })),
+      trustCodexProject: vi.fn(async (request: TrustCodexProjectRequest) => ({
+        ...request,
+        trusted: true,
+      })),
+    } as unknown as FederationBackendOperations;
+    const replies: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({
+      localInstanceId: "client_one",
+      methodCapabilities: FEDERATION_BACKEND_METHOD_CAPABILITIES,
+    });
+    router.registerConnection({
+      peerId: "gateway_one",
+      capabilities: [
+        "turn_control",
+        "remote_window",
+        "environment_actions",
+      ],
+      sendEnvelope: (envelope) => replies.push(envelope),
+    });
+    registerFederationBackendHandlers({ router, backend });
+
+    await router.routeEnvelope({
+      sourcePeerId: "gateway_one",
+      envelope: {
+        id: "rename-request",
+        kind: "request",
+        method: FEDERATION_BACKEND_METHODS.renameThread,
+        params: {
+          backend: "codex",
+          threadId: "thread-1",
+          name: "Remote title",
+        },
+        protocolVersion: 1,
+        sourceInstanceId: "gateway_one",
+        targetInstanceId: "client_one",
+        createdAt: 1_000,
+      },
+    });
+    await router.routeEnvelope({
+      sourcePeerId: "gateway_one",
+      envelope: {
+        id: "application-request",
+        kind: "request",
+        method: FEDERATION_BACKEND_METHODS.openApplication,
+        params: {
+          applicationId: "terminal",
+          kind: "terminal",
+          targetPath: "/remote/repo",
+        },
+        protocolVersion: 1,
+        sourceInstanceId: "gateway_one",
+        targetInstanceId: "client_one",
+        createdAt: 1_100,
+      },
+    });
+    await router.routeEnvelope({
+      sourcePeerId: "gateway_one",
+      envelope: {
+        id: "trust-request",
+        kind: "request",
+        method: FEDERATION_BACKEND_METHODS.trustCodexProject,
+        params: {
+          projectPath: "/remote/repo",
+          configPath: "/remote/.codex/config.toml",
+        },
+        protocolVersion: 1,
+        sourceInstanceId: "gateway_one",
+        targetInstanceId: "client_one",
+        createdAt: 1_200,
+      },
+    });
+
+    expect(backend.renameThread).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      name: "Remote title",
+    });
+    expect(backend.openApplication).toHaveBeenCalledWith({
+      applicationId: "terminal",
+      kind: "terminal",
+      targetPath: "/remote/repo",
+    });
+    expect(backend.trustCodexProject).toHaveBeenCalledWith({
+      projectPath: "/remote/repo",
+      configPath: "/remote/.codex/config.toml",
+    });
+    expect(replies).toMatchObject([
+      {
+        kind: "response",
+        requestId: "rename-request",
+        result: { renamedAt: 2_000 },
+      },
+      {
+        kind: "response",
+        requestId: "application-request",
+        result: { opened: true },
+      },
+      {
+        kind: "response",
+        requestId: "trust-request",
+        result: { trusted: true },
       },
     ]);
   });

--- a/apps/desktop/src/main/__tests__/federation-enrollment.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-enrollment.test.ts
@@ -44,7 +44,7 @@ describe("federation enrollment", () => {
     const message = buildFederationProofMessage({
       purpose: "enroll",
       gatewayInstanceId: "gateway_one",
-      peerInstanceId: "child_one",
+      peerInstanceId: "client_one",
       publicKeyPem: keyPair.publicKeyPem,
       protocolVersion: 1,
       nonce: "nonce-1",
@@ -57,9 +57,9 @@ describe("federation enrollment", () => {
       inviteToken: invite.token,
       now: 1_500,
       peer: {
-        instanceId: "child_one",
-        label: "Child",
-        role: "child",
+        instanceId: "client_one",
+        label: "Client",
+        role: "client",
         publicKeyPem: keyPair.publicKeyPem,
         capabilities,
         protocolVersion: 1,
@@ -74,18 +74,18 @@ describe("federation enrollment", () => {
     expect(decision).toMatchObject({
       accepted: true,
       peer: {
-        id: "child_one",
-        label: "Child",
+        id: "client_one",
+        label: "Client",
         status: "connected",
         capabilities,
       },
     });
-    expect(store.getPeer("child_one")).toMatchObject({
+    expect(store.getPeer("client_one")).toMatchObject({
       pinnedPublicKeyPem: keyPair.publicKeyPem,
     });
     expect(store.getEnrollment(invite.id)).toMatchObject({
       status: "used",
-      peerId: "child_one",
+      peerId: "client_one",
     });
   });
 
@@ -101,7 +101,7 @@ describe("federation enrollment", () => {
     const message = buildFederationProofMessage({
       purpose: "enroll",
       gatewayInstanceId: "gateway_one",
-      peerInstanceId: "child_one",
+      peerInstanceId: "client_one",
       publicKeyPem: keyPair.publicKeyPem,
       protocolVersion: 1,
       nonce: "nonce-1",
@@ -115,9 +115,9 @@ describe("federation enrollment", () => {
         inviteToken: invite.token,
         now: 1_500,
         peer: {
-          instanceId: "child_one",
-          label: "Child",
-          role: "child",
+          instanceId: "client_one",
+          label: "Client",
+          role: "client",
           publicKeyPem: keyPair.publicKeyPem,
           capabilities: ["remote_window"],
           protocolVersion: 1,
@@ -140,9 +140,9 @@ describe("federation enrollment", () => {
         inviteToken: invite.token,
         now: 1_500,
         peer: {
-          instanceId: "child_one",
-          label: "Child",
-          role: "child",
+          instanceId: "client_one",
+          label: "Client",
+          role: "client",
           publicKeyPem: keyPair.publicKeyPem,
           capabilities: ["remote_window"],
           protocolVersion: 1,
@@ -164,9 +164,9 @@ describe("federation enrollment", () => {
       inviteToken: invite.token,
       now: 1_500,
       peer: {
-        instanceId: "child_one",
-        label: "Child",
-        role: "child",
+        instanceId: "client_one",
+        label: "Client",
+        role: "client",
         publicKeyPem: keyPair.publicKeyPem,
         capabilities: ["remote_window"],
         protocolVersion: 1,
@@ -185,9 +185,9 @@ describe("federation enrollment", () => {
         inviteToken: invite.token,
         now: 1_600,
         peer: {
-          instanceId: "child_two",
-          label: "Child 2",
-          role: "child",
+          instanceId: "client_two",
+          label: "Client 2",
+          role: "client",
           publicKeyPem: keyPair.publicKeyPem,
           capabilities: ["remote_window"],
           protocolVersion: 1,
@@ -209,9 +209,9 @@ describe("federation enrollment", () => {
     store.upsertPeer({
       updatedAt: 1_000,
       peer: {
-        id: "child_one",
-        label: "Child",
-        role: "child",
+        id: "client_one",
+        label: "Client",
+        role: "client",
         status: "disconnected",
         capabilities: ["remote_window"],
         protocolVersion: 1,
@@ -221,7 +221,7 @@ describe("federation enrollment", () => {
     const message = buildFederationProofMessage({
       purpose: "reconnect",
       gatewayInstanceId: "gateway_one",
-      peerInstanceId: "child_one",
+      peerInstanceId: "client_one",
       publicKeyPem: keyPair.publicKeyPem,
       protocolVersion: 1,
       nonce: "nonce-3",
@@ -232,7 +232,7 @@ describe("federation enrollment", () => {
       authenticateFederationReconnect({
         store,
         gatewayInstanceId: "gateway_one",
-        peerInstanceId: "child_one",
+        peerInstanceId: "client_one",
         protocolVersion: 1,
         nonce: "nonce-3",
         requestedCapabilities: ["remote_window"],
@@ -244,14 +244,14 @@ describe("federation enrollment", () => {
       }),
     ).toMatchObject({
       accepted: true,
-      peer: { id: "child_one", status: "connected" },
+      peer: { id: "client_one", status: "connected" },
     });
 
     expect(
       authenticateFederationReconnect({
         store,
         gatewayInstanceId: "gateway_one",
-        peerInstanceId: "child_one",
+        peerInstanceId: "client_one",
         protocolVersion: 1,
         nonce: "nonce-4",
         requestedCapabilities: ["gateway_relay"],

--- a/apps/desktop/src/main/__tests__/federation-enrollment.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-enrollment.test.ts
@@ -1,0 +1,269 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  buildFederationProofMessage,
+  completeFederationEnrollment,
+  createFederationEnrollmentInvite,
+  authenticateFederationReconnect,
+} from "../federation/federation-enrollment";
+import {
+  generateFederationIdentityKeyPair,
+  signFederationMessage,
+} from "../federation/federation-identity";
+import { FederationStore } from "../federation/federation-store";
+import { StateDb } from "../state/state-db";
+
+let stateDb: StateDb;
+let store: FederationStore;
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-federation-auth-"));
+  stateDb = StateDb.open(path.join(tempDir, "state.db"));
+  store = new FederationStore(stateDb);
+});
+
+afterEach(() => {
+  stateDb.close();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("federation enrollment", () => {
+  it("enrolls a peer with a valid invite and signed key proof", () => {
+    const keyPair = generateFederationIdentityKeyPair();
+    const capabilities = ["remote_window", "federated_search"] as const;
+    const invite = createFederationEnrollmentInvite({
+      store,
+      token: "invite-token-1234567890",
+      gatewayInstanceId: "gateway_one",
+      generatedAt: 1_000,
+      expiresAt: 2_000,
+    });
+    const message = buildFederationProofMessage({
+      purpose: "enroll",
+      gatewayInstanceId: "gateway_one",
+      peerInstanceId: "child_one",
+      publicKeyPem: keyPair.publicKeyPem,
+      protocolVersion: 1,
+      nonce: "nonce-1",
+      capabilities,
+    });
+
+    const decision = completeFederationEnrollment({
+      store,
+      gatewayInstanceId: "gateway_one",
+      inviteToken: invite.token,
+      now: 1_500,
+      peer: {
+        instanceId: "child_one",
+        label: "Child",
+        role: "child",
+        publicKeyPem: keyPair.publicKeyPem,
+        capabilities,
+        protocolVersion: 1,
+        nonce: "nonce-1",
+        signatureBase64: signFederationMessage({
+          privateKeyPem: keyPair.privateKeyPem,
+          message,
+        }),
+      },
+    });
+
+    expect(decision).toMatchObject({
+      accepted: true,
+      peer: {
+        id: "child_one",
+        label: "Child",
+        status: "connected",
+        capabilities,
+      },
+    });
+    expect(store.getPeer("child_one")).toMatchObject({
+      pinnedPublicKeyPem: keyPair.publicKeyPem,
+    });
+    expect(store.getEnrollment(invite.id)).toMatchObject({
+      status: "used",
+      peerId: "child_one",
+    });
+  });
+
+  it("rejects bad signatures, wrong gateway invites, and reused invites", () => {
+    const keyPair = generateFederationIdentityKeyPair();
+    const invite = createFederationEnrollmentInvite({
+      store,
+      token: "invite-token-1234567890",
+      gatewayInstanceId: "gateway_one",
+      generatedAt: 1_000,
+      expiresAt: 2_000,
+    });
+    const message = buildFederationProofMessage({
+      purpose: "enroll",
+      gatewayInstanceId: "gateway_one",
+      peerInstanceId: "child_one",
+      publicKeyPem: keyPair.publicKeyPem,
+      protocolVersion: 1,
+      nonce: "nonce-1",
+      capabilities: ["remote_window"],
+    });
+
+    expect(
+      completeFederationEnrollment({
+        store,
+        gatewayInstanceId: "gateway_two",
+        inviteToken: invite.token,
+        now: 1_500,
+        peer: {
+          instanceId: "child_one",
+          label: "Child",
+          role: "child",
+          publicKeyPem: keyPair.publicKeyPem,
+          capabilities: ["remote_window"],
+          protocolVersion: 1,
+          nonce: "nonce-1",
+          signatureBase64: signFederationMessage({
+            privateKeyPem: keyPair.privateKeyPem,
+            message,
+          }),
+        },
+      }),
+    ).toMatchObject({
+      accepted: false,
+      failure: { code: "wrong_gateway" },
+    });
+
+    expect(
+      completeFederationEnrollment({
+        store,
+        gatewayInstanceId: "gateway_one",
+        inviteToken: invite.token,
+        now: 1_500,
+        peer: {
+          instanceId: "child_one",
+          label: "Child",
+          role: "child",
+          publicKeyPem: keyPair.publicKeyPem,
+          capabilities: ["remote_window"],
+          protocolVersion: 1,
+          nonce: "nonce-1",
+          signatureBase64: signFederationMessage({
+            privateKeyPem: keyPair.privateKeyPem,
+            message: "tampered",
+          }),
+        },
+      }),
+    ).toMatchObject({
+      accepted: false,
+      failure: { code: "bad_signature" },
+    });
+
+    const accepted = completeFederationEnrollment({
+      store,
+      gatewayInstanceId: "gateway_one",
+      inviteToken: invite.token,
+      now: 1_500,
+      peer: {
+        instanceId: "child_one",
+        label: "Child",
+        role: "child",
+        publicKeyPem: keyPair.publicKeyPem,
+        capabilities: ["remote_window"],
+        protocolVersion: 1,
+        nonce: "nonce-1",
+        signatureBase64: signFederationMessage({
+          privateKeyPem: keyPair.privateKeyPem,
+          message,
+        }),
+      },
+    });
+    expect(accepted.accepted).toBe(true);
+    expect(
+      completeFederationEnrollment({
+        store,
+        gatewayInstanceId: "gateway_one",
+        inviteToken: invite.token,
+        now: 1_600,
+        peer: {
+          instanceId: "child_two",
+          label: "Child 2",
+          role: "child",
+          publicKeyPem: keyPair.publicKeyPem,
+          capabilities: ["remote_window"],
+          protocolVersion: 1,
+          nonce: "nonce-2",
+          signatureBase64: signFederationMessage({
+            privateKeyPem: keyPair.privateKeyPem,
+            message,
+          }),
+        },
+      }),
+    ).toMatchObject({
+      accepted: false,
+      failure: { code: "missing_invite" },
+    });
+  });
+
+  it("authenticates enrolled reconnects and rejects denied capabilities", () => {
+    const keyPair = generateFederationIdentityKeyPair();
+    store.upsertPeer({
+      updatedAt: 1_000,
+      peer: {
+        id: "child_one",
+        label: "Child",
+        role: "child",
+        status: "disconnected",
+        capabilities: ["remote_window"],
+        protocolVersion: 1,
+        pinnedPublicKeyPem: keyPair.publicKeyPem,
+      },
+    });
+    const message = buildFederationProofMessage({
+      purpose: "reconnect",
+      gatewayInstanceId: "gateway_one",
+      peerInstanceId: "child_one",
+      publicKeyPem: keyPair.publicKeyPem,
+      protocolVersion: 1,
+      nonce: "nonce-3",
+      capabilities: ["remote_window"],
+    });
+
+    expect(
+      authenticateFederationReconnect({
+        store,
+        gatewayInstanceId: "gateway_one",
+        peerInstanceId: "child_one",
+        protocolVersion: 1,
+        nonce: "nonce-3",
+        requestedCapabilities: ["remote_window"],
+        signatureBase64: signFederationMessage({
+          privateKeyPem: keyPair.privateKeyPem,
+          message,
+        }),
+        now: 2_000,
+      }),
+    ).toMatchObject({
+      accepted: true,
+      peer: { id: "child_one", status: "connected" },
+    });
+
+    expect(
+      authenticateFederationReconnect({
+        store,
+        gatewayInstanceId: "gateway_one",
+        peerInstanceId: "child_one",
+        protocolVersion: 1,
+        nonce: "nonce-4",
+        requestedCapabilities: ["gateway_relay"],
+        signatureBase64: signFederationMessage({
+          privateKeyPem: keyPair.privateKeyPem,
+          message,
+        }),
+        now: 2_100,
+      }),
+    ).toMatchObject({
+      accepted: false,
+      failure: { code: "capability_denied" },
+    });
+  });
+});

--- a/apps/desktop/src/main/__tests__/federation-enrollment.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-enrollment.test.ts
@@ -6,6 +6,8 @@ import {
   buildFederationProofMessage,
   completeFederationEnrollment,
   createFederationEnrollmentInvite,
+  decodeFederationInvite,
+  encodeFederationInvite,
   authenticateFederationReconnect,
 } from "../federation/federation-enrollment";
 import {
@@ -31,6 +33,30 @@ afterEach(() => {
 });
 
 describe("federation enrollment", () => {
+  it("carries the pinned gateway public key in a one-time invite", () => {
+    const gatewayKeyPair = generateFederationIdentityKeyPair();
+    const invite = encodeFederationInvite({
+      version: 1,
+      token: "invite-token-1234567890",
+      gatewayInstanceId: "gateway_one",
+      gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+      gatewayUrl: "ws://127.0.0.1:47830",
+      expiresAt: 2_000,
+    });
+
+    expect(decodeFederationInvite(invite, 1_000)).toEqual({
+      version: 1,
+      token: "invite-token-1234567890",
+      gatewayInstanceId: "gateway_one",
+      gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+      gatewayUrl: "ws://127.0.0.1:47830",
+      expiresAt: 2_000,
+    });
+    expect(() => decodeFederationInvite(invite, 2_000)).toThrow(
+      "Federation invite has expired.",
+    );
+  });
+
   it("enrolls a peer with a valid invite and signed key proof", () => {
     const keyPair = generateFederationIdentityKeyPair();
     const capabilities = ["remote_window", "federated_search"] as const;

--- a/apps/desktop/src/main/__tests__/federation-health.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-health.test.ts
@@ -12,9 +12,9 @@ import {
 describe("federation health", () => {
   it("reports the configured listener and peers without exposing key material", () => {
     const peer = {
-      id: "child_one",
+      id: "client_one",
       label: "Studio Mac",
-      role: "child",
+      role: "client",
       status: "connected",
       capabilities: ["thread_navigation"],
       protocolVersion: 1,
@@ -40,9 +40,9 @@ describe("federation health", () => {
       publicUrl: "wss://pwragent.example.com/federation",
     });
     expect(health.peers[0]).toEqual({
-      id: "child_one",
+      id: "client_one",
       label: "Studio Mac",
-      role: "child",
+      role: "client",
       status: "connected",
       capabilities: ["thread_navigation"],
       protocolVersion: 1,
@@ -70,9 +70,9 @@ describe("federation health", () => {
 
   it("copies peer capabilities when normalizing public summaries", () => {
     const peer: FederationPeerSummary = {
-      id: "child_one",
+      id: "client_one",
       label: "Studio Mac",
-      role: "child",
+      role: "client",
       status: "connected",
       capabilities: ["thread_navigation"],
     };

--- a/apps/desktop/src/main/__tests__/federation-health.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-health.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import type {
+  DesktopFederationMode,
+  DesktopSettingsSnapshot,
+  FederationPeerSummary,
+} from "@pwragent/shared";
+import {
+  buildFederationHealthStatus,
+  publicPeerSummary,
+} from "../federation/federation-health";
+
+describe("federation health", () => {
+  it("reports the configured listener and peers without exposing key material", () => {
+    const peer = {
+      id: "child_one",
+      label: "Studio Mac",
+      role: "child",
+      status: "connected",
+      capabilities: ["thread_navigation"],
+      protocolVersion: 1,
+      endpoint: "wss://pwragent.example.com/federation",
+      pinnedPublicKeyPem: "secret-public-key",
+    } as FederationPeerSummary & { pinnedPublicKeyPem: string };
+
+    const health = buildFederationHealthStatus({
+      settings: settingsSnapshot({
+        mode: "gateway",
+        publicUrl: "wss://pwragent.example.com/federation",
+      }),
+      peers: [peer],
+      instanceId: "master_one",
+    });
+
+    expect(health).toMatchObject({
+      enabled: true,
+      role: "gateway",
+      status: "listening",
+      instanceId: "master_one",
+      listenUrl: "ws://127.0.0.1:8765",
+      publicUrl: "wss://pwragent.example.com/federation",
+    });
+    expect(health.peers[0]).toEqual({
+      id: "child_one",
+      label: "Studio Mac",
+      role: "child",
+      status: "connected",
+      capabilities: ["thread_navigation"],
+      protocolVersion: 1,
+      endpoint: "wss://pwragent.example.com/federation",
+      profileName: undefined,
+      lastConnectedAt: undefined,
+      lastActivityAt: undefined,
+      revokedAt: undefined,
+      unavailableReason: undefined,
+    });
+    expect("pinnedPublicKeyPem" in health.peers[0]).toBe(false);
+  });
+
+  it("reports disabled mode without listener or public URL", () => {
+    const health = buildFederationHealthStatus({
+      settings: settingsSnapshot({ mode: "disabled", publicUrl: "" }),
+      peers: [],
+    });
+
+    expect(health.enabled).toBe(false);
+    expect(health.status).toBe("disabled");
+    expect(health.listenUrl).toBeUndefined();
+    expect(health.publicUrl).toBeUndefined();
+  });
+
+  it("copies peer capabilities when normalizing public summaries", () => {
+    const peer: FederationPeerSummary = {
+      id: "child_one",
+      label: "Studio Mac",
+      role: "child",
+      status: "connected",
+      capabilities: ["thread_navigation"],
+    };
+
+    const summary = publicPeerSummary(peer);
+    summary.capabilities.push("thread_detail");
+
+    expect(peer.capabilities).toEqual(["thread_navigation"]);
+  });
+});
+
+function settingsSnapshot(params: {
+  mode: DesktopFederationMode;
+  publicUrl: string;
+}): DesktopSettingsSnapshot {
+  return {
+    federation: {
+      mode: { value: params.mode, source: "config" },
+      listenHost: { value: "127.0.0.1", source: "config" },
+      listenPort: { value: 8765, source: "config" },
+      publicUrl: { value: params.publicUrl, source: "config" },
+    },
+  } as DesktopSettingsSnapshot;
+}

--- a/apps/desktop/src/main/__tests__/federation-health.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-health.test.ts
@@ -29,6 +29,7 @@ describe("federation health", () => {
       }),
       peers: [peer],
       instanceId: "master_one",
+      listenUrl: "ws://127.0.0.1:8765",
     });
 
     expect(health).toMatchObject({
@@ -45,6 +46,7 @@ describe("federation health", () => {
       role: "client",
       status: "connected",
       capabilities: ["thread_navigation"],
+      canRevoke: undefined,
       protocolVersion: 1,
       endpoint: "wss://pwragent.example.com/federation",
       profileName: undefined,
@@ -66,6 +68,18 @@ describe("federation health", () => {
     expect(health.status).toBe("disabled");
     expect(health.listenUrl).toBeUndefined();
     expect(health.publicUrl).toBeUndefined();
+  });
+
+  it("reports a bind failure instead of claiming the configured listener", () => {
+    const health = buildFederationHealthStatus({
+      settings: settingsSnapshot({ mode: "gateway", publicUrl: "" }),
+      peers: [],
+      unavailableReason: "listen EADDRINUSE: address already in use 127.0.0.1:8765",
+    });
+
+    expect(health.status).toBe("degraded");
+    expect(health.listenUrl).toBeUndefined();
+    expect(health.unavailableReason).toContain("EADDRINUSE");
   });
 
   it("copies peer capabilities when normalizing public summaries", () => {

--- a/apps/desktop/src/main/__tests__/federation-identity.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-identity.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { MemoryDesktopSecretStore } from "../settings/desktop-secret-store";
+import {
+  generateFederationIdentityKeyPair,
+  getOrCreateFederationIdentity,
+  signFederationMessage,
+  verifyFederationMessageSignature,
+} from "../federation/federation-identity";
+
+describe("federation identity", () => {
+  it("generates an Ed25519 identity and verifies signatures", () => {
+    const keyPair = generateFederationIdentityKeyPair();
+    const signatureBase64 = signFederationMessage({
+      privateKeyPem: keyPair.privateKeyPem,
+      message: "hello",
+    });
+
+    expect(
+      verifyFederationMessageSignature({
+        publicKeyPem: keyPair.publicKeyPem,
+        message: "hello",
+        signatureBase64,
+      }),
+    ).toBe(true);
+    expect(
+      verifyFederationMessageSignature({
+        publicKeyPem: keyPair.publicKeyPem,
+        message: "tampered",
+        signatureBase64,
+      }),
+    ).toBe(false);
+  });
+
+  it("stores the local private key and reuses it", async () => {
+    const secretStore = new MemoryDesktopSecretStore();
+
+    const first = await getOrCreateFederationIdentity(secretStore);
+    const second = await getOrCreateFederationIdentity(secretStore);
+
+    expect(first.publicKeyPem).toBe(second.publicKeyPem);
+    expect(
+      await secretStore.getSecret("federationInstancePrivateKey"),
+    ).toContain("BEGIN PRIVATE KEY");
+  });
+});

--- a/apps/desktop/src/main/__tests__/federation-policy.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-policy.test.ts
@@ -19,9 +19,9 @@ describe("federation policy", () => {
     expect(
       evaluateFederationSessionPolicy({
         peer: {
-          id: "child_one",
-          label: "Child",
-          role: "child",
+          id: "client_one",
+          label: "Client",
+          role: "client",
           status: "revoked",
           revokedAt: 1_000,
           capabilities: ["remote_window"],
@@ -37,9 +37,9 @@ describe("federation policy", () => {
     expect(
       evaluateFederationSessionPolicy({
         peer: {
-          id: "child_one",
-          label: "Child",
-          role: "child",
+          id: "client_one",
+          label: "Client",
+          role: "client",
           status: "connected",
           capabilities: ["remote_window"],
         },
@@ -54,9 +54,9 @@ describe("federation policy", () => {
     expect(
       evaluateFederationSessionPolicy({
         peer: {
-          id: "child_one",
-          label: "Child",
-          role: "child",
+          id: "client_one",
+          label: "Client",
+          role: "client",
           status: "connected",
           capabilities: ["remote_window"],
         },
@@ -89,13 +89,13 @@ describe("FederationSessionRegistry", () => {
 
     registry.openSession({
       sessionId: "session-1",
-      peerId: "child_one",
+      peerId: "client_one",
       connectedAt: 1_000,
       capabilities: ["remote_window"],
     });
     registry.openSession({
       sessionId: "session-2",
-      peerId: "child_one",
+      peerId: "client_one",
       connectedAt: 1_100,
       capabilities: ["remote_window"],
     });
@@ -110,7 +110,7 @@ describe("FederationSessionRegistry", () => {
 
     expect(
       registry.closePeerSessions({
-        peerId: "child_one",
+        peerId: "client_one",
         closedAt: 1_200,
         reason: "revoked",
       }),
@@ -119,7 +119,7 @@ describe("FederationSessionRegistry", () => {
 
     registry.openSession({
       sessionId: "session-3",
-      peerId: "child_two",
+      peerId: "client_two",
       connectedAt: 2_000,
       capabilities: ["federated_search"],
     });

--- a/apps/desktop/src/main/__tests__/federation-policy.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-policy.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import { evaluateFederationSessionPolicy } from "../federation/federation-policy";
+import { redactFederationDiagnostic } from "../federation/federation-redaction";
+import { FederationSessionRegistry } from "../federation/federation-session-state";
+
+describe("federation policy", () => {
+  it("fails closed for unknown, revoked, version-mismatched, and denied peers", () => {
+    expect(
+      evaluateFederationSessionPolicy({
+        peer: undefined,
+        protocolVersion: 1,
+        requestedCapabilities: ["remote_window"],
+      }),
+    ).toMatchObject({
+      accepted: false,
+      failure: { code: "unknown_peer" },
+    });
+
+    expect(
+      evaluateFederationSessionPolicy({
+        peer: {
+          id: "child_one",
+          label: "Child",
+          role: "child",
+          status: "revoked",
+          revokedAt: 1_000,
+          capabilities: ["remote_window"],
+        },
+        protocolVersion: 1,
+        requestedCapabilities: ["remote_window"],
+      }),
+    ).toMatchObject({
+      accepted: false,
+      failure: { code: "revoked_peer" },
+    });
+
+    expect(
+      evaluateFederationSessionPolicy({
+        peer: {
+          id: "child_one",
+          label: "Child",
+          role: "child",
+          status: "connected",
+          capabilities: ["remote_window"],
+        },
+        protocolVersion: 99,
+        requestedCapabilities: ["remote_window"],
+      }),
+    ).toMatchObject({
+      accepted: false,
+      failure: { code: "invalid_protocol_version" },
+    });
+
+    expect(
+      evaluateFederationSessionPolicy({
+        peer: {
+          id: "child_one",
+          label: "Child",
+          role: "child",
+          status: "connected",
+          capabilities: ["remote_window"],
+        },
+        protocolVersion: 1,
+        requestedCapabilities: ["gateway_relay"],
+      }),
+    ).toMatchObject({
+      accepted: false,
+      failure: { code: "capability_denied" },
+    });
+  });
+
+  it("redacts PEM blocks and token-like diagnostics", () => {
+    expect(
+      redactFederationDiagnostic(
+        [
+          "bad token abcdefghijklmnopqrstuvwxyz1234567890",
+          "-----BEGIN PRIVATE KEY-----",
+          "secret",
+          "-----END PRIVATE KEY-----",
+        ].join("\n"),
+      ),
+    ).toBe("bad token [redacted-token]\n[redacted-pem]");
+  });
+});
+
+describe("FederationSessionRegistry", () => {
+  it("replaces duplicate sessions and closes revoked or stale sessions", () => {
+    const registry = new FederationSessionRegistry();
+
+    registry.openSession({
+      sessionId: "session-1",
+      peerId: "child_one",
+      connectedAt: 1_000,
+      capabilities: ["remote_window"],
+    });
+    registry.openSession({
+      sessionId: "session-2",
+      peerId: "child_one",
+      connectedAt: 1_100,
+      capabilities: ["remote_window"],
+    });
+
+    expect(registry.getSession("session-1")).toMatchObject({
+      status: "closed",
+      closeReason: "replaced",
+    });
+    expect(registry.listActiveSessions()).toMatchObject([
+      { sessionId: "session-2", status: "active" },
+    ]);
+
+    expect(
+      registry.closePeerSessions({
+        peerId: "child_one",
+        closedAt: 1_200,
+        reason: "revoked",
+      }),
+    ).toHaveLength(1);
+    expect(registry.listActiveSessions()).toEqual([]);
+
+    registry.openSession({
+      sessionId: "session-3",
+      peerId: "child_two",
+      connectedAt: 2_000,
+      capabilities: ["federated_search"],
+    });
+    expect(
+      registry.expireStaleSessions({
+        now: 2_500,
+        heartbeatTimeoutMs: 400,
+      }),
+    ).toMatchObject([{ sessionId: "session-3", closeReason: "timeout" }]);
+  });
+});

--- a/apps/desktop/src/main/__tests__/federation-router.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-router.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+import type { FederationProtocolEnvelope } from "@pwragent/shared";
+import { FederationRouter } from "../federation/federation-router";
+
+describe("FederationRouter", () => {
+  it("handles local requests and replies to the source peer", async () => {
+    const replies: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({
+      localInstanceId: "gateway_one",
+      methodCapabilities: {
+        "thread.list": "thread_navigation",
+      },
+      now: () => 2_000,
+    });
+    router.registerConnection({
+      peerId: "child_one",
+      capabilities: ["thread_navigation"],
+      sendEnvelope: (envelope) => replies.push(envelope),
+    });
+    router.registerHandler("thread.list", () => ({ threads: [] }));
+
+    await expect(
+      router.routeEnvelope({
+        sourcePeerId: "child_one",
+        envelope: {
+          id: "request-1",
+          kind: "request",
+          method: "thread.list",
+          params: {},
+          protocolVersion: 1,
+          sourceInstanceId: "child_one",
+          targetInstanceId: "gateway_one",
+          createdAt: 1_000,
+        },
+      }),
+    ).resolves.toMatchObject({
+      status: "handled",
+      response: {
+        kind: "response",
+        requestId: "request-1",
+        result: { threads: [] },
+      },
+    });
+    expect(replies).toMatchObject([
+      {
+        kind: "response",
+        requestId: "request-1",
+        targetInstanceId: "child_one",
+      },
+    ]);
+  });
+
+  it("relays child-to-child envelopes when the source is authorized", async () => {
+    const relayed: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({
+      localInstanceId: "gateway_one",
+    });
+    router.registerConnection({
+      peerId: "child_one",
+      capabilities: ["gateway_relay"],
+      sendEnvelope: () => undefined,
+    });
+    router.registerConnection({
+      peerId: "child_two",
+      capabilities: ["remote_window"],
+      sendEnvelope: (envelope) => relayed.push(envelope),
+    });
+
+    await expect(
+      router.routeEnvelope({
+        sourcePeerId: "child_one",
+        envelope: {
+          id: "request-1",
+          kind: "request",
+          method: "thread.read",
+          params: {},
+          protocolVersion: 1,
+          sourceInstanceId: "child_one",
+          targetInstanceId: "child_two",
+          createdAt: 1_000,
+        },
+      }),
+    ).resolves.toEqual({
+      status: "relayed",
+      targetInstanceId: "child_two",
+    });
+    expect(relayed).toMatchObject([
+      {
+        id: "request-1",
+        targetInstanceId: "child_two",
+        hopCount: 1,
+      },
+    ]);
+  });
+
+  it("fails closed for denied capabilities, unauthorized relay, and expired deadlines", async () => {
+    const replies: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({
+      localInstanceId: "gateway_one",
+      methodCapabilities: {
+        "turn.submit": "turn_control",
+      },
+      now: () => 2_000,
+    });
+    router.registerConnection({
+      peerId: "child_one",
+      capabilities: ["thread_navigation"],
+      sendEnvelope: (envelope) => replies.push(envelope),
+    });
+    router.registerHandler("turn.submit", () => ({ ok: true }));
+
+    await expect(
+      router.routeEnvelope({
+        sourcePeerId: "child_one",
+        envelope: {
+          id: "request-1",
+          kind: "request",
+          method: "turn.submit",
+          params: {},
+          protocolVersion: 1,
+          sourceInstanceId: "child_one",
+          targetInstanceId: "gateway_one",
+          createdAt: 1_000,
+        },
+      }),
+    ).resolves.toMatchObject({
+      status: "rejected",
+      code: "capability_denied",
+    });
+
+    await expect(
+      router.routeEnvelope({
+        sourcePeerId: "child_one",
+        envelope: {
+          id: "request-2",
+          kind: "request",
+          method: "thread.read",
+          params: {},
+          protocolVersion: 1,
+          sourceInstanceId: "child_one",
+          targetInstanceId: "child_two",
+          createdAt: 1_000,
+        },
+      }),
+    ).resolves.toMatchObject({
+      status: "rejected",
+      code: "relay_not_authorized",
+    });
+
+    await expect(
+      router.routeEnvelope({
+        sourcePeerId: "child_one",
+        envelope: {
+          id: "request-3",
+          kind: "request",
+          method: "thread.list",
+          params: {},
+          protocolVersion: 1,
+          sourceInstanceId: "child_one",
+          targetInstanceId: "gateway_one",
+          createdAt: 1_000,
+          deadlineAt: 1_500,
+        },
+      }),
+    ).resolves.toMatchObject({
+      status: "rejected",
+      code: "deadline_expired",
+    });
+
+    expect(replies).toMatchObject([
+      { kind: "error", error: { code: "capability_denied" } },
+      { kind: "error", error: { code: "relay_not_authorized" } },
+      { kind: "error", error: { code: "deadline_expired" } },
+    ]);
+  });
+});

--- a/apps/desktop/src/main/__tests__/federation-router.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-router.test.ts
@@ -13,7 +13,7 @@ describe("FederationRouter", () => {
       now: () => 2_000,
     });
     router.registerConnection({
-      peerId: "child_one",
+      peerId: "client_one",
       capabilities: ["thread_navigation"],
       sendEnvelope: (envelope) => replies.push(envelope),
     });
@@ -21,14 +21,14 @@ describe("FederationRouter", () => {
 
     await expect(
       router.routeEnvelope({
-        sourcePeerId: "child_one",
+        sourcePeerId: "client_one",
         envelope: {
           id: "request-1",
           kind: "request",
           method: "thread.list",
           params: {},
           protocolVersion: 1,
-          sourceInstanceId: "child_one",
+          sourceInstanceId: "client_one",
           targetInstanceId: "gateway_one",
           createdAt: 1_000,
         },
@@ -45,49 +45,49 @@ describe("FederationRouter", () => {
       {
         kind: "response",
         requestId: "request-1",
-        targetInstanceId: "child_one",
+        targetInstanceId: "client_one",
       },
     ]);
   });
 
-  it("relays child-to-child envelopes when the source is authorized", async () => {
+  it("relays client-to-client envelopes when the source is authorized", async () => {
     const relayed: FederationProtocolEnvelope[] = [];
     const router = new FederationRouter({
       localInstanceId: "gateway_one",
     });
     router.registerConnection({
-      peerId: "child_one",
+      peerId: "client_one",
       capabilities: ["gateway_relay"],
       sendEnvelope: () => undefined,
     });
     router.registerConnection({
-      peerId: "child_two",
+      peerId: "client_two",
       capabilities: ["remote_window"],
       sendEnvelope: (envelope) => relayed.push(envelope),
     });
 
     await expect(
       router.routeEnvelope({
-        sourcePeerId: "child_one",
+        sourcePeerId: "client_one",
         envelope: {
           id: "request-1",
           kind: "request",
           method: "thread.read",
           params: {},
           protocolVersion: 1,
-          sourceInstanceId: "child_one",
-          targetInstanceId: "child_two",
+          sourceInstanceId: "client_one",
+          targetInstanceId: "client_two",
           createdAt: 1_000,
         },
       }),
     ).resolves.toEqual({
       status: "relayed",
-      targetInstanceId: "child_two",
+      targetInstanceId: "client_two",
     });
     expect(relayed).toMatchObject([
       {
         id: "request-1",
-        targetInstanceId: "child_two",
+        targetInstanceId: "client_two",
         hopCount: 1,
       },
     ]);
@@ -103,7 +103,7 @@ describe("FederationRouter", () => {
       now: () => 2_000,
     });
     router.registerConnection({
-      peerId: "child_one",
+      peerId: "client_one",
       capabilities: ["thread_navigation"],
       sendEnvelope: (envelope) => replies.push(envelope),
     });
@@ -111,14 +111,14 @@ describe("FederationRouter", () => {
 
     await expect(
       router.routeEnvelope({
-        sourcePeerId: "child_one",
+        sourcePeerId: "client_one",
         envelope: {
           id: "request-1",
           kind: "request",
           method: "turn.submit",
           params: {},
           protocolVersion: 1,
-          sourceInstanceId: "child_one",
+          sourceInstanceId: "client_one",
           targetInstanceId: "gateway_one",
           createdAt: 1_000,
         },
@@ -130,15 +130,15 @@ describe("FederationRouter", () => {
 
     await expect(
       router.routeEnvelope({
-        sourcePeerId: "child_one",
+        sourcePeerId: "client_one",
         envelope: {
           id: "request-2",
           kind: "request",
           method: "thread.read",
           params: {},
           protocolVersion: 1,
-          sourceInstanceId: "child_one",
-          targetInstanceId: "child_two",
+          sourceInstanceId: "client_one",
+          targetInstanceId: "client_two",
           createdAt: 1_000,
         },
       }),
@@ -149,14 +149,14 @@ describe("FederationRouter", () => {
 
     await expect(
       router.routeEnvelope({
-        sourcePeerId: "child_one",
+        sourcePeerId: "client_one",
         envelope: {
           id: "request-3",
           kind: "request",
           method: "thread.list",
           params: {},
           protocolVersion: 1,
-          sourceInstanceId: "child_one",
+          sourceInstanceId: "client_one",
           targetInstanceId: "gateway_one",
           createdAt: 1_000,
           deadlineAt: 1_500,

--- a/apps/desktop/src/main/__tests__/federation-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-runtime.test.ts
@@ -50,9 +50,9 @@ function createConnection(params: {
 }
 
 describe("DesktopFederationRuntime", () => {
-  it("records gateway-advertised peers for child instance health and opening", () => {
+  it("records gateway-advertised peers for client instance health and opening", () => {
     const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
-    runtime.localInstanceId = "child_one";
+    runtime.localInstanceId = "client_one";
 
     const handled = runtime.applyPeerDirectory({
       id: "peers-1",
@@ -68,16 +68,16 @@ describe("DesktopFederationRuntime", () => {
             capabilities: ["remote_window", "gateway_relay"],
           },
           {
-            id: "child_two",
+            id: "client_two",
             label: "Laptop",
-            role: "child",
+            role: "client",
             status: "connected",
             capabilities: ["remote_window", "thread_detail"],
           },
           {
-            id: "child_one",
+            id: "client_one",
             label: "Self",
-            role: "child",
+            role: "client",
             status: "connected",
             capabilities: ["remote_window"],
           },
@@ -85,7 +85,7 @@ describe("DesktopFederationRuntime", () => {
       },
       protocolVersion: FEDERATION_PROTOCOL_VERSION,
       sourceInstanceId: "gateway_one",
-      targetInstanceId: "child_one",
+      targetInstanceId: "client_one",
       createdAt: 2_000,
     });
 
@@ -98,17 +98,17 @@ describe("DesktopFederationRuntime", () => {
         status: "connected",
       },
       {
-        id: "child_two",
+        id: "client_two",
         label: "Laptop",
-        role: "child",
+        role: "client",
         status: "connected",
       },
     ]);
   });
 
-  it("falls back to the gateway when a child targets a sibling peer", () => {
+  it("falls back to the gateway when a client targets a sibling peer", () => {
     const sentToGateway: FederationProtocolEnvelope[] = [];
-    const router = new FederationRouter({ localInstanceId: "child_one" });
+    const router = new FederationRouter({ localInstanceId: "client_one" });
     router.registerConnection(
       createConnection({
         peerId: "gateway_one",
@@ -118,7 +118,7 @@ describe("DesktopFederationRuntime", () => {
     );
     const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
     runtime.gatewayInstanceId = "gateway_one";
-    runtime.localInstanceId = "child_one";
+    runtime.localInstanceId = "client_one";
     runtime.router = router;
 
     const request: FederationProtocolEnvelope = {
@@ -127,12 +127,12 @@ describe("DesktopFederationRuntime", () => {
       method: "backend.listThreads",
       params: {},
       protocolVersion: FEDERATION_PROTOCOL_VERSION,
-      sourceInstanceId: "child_one",
-      targetInstanceId: "child_two",
+      sourceInstanceId: "client_one",
+      targetInstanceId: "client_two",
       createdAt: 2_000,
     };
 
-    runtime.sendEnvelopeToTarget("child_two", request);
+    runtime.sendEnvelopeToTarget("client_two", request);
 
     expect(sentToGateway).toEqual([request]);
   });
@@ -142,7 +142,7 @@ describe("DesktopFederationRuntime", () => {
     const router = new FederationRouter({ localInstanceId: "gateway_one" });
     router.registerConnection(
       createConnection({
-        peerId: "child_one",
+        peerId: "client_one",
         capabilities: ["remote_window"],
         sendEnvelope: (envelope) => forwarded.push(envelope),
       }),
@@ -186,7 +186,7 @@ describe("DesktopFederationRuntime", () => {
         },
         protocolVersion: FEDERATION_PROTOCOL_VERSION,
         sourceInstanceId: "gateway_one",
-        targetInstanceId: "child_one",
+        targetInstanceId: "client_one",
       },
     ]);
   });
@@ -216,18 +216,18 @@ describe("DesktopFederationRuntime", () => {
           },
         },
         protocolVersion: FEDERATION_PROTOCOL_VERSION,
-        sourceInstanceId: "child_one",
+        sourceInstanceId: "client_one",
         targetInstanceId: "gateway_one",
         createdAt: 2_000,
       },
-      "child_one",
+      "client_one",
     );
 
     expect(handled).toBe(true);
     expect(published).toEqual([
       {
         backend: "codex",
-        federationTarget: { scope: "remote", instanceId: "child_one" },
+        federationTarget: { scope: "remote", instanceId: "client_one" },
         notification: {
           method: "item/agentMessage/delta",
           params: {
@@ -241,18 +241,18 @@ describe("DesktopFederationRuntime", () => {
     ]);
   });
 
-  it("relays child backend events to sibling peers through the gateway", () => {
+  it("relays client backend events to sibling peers through the gateway", () => {
     const relayedToSibling: FederationProtocolEnvelope[] = [];
     const router = new FederationRouter({ localInstanceId: "gateway_one" });
     router.registerConnection(
       createConnection({
-        peerId: "child_one",
+        peerId: "client_one",
         capabilities: ["remote_window"],
       }),
     );
     router.registerConnection(
       createConnection({
-        peerId: "child_two",
+        peerId: "client_two",
         capabilities: ["remote_window"],
         sendEnvelope: (envelope) => relayedToSibling.push(envelope),
       }),
@@ -279,11 +279,11 @@ describe("DesktopFederationRuntime", () => {
           },
         },
         protocolVersion: FEDERATION_PROTOCOL_VERSION,
-        sourceInstanceId: "child_one",
+        sourceInstanceId: "client_one",
         targetInstanceId: "gateway_one",
         createdAt: 2_000,
       },
-      "child_one",
+      "client_one",
     );
 
     expect(relayedToSibling).toMatchObject([
@@ -291,8 +291,8 @@ describe("DesktopFederationRuntime", () => {
         id: "event-1",
         kind: "notification",
         method: FEDERATION_BACKEND_EVENT_METHOD,
-        sourceInstanceId: "child_one",
-        targetInstanceId: "child_two",
+        sourceInstanceId: "client_one",
+        targetInstanceId: "client_two",
         hopCount: 1,
       },
     ]);
@@ -303,13 +303,13 @@ describe("DesktopFederationRuntime", () => {
     const router = new FederationRouter({ localInstanceId: "gateway_one" });
     router.registerConnection(
       createConnection({
-        peerId: "child_one",
+        peerId: "client_one",
         sendEnvelope: (envelope) => relayed.push(envelope),
       }),
     );
     router.registerConnection(
       createConnection({
-        peerId: "child_two",
+        peerId: "client_two",
         capabilities: ["gateway_relay"],
       }),
     );
@@ -322,20 +322,20 @@ describe("DesktopFederationRuntime", () => {
         kind: "response",
         requestId: "request-1",
         protocolVersion: 1,
-        sourceInstanceId: "child_two",
-        targetInstanceId: "child_one",
+        sourceInstanceId: "client_two",
+        targetInstanceId: "client_one",
         createdAt: 2_000,
         result: { ok: true },
       },
-      "child_two",
+      "client_two",
     );
 
     expect(relayed).toMatchObject([
       {
         kind: "response",
         requestId: "request-1",
-        sourceInstanceId: "child_two",
-        targetInstanceId: "child_one",
+        sourceInstanceId: "client_two",
+        targetInstanceId: "client_one",
         hopCount: 1,
       },
     ]);
@@ -346,12 +346,12 @@ describe("DesktopFederationRuntime", () => {
     const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
     runtime.router = router;
     const oldConnection = createConnection({
-      peerId: "child_one",
+      peerId: "client_one",
       sendEnvelope: () => undefined,
     });
     const newSendEnvelope = () => undefined;
     const newConnection = createConnection({
-      peerId: "child_one",
+      peerId: "client_one",
       sendEnvelope: newSendEnvelope,
     });
 
@@ -359,10 +359,10 @@ describe("DesktopFederationRuntime", () => {
     runtime.registerGatewayConnection(newConnection);
     runtime.unregisterGatewayConnection(oldConnection);
 
-    expect(router.getConnection("child_one")?.sendEnvelope).toBe(newSendEnvelope);
+    expect(router.getConnection("client_one")?.sendEnvelope).toBe(newSendEnvelope);
 
     runtime.unregisterGatewayConnection(newConnection);
 
-    expect(router.getConnection("child_one")).toBeUndefined();
+    expect(router.getConnection("client_one")).toBeUndefined();
   });
 });

--- a/apps/desktop/src/main/__tests__/federation-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-runtime.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from "vitest";
+import type {
+  AgentEvent,
+  FederationCapability,
+  FederationInstanceId,
+  FederationProtocolEnvelope,
+} from "@pwragent/shared";
+import { FEDERATION_PROTOCOL_VERSION } from "@pwragent/shared";
+import { FEDERATION_BACKEND_EVENT_METHOD } from "../federation/federation-backend-bridge";
+import { DesktopFederationRuntime } from "../federation/federation-runtime";
+import { FederationRouter } from "../federation/federation-router";
+import type { FederationGatewayConnection } from "../federation/federation-transport";
+
+type RuntimeHarness = {
+  router?: FederationRouter;
+  receiveEnvelope: (
+    envelope: FederationProtocolEnvelope,
+    sourcePeerId: FederationInstanceId,
+  ) => Promise<void>;
+  forwardLocalBackendEvent: (event: AgentEvent) => void;
+  localInstanceId?: FederationInstanceId;
+  publishRemoteBackendEvent: (
+    envelope: FederationProtocolEnvelope,
+    sourcePeerId: FederationInstanceId,
+  ) => boolean;
+  registerGatewayConnection: (connection: FederationGatewayConnection) => void;
+  setAgentEventPublisher: (publisher: (event: AgentEvent) => void) => void;
+  unregisterGatewayConnection: (connection: FederationGatewayConnection) => void;
+};
+
+function createConnection(params: {
+  peerId: FederationInstanceId;
+  capabilities?: FederationCapability[];
+  sendEnvelope?: (envelope: FederationProtocolEnvelope) => void;
+}): FederationGatewayConnection {
+  return {
+    peerId: params.peerId,
+    sessionId: `session:${params.peerId}`,
+    capabilities: params.capabilities ?? ["gateway_relay"],
+    sendEnvelope: params.sendEnvelope ?? (() => undefined),
+    close: () => undefined,
+  };
+}
+
+describe("DesktopFederationRuntime", () => {
+  it("forwards local backend events to remote-capable peers", () => {
+    const forwarded: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({ localInstanceId: "gateway_one" });
+    router.registerConnection(
+      createConnection({
+        peerId: "child_one",
+        capabilities: ["remote_window"],
+        sendEnvelope: (envelope) => forwarded.push(envelope),
+      }),
+    );
+    router.registerConnection(
+      createConnection({
+        peerId: "limited_peer",
+        capabilities: ["messaging_route"],
+        sendEnvelope: (envelope) => forwarded.push(envelope),
+      }),
+    );
+    const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
+    runtime.localInstanceId = "gateway_one";
+    runtime.router = router;
+
+    runtime.forwardLocalBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "thread-1",
+          turn: { id: "turn-1", status: "in_progress" },
+          turnId: "turn-1",
+        },
+      },
+    } as AgentEvent);
+
+    expect(forwarded).toMatchObject([
+      {
+        kind: "notification",
+        method: FEDERATION_BACKEND_EVENT_METHOD,
+        params: {
+          backend: "codex",
+          notification: {
+            method: "turn/started",
+            params: {
+              threadId: "thread-1",
+              turnId: "turn-1",
+            },
+          },
+        },
+        protocolVersion: FEDERATION_PROTOCOL_VERSION,
+        sourceInstanceId: "gateway_one",
+        targetInstanceId: "child_one",
+      },
+    ]);
+  });
+
+  it("publishes remote backend events with the source peer as federation target", () => {
+    const published: AgentEvent[] = [];
+    const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
+    runtime.setAgentEventPublisher((event) => {
+      published.push(event);
+    });
+
+    const handled = runtime.publishRemoteBackendEvent(
+      {
+        id: "event-1",
+        kind: "notification",
+        method: FEDERATION_BACKEND_EVENT_METHOD,
+        params: {
+          backend: "codex",
+          notification: {
+            method: "item/agentMessage/delta",
+            params: {
+              delta: "hello",
+              itemId: "item-1",
+              threadId: "thread-1",
+              turnId: "turn-1",
+            },
+          },
+        },
+        protocolVersion: FEDERATION_PROTOCOL_VERSION,
+        sourceInstanceId: "child_one",
+        targetInstanceId: "gateway_one",
+        createdAt: 2_000,
+      },
+      "child_one",
+    );
+
+    expect(handled).toBe(true);
+    expect(published).toEqual([
+      {
+        backend: "codex",
+        federationTarget: { scope: "remote", instanceId: "child_one" },
+        notification: {
+          method: "item/agentMessage/delta",
+          params: {
+            delta: "hello",
+            itemId: "item-1",
+            threadId: "thread-1",
+            turnId: "turn-1",
+          },
+        },
+      },
+    ]);
+  });
+
+  it("routes unmatched relayed responses back to the target peer", async () => {
+    const relayed: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({ localInstanceId: "gateway_one" });
+    router.registerConnection(
+      createConnection({
+        peerId: "child_one",
+        sendEnvelope: (envelope) => relayed.push(envelope),
+      }),
+    );
+    router.registerConnection(
+      createConnection({
+        peerId: "child_two",
+        capabilities: ["gateway_relay"],
+      }),
+    );
+    const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
+    runtime.router = router;
+
+    await runtime.receiveEnvelope(
+      {
+        id: "response-1",
+        kind: "response",
+        requestId: "request-1",
+        protocolVersion: 1,
+        sourceInstanceId: "child_two",
+        targetInstanceId: "child_one",
+        createdAt: 2_000,
+        result: { ok: true },
+      },
+      "child_two",
+    );
+
+    expect(relayed).toMatchObject([
+      {
+        kind: "response",
+        requestId: "request-1",
+        sourceInstanceId: "child_two",
+        targetInstanceId: "child_one",
+        hopCount: 1,
+      },
+    ]);
+  });
+
+  it("ignores stale disconnects after the peer has reconnected", () => {
+    const router = new FederationRouter({ localInstanceId: "gateway_one" });
+    const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
+    runtime.router = router;
+    const oldConnection = createConnection({
+      peerId: "child_one",
+      sendEnvelope: () => undefined,
+    });
+    const newSendEnvelope = () => undefined;
+    const newConnection = createConnection({
+      peerId: "child_one",
+      sendEnvelope: newSendEnvelope,
+    });
+
+    runtime.registerGatewayConnection(oldConnection);
+    runtime.registerGatewayConnection(newConnection);
+    runtime.unregisterGatewayConnection(oldConnection);
+
+    expect(router.getConnection("child_one")?.sendEnvelope).toBe(newSendEnvelope);
+
+    runtime.unregisterGatewayConnection(newConnection);
+
+    expect(router.getConnection("child_one")).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/main/__tests__/federation-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-runtime.test.ts
@@ -17,13 +17,20 @@ type RuntimeHarness = {
     envelope: FederationProtocolEnvelope,
     sourcePeerId: FederationInstanceId,
   ) => Promise<void>;
+  applyPeerDirectory: (envelope: FederationProtocolEnvelope) => boolean;
   forwardLocalBackendEvent: (event: AgentEvent) => void;
+  gatewayInstanceId?: FederationInstanceId;
   localInstanceId?: FederationInstanceId;
   publishRemoteBackendEvent: (
     envelope: FederationProtocolEnvelope,
     sourcePeerId: FederationInstanceId,
   ) => boolean;
+  remotePeerDirectory: Map<FederationInstanceId, unknown>;
   registerGatewayConnection: (connection: FederationGatewayConnection) => void;
+  sendEnvelopeToTarget: (
+    targetInstanceId: FederationInstanceId,
+    envelope: FederationProtocolEnvelope,
+  ) => void;
   setAgentEventPublisher: (publisher: (event: AgentEvent) => void) => void;
   unregisterGatewayConnection: (connection: FederationGatewayConnection) => void;
 };
@@ -43,6 +50,93 @@ function createConnection(params: {
 }
 
 describe("DesktopFederationRuntime", () => {
+  it("records gateway-advertised peers for child instance health and opening", () => {
+    const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
+    runtime.localInstanceId = "child_one";
+
+    const handled = runtime.applyPeerDirectory({
+      id: "peers-1",
+      kind: "notification",
+      method: "federation.peerDirectory",
+      params: {
+        peers: [
+          {
+            id: "gateway_one",
+            label: "Studio",
+            role: "gateway",
+            status: "connected",
+            capabilities: ["remote_window", "gateway_relay"],
+          },
+          {
+            id: "child_two",
+            label: "Laptop",
+            role: "child",
+            status: "connected",
+            capabilities: ["remote_window", "thread_detail"],
+          },
+          {
+            id: "child_one",
+            label: "Self",
+            role: "child",
+            status: "connected",
+            capabilities: ["remote_window"],
+          },
+        ],
+      },
+      protocolVersion: FEDERATION_PROTOCOL_VERSION,
+      sourceInstanceId: "gateway_one",
+      targetInstanceId: "child_one",
+      createdAt: 2_000,
+    });
+
+    expect(handled).toBe(true);
+    expect([...runtime.remotePeerDirectory.values()]).toMatchObject([
+      {
+        id: "gateway_one",
+        label: "Studio",
+        role: "gateway",
+        status: "connected",
+      },
+      {
+        id: "child_two",
+        label: "Laptop",
+        role: "child",
+        status: "connected",
+      },
+    ]);
+  });
+
+  it("falls back to the gateway when a child targets a sibling peer", () => {
+    const sentToGateway: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({ localInstanceId: "child_one" });
+    router.registerConnection(
+      createConnection({
+        peerId: "gateway_one",
+        capabilities: ["gateway_relay"],
+        sendEnvelope: (envelope) => sentToGateway.push(envelope),
+      }),
+    );
+    const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
+    runtime.gatewayInstanceId = "gateway_one";
+    runtime.localInstanceId = "child_one";
+    runtime.router = router;
+
+    const request: FederationProtocolEnvelope = {
+      id: "request-1",
+      kind: "request",
+      method: "backend.listThreads",
+      params: {},
+      protocolVersion: FEDERATION_PROTOCOL_VERSION,
+      sourceInstanceId: "child_one",
+      targetInstanceId: "child_two",
+      createdAt: 2_000,
+    };
+
+    runtime.sendEnvelopeToTarget("child_two", request);
+
+    expect(sentToGateway).toEqual([request]);
+  });
+
   it("forwards local backend events to remote-capable peers", () => {
     const forwarded: FederationProtocolEnvelope[] = [];
     const router = new FederationRouter({ localInstanceId: "gateway_one" });
@@ -143,6 +237,63 @@ describe("DesktopFederationRuntime", () => {
             turnId: "turn-1",
           },
         },
+      },
+    ]);
+  });
+
+  it("relays child backend events to sibling peers through the gateway", () => {
+    const relayedToSibling: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({ localInstanceId: "gateway_one" });
+    router.registerConnection(
+      createConnection({
+        peerId: "child_one",
+        capabilities: ["remote_window"],
+      }),
+    );
+    router.registerConnection(
+      createConnection({
+        peerId: "child_two",
+        capabilities: ["remote_window"],
+        sendEnvelope: (envelope) => relayedToSibling.push(envelope),
+      }),
+    );
+    const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
+    runtime.localInstanceId = "gateway_one";
+    runtime.router = router;
+
+    runtime.publishRemoteBackendEvent(
+      {
+        id: "event-1",
+        kind: "notification",
+        method: FEDERATION_BACKEND_EVENT_METHOD,
+        params: {
+          backend: "codex",
+          notification: {
+            method: "item/agentMessage/delta",
+            params: {
+              delta: "hello",
+              itemId: "item-1",
+              threadId: "thread-1",
+              turnId: "turn-1",
+            },
+          },
+        },
+        protocolVersion: FEDERATION_PROTOCOL_VERSION,
+        sourceInstanceId: "child_one",
+        targetInstanceId: "gateway_one",
+        createdAt: 2_000,
+      },
+      "child_one",
+    );
+
+    expect(relayedToSibling).toMatchObject([
+      {
+        id: "event-1",
+        kind: "notification",
+        method: FEDERATION_BACKEND_EVENT_METHOD,
+        sourceInstanceId: "child_one",
+        targetInstanceId: "child_two",
+        hopCount: 1,
       },
     ]);
   });

--- a/apps/desktop/src/main/__tests__/federation-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-runtime.test.ts
@@ -1,12 +1,17 @@
 import { describe, expect, it } from "vitest";
 import type {
   AgentEvent,
+  CodexEnvironmentSetupProgressEvent,
   FederationCapability,
   FederationInstanceId,
   FederationProtocolEnvelope,
+  NavigationSnapshot,
 } from "@pwragent/shared";
 import { FEDERATION_PROTOCOL_VERSION } from "@pwragent/shared";
-import { FEDERATION_BACKEND_EVENT_METHOD } from "../federation/federation-backend-bridge";
+import {
+  FEDERATION_BACKEND_EVENT_METHOD,
+  FEDERATION_ENVIRONMENT_SETUP_PROGRESS_METHOD,
+} from "../federation/federation-backend-bridge";
 import { DesktopFederationRuntime } from "../federation/federation-runtime";
 import { FederationRouter } from "../federation/federation-router";
 import type { FederationGatewayConnection } from "../federation/federation-transport";
@@ -25,14 +30,39 @@ type RuntimeHarness = {
     envelope: FederationProtocolEnvelope,
     sourcePeerId: FederationInstanceId,
   ) => boolean;
+  publishRemoteEnvironmentSetupProgress: (
+    envelope: FederationProtocolEnvelope,
+    sourcePeerId: FederationInstanceId,
+  ) => boolean;
   remotePeerDirectory: Map<FederationInstanceId, unknown>;
   registerGatewayConnection: (connection: FederationGatewayConnection) => void;
+  remoteBackend: () => {
+    getNavigationSnapshot: () => Promise<NavigationSnapshot>;
+  };
+  remoteNavigationSnapshot: (
+    target: { scope: "remote"; instanceId: FederationInstanceId },
+    request: Record<string, never>,
+  ) => Promise<NavigationSnapshot>;
   sendEnvelopeToTarget: (
     targetInstanceId: FederationInstanceId,
     envelope: FederationProtocolEnvelope,
   ) => void;
   setAgentEventPublisher: (publisher: (event: AgentEvent) => void) => void;
+  setEnvironmentSetupProgressPublisher: (
+    publisher: (event: CodexEnvironmentSetupProgressEvent) => void,
+  ) => void;
+  store: () => {
+    getPeer: (peerId: FederationInstanceId) => {
+      label: string;
+      status: "connected";
+    } | undefined;
+    listPeers: () => [];
+  };
   unregisterGatewayConnection: (connection: FederationGatewayConnection) => void;
+  visiblePeers: () => Array<{
+    id: FederationInstanceId;
+    status: string;
+  }>;
 };
 
 function createConnection(params: {
@@ -50,9 +80,82 @@ function createConnection(params: {
 }
 
 describe("DesktopFederationRuntime", () => {
+  it("preserves remote navigation lenses while federating thread keys", async () => {
+    const response: NavigationSnapshot = {
+      backend: "all",
+      fetchedAt: 1_000,
+      unchanged: false,
+      threads: [
+        {
+          id: "thread-1",
+          title: "Remote work",
+          titleSource: "fallback",
+          linkedDirectories: [],
+          source: "codex",
+          inbox: { inInbox: false },
+        },
+      ],
+      inboxThreadKeys: [],
+      directories: [
+        {
+          key: "directory:/repo",
+          kind: "directory",
+          label: "repo",
+          path: "/repo",
+          threadKeys: ["codex:thread-1"],
+          needsAttentionCount: 0,
+        },
+      ],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+    };
+    const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
+    runtime.remoteBackend = () => ({
+      getNavigationSnapshot: async () => response,
+    });
+    runtime.store = () => ({
+      getPeer: () => ({
+        label: "Studio Mac",
+        status: "connected",
+      }),
+      listPeers: () => [],
+    });
+
+    const snapshot = await runtime.remoteNavigationSnapshot(
+      { scope: "remote", instanceId: "client_one" },
+      {},
+    );
+
+    expect(snapshot.threads[0]).toMatchObject({
+      id: "thread-1",
+      inbox: { inInbox: false },
+      federation: {
+        instanceLabel: "Studio Mac",
+        ref: {
+          backend: "codex",
+          target: {
+            scope: "remote",
+            instanceId: "client_one",
+          },
+          threadId: "thread-1",
+        },
+      },
+    });
+    expect(snapshot.inboxThreadKeys).toEqual([]);
+    expect(snapshot.directories[0]?.threadKeys).toEqual([
+      "remote:client_one:codex:thread-1",
+    ]);
+  });
+
   it("records gateway-advertised peers for client instance health and opening", () => {
     const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
     runtime.localInstanceId = "client_one";
+    runtime.store = () => ({
+      getPeer: () => undefined,
+      listPeers: () => [],
+    });
 
     const handled = runtime.applyPeerDirectory({
       id: "peers-1",
@@ -103,6 +206,10 @@ describe("DesktopFederationRuntime", () => {
         role: "client",
         status: "connected",
       },
+    ]);
+    expect(runtime.visiblePeers()).toMatchObject([
+      { id: "gateway_one", status: "connected" },
+      { id: "client_two", status: "connected" },
     ]);
   });
 
@@ -237,6 +344,108 @@ describe("DesktopFederationRuntime", () => {
             turnId: "turn-1",
           },
         },
+      },
+    ]);
+  });
+
+  it("publishes remote environment setup progress with its source target", () => {
+    const published: CodexEnvironmentSetupProgressEvent[] = [];
+    const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
+    runtime.localInstanceId = "gateway_one";
+    runtime.setEnvironmentSetupProgressPublisher((event) => {
+      published.push(event);
+    });
+
+    const handled = runtime.publishRemoteEnvironmentSetupProgress(
+      {
+        id: "setup-1",
+        kind: "notification",
+        method: FEDERATION_ENVIRONMENT_SETUP_PROGRESS_METHOD,
+        params: {
+          directoryKey: "directory:/repo/app",
+          environmentId: "node",
+          environmentName: "Node",
+          command: "pnpm install",
+          phase: "stdout",
+          chunk: "Installing",
+          at: 2_000,
+        },
+        protocolVersion: FEDERATION_PROTOCOL_VERSION,
+        sourceInstanceId: "client_one",
+        targetInstanceId: "gateway_one",
+        createdAt: 2_000,
+      },
+      "client_one",
+    );
+
+    expect(handled).toBe(true);
+    expect(published).toEqual([
+      {
+        directoryKey: "directory:/repo/app",
+        federationTarget: { scope: "remote", instanceId: "client_one" },
+        environmentId: "node",
+        environmentName: "Node",
+        command: "pnpm install",
+        phase: "stdout",
+        chunk: "Installing",
+        at: 2_000,
+      },
+    ]);
+  });
+
+  it("relays environment setup progress to the requesting sibling", () => {
+    const published: CodexEnvironmentSetupProgressEvent[] = [];
+    const relayed: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({ localInstanceId: "gateway_one" });
+    router.registerConnection(
+      createConnection({
+        peerId: "client_one",
+        capabilities: ["environment_actions", "gateway_relay"],
+      }),
+    );
+    router.registerConnection(
+      createConnection({
+        peerId: "client_two",
+        capabilities: ["environment_actions", "gateway_relay"],
+        sendEnvelope: (envelope) => relayed.push(envelope),
+      }),
+    );
+    const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
+    runtime.localInstanceId = "gateway_one";
+    runtime.router = router;
+    runtime.setEnvironmentSetupProgressPublisher((event) => {
+      published.push(event);
+    });
+    const notification: FederationProtocolEnvelope = {
+      id: "setup-relay-1",
+      kind: "notification",
+      method: FEDERATION_ENVIRONMENT_SETUP_PROGRESS_METHOD,
+      params: {
+        directoryKey: "directory:/repo/app",
+        environmentId: "node",
+        environmentName: "Node",
+        command: "pnpm install",
+        phase: "stdout",
+        chunk: "Installing",
+        at: 2_000,
+      },
+      protocolVersion: FEDERATION_PROTOCOL_VERSION,
+      sourceInstanceId: "client_one",
+      targetInstanceId: "client_two",
+      createdAt: 2_000,
+    };
+
+    const handled = runtime.publishRemoteEnvironmentSetupProgress(
+      notification,
+      "client_one",
+    );
+
+    expect(handled).toBe(true);
+    expect(published).toEqual([]);
+    expect(relayed).toEqual([
+      {
+        ...notification,
+        hopCount: 1,
       },
     ]);
   });

--- a/apps/desktop/src/main/__tests__/federation-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-runtime.test.ts
@@ -35,9 +35,18 @@ type RuntimeHarness = {
     sourcePeerId: FederationInstanceId,
   ) => boolean;
   remotePeerDirectory: Map<FederationInstanceId, unknown>;
+  disconnectAdvertisedPeers: (reason: string) => void;
   registerGatewayConnection: (connection: FederationGatewayConnection) => void;
-  remoteBackend: () => {
+  remoteBackend: (target?: {
+    scope: "remote";
+    instanceId: FederationInstanceId;
+  }) => {
     getNavigationSnapshot: () => Promise<NavigationSnapshot>;
+    listThreads: (request: { backend: "codex" }) => Promise<{
+      backend: "codex";
+      fetchedAt: number;
+      threads: [];
+    }>;
   };
   remoteNavigationSnapshot: (
     target: { scope: "remote"; instanceId: FederationInstanceId },
@@ -63,6 +72,10 @@ type RuntimeHarness = {
     id: FederationInstanceId;
     status: string;
   }>;
+  connectedPeerTargets: () => Array<{
+    target: { scope: "remote"; instanceId: FederationInstanceId };
+    label: string;
+  }>;
 };
 
 function createConnection(params: {
@@ -80,7 +93,7 @@ function createConnection(params: {
 }
 
 describe("DesktopFederationRuntime", () => {
-  it("preserves remote navigation lenses while federating thread keys", async () => {
+  it("preserves renderer-compatible thread keys in remote navigation lenses", async () => {
     const response: NavigationSnapshot = {
       backend: "all",
       fetchedAt: 1_000,
@@ -114,6 +127,7 @@ describe("DesktopFederationRuntime", () => {
     const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
     runtime.remoteBackend = () => ({
       getNavigationSnapshot: async () => response,
+      listThreads: async () => ({ backend: "codex", fetchedAt: 1_000, threads: [] }),
     });
     runtime.store = () => ({
       getPeer: () => ({
@@ -144,9 +158,7 @@ describe("DesktopFederationRuntime", () => {
       },
     });
     expect(snapshot.inboxThreadKeys).toEqual([]);
-    expect(snapshot.directories[0]?.threadKeys).toEqual([
-      "remote:client_one:codex:thread-1",
-    ]);
+    expect(snapshot.directories[0]?.threadKeys).toEqual(["codex:thread-1"]);
   });
 
   it("records gateway-advertised peers for client instance health and opening", () => {
@@ -199,18 +211,72 @@ describe("DesktopFederationRuntime", () => {
         label: "Studio",
         role: "gateway",
         status: "connected",
+        canRevoke: false,
       },
       {
         id: "client_two",
         label: "Laptop",
         role: "client",
         status: "connected",
+        canRevoke: false,
       },
     ]);
     expect(runtime.visiblePeers()).toMatchObject([
       { id: "gateway_one", status: "connected" },
       { id: "client_two", status: "connected" },
     ]);
+  });
+
+  it("marks gateway-advertised routes disconnected when the gateway closes", () => {
+    const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
+    runtime.localInstanceId = "client_one";
+    runtime.store = () => ({
+      getPeer: () => undefined,
+      listPeers: () => [],
+    });
+    runtime.applyPeerDirectory({
+      id: "peers-1",
+      kind: "notification",
+      method: "federation.peerDirectory",
+      params: {
+        peers: [
+          {
+            id: "gateway_one",
+            label: "Studio",
+            role: "gateway",
+            status: "connected",
+            capabilities: ["gateway_relay"],
+          },
+          {
+            id: "client_two",
+            label: "Laptop",
+            role: "client",
+            status: "connected",
+            capabilities: ["thread_detail"],
+          },
+        ],
+      },
+      protocolVersion: FEDERATION_PROTOCOL_VERSION,
+      sourceInstanceId: "gateway_one",
+      targetInstanceId: "client_one",
+      createdAt: 2_000,
+    });
+
+    runtime.disconnectAdvertisedPeers("Gateway transport closed.");
+
+    expect(runtime.visiblePeers()).toMatchObject([
+      {
+        id: "gateway_one",
+        status: "disconnected",
+        unavailableReason: "Gateway transport closed.",
+      },
+      {
+        id: "client_two",
+        status: "disconnected",
+        unavailableReason: "Gateway transport closed.",
+      },
+    ]);
+    expect(runtime.connectedPeerTargets()).toEqual([]);
   });
 
   it("falls back to the gateway when a client targets a sibling peer", () => {
@@ -242,6 +308,48 @@ describe("DesktopFederationRuntime", () => {
     runtime.sendEnvelopeToTarget("client_two", request);
 
     expect(sentToGateway).toEqual([request]);
+  });
+
+  it("resolves sibling RPC responses received from the gateway transport", async () => {
+    const sentToGateway: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({ localInstanceId: "client_one" });
+    router.registerConnection(
+      createConnection({
+        peerId: "gateway_one",
+        capabilities: ["gateway_relay"],
+        sendEnvelope: (envelope) => sentToGateway.push(envelope),
+      }),
+    );
+    const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
+    runtime.gatewayInstanceId = "gateway_one";
+    runtime.localInstanceId = "client_one";
+    runtime.router = router;
+
+    const pending = runtime.remoteBackend({
+      scope: "remote",
+      instanceId: "client_two",
+    }).listThreads({ backend: "codex" });
+    const request = sentToGateway[0]!;
+
+    await runtime.receiveEnvelope(
+      {
+        id: "response-1",
+        kind: "response",
+        requestId: request.id,
+        protocolVersion: FEDERATION_PROTOCOL_VERSION,
+        sourceInstanceId: "client_two",
+        targetInstanceId: "client_one",
+        createdAt: 2_000,
+        result: { backend: "codex", fetchedAt: 2_000, threads: [] },
+      },
+      "gateway_one",
+    );
+
+    await expect(pending).resolves.toEqual({
+      backend: "codex",
+      fetchedAt: 2_000,
+      threads: [],
+    });
   });
 
   it("forwards local backend events to remote-capable peers", () => {

--- a/apps/desktop/src/main/__tests__/federation-store.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-store.test.ts
@@ -27,7 +27,7 @@ describe("FederationStore", () => {
       peer: {
         id: "laptop_one",
         label: "Laptop",
-        role: "child",
+        role: "client",
         status: "connected",
         capabilities: ["remote_window", "federated_search"],
         protocolVersion: 1,
@@ -40,7 +40,7 @@ describe("FederationStore", () => {
     expect(store.getPeer("laptop_one")).toMatchObject({
       id: "laptop_one",
       label: "Laptop",
-      role: "child",
+      role: "client",
       status: "connected",
       capabilities: ["remote_window", "federated_search"],
       protocolVersion: 1,
@@ -70,7 +70,7 @@ describe("FederationStore", () => {
       generatedAt: 1_000,
       expiresAt: 2_000,
       label: "Travel laptop",
-      role: "child",
+      role: "client",
       endpoint: "wss://pwragent.example.com/federation",
     });
 
@@ -83,7 +83,7 @@ describe("FederationStore", () => {
       id: enrollment.id,
       status: "pending",
       label: "Travel laptop",
-      role: "child",
+      role: "client",
     });
 
     const row = stateDb.raw

--- a/apps/desktop/src/main/__tests__/federation-store.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-store.test.ts
@@ -1,0 +1,175 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { FederationStore } from "../federation/federation-store";
+import { StateDb } from "../state/state-db";
+
+let stateDb: StateDb;
+let store: FederationStore;
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-federation-"));
+  stateDb = StateDb.open(path.join(tempDir, "state.db"));
+  store = new FederationStore(stateDb);
+});
+
+afterEach(() => {
+  stateDb.close();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("FederationStore", () => {
+  it("persists peer metadata and filters revoked peers by default", () => {
+    store.upsertPeer({
+      updatedAt: 1_000,
+      peer: {
+        id: "laptop_one",
+        label: "Laptop",
+        role: "child",
+        status: "connected",
+        capabilities: ["remote_window", "federated_search"],
+        protocolVersion: 1,
+        endpoint: "wss://example.cloudflareaccess.com/pwragent",
+        profileName: "default",
+        lastActivityAt: 950,
+      },
+    });
+
+    expect(store.getPeer("laptop_one")).toMatchObject({
+      id: "laptop_one",
+      label: "Laptop",
+      role: "child",
+      status: "connected",
+      capabilities: ["remote_window", "federated_search"],
+      protocolVersion: 1,
+      endpoint: "wss://example.cloudflareaccess.com/pwragent",
+      profileName: "default",
+      createdAt: 1_000,
+      updatedAt: 1_000,
+      lastSeenAt: 950,
+    });
+
+    store.revokePeer("laptop_one", 2_000);
+
+    expect(store.listPeers()).toEqual([]);
+    expect(store.listPeers({ includeRevoked: true })).toMatchObject([
+      {
+        id: "laptop_one",
+        status: "revoked",
+        revokedAt: 2_000,
+      },
+    ]);
+  });
+
+  it("matches pending enrollments without storing the raw token", () => {
+    const token = "123456789ABCDEFGHJKLMNPQRSTUVWX";
+    const enrollment = store.createEnrollment({
+      token,
+      generatedAt: 1_000,
+      expiresAt: 2_000,
+      label: "Travel laptop",
+      role: "child",
+      endpoint: "wss://pwragent.example.com/federation",
+    });
+
+    expect(
+      store.findMatchingPendingEnrollment({
+        token,
+        now: 1_500,
+      }),
+    ).toMatchObject({
+      id: enrollment.id,
+      status: "pending",
+      label: "Travel laptop",
+      role: "child",
+    });
+
+    const row = stateDb.raw
+      .prepare(
+        "SELECT token_hmac, payload FROM federation_enrollment_tokens WHERE enrollment_id = ?",
+      )
+      .get(enrollment.id) as { token_hmac: string; payload: string };
+    expect(row.token_hmac).not.toContain(token);
+    expect(row.payload).not.toContain(token);
+  });
+
+  it("expires enrollments and prevents replay after use", () => {
+    const expiredToken = "ABCDEFGHJKLMNPQRSTUVWXYZ1234567";
+    const expired = store.createEnrollment({
+      token: expiredToken,
+      generatedAt: 1_000,
+      expiresAt: 2_000,
+    });
+
+    expect(
+      store.findMatchingPendingEnrollment({
+        token: expiredToken,
+        now: 2_000,
+      }),
+    ).toBeUndefined();
+    expect(store.getEnrollment(expired.id)).toMatchObject({ status: "expired" });
+
+    const replayToken = "abcdefghijkmnopqrstuvwxyz1234567";
+    const replay = store.createEnrollment({
+      token: replayToken,
+      generatedAt: 3_000,
+      expiresAt: 4_000,
+    });
+    store.markEnrollmentUsed({
+      enrollmentId: replay.id,
+      peerId: "desktop_one",
+      usedAt: 3_100,
+    });
+
+    expect(
+      store.findMatchingPendingEnrollment({
+        token: replayToken,
+        now: 3_200,
+      }),
+    ).toBeUndefined();
+    expect(store.getEnrollment(replay.id)).toMatchObject({
+      status: "used",
+      peerId: "desktop_one",
+      usedAt: 3_100,
+    });
+  });
+
+  it("parameterizes token and audit lookups", () => {
+    const token = "123456789ABCDEFGHJKLMNPQRSTUVWX";
+    const enrollment = store.createEnrollment({
+      token,
+      generatedAt: 1_000,
+      expiresAt: 2_000,
+    });
+
+    store.appendAudit({
+      peerId: "desktop_one",
+      sessionId: "session-1",
+      kind: "connected",
+      createdAt: 1_250,
+      detail: "connected over tunnel",
+    });
+
+    expect(
+      store.findMatchingPendingEnrollment({
+        token: "' OR 1=1 --",
+        now: 1_500,
+      }),
+    ).toBeUndefined();
+    expect(store.getEnrollment(enrollment.id)).toMatchObject({
+      id: enrollment.id,
+      status: "pending",
+    });
+    expect(store.listAudit({ peerId: "desktop_one" })).toMatchObject([
+      {
+        peerId: "desktop_one",
+        sessionId: "session-1",
+        kind: "connected",
+        detail: "connected over tunnel",
+      },
+    ]);
+    expect(store.listAudit({ peerId: "missing_peer" })).toEqual([]);
+  });
+});

--- a/apps/desktop/src/main/__tests__/federation-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-transport.test.ts
@@ -14,7 +14,7 @@ import {
 } from "../federation/federation-identity";
 import { FederationStore } from "../federation/federation-store";
 import {
-  connectFederationChild,
+  connectFederationClient,
   FederationGatewayWebSocketServer,
 } from "../federation/federation-transport";
 import { StateDb } from "../state/state-db";
@@ -38,8 +38,8 @@ afterEach(async () => {
 });
 
 describe("federation transport", () => {
-  it("authenticates a child and carries protocol envelopes", async () => {
-    const childKeyPair = generateFederationIdentityKeyPair();
+  it("authenticates a client and carries protocol envelopes", async () => {
+    const clientKeyPair = generateFederationIdentityKeyPair();
     const invite = createFederationEnrollmentInvite({
       store,
       token: "invite-token-transport",
@@ -71,17 +71,17 @@ describe("federation transport", () => {
     const { url } = await server!.start();
 
     const reply = new Promise<FederationProtocolEnvelope>((resolve) => {
-      void connectFederationChild({
+      void connectFederationClient({
         url,
         mode: "enroll",
         gatewayInstanceId: "gateway_one",
-        peerInstanceId: "child_one",
-        privateKeyPem: childKeyPair.privateKeyPem,
-        publicKeyPem: childKeyPair.publicKeyPem,
+        peerInstanceId: "client_one",
+        privateKeyPem: clientKeyPair.privateKeyPem,
+        publicKeyPem: clientKeyPair.publicKeyPem,
         capabilities: ["remote_window"],
         inviteToken: invite.token,
-        label: "Child",
-        role: "child",
+        label: "Client",
+        role: "client",
         onEnvelope: resolve,
       }).then((client) => {
         client.sendEnvelope({
@@ -90,7 +90,7 @@ describe("federation transport", () => {
           method: "thread.list",
           params: {},
           protocolVersion: 1,
-          sourceInstanceId: "child_one",
+          sourceInstanceId: "client_one",
           targetInstanceId: "gateway_one",
           createdAt: 1_000,
         });
@@ -100,21 +100,21 @@ describe("federation transport", () => {
     await expect(received).resolves.toMatchObject({
       id: "request-1",
       kind: "request",
-      sourceInstanceId: "child_one",
+      sourceInstanceId: "client_one",
     });
     await expect(reply).resolves.toMatchObject({
       kind: "response",
       requestId: "request-1",
       result: { ok: true },
     });
-    expect(store.getPeer("child_one")).toMatchObject({
+    expect(store.getPeer("client_one")).toMatchObject({
       status: "connected",
-      pinnedPublicKeyPem: childKeyPair.publicKeyPem,
+      pinnedPublicKeyPem: clientKeyPair.publicKeyPem,
     });
   });
 
   it("rejects websocket clients that cannot prove an enrolled identity", async () => {
-    const childKeyPair = generateFederationIdentityKeyPair();
+    const clientKeyPair = generateFederationIdentityKeyPair();
     server = new FederationGatewayWebSocketServer({
       gatewayInstanceId: "gateway_one",
       host: "127.0.0.1",
@@ -124,20 +124,20 @@ describe("federation transport", () => {
     const { url } = await server.start();
 
     await expect(
-      connectFederationChild({
+      connectFederationClient({
         url,
         mode: "reconnect",
         gatewayInstanceId: "gateway_one",
-        peerInstanceId: "child_one",
-        privateKeyPem: childKeyPair.privateKeyPem,
-        publicKeyPem: childKeyPair.publicKeyPem,
+        peerInstanceId: "client_one",
+        privateKeyPem: clientKeyPair.privateKeyPem,
+        publicKeyPem: clientKeyPair.publicKeyPem,
         capabilities: ["remote_window"],
       }),
     ).rejects.toThrow("unknown_peer");
   });
 
   it("rejects auth proofs signed with a client-selected nonce", async () => {
-    const childKeyPair = generateFederationIdentityKeyPair();
+    const clientKeyPair = generateFederationIdentityKeyPair();
     const invite = createFederationEnrollmentInvite({
       store,
       token: "invite-token-stale-nonce",
@@ -166,26 +166,26 @@ describe("federation transport", () => {
         kind: "auth",
         mode: "enroll",
         gatewayInstanceId: "gateway_one",
-        peerInstanceId: "child_one",
+        peerInstanceId: "client_one",
         protocolVersion: 1,
         nonce,
         capabilities: ["remote_window"],
         signatureBase64: signFederationMessage({
-          privateKeyPem: childKeyPair.privateKeyPem,
+          privateKeyPem: clientKeyPair.privateKeyPem,
           message: buildFederationProofMessage({
             purpose: "enroll",
             gatewayInstanceId: "gateway_one",
-            peerInstanceId: "child_one",
-            publicKeyPem: childKeyPair.publicKeyPem,
+            peerInstanceId: "client_one",
+            publicKeyPem: clientKeyPair.publicKeyPem,
             protocolVersion: 1,
             nonce,
             capabilities: ["remote_window"],
           }),
         }),
         inviteToken: invite.token,
-        publicKeyPem: childKeyPair.publicKeyPem,
-        label: "Child",
-        role: "child",
+        publicKeyPem: clientKeyPair.publicKeyPem,
+        label: "Client",
+        role: "client",
       }),
     );
 
@@ -194,7 +194,7 @@ describe("federation transport", () => {
       failure: { code: "policy_denied" },
     });
     socket.close();
-    expect(store.getPeer("child_one")).toBeUndefined();
+    expect(store.getPeer("client_one")).toBeUndefined();
   });
 });
 

--- a/apps/desktop/src/main/__tests__/federation-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-transport.test.ts
@@ -1,13 +1,16 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import WebSocket from "ws";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { FederationProtocolEnvelope } from "@pwragent/shared";
 import {
+  buildFederationProofMessage,
   createFederationEnrollmentInvite,
 } from "../federation/federation-enrollment";
 import {
   generateFederationIdentityKeyPair,
+  signFederationMessage,
 } from "../federation/federation-identity";
 import { FederationStore } from "../federation/federation-store";
 import {
@@ -132,4 +135,85 @@ describe("federation transport", () => {
       }),
     ).rejects.toThrow("unknown_peer");
   });
+
+  it("rejects auth proofs signed with a client-selected nonce", async () => {
+    const childKeyPair = generateFederationIdentityKeyPair();
+    const invite = createFederationEnrollmentInvite({
+      store,
+      token: "invite-token-stale-nonce",
+      gatewayInstanceId: "gateway_one",
+      generatedAt: Date.now() - 1_000,
+      expiresAt: Date.now() + 60_000,
+    });
+    server = new FederationGatewayWebSocketServer({
+      gatewayInstanceId: "gateway_one",
+      host: "127.0.0.1",
+      port: 0,
+      store,
+    });
+    const { url } = await server.start();
+    const socket = new WebSocket(url);
+    const challenge = nextSocketMessage(socket);
+    await waitForSocketOpen(socket);
+    await expect(challenge).resolves.toMatchObject({
+      kind: "auth.challenge",
+      gatewayInstanceId: "gateway_one",
+    });
+
+    const nonce = "nonce:client-selected";
+    socket.send(
+      JSON.stringify({
+        kind: "auth",
+        mode: "enroll",
+        gatewayInstanceId: "gateway_one",
+        peerInstanceId: "child_one",
+        protocolVersion: 1,
+        nonce,
+        capabilities: ["remote_window"],
+        signatureBase64: signFederationMessage({
+          privateKeyPem: childKeyPair.privateKeyPem,
+          message: buildFederationProofMessage({
+            purpose: "enroll",
+            gatewayInstanceId: "gateway_one",
+            peerInstanceId: "child_one",
+            publicKeyPem: childKeyPair.publicKeyPem,
+            protocolVersion: 1,
+            nonce,
+            capabilities: ["remote_window"],
+          }),
+        }),
+        inviteToken: invite.token,
+        publicKeyPem: childKeyPair.publicKeyPem,
+        label: "Child",
+        role: "child",
+      }),
+    );
+
+    await expect(nextSocketMessage(socket)).resolves.toMatchObject({
+      kind: "auth.rejected",
+      failure: { code: "policy_denied" },
+    });
+    socket.close();
+    expect(store.getPeer("child_one")).toBeUndefined();
+  });
 });
+
+function waitForSocketOpen(socket: WebSocket): Promise<void> {
+  return new Promise((resolve, reject) => {
+    socket.once("open", () => resolve());
+    socket.once("error", reject);
+  });
+}
+
+function nextSocketMessage(socket: WebSocket): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    socket.once("message", (raw) => {
+      try {
+        resolve(JSON.parse(raw.toString()));
+      } catch (error) {
+        reject(error);
+      }
+    });
+    socket.once("error", reject);
+  });
+}

--- a/apps/desktop/src/main/__tests__/federation-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-transport.test.ts
@@ -1,0 +1,135 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { FederationProtocolEnvelope } from "@pwragent/shared";
+import {
+  createFederationEnrollmentInvite,
+} from "../federation/federation-enrollment";
+import {
+  generateFederationIdentityKeyPair,
+} from "../federation/federation-identity";
+import { FederationStore } from "../federation/federation-store";
+import {
+  connectFederationChild,
+  FederationGatewayWebSocketServer,
+} from "../federation/federation-transport";
+import { StateDb } from "../state/state-db";
+
+let stateDb: StateDb;
+let store: FederationStore;
+let tempDir: string;
+let server: FederationGatewayWebSocketServer | undefined;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-federation-transport-"));
+  stateDb = StateDb.open(path.join(tempDir, "state.db"));
+  store = new FederationStore(stateDb);
+});
+
+afterEach(async () => {
+  await server?.stop();
+  server = undefined;
+  stateDb.close();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("federation transport", () => {
+  it("authenticates a child and carries protocol envelopes", async () => {
+    const childKeyPair = generateFederationIdentityKeyPair();
+    const invite = createFederationEnrollmentInvite({
+      store,
+      token: "invite-token-transport",
+      gatewayInstanceId: "gateway_one",
+      generatedAt: Date.now() - 1_000,
+      expiresAt: Date.now() + 60_000,
+    });
+    const received = new Promise<FederationProtocolEnvelope>((resolve) => {
+      server = new FederationGatewayWebSocketServer({
+        gatewayInstanceId: "gateway_one",
+        host: "127.0.0.1",
+        port: 0,
+        store,
+        onEnvelope: (envelope, connection) => {
+          connection.sendEnvelope({
+            id: "response-1",
+            kind: "response",
+            requestId: envelope.id,
+            protocolVersion: 1,
+            sourceInstanceId: "gateway_one",
+            targetInstanceId: connection.peerId,
+            createdAt: 2_000,
+            result: { ok: true },
+          });
+          resolve(envelope);
+        },
+      });
+    });
+    const { url } = await server!.start();
+
+    const reply = new Promise<FederationProtocolEnvelope>((resolve) => {
+      void connectFederationChild({
+        url,
+        mode: "enroll",
+        gatewayInstanceId: "gateway_one",
+        peerInstanceId: "child_one",
+        privateKeyPem: childKeyPair.privateKeyPem,
+        publicKeyPem: childKeyPair.publicKeyPem,
+        capabilities: ["remote_window"],
+        inviteToken: invite.token,
+        label: "Child",
+        role: "child",
+        onEnvelope: resolve,
+      }).then((client) => {
+        client.sendEnvelope({
+          id: "request-1",
+          kind: "request",
+          method: "thread.list",
+          params: {},
+          protocolVersion: 1,
+          sourceInstanceId: "child_one",
+          targetInstanceId: "gateway_one",
+          createdAt: 1_000,
+        });
+      });
+    });
+
+    await expect(received).resolves.toMatchObject({
+      id: "request-1",
+      kind: "request",
+      sourceInstanceId: "child_one",
+    });
+    await expect(reply).resolves.toMatchObject({
+      kind: "response",
+      requestId: "request-1",
+      result: { ok: true },
+    });
+    expect(store.getPeer("child_one")).toMatchObject({
+      status: "connected",
+      pinnedPublicKeyPem: childKeyPair.publicKeyPem,
+    });
+  });
+
+  it("rejects websocket clients that cannot prove an enrolled identity", async () => {
+    const childKeyPair = generateFederationIdentityKeyPair();
+    server = new FederationGatewayWebSocketServer({
+      gatewayInstanceId: "gateway_one",
+      host: "127.0.0.1",
+      port: 0,
+      store,
+    });
+    const { url } = await server.start();
+
+    await expect(
+      connectFederationChild({
+        url,
+        mode: "reconnect",
+        gatewayInstanceId: "gateway_one",
+        peerInstanceId: "child_one",
+        privateKeyPem: childKeyPair.privateKeyPem,
+        publicKeyPem: childKeyPair.publicKeyPem,
+        capabilities: ["remote_window"],
+      }),
+    ).rejects.toThrow("unknown_peer");
+  });
+});

--- a/apps/desktop/src/main/__tests__/federation-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-transport.test.ts
@@ -111,6 +111,18 @@ describe("federation transport", () => {
       status: "connected",
       pinnedPublicKeyPem: clientKeyPair.publicKeyPem,
     });
+    expect(store.listAudit({ peerId: "client_one" })).toMatchObject([
+      {
+        kind: "connected",
+        detail: "enroll",
+      },
+      {
+        kind: "connect_attempt",
+        detail: "enroll",
+      },
+    ]);
+    expect(server?.closePeer("client_one")).toBe(true);
+    expect(server?.closePeer("client_one")).toBe(false);
   });
 
   it("rejects websocket clients that cannot prove an enrolled identity", async () => {
@@ -134,6 +146,16 @@ describe("federation transport", () => {
         capabilities: ["remote_window"],
       }),
     ).rejects.toThrow("unknown_peer");
+    expect(store.listAudit({ peerId: "client_one" })).toMatchObject([
+      {
+        kind: "rejected",
+        detail: "unknown_peer",
+      },
+      {
+        kind: "connect_attempt",
+        detail: "reconnect",
+      },
+    ]);
   });
 
   it("rejects auth proofs signed with a client-selected nonce", async () => {

--- a/apps/desktop/src/main/__tests__/federation-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-transport.test.ts
@@ -50,6 +50,11 @@ afterEach(async () => {
 describe("federation transport", () => {
   it("authenticates a client and carries protocol envelopes", async () => {
     const clientKeyPair = generateFederationIdentityKeyPair();
+    let closeCount = 0;
+    let resolveClosed: (() => void) | undefined;
+    const closed = new Promise<void>((resolve) => {
+      resolveClosed = resolve;
+    });
     const invite = createFederationEnrollmentInvite({
       store,
       token: "invite-token-transport",
@@ -96,6 +101,10 @@ describe("federation transport", () => {
         label: "Client",
         role: "client",
         onEnvelope: resolve,
+        onClose: () => {
+          closeCount += 1;
+          resolveClosed?.();
+        },
       }).then((client) => {
         client.sendEnvelope({
           id: "request-1",
@@ -135,6 +144,8 @@ describe("federation transport", () => {
       },
     ]);
     expect(server?.closePeer("client_one")).toBe(true);
+    await closed;
+    expect(closeCount).toBe(1);
     expect(server?.closePeer("client_one")).toBe(false);
   });
 

--- a/apps/desktop/src/main/__tests__/federation-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-transport.test.ts
@@ -1,10 +1,12 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import WebSocket from "ws";
+import WebSocket, { WebSocketServer } from "ws";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { FederationProtocolEnvelope } from "@pwragent/shared";
 import {
+  buildFederationGatewayAcceptedMessage,
+  buildFederationGatewayChallengeMessage,
   buildFederationProofMessage,
   createFederationEnrollmentInvite,
 } from "../federation/federation-enrollment";
@@ -23,16 +25,24 @@ let stateDb: StateDb;
 let store: FederationStore;
 let tempDir: string;
 let server: FederationGatewayWebSocketServer | undefined;
+let rawServer: WebSocketServer | undefined;
+let gatewayKeyPair: ReturnType<typeof generateFederationIdentityKeyPair>;
 
 beforeEach(() => {
   tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-federation-transport-"));
   stateDb = StateDb.open(path.join(tempDir, "state.db"));
   store = new FederationStore(stateDb);
+  gatewayKeyPair = generateFederationIdentityKeyPair();
 });
 
 afterEach(async () => {
   await server?.stop();
   server = undefined;
+  for (const client of rawServer?.clients ?? []) {
+    client.terminate();
+  }
+  await new Promise<void>((resolve) => rawServer?.close(() => resolve()) ?? resolve());
+  rawServer = undefined;
   stateDb.close();
   rmSync(tempDir, { recursive: true, force: true });
 });
@@ -50,6 +60,8 @@ describe("federation transport", () => {
     const received = new Promise<FederationProtocolEnvelope>((resolve) => {
       server = new FederationGatewayWebSocketServer({
         gatewayInstanceId: "gateway_one",
+        gatewayPrivateKeyPem: gatewayKeyPair.privateKeyPem,
+        gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
         host: "127.0.0.1",
         port: 0,
         store,
@@ -75,6 +87,7 @@ describe("federation transport", () => {
         url,
         mode: "enroll",
         gatewayInstanceId: "gateway_one",
+        gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
         peerInstanceId: "client_one",
         privateKeyPem: clientKeyPair.privateKeyPem,
         publicKeyPem: clientKeyPair.publicKeyPem,
@@ -129,6 +142,8 @@ describe("federation transport", () => {
     const clientKeyPair = generateFederationIdentityKeyPair();
     server = new FederationGatewayWebSocketServer({
       gatewayInstanceId: "gateway_one",
+      gatewayPrivateKeyPem: gatewayKeyPair.privateKeyPem,
+      gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
       host: "127.0.0.1",
       port: 0,
       store,
@@ -140,6 +155,7 @@ describe("federation transport", () => {
         url,
         mode: "reconnect",
         gatewayInstanceId: "gateway_one",
+        gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
         peerInstanceId: "client_one",
         privateKeyPem: clientKeyPair.privateKeyPem,
         publicKeyPem: clientKeyPair.publicKeyPem,
@@ -169,6 +185,8 @@ describe("federation transport", () => {
     });
     server = new FederationGatewayWebSocketServer({
       gatewayInstanceId: "gateway_one",
+      gatewayPrivateKeyPem: gatewayKeyPair.privateKeyPem,
+      gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
       host: "127.0.0.1",
       port: 0,
       store,
@@ -218,7 +236,115 @@ describe("federation transport", () => {
     socket.close();
     expect(store.getPeer("client_one")).toBeUndefined();
   });
+
+  it("rejects an auth challenge not signed by the pinned gateway", async () => {
+    const attackerKeyPair = generateFederationIdentityKeyPair();
+    const clientKeyPair = generateFederationIdentityKeyPair();
+    const nonce = "challenge:forged";
+    rawServer = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    rawServer.on("connection", (socket) => {
+      socket.send(JSON.stringify({
+        kind: "auth.challenge",
+        gatewayInstanceId: "gateway_one",
+        gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+        protocolVersion: 1,
+        nonce,
+        signatureBase64: signFederationMessage({
+          privateKeyPem: attackerKeyPair.privateKeyPem,
+          message: buildFederationGatewayChallengeMessage({
+            gatewayInstanceId: "gateway_one",
+            gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+            protocolVersion: 1,
+            nonce,
+          }),
+        }),
+      }));
+    });
+    const url = await websocketServerUrl(rawServer);
+
+    await expect(connectFederationClient({
+      url,
+      mode: "reconnect",
+      gatewayInstanceId: "gateway_one",
+      gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+      peerInstanceId: "client_one",
+      privateKeyPem: clientKeyPair.privateKeyPem,
+      publicKeyPem: clientKeyPair.publicKeyPem,
+      capabilities: ["remote_window"],
+    })).rejects.toThrow("Invalid federation auth challenge signature");
+  });
+
+  it("rejects an auth acceptance not signed by the pinned gateway", async () => {
+    const attackerKeyPair = generateFederationIdentityKeyPair();
+    const clientKeyPair = generateFederationIdentityKeyPair();
+    const nonce = "challenge:trusted";
+    rawServer = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    rawServer.on("connection", (socket) => {
+      socket.send(JSON.stringify({
+        kind: "auth.challenge",
+        gatewayInstanceId: "gateway_one",
+        gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+        protocolVersion: 1,
+        nonce,
+        signatureBase64: signFederationMessage({
+          privateKeyPem: gatewayKeyPair.privateKeyPem,
+          message: buildFederationGatewayChallengeMessage({
+            gatewayInstanceId: "gateway_one",
+            gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+            protocolVersion: 1,
+            nonce,
+          }),
+        }),
+      }));
+      socket.once("message", () => {
+        const sessionId = "federation-session:forged";
+        const capabilities = ["remote_window"] as const;
+        socket.send(JSON.stringify({
+          kind: "auth.accepted",
+          gatewayInstanceId: "gateway_one",
+          sessionId,
+          protocolVersion: 1,
+          nonce,
+          capabilities,
+          signatureBase64: signFederationMessage({
+            privateKeyPem: attackerKeyPair.privateKeyPem,
+            message: buildFederationGatewayAcceptedMessage({
+              gatewayInstanceId: "gateway_one",
+              peerInstanceId: "client_one",
+              sessionId,
+              protocolVersion: 1,
+              nonce,
+              capabilities,
+            }),
+          }),
+        }));
+      });
+    });
+    const url = await websocketServerUrl(rawServer);
+
+    await expect(connectFederationClient({
+      url,
+      mode: "reconnect",
+      gatewayInstanceId: "gateway_one",
+      gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+      peerInstanceId: "client_one",
+      privateKeyPem: clientKeyPair.privateKeyPem,
+      publicKeyPem: clientKeyPair.publicKeyPem,
+      capabilities: ["remote_window"],
+    })).rejects.toThrow("Invalid federation auth acceptance signature");
+  });
 });
+
+async function websocketServerUrl(wsServer: WebSocketServer): Promise<string> {
+  if (!wsServer.address()) {
+    await new Promise<void>((resolve) => wsServer.once("listening", () => resolve()));
+  }
+  const address = wsServer.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Expected websocket server to listen on a TCP port");
+  }
+  return `ws://127.0.0.1:${address.port}`;
+}
 
 function waitForSocketOpen(socket: WebSocket): Promise<void> {
   return new Promise((resolve, reject) => {

--- a/apps/desktop/src/main/__tests__/federation-window-bootstrap.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-window-bootstrap.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+  FEDERATION_WINDOW_TARGET_ARG_PREFIX,
+  federationWindowTargetAdditionalArguments,
+  readFederationWindowTargetFromArgv,
+} from "../../shared/federation-window";
+
+describe("federation window bootstrap", () => {
+  it("round-trips a remote target through BrowserWindow additional arguments", () => {
+    const args = federationWindowTargetAdditionalArguments({
+      scope: "remote",
+      instanceId: "child_one",
+    });
+
+    expect(args).toHaveLength(1);
+    expect(args[0]).toContain(FEDERATION_WINDOW_TARGET_ARG_PREFIX);
+    expect(readFederationWindowTargetFromArgv(args)).toEqual({
+      scope: "remote",
+      instanceId: "child_one",
+    });
+  });
+
+  it("ignores absent or malformed targets", () => {
+    expect(federationWindowTargetAdditionalArguments(undefined)).toEqual([]);
+    expect(
+      readFederationWindowTargetFromArgv([
+        `${FEDERATION_WINDOW_TARGET_ARG_PREFIX}${JSON.stringify({
+          scope: "local",
+        })}`,
+      ]),
+    ).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/main/__tests__/federation-window-bootstrap.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-window-bootstrap.test.ts
@@ -9,14 +9,14 @@ describe("federation window bootstrap", () => {
   it("round-trips a remote target through BrowserWindow additional arguments", () => {
     const args = federationWindowTargetAdditionalArguments({
       scope: "remote",
-      instanceId: "child_one",
+      instanceId: "client_one",
     });
 
     expect(args).toHaveLength(1);
     expect(args[0]).toContain(FEDERATION_WINDOW_TARGET_ARG_PREFIX);
     expect(readFederationWindowTargetFromArgv(args)).toEqual({
       scope: "remote",
-      instanceId: "child_one",
+      instanceId: "client_one",
     });
   });
 

--- a/apps/desktop/src/main/__tests__/federation-window-bootstrap.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-window-bootstrap.test.ts
@@ -1,23 +1,30 @@
 import { describe, expect, it } from "vitest";
 import {
+  FEDERATION_WINDOW_LABEL_ARG_PREFIX,
   FEDERATION_WINDOW_TARGET_ARG_PREFIX,
   federationWindowTargetAdditionalArguments,
+  readFederationWindowLabelFromArgv,
   readFederationWindowTargetFromArgv,
 } from "../../shared/federation-window";
 
 describe("federation window bootstrap", () => {
   it("round-trips a remote target through BrowserWindow additional arguments", () => {
-    const args = federationWindowTargetAdditionalArguments({
-      scope: "remote",
-      instanceId: "client_one",
-    });
+    const args = federationWindowTargetAdditionalArguments(
+      {
+        scope: "remote",
+        instanceId: "client_one",
+      },
+      "Studio Mac",
+    );
 
-    expect(args).toHaveLength(1);
+    expect(args).toHaveLength(2);
     expect(args[0]).toContain(FEDERATION_WINDOW_TARGET_ARG_PREFIX);
+    expect(args[1]).toContain(FEDERATION_WINDOW_LABEL_ARG_PREFIX);
     expect(readFederationWindowTargetFromArgv(args)).toEqual({
       scope: "remote",
       instanceId: "client_one",
     });
+    expect(readFederationWindowLabelFromArgv(args)).toBe("Studio Mac");
   });
 
   it("ignores absent or malformed targets", () => {

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -34,6 +34,8 @@ const disposeDiagnosticsIpcHandlersMock = vi.fn();
 const stopAllCodexEnvironmentDetachedCommandsMock = vi.fn(() => 0);
 const registerComposerDraftIpcHandlersMock = vi.fn();
 const disposeComposerDraftIpcHandlersMock = vi.fn();
+const registerFederationIpcHandlersMock = vi.fn();
+const disposeFederationIpcHandlersMock = vi.fn();
 const registerPreloadLogIpcHandlersMock = vi.fn();
 const disposePreloadLogIpcHandlersMock = vi.fn();
 const registerProfilesIpcHandlersMock = vi.fn();
@@ -76,6 +78,8 @@ const initializeAppStateMock = vi.fn();
 const disposeAppStateMock = vi.fn();
 const isAppStateInitializedMock = vi.fn();
 const messagingRuntimeStartMock = vi.fn<() => Promise<void>>();
+const federationRuntimeRestartMock = vi.fn<() => Promise<void>>();
+const disposeDesktopFederationRuntimeMock = vi.fn<() => Promise<void>>();
 const messagingLeaseStartMock = vi.fn<() => Promise<void>>();
 const messagingLeaseShutdownSyncMock = vi.fn();
 const getRuntimeMessagingLeaseCoordinatorMock = vi.fn();
@@ -291,6 +295,11 @@ vi.mock("../ipc/composer-drafts", () => ({
   disposeComposerDraftIpcHandlers: disposeComposerDraftIpcHandlersMock,
 }));
 
+vi.mock("../ipc/federation", () => ({
+  registerFederationIpcHandlers: registerFederationIpcHandlersMock,
+  disposeFederationIpcHandlers: disposeFederationIpcHandlersMock,
+}));
+
 vi.mock("../ipc/preload-log", () => ({
   registerPreloadLogIpcHandlers: registerPreloadLogIpcHandlersMock,
   disposePreloadLogIpcHandlers: disposePreloadLogIpcHandlersMock,
@@ -346,6 +355,13 @@ vi.mock("../messaging/messaging-runtime", () => ({
     getPlatformStatuses: vi.fn(() => []),
   })),
   disposeDesktopMessagingRuntime: disposeDesktopMessagingRuntimeMock,
+}));
+
+vi.mock("../federation/federation-runtime", () => ({
+  getDesktopFederationRuntime: vi.fn(() => ({
+    restart: federationRuntimeRestartMock,
+  })),
+  disposeDesktopFederationRuntime: disposeDesktopFederationRuntimeMock,
 }));
 
 vi.mock("../runtime-messaging-lease", () => ({
@@ -456,6 +472,8 @@ describe("bootstrapApp", () => {
     disposeIntegratedTerminalIpcHandlersMock.mockReset();
     registerComposerDraftIpcHandlersMock.mockReset();
     disposeComposerDraftIpcHandlersMock.mockReset();
+    registerFederationIpcHandlersMock.mockReset();
+    disposeFederationIpcHandlersMock.mockReset();
     registerPreloadLogIpcHandlersMock.mockReset();
     disposePreloadLogIpcHandlersMock.mockReset();
     registerProfilesIpcHandlersMock.mockReset();
@@ -522,6 +540,10 @@ describe("bootstrapApp", () => {
     isAppStateInitializedMock.mockReturnValue(true);
     messagingRuntimeStartMock.mockReset();
     messagingRuntimeStartMock.mockResolvedValue();
+    federationRuntimeRestartMock.mockReset();
+    federationRuntimeRestartMock.mockResolvedValue();
+    disposeDesktopFederationRuntimeMock.mockReset();
+    disposeDesktopFederationRuntimeMock.mockResolvedValue();
     messagingLeaseStartMock.mockReset();
     messagingLeaseStartMock.mockResolvedValue();
     messagingLeaseShutdownSyncMock.mockReset();
@@ -628,6 +650,7 @@ describe("bootstrapApp", () => {
     expect(registerAgentIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(registerApplicationIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(registerComposerDraftIpcHandlersMock).toHaveBeenCalledTimes(1);
+    expect(registerFederationIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(registerImageNormalizationIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(registerIntegratedTerminalIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(registerPreloadLogIpcHandlersMock).toHaveBeenCalledTimes(1);
@@ -1208,12 +1231,14 @@ describe("bootstrapApp", () => {
     expect(event.preventDefault).toHaveBeenCalledOnce();
     expect(disposeComposerDraftIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(disposeIntegratedTerminalIpcHandlersMock).toHaveBeenCalledTimes(1);
+    expect(disposeFederationIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(disposeSettingsIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(disposeAppServerIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(disposeAppServerIpcHandlersMock.mock.invocationCallOrder[0]).toBeLessThan(
       disposeAppStateMock.mock.invocationCallOrder[0],
     );
     expect(disposeDesktopMessagingRuntimeMock).toHaveBeenCalledTimes(1);
+    expect(disposeDesktopFederationRuntimeMock).toHaveBeenCalledTimes(1);
     expect(disposeAppStateMock).toHaveBeenCalledTimes(1);
     expect(quitMock).toHaveBeenCalledTimes(1);
 
@@ -1221,6 +1246,7 @@ describe("bootstrapApp", () => {
     await flushMicrotasks();
     expect(disposeAppServerIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(disposeDesktopMessagingRuntimeMock).toHaveBeenCalledTimes(1);
+    expect(disposeDesktopFederationRuntimeMock).toHaveBeenCalledTimes(1);
   });
 
   it("reuses one quit barrier while messaging and app-server teardown settle", async () => {
@@ -1413,6 +1439,7 @@ describe("bootstrapApp", () => {
     expect(disposeApplicationIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(disposeComposerDraftIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(disposeIntegratedTerminalIpcHandlersMock).toHaveBeenCalledTimes(1);
+    expect(disposeFederationIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(disposeSettingsIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(disposeWindowPointerIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(disposeRuntimeIdentityIpcHandlersMock).not.toHaveBeenCalled();

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -2268,6 +2268,46 @@ describe("MessagingController", () => {
     });
   });
 
+  it("routes bound remote thread input to its federation target", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.threads[0]!.federation = {
+      ref: {
+        backend: "codex",
+        target: { scope: "remote", instanceId: "client_one" },
+        threadId: "thread-1",
+      },
+      instanceLabel: "Studio Mac",
+      peerStatus: "connected",
+    };
+    const harness = await createHarness({ navigation });
+    const event = buildTextEvent("remote request");
+    await harness.store.upsertBinding({
+      id: "binding:remote-client-one",
+      authorizedActorIds: ["user-1"],
+      backend: "codex",
+      channel: event.channel,
+      createdAt: 1000,
+      federatedThread: navigation.threads[0]!.federation!.ref,
+      routingState: event.routingState,
+      targetKind: "thread",
+      threadId: "thread-1",
+      updatedAt: 1000,
+    });
+
+    await harness.controller.handleInboundEvent(event);
+
+    expect(harness.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: "codex",
+        federationTarget: {
+          scope: "remote",
+          instanceId: "client_one",
+        },
+        threadId: "thread-1",
+      }),
+    );
+  });
+
   it("creates a native Telegram topic, attaches a target thread, and posts resume status there", async () => {
     const now = Date.UTC(2026, 5, 9, 23, 5);
     const navigation = buildNavigationSnapshot();

--- a/apps/desktop/src/main/__tests__/messaging-federated-bindings.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-federated-bindings.test.ts
@@ -1,0 +1,117 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { MessagingBindingRecord } from "@pwragent/messaging-interface";
+import { buildFederatedThreadRef } from "@pwragent/shared";
+import { SqliteMessagingStore } from "../state/messaging-store-sqlite";
+import { StateDb } from "../state/state-db";
+import {
+  federatedThreadRefForMessagingBinding,
+  messagingBindingTargetsRemoteInstance,
+} from "../messaging/federated-messaging-routing";
+
+let stateDb: StateDb;
+let store: SqliteMessagingStore;
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-msg-federation-"));
+  stateDb = StateDb.open(path.join(tempDir, "state.db"));
+  store = new SqliteMessagingStore(stateDb);
+});
+
+afterEach(() => {
+  stateDb.close();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("messaging federated bindings", () => {
+  it("finds active bindings by full federated thread identity", async () => {
+    const federatedThread = buildFederatedThreadRef({
+      backend: "codex",
+      instanceId: "child_one",
+      threadId: "thread-1",
+    });
+    const binding: MessagingBindingRecord = {
+      id: "binding-1",
+      backend: "codex",
+      threadId: "thread-1",
+      federatedThread,
+      authorizedActorIds: ["user-1"],
+      channel: {
+        channel: "telegram",
+        conversation: {
+          id: "chat-1",
+          kind: "dm",
+        },
+      },
+      createdAt: 1_000,
+      updatedAt: 1_000,
+    };
+
+    await store.upsertBinding(binding);
+    await store.upsertBinding({
+      ...binding,
+      id: "binding-local",
+      channel: {
+        channel: "discord",
+        conversation: { id: "channel-1", kind: "channel" },
+      },
+      federatedThread: undefined,
+    });
+
+    await expect(
+      store.findActiveBindingsForFederatedThread(federatedThread),
+    ).resolves.toMatchObject([
+      {
+        id: "binding-1",
+        federatedThread: {
+          target: { scope: "remote", instanceId: "child_one" },
+          threadId: "thread-1",
+        },
+      },
+    ]);
+    await expect(
+      store.findActiveBindingsForFederatedThread({
+        ...federatedThread,
+        target: { scope: "remote", instanceId: "child_two" },
+      }),
+    ).resolves.toEqual([]);
+  });
+
+  it("normalizes messaging bindings to local or remote federation refs", () => {
+    const localBinding: MessagingBindingRecord = {
+      id: "binding-local",
+      backend: "codex",
+      threadId: "thread-1",
+      authorizedActorIds: ["user-1"],
+      channel: {
+        channel: "telegram",
+        conversation: { id: "chat-1", kind: "dm" },
+      },
+      createdAt: 1_000,
+      updatedAt: 1_000,
+    };
+    const remoteBinding: MessagingBindingRecord = {
+      ...localBinding,
+      id: "binding-remote",
+      federatedThread: buildFederatedThreadRef({
+        backend: "codex",
+        instanceId: "child_one",
+        threadId: "thread-1",
+      }),
+    };
+
+    expect(federatedThreadRefForMessagingBinding(localBinding)).toMatchObject({
+      target: { scope: "local" },
+      threadId: "thread-1",
+    });
+    expect(messagingBindingTargetsRemoteInstance(localBinding)).toBe(false);
+    expect(federatedThreadRefForMessagingBinding(remoteBinding)).toMatchObject({
+      target: { scope: "remote", instanceId: "child_one" },
+      threadId: "thread-1",
+    });
+    expect(messagingBindingTargetsRemoteInstance(remoteBinding)).toBe(true);
+  });
+});

--- a/apps/desktop/src/main/__tests__/messaging-resume-browser.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-resume-browser.test.ts
@@ -11,6 +11,7 @@ import {
   parseResumeCommandArgs,
   RESUME_BROWSER_PAGE_SIZE,
   resumeBrowserPageSize,
+  selectThreadFromValue,
 } from "../messaging/core/messaging-resume-browser";
 
 describe("messaging resume browser", () => {
@@ -70,6 +71,47 @@ describe("messaging resume browser", () => {
     expect(intent.prompt).not.toContain("1. Thread one");
     expect(intent.fallbackText).toContain("1. Thread one");
     expect(intent.fallbackText).toContain("Reply with a number");
+  });
+
+  it("labels remote threads and preserves their instance in callbacks", () => {
+    const intent = buildResumeIntent({
+      id: "intent-remote",
+      createdAt: 1000,
+      navigation: buildNavigationSnapshot({
+        threads: [
+          buildThread({
+            federation: {
+              ref: {
+                backend: "codex",
+                target: { scope: "remote", instanceId: "client_one" },
+                threadId: "thread-1",
+              },
+              instanceLabel: "Studio Mac",
+              peerStatus: "connected",
+            },
+          }),
+        ],
+      }),
+      session: buildBrowseSession({ mode: "recents" }),
+    });
+    expect(intent.fallbackText).toContain("[Studio Mac] Thread one");
+    const action = intent.page.actions.find(
+      (candidate) => candidate.id === "browse:select-thread",
+    );
+    expect(action?.value).toEqual({
+      backend: "codex",
+      federationInstanceId: "client_one",
+      threadId: "thread-1",
+    });
+    expect(selectThreadFromValue(action?.value)).toEqual({
+      backend: "codex",
+      federatedThread: {
+        backend: "codex",
+        target: { scope: "remote", instanceId: "client_one" },
+        threadId: "thread-1",
+      },
+      threadId: "thread-1",
+    });
   });
 
   it("fits middle-page resume controls within LINE action budgets", () => {

--- a/apps/desktop/src/main/__tests__/messaging-turn-admission.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-turn-admission.test.ts
@@ -141,6 +141,24 @@ describe("MessagingTurnAdmission", () => {
 
     expect(first.id).not.toBe(second.id);
   });
+
+  it("separates identical thread ids owned by different instances", () => {
+    const local = buildBinding();
+    const remote: MessagingBindingRecord = {
+      ...buildBinding(),
+      id: "binding-remote",
+      federatedThread: {
+        backend: "codex",
+        target: { scope: "remote", instanceId: "client_one" },
+        threadId: "thread-1",
+      },
+    };
+
+    expect(threadKeyForBinding(local)).toBe("codex:thread-1");
+    expect(threadKeyForBinding(remote)).toBe(
+      "remote:client_one:codex:thread-1",
+    );
+  });
 });
 
 function buildBinding(): MessagingBindingRecord {

--- a/apps/desktop/src/main/__tests__/state-db.test.ts
+++ b/apps/desktop/src/main/__tests__/state-db.test.ts
@@ -30,12 +30,18 @@ describe("StateDb", () => {
   it("creates additive runtime cache tables", () => {
     const tables = stateDb.raw
       .prepare(
-        `SELECT name FROM sqlite_master WHERE type = 'table' AND name IN (?, ?, ?, ?, ?) ORDER BY name`,
+        `SELECT name FROM sqlite_master
+         WHERE type = 'table'
+           AND name IN (?, ?, ?, ?, ?, ?, ?, ?)
+         ORDER BY name`,
       )
       .all(
         "acp_installed_agents",
         "acp_registry_cache",
         "acp_sessions",
+        "federation_enrollment_tokens",
+        "federation_peers",
+        "federation_session_audit",
         "pr_lookup_cache",
         "pr_status_cache",
       ) as Array<{ name: string }>;
@@ -44,6 +50,9 @@ describe("StateDb", () => {
       "acp_installed_agents",
       "acp_registry_cache",
       "acp_sessions",
+      "federation_enrollment_tokens",
+      "federation_peers",
+      "federation_session_audit",
       "pr_lookup_cache",
       "pr_status_cache",
     ]);
@@ -1365,6 +1374,9 @@ describe("StateDb", () => {
     stateDb = StateDb.open(dbPath);
 
     expect(existingTables()).toEqual([
+      "federation_enrollment_tokens",
+      "federation_peers",
+      "federation_session_audit",
       "pr_lookup_cache",
       "pr_status_cache",
       "thread_search_documents",
@@ -1427,6 +1439,9 @@ describe("StateDb", () => {
     stateDb = StateDb.open(dbPath);
 
     expect(existingTables()).toEqual([
+      "federation_enrollment_tokens",
+      "federation_peers",
+      "federation_session_audit",
       "pr_lookup_cache",
       "pr_status_cache",
       "thread_search_documents",
@@ -1580,9 +1595,15 @@ function openRawDb(dbPath: string): BetterSqlite3.Database {
 function existingTables(): string[] {
   const rows = stateDb.raw
     .prepare(
-      `SELECT name FROM sqlite_master WHERE type = 'table' AND name IN (?, ?, ?, ?) ORDER BY name`,
+      `SELECT name FROM sqlite_master
+       WHERE type = 'table'
+         AND name IN (?, ?, ?, ?, ?, ?, ?)
+       ORDER BY name`,
     )
     .all(
+      "federation_enrollment_tokens",
+      "federation_peers",
+      "federation_session_audit",
       "pr_lookup_cache",
       "pr_status_cache",
       "thread_search_documents",

--- a/apps/desktop/src/main/federation/federated-search-service.ts
+++ b/apps/desktop/src/main/federation/federated-search-service.ts
@@ -1,0 +1,120 @@
+import type {
+  AppServerListThreadsResponse,
+  AppServerThreadSummary,
+  FederatedSearchRequest,
+  FederatedSearchResponse,
+  FederationInstanceId,
+  FederationPeerSummary,
+} from "@pwragent/shared";
+import { buildFederatedThreadRef } from "@pwragent/shared";
+import type { FederationBackendOperations } from "./federation-backend-bridge";
+
+export type FederatedSearchPeer = {
+  instanceId: FederationInstanceId;
+  label: string;
+  status?: FederationPeerSummary["status"];
+  backend: Pick<FederationBackendOperations, "listThreads">;
+};
+
+export type FederatedSearchLocalBackend = Pick<
+  FederationBackendOperations,
+  "listThreads"
+>;
+
+export class FederatedSearchService {
+  constructor(
+    private readonly options: {
+      local: FederatedSearchLocalBackend;
+      peers: () => readonly FederatedSearchPeer[];
+      now?: () => number;
+    },
+  ) {}
+
+  async search(request: FederatedSearchRequest): Promise<FederatedSearchResponse> {
+    const query = request.query.trim();
+    const limit = Math.max(1, Math.min(request.limit ?? 50, 200));
+    const searchedAt = this.options.now?.() ?? Date.now();
+    const failures: FederatedSearchResponse["failures"] = [];
+    const resultGroups = await Promise.all([
+      this.searchLocal(query),
+      ...this.options.peers().map(async (peer) => {
+        try {
+          return await this.searchPeer(peer, query);
+        } catch (error) {
+          failures.push({
+            instanceId: peer.instanceId,
+            instanceLabel: peer.label,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          return [];
+        }
+      }),
+    ]);
+    const results = resultGroups
+      .flat()
+      .sort((left, right) => {
+        if (right.score !== left.score) return right.score - left.score;
+        return (right.thread.updatedAt ?? 0) - (left.thread.updatedAt ?? 0);
+      })
+      .slice(0, limit);
+
+    return {
+      query,
+      searchedAt,
+      results,
+      failures,
+    };
+  }
+
+  private async searchLocal(query: string): Promise<FederatedSearchResponse["results"]> {
+    const response = await this.options.local.listThreads({ filter: query });
+    return response.threads.map((thread) => ({
+      ref: buildFederatedThreadRef({
+        backend: thread.source,
+        threadId: thread.id,
+      }),
+      thread,
+      instanceLabel: "This Mac",
+      score: scoreThread(thread, query),
+    }));
+  }
+
+  private async searchPeer(
+    peer: FederatedSearchPeer,
+    query: string,
+  ): Promise<FederatedSearchResponse["results"]> {
+    const response: AppServerListThreadsResponse = await peer.backend.listThreads({
+      filter: query,
+    });
+    return response.threads.map((thread) => ({
+      ref: buildFederatedThreadRef({
+        backend: thread.source,
+        instanceId: peer.instanceId,
+        threadId: thread.id,
+      }),
+      thread,
+      instanceLabel: peer.label,
+      peerStatus: peer.status,
+      score: scoreThread(thread, query),
+    }));
+  }
+}
+
+function scoreThread(thread: AppServerThreadSummary, query: string): number {
+  if (!query) return thread.updatedAt ?? thread.createdAt ?? 0;
+  const normalized = query.toLowerCase();
+  const title = thread.title.toLowerCase();
+  const summary = thread.summary?.toLowerCase() ?? "";
+  const directories = thread.linkedDirectories
+    .map((directory) => `${directory.label} ${directory.path} ${directory.worktreePath ?? ""}`)
+    .join(" ")
+    .toLowerCase();
+  let score = 0;
+  if (title === normalized) score += 1_000;
+  if (title.startsWith(normalized)) score += 500;
+  if (title.includes(normalized)) score += 250;
+  if (summary.includes(normalized)) score += 100;
+  if (directories.includes(normalized)) score += 50;
+  score += Math.min(thread.updatedAt ?? thread.createdAt ?? 0, 9_999_999_999) / 1_000_000;
+  return score;
+}

--- a/apps/desktop/src/main/federation/federated-search-service.ts
+++ b/apps/desktop/src/main/federation/federated-search-service.ts
@@ -26,6 +26,7 @@ export class FederatedSearchService {
     private readonly options: {
       local: FederatedSearchLocalBackend;
       peers: () => readonly FederatedSearchPeer[];
+      includeLocal?: boolean;
       now?: () => number;
     },
   ) {}
@@ -36,10 +37,12 @@ export class FederatedSearchService {
     const searchedAt = this.options.now?.() ?? Date.now();
     const failures: FederatedSearchResponse["failures"] = [];
     const resultGroups = await Promise.all([
-      this.searchLocal(query),
+      ...(this.options.includeLocal === false
+        ? []
+        : [this.searchLocal(query, request.backend)]),
       ...this.options.peers().map(async (peer) => {
         try {
-          return await this.searchPeer(peer, query);
+          return await this.searchPeer(peer, query, request.backend);
         } catch (error) {
           failures.push({
             instanceId: peer.instanceId,
@@ -66,8 +69,14 @@ export class FederatedSearchService {
     };
   }
 
-  private async searchLocal(query: string): Promise<FederatedSearchResponse["results"]> {
-    const response = await this.options.local.listThreads({ filter: query });
+  private async searchLocal(
+    query: string,
+    backend?: FederatedSearchRequest["backend"],
+  ): Promise<FederatedSearchResponse["results"]> {
+    const response = await this.options.local.listThreads({
+      backend: backend === "all" ? undefined : backend,
+      filter: query,
+    });
     return response.threads.map((thread) => ({
       ref: buildFederatedThreadRef({
         backend: thread.source,
@@ -82,8 +91,10 @@ export class FederatedSearchService {
   private async searchPeer(
     peer: FederatedSearchPeer,
     query: string,
+    backend?: FederatedSearchRequest["backend"],
   ): Promise<FederatedSearchResponse["results"]> {
     const response: AppServerListThreadsResponse = await peer.backend.listThreads({
+      backend: backend === "all" ? undefined : backend,
       filter: query,
     });
     return response.threads.map((thread) => ({

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -6,6 +6,8 @@ import type {
   AppServerReadThreadRequest,
   AppServerReadThreadResponse,
   FederationCapability,
+  StartTurnRequest,
+  StartTurnResponse,
 } from "@pwragent/shared";
 import type { FederationRouter } from "./federation-router";
 import type { FederationRpcEndpoint } from "./federation-rpc";
@@ -14,6 +16,7 @@ export const FEDERATION_BACKEND_METHODS = {
   listThreads: "backend.listThreads",
   readThread: "backend.readThread",
   listSkills: "backend.listSkills",
+  startTurn: "backend.startTurn",
 } as const;
 
 export type FederationBackendMethod =
@@ -26,6 +29,7 @@ export const FEDERATION_BACKEND_METHOD_CAPABILITIES: Record<
   [FEDERATION_BACKEND_METHODS.listThreads]: "thread_navigation",
   [FEDERATION_BACKEND_METHODS.readThread]: "thread_detail",
   [FEDERATION_BACKEND_METHODS.listSkills]: "thread_detail",
+  [FEDERATION_BACKEND_METHODS.startTurn]: "turn_control",
 };
 
 export type FederationBackendOperations = {
@@ -38,6 +42,7 @@ export type FederationBackendOperations = {
   listSkills(
     request?: AppServerListSkillsRequest,
   ): Promise<AppServerListSkillsResponse>;
+  startTurn(request: StartTurnRequest): Promise<StartTurnResponse>;
 };
 
 export function registerFederationBackendHandlers(params: {
@@ -63,6 +68,13 @@ export function registerFederationBackendHandlers(params: {
     async (envelope) =>
       await params.backend.listSkills(
         (envelope.params ?? {}) as AppServerListSkillsRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.startTurn,
+    async (envelope) =>
+      await params.backend.startTurn(
+        envelope.params as StartTurnRequest,
       ),
   );
 }
@@ -93,6 +105,13 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
   ): Promise<AppServerListSkillsResponse> {
     return await this.rpc.request<AppServerListSkillsResponse>({
       method: FEDERATION_BACKEND_METHODS.listSkills,
+      params: request,
+    });
+  }
+
+  async startTurn(request: StartTurnRequest): Promise<StartTurnResponse> {
+    return await this.rpc.request<StartTurnResponse>({
+      method: FEDERATION_BACKEND_METHODS.startTurn,
       params: request,
     });
   }

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -5,6 +5,7 @@ import type {
   AppServerListThreadsResponse,
   AppServerReadThreadRequest,
   AppServerReadThreadResponse,
+  AgentEvent,
   FederationCapability,
   StartTurnRequest,
   StartTurnResponse,
@@ -18,6 +19,13 @@ export const FEDERATION_BACKEND_METHODS = {
   listSkills: "backend.listSkills",
   startTurn: "backend.startTurn",
 } as const;
+
+export const FEDERATION_BACKEND_EVENT_METHOD = "backend.event";
+
+export type FederationBackendEventNotification = {
+  method: typeof FEDERATION_BACKEND_EVENT_METHOD;
+  params: AgentEvent;
+};
 
 export type FederationBackendMethod =
   (typeof FEDERATION_BACKEND_METHODS)[keyof typeof FEDERATION_BACKEND_METHODS];

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -6,9 +6,33 @@ import type {
   AppServerReadThreadRequest,
   AppServerReadThreadResponse,
   AgentEvent,
+  CancelThreadExecutionModeQueueRequest,
+  CancelThreadExecutionModeQueueResponse,
+  CompactThreadRequest,
+  CompactThreadResponse,
   FederationCapability,
+  HandoffThreadWorkspaceRequest,
+  HandoffThreadWorkspaceResponse,
+  InterruptTurnRequest,
+  InterruptTurnResponse,
+  QueueThreadExecutionModeRequest,
+  QueueThreadExecutionModeResponse,
+  RunCodexEnvironmentActionRequest,
+  RunCodexEnvironmentActionResponse,
+  SetAcpSessionRuntimeOptionRequest,
+  SetAcpSessionRuntimeOptionResponse,
+  SetCodexThreadEnvironmentRequest,
+  SetCodexThreadEnvironmentResponse,
+  SetThreadExecutionModeRequest,
+  SetThreadExecutionModeResponse,
+  SetThreadModelSettingsRequest,
+  SetThreadModelSettingsResponse,
+  SteerTurnRequest,
+  SteerTurnResponse,
   StartTurnRequest,
   StartTurnResponse,
+  SubmitServerRequestRequest,
+  SubmitServerRequestResponse,
 } from "@pwragent/shared";
 import type { FederationRouter } from "./federation-router";
 import type { FederationRpcEndpoint } from "./federation-rpc";
@@ -18,6 +42,18 @@ export const FEDERATION_BACKEND_METHODS = {
   readThread: "backend.readThread",
   listSkills: "backend.listSkills",
   startTurn: "backend.startTurn",
+  compactThread: "backend.compactThread",
+  interruptTurn: "backend.interruptTurn",
+  steerTurn: "backend.steerTurn",
+  setThreadExecutionMode: "backend.setThreadExecutionMode",
+  queueThreadExecutionMode: "backend.queueThreadExecutionMode",
+  cancelThreadExecutionModeQueue: "backend.cancelThreadExecutionModeQueue",
+  setAcpSessionRuntimeOption: "backend.setAcpSessionRuntimeOption",
+  setThreadModelSettings: "backend.setThreadModelSettings",
+  submitServerRequest: "backend.submitServerRequest",
+  runCodexEnvironmentAction: "backend.runCodexEnvironmentAction",
+  setCodexThreadEnvironment: "backend.setCodexThreadEnvironment",
+  handoffThreadWorkspace: "backend.handoffThreadWorkspace",
 } as const;
 
 export const FEDERATION_BACKEND_EVENT_METHOD = "backend.event";
@@ -38,6 +74,18 @@ export const FEDERATION_BACKEND_METHOD_CAPABILITIES: Record<
   [FEDERATION_BACKEND_METHODS.readThread]: "thread_detail",
   [FEDERATION_BACKEND_METHODS.listSkills]: "thread_detail",
   [FEDERATION_BACKEND_METHODS.startTurn]: "turn_control",
+  [FEDERATION_BACKEND_METHODS.compactThread]: "turn_control",
+  [FEDERATION_BACKEND_METHODS.interruptTurn]: "turn_control",
+  [FEDERATION_BACKEND_METHODS.steerTurn]: "turn_control",
+  [FEDERATION_BACKEND_METHODS.setThreadExecutionMode]: "turn_control",
+  [FEDERATION_BACKEND_METHODS.queueThreadExecutionMode]: "turn_control",
+  [FEDERATION_BACKEND_METHODS.cancelThreadExecutionModeQueue]: "turn_control",
+  [FEDERATION_BACKEND_METHODS.setAcpSessionRuntimeOption]: "turn_control",
+  [FEDERATION_BACKEND_METHODS.setThreadModelSettings]: "turn_control",
+  [FEDERATION_BACKEND_METHODS.submitServerRequest]: "pending_request_control",
+  [FEDERATION_BACKEND_METHODS.runCodexEnvironmentAction]: "environment_actions",
+  [FEDERATION_BACKEND_METHODS.setCodexThreadEnvironment]: "environment_actions",
+  [FEDERATION_BACKEND_METHODS.handoffThreadWorkspace]: "turn_control",
 };
 
 export type FederationBackendOperations = {
@@ -51,6 +99,36 @@ export type FederationBackendOperations = {
     request?: AppServerListSkillsRequest,
   ): Promise<AppServerListSkillsResponse>;
   startTurn(request: StartTurnRequest): Promise<StartTurnResponse>;
+  compactThread(request: CompactThreadRequest): Promise<CompactThreadResponse>;
+  interruptTurn(request: InterruptTurnRequest): Promise<InterruptTurnResponse>;
+  steerTurn(request: SteerTurnRequest): Promise<SteerTurnResponse>;
+  setThreadExecutionMode(
+    request: SetThreadExecutionModeRequest,
+  ): Promise<SetThreadExecutionModeResponse>;
+  queueThreadExecutionMode(
+    request: QueueThreadExecutionModeRequest,
+  ): Promise<QueueThreadExecutionModeResponse>;
+  cancelThreadExecutionModeQueue(
+    request: CancelThreadExecutionModeQueueRequest,
+  ): Promise<CancelThreadExecutionModeQueueResponse>;
+  setAcpSessionRuntimeOption(
+    request: SetAcpSessionRuntimeOptionRequest,
+  ): Promise<SetAcpSessionRuntimeOptionResponse>;
+  setThreadModelSettings(
+    request: SetThreadModelSettingsRequest,
+  ): Promise<SetThreadModelSettingsResponse>;
+  submitServerRequest(
+    request: SubmitServerRequestRequest,
+  ): Promise<SubmitServerRequestResponse>;
+  runCodexEnvironmentAction(
+    request: RunCodexEnvironmentActionRequest,
+  ): Promise<RunCodexEnvironmentActionResponse>;
+  setCodexThreadEnvironment(
+    request: SetCodexThreadEnvironmentRequest,
+  ): Promise<SetCodexThreadEnvironmentResponse>;
+  handoffThreadWorkspace(
+    request: HandoffThreadWorkspaceRequest,
+  ): Promise<HandoffThreadWorkspaceResponse>;
 };
 
 export function registerFederationBackendHandlers(params: {
@@ -83,6 +161,90 @@ export function registerFederationBackendHandlers(params: {
     async (envelope) =>
       await params.backend.startTurn(
         envelope.params as StartTurnRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.compactThread,
+    async (envelope) =>
+      await params.backend.compactThread(
+        envelope.params as CompactThreadRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.interruptTurn,
+    async (envelope) =>
+      await params.backend.interruptTurn(
+        envelope.params as InterruptTurnRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.steerTurn,
+    async (envelope) =>
+      await params.backend.steerTurn(
+        envelope.params as SteerTurnRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.setThreadExecutionMode,
+    async (envelope) =>
+      await params.backend.setThreadExecutionMode(
+        envelope.params as SetThreadExecutionModeRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.queueThreadExecutionMode,
+    async (envelope) =>
+      await params.backend.queueThreadExecutionMode(
+        envelope.params as QueueThreadExecutionModeRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.cancelThreadExecutionModeQueue,
+    async (envelope) =>
+      await params.backend.cancelThreadExecutionModeQueue(
+        envelope.params as CancelThreadExecutionModeQueueRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.setAcpSessionRuntimeOption,
+    async (envelope) =>
+      await params.backend.setAcpSessionRuntimeOption(
+        envelope.params as SetAcpSessionRuntimeOptionRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.setThreadModelSettings,
+    async (envelope) =>
+      await params.backend.setThreadModelSettings(
+        envelope.params as SetThreadModelSettingsRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.submitServerRequest,
+    async (envelope) =>
+      await params.backend.submitServerRequest(
+        envelope.params as SubmitServerRequestRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.runCodexEnvironmentAction,
+    async (envelope) =>
+      await params.backend.runCodexEnvironmentAction(
+        envelope.params as RunCodexEnvironmentActionRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.setCodexThreadEnvironment,
+    async (envelope) =>
+      await params.backend.setCodexThreadEnvironment(
+        envelope.params as SetCodexThreadEnvironmentRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.handoffThreadWorkspace,
+    async (envelope) =>
+      await params.backend.handoffThreadWorkspace(
+        envelope.params as HandoffThreadWorkspaceRequest,
       ),
   );
 }
@@ -120,6 +282,112 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
   async startTurn(request: StartTurnRequest): Promise<StartTurnResponse> {
     return await this.rpc.request<StartTurnResponse>({
       method: FEDERATION_BACKEND_METHODS.startTurn,
+      params: request,
+    });
+  }
+
+  async compactThread(
+    request: CompactThreadRequest,
+  ): Promise<CompactThreadResponse> {
+    return await this.rpc.request<CompactThreadResponse>({
+      method: FEDERATION_BACKEND_METHODS.compactThread,
+      params: request,
+    });
+  }
+
+  async interruptTurn(
+    request: InterruptTurnRequest,
+  ): Promise<InterruptTurnResponse> {
+    return await this.rpc.request<InterruptTurnResponse>({
+      method: FEDERATION_BACKEND_METHODS.interruptTurn,
+      params: request,
+    });
+  }
+
+  async steerTurn(request: SteerTurnRequest): Promise<SteerTurnResponse> {
+    return await this.rpc.request<SteerTurnResponse>({
+      method: FEDERATION_BACKEND_METHODS.steerTurn,
+      params: request,
+    });
+  }
+
+  async setThreadExecutionMode(
+    request: SetThreadExecutionModeRequest,
+  ): Promise<SetThreadExecutionModeResponse> {
+    return await this.rpc.request<SetThreadExecutionModeResponse>({
+      method: FEDERATION_BACKEND_METHODS.setThreadExecutionMode,
+      params: request,
+    });
+  }
+
+  async queueThreadExecutionMode(
+    request: QueueThreadExecutionModeRequest,
+  ): Promise<QueueThreadExecutionModeResponse> {
+    return await this.rpc.request<QueueThreadExecutionModeResponse>({
+      method: FEDERATION_BACKEND_METHODS.queueThreadExecutionMode,
+      params: request,
+    });
+  }
+
+  async cancelThreadExecutionModeQueue(
+    request: CancelThreadExecutionModeQueueRequest,
+  ): Promise<CancelThreadExecutionModeQueueResponse> {
+    return await this.rpc.request<CancelThreadExecutionModeQueueResponse>({
+      method: FEDERATION_BACKEND_METHODS.cancelThreadExecutionModeQueue,
+      params: request,
+    });
+  }
+
+  async setAcpSessionRuntimeOption(
+    request: SetAcpSessionRuntimeOptionRequest,
+  ): Promise<SetAcpSessionRuntimeOptionResponse> {
+    return await this.rpc.request<SetAcpSessionRuntimeOptionResponse>({
+      method: FEDERATION_BACKEND_METHODS.setAcpSessionRuntimeOption,
+      params: request,
+    });
+  }
+
+  async setThreadModelSettings(
+    request: SetThreadModelSettingsRequest,
+  ): Promise<SetThreadModelSettingsResponse> {
+    return await this.rpc.request<SetThreadModelSettingsResponse>({
+      method: FEDERATION_BACKEND_METHODS.setThreadModelSettings,
+      params: request,
+    });
+  }
+
+  async submitServerRequest(
+    request: SubmitServerRequestRequest,
+  ): Promise<SubmitServerRequestResponse> {
+    return await this.rpc.request<SubmitServerRequestResponse>({
+      method: FEDERATION_BACKEND_METHODS.submitServerRequest,
+      params: request,
+    });
+  }
+
+  async runCodexEnvironmentAction(
+    request: RunCodexEnvironmentActionRequest,
+  ): Promise<RunCodexEnvironmentActionResponse> {
+    return await this.rpc.request<RunCodexEnvironmentActionResponse>({
+      method: FEDERATION_BACKEND_METHODS.runCodexEnvironmentAction,
+      params: request,
+    });
+  }
+
+  async setCodexThreadEnvironment(
+    request: SetCodexThreadEnvironmentRequest,
+  ): Promise<SetCodexThreadEnvironmentResponse> {
+    return await this.rpc.request<SetCodexThreadEnvironmentResponse>({
+      method: FEDERATION_BACKEND_METHODS.setCodexThreadEnvironment,
+      params: request,
+    });
+  }
+
+  async handoffThreadWorkspace(
+    request: HandoffThreadWorkspaceRequest,
+  ): Promise<HandoffThreadWorkspaceResponse> {
+    return await this.rpc.request<HandoffThreadWorkspaceResponse>({
+      method: FEDERATION_BACKEND_METHODS.handoffThreadWorkspace,
       params: request,
     });
   }

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -1,0 +1,99 @@
+import type {
+  AppServerListSkillsRequest,
+  AppServerListSkillsResponse,
+  AppServerListThreadsRequest,
+  AppServerListThreadsResponse,
+  AppServerReadThreadRequest,
+  AppServerReadThreadResponse,
+  FederationCapability,
+} from "@pwragent/shared";
+import type { FederationRouter } from "./federation-router";
+import type { FederationRpcEndpoint } from "./federation-rpc";
+
+export const FEDERATION_BACKEND_METHODS = {
+  listThreads: "backend.listThreads",
+  readThread: "backend.readThread",
+  listSkills: "backend.listSkills",
+} as const;
+
+export type FederationBackendMethod =
+  (typeof FEDERATION_BACKEND_METHODS)[keyof typeof FEDERATION_BACKEND_METHODS];
+
+export const FEDERATION_BACKEND_METHOD_CAPABILITIES: Record<
+  FederationBackendMethod,
+  FederationCapability
+> = {
+  [FEDERATION_BACKEND_METHODS.listThreads]: "thread_navigation",
+  [FEDERATION_BACKEND_METHODS.readThread]: "thread_detail",
+  [FEDERATION_BACKEND_METHODS.listSkills]: "thread_detail",
+};
+
+export type FederationBackendOperations = {
+  listThreads(
+    request?: AppServerListThreadsRequest,
+  ): Promise<AppServerListThreadsResponse>;
+  readThread(
+    request: AppServerReadThreadRequest,
+  ): Promise<AppServerReadThreadResponse>;
+  listSkills(
+    request?: AppServerListSkillsRequest,
+  ): Promise<AppServerListSkillsResponse>;
+};
+
+export function registerFederationBackendHandlers(params: {
+  router: FederationRouter;
+  backend: FederationBackendOperations;
+}): void {
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.listThreads,
+    async (envelope) =>
+      await params.backend.listThreads(
+        (envelope.params ?? {}) as AppServerListThreadsRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.readThread,
+    async (envelope) =>
+      await params.backend.readThread(
+        envelope.params as AppServerReadThreadRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.listSkills,
+    async (envelope) =>
+      await params.backend.listSkills(
+        (envelope.params ?? {}) as AppServerListSkillsRequest,
+      ),
+  );
+}
+
+export class FederationRemoteBackendClient implements FederationBackendOperations {
+  constructor(private readonly rpc: FederationRpcEndpoint) {}
+
+  async listThreads(
+    request: AppServerListThreadsRequest = {},
+  ): Promise<AppServerListThreadsResponse> {
+    return await this.rpc.request<AppServerListThreadsResponse>({
+      method: FEDERATION_BACKEND_METHODS.listThreads,
+      params: request,
+    });
+  }
+
+  async readThread(
+    request: AppServerReadThreadRequest,
+  ): Promise<AppServerReadThreadResponse> {
+    return await this.rpc.request<AppServerReadThreadResponse>({
+      method: FEDERATION_BACKEND_METHODS.readThread,
+      params: request,
+    });
+  }
+
+  async listSkills(
+    request: AppServerListSkillsRequest = {},
+  ): Promise<AppServerListSkillsResponse> {
+    return await this.rpc.request<AppServerListSkillsResponse>({
+      method: FEDERATION_BACKEND_METHODS.listSkills,
+      params: request,
+    });
+  }
+}

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -10,11 +10,21 @@ import type {
   CancelThreadExecutionModeQueueResponse,
   CompactThreadRequest,
   CompactThreadResponse,
+  CodexEnvironmentSetupProgressEvent,
   FederationCapability,
+  ForkThreadRequest,
+  ForkThreadResponse,
+  GetNavigationSnapshotRequest,
   HandoffThreadWorkspaceRequest,
   HandoffThreadWorkspaceResponse,
   InterruptTurnRequest,
   InterruptTurnResponse,
+  ListBackendsRequest,
+  ListBackendsResponse,
+  MaterializeDirectoryLaunchpadOptions,
+  MaterializeDirectoryLaunchpadRequest,
+  MaterializeDirectoryLaunchpadResponse,
+  NavigationSnapshot,
   QueueThreadExecutionModeRequest,
   QueueThreadExecutionModeResponse,
   RunCodexEnvironmentActionRequest,
@@ -31,6 +41,12 @@ import type {
   SteerTurnResponse,
   StartTurnRequest,
   StartTurnResponse,
+  StartReviewRequest,
+  StartReviewResponse,
+  StartThreadRequest,
+  StartThreadResponse,
+  StopCodexEnvironmentActionRequest,
+  StopCodexEnvironmentActionResponse,
   SubmitServerRequestRequest,
   SubmitServerRequestResponse,
 } from "@pwragent/shared";
@@ -38,10 +54,15 @@ import type { FederationRouter } from "./federation-router";
 import type { FederationRpcEndpoint } from "./federation-rpc";
 
 export const FEDERATION_BACKEND_METHODS = {
+  getNavigationSnapshot: "backend.getNavigationSnapshot",
   listThreads: "backend.listThreads",
   readThread: "backend.readThread",
   listSkills: "backend.listSkills",
+  listBackends: "backend.listBackends",
+  startThread: "backend.startThread",
+  forkThread: "backend.forkThread",
   startTurn: "backend.startTurn",
+  startReview: "backend.startReview",
   compactThread: "backend.compactThread",
   interruptTurn: "backend.interruptTurn",
   steerTurn: "backend.steerTurn",
@@ -52,15 +73,24 @@ export const FEDERATION_BACKEND_METHODS = {
   setThreadModelSettings: "backend.setThreadModelSettings",
   submitServerRequest: "backend.submitServerRequest",
   runCodexEnvironmentAction: "backend.runCodexEnvironmentAction",
+  stopCodexEnvironmentAction: "backend.stopCodexEnvironmentAction",
   setCodexThreadEnvironment: "backend.setCodexThreadEnvironment",
+  materializeDirectoryLaunchpad: "backend.materializeDirectoryLaunchpad",
   handoffThreadWorkspace: "backend.handoffThreadWorkspace",
 } as const;
 
 export const FEDERATION_BACKEND_EVENT_METHOD = "backend.event";
+export const FEDERATION_ENVIRONMENT_SETUP_PROGRESS_METHOD =
+  "backend.environmentSetupProgress";
 
 export type FederationBackendEventNotification = {
   method: typeof FEDERATION_BACKEND_EVENT_METHOD;
   params: AgentEvent;
+};
+
+export type FederationEnvironmentSetupProgressNotification = {
+  method: typeof FEDERATION_ENVIRONMENT_SETUP_PROGRESS_METHOD;
+  params: CodexEnvironmentSetupProgressEvent;
 };
 
 export type FederationBackendMethod =
@@ -70,10 +100,15 @@ export const FEDERATION_BACKEND_METHOD_CAPABILITIES: Record<
   FederationBackendMethod,
   FederationCapability
 > = {
+  [FEDERATION_BACKEND_METHODS.getNavigationSnapshot]: "thread_navigation",
   [FEDERATION_BACKEND_METHODS.listThreads]: "thread_navigation",
   [FEDERATION_BACKEND_METHODS.readThread]: "thread_detail",
   [FEDERATION_BACKEND_METHODS.listSkills]: "thread_detail",
+  [FEDERATION_BACKEND_METHODS.listBackends]: "thread_detail",
+  [FEDERATION_BACKEND_METHODS.startThread]: "turn_control",
+  [FEDERATION_BACKEND_METHODS.forkThread]: "turn_control",
   [FEDERATION_BACKEND_METHODS.startTurn]: "turn_control",
+  [FEDERATION_BACKEND_METHODS.startReview]: "turn_control",
   [FEDERATION_BACKEND_METHODS.compactThread]: "turn_control",
   [FEDERATION_BACKEND_METHODS.interruptTurn]: "turn_control",
   [FEDERATION_BACKEND_METHODS.steerTurn]: "turn_control",
@@ -84,11 +119,16 @@ export const FEDERATION_BACKEND_METHOD_CAPABILITIES: Record<
   [FEDERATION_BACKEND_METHODS.setThreadModelSettings]: "turn_control",
   [FEDERATION_BACKEND_METHODS.submitServerRequest]: "pending_request_control",
   [FEDERATION_BACKEND_METHODS.runCodexEnvironmentAction]: "environment_actions",
+  [FEDERATION_BACKEND_METHODS.stopCodexEnvironmentAction]: "environment_actions",
   [FEDERATION_BACKEND_METHODS.setCodexThreadEnvironment]: "environment_actions",
+  [FEDERATION_BACKEND_METHODS.materializeDirectoryLaunchpad]: "environment_actions",
   [FEDERATION_BACKEND_METHODS.handoffThreadWorkspace]: "turn_control",
 };
 
 export type FederationBackendOperations = {
+  getNavigationSnapshot(
+    request?: GetNavigationSnapshotRequest,
+  ): Promise<NavigationSnapshot>;
   listThreads(
     request?: AppServerListThreadsRequest,
   ): Promise<AppServerListThreadsResponse>;
@@ -98,7 +138,17 @@ export type FederationBackendOperations = {
   listSkills(
     request?: AppServerListSkillsRequest,
   ): Promise<AppServerListSkillsResponse>;
+  listBackends(request?: ListBackendsRequest): Promise<ListBackendsResponse>;
+  startThread(request: StartThreadRequest): Promise<StartThreadResponse>;
+  forkThread(
+    request: ForkThreadRequest,
+    options?: Pick<
+      MaterializeDirectoryLaunchpadOptions,
+      "onCodexEnvironmentSetupProgress"
+    >,
+  ): Promise<ForkThreadResponse>;
   startTurn(request: StartTurnRequest): Promise<StartTurnResponse>;
+  startReview(request: StartReviewRequest): Promise<StartReviewResponse>;
   compactThread(request: CompactThreadRequest): Promise<CompactThreadResponse>;
   interruptTurn(request: InterruptTurnRequest): Promise<InterruptTurnResponse>;
   steerTurn(request: SteerTurnRequest): Promise<SteerTurnResponse>;
@@ -123,9 +173,16 @@ export type FederationBackendOperations = {
   runCodexEnvironmentAction(
     request: RunCodexEnvironmentActionRequest,
   ): Promise<RunCodexEnvironmentActionResponse>;
+  stopCodexEnvironmentAction(
+    request: StopCodexEnvironmentActionRequest,
+  ): Promise<StopCodexEnvironmentActionResponse>;
   setCodexThreadEnvironment(
     request: SetCodexThreadEnvironmentRequest,
   ): Promise<SetCodexThreadEnvironmentResponse>;
+  materializeDirectoryLaunchpad(
+    request: MaterializeDirectoryLaunchpadRequest,
+    options?: MaterializeDirectoryLaunchpadOptions,
+  ): Promise<MaterializeDirectoryLaunchpadResponse>;
   handoffThreadWorkspace(
     request: HandoffThreadWorkspaceRequest,
   ): Promise<HandoffThreadWorkspaceResponse>;
@@ -134,7 +191,18 @@ export type FederationBackendOperations = {
 export function registerFederationBackendHandlers(params: {
   router: FederationRouter;
   backend: FederationBackendOperations;
+  onEnvironmentSetupProgress?: (
+    event: CodexEnvironmentSetupProgressEvent,
+    targetInstanceId: string,
+  ) => void;
 }): void {
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.getNavigationSnapshot,
+    async (envelope) =>
+      await params.backend.getNavigationSnapshot(
+        (envelope.params ?? {}) as GetNavigationSnapshotRequest,
+      ),
+  );
   params.router.registerHandler(
     FEDERATION_BACKEND_METHODS.listThreads,
     async (envelope) =>
@@ -157,10 +225,46 @@ export function registerFederationBackendHandlers(params: {
       ),
   );
   params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.listBackends,
+    async (envelope) =>
+      await params.backend.listBackends(
+        (envelope.params ?? {}) as ListBackendsRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.startThread,
+    async (envelope) =>
+      await params.backend.startThread(
+        envelope.params as StartThreadRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.forkThread,
+    async (envelope) =>
+      await params.backend.forkThread(
+        envelope.params as ForkThreadRequest,
+        {
+          onCodexEnvironmentSetupProgress: (event) => {
+            params.onEnvironmentSetupProgress?.(
+              event,
+              envelope.sourceInstanceId,
+            );
+          },
+        },
+      ),
+  );
+  params.router.registerHandler(
     FEDERATION_BACKEND_METHODS.startTurn,
     async (envelope) =>
       await params.backend.startTurn(
         envelope.params as StartTurnRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.startReview,
+    async (envelope) =>
+      await params.backend.startReview(
+        envelope.params as StartReviewRequest,
       ),
   );
   params.router.registerHandler(
@@ -234,10 +338,32 @@ export function registerFederationBackendHandlers(params: {
       ),
   );
   params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.stopCodexEnvironmentAction,
+    async (envelope) =>
+      await params.backend.stopCodexEnvironmentAction(
+        envelope.params as StopCodexEnvironmentActionRequest,
+      ),
+  );
+  params.router.registerHandler(
     FEDERATION_BACKEND_METHODS.setCodexThreadEnvironment,
     async (envelope) =>
       await params.backend.setCodexThreadEnvironment(
         envelope.params as SetCodexThreadEnvironmentRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.materializeDirectoryLaunchpad,
+    async (envelope) =>
+      await params.backend.materializeDirectoryLaunchpad(
+        envelope.params as MaterializeDirectoryLaunchpadRequest,
+        {
+          onCodexEnvironmentSetupProgress: (event) => {
+            params.onEnvironmentSetupProgress?.(
+              event,
+              envelope.sourceInstanceId,
+            );
+          },
+        },
       ),
   );
   params.router.registerHandler(
@@ -251,6 +377,15 @@ export function registerFederationBackendHandlers(params: {
 
 export class FederationRemoteBackendClient implements FederationBackendOperations {
   constructor(private readonly rpc: FederationRpcEndpoint) {}
+
+  async getNavigationSnapshot(
+    request: GetNavigationSnapshotRequest = {},
+  ): Promise<NavigationSnapshot> {
+    return await this.rpc.request<NavigationSnapshot>({
+      method: FEDERATION_BACKEND_METHODS.getNavigationSnapshot,
+      params: request,
+    });
+  }
 
   async listThreads(
     request: AppServerListThreadsRequest = {},
@@ -279,9 +414,39 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
     });
   }
 
+  async listBackends(
+    request: ListBackendsRequest = {},
+  ): Promise<ListBackendsResponse> {
+    return await this.rpc.request<ListBackendsResponse>({
+      method: FEDERATION_BACKEND_METHODS.listBackends,
+      params: request,
+    });
+  }
+
+  async startThread(request: StartThreadRequest): Promise<StartThreadResponse> {
+    return await this.rpc.request<StartThreadResponse>({
+      method: FEDERATION_BACKEND_METHODS.startThread,
+      params: request,
+    });
+  }
+
+  async forkThread(request: ForkThreadRequest): Promise<ForkThreadResponse> {
+    return await this.rpc.request<ForkThreadResponse>({
+      method: FEDERATION_BACKEND_METHODS.forkThread,
+      params: request,
+    });
+  }
+
   async startTurn(request: StartTurnRequest): Promise<StartTurnResponse> {
     return await this.rpc.request<StartTurnResponse>({
       method: FEDERATION_BACKEND_METHODS.startTurn,
+      params: request,
+    });
+  }
+
+  async startReview(request: StartReviewRequest): Promise<StartReviewResponse> {
+    return await this.rpc.request<StartReviewResponse>({
+      method: FEDERATION_BACKEND_METHODS.startReview,
       params: request,
     });
   }
@@ -374,11 +539,29 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
     });
   }
 
+  async stopCodexEnvironmentAction(
+    request: StopCodexEnvironmentActionRequest,
+  ): Promise<StopCodexEnvironmentActionResponse> {
+    return await this.rpc.request<StopCodexEnvironmentActionResponse>({
+      method: FEDERATION_BACKEND_METHODS.stopCodexEnvironmentAction,
+      params: request,
+    });
+  }
+
   async setCodexThreadEnvironment(
     request: SetCodexThreadEnvironmentRequest,
   ): Promise<SetCodexThreadEnvironmentResponse> {
     return await this.rpc.request<SetCodexThreadEnvironmentResponse>({
       method: FEDERATION_BACKEND_METHODS.setCodexThreadEnvironment,
+      params: request,
+    });
+  }
+
+  async materializeDirectoryLaunchpad(
+    request: MaterializeDirectoryLaunchpadRequest,
+  ): Promise<MaterializeDirectoryLaunchpadResponse> {
+    return await this.rpc.request<MaterializeDirectoryLaunchpadResponse>({
+      method: FEDERATION_BACKEND_METHODS.materializeDirectoryLaunchpad,
       params: request,
     });
   }

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -6,6 +6,8 @@ import type {
   AppServerReadThreadRequest,
   AppServerReadThreadResponse,
   AgentEvent,
+  ArchiveThreadRequest,
+  ArchiveThreadResponse,
   CancelThreadExecutionModeQueueRequest,
   CancelThreadExecutionModeQueueResponse,
   CompactThreadRequest,
@@ -66,6 +68,7 @@ export const FEDERATION_BACKEND_METHODS = {
   readThread: "backend.readThread",
   listSkills: "backend.listSkills",
   listBackends: "backend.listBackends",
+  archiveThread: "backend.archiveThread",
   startThread: "backend.startThread",
   forkThread: "backend.forkThread",
   startTurn: "backend.startTurn",
@@ -116,6 +119,7 @@ export const FEDERATION_BACKEND_METHOD_CAPABILITIES: Record<
   [FEDERATION_BACKEND_METHODS.readThread]: "thread_detail",
   [FEDERATION_BACKEND_METHODS.listSkills]: "thread_detail",
   [FEDERATION_BACKEND_METHODS.listBackends]: "thread_detail",
+  [FEDERATION_BACKEND_METHODS.archiveThread]: "turn_control",
   [FEDERATION_BACKEND_METHODS.startThread]: "turn_control",
   [FEDERATION_BACKEND_METHODS.forkThread]: "turn_control",
   [FEDERATION_BACKEND_METHODS.startTurn]: "turn_control",
@@ -154,6 +158,7 @@ export type FederationBackendOperations = {
     request?: AppServerListSkillsRequest,
   ): Promise<AppServerListSkillsResponse>;
   listBackends(request?: ListBackendsRequest): Promise<ListBackendsResponse>;
+  archiveThread(request: ArchiveThreadRequest): Promise<ArchiveThreadResponse>;
   startThread(request: StartThreadRequest): Promise<StartThreadResponse>;
   forkThread(
     request: ForkThreadRequest,
@@ -252,6 +257,13 @@ export function registerFederationBackendHandlers(params: {
     async (envelope) =>
       await params.backend.listBackends(
         (envelope.params ?? {}) as ListBackendsRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.archiveThread,
+    async (envelope) =>
+      await params.backend.archiveThread(
+        envelope.params as ArchiveThreadRequest,
       ),
   );
   params.router.registerHandler(
@@ -467,6 +479,15 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
   ): Promise<ListBackendsResponse> {
     return await this.rpc.request<ListBackendsResponse>({
       method: FEDERATION_BACKEND_METHODS.listBackends,
+      params: request,
+    });
+  }
+
+  async archiveThread(
+    request: ArchiveThreadRequest,
+  ): Promise<ArchiveThreadResponse> {
+    return await this.rpc.request<ArchiveThreadResponse>({
+      method: FEDERATION_BACKEND_METHODS.archiveThread,
       params: request,
     });
   }

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -25,6 +25,7 @@ import type {
   MaterializeDirectoryLaunchpadRequest,
   MaterializeDirectoryLaunchpadResponse,
   NavigationSnapshot,
+  DesktopApplicationsSnapshot,
   OpenDesktopApplicationRequest,
   OpenDesktopApplicationResponse,
   QueueThreadExecutionModeRequest,
@@ -84,6 +85,7 @@ export const FEDERATION_BACKEND_METHODS = {
   materializeDirectoryLaunchpad: "backend.materializeDirectoryLaunchpad",
   handoffThreadWorkspace: "backend.handoffThreadWorkspace",
   renameThread: "backend.renameThread",
+  readApplications: "backend.readApplications",
   openApplication: "backend.openApplication",
   trustCodexProject: "backend.trustCodexProject",
 } as const;
@@ -133,6 +135,7 @@ export const FEDERATION_BACKEND_METHOD_CAPABILITIES: Record<
   [FEDERATION_BACKEND_METHODS.materializeDirectoryLaunchpad]: "environment_actions",
   [FEDERATION_BACKEND_METHODS.handoffThreadWorkspace]: "turn_control",
   [FEDERATION_BACKEND_METHODS.renameThread]: "turn_control",
+  [FEDERATION_BACKEND_METHODS.readApplications]: "remote_window",
   [FEDERATION_BACKEND_METHODS.openApplication]: "remote_window",
   [FEDERATION_BACKEND_METHODS.trustCodexProject]: "environment_actions",
 };
@@ -199,6 +202,7 @@ export type FederationBackendOperations = {
     request: HandoffThreadWorkspaceRequest,
   ): Promise<HandoffThreadWorkspaceResponse>;
   renameThread(request: RenameThreadRequest): Promise<RenameThreadResponse>;
+  readApplications(): Promise<DesktopApplicationsSnapshot>;
   openApplication(
     request: OpenDesktopApplicationRequest,
   ): Promise<OpenDesktopApplicationResponse>;
@@ -398,6 +402,10 @@ export function registerFederationBackendHandlers(params: {
       await params.backend.renameThread(
         envelope.params as RenameThreadRequest,
       ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.readApplications,
+    async () => await params.backend.readApplications(),
   );
   params.router.registerHandler(
     FEDERATION_BACKEND_METHODS.openApplication,
@@ -630,6 +638,13 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
     return await this.rpc.request<OpenDesktopApplicationResponse>({
       method: FEDERATION_BACKEND_METHODS.openApplication,
       params: request,
+    });
+  }
+
+  async readApplications(): Promise<DesktopApplicationsSnapshot> {
+    return await this.rpc.request<DesktopApplicationsSnapshot>({
+      method: FEDERATION_BACKEND_METHODS.readApplications,
+      params: {},
     });
   }
 

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -25,8 +25,12 @@ import type {
   MaterializeDirectoryLaunchpadRequest,
   MaterializeDirectoryLaunchpadResponse,
   NavigationSnapshot,
+  OpenDesktopApplicationRequest,
+  OpenDesktopApplicationResponse,
   QueueThreadExecutionModeRequest,
   QueueThreadExecutionModeResponse,
+  RenameThreadRequest,
+  RenameThreadResponse,
   RunCodexEnvironmentActionRequest,
   RunCodexEnvironmentActionResponse,
   SetAcpSessionRuntimeOptionRequest,
@@ -49,6 +53,8 @@ import type {
   StopCodexEnvironmentActionResponse,
   SubmitServerRequestRequest,
   SubmitServerRequestResponse,
+  TrustCodexProjectRequest,
+  TrustCodexProjectResponse,
 } from "@pwragent/shared";
 import type { FederationRouter } from "./federation-router";
 import type { FederationRpcEndpoint } from "./federation-rpc";
@@ -77,6 +83,9 @@ export const FEDERATION_BACKEND_METHODS = {
   setCodexThreadEnvironment: "backend.setCodexThreadEnvironment",
   materializeDirectoryLaunchpad: "backend.materializeDirectoryLaunchpad",
   handoffThreadWorkspace: "backend.handoffThreadWorkspace",
+  renameThread: "backend.renameThread",
+  openApplication: "backend.openApplication",
+  trustCodexProject: "backend.trustCodexProject",
 } as const;
 
 export const FEDERATION_BACKEND_EVENT_METHOD = "backend.event";
@@ -123,6 +132,9 @@ export const FEDERATION_BACKEND_METHOD_CAPABILITIES: Record<
   [FEDERATION_BACKEND_METHODS.setCodexThreadEnvironment]: "environment_actions",
   [FEDERATION_BACKEND_METHODS.materializeDirectoryLaunchpad]: "environment_actions",
   [FEDERATION_BACKEND_METHODS.handoffThreadWorkspace]: "turn_control",
+  [FEDERATION_BACKEND_METHODS.renameThread]: "turn_control",
+  [FEDERATION_BACKEND_METHODS.openApplication]: "remote_window",
+  [FEDERATION_BACKEND_METHODS.trustCodexProject]: "environment_actions",
 };
 
 export type FederationBackendOperations = {
@@ -186,6 +198,13 @@ export type FederationBackendOperations = {
   handoffThreadWorkspace(
     request: HandoffThreadWorkspaceRequest,
   ): Promise<HandoffThreadWorkspaceResponse>;
+  renameThread(request: RenameThreadRequest): Promise<RenameThreadResponse>;
+  openApplication(
+    request: OpenDesktopApplicationRequest,
+  ): Promise<OpenDesktopApplicationResponse>;
+  trustCodexProject(
+    request: TrustCodexProjectRequest,
+  ): Promise<TrustCodexProjectResponse>;
 };
 
 export function registerFederationBackendHandlers(params: {
@@ -371,6 +390,27 @@ export function registerFederationBackendHandlers(params: {
     async (envelope) =>
       await params.backend.handoffThreadWorkspace(
         envelope.params as HandoffThreadWorkspaceRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.renameThread,
+    async (envelope) =>
+      await params.backend.renameThread(
+        envelope.params as RenameThreadRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.openApplication,
+    async (envelope) =>
+      await params.backend.openApplication(
+        envelope.params as OpenDesktopApplicationRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.trustCodexProject,
+    async (envelope) =>
+      await params.backend.trustCodexProject(
+        envelope.params as TrustCodexProjectRequest,
       ),
   );
 }
@@ -571,6 +611,33 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
   ): Promise<HandoffThreadWorkspaceResponse> {
     return await this.rpc.request<HandoffThreadWorkspaceResponse>({
       method: FEDERATION_BACKEND_METHODS.handoffThreadWorkspace,
+      params: request,
+    });
+  }
+
+  async renameThread(
+    request: RenameThreadRequest,
+  ): Promise<RenameThreadResponse> {
+    return await this.rpc.request<RenameThreadResponse>({
+      method: FEDERATION_BACKEND_METHODS.renameThread,
+      params: request,
+    });
+  }
+
+  async openApplication(
+    request: OpenDesktopApplicationRequest,
+  ): Promise<OpenDesktopApplicationResponse> {
+    return await this.rpc.request<OpenDesktopApplicationResponse>({
+      method: FEDERATION_BACKEND_METHODS.openApplication,
+      params: request,
+    });
+  }
+
+  async trustCodexProject(
+    request: TrustCodexProjectRequest,
+  ): Promise<TrustCodexProjectResponse> {
+    return await this.rpc.request<TrustCodexProjectResponse>({
+      method: FEDERATION_BACKEND_METHODS.trustCodexProject,
       params: request,
     });
   }

--- a/apps/desktop/src/main/federation/federation-enrollment.ts
+++ b/apps/desktop/src/main/federation/federation-enrollment.ts
@@ -1,0 +1,255 @@
+import type {
+  FederationCapability,
+  FederationInstanceId,
+  FederationInstanceRole,
+  FederationPeerSummary,
+} from "@pwragent/shared";
+import {
+  FEDERATION_PROTOCOL_VERSION,
+  isFederationInstanceId,
+} from "@pwragent/shared";
+import {
+  verifyFederationMessageSignature,
+} from "./federation-identity";
+import { evaluateFederationSessionPolicy } from "./federation-policy";
+import {
+  federationFailure,
+  type FederationRedactedFailure,
+} from "./federation-redaction";
+import type {
+  FederationEnrollmentEntry,
+  FederationStore,
+} from "./federation-store";
+
+export type FederationEnrollmentInvite = FederationEnrollmentEntry & {
+  token: string;
+};
+
+export type FederationAuthDecision =
+  | {
+      accepted: true;
+      peer: FederationPeerSummary;
+      capabilities: FederationCapability[];
+    }
+  | {
+      accepted: false;
+      failure: FederationRedactedFailure;
+    };
+
+export function createFederationEnrollmentInvite(params: {
+  store: FederationStore;
+  token: string;
+  gatewayInstanceId: FederationInstanceId;
+  generatedAt: number;
+  expiresAt: number;
+  label?: string;
+  role?: FederationInstanceRole;
+  endpoint?: string;
+}): FederationEnrollmentInvite {
+  const entry = params.store.createEnrollment({
+    token: params.token,
+    generatedAt: params.generatedAt,
+    expiresAt: params.expiresAt,
+    label: params.label,
+    role: params.role,
+    endpoint: params.endpoint,
+    gatewayInstanceId: params.gatewayInstanceId,
+  });
+  return {
+    ...entry,
+    token: params.token,
+  };
+}
+
+export function completeFederationEnrollment(params: {
+  store: FederationStore;
+  gatewayInstanceId: FederationInstanceId;
+  inviteToken: string;
+  now: number;
+  peer: {
+    instanceId: FederationInstanceId;
+    label: string;
+    role: FederationInstanceRole;
+    publicKeyPem: string;
+    capabilities: readonly FederationCapability[];
+    protocolVersion: number;
+    nonce: string;
+    signatureBase64: string;
+    endpoint?: string;
+    profileName?: string;
+  };
+}): FederationAuthDecision {
+  if (!isFederationInstanceId(params.peer.instanceId)) {
+    return {
+      accepted: false,
+      failure: federationFailure("invalid_peer_id"),
+    };
+  }
+  if (params.peer.protocolVersion !== FEDERATION_PROTOCOL_VERSION) {
+    return {
+      accepted: false,
+      failure: federationFailure("invalid_protocol_version"),
+    };
+  }
+
+  const enrollment = params.store.findMatchingPendingEnrollment({
+    token: params.inviteToken,
+    now: params.now,
+  });
+  if (!enrollment) {
+    return {
+      accepted: false,
+      failure: federationFailure("missing_invite"),
+    };
+  }
+  if (
+    enrollment.gatewayInstanceId &&
+    enrollment.gatewayInstanceId !== params.gatewayInstanceId
+  ) {
+    return {
+      accepted: false,
+      failure: federationFailure("wrong_gateway"),
+    };
+  }
+
+  const message = buildFederationProofMessage({
+    purpose: "enroll",
+    gatewayInstanceId: params.gatewayInstanceId,
+    peerInstanceId: params.peer.instanceId,
+    publicKeyPem: params.peer.publicKeyPem,
+    protocolVersion: params.peer.protocolVersion,
+    nonce: params.peer.nonce,
+    capabilities: params.peer.capabilities,
+  });
+  const signatureValid = verifyFederationMessageSignature({
+    publicKeyPem: params.peer.publicKeyPem,
+    message,
+    signatureBase64: params.peer.signatureBase64,
+  });
+  if (!signatureValid) {
+    return {
+      accepted: false,
+      failure: federationFailure("bad_signature"),
+    };
+  }
+
+  const peer: FederationPeerSummary & { pinnedPublicKeyPem: string } = {
+    id: params.peer.instanceId,
+    label: params.peer.label,
+    role: params.peer.role,
+    status: "connected",
+    capabilities: params.peer.capabilities.slice(),
+    protocolVersion: params.peer.protocolVersion,
+    endpoint: params.peer.endpoint ?? enrollment.endpoint,
+    profileName: params.peer.profileName,
+    lastConnectedAt: params.now,
+    lastActivityAt: params.now,
+    pinnedPublicKeyPem: params.peer.publicKeyPem,
+  };
+  params.store.upsertPeer({ peer, updatedAt: params.now });
+  params.store.markEnrollmentUsed({
+    enrollmentId: enrollment.id,
+    peerId: params.peer.instanceId,
+    usedAt: params.now,
+  });
+
+  return {
+    accepted: true,
+    peer,
+    capabilities: peer.capabilities,
+  };
+}
+
+export function authenticateFederationReconnect(params: {
+  store: FederationStore;
+  gatewayInstanceId: FederationInstanceId;
+  peerInstanceId: FederationInstanceId;
+  protocolVersion: number;
+  nonce: string;
+  requestedCapabilities: readonly FederationCapability[];
+  signatureBase64: string;
+  now: number;
+}): FederationAuthDecision {
+  if (!isFederationInstanceId(params.peerInstanceId)) {
+    return {
+      accepted: false,
+      failure: federationFailure("invalid_peer_id"),
+    };
+  }
+  const peer = params.store.getPeer(params.peerInstanceId);
+  const policy = evaluateFederationSessionPolicy({
+    peer,
+    protocolVersion: params.protocolVersion,
+    requestedCapabilities: params.requestedCapabilities,
+  });
+  if (!policy.accepted) {
+    return policy;
+  }
+  if (!peer) {
+    return {
+      accepted: false,
+      failure: federationFailure("unknown_peer"),
+    };
+  }
+  if (!peer.pinnedPublicKeyPem) {
+    return {
+      accepted: false,
+      failure: federationFailure("unknown_peer"),
+    };
+  }
+
+  const message = buildFederationProofMessage({
+    purpose: "reconnect",
+    gatewayInstanceId: params.gatewayInstanceId,
+    peerInstanceId: params.peerInstanceId,
+    publicKeyPem: peer.pinnedPublicKeyPem,
+    protocolVersion: params.protocolVersion,
+    nonce: params.nonce,
+    capabilities: params.requestedCapabilities,
+  });
+  const signatureValid = verifyFederationMessageSignature({
+    publicKeyPem: peer.pinnedPublicKeyPem,
+    message,
+    signatureBase64: params.signatureBase64,
+  });
+  if (!signatureValid) {
+    return {
+      accepted: false,
+      failure: federationFailure("bad_signature"),
+    };
+  }
+
+  const connectedPeer: FederationPeerSummary & { pinnedPublicKeyPem?: string } = {
+    ...peer,
+    status: "connected",
+    lastConnectedAt: params.now,
+    lastActivityAt: params.now,
+  };
+  params.store.upsertPeer({ peer: connectedPeer, updatedAt: params.now });
+
+  return {
+    accepted: true,
+    peer: connectedPeer,
+    capabilities: policy.capabilities,
+  };
+}
+
+export function buildFederationProofMessage(params: {
+  purpose: "enroll" | "reconnect";
+  gatewayInstanceId: FederationInstanceId;
+  peerInstanceId: FederationInstanceId;
+  publicKeyPem: string;
+  protocolVersion: number;
+  nonce: string;
+  capabilities: readonly FederationCapability[];
+}): string {
+  return JSON.stringify({
+    capabilities: params.capabilities.slice().sort(),
+    gatewayInstanceId: params.gatewayInstanceId,
+    nonce: params.nonce,
+    peerInstanceId: params.peerInstanceId,
+    protocolVersion: params.protocolVersion,
+    publicKeyPem: params.publicKeyPem,
+    purpose: params.purpose,
+  });
+}

--- a/apps/desktop/src/main/federation/federation-enrollment.ts
+++ b/apps/desktop/src/main/federation/federation-enrollment.ts
@@ -25,6 +25,15 @@ export type FederationEnrollmentInvite = FederationEnrollmentEntry & {
   token: string;
 };
 
+export type FederationInvitePayload = {
+  version: 1;
+  token: string;
+  gatewayInstanceId: FederationInstanceId;
+  gatewayPublicKeyPem: string;
+  gatewayUrl: string;
+  expiresAt: number;
+};
+
 export type FederationAuthDecision =
   | {
       accepted: true;
@@ -59,6 +68,34 @@ export function createFederationEnrollmentInvite(params: {
     ...entry,
     token: params.token,
   };
+}
+
+export function encodeFederationInvite(payload: FederationInvitePayload): string {
+  return `pwragent-federation:${Buffer.from(JSON.stringify(payload), "utf8").toString("base64url")}`;
+}
+
+export function decodeFederationInvite(
+  invite: string,
+  now = Date.now(),
+): FederationInvitePayload {
+  const encoded = invite.trim().replace(/^pwragent-federation:/, "");
+  const parsed = JSON.parse(
+    Buffer.from(encoded, "base64url").toString("utf8"),
+  ) as Partial<FederationInvitePayload>;
+  if (
+    parsed.version !== 1 ||
+    typeof parsed.token !== "string" ||
+    typeof parsed.gatewayInstanceId !== "string" ||
+    typeof parsed.gatewayPublicKeyPem !== "string" ||
+    typeof parsed.gatewayUrl !== "string" ||
+    typeof parsed.expiresAt !== "number"
+  ) {
+    throw new Error("Invalid federation invite.");
+  }
+  if (parsed.expiresAt <= now) {
+    throw new Error("Federation invite has expired.");
+  }
+  return parsed as FederationInvitePayload;
 }
 
 export function completeFederationEnrollment(params: {
@@ -251,5 +288,39 @@ export function buildFederationProofMessage(params: {
     protocolVersion: params.protocolVersion,
     publicKeyPem: params.publicKeyPem,
     purpose: params.purpose,
+  });
+}
+
+export function buildFederationGatewayChallengeMessage(params: {
+  gatewayInstanceId: FederationInstanceId;
+  gatewayPublicKeyPem: string;
+  protocolVersion: number;
+  nonce: string;
+}): string {
+  return JSON.stringify({
+    gatewayInstanceId: params.gatewayInstanceId,
+    gatewayPublicKeyPem: params.gatewayPublicKeyPem,
+    nonce: params.nonce,
+    protocolVersion: params.protocolVersion,
+    purpose: "gateway_challenge",
+  });
+}
+
+export function buildFederationGatewayAcceptedMessage(params: {
+  gatewayInstanceId: FederationInstanceId;
+  peerInstanceId: FederationInstanceId;
+  sessionId: string;
+  protocolVersion: number;
+  nonce: string;
+  capabilities: readonly FederationCapability[];
+}): string {
+  return JSON.stringify({
+    capabilities: params.capabilities.slice().sort(),
+    gatewayInstanceId: params.gatewayInstanceId,
+    nonce: params.nonce,
+    peerInstanceId: params.peerInstanceId,
+    protocolVersion: params.protocolVersion,
+    purpose: "gateway_accepted",
+    sessionId: params.sessionId,
   });
 }

--- a/apps/desktop/src/main/federation/federation-health.ts
+++ b/apps/desktop/src/main/federation/federation-health.ts
@@ -50,14 +50,14 @@ function roleForMode(mode: DesktopFederationMode): FederationInstanceRole {
       return "gateway";
     case "dual":
       return "dual";
-    case "child":
+    case "client":
     case "disabled":
-      return "child";
+      return "client";
   }
 }
 
 function statusForMode(mode: DesktopFederationMode): FederationHealthStatus["status"] {
-  return mode === "child" ? "connecting" : "listening";
+  return mode === "client" ? "connecting" : "listening";
 }
 
 function listenUrlForSettings(settings: DesktopSettingsSnapshot): string {

--- a/apps/desktop/src/main/federation/federation-health.ts
+++ b/apps/desktop/src/main/federation/federation-health.ts
@@ -1,0 +1,65 @@
+import type {
+  DesktopFederationMode,
+  DesktopSettingsSnapshot,
+  FederationHealthStatus,
+  FederationInstanceId,
+  FederationInstanceRole,
+  FederationPeerSummary,
+} from "@pwragent/shared";
+
+export function buildFederationHealthStatus(params: {
+  settings: DesktopSettingsSnapshot;
+  peers: FederationPeerSummary[];
+  instanceId?: FederationInstanceId;
+}): FederationHealthStatus {
+  const mode = params.settings.federation.mode.value;
+  const enabled = mode !== "disabled";
+  const publicUrl = params.settings.federation.publicUrl.value.trim();
+
+  return {
+    enabled,
+    role: roleForMode(mode),
+    status: enabled ? statusForMode(mode) : "disabled",
+    instanceId: params.instanceId,
+    listenUrl: enabled ? listenUrlForSettings(params.settings) : undefined,
+    publicUrl: publicUrl.length > 0 ? publicUrl : undefined,
+    peers: params.peers.map(publicPeerSummary),
+  };
+}
+
+export function publicPeerSummary(peer: FederationPeerSummary): FederationPeerSummary {
+  return {
+    id: peer.id,
+    label: peer.label,
+    role: peer.role,
+    status: peer.status,
+    capabilities: [...peer.capabilities],
+    protocolVersion: peer.protocolVersion,
+    endpoint: peer.endpoint,
+    profileName: peer.profileName,
+    lastConnectedAt: peer.lastConnectedAt,
+    lastActivityAt: peer.lastActivityAt,
+    revokedAt: peer.revokedAt,
+    unavailableReason: peer.unavailableReason,
+  };
+}
+
+function roleForMode(mode: DesktopFederationMode): FederationInstanceRole {
+  switch (mode) {
+    case "gateway":
+      return "gateway";
+    case "dual":
+      return "dual";
+    case "child":
+    case "disabled":
+      return "child";
+  }
+}
+
+function statusForMode(mode: DesktopFederationMode): FederationHealthStatus["status"] {
+  return mode === "child" ? "connecting" : "listening";
+}
+
+function listenUrlForSettings(settings: DesktopSettingsSnapshot): string {
+  return `ws://${settings.federation.listenHost.value}:${settings.federation.listenPort.value}`;
+}

--- a/apps/desktop/src/main/federation/federation-health.ts
+++ b/apps/desktop/src/main/federation/federation-health.ts
@@ -11,6 +11,8 @@ export function buildFederationHealthStatus(params: {
   settings: DesktopSettingsSnapshot;
   peers: FederationPeerSummary[];
   instanceId?: FederationInstanceId;
+  listenUrl?: string;
+  unavailableReason?: string;
 }): FederationHealthStatus {
   const mode = params.settings.federation.mode.value;
   const enabled = mode !== "disabled";
@@ -19,10 +21,13 @@ export function buildFederationHealthStatus(params: {
   return {
     enabled,
     role: roleForMode(mode),
-    status: enabled ? statusForMode(mode) : "disabled",
+    status: enabled
+      ? statusForMode(mode, params.listenUrl, params.unavailableReason)
+      : "disabled",
     instanceId: params.instanceId,
-    listenUrl: enabled ? listenUrlForSettings(params.settings) : undefined,
+    listenUrl: enabled ? params.listenUrl : undefined,
     publicUrl: publicUrl.length > 0 ? publicUrl : undefined,
+    unavailableReason: enabled ? params.unavailableReason : undefined,
     peers: params.peers.map(publicPeerSummary),
   };
 }
@@ -34,6 +39,7 @@ export function publicPeerSummary(peer: FederationPeerSummary): FederationPeerSu
     role: peer.role,
     status: peer.status,
     capabilities: [...peer.capabilities],
+    canRevoke: peer.canRevoke,
     protocolVersion: peer.protocolVersion,
     endpoint: peer.endpoint,
     profileName: peer.profileName,
@@ -56,10 +62,16 @@ function roleForMode(mode: DesktopFederationMode): FederationInstanceRole {
   }
 }
 
-function statusForMode(mode: DesktopFederationMode): FederationHealthStatus["status"] {
-  return mode === "client" ? "connecting" : "listening";
-}
-
-function listenUrlForSettings(settings: DesktopSettingsSnapshot): string {
-  return `ws://${settings.federation.listenHost.value}:${settings.federation.listenPort.value}`;
+function statusForMode(
+  mode: DesktopFederationMode,
+  listenUrl: string | undefined,
+  unavailableReason: string | undefined,
+): FederationHealthStatus["status"] {
+  if (unavailableReason) {
+    return "degraded";
+  }
+  if (mode === "client") {
+    return "connecting";
+  }
+  return listenUrl ? "listening" : "connecting";
 }

--- a/apps/desktop/src/main/federation/federation-identity.ts
+++ b/apps/desktop/src/main/federation/federation-identity.ts
@@ -1,0 +1,75 @@
+import {
+  createPrivateKey,
+  createPublicKey,
+  generateKeyPairSync,
+  sign,
+  verify,
+} from "node:crypto";
+import type { DesktopSecretStore } from "../settings/desktop-secret-store";
+
+const FEDERATION_PRIVATE_KEY_SECRET = "federationInstancePrivateKey";
+
+export type FederationIdentity = {
+  publicKeyPem: string;
+};
+
+export type FederationIdentityKeyPair = {
+  publicKeyPem: string;
+  privateKeyPem: string;
+};
+
+export async function getOrCreateFederationIdentity(
+  secretStore: DesktopSecretStore,
+): Promise<FederationIdentity> {
+  const existing = await secretStore.getSecret(FEDERATION_PRIVATE_KEY_SECRET);
+  const privateKeyPem = existing ?? generateFederationIdentityKeyPair().privateKeyPem;
+  if (!existing) {
+    await secretStore.setSecret(FEDERATION_PRIVATE_KEY_SECRET, privateKeyPem);
+  }
+  return {
+    publicKeyPem: publicKeyPemFromPrivateKey(privateKeyPem),
+  };
+}
+
+export function generateFederationIdentityKeyPair(): FederationIdentityKeyPair {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  return {
+    publicKeyPem: publicKey.export({ type: "spki", format: "pem" }).toString(),
+    privateKeyPem: privateKey.export({ type: "pkcs8", format: "pem" }).toString(),
+  };
+}
+
+export function signFederationMessage(params: {
+  privateKeyPem: string;
+  message: string;
+}): string {
+  const signature = sign(
+    null,
+    Buffer.from(params.message, "utf8"),
+    createPrivateKey(params.privateKeyPem),
+  );
+  return signature.toString("base64");
+}
+
+export function verifyFederationMessageSignature(params: {
+  publicKeyPem: string;
+  message: string;
+  signatureBase64: string;
+}): boolean {
+  try {
+    return verify(
+      null,
+      Buffer.from(params.message, "utf8"),
+      createPublicKey(params.publicKeyPem),
+      Buffer.from(params.signatureBase64, "base64"),
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function publicKeyPemFromPrivateKey(privateKeyPem: string): string {
+  return createPublicKey(createPrivateKey(privateKeyPem))
+    .export({ type: "spki", format: "pem" })
+    .toString();
+}

--- a/apps/desktop/src/main/federation/federation-policy.ts
+++ b/apps/desktop/src/main/federation/federation-policy.ts
@@ -1,0 +1,60 @@
+import type {
+  FederationCapability,
+  FederationPeerSummary,
+} from "@pwragent/shared";
+import { FEDERATION_PROTOCOL_VERSION } from "@pwragent/shared";
+import {
+  federationFailure,
+  type FederationRedactedFailure,
+} from "./federation-redaction";
+
+export type FederationPolicyDecision =
+  | {
+      accepted: true;
+      capabilities: FederationCapability[];
+    }
+  | {
+      accepted: false;
+      failure: FederationRedactedFailure;
+    };
+
+export function evaluateFederationSessionPolicy(params: {
+  peer: FederationPeerSummary | undefined;
+  protocolVersion: number;
+  requestedCapabilities: readonly FederationCapability[];
+}): FederationPolicyDecision {
+  if (params.protocolVersion !== FEDERATION_PROTOCOL_VERSION) {
+    return {
+      accepted: false,
+      failure: federationFailure("invalid_protocol_version"),
+    };
+  }
+  if (!params.peer) {
+    return {
+      accepted: false,
+      failure: federationFailure("unknown_peer"),
+    };
+  }
+  if (params.peer.status === "revoked" || params.peer.revokedAt !== undefined) {
+    return {
+      accepted: false,
+      failure: federationFailure("revoked_peer"),
+    };
+  }
+
+  const allowed = new Set(params.peer.capabilities);
+  const denied = params.requestedCapabilities.some(
+    (capability) => !allowed.has(capability),
+  );
+  if (denied) {
+    return {
+      accepted: false,
+      failure: federationFailure("capability_denied"),
+    };
+  }
+
+  return {
+    accepted: true,
+    capabilities: params.requestedCapabilities.slice(),
+  };
+}

--- a/apps/desktop/src/main/federation/federation-redaction.ts
+++ b/apps/desktop/src/main/federation/federation-redaction.ts
@@ -1,0 +1,46 @@
+export type FederationAuthFailureCode =
+  | "invalid_protocol_version"
+  | "invalid_peer_id"
+  | "unknown_peer"
+  | "revoked_peer"
+  | "missing_invite"
+  | "expired_invite"
+  | "wrong_gateway"
+  | "reused_invite"
+  | "bad_signature"
+  | "capability_denied"
+  | "policy_denied";
+
+export type FederationRedactedFailure = {
+  code: FederationAuthFailureCode;
+  message: string;
+};
+
+const FAILURE_MESSAGES: Record<FederationAuthFailureCode, string> = {
+  invalid_protocol_version: "Protocol version is not supported.",
+  invalid_peer_id: "Peer id is invalid.",
+  unknown_peer: "Peer is not enrolled.",
+  revoked_peer: "Peer has been revoked.",
+  missing_invite: "Enrollment invite is missing.",
+  expired_invite: "Enrollment invite is expired.",
+  wrong_gateway: "Enrollment invite belongs to a different gateway.",
+  reused_invite: "Enrollment invite has already been used.",
+  bad_signature: "Peer proof signature is invalid.",
+  capability_denied: "Requested capability is not authorized.",
+  policy_denied: "Federation policy denied the session.",
+};
+
+export function federationFailure(
+  code: FederationAuthFailureCode,
+): FederationRedactedFailure {
+  return {
+    code,
+    message: FAILURE_MESSAGES[code],
+  };
+}
+
+export function redactFederationDiagnostic(value: string): string {
+  return value
+    .replace(/-----BEGIN [^-]+-----[\s\S]*?-----END [^-]+-----/g, "[redacted-pem]")
+    .replace(/[A-Za-z0-9+/=]{32,}/g, "[redacted-token]");
+}

--- a/apps/desktop/src/main/federation/federation-router.ts
+++ b/apps/desktop/src/main/federation/federation-router.ts
@@ -1,0 +1,248 @@
+import type {
+  FederationCapability,
+  FederationErrorEnvelope,
+  FederationInstanceId,
+  FederationProtocolEnvelope,
+  FederationRequestEnvelope,
+  FederationResponseEnvelope,
+} from "@pwragent/shared";
+import { FEDERATION_PROTOCOL_VERSION } from "@pwragent/shared";
+
+export type FederationRouterConnection = {
+  peerId: FederationInstanceId;
+  capabilities: readonly FederationCapability[];
+  sendEnvelope: (envelope: FederationProtocolEnvelope) => void;
+};
+
+export type FederationRequestHandler = (
+  envelope: FederationRequestEnvelope,
+) => Promise<unknown> | unknown;
+
+export type FederationRouteResult =
+  | { status: "handled"; response?: FederationResponseEnvelope }
+  | { status: "relayed"; targetInstanceId: FederationInstanceId }
+  | { status: "rejected"; code: string; message: string };
+
+export class FederationRouter {
+  private readonly connections = new Map<FederationInstanceId, FederationRouterConnection>();
+  private readonly handlers = new Map<string, FederationRequestHandler>();
+
+  constructor(
+    private readonly options: {
+      localInstanceId: FederationInstanceId;
+      methodCapabilities?: Record<string, FederationCapability>;
+      maxHopCount?: number;
+      now?: () => number;
+    },
+  ) {}
+
+  registerConnection(connection: FederationRouterConnection): void {
+    this.connections.set(connection.peerId, connection);
+  }
+
+  unregisterConnection(peerId: FederationInstanceId): void {
+    this.connections.delete(peerId);
+  }
+
+  registerHandler(method: string, handler: FederationRequestHandler): void {
+    this.handlers.set(method, handler);
+  }
+
+  async routeEnvelope(params: {
+    envelope: FederationProtocolEnvelope;
+    sourcePeerId?: FederationInstanceId;
+  }): Promise<FederationRouteResult> {
+    const deadlineFailure = this.checkDeadline(params.envelope);
+    if (deadlineFailure) {
+      this.replyToSource(params.sourcePeerId, deadlineFailure);
+      return {
+        status: "rejected",
+        code: deadlineFailure.error.code,
+        message: deadlineFailure.error.message,
+      };
+    }
+
+    if (
+      params.envelope.targetInstanceId &&
+      params.envelope.targetInstanceId !== this.options.localInstanceId
+    ) {
+      return this.relayEnvelope(params);
+    }
+
+    if (params.envelope.kind !== "request") {
+      return { status: "handled" };
+    }
+
+    const capabilityFailure = this.checkCapability(
+      params.envelope,
+      params.sourcePeerId,
+    );
+    if (capabilityFailure) {
+      this.replyToSource(params.sourcePeerId, capabilityFailure);
+      return {
+        status: "rejected",
+        code: capabilityFailure.error.code,
+        message: capabilityFailure.error.message,
+      };
+    }
+
+    const handler = this.handlers.get(params.envelope.method);
+    if (!handler) {
+      const failure = this.errorEnvelope(params.envelope, {
+        code: "method_not_found",
+        message: `No federation handler registered for ${params.envelope.method}`,
+      });
+      this.replyToSource(params.sourcePeerId, failure);
+      return {
+        status: "rejected",
+        code: failure.error.code,
+        message: failure.error.message,
+      };
+    }
+
+    try {
+      const result = await handler(params.envelope);
+      const response: FederationResponseEnvelope = {
+        id: `${params.envelope.id}:response`,
+        kind: "response",
+        requestId: params.envelope.id,
+        protocolVersion: FEDERATION_PROTOCOL_VERSION,
+        sourceInstanceId: this.options.localInstanceId,
+        targetInstanceId: params.envelope.sourceInstanceId,
+        createdAt: this.now(),
+        result,
+      };
+      this.replyToSource(params.sourcePeerId, response);
+      return { status: "handled", response };
+    } catch (error) {
+      const failure = this.errorEnvelope(params.envelope, {
+        code: "handler_failed",
+        message: error instanceof Error ? error.message : String(error),
+      });
+      this.replyToSource(params.sourcePeerId, failure);
+      return {
+        status: "rejected",
+        code: failure.error.code,
+        message: failure.error.message,
+      };
+    }
+  }
+
+  private relayEnvelope(params: {
+    envelope: FederationProtocolEnvelope;
+    sourcePeerId?: FederationInstanceId;
+  }): FederationRouteResult {
+    const targetInstanceId = params.envelope.targetInstanceId;
+    if (!targetInstanceId) {
+      return {
+        status: "rejected",
+        code: "missing_target",
+        message: "Remote relay target is missing.",
+      };
+    }
+    const hopCount = params.envelope.hopCount ?? 0;
+    if (hopCount >= (this.options.maxHopCount ?? 4)) {
+      const failure = this.errorEnvelope(params.envelope, {
+        code: "relay_hop_limit",
+        message: "Federation relay hop limit exceeded.",
+      });
+      this.replyToSource(params.sourcePeerId, failure);
+      return {
+        status: "rejected",
+        code: failure.error.code,
+        message: failure.error.message,
+      };
+    }
+
+    if (params.sourcePeerId) {
+      const source = this.connections.get(params.sourcePeerId);
+      if (!source?.capabilities.includes("gateway_relay")) {
+        const failure = this.errorEnvelope(params.envelope, {
+          code: "relay_not_authorized",
+          message: "Source peer is not authorized to relay through this gateway.",
+        });
+        this.replyToSource(params.sourcePeerId, failure);
+        return {
+          status: "rejected",
+          code: failure.error.code,
+          message: failure.error.message,
+        };
+      }
+    }
+
+    const target = this.connections.get(targetInstanceId);
+    if (!target) {
+      const failure = this.errorEnvelope(params.envelope, {
+        code: "target_unavailable",
+        message: "Target federation peer is not connected.",
+      });
+      this.replyToSource(params.sourcePeerId, failure);
+      return {
+        status: "rejected",
+        code: failure.error.code,
+        message: failure.error.message,
+      };
+    }
+
+    target.sendEnvelope({
+      ...params.envelope,
+      hopCount: hopCount + 1,
+    });
+    return { status: "relayed", targetInstanceId };
+  }
+
+  private checkCapability(
+    envelope: FederationRequestEnvelope,
+    sourcePeerId: FederationInstanceId | undefined,
+  ): FederationErrorEnvelope | undefined {
+    if (!sourcePeerId) return undefined;
+    const requiredCapability = this.options.methodCapabilities?.[envelope.method];
+    if (!requiredCapability) return undefined;
+    const source = this.connections.get(sourcePeerId);
+    if (source?.capabilities.includes(requiredCapability)) return undefined;
+    return this.errorEnvelope(envelope, {
+      code: "capability_denied",
+      message: `Method ${envelope.method} requires ${requiredCapability}.`,
+    });
+  }
+
+  private checkDeadline(
+    envelope: FederationProtocolEnvelope,
+  ): FederationErrorEnvelope | undefined {
+    if (envelope.deadlineAt === undefined || envelope.deadlineAt > this.now()) {
+      return undefined;
+    }
+    return this.errorEnvelope(envelope, {
+      code: "deadline_expired",
+      message: "Federation request deadline expired.",
+    });
+  }
+
+  private replyToSource(
+    sourcePeerId: FederationInstanceId | undefined,
+    envelope: FederationProtocolEnvelope,
+  ): void {
+    if (!sourcePeerId) return;
+    this.connections.get(sourcePeerId)?.sendEnvelope(envelope);
+  }
+
+  private errorEnvelope(
+    envelope: FederationProtocolEnvelope,
+    error: { code: string; message: string },
+  ): FederationErrorEnvelope {
+    return {
+      id: `${envelope.id}:error`,
+      kind: "error",
+      requestId: envelope.kind === "request" ? envelope.id : undefined,
+      protocolVersion: FEDERATION_PROTOCOL_VERSION,
+      sourceInstanceId: this.options.localInstanceId,
+      targetInstanceId: envelope.sourceInstanceId,
+      createdAt: this.now(),
+      error,
+    };
+  }
+
+  private now(): number {
+    return this.options.now?.() ?? Date.now();
+  }
+}

--- a/apps/desktop/src/main/federation/federation-router.ts
+++ b/apps/desktop/src/main/federation/federation-router.ts
@@ -40,6 +40,20 @@ export class FederationRouter {
     this.connections.set(connection.peerId, connection);
   }
 
+  getConnection(peerId: FederationInstanceId): FederationRouterConnection | undefined {
+    return this.connections.get(peerId);
+  }
+
+  sendToPeer(
+    peerId: FederationInstanceId,
+    envelope: FederationProtocolEnvelope,
+  ): boolean {
+    const connection = this.connections.get(peerId);
+    if (!connection) return false;
+    connection.sendEnvelope(envelope);
+    return true;
+  }
+
   unregisterConnection(peerId: FederationInstanceId): void {
     this.connections.delete(peerId);
   }

--- a/apps/desktop/src/main/federation/federation-router.ts
+++ b/apps/desktop/src/main/federation/federation-router.ts
@@ -44,6 +44,10 @@ export class FederationRouter {
     return this.connections.get(peerId);
   }
 
+  listConnections(): FederationRouterConnection[] {
+    return [...this.connections.values()];
+  }
+
   sendToPeer(
     peerId: FederationInstanceId,
     envelope: FederationProtocolEnvelope,

--- a/apps/desktop/src/main/federation/federation-rpc.ts
+++ b/apps/desktop/src/main/federation/federation-rpc.ts
@@ -1,0 +1,105 @@
+import { randomUUID } from "node:crypto";
+import type {
+  FederationErrorEnvelope,
+  FederationInstanceId,
+  FederationProtocolEnvelope,
+  FederationRequestEnvelope,
+  FederationResponseEnvelope,
+} from "@pwragent/shared";
+import { FEDERATION_PROTOCOL_VERSION } from "@pwragent/shared";
+
+type PendingRequest = {
+  reject: (error: Error) => void;
+  resolve: (value: unknown) => void;
+  timer: ReturnType<typeof setTimeout>;
+};
+
+export class FederationRpcEndpoint {
+  private readonly pending = new Map<string, PendingRequest>();
+
+  constructor(
+    private readonly options: {
+      localInstanceId: FederationInstanceId;
+      remoteInstanceId: FederationInstanceId;
+      sendEnvelope: (envelope: FederationProtocolEnvelope) => void;
+      now?: () => number;
+      defaultTimeoutMs?: number;
+    },
+  ) {}
+
+  request<Result = unknown>(params: {
+    method: string;
+    params: unknown;
+    timeoutMs?: number;
+  }): Promise<Result> {
+    const id = `federation-request:${randomUUID()}`;
+    const timeoutMs = params.timeoutMs ?? this.options.defaultTimeoutMs ?? 30_000;
+    const envelope: FederationRequestEnvelope = {
+      id,
+      kind: "request",
+      method: params.method,
+      params: params.params,
+      protocolVersion: FEDERATION_PROTOCOL_VERSION,
+      sourceInstanceId: this.options.localInstanceId,
+      targetInstanceId: this.options.remoteInstanceId,
+      createdAt: this.now(),
+      deadlineAt: this.now() + timeoutMs,
+    };
+
+    const promise = new Promise<Result>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`Federation request timed out: ${params.method}`));
+      }, timeoutMs);
+      if (timer.unref) timer.unref();
+      this.pending.set(id, {
+        resolve: resolve as (value: unknown) => void,
+        reject,
+        timer,
+      });
+    });
+    this.options.sendEnvelope(envelope);
+    return promise;
+  }
+
+  receiveEnvelope(envelope: FederationProtocolEnvelope): boolean {
+    if (envelope.kind === "response") {
+      return this.resolveResponse(envelope);
+    }
+    if (envelope.kind === "error") {
+      return this.rejectError(envelope);
+    }
+    return false;
+  }
+
+  rejectAll(error: Error): void {
+    for (const [id, pending] of this.pending) {
+      clearTimeout(pending.timer);
+      this.pending.delete(id);
+      pending.reject(error);
+    }
+  }
+
+  private resolveResponse(envelope: FederationResponseEnvelope): boolean {
+    const pending = this.pending.get(envelope.requestId);
+    if (!pending) return false;
+    clearTimeout(pending.timer);
+    this.pending.delete(envelope.requestId);
+    pending.resolve(envelope.result);
+    return true;
+  }
+
+  private rejectError(envelope: FederationErrorEnvelope): boolean {
+    if (!envelope.requestId) return false;
+    const pending = this.pending.get(envelope.requestId);
+    if (!pending) return false;
+    clearTimeout(pending.timer);
+    this.pending.delete(envelope.requestId);
+    pending.reject(new Error(envelope.error.code));
+    return true;
+  }
+
+  private now(): number {
+    return this.options.now?.() ?? Date.now();
+  }
+}

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -46,9 +46,9 @@ import { FederationRouter } from "./federation-router";
 import { FederationRpcEndpoint } from "./federation-rpc";
 import { FederationStore } from "./federation-store";
 import {
-  connectFederationChild,
+  connectFederationClient,
   FederationGatewayWebSocketServer,
-  type FederationChildWebSocketClient,
+  type FederationClientWebSocketClient,
   type FederationGatewayConnection,
 } from "./federation-transport";
 
@@ -85,7 +85,7 @@ type FederationPeerDirectoryNotification = {
 export class DesktopFederationRuntime {
   private router?: FederationRouter;
   private server?: FederationGatewayWebSocketServer;
-  private child?: FederationChildWebSocketClient;
+  private client?: FederationClientWebSocketClient;
   private localInstanceId?: FederationInstanceId;
   private listenUrl?: string;
   private gatewayUrl?: string;
@@ -113,8 +113,8 @@ export class DesktopFederationRuntime {
   async stop(): Promise<void> {
     this.unsubscribeLocalBackendEvents?.();
     this.unsubscribeLocalBackendEvents = undefined;
-    this.child?.close();
-    this.child = undefined;
+    this.client?.close();
+    this.client = undefined;
     await this.server?.stop();
     this.server = undefined;
     this.router = undefined;
@@ -152,7 +152,7 @@ export class DesktopFederationRuntime {
       generatedAt: now,
       expiresAt,
       label: request.label,
-      role: "child",
+      role: "client",
       endpoint: gatewayUrl,
     });
     return {
@@ -178,7 +178,7 @@ export class DesktopFederationRuntime {
     stateDb.setMeta(PENDING_INVITE_TOKEN_META_KEY, payload.token);
     await getDesktopSettingsService().writeConfigPatch({
       federation: {
-        mode: "child",
+        mode: "client",
         gatewayUrl: payload.gatewayUrl,
       },
     });
@@ -285,16 +285,16 @@ export class DesktopFederationRuntime {
       log.info("federation gateway listening", { url: started.url });
     }
 
-    if (mode === "child" || mode === "dual") {
-      await this.connectChild(settings.federation.gatewayUrl.value.trim());
+    if (mode === "client" || mode === "dual") {
+      await this.connectClient(settings.federation.gatewayUrl.value.trim());
     }
   }
 
-  private async connectChild(gatewayUrl: string): Promise<void> {
+  private async connectClient(gatewayUrl: string): Promise<void> {
     if (!gatewayUrl) return;
     const gatewayInstanceId = getAppStateDb().getMeta(GATEWAY_INSTANCE_ID_META_KEY);
     if (!gatewayInstanceId) {
-      log.warn("federation child mode missing gateway instance id");
+      log.warn("federation client mode missing gateway instance id");
       return;
     }
     this.gatewayInstanceId = gatewayInstanceId;
@@ -302,7 +302,7 @@ export class DesktopFederationRuntime {
     const keyPair = await getDesktopSettingsService()
       .getOrCreateFederationIdentityKeyPair();
     this.gatewayUrl = gatewayUrl;
-    this.child = await connectFederationChild({
+    this.client = await connectFederationClient({
       url: gatewayUrl,
       mode: pendingInviteToken ? "enroll" : "reconnect",
       gatewayInstanceId,
@@ -312,19 +312,19 @@ export class DesktopFederationRuntime {
       capabilities: DEFAULT_CAPABILITIES,
       inviteToken: pendingInviteToken || undefined,
       label: getAppStateDb().getMeta("profile_name") || this.ensureLocalInstanceId(),
-      role: "child",
+      role: "client",
       onEnvelope: (envelope) =>
         void this.receiveEnvelope(envelope, gatewayInstanceId),
     });
     this.router?.registerConnection({
       peerId: gatewayInstanceId,
       capabilities: DEFAULT_CAPABILITIES,
-      sendEnvelope: (envelope) => this.child?.sendEnvelope(envelope),
+      sendEnvelope: (envelope) => this.client?.sendEnvelope(envelope),
     });
     if (pendingInviteToken) {
       getAppStateDb().setMeta(PENDING_INVITE_TOKEN_META_KEY, "");
     }
-    log.info("federation child connected", { gatewayUrl });
+    log.info("federation client connected", { gatewayUrl });
   }
 
   private registerGatewayConnection(connection: FederationGatewayConnection): void {
@@ -459,7 +459,7 @@ export class DesktopFederationRuntime {
   private defaultPeerRole(peerId: FederationInstanceId): FederationInstanceRole {
     return peerId === getAppStateDb().getMeta(GATEWAY_INSTANCE_ID_META_KEY)
       ? "gateway"
-      : "child";
+      : "client";
   }
 
   private buildPeerDirectory(

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -1,0 +1,454 @@
+import { randomBytes, randomUUID } from "node:crypto";
+import type {
+  AppServerListSkillsResponse,
+  AppServerListThreadsResponse,
+  AppServerReadThreadResponse,
+  FederationCapability,
+  FederationHealthStatus,
+  FederationInstanceId,
+  FederationPeerSummary,
+  FederationProtocolEnvelope,
+} from "@pwragent/shared";
+import {
+  buildFederatedThreadRef,
+  buildThreadIdentityKey,
+  isRemoteFederationTarget,
+  type AppServerListSkillsRequest,
+  type AppServerListThreadsRequest,
+  type AppServerReadThreadRequest,
+  type FederationRemoteTarget,
+  type NavigationSnapshot,
+  type StartTurnRequest,
+  type StartTurnResponse,
+} from "@pwragent/shared";
+import { getDesktopBackendRegistry } from "../app-server/backend-registry";
+import { rewriteTranscriptImageUrlsForRenderer } from "../transcript-image-protocol";
+import { getMainLogger } from "../log";
+import { getDesktopSettingsService } from "../settings/desktop-settings-singleton";
+import { getAppStateDb } from "../state/app-state";
+import {
+  createFederationEnrollmentInvite,
+  type FederationEnrollmentInvite,
+} from "./federation-enrollment";
+import {
+  FEDERATION_BACKEND_METHOD_CAPABILITIES,
+  FederationRemoteBackendClient,
+  registerFederationBackendHandlers,
+  type FederationBackendOperations,
+} from "./federation-backend-bridge";
+import { buildFederationHealthStatus } from "./federation-health";
+import { FederationRouter } from "./federation-router";
+import { FederationRpcEndpoint } from "./federation-rpc";
+import { FederationStore } from "./federation-store";
+import {
+  connectFederationChild,
+  FederationGatewayWebSocketServer,
+  type FederationChildWebSocketClient,
+  type FederationGatewayConnection,
+} from "./federation-transport";
+
+const log = getMainLogger("pwragent:federation-runtime");
+const INSTANCE_ID_META_KEY = "federation_instance_id";
+const GATEWAY_INSTANCE_ID_META_KEY = "federation_gateway_instance_id";
+const PENDING_INVITE_TOKEN_META_KEY = "federation_pending_invite_token";
+
+const DEFAULT_CAPABILITIES: FederationCapability[] = [
+  "remote_window",
+  "thread_navigation",
+  "thread_detail",
+  "turn_control",
+  "federated_search",
+  "gateway_relay",
+];
+
+type FederationInvitePayload = {
+  version: 1;
+  token: string;
+  gatewayInstanceId: FederationInstanceId;
+  gatewayUrl: string;
+  expiresAt: number;
+};
+
+export class DesktopFederationRuntime {
+  private router?: FederationRouter;
+  private server?: FederationGatewayWebSocketServer;
+  private child?: FederationChildWebSocketClient;
+  private localInstanceId?: FederationInstanceId;
+  private listenUrl?: string;
+  private gatewayUrl?: string;
+  private readonly rpcByPeer = new Map<FederationInstanceId, FederationRpcEndpoint>();
+  private restartPromise: Promise<void> | undefined;
+
+  async restart(): Promise<void> {
+    this.restartPromise ??= this.restartNow().finally(() => {
+      this.restartPromise = undefined;
+    });
+    return await this.restartPromise;
+  }
+
+  async stop(): Promise<void> {
+    this.child?.close();
+    this.child = undefined;
+    await this.server?.stop();
+    this.server = undefined;
+    this.router = undefined;
+    this.listenUrl = undefined;
+    this.gatewayUrl = undefined;
+    this.rpcByPeer.clear();
+  }
+
+  async health(): Promise<FederationHealthStatus> {
+    const settings = await getDesktopSettingsService().readSettings();
+    const peers = this.store().listPeers({ includeRevoked: true });
+    return buildFederationHealthStatus({
+      settings,
+      peers: peers.map((peer) =>
+        this.router?.getConnection(peer.id)
+          ? { ...peer, status: "connected" }
+          : {
+              ...peer,
+              status: peer.status === "connected" ? "disconnected" : peer.status,
+            },
+      ),
+      instanceId: this.ensureLocalInstanceId(),
+    });
+  }
+
+  async generateInvite(request: {
+    label?: string;
+    ttlMs?: number;
+  }): Promise<{ invite: string; expiresAt: number }> {
+    const settings = await getDesktopSettingsService().readSettings();
+    const gatewayUrl = settings.federation.publicUrl.value.trim() || this.listenUrl;
+    if (!gatewayUrl) {
+      throw new Error("Federation gateway URL is not configured.");
+    }
+    const now = Date.now();
+    const expiresAt = now + Math.max(60_000, Math.min(request.ttlMs ?? 3_600_000, 86_400_000));
+    const entry = createFederationEnrollmentInvite({
+      store: this.store(),
+      token: randomBytes(24).toString("base64url"),
+      gatewayInstanceId: this.ensureLocalInstanceId(),
+      generatedAt: now,
+      expiresAt,
+      label: request.label,
+      role: "child",
+      endpoint: gatewayUrl,
+    });
+    return {
+      invite: encodeInvite({
+        version: 1,
+        token: entry.token,
+        gatewayInstanceId: this.ensureLocalInstanceId(),
+        gatewayUrl,
+        expiresAt,
+      }),
+      expiresAt,
+    };
+  }
+
+  async importInvite(invite: string): Promise<{
+    accepted: boolean;
+    gatewayInstanceId: FederationInstanceId;
+    gatewayUrl: string;
+  }> {
+    const payload = decodeInvite(invite);
+    const stateDb = getAppStateDb();
+    stateDb.setMeta(GATEWAY_INSTANCE_ID_META_KEY, payload.gatewayInstanceId);
+    stateDb.setMeta(PENDING_INVITE_TOKEN_META_KEY, payload.token);
+    await getDesktopSettingsService().writeConfigPatch({
+      federation: {
+        mode: "child",
+        gatewayUrl: payload.gatewayUrl,
+      },
+    });
+    await this.restart();
+    return {
+      accepted: true,
+      gatewayInstanceId: payload.gatewayInstanceId,
+      gatewayUrl: payload.gatewayUrl,
+    };
+  }
+
+  remoteBackend(target: FederationRemoteTarget): FederationBackendOperations {
+    if (!isRemoteFederationTarget(target)) {
+      throw new Error("Federation target is not remote.");
+    }
+    let rpc = this.rpcByPeer.get(target.instanceId);
+    if (!rpc) {
+      rpc = new FederationRpcEndpoint({
+        localInstanceId: this.ensureLocalInstanceId(),
+        remoteInstanceId: target.instanceId,
+        sendEnvelope: (envelope) => {
+          if (!this.router?.sendToPeer(target.instanceId, envelope)) {
+            throw new Error(`Federation peer ${target.instanceId} is not connected.`);
+          }
+        },
+      });
+      this.rpcByPeer.set(target.instanceId, rpc);
+    }
+    return new FederationRemoteBackendClient(rpc);
+  }
+
+  async remoteNavigationSnapshot(
+    target: FederationRemoteTarget,
+    request: { backend?: AppServerListThreadsRequest["backend"]; filter?: string },
+  ): Promise<NavigationSnapshot> {
+    const backend = this.remoteBackend(target);
+    const response = await backend.listThreads({
+      backend: request.backend,
+      filter: request.filter,
+    });
+    const peer = this.store().getPeer(target.instanceId);
+    const instanceLabel = peer?.label ?? target.instanceId;
+    const threads = response.threads.map((thread) => ({
+      ...thread,
+      federation: {
+        ref: buildFederatedThreadRef({
+          backend: thread.source,
+          instanceId: target.instanceId,
+          threadId: thread.id,
+        }),
+        instanceLabel,
+        peerStatus: peer?.status,
+      },
+      inbox: { inInbox: true },
+    }));
+    return {
+      backend: response.backend,
+      fetchedAt: response.fetchedAt,
+      federationTarget: target,
+      unchanged: false,
+      threads,
+      inboxThreadKeys: threads.map((thread) =>
+        buildThreadIdentityKey(thread.source, thread.id),
+      ),
+      directories: [],
+      launchpadDefaults: {
+        backend: request.backend ?? "codex",
+        executionMode: "default",
+      },
+    };
+  }
+
+  private async restartNow(): Promise<void> {
+    await this.stop();
+    const settings = await getDesktopSettingsService().readSettings();
+    const mode = settings.federation.mode.value;
+    if (mode === "disabled") {
+      return;
+    }
+
+    const localInstanceId = this.ensureLocalInstanceId();
+    const router = new FederationRouter({
+      localInstanceId,
+      methodCapabilities: FEDERATION_BACKEND_METHOD_CAPABILITIES,
+    });
+    registerFederationBackendHandlers({
+      router,
+      backend: localBackendOperations(),
+    });
+    this.router = router;
+
+    if (mode === "gateway" || mode === "dual") {
+      this.server = new FederationGatewayWebSocketServer({
+        gatewayInstanceId: localInstanceId,
+        host: settings.federation.listenHost.value,
+        port: settings.federation.listenPort.value,
+        store: this.store(),
+        onConnection: (connection) => this.registerGatewayConnection(connection),
+        onDisconnect: (connection) => this.unregisterPeer(connection.peerId),
+        onEnvelope: (envelope, connection) =>
+          void this.receiveEnvelope(envelope, connection.peerId),
+      });
+      const started = await this.server.start();
+      this.listenUrl = started.url;
+      log.info("federation gateway listening", { url: started.url });
+    }
+
+    if (mode === "child" || mode === "dual") {
+      await this.connectChild(settings.federation.gatewayUrl.value.trim());
+    }
+  }
+
+  private async connectChild(gatewayUrl: string): Promise<void> {
+    if (!gatewayUrl) return;
+    const gatewayInstanceId = getAppStateDb().getMeta(GATEWAY_INSTANCE_ID_META_KEY);
+    if (!gatewayInstanceId) {
+      log.warn("federation child mode missing gateway instance id");
+      return;
+    }
+    const pendingInviteToken = getAppStateDb().getMeta(PENDING_INVITE_TOKEN_META_KEY);
+    const keyPair = await getDesktopSettingsService()
+      .getOrCreateFederationIdentityKeyPair();
+    this.gatewayUrl = gatewayUrl;
+    this.child = await connectFederationChild({
+      url: gatewayUrl,
+      mode: pendingInviteToken ? "enroll" : "reconnect",
+      gatewayInstanceId,
+      peerInstanceId: this.ensureLocalInstanceId(),
+      privateKeyPem: keyPair.privateKeyPem,
+      publicKeyPem: keyPair.publicKeyPem,
+      capabilities: DEFAULT_CAPABILITIES,
+      inviteToken: pendingInviteToken || undefined,
+      label: getAppStateDb().getMeta("profile_name") || this.ensureLocalInstanceId(),
+      role: "child",
+      onEnvelope: (envelope) =>
+        void this.receiveEnvelope(envelope, gatewayInstanceId),
+    });
+    this.router?.registerConnection({
+      peerId: gatewayInstanceId,
+      capabilities: DEFAULT_CAPABILITIES,
+      sendEnvelope: (envelope) => this.child?.sendEnvelope(envelope),
+    });
+    if (pendingInviteToken) {
+      getAppStateDb().setMeta(PENDING_INVITE_TOKEN_META_KEY, "");
+    }
+    log.info("federation child connected", { gatewayUrl });
+  }
+
+  private registerGatewayConnection(connection: FederationGatewayConnection): void {
+    this.router?.registerConnection({
+      peerId: connection.peerId,
+      capabilities: connection.capabilities,
+      sendEnvelope: connection.sendEnvelope,
+    });
+  }
+
+  private unregisterPeer(peerId: FederationInstanceId): void {
+    this.router?.unregisterConnection(peerId);
+    this.rpcByPeer.delete(peerId);
+  }
+
+  private async receiveEnvelope(
+    envelope: FederationProtocolEnvelope,
+    sourcePeerId: FederationInstanceId,
+  ): Promise<void> {
+    if (envelope.kind === "response" || envelope.kind === "error") {
+      this.rpcByPeer.get(sourcePeerId)?.receiveEnvelope(envelope);
+      return;
+    }
+    await this.router?.routeEnvelope({ envelope, sourcePeerId });
+  }
+
+  private ensureLocalInstanceId(): FederationInstanceId {
+    if (this.localInstanceId) return this.localInstanceId;
+    const stateDb = getAppStateDb();
+    const existing = stateDb.getMeta(INSTANCE_ID_META_KEY);
+    if (existing) {
+      this.localInstanceId = existing;
+      return existing;
+    }
+    const next = `pwr_${randomUUID()}`;
+    stateDb.setMeta(INSTANCE_ID_META_KEY, next);
+    this.localInstanceId = next;
+    return next;
+  }
+
+  private store(): FederationStore {
+    return new FederationStore(getAppStateDb());
+  }
+}
+
+function localBackendOperations(): FederationBackendOperations {
+  return {
+    async listThreads(
+      request: AppServerListThreadsRequest = {},
+    ): Promise<AppServerListThreadsResponse> {
+      const threads = await getDesktopBackendRegistry().listThreads({
+        backend: request.backend,
+        archived: request.archived,
+        callerReason: "federation-list-threads",
+        filter: request.filter,
+      });
+      return {
+        backend: request.backend ?? "all",
+        fetchedAt: Date.now(),
+        threads,
+      };
+    },
+    async readThread(
+      request: AppServerReadThreadRequest,
+    ): Promise<AppServerReadThreadResponse> {
+      const backend = request.backend ?? "codex";
+      const response = await getDesktopBackendRegistry().readThread({
+        backend,
+        threadId: request.threadId,
+        before: request.before,
+        limit: request.limit,
+      });
+      return rewriteTranscriptImageUrlsForRenderer(response);
+    },
+    async listSkills(
+      request: AppServerListSkillsRequest = {},
+    ): Promise<AppServerListSkillsResponse> {
+      const backend = request.backend ?? "codex";
+      const response = await getDesktopBackendRegistry().listSkills({
+        backend,
+        cwd: request.cwd,
+        cwds: request.cwds,
+        threadId: request.threadId,
+      });
+      return {
+        backend,
+        fetchedAt: Date.now(),
+        data: response.data,
+      };
+    },
+    async startTurn(request: StartTurnRequest): Promise<StartTurnResponse> {
+      const submitted = await getDesktopBackendRegistry().submitTurn({
+        ...request,
+        origin: "manual",
+      });
+      return submitted.status === "started"
+        ? {
+            backend: submitted.entry.backend,
+            threadId: submitted.entry.threadId,
+            turnId: submitted.turnId,
+            queueStatus: "started",
+            queueEntryId: submitted.entry.id,
+          }
+        : {
+            backend: submitted.entry.backend,
+            threadId: submitted.entry.threadId,
+            turnId: submitted.entry.id,
+            queueStatus: "queued",
+            queueEntryId: submitted.entry.id,
+          };
+    },
+  };
+}
+
+function encodeInvite(payload: FederationInvitePayload): string {
+  return `pwragent-federation:${Buffer.from(JSON.stringify(payload), "utf8").toString("base64url")}`;
+}
+
+function decodeInvite(invite: string): FederationInvitePayload {
+  const encoded = invite.trim().replace(/^pwragent-federation:/, "");
+  const parsed = JSON.parse(Buffer.from(encoded, "base64url").toString("utf8")) as Partial<FederationInvitePayload>;
+  if (
+    parsed.version !== 1 ||
+    typeof parsed.token !== "string" ||
+    typeof parsed.gatewayInstanceId !== "string" ||
+    typeof parsed.gatewayUrl !== "string" ||
+    typeof parsed.expiresAt !== "number"
+  ) {
+    throw new Error("Invalid federation invite.");
+  }
+  if (parsed.expiresAt <= Date.now()) {
+    throw new Error("Federation invite has expired.");
+  }
+  return parsed as FederationInvitePayload;
+}
+
+let runtime: DesktopFederationRuntime | undefined;
+
+export function getDesktopFederationRuntime(): DesktopFederationRuntime {
+  runtime ??= new DesktopFederationRuntime();
+  return runtime;
+}
+
+export async function disposeDesktopFederationRuntime(): Promise<void> {
+  await runtime?.stop();
+  runtime = undefined;
+}

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -4,12 +4,24 @@ import type {
   AppServerListSkillsResponse,
   AppServerListThreadsResponse,
   AppServerReadThreadResponse,
+  CancelThreadExecutionModeQueueResponse,
+  CompactThreadResponse,
   FederationCapability,
   FederationHealthStatus,
   FederationInstanceId,
   FederationInstanceRole,
   FederationPeerSummary,
   FederationProtocolEnvelope,
+  HandoffThreadWorkspaceResponse,
+  InterruptTurnResponse,
+  QueueThreadExecutionModeResponse,
+  RunCodexEnvironmentActionResponse,
+  SetAcpSessionRuntimeOptionResponse,
+  SetCodexThreadEnvironmentResponse,
+  SetThreadExecutionModeResponse,
+  SetThreadModelSettingsResponse,
+  SteerTurnResponse,
+  SubmitServerRequestResponse,
 } from "@pwragent/shared";
 import {
   FEDERATION_PROTOCOL_VERSION,
@@ -19,10 +31,22 @@ import {
   type AppServerListSkillsRequest,
   type AppServerListThreadsRequest,
   type AppServerReadThreadRequest,
+  type CancelThreadExecutionModeQueueRequest,
+  type CompactThreadRequest,
   type FederationRemoteTarget,
+  type HandoffThreadWorkspaceRequest,
+  type InterruptTurnRequest,
   type NavigationSnapshot,
+  type QueueThreadExecutionModeRequest,
+  type RunCodexEnvironmentActionRequest,
+  type SetAcpSessionRuntimeOptionRequest,
+  type SetCodexThreadEnvironmentRequest,
+  type SetThreadExecutionModeRequest,
+  type SetThreadModelSettingsRequest,
+  type SteerTurnRequest,
   type StartTurnRequest,
   type StartTurnResponse,
+  type SubmitServerRequestRequest,
 } from "@pwragent/shared";
 import { getDesktopBackendRegistry } from "../app-server/backend-registry";
 import { rewriteTranscriptImageUrlsForRenderer } from "../transcript-image-protocol";
@@ -63,6 +87,8 @@ const DEFAULT_CAPABILITIES: FederationCapability[] = [
   "thread_navigation",
   "thread_detail",
   "turn_control",
+  "pending_request_control",
+  "environment_actions",
   "federated_search",
   "gateway_relay",
 ];
@@ -681,6 +707,64 @@ function localBackendOperations(): FederationBackendOperations {
             queueStatus: "queued",
             queueEntryId: submitted.entry.id,
           };
+    },
+    async compactThread(
+      request: CompactThreadRequest,
+    ): Promise<CompactThreadResponse> {
+      return await getDesktopBackendRegistry().compactThread(request);
+    },
+    async interruptTurn(
+      request: InterruptTurnRequest,
+    ): Promise<InterruptTurnResponse> {
+      return await getDesktopBackendRegistry().interruptTurn(request);
+    },
+    async steerTurn(request: SteerTurnRequest): Promise<SteerTurnResponse> {
+      return await getDesktopBackendRegistry().steerTurn(request);
+    },
+    async setThreadExecutionMode(
+      request: SetThreadExecutionModeRequest,
+    ): Promise<SetThreadExecutionModeResponse> {
+      return await getDesktopBackendRegistry().setThreadExecutionMode(request);
+    },
+    async queueThreadExecutionMode(
+      request: QueueThreadExecutionModeRequest,
+    ): Promise<QueueThreadExecutionModeResponse> {
+      return await getDesktopBackendRegistry().queueThreadExecutionMode(request);
+    },
+    async cancelThreadExecutionModeQueue(
+      request: CancelThreadExecutionModeQueueRequest,
+    ): Promise<CancelThreadExecutionModeQueueResponse> {
+      return await getDesktopBackendRegistry().cancelThreadExecutionModeQueue(request);
+    },
+    async setAcpSessionRuntimeOption(
+      request: SetAcpSessionRuntimeOptionRequest,
+    ): Promise<SetAcpSessionRuntimeOptionResponse> {
+      return await getDesktopBackendRegistry().setAcpSessionRuntimeOption(request);
+    },
+    async setThreadModelSettings(
+      request: SetThreadModelSettingsRequest,
+    ): Promise<SetThreadModelSettingsResponse> {
+      return await getDesktopBackendRegistry().setThreadModelSettings(request);
+    },
+    async submitServerRequest(
+      request: SubmitServerRequestRequest,
+    ): Promise<SubmitServerRequestResponse> {
+      return await getDesktopBackendRegistry().submitServerRequest(request);
+    },
+    async runCodexEnvironmentAction(
+      request: RunCodexEnvironmentActionRequest,
+    ): Promise<RunCodexEnvironmentActionResponse> {
+      return await getDesktopBackendRegistry().runCodexEnvironmentAction(request);
+    },
+    async setCodexThreadEnvironment(
+      request: SetCodexThreadEnvironmentRequest,
+    ): Promise<SetCodexThreadEnvironmentResponse> {
+      return await getDesktopBackendRegistry().setCodexThreadEnvironment(request);
+    },
+    async handoffThreadWorkspace(
+      request: HandoffThreadWorkspaceRequest,
+    ): Promise<HandoffThreadWorkspaceResponse> {
+      return await getDesktopBackendRegistry().handoffThreadWorkspace(request);
     },
   };
 }

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -1,5 +1,6 @@
 import { randomBytes, randomUUID } from "node:crypto";
 import type {
+  AgentEvent,
   AppServerListSkillsResponse,
   AppServerListThreadsResponse,
   AppServerReadThreadResponse,
@@ -10,8 +11,9 @@ import type {
   FederationProtocolEnvelope,
 } from "@pwragent/shared";
 import {
+  FEDERATION_PROTOCOL_VERSION,
   buildFederatedThreadRef,
-  buildThreadIdentityKey,
+  federatedThreadIdentityKey,
   isRemoteFederationTarget,
   type AppServerListSkillsRequest,
   type AppServerListThreadsRequest,
@@ -31,9 +33,11 @@ import {
   type FederationEnrollmentInvite,
 } from "./federation-enrollment";
 import {
+  FEDERATION_BACKEND_EVENT_METHOD,
   FEDERATION_BACKEND_METHOD_CAPABILITIES,
   FederationRemoteBackendClient,
   registerFederationBackendHandlers,
+  type FederationBackendEventNotification,
   type FederationBackendOperations,
 } from "./federation-backend-bridge";
 import { buildFederationHealthStatus } from "./federation-health";
@@ -77,7 +81,13 @@ export class DesktopFederationRuntime {
   private listenUrl?: string;
   private gatewayUrl?: string;
   private readonly rpcByPeer = new Map<FederationInstanceId, FederationRpcEndpoint>();
+  private publishAgentEvent?: (event: AgentEvent) => void;
+  private unsubscribeLocalBackendEvents?: () => void;
   private restartPromise: Promise<void> | undefined;
+
+  setAgentEventPublisher(publisher: (event: AgentEvent) => void): void {
+    this.publishAgentEvent = publisher;
+  }
 
   async restart(): Promise<void> {
     this.restartPromise ??= this.restartNow().finally(() => {
@@ -87,6 +97,8 @@ export class DesktopFederationRuntime {
   }
 
   async stop(): Promise<void> {
+    this.unsubscribeLocalBackendEvents?.();
+    this.unsubscribeLocalBackendEvents = undefined;
     this.child?.close();
     this.child = undefined;
     await this.server?.stop();
@@ -221,7 +233,7 @@ export class DesktopFederationRuntime {
       unchanged: false,
       threads,
       inboxThreadKeys: threads.map((thread) =>
-        buildThreadIdentityKey(thread.source, thread.id),
+        federatedThreadIdentityKey(thread.federation.ref),
       ),
       directories: [],
       launchpadDefaults: {
@@ -249,6 +261,7 @@ export class DesktopFederationRuntime {
       backend: localBackendOperations(),
     });
     this.router = router;
+    this.subscribeLocalBackendEvents();
 
     if (mode === "gateway" || mode === "dual") {
       this.server = new FederationGatewayWebSocketServer({
@@ -257,7 +270,7 @@ export class DesktopFederationRuntime {
         port: settings.federation.listenPort.value,
         store: this.store(),
         onConnection: (connection) => this.registerGatewayConnection(connection),
-        onDisconnect: (connection) => this.unregisterPeer(connection.peerId),
+        onDisconnect: (connection) => this.unregisterGatewayConnection(connection),
         onEnvelope: (envelope, connection) =>
           void this.receiveEnvelope(envelope, connection.peerId),
       });
@@ -315,6 +328,14 @@ export class DesktopFederationRuntime {
     });
   }
 
+  private unregisterGatewayConnection(connection: FederationGatewayConnection): void {
+    const activeConnection = this.router?.getConnection(connection.peerId);
+    if (activeConnection?.sendEnvelope !== connection.sendEnvelope) {
+      return;
+    }
+    this.unregisterPeer(connection.peerId);
+  }
+
   private unregisterPeer(peerId: FederationInstanceId): void {
     this.router?.unregisterConnection(peerId);
     this.rpcByPeer.delete(peerId);
@@ -324,9 +345,12 @@ export class DesktopFederationRuntime {
     envelope: FederationProtocolEnvelope,
     sourcePeerId: FederationInstanceId,
   ): Promise<void> {
-    if (envelope.kind === "response" || envelope.kind === "error") {
-      this.rpcByPeer.get(sourcePeerId)?.receiveEnvelope(envelope);
+    if (this.publishRemoteBackendEvent(envelope, sourcePeerId)) {
       return;
+    }
+    if (envelope.kind === "response" || envelope.kind === "error") {
+      const handled = this.rpcByPeer.get(sourcePeerId)?.receiveEnvelope(envelope) ?? false;
+      if (handled) return;
     }
     await this.router?.routeEnvelope({ envelope, sourcePeerId });
   }
@@ -347,6 +371,64 @@ export class DesktopFederationRuntime {
 
   private store(): FederationStore {
     return new FederationStore(getAppStateDb());
+  }
+
+  private subscribeLocalBackendEvents(): void {
+    this.unsubscribeLocalBackendEvents?.();
+    this.unsubscribeLocalBackendEvents = getDesktopBackendRegistry().onEvent((event) => {
+      this.forwardLocalBackendEvent(event);
+    });
+  }
+
+  private forwardLocalBackendEvent(event: AgentEvent): void {
+    const router = this.router;
+    if (!router) return;
+
+    for (const connection of router.listConnections()) {
+      if (
+        !connection.capabilities.includes("remote_window") &&
+        !connection.capabilities.includes("thread_detail")
+      ) {
+        continue;
+      }
+
+      connection.sendEnvelope({
+        id: `federation-event:${randomUUID()}`,
+        kind: "notification",
+        method: FEDERATION_BACKEND_EVENT_METHOD,
+        params: {
+          backend: event.backend,
+          notification: event.notification,
+        },
+        protocolVersion: FEDERATION_PROTOCOL_VERSION,
+        sourceInstanceId: this.ensureLocalInstanceId(),
+        targetInstanceId: connection.peerId,
+        createdAt: Date.now(),
+      });
+    }
+  }
+
+  private publishRemoteBackendEvent(
+    envelope: FederationProtocolEnvelope,
+    sourcePeerId: FederationInstanceId,
+  ): boolean {
+    if (
+      envelope.kind !== "notification" ||
+      envelope.method !== FEDERATION_BACKEND_EVENT_METHOD
+    ) {
+      return false;
+    }
+
+    const notification = envelope as FederationBackendEventNotification & typeof envelope;
+    this.publishAgentEvent?.({
+      backend: notification.params.backend,
+      federationTarget: {
+        scope: "remote",
+        instanceId: envelope.sourceInstanceId || sourcePeerId,
+      },
+      notification: notification.params.notification,
+    });
+    return true;
   }
 }
 

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -7,6 +7,7 @@ import type {
   FederationCapability,
   FederationHealthStatus,
   FederationInstanceId,
+  FederationInstanceRole,
   FederationPeerSummary,
   FederationProtocolEnvelope,
 } from "@pwragent/shared";
@@ -27,7 +28,7 @@ import { getDesktopBackendRegistry } from "../app-server/backend-registry";
 import { rewriteTranscriptImageUrlsForRenderer } from "../transcript-image-protocol";
 import { getMainLogger } from "../log";
 import { getDesktopSettingsService } from "../settings/desktop-settings-singleton";
-import { getAppStateDb } from "../state/app-state";
+import { getAppStateDb, isAppStateInitialized } from "../state/app-state";
 import {
   createFederationEnrollmentInvite,
   type FederationEnrollmentInvite,
@@ -55,6 +56,7 @@ const log = getMainLogger("pwragent:federation-runtime");
 const INSTANCE_ID_META_KEY = "federation_instance_id";
 const GATEWAY_INSTANCE_ID_META_KEY = "federation_gateway_instance_id";
 const PENDING_INVITE_TOKEN_META_KEY = "federation_pending_invite_token";
+const FEDERATION_PEER_DIRECTORY_METHOD = "federation.peerDirectory";
 
 const DEFAULT_CAPABILITIES: FederationCapability[] = [
   "remote_window",
@@ -73,6 +75,13 @@ type FederationInvitePayload = {
   expiresAt: number;
 };
 
+type FederationPeerDirectoryNotification = {
+  method: typeof FEDERATION_PEER_DIRECTORY_METHOD;
+  params: {
+    peers: FederationPeerSummary[];
+  };
+};
+
 export class DesktopFederationRuntime {
   private router?: FederationRouter;
   private server?: FederationGatewayWebSocketServer;
@@ -80,7 +89,12 @@ export class DesktopFederationRuntime {
   private localInstanceId?: FederationInstanceId;
   private listenUrl?: string;
   private gatewayUrl?: string;
+  private gatewayInstanceId?: FederationInstanceId;
   private readonly rpcByPeer = new Map<FederationInstanceId, FederationRpcEndpoint>();
+  private readonly remotePeerDirectory = new Map<
+    FederationInstanceId,
+    FederationPeerSummary
+  >();
   private publishAgentEvent?: (event: AgentEvent) => void;
   private unsubscribeLocalBackendEvents?: () => void;
   private restartPromise: Promise<void> | undefined;
@@ -106,22 +120,16 @@ export class DesktopFederationRuntime {
     this.router = undefined;
     this.listenUrl = undefined;
     this.gatewayUrl = undefined;
+    this.gatewayInstanceId = undefined;
     this.rpcByPeer.clear();
+    this.remotePeerDirectory.clear();
   }
 
   async health(): Promise<FederationHealthStatus> {
     const settings = await getDesktopSettingsService().readSettings();
-    const peers = this.store().listPeers({ includeRevoked: true });
     return buildFederationHealthStatus({
       settings,
-      peers: peers.map((peer) =>
-        this.router?.getConnection(peer.id)
-          ? { ...peer, status: "connected" }
-          : {
-              ...peer,
-              status: peer.status === "connected" ? "disconnected" : peer.status,
-            },
-      ),
+      peers: this.visiblePeers(),
       instanceId: this.ensureLocalInstanceId(),
     });
   }
@@ -192,9 +200,7 @@ export class DesktopFederationRuntime {
         localInstanceId: this.ensureLocalInstanceId(),
         remoteInstanceId: target.instanceId,
         sendEnvelope: (envelope) => {
-          if (!this.router?.sendToPeer(target.instanceId, envelope)) {
-            throw new Error(`Federation peer ${target.instanceId} is not connected.`);
-          }
+          this.sendEnvelopeToTarget(target.instanceId, envelope);
         },
       });
       this.rpcByPeer.set(target.instanceId, rpc);
@@ -291,6 +297,7 @@ export class DesktopFederationRuntime {
       log.warn("federation child mode missing gateway instance id");
       return;
     }
+    this.gatewayInstanceId = gatewayInstanceId;
     const pendingInviteToken = getAppStateDb().getMeta(PENDING_INVITE_TOKEN_META_KEY);
     const keyPair = await getDesktopSettingsService()
       .getOrCreateFederationIdentityKeyPair();
@@ -326,6 +333,7 @@ export class DesktopFederationRuntime {
       capabilities: connection.capabilities,
       sendEnvelope: connection.sendEnvelope,
     });
+    this.broadcastPeerDirectory();
   }
 
   private unregisterGatewayConnection(connection: FederationGatewayConnection): void {
@@ -334,6 +342,7 @@ export class DesktopFederationRuntime {
       return;
     }
     this.unregisterPeer(connection.peerId);
+    this.broadcastPeerDirectory();
   }
 
   private unregisterPeer(peerId: FederationInstanceId): void {
@@ -345,6 +354,9 @@ export class DesktopFederationRuntime {
     envelope: FederationProtocolEnvelope,
     sourcePeerId: FederationInstanceId,
   ): Promise<void> {
+    if (this.applyPeerDirectory(envelope)) {
+      return;
+    }
     if (this.publishRemoteBackendEvent(envelope, sourcePeerId)) {
       return;
     }
@@ -371,6 +383,148 @@ export class DesktopFederationRuntime {
 
   private store(): FederationStore {
     return new FederationStore(getAppStateDb());
+  }
+
+  private sendEnvelopeToTarget(
+    targetInstanceId: FederationInstanceId,
+    envelope: FederationProtocolEnvelope,
+  ): void {
+    if (this.router?.sendToPeer(targetInstanceId, envelope)) {
+      return;
+    }
+
+    const gatewayInstanceId = this.gatewayInstanceId ??
+      getAppStateDb().getMeta(GATEWAY_INSTANCE_ID_META_KEY);
+    if (
+      gatewayInstanceId &&
+      gatewayInstanceId !== targetInstanceId &&
+      this.router?.sendToPeer(gatewayInstanceId, envelope)
+    ) {
+      return;
+    }
+
+    throw new Error(`Federation peer ${targetInstanceId} is not connected.`);
+  }
+
+  private visiblePeers(): FederationPeerSummary[] {
+    const localInstanceId = this.ensureLocalInstanceId();
+    const visible = new Map<FederationInstanceId, FederationPeerSummary>();
+
+    for (const peer of this.remotePeerDirectory.values()) {
+      if (peer.id !== localInstanceId) {
+        visible.set(peer.id, peer);
+      }
+    }
+
+    for (const peer of this.store().listPeers({ includeRevoked: true })) {
+      if (peer.id === localInstanceId) continue;
+      visible.set(peer.id, peer);
+    }
+
+    for (const connection of this.router?.listConnections() ?? []) {
+      if (connection.peerId === localInstanceId) continue;
+      const existing = visible.get(connection.peerId);
+      visible.set(connection.peerId, {
+        id: connection.peerId,
+        label: existing?.label ?? this.defaultPeerLabel(connection.peerId),
+        role: existing?.role ?? this.defaultPeerRole(connection.peerId),
+        status: "connected",
+        capabilities: [...connection.capabilities],
+        protocolVersion: existing?.protocolVersion,
+        endpoint: existing?.endpoint,
+        profileName: existing?.profileName,
+        lastConnectedAt: existing?.lastConnectedAt,
+        lastActivityAt: existing?.lastActivityAt,
+        revokedAt: existing?.revokedAt,
+        unavailableReason: existing?.unavailableReason,
+      });
+    }
+
+    return [...visible.values()].map((peer) =>
+      this.router?.getConnection(peer.id)
+        ? { ...peer, status: "connected" }
+        : {
+            ...peer,
+            status: peer.status === "connected" ? "disconnected" : peer.status,
+          },
+    );
+  }
+
+  private defaultPeerLabel(peerId: FederationInstanceId): string {
+    return peerId === getAppStateDb().getMeta(GATEWAY_INSTANCE_ID_META_KEY)
+      ? "Gateway"
+      : peerId;
+  }
+
+  private defaultPeerRole(peerId: FederationInstanceId): FederationInstanceRole {
+    return peerId === getAppStateDb().getMeta(GATEWAY_INSTANCE_ID_META_KEY)
+      ? "gateway"
+      : "child";
+  }
+
+  private buildPeerDirectory(
+    recipientPeerId: FederationInstanceId,
+  ): FederationPeerSummary[] {
+    const localInstanceId = this.ensureLocalInstanceId();
+    const localProfileName = getAppStateDb().getMeta("profile_name") || undefined;
+    const peers: FederationPeerSummary[] = [
+      {
+        id: localInstanceId,
+        label: localProfileName || "Gateway",
+        role: "gateway",
+        status: "connected",
+        capabilities: DEFAULT_CAPABILITIES,
+        protocolVersion: FEDERATION_PROTOCOL_VERSION,
+        profileName: localProfileName,
+      },
+    ];
+
+    for (const peer of this.visiblePeers()) {
+      if (peer.id === recipientPeerId) continue;
+      peers.push(peer);
+    }
+
+    return peers;
+  }
+
+  private broadcastPeerDirectory(): void {
+    const router = this.router;
+    if (!router) return;
+    if (!isAppStateInitialized()) return;
+    const localInstanceId = this.ensureLocalInstanceId();
+
+    for (const connection of router.listConnections()) {
+      connection.sendEnvelope({
+        id: `federation-peers:${randomUUID()}`,
+        kind: "notification",
+        method: FEDERATION_PEER_DIRECTORY_METHOD,
+        params: {
+          peers: this.buildPeerDirectory(connection.peerId),
+        },
+        protocolVersion: FEDERATION_PROTOCOL_VERSION,
+        sourceInstanceId: localInstanceId,
+        targetInstanceId: connection.peerId,
+        createdAt: Date.now(),
+      });
+    }
+  }
+
+  private applyPeerDirectory(envelope: FederationProtocolEnvelope): boolean {
+    if (
+      envelope.kind !== "notification" ||
+      envelope.method !== FEDERATION_PEER_DIRECTORY_METHOD
+    ) {
+      return false;
+    }
+
+    const notification = envelope as FederationPeerDirectoryNotification & typeof envelope;
+    this.remotePeerDirectory.clear();
+    for (const peer of notification.params.peers) {
+      if (peer.id !== this.ensureLocalInstanceId()) {
+        this.remotePeerDirectory.set(peer.id, peer);
+      }
+    }
+    return true;
   }
 
   private subscribeLocalBackendEvents(): void {
@@ -428,7 +582,37 @@ export class DesktopFederationRuntime {
       },
       notification: notification.params.notification,
     });
+    this.relayRemoteBackendEvent(envelope, sourcePeerId);
     return true;
+  }
+
+  private relayRemoteBackendEvent(
+    envelope: FederationProtocolEnvelope,
+    sourcePeerId: FederationInstanceId,
+  ): void {
+    const router = this.router;
+    if (!router || sourcePeerId === this.gatewayInstanceId) {
+      return;
+    }
+    const hopCount = envelope.hopCount ?? 0;
+    if (hopCount >= 1) {
+      return;
+    }
+
+    for (const connection of router.listConnections()) {
+      if (connection.peerId === sourcePeerId) continue;
+      if (
+        !connection.capabilities.includes("remote_window") &&
+        !connection.capabilities.includes("thread_detail")
+      ) {
+        continue;
+      }
+      connection.sendEnvelope({
+        ...envelope,
+        hopCount: hopCount + 1,
+        targetInstanceId: connection.peerId,
+      });
+    }
   }
 }
 

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -6,25 +6,35 @@ import type {
   AppServerReadThreadResponse,
   CancelThreadExecutionModeQueueResponse,
   CompactThreadResponse,
+  CodexEnvironmentSetupProgressEvent,
   FederationCapability,
+  FederationDiagnosticEvent,
+  FederatedSearchRequest,
+  FederatedSearchResponse,
   FederationHealthStatus,
   FederationInstanceId,
   FederationInstanceRole,
   FederationPeerSummary,
   FederationProtocolEnvelope,
+  ForkThreadResponse,
   HandoffThreadWorkspaceResponse,
   InterruptTurnResponse,
+  MaterializeDirectoryLaunchpadResponse,
   QueueThreadExecutionModeResponse,
   RunCodexEnvironmentActionResponse,
   SetAcpSessionRuntimeOptionResponse,
   SetCodexThreadEnvironmentResponse,
   SetThreadExecutionModeResponse,
   SetThreadModelSettingsResponse,
+  StartReviewResponse,
+  StartThreadResponse,
   SteerTurnResponse,
+  StopCodexEnvironmentActionResponse,
   SubmitServerRequestResponse,
 } from "@pwragent/shared";
 import {
   FEDERATION_PROTOCOL_VERSION,
+  buildThreadIdentityKey,
   buildFederatedThreadRef,
   federatedThreadIdentityKey,
   isRemoteFederationTarget,
@@ -33,9 +43,12 @@ import {
   type AppServerReadThreadRequest,
   type CancelThreadExecutionModeQueueRequest,
   type CompactThreadRequest,
+  type ForkThreadRequest,
   type FederationRemoteTarget,
   type HandoffThreadWorkspaceRequest,
   type InterruptTurnRequest,
+  type MaterializeDirectoryLaunchpadRequest,
+  type MaterializeDirectoryLaunchpadOptions,
   type NavigationSnapshot,
   type QueueThreadExecutionModeRequest,
   type RunCodexEnvironmentActionRequest,
@@ -43,32 +56,42 @@ import {
   type SetCodexThreadEnvironmentRequest,
   type SetThreadExecutionModeRequest,
   type SetThreadModelSettingsRequest,
+  type StartReviewRequest,
+  type StartThreadRequest,
   type SteerTurnRequest,
   type StartTurnRequest,
   type StartTurnResponse,
   type SubmitServerRequestRequest,
+  type StopCodexEnvironmentActionRequest,
 } from "@pwragent/shared";
 import { getDesktopBackendRegistry } from "../app-server/backend-registry";
 import { rewriteTranscriptImageUrlsForRenderer } from "../transcript-image-protocol";
 import { getMainLogger } from "../log";
 import { getDesktopSettingsService } from "../settings/desktop-settings-singleton";
 import { getAppStateDb, isAppStateInitialized } from "../state/app-state";
+import { DesktopMessagingBackendBridge } from "../messaging/desktop-backend-bridge";
 import {
   createFederationEnrollmentInvite,
-  type FederationEnrollmentInvite,
 } from "./federation-enrollment";
+import { FederatedSearchService } from "./federated-search-service";
 import {
   FEDERATION_BACKEND_EVENT_METHOD,
   FEDERATION_BACKEND_METHOD_CAPABILITIES,
+  FEDERATION_ENVIRONMENT_SETUP_PROGRESS_METHOD,
   FederationRemoteBackendClient,
   registerFederationBackendHandlers,
   type FederationBackendEventNotification,
   type FederationBackendOperations,
+  type FederationEnvironmentSetupProgressNotification,
 } from "./federation-backend-bridge";
-import { buildFederationHealthStatus } from "./federation-health";
+import {
+  buildFederationHealthStatus,
+  publicPeerSummary,
+} from "./federation-health";
 import { FederationRouter } from "./federation-router";
 import { FederationRpcEndpoint } from "./federation-rpc";
 import { FederationStore } from "./federation-store";
+import { redactFederationDiagnostic } from "./federation-redaction";
 import {
   connectFederationClient,
   FederationGatewayWebSocketServer,
@@ -81,6 +104,7 @@ const INSTANCE_ID_META_KEY = "federation_instance_id";
 const GATEWAY_INSTANCE_ID_META_KEY = "federation_gateway_instance_id";
 const PENDING_INVITE_TOKEN_META_KEY = "federation_pending_invite_token";
 const FEDERATION_PEER_DIRECTORY_METHOD = "federation.peerDirectory";
+const FEDERATION_RECONNECT_MAX_DELAY_MS = 30_000;
 
 const DEFAULT_CAPABILITIES: FederationCapability[] = [
   "remote_window",
@@ -122,11 +146,49 @@ export class DesktopFederationRuntime {
     FederationPeerSummary
   >();
   private publishAgentEvent?: (event: AgentEvent) => void;
+  private publishEnvironmentSetupProgress?: (
+    event: CodexEnvironmentSetupProgressEvent,
+  ) => void;
+  private readonly remoteBackendEventListeners = new Set<
+    (event: AgentEvent) => void | Promise<void>
+  >();
   private unsubscribeLocalBackendEvents?: () => void;
   private restartPromise: Promise<void> | undefined;
+  private reconnectTimer?: ReturnType<typeof setTimeout>;
+  private reconnectAttempt = 0;
+  private connectionGeneration = 0;
+  private stopping = true;
+  private lastConnectionError?: string;
 
   setAgentEventPublisher(publisher: (event: AgentEvent) => void): void {
     this.publishAgentEvent = publisher;
+  }
+
+  setEnvironmentSetupProgressPublisher(
+    publisher: (event: CodexEnvironmentSetupProgressEvent) => void,
+  ): void {
+    this.publishEnvironmentSetupProgress = publisher;
+  }
+
+  onRemoteBackendEvent(
+    listener: (event: AgentEvent) => void | Promise<void>,
+  ): () => void {
+    this.remoteBackendEventListeners.add(listener);
+    return () => {
+      this.remoteBackendEventListeners.delete(listener);
+    };
+  }
+
+  connectedPeerTargets(): Array<{
+    target: FederationRemoteTarget;
+    label: string;
+  }> {
+    return this.visiblePeers()
+      .filter((peer) => peer.status === "connected")
+      .map((peer) => ({
+        target: { scope: "remote", instanceId: peer.id },
+        label: peer.label,
+      }));
   }
 
   async restart(): Promise<void> {
@@ -137,6 +199,12 @@ export class DesktopFederationRuntime {
   }
 
   async stop(): Promise<void> {
+    this.stopping = true;
+    this.connectionGeneration += 1;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = undefined;
+    }
     this.unsubscribeLocalBackendEvents?.();
     this.unsubscribeLocalBackendEvents = undefined;
     this.client?.close();
@@ -149,14 +217,65 @@ export class DesktopFederationRuntime {
     this.gatewayInstanceId = undefined;
     this.rpcByPeer.clear();
     this.remotePeerDirectory.clear();
+    this.reconnectAttempt = 0;
+    this.lastConnectionError = undefined;
   }
 
   async health(): Promise<FederationHealthStatus> {
     const settings = await getDesktopSettingsService().readSettings();
-    return buildFederationHealthStatus({
+    const health = buildFederationHealthStatus({
       settings,
       peers: this.visiblePeers(),
       instanceId: this.ensureLocalInstanceId(),
+    });
+    if (
+      settings.federation.mode.value === "client" ||
+      settings.federation.mode.value === "dual"
+    ) {
+      health.status = this.client
+        ? "connected"
+        : this.reconnectTimer
+          ? "connecting"
+          : "disconnected";
+      health.unavailableReason = this.lastConnectionError;
+    }
+    return health;
+  }
+
+  async diagnostics(request: {
+    limit?: number;
+    peerId?: FederationInstanceId;
+  }): Promise<{
+    health: FederationHealthStatus;
+    events: FederationDiagnosticEvent[];
+  }> {
+    return {
+      health: await this.health(),
+      events: this.store().listAudit(request).map((entry) => ({
+        ...entry,
+        detail: entry.detail
+          ? redactFederationDiagnostic(entry.detail)
+          : undefined,
+      })),
+    };
+  }
+
+  async revokePeer(peerId: FederationInstanceId): Promise<FederationPeerSummary> {
+    const store = this.store();
+    const peer = store.getPeer(peerId);
+    if (!peer) {
+      throw new Error("Federation peer is not enrolled.");
+    }
+    const revokedAt = Date.now();
+    store.revokePeer(peerId, revokedAt);
+    this.server?.closePeer(peerId);
+    this.unregisterPeer(peerId);
+    this.remotePeerDirectory.delete(peerId);
+    this.broadcastPeerDirectory();
+    return publicPeerSummary({
+      ...peer,
+      status: "revoked",
+      revokedAt,
     });
   }
 
@@ -239,40 +358,73 @@ export class DesktopFederationRuntime {
     request: { backend?: AppServerListThreadsRequest["backend"]; filter?: string },
   ): Promise<NavigationSnapshot> {
     const backend = this.remoteBackend(target);
-    const response = await backend.listThreads({
+    const response = await backend.getNavigationSnapshot({
       backend: request.backend,
       filter: request.filter,
     });
     const peer = this.store().getPeer(target.instanceId);
     const instanceLabel = peer?.label ?? target.instanceId;
-    const threads = response.threads.map((thread) => ({
-      ...thread,
-      federation: {
-        ref: buildFederatedThreadRef({
-          backend: thread.source,
-          instanceId: target.instanceId,
-          threadId: thread.id,
-        }),
-        instanceLabel,
-        peerStatus: peer?.status,
-      },
-      inbox: { inInbox: true },
-    }));
+    const remoteThreadKeyByLocalKey = new Map<string, string>();
+    const threads = response.threads.map((thread) => {
+      const ref = buildFederatedThreadRef({
+        backend: thread.source,
+        instanceId: target.instanceId,
+        threadId: thread.id,
+      });
+      remoteThreadKeyByLocalKey.set(
+        buildThreadIdentityKey(thread.source, thread.id),
+        federatedThreadIdentityKey(ref),
+      );
+      return {
+        ...thread,
+        federation: {
+          ref,
+          instanceLabel,
+          peerStatus: peer?.status,
+        },
+      };
+    });
     return {
-      backend: response.backend,
-      fetchedAt: response.fetchedAt,
+      ...response,
       federationTarget: target,
       unchanged: false,
       threads,
-      inboxThreadKeys: threads.map((thread) =>
-        federatedThreadIdentityKey(thread.federation.ref),
+      inboxThreadKeys: response.inboxThreadKeys.map(
+        (threadKey) => remoteThreadKeyByLocalKey.get(threadKey) ?? threadKey,
       ),
-      directories: [],
-      launchpadDefaults: {
-        backend: request.backend ?? "codex",
-        executionMode: "default",
-      },
+      directories: response.directories.map((directory) => ({
+        ...directory,
+        threadKeys: directory.threadKeys.map(
+          (threadKey) => remoteThreadKeyByLocalKey.get(threadKey) ?? threadKey,
+        ),
+      })),
     };
+  }
+
+  async searchConnectedPeers(
+    request: FederatedSearchRequest,
+  ): Promise<FederatedSearchResponse> {
+    const service = new FederatedSearchService({
+      includeLocal: false,
+      local: localBackendOperations(),
+      peers: () =>
+        this.visiblePeers()
+          .filter(
+            (peer) =>
+              peer.status === "connected" &&
+              peer.capabilities.includes("federated_search"),
+          )
+          .map((peer) => ({
+            instanceId: peer.id,
+            label: peer.label,
+            status: peer.status,
+            backend: this.remoteBackend({
+              scope: "remote",
+              instanceId: peer.id,
+            }),
+          })),
+    });
+    return await service.search(request);
   }
 
   private async restartNow(): Promise<void> {
@@ -282,6 +434,7 @@ export class DesktopFederationRuntime {
     if (mode === "disabled") {
       return;
     }
+    this.stopping = false;
 
     const localInstanceId = this.ensureLocalInstanceId();
     const router = new FederationRouter({
@@ -291,6 +444,9 @@ export class DesktopFederationRuntime {
     registerFederationBackendHandlers({
       router,
       backend: localBackendOperations(),
+      onEnvironmentSetupProgress: (event, targetInstanceId) => {
+        this.sendEnvironmentSetupProgress(event, targetInstanceId);
+      },
     });
     this.router = router;
     this.subscribeLocalBackendEvents();
@@ -312,7 +468,14 @@ export class DesktopFederationRuntime {
     }
 
     if (mode === "client" || mode === "dual") {
-      await this.connectClient(settings.federation.gatewayUrl.value.trim());
+      const gatewayUrl = settings.federation.gatewayUrl.value.trim();
+      if (!gatewayUrl) {
+        this.lastConnectionError = "Federation gateway URL is not configured.";
+      } else {
+        await this.connectClient(gatewayUrl).catch((error) => {
+          this.handleClientConnectionFailure(gatewayUrl, error);
+        });
+      }
     }
   }
 
@@ -320,15 +483,41 @@ export class DesktopFederationRuntime {
     if (!gatewayUrl) return;
     const gatewayInstanceId = getAppStateDb().getMeta(GATEWAY_INSTANCE_ID_META_KEY);
     if (!gatewayInstanceId) {
-      log.warn("federation client mode missing gateway instance id");
-      return;
+      throw new Error("Federation client mode is missing its gateway identity.");
     }
     this.gatewayInstanceId = gatewayInstanceId;
     const pendingInviteToken = getAppStateDb().getMeta(PENDING_INVITE_TOKEN_META_KEY);
     const keyPair = await getDesktopSettingsService()
       .getOrCreateFederationIdentityKeyPair();
+    const settingsService = getDesktopSettingsService();
+    const settings = await settingsService.readSettings();
+    const cloudflareCredentials =
+      await settingsService.resolveFederationCloudflareCredentials();
+    const cloudflareMtlsEnabled =
+      settings.federation.cloudflareMtlsEnabled.value;
+    const cloudflareAccessEnabled =
+      settings.federation.cloudflareAccessServiceAuthEnabled.value;
+    if (
+      cloudflareMtlsEnabled &&
+      (!cloudflareCredentials.clientCertificate ||
+        !cloudflareCredentials.clientPrivateKey)
+    ) {
+      throw new Error(
+        "Cloudflare mTLS is enabled but the client certificate or private key is missing.",
+      );
+    }
+    if (
+      cloudflareAccessEnabled &&
+      (!cloudflareCredentials.accessClientId ||
+        !cloudflareCredentials.accessClientSecret)
+    ) {
+      throw new Error(
+        "Cloudflare Access service auth is enabled but its credentials are missing.",
+      );
+    }
     this.gatewayUrl = gatewayUrl;
-    this.client = await connectFederationClient({
+    const connectionGeneration = ++this.connectionGeneration;
+    const client = await connectFederationClient({
       url: gatewayUrl,
       mode: pendingInviteToken ? "enroll" : "reconnect",
       gatewayInstanceId,
@@ -339,9 +528,42 @@ export class DesktopFederationRuntime {
       inviteToken: pendingInviteToken || undefined,
       label: getAppStateDb().getMeta("profile_name") || this.ensureLocalInstanceId(),
       role: "client",
+      headers: cloudflareAccessEnabled
+        ? {
+            "CF-Access-Client-Id": cloudflareCredentials.accessClientId!,
+            "CF-Access-Client-Secret":
+              cloudflareCredentials.accessClientSecret!,
+          }
+        : undefined,
+      clientCertificate: cloudflareMtlsEnabled
+        ? cloudflareCredentials.clientCertificate
+        : undefined,
+      clientPrivateKey: cloudflareMtlsEnabled
+        ? cloudflareCredentials.clientPrivateKey
+        : undefined,
+      onClose: () => {
+        if (
+          this.stopping ||
+          connectionGeneration !== this.connectionGeneration
+        ) {
+          return;
+        }
+        this.client = undefined;
+        this.lastConnectionError = "Federation gateway connection closed.";
+        this.unregisterPeer(gatewayInstanceId);
+        this.scheduleReconnect(gatewayUrl);
+      },
       onEnvelope: (envelope) =>
         void this.receiveEnvelope(envelope, gatewayInstanceId),
     });
+    if (
+      this.stopping ||
+      connectionGeneration !== this.connectionGeneration
+    ) {
+      client.close();
+      return;
+    }
+    this.client = client;
     this.router?.registerConnection({
       peerId: gatewayInstanceId,
       capabilities: DEFAULT_CAPABILITIES,
@@ -350,7 +572,47 @@ export class DesktopFederationRuntime {
     if (pendingInviteToken) {
       getAppStateDb().setMeta(PENDING_INVITE_TOKEN_META_KEY, "");
     }
+    this.reconnectAttempt = 0;
+    this.lastConnectionError = undefined;
     log.info("federation client connected", { gatewayUrl });
+  }
+
+  private handleClientConnectionFailure(
+    gatewayUrl: string,
+    error: unknown,
+  ): void {
+    if (this.stopping) return;
+    this.client = undefined;
+    this.lastConnectionError = redactFederationDiagnostic(
+      error instanceof Error ? error.message : String(error),
+    );
+    this.store().appendAudit({
+      peerId: this.gatewayInstanceId,
+      kind: "error",
+      createdAt: Date.now(),
+      detail: this.lastConnectionError,
+    });
+    log.warn("federation client connection failed", {
+      gatewayUrl,
+      error: this.lastConnectionError,
+    });
+    this.scheduleReconnect(gatewayUrl);
+  }
+
+  private scheduleReconnect(gatewayUrl: string): void {
+    if (this.stopping || this.reconnectTimer) return;
+    const delayMs = Math.min(
+      1_000 * 2 ** this.reconnectAttempt,
+      FEDERATION_RECONNECT_MAX_DELAY_MS,
+    );
+    this.reconnectAttempt += 1;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = undefined;
+      if (this.stopping) return;
+      void this.connectClient(gatewayUrl).catch((error) => {
+        this.handleClientConnectionFailure(gatewayUrl, error);
+      });
+    }, delayMs);
   }
 
   private registerGatewayConnection(connection: FederationGatewayConnection): void {
@@ -383,6 +645,9 @@ export class DesktopFederationRuntime {
     if (this.applyPeerDirectory(envelope)) {
       return;
     }
+    if (this.publishRemoteEnvironmentSetupProgress(envelope, sourcePeerId)) {
+      return;
+    }
     if (this.publishRemoteBackendEvent(envelope, sourcePeerId)) {
       return;
     }
@@ -391,6 +656,52 @@ export class DesktopFederationRuntime {
       if (handled) return;
     }
     await this.router?.routeEnvelope({ envelope, sourcePeerId });
+  }
+
+  private sendEnvironmentSetupProgress(
+    event: CodexEnvironmentSetupProgressEvent,
+    targetInstanceId: FederationInstanceId,
+  ): void {
+    this.sendEnvelopeToTarget(targetInstanceId, {
+      id: `federation-environment-setup:${randomUUID()}`,
+      kind: "notification",
+      method: FEDERATION_ENVIRONMENT_SETUP_PROGRESS_METHOD,
+      params: event,
+      protocolVersion: FEDERATION_PROTOCOL_VERSION,
+      sourceInstanceId: this.ensureLocalInstanceId(),
+      targetInstanceId,
+      createdAt: Date.now(),
+    });
+  }
+
+  private publishRemoteEnvironmentSetupProgress(
+    envelope: FederationProtocolEnvelope,
+    sourcePeerId: FederationInstanceId,
+  ): boolean {
+    if (
+      envelope.kind !== "notification" ||
+      envelope.method !== FEDERATION_ENVIRONMENT_SETUP_PROGRESS_METHOD
+    ) {
+      return false;
+    }
+    const notification =
+      envelope as FederationEnvironmentSetupProgressNotification & typeof envelope;
+    const targetInstanceId = envelope.targetInstanceId;
+    if (
+      targetInstanceId &&
+      targetInstanceId !== this.ensureLocalInstanceId()
+    ) {
+      void this.router?.routeEnvelope({ envelope, sourcePeerId });
+      return true;
+    }
+    this.publishEnvironmentSetupProgress?.({
+      ...notification.params,
+      federationTarget: {
+        scope: "remote",
+        instanceId: envelope.sourceInstanceId || sourcePeerId,
+      },
+    });
+    return true;
   }
 
   private ensureLocalInstanceId(): FederationInstanceId {
@@ -469,6 +780,8 @@ export class DesktopFederationRuntime {
     return [...visible.values()].map((peer) =>
       this.router?.getConnection(peer.id)
         ? { ...peer, status: "connected" }
+        : this.remotePeerDirectory.has(peer.id)
+          ? peer
         : {
             ...peer,
             status: peer.status === "connected" ? "disconnected" : peer.status,
@@ -600,14 +913,23 @@ export class DesktopFederationRuntime {
     }
 
     const notification = envelope as FederationBackendEventNotification & typeof envelope;
-    this.publishAgentEvent?.({
+    const event: AgentEvent = {
       backend: notification.params.backend,
       federationTarget: {
         scope: "remote",
         instanceId: envelope.sourceInstanceId || sourcePeerId,
       },
       notification: notification.params.notification,
-    });
+    };
+    this.publishAgentEvent?.(event);
+    for (const listener of this.remoteBackendEventListeners) {
+      void Promise.resolve(listener(event)).catch((error) => {
+        log.warn("federation remote backend event listener failed", {
+          error: error instanceof Error ? error.message : String(error),
+          method: event.notification.method,
+        });
+      });
+    }
     this.relayRemoteBackendEvent(envelope, sourcePeerId);
     return true;
   }
@@ -644,6 +966,10 @@ export class DesktopFederationRuntime {
 
 function localBackendOperations(): FederationBackendOperations {
   return {
+    async getNavigationSnapshot(request = {}): Promise<NavigationSnapshot> {
+      return await new DesktopMessagingBackendBridge()
+        .getNavigationSnapshot(request);
+    },
     async listThreads(
       request: AppServerListThreadsRequest = {},
     ): Promise<AppServerListThreadsResponse> {
@@ -671,7 +997,7 @@ function localBackendOperations(): FederationBackendOperations {
       });
       return rewriteTranscriptImageUrlsForRenderer(response);
     },
-    async listSkills(
+  async listSkills(
       request: AppServerListSkillsRequest = {},
     ): Promise<AppServerListSkillsResponse> {
       const backend = request.backend ?? "codex";
@@ -686,6 +1012,25 @@ function localBackendOperations(): FederationBackendOperations {
         fetchedAt: Date.now(),
         data: response.data,
       };
+    },
+    async listBackends(request = {}) {
+      return await getDesktopBackendRegistry().listBackends(request);
+    },
+    async startThread(request: StartThreadRequest): Promise<StartThreadResponse> {
+      return await getDesktopBackendRegistry().startThread(request);
+    },
+    async forkThread(
+      request: ForkThreadRequest,
+      options?: Pick<
+        MaterializeDirectoryLaunchpadOptions,
+        "onCodexEnvironmentSetupProgress"
+      >,
+    ): Promise<ForkThreadResponse> {
+      return await getDesktopBackendRegistry().forkThread({
+        ...request,
+        onCodexEnvironmentSetupProgress:
+          options?.onCodexEnvironmentSetupProgress,
+      });
     },
     async startTurn(request: StartTurnRequest): Promise<StartTurnResponse> {
       const submitted = await getDesktopBackendRegistry().submitTurn({
@@ -707,6 +1052,11 @@ function localBackendOperations(): FederationBackendOperations {
             queueStatus: "queued",
             queueEntryId: submitted.entry.id,
           };
+    },
+    async startReview(
+      request: StartReviewRequest,
+    ): Promise<StartReviewResponse> {
+      return await getDesktopBackendRegistry().startReview(request);
     },
     async compactThread(
       request: CompactThreadRequest,
@@ -756,10 +1106,22 @@ function localBackendOperations(): FederationBackendOperations {
     ): Promise<RunCodexEnvironmentActionResponse> {
       return await getDesktopBackendRegistry().runCodexEnvironmentAction(request);
     },
+    async stopCodexEnvironmentAction(
+      request: StopCodexEnvironmentActionRequest,
+    ): Promise<StopCodexEnvironmentActionResponse> {
+      return await getDesktopBackendRegistry().stopCodexEnvironmentAction(request);
+    },
     async setCodexThreadEnvironment(
       request: SetCodexThreadEnvironmentRequest,
     ): Promise<SetCodexThreadEnvironmentResponse> {
       return await getDesktopBackendRegistry().setCodexThreadEnvironment(request);
+    },
+    async materializeDirectoryLaunchpad(
+      request: MaterializeDirectoryLaunchpadRequest,
+      options?: MaterializeDirectoryLaunchpadOptions,
+    ): Promise<MaterializeDirectoryLaunchpadResponse> {
+      return await getDesktopBackendRegistry()
+        .materializeDirectoryLaunchpad(request, options);
     },
     async handoffThreadWorkspace(
       request: HandoffThreadWorkspaceRequest,

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -20,7 +20,9 @@ import type {
   HandoffThreadWorkspaceResponse,
   InterruptTurnResponse,
   MaterializeDirectoryLaunchpadResponse,
+  OpenDesktopApplicationResponse,
   QueueThreadExecutionModeResponse,
+  RenameThreadResponse,
   RunCodexEnvironmentActionResponse,
   SetAcpSessionRuntimeOptionResponse,
   SetCodexThreadEnvironmentResponse,
@@ -31,6 +33,7 @@ import type {
   SteerTurnResponse,
   StopCodexEnvironmentActionResponse,
   SubmitServerRequestResponse,
+  TrustCodexProjectResponse,
 } from "@pwragent/shared";
 import {
   FEDERATION_PROTOCOL_VERSION,
@@ -50,7 +53,9 @@ import {
   type MaterializeDirectoryLaunchpadRequest,
   type MaterializeDirectoryLaunchpadOptions,
   type NavigationSnapshot,
+  type OpenDesktopApplicationRequest,
   type QueueThreadExecutionModeRequest,
+  type RenameThreadRequest,
   type RunCodexEnvironmentActionRequest,
   type SetAcpSessionRuntimeOptionRequest,
   type SetCodexThreadEnvironmentRequest,
@@ -63,10 +68,12 @@ import {
   type StartTurnResponse,
   type SubmitServerRequestRequest,
   type StopCodexEnvironmentActionRequest,
+  type TrustCodexProjectRequest,
 } from "@pwragent/shared";
 import { getDesktopBackendRegistry } from "../app-server/backend-registry";
 import { rewriteTranscriptImageUrlsForRenderer } from "../transcript-image-protocol";
 import { getMainLogger } from "../log";
+import { openDesktopApplication } from "../settings/application-discovery";
 import { getDesktopSettingsService } from "../settings/desktop-settings-singleton";
 import { getAppStateDb, isAppStateInitialized } from "../state/app-state";
 import { DesktopMessagingBackendBridge } from "../messaging/desktop-backend-bridge";
@@ -1127,6 +1134,21 @@ function localBackendOperations(): FederationBackendOperations {
       request: HandoffThreadWorkspaceRequest,
     ): Promise<HandoffThreadWorkspaceResponse> {
       return await getDesktopBackendRegistry().handoffThreadWorkspace(request);
+    },
+    async renameThread(
+      request: RenameThreadRequest,
+    ): Promise<RenameThreadResponse> {
+      return await getDesktopBackendRegistry().renameThread(request);
+    },
+    async openApplication(
+      request: OpenDesktopApplicationRequest,
+    ): Promise<OpenDesktopApplicationResponse> {
+      return await openDesktopApplication(request);
+    },
+    async trustCodexProject(
+      request: TrustCodexProjectRequest,
+    ): Promise<TrustCodexProjectResponse> {
+      return await getDesktopBackendRegistry().trustCodexProject(request);
     },
   };
 }

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -37,9 +37,7 @@ import type {
 } from "@pwragent/shared";
 import {
   FEDERATION_PROTOCOL_VERSION,
-  buildThreadIdentityKey,
   buildFederatedThreadRef,
-  federatedThreadIdentityKey,
   isRemoteFederationTarget,
   type AppServerListSkillsRequest,
   type AppServerListThreadsRequest,
@@ -83,6 +81,8 @@ import { getAppStateDb, isAppStateInitialized } from "../state/app-state";
 import { DesktopMessagingBackendBridge } from "../messaging/desktop-backend-bridge";
 import {
   createFederationEnrollmentInvite,
+  decodeFederationInvite,
+  encodeFederationInvite,
 } from "./federation-enrollment";
 import { FederatedSearchService } from "./federated-search-service";
 import {
@@ -113,6 +113,7 @@ import {
 const log = getMainLogger("pwragent:federation-runtime");
 const INSTANCE_ID_META_KEY = "federation_instance_id";
 const GATEWAY_INSTANCE_ID_META_KEY = "federation_gateway_instance_id";
+const GATEWAY_PUBLIC_KEY_META_KEY = "federation_gateway_public_key_pem";
 const PENDING_INVITE_TOKEN_META_KEY = "federation_pending_invite_token";
 const FEDERATION_PEER_DIRECTORY_METHOD = "federation.peerDirectory";
 const FEDERATION_RECONNECT_MAX_DELAY_MS = 30_000;
@@ -127,14 +128,6 @@ const DEFAULT_CAPABILITIES: FederationCapability[] = [
   "federated_search",
   "gateway_relay",
 ];
-
-type FederationInvitePayload = {
-  version: 1;
-  token: string;
-  gatewayInstanceId: FederationInstanceId;
-  gatewayUrl: string;
-  expiresAt: number;
-};
 
 type FederationPeerDirectoryNotification = {
   method: typeof FEDERATION_PEER_DIRECTORY_METHOD;
@@ -170,6 +163,7 @@ export class DesktopFederationRuntime {
   private connectionGeneration = 0;
   private stopping = true;
   private lastConnectionError?: string;
+  private gatewayListenerError?: string;
 
   setAgentEventPublisher(publisher: (event: AgentEvent) => void): void {
     this.publishAgentEvent = publisher;
@@ -230,6 +224,7 @@ export class DesktopFederationRuntime {
     this.remotePeerDirectory.clear();
     this.reconnectAttempt = 0;
     this.lastConnectionError = undefined;
+    this.gatewayListenerError = undefined;
   }
 
   async health(): Promise<FederationHealthStatus> {
@@ -238,6 +233,8 @@ export class DesktopFederationRuntime {
       settings,
       peers: this.visiblePeers(),
       instanceId: this.ensureLocalInstanceId(),
+      listenUrl: this.listenUrl,
+      unavailableReason: this.gatewayListenerError,
     });
     if (
       settings.federation.mode.value === "client" ||
@@ -249,6 +246,10 @@ export class DesktopFederationRuntime {
           ? "connecting"
           : "disconnected";
       health.unavailableReason = this.lastConnectionError;
+    }
+    if (this.gatewayListenerError) {
+      health.status = "degraded";
+      health.unavailableReason = this.gatewayListenerError;
     }
     return health;
   }
@@ -301,6 +302,8 @@ export class DesktopFederationRuntime {
     }
     const now = Date.now();
     const expiresAt = now + Math.max(60_000, Math.min(request.ttlMs ?? 3_600_000, 86_400_000));
+    const gatewayIdentity = await getDesktopSettingsService()
+      .getOrCreateFederationIdentityKeyPair();
     const entry = createFederationEnrollmentInvite({
       store: this.store(),
       token: randomBytes(24).toString("base64url"),
@@ -312,10 +315,11 @@ export class DesktopFederationRuntime {
       endpoint: gatewayUrl,
     });
     return {
-      invite: encodeInvite({
+      invite: encodeFederationInvite({
         version: 1,
         token: entry.token,
         gatewayInstanceId: this.ensureLocalInstanceId(),
+        gatewayPublicKeyPem: gatewayIdentity.publicKeyPem,
         gatewayUrl,
         expiresAt,
       }),
@@ -328,9 +332,10 @@ export class DesktopFederationRuntime {
     gatewayInstanceId: FederationInstanceId;
     gatewayUrl: string;
   }> {
-    const payload = decodeInvite(invite);
+    const payload = decodeFederationInvite(invite);
     const stateDb = getAppStateDb();
     stateDb.setMeta(GATEWAY_INSTANCE_ID_META_KEY, payload.gatewayInstanceId);
+    stateDb.setMeta(GATEWAY_PUBLIC_KEY_META_KEY, payload.gatewayPublicKeyPem);
     stateDb.setMeta(PENDING_INVITE_TOKEN_META_KEY, payload.token);
     await getDesktopSettingsService().writeConfigPatch({
       federation: {
@@ -375,17 +380,12 @@ export class DesktopFederationRuntime {
     });
     const peer = this.store().getPeer(target.instanceId);
     const instanceLabel = peer?.label ?? target.instanceId;
-    const remoteThreadKeyByLocalKey = new Map<string, string>();
     const threads = response.threads.map((thread) => {
       const ref = buildFederatedThreadRef({
         backend: thread.source,
         instanceId: target.instanceId,
         threadId: thread.id,
       });
-      remoteThreadKeyByLocalKey.set(
-        buildThreadIdentityKey(thread.source, thread.id),
-        federatedThreadIdentityKey(ref),
-      );
       return {
         ...thread,
         federation: {
@@ -400,15 +400,6 @@ export class DesktopFederationRuntime {
       federationTarget: target,
       unchanged: false,
       threads,
-      inboxThreadKeys: response.inboxThreadKeys.map(
-        (threadKey) => remoteThreadKeyByLocalKey.get(threadKey) ?? threadKey,
-      ),
-      directories: response.directories.map((directory) => ({
-        ...directory,
-        threadKeys: directory.threadKeys.map(
-          (threadKey) => remoteThreadKeyByLocalKey.get(threadKey) ?? threadKey,
-        ),
-      })),
     };
   }
 
@@ -463,8 +454,12 @@ export class DesktopFederationRuntime {
     this.subscribeLocalBackendEvents();
 
     if (mode === "gateway" || mode === "dual") {
+      const gatewayIdentity = await getDesktopSettingsService()
+        .getOrCreateFederationIdentityKeyPair();
       this.server = new FederationGatewayWebSocketServer({
         gatewayInstanceId: localInstanceId,
+        gatewayPrivateKeyPem: gatewayIdentity.privateKeyPem,
+        gatewayPublicKeyPem: gatewayIdentity.publicKeyPem,
         host: settings.federation.listenHost.value,
         port: settings.federation.listenPort.value,
         store: this.store(),
@@ -473,9 +468,20 @@ export class DesktopFederationRuntime {
         onEnvelope: (envelope, connection) =>
           void this.receiveEnvelope(envelope, connection.peerId),
       });
-      const started = await this.server.start();
-      this.listenUrl = started.url;
-      log.info("federation gateway listening", { url: started.url });
+      try {
+        const started = await this.server.start();
+        this.listenUrl = started.url;
+        log.info("federation gateway listening", { url: started.url });
+      } catch (error) {
+        this.gatewayListenerError = redactFederationDiagnostic(
+          error instanceof Error ? error.message : String(error),
+        );
+        await this.server.stop().catch(() => undefined);
+        this.server = undefined;
+        log.error("federation gateway failed to listen", {
+          error: this.gatewayListenerError,
+        });
+      }
     }
 
     if (mode === "client" || mode === "dual") {
@@ -495,6 +501,10 @@ export class DesktopFederationRuntime {
     const gatewayInstanceId = getAppStateDb().getMeta(GATEWAY_INSTANCE_ID_META_KEY);
     if (!gatewayInstanceId) {
       throw new Error("Federation client mode is missing its gateway identity.");
+    }
+    const gatewayPublicKeyPem = getAppStateDb().getMeta(GATEWAY_PUBLIC_KEY_META_KEY);
+    if (!gatewayPublicKeyPem) {
+      throw new Error("Federation client mode is missing its pinned gateway key.");
     }
     this.gatewayInstanceId = gatewayInstanceId;
     const pendingInviteToken = getAppStateDb().getMeta(PENDING_INVITE_TOKEN_META_KEY);
@@ -532,6 +542,7 @@ export class DesktopFederationRuntime {
       url: gatewayUrl,
       mode: pendingInviteToken ? "enroll" : "reconnect",
       gatewayInstanceId,
+      gatewayPublicKeyPem,
       peerInstanceId: this.ensureLocalInstanceId(),
       privateKeyPem: keyPair.privateKeyPem,
       publicKeyPem: keyPair.publicKeyPem,
@@ -562,6 +573,7 @@ export class DesktopFederationRuntime {
         this.client = undefined;
         this.lastConnectionError = "Federation gateway connection closed.";
         this.unregisterPeer(gatewayInstanceId);
+        this.disconnectAdvertisedPeers(this.lastConnectionError);
         this.scheduleReconnect(gatewayUrl);
       },
       onEnvelope: (envelope) =>
@@ -597,6 +609,7 @@ export class DesktopFederationRuntime {
     this.lastConnectionError = redactFederationDiagnostic(
       error instanceof Error ? error.message : String(error),
     );
+    this.disconnectAdvertisedPeers(this.lastConnectionError);
     this.store().appendAudit({
       peerId: this.gatewayInstanceId,
       kind: "error",
@@ -646,7 +659,24 @@ export class DesktopFederationRuntime {
 
   private unregisterPeer(peerId: FederationInstanceId): void {
     this.router?.unregisterConnection(peerId);
+    this.rpcByPeer.get(peerId)?.rejectAll(
+      new Error(`Federation peer ${peerId} disconnected.`),
+    );
     this.rpcByPeer.delete(peerId);
+  }
+
+  private disconnectAdvertisedPeers(reason: string): void {
+    for (const [peerId, peer] of this.remotePeerDirectory) {
+      this.remotePeerDirectory.set(peerId, {
+        ...peer,
+        status: peer.status === "revoked" ? "revoked" : "disconnected",
+        unavailableReason: reason,
+      });
+    }
+    for (const rpc of this.rpcByPeer.values()) {
+      rpc.rejectAll(new Error(reason));
+    }
+    this.rpcByPeer.clear();
   }
 
   private async receiveEnvelope(
@@ -663,7 +693,15 @@ export class DesktopFederationRuntime {
       return;
     }
     if (envelope.kind === "response" || envelope.kind === "error") {
-      const handled = this.rpcByPeer.get(sourcePeerId)?.receiveEnvelope(envelope) ?? false;
+      const sourceInstanceId = envelope.sourceInstanceId;
+      const originatingRpc = sourceInstanceId
+        ? this.rpcByPeer.get(sourceInstanceId)
+        : undefined;
+      const handledByOrigin = originatingRpc?.receiveEnvelope(envelope) ?? false;
+      const handled = handledByOrigin || [...this.rpcByPeer.entries()].some(
+        ([peerId, rpc]) =>
+          peerId !== sourceInstanceId && rpc.receiveEnvelope(envelope),
+      );
       if (handled) return;
     }
     await this.router?.routeEnvelope({ envelope, sourcePeerId });
@@ -760,13 +798,13 @@ export class DesktopFederationRuntime {
 
     for (const peer of this.remotePeerDirectory.values()) {
       if (peer.id !== localInstanceId) {
-        visible.set(peer.id, peer);
+        visible.set(peer.id, { ...peer, canRevoke: false });
       }
     }
 
     for (const peer of this.store().listPeers({ includeRevoked: true })) {
       if (peer.id === localInstanceId) continue;
-      visible.set(peer.id, peer);
+      visible.set(peer.id, { ...peer, canRevoke: true });
     }
 
     for (const connection of this.router?.listConnections() ?? []) {
@@ -785,6 +823,7 @@ export class DesktopFederationRuntime {
         lastActivityAt: existing?.lastActivityAt,
         revokedAt: existing?.revokedAt,
         unavailableReason: existing?.unavailableReason,
+        canRevoke: existing?.canRevoke ?? false,
       });
     }
 
@@ -871,7 +910,7 @@ export class DesktopFederationRuntime {
     this.remotePeerDirectory.clear();
     for (const peer of notification.params.peers) {
       if (peer.id !== this.ensureLocalInstanceId()) {
-        this.remotePeerDirectory.set(peer.id, peer);
+        this.remotePeerDirectory.set(peer.id, { ...peer, canRevoke: false });
       }
     }
     return true;
@@ -1027,6 +1066,9 @@ function localBackendOperations(): FederationBackendOperations {
     async listBackends(request = {}) {
       return await getDesktopBackendRegistry().listBackends(request);
     },
+    async archiveThread(request) {
+      return await getDesktopBackendRegistry().archiveThread(request);
+    },
     async startThread(request: StartThreadRequest): Promise<StartThreadResponse> {
       return await getDesktopBackendRegistry().startThread(request);
     },
@@ -1158,28 +1200,6 @@ function localBackendOperations(): FederationBackendOperations {
       return await getDesktopBackendRegistry().trustCodexProject(request);
     },
   };
-}
-
-function encodeInvite(payload: FederationInvitePayload): string {
-  return `pwragent-federation:${Buffer.from(JSON.stringify(payload), "utf8").toString("base64url")}`;
-}
-
-function decodeInvite(invite: string): FederationInvitePayload {
-  const encoded = invite.trim().replace(/^pwragent-federation:/, "");
-  const parsed = JSON.parse(Buffer.from(encoded, "base64url").toString("utf8")) as Partial<FederationInvitePayload>;
-  if (
-    parsed.version !== 1 ||
-    typeof parsed.token !== "string" ||
-    typeof parsed.gatewayInstanceId !== "string" ||
-    typeof parsed.gatewayUrl !== "string" ||
-    typeof parsed.expiresAt !== "number"
-  ) {
-    throw new Error("Invalid federation invite.");
-  }
-  if (parsed.expiresAt <= Date.now()) {
-    throw new Error("Federation invite has expired.");
-  }
-  return parsed as FederationInvitePayload;
 }
 
 let runtime: DesktopFederationRuntime | undefined;

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -48,6 +48,7 @@ import {
   type CompactThreadRequest,
   type ForkThreadRequest,
   type FederationRemoteTarget,
+  type DesktopApplicationsSnapshot,
   type HandoffThreadWorkspaceRequest,
   type InterruptTurnRequest,
   type MaterializeDirectoryLaunchpadRequest,
@@ -73,7 +74,10 @@ import {
 import { getDesktopBackendRegistry } from "../app-server/backend-registry";
 import { rewriteTranscriptImageUrlsForRenderer } from "../transcript-image-protocol";
 import { getMainLogger } from "../log";
-import { openDesktopApplication } from "../settings/application-discovery";
+import {
+  discoverDesktopApplications,
+  openDesktopApplication,
+} from "../settings/application-discovery";
 import { getDesktopSettingsService } from "../settings/desktop-settings-singleton";
 import { getAppStateDb, isAppStateInitialized } from "../state/app-state";
 import { DesktopMessagingBackendBridge } from "../messaging/desktop-backend-bridge";
@@ -1139,6 +1143,9 @@ function localBackendOperations(): FederationBackendOperations {
       request: RenameThreadRequest,
     ): Promise<RenameThreadResponse> {
       return await getDesktopBackendRegistry().renameThread(request);
+    },
+    async readApplications(): Promise<DesktopApplicationsSnapshot> {
+      return await discoverDesktopApplications();
     },
     async openApplication(
       request: OpenDesktopApplicationRequest,

--- a/apps/desktop/src/main/federation/federation-session-state.ts
+++ b/apps/desktop/src/main/federation/federation-session-state.ts
@@ -1,0 +1,117 @@
+import type {
+  FederationCapability,
+  FederationPeerId,
+  FederationSessionId,
+} from "@pwragent/shared";
+
+export type FederationActiveSession = {
+  sessionId: FederationSessionId;
+  peerId: FederationPeerId;
+  connectedAt: number;
+  lastHeartbeatAt: number;
+  capabilities: FederationCapability[];
+  status: "active" | "closed";
+  closedAt?: number;
+  closeReason?: "replaced" | "revoked" | "timeout" | "transport_closed";
+};
+
+export class FederationSessionRegistry {
+  private readonly sessions = new Map<FederationSessionId, FederationActiveSession>();
+
+  openSession(params: {
+    sessionId: FederationSessionId;
+    peerId: FederationPeerId;
+    connectedAt: number;
+    capabilities: readonly FederationCapability[];
+  }): FederationActiveSession {
+    for (const session of this.sessions.values()) {
+      if (session.peerId === params.peerId && session.status === "active") {
+        this.closeSession({
+          sessionId: session.sessionId,
+          closedAt: params.connectedAt,
+          reason: "replaced",
+        });
+      }
+    }
+    const session: FederationActiveSession = {
+      sessionId: params.sessionId,
+      peerId: params.peerId,
+      connectedAt: params.connectedAt,
+      lastHeartbeatAt: params.connectedAt,
+      capabilities: params.capabilities.slice(),
+      status: "active",
+    };
+    this.sessions.set(params.sessionId, session);
+    return session;
+  }
+
+  heartbeat(sessionId: FederationSessionId, heartbeatAt: number): FederationActiveSession | undefined {
+    const session = this.sessions.get(sessionId);
+    if (!session || session.status !== "active") return session;
+    session.lastHeartbeatAt = heartbeatAt;
+    return session;
+  }
+
+  closeSession(params: {
+    sessionId: FederationSessionId;
+    closedAt: number;
+    reason: FederationActiveSession["closeReason"];
+  }): FederationActiveSession | undefined {
+    const session = this.sessions.get(params.sessionId);
+    if (!session || session.status === "closed") return session;
+    session.status = "closed";
+    session.closedAt = params.closedAt;
+    session.closeReason = params.reason;
+    return session;
+  }
+
+  closePeerSessions(params: {
+    peerId: FederationPeerId;
+    closedAt: number;
+    reason: FederationActiveSession["closeReason"];
+  }): FederationActiveSession[] {
+    const closed: FederationActiveSession[] = [];
+    for (const session of this.sessions.values()) {
+      if (session.peerId !== params.peerId || session.status !== "active") {
+        continue;
+      }
+      const next = this.closeSession({
+        sessionId: session.sessionId,
+        closedAt: params.closedAt,
+        reason: params.reason,
+      });
+      if (next) closed.push(next);
+    }
+    return closed;
+  }
+
+  expireStaleSessions(params: {
+    now: number;
+    heartbeatTimeoutMs: number;
+  }): FederationActiveSession[] {
+    const expired: FederationActiveSession[] = [];
+    for (const session of this.sessions.values()) {
+      if (session.status !== "active") continue;
+      if (session.lastHeartbeatAt + params.heartbeatTimeoutMs > params.now) {
+        continue;
+      }
+      const next = this.closeSession({
+        sessionId: session.sessionId,
+        closedAt: params.now,
+        reason: "timeout",
+      });
+      if (next) expired.push(next);
+    }
+    return expired;
+  }
+
+  getSession(sessionId: FederationSessionId): FederationActiveSession | undefined {
+    return this.sessions.get(sessionId);
+  }
+
+  listActiveSessions(): FederationActiveSession[] {
+    return Array.from(this.sessions.values()).filter(
+      (session) => session.status === "active",
+    );
+  }
+}

--- a/apps/desktop/src/main/federation/federation-store.ts
+++ b/apps/desktop/src/main/federation/federation-store.ts
@@ -421,7 +421,7 @@ function rowToPeer(row: FederationPeerRow): FederationPeerSummary & {
   return {
     id: row.peer_id,
     label: row.label,
-    role: row.role as FederationInstanceRole,
+    role: normalizeFederationInstanceRole(row.role) ?? "client",
     status: row.status as FederationConnectionState,
     capabilities: payload.capabilities ?? [],
     protocolVersion: payload.protocolVersion,
@@ -448,10 +448,21 @@ function rowToEnrollment(row: FederationEnrollmentRow): FederationEnrollmentEntr
     usedAt: row.used_at ?? undefined,
     peerId: row.peer_id ?? undefined,
     label: payload.label,
-    role: payload.role,
+    role: normalizeFederationInstanceRole(payload.role),
     endpoint: payload.endpoint,
     gatewayInstanceId: payload.gatewayInstanceId,
   };
+}
+
+function normalizeFederationInstanceRole(
+  value: FederationInstanceRole | string | undefined,
+): FederationInstanceRole | undefined {
+  if (value === "child") {
+    return "client";
+  }
+  return value === "gateway" || value === "client" || value === "dual"
+    ? value
+    : undefined;
 }
 
 function rowToAudit(row: FederationSessionAuditRow): FederationSessionAuditEntry {

--- a/apps/desktop/src/main/federation/federation-store.ts
+++ b/apps/desktop/src/main/federation/federation-store.ts
@@ -1,0 +1,482 @@
+import {
+  createHmac,
+  randomBytes,
+  randomUUID,
+  timingSafeEqual,
+} from "node:crypto";
+import type {
+  FederationCapability,
+  FederationConnectionState,
+  FederationInstanceRole,
+  FederationPeerId,
+  FederationPeerSummary,
+  FederationSessionId,
+} from "@pwragent/shared";
+import { isFederationInstanceId } from "@pwragent/shared";
+import type { StateDb } from "../state/state-db";
+
+const FEDERATION_ENROLLMENT_SECRET_META_KEY =
+  "federation_enrollment_secret_v1";
+
+export type FederationEnrollmentStatus =
+  | "pending"
+  | "used"
+  | "expired"
+  | "revoked";
+
+export type FederationEnrollmentEntry = {
+  id: string;
+  status: FederationEnrollmentStatus;
+  generatedAt: number;
+  expiresAt: number;
+  usedAt?: number;
+  peerId?: FederationPeerId;
+  label?: string;
+  role?: FederationInstanceRole;
+  endpoint?: string;
+  gatewayInstanceId?: string;
+};
+
+export type FederationSessionAuditKind =
+  | "connect_attempt"
+  | "connected"
+  | "rejected"
+  | "disconnected"
+  | "relay"
+  | "error";
+
+export type FederationSessionAuditEntry = {
+  eventId: number;
+  peerId?: FederationPeerId;
+  sessionId?: FederationSessionId;
+  kind: FederationSessionAuditKind;
+  createdAt: number;
+  detail?: string;
+};
+
+type FederationPeerPayload = {
+  capabilities?: FederationCapability[];
+  protocolVersion?: number;
+  endpoint?: string;
+  profileName?: string;
+  pinnedPublicKeyPem?: string;
+  lastConnectedAt?: number;
+  lastActivityAt?: number;
+  unavailableReason?: string;
+};
+
+type FederationEnrollmentPayload = {
+  label?: string;
+  role?: FederationInstanceRole;
+  endpoint?: string;
+  gatewayInstanceId?: string;
+};
+
+type FederationSessionAuditPayload = {
+  detail?: string;
+};
+
+type FederationPeerRow = {
+  peer_id: string;
+  label: string;
+  role: string;
+  status: string;
+  created_at: number;
+  updated_at: number;
+  last_seen_at: number | null;
+  revoked_at: number | null;
+  payload: string;
+};
+
+type FederationEnrollmentRow = {
+  enrollment_id: string;
+  token_hmac: string;
+  status: string;
+  generated_at: number;
+  expires_at: number;
+  used_at: number | null;
+  peer_id: string | null;
+  payload: string;
+};
+
+type FederationSessionAuditRow = {
+  event_id: number;
+  peer_id: string | null;
+  session_id: string | null;
+  kind: string;
+  created_at: number;
+  payload: string;
+};
+
+export class FederationStore {
+  constructor(private readonly stateDb: StateDb) {}
+
+  upsertPeer(params: {
+    peer: FederationPeerSummary & { pinnedPublicKeyPem?: string };
+    createdAt?: number;
+    updatedAt: number;
+  }): void {
+    assertPeerId(params.peer.id);
+    const existing = this.getPeer(params.peer.id);
+    const createdAt = params.createdAt ?? existing?.createdAt ?? params.updatedAt;
+    const revokedAt = params.peer.revokedAt ?? existing?.revokedAt;
+    const payload: FederationPeerPayload = {
+      capabilities: params.peer.capabilities,
+      protocolVersion: params.peer.protocolVersion,
+      endpoint: params.peer.endpoint,
+      profileName: params.peer.profileName,
+      pinnedPublicKeyPem: params.peer.pinnedPublicKeyPem,
+      lastConnectedAt: params.peer.lastConnectedAt,
+      lastActivityAt: params.peer.lastActivityAt,
+      unavailableReason: params.peer.unavailableReason,
+    };
+    this.stateDb.raw
+      .prepare(
+        `INSERT INTO federation_peers(
+           peer_id, label, role, status, created_at, updated_at, last_seen_at,
+           revoked_at, payload
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(peer_id) DO UPDATE SET
+           label = excluded.label,
+           role = excluded.role,
+           status = excluded.status,
+           updated_at = excluded.updated_at,
+           last_seen_at = excluded.last_seen_at,
+           revoked_at = excluded.revoked_at,
+           payload = excluded.payload`,
+      )
+      .run(
+        params.peer.id,
+        params.peer.label,
+        params.peer.role,
+        params.peer.status,
+        createdAt,
+        params.updatedAt,
+        params.peer.lastActivityAt ?? null,
+        revokedAt ?? null,
+        JSON.stringify(payload),
+      );
+  }
+
+  getPeer(peerId: FederationPeerId): (FederationPeerSummary & {
+    createdAt: number;
+    updatedAt: number;
+    lastSeenAt?: number;
+    pinnedPublicKeyPem?: string;
+  }) | undefined {
+    assertPeerId(peerId);
+    const row = this.stateDb.raw
+      .prepare(
+        `SELECT peer_id, label, role, status, created_at, updated_at,
+                last_seen_at, revoked_at, payload
+         FROM federation_peers
+         WHERE peer_id = ?`,
+      )
+      .get(peerId) as FederationPeerRow | undefined;
+    return row ? rowToPeer(row) : undefined;
+  }
+
+  listPeers(options?: { includeRevoked?: boolean }): FederationPeerSummary[] {
+    const rows = options?.includeRevoked
+      ? (this.stateDb.raw
+          .prepare(
+            `SELECT peer_id, label, role, status, created_at, updated_at,
+                    last_seen_at, revoked_at, payload
+             FROM federation_peers
+             ORDER BY updated_at DESC`,
+          )
+          .all() as FederationPeerRow[])
+      : (this.stateDb.raw
+          .prepare(
+            `SELECT peer_id, label, role, status, created_at, updated_at,
+                    last_seen_at, revoked_at, payload
+             FROM federation_peers
+             WHERE revoked_at IS NULL
+             ORDER BY updated_at DESC`,
+          )
+          .all() as FederationPeerRow[]);
+    return rows.map(rowToPeer);
+  }
+
+  revokePeer(peerId: FederationPeerId, revokedAt: number): void {
+    assertPeerId(peerId);
+    this.stateDb.raw
+      .prepare(
+        `UPDATE federation_peers
+         SET status = 'revoked', revoked_at = ?, updated_at = ?
+         WHERE peer_id = ?`,
+      )
+      .run(revokedAt, revokedAt, peerId);
+  }
+
+  createEnrollment(params: {
+    token: string;
+    generatedAt: number;
+    expiresAt: number;
+    label?: string;
+    role?: FederationInstanceRole;
+    endpoint?: string;
+    gatewayInstanceId?: string;
+  }): FederationEnrollmentEntry {
+    const entry: FederationEnrollmentEntry = {
+      id: `federation-enrollment:${randomUUID()}`,
+      status: "pending",
+      generatedAt: params.generatedAt,
+      expiresAt: params.expiresAt,
+      label: params.label,
+      role: params.role,
+      endpoint: params.endpoint,
+      gatewayInstanceId: params.gatewayInstanceId,
+    };
+    this.stateDb.raw
+      .prepare(
+        `INSERT INTO federation_enrollment_tokens(
+           enrollment_id, token_hmac, status, generated_at, expires_at,
+           used_at, peer_id, payload
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        entry.id,
+        this.hmacToken(params.token, params.generatedAt),
+        entry.status,
+        params.generatedAt,
+        params.expiresAt,
+        null,
+        null,
+        JSON.stringify({
+          label: params.label,
+          role: params.role,
+          endpoint: params.endpoint,
+          gatewayInstanceId: params.gatewayInstanceId,
+        } satisfies FederationEnrollmentPayload),
+      );
+    return entry;
+  }
+
+  findMatchingPendingEnrollment(params: {
+    token: string;
+    now: number;
+  }): FederationEnrollmentEntry | undefined {
+    this.expireEnrollments(params.now);
+    const rows = this.stateDb.raw
+      .prepare(
+        `SELECT enrollment_id, token_hmac, status, generated_at, expires_at,
+                used_at, peer_id, payload
+         FROM federation_enrollment_tokens
+         WHERE status = 'pending'
+           AND expires_at > ?
+         ORDER BY generated_at DESC`,
+      )
+      .all(params.now) as FederationEnrollmentRow[];
+
+    for (const row of rows) {
+      const candidate = this.hmacToken(params.token, row.generated_at);
+      if (safeEqualHex(candidate, row.token_hmac)) {
+        return rowToEnrollment(row);
+      }
+    }
+    return undefined;
+  }
+
+  markEnrollmentUsed(params: {
+    enrollmentId: string;
+    peerId: FederationPeerId;
+    usedAt: number;
+  }): FederationEnrollmentEntry | undefined {
+    assertPeerId(params.peerId);
+    this.stateDb.raw
+      .prepare(
+        `UPDATE federation_enrollment_tokens
+         SET status = 'used', used_at = ?, peer_id = ?
+         WHERE enrollment_id = ? AND status = 'pending'`,
+      )
+      .run(params.usedAt, params.peerId, params.enrollmentId);
+    return this.getEnrollment(params.enrollmentId);
+  }
+
+  getEnrollment(enrollmentId: string): FederationEnrollmentEntry | undefined {
+    const row = this.stateDb.raw
+      .prepare(
+        `SELECT enrollment_id, token_hmac, status, generated_at, expires_at,
+                used_at, peer_id, payload
+         FROM federation_enrollment_tokens
+         WHERE enrollment_id = ?`,
+      )
+      .get(enrollmentId) as FederationEnrollmentRow | undefined;
+    return row ? rowToEnrollment(row) : undefined;
+  }
+
+  expireEnrollments(now: number): void {
+    this.stateDb.raw
+      .prepare(
+        `UPDATE federation_enrollment_tokens
+         SET status = 'expired'
+         WHERE status = 'pending' AND expires_at <= ?`,
+      )
+      .run(now);
+  }
+
+  appendAudit(params: {
+    peerId?: FederationPeerId;
+    sessionId?: FederationSessionId;
+    kind: FederationSessionAuditKind;
+    createdAt: number;
+    detail?: string;
+  }): FederationSessionAuditEntry {
+    if (params.peerId) assertPeerId(params.peerId);
+    const result = this.stateDb.raw
+      .prepare(
+        `INSERT INTO federation_session_audit(
+           peer_id, session_id, kind, created_at, payload
+         ) VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run(
+        params.peerId ?? null,
+        params.sessionId ?? null,
+        params.kind,
+        params.createdAt,
+        JSON.stringify({ detail: params.detail } satisfies FederationSessionAuditPayload),
+      );
+    return {
+      eventId: Number(result.lastInsertRowid),
+      peerId: params.peerId,
+      sessionId: params.sessionId,
+      kind: params.kind,
+      createdAt: params.createdAt,
+      detail: params.detail,
+    };
+  }
+
+  listAudit(params?: {
+    peerId?: FederationPeerId;
+    sessionId?: FederationSessionId;
+    limit?: number;
+  }): FederationSessionAuditEntry[] {
+    if (params?.peerId) assertPeerId(params.peerId);
+    const limit = Math.max(1, Math.min(params?.limit ?? 50, 500));
+    const rows = params?.peerId
+      ? (this.stateDb.raw
+          .prepare(
+            `SELECT event_id, peer_id, session_id, kind, created_at, payload
+             FROM federation_session_audit
+             WHERE peer_id = ?
+             ORDER BY created_at DESC, event_id DESC
+             LIMIT ?`,
+          )
+          .all(params.peerId, limit) as FederationSessionAuditRow[])
+      : params?.sessionId
+        ? (this.stateDb.raw
+            .prepare(
+              `SELECT event_id, peer_id, session_id, kind, created_at, payload
+               FROM federation_session_audit
+               WHERE session_id = ?
+               ORDER BY created_at DESC, event_id DESC
+               LIMIT ?`,
+            )
+            .all(params.sessionId, limit) as FederationSessionAuditRow[])
+        : (this.stateDb.raw
+            .prepare(
+              `SELECT event_id, peer_id, session_id, kind, created_at, payload
+               FROM federation_session_audit
+               ORDER BY created_at DESC, event_id DESC
+               LIMIT ?`,
+            )
+            .all(limit) as FederationSessionAuditRow[]);
+    return rows.map(rowToAudit);
+  }
+
+  private hmacToken(token: string, generatedAt: number): string {
+    return createHmac("sha256", this.enrollmentSecret())
+      .update(token)
+      .update("\0")
+      .update(String(generatedAt))
+      .digest("hex");
+  }
+
+  private enrollmentSecret(): Buffer {
+    const existing = this.stateDb.getMeta(FEDERATION_ENROLLMENT_SECRET_META_KEY);
+    if (existing) return Buffer.from(existing, "base64");
+    const generated = randomBytes(32);
+    this.stateDb.setMeta(
+      FEDERATION_ENROLLMENT_SECRET_META_KEY,
+      generated.toString("base64"),
+    );
+    return generated;
+  }
+}
+
+function assertPeerId(peerId: FederationPeerId): void {
+  if (!isFederationInstanceId(peerId)) {
+    throw new Error(`Invalid federation peer id: ${peerId}`);
+  }
+}
+
+function rowToPeer(row: FederationPeerRow): FederationPeerSummary & {
+  createdAt: number;
+  updatedAt: number;
+  lastSeenAt?: number;
+  pinnedPublicKeyPem?: string;
+} {
+  const payload = parseJson<FederationPeerPayload>(row.payload);
+  return {
+    id: row.peer_id,
+    label: row.label,
+    role: row.role as FederationInstanceRole,
+    status: row.status as FederationConnectionState,
+    capabilities: payload.capabilities ?? [],
+    protocolVersion: payload.protocolVersion,
+    endpoint: payload.endpoint,
+    profileName: payload.profileName,
+    pinnedPublicKeyPem: payload.pinnedPublicKeyPem,
+    lastConnectedAt: payload.lastConnectedAt,
+    lastActivityAt: payload.lastActivityAt,
+    revokedAt: row.revoked_at ?? undefined,
+    unavailableReason: payload.unavailableReason,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    lastSeenAt: row.last_seen_at ?? undefined,
+  };
+}
+
+function rowToEnrollment(row: FederationEnrollmentRow): FederationEnrollmentEntry {
+  const payload = parseJson<FederationEnrollmentPayload>(row.payload);
+  return {
+    id: row.enrollment_id,
+    status: row.status as FederationEnrollmentStatus,
+    generatedAt: row.generated_at,
+    expiresAt: row.expires_at,
+    usedAt: row.used_at ?? undefined,
+    peerId: row.peer_id ?? undefined,
+    label: payload.label,
+    role: payload.role,
+    endpoint: payload.endpoint,
+    gatewayInstanceId: payload.gatewayInstanceId,
+  };
+}
+
+function rowToAudit(row: FederationSessionAuditRow): FederationSessionAuditEntry {
+  const payload = parseJson<FederationSessionAuditPayload>(row.payload);
+  return {
+    eventId: row.event_id,
+    peerId: row.peer_id ?? undefined,
+    sessionId: row.session_id ?? undefined,
+    kind: row.kind as FederationSessionAuditKind,
+    createdAt: row.created_at,
+    detail: payload.detail,
+  };
+}
+
+function parseJson<T extends object>(payload: string): Partial<T> {
+  try {
+    return JSON.parse(payload) as Partial<T>;
+  } catch {
+    return {};
+  }
+}
+
+function safeEqualHex(left: string, right: string): boolean {
+  const leftBuffer = Buffer.from(left, "hex");
+  const rightBuffer = Buffer.from(right, "hex");
+  if (leftBuffer.length !== rightBuffer.length) return false;
+  return timingSafeEqual(leftBuffer, rightBuffer);
+}

--- a/apps/desktop/src/main/federation/federation-transport.ts
+++ b/apps/desktop/src/main/federation/federation-transport.ts
@@ -272,14 +272,14 @@ export class FederationGatewayWebSocketServer {
   }
 }
 
-export type FederationChildWebSocketClient = {
+export type FederationClientWebSocketClient = {
   sessionId: FederationSessionId;
   capabilities: FederationCapability[];
   sendEnvelope: (envelope: FederationProtocolEnvelope) => void;
   close: () => void;
 };
 
-export async function connectFederationChild(params: {
+export async function connectFederationClient(params: {
   url: string;
   mode: "enroll" | "reconnect";
   gatewayInstanceId: FederationInstanceId;
@@ -294,7 +294,7 @@ export async function connectFederationChild(params: {
   profileName?: string;
   headers?: Record<string, string>;
   onEnvelope?: (envelope: FederationProtocolEnvelope) => void;
-}): Promise<FederationChildWebSocketClient> {
+}): Promise<FederationClientWebSocketClient> {
   const socket = new WebSocket(params.url, {
     headers: params.headers,
   });

--- a/apps/desktop/src/main/federation/federation-transport.ts
+++ b/apps/desktop/src/main/federation/federation-transport.ts
@@ -1,0 +1,392 @@
+import http from "node:http";
+import { randomUUID } from "node:crypto";
+import WebSocket, { WebSocketServer } from "ws";
+import type {
+  FederationCapability,
+  FederationInstanceId,
+  FederationInstanceRole,
+  FederationProtocolEnvelope,
+  FederationSessionId,
+} from "@pwragent/shared";
+import {
+  FEDERATION_PROTOCOL_VERSION,
+  isFederationCapability,
+} from "@pwragent/shared";
+import {
+  authenticateFederationReconnect,
+  buildFederationProofMessage,
+  completeFederationEnrollment,
+} from "./federation-enrollment";
+import { signFederationMessage } from "./federation-identity";
+import {
+  federationFailure,
+  type FederationRedactedFailure,
+} from "./federation-redaction";
+import { FederationSessionRegistry } from "./federation-session-state";
+import type { FederationStore } from "./federation-store";
+
+type FederationSocketAuthMessage = {
+  kind: "auth";
+  mode: "enroll" | "reconnect";
+  gatewayInstanceId: FederationInstanceId;
+  peerInstanceId: FederationInstanceId;
+  protocolVersion: number;
+  nonce: string;
+  capabilities: FederationCapability[];
+  signatureBase64: string;
+  inviteToken?: string;
+  publicKeyPem?: string;
+  label?: string;
+  role?: FederationInstanceRole;
+  endpoint?: string;
+  profileName?: string;
+};
+
+type FederationSocketAcceptedMessage = {
+  kind: "auth.accepted";
+  sessionId: FederationSessionId;
+  protocolVersion: number;
+  capabilities: FederationCapability[];
+};
+
+type FederationSocketRejectedMessage = {
+  kind: "auth.rejected";
+  failure: FederationRedactedFailure;
+};
+
+type FederationSocketEnvelopeMessage = {
+  kind: "envelope";
+  envelope: FederationProtocolEnvelope;
+};
+
+type FederationSocketMessage =
+  | FederationSocketAuthMessage
+  | FederationSocketAcceptedMessage
+  | FederationSocketRejectedMessage
+  | FederationSocketEnvelopeMessage;
+
+export type FederationGatewayConnection = {
+  peerId: FederationInstanceId;
+  sessionId: FederationSessionId;
+  capabilities: FederationCapability[];
+  sendEnvelope: (envelope: FederationProtocolEnvelope) => void;
+  close: () => void;
+};
+
+export type FederationGatewayWebSocketServerOptions = {
+  gatewayInstanceId: FederationInstanceId;
+  host: string;
+  port: number;
+  store: FederationStore;
+  sessions?: FederationSessionRegistry;
+  onEnvelope?: (
+    envelope: FederationProtocolEnvelope,
+    connection: FederationGatewayConnection,
+  ) => void;
+};
+
+export class FederationGatewayWebSocketServer {
+  private httpServer?: http.Server;
+  private wsServer?: WebSocketServer;
+  private readonly sessions: FederationSessionRegistry;
+
+  constructor(private readonly options: FederationGatewayWebSocketServerOptions) {
+    this.sessions = options.sessions ?? new FederationSessionRegistry();
+  }
+
+  async start(): Promise<{ url: string; port: number }> {
+    if (this.httpServer) {
+      const address = this.httpServer.address();
+      const port = typeof address === "object" && address ? address.port : this.options.port;
+      return { url: `ws://${this.options.host}:${port}`, port };
+    }
+    this.httpServer = http.createServer();
+    this.wsServer = new WebSocketServer({ server: this.httpServer });
+    this.wsServer.on("connection", (socket) => this.handleSocket(socket));
+
+    await new Promise<void>((resolve, reject) => {
+      const server = this.httpServer;
+      if (!server) {
+        reject(new Error("Federation HTTP server was not initialized"));
+        return;
+      }
+      server.once("error", reject);
+      server.listen(this.options.port, this.options.host, () => {
+        server.off("error", reject);
+        resolve();
+      });
+    });
+    const address = this.httpServer.address();
+    const port = typeof address === "object" && address ? address.port : this.options.port;
+    return {
+      url: `ws://${this.options.host}:${port}`,
+      port,
+    };
+  }
+
+  async stop(): Promise<void> {
+    const wsServer = this.wsServer;
+    const httpServer = this.httpServer;
+    this.wsServer = undefined;
+    this.httpServer = undefined;
+    for (const client of wsServer?.clients ?? []) {
+      client.close();
+    }
+    await new Promise<void>((resolve) => wsServer?.close(() => resolve()) ?? resolve());
+    await new Promise<void>((resolve) => httpServer?.close(() => resolve()) ?? resolve());
+  }
+
+  private handleSocket(socket: WebSocket): void {
+    let connection: FederationGatewayConnection | undefined;
+    socket.once("message", (raw) => {
+      const message = parseSocketMessage(raw);
+      if (!message || message.kind !== "auth") {
+        sendSocketMessage(socket, {
+          kind: "auth.rejected",
+          failure: federationFailure("policy_denied"),
+        });
+        socket.close();
+        return;
+      }
+      const decision = this.authenticate(message);
+      if (!decision.accepted) {
+        sendSocketMessage(socket, {
+          kind: "auth.rejected",
+          failure: decision.failure,
+        });
+        socket.close();
+        return;
+      }
+
+      const sessionId = `federation-session:${randomUUID()}`;
+      this.sessions.openSession({
+        sessionId,
+        peerId: decision.peer.id,
+        connectedAt: Date.now(),
+        capabilities: decision.capabilities,
+      });
+      connection = {
+        peerId: decision.peer.id,
+        sessionId,
+        capabilities: decision.capabilities,
+        sendEnvelope: (envelope) => {
+          sendSocketMessage(socket, { kind: "envelope", envelope });
+        },
+        close: () => socket.close(),
+      };
+      sendSocketMessage(socket, {
+        kind: "auth.accepted",
+        sessionId,
+        protocolVersion: FEDERATION_PROTOCOL_VERSION,
+        capabilities: decision.capabilities,
+      });
+
+      socket.on("message", (nextRaw) => {
+        const next = parseSocketMessage(nextRaw);
+        if (!next || next.kind !== "envelope" || !connection) return;
+        this.sessions.heartbeat(sessionId, Date.now());
+        this.options.onEnvelope?.(next.envelope, connection);
+      });
+      socket.once("close", () => {
+        this.sessions.closeSession({
+          sessionId,
+          closedAt: Date.now(),
+          reason: "transport_closed",
+        });
+      });
+    });
+  }
+
+  private authenticate(message: FederationSocketAuthMessage) {
+    if (message.gatewayInstanceId !== this.options.gatewayInstanceId) {
+      return {
+        accepted: false as const,
+        failure: federationFailure("wrong_gateway"),
+      };
+    }
+    if (message.mode === "enroll") {
+      if (!message.inviteToken || !message.publicKeyPem || !message.role) {
+        return {
+          accepted: false as const,
+          failure: federationFailure("missing_invite"),
+        };
+      }
+      return completeFederationEnrollment({
+        store: this.options.store,
+        gatewayInstanceId: this.options.gatewayInstanceId,
+        inviteToken: message.inviteToken,
+        now: Date.now(),
+        peer: {
+          instanceId: message.peerInstanceId,
+          label: message.label ?? message.peerInstanceId,
+          role: message.role,
+          publicKeyPem: message.publicKeyPem,
+          capabilities: message.capabilities,
+          protocolVersion: message.protocolVersion,
+          nonce: message.nonce,
+          signatureBase64: message.signatureBase64,
+          endpoint: message.endpoint,
+          profileName: message.profileName,
+        },
+      });
+    }
+    return authenticateFederationReconnect({
+      store: this.options.store,
+      gatewayInstanceId: this.options.gatewayInstanceId,
+      peerInstanceId: message.peerInstanceId,
+      protocolVersion: message.protocolVersion,
+      nonce: message.nonce,
+      requestedCapabilities: message.capabilities,
+      signatureBase64: message.signatureBase64,
+      now: Date.now(),
+    });
+  }
+}
+
+export type FederationChildWebSocketClient = {
+  sessionId: FederationSessionId;
+  capabilities: FederationCapability[];
+  sendEnvelope: (envelope: FederationProtocolEnvelope) => void;
+  close: () => void;
+};
+
+export async function connectFederationChild(params: {
+  url: string;
+  mode: "enroll" | "reconnect";
+  gatewayInstanceId: FederationInstanceId;
+  peerInstanceId: FederationInstanceId;
+  privateKeyPem: string;
+  publicKeyPem: string;
+  capabilities: readonly FederationCapability[];
+  inviteToken?: string;
+  label?: string;
+  role?: FederationInstanceRole;
+  endpoint?: string;
+  profileName?: string;
+  headers?: Record<string, string>;
+  onEnvelope?: (envelope: FederationProtocolEnvelope) => void;
+}): Promise<FederationChildWebSocketClient> {
+  const nonce = `nonce:${randomUUID()}`;
+  const messageToSign = buildFederationProofMessage({
+    purpose: params.mode === "enroll" ? "enroll" : "reconnect",
+    gatewayInstanceId: params.gatewayInstanceId,
+    peerInstanceId: params.peerInstanceId,
+    publicKeyPem: params.publicKeyPem,
+    protocolVersion: FEDERATION_PROTOCOL_VERSION,
+    nonce,
+    capabilities: params.capabilities,
+  });
+  const authMessage: FederationSocketAuthMessage = {
+    kind: "auth",
+    mode: params.mode,
+    gatewayInstanceId: params.gatewayInstanceId,
+    peerInstanceId: params.peerInstanceId,
+    protocolVersion: FEDERATION_PROTOCOL_VERSION,
+    nonce,
+    capabilities: params.capabilities.slice(),
+    signatureBase64: signFederationMessage({
+      privateKeyPem: params.privateKeyPem,
+      message: messageToSign,
+    }),
+    inviteToken: params.inviteToken,
+    publicKeyPem: params.mode === "enroll" ? params.publicKeyPem : undefined,
+    label: params.label,
+    role: params.role,
+    endpoint: params.endpoint,
+    profileName: params.profileName,
+  };
+
+  const socket = new WebSocket(params.url, {
+    headers: params.headers,
+  });
+  await waitForOpen(socket);
+  sendSocketMessage(socket, authMessage);
+  const accepted = await waitForAuthResult(socket);
+  socket.on("message", (raw) => {
+    const message = parseSocketMessage(raw);
+    if (message?.kind === "envelope") {
+      params.onEnvelope?.(message.envelope);
+    }
+  });
+  return {
+    sessionId: accepted.sessionId,
+    capabilities: accepted.capabilities,
+    sendEnvelope: (envelope) => {
+      sendSocketMessage(socket, { kind: "envelope", envelope });
+    },
+    close: () => socket.close(),
+  };
+}
+
+function waitForOpen(socket: WebSocket): Promise<void> {
+  return new Promise((resolve, reject) => {
+    socket.once("open", () => resolve());
+    socket.once("error", reject);
+  });
+}
+
+function waitForAuthResult(socket: WebSocket): Promise<FederationSocketAcceptedMessage> {
+  return new Promise((resolve, reject) => {
+    socket.once("message", (raw) => {
+      const message = parseSocketMessage(raw);
+      if (message?.kind === "auth.accepted") {
+        resolve(message);
+        return;
+      }
+      if (message?.kind === "auth.rejected") {
+        reject(new Error(message.failure.code));
+        return;
+      }
+      reject(new Error("Unexpected federation auth response"));
+    });
+    socket.once("error", reject);
+  });
+}
+
+function sendSocketMessage(socket: WebSocket, message: FederationSocketMessage): void {
+  if (socket.readyState !== WebSocket.OPEN) return;
+  socket.send(JSON.stringify(message));
+}
+
+function parseSocketMessage(raw: WebSocket.RawData): FederationSocketMessage | undefined {
+  try {
+    const parsed = JSON.parse(raw.toString()) as Partial<FederationSocketMessage>;
+    if (parsed.kind === "auth" && isAuthMessage(parsed)) return parsed;
+    if (parsed.kind === "auth.accepted" && isAcceptedMessage(parsed)) return parsed;
+    if (parsed.kind === "auth.rejected" && parsed.failure) {
+      return parsed as FederationSocketRejectedMessage;
+    }
+    if (parsed.kind === "envelope" && parsed.envelope) {
+      return parsed as FederationSocketEnvelopeMessage;
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isAuthMessage(value: Partial<FederationSocketAuthMessage>): value is FederationSocketAuthMessage {
+  return (
+    value.kind === "auth" &&
+    (value.mode === "enroll" || value.mode === "reconnect") &&
+    typeof value.gatewayInstanceId === "string" &&
+    typeof value.peerInstanceId === "string" &&
+    typeof value.protocolVersion === "number" &&
+    typeof value.nonce === "string" &&
+    typeof value.signatureBase64 === "string" &&
+    Array.isArray(value.capabilities) &&
+    value.capabilities.every(isFederationCapability)
+  );
+}
+
+function isAcceptedMessage(
+  value: Partial<FederationSocketAcceptedMessage>,
+): value is FederationSocketAcceptedMessage {
+  return (
+    value.kind === "auth.accepted" &&
+    typeof value.sessionId === "string" &&
+    typeof value.protocolVersion === "number" &&
+    Array.isArray(value.capabilities) &&
+    value.capabilities.every(isFederationCapability)
+  );
+}

--- a/apps/desktop/src/main/federation/federation-transport.ts
+++ b/apps/desktop/src/main/federation/federation-transport.ts
@@ -79,6 +79,8 @@ export type FederationGatewayWebSocketServerOptions = {
   port: number;
   store: FederationStore;
   sessions?: FederationSessionRegistry;
+  onConnection?: (connection: FederationGatewayConnection) => void;
+  onDisconnect?: (connection: FederationGatewayConnection) => void;
   onEnvelope?: (
     envelope: FederationProtocolEnvelope,
     connection: FederationGatewayConnection,
@@ -180,6 +182,7 @@ export class FederationGatewayWebSocketServer {
         protocolVersion: FEDERATION_PROTOCOL_VERSION,
         capabilities: decision.capabilities,
       });
+      this.options.onConnection?.(connection);
 
       socket.on("message", (nextRaw) => {
         const next = parseSocketMessage(nextRaw);
@@ -193,6 +196,9 @@ export class FederationGatewayWebSocketServer {
           closedAt: Date.now(),
           reason: "transport_closed",
         });
+        if (connection) {
+          this.options.onDisconnect?.(connection);
+        }
       });
     });
   }

--- a/apps/desktop/src/main/federation/federation-transport.ts
+++ b/apps/desktop/src/main/federation/federation-transport.ts
@@ -42,6 +42,13 @@ type FederationSocketAuthMessage = {
   profileName?: string;
 };
 
+type FederationSocketChallengeMessage = {
+  kind: "auth.challenge";
+  gatewayInstanceId: FederationInstanceId;
+  protocolVersion: number;
+  nonce: string;
+};
+
 type FederationSocketAcceptedMessage = {
   kind: "auth.accepted";
   sessionId: FederationSessionId;
@@ -61,6 +68,7 @@ type FederationSocketEnvelopeMessage = {
 
 type FederationSocketMessage =
   | FederationSocketAuthMessage
+  | FederationSocketChallengeMessage
   | FederationSocketAcceptedMessage
   | FederationSocketRejectedMessage
   | FederationSocketEnvelopeMessage;
@@ -140,9 +148,24 @@ export class FederationGatewayWebSocketServer {
 
   private handleSocket(socket: WebSocket): void {
     let connection: FederationGatewayConnection | undefined;
+    const challengeNonce = `challenge:${randomUUID()}`;
+    sendSocketMessage(socket, {
+      kind: "auth.challenge",
+      gatewayInstanceId: this.options.gatewayInstanceId,
+      protocolVersion: FEDERATION_PROTOCOL_VERSION,
+      nonce: challengeNonce,
+    });
     socket.once("message", (raw) => {
       const message = parseSocketMessage(raw);
       if (!message || message.kind !== "auth") {
+        sendSocketMessage(socket, {
+          kind: "auth.rejected",
+          failure: federationFailure("policy_denied"),
+        });
+        socket.close();
+        return;
+      }
+      if (message.nonce !== challengeNonce) {
         sendSocketMessage(socket, {
           kind: "auth.rejected",
           failure: federationFailure("policy_denied"),
@@ -272,14 +295,27 @@ export async function connectFederationChild(params: {
   headers?: Record<string, string>;
   onEnvelope?: (envelope: FederationProtocolEnvelope) => void;
 }): Promise<FederationChildWebSocketClient> {
-  const nonce = `nonce:${randomUUID()}`;
+  const socket = new WebSocket(params.url, {
+    headers: params.headers,
+  });
+  const [challenge] = await Promise.all([
+    waitForAuthChallenge(socket),
+    waitForOpen(socket),
+  ]);
+  if (
+    challenge.gatewayInstanceId !== params.gatewayInstanceId ||
+    challenge.protocolVersion !== FEDERATION_PROTOCOL_VERSION
+  ) {
+    socket.close();
+    throw new Error("Invalid federation auth challenge");
+  }
   const messageToSign = buildFederationProofMessage({
     purpose: params.mode === "enroll" ? "enroll" : "reconnect",
     gatewayInstanceId: params.gatewayInstanceId,
     peerInstanceId: params.peerInstanceId,
     publicKeyPem: params.publicKeyPem,
     protocolVersion: FEDERATION_PROTOCOL_VERSION,
-    nonce,
+    nonce: challenge.nonce,
     capabilities: params.capabilities,
   });
   const authMessage: FederationSocketAuthMessage = {
@@ -288,7 +324,7 @@ export async function connectFederationChild(params: {
     gatewayInstanceId: params.gatewayInstanceId,
     peerInstanceId: params.peerInstanceId,
     protocolVersion: FEDERATION_PROTOCOL_VERSION,
-    nonce,
+    nonce: challenge.nonce,
     capabilities: params.capabilities.slice(),
     signatureBase64: signFederationMessage({
       privateKeyPem: params.privateKeyPem,
@@ -302,10 +338,6 @@ export async function connectFederationChild(params: {
     profileName: params.profileName,
   };
 
-  const socket = new WebSocket(params.url, {
-    headers: params.headers,
-  });
-  await waitForOpen(socket);
   sendSocketMessage(socket, authMessage);
   const accepted = await waitForAuthResult(socket);
   socket.on("message", (raw) => {
@@ -327,6 +359,24 @@ export async function connectFederationChild(params: {
 function waitForOpen(socket: WebSocket): Promise<void> {
   return new Promise((resolve, reject) => {
     socket.once("open", () => resolve());
+    socket.once("error", reject);
+  });
+}
+
+function waitForAuthChallenge(socket: WebSocket): Promise<FederationSocketChallengeMessage> {
+  return new Promise((resolve, reject) => {
+    socket.once("message", (raw) => {
+      const message = parseSocketMessage(raw);
+      if (message?.kind === "auth.challenge") {
+        resolve(message);
+        return;
+      }
+      if (message?.kind === "auth.rejected") {
+        reject(new Error(message.failure.code));
+        return;
+      }
+      reject(new Error("Unexpected federation auth challenge"));
+    });
     socket.once("error", reject);
   });
 }
@@ -358,6 +408,7 @@ function parseSocketMessage(raw: WebSocket.RawData): FederationSocketMessage | u
   try {
     const parsed = JSON.parse(raw.toString()) as Partial<FederationSocketMessage>;
     if (parsed.kind === "auth" && isAuthMessage(parsed)) return parsed;
+    if (parsed.kind === "auth.challenge" && isChallengeMessage(parsed)) return parsed;
     if (parsed.kind === "auth.accepted" && isAcceptedMessage(parsed)) return parsed;
     if (parsed.kind === "auth.rejected" && parsed.failure) {
       return parsed as FederationSocketRejectedMessage;
@@ -382,6 +433,17 @@ function isAuthMessage(value: Partial<FederationSocketAuthMessage>): value is Fe
     typeof value.signatureBase64 === "string" &&
     Array.isArray(value.capabilities) &&
     value.capabilities.every(isFederationCapability)
+  );
+}
+
+function isChallengeMessage(
+  value: Partial<FederationSocketChallengeMessage>,
+): value is FederationSocketChallengeMessage {
+  return (
+    value.kind === "auth.challenge" &&
+    typeof value.gatewayInstanceId === "string" &&
+    typeof value.protocolVersion === "number" &&
+    typeof value.nonce === "string"
   );
 }
 

--- a/apps/desktop/src/main/federation/federation-transport.ts
+++ b/apps/desktop/src/main/federation/federation-transport.ts
@@ -15,10 +15,15 @@ import {
 } from "@pwragent/shared";
 import {
   authenticateFederationReconnect,
+  buildFederationGatewayAcceptedMessage,
+  buildFederationGatewayChallengeMessage,
   buildFederationProofMessage,
   completeFederationEnrollment,
 } from "./federation-enrollment";
-import { signFederationMessage } from "./federation-identity";
+import {
+  signFederationMessage,
+  verifyFederationMessageSignature,
+} from "./federation-identity";
 import {
   federationFailure,
   type FederationRedactedFailure,
@@ -46,15 +51,20 @@ type FederationSocketAuthMessage = {
 type FederationSocketChallengeMessage = {
   kind: "auth.challenge";
   gatewayInstanceId: FederationInstanceId;
+  gatewayPublicKeyPem: string;
   protocolVersion: number;
   nonce: string;
+  signatureBase64: string;
 };
 
 type FederationSocketAcceptedMessage = {
   kind: "auth.accepted";
+  gatewayInstanceId: FederationInstanceId;
   sessionId: FederationSessionId;
   protocolVersion: number;
+  nonce: string;
   capabilities: FederationCapability[];
+  signatureBase64: string;
 };
 
 type FederationSocketRejectedMessage = {
@@ -84,6 +94,8 @@ export type FederationGatewayConnection = {
 
 export type FederationGatewayWebSocketServerOptions = {
   gatewayInstanceId: FederationInstanceId;
+  gatewayPrivateKeyPem: string;
+  gatewayPublicKeyPem: string;
   host: string;
   port: number;
   store: FederationStore;
@@ -171,11 +183,22 @@ export class FederationGatewayWebSocketServer {
   private handleSocket(socket: WebSocket): void {
     let connection: FederationGatewayConnection | undefined;
     const challengeNonce = `challenge:${randomUUID()}`;
+    const challengeMessage = buildFederationGatewayChallengeMessage({
+      gatewayInstanceId: this.options.gatewayInstanceId,
+      gatewayPublicKeyPem: this.options.gatewayPublicKeyPem,
+      protocolVersion: FEDERATION_PROTOCOL_VERSION,
+      nonce: challengeNonce,
+    });
     sendSocketMessage(socket, {
       kind: "auth.challenge",
       gatewayInstanceId: this.options.gatewayInstanceId,
+      gatewayPublicKeyPem: this.options.gatewayPublicKeyPem,
       protocolVersion: FEDERATION_PROTOCOL_VERSION,
       nonce: challengeNonce,
+      signatureBase64: signFederationMessage({
+        privateKeyPem: this.options.gatewayPrivateKeyPem,
+        message: challengeMessage,
+      }),
     });
     socket.once("message", (raw) => {
       const message = parseSocketMessage(raw);
@@ -264,9 +287,22 @@ export class FederationGatewayWebSocketServer {
       });
       sendSocketMessage(socket, {
         kind: "auth.accepted",
+        gatewayInstanceId: this.options.gatewayInstanceId,
         sessionId,
         protocolVersion: FEDERATION_PROTOCOL_VERSION,
+        nonce: challengeNonce,
         capabilities: decision.capabilities,
+        signatureBase64: signFederationMessage({
+          privateKeyPem: this.options.gatewayPrivateKeyPem,
+          message: buildFederationGatewayAcceptedMessage({
+            gatewayInstanceId: this.options.gatewayInstanceId,
+            peerInstanceId: decision.peer.id,
+            sessionId,
+            protocolVersion: FEDERATION_PROTOCOL_VERSION,
+            nonce: challengeNonce,
+            capabilities: decision.capabilities,
+          }),
+        }),
       });
       this.options.onConnection?.(connection);
 
@@ -358,6 +394,7 @@ export async function connectFederationClient(params: {
   url: string;
   mode: "enroll" | "reconnect";
   gatewayInstanceId: FederationInstanceId;
+  gatewayPublicKeyPem: string;
   peerInstanceId: FederationInstanceId;
   privateKeyPem: string;
   publicKeyPem: string;
@@ -384,10 +421,25 @@ export async function connectFederationClient(params: {
   ]);
   if (
     challenge.gatewayInstanceId !== params.gatewayInstanceId ||
+    challenge.gatewayPublicKeyPem !== params.gatewayPublicKeyPem ||
     challenge.protocolVersion !== FEDERATION_PROTOCOL_VERSION
   ) {
     socket.close();
     throw new Error("Invalid federation auth challenge");
+  }
+  const challengeSignatureValid = verifyFederationMessageSignature({
+    publicKeyPem: params.gatewayPublicKeyPem,
+    message: buildFederationGatewayChallengeMessage({
+      gatewayInstanceId: challenge.gatewayInstanceId,
+      gatewayPublicKeyPem: challenge.gatewayPublicKeyPem,
+      protocolVersion: challenge.protocolVersion,
+      nonce: challenge.nonce,
+    }),
+    signatureBase64: challenge.signatureBase64,
+  });
+  if (!challengeSignatureValid) {
+    socket.close();
+    throw new Error("Invalid federation auth challenge signature");
   }
   const messageToSign = buildFederationProofMessage({
     purpose: params.mode === "enroll" ? "enroll" : "reconnect",
@@ -420,6 +472,26 @@ export async function connectFederationClient(params: {
 
   sendSocketMessage(socket, authMessage);
   const accepted = await waitForAuthResult(socket);
+  const acceptedSignatureValid =
+    accepted.gatewayInstanceId === params.gatewayInstanceId &&
+    accepted.nonce === challenge.nonce &&
+    accepted.protocolVersion === FEDERATION_PROTOCOL_VERSION &&
+    verifyFederationMessageSignature({
+      publicKeyPem: params.gatewayPublicKeyPem,
+      message: buildFederationGatewayAcceptedMessage({
+        gatewayInstanceId: accepted.gatewayInstanceId,
+        peerInstanceId: params.peerInstanceId,
+        sessionId: accepted.sessionId,
+        protocolVersion: accepted.protocolVersion,
+        nonce: accepted.nonce,
+        capabilities: accepted.capabilities,
+      }),
+      signatureBase64: accepted.signatureBase64,
+    });
+  if (!acceptedSignatureValid) {
+    socket.close();
+    throw new Error("Invalid federation auth acceptance signature");
+  }
   socket.once("close", () => params.onClose?.());
   socket.on("message", (raw) => {
     const message = parseSocketMessage(raw);
@@ -523,8 +595,10 @@ function isChallengeMessage(
   return (
     value.kind === "auth.challenge" &&
     typeof value.gatewayInstanceId === "string" &&
+    typeof value.gatewayPublicKeyPem === "string" &&
     typeof value.protocolVersion === "number" &&
-    typeof value.nonce === "string"
+    typeof value.nonce === "string" &&
+    typeof value.signatureBase64 === "string"
   );
 }
 
@@ -533,8 +607,11 @@ function isAcceptedMessage(
 ): value is FederationSocketAcceptedMessage {
   return (
     value.kind === "auth.accepted" &&
+    typeof value.gatewayInstanceId === "string" &&
     typeof value.sessionId === "string" &&
     typeof value.protocolVersion === "number" &&
+    typeof value.nonce === "string" &&
+    typeof value.signatureBase64 === "string" &&
     Array.isArray(value.capabilities) &&
     value.capabilities.every(isFederationCapability)
   );

--- a/apps/desktop/src/main/federation/federation-transport.ts
+++ b/apps/desktop/src/main/federation/federation-transport.ts
@@ -492,7 +492,16 @@ export async function connectFederationClient(params: {
     socket.close();
     throw new Error("Invalid federation auth acceptance signature");
   }
-  socket.once("close", () => params.onClose?.());
+  let transportEnded = false;
+  const notifyTransportEnded = () => {
+    if (transportEnded) return;
+    transportEnded = true;
+    socket.off("close", notifyTransportEnded);
+    socket.off("error", notifyTransportEnded);
+    params.onClose?.();
+  };
+  socket.once("close", notifyTransportEnded);
+  socket.once("error", notifyTransportEnded);
   socket.on("message", (raw) => {
     const message = parseSocketMessage(raw);
     if (message?.kind === "envelope") {
@@ -511,14 +520,31 @@ export async function connectFederationClient(params: {
 
 function waitForOpen(socket: WebSocket): Promise<void> {
   return new Promise((resolve, reject) => {
-    socket.once("open", () => resolve());
-    socket.once("error", reject);
+    const cleanup = () => {
+      socket.off("open", onOpen);
+      socket.off("error", onError);
+    };
+    const onOpen = () => {
+      cleanup();
+      resolve();
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    socket.once("open", onOpen);
+    socket.once("error", onError);
   });
 }
 
 function waitForAuthChallenge(socket: WebSocket): Promise<FederationSocketChallengeMessage> {
   return new Promise((resolve, reject) => {
-    socket.once("message", (raw) => {
+    const cleanup = () => {
+      socket.off("message", onMessage);
+      socket.off("error", onError);
+    };
+    const onMessage = (raw: WebSocket.RawData) => {
+      cleanup();
       const message = parseSocketMessage(raw);
       if (message?.kind === "auth.challenge") {
         resolve(message);
@@ -529,14 +555,24 @@ function waitForAuthChallenge(socket: WebSocket): Promise<FederationSocketChalle
         return;
       }
       reject(new Error("Unexpected federation auth challenge"));
-    });
-    socket.once("error", reject);
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    socket.once("message", onMessage);
+    socket.once("error", onError);
   });
 }
 
 function waitForAuthResult(socket: WebSocket): Promise<FederationSocketAcceptedMessage> {
   return new Promise((resolve, reject) => {
-    socket.once("message", (raw) => {
+    const cleanup = () => {
+      socket.off("message", onMessage);
+      socket.off("error", onError);
+    };
+    const onMessage = (raw: WebSocket.RawData) => {
+      cleanup();
       const message = parseSocketMessage(raw);
       if (message?.kind === "auth.accepted") {
         resolve(message);
@@ -547,8 +583,13 @@ function waitForAuthResult(socket: WebSocket): Promise<FederationSocketAcceptedM
         return;
       }
       reject(new Error("Unexpected federation auth response"));
-    });
-    socket.once("error", reject);
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    socket.once("message", onMessage);
+    socket.once("error", onError);
   });
 }
 

--- a/apps/desktop/src/main/federation/federation-transport.ts
+++ b/apps/desktop/src/main/federation/federation-transport.ts
@@ -11,6 +11,7 @@ import type {
 import {
   FEDERATION_PROTOCOL_VERSION,
   isFederationCapability,
+  isFederationInstanceId,
 } from "@pwragent/shared";
 import {
   authenticateFederationReconnect,
@@ -99,6 +100,11 @@ export class FederationGatewayWebSocketServer {
   private httpServer?: http.Server;
   private wsServer?: WebSocketServer;
   private readonly sessions: FederationSessionRegistry;
+  private stopping = false;
+  private readonly connections = new Map<
+    FederationInstanceId,
+    FederationGatewayConnection
+  >();
 
   constructor(private readonly options: FederationGatewayWebSocketServerOptions) {
     this.sessions = options.sessions ?? new FederationSessionRegistry();
@@ -110,6 +116,7 @@ export class FederationGatewayWebSocketServer {
       const port = typeof address === "object" && address ? address.port : this.options.port;
       return { url: `ws://${this.options.host}:${port}`, port };
     }
+    this.stopping = false;
     this.httpServer = http.createServer();
     this.wsServer = new WebSocketServer({ server: this.httpServer });
     this.wsServer.on("connection", (socket) => this.handleSocket(socket));
@@ -135,15 +142,30 @@ export class FederationGatewayWebSocketServer {
   }
 
   async stop(): Promise<void> {
+    this.stopping = true;
     const wsServer = this.wsServer;
     const httpServer = this.httpServer;
     this.wsServer = undefined;
     this.httpServer = undefined;
+    this.connections.clear();
     for (const client of wsServer?.clients ?? []) {
       client.close();
     }
     await new Promise<void>((resolve) => wsServer?.close(() => resolve()) ?? resolve());
     await new Promise<void>((resolve) => httpServer?.close(() => resolve()) ?? resolve());
+  }
+
+  closePeer(peerId: FederationInstanceId): boolean {
+    const connection = this.connections.get(peerId);
+    if (!connection) return false;
+    this.connections.delete(peerId);
+    this.sessions.closePeerSessions({
+      peerId,
+      closedAt: Date.now(),
+      reason: "revoked",
+    });
+    connection.close();
+    return true;
   }
 
   private handleSocket(socket: WebSocket): void {
@@ -158,6 +180,11 @@ export class FederationGatewayWebSocketServer {
     socket.once("message", (raw) => {
       const message = parseSocketMessage(raw);
       if (!message || message.kind !== "auth") {
+        this.options.store.appendAudit({
+          kind: "rejected",
+          createdAt: Date.now(),
+          detail: "policy_denied",
+        });
         sendSocketMessage(socket, {
           kind: "auth.rejected",
           failure: federationFailure("policy_denied"),
@@ -165,7 +192,23 @@ export class FederationGatewayWebSocketServer {
         socket.close();
         return;
       }
+      this.options.store.appendAudit({
+        peerId: isFederationInstanceId(message.peerInstanceId)
+          ? message.peerInstanceId
+          : undefined,
+        kind: "connect_attempt",
+        createdAt: Date.now(),
+        detail: message.mode,
+      });
       if (message.nonce !== challengeNonce) {
+        this.options.store.appendAudit({
+          peerId: isFederationInstanceId(message.peerInstanceId)
+            ? message.peerInstanceId
+            : undefined,
+          kind: "rejected",
+          createdAt: Date.now(),
+          detail: "policy_denied",
+        });
         sendSocketMessage(socket, {
           kind: "auth.rejected",
           failure: federationFailure("policy_denied"),
@@ -175,6 +218,14 @@ export class FederationGatewayWebSocketServer {
       }
       const decision = this.authenticate(message);
       if (!decision.accepted) {
+        this.options.store.appendAudit({
+          peerId: isFederationInstanceId(message.peerInstanceId)
+            ? message.peerInstanceId
+            : undefined,
+          kind: "rejected",
+          createdAt: Date.now(),
+          detail: decision.failure.code,
+        });
         sendSocketMessage(socket, {
           kind: "auth.rejected",
           failure: decision.failure,
@@ -199,6 +250,18 @@ export class FederationGatewayWebSocketServer {
         },
         close: () => socket.close(),
       };
+      const previous = this.connections.get(connection.peerId);
+      if (previous && previous.sessionId !== connection.sessionId) {
+        previous.close();
+      }
+      this.connections.set(connection.peerId, connection);
+      this.options.store.appendAudit({
+        peerId: connection.peerId,
+        sessionId,
+        kind: "connected",
+        createdAt: Date.now(),
+        detail: message.mode,
+      });
       sendSocketMessage(socket, {
         kind: "auth.accepted",
         sessionId,
@@ -220,6 +283,18 @@ export class FederationGatewayWebSocketServer {
           reason: "transport_closed",
         });
         if (connection) {
+          if (this.connections.get(connection.peerId)?.sessionId === sessionId) {
+            this.connections.delete(connection.peerId);
+          }
+          if (!this.stopping) {
+            this.options.store.appendAudit({
+              peerId: connection.peerId,
+              sessionId,
+              kind: "disconnected",
+              createdAt: Date.now(),
+              detail: "transport_closed",
+            });
+          }
           this.options.onDisconnect?.(connection);
         }
       });
@@ -293,10 +368,15 @@ export async function connectFederationClient(params: {
   endpoint?: string;
   profileName?: string;
   headers?: Record<string, string>;
+  clientCertificate?: string;
+  clientPrivateKey?: string;
   onEnvelope?: (envelope: FederationProtocolEnvelope) => void;
+  onClose?: () => void;
 }): Promise<FederationClientWebSocketClient> {
   const socket = new WebSocket(params.url, {
     headers: params.headers,
+    cert: params.clientCertificate,
+    key: params.clientPrivateKey,
   });
   const [challenge] = await Promise.all([
     waitForAuthChallenge(socket),
@@ -340,6 +420,7 @@ export async function connectFederationClient(params: {
 
   sendSocketMessage(socket, authMessage);
   const accepted = await waitForAuthResult(socket);
+  socket.once("close", () => params.onClose?.());
   socket.on("message", (raw) => {
     const message = parseSocketMessage(raw);
     if (message?.kind === "envelope") {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -38,6 +38,10 @@ import {
   registerImageNormalizationIpcHandlers,
 } from "./ipc/image-normalization";
 import {
+  disposeFederationIpcHandlers,
+  registerFederationIpcHandlers,
+} from "./ipc/federation";
+import {
   disposeIntegratedTerminalIpcHandlers,
   registerIntegratedTerminalIpcHandlers,
 } from "./ipc/integrated-terminal";
@@ -398,6 +402,7 @@ function disposeMainProcessResourcesSync(): void {
   disposeAppUpdateIpcHandlers();
   disposeComposerDraftIpcHandlers();
   disposeDiagnosticsIpcHandlers();
+  disposeFederationIpcHandlers();
   disposeImageNormalizationIpcHandlers();
   disposeIntegratedTerminalIpcHandlers();
   // Detached env-action trees (`pnpm dev` and friends) were previously just
@@ -841,6 +846,7 @@ export function bootstrapApp(): void {
     });
     registerComposerDraftIpcHandlers();
     registerDiagnosticsIpcHandlers();
+    registerFederationIpcHandlers();
     registerImageNormalizationIpcHandlers();
     registerIntegratedTerminalIpcHandlers();
     installTranscriptImageProtocol();

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -42,6 +42,10 @@ import {
   registerFederationIpcHandlers,
 } from "./ipc/federation";
 import {
+  disposeDesktopFederationRuntime,
+  getDesktopFederationRuntime,
+} from "./federation/federation-runtime";
+import {
   disposeIntegratedTerminalIpcHandlers,
   registerIntegratedTerminalIpcHandlers,
 } from "./ipc/integrated-terminal";
@@ -158,6 +162,7 @@ const mainLog = getMainLogger("pwragent:main");
 const mainProcessStartedAt = Date.now();
 const MAIN_PROCESS_SHUTDOWN_TIMEOUT_MS = 12_000;
 const MESSAGING_SHUTDOWN_TIMEOUT_MS = 4_000;
+const FEDERATION_SHUTDOWN_TIMEOUT_MS = 4_000;
 const APP_SERVER_SHUTDOWN_TIMEOUT_MS = 7_500;
 
 // Tart's AppleParavirtGPU can reset under sustained Electron E2E load,
@@ -440,6 +445,11 @@ const runMainProcessShutdownBarrier = createShutdownBarrier({
         await disposeMessagingStatusIpcHandlers();
         await disposeDesktopMessagingRuntime();
       },
+    },
+    {
+      name: "federation",
+      timeoutMs: FEDERATION_SHUTDOWN_TIMEOUT_MS,
+      run: disposeDesktopFederationRuntime,
     },
     {
       name: "app-server",
@@ -860,6 +870,9 @@ export function bootstrapApp(): void {
     });
     registerSettingsIpcHandlers(undefined, {
       onConfigPatchWritten: async (patch) => {
+        if (patch.federation !== undefined) {
+          await getDesktopFederationRuntime().restart();
+        }
         if (
           patch.general?.developerMode !== undefined ||
           patch.general?.hotCpuProfilingEnabled !== undefined ||
@@ -878,6 +891,11 @@ export function bootstrapApp(): void {
     if (isDevelopment) {
       registerRuntimeIdentityIpcHandlers();
     }
+    void getDesktopFederationRuntime().restart().catch((error) => {
+      mainLog.error("federation runtime failed during startup", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
     const messagingRuntime = getDesktopMessagingRuntime((options) =>
       loadDesktopMessagingConfigFromSettings(
         getDesktopSettingsService(),

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -147,6 +147,13 @@ function summarizeTurnInput(input: StartTurnRequest["input"]): Record<string, un
   };
 }
 
+function stripFederationTarget<T extends { federationTarget?: unknown }>(
+  request: T,
+): Omit<T, "federationTarget"> {
+  const { federationTarget: _federationTarget, ...rest } = request;
+  return rest;
+}
+
 function summarizeAgentEvent(event: AgentEvent): Record<string, unknown> | undefined {
   const params = event.notification.params;
   const turn =
@@ -410,10 +417,7 @@ export function registerAgentIpcHandlers(): void {
         ) {
           return await getDesktopFederationRuntime()
             .remoteBackend(request.federationTarget)
-            .startTurn({
-              ...request,
-              federationTarget: undefined,
-            });
+            .startTurn(stripFederationTarget(request));
         }
         const submitted = await registry.submitTurn({
           ...request,
@@ -515,6 +519,21 @@ export function registerAgentIpcHandlers(): void {
       });
 
       try {
+        if (
+          request.federationTarget &&
+          isRemoteFederationTarget(request.federationTarget)
+        ) {
+          const response = await getDesktopFederationRuntime()
+            .remoteBackend(request.federationTarget)
+            .compactThread(stripFederationTarget(request));
+          logDebug("compactThreadResult", {
+            backend: response.backend,
+            threadId: response.threadId,
+            turnId: response.turnId,
+            itemId: response.itemId,
+          });
+          return response;
+        }
         const response = await registry.compactThread(request);
         logDebug("compactThreadResult", {
           backend: response.backend,
@@ -548,6 +567,14 @@ export function registerAgentIpcHandlers(): void {
       });
 
       try {
+        if (
+          request.federationTarget &&
+          isRemoteFederationTarget(request.federationTarget)
+        ) {
+          return await getDesktopFederationRuntime()
+            .remoteBackend(request.federationTarget)
+            .interruptTurn(stripFederationTarget(request));
+        }
         return await registry.interruptTurn(request);
       } catch (error) {
         appServerLog.error("interruptTurn failed", {
@@ -604,6 +631,14 @@ export function registerAgentIpcHandlers(): void {
       });
 
       try {
+        if (
+          request.federationTarget &&
+          isRemoteFederationTarget(request.federationTarget)
+        ) {
+          return await getDesktopFederationRuntime()
+            .remoteBackend(request.federationTarget)
+            .steerTurn(stripFederationTarget(request));
+        }
         return await registry.steerTurn(request);
       } catch (error) {
         appServerLog.error("steerTurn failed", {
@@ -625,6 +660,14 @@ export function registerAgentIpcHandlers(): void {
       _event,
       request: SetThreadExecutionModeRequest
     ): Promise<SetThreadExecutionModeResponse> => {
+      if (
+        request.federationTarget &&
+        isRemoteFederationTarget(request.federationTarget)
+      ) {
+        return await getDesktopFederationRuntime()
+          .remoteBackend(request.federationTarget)
+          .setThreadExecutionMode(stripFederationTarget(request));
+      }
       return await registry.setThreadExecutionMode(request);
     },
   );
@@ -636,6 +679,14 @@ export function registerAgentIpcHandlers(): void {
       _event,
       request: QueueThreadExecutionModeRequest,
     ): Promise<QueueThreadExecutionModeResponse> => {
+      if (
+        request.federationTarget &&
+        isRemoteFederationTarget(request.federationTarget)
+      ) {
+        return await getDesktopFederationRuntime()
+          .remoteBackend(request.federationTarget)
+          .queueThreadExecutionMode(stripFederationTarget(request));
+      }
       return await registry.queueThreadExecutionMode(request);
     },
   );
@@ -647,6 +698,14 @@ export function registerAgentIpcHandlers(): void {
       _event,
       request: CancelThreadExecutionModeQueueRequest,
     ): Promise<CancelThreadExecutionModeQueueResponse> => {
+      if (
+        request.federationTarget &&
+        isRemoteFederationTarget(request.federationTarget)
+      ) {
+        return await getDesktopFederationRuntime()
+          .remoteBackend(request.federationTarget)
+          .cancelThreadExecutionModeQueue(stripFederationTarget(request));
+      }
       return await registry.cancelThreadExecutionModeQueue(request);
     },
   );
@@ -658,6 +717,14 @@ export function registerAgentIpcHandlers(): void {
       _event,
       request: SetAcpSessionRuntimeOptionRequest,
     ): Promise<SetAcpSessionRuntimeOptionResponse> => {
+      if (
+        request.federationTarget &&
+        isRemoteFederationTarget(request.federationTarget)
+      ) {
+        return await getDesktopFederationRuntime()
+          .remoteBackend(request.federationTarget)
+          .setAcpSessionRuntimeOption(stripFederationTarget(request));
+      }
       return await registry.setAcpSessionRuntimeOption(request);
     },
   );
@@ -669,6 +736,14 @@ export function registerAgentIpcHandlers(): void {
       _event,
       request: SetThreadModelSettingsRequest
     ): Promise<SetThreadModelSettingsResponse> => {
+      if (
+        request.federationTarget &&
+        isRemoteFederationTarget(request.federationTarget)
+      ) {
+        return await getDesktopFederationRuntime()
+          .remoteBackend(request.federationTarget)
+          .setThreadModelSettings(stripFederationTarget(request));
+      }
       return await registry.setThreadModelSettings(request);
     },
   );
@@ -758,6 +833,14 @@ export function registerAgentIpcHandlers(): void {
       _event,
       request: RunCodexEnvironmentActionRequest,
     ): Promise<RunCodexEnvironmentActionResponse> => {
+      if (
+        request.federationTarget &&
+        isRemoteFederationTarget(request.federationTarget)
+      ) {
+        return await getDesktopFederationRuntime()
+          .remoteBackend(request.federationTarget)
+          .runCodexEnvironmentAction(stripFederationTarget(request));
+      }
       return await registry.runCodexEnvironmentAction(request);
     },
   );
@@ -780,6 +863,14 @@ export function registerAgentIpcHandlers(): void {
       _event,
       request: SetCodexThreadEnvironmentRequest,
     ): Promise<SetCodexThreadEnvironmentResponse> => {
+      if (
+        request.federationTarget &&
+        isRemoteFederationTarget(request.federationTarget)
+      ) {
+        return await getDesktopFederationRuntime()
+          .remoteBackend(request.federationTarget)
+          .setCodexThreadEnvironment(stripFederationTarget(request));
+      }
       return await registry.setCodexThreadEnvironment(request);
     },
   );
@@ -791,6 +882,14 @@ export function registerAgentIpcHandlers(): void {
       _event,
       request: SubmitServerRequestRequest
     ): Promise<SubmitServerRequestResponse> => {
+      if (
+        request.federationTarget &&
+        isRemoteFederationTarget(request.federationTarget)
+      ) {
+        return await getDesktopFederationRuntime()
+          .remoteBackend(request.federationTarget)
+          .submitServerRequest(stripFederationTarget(request));
+      }
       return await registry.submitServerRequest(request);
     },
   );

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -11,6 +11,7 @@ import {
   type CancelThreadExecutionModeQueueResponse,
   type CheckThreadBranchDriftRequest,
   type CheckThreadBranchDriftResponse,
+  type CodexEnvironmentSetupProgressEvent,
   type CompactThreadRequest,
   type CompactThreadResponse,
   type ForkThreadRequest,
@@ -318,11 +319,26 @@ export function broadcastAgentEvent(event: AgentEvent): void {
   }
 }
 
+function broadcastCodexEnvironmentSetupProgress(
+  event: CodexEnvironmentSetupProgressEvent,
+): void {
+  const rendererEvent = sanitizeRendererPayload(event);
+  for (const webContents of subscribersForChannel(
+    CODEX_ENVIRONMENT_SETUP_PROGRESS_CHANNEL,
+  )) {
+    if (typeof webContents.send !== "function") continue;
+    webContents.send(CODEX_ENVIRONMENT_SETUP_PROGRESS_CHANNEL, rendererEvent);
+  }
+}
+
 export function registerAgentIpcHandlers(): void {
   const registry = getDesktopBackendRegistry();
 
   unsubscribeRegistryEvents?.();
   getDesktopFederationRuntime().setAgentEventPublisher(broadcastAgentEvent);
+  getDesktopFederationRuntime().setEnvironmentSetupProgressPublisher(
+    broadcastCodexEnvironmentSetupProgress,
+  );
   unsubscribeRegistryEvents = registry.onEvent((event) => {
     broadcastAgentEvent(event);
   });
@@ -373,6 +389,14 @@ export function registerAgentIpcHandlers(): void {
       _event,
       request: StartThreadRequest
     ): Promise<StartThreadResponse> => {
+      if (
+        request.federationTarget &&
+        isRemoteFederationTarget(request.federationTarget)
+      ) {
+        return await getDesktopFederationRuntime()
+          .remoteBackend(request.federationTarget)
+          .startThread(stripFederationTarget(request));
+      }
       return await registry.startThread(request);
     },
   );
@@ -384,6 +408,14 @@ export function registerAgentIpcHandlers(): void {
       event: IpcMainInvokeEvent,
       request: ForkThreadRequest,
     ): Promise<ForkThreadResponse> => {
+      if (
+        request.federationTarget &&
+        isRemoteFederationTarget(request.federationTarget)
+      ) {
+        return await getDesktopFederationRuntime()
+          .remoteBackend(request.federationTarget)
+          .forkThread(stripFederationTarget(request));
+      }
       return await registry.forkThread({
         ...request,
         onCodexEnvironmentSetupProgress: (progress) => {
@@ -487,6 +519,14 @@ export function registerAgentIpcHandlers(): void {
       });
 
       try {
+        if (
+          request.federationTarget &&
+          isRemoteFederationTarget(request.federationTarget)
+        ) {
+          return await getDesktopFederationRuntime()
+            .remoteBackend(request.federationTarget)
+            .startReview(stripFederationTarget(request));
+        }
         const response = await registry.startReview(request);
         logDebug("startReviewResult", {
           backend: response.backend,
@@ -818,6 +858,14 @@ export function registerAgentIpcHandlers(): void {
       event,
       request: MaterializeDirectoryLaunchpadRequest
     ): Promise<MaterializeDirectoryLaunchpadResponse> => {
+      if (
+        request.federationTarget &&
+        isRemoteFederationTarget(request.federationTarget)
+      ) {
+        return await getDesktopFederationRuntime()
+          .remoteBackend(request.federationTarget)
+          .materializeDirectoryLaunchpad(stripFederationTarget(request));
+      }
       return await registry.materializeDirectoryLaunchpad(request, {
         onCodexEnvironmentSetupProgress: (progress) => {
           event.sender?.send?.(CODEX_ENVIRONMENT_SETUP_PROGRESS_CHANNEL, progress);
@@ -852,6 +900,14 @@ export function registerAgentIpcHandlers(): void {
       _event,
       request: StopCodexEnvironmentActionRequest,
     ): Promise<StopCodexEnvironmentActionResponse> => {
+      if (
+        request.federationTarget &&
+        isRemoteFederationTarget(request.federationTarget)
+      ) {
+        return await getDesktopFederationRuntime()
+          .remoteBackend(request.federationTarget)
+          .stopCodexEnvironmentAction(stripFederationTarget(request));
+      }
       return await registry.stopCodexEnvironmentAction(request);
     },
   );

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -62,6 +62,8 @@ import {
   type UpdateThreadExpectedBranchRequest,
   type UpdateThreadExpectedBranchResponse,
 } from "@pwragent/shared";
+import { isRemoteFederationTarget } from "@pwragent/shared";
+import { getDesktopFederationRuntime } from "../federation/federation-runtime";
 import { getDesktopBackendRegistry } from "../app-server/backend-registry";
 import { buildLiveDiffActivityEntry } from "../app-server/live-diff-activity";
 import { timeStartupProfileOperation } from "../diagnostics/startup-profile-events";
@@ -401,6 +403,17 @@ export function registerAgentIpcHandlers(): void {
       });
 
       try {
+        if (
+          request.federationTarget &&
+          isRemoteFederationTarget(request.federationTarget)
+        ) {
+          return await getDesktopFederationRuntime()
+            .remoteBackend(request.federationTarget)
+            .startTurn({
+              ...request,
+              federationTarget: undefined,
+            });
+        }
         const submitted = await registry.submitTurn({
           ...request,
           origin: "manual",

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -355,7 +355,17 @@ export function registerAgentIpcHandlers(): void {
         detail: {
           hasRequest: request !== undefined,
         },
-        operation: async () => await registry.listBackends(request),
+        operation: async () => {
+          if (
+            request?.federationTarget
+            && isRemoteFederationTarget(request.federationTarget)
+          ) {
+            return await getDesktopFederationRuntime()
+              .remoteBackend(request.federationTarget)
+              .listBackends(stripFederationTarget(request));
+          }
+          return await registry.listBackends(request);
+        },
       });
     },
   );

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -295,7 +295,7 @@ function withRendererActivityEntry(event: AgentEvent): AgentEvent {
   return rendererActivityEntry ? { ...event, rendererActivityEntry } : event;
 }
 
-function broadcastAgentEvent(event: AgentEvent): void {
+export function broadcastAgentEvent(event: AgentEvent): void {
   const eventSummary = summarizeAgentEvent(event);
   if (eventSummary) {
     logAgentEventSummary(eventSummary);
@@ -315,6 +315,7 @@ export function registerAgentIpcHandlers(): void {
   const registry = getDesktopBackendRegistry();
 
   unsubscribeRegistryEvents?.();
+  getDesktopFederationRuntime().setAgentEventPublisher(broadcastAgentEvent);
   unsubscribeRegistryEvents = registry.onEvent((event) => {
     broadcastAgentEvent(event);
   });

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -957,6 +957,14 @@ export function registerAgentIpcHandlers(): void {
       _event,
       request: TrustCodexProjectRequest,
     ): Promise<TrustCodexProjectResponse> => {
+      if (
+        request.federationTarget &&
+        isRemoteFederationTarget(request.federationTarget)
+      ) {
+        return await getDesktopFederationRuntime()
+          .remoteBackend(request.federationTarget)
+          .trustCodexProject(stripFederationTarget(request));
+      }
       return await registry.trustCodexProject(request);
     },
   );

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1455,6 +1455,21 @@ class DesktopAppServerService {
   async handoffThreadWorkspace(
     request: HandoffThreadWorkspaceRequest,
   ): Promise<HandoffThreadWorkspaceResponse> {
+    if (request.federationTarget && isRemoteFederationTarget(request.federationTarget)) {
+      const { federationTarget: _federationTarget, ...remoteRequest } = request;
+      const response = await getDesktopFederationRuntime()
+        .remoteBackend(request.federationTarget)
+        .handoffThreadWorkspace(remoteRequest);
+      logDebug("handoffThreadWorkspace", {
+        backend: request.backend,
+        threadId: request.threadId,
+        direction: request.direction,
+        workMode: response.workMode,
+        targetPath: response.targetPath,
+        federationTarget: request.federationTarget.instanceId,
+      });
+      return response;
+    }
     const response = await getDesktopBackendRegistry().handoffThreadWorkspace(request);
 
     logDebug("handoffThreadWorkspace", {

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -148,6 +148,7 @@ import {
   normalizePullRequestProvider as normalizeSharedPullRequestProvider,
   parseThreadIdentityKey,
 } from "@pwragent/shared";
+import { isRemoteFederationTarget } from "@pwragent/shared";
 import { registerDirectoryFromDisk } from "../app-server/directory-registration-service";
 import {
   disposeDesktopBackendRegistry,
@@ -220,6 +221,7 @@ import {
   NAVIGATION_UPDATE_DIRECTORY_LAUNCHPAD_CHANNEL,
 } from "../../shared/ipc";
 import { subscribersForChannel } from "../window-channels";
+import { getDesktopFederationRuntime } from "../federation/federation-runtime";
 import { FocusedDiffService } from "../diff-focus/focused-diff-service";
 import { renderComposerPdfPreview } from "../pdf/composer-pdf-preview";
 import { getMainLogger } from "../log";
@@ -621,6 +623,7 @@ function getNavigationSnapshotRequestKey(
 ): string {
   return JSON.stringify({
     backend: request.backend ?? "all",
+    federationTarget: request.federationTarget ?? { scope: "local" },
     filter: request.filter ?? "",
     forceRefresh: request.forceRefresh === true,
     refreshMode: request.refreshMode ?? "full",
@@ -1214,6 +1217,15 @@ class DesktopAppServerService {
   async listThreads(
     request: AppServerListThreadsRequest = {}
   ): Promise<AppServerListThreadsResponse> {
+    if (request.federationTarget && isRemoteFederationTarget(request.federationTarget)) {
+      return await getDesktopFederationRuntime()
+        .remoteBackend(request.federationTarget)
+        .listThreads({
+          backend: request.backend,
+          archived: request.archived,
+          filter: request.filter,
+        });
+    }
     const backend = request.backend;
     const threads = await getDesktopBackendRegistry().listThreads({
       backend,
@@ -1249,6 +1261,16 @@ class DesktopAppServerService {
   async listSkills(
     request: AppServerListSkillsRequest = {},
   ): Promise<AppServerListSkillsResponse> {
+    if (request.federationTarget && isRemoteFederationTarget(request.federationTarget)) {
+      return await getDesktopFederationRuntime()
+        .remoteBackend(request.federationTarget)
+        .listSkills({
+          backend: request.backend,
+          cwd: request.cwd,
+          cwds: request.cwds,
+          threadId: request.threadId,
+        });
+    }
     const backend = request.backend ?? "codex";
     const response = await getDesktopBackendRegistry().listSkills({
       backend,
@@ -1279,6 +1301,16 @@ class DesktopAppServerService {
   async readThread(
     request: AppServerReadThreadRequest
   ): Promise<AppServerReadThreadResponse> {
+    if (request.federationTarget && isRemoteFederationTarget(request.federationTarget)) {
+      return await getDesktopFederationRuntime()
+        .remoteBackend(request.federationTarget)
+        .readThread({
+          backend: request.backend,
+          threadId: request.threadId,
+          before: request.before,
+          limit: request.limit,
+        });
+    }
     const backend = request.backend ?? "codex";
     const registry = getDesktopBackendRegistry();
     const response = await registry.readThread({
@@ -1487,6 +1519,15 @@ class DesktopAppServerService {
   private async readNavigationSnapshot(
     request: GetNavigationSnapshotRequest,
   ): Promise<NavigationSnapshot> {
+    if (request.federationTarget && isRemoteFederationTarget(request.federationTarget)) {
+      return await getDesktopFederationRuntime().remoteNavigationSnapshot(
+        request.federationTarget,
+        {
+          backend: request.backend === "all" ? undefined : request.backend,
+          filter: request.filter,
+        },
+      );
+    }
     const backend: AppServerBackendScope = request.backend ?? "all";
     const refreshMode = request.refreshMode ?? "full";
     const activeRecentRefresh = refreshMode === "active-recent";

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -144,11 +144,12 @@ import {
   DEFAULT_PULL_REQUEST_PROVIDER,
   buildPullRequestStatusKey,
   buildThreadIdentityKey,
+  federatedThreadIdentityKey,
   isAppServerBackendKind,
+  isRemoteFederationTarget,
   normalizePullRequestProvider as normalizeSharedPullRequestProvider,
   parseThreadIdentityKey,
 } from "@pwragent/shared";
-import { isRemoteFederationTarget } from "@pwragent/shared";
 import { registerDirectoryFromDisk } from "../app-server/directory-registration-service";
 import {
   disposeDesktopBackendRegistry,
@@ -1255,7 +1256,86 @@ class DesktopAppServerService {
   async searchThreads(
     request: ThreadSearchRequest = {},
   ): Promise<ThreadSearchResponse> {
-    return await this.getThreadSearchService().search(request);
+    const local = await this.getThreadSearchService().search(request);
+    const federated = await getDesktopFederationRuntime().searchConnectedPeers({
+      query: local.query,
+      limit: request.limit,
+      backend: request.filters?.backend,
+    });
+    const remoteResults = federated.results
+      .filter((result) => isRemoteFederationTarget(result.ref.target))
+      .map((result) => ({
+        backend: result.thread.source,
+        threadId: result.thread.id,
+        identityKey: federatedThreadIdentityKey(result.ref),
+        title: result.thread.title,
+        titleSource: result.thread.titleSource,
+        summary: result.thread.summary,
+        projectKey: result.thread.projectKey,
+        createdAt: result.thread.createdAt,
+        updatedAt: result.thread.updatedAt,
+        archivedAt: result.thread.archivedAt,
+        linkedDirectories: result.thread.linkedDirectories,
+        source: result.thread.source,
+        gitBranch: result.thread.gitBranch,
+        model: result.thread.model,
+        score: result.score,
+        confidence: result.thread.title.trim().toLowerCase() ===
+          local.query.trim().toLowerCase()
+          ? "high" as const
+          : "medium" as const,
+        matchReasons: [
+          {
+            kind: result.thread.title.trim().toLowerCase() ===
+              local.query.trim().toLowerCase()
+              ? "exact_title" as const
+              : "title_token_overlap" as const,
+            field: "title",
+            value: result.thread.title,
+          },
+        ],
+        snippets: [
+          {
+            scope: "metadata" as const,
+            field: "title",
+            text: result.thread.title,
+          },
+          ...(result.thread.summary
+            ? [{
+                scope: "metadata" as const,
+                field: "summary",
+                text: result.thread.summary,
+              }]
+            : []),
+        ],
+        federation: {
+          ref: result.ref,
+          instanceLabel: result.instanceLabel,
+          peerStatus: result.peerStatus,
+        },
+      }));
+    const limit = Math.max(1, Math.min(request.limit ?? 20, 100));
+    const confidenceRank = { high: 3, medium: 2, low: 1 };
+    const results = [...local.results, ...remoteResults]
+      .sort(
+        (left, right) =>
+          confidenceRank[right.confidence] - confidenceRank[left.confidence],
+      )
+      .slice(0, limit);
+    return {
+      ...local,
+      results,
+      unavailableScopes: [
+        ...local.unavailableScopes,
+        ...federated.failures.map((failure) => ({
+          scope: "metadata" as const,
+          reason: "error" as const,
+          message: `${failure.instanceLabel}: ${failure.error}`,
+        })),
+      ],
+      truncated: local.truncated ||
+        local.results.length + remoteResults.length > results.length,
+    };
   }
 
   async listSkills(

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1448,6 +1448,15 @@ class DesktopAppServerService {
   async archiveThread(
     request: ArchiveThreadRequest,
   ): Promise<ArchiveThreadResponse> {
+    if (
+      request.federationTarget
+      && isRemoteFederationTarget(request.federationTarget)
+    ) {
+      const { federationTarget, ...remoteRequest } = request;
+      return await getDesktopFederationRuntime()
+        .remoteBackend(federationTarget)
+        .archiveThread(remoteRequest);
+    }
     const backend = request.backend ?? "codex";
     const response = await getDesktopBackendRegistry().archiveThread({
       ...request,

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1567,6 +1567,21 @@ class DesktopAppServerService {
     request: RenameThreadRequest,
   ): Promise<RenameThreadResponse> {
     const backend = request.backend ?? "codex";
+    if (request.federationTarget && isRemoteFederationTarget(request.federationTarget)) {
+      const { federationTarget: _federationTarget, ...remoteRequest } = request;
+      const response = await getDesktopFederationRuntime()
+        .remoteBackend(request.federationTarget)
+        .renameThread({
+          ...remoteRequest,
+          backend,
+        });
+      logDebug("renameThread", {
+        backend,
+        threadId: request.threadId,
+        federationTarget: request.federationTarget.instanceId,
+      });
+      return response;
+    }
     const response = await getDesktopBackendRegistry().renameThread({
       ...request,
       backend,

--- a/apps/desktop/src/main/ipc/applications.ts
+++ b/apps/desktop/src/main/ipc/applications.ts
@@ -1,18 +1,19 @@
 import { access, readFile, stat } from "node:fs/promises";
 import { BrowserWindow, ipcMain, shell } from "electron";
-import type {
-  OpenDesktopApplicationRequest,
-  OpenDesktopApplicationResponse,
-  OpenMarkdownFileViewerRequest,
-  OpenMarkdownFileViewerResponse,
-  OpenSubAgentTranscriptWindowRequest,
-  OpenSubAgentTranscriptWindowResponse,
-  OpenPathRequest,
-  OpenPathResponse,
-  ReadMarkdownFileRequest,
-  ReadMarkdownFileResponse,
-  ReadMarkdownFileViewerSnapshotRequest,
-  ReadMarkdownFileViewerSnapshotResponse,
+import {
+  isRemoteFederationTarget,
+  type OpenDesktopApplicationRequest,
+  type OpenDesktopApplicationResponse,
+  type OpenMarkdownFileViewerRequest,
+  type OpenMarkdownFileViewerResponse,
+  type OpenSubAgentTranscriptWindowRequest,
+  type OpenSubAgentTranscriptWindowResponse,
+  type OpenPathRequest,
+  type OpenPathResponse,
+  type ReadMarkdownFileRequest,
+  type ReadMarkdownFileResponse,
+  type ReadMarkdownFileViewerSnapshotRequest,
+  type ReadMarkdownFileViewerSnapshotResponse,
 } from "@pwragent/shared";
 import {
   APPLICATION_OPEN_CHANNEL,
@@ -27,6 +28,7 @@ import {
   readMarkdownFileViewerSnapshot,
   showMarkdownFileViewerWindow,
 } from "../markdown-files-window";
+import { getDesktopFederationRuntime } from "../federation/federation-runtime";
 import { showSubAgentTranscriptWindow } from "../subagent-transcript-window";
 import { openDesktopApplication } from "../settings/application-discovery";
 
@@ -105,6 +107,18 @@ async function readMarkdownFile(
   }
 }
 
+async function openApplication(
+  request: OpenDesktopApplicationRequest,
+): Promise<OpenDesktopApplicationResponse> {
+  if (request.federationTarget && isRemoteFederationTarget(request.federationTarget)) {
+    const { federationTarget: _federationTarget, ...remoteRequest } = request;
+    return await getDesktopFederationRuntime()
+      .remoteBackend(request.federationTarget)
+      .openApplication(remoteRequest);
+  }
+  return await openDesktopApplication(request);
+}
+
 export function registerApplicationIpcHandlers(): void {
   ipcMain.removeHandler(APPLICATION_OPEN_CHANNEL);
   ipcMain.handle(
@@ -112,7 +126,7 @@ export function registerApplicationIpcHandlers(): void {
     async (
       _event,
       request: OpenDesktopApplicationRequest,
-    ): Promise<OpenDesktopApplicationResponse> => openDesktopApplication(request),
+    ): Promise<OpenDesktopApplicationResponse> => openApplication(request),
   );
 
   ipcMain.removeHandler(PATH_OPEN_CHANNEL);

--- a/apps/desktop/src/main/ipc/applications.ts
+++ b/apps/desktop/src/main/ipc/applications.ts
@@ -4,6 +4,8 @@ import {
   isRemoteFederationTarget,
   type OpenDesktopApplicationRequest,
   type OpenDesktopApplicationResponse,
+  type ReadDesktopApplicationsRequest,
+  type ReadDesktopApplicationsResponse,
   type OpenMarkdownFileViewerRequest,
   type OpenMarkdownFileViewerResponse,
   type OpenSubAgentTranscriptWindowRequest,
@@ -16,6 +18,7 @@ import {
   type ReadMarkdownFileViewerSnapshotResponse,
 } from "@pwragent/shared";
 import {
+  APPLICATIONS_READ_CHANNEL,
   APPLICATION_OPEN_CHANNEL,
   MARKDOWN_FILE_READ_CHANNEL,
   MARKDOWN_FILE_VIEWER_OPEN_CHANNEL,
@@ -30,7 +33,10 @@ import {
 } from "../markdown-files-window";
 import { getDesktopFederationRuntime } from "../federation/federation-runtime";
 import { showSubAgentTranscriptWindow } from "../subagent-transcript-window";
-import { openDesktopApplication } from "../settings/application-discovery";
+import {
+  discoverDesktopApplications,
+  openDesktopApplication,
+} from "../settings/application-discovery";
 
 const MAX_MARKDOWN_FILE_BYTES = 2 * 1024 * 1024;
 
@@ -119,7 +125,29 @@ async function openApplication(
   return await openDesktopApplication(request);
 }
 
+async function readApplications(
+  request: ReadDesktopApplicationsRequest,
+): Promise<ReadDesktopApplicationsResponse> {
+  if (request.federationTarget && isRemoteFederationTarget(request.federationTarget)) {
+    return {
+      applications: await getDesktopFederationRuntime()
+        .remoteBackend(request.federationTarget)
+        .readApplications(),
+    };
+  }
+  return { applications: await discoverDesktopApplications() };
+}
+
 export function registerApplicationIpcHandlers(): void {
+  ipcMain.removeHandler(APPLICATIONS_READ_CHANNEL);
+  ipcMain.handle(
+    APPLICATIONS_READ_CHANNEL,
+    async (
+      _event,
+      request: ReadDesktopApplicationsRequest,
+    ): Promise<ReadDesktopApplicationsResponse> => readApplications(request),
+  );
+
   ipcMain.removeHandler(APPLICATION_OPEN_CHANNEL);
   ipcMain.handle(
     APPLICATION_OPEN_CHANNEL,

--- a/apps/desktop/src/main/ipc/federation.ts
+++ b/apps/desktop/src/main/ipc/federation.ts
@@ -2,13 +2,23 @@ import { ipcMain } from "electron";
 import type {
   OpenFederationWindowRequest,
   OpenFederationWindowResponse,
+  ReadFederationHealthRequest,
+  ReadFederationHealthResponse,
 } from "@pwragent/shared";
 import { isFederationInstanceId } from "@pwragent/shared";
-import { FEDERATION_OPEN_WINDOW_CHANNEL } from "../../shared/ipc";
+import {
+  FEDERATION_GET_HEALTH_CHANNEL,
+  FEDERATION_OPEN_WINDOW_CHANNEL,
+} from "../../shared/ipc";
+import { buildFederationHealthStatus } from "../federation/federation-health";
+import { FederationStore } from "../federation/federation-store";
+import { getDesktopSettingsService } from "../settings/desktop-settings-singleton";
+import { getAppStateDb } from "../state/app-state";
 import { createMainWindow } from "../window";
 
 export function registerFederationIpcHandlers(): void {
   ipcMain.removeHandler(FEDERATION_OPEN_WINDOW_CHANNEL);
+  ipcMain.removeHandler(FEDERATION_GET_HEALTH_CHANNEL);
   ipcMain.handle(
     FEDERATION_OPEN_WINDOW_CHANNEL,
     async (
@@ -31,8 +41,24 @@ export function registerFederationIpcHandlers(): void {
       };
     },
   );
+  ipcMain.handle(
+    FEDERATION_GET_HEALTH_CHANNEL,
+    async (
+      _event,
+      _request?: ReadFederationHealthRequest,
+    ): Promise<ReadFederationHealthResponse> => {
+      const settings = await getDesktopSettingsService().readSettings();
+      const peers = new FederationStore(getAppStateDb()).listPeers({
+        includeRevoked: true,
+      });
+      return {
+        health: buildFederationHealthStatus({ settings, peers }),
+      };
+    },
+  );
 }
 
 export function disposeFederationIpcHandlers(): void {
   ipcMain.removeHandler(FEDERATION_OPEN_WINDOW_CHANNEL);
+  ipcMain.removeHandler(FEDERATION_GET_HEALTH_CHANNEL);
 }

--- a/apps/desktop/src/main/ipc/federation.ts
+++ b/apps/desktop/src/main/ipc/federation.ts
@@ -1,5 +1,9 @@
 import { ipcMain } from "electron";
 import type {
+  GenerateFederationInviteRequest,
+  GenerateFederationInviteResponse,
+  ImportFederationInviteRequest,
+  ImportFederationInviteResponse,
   OpenFederationWindowRequest,
   OpenFederationWindowResponse,
   ReadFederationHealthRequest,
@@ -8,17 +12,18 @@ import type {
 import { isFederationInstanceId } from "@pwragent/shared";
 import {
   FEDERATION_GET_HEALTH_CHANNEL,
+  FEDERATION_GENERATE_INVITE_CHANNEL,
+  FEDERATION_IMPORT_INVITE_CHANNEL,
   FEDERATION_OPEN_WINDOW_CHANNEL,
 } from "../../shared/ipc";
-import { buildFederationHealthStatus } from "../federation/federation-health";
-import { FederationStore } from "../federation/federation-store";
-import { getDesktopSettingsService } from "../settings/desktop-settings-singleton";
-import { getAppStateDb } from "../state/app-state";
+import { getDesktopFederationRuntime } from "../federation/federation-runtime";
 import { createMainWindow } from "../window";
 
 export function registerFederationIpcHandlers(): void {
   ipcMain.removeHandler(FEDERATION_OPEN_WINDOW_CHANNEL);
   ipcMain.removeHandler(FEDERATION_GET_HEALTH_CHANNEL);
+  ipcMain.removeHandler(FEDERATION_GENERATE_INVITE_CHANNEL);
+  ipcMain.removeHandler(FEDERATION_IMPORT_INVITE_CHANNEL);
   ipcMain.handle(
     FEDERATION_OPEN_WINDOW_CHANNEL,
     async (
@@ -47,18 +52,32 @@ export function registerFederationIpcHandlers(): void {
       _event,
       _request?: ReadFederationHealthRequest,
     ): Promise<ReadFederationHealthResponse> => {
-      const settings = await getDesktopSettingsService().readSettings();
-      const peers = new FederationStore(getAppStateDb()).listPeers({
-        includeRevoked: true,
-      });
       return {
-        health: buildFederationHealthStatus({ settings, peers }),
+        health: await getDesktopFederationRuntime().health(),
       };
     },
+  );
+  ipcMain.handle(
+    FEDERATION_GENERATE_INVITE_CHANNEL,
+    async (
+      _event,
+      request: GenerateFederationInviteRequest = {},
+    ): Promise<GenerateFederationInviteResponse> =>
+      await getDesktopFederationRuntime().generateInvite(request),
+  );
+  ipcMain.handle(
+    FEDERATION_IMPORT_INVITE_CHANNEL,
+    async (
+      _event,
+      request: ImportFederationInviteRequest,
+    ): Promise<ImportFederationInviteResponse> =>
+      await getDesktopFederationRuntime().importInvite(request.invite),
   );
 }
 
 export function disposeFederationIpcHandlers(): void {
   ipcMain.removeHandler(FEDERATION_OPEN_WINDOW_CHANNEL);
   ipcMain.removeHandler(FEDERATION_GET_HEALTH_CHANNEL);
+  ipcMain.removeHandler(FEDERATION_GENERATE_INVITE_CHANNEL);
+  ipcMain.removeHandler(FEDERATION_IMPORT_INVITE_CHANNEL);
 }

--- a/apps/desktop/src/main/ipc/federation.ts
+++ b/apps/desktop/src/main/ipc/federation.ts
@@ -1,0 +1,38 @@
+import { ipcMain } from "electron";
+import type {
+  OpenFederationWindowRequest,
+  OpenFederationWindowResponse,
+} from "@pwragent/shared";
+import { isFederationInstanceId } from "@pwragent/shared";
+import { FEDERATION_OPEN_WINDOW_CHANNEL } from "../../shared/ipc";
+import { createMainWindow } from "../window";
+
+export function registerFederationIpcHandlers(): void {
+  ipcMain.removeHandler(FEDERATION_OPEN_WINDOW_CHANNEL);
+  ipcMain.handle(
+    FEDERATION_OPEN_WINDOW_CHANNEL,
+    async (
+      _event,
+      request: OpenFederationWindowRequest,
+    ): Promise<OpenFederationWindowResponse> => {
+      if (
+        request.target?.scope !== "remote" ||
+        !isFederationInstanceId(request.target.instanceId)
+      ) {
+        throw new Error("Invalid federation window target");
+      }
+      const window = createMainWindow({
+        federationTarget: request.target,
+      });
+      return {
+        opened: true,
+        windowId: window.id,
+        target: request.target,
+      };
+    },
+  );
+}
+
+export function disposeFederationIpcHandlers(): void {
+  ipcMain.removeHandler(FEDERATION_OPEN_WINDOW_CHANNEL);
+}

--- a/apps/desktop/src/main/ipc/federation.ts
+++ b/apps/desktop/src/main/ipc/federation.ts
@@ -8,13 +8,19 @@ import type {
   OpenFederationWindowResponse,
   ReadFederationHealthRequest,
   ReadFederationHealthResponse,
+  ReadFederationDiagnosticsRequest,
+  ReadFederationDiagnosticsResponse,
+  RevokeFederationPeerRequest,
+  RevokeFederationPeerResponse,
 } from "@pwragent/shared";
 import { isFederationInstanceId } from "@pwragent/shared";
 import {
   FEDERATION_GET_HEALTH_CHANNEL,
+  FEDERATION_GET_DIAGNOSTICS_CHANNEL,
   FEDERATION_GENERATE_INVITE_CHANNEL,
   FEDERATION_IMPORT_INVITE_CHANNEL,
   FEDERATION_OPEN_WINDOW_CHANNEL,
+  FEDERATION_REVOKE_PEER_CHANNEL,
 } from "../../shared/ipc";
 import { getDesktopFederationRuntime } from "../federation/federation-runtime";
 import { createMainWindow } from "../window";
@@ -22,8 +28,18 @@ import { createMainWindow } from "../window";
 export function registerFederationIpcHandlers(): void {
   ipcMain.removeHandler(FEDERATION_OPEN_WINDOW_CHANNEL);
   ipcMain.removeHandler(FEDERATION_GET_HEALTH_CHANNEL);
+  ipcMain.removeHandler(FEDERATION_GET_DIAGNOSTICS_CHANNEL);
   ipcMain.removeHandler(FEDERATION_GENERATE_INVITE_CHANNEL);
   ipcMain.removeHandler(FEDERATION_IMPORT_INVITE_CHANNEL);
+  ipcMain.removeHandler(FEDERATION_REVOKE_PEER_CHANNEL);
+  ipcMain.handle(
+    FEDERATION_GET_DIAGNOSTICS_CHANNEL,
+    async (
+      _event,
+      request: ReadFederationDiagnosticsRequest = {},
+    ): Promise<ReadFederationDiagnosticsResponse> =>
+      await getDesktopFederationRuntime().diagnostics(request),
+  );
   ipcMain.handle(
     FEDERATION_OPEN_WINDOW_CHANNEL,
     async (
@@ -36,8 +52,32 @@ export function registerFederationIpcHandlers(): void {
       ) {
         throw new Error("Invalid federation window target");
       }
+      const runtime = getDesktopFederationRuntime();
+      const peer = runtime.connectedPeerTargets().find(
+        (candidate) =>
+          candidate.target.instanceId === request.target.instanceId,
+      );
+      if (!peer) {
+        throw new Error("Federation peer is not connected.");
+      }
+      if (
+        request.initialThread &&
+        (
+          request.initialThread.target.scope !== "remote" ||
+          request.initialThread.target.instanceId !== request.target.instanceId
+        )
+      ) {
+        throw new Error("Federation initial thread target does not match its window.");
+      }
       const window = createMainWindow({
+        federationLabel: peer.label,
         federationTarget: request.target,
+        initialThread: request.initialThread
+          ? {
+              backend: request.initialThread.backend,
+              threadId: request.initialThread.threadId,
+            }
+          : undefined,
       });
       return {
         opened: true,
@@ -73,11 +113,27 @@ export function registerFederationIpcHandlers(): void {
     ): Promise<ImportFederationInviteResponse> =>
       await getDesktopFederationRuntime().importInvite(request.invite),
   );
+  ipcMain.handle(
+    FEDERATION_REVOKE_PEER_CHANNEL,
+    async (
+      _event,
+      request: RevokeFederationPeerRequest,
+    ): Promise<RevokeFederationPeerResponse> => {
+      if (!isFederationInstanceId(request.peerId)) {
+        throw new Error("Invalid federation peer id");
+      }
+      return {
+        peer: await getDesktopFederationRuntime().revokePeer(request.peerId),
+      };
+    },
+  );
 }
 
 export function disposeFederationIpcHandlers(): void {
   ipcMain.removeHandler(FEDERATION_OPEN_WINDOW_CHANNEL);
   ipcMain.removeHandler(FEDERATION_GET_HEALTH_CHANNEL);
+  ipcMain.removeHandler(FEDERATION_GET_DIAGNOSTICS_CHANNEL);
   ipcMain.removeHandler(FEDERATION_GENERATE_INVITE_CHANNEL);
   ipcMain.removeHandler(FEDERATION_IMPORT_INVITE_CHANNEL);
+  ipcMain.removeHandler(FEDERATION_REVOKE_PEER_CHANNEL);
 }

--- a/apps/desktop/src/main/messaging/core/messaging-adapter.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-adapter.ts
@@ -16,6 +16,7 @@ import type {
   InterruptTurnRequest,
   InterruptTurnResponse,
   GetNavigationSnapshotRequest,
+  FederationTarget,
   ListBackendsRequest,
   ListBackendsResponse,
   MaterializeDirectoryLaunchpadOptions,
@@ -135,18 +136,22 @@ export type MessagingBackendBridge = {
   ): Promise<NavigationSnapshot>;
   readThreadStatus?(request: {
     backend: AppServerBackendKind;
+    federationTarget?: FederationTarget;
     threadId: string;
   }): Promise<AppServerThreadStatus | undefined>;
   readActiveTurn?(request: {
     backend: AppServerBackendKind;
+    federationTarget?: FederationTarget;
     threadId: string;
   }): Promise<MessagingActiveBackendTurn | undefined>;
   readThreadLastAssistantMessage?(request: {
     backend: AppServerBackendKind;
+    federationTarget?: FederationTarget;
     threadId: string;
   }): Promise<string | undefined>;
   readThreadLastAssistantReply?(request: {
     backend: AppServerBackendKind;
+    federationTarget?: FederationTarget;
     threadId: string;
   }): Promise<MessagingLastAssistantReply | undefined>;
   resolveAssistantMessageImages?(request: {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -3,8 +3,10 @@ import path from "node:path";
 import {
   applyNavigationLaunchpadProviderSettingsPatch,
   buildReviewBranchOptions,
+  buildFederatedThreadRef,
   buildThreadIdentityKey,
   findPreferredReviewWorkspaceCwd,
+  federatedThreadIdentityKey,
   isAcpBackendId,
   isAppServerBackendKind,
   isMessagingBindingTargetKind,
@@ -33,6 +35,8 @@ import type {
   AppServerToolRequestUserInputNotification,
   DesktopAuthorizedContact,
   DesktopMessagingFullAccessWarningGlobalPolicy,
+  FederatedThreadRef,
+  FederationTarget,
   HandoffThreadWorkspaceRequest,
   HandoffThreadWorkspaceResponse,
   LinkedDirectorySummary,
@@ -422,8 +426,60 @@ function findThreadForBinding(
   binding: MessagingBindingRecord,
 ): NavigationThreadSummary | undefined {
   return navigation?.threads.find(
-    (thread) => thread.source === binding.backend && thread.id === binding.threadId,
+    (thread) =>
+      thread.source === binding.backend &&
+      thread.id === binding.threadId &&
+      federationRefsMatch(thread.federation?.ref, binding.federatedThread),
   );
+}
+
+function federationRefsMatch(
+  left: FederatedThreadRef | undefined,
+  right: FederatedThreadRef | undefined,
+): boolean {
+  const leftTarget = left?.target ?? { scope: "local" as const };
+  const rightTarget = right?.target ?? { scope: "local" as const };
+  return leftTarget.scope === rightTarget.scope &&
+    (leftTarget.scope === "local" ||
+      (rightTarget.scope === "remote" &&
+        leftTarget.instanceId === rightTarget.instanceId));
+}
+
+function federationTargetForBinding(
+  binding: MessagingBindingRecord,
+): FederationTarget | undefined {
+  return binding.federatedThread?.target.scope === "remote"
+    ? binding.federatedThread.target
+    : undefined;
+}
+
+function bindingMatchesFederationTarget(
+  binding: MessagingBindingRecord,
+  target: FederationTarget | undefined,
+): boolean {
+  const bindingTarget = federationTargetForBinding(binding);
+  if (!bindingTarget) {
+    return !target || target.scope === "local";
+  }
+  return target?.scope === "remote" &&
+    bindingTarget.scope === "remote" &&
+    bindingTarget.instanceId === target.instanceId;
+}
+
+function federationTargetForThread(
+  thread: NavigationThreadSummary,
+): FederationTarget | undefined {
+  return thread.federation?.ref.target.scope === "remote"
+    ? thread.federation.ref.target
+    : undefined;
+}
+
+function threadKeyForNavigationThread(
+  thread: NavigationThreadSummary,
+): string {
+  return thread.federation
+    ? federatedThreadIdentityKey(thread.federation.ref)
+    : buildThreadIdentityKey(thread.source, thread.id);
 }
 
 function formatAttachmentRejections(
@@ -519,6 +575,7 @@ type FullAccessEscalationContext =
     }
   | {
       backend: AppServerBackendKind;
+      federatedThread?: FederatedThreadRef;
       kind: "resume-thread";
       session: MessagingBrowseSessionRecord;
       threadId: ThreadIdentifier;
@@ -537,6 +594,7 @@ type FullAccessRiskWarningContext =
     }
   | {
       backend: AppServerBackendKind;
+      federationInstanceId?: string;
       kind: "resume-thread";
       sessionId: string;
       threadId: ThreadIdentifier;
@@ -1211,6 +1269,7 @@ export class MessagingController {
         event.backend,
         threadId,
         event.notification.method,
+        event.federationTarget,
       );
       return;
     }
@@ -1221,6 +1280,7 @@ export class MessagingController {
         event.backend,
         threadId,
         event.notification.method,
+        event.federationTarget,
       );
       return;
     }
@@ -1239,6 +1299,7 @@ export class MessagingController {
         event.backend,
         threadId,
         event.notification.method,
+        event.federationTarget,
       );
       return;
     }
@@ -1248,6 +1309,8 @@ export class MessagingController {
         backend: event.backend,
         threadId,
       }),
+    ).filter((binding) =>
+      bindingMatchesFederationTarget(binding, event.federationTarget)
     );
     const bindings = this.bindingsForAgentTurn(
       event.backend,
@@ -1643,12 +1706,15 @@ export class MessagingController {
   async handleBackendPendingRequest(
     backend: AppServerBackendKind,
     request: AppServerPendingRequestNotification,
+    federationTarget?: FederationTarget,
   ): Promise<void> {
     const persistentBindings = this.filterBindingsForChannel(
       await this.options.store.findActiveBindingsForThread({
         backend,
         threadId: request.params.threadId,
       }),
+    ).filter((binding) =>
+      bindingMatchesFederationTarget(binding, federationTarget)
     );
     const bindings = this.bindingsForAgentTurn(
       backend,
@@ -3132,6 +3198,7 @@ export class MessagingController {
       });
       const started = await this.options.backend.startTurn({
         backend: params.binding.backend,
+        federationTarget: federationTargetForBinding(params.binding),
         threadId: params.binding.threadId,
         input: params.input,
         messageOrigin: messageOriginForInboundEvent(params.event),
@@ -3430,6 +3497,7 @@ export class MessagingController {
     try {
       await this.options.backend.steerTurn({
         backend: entry.binding.backend,
+        federationTarget: federationTargetForBinding(entry.binding),
         threadId: entry.binding.threadId,
         expectedTurnId: activeTurn.turnId,
         input: entry.input,
@@ -4378,9 +4446,15 @@ export class MessagingController {
     if (!requestContext || !this.options.backend.submitServerRequest) {
       return;
     }
+    const binding = intent.bindingId
+      ? await this.options.store.getBinding(intent.bindingId)
+      : undefined;
 
     await this.options.backend.submitServerRequest({
       backend: requestContext.backend,
+      federationTarget: binding
+        ? federationTargetForBinding(binding)
+        : undefined,
       threadId: requestContext.threadId,
       turnId: requestContext.turnId,
       requestId: requestContext.requestId,
@@ -4407,9 +4481,15 @@ export class MessagingController {
     if (!requestContext || !action || !this.options.backend.submitServerRequest) {
       return decision;
     }
+    const binding = intent.bindingId
+      ? await this.options.store.getBinding(intent.bindingId)
+      : undefined;
 
     await this.options.backend.submitServerRequest({
       backend: requestContext.backend,
+      federationTarget: binding
+        ? federationTargetForBinding(binding)
+        : undefined,
       threadId: requestContext.threadId,
       turnId: requestContext.turnId,
       requestId: requestContext.requestId,
@@ -4429,12 +4509,15 @@ export class MessagingController {
     backend: AppServerBackendKind,
     threadId: ThreadIdentifier,
     reason: string,
+    federationTarget?: FederationTarget,
   ): Promise<void> {
     const bindings = this.filterBindingsForChannel(
       await this.options.store.findActiveBindingsForThread({
         backend,
         threadId,
       }),
+    ).filter((binding) =>
+      bindingMatchesFederationTarget(binding, federationTarget)
     );
     const renderableBindings = bindings.filter(
       (binding) => binding.statusSurface || binding.pinnedStatusSurface,
@@ -4688,6 +4771,15 @@ export class MessagingController {
     for (const pendingIntent of pendingIntents.filter((intent) =>
       this.isChannelInScope(intent.channel),
     )) {
+      const binding = pendingIntent.bindingId
+        ? await this.options.store.getBinding(pendingIntent.bindingId)
+        : undefined;
+      if (
+        binding &&
+        !bindingMatchesFederationTarget(binding, event.federationTarget)
+      ) {
+        continue;
+      }
       await this.retireApprovalIntent(pendingIntent, undefined, "Resolved");
       await this.options.store.deletePendingIntent(pendingIntent.id);
       await this.resumeBindingForPendingIntent(
@@ -5245,11 +5337,13 @@ export class MessagingController {
       if (readLastAssistantReply) {
         reply = await readLastAssistantReply.call(this.options.backend, {
           backend: binding.backend,
+          federationTarget: federationTargetForBinding(binding),
           threadId: binding.threadId,
         });
       } else if (readLastAssistantMessage) {
         const text = await readLastAssistantMessage.call(this.options.backend, {
           backend: binding.backend,
+          federationTarget: federationTargetForBinding(binding),
           threadId: binding.threadId,
         });
         reply = text ? { text } : undefined;
@@ -6446,7 +6540,10 @@ export class MessagingController {
         return;
       }
       const targetThread = navigation.threads.find(
-        (thread) => thread.source === target.backend && thread.id === target.threadId,
+        (thread) =>
+          thread.source === target.backend &&
+          thread.id === target.threadId &&
+          federationRefsMatch(thread.federation?.ref, target.federatedThread),
       );
       if (session.mode === "agents" && !targetThread?.agent) {
         await this.deliverInvalidBrowseSelection(event);
@@ -6506,6 +6603,7 @@ export class MessagingController {
         const allowed = await this.ensureFullAccessEscalationAllowed(
           {
             backend: target.backend,
+            federatedThread: target.federatedThread,
             kind: "resume-thread",
             session,
             threadId: target.threadId,
@@ -6526,6 +6624,7 @@ export class MessagingController {
       if (shouldEscalateTarget) {
         await this.options.backend.setThreadExecutionMode?.({
           backend: target.backend,
+          federationTarget: target.federatedThread?.target,
           threadId: target.threadId,
           executionMode: "full-access",
         });
@@ -9534,9 +9633,13 @@ export class MessagingController {
     }
     if (actionId === "status:permissions") {
       if (isAcpBackendId(binding.backend)) {
-        const summary = await this.getBackendSummary(binding.backend);
+        const summary = await this.getBackendSummary(
+          binding.backend,
+          federationTargetForBinding(binding),
+        );
         const navigation = await this.options.backend.getNavigationSnapshot({
           backend: "all",
+          federationTarget: federationTargetForBinding(binding),
         });
         const thread = findThreadForBinding(navigation, binding);
         const runtimeMode = buildMessagingAcpRuntimeModeSummary({
@@ -9622,6 +9725,7 @@ export class MessagingController {
       const cwds = skillSearchCwdsForThreadState(threadState);
       const response = await this.options.backend.listSkills({
         backend: binding.backend,
+        federationTarget: federationTargetForBinding(binding),
         ...(cwds.length > 0 ? { cwds: [...new Set(cwds)] } : {}),
       });
       const targetSurface = options.targetSurface ??
@@ -10039,7 +10143,10 @@ export class MessagingController {
     );
 
     try {
-      const result = await this.options.backend.handoffThreadWorkspace(request);
+      const result = await this.options.backend.handoffThreadWorkspace({
+        ...request,
+        federationTarget: federationTargetForBinding(currentBinding),
+      });
       await this.clearActiveHandoffIntent(event);
       const refreshedNavigation = await this.options.backend.getNavigationSnapshot({
         backend: "all",
@@ -10240,7 +10347,15 @@ export class MessagingController {
     binding: MessagingBindingRecord,
     event: MessagingInboundEvent,
   ): Promise<void> {
-    const summary = await this.getBackendSummary(binding.backend);
+    const summary = await this.getBackendSummary(
+      binding.backend,
+      federationTargetForBinding(binding),
+    );
+    const navigation = await this.options.backend.getNavigationSnapshot({
+      backend: "all",
+      federationTarget: federationTargetForBinding(binding),
+    });
+    const thread = findThreadForBinding(navigation, binding);
     const models = summary?.launchpadOptions?.models ?? [];
     if (models.length === 0) {
       await this.deliver(
@@ -10257,10 +10372,6 @@ export class MessagingController {
       return;
     }
 
-    const navigation = await this.options.backend.getNavigationSnapshot({
-      backend: "all",
-    });
-    const thread = findThreadForBinding(navigation, binding);
     const currentModelId =
       thread?.model ??
       binding.preferences?.model ??
@@ -10285,9 +10396,13 @@ export class MessagingController {
     binding: MessagingBindingRecord,
     event: MessagingInboundEvent,
   ): Promise<void> {
-    const summary = await this.getBackendSummary(binding.backend);
+    const summary = await this.getBackendSummary(
+      binding.backend,
+      federationTargetForBinding(binding),
+    );
     const navigation = await this.options.backend.getNavigationSnapshot({
       backend: "all",
+      federationTarget: federationTargetForBinding(binding),
     });
     const thread = findThreadForBinding(navigation, binding);
     const models = summary?.launchpadOptions?.models ?? [];
@@ -10327,7 +10442,10 @@ export class MessagingController {
     binding: MessagingBindingRecord,
     event: MessagingInboundEvent,
   ): Promise<void> {
-    const summary = await this.getBackendSummary(binding.backend);
+    const summary = await this.getBackendSummary(
+      binding.backend,
+      federationTargetForBinding(binding),
+    );
     const navigation = await this.options.backend.getNavigationSnapshot({
       backend: "all",
     });
@@ -10438,9 +10556,13 @@ export class MessagingController {
       return;
     }
 
-    const summary = await this.getBackendSummary(binding.backend);
+    const summary = await this.getBackendSummary(
+      binding.backend,
+      federationTargetForBinding(binding),
+    );
     const navigation = await this.options.backend.getNavigationSnapshot({
       backend: "all",
+      federationTarget: federationTargetForBinding(binding),
     });
     const models = summary?.launchpadOptions?.models ?? [];
     const modelOption = models.find((candidate) => candidate.id === model);
@@ -10451,6 +10573,7 @@ export class MessagingController {
     let updatedBinding = await this.updateBindingPreferences(binding, { model });
     const settingsResponse = await this.options.backend.setThreadModelSettings?.({
       backend: binding.backend,
+      federationTarget: federationTargetForBinding(binding),
       threadId: binding.threadId,
       model,
       fastMode: updatedBinding.preferences?.fastMode,
@@ -10468,7 +10591,9 @@ export class MessagingController {
     const optimisticNavigation: NavigationSnapshot = {
       ...navigation,
       threads: navigation.threads.map((candidate) =>
-        candidate.source === binding.backend && candidate.id === binding.threadId
+        candidate.source === binding.backend &&
+        candidate.id === binding.threadId &&
+        federationRefsMatch(candidate.federation?.ref, binding.federatedThread)
           ? {
               ...candidate,
               model,
@@ -10490,9 +10615,13 @@ export class MessagingController {
       await this.deliverInvalidStatusSelection(event);
       return;
     }
-    const summary = await this.getBackendSummary(binding.backend);
+    const summary = await this.getBackendSummary(
+      binding.backend,
+      federationTargetForBinding(binding),
+    );
     const navigation = await this.options.backend.getNavigationSnapshot({
       backend: "all",
+      federationTarget: federationTargetForBinding(binding),
     });
     const thread = findThreadForBinding(navigation, binding);
     const models = summary?.launchpadOptions?.models ?? [];
@@ -10512,6 +10641,7 @@ export class MessagingController {
     });
     await this.options.backend.setThreadModelSettings?.({
       backend: binding.backend,
+      federationTarget: federationTargetForBinding(binding),
       threadId: binding.threadId,
       fastMode: updatedBinding.preferences?.fastMode,
       model: updatedBinding.preferences?.model,
@@ -10521,7 +10651,9 @@ export class MessagingController {
     const optimisticNavigation: NavigationSnapshot = {
       ...navigation,
       threads: navigation.threads.map((candidate) =>
-        candidate.source === binding.backend && candidate.id === binding.threadId
+        candidate.source === binding.backend &&
+        candidate.id === binding.threadId &&
+        federationRefsMatch(candidate.federation?.ref, binding.federatedThread)
           ? { ...candidate, reasoningEffort }
           : candidate,
       ),
@@ -10546,9 +10678,13 @@ export class MessagingController {
       return;
     }
 
-    const summary = await this.getBackendSummary(binding.backend);
+    const summary = await this.getBackendSummary(
+      binding.backend,
+      federationTargetForBinding(binding),
+    );
     const navigation = await this.options.backend.getNavigationSnapshot({
       backend: "all",
+      federationTarget: federationTargetForBinding(binding),
     });
     const thread = findThreadForBinding(navigation, binding);
     const currentRuntime = thread?.acpRuntime ?? binding.preferences?.acpRuntime;
@@ -10625,6 +10761,7 @@ export class MessagingController {
     });
     await this.options.backend.setAcpSessionRuntimeOption({
       backend: binding.backend,
+      federationTarget: federationTargetForBinding(binding),
       threadId: binding.threadId,
       source: selection.source,
       optionId: selection.optionId,
@@ -10633,7 +10770,9 @@ export class MessagingController {
     const optimisticNavigation: NavigationSnapshot = {
       ...navigation,
       threads: navigation.threads.map((candidate) =>
-        candidate.source === binding.backend && candidate.id === binding.threadId
+        candidate.source === binding.backend &&
+        candidate.id === binding.threadId &&
+        federationRefsMatch(candidate.federation?.ref, binding.federatedThread)
           ? { ...candidate, acpRuntime }
           : candidate,
       ),
@@ -10646,7 +10785,10 @@ export class MessagingController {
     binding: MessagingBindingRecord,
     event: MessagingInboundEvent,
   ): Promise<void> {
-    const summary = await this.getBackendSummary(binding.backend);
+    const summary = await this.getBackendSummary(
+      binding.backend,
+      federationTargetForBinding(binding),
+    );
     if (
       summary &&
       (summary.kind !== "codex" || summary.launchpadOptions?.supportsFastMode === false)
@@ -10660,6 +10802,7 @@ export class MessagingController {
     });
     await this.options.backend.setThreadModelSettings?.({
       backend: binding.backend,
+      federationTarget: federationTargetForBinding(binding),
       threadId: binding.threadId,
       fastMode,
       model: updatedBinding.preferences?.model,
@@ -10720,6 +10863,7 @@ export class MessagingController {
     });
     await this.options.backend.setThreadExecutionMode?.({
       backend: binding.backend,
+      federationTarget: federationTargetForBinding(binding),
       threadId: binding.threadId,
       executionMode,
     });
@@ -10770,6 +10914,7 @@ export class MessagingController {
     await this.clearActiveBindingSubmodeIntent(event, binding);
     await this.options.backend.setThreadExecutionMode?.({
       backend: binding.backend,
+      federationTarget: federationTargetForBinding(binding),
       threadId: binding.threadId,
       executionMode,
     });
@@ -10944,6 +11089,12 @@ export class MessagingController {
           }
           : {
               backend: context.backend,
+              ...(context.federatedThread?.target.scope === "remote"
+                ? {
+                    federationInstanceId:
+                      context.federatedThread.target.instanceId,
+                  }
+                : {}),
               kind: "resume-thread",
               sessionId: context.session.id,
               threadId: context.threadId,
@@ -11160,6 +11311,7 @@ export class MessagingController {
       const { session } = escalationContext;
       const target = {
         backend: escalationContext.backend,
+        federatedThread: escalationContext.federatedThread,
         threadId: escalationContext.threadId,
       };
       const binding = await this.bindChannelToThread(event, target);
@@ -11172,6 +11324,7 @@ export class MessagingController {
       const updatedBinding = await this.updateBindingPreferences(binding, preferences);
       await this.options.backend.setThreadExecutionMode?.({
         backend: escalationContext.backend,
+        federationTarget: escalationContext.federatedThread?.target,
         threadId: escalationContext.threadId,
         executionMode: "full-access",
       });
@@ -11212,6 +11365,7 @@ export class MessagingController {
     await this.clearActiveBindingSubmodeIntent(event, binding);
     await this.options.backend.setThreadExecutionMode?.({
       backend: binding.backend,
+      federationTarget: federationTargetForBinding(binding),
       threadId: escalationContext.threadId,
       executionMode: "full-access",
     });
@@ -11335,6 +11489,15 @@ export class MessagingController {
       }
       return {
         backend: context.backend,
+        ...(context.federationInstanceId
+          ? {
+              federatedThread: buildFederatedThreadRef({
+                backend: context.backend,
+                instanceId: context.federationInstanceId,
+                threadId: context.threadId,
+              }),
+            }
+          : {}),
         kind: "resume-thread",
         session,
         threadId: context.threadId,
@@ -11578,6 +11741,7 @@ export class MessagingController {
     try {
       await this.options.backend.cancelThreadExecutionModeQueue({
         backend: binding.backend,
+        federationTarget: federationTargetForBinding(binding),
         threadId: binding.threadId,
       });
     } catch (error) {
@@ -11616,6 +11780,7 @@ export class MessagingController {
     }
     await this.options.backend.interruptTurn?.({
       backend: binding.backend,
+      federationTarget: federationTargetForBinding(binding),
       threadId: binding.threadId,
       turnId: targetTurn.turnId,
     });
@@ -11657,6 +11822,7 @@ export class MessagingController {
 
     const compacted = await this.options.backend.compactThread({
       backend: binding.backend,
+      federationTarget: federationTargetForBinding(binding),
       threadId: binding.threadId,
     });
     const activeTurn: MessagingActiveTurnSummary = {
@@ -11857,9 +12023,13 @@ export class MessagingController {
     });
   }
 
-  private async getBackendSummary(backend: AppServerBackendKind) {
+  private async getBackendSummary(
+    backend: AppServerBackendKind,
+    federationTarget?: FederationTarget,
+  ) {
     const response = await this.options.backend.listBackends?.({
       includeUnavailable: true,
+      federationTarget,
     });
     return response?.backends.find((candidate) => candidate.kind === backend);
   }
@@ -11895,7 +12065,15 @@ export class MessagingController {
       return;
     }
     this.contextUsageSummariesByThreadKey.set(
-      buildThreadIdentityKey(event.backend, params.threadId),
+      event.federationTarget?.scope === "remote"
+        ? federatedThreadIdentityKey(
+            buildFederatedThreadRef({
+              backend: event.backend,
+              instanceId: event.federationTarget.instanceId,
+              threadId: params.threadId,
+            }),
+          )
+        : buildThreadIdentityKey(event.backend, params.threadId),
       summary,
     );
   }
@@ -11904,7 +12082,7 @@ export class MessagingController {
     binding: MessagingBindingRecord,
   ): string | undefined {
     return this.contextUsageSummariesByThreadKey.get(
-      buildThreadIdentityKey(binding.backend, binding.threadId),
+      this.threadKeyForBinding(binding),
     );
   }
 
@@ -12218,7 +12396,10 @@ export class MessagingController {
       binding,
       "status_refresh",
     );
-    const backendSummary = await this.getBackendSummary(binding.backend);
+    const backendSummary = await this.getBackendSummary(
+      binding.backend,
+      federationTargetForBinding(binding),
+    );
     const intent = buildBindingStatusIntent({
       id: this.newIntentId("status"),
       allowFullAccessEscalation: (await this.resolveFullAccessControls())
@@ -12560,11 +12741,12 @@ export class MessagingController {
     const threads = selectMonitorThreads({ monitor, navigation }).threads;
     await Promise.all(
       threads.map(async (thread) => {
-        const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+        const threadKey = threadKeyForNavigationThread(thread);
         const existing = activeTurns.get(threadKey);
         try {
           const status = await this.options.backend.readThreadStatus?.({
             backend: thread.source,
+            federationTarget: federationTargetForThread(thread),
             threadId: thread.id,
           });
           if (status === "active") {
@@ -12611,11 +12793,12 @@ export class MessagingController {
     const threads = selectMonitorThreads({ monitor, navigation }).threads;
     await Promise.all(
       threads.map(async (thread) => {
-        const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+        const threadKey = threadKeyForNavigationThread(thread);
         try {
           const text =
             await this.options.backend.readThreadLastAssistantMessage?.({
               backend: thread.source,
+              federationTarget: federationTargetForThread(thread),
               threadId: thread.id,
             });
           const trimmed = text?.trim();
@@ -12694,6 +12877,7 @@ export class MessagingController {
 
     const backendTurn = await this.options.backend.readActiveTurn?.({
       backend: binding.backend,
+      federationTarget: federationTargetForBinding(binding),
       threadId: binding.threadId,
     });
     if (!backendTurn?.turnId) {
@@ -12768,6 +12952,7 @@ export class MessagingController {
   ): Promise<string | undefined> {
     return await this.options.backend.readThreadStatus?.({
       backend: binding.backend,
+      federationTarget: federationTargetForBinding(binding),
       threadId: binding.threadId,
     });
   }
@@ -13343,6 +13528,7 @@ export class MessagingController {
     event: MessagingInboundEvent,
     target: {
       backend: AppServerBackendKind;
+      federatedThread?: FederatedThreadRef;
       threadId: ThreadIdentifier;
       targetKind?: MessagingBindingRecord["targetKind"];
     },
@@ -13351,12 +13537,16 @@ export class MessagingController {
     const previousBinding = await this.options.store.findActiveBindingForChannel(
       event.channel,
     );
+    const targetIdentity = target.federatedThread
+      ? federatedThreadIdentityKey(target.federatedThread)
+      : buildThreadIdentityKey(target.backend, target.threadId);
     const binding: MessagingBindingRecord = {
-      id: `binding:${buildMessagingConversationKey(event.channel)}:${target.backend}:${target.threadId}`,
+      id: `binding:${buildMessagingConversationKey(event.channel)}:${targetIdentity}`,
       channel: event.channel,
       targetKind: target.targetKind ?? "thread",
       backend: target.backend,
       threadId: target.threadId,
+      federatedThread: target.federatedThread,
       authorizedActorIds: [event.actor.platformUserId],
       routingState: event.routingState,
       createdAt: now,
@@ -13367,7 +13557,11 @@ export class MessagingController {
       previousBinding &&
       (previousBinding.id !== binding.id ||
         previousBinding.backend !== binding.backend ||
-        previousBinding.threadId !== binding.threadId)
+        previousBinding.threadId !== binding.threadId ||
+        !federationRefsMatch(
+          previousBinding.federatedThread,
+          binding.federatedThread,
+        ))
     ) {
       await this.options.store.revokeBinding({
         bindingId: previousBinding.id,
@@ -13378,14 +13572,22 @@ export class MessagingController {
     if (
       previousBinding &&
       (previousBinding.backend !== upserted.backend ||
-        previousBinding.threadId !== upserted.threadId)
+        previousBinding.threadId !== upserted.threadId ||
+        !federationRefsMatch(
+          previousBinding.federatedThread,
+          upserted.federatedThread,
+        ))
     ) {
       await this.recordBindingTransition("unbound", previousBinding, now);
     }
     if (
       !previousBinding ||
       previousBinding.backend !== upserted.backend ||
-      previousBinding.threadId !== upserted.threadId
+      previousBinding.threadId !== upserted.threadId ||
+      !federationRefsMatch(
+        previousBinding.federatedThread,
+        upserted.federatedThread,
+      )
     ) {
       await this.recordBindingTransition("bound", upserted, now);
     }
@@ -15309,6 +15511,9 @@ function readFullAccessRiskContext(
   ) {
     return {
       backend: value.backend,
+      ...(typeof value.federationInstanceId === "string"
+        ? { federationInstanceId: value.federationInstanceId }
+        : {}),
       kind: "resume-thread",
       sessionId: value.sessionId,
       threadId: value.threadId,
@@ -17981,7 +18186,11 @@ function isStreamFallbackText(text: string): boolean {
 
 function readBindingTarget(
   event: MessagingInboundCallbackEvent,
-): { backend: AppServerBackendKind; threadId: ThreadIdentifier } | undefined {
+): {
+  backend: AppServerBackendKind;
+  federatedThread?: FederatedThreadRef;
+  threadId: ThreadIdentifier;
+} | undefined {
   const fromValue = readBindingTargetFromValue(event.value);
   if (fromValue) {
     return fromValue;
@@ -18005,16 +18214,30 @@ function readBindingTarget(
 
 function readBindingTargetFromValue(
   value: MessagingJsonValue | undefined,
-): { backend: AppServerBackendKind; threadId: ThreadIdentifier } | undefined {
+): {
+  backend: AppServerBackendKind;
+  federatedThread?: FederatedThreadRef;
+  threadId: ThreadIdentifier;
+} | undefined {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return undefined;
   }
 
   const backend = value.backend;
+  const federationInstanceId = value.federationInstanceId;
   const threadId = value.threadId;
   if (typeof backend === "string" && isAppServerBackendKind(backend) && typeof threadId === "string") {
     return {
       backend,
+      ...(typeof federationInstanceId === "string"
+        ? {
+            federatedThread: buildFederatedThreadRef({
+              backend,
+              instanceId: federationInstanceId,
+              threadId,
+            }),
+          }
+        : {}),
       threadId,
     };
   }

--- a/apps/desktop/src/main/messaging/core/messaging-resume-browser.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-resume-browser.ts
@@ -1,5 +1,6 @@
 import type {
   AppServerBackendKind,
+  FederatedThreadRef,
   NavigationDirectorySummary,
   NavigationSnapshot,
   NavigationThreadSummary,
@@ -17,7 +18,12 @@ import type {
   MessagingSurfaceAction,
   MessagingThreadPickerIntent,
 } from "@pwragent/messaging-interface";
-import { buildThreadIdentityKey, isAppServerBackendKind } from "@pwragent/shared";
+import {
+  buildFederatedThreadRef,
+  buildThreadIdentityKey,
+  federatedThreadIdentityKey,
+  isAppServerBackendKind,
+} from "@pwragent/shared";
 import type { MessagingCapabilityProfile } from "@pwragent/messaging-interface";
 import { capabilityProfilePageSize } from "@pwragent/messaging-interface";
 
@@ -49,6 +55,7 @@ export type ParsedResumeCommand = {
 
 export type ResumeBrowserThreadSelection = {
   backend: AppServerBackendKind;
+  federatedThread?: FederatedThreadRef;
   threadId: ThreadIdentifier;
 };
 
@@ -190,6 +197,15 @@ export function selectThreadFromValue(
 
   return {
     backend: value.backend,
+    ...(typeof value.federationInstanceId === "string"
+      ? {
+          federatedThread: buildFederatedThreadRef({
+            backend: value.backend,
+            instanceId: value.federationInstanceId,
+            threadId: value.threadId,
+          }),
+        }
+      : {}),
     threadId: value.threadId,
   };
 }
@@ -235,6 +251,12 @@ function buildThreadPickerIntent(params: {
       fallbackText: String(index + 1),
       value: {
         backend: thread.source,
+        ...(thread.federation?.ref.target.scope === "remote"
+          ? {
+              federationInstanceId:
+                thread.federation.ref.target.instanceId,
+            }
+          : {}),
         threadId: thread.id,
       },
     })),
@@ -346,7 +368,11 @@ function threadsForSession(
   if (selectedDirectory) {
     const threadKeys = new Set(selectedDirectory.threadKeys);
     threads = threads.filter((thread) =>
-      threadKeys.has(buildThreadIdentityKey(thread.source, thread.id)),
+      threadKeys.has(
+        thread.federation
+          ? federatedThreadIdentityKey(thread.federation.ref)
+          : buildThreadIdentityKey(thread.source, thread.id),
+      ),
     );
   }
 
@@ -765,7 +791,10 @@ function formatThreadLabel(thread: NavigationThreadSummary): string {
   const directory = thread.linkedDirectories.find((item) => item.kind === "worktree") ??
     thread.linkedDirectories[0];
   const suffix = directory?.label ? ` (${directory.label})` : "";
-  return `${thread.title}${suffix}`;
+  const instancePrefix = thread.federation
+    ? `[${thread.federation.instanceLabel}] `
+    : "";
+  return `${instancePrefix}${thread.title}${suffix}`;
 }
 
 function formatControlList(controls: Array<string | undefined>): string {

--- a/apps/desktop/src/main/messaging/core/messaging-store.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-store.ts
@@ -18,6 +18,10 @@ import type {
 } from "@pwragent/messaging-interface";
 import { normalizeMessagingBindingTargetKind } from "@pwragent/shared";
 import {
+  federatedThreadIdentityKey,
+  type FederatedThreadRef,
+} from "@pwragent/shared";
+import {
   CURRENT_MESSAGING_STORE_VERSION,
   migrateMessagingStoreData,
   type MessagingDeliveryRecord,
@@ -238,6 +242,22 @@ export class MessagingStore {
             !binding.revokedAt &&
             binding.backend === params.backend &&
             binding.threadId === params.threadId,
+        )
+        .map((binding) => structuredClone(binding)),
+    );
+  }
+
+  async findActiveBindingsForFederatedThread(
+    ref: FederatedThreadRef,
+  ): Promise<MessagingBindingRecord[]> {
+    const wanted = federatedThreadIdentityKey(ref);
+    return await this.withReadData((data) =>
+      Object.values(data.bindings)
+        .filter(
+          (binding) =>
+            !binding.revokedAt &&
+            binding.federatedThread !== undefined &&
+            federatedThreadIdentityKey(binding.federatedThread) === wanted,
         )
         .map((binding) => structuredClone(binding)),
     );

--- a/apps/desktop/src/main/messaging/core/messaging-turn-admission.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-turn-admission.ts
@@ -9,7 +9,11 @@ import type {
   MessagingInboundTextEvent,
   MessagingSurfaceRef,
 } from "@pwragent/messaging-interface";
-import { buildThreadIdentityKey } from "@pwragent/shared";
+import {
+  buildThreadIdentityKey,
+  federatedThreadIdentityKey,
+  isRemoteFederationTarget,
+} from "@pwragent/shared";
 import type { PendingPdfAttachment } from "../../pdf/pdf-attachment-store";
 
 export type MessagingTurnInputEvent =
@@ -241,5 +245,8 @@ function pendingKeyForActor(threadKey: string, platformUserId: string): string {
 }
 
 export function threadKeyForBinding(binding: MessagingBindingRecord): string {
-  return buildThreadIdentityKey(binding.backend, binding.threadId);
+  return binding.federatedThread &&
+    isRemoteFederationTarget(binding.federatedThread.target)
+    ? federatedThreadIdentityKey(binding.federatedThread)
+    : buildThreadIdentityKey(binding.backend, binding.threadId);
 }

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -14,6 +14,8 @@ import type {
   CompactThreadResponse,
   EnsureDirectoryLaunchpadRequest,
   EnsureDirectoryLaunchpadResponse,
+  FederationRemoteTarget,
+  FederationTarget,
   GetNavigationSnapshotRequest,
   HandoffThreadWorkspaceRequest,
   HandoffThreadWorkspaceResponse,
@@ -45,6 +47,7 @@ import type {
   UpdateDirectoryLaunchpadResponse,
 } from "@pwragent/shared";
 import type { MessagingImagePart } from "@pwragent/messaging-interface";
+import { isRemoteFederationTarget } from "@pwragent/shared";
 import type {
   MessagingBackendBridge,
   MessagingLastAssistantReply,
@@ -55,6 +58,22 @@ import { getDesktopOverlayStore } from "../app-server/desktop-overlay-store";
 import { resolveScratchProjectsRoots } from "../app-server/scratch-projects";
 import { buildMessagingBindingsByThreadKey } from "./messaging-bindings-snapshot";
 import { materializeTranscriptMessageImagesForMessaging } from "../transcript-image-protocol";
+import type { FederationBackendOperations } from "../federation/federation-backend-bridge";
+
+export type DesktopMessagingFederationBridge = {
+  connectedPeerTargets(): Array<{
+    target: FederationRemoteTarget;
+    label: string;
+  }>;
+  onRemoteBackendEvent(
+    listener: (event: AgentEvent) => void | Promise<void>,
+  ): () => void;
+  remoteBackend(target: FederationRemoteTarget): FederationBackendOperations;
+  remoteNavigationSnapshot(
+    target: FederationRemoteTarget,
+    request: GetNavigationSnapshotRequest,
+  ): Promise<NavigationSnapshot>;
+};
 
 export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
   private readonly assistantImageResolutions = new Map<
@@ -64,11 +83,22 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
 
   constructor(
     private readonly registry: DesktopBackendRegistry = getDesktopBackendRegistry(),
+    private readonly federation?: DesktopMessagingFederationBridge,
   ) {}
 
   async getNavigationSnapshot(
     request: GetNavigationSnapshotRequest = {},
   ): Promise<NavigationSnapshot> {
+    if (
+      request.federationTarget &&
+      isRemoteFederationTarget(request.federationTarget) &&
+      this.federation
+    ) {
+      return await this.federation.remoteNavigationSnapshot(
+        request.federationTarget,
+        request,
+      );
+    }
     const backend = request.backend ?? "all";
     const threads = await this.registry.listThreads({
       backend: backend === "all" ? undefined : backend,
@@ -101,30 +131,58 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
       snapshot.directories,
     );
 
-    return {
+    const localSnapshot: NavigationSnapshot = {
       ...snapshot,
       directories: snapshot.directories.map((directory) => ({
         ...directory,
         gitStatus: directoryStatuses[directory.key],
       })),
     };
+    if (!this.federation) {
+      return localSnapshot;
+    }
+    const remoteSnapshots = await Promise.allSettled(
+      this.federation.connectedPeerTargets().map(({ target }) =>
+        this.federation!.remoteNavigationSnapshot(target, request)
+      ),
+    );
+    const availableRemoteSnapshots = remoteSnapshots.flatMap((result) =>
+      result.status === "fulfilled" ? [result.value] : []
+    );
+    return {
+      ...localSnapshot,
+      fetchedAt: Math.max(
+        localSnapshot.fetchedAt,
+        ...availableRemoteSnapshots.map((remote) => remote.fetchedAt),
+      ),
+      unchanged: false,
+      threads: [
+        ...localSnapshot.threads,
+        ...availableRemoteSnapshots.flatMap((remote) => remote.threads),
+      ],
+      inboxThreadKeys: [
+        ...localSnapshot.inboxThreadKeys,
+        ...availableRemoteSnapshots.flatMap((remote) => remote.inboxThreadKeys),
+      ],
+    };
   }
 
   async readThreadStatus(request: {
     backend: AppServerBackendKind;
+    federationTarget?: FederationTarget;
     threadId: string;
   }): Promise<AppServerThreadStatus | undefined> {
-    const response = await this.registry.readThread({
-      backend: request.backend,
+    const response = await this.readThread({
+      ...request,
       includeTurns: false,
       limit: 0,
-      threadId: request.threadId,
     });
     return response.threadStatus ?? response.replay.threadStatus;
   }
 
   async readActiveTurn(request: {
     backend: AppServerBackendKind;
+    federationTarget?: FederationTarget;
     threadId: string;
   }): Promise<
     | {
@@ -134,11 +192,31 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
       }
     | undefined
   > {
+    if (this.remoteBackend(request.federationTarget)) {
+      const response = await this.readThread({
+        ...request,
+        includeTurns: true,
+        limit: 20,
+      });
+      const status = response.threadStatus ?? response.replay.threadStatus;
+      if (status !== "active") return undefined;
+      const entry = [...response.replay.entries]
+        .reverse()
+        .find((candidate) => candidate.turn?.id);
+      return entry?.turn?.id
+        ? {
+            backend: request.backend,
+            threadId: request.threadId,
+            turnId: entry.turn.id,
+          }
+        : undefined;
+    }
     return this.registry.getActiveTurnForThread(request);
   }
 
   async readThreadLastAssistantMessage(request: {
     backend: AppServerBackendKind;
+    federationTarget?: FederationTarget;
     threadId: string;
   }): Promise<string | undefined> {
     return (await this.readThreadLastAssistantReply(request))?.text;
@@ -146,12 +224,12 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
 
   async readThreadLastAssistantReply(request: {
     backend: AppServerBackendKind;
+    federationTarget?: FederationTarget;
     threadId: string;
   }): Promise<MessagingLastAssistantReply | undefined> {
-    const response = await this.registry.readThread({
-      backend: request.backend,
+    const response = await this.readThread({
+      ...request,
       limit: 20,
-      threadId: request.threadId,
     });
     const entryReply = findLastAssistantEntryReply(response.replay);
     const messageReply = findLastAssistantMessageReply(response.replay);
@@ -262,6 +340,12 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
   async handoffThreadWorkspace(
     request: HandoffThreadWorkspaceRequest,
   ): Promise<HandoffThreadWorkspaceResponse> {
+    const remote = this.remoteBackend(request.federationTarget);
+    if (remote) {
+      return await remote.handoffThreadWorkspace(
+        stripFederationTarget(request),
+      );
+    }
     return await this.registry.handoffThreadWorkspace(request);
   }
 
@@ -275,6 +359,12 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
     request: MaterializeDirectoryLaunchpadRequest,
     options?: MaterializeDirectoryLaunchpadOptions,
   ): Promise<MaterializeDirectoryLaunchpadResponse> {
+    const remote = this.remoteBackend(request.federationTarget);
+    if (remote) {
+      return await remote.materializeDirectoryLaunchpad(
+        stripFederationTarget(request),
+      );
+    }
     return await this.registry.materializeDirectoryLaunchpad(request, options);
   }
 
@@ -287,6 +377,10 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
   async startTurn(
     request: StartTurnRequest & { messageOrigin?: AppServerThreadMessageOrigin },
   ): Promise<StartTurnResponse> {
+    const remote = this.remoteBackend(request.federationTarget);
+    if (remote) {
+      return await remote.startTurn(stripFederationTarget(request));
+    }
     const submitted = await this.registry.submitTurn({
       ...request,
       origin: "messaging",
@@ -319,12 +413,23 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
         invokingTurnId: string;
       }
   > {
+    const remote = this.remoteBackend(request.federationTarget);
+    if (remote) {
+      return {
+        status: "started",
+        response: await remote.startReview(stripFederationTarget(request)),
+      };
+    }
     return await this.registry.submitReview(request);
   }
 
   async steerTurn(
     request: SteerTurnRequest & { messageOrigin?: AppServerThreadMessageOrigin },
   ): Promise<SteerTurnResponse> {
+    const remote = this.remoteBackend(request.federationTarget);
+    if (remote) {
+      return await remote.steerTurn(stripFederationTarget(request));
+    }
     return await this.registry.steerTurn(
       request,
       request.messageOrigin ?? { kind: "messaging" },
@@ -332,48 +437,92 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
   }
 
   async startThread(request: StartThreadRequest): Promise<StartThreadResponse> {
+    const remote = this.remoteBackend(request.federationTarget);
+    if (remote) {
+      return await remote.startThread(stripFederationTarget(request));
+    }
     return await this.registry.startThread(request);
   }
 
   async compactThread(request: CompactThreadRequest): Promise<CompactThreadResponse> {
+    const remote = this.remoteBackend(request.federationTarget);
+    if (remote) {
+      return await remote.compactThread(stripFederationTarget(request));
+    }
     return await this.registry.compactThread(request);
   }
 
   async interruptTurn(request: InterruptTurnRequest): Promise<InterruptTurnResponse> {
+    const remote = this.remoteBackend(request.federationTarget);
+    if (remote) {
+      return await remote.interruptTurn(stripFederationTarget(request));
+    }
     return await this.registry.interruptTurn(request);
   }
 
   async listSkills(
     request: AppServerListSkillsRequest = {},
   ): Promise<Pick<AppServerListSkillsResponse, "data">> {
+    const remote = this.remoteBackend(request.federationTarget);
+    if (remote) {
+      return await remote.listSkills(stripFederationTarget(request));
+    }
     return await this.registry.listSkills(request);
   }
 
   async listBackends(request: ListBackendsRequest = {}): Promise<ListBackendsResponse> {
+    const remote = this.remoteBackend(request.federationTarget);
+    if (remote) {
+      return await remote.listBackends(stripFederationTarget(request));
+    }
     return await this.registry.listBackends(request);
   }
 
   async setThreadExecutionMode(
     request: SetThreadExecutionModeRequest,
   ): Promise<SetThreadExecutionModeResponse> {
+    const remote = this.remoteBackend(request.federationTarget);
+    if (remote) {
+      return await remote.setThreadExecutionMode(
+        stripFederationTarget(request),
+      );
+    }
     return await this.registry.setThreadExecutionMode(request);
   }
 
   async setAcpSessionRuntimeOption(
     request: SetAcpSessionRuntimeOptionRequest,
   ): Promise<SetAcpSessionRuntimeOptionResponse> {
+    const remote = this.remoteBackend(request.federationTarget);
+    if (remote) {
+      return await remote.setAcpSessionRuntimeOption(
+        stripFederationTarget(request),
+      );
+    }
     return await this.registry.setAcpSessionRuntimeOption(request);
   }
 
   async cancelThreadExecutionModeQueue(
     request: CancelThreadExecutionModeQueueRequest,
   ): Promise<CancelThreadExecutionModeQueueResponse> {
+    const remote = this.remoteBackend(request.federationTarget);
+    if (remote) {
+      return await remote.cancelThreadExecutionModeQueue(
+        stripFederationTarget(request),
+      );
+    }
     return await this.registry.cancelThreadExecutionModeQueue(request);
   }
 
   async setThreadModelSettings(
     request: SetThreadModelSettingsRequest,
   ): Promise<SetThreadModelSettingsResponse> {
+    const remote = this.remoteBackend(request.federationTarget);
+    if (remote) {
+      return await remote.setThreadModelSettings(
+        stripFederationTarget(request),
+      );
+    }
     return await this.registry.setThreadModelSettings(request);
   }
 
@@ -388,12 +537,54 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
   async submitServerRequest(
     request: SubmitServerRequestRequest,
   ): Promise<SubmitServerRequestResponse> {
+    const remote = this.remoteBackend(request.federationTarget);
+    if (remote) {
+      return await remote.submitServerRequest(
+        stripFederationTarget(request),
+      );
+    }
     return await this.registry.submitServerRequest(request);
   }
 
   onEvent(listener: (event: AgentEvent) => void | Promise<void>): () => void {
-    return this.registry.onEvent(listener);
+    const unsubscribeLocal = this.registry.onEvent(listener);
+    const unsubscribeRemote = this.federation?.onRemoteBackendEvent(listener);
+    return () => {
+      unsubscribeLocal();
+      unsubscribeRemote?.();
+    };
   }
+
+  private remoteBackend(
+    target: FederationTarget | undefined,
+  ): FederationBackendOperations | undefined {
+    return target &&
+      isRemoteFederationTarget(target) &&
+      this.federation
+      ? this.federation.remoteBackend(target)
+      : undefined;
+  }
+
+  private async readThread(request: {
+    backend: AppServerBackendKind;
+    federationTarget?: FederationTarget;
+    threadId: string;
+    includeTurns?: boolean;
+    limit?: number;
+  }) {
+    const remote = this.remoteBackend(request.federationTarget);
+    if (remote) {
+      return await remote.readThread(stripFederationTarget(request));
+    }
+    return await this.registry.readThread(request);
+  }
+}
+
+function stripFederationTarget<T extends { federationTarget?: FederationTarget }>(
+  request: T,
+): Omit<T, "federationTarget"> {
+  const { federationTarget: _federationTarget, ...localRequest } = request;
+  return localRequest;
 }
 
 function findAssistantMessageForText(

--- a/apps/desktop/src/main/messaging/federated-messaging-routing.ts
+++ b/apps/desktop/src/main/messaging/federated-messaging-routing.ts
@@ -1,0 +1,23 @@
+import type { MessagingBindingRecord } from "@pwragent/messaging-interface";
+import type { FederatedThreadRef } from "@pwragent/shared";
+import {
+  buildFederatedThreadRef,
+  isRemoteFederationTarget,
+} from "@pwragent/shared";
+
+export function federatedThreadRefForMessagingBinding(
+  binding: MessagingBindingRecord,
+): FederatedThreadRef {
+  return binding.federatedThread ?? buildFederatedThreadRef({
+    backend: binding.backend,
+    threadId: binding.threadId,
+  });
+}
+
+export function messagingBindingTargetsRemoteInstance(
+  binding: MessagingBindingRecord,
+): boolean {
+  return isRemoteFederationTarget(
+    federatedThreadRefForMessagingBinding(binding).target,
+  );
+}

--- a/apps/desktop/src/main/messaging/messaging-bindings-snapshot.ts
+++ b/apps/desktop/src/main/messaging/messaging-bindings-snapshot.ts
@@ -2,7 +2,10 @@ import type {
   AppServerThreadSummary,
   MessagingThreadBindingSummary,
 } from "@pwragent/shared";
-import { buildThreadIdentityKey } from "@pwragent/shared";
+import {
+  buildThreadIdentityKey,
+  isRemoteFederationTarget,
+} from "@pwragent/shared";
 import { getDesktopMessagingStore } from "./desktop-messaging-store";
 import { getMainLogger } from "../log";
 
@@ -41,6 +44,11 @@ export async function buildMessagingBindingsByThreadKey(
         backend: thread.source,
         threadId: thread.id,
       });
+      bindings = bindings.filter(
+        (binding) =>
+          !binding.federatedThread ||
+          !isRemoteFederationTarget(binding.federatedThread.target),
+      );
     } catch (error) {
       log.warn("failed to resolve bindings for thread", {
         backend: thread.source,

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -72,6 +72,7 @@ import {
   type DesktopMessagingChannelConfigUpdate,
 } from "./messaging-config";
 import { DesktopMessagingBackendBridge } from "./desktop-backend-bridge";
+import { getDesktopFederationRuntime } from "../federation/federation-runtime";
 import { getDesktopMessagingActivityLog } from "./desktop-messaging-activity-log";
 import {
   hasActiveInboundPreview,
@@ -1336,6 +1337,7 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
               await controller.handleBackendPendingRequest(
                 event.backend,
                 event.notification,
+                event.federationTarget,
               );
             } else {
               await controller.handleBackendEvent(event);
@@ -2193,7 +2195,10 @@ export function getDesktopMessagingRuntime(
   if (!runtime) {
     runtime = new DesktopMessagingRuntime({
       adapterFactory: createConfiguredAdapters,
-      backendBridge: new DesktopMessagingBackendBridge(),
+      backendBridge: new DesktopMessagingBackendBridge(
+        undefined,
+        getDesktopFederationRuntime(),
+      ),
       config: config ?? (() => loadDesktopMessagingConfig()),
       automationInboundHandler: (event) =>
         getDesktopAutomationService().handleMessagingInboundEvent(event),

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -2223,7 +2223,9 @@ function readHotCpuProfileTriggerMode(
 function readFederationMode(
   value: TomlScalar | undefined,
 ): DesktopFederationMode | undefined {
-  if (value === "child") return "client";
+  if (value === "child") {
+    return "client";
+  }
   return typeof value === "string" && isDesktopFederationMode(value)
     ? value
     : undefined;

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -7,6 +7,7 @@ import type {
   DesktopChatReplyComposer,
   DesktopAuthorizedContact,
   DesktopCodexProfileModel,
+  DesktopFederationMode,
   DesktopHotCpuProfileStartDelayMs,
   DesktopHotCpuProfileTriggerMode,
   DesktopIntegratedTerminalWindowsShell,
@@ -31,11 +32,13 @@ import {
   DESKTOP_APPEARANCE_DENSITY_DEFAULT,
   DESKTOP_APPEARANCE_THEME_DEFAULT,
   DESKTOP_CODEX_PROFILE_MODEL_DEFAULT,
+  DESKTOP_FEDERATION_MODE_DEFAULT,
   DESKTOP_INTEGRATED_TERMINAL_WINDOWS_SHELL_DEFAULT,
   DESKTOP_UPDATE_CHANNEL_DEFAULT,
   isDesktopAppearanceDensity,
   isDesktopAppearanceTheme,
   isDesktopCodexProfileModel,
+  isDesktopFederationMode,
   isDesktopHotCpuProfileStartDelayMs,
   isDesktopHotCpuProfileTriggerMode,
   isDesktopIntegratedTerminalWindowsShell,
@@ -134,6 +137,15 @@ export type DesktopSettingsConfig = {
     activeContextTab?: string;
     editedFilesDock?: string;
     actionRunsDock?: string;
+  };
+  federation?: {
+    mode?: DesktopFederationMode;
+    listenHost?: string;
+    listenPort?: number;
+    publicUrl?: string;
+    gatewayUrl?: string;
+    cloudflareMtlsEnabled?: boolean;
+    cloudflareAccessServiceAuthEnabled?: boolean;
   };
   messaging?: {
     enabled?: boolean;
@@ -897,6 +909,62 @@ export function desktopSettingsPatchToEdits(
     }
   }
 
+  if (patch.federation?.mode !== undefined) {
+    if (patch.federation.mode === DESKTOP_FEDERATION_MODE_DEFAULT) {
+      edits.push({ op: "delete", path: ["federation", "mode"] });
+    } else {
+      set(["federation", "mode"], patch.federation.mode);
+    }
+  }
+  if (patch.federation?.listenHost !== undefined) {
+    if (patch.federation.listenHost.trim() === "") {
+      edits.push({ op: "delete", path: ["federation", "listen_host"] });
+    } else {
+      set(["federation", "listen_host"], patch.federation.listenHost);
+    }
+  }
+  if (patch.federation?.listenPort !== undefined) {
+    if (patch.federation.listenPort === 0) {
+      edits.push({ op: "delete", path: ["federation", "listen_port"] });
+    } else {
+      set(["federation", "listen_port"], patch.federation.listenPort);
+    }
+  }
+  if (patch.federation?.publicUrl !== undefined) {
+    if (patch.federation.publicUrl.trim() === "") {
+      edits.push({ op: "delete", path: ["federation", "public_url"] });
+    } else {
+      set(["federation", "public_url"], patch.federation.publicUrl);
+    }
+  }
+  if (patch.federation?.gatewayUrl !== undefined) {
+    if (patch.federation.gatewayUrl.trim() === "") {
+      edits.push({ op: "delete", path: ["federation", "gateway_url"] });
+    } else {
+      set(["federation", "gateway_url"], patch.federation.gatewayUrl);
+    }
+  }
+  if (patch.federation?.cloudflareMtlsEnabled !== undefined) {
+    if (patch.federation.cloudflareMtlsEnabled) {
+      set(["federation", "cloudflare_mtls_enabled"], true);
+    } else {
+      edits.push({
+        op: "delete",
+        path: ["federation", "cloudflare_mtls_enabled"],
+      });
+    }
+  }
+  if (patch.federation?.cloudflareAccessServiceAuthEnabled !== undefined) {
+    if (patch.federation.cloudflareAccessServiceAuthEnabled) {
+      set(["federation", "cloudflare_access_service_auth_enabled"], true);
+    } else {
+      edits.push({
+        op: "delete",
+        path: ["federation", "cloudflare_access_service_auth_enabled"],
+      });
+    }
+  }
+
   if (patch.messaging?.inputDebounceMs !== undefined) {
     set(["messaging", "input_debounce_ms"], patch.messaging.inputDebounceMs);
   }
@@ -1427,6 +1495,7 @@ function normalizeDesktopConfig(
   const updates = tables["updates"];
   const integratedTerminal = tables["integrated_terminal"];
   const ui = tables["ui"];
+  const federation = tables["federation"];
   const messaging = tables["messaging"];
   const attachments = tables["messaging.attachments"];
   const telegram = tables["messaging.telegram"];
@@ -1537,6 +1606,19 @@ function normalizeDesktopConfig(
       activeContextTab: readString(ui?.active_context_tab),
       editedFilesDock: readString(ui?.edited_files_dock),
       actionRunsDock: readString(ui?.action_runs_dock),
+    },
+    federation: {
+      mode: readFederationMode(federation?.mode),
+      listenHost: readString(federation?.listen_host),
+      listenPort: readNumber(federation?.listen_port),
+      publicUrl: readString(federation?.public_url),
+      gatewayUrl: readString(federation?.gateway_url),
+      cloudflareMtlsEnabled: readBoolean(
+        federation?.cloudflare_mtls_enabled,
+      ),
+      cloudflareAccessServiceAuthEnabled: readBoolean(
+        federation?.cloudflare_access_service_auth_enabled,
+      ),
     },
     messaging: {
       enabled: readBoolean(messaging?.enabled),
@@ -1881,6 +1963,10 @@ function pruneEmptyConfig(config: DesktopSettingsConfig): DesktopSettingsConfig 
     pruned.ui = config.ui;
   }
 
+  if (config.federation && hasDefinedValue(config.federation)) {
+    pruned.federation = config.federation;
+  }
+
   const attachments = config.messaging?.attachments;
   const telegram = config.messaging?.telegram;
   const discord = config.messaging?.discord;
@@ -2130,6 +2216,15 @@ function readHotCpuProfileTriggerMode(
   value: TomlScalar | undefined,
 ): DesktopHotCpuProfileTriggerMode | undefined {
   return typeof value === "string" && isDesktopHotCpuProfileTriggerMode(value)
+    ? value
+    : undefined;
+}
+
+function readFederationMode(
+  value: TomlScalar | undefined,
+): DesktopFederationMode | undefined {
+  if (value === "child") return "client";
+  return typeof value === "string" && isDesktopFederationMode(value)
     ? value
     : undefined;
 }

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -1397,6 +1397,39 @@ export class DesktopSettingsService {
     return keyPair;
   }
 
+  async resolveFederationCloudflareCredentials(): Promise<{
+    clientCertificate?: string;
+    clientPrivateKey?: string;
+    accessClientId?: string;
+    accessClientSecret?: string;
+  }> {
+    const [
+      clientCertificate,
+      clientPrivateKey,
+      accessClientId,
+      accessClientSecret,
+    ] = await Promise.all([
+      this.options.secretStore.getSecret(
+        "federationCloudflareClientCertificate",
+      ),
+      this.options.secretStore.getSecret(
+        "federationCloudflareClientPrivateKey",
+      ),
+      this.options.secretStore.getSecret(
+        "federationCloudflareAccessClientId",
+      ),
+      this.options.secretStore.getSecret(
+        "federationCloudflareAccessClientSecret",
+      ),
+    ]);
+    return {
+      clientCertificate,
+      clientPrivateKey,
+      accessClientId,
+      accessClientSecret,
+    };
+  }
+
   resolveTelegramBotTokenSync(): string | undefined {
     return this.resolveSecretSync("telegramBotToken", TELEGRAM_BOT_TOKEN_ENV);
   }

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -62,6 +62,12 @@ import {
 } from "@pwragent/messaging-interface";
 import { DEFAULT_PASTED_IMAGE_MAX_PATCHES } from "../../shared/image-normalization";
 import {
+  generateFederationIdentityKeyPair,
+  publicKeyPemFromPrivateKey,
+  type FederationIdentityKeyPair,
+} from "../federation/federation-identity";
+
+import {
   applyDesktopSettingsPatch,
   readDesktopSettingsConfig,
   resolveDesktopConfigPath,
@@ -1371,6 +1377,24 @@ export class DesktopSettingsService {
 
   async resolveGrokApiKey(): Promise<string | undefined> {
     return await this.options.secretStore.getSecret("grokApiKey");
+  }
+
+  async getOrCreateFederationIdentityKeyPair(): Promise<FederationIdentityKeyPair> {
+    const existing = await this.options.secretStore.getSecret(
+      "federationInstancePrivateKey",
+    );
+    if (existing) {
+      return {
+        privateKeyPem: existing,
+        publicKeyPem: publicKeyPemFromPrivateKey(existing),
+      };
+    }
+    const keyPair = generateFederationIdentityKeyPair();
+    await this.options.secretStore.setSecret(
+      "federationInstancePrivateKey",
+      keyPair.privateKeyPem,
+    );
+    return keyPair;
   }
 
   resolveTelegramBotTokenSync(): string | undefined {

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -6,6 +6,7 @@ import type {
   DesktopAuthorizedContact,
   DesktopCodexAuthProfileDiscoverySnapshot,
   DesktopCodexProfileModel,
+  DesktopFederationMode,
   DesktopGitDiscoverySnapshot,
   DesktopHotCpuProfileStartDelayMs,
   DesktopHotCpuProfileTriggerMode,
@@ -40,6 +41,7 @@ import {
   DESKTOP_APPEARANCE_THEME_DEFAULT,
   DESKTOP_CHAT_REPLY_COMPOSER_DEFAULT,
   DESKTOP_CODEX_PROFILE_MODEL_DEFAULT,
+  DESKTOP_FEDERATION_MODE_DEFAULT,
   DESKTOP_HOT_CPU_PROFILE_SLOWBURN_THRESHOLD_DEFAULT_PERCENT,
   DESKTOP_HOT_CPU_PROFILE_START_DELAY_DEFAULT_MS,
   DESKTOP_HOT_CPU_PROFILE_TRIGGER_MODE_DEFAULT,
@@ -484,6 +486,31 @@ export class DesktopSettingsService {
       undefined,
       secretStorage.available,
     );
+    const federationInstancePrivateKey = await this.readSecretState(
+      "federationInstancePrivateKey",
+      undefined,
+      secretStorage.available,
+    );
+    const federationCloudflareClientCertificate = await this.readSecretState(
+      "federationCloudflareClientCertificate",
+      undefined,
+      secretStorage.available,
+    );
+    const federationCloudflareClientPrivateKey = await this.readSecretState(
+      "federationCloudflareClientPrivateKey",
+      undefined,
+      secretStorage.available,
+    );
+    const federationCloudflareAccessClientId = await this.readSecretState(
+      "federationCloudflareAccessClientId",
+      undefined,
+      secretStorage.available,
+    );
+    const federationCloudflareAccessClientSecret = await this.readSecretState(
+      "federationCloudflareAccessClientSecret",
+      undefined,
+      secretStorage.available,
+    );
     const codexDiscovery = await this.codexDiscoveryCoordinator.discover(
       this.resolveCodexCommandPreferenceFromConfig(config),
       {
@@ -707,6 +734,29 @@ export class DesktopSettingsService {
           value: config.ui?.actionRunsDock ?? "above",
           source: config.ui?.actionRunsDock === undefined ? "default" : "config",
         },
+      },
+      federation: {
+        mode: this.resolveFederationMode(config.federation?.mode),
+        listenHost: this.resolveConfigStringWithDefault(
+          config.federation?.listenHost,
+          "127.0.0.1",
+        ),
+        listenPort: this.resolveConfigNumber(config.federation?.listenPort, 47830),
+        publicUrl: this.resolveConfigString(config.federation?.publicUrl),
+        gatewayUrl: this.resolveConfigString(config.federation?.gatewayUrl),
+        cloudflareMtlsEnabled: this.resolveConfigBoolean(
+          config.federation?.cloudflareMtlsEnabled,
+          false,
+        ),
+        cloudflareAccessServiceAuthEnabled: this.resolveConfigBoolean(
+          config.federation?.cloudflareAccessServiceAuthEnabled,
+          false,
+        ),
+        instancePrivateKey: federationInstancePrivateKey,
+        cloudflareClientCertificate: federationCloudflareClientCertificate,
+        cloudflareClientPrivateKey: federationCloudflareClientPrivateKey,
+        cloudflareAccessClientId: federationCloudflareAccessClientId,
+        cloudflareAccessClientSecret: federationCloudflareAccessClientSecret,
       },
       messaging: {
         enabled: this.resolveConfigBoolean(config.messaging?.enabled, true),
@@ -1836,6 +1886,15 @@ export class DesktopSettingsService {
     };
   }
 
+  private resolveFederationMode(
+    configValue: DesktopFederationMode | undefined,
+  ): DesktopSettingsValue<DesktopFederationMode> {
+    return {
+      value: configValue ?? DESKTOP_FEDERATION_MODE_DEFAULT,
+      source: configValue === undefined ? "default" : "config",
+    };
+  }
+
   private resolveNumber(
     configValue: number | undefined,
     defaultValue: number,
@@ -2087,6 +2146,26 @@ export class DesktopSettingsService {
   ): DesktopSettingsValue<string> {
     return {
       value: configValue ?? "",
+      source: configValue === undefined ? "default" : "config",
+    };
+  }
+
+  private resolveConfigStringWithDefault(
+    configValue: string | undefined,
+    defaultValue: string,
+  ): DesktopSettingsValue<string> {
+    return {
+      value: configValue ?? defaultValue,
+      source: configValue === undefined ? "default" : "config",
+    };
+  }
+
+  private resolveConfigNumber(
+    configValue: number | undefined,
+    defaultValue: number,
+  ): DesktopSettingsValue<number> {
+    return {
+      value: configValue ?? defaultValue,
       source: configValue === undefined ? "default" : "config",
     };
   }

--- a/apps/desktop/src/main/state/messaging-store-sqlite.ts
+++ b/apps/desktop/src/main/state/messaging-store-sqlite.ts
@@ -14,7 +14,11 @@ import type {
   MessagingThreadTopicLinkRecord,
   MessagingTopicCleanupProposalRecord,
 } from "@pwragent/messaging-interface";
-import { normalizeMessagingBindingTargetKind } from "@pwragent/shared";
+import {
+  federatedThreadIdentityKey,
+  normalizeMessagingBindingTargetKind,
+  type FederatedThreadRef,
+} from "@pwragent/shared";
 import type { StateDb } from "./state-db.js";
 import type {
   MessagingDeliveryRecord,
@@ -378,6 +382,23 @@ export class SqliteMessagingStore {
         // enough across the user's history).
         if (!binding.backend) return true;
         return binding.backend === params.backend;
+      });
+  }
+
+  async findActiveBindingsForFederatedThread(
+    ref: FederatedThreadRef,
+  ): Promise<MessagingBindingRecord[]> {
+    const wanted = federatedThreadIdentityKey(ref);
+    const rows = this.stateDb.raw
+      .prepare(
+        "SELECT payload FROM bindings WHERE status = 'active' AND thread_id = ?",
+      )
+      .all(ref.threadId) as { payload: string }[];
+    return rows
+      .map((row) => JSON.parse(row.payload) as MessagingBindingRecord)
+      .filter((binding) => {
+        if (binding.revokedAt || !binding.federatedThread) return false;
+        return federatedThreadIdentityKey(binding.federatedThread) === wanted;
       });
   }
 

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -9,7 +9,7 @@ import {
 } from "@pwragent/shared";
 import { getNativeBinding } from "./native-binding.js";
 
-export const CURRENT_STATE_DB_USER_VERSION = 37;
+export const CURRENT_STATE_DB_USER_VERSION = 38;
 export const STATE_DB_WAL_AUTOCHECKPOINT_PAGES = 1000;
 export const STATE_DB_JOURNAL_SIZE_LIMIT_BYTES = 16 * 1024 * 1024;
 
@@ -842,6 +842,50 @@ CREATE INDEX IF NOT EXISTS idx_thread_message_origins_thread
   ON thread_message_origins(backend, thread_id, created_at, message_id);
 `;
 
+export const FEDERATION_SCHEMA = `
+CREATE TABLE IF NOT EXISTS federation_peers (
+  peer_id       TEXT PRIMARY KEY,
+  label         TEXT NOT NULL,
+  role          TEXT NOT NULL,
+  status        TEXT NOT NULL,
+  created_at    INTEGER NOT NULL,
+  updated_at    INTEGER NOT NULL,
+  last_seen_at  INTEGER,
+  revoked_at    INTEGER,
+  payload       TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_federation_peers_status_updated
+  ON federation_peers(status, updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS federation_enrollment_tokens (
+  enrollment_id  TEXT PRIMARY KEY,
+  token_hmac     TEXT NOT NULL UNIQUE,
+  status         TEXT NOT NULL,
+  generated_at   INTEGER NOT NULL,
+  expires_at     INTEGER NOT NULL,
+  used_at        INTEGER,
+  peer_id        TEXT,
+  payload        TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_federation_enrollment_tokens_status_expires
+  ON federation_enrollment_tokens(status, expires_at);
+CREATE INDEX IF NOT EXISTS idx_federation_enrollment_tokens_peer
+  ON federation_enrollment_tokens(peer_id);
+
+CREATE TABLE IF NOT EXISTS federation_session_audit (
+  event_id    INTEGER PRIMARY KEY,
+  peer_id     TEXT,
+  session_id  TEXT,
+  kind        TEXT NOT NULL,
+  created_at  INTEGER NOT NULL,
+  payload     TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_federation_session_audit_peer_created
+  ON federation_session_audit(peer_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_federation_session_audit_session_created
+  ON federation_session_audit(session_id, created_at DESC);
+`;
+
 const DELIVERIES_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 const REVOKED_BINDINGS_RETENTION_MS = 90 * 24 * 60 * 60 * 1000;
 const APP_RUNTIME_INSTANCE_RETENTION_MS = 60 * 60 * 1000;
@@ -1141,6 +1185,12 @@ export class StateDb {
         db.pragma("user_version = 37");
       })();
     }
+    if ((db.pragma("user_version", { simple: true }) as number) < 38) {
+      db.transaction(() => {
+        db.exec(FEDERATION_SCHEMA);
+        db.pragma(`user_version = ${CURRENT_STATE_DB_USER_VERSION}`);
+      })();
+    }
     // Keep current-version databases converged without asking pre-v36 profiles
     // to install the unique index before the migration above removes duplicates.
     db.exec(PR_AUTO_DISPATCH_GLOBAL_FINGERPRINT_INDEX);
@@ -1308,8 +1358,10 @@ function ensureCurrentSchema(db: BetterSqlite3.Database): void {
     ensurePullRequestProviderColumns(db);
     ensureThreadUsagePricingProviderScope(db);
     ensureThreadUsagePricingCumulativeColumns(db);
+    ensureThreadUsagePricingIndexes(db);
     db.exec(THREAD_TOOL_ACCOUNTING_SCHEMA);
     ensureThreadMessageOriginSchema(db);
+    db.exec(FEDERATION_SCHEMA);
     if ((db.pragma("user_version", { simple: true }) as number) < 4) {
       db.pragma("user_version = 4");
     }

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -10,7 +10,10 @@ import {
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import type { FederationRemoteTarget } from "@pwragent/shared";
+import type {
+  AppServerBackendKind,
+  FederationRemoteTarget,
+} from "@pwragent/shared";
 import { resolveHeapMonitorConfig } from "./diagnostics/heap-monitor-config";
 import { createHeapSession } from "./diagnostics/heap-session";
 import { resolveHotCpuProfileConfig } from "./diagnostics/hot-cpu-profile-config";
@@ -319,7 +322,12 @@ export function syncHotCpuProfilersFromSettings(
 
 export function createMainWindow(options?: {
   onShown?: () => void;
+  federationLabel?: string;
   federationTarget?: FederationRemoteTarget;
+  initialThread?: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  };
   startupCpuProfiler?: {
     attachWindow: (window: BrowserWindow) => void;
   };
@@ -354,7 +362,9 @@ export function createMainWindow(options?: {
     minWidth: 1200,
     minHeight: 760,
     show: false,
-    title: "PwrAgent",
+    title: options?.federationLabel
+      ? `PwrAgent - ${options.federationLabel}`
+      : "PwrAgent",
     ...windowChrome,
     // Pre-tinted so the OS window fill matches the renderer's first
     // paint and we don't flash dark before a light renderer mounts.
@@ -386,7 +396,10 @@ export function createMainWindow(options?: {
         // Surface the OS home directory so the renderer can collapse long
         // absolute paths to `~` (the sandboxed preload can't read it itself).
         `--pwragent-home-dir=${JSON.stringify(homedir())}`,
-        ...federationWindowTargetAdditionalArguments(options?.federationTarget),
+        ...federationWindowTargetAdditionalArguments(
+          options?.federationTarget,
+          options?.federationLabel,
+        ),
       ],
     }
   });
@@ -435,6 +448,12 @@ export function createMainWindow(options?: {
   window.once("ready-to-show", () => {
     recordStartupProfileEvent({ type: "window-ready-to-show" });
     showWindow("ready-to-show");
+    if (options?.initialThread) {
+      window.webContents.send(
+        WINDOW_SHOW_THREAD_CHANNEL,
+        options.initialThread,
+      );
+    }
   });
   if (!isMac) {
     window.webContents.once("did-finish-load", () => {

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -10,6 +10,7 @@ import {
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import type { FederationRemoteTarget } from "@pwragent/shared";
 import { resolveHeapMonitorConfig } from "./diagnostics/heap-monitor-config";
 import { createHeapSession } from "./diagnostics/heap-session";
 import { resolveHotCpuProfileConfig } from "./diagnostics/hot-cpu-profile-config";
@@ -56,6 +57,7 @@ import {
   readBootstrapNavigationPreferences,
 } from "./navigation-browse-mode-bootstrap";
 import { placementForCursorDisplay } from "./window-placement";
+import { federationWindowTargetAdditionalArguments } from "../shared/federation-window";
 
 const isDevelopment = process.env.NODE_ENV !== "production";
 const isMac = process.platform === "darwin";
@@ -317,6 +319,7 @@ export function syncHotCpuProfilersFromSettings(
 
 export function createMainWindow(options?: {
   onShown?: () => void;
+  federationTarget?: FederationRemoteTarget;
   startupCpuProfiler?: {
     attachWindow: (window: BrowserWindow) => void;
   };
@@ -383,6 +386,7 @@ export function createMainWindow(options?: {
         // Surface the OS home directory so the renderer can collapse long
         // absolute paths to `~` (the sandboxed preload can't read it itself).
         `--pwragent-home-dir=${JSON.stringify(homedir())}`,
+        ...federationWindowTargetAdditionalArguments(options?.federationTarget),
       ],
     }
   });

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -244,6 +244,10 @@ import type {
   OpenDesktopPwrAgentProfileResponse,
   ReadFederationHealthRequest,
   ReadFederationHealthResponse,
+  ReadFederationDiagnosticsRequest,
+  ReadFederationDiagnosticsResponse,
+  RevokeFederationPeerRequest,
+  RevokeFederationPeerResponse,
   ReadDesktopSettingsRequest,
   ReadDesktopSettingsResponse,
   RefreshDesktopCodexDiscoveryRequest,
@@ -280,7 +284,10 @@ import type {
 } from "@pwragent/shared";
 import type { RendererErrorReport } from "../shared/renderer-error";
 import type { RendererDiagnosticLogRequest } from "../shared/renderer-diagnostic";
-import { readFederationWindowTargetFromArgv } from "../shared/federation-window";
+import {
+  readFederationWindowLabelFromArgv,
+  readFederationWindowTargetFromArgv,
+} from "../shared/federation-window";
 import type {
   ImageUploadFallbackRequest,
   ImageUploadFallbackResponse,
@@ -402,9 +409,11 @@ import {
   PATH_REVEAL_CHANNEL,
   BACKEND_LIST_CHANNEL,
   FEDERATION_GET_HEALTH_CHANNEL,
+  FEDERATION_GET_DIAGNOSTICS_CHANNEL,
   FEDERATION_GENERATE_INVITE_CHANNEL,
   FEDERATION_IMPORT_INVITE_CHANNEL,
   FEDERATION_OPEN_WINDOW_CHANNEL,
+  FEDERATION_REVOKE_PEER_CHANNEL,
   CODEX_ENVIRONMENT_SETUP_PROGRESS_CHANNEL,
   COMPOSER_DRAFT_CLEAR_CHANNEL,
   COMPOSER_DRAFT_LIST_CANDIDATES_CHANNEL,
@@ -780,6 +789,10 @@ const desktopApi = Object.freeze({
     request?: ReadFederationHealthRequest,
   ): Promise<ReadFederationHealthResponse> =>
     await ipcRenderer.invoke(FEDERATION_GET_HEALTH_CHANNEL, request),
+  readFederationDiagnostics: async (
+    request?: ReadFederationDiagnosticsRequest,
+  ): Promise<ReadFederationDiagnosticsResponse> =>
+    await ipcRenderer.invoke(FEDERATION_GET_DIAGNOSTICS_CHANNEL, request),
   generateFederationInvite: async (
     request?: GenerateFederationInviteRequest,
   ): Promise<GenerateFederationInviteResponse> =>
@@ -788,6 +801,10 @@ const desktopApi = Object.freeze({
     request: ImportFederationInviteRequest,
   ): Promise<ImportFederationInviteResponse> =>
     await ipcRenderer.invoke(FEDERATION_IMPORT_INVITE_CHANNEL, request),
+  revokeFederationPeer: async (
+    request: RevokeFederationPeerRequest,
+  ): Promise<RevokeFederationPeerResponse> =>
+    await ipcRenderer.invoke(FEDERATION_REVOKE_PEER_CHANNEL, request),
   ...(isDevelopment
     ? {
         getRuntimeIdentity: async (): Promise<RuntimeIdentity> =>
@@ -1792,6 +1809,9 @@ const bootstrapNavigationPreferences = readBootstrapNavigationPreferences();
 const bootstrapFederationTarget = readFederationWindowTargetFromArgv(
   process.argv,
 );
+const bootstrapFederationLabel = readFederationWindowLabelFromArgv(
+  process.argv,
+);
 
 // Decode the OS home directory passed from main via
 // `webPreferences.additionalArguments`. The sandboxed preload can't call
@@ -1852,6 +1872,10 @@ if (process.contextIsolated) {
   contextBridge.exposeInMainWorld(
     "__pwragentFederationTarget",
     bootstrapFederationTarget,
+  );
+  contextBridge.exposeInMainWorld(
+    "__pwragentFederationLabel",
+    bootstrapFederationLabel,
   );
   recordPreloadLog("info", "exposed context bridge", {
     keyCount: Object.keys(desktopApi).length

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -228,6 +228,8 @@ import type {
   ImportFederationInviteResponse,
   OpenDesktopApplicationRequest,
   OpenDesktopApplicationResponse,
+  ReadDesktopApplicationsRequest,
+  ReadDesktopApplicationsResponse,
   OpenFederationWindowRequest,
   OpenFederationWindowResponse,
   OpenMarkdownFileViewerRequest,
@@ -386,6 +388,7 @@ import {
   APP_SERVER_RENAME_THREAD_CHANNEL,
   APP_SERVER_READ_THREAD_CHANNEL,
   APP_SERVER_GET_THREAD_FILE_DIFF_CHANNEL,
+  APPLICATIONS_READ_CHANNEL,
   APPLICATION_OPEN_CHANNEL,
   MARKDOWN_FILE_READ_CHANNEL,
   MARKDOWN_FILE_VIEWER_OPEN_CHANNEL,
@@ -913,6 +916,10 @@ const desktopApi = Object.freeze({
     request: OpenDesktopApplicationRequest,
   ): Promise<OpenDesktopApplicationResponse> =>
     await ipcRenderer.invoke(APPLICATION_OPEN_CHANNEL, request),
+  readApplications: async (
+    request: ReadDesktopApplicationsRequest,
+  ): Promise<ReadDesktopApplicationsResponse> =>
+    await ipcRenderer.invoke(APPLICATIONS_READ_CHANNEL, request),
   openPath: async (request: OpenPathRequest): Promise<OpenPathResponse> =>
     await ipcRenderer.invoke(PATH_OPEN_CHANNEL, request),
   revealPath: async (request: OpenPathRequest): Promise<OpenPathResponse> =>

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -224,6 +224,8 @@ import type {
   DesktopSettingsWriteResponse,
   OpenDesktopApplicationRequest,
   OpenDesktopApplicationResponse,
+  OpenFederationWindowRequest,
+  OpenFederationWindowResponse,
   OpenMarkdownFileViewerRequest,
   OpenMarkdownFileViewerResponse,
   OpenSubAgentTranscriptWindowRequest,
@@ -272,6 +274,7 @@ import type {
 } from "@pwragent/shared";
 import type { RendererErrorReport } from "../shared/renderer-error";
 import type { RendererDiagnosticLogRequest } from "../shared/renderer-diagnostic";
+import { readFederationWindowTargetFromArgv } from "../shared/federation-window";
 import type {
   ImageUploadFallbackRequest,
   ImageUploadFallbackResponse,
@@ -392,6 +395,7 @@ import {
   PATH_OPEN_CHANNEL,
   PATH_REVEAL_CHANNEL,
   BACKEND_LIST_CHANNEL,
+  FEDERATION_OPEN_WINDOW_CHANNEL,
   CODEX_ENVIRONMENT_SETUP_PROGRESS_CHANNEL,
   COMPOSER_DRAFT_CLEAR_CHANNEL,
   COMPOSER_DRAFT_LIST_CANDIDATES_CHANNEL,
@@ -759,6 +763,10 @@ const desktopApi = Object.freeze({
     request: WaitForDesktopProfileAliveRequest,
   ): Promise<WaitForDesktopProfileAliveResponse> =>
     await ipcRenderer.invoke(APP_WAIT_FOR_PROFILE_ALIVE_CHANNEL, request),
+  openFederationWindow: async (
+    request: OpenFederationWindowRequest,
+  ): Promise<OpenFederationWindowResponse> =>
+    await ipcRenderer.invoke(FEDERATION_OPEN_WINDOW_CHANNEL, request),
   ...(isDevelopment
     ? {
         getRuntimeIdentity: async (): Promise<RuntimeIdentity> =>
@@ -1760,6 +1768,9 @@ function readBootstrapNavigationPreferences(): {
   return { browseMode: "inbox" };
 }
 const bootstrapNavigationPreferences = readBootstrapNavigationPreferences();
+const bootstrapFederationTarget = readFederationWindowTargetFromArgv(
+  process.argv,
+);
 
 // Decode the OS home directory passed from main via
 // `webPreferences.additionalArguments`. The sandboxed preload can't call
@@ -1816,6 +1827,10 @@ if (process.contextIsolated) {
   contextBridge.exposeInMainWorld(
     "__pwragentLogFilePath",
     bootstrapLogFilePath,
+  );
+  contextBridge.exposeInMainWorld(
+    "__pwragentFederationTarget",
+    bootstrapFederationTarget,
   );
   recordPreloadLog("info", "exposed context bridge", {
     keyCount: Object.keys(desktopApi).length

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -222,6 +222,10 @@ import type {
   DesktopMessagingContactLookupRequest,
   DesktopMessagingContactLookupResponse,
   DesktopSettingsWriteResponse,
+  GenerateFederationInviteRequest,
+  GenerateFederationInviteResponse,
+  ImportFederationInviteRequest,
+  ImportFederationInviteResponse,
   OpenDesktopApplicationRequest,
   OpenDesktopApplicationResponse,
   OpenFederationWindowRequest,
@@ -398,6 +402,8 @@ import {
   PATH_REVEAL_CHANNEL,
   BACKEND_LIST_CHANNEL,
   FEDERATION_GET_HEALTH_CHANNEL,
+  FEDERATION_GENERATE_INVITE_CHANNEL,
+  FEDERATION_IMPORT_INVITE_CHANNEL,
   FEDERATION_OPEN_WINDOW_CHANNEL,
   CODEX_ENVIRONMENT_SETUP_PROGRESS_CHANNEL,
   COMPOSER_DRAFT_CLEAR_CHANNEL,
@@ -774,6 +780,14 @@ const desktopApi = Object.freeze({
     request?: ReadFederationHealthRequest,
   ): Promise<ReadFederationHealthResponse> =>
     await ipcRenderer.invoke(FEDERATION_GET_HEALTH_CHANNEL, request),
+  generateFederationInvite: async (
+    request?: GenerateFederationInviteRequest,
+  ): Promise<GenerateFederationInviteResponse> =>
+    await ipcRenderer.invoke(FEDERATION_GENERATE_INVITE_CHANNEL, request),
+  importFederationInvite: async (
+    request: ImportFederationInviteRequest,
+  ): Promise<ImportFederationInviteResponse> =>
+    await ipcRenderer.invoke(FEDERATION_IMPORT_INVITE_CHANNEL, request),
   ...(isDevelopment
     ? {
         getRuntimeIdentity: async (): Promise<RuntimeIdentity> =>

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -238,6 +238,8 @@ import type {
   ReadMarkdownFileViewerSnapshotResponse,
   OpenDesktopPwrAgentProfileRequest,
   OpenDesktopPwrAgentProfileResponse,
+  ReadFederationHealthRequest,
+  ReadFederationHealthResponse,
   ReadDesktopSettingsRequest,
   ReadDesktopSettingsResponse,
   RefreshDesktopCodexDiscoveryRequest,
@@ -395,6 +397,7 @@ import {
   PATH_OPEN_CHANNEL,
   PATH_REVEAL_CHANNEL,
   BACKEND_LIST_CHANNEL,
+  FEDERATION_GET_HEALTH_CHANNEL,
   FEDERATION_OPEN_WINDOW_CHANNEL,
   CODEX_ENVIRONMENT_SETUP_PROGRESS_CHANNEL,
   COMPOSER_DRAFT_CLEAR_CHANNEL,
@@ -767,6 +770,10 @@ const desktopApi = Object.freeze({
     request: OpenFederationWindowRequest,
   ): Promise<OpenFederationWindowResponse> =>
     await ipcRenderer.invoke(FEDERATION_OPEN_WINDOW_CHANNEL, request),
+  readFederationHealth: async (
+    request?: ReadFederationHealthRequest,
+  ): Promise<ReadFederationHealthResponse> =>
+    await ipcRenderer.invoke(FEDERATION_GET_HEALTH_CHANNEL, request),
   ...(isDevelopment
     ? {
         getRuntimeIdentity: async (): Promise<RuntimeIdentity> =>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -53,6 +53,8 @@ import { useDurableComposerDraftStore } from "./features/composer/useDurableComp
 import { useAppearance, type AppearanceController } from "./lib/useAppearance";
 import { useBackendSummaries } from "./lib/useBackendSummaries";
 import { useDesktopApi, type DesktopApi } from "./lib/desktop-api";
+import { useDesktopApplications } from "./lib/useDesktopApplications";
+import { readRendererFederationTarget } from "./lib/federation-window";
 import { useRuntimeIdentity } from "./lib/runtime-identity";
 import {
   useNavigationHistory,
@@ -665,6 +667,18 @@ function DesktopAppShell(props: {
       settings.snapshot?.experimental.lightweightNavigationRefresh?.value ?? false,
     threadViewVisible: mainView === "thread",
   });
+  const selectedThreadFederationTarget =
+    navigation.selectedThread?.federation?.ref.target;
+  const remoteApplicationInstanceId =
+    selectedThreadFederationTarget
+    && isRemoteFederationTarget(selectedThreadFederationTarget)
+      ? selectedThreadFederationTarget.instanceId
+      : readRendererFederationTarget()?.instanceId;
+  const applications = useDesktopApplications({
+    desktopApi,
+    localApplications: settings.snapshot?.applications,
+    remoteInstanceId: remoteApplicationInstanceId,
+  });
   // Keep the backend-error toast's thread lookup fresh without making the
   // toast subscription depend on (and re-subscribe to) the thread list.
   useEffect(() => {
@@ -1068,7 +1082,7 @@ function DesktopAppShell(props: {
     addOptimisticUserMessage: session.addOptimisticUserMessage,
     backendError: backendSummaries.error,
     backends: backendSummaries.backends,
-    applications: settings.snapshot?.applications,
+    applications,
     codexFastAllowed:
       settings.snapshot?.models?.codex.allowFast?.value ?? true,
     providerModelDefaults: settings.snapshot?.models?.providerDefaults,

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -55,6 +55,7 @@ import { useBackendSummaries } from "./lib/useBackendSummaries";
 import { useDesktopApi, type DesktopApi } from "./lib/desktop-api";
 import { useDesktopApplications } from "./lib/useDesktopApplications";
 import { readRendererFederationTarget } from "./lib/federation-window";
+import { scopeDesktopApiToFederationTarget } from "./lib/federation-desktop-api";
 import { useRuntimeIdentity } from "./lib/runtime-identity";
 import {
   useNavigationHistory,
@@ -674,6 +675,16 @@ function DesktopAppShell(props: {
     && isRemoteFederationTarget(selectedThreadFederationTarget)
       ? selectedThreadFederationTarget.instanceId
       : readRendererFederationTarget()?.instanceId;
+  const activeFederationTarget = useMemo(
+    () => remoteApplicationInstanceId
+      ? { scope: "remote" as const, instanceId: remoteApplicationInstanceId }
+      : undefined,
+    [remoteApplicationInstanceId],
+  );
+  const threadDesktopApi = useMemo(
+    () => scopeDesktopApiToFederationTarget(desktopApi, activeFederationTarget),
+    [activeFederationTarget, desktopApi],
+  );
   const applications = useDesktopApplications({
     desktopApi,
     localApplications: settings.snapshot?.applications,
@@ -686,6 +697,7 @@ function DesktopAppShell(props: {
   }, [navigation.threads]);
   const backendSummaries = useBackendSummaries(desktopApi, {
     enabled: normalAppEnabled,
+    federationTarget: activeFederationTarget,
   });
   const refreshAcpAgents = backendSummaries.refreshAcpAgents;
   const refreshSelectedAcpProvider = useCallback(
@@ -1099,7 +1111,7 @@ function DesktopAppShell(props: {
       ),
     composerImplementation: settings.composerImplementation,
     composerDraftStore,
-    desktopApi,
+    desktopApi: threadDesktopApi,
     launchpadError: navigation.launchpadError,
     onProviderSelected: refreshSelectedAcpProvider,
     onShowNotice: setComposerNotice,

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -14,6 +14,7 @@ import {
   buildThreadIdentityKey,
   DEFAULT_BACKGROUND_PR_POLLING,
   DEFAULT_PR_AUTO_DISPATCH_ALLOWED,
+  isRemoteFederationTarget,
   parseThreadIdentityKey,
   type AppServerBackendKind,
   type DesktopBootInfo,
@@ -1577,6 +1578,17 @@ function DesktopAppShell(props: {
                 }
               }}
               onOpenResult={async (result) => {
+                if (
+                  result.federation &&
+                  isRemoteFederationTarget(result.federation.ref.target)
+                ) {
+                  await desktopApi?.openFederationWindow?.({
+                    target: result.federation.ref.target,
+                    label: result.federation.instanceLabel,
+                    initialThread: result.federation.ref,
+                  });
+                  return;
+                }
                 // Deep-link to the match: open the thread with the find bar
                 // seeded with the search query so it highlights + scrolls the
                 // matched message into view (auto-loading older history if the

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -476,6 +476,43 @@ describe("App", () => {
         editedFilesDock: { value: "above", source: "default" },
         actionRunsDock: { value: "above", source: "default" },
       },
+      federation: {
+        mode: { value: "disabled", source: "default" },
+        listenHost: { value: "127.0.0.1", source: "default" },
+        listenPort: { value: 47830, source: "default" },
+        publicUrl: { value: "", source: "default" },
+        gatewayUrl: { value: "", source: "default" },
+        cloudflareMtlsEnabled: { value: false, source: "default" },
+        cloudflareAccessServiceAuthEnabled: {
+          value: false,
+          source: "default",
+        },
+        instancePrivateKey: {
+          configured: false,
+          source: "unset",
+          writable: true,
+        },
+        cloudflareClientCertificate: {
+          configured: false,
+          source: "unset",
+          writable: true,
+        },
+        cloudflareClientPrivateKey: {
+          configured: false,
+          source: "unset",
+          writable: true,
+        },
+        cloudflareAccessClientId: {
+          configured: false,
+          source: "unset",
+          writable: true,
+        },
+        cloudflareAccessClientSecret: {
+          configured: false,
+          source: "unset",
+          writable: true,
+        },
+      },
       messaging: {
         enabled: { value: true, source: "default" },
         allowFullAccessEscalation: { value: true, source: "default" },

--- a/apps/desktop/src/renderer/src/features/codex-config/CodexConfigWarningBanner.tsx
+++ b/apps/desktop/src/renderer/src/features/codex-config/CodexConfigWarningBanner.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
 import type { AgentEvent } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
+import { readRendererFederationTarget } from "../../lib/federation-window";
+import { federationTargetsEqual } from "../../lib/federated-thread-events";
 
 type ConfigWarningNotice = {
   id: string;
@@ -53,6 +55,7 @@ export function CodexConfigWarningBanner(props: { desktopApi?: DesktopApi }) {
   const [trusting, setTrusting] = useState(false);
   const [trustError, setTrustError] = useState<string | null>(null);
   const desktopApi = props.desktopApi;
+  const federationTargetInstanceId = readRendererFederationTarget()?.instanceId;
 
   useEffect(() => {
     if (!desktopApi?.onAgentEvent && !desktopApi?.getLatestCodexConfigWarning) {
@@ -62,6 +65,12 @@ export function CodexConfigWarningBanner(props: { desktopApi?: DesktopApi }) {
     let cancelled = false;
     const applyEvent = (event: AgentEvent): void => {
       if (cancelled) {
+        return;
+      }
+      const rendererTarget = federationTargetInstanceId
+        ? { scope: "remote" as const, instanceId: federationTargetInstanceId }
+        : undefined;
+      if (!federationTargetsEqual(event.federationTarget, rendererTarget)) {
         return;
       }
       const nextNotice = noticeFromEvent(event);
@@ -91,7 +100,7 @@ export function CodexConfigWarningBanner(props: { desktopApi?: DesktopApi }) {
       cancelled = true;
       unsubscribe?.();
     };
-  }, [desktopApi, dismissedIds]);
+  }, [desktopApi, dismissedIds, federationTargetInstanceId]);
 
   const actionLabel = useMemo(() => {
     const projectPath = notice?.trustedProjectPath;
@@ -116,6 +125,14 @@ export function CodexConfigWarningBanner(props: { desktopApi?: DesktopApi }) {
     setTrustError(null);
     try {
       await desktopApi.trustCodexProject({
+        ...(federationTargetInstanceId
+          ? {
+              federationTarget: {
+                scope: "remote",
+                instanceId: federationTargetInstanceId,
+              } as const,
+            }
+          : {}),
         projectPath: notice.trustedProjectPath,
         ...(notice.configPath ? { configPath: notice.configPath } : {}),
       });

--- a/apps/desktop/src/renderer/src/features/codex-config/__tests__/CodexConfigWarningBanner.test.tsx
+++ b/apps/desktop/src/renderer/src/features/codex-config/__tests__/CodexConfigWarningBanner.test.tsx
@@ -1,0 +1,119 @@
+import "@testing-library/jest-dom/vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type { AgentEvent, TrustCodexProjectRequest } from "@pwragent/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { DesktopApi } from "../../../lib/desktop-api";
+import { CodexConfigWarningBanner } from "../CodexConfigWarningBanner";
+
+function configWarningEvent(params: {
+  federationTarget?: AgentEvent["federationTarget"];
+  summary: string;
+}): AgentEvent {
+  return {
+    backend: "codex",
+    ...(params.federationTarget
+      ? { federationTarget: params.federationTarget }
+      : {}),
+    notification: {
+      method: "configWarning",
+      params: {
+        summary: params.summary,
+        details: null,
+        trustedProjectPath: "/remote/repo",
+        configPath: "/remote/.codex/config.toml",
+      },
+    },
+  };
+}
+
+afterEach(() => {
+  delete (window as unknown as {
+    __pwragentFederationTarget?: unknown;
+  }).__pwragentFederationTarget;
+  cleanup();
+});
+
+describe("CodexConfigWarningBanner", () => {
+  it("ignores remote warnings in a local controller window", async () => {
+    let publish: ((event: AgentEvent) => void) | undefined;
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        publish = callback;
+        return () => undefined;
+      },
+    };
+    render(<CodexConfigWarningBanner desktopApi={desktopApi} />);
+    await waitFor(() => expect(publish).toBeDefined());
+
+    publish?.(configWarningEvent({
+      federationTarget: {
+        scope: "remote",
+        instanceId: "remote-instance",
+      },
+      summary: "Remote warning",
+    }));
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("shows only warnings from the remote window's selected instance", async () => {
+    (window as unknown as {
+      __pwragentFederationTarget?: unknown;
+    }).__pwragentFederationTarget = {
+      scope: "remote",
+      instanceId: "selected-instance",
+    };
+    let publish: ((event: AgentEvent) => void) | undefined;
+    const trustCodexProject = vi.fn(async (request: TrustCodexProjectRequest) => ({
+      ...request,
+      trusted: true,
+    }));
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        publish = callback;
+        return () => undefined;
+      },
+      trustCodexProject,
+    };
+    render(<CodexConfigWarningBanner desktopApi={desktopApi} />);
+    await waitFor(() => expect(publish).toBeDefined());
+
+    publish?.(configWarningEvent({
+      federationTarget: {
+        scope: "remote",
+        instanceId: "other-instance",
+      },
+      summary: "Other warning",
+    }));
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+
+    publish?.(configWarningEvent({
+      federationTarget: {
+        scope: "remote",
+        instanceId: "selected-instance",
+      },
+      summary: "Selected warning",
+    }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Selected warning",
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Trust repo" }));
+    await waitFor(() => {
+      expect(trustCodexProject).toHaveBeenCalledWith({
+        federationTarget: {
+          scope: "remote",
+          instanceId: "selected-instance",
+        },
+        projectPath: "/remote/repo",
+        configPath: "/remote/.codex/config.toml",
+      });
+    });
+  });
+});

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -72,6 +72,7 @@ import { formatBackendLabel } from "../../lib/backend-label";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { BACKEND_SUMMARIES_REFRESH_EVENT } from "../../lib/useBackendSummaries";
 import { readRendererFederationTarget } from "../../lib/federation-window";
+import { agentEventMatchesThread } from "../../lib/federated-thread-events";
 import {
   acpRuntimeModeRequiresFullAccess,
   formatExecutionModeLabel,
@@ -4883,7 +4884,7 @@ export function Composer(props: ComposerProps) {
           notificationThreadId,
         );
         const queueEventIsCurrentThread =
-          event.backend === thread.source && notificationThreadId === thread.id;
+          agentEventMatchesThread(event, thread, notificationThreadId);
         if (
           queueEventIsCurrentThread &&
           (turnQueueRecord.status === "started" ||
@@ -4938,7 +4939,7 @@ export function Composer(props: ComposerProps) {
         }
       }
 
-      if (event.backend !== thread.source || notificationThreadId !== thread.id) {
+      if (!agentEventMatchesThread(event, thread, notificationThreadId)) {
         return;
       }
 

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -71,6 +71,7 @@ import type { AppNoticeToastNotice } from "../notifications/AppNoticeToast";
 import { formatBackendLabel } from "../../lib/backend-label";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { BACKEND_SUMMARIES_REFRESH_EVENT } from "../../lib/useBackendSummaries";
+import { readRendererFederationTarget } from "../../lib/federation-window";
 import {
   acpRuntimeModeRequiresFullAccess,
   formatExecutionModeLabel,
@@ -5709,6 +5710,8 @@ export function Composer(props: ComposerProps) {
     try {
       const response = await props.desktopApi.startTurn({
         backend: props.thread.source,
+        federationTarget: props.thread.federation?.ref.target ??
+          readRendererFederationTarget(),
         threadId: props.thread.id,
         input: payload.input,
         executionMode: props.thread.executionMode,

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -2718,6 +2718,7 @@ function CopyableComposerError(props: {
 
 export function Composer(props: ComposerProps) {
   const threadLinks = useThreadLinks();
+  const rendererFederationTarget = readRendererFederationTarget();
   const inputRef = useRef<ComposerInputHandle>(null);
   const inputWrapRef = useRef<HTMLDivElement>(null);
   const autocompleteListRef = useRef<HTMLDivElement>(null);
@@ -8209,6 +8210,12 @@ export function Composer(props: ComposerProps) {
     try {
       await props.desktopApi.openApplication({
         applicationId: application.id,
+        ...(props.thread?.federation?.ref.target || rendererFederationTarget
+          ? {
+              federationTarget:
+                props.thread?.federation?.ref.target ?? rendererFederationTarget,
+            }
+          : {}),
         kind: application.kind,
         targetPath: workspaceOpenPath,
       });
@@ -9907,10 +9914,14 @@ export function Composer(props: ComposerProps) {
                     }
                   : undefined
               }
-              onPickFromDisk={() => {
-                props.onClearPickDirectoryError?.();
-                props.onPickAndRegisterDirectory?.();
-              }}
+              onPickFromDisk={
+                rendererFederationTarget
+                  ? undefined
+                  : () => {
+                      props.onClearPickDirectoryError?.();
+                      props.onPickAndRegisterDirectory?.();
+                    }
+              }
             />
           ) : null}
 

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -5249,6 +5249,8 @@ export function Composer(props: ComposerProps) {
     try {
       const response = await props.desktopApi.startReview({
         backend: props.thread.source,
+        federationTarget: props.thread.federation?.ref.target ??
+          readRendererFederationTarget(),
         threadId: props.thread.id,
         target: reviewCommand.target,
         delivery: "inline",

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -5351,6 +5351,8 @@ export function Composer(props: ComposerProps) {
     try {
       const response = await props.desktopApi.compactThread({
         backend: props.thread.source,
+        federationTarget: props.thread.federation?.ref.target ??
+          readRendererFederationTarget(),
         threadId: props.thread.id,
       });
       updateActiveTurnId(response.turnId);
@@ -6143,6 +6145,8 @@ export function Composer(props: ComposerProps) {
     try {
       await props.desktopApi.steerTurn({
         backend: props.thread.source,
+        federationTarget: props.thread.federation?.ref.target ??
+          readRendererFederationTarget(),
         threadId: props.thread.id,
         expectedTurnId: turnId,
         input: payload.input,
@@ -6616,6 +6620,8 @@ export function Composer(props: ComposerProps) {
     try {
       await props.desktopApi.interruptTurn({
         backend: props.thread.source,
+        federationTarget: props.thread.federation?.ref.target ??
+          readRendererFederationTarget(),
         threadId: props.thread.id,
         turnId,
       });
@@ -7699,6 +7705,8 @@ export function Composer(props: ComposerProps) {
     try {
       await props.desktopApi.runCodexEnvironmentAction({
         backend: thread.source,
+        federationTarget: thread.federation?.ref.target ??
+          readRendererFederationTarget(),
         threadId: thread.id,
         actionId: action.id,
         ...(cwd ? { cwd } : {}),
@@ -7734,6 +7742,8 @@ export function Composer(props: ComposerProps) {
     try {
       await props.desktopApi.setCodexThreadEnvironment({
         backend: props.thread.source,
+        federationTarget: props.thread.federation?.ref.target ??
+          readRendererFederationTarget(),
         threadId: props.thread.id,
         environmentId,
         actionId,

--- a/apps/desktop/src/renderer/src/features/composer/ProjectPicker.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ProjectPicker.tsx
@@ -36,7 +36,7 @@ export type ProjectPickerProps = {
   /** Whether the system dialog is currently open / register in flight. */
   picking?: boolean;
   onSelect: (directory: NavigationDirectorySummary) => void;
-  onPickFromDisk: () => void;
+  onPickFromDisk?: () => void;
   /**
    * Switch the launchpad to a directory-less ("workspace") thread. When
    * omitted, the "Chat without a directory" row is not rendered.
@@ -229,25 +229,29 @@ export function ProjectPicker(props: ProjectPickerProps): ReactElement {
             )}
           </ul>
 
-          <div className="project-picker__separator" />
+          {props.onPickFromDisk ? (
+            <>
+              <div className="project-picker__separator" />
 
-          <button
-            type="button"
-            className="project-picker__row project-picker__row--action"
-            disabled={props.picking}
-            onClick={() => {
-              setOpen(false);
-              props.onPickFromDisk();
-            }}
-          >
-            <span aria-hidden="true" className="project-picker__row-check" />
-            <span aria-hidden="true" className="project-picker__plus">
-              +
-            </span>
-            <span className="project-picker__row-name">
-              {props.picking ? "Picking…" : "Add directory…"}
-            </span>
-          </button>
+              <button
+                type="button"
+                className="project-picker__row project-picker__row--action"
+                disabled={props.picking}
+                onClick={() => {
+                  setOpen(false);
+                  props.onPickFromDisk?.();
+                }}
+              >
+                <span aria-hidden="true" className="project-picker__row-check" />
+                <span aria-hidden="true" className="project-picker__plus">
+                  +
+                </span>
+                <span className="project-picker__row-name">
+                  {props.picking ? "Picking…" : "Add directory…"}
+                </span>
+              </button>
+            </>
+          ) : null}
 
           {props.pickError ? (
             <p

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/ProjectPicker.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/ProjectPicker.test.tsx
@@ -189,6 +189,22 @@ describe("ProjectPicker", () => {
     expect(onPickFromDisk).toHaveBeenCalledOnce();
   });
 
+  it("hides the local disk action when no picker callback is available", () => {
+    render(
+      <ProjectPicker
+        directories={[dirA]}
+        onSelect={() => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /choose a project/i }));
+
+    expect(screen.getByRole("option", { name: /pwragent/i })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /add directory/i }),
+    ).not.toBeInTheDocument();
+  });
+
   it("disables the Add directory… row while picking is in flight", () => {
     render(
       <ProjectPicker

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -94,6 +94,9 @@ function createDeferred<T>(): {
 }
 
 afterEach(async () => {
+  delete (window as unknown as {
+    __pwragentFederationTarget?: unknown;
+  }).__pwragentFederationTarget;
   vi.useRealTimers();
   await flushReactUpdates();
   vi.mocked(normalizeImageFile).mockClear();
@@ -1100,7 +1103,7 @@ describe("Composer", () => {
     expect(screen.getByText(unavailableReason)).toHaveClass("composer__meta--error");
   });
 
-  it("opens the current workspace in discovered applications", async () => {
+  it("opens a remote thread workspace on its owning instance", async () => {
     const openApplication = vi.fn(async () => ({ opened: true as const }));
 
     render(
@@ -1154,6 +1157,18 @@ describe("Composer", () => {
           titleSource: "explicit",
           source: "codex",
           executionMode: "default",
+          federation: {
+            ref: {
+              backend: "codex",
+              target: {
+                scope: "remote",
+                instanceId: "remote-instance",
+              },
+              threadId: "thread-1",
+            },
+            instanceLabel: "Tart VM",
+            peerStatus: "connected",
+          },
           linkedDirectories: [
             {
               id: "directory-1",
@@ -1171,6 +1186,10 @@ describe("Composer", () => {
     await waitFor(() => {
       expect(openApplication).toHaveBeenCalledWith({
         applicationId: "vscode",
+        federationTarget: {
+          scope: "remote",
+          instanceId: "remote-instance",
+        },
         kind: "editor",
         targetPath: "/repo/PwrAgent",
       });
@@ -1180,6 +1199,10 @@ describe("Composer", () => {
     await waitFor(() => {
       expect(openApplication).toHaveBeenCalledWith({
         applicationId: "ghostty",
+        federationTarget: {
+          scope: "remote",
+          instanceId: "remote-instance",
+        },
         kind: "terminal",
         targetPath: "/repo/PwrAgent",
       });
@@ -1330,6 +1353,55 @@ describe("Composer", () => {
 
     expect(screen.queryByRole("button", { name: "VS Code" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Ghostty" })).not.toBeInTheDocument();
+  });
+
+  it("does not offer the controller's disk picker in a remote launchpad", () => {
+    (window as unknown as {
+      __pwragentFederationTarget?: unknown;
+    }).__pwragentFederationTarget = {
+      scope: "remote",
+      instanceId: "remote-instance",
+    };
+    const onPickAndRegisterDirectory = vi.fn();
+
+    render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        directories={[
+          {
+            key: "directory:/remote/repo",
+            kind: "directory",
+            label: "Remote repo",
+            path: "/remote/repo",
+            threadKeys: [],
+            needsAttentionCount: 0,
+          },
+        ]}
+        disabled={false}
+        launchpad={{
+          directoryKey: "workspace:new-thread",
+          directoryKind: "workspace",
+          directoryLabel: "Workspaces",
+          backend: "codex",
+          executionMode: "default",
+          prompt: "",
+          workMode: "local",
+          createdAt: 1,
+          updatedAt: 1,
+        }}
+        onPickAndRegisterDirectory={onPickAndRegisterDirectory}
+        onSelectDirectoryFromPicker={() => undefined}
+        skills={[]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Choose a project" }));
+
+    expect(screen.getByRole("option", { name: /remote repo/i })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /add directory/i }),
+    ).not.toBeInTheDocument();
+    expect(onPickAndRegisterDirectory).not.toHaveBeenCalled();
   });
 
   it("shows thread environment commands from refreshed environment options", async () => {

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -25,7 +25,10 @@ import {
   moveDirectoryKey,
   moveThreadKey,
 } from "@pwragent/shared";
-import { readRendererFederationLabel } from "../../lib/federation-window";
+import {
+  readRendererFederationLabel,
+  readRendererFederationTarget,
+} from "../../lib/federation-window";
 import type { RuntimeIdentity } from "../../../../shared/runtime-identity";
 import { copyText } from "../../lib/copy-text";
 import { BranchIcon, FolderIcon, SearchIcon } from "../../icons";
@@ -246,6 +249,10 @@ function uniqueContextMenuValues(
 
 export function Sidebar(props: SidebarProps) {
   const federationLabel = readRendererFederationLabel();
+  const federationTarget = readRendererFederationTarget();
+  const federationInstanceTag = federationTarget?.instanceId
+    .replace(/^pwr_/, "")
+    .slice(0, 4);
   const contextMenuRef = useRef<HTMLDivElement>(null);
   const directoryContextMenuRef = useRef<HTMLDivElement>(null);
   const renameInputRef = useRef<HTMLInputElement>(null);
@@ -1320,8 +1327,14 @@ export function Sidebar(props: SidebarProps) {
         <p className="sidebar__brand">
           Pwr<span className="sidebar__brand-accent">Agent</span>
           {federationLabel ? (
-            <span className="sidebar__federation-label">
-              {federationLabel}
+            <span
+              className="sidebar__federation-label"
+              title={federationTarget
+                ? `${federationLabel} · ${federationTarget.instanceId}`
+                : federationLabel}
+            >
+              Remote · {federationLabel}
+              {federationInstanceTag ? ` · ${federationInstanceTag}` : ""}
             </span>
           ) : null}
         </p>
@@ -1369,7 +1382,7 @@ export function Sidebar(props: SidebarProps) {
         </div>
       </header>
 
-      {props.runtimeIdentity ? (
+      {!federationLabel && props.runtimeIdentity ? (
         <div className="runtime-identity" aria-label="Runtime identity">
           <RuntimeIdentityButton
             copied={copiedRuntimeValue === "cwd"}
@@ -1393,7 +1406,7 @@ export function Sidebar(props: SidebarProps) {
         </div>
       ) : null}
 
-      {props.activeProfile ? (
+      {!federationLabel && props.activeProfile ? (
         <div className="runtime-identity" aria-label="PwrAgent profile">
           <ProfileIdentityButton
             label={profileLabel ?? `profile:${props.activeProfile}`}

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -25,6 +25,7 @@ import {
   moveDirectoryKey,
   moveThreadKey,
 } from "@pwragent/shared";
+import { readRendererFederationLabel } from "../../lib/federation-window";
 import type { RuntimeIdentity } from "../../../../shared/runtime-identity";
 import { copyText } from "../../lib/copy-text";
 import { BranchIcon, FolderIcon, SearchIcon } from "../../icons";
@@ -244,6 +245,7 @@ function uniqueContextMenuValues(
 }
 
 export function Sidebar(props: SidebarProps) {
+  const federationLabel = readRendererFederationLabel();
   const contextMenuRef = useRef<HTMLDivElement>(null);
   const directoryContextMenuRef = useRef<HTMLDivElement>(null);
   const renameInputRef = useRef<HTMLInputElement>(null);
@@ -1315,7 +1317,14 @@ export function Sidebar(props: SidebarProps) {
         onPointerDown={props.onResizeStart}
       />
       <header className="sidebar__masthead">
-        <p className="sidebar__brand">Pwr<span className="sidebar__brand-accent">Agent</span></p>
+        <p className="sidebar__brand">
+          Pwr<span className="sidebar__brand-accent">Agent</span>
+          {federationLabel ? (
+            <span className="sidebar__federation-label">
+              {federationLabel}
+            </span>
+          ) : null}
+        </p>
 
         <div className="sidebar__masthead-actions">
           <MastheadActionButton

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -213,6 +213,12 @@ function createDataTransfer(threadKey: string) {
 }
 
 afterEach(() => {
+  delete (window as unknown as {
+    __pwragentFederationLabel?: unknown;
+  }).__pwragentFederationLabel;
+  delete (window as unknown as {
+    __pwragentFederationTarget?: unknown;
+  }).__pwragentFederationTarget;
   vi.restoreAllMocks();
   document
     .querySelectorAll(".thread-row--drag-image")
@@ -221,6 +227,51 @@ afterEach(() => {
 });
 
 describe("Sidebar", () => {
+  it("labels a remote window without showing the controller's runtime identity", () => {
+    (window as unknown as {
+      __pwragentFederationLabel?: unknown;
+    }).__pwragentFederationLabel = "Tart VM";
+    (window as unknown as {
+      __pwragentFederationTarget?: unknown;
+    }).__pwragentFederationTarget = {
+      scope: "remote",
+      instanceId: "remote-instance",
+    };
+
+    render(
+      <Sidebar
+        activeProfile="dev"
+        backends={backends}
+        browseMode="recents"
+        createThreadError={undefined}
+        directories={directories}
+        inboxThreads={[sharedThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        profiles={[]}
+        runtimeIdentity={{
+          branch: "controller-branch",
+          cwd: "/controller/repo",
+        }}
+        selectedItemKey="codex:thread-1"
+        threads={[sharedThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />,
+    );
+
+    expect(screen.getByText("Remote · Tart VM · remo")).toHaveAttribute(
+      "title",
+      "Tart VM · remote-instance",
+    );
+    expect(screen.queryByLabelText("Runtime identity")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("PwrAgent profile")).not.toBeInTheDocument();
+    expect(screen.queryByText("controller-branch")).not.toBeInTheDocument();
+  });
+
   it("scrolls a newly selected thread row into view", () => {
     const { scrollIntoView, restore } = withMockScrollIntoView();
     const nextThread: NavigationThreadSummary = {

--- a/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
@@ -1,0 +1,231 @@
+import { useEffect, useState } from "react";
+import type {
+  DesktopSettingsSnapshot,
+  FederationConnectionState,
+  FederationHealthStatus,
+  FederationInstanceRole,
+} from "@pwragent/shared";
+import type { DesktopApi } from "../../lib/desktop-api";
+import {
+  SettingsField,
+  SettingsPanelHead,
+  SettingsSection,
+  SettingsSectionStack,
+} from "./SettingsLayout";
+
+type FederationSettingsProps = {
+  desktopApi?: DesktopApi;
+  snapshot: DesktopSettingsSnapshot;
+};
+
+export function FederationSettings(props: FederationSettingsProps) {
+  const [health, setHealth] = useState<FederationHealthStatus>();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string>();
+
+  const loadHealth = async () => {
+    const reader = props.desktopApi?.readFederationHealth;
+    if (!reader) {
+      setError("Federation diagnostics are unavailable.");
+      return;
+    }
+    setLoading(true);
+    setError(undefined);
+    try {
+      const response = await reader({});
+      setHealth(response.health);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void loadHealth();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.desktopApi]);
+
+  const mode = props.snapshot.federation.mode.value;
+  const effectiveHealth =
+    health ??
+    ({
+      enabled: mode !== "disabled",
+      role: mode === "gateway" || mode === "dual" ? mode : "child",
+      status: mode === "disabled" ? "disabled" : "disconnected",
+      listenUrl:
+        mode === "disabled"
+          ? undefined
+          : `ws://${props.snapshot.federation.listenHost.value}:${props.snapshot.federation.listenPort.value}`,
+      publicUrl: trimmedOrUndefined(props.snapshot.federation.publicUrl.value),
+      peers: [],
+    } satisfies FederationHealthStatus);
+
+  return (
+    <SettingsSectionStack paneId="federation" aria-label="Federation settings">
+      <SettingsPanelHead
+        eyebrow="Federation"
+        title="Instance Federation"
+        help="Remote instance connectivity, sanitized peer status, and gateway diagnostics."
+        action={
+          <button
+            className="button button--secondary"
+            type="button"
+            disabled={loading || !props.desktopApi?.readFederationHealth}
+            onClick={() => {
+              void loadHealth();
+            }}
+          >
+            {loading ? "Refreshing..." : "Refresh"}
+          </button>
+        }
+      />
+
+      {error ? <p className="settings-row__error">{error}</p> : null}
+
+      <SettingsSection
+        eyebrow="Runtime"
+        title="Connection"
+        chip={statusLabel(effectiveHealth.status)}
+        chipKind={chipKindForStatus(effectiveHealth.status)}
+      >
+        <div className="settings-fields">
+          <SettingsField
+            label="Mode"
+            sub="Configured role for this profile."
+            control={<code>{mode}</code>}
+          />
+          <SettingsField
+            label="Runtime role"
+            sub="Role advertised by the federation health surface."
+            control={<span>{roleLabel(effectiveHealth.role)}</span>}
+          />
+          <SettingsField
+            label="Local listener"
+            sub="Loopback or local bind target used by gateway modes."
+            control={<code>{effectiveHealth.listenUrl ?? "Not listening"}</code>}
+          />
+          <SettingsField
+            label="Public URL"
+            sub="Cloudflare Tunnel or other remote endpoint."
+            control={<code>{effectiveHealth.publicUrl ?? "Not configured"}</code>}
+          />
+          <SettingsField
+            label="Gateway URL"
+            sub="Outbound target used by child mode."
+            control={
+              <code>
+                {trimmedOrUndefined(props.snapshot.federation.gatewayUrl.value) ??
+                  "Not configured"}
+              </code>
+            }
+          />
+        </div>
+      </SettingsSection>
+
+      <SettingsSection
+        eyebrow="Peers"
+        title="Enrolled Peers"
+        chip={`${effectiveHealth.peers.length}`}
+      >
+        {effectiveHealth.peers.length === 0 ? (
+          <p className="settings-empty">No enrolled peers.</p>
+        ) : (
+          <dl className="settings-aboutkv">
+            {effectiveHealth.peers.map((peer) => (
+              <div key={peer.id}>
+                <dt>{peer.label}</dt>
+                <dd>
+                  {peer.id} · {roleLabel(peer.role)} · {statusLabel(peer.status)}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        )}
+      </SettingsSection>
+
+      <SettingsSection
+        eyebrow="Edge Policy"
+        title="Cloudflare"
+        chip={
+          props.snapshot.federation.cloudflareMtlsEnabled.value ||
+          props.snapshot.federation.cloudflareAccessServiceAuthEnabled.value
+            ? "Configured"
+            : "Optional"
+        }
+        chipKind={
+          props.snapshot.federation.cloudflareMtlsEnabled.value ||
+          props.snapshot.federation.cloudflareAccessServiceAuthEnabled.value
+            ? "ok"
+            : "muted"
+        }
+      >
+        <div className="settings-fields">
+          <SettingsField
+            label="mTLS"
+            sub="Cloudflare edge certificate gate."
+            control={
+              <span>
+                {props.snapshot.federation.cloudflareMtlsEnabled.value
+                  ? "Enabled"
+                  : "Disabled"}
+              </span>
+            }
+          />
+          <SettingsField
+            label="Access service auth"
+            sub="Cloudflare Access service-token gate."
+            control={
+              <span>
+                {props.snapshot.federation.cloudflareAccessServiceAuthEnabled.value
+                  ? "Enabled"
+                  : "Disabled"}
+              </span>
+            }
+          />
+        </div>
+      </SettingsSection>
+    </SettingsSectionStack>
+  );
+}
+
+function trimmedOrUndefined(value: string): string | undefined {
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function roleLabel(role: FederationInstanceRole): string {
+  switch (role) {
+    case "gateway":
+      return "Gateway";
+    case "child":
+      return "Child";
+    case "dual":
+      return "Dual";
+  }
+}
+
+function statusLabel(status: FederationConnectionState): string {
+  return status
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function chipKindForStatus(status: FederationConnectionState) {
+  switch (status) {
+    case "connected":
+    case "listening":
+      return "ok";
+    case "connecting":
+    case "handshaking":
+    case "degraded":
+      return "warn";
+    case "disabled":
+    case "disconnected":
+      return "muted";
+    case "rejected":
+    case "revoked":
+      return "err";
+  }
+}

--- a/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
@@ -331,11 +331,11 @@ export function FederationSettings(props: FederationSettingsProps) {
 
       <SettingsSection
         eyebrow="Peers"
-        title="Enrolled Peers"
+        title="Federation Instances"
         chip={`${effectiveHealth.peers.length}`}
       >
         {effectiveHealth.peers.length === 0 ? (
-          <p className="settings-empty">No enrolled peers.</p>
+          <p className="settings-empty">No federation instances.</p>
         ) : (
           <dl className="settings-aboutkv">
             {effectiveHealth.peers.map((peer) => (

--- a/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
@@ -85,7 +85,7 @@ export function FederationSettings(props: FederationSettingsProps) {
       role: props.snapshot.federation.mode.value === "gateway" ||
         props.snapshot.federation.mode.value === "dual"
         ? props.snapshot.federation.mode.value
-        : "child",
+        : "client",
       status: props.snapshot.federation.mode.value === "disabled" ? "disabled" : "disconnected",
       listenUrl:
         props.snapshot.federation.mode.value === "disabled"
@@ -126,7 +126,7 @@ export function FederationSettings(props: FederationSettingsProps) {
         <div className="settings-fields">
           <SettingsField
             label="Mode"
-            sub="Gateway listens for peers; child connects to a gateway."
+            sub="Gateway listens for peers; client connects to a gateway."
             control={
               <select
                 value={mode}
@@ -177,7 +177,7 @@ export function FederationSettings(props: FederationSettingsProps) {
           />
           <SettingsField
             label="Gateway URL"
-            sub="Child-mode gateway WebSocket URL."
+            sub="Client-mode gateway WebSocket URL."
             control={
               <input
                 value={gatewayUrl}
@@ -218,7 +218,7 @@ export function FederationSettings(props: FederationSettingsProps) {
         <div className="settings-fields">
           <SettingsField
             label="Generate invite"
-            sub="Creates a one-time child enrollment payload."
+            sub="Creates a one-time client enrollment payload."
             control={
               <button
                 className="button button--secondary"
@@ -240,7 +240,7 @@ export function FederationSettings(props: FederationSettingsProps) {
           {generatedInvite ? (
             <SettingsField
               label="Invite payload"
-              sub="Paste this into the child instance."
+              sub="Paste this into the client instance."
               control={
                 <textarea
                   readOnly
@@ -252,7 +252,7 @@ export function FederationSettings(props: FederationSettingsProps) {
           ) : null}
           <SettingsField
             label="Import invite"
-            sub="Paste a gateway invite on the child instance."
+            sub="Paste a gateway invite on the client instance."
             control={
               <textarea
                 rows={4}
@@ -318,7 +318,7 @@ export function FederationSettings(props: FederationSettingsProps) {
           />
           <SettingsField
             label="Gateway URL"
-            sub="Outbound target used by child mode."
+            sub="Outbound target used by client mode."
             control={
               <code>
                 {trimmedOrUndefined(props.snapshot.federation.gatewayUrl.value) ??
@@ -420,8 +420,8 @@ function roleLabel(role: FederationInstanceRole): string {
   switch (role) {
     case "gateway":
       return "Gateway";
-    case "child":
-      return "Child";
+    case "client":
+      return "Client";
     case "dual":
       return "Dual";
   }

--- a/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
@@ -1,10 +1,13 @@
 import { useEffect, useState } from "react";
 import type {
+  DesktopFederationMode,
+  DesktopSettingsConfigPatch,
   DesktopSettingsSnapshot,
   FederationConnectionState,
   FederationHealthStatus,
   FederationInstanceRole,
 } from "@pwragent/shared";
+import { DESKTOP_FEDERATION_MODES } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 import {
   SettingsField,
@@ -15,6 +18,9 @@ import {
 
 type FederationSettingsProps = {
   desktopApi?: DesktopApi;
+  onSettingsChanged: () => Promise<void>;
+  onWriteConfig: (patch: DesktopSettingsConfigPatch) => Promise<boolean>;
+  saving: boolean;
   snapshot: DesktopSettingsSnapshot;
 };
 
@@ -22,6 +28,32 @@ export function FederationSettings(props: FederationSettingsProps) {
   const [health, setHealth] = useState<FederationHealthStatus>();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string>();
+  const [actionError, setActionError] = useState<string>();
+  const [generatedInvite, setGeneratedInvite] = useState("");
+  const [inviteToImport, setInviteToImport] = useState("");
+  const [mode, setMode] = useState<DesktopFederationMode>(
+    props.snapshot.federation.mode.value,
+  );
+  const [listenHost, setListenHost] = useState(
+    props.snapshot.federation.listenHost.value,
+  );
+  const [listenPort, setListenPort] = useState(
+    String(props.snapshot.federation.listenPort.value),
+  );
+  const [publicUrl, setPublicUrl] = useState(
+    props.snapshot.federation.publicUrl.value,
+  );
+  const [gatewayUrl, setGatewayUrl] = useState(
+    props.snapshot.federation.gatewayUrl.value,
+  );
+
+  useEffect(() => {
+    setMode(props.snapshot.federation.mode.value);
+    setListenHost(props.snapshot.federation.listenHost.value);
+    setListenPort(String(props.snapshot.federation.listenPort.value));
+    setPublicUrl(props.snapshot.federation.publicUrl.value);
+    setGatewayUrl(props.snapshot.federation.gatewayUrl.value);
+  }, [props.snapshot]);
 
   const loadHealth = async () => {
     const reader = props.desktopApi?.readFederationHealth;
@@ -46,15 +78,17 @@ export function FederationSettings(props: FederationSettingsProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.desktopApi]);
 
-  const mode = props.snapshot.federation.mode.value;
   const effectiveHealth =
     health ??
     ({
-      enabled: mode !== "disabled",
-      role: mode === "gateway" || mode === "dual" ? mode : "child",
-      status: mode === "disabled" ? "disabled" : "disconnected",
+      enabled: props.snapshot.federation.mode.value !== "disabled",
+      role: props.snapshot.federation.mode.value === "gateway" ||
+        props.snapshot.federation.mode.value === "dual"
+        ? props.snapshot.federation.mode.value
+        : "child",
+      status: props.snapshot.federation.mode.value === "disabled" ? "disabled" : "disconnected",
       listenUrl:
-        mode === "disabled"
+        props.snapshot.federation.mode.value === "disabled"
           ? undefined
           : `ws://${props.snapshot.federation.listenHost.value}:${props.snapshot.federation.listenPort.value}`,
       publicUrl: trimmedOrUndefined(props.snapshot.federation.publicUrl.value),
@@ -84,6 +118,178 @@ export function FederationSettings(props: FederationSettingsProps) {
       {error ? <p className="settings-row__error">{error}</p> : null}
 
       <SettingsSection
+        eyebrow="Setup"
+        title="Configuration"
+        chip={props.saving ? "Saving" : "Editable"}
+        chipKind={props.saving ? "warn" : "muted"}
+      >
+        <div className="settings-fields">
+          <SettingsField
+            label="Mode"
+            sub="Gateway listens for peers; child connects to a gateway."
+            control={
+              <select
+                value={mode}
+                disabled={props.saving}
+                onChange={(event) => setMode(event.target.value as DesktopFederationMode)}
+              >
+                {DESKTOP_FEDERATION_MODES.map((entry) => (
+                  <option key={entry} value={entry}>
+                    {entry}
+                  </option>
+                ))}
+              </select>
+            }
+          />
+          <SettingsField
+            label="Listen host"
+            sub="Local address for gateway mode."
+            control={
+              <input
+                value={listenHost}
+                disabled={props.saving}
+                onChange={(event) => setListenHost(event.target.value)}
+              />
+            }
+          />
+          <SettingsField
+            label="Listen port"
+            sub="Local port for gateway mode."
+            control={
+              <input
+                inputMode="numeric"
+                value={listenPort}
+                disabled={props.saving}
+                onChange={(event) => setListenPort(event.target.value)}
+              />
+            }
+          />
+          <SettingsField
+            label="Public URL"
+            sub="Cloudflare Tunnel URL or local WebSocket URL for peers."
+            control={
+              <input
+                value={publicUrl}
+                disabled={props.saving}
+                onChange={(event) => setPublicUrl(event.target.value)}
+              />
+            }
+          />
+          <SettingsField
+            label="Gateway URL"
+            sub="Child-mode gateway WebSocket URL."
+            control={
+              <input
+                value={gatewayUrl}
+                disabled={props.saving}
+                onChange={(event) => setGatewayUrl(event.target.value)}
+              />
+            }
+          />
+          <div className="settings-button-row">
+            <button
+              className="button button--primary"
+              type="button"
+              disabled={props.saving}
+              onClick={() => {
+                void props.onWriteConfig({
+                  federation: {
+                    mode,
+                    listenHost,
+                    listenPort: Number.parseInt(listenPort, 10) || 0,
+                    publicUrl,
+                    gatewayUrl,
+                  },
+                }).then(() => loadHealth());
+              }}
+            >
+              Save federation settings
+            </button>
+          </div>
+        </div>
+      </SettingsSection>
+
+      <SettingsSection
+        eyebrow="Enrollment"
+        title="Invites"
+        chip={generatedInvite ? "Generated" : "Ready"}
+        chipKind={generatedInvite ? "ok" : "muted"}
+      >
+        <div className="settings-fields">
+          <SettingsField
+            label="Generate invite"
+            sub="Creates a one-time child enrollment payload."
+            control={
+              <button
+                className="button button--secondary"
+                type="button"
+                disabled={!props.desktopApi?.generateFederationInvite}
+                onClick={() => {
+                  setActionError(undefined);
+                  props.desktopApi?.generateFederationInvite?.({})
+                    .then((response) => setGeneratedInvite(response.invite))
+                    .catch((err: unknown) =>
+                      setActionError(err instanceof Error ? err.message : String(err)),
+                    );
+                }}
+              >
+                Generate invite
+              </button>
+            }
+          />
+          {generatedInvite ? (
+            <SettingsField
+              label="Invite payload"
+              sub="Paste this into the child instance."
+              control={
+                <textarea
+                  readOnly
+                  rows={4}
+                  value={generatedInvite}
+                />
+              }
+            />
+          ) : null}
+          <SettingsField
+            label="Import invite"
+            sub="Paste a gateway invite on the child instance."
+            control={
+              <textarea
+                rows={4}
+                value={inviteToImport}
+                disabled={!props.desktopApi?.importFederationInvite}
+                onChange={(event) => setInviteToImport(event.target.value)}
+              />
+            }
+          />
+          <div className="settings-button-row">
+            <button
+              className="button button--secondary"
+              type="button"
+              disabled={!props.desktopApi?.importFederationInvite || !inviteToImport.trim()}
+              onClick={() => {
+                setActionError(undefined);
+                props.desktopApi?.importFederationInvite?.({ invite: inviteToImport })
+                  .then(async () => {
+                    setInviteToImport("");
+                    await props.onSettingsChanged();
+                    await loadHealth();
+                  })
+                  .catch((err: unknown) =>
+                    setActionError(err instanceof Error ? err.message : String(err)),
+                  );
+              }}
+            >
+              Import invite
+            </button>
+          </div>
+          {actionError ? (
+            <p className="settings-row__error">{actionError}</p>
+          ) : null}
+        </div>
+      </SettingsSection>
+
+      <SettingsSection
         eyebrow="Runtime"
         title="Connection"
         chip={statusLabel(effectiveHealth.status)}
@@ -93,7 +299,7 @@ export function FederationSettings(props: FederationSettingsProps) {
           <SettingsField
             label="Mode"
             sub="Configured role for this profile."
-            control={<code>{mode}</code>}
+            control={<code>{props.snapshot.federation.mode.value}</code>}
           />
           <SettingsField
             label="Runtime role"
@@ -137,6 +343,22 @@ export function FederationSettings(props: FederationSettingsProps) {
                 <dt>{peer.label}</dt>
                 <dd>
                   {peer.id} · {roleLabel(peer.role)} · {statusLabel(peer.status)}
+                  <button
+                    className="button button--ghost"
+                    type="button"
+                    disabled={
+                      peer.status === "revoked" ||
+                      !props.desktopApi?.openFederationWindow
+                    }
+                    onClick={() => {
+                      void props.desktopApi?.openFederationWindow?.({
+                        target: { scope: "remote", instanceId: peer.id },
+                        label: peer.label,
+                      });
+                    }}
+                  >
+                    Open
+                  </button>
                 </dd>
               </div>
             ))}

--- a/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
@@ -423,31 +423,33 @@ export function FederationSettings(props: FederationSettingsProps) {
                   >
                     Open
                   </button>
-                  <button
-                    className="button button--ghost"
-                    type="button"
-                    disabled={
-                      peer.status === "revoked" ||
-                      revokingPeerId === peer.id ||
-                      !props.desktopApi?.revokeFederationPeer
-                    }
-                    onClick={() => {
-                      setActionError(undefined);
-                      setRevokingPeerId(peer.id);
-                      props.desktopApi?.revokeFederationPeer?.({
-                        peerId: peer.id,
-                      })
-                        .then(() => loadHealth())
-                        .catch((err: unknown) =>
-                          setActionError(
-                            err instanceof Error ? err.message : String(err),
-                          ),
-                        )
-                        .finally(() => setRevokingPeerId(undefined));
-                    }}
-                  >
-                    {revokingPeerId === peer.id ? "Revoking..." : "Revoke"}
-                  </button>
+                  {peer.canRevoke ? (
+                    <button
+                      className="button button--ghost"
+                      type="button"
+                      disabled={
+                        peer.status === "revoked" ||
+                        revokingPeerId === peer.id ||
+                        !props.desktopApi?.revokeFederationPeer
+                      }
+                      onClick={() => {
+                        setActionError(undefined);
+                        setRevokingPeerId(peer.id);
+                        props.desktopApi?.revokeFederationPeer?.({
+                          peerId: peer.id,
+                        })
+                          .then(() => loadHealth())
+                          .catch((err: unknown) =>
+                            setActionError(
+                              err instanceof Error ? err.message : String(err),
+                            ),
+                          )
+                          .finally(() => setRevokingPeerId(undefined));
+                      }}
+                    >
+                      {revokingPeerId === peer.id ? "Revoking..." : "Revoke"}
+                    </button>
+                  ) : null}
                 </dd>
               </div>
             ))}

--- a/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
@@ -116,6 +116,10 @@ export function FederationSettings(props: FederationSettingsProps) {
 
   useEffect(() => {
     void loadHealth();
+    const refreshInterval = window.setInterval(() => {
+      void loadHealth();
+    }, 2_000);
+    return () => window.clearInterval(refreshInterval);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.desktopApi]);
 

--- a/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from "react";
 import type {
   DesktopFederationMode,
+  DesktopSettingsSecretName,
   DesktopSettingsConfigPatch,
   DesktopSettingsSnapshot,
   FederationConnectionState,
+  FederationDiagnosticEvent,
   FederationHealthStatus,
   FederationInstanceRole,
 } from "@pwragent/shared";
@@ -19,6 +21,11 @@ import {
 type FederationSettingsProps = {
   desktopApi?: DesktopApi;
   onSettingsChanged: () => Promise<void>;
+  onClearSecret: (secret: DesktopSettingsSecretName) => Promise<boolean>;
+  onReplaceSecret: (
+    secret: DesktopSettingsSecretName,
+    value: string,
+  ) => Promise<boolean>;
   onWriteConfig: (patch: DesktopSettingsConfigPatch) => Promise<boolean>;
   saving: boolean;
   snapshot: DesktopSettingsSnapshot;
@@ -26,11 +33,15 @@ type FederationSettingsProps = {
 
 export function FederationSettings(props: FederationSettingsProps) {
   const [health, setHealth] = useState<FederationHealthStatus>();
+  const [diagnosticEvents, setDiagnosticEvents] = useState<
+    FederationDiagnosticEvent[]
+  >([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string>();
   const [actionError, setActionError] = useState<string>();
   const [generatedInvite, setGeneratedInvite] = useState("");
   const [inviteToImport, setInviteToImport] = useState("");
+  const [revokingPeerId, setRevokingPeerId] = useState<string>();
   const [mode, setMode] = useState<DesktopFederationMode>(
     props.snapshot.federation.mode.value,
   );
@@ -46,6 +57,22 @@ export function FederationSettings(props: FederationSettingsProps) {
   const [gatewayUrl, setGatewayUrl] = useState(
     props.snapshot.federation.gatewayUrl.value,
   );
+  const [cloudflareMtlsEnabled, setCloudflareMtlsEnabled] = useState(
+    props.snapshot.federation.cloudflareMtlsEnabled.value,
+  );
+  const [
+    cloudflareAccessServiceAuthEnabled,
+    setCloudflareAccessServiceAuthEnabled,
+  ] = useState(
+    props.snapshot.federation.cloudflareAccessServiceAuthEnabled.value,
+  );
+  const [cloudflareClientCertificate, setCloudflareClientCertificate] =
+    useState("");
+  const [cloudflareClientPrivateKey, setCloudflareClientPrivateKey] =
+    useState("");
+  const [cloudflareAccessClientId, setCloudflareAccessClientId] = useState("");
+  const [cloudflareAccessClientSecret, setCloudflareAccessClientSecret] =
+    useState("");
 
   useEffect(() => {
     setMode(props.snapshot.federation.mode.value);
@@ -53,19 +80,33 @@ export function FederationSettings(props: FederationSettingsProps) {
     setListenPort(String(props.snapshot.federation.listenPort.value));
     setPublicUrl(props.snapshot.federation.publicUrl.value);
     setGatewayUrl(props.snapshot.federation.gatewayUrl.value);
+    setCloudflareMtlsEnabled(
+      props.snapshot.federation.cloudflareMtlsEnabled.value,
+    );
+    setCloudflareAccessServiceAuthEnabled(
+      props.snapshot.federation.cloudflareAccessServiceAuthEnabled.value,
+    );
   }, [props.snapshot]);
 
   const loadHealth = async () => {
-    const reader = props.desktopApi?.readFederationHealth;
-    if (!reader) {
+    const diagnosticsReader = props.desktopApi?.readFederationDiagnostics;
+    const healthReader = props.desktopApi?.readFederationHealth;
+    if (!diagnosticsReader && !healthReader) {
       setError("Federation diagnostics are unavailable.");
       return;
     }
     setLoading(true);
     setError(undefined);
     try {
-      const response = await reader({});
-      setHealth(response.health);
+      if (diagnosticsReader) {
+        const response = await diagnosticsReader({ limit: 50 });
+        setHealth(response.health);
+        setDiagnosticEvents(response.events);
+      } else if (healthReader) {
+        const response = await healthReader({});
+        setHealth(response.health);
+        setDiagnosticEvents([]);
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
@@ -105,7 +146,11 @@ export function FederationSettings(props: FederationSettingsProps) {
           <button
             className="button button--secondary"
             type="button"
-            disabled={loading || !props.desktopApi?.readFederationHealth}
+            disabled={
+              loading ||
+              (!props.desktopApi?.readFederationDiagnostics &&
+                !props.desktopApi?.readFederationHealth)
+            }
             onClick={() => {
               void loadHealth();
             }}
@@ -199,6 +244,8 @@ export function FederationSettings(props: FederationSettingsProps) {
                     listenPort: Number.parseInt(listenPort, 10) || 0,
                     publicUrl,
                     gatewayUrl,
+                    cloudflareMtlsEnabled,
+                    cloudflareAccessServiceAuthEnabled,
                   },
                 }).then(() => loadHealth());
               }}
@@ -326,6 +373,11 @@ export function FederationSettings(props: FederationSettingsProps) {
               </code>
             }
           />
+          {effectiveHealth.unavailableReason ? (
+            <p className="settings-row__error">
+              {effectiveHealth.unavailableReason}
+            </p>
+          ) : null}
         </div>
       </SettingsSection>
 
@@ -341,13 +393,25 @@ export function FederationSettings(props: FederationSettingsProps) {
             {effectiveHealth.peers.map((peer) => (
               <div key={peer.id}>
                 <dt>{peer.label}</dt>
-                <dd>
-                  {peer.id} · {roleLabel(peer.role)} · {statusLabel(peer.status)}
+                <dd className="federation-peer-summary">
+                  <span>
+                    {peer.id} · {roleLabel(peer.role)} · {statusLabel(peer.status)}
+                  </span>
+                  <span>
+                    Protocol {peer.protocolVersion ?? "unknown"} ·{" "}
+                    {peer.capabilities.length} capabilities
+                    {peer.lastActivityAt
+                      ? ` · Active ${formatTimestamp(peer.lastActivityAt)}`
+                      : ""}
+                  </span>
+                  {peer.unavailableReason ? (
+                    <span>{peer.unavailableReason}</span>
+                  ) : null}
                   <button
                     className="button button--ghost"
                     type="button"
                     disabled={
-                      peer.status === "revoked" ||
+                      peer.status !== "connected" ||
                       !props.desktopApi?.openFederationWindow
                     }
                     onClick={() => {
@@ -359,6 +423,56 @@ export function FederationSettings(props: FederationSettingsProps) {
                   >
                     Open
                   </button>
+                  <button
+                    className="button button--ghost"
+                    type="button"
+                    disabled={
+                      peer.status === "revoked" ||
+                      revokingPeerId === peer.id ||
+                      !props.desktopApi?.revokeFederationPeer
+                    }
+                    onClick={() => {
+                      setActionError(undefined);
+                      setRevokingPeerId(peer.id);
+                      props.desktopApi?.revokeFederationPeer?.({
+                        peerId: peer.id,
+                      })
+                        .then(() => loadHealth())
+                        .catch((err: unknown) =>
+                          setActionError(
+                            err instanceof Error ? err.message : String(err),
+                          ),
+                        )
+                        .finally(() => setRevokingPeerId(undefined));
+                    }}
+                  >
+                    {revokingPeerId === peer.id ? "Revoking..." : "Revoke"}
+                  </button>
+                </dd>
+              </div>
+            ))}
+          </dl>
+        )}
+      </SettingsSection>
+
+      <SettingsSection
+        eyebrow="Diagnostics"
+        title="Recent Federation Activity"
+        chip={`${diagnosticEvents.length}`}
+      >
+        {diagnosticEvents.length === 0 ? (
+          <p className="settings-empty">No federation activity recorded.</p>
+        ) : (
+          <dl className="settings-aboutkv">
+            {diagnosticEvents.map((event) => (
+              <div key={event.eventId}>
+                <dt>{diagnosticEventLabel(event.kind)}</dt>
+                <dd className="federation-peer-summary">
+                  <span>
+                    {formatTimestamp(event.createdAt)}
+                    {event.peerId ? ` · ${event.peerId}` : ""}
+                  </span>
+                  {event.detail ? <span>{event.detail}</span> : null}
                 </dd>
               </div>
             ))}
@@ -370,14 +484,14 @@ export function FederationSettings(props: FederationSettingsProps) {
         eyebrow="Edge Policy"
         title="Cloudflare"
         chip={
-          props.snapshot.federation.cloudflareMtlsEnabled.value ||
-          props.snapshot.federation.cloudflareAccessServiceAuthEnabled.value
+          cloudflareMtlsEnabled ||
+          cloudflareAccessServiceAuthEnabled
             ? "Configured"
             : "Optional"
         }
         chipKind={
-          props.snapshot.federation.cloudflareMtlsEnabled.value ||
-          props.snapshot.federation.cloudflareAccessServiceAuthEnabled.value
+          cloudflareMtlsEnabled ||
+          cloudflareAccessServiceAuthEnabled
             ? "ok"
             : "muted"
         }
@@ -387,28 +501,247 @@ export function FederationSettings(props: FederationSettingsProps) {
             label="mTLS"
             sub="Cloudflare edge certificate gate."
             control={
-              <span>
-                {props.snapshot.federation.cloudflareMtlsEnabled.value
-                  ? "Enabled"
-                  : "Disabled"}
-              </span>
+              <input
+                aria-label="mTLS"
+                type="checkbox"
+                checked={cloudflareMtlsEnabled}
+                onChange={(event) =>
+                  setCloudflareMtlsEnabled(event.target.checked)
+                }
+              />
+            }
+          />
+          <SettingsField
+            label="Client certificate"
+            sub={secretStatus(
+              props.snapshot.federation.cloudflareClientCertificate.configured,
+            )}
+            control={
+              <textarea
+                aria-label="Client certificate"
+                rows={3}
+                value={cloudflareClientCertificate}
+                placeholder="PEM certificate"
+                onChange={(event) =>
+                  setCloudflareClientCertificate(event.target.value)
+                }
+              />
+            }
+          />
+          <SettingsField
+            label="Client private key"
+            sub={secretStatus(
+              props.snapshot.federation.cloudflareClientPrivateKey.configured,
+            )}
+            control={
+              <textarea
+                aria-label="Client private key"
+                rows={3}
+                value={cloudflareClientPrivateKey}
+                placeholder="PEM private key"
+                onChange={(event) =>
+                  setCloudflareClientPrivateKey(event.target.value)
+                }
+              />
             }
           />
           <SettingsField
             label="Access service auth"
             sub="Cloudflare Access service-token gate."
             control={
-              <span>
-                {props.snapshot.federation.cloudflareAccessServiceAuthEnabled.value
-                  ? "Enabled"
-                  : "Disabled"}
-              </span>
+              <input
+                aria-label="Access service auth"
+                type="checkbox"
+                checked={cloudflareAccessServiceAuthEnabled}
+                onChange={(event) =>
+                  setCloudflareAccessServiceAuthEnabled(event.target.checked)
+                }
+              />
             }
           />
+          <SettingsField
+            label="Access client ID"
+            sub={secretStatus(
+              props.snapshot.federation.cloudflareAccessClientId.configured,
+            )}
+            control={
+              <input
+                aria-label="Access client ID"
+                type="password"
+                value={cloudflareAccessClientId}
+                placeholder="Cloudflare Access client ID"
+                onChange={(event) =>
+                  setCloudflareAccessClientId(event.target.value)
+                }
+              />
+            }
+          />
+          <SettingsField
+            label="Access client secret"
+            sub={secretStatus(
+              props.snapshot.federation.cloudflareAccessClientSecret.configured,
+            )}
+            control={
+              <input
+                aria-label="Access client secret"
+                type="password"
+                value={cloudflareAccessClientSecret}
+                placeholder="Cloudflare Access client secret"
+                onChange={(event) =>
+                  setCloudflareAccessClientSecret(event.target.value)
+                }
+              />
+            }
+          />
+          <div className="settings-button-row">
+            <button
+              className="button button--secondary"
+              type="button"
+              disabled={props.saving}
+              onClick={() => {
+                setActionError(undefined);
+                void saveCloudflareSettings({
+                  config: {
+                    cloudflareMtlsEnabled,
+                    cloudflareAccessServiceAuthEnabled,
+                  },
+                  secrets: [
+                    [
+                      "federationCloudflareClientCertificate",
+                      cloudflareClientCertificate,
+                    ],
+                    [
+                      "federationCloudflareClientPrivateKey",
+                      cloudflareClientPrivateKey,
+                    ],
+                    [
+                      "federationCloudflareAccessClientId",
+                      cloudflareAccessClientId,
+                    ],
+                    [
+                      "federationCloudflareAccessClientSecret",
+                      cloudflareAccessClientSecret,
+                    ],
+                  ],
+                  onReplaceSecret: props.onReplaceSecret,
+                  onWriteConfig: props.onWriteConfig,
+                })
+                  .then(async () => {
+                    setCloudflareClientCertificate("");
+                    setCloudflareClientPrivateKey("");
+                    setCloudflareAccessClientId("");
+                    setCloudflareAccessClientSecret("");
+                    await props.onSettingsChanged();
+                    await loadHealth();
+                  })
+                  .catch((err: unknown) =>
+                    setActionError(
+                      err instanceof Error ? err.message : String(err),
+                    ),
+                  );
+              }}
+            >
+              Save edge policy
+            </button>
+            <button
+              className="button button--ghost"
+              type="button"
+              disabled={props.saving}
+              onClick={() => {
+                setActionError(undefined);
+                void Promise.all([
+                  props.onClearSecret(
+                    "federationCloudflareClientCertificate",
+                  ),
+                  props.onClearSecret(
+                    "federationCloudflareClientPrivateKey",
+                  ),
+                  props.onClearSecret("federationCloudflareAccessClientId"),
+                  props.onClearSecret(
+                    "federationCloudflareAccessClientSecret",
+                  ),
+                ])
+                  .then(async (cleared) => {
+                    if (cleared.some((result) => !result)) {
+                      throw new Error(
+                        "One or more Cloudflare credentials could not be cleared.",
+                      );
+                    }
+                    const written = await props.onWriteConfig({
+                      federation: {
+                        cloudflareMtlsEnabled: false,
+                        cloudflareAccessServiceAuthEnabled: false,
+                      },
+                    });
+                    if (!written) {
+                      throw new Error(
+                        "Cloudflare edge policy could not be updated.",
+                      );
+                    }
+                    setCloudflareMtlsEnabled(false);
+                    setCloudflareAccessServiceAuthEnabled(false);
+                    await props.onSettingsChanged();
+                    await loadHealth();
+                  })
+                  .catch((err: unknown) =>
+                    setActionError(
+                      err instanceof Error ? err.message : String(err),
+                    ),
+                  );
+              }}
+            >
+              Clear credentials
+            </button>
+          </div>
         </div>
       </SettingsSection>
     </SettingsSectionStack>
   );
+}
+
+async function saveCloudflareSettings(params: {
+  config: {
+    cloudflareMtlsEnabled: boolean;
+    cloudflareAccessServiceAuthEnabled: boolean;
+  };
+  secrets: Array<[DesktopSettingsSecretName, string]>;
+  onReplaceSecret: (
+    secret: DesktopSettingsSecretName,
+    value: string,
+  ) => Promise<boolean>;
+  onWriteConfig: (patch: DesktopSettingsConfigPatch) => Promise<boolean>;
+}): Promise<void> {
+  for (const [secret, value] of params.secrets) {
+    if (value.trim()) {
+      const saved = await params.onReplaceSecret(secret, value);
+      if (!saved) {
+        throw new Error(`Cloudflare credential ${secret} could not be saved.`);
+      }
+    }
+  }
+  const written = await params.onWriteConfig({
+    federation: params.config,
+  });
+  if (!written) {
+    throw new Error("Cloudflare edge policy could not be updated.");
+  }
+}
+
+function secretStatus(configured: boolean): string {
+  return configured
+    ? "Stored securely. Leave blank to keep it."
+    : "Not configured.";
+}
+
+function diagnosticEventLabel(kind: FederationDiagnosticEvent["kind"]): string {
+  return kind
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function formatTimestamp(value: number): string {
+  return new Date(value).toLocaleString();
 }
 
 function trimmedOrUndefined(value: string): string | undefined {

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -657,7 +657,10 @@ function SettingsSectionBody(props: {
     return (
       <FederationSettings
         desktopApi={props.desktopApi}
+        saving={props.settings.saving}
         snapshot={props.snapshot}
+        onSettingsChanged={props.settings.refresh}
+        onWriteConfig={props.settings.writeConfig}
       />
     );
   }

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -15,6 +15,7 @@ import type { PwrAgentProfilesState } from "../../lib/usePwrAgentProfiles";
 import type { DesktopSettingsState } from "./useDesktopSettings";
 import { AboutSettings } from "./AboutSettings";
 import { ExperimentalSettings } from "./ExperimentalSettings";
+import { FederationSettings } from "./FederationSettings";
 import { GeneralSettings } from "./GeneralSettings";
 import { GitSettings } from "./GitSettings";
 import { MessagingSettings } from "./MessagingSettings";
@@ -41,6 +42,7 @@ export type SettingsSection =
   | "git"
   | "experimental"
   | "messaging"
+  | "federation"
   | "models"
   | "profiles"
   | "applications"
@@ -57,6 +59,7 @@ const SECTIONS: Array<{ id: SettingsSection; label: string }> = [
   { id: "models", label: "AI Providers" },
   { id: "messaging", label: "Messaging" },
   { id: "git", label: "Git" },
+  { id: "federation", label: "Federation" },
   { id: "worktrees", label: "Worktrees" },
   { id: "thread-management", label: "Thread Management" },
   { id: "archived", label: "Archived Threads" },
@@ -71,9 +74,10 @@ const PRIMARY_SECTIONS: SettingsSection[] = [
   "profiles",
   "models",
   "messaging",
+  "federation",
 ];
 
-const SETTINGS_NAV_DIVIDER_AFTER: SettingsSection = "messaging";
+const SETTINGS_NAV_DIVIDER_AFTER: SettingsSection = "federation";
 
 const SECTION_LABELS = new Map(
   SECTIONS.map((section) => [section.id, section.label] as const),
@@ -645,6 +649,15 @@ function SettingsSectionBody(props: {
             messaging: { line: delta },
           });
         }}
+      />
+    );
+  }
+
+  if (props.section === "federation") {
+    return (
+      <FederationSettings
+        desktopApi={props.desktopApi}
+        snapshot={props.snapshot}
       />
     );
   }

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -659,6 +659,8 @@ function SettingsSectionBody(props: {
         desktopApi={props.desktopApi}
         saving={props.settings.saving}
         snapshot={props.snapshot}
+        onClearSecret={props.settings.clearSecret}
+        onReplaceSecret={props.settings.replaceSecret}
         onSettingsChanged={props.settings.refresh}
         onWriteConfig={props.settings.writeConfig}
       />

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
@@ -37,7 +37,10 @@ describe("FederationSettings", () => {
     render(
       <FederationSettings
         desktopApi={desktopApi}
+        saving={false}
         snapshot={settingsSnapshot()}
+        onSettingsChanged={vi.fn()}
+        onWriteConfig={vi.fn(async () => true)}
       />,
     );
 
@@ -54,11 +57,18 @@ describe("FederationSettings", () => {
   });
 
   it("falls back to the settings snapshot when diagnostics are unavailable", () => {
-    render(<FederationSettings snapshot={settingsSnapshot()} />);
+    render(
+      <FederationSettings
+        saving={false}
+        snapshot={settingsSnapshot()}
+        onSettingsChanged={vi.fn()}
+        onWriteConfig={vi.fn(async () => true)}
+      />,
+    );
 
     expect(screen.getByText("Federation diagnostics are unavailable."))
       .toBeInTheDocument();
-    expect(screen.getByText("gateway")).toBeInTheDocument();
+    expect(screen.getAllByText("gateway").length).toBeGreaterThan(0);
     expect(screen.getByText("wss://child.example.com/federation"))
       .toBeInTheDocument();
   });

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
@@ -22,9 +22,9 @@ describe("FederationSettings", () => {
       publicUrl: "wss://pwragent.example.com/federation",
       peers: [
         {
-          id: "child_one",
+          id: "client_one",
           label: "Studio Mac",
-          role: "child",
+          role: "client",
           status: "connected",
           capabilities: ["thread_navigation"],
         },
@@ -69,7 +69,7 @@ describe("FederationSettings", () => {
     expect(screen.getByText("Federation diagnostics are unavailable."))
       .toBeInTheDocument();
     expect(screen.getAllByText("gateway").length).toBeGreaterThan(0);
-    expect(screen.getByText("wss://child.example.com/federation"))
+    expect(screen.getByText("wss://client.example.com/federation"))
       .toBeInTheDocument();
   });
 });
@@ -85,7 +85,7 @@ function settingsSnapshot(): DesktopSettingsSnapshot {
         source: "config",
       },
       gatewayUrl: {
-        value: "wss://child.example.com/federation",
+        value: "wss://client.example.com/federation",
         source: "config",
       },
       cloudflareMtlsEnabled: { value: true, source: "config" },

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
@@ -1,0 +1,85 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  DesktopSettingsSnapshot,
+  FederationHealthStatus,
+} from "@pwragent/shared";
+import type { DesktopApi } from "../../../lib/desktop-api";
+import { FederationSettings } from "../FederationSettings";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("FederationSettings", () => {
+  it("renders configured endpoints and sanitized peer health", async () => {
+    const health: FederationHealthStatus = {
+      enabled: true,
+      role: "gateway",
+      status: "listening",
+      listenUrl: "ws://127.0.0.1:8765",
+      publicUrl: "wss://pwragent.example.com/federation",
+      peers: [
+        {
+          id: "child_one",
+          label: "Studio Mac",
+          role: "child",
+          status: "connected",
+          capabilities: ["thread_navigation"],
+        },
+      ],
+    };
+    const desktopApi: DesktopApi = {
+      readFederationHealth: vi.fn(async () => ({ health })),
+    };
+
+    render(
+      <FederationSettings
+        desktopApi={desktopApi}
+        snapshot={settingsSnapshot()}
+      />,
+    );
+
+    expect(await screen.findByText("Instance Federation")).toBeInTheDocument();
+    expect(screen.getByText("ws://127.0.0.1:8765")).toBeInTheDocument();
+    expect(
+      screen.getByText("wss://pwragent.example.com/federation"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Studio Mac")).toBeInTheDocument();
+    expect(screen.queryByText("secret-public-key")).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(desktopApi.readFederationHealth).toHaveBeenCalledWith({}),
+    );
+  });
+
+  it("falls back to the settings snapshot when diagnostics are unavailable", () => {
+    render(<FederationSettings snapshot={settingsSnapshot()} />);
+
+    expect(screen.getByText("Federation diagnostics are unavailable."))
+      .toBeInTheDocument();
+    expect(screen.getByText("gateway")).toBeInTheDocument();
+    expect(screen.getByText("wss://child.example.com/federation"))
+      .toBeInTheDocument();
+  });
+});
+
+function settingsSnapshot(): DesktopSettingsSnapshot {
+  return {
+    federation: {
+      mode: { value: "gateway", source: "config" },
+      listenHost: { value: "127.0.0.1", source: "config" },
+      listenPort: { value: 8765, source: "config" },
+      publicUrl: {
+        value: "wss://pwragent.example.com/federation",
+        source: "config",
+      },
+      gatewayUrl: {
+        value: "wss://child.example.com/federation",
+        source: "config",
+      },
+      cloudflareMtlsEnabled: { value: true, source: "config" },
+      cloudflareAccessServiceAuthEnabled: { value: false, source: "config" },
+    },
+  } as DesktopSettingsSnapshot;
+}

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
@@ -1,5 +1,6 @@
 import "@testing-library/jest-dom/vitest";
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -17,6 +18,7 @@ import { FederationSettings } from "../FederationSettings";
 
 afterEach(() => {
   cleanup();
+  vi.useRealTimers();
 });
 
 describe("FederationSettings", () => {
@@ -156,6 +158,68 @@ describe("FederationSettings", () => {
       }),
     );
     expect(openFederationWindow).not.toHaveBeenCalled();
+  });
+
+  it("refreshes stale connection health while settings remains open", async () => {
+    vi.useFakeTimers();
+    const connected: FederationHealthStatus = {
+      enabled: true,
+      role: "client",
+      status: "connected",
+      peers: [
+        {
+          id: "gateway_one",
+          label: "Studio Mac",
+          role: "gateway",
+          status: "connected",
+          capabilities: ["remote_window"],
+        },
+      ],
+    };
+    const disconnected: FederationHealthStatus = {
+      ...connected,
+      status: "connecting",
+      unavailableReason: "Federation gateway connection closed.",
+      peers: connected.peers.map((peer) => ({
+        ...peer,
+        status: "disconnected",
+        unavailableReason: "Federation gateway connection closed.",
+      })),
+    };
+    const readFederationHealth = vi.fn()
+      .mockResolvedValueOnce({ health: connected })
+      .mockResolvedValue({ health: disconnected });
+    const view = render(
+      <FederationSettings
+        desktopApi={{
+          openFederationWindow: vi.fn(),
+          readFederationHealth,
+        }}
+        onClearSecret={vi.fn(async () => true)}
+        onReplaceSecret={vi.fn(async () => true)}
+        saving={false}
+        snapshot={settingsSnapshot()}
+        onSettingsChanged={vi.fn()}
+        onWriteConfig={vi.fn(async () => true)}
+      />,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.getByText("Connected")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Open" })).toBeEnabled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+    });
+
+    expect(screen.getByText("Connecting")).toBeInTheDocument();
+    expect(screen.getAllByText("Federation gateway connection closed."))
+      .toHaveLength(2);
+    expect(screen.getByRole("button", { name: "Open" })).toBeDisabled();
+    view.unmount();
+    vi.useRealTimers();
   });
 
   it("stores Cloudflare client credentials before enabling edge policy", async () => {

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
@@ -1,9 +1,16 @@
 import "@testing-library/jest-dom/vitest";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
   DesktopSettingsSnapshot,
   FederationHealthStatus,
+  ReadFederationDiagnosticsResponse,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../../lib/desktop-api";
 import { FederationSettings } from "../FederationSettings";
@@ -37,6 +44,8 @@ describe("FederationSettings", () => {
     render(
       <FederationSettings
         desktopApi={desktopApi}
+        onClearSecret={vi.fn(async () => true)}
+        onReplaceSecret={vi.fn(async () => true)}
         saving={false}
         snapshot={settingsSnapshot()}
         onSettingsChanged={vi.fn()}
@@ -59,6 +68,8 @@ describe("FederationSettings", () => {
   it("falls back to the settings snapshot when diagnostics are unavailable", () => {
     render(
       <FederationSettings
+        onClearSecret={vi.fn(async () => true)}
+        onReplaceSecret={vi.fn(async () => true)}
         saving={false}
         snapshot={settingsSnapshot()}
         onSettingsChanged={vi.fn()}
@@ -71,6 +82,122 @@ describe("FederationSettings", () => {
     expect(screen.getAllByText("gateway").length).toBeGreaterThan(0);
     expect(screen.getByText("wss://client.example.com/federation"))
       .toBeInTheDocument();
+  });
+
+  it("shows audit diagnostics and revokes peers without opening unavailable ones", async () => {
+    const revokeFederationPeer = vi.fn(async () => ({
+      peer: {
+        id: "client_one",
+        label: "Studio Mac",
+        role: "client" as const,
+        status: "revoked" as const,
+        capabilities: [],
+      },
+    }));
+    const openFederationWindow = vi.fn();
+    const desktopApi: DesktopApi = {
+      openFederationWindow,
+      readFederationDiagnostics: vi.fn(
+        async (): Promise<ReadFederationDiagnosticsResponse> => ({
+          health: {
+            enabled: true,
+            role: "gateway",
+            status: "listening",
+            peers: [
+              {
+                id: "client_one",
+                label: "Studio Mac",
+                role: "client",
+                status: "disconnected",
+                capabilities: ["thread_navigation", "turn_control"],
+                protocolVersion: 1,
+                unavailableReason: "Transport closed.",
+              },
+            ],
+          },
+          events: [
+            {
+              eventId: 1,
+              peerId: "client_one",
+              kind: "rejected",
+              createdAt: 1_000,
+              detail: "bad_signature",
+            },
+          ],
+        }),
+      ),
+      revokeFederationPeer,
+    };
+
+    render(
+      <FederationSettings
+        desktopApi={desktopApi}
+        onClearSecret={vi.fn(async () => true)}
+        onReplaceSecret={vi.fn(async () => true)}
+        saving={false}
+        snapshot={settingsSnapshot()}
+        onSettingsChanged={vi.fn()}
+        onWriteConfig={vi.fn(async () => true)}
+      />,
+    );
+
+    expect(await screen.findByText("bad_signature")).toBeInTheDocument();
+    expect(screen.getByText("Transport closed.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Open" })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Revoke" }));
+
+    await waitFor(() =>
+      expect(revokeFederationPeer).toHaveBeenCalledWith({
+        peerId: "client_one",
+      }),
+    );
+    expect(openFederationWindow).not.toHaveBeenCalled();
+  });
+
+  it("stores Cloudflare client credentials before enabling edge policy", async () => {
+    const onReplaceSecret = vi.fn(async () => true);
+    const onWriteConfig = vi.fn(async () => true);
+    render(
+      <FederationSettings
+        onClearSecret={vi.fn(async () => true)}
+        onReplaceSecret={onReplaceSecret}
+        saving={false}
+        snapshot={settingsSnapshot()}
+        onSettingsChanged={vi.fn()}
+        onWriteConfig={onWriteConfig}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole("checkbox", { name: "mTLS" }), {
+      target: { checked: true },
+    });
+    fireEvent.change(screen.getByPlaceholderText("PEM certificate"), {
+      target: { value: "certificate-pem" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("PEM private key"), {
+      target: { value: "private-key-pem" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save edge policy" }));
+
+    await waitFor(() =>
+      expect(onReplaceSecret).toHaveBeenCalledWith(
+        "federationCloudflareClientCertificate",
+        "certificate-pem",
+      ),
+    );
+    await waitFor(() => {
+      expect(onReplaceSecret).toHaveBeenCalledWith(
+        "federationCloudflareClientPrivateKey",
+        "private-key-pem",
+      );
+      expect(onWriteConfig).toHaveBeenCalledWith({
+        federation: {
+          cloudflareMtlsEnabled: true,
+          cloudflareAccessServiceAuthEnabled: false,
+        },
+      });
+    });
   });
 });
 
@@ -90,6 +217,26 @@ function settingsSnapshot(): DesktopSettingsSnapshot {
       },
       cloudflareMtlsEnabled: { value: true, source: "config" },
       cloudflareAccessServiceAuthEnabled: { value: false, source: "config" },
+      cloudflareClientCertificate: {
+        configured: false,
+        source: "unset",
+        writable: true,
+      },
+      cloudflareClientPrivateKey: {
+        configured: false,
+        source: "unset",
+        writable: true,
+      },
+      cloudflareAccessClientId: {
+        configured: false,
+        source: "unset",
+        writable: true,
+      },
+      cloudflareAccessClientSecret: {
+        configured: false,
+        source: "unset",
+        writable: true,
+      },
     },
   } as DesktopSettingsSnapshot;
 }

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
@@ -59,6 +59,8 @@ describe("FederationSettings", () => {
       screen.getByText("wss://pwragent.example.com/federation"),
     ).toBeInTheDocument();
     expect(screen.getByText("Studio Mac")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Revoke" }))
+      .not.toBeInTheDocument();
     expect(screen.queryByText("secret-public-key")).not.toBeInTheDocument();
     await waitFor(() =>
       expect(desktopApi.readFederationHealth).toHaveBeenCalledWith({}),
@@ -110,6 +112,7 @@ describe("FederationSettings", () => {
                 role: "client",
                 status: "disconnected",
                 capabilities: ["thread_navigation", "turn_control"],
+                canRevoke: true,
                 protocolVersion: 1,
                 unavailableReason: "Transport closed.",
               },

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -4114,6 +4114,7 @@ describe("SettingsScreen", () => {
       "Profiles",
       "AI Providers",
       "Messaging",
+      "Federation",
       "Git",
       "Worktrees",
       "Thread Management",

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -197,6 +197,43 @@ function createSnapshot(
       editedFilesDock: { value: "above", source: "default" },
       actionRunsDock: { value: "above", source: "default" },
     },
+    federation: {
+      mode: { value: "disabled", source: "default" },
+      listenHost: { value: "127.0.0.1", source: "default" },
+      listenPort: { value: 47830, source: "default" },
+      publicUrl: { value: "", source: "default" },
+      gatewayUrl: { value: "", source: "default" },
+      cloudflareMtlsEnabled: { value: false, source: "default" },
+      cloudflareAccessServiceAuthEnabled: {
+        value: false,
+        source: "default",
+      },
+      instancePrivateKey: {
+        configured: false,
+        source: "unset",
+        writable: true,
+      },
+      cloudflareClientCertificate: {
+        configured: false,
+        source: "unset",
+        writable: true,
+      },
+      cloudflareClientPrivateKey: {
+        configured: false,
+        source: "unset",
+        writable: true,
+      },
+      cloudflareAccessClientId: {
+        configured: false,
+        source: "unset",
+        writable: true,
+      },
+      cloudflareAccessClientSecret: {
+        configured: false,
+        source: "unset",
+        writable: true,
+      },
+    },
     messaging: {
       enabled: { value: true, source: "default" },
       allowFullAccessEscalation: { value: true, source: "default" },

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
@@ -142,6 +142,11 @@ export function ThreadHeader(props: ThreadHeaderProps) {
                 )}
               </h2>
             </div>
+            {props.thread.federation ? (
+              <span className="chip">
+                {props.thread.federation.instanceLabel}
+              </span>
+            ) : null}
             <span className="chip chip--backend">
               {formatBackendLabel(props.thread.source)}
             </span>

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -2235,6 +2235,8 @@ export function ThreadView(props: ThreadViewProps) {
       void props.desktopApi
         .stopCodexEnvironmentAction({
           backend: selectedThread.source,
+          federationTarget: selectedThread.federation?.ref.target ??
+            readRendererFederationTarget(),
           threadId: selectedThread.id,
           runId: run.runId,
           mode,

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -50,6 +50,7 @@ import {
   readCodexEnvironmentActionRuns,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
+import { agentEventMatchesThread } from "../../lib/federated-thread-events";
 import type { IntegratedTerminalsController } from "../../lib/useIntegratedTerminals";
 import type { ThreadContextWindowState } from "../../lib/useThreadSessionState";
 import type { PendingForkEnvironmentSetup } from "../../lib/useThreadNavigation";
@@ -2302,8 +2303,9 @@ export function ThreadView(props: ThreadViewProps) {
           event.notification.method === "mcpServer/oauthLogin/completed");
 
       if (
-        event.backend !== selectedThread.source ||
-        (notificationThreadId !== selectedThread.id && !isGlobalMcpStatus)
+        isGlobalMcpStatus
+          ? event.backend !== selectedThread.source
+          : !agentEventMatchesThread(event, selectedThread, notificationThreadId)
       ) {
         return;
       }

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -51,6 +51,7 @@ import {
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { agentEventMatchesThread } from "../../lib/federated-thread-events";
+import { readRendererFederationTarget } from "../../lib/federation-window";
 import type { IntegratedTerminalsController } from "../../lib/useIntegratedTerminals";
 import type { ThreadContextWindowState } from "../../lib/useThreadSessionState";
 import type { PendingForkEnvironmentSetup } from "../../lib/useThreadNavigation";
@@ -1655,6 +1656,8 @@ export function ThreadView(props: ThreadViewProps) {
     try {
       const response = await props.desktopApi.startTurn({
         backend: selectedThread.source,
+        federationTarget: selectedThread.federation?.ref.target ??
+          readRendererFederationTarget(),
         threadId: selectedThread.id,
         input,
         executionMode: selectedThread.executionMode,
@@ -2572,6 +2575,8 @@ export function ThreadView(props: ThreadViewProps) {
     try {
       await props.desktopApi.submitServerRequest({
         backend: selectedThread.source,
+        federationTarget: selectedThread.federation?.ref.target ??
+          readRendererFederationTarget(),
         threadId: selectedThread.id,
         turnId:
           typeof props.pendingRequest.params.turnId === "string"
@@ -2612,6 +2617,8 @@ export function ThreadView(props: ThreadViewProps) {
     try {
       await props.desktopApi.submitServerRequest({
         backend: selectedThread.source,
+        federationTarget: selectedThread.federation?.ref.target ??
+          readRendererFederationTarget(),
         threadId: selectedThread.id,
         turnId: pendingUserInput.turnId,
         requestId: pendingUserInput.requestId,
@@ -2640,6 +2647,8 @@ export function ThreadView(props: ThreadViewProps) {
     try {
       await props.desktopApi.submitServerRequest({
         backend: selectedThread.source,
+        federationTarget: selectedThread.federation?.ref.target ??
+          readRendererFederationTarget(),
         threadId: selectedThread.id,
         turnId:
           typeof pendingMcpInteraction.turnId === "string"

--- a/apps/desktop/src/renderer/src/features/thread-search/ThreadSearchPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-search/ThreadSearchPanel.tsx
@@ -48,6 +48,7 @@ type ThreadSearchPanelProps = {
   desktopApi?: DesktopApi;
   onOpenResult: (result: {
     backend: AppServerBackendKind;
+    federation?: ThreadSearchResult["federation"];
     threadId: string;
     /** Turn of the matched message, for deep-linking to it in the thread. */
     turnId?: string;
@@ -184,6 +185,9 @@ function ThreadSearchResultRow(props: {
         <span className="thread-search-result__meta">
           <span className="chip chip--backend">{result.backend}</span>
           {props.isAgent ? <AgentThreadChip /> : null}
+          {result.federation ? (
+            <span className="chip">{result.federation.instanceLabel}</span>
+          ) : null}
           {workspaceLabel ? (
             <span className="thread-search-result__meta-item">
               <WorkspaceIcon size={13} aria-hidden />
@@ -377,6 +381,9 @@ export function ThreadSearchPanel(props: ThreadSearchPanelProps) {
                     onOpen={() => {
                       void props.onOpenResult({
                         backend: result.backend,
+                        ...(result.federation
+                          ? { federation: result.federation }
+                          : {}),
                         threadId: result.threadId,
                         turnId: result.snippets.find((s) => s.turnId)?.turnId,
                       });

--- a/apps/desktop/src/renderer/src/features/thread-search/__tests__/ThreadSearchPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-search/__tests__/ThreadSearchPanel.test.tsx
@@ -123,6 +123,71 @@ describe("ThreadSearchPanel", () => {
     expect(screen.getByLabelText("Agent thread")).toHaveTextContent("Agent");
     expect(screen.getByText("Agent match")).toBeInTheDocument();
   });
+
+  it("labels remote search results and preserves their federation target", async () => {
+    const onOpenResult = vi.fn();
+    const searchThreads = vi.fn(async (): Promise<ThreadSearchResponse> => ({
+      backend: "all",
+      contentMode: "available",
+      fetchedAt: 1_000,
+      filters: { backend: "all", includeArchived: false },
+      query: "deploy",
+      results: [
+        {
+          backend: "codex",
+          confidence: "medium",
+          identityKey: "remote:client_one:codex:thread-1",
+          linkedDirectories: [],
+          matchReasons: [{ kind: "title_token_overlap" }],
+          score: 10,
+          snippets: [{ scope: "metadata", text: "Deploy release" }],
+          source: "codex",
+          threadId: "thread-1",
+          title: "Deploy release",
+          federation: {
+            ref: {
+              backend: "codex",
+              target: { scope: "remote", instanceId: "client_one" },
+              threadId: "thread-1",
+            },
+            instanceLabel: "Studio Mac",
+            peerStatus: "connected",
+          },
+        },
+      ],
+      searchedScopes: ["metadata"],
+      semanticMode: "disabled",
+      unavailableScopes: [],
+    }));
+
+    render(
+      <ThreadSearchPanel
+        desktopApi={{ searchThreads } as DesktopApi}
+        onOpenResult={onOpenResult}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText("Search threads"), {
+      target: { value: "deploy" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Search" }));
+
+    expect(await screen.findByText("Studio Mac")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Deploy release/ }));
+
+    expect(onOpenResult).toHaveBeenCalledWith({
+      backend: "codex",
+      federation: {
+        ref: {
+          backend: "codex",
+          target: { scope: "remote", instanceId: "client_one" },
+          threadId: "thread-1",
+        },
+        instanceLabel: "Studio Mac",
+        peerStatus: "connected",
+      },
+      threadId: "thread-1",
+    });
+  });
 });
 
 describe("basename", () => {

--- a/apps/desktop/src/renderer/src/lib/__tests__/federation-desktop-api.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/federation-desktop-api.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+import type { DesktopApi } from "../desktop-api";
+import { scopeDesktopApiToFederationTarget } from "../federation-desktop-api";
+
+describe("scopeDesktopApiToFederationTarget", () => {
+  it("routes application opens remotely and removes local path helpers", async () => {
+    const openApplication = vi.fn(async () => ({ opened: true }));
+    const desktopApi = {
+      openApplication,
+      openPath: vi.fn(),
+      revealPath: vi.fn(),
+      readMarkdownFile: vi.fn(),
+      openMarkdownFileViewer: vi.fn(),
+      readMarkdownFileViewerSnapshot: vi.fn(),
+      onMarkdownFileViewerSnapshotChanged: vi.fn(),
+    } as DesktopApi;
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "remote-instance",
+    };
+
+    const scopedApi = scopeDesktopApiToFederationTarget(
+      desktopApi,
+      federationTarget,
+    );
+    await scopedApi?.openApplication?.({
+      applicationId: "vscode",
+      kind: "editor",
+      targetPath: "/remote/repo/file.ts",
+    });
+
+    expect(openApplication).toHaveBeenCalledWith({
+      applicationId: "vscode",
+      kind: "editor",
+      targetPath: "/remote/repo/file.ts",
+      federationTarget,
+    });
+    expect(scopedApi?.openPath).toBeUndefined();
+    expect(scopedApi?.revealPath).toBeUndefined();
+    expect(scopedApi?.readMarkdownFile).toBeUndefined();
+    expect(scopedApi?.openMarkdownFileViewer).toBeUndefined();
+    expect(scopedApi?.readMarkdownFileViewerSnapshot).toBeUndefined();
+    expect(scopedApi?.onMarkdownFileViewerSnapshotChanged).toBeUndefined();
+  });
+
+  it("keeps the local desktop API unchanged without a remote target", () => {
+    const desktopApi: DesktopApi = { openPath: vi.fn() };
+
+    expect(scopeDesktopApiToFederationTarget(desktopApi, undefined)).toBe(
+      desktopApi,
+    );
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/__tests__/useBackendSummaries.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useBackendSummaries.test.tsx
@@ -465,4 +465,63 @@ describe("useBackendSummaries", () => {
     });
     expect(listBackends).toHaveBeenCalledTimes(2);
   });
+
+  it("loads backend summaries from the selected remote instance", async () => {
+    let eventHandler: ((event: AgentEvent) => void) | undefined;
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "remote-instance",
+    };
+    const listAcpAgents = vi.fn();
+    const listBackends = vi
+      .fn<NonNullable<DesktopApi["listBackends"]>>()
+      .mockResolvedValue({ fetchedAt: 1, backends: [] });
+    const desktopApi: DesktopApi = {
+      listAcpAgents,
+      listBackends,
+      onAgentEvent: (callback) => {
+        eventHandler = callback;
+        return () => undefined;
+      },
+    };
+
+    const { result } = renderHook(() => useBackendSummaries(desktopApi, {
+      federationTarget,
+    }));
+
+    await waitFor(() => {
+      expect(listBackends).toHaveBeenCalledWith({
+        includeUnavailable: true,
+        federationTarget,
+      });
+    });
+
+    await act(async () => {
+      await result.current.refreshAcpAgents();
+    });
+    expect(listAcpAgents).not.toHaveBeenCalled();
+    expect(listBackends).toHaveBeenCalledTimes(2);
+
+    eventHandler?.({
+      backend: "codex",
+      notification: {
+        method: "account/updated",
+        params: {},
+      },
+    });
+    await act(async () => undefined);
+    expect(listBackends).toHaveBeenCalledTimes(2);
+
+    eventHandler?.({
+      backend: "codex",
+      federationTarget,
+      notification: {
+        method: "account/updated",
+        params: {},
+      },
+    });
+    await waitFor(() => {
+      expect(listBackends).toHaveBeenCalledTimes(3);
+    });
+  });
 });

--- a/apps/desktop/src/renderer/src/lib/__tests__/useDesktopApplications.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useDesktopApplications.test.tsx
@@ -1,0 +1,115 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type {
+  DesktopApplicationsSnapshot,
+  ReadDesktopApplicationsRequest,
+} from "@pwragent/shared";
+import { describe, expect, it, vi } from "vitest";
+import type { DesktopApi } from "../desktop-api";
+import { useDesktopApplications } from "../useDesktopApplications";
+
+function applications(params: {
+  editorId?: string;
+  terminalId?: string;
+}): DesktopApplicationsSnapshot {
+  return {
+    editors: params.editorId
+      ? [{
+          id: params.editorId,
+          kind: "editor",
+          name: params.editorId,
+          source: "application",
+          canOpenWorkspace: true,
+        }]
+      : [],
+    terminals: params.terminalId
+      ? [{
+          id: params.terminalId,
+          kind: "terminal",
+          name: params.terminalId,
+          source: "application",
+          canOpenWorkspace: true,
+        }]
+      : [],
+    preferredEditorId: { value: "", source: "default" },
+    preferredTerminalId: { value: "", source: "default" },
+    gh: {
+      path: { value: "", source: "default" },
+      discovery: { candidates: [] },
+    },
+    git: { discovery: { candidates: [] } },
+  };
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
+describe("useDesktopApplications", () => {
+  it("fails closed until the selected peer's applications are available", async () => {
+    const guestApplications = deferred<{
+      applications: DesktopApplicationsSnapshot;
+    }>();
+    const hostApplications = deferred<{
+      applications: DesktopApplicationsSnapshot;
+    }>();
+    const readApplications = vi.fn((request: ReadDesktopApplicationsRequest) =>
+      request.federationTarget?.scope === "remote"
+      && request.federationTarget.instanceId === "guest"
+        ? guestApplications.promise
+        : hostApplications.promise
+    );
+    const desktopApi = { readApplications } as DesktopApi;
+    const localApplications = applications({ editorId: "host-vscode" });
+    const { rerender, result } = renderHook(
+      ({ remoteInstanceId }: { remoteInstanceId?: string }) =>
+        useDesktopApplications({
+          desktopApi,
+          localApplications,
+          remoteInstanceId,
+        }),
+      { initialProps: { remoteInstanceId: "guest" } },
+    );
+
+    expect(result.current).toBeUndefined();
+    expect(readApplications).toHaveBeenCalledWith({
+      federationTarget: { scope: "remote", instanceId: "guest" },
+    });
+
+    await act(async () => {
+      guestApplications.resolve({
+        applications: applications({ terminalId: "guest-terminal" }),
+      });
+    });
+    await waitFor(() => {
+      expect(result.current?.terminals[0]?.id).toBe("guest-terminal");
+    });
+    expect(result.current?.editors).toEqual([]);
+
+    rerender({ remoteInstanceId: "host" });
+    expect(result.current).toBeUndefined();
+    expect(readApplications).toHaveBeenLastCalledWith({
+      federationTarget: { scope: "remote", instanceId: "host" },
+    });
+  });
+
+  it("uses the local settings snapshot when no peer is selected", () => {
+    const localApplications = applications({ editorId: "host-vscode" });
+    const readApplications = vi.fn();
+    const { result } = renderHook(() =>
+      useDesktopApplications({
+        desktopApi: { readApplications } as DesktopApi,
+        localApplications,
+      })
+    );
+
+    expect(result.current).toBe(localApplications);
+    expect(readApplications).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -1929,6 +1929,67 @@ describe("useThreadNavigation", () => {
     expect(result.current.directories[0]?.needsAttentionCount).toBe(0);
   });
 
+  it("archives a remote thread through its owning federation target", async () => {
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "remote-instance",
+    };
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: 1_000,
+      unchanged: false,
+      inboxThreadKeys: ["codex:thread-remote"],
+      threads: [
+        {
+          id: "thread-remote",
+          title: "Remote thread",
+          titleSource: "explicit" as const,
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: { inInbox: true },
+          federation: {
+            instanceLabel: "Remote Mac",
+            ref: {
+              backend: "codex" as const,
+              target: federationTarget,
+              threadId: "thread-remote",
+            },
+          },
+        },
+      ],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const archiveThread = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-remote",
+      archivedAt: 2_000,
+      cleanup: [],
+    }));
+    const desktopApi: DesktopApi = {
+      archiveThread,
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+    };
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.threads[0]?.id).toBe("thread-remote");
+    });
+    await act(async () => {
+      await result.current.archiveThread(result.current.threads[0]!);
+    });
+
+    expect(archiveThread).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-remote",
+      federationTarget,
+    });
+  });
+
   it("surfaces archive worktree cleanup failures returned by the desktop bridge", async () => {
     let archived = false;
     const getNavigationSnapshot = vi.fn(async () => ({

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -25,6 +25,9 @@ describe("useThreadNavigation", () => {
     delete (window as unknown as {
       __pwragentNavigationPreferences?: unknown;
     }).__pwragentNavigationPreferences;
+    delete (window as unknown as {
+      __pwragentFederationTarget?: unknown;
+    }).__pwragentFederationTarget;
     vi.restoreAllMocks();
   });
 
@@ -2402,6 +2405,12 @@ describe("useThreadNavigation", () => {
   });
 
   it("renames a thread and refreshes navigation with the explicit title", async () => {
+    (window as unknown as {
+      __pwragentFederationTarget?: unknown;
+    }).__pwragentFederationTarget = {
+      scope: "remote",
+      instanceId: "remote-instance",
+    };
     let threadTitle = "First thread";
     const renameThread = vi.fn(async ({ name }: { name: string }) => {
       threadTitle = name;
@@ -2461,6 +2470,10 @@ describe("useThreadNavigation", () => {
 
     expect(renameThread).toHaveBeenCalledWith({
       backend: "codex",
+      federationTarget: {
+        scope: "remote",
+        instanceId: "remote-instance",
+      },
       threadId: "thread-1",
       name: "Renamed thread",
     });

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -249,6 +249,10 @@ import type {
   DesktopMessagingContactLookupRequest,
   DesktopMessagingContactLookupResponse,
   DesktopSettingsWriteResponse,
+  GenerateFederationInviteRequest,
+  GenerateFederationInviteResponse,
+  ImportFederationInviteRequest,
+  ImportFederationInviteResponse,
   OpenDesktopApplicationRequest,
   OpenDesktopApplicationResponse,
   OpenMarkdownFileViewerRequest,
@@ -430,6 +434,12 @@ export type DesktopApi = {
   readFederationHealth?: (
     request?: ReadFederationHealthRequest,
   ) => Promise<ReadFederationHealthResponse>;
+  generateFederationInvite?: (
+    request?: GenerateFederationInviteRequest,
+  ) => Promise<GenerateFederationInviteResponse>;
+  importFederationInvite?: (
+    request: ImportFederationInviteRequest,
+  ) => Promise<ImportFederationInviteResponse>;
   ping?: () => string;
   listSkills?: (
     request?: AppServerListSkillsRequest

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -94,6 +94,10 @@ import type {
   OpenFederationWindowResponse,
   ReadFederationHealthRequest,
   ReadFederationHealthResponse,
+  ReadFederationDiagnosticsRequest,
+  ReadFederationDiagnosticsResponse,
+  RevokeFederationPeerRequest,
+  RevokeFederationPeerResponse,
   ReorderDirectoryPinsRequest,
   ReorderDirectoryPinsResponse,
   ReorderThreadPinsRequest,
@@ -434,12 +438,18 @@ export type DesktopApi = {
   readFederationHealth?: (
     request?: ReadFederationHealthRequest,
   ) => Promise<ReadFederationHealthResponse>;
+  readFederationDiagnostics?: (
+    request?: ReadFederationDiagnosticsRequest,
+  ) => Promise<ReadFederationDiagnosticsResponse>;
   generateFederationInvite?: (
     request?: GenerateFederationInviteRequest,
   ) => Promise<GenerateFederationInviteResponse>;
   importFederationInvite?: (
     request: ImportFederationInviteRequest,
   ) => Promise<ImportFederationInviteResponse>;
+  revokeFederationPeer?: (
+    request: RevokeFederationPeerRequest,
+  ) => Promise<RevokeFederationPeerResponse>;
   ping?: () => string;
   listSkills?: (
     request?: AppServerListSkillsRequest

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -259,6 +259,8 @@ import type {
   ImportFederationInviteResponse,
   OpenDesktopApplicationRequest,
   OpenDesktopApplicationResponse,
+  ReadDesktopApplicationsRequest,
+  ReadDesktopApplicationsResponse,
   OpenMarkdownFileViewerRequest,
   OpenMarkdownFileViewerResponse,
   OpenSubAgentTranscriptWindowRequest,
@@ -625,6 +627,9 @@ export type DesktopApi = {
   openApplication?: (
     request: OpenDesktopApplicationRequest
   ) => Promise<OpenDesktopApplicationResponse>;
+  readApplications?: (
+    request: ReadDesktopApplicationsRequest
+  ) => Promise<ReadDesktopApplicationsResponse>;
   openPath?: (request: OpenPathRequest) => Promise<OpenPathResponse>;
   revealPath?: (request: OpenPathRequest) => Promise<OpenPathResponse>;
   readMarkdownFile?: (

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -90,6 +90,8 @@ import type {
   MaterializeDirectoryLaunchpadRequest,
   MaterializeDirectoryLaunchpadResponse,
   MarkThreadSeenRequest,
+  OpenFederationWindowRequest,
+  OpenFederationWindowResponse,
   ReorderDirectoryPinsRequest,
   ReorderDirectoryPinsResponse,
   ReorderThreadPinsRequest,
@@ -420,6 +422,9 @@ export type DesktopApi = {
   waitForProfileAlive?: (
     request: WaitForDesktopProfileAliveRequest,
   ) => Promise<WaitForDesktopProfileAliveResponse>;
+  openFederationWindow?: (
+    request: OpenFederationWindowRequest,
+  ) => Promise<OpenFederationWindowResponse>;
   ping?: () => string;
   listSkills?: (
     request?: AppServerListSkillsRequest

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -92,6 +92,8 @@ import type {
   MarkThreadSeenRequest,
   OpenFederationWindowRequest,
   OpenFederationWindowResponse,
+  ReadFederationHealthRequest,
+  ReadFederationHealthResponse,
   ReorderDirectoryPinsRequest,
   ReorderDirectoryPinsResponse,
   ReorderThreadPinsRequest,
@@ -425,6 +427,9 @@ export type DesktopApi = {
   openFederationWindow?: (
     request: OpenFederationWindowRequest,
   ) => Promise<OpenFederationWindowResponse>;
+  readFederationHealth?: (
+    request?: ReadFederationHealthRequest,
+  ) => Promise<ReadFederationHealthResponse>;
   ping?: () => string;
   listSkills?: (
     request?: AppServerListSkillsRequest

--- a/apps/desktop/src/renderer/src/lib/federated-thread-events.ts
+++ b/apps/desktop/src/renderer/src/lib/federated-thread-events.ts
@@ -1,0 +1,51 @@
+import type {
+  AgentEvent,
+  FederationTarget,
+  NavigationThreadSummary,
+  ThreadIdentifier,
+} from "@pwragent/shared";
+import {
+  buildThreadIdentityKey,
+  federatedThreadIdentityKey,
+} from "@pwragent/shared";
+
+export function federationTargetsEqual(
+  left: FederationTarget | undefined,
+  right: FederationTarget | undefined,
+): boolean {
+  if (!left || left.scope === "local") {
+    return !right || right.scope === "local";
+  }
+  return right?.scope === "remote" && right.instanceId === left.instanceId;
+}
+
+export function threadSummaryIdentityKey(thread: NavigationThreadSummary): string {
+  return thread.federation?.ref
+    ? federatedThreadIdentityKey(thread.federation.ref)
+    : buildThreadIdentityKey(thread.source, thread.id);
+}
+
+export function agentEventThreadIdentityKey(
+  event: AgentEvent,
+  threadId: ThreadIdentifier,
+): string {
+  return event.federationTarget
+    ? federatedThreadIdentityKey({
+        backend: event.backend,
+        target: event.federationTarget,
+        threadId,
+      })
+    : buildThreadIdentityKey(event.backend, threadId);
+}
+
+export function agentEventMatchesThread(
+  event: AgentEvent,
+  thread: NavigationThreadSummary,
+  threadId: ThreadIdentifier | undefined,
+): boolean {
+  return (
+    event.backend === thread.source &&
+    threadId === thread.id &&
+    federationTargetsEqual(event.federationTarget, thread.federation?.ref.target)
+  );
+}

--- a/apps/desktop/src/renderer/src/lib/federation-desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/federation-desktop-api.ts
@@ -1,0 +1,28 @@
+import type { FederationRemoteTarget } from "@pwragent/shared";
+import type { DesktopApi } from "./desktop-api";
+
+export function scopeDesktopApiToFederationTarget(
+  desktopApi: DesktopApi | undefined,
+  federationTarget: FederationRemoteTarget | undefined,
+): DesktopApi | undefined {
+  if (!desktopApi || !federationTarget) {
+    return desktopApi;
+  }
+  const openApplication = desktopApi.openApplication;
+
+  return {
+    ...desktopApi,
+    openApplication: openApplication
+      ? async (request) => await openApplication({
+          ...request,
+          federationTarget,
+        })
+      : undefined,
+    openPath: undefined,
+    revealPath: undefined,
+    readMarkdownFile: undefined,
+    openMarkdownFileViewer: undefined,
+    readMarkdownFileViewerSnapshot: undefined,
+    onMarkdownFileViewerSnapshotChanged: undefined,
+  };
+}

--- a/apps/desktop/src/renderer/src/lib/federation-window.ts
+++ b/apps/desktop/src/renderer/src/lib/federation-window.ts
@@ -1,0 +1,10 @@
+import type { FederationRemoteTarget } from "@pwragent/shared";
+
+export function readRendererFederationTarget(): FederationRemoteTarget | undefined {
+  const target = (window as typeof window & {
+    __pwragentFederationTarget?: Partial<FederationRemoteTarget>;
+  }).__pwragentFederationTarget;
+  return target?.scope === "remote" && typeof target.instanceId === "string"
+    ? { scope: "remote", instanceId: target.instanceId }
+    : undefined;
+}

--- a/apps/desktop/src/renderer/src/lib/federation-window.ts
+++ b/apps/desktop/src/renderer/src/lib/federation-window.ts
@@ -8,3 +8,12 @@ export function readRendererFederationTarget(): FederationRemoteTarget | undefin
     ? { scope: "remote", instanceId: target.instanceId }
     : undefined;
 }
+
+export function readRendererFederationLabel(): string | undefined {
+  const label = (window as typeof window & {
+    __pwragentFederationLabel?: unknown;
+  }).__pwragentFederationLabel;
+  return typeof label === "string" && label.trim()
+    ? label.trim()
+    : undefined;
+}

--- a/apps/desktop/src/renderer/src/lib/useBackendSummaries.ts
+++ b/apps/desktop/src/renderer/src/lib/useBackendSummaries.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { BackendSummary } from "@pwragent/shared";
+import type { BackendSummary, FederationTarget } from "@pwragent/shared";
 import type { DesktopApi } from "./desktop-api";
+import { federationTargetsEqual } from "./federated-thread-events";
 
 type BackendSummaryData = {
   backends: BackendSummary[];
@@ -16,9 +17,13 @@ export const BACKEND_SUMMARIES_REFRESH_EVENT =
 
 export function useBackendSummaries(
   desktopApi?: DesktopApi,
-  options: { enabled?: boolean } = {},
+  options: {
+    enabled?: boolean;
+    federationTarget?: FederationTarget;
+  } = {},
 ): BackendSummaryState {
   const enabled = options.enabled ?? true;
+  const federationTarget = options.federationTarget;
   const [state, setState] = useState<BackendSummaryData>({
     backends: []
   });
@@ -44,7 +49,8 @@ export function useBackendSummaries(
 
     try {
       const response = await desktopApi.listBackends({
-        includeUnavailable: true
+        includeUnavailable: true,
+        ...(federationTarget ? { federationTarget } : {}),
       });
       setState({
         backends: response.backends,
@@ -58,9 +64,12 @@ export function useBackendSummaries(
       });
       return [];
     }
-  }, [desktopApi, enabled]);
+  }, [desktopApi, enabled, federationTarget]);
 
   const refreshAcpAgents = useCallback(async (): Promise<BackendSummary[]> => {
+    if (federationTarget?.scope === "remote") {
+      return await refresh();
+    }
     if (!enabled || !desktopApi?.listAcpAgents) {
       return [];
     }
@@ -89,7 +98,7 @@ export function useBackendSummaries(
         acpRefreshPromiseRef.current = undefined;
       }
     }
-  }, [desktopApi, enabled, refresh]);
+  }, [desktopApi, enabled, federationTarget, refresh]);
 
   useEffect(() => {
     void refresh();
@@ -110,6 +119,9 @@ export function useBackendSummaries(
       return;
     }
     return desktopApi.onAgentEvent((event) => {
+      if (!federationTargetsEqual(event.federationTarget, federationTarget)) {
+        return;
+      }
       if (
         (event.backend === "codex" &&
           (event.notification.method === "account/rateLimits/updated" ||
@@ -120,7 +132,7 @@ export function useBackendSummaries(
         void refresh();
       }
     });
-  }, [desktopApi, enabled, refresh]);
+  }, [desktopApi, enabled, federationTarget, refresh]);
 
   return {
     ...state,

--- a/apps/desktop/src/renderer/src/lib/useDesktopApplications.ts
+++ b/apps/desktop/src/renderer/src/lib/useDesktopApplications.ts
@@ -1,0 +1,52 @@
+import { useEffect, useState } from "react";
+import type { DesktopApplicationsSnapshot } from "@pwragent/shared";
+import type { DesktopApi } from "./desktop-api";
+
+export function useDesktopApplications(params: {
+  desktopApi?: DesktopApi;
+  localApplications?: DesktopApplicationsSnapshot;
+  remoteInstanceId?: string;
+}): DesktopApplicationsSnapshot | undefined {
+  const [remoteApplications, setRemoteApplications] = useState<{
+    applications: DesktopApplicationsSnapshot;
+    instanceId: string;
+  }>();
+
+  useEffect(() => {
+    if (!params.remoteInstanceId || !params.desktopApi?.readApplications) {
+      setRemoteApplications(undefined);
+      return;
+    }
+
+    const remoteInstanceId = params.remoteInstanceId;
+    let cancelled = false;
+    void params.desktopApi.readApplications({
+      federationTarget: {
+        scope: "remote",
+        instanceId: remoteInstanceId,
+      },
+    }).then((response) => {
+      if (!cancelled) {
+        setRemoteApplications({
+          applications: response.applications,
+          instanceId: remoteInstanceId,
+        });
+      }
+    }).catch(() => {
+      if (!cancelled) {
+        setRemoteApplications(undefined);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [params.desktopApi, params.remoteInstanceId]);
+
+  if (!params.remoteInstanceId) {
+    return params.localApplications;
+  }
+  return remoteApplications?.instanceId === params.remoteInstanceId
+    ? remoteApplications.applications
+    : undefined;
+}

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -38,6 +38,7 @@ import {
 } from "@pwragent/shared";
 import type { DesktopApi } from "./desktop-api";
 import { fileLabelFromPath } from "./directory-references";
+import { readRendererFederationTarget } from "./federation-window";
 import {
   buildSubthreadLaunchpadKey,
   getParentThreadIdFromSubthreadLaunchpadKey,
@@ -2678,11 +2679,13 @@ export function useThreadNavigation(
           hasCurrentResponse: Boolean(stateRef.current.response),
           preferredSelectionKey: preferredSelectionKey ?? null,
         });
+        const federationTarget = readRendererFederationTarget();
         const snapshotRequest =
-          options?.forceRefresh || options?.refreshMode
+          options?.forceRefresh || options?.refreshMode || federationTarget
             ? {
                 ...(options?.forceRefresh ? { forceRefresh: true } : {}),
                 ...(options?.refreshMode ? { refreshMode: options.refreshMode } : {}),
+                ...(federationTarget ? { federationTarget } : {}),
               }
             : undefined;
         const snapshot = snapshotRequest

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -4478,6 +4478,8 @@ export function useThreadNavigation(
       try {
         const response = await forkThreadRequest({
           backend: parent.source,
+          federationTarget: parent.federation?.ref.target ??
+            readRendererFederationTarget(),
           sourceThreadId: parent.id,
           parentThreadId: groupRoot.id,
           executionMode,
@@ -5154,6 +5156,7 @@ export function useThreadNavigation(
       try {
         response = await desktopApi.materializeDirectoryLaunchpad({
           directoryKey,
+          federationTarget: readRendererFederationTarget(),
           launchpad,
           input,
           collaborationMode,

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -5584,8 +5584,11 @@ export function useThreadNavigation(
       );
 
       try {
+        const federationTarget = thread.federation?.ref.target ??
+          readRendererFederationTarget();
         await renameThreadRequest({
           backend: thread.source,
+          ...(federationTarget ? { federationTarget } : {}),
           threadId: thread.id,
           name: nextName,
         });

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -40,6 +40,10 @@ import type { DesktopApi } from "./desktop-api";
 import { fileLabelFromPath } from "./directory-references";
 import { readRendererFederationTarget } from "./federation-window";
 import {
+  agentEventThreadIdentityKey,
+  federationTargetsEqual,
+} from "./federated-thread-events";
+import {
   buildSubthreadLaunchpadKey,
   getParentThreadIdFromSubthreadLaunchpadKey,
   type ThreadWorkspaceMode,
@@ -3086,6 +3090,10 @@ export function useThreadNavigation(
     }
 
     return desktopApi.onAgentEvent((event) => {
+      if (!federationTargetsEqual(event.federationTarget, readRendererFederationTarget())) {
+        return;
+      }
+
       markNavigationActivity({ refreshOnIdleResume: false });
       const method = event.notification.method as string;
       if (method === "navigation/directoryGitStatus/updated") {
@@ -3248,7 +3256,7 @@ export function useThreadNavigation(
         const { threadId } = event.notification.params as {
           threadId: string;
         };
-        const threadKey = buildThreadIdentityKey(event.backend, threadId);
+        const threadKey = agentEventThreadIdentityKey(event, threadId);
         suppressedArchivedThreadKeysRef.current.add(threadKey);
 
         setState((current) => ({
@@ -3700,7 +3708,7 @@ export function useThreadNavigation(
           threadId: string;
         };
         suppressedArchivedThreadKeysRef.current.delete(
-          buildThreadIdentityKey(event.backend, threadId)
+          agentEventThreadIdentityKey(event, threadId)
         );
         scheduleRefresh();
         return;

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -5518,6 +5518,8 @@ export function useThreadNavigation(
         await handoffThreadWorkspaceRequest({
           ...request,
           backend: thread.source,
+          federationTarget: thread.federation?.ref.target ??
+            readRendererFederationTarget(),
           threadId: thread.id,
         });
         await refresh(buildThreadIdentityKey(thread.source, thread.id));
@@ -6042,6 +6044,8 @@ export function useThreadNavigation(
       try {
         await setThreadExecutionMode({
           backend: thread.source,
+          federationTarget: thread.federation?.ref.target ??
+            readRendererFederationTarget(),
           threadId: thread.id,
           executionMode,
         });
@@ -6068,6 +6072,8 @@ export function useThreadNavigation(
       try {
         await cancelThreadExecutionModeQueueRequest({
           backend: thread.source,
+          federationTarget: thread.federation?.ref.target ??
+            readRendererFederationTarget(),
           threadId: thread.id,
         });
         await refresh(buildThreadIdentityKey(thread.source, thread.id));
@@ -6131,6 +6137,8 @@ export function useThreadNavigation(
       try {
         await setThreadModelSettings({
           backend: thread.source,
+          federationTarget: thread.federation?.ref.target ??
+            readRendererFederationTarget(),
           threadId: thread.id,
           ...nextSettings,
         });
@@ -6265,6 +6273,8 @@ export function useThreadNavigation(
       try {
         await setAcpSessionRuntimeOption({
           backend: thread.source,
+          federationTarget: thread.federation?.ref.target ??
+            readRendererFederationTarget(),
           threadId: thread.id,
           ...params,
         });

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -5424,9 +5424,12 @@ export function useThreadNavigation(
 
       try {
         for (const target of targetThreads) {
+          const federationTarget = target.federation?.ref.target
+            ?? readRendererFederationTarget();
           const response = await archiveThreadRequest({
             backend: target.source,
             threadId: target.id,
+            ...(federationTarget ? { federationTarget } : {}),
           });
           const cleanupNotice = formatArchiveCleanupNotice(response.cleanup);
           if (cleanupNotice) {

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -22,9 +22,12 @@ import type {
   MessagingConversationKind,
   NavigationThreadSummary,
 } from "@pwragent/shared";
-import { buildThreadIdentityKey } from "@pwragent/shared";
 import type { DesktopApi } from "./desktop-api";
 import { readRendererFederationTarget } from "./federation-window";
+import {
+  agentEventThreadIdentityKey,
+  threadSummaryIdentityKey,
+} from "./federated-thread-events";
 import {
   createQuestionnaireState,
   type PendingQuestionnaireState,
@@ -3468,7 +3471,7 @@ export function useThreadSessionState(params: {
 } {
   const { desktopApi, liveTranscriptEventFiltering = false, thread } = params;
   const threadKey = thread
-    ? buildThreadIdentityKey(thread.source, thread.id)
+    ? threadSummaryIdentityKey(thread)
     : undefined;
   const selectedThreadKeyRef = useRef<string | undefined>(undefined);
   const consumedOptimisticActiveTurnKeysRef = useRef<Set<string>>(new Set());
@@ -3576,7 +3579,7 @@ export function useThreadSessionState(params: {
   const loadLatest = useCallback(
     async (targetThread: NavigationThreadSummary): Promise<void> => {
       const readThread = desktopApi?.readThread;
-      const targetThreadKey = buildThreadIdentityKey(targetThread.source, targetThread.id);
+      const targetThreadKey = threadSummaryIdentityKey(targetThread);
       const hydrationVersion = getThreadHydrationVersion(targetThread);
 
       if (!readThread) {
@@ -4044,7 +4047,7 @@ export function useThreadSessionState(params: {
         return;
       }
 
-      const targetThreadKey = buildThreadIdentityKey(event.backend, notificationThreadId);
+      const targetThreadKey = agentEventThreadIdentityKey(event, notificationThreadId);
       const isUnfocusedThread = targetThreadKey !== selectedThreadKeyRef.current;
       if (
         liveTranscriptEventFiltering &&

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -24,6 +24,7 @@ import type {
 } from "@pwragent/shared";
 import { buildThreadIdentityKey } from "@pwragent/shared";
 import type { DesktopApi } from "./desktop-api";
+import { readRendererFederationTarget } from "./federation-window";
 import {
   createQuestionnaireState,
   type PendingQuestionnaireState,
@@ -3611,6 +3612,8 @@ export function useThreadSessionState(params: {
           ...(initialHistoryLimit !== undefined
             ? { limit: initialHistoryLimit }
             : {}),
+          federationTarget: targetThread.federation?.ref.target ??
+            readRendererFederationTarget(),
           threadId: targetThread.id,
         }));
         desktopApi?.recordStartupProfileEvent?.("thread-hydration:response", {
@@ -5125,6 +5128,8 @@ export function useThreadSessionState(params: {
     try {
       const olderResponse = await desktopApi.readThread({
         backend: thread.source,
+        federationTarget: thread.federation?.ref.target ??
+          readRendererFederationTarget(),
         threadId: thread.id,
         before: selectedSession.response.replay.pagination.previousCursor,
         limit: THREAD_HISTORY_PAGE_LIMIT,

--- a/apps/desktop/src/renderer/src/lib/useThreadSkills.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSkills.ts
@@ -6,8 +6,12 @@ import type {
   NavigationLaunchpadDraft,
   NavigationThreadSummary,
 } from "@pwragent/shared";
-import { buildThreadIdentityKey } from "@pwragent/shared";
 import type { DesktopApi } from "./desktop-api";
+import {
+  agentEventMatchesThread,
+  federationTargetsEqual,
+  threadSummaryIdentityKey,
+} from "./federated-thread-events";
 
 type SkillState = {
   error?: string;
@@ -48,7 +52,8 @@ export function useThreadSkills(params: {
       return {
         backend: thread.source,
         cwds,
-        key: buildThreadIdentityKey(thread.source, thread.id),
+        federationTarget: thread.federation?.ref.target,
+        key: threadSummaryIdentityKey(thread),
         threadId: thread.id,
       };
     }
@@ -58,6 +63,7 @@ export function useThreadSkills(params: {
       return {
         backend: launchpad.backend,
         cwds,
+        federationTarget: undefined,
         key: `launchpad:${launchpad.backend}:${launchpad.directoryKey}`,
         threadId: undefined,
       };
@@ -112,6 +118,9 @@ export function useThreadSkills(params: {
           backend: skillTarget.backend,
           ...(cwds.length === 1 ? { cwd: cwds[0] } : {}),
           ...(cwds.length > 0 ? { cwds } : {}),
+          ...(skillTarget.federationTarget
+            ? { federationTarget: skillTarget.federationTarget }
+            : {}),
           ...(skillTarget.threadId ? { threadId: skillTarget.threadId } : {}),
         });
 
@@ -150,9 +159,12 @@ export function useThreadSkills(params: {
       return;
     }
 
-    const { backend, key, threadId } = skillTarget;
+    const { backend, federationTarget, key, threadId } = skillTarget;
     return desktopApi.onAgentEvent((event) => {
       if (event.backend !== backend) {
+        return;
+      }
+      if (!federationTargetsEqual(event.federationTarget, federationTarget)) {
         return;
       }
 
@@ -183,9 +195,10 @@ export function useThreadSkills(params: {
       }
 
       if (
+        !thread ||
         !threadId ||
         event.notification.method !== "thread/availableCommands/updated" ||
-        event.notification.params.threadId !== threadId
+        !agentEventMatchesThread(event, thread, event.notification.params.threadId)
       ) {
         return;
       }
@@ -217,7 +230,7 @@ export function useThreadSkills(params: {
         },
       }));
     });
-  }, [desktopApi, loadTarget, skillTarget]);
+  }, [desktopApi, loadTarget, skillTarget, thread]);
 
   const ensureLoaded = useCallback(async (): Promise<void> => {
     await loadTarget();

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2602,6 +2602,20 @@ textarea,
   color: var(--accent);
 }
 
+.sidebar__federation-label {
+  display: inline-block;
+  max-width: 110px;
+  margin-left: 8px;
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0;
+  text-overflow: ellipsis;
+  vertical-align: bottom;
+  white-space: nowrap;
+}
+
 .runtime-identity {
   display: flex;
   position: relative;
@@ -8517,6 +8531,13 @@ textarea,
 
 .settings-aboutkv dd a:hover {
   text-decoration: underline;
+}
+
+.federation-peer-summary {
+  display: flex;
+  align-items: flex-start;
+  flex-direction: column;
+  gap: 6px;
 }
 
 .settings-license-actions {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2604,7 +2604,7 @@ textarea,
 
 .sidebar__federation-label {
   display: inline-block;
-  max-width: 110px;
+  max-width: 140px;
   margin-left: 8px;
   overflow: hidden;
   color: var(--text-muted);

--- a/apps/desktop/src/shared/federation-window.ts
+++ b/apps/desktop/src/shared/federation-window.ts
@@ -1,0 +1,31 @@
+import type { FederationRemoteTarget } from "@pwragent/shared";
+
+export const FEDERATION_WINDOW_TARGET_ARG_PREFIX =
+  "--pwragent-federation-target=";
+
+export function federationWindowTargetAdditionalArguments(
+  target: FederationRemoteTarget | undefined,
+): string[] {
+  return target
+    ? [`${FEDERATION_WINDOW_TARGET_ARG_PREFIX}${JSON.stringify(target)}`]
+    : [];
+}
+
+export function readFederationWindowTargetFromArgv(
+  argv: readonly string[],
+): FederationRemoteTarget | undefined {
+  for (const arg of argv) {
+    if (!arg.startsWith(FEDERATION_WINDOW_TARGET_ARG_PREFIX)) continue;
+    try {
+      const raw = JSON.parse(
+        arg.slice(FEDERATION_WINDOW_TARGET_ARG_PREFIX.length),
+      ) as Partial<FederationRemoteTarget>;
+      return raw.scope === "remote" && typeof raw.instanceId === "string"
+        ? { scope: "remote", instanceId: raw.instanceId }
+        : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+}

--- a/apps/desktop/src/shared/federation-window.ts
+++ b/apps/desktop/src/shared/federation-window.ts
@@ -2,12 +2,20 @@ import type { FederationRemoteTarget } from "@pwragent/shared";
 
 export const FEDERATION_WINDOW_TARGET_ARG_PREFIX =
   "--pwragent-federation-target=";
+export const FEDERATION_WINDOW_LABEL_ARG_PREFIX =
+  "--pwragent-federation-label=";
 
 export function federationWindowTargetAdditionalArguments(
   target: FederationRemoteTarget | undefined,
+  label?: string,
 ): string[] {
   return target
-    ? [`${FEDERATION_WINDOW_TARGET_ARG_PREFIX}${JSON.stringify(target)}`]
+    ? [
+        `${FEDERATION_WINDOW_TARGET_ARG_PREFIX}${JSON.stringify(target)}`,
+        ...(label?.trim()
+          ? [`${FEDERATION_WINDOW_LABEL_ARG_PREFIX}${JSON.stringify(label.trim())}`]
+          : []),
+      ]
     : [];
 }
 
@@ -22,6 +30,25 @@ export function readFederationWindowTargetFromArgv(
       ) as Partial<FederationRemoteTarget>;
       return raw.scope === "remote" && typeof raw.instanceId === "string"
         ? { scope: "remote", instanceId: raw.instanceId }
+        : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
+export function readFederationWindowLabelFromArgv(
+  argv: readonly string[],
+): string | undefined {
+  for (const arg of argv) {
+    if (!arg.startsWith(FEDERATION_WINDOW_LABEL_ARG_PREFIX)) continue;
+    try {
+      const label = JSON.parse(
+        arg.slice(FEDERATION_WINDOW_LABEL_ARG_PREFIX.length),
+      );
+      return typeof label === "string" && label.trim()
+        ? label.trim()
         : undefined;
     } catch {
       return undefined;

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -2,6 +2,8 @@ export const APP_SERVER_LIST_THREADS_CHANNEL = "app-server:list-threads";
 export const THREAD_SEARCH_CHANNEL = "thread-search:search";
 export const FEDERATION_OPEN_WINDOW_CHANNEL = "federation:open-window";
 export const FEDERATION_GET_HEALTH_CHANNEL = "federation:get-health";
+export const FEDERATION_GENERATE_INVITE_CHANNEL = "federation:generate-invite";
+export const FEDERATION_IMPORT_INVITE_CHANNEL = "federation:import-invite";
 export const APP_SERVER_READ_THREAD_CHANNEL = "app-server:read-thread";
 export const APP_SERVER_GET_THREAD_FILE_DIFF_CHANNEL =
   "app-server:get-thread-file-diff";

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -1,5 +1,6 @@
 export const APP_SERVER_LIST_THREADS_CHANNEL = "app-server:list-threads";
 export const THREAD_SEARCH_CHANNEL = "thread-search:search";
+export const FEDERATION_OPEN_WINDOW_CHANNEL = "federation:open-window";
 export const APP_SERVER_READ_THREAD_CHANNEL = "app-server:read-thread";
 export const APP_SERVER_GET_THREAD_FILE_DIFF_CHANNEL =
   "app-server:get-thread-file-diff";

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -1,6 +1,7 @@
 export const APP_SERVER_LIST_THREADS_CHANNEL = "app-server:list-threads";
 export const THREAD_SEARCH_CHANNEL = "thread-search:search";
 export const FEDERATION_OPEN_WINDOW_CHANNEL = "federation:open-window";
+export const FEDERATION_GET_HEALTH_CHANNEL = "federation:get-health";
 export const APP_SERVER_READ_THREAD_CHANNEL = "app-server:read-thread";
 export const APP_SERVER_GET_THREAD_FILE_DIFF_CHANNEL =
   "app-server:get-thread-file-diff";

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -2,8 +2,10 @@ export const APP_SERVER_LIST_THREADS_CHANNEL = "app-server:list-threads";
 export const THREAD_SEARCH_CHANNEL = "thread-search:search";
 export const FEDERATION_OPEN_WINDOW_CHANNEL = "federation:open-window";
 export const FEDERATION_GET_HEALTH_CHANNEL = "federation:get-health";
+export const FEDERATION_GET_DIAGNOSTICS_CHANNEL = "federation:get-diagnostics";
 export const FEDERATION_GENERATE_INVITE_CHANNEL = "federation:generate-invite";
 export const FEDERATION_IMPORT_INVITE_CHANNEL = "federation:import-invite";
+export const FEDERATION_REVOKE_PEER_CHANNEL = "federation:revoke-peer";
 export const APP_SERVER_READ_THREAD_CHANNEL = "app-server:read-thread";
 export const APP_SERVER_GET_THREAD_FILE_DIFF_CHANNEL =
   "app-server:get-thread-file-diff";

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -350,6 +350,7 @@ export const SETTINGS_PICK_GH_COMMAND_CHANNEL =
   "settings:pick-gh-command";
 export const ONBOARDING_COMPLETE_CODEX_BOOTSTRAP_CHANNEL =
   "onboarding:complete-codex-bootstrap";
+export const APPLICATIONS_READ_CHANNEL = "applications:read";
 export const APPLICATION_OPEN_CHANNEL = "application:open";
 export const PATH_OPEN_CHANNEL = "path:open";
 export const PATH_REVEAL_CHANNEL = "path:reveal";

--- a/docs/federation-architecture.md
+++ b/docs/federation-architecture.md
@@ -2,7 +2,7 @@
 
 PwrAgent instance federation lets one profile act as a gateway for other
 PwrAgent instances. The first implementation is shaped around a local gateway
-listener exposed through a stable Cloudflare Tunnel endpoint, with child
+listener exposed through a stable Cloudflare Tunnel endpoint, with client
 instances connecting back over WebSocket.
 
 ## Trust Model
@@ -23,8 +23,8 @@ instances connecting back over WebSocket.
 ## Modes
 
 - `disabled`: no federation listener or outbound federation connection.
-- `gateway`: listens locally and accepts enrolled child peers.
-- `child`: connects to the configured gateway URL.
+- `gateway`: listens locally and accepts enrolled client peers.
+- `client`: connects to the configured gateway URL.
 - `dual`: listens as a gateway and can also connect through another gateway.
 
 The current settings contract stores these under `[federation]` in the active
@@ -45,7 +45,7 @@ Secrets are stored separately under the desktop secret-store names defined by
 
 The federation transport is a bidirectional WebSocket protocol. Envelopes carry
 protocol version, source instance, optional target instance, request IDs, and
-deadlines. Gateways may relay envelopes when a child targets another enrolled
+deadlines. Gateways may relay envelopes when a client targets another enrolled
 instance.
 
 The first RPC surface intentionally maps read-oriented backend operations:
@@ -76,11 +76,11 @@ Build once, then run two isolated profiles from the same checkout:
 
 ```sh
 pnpm --filter @pwragent/desktop build
-PWRAGENT_PROFILE=master pnpm --filter @pwragent/desktop preview
-PWRAGENT_PROFILE=child pnpm --filter @pwragent/desktop preview
+PWRAGENT_PROFILE=gateway pnpm --filter @pwragent/desktop preview
+PWRAGENT_PROFILE=client pnpm --filter @pwragent/desktop preview
 ```
 
-In the master profile, open Settings -> Federation:
+In the gateway profile, open Settings -> Federation:
 
 1. Set mode to `gateway`.
 2. Keep `listen_host` as `127.0.0.1`.
@@ -90,28 +90,28 @@ In the master profile, open Settings -> Federation:
 5. Save federation settings.
 6. Generate an invite.
 
-In the child profile, open Settings -> Federation:
+In the client profile, open Settings -> Federation:
 
 1. Paste the invite into Import invite.
-2. Import it. The child switches to `child` mode and stores the gateway URL.
+2. Import it. The client switches to `client` mode and stores the gateway URL.
 3. Refresh health on both profiles.
 
-Back in the master profile:
+Back in the gateway profile:
 
-1. Confirm the child appears under Federation Instances.
-2. Click Open next to the child.
-3. The new window is scoped to the child instance for thread list, thread read,
+1. Confirm the client appears under Federation Instances.
+2. Click Open next to the client.
+3. The new window is scoped to the client instance for thread list, thread read,
    skill list, and prompt submission.
 
-In a child profile:
+In a client profile:
 
 1. Refresh Settings -> Federation after connecting.
-2. Confirm the gateway and any sibling children appear under Federation
+2. Confirm the gateway and any sibling clients appear under Federation
    Instances.
-3. Click Open next to the gateway to work against the master, or next to a
-   sibling child to route through the gateway.
+3. Click Open next to the gateway to work against the gateway, or next to a
+   sibling client to route through the gateway.
 
 Remote backend events stream back into the matching remote window, so prompt
 submission should show live turn status, tool activity, and assistant deltas
 without reopening the thread. The MVP still expects you to test against an
-existing child thread; remote new-thread creation is not wired yet.
+existing client thread; remote new-thread creation is not wired yet.

--- a/docs/federation-architecture.md
+++ b/docs/federation-architecture.md
@@ -69,3 +69,40 @@ future support tooling:
 
 UI surfaces should treat this as operator-visible status, not as an authority
 for making authorization decisions.
+
+## MVP Dogfood Flow
+
+Build once, then run two isolated profiles from the same checkout:
+
+```sh
+pnpm --filter @pwragent/desktop build
+PWRAGENT_PROFILE=master pnpm --filter @pwragent/desktop preview
+PWRAGENT_PROFILE=child pnpm --filter @pwragent/desktop preview
+```
+
+In the master profile, open Settings -> Federation:
+
+1. Set mode to `gateway`.
+2. Keep `listen_host` as `127.0.0.1`.
+3. Set a local test port, for example `8765`.
+4. Set Public URL to `ws://127.0.0.1:8765` for local testing, or to the
+   Cloudflare Tunnel `wss://...` endpoint for remote testing.
+5. Save federation settings.
+6. Generate an invite.
+
+In the child profile, open Settings -> Federation:
+
+1. Paste the invite into Import invite.
+2. Import it. The child switches to `child` mode and stores the gateway URL.
+3. Refresh health on both profiles.
+
+Back in the master profile:
+
+1. Confirm the child appears under Enrolled Peers.
+2. Click Open next to the child.
+3. The new window is scoped to the child instance for thread list, thread read,
+   skill list, and prompt submission.
+
+The MVP does not yet stream remote live events into the master window. After
+submitting a prompt to a remote thread, refresh/reopen the thread to inspect the
+updated transcript.

--- a/docs/federation-architecture.md
+++ b/docs/federation-architecture.md
@@ -1,0 +1,71 @@
+# PwrAgent Instance Federation
+
+PwrAgent instance federation lets one profile act as a gateway for other
+PwrAgent instances. The first implementation is shaped around a local gateway
+listener exposed through a stable Cloudflare Tunnel endpoint, with child
+instances connecting back over WebSocket.
+
+## Trust Model
+
+- Cloudflare Tunnel is a reachability and edge-filtering layer. It can restrict
+  source IPs, enforce Cloudflare Access, and optionally require Cloudflare-managed
+  client certificates before traffic reaches the local gateway port.
+- PwrAgent still authenticates peers inside the federation protocol. Each
+  instance owns an Ed25519 identity key stored through the desktop secret store.
+  Enrollment pins the accepted peer public key, and later handshakes must prove
+  possession of the matching private key.
+- Enrollment tokens are one-time bootstrap material. The sqlite store keeps an
+  HMAC of the invite token, not the token itself.
+- Diagnostics and renderer IPC must not expose private keys, client certificate
+  private keys, Cloudflare Access secrets, enrollment tokens, or pinned peer key
+  material.
+
+## Modes
+
+- `disabled`: no federation listener or outbound federation connection.
+- `gateway`: listens locally and accepts enrolled child peers.
+- `child`: connects to the configured gateway URL.
+- `dual`: listens as a gateway and can also connect through another gateway.
+
+The current settings contract stores these under `[federation]` in the active
+profile config:
+
+- `mode`
+- `listen_host`
+- `listen_port`
+- `public_url`
+- `gateway_url`
+- `cloudflare_mtls_enabled`
+- `cloudflare_access_service_auth_enabled`
+
+Secrets are stored separately under the desktop secret-store names defined by
+`DesktopSettingsSecretName`.
+
+## Transport And Routing
+
+The federation transport is a bidirectional WebSocket protocol. Envelopes carry
+protocol version, source instance, optional target instance, request IDs, and
+deadlines. Gateways may relay envelopes when a child targets another enrolled
+instance.
+
+The first RPC surface intentionally maps read-oriented backend operations:
+
+- `backend.listThreads`
+- `backend.readThread`
+- `backend.listSkills`
+
+This is enough to bootstrap remote windows, thread discovery, and federated
+search without prematurely exposing turn-control or environment mutation.
+
+## Diagnostics
+
+`federation:get-health` returns a sanitized health snapshot for settings and
+future support tooling:
+
+- configured role and enabled status
+- local listener URL when enabled
+- public Cloudflare/Tunnel URL when configured
+- enrolled peers, including revoked peers, without pinned public key material
+
+UI surfaces should treat this as operator-visible status, not as an authority
+for making authorization decisions.

--- a/docs/federation-architecture.md
+++ b/docs/federation-architecture.md
@@ -98,10 +98,18 @@ In the child profile, open Settings -> Federation:
 
 Back in the master profile:
 
-1. Confirm the child appears under Enrolled Peers.
+1. Confirm the child appears under Federation Instances.
 2. Click Open next to the child.
 3. The new window is scoped to the child instance for thread list, thread read,
    skill list, and prompt submission.
+
+In a child profile:
+
+1. Refresh Settings -> Federation after connecting.
+2. Confirm the gateway and any sibling children appear under Federation
+   Instances.
+3. Click Open next to the gateway to work against the master, or next to a
+   sibling child to route through the gateway.
 
 Remote backend events stream back into the matching remote window, so prompt
 submission should show live turn status, tool activity, and assistant deltas

--- a/docs/federation-architecture.md
+++ b/docs/federation-architecture.md
@@ -103,6 +103,7 @@ Back in the master profile:
 3. The new window is scoped to the child instance for thread list, thread read,
    skill list, and prompt submission.
 
-The MVP does not yet stream remote live events into the master window. After
-submitting a prompt to a remote thread, refresh/reopen the thread to inspect the
-updated transcript.
+Remote backend events stream back into the matching remote window, so prompt
+submission should show live turn status, tool activity, and assistant deltas
+without reopening the thread. The MVP still expects you to test against an
+existing child thread; remote new-thread creation is not wired yet.

--- a/docs/federation-architecture.md
+++ b/docs/federation-architecture.md
@@ -13,7 +13,9 @@ instances connecting back over WebSocket.
 - PwrAgent still authenticates peers inside the federation protocol. Each
   instance owns an Ed25519 identity key stored through the desktop secret store.
   Enrollment pins the accepted peer public key, and later handshakes must prove
-  possession of the matching private key.
+  possession of the matching private key. The invite also carries the gateway
+  public key so a client verifies the gateway's signed challenge before it
+  installs the connection.
 - Enrollment tokens are one-time bootstrap material. The sqlite store keeps an
   HMAC of the invite token, not the token itself.
 - Diagnostics and renderer IPC must not expose private keys, client certificate

--- a/docs/federation-architecture.md
+++ b/docs/federation-architecture.md
@@ -48,19 +48,18 @@ protocol version, source instance, optional target instance, request IDs, and
 deadlines. Gateways may relay envelopes when a client targets another enrolled
 instance.
 
-The first RPC surface intentionally maps read-oriented backend operations:
-
-- `backend.listThreads`
-- `backend.readThread`
-- `backend.listSkills`
-
-This is enough to bootstrap remote windows, thread discovery, and federated
-search without prematurely exposing turn-control or environment mutation.
+The RPC surface maps navigation and thread reads plus the remote operation
+surface used by desktop windows and messaging. It includes thread creation,
+fork/review, turn start/steer/interrupt/compact, pending-request submission,
+model and execution settings, environment actions, environment setup progress,
+and workspace handoff. Capability checks remain attached to every method, so an
+older or restricted peer fails closed instead of silently executing locally.
 
 ## Diagnostics
 
 `federation:get-health` returns a sanitized health snapshot for settings and
-future support tooling:
+support tooling. `federation:get-diagnostics` adds bounded, redacted session
+audit events:
 
 - configured role and enabled status
 - local listener URL when enabled
@@ -111,7 +110,10 @@ In a client profile:
 3. Click Open next to the gateway to work against the gateway, or next to a
    sibling client to route through the gateway.
 
-Remote backend events stream back into the matching remote window, so prompt
-submission should show live turn status, tool activity, and assistant deltas
-without reopening the thread. The MVP still expects you to test against an
-existing client thread; remote new-thread creation is not wired yet.
+Remote backend events and environment setup progress stream back into the
+matching remote window. Remote navigation includes the target instance's
+directories and launchpads, so new threads, forks, and reviews execute on the
+remote machine as well as operations on existing threads.
+
+See `docs/federation.md` for direct-mode and Cloudflare Tunnel setup, Access
+service-token and mTLS credential handling, diagnostics, and revocation.

--- a/docs/federation.md
+++ b/docs/federation.md
@@ -21,8 +21,9 @@ Federation uses two independent admission layers:
 
 Each PwrAgent profile owns an Ed25519 identity key in encrypted desktop secret
 storage. Enrollment invites are short-lived and single-use. The gateway stores
-the enrolled public identity and can revoke it. Revocation closes the active
-gateway connection and blocks reconnects with that identity.
+the enrolled public identity, while the client pins the gateway public identity
+from the invite. Revocation closes the active gateway connection and blocks
+reconnects with that identity.
 
 Keep the gateway listener on `127.0.0.1` when using `cloudflared`. Do not expose
 the listener port through a router or host firewall.

--- a/docs/federation.md
+++ b/docs/federation.md
@@ -1,0 +1,206 @@
+# PwrAgent Federation Operator Guide
+
+PwrAgent federation connects multiple PwrAgent profiles through an authenticated
+WebSocket control plane. A gateway accepts connections, clients connect to that
+gateway, and the gateway relays authorized traffic between clients.
+
+Federation is disabled by default. The first supported remote posture is a
+loopback gateway listener published through Cloudflare Tunnel. Direct
+localhost/LAN WebSocket URLs use the same PwrAgent enrollment and peer
+authentication.
+
+## Security Boundaries
+
+Federation uses two independent admission layers:
+
+1. Cloudflare can restrict which traffic reaches the tunnel hostname with IP,
+   Access service-token, or mTLS policy.
+2. PwrAgent always requires an enrolled instance identity and a signed
+   challenge. Cloudflare headers or certificates never replace PwrAgent peer
+   authentication.
+
+Each PwrAgent profile owns an Ed25519 identity key in encrypted desktop secret
+storage. Enrollment invites are short-lived and single-use. The gateway stores
+the enrolled public identity and can revoke it. Revocation closes the active
+gateway connection and blocks reconnects with that identity.
+
+Keep the gateway listener on `127.0.0.1` when using `cloudflared`. Do not expose
+the listener port through a router or host firewall.
+
+## Local Dogfood Setup
+
+Build the desktop app once, then launch isolated profiles:
+
+```sh
+pnpm --filter @pwragent/desktop build
+PWRAGENT_PROFILE=gateway pnpm --filter @pwragent/desktop preview
+PWRAGENT_PROFILE=laptop pnpm --filter @pwragent/desktop preview
+```
+
+On the gateway profile, open Settings -> Federation and set:
+
+- Mode: `gateway`
+- Listen host: `127.0.0.1`
+- Listen port: `47830`
+- Public URL: `ws://127.0.0.1:47830`
+
+Save, generate an invite, and import it on the laptop profile. The imported
+profile switches to client mode and connects immediately.
+
+Both profiles should list the other instance as Connected. Open the remote
+instance from either profile. A client can also open the gateway or another
+connected client; sibling traffic is relayed by the gateway.
+
+## Cloudflare Tunnel
+
+Cloudflare Tunnel supports WebSockets and connects to the origin without an
+inbound public port. See Cloudflare's
+[Tunnel overview](https://developers.cloudflare.com/tunnel/) and
+[Tunnel WebSocket support](https://developers.cloudflare.com/cloudflare-one/faq/cloudflare-tunnels-faq/).
+
+Create a named tunnel and DNS route:
+
+```sh
+cloudflared tunnel login
+cloudflared tunnel create pwragent-federation
+cloudflared tunnel route dns pwragent-federation pwragent.example.com
+```
+
+Use a `cloudflared` configuration like:
+
+```yaml
+tunnel: YOUR_TUNNEL_ID
+credentials-file: /absolute/path/to/YOUR_TUNNEL_ID.json
+
+ingress:
+  - hostname: pwragent.example.com
+    service: http://127.0.0.1:47830
+  - service: http_status:404
+```
+
+Start the tunnel:
+
+```sh
+cloudflared tunnel run pwragent-federation
+```
+
+On the gateway, keep the listener at `127.0.0.1:47830` and set Public URL to
+`wss://pwragent.example.com`. Generate new invites after changing the public
+URL because the URL is embedded in each invite.
+
+### Source IP Restriction
+
+An IP allow rule at Cloudflare is a useful outer gate while the gateway is at a
+stable location. Verify the rule against the hostname before relying on it and
+remove or change it deliberately when the connecting laptop moves networks.
+PwrAgent enrollment remains mandatory whether or not the IP rule is active.
+
+### Cloudflare Access Service Token
+
+Cloudflare Access service tokens use the
+`CF-Access-Client-Id` and `CF-Access-Client-Secret` headers. Configure a
+Self-hosted Access application and a Service Auth policy for the federation
+hostname. Cloudflare documents the current flow in
+[Service tokens](https://developers.cloudflare.com/cloudflare-one/access-controls/service-credentials/service-tokens/)
+and [Access policies](https://developers.cloudflare.com/cloudflare-one/access-controls/policies/).
+
+On every client profile, before importing its federation invite:
+
+1. Open Settings -> Federation -> Cloudflare.
+2. Enable Access service auth.
+3. Enter the Access client ID and client secret.
+4. Select Save edge policy.
+5. Import the federation invite.
+
+PwrAgent stores both values in encrypted desktop secret storage and sends them
+only in the WebSocket upgrade request. If either value is missing while the
+mode is enabled, the connector fails closed with a Settings diagnostic.
+
+### Cloudflare Access mTLS
+
+Cloudflare Access can enforce a Service Auth policy with a Valid Certificate or
+Common Name selector. Its current setup and certificate requirements are in
+[Cloudflare Access mTLS](https://developers.cloudflare.com/cloudflare-one/access-controls/service-credentials/mutual-tls-authentication/).
+Availability depends on the Cloudflare account and product configuration; check
+the dashboard before treating mTLS as an available outer gate.
+
+Issue each client a certificate and private key from the CA associated with the
+federation hostname. On the client profile, before importing its invite:
+
+1. Open Settings -> Federation -> Cloudflare.
+2. Enable mTLS.
+3. Paste the PEM client certificate and matching PEM private key.
+4. Select Save edge policy.
+5. Import the federation invite.
+
+The private key stays in encrypted desktop secret storage. PwrAgent supplies
+the certificate and key only during the TLS handshake. Missing certificate
+material causes a closed failure before a WebSocket is opened.
+
+Access service tokens and mTLS can be enabled together when the Access policy
+requires both.
+
+## Remote Operation
+
+A remote window routes its navigation, thread reads, prompt submission,
+steering, interruption, compaction, approvals, model and execution settings,
+environment selection/actions, environment action stop, reviews, forks,
+launchpad materialization, and workspace handoff to the selected instance.
+Backend events and environment setup output stream back with the source
+instance identity.
+
+Global thread search fans out metadata queries to connected peers. Remote
+results carry their instance label and open directly in a window scoped to that
+instance.
+
+Messaging thread browse includes connected remote threads with an instance
+label. Selecting one persists its full federated identity, so prompts, steering,
+interrupts, compaction, settings changes, approvals, status reads, and streamed
+events continue to route to the owning instance. A disconnected remote binding
+remains stored and reports unavailable thread state rather than rebinding to a
+same-named local thread.
+
+Disconnected or revoked peers remain visible for diagnosis, but Open is
+disabled. PwrAgent does not fall back to local execution when a remote target
+is unavailable.
+
+Remote filesystem paths describe the remote machine. Do not assume a path is
+present on the machine displaying the remote window.
+
+## Diagnostics And Revocation
+
+Settings -> Federation shows:
+
+- local mode, listener, public URL, and connector status
+- peer role, status, protocol version, negotiated capabilities, and activity
+- recent connection attempts, accepts, rejects, disconnects, relays, and errors
+- redacted failure details without invites, private keys, or raw credentials
+
+Select Revoke next to a peer to close its active gateway connection and prevent
+that identity from reconnecting. Re-enrollment requires a fresh invite and a
+new instance identity.
+
+Common failures:
+
+- `unknown_peer`: the client identity was never enrolled or local state was
+  replaced; generate and import a new invite.
+- `revoked_peer`: the gateway has revoked this identity.
+- `bad_signature`: the stored private key does not match the enrolled public
+  identity.
+- HTTP `401` or `403` before a PwrAgent audit event: Cloudflare rejected the
+  WebSocket upgrade. Check IP, Access token, or mTLS policy.
+- Missing Cloudflare credential error: enable the edge mode only after storing
+  all required fields.
+
+## Threat Model
+
+The design protects against arbitrary Internet clients reaching a tunnel,
+unenrolled PwrAgent instances, replay of used enrollment invites, reconnect by
+revoked identities, and accidental routing of remote commands to the local
+profile.
+
+It does not protect against a compromised enrolled machine, an attacker who can
+use that profile's unlocked desktop secret storage, or commands explicitly
+approved on a remote coding-agent thread. Treat every enrolled peer as able to
+exercise the capabilities shown in Settings and revoke peers that are lost or
+retired.

--- a/docs/plans/2026-06-10-001-feat-pwragent-instance-federation-plan.md
+++ b/docs/plans/2026-06-10-001-feat-pwragent-instance-federation-plan.md
@@ -1,0 +1,591 @@
+---
+title: "feat: add secure PwrAgent instance federation"
+type: feat
+date: 2026-06-10
+deepened: 2026-06-10
+---
+
+# feat: add secure PwrAgent instance federation
+
+## Summary
+
+This plan adds a secure federation layer where one PwrAgent instance can act as a gateway for locally and remotely connected PwrAgent instances. The first build supports Cloudflare Tunnel as the remote reachability path, a bidirectional authenticated WebSocket control plane, remote thread/window operation, federated search, and messaging routes that can target any authorized instance.
+
+---
+
+## Problem Frame
+
+The operator wants one master PwrAgent instance that can reach child instances at home, on remote machines, or through a laptop-on-the-go posture without opening arbitrary public ports. The design must be secure enough for personal dogfooding, rich enough to validate remote UI and messaging workflows, and structured so a local-only or non-Cloudflare transport can be added later without rewriting thread, search, or messaging behavior.
+
+The existing codebase has strong local patterns for thread operations through `BackendRegistry`, renderer IPC through `apps/desktop/src/main/ipc/app-server.ts`, and messaging orchestration through `apps/desktop/src/main/messaging/desktop-backend-bridge.ts`. It does not have an inter-instance transport, persistent peer identity model, or remote thread projection.
+
+---
+
+## Requirements
+
+### Security and Enrollment
+
+- R1. A gateway instance must accept federation traffic only from enrolled peer instances with revocable instance identity.
+- R2. Cloudflare policy may block unauthenticated Internet traffic before it reaches the tunnel, but PwrAgent must still authenticate and authorize every peer at the application layer.
+- R3. Direct local connections must support the same peer identity and authorization semantics as tunneled remote connections.
+- R4. Private keys, Cloudflare service credentials, and enrollment secrets must be stored through the existing encrypted secret-store path and never written into plaintext config or logs.
+- R5. Peer revocation must close active sessions and prevent reconnect with the revoked identity.
+
+### Federation Protocol
+
+- R6. Child instances must initiate long-lived bidirectional WebSocket sessions to the gateway and use the same channel for requests, responses, and backend notifications.
+- R7. The protocol must support capability negotiation so older peers degrade safely when remote windows, search, or messaging routing features differ by version.
+- R8. The gateway must route peer-to-peer requests through relay semantics rather than requiring children to connect directly to each other.
+- R9. Requests must carry correlation ids, deadlines, actor/origin metadata, and redaction-safe error surfaces.
+
+### Remote Operation
+
+- R10. A local user must be able to open a separate PwrAgent window scoped to a remote instance/profile and operate remote threads as if they were local.
+- R11. Remote actions such as thread start, turn steer, approvals, environment actions, scripts, and worktree operations must execute on the remote instance, not on the gateway machine.
+- R12. Remote thread lists and thread detail views must clearly show the target instance without mixing remote execution context into the local default profile.
+
+### Cross-Instance Features
+
+- R13. Federated search must fan out across authorized connected instances, merge results, and preserve source instance identity in every result.
+- R14. Messaging bindings on the gateway must be able to browse, bind, resume, and steer threads on authorized child instances.
+- R15. Child instances must also be able to open remote windows or route requests through the gateway to another child or back to the gateway when authorization permits.
+
+### Operations and Observability
+
+- R16. Operators must be able to configure gateway/child mode, endpoint URL, local listen port, Cloudflare posture notes, and peer enrollment from Settings.
+- R17. Federation health, last activity, protocol version, and authorization failures must be visible in a local diagnostics surface.
+- R18. The implementation must preserve dependency-cruiser boundaries: renderer code imports only `@pwragent/shared`, messaging providers remain isolated, and desktop main owns orchestration.
+
+---
+
+## Key Technical Decisions
+
+- KTD1. Add desktop-owned federation modules, not messaging-provider adapters: federation is a PwrAgent-to-PwrAgent control plane with richer privileges than ordinary messaging clients. It should reuse `BackendRegistry` and messaging bridge concepts but live under `apps/desktop/src/main/federation/`.
+- KTD2. Use WebSocket over HTTP(S) as the first transport: Cloudflare documents WebSocket support for proxied HTTP requests, and Tunnel already exposes localhost services without a public origin IP. A direct localhost/LAN mode can use the same transport without Cloudflare.
+- KTD3. Treat Cloudflare mTLS as an outer gate, not the only auth boundary: Cloudflare can require client certificates at the edge, but the localhost service must still perform peer authentication because tunnel/origin forwarding does not make Cloudflare's edge certificate validation equivalent to local process identity.
+- KTD4. Use an application-level peer key handshake for PwrAgent identity: each instance has a generated asymmetric keypair and signed identity document; enrollment pins the public identity, not a bearer token. TLS client certs can be used for direct local mode, but the signed protocol handshake remains canonical across tunneled and direct transports.
+- KTD5. Model remote instances as a new top-level desktop orchestration target, not as `AppServerBackendKind`: backend kind already means Codex/Grok/ACP runtime inside one instance. Federation adds an instance dimension above backend, so contracts should carry `{ instanceId, backend, threadId }` where remote identity matters.
+- KTD6. Route remote windows through a dedicated window context: a remote window should have its own navigation snapshot source, transcript source, and command path so local and remote profiles do not silently share execution context.
+- KTD7. Extend messaging at the bridge/controller boundary: gateway messaging should see remote threads through a federation-aware backend bridge, while provider packages keep the same generic adapter contract and never learn about remote instances.
+- KTD8. Persist peer registry and audit state in sqlite, but keep private key material in the secret store: non-secret peer metadata belongs in `state.db`; secrets follow the existing `DbBackedSafeStorageSecretStore` pattern.
+
+---
+
+## High-Level Technical Design
+
+### Component Topology
+
+```mermaid
+flowchart TB
+  subgraph Gateway["Gateway PwrAgent instance"]
+    GatewayListener["Federation listener"]
+    GatewayRegistry["Peer registry + session manager"]
+    GatewayBridge["Federation backend bridge"]
+    LocalBackend["Local BackendRegistry"]
+    Messaging["Messaging runtime"]
+    RemoteWindow["Remote BrowserWindow context"]
+  end
+
+  subgraph Cloudflare["Optional Cloudflare edge"]
+    Tunnel["cloudflared tunnel"]
+    EdgePolicy["Access/WAF policy + mTLS"]
+  end
+
+  subgraph ChildA["Child instance A"]
+    ChildConnectorA["Federation connector"]
+    ChildBackendA["Local BackendRegistry"]
+  end
+
+  subgraph ChildB["Child instance B"]
+    ChildConnectorB["Federation connector"]
+    ChildBackendB["Local BackendRegistry"]
+  end
+
+  ChildConnectorA -->|WebSocket + app peer auth| EdgePolicy
+  EdgePolicy --> Tunnel
+  Tunnel --> GatewayListener
+  ChildConnectorB -->|direct or tunneled WebSocket| GatewayListener
+  GatewayListener --> GatewayRegistry
+  GatewayRegistry --> GatewayBridge
+  GatewayBridge --> LocalBackend
+  GatewayBridge --> ChildConnectorA
+  GatewayBridge --> ChildConnectorB
+  Messaging --> GatewayBridge
+  RemoteWindow --> GatewayBridge
+  ChildConnectorA --> ChildBackendA
+  ChildConnectorB --> ChildBackendB
+```
+
+### Connection and Enrollment Flow
+
+```mermaid
+sequenceDiagram
+  participant Operator
+  participant Gateway
+  participant Child
+  participant Cloudflare
+
+  Operator->>Gateway: generate enrollment invite
+  Gateway-->>Operator: short-lived invite payload
+  Operator->>Child: paste/import invite
+  Child->>Child: generate instance keypair
+  Child->>Cloudflare: connect to gateway hostname with edge credentials when configured
+  Cloudflare->>Gateway: forward WebSocket upgrade after edge policy
+  Child->>Gateway: hello(instance identity, nonce, capabilities)
+  Gateway->>Child: challenge(nonce, gateway identity)
+  Child->>Gateway: signed challenge + invite proof
+  Gateway->>Gateway: pin peer identity and grant policy
+  Gateway-->>Child: session accepted + capability contract
+```
+
+### Request Routing Model
+
+```mermaid
+flowchart TB
+  UI["Renderer or messaging command"] --> MainBridge["Desktop main bridge"]
+  MainBridge --> Target{"Target instance"}
+  Target -->|local| LocalRegistry["BackendRegistry"]
+  Target -->|connected peer| PeerSession["Federation session"]
+  Target -->|other child| Relay["Gateway relay"]
+  Relay --> PeerSession
+  PeerSession --> RemoteRegistry["Remote BackendRegistry"]
+  RemoteRegistry --> Response["response/notification"]
+  LocalRegistry --> Response
+  Response --> MainBridge
+```
+
+### Peer Session State
+
+```mermaid
+stateDiagram-v2
+  [*] --> Disabled
+  Disabled --> Listening: gateway enabled
+  Disabled --> Connecting: child enabled
+  Listening --> Handshaking: socket accepted
+  Connecting --> Handshaking: socket opened
+  Handshaking --> Connected: identity and policy accepted
+  Handshaking --> Rejected: auth/policy/version failure
+  Connected --> Degraded: missed heartbeat or backpressure
+  Degraded --> Connected: recovered
+  Connected --> Revoked: peer revoked
+  Degraded --> Revoked: peer revoked
+  Connected --> Disconnected: socket closed
+  Degraded --> Disconnected: socket closed
+  Rejected --> Disconnected
+  Revoked --> Disabled
+  Disconnected --> Connecting: retry allowed
+  Disconnected --> Listening: gateway remains enabled
+```
+
+---
+
+## Scope Boundaries
+
+### In Scope
+
+- Gateway and child roles in the desktop app.
+- Cloudflare Tunnel-compatible WebSocket transport.
+- Edge mTLS guidance and in-app peer authentication.
+- Remote window operation for thread navigation/detail/composer actions.
+- Federated search across connected instances.
+- Gateway messaging routing to local and remote threads.
+- Relay routing through the gateway for child-to-child access.
+
+### Deferred to Follow-Up Work
+
+- A polished local-only transport that does not assume Cloudflare or a stable DNS hostname.
+- Fully automated Cloudflare API provisioning of tunnels, hostnames, WAF rules, and Access policies.
+- Multi-gateway mesh discovery or quorum behavior.
+- End-user multi-tenant policy controls beyond the operator's personal trusted-instance model.
+- Mobile native certificate installation workflows.
+
+### Out of Scope
+
+- Treating remote instances as ordinary Telegram/Discord/Slack/etc. providers.
+- Running remote commands locally on the gateway for convenience.
+- Allowing unauthenticated LAN discovery to auto-enroll peers.
+
+---
+
+## Implementation Units
+
+### U1. Federation Contracts and Target Identity
+
+**Goal:** Define shared type contracts for federated instance identity, target addressing, protocol envelopes, capabilities, health, and renderer-visible summaries.
+
+**Requirements:** R6, R7, R8, R9, R10, R12, R13, R14, R18.
+
+**Dependencies:** None.
+
+**Files:**
+
+- `packages/shared/src/contracts/federation.ts`
+- `packages/shared/src/contracts/navigation.ts`
+- `packages/shared/src/contracts/messaging.ts`
+- `packages/shared/src/index.ts`
+- `packages/shared/src/contracts/__tests__/federation.test.ts`
+- `packages/shared/src/contracts/__tests__/navigation.test.ts`
+
+**Approach:** Add a new shared federation contract rather than overloading backend or messaging contracts. Use `FederatedInstanceId`, `FederatedThreadRef`, `FederationProtocolEnvelope`, `FederationCapabilitySet`, `FederationPeerSummary`, and `FederationHealthStatus` as shared primitives. Keep protocol payloads typed around existing app-server request/response contracts where possible, but wrap them with source/target instance metadata and protocol version.
+
+**Patterns to follow:** `packages/shared/src/contracts/normalized-app-server.ts` for app-server request shapes; `packages/shared/src/contracts/messaging.ts` for health/degradation status naming; `packages/shared/src/contracts/navigation.ts` for renderer-facing summaries.
+
+**Test scenarios:**
+
+- Happy path: a `FederatedThreadRef` with remote instance, backend, and thread id serializes without losing the local `AppServerBackendKind`.
+- Edge case: local targets can be represented without a remote instance id so existing local-only callers do not need fake peer ids.
+- Error path: invalid peer ids, protocol versions, and capability names fail normalization with redaction-safe messages.
+- Integration: navigation summaries can include remote instance labels without requiring the renderer to import desktop-only code.
+
+**Verification:** Shared contract tests cover target identity, capability negotiation types, and navigation/messaging extension compatibility.
+
+### U2. Persistent Peer Registry, Secret Storage, and Config
+
+**Goal:** Persist federation mode/configuration, enrolled peer metadata, revocation state, and encrypted peer private material.
+
+**Requirements:** R1, R3, R4, R5, R16, R17, R18.
+
+**Dependencies:** U1.
+
+**Files:**
+
+- `apps/desktop/src/main/state/state-db.ts`
+- `apps/desktop/src/main/state/federation-store-sqlite.ts`
+- `apps/desktop/src/main/settings/desktop-config.ts`
+- `apps/desktop/src/main/settings/desktop-settings-service.ts`
+- `apps/desktop/src/main/settings/desktop-secret-store.ts`
+- `packages/shared/src/contracts/settings.ts`
+- `apps/desktop/src/main/__tests__/federation-store.test.ts`
+- `apps/desktop/src/main/__tests__/desktop-config.test.ts`
+- `apps/desktop/src/main/__tests__/desktop-settings-service.test.ts`
+- `packages/shared/src/contracts/__tests__/settings.test.ts`
+
+**Approach:** Add sqlite tables for peer metadata, peer grants, invite records, session audit, and optional Cloudflare posture metadata. Store the local instance private key and any Cloudflare Access/service credentials through the existing secret-store abstraction. Add config keys under a new `[federation]` section with read-fallback and lazy conversion rules from `docs/config-file-evolution.md`.
+
+**Execution note:** Add config and store tests before wiring runtime behavior because config shape is hard to change after dogfooding.
+
+**Patterns to follow:** `messaging_pairing_tokens` and `app_runtime_instances` in `apps/desktop/src/main/state/state-db.ts`; `apps/desktop/src/main/messaging/desktop-messaging-pairing-store.ts`; encrypted secret access through `apps/desktop/src/main/state/secret-store-sqlite.ts`.
+
+**Test scenarios:**
+
+- Happy path: gateway config with a listen port, public endpoint, and enrolled peer round-trips through TOML and sqlite.
+- Happy path: a child config with gateway URL and local identity id loads without requiring messaging to be enabled.
+- Edge case: missing optional Cloudflare fields keeps local/direct mode valid.
+- Error path: secret storage unavailable reports federation credentials as unavailable without writing plaintext fallback values.
+- Error path: revoked peers remain stored for audit but cannot be returned as connectable peers.
+- Integration: config patching preserves unrelated TOML comments and existing messaging settings.
+
+**Verification:** Config, settings-service, shared settings, and sqlite store tests prove state persistence, encrypted secret routing, and backwards-compatible TOML edits.
+
+### U3. Enrollment, Peer Authentication, and Session Policy
+
+**Goal:** Implement invite-based enrollment, key generation, signed challenge/response, session policy evaluation, revocation, and heartbeat/backoff state.
+
+**Requirements:** R1, R2, R3, R4, R5, R7, R9, R17.
+
+**Dependencies:** U1, U2.
+
+**Files:**
+
+- `apps/desktop/src/main/federation/federation-identity.ts`
+- `apps/desktop/src/main/federation/federation-enrollment.ts`
+- `apps/desktop/src/main/federation/federation-policy.ts`
+- `apps/desktop/src/main/federation/federation-session-state.ts`
+- `apps/desktop/src/main/federation/federation-redaction.ts`
+- `apps/desktop/src/main/__tests__/federation-identity.test.ts`
+- `apps/desktop/src/main/__tests__/federation-enrollment.test.ts`
+- `apps/desktop/src/main/__tests__/federation-policy.test.ts`
+
+**Approach:** Generate a per-instance asymmetric keypair and expose short-lived enrollment invites from the gateway. During first connection, the child proves invite possession and key ownership; the gateway pins the public identity and grants explicit capabilities. Subsequent sessions authenticate with nonce signatures and check revocation/policy before protocol use. Do not trust Cloudflare-forwarded identity headers as the only peer identity signal.
+
+**Technical design:** Directional guidance, not implementation specification: the handshake should have four phases: `hello`, `challenge`, `proof`, `accept/reject`. Every phase should include a protocol version, connection nonce, instance id, and redacted failure code so logs can diagnose bad certs, stale invites, and policy denials without logging secrets.
+
+**Patterns to follow:** `apps/desktop/src/main/messaging/desktop-messaging-pairing-store.ts` for short-lived pairing; `packages/shared/src/messaging-id-validation.ts` for defensive identifier validation; the solution note in `docs/solutions/2026-05-07-codex-permission-mode-state-machine.md` for avoiding silent security fallbacks.
+
+**Test scenarios:**
+
+- Covers AE1. Happy path: a valid invite plus signed child challenge enrolls a peer and stores a pinned public identity.
+- Happy path: an already-enrolled peer reconnects without an invite when its signature and policy match.
+- Edge case: expired invite, reused invite, and invite for a different gateway are rejected.
+- Error path: bad signatures, unknown peer ids, revoked peers, and capability-denied peers fail closed and log redacted diagnostics.
+- Integration: revoking a peer terminates active sessions and prevents reconnect using the same identity.
+
+**Verification:** Identity and policy tests cover first enrollment, reconnect, revocation, and redaction behavior without opening network sockets.
+
+### U4. Federation Transport Runtime
+
+**Goal:** Add the gateway listener, child connector, WebSocket envelope transport, request/response correlation, notification streaming, reconnect, and backpressure behavior.
+
+**Requirements:** R2, R3, R6, R7, R8, R9, R15, R17.
+
+**Dependencies:** U1, U2, U3.
+
+**Files:**
+
+- `apps/desktop/package.json`
+- `apps/desktop/src/main/federation/federation-runtime.ts`
+- `apps/desktop/src/main/federation/federation-listener.ts`
+- `apps/desktop/src/main/federation/federation-connector.ts`
+- `apps/desktop/src/main/federation/federation-transport.ts`
+- `apps/desktop/src/main/federation/federation-protocol.ts`
+- `apps/desktop/src/main/federation/federation-cloudflare.ts`
+- `apps/desktop/src/main/index.ts`
+- `apps/desktop/src/main/__tests__/federation-runtime.test.ts`
+- `apps/desktop/src/main/__tests__/federation-transport.test.ts`
+- `apps/desktop/src/main/__tests__/app-bootstrap.test.ts`
+
+**Approach:** Add a direct `ws` dependency for Node WebSocket server/client support and keep the listener bound to configured loopback/local addresses by default. The gateway accepts WebSocket upgrades, delegates authentication to U3, and registers connected sessions. The child connector retries with bounded exponential backoff and exposes health transitions to Settings/diagnostics. Cloudflare-specific code should be limited to endpoint/policy metadata and header handling; it must not be required for direct local operation.
+
+**Patterns to follow:** `DesktopMessagingRuntime` lifecycle queueing and health event emission in `apps/desktop/src/main/messaging/messaging-runtime.ts`; Mattermost callback listener hardening in `packages/messaging/providers/mattermost/src/mattermost-callback-server.ts`; app bootstrap wiring in `apps/desktop/src/main/index.ts`.
+
+**Test scenarios:**
+
+- Covers AE1. Happy path: child connects to a gateway through direct or Cloudflare-routed WebSocket, authenticates, negotiates capabilities, sends a request, receives a correlated response, and receives an async notification.
+- Happy path: gateway listener binds only to configured host/port and reports health to subscribers.
+- Edge case: peer reconnect replaces or rejects duplicate sessions according to policy without leaving stale listeners.
+- Edge case: slow peer hits backpressure limits and degrades without blocking local registry events.
+- Error path: malformed JSON, oversized envelopes, unknown message types, missed heartbeats, and deadline expiry close or reject safely.
+- Integration: runtime start/stop through app bootstrap does not start when federation config is disabled.
+
+**Verification:** Runtime tests exercise an in-process WebSocket gateway/child pair, protocol rejection paths, lifecycle stop/start, and health notifications.
+
+### U5. Federation Backend Bridge and Relay
+
+**Goal:** Bridge local app-server operations to remote instances and route child-to-child requests through the gateway relay.
+
+**Requirements:** R6, R8, R9, R10, R11, R12, R15, R18.
+
+**Dependencies:** U1, U3, U4.
+
+**Files:**
+
+- `apps/desktop/src/main/federation/federation-backend-bridge.ts`
+- `apps/desktop/src/main/federation/federation-relay.ts`
+- `apps/desktop/src/main/federation/federation-target-router.ts`
+- `apps/desktop/src/main/app-server/backend-registry.ts`
+- `apps/desktop/src/main/ipc/app-server.ts`
+- `apps/desktop/src/main/messaging/desktop-backend-bridge.ts`
+- `apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts`
+- `apps/desktop/src/main/__tests__/federation-relay.test.ts`
+- `apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts`
+
+**Approach:** Create a target router that can resolve local versus remote instance targets. Local operations continue to call `BackendRegistry`; remote operations serialize existing app-server requests over the federation protocol. The gateway relay authorizes both source peer and destination peer before forwarding, preserves correlation ids, and prevents loops with hop count/deadline fields.
+
+**Technical design:** Directional guidance, not implementation specification: bridge operations should begin with the subset needed by remote windows and messaging: list/read thread, navigation snapshot, start/steer/interrupt/compact turn, submit pending request, set model/settings/execution mode, list skills, environment actions, and thread/workspace handoff. Low-use operations can be capability-gated rather than all shipped in the first unit.
+
+**Patterns to follow:** `apps/desktop/src/main/messaging/desktop-backend-bridge.ts` for a narrow bridge over `BackendRegistry`; `BackendRegistry.onEvent` fan-out for notifications; `apps/desktop/src/main/ipc/app-server.ts` for renderer request shapes.
+
+**Test scenarios:**
+
+- Happy path: remote `getNavigationSnapshot`, `readThread`, and `startTurn` return the same response shape local callers expect, with source instance metadata added by the bridge.
+- Happy path: remote backend notifications flow through the bridge to subscribed window/messaging consumers.
+- Covers AE3. Happy path: a child-to-child request is authorized by the gateway and delivered to the destination child.
+- Edge case: disconnected target returns a typed unavailable result rather than hanging.
+- Error path: unauthorized source/destination combinations, expired deadlines, relay loops, and missing capabilities fail closed.
+- Integration: existing local `DesktopMessagingBackendBridge` tests keep passing for local targets while new remote-target tests use a fake federation runtime.
+
+**Verification:** Bridge and relay tests prove local behavior is preserved and remote/relay routing adds authorization, deadlines, and target metadata.
+
+### U6. Remote Window Context and Renderer Integration
+
+**Goal:** Let users open a separate PwrAgent window scoped to a remote instance/profile and operate remote threads through the federation bridge.
+
+**Requirements:** R10, R11, R12, R16, R18.
+
+**Dependencies:** U1, U5.
+
+**Files:**
+
+- `apps/desktop/src/main/window-open-remote-instance.ts`
+- `apps/desktop/src/main/window-channels.ts`
+- `apps/desktop/src/main/ipc/app-server.ts`
+- `apps/desktop/src/preload/index.ts`
+- `apps/desktop/src/shared/ipc.ts`
+- `apps/desktop/src/renderer/src/App.tsx`
+- `apps/desktop/src/renderer/src/lib/desktop-api.ts`
+- `apps/desktop/src/renderer/src/lib/useThreadNavigation.ts`
+- `apps/desktop/src/renderer/src/lib/useThreadTranscript.ts`
+- `apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx`
+- `apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx`
+- `apps/desktop/src/main/__tests__/window-open-remote-instance.test.ts`
+- `apps/desktop/src/main/__tests__/app-server-ipc.test.ts`
+- `apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx`
+- `apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx`
+
+**Approach:** Add a remote window creation path that injects a target instance context into preload/renderer bootstrap. Renderer hooks pass the target context through existing IPC calls without importing non-shared packages. The shell should visibly brand the remote instance/profile in chrome and thread headers, using existing titlebar/sidebar token patterns from `apps/desktop/src/renderer/src/styles/app.css`.
+
+**Patterns to follow:** `apps/desktop/src/main/window-open-new-thread.ts` and `apps/desktop/src/main/window-show-thread.ts` for window routing; `apps/desktop/src/main/window.ts` for BrowserWindow hardening; existing renderer hooks for navigation and transcript state.
+
+**Test scenarios:**
+
+- Happy path: opening a remote instance window boots with the remote target context and fetches remote navigation.
+- Covers AE2. Happy path: composer submission in a remote window sends `startTurn` to the remote instance.
+- Edge case: if the remote disconnects while the window is open, the UI shows an unavailable state and does not fall back to local threads.
+- Error path: window creation rejects unknown or unauthorized instance ids.
+- Integration: local default windows continue to omit target context and use local IPC paths.
+
+**Verification:** Main-process IPC/window tests cover target propagation; renderer tests cover remote labels, disabled states, and no local fallback.
+
+### U7. Federated Search
+
+**Goal:** Add cross-instance search that fans out to connected authorized peers, merges results, and preserves source identity.
+
+**Requirements:** R13, R15, R17, R18.
+
+**Dependencies:** U1, U5, U6.
+
+**Files:**
+
+- `apps/desktop/src/main/federation/federated-search-service.ts`
+- `apps/desktop/src/main/ipc/app-server.ts`
+- `apps/desktop/src/preload/index.ts`
+- `apps/desktop/src/shared/ipc.ts`
+- `apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx`
+- `apps/desktop/src/renderer/src/lib/useThreadNavigation.ts`
+- `packages/shared/src/contracts/navigation.ts`
+- `apps/desktop/src/main/__tests__/federated-search-service.test.ts`
+- `apps/desktop/src/main/__tests__/app-server-ipc.test.ts`
+- `apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx`
+
+**Approach:** Start with thread finding rather than full transcript content search. Query local navigation/search data and all authorized connected peers in parallel with per-peer deadlines. Merge by relevance and recency, group or badge by source instance, and make partial failure visible without discarding successful peers.
+
+**Patterns to follow:** navigation snapshot hydration in `apps/desktop/src/main/ipc/app-server.ts`; inbox/thread ranking logic in `packages/agent-core/src/domain/inbox.ts`; renderer sidebar search/filter patterns in `apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx`.
+
+**Test scenarios:**
+
+- Covers AE5. Happy path: a query returns local and remote thread hits sorted with stable source labels.
+- Edge case: one slow peer times out while other peers and local results still render.
+- Edge case: duplicate-looking thread titles from different instances remain distinct.
+- Error path: unauthorized peers are skipped and logged without revealing their thread metadata.
+- Integration: selecting a remote search result opens or focuses the correct remote window context.
+
+**Verification:** Search service tests cover fan-out, merge, timeout, authorization, and selection routing.
+
+### U8. Messaging Routing Across Instances
+
+**Goal:** Let gateway-hosted messaging browse, bind, resume, and steer threads that live on child instances while preserving provider-neutral adapter boundaries.
+
+**Requirements:** R14, R15, R18.
+
+**Dependencies:** U1, U5, U7.
+
+**Files:**
+
+- `apps/desktop/src/main/messaging/desktop-backend-bridge.ts`
+- `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- `apps/desktop/src/main/messaging/messaging-bindings-snapshot.ts`
+- `apps/desktop/src/main/state/messaging-store-sqlite.ts`
+- `packages/messaging/interface/src/index.ts`
+- `packages/messaging/interface/src/__tests__/messaging-contract.test.ts`
+- `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+- `apps/desktop/src/main/__tests__/messaging-resume-browser.test.ts`
+- `apps/desktop/src/main/__tests__/messaging-thread-state.test.ts`
+- `apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts`
+
+**Approach:** Extend binding and browse-session records with optional federated target metadata. The controller still produces channel-neutral intents and providers still render opaque callback handles. Remote operations go through the federation-aware backend bridge; status cards and browse results include source instance labels so operators know where a turn will run.
+
+**Patterns to follow:** `docs/messaging-architecture.md` for workflow/provider separation; `docs/messaging-adapter-contract.md` for opaque callback state; `docs/plans/2026-05-02-001-refactor-messaging-live-thread-state-plan.md` for keeping live thread facts out of long-lived messaging bindings.
+
+**Test scenarios:**
+
+- Covers AE4. Happy path: `/resume` browse shows local and remote thread choices with source labels.
+- Happy path: selecting a remote thread creates a binding whose callbacks route to the remote instance.
+- Happy path: steering a bound remote thread sends the turn input to the child instance and delivers remote notifications back to the messaging surface.
+- Edge case: remote binding remains visible but degraded when the child disconnects.
+- Error path: revoked peer or removed remote thread causes callbacks to fail closed with a safe user-facing message.
+- Integration: Telegram/Discord/provider tests do not need provider-specific changes because callback payloads remain opaque handles.
+
+**Verification:** Messaging controller and backend bridge tests prove remote binding lifecycle, callback routing, degraded remote state, and provider-neutral behavior.
+
+### U9. Settings, Diagnostics, and Operator Documentation
+
+**Goal:** Expose federation setup and health in Settings, add diagnostics/audit surfaces, and document the Cloudflare Tunnel + mTLS posture.
+
+**Requirements:** R2, R4, R5, R16, R17.
+
+**Dependencies:** U2, U3, U4, U8.
+
+**Files:**
+
+- `apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx`
+- `apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx`
+- `apps/desktop/src/renderer/src/features/settings/useDesktopSettings.ts`
+- `apps/desktop/src/renderer/src/features/messaging-activity/MessagingActivityScreen.tsx`
+- `apps/desktop/src/renderer/src/styles/app.css`
+- `apps/desktop/src/main/ipc/settings.ts`
+- `docs/federation.md`
+- `docs/config-file-evolution.md`
+- `apps/desktop/src/renderer/src/features/settings/FederationSettings.test.tsx`
+- `apps/desktop/src/main/__tests__/settings-ipc.test.ts`
+- `apps/desktop/src/main/__tests__/messaging-activity-log.test.ts`
+
+**Approach:** Add a Settings section for mode selection, local listen endpoint, public gateway URL, invite generation/import, peer list, revocation, and health. Add operator documentation that distinguishes Cloudflare Tunnel reachability, Cloudflare edge mTLS, Access service tokens as an optional adjunct, and PwrAgent's mandatory app-level peer auth. Keep setup docs in this repo for contributor-facing architecture; operator-site walkthroughs can be added in the separate docs repo later.
+
+**Patterns to follow:** `apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx` for secret-backed connection tests; `apps/desktop/src/renderer/src/features/messaging-activity/MessagingActivityScreen.tsx` for diagnostics; `docs/messaging-platform-integration.md` for Cloudflare/Tailscale deployment posture.
+
+**Test scenarios:**
+
+- Happy path: gateway mode displays endpoint, invite generation, enrolled peers, and active session health.
+- Happy path: child mode accepts an invite payload, stores identity material through the secret store, and shows connection status.
+- Edge case: Cloudflare fields are optional when direct local mode is selected.
+- Error path: revoking a peer updates Settings state and the runtime health surface.
+- Integration: Settings IPC redacts secrets and private keys in snapshots and logs.
+
+**Verification:** Renderer and IPC tests cover settings state, redaction, peer revocation, and health rendering; docs explain the current Cloudflare-supported posture and the in-app auth boundary.
+
+---
+
+## Acceptance Examples
+
+- AE1. Given a gateway with Cloudflare edge mTLS enabled and one enrolled child, when the child connects through the public hostname, then Cloudflare blocks clients without a valid edge certificate and PwrAgent still verifies the enrolled peer identity before accepting the WebSocket session.
+- AE2. Given a local default window and a connected child instance, when the operator opens a remote child window and submits a prompt, then the prompt runs on the child machine and the local default profile remains unchanged.
+- AE3. Given two connected child instances, when child A opens a thread on child B, then the request is relayed through the gateway, authorized against both peer policies, and executed by child B.
+- AE4. Given gateway messaging is configured, when the operator runs a thread browse command from Telegram or Discord, then remote threads appear with source instance labels and selected remote bindings route callbacks to the owning child.
+- AE5. Given one connected peer is slow or disconnected, when the operator runs federated search, then local and healthy-peer results still render with a visible partial-failure indication.
+
+---
+
+## System-Wide Impact
+
+- **Security boundary:** Federation introduces remote control over machine-local coding agents, so auth failures must fail closed and logs must avoid raw tokens, private keys, invite payloads, and peer-provided identifiers beyond safe hashes.
+- **Data model:** Thread identity becomes two-dimensional for remote surfaces: instance id plus backend/thread id. Local storage must avoid pretending remote threads are local overlay rows unless the row is explicitly remote-scoped.
+- **Messaging behavior:** Gateway messaging can now steer work on other machines, which expands the meaning of binding authorization. Existing actor allowlists remain necessary but are not sufficient; remote peer policy must also allow messaging-originated operations.
+- **Renderer posture:** Remote windows need clear chrome and no local fallback. A disconnected remote should be visibly unavailable, not silently replaced with the local inbox.
+- **Operations:** Cloudflare setup is partly outside the app in the first build. Documentation and diagnostics need to make edge policy, app policy, and direct local mode distinct.
+
+---
+
+## Risks and Dependencies
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Cloudflare edge mTLS is mistaken for end-to-end peer identity | Unauthorized local or tunnel-origin traffic could be trusted too much | Keep app-level signed peer handshake mandatory and document Cloudflare as outer admission only |
+| Remote target identity leaks into local-only assumptions | Local UI, messaging bindings, or overlay state could act on the wrong machine | Add `FederatedThreadRef` and target context tests before renderer/messaging integration |
+| Long-lived WebSockets accumulate stale sessions | Remote health and routing become unreliable | Heartbeats, duplicate-session policy, deadlines, and revocation-triggered disconnects in the transport runtime |
+| Messaging provider packages learn federation details | Dependency boundaries and channel-neutral architecture regress | Keep federation in desktop bridge/controller layers and add interface contract tests |
+| Certificate/key recovery UX is rough | Dogfooding setup becomes fragile | Phase enrollment/import/export flows carefully and store secrets through the existing encrypted secret-store path |
+| Desired Cloudflare mTLS policy is unavailable on the operator's current plan | Remote access could be less locked down than expected | Keep in-app peer auth mandatory and document Cloudflare plan validation before relying on edge mTLS as the outer gate |
+
+---
+
+## Documentation and Operational Notes
+
+- `docs/federation.md` should include a Cloudflare Tunnel reference setup, edge mTLS policy guidance, optional Access service token notes, local-only direct mode notes, and a threat-model section.
+- Operator-facing setup walkthroughs for `docs.pwragent.ai` are deferred because that site lives in a separate repository.
+- The app should ship with federation disabled by default.
+- Packaged builds must reject dev-only federation bypass flags if any are introduced, following the existing dev-only env var policy.
+
+---
+
+## Sources and Research
+
+- `docs/messaging-architecture.md` and `docs/messaging-adapter-contract.md` define the existing messaging separation: providers normalize/render platform messages; desktop owns workflow, authorization, persistence, and backend routing.
+- `apps/desktop/src/main/messaging/desktop-backend-bridge.ts` is the closest local pattern for a narrow bridge over `BackendRegistry`.
+- `apps/desktop/src/main/messaging/messaging-runtime.ts` provides lifecycle, health, pairing, and event subscription patterns for a long-running desktop runtime.
+- `apps/desktop/src/main/state/state-db.ts` and `apps/desktop/src/main/state/secret-store-sqlite.ts` show the profile-scoped sqlite plus encrypted secret-store model.
+- `docs/solutions/2026-05-07-codex-permission-mode-state-machine.md` is relevant security guidance: avoid silent fallbacks and make security state structurally deterministic.
+- Cloudflare Tunnel docs: `cloudflared` creates outbound-only connections and can expose local services without a public routable origin IP: https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/
+- Cloudflare WebSocket docs: WebSocket upgrade requests are supported, and WAF/custom rules apply to the initial HTTP 101 request: https://developers.cloudflare.com/network/websockets/
+- Cloudflare mTLS docs: Cloudflare can require client certificates for hostnames and exposes certificate verification at the edge; BYOCA is Enterprise-only, while Cloudflare-managed client certificates are the default path: https://developers.cloudflare.com/ssl/client-certificates/
+- Cloudflare Access mTLS docs: Access can enforce mTLS policies for self-hosted applications and can use `Service Auth` for non-IdP clients: https://developers.cloudflare.com/cloudflare-one/access-controls/service-credentials/mutual-tls-authentication/
+- Cloudflare service token docs: service tokens are an alternative or adjunct for automated systems reaching Access-protected applications, but they are bearer credentials and should not replace pinned peer identity: https://developers.cloudflare.com/cloudflare-one/access-controls/service-credentials/service-tokens/

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -8,6 +8,7 @@ import type {
   AppServerThreadMessagePart,
   AppServerThreadSummary,
   PendingRequestApprovalContext,
+  FederatedThreadRef,
   MessagingBindingTargetKind,
   MessagingDeliveryScope,
   MessagingToolUpdateMode,
@@ -1447,6 +1448,7 @@ export type MessagingBindingRecord = {
   targetKind?: MessagingBindingTargetKind;
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;
+  federatedThread?: FederatedThreadRef;
   authorizedActorIds: string[];
   routingState?: MessagingAdapterState;
   /**

--- a/packages/shared/src/__tests__/isMessagingRuntimeSecret.test.ts
+++ b/packages/shared/src/__tests__/isMessagingRuntimeSecret.test.ts
@@ -29,6 +29,11 @@ describe("isMessagingRuntimeSecret", () => {
     { name: "lineChannelAccessToken", expected: true },
     { name: "lineChannelSecret", expected: true },
     { name: "grokApiKey", expected: false },
+    { name: "federationInstancePrivateKey", expected: false },
+    { name: "federationCloudflareClientCertificate", expected: false },
+    { name: "federationCloudflareClientPrivateKey", expected: false },
+    { name: "federationCloudflareAccessClientId", expected: false },
+    { name: "federationCloudflareAccessClientSecret", expected: false },
   ];
 
   for (const { name, expected } of cases) {

--- a/packages/shared/src/contracts/__tests__/federation.test.ts
+++ b/packages/shared/src/contracts/__tests__/federation.test.ts
@@ -62,7 +62,7 @@ describe("federation contracts", () => {
       id: "req-1",
       kind: "request",
       protocolVersion: FEDERATION_PROTOCOL_VERSION,
-      sourceInstanceId: "child-1",
+      sourceInstanceId: "client-1",
       targetInstanceId: "gateway-1",
       method: "appServer.getNavigationSnapshot",
       createdAt: 1,
@@ -76,7 +76,7 @@ describe("federation contracts", () => {
       protocolVersion: FEDERATION_PROTOCOL_VERSION,
       requestId: request.id,
       sourceInstanceId: "gateway-1",
-      targetInstanceId: "child-1",
+      targetInstanceId: "client-1",
       createdAt: 2,
       result: { ok: true },
     } satisfies FederationProtocolEnvelope;

--- a/packages/shared/src/contracts/__tests__/federation.test.ts
+++ b/packages/shared/src/contracts/__tests__/federation.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import {
+  FEDERATION_PROTOCOL_VERSION,
+  buildFederatedThreadRef,
+  federatedThreadIdentityKey,
+  federationTargetKey,
+  isFederationCapability,
+  isFederationInstanceId,
+  isRemoteFederationTarget,
+  type FederationCapabilitySet,
+  type FederationProtocolEnvelope,
+  type NavigationSnapshot,
+} from "../..";
+
+describe("federation contracts", () => {
+  it("represents local targets without fake peer ids", () => {
+    const ref = buildFederatedThreadRef({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    expect(ref).toEqual({
+      backend: "codex",
+      target: { scope: "local" },
+      threadId: "thread-1",
+    });
+    expect(isRemoteFederationTarget(ref.target)).toBe(false);
+    expect(federationTargetKey(ref.target)).toBe("local");
+  });
+
+  it("represents remote thread refs without losing backend identity", () => {
+    const ref = buildFederatedThreadRef({
+      backend: "acp:gemini",
+      instanceId: "mac-studio_home",
+      threadId: "thread:with:colon",
+    });
+
+    expect(ref.target).toEqual({
+      scope: "remote",
+      instanceId: "mac-studio_home",
+    });
+    expect(ref.backend).toBe("acp:gemini");
+    expect(federationTargetKey(ref.target)).toBe("remote:mac-studio_home");
+    expect(federatedThreadIdentityKey(ref)).toBe(
+      "remote:mac-studio_home:acp%3Agemini:thread:with:colon",
+    );
+  });
+
+  it("validates peer ids and capability names defensively", () => {
+    expect(isFederationInstanceId("home-mac_1")).toBe(true);
+    expect(isFederationInstanceId("ab")).toBe(false);
+    expect(isFederationInstanceId("bad id")).toBe(false);
+    expect(isFederationInstanceId("../bad")).toBe(false);
+    expect(isFederationInstanceId("x".repeat(121))).toBe(false);
+
+    expect(isFederationCapability("remote_window")).toBe(true);
+    expect(isFederationCapability("unknown")).toBe(false);
+  });
+
+  it("keeps protocol envelopes correlated and versioned", () => {
+    const request = {
+      id: "req-1",
+      kind: "request",
+      protocolVersion: FEDERATION_PROTOCOL_VERSION,
+      sourceInstanceId: "child-1",
+      targetInstanceId: "gateway-1",
+      method: "appServer.getNavigationSnapshot",
+      createdAt: 1,
+      deadlineAt: 1001,
+      params: { backend: "all" },
+    } satisfies FederationProtocolEnvelope;
+
+    const response = {
+      id: "res-1",
+      kind: "response",
+      protocolVersion: FEDERATION_PROTOCOL_VERSION,
+      requestId: request.id,
+      sourceInstanceId: "gateway-1",
+      targetInstanceId: "child-1",
+      createdAt: 2,
+      result: { ok: true },
+    } satisfies FederationProtocolEnvelope;
+
+    expect(request.kind).toBe("request");
+    expect(response.requestId).toBe(request.id);
+  });
+
+  it("allows navigation snapshots to carry remote source labels through shared contracts", () => {
+    const capabilities = {
+      capabilities: ["thread_navigation", "remote_window"],
+      protocolVersion: FEDERATION_PROTOCOL_VERSION,
+    } satisfies FederationCapabilitySet;
+    const snapshot = {
+      backend: "all",
+      fetchedAt: 123,
+      federationTarget: {
+        scope: "remote",
+        instanceId: "home-mac",
+      },
+      unchanged: false,
+      threads: [],
+      inboxThreadKeys: [],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+    } satisfies NavigationSnapshot;
+
+    expect(capabilities.capabilities).toContain("remote_window");
+    expect(snapshot.federationTarget?.scope).toBe("remote");
+  });
+});

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -132,6 +132,40 @@ describe("desktop settings contracts", () => {
         editedFilesDock: { value: "above", source: "default" },
         actionRunsDock: { value: "above", source: "default" },
       },
+      federation: {
+        mode: { value: "disabled", source: "default" },
+        listenHost: { value: "127.0.0.1", source: "default" },
+        listenPort: { value: 8765, source: "default" },
+        publicUrl: { value: "", source: "default" },
+        gatewayUrl: { value: "", source: "default" },
+        cloudflareMtlsEnabled: { value: false, source: "default" },
+        cloudflareAccessServiceAuthEnabled: { value: false, source: "default" },
+        instancePrivateKey: {
+          configured: false,
+          source: "unset",
+          writable: true,
+        },
+        cloudflareClientCertificate: {
+          configured: false,
+          source: "unset",
+          writable: true,
+        },
+        cloudflareClientPrivateKey: {
+          configured: false,
+          source: "unset",
+          writable: true,
+        },
+        cloudflareAccessClientId: {
+          configured: false,
+          source: "unset",
+          writable: true,
+        },
+        cloudflareAccessClientSecret: {
+          configured: false,
+          source: "unset",
+          writable: true,
+        },
+      },
       messaging: {
         enabled: {
           value: true,

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -541,6 +541,7 @@ export type SubmitServerRequestResponse = {
 };
 
 export type TrustCodexProjectRequest = {
+  federationTarget?: FederationTarget;
   projectPath: string;
   configPath?: string;
 };

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -28,6 +28,7 @@ import type { FederationTarget } from "./federation";
 
 export type StartThreadRequest = {
   backend: AppServerBackendKind;
+  federationTarget?: FederationTarget;
   /**
    * When present, start the thread with Agent/persona metadata.
    */
@@ -70,6 +71,7 @@ export type ThreadAutoPinFailure = {
 
 export type ForkThreadRequest = {
   backend: AppServerBackendKind;
+  federationTarget?: FederationTarget;
   sourceThreadId: ThreadIdentifier;
   parentThreadId?: ThreadIdentifier;
   executionMode?: ThreadExecutionMode;
@@ -262,6 +264,7 @@ export type CancelQueuedTurnResponse = {
 
 export type StartReviewRequest = {
   backend: AppServerBackendKind;
+  federationTarget?: FederationTarget;
   threadId: ThreadIdentifier;
   target: AppServerReviewTarget;
   delivery?: AppServerReviewDelivery;
@@ -624,6 +627,7 @@ export type ResetDirectoryLaunchpadResponse = {
 
 export type MaterializeDirectoryLaunchpadRequest = {
   directoryKey: string;
+  federationTarget?: FederationTarget;
   launchpad?: NavigationLaunchpadDraft;
   /**
    * When present, materialize the launchpad with Agent/persona metadata.
@@ -667,6 +671,7 @@ export type MaterializeDirectoryLaunchpadResponse = MaterializedDirectoryLaunchp
 
 export type CodexEnvironmentSetupProgressEvent = {
   directoryKey: string;
+  federationTarget?: FederationTarget;
   environmentId: string;
   environmentName: string;
   command: string;
@@ -701,6 +706,7 @@ export type RunCodexEnvironmentActionResponse = {
 
 export type StopCodexEnvironmentActionRequest = {
   backend: AppServerBackendKind;
+  federationTarget?: FederationTarget;
   threadId: ThreadIdentifier;
   runId: string;
   mode: "stop" | "terminate";

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -851,6 +851,7 @@ export type RegisterDirectoryFromDiskResponse =
 
 export type AgentEvent = {
   backend: AppServerBackendKind;
+  federationTarget?: FederationTarget;
   notification: AppServerNotification;
   /**
    * Optional main-process display model for live protocol notifications whose

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -281,6 +281,7 @@ export type StartReviewResponse = {
 
 export type InterruptTurnRequest = {
   backend: AppServerBackendKind;
+  federationTarget?: FederationTarget;
   threadId: ThreadIdentifier;
   turnId: string;
 };
@@ -306,6 +307,7 @@ export type StopSubAgentResponse = {
 
 export type CompactThreadRequest = {
   backend: AppServerBackendKind;
+  federationTarget?: FederationTarget;
   threadId: ThreadIdentifier;
 };
 
@@ -318,6 +320,7 @@ export type CompactThreadResponse = {
 
 export type SteerTurnRequest = {
   backend: AppServerBackendKind;
+  federationTarget?: FederationTarget;
   threadId: ThreadIdentifier;
   input: AppServerTurnInputItem[];
   expectedTurnId: string;
@@ -332,6 +335,7 @@ export type SteerTurnResponse = {
 
 export type SetThreadExecutionModeRequest = {
   backend: AppServerBackendKind;
+  federationTarget?: FederationTarget;
   threadId: ThreadIdentifier;
   executionMode: ThreadExecutionMode;
 };
@@ -344,6 +348,7 @@ export type SetThreadExecutionModeResponse = {
 
 export type QueueThreadExecutionModeRequest = {
   backend: AppServerBackendKind;
+  federationTarget?: FederationTarget;
   threadId: ThreadIdentifier;
   executionMode: ThreadExecutionMode;
 };
@@ -362,6 +367,7 @@ export type QueueThreadExecutionModeResponse = {
 
 export type CancelThreadExecutionModeQueueRequest = {
   backend: AppServerBackendKind;
+  federationTarget?: FederationTarget;
   threadId: ThreadIdentifier;
 };
 
@@ -377,6 +383,7 @@ export type CancelThreadExecutionModeQueueResponse = {
 
 export type SetThreadModelSettingsRequest = {
   backend: AppServerBackendKind;
+  federationTarget?: FederationTarget;
   threadId: ThreadIdentifier;
   model?: string;
   serviceTier?: string;
@@ -462,6 +469,7 @@ export type TurnOffCodexFastEverywhereResponse = {
 
 export type SetAcpSessionRuntimeOptionRequest = {
   backend: AppServerBackendKind;
+  federationTarget?: FederationTarget;
   threadId: ThreadIdentifier;
   source: BackendAcpRuntimeOptionSource;
   optionId: string;
@@ -515,6 +523,7 @@ export type RetainThreadBranchDriftResponse = RetainThreadBranchDriftRequest & {
 
 export type SubmitServerRequestRequest = {
   backend: AppServerBackendKind;
+  federationTarget?: FederationTarget;
   threadId: ThreadIdentifier;
   turnId?: string;
   requestId: string;
@@ -673,6 +682,7 @@ export type CodexEnvironmentSetupProgressEvent = {
 
 export type RunCodexEnvironmentActionRequest = {
   backend: AppServerBackendKind;
+  federationTarget?: FederationTarget;
   threadId: ThreadIdentifier;
   actionId: string;
   /**
@@ -704,6 +714,7 @@ export type StopCodexEnvironmentActionResponse = {
 
 export type SetCodexThreadEnvironmentRequest = {
   backend: AppServerBackendKind;
+  federationTarget?: FederationTarget;
   threadId: ThreadIdentifier;
   environmentId?: string;
   actionId?: string;

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -24,6 +24,7 @@ import type {
   NavigationLaunchpadDraft,
   NavigationLaunchpadDefaults,
 } from "./navigation";
+import type { FederationTarget } from "./federation";
 
 export type StartThreadRequest = {
   backend: AppServerBackendKind;
@@ -228,6 +229,7 @@ export type StartThreadMigrationResponse = {
 
 export type StartTurnRequest = {
   backend: AppServerBackendKind;
+  federationTarget?: FederationTarget;
   threadId: ThreadIdentifier;
   input: AppServerTurnInputItem[];
   executionMode?: ThreadExecutionMode;

--- a/packages/shared/src/contracts/backend.ts
+++ b/packages/shared/src/contracts/backend.ts
@@ -1,4 +1,5 @@
 import type { AppServerBackendKind, ThreadExecutionMode } from "./normalized-app-server";
+import type { FederationTarget } from "./federation";
 
 export type BackendSourceKind = "builtin" | "acp";
 
@@ -230,6 +231,7 @@ export type ListBackendsRequest = {
    * refreshes one provider; `true` refreshes every provider.
    */
   refreshModels?: true | AppServerBackendKind;
+  federationTarget?: FederationTarget;
 };
 
 export type ListBackendsResponse = {

--- a/packages/shared/src/contracts/federation.ts
+++ b/packages/shared/src/contracts/federation.ts
@@ -21,7 +21,7 @@ export const FEDERATION_CAPABILITIES = [
 
 export type FederationCapability = (typeof FEDERATION_CAPABILITIES)[number];
 
-export type FederationInstanceRole = "gateway" | "child" | "dual";
+export type FederationInstanceRole = "gateway" | "client" | "dual";
 
 export type FederationConnectionState =
   | "disabled"

--- a/packages/shared/src/contracts/federation.ts
+++ b/packages/shared/src/contracts/federation.ts
@@ -92,6 +92,18 @@ export type FederationHealthStatus = {
   peers: FederationPeerSummary[];
 };
 
+export type OpenFederationWindowRequest = {
+  target: FederationRemoteTarget;
+  label?: string;
+  initialThread?: FederatedThreadRef;
+};
+
+export type OpenFederationWindowResponse = {
+  opened: boolean;
+  windowId?: number;
+  target: FederationRemoteTarget;
+};
+
 export type FederationEnvelopeBase = {
   id: FederationRequestId;
   protocolVersion: number;

--- a/packages/shared/src/contracts/federation.ts
+++ b/packages/shared/src/contracts/federation.ts
@@ -93,6 +93,12 @@ export type FederationHealthStatus = {
   peers: FederationPeerSummary[];
 };
 
+export type ReadFederationHealthRequest = Record<string, never>;
+
+export type ReadFederationHealthResponse = {
+  health: FederationHealthStatus;
+};
+
 export type OpenFederationWindowRequest = {
   target: FederationRemoteTarget;
   label?: string;

--- a/packages/shared/src/contracts/federation.ts
+++ b/packages/shared/src/contracts/federation.ts
@@ -99,6 +99,26 @@ export type ReadFederationHealthResponse = {
   health: FederationHealthStatus;
 };
 
+export type GenerateFederationInviteRequest = {
+  label?: string;
+  ttlMs?: number;
+};
+
+export type GenerateFederationInviteResponse = {
+  invite: string;
+  expiresAt: number;
+};
+
+export type ImportFederationInviteRequest = {
+  invite: string;
+};
+
+export type ImportFederationInviteResponse = {
+  accepted: boolean;
+  gatewayInstanceId: FederationInstanceId;
+  gatewayUrl: string;
+};
+
 export type OpenFederationWindowRequest = {
   target: FederationRemoteTarget;
   label?: string;

--- a/packages/shared/src/contracts/federation.ts
+++ b/packages/shared/src/contracts/federation.ts
@@ -1,0 +1,195 @@
+import type {
+  AppServerBackendKind,
+  AppServerBackendScope,
+  ThreadIdentifier,
+} from "./normalized-app-server";
+
+export const FEDERATION_PROTOCOL_VERSION = 1;
+
+export const FEDERATION_CAPABILITIES = [
+  "remote_window",
+  "thread_navigation",
+  "thread_detail",
+  "turn_control",
+  "pending_request_control",
+  "environment_actions",
+  "federated_search",
+  "messaging_route",
+  "gateway_relay",
+] as const;
+
+export type FederationCapability = (typeof FEDERATION_CAPABILITIES)[number];
+
+export type FederationInstanceRole = "gateway" | "child" | "dual";
+
+export type FederationConnectionState =
+  | "disabled"
+  | "listening"
+  | "connecting"
+  | "handshaking"
+  | "connected"
+  | "degraded"
+  | "rejected"
+  | "revoked"
+  | "disconnected";
+
+export type FederationInstanceId = string;
+export type FederationPeerId = FederationInstanceId;
+export type FederationRequestId = string;
+export type FederationSessionId = string;
+
+export type FederationLocalTarget = {
+  scope: "local";
+};
+
+export type FederationRemoteTarget = {
+  instanceId: FederationInstanceId;
+  scope: "remote";
+};
+
+export type FederationTarget =
+  | FederationLocalTarget
+  | FederationRemoteTarget;
+
+export type FederatedThreadRef = {
+  backend: AppServerBackendKind;
+  target: FederationTarget;
+  threadId: ThreadIdentifier;
+};
+
+export type FederatedBackendScope = {
+  backend: AppServerBackendScope;
+  target: FederationTarget;
+};
+
+export type FederationCapabilitySet = {
+  protocolVersion: number;
+  capabilities: FederationCapability[];
+};
+
+export type FederationPeerSummary = {
+  id: FederationPeerId;
+  label: string;
+  role: FederationInstanceRole;
+  status: FederationConnectionState;
+  capabilities: FederationCapability[];
+  protocolVersion?: number;
+  endpoint?: string;
+  profileName?: string;
+  lastConnectedAt?: number;
+  lastActivityAt?: number;
+  revokedAt?: number;
+  unavailableReason?: string;
+};
+
+export type FederationHealthStatus = {
+  enabled: boolean;
+  role: FederationInstanceRole;
+  status: FederationConnectionState;
+  instanceId?: FederationInstanceId;
+  listenUrl?: string;
+  publicUrl?: string;
+  peers: FederationPeerSummary[];
+};
+
+export type FederationEnvelopeBase = {
+  id: FederationRequestId;
+  protocolVersion: number;
+  sourceInstanceId: FederationInstanceId;
+  targetInstanceId?: FederationInstanceId;
+  createdAt: number;
+  deadlineAt?: number;
+  hopCount?: number;
+};
+
+export type FederationRequestEnvelope<Method extends string = string, Params = unknown> =
+  FederationEnvelopeBase & {
+    kind: "request";
+    method: Method;
+    params: Params;
+  };
+
+export type FederationResponseEnvelope<Result = unknown> = FederationEnvelopeBase & {
+  kind: "response";
+  requestId: FederationRequestId;
+  result: Result;
+};
+
+export type FederationErrorEnvelope = FederationEnvelopeBase & {
+  kind: "error";
+  requestId?: FederationRequestId;
+  error: {
+    code: string;
+    message: string;
+    retryable?: boolean;
+  };
+};
+
+export type FederationNotificationEnvelope<
+  Method extends string = string,
+  Params = unknown,
+> = FederationEnvelopeBase & {
+  kind: "notification";
+  method: Method;
+  params: Params;
+};
+
+export type FederationProtocolEnvelope =
+  | FederationRequestEnvelope
+  | FederationResponseEnvelope
+  | FederationErrorEnvelope
+  | FederationNotificationEnvelope;
+
+export function isFederationCapability(
+  value: unknown,
+): value is FederationCapability {
+  return (
+    typeof value === "string" &&
+    (FEDERATION_CAPABILITIES as readonly string[]).includes(value)
+  );
+}
+
+export function isFederationInstanceId(value: unknown): value is FederationInstanceId {
+  if (typeof value !== "string") return false;
+  if (value.length < 3 || value.length > 120) return false;
+  for (const ch of value) {
+    const code = ch.charCodeAt(0);
+    const isDigit = code >= 48 && code <= 57;
+    const isUpper = code >= 65 && code <= 90;
+    const isLower = code >= 97 && code <= 122;
+    if (!isDigit && !isUpper && !isLower && ch !== "-" && ch !== "_") {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function buildFederatedThreadRef(params: {
+  backend: AppServerBackendKind;
+  instanceId?: FederationInstanceId;
+  threadId: ThreadIdentifier;
+}): FederatedThreadRef {
+  return {
+    backend: params.backend,
+    target: params.instanceId
+      ? { scope: "remote", instanceId: params.instanceId }
+      : { scope: "local" },
+    threadId: params.threadId,
+  };
+}
+
+export function isRemoteFederationTarget(
+  target: FederationTarget,
+): target is FederationRemoteTarget {
+  return target.scope === "remote";
+}
+
+export function federationTargetKey(target: FederationTarget): string {
+  return isRemoteFederationTarget(target) ? `remote:${target.instanceId}` : "local";
+}
+
+export function federatedThreadIdentityKey(ref: FederatedThreadRef): string {
+  return `${federationTargetKey(ref.target)}:${encodeURIComponent(
+    ref.backend,
+  )}:${ref.threadId}`;
+}

--- a/packages/shared/src/contracts/federation.ts
+++ b/packages/shared/src/contracts/federation.ts
@@ -1,6 +1,7 @@
 import type {
   AppServerBackendKind,
   AppServerBackendScope,
+  AppServerThreadSummary,
   ThreadIdentifier,
 } from "./normalized-app-server";
 
@@ -102,6 +103,32 @@ export type OpenFederationWindowResponse = {
   opened: boolean;
   windowId?: number;
   target: FederationRemoteTarget;
+};
+
+export type FederatedSearchRequest = {
+  query: string;
+  limit?: number;
+};
+
+export type FederatedSearchResult = {
+  ref: FederatedThreadRef;
+  thread: AppServerThreadSummary;
+  instanceLabel: string;
+  peerStatus?: FederationPeerSummary["status"];
+  score: number;
+};
+
+export type FederatedSearchPeerFailure = {
+  instanceId: FederationInstanceId;
+  instanceLabel: string;
+  error: string;
+};
+
+export type FederatedSearchResponse = {
+  query: string;
+  searchedAt: number;
+  results: FederatedSearchResult[];
+  failures: FederatedSearchPeerFailure[];
 };
 
 export type FederationEnvelopeBase = {

--- a/packages/shared/src/contracts/federation.ts
+++ b/packages/shared/src/contracts/federation.ts
@@ -90,6 +90,7 @@ export type FederationHealthStatus = {
   instanceId?: FederationInstanceId;
   listenUrl?: string;
   publicUrl?: string;
+  unavailableReason?: string;
   peers: FederationPeerSummary[];
 };
 
@@ -97,6 +98,41 @@ export type ReadFederationHealthRequest = Record<string, never>;
 
 export type ReadFederationHealthResponse = {
   health: FederationHealthStatus;
+};
+
+export type FederationDiagnosticEventKind =
+  | "connect_attempt"
+  | "connected"
+  | "rejected"
+  | "disconnected"
+  | "relay"
+  | "error";
+
+export type FederationDiagnosticEvent = {
+  eventId: number;
+  peerId?: FederationPeerId;
+  sessionId?: FederationSessionId;
+  kind: FederationDiagnosticEventKind;
+  createdAt: number;
+  detail?: string;
+};
+
+export type ReadFederationDiagnosticsRequest = {
+  limit?: number;
+  peerId?: FederationPeerId;
+};
+
+export type ReadFederationDiagnosticsResponse = {
+  health: FederationHealthStatus;
+  events: FederationDiagnosticEvent[];
+};
+
+export type RevokeFederationPeerRequest = {
+  peerId: FederationPeerId;
+};
+
+export type RevokeFederationPeerResponse = {
+  peer: FederationPeerSummary;
 };
 
 export type GenerateFederationInviteRequest = {
@@ -134,6 +170,7 @@ export type OpenFederationWindowResponse = {
 export type FederatedSearchRequest = {
   query: string;
   limit?: number;
+  backend?: AppServerBackendScope;
 };
 
 export type FederatedSearchResult = {

--- a/packages/shared/src/contracts/federation.ts
+++ b/packages/shared/src/contracts/federation.ts
@@ -74,6 +74,7 @@ export type FederationPeerSummary = {
   role: FederationInstanceRole;
   status: FederationConnectionState;
   capabilities: FederationCapability[];
+  canRevoke?: boolean;
   protocolVersion?: number;
   endpoint?: string;
   profileName?: string;

--- a/packages/shared/src/contracts/messaging.ts
+++ b/packages/shared/src/contracts/messaging.ts
@@ -8,6 +8,7 @@ import type {
   AppServerBackendKind,
   ThreadIdentifier,
 } from "./normalized-app-server";
+import type { FederatedThreadRef } from "./federation";
 
 export const MESSAGING_TOOL_UPDATE_MODES = [
   "show_none",
@@ -212,6 +213,8 @@ export type MessagingActivityEntry = {
   kind: MessagingActivityKind;
   /** Backend the entry routed to / from, if known. */
   backend?: AppServerBackendKind;
+  /** Remote thread target for federation-routed messaging activity. */
+  federatedThread?: FederatedThreadRef;
   threadId?: ThreadIdentifier;
   bindingId?: string;
   conversationId?: string;

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -26,6 +26,11 @@ import type { DesktopGhDiscoverySnapshot } from "./settings";
 import type { BackendAcpSessionRuntimeState } from "./backend";
 import type { AutomationThreadSummary } from "./automations";
 import type {
+  FederatedThreadRef,
+  FederationPeerSummary,
+  FederationTarget,
+} from "./federation";
+import type {
   TaskMonitorCompletionSource,
   TaskMonitorUsageSnapshot,
 } from "./task-monitor-tools";
@@ -60,6 +65,12 @@ export type NavigationLaunchpadAgent = Pick<
 >;
 
 export type NavigationThreadSummary = AppServerThreadSummary & {
+  /** Present when this row describes a thread owned by another PwrAgent instance. */
+  federation?: {
+    ref: FederatedThreadRef;
+    instanceLabel: string;
+    peerStatus?: FederationPeerSummary["status"];
+  };
   inbox: ThreadInboxState;
   /**
    * Normalized host/owner/repository identity resolved from the thread's
@@ -933,6 +944,8 @@ export function parseThreadIdentityKey(
 export type NavigationSnapshot = {
   backend: AppServerBackendScope;
   fetchedAt: number;
+  /** Source instance for this snapshot. Omitted for the local default instance. */
+  federationTarget?: FederationTarget;
   unchanged: boolean;
   threads: NavigationThreadSummary[];
   inboxThreadKeys: string[];
@@ -942,6 +955,7 @@ export type NavigationSnapshot = {
 
 export type GetNavigationSnapshotRequest = {
   backend?: AppServerBackendScope;
+  federationTarget?: FederationTarget;
   filter?: string;
   forceRefresh?: boolean;
   refreshMode?: "active-recent" | "full";

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -801,6 +801,7 @@ export type RestoreWorktreeResponse = {
 
 export type RenameThreadRequest = {
   backend: AppServerBackendKind;
+  federationTarget?: FederationTarget;
   threadId: ThreadIdentifier;
   name: string;
 };

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -678,6 +678,7 @@ export type ArchiveThreadCleanupResult = {
 export type ArchiveThreadRequest = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;
+  federationTarget?: FederationTarget;
 };
 
 export type ArchiveThreadResponse = {

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -750,6 +750,7 @@ export type ThreadWorkspaceHandoffStashSummary = {
 
 export type HandoffThreadWorkspaceRequest = {
   backend: AppServerBackendKind;
+  federationTarget?: FederationTarget;
   threadId: ThreadIdentifier;
   direction: ThreadWorkspaceHandoffDirection;
   strategy?: ThreadWorkspaceHandoffStrategy;

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -3,6 +3,7 @@ import type {
   MessagingChannelKind,
   MessagingConversationKind,
 } from "./messaging";
+import type { FederationTarget } from "./federation";
 import type {
   PrSummary,
   ThreadPrAutoDispatchEventKind,
@@ -654,6 +655,7 @@ export type AppServerThreadReplay = {
 export type AppServerListThreadsRequest = {
   backend?: AppServerBackendKind;
   archived?: boolean;
+  federationTarget?: FederationTarget;
   filter?: string;
 };
 
@@ -810,6 +812,7 @@ export type RenameThreadResponse = {
 
 export type AppServerReadThreadRequest = {
   backend?: AppServerBackendKind;
+  federationTarget?: FederationTarget;
   threadId: ThreadIdentifier;
   includeTurns?: boolean;
   before?: string;
@@ -941,6 +944,7 @@ export type AppServerListSkillsRequest = {
   backend?: AppServerBackendKind;
   cwd?: string;
   cwds?: string[];
+  federationTarget?: FederationTarget;
   threadId?: ThreadIdentifier;
 };
 

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -87,7 +87,11 @@ export type DesktopCodexProfileModel =
 export const DESKTOP_CODEX_PROFILE_MODEL_DEFAULT: DesktopCodexProfileModel =
   "shared";
 
-export const DESKTOP_HOT_CPU_PROFILE_START_DELAYS_MS = [0, 5_000, 10_000] as const;
+export const DESKTOP_HOT_CPU_PROFILE_START_DELAYS_MS = [
+  0,
+  5_000,
+  10_000,
+] as const;
 export type DesktopHotCpuProfileStartDelayMs =
   (typeof DESKTOP_HOT_CPU_PROFILE_START_DELAYS_MS)[number];
 export const DESKTOP_HOT_CPU_PROFILE_START_DELAY_DEFAULT_MS: DesktopHotCpuProfileStartDelayMs =
@@ -103,6 +107,18 @@ export type DesktopHotCpuProfileTriggerMode =
 export const DESKTOP_HOT_CPU_PROFILE_TRIGGER_MODE_DEFAULT: DesktopHotCpuProfileTriggerMode =
   "sustained";
 export const DESKTOP_HOT_CPU_PROFILE_SLOWBURN_THRESHOLD_DEFAULT_PERCENT = 15;
+
+export const DESKTOP_FEDERATION_MODES = [
+  "disabled",
+  "gateway",
+  "client",
+  "dual",
+] as const;
+
+export type DesktopFederationMode = (typeof DESKTOP_FEDERATION_MODES)[number];
+
+export const DESKTOP_FEDERATION_MODE_DEFAULT: DesktopFederationMode =
+  "disabled";
 
 /**
  * Persisted record that the operator acknowledged the messaging-safety
@@ -253,7 +269,12 @@ export type DesktopSettingsSecretName =
   | "feishuEncryptKey"
   | "feishuVerificationToken"
   | "lineChannelAccessToken"
-  | "lineChannelSecret";
+  | "lineChannelSecret"
+  | "federationInstancePrivateKey"
+  | "federationCloudflareClientCertificate"
+  | "federationCloudflareClientPrivateKey"
+  | "federationCloudflareAccessClientId"
+  | "federationCloudflareAccessClientSecret";
 
 /**
  * Predicate: does writing or clearing this secret affect the
@@ -288,6 +309,11 @@ export function isMessagingRuntimeSecret(
     case "lineChannelSecret":
       return true;
     case "grokApiKey":
+    case "federationInstancePrivateKey":
+    case "federationCloudflareClientCertificate":
+    case "federationCloudflareClientPrivateKey":
+    case "federationCloudflareAccessClientId":
+    case "federationCloudflareAccessClientSecret":
       return false;
   }
 }
@@ -506,6 +532,21 @@ export type DesktopApplicationsSnapshot = {
   };
 };
 
+export type DesktopFederationSettingsSnapshot = {
+  mode: DesktopSettingsValue<DesktopFederationMode>;
+  listenHost: DesktopSettingsValue<string>;
+  listenPort: DesktopSettingsValue<number>;
+  publicUrl: DesktopSettingsValue<string>;
+  gatewayUrl: DesktopSettingsValue<string>;
+  cloudflareMtlsEnabled: DesktopSettingsValue<boolean>;
+  cloudflareAccessServiceAuthEnabled: DesktopSettingsValue<boolean>;
+  instancePrivateKey: DesktopSettingsSecretState;
+  cloudflareClientCertificate: DesktopSettingsSecretState;
+  cloudflareClientPrivateKey: DesktopSettingsSecretState;
+  cloudflareAccessClientId: DesktopSettingsSecretState;
+  cloudflareAccessClientSecret: DesktopSettingsSecretState;
+};
+
 export type DesktopSettingsSnapshot = {
   fetchedAt: number;
   configPath: string;
@@ -635,6 +676,7 @@ export type DesktopSettingsSnapshot = {
     editedFilesDock: DesktopSettingsValue<string>;
     actionRunsDock: DesktopSettingsValue<string>;
   };
+  federation: DesktopFederationSettingsSnapshot;
   messaging: {
     enabled: DesktopSettingsValue<boolean>;
     allowFullAccessEscalation: DesktopSettingsValue<boolean>;
@@ -882,6 +924,15 @@ export type DesktopSettingsConfigPatch = {
     activeContextTab?: string;
     editedFilesDock?: string;
     actionRunsDock?: string;
+  };
+  federation?: {
+    mode?: DesktopFederationMode;
+    listenHost?: string;
+    listenPort?: number;
+    publicUrl?: string;
+    gatewayUrl?: string;
+    cloudflareMtlsEnabled?: boolean;
+    cloudflareAccessServiceAuthEnabled?: boolean;
   };
   messaging?: {
     enabled?: boolean;
@@ -1474,6 +1525,12 @@ export function isDesktopHotCpuProfileTriggerMode(
   return DESKTOP_HOT_CPU_PROFILE_TRIGGER_MODES.includes(
     value as DesktopHotCpuProfileTriggerMode,
   );
+}
+
+export function isDesktopFederationMode(
+  value: string,
+): value is DesktopFederationMode {
+  return DESKTOP_FEDERATION_MODES.includes(value as DesktopFederationMode);
 }
 
 /**

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -1,4 +1,5 @@
 import type { MessagingToolUpdateMode } from "./messaging";
+import type { FederationTarget } from "./federation";
 
 export const DESKTOP_CHAT_REPLY_COMPOSERS = [
   "tiptap-wysiwyg-markdown-chips",
@@ -1385,6 +1386,7 @@ export type SetDesktopPwrAgentProfileCodexProfileResponse = {
 
 export type OpenDesktopApplicationRequest = {
   applicationId: string;
+  federationTarget?: FederationTarget;
   kind: DesktopApplicationKind;
   targetPath: string;
   targetLine?: number;

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -1397,6 +1397,14 @@ export type OpenDesktopApplicationResponse = {
   opened: true;
 };
 
+export type ReadDesktopApplicationsRequest = {
+  federationTarget?: FederationTarget;
+};
+
+export type ReadDesktopApplicationsResponse = {
+  applications: DesktopApplicationsSnapshot;
+};
+
 /**
  * Open a filesystem path with the OS default handler (`shell.openPath`). The
  * fallback for "open this edited file" when no editor application is

--- a/packages/shared/src/contracts/thread-search.ts
+++ b/packages/shared/src/contracts/thread-search.ts
@@ -5,6 +5,10 @@ import type {
   LinkedDirectorySummary,
   ThreadIdentifier,
 } from "./normalized-app-server";
+import type {
+  FederatedThreadRef,
+  FederationPeerSummary,
+} from "./federation";
 
 export const DEFAULT_THREAD_SEARCH_LIMIT = 20;
 export const MAX_THREAD_SEARCH_LIMIT = 100;
@@ -142,6 +146,11 @@ export type ThreadSearchResult = {
   confidence: ThreadSearchConfidenceBand;
   matchReasons: ThreadSearchMatchReason[];
   snippets: ThreadSearchSnippet[];
+  federation?: {
+    ref: FederatedThreadRef;
+    instanceLabel: string;
+    peerStatus?: FederationPeerSummary["status"];
+  };
 };
 
 export type ThreadSearchResponse = {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -14,6 +14,7 @@ export * from "./contracts/thread-orchestration-tools";
 export * from "./contracts/branch-drift";
 export * from "./contracts/composer-drafts";
 export * from "./contracts/diff-focus";
+export * from "./contracts/federation";
 export * from "./contracts/messaging";
 export * from "./contracts/messaging-tools";
 export * from "./contracts/navigation";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,9 @@ importers:
       remark-math:
         specifier: ^6.0.0
         version: 6.0.0
+      ws:
+        specifier: 8.21.0
+        version: 8.21.0
     devDependencies:
       '@axe-core/playwright':
         specifier: ^4.11.3
@@ -211,6 +214,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
+      '@types/ws':
+        specifier: 8.18.1
+        version: 8.18.1
       '@vitejs/plugin-react':
         specifier: ^5.2.0
         version: 5.2.0(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.1))


### PR DESCRIPTION
## Summary

Completes the U1-U9 instance-federation workflow: gateway and client instances can enroll over the authenticated WebSocket transport, discover every connected federation member, open branded remote windows, operate remote threads with live events, search across instances, and route messaging bindings to remote threads through the gateway relay.

## What changed

- Completes the federation backend surface for navigation, thread creation/fork/review, turn start/steer/interrupt/compact, pending requests and approvals, model/runtime/execution settings, skills, environment selection/actions with setup progress, and workspace handoff.
- Relays client-to-client RPC, backend events, and environment progress through the gateway with capability checks, deadlines, loop prevention, reconnect backoff, duplicate-session replacement, and active revocation.
- Adds federation-aware thread search with source identity, remote-window selection, partial-failure reporting, and no local fallback.
- Routes messaging browse/resume/bind/status/turn controls/settings/approvals to remote owners while keeping callback payloads provider-neutral and remote thread identities collision-safe.
- Expands Settings with Cloudflare Access service-token and mTLS credentials, peer health, unavailable reasons, audit diagnostics, revocation, and connected-only remote-window actions.
- Brands remote windows and thread chrome with the authoritative instance label.
- Adds `docs/federation.md` with local dogfood, Cloudflare Tunnel, Access, mTLS, credential, diagnostics, revocation, and threat-model guidance.

## Test locally

Build the desktop app, then launch isolated gateway and client profiles:

```bash
pnpm --filter @pwragent/desktop build
PWRAGENT_PROFILE=gateway pnpm --filter @pwragent/desktop preview
PWRAGENT_PROFILE=client pnpm --filter @pwragent/desktop preview
```

Use Settings -> Federation on the gateway to generate an invite, import it on the client, then use the connected peer list to open either instance. Detailed direct-local and Cloudflare setup is in `docs/federation.md`.

Cloudflare provisioning remains an operator-managed deployment step; PwrAgent stores and applies the configured Access/mTLS credentials but does not create tunnels or Access policies.

## Validation

- `pnpm test` (388 files, 4,874 tests)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; repository warning baseline remains)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `pnpm lint:colors`
- `pnpm lint:sql`
- `pnpm licenses:check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)