### PR TITLE
fix(desktop): include heap snapshots in hot CPU handoff

### DIFF
--- a/apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts
@@ -425,6 +425,7 @@ describe("RendererHotCpuProfiler", () => {
 
     const { target } = createTarget();
     const onHeapSnapshotLimitReached = vi.fn(async () => undefined);
+    const onProfileWritten = vi.fn();
     let nowCallCount = 0;
     const metrics = [
       createMetric(0, 100),
@@ -435,6 +436,7 @@ describe("RendererHotCpuProfiler", () => {
       config,
       getAppMetrics: () => [metrics.shift() ?? createMetric(0)],
       onHeapSnapshotLimitReached,
+      onProfileWritten,
       session: sessionResult.session,
       target,
       logger: {
@@ -466,6 +468,29 @@ describe("RendererHotCpuProfiler", () => {
       "renderer-hot-0001-mid.heapsnapshot",
       "renderer-hot-0001-stop.heapsnapshot",
     ]);
+    expect(onProfileWritten).toHaveBeenCalledWith(
+      expect.objectContaining({
+        heapSnapshotArtifacts: [
+          {
+            filename: "renderer-hot-0001-start.heapsnapshot",
+            path: sessionResult.session.createHeapSnapshotPath(1, "start"),
+            phase: "start",
+          },
+          {
+            filename: "renderer-hot-0001-mid.heapsnapshot",
+            path: sessionResult.session.createHeapSnapshotPath(1, "mid"),
+            phase: "mid",
+          },
+          {
+            filename: "renderer-hot-0001-stop.heapsnapshot",
+            path: sessionResult.session.createHeapSnapshotPath(1, "stop"),
+            phase: "stop",
+          },
+        ],
+        profileFilename: "renderer-hot-0001.cpuprofile",
+        profilePath: sessionResult.session.createProfilePath(1),
+      }),
+    );
 
     const events = (await fs.readFile(sessionResult.session.eventsPath, "utf8"))
       .trim()

--- a/apps/desktop/src/main/diagnostics/renderer-hot-cpu-profiler.ts
+++ b/apps/desktop/src/main/diagnostics/renderer-hot-cpu-profiler.ts
@@ -1,7 +1,10 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { ProcessMetric } from "electron";
-import type { HotCpuProfileCapturedEvent } from "../../shared/hot-cpu-profile";
+import type {
+  HotCpuProfileCapturedEvent,
+  HotCpuProfileHeapSnapshotArtifact,
+} from "../../shared/hot-cpu-profile";
 import type { HotCpuProfileConfig } from "./hot-cpu-profile-config";
 import type { HotCpuProfileSession } from "./hot-cpu-profile-session";
 import { getMainLogger } from "../log";
@@ -87,6 +90,7 @@ export class RendererHotCpuProfiler {
   private profileCount = 0;
   private profiling = false;
   private activeProfileTrigger: ActiveProfileTrigger | null = null;
+  private activeProfileHeapSnapshots: HotCpuProfileHeapSnapshotArtifact[] = [];
   private stopped = false;
 
   constructor(options: {
@@ -347,6 +351,7 @@ export class RendererHotCpuProfiler {
       await this.target.debugger.sendCommand("Profiler.enable");
       await this.target.debugger.sendCommand("Profiler.start");
       this.profiling = true;
+      this.activeProfileHeapSnapshots = [];
       this.activeProfileTrigger = {
         triggerConsecutiveSamples: this.triggerConsecutiveSamples(),
         triggerCpuPercent: options.cpuPercent,
@@ -450,6 +455,7 @@ export class RendererHotCpuProfiler {
       }
       await this.onProfileWritten?.({
         capturedAt: this.now().toISOString(),
+        heapSnapshotArtifacts: [...this.activeProfileHeapSnapshots],
         profileFilename,
         profilePath,
         sessionDirectory: this.session.directoryPath,
@@ -469,6 +475,7 @@ export class RendererHotCpuProfiler {
       this.logger.error("[pwragent:hot-cpu] CPU profile failed to stop", error);
     } finally {
       this.activeProfileTrigger = null;
+      this.activeProfileHeapSnapshots = [];
       this.detachDebugger();
     }
   }
@@ -500,6 +507,13 @@ export class RendererHotCpuProfiler {
     try {
       await this.target.takeHeapSnapshot(snapshotPath);
       await this.session.registerArtifact(snapshotFilename);
+      if (index === this.profileCount) {
+        this.activeProfileHeapSnapshots.push({
+          filename: snapshotFilename,
+          path: snapshotPath,
+          phase,
+        });
+      }
       await this.session.appendEvent({
         capturedAt: this.now().toISOString(),
         type: "heap-snapshot-written",

--- a/apps/desktop/src/shared/__tests__/hot-cpu-profile.test.ts
+++ b/apps/desktop/src/shared/__tests__/hot-cpu-profile.test.ts
@@ -29,4 +29,47 @@ describe("hot CPU profile handoff message", () => {
       ].join("\n"),
     );
   });
+
+  it("includes heap snapshot artifacts when present", () => {
+    expect(
+      buildHotCpuProfileHandoffMessage({
+        capturedAt: "2026-06-10T12:00:00.000Z",
+        heapSnapshotArtifacts: [
+          {
+            filename: "renderer-hot-0001-start.heapsnapshot",
+            path: "/tmp/hot-cpu/renderer-hot-0001-start.heapsnapshot",
+            phase: "start",
+          },
+          {
+            filename: "renderer-hot-0001-stop.heapsnapshot",
+            path: "/tmp/hot-cpu/renderer-hot-0001-stop.heapsnapshot",
+            phase: "stop",
+          },
+        ],
+        profileFilename: "renderer-hot-0001.cpuprofile",
+        profilePath: "/tmp/hot-cpu/renderer-hot-0001.cpuprofile",
+        sessionDirectory: "/tmp/hot-cpu",
+        sessionDirectoryName: "hot-cpu",
+        triggerConsecutiveSamples: 1,
+        triggerCpuPercent: 80,
+        triggerMode: "spike",
+        triggerThresholdPercent: 50,
+      }),
+    ).toBe(
+      [
+        "PwrAgent captured a renderer CPU profile.",
+        "Trigger: Spike (1 sample >= 50%; trigger sample 80%)",
+        "Session basename: hot-cpu",
+        "Session directory path: /tmp/hot-cpu",
+        "CPU profile basename: renderer-hot-0001.cpuprofile",
+        "CPU profile path: /tmp/hot-cpu/renderer-hot-0001.cpuprofile",
+        "Heap snapshots captured: 2",
+        "Heap snapshot start basename: renderer-hot-0001-start.heapsnapshot",
+        "Heap snapshot start path: /tmp/hot-cpu/renderer-hot-0001-start.heapsnapshot",
+        "Heap snapshot stop basename: renderer-hot-0001-stop.heapsnapshot",
+        "Heap snapshot stop path: /tmp/hot-cpu/renderer-hot-0001-stop.heapsnapshot",
+        "Open the .cpuprofile in Chrome DevTools Performance, or inspect the full session directory for samples, events, and optional heap snapshots.",
+      ].join("\n"),
+    );
+  });
 });

--- a/apps/desktop/src/shared/hot-cpu-profile.ts
+++ b/apps/desktop/src/shared/hot-cpu-profile.ts
@@ -1,7 +1,14 @@
 export type HotCpuProfileTriggerMode = "spike" | "sustained" | "slowburn";
 
+export type HotCpuProfileHeapSnapshotArtifact = {
+  filename: string;
+  path: string;
+  phase: string;
+};
+
 export type HotCpuProfileCapturedEvent = {
   capturedAt: string;
+  heapSnapshotArtifacts?: HotCpuProfileHeapSnapshotArtifact[];
   profileFilename: string;
   profilePath: string;
   sessionDirectory: string;
@@ -52,6 +59,18 @@ export function formatHotCpuProfileTriggerSummary(
 export function buildHotCpuProfileHandoffMessage(
   event: HotCpuProfileCapturedEvent,
 ): string {
+  const heapSnapshotArtifacts = event.heapSnapshotArtifacts ?? [];
+  const heapSnapshotLines =
+    heapSnapshotArtifacts.length > 0
+      ? [
+          `Heap snapshots captured: ${heapSnapshotArtifacts.length}`,
+          ...heapSnapshotArtifacts.flatMap((artifact) => [
+            `Heap snapshot ${artifact.phase} basename: ${artifact.filename}`,
+            `Heap snapshot ${artifact.phase} path: ${artifact.path}`,
+          ]),
+        ]
+      : [];
+
   return [
     "PwrAgent captured a renderer CPU profile.",
     `Trigger: ${formatHotCpuProfileTriggerSummary(event)}`,
@@ -59,6 +78,7 @@ export function buildHotCpuProfileHandoffMessage(
     `Session directory path: ${event.sessionDirectory}`,
     `CPU profile basename: ${event.profileFilename}`,
     `CPU profile path: ${event.profilePath}`,
+    ...heapSnapshotLines,
     "Open the .cpuprofile in Chrome DevTools Performance, or inspect the full session directory for samples, events, and optional heap snapshots.",
   ].join("\n");
 }


### PR DESCRIPTION
## Summary

- I made hot CPU handoff messages include heap snapshot basenames and full paths when smart heap snapshots are captured.
- I kept the no-heap path unchanged and added coverage for the profiler payload and renderer-facing handoff text.

## Verification

- I ran `pnpm test apps/desktop/src/shared/__tests__/hot-cpu-profile.test.ts apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts`.

## Notes

- This is diagnostic plumbing; I did not capture visual evidence.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
