### PR TITLE
fix(desktop): respect branch selection for child worktrees

### DIFF
--- a/apps/desktop/src/main/__tests__/git-directory-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-directory-service.test.ts
@@ -310,6 +310,57 @@ describe("GitDirectoryService", () => {
     expect(branchesAfter).toEqual(branchesBefore);
   });
 
+  it("uses the default branch when a detached launchpad passes HEAD", async () => {
+    const repoDir = await createFixtureRepo();
+    cleanupPaths.push(repoDir);
+    const mainRevision = runGit(repoDir, ["rev-parse", "main"]);
+    runGit(repoDir, ["checkout", "release"]);
+    execFileSync(
+      "git",
+      ["-C", repoDir, "commit", "--allow-empty", "-m", "Release branch"],
+      { stdio: "ignore" },
+    );
+    const releaseRevision = runGit(repoDir, ["rev-parse", "release"]);
+    runGit(repoDir, ["checkout", "-B", "feature-with-pr"]);
+    execFileSync(
+      "git",
+      ["-C", repoDir, "commit", "--allow-empty", "-m", "Feature PR branch"],
+      { stdio: "ignore" },
+    );
+    const featureRevision = runGit(repoDir, ["rev-parse", "HEAD"]);
+    const sourceWorktree = path.join(
+      await mkdtemp(path.join(os.tmpdir(), "pwragent-source-detached-worktree-")),
+      "fixture",
+    );
+    cleanupPaths.push(path.dirname(sourceWorktree));
+    runGit(repoDir, ["worktree", "add", "--detach", sourceWorktree, releaseRevision]);
+    const service = new GitDirectoryService({
+      resolveWorktreeStorage: () => "in-repo",
+    });
+
+    const workspace = await service.prepareLaunchpadWorkspace({
+      directoryKind: "directory",
+      directoryLabel: "FixtureRepo",
+      directoryPath: sourceWorktree,
+      workMode: "worktree",
+      branchName: "HEAD",
+    });
+
+    expect(workspace.workMode).toBe("worktree");
+    const repoRealPath = await realpath(repoDir);
+    await expect(realpath(workspace.repositoryPath!)).resolves.toBe(repoRealPath);
+    expect(workspace.cwd).toBeDefined();
+    expect(
+      toForwardSlashes(workspace.cwd!).startsWith(
+        `${toForwardSlashes(path.join(repoRealPath, ".worktrees"))}/`,
+      ),
+    ).toBe(true);
+    expect(runGit(workspace.cwd!, ["rev-parse", "--abbrev-ref", "HEAD"])).toBe("HEAD");
+    expect(runGit(workspace.cwd!, ["rev-parse", "HEAD"])).toBe(mainRevision);
+    expect(runGit(workspace.cwd!, ["rev-parse", "HEAD"])).not.toBe(releaseRevision);
+    expect(runGit(workspace.cwd!, ["rev-parse", "HEAD"])).not.toBe(featureRevision);
+  });
+
   it("creates an attached branch worktree and reuses it for the same branch", async () => {
     const repoDir = await createFixtureRepo();
     cleanupPaths.push(repoDir);

--- a/apps/desktop/src/main/__tests__/pr-detection.test.ts
+++ b/apps/desktop/src/main/__tests__/pr-detection.test.ts
@@ -18,27 +18,12 @@ afterEach(async () => {
 });
 
 describe("detectPullRequestsForThread", () => {
-  it("uses local feature branches pointing at detached HEAD", async () => {
+  it("does not use local feature branches pointing at detached HEAD", async () => {
     const repo = await createDetachedRepoWithFeatureBranchAtHead(
       "fix/messaging-nonblocking-startup",
     );
-    const fetchedBranches: string[] = [];
     const fetcher = {
-      fetchAllPullRequestsForBranch: vi.fn(async ({ branch }) => {
-        fetchedBranches.push(branch);
-        if (branch !== "fix/messaging-nonblocking-startup") {
-          return [];
-        }
-        return [
-          {
-            number: 271,
-            org: "pwrdrvr",
-            repo: "PwrAgent",
-            state: "passing",
-            url: `https://github.com/pwrdrvr/PwrAgent/pull/${branch}`,
-          },
-        ];
-      }),
+      fetchAllPullRequestsForBranch: vi.fn(async () => []),
     } as unknown as GithubPrFetcher;
 
     const prs = await detectPullRequestsForThread({
@@ -47,10 +32,8 @@ describe("detectPullRequestsForThread", () => {
       directoryPaths: [repo],
     });
 
-    expect(fetchedBranches).toEqual(
-      expect.arrayContaining(["fix/messaging-nonblocking-startup"]),
-    );
-    expect(prs).toHaveLength(1);
+    expect(prs).toEqual([]);
+    expect(fetcher.fetchAllPullRequestsForBranch).not.toHaveBeenCalled();
   });
 
   it("does not use detached HEAD at the default branch tip for PR lookup", async () => {
@@ -148,27 +131,12 @@ describe("detectPullRequestsForThread", () => {
     expect(fetcher.fetchAllPullRequestsForBranch).not.toHaveBeenCalled();
   });
 
-  it("preserves feature branch lookup when fallback default candidates are not at HEAD", async () => {
+  it("does not infer PR lookup branches for detached HEAD even when feature branches point at it", async () => {
     const repo = await createDetachedRepoWithDevelopAndFeatureAtHead(
       "fix/detached-feature-pr",
     );
-    const fetchedBranches: string[] = [];
     const fetcher = {
-      fetchAllPullRequestsForBranch: vi.fn(async ({ branch }) => {
-        fetchedBranches.push(branch);
-        if (branch !== "fix/detached-feature-pr") {
-          return [];
-        }
-        return [
-          {
-            number: 393,
-            org: "pwrdrvr",
-            repo: "PwrAgent",
-            state: "passing",
-            url: "https://github.com/pwrdrvr/PwrAgent/pull/393",
-          },
-        ];
-      }),
+      fetchAllPullRequestsForBranch: vi.fn(async () => []),
     } as unknown as GithubPrFetcher;
 
     const prs = await detectPullRequestsForThread({
@@ -177,11 +145,8 @@ describe("detectPullRequestsForThread", () => {
       directoryPaths: [repo],
     });
 
-    expect(fetchedBranches).toEqual(
-      expect.arrayContaining(["develop", "fix/detached-feature-pr"]),
-    );
-    expect(fetchedBranches).not.toEqual(["develop"]);
-    expect(prs).toHaveLength(1);
+    expect(prs).toEqual([]);
+    expect(fetcher.fetchAllPullRequestsForBranch).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts
@@ -225,6 +225,67 @@ describe("RendererHotCpuProfiler", () => {
     );
   });
 
+  it("waits for an in-flight duration profile stop before stopping the monitor", async () => {
+    const workspace = await createTemporaryTestDirectory();
+    cleanups.push(workspace.cleanup);
+
+    const config = createEnabledConfig(workspace.path);
+    const sessionResult = await createHotCpuProfileSession({
+      config,
+      createdAt: new Date(2026, 5, 1, 15, 30, 0),
+      sessionId: "abc123",
+      versions: {
+        appVersion: "1.0.0",
+        electronVersion: "41.2.1",
+        chromeVersion: "146.0.0.0",
+        nodeVersion: "24.0.0",
+      },
+    });
+    expect(sessionResult.ok).toBe(true);
+    if (!sessionResult.ok) return;
+
+    const { target } = createTarget();
+    const profileWritten = deferred();
+    const onProfileWritten = vi.fn(async () => {
+      await profileWritten.promise;
+    });
+    let nowCallCount = 0;
+    const metrics = [
+      createMetric(0, 100),
+      createMetric(4, 101.5),
+      createMetric(4, 103),
+    ];
+    const profiler = new RendererHotCpuProfiler({
+      config,
+      getAppMetrics: () => [metrics.shift() ?? createMetric(0)],
+      session: sessionResult.session,
+      target,
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+      now: () => new Date(1_780_000_000_000 + nowCallCount++ * 2_000),
+      onProfileWritten,
+    });
+
+    await profiler.start();
+    await vi.waitFor(() => {
+      expect(onProfileWritten).toHaveBeenCalledTimes(1);
+    });
+
+    let stopResolved = false;
+    const stopPromise = profiler.stop("test-complete").then(() => {
+      stopResolved = true;
+    });
+    await Promise.resolve();
+    expect(stopResolved).toBe(false);
+
+    profileWritten.resolve();
+    await stopPromise;
+    expect(stopResolved).toBe(true);
+  });
+
   it("waits for the configured delay before sampling", async () => {
     const workspace = await createTemporaryTestDirectory();
     cleanups.push(workspace.cleanup);

--- a/apps/desktop/src/main/app-server/git-directory-service.ts
+++ b/apps/desktop/src/main/app-server/git-directory-service.ts
@@ -253,6 +253,16 @@ function parseGitWorktreeEntries(output: string): WorktreeEntry[] {
   return entries;
 }
 
+async function readPrimaryWorktreePath(
+  cwd: string,
+  runGit: GitCommandRunner,
+  env?: NodeJS.ProcessEnv,
+): Promise<string | undefined> {
+  const worktreeList = await runGit(cwd, ["worktree", "list", "--porcelain"], env)
+    .catch(() => "");
+  return parseGitWorktreeEntries(worktreeList)[0]?.path;
+}
+
 function parseGitLines(output: string): string[] {
   return output
     .split("\n")
@@ -324,13 +334,14 @@ function isProtectedBranch(branch?: string): boolean {
 
 async function resolveVerifiedWorktreeBaseBranch(params: {
   repoRoot: string;
+  sourceRoot?: string;
   requestedBranch?: string;
   gitEnv?: NodeJS.ProcessEnv;
   runGit?: GitCommandRunner;
 }): Promise<string | undefined> {
   const runGit = params.runGit ?? defaultRunGit;
   const requestedBranch = sanitizeBranchName(params.requestedBranch ?? "");
-  if (requestedBranch) {
+  if (requestedBranch && requestedBranch !== "HEAD") {
     const commit = await runGit(
       params.repoRoot,
       ["rev-parse", "--verify", `${requestedBranch}^{commit}`],
@@ -339,8 +350,9 @@ async function resolveVerifiedWorktreeBaseBranch(params: {
     return commit ? requestedBranch : undefined;
   }
 
-  const [currentBranch, branchesOutput, remoteHead] = await Promise.all([
-    runGit(params.repoRoot, ["rev-parse", "--abbrev-ref", "HEAD"], params.gitEnv).catch(
+  const sourceRoot = params.sourceRoot ?? params.repoRoot;
+  const [rawCurrentBranch, branchesOutput, remoteHead] = await Promise.all([
+    runGit(sourceRoot, ["rev-parse", "--abbrev-ref", "HEAD"], params.gitEnv).catch(
       () => "",
     ),
     runGit(
@@ -359,6 +371,7 @@ async function resolveVerifiedWorktreeBaseBranch(params: {
       params.gitEnv,
     ).catch(() => ""),
   ]);
+  const currentBranch = rawCurrentBranch.trim() === "HEAD" ? "" : rawCurrentBranch;
   const branches = parseGitLines(branchesOutput);
   const defaultBranch = resolveDefaultBranch({ branches, remoteHead });
   const candidates = uniqueBranches([
@@ -569,7 +582,7 @@ export class GitDirectoryService {
       return undefined;
     }
 
-    const [currentBranch, branchesOutput, remoteHead, worktreeList] =
+    const [rawCurrentBranch, branchesOutput, remoteHead, worktreeList] =
       await Promise.all([
         runGit(repoRoot, ["rev-parse", "--abbrev-ref", "HEAD"], gitEnv).catch(
           () => "",
@@ -593,6 +606,8 @@ export class GitDirectoryService {
           () => "",
         ),
       ]);
+    const currentBranch =
+      rawCurrentBranch.trim() === "HEAD" ? "" : rawCurrentBranch.trim();
     const upstreamBranch = await runGit(
       repoRoot,
       [
@@ -715,23 +730,27 @@ export class GitDirectoryService {
       };
     }
 
-    const repoRoot = await readGitRoot(
+    const sourceRoot = await readGitRoot(
       directoryPath,
       this.runGitCommand,
       this.gitEnv,
     );
-    if (!repoRoot) {
+    if (!sourceRoot) {
       return {
         cwd: directoryPath,
         workMode: "local",
       };
     }
+    const repoRoot =
+      (await readPrimaryWorktreePath(sourceRoot, this.runGitCommand, this.gitEnv))
+      ?? sourceRoot;
 
     const baseBranch = await resolveVerifiedWorktreeBaseBranch({
       gitEnv: this.gitEnv,
       repoRoot,
       requestedBranch: launchpad.branchName,
       runGit: this.runGitCommand,
+      sourceRoot,
     });
     if (!baseBranch) {
       return {

--- a/apps/desktop/src/main/diagnostics/renderer-hot-cpu-profiler.ts
+++ b/apps/desktop/src/main/diagnostics/renderer-hot-cpu-profiler.ts
@@ -85,6 +85,7 @@ export class RendererHotCpuProfiler {
   private previousSampleAtMs: number | null = null;
   private profileDurationTimer: ReturnType<typeof setTimeout> | null = null;
   private profileCount = 0;
+  private stopProfilePromise: Promise<void> | null = null;
   private profiling = false;
   private activeProfileTrigger: ActiveProfileTrigger | null = null;
   private stopped = false;
@@ -153,7 +154,7 @@ export class RendererHotCpuProfiler {
     this.clearProfileDurationTimer();
     this.clearHeapSnapshotMidTimer();
 
-    if (this.profiling) {
+    if (this.profiling || this.stopProfilePromise) {
       await this.stopProfile(reason);
     }
 
@@ -404,10 +405,24 @@ export class RendererHotCpuProfiler {
   }
 
   private async stopProfile(reason: string): Promise<void> {
+    if (this.stopProfilePromise) {
+      await this.stopProfilePromise;
+      return;
+    }
+
     if (!this.profiling) {
       return;
     }
 
+    this.stopProfilePromise = this.stopProfileInner(reason);
+    try {
+      await this.stopProfilePromise;
+    } finally {
+      this.stopProfilePromise = null;
+    }
+  }
+
+  private async stopProfileInner(reason: string): Promise<void> {
     this.profiling = false;
     this.clearProfileDurationTimer();
     this.clearHeapSnapshotMidTimer();

--- a/apps/desktop/src/main/pr-status/pr-detection.ts
+++ b/apps/desktop/src/main/pr-status/pr-detection.ts
@@ -12,11 +12,6 @@ const FALLBACK_DEFAULT_BRANCHES = [
   "trunk",
 ] as const;
 
-type LocalBranchAtHead = {
-  name: string;
-  upstream?: string;
-};
-
 type DefaultBranchInfo = {
   names: Set<string>;
   upstreams: Set<string>;
@@ -83,68 +78,7 @@ async function resolvePrLookupBranches(params: {
     return defaultBranchInfo.names.has(params.branch) ? [] : [params.branch];
   }
 
-  const branchesAtHead = await readLocalBranchesPointingAtHead(params.cwd);
-  if (branchesAtHead.some((branch) => isDefaultBranch(branch, defaultBranchInfo))) {
-    return [];
-  }
-
-  return uniqueNonEmpty(
-    branchesAtHead
-      .filter((branch) => branch.name !== "HEAD")
-      .map((branch) => branch.name),
-  );
-}
-
-function isDefaultBranch(
-  branch: LocalBranchAtHead,
-  defaultBranchInfo: DefaultBranchInfo,
-): boolean {
-  return (
-    defaultBranchInfo.names.has(branch.name) ||
-    Boolean(branch.upstream && defaultBranchInfo.upstreams.has(branch.upstream))
-  );
-}
-
-async function readLocalBranchesPointingAtHead(
-  cwd: string,
-): Promise<LocalBranchAtHead[]> {
-  try {
-    return await readBranchesPointingAtHead(cwd);
-  } catch {
-    return [];
-  }
-}
-
-async function readBranchesPointingAtHead(
-  cwd: string,
-): Promise<LocalBranchAtHead[]> {
-  const { stdout } = await execFileAsync(
-    "git",
-    [
-      "for-each-ref",
-      "--points-at",
-      "HEAD",
-      "--format=%(refname:short)%09%(upstream:short)",
-      "refs/heads",
-    ],
-    {
-      cwd,
-      maxBuffer: 64 * 1024,
-      timeout: GIT_BRANCH_LOOKUP_TIMEOUT_MS,
-    },
-  );
-  return stdout
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .map((line) => {
-      const [name = "", upstream = ""] = line.split("\t");
-      return {
-        name: name.trim(),
-        upstream: upstream.trim() || undefined,
-      };
-    })
-    .filter((branch) => branch.name);
+  return [];
 }
 
 async function readDefaultBranchInfo(cwd: string): Promise<DefaultBranchInfo> {

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -5748,8 +5748,9 @@ export function Composer(props: ComposerProps) {
               disabled={launchpadSubmitting}
               kind="branch"
               value={
-                props.launchpad.branchName ??
-                props.directory?.gitStatus?.currentBranch ??
+                normalizeSelectableLaunchpadBranch(props.launchpad.branchName) ??
+                normalizeSelectableLaunchpadBranch(props.directory?.gitStatus?.currentBranch) ??
+                props.directory?.gitStatus?.defaultBranch ??
                 ""
               }
               options={launchpadBranchOptions.map((branch) => ({
@@ -6555,16 +6556,25 @@ function buildLaunchpadBranchOptions(
   const candidates = [
     launchpad.branchName,
     directory?.gitStatus?.currentBranch,
+    directory?.gitStatus?.defaultBranch,
     ...(directory?.gitStatus?.branches ?? []),
   ];
   const options = new Set<string>();
   for (const candidate of candidates) {
-    const value = candidate?.trim();
+    const value = normalizeSelectableLaunchpadBranch(candidate);
     if (value) {
       options.add(value);
     }
   }
   return [...options];
+}
+
+function normalizeSelectableLaunchpadBranch(branch?: string): string | undefined {
+  const value = branch?.trim();
+  if (!value || value.toUpperCase() === "HEAD") {
+    return undefined;
+  }
+  return value;
 }
 
 function formatThreadWorkspaceLabel(thread?: NavigationThreadSummary): string | undefined {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -6130,6 +6130,47 @@ describe("Composer", () => {
     ).toHaveAttribute("aria-selected", "true");
   });
 
+  it("defaults detached new-worktree launchpads to the repository default branch", () => {
+    render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        directory={{
+          key: "subthread:codex:thread-parent:new-worktree",
+          kind: "directory",
+          label: "PwrAgent",
+          path: "/Users/huntharo/.codex/worktrees/mq8mwn78/PwrAgnt",
+          threadKeys: [],
+          needsAttentionCount: 0,
+          gitStatus: {
+            defaultBranch: "main",
+            branches: ["fix/layout-chord-single-owner", "main", "release"],
+            syncState: "untracked",
+          },
+        }}
+        launchpad={{
+          directoryKey: "subthread:codex:thread-parent:new-worktree",
+          directoryKind: "directory",
+          directoryLabel: "PwrAgent",
+          directoryPath: "/Users/huntharo/.codex/worktrees/mq8mwn78/PwrAgnt",
+          backend: "codex",
+          executionMode: "default",
+          prompt: "",
+          workMode: "worktree",
+          branchName: "HEAD",
+          parentThreadId: "thread-parent",
+          parentThreadTitle: "Renderer hot CPU profile",
+          createdAt: 1,
+          updatedAt: 1,
+        }}
+        skills={[]}
+      />
+    );
+
+    expect(screen.getByLabelText("Base branch")).toHaveValue("main");
+    fireEvent.click(screen.getByLabelText("Base branch"));
+    expect(screen.queryByRole("option", { name: "HEAD" })).not.toBeInTheDocument();
+  });
+
   it("shows handoff to local for existing worktree threads", async () => {
     const onHandoffThreadWorkspace = vi.fn(async () => undefined);
     const openApplication = vi.fn(async () => ({ opened: true as const }));

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -3387,7 +3387,7 @@ describe("useThreadNavigation", () => {
       executionMode: "default",
       directoryKind: "directory",
       directoryLabel: "app",
-      directoryPath: "/repo/app",
+      directoryPath: "/repo/app/.worktrees/parent/app",
       branchName: "feature/parent",
       workMode: "worktree",
       model: "gpt-5.5",
@@ -3413,6 +3413,85 @@ describe("useThreadNavigation", () => {
     expect(result.current.selectedThread?.messagingBindings).toBeUndefined();
     expect(result.current.selectedThread?.prs).toBeUndefined();
     expect(result.current.selectedThread?.reactions).toBeUndefined();
+  });
+
+  it("forks detached worktree parents from the parent worktree path", async () => {
+    const parentThread = {
+      id: "thread-parent",
+      title: "Detached parent",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      executionMode: "default" as const,
+      observedGitBranch: "HEAD",
+      linkedDirectories: [
+        {
+          id: "/repo/app/.worktrees/parent/app",
+          label: "app",
+          path: "/repo/app",
+          worktreePath: "/repo/app/.worktrees/parent/app",
+          kind: "worktree" as const,
+        },
+      ],
+      inbox: {
+        inInbox: true,
+        reason: "new-thread" as const,
+      },
+      createdAt: 1_000,
+      updatedAt: 2_000,
+    };
+    const forkThread = vi.fn(async () => ({
+      backend: "codex" as const,
+      sourceThreadId: "thread-parent",
+      threadId: "thread-fork",
+      executionMode: "default" as const,
+      workMode: "worktree" as const,
+      linkedDirectory: {
+        id: "/repo/app/.worktrees/thread-fork/app",
+        label: "app",
+        path: "/repo/app",
+        worktreePath: "/repo/app/.worktrees/thread-fork/app",
+        kind: "worktree" as const,
+      },
+    }));
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: ["codex:thread-parent"],
+      threads: [parentThread],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const desktopApi: DesktopApi = {
+      forkThread,
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.id).toBe("thread-parent");
+    });
+
+    await act(async () => {
+      await result.current.forkThread(parentThread, "new-worktree");
+    });
+
+    expect(forkThread).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        branchName: expect.any(String),
+      }),
+    );
+    expect(forkThread).toHaveBeenCalledWith(
+      expect.objectContaining({
+        directoryPath: "/repo/app/.worktrees/parent/app",
+        workMode: "worktree",
+      }),
+    );
   });
 
   it("opens local sub-thread launchpads against the parent's local checkout", async () => {
@@ -3627,7 +3706,7 @@ describe("useThreadNavigation", () => {
       directoryKey: "subthread:codex:thread-parent:new-worktree",
       patch: expect.objectContaining({
         workMode: "worktree",
-        directoryPath: "/repo/app",
+        directoryPath: "/repo/app/.worktrees/parent/app",
         branchName: "feature/parent",
         parentThreadId: "thread-parent",
       }),

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -112,11 +112,18 @@ function selectThreadWorkspace(
   const worktree = thread.linkedDirectories.find((directory) => directory.kind === "worktree");
   const local = thread.linkedDirectories.find((directory) => directory.kind === "local");
   const preferred = worktree ?? local;
+  const namedBranch =
+    thread.observedGitBranch && thread.observedGitBranch !== "HEAD"
+      ? thread.observedGitBranch
+      : thread.gitBranch && thread.gitBranch !== "HEAD"
+        ? thread.gitBranch
+        : undefined;
 
   if (mode === "new-worktree") {
-    const repository = preferred?.path ?? thread.projectKey;
+    const repository =
+      worktree?.worktreePath ?? worktree?.path ?? local?.path ?? thread.projectKey;
     return {
-      branchName: thread.observedGitBranch ?? thread.gitBranch,
+      branchName: namedBranch,
       directoryKind: repository ? "directory" : "workspace",
       directoryLabel: preferred?.label ?? thread.title,
       directoryPath: repository,
@@ -136,9 +143,7 @@ function selectThreadWorkspace(
         : preferred?.label ?? thread.title,
     directoryPath: sameWorkspacePath,
     workMode: "local",
-    ...(mode === "same-worktree"
-      ? { branchName: thread.observedGitBranch ?? thread.gitBranch }
-      : {}),
+    ...(mode === "same-worktree" && namedBranch ? { branchName: namedBranch } : {}),
   };
 }
 


### PR DESCRIPTION
## Summary

- I fixed new-worktree sub-threads so detached parents do not carry `HEAD` forward as if it were a selectable branch.
- I made the branch chooser fall back to the repository default branch for detached launchpads, while still honoring any named branch the operator selects.
- I stopped PR chips from inferring a pull request for detached `HEAD` just because some local branch points at the same commit.
- I also fixed a hot CPU profiler stop race that the Windows CI run exposed, so `stop()` waits for an in-flight duration-triggered profile write callback.

## Verification

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx`
- `pnpm test apps/desktop/src/main/__tests__/git-directory-service.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/pr-detection.test.ts`
- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
- `pnpm test apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/pr-detection.test.ts apps/desktop/src/main/__tests__/git-directory-service.test.ts apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
- `pnpm test apps/desktop/src/main/__tests__/pr-detection.test.ts apps/desktop/src/main/__tests__/git-directory-service.test.ts apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
- `pnpm lint:boundaries`

## Notes

- I verified the original bad chip came from detached `HEAD` PR detection resolving to the existing `fix/layout-chord-single-owner` branch, which GitHub maps to pwrdrvr/PwrAgent#737.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5.5](https://img.shields.io/badge/GPT--5.5-000000)
