### PR TITLE
fix(desktop): polish sub-agent cards + drop duplicate rail tab titles

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -111,8 +111,6 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
   const outsideRailSinceRef = useRef<number | undefined>(undefined);
 
   const activeTab = props.activeTab;
-  const activeTabMeta =
-    CONTEXT_TABS.find((tab) => tab.id === activeTab) ?? CONTEXT_TABS[0]!;
   const topTabs = CONTEXT_TABS.filter((tab) => !tab.bottom);
   const bottomTabs = CONTEXT_TABS.filter((tab) => tab.bottom);
 
@@ -452,9 +450,9 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
       {open ? (
         <div className="context-panel">
           <div className="context-panel__inner">
-            <div className="context-panel__header">
-              <span className="context-panel__title">{activeTabMeta.label}</span>
-            </div>
+            {/* No panel title here — each panel's own section <h3> is the
+                title. A separate header duplicated it verbatim on the
+                single-section tabs (Sub-agents, Automations, …). */}
             <div
               className="context-panel__scroll"
               id="context-rail-panel"

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -259,23 +259,28 @@ describe("ThreadContextPanel", () => {
     expect(screen.getByText("Ended")).toBeInTheDocument();
 
     // Details (renamed from the disabled History button) opens a modal with
-    // the request, final response, model, and token/pricing breakdown.
+    // the request, latest message, model, and token/pricing breakdown.
     const detailsButtons = screen.getAllByRole("button", { name: "Details" });
     expect(detailsButtons[0]).toBeEnabled();
+    detailsButtons[0]!.focus();
     fireEvent.click(detailsButtons[0]!);
     const dialog = screen.getByRole("dialog");
     const modal = within(dialog);
     expect(
       modal.getByRole("heading", { level: 2, name: "Watch CI until it completes." }),
     ).toBeInTheDocument();
-    expect(modal.getByText("Final response")).toBeInTheDocument();
+    expect(modal.getByText("Latest message")).toBeInTheDocument();
     expect(modal.getByText("Lint is still running.")).toBeInTheDocument();
     expect(modal.getByText("Tokens & pricing")).toBeInTheDocument();
     expect(modal.getByText("gpt-5.4-mini")).toBeInTheDocument();
     expect(modal.getByText("1,060")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    // Focus moves into the dialog on open and returns to the opener on close.
+    const closeButton = modal.getByRole("button", { name: "Close" });
+    expect(closeButton).toHaveFocus();
+    fireEvent.click(closeButton);
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(detailsButtons[0]).toHaveFocus();
   });
 
   it("moves focus between tabs with Arrow keys (roving tablist)", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -6,6 +6,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ComponentProps } from "react";
@@ -15,10 +16,11 @@ import type { ContextTabId } from "../context-panels/context-tab";
 
 const HOVER_RAIL_REVEAL_DELAY_MS = 350;
 
-// When the rail is open, the active tab's title renders in the panel
-// header. The default tab is "info" → "Thread info", so its presence is a
-// stable "the panel is revealed" signal (the old "Auto-hide" pill is gone).
-const REVEALED_SIGNAL = "Thread info";
+// When the rail is open, the active tab's panel content renders. The
+// default tab is "info"; its first (unconditional) section heading is a
+// stable "the panel is revealed" signal. There is no separate panel title
+// anymore — each panel's own section <h3> is the title.
+const REVEALED_SIGNAL = "Linked directories";
 
 afterEach(() => {
   cleanup();
@@ -234,6 +236,7 @@ describe("ThreadContextPanel", () => {
             status: "success",
             createdAt: 1000,
             updatedAt: 1500,
+            completedAt: 1500,
           },
         ],
       },
@@ -250,7 +253,29 @@ describe("ThreadContextPanel", () => {
     expect(screen.getAllByRole("listitem")[0]).toHaveTextContent(
       "Watch CI until it completes.",
     );
-    expect(screen.getAllByRole("button", { name: "History" })[0]).toBeDisabled();
+    // Every card shows a labeled start time; the completed one also shows
+    // the optional end time.
+    expect(screen.getAllByText("Started")).toHaveLength(2);
+    expect(screen.getByText("Ended")).toBeInTheDocument();
+
+    // Details (renamed from the disabled History button) opens a modal with
+    // the request, final response, model, and token/pricing breakdown.
+    const detailsButtons = screen.getAllByRole("button", { name: "Details" });
+    expect(detailsButtons[0]).toBeEnabled();
+    fireEvent.click(detailsButtons[0]!);
+    const dialog = screen.getByRole("dialog");
+    const modal = within(dialog);
+    expect(
+      modal.getByRole("heading", { level: 2, name: "Watch CI until it completes." }),
+    ).toBeInTheDocument();
+    expect(modal.getByText("Final response")).toBeInTheDocument();
+    expect(modal.getByText("Lint is still running.")).toBeInTheDocument();
+    expect(modal.getByText("Tokens & pricing")).toBeInTheDocument();
+    expect(modal.getByText("gpt-5.4-mini")).toBeInTheDocument();
+    expect(modal.getByText("1,060")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
   it("moves focus between tabs with Arrow keys (roving tablist)", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentDetailsModal.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentDetailsModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import type { ThreadSubAgentSummary } from "@pwragent/shared";
 import { formatTimestamp } from "./context-rail-shared";
@@ -23,16 +23,54 @@ type SubAgentDetailsModalProps = {
  */
 export function SubAgentDetailsModal(props: SubAgentDetailsModalProps) {
   const { subAgent } = props;
+  const contentRef = useRef<HTMLDivElement>(null);
 
+  // Dialog focus management: move focus into the dialog on open, keep Tab
+  // cycling within it (so focus can't fall behind the scrim), restore focus
+  // to the opener on close, and close on Escape.
   useEffect(() => {
+    const restoreFocus = document.activeElement as HTMLElement | null;
+    const focusables = (): HTMLElement[] =>
+      Array.from(
+        contentRef.current?.querySelectorAll<HTMLElement>(
+          'button, a[href], [tabindex]:not([tabindex="-1"])',
+        ) ?? [],
+      ).filter((el) => !el.hasAttribute("disabled"));
+
+    focusables()[0]?.focus();
+
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
+        event.preventDefault();
         props.onClose();
+        return;
+      }
+      if (event.key !== "Tab") {
+        return;
+      }
+      const items = focusables();
+      if (items.length === 0) {
+        return;
+      }
+      const first = items[0]!;
+      const last = items[items.length - 1]!;
+      const active = document.activeElement;
+      if (!contentRef.current?.contains(active)) {
+        event.preventDefault();
+        first.focus();
+      } else if (event.shiftKey && active === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && active === last) {
+        event.preventDefault();
+        first.focus();
       }
     };
-    window.addEventListener("keydown", handleKeyDown);
+
+    window.addEventListener("keydown", handleKeyDown, true);
     return () => {
-      window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("keydown", handleKeyDown, true);
+      restoreFocus?.focus?.();
     };
   }, [props.onClose]);
 
@@ -53,6 +91,7 @@ export function SubAgentDetailsModal(props: SubAgentDetailsModalProps) {
       onClick={props.onClose}
     >
       <div
+        ref={contentRef}
         className="subagent-modal__content"
         onClick={(event) => event.stopPropagation()}
       >
@@ -103,9 +142,9 @@ export function SubAgentDetailsModal(props: SubAgentDetailsModalProps) {
         </dl>
 
         <section className="subagent-modal__section">
-          <h3>Final response</h3>
+          <h3>Latest message</h3>
           <p className="subagent-modal__body">
-            {subAgent.lastMessage ?? "No response yet."}
+            {subAgent.lastMessage ?? "No messages yet."}
           </p>
         </section>
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentDetailsModal.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentDetailsModal.tsx
@@ -1,0 +1,156 @@
+import { useEffect } from "react";
+import { createPortal } from "react-dom";
+import type { ThreadSubAgentSummary } from "@pwragent/shared";
+import { formatTimestamp } from "./context-rail-shared";
+import {
+  formatTokenCount,
+  formatUsd,
+  subAgentStatusLabel,
+  subAgentTone,
+} from "./subagent-format";
+
+type SubAgentDetailsModalProps = {
+  subAgent: ThreadSubAgentSummary;
+  onClose: () => void;
+};
+
+/**
+ * Centered, in-window detail view for a single sub-agent — opened from the
+ * card's Details button. Mirrors {@link TranscriptImageLightbox}: a fixed
+ * scrim that closes on backdrop click or Escape, portaled to the body so it
+ * escapes the context rail's clipping + transforms. Surfaces the request,
+ * final response, run timing, model, and token/pricing usage.
+ */
+export function SubAgentDetailsModal(props: SubAgentDetailsModalProps) {
+  const { subAgent } = props;
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        props.onClose();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [props.onClose]);
+
+  const tone = subAgentTone(subAgent.status);
+  const usage = subAgent.monitorUsage;
+  const model = subAgent.preferredModel ?? usage?.model ?? usage?.cost?.model;
+
+  if (typeof document === "undefined") {
+    return null;
+  }
+
+  return createPortal(
+    <div
+      className="subagent-modal"
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Sub-agent details: ${subAgent.task}`}
+      onClick={props.onClose}
+    >
+      <div
+        className="subagent-modal__content"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="subagent-modal__head">
+          <span className="subagent-card__status-line">
+            <span
+              aria-hidden="true"
+              className={`subagent-card__dot subagent-card__dot--${tone}`}
+            />
+            <span className={`subagent-card__status subagent-card__status--${tone}`}>
+              {subAgentStatusLabel(subAgent.status)}
+            </span>
+          </span>
+          <button
+            type="button"
+            className="button button--ghost subagent-modal__close"
+            onClick={props.onClose}
+          >
+            Close
+          </button>
+        </div>
+
+        <h2 className="subagent-modal__title">{subAgent.task}</h2>
+
+        <dl className="subagent-modal__facts">
+          {model ? (
+            <div>
+              <dt>Model</dt>
+              <dd className="subagent-modal__mono">{model}</dd>
+            </div>
+          ) : null}
+          {subAgent.preferredReasoningEffort ? (
+            <div>
+              <dt>Reasoning</dt>
+              <dd>{subAgent.preferredReasoningEffort}</dd>
+            </div>
+          ) : null}
+          <div>
+            <dt>Started</dt>
+            <dd>{formatTimestamp(subAgent.createdAt)}</dd>
+          </div>
+          {subAgent.completedAt ? (
+            <div>
+              <dt>Ended</dt>
+              <dd>{formatTimestamp(subAgent.completedAt)}</dd>
+            </div>
+          ) : null}
+        </dl>
+
+        <section className="subagent-modal__section">
+          <h3>Final response</h3>
+          <p className="subagent-modal__body">
+            {subAgent.lastMessage ?? "No response yet."}
+          </p>
+        </section>
+
+        {usage ? (
+          <section className="subagent-modal__section">
+            <h3>Tokens &amp; pricing</h3>
+            <dl className="subagent-modal__facts">
+              {usage.tokenUsage.inputTokens !== undefined ? (
+                <div>
+                  <dt>Input</dt>
+                  <dd>{formatTokenCount(usage.tokenUsage.inputTokens)}</dd>
+                </div>
+              ) : null}
+              {usage.tokenUsage.outputTokens !== undefined ? (
+                <div>
+                  <dt>Output</dt>
+                  <dd>{formatTokenCount(usage.tokenUsage.outputTokens)}</dd>
+                </div>
+              ) : null}
+              {usage.tokenUsage.reasoningOutputTokens !== undefined ? (
+                <div>
+                  <dt>Reasoning</dt>
+                  <dd>{formatTokenCount(usage.tokenUsage.reasoningOutputTokens)}</dd>
+                </div>
+              ) : null}
+              {usage.tokenUsage.totalTokens !== undefined ? (
+                <div>
+                  <dt>Total</dt>
+                  <dd>{formatTokenCount(usage.tokenUsage.totalTokens)}</dd>
+                </div>
+              ) : null}
+              {usage.cost ? (
+                <div>
+                  <dt>Cost</dt>
+                  <dd>{formatUsd(usage.cost.totalUsd)}</dd>
+                </div>
+              ) : null}
+            </dl>
+            {usage.summary ? (
+              <p className="subagent-modal__usage-summary">{usage.summary}</p>
+            ) : null}
+          </section>
+        ) : null}
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
@@ -1,20 +1,21 @@
-import type { NavigationThreadSummary } from "@pwragent/shared";
-import {
-  useSubAgents,
-  type SubAgentStatus,
-  type SubAgentSummary,
-} from "./useSubAgents";
+import { useState } from "react";
+import type {
+  NavigationThreadSummary,
+  ThreadSubAgentSummary,
+} from "@pwragent/shared";
+import { useSubAgents } from "./useSubAgents";
 import { formatTimestamp } from "./context-rail-shared";
+import { subAgentStatusLabel, subAgentTone } from "./subagent-format";
+import { SubAgentDetailsModal } from "./SubAgentDetailsModal";
 
 type SubAgentsPanelProps = {
   thread: NavigationThreadSummary;
-  /** Opens a sub-agent's monitor thread in the main view, when wired. */
-  onViewSubAgent?: (subAgent: SubAgentSummary) => void;
 };
 
 /** Sub-Agents tab: durable task-monitor cards spawned from this thread. */
 export function SubAgentsPanel(props: SubAgentsPanelProps) {
   const { subAgents, loading } = useSubAgents(props.thread);
+  const [detailsFor, setDetailsFor] = useState<ThreadSubAgentSummary | null>(null);
 
   return (
     <section className="context-panel__section">
@@ -23,44 +24,56 @@ export function SubAgentsPanel(props: SubAgentsPanelProps) {
         <p className="context-empty">Loading sub-agents…</p>
       ) : subAgents.length > 0 ? (
         <ul className="context-list context-list--cards">
-          {subAgents.map((subAgent) => (
-            <li key={subAgent.monitorId} className="subagent-card">
-              <div className="subagent-card__header">
-                <div className="subagent-card__title-row">
+          {subAgents.map((subAgent) => {
+            const tone = subAgentTone(subAgent.status);
+            return (
+              <li key={subAgent.monitorId} className="subagent-card">
+                {/* Status on its own line so it never competes with the
+                    title for the top row (the title pushed it off before). */}
+                <p className="subagent-card__status-line">
                   <span
                     aria-hidden="true"
-                    className={`subagent-card__dot subagent-card__dot--${statusTone(subAgent.status)}`}
+                    className={`subagent-card__dot subagent-card__dot--${tone}`}
                   />
-                  <p className="context-list__label">{subAgent.task}</p>
-                </div>
-                <span
-                  className={`subagent-card__status subagent-card__status--${statusTone(subAgent.status)}`}
-                >
-                  {statusLabel(subAgent.status)}
-                </span>
-              </div>
-              <p className="context-list__meta">
-                {subAgent.preferredModel ? `${subAgent.preferredModel} · ` : ""}
-                {formatTimestamp(subAgent.createdAt)}
-              </p>
-              {subAgent.lastMessage ? (
-                <p className="subagent-card__message">{subAgent.lastMessage}</p>
-              ) : null}
-              {subAgent.monitorUsage?.summary ? (
-                <p className="subagent-card__usage">
-                  Monitor usage: {subAgent.monitorUsage.summary}
+                  <span className={`subagent-card__status subagent-card__status--${tone}`}>
+                    {subAgentStatusLabel(subAgent.status)}
+                  </span>
                 </p>
-              ) : null}
-              <button
-                className="context-list__action"
-                type="button"
-                disabled
-                title="Sub-agent history is not available yet."
-              >
-                History
-              </button>
-            </li>
-          ))}
+                <p className="subagent-card__title" title={subAgent.task}>
+                  {subAgent.task}
+                </p>
+                {subAgent.preferredModel ? (
+                  <p className="subagent-card__model">{subAgent.preferredModel}</p>
+                ) : null}
+                <p className="subagent-card__times">
+                  <span className="subagent-card__time-label">Started</span>{" "}
+                  {formatTimestamp(subAgent.createdAt)}
+                  {subAgent.completedAt ? (
+                    <>
+                      {" · "}
+                      <span className="subagent-card__time-label">Ended</span>{" "}
+                      {formatTimestamp(subAgent.completedAt)}
+                    </>
+                  ) : null}
+                </p>
+                {subAgent.lastMessage ? (
+                  <p className="subagent-card__message">{subAgent.lastMessage}</p>
+                ) : null}
+                {subAgent.monitorUsage?.summary ? (
+                  <p className="subagent-card__usage">
+                    Monitor usage: {subAgent.monitorUsage.summary}
+                  </p>
+                ) : null}
+                <button
+                  className="context-list__action"
+                  type="button"
+                  onClick={() => setDetailsFor(subAgent)}
+                >
+                  Details
+                </button>
+              </li>
+            );
+          })}
         </ul>
       ) : (
         <p className="context-empty">
@@ -68,41 +81,12 @@ export function SubAgentsPanel(props: SubAgentsPanelProps) {
           will appear here.
         </p>
       )}
+      {detailsFor ? (
+        <SubAgentDetailsModal
+          subAgent={detailsFor}
+          onClose={() => setDetailsFor(null)}
+        />
+      ) : null}
     </section>
   );
-}
-
-function statusTone(status: SubAgentStatus): "active" | "done" | "warn" | "idle" {
-  switch (status) {
-    case "running":
-      return "active";
-    case "success":
-      return "done";
-    case "blocked":
-    case "failed":
-    case "failure":
-    case "cancelled":
-      return "warn";
-    case "pending":
-      return "idle";
-  }
-}
-
-function statusLabel(status: SubAgentStatus): string {
-  switch (status) {
-    case "pending":
-      return "Pending";
-    case "running":
-      return "Running";
-    case "blocked":
-      return "Blocked";
-    case "failed":
-      return "Failed";
-    case "success":
-      return "Completed";
-    case "failure":
-      return "Failed";
-    case "cancelled":
-      return "Cancelled";
-  }
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/subagent-format.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/subagent-format.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { formatTokenCount, formatUsd } from "../subagent-format";
+
+describe("formatUsd", () => {
+  it("keeps three decimals for sub-cent runs", () => {
+    expect(formatUsd(0.047)).toBe("$0.047");
+    expect(formatUsd(0.032)).toBe("$0.032");
+    expect(formatUsd(0.00084)).toBe("$0.001");
+  });
+
+  it("trims to two decimals when the thousandths digit is zero", () => {
+    expect(formatUsd(0.05)).toBe("$0.05");
+    expect(formatUsd(0.04)).toBe("$0.04");
+    expect(formatUsd(0)).toBe("$0.00");
+  });
+
+  it("uses plain cents at ten cents and above", () => {
+    expect(formatUsd(0.1)).toBe("$0.10");
+    expect(formatUsd(0.13)).toBe("$0.13");
+    expect(formatUsd(1.239)).toBe("$1.24");
+  });
+});
+
+describe("formatTokenCount", () => {
+  it("groups thousands", () => {
+    expect(formatTokenCount(303488)).toBe("303,488");
+    expect(formatTokenCount(0)).toBe("0");
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/subagent-format.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/subagent-format.ts
@@ -39,14 +39,20 @@ export function subAgentStatusLabel(status: ThreadSubAgentStatus): string {
 }
 
 /** Compact, locale-grouped token count (e.g. `303,488`). */
-export function formatTokenCount(value: number | undefined): string | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
+export function formatTokenCount(value: number): string {
   return value.toLocaleString();
 }
 
-/** Two-decimal USD, e.g. `$0.047` → `$0.05` is too lossy, so keep 3 dp. */
+/**
+ * USD for a sub-agent run cost. Sub-cent runs need three decimals to be
+ * meaningful (e.g. `$0.047`), but we trim the thousandths digit when it
+ * rounds to zero so `$0.05` doesn't read as `$0.050` (and `$0` as `$0.00`).
+ * At ten cents and up, plain two-decimal cents.
+ */
 export function formatUsd(value: number): string {
-  return `$${value.toFixed(3)}`;
+  if (value >= 0.1) {
+    return `$${value.toFixed(2)}`;
+  }
+  const precise = value.toFixed(3);
+  return `$${precise.endsWith("0") ? value.toFixed(2) : precise}`;
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/subagent-format.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/subagent-format.ts
@@ -1,0 +1,52 @@
+import type { ThreadSubAgentStatus } from "@pwragent/shared";
+
+export type SubAgentTone = "active" | "done" | "warn" | "idle";
+
+/** Maps a sub-agent status onto the dot/label color tone. */
+export function subAgentTone(status: ThreadSubAgentStatus): SubAgentTone {
+  switch (status) {
+    case "running":
+      return "active";
+    case "success":
+      return "done";
+    case "blocked":
+    case "failed":
+    case "failure":
+    case "cancelled":
+      return "warn";
+    case "pending":
+      return "idle";
+  }
+}
+
+/** Human label for a sub-agent status. */
+export function subAgentStatusLabel(status: ThreadSubAgentStatus): string {
+  switch (status) {
+    case "pending":
+      return "Pending";
+    case "running":
+      return "Running";
+    case "blocked":
+      return "Blocked";
+    case "failed":
+    case "failure":
+      return "Failed";
+    case "success":
+      return "Completed";
+    case "cancelled":
+      return "Cancelled";
+  }
+}
+
+/** Compact, locale-grouped token count (e.g. `303,488`). */
+export function formatTokenCount(value: number | undefined): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  return value.toLocaleString();
+}
+
+/** Two-decimal USD, e.g. `$0.047` → `$0.05` is too lossy, so keep 3 dp. */
+export function formatUsd(value: number): string {
+  return `$${value.toFixed(3)}`;
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/useSubAgents.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/useSubAgents.ts
@@ -1,14 +1,10 @@
 import type {
   NavigationThreadSummary,
-  ThreadSubAgentStatus,
   ThreadSubAgentSummary,
 } from "@pwragent/shared";
 
-export type SubAgentStatus = ThreadSubAgentStatus;
-export type SubAgentSummary = ThreadSubAgentSummary;
-
 export type UseSubAgentsResult = {
-  subAgents: SubAgentSummary[];
+  subAgents: ThreadSubAgentSummary[];
   loading: boolean;
   /** True when the running backend exposes the monitor surface. */
   supported: boolean;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9395,22 +9395,6 @@ textarea,
   min-height: 0;
 }
 
-.context-panel__header {
-  display: flex;
-  flex: 0 0 auto;
-  align-items: center;
-  gap: 8px;
-  padding: 13px 16px;
-  border-bottom: 1px solid var(--border-subtle);
-}
-
-.context-panel__title {
-  color: var(--text-primary);
-  font-size: 13px;
-  font-weight: 650;
-  letter-spacing: -0.01em;
-}
-
 .context-panel__scroll {
   flex: 1;
   min-height: 0;
@@ -10040,18 +10024,15 @@ textarea,
   background: var(--surface-overlay-faint);
 }
 
-.subagent-card__header {
+/* Status line: dot + label on their own row, above the title, so the
+   title never has to share the top row (it used to push the dot + status
+   out of alignment). align-items: center keeps the dot centered on the
+   status label regardless of sidebar width. */
+.subagent-card__status-line {
   display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 8px;
-  min-width: 0;
-}
-
-.subagent-card__title-row {
-  display: flex;
-  align-items: flex-start;
-  gap: 8px;
+  align-items: center;
+  gap: 6px;
+  margin: 0;
   min-width: 0;
 }
 
@@ -10059,9 +10040,41 @@ textarea,
   flex: 0 0 auto;
   width: 8px;
   height: 8px;
-  margin-top: 5px;
   border-radius: 999px;
   background: var(--text-muted);
+}
+
+/* Title sits on its own row, full width, and wraps (clamped) instead of
+   truncating mid-word in a shared flex row. */
+.subagent-card__title {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 650;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.subagent-card__model {
+  margin: 0;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.subagent-card__times {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.subagent-card__time-label {
+  color: var(--text-secondary);
 }
 
 .subagent-card__dot--active {
@@ -10106,6 +10119,111 @@ textarea,
 
 .subagent-card__usage {
   color: var(--text-secondary);
+}
+
+/* Sub-agent Details modal — a centered, in-window dialog (mirrors the
+   transcript image lightbox) portaled to the body so it escapes the rail's
+   clipping. Opened from the card's Details button. */
+.subagent-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: var(--scrim-opaque);
+}
+
+.subagent-modal__content {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  width: min(100%, 560px);
+  max-height: min(100vh - 96px, 720px);
+  overflow-y: auto;
+  padding: 20px;
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  background: var(--bg-panel);
+}
+
+.subagent-modal__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.subagent-modal__close {
+  flex: 0 0 auto;
+}
+
+.subagent-modal__title {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 17px;
+  font-weight: 650;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+}
+
+.subagent-modal__facts {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 6px 16px;
+  margin: 0;
+}
+
+.subagent-modal__facts div {
+  display: contents;
+}
+
+.subagent-modal__facts dt {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.subagent-modal__facts dd {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+
+.subagent-modal__mono {
+  font-family: var(--font-mono);
+}
+
+.subagent-modal__section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding-top: 14px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.subagent-modal__section h3 {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 650;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.subagent-modal__body,
+.subagent-modal__usage-summary {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.subagent-modal__usage-summary {
+  color: var(--text-muted);
 }
 
 /* Pull Requests panel rows. */


### PR DESCRIPTION
## Summary

Polishes the sub-agent cards Codex landed in the context rail's **Sub-agents** tab, and removes the redundant per-tab title across the rail.

**Sub-agent cards**
1. **Status no longer competes with the title.** The colored dot + status label move to their own line at the top of the card; the title gets its own full-width row and wraps (2-line clamp) instead of being pushed out and truncated mid-word. This fixes the dot/title/status misalignment at every sidebar width.
2. **End time.** Added a labeled `Started … · Ended …` line. The end time comes from the optional `completedAt` and only renders once it arrives.
3. **History → Details.** Renamed the (previously disabled) button to **Details** and wired it to open a centered in-window modal — mirroring the transcript image lightbox (portaled to `body`, closes on backdrop click or Escape). The modal shows the request (task), **Final response**, run timing, the **model used**, and a **Tokens & pricing** breakdown + cost.

**Context rail tab titles**
- Dropped the `.context-panel__header` tab title. It duplicated each panel's own section `<h3>` verbatim on the single-section tabs (Sub-agents / Automations / Pull requests / Linked projects) and was needless on Thread info. Each panel's section heading is now the only title. The tabpanel stays labelled by its tab button, so removing the visual header doesn't affect accessibility.

New files: `SubAgentDetailsModal.tsx`, `subagent-format.ts` (shared status tone/label + token/USD formatting).

## Verification

- **Live (dev profile):** the restructured card renders as intended — status line on top, title on its own row, `Started … · Ended …`, model, message, usage, Details button; and the panel shows only its section heading (no duplicate tab title).
- Could not click *Details* live (a Splashtop Streamer remote-session overlay was blocking clicks on the rail), but the modal is locked by a unit test: clicking Details opens a `role="dialog"` showing the task heading, **Final response** + message, **Tokens & pricing** + model + token count, and closes via the Close button.
- 1002 renderer unit tests ✓ · full Desktop E2E **145 passed / 0 failed** ✓ · `typecheck` ✓ · `lint:boundaries` / `lint:colors` / `lint:codex-storage` / `lint:sql` ✓

## Notes

- All data already existed on `ThreadSubAgentSummary` (`completedAt`, `monitorUsage`, `preferredModel`, `lastMessage`), so this is renderer-only — no contract or main-process changes.
- `useSubAgents.ts` still re-exports the `SubAgentStatus`/`SubAgentSummary` type aliases; they're now unused (the panel imports the shared types directly) but left in place as a harmless re-export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)