### PR TITLE
fix(desktop): sidebar sticky-header coverage + scrollbar clearance

### DIFF
--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2227,14 +2227,16 @@ textarea,
   flex: 1;
   overflow-y: auto;
   min-height: 0;
-  /* 4px gutters on both sides hold row content clear of the scroll
-     container's `overflow: hidden` clip. The right gutter also keeps the
-     selected row's accent-border from kissing the scrollbar thumb. The
-     left gutter is what makes the focus-visible outline (2px wide at
-     2px offset → extends 4px outside the row's box) visible on the left
-     edge of the active row — without it the outline gets clipped against
-     the sidebar's left wall and the selected row reads as missing a side. */
-  padding-inline: 4px;
+  /* Asymmetric gutters. Left (4px) keeps the focus-visible outline
+     (2px wide at 2px offset → extends 4px outside the row's box) clear
+     of the sidebar's left wall — without it the outline clips and the
+     active row reads as missing a side. Right (8px) holds row content —
+     and the per-directory launchpad (+) button on directory headers —
+     well clear of the native scrollbar thumb that lives in the reserved
+     gutter, so the auto-hiding bar never visually kisses the + button
+     when it appears. (Bumped from 4px after the thumb read as crowding
+     the launchpad button.) */
+  padding-inline: 4px 8px;
   scrollbar-width: thin;
   scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
   /* Finder-style scrollbar gutter (sidebar-tightening pass): reserve
@@ -2250,9 +2252,9 @@ textarea,
   min-height: 0;
   overflow-y: auto;
   padding-top: 0;
-  /* Mirrors `.sidebar-list--dense` — see that block for the gutter
-     rationale. */
-  padding-inline: 4px;
+  /* Mirrors `.sidebar-list--dense` — see that block for the asymmetric
+     gutter rationale (4px left / 8px right for scrollbar clearance). */
+  padding-inline: 4px 8px;
   scrollbar-width: thin;
   scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
   scrollbar-gutter: stable;
@@ -3337,7 +3339,15 @@ textarea,
 }
 
 .directory-row__threads {
+  /* Mirror the 8px left inset on the right so the sticky directory
+     header (which spans the full `.directory-row` width) covers a
+     selected row's accent border with the same 8px overlap on both
+     edges. Without the right inset the row's right border aligned
+     exactly with the header's right edge, so a 1px orange sliver
+     leaked through when a selected row scrolled under the pinned
+     header. */
   padding-left: 8px;
+  padding-right: 8px;
 }
 
 .directory-row__thread-divider {


### PR DESCRIPTION
## Summary

Two small polish fixes to the sidebar's right edge, both reported from the Directories lens. Net change is 3 values in [app.css](apps/desktop/src/renderer/src/styles/app.css).

- **Sticky-header selection coverage.** `.directory-row__threads` only inset its rows on the left (8px), so a selected row's right accent border aligned exactly with the full-width sticky directory header's right edge — a 1px orange sliver leaked through when the row scrolled under the pinned header. The right inset now mirrors the left (8px) so the header covers the border with the same cushion on both edges.
- **Scrollbar clearance.** The native auto-hiding scrollbar's thumb sat nearly flush against the per-directory launchpad (`+`) button. The scroll containers' right gutter widens from 4px to 8px (`padding-inline: 4px 8px` on `.sidebar-list--dense` / `.directory-groups`) so the bar clears the `+` button and row content when it appears.

**Deliberately minimal:** an earlier draft swapped the whole scrollbar mechanism (native auto-hide → an always-visible custom `::-webkit-scrollbar` pill in a wide lane). That delivered a nicer "floating in a gutter" look but added permanent visual furniture nobody asked for, plus a cross-platform / consistency / token-hygiene tail. This version keeps the original native auto-hiding scrollbar — calmer, and the only thing that actually changes is how far the thumb sits from the `+`.

## Verification

- `pnpm test apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx` → 104 passed. (The theme-contract `scrollbar-gutter` assertions target the transcript code/quote blocks, not the sidebar scrollers.)
- The sticky-header coverage fix was confirmed live (selected row scrolled behind the header, no sliver) — it's unchanged here.
- The 8px right gutter is a reasoned, monotonic bump on the *unchanged* native scrollbar (more padding → more thumb clearance); it wasn't separately re-eyeballed in this minimal form. The value is trivially tunable if it wants to be a touch more or less.

## Notes

- CSS-only, scoped to three declarations; fully reversible. No token changes, no raw color literals.
- Scrollbar behavior is unchanged from `main` (native, auto-hiding) — only its distance from the `+` button changes.
- Committed README/docs-site screenshots are visually unaffected by an 8px gutter shift; not regenerated.
