### PR TITLE
fix(messaging): reconcile stale waiting turns

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2641,6 +2641,9 @@ describe("DesktopBackendRegistry", () => {
       },
     ]);
     expect(cancelledSessions).toEqual(["session-1"]);
+    await waitForCondition(() =>
+      emittedEvents.some((event) => event.notification.method === "thread/name/updated"),
+    );
     expect(emittedEvents.map((event) => event.notification.method)).toEqual([
       "turn/started",
       "thread/name/updated",

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -7064,6 +7064,52 @@ describe("MessagingController", () => {
     });
   });
 
+  it("does not steer a queued follow-up into a waiting turn after the backend is idle", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+
+    await harness.controller.handleInboundEvent(buildTextEvent("start the task"));
+    await harness.controller.handleBackendPendingRequest("codex", {
+      method: "item/commandExecution/requestApproval",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        requestId: "approval-1",
+        prompt: "Run tests?",
+        command: "pnpm test",
+      },
+    });
+    await harness.controller.handleInboundEvent(buildTextEvent("also check the logs"));
+    const queuedNotice = harness.delivered
+      .filter((intent) => intent.kind === "confirmation" && intent.title === "Message queued")
+      .at(-1);
+    if (!queuedNotice || !("actions" in queuedNotice)) {
+      throw new Error("Queued notice was not delivered");
+    }
+    const queuedActions = Array.isArray(queuedNotice.actions)
+      ? queuedNotice.actions
+      : [];
+    const steerAction = queuedActions.find((action) =>
+      action.id.startsWith("queued-turn:steer:"),
+    );
+    expect(steerAction).toBeDefined();
+    harness.steerTurn.mockClear();
+    harness.readThreadStatus.mockResolvedValue("idle");
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: steerAction!.id,
+      }),
+    );
+
+    expect(harness.steerTurn).not.toHaveBeenCalled();
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "error",
+      title: "Steer unavailable",
+      body: expect.stringContaining("There is no active turn available to steer"),
+    });
+  });
+
   it("routes completed assistant output to active thread bindings", async () => {
     const harness = await createHarness();
     await harness.controller.handleInboundEvent(
@@ -9056,6 +9102,125 @@ describe("MessagingController", () => {
     });
   });
 
+  it("does not resurrect waiting when a delayed approval arrives after the backend is idle", async () => {
+    const harness = await createHarness();
+    harness.startTurn
+      .mockResolvedValueOnce({
+        backend: "codex",
+        threadId: "thread-1",
+        turnId: "turn-1",
+      })
+      .mockResolvedValueOnce({
+        backend: "codex",
+        threadId: "thread-1",
+        turnId: "turn-2",
+      });
+    await bindThread(harness);
+    await harness.controller.handleInboundEvent(buildTextEvent("run a command"));
+    harness.readThreadStatus.mockResolvedValueOnce("active").mockResolvedValue("idle");
+    harness.delivered.length = 0;
+
+    await harness.controller.handleBackendPendingRequest("codex", {
+      method: "item/commandExecution/requestApproval",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        requestId: "approval-1",
+        prompt: "Run tests?",
+        command: "pnpm test",
+      },
+    });
+
+    expect(harness.delivered).toEqual([
+      expect.objectContaining({
+        kind: "approval",
+      }),
+      expect.objectContaining({
+        kind: "activity",
+        activity: "typing",
+        state: "idle",
+      }),
+      expect.objectContaining({
+        kind: "approval",
+        body: expect.stringContaining("Response Received: Resolved"),
+        decisions: [],
+      }),
+    ]);
+    expect(harness.delivered).not.toContainEqual(
+      expect.objectContaining({
+        kind: "status",
+        status: "waiting",
+      }),
+    );
+
+    await harness.controller.handleInboundEvent(buildTextEvent("next message"));
+
+    expect(harness.startTurn).toHaveBeenCalledTimes(2);
+    expect(harness.startTurn).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        input: [{ type: "text", text: "next message" }],
+      }),
+    );
+    expect(harness.delivered).not.toContainEqual(
+      expect.objectContaining({
+        kind: "confirmation",
+        title: "Message queued",
+      }),
+    );
+  });
+
+  it("starts queued follow-ups when a delayed approval first observes the backend is idle", async () => {
+    const harness = await createHarness();
+    harness.startTurn
+      .mockResolvedValueOnce({
+        backend: "codex",
+        threadId: "thread-1",
+        turnId: "turn-1",
+      })
+      .mockResolvedValueOnce({
+        backend: "codex",
+        threadId: "thread-1",
+        turnId: "turn-2",
+      });
+    await bindThread(harness);
+    await harness.controller.handleInboundEvent(buildTextEvent("run a command"));
+    await harness.controller.handleInboundEvent(buildTextEvent("queued follow-up"));
+    const queuedNotice = harness.delivered
+      .filter((intent) => intent.kind === "confirmation" && intent.title === "Message queued")
+      .at(-1);
+    expect(queuedNotice).toMatchObject({
+      kind: "confirmation",
+      title: "Message queued",
+      body: expect.stringContaining("> queued follow-up"),
+    });
+    harness.readThreadStatus.mockResolvedValue("idle");
+    harness.delivered.length = 0;
+
+    await harness.controller.handleBackendPendingRequest("codex", {
+      method: "item/commandExecution/requestApproval",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        requestId: "approval-1",
+        prompt: "Run tests?",
+        command: "pnpm test",
+      },
+    });
+
+    expect(harness.startTurn).toHaveBeenCalledTimes(2);
+    expect(harness.startTurn).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        input: [{ type: "text", text: "queued follow-up" }],
+      }),
+    );
+    expect(harness.delivered).toContainEqual(
+      expect.objectContaining({
+        kind: "confirmation",
+        body: "Queued message sent as the next turn.",
+      }),
+    );
+  });
+
   it("submits approval callbacks through the backend bridge", async () => {
     const harness = await createHarness();
     await harness.controller.handleInboundEvent(
@@ -9135,6 +9300,43 @@ describe("MessagingController", () => {
         kind: "activity",
         activity: "typing",
         state: "active",
+      }),
+    ]);
+  });
+
+  it("retires approval callbacks without submitting when the backend turn is already idle", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+    await harness.controller.handleInboundEvent(buildTextEvent("run a command"));
+    await harness.controller.handleBackendPendingRequest("codex", {
+      method: "item/commandExecution/requestApproval",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        requestId: "approval-1",
+        prompt: "Run tests?",
+        command: "pnpm test",
+      },
+    });
+    harness.delivered.length = 0;
+    harness.submitServerRequest.mockClear();
+    harness.readThreadStatus.mockResolvedValue("idle");
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "approval:accept" }),
+    );
+
+    expect(harness.submitServerRequest).not.toHaveBeenCalled();
+    expect(harness.delivered).toEqual([
+      expect.objectContaining({
+        kind: "activity",
+        activity: "typing",
+        state: "idle",
+      }),
+      expect.objectContaining({
+        kind: "approval",
+        body: expect.stringContaining("Response Received: Resolved"),
+        decisions: [],
       }),
     ]);
   });

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -1058,15 +1058,39 @@ export class MessagingController {
         now: this.now(),
         threadId: request.params.threadId,
       });
