### PR TITLE
fix(desktop): preserve image attachment filenames

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,7 +6,7 @@ namespaced with `ci:` when they start, skip, or narrow CI work.
 | Label | Workflow | Effect |
 |---|---|---|
 | `ci:build-preview` | `preview-build.yml` | Builds an unsigned macOS preview DMG and uploads it as a workflow artifact. Use for PRs that change release packaging, installer assets, or desktop distribution behavior. |
-| `ci:live-agent-core` | `ci.yml` | Runs the live agent-core smoke test even when the changed-file detector would otherwise skip it. Adding the label alone does not start CI; add it before opening the PR, rerun CI, or push a commit after adding it. |
+| `ci:live-agent-core` | `ci.yml` | Runs the live agent-core smoke test. Off by default because it depends on a live model provider. Adding the label alone does not start CI; add it before opening the PR, rerun CI, or push a commit after adding it. |
 | `ci:windows-package` | `ci.yml` | Builds the unsigned Windows NSIS installer (`release.mjs --win`) and uploads it as a workflow artifact. Off by default — the normal Windows CI job is build + test only. Adding the label alone does not start CI; add it before opening the PR, rerun CI, or push a commit after adding it. The release workflow (`release.yml`) builds the Windows installer automatically on version tags. |
 
 If you add another label-influenced workflow path, document it here in the same

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,43 +265,15 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           FORCE_LIVE_AGENT_CORE: ${{ contains(github.event.pull_request.labels.*.name, 'ci:live-agent-core') }}
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          PUSH_BEFORE_SHA: ${{ github.event.before }}
-          GITHUB_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
           live_agent_core_label="ci:live-agent-core"
-
-          if [[ "$EVENT_NAME" == "pull_request" ]]; then
-            base="$PR_BASE_SHA"
-            head="$PR_HEAD_SHA"
-          else
-            base="$PUSH_BEFORE_SHA"
-            head="$GITHUB_SHA"
-          fi
-
-          if [[ -z "$base" || "$base" =~ ^0+$ ]]; then
-            base="$(git rev-list --max-parents=0 "$head")"
-          fi
 
           relevant=false
           matched_path=""
           if [[ "$EVENT_NAME" == "pull_request" && "$FORCE_LIVE_AGENT_CORE" == "true" ]]; then
             relevant=true
             matched_path="pull request label present: $live_agent_core_label"
