### PR TITLE
fix(desktop): keep scrollbars thin in classic-scrollbar mode

### DIFF
--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -782,6 +782,45 @@ describe("Tangerine Terminal theme contract", () => {
     expect(css).not.toContain("transcript-message__collapse-toggle");
   });
 
+  it("styles the sidebar scroll lanes with scrollbar-width only (no ::-webkit-scrollbar fat-flicker)", () => {
+    // Regression guard. A `::-webkit-scrollbar` block on these lanes
+    // makes Chromium render a fat *custom* scrollbar whenever it drops
+    // into classic-scrollbar mode (a mouse is attached, "Show scroll
+    // bars: Always" is set, or transiently while another app grabs the
+    // screen) — the webkit width overrides `scrollbar-width: thin`, so
+    // the bar visibly jumps fat and snaps back. The lanes must style the
+    // scrollbar ONLY via the standard properties so it stays thin in
+    // both overlay and classic modes.
+    // Each lane appears in more than one rule (a shared base rule plus
+    // its dedicated scroll rule), so collect every rule body for the
+    // selector and assert the scroll rule among them opts into thin.
+    for (const selector of [".sidebar-list--dense", ".directory-groups"]) {
+      const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const bodies = [
+        ...css.matchAll(new RegExp(`(?:^|\\n)${escaped}\\s*\\{([^}]*)\\}`, "g")),
+      ].map((match) => match[1]);
+      expect(bodies.some((body) => body.includes("scrollbar-width: thin;"))).toBe(
+        true
+      );
+    }
+    expect(css).not.toMatch(
+      /\.(?:sidebar-list--dense|directory-groups)::-webkit-scrollbar/
+    );
+  });
+
+  it("applies a thin, themed scrollbar to every scroller via the universal selector (scrollbar-width does not inherit)", () => {
+    // `scrollbar-color` inherits but `scrollbar-width` does NOT, so a
+    // `:root` rule alone leaves scrollers at the chunky default width in
+    // classic mode (only tinted). The universal selector sets the thin
+    // width on every element so all scroll containers (transcript,
+    // settings, …) actually render thin.
+    const universal = extractRuleBody(css, "*");
+    expect(universal).toContain("scrollbar-width: thin;");
+    expect(universal).toContain(
+      "scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);"
+    );
+  });
+
   it("keeps thinking scanner variants on one shared visible sweep", () => {
     expect(css).not.toContain("--thinking-scanner-progress");
     expect(css).not.toContain("--thinking-scanner-full-offset");

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -56,7 +56,6 @@
   --surface-overlay-subtle: color-mix(in srgb, var(--text-primary) 3%, transparent);
   --surface-overlay-faint: color-mix(in srgb, var(--text-primary) 3.5%, transparent);
   --surface-overlay-soft: color-mix(in srgb, var(--text-primary) 4%, transparent);
-  --surface-overlay: color-mix(in srgb, var(--text-primary) 5%, transparent);
 
   /* Popover backdrops use the panel base at high alpha so they read as
      the same surface as the rest of the panel. */
@@ -82,10 +81,10 @@
   --scrim-strong: color-mix(in srgb, var(--shadow-base) 62%, transparent);
   --scrim-opaque: color-mix(in srgb, var(--shadow-base) 88%, transparent);
 
-  /* Scrollbar tones. */
+  /* Scrollbar tones — thumb + track for the native (`scrollbar-color`)
+     thin scrollbars; no hover tone since the OS handles thumb hover. */
   --scrollbar-track: color-mix(in srgb, var(--text-primary) 5%, transparent);
   --scrollbar-thumb: color-mix(in srgb, var(--text-muted) 46%, transparent);
-  --scrollbar-thumb-hover: color-mix(in srgb, var(--text-secondary) 58%, transparent);
 
   /* Text-decoration underline overlay (e.g. dotted underlines on links
      under secondary text). */
@@ -348,8 +347,28 @@
   gap: 2px;
 }
 
+/* Thin, themed scrollbars on every scroll container — sidebar,
+   transcript, settings, dropdowns, … — in BOTH overlay and classic
+   scrollbar modes. Classic mode (chunky, always-visible bars) shows up
+   when a mouse is attached, "Show scroll bars: Always" is set, or
+   transiently while another app re-evaluates the scroller style during a
+   screen capture (e.g. a PwrSnap ⌘⇧C grab); without an explicit thin
+   width those bars render fat.
+
+   This MUST use the universal selector, not `:root`. `scrollbar-color`
+   is an inherited property, but `scrollbar-width` is NOT — a `:root`
+   rule would tint every scroller yet leave its WIDTH at the chunky
+   default (only the root/viewport bar would go thin). Setting both on
+   `*` is the standard workaround so every element's scroll container
+   picks up the thin width. Per-scroller color overrides (e.g.
+   `.composer__autocomplete`) still win on specificity, and a
+   `::-webkit-scrollbar` block must NOT be added (it overrides this and
+   reintroduces the classic-mode fat bar — theme-contract.test.tsx
+   guards the sidebar lanes). */
 * {
   box-sizing: border-box;
+  scrollbar-width: thin;
+  scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
 }
 
 html,
@@ -2239,11 +2258,19 @@ textarea,
   padding-inline: 4px 8px;
   scrollbar-width: thin;
   scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
-  /* Finder-style scrollbar gutter (sidebar-tightening pass): reserve
-     a stable 10px column on the right for the scrollbar so the thumb
-     never overlays row content. The previous overlay-scrollbar
-     behavior intermittently failed to hide on macOS Chromium and
-     visually collided with titles + the per-row launchpad button. */
+  /* Reserve a stable gutter so the thin auto-hiding scrollbar never
+     shifts row content when it appears.
+
+     Style the scrollbar ONLY via `scrollbar-width` / `scrollbar-color`
+     above — do NOT add a `::-webkit-scrollbar` block here. Defining one
+     makes Chromium render a *custom, non-overlay* scrollbar whenever it
+     falls into classic-scrollbar mode (a mouse is attached, "Show scroll
+     bars: Always" is set, or transiently while another app grabs the
+     screen — e.g. a PwrSnap ⌘⇧C capture re-evaluates the scroller style).
+     In that mode the webkit `width` overrides `scrollbar-width: thin`, so
+     the bar visibly jumps fat and then snaps back. Letting
+     `scrollbar-width: thin` govern both overlay and classic modes keeps
+     it thin and stable. (theme-contract.test.tsx guards this.) */
   scrollbar-gutter: stable;
 }
 