+      if (request.params.turnId) {
+        const threadStatus = await this.readBackendThreadStatus(binding);
+        if (threadStatus === "idle") {
+          await this.reconcileIdleTurnAndStartNext(binding, "pending_request");
+          continue;
+        }
+      }
       const pendingIntent = await this.storePendingIntent(intent, binding);
       const delivery = await this.deliver(intent, binding);
+      let deliveredPendingIntent = pendingIntent;
       if (delivery.surface) {
-        await this.options.store.upsertPendingIntent({
+        deliveredPendingIntent = {
           ...pendingIntent,
           surface: delivery.surface,
-        });
+        };
+        await this.options.store.upsertPendingIntent(deliveredPendingIntent);
       }
       if (request.params.turnId) {
+        const reconciledTurn = await this.reconcileActiveTurnFromBackendStatus(
+          binding,
+          "pending_request",
+        );
+        if (isTerminalTurnLifecycle(reconciledTurn)) {
+          await this.retireStalePendingIntent(deliveredPendingIntent);
+          await this.startNextQueuedTurn(binding);
+          continue;
+        }
+        const threadStatus = await this.readBackendThreadStatus(binding);
+        if (threadStatus === "idle") {
+          await this.retireStalePendingIntent(deliveredPendingIntent);
+          await this.reconcileIdleTurnAndStartNext(binding, "pending_request");
+          continue;
+        }
         const activeTurn: MessagingActiveTurnSummary = {
           turnId: request.params.turnId,
           status: "waiting",
@@ -1826,19 +1850,15 @@ export class MessagingController {
       return true;
     }
 
-    const activeTurn = this.getActiveTurn(binding);
+    const activeTurn = await this.reconcileActiveTurnFromBackendStatus(
+      binding,
+      "turn_admission",
+    );
     if (activeTurn && ["working", "waiting"].includes(activeTurn.status)) {
       return true;
     }
 
-    if (!this.options.backend.readThreadStatus) {
-      return false;
-    }
-
-    const threadStatus = await this.options.backend.readThreadStatus({
-      backend: binding.backend,
-      threadId: binding.threadId,
-    });
+    const threadStatus = await this.readBackendThreadStatus(binding);
     return threadStatus === "active";
   }
 
@@ -1992,7 +2012,10 @@ export class MessagingController {
       return;
     }
 
-    const activeTurn = this.getActiveTurn(entry.binding);
+    const activeTurn = await this.reconcileActiveTurnFromBackendStatus(
+      entry.binding,
+      "queued_turn_steer",
+    );
     if (
       !this.options.backend.steerTurn ||
       !activeTurn ||
@@ -2190,6 +2213,9 @@ export class MessagingController {
         (candidate) => candidate.id === (event.actionId ?? event.interaction.id),
       );
       if (action && pendingIntent.intent.kind === "approval") {
+        if (await this.retireApprovalCallbackIfBackendIdle(pendingIntent, event)) {
+          return;
+        }
         const decision = await this.submitApprovalAction(
           pendingIntent.intent,
           action.id,
@@ -9305,16 +9331,12 @@ export class MessagingController {
     const activeTurn = this.getActiveTurn(binding);
     if (
       !activeTurn ||
-      activeTurn.status !== "working" ||
-      !this.options.backend.readThreadStatus
+      !["working", "waiting"].includes(activeTurn.status)
     ) {
       return activeTurn;
     }
 
-    const threadStatus = await this.options.backend.readThreadStatus({
-      backend: binding.backend,
-      threadId: binding.threadId,
-    });
+    const threadStatus = await this.readBackendThreadStatus(binding);
     if (threadStatus !== "idle") {
       return activeTurn;
     }
@@ -9336,6 +9358,57 @@ export class MessagingController {
       reason: `${reason}:thread_status_idle`,
     });
     return completedTurn;
+  }
+
+  private async retireApprovalCallbackIfBackendIdle(
+    pendingIntent: MessagingPendingIntentRecord,
+    event: MessagingInboundCallbackEvent,
+  ): Promise<boolean> {
+    const binding = pendingIntent.bindingId
+      ? await this.options.store.getBinding(pendingIntent.bindingId)
+      : undefined;
+    const turnId = pendingIntent.intent.requestContext?.turnId;
+    if (!binding || binding.revokedAt || !turnId) {
+      return false;
+    }
+
+    const threadStatus = await this.readBackendThreadStatus(binding);
+    if (threadStatus !== "idle") {
+      return false;
+    }
+
+    await this.reconcileActiveTurnFromBackendStatus(
+      binding,
+      "pending_request.submitted",
+    );
+    await this.options.store.deletePendingIntent(pendingIntent.id);
+    await this.retireApprovalIntent(pendingIntent, event, "Resolved");
+    await this.startNextQueuedTurn(binding);
+    return true;
+  }
+
+  private async reconcileIdleTurnAndStartNext(
+    binding: MessagingBindingRecord,
+    reason: string,
+  ): Promise<void> {
+    await this.reconcileActiveTurnFromBackendStatus(binding, reason);
+    await this.startNextQueuedTurn(binding);
+  }
+
+  private async retireStalePendingIntent(
+    pendingIntent: MessagingPendingIntentRecord,
+  ): Promise<void> {
+    await this.options.store.deletePendingIntent(pendingIntent.id);
+    await this.retireApprovalIntent(pendingIntent, undefined, "Resolved");
+  }
+
+  private async readBackendThreadStatus(
+    binding: MessagingBindingRecord,
+  ): Promise<string | undefined> {
+    return await this.options.backend.readThreadStatus?.({
+      backend: binding.backend,
+      threadId: binding.threadId,
+    });
   }
 
   private getActiveTurn(


### PR DESCRIPTION
## Summary

- Telegram messaging no longer treats a stale `waiting` turn as active after the backend has already gone idle.
- Delayed approval prompts are retired instead of resurrecting a dead turn and intercepting the next user message.
- Queued follow-up Steer actions re-check backend state before calling `turn/steer`, so they fail locally as unavailable instead of producing a JSON-RPC `no active turn to steer` error.
- Stale approval button callbacks also re-check backend state before submitting, so old buttons retire cleanly instead of sending decisions to a dead turn.
- When stale-idle reconciliation completes the old turn, queued follow-ups are drained immediately so later messages cannot jump ahead of the queue.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts -t "starts ACP sessions, prompts them, reads replay, and cancels turns"`
- `pnpm --filter @pwragent/desktop typecheck`

## Notes

- I reproduced this from the Telegram thread state mismatch: messaging showed turn `waiting`, while Codex rejected Steer because the app-server had no active turn.
- I added a failing callback regression after opening the PR: before the fix, clicking an old Approve button still called `submitServerRequest` even when backend status was idle.
- I addressed review feedback that stale-idle reconciliation could strand queued follow-ups by adding a failing queued-drain regression and draining the queue after idle reconciliation.
- Windows CI failed in `backend-registry.test.ts` because an async `thread/name/updated` event had not landed before a fixed order assertion; the test now waits for that event before asserting the order.
- `pnpm install` was run first because this worktree was missing workspace package links.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
