### PR TITLE
fix(desktop): show token usage cost breakdown

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts
@@ -199,9 +199,9 @@ describe("buildTokenUsageActivityEntry", () => {
     );
   });
 
-  it("uses long-context standard rates above 128K input tokens", () => {
+  it("uses standard Codex rates above 128K aggregate input tokens", () => {
     const entry = buildTokenUsageActivityEntry({
-      id: "usage-long-context",
+      id: "usage-large-aggregate",
       model: "gpt-5.5",
       tokenUsage: {
         total: {
@@ -213,23 +213,23 @@ describe("buildTokenUsageActivityEntry", () => {
     });
 
     expect(entry?.details.map((detail) => detail.label)).toContain(
-      "Uncached input cost: 110,000 tokens at $10.00/M = $1.10",
+      "Uncached input cost: 110,000 tokens at $5.00/M = $0.55",
     );
     expect(entry?.details.map((detail) => detail.label)).toContain(
-      "Cached input cost: 20,000 tokens at $1.00/M (0.1x uncached) = $0.020",
+      "Cached input cost: 20,000 tokens at $0.50/M (0.1x uncached) = $0.010",
     );
     expect(entry?.details.map((detail) => detail.label)).toContain(
-      "Output cost: 1,000 tokens at $45.00/M = $0.045",
+      "Output cost: 1,000 tokens at $30.00/M = $0.030",
     );
     expect(entry?.details.at(-1)?.label).toBe(
-      "Cost: $1.17 list price for GPT-5.5 Standard long context",
+      "Cost: $0.59 list price for GPT-5.5 Standard",
     );
   });
 
-  it("does not estimate Fast cost for long-context requests without a Priority price", () => {
+  it("uses Fast priority Codex rates above 128K aggregate input tokens", () => {
     const entry = buildTokenUsageActivityEntry({
       fastMode: true,
-      id: "usage-fast-long-context",
+      id: "usage-fast-large-aggregate",
       model: "gpt-5.5",
       tokenUsage: {
         total: {
@@ -240,9 +240,18 @@ describe("buildTokenUsageActivityEntry", () => {
       },
     });
 
-    expect(entry?.summary).toBe("Usage: 110,000 uncached in · 20,000 cached · 1,000 out");
+    expect(entry?.summary).toBe("Usage: 110,000 uncached in · 20,000 cached · 1,000 out · $1.48 list price");
+    expect(entry?.details.map((detail) => detail.label)).toContain(
+      "Uncached input cost: 110,000 tokens at $12.50/M 2.5x Standard = $1.38",
+    );
+    expect(entry?.details.map((detail) => detail.label)).toContain(
+      "Cached input cost: 20,000 tokens at $1.25/M (0.1x uncached, 2.5x Standard) = $0.025",
+    );
+    expect(entry?.details.map((detail) => detail.label)).toContain(
+      "Output cost: 1,000 tokens at $75.00/M 2.5x Standard = $0.075",
+    );
     expect(entry?.details.at(-1)?.label).toBe(
-      "Cost unavailable: no local pricing entry for gpt-5.5 Fast/Priority long context",
+      "Cost: $1.48 list price for GPT-5.5 Fast (Priority)",
     );
   });
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts
@@ -107,8 +107,67 @@ describe("buildTokenUsageActivityEntry", () => {
       "Uncached input cost: 19,549 tokens at $5.00/M = $0.098",
       "Cached input cost: 2,432 tokens at $0.50/M (0.1x uncached) = $0.002",
       "Output cost: 174 tokens at $30.00/M = $0.006",
-      "Cost: $0.11 list price for gpt-5.5",
+      "Cost: $0.11 list price for GPT-5.5 Standard",
     ]);
+  });
+
+  it("uses Fast priority rates and labels the model variant", () => {
+    const entry = buildTokenUsageActivityEntry({
+      fastMode: true,
+      id: "usage-fast",
+      model: "gpt-5.5",
+      tokenUsage: {
+        total: {
+          inputTokens: 27_697,
+          cachedInputTokens: 10_112,
+          outputTokens: 95,
+        },
+      },
+    });
+
+    expect(entry?.summary).toContain("17,585 uncached in");
+    expect(entry?.summary).toContain("10,112 cached");
+    expect(entry?.summary).toContain("$0.24 list price");
+    expect(entry?.details.map((detail) => detail.label)).toContain(
+      "Uncached input cost: 17,585 tokens at $12.50/M 2.5x Standard = $0.22",
+    );
+    expect(entry?.details.map((detail) => detail.label)).toContain(
+      "Cached input cost: 10,112 tokens at $1.25/M (0.1x uncached, 2.5x Standard) = $0.013",
+    );
+    expect(entry?.details.map((detail) => detail.label)).toContain(
+      "Output cost: 95 tokens at $75.00/M 2.5x Standard = $0.008",
+    );
+    expect(entry?.details.at(-1)?.label).toBe(
+      "Cost: $0.24 list price for GPT-5.5 Fast (Priority)",
+    );
+  });
+
+  it("uses GPT-5.4 Fast priority rates with a 2x standard multiplier", () => {
+    const entry = buildTokenUsageActivityEntry({
+      fastMode: true,
+      id: "usage-fast-54",
+      model: "gpt-5.4",
+      tokenUsage: {
+        total: {
+          inputTokens: 1_000,
+          cachedInputTokens: 200,
+          outputTokens: 100,
+        },
+      },
+    });
+
+    expect(entry?.details.map((detail) => detail.label)).toContain(
+      "Uncached input cost: 800 tokens at $5.00/M 2.0x Standard = $0.004",
+    );
+    expect(entry?.details.map((detail) => detail.label)).toContain(
+      "Cached input cost: 200 tokens at $0.50/M (0.1x uncached, 2.0x Standard) = <$0.001",
+    );
+    expect(entry?.details.map((detail) => detail.label)).toContain(
+      "Output cost: 100 tokens at $30.00/M 2.0x Standard = $0.003",
+    );
+    expect(entry?.details.at(-1)?.label).toBe(
+      "Cost: $0.008 list price for GPT-5.4 Fast (Priority)",
+    );
   });
 
   it("rounds list-price costs below ten cents to tenths of a penny", () => {
@@ -136,7 +195,54 @@ describe("buildTokenUsageActivityEntry", () => {
       "Output cost: 1,000 tokens at $4.50/M = $0.005",
     );
     expect(entry?.details.at(-1)?.label).toBe(
-      "Cost: $0.006 list price for gpt-5.4-mini",
+      "Cost: $0.006 list price for GPT-5.4 mini Standard",
+    );
+  });
+
+  it("uses long-context standard rates above 128K input tokens", () => {
+    const entry = buildTokenUsageActivityEntry({
+      id: "usage-long-context",
+      model: "gpt-5.5",
+      tokenUsage: {
+        total: {
+          inputTokens: 130_000,
+          cachedInputTokens: 20_000,
+          outputTokens: 1_000,
+        },
+      },
+    });
+
+    expect(entry?.details.map((detail) => detail.label)).toContain(
+      "Uncached input cost: 110,000 tokens at $10.00/M = $1.10",
+    );
+    expect(entry?.details.map((detail) => detail.label)).toContain(
+      "Cached input cost: 20,000 tokens at $1.00/M (0.1x uncached) = $0.020",
+    );
+    expect(entry?.details.map((detail) => detail.label)).toContain(
+      "Output cost: 1,000 tokens at $45.00/M = $0.045",
+    );
+    expect(entry?.details.at(-1)?.label).toBe(
+      "Cost: $1.17 list price for GPT-5.5 Standard long context",
+    );
+  });
+
+  it("does not estimate Fast cost for long-context requests without a Priority price", () => {
+    const entry = buildTokenUsageActivityEntry({
+      fastMode: true,
+      id: "usage-fast-long-context",
+      model: "gpt-5.5",
+      tokenUsage: {
+        total: {
+          inputTokens: 130_000,
+          cachedInputTokens: 20_000,
+          outputTokens: 1_000,
+        },
+      },
+    });
+
+    expect(entry?.summary).toBe("Usage: 110,000 uncached in · 20,000 cached · 1,000 out");
+    expect(entry?.details.at(-1)?.label).toBe(
+      "Cost unavailable: no local pricing entry for gpt-5.5 Fast/Priority long context",
     );
   });
 
@@ -156,6 +262,25 @@ describe("buildTokenUsageActivityEntry", () => {
     expect(entry?.summary).toBe("Usage: 80 uncached in · 20 cached · 30 out");
     expect(entry?.details.at(-1)?.label).toBe(
       "Cost unavailable: no local pricing entry for custom-model",
+    );
+  });
+
+  it("does not estimate cost for Codex Spark without a local API price", () => {
+    const entry = buildTokenUsageActivityEntry({
+      id: "usage-spark",
+      model: "gpt-5.3-codex-spark",
+      tokenUsage: {
+        total: {
+          inputTokens: 100,
+          cachedInputTokens: 20,
+          outputTokens: 30,
+        },
+      },
+    });
+
+    expect(entry?.summary).toBe("Usage: 80 uncached in · 20 cached · 30 out");
+    expect(entry?.details.at(-1)?.label).toBe(
+      "Cost unavailable: no local pricing entry for gpt-5.3-codex-spark",
     );
   });
 });
@@ -194,7 +319,7 @@ describe("buildTaskMonitorUsageActivityEntry", () => {
       turn: { id: "monitor:monitor-1" },
     });
     expect(entry?.details.at(-1)?.label).toBe(
-      "Cost: <$0.001 list price for gpt-5.4-mini",
+      "Cost: <$0.001 list price for GPT-5.4 mini Standard",
     );
   });
 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts
@@ -104,6 +104,9 @@ describe("buildTokenUsageActivityEntry", () => {
     expect(entry?.details.map((detail) => detail.label)).toEqual([
       "Input: 21,981 tokens (19,549 uncached, 2,432 cached)",
       "Output: 174 tokens, including 25 reasoning",
+      "Uncached input cost: 19,549 tokens at $5.00/M = $0.098",
+      "Cached input cost: 2,432 tokens at $0.50/M (0.1x uncached) = $0.002",
+      "Output cost: 174 tokens at $30.00/M = $0.006",
       "Cost: $0.11 list price for gpt-5.5",
     ]);
   });
@@ -123,6 +126,15 @@ describe("buildTokenUsageActivityEntry", () => {
 
     expect(entry?.summary).toContain("Usage: 1,000 uncached in");
     expect(entry?.summary).toContain("$0.006 list price");
+    expect(entry?.details.map((detail) => detail.label)).toContain(
+      "Uncached input cost: 1,000 tokens at $0.75/M = <$0.001",
+    );
+    expect(entry?.details.map((detail) => detail.label)).toContain(
+      "Cached input cost: 0 tokens at $0.075/M (0.1x uncached) = $0.000",
+    );
+    expect(entry?.details.map((detail) => detail.label)).toContain(
+      "Output cost: 1,000 tokens at $4.50/M = $0.005",
+    );
     expect(entry?.details.at(-1)?.label).toBe(
       "Cost: $0.006 list price for gpt-5.4-mini",
     );

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts
@@ -246,6 +246,26 @@ describe("buildTokenUsageActivityEntry", () => {
     );
   });
 
+  it("does not estimate unsupported service tiers as Standard", () => {
+    const entry = buildTokenUsageActivityEntry({
+      id: "usage-flex-tier",
+      model: "gpt-5.5",
+      serviceTier: "flex",
+      tokenUsage: {
+        total: {
+          inputTokens: 1_000,
+          cachedInputTokens: 200,
+          outputTokens: 100,
+        },
+      },
+    });
+
+    expect(entry?.summary).toBe("Usage: 800 uncached in · 200 cached · 100 out");
+    expect(entry?.details.at(-1)?.label).toBe(
+      "Cost unavailable: no local pricing entry for gpt-5.5 service tier flex",
+    );
+  });
+
   it("reports unavailable cost without dropping token accounting", () => {
     const entry = buildTokenUsageActivityEntry({
       id: "usage-unknown",

--- a/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
@@ -655,12 +655,19 @@ function estimateUsageCost(params: {
 function resolvePricingServiceTier(params: {
   fastMode?: boolean;
   serviceTier?: string;
-}): "standard" | "priority" {
-  return params.fastMode === true ||
-    params.serviceTier === "fast" ||
-    params.serviceTier === "priority"
-    ? "priority"
-    : "standard";
+}): "standard" | "priority" | undefined {
+  if (params.fastMode === true) {
+    return "priority";
+  }
+
+  const serviceTier = params.serviceTier?.trim().toLowerCase();
+  if (!serviceTier || serviceTier === "default" || serviceTier === "standard") {
+    return "standard";
+  }
+  if (serviceTier === "fast" || serviceTier === "priority") {
+    return "priority";
+  }
+  return undefined;
 }
 
 function resolvePricingContext(inputTokens: number): "short" | "long" {
@@ -755,6 +762,9 @@ function formatUnpricedModelName(params: {
   return [
     params.model,
     serviceTier === "priority" ? "Fast/Priority" : undefined,
+    serviceTier === undefined && params.serviceTier
+      ? `service tier ${params.serviceTier}`
+      : undefined,
     context === "long" ? "long context" : undefined,
   ]
     .filter(Boolean)

--- a/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
@@ -248,7 +248,6 @@ type NormalizedTokenUsage = {
 
 type PricingCatalogEntry = {
   cachedInputUsdPerMillion: number;
-  context: "short" | "long";
   displayModel: string;
   displayTier: string;
   inputUsdPerMillion: number;
@@ -260,7 +259,6 @@ type PricingCatalogEntry = {
 type UsageCostEstimate = {
   cachedInputUsd: number;
   cachedInputUsdPerMillion: number;
-  context: "short" | "long";
   displayName: string;
   inputUsdPerMillion: number;
   model: string;
@@ -280,7 +278,6 @@ const PRICING_CATALOG: readonly PricingCatalogEntry[] = [
     displayModel: "GPT-5.5",
     displayTier: "Standard",
     serviceTier: "standard",
-    context: "short",
     inputUsdPerMillion: 5,
     cachedInputUsdPerMillion: 0.5,
     outputUsdPerMillion: 30,
@@ -288,19 +285,8 @@ const PRICING_CATALOG: readonly PricingCatalogEntry[] = [
   {
     model: "gpt-5.5",
     displayModel: "GPT-5.5",
-    displayTier: "Standard long context",
-    serviceTier: "standard",
-    context: "long",
-    inputUsdPerMillion: 10,
-    cachedInputUsdPerMillion: 1,
-    outputUsdPerMillion: 45,
-  },
-  {
-    model: "gpt-5.5",
-    displayModel: "GPT-5.5",
     displayTier: "Fast (Priority)",
     serviceTier: "priority",
-    context: "short",
     inputUsdPerMillion: 12.5,
     cachedInputUsdPerMillion: 1.25,
     outputUsdPerMillion: 75,
@@ -310,7 +296,6 @@ const PRICING_CATALOG: readonly PricingCatalogEntry[] = [
     displayModel: "GPT-5.4",
     displayTier: "Standard",
     serviceTier: "standard",
-    context: "short",
     inputUsdPerMillion: 2.5,
     cachedInputUsdPerMillion: 0.25,
     outputUsdPerMillion: 15,
@@ -318,19 +303,8 @@ const PRICING_CATALOG: readonly PricingCatalogEntry[] = [
   {
     model: "gpt-5.4",
     displayModel: "GPT-5.4",
-    displayTier: "Standard long context",
-    serviceTier: "standard",
-    context: "long",
-    inputUsdPerMillion: 5,
-    cachedInputUsdPerMillion: 0.5,
-    outputUsdPerMillion: 22.5,
-  },
-  {
-    model: "gpt-5.4",
-    displayModel: "GPT-5.4",
     displayTier: "Fast (Priority)",
     serviceTier: "priority",
-    context: "short",
     inputUsdPerMillion: 5,
     cachedInputUsdPerMillion: 0.5,
     outputUsdPerMillion: 30,
@@ -340,7 +314,6 @@ const PRICING_CATALOG: readonly PricingCatalogEntry[] = [
     displayModel: "GPT-5.4 mini",
     displayTier: "Standard",
     serviceTier: "standard",
-    context: "short",
     inputUsdPerMillion: 0.75,
     cachedInputUsdPerMillion: 0.075,
     outputUsdPerMillion: 4.5,
@@ -350,7 +323,6 @@ const PRICING_CATALOG: readonly PricingCatalogEntry[] = [
     displayModel: "GPT-5.4 mini",
     displayTier: "Fast (Priority)",
     serviceTier: "priority",
-    context: "short",
     inputUsdPerMillion: 1.5,
     cachedInputUsdPerMillion: 0.15,
     outputUsdPerMillion: 9,
@@ -380,7 +352,6 @@ export function buildTokenUsageActivityEntry(params: {
   const cost = estimateUsageCost({
     cachedInputTokens,
     fastMode: params.fastMode,
-    inputTokens,
     model: params.model,
     outputTokens,
     serviceTier: params.serviceTier,
@@ -471,7 +442,6 @@ export function buildTokenUsageActivityEntry(params: {
       kind: "read",
       label: `Cost unavailable: no local pricing entry for ${formatUnpricedModelName({
         fastMode: params.fastMode,
-        inputTokens,
         model: params.model,
         serviceTier: params.serviceTier,
       })}`,
@@ -585,7 +555,6 @@ function readTokenBreakdown(record: Record<string, unknown>): TokenUsageBreakdow
 function estimateUsageCost(params: {
   cachedInputTokens: number;
   fastMode?: boolean;
-  inputTokens: number;
   model?: string;
   outputTokens: number;
   serviceTier?: string;
@@ -599,12 +568,10 @@ function estimateUsageCost(params: {
     fastMode: params.fastMode,
     serviceTier: params.serviceTier,
   });
-  const context = resolvePricingContext(params.inputTokens);
   const entry = PRICING_CATALOG.find(
     (candidate) =>
       candidate.model === model &&
-      candidate.serviceTier === serviceTier &&
-      candidate.context === context,
+      candidate.serviceTier === serviceTier,
   );
   if (!entry) {
     return undefined;
@@ -612,8 +579,7 @@ function estimateUsageCost(params: {
   const standardEntry = PRICING_CATALOG.find(
     (candidate) =>
       candidate.model === model &&
-      candidate.serviceTier === "standard" &&
-      candidate.context === context,
+      candidate.serviceTier === "standard",
   );
   const uncachedInputUsd =
     (params.uncachedInputTokens * entry.inputUsdPerMillion) / 1_000_000;
@@ -628,7 +594,6 @@ function estimateUsageCost(params: {
   return {
     cachedInputUsd,
     cachedInputUsdPerMillion: entry.cachedInputUsdPerMillion,
-    context: entry.context,
     displayName: `${entry.displayModel} ${entry.displayTier}`,
     inputUsdPerMillion: entry.inputUsdPerMillion,
     model,
@@ -668,10 +633,6 @@ function resolvePricingServiceTier(params: {
     return "priority";
   }
   return undefined;
-}
-
-function resolvePricingContext(inputTokens: number): "short" | "long" {
-  return inputTokens > 128_000 ? "long" : "short";
 }
 
 function rateMultiplier(rate: number, standardRate: number | undefined): number | undefined {
@@ -753,19 +714,16 @@ function formatMultiplier(multiplier: number): string {
 
 function formatUnpricedModelName(params: {
   fastMode?: boolean;
-  inputTokens: number;
   model: string;
   serviceTier?: string;
 }): string {
   const serviceTier = resolvePricingServiceTier(params);
-  const context = resolvePricingContext(params.inputTokens);
   return [
     params.model,
     serviceTier === "priority" ? "Fast/Priority" : undefined,
     serviceTier === undefined && params.serviceTier
       ? `service tier ${params.serviceTier}`
       : undefined,
-    context === "long" ? "long context" : undefined,
   ]
     .filter(Boolean)
     .join(" ");

--- a/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
@@ -248,18 +248,28 @@ type NormalizedTokenUsage = {
 
 type PricingCatalogEntry = {
   cachedInputUsdPerMillion: number;
+  context: "short" | "long";
+  displayModel: string;
+  displayTier: string;
   inputUsdPerMillion: number;
   model: string;
   outputUsdPerMillion: number;
+  serviceTier: "standard" | "priority";
 };
 
 type UsageCostEstimate = {
   cachedInputUsd: number;
   cachedInputUsdPerMillion: number;
+  context: "short" | "long";
+  displayName: string;
   inputUsdPerMillion: number;
   model: string;
   outputUsd: number;
   outputUsdPerMillion: number;
+  serviceTier: "standard" | "priority";
+  standardCachedInputRateMultiplier?: number;
+  standardInputRateMultiplier?: number;
+  standardOutputRateMultiplier?: number;
   totalUsd: number;
   uncachedInputUsd: number;
 };
@@ -267,27 +277,91 @@ type UsageCostEstimate = {
 const PRICING_CATALOG: readonly PricingCatalogEntry[] = [
   {
     model: "gpt-5.5",
+    displayModel: "GPT-5.5",
+    displayTier: "Standard",
+    serviceTier: "standard",
+    context: "short",
     inputUsdPerMillion: 5,
     cachedInputUsdPerMillion: 0.5,
     outputUsdPerMillion: 30,
   },
   {
+    model: "gpt-5.5",
+    displayModel: "GPT-5.5",
+    displayTier: "Standard long context",
+    serviceTier: "standard",
+    context: "long",
+    inputUsdPerMillion: 10,
+    cachedInputUsdPerMillion: 1,
+    outputUsdPerMillion: 45,
+  },
+  {
+    model: "gpt-5.5",
+    displayModel: "GPT-5.5",
+    displayTier: "Fast (Priority)",
+    serviceTier: "priority",
+    context: "short",
+    inputUsdPerMillion: 12.5,
+    cachedInputUsdPerMillion: 1.25,
+    outputUsdPerMillion: 75,
+  },
+  {
     model: "gpt-5.4",
+    displayModel: "GPT-5.4",
+    displayTier: "Standard",
+    serviceTier: "standard",
+    context: "short",
     inputUsdPerMillion: 2.5,
     cachedInputUsdPerMillion: 0.25,
     outputUsdPerMillion: 15,
   },
   {
+    model: "gpt-5.4",
+    displayModel: "GPT-5.4",
+    displayTier: "Standard long context",
+    serviceTier: "standard",
+    context: "long",
+    inputUsdPerMillion: 5,
+    cachedInputUsdPerMillion: 0.5,
+    outputUsdPerMillion: 22.5,
+  },
+  {
+    model: "gpt-5.4",
+    displayModel: "GPT-5.4",
+    displayTier: "Fast (Priority)",
+    serviceTier: "priority",
+    context: "short",
+    inputUsdPerMillion: 5,
+    cachedInputUsdPerMillion: 0.5,
+    outputUsdPerMillion: 30,
+  },
+  {
     model: "gpt-5.4-mini",
+    displayModel: "GPT-5.4 mini",
+    displayTier: "Standard",
+    serviceTier: "standard",
+    context: "short",
     inputUsdPerMillion: 0.75,
     cachedInputUsdPerMillion: 0.075,
     outputUsdPerMillion: 4.5,
   },
+  {
+    model: "gpt-5.4-mini",
+    displayModel: "GPT-5.4 mini",
+    displayTier: "Fast (Priority)",
+    serviceTier: "priority",
+    context: "short",
+    inputUsdPerMillion: 1.5,
+    cachedInputUsdPerMillion: 0.15,
+    outputUsdPerMillion: 9,
+  },
 ];
 
 export function buildTokenUsageActivityEntry(params: {
+  fastMode?: boolean;
   id: string;
   model?: string;
+  serviceTier?: string;
   summaryPrefix?: string;
   tokenUsage: unknown;
   turn?: AppServerThreadTurnMetadata;
@@ -305,8 +379,11 @@ export function buildTokenUsageActivityEntry(params: {
   const reasoningOutputTokens = Math.max(0, tokens.reasoningOutputTokens ?? 0);
   const cost = estimateUsageCost({
     cachedInputTokens,
+    fastMode: params.fastMode,
+    inputTokens,
     model: params.model,
     outputTokens,
+    serviceTier: params.serviceTier,
     uncachedInputTokens,
   });
   const summaryParts = [
@@ -350,7 +427,9 @@ export function buildTokenUsageActivityEntry(params: {
           uncachedInputTokens,
         )} tokens at ${formatUsdPerMillion(
           cost.inputUsdPerMillion,
-        )}/M = ${formatUsd(cost.uncachedInputUsd)}`,
+        )}/M${formatStandardRateSuffix(
+          cost.standardInputRateMultiplier,
+        )} = ${formatUsd(cost.uncachedInputUsd)}`,
         status: "completed",
       },
       {
@@ -363,7 +442,10 @@ export function buildTokenUsageActivityEntry(params: {
         )}/M (${formatPriceFactor(
           cost.cachedInputUsdPerMillion,
           cost.inputUsdPerMillion,
-        )} uncached) = ${formatUsd(cost.cachedInputUsd)}`,
+        )} uncached${formatStandardRateSuffix(
+          cost.standardCachedInputRateMultiplier,
+          ", ",
+        )}) = ${formatUsd(cost.cachedInputUsd)}`,
         status: "completed",
       },
       {
@@ -371,21 +453,28 @@ export function buildTokenUsageActivityEntry(params: {
         kind: "read",
         label: `Output cost: ${formatTokenCount(outputTokens)} tokens at ${formatUsdPerMillion(
           cost.outputUsdPerMillion,
-        )}/M = ${formatUsd(cost.outputUsd)}`,
+        )}/M${formatStandardRateSuffix(
+          cost.standardOutputRateMultiplier,
+        )} = ${formatUsd(cost.outputUsd)}`,
         status: "completed",
       },
     );
     details.push({
       id: `${params.id}-cost`,
       kind: "read",
-      label: `Cost: ${formatUsd(cost.totalUsd)} list price for ${cost.model}`,
+      label: `Cost: ${formatUsd(cost.totalUsd)} list price for ${cost.displayName}`,
       status: "completed",
     });
   } else if (params.model) {
     details.push({
       id: `${params.id}-cost-unavailable`,
       kind: "read",
-      label: `Cost unavailable: no local pricing entry for ${params.model}`,
+      label: `Cost unavailable: no local pricing entry for ${formatUnpricedModelName({
+        fastMode: params.fastMode,
+        inputTokens,
+        model: params.model,
+        serviceTier: params.serviceTier,
+      })}`,
       status: "completed",
     });
   }
@@ -495,18 +584,37 @@ function readTokenBreakdown(record: Record<string, unknown>): TokenUsageBreakdow
 
 function estimateUsageCost(params: {
   cachedInputTokens: number;
+  fastMode?: boolean;
+  inputTokens: number;
   model?: string;
   outputTokens: number;
+  serviceTier?: string;
   uncachedInputTokens: number;
 }): UsageCostEstimate | undefined {
   const model = params.model?.trim();
   if (!model) {
     return undefined;
   }
-  const entry = PRICING_CATALOG.find((candidate) => candidate.model === model);
+  const serviceTier = resolvePricingServiceTier({
+    fastMode: params.fastMode,
+    serviceTier: params.serviceTier,
+  });
+  const context = resolvePricingContext(params.inputTokens);
+  const entry = PRICING_CATALOG.find(
+    (candidate) =>
+      candidate.model === model &&
+      candidate.serviceTier === serviceTier &&
+      candidate.context === context,
+  );
   if (!entry) {
     return undefined;
   }
+  const standardEntry = PRICING_CATALOG.find(
+    (candidate) =>
+      candidate.model === model &&
+      candidate.serviceTier === "standard" &&
+      candidate.context === context,
+  );
   const uncachedInputUsd =
     (params.uncachedInputTokens * entry.inputUsdPerMillion) / 1_000_000;
   const cachedInputUsd =
@@ -520,13 +628,51 @@ function estimateUsageCost(params: {
   return {
     cachedInputUsd,
     cachedInputUsdPerMillion: entry.cachedInputUsdPerMillion,
+    context: entry.context,
+    displayName: `${entry.displayModel} ${entry.displayTier}`,
     inputUsdPerMillion: entry.inputUsdPerMillion,
     model,
     outputUsd,
     outputUsdPerMillion: entry.outputUsdPerMillion,
+    serviceTier: entry.serviceTier,
+    standardCachedInputRateMultiplier: rateMultiplier(
+      entry.cachedInputUsdPerMillion,
+      standardEntry?.cachedInputUsdPerMillion,
+    ),
+    standardInputRateMultiplier: rateMultiplier(
+      entry.inputUsdPerMillion,
+      standardEntry?.inputUsdPerMillion,
+    ),
+    standardOutputRateMultiplier: rateMultiplier(
+      entry.outputUsdPerMillion,
+      standardEntry?.outputUsdPerMillion,
+    ),
     totalUsd,
     uncachedInputUsd,
   };
+}
+
+function resolvePricingServiceTier(params: {
+  fastMode?: boolean;
+  serviceTier?: string;
+}): "standard" | "priority" {
+  return params.fastMode === true ||
+    params.serviceTier === "fast" ||
+    params.serviceTier === "priority"
+    ? "priority"
+    : "standard";
+}
+
+function resolvePricingContext(inputTokens: number): "short" | "long" {
+  return inputTokens > 128_000 ? "long" : "short";
+}
+
+function rateMultiplier(rate: number, standardRate: number | undefined): number | undefined {
+  if (!standardRate || standardRate <= 0) {
+    return undefined;
+  }
+  const multiplier = rate / standardRate;
+  return Math.abs(multiplier - 1) < 0.001 ? undefined : multiplier;
 }
 
 function formatTokenCount(value: number): string {
@@ -543,7 +689,7 @@ function formatUsd(value: number): string {
       maximumFractionDigits: 3,
       minimumFractionDigits: 3,
       style: "currency",
-    }).format(Math.ceil(value * 1_000) / 1_000);
+    }).format(roundUpCurrency(value, 3));
   }
 
   return new Intl.NumberFormat(undefined, {
@@ -551,7 +697,15 @@ function formatUsd(value: number): string {
     maximumFractionDigits: 2,
     minimumFractionDigits: 2,
     style: "currency",
-  }).format(Math.ceil(value * 100) / 100);
+  }).format(roundUpCurrency(value, 2));
+}
+
+function roundUpCurrency(value: number, fractionDigits: number): number {
+  if (value <= 0) {
+    return 0;
+  }
+  const scale = 10 ** fractionDigits;
+  return Math.ceil(value * scale - Number.EPSILON * scale) / scale;
 }
 
 function formatUsdPerMillion(value: number): string {
@@ -572,6 +726,39 @@ function formatPriceFactor(discountedRate: number, standardRate: number): string
     maximumFractionDigits: 3,
     minimumFractionDigits: 1,
   }).format(factor)}x`;
+}
+
+function formatStandardRateSuffix(
+  multiplier: number | undefined,
+  prefix = " ",
+): string {
+  return multiplier === undefined
+    ? ""
+    : `${prefix}${formatMultiplier(multiplier)} Standard`;
+}
+
+function formatMultiplier(multiplier: number): string {
+  return `${new Intl.NumberFormat(undefined, {
+    maximumFractionDigits: 3,
+    minimumFractionDigits: 1,
+  }).format(multiplier)}x`;
+}
+
+function formatUnpricedModelName(params: {
+  fastMode?: boolean;
+  inputTokens: number;
+  model: string;
+  serviceTier?: string;
+}): string {
+  const serviceTier = resolvePricingServiceTier(params);
+  const context = resolvePricingContext(params.inputTokens);
+  return [
+    params.model,
+    serviceTier === "priority" ? "Fast/Priority" : undefined,
+    context === "long" ? "long context" : undefined,
+  ]
+    .filter(Boolean)
+    .join(" ");
 }
 
 function readCommandActionLabel(item: Record<string, unknown>): string | undefined {

--- a/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
@@ -253,6 +253,17 @@ type PricingCatalogEntry = {
   outputUsdPerMillion: number;
 };
 
+type UsageCostEstimate = {
+  cachedInputUsd: number;
+  cachedInputUsdPerMillion: number;
+  inputUsdPerMillion: number;
+  model: string;
+  outputUsd: number;
+  outputUsdPerMillion: number;
+  totalUsd: number;
+  uncachedInputUsd: number;
+};
+
 const PRICING_CATALOG: readonly PricingCatalogEntry[] = [
   {
     model: "gpt-5.5",
@@ -331,6 +342,39 @@ export function buildTokenUsageActivityEntry(params: {
     },
   ];
   if (cost) {
+    details.push(
+      {
+        id: `${params.id}-uncached-input-cost`,
+        kind: "read",
+        label: `Uncached input cost: ${formatTokenCount(
+          uncachedInputTokens,
+        )} tokens at ${formatUsdPerMillion(
+          cost.inputUsdPerMillion,
+        )}/M = ${formatUsd(cost.uncachedInputUsd)}`,
+        status: "completed",
+      },
+      {
+        id: `${params.id}-cached-input-cost`,
+        kind: "read",
+        label: `Cached input cost: ${formatTokenCount(
+          cachedInputTokens,
+        )} tokens at ${formatUsdPerMillion(
+          cost.cachedInputUsdPerMillion,
+        )}/M (${formatPriceFactor(
+          cost.cachedInputUsdPerMillion,
+          cost.inputUsdPerMillion,
+        )} uncached) = ${formatUsd(cost.cachedInputUsd)}`,
+        status: "completed",
+      },
+      {
+        id: `${params.id}-output-cost`,
+        kind: "read",
+        label: `Output cost: ${formatTokenCount(outputTokens)} tokens at ${formatUsdPerMillion(
+          cost.outputUsdPerMillion,
+        )}/M = ${formatUsd(cost.outputUsd)}`,
+        status: "completed",
+      },
+    );
     details.push({
       id: `${params.id}-cost`,
       kind: "read",
@@ -454,7 +498,7 @@ function estimateUsageCost(params: {
   model?: string;
   outputTokens: number;
   uncachedInputTokens: number;
-}): { model: string; totalUsd: number } | undefined {
+}): UsageCostEstimate | undefined {
   const model = params.model?.trim();
   if (!model) {
     return undefined;
@@ -463,11 +507,26 @@ function estimateUsageCost(params: {
   if (!entry) {
     return undefined;
   }
-  const totalUsd =
-    (params.uncachedInputTokens * entry.inputUsdPerMillion) / 1_000_000 +
-    (params.cachedInputTokens * entry.cachedInputUsdPerMillion) / 1_000_000 +
+  const uncachedInputUsd =
+    (params.uncachedInputTokens * entry.inputUsdPerMillion) / 1_000_000;
+  const cachedInputUsd =
+    (params.cachedInputTokens * entry.cachedInputUsdPerMillion) / 1_000_000;
+  const outputUsd =
     (params.outputTokens * entry.outputUsdPerMillion) / 1_000_000;
-  return { model, totalUsd };
+  const totalUsd =
+    uncachedInputUsd +
+    cachedInputUsd +
+    outputUsd;
+  return {
+    cachedInputUsd,
+    cachedInputUsdPerMillion: entry.cachedInputUsdPerMillion,
+    inputUsdPerMillion: entry.inputUsdPerMillion,
+    model,
+    outputUsd,
+    outputUsdPerMillion: entry.outputUsdPerMillion,
+    totalUsd,
+    uncachedInputUsd,
+  };
 }
 
 function formatTokenCount(value: number): string {
@@ -493,6 +552,26 @@ function formatUsd(value: number): string {
     minimumFractionDigits: 2,
     style: "currency",
   }).format(Math.ceil(value * 100) / 100);
+}
+
+function formatUsdPerMillion(value: number): string {
+  return new Intl.NumberFormat(undefined, {
+    currency: "USD",
+    maximumFractionDigits: 3,
+    minimumFractionDigits: 2,
+    style: "currency",
+  }).format(value);
+}
+
+function formatPriceFactor(discountedRate: number, standardRate: number): string {
+  if (standardRate <= 0) {
+    return "unknown factor";
+  }
+  const factor = discountedRate / standardRate;
+  return `${new Intl.NumberFormat(undefined, {
+    maximumFractionDigits: 3,
+    minimumFractionDigits: 1,
+  }).format(factor)}x`;
 }
 
 function readCommandActionLabel(item: Record<string, unknown>): string | undefined {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -4279,7 +4279,7 @@ describe("useThreadSessionState", () => {
           params: {
             threadId: "thread-1",
             turnId: "turn-1",
-            model: "gpt-5.4-mini",
+            model: "gpt-5.4",
             tokenUsage: {
               last_token_usage: {
                 input_tokens: 1_217_026,
@@ -4319,7 +4319,7 @@ describe("useThreadSessionState", () => {
 
     expect(transcriptLabels(result.current.entries)).toEqual([
       "message:Done.",
-      "activity:Turn usage: 96,642 uncached in · 1,120,384 cached · 3,721 out (1,130 reasoning) · $0.18 list price",
+      "activity:Turn usage: 96,642 uncached in · 1,120,384 cached · 3,721 out (1,130 reasoning) · $1.13 list price",
     ]);
   });
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -4005,6 +4005,71 @@ describe("useThreadSessionState", () => {
     });
   });
 
+  it("prices token usage with Fast priority rates from thread settings", async () => {
+    let agentEventHandler: Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0] | undefined;
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback;
+        return () => undefined;
+      },
+      readThread: async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: {
+          ...buildThread({ id: "thread-1", updatedAt: 1_000 }),
+          fastMode: true,
+          model: "gpt-5.5",
+        },
+      })
+    );
+
+    await waitForThreadHydration(result);
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "thread/tokenUsage/updated",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            tokenUsage: {
+              total: {
+                inputTokens: 27_697,
+                cachedInputTokens: 10_112,
+                outputTokens: 95,
+              },
+            },
+          },
+        },
+      });
+    });
+
+    const usageEntry = result.current.entries[0];
+    expect(usageEntry?.type).toBe("activity");
+    expect(usageEntry?.type === "activity" ? usageEntry.summary : undefined).toBe(
+      "Usage: 17,585 uncached in · 10,112 cached · 95 out · $0.24 list price",
+    );
+    expect(usageEntry?.type === "activity" ? usageEntry.details.at(-1)?.label : undefined).toBe(
+      "Cost: $0.24 list price for GPT-5.5 Fast (Priority)",
+    );
+  });
+
   it("finalizes active-turn usage from cumulative token deltas", async () => {
     let agentEventHandler: Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0] | undefined;
     const desktopApi: DesktopApi = {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -4319,7 +4319,7 @@ describe("useThreadSessionState", () => {
 
     expect(transcriptLabels(result.current.entries)).toEqual([
       "message:Done.",
-      "activity:Turn usage: 96,642 uncached in · 1,120,384 cached · 3,721 out (1,130 reasoning) · $1.13 list price",
+      "activity:Turn usage: 96,642 uncached in · 1,120,384 cached · 3,721 out (1,130 reasoning) · $0.58 list price",
     ]);
   });
 

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -1391,6 +1391,50 @@ function resolveTokenUsageModel(params: {
   );
 }
 
+function resolveTokenUsageServiceTier(params: {
+  backend: AppServerBackendKind;
+  notificationParams: Extract<
+    AppServerNotification,
+    { method: "thread/tokenUsage/updated" }
+  >["params"];
+  thread?: NavigationThreadSummary;
+  threadId: string;
+}): string | undefined {
+  return (
+    readStringValue(
+      findFirstNestedValue(params.notificationParams.tokenUsage, [
+        "serviceTier",
+        "service_tier",
+      ])
+    ) ??
+    (params.thread?.source === params.backend && params.thread.id === params.threadId
+      ? params.thread.serviceTier
+      : undefined)
+  );
+}
+
+function resolveTokenUsageFastMode(params: {
+  backend: AppServerBackendKind;
+  notificationParams: Extract<
+    AppServerNotification,
+    { method: "thread/tokenUsage/updated" }
+  >["params"];
+  thread?: NavigationThreadSummary;
+  threadId: string;
+}): boolean | undefined {
+  const tokenUsageFastMode = findFirstNestedValue(params.notificationParams.tokenUsage, [
+    "fastMode",
+    "fast_mode",
+  ]);
+  if (typeof tokenUsageFastMode === "boolean") {
+    return tokenUsageFastMode;
+  }
+
+  return params.thread?.source === params.backend && params.thread.id === params.threadId
+    ? params.thread.fastMode
+    : undefined;
+}
+
 function readTokenBreakdown(record: Record<string, unknown>): TokenUsageBreakdown | undefined {
   const explicitTotal = readFiniteNumber(record, ["totalTokens", "total_tokens"]);
   const inputTokens = readFiniteNumber(record, ["inputTokens", "input_tokens"]);
@@ -1552,7 +1596,9 @@ function deriveTurnUsageBaseline(params: {
 function buildPendingTurnUsage(params: {
   contextWindow?: ThreadContextWindowState;
   existing?: TurnUsageAccumulator;
+  fastMode?: boolean;
   model?: string;
+  serviceTier?: string;
   tokenUsage: unknown;
   turn?: AppServerThreadTurnMetadata;
 }): {
@@ -1583,8 +1629,10 @@ function buildPendingTurnUsage(params: {
     : usageRecords.latestUsage;
   const entry = turnUsage
     ? buildTokenUsageActivityEntry({
+        fastMode: params.fastMode,
         id: `live-turn-usage-${turnId}`,
         model: params.model,
+        serviceTier: params.serviceTier,
         summaryPrefix: "Turn usage",
         tokenUsage: tokenUsagePayloadFromBreakdown(turnUsage),
         turn: params.turn,
@@ -4044,9 +4092,23 @@ export function useThreadSessionState(params: {
             thread,
             threadId: notificationThreadId,
           });
+          const serviceTier = resolveTokenUsageServiceTier({
+            backend: event.backend,
+            notificationParams: event.notification.params,
+            thread,
+            threadId: notificationThreadId,
+          });
+          const fastMode = resolveTokenUsageFastMode({
+            backend: event.backend,
+            notificationParams: event.notification.params,
+            thread,
+            threadId: notificationThreadId,
+          });
           let usageEntry = buildTokenUsageActivityEntry({
+            fastMode,
             id: usageEntryId,
             model,
+            serviceTier,
             tokenUsage: event.notification.params.tokenUsage,
             turn,
           });
@@ -4061,7 +4123,9 @@ export function useThreadSessionState(params: {
             const turnUsage = buildPendingTurnUsage({
               contextWindow: current.contextWindow,
               existing: current.pendingTurnUsage,
+              fastMode,
               model,
+              serviceTier,
               tokenUsage: event.notification.params.tokenUsage,
               turn,
             });


### PR DESCRIPTION
## Summary

- Expanded token usage details now show the line-item list-price math behind the aggregate cost.
- Cached input rows now include the cached-token rate and factor, for example `0.1x uncached`, so the discount is visible instead of implied.
- Fast-mode Codex usage now prices against OpenAI Priority rates and labels the variant, for example `GPT-5.5 Fast (Priority)`.
- Unsupported service tiers and unpriced models such as Codex Spark report cost unavailable instead of guessing.
- Codex usage no longer switches to long-context API pricing when aggregate turn input crosses 128K tokens; large aggregate totals stay on the normal Codex Standard or Fast/Priority rates.

## Verification

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts`
- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx`
- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx`
- `pnpm typecheck`
- `pnpm --filter @pwragent/desktop typecheck`

## Notes

- I verified the cost breakdown behavior with focused unit coverage, including large aggregate usage over 128K tokens staying on the Codex Standard/Fast pricing path.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
