### PR TITLE
test(desktop): make hot-cpu-profiler sampling-pause test deterministic

### DIFF
--- a/apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts
@@ -358,6 +358,17 @@ describe("RendererHotCpuProfiler", () => {
       await vi.advanceTimersByTimeAsync(config.intervalMs);
       await vi.waitFor(() => expect(getAppMetrics).toHaveBeenCalledTimes(4));
 
+      // Stop the profiler BEFORE asserting the sample file. The sampler is a
+      // self-rescheduling setTimeout loop, and `vi.waitFor` advances fake
+      // timers between retries — so a `waitFor(() => toHaveLength(4))` against
+      // a still-running loop drives the loop forward each retry, growing the
+      // file past 4 and never settling (the CI flake: "expected length 4, got
+      // 23"). `stop()` clears the interval timer and latches `stopped`, after
+      // which `scheduleNextSample` no-ops, freezing the count at the 4 samples
+      // already confirmed via getAppMetrics above. It's idempotent, so the
+      // `finally` stop below is a safe no-op.
+      await profiler.stop("test-complete");
+
       let samples: Array<Record<string, unknown>> = [];
       await vi.waitFor(async () => {
         samples = (await fs.readFile(sessionResult.session.samplesPath, "utf8"))


### PR DESCRIPTION
## Summary

The `renderer-hot-cpu-profiler.test.ts` > "pauses process metric sampling while the renderer CPU profiler is active" test was flaky on CI — it intermittently failed with `AssertionError: expected [...] to have a length of 4 but got 23`. It passes reliably locally (could not reproduce in 16+ runs, even under added CPU load), which pointed at a CI-load-sensitive harness race rather than a product bug.

**Root cause:** the profiler's metric sampler is a *self-rescheduling* `setTimeout` loop (`captureSample` reschedules itself in its `finally`), and `vi.waitFor` advances fake timers between retries. The final assertion —

```ts
await vi.waitFor(() => expect(samples).toHaveLength(4));
```

— ran while that loop was still active. `getAppMetrics` was already confirmed at exactly 4 immediately above (that `waitFor` passed in the CI failure), but each `waitFor` retry on the file then advanced fake timers, fired another sample, and appended another line. Because the count only grows, `toHaveLength(4)` can never settle once it overshoots — it times out reporting whatever inflated count it reached (23). Locally `waitFor` finds 4 before extra ticks fire; CI contention widens the window.

**Fix:** stop the profiler *before* asserting the sample file. `stop()` clears the interval timer and latches `stopped`, after which `scheduleNextSample` no-ops — so the sample count is frozen at the 4 already confirmed via `getAppMetrics`, and overshoot is structurally impossible rather than timing-dependent. `stop()` is idempotent (early-returns when already stopped), so the test's existing `finally` stop is a safe no-op. No production code changes; the assertions (exactly 4 samples + last-sample content) are preserved.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts` — 13/13, run 5× consecutively, all green.
- Reproduction attempt (16 runs under 4 background CPU-spinners) passed 16/16 before *and* after — confirms it's a rare CI-only race; the fix removes the mechanism that allows overshoot rather than relying on timing.

## Notes

- Surfaced while driving an unrelated PR (#769) through CI, where this flake blocked the `Test` job; cleared on re-run. Splitting the fix out so it lands independently and stops intermittently blocking other PRs.
- Considered relaxing the assertion to "no new samples during the paused window," but the exact-count + content check is worth keeping; freezing the loop before the read preserves that intent deterministically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)