### PR TITLE
fix(desktop): bind layout chords once at the shell (Windows double-toggle)

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -16,6 +16,7 @@ import type {
 } from "@pwragent/shared";
 import { Sidebar } from "./features/navigation/Sidebar";
 import { AppTitleBar } from "./features/chrome/AppTitleBar";
+import { useLayoutChordHotkeys } from "./features/chrome/useLayoutChordHotkeys";
 import type { SettingsSection } from "./features/settings/SettingsScreen";
 import {
   useDesktopSettings,
@@ -250,6 +251,14 @@ function DesktopAppShell(props: {
     },
     [writeConfig],
   );
+
+  // Single owner of the window-layout keyboard chords (⌘B/⌃B sidebar,
+  // ⌘⌥B/⌃⌥B rail). Bound once here — never per PanelToggleButtons chip — so
+  // it fires exactly once regardless of how many chips are mounted.
+  useLayoutChordHotkeys({
+    onToggleSidebar: () => setSidebarHiddenPersisted(!sidebarHidden),
+    onToggleRail: () => setContextRailPinnedPersisted(!contextRailPinned),
+  });
   const setActiveContextTabPersisted = useCallback(
     (tab: ContextTabId) => {
       setActiveContextTab(tab);

--- a/apps/desktop/src/renderer/src/features/chrome/PanelToggleButtons.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/PanelToggleButtons.tsx
@@ -1,10 +1,5 @@
-import { useEffect, type ReactElement } from "react";
-import {
-  formatPrimaryAccel,
-  isAccelLetter,
-  isEditableTarget,
-  isPrimaryAccel,
-} from "../../lib/keyboard-accel";
+import { type ReactElement } from "react";
+import { formatPrimaryAccel } from "../../lib/keyboard-accel";
 
 /**
  * Window layout chips — show/hide the left sidebar (primary) and the
@@ -15,10 +10,12 @@ import {
  * accent color; when closed only the outline remains. Same idea Apple /
  * VS Code use for their side-bar chips.
  *
- * Presentational: the parent owns the open/hidden state + persistence;
- * these buttons paint the state and dispatch callbacks.
- *
- * Keyboard: ⌘B / ⌃B toggles the sidebar, ⌘⌥B / ⌃⌥B toggles the rail.
+ * Purely presentational: the parent owns the open/hidden state + persistence;
+ * these buttons paint the state, show the chord in their tooltip, and dispatch
+ * click callbacks. The keyboard chords themselves (⌘B / ⌃B sidebar, ⌘⌥B / ⌃⌥B
+ * rail) are bound ONCE at the shell via `useLayoutChordHotkeys` — never here,
+ * so multiple mounted chips (Windows title bar + thread header) can't each bind
+ * a listener and double-toggle to a no-op.
  */
 export type PanelToggleButtonsProps = {
   /** Whether the left sidebar is currently shown. */
@@ -28,8 +25,6 @@ export type PanelToggleButtonsProps = {
   onToggleSidebar: () => void;
   onToggleRail: () => void;
   className?: string;
-  /** Skip the window-level keydown listener (when a parent owns chords). */
-  disableHotkeys?: boolean;
 };
 
 export function PanelToggleButtons({
@@ -38,38 +33,7 @@ export function PanelToggleButtons({
   onToggleSidebar,
   onToggleRail,
   className,
-  disableHotkeys = false,
 }: PanelToggleButtonsProps): ReactElement {
-  useEffect(() => {
-    if (disableHotkeys) {
-      return;
-    }
-    const handler = (event: KeyboardEvent): void => {
-      if (isEditableTarget(event)) {
-        return;
-      }
-      if (!isPrimaryAccel(event)) {
-        return;
-      }
-      // Match the physical "B" via event.code, NOT event.key: on macOS the
-      // Option modifier composes event.key into "∫", so ⌘⌥B (toggle rail)
-      // would never match a literal "b"/"B" check. See isAccelLetter.
-      if (!isAccelLetter(event, "b")) {
-        return;
-      }
-      event.preventDefault();
-      if (event.altKey) {
-        onToggleRail();
-      } else {
-        onToggleSidebar();
-      }
-    };
-    window.addEventListener("keydown", handler);
-    return () => {
-      window.removeEventListener("keydown", handler);
-    };
-  }, [disableHotkeys, onToggleSidebar, onToggleRail]);
-
   return (
     <div
       className={`panel-toggle${className ? ` ${className}` : ""}`}

--- a/apps/desktop/src/renderer/src/features/chrome/useLayoutChordHotkeys.ts
+++ b/apps/desktop/src/renderer/src/features/chrome/useLayoutChordHotkeys.ts
@@ -1,0 +1,45 @@
+import { useEffect, useRef } from "react";
+import { matchLayoutChord } from "../../lib/keyboard-accel";
+
+/**
+ * Binds the single window-level listener for the layout chords
+ * (⌘B / ⌃B → sidebar, ⌘⌥B / ⌃⌥B → rail). Call this exactly ONCE, from the
+ * always-mounted shell owner — NOT from each `PanelToggleButtons` chip.
+ *
+ * Multiple chips can be mounted at the same time (on Windows the custom title
+ * bar AND the thread header both render them), and binding one listener per
+ * chip double-toggled the state to a visible no-op. Hoisting the chord to a
+ * single owner also makes it work app-wide, regardless of how many chips —
+ * or none — are currently on screen.
+ *
+ * A ref holds the latest handlers so the listener binds once and never goes
+ * stale, even though the toggle callbacks close over fresh state each render.
+ */
+export function useLayoutChordHotkeys(handlers: {
+  onToggleSidebar: () => void;
+  onToggleRail: () => void;
+}): void {
+  const handlersRef = useRef(handlers);
+  useEffect(() => {
+    handlersRef.current = handlers;
+  });
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent): void => {
+      const chord = matchLayoutChord(event);
+      if (chord === null) {
+        return;
+      }
+      event.preventDefault();
+      if (chord === "rail") {
+        handlersRef.current.onToggleRail();
+      } else {
+        handlersRef.current.onToggleSidebar();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => {
+      window.removeEventListener("keydown", handler);
+    };
+  }, []);
+}

--- a/apps/desktop/src/renderer/src/lib/__tests__/keyboard-accel.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/keyboard-accel.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { formatPrimaryAccel, isAccelLetter } from "../keyboard-accel";
+import {
+  formatPrimaryAccel,
+  isAccelLetter,
+  matchLayoutChord,
+} from "../keyboard-accel";
 
 type PwrWindow = Window & { pwragent?: { platform?: string } };
 
@@ -68,5 +72,54 @@ describe("isAccelLetter", () => {
     expect(
       isAccelLetter(keydown({ code: "KeyV", key: "√", altKey: true }), "b"),
     ).toBe(false);
+  });
+});
+
+describe("matchLayoutChord", () => {
+  const keydown = (init: KeyboardEventInit): KeyboardEvent =>
+    new KeyboardEvent("keydown", init);
+
+  it("classifies ⌘B / ⌃B as the sidebar chord", () => {
+    expect(
+      matchLayoutChord(keydown({ metaKey: true, code: "KeyB", key: "b" })),
+    ).toBe("sidebar");
+    expect(
+      matchLayoutChord(keydown({ ctrlKey: true, code: "KeyB", key: "b" })),
+    ).toBe("sidebar");
+  });
+
+  it("classifies ⌘⌥B as the rail chord even when Option composes the key", () => {
+    // macOS delivers key "∫" while Option is held — the chord must still match.
+    expect(
+      matchLayoutChord(
+        keydown({ metaKey: true, altKey: true, code: "KeyB", key: "∫" }),
+      ),
+    ).toBe("rail");
+    expect(
+      matchLayoutChord(
+        keydown({ ctrlKey: true, altKey: true, code: "KeyB", key: "b" }),
+      ),
+    ).toBe("rail");
+  });
+
+  it("returns null without the primary modifier or for other keys", () => {
+    expect(matchLayoutChord(keydown({ code: "KeyB", key: "b" }))).toBe(null);
+    // Both Cmd and Ctrl held → not a single primary accelerator.
+    expect(
+      matchLayoutChord(
+        keydown({ metaKey: true, ctrlKey: true, code: "KeyB", key: "b" }),
+      ),
+    ).toBe(null);
+    expect(
+      matchLayoutChord(keydown({ metaKey: true, code: "KeyA", key: "a" })),
+    ).toBe(null);
+  });
+
+  it("returns null while typing in an editable field", () => {
+    const event = keydown({ metaKey: true, code: "KeyB", key: "b" });
+    Object.defineProperty(event, "target", {
+      value: document.createElement("input"),
+    });
+    expect(matchLayoutChord(event)).toBe(null);
   });
 });

--- a/apps/desktop/src/renderer/src/lib/keyboard-accel.ts
+++ b/apps/desktop/src/renderer/src/lib/keyboard-accel.ts
@@ -46,6 +46,34 @@ export function isAccelLetter(event: KeyboardEvent, letter: string): boolean {
 }
 
 /**
+ * Classify a keydown as one of the two window-layout chords, or `null`:
+ *   ⌘B / ⌃B   → "sidebar" (toggle the left sidebar)
+ *   ⌘⌥B / ⌃⌥B → "rail"    (toggle the right context rail)
+ * Returns `null` while typing in a field, without the primary modifier, or
+ * for any other key.
+ *
+ * Pure + side-effect-free so a SINGLE owner can wire one window listener to it
+ * (see `useLayoutChordHotkeys`). Previously each `PanelToggleButtons` instance
+ * bound its own listener; on Windows the title bar and the thread header both
+ * render the chips, so two listeners fired and the chord toggled twice — a
+ * visible no-op.
+ */
+export function matchLayoutChord(
+  event: KeyboardEvent,
+): "sidebar" | "rail" | null {
+  if (isEditableTarget(event)) {
+    return null;
+  }
+  if (!isPrimaryAccel(event)) {
+    return null;
+  }
+  if (!isAccelLetter(event, "b")) {
+    return null;
+  }
+  return event.altKey ? "rail" : "sidebar";
+}
+
+/**
  * Render the display label for a primary-accelerator chord, adjusted for
  * the current platform: ⌘/⌥ glyphs on macOS, "Ctrl"/"Alt" words joined
  * with "+" on Windows/Linux. This is presentation only — {@link


### PR DESCRIPTION
## Summary

The window-layout keyboard chords — ⌘B/⌃B (toggle sidebar) and ⌘⌥B/⌃⌥B (toggle context rail) — **double-fire on Windows**, producing a net no-op. Every mounted `PanelToggleButtons` attaches its own window `keydown` listener; on Windows the custom title bar (`AppTitleBar`, win32-only) **and** the thread header both render the chips, so two listeners fire and the chord toggles the state twice. macOS is unaffected (`AppTitleBar` returns `null` off win32 → a single listener).

## Fix

Hoist the chord to a single owner:

- **`PanelToggleButtons` is now purely presentational** — its keydown `useEffect` and the never-wired `disableHotkeys` prop are removed. It only paints state, shows the chord in its tooltip, and dispatches click callbacks.
- **New `useLayoutChordHotkeys` hook**, called **once** in `DesktopAppShell` (always mounted), binds the only window listener. A ref keeps the latest toggle handlers so it binds once without going stale.
- **New pure `matchLayoutChord(event)`** classifier in `keyboard-accel.ts` (`"sidebar" | "rail" | null`) holds the actual logic, so it's unit-testable without React or a window listener. It reuses `isEditableTarget`, `isPrimaryAccel`, and `isAccelLetter`.

The chord now fires exactly once regardless of how many chips are mounted, and works app-wide rather than only where a header is rendered. The `isEditableTarget` guard still suppresses it while typing in the composer.

## Verification

- `keyboard-accel` unit tests: 12/12 ✓ — new `matchLayoutChord` cases cover ⌘B/⌃B → sidebar, ⌘⌥B → rail (including the macOS Option-compose event `key: "∫"`), the no-modifier / both-modifier / other-key null cases, and the editable-target guard.
- `ThreadHeader` component test ✓ (still renders the now-presentational chips).
- `pnpm --filter @pwragent/desktop typecheck` ✓
- `pnpm lint:boundaries` ✓ (renderer still imports only `@pwragent/shared`)

## Note

Builds on the `isAccelLetter` helper from #736 (macOS Option-compose: match the physical key via `event.code`, not `event.key`). #736 is now merged, so this branch is rebased onto `main` and targets it directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)