### PR TITLE
feat(desktop): fork & sub-thread from child cards, inserted in place

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -587,6 +587,7 @@ function DesktopAppShell(props: {
       : undefined,
     onLoadOlder: session.loadOlder,
     onLiveTranscriptEntry: session.upsertLiveTranscriptEntry,
+    onCancelLaunchpad: navigation.discardLaunchpad,
     onMaterializeLaunchpad: navigation.materializeDirectoryLaunchpad,
     onPendingStatusChange: session.setPendingStatusText,
     onRefreshNavigation: navigation.refresh,
@@ -686,6 +687,7 @@ function DesktopAppShell(props: {
           launchpadError={navigation.launchpadError}
           loading={navigation.loading}
           approvalRequestThreadKeys={session.approvalRequestThreadKeys}
+          composerSourceThreadKey={navigation.composerSourceThreadKey}
           selectedItemKey={navigation.selectedItemKey}
           thinkingThreadKeys={session.thinkingThreadKeys}
           threads={navigation.threads}

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -115,6 +115,8 @@ type ComposerProps = {
     collaborationMode?: AppServerCollaborationModeRequest,
     reviewTarget?: AppServerReviewTarget
   ) => Promise<void>;
+  /** Discard this launchpad draft (the "Cancel" button next to "Start thread"). */
+  onCancelLaunchpad?: (directoryKey: string) => void;
   onBeforeSendTurn?: () => void;
   onPendingStatusChange?: (status?: string) => void;
   onRefreshNavigation?: () => Promise<void>;
@@ -6110,6 +6112,18 @@ export function Composer(props: ComposerProps) {
               }}
             >
               {interrupting ? "Stopping…" : "Stop"}
+            </button>
+          ) : null}
+          {props.launchpad && props.onCancelLaunchpad ? (
+            <button
+              className="button button--ghost"
+              disabled={sending}
+              type="button"
+              onClick={() => {
+                props.onCancelLaunchpad?.(props.launchpad!.directoryKey);
+              }}
+            >
+              Cancel
             </button>
           ) : null}
           <button

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -21,6 +21,7 @@ import {
   isPinnedThread,
   moveDirectoryKey,
   moveThreadKey,
+  sortSubthreadSummaries,
 } from "@pwragent/shared";
 import {
   FolderIcon,
@@ -37,6 +38,7 @@ import { ThreadRow } from "./ThreadRow";
 
 type DirectoriesListProps = {
   approvalRequestThreadKeys?: Record<string, boolean>;
+  composerSourceThreadKey?: string;
   directories: NavigationDirectorySummary[];
   selectedItemKey?: string;
   thinkingThreadKeys?: Record<string, boolean>;
@@ -424,25 +426,9 @@ export function DirectoriesList(props: DirectoriesListProps) {
       if (!thread.parentThreadId) return true;
       return !visibleThreadKeys.has(buildThreadIdentityKey(thread.source, thread.parentThreadId));
     });
-    const sortSubthreads = (
-      parent: NavigationThreadSummary,
-      children: NavigationThreadSummary[],
-    ): NavigationThreadSummary[] => {
-      const order = new Map(
-        (parent.subthreadOrder ?? []).map((threadId, index) => [threadId, index]),
-      );
-      return [...children].sort((left, right) => {
-        const leftRank = order.get(left.id);
-        const rightRank = order.get(right.id);
-        if (leftRank !== undefined || rightRank !== undefined) {
-          return (leftRank ?? Number.MAX_SAFE_INTEGER) - (rightRank ?? Number.MAX_SAFE_INTEGER);
-        }
-        return (right.createdAt ?? 0) - (left.createdAt ?? 0);
-      });
-    };
     const renderStaticSubthreads = (parent: NavigationThreadSummary): ReactElement | null => {
       const parentKey = buildThreadIdentityKey(parent.source, parent.id);
-      const children = sortSubthreads(parent, childThreadsByParentKey.get(parentKey) ?? []);
+      const children = sortSubthreadSummaries(parent, childThreadsByParentKey.get(parentKey) ?? []);
       if (children.length === 0 || parent.subthreadsCollapsed) {
         return null;
       }
@@ -452,6 +438,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
             <ThreadRow
               key={`${directory.key}:${buildThreadIdentityKey(child.source, child.id)}`}
               approvalRequestThreadKeys={props.approvalRequestThreadKeys}
+              composerSourceThreadKey={props.composerSourceThreadKey}
               compact
               includeLinkedDirectories
               linkedDirectoryMode="kind"
@@ -739,6 +726,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
 	                        <ThreadRow
 	                          key={`${directory.key}:${threadKey}`}
                           approvalRequestThreadKeys={props.approvalRequestThreadKeys}
+                          composerSourceThreadKey={props.composerSourceThreadKey}
                           compact
                           dropIndicator={
                             dropIndicator?.targetKey === rowDropKey
@@ -886,6 +874,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
 	                        <ThreadRow
 	                          key={`${directory.key}:${threadKey}`}
                           approvalRequestThreadKeys={props.approvalRequestThreadKeys}
+                          composerSourceThreadKey={props.composerSourceThreadKey}
                           compact
                           draggable={Boolean(props.onReorderThreadPins)}
                           includeLinkedDirectories

--- a/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
@@ -10,6 +10,7 @@ import {
   isPinnedThread,
   moveThreadKey,
   parseThreadIdentityKey,
+  sortSubthreadSummaries,
 } from "@pwragent/shared";
 import {
   didDragLeaveCurrentTarget,
@@ -20,6 +21,7 @@ import { ThreadRow } from "./ThreadRow";
 
 type RecentsListProps = {
   approvalRequestThreadKeys?: Record<string, boolean>;
+  composerSourceThreadKey?: string;
   selectedThreadKey?: string;
   thinkingThreadKeys?: Record<string, boolean>;
   threads: NavigationThreadSummary[];
@@ -81,22 +83,6 @@ export function RecentsList(props: RecentsListProps) {
     children.push(thread);
     childrenByParentKey.set(parentKey, children);
   }
-  const sortSubthreads = (
-    parent: NavigationThreadSummary,
-    children: NavigationThreadSummary[],
-  ): NavigationThreadSummary[] => {
-    const order = new Map(
-      (parent.subthreadOrder ?? []).map((threadId, index) => [threadId, index]),
-    );
-    return [...children].sort((left, right) => {
-      const leftRank = order.get(left.id);
-      const rightRank = order.get(right.id);
-      if (leftRank !== undefined || rightRank !== undefined) {
-        return (leftRank ?? Number.MAX_SAFE_INTEGER) - (rightRank ?? Number.MAX_SAFE_INTEGER);
-      }
-      return (right.createdAt ?? 0) - (left.createdAt ?? 0);
-    });
-  };
   const pinnedThreads = topLevelThreads
     .filter(isPinnedThread)
     .sort(comparePinnedThreads);
@@ -135,7 +121,7 @@ export function RecentsList(props: RecentsListProps) {
 
   const renderSubthreads = (parent: NavigationThreadSummary) => {
     const parentKey = buildThreadIdentityKey(parent.source, parent.id);
-    const children = sortSubthreads(parent, childrenByParentKey.get(parentKey) ?? []);
+    const children = sortSubthreadSummaries(parent, childrenByParentKey.get(parentKey) ?? []);
     if (children.length === 0 || parent.subthreadsCollapsed) {
       return null;
     }
@@ -150,6 +136,7 @@ export function RecentsList(props: RecentsListProps) {
             <ThreadRow
               key={childKey}
               approvalRequestThreadKeys={props.approvalRequestThreadKeys}
+              composerSourceThreadKey={props.composerSourceThreadKey}
               dropIndicator={
                 dropIndicator?.targetKey === rowDropKey
                   ? dropIndicator.position
@@ -232,12 +219,13 @@ export function RecentsList(props: RecentsListProps) {
 
   const renderThreadGroup = (thread: NavigationThreadSummary) => {
     const key = buildThreadIdentityKey(thread.source, thread.id);
-    const children = sortSubthreads(thread, childrenByParentKey.get(key) ?? []);
+    const children = sortSubthreadSummaries(thread, childrenByParentKey.get(key) ?? []);
     const pinned = isPinnedThread(thread);
     return (
       <div key={key} className="thread-group">
         <ThreadRow
           approvalRequestThreadKeys={props.approvalRequestThreadKeys}
+          composerSourceThreadKey={props.composerSourceThreadKey}
           dropIndicator={
             dropIndicator?.targetKey === key
               ? dropIndicator.position

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -75,6 +75,8 @@ type SidebarProps = {
   threadSearchActive?: boolean;
   settingsActive?: boolean;
   approvalRequestThreadKeys?: Record<string, boolean>;
+  /** Identity key of the card to highlight as the open composer's source. */
+  composerSourceThreadKey?: string;
   selectedItemKey?: string;
   thinkingThreadKeys?: Record<string, boolean>;
   threads: NavigationThreadSummary[];
@@ -626,16 +628,15 @@ export function Sidebar(props: SidebarProps) {
   const contextMenuBranchName = contextMenu?.thread.gitBranch;
   const contextMenuPullRequest = contextMenu?.pullRequest;
   const contextMenuIsSubthread = Boolean(contextMenu?.thread.parentThreadId);
+  // Sub-thread / fork are available from child cards too: spawning from a child
+  // re-parents the new thread to the group root (one level deep, inserted below
+  // the source), so there is no orphaned-grandchild risk to gate against.
   const contextMenuCanCreateSubthread = Boolean(
-    contextMenu &&
-      !contextMenuIsSubthread &&
-      contextMenuHasWorkspace &&
-      props.onCreateSubthread,
+    contextMenu && contextMenuHasWorkspace && props.onCreateSubthread,
   );
   const contextMenuCanFork = Boolean(
     contextMenu &&
       contextMenu.thread.source === "codex" &&
-      !contextMenuIsSubthread &&
       contextMenuHasWorkspace &&
       canForkThread(contextMenu.thread) &&
       props.onForkThread,
@@ -866,6 +867,7 @@ export function Sidebar(props: SidebarProps) {
           ) : props.browseMode === "directories" ? (
             <DirectoriesList
               approvalRequestThreadKeys={props.approvalRequestThreadKeys}
+              composerSourceThreadKey={props.composerSourceThreadKey}
               directories={props.directories}
               selectedItemKey={props.selectedItemKey}
               thinkingThreadKeys={props.thinkingThreadKeys}
@@ -892,6 +894,7 @@ export function Sidebar(props: SidebarProps) {
             ) : (
               <RecentsList
                 approvalRequestThreadKeys={props.approvalRequestThreadKeys}
+                composerSourceThreadKey={props.composerSourceThreadKey}
                 selectedThreadKey={props.selectedItemKey}
                 thinkingThreadKeys={props.thinkingThreadKeys}
                 threads={visibleThreads}

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -32,6 +32,11 @@ const absoluteDateFormatter = new Intl.DateTimeFormat(undefined, {
 
 type ThreadRowProps = {
   approvalRequestThreadKeys?: Record<string, boolean>;
+  /**
+   * Identity key of the card the open composer was spawned from. When it
+   * matches this row, the row renders as the orange "composing" source.
+   */
+  composerSourceThreadKey?: string;
   compact?: boolean;
   dropIndicator?: DropIndicatorPosition;
   draggable?: boolean;
@@ -90,6 +95,7 @@ export function ThreadRow(props: ThreadRowProps) {
   const threadKey = buildThreadIdentityKey(props.thread.source, props.thread.id);
   const selected =
     threadKey === props.selectedThreadKey;
+  const isComposerSource = threadKey === props.composerSourceThreadKey;
   const status = getThreadRowStatus(props.thread, props.thinkingThreadKeys);
   const [pickerOpen, setPickerOpen] = useState(false);
   const addReactionRef = useRef<HTMLSpanElement>(null);
@@ -183,7 +189,7 @@ export function ThreadRow(props: ThreadRowProps) {
         aria-pressed={selected}
         className={`thread-row${props.compact ? " thread-row--compact" : ""}${
           selected ? " is-selected" : ""
-        }`}
+        }${isComposerSource ? " is-composer-source" : ""}`}
         type="button"
         onKeyDown={(event) => {
           // Reorder a pinned thread within its backend's pinned

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -522,6 +522,55 @@ describe("Sidebar", () => {
     expect(screen.queryByRole("menuitem", { name: "Fork in Local" })).toBeNull();
   });
 
+  it("exposes sub-thread and fork actions on a child card", () => {
+    const onCreateSubthread = vi.fn(async () => undefined);
+    const onForkThread = vi.fn(async () => undefined);
+    const forkBackends: BackendSummary[] = [
+      {
+        ...backends[0]!,
+        capabilities: { ...backends[0]!.capabilities, forkThread: true },
+      },
+    ];
+    const childThread = {
+      ...sharedThread,
+      id: "thread-child",
+      title: "Child cleanup",
+      parentThreadId: sharedThread.id,
+      updatedAt: sharedThread.updatedAt + 1,
+    };
+    render(
+      <Sidebar
+        backends={forkBackends}
+        browseMode="inbox"
+        directories={directories}
+        inboxThreads={[childThread, sharedThread]}
+        loading={false}
+        selectedItemKey="codex:thread-1"
+        threads={[childThread, sharedThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onCreateSubthread={onCreateSubthread}
+        onForkThread={onForkThread}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />,
+    );
+
+    // A child card now offers the same spawn actions; the parent hook
+    // re-parents the result to the group root, so the menu can stay open.
+    fireEvent.contextMenu(screen.getByRole("button", { name: "Child cleanup" }));
+    fireEvent.click(
+      screen.getByRole("menuitem", { name: "Sub-thread in Same Worktree" }),
+    );
+    expect(onCreateSubthread).toHaveBeenCalledWith(childThread, "same-worktree");
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: "Child cleanup" }));
+    fireEvent.click(
+      screen.getByRole("menuitem", { name: "Fork into Same Worktree" }),
+    );
+    expect(onForkThread).toHaveBeenCalledWith(childThread, "same-worktree");
+  });
+
   it("shows the active PwrAgent and Codex profiles with account tooltip details", async () => {
     render(
       <Sidebar

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -901,6 +901,7 @@ export type ThreadViewProps = {
     collaborationMode?: AppServerCollaborationModeRequest,
     reviewTarget?: AppServerReviewTarget
   ) => Promise<void>;
+  onCancelLaunchpad?: (directoryKey: string) => void;
   onPendingStatusChange?: (status?: string) => void;
   onUpdatePendingUserInput?: (
     requestId: string,
@@ -2149,6 +2150,7 @@ export function ThreadView(props: ThreadViewProps) {
                 props.onDismissFullAccessRiskWarning
               }
               onMaterializeLaunchpad={handleMaterializeLaunchpad}
+              onCancelLaunchpad={props.onCancelLaunchpad}
               onUpdateLaunchpad={props.onUpdateLaunchpad}
               onSelectDirectoryFromPicker={props.onSelectDirectoryFromPicker}
               onSelectNoDirectoryFromPicker={props.onSelectNoDirectoryFromPicker}

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -1341,6 +1341,109 @@ describe("useThreadNavigation", () => {
     });
   });
 
+  it("forks a child below its source and re-parents it to the group root", async () => {
+    const worktree = {
+      id: "wt",
+      label: "Repo",
+      path: "/repo",
+      worktreePath: "/wt/repo",
+      kind: "worktree" as const,
+    };
+    const rootThread = {
+      id: "thread-root",
+      title: "Root thread",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      linkedDirectories: [worktree],
+      inbox: { inInbox: false },
+      updatedAt: 1_000,
+      createdAt: 1_000,
+      subthreadOrder: ["thread-a", "thread-b"],
+    };
+    const childA = {
+      id: "thread-a",
+      title: "Child A",
+      titleSource: "explicit" as const,
+      parentThreadId: "thread-root",
+      source: "codex" as const,
+      linkedDirectories: [worktree],
+      inbox: { inInbox: false },
+      updatedAt: 2_000,
+      createdAt: 2_000,
+    };
+    const childB = { ...childA, id: "thread-b", title: "Child B", createdAt: 3_000 };
+
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [rootThread, childA, childB],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const forkThread = vi.fn(
+      async (request: { parentThreadId?: string; sourceThreadId: string }) => ({
+        backend: "codex" as const,
+        sourceThreadId: request.sourceThreadId,
+        threadId: "thread-fork",
+        executionMode: "default" as const,
+        workMode: "local" as const,
+      }),
+    );
+    const updateSubthreadOrder = vi.fn(
+      async (request: {
+        backend?: string;
+        parentThreadId: string;
+        threadIds: string[];
+      }) => ({
+        backend: "codex" as const,
+        parentThreadId: request.parentThreadId,
+        threadIds: request.threadIds,
+      }),
+    );
+
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      forkThread,
+      updateSubthreadOrder,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.threads.map((thread) => thread.id)).toEqual([
+        "thread-root",
+        "thread-a",
+        "thread-b",
+      ]);
+    });
+
+    const sourceChild = result.current.threads.find((thread) => thread.id === "thread-a")!;
+    await act(async () => {
+      await result.current.forkThread(sourceChild, "same-worktree");
+    });
+
+    // Forks the clicked child's content but links the new thread to the root,
+    // so it renders one level deep rather than as an unrenderable grandchild.
+    expect(forkThread).toHaveBeenCalledTimes(1);
+    expect(forkThread.mock.calls[0]![0]).toMatchObject({
+      parentThreadId: "thread-root",
+      sourceThreadId: "thread-a",
+    });
+
+    // The new thread lands directly below its source child in the root's tray.
+    expect(updateSubthreadOrder).toHaveBeenCalledTimes(1);
+    expect(updateSubthreadOrder.mock.calls[0]![0]).toMatchObject({
+      parentThreadId: "thread-root",
+      threadIds: ["thread-a", "thread-fork", "thread-b"],
+    });
+  });
+
   it("restores focus to the selected thread when archive fails", async () => {
     const navigationSnapshot = {
       backend: "all" as const,

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -3237,12 +3237,12 @@ export function useThreadNavigation(
    * then expands the group if it was collapsed so the new child is visible.
    */
   const insertSubthreadBelowSource = useCallback(
-    (
+    async (
       backend: AppServerBackendKind,
       rootThreadId: string,
       sourceThreadId: string,
       newThreadId: string,
-    ): void => {
+    ): Promise<void> => {
       const snapshot = stateRef.current.response;
       if (!snapshot) {
         return;
@@ -3272,26 +3272,28 @@ export function useThreadNavigation(
           threadIds: nextOrder,
         }),
       }));
+      // Await the persist so callers can sequence the authoritative refresh
+      // after it commits — otherwise a refresh racing ahead of this write can
+      // momentarily resurrect the pre-insert order.
       const persistOrder = desktopApi?.updateSubthreadOrder;
       if (persistOrder) {
-        void persistOrder({
-          backend,
-          parentThreadId: rootThreadId,
-          threadIds: nextOrder,
-        })
-          .then((result) => {
-            setState((current) => ({
-              ...current,
-              response: updateSubthreadOrderInSnapshot(current.response, {
-                backend: result.backend,
-                parentThreadId: result.parentThreadId,
-                threadIds: result.threadIds,
-              }),
-            }));
-          })
-          .catch(() => {
-            void refresh(buildThreadIdentityKey(backend, rootThreadId));
+        try {
+          const result = await persistOrder({
+            backend,
+            parentThreadId: rootThreadId,
+            threadIds: nextOrder,
           });
+          setState((current) => ({
+            ...current,
+            response: updateSubthreadOrderInSnapshot(current.response, {
+              backend: result.backend,
+              parentThreadId: result.parentThreadId,
+              threadIds: result.threadIds,
+            }),
+          }));
+        } catch {
+          await refresh(buildThreadIdentityKey(backend, rootThreadId));
+        }
       }
 
       if (root?.subthreadsCollapsed) {
@@ -3466,8 +3468,9 @@ export function useThreadNavigation(
           parentThreadId: groupRoot.id,
         };
         const nextThreadKey = buildThreadIdentityKey(response.backend, response.threadId);
-        // Drop the fork directly below the card it was spawned from.
-        insertSubthreadBelowSource(
+        // Drop the fork directly below the card it was spawned from, and let
+        // the order write land before the refresh below reads it back.
+        await insertSubthreadBelowSource(
           response.backend,
           groupRoot.id,
           parent.id,
@@ -3891,9 +3894,10 @@ export function useThreadNavigation(
       });
       const nextThreadKey = buildThreadIdentityKey(response.backend, response.threadId);
       // Sub-thread launchpads drop the new child directly below their source
-      // card. Plain new-thread launchpads have no parent and skip this.
+      // card. Plain new-thread launchpads have no parent and skip this. Await
+      // so the order write commits before the refresh below reads it back.
       if (materializeParentThreadId) {
-        insertSubthreadBelowSource(
+        await insertSubthreadBelowSource(
           response.backend,
           materializeParentThreadId,
           launchpad.sourceThreadId ?? materializeParentThreadId,

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -25,7 +25,9 @@ import {
   buildThreadIdentityKey,
   comparePinnedThreads,
   compareThreadsByCreatedAtDesc,
+  insertSubthreadIdAfter,
   shortenDerivedThreadTitle,
+  sortSubthreadSummaries,
 } from "@pwragent/shared";
 import type { DesktopApi } from "./desktop-api";
 import {
@@ -1809,6 +1811,8 @@ export function useThreadNavigation(
   options: UseThreadNavigationOptions = {}
 ): {
   browseMode: BrowseMode;
+  /** Identity key of the card to highlight as the open composer's source. */
+  composerSourceThreadKey?: string;
   createThread: (
     backend?: AppServerBackendKind,
     executionMode?: ThreadExecutionMode,
@@ -1818,6 +1822,7 @@ export function useThreadNavigation(
     parent: NavigationThreadSummary,
     mode?: ThreadWorkspaceMode,
   ) => Promise<void>;
+  discardLaunchpad: (directoryKey: string) => void;
   forkThread: (
     parent: NavigationThreadSummary,
     mode: ThreadWorkspaceMode,
@@ -2038,9 +2043,11 @@ export function useThreadNavigation(
   const launchpadUpdateRevisionRef = useRef(new Map<string, number>());
   const pendingPickedLaunchpadRef = useRef(new Map<string, NavigationLaunchpadDraft>());
   const setNavigationBrowseModeRequestRef = useRef(setNavigationBrowseModeRequest);
+  const stateRef = useRef(state);
 
   optimisticThreadRef.current = optimisticThread;
   retainedUnreadThreadRef.current = retainedUnreadThread;
+  stateRef.current = state;
 
   useEffect(() => {
     setNavigationBrowseModeRequestRef.current = setNavigationBrowseModeRequest;
@@ -2935,6 +2942,17 @@ export function useThreadNavigation(
     });
     return target.directoryKind === "directory" ? target.directoryLabel : undefined;
   }, [directories, selectedDirectory, selectedThreadKey]);
+  // The thread card to render as the orange "composing" source while a
+  // sub-thread launchpad is open. Plain new-thread launchpads have no source.
+  const composerSourceThreadKey = useMemo(() => {
+    if (!selectedLaunchpad?.sourceThreadId || !selectedLaunchpad.backend) {
+      return undefined;
+    }
+    return buildThreadIdentityKey(
+      selectedLaunchpad.backend,
+      selectedLaunchpad.sourceThreadId,
+    );
+  }, [selectedLaunchpad]);
 
   useEffect(() => {
     releaseRetainedUnreadThread(selectedItemKey);
@@ -3189,6 +3207,112 @@ export function useThreadNavigation(
     [desktopApi, directories, refresh, selectedDirectory, selectedThreadKey]
   );
 
+  /**
+   * The "group root" for a source card. Sub-threads and forks never nest deeper
+   * than one level: spawning from a child re-parents the new thread to that
+   * child's root so it renders as a sibling, not an (unrenderable) grandchild.
+   * Falls back to the source itself when its root is gone (archived/unlinked),
+   * since the source has then become effectively top-level.
+   */
+  const resolveGroupRoot = useCallback(
+    (source: NavigationThreadSummary): NavigationThreadSummary => {
+      if (!source.parentThreadId) {
+        return source;
+      }
+      const root = stateRef.current.response?.threads.find(
+        (thread) =>
+          thread.source === source.source &&
+          thread.id === source.parentThreadId,
+      );
+      return root ?? source;
+    },
+    [],
+  );
+
+  /**
+   * Place a freshly created child directly below the card it was spawned from.
+   * Writes the full current child order into the root's `subthreadOrder` (so the
+   * tray behaves like a pinned tray — every child explicitly ranked, born in
+   * place and staying there) with `newThreadId` inserted after `sourceThreadId`,
+   * then expands the group if it was collapsed so the new child is visible.
+   */
+  const insertSubthreadBelowSource = useCallback(
+    (
+      backend: AppServerBackendKind,
+      rootThreadId: string,
+      sourceThreadId: string,
+      newThreadId: string,
+    ): void => {
+      const snapshot = stateRef.current.response;
+      if (!snapshot) {
+        return;
+      }
+      const root = snapshot.threads.find(
+        (thread) => thread.source === backend && thread.id === rootThreadId,
+      );
+      const currentChildIds = sortSubthreadSummaries(
+        root ?? { subthreadOrder: undefined },
+        snapshot.threads.filter(
+          (thread) =>
+            thread.source === backend &&
+            thread.parentThreadId === rootThreadId,
+        ),
+      ).map((child) => child.id);
+      const nextOrder = insertSubthreadIdAfter(
+        currentChildIds,
+        sourceThreadId,
+        newThreadId,
+      );
+
+      setState((current) => ({
+        ...current,
+        response: updateSubthreadOrderInSnapshot(current.response, {
+          backend,
+          parentThreadId: rootThreadId,
+          threadIds: nextOrder,
+        }),
+      }));
+      const persistOrder = desktopApi?.updateSubthreadOrder;
+      if (persistOrder) {
+        void persistOrder({
+          backend,
+          parentThreadId: rootThreadId,
+          threadIds: nextOrder,
+        })
+          .then((result) => {
+            setState((current) => ({
+              ...current,
+              response: updateSubthreadOrderInSnapshot(current.response, {
+                backend: result.backend,
+                parentThreadId: result.parentThreadId,
+                threadIds: result.threadIds,
+              }),
+            }));
+          })
+          .catch(() => {
+            void refresh(buildThreadIdentityKey(backend, rootThreadId));
+          });
+      }
+
+      if (root?.subthreadsCollapsed) {
+        setState((current) => ({
+          ...current,
+          response: updateSubthreadsCollapsedInSnapshot(current.response, {
+            backend,
+            parentThreadId: rootThreadId,
+            collapsed: false,
+          }),
+        }));
+        void desktopApi?.setSubthreadsCollapsed?.({
+          backend,
+          parentThreadId: rootThreadId,
+          collapsed: false,
+        }).catch(() => {});
+      }
+    },
+    [desktopApi, refresh],
+  );
+
   const createSubthread = useCallback(
     async (
       parent: NavigationThreadSummary,
@@ -3200,7 +3324,11 @@ export function useThreadNavigation(
       }
 
       const directory = selectThreadWorkspace(parent, mode);
+      // Key the launchpad on the clicked card so each source gets its own
+      // composer (two children of one root must not collide), but link the new
+      // thread to the group root and remember the source for in-place insertion.
       const directoryKey = buildSubthreadLaunchpadKey(parent, mode);
+      const groupRoot = resolveGroupRoot(parent);
       setCreatingThread({
         backend: parent.source,
         executionMode: parent.executionMode ?? "default",
@@ -3216,14 +3344,15 @@ export function useThreadNavigation(
           directoryKind: directory.directoryKind,
           directoryLabel: directory.directoryLabel,
           directoryPath: directory.directoryPath,
-          parentThreadId: parent.id,
-          parentThreadTitle: parent.title,
+          parentThreadId: groupRoot.id,
+          parentThreadTitle: groupRoot.title,
           preferredBackend: parent.source,
         });
         let launchpad: NavigationLaunchpadDraft = {
           ...response.launchpad,
-          parentThreadId: parent.id,
-          parentThreadTitle: parent.title,
+          parentThreadId: groupRoot.id,
+          parentThreadTitle: groupRoot.title,
+          sourceThreadId: parent.id,
         };
         let defaults: NavigationLaunchpadDefaults = response.defaults;
         const patch: Parameters<NonNullable<DesktopApi["updateDirectoryLaunchpad"]>>[0]["patch"] = {
@@ -3233,8 +3362,8 @@ export function useThreadNavigation(
           directoryLabel: directory.directoryLabel,
           directoryPath: directory.directoryPath,
           ...(directory.branchName ? { branchName: directory.branchName } : {}),
-          parentThreadId: parent.id,
-          parentThreadTitle: parent.title,
+          parentThreadId: groupRoot.id,
+          parentThreadTitle: groupRoot.title,
         };
         if (desktopApi.updateDirectoryLaunchpad) {
           const updated = await desktopApi.updateDirectoryLaunchpad({
@@ -3243,8 +3372,9 @@ export function useThreadNavigation(
           });
           launchpad = {
             ...updated.launchpad,
-            parentThreadId: parent.id,
-            parentThreadTitle: parent.title,
+            parentThreadId: groupRoot.id,
+            parentThreadTitle: groupRoot.title,
+            sourceThreadId: parent.id,
           };
           defaults = updated.defaults;
         }
@@ -3263,7 +3393,7 @@ export function useThreadNavigation(
         setCreatingThread(undefined);
       }
     },
-    [desktopApi],
+    [desktopApi, resolveGroupRoot],
   );
 
   const forkThread = useCallback(
@@ -3277,6 +3407,7 @@ export function useThreadNavigation(
       }
 
       const directory = selectThreadWorkspace(parent, mode);
+      const groupRoot = resolveGroupRoot(parent);
       const executionMode = parent.executionMode ?? "default";
       setCreatingThread({
         backend: parent.source,
@@ -3291,7 +3422,7 @@ export function useThreadNavigation(
         const response = await forkThreadRequest({
           backend: parent.source,
           sourceThreadId: parent.id,
-          parentThreadId: parent.id,
+          parentThreadId: groupRoot.id,
           executionMode,
           directoryKind: directory.directoryKind,
           directoryLabel: directory.directoryLabel,
@@ -3332,9 +3463,16 @@ export function useThreadNavigation(
           observedGitBranch: parent.observedGitBranch,
           codexEnvironmentRuntime: response.codexEnvironmentRuntime,
           linkedDirectories,
-          parentThreadId: parent.id,
+          parentThreadId: groupRoot.id,
         };
         const nextThreadKey = buildThreadIdentityKey(response.backend, response.threadId);
+        // Drop the fork directly below the card it was spawned from.
+        insertSubthreadBelowSource(
+          response.backend,
+          groupRoot.id,
+          parent.id,
+          response.threadId,
+        );
         setOptimisticThread(optimisticFork);
         setSelectedItemKey(nextThreadKey);
         setPendingSeenThreadKey(nextThreadKey);
@@ -3345,7 +3483,7 @@ export function useThreadNavigation(
         setCreatingThread(undefined);
       }
     },
-    [forkThreadRequest, refresh],
+    [forkThreadRequest, insertSubthreadBelowSource, refresh, resolveGroupRoot],
   );
 
   const openDirectoryLaunchpad = useCallback(
@@ -3701,8 +3839,13 @@ export function useThreadNavigation(
 
       setLaunchpadError(undefined);
 
+      // The draft carries the group root (sub-threading a child re-parents to
+      // the root); prefer it over the key-parsed source so the new thread links
+      // to the root and renders one level deep.
       const materializeParentThreadId =
-        parentThreadId ?? getParentThreadIdFromSubthreadLaunchpadKey(directoryKey);
+        parentThreadId ??
+        launchpad.parentThreadId ??
+        getParentThreadIdFromSubthreadLaunchpadKey(directoryKey);
       let response: Awaited<ReturnType<NonNullable<DesktopApi["materializeDirectoryLaunchpad"]>>>;
       try {
         response = await desktopApi.materializeDirectoryLaunchpad({
@@ -3747,6 +3890,16 @@ export function useThreadNavigation(
         parentThreadId: materializeParentThreadId,
       });
       const nextThreadKey = buildThreadIdentityKey(response.backend, response.threadId);
+      // Sub-thread launchpads drop the new child directly below their source
+      // card. Plain new-thread launchpads have no parent and skip this.
+      if (materializeParentThreadId) {
+        insertSubthreadBelowSource(
+          response.backend,
+          materializeParentThreadId,
+          launchpad.sourceThreadId ?? materializeParentThreadId,
+          response.threadId,
+        );
+      }
       setLocalLaunchpads((current) => {
         if (!current[directoryKey]) {
           return current;
@@ -3777,8 +3930,46 @@ export function useThreadNavigation(
         setLaunchpadError(error instanceof Error ? error.message : String(error));
       }
     },
-    [desktopApi, directories, refresh]
+    [desktopApi, directories, insertSubthreadBelowSource, refresh]
   );
+
+  /**
+   * Cancel an open launchpad composer (the "Cancel" button next to "Start
+   * thread"). Drops the draft and, for a sub-thread composer, returns the
+   * selection to the source card the user invoked it from.
+   */
+  const discardLaunchpad = useCallback((directoryKey: string): void => {
+    const launchpad = stateRef.current.response?.directories.find(
+      (candidate) => candidate.key === directoryKey,
+    )?.launchpad;
+    const sourceThreadId = launchpad?.sourceThreadId;
+    const sourceBackend = launchpad?.backend;
+
+    setLocalLaunchpads((current) => {
+      if (!current[directoryKey]) {
+        return current;
+      }
+      const next = { ...current };
+      delete next[directoryKey];
+      return next;
+    });
+    setState((current) => ({
+      ...current,
+      response: current.response
+        ? applyLaunchpadReset(
+            current.response,
+            directoryKey,
+            current.response.launchpadDefaults,
+          )
+        : current.response,
+    }));
+
+    setSelectedItemKey(
+      sourceThreadId && sourceBackend
+        ? buildThreadIdentityKey(sourceBackend, sourceThreadId)
+        : undefined,
+    );
+  }, []);
 
   const archiveThread = useCallback(
     async (
@@ -4597,8 +4788,10 @@ export function useThreadNavigation(
 
   return {
     browseMode,
+    composerSourceThreadKey,
     createThread,
     createSubthread,
+    discardLaunchpad,
     forkThread,
     createThreadError,
     creatingThread,

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2592,6 +2592,18 @@ textarea,
   box-shadow: none;
 }
 
+/* The thinking sweep is an accent-on-accent gradient — invisible on the solid
+   accent fill. Recolor it to the on-accent token so a source card that's still
+   working stays legible. */
+.thread-row.is-composer-source .thinking-scanner__beam {
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--accent-on) 18%, transparent) 0%,
+    color-mix(in srgb, var(--accent-on) 95%, transparent) 48%,
+    color-mix(in srgb, var(--accent-on) 18%, transparent) 100%
+  );
+}
+
 .thread-row.thread-row--drag-image {
   position: fixed;
   top: 0;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -27,6 +27,10 @@
   --accent: #ff8a1f;
   --accent-strong: #ffa33d;
   --accent-bright: #ffb35c;
+  /* Foreground for content sitting on a solid `--accent` fill (the orange
+     "composing source" thread row). Near-black on the bright dark-theme
+     accent for a strong AA-passing contrast. */
+  --accent-on: #160a00;
   --accent-soft: color-mix(in srgb, var(--accent) 12%, transparent);
   --accent-border: color-mix(in srgb, var(--accent) 42%, transparent);
   --accent-shadow: color-mix(in srgb, var(--accent) 34%, transparent);
@@ -210,6 +214,8 @@
   --accent: #c45200;
   --accent-strong: #b34a00;
   --accent-bright: #d96d00;
+  /* Light foreground on the darker light-theme accent fill. */
+  --accent-on: #ffffff;
   --focus-ring: var(--accent);
 
   /* Semantic — darker bases for contrast. */
@@ -2555,6 +2561,35 @@ textarea,
 .thread-row.is-selected {
   border-color: var(--accent-border);
   background: var(--bg-row-active);
+}
+
+/* The thread card a sub-thread / new-thread composer is being created from.
+   Filled solid accent while the composer is open so the source is unmistakable;
+   foreground flips to the on-accent token and meta chips invert to readable
+   pills. Declared after `.thread-row:hover` (equal specificity) so the fill
+   survives hover. Clears automatically when the composer materializes, is
+   cancelled, or the user navigates away. */
+.thread-row.is-composer-source {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: var(--accent-on);
+}
+
+.thread-row.is-composer-source .thread-row__time,
+.thread-row.is-composer-source .thread-row__summary {
+  color: var(--accent-on);
+}
+
+.thread-row.is-composer-source .thread-row__chip {
+  border-color: transparent;
+  background: var(--accent-on);
+  color: var(--accent);
+}
+
+.thread-row.is-composer-source .thread-row__status-cookie {
+  border-color: var(--accent-on);
+  background: var(--accent-on);
+  box-shadow: none;
 }
 
 .thread-row.thread-row--drag-image {

--- a/packages/shared/src/__tests__/subthreads.test.ts
+++ b/packages/shared/src/__tests__/subthreads.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  insertSubthreadIdAfter,
+  sortSubthreadSummaries,
+} from "../subthreads";
+
+describe("sortSubthreadSummaries", () => {
+  it("orders explicitly-ranked children by subthreadOrder", () => {
+    const sorted = sortSubthreadSummaries(
+      { subthreadOrder: ["c", "a", "b"] },
+      [
+        { id: "a", createdAt: 1 },
+        { id: "b", createdAt: 2 },
+        { id: "c", createdAt: 3 },
+      ],
+    );
+    expect(sorted.map((child) => child.id)).toEqual(["c", "a", "b"]);
+  });
+
+  it("falls back to newest-first by createdAt when unranked", () => {
+    const sorted = sortSubthreadSummaries({ subthreadOrder: undefined }, [
+      { id: "old", createdAt: 1 },
+      { id: "new", createdAt: 3 },
+      { id: "mid", createdAt: 2 },
+    ]);
+    expect(sorted.map((child) => child.id)).toEqual(["new", "mid", "old"]);
+  });
+
+  it("sorts ranked children ahead of unranked ones", () => {
+    const sorted = sortSubthreadSummaries({ subthreadOrder: ["ranked"] }, [
+      { id: "unranked-new", createdAt: 100 },
+      { id: "ranked", createdAt: 1 },
+    ]);
+    expect(sorted.map((child) => child.id)).toEqual(["ranked", "unranked-new"]);
+  });
+});
+
+describe("insertSubthreadIdAfter", () => {
+  it("inserts immediately after the source child", () => {
+    expect(insertSubthreadIdAfter(["a", "b", "c"], "b", "new")).toEqual([
+      "a",
+      "b",
+      "new",
+      "c",
+    ]);
+  });
+
+  it("prepends when the source is the root (not in the child list)", () => {
+    expect(insertSubthreadIdAfter(["a", "b"], "root", "new")).toEqual([
+      "new",
+      "a",
+      "b",
+    ]);
+  });
+
+  it("prepends into an empty tray", () => {
+    expect(insertSubthreadIdAfter([], "root", "new")).toEqual(["new"]);
+  });
+
+  it("is idempotent when the new id already exists", () => {
+    expect(insertSubthreadIdAfter(["a", "new", "b"], "a", "new")).toEqual([
+      "a",
+      "new",
+      "b",
+    ]);
+  });
+});

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -410,6 +410,14 @@ export type NavigationLaunchpadDraft = NavigationLaunchpadDefaults & {
   branchName?: string;
   parentThreadId?: string;
   parentThreadTitle?: string;
+  /**
+   * The thread card this launchpad was spawned from. May differ from
+   * `parentThreadId`: forking/sub-threading a child re-parents the new thread to
+   * the group root (`parentThreadId`), but the new thread is inserted directly
+   * below this source card and the source card renders as the orange "composing"
+   * highlight. Undefined for the plain directory new-thread launchpad.
+   */
+  sourceThreadId?: string;
   codexEnvironmentId?: string;
   codexEnvironmentExecutionTarget?: CodexEnvironmentExecutionTarget;
   /**

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -23,6 +23,7 @@ export * from "./profile-names";
 export * from "./directory-pins";
 export * from "./pending-request-response";
 export * from "./renderer-payload-boundary";
+export * from "./subthreads";
 export * from "./thread-pins";
 export * from "./thread-titles";
 export * from "./worktree-paths";

--- a/packages/shared/src/subthreads.ts
+++ b/packages/shared/src/subthreads.ts
@@ -1,0 +1,55 @@
+import type { NavigationThreadSummary } from "./contracts/navigation";
+
+type SubthreadParent = Pick<NavigationThreadSummary, "subthreadOrder">;
+type SubthreadChild = Pick<NavigationThreadSummary, "id" | "createdAt">;
+
+/**
+ * Order a parent's child threads for display. Children explicitly listed in the
+ * parent's `subthreadOrder` come first, in that order; any remaining children
+ * fall back to newest-first by `createdAt`. This is the single source of truth
+ * shared by the sidebar list views and the navigation hook so the "born here,
+ * stays here" tray order stays consistent.
+ */
+export function sortSubthreadSummaries<T extends SubthreadChild>(
+  parent: SubthreadParent,
+  children: T[],
+): T[] {
+  const order = new Map(
+    (parent.subthreadOrder ?? []).map((threadId, index) => [threadId, index]),
+  );
+  return [...children].sort((left, right) => {
+    const leftRank = order.get(left.id);
+    const rightRank = order.get(right.id);
+    if (leftRank !== undefined || rightRank !== undefined) {
+      return (
+        (leftRank ?? Number.MAX_SAFE_INTEGER) -
+        (rightRank ?? Number.MAX_SAFE_INTEGER)
+      );
+    }
+    return (right.createdAt ?? 0) - (left.createdAt ?? 0);
+  });
+}
+
+/**
+ * Return a new child-id order with `newId` placed immediately after `sourceId`.
+ * When `sourceId` is not in the list — i.e. the source card is the group root
+ * rather than a sibling child — `newId` is prepended so the new child lands at
+ * the top of the tray, directly below the root card. Any pre-existing instance
+ * of `newId` is removed first so repeated inserts stay idempotent.
+ */
+export function insertSubthreadIdAfter(
+  orderedChildIds: string[],
+  sourceId: string,
+  newId: string,
+): string[] {
+  const withoutNew = orderedChildIds.filter((id) => id !== newId);
+  const sourceIndex = withoutNew.indexOf(sourceId);
+  if (sourceIndex === -1) {
+    return [newId, ...withoutNew];
+  }
+  return [
+    ...withoutNew.slice(0, sourceIndex + 1),
+    newId,
+    ...withoutNew.slice(sourceIndex + 1),
+  ];
+}


### PR DESCRIPTION
## What

Lets you fork or sub-thread a **child** card (not just a top-level thread). The new thread is created **directly below the source card**, never indented further, and child threads behave like a pinned tray (explicit order, drag-reorderable, born-in-place).

## Why

Sub-thread and fork were gated off child cards behind `!contextMenuIsSubthread` — and for a real reason. The sidebar renders **exactly one nesting level**: `renderSubthreads` runs only on top-level threads and doesn't recurse, so a "grandchild" (a thread whose parent is itself a child) lands in `childrenByParentKey` but is **never rendered** — it silently disappears.

Rather than teach the renderer arbitrary-depth flattening, this **flattens to the group root**: spawning a sub-thread/fork from any card — root or child — re-parents the new thread to the group root as a *sibling* (one level deep), inserted directly below whichever card was invoked. The clicked card stays the visual "source".

## Changes

- **`packages/shared`** — extract the duplicated child-sort into `sortSubthreadSummaries`; add `insertSubthreadIdAfter` (insert after source; prepend when the source *is* the root). Add `sourceThreadId` to `NavigationLaunchpadDraft`.
- **`useThreadNavigation`** — `resolveGroupRoot` + `insertSubthreadBelowSource` write the **full** current child order into `subthreadOrder` (a true "born-here, stays-here" tray, not the createdAt fallback) and auto-expand a collapsed group. Used by both `forkThread` (instant) and `materializeDirectoryLaunchpad` (sub-thread). Adds `discardLaunchpad` (Cancel) and `composerSourceThreadKey` (highlight).
- **`Sidebar`** — child cards now offer Sub-thread/Fork; Pin and Move stay root-only (children reorder by drag).
- **`Composer`** — a ghost **Cancel** button left of **Start thread** for the sub-thread / new-thread flows (fork is instant, no composer). Wired through `ThreadView` → `App` to `discardLaunchpad`, which returns selection to the source card.
- **Source card highlight** — the source card fills solid `--accent` while its composer is open. New `--accent-on` token (per theme) recolors the row foreground and inverts meta chips to readable pills (≈8:1 dark, AA on light).

## Reviewer notes

- **Fork stays instant** (no composer ⇒ no Cancel / orange source for fork), but it still inserts below its source.
- **No deeper nesting** — grandchildren can no longer be created at all; the data-parent of any spawned thread is always the top-level root.
- The sub-thread launchpad key stays keyed by the *clicked* card (per-source uniqueness so two children of one root don't collide); the **root** linkage rides on the draft (`parentThreadId`) and `materializeDirectoryLaunchpad` prefers it over the key-parsed value.

## Verification

- `pnpm typecheck` (all packages), `pnpm lint` (boundaries / colors / sql / codex-storage / licenses), `pnpm --filter @pwragent/desktop build` — all green.
- Unit tests: new `subthreads.test.ts` (helpers), new child-card Sub-thread/Fork case in `sidebar.test.tsx`, plus existing nav / composer / thread-view / theme-contract suites.
- Not yet run live: visual pass (orange highlight, in-place insertion, Cancel) and desktop e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)