### PR TITLE
fix(desktop): hide retired Codex 5.3 models

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -22,6 +22,7 @@ import type {
   BackendAccountSummary,
   BackendAcpRuntimeOptionSource,
   BackendAcpSessionRuntimeState,
+  BackendModelOption,
   BackendRateLimitSummary,
   CodexThreadEnvironmentRuntime,
   LinkedDirectorySummary,
@@ -703,6 +704,14 @@ async function waitForDetachedActionRunToExit(
   }, true);
 }
 
+const TEST_TASK_MONITOR_MODELS: BackendModelOption[] = [
+  {
+    id: "gpt-5.4-mini",
+    label: "GPT-5.4-Mini",
+    supportsReasoning: true,
+  },
+];
+
 class MockBackendClient {
   private readonly listeners = new Set<
     (notification: AppServerNotification) => void | Promise<void>
@@ -770,6 +779,10 @@ class MockBackendClient {
     threadId: string;
     target: AppServerReviewTarget;
     delivery?: "inline" | "detached";
+    model?: string;
+    serviceTier?: string | null;
+    reasoningEffort?: string;
+    fastMode?: boolean;
     cwd?: string;
     codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
   };
@@ -1640,11 +1653,6 @@ describe("DesktopBackendRegistry", () => {
             {
               id: "gpt-5.4-mini",
               label: "GPT-5.4-Mini",
-              supportsReasoning: true,
-            },
-            {
-              id: "gpt-5.3-codex",
-              label: "GPT-5.3-Codex",
               supportsReasoning: true,
             },
             {
@@ -6420,8 +6428,8 @@ script = "echo setup"
         initializeResult: { methods: ["thread/start"] },
         models: [
           {
-            id: "gpt-5.3-codex",
-            label: "GPT-5.3 Codex",
+            id: "gpt-5.4",
+            label: "GPT-5.4",
             supportsFast: true,
             supportsReasoning: true,
           },
@@ -6435,13 +6443,13 @@ script = "echo setup"
           backend: "codex",
           executionMode: "full-access",
           workMode: "local",
-          model: "gpt-5.3-codex",
+          model: "gpt-5.4",
           reasoningEffort: "high",
           fastMode: true,
           providerSettings: {
             codex: {
               executionMode: "full-access",
-              model: "gpt-5.3-codex",
+              model: "gpt-5.4",
               reasoningEffort: "high",
               fastMode: true,
             },
@@ -6485,14 +6493,14 @@ script = "echo setup"
       backend: "codex",
       executionMode: "full-access",
       fastMode: true,
-      model: "gpt-5.3-codex",
+      model: "gpt-5.4",
       reasoningEffort: "high",
     });
     expect(codex.launchpad).toMatchObject({
       backend: "codex",
       executionMode: "full-access",
       fastMode: true,
-      model: "gpt-5.3-codex",
+      model: "gpt-5.4",
       reasoningEffort: "high",
     });
 
@@ -7002,6 +7010,14 @@ script = "pnpm install"
         serverInfo: { name: "Codex App Server", version: "1.0.0" },
         methods: ["thread/start", "review/start"],
       },
+      models: [
+        {
+          id: "gpt-5.4",
+          label: "GPT-5.4",
+          supportsFast: true,
+          supportsReasoning: true,
+        },
+      ],
     });
     const overlayStore = createOverlayStoreMock();
     const registry = new DesktopBackendRegistry({
@@ -10705,6 +10721,15 @@ command = "pnpm dev"
   it("passes persisted Codex environment hydration when starting reviews", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["review/start"] },
+      models: [
+        {
+          id: "gpt-5.5",
+          label: "GPT-5.5",
+          current: true,
+          supportsFast: true,
+          supportsReasoning: true,
+        },
+      ],
     });
     const codexEnvironmentRuntime: CodexThreadEnvironmentRuntime = {
       environmentId: "env",
@@ -10760,6 +10785,44 @@ command = "pnpm dev"
       serviceTier: "priority",
       fastMode: true,
     });
