### PR TITLE
fix(desktop): model Codex reviews as subagents

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -10854,6 +10854,7 @@ command = "pnpm dev"
         turn: {
           id: "turn-review-1",
           status: "completed",
+          completedAt: 1_781_178_272,
           output: [],
         },
       },
@@ -10954,6 +10955,7 @@ command = "pnpm dev"
         turn: {
           id: "turn-review-1",
           status: "completed",
+          completedAt: 1_781_178_272,
           output: [],
         },
       },
@@ -10972,7 +10974,7 @@ command = "pnpm dev"
         outcome: "success",
         status: "success",
         lastMessage: "Review completed.",
-        completedAt: expect.any(Number),
+        completedAt: 1_781_178_272_000,
       });
 
     await registry.close();

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -11063,6 +11063,87 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("patches detached Codex review usage on the parent thread after completion", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start", "review/start"] },
+      startReviewResult: {
+        threadId: "thread-parent",
+        reviewThreadId: "thread-review",
+        turnId: "turn-review-1",
+      },
+    });
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+
+    await registry.startReview({
+      backend: "codex",
+      threadId: "thread-parent",
+      target: { type: "baseBranch", branch: "main" },
+      delivery: "detached",
+    });
+
+    await codexClient.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-review",
+        turnId: "turn-review-1",
+        turn: {
+          id: "turn-review-1",
+          status: "completed",
+          output: [],
+        },
+      },
+    });
+
+    await codexClient.emit({
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: "thread-review",
+        turnId: "turn-review-1",
+        tokenUsage: {
+          total: {
+            inputTokens: 1_000,
+            cachedInputTokens: 200,
+            outputTokens: 50,
+            reasoningOutputTokens: 10,
+          },
+        },
+      },
+    });
+
+    await expect
+      .poll(async () => {
+        const overlay = await overlayStore.getThreadOverlayState({
+          backend: "codex",
+          threadId: "thread-parent",
+        });
+        return overlay?.subAgents?.[0];
+      })
+      .toMatchObject({
+        monitorId: "review:turn-review-1",
+        monitorThreadId: "thread-review",
+        monitorTurnId: "turn-review-1",
+        outcome: "success",
+        status: "success",
+        monitorUsage: {
+          summary: "800 uncached in · 200 cached · 50 out (10 reasoning)",
+        },
+      });
+    const reviewOverlay = await overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-review",
+    });
+    expect(reviewOverlay?.subAgents).toBeUndefined();
+
+    await registry.close();
+  });
+
   it("interrupts Codex reviews with the backend active turn id", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/interrupt", "review/start"] },
@@ -11072,12 +11153,13 @@ command = "pnpm dev"
         turnId: "turn-review-1",
       },
     });
+    const overlayStore = createOverlayStoreMock();
     const registry = new DesktopBackendRegistry({
       codexClient,
       grokClient: new MockBackendClient({
         initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
       }),
-      overlayStore: createOverlayStoreMock(),
+      overlayStore,
     });
 
     await registry.startReview({
@@ -11109,6 +11191,35 @@ command = "pnpm dev"
       threadId: "thread-1",
       turnId: "turn-interrupt-1",
     });
+
+    await codexClient.emit({
+      method: "turn/cancelled",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-interrupt-1",
+        turn: {
+          id: "turn-interrupt-1",
+          status: "cancelled",
+          completedAt: 1_781_178_300,
+        },
+      },
+    });
+
+    await expect
+      .poll(async () => {
+        const overlay = await overlayStore.getThreadOverlayState({
+          backend: "codex",
+          threadId: "thread-1",
+        });
+        return overlay?.subAgents?.[0];
+      })
+      .toMatchObject({
+        monitorId: "review:turn-review-1",
+        outcome: "cancelled",
+        status: "cancelled",
+        lastMessage: "Review cancelled.",
+        completedAt: 1_781_178_300_000,
+      });
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1064,6 +1064,10 @@ class MockBackendClient {
     threadId: string;
     target: AppServerReviewTarget;
     delivery?: "inline" | "detached";
+    model?: string;
+    serviceTier?: string | null;
+    reasoningEffort?: string;
+    fastMode?: boolean;
     cwd?: string;
     codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
   }): Promise<{ threadId: string; reviewThreadId: string; turnId: string }> {
@@ -10626,6 +10630,10 @@ command = "pnpm dev"
       threadId: "thread-1",
       target: { type: "baseBranch", branch: "main" },
       delivery: "inline",
+      model: "grok-4.20-reasoning",
+      reasoningEffort: undefined,
+      serviceTier: undefined,
+      fastMode: undefined,
     });
 
     await registry.close();
@@ -10674,12 +10682,20 @@ command = "pnpm dev"
       threadId: "thread-env",
       target: { type: "baseBranch", branch: "main" },
       delivery: "inline",
+      model: "gpt-5.5",
+      reasoningEffort: "high",
+      serviceTier: "priority",
+      fastMode: true,
     });
 
     expect(codexClient.lastStartReviewParams).toMatchObject({
       threadId: "thread-env",
       cwd: "/repo/app",
       codexEnvironmentRuntime,
+      model: "gpt-5.5",
+      reasoningEffort: "high",
+      serviceTier: "priority",
+      fastMode: true,
     });
 
     await registry.close();
@@ -17128,6 +17144,10 @@ command = "pnpm dev"
         threadId: "thread-1",
         target: { type: "baseBranch", branch: "main" },
         delivery: "inline",
+        model: "gpt-5.5",
+        reasoningEffort: "medium",
+        serviceTier: undefined,
+        fastMode: undefined,
       });
       const overlay = await overlayStore.getThreadOverlayState({
         backend: "codex",

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -10832,6 +10832,42 @@ command = "pnpm dev"
       });
 
     await codexClient.emit({
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-review-1",
+        tokenUsage: {
+          total: {
+            inputTokens: 1_000,
+            cachedInputTokens: 200,
+            outputTokens: 50,
+            reasoningOutputTokens: 10,
+          },
+        },
+      },
+    });
+
+    await expect
+      .poll(async () => {
+        const overlay = await overlayStore.getThreadOverlayState({
+          backend: "codex",
+          threadId: "thread-1",
+        });
+        return overlay?.subAgents?.[0]?.monitorUsage;
+      })
+      .toMatchObject({
+        summary: "800 uncached in · 200 cached · 50 out (10 reasoning)",
+        tokenUsage: {
+          cachedInputTokens: 200,
+          inputTokens: 1_000,
+          outputTokens: 50,
+          reasoningOutputTokens: 10,
+          totalTokens: 1_060,
+          uncachedInputTokens: 800,
+        },
+      });
+
+    await codexClient.emit({
       method: "turn/completed",
       params: {
         threadId: "thread-1",

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -10978,6 +10978,89 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("patches Codex review sub-agent usage when usage arrives after completion", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start", "review/start"] },
+      startReviewResult: {
+        threadId: "thread-1",
+        reviewThreadId: "thread-1",
+        turnId: "turn-review-1",
+      },
+    });
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+
+    await registry.startReview({
+      backend: "codex",
+      threadId: "thread-1",
+      target: { type: "baseBranch", branch: "main" },
+      delivery: "inline",
+    });
+
+    await codexClient.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-review-1",
+        turn: {
+          id: "turn-review-1",
+          status: "completed",
+          output: [],
+        },
+      },
+    });
+
+    await codexClient.emit({
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-review-1",
+        tokenUsage: {
+          total: {
+            inputTokens: 1_000,
+            cachedInputTokens: 200,
+            outputTokens: 50,
+            reasoningOutputTokens: 10,
+          },
+        },
+      },
+    });
+
+    await expect
+      .poll(async () => {
+        const overlay = await overlayStore.getThreadOverlayState({
+          backend: "codex",
+          threadId: "thread-1",
+        });
+        return overlay?.subAgents?.[0];
+      })
+      .toMatchObject({
+        monitorId: "review:turn-review-1",
+        outcome: "success",
+        status: "success",
+        lastMessage: "Review completed.",
+        monitorUsage: {
+          summary: "800 uncached in · 200 cached · 50 out (10 reasoning)",
+          tokenUsage: {
+            cachedInputTokens: 200,
+            inputTokens: 1_000,
+            outputTokens: 50,
+            reasoningOutputTokens: 10,
+            totalTokens: 1_060,
+            uncachedInputTokens: 800,
+          },
+        },
+      });
+
+    await registry.close();
+  });
+
   it("interrupts Codex reviews with the backend active turn id", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/interrupt", "review/start"] },

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -6996,6 +6996,73 @@ script = "pnpm install"
     await registry.close();
   });
 
+  it("uses submitted launchpad model settings when materializing Codex review launchpads", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: {
+        serverInfo: { name: "Codex App Server", version: "1.0.0" },
+        methods: ["thread/start", "review/start"],
+      },
+    });
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is set"),
+      }),
+      overlayStore,
+    });
+
+    await registry.materializeDirectoryLaunchpad({
+      directoryKey: "directory:/repo/app",
+      reviewTarget: { type: "baseBranch", branch: "main" },
+      launchpad: {
+        directoryKey: "directory:/repo/app",
+        directoryKind: "directory",
+        directoryLabel: "app",
+        directoryPath: "/repo/app",
+        backend: "codex",
+        executionMode: "default",
+        prompt: "/review main",
+        workMode: "local",
+        model: "gpt-5.4",
+        reasoningEffort: "high",
+        serviceTier: "priority",
+        fastMode: true,
+        createdAt: 1_000,
+        updatedAt: 2_000,
+      },
+    });
+
+    expect(codexClient.lastStartThreadParams).toMatchObject({
+      model: "gpt-5.4",
+      reasoningEffort: "high",
+      serviceTier: "priority",
+      fastMode: true,
+    });
+    expect(codexClient.lastStartReviewParams).toMatchObject({
+      threadId: "thread-1",
+      target: { type: "baseBranch", branch: "main" },
+      delivery: "inline",
+      model: "gpt-5.4",
+      reasoningEffort: "high",
+      serviceTier: "priority",
+      fastMode: true,
+    });
+
+    const overlay = await overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(overlay).toMatchObject({
+      model: "gpt-5.4",
+      reasoningEffort: "high",
+      serviceTier: "priority",
+      fastMode: true,
+    });
+
+    await registry.close();
+  });
+
   it("creates a scratch workspace for Codex thread creation when cwd is omitted", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/start"] },
@@ -10630,10 +10697,6 @@ command = "pnpm dev"
       threadId: "thread-1",
       target: { type: "baseBranch", branch: "main" },
       delivery: "inline",
-      model: "grok-4.20-reasoning",
-      reasoningEffort: undefined,
-      serviceTier: undefined,
-      fastMode: undefined,
     });
 
     await registry.close();
