### PR TITLE
feat(desktop): add "without a directory" option for new threads

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -469,6 +469,7 @@ function DesktopAppShell(props: {
     settingsActive: mainView === "settings",
     threadSearchActive: mainView === "search",
     creatingThread: Boolean(navigation.creatingThread),
+    newThreadDirectoryLabel: navigation.newThreadDirectoryLabel,
     onOpenAutomations: () => {
       setMainView("automations");
     },
@@ -482,6 +483,10 @@ function DesktopAppShell(props: {
     onCreateThread: async () => {
       setMainView("thread");
       await navigation.createThread();
+    },
+    onCreateThreadWithoutDirectory: async () => {
+      setMainView("thread");
+      await navigation.createThread(undefined, "default", { forceWorkspace: true });
     },
   };
   const threadViewProps = {
@@ -531,6 +536,9 @@ function DesktopAppShell(props: {
     pickingDirectory: navigation.pickingDirectory,
     onSelectDirectoryFromPicker: (directory) => {
       void navigation.openDirectoryLaunchpad(directory);
+    },
+    onSelectNoDirectoryFromPicker: () => {
+      void navigation.openWorkspaceLaunchpad();
     },
     onPickAndRegisterDirectory: () => {
       void navigation.pickAndRegisterDirectory();
@@ -685,9 +693,16 @@ function DesktopAppShell(props: {
           threadSearchActive={mainView === "search"}
           settingsActive={mainView === "settings"}
           onBrowseModeChange={navigation.setBrowseMode}
+          newThreadDirectoryLabel={navigation.newThreadDirectoryLabel}
           onCreateThread={async () => {
             setMainView("thread");
             await navigation.createThread();
+          }}
+          onCreateThreadWithoutDirectory={async () => {
+            setMainView("thread");
+            await navigation.createThread(undefined, "default", {
+              forceWorkspace: true,
+            });
           }}
           onCreateSubthread={async (thread, mode) => {
             setMainView("thread");

--- a/apps/desktop/src/renderer/src/features/chrome/MastheadActions.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/MastheadActions.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from "react";
-import { AutomationsIcon, NewThreadIcon, SearchIcon, SettingsIcon } from "../../icons";
+import { AutomationsIcon, SearchIcon, SettingsIcon } from "../../icons";
+import { NewThreadButton } from "./NewThreadButton";
 
 /**
  * The window-level action buttons (Search / Automations / Settings / New
@@ -13,10 +14,13 @@ export type MastheadActionsProps = {
   settingsActive?: boolean;
   threadSearchActive?: boolean;
   creatingThread?: boolean;
+  /** Directory the default New Thread action resolves to (flyout label). */
+  newThreadDirectoryLabel?: string;
   onOpenAutomations?: () => void;
   onOpenSettings?: () => void;
   onToggleThreadSearch?: () => void;
   onCreateThread?: () => void | Promise<void>;
+  onCreateThreadWithoutDirectory?: () => void | Promise<void>;
 };
 
 export function MastheadActions(props: MastheadActionsProps): ReactElement {
@@ -51,17 +55,12 @@ export function MastheadActions(props: MastheadActionsProps): ReactElement {
       >
         <SettingsIcon size={16} strokeWidth={1.5} aria-hidden="true" />
       </button>
-      <button
-        type="button"
-        aria-label="New thread"
-        className="sidebar__icon-button"
-        disabled={Boolean(props.creatingThread)}
-        onClick={() => {
-          void props.onCreateThread?.();
-        }}
-      >
-        <NewThreadIcon size={16} strokeWidth={1.5} aria-hidden="true" />
-      </button>
+      <NewThreadButton
+        creatingThread={props.creatingThread}
+        directoryLabel={props.newThreadDirectoryLabel}
+        onCreateThread={() => props.onCreateThread?.()}
+        onCreateThreadWithoutDirectory={props.onCreateThreadWithoutDirectory}
+      />
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/features/chrome/NewThreadButton.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/NewThreadButton.tsx
@@ -6,6 +6,7 @@ import {
   type ReactElement,
 } from "react";
 import { NewThreadIcon } from "../../icons";
+import { useViewportTooltip } from "../../lib/useViewportTooltip";
 
 /**
  * The masthead "New thread" button with a hover/focus flyout.
@@ -20,7 +21,8 @@ import { NewThreadIcon } from "../../icons";
  * The flyout only renders when there's a directory to contrast against the
  * workspace choice (`directoryLabel` set) and a directory-less handler exists.
  * When the context already resolves to the directory-less workspace, the two
- * items would be identical, so the button behaves as a plain button.
+ * items would be identical, so the button falls back to a plain "New thread"
+ * tooltip — matching the hover affordance of its masthead siblings.
  *
  * Shared by the sidebar masthead and the relocated thread-header / Windows
  * title-bar placements so every surface reads identically.
@@ -41,19 +43,35 @@ export function NewThreadButton(props: NewThreadButtonProps): ReactElement {
   const wrapperRef = useRef<HTMLSpanElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const menuId = useId();
+  const tooltip = useViewportTooltip({ className: "viewport-tooltip" });
 
   const hasFlyout = Boolean(
     props.directoryLabel && props.onCreateThreadWithoutDirectory,
   );
   const menuOpen = open && hasFlyout && !props.creatingThread;
 
+  // With no flyout to reveal, keep a plain "New thread" tooltip so the button
+  // has the same hover/focus affordance as its (tooltip-bearing) siblings.
+  const showTooltip = (): void => {
+    if (!hasFlyout && buttonRef.current) {
+      tooltip.show(buttonRef.current, "New thread");
+    }
+  };
+
   useEffect(() => {
     if (!menuOpen) {
       return;
     }
     const onKeyDown = (event: KeyboardEvent): void => {
-      if (event.key === "Escape") {
-        setOpen(false);
+      if (event.key !== "Escape") {
+        return;
+      }
+      setOpen(false);
+      // Only pull focus back to the trigger when focus is actually inside the
+      // flyout (keyboard-driven). A hover-opened menu must close without
+      // stealing focus. The onFocus guard below then keeps this refocus from
+      // re-opening the just-dismissed menu.
+      if (wrapperRef.current?.contains(document.activeElement)) {
         buttonRef.current?.focus();
       }
     };
@@ -66,12 +84,28 @@ export function NewThreadButton(props: NewThreadButtonProps): ReactElement {
       ref={wrapperRef}
       className="new-thread-button"
       data-state={menuOpen ? "open" : "closed"}
-      onMouseEnter={() => setOpen(true)}
-      onMouseLeave={() => setOpen(false)}
-      onFocus={() => setOpen(true)}
+      onMouseEnter={() => {
+        setOpen(true);
+        showTooltip();
+      }}
+      onMouseLeave={() => {
+        setOpen(false);
+        tooltip.hide();
+      }}
+      onFocus={(event) => {
+        // Only react to focus entering the wrapper from outside. Focus moving
+        // within the wrapper (e.g. Escape refocusing the trigger from a menu
+        // item) must not re-open the menu or re-trigger the tooltip.
+        if (wrapperRef.current?.contains(event.relatedTarget as Node)) {
+          return;
+        }
+        setOpen(true);
+        showTooltip();
+      }}
       onBlur={(event) => {
         if (!wrapperRef.current?.contains(event.relatedTarget as Node)) {
           setOpen(false);
+          tooltip.hide();
         }
       }}
     >
@@ -86,6 +120,7 @@ export function NewThreadButton(props: NewThreadButtonProps): ReactElement {
         disabled={Boolean(props.creatingThread)}
         onClick={() => {
           setOpen(false);
+          tooltip.hide();
           void props.onCreateThread();
         }}
       >
@@ -125,6 +160,7 @@ export function NewThreadButton(props: NewThreadButtonProps): ReactElement {
           </div>
         </div>
       ) : null}
+      {tooltip.tooltipNode}
     </span>
   );
 }

--- a/apps/desktop/src/renderer/src/features/chrome/NewThreadButton.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/NewThreadButton.tsx
@@ -1,0 +1,130 @@
+import {
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type ReactElement,
+} from "react";
+import { NewThreadIcon } from "../../icons";
+
+/**
+ * The masthead "New thread" button with a hover/focus flyout.
+ *
+ * Clicking the button keeps its original behavior: start a new thread in the
+ * directory the navigation context resolves to (`onCreateThread`). Hovering or
+ * focusing the button reveals a flyout that makes the two outcomes explicit:
+ *
+ *   1. New chat in <directory>     → `onCreateThread` (context default)
+ *   2. New chat without a directory → `onCreateThreadWithoutDirectory`
+ *
+ * The flyout only renders when there's a directory to contrast against the
+ * workspace choice (`directoryLabel` set) and a directory-less handler exists.
+ * When the context already resolves to the directory-less workspace, the two
+ * items would be identical, so the button behaves as a plain button.
+ *
+ * Shared by the sidebar masthead and the relocated thread-header / Windows
+ * title-bar placements so every surface reads identically.
+ */
+export type NewThreadButtonProps = {
+  creatingThread?: boolean;
+  /**
+   * Label of the directory the default action resolves to, or undefined when
+   * that's the directory-less workspace (no meaningful flyout to show).
+   */
+  directoryLabel?: string;
+  onCreateThread: () => void | Promise<void>;
+  onCreateThreadWithoutDirectory?: () => void | Promise<void>;
+};
+
+export function NewThreadButton(props: NewThreadButtonProps): ReactElement {
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef<HTMLSpanElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const menuId = useId();
+
+  const hasFlyout = Boolean(
+    props.directoryLabel && props.onCreateThreadWithoutDirectory,
+  );
+  const menuOpen = open && hasFlyout && !props.creatingThread;
+
+  useEffect(() => {
+    if (!menuOpen) {
+      return;
+    }
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === "Escape") {
+        setOpen(false);
+        buttonRef.current?.focus();
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [menuOpen]);
+
+  return (
+    <span
+      ref={wrapperRef}
+      className="new-thread-button"
+      data-state={menuOpen ? "open" : "closed"}
+      onMouseEnter={() => setOpen(true)}
+      onMouseLeave={() => setOpen(false)}
+      onFocus={() => setOpen(true)}
+      onBlur={(event) => {
+        if (!wrapperRef.current?.contains(event.relatedTarget as Node)) {
+          setOpen(false);
+        }
+      }}
+    >
+      <button
+        ref={buttonRef}
+        type="button"
+        aria-label="New thread"
+        aria-haspopup={hasFlyout ? "menu" : undefined}
+        aria-expanded={hasFlyout ? menuOpen : undefined}
+        aria-controls={menuOpen ? menuId : undefined}
+        className="sidebar__icon-button"
+        disabled={Boolean(props.creatingThread)}
+        onClick={() => {
+          setOpen(false);
+          void props.onCreateThread();
+        }}
+      >
+        <NewThreadIcon size={16} strokeWidth={1.5} aria-hidden="true" />
+      </button>
+
+      {menuOpen ? (
+        <div className="new-thread-menu">
+          <div
+            className="new-thread-menu__card"
+            id={menuId}
+            role="menu"
+            aria-label="New thread options"
+          >
+            <button
+              type="button"
+              role="menuitem"
+              className="new-thread-menu__item"
+              onClick={() => {
+                setOpen(false);
+                void props.onCreateThread();
+              }}
+            >
+              New chat in {props.directoryLabel}
+            </button>
+            <button
+              type="button"
+              role="menuitem"
+              className="new-thread-menu__item"
+              onClick={() => {
+                setOpen(false);
+                void props.onCreateThreadWithoutDirectory?.();
+              }}
+            >
+              New chat without a directory
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </span>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/chrome/__tests__/NewThreadButton.test.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/__tests__/NewThreadButton.test.tsx
@@ -1,0 +1,99 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { NewThreadButton } from "../NewThreadButton";
+
+afterEach(cleanup);
+
+describe("NewThreadButton", () => {
+  it("clicking runs the default action and shows no flyout without a directory", () => {
+    const onCreateThread = vi.fn();
+    render(<NewThreadButton onCreateThread={onCreateThread} />);
+
+    const button = screen.getByRole("button", { name: "New thread" });
+    fireEvent.mouseEnter(button.parentElement as HTMLElement);
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+
+    fireEvent.click(button);
+    expect(onCreateThread).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to a 'New thread' tooltip when there is no flyout", async () => {
+    render(<NewThreadButton onCreateThread={vi.fn()} />);
+
+    const button = screen.getByRole("button", { name: "New thread" });
+    fireEvent.mouseEnter(button.parentElement as HTMLElement);
+    expect((await screen.findByRole("tooltip")).textContent).toBe("New thread");
+
+    fireEvent.mouseLeave(button.parentElement as HTMLElement);
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  it("reveals the flyout on hover and suppresses the tooltip when a directory is set", async () => {
+    const onCreateThread = vi.fn();
+    const onCreateThreadWithoutDirectory = vi.fn();
+    render(
+      <NewThreadButton
+        directoryLabel="PwrAgnt"
+        onCreateThread={onCreateThread}
+        onCreateThreadWithoutDirectory={onCreateThreadWithoutDirectory}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "New thread" });
+    fireEvent.mouseEnter(button.parentElement as HTMLElement);
+
+    expect(
+      await screen.findByRole("menuitem", { name: "New chat in PwrAgnt" }),
+    ).toBeInTheDocument();
+    // The flyout replaces the plain tooltip.
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("menuitem", { name: "New chat without a directory" }),
+    );
+    expect(onCreateThreadWithoutDirectory).toHaveBeenCalledTimes(1);
+    expect(onCreateThread).not.toHaveBeenCalled();
+  });
+
+  it("closes the flyout on Escape while a menu item is focused (regression)", async () => {
+    render(
+      <NewThreadButton
+        directoryLabel="PwrAgnt"
+        onCreateThread={vi.fn()}
+        onCreateThreadWithoutDirectory={vi.fn()}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "New thread" });
+    fireEvent.mouseEnter(button.parentElement as HTMLElement);
+    const item = await screen.findByRole("menuitem", {
+      name: "New chat without a directory",
+    });
+
+    // Move keyboard focus into the menu, then dismiss with Escape. Refocusing
+    // the trigger must NOT re-open the menu.
+    item.focus();
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    expect(button).toHaveFocus();
+  });
+
+  it("does not render the flyout while a thread is being created", async () => {
+    render(
+      <NewThreadButton
+        creatingThread
+        directoryLabel="PwrAgnt"
+        onCreateThread={vi.fn()}
+        onCreateThreadWithoutDirectory={vi.fn()}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "New thread" });
+    expect(button).toBeDisabled();
+    fireEvent.mouseEnter(button.parentElement as HTMLElement);
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -152,6 +152,7 @@ type ComposerProps = {
    * these through and the picker won't render.
    */
   onSelectDirectoryFromPicker?: (directory: NavigationDirectorySummary) => void;
+  onSelectNoDirectoryFromPicker?: () => void;
   onPickAndRegisterDirectory?: () => void;
   onClearPickDirectoryError?: () => void;
   pickDirectoryError?: string;
@@ -5673,6 +5674,14 @@ export function Composer(props: ComposerProps) {
                 props.onClearPickDirectoryError?.();
                 props.onSelectDirectoryFromPicker?.(directory);
               }}
+              onSelectNoDirectory={
+                props.onSelectNoDirectoryFromPicker
+                  ? () => {
+                      props.onClearPickDirectoryError?.();
+                      props.onSelectNoDirectoryFromPicker?.();
+                    }
+                  : undefined
+              }
               onPickFromDisk={() => {
                 props.onClearPickDirectoryError?.();
                 props.onPickAndRegisterDirectory?.();

--- a/apps/desktop/src/renderer/src/features/composer/ProjectPicker.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ProjectPicker.tsx
@@ -36,6 +36,11 @@ export type ProjectPickerProps = {
   picking?: boolean;
   onSelect: (directory: NavigationDirectorySummary) => void;
   onPickFromDisk: () => void;
+  /**
+   * Switch the launchpad to a directory-less ("workspace") thread. When
+   * omitted, the "Chat without a directory" row is not rendered.
+   */
+  onSelectNoDirectory?: () => void;
 };
 
 const RECENTS_LIMIT = 10;
@@ -149,6 +154,28 @@ export function ProjectPicker(props: ProjectPickerProps): ReactElement {
               onChange={(event) => setQuery(event.target.value)}
             />
           </div>
+
+          {props.onSelectNoDirectory ? (
+            <button
+              type="button"
+              aria-pressed={isEmpty}
+              className={`project-picker__row project-picker__row--no-directory${
+                isEmpty ? " is-active" : ""
+              }`}
+              onClick={() => {
+                setOpen(false);
+                props.onSelectNoDirectory?.();
+              }}
+            >
+              <span className="project-picker__no-directory-icon" aria-hidden="true">
+                <FolderIcon size={11} />
+                <span className="project-picker__no-directory-slash" />
+              </span>
+              <span className="project-picker__no-directory-text">
+                Chat without a directory
+              </span>
+            </button>
+          ) : null}
 
           <div className="project-picker__section">Recent directories</div>
           <ul

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/ProjectPicker.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/ProjectPicker.test.tsx
@@ -214,6 +214,70 @@ describe("ProjectPicker", () => {
     expect(screen.getByText(/no tracked directories yet/i)).toBeInTheDocument();
   });
 
+  it("renders 'Chat without a directory' only when onSelectNoDirectory is provided", () => {
+    const { rerender } = render(
+      <ProjectPicker
+        directories={[dirA]}
+        onSelect={() => undefined}
+        onPickFromDisk={() => undefined}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /choose a project/i }));
+    expect(
+      screen.queryByRole("button", { name: /chat without a directory/i }),
+    ).not.toBeInTheDocument();
+
+    rerender(
+      <ProjectPicker
+        directories={[dirA]}
+        onSelect={() => undefined}
+        onPickFromDisk={() => undefined}
+        onSelectNoDirectory={() => undefined}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: /chat without a directory/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("marks 'Chat without a directory' active and invokes onSelectNoDirectory", () => {
+    const onSelectNoDirectory = vi.fn();
+    render(
+      <ProjectPicker
+        directories={[dirA]}
+        onSelect={() => undefined}
+        onPickFromDisk={() => undefined}
+        onSelectNoDirectory={onSelectNoDirectory}
+      />,
+    );
+
+    // No value set → the launchpad is directory-less, so the row is active.
+    fireEvent.click(screen.getByRole("button", { name: /choose a project/i }));
+    const row = screen.getByRole("button", { name: /chat without a directory/i });
+    expect(row).toHaveAttribute("aria-pressed", "true");
+    expect(row.className).toContain("is-active");
+
+    fireEvent.click(row);
+    expect(onSelectNoDirectory).toHaveBeenCalledOnce();
+  });
+
+  it("does not mark 'Chat without a directory' active when a directory is selected", () => {
+    render(
+      <ProjectPicker
+        value={dirA}
+        directories={[dirA]}
+        onSelect={() => undefined}
+        onPickFromDisk={() => undefined}
+        onSelectNoDirectory={() => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /project: pwragent/i }));
+    expect(
+      screen.getByRole("button", { name: /chat without a directory/i }),
+    ).toHaveAttribute("aria-pressed", "false");
+  });
+
   it("closes the popover when Escape is pressed", () => {
     render(
       <ProjectPicker

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -27,6 +27,7 @@ import {
 import type { RuntimeIdentity } from "../../../../shared/runtime-identity";
 import { copyText } from "../../lib/copy-text";
 import { BranchIcon, FolderIcon, SearchIcon } from "../../icons";
+import { NewThreadButton } from "../chrome/NewThreadButton";
 import type {
   ArchiveThreadOptions,
   BrowseMode,
@@ -79,6 +80,9 @@ type SidebarProps = {
   threads: NavigationThreadSummary[];
   onBrowseModeChange: (browseMode: BrowseMode) => void;
   onCreateThread: () => Promise<void>;
+  onCreateThreadWithoutDirectory?: () => Promise<void>;
+  /** Directory the default New Thread action resolves to (flyout label). */
+  newThreadDirectoryLabel?: string;
   onCreateSubthread?: (
     thread: NavigationThreadSummary,
     mode: ThreadWorkspaceMode,
@@ -741,16 +745,12 @@ export function Sidebar(props: SidebarProps) {
           >
             <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/></svg>
           </MastheadActionButton>
-          <MastheadActionButton
-            ariaLabel="New thread"
-            className="sidebar__icon-button"
-            disabled={Boolean(props.creatingThread)}
-            onClick={() => {
-              void props.onCreateThread();
-            }}
-          >
-            <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/><line x1="12" y1="18" x2="12" y2="12"/><line x1="9" y1="15" x2="15" y2="15"/></svg>
-          </MastheadActionButton>
+          <NewThreadButton
+            creatingThread={Boolean(props.creatingThread)}
+            directoryLabel={props.newThreadDirectoryLabel}
+            onCreateThread={() => props.onCreateThread()}
+            onCreateThreadWithoutDirectory={props.onCreateThreadWithoutDirectory}
+          />
         </div>
       </header>
 

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -275,10 +275,14 @@ describe("Sidebar", () => {
     fireEvent.click(settingsButton);
     expect(onOpenSettings).toHaveBeenCalledTimes(1);
 
-    // The New Thread button carries a hover flyout instead of a viewport
-    // tooltip; with no directory in context it behaves as a plain button.
+    // With no directory in context the New Thread button has no flyout, so it
+    // keeps a plain "New thread" tooltip for parity with its siblings. The
+    // tooltip/flyout live on the wrapper, so hover the wrapper, not the button.
     const newThreadButton = screen.getByRole("button", { name: "New thread" });
-    fireEvent.mouseEnter(newThreadButton);
+    fireEvent.mouseEnter(newThreadButton.parentElement as HTMLElement);
+    expect((await screen.findByRole("tooltip")).textContent).toBe("New thread");
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    fireEvent.mouseLeave(newThreadButton.parentElement as HTMLElement);
     expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
     fireEvent.click(newThreadButton);
     expect(onCreateThread).toHaveBeenCalledTimes(1);

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -275,12 +275,58 @@ describe("Sidebar", () => {
     fireEvent.click(settingsButton);
     expect(onOpenSettings).toHaveBeenCalledTimes(1);
 
+    // The New Thread button carries a hover flyout instead of a viewport
+    // tooltip; with no directory in context it behaves as a plain button.
     const newThreadButton = screen.getByRole("button", { name: "New thread" });
     fireEvent.mouseEnter(newThreadButton);
-    expect((await screen.findByRole("tooltip")).textContent).toBe("New thread");
-    fireEvent.mouseLeave(newThreadButton);
     expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
     fireEvent.click(newThreadButton);
+    expect(onCreateThread).toHaveBeenCalledTimes(1);
+  });
+
+  it("reveals the New Thread flyout on hover when a directory is in context", async () => {
+    const onCreateThread = vi.fn(async () => undefined);
+    const onCreateThreadWithoutDirectory = vi.fn(async () => undefined);
+
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="recents"
+        createThreadError={undefined}
+        directories={directories}
+        inboxThreads={[sharedThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        newThreadDirectoryLabel="PwrAgnt"
+        selectedItemKey="codex:thread-1"
+        threads={[sharedThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={onCreateThread}
+        onCreateThreadWithoutDirectory={onCreateThreadWithoutDirectory}
+        onOpenAutomations={() => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onOpenSettings={() => undefined}
+        onSelectThread={() => undefined}
+      />
+    );
+
+    const newThreadButton = screen.getByRole("button", { name: "New thread" });
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+
+    fireEvent.mouseEnter(newThreadButton.parentElement as HTMLElement);
+    await screen.findByRole("menuitem", { name: "New chat in PwrAgnt" });
+
+    fireEvent.click(
+      screen.getByRole("menuitem", { name: "New chat without a directory" })
+    );
+    expect(onCreateThreadWithoutDirectory).toHaveBeenCalledTimes(1);
+    expect(onCreateThread).not.toHaveBeenCalled();
+
+    fireEvent.mouseEnter(newThreadButton.parentElement as HTMLElement);
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: "New chat in PwrAgnt" })
+    );
     expect(onCreateThread).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -852,6 +852,7 @@ export type ThreadViewProps = {
   pickDirectoryError?: string;
   pickingDirectory?: boolean;
   onSelectDirectoryFromPicker?: (directory: NavigationDirectorySummary) => void;
+  onSelectNoDirectoryFromPicker?: () => void;
   onPickAndRegisterDirectory?: () => void;
   onClearPickDirectoryError?: () => void;
   setExecutionModeError?: string;
@@ -2150,6 +2151,7 @@ export function ThreadView(props: ThreadViewProps) {
               onMaterializeLaunchpad={handleMaterializeLaunchpad}
               onUpdateLaunchpad={props.onUpdateLaunchpad}
               onSelectDirectoryFromPicker={props.onSelectDirectoryFromPicker}
+              onSelectNoDirectoryFromPicker={props.onSelectNoDirectoryFromPicker}
               onPickAndRegisterDirectory={props.onPickAndRegisterDirectory}
               onClearPickDirectoryError={props.onClearPickDirectoryError}
               pickDirectoryError={props.pickDirectoryError}

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -2963,6 +2963,168 @@ describe("useThreadNavigation", () => {
     expect(result.current.selectedLaunchpad?.directoryKey).toBe(directoryKey);
   });
 
+  it("forces a directory-less workspace draft even when a directory is in context", async () => {
+    const directoryKey = "directory:/Users/test/PwrAgent";
+    const workspaceKey = "workspace:/Users/test/.pwragent/projects";
+    const ensureDirectoryLaunchpad = vi.fn(async () => ({
+      launchpad: {
+        directoryKey: workspaceKey,
+        directoryKind: "workspace" as const,
+        directoryLabel: "Workspaces",
+        directoryPath: "/Users/test/.pwragent/projects",
+        backend: "codex" as const,
+        executionMode: "default" as const,
+        prompt: "",
+        workMode: "local" as const,
+        createdAt: 1,
+        updatedAt: 2,
+      },
+      defaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: ["codex:thread-1"],
+      threads: [
+        {
+          id: "thread-1",
+          title: "Project thread",
+          titleSource: "explicit" as const,
+          source: "codex" as const,
+          linkedDirectories: [
+            {
+              id: "linked-dir-1",
+              label: "PwrAgent",
+              path: "/Users/test/PwrAgent",
+              kind: "local" as const,
+            },
+          ],
+          inbox: {
+            inInbox: false,
+          },
+          updatedAt: 1_000,
+        },
+      ],
+      directories: [
+        {
+          key: directoryKey,
+          kind: "directory" as const,
+          label: "PwrAgent",
+          path: "/Users/test/PwrAgent",
+          threadKeys: ["codex:thread-1"],
+          needsAttentionCount: 0,
+        },
+        {
+          key: workspaceKey,
+          kind: "workspace" as const,
+          label: "Workspaces",
+          path: "/Users/test/.pwragent/projects",
+          threadKeys: [],
+          needsAttentionCount: 0,
+        },
+      ],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const desktopApi: DesktopApi = {
+      ensureDirectoryLaunchpad,
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.threads).toHaveLength(1);
+    });
+
+    // Select a thread bound to a real directory — the default createThread()
+    // path would target that directory, and the flyout label reflects it.
+    act(() => {
+      result.current.selectThread(result.current.threads[0]!);
+    });
+    expect(result.current.newThreadDirectoryLabel).toBe("PwrAgent");
+
+    await act(async () => {
+      await result.current.createThread(undefined, "default", {
+        forceWorkspace: true,
+      });
+    });
+
+    // forceWorkspace must bypass the selected directory and land on workspace.
+    expect(ensureDirectoryLaunchpad).toHaveBeenCalledWith({
+      directoryKey: workspaceKey,
+      directoryKind: "workspace",
+      directoryLabel: "Workspaces",
+      directoryPath: "/Users/test/.pwragent/projects",
+      preferredBackend: undefined,
+    });
+    expect(result.current.selectedLaunchpad?.directoryKind).toBe("workspace");
+  });
+
+  it("openWorkspaceLaunchpad synthesizes a workspace target when the snapshot has none", async () => {
+    const ensureDirectoryLaunchpad = vi.fn(async () => ({
+      launchpad: {
+        directoryKey: "workspace:new-thread",
+        directoryKind: "workspace" as const,
+        directoryLabel: "Workspaces",
+        backend: "codex" as const,
+        executionMode: "default" as const,
+        prompt: "",
+        workMode: "local" as const,
+        createdAt: 1,
+        updatedAt: 2,
+      },
+      defaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const desktopApi: DesktopApi = {
+      ensureDirectoryLaunchpad,
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(getNavigationSnapshot).toHaveBeenCalled();
+    });
+
+    await act(async () => {
+      await result.current.openWorkspaceLaunchpad();
+    });
+
+    expect(ensureDirectoryLaunchpad).toHaveBeenCalledWith({
+      directoryKey: "workspace:new-thread",
+      directoryKind: "workspace",
+      directoryLabel: "Workspaces",
+      directoryPath: undefined,
+      currentBranch: undefined,
+      preferredBackend: undefined,
+    });
+    expect(result.current.selectedItemKey).toBe("launchpad:workspace:new-thread");
+  });
+
   it("reuses the selected directory launchpad context for new threads", async () => {
     const directoryKey = "directory:/Users/test/PwrAgent";
     const ensureDirectoryLaunchpad = vi.fn(async () => ({

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -217,15 +217,21 @@ function resolveCreateThreadTargetDirectory(args: {
   directories: NavigationSnapshot["directories"];
   selectedDirectory?: NavigationDirectorySummary;
   selectedThreadKey?: string;
+  /**
+   * When true, ignore the selected directory / thread context and resolve
+   * straight to the directory-less workspace target. Drives the "New chat
+   * without a directory" affordances (New Thread flyout + project picker).
+   */
+  forceWorkspace?: boolean;
 }): {
   directoryKey: string;
   directoryKind: NavigationDirectorySummary["kind"];
   directoryLabel: string;
   directoryPath?: string;
 } {
-  const { directories, selectedDirectory, selectedThreadKey } = args;
+  const { directories, selectedDirectory, selectedThreadKey, forceWorkspace } = args;
 
-  if (selectedDirectory?.kind === "directory") {
+  if (!forceWorkspace && selectedDirectory?.kind === "directory") {
     return {
       directoryKey: selectedDirectory.key,
       directoryKind: selectedDirectory.kind,
@@ -234,7 +240,7 @@ function resolveCreateThreadTargetDirectory(args: {
     };
   }
 
-  if (selectedThreadKey) {
+  if (!forceWorkspace && selectedThreadKey) {
     const threadDirectories = directories.filter(
       (directory) =>
         directory.kind === "directory" && directory.threadKeys.includes(selectedThreadKey)
@@ -1805,7 +1811,8 @@ export function useThreadNavigation(
   browseMode: BrowseMode;
   createThread: (
     backend?: AppServerBackendKind,
-    executionMode?: ThreadExecutionMode
+    executionMode?: ThreadExecutionMode,
+    options?: { forceWorkspace?: boolean }
   ) => Promise<void>;
   createSubthread: (
     parent: NavigationThreadSummary,
@@ -1840,8 +1847,14 @@ export function useThreadNavigation(
     reviewTarget?: AppServerReviewTarget,
     parentThreadId?: string,
   ) => Promise<void>;
+  /** Directory the New Thread button resolves to by default, or undefined for the directory-less workspace. */
+  newThreadDirectoryLabel?: string;
   openDirectoryLaunchpad: (
     directory: NavigationDirectorySummary,
+    preferredBackend?: AppServerBackendKind
+  ) => Promise<void>;
+  /** Switch the composer to the directory-less ("workspace") launchpad. */
+  openWorkspaceLaunchpad: (
     preferredBackend?: AppServerBackendKind
   ) => Promise<void>;
   /** Project-directory picker (issue #223): OS dialog → validate → seed launchpad → focus it. */
@@ -2909,6 +2922,20 @@ export function useThreadNavigation(
       ?.launchpad;
   }, [directories, selectedItemKey]);
 
+  // The directory label the New Thread button would resolve to with its
+  // default (context-aware) behavior, or undefined when that resolves to the
+  // directory-less workspace. Drives the "New chat in <directory>" item in the
+  // New Thread flyout, and lets callers hide that item when there's no
+  // directory to contrast against the "without a directory" choice.
+  const newThreadDirectoryLabel = useMemo(() => {
+    const target = resolveCreateThreadTargetDirectory({
+      directories,
+      selectedDirectory,
+      selectedThreadKey,
+    });
+    return target.directoryKind === "directory" ? target.directoryLabel : undefined;
+  }, [directories, selectedDirectory, selectedThreadKey]);
+
   useEffect(() => {
     releaseRetainedUnreadThread(selectedItemKey);
   }, [releaseRetainedUnreadThread, retainedUnreadThread, selectedItemKey]);
@@ -3081,7 +3108,8 @@ export function useThreadNavigation(
   const createThread = useCallback(
     async (
       backend?: AppServerBackendKind,
-      executionMode: ThreadExecutionMode = "default"
+      executionMode: ThreadExecutionMode = "default",
+      options?: { forceWorkspace?: boolean }
     ): Promise<void> => {
       if (!desktopApi?.ensureDirectoryLaunchpad) {
         setCreateThreadError("Desktop bridge is missing ensureDirectoryLaunchpad().");
@@ -3099,6 +3127,7 @@ export function useThreadNavigation(
           directories,
           selectedDirectory,
           selectedThreadKey,
+          forceWorkspace: options?.forceWorkspace,
         });
         const directoryKey = targetDirectory.directoryKey;
         const response = await desktopApi.ensureDirectoryLaunchpad({
@@ -3151,6 +3180,7 @@ export function useThreadNavigation(
           directories,
           selectedDirectory,
           selectedThreadKey,
+          forceWorkspace: options?.forceWorkspace,
         });
         pendingPickedLaunchpadRef.current.delete(targetDirectory.directoryKey);
         setCreatingThread(undefined);
@@ -3361,6 +3391,30 @@ export function useThreadNavigation(
       }
     },
     [desktopApi]
+  );
+
+  // Switch the composer to the directory-less "workspace" launchpad. Backs the
+  // "Chat without a directory" row in the project picker. Reuses the existing
+  // workspace pseudo-directory when the snapshot already has one, otherwise
+  // synthesizes the same key/label `resolveCreateThreadTargetDirectory` falls
+  // back to so both entry points land on the identical launchpad.
+  const openWorkspaceLaunchpad = useCallback(
+    async (preferredBackend?: AppServerBackendKind): Promise<void> => {
+      const workspaceDirectory = directories.find(
+        (directory) => directory.kind === "workspace"
+      );
+      await openDirectoryLaunchpad(
+        workspaceDirectory ?? {
+          key: ROOT_NEW_THREAD_WORKSPACE_LAUNCHPAD_KEY,
+          kind: "workspace",
+          label: ROOT_NEW_THREAD_WORKSPACE_LABEL,
+          threadKeys: [],
+          needsAttentionCount: 0,
+        },
+        preferredBackend
+      );
+    },
+    [directories, openDirectoryLaunchpad]
   );
 
   const pickAndRegisterDirectory = useCallback(
@@ -4562,7 +4616,9 @@ export function useThreadNavigation(
     refreshing: state.refreshing,
     refresh: refreshNavigation,
     materializeDirectoryLaunchpad,
+    newThreadDirectoryLabel,
     openDirectoryLaunchpad,
+    openWorkspaceLaunchpad,
     pickAndRegisterDirectory,
     pickDirectoryError,
     pickingDirectory,

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -464,6 +464,64 @@ textarea,
   -webkit-app-region: no-drag;
 }
 
+/* New Thread button + hover/focus flyout. The button keeps its default
+   click action; the flyout drops down (right-aligned so it never spills off
+   the sidebar's right edge) with the explicit "in directory" / "without a
+   directory" choices. */
+.new-thread-button {
+  position: relative;
+  display: inline-flex;
+}
+
+.new-thread-menu {
+  position: absolute;
+  z-index: 40;
+  top: 100%;
+  right: 0;
+  /* Transparent top spacer keeps the hover region contiguous between the
+     button and the card, so sliding the pointer into the menu does not fire
+     pointerleave on the wrapper and close it before the cursor lands. */
+  padding-top: 6px;
+}
+
+.new-thread-menu__card {
+  min-width: 220px;
+  max-width: min(320px, calc(100vw - 32px));
+  padding: 6px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-panel-elevated);
+  box-shadow: var(--shadow-popover);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.new-thread-menu__item {
+  width: 100%;
+  display: block;
+  min-height: 36px;
+  padding: 8px 10px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.new-thread-menu__item:hover,
+.new-thread-menu__item:focus-visible {
+  background: var(--accent-soft);
+  color: var(--accent-bright);
+  outline: none;
+}
+
 /* macOS floats the traffic lights over the cluster's left. Match the sidebar
    masthead's wordmark offset exactly — its 16px sidebar gutter + 80px
    stoplight reservation — so the wordmark sits in the same spot whether the
@@ -11576,6 +11634,48 @@ textarea,
   color: var(--danger-text);
   font-size: 12px;
   line-height: 1.35;
+}
+
+/* "Chat without a directory" row — pinned above the recents so the
+   directory-less choice is always reachable regardless of the filtered list. */
+.project-picker__row--no-directory {
+  flex: 0 0 auto;
+  color: var(--text-secondary);
+}
+
+.project-picker__row--no-directory.is-active {
+  color: var(--accent-bright);
+}
+
+.project-picker__no-directory-icon {
+  position: relative;
+  display: inline-flex;
+  width: 14px;
+  flex: 0 0 14px;
+  align-items: center;
+  justify-content: center;
+}
+
+.project-picker__no-directory-text {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 500;
+}
+
+/* Diagonal strike across the folder glyph → "no directory". currentColor
+   follows the row text color so it tracks the hover/active accent. */
+.project-picker__no-directory-slash {
+  position: absolute;
+  left: 50%;
+  top: 0;
+  bottom: 0;
+  width: 1.5px;
+  transform: translateX(-50%) rotate(45deg);
+  background: currentColor;
+  border-radius: 1px;
 }
 
 .workspace-handoff-modal {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -475,6 +475,9 @@ textarea,
 
 .new-thread-menu {
   position: absolute;
+  /* Matches the title-bar z-index; the title bar forms its own stacking
+     context, so within the masthead this reliably layers above sibling
+     content without competing with it. */
   z-index: 40;
   top: 100%;
   right: 0;
@@ -11640,7 +11643,7 @@ textarea,
    directory-less choice is always reachable regardless of the filtered list. */
 .project-picker__row--no-directory {
   flex: 0 0 auto;
-  color: var(--text-secondary);
+  color: var(--text-primary);
 }
 
 .project-picker__row--no-directory.is-active {


### PR DESCRIPTION
## Summary

- The top-level **New Thread** button started resolving a directory from the current context, which lost the ability to start a thread with **no directory**. Directory-less threads already exist in the model (the `workspace` kind that `resolveCreateThreadTargetDirectory` falls back to) — this surfaces a way to deliberately choose that path from two places.
- **Directory popup (`ProjectPicker`):** a pinned **"Chat without a directory"** row above the recents (folder glyph with a diagonal strike), shown as active when the launchpad is already directory-less. Selecting it switches the composer to the workspace launchpad via the new `openWorkspaceLaunchpad()`.
- **New shared `NewThreadButton` with a hover/focus flyout:** clicking the button keeps its current default action; hovering (or keyboard-focusing) reveals **New chat in \<directory\>** and **New chat without a directory**. Escape / mouse-out / outside-focus closes it. Reused in the sidebar masthead and the shared `MastheadActions` (thread header when the sidebar is hidden, Windows title bar) so it reads identically everywhere.
- **`useThreadNavigation` plumbing:** `createThread` gains a `forceWorkspace` option; `openWorkspaceLaunchpad()` and the derived `newThreadDirectoryLabel` feed the picker row and the flyout label. Wired through `App` → `Sidebar`/`ThreadView` → `Composer`.

## Verification

- `tsc --noEmit` typecheck passes.
- `pnpm lint:colors` (CSS uses only `var(--token)` / `currentColor`) and `pnpm lint:boundaries` (new cross-feature import is clean) pass.
- Extended unit specs pass: sidebar (flyout reveals on hover, each item calls the right handler, plain button when no directory in context) and `ProjectPicker` (row renders only when wired, active state, click), plus the masthead `theme-contract` lock — full affected suites green (359+ tests).
- Ruled out flyout clipping (the one thing tests can't catch): `.sidebar` / `.app-shell` are `overflow:hidden`, but the menu drops down-and-left *into* their bounds, so it isn't cut off. Booted a dev instance to confirm clean startup, then shut it down without touching the already-running instance.

## Notes

- **Deliberate behavior:** the flyout only appears when there's a directory to contrast against the workspace choice. When you're *already* directory-less, the default click is the workspace thread and both menu items would be identical, so the button stays plain.
- The New Thread button's old hover **tooltip** ("New thread") was removed since the flyout now serves that role; the other two masthead buttons keep their tooltips. Easy to add back if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)