### PR TITLE
fix(desktop): polish and integrate the thread search panel

### DIFF
--- a/apps/desktop/e2e/a11y.spec.ts
+++ b/apps/desktop/e2e/a11y.spec.ts
@@ -139,6 +139,28 @@ test.describe("desktop renderer accessibility (WCAG2 AA)", () => {
     }
   });
 
+  test("thread search has no violations", async () => {
+    const app = await launchElectronApp({
+      fixturePath: path.resolve(specDir, "fixtures/smoke/replay.fixture.json"),
+    });
+    try {
+      await expect(
+        app.window.getByRole("button", { name: /Replay smoke thread/i }).first(),
+      ).toBeVisible();
+      // Open Search from the sidebar masthead. Before it opens, "Search
+      // threads" is unambiguously the masthead button; the autofocused
+      // search field (same accessible name, but role=textbox) is the
+      // stable signal that the search view has mounted.
+      await app.window.getByRole("button", { name: "Search threads" }).click();
+      await expect(
+        app.window.getByRole("textbox", { name: "Search threads" }),
+      ).toBeVisible();
+      await runAxe(app.window);
+    } finally {
+      await app.close();
+    }
+  });
+
   test("settings → messaging has no violations", async () => {
     const app = await launchElectronApp({
       fixturePath: path.resolve(specDir, "fixtures/smoke/replay.fixture.json"),

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -467,6 +467,7 @@ function DesktopAppShell(props: {
   const mastheadActions = {
     automationsActive: mainView === "automations",
     settingsActive: mainView === "settings",
+    threadSearchActive: mainView === "search",
     creatingThread: Boolean(navigation.creatingThread),
     onOpenAutomations: () => {
       setMainView("automations");
@@ -474,6 +475,9 @@ function DesktopAppShell(props: {
     onOpenSettings: () => {
       setSettingsInitialSection(undefined);
       setMainView("settings");
+    },
+    onToggleThreadSearch: () => {
+      setMainView(mainView === "search" ? "thread" : "search");
     },
     onCreateThread: async () => {
       setMainView("thread");
@@ -697,7 +701,7 @@ function DesktopAppShell(props: {
             setMainView("automations");
           }}
           onOpenThreadSearch={() => {
-            setMainView("search");
+            setMainView(mainView === "search" ? "thread" : "search");
           }}
           onOpenLaunchpad={async (directory, preferredBackend) => {
             setMainView("thread");
@@ -743,7 +747,14 @@ function DesktopAppShell(props: {
           {mainView === "search" ? (
             <ThreadSearchPanel
               desktopApi={desktopApi}
-              onClose={() => setMainView("thread")}
+              onOpenMessagingActivity={openMessagingActivityWindow}
+              layout={{
+                sidebarOpen: !sidebarHidden,
+                railOpen: contextRailPinned,
+                onToggleSidebar: () => setSidebarHiddenPersisted(!sidebarHidden),
+                onToggleRail: () => setContextRailPinnedPersisted(!contextRailPinned),
+              }}
+              masthead={mastheadActions}
               onOpenResult={async (result) => {
                 setMainView("thread");
                 await navigation.showThread(result);

--- a/apps/desktop/src/renderer/src/features/chrome/MastheadActions.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/MastheadActions.tsx
@@ -1,25 +1,38 @@
 import type { ReactElement } from "react";
-import { AutomationsIcon, NewThreadIcon, SettingsIcon } from "../../icons";
+import { AutomationsIcon, NewThreadIcon, SearchIcon, SettingsIcon } from "../../icons";
 
 /**
- * The window-level action buttons (Automations / Settings / New Thread)
- * that live in the sidebar masthead. Extracted so they can also render in
- * the thread header when the sidebar is hidden — the buttons otherwise
- * vanish with the sidebar. Reuses the `.sidebar__icon-button` styling so
- * every placement reads identically.
+ * The window-level action buttons (Search / Automations / Settings / New
+ * Thread) that live in the sidebar masthead. Extracted so they can also
+ * render in the thread header when the sidebar is hidden — the buttons
+ * otherwise vanish with the sidebar. Reuses the `.sidebar__icon-button`
+ * styling so every placement reads identically.
  */
 export type MastheadActionsProps = {
   automationsActive?: boolean;
   settingsActive?: boolean;
+  threadSearchActive?: boolean;
   creatingThread?: boolean;
   onOpenAutomations?: () => void;
   onOpenSettings?: () => void;
+  onToggleThreadSearch?: () => void;
   onCreateThread?: () => void | Promise<void>;
 };
 
 export function MastheadActions(props: MastheadActionsProps): ReactElement {
   return (
     <div className="masthead-actions">
+      {props.onToggleThreadSearch ? (
+        <button
+          type="button"
+          aria-label="Search threads"
+          aria-pressed={props.threadSearchActive}
+          className={`sidebar__icon-button${props.threadSearchActive ? " is-active" : ""}`}
+          onClick={props.onToggleThreadSearch}
+        >
+          <SearchIcon size={16} strokeWidth={1.5} aria-hidden="true" />
+        </button>
+      ) : null}
       <button
         type="button"
         aria-label="Open automations"

--- a/apps/desktop/src/renderer/src/features/chrome/PanelToggleButtons.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/PanelToggleButtons.tsx
@@ -89,7 +89,9 @@ function LayoutChip({
       aria-label={label}
       aria-pressed={disabled ? undefined : open}
       disabled={disabled}
-      title={disabled ? label : `${label}  (${chord})`}
+      // No title when disabled: `pointer-events: none` makes a native
+      // tooltip unreachable anyway; the aria-label still names it for AT.
+      title={disabled ? undefined : `${label}  (${chord})`}
       onClick={disabled ? undefined : onClick}
     >
       <LayoutGlyph kind={kind} open={open} />

--- a/apps/desktop/src/renderer/src/features/chrome/PanelToggleButtons.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/PanelToggleButtons.tsx
@@ -24,6 +24,12 @@ export type PanelToggleButtonsProps = {
   railOpen: boolean;
   onToggleSidebar: () => void;
   onToggleRail: () => void;
+  /**
+   * Render the rail (secondary) chip greyed-out and non-interactive — for
+   * views that have no context rail (e.g. thread search). The chip stays in
+   * place so the chrome doesn't shift; it just reads as "not applicable here."
+   */
+  railToggleDisabled?: boolean;
   className?: string;
 };
 
@@ -32,6 +38,7 @@ export function PanelToggleButtons({
   railOpen,
   onToggleSidebar,
   onToggleRail,
+  railToggleDisabled,
   className,
 }: PanelToggleButtonsProps): ReactElement {
   return (
@@ -41,7 +48,12 @@ export function PanelToggleButtons({
       aria-label="Window layout"
     >
       <LayoutChip kind="primary" open={sidebarOpen} onClick={onToggleSidebar} />
-      <LayoutChip kind="secondary" open={railOpen} onClick={onToggleRail} />
+      <LayoutChip
+        kind="secondary"
+        open={railOpen}
+        onClick={onToggleRail}
+        disabled={railToggleDisabled}
+      />
     </div>
   );
 }
@@ -50,13 +62,16 @@ function LayoutChip({
   kind,
   open,
   onClick,
+  disabled = false,
 }: {
   kind: "primary" | "secondary";
   open: boolean;
   onClick: () => void;
+  disabled?: boolean;
 }): ReactElement {
-  const label =
-    kind === "primary"
+  const label = disabled
+    ? "No context rail in this view"
+    : kind === "primary"
       ? open
         ? "Hide sidebar"
         : "Show sidebar"
@@ -72,9 +87,10 @@ function LayoutChip({
       type="button"
       className={`panel-toggle__chip is-${kind} ${open ? "is-open" : "is-closed"}`}
       aria-label={label}
-      aria-pressed={open}
-      title={`${label}  (${chord})`}
-      onClick={onClick}
+      aria-pressed={disabled ? undefined : open}
+      disabled={disabled}
+      title={disabled ? label : `${label}  (${chord})`}
+      onClick={disabled ? undefined : onClick}
     >
       <LayoutGlyph kind={kind} open={open} />
     </button>

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadPlaceholderHeader.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadPlaceholderHeader.tsx
@@ -9,6 +9,8 @@ type ThreadPlaceholderLayoutControls = {
   railOpen: boolean;
   onToggleSidebar: () => void;
   onToggleRail: () => void;
+  /** Grey out the rail toggle for views with no context rail (search). */
+  railToggleDisabled?: boolean;
 };
 
 type ThreadPlaceholderHeaderProps = {
@@ -62,6 +64,7 @@ export function ThreadPlaceholderHeader(props: ThreadPlaceholderHeaderProps) {
               railOpen={props.layout.railOpen}
               onToggleSidebar={props.layout.onToggleSidebar}
               onToggleRail={props.layout.onToggleRail}
+              railToggleDisabled={props.layout.railToggleDisabled}
             />
           ) : null}
           <MessagingStatusBar

--- a/apps/desktop/src/renderer/src/features/thread-search/ThreadSearchPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-search/ThreadSearchPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, type FormEvent, type ReactNode } from "react";
+import { useState, type FormEvent, type ReactElement, type ReactNode } from "react";
 import type {
   AppServerBackendKind,
   MessagingChannelKind,
@@ -59,7 +59,7 @@ function describeMatchReason(kind: ThreadSearchMatchReasonKind | undefined): str
   return MATCH_REASON_LABELS[kind] ?? kind.replaceAll("_", " ");
 }
 
-function basename(value: string): string {
+export function basename(value: string): string {
   const trimmed = value.replace(/[\\/]+$/, "");
   const cut = Math.max(trimmed.lastIndexOf("/"), trimmed.lastIndexOf("\\"));
   return cut >= 0 ? trimmed.slice(cut + 1) : trimmed;
@@ -70,7 +70,7 @@ function basename(value: string): string {
  * reads as a tangerine highlight instead of a flat gray run. React owns the
  * escaping; we only split on literal, regex-escaped tokens.
  */
-function highlightSnippet(text: string, query: string): ReactNode[] {
+export function highlightSnippet(text: string, query: string): ReactNode[] {
   const tokens = Array.from(
     new Set(
       query
@@ -85,28 +85,32 @@ function highlightSnippet(text: string, query: string): ReactNode[] {
   const escaped = tokens.map((token) => token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
   const splitter = new RegExp(`(${escaped.join("|")})`, "ig");
   const tokenSet = new Set(tokens);
-  return text.split(splitter).map((part, index) =>
-    part && tokenSet.has(part.toLowerCase()) ? (
-      <mark key={index} className="thread-search-result__mark">
-        {part}
-      </mark>
-    ) : (
-      <span key={index}>{part}</span>
-    ),
-  );
+  return text
+    .split(splitter)
+    .filter((part) => part.length > 0)
+    .map((part, index) =>
+      tokenSet.has(part.toLowerCase()) ? (
+        <mark key={index} className="thread-search-result__mark">
+          {part}
+        </mark>
+      ) : (
+        <span key={index}>{part}</span>
+      ),
+    );
 }
 
 function ThreadSearchResultRow(props: {
   result: ThreadSearchResult;
   query: string;
   onOpen: () => void;
-}): ReactNode {
+}): ReactElement {
   const { result, query } = props;
   const directory = result.linkedDirectories[0];
   // `projectKey` is often a full checkout/worktree path (Codex keys projects by
   // cwd), so collapse whatever we resolve down to its final path segment — the
-  // repo folder — and let the branch carry the distinguishing detail.
-  const rawWorkspace = result.projectKey ?? directory?.label ?? directory?.path;
+  // repo folder — and let the branch carry the distinguishing detail. `||`
+  // (not `??`) so an empty-string projectKey falls through to the directory.
+  const rawWorkspace = result.projectKey || directory?.label || directory?.path;
   const workspaceLabel = rawWorkspace ? basename(rawWorkspace) : undefined;
   const WorkspaceIcon = directory?.kind === "worktree" ? WorktreeIcon : FolderIcon;
   const titleNormalized = result.title.trim().toLowerCase();
@@ -160,7 +164,7 @@ function ThreadSearchResultRow(props: {
 function ThreadSearchEmptyState(props: {
   title: string;
   hint: string;
-}): ReactNode {
+}): ReactElement {
   return (
     <div className="thread-search-empty">
       <span className="thread-search-empty__glyph" aria-hidden>
@@ -218,9 +222,9 @@ export function ThreadSearchPanel(props: ThreadSearchPanelProps) {
       />
 
       <div className="thread-search__body">
-        <form className="thread-search-view__form" onSubmit={(event) => void submit(event)}>
-          <div className="thread-search-view__field">
-            <span className="thread-search-view__field-icon" aria-hidden>
+        <form className="thread-search__form" onSubmit={(event) => void submit(event)}>
+          <div className="thread-search__field">
+            <span className="thread-search__field-icon" aria-hidden>
               <SearchIcon size={16} />
             </span>
             <input
@@ -232,7 +236,7 @@ export function ThreadSearchPanel(props: ThreadSearchPanelProps) {
             />
           </div>
           <button
-            className="button button--primary thread-search-view__submit"
+            className="button button--primary thread-search__submit"
             disabled={loading || !query.trim() || searchUnavailable}
             type="submit"
           >
@@ -241,10 +245,10 @@ export function ThreadSearchPanel(props: ThreadSearchPanelProps) {
           </button>
         </form>
 
-        {error ? <p className="thread-search-view__error">{error}</p> : null}
+        {error ? <p className="thread-search__error">{error}</p> : null}
 
         {response?.unavailableScopes.length ? (
-          <div className="thread-search-view__scopes" aria-label="Unavailable scopes">
+          <div className="thread-search__scopes" aria-label="Unavailable scopes">
             {response.unavailableScopes.map((scope, index) => (
               <span key={`${scope.scope}:${scope.backend ?? "all"}:${index}`}>
                 {scope.backend ? `${scope.backend} ` : ""}

--- a/apps/desktop/src/renderer/src/features/thread-search/ThreadSearchPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-search/ThreadSearchPanel.tsx
@@ -1,22 +1,184 @@
-import { useState, type FormEvent } from "react";
-import type { AppServerBackendKind, ThreadSearchResponse } from "@pwragent/shared";
+import { useState, type FormEvent, type ReactNode } from "react";
+import type {
+  AppServerBackendKind,
+  MessagingChannelKind,
+  ThreadSearchConfidenceBand,
+  ThreadSearchMatchReasonKind,
+  ThreadSearchResponse,
+  ThreadSearchResult,
+} from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
-import { SearchIcon } from "../../icons";
+import type { MastheadActionsProps } from "../chrome/MastheadActions";
+import { ThreadPlaceholderHeader } from "../thread-detail/ThreadPlaceholderHeader";
+import { BranchIcon, FolderIcon, SearchIcon, WorktreeIcon } from "../../icons";
 
 type ThreadSearchPanelProps = {
   desktopApi?: DesktopApi;
-  onClose: () => void;
   onOpenResult: (result: {
     backend: AppServerBackendKind;
     threadId: string;
   }) => Promise<void> | void;
+  onOpenMessagingActivity?: (platform?: MessagingChannelKind) => void;
+  /**
+   * Window panel toggles + relocated masthead, threaded straight through to
+   * the shared {@link ThreadPlaceholderHeader} so search wears the same title
+   * bar as the thread view — the MSG status, the sidebar toggle, and the
+   * (disabled) rail toggle stay put instead of vanishing behind a bespoke
+   * header. Optional so the component still renders bare in unit tests.
+   */
+  layout?: {
+    sidebarOpen: boolean;
+    railOpen: boolean;
+    onToggleSidebar: () => void;
+    onToggleRail: () => void;
+  };
+  masthead?: MastheadActionsProps;
 };
+
+const MATCH_REASON_LABELS: Record<ThreadSearchMatchReasonKind, string> = {
+  exact_title: "Exact title",
+  title_token_overlap: "Title match",
+  summary_match: "Summary match",
+  project_match: "Project match",
+  directory_match: "Directory match",
+  path_match: "Path match",
+  branch_match: "Branch match",
+  backend_match: "Backend match",
+  model_match: "Model match",
+  time_filter: "Recent",
+  archive_filter: "Archived",
+  provider_content_match: "Message content",
+  semantic_match: "Semantic match",
+  recent_activity: "Recent activity",
+};
+
+function describeMatchReason(kind: ThreadSearchMatchReasonKind | undefined): string {
+  if (!kind) {
+    return "Match";
+  }
+  return MATCH_REASON_LABELS[kind] ?? kind.replaceAll("_", " ");
+}
+
+function basename(value: string): string {
+  const trimmed = value.replace(/[\\/]+$/, "");
+  const cut = Math.max(trimmed.lastIndexOf("/"), trimmed.lastIndexOf("\\"));
+  return cut >= 0 ? trimmed.slice(cut + 1) : trimmed;
+}
+
+/**
+ * Wrap each query token where it appears in a snippet so the matched text
+ * reads as a tangerine highlight instead of a flat gray run. React owns the
+ * escaping; we only split on literal, regex-escaped tokens.
+ */
+function highlightSnippet(text: string, query: string): ReactNode[] {
+  const tokens = Array.from(
+    new Set(
+      query
+        .toLowerCase()
+        .split(/\s+/)
+        .filter((token) => token.length >= 2),
+    ),
+  ).sort((a, b) => b.length - a.length);
+  if (tokens.length === 0) {
+    return [text];
+  }
+  const escaped = tokens.map((token) => token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+  const splitter = new RegExp(`(${escaped.join("|")})`, "ig");
+  const tokenSet = new Set(tokens);
+  return text.split(splitter).map((part, index) =>
+    part && tokenSet.has(part.toLowerCase()) ? (
+      <mark key={index} className="thread-search-result__mark">
+        {part}
+      </mark>
+    ) : (
+      <span key={index}>{part}</span>
+    ),
+  );
+}
+
+function ThreadSearchResultRow(props: {
+  result: ThreadSearchResult;
+  query: string;
+  onOpen: () => void;
+}): ReactNode {
+  const { result, query } = props;
+  const directory = result.linkedDirectories[0];
+  // `projectKey` is often a full checkout/worktree path (Codex keys projects by
+  // cwd), so collapse whatever we resolve down to its final path segment — the
+  // repo folder — and let the branch carry the distinguishing detail.
+  const rawWorkspace = result.projectKey ?? directory?.label ?? directory?.path;
+  const workspaceLabel = rawWorkspace ? basename(rawWorkspace) : undefined;
+  const WorkspaceIcon = directory?.kind === "worktree" ? WorktreeIcon : FolderIcon;
+  const titleNormalized = result.title.trim().toLowerCase();
+  const snippet = result.snippets.find(
+    (entry) => entry.text.trim().toLowerCase() !== titleNormalized,
+  )?.text;
+
+  return (
+    <button className="thread-search-result" type="button" onClick={props.onOpen}>
+      <span className="thread-search-result__body">
+        <span className="thread-search-result__title">{result.title}</span>
+        <span className="thread-search-result__meta">
+          <span className="chip chip--backend">{result.backend}</span>
+          {workspaceLabel ? (
+            <span className="thread-search-result__meta-item">
+              <WorkspaceIcon size={13} aria-hidden />
+              <span className="thread-search-result__meta-text">{workspaceLabel}</span>
+            </span>
+          ) : null}
+          {result.gitBranch ? (
+            <span className="thread-search-result__meta-item thread-search-result__meta-item--mono">
+              <BranchIcon size={13} aria-hidden />
+              <span className="thread-search-result__meta-text">{result.gitBranch}</span>
+            </span>
+          ) : null}
+          {result.model ? (
+            <span className="thread-search-result__meta-item thread-search-result__meta-item--mono thread-search-result__meta-item--muted">
+              <span className="thread-search-result__meta-text">{result.model}</span>
+            </span>
+          ) : null}
+        </span>
+        {snippet ? (
+          <span className="thread-search-result__snippet">{highlightSnippet(snippet, query)}</span>
+        ) : null}
+      </span>
+      <span className="thread-search-result__side">
+        <span
+          className={`thread-search-result__confidence thread-search-result__confidence--${result.confidence}`}
+        >
+          <span className="thread-search-result__confidence-dot" aria-hidden />
+          {result.confidence}
+        </span>
+        <span className="thread-search-result__reason">
+          {describeMatchReason(result.matchReasons[0]?.kind)}
+        </span>
+      </span>
+    </button>
+  );
+}
+
+function ThreadSearchEmptyState(props: {
+  title: string;
+  hint: string;
+}): ReactNode {
+  return (
+    <div className="thread-search-empty">
+      <span className="thread-search-empty__glyph" aria-hidden>
+        <SearchIcon size={22} />
+      </span>
+      <p className="thread-search-empty__title">{props.title}</p>
+      <p className="thread-search-empty__hint">{props.hint}</p>
+    </div>
+  );
+}
 
 export function ThreadSearchPanel(props: ThreadSearchPanelProps) {
   const [query, setQuery] = useState("");
   const [response, setResponse] = useState<ThreadSearchResponse>();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string>();
+
+  const searchUnavailable = !props.desktopApi?.searchThreads;
 
   const submit = async (event: FormEvent): Promise<void> => {
     event.preventDefault();
@@ -41,92 +203,105 @@ export function ThreadSearchPanel(props: ThreadSearchPanelProps) {
     }
   };
 
+  const resultCount = response?.results.length ?? 0;
+
   return (
-    <section className="thread-search-view" aria-label="Thread search">
-      <header className="thread-search-view__header">
-        <div>
-          <p className="thread-search-view__eyebrow">Threads</p>
-          <h1>Search</h1>
-        </div>
-        <button className="button button--ghost" type="button" onClick={props.onClose}>
-          Close
-        </button>
-      </header>
+    <section className="thread-view thread-search" aria-label="Thread search">
+      <ThreadPlaceholderHeader
+        desktopApi={props.desktopApi}
+        title="Search"
+        onOpenMessagingActivity={props.onOpenMessagingActivity}
+        layout={
+          props.layout ? { ...props.layout, railToggleDisabled: true } : undefined
+        }
+        masthead={props.masthead}
+      />
 
-      <form className="thread-search-view__form" onSubmit={(event) => void submit(event)}>
-        <label className="thread-search-view__field">
-          <span>Query</span>
-          <input
-            autoFocus
-            value={query}
-            placeholder="Search threads"
-            onChange={(event) => setQuery(event.target.value)}
-          />
-        </label>
-        <button
-          className="button button--primary thread-search-view__submit"
-          disabled={loading || !query.trim() || !props.desktopApi?.searchThreads}
-          type="submit"
-        >
-          <SearchIcon size={15} aria-hidden />
-          <span>{loading ? "Searching" : "Search"}</span>
-        </button>
-      </form>
-
-      {error ? <p className="thread-search-view__error">{error}</p> : null}
-
-      {response?.unavailableScopes.length ? (
-        <div className="thread-search-view__scopes" aria-label="Unavailable scopes">
-          {response.unavailableScopes.map((scope, index) => (
-            <span key={`${scope.scope}:${scope.backend ?? "all"}:${index}`}>
-              {scope.backend ? `${scope.backend} ` : ""}
-              {scope.scope.replace("_", " ")}: {scope.reason}
+      <div className="thread-search__body">
+        <form className="thread-search-view__form" onSubmit={(event) => void submit(event)}>
+          <div className="thread-search-view__field">
+            <span className="thread-search-view__field-icon" aria-hidden>
+              <SearchIcon size={16} />
             </span>
-          ))}
-        </div>
-      ) : null}
-
-      <div className="thread-search-results" role="list">
-        {response?.results.map((result) => (
-          <div key={result.identityKey} role="listitem">
-            <button
-              className="thread-search-result"
-              type="button"
-              onClick={() => {
-                void props.onOpenResult({
-                  backend: result.backend,
-                  threadId: result.threadId,
-                });
-              }}
-            >
-              <span className="thread-search-result__main">
-                <span className="thread-search-result__title">{result.title}</span>
-                <span className="thread-search-result__meta">
-                  {[
-                    result.backend,
-                    result.projectKey,
-                    result.linkedDirectories[0]?.label,
-                    result.model,
-                  ]
-                    .filter(Boolean)
-                    .join(" · ")}
-                </span>
-                {result.snippets[0] ? (
-                  <span className="thread-search-result__snippet">
-                    {result.snippets[0].text}
-                  </span>
-                ) : null}
-              </span>
-              <span className="thread-search-result__side">
-                <span>{result.confidence}</span>
-                <span>{result.matchReasons[0]?.kind.replaceAll("_", " ") ?? "match"}</span>
-              </span>
-            </button>
+            <input
+              autoFocus
+              aria-label="Search threads"
+              value={query}
+              placeholder="Search by title, message content, or branch"
+              onChange={(event) => setQuery(event.target.value)}
+            />
           </div>
-        ))}
-        {response && response.results.length === 0 ? (
-          <p className="thread-search-results__empty">No matches</p>
+          <button
+            className="button button--primary thread-search-view__submit"
+            disabled={loading || !query.trim() || searchUnavailable}
+            type="submit"
+          >
+            <SearchIcon size={15} aria-hidden />
+            <span>{loading ? "Searching" : "Search"}</span>
+          </button>
+        </form>
+
+        {error ? <p className="thread-search-view__error">{error}</p> : null}
+
+        {response?.unavailableScopes.length ? (
+          <div className="thread-search-view__scopes" aria-label="Unavailable scopes">
+            {response.unavailableScopes.map((scope, index) => (
+              <span key={`${scope.scope}:${scope.backend ?? "all"}:${index}`}>
+                {scope.backend ? `${scope.backend} ` : ""}
+                {scope.scope.replace("_", " ")}: {scope.reason}
+              </span>
+            ))}
+          </div>
         ) : null}
+
+        {response && resultCount > 0 ? (
+          <p className="thread-search-results-meta">
+            <span>
+              <strong>{resultCount}</strong> {resultCount === 1 ? "thread" : "threads"}
+            </span>
+            {response.truncated ? <span>Showing the top matches</span> : null}
+          </p>
+        ) : null}
+
+        {loading && !response ? (
+          <ThreadSearchEmptyState
+            title="Searching threads…"
+            hint="Looking across titles, summaries, branches, and message content."
+          />
+        ) : response ? (
+          resultCount > 0 ? (
+            <div className="thread-search-results" role="list">
+              {response.results.map((result) => (
+                <div key={result.identityKey} role="listitem">
+                  <ThreadSearchResultRow
+                    result={result}
+                    query={response.query}
+                    onOpen={() => {
+                      void props.onOpenResult({
+                        backend: result.backend,
+                        threadId: result.threadId,
+                      });
+                    }}
+                  />
+                </div>
+              ))}
+            </div>
+          ) : (
+            <ThreadSearchEmptyState
+              title="No threads match that search"
+              hint={`Nothing came back for “${response.query}”. Try a broader term or different wording.`}
+            />
+          )
+        ) : (
+          <ThreadSearchEmptyState
+            title={searchUnavailable ? "Search is unavailable" : "Search your threads"}
+            hint={
+              searchUnavailable
+                ? "Thread search isn’t available in this session yet."
+                : "Find any thread by its title, summary, linked branch, or message content across every backend."
+            }
+          />
+        )}
       </div>
     </section>
   );

--- a/apps/desktop/src/renderer/src/features/thread-search/__tests__/ThreadSearchPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-search/__tests__/ThreadSearchPanel.test.tsx
@@ -42,12 +42,11 @@ describe("ThreadSearchPanel", () => {
     render(
       <ThreadSearchPanel
         desktopApi={{ searchThreads } as DesktopApi}
-        onClose={vi.fn()}
         onOpenResult={onOpenResult}
       />,
     );
 
-    fireEvent.change(screen.getByLabelText("Query"), {
+    fireEvent.change(screen.getByLabelText("Search threads"), {
       target: { value: "branch drift" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Search" }));

--- a/apps/desktop/src/renderer/src/features/thread-search/__tests__/ThreadSearchPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-search/__tests__/ThreadSearchPanel.test.tsx
@@ -3,7 +3,7 @@ import "@testing-library/jest-dom/vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { ThreadSearchResponse } from "@pwragent/shared";
-import { ThreadSearchPanel } from "../ThreadSearchPanel";
+import { basename, highlightSnippet, ThreadSearchPanel } from "../ThreadSearchPanel";
 import type { DesktopApi } from "../../../lib/desktop-api";
 
 describe("ThreadSearchPanel", () => {
@@ -60,5 +60,53 @@ describe("ThreadSearchPanel", () => {
         threadId: "thread-1",
       });
     });
+  });
+});
+
+describe("basename", () => {
+  it("returns the final segment of a posix path", () => {
+    expect(basename("/Users/me/code/PwrAgnt")).toBe("PwrAgnt");
+  });
+
+  it("returns the final segment of a windows path", () => {
+    expect(basename("C:\\Users\\me\\PwrAgnt")).toBe("PwrAgnt");
+  });
+
+  it("ignores a trailing slash", () => {
+    expect(basename("/a/b/")).toBe("b");
+  });
+
+  it("returns a bare name unchanged", () => {
+    expect(basename("PwrAgnt")).toBe("PwrAgnt");
+  });
+});
+
+describe("highlightSnippet", () => {
+  it("wraps each query token occurrence in a <mark>, case-insensitively", () => {
+    const { container } = render(<>{highlightSnippet("the Bar and a bar", "bar")}</>);
+    const marks = container.querySelectorAll("mark");
+    expect(marks).toHaveLength(2);
+    expect(marks[0]).toHaveTextContent("Bar");
+    expect(marks[1]).toHaveTextContent("bar");
+    // The full text is preserved, just segmented.
+    expect(container.textContent).toBe("the Bar and a bar");
+  });
+
+  it("treats regex-special characters in the query as literals", () => {
+    const { container } = render(<>{highlightSnippet("use a+b not axb", "a+b")}</>);
+    const marks = container.querySelectorAll("mark");
+    expect(marks).toHaveLength(1);
+    expect(marks[0]).toHaveTextContent("a+b");
+  });
+
+  it("renders no marks and preserves text when nothing matches", () => {
+    const { container } = render(<>{highlightSnippet("hello world", "zzz")}</>);
+    expect(container.querySelectorAll("mark")).toHaveLength(0);
+    expect(container.textContent).toBe("hello world");
+  });
+
+  it("ignores query tokens shorter than two characters", () => {
+    const { container } = render(<>{highlightSnippet("a apple", "a")}</>);
+    expect(container.querySelectorAll("mark")).toHaveLength(0);
   });
 });

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -844,6 +844,17 @@ textarea,
   background: color-mix(in srgb, var(--accent) 15%, transparent);
 }
 
+/* Greyed-out, non-interactive chip — e.g. the rail toggle in thread search,
+   where there is no context rail to toggle. Stays in place so the chrome
+   doesn't shift; just reads as "not applicable here." `pointer-events: none`
+   makes it fully inert so no hover state (its own or a broader selector's)
+   can darken it on mouseover. */
+.panel-toggle__chip:disabled {
+  opacity: 0.32;
+  cursor: default;
+  pointer-events: none;
+}
+
 .thread-header__main {
   display: flex;
   flex-direction: column;
@@ -3634,91 +3645,87 @@ textarea,
   background: var(--bg-app);
 }
 
-.thread-search-view {
-  display: flex;
-  width: 100%;
-  min-width: 0;
-  min-height: 0;
-  flex-direction: column;
-  gap: 18px;
-  padding: 28px;
-  overflow: hidden;
+/* Search reuses the shared thread title bar (ThreadPlaceholderHeader) for its
+   chrome — MSG status, sidebar toggle, disabled rail toggle — via the
+   `.thread-view` column layout. The section only owns the scrolling body
+   beneath that header. */
+.thread-search {
   background: var(--bg-app);
   color: var(--text-primary);
 }
 
-.thread-search-view__header {
+.thread-search__body {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
   gap: 16px;
-  -webkit-app-region: drag;
-}
-
-.thread-search-view__header button,
-.thread-search-view__form,
-.thread-search-results {
-  -webkit-app-region: no-drag;
-}
-
-.thread-search-view__eyebrow {
-  margin: 0 0 2px;
-  color: var(--accent);
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0;
-  text-transform: uppercase;
-}
-
-.thread-search-view__header h1 {
-  margin: 0;
-  font-size: 24px;
-  line-height: 1.15;
+  padding: 12px 24px 20px;
+  overflow: hidden;
 }
 
 .thread-search-view__form {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
+  display: flex;
   gap: 10px;
-  align-items: end;
+  align-items: stretch;
 }
 
 .thread-search-view__field {
-  display: grid;
+  position: relative;
+  display: flex;
+  flex: 1;
   min-width: 0;
-  gap: 6px;
-  color: var(--text-secondary);
-  font-size: 12px;
-  font-weight: 700;
+  align-items: center;
+}
+
+.thread-search-view__field-icon {
+  position: absolute;
+  left: 12px;
+  display: inline-flex;
+  color: var(--text-muted);
+  pointer-events: none;
+  transition: color 120ms ease;
+}
+
+.thread-search-view__field:focus-within .thread-search-view__field-icon {
+  color: var(--accent);
 }
 
 .thread-search-view__field input {
   width: 100%;
   min-width: 0;
-  height: 38px;
+  height: 40px;
   border: 1px solid var(--border-subtle);
-  border-radius: 6px;
-  padding: 0 12px;
-  background: var(--bg-panel);
+  border-radius: 8px;
+  padding: 0 14px 0 38px;
+  background: var(--bg-input);
   color: var(--text-primary);
   font: inherit;
+}
+
+.thread-search-view__field input::placeholder {
+  color: var(--text-muted);
 }
 
 .thread-search-view__field input:focus {
   outline: 2px solid var(--focus-ring);
   outline-offset: 2px;
+  border-color: transparent;
 }
 
 .thread-search-view__submit {
+  height: 40px;
   display: inline-flex;
   align-items: center;
   gap: 7px;
+  white-space: nowrap;
 }
 
 .thread-search-view__error {
   margin: 0;
   border: 1px solid color-mix(in srgb, var(--status-error) 50%, var(--border-subtle));
-  border-radius: 6px;
+  border-radius: 8px;
   padding: 10px 12px;
   background: color-mix(in srgb, var(--status-error) 10%, transparent);
   color: var(--text-primary);
@@ -3734,13 +3741,30 @@ textarea,
 .thread-search-view__scopes span {
   border: 1px solid var(--border-subtle);
   border-radius: 999px;
-  padding: 4px 8px;
-  color: var(--text-secondary);
+  padding: 4px 10px;
+  color: var(--text-muted);
   font-size: 12px;
 }
 
+.thread-search-results-meta {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.thread-search-results-meta strong {
+  color: var(--text-secondary);
+  font-weight: 600;
+}
+
 .thread-search-results {
-  display: grid;
+  display: flex;
+  flex: 1;
+  flex-direction: column;
   min-height: 0;
   gap: 8px;
   overflow: auto;
@@ -3753,59 +3777,181 @@ textarea,
   gap: 16px;
   width: 100%;
   border: 1px solid var(--border-subtle);
-  border-radius: 6px;
-  padding: 12px;
+  border-radius: 8px;
+  padding: 12px 14px;
   background: var(--bg-panel);
   color: inherit;
   text-align: left;
+  transition:
+    border-color 120ms ease,
+    background-color 120ms ease;
 }
 
-.thread-search-result:hover,
-.thread-search-result:focus-visible {
+.thread-search-result:hover {
   border-color: var(--accent-border);
   background: var(--bg-panel-hover);
 }
 
-.thread-search-result__main {
+.thread-search-result:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+  border-color: var(--accent-border);
+  background: var(--bg-panel-hover);
+}
+
+.thread-search-result__body {
   display: grid;
   min-width: 0;
-  gap: 5px;
+  gap: 6px;
 }
 
 .thread-search-result__title {
   overflow: hidden;
-  font-weight: 700;
+  font-size: 14px;
+  font-weight: 600;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.thread-search-result__meta,
-.thread-search-result__snippet,
-.thread-search-result__side {
+.thread-search-result__meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px 10px;
+  min-width: 0;
   color: var(--text-secondary);
   font-size: 12px;
-  line-height: 1.35;
+  line-height: 1.3;
+}
+
+.thread-search-result__meta-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.thread-search-result__meta-item svg {
+  flex: none;
+  color: var(--text-muted);
+}
+
+.thread-search-result__meta-item--mono {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+}
+
+.thread-search-result__meta-item--muted {
+  color: var(--text-muted);
+}
+
+.thread-search-result__meta-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .thread-search-result__snippet {
   display: -webkit-box;
   overflow: hidden;
+  margin-top: 1px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.45;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
 }
 
-.thread-search-result__side {
-  display: grid;
-  min-width: 96px;
-  justify-items: end;
-  align-content: start;
-  gap: 4px;
-  text-transform: capitalize;
+.thread-search-result__mark {
+  border-radius: 3px;
+  padding: 0 1px;
+  background: var(--accent-soft);
+  color: var(--accent-bright);
+  font-weight: 600;
 }
 
-.thread-search-results__empty {
-  margin: 24px 0 0;
+.thread-search-result__side {
+  display: grid;
+  justify-items: end;
+  align-content: start;
+  gap: 5px;
+  text-align: right;
+}
+
+.thread-search-result__confidence {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.thread-search-result__confidence-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+.thread-search-result__confidence--high {
+  color: var(--accent-bright);
+}
+
+.thread-search-result__confidence--medium {
+  color: var(--text-secondary);
+}
+
+.thread-search-result__confidence--low {
+  color: var(--text-muted);
+}
+
+.thread-search-result__reason {
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.3;
+}
+
+.thread-search-empty {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 24px 24px 56px;
+  text-align: center;
+}
+
+.thread-search-empty__glyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  background: var(--bg-panel);
+  color: var(--text-muted);
+}
+
+.thread-search-empty__title {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.thread-search-empty__hint {
+  margin: 0;
+  max-width: 420px;
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.5;
 }
 
 .codex-config-warning-banner {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -452,6 +452,18 @@ textarea,
   gap: 6px;
 }
 
+/* When the sidebar is hidden this cluster relocates into the thread/search
+   header, a window-drag region (`.thread-header * { drag }`). That re-marks each
+   button's icon glyph as draggable, so the center of the button becomes an OS
+   drag zone — arrow cursor, clicks eaten — while only the padding edges stay
+   clickable. Force the cluster no-drag so every pixel of every button works.
+   Scoped through `.thread-header` for specificity (0,2,0) so it beats
+   `.thread-header *` (0,1,0) regardless of source order. */
+.thread-header .masthead-actions,
+.thread-header .masthead-actions * {
+  -webkit-app-region: no-drag;
+}
+
 /* macOS floats the traffic lights over the cluster's left. Match the sidebar
    masthead's wordmark offset exactly — its 16px sidebar gutter + 80px
    stoplight reservation — so the wordmark sits in the same spot whether the

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3665,13 +3665,13 @@ textarea,
   overflow: hidden;
 }
 
-.thread-search-view__form {
+.thread-search__form {
   display: flex;
   gap: 10px;
   align-items: stretch;
 }
 
-.thread-search-view__field {
+.thread-search__field {
   position: relative;
   display: flex;
   flex: 1;
@@ -3679,7 +3679,7 @@ textarea,
   align-items: center;
 }
 
-.thread-search-view__field-icon {
+.thread-search__field-icon {
   position: absolute;
   left: 12px;
   display: inline-flex;
@@ -3688,11 +3688,11 @@ textarea,
   transition: color 120ms ease;
 }
 
-.thread-search-view__field:focus-within .thread-search-view__field-icon {
+.thread-search__field:focus-within .thread-search__field-icon {
   color: var(--accent);
 }
 
-.thread-search-view__field input {
+.thread-search__field input {
   width: 100%;
   min-width: 0;
   height: 40px;
@@ -3704,17 +3704,17 @@ textarea,
   font: inherit;
 }
 
-.thread-search-view__field input::placeholder {
+.thread-search__field input::placeholder {
   color: var(--text-muted);
 }
 
-.thread-search-view__field input:focus {
+.thread-search__field input:focus {
   outline: 2px solid var(--focus-ring);
   outline-offset: 2px;
   border-color: transparent;
 }
 
-.thread-search-view__submit {
+.thread-search__submit {
   height: 40px;
   display: inline-flex;
   align-items: center;
@@ -3722,7 +3722,7 @@ textarea,
   white-space: nowrap;
 }
 
-.thread-search-view__error {
+.thread-search__error {
   margin: 0;
   border: 1px solid color-mix(in srgb, var(--status-error) 50%, var(--border-subtle));
   border-radius: 8px;
@@ -3732,13 +3732,13 @@ textarea,
   font-size: 13px;
 }
 
-.thread-search-view__scopes {
+.thread-search__scopes {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
 }
 
-.thread-search-view__scopes span {
+.thread-search__scopes span {
   border: 1px solid var(--border-subtle);
   border-radius: 999px;
   padding: 4px 10px;
@@ -3839,7 +3839,7 @@ textarea,
 
 .thread-search-result__meta-item--mono {
   font-family: var(--font-mono);
-  font-size: 11.5px;
+  font-size: 11px;
 }
 
 .thread-search-result__meta-item--muted {


### PR DESCRIPTION
## Summary

The agentic thread search panel (#743) shipped as a bare form over an empty void, dumped raw absolute worktree paths in its result rows, and rendered its own header — so opening Search hid the MSG status and the window chrome. This gives it an editorial tune-up and folds it into the shared title bar. Renderer-only; uses existing theme tokens (no new colors).

**Panel**
- Search field: dropped the redundant "Query" label, moved the search glyph inside the input (tangerine on focus), clearer placeholder.
- Calm empty states: an initial "Search your threads" prompt and a no-match state that echoes the query.
- Rebuilt result rows to reuse existing chrome — backend chip, repo name with a worktree/folder icon, branch in mono with the branch icon, muted mono model — instead of dumping absolute checkout paths.
- Added a result count and a confidence dot + humanized match reason.
- Highlight query tokens in snippets; skip snippets that merely duplicate the title.

**Title bar / shell integration**
- Search now renders the shared `ThreadPlaceholderHeader` (title "Search"), so it wears the same chrome as the thread view; the bespoke header and **Close button are gone**. The body scrolls beneath the header via the `.thread-view` column layout.
- The **MSG status** and the **sidebar toggle** stay visible in Search; the **context-rail toggle** renders greyed-out and fully inert (`pointer-events: none`) since there's no rail in this mode — via a new `PanelToggleButtons` `railToggleDisabled` prop.
- Search is now a **toggle**: the masthead/sidebar Search button flips Search on and off (active state), and `MastheadActions` gains a Search button so it stays reachable when the sidebar is hidden. Clicking a thread/result also exits.

## Verification

- `pnpm --filter @pwragent/desktop typecheck` ✅
- `pnpm lint:boundaries` ✅ (868 modules, 0 violations)
- `pnpm lint:colors` ✅
- `ThreadSearchPanel` unit test ✅ (updated for the new `aria-label` + props)
- Drove the real desktop build (`pnpm dev:no-messaging`) and verified each surface: initial empty state, a live results query, the no-match state, the MSG cluster + sidebar toggle visible in Search, the greyed/inert rail toggle (rest == hover), and the Search button toggling on/off.

## Notes

- No contract or main-process changes — types/data shapes are unchanged; this is renderer markup + CSS only.
- Behavioral change worth flagging: the **Close button was intentionally removed**. Exit Search via the Search toggle (sidebar masthead, or the relocated masthead when the sidebar is hidden) or by opening any thread/result.
- The `projectKey` Codex returns is often a full checkout path, so the workspace label is collapsed to its basename and the branch carries the distinguishing detail.