### PR TITLE
fix(desktop): toggle the context rail on ⌘⌥B (macOS Option-compose)

### DIFF
--- a/apps/desktop/src/renderer/src/features/chrome/PanelToggleButtons.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/PanelToggleButtons.tsx
@@ -1,6 +1,7 @@
 import { useEffect, type ReactElement } from "react";
 import {
   formatPrimaryAccel,
+  isAccelLetter,
   isEditableTarget,
   isPrimaryAccel,
 } from "../../lib/keyboard-accel";
@@ -50,7 +51,10 @@ export function PanelToggleButtons({
       if (!isPrimaryAccel(event)) {
         return;
       }
-      if (event.key !== "b" && event.key !== "B") {
+      // Match the physical "B" via event.code, NOT event.key: on macOS the
+      // Option modifier composes event.key into "∫", so ⌘⌥B (toggle rail)
+      // would never match a literal "b"/"B" check. See isAccelLetter.
+      if (!isAccelLetter(event, "b")) {
         return;
       }
       event.preventDefault();

--- a/apps/desktop/src/renderer/src/lib/__tests__/keyboard-accel.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/keyboard-accel.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { formatPrimaryAccel } from "../keyboard-accel";
+import { formatPrimaryAccel, isAccelLetter } from "../keyboard-accel";
 
 type PwrWindow = Window & { pwragent?: { platform?: string } };
 
@@ -39,5 +39,34 @@ describe("formatPrimaryAccel", () => {
     setPlatform(undefined);
     expect(formatPrimaryAccel("B")).toBe("Ctrl+B");
     expect(formatPrimaryAccel("B", { alt: true })).toBe("Ctrl+Alt+B");
+  });
+});
+
+describe("isAccelLetter", () => {
+  const keydown = (init: KeyboardEventInit): KeyboardEvent =>
+    new KeyboardEvent("keydown", init);
+
+  it("matches the physical key when Option composes a glyph (⌘⌥B → key '∫')", () => {
+    // The regression: macOS rewrites event.key to "∫" while Option is held,
+    // so the old `event.key === "b"` check never fired for ⌘⌥B (toggle rail).
+    expect(
+      isAccelLetter(keydown({ code: "KeyB", key: "∫", altKey: true }), "b"),
+    ).toBe(true);
+  });
+
+  it("matches a plain letter when code is absent (defensive fallback)", () => {
+    expect(isAccelLetter(keydown({ code: "", key: "b" }), "b")).toBe(true);
+    expect(isAccelLetter(keydown({ code: "", key: "B" }), "b")).toBe(true);
+  });
+
+  it("matches ⌘B (no Option) via either code or key", () => {
+    expect(isAccelLetter(keydown({ code: "KeyB", key: "b" }), "b")).toBe(true);
+  });
+
+  it("rejects other keys, including other Option-composed glyphs", () => {
+    expect(isAccelLetter(keydown({ code: "KeyA", key: "a" }), "b")).toBe(false);
+    expect(
+      isAccelLetter(keydown({ code: "KeyV", key: "√", altKey: true }), "b"),
+    ).toBe(false);
   });
 });

--- a/apps/desktop/src/renderer/src/lib/keyboard-accel.ts
+++ b/apps/desktop/src/renderer/src/lib/keyboard-accel.ts
@@ -27,6 +27,25 @@ export function isEditableTarget(event: KeyboardEvent): boolean {
 }
 
 /**
+ * Whether `event` targets the given single letter, robust to the macOS
+ * Option-compose quirk. Holding Option (Alt) on macOS rewrites `event.key`
+ * into the composed character it would type (⌥B → "∫", ⌥V → "√", …), so any
+ * chord that includes Alt can NEVER be matched against `event.key` — which is
+ * why ⌘⌥B silently did nothing while ⌘B worked. Match the physical key via
+ * `event.code` ("Key" + the uppercased letter) instead, which is independent
+ * of modifiers and layout-composition; fall back to `event.key` for the rare
+ * environment that doesn't populate `code`.
+ */
+export function isAccelLetter(event: KeyboardEvent, letter: string): boolean {
+  const upper = letter.toUpperCase();
+  return (
+    event.code === `Key${upper}` ||
+    event.key === upper ||
+    event.key === upper.toLowerCase()
+  );
+}
+
+/**
  * Render the display label for a primary-accelerator chord, adjusted for
  * the current platform: ⌘/⌥ glyphs on macOS, "Ctrl"/"Alt" words joined
  * with "+" on Windows/Linux. This is presentation only — {@link


### PR DESCRIPTION
## Summary

⌘⌥B (toggle the right context rail) did nothing on macOS, while ⌘B (toggle the left sidebar) worked. The window-layout chord handler in `PanelToggleButtons` gated on `event.key`, but **macOS rewrites `event.key` into the character Option would type while Option is held** — ⌥B composes to `"∫"`. So the literal `event.key !== "b" && event.key !== "B"` check was always true for ⌘⌥B and the handler bailed before reaching the `event.altKey` → `onToggleRail()` branch. ⌘B was unaffected because its `event.key` really is `"b"`.

## Fix

Match the **physical** key via `event.code === "KeyB"` (modifier- and composition-independent) instead of `event.key`, through a new `isAccelLetter(event, "b")` helper in `keyboard-accel.ts`. The helper keeps an `event.key` fallback for environments that don't populate `code`. ⌘B / ⌃B / ⌃⌥B behavior is unchanged.

## Verification

- New unit tests feed the **exact composed event macOS delivers** for ⌘⌥B (`code: "KeyB"`, `key: "∫"`, `altKey: true`) and assert the helper matches, plus the no-Option, code-absent, and reject-other-keys cases. `keyboard-accel` suite: 8/8 ✓.
- `pnpm --filter @pwragent/desktop typecheck` ✓
- `pnpm lint:boundaries` ✓ (renderer still imports only `@pwragent/shared`)

## Notes

- There is a **separate, pre-existing** issue on Windows: `AppTitleBar` (win32-only) and the thread header both mount `PanelToggleButtons`, so two window-level keydown listeners are active and any layout chord double-toggles to a net no-op. `AppTitleBar` returns `null` off win32, so macOS has exactly one listener and is unaffected. Not addressed here — flagged for a follow-up (the unused `disableHotkeys` prop was the intended guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)