### PR TITLE
fix(desktop): keep hot CPU handoff reliable and compact

### DIFF
--- a/apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts
@@ -576,6 +576,112 @@ describe("RendererHotCpuProfiler", () => {
     );
   });
 
+  it("waits for an in-flight heap snapshot before handing off profile artifacts", async () => {
+    const workspace = await createTemporaryTestDirectory();
+    cleanups.push(workspace.cleanup);
+
+    const config = createEnabledConfig(workspace.path, {
+      PWRAGENT_HOT_CPU_PROFILING_DURATION_MS: "1000",
+      PWRAGENT_HOT_CPU_PROFILING_HEAP_SNAPSHOT: "1",
+      PWRAGENT_HOT_CPU_PROFILING_HEAP_SNAPSHOT_LIMIT: "3",
+    });
+    const sessionResult = await createHotCpuProfileSession({
+      config,
+      createdAt: new Date(2026, 5, 1, 15, 30, 0),
+      sessionId: "abc123",
+      versions: {
+        appVersion: "1.0.0",
+        electronVersion: "41.2.1",
+        chromeVersion: "146.0.0.0",
+        nodeVersion: "24.0.0",
+      },
+    });
+    expect(sessionResult.ok).toBe(true);
+    if (!sessionResult.ok) return;
+
+    const midSnapshot = deferred();
+    const { target, debuggerApi } = createTarget();
+    target.takeHeapSnapshot.mockImplementation(async (filePath: string) => {
+      if (filePath.includes("-mid.")) {
+        await midSnapshot.promise;
+      }
+    });
+    const onProfileWritten = vi.fn();
+    const profiler = new RendererHotCpuProfiler({
+      config,
+      getAppMetrics: () => [createMetric(89)],
+      onProfileWritten,
+      session: sessionResult.session,
+      target,
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+    });
+
+    await (
+      profiler as unknown as {
+        startProfile: (options: {
+          capturedAt: string;
+          cpuPercent: number;
+          pid: number;
+        }) => Promise<void>;
+      }
+    ).startProfile({
+      capturedAt: new Date().toISOString(),
+      cpuPercent: 89,
+      pid: 1234,
+    });
+
+    const midCapture = (
+      profiler as unknown as {
+        captureHeapSnapshot: (index: number, phase: string) => Promise<void>;
+      }
+    ).captureHeapSnapshot(1, "mid");
+    await vi.waitFor(() => {
+      expect(target.takeHeapSnapshot).toHaveBeenCalledTimes(2);
+    });
+
+    const stopProfile = (
+      profiler as unknown as { stopProfile: (reason: string) => Promise<void> }
+    ).stopProfile("duration-elapsed");
+    await vi.waitFor(() => {
+      expect(debuggerApi.sendCommand).toHaveBeenCalledWith("Profiler.stop");
+    });
+
+    expect(target.takeHeapSnapshot).toHaveBeenCalledTimes(2);
+    expect(onProfileWritten).not.toHaveBeenCalled();
+
+    midSnapshot.resolve();
+    await Promise.all([midCapture, stopProfile]);
+
+    expect(target.takeHeapSnapshot).toHaveBeenCalledTimes(3);
+    expect(onProfileWritten).toHaveBeenCalledWith(
+      expect.objectContaining({
+        heapSnapshotArtifacts: [
+          {
+            filename: "renderer-hot-0001-start.heapsnapshot",
+            path: sessionResult.session.createHeapSnapshotPath(1, "start"),
+            phase: "start",
+          },
+          {
+            filename: "renderer-hot-0001-mid.heapsnapshot",
+            path: sessionResult.session.createHeapSnapshotPath(1, "mid"),
+            phase: "mid",
+          },
+          {
+            filename: "renderer-hot-0001-stop.heapsnapshot",
+            path: sessionResult.session.createHeapSnapshotPath(1, "stop"),
+            phase: "stop",
+          },
+        ],
+        profileFilename: "renderer-hot-0001.cpuprofile",
+        profilePath: sessionResult.session.createProfilePath(1),
+      }),
+    );
+  });
+
   it("does not schedule heap or duration timers after being stopped during the start heap snapshot", async () => {
     const workspace = await createTemporaryTestDirectory();
     cleanups.push(workspace.cleanup);
@@ -628,8 +734,12 @@ describe("RendererHotCpuProfiler", () => {
       expect(target.takeHeapSnapshot).toHaveBeenCalledTimes(1);
     });
 
-    await profiler.stop("settings-disabled");
+    const stopProfiler = profiler.stop("settings-disabled");
+    await vi.waitFor(() => {
+      expect(debuggerApi.sendCommand).toHaveBeenCalledWith("Profiler.stop");
+    });
     startSnapshot.resolve();
+    await stopProfiler;
     await new Promise((resolve) =>
       setTimeout(resolve, config.profileDurationMs * 2),
     );

--- a/apps/desktop/src/main/diagnostics/renderer-hot-cpu-profiler.ts
+++ b/apps/desktop/src/main/diagnostics/renderer-hot-cpu-profiler.ts
@@ -92,6 +92,7 @@ export class RendererHotCpuProfiler {
   private profiling = false;
   private activeProfileTrigger: ActiveProfileTrigger | null = null;
   private activeProfileHeapSnapshots: HotCpuProfileHeapSnapshotArtifact[] = [];
+  private activeProfileHeapSnapshotCaptures = new Set<Promise<void>>();
   private stopped = false;
 
   constructor(options: {
@@ -466,8 +467,10 @@ export class RendererHotCpuProfiler {
         this.config.captureHeapSnapshot &&
         this.target.takeHeapSnapshot
       ) {
+        await this.drainActiveHeapSnapshotCaptures();
         await this.captureHeapSnapshot(index, "stop");
       }
+      await this.drainActiveHeapSnapshotCaptures();
       await this.onProfileWritten?.({
         capturedAt: this.now().toISOString(),
         heapSnapshotArtifacts: [...this.activeProfileHeapSnapshots],
@@ -491,11 +494,25 @@ export class RendererHotCpuProfiler {
     } finally {
       this.activeProfileTrigger = null;
       this.activeProfileHeapSnapshots = [];
+      this.activeProfileHeapSnapshotCaptures.clear();
       this.detachDebugger();
     }
   }
 
   private async captureHeapSnapshot(index: number, phase: string): Promise<void> {
+    const capture = this.writeHeapSnapshot(index, phase);
+    if (index === this.profileCount) {
+      this.activeProfileHeapSnapshotCaptures.add(capture);
+    }
+
+    try {
+      await capture;
+    } finally {
+      this.activeProfileHeapSnapshotCaptures.delete(capture);
+    }
+  }
+
+  private async writeHeapSnapshot(index: number, phase: string): Promise<void> {
     if (!this.target.takeHeapSnapshot) {
       return;
     }
@@ -558,6 +575,12 @@ export class RendererHotCpuProfiler {
       if (this.heapSnapshotsCaptured >= this.config.heapSnapshotLimit) {
         await this.notifyHeapSnapshotLimitReached();
       }
+    }
+  }
+
+  private async drainActiveHeapSnapshotCaptures(): Promise<void> {
+    while (this.activeProfileHeapSnapshotCaptures.size > 0) {
+      await Promise.all([...this.activeProfileHeapSnapshotCaptures]);
     }
   }
 

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -208,15 +208,22 @@ function DesktopAppShell(props: {
 
   useEffect(() => {
     return desktopApi?.onHotCpuProfileCaptured?.((event) => {
+      const heapSnapshotCount = event.heapSnapshotArtifacts?.length ?? 0;
+      const heapSnapshotSummary =
+        heapSnapshotCount > 0
+          ? ` ${heapSnapshotCount} heap snapshots captured.`
+          : "";
       setHotCpuProfileNotice({
         autoDismiss: false,
+        copyText: buildHotCpuProfileHandoffMessage(event),
+        detail: `Session: ${event.sessionDirectoryName}`,
         id: `hot-cpu-profile:${event.capturedAt}:${event.profileFilename}`,
         title: "CPU profile captured",
         message: [
           `${formatHotCpuProfileTriggerSummary(event)} saved ${event.profileFilename}.`,
-          "Copy this notice to hand off the profile path.",
-        ].join(" "),
-        detail: buildHotCpuProfileHandoffMessage(event),
+          heapSnapshotSummary,
+          " Copy this notice to hand off the profile path.",
+        ].join(""),
       });
     });
   }, [desktopApi]);

--- a/apps/desktop/src/renderer/src/features/notifications/AppNoticeToast.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/AppNoticeToast.tsx
@@ -11,6 +11,7 @@ export type AppNoticeToastNotice = {
   title: string;
   message: string;
   detail?: string;
+  copyText?: string;
 };
 
 export function AppNoticeToast(props: {
@@ -57,9 +58,11 @@ export function AppNoticeToast(props: {
     return null;
   }
 
-  const copyValue = [props.notice.title, props.notice.message, props.notice.detail]
-    .filter(Boolean)
-    .join("\n");
+  const copyValue =
+    props.notice.copyText ??
+    [props.notice.title, props.notice.message, props.notice.detail]
+      .filter(Boolean)
+      .join("\n");
 
   return (
     <aside

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeToast.test.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeToast.test.tsx
@@ -41,6 +41,33 @@ describe("AppNoticeToast", () => {
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 
+  it("copies an explicit handoff value without rendering it", () => {
+    const copyText = vi.fn(async () => undefined);
+    const handoff = [
+      "PwrAgent captured a renderer CPU profile.",
+      "Heap snapshot start path: /Users/test/.pwragent/diagnostics/renderer-hot-0001-start.heapsnapshot",
+      "Heap snapshot stop path: /Users/test/.pwragent/diagnostics/renderer-hot-0001-stop.heapsnapshot",
+    ].join("\n");
+
+    render(
+      <AppNoticeToast
+        desktopApi={{ copyText }}
+        notice={{
+          ...notice,
+          copyText: handoff,
+          detail: "Session: hot-cpu-2026-06-10-2211-bd972c",
+        }}
+        onDismiss={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Session: hot-cpu-2026-06-10-2211-bd972c")).toBeInTheDocument();
+    expect(screen.queryByText(/Heap snapshot start path/)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy notice" }));
+    expect(copyText).toHaveBeenCalledWith(handoff);
+  });
+
   it("auto-dismisses unless the notice is hovered", () => {
     vi.useFakeTimers();
     const onDismiss = vi.fn();


### PR DESCRIPTION
## Summary

- I fixed hot CPU handoffs so they wait for any in-flight heap snapshot writes before emitting the profile event, which keeps copied diagnostic notices from missing snapshots that finish moments later.
- I also kept the visible renderer toast compact: the copy button still carries the full handoff with paths, but the on-screen notice now shows only the trigger, profile filename, heap snapshot count, and session name.

## Verification

- I ran `pnpm test apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeToast.test.tsx apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts`.

## Notes

- This follows up https://github.com/pwrdrvr/PwrAgent/pull/746 with the review race fix and the toast-size fix found from the latest hot CPU notice.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
