### PR TITLE
fix(desktop): omit oversized transcript diffs

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -2621,6 +2621,127 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("preserves add and delete patches that start with unified diff metadata", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.readThreadResultByThreadId.set("thread-metadata-patches", {
+      thread: {
+        id: "thread-metadata-patches",
+        turns: [
+          {
+            id: "turn-metadata-patches",
+            status: "completed",
+            startedAt: 1_763_500_150,
+            items: [
+              {
+                type: "fileChange",
+                id: "item-metadata-patches",
+                status: "completed",
+                changes: [
+                  {
+                    path: "/repo/metadata-added-file.ts",
+                    kind: {
+                      type: "add"
+                    },
+                    diff: [
+                      "Index: metadata-added-file.ts",
+                      "===================================================================",
+                      "new file mode 100644",
+                      "--- /dev/null",
+                      "+++ b/metadata-added-file.ts",
+                      "@@ -0,0 +1,2 @@",
+                      "+metadata added one",
+                      "+metadata added two"
+                    ].join("\n")
+                  },
+                  {
+                    path: "/repo/metadata-deleted-file.ts",
+                    kind: {
+                      type: "delete"
+                    },
+                    diff: [
+                      "Index: metadata-deleted-file.ts",
+                      "===================================================================",
+                      "deleted file mode 100644",
+                      "--- a/metadata-deleted-file.ts",
+                      "+++ /dev/null",
+                      "@@ -1,2 +0,0 @@",
+                      "-metadata deleted one",
+                      "-metadata deleted two"
+                    ].join("\n")
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    });
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => []
+    });
+
+    const replay = await client.readThread({
+      threadId: "thread-metadata-patches"
+    });
+
+    expect(replay.entries).toEqual([
+      {
+        type: "activity",
+        id: "activity-item-metadata-patches",
+        summary: "Edited 2 files, +2, -2",
+        createdAt: 1_763_500_150_000,
+        status: "completed",
+        turn: {
+          id: "turn-metadata-patches",
+          startedAt: 1_763_500_150_000,
+          status: "completed"
+        },
+        details: [
+          expect.objectContaining({
+            label: "Add metadata-added-file.ts",
+            fileDiff: {
+              kind: "add",
+              diff: [
+                "Index: metadata-added-file.ts",
+                "===================================================================",
+                "new file mode 100644",
+                "--- /dev/null",
+                "+++ b/metadata-added-file.ts",
+                "@@ -0,0 +1,2 @@",
+                "+metadata added one",
+                "+metadata added two"
+              ].join("\n"),
+              additions: 2,
+              removals: 0
+            }
+          }),
+          expect.objectContaining({
+            label: "Delete metadata-deleted-file.ts",
+            fileDiff: {
+              kind: "delete",
+              diff: [
+                "Index: metadata-deleted-file.ts",
+                "===================================================================",
+                "deleted file mode 100644",
+                "--- a/metadata-deleted-file.ts",
+                "+++ /dev/null",
+                "@@ -1,2 +0,0 @@",
+                "-metadata deleted one",
+                "-metadata deleted two"
+              ].join("\n"),
+              additions: 0,
+              removals: 2
+            }
+          })
+        ]
+      }
+    ]);
+
+    await client.close();
+  });
+
   it("omits giant raw file-change payloads from inline transcript diffs", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
     const rawJsonl = [

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -2621,6 +2621,77 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("omits giant raw file-change payloads from inline transcript diffs", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const rawJsonl = [
+      '{"backend":"codex","captureId":"large","method":"initialize"}',
+      '{"backend":"codex","captureId":"large","method":"thread/read"}',
+      `{"backend":"codex","captureId":"large","raw":"${"x".repeat(530_000)}"}`
+    ].join("\n");
+
+    MockTransport.readThreadResultByThreadId.set("thread-large-raw-delete", {
+      thread: {
+        id: "thread-large-raw-delete",
+        turns: [
+          {
+            id: "turn-large-raw-delete",
+            status: "completed",
+            startedAt: 1_763_500_200,
+            items: [
+              {
+                type: "fileChange",
+                id: "item-large-raw-delete",
+                status: "completed",
+                changes: [
+                  {
+                    path: "/repo/apps/desktop/e2e/fixtures/codex-todo-list/raw.capture.jsonl",
+                    kind: {
+                      type: "delete"
+                    },
+                    diff: rawJsonl
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    });
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => []
+    });
+
+    const replay = await client.readThread({
+      threadId: "thread-large-raw-delete"
+    });
+
+    const fileDiff = replay.entries[0]?.type === "activity"
+      ? replay.entries[0].details[0]?.fileDiff
+      : undefined;
+
+    expect(replay.entries[0]).toEqual(
+      expect.objectContaining({
+        type: "activity",
+        summary: "Edited 1 file, +0, -3"
+      })
+    );
+    expect(fileDiff).toEqual(
+      expect.objectContaining({
+        kind: "delete",
+        diff: "",
+        additions: 0,
+        removals: 3,
+        omittedReason: expect.stringContaining("Large file diff omitted"),
+        originalLength: rawJsonl.length
+      })
+    );
+    expect(fileDiff?.omittedReason).toContain("518 KB");
+
+    await client.close();
+  });
+
   it("extracts thread status from thread/read", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
     MockTransport.readThreadResultByThreadId.set("thread-idle-status", {

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -100,6 +100,7 @@ const SUPPORTED_CODEX_MODEL_ORDER = [
   "gpt-5.2",
 ] as const;
 const SUPPORTED_CODEX_MODELS = new Set<string>(SUPPORTED_CODEX_MODEL_ORDER);
+const MAX_INLINE_FILE_DIFF_CHARS = 512 * 1024;
 
 type CodexClientOptions = {
   command?: string;
@@ -2345,7 +2346,12 @@ function extractFileChangeText(params: {
     }
 
     const diff = extractDiffText(params.change);
-    return diff !== undefined ? { source: "diff", text: diff } : undefined;
+    if (diff === undefined) {
+      return undefined;
+    }
+    return looksLikeUnifiedDiff(diff)
+      ? { source: "diff", text: diff }
+      : { source: "content", text: diff };
   }
 
   const diff =
@@ -2354,36 +2360,62 @@ function extractFileChangeText(params: {
   return diff !== undefined ? { source: "diff", text: diff } : undefined;
 }
 
+function looksLikeUnifiedDiff(text: string): boolean {
+  const prefix = text.slice(0, 512).trimStart();
+  return (
+    prefix.startsWith("diff --git ") ||
+    prefix.startsWith("--- ") ||
+    prefix.startsWith("@@ ")
+  );
+}
+
 function summarizeDiff(diff: string): { additions: number; removals: number } {
   let additions = 0;
   let removals = 0;
 
-  for (const line of diff.split("\n")) {
+  let lineStart = 0;
+  while (lineStart <= diff.length) {
+    const lineEnd = diff.indexOf("\n", lineStart);
+    const end = lineEnd === -1 ? diff.length : lineEnd;
+    if (lineEnd === -1 && end === lineStart) {
+      break;
+    }
+
     if (
-      !line ||
-      line.startsWith("+++") ||
-      line.startsWith("---") ||
-      line.startsWith("@@") ||
-      line.startsWith("\\")
+      end === lineStart ||
+      diff.startsWith("+++", lineStart) ||
+      diff.startsWith("---", lineStart) ||
+      diff.startsWith("@@", lineStart) ||
+      diff.startsWith("\\", lineStart)
     ) {
+      lineStart = lineEnd === -1 ? diff.length + 1 : lineEnd + 1;
       continue;
     }
 
-    if (line.startsWith("+")) {
+    if (diff.charCodeAt(lineStart) === 43) {
       additions += 1;
-      continue;
-    }
-
-    if (line.startsWith("-")) {
+    } else if (diff.charCodeAt(lineStart) === 45) {
       removals += 1;
     }
+
+    lineStart = lineEnd === -1 ? diff.length + 1 : lineEnd + 1;
   }
 
   return { additions, removals };
 }
 
 function countContentLines(content: string): number {
-  return splitFileContentLines(content).length;
+  if (content.length === 0) {
+    return 0;
+  }
+
+  let lines = content.endsWith("\n") ? 0 : 1;
+  for (let index = 0; index < content.length; index += 1) {
+    if (content.charCodeAt(index) === 10) {
+      lines += 1;
+    }
+  }
+  return lines;
 }
 
 function splitFileContentLines(content: string): string[] {
@@ -2441,16 +2473,38 @@ function buildFileChangeDiff(params: {
   changeType: "add" | "delete" | "update";
   text: FileChangeText;
   path?: string;
-}): string {
-  if (params.text.source === "diff") {
-    return params.text.text;
+}): { diff: string; omittedReason?: string; originalLength?: number } {
+  if (params.text.text.length > MAX_INLINE_FILE_DIFF_CHARS) {
+    return {
+      diff: "",
+      omittedReason: `Large file diff omitted from transcript view (${formatByteSize(
+        params.text.text.length
+      )}).`,
+      originalLength: params.text.text.length
+    };
   }
 
-  return buildContentDiff({
-    changeType: params.changeType,
-    content: params.text.text,
-    path: params.path
-  });
+  if (params.text.source === "diff") {
+    return { diff: params.text.text };
+  }
+
+  return {
+    diff: buildContentDiff({
+      changeType: params.changeType,
+      content: params.text.text,
+      path: params.path
+    })
+  };
+}
+
+function formatByteSize(bytes: number): string {
+  if (bytes >= 1024 * 1024) {
+    return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+  }
+  if (bytes >= 1024) {
+    return `${Math.round(bytes / 1024)} KB`;
+  }
+  return `${bytes} B`;
 }
 
 function formatCommandLabel(command: string | undefined): string {
@@ -2956,7 +3010,7 @@ function summarizeActivityItems(
           changeText !== undefined
             ? summarizeFileChangeText({ changeType, text: changeText })
             : undefined;
-        const diff =
+        const diffPayload =
           changeText !== undefined
             ? buildFileChangeDiff({
                 changeType,
@@ -2975,13 +3029,19 @@ function summarizeActivityItems(
           }`,
           path: changePath,
           status: itemStatus,
-          ...(diff !== undefined && diffSummary
+          ...(diffPayload !== undefined && diffSummary
             ? {
                 fileDiff: {
                   kind: changeType,
-                  diff,
+                  diff: diffPayload.diff,
                   additions: diffSummary.additions,
-                  removals: diffSummary.removals
+                  removals: diffSummary.removals,
+                  ...(diffPayload.omittedReason
+                    ? { omittedReason: diffPayload.omittedReason }
+                    : {}),
+                  ...(diffPayload.originalLength !== undefined
+                    ? { originalLength: diffPayload.originalLength }
+                    : {})
                 }
               }
             : {})

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -2361,11 +2361,51 @@ function extractFileChangeText(params: {
 }
 
 function looksLikeUnifiedDiff(text: string): boolean {
-  const prefix = text.slice(0, 512).trimStart();
+  let lineStart = 0;
+  while (lineStart <= text.length && lineStart < 4096) {
+    const lineEnd = text.indexOf("\n", lineStart);
+    const end = lineEnd === -1 ? text.length : lineEnd;
+    const line = text.slice(lineStart, end).trim();
+    if (!line) {
+      lineStart = lineEnd === -1 ? text.length + 1 : lineEnd + 1;
+      continue;
+    }
+
+    if (
+      line.startsWith("diff --git ") ||
+      line.startsWith("--- ") ||
+      line.startsWith("@@ ")
+    ) {
+      return true;
+    }
+
+    if (!isUnifiedDiffMetadataLine(line)) {
+      return false;
+    }
+
+    lineStart = lineEnd === -1 ? text.length + 1 : lineEnd + 1;
+  }
+
+  return false;
+}
+
+function isUnifiedDiffMetadataLine(line: string): boolean {
   return (
-    prefix.startsWith("diff --git ") ||
-    prefix.startsWith("--- ") ||
-    prefix.startsWith("@@ ")
+    line.startsWith("Index: ") ||
+    line.startsWith("index ") ||
+    line.startsWith("new file mode ") ||
+    line.startsWith("deleted file mode ") ||
+    line.startsWith("old mode ") ||
+    line.startsWith("new mode ") ||
+    line.startsWith("similarity index ") ||
+    line.startsWith("dissimilarity index ") ||
+    line.startsWith("rename from ") ||
+    line.startsWith("rename to ") ||
+    line.startsWith("copy from ") ||
+    line.startsWith("copy to ") ||
+    line.startsWith("Binary files ") ||
+    line === "GIT binary patch" ||
+    /^=+$/.test(line)
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptDiff.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptDiff.tsx
@@ -24,8 +24,9 @@ export function TranscriptDiff(props: TranscriptDiffProps) {
   const [isZoomedIn, setIsZoomedIn] = useState(false);
   const [focusedView, setFocusedView] = useState<DiffView | null>(null);
   const diff = props.detail.fileDiff;
+  const diffText = diff?.omittedReason ? "" : diff?.diff ?? "";
   const desktopApi = useDesktopApi();
-  const parsed = useMemo(() => parseUnifiedDiff(diff?.diff ?? ""), [diff?.diff]);
+  const parsed = useMemo(() => parseUnifiedDiff(diffText), [diffText]);
   const eligibility = useMemo(() => getFocusedDiffEligibility(parsed), [parsed]);
   const hunkSummaries = useMemo(() => summarizeHunksForFocus(parsed), [parsed]);
   const fullView = useMemo(() => buildDiffView(parsed, { mode: "full" }), [parsed]);
@@ -33,10 +34,10 @@ export function TranscriptDiff(props: TranscriptDiffProps) {
   useEffect(() => {
     setIsZoomedIn(false);
     setFocusedView(null);
-  }, [diff?.diff, props.detail.path]);
+  }, [diffText, props.detail.path]);
 
   useEffect(() => {
-    if (!diff || !eligibility.eligible || !desktopApi?.analyzeFocusedDiff) {
+    if (!diff || diff.omittedReason || !eligibility.eligible || !desktopApi?.analyzeFocusedDiff) {
       return;
     }
 
@@ -45,7 +46,7 @@ export function TranscriptDiff(props: TranscriptDiffProps) {
     void desktopApi
       .analyzeFocusedDiff({
         filePath: props.detail.path,
-        diff: diff.diff,
+        diff: diffText,
         hunks: hunkSummaries
       })
       .then((response) => {
@@ -70,7 +71,7 @@ export function TranscriptDiff(props: TranscriptDiffProps) {
     return () => {
       active = false;
     };
-  }, [desktopApi, diff, eligibility.eligible, hunkSummaries, parsed, props.detail.path]);
+  }, [desktopApi, diff, diffText, eligibility.eligible, hunkSummaries, parsed, props.detail.path]);
 
   const defaultView = useMemo(() => {
     if (!eligibility.eligible) {
@@ -81,7 +82,24 @@ export function TranscriptDiff(props: TranscriptDiffProps) {
   }, [eligibility.eligible, focusedView, fullView, parsed]);
   const visibleView = isZoomedIn ? fullView : defaultView;
 
-  if (!diff || fullView.rows.length === 0) {
+  if (!diff) {
+    return null;
+  }
+
+  if (diff.omittedReason) {
+    return (
+      <div className="transcript-diff transcript-diff--omitted">
+        {props.detail.path && !props.compact ? (
+          <p className="transcript-diff__path" title={props.detail.path}>
+            {props.detail.path}
+          </p>
+        ) : null}
+        <p className="transcript-diff__omitted">{diff.omittedReason}</p>
+      </div>
+    );
+  }
+
+  if (fullView.rows.length === 0) {
     return null;
   }
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-diff.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-diff.test.tsx
@@ -106,4 +106,33 @@ describe("TranscriptDiff", () => {
 
     expect(screen.getByText("const keep3 = 3;")).toBeInTheDocument();
   });
+
+  it("renders omitted large diffs without focused analysis", () => {
+    const analyzeFocusedDiff = vi.fn();
+    (window as Window & { pwragent?: unknown }).pwragent = {
+      analyzeFocusedDiff
+    };
+
+    render(
+      <TranscriptDiff
+        detail={{
+          ...DETAIL,
+          fileDiff: {
+            kind: "delete",
+            additions: 0,
+            removals: 3,
+            diff: "",
+            omittedReason: "Large file diff omitted from transcript view (518 KB).",
+            originalLength: 530_180
+          }
+        }}
+      />
+    );
+
+    expect(
+      screen.getByText("Large file diff omitted from transcript view (518 KB).")
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Zoom in" })).not.toBeInTheDocument();
+    expect(analyzeFocusedDiff).not.toHaveBeenCalled();
+  });
 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts
@@ -498,6 +498,108 @@ describe("buildTranscriptRenderItems", () => {
     ]);
   });
 
+  it("keeps empty non-omitted file diffs nested with ordinary work", () => {
+    const turn = completedTurn("turn-1", 70_000);
+    const firstActivity: AppServerThreadActivityEntry = {
+      type: "activity",
+      id: "tool-1",
+      summary: "Used 2 tools",
+      details: [],
+      turn,
+    };
+    const answer = final("f1", "Final answer.", turn);
+    const emptyDiffActivity: AppServerThreadActivityEntry = {
+      type: "activity",
+      id: "diff-empty",
+      summary: "Edited 1 file, +0, -0",
+      details: [
+        {
+          id: "diff-detail-empty",
+          kind: "write",
+          label: "Update binary.dat",
+          fileDiff: {
+            kind: "update",
+            additions: 0,
+            removals: 0,
+            diff: "",
+          },
+        },
+      ],
+      turn,
+    };
+
+    const items = buildTranscriptRenderItems({
+      entries: [firstActivity, answer, emptyDiffActivity],
+    });
+
+    expect(items).toEqual([
+      {
+        type: "workPhaseGroup",
+        id: "work:turn-1:tool-1:complete",
+        collapsible: true,
+        entries: [firstActivity],
+        label: "Worked for 1m 10s",
+      },
+      { type: "entry", entry: answer },
+      {
+        type: "workPhaseGroup",
+        id: "work:turn-1:diff-empty:complete",
+        collapsible: true,
+        entries: [emptyDiffActivity],
+        label: "More work",
+      },
+    ]);
+  });
+
+  it("renders omitted file diffs as top-level activity", () => {
+    const turn = completedTurn("turn-1", 70_000);
+    const firstActivity: AppServerThreadActivityEntry = {
+      type: "activity",
+      id: "tool-1",
+      summary: "Used 2 tools",
+      details: [],
+      turn,
+    };
+    const answer = final("f1", "Final answer.", turn);
+    const omittedDiffActivity: AppServerThreadActivityEntry = {
+      type: "activity",
+      id: "diff-omitted",
+      summary: "Edited 1 file, +0, -3",
+      details: [
+        {
+          id: "diff-detail-omitted",
+          kind: "write",
+          label: "Delete raw.capture.jsonl",
+          fileDiff: {
+            kind: "delete",
+            additions: 0,
+            removals: 3,
+            diff: "",
+            omittedReason: "Large file diff omitted from transcript view (518 KB).",
+            originalLength: 530_180,
+          },
+        },
+      ],
+      turn,
+    };
+
+    const items = buildTranscriptRenderItems({
+      entries: [firstActivity, answer, omittedDiffActivity],
+    });
+
+    expect(items).toEqual([
+      {
+        type: "workPhaseGroup",
+        id: "work:turn-1:tool-1:complete",
+        collapsible: true,
+        entries: [firstActivity],
+        label: "Worked for 1m 10s",
+      },
+      { type: "entry", entry: answer },
+      { type: "entry", entry: omittedDiffActivity },
+    ]);
+  });
+
   it("renders terminal turn failures as top-level activity instead of nested work", () => {
     const turn = failedTurn("turn-1");
     const toolActivity: AppServerThreadActivityEntry = {

--- a/apps/desktop/src/renderer/src/features/thread-detail/transcript-render-items.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/transcript-render-items.ts
@@ -308,7 +308,9 @@ function isTerminalTurnFailureActivity(
 }
 
 function isFileDiffActivity(entry: AppServerThreadActivityEntry): boolean {
-  return entry.details.some((detail) => Boolean(detail.fileDiff));
+  return entry.details.some((detail) =>
+    Boolean(detail.fileDiff?.diff || detail.fileDiff?.omittedReason)
+  );
 }
 
 function isTokenUsageActivity(entry: AppServerThreadActivityEntry): boolean {

--- a/apps/desktop/src/renderer/src/features/thread-detail/transcript-render-items.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/transcript-render-items.ts
@@ -308,7 +308,7 @@ function isTerminalTurnFailureActivity(
 }
 
 function isFileDiffActivity(entry: AppServerThreadActivityEntry): boolean {
-  return entry.details.some((detail) => Boolean(detail.fileDiff?.diff));
+  return entry.details.some((detail) => Boolean(detail.fileDiff));
 }
 
 function isTokenUsageActivity(entry: AppServerThreadActivityEntry): boolean {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -8813,6 +8813,18 @@ textarea,
   word-break: break-word;
 }
 
+.transcript-diff__omitted {
+  margin: 0;
+  padding: 0 12px 12px;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.transcript-diff--omitted .transcript-diff__omitted:first-child {
+  padding-top: 12px;
+}
+
 .transcript-diff__toolbar {
   display: flex;
   align-items: center;

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -341,6 +341,8 @@ export type AppServerThreadFileDiff = {
   diff: string;
   additions: number;
   removals: number;
+  omittedReason?: string;
+  originalLength?: number;
 };
 
 export type AppServerThreadCommandDetail = {


### PR DESCRIPTION
## Summary

- Large transcript file changes now keep their path and addition/removal stats without embedding oversized diff text into the renderer payload.
- The transcript UI now renders an explicit omitted state for those large diffs instead of trying to parse, focus, or zoom an empty giant payload.
- This complements pwrdrvr/PwrAgent#745: the renderer protocol cap protects arbitrary payloads, while this preserves the file-change semantics before the transcript diff reaches the renderer.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/codex-client.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-diff.test.tsx`
- `pnpm lint:boundaries`
- `git diff --check origin/main...HEAD`

## Notes

- Cherry-picked from the leftover local commit `9786667d7 fix(desktop): omit oversized transcript diffs` onto current `origin/main`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