-          else
-            git diff --name-only "$base" "$head" > changed-files.txt
-
-            while IFS= read -r path; do
-              case "$path" in
-                packages/agent-core/src/app-server/*|packages/agent-core/src/config/*|packages/agent-core/src/persistence/*|packages/agent-core/src/providers/*|packages/agent-core/src/testing/*|packages/agent-core/src/tools/*|packages/agent-core/src/__tests__/grok-live.test.ts|packages/agent-core/package.json|package.json|pnpm-lock.yaml|pnpm-workspace.yaml|tsconfig.base.json|vitest.workspace.ts|.nvmrc)
-                  relevant=true
-                  matched_path="$path"
-                  break
-                  ;;
-              esac
-            done < changed-files.txt
           fi
 
           echo "relevant=$relevant" >> "$GITHUB_OUTPUT"
@@ -313,9 +285,9 @@ jobs:
             {
               echo "### Live Agent Core"
               echo
-              echo "Skipped live agent-core smoke test because no agent-core inputs changed."
+              echo "Skipped live agent-core smoke test because the \`$live_agent_core_label\` PR label is not present."
               echo
-              echo "Relevant inputs: live app-server/provider/config/tool paths, the live test itself, agent-core package metadata, root dependency/test config, or the \`ci:live-agent-core\` PR label."
+              echo "Add \`$live_agent_core_label\` and rerun CI when live provider coverage is needed."
             } >> "$GITHUB_STEP_SUMMARY"
           fi
 

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -10456,7 +10456,13 @@ command = "pnpm dev"
       await registry.startTurn({
         backend: "codex",
         threadId: "thread-image",
-        input: [{ type: "image", url: "data:image/png;base64,AQID" }],
+        input: [
+          {
+            type: "image",
+            name: "workspace setup.png",
+            url: "data:image/png;base64,AQID",
+          },
+        ],
       });
 
       const input = codexClient.lastStartTurnParams?.input;
@@ -10464,6 +10470,7 @@ command = "pnpm dev"
       expect(input?.[0]).toMatchObject({ type: "localImage" });
       const imagePath = input?.[0]?.type === "localImage" ? input[0].path : "";
       expect(imagePath).toContain(path.join("state", "image-inputs"));
+      expect(path.basename(imagePath)).toBe("workspace setup-039058c6.png");
       await expect(readFile(imagePath)).resolves.toEqual(Buffer.from([1, 2, 3]));
     } finally {
       await registry.close();

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -10470,7 +10470,10 @@ command = "pnpm dev"
       expect(input?.[0]).toMatchObject({ type: "localImage" });
       const imagePath = input?.[0]?.type === "localImage" ? input[0].path : "";
       expect(imagePath).toContain(path.join("state", "image-inputs"));
-      expect(path.basename(imagePath)).toBe("workspace setup-039058c6.png");
+      expect(path.basename(path.dirname(imagePath))).toBe(
+        "039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81",
+      );
+      expect(path.basename(imagePath)).toBe("workspace setup.png");
       await expect(readFile(imagePath)).resolves.toEqual(Buffer.from([1, 2, 3]));
     } finally {
       await registry.close();

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -6029,6 +6029,45 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("passes image filenames to Codex as adjacent text context", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    await client.startTurn({
+      threadId: "thread-2",
+      input: [
+        {
+          type: "image",
+          name: "pwrsagent-workspace-setup-in-progress-high.png",
+          url: "data:image/png;base64,AQID",
+        },
+      ],
+    });
+
+    const transport = MockTransport.instances.at(-1);
+    expect(transport).toBeDefined();
+    const turnStartPayload = transport!.sentMessages
+      .map((message) => JSON.parse(message) as { method?: string; params?: { input?: unknown } })
+      .find((payload) => payload.method === "turn/start");
+    expect(turnStartPayload?.params?.input).toEqual([
+      {
+        type: "text",
+        text: "Attached image filename: pwrsagent-workspace-setup-in-progress-high.png",
+        text_elements: [],
+      },
+      {
+        type: "image",
+        url: "data:image/png;base64,AQID",
+      },
+    ]);
+
+    await client.close();
+  });
+
   it("forwards approvalPolicy and sandboxPolicy on every turn/start so per-thread permission profile refreshes", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
 

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -6029,7 +6029,7 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
-  it("passes image filenames to Codex as adjacent text context", async () => {
+  it("does not pass image filenames to Codex as adjacent text context", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
 
     const client = new CodexAppServerClient({
@@ -6054,11 +6054,6 @@ describe("CodexAppServerClient", () => {
       .map((message) => JSON.parse(message) as { method?: string; params?: { input?: unknown } })
       .find((payload) => payload.method === "turn/start");
     expect(turnStartPayload?.params?.input).toEqual([
-      {
-        type: "text",
-        text: "Attached image filename: pwrsagent-workspace-setup-in-progress-high.png",
-        text_elements: [],
-      },
       {
         type: "image",
         url: "data:image/png;base64,AQID",

--- a/apps/desktop/src/main/__tests__/image-input-files.test.ts
+++ b/apps/desktop/src/main/__tests__/image-input-files.test.ts
@@ -12,7 +12,7 @@ describe("image input files", () => {
       const first = await materializeLocalImageInputs(
         [
           { type: "text", text: "Describe it" },
-          { type: "image", url: dataUrl },
+          { type: "image", name: "original-paste.png", url: dataUrl },
         ],
         { resolveRoot: () => tempDir },
       );
@@ -22,9 +22,9 @@ describe("image input files", () => {
       );
 
       expect(first[0]).toEqual({ type: "text", text: "Describe it" });
-      expect(first[1]).toMatchObject({ type: "localImage" });
-      expect(second[0]).toEqual(first[1]);
+      expect(first[1]).toMatchObject({ type: "localImage", name: "original-paste.png" });
       const imagePath = first[1]?.type === "localImage" ? first[1].path : "";
+      expect(second[0]).toEqual({ type: "localImage", path: imagePath });
       expect(path.basename(imagePath)).toMatch(/^[a-f0-9]{64}\.png$/);
       await expect(readFile(imagePath)).resolves.toEqual(Buffer.from([1, 2, 3]));
     } finally {
@@ -49,11 +49,11 @@ describe("image input files", () => {
 
   it("converts file URLs for supported local image paths", async () => {
     const result = await materializeLocalImageInputs([
-      { type: "image", url: "file:///tmp/screenshot%20one.jpg" },
+      { type: "image", name: "friendly screenshot.jpg", url: "file:///tmp/screenshot%20one.jpg" },
     ]);
 
     expect(result).toEqual([
-      { type: "localImage", path: "/tmp/screenshot one.jpg" },
+      { type: "localImage", name: "friendly screenshot.jpg", path: "/tmp/screenshot one.jpg" },
     ]);
   });
 

--- a/apps/desktop/src/main/__tests__/image-input-files.test.ts
+++ b/apps/desktop/src/main/__tests__/image-input-files.test.ts
@@ -24,7 +24,13 @@ describe("image input files", () => {
       expect(first[0]).toEqual({ type: "text", text: "Describe it" });
       expect(first[1]).toMatchObject({ type: "localImage", name: "original-paste.png" });
       const imagePath = first[1]?.type === "localImage" ? first[1].path : "";
-      expect(path.basename(imagePath)).toBe("original-paste-039058c6.png");
+      expect(imagePath).toBe(
+        path.join(
+          tempDir,
+          "039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81",
+          "original-paste.png",
+        ),
+      );
       expect(second[0]).toEqual({
         type: "localImage",
         path: path.join(

--- a/apps/desktop/src/main/__tests__/image-input-files.test.ts
+++ b/apps/desktop/src/main/__tests__/image-input-files.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest";
 import { materializeLocalImageInputs } from "../app-server/image-input-files";
 
 describe("image input files", () => {
-  it("materializes PNG data URLs as stable local image inputs", async () => {
+  it("materializes named PNG data URLs with the pasted filename in the local image path", async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-image-inputs-"));
     const dataUrl = "data:image/png;base64,AQID";
     try {
@@ -24,8 +24,14 @@ describe("image input files", () => {
       expect(first[0]).toEqual({ type: "text", text: "Describe it" });
       expect(first[1]).toMatchObject({ type: "localImage", name: "original-paste.png" });
       const imagePath = first[1]?.type === "localImage" ? first[1].path : "";
-      expect(second[0]).toEqual({ type: "localImage", path: imagePath });
-      expect(path.basename(imagePath)).toMatch(/^[a-f0-9]{64}\.png$/);
+      expect(path.basename(imagePath)).toBe("original-paste-039058c6.png");
+      expect(second[0]).toEqual({
+        type: "localImage",
+        path: path.join(
+          tempDir,
+          "039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81.png",
+        ),
+      });
       await expect(readFile(imagePath)).resolves.toEqual(Buffer.from([1, 2, 3]));
     } finally {
       await rm(tempDir, { recursive: true, force: true });

--- a/apps/desktop/src/main/__tests__/image-input-files.test.ts
+++ b/apps/desktop/src/main/__tests__/image-input-files.test.ts
@@ -104,4 +104,77 @@ describe("image input files", () => {
       await rm(tempDir, { recursive: true, force: true });
     }
   });
+
+  it("does not delete an old named-image directory when a child image is fresh", async () => {
+    const root = "/tmp/pwragent-image-inputs";
+    const now = 10 * 24 * 60 * 60 * 1000;
+    const stats = new Map<string, { kind: "dir" | "file"; mtimeMs: number }>();
+    const removedPaths: string[] = [];
+
+    const dependencies = {
+      now: () => now,
+      resolveRoot: () => root,
+      mkdir: async (dirPath: string) => {
+        stats.set(dirPath, { kind: "dir", mtimeMs: 0 });
+      },
+      readdir: async (dirPath: string) => {
+        const prefix = `${dirPath}${path.sep}`;
+        const entries = new Set<string>();
+        for (const candidate of stats.keys()) {
+          if (!candidate.startsWith(prefix)) {
+            continue;
+          }
+          const child = candidate.slice(prefix.length);
+          if (child && !child.includes(path.sep)) {
+            entries.add(child);
+          }
+        }
+        return [...entries];
+      },
+      stat: async (filePath: string) => {
+        const info = stats.get(filePath);
+        if (!info) {
+          throw new Error(`missing stat for ${filePath}`);
+        }
+        return {
+          isFile: () => info.kind === "file",
+          isDirectory: () => info.kind === "dir",
+          mtimeMs: info.mtimeMs,
+        };
+      },
+      writeFile: async (filePath: string) => {
+        stats.set(path.dirname(filePath), { kind: "dir", mtimeMs: 0 });
+        stats.set(filePath, { kind: "file", mtimeMs: now });
+      },
+      unlink: async (filePath: string) => {
+        stats.delete(filePath);
+      },
+      rm: async (filePath: string) => {
+        removedPaths.push(filePath);
+        const prefix = `${filePath}${path.sep}`;
+        for (const candidate of [...stats.keys()]) {
+          if (candidate === filePath || candidate.startsWith(prefix)) {
+            stats.delete(candidate);
+          }
+        }
+      },
+    };
+
+    const [first] = await materializeLocalImageInputs(
+      [{ type: "image", name: "original-paste.png", url: "data:image/png;base64,AQID" }],
+      dependencies,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const firstPath = first?.type === "localImage" ? first.path : "";
+    await materializeLocalImageInputs(
+      [{ type: "image", name: "different.png", url: "data:image/png;base64,BAUG" }],
+      dependencies,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(path.basename(firstPath)).toBe("original-paste.png");
+    expect(removedPaths).not.toContain(path.dirname(firstPath));
+    expect(stats.has(firstPath)).toBe(true);
+  });
 });

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -6561,6 +6561,7 @@ describe("MessagingController", () => {
           },
           {
             type: "image",
+            name: "screen.png",
             url: "data:image/png;base64,AQID",
           },
           {

--- a/apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts
@@ -178,18 +178,20 @@ describe("RendererHotCpuProfiler", () => {
 
     expect(debuggerApi.sendCommand).toHaveBeenCalledWith("Profiler.stop");
     expect(debuggerApi.detach).toHaveBeenCalled();
-    expect(onProfileWritten).toHaveBeenCalledWith(
-      expect.objectContaining({
-        profileFilename: "renderer-hot-0001.cpuprofile",
-        profilePath: sessionResult.session.createProfilePath(1),
-        sessionDirectory: sessionResult.session.directoryPath,
-        sessionDirectoryName: sessionResult.session.directoryName,
-        triggerConsecutiveSamples: 2,
-        triggerCpuPercent: 75,
-        triggerMode: "sustained",
-        triggerThresholdPercent: 50,
-      }),
-    );
+    await vi.waitFor(() => {
+      expect(onProfileWritten).toHaveBeenCalledWith(
+        expect.objectContaining({
+          profileFilename: "renderer-hot-0001.cpuprofile",
+          profilePath: sessionResult.session.createProfilePath(1),
+          sessionDirectory: sessionResult.session.directoryPath,
+          sessionDirectoryName: sessionResult.session.directoryName,
+          triggerConsecutiveSamples: 2,
+          triggerCpuPercent: 75,
+          triggerMode: "sustained",
+          triggerThresholdPercent: 50,
+        }),
+      );
+    });
 
     const profile = JSON.parse(
       await fs.readFile(

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -613,7 +613,11 @@ export function inputToAcpPrompt(
     }
 
     if (item.type === "image") {
-      parts.push({ type: "image", url: item.url });
+      const name = item.name?.trim();
+      if (name) {
+        promptContent.push({ type: "text", text: `Attached image filename: ${name}` });
+      }
+      parts.push({ type: "image", ...(name ? { alt: name } : {}), url: item.url });
       const image = parseImageDataUrl(item.url);
       if (image) {
         promptContent.push({
@@ -627,7 +631,7 @@ export function inputToAcpPrompt(
       continue;
     }
 
-    const fileName = path.basename(item.path);
+    const fileName = item.name?.trim() || path.basename(item.path);
     const text = `[Local image: ${fileName}]`;
     promptContent.push({ type: "text", text });
     parts.push({ type: "text", text });

--- a/apps/desktop/src/main/app-server/image-input-files.ts
+++ b/apps/desktop/src/main/app-server/image-input-files.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { mkdir, readdir, stat, unlink, writeFile } from "node:fs/promises";
+import { mkdir, readdir, rm, stat, unlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { AppServerTurnInputItem } from "@pwragent/shared";
 import { resolveActiveProfilePath } from "../profile";
@@ -12,8 +12,16 @@ export type ImageInputFileDependencies = {
   writeFile: (filePath: string, data: Buffer) => Promise<unknown>;
   mkdir: (dirPath: string, options: { recursive: true }) => Promise<unknown>;
   readdir: (dirPath: string) => Promise<string[]>;
-  stat: (filePath: string) => Promise<{ isFile: () => boolean; mtimeMs: number }>;
+  stat: (filePath: string) => Promise<{
+    isFile: () => boolean;
+    isDirectory?: () => boolean;
+    mtimeMs: number;
+  }>;
   unlink: (filePath: string) => Promise<unknown>;
+  rm: (
+    filePath: string,
+    options: { recursive?: boolean; force?: boolean },
+  ) => Promise<unknown>;
 };
 
 const defaultDependencies: ImageInputFileDependencies = {
@@ -24,6 +32,7 @@ const defaultDependencies: ImageInputFileDependencies = {
   readdir,
   stat,
   unlink,
+  rm,
 };
 
 export async function materializeLocalImageInputs(
@@ -46,10 +55,8 @@ export async function materializeLocalImageInputs(
       const root = deps.resolveRoot();
       materializedRoot = root;
       await deps.mkdir(root, { recursive: true });
-      const filePath = path.join(
-        root,
-        materializedImageFileName(item.name, dataImage),
-      );
+      const filePath = materializedImageFilePath(root, item.name, dataImage);
+      await deps.mkdir(path.dirname(filePath), { recursive: true });
       await deps.writeFile(filePath, dataImage.buffer);
       materializedFilePaths.add(filePath);
       materialized.push({
@@ -115,19 +122,19 @@ function filePathFromFileUrl(url: string): string | undefined {
   }
 }
 
-function materializedImageFileName(
+function materializedImageFilePath(
+  root: string,
   name: string | undefined,
   dataImage: { mimeType: "image/jpeg" | "image/png"; sha256: string },
 ): string {
   const extension = extensionForMimeType(dataImage.mimeType);
-  const fallback = `${dataImage.sha256}.${extension}`;
+  const fallback = path.join(root, `${dataImage.sha256}.${extension}`);
   const basename = sanitizeImageBasename(name, extension);
   if (!basename) {
     return fallback;
   }
 
-  const stem = basename.slice(0, -(extension.length + 1));
-  return `${stem}-${dataImage.sha256.slice(0, 8)}.${extension}`;
+  return path.join(root, dataImage.sha256, basename);
 }
 
 function sanitizeImageBasename(
@@ -176,17 +183,34 @@ async function cleanupOldImageInputs(
   await Promise.all(
     entries.map(async (entry) => {
       const filePath = path.join(root, entry);
-      if (excludedFilePaths.has(filePath)) {
+      if (isExcludedImageInputPath(filePath, excludedFilePaths)) {
+        return;
+      }
+      const info = await deps.stat(filePath).catch(() => undefined);
+      if (!info?.isFile() || info.mtimeMs >= cutoff) {
+        if (info?.isDirectory?.() && info.mtimeMs < cutoff) {
+          await deps
+            .rm(filePath, { recursive: true, force: true })
+            .catch(() => undefined);
+        }
         return;
       }
       if (!isSupportedImagePath(filePath)) {
         return;
       }
-      const info = await deps.stat(filePath).catch(() => undefined);
-      if (!info?.isFile() || info.mtimeMs >= cutoff) {
-        return;
-      }
       await deps.unlink(filePath).catch(() => undefined);
     }),
   );
+}
+
+function isExcludedImageInputPath(
+  filePath: string,
+  excludedFilePaths: ReadonlySet<string>,
+): boolean {
+  for (const excludedPath of excludedFilePaths) {
+    if (excludedPath === filePath || excludedPath.startsWith(`${filePath}${path.sep}`)) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/apps/desktop/src/main/app-server/image-input-files.ts
+++ b/apps/desktop/src/main/app-server/image-input-files.ts
@@ -52,13 +52,21 @@ export async function materializeLocalImageInputs(
       );
       await deps.writeFile(filePath, dataImage.buffer);
       materializedFilePaths.add(filePath);
-      materialized.push({ type: "localImage", path: filePath });
+      materialized.push({
+        type: "localImage",
+        ...(item.name ? { name: item.name } : {}),
+        path: filePath,
+      });
       continue;
     }
 
     const filePath = filePathFromFileUrl(item.url);
     if (filePath && isSupportedImagePath(filePath)) {
-      materialized.push({ type: "localImage", path: filePath });
+      materialized.push({
+        type: "localImage",
+        ...(item.name ? { name: item.name } : {}),
+        path: filePath,
+      });
       continue;
     }
 

--- a/apps/desktop/src/main/app-server/image-input-files.ts
+++ b/apps/desktop/src/main/app-server/image-input-files.ts
@@ -48,7 +48,7 @@ export async function materializeLocalImageInputs(
       await deps.mkdir(root, { recursive: true });
       const filePath = path.join(
         root,
-        `${dataImage.sha256}.${extensionForMimeType(dataImage.mimeType)}`,
+        materializedImageFileName(item.name, dataImage),
       );
       await deps.writeFile(filePath, dataImage.buffer);
       materializedFilePaths.add(filePath);
@@ -113,6 +113,48 @@ function filePathFromFileUrl(url: string): string | undefined {
   } catch {
     return undefined;
   }
+}
+
+function materializedImageFileName(
+  name: string | undefined,
+  dataImage: { mimeType: "image/jpeg" | "image/png"; sha256: string },
+): string {
+  const extension = extensionForMimeType(dataImage.mimeType);
+  const fallback = `${dataImage.sha256}.${extension}`;
+  const basename = sanitizeImageBasename(name, extension);
+  if (!basename) {
+    return fallback;
+  }
+
+  const stem = basename.slice(0, -(extension.length + 1));
+  return `${stem}-${dataImage.sha256.slice(0, 8)}.${extension}`;
+}
+
+function sanitizeImageBasename(
+  name: string | undefined,
+  extension: "jpg" | "png",
+): string | undefined {
+  const normalized = name
+    ?.trim()
+    .replace(/\\/g, "/")
+    .split("/")
+    .pop()
+    ?.replace(/[\u0000-\u001f\u007f]/g, "")
+    .trim();
+  if (!normalized) {
+    return undefined;
+  }
+
+  const parsed = path.parse(normalized);
+  const stem = (parsed.name || normalized)
+    .replace(/[^a-zA-Z0-9._ -]+/g, "-")
+    .replace(/^[.\s-]+|[.\s-]+$/g, "")
+    .slice(0, 96);
+  if (!stem) {
+    return undefined;
+  }
+
+  return `${stem}.${extension}`;
 }
 
 function extensionForMimeType(mimeType: "image/jpeg" | "image/png"): "jpg" | "png" {

--- a/apps/desktop/src/main/app-server/image-input-files.ts
+++ b/apps/desktop/src/main/app-server/image-input-files.ts
@@ -187,12 +187,18 @@ async function cleanupOldImageInputs(
         return;
       }
       const info = await deps.stat(filePath).catch(() => undefined);
-      if (!info?.isFile() || info.mtimeMs >= cutoff) {
-        if (info?.isDirectory?.() && info.mtimeMs < cutoff) {
+      if (info?.isDirectory?.()) {
+        if (
+          info.mtimeMs < cutoff &&
+          !(await containsFreshImageInput(filePath, deps, cutoff, excludedFilePaths))
+        ) {
           await deps
             .rm(filePath, { recursive: true, force: true })
             .catch(() => undefined);
         }
+        return;
+      }
+      if (!info?.isFile() || info.mtimeMs >= cutoff) {
         return;
       }
       if (!isSupportedImagePath(filePath)) {
@@ -201,6 +207,34 @@ async function cleanupOldImageInputs(
       await deps.unlink(filePath).catch(() => undefined);
     }),
   );
+}
+
+async function containsFreshImageInput(
+  dirPath: string,
+  deps: ImageInputFileDependencies,
+  cutoff: number,
+  excludedFilePaths: ReadonlySet<string>,
+): Promise<boolean> {
+  const entries = await deps.readdir(dirPath).catch(() => undefined);
+  if (!entries) {
+    return true;
+  }
+
+  for (const entry of entries) {
+    const childPath = path.join(dirPath, entry);
+    if (isExcludedImageInputPath(childPath, excludedFilePaths)) {
+      return true;
+    }
+    if (!isSupportedImagePath(childPath)) {
+      continue;
+    }
+    const info = await deps.stat(childPath).catch(() => undefined);
+    if (info?.isFile() && info.mtimeMs >= cutoff) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 function isExcludedImageInputPath(

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -4605,16 +4605,44 @@ function buildCollaborationModeOverrides(params: {
   };
 }
 
-function toCodexUserInput(input: AppServerTurnInputItem): CodexUserInput {
+function imageAttachmentNameInput(name: string): CodexUserInput {
+  return {
+    type: "text",
+    text: `Attached image filename: ${name}`,
+    text_elements: [],
+  };
+}
+
+function toCodexUserInputs(input: AppServerTurnInputItem): CodexUserInput[] {
   if (input.type === "text") {
-    return {
-      type: "text",
-      text: input.text,
-      text_elements: [],
-    };
+    return [
+      {
+        type: "text",
+        text: input.text,
+        text_elements: [],
+      },
+    ];
   }
 
-  return input;
+  const name = input.name?.trim();
+  const prefix = name ? [imageAttachmentNameInput(name)] : [];
+  if (input.type === "image") {
+    return [
+      ...prefix,
+      {
+        type: "image",
+        url: input.url,
+      },
+    ];
+  }
+
+  return [
+    ...prefix,
+    {
+      type: "localImage",
+      path: input.path,
+    },
+  ];
 }
 
 function buildTurnStartPayload(params: {
@@ -4634,7 +4662,7 @@ function buildTurnStartPayload(params: {
 }): CodexTurnStartParams {
   const base: CodexTurnStartParams = {
     threadId: params.threadId,
-    input: params.input.map(toCodexUserInput),
+    input: params.input.flatMap(toCodexUserInputs),
   };
 
   if (params.cwd?.trim()) {
@@ -6005,7 +6033,7 @@ export class CodexAppServerClient {
 
     const payload: CodexTurnSteerParams = {
       threadId: params.threadId,
-      input: params.input.map(toCodexUserInput),
+      input: params.input.flatMap(toCodexUserInputs),
       expectedTurnId: params.expectedTurnId,
     };
     const result = await requestWithFallbacks({

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -4605,44 +4605,26 @@ function buildCollaborationModeOverrides(params: {
   };
 }
 
-function imageAttachmentNameInput(name: string): CodexUserInput {
-  return {
-    type: "text",
-    text: `Attached image filename: ${name}`,
-    text_elements: [],
-  };
-}
-
-function toCodexUserInputs(input: AppServerTurnInputItem): CodexUserInput[] {
+function toCodexUserInput(input: AppServerTurnInputItem): CodexUserInput {
   if (input.type === "text") {
-    return [
-      {
-        type: "text",
-        text: input.text,
-        text_elements: [],
-      },
-    ];
+    return {
+      type: "text",
+      text: input.text,
+      text_elements: [],
+    };
   }
 
-  const name = input.name?.trim();
-  const prefix = name ? [imageAttachmentNameInput(name)] : [];
   if (input.type === "image") {
-    return [
-      ...prefix,
-      {
-        type: "image",
-        url: input.url,
-      },
-    ];
+    return {
+      type: "image",
+      url: input.url,
+    };
   }
 
-  return [
-    ...prefix,
-    {
-      type: "localImage",
-      path: input.path,
-    },
-  ];
+  return {
+    type: "localImage",
+    path: input.path,
+  };
 }
 
 function buildTurnStartPayload(params: {
@@ -4662,7 +4644,7 @@ function buildTurnStartPayload(params: {
 }): CodexTurnStartParams {
   const base: CodexTurnStartParams = {
     threadId: params.threadId,
-    input: params.input.flatMap(toCodexUserInputs),
+    input: params.input.map(toCodexUserInput),
   };
 
   if (params.cwd?.trim()) {
@@ -6033,7 +6015,7 @@ export class CodexAppServerClient {
 
     const payload: CodexTurnSteerParams = {
       threadId: params.threadId,
-      input: params.input.flatMap(toCodexUserInputs),
+      input: params.input.map(toCodexUserInput),
       expectedTurnId: params.expectedTurnId,
     };
     const result = await requestWithFallbacks({

--- a/apps/desktop/src/main/messaging/core/messaging-attachment-processor.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-attachment-processor.ts
@@ -160,6 +160,7 @@ export async function processMessagingAttachments(params: {
         }
         mediaInput.push({
           type: "image",
+          name: downloaded.fileName,
           url: normalized.dataUrl,
         });
         continue;

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -3140,7 +3140,11 @@ export function Composer(props: ComposerProps) {
     }));
     const input: AppServerTurnInputItem[] = [
       ...(displayText ? [{ type: "text" as const, text: displayText }] : []),
-      ...imageParts.map(({ url }) => ({ type: "image" as const, url })),
+      ...attachments.map((attachment) => ({
+        type: "image" as const,
+        name: attachment.name,
+        url: attachment.url,
+      })),
     ];
 
     return { displayText, imageParts, input };

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -3076,6 +3076,7 @@ describe("Composer", () => {
         input: [
           {
             type: "image",
+            name: "steer.png",
             url: expect.stringMatching(/^data:image\/png;base64,/),
           },
         ],
@@ -8094,6 +8095,7 @@ describe("Composer", () => {
           { type: "text", text: "Describe this screenshot" },
           {
             type: "image",
+            name: "screenshot.jpeg",
             url: expect.stringMatching(/^data:image\/jpeg;base64,/),
           },
         ],
@@ -8182,6 +8184,7 @@ describe("Composer", () => {
         input: [
           {
             type: "image",
+            name: "diagram.png",
             url: expect.stringMatching(/^data:image\/png;base64,/),
           },
         ],
@@ -8636,6 +8639,7 @@ describe("Composer", () => {
         input: [
           {
             type: "image",
+            name: "demo.gif",
             url: expect.stringMatching(/^data:image\/gif;base64,/),
           },
         ],
@@ -8703,6 +8707,7 @@ describe("Composer", () => {
         input: [
           {
             type: "image",
+            name: "clipboard-item.png",
             url: expect.stringMatching(/^data:image\/png;base64,/),
           },
         ],

--- a/packages/agent-core/src/__tests__/ai-sdk-message-builder.test.ts
+++ b/packages/agent-core/src/__tests__/ai-sdk-message-builder.test.ts
@@ -63,6 +63,41 @@ describe("buildAiSdkMessages", () => {
     }
   });
 
+  it("adds filename context before named image parts", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "ai-sdk-message-"));
+    const imagePath = path.join(tempDir, "local.png");
+    await writeFile(imagePath, Buffer.from([4, 5, 6]));
+    try {
+      const messages = await buildAiSdkMessages({
+        input: [
+          { type: "image", name: "pasted-screenshot.png", url: "data:image/png;base64,AQID" },
+          { type: "localImage", name: "materialized-screenshot.png", path: imagePath },
+        ],
+      });
+      expect(messages).toEqual([
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "Attached image filename: pasted-screenshot.png" },
+            {
+              type: "image",
+              image: new URL("data:image/png;base64,AQID"),
+              mediaType: "image/png",
+            },
+            { type: "text", text: "Attached image filename: materialized-screenshot.png" },
+            {
+              type: "image",
+              image: Buffer.from([4, 5, 6]),
+              mediaType: "image/png",
+            },
+          ],
+        },
+      ]);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("rejects file URLs because remote xAI cannot access them", async () => {
     await expect(
       buildAiSdkMessages({

--- a/packages/agent-core/src/app-server/codex-app-server.ts
+++ b/packages/agent-core/src/app-server/codex-app-server.ts
@@ -513,12 +513,18 @@ function normalizeTurnInput(value: unknown): AppServerTurnInputItem[] {
     if (type === "image") {
       return {
         type: "image",
+        ...(typeof record.name === "string" && record.name.trim()
+          ? { name: record.name.trim() }
+          : {}),
         url: asRequiredString(record.url, "image input requires url"),
       };
     }
     if (type === "localImage") {
       return {
         type: "localImage",
+        ...(typeof record.name === "string" && record.name.trim()
+          ? { name: record.name.trim() }
+          : {}),
         path: asRequiredString(record.path, "localImage input requires path"),
       };
     }

--- a/packages/agent-core/src/providers/ai-sdk-message-builder.ts
+++ b/packages/agent-core/src/providers/ai-sdk-message-builder.ts
@@ -31,8 +31,16 @@ export async function buildAiSdkMessages(params: {
       continue;
     }
     if (item.type === "image") {
+      const name = item.name?.trim();
+      if (name) {
+        content.push({ type: "text", text: `Attached image filename: ${name}` });
+      }
       content.push(parseImageUrl(item.url));
       continue;
+    }
+    const name = item.name?.trim();
+    if (name) {
+      content.push({ type: "text", text: `Attached image filename: ${name}` });
     }
     content.push(await readLocalImage(item.path));
   }

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -15,11 +15,15 @@ export type AppServerTextInputItem = {
 
 export type AppServerImageInputItem = {
   type: "image";
+  /** User-visible filename / attachment label when available. */
+  name?: string;
   url: string;
 };
 
 export type AppServerLocalImageInputItem = {
   type: "localImage";
+  /** User-visible filename / attachment label when available. */
+  name?: string;
   path: string;
 };
 


### PR DESCRIPTION
## Summary

- Preserve pasted image attachment filenames through the desktop composer and app-server request flow.
- Carry image names into ACP, Codex app-server, messaging attachment processing, and AI SDK message construction so model context includes the original file names.
- Add focused coverage for composer image handling, Codex app-server image files, ACP, messaging attachments, and AI SDK message building.

## Root cause

Pasted images were passed through as image data without keeping the original file name in the normalized attachment context. Downstream model/message builders therefore had no filename metadata to include when describing attached images.

## Validation

- Focused composer/Codex/image-file/AI SDK tests
- ACP + messaging attachment tests
- `pnpm typecheck`