### PR TITLE
fix(desktop): pause wakeup sampling during CPU profiles

### DIFF
--- a/apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts
@@ -354,12 +354,16 @@ describe("RendererHotCpuProfiler", () => {
       await vi.waitFor(() => expect(debuggerApi.detach).toHaveBeenCalled());
 
       await vi.advanceTimersByTimeAsync(config.intervalMs);
-      expect(getAppMetrics).toHaveBeenCalledTimes(4);
+      await vi.waitFor(() => expect(getAppMetrics).toHaveBeenCalledTimes(4));
 
-      const samples = (await fs.readFile(sessionResult.session.samplesPath, "utf8"))
-        .trim()
-        .split("\n")
-        .map((line) => JSON.parse(line));
+      let samples: Array<Record<string, unknown>> = [];
+      await vi.waitFor(async () => {
+        samples = (await fs.readFile(sessionResult.session.samplesPath, "utf8"))
+          .trim()
+          .split("\n")
+          .map((line) => JSON.parse(line));
+        expect(samples).toHaveLength(4);
+      });
       expect(samples.at(-1)).toMatchObject({
         cpuPercent: 0,
         cumulativeCpuSeconds: 110,

--- a/apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts
@@ -286,6 +286,80 @@ describe("RendererHotCpuProfiler", () => {
     expect(stopResolved).toBe(true);
   });
 
+  it("pauses process metric sampling while the renderer CPU profiler is active", async () => {
+    const workspace = await createTemporaryTestDirectory();
+    cleanups.push(workspace.cleanup);
+
+    const config = createEnabledConfig(workspace.path, {
+      PWRAGENT_HOT_CPU_PROFILING_START_DELAY_MS: "0",
+      PWRAGENT_HOT_CPU_PROFILING_DURATION_MS: "10000",
+      PWRAGENT_HOT_CPU_PROFILING_MAX_PROFILES: "1",
+    });
+    const sessionResult = await createHotCpuProfileSession({
+      config,
+      createdAt: new Date(2026, 5, 1, 15, 30, 0),
+      sessionId: "abc123",
+      versions: {
+        appVersion: "1.0.0",
+        electronVersion: "41.2.1",
+        chromeVersion: "146.0.0.0",
+        nodeVersion: "24.0.0",
+      },
+    });
+    expect(sessionResult.ok).toBe(true);
+    if (!sessionResult.ok) return;
+
+    vi.useFakeTimers();
+
+    const { target, debuggerApi } = createTarget();
+    let nowCallCount = 0;
+    const metrics = [
+      createMetric(0, 100),
+      createMetric(4, 100.5),
+      createMetric(4, 101),
+      createMetric(0, 101),
+    ];
+    const getAppMetrics = vi.fn(() => [metrics.shift() ?? createMetric(0, 101)]);
+    const profiler = new RendererHotCpuProfiler({
+      config,
+      getAppMetrics,
+      session: sessionResult.session,
+      target,
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+      now: () => new Date(1_780_000_000_000 + nowCallCount++ * 5),
+    });
+
+    try {
+      await profiler.start();
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.waitFor(() => expect(getAppMetrics).toHaveBeenCalledTimes(1));
+      await vi.advanceTimersByTimeAsync(config.intervalMs);
+      await vi.waitFor(() => expect(getAppMetrics).toHaveBeenCalledTimes(2));
+      await vi.advanceTimersByTimeAsync(config.intervalMs);
+      await vi.waitFor(() => expect(debuggerApi.attach).toHaveBeenCalledWith("1.3"));
+
+      expect(debuggerApi.sendCommand).toHaveBeenCalledWith("Profiler.start");
+      expect(getAppMetrics).toHaveBeenCalledTimes(3);
+
+      await vi.advanceTimersByTimeAsync(config.intervalMs * 4);
+      expect(getAppMetrics).toHaveBeenCalledTimes(3);
+      expect(debuggerApi.sendCommand).not.toHaveBeenCalledWith("Profiler.stop");
+
+      await vi.runOnlyPendingTimersAsync();
+      expect(debuggerApi.sendCommand).toHaveBeenCalledWith("Profiler.stop");
+      await vi.waitFor(() => expect(debuggerApi.detach).toHaveBeenCalled());
+
+      await vi.advanceTimersByTimeAsync(config.intervalMs);
+      expect(getAppMetrics).toHaveBeenCalledTimes(4);
+    } finally {
+      await profiler.stop("test-complete");
+    }
+  });
+
   it("waits for the configured delay before sampling", async () => {
     const workspace = await createTemporaryTestDirectory();
     cleanups.push(workspace.cleanup);

--- a/apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts
@@ -317,7 +317,7 @@ describe("RendererHotCpuProfiler", () => {
       createMetric(0, 100),
       createMetric(4, 100.5),
       createMetric(4, 101),
-      createMetric(0, 101),
+      createMetric(0, 110),
     ];
     const getAppMetrics = vi.fn(() => [metrics.shift() ?? createMetric(0, 101)]);
     const profiler = new RendererHotCpuProfiler({
@@ -355,6 +355,18 @@ describe("RendererHotCpuProfiler", () => {
 
       await vi.advanceTimersByTimeAsync(config.intervalMs);
       expect(getAppMetrics).toHaveBeenCalledTimes(4);
+
+      const samples = (await fs.readFile(sessionResult.session.samplesPath, "utf8"))
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+      expect(samples.at(-1)).toMatchObject({
+        cpuPercent: 0,
+        cumulativeCpuSeconds: 110,
+        electronCpuPercent: 0,
+      });
+      expect(samples.at(-1)).not.toHaveProperty("cumulativeCpuDeltaSeconds");
+      expect(samples.at(-1)).not.toHaveProperty("wallDeltaSeconds");
     } finally {
       await profiler.stop("test-complete");
     }

--- a/apps/desktop/src/main/diagnostics/renderer-hot-cpu-profiler.ts
+++ b/apps/desktop/src/main/diagnostics/renderer-hot-cpu-profiler.ts
@@ -507,6 +507,8 @@ export class RendererHotCpuProfiler {
     }
 
     this.samplingPausedForProfile = false;
+    this.previousCumulativeCpuSeconds = null;
+    this.previousSampleAtMs = null;
     if (this.stopped || this.intervalTimer || this.isTargetDestroyed()) {
       return;
     }

--- a/apps/desktop/src/main/diagnostics/renderer-hot-cpu-profiler.ts
+++ b/apps/desktop/src/main/diagnostics/renderer-hot-cpu-profiler.ts
@@ -90,6 +90,7 @@ export class RendererHotCpuProfiler {
   private profileCount = 0;
   private stopProfilePromise: Promise<void> | null = null;
   private profiling = false;
+  private samplingPausedForProfile = false;
   private activeProfileTrigger: ActiveProfileTrigger | null = null;
   private activeProfileHeapSnapshots: HotCpuProfileHeapSnapshotArtifact[] = [];
   private stopped = false;
@@ -249,7 +250,11 @@ export class RendererHotCpuProfiler {
       });
       this.logger.error("[pwragent:hot-cpu] sample failed", error);
     } finally {
-      this.scheduleNextSample();
+      if (!this.profiling) {
+        this.scheduleNextSample();
+      } else {
+        this.samplingPausedForProfile = true;
+      }
     }
   }
 
@@ -492,7 +497,21 @@ export class RendererHotCpuProfiler {
       this.activeProfileTrigger = null;
       this.activeProfileHeapSnapshots = [];
       this.detachDebugger();
+      this.resumeSamplingAfterProfile();
     }
+  }
+
+  private resumeSamplingAfterProfile(): void {
+    if (!this.samplingPausedForProfile) {
+      return;
+    }
+
+    this.samplingPausedForProfile = false;
+    if (this.stopped || this.intervalTimer || this.isTargetDestroyed()) {
+      return;
+    }
+
+    this.scheduleNextSample();
   }
 
   private async captureHeapSnapshot(index: number, phase: string): Promise<void> {

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -35,7 +35,10 @@ import { TranscriptReview } from "./TranscriptReview";
 import { TranscriptWorkPhaseGroup } from "./TranscriptWorkPhaseGroup";
 import type { PendingQuestionnaireState } from "./questionnaire";
 import type { PendingMcpInteractionState } from "./mcp-elicitation";
-import { buildTranscriptRenderItems } from "./transcript-render-items";
+import {
+  ACTIVE_WORK_GROUP_THRESHOLD_MS,
+  buildTranscriptRenderItems,
+} from "./transcript-render-items";
 
 type TranscriptViewport = {
   distanceFromBottom: number;
@@ -479,13 +482,34 @@ export function TranscriptList(props: TranscriptListProps) {
       return undefined;
     }
 
-    const interval = window.setInterval(() => {
+    const activeTurnStartedAt =
+      typeof props.activeTurnStartedAt === "number"
+        ? props.activeTurnStartedAt
+        : transcriptEntries.find((entry) => entry.turn?.id === props.activeTurnId)
+            ?.turn?.startedAt;
+    if (typeof activeTurnStartedAt !== "number") {
+      return undefined;
+    }
+
+    const firstEligibleAt =
+      activeTurnStartedAt + ACTIVE_WORK_GROUP_THRESHOLD_MS + 1;
+    const delayMs = Math.max(firstEligibleAt - Date.now(), 0);
+    if (delayMs === 0) {
+      setRenderNow((current) =>
+        current > activeTurnStartedAt + ACTIVE_WORK_GROUP_THRESHOLD_MS
+          ? current
+          : Date.now()
+      );
+      return undefined;
+    }
+
+    const timeout = window.setTimeout(() => {
       setRenderNow(Date.now());
-    }, 1000);
+    }, delayMs);
     return () => {
-      window.clearInterval(interval);
+      window.clearTimeout(timeout);
     };
-  }, [props.activeTurnId]);
+  }, [props.activeTurnId, props.activeTurnStartedAt, transcriptEntries]);
 
   const toggleCommentaryGroup = useCallback((groupId: string) => {
     setExpandedCommentaryGroupIds((current) => {
@@ -848,6 +872,7 @@ export function TranscriptList(props: TranscriptListProps) {
             const body =
               item.type === "workPhaseGroup" ? (
                 <TranscriptWorkPhaseGroup
+                  activeStartedAt={item.activeStartedAt}
                   applications={props.applications}
                   collapsible={item.collapsible}
                   directoryPaths={props.directoryPaths}

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -482,14 +482,15 @@ export function TranscriptList(props: TranscriptListProps) {
       return undefined;
     }
 
-    const activeTurnStartedAt =
-      typeof props.activeTurnStartedAt === "number"
-        ? props.activeTurnStartedAt
-        : transcriptEntries.find((entry) => entry.turn?.id === props.activeTurnId)
-            ?.turn?.startedAt;
-    if (typeof activeTurnStartedAt !== "number") {
+    const activeTurnStartedAtCandidates = [
+      props.activeTurnStartedAt,
+      transcriptEntries.find((entry) => entry.turn?.id === props.activeTurnId)
+        ?.turn?.startedAt,
+    ].filter((value): value is number => typeof value === "number");
+    if (activeTurnStartedAtCandidates.length === 0) {
       return undefined;
     }
+    const activeTurnStartedAt = Math.min(...activeTurnStartedAtCandidates);
 
     const firstEligibleAt =
       activeTurnStartedAt + ACTIVE_WORK_GROUP_THRESHOLD_MS + 1;

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptWorkPhaseGroup.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptWorkPhaseGroup.tsx
@@ -1,4 +1,4 @@
-import { memo, useId } from "react";
+import { memo, useEffect, useId, useState } from "react";
 import type {
   AppServerSkillSummary,
   AppServerThreadEntry,
@@ -10,8 +10,10 @@ import { TranscriptActivity } from "./TranscriptActivity";
 import { TranscriptMessage } from "./TranscriptMessage";
 import { TranscriptPlan } from "./TranscriptPlan";
 import { TranscriptReview } from "./TranscriptReview";
+import { formatElapsedMs } from "./transcript-render-items";
 
 type TranscriptWorkPhaseGroupProps = {
+  activeStartedAt?: number;
   applications?: DesktopApplicationsSnapshot;
   collapsible: boolean;
   directoryPaths?: string[];
@@ -40,13 +42,23 @@ export const TranscriptWorkPhaseGroup = memo(function TranscriptWorkPhaseGroup(
           aria-expanded={props.expanded}
           onClick={props.onToggle}
         >
-          <span>{props.label}</span>
+          <span>
+            <TranscriptWorkPhaseGroupLabel
+              activeStartedAt={props.activeStartedAt}
+              label={props.label}
+            />
+          </span>
           <span className="transcript-work-phase-group__chevron" aria-hidden="true">
             {props.expanded ? "^" : "v"}
           </span>
         </button>
       ) : (
-        <div className="transcript-work-phase-group__label">{props.label}</div>
+        <div className="transcript-work-phase-group__label">
+          <TranscriptWorkPhaseGroupLabel
+            activeStartedAt={props.activeStartedAt}
+            label={props.label}
+          />
+        </div>
       )}
       {shouldRenderContent ? (
         <div id={hiddenRegionId} className="transcript-work-phase-group__content">
@@ -67,6 +79,33 @@ export const TranscriptWorkPhaseGroup = memo(function TranscriptWorkPhaseGroup(
 });
 
 TranscriptWorkPhaseGroup.displayName = "TranscriptWorkPhaseGroup";
+
+function TranscriptWorkPhaseGroupLabel(props: {
+  activeStartedAt?: number;
+  label: string;
+}) {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (typeof props.activeStartedAt !== "number") {
+      return undefined;
+    }
+
+    setNow(Date.now());
+    const interval = window.setInterval(() => {
+      setNow(Date.now());
+    }, 1000);
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, [props.activeStartedAt]);
+
+  if (typeof props.activeStartedAt !== "number") {
+    return props.label;
+  }
+
+  return `Working for ${formatElapsedMs(now - props.activeStartedAt)}`;
+}
 
 function renderEntry(params: {
   applications?: DesktopApplicationsSnapshot;

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -1207,7 +1207,7 @@ describe("TranscriptList", () => {
     expect(laterActivityIndex).toBeGreaterThan(commentaryIndex);
   });
 
-  it("waits until the active work threshold before ticking elapsed labels", () => {
+  it("waits until the earliest active work threshold before ticking elapsed labels", () => {
     vi.useFakeTimers();
     vi.setSystemTime(10_000);
     const setIntervalSpy = vi.spyOn(window, "setInterval");
@@ -1221,7 +1221,7 @@ describe("TranscriptList", () => {
     render(
       <TranscriptList
         activeTurnId="turn-1"
-        activeTurnStartedAt={10_000}
+        activeTurnStartedAt={20_000}
         entries={[
           {
             type: "activity",

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildAutomationCardActivityEntries } from "../automation-card-entries";
 import { TranscriptList } from "../TranscriptList";
@@ -118,6 +118,7 @@ describe("TranscriptList", () => {
   afterEach(() => {
     cleanup();
     vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   it("renders messaging binding transitions without transcript history", () => {
@@ -1204,6 +1205,55 @@ describe("TranscriptList", () => {
     expect(changedIndex).toBeGreaterThan(firstActivityIndex);
     expect(commentaryIndex).toBeGreaterThan(changedIndex);
     expect(laterActivityIndex).toBeGreaterThan(commentaryIndex);
+  });
+
+  it("waits until the active work threshold before ticking elapsed labels", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+    const setIntervalSpy = vi.spyOn(window, "setInterval");
+    const setTimeoutSpy = vi.spyOn(window, "setTimeout");
+    const activeTurn = {
+      id: "turn-1",
+      status: "in_progress" as const,
+      startedAt: 10_000,
+    };
+
+    render(
+      <TranscriptList
+        activeTurnId="turn-1"
+        activeTurnStartedAt={10_000}
+        entries={[
+          {
+            type: "activity",
+            id: "activity-1",
+            summary: "Read one file",
+            details: [],
+            turn: activeTurn,
+          },
+        ]}
+        loading={false}
+        loadingMore={false}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(screen.queryByText(/Working for/)).not.toBeInTheDocument();
+    expect(setIntervalSpy).not.toHaveBeenCalled();
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 60_001);
+
+    act(() => {
+      vi.advanceTimersByTime(60_001);
+    });
+
+    expect(screen.getByText("Working for 1m 00s")).toBeInTheDocument();
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 1000);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(screen.getByText("Working for 1m 01s")).toBeInTheDocument();
   });
 
   it("keeps just-finished live tool activity reachable when the final message arrives", async () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts
@@ -148,6 +148,7 @@ describe("buildTranscriptRenderItems", () => {
       { type: "entry", entry: first },
       {
         type: "workPhaseGroup",
+        activeStartedAt: 1_000,
         id: "work:turn-1:active",
         collapsible: false,
         entries: [activity],
@@ -179,6 +180,7 @@ describe("buildTranscriptRenderItems", () => {
     expect(items).toEqual([
       {
         type: "workPhaseGroup",
+        activeStartedAt: 1_000,
         id: "work:turn-1:active",
         collapsible: false,
         entries: [activity],
@@ -228,6 +230,7 @@ describe("buildTranscriptRenderItems", () => {
       { type: "entry", entry: oldFinal },
       {
         type: "workPhaseGroup",
+        activeStartedAt: 1_000,
         id: "work:turn-2:active",
         collapsible: false,
         entries: [activeActivity],
@@ -324,6 +327,7 @@ describe("buildTranscriptRenderItems", () => {
       { type: "entry", entry: answer },
       {
         type: "workPhaseGroup",
+        activeStartedAt: 1_000,
         id: "work:turn-1:active",
         collapsible: false,
         entries: [secondActivity],

--- a/apps/desktop/src/renderer/src/features/thread-detail/transcript-render-items.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/transcript-render-items.ts
@@ -13,11 +13,14 @@ export type TranscriptRenderItem =
     }
   | {
       type: "workPhaseGroup";
+      activeStartedAt?: number;
       id: string;
       collapsible: boolean;
       entries: AppServerThreadEntry[];
       label: string;
     };
+
+export const ACTIVE_WORK_GROUP_THRESHOLD_MS = 60_000;
 
 export function buildTranscriptRenderItems(params: {
   entries: AppServerThreadEntry[];
@@ -64,6 +67,7 @@ export function buildTranscriptRenderItems(params: {
 }
 
 type RenderGroup = {
+  activeStartedAt?: number;
   collapsible: boolean;
   entries: AppServerThreadEntry[];
   id: string;
@@ -84,7 +88,10 @@ function buildActiveWorkGroups(
     startedAtCandidates.length > 0 ? Math.min(...startedAtCandidates) : undefined;
   const elapsedMs =
     typeof startedAt === "number" ? Math.max(now - startedAt, 0) : undefined;
-  if (typeof elapsedMs !== "number" || elapsedMs <= 60_000) {
+  if (
+    typeof elapsedMs !== "number" ||
+    elapsedMs <= ACTIVE_WORK_GROUP_THRESHOLD_MS
+  ) {
     return [];
   }
 
@@ -103,6 +110,7 @@ function buildActiveWorkGroups(
 
   return [
     {
+      activeStartedAt: startedAt,
       collapsible: false,
       entries: activeEntries,
       id: `work:${activeTurnId}:active`,


### PR DESCRIPTION
## Summary

- I found that hot CPU diagnostics were still sampling `app.getAppMetrics()` while Chrome DevTools CPU profiling was attached to the same renderer, so the profiler's own activity could appear as renderer idle wakeups in `samples.ndjson`.
- I pause process metric sampling for the active CPU profile window, reset the cumulative CPU baseline, and resume after `Profiler.stop`, leaving the `.cpuprofile` as the source of truth for that interval without contaminating wakeup or CPU samples.
- After a fresh Kimi-thread capture showed real pre-profile transcript render bursts, I moved the active work elapsed timer out of `TranscriptList` so the whole transcript list no longer re-renders once per second just to update the "Working for ..." label.
- I added regression coverage that proves process metrics are not sampled while profiling is active and the first resumed sample does not compute a CPU delta across profiler overhead.

## Verification

- I ran `pnpm test apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts`.
- I ran `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts`.
- I ran `pnpm --filter @pwragent/desktop exec tsc --noEmit`.
- I ran `git diff --check`.
- I ran `pnpm lint:boundaries`.

## Notes

- The diagnostic change still leaves `.cpuprofile` capture behavior unchanged; the renderer follow-up only changes where the live elapsed label timer runs.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5_Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