+
+    await registry.close();
+  });
+
+  it("rejects Codex reviews with a selected model that is not in the discovered model list", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["review/start"] },
+      models: [
+        {
+          id: "gpt-5.5",
+          label: "GPT-5.5",
+          current: true,
+          supportsFast: true,
+          supportsReasoning: true,
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await expect(
+      registry.startReview({
+        backend: "codex",
+        threadId: "thread-1",
+        target: { type: "baseBranch", branch: "main" },
+        delivery: "inline",
+        model: "gpt-5.3-codex",
+        reasoningEffort: "high",
+      }),
+    ).rejects.toThrow(
+      "Selected review model is not available for codex: gpt-5.3-codex",
+    );
+    expect(codexClient.lastStartReviewParams).toBeUndefined();
 
     await registry.close();
   });
@@ -12574,6 +12637,7 @@ command = "pnpm dev"
   it("creates task monitor delegations for active Codex turns", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start"] },
+      models: TEST_TASK_MONITOR_MODELS,
       startThreadResult: { threadId: "monitor-thread" },
     });
     const registry = new DesktopBackendRegistry({
@@ -12688,6 +12752,7 @@ command = "pnpm dev"
   it("tracks managed task monitor turns as in-progress quit work", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start"] },
+      models: TEST_TASK_MONITOR_MODELS,
       startThreadResult: { threadId: "monitor-thread" },
     });
     const registry = new DesktopBackendRegistry({
@@ -12771,6 +12836,7 @@ command = "pnpm dev"
   it("rejects task monitor delegations that only reference a parent Codex exec session", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start"] },
+      models: TEST_TASK_MONITOR_MODELS,
       startThreadResult: { threadId: "monitor-thread" },
     });
     const registry = new DesktopBackendRegistry({
@@ -12835,6 +12901,7 @@ command = "pnpm dev"
   it("allows external numeric session ids in task monitor delegations", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start"] },
+      models: TEST_TASK_MONITOR_MODELS,
       startThreadResult: { threadId: "monitor-thread" },
     });
     const registry = new DesktopBackendRegistry({
@@ -12886,6 +12953,7 @@ command = "pnpm dev"
   it("inherits Codex environment runtime and Full Access for managed task monitors", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start"] },
+      models: TEST_TASK_MONITOR_MODELS,
       startThreadResult: { threadId: "monitor-thread" },
     });
     const codexEnvironmentRuntime: CodexThreadEnvironmentRuntime = {
@@ -13033,6 +13101,7 @@ command = "pnpm dev"
   it("injects task monitor progress without waking the parent and completes with one parent turn", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start"] },
+      models: TEST_TASK_MONITOR_MODELS,
       startThreadResult: { threadId: "monitor-thread" },
     });
     const overlayStore = createOverlayStoreMock();
@@ -13362,6 +13431,7 @@ command = "pnpm dev"
   it("recovers an ended monitor turn once before synthesizing fallback completion", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start"] },
+      models: TEST_TASK_MONITOR_MODELS,
       startThreadResult: { threadId: "monitor-thread" },
     });
     const registry = new DesktopBackendRegistry({
@@ -13536,6 +13606,7 @@ command = "pnpm dev"
   it("interrupts stale active monitors before fallback completion", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start"] },
+      models: TEST_TASK_MONITOR_MODELS,
       startThreadResult: { threadId: "monitor-thread" },
     });
     const registry = new DesktopBackendRegistry({
@@ -13708,6 +13779,7 @@ command = "pnpm dev"
   it("rejects task monitor updates from a different monitor thread after binding", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start"] },
+      models: TEST_TASK_MONITOR_MODELS,
       startThreadResult: { threadId: "monitor-thread-1" },
     });
     const registry = new DesktopBackendRegistry({

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -10791,7 +10791,7 @@ command = "pnpm dev"
 
   it("rejects Codex reviews with a selected model that is not in the discovered model list", async () => {
     const codexClient = new MockBackendClient({
-      initializeResult: { methods: ["review/start"] },
+      initializeResult: { methods: ["turn/start", "review/start"] },
       models: [
         {
           id: "gpt-5.5",
@@ -10823,6 +10823,17 @@ command = "pnpm dev"
       "Selected review model is not available for codex: gpt-5.3-codex",
     );
     expect(codexClient.lastStartReviewParams).toBeUndefined();
+
+    await expect(
+      registry.startTurn({
+        backend: "codex",
+        threadId: "thread-1",
+        input: [{ type: "text", text: "Continue after rejected review" }],
+      }),
+    ).resolves.toMatchObject({ threadId: "thread-1", turnId: "turn-1" });
+    expect(codexClient.lastStartTurnParams?.input).toEqual([
+      { type: "text", text: "Continue after rejected review" },
+    ]);
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -1500,17 +1500,10 @@ describe("CodexAppServerClient", () => {
         supportsReasoning: true,
       },
       {
-        id: "gpt-5.3-codex",
-        label: "GPT-5.3-Codex",
-        current: undefined,
-        supportsReasoning: true,
-      },
-      {
         id: "gpt-5.3-codex-spark",
         label: "GPT-5.3-Codex-Spark",
         current: undefined,
         supportsReasoning: true,
-        // Spark does not accept image input — gates composer image pastes.
         supportsImage: false,
       },
       {
@@ -1522,12 +1515,12 @@ describe("CodexAppServerClient", () => {
     ]);
   });
 
-  it("marks Codex Spark as not supporting images and honors an explicit protocol flag", async () => {
+  it("keeps available Spark models image-disabled and honors an explicit image-support protocol flag", async () => {
     MockTransport.modelListResult = {
       data: [
         { id: "gpt-5.5", supportsReasoning: true },
         { id: "gpt-5.3-codex-spark", supportsReasoning: true },
-        // An explicit protocol flag wins over the name-based Spark fallback.
+        // An explicit protocol flag wins over the name-based image fallback.
         { id: "gpt-5.4", supportsReasoning: true, supports_image: false },
       ],
     };
@@ -1540,7 +1533,7 @@ describe("CodexAppServerClient", () => {
 
     // Non-Spark default leaves the flag unset ("assume supported").
     expect(byId.get("gpt-5.5")?.supportsImage).toBeUndefined();
-    // Spark name fallback blocks images.
+    // Spark is available only when Codex advertises it, and remains image-disabled.
     expect(byId.get("gpt-5.3-codex-spark")?.supportsImage).toBe(false);
     // Explicit protocol flag is honored.
     expect(byId.get("gpt-5.4")?.supportsImage).toBe(false);

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6090,12 +6090,12 @@ export class DesktopBackendRegistry {
       }
       this.reservedCodexStartThreadIds.add(params.threadId);
     }
-    const modelSettings = hasExplicitModelSettings(params)
-      ? await this.resolveReviewModelSettings(params.backend, params)
-      : {};
-
+    let modelSettings: ModelSettings = {};
     let result: { threadId: string; reviewThreadId: string; turnId: string };
     try {
+      modelSettings = hasExplicitModelSettings(params)
+        ? await this.resolveReviewModelSettings(params.backend, params)
+        : {};
       if (params.backend === "codex") {
         await this.flushQueuedExecutionModeIfPresent(params.threadId);
       }

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -898,12 +898,6 @@ const OPENAI_FALLBACK_MODELS: BackendModelOption[] = [
     supportsSteering: true,
   },
   {
-    id: "gpt-5.3-codex",
-    label: "GPT-5.3-Codex",
-    supportsReasoning: true,
-    supportsSteering: true,
-  },
-  {
     id: "gpt-5.2",
     label: "GPT-5.2",
     supportsReasoning: true,
@@ -2054,10 +2048,16 @@ function dedupeModelOptions(
 function buildLaunchpadOptions(
   backend: AppServerBackendKind,
   models: BackendModelOption[],
+  options: { allowFallbackModels?: boolean } = {},
 ): BackendLaunchpadOptions | undefined {
+  const allowFallbackModels = options.allowFallbackModels ?? true;
   const normalizedModels = dedupeModelOptions(
     backend,
-    models.length > 0 ? models : getBackendFallbackModels(backend),
+    models.length > 0
+      ? models
+      : allowFallbackModels
+        ? getBackendFallbackModels(backend)
+        : [],
   );
   if (normalizedModels.length === 0) {
     return undefined;
@@ -6091,7 +6091,7 @@ export class DesktopBackendRegistry {
       this.reservedCodexStartThreadIds.add(params.threadId);
     }
     const modelSettings = hasExplicitModelSettings(params)
-      ? await this.resolveModelSettings(params.backend, params)
+      ? await this.resolveReviewModelSettings(params.backend, params)
       : {};
 
     let result: { threadId: string; reviewThreadId: string; turnId: string };
@@ -8404,6 +8404,37 @@ export class DesktopBackendRegistry {
       await this.getBackendLaunchpadOptions(backend, callerReason),
       settings,
     );
+  }
+
+  private async resolveReviewModelSettings(
+    backend: AppServerBackendKind,
+    settings: ModelSettings,
+  ): Promise<ModelSettings> {
+    if (isAcpBackendId(backend)) {
+      return await this.resolveModelSettings(backend, settings, "review-start");
+    }
+
+    const models =
+      backend === "codex"
+        ? await this.readCodexDefaultModelsOnce("review-start")
+        : await this.readGrokDefaultModelsOnce("review-start");
+    const launchpadOptions = buildLaunchpadOptions(backend, models, {
+      allowFallbackModels: false,
+    });
+    const availableModels = launchpadOptions?.models ?? [];
+    if (
+      settings.model !== undefined &&
+      !availableModels.some((model) => model.id === settings.model)
+    ) {
+      const available = availableModels.map((model) => model.id).join(", ");
+      throw new Error(
+        available
+          ? `Selected review model is not available for ${backend}: ${settings.model}. Available models: ${available}`
+          : `Selected review model is not available for ${backend}: ${settings.model}. Model discovery returned no available models.`,
+      );
+    }
+
+    return resolveModelSettingsFromOptions(backend, launchpadOptions, settings);
   }
 
   private async resolveLaunchpadBackend(
@@ -11376,7 +11407,10 @@ export class DesktopBackendRegistry {
     const requestedReasoningEffort = normalizePreferredMonitorReasoningEffort(
       params.preferredReasoningEffort,
     );
-    const options = await this.getBackendLaunchpadOptions("codex", "task-monitor");
+    const discoveredModels = await this.readCodexDefaultModelsOnce("task-monitor");
+    const options = buildLaunchpadOptions("codex", discoveredModels, {
+      allowFallbackModels: false,
+    });
     const models = options?.models ?? [];
     const selectedModel =
       models.find((model) => model.id === requestedModel) ??
@@ -11385,7 +11419,13 @@ export class DesktopBackendRegistry {
       models.find((model) => model.current) ??
       models.find((model) => model.supportsReasoning) ??
       models[0];
-    const preferredModel = selectedModel?.id ?? DEFAULT_TASK_MONITOR_MODEL;
+    if (!selectedModel) {
+      throw new Error(
+        "No available Codex models were discovered for task monitor delegation.",
+      );
+    }
+
+    const preferredModel = selectedModel.id;
     const reasoningEfforts = options?.reasoningEfforts ?? OPENAI_REASONING_EFFORTS;
     const preferredReasoningEffort = reasoningEfforts.includes(
       requestedReasoningEffort,

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -96,7 +96,6 @@ const SUPPORTED_CODEX_MODEL_ORDER = [
   "gpt-5.5",
   "gpt-5.4",
   "gpt-5.4-mini",
-  "gpt-5.3-codex",
   "gpt-5.3-codex-spark",
   "gpt-5.2",
 ] as const;

--- a/apps/desktop/src/main/testing/replay-client.ts
+++ b/apps/desktop/src/main/testing/replay-client.ts
@@ -1,4 +1,5 @@
 import type {
+  AppServerBackendKind,
   AppServerCollaborationModeRequest,
   AppServerListSkillsResponse,
   AppServerNotification,
@@ -8,6 +9,7 @@ import type {
   AppServerReadThreadResponse,
   AppServerThreadSummary,
   AppServerTurnInputItem,
+  BackendModelOption,
 } from "@pwragent/shared";
 import { ReplayController } from "./replay-controller";
 import {
@@ -26,6 +28,81 @@ type InitializeResult = {
   };
   methods?: string[];
 };
+
+const REPLAY_CODEX_MODELS: BackendModelOption[] = [
+  {
+    id: "gpt-5.5",
+    label: "GPT-5.5",
+    current: true,
+    supportsReasoning: true,
+    supportsFast: true,
+    supportsSteering: true,
+  },
+  {
+    id: "gpt-5.4",
+    label: "GPT-5.4",
+    supportsReasoning: true,
+    supportsFast: true,
+    supportsSteering: true,
+  },
+  {
+    id: "gpt-5.4-mini",
+    label: "GPT-5.4-Mini",
+    supportsReasoning: true,
+    supportsFast: true,
+    supportsSteering: true,
+  },
+  {
+    id: "gpt-5.2",
+    label: "GPT-5.2",
+    supportsReasoning: true,
+    supportsSteering: true,
+  },
+];
+
+const REPLAY_GROK_MODELS: BackendModelOption[] = [
+  {
+    id: "grok-4.20-reasoning",
+    label: "Grok 4.20 Reasoning",
+    current: true,
+    supportsReasoning: false,
+    supportsSteering: false,
+  },
+  {
+    id: "grok-4.20-non-reasoning",
+    label: "Grok 4.20 Non-Reasoning",
+    supportsReasoning: false,
+    supportsSteering: false,
+  },
+  {
+    id: "grok-4-1-fast-reasoning",
+    label: "Grok 4.1 Fast Reasoning",
+    supportsReasoning: false,
+    supportsFast: true,
+    supportsSteering: false,
+  },
+  {
+    id: "grok-4-1-fast-non-reasoning",
+    label: "Grok 4.1 Fast Non-Reasoning",
+    supportsReasoning: false,
+    supportsFast: true,
+    supportsSteering: false,
+  },
+  {
+    id: "grok-4-fast-reasoning",
+    label: "Grok 4 Fast Reasoning",
+    supportsReasoning: false,
+    supportsFast: true,
+    supportsSteering: false,
+  },
+  {
+    id: "grok-4-fast-non-reasoning",
+    label: "Grok 4 Fast Non-Reasoning",
+    supportsReasoning: false,
+    supportsFast: true,
+    supportsSteering: false,
+  },
+];
 
 export class ReplayClient {
   private readonly notificationListeners = new Set<
@@ -64,10 +141,13 @@ export class ReplayClient {
     turnId: string;
   }> = [];
 
-  constructor(private readonly controller: ReplayController) {}
+  constructor(
+    private readonly controller: ReplayController,
+    private readonly backend: AppServerBackendKind,
+  ) {}
 
   static fromFixture(fixture: ReplayFixture): ReplayClient {
-    return new ReplayClient(new ReplayController(fixture));
+    return new ReplayClient(new ReplayController(fixture), fixture.metadata.backend);
   }
 
   async close(): Promise<void> {
@@ -95,6 +175,11 @@ export class ReplayClient {
   }): Promise<AppServerListSkillsResponse["data"]> {
     await this.ensureInitialized();
     return asSkillList(this.controller.consumeResponse("skills/list").result);
+  }
+
+  async listModels(): Promise<BackendModelOption[]> {
+    await this.ensureInitialized();
+    return this.backend === "grok" ? REPLAY_GROK_MODELS : REPLAY_CODEX_MODELS;
   }
 
   onNotification(

--- a/apps/desktop/src/main/testing/replay-runtime.ts
+++ b/apps/desktop/src/main/testing/replay-runtime.ts
@@ -10,6 +10,7 @@ import type {
   AppServerReadThreadResponse,
   AppServerThreadSummary,
   AppServerTurnInputItem,
+  BackendModelOption,
   ThreadExecutionMode,
 } from "@pwragent/shared";
 import { ReplayClient } from "./replay-client";
@@ -126,6 +127,7 @@ type ReplayRuntimeClient = {
     cwd?: string;
     cwds?: string[];
   }): Promise<AppServerListSkillsResponse["data"]>;
+  listModels?(): Promise<BackendModelOption[]>;
   onNotification(
     listener: (notification: AppServerNotification) => void | Promise<void>
   ): () => void;
@@ -321,6 +323,9 @@ function createUnavailableReplayClient(
       throw new Error(message);
     },
     listSkills: async () => {
+      throw new Error(message);
+    },
+    listModels: async () => {
       throw new Error(message);
     },
     onNotification: () => () => undefined,


### PR DESCRIPTION
## Summary

This fixes Codex review and monitor model selection so PwrAgent no longer offers retired `gpt-5.3-codex` for spawned review/sub-agent turns.

The UI already gets the available Codex model list from the app-server protocol. This change makes the review and task-monitor paths use that same discovered model set instead of falling back to stale hard-coded Codex choices.

## Details

- Filter retired non-Spark `gpt-5.3-codex` out of Codex model options.
- Keep `gpt-5.3-codex-spark` available only when Codex advertises it, since Spark is still valid for users who have access.
- Validate explicit review model requests against the discovered backend model list before starting the review.
- Resolve task-monitor model settings from available Codex models without inventing unavailable fallback options.
- Add backend-registry and Codex client coverage for unavailable review models, monitor model fallback behavior, and Spark availability.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/codex-client.test.ts -t "filters Codex models|Spark"`
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts`
