### PR TITLE
fix(desktop): materialize transcript data images

### DIFF
--- a/apps/desktop/src/main/__tests__/transcript-image-protocol.test.ts
+++ b/apps/desktop/src/main/__tests__/transcript-image-protocol.test.ts
@@ -1,7 +1,14 @@
-import { mkdtemp, mkdir, realpath, rm, writeFile } from "node:fs/promises";
+import {
+  mkdtemp,
+  mkdir,
+  readFile,
+  realpath,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const protocolHandleMock = vi.fn();
@@ -133,6 +140,121 @@ describe("transcript image protocol", () => {
     });
   });
 
+  it("materializes data image URLs into thread-scoped files before renderer IPC", async () => {
+    const { materializeTranscriptImageUrlsForRenderer } = await import(
+      "../transcript-image-protocol"
+    );
+    const dataUrl = "data:image/png;base64,AQID";
+    const writes: string[] = [];
+
+    const response = await materializeTranscriptImageUrlsForRenderer(
+      {
+        backend: "codex",
+        fetchedAt: 1,
+        threadId: "codex:thread/images",
+        replay: {
+          entries: [
+            {
+              type: "message",
+              id: "entry-1",
+              role: "user",
+              text: "what's in this?",
+              parts: [
+                { type: "text", text: "what's in this?" },
+                { type: "image", url: dataUrl },
+              ],
+            },
+          ],
+          messages: [
+            {
+              id: "message-1",
+              role: "user",
+              text: "what's in this?",
+              parts: [{ type: "image", url: dataUrl }],
+            },
+          ],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      },
+      {
+        resolveRoot: ({ backend, threadId }) =>
+          path.join(
+            tempDir,
+            "thread-images",
+            backend,
+            encodeURIComponent(threadId),
+          ),
+        writeFile: async (filePath, data) => {
+          writes.push(filePath);
+          await writeFile(filePath, data);
+        },
+      }
+    );
+
+    const entryPart = response.replay.entries[0]?.type === "message"
+      ? response.replay.entries[0].parts?.[1]
+      : undefined;
+    const messagePart = response.replay.messages[0]?.parts?.[0];
+    expect(entryPart).toMatchObject({
+      type: "image",
+      url: expect.stringMatching(/^pwragent-image:\/\/file\//),
+    });
+    expect(messagePart).toEqual(entryPart);
+    expect(writes).toHaveLength(1);
+    const materializedPath =
+      entryPart?.type === "image" ? filePathFromProtocolUrl(entryPart.url) : "";
+    expect(materializedPath).toContain(
+      path.join("thread-images", "codex", "codex%3Athread%2Fimages")
+    );
+    expect(path.basename(materializedPath)).toMatch(/^[a-f0-9]{64}\.png$/);
+    await expect(readFile(materializedPath)).resolves.toEqual(Buffer.from([1, 2, 3]));
+  });
+
+  it("leaves unsupported and malformed data image URLs unchanged", async () => {
+    const { materializeTranscriptImageUrlsForRenderer } = await import(
+      "../transcript-image-protocol"
+    );
+    const unsupportedDataUrl = "data:image/svg+xml;base64,PHN2Zy8+";
+    const malformedDataUrl = "data:image/png;base64,!!!!";
+
+    const response = await materializeTranscriptImageUrlsForRenderer(
+      {
+        backend: "codex",
+        fetchedAt: 1,
+        threadId: "thread-images",
+        replay: {
+          entries: [],
+          messages: [
+            {
+              id: "message-1",
+              role: "user",
+              text: "images",
+              parts: [
+                { type: "image", url: unsupportedDataUrl },
+                { type: "image", url: malformedDataUrl },
+              ],
+            },
+          ],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      },
+      {
+        resolveRoot: () => path.join(tempDir, "unused"),
+      }
+    );
+
+    expect(response.replay.messages[0]?.parts).toEqual([
+      { type: "image", url: unsupportedDataUrl },
+      { type: "image", url: malformedDataUrl },
+    ]);
+  });
+
   it("resolves raster images from the default Codex home", async () => {
     const { resolveTranscriptImageProtocolRequest } = await import(
       "../transcript-image-protocol"
@@ -196,4 +318,10 @@ describe("transcript image protocol", () => {
 
 function toProtocolUrl(filePath: string): string {
   return `pwragent-image://file/${encodeURIComponent(pathToFileURL(filePath).toString())}`;
+}
+
+function filePathFromProtocolUrl(protocolUrl: string): string {
+  const parsed = new URL(protocolUrl);
+  const encodedSource = parsed.pathname.replace(/^\//, "");
+  return fileURLToPath(decodeURIComponent(encodedSource));
 }

--- a/apps/desktop/src/main/__tests__/transcript-image-protocol.test.ts
+++ b/apps/desktop/src/main/__tests__/transcript-image-protocol.test.ts
@@ -213,6 +213,46 @@ describe("transcript image protocol", () => {
     await expect(readFile(materializedPath)).resolves.toEqual(Buffer.from([1, 2, 3]));
   });
 
+  it("keeps data image URLs when materialization writes fail", async () => {
+    const { materializeTranscriptImageUrlsForRenderer } = await import(
+      "../transcript-image-protocol"
+    );
+    const dataUrl = "data:image/png;base64,AQID";
+
+    const response = await materializeTranscriptImageUrlsForRenderer(
+      {
+        backend: "codex",
+        fetchedAt: 1,
+        threadId: "thread-images",
+        replay: {
+          entries: [],
+          messages: [
+            {
+              id: "message-1",
+              role: "user",
+              text: "what's in this?",
+              parts: [{ type: "image", url: dataUrl }],
+            },
+          ],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      },
+      {
+        resolveRoot: () => path.join(tempDir, "thread-images"),
+        writeFile: async () => {
+          throw new Error("disk full");
+        },
+      }
+    );
+
+    expect(response.replay.messages[0]?.parts).toEqual([
+      { type: "image", url: dataUrl },
+    ]);
+  });
+
   it("leaves unsupported and malformed data image URLs unchanged", async () => {
     const { materializeTranscriptImageUrlsForRenderer } = await import(
       "../transcript-image-protocol"

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -89,7 +89,7 @@ import {
   disposeDesktopBackendRegistry,
   getDesktopBackendRegistry,
 } from "../app-server/backend-registry";
-import { rewriteTranscriptImageUrlsForRenderer } from "../transcript-image-protocol";
+import { materializeTranscriptImageUrlsForRenderer } from "../transcript-image-protocol";
 import { hydrateLaunchpadCodexEnvironmentOptions } from "../app-server/codex-environment-config";
 import { getDesktopOverlayStore } from "../app-server/desktop-overlay-store";
 import {
@@ -458,7 +458,9 @@ class DesktopAppServerService {
       threadStatus: response.threadStatus ?? response.replay.threadStatus,
     });
 
-    return sanitizeRendererPayload(rewriteTranscriptImageUrlsForRenderer(response));
+    return sanitizeRendererPayload(
+      await materializeTranscriptImageUrlsForRenderer(response),
+    );
   }
 
   async persistThreadUsageActivity(

--- a/apps/desktop/src/main/transcript-image-protocol.ts
+++ b/apps/desktop/src/main/transcript-image-protocol.ts
@@ -207,19 +207,23 @@ async function materializeTranscriptMessagePartImageUrl(
     backend: response.backend,
     threadId: response.threadId,
   });
-  await deps.mkdir(root, { recursive: true });
-  const filePath = path.join(root, `${dataImage.sha256}.${dataImage.extension}`);
-  let writePromise = materializedFileWrites.get(filePath);
-  if (!writePromise) {
-    writePromise = deps.writeFile(filePath, dataImage.buffer).then(() => undefined);
-    materializedFileWrites.set(filePath, writePromise);
-  }
-  await writePromise;
+  try {
+    await deps.mkdir(root, { recursive: true });
+    const filePath = path.join(root, `${dataImage.sha256}.${dataImage.extension}`);
+    let writePromise = materializedFileWrites.get(filePath);
+    if (!writePromise) {
+      writePromise = deps.writeFile(filePath, dataImage.buffer).then(() => undefined);
+      materializedFileWrites.set(filePath, writePromise);
+    }
+    await writePromise;
 
-  return {
-    ...part,
-    url: toTranscriptImageProtocolUrl(pathToFileURL(filePath).toString()),
-  };
+    return {
+      ...part,
+      url: toTranscriptImageProtocolUrl(pathToFileURL(filePath).toString()),
+    };
+  } catch {
+    return part;
+  }
 }
 
 function rewriteTranscriptEntryImageUrls(entry: AppServerThreadEntry): AppServerThreadEntry {

--- a/apps/desktop/src/main/transcript-image-protocol.ts
+++ b/apps/desktop/src/main/transcript-image-protocol.ts
@@ -1,16 +1,18 @@
 import { protocol } from "electron";
 import type {
+  AppServerBackendKind,
   AppServerReadThreadResponse,
   AppServerThreadEntry,
   AppServerThreadMessage,
   AppServerThreadMessageEntry,
   AppServerThreadMessagePart,
 } from "@pwragent/shared";
-import { readFile, realpath, stat } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { mkdir, readFile, realpath, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
-import { resolvePwragentRoot } from "./profile";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { resolveActiveProfilePath, resolvePwragentRoot } from "./profile";
 import { resolveDefaultCodexHome } from "@pwrdrvr/codex-discovery";
 
 export const TRANSCRIPT_IMAGE_PROTOCOL_SCHEME = "pwragent-image";
@@ -25,14 +27,47 @@ const IMAGE_MIME_TYPES = new Map<string, string>([
   [".webp", "image/webp"],
 ]);
 
+const DATA_IMAGE_EXTENSIONS = new Map<string, string>([
+  ["image/avif", "avif"],
+  ["image/bmp", "bmp"],
+  ["image/gif", "gif"],
+  ["image/jpeg", "jpg"],
+  ["image/jpg", "jpg"],
+  ["image/png", "png"],
+  ["image/webp", "webp"],
+]);
+
 export type TranscriptImageProtocolOptions = {
   env?: NodeJS.ProcessEnv;
   homeDir?: string;
 };
 
+export type TranscriptImageMaterializerDependencies = {
+  resolveRoot: (request: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }) => string;
+  mkdir: (dirPath: string, options: { recursive: true }) => Promise<unknown>;
+  writeFile: (filePath: string, data: Buffer) => Promise<unknown>;
+};
+
 export type TranscriptImageFileResolution =
   | { ok: true; path: string; mimeType: string }
   | { ok: false; status: number; message: string };
+
+const defaultMaterializerDependencies: TranscriptImageMaterializerDependencies = {
+  resolveRoot: ({ backend, threadId }) =>
+    resolveActiveProfilePath(
+      path.join(
+        "state",
+        "thread-images",
+        encodePathSegment(backend),
+        encodePathSegment(threadId),
+      ),
+    ),
+  mkdir,
+  writeFile,
+};
 
 export function toTranscriptImageProtocolUrl(src: string): string {
   return `pwragent-image://file/${encodeURIComponent(src)}`;
@@ -51,6 +86,41 @@ export function rewriteTranscriptImageUrlsForRenderer(
   };
 }
 
+export async function materializeTranscriptImageUrlsForRenderer(
+  response: AppServerReadThreadResponse,
+  dependencies: Partial<TranscriptImageMaterializerDependencies> = {},
+): Promise<AppServerReadThreadResponse> {
+  const deps = { ...defaultMaterializerDependencies, ...dependencies };
+  const materializedFileWrites = new Map<string, Promise<void>>();
+
+  return {
+    ...response,
+    replay: {
+      ...response.replay,
+      entries: await Promise.all(
+        response.replay.entries.map((entry) =>
+          materializeTranscriptEntryImageUrls(
+            entry,
+            response,
+            deps,
+            materializedFileWrites,
+          ),
+        ),
+      ),
+      messages: await Promise.all(
+        response.replay.messages.map((message) =>
+          materializeTranscriptMessageImageUrls(
+            message,
+            response,
+            deps,
+            materializedFileWrites,
+          ),
+        ),
+      ),
+    },
+  };
+}
+
 export function registerTranscriptImageProtocolScheme(): void {
   protocol.registerSchemesAsPrivileged([
     {
@@ -62,6 +132,94 @@ export function registerTranscriptImageProtocolScheme(): void {
       },
     },
   ]);
+}
+
+async function materializeTranscriptEntryImageUrls(
+  entry: AppServerThreadEntry,
+  response: AppServerReadThreadResponse,
+  deps: TranscriptImageMaterializerDependencies,
+  materializedFileWrites: Map<string, Promise<void>>,
+): Promise<AppServerThreadEntry> {
+  if (entry.type !== "message") {
+    return entry;
+  }
+
+  return (await materializeTranscriptMessageImageUrls(
+    entry,
+    response,
+    deps,
+    materializedFileWrites,
+  )) as AppServerThreadMessageEntry;
+}
+
+async function materializeTranscriptMessageImageUrls<T extends AppServerThreadMessage>(
+  message: T,
+  response: AppServerReadThreadResponse,
+  deps: TranscriptImageMaterializerDependencies,
+  materializedFileWrites: Map<string, Promise<void>>,
+): Promise<T> {
+  if (
+    !message.parts?.some(
+      (part) => part.type === "image" && isMaterializableImageUrl(part.url),
+    )
+  ) {
+    return message;
+  }
+
+  return {
+    ...message,
+    parts: await Promise.all(
+      message.parts.map((part) =>
+        materializeTranscriptMessagePartImageUrl(
+          part,
+          response,
+          deps,
+          materializedFileWrites,
+        ),
+      ),
+    ),
+  };
+}
+
+async function materializeTranscriptMessagePartImageUrl(
+  part: AppServerThreadMessagePart,
+  response: AppServerReadThreadResponse,
+  deps: TranscriptImageMaterializerDependencies,
+  materializedFileWrites: Map<string, Promise<void>>,
+): Promise<AppServerThreadMessagePart> {
+  if (part.type !== "image") {
+    return part;
+  }
+
+  if (isFileImageUrl(part.url)) {
+    return {
+      ...part,
+      url: toTranscriptImageProtocolUrl(part.url),
+    };
+  }
+
+  const dataImage = parseSupportedImageDataUrl(part.url);
+  if (!dataImage) {
+    return part;
+  }
+
+  const root = deps.resolveRoot({
+    backend: response.backend,
+    threadId: response.threadId,
+  });
+  await deps.mkdir(root, { recursive: true });
+  const filePath = path.join(root, `${dataImage.sha256}.${dataImage.extension}`);
+  let writePromise = materializedFileWrites.get(filePath);
+  if (!writePromise) {
+    writePromise = deps.writeFile(filePath, dataImage.buffer).then(() => undefined);
+    materializedFileWrites.set(filePath, writePromise);
+  }
+  await writePromise;
+
+  return {
+    ...part,
+    url: toTranscriptImageProtocolUrl(pathToFileURL(filePath).toString()),
+  };
 }
 
 function rewriteTranscriptEntryImageUrls(entry: AppServerThreadEntry): AppServerThreadEntry {
@@ -100,6 +258,10 @@ function rewriteTranscriptMessagePartImageUrl(
 
 function isFileImageUrl(url: string): boolean {
   return url.startsWith("file://");
+}
+
+function isMaterializableImageUrl(url: string): boolean {
+  return isFileImageUrl(url) || url.startsWith("data:image/");
 }
 
 export function installTranscriptImageProtocol(): void {
@@ -252,4 +414,37 @@ function isPathInsideRoot(targetPath: string, rootPath: string): boolean {
 
 function mimeTypeForImagePath(filePath: string): string | undefined {
   return IMAGE_MIME_TYPES.get(path.extname(filePath).toLowerCase());
+}
+
+function parseSupportedImageDataUrl(
+  url: string,
+): { buffer: Buffer; extension: string; sha256: string } | undefined {
+  const match = /^data:(image\/[a-z0-9.+-]+);base64,([a-z0-9+/]+={0,2})$/iu.exec(
+    url,
+  );
+  if (!match) {
+    return undefined;
+  }
+
+  const mimeType = match[1]?.toLowerCase();
+  const extension = mimeType ? DATA_IMAGE_EXTENSIONS.get(mimeType) : undefined;
+  const payload = match[2] ?? "";
+  if (!extension || payload.length % 4 === 1) {
+    return undefined;
+  }
+
+  const buffer = Buffer.from(payload, "base64");
+  if (buffer.byteLength === 0) {
+    return undefined;
+  }
+
+  return {
+    buffer,
+    extension,
+    sha256: createHash("sha256").update(buffer).digest("hex"),
+  };
+}
+
+function encodePathSegment(value: string): string {
+  return encodeURIComponent(value);
 }


### PR DESCRIPTION
## Summary

- I fixed legacy transcript image parts that still carried `data:image/...` URLs so supported raster images are decoded into profile-owned thread image files before renderer IPC.
- I reused the existing `pwragent-image://file/...` renderer scheme, preserved the existing `file://` rewrite behavior, and dedupe identical data URLs by SHA under `state/thread-images/<backend>/<threadId>/`.
- I left unsupported or malformed data URLs unchanged and did not add archive cleanup; thread-image retention should be handled by a future hard-delete/purge lifecycle, not archive.

## Verification

- I ran `pnpm test apps/desktop/src/main/__tests__/transcript-image-protocol.test.ts`.
- I ran `pnpm --filter @pwragent/desktop typecheck`.
- I ran `pnpm typecheck`.
- I ran `pnpm lint:boundaries`.
- I ran `pnpm lint:codex-storage`.
- I ran `git diff --check`.

## Notes

- I verified the checkpoint commit is signed.
- No demo artifact is included because this is main-process transcript materialization and renderer heap-retention plumbing rather than a directly visible UI change.

## Post-Deploy Monitoring & Validation

- Watch desktop main-process logs for transcript image protocol failures containing `transcript image` or `pwragent-image`.
- Validate that opening older Codex threads with image parts renders images via `pwragent-image://file/...` without retaining large `data:image/...` strings in renderer heap snapshots.
- Healthy signal: `thread/read` completes normally, image previews continue rendering, and heap snapshots no longer show large transcript image base64 strings retained under renderer message parts.
- Failure signal: older image transcript parts stop rendering, protocol requests return 4xx/5xx unexpectedly, or main-process logs show repeated materialization errors. Roll back this PR if those failures reproduce on legacy image transcripts.
- Validation window: first internal desktop dogfood session that opens older image-heavy Codex threads; owner: PwrDrvr desktop maintainer.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5_Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