@@ -2258,31 +2285,6 @@ textarea,
   scrollbar-width: thin;
   scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
   scrollbar-gutter: stable;
-}
-
-.sidebar-list--dense::-webkit-scrollbar,
-.directory-groups::-webkit-scrollbar {
-  width: 10px;
-}
-
-.sidebar-list--dense::-webkit-scrollbar-track,
-.directory-groups::-webkit-scrollbar-track {
-  background: var(--surface-overlay);
-  border-radius: 999px;
-}
-
-.sidebar-list--dense::-webkit-scrollbar-thumb,
-.directory-groups::-webkit-scrollbar-thumb {
-  border: 2px solid transparent;
-  border-radius: 999px;
-  background: var(--scrollbar-thumb);
-  background-clip: padding-box;
-}
-
-.sidebar-list--dense::-webkit-scrollbar-thumb:hover,
-.directory-groups::-webkit-scrollbar-thumb:hover {
-  background: var(--scrollbar-thumb-hover);
-  background-clip: padding-box;
 }
 
 .sidebar-list--compact {


### PR DESCRIPTION
## Summary

Fixes scrollbars intermittently rendering **fat** and then snapping back to thin — on the sidebar, the **thread transcript**, and other panes — most visibly when a screen-capture tool (PwrSnap `⌘⇧C`) grabs the screen.

**Cause.** Chromium flips between **overlay** scrollbars (thin, auto-hiding — the trackpad / "when scrolling" default) and **classic** ones (chunky, always-visible). Classic mode kicks in when a mouse is attached, "Show scroll bars: Always" is set, or *transiently* while another app re-evaluates the scroller style during a screen capture. Two ways that surfaced:

- **Sidebar lanes** carried a `::-webkit-scrollbar { width: 10px }` block that, in classic mode, *overrode* `scrollbar-width: thin` with a fat custom bar.
- **Most other scrollers** (transcript, settings, dropdowns — ~29 of ~32) declared **no** scrollbar styling at all, so classic mode fell back to the browser's chunky **default** classic bar.

Pre-existing; only 3 of ~32 scrollers opted into thin.

**Fix.**
1. Delete the sidebar's `::-webkit-scrollbar` block — a global rule can't override a webkit block, so the sidebar specifically needs it gone.
2. Set `scrollbar-width: thin` + `scrollbar-color` on the **universal selector `*`**.

> ⚠️ **Why `*` and not `:root`:** `scrollbar-color` is an *inherited* property, but `scrollbar-width` is **not**. A `:root` rule tints every scroller yet leaves its *width* at the chunky default (only the root/viewport bar goes thin) — which is exactly the half-fixed state an earlier revision of this PR shipped. The universal selector is the standard workaround so every scroll container actually renders thin. Per-scroller color overrides (e.g. `.composer__autocomplete`) still win on specificity.

Also drops the now-orphaned `--surface-overlay` / `--scrollbar-thumb-hover` tokens and adds `theme-contract` guards for the universal rule and the sidebar's no-`::-webkit-scrollbar` invariant.

## Verification

- `pnpm test …/theme-contract.test.tsx …/sidebar.test.tsx` → **106 passed** (2 new guards).
- Confirmed the mechanism in DevTools with "Show scroll bars: Always": before the `*` fix, transcript/settings inherited `scrollbar-color` (tinted) but `scrollbar-width: thin` showed **greyed-out** (non-inherited) so they stayed chunky; after, the thin width applies to every scroller.
- Sidebar overlay mode (the everyday case) is unchanged — only a dormant block was removed.
- **Deterministic A/B:** System Settings → Appearance → *Show scroll bars: Always*, then scroll the sidebar, transcript, and a settings pane. On `main` the bars go fat; on this branch they stay thin. Flip back to "Automatically" after.

## Notes

- CSS + tests only; no raw color literals; per-scroller color overrides preserved.
- The sidebar lanes still declare `scrollbar-width`/`scrollbar-color` explicitly — now redundant with the universal rule, but kept as defensive documentation at the exact site of the former webkit bug (the comment there warns against re-adding a webkit block).
- Branch is a few commits behind `main`, but main's `app.css` changes don't overlap the edited regions (verified) — merges cleanly. Screenshots unaffected (overlay-mode thin scrollbar is unchanged); not regenerated.
