### PR TITLE
fix(desktop): collapse macOS stoplight inset in fullscreen

### DIFF
--- a/apps/desktop/src/main/__tests__/auxiliary-window-chrome.test.ts
+++ b/apps/desktop/src/main/__tests__/auxiliary-window-chrome.test.ts
@@ -67,6 +67,33 @@ afterEach(() => {
 });
 
 describe("auxiliary window chrome", () => {
+  it("trades native fullscreen for windowed zoom on macOS secondary windows", async () => {
+    setPlatform("darwin");
+    const { auxiliaryWindowChromeOptions } = await import(
+      "../auxiliary-window-chrome"
+    );
+
+    const options = auxiliaryWindowChromeOptions();
+
+    // Fullscreen off → the green traffic light reverts to a windowed
+    // Zoom. `maximizable` stays true so the button isn't greyed out.
+    expect(options.fullscreenable).toBe(false);
+    expect(options.maximizable).toBe(true);
+    expect(options.titleBarStyle).toBe("hiddenInset");
+  });
+
+  it("does not constrain fullscreen/maximize on Linux secondary windows", async () => {
+    setPlatform("linux");
+    const { auxiliaryWindowChromeOptions } = await import(
+      "../auxiliary-window-chrome"
+    );
+
+    const options = auxiliaryWindowChromeOptions();
+
+    expect(options.fullscreenable).toBeUndefined();
+    expect(options.maximizable).toBeUndefined();
+  });
+
   it("retries Linux raises after the window has had time to map", async () => {
     vi.useFakeTimers();
     setPlatform("linux");

--- a/apps/desktop/src/main/__tests__/window-fullscreen-sync.test.ts
+++ b/apps/desktop/src/main/__tests__/window-fullscreen-sync.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from "vitest";
+import type { BrowserWindow } from "electron";
+import { WINDOW_FULLSCREEN_SYNC_CHANNEL } from "../../shared/ipc";
+import { attachWindowFullscreenSync } from "../window-fullscreen-sync";
+
+type FakeWindow = BrowserWindow & {
+  emitWindowEvent: (event: string) => void;
+  emitWebContentsEvent: (event: string) => void;
+  sendMock: ReturnType<typeof vi.fn>;
+  setDestroyed: (value: boolean) => void;
+  setFullScreen: (value: boolean) => void;
+};
+
+function createWindow(initialFullScreen = false): FakeWindow {
+  const windowListeners = new Map<string, Array<() => void>>();
+  const webContentsListeners = new Map<string, Array<() => void>>();
+  let destroyed = false;
+  let fullScreen = initialFullScreen;
+  const sendMock = vi.fn();
+
+  const window = {
+    emitWindowEvent: (event: string) => {
+      for (const listener of windowListeners.get(event) ?? []) listener();
+    },
+    emitWebContentsEvent: (event: string) => {
+      for (const listener of webContentsListeners.get(event) ?? []) listener();
+    },
+    sendMock,
+    setDestroyed: (value: boolean) => {
+      destroyed = value;
+    },
+    setFullScreen: (value: boolean) => {
+      fullScreen = value;
+    },
+    on: vi.fn((event: string, listener: () => void) => {
+      windowListeners.set(event, [
+        ...(windowListeners.get(event) ?? []),
+        listener,
+      ]);
+    }),
+    isDestroyed: vi.fn(() => destroyed),
+    isFullScreen: vi.fn(() => fullScreen),
+    webContents: {
+      send: sendMock,
+      on: vi.fn((event: string, listener: () => void) => {
+        webContentsListeners.set(event, [
+          ...(webContentsListeners.get(event) ?? []),
+          listener,
+        ]);
+      }),
+    },
+  };
+
+  return window as unknown as FakeWindow;
+}
+
+describe("window fullscreen sync", () => {
+  it("pushes fullscreen=true on enter-full-screen", () => {
+    const window = createWindow();
+    attachWindowFullscreenSync(window);
+
+    window.emitWindowEvent("enter-full-screen");
+
+    expect(window.sendMock).toHaveBeenCalledWith(WINDOW_FULLSCREEN_SYNC_CHANNEL, {
+      isFullScreen: true,
+    });
+  });
+
+  it("pushes fullscreen=false on leave-full-screen", () => {
+    const window = createWindow(true);
+    attachWindowFullscreenSync(window);
+
+    window.emitWindowEvent("leave-full-screen");
+
+    expect(window.sendMock).toHaveBeenCalledWith(WINDOW_FULLSCREEN_SYNC_CHANNEL, {
+      isFullScreen: false,
+    });
+  });
+
+  it("re-emits the live fullscreen state on every renderer load", () => {
+    // Covers the dev-HMR / crash-reload case: the BrowserWindow stays
+    // fullscreen across a renderer remount, so did-finish-load must report
+    // the CURRENT state rather than the non-fullscreen creation default.
+    const window = createWindow(true);
+    attachWindowFullscreenSync(window);
+
+    window.emitWebContentsEvent("did-finish-load");
+    expect(window.sendMock).toHaveBeenLastCalledWith(
+      WINDOW_FULLSCREEN_SYNC_CHANNEL,
+      { isFullScreen: true },
+    );
+
+    window.setFullScreen(false);
+    window.emitWebContentsEvent("did-finish-load");
+    expect(window.sendMock).toHaveBeenLastCalledWith(
+      WINDOW_FULLSCREEN_SYNC_CHANNEL,
+      { isFullScreen: false },
+    );
+  });
+
+  it("does not push to a destroyed window", () => {
+    const window = createWindow();
+    attachWindowFullscreenSync(window);
+
+    window.setDestroyed(true);
+    window.emitWindowEvent("enter-full-screen");
+
+    expect(window.sendMock).not.toHaveBeenCalled();
+  });
+
+  it("no-ops for a window without an event emitter", () => {
+    const window = { on: undefined } as unknown as BrowserWindow;
+
+    expect(() => attachWindowFullscreenSync(window)).not.toThrow();
+  });
+});

--- a/apps/desktop/src/main/auxiliary-window-chrome.ts
+++ b/apps/desktop/src/main/auxiliary-window-chrome.ts
@@ -27,11 +27,25 @@ export function auxiliaryWindowChromeOptions(): Pick<
   | "titleBarStyle"
   | "trafficLightPosition"
   | "titleBarOverlay"
+  | "fullscreenable"
+  | "maximizable"
 > {
   if (process.platform === "darwin") {
+    // Secondary windows (Changelog / License / Logs / Activity) are
+    // supporting surfaces, not the app shell. macOS native fullscreen
+    // would hide the stoplights and strand the reserved inset in
+    // `.activity-titlebar` (the dead gap we fix on the main window), and
+    // a fullscreened helper window jumps to its own Space, away from the
+    // work it's meant to support — so turn fullscreen OFF. With
+    // `fullscreenable` false the green traffic light reverts to its
+    // classic macOS Zoom: a windowed maximize that fills the screen
+    // without leaving the current Space. Keep `maximizable` true so that
+    // button stays live (it'd grey out otherwise).
     return {
       titleBarStyle: "hiddenInset",
       trafficLightPosition: { x: 20, y: 18 },
+      fullscreenable: false,
+      maximizable: true,
     };
   }
 

--- a/apps/desktop/src/main/window-fullscreen-sync.ts
+++ b/apps/desktop/src/main/window-fullscreen-sync.ts
@@ -31,10 +31,18 @@ export function attachWindowFullscreenSync(window: BrowserWindow): void {
   window.on("leave-full-screen", () => send(false));
 
   // The renderer can mount AFTER a fullscreen transition has already
-  // happened — a dev HMR reload while fullscreen, or the window being
-  // restored into fullscreen. Re-emit the current state on every load so
-  // `<html data-fullscreen>` matches reality instead of the non-fullscreen
-  // default the renderer bootstraps with.
+  // happened — e.g. a dev HMR reload or a renderer-crash reload that keeps
+  // the same (still-fullscreen) BrowserWindow. Re-emit the current state on
+  // every load so `<html data-fullscreen>` matches reality instead of the
+  // non-fullscreen default the renderer bootstraps with.
+  //
+  // This stands in for a synchronous pre-paint bootstrap (like the
+  // data-platform / data-theme `process.argv` path): we deliberately don't
+  // have one. argv is frozen at window creation — where the window is never
+  // fullscreen — so it can't describe a later transition, and a correct
+  // synchronous read would need a blocking `ipcRenderer.sendSync`. The cost
+  // (a sub-frame over-reservation on reload-while-fullscreen, never a broken
+  // layout, never on a normal launch) doesn't justify that.
   if (typeof window.webContents?.on === "function") {
     window.webContents.on("did-finish-load", () => {
       send(

--- a/apps/desktop/src/main/window-fullscreen-sync.ts
+++ b/apps/desktop/src/main/window-fullscreen-sync.ts
@@ -1,0 +1,47 @@
+import type { BrowserWindow } from "electron";
+import { WINDOW_FULLSCREEN_SYNC_CHANNEL } from "../shared/ipc";
+
+/**
+ * Mirror native fullscreen state into the renderer.
+ *
+ * On macOS the OS hides the traffic-light stoplights when a window goes
+ * fullscreen, but the renderer reserves a fixed left inset for them (see
+ * the `.sidebar__masthead` / `.thread-header__masthead` rules in app.css).
+ * Without telling the renderer about the transition, that inset stays put
+ * and leaves a dead gap where the lights used to be. We forward the
+ * `enter-full-screen` / `leave-full-screen` events so the renderer can
+ * toggle `<html data-fullscreen>` and collapse the inset.
+ */
+export function attachWindowFullscreenSync(window: BrowserWindow): void {
+  if (typeof window.on !== "function") {
+    return;
+  }
+
+  const send = (isFullScreen: boolean): void => {
+    if (typeof window.isDestroyed === "function" && window.isDestroyed()) {
+      return;
+    }
+    if (typeof window.webContents?.send !== "function") {
+      return;
+    }
+    window.webContents.send(WINDOW_FULLSCREEN_SYNC_CHANNEL, { isFullScreen });
+  };
+
+  window.on("enter-full-screen", () => send(true));
+  window.on("leave-full-screen", () => send(false));
+
+  // The renderer can mount AFTER a fullscreen transition has already
+  // happened — a dev HMR reload while fullscreen, or the window being
+  // restored into fullscreen. Re-emit the current state on every load so
+  // `<html data-fullscreen>` matches reality instead of the non-fullscreen
+  // default the renderer bootstraps with.
+  if (typeof window.webContents?.on === "function") {
+    window.webContents.on("did-finish-load", () => {
+      send(
+        typeof window.isFullScreen === "function"
+          ? window.isFullScreen()
+          : false,
+      );
+    });
+  }
+}

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -19,6 +19,7 @@ import { getMainLogger } from "./log";
 import { resolveActiveProfilePath } from "./profile";
 import { getDesktopSettingsService } from "./settings/desktop-settings-singleton";
 import { attachWindowFocusSync } from "./window-focus-sync";
+import { attachWindowFullscreenSync } from "./window-fullscreen-sync";
 import {
   WINDOW_KIND_MAIN,
   registerWindowChannels,
@@ -402,6 +403,7 @@ export function createMainWindow(options?: {
 
   const { webContents } = window;
   attachWindowFocusSync(window);
+  attachWindowFullscreenSync(window);
   let rendererLoaded = false;
   let hotCpuProfilerConfigKey: string | null = null;
   let hotCpuProfilerPromise: Promise<RendererHotCpuProfiler | null> | null = null;

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -347,6 +347,7 @@ import {
   THREAD_MIGRATION_RETRY_CHANNEL,
   THREAD_MIGRATION_START_CHANNEL,
   WINDOW_FOCUS_SYNC_CHANNEL,
+  WINDOW_FULLSCREEN_SYNC_CHANNEL,
   WINDOW_OPEN_NEW_THREAD_CHANNEL,
   WINDOW_OPEN_SETTINGS_CHANNEL,
   WINDOW_POINTER_SNAPSHOT_CHANNEL,
@@ -904,6 +905,18 @@ const desktopApi = Object.freeze({
     ipcRenderer.on(WINDOW_FOCUS_SYNC_CHANNEL, listener);
     return () => {
       ipcRenderer.off(WINDOW_FOCUS_SYNC_CHANNEL, listener);
+    };
+  },
+  onWindowFullscreen: (
+    callback: (isFullScreen: boolean) => void,
+  ): (() => void) => {
+    const listener = (
+      _event: Electron.IpcRendererEvent,
+      payload?: { isFullScreen?: unknown },
+    ) => callback(Boolean(payload?.isFullScreen));
+    ipcRenderer.on(WINDOW_FULLSCREEN_SYNC_CHANNEL, listener);
+    return () => {
+      ipcRenderer.off(WINDOW_FULLSCREEN_SYNC_CHANNEL, listener);
     };
   },
   onOpenSettingsRequested: (

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -646,6 +646,16 @@ export type DesktopApi = {
   shutdownMessagingRuntime?: () => Promise<void>;
   onWindowFocus?: (callback: () => void) => () => void;
   /**
+   * Main → renderer push: fires on native `enter-full-screen` /
+   * `leave-full-screen` for the main window. The renderer toggles
+   * `<html data-fullscreen>` so the macOS traffic-light inset collapses
+   * in fullscreen (the OS hides the stoplights there). Returns an
+   * unsubscribe function.
+   */
+  onWindowFullscreen?: (
+    callback: (isFullScreen: boolean) => void,
+  ) => () => void;
+  /**
    * Main → renderer push: fires when the user invokes the app's
    * "Settings…" menu item. The main-window shell subscribes and
    * switches its main view to the Settings overlay. Returns an

--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -37,6 +37,9 @@ const desktopApi = (
           density: DesktopAppearanceDensity;
         }) => void,
       ) => () => void;
+      onWindowFullscreen?: (
+        callback: (isFullScreen: boolean) => void,
+      ) => () => void;
       platform?: string;
     };
   }
@@ -50,6 +53,21 @@ const unsubscribeAppearance = desktopApi?.onAppearanceChanged?.(
       resolveTheme(appearance.theme),
       appearance.density,
     );
+  },
+);
+
+// Mirror native fullscreen state onto <html data-fullscreen>. macOS hides
+// the traffic-light stoplights in fullscreen, so app.css reads this to
+// drop the reserved stoplight inset that would otherwise leave a dead gap
+// at the left of the masthead. Only the main window ever fires this (aux
+// windows are not fullscreenable); the listener is harmless elsewhere.
+const unsubscribeFullscreen = desktopApi?.onWindowFullscreen?.(
+  (isFullScreen) => {
+    if (isFullScreen) {
+      document.documentElement.setAttribute("data-fullscreen", "true");
+    } else {
+      document.documentElement.removeAttribute("data-fullscreen");
+    }
   },
 );
 
@@ -71,6 +89,7 @@ const importMetaHot = (
 if (importMetaHot) {
   importMetaHot.dispose(() => {
     unsubscribeAppearance?.();
+    unsubscribeFullscreen?.();
     performancePruning?.stop();
   });
 }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -473,6 +473,14 @@ textarea,
   padding-left: 96px;
 }
 
+/* In macOS fullscreen the stoplights are gone, so the wordmark no longer
+   needs to clear them. Fall back to the base 14px inset (the value every
+   non-macOS platform uses) so the breadcrumb sits flush with the rest of
+   the header instead of floating 96px in from the edge. */
+:root[data-platform="darwin"][data-fullscreen="true"] .thread-header__masthead {
+  padding-left: 14px;
+}
+
 /* Windows custom title-bar strip (File / View / Profiles / Window / Help).
    Frameless WCO draws the OS caption buttons at the top-right; this strip
    fills the rest of that line with the painted menu bar (left) and a draggable
@@ -719,6 +727,13 @@ textarea,
    platform (Linux normal frame; Windows frameless with caption buttons on
    the right, never the left) starts the brand at the left edge. */
 :root[data-platform]:not([data-platform="darwin"]) .sidebar__masthead {
+  padding-left: 0;
+}
+
+/* macOS fullscreen hides the stoplights entirely, so the 80px reservation
+   becomes a dead gap. Drop it to the left edge — same as every non-macOS
+   platform — for as long as the window stays fullscreen. */
+:root[data-platform="darwin"][data-fullscreen="true"] .sidebar__masthead {
   padding-left: 0;
 }
 
@@ -4524,6 +4539,13 @@ textarea,
 
 :root[data-platform]:not([data-platform="darwin"]):not([data-platform="win32"])
   .settings-nav__masthead {
+  padding-left: 0;
+}
+
+/* macOS fullscreen drops the stoplights, so the Settings nav masthead
+   collapses its 80px reservation to the left edge too — mirrors the main
+   `.sidebar__masthead` fullscreen behavior so the two screens stay aligned. */
+:root[data-platform="darwin"][data-fullscreen="true"] .settings-nav__masthead {
   padding-left: 0;
 }
 

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -204,6 +204,14 @@ export const IMAGE_UPLOAD_NORMALIZATION_LOG_CHANNEL =
   "image-upload:normalization-log";
 export const PRELOAD_LOG_CHANNEL = "preload:log";
 export const WINDOW_FOCUS_SYNC_CHANNEL = "window:focus-sync";
+/**
+ * Main → renderer push: fired on `enter-full-screen` / `leave-full-screen`
+ * for the main window. macOS hides the traffic-light stoplights in native
+ * fullscreen, so the renderer toggles `<html data-fullscreen>` to drop the
+ * reserved stoplight inset (the dead gap that would otherwise remain where
+ * the lights used to be).
+ */
+export const WINDOW_FULLSCREEN_SYNC_CHANNEL = "window:fullscreen-sync";
 export const WINDOW_POINTER_SNAPSHOT_CHANNEL = "window:pointer-snapshot";
 /**
  * Main → renderer push: fired when the user invokes File → New Thread


### PR DESCRIPTION
## Summary

- macOS hides the traffic-light stoplights in native fullscreen, but the renderer reserves a fixed left inset for them — leaving a dead gap at the left of the masthead once the lights vanish (visible whether the left bar is shown or hidden).
- Forward the **main** window's `enter-full-screen` / `leave-full-screen` events to the renderer via a new `WINDOW_FULLSCREEN_SYNC_CHANNEL` (mirroring the existing `window-focus-sync` pattern), toggle `<html data-fullscreen>`, and collapse the `.sidebar__masthead`, `.thread-header__masthead`, and `.settings-nav__masthead` insets to the window edge while fullscreen.
- Stop secondary windows (Changelog / License / Logs / Activity) from going fullscreen on macOS: set `fullscreenable: false` so the green traffic light reverts to a **windowed Zoom** instead of taking over its own Space, keeping `maximizable: true` so the button stays live rather than greying out.

## Verification

- `pnpm --filter @pwragent/desktop run typecheck` ✓
- `pnpm lint:boundaries` (no violations) ✓, `pnpm lint:colors` ✓
- `auxiliary-window-chrome.test.ts` — 9 passed, incl. new tests locking the darwin `fullscreenable: false` / `maximizable: true` shape and the Linux no-op ✓
- `theme-contract.test.tsx` — 37 passed (CSS still parses; brand/token contract intact) ✓
- Manually verified on macOS: main-window fullscreen no longer leaves the stoplight gap (both left bar shown and hidden); secondary windows green-button now does a windowed zoom instead of fullscreen.

## Notes

- There's no pure-CSS way for the renderer to detect *native* macOS fullscreen, so the authoritative signal comes from the main process over IPC — the established pattern in this codebase.
- Sync is attached to the main window only. Secondary windows can no longer fullscreen, so their `.activity-titlebar` inset can never strand and needs no change.
- Scoped to macOS (`data-platform="darwin"` / `process.platform === "darwin"`); Windows (WCO) and Linux chrome are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)