### PR TITLE
fix(desktop): prune dev performance measures

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/dev-performance-pruning.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/dev-performance-pruning.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest";
+import { installDevPerformancePruning } from "../dev-performance-pruning";
+
+function makePerformanceTimeline(params: {
+  markCount: number;
+  measureCount: number;
+}) {
+  return {
+    clearMarks: vi.fn(),
+    clearMeasures: vi.fn(),
+    getEntriesByType: vi.fn((type: string) => {
+      if (type === "measure") {
+        return Array.from({ length: params.measureCount });
+      }
+      if (type === "mark") {
+        return Array.from({ length: params.markCount });
+      }
+      return [];
+    })
+  };
+}
+
+describe("installDevPerformancePruning", () => {
+  it("leaves small user timing buffers alone", () => {
+    const performance = makePerformanceTimeline({
+      markCount: 2,
+      measureCount: 3
+    });
+    const intervalId = 42;
+    const timerApi = {
+      setInterval: vi.fn(() => intervalId),
+      clearInterval: vi.fn()
+    };
+
+    const handle = installDevPerformancePruning({
+      maxMarks: 10,
+      maxMeasures: 10,
+      performance,
+      timerApi
+    });
+
+    expect(handle.prune()).toBe(0);
+    expect(performance.clearMeasures).not.toHaveBeenCalled();
+    expect(performance.clearMarks).not.toHaveBeenCalled();
+
+    handle.stop();
+    expect(timerApi.clearInterval).toHaveBeenCalledWith(intervalId);
+  });
+
+  it("clears marks and measures once either buffer exceeds the cap", () => {
+    const performance = makePerformanceTimeline({
+      markCount: 11,
+      measureCount: 3
+    });
+
+    const handle = installDevPerformancePruning({
+      maxMarks: 10,
+      maxMeasures: 10,
+      performance,
+      timerApi: {
+        setInterval: vi.fn(() => 7),
+        clearInterval: vi.fn()
+      }
+    });
+
+    expect(handle.prune()).toBe(14);
+    expect(performance.clearMeasures).toHaveBeenCalledTimes(1);
+    expect(performance.clearMarks).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/dev-performance-pruning.ts
+++ b/apps/desktop/src/renderer/src/lib/dev-performance-pruning.ts
@@ -1,0 +1,58 @@
+type PerformanceTimeline = Pick<
+  Performance,
+  "clearMarks" | "clearMeasures"
+> & {
+  getEntriesByType: (type: "mark" | "measure") => ArrayLike<unknown>;
+};
+
+type TimerApi = {
+  setInterval: (callback: () => void, intervalMs: number) => unknown;
+  clearInterval: (intervalId: unknown) => void;
+};
+
+export type DevPerformancePruningHandle = {
+  prune: () => number;
+  stop: () => void;
+};
+
+export function installDevPerformancePruning(
+  options: {
+    intervalMs?: number;
+    maxMarks?: number;
+    maxMeasures?: number;
+    performance?: PerformanceTimeline;
+    timerApi?: TimerApi;
+  } = {}
+): DevPerformancePruningHandle {
+  const performanceApi = options.performance ?? window.performance;
+  const timerApi: TimerApi = options.timerApi ?? {
+    setInterval: (callback, intervalMs) => window.setInterval(callback, intervalMs),
+    clearInterval: (intervalId) => {
+      window.clearInterval(intervalId as number);
+    }
+  };
+  const maxMarks = options.maxMarks ?? 10_000;
+  const maxMeasures = options.maxMeasures ?? 10_000;
+
+  const prune = () => {
+    const measureCount = performanceApi.getEntriesByType("measure").length;
+    const markCount = performanceApi.getEntriesByType("mark").length;
+
+    if (measureCount <= maxMeasures && markCount <= maxMarks) {
+      return 0;
+    }
+
+    performanceApi.clearMeasures();
+    performanceApi.clearMarks();
+    return measureCount + markCount;
+  };
+
+  const intervalId = timerApi.setInterval(prune, options.intervalMs ?? 10_000);
+
+  return {
+    prune,
+    stop: () => {
+      timerApi.clearInterval(intervalId);
+    }
+  };
+}

--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -7,10 +7,14 @@ import type {
 import { App } from "./App";
 import { RendererErrorBoundary } from "./features/diagnostics/RendererErrorBoundary";
 import { applyAppearanceAttributes, resolveTheme } from "./lib/appearance";
+import { installDevPerformancePruning } from "./lib/dev-performance-pruning";
 import { installGlobalRendererErrorHandlers } from "./lib/renderer-error-reporting";
 import "./styles/app.css";
 
 installGlobalRendererErrorHandlers();
+const performancePruning = import.meta.env.DEV
+  ? installDevPerformancePruning()
+  : undefined;
 
 // Subscribe to main → renderer appearance broadcasts. Every window
 // (including secondary surfaces like changelog, app-log, license,
@@ -67,6 +71,7 @@ const importMetaHot = (
 if (importMetaHot) {
   importMetaHot.dispose(() => {
     unsubscribeAppearance?.();
+    performancePruning?.stop();
   });
 }
 


### PR DESCRIPTION
## Summary

- Dev renderer sessions no longer keep accumulating React User Timing entries indefinitely; once marks or measures pass the cap, PwrAgent clears them on a short interval.
- HMR disposes the pruning interval when the renderer module reloads, so dev sessions do not stack duplicate cleanup timers.
- I scoped this to Vite dev builds only, leaving packaged production behavior unchanged.

## Verification

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/dev-performance-pruning.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `git diff --check origin/main...HEAD`

## Notes

- This targets the heap captures that showed hundreds of thousands of `PerformanceMeasure` entries from React dev User Timing in long-running dogfood sessions.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-000000)
