### PR TITLE
fix(desktop): preserve turn usage pricing

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -9535,6 +9535,52 @@ command = "pnpm dev"
     });
   });
 
+  it("persists observed Codex model settings for later thread snapshots", async () => {
+    const codexClient = new MockBackendClient({});
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-observed-model": {
+          backend: "codex",
+          threadId: "thread-observed-model",
+          executionMode: "default",
+          serviceTier: "fast",
+          fastMode: true,
+          extraLinkedDirectories: [],
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({}),
+      overlayStore,
+    });
+
+    await codexClient.emit({
+      method: "thread/codexSettings/observed",
+      params: {
+        threadId: "thread-observed-model",
+        model: "gpt-5.4-mini",
+        reasoningEffort: "low",
+        serviceTier: null,
+        fastMode: false,
+      },
+    });
+
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-observed-model",
+      }),
+    ).resolves.toMatchObject({
+      model: "gpt-5.4-mini",
+      reasoningEffort: "low",
+      serviceTier: "fast",
+      fastMode: true,
+    });
+
+    await registry.close();
+  });
+
   it("resumes Codex turns in the current handoff worktree cwd", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start"] },

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -9536,7 +9536,17 @@ command = "pnpm dev"
   });
 
   it("persists observed Codex model settings for later thread snapshots", async () => {
-    const codexClient = new MockBackendClient({});
+    const codexClient = new MockBackendClient({
+      threads: [
+        {
+          id: "thread-observed-model",
+          title: "Observed model thread",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+        },
+      ],
+    });
     const overlayStore = createOverlayStoreMock({
       overlays: {
         "codex:thread-observed-model": {
@@ -9553,6 +9563,10 @@ command = "pnpm dev"
       codexClient,
       grokClient: new MockBackendClient({}),
       overlayStore,
+    });
+    const events: AgentEvent[] = [];
+    const unsubscribe = registry.onEvent((event) => {
+      events.push(event);
     });
 
     await codexClient.emit({
@@ -9577,7 +9591,30 @@ command = "pnpm dev"
       serviceTier: "fast",
       fastMode: true,
     });
+    expect(events).toContainEqual({
+      backend: "codex",
+      notification: {
+        method: "thread/modelSettings/updated",
+        params: {
+          threadId: "thread-observed-model",
+          model: "gpt-5.4-mini",
+          reasoningEffort: "low",
+          serviceTier: "fast",
+          fastMode: true,
+        },
+      },
+    });
+    await expect(registry.listThreads({ backend: "codex" })).resolves.toEqual([
+      expect.objectContaining({
+        id: "thread-observed-model",
+        model: "gpt-5.4-mini",
+        reasoningEffort: "low",
+        serviceTier: "fast",
+        fastMode: true,
+      }),
+    ]);
 
+    unsubscribe();
     await registry.close();
   });
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -8338,8 +8338,11 @@ export class DesktopBackendRegistry {
     this.unsubscribers.push(
       client.onNotification(async (notification) => {
         logBackendLifecycleNotification(backend, notification);
-        if (backend === "codex") {
-          this.recordObservedCodexSettings(notification);
+        if (
+          backend === "codex" &&
+          notification.method === "thread/codexSettings/observed"
+        ) {
+          await this.recordObservedCodexSettings(notification);
         }
         if (this.shouldInvalidateThreadListCacheForNotification(notification.method)) {
           this.invalidateThreadListCache(backend);
@@ -8369,13 +8372,17 @@ export class DesktopBackendRegistry {
     }
   }
 
-  private recordObservedCodexSettings(notification: AppServerNotification): void {
+  private async recordObservedCodexSettings(
+    notification: AppServerNotification,
+  ): Promise<void> {
     if (notification.method !== "thread/codexSettings/observed") {
       return;
     }
     const params = notification.params as {
       fastMode?: unknown;
+      model?: unknown;
       rawServiceTier?: unknown;
+      reasoningEffort?: unknown;
       serviceTier?: unknown;
       threadId?: unknown;
     };
@@ -8393,9 +8400,29 @@ export class DesktopBackendRegistry {
       observedAt: Date.now(),
     };
     this.observedCodexSettingsByThread.set(params.threadId, observed);
+    const observedModel = typeof params.model === "string" ? params.model : undefined;
+    const observedReasoningEffort =
+      typeof params.reasoningEffort === "string" ? params.reasoningEffort : undefined;
+    if (observedModel || observedReasoningEffort) {
+      const current = await this.overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: params.threadId,
+      });
+      await this.overlayStore.setThreadModelSettings({
+        backend: "codex",
+        threadId: params.threadId,
+        model: observedModel ?? current?.model,
+        reasoningEffort: observedReasoningEffort ?? current?.reasoningEffort,
+        serviceTier: current?.serviceTier,
+        fastMode: current?.fastMode,
+      });
+      this.invalidateThreadListCache("codex");
+    }
     backendRegistryLog.info("codex thread settings observed", {
       threadId: params.threadId,
+      model: observedModel ?? null,
       fastMode: observed.fastMode ?? null,
+      reasoningEffort: observedReasoningEffort ?? null,
       serviceTier: observed.serviceTier ?? null,
       rawServiceTier: observed.rawServiceTier ?? null,
     });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -8408,15 +8408,28 @@ export class DesktopBackendRegistry {
         backend: "codex",
         threadId: params.threadId,
       });
-      await this.overlayStore.setThreadModelSettings({
-        backend: "codex",
-        threadId: params.threadId,
+      const modelSettings = {
         model: observedModel ?? current?.model,
         reasoningEffort: observedReasoningEffort ?? current?.reasoningEffort,
         serviceTier: current?.serviceTier,
         fastMode: current?.fastMode,
+      };
+      await this.overlayStore.setThreadModelSettings({
+        backend: "codex",
+        threadId: params.threadId,
+        ...modelSettings,
       });
       this.invalidateThreadListCache("codex");
+      await this.emit({
+        backend: "codex",
+        notification: {
+          method: "thread/modelSettings/updated",
+          params: {
+            threadId: params.threadId,
+            ...modelSettings,
+          },
+        },
+      });
     }
     backendRegistryLog.info("codex thread settings observed", {
       threadId: params.threadId,
@@ -9157,6 +9170,10 @@ export class DesktopBackendRegistry {
         return {
           ...thread,
           executionMode: overlay?.executionMode ?? thread.executionMode,
+          model: overlay?.model ?? thread.model,
+          reasoningEffort: overlay?.reasoningEffort ?? thread.reasoningEffort,
+          serviceTier: overlay?.serviceTier ?? thread.serviceTier,
+          fastMode: overlay?.fastMode ?? thread.fastMode,
           codexEnvironmentOptions,
         };
       }),

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -4171,6 +4171,93 @@ describe("useThreadSessionState", () => {
     expect(result.current.runningTurnUsageText).toBeUndefined();
   });
 
+  it("prices finalized active-turn usage from the token usage notification model", async () => {
+    let agentEventHandler: Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0] | undefined;
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback;
+        return () => undefined;
+      },
+      readThread: async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitForThreadHydration(result);
+
+    act(() => {
+      result.current.setActiveTurnId("turn-1");
+    });
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "thread/tokenUsage/updated",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            model: "gpt-5.4-mini",
+            tokenUsage: {
+              last_token_usage: {
+                input_tokens: 1_217_026,
+                cached_input_tokens: 1_120_384,
+                output_tokens: 3_721,
+                reasoning_output_tokens: 1_130,
+              },
+              total_token_usage: {
+                input_tokens: 1_217_026,
+                cached_input_tokens: 1_120_384,
+                output_tokens: 3_721,
+                reasoning_output_tokens: 1_130,
+              },
+            },
+          },
+        } as any,
+      });
+    });
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            turn: {
+              id: "turn-1",
+              status: "completed",
+              output: [{ type: "text", text: "Done." }],
+            },
+          },
+        },
+      });
+    });
+
+    expect(transcriptLabels(result.current.entries)).toEqual([
+      "message:Done.",
+      "activity:Turn usage: 96,642 uncached in · 1,120,384 cached · 3,721 out (1,130 reasoning) · $0.18 list price",
+    ]);
+  });
+
   it("keeps aggregate turn usage when hydration includes per-request usage", async () => {
     let agentEventHandler: Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0] | undefined;
     let readCount = 0;

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -1363,6 +1363,34 @@ function findFirstNestedValue(value: unknown, keys: string[]): unknown {
   return undefined;
 }
 
+function readStringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function resolveTokenUsageModel(params: {
+  backend: AppServerBackendKind;
+  notificationParams: Extract<
+    AppServerNotification,
+    { method: "thread/tokenUsage/updated" }
+  >["params"];
+  thread?: NavigationThreadSummary;
+  threadId: string;
+}): string | undefined {
+  return (
+    readStringValue(params.notificationParams.model) ??
+    readStringValue(
+      findFirstNestedValue(params.notificationParams.tokenUsage, [
+        "model",
+        "modelId",
+        "model_id",
+      ])
+    ) ??
+    (params.thread?.source === params.backend && params.thread.id === params.threadId
+      ? params.thread.model
+      : undefined)
+  );
+}
+
 function readTokenBreakdown(record: Record<string, unknown>): TokenUsageBreakdown | undefined {
   const explicitTotal = readFiniteNumber(record, ["totalTokens", "total_tokens"]);
   const inputTokens = readFiniteNumber(record, ["inputTokens", "input_tokens"]);
@@ -4010,10 +4038,12 @@ export function useThreadSessionState(params: {
             fallbackStatus: current.activeTurnId ? "in_progress" : "completed",
           });
           const usageEntryId = `live-token-usage-${turn?.id ?? notificationThreadId}`;
-          const model =
-            thread?.source === event.backend && thread.id === notificationThreadId
-              ? thread.model
-              : undefined;
+          const model = resolveTokenUsageModel({
+            backend: event.backend,
+            notificationParams: event.notification.params,
+            thread,
+            threadId: notificationThreadId,
+          });
           let usageEntry = buildTokenUsageActivityEntry({
             id: usageEntryId,
             model,

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -863,6 +863,7 @@ export type AppServerNotification =
       params: {
         threadId: string;
         turnId?: string;
+        model?: string;
         tokenUsage: unknown;
       };
     }


### PR DESCRIPTION
## Summary

- Turn usage cards now keep showing list-price cost when token usage arrives before the selected thread summary has a model. The card uses the model from the token-usage notification first, then falls back to the thread summary.
- Observed Codex model settings are persisted into the thread overlay so later navigation snapshots have the model needed for pricing.
- Added regressions for the screenshot-class failure: exact token counts rendered, but the turn usage price disappeared.

## Verification

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx`
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts`
- `pnpm lint:boundaries`
- `pnpm --filter @pwragent/desktop exec tsc --noEmit`

## Notes

- No demo capture; this is a transcript metadata/pricing consistency fix covered by targeted regression tests.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