@@ -17144,10 +17207,6 @@ command = "pnpm dev"
         threadId: "thread-1",
         target: { type: "baseBranch", branch: "main" },
         delivery: "inline",
-        model: "gpt-5.5",
-        reasoningEffort: "medium",
-        serviceTier: undefined,
-        fastMode: undefined,
       });
       const overlay = await overlayStore.getThreadOverlayState({
         backend: "codex",

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -871,6 +871,11 @@ class MockBackendClient {
       steerTurnError?: Error;
       setThreadPermissionsError?: Error;
       setThreadPermissionsDelay?: Promise<unknown>;
+      startReviewResult?: {
+        threadId: string;
+        reviewThreadId: string;
+        turnId: string;
+      };
     }
   ) {}
 
@@ -1063,7 +1068,7 @@ class MockBackendClient {
     codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
   }): Promise<{ threadId: string; reviewThreadId: string; turnId: string }> {
     this.lastStartReviewParams = params;
-    return {
+    return this.options.startReviewResult ?? {
       threadId: params.threadId,
       reviewThreadId: params.threadId,
       turnId: "turn-review-1",
@@ -10781,6 +10786,56 @@ command = "pnpm dev"
       input: [{ type: "text", text: "Follow-up after review" }],
     });
     expect(codexClient.startTurnCallCount).toBe(1);
+
+    await registry.close();
+  });
+
+  it("interrupts Codex reviews with the backend active turn id", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/interrupt", "review/start"] },
+      startReviewResult: {
+        threadId: "thread-1",
+        reviewThreadId: "thread-1",
+        turnId: "turn-review-1",
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await registry.startReview({
+      backend: "codex",
+      threadId: "thread-1",
+      target: { type: "baseBranch", branch: "main" },
+      delivery: "inline",
+    });
+    await codexClient.emit({
+      method: "turn/started",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-interrupt-1",
+        turn: {
+          id: "turn-interrupt-1",
+          status: "in_progress",
+          startedAt: 1_000,
+        },
+      },
+    });
+
+    await registry.interruptTurn({
+      backend: "codex",
+      threadId: "thread-1",
+      turnId: "turn-review-1",
+    });
+
+    expect(codexClient.lastInterruptTurnParams).toMatchObject({
+      threadId: "thread-1",
+      turnId: "turn-interrupt-1",
+    });
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -10790,6 +10790,79 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("persists Codex reviews as sub-agent summaries on the parent thread", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start", "review/start"] },
+      startReviewResult: {
+        threadId: "thread-1",
+        reviewThreadId: "thread-1",
+        turnId: "turn-review-1",
+      },
+    });
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+
+    await registry.startReview({
+      backend: "codex",
+      threadId: "thread-1",
+      target: { type: "baseBranch", branch: "main" },
+      delivery: "inline",
+    });
+
+    await expect
+      .poll(async () => {
+        const overlay = await overlayStore.getThreadOverlayState({
+          backend: "codex",
+          threadId: "thread-1",
+        });
+        return overlay?.subAgents?.[0];
+      })
+      .toMatchObject({
+        monitorId: "review:turn-review-1",
+        monitorThreadId: "thread-1",
+        monitorTurnId: "turn-review-1",
+        task: "Review changes against main",
+        status: "running",
+      });
+
+    await codexClient.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-review-1",
+        turn: {
+          id: "turn-review-1",
+          status: "completed",
+          output: [],
+        },
+      },
+    });
+
+    await expect
+      .poll(async () => {
+        const overlay = await overlayStore.getThreadOverlayState({
+          backend: "codex",
+          threadId: "thread-1",
+        });
+        return overlay?.subAgents?.[0];
+      })
+      .toMatchObject({
+        monitorId: "review:turn-review-1",
+        outcome: "success",
+        status: "success",
+        lastMessage: "Review completed.",
+        completedAt: expect.any(Number),
+      });
+
+    await registry.close();
+  });
+
   it("interrupts Codex reviews with the backend active turn id", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/interrupt", "review/start"] },

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -3822,6 +3822,63 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("keeps review start history and timestamps final reviews at completion", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.readThreadResultByThreadId.set("thread-review-history", {
+      thread: {
+        turns: [
+          {
+            id: "turn-review",
+            status: "completed",
+            startedAt: 1_781_178_065,
+            completedAt: 1_781_178_272,
+            items: [
+              {
+                type: "event_msg",
+                id: "entered-review",
+                payload: {
+                  type: "entered_review_mode",
+                  user_facing_hint: "changes against 'main'",
+                },
+              },
+              {
+                type: "exitedReviewMode",
+                id: "exited-review",
+                review: "No findings. Ready to merge.",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    const replay = await client.readThread({
+      threadId: "thread-review-history",
+    });
+
+    expect(replay.entries).toEqual([
+      expect.objectContaining({
+        type: "review",
+        id: "entered-review",
+        displayText: "Review changes against main",
+        createdAt: 1_781_178_065_000,
+      }),
+      expect.objectContaining({
+        type: "review",
+        id: "exited-review",
+        review: "No findings. Ready to merge.",
+        createdAt: 1_781_178_272_000,
+      }),
+    ]);
+
+    await client.close();
+  });
+
   it("normalizes generated in-progress activity statuses from thread/read", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
     MockTransport.readThreadResultByThreadId.set("thread-in-progress-tools", {

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -6284,6 +6284,28 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("rejects review/start responses that omit a real turn id", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.reviewStartResult = {
+      reviewThreadId: "thread-2",
+    };
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => []
+    });
+
+    await expect(
+      client.startReview({
+        threadId: "thread-2",
+        target: { type: "baseBranch", branch: "main" },
+        delivery: "inline",
+      })
+    ).rejects.toThrow("codex app server review/start did not return turnId");
+
+    await client.close();
+  });
+
   it("maps plan-mode turns onto supported model and reasoning overrides", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
     MockTransport.threadResumeResult = {

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -828,6 +828,17 @@ class MockTransport implements JsonRpcTransport {
       return;
     }
 
+    if (payload.method === "thread/settings/update") {
+      this.messageHandler(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: payload.id,
+          result: {},
+        })
+      );
+      return;
+    }
+
     if (payload.method === "turn/start") {
       if (MockTransport.turnStartPreResponseNotification) {
         this.messageHandler(JSON.stringify(MockTransport.turnStartPreResponseNotification));
@@ -6231,6 +6242,9 @@ describe("CodexAppServerClient", () => {
       threadId: "thread-2",
       target: { type: "baseBranch", branch: "main" },
       delivery: "inline",
+      model: "gpt-5.5",
+      reasoningEffort: "high",
+      fastMode: true,
       cwd: "/Users/example/project",
       codexEnvironmentRuntime: {
         environmentId: "env",
@@ -6260,14 +6274,28 @@ describe("CodexAppServerClient", () => {
         method: "thread/resume",
         params: expect.objectContaining({
           threadId: "thread-2",
+          model: "gpt-5.5",
+          serviceTier: "priority",
           cwd: "/Users/example/project",
           "config": {
+            fast_mode: true,
             "shell_environment_policy.set.PATH":
               "/Users/example/project/.venv/bin:/usr/bin",
             "shell_environment_policy.set.VIRTUAL_ENV":
               "/Users/example/project/.venv",
           },
         }),
+      }),
+    );
+    expect(requests).toContainEqual(
+      expect.objectContaining({
+        method: "thread/settings/update",
+        params: {
+          threadId: "thread-2",
+          model: "gpt-5.5",
+          effort: "high",
+          serviceTier: "priority",
+        },
       }),
     );
     expect(requests).toContainEqual(

--- a/apps/desktop/src/main/__tests__/grok-app-server-client.test.ts
+++ b/apps/desktop/src/main/__tests__/grok-app-server-client.test.ts
@@ -398,6 +398,74 @@ describe("GrokAppServerClient", () => {
     await client.close();
   });
 
+  it("resumes Grok reviews with selected model settings before review/start", async () => {
+    const requests: Array<{ method: string; params?: unknown }> = [];
+    const server = {
+      request: async (method: string, params?: unknown): Promise<unknown> => {
+        requests.push({ method, params });
+        if (method === "initialize") {
+          return {
+            serverInfo: { name: "@pwragent/grok-app-server", version: "1.0.0" },
+            methods: ["thread/resume", "review/start"],
+          };
+        }
+        if (method === "thread/resume") {
+          return { threadId: "thread-1" };
+        }
+        if (method === "review/start") {
+          return {
+            threadId: "thread-1",
+            reviewThreadId: "thread-review-1",
+            turnId: "turn-review-1",
+          };
+        }
+        throw new Error(`Unexpected request ${method}`);
+      },
+      onNotification: () => () => undefined,
+    };
+    const client = new GrokAppServerClient({ server });
+
+    await expect(
+      client.startReview({
+        threadId: "thread-1",
+        target: { type: "baseBranch", branch: "main" },
+        delivery: "inline",
+        model: "grok-4.20-reasoning",
+        serviceTier: "priority",
+        reasoningEffort: "high",
+        fastMode: true,
+      }),
+    ).resolves.toEqual({
+      threadId: "thread-1",
+      reviewThreadId: "thread-review-1",
+      turnId: "turn-review-1",
+    });
+
+    expect(requests).toEqual([
+      expect.objectContaining({ method: "initialize" }),
+      {
+        method: "thread/resume",
+        params: {
+          threadId: "thread-1",
+          model: "grok-4.20-reasoning",
+          serviceTier: "priority",
+          reasoningEffort: "high",
+          fastMode: true,
+        },
+      },
+      {
+        method: "review/start",
+        params: {
+          threadId: "thread-1",
+          target: { type: "baseBranch", branch: "main" },
+          delivery: "inline",
+        },
+      },
+    ]);
+
+    await client.close();
+  });
+
   it("fails a Grok turn that resolves without assistant text", async () => {
     const provider = new FakeProvider();
     const server = new CodexAppServer({

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1298,6 +1298,31 @@ function buildActiveTurnKey(
   return `${backend}:${threadId}:${turnId}`;
 }
 
+function buildReviewSubAgentKey(
+  backend: AppServerBackendKind,
+  threadId: string,
+  turnId: string,
+): string {
+  return buildActiveTurnKey(backend, threadId, turnId);
+}
+
+function reviewSubAgentId(turnId: string): string {
+  return `review:${turnId}`;
+}
+
+function reviewTaskLabel(target: StartReviewRequest["target"]): string {
+  switch (target.type) {
+    case "baseBranch":
+      return `Review changes against ${target.branch}`;
+    case "commit":
+      return `Review commit ${target.sha.slice(0, 7)}`;
+    case "custom":
+      return target.instructions.trim() || "Review changes";
+    case "uncommittedChanges":
+      return "Review current changes";
+  }
+}
+
 function parseThreadTurnKeyBody(
   body: string,
 ): { threadId: string; turnId: string } | undefined {
@@ -1470,6 +1495,15 @@ type TaskMonitorDelegationRecord = {
   staleInterruptAttempted?: boolean;
   startupTimeoutSeconds: number;
   task: string;
+};
+
+type ReviewSubAgentRecord = {
+  backend: Exclude<AppServerBackendKind, AcpBackendId>;
+  createdAt: number;
+  parentThreadId: string;
+  reviewThreadId: string;
+  task: string;
+  turnId: string;
 };
 
 function taskMonitorFailure<TOperation extends TaskMonitorRequest["operation"]>(
@@ -2908,6 +2942,7 @@ export class DesktopBackendRegistry {
   private readonly activeCodexTurnModes = new Map<string, ThreadExecutionMode>();
   private readonly activeCodexReviewTurnKeys = new Set<string>();
   private readonly activeCodexReviewInterruptTurnIds = new Map<string, string>();
+  private readonly activeReviewSubAgents = new Map<string, ReviewSubAgentRecord>();
   private readonly observedCodexSettingsByThread = new Map<string, ObservedCodexSettings>();
   private readonly reservedCodexStartThreadIds = new Set<string>();
   private readonly reservedAcpStartThreadKeys = new Set<string>();
@@ -6087,6 +6122,23 @@ export class DesktopBackendRegistry {
         this.reservedCodexStartThreadIds.delete(params.threadId);
       }
     }
+    const reviewSubAgentRecord: ReviewSubAgentRecord = {
+      backend: params.backend as Exclude<AppServerBackendKind, AcpBackendId>,
+      createdAt: Date.now(),
+      parentThreadId: result.threadId,
+      reviewThreadId: result.reviewThreadId || result.threadId,
+      task: reviewTaskLabel(params.target),
+      turnId: result.turnId,
+    };
+    this.activeReviewSubAgents.set(
+      buildReviewSubAgentKey(
+        reviewSubAgentRecord.backend,
+        reviewSubAgentRecord.reviewThreadId,
+        reviewSubAgentRecord.turnId,
+      ),
+      reviewSubAgentRecord,
+    );
+    await this.persistReviewSubAgent(reviewSubAgentRecord);
 
     return {
       backend: params.backend,
@@ -9598,6 +9650,112 @@ export class DesktopBackendRegistry {
     });
   }
 
+  private async persistReviewSubAgent(
+    record: ReviewSubAgentRecord,
+    patch: Partial<
+      Pick<
+        ThreadSubAgentSummary,
+        | "completedAt"
+        | "lastMessage"
+        | "monitorUsage"
+        | "outcome"
+        | "status"
+        | "updatedAt"
+      >
+    > = {},
+  ): Promise<void> {
+    const existingOverlay = await this.overlayStore.getThreadOverlayState({
+      backend: record.backend,
+      threadId: record.parentThreadId,
+    });
+    const monitorId = reviewSubAgentId(record.turnId);
+    const existing = existingOverlay?.subAgents?.find(
+      (subAgent) => subAgent.monitorId === monitorId,
+    );
+    const subAgent: ThreadSubAgentSummary = {
+      monitorId,
+      task: record.task,
+      status: patch.status ?? existing?.status ?? "running",
+      createdAt: record.createdAt,
+      updatedAt: patch.updatedAt ?? Date.now(),
+      monitorThreadId: record.reviewThreadId,
+      monitorTurnId: record.turnId,
+      ...(patch.lastMessage ?? existing?.lastMessage
+        ? { lastMessage: patch.lastMessage ?? existing?.lastMessage }
+        : {}),
+      ...(patch.outcome ?? existing?.outcome
+        ? { outcome: patch.outcome ?? existing?.outcome }
+        : {}),
+      ...(patch.completedAt ?? existing?.completedAt
+        ? { completedAt: patch.completedAt ?? existing?.completedAt }
+        : {}),
+      ...(patch.monitorUsage ?? existing?.monitorUsage
+        ? { monitorUsage: patch.monitorUsage ?? existing?.monitorUsage }
+        : {}),
+    };
+
+    await this.overlayStore.upsertThreadSubAgent({
+      backend: record.backend,
+      threadId: record.parentThreadId,
+      subAgent,
+    });
+    this.invalidateThreadListCache(record.backend);
+    await this.emit({
+      backend: record.backend,
+      notification: {
+        method: "thread/subAgents/updated",
+        params: {
+          threadId: record.parentThreadId,
+        },
+      },
+    });
+  }
+
+  private async completeReviewSubAgent(params: {
+    backend: AppServerBackendKind;
+    method: AppServerNotification["method"];
+    threadId: string;
+    turnId: string;
+  }): Promise<void> {
+    const key = buildReviewSubAgentKey(params.backend, params.threadId, params.turnId);
+    const record = this.activeReviewSubAgents.get(key);
+    if (!record) {
+      return;
+    }
+
+    this.activeReviewSubAgents.delete(key);
+    const completedAt = Date.now();
+    if (params.method === "turn/completed") {
+      await this.persistReviewSubAgent(record, {
+        completedAt,
+        lastMessage: "Review completed.",
+        outcome: "success",
+        status: "success",
+        updatedAt: completedAt,
+      });
+      return;
+    }
+
+    if (params.method === "turn/cancelled") {
+      await this.persistReviewSubAgent(record, {
+        completedAt,
+        lastMessage: "Review cancelled.",
+        outcome: "cancelled",
+        status: "cancelled",
+        updatedAt: completedAt,
+      });
+      return;
+    }
+
+    await this.persistReviewSubAgent(record, {
+      completedAt,
+      lastMessage: "Review failed.",
+      outcome: "failure",
+      status: "failed",
+      updatedAt: completedAt,
+    });
+  }
+
   private recordTaskMonitorActivity(notification: AppServerNotification): void {
     const params = readRecord(notification.params);
     const threadId = typeof params?.threadId === "string" ? params.threadId : undefined;
@@ -12359,6 +12517,14 @@ export class DesktopBackendRegistry {
         };
       };
       const turnId = turnIdFromTerminalNotification(notification);
+      if (turnId) {
+        await this.completeReviewSubAgent({
+          backend: event.backend,
+          method: event.notification.method,
+          threadId: notification.params.threadId,
+          turnId,
+        });
+      }
       if (turnId) {
         this.activeTurnKeys.delete(
           buildActiveTurnKey(event.backend, notification.params.threadId, turnId),

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1866,6 +1866,31 @@ function turnIdFromTerminalNotification(
   return notification.params.turnId ?? notification.params.turn?.id ?? undefined;
 }
 
+function normalizeNotificationTimestamp(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return undefined;
+  }
+
+  return value < 1_000_000_000_000 ? value * 1_000 : value;
+}
+
+function completedAtFromTerminalNotification(
+  notification: AppServerNotification,
+): number | undefined {
+  if (
+    notification.method !== "turn/completed" &&
+    notification.method !== "turn/failed" &&
+    notification.method !== "turn/cancelled"
+  ) {
+    return undefined;
+  }
+
+  return normalizeNotificationTimestamp(
+    readRecord(notification.params.turn)?.completedAt ??
+      readRecord(notification.params.turn)?.completed_at,
+  );
+}
+
 function finalTextFromTerminalNotification(
   notification: AppServerNotification,
 ): string | undefined {
@@ -9824,6 +9849,7 @@ export class DesktopBackendRegistry {
 
   private async completeReviewSubAgent(params: {
     backend: AppServerBackendKind;
+    completedAt?: number;
     method: AppServerNotification["method"];
     threadId: string;
     turnId: string;
@@ -9835,7 +9861,7 @@ export class DesktopBackendRegistry {
     }
 
     this.activeReviewSubAgents.delete(key);
-    const completedAt = Date.now();
+    const completedAt = params.completedAt ?? Date.now();
     if (params.method === "turn/completed") {
       await this.persistReviewSubAgent(record, {
         completedAt,
@@ -12631,6 +12657,7 @@ export class DesktopBackendRegistry {
       if (turnId) {
         await this.completeReviewSubAgent({
           backend: event.backend,
+          completedAt: completedAtFromTerminalNotification(event.notification),
           method: event.notification.method,
           threadId: notification.params.threadId,
           turnId,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -2982,6 +2982,10 @@ export class DesktopBackendRegistry {
   private readonly activeCodexReviewTurnKeys = new Set<string>();
   private readonly activeCodexReviewInterruptTurnIds = new Map<string, string>();
   private readonly activeReviewSubAgents = new Map<string, ReviewSubAgentRecord>();
+  private readonly reviewSubAgentsByReviewTurn = new Map<
+    string,
+    ReviewSubAgentRecord
+  >();
   private readonly observedCodexSettingsByThread = new Map<string, ObservedCodexSettings>();
   private readonly reservedCodexStartThreadIds = new Set<string>();
   private readonly reservedAcpStartThreadKeys = new Set<string>();
@@ -6173,14 +6177,13 @@ export class DesktopBackendRegistry {
       task: reviewTaskLabel(params.target),
       turnId: result.turnId,
     };
-    this.activeReviewSubAgents.set(
-      buildReviewSubAgentKey(
-        reviewSubAgentRecord.backend,
-        reviewSubAgentRecord.reviewThreadId,
-        reviewSubAgentRecord.turnId,
-      ),
-      reviewSubAgentRecord,
+    const reviewSubAgentKey = buildReviewSubAgentKey(
+      reviewSubAgentRecord.backend,
+      reviewSubAgentRecord.reviewThreadId,
+      reviewSubAgentRecord.turnId,
     );
+    this.activeReviewSubAgents.set(reviewSubAgentKey, reviewSubAgentRecord);
+    this.reviewSubAgentsByReviewTurn.set(reviewSubAgentKey, reviewSubAgentRecord);
     await this.persistReviewSubAgent(reviewSubAgentRecord);
     if (hasExplicitModelSettings(modelSettings)) {
       await this.overlayStore.setThreadModelSettings({
@@ -6261,11 +6264,9 @@ export class DesktopBackendRegistry {
       const activeTurnModeKey = buildActiveTurnModeKey(result.threadId, result.turnId);
       this.activeCodexTurnModes.delete(activeTurnModeKey);
       this.activeCodexReviewTurnKeys.delete(activeTurnModeKey);
-      this.clearCodexReviewInterruptMappingForTurn(result.threadId, result.turnId);
       if (requestedCodexTurnModeKey && requestedCodexTurnModeKey !== activeTurnModeKey) {
         this.activeCodexTurnModes.delete(requestedCodexTurnModeKey);
         this.activeCodexReviewTurnKeys.delete(requestedCodexTurnModeKey);
-        this.activeCodexReviewInterruptTurnIds.delete(requestedCodexTurnModeKey);
       }
     }
 
@@ -9631,9 +9632,13 @@ export class DesktopBackendRegistry {
         });
         return;
       }
+      const completedReviewRecord = this.reviewSubAgentsByReviewTurn.get(reviewKey);
       const reviewUsagePersisted = await this.persistExistingReviewSubAgentUsage({
         backend: event.backend,
-        threadId: notification.params.threadId,
+        parentThreadId:
+          completedReviewRecord?.parentThreadId ?? notification.params.threadId,
+        reviewThreadId:
+          completedReviewRecord?.reviewThreadId ?? notification.params.threadId,
         turnId: notification.params.turnId,
         usage: usageSnapshot,
       });
@@ -9668,19 +9673,20 @@ export class DesktopBackendRegistry {
 
   private async persistExistingReviewSubAgentUsage(params: {
     backend: AppServerBackendKind;
-    threadId: string;
+    parentThreadId: string;
+    reviewThreadId: string;
     turnId: string;
     usage: ThreadSubAgentSummary["monitorUsage"];
   }): Promise<boolean> {
     const overlay = await this.overlayStore.getThreadOverlayState({
       backend: params.backend,
-      threadId: params.threadId,
+      threadId: params.parentThreadId,
     });
     const monitorId = reviewSubAgentId(params.turnId);
     const existing = overlay?.subAgents?.find(
       (subAgent) =>
         subAgent.monitorId === monitorId ||
-        (subAgent.monitorThreadId === params.threadId &&
+        (subAgent.monitorThreadId === params.reviewThreadId &&
           subAgent.monitorTurnId === params.turnId),
     );
     if (!existing) {
@@ -9689,7 +9695,7 @@ export class DesktopBackendRegistry {
 
     await this.overlayStore.upsertThreadSubAgent({
       backend: params.backend,
-      threadId: params.threadId,
+      threadId: params.parentThreadId,
       subAgent: {
         ...existing,
         monitorUsage: params.usage,
@@ -9702,7 +9708,7 @@ export class DesktopBackendRegistry {
       notification: {
         method: "thread/subAgents/updated",
         params: {
-          threadId: params.threadId,
+          threadId: params.parentThreadId,
         },
       },
     });
@@ -9854,13 +9860,13 @@ export class DesktopBackendRegistry {
     threadId: string;
     turnId: string;
   }): Promise<void> {
-    const key = buildReviewSubAgentKey(params.backend, params.threadId, params.turnId);
-    const record = this.activeReviewSubAgents.get(key);
-    if (!record) {
+    const activeReview = this.findActiveReviewSubAgentForTerminal(params);
+    if (!activeReview) {
       return;
     }
 
-    this.activeReviewSubAgents.delete(key);
+    this.activeReviewSubAgents.delete(activeReview.key);
+    const { record } = activeReview;
     const completedAt = params.completedAt ?? Date.now();
     if (params.method === "turn/completed") {
       await this.persistReviewSubAgent(record, {
@@ -9891,6 +9897,41 @@ export class DesktopBackendRegistry {
       status: "failed",
       updatedAt: completedAt,
     });
+  }
+
+  private findActiveReviewSubAgentForTerminal(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    turnId: string;
+  }): { key: string; record: ReviewSubAgentRecord } | undefined {
+    const exactKey = buildReviewSubAgentKey(
+      params.backend,
+      params.threadId,
+      params.turnId,
+    );
+    const exactRecord = this.activeReviewSubAgents.get(exactKey);
+    if (exactRecord) {
+      return { key: exactKey, record: exactRecord };
+    }
+
+    if (params.backend !== "codex") {
+      return undefined;
+    }
+
+    for (const [key, record] of this.activeReviewSubAgents.entries()) {
+      if (record.backend !== params.backend || record.reviewThreadId !== params.threadId) {
+        continue;
+      }
+      const reviewTurnKey = buildActiveTurnModeKey(
+        record.reviewThreadId,
+        record.turnId,
+      );
+      if (this.activeCodexReviewInterruptTurnIds.get(reviewTurnKey) === params.turnId) {
+        return { key, record };
+      }
+    }
+
+    return undefined;
   }
 
   private recordTaskMonitorActivity(notification: AppServerNotification): void {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -2094,6 +2094,15 @@ type ModelSettings = {
   fastMode?: boolean;
 };
 
+function hasExplicitModelSettings(settings: ModelSettings): boolean {
+  return (
+    settings.model !== undefined ||
+    settings.reasoningEffort !== undefined ||
+    settings.serviceTier !== undefined ||
+    settings.fastMode !== undefined
+  );
+}
+
 type CodexFastModeMismatchWarning = {
   threadId: string;
   turnId: string;
@@ -6052,7 +6061,9 @@ export class DesktopBackendRegistry {
       }
       this.reservedCodexStartThreadIds.add(params.threadId);
     }
-    const modelSettings = await this.resolveModelSettings(params.backend, params);
+    const modelSettings = hasExplicitModelSettings(params)
+      ? await this.resolveModelSettings(params.backend, params)
+      : {};
 
     let result: { threadId: string; reviewThreadId: string; turnId: string };
     try {
@@ -6146,12 +6157,7 @@ export class DesktopBackendRegistry {
       reviewSubAgentRecord,
     );
     await this.persistReviewSubAgent(reviewSubAgentRecord);
-    if (
-      modelSettings.model !== undefined ||
-      modelSettings.reasoningEffort !== undefined ||
-      modelSettings.serviceTier !== undefined ||
-      modelSettings.fastMode !== undefined
-    ) {
+    if (hasExplicitModelSettings(modelSettings)) {
       await this.overlayStore.setThreadModelSettings({
         backend: params.backend,
         threadId: result.threadId,
@@ -8294,6 +8300,10 @@ export class DesktopBackendRegistry {
           threadId: startThreadResponse.threadId,
           target: request.reviewTarget,
           delivery: "inline",
+          model: launchpad.model,
+          reasoningEffort: launchpad.reasoningEffort,
+          serviceTier: launchpad.serviceTier,
+          fastMode: launchpad.backend === "codex" ? launchpad.fastMode : undefined,
         });
         turnId = reviewResponse.turnId;
       } catch (error) {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1500,6 +1500,7 @@ type TaskMonitorDelegationRecord = {
 type ReviewSubAgentRecord = {
   backend: Exclude<AppServerBackendKind, AcpBackendId>;
   createdAt: number;
+  latestUsage?: TaskMonitorUsageSnapshot;
   parentThreadId: string;
   reviewThreadId: string;
   task: string;
@@ -9556,6 +9557,27 @@ export class DesktopBackendRegistry {
       return;
     }
 
+    if (notification.params.turnId) {
+      const reviewKey = buildReviewSubAgentKey(
+        "codex",
+        notification.params.threadId,
+        notification.params.turnId,
+      );
+      const reviewRecord = this.activeReviewSubAgents.get(reviewKey);
+      if (reviewRecord) {
+        const usageSnapshot = buildTaskMonitorUsageSnapshot({
+          tokenUsage: notification.params.tokenUsage,
+        });
+        if (usageSnapshot) {
+          reviewRecord.latestUsage = usageSnapshot;
+          await this.persistReviewSubAgent(reviewRecord, {
+            monitorUsage: usageSnapshot,
+          });
+        }
+        return;
+      }
+    }
+
     const monitorRecord = Array.from(this.taskMonitorDelegations.values()).find(
       (record) => record.monitorThreadId === notification.params.threadId,
     );
@@ -9689,8 +9711,11 @@ export class DesktopBackendRegistry {
       ...(patch.completedAt ?? existing?.completedAt
         ? { completedAt: patch.completedAt ?? existing?.completedAt }
         : {}),
-      ...(patch.monitorUsage ?? existing?.monitorUsage
-        ? { monitorUsage: patch.monitorUsage ?? existing?.monitorUsage }
+      ...(patch.monitorUsage ?? record.latestUsage ?? existing?.monitorUsage
+        ? {
+            monitorUsage:
+              patch.monitorUsage ?? record.latestUsage ?? existing?.monitorUsage,
+          }
         : {}),
     };
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -431,6 +431,10 @@ type BackendClient = {
     threadId: string;
     target: StartReviewRequest["target"];
     delivery?: StartReviewRequest["delivery"];
+    model?: string;
+    serviceTier?: string;
+    reasoningEffort?: string;
+    fastMode?: boolean;
     cwd?: string;
     codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
   }): Promise<{ threadId: string; reviewThreadId: string; turnId: string }>;
@@ -6048,6 +6052,7 @@ export class DesktopBackendRegistry {
       }
       this.reservedCodexStartThreadIds.add(params.threadId);
     }
+    const modelSettings = await this.resolveModelSettings(params.backend, params);
 
     let result: { threadId: string; reviewThreadId: string; turnId: string };
     try {
@@ -6080,6 +6085,7 @@ export class DesktopBackendRegistry {
           threadId: params.threadId,
           target: params.target,
           delivery: params.delivery ?? "inline",
+          ...modelSettings,
           ...(cwd ? { cwd } : {}),
           ...(overlay?.codexEnvironmentRuntime
             ? { codexEnvironmentRuntime: overlay.codexEnvironmentRuntime }
@@ -6140,6 +6146,18 @@ export class DesktopBackendRegistry {
       reviewSubAgentRecord,
     );
     await this.persistReviewSubAgent(reviewSubAgentRecord);
+    if (
+      modelSettings.model !== undefined ||
+      modelSettings.reasoningEffort !== undefined ||
+      modelSettings.serviceTier !== undefined ||
+      modelSettings.fastMode !== undefined
+    ) {
+      await this.overlayStore.setThreadModelSettings({
+        backend: params.backend,
+        threadId: result.threadId,
+        ...modelSettings,
+      });
+    }
 
     return {
       backend: params.backend,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -2907,6 +2907,7 @@ export class DesktopBackendRegistry {
   >();
   private readonly activeCodexTurnModes = new Map<string, ThreadExecutionMode>();
   private readonly activeCodexReviewTurnKeys = new Set<string>();
+  private readonly activeCodexReviewInterruptTurnIds = new Map<string, string>();
   private readonly observedCodexSettingsByThread = new Map<string, ObservedCodexSettings>();
   private readonly reservedCodexStartThreadIds = new Set<string>();
   private readonly reservedAcpStartThreadKeys = new Set<string>();
@@ -6121,18 +6122,36 @@ export class DesktopBackendRegistry {
       return params;
     }
 
+    const requestedCodexTurnModeKey =
+      params.backend === "codex"
+        ? buildActiveTurnModeKey(params.threadId, params.turnId)
+        : undefined;
+    const codexInterruptTurnId =
+      requestedCodexTurnModeKey
+        ? this.activeCodexReviewInterruptTurnIds.get(requestedCodexTurnModeKey) ??
+          params.turnId
+        : params.turnId;
+    const interruptParams =
+      params.backend === "codex" && codexInterruptTurnId !== params.turnId
+        ? { ...params, turnId: codexInterruptTurnId }
+        : params;
     const activeCodexTurnMode =
       params.backend === "codex"
         ? this.activeCodexTurnModes.get(
-            buildActiveTurnModeKey(params.threadId, params.turnId),
-          )
+            buildActiveTurnModeKey(params.threadId, codexInterruptTurnId),
+          ) ??
+          (requestedCodexTurnModeKey
+            ? this.activeCodexTurnModes.get(requestedCodexTurnModeKey)
+            : undefined)
         : undefined;
     const result =
       params.backend === "codex" && activeCodexTurnMode
-        ? await this.getClient("codex", activeCodexTurnMode).interruptTurn(params)
+        ? await this.getClient("codex", activeCodexTurnMode).interruptTurn(
+            interruptParams,
+          )
         : params.backend === "codex"
           ? await this.withCodexThreadClient(params.threadId, async (client) =>
-              await client.interruptTurn(params),
+              await client.interruptTurn(interruptParams),
             )
         : await this.grokClient.interruptTurn(params);
 
@@ -6140,6 +6159,12 @@ export class DesktopBackendRegistry {
       const activeTurnModeKey = buildActiveTurnModeKey(result.threadId, result.turnId);
       this.activeCodexTurnModes.delete(activeTurnModeKey);
       this.activeCodexReviewTurnKeys.delete(activeTurnModeKey);
+      this.clearCodexReviewInterruptMappingForTurn(result.threadId, result.turnId);
+      if (requestedCodexTurnModeKey && requestedCodexTurnModeKey !== activeTurnModeKey) {
+        this.activeCodexTurnModes.delete(requestedCodexTurnModeKey);
+        this.activeCodexReviewTurnKeys.delete(requestedCodexTurnModeKey);
+        this.activeCodexReviewInterruptTurnIds.delete(requestedCodexTurnModeKey);
+      }
     }
 
     return {
@@ -6923,13 +6948,35 @@ export class DesktopBackendRegistry {
   }
 
   private threadHasActiveCodexReviewTurn(threadId: string): boolean {
+    return Boolean(this.findActiveCodexReviewTurnKey(threadId));
+  }
+
+  private findActiveCodexReviewTurnKey(threadId: string): string | undefined {
     const prefix = `${threadId}:`;
     for (const key of this.activeCodexReviewTurnKeys) {
       if (key.startsWith(prefix)) {
-        return true;
+        return key;
       }
     }
-    return false;
+    return undefined;
+  }
+
+  private clearCodexReviewInterruptMappingForTurn(
+    threadId: string,
+    turnId: string,
+  ): void {
+    const activeTurnModeKey = buildActiveTurnModeKey(threadId, turnId);
+    this.activeCodexReviewInterruptTurnIds.delete(activeTurnModeKey);
+    for (const [reviewTurnKey, interruptTurnId] of Array.from(
+      this.activeCodexReviewInterruptTurnIds.entries()
+    )) {
+      if (
+        reviewTurnKey.startsWith(`${threadId}:`) &&
+        interruptTurnId === turnId
+      ) {
+        this.activeCodexReviewInterruptTurnIds.delete(reviewTurnKey);
+      }
+    }
   }
 
   private async resolveCodexThreadExecutionModeForActiveTurn(
@@ -12280,6 +12327,12 @@ export class DesktopBackendRegistry {
           notification.params.threadId,
           turnId,
         );
+        const activeReviewTurnKey = this.findActiveCodexReviewTurnKey(
+          notification.params.threadId,
+        );
+        if (activeReviewTurnKey && activeReviewTurnKey !== key) {
+          this.activeCodexReviewInterruptTurnIds.set(activeReviewTurnKey, turnId);
+        }
         if (!this.activeCodexTurnModes.has(key)) {
           this.activeCodexTurnModes.set(
             key,
@@ -12319,6 +12372,10 @@ export class DesktopBackendRegistry {
         const wasKnownActiveTurn =
           !turnId.startsWith("pending:") &&
           this.activeCodexTurnModes.has(activeTurnModeKey);
+        this.clearCodexReviewInterruptMappingForTurn(
+          notification.params.threadId,
+          turnId,
+        );
         this.activeCodexTurnModes.delete(activeTurnModeKey);
         this.activeCodexReviewTurnKeys.delete(activeTurnModeKey);
         if (wasKnownActiveTurn) {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -9580,30 +9580,45 @@ export class DesktopBackendRegistry {
     };
   }
 
-  private async recordTaskMonitorUsage(notification: AppServerNotification): Promise<void> {
+  private async recordTaskMonitorUsage(event: AgentEvent): Promise<void> {
+    const notification = event.notification;
     if (notification.method !== "thread/tokenUsage/updated") {
       return;
     }
 
     if (notification.params.turnId) {
       const reviewKey = buildReviewSubAgentKey(
-        "codex",
+        event.backend,
         notification.params.threadId,
         notification.params.turnId,
       );
       const reviewRecord = this.activeReviewSubAgents.get(reviewKey);
-      if (reviewRecord) {
-        const usageSnapshot = buildTaskMonitorUsageSnapshot({
-          tokenUsage: notification.params.tokenUsage,
-        });
-        if (usageSnapshot) {
-          reviewRecord.latestUsage = usageSnapshot;
-          await this.persistReviewSubAgent(reviewRecord, {
-            monitorUsage: usageSnapshot,
-          });
-        }
+      const usageSnapshot = buildTaskMonitorUsageSnapshot({
+        tokenUsage: notification.params.tokenUsage,
+      });
+      if (!usageSnapshot) {
         return;
       }
+      if (reviewRecord) {
+        reviewRecord.latestUsage = usageSnapshot;
+        await this.persistReviewSubAgent(reviewRecord, {
+          monitorUsage: usageSnapshot,
+        });
+        return;
+      }
+      const reviewUsagePersisted = await this.persistExistingReviewSubAgentUsage({
+        backend: event.backend,
+        threadId: notification.params.threadId,
+        turnId: notification.params.turnId,
+        usage: usageSnapshot,
+      });
+      if (reviewUsagePersisted) {
+        return;
+      }
+    }
+
+    if (event.backend !== "codex") {
+      return;
     }
 
     const monitorRecord = Array.from(this.taskMonitorDelegations.values()).find(
@@ -9624,6 +9639,49 @@ export class DesktopBackendRegistry {
         monitorUsage: usageSnapshot,
       });
     }
+  }
+
+  private async persistExistingReviewSubAgentUsage(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    turnId: string;
+    usage: ThreadSubAgentSummary["monitorUsage"];
+  }): Promise<boolean> {
+    const overlay = await this.overlayStore.getThreadOverlayState({
+      backend: params.backend,
+      threadId: params.threadId,
+    });
+    const monitorId = reviewSubAgentId(params.turnId);
+    const existing = overlay?.subAgents?.find(
+      (subAgent) =>
+        subAgent.monitorId === monitorId ||
+        (subAgent.monitorThreadId === params.threadId &&
+          subAgent.monitorTurnId === params.turnId),
+    );
+    if (!existing) {
+      return false;
+    }
+
+    await this.overlayStore.upsertThreadSubAgent({
+      backend: params.backend,
+      threadId: params.threadId,
+      subAgent: {
+        ...existing,
+        monitorUsage: params.usage,
+        updatedAt: Date.now(),
+      },
+    });
+    this.invalidateThreadListCache(params.backend);
+    await this.emit({
+      backend: params.backend,
+      notification: {
+        method: "thread/subAgents/updated",
+        params: {
+          threadId: params.threadId,
+        },
+      },
+    });
+    return true;
   }
 
   private async persistTaskMonitorSubAgent(
@@ -12505,8 +12563,8 @@ export class DesktopBackendRegistry {
   private async emit(event: AgentEvent): Promise<void> {
     if (event.backend === "codex") {
       this.recordTaskMonitorActivity(event.notification);
-      await this.recordTaskMonitorUsage(event.notification);
     }
+    await this.recordTaskMonitorUsage(event);
 
     if (this.shouldInvalidateThreadListCacheForNotification(event.notification.method)) {
       this.invalidateThreadListCache(event.backend);

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -5823,8 +5823,10 @@ export class CodexAppServerClient {
     const turnRecord = asRecord(record?.turn);
     const turnId =
       extractTurnIdFromValue(result) ??
-      pickString(turnRecord ?? {}, ["id", "turnId", "turn_id"]) ??
-      `pending:${reviewThreadId}`;
+      pickString(turnRecord ?? {}, ["id", "turnId", "turn_id"]);
+    if (!turnId) {
+      throw new Error("codex app server review/start did not return turnId");
+    }
     this.pendingFirstTurnThreadResults.delete(params.threadId);
 
     return {

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -2165,7 +2165,10 @@ function extractPlanEntryFromItem(
 
 function extractReviewEntryFromItem(
   item: Record<string, unknown>,
-  createdAt?: number,
+  timestamps: {
+    itemCreatedAt?: number;
+    turnCreatedAt?: number;
+  },
   turn?: AppServerThreadTurnMetadata,
 ): AppServerThreadReviewEntry | undefined {
   const reviewEvent = normalizeReviewEventItem(item);
@@ -2174,6 +2177,10 @@ function extractReviewEntryFromItem(
   }
 
   const { event, item: reviewItem, parent } = reviewEvent;
+  const createdAt =
+    timestamps.itemCreatedAt ??
+    (event === "exitedreviewmode" ? turn?.completedAt : undefined) ??
+    timestamps.turnCreatedAt;
   const reviewOutput = normalizeReviewOutput(reviewItem);
   const review =
     pickRawString(reviewItem, ["review", "text"]) ??
@@ -3503,7 +3510,11 @@ function extractThreadEntries(value: unknown): AppServerThreadEntry[] {
         continue;
       }
 
-      const reviewEntry = extractReviewEntryFromItem(item, createdAt, turnMetadata);
+      const reviewEntry = extractReviewEntryFromItem(
+        item,
+        { itemCreatedAt, turnCreatedAt: createdAt },
+        turnMetadata
+      );
       if (reviewEntry) {
         flushActivityItems();
         const assistantReviewText =

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -58,6 +58,7 @@ import type {
   ThreadListParams as CodexThreadListParams,
   ThreadReadParams as CodexThreadReadParams,
   ThreadResumeParams as CodexThreadResumeParams,
+  ThreadSettingsUpdateParams as CodexThreadSettingsUpdateParams,
   ThreadStartParams as CodexThreadStartParams,
   TurnInterruptParams as CodexTurnInterruptParams,
   TurnStartParams as CodexTurnStartParams,
@@ -4715,6 +4716,38 @@ function buildReviewStartPayload(params: {
   };
 }
 
+function buildThreadSettingsUpdatePayload(params: {
+  threadId: string;
+  model?: string;
+  serviceTier?: string | null;
+  reasoningEffort?: string;
+  fastMode?: boolean;
+}): CodexThreadSettingsUpdateParams | undefined {
+  const payload: CodexThreadSettingsUpdateParams = {
+    threadId: params.threadId,
+  };
+
+  if (params.model?.trim()) {
+    payload.model = params.model.trim();
+  }
+
+  const serviceTier = normalizeCodexServiceTier(resolveCodexServiceTier(params));
+  if (serviceTier !== undefined) {
+    payload.serviceTier = serviceTier;
+  }
+
+  const effort = normalizeCodexReasoningEffort(params.reasoningEffort);
+  if (effort) {
+    payload.effort = effort;
+  }
+
+  return payload.model !== undefined ||
+    payload.serviceTier !== undefined ||
+    payload.effort !== undefined
+    ? payload
+    : undefined;
+}
+
 type CodexThreadReadPayload = CodexThreadReadParams & {
   before?: string;
   limit?: number;
@@ -5793,6 +5826,10 @@ export class CodexAppServerClient {
     threadId: string;
     target: AppServerReviewTarget;
     delivery?: AppServerReviewDelivery;
+    model?: string;
+    serviceTier?: string | null;
+    reasoningEffort?: string;
+    fastMode?: boolean;
     cwd?: string;
     codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
   }): Promise<{ threadId: string; reviewThreadId: string; turnId: string }> {
@@ -5805,10 +5842,24 @@ export class CodexAppServerClient {
         payloads: buildThreadResumePayloads({
           threadId: params.threadId,
           cwd: params.cwd,
+          model: params.model,
+          serviceTier: params.serviceTier,
+          reasoningEffort: params.reasoningEffort,
+          fastMode: params.fastMode,
           codexEnvironmentRuntime: params.codexEnvironmentRuntime,
         }),
         timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
       }).catch(() => undefined);
+    }
+
+    const settingsPayload = buildThreadSettingsUpdatePayload(params);
+    if (settingsPayload) {
+      await requestWithFallbacks({
+        client: this.connection,
+        methods: ["thread/settings/update"],
+        payloads: [settingsPayload],
+        timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+      });
     }
 
     const result = await requestWithFallbacks({

--- a/apps/desktop/src/main/grok-app-server/client.ts
+++ b/apps/desktop/src/main/grok-app-server/client.ts
@@ -1017,6 +1017,10 @@ export class GrokAppServerClient {
 
     await this.request("thread/resume", {
       threadId: params.threadId,
+      model: params.model,
+      serviceTier: params.serviceTier ?? undefined,
+      reasoningEffort: params.reasoningEffort,
+      fastMode: params.fastMode,
     });
 
     const result = await this.request("review/start", {

--- a/apps/desktop/src/main/grok-app-server/client.ts
+++ b/apps/desktop/src/main/grok-app-server/client.ts
@@ -1008,6 +1008,10 @@ export class GrokAppServerClient {
     threadId: string;
     target: AppServerReviewTarget;
     delivery?: AppServerReviewDelivery;
+    model?: string;
+    serviceTier?: string | null;
+    reasoningEffort?: string;
+    fastMode?: boolean;
   }): Promise<{ threadId: string; reviewThreadId: string; turnId: string }> {
     await this.ensureInitialized();
 

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -2986,6 +2986,14 @@ export function Composer(props: ComposerProps) {
         threadId: props.thread.id,
         target: reviewCommand.target,
         delivery: "inline",
+        ...(selectedModelOption?.id ? { model: selectedModelOption.id } : {}),
+        ...(supportsReasoning && selectedReasoningEffort
+          ? { reasoningEffort: selectedReasoningEffort }
+          : {}),
+        ...(selectedServiceTier ? { serviceTier: selectedServiceTier } : {}),
+        ...(props.thread.source === "codex" && supportsFast
+          ? { fastMode: Boolean(currentSettings?.fastMode) }
+          : {}),
       });
       inFlightReviewSubmissionKeyRef.current = undefined;
       updateActiveTurnId(response.turnId, { review: true });

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -4124,6 +4124,77 @@ describe("Composer", () => {
     expect(startTurn).not.toHaveBeenCalled();
   });
 
+  it("starts slash reviews with the current composer model settings", async () => {
+    const startReview = vi.fn(async (request: StartReviewRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      reviewThreadId: request.threadId,
+      turnId: "turn-review-1",
+    }));
+
+    render(
+      <Composer
+        backends={[
+          {
+            ...backendSummary("codex", {
+              models: [
+                {
+                  id: "gpt-5.5",
+                  label: "GPT-5.5",
+                  current: true,
+                  supportsFast: true,
+                  supportsReasoning: true,
+                },
+              ],
+              reasoningEfforts: ["medium", "high"],
+            }),
+            capabilities: {
+              ...backendSummary("codex").capabilities,
+              startReview: true,
+            },
+          },
+        ]}
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Review thread",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+          model: "gpt-5.5",
+          reasoningEffort: "high",
+          serviceTier: "priority",
+          fastMode: true,
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review main" },
+    });
+    await clickButton("Send");
+
+    await waitFor(() => {
+      expect(startReview).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        target: { type: "baseBranch", branch: "main" },
+        delivery: "inline",
+        model: "gpt-5.5",
+        reasoningEffort: "high",
+        serviceTier: "priority",
+        fastMode: true,
+      });
+    });
+  });
+
   it("ignores a duplicate slash review submit while the review start is pending", async () => {
     const startTurn = vi.fn();
     const addOptimisticReviewEntry = vi.fn(() => "review-optimistic-1");
@@ -4512,6 +4583,7 @@ describe("Composer", () => {
         threadId: "thread-1",
         target: { type: "baseBranch", branch: "main" },
         delivery: "inline",
+        model: "gpt-5.5",
       });
     });
   });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -283,6 +283,41 @@ describe("ThreadContextPanel", () => {
     expect(detailsButtons[0]).toHaveFocus();
   });
 
+  it("labels review sub-agent usage separately from monitor usage", () => {
+    renderPanel({
+      activeTab: "subagents",
+      pinned: true,
+      thread: {
+        ...baseThread,
+        subAgents: [
+          {
+            monitorId: "review:turn-review-1",
+            task: "Review changes against main",
+            status: "running",
+            createdAt: 2000,
+            updatedAt: 2500,
+            monitorThreadId: "thread-1",
+            monitorTurnId: "turn-review-1",
+            monitorUsage: {
+              summary: "800 uncached in · 200 cached · 50 out",
+              tokenUsage: {
+                inputTokens: 1000,
+                cachedInputTokens: 200,
+                uncachedInputTokens: 800,
+                outputTokens: 50,
+                totalTokens: 1050,
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(
+      screen.getByText("Review usage: 800 uncached in · 200 cached · 50 out"),
+    ).toBeInTheDocument();
+  });
+
   it("moves focus between tabs with Arrow keys (roving tablist)", () => {
     renderPanel({ pinned: true });
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts
@@ -8,6 +8,53 @@ import {
 } from "../live-transcript-activity";
 
 describe("buildLiveToolDetails", () => {
+  it("surfaces Codex function call activity while reviews run", () => {
+    const details = buildLiveToolDetails({
+      type: "functionCall",
+      call_id: "call-1",
+      name: "exec_command",
+      status: "completed",
+      arguments: {
+        cmd: "git diff main",
+      },
+      output: "diff --git a/app.ts b/app.ts",
+    });
+
+    expect(details).toEqual([
+      {
+        id: "call-1",
+        kind: "command",
+        label: "git diff main",
+        status: "completed",
+        command: expect.objectContaining({
+          displayCommand: "git diff main",
+          rawCommand: "git diff main",
+        }),
+      },
+    ]);
+  });
+
+  it("surfaces review read/search function calls as live activity", () => {
+    const details = buildLiveToolDetails({
+      type: "functionCall",
+      call_id: "call-search",
+      name: "search_query",
+      status: "inProgress",
+      arguments: {
+        query: "review/start app server",
+      },
+    });
+
+    expect(details).toEqual([
+      {
+        id: "call-search",
+        kind: "read",
+        label: "search query: review/start app server",
+        status: "in_progress",
+      },
+    ]);
+  });
+
   it("surfaces collaboration agent activity from live tool items", () => {
     const details = buildLiveToolDetails({
       type: "collabAgentToolCall",

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
@@ -61,7 +61,8 @@ export function SubAgentsPanel(props: SubAgentsPanelProps) {
                 ) : null}
                 {subAgent.monitorUsage?.summary ? (
                   <p className="subagent-card__usage">
-                    Monitor usage: {subAgent.monitorUsage.summary}
+                    {subAgent.monitorId.startsWith("review:") ? "Review" : "Monitor"} usage:{" "}
+                    {subAgent.monitorUsage.summary}
                   </p>
                 ) : null}
                 <button

--- a/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
@@ -97,7 +97,9 @@ function normalizeTimestamp(value: unknown): number | undefined {
 }
 
 function readToolArgument(item: Record<string, unknown>, key: string): string | undefined {
-  return readString(readRecord(item.arguments), key);
+  const argumentsRecord =
+    readRecord(item.arguments) ?? readRecord(item.input);
+  return readString(argumentsRecord, key);
 }
 
 function readToolOutputText(item: Record<string, unknown>): string | undefined {
@@ -888,6 +890,14 @@ function buildLiveToolLabel(
     );
   }
 
+  if (itemType === "functioncall" && toolName === "exec_command") {
+    const command =
+      readToolArgument(item, "cmd") ??
+      readToolArgument(item, "command") ??
+      readToolArgument(item, "displayCommand");
+    return command ? formatCommandLabel(command) : formatLiveToolName(toolName, status);
+  }
+
   if (itemType === "mcptoolcall") {
     const serverName = readString(item, "server") ?? readString(item, "serverName");
     return formatMcpToolName(serverName, toolName, status);
@@ -1019,6 +1029,7 @@ export function buildLiveToolDetails(
   if (
     itemType !== "dynamictoolcall" &&
     itemType !== "commandexecution" &&
+    itemType !== "functioncall" &&
     itemType !== "mcptoolcall" &&
     itemType !== "collabagenttoolcall" &&
     itemType !== "websearch"
@@ -1026,7 +1037,13 @@ export function buildLiveToolDetails(
     return [];
   }
 
-  const itemId = readString(item, "id") ?? readString(item, "itemId") ?? "tool";
+  const itemId =
+    readString(item, "id") ??
+    readString(item, "itemId") ??
+    readString(item, "item_id") ??
+    readString(item, "call_id") ??
+    readString(item, "callId") ??
+    "tool";
   const toolName =
     readString(item, "tool") ??
     readString(item, "toolName") ??
@@ -1040,18 +1057,29 @@ export function buildLiveToolDetails(
       ? summarizeJsonValue(item.error) ?? summarizeJsonValue(item.result)
       : summarizeToolOutput(readToolOutputText(item));
   const elapsedMs = readElapsedMs(item);
-  const command = itemType === "commandexecution" ? readString(item, "command") : undefined;
-  const commandDetail = itemType === "commandexecution"
-    ? buildLiveCommandDetail(item, command, elapsedMs)
-    : itemType === "collabagenttoolcall"
-      ? buildCollabAgentCommandDetail(item, toolName, readStringArray(item.receiverThreadIds))
-    : undefined;
+  const command =
+    itemType === "commandexecution"
+      ? readString(item, "command")
+      : itemType === "functioncall" && toolName === "exec_command"
+        ? readToolArgument(item, "cmd") ??
+          readToolArgument(item, "command") ??
+          readToolArgument(item, "displayCommand")
+        : undefined;
+  const isExecFunctionCall = itemType === "functioncall" && toolName === "exec_command";
+  const commandDetail =
+    itemType === "commandexecution" || isExecFunctionCall
+      ? buildLiveCommandDetail(item, command, elapsedMs)
+      : itemType === "collabagenttoolcall"
+        ? buildCollabAgentCommandDetail(item, toolName, readStringArray(item.receiverThreadIds))
+        : undefined;
   const details: AppServerThreadActivityDetail[] = [
     {
       id: itemId,
       kind:
         itemType === "commandexecution"
           ? readCommandActivityKind(item)
+          : isExecFunctionCall
+            ? "command"
           : itemType === "websearch" || toolName.startsWith("search_")
             ? "read"
             : "command",

--- a/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx
@@ -167,7 +167,15 @@ describe("useQueuedTurnRelease", () => {
         composerDraftStore,
         desktopApi,
         selectedThread: thread("thread-b"),
-        threads: [thread("thread-a"), thread("thread-b")],
+        threads: [
+          thread("thread-a", {
+            model: "gpt-5.5",
+            reasoningEffort: "high",
+            serviceTier: "priority",
+            fastMode: true,
+          }),
+          thread("thread-b"),
+        ],
       })
     );
 
@@ -312,7 +320,15 @@ describe("useQueuedTurnRelease", () => {
         composerDraftStore,
         desktopApi,
         selectedThread: thread("thread-b"),
-        threads: [thread("thread-a"), thread("thread-b")],
+        threads: [
+          thread("thread-a", {
+            model: "gpt-5.5",
+            reasoningEffort: "high",
+            serviceTier: "priority",
+            fastMode: true,
+          }),
+          thread("thread-b"),
+        ],
       })
     );
 
@@ -385,7 +401,15 @@ describe("useQueuedTurnRelease", () => {
         composerDraftStore,
         desktopApi,
         selectedThread: thread("thread-b"),
-        threads: [thread("thread-a"), thread("thread-b")],
+        threads: [
+          thread("thread-a", {
+            model: "gpt-5.5",
+            reasoningEffort: "high",
+            serviceTier: "priority",
+            fastMode: true,
+          }),
+          thread("thread-b"),
+        ],
       })
     );
 
@@ -418,6 +442,10 @@ describe("useQueuedTurnRelease", () => {
           branch: "main",
         },
         delivery: "inline",
+        model: "gpt-5.5",
+        reasoningEffort: "high",
+        serviceTier: "priority",
+        fastMode: true,
       });
     });
     expect(startTurn).not.toHaveBeenCalled();

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -3986,6 +3986,94 @@ describe("useThreadNavigation", () => {
     });
   });
 
+  it("refreshes the selected thread when review sub-agents change", async () => {
+    const listeners = new Set<(event: any) => void>();
+    let navigationCallCount = 0;
+    const getNavigationSnapshot = vi.fn(async () => {
+      navigationCallCount += 1;
+      return {
+        backend: "all" as const,
+        fetchedAt: Date.now(),
+        unchanged: false,
+        inboxThreadKeys: [],
+        threads: [
+          {
+            id: "thread-review",
+            title: "Review thread",
+            titleSource: "explicit" as const,
+            summary: "A thread that started a review.",
+            source: "codex" as const,
+            linkedDirectories: [],
+            inbox: {
+              inInbox: false,
+            },
+            subAgents:
+              navigationCallCount === 1
+                ? []
+                : [
+                    {
+                      monitorId: "review:turn-review-1",
+                      task: "Review changes against main",
+                      status: "running" as const,
+                      createdAt: 1_000,
+                      updatedAt: 1_000,
+                      monitorThreadId: "thread-review",
+                      monitorTurnId: "turn-review-1",
+                    },
+                  ],
+            updatedAt: 1_000,
+          },
+        ],
+        directories: [],
+        launchpadDefaults: {
+          backend: "codex" as const,
+          executionMode: "default" as const,
+        },
+      };
+    });
+
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: (callback) => {
+        listeners.add(callback);
+        return () => {
+          listeners.delete(callback);
+        };
+      },
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.id).toBe("thread-review");
+    });
+    expect(result.current.selectedThread?.subAgents).toEqual([]);
+
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "thread/subAgents/updated",
+            params: {
+              threadId: "thread-review",
+            },
+          },
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.subAgents).toEqual([
+        expect.objectContaining({
+          monitorId: "review:turn-review-1",
+          task: "Review changes against main",
+          status: "running",
+        }),
+      ]);
+    });
+  });
+
   it("restores backend state and surfaces errors when rename fails", async () => {
     const renameThread = vi.fn(async () => {
       throw new Error("rename failed");

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -6658,6 +6658,85 @@ describe("useThreadSessionState", () => {
     ]);
   });
 
+  it("keeps the review start marker when only the final review item arrives live", async () => {
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (listener) => {
+        agentEventHandler = listener;
+        return () => undefined;
+      },
+      readThread: async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitForThreadHydration(result);
+
+    const finalReviewCreatedAt = Date.now() + 1_000;
+    act(() => {
+      result.current.addOptimisticReviewEntry("Review changes against main");
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-review-1",
+            item: {
+              id: "turn-review-1-item",
+              type: "exitedReviewMode",
+              review: "No findings. Ready to merge.",
+              createdAt: finalReviewCreatedAt,
+              data: {
+                reviewOutput: {
+                  findings: [],
+                  overall_correctness: "patch is correct",
+                  overall_explanation: "No findings. Ready to merge.",
+                  overall_confidence_score: 0.92,
+                },
+              },
+            },
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        result.current.entries.map((entry) =>
+          entry.type === "review" ? entry.review : entry.type
+        )
+      ).toEqual([
+        "Review changes against main",
+        "No findings. Ready to merge.",
+      ]);
+    });
+    expect(result.current.entries[1]).toMatchObject({
+      type: "review",
+      id: "turn-review-1-item",
+      createdAt: finalReviewCreatedAt,
+    });
+  });
+
   it("keeps a review turn active when a separate turn/started arrives", async () => {
     let agentEventHandler:
       | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]

--- a/apps/desktop/src/renderer/src/lib/useQueuedTurnRelease.ts
+++ b/apps/desktop/src/renderer/src/lib/useQueuedTurnRelease.ts
@@ -288,6 +288,10 @@ export function useQueuedTurnRelease(params: {
           );
           return;
         }
+        const reviewFastMode =
+          releaseThread.source === "codex" && typeof releaseThread.fastMode === "boolean"
+            ? releaseThread.fastMode
+            : undefined;
 
         try {
           await startReview({
@@ -295,6 +299,12 @@ export function useQueuedTurnRelease(params: {
             threadId: releaseThread.id,
             target: reviewCommand.target,
             delivery: "inline",
+            ...(releaseThread.model ? { model: releaseThread.model } : {}),
+            ...(releaseThread.reasoningEffort
+              ? { reasoningEffort: releaseThread.reasoningEffort }
+              : {}),
+            ...(releaseThread.serviceTier ? { serviceTier: releaseThread.serviceTier } : {}),
+            ...(reviewFastMode !== undefined ? { fastMode: reviewFastMode } : {}),
           });
         } catch (error) {
           restoreQueuedTurn(

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -2536,7 +2536,8 @@ export function useThreadNavigation(
         method === "thread/automations/updated" ||
         method === "automation/run/updated" ||
         method === "thread/turnQueue/updated" ||
-        method === "thread/agent/updated"
+        method === "thread/agent/updated" ||
+        method === "thread/subAgents/updated"
       ) {
         scheduleRefresh();
         return;

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -1042,9 +1042,17 @@ function reviewEntriesMatch(
   candidate: AppServerThreadReviewEntry,
   optimisticEntry: AppServerThreadReviewEntry
 ): boolean {
+  if (isReviewStartEntry(candidate) !== isReviewStartEntry(optimisticEntry)) {
+    return false;
+  }
+
   const candidateLabels = reviewEntryLabels(candidate);
   const optimisticLabels = reviewEntryLabels(optimisticEntry);
   return optimisticLabels.some((label) => candidateLabels.includes(label));
+}
+
+function isReviewStartEntry(entry: AppServerThreadReviewEntry): boolean {
+  return Boolean(entry.displayText);
 }
 
 function reviewEntryLabels(entry: AppServerThreadReviewEntry): string[] {
@@ -2404,6 +2412,8 @@ function normalizeReviewOutput(value: unknown): AppServerReviewOutput | undefine
 function reviewEntryFromCompletedItem(params: {
   turnId?: string;
   item?: {
+    createdAt?: number;
+    created_at?: number;
     id: string;
     type: string;
     review?: string;
@@ -2418,6 +2428,8 @@ function reviewEntryFromCompletedItem(params: {
 
   const record = item as {
     id?: unknown;
+    createdAt?: unknown;
+    created_at?: unknown;
     type?: unknown;
     review?: unknown;
     text?: unknown;
@@ -2453,7 +2465,10 @@ function reviewEntryFromCompletedItem(params: {
     ...(displayText ? { displayText } : {}),
     ...(output ? { output } : {}),
     ...(turn ? { turn } : {}),
-    createdAt: Date.now(),
+    createdAt:
+      normalizeNotificationTimestamp(record.createdAt) ??
+      normalizeNotificationTimestamp(record.created_at) ??
+      Date.now(),
   };
 }
 
@@ -3693,7 +3708,9 @@ export function useThreadSessionState(params: {
               interacted: true,
               lastTouchedAt: nextLastTouchedAt,
               optimisticEntries: current.optimisticEntries.filter(
-                (entry) => entry.type !== "review"
+                (entry) =>
+                  entry.type !== "review" ||
+                  !reviewEntriesMatch(reviewEntry, entry)
               ),
               response: nextResponse,
             };

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -1052,7 +1052,24 @@ function reviewEntriesMatch(
 }
 
 function isReviewStartEntry(entry: AppServerThreadReviewEntry): boolean {
-  return Boolean(entry.displayText);
+  const displayText = entry.displayText?.trim();
+  if (!displayText || entry.output) {
+    return false;
+  }
+
+  if (entry.turn?.status === "in_progress") {
+    return true;
+  }
+
+  const normalizedDisplayText = normalizeReviewDisplayText(displayText).toLocaleLowerCase();
+  const normalizedReview = normalizeReviewDisplayText(entry.review).toLocaleLowerCase();
+  return (
+    normalizedDisplayText === normalizedReview ||
+    normalizedDisplayText === "code review started" ||
+    normalizedDisplayText.startsWith("review changes") ||
+    normalizedDisplayText.startsWith("review current") ||
+    normalizedDisplayText.startsWith("review commit")
+  );
 }
 
 function reviewEntryLabels(entry: AppServerThreadReviewEntry): string[] {

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -229,6 +229,10 @@ export type StartReviewRequest = {
   threadId: ThreadIdentifier;
   target: AppServerReviewTarget;
   delivery?: AppServerReviewDelivery;
+  model?: string;
+  serviceTier?: string;
+  reasoningEffort?: string;
+  fastMode?: boolean;
 };
 
 export type StartReviewResponse = {


### PR DESCRIPTION
## Summary

- Codex reviews now stay interruptible with the real backend review turn id even when Codex emits a separate mismatched `turn/started` id.
- Reviews are represented as review sub-agents in the existing Sub-agents rail while their live transcript output continues to stream in the parent thread.
- Review token usage is attributed to the review sub-agent card and labeled as review usage instead of monitor usage.
- Review sub-agents now preserve the composer-selected model, reasoning effort, service tier, and fast-mode setting instead of falling back to backend defaults.
- Launchpad and Grok reviews now keep explicit model settings without overwriting existing thread settings when review callers omit them.
- Sub-agent panels now refresh immediately on `thread/subAgents/updated`, so review cards appear as soon as the backend registers them.
- Completed review cards now still receive token usage when Codex reports usage after the terminal turn event.
- Review transcript history now keeps the start marker and timestamps final review output at completion instead of start time.
- Review function-call tool activity now appears live in the parent transcript instead of waiting for hydration.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/codex-client.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/main/__tests__/codex-client.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx`
- `pnpm test apps/desktop/src/main/__tests__/codex-client.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx`
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/main/__tests__/grok-app-server-client.test.ts apps/desktop/src/main/__tests__/codex-client.test.ts apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx`
- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/main/__tests__/codex-client.test.ts apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx`
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/main/__tests__/codex-client.test.ts apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx`
- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx -t "function call|review|activity"`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm --filter @pwragent/desktop test:e2e -- e2e/review-output-rendering.spec.ts`

## Notes

- This matches Codex's review model more closely: `/review` starts a contextless review sub-agent via `review/start`, relays live review activity into the visible parent transcript, and returns a canonical review turn id that Stop must use.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.5-000000)
