### PR TITLE
fix(desktop): reduce transcript DOM weight

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptCopyButton.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptCopyButton.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useRef, useState } from "react";
-import { CopyIcon } from "../../icons";
 import { copyText } from "../../lib/copy-text";
 import type { DesktopApi } from "../../lib/desktop-api";
 
@@ -49,7 +48,6 @@ export function TranscriptCopyButton(props: TranscriptCopyButtonProps) {
           });
       }}
     >
-      <CopyIcon size={14} aria-hidden="true" />
     </button>
   );
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptWorkPhaseGroup.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptWorkPhaseGroup.tsx
@@ -28,24 +28,7 @@ export const TranscriptWorkPhaseGroup = memo(function TranscriptWorkPhaseGroup(
   props: TranscriptWorkPhaseGroupProps
 ) {
   const hiddenRegionId = useId();
-  const content = (
-    <div
-      id={hiddenRegionId}
-      className="transcript-work-phase-group__content"
-      hidden={props.collapsible && !props.expanded}
-    >
-      {props.entries.map((entry) =>
-        renderEntry({
-          applications: props.applications,
-          directoryPaths: props.directoryPaths,
-          desktopApi: props.desktopApi,
-          entry,
-          onOpenImage: props.onOpenImage,
-          skills: props.skills,
-        })
-      )}
-    </div>
-  );
+  const shouldRenderContent = !props.collapsible || props.expanded;
 
   return (
     <div className="transcript-work-phase-group">
@@ -65,7 +48,20 @@ export const TranscriptWorkPhaseGroup = memo(function TranscriptWorkPhaseGroup(
       ) : (
         <div className="transcript-work-phase-group__label">{props.label}</div>
       )}
-      {content}
+      {shouldRenderContent ? (
+        <div id={hiddenRegionId} className="transcript-work-phase-group__content">
+          {props.entries.map((entry) =>
+            renderEntry({
+              applications: props.applications,
+              directoryPaths: props.directoryPaths,
+              desktopApi: props.desktopApi,
+              entry,
+              onOpenImage: props.onOpenImage,
+              skills: props.skills,
+            })
+          )}
+        </div>
+      ) : null}
     </div>
   );
 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -358,7 +358,7 @@ describe("TranscriptList", () => {
     const copyText = vi.fn(async () => undefined);
     const messageText = `Intro prose should stay in the normal readable assistant bubble.\n\n${wideMarkdownTable}\n\nFollow-up prose should not inherit the table width.`;
 
-    render(
+    const { container } = render(
       <TranscriptList
         desktopApi={{ copyText }}
         entries={[
@@ -376,6 +376,7 @@ describe("TranscriptList", () => {
     );
 
     expect(screen.getAllByRole("button", { name: "Copy message" })).toHaveLength(1);
+    expect(container.querySelector(".transcript-copy-button svg")).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Copy message" }));
 
@@ -998,7 +999,7 @@ describe("TranscriptList", () => {
     const toggle = screen.getByRole("button", { name: "3 previous messages" });
     expect(toggle).toHaveAttribute("aria-expanded", "false");
     expect(screen.getByText("Final answer.")).toBeVisible();
-    expect(screen.getByText("First commentary.")).not.toBeVisible();
+    expect(screen.queryByText("First commentary.")).not.toBeInTheDocument();
 
     fireEvent.click(toggle);
 
@@ -1258,6 +1259,7 @@ describe("TranscriptList", () => {
 
     const workGroup = screen.getByRole("button", { name: /Worked for 1m 11s/i });
     expect(workGroup).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("Used 2 tools")).not.toBeInTheDocument();
 
     fireEvent.click(workGroup);
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -7059,11 +7059,7 @@ textarea,
   color: var(--text-muted);
 }
 
-.transcript-work-phase-group__content[hidden] {
-  display: none !important;
-}
-
-.transcript-work-phase-group__content:not([hidden]) {
+.transcript-work-phase-group__content {
   display: contents;
 }
 
@@ -7105,6 +7101,16 @@ textarea,
     border-color 120ms ease,
     color 120ms ease,
     opacity 120ms ease;
+}
+
+.transcript-copy-button::before {
+  content: "";
+  width: 14px;
+  height: 14px;
+  background: currentColor;
+  mask:
+    url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' xmlns='http://www.w3.org/2000/svg'%3E%3Crect x='9' y='9' width='11' height='11' rx='2'/%3E%3Cpath d='M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1'/%3E%3C/svg%3E")
+    center / contain no-repeat;
 }
 
 .transcript-copy-button:hover,


### PR DESCRIPTION
## Summary

- I reduced transcript DOM weight by not mounting collapsed work-phase/commentary group entries until the group is expanded.
- I kept transcript copy controls keyboard-accessible while removing the per-button SVG child; the copy glyph is now painted by CSS.
- I added regression coverage for the two DOM-size contracts this depends on.

| Hot profile finding | Before | After |
|---|---|---|
| Collapsed transcript groups | Hidden grouped entries stayed mounted with their message/article/markdown DOM. | Collapsed group content is absent from the DOM until expanded. |
| Transcript copy glyphs | Each transcript copy button rendered its own SVG subtree. | Transcript copy buttons render no SVG child and use a CSS pseudo-element glyph. |

## Verification

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx`
- `pnpm test apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`

## Notes

- I kept this scoped to DOM pruning from the hot CPU/heap profile findings; I have not captured a fresh post-change CPU/heap profile on this branch.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
