### PR TITLE
fix(desktop): show review sub-agent usage metadata

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -10873,6 +10873,7 @@ command = "pnpm dev"
   it("persists Codex reviews as sub-agent summaries on the parent thread", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start", "review/start"] },
+      models: [{ id: "gpt-5.4-mini", supportsReasoning: true }],
       startReviewResult: {
         threadId: "thread-1",
         reviewThreadId: "thread-1",
@@ -10893,6 +10894,7 @@ command = "pnpm dev"
       threadId: "thread-1",
       target: { type: "baseBranch", branch: "main" },
       delivery: "inline",
+      model: "gpt-5.4-mini",
     });
 
     await expect
@@ -10907,6 +10909,7 @@ command = "pnpm dev"
         monitorId: "review:turn-review-1",
         monitorThreadId: "thread-1",
         monitorTurnId: "turn-review-1",
+        preferredModel: "gpt-5.4-mini",
         task: "Review changes against main",
         status: "running",
       });
@@ -10936,7 +10939,13 @@ command = "pnpm dev"
         return overlay?.subAgents?.[0]?.monitorUsage;
       })
       .toMatchObject({
-        summary: "800 uncached in · 200 cached · 50 out (10 reasoning)",
+        model: "gpt-5.4-mini",
+        summary:
+          "800 uncached in · 200 cached · 50 out (10 reasoning) · <$0.001 list price",
+        cost: {
+          model: "gpt-5.4-mini",
+          totalUsd: 0.00084,
+        },
         tokenUsage: {
           cachedInputTokens: 200,
           inputTokens: 1_000,
@@ -10983,6 +10992,7 @@ command = "pnpm dev"
   it("patches Codex review sub-agent usage when usage arrives after completion", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start", "review/start"] },
+      models: [{ id: "gpt-5.4-mini" }],
       startReviewResult: {
         threadId: "thread-1",
         reviewThreadId: "thread-1",
@@ -11003,6 +11013,7 @@ command = "pnpm dev"
       threadId: "thread-1",
       target: { type: "baseBranch", branch: "main" },
       delivery: "inline",
+      model: "gpt-5.4-mini",
     });
 
     await codexClient.emit({
@@ -11047,8 +11058,15 @@ command = "pnpm dev"
         outcome: "success",
         status: "success",
         lastMessage: "Review completed.",
+        preferredModel: "gpt-5.4-mini",
         monitorUsage: {
-          summary: "800 uncached in · 200 cached · 50 out (10 reasoning)",
+          model: "gpt-5.4-mini",
+          summary:
+            "800 uncached in · 200 cached · 50 out (10 reasoning) · <$0.001 list price",
+          cost: {
+            model: "gpt-5.4-mini",
+            totalUsd: 0.00084,
+          },
           tokenUsage: {
             cachedInputTokens: 200,
             inputTokens: 1_000,

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -11223,6 +11223,102 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("keeps Codex review usage when Codex emits a different runtime turn id", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start", "review/start"] },
+      models: [{ id: "gpt-5.5" }],
+      startReviewResult: {
+        threadId: "thread-1",
+        reviewThreadId: "thread-1",
+        turnId: "turn-review-1",
+      },
+    });
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+
+    await registry.startReview({
+      backend: "codex",
+      threadId: "thread-1",
+      target: { type: "baseBranch", branch: "main" },
+      delivery: "inline",
+      model: "gpt-5.5",
+    });
+
+    await codexClient.emit({
+      method: "turn/started",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-runtime-1",
+        turn: {
+          id: "turn-runtime-1",
+          status: "in_progress",
+        },
+      },
+    });
+
+    await codexClient.emit({
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-runtime-1",
+        tokenUsage: {
+          total: {
+            inputTokens: 170_887,
+            cachedInputTokens: 114_048,
+            outputTokens: 117,
+          },
+        },
+      },
+    });
+
+    await codexClient.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-runtime-1",
+        turn: {
+          id: "turn-runtime-1",
+          status: "completed",
+          output: [],
+        },
+      },
+    });
+
+    await expect
+      .poll(async () => {
+        const overlay = await overlayStore.getThreadOverlayState({
+          backend: "codex",
+          threadId: "thread-1",
+        });
+        return overlay?.subAgents?.[0];
+      })
+      .toMatchObject({
+        monitorId: "review:turn-review-1",
+        monitorTurnId: "turn-review-1",
+        outcome: "success",
+        status: "success",
+        monitorUsage: {
+          model: "gpt-5.5",
+          serviceTier: "standard",
+          summary:
+            "56,839 uncached in · 114,048 cached · 117 out · $0.35 list price",
+          cost: {
+            model: "gpt-5.5",
+            serviceTier: "standard",
+            totalUsd: 0.344729,
+          },
+        },
+      });
+
+    await registry.close();
+  });
+
   it("patches detached Codex review usage on the parent thread after completion", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start", "review/start"] },

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -11152,6 +11152,120 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("backfills completed Codex review usage from replay token usage activity", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start", "review/start"] },
+      models: [{ id: "gpt-5.5" }],
+      replay: {
+        entries: [
+          {
+            type: "review",
+            id: "review-turn-review-1",
+            createdAt: 1_781_365_655_000,
+            review: "Review completed.",
+            turn: {
+              id: "turn-review-1",
+              status: "completed",
+              completedAt: 1_781_365_655_000,
+            },
+          },
+          {
+            type: "activity",
+            id: "live-token-usage-turn-review-1",
+            createdAt: 1_781_365_655_100,
+            summary:
+              "Latest request usage: 56,839 uncached in · 114,048 cached · 117 out",
+            status: "completed",
+            details: [],
+            tokenUsage: {
+              inputTokens: 170_887,
+              cachedInputTokens: 114_048,
+              outputTokens: 117,
+              totalTokens: 171_004,
+            },
+            turn: {
+              id: "turn-review-1",
+              status: "completed",
+              completedAt: 1_781_365_655_000,
+            },
+          },
+        ],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+      },
+      startReviewResult: {
+        threadId: "thread-1",
+        reviewThreadId: "thread-1",
+        turnId: "turn-review-1",
+      },
+    });
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+
+    await registry.startReview({
+      backend: "codex",
+      threadId: "thread-1",
+      target: { type: "baseBranch", branch: "main" },
+      delivery: "inline",
+      model: "gpt-5.5",
+    });
+
+    await codexClient.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-review-1",
+        turn: {
+          id: "turn-review-1",
+          status: "completed",
+          completedAt: 1_781_365_655_000,
+          output: [],
+        },
+      },
+    });
+
+    await registry.readThread({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    await expect
+      .poll(async () => {
+        const overlay = await overlayStore.getThreadOverlayState({
+          backend: "codex",
+          threadId: "thread-1",
+        });
+        return overlay?.subAgents?.[0];
+      })
+      .toMatchObject({
+        monitorId: "review:turn-review-1",
+        outcome: "success",
+        status: "success",
+        monitorUsage: {
+          model: "gpt-5.5",
+          serviceTier: "standard",
+          summary:
+            "56,839 uncached in · 114,048 cached · 117 out · $0.35 list price",
+          cost: {
+            model: "gpt-5.5",
+            serviceTier: "standard",
+            totalUsd: 0.344729,
+          },
+        },
+      });
+
+    await registry.close();
+  });
+
   it("uses Codex Fast pricing for review sub-agent usage", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start", "review/start"] },

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -11223,6 +11223,170 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("records Codex review usage when usage updates omit a turn id", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start", "review/start"] },
+      models: [{ id: "gpt-5.5" }],
+      startReviewResult: {
+        threadId: "thread-1",
+        reviewThreadId: "thread-1",
+        turnId: "turn-review-1",
+      },
+    });
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+
+    await registry.startReview({
+      backend: "codex",
+      threadId: "thread-1",
+      target: { type: "baseBranch", branch: "main" },
+      delivery: "inline",
+      model: "gpt-5.5",
+    });
+
+    await codexClient.emit({
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: "thread-1",
+        tokenUsage: {
+          total: {
+            inputTokens: 170_887,
+            cachedInputTokens: 114_048,
+            outputTokens: 117,
+          },
+        },
+      },
+    } as AppServerNotification);
+
+    await codexClient.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-review-1",
+        turn: {
+          id: "turn-review-1",
+          status: "completed",
+          output: [],
+        },
+      },
+    });
+
+    await expect
+      .poll(async () => {
+        const overlay = await overlayStore.getThreadOverlayState({
+          backend: "codex",
+          threadId: "thread-1",
+        });
+        return overlay?.subAgents?.[0];
+      })
+      .toMatchObject({
+        monitorId: "review:turn-review-1",
+        outcome: "success",
+        status: "success",
+        monitorUsage: {
+          model: "gpt-5.5",
+          serviceTier: "standard",
+          summary:
+            "56,839 uncached in · 114,048 cached · 117 out · $0.35 list price",
+        },
+      });
+
+    await registry.close();
+  });
+
+  it("uses inherited Codex Fast settings when pricing review sub-agent usage", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start", "review/start"] },
+      models: [{ id: "gpt-5.4-mini", supportsFast: true }],
+      startReviewResult: {
+        threadId: "thread-1",
+        reviewThreadId: "thread-1",
+        turnId: "turn-review-1",
+      },
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          model: "gpt-5.4-mini",
+          fastMode: true,
+          serviceTier: "priority",
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+
+    await registry.startReview({
+      backend: "codex",
+      threadId: "thread-1",
+      target: { type: "baseBranch", branch: "main" },
+      delivery: "inline",
+    });
+
+    expect(codexClient.lastStartReviewParams).toMatchObject({
+      model: "gpt-5.4-mini",
+      fastMode: true,
+      serviceTier: "priority",
+    });
+
+    await codexClient.emit({
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: "thread-1",
+        tokenUsage: {
+          total: {
+            inputTokens: 1_000,
+            cachedInputTokens: 200,
+            outputTokens: 50,
+          },
+        },
+      },
+    } as AppServerNotification);
+
+    await expect
+      .poll(async () => {
+        const overlay = await overlayStore.getThreadOverlayState({
+          backend: "codex",
+          threadId: "thread-1",
+        });
+        return overlay?.subAgents?.[0];
+      })
+      .toMatchObject({
+        monitorId: "review:turn-review-1",
+        preferredFastMode: true,
+        preferredModel: "gpt-5.4-mini",
+        preferredServiceTier: "priority",
+        monitorUsage: {
+          fastMode: true,
+          model: "gpt-5.4-mini",
+          serviceTier: "priority",
+          summary: "800 uncached in · 200 cached · 50 out · $0.002 list price",
+          cost: {
+            model: "gpt-5.4-mini",
+            serviceTier: "priority",
+            totalUsd: 0.00168,
+          },
+        },
+      });
+
+    await registry.close();
+  });
+
   it("keeps Codex review usage when Codex emits a different runtime turn id", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start", "review/start"] },
@@ -17655,10 +17819,12 @@ command = "pnpm dev"
         approvalPolicy: "never",
         sandbox: "danger-full-access",
       });
-      expect(codexClient.lastStartReviewParams).toEqual({
+      expect(codexClient.lastStartReviewParams).toMatchObject({
         threadId: "thread-1",
         target: { type: "baseBranch", branch: "main" },
         delivery: "inline",
+        model: "gpt-5.5",
+        reasoningEffort: "medium",
       });
       const overlay = await overlayStore.getThreadOverlayState({
         backend: "codex",

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -11081,6 +11081,148 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("captures Codex review usage from the terminal completion payload", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start", "review/start"] },
+      models: [{ id: "gpt-5.4-mini" }],
+      startReviewResult: {
+        threadId: "thread-1",
+        reviewThreadId: "thread-1",
+        turnId: "turn-review-1",
+      },
+    });
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+
+    await registry.startReview({
+      backend: "codex",
+      threadId: "thread-1",
+      target: { type: "baseBranch", branch: "main" },
+      delivery: "inline",
+      model: "gpt-5.4-mini",
+    });
+
+    await codexClient.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-review-1",
+        turn: {
+          id: "turn-review-1",
+          status: "completed",
+          output: [],
+          tokenUsage: {
+            total: {
+              inputTokens: 1_000,
+              cachedInputTokens: 200,
+              outputTokens: 50,
+              reasoningOutputTokens: 10,
+            },
+          },
+        },
+      },
+    } as AppServerNotification);
+
+    await expect
+      .poll(async () => {
+        const overlay = await overlayStore.getThreadOverlayState({
+          backend: "codex",
+          threadId: "thread-1",
+        });
+        return overlay?.subAgents?.[0];
+      })
+      .toMatchObject({
+        monitorId: "review:turn-review-1",
+        outcome: "success",
+        status: "success",
+        lastMessage: "Review completed.",
+        monitorUsage: {
+          model: "gpt-5.4-mini",
+          summary:
+            "800 uncached in · 200 cached · 50 out (10 reasoning) · <$0.001 list price",
+        },
+      });
+
+    await registry.close();
+  });
+
+  it("uses Codex Fast pricing for review sub-agent usage", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start", "review/start"] },
+      models: [{ id: "gpt-5.4-mini", supportsFast: true }],
+      startReviewResult: {
+        threadId: "thread-1",
+        reviewThreadId: "thread-1",
+        turnId: "turn-review-1",
+      },
+    });
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+
+    await registry.startReview({
+      backend: "codex",
+      threadId: "thread-1",
+      target: { type: "baseBranch", branch: "main" },
+      delivery: "inline",
+      model: "gpt-5.4-mini",
+      fastMode: true,
+    });
+
+    await codexClient.emit({
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-review-1",
+        tokenUsage: {
+          total: {
+            inputTokens: 1_000,
+            cachedInputTokens: 200,
+            outputTokens: 50,
+          },
+        },
+      },
+    });
+
+    await expect
+      .poll(async () => {
+        const overlay = await overlayStore.getThreadOverlayState({
+          backend: "codex",
+          threadId: "thread-1",
+        });
+        return overlay?.subAgents?.[0];
+      })
+      .toMatchObject({
+        monitorId: "review:turn-review-1",
+        preferredFastMode: true,
+        preferredServiceTier: "priority",
+        monitorUsage: {
+          fastMode: true,
+          model: "gpt-5.4-mini",
+          serviceTier: "priority",
+          summary: "800 uncached in · 200 cached · 50 out · $0.002 list price",
+          cost: {
+            model: "gpt-5.4-mini",
+            serviceTier: "priority",
+            totalUsd: 0.00168,
+          },
+        },
+      });
+
+    await registry.close();
+  });
+
   it("patches detached Codex review usage on the parent thread after completion", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start", "review/start"] },

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -3291,6 +3291,13 @@ describe("CodexAppServerClient", () => {
         id: "live-token-usage-1780246301079",
         summary: "Latest request usage: 17,263 uncached in · 4,480 cached · 148 out",
         status: "completed",
+        tokenUsage: {
+          cachedInputTokens: 4_480,
+          inputTokens: 21_743,
+          outputTokens: 148,
+          reasoningOutputTokens: 0,
+          totalTokens: 21_891,
+        },
       },
     ]);
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1506,6 +1506,8 @@ type ReviewSubAgentRecord = {
   createdAt: number;
   latestUsage?: TaskMonitorUsageSnapshot;
   parentThreadId: string;
+  preferredModel?: string;
+  preferredReasoningEffort?: string;
   reviewThreadId: string;
   task: string;
   turnId: string;
@@ -6173,6 +6175,10 @@ export class DesktopBackendRegistry {
       backend: params.backend as Exclude<AppServerBackendKind, AcpBackendId>,
       createdAt: Date.now(),
       parentThreadId: result.threadId,
+      ...(modelSettings.model ? { preferredModel: modelSettings.model } : {}),
+      ...(modelSettings.reasoningEffort
+        ? { preferredReasoningEffort: modelSettings.reasoningEffort }
+        : {}),
       reviewThreadId: result.reviewThreadId || result.threadId,
       task: reviewTaskLabel(params.target),
       turnId: result.turnId,
@@ -9619,7 +9625,9 @@ export class DesktopBackendRegistry {
         notification.params.turnId,
       );
       const reviewRecord = this.activeReviewSubAgents.get(reviewKey);
+      const completedReviewRecord = this.reviewSubAgentsByReviewTurn.get(reviewKey);
       const usageSnapshot = buildTaskMonitorUsageSnapshot({
+        model: reviewRecord?.preferredModel ?? completedReviewRecord?.preferredModel,
         tokenUsage: notification.params.tokenUsage,
       });
       if (!usageSnapshot) {
@@ -9632,7 +9640,6 @@ export class DesktopBackendRegistry {
         });
         return;
       }
-      const completedReviewRecord = this.reviewSubAgentsByReviewTurn.get(reviewKey);
       const reviewUsagePersisted = await this.persistExistingReviewSubAgentUsage({
         backend: event.backend,
         parentThreadId:
@@ -9817,6 +9824,15 @@ export class DesktopBackendRegistry {
       status: patch.status ?? existing?.status ?? "running",
       createdAt: record.createdAt,
       updatedAt: patch.updatedAt ?? Date.now(),
+      ...(record.preferredModel ?? existing?.preferredModel
+        ? { preferredModel: record.preferredModel ?? existing?.preferredModel }
+        : {}),
+      ...(record.preferredReasoningEffort ?? existing?.preferredReasoningEffort
+        ? {
+            preferredReasoningEffort:
+              record.preferredReasoningEffort ?? existing?.preferredReasoningEffort,
+          }
+        : {}),
       monitorThreadId: record.reviewThreadId,
       monitorTurnId: record.turnId,
       ...(patch.lastMessage ?? existing?.lastMessage

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -2630,6 +2630,44 @@ function mergeImmutableUsageActivities(params: {
   };
 }
 
+function isReplayTokenUsageActivity(
+  entry: AppServerThreadEntry,
+): entry is AppServerThreadActivityEntry {
+  return (
+    isUsageActivityEntry(entry) &&
+    entry.tokenUsage !== undefined &&
+    usageActivityScope(entry) !== "monitor"
+  );
+}
+
+function findReviewReplayUsageActivity(params: {
+  completedAt?: number;
+  createdAt: number;
+  replay: AppServerThreadReplay;
+  turnId?: string;
+}): AppServerThreadActivityEntry | undefined {
+  const usageActivities = params.replay.entries.filter(isReplayTokenUsageActivity);
+  if (params.turnId) {
+    const exact = usageActivities.findLast(
+      (entry) => entry.turn?.id === params.turnId,
+    );
+    if (exact) {
+      return exact;
+    }
+  }
+
+  const latestAllowed = (params.completedAt ?? Date.now()) + 10_000;
+  const earliestAllowed = params.createdAt - 10_000;
+  return usageActivities
+    .filter(
+      (entry) =>
+        typeof entry.createdAt === "number" &&
+        entry.createdAt >= earliestAllowed &&
+        entry.createdAt <= latestAllowed,
+    )
+    .at(-1);
+}
+
 function extractFirstMeaningfulTextInput(input: AppServerTurnInputItem[]): string | undefined {
   const text = input
     .filter((item): item is Extract<AppServerTurnInputItem, { type: "text" }> => item.type === "text")
@@ -5345,6 +5383,13 @@ export class DesktopBackendRegistry {
           replay: replayWithEnvironment,
           activities: overlay?.immutableUsageActivities,
         });
+    if (!request.before) {
+      await this.backfillReviewSubAgentUsageFromReplay({
+        backend,
+        replay: replayWithEnvironment,
+        threadId: request.threadId,
+      });
+    }
 
     return {
       backend,
@@ -9880,6 +9925,66 @@ export class DesktopBackendRegistry {
       },
     });
     return true;
+  }
+
+  private async backfillReviewSubAgentUsageFromReplay(params: {
+    backend: AppServerBackendKind;
+    replay: AppServerThreadReplay;
+    threadId: string;
+  }): Promise<void> {
+    const overlay = await this.overlayStore.getThreadOverlayState({
+      backend: params.backend,
+      threadId: params.threadId,
+    });
+    const reviewSubAgents = overlay?.subAgents?.filter(
+      (subAgent) =>
+        subAgent.monitorId.startsWith("review:") &&
+        !subAgent.monitorUsage &&
+        (subAgent.status === "success" ||
+          subAgent.status === "failed" ||
+          subAgent.status === "cancelled"),
+    );
+    if (!reviewSubAgents?.length) {
+      return;
+    }
+
+    for (const subAgent of reviewSubAgents) {
+      const usageActivity = findReviewReplayUsageActivity({
+        completedAt: subAgent.completedAt,
+        createdAt: subAgent.createdAt,
+        replay: params.replay,
+        turnId: subAgent.monitorTurnId,
+      });
+      if (!usageActivity?.tokenUsage) {
+        continue;
+      }
+      const usage = buildReviewSubAgentUsageSnapshot({
+        existing: subAgent,
+        tokenUsage: usageActivity.tokenUsage,
+      });
+      if (!usage) {
+        continue;
+      }
+      await this.overlayStore.upsertThreadSubAgent({
+        backend: params.backend,
+        threadId: params.threadId,
+        subAgent: {
+          ...subAgent,
+          monitorUsage: usage,
+          updatedAt: Date.now(),
+        },
+      });
+      this.invalidateThreadListCache(params.backend);
+      await this.emit({
+        backend: params.backend,
+        notification: {
+          method: "thread/subAgents/updated",
+          params: {
+            threadId: params.threadId,
+          },
+        },
+      });
+    }
   }
 
   private async persistTaskMonitorSubAgent(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6197,11 +6197,8 @@ export class DesktopBackendRegistry {
       }
       this.reservedCodexStartThreadIds.add(params.threadId);
     }
-    const modelSettings = hasExplicitModelSettings(params)
-      ? await this.resolveModelSettings(params.backend, params)
-      : {};
-
     let result: { threadId: string; reviewThreadId: string; turnId: string };
+    let modelSettings: ModelSettings = {};
     try {
       if (params.backend === "codex") {
         await this.flushQueuedExecutionModeIfPresent(params.threadId);
@@ -6213,6 +6210,16 @@ export class DesktopBackendRegistry {
               threadId: params.threadId,
             })
           : undefined;
+      const requestedModelSettings: ModelSettings = {
+        ...params,
+        model: params.model ?? overlay?.model,
+        serviceTier: params.serviceTier ?? overlay?.serviceTier,
+        reasoningEffort: params.reasoningEffort ?? overlay?.reasoningEffort,
+        fastMode: params.backend === "codex" ? params.fastMode ?? overlay?.fastMode : undefined,
+      };
+      modelSettings = hasExplicitModelSettings(requestedModelSettings)
+        ? await this.resolveModelSettings(params.backend, requestedModelSettings)
+        : {};
       const cwd =
         params.backend === "codex"
           ? await this.resolveThreadEnvironmentCwd(
@@ -9733,19 +9740,33 @@ export class DesktopBackendRegistry {
       return;
     }
 
-    if (notification.params.turnId) {
-      const reviewKey = buildReviewSubAgentKey(
-        event.backend,
-        notification.params.threadId,
-        notification.params.turnId,
-      );
-      const activeReview = this.findActiveReviewSubAgentForTurn({
-        backend: event.backend,
-        threadId: notification.params.threadId,
-        turnId: notification.params.turnId,
-      });
+    const usageTurnId =
+      typeof notification.params.turnId === "string"
+        ? notification.params.turnId
+        : undefined;
+    const activeReview = usageTurnId
+      ? this.findActiveReviewSubAgentForTurn({
+          backend: event.backend,
+          threadId: notification.params.threadId,
+          turnId: usageTurnId,
+        })
+      : this.findActiveReviewSubAgentForThread({
+          backend: event.backend,
+          threadId: notification.params.threadId,
+        });
+
+    if (usageTurnId || activeReview) {
+      const reviewKey = usageTurnId
+        ? buildReviewSubAgentKey(
+            event.backend,
+            notification.params.threadId,
+            usageTurnId,
+          )
+        : undefined;
       const reviewRecord = activeReview?.record;
-      const completedReviewRecord = this.reviewSubAgentsByReviewTurn.get(reviewKey);
+      const completedReviewRecord = reviewKey
+        ? this.reviewSubAgentsByReviewTurn.get(reviewKey)
+        : undefined;
       const persistedRecord = reviewRecord ?? completedReviewRecord;
       const notificationParams = readRecord(notification.params);
       const usageModel =
@@ -9765,13 +9786,17 @@ export class DesktopBackendRegistry {
         });
         return;
       }
+      const persistedTurnId = completedReviewRecord?.turnId ?? usageTurnId;
+      if (!persistedTurnId) {
+        return;
+      }
       const reviewUsagePersisted = await this.persistExistingReviewSubAgentUsage({
         backend: event.backend,
         parentThreadId:
           completedReviewRecord?.parentThreadId ?? notification.params.threadId,
         reviewThreadId:
           completedReviewRecord?.reviewThreadId ?? notification.params.threadId,
-        turnId: completedReviewRecord?.turnId ?? notification.params.turnId,
+        turnId: persistedTurnId,
         tokenUsage: notification.params.tokenUsage,
         usageModel,
       });
@@ -10119,6 +10144,23 @@ export class DesktopBackendRegistry {
     }
 
     return undefined;
+  }
+
+  private findActiveReviewSubAgentForThread(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): { key: string; record: ReviewSubAgentRecord } | undefined {
+    let match: { key: string; record: ReviewSubAgentRecord } | undefined;
+    for (const [key, record] of this.activeReviewSubAgents.entries()) {
+      if (record.backend !== params.backend || record.reviewThreadId !== params.threadId) {
+        continue;
+      }
+      if (match) {
+        return undefined;
+      }
+      match = { key, record };
+    }
+    return match;
   }
 
   private recordTaskMonitorActivity(notification: AppServerNotification): void {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1506,8 +1506,10 @@ type ReviewSubAgentRecord = {
   createdAt: number;
   latestUsage?: TaskMonitorUsageSnapshot;
   parentThreadId: string;
+  preferredFastMode?: boolean;
   preferredModel?: string;
   preferredReasoningEffort?: string;
+  preferredServiceTier?: string;
   reviewThreadId: string;
   task: string;
   turnId: string;
@@ -1626,6 +1628,7 @@ type TaskMonitorPricingCatalogEntry = {
   inputUsdPerMillion: number;
   model: string;
   outputUsdPerMillion: number;
+  serviceTier: "standard" | "priority";
 };
 
 const TASK_MONITOR_PRICING_CATALOG: readonly TaskMonitorPricingCatalogEntry[] = [
@@ -1634,23 +1637,49 @@ const TASK_MONITOR_PRICING_CATALOG: readonly TaskMonitorPricingCatalogEntry[] = 
     inputUsdPerMillion: 5,
     cachedInputUsdPerMillion: 0.5,
     outputUsdPerMillion: 30,
+    serviceTier: "standard",
+  },
+  {
+    model: "gpt-5.5",
+    inputUsdPerMillion: 12.5,
+    cachedInputUsdPerMillion: 1.25,
+    outputUsdPerMillion: 75,
+    serviceTier: "priority",
   },
   {
     model: "gpt-5.4",
     inputUsdPerMillion: 2.5,
     cachedInputUsdPerMillion: 0.25,
     outputUsdPerMillion: 15,
+    serviceTier: "standard",
+  },
+  {
+    model: "gpt-5.4",
+    inputUsdPerMillion: 5,
+    cachedInputUsdPerMillion: 0.5,
+    outputUsdPerMillion: 30,
+    serviceTier: "priority",
   },
   {
     model: "gpt-5.4-mini",
     inputUsdPerMillion: 0.75,
     cachedInputUsdPerMillion: 0.075,
     outputUsdPerMillion: 4.5,
+    serviceTier: "standard",
+  },
+  {
+    model: "gpt-5.4-mini",
+    inputUsdPerMillion: 1.5,
+    cachedInputUsdPerMillion: 0.15,
+    outputUsdPerMillion: 9,
+    serviceTier: "priority",
   },
 ];
 
 function buildTaskMonitorUsageSnapshot(params: {
+  fastMode?: boolean;
   model?: string;
+  serviceTier?: string;
   tokenUsage: unknown;
 }): TaskMonitorUsageSnapshot | undefined {
   const tokens = normalizeTaskMonitorTokenUsage(params.tokenUsage);
@@ -1669,8 +1698,10 @@ function buildTaskMonitorUsageSnapshot(params: {
   );
   const cost = estimateTaskMonitorUsageCost({
     cachedInputTokens,
+    fastMode: params.fastMode,
     model: params.model,
     outputTokens,
+    serviceTier: params.serviceTier,
     uncachedInputTokens,
   });
 
@@ -1689,7 +1720,9 @@ function buildTaskMonitorUsageSnapshot(params: {
 
   return {
     ...(cost ? { cost } : {}),
+    ...(params.fastMode !== undefined ? { fastMode: params.fastMode } : {}),
     ...(params.model ? { model: params.model } : {}),
+    ...(params.serviceTier ? { serviceTier: params.serviceTier } : {}),
     summary,
     tokenUsage: {
       cachedInputTokens,
@@ -1700,6 +1733,27 @@ function buildTaskMonitorUsageSnapshot(params: {
       uncachedInputTokens,
     },
   };
+}
+
+function buildReviewSubAgentUsageSnapshot(params: {
+  existing?: ThreadSubAgentSummary;
+  model?: string;
+  record?: ReviewSubAgentRecord;
+  tokenUsage: unknown;
+}): TaskMonitorUsageSnapshot | undefined {
+  const fastMode = params.record?.preferredFastMode ?? params.existing?.preferredFastMode;
+  const serviceTier =
+    params.record?.preferredServiceTier ?? params.existing?.preferredServiceTier;
+  const model =
+    params.record?.preferredModel ??
+    params.existing?.preferredModel ??
+    params.model;
+  return buildTaskMonitorUsageSnapshot({
+    fastMode,
+    model: serviceTier !== undefined || fastMode !== undefined ? model : undefined,
+    serviceTier,
+    tokenUsage: params.tokenUsage,
+  });
 }
 
 function normalizeTaskMonitorTokenUsage(
@@ -1787,16 +1841,27 @@ function readTaskMonitorNumber(
 
 function estimateTaskMonitorUsageCost(params: {
   cachedInputTokens: number;
+  fastMode?: boolean;
   model?: string;
   outputTokens: number;
+  serviceTier?: string;
   uncachedInputTokens: number;
-}): { model: string; totalUsd: number } | undefined {
+}): { model: string; serviceTier: string; totalUsd: number } | undefined {
   const model = params.model?.trim();
   if (!model) {
     return undefined;
   }
+  const serviceTier = resolveTaskMonitorPricingServiceTier({
+    fastMode: params.fastMode,
+    serviceTier: params.serviceTier,
+  });
+  if (!serviceTier) {
+    return undefined;
+  }
   const entry = TASK_MONITOR_PRICING_CATALOG.find(
-    (candidate) => candidate.model === model,
+    (candidate) =>
+      candidate.model === model &&
+      candidate.serviceTier === serviceTier,
   );
   if (!entry) {
     return undefined;
@@ -1805,7 +1870,25 @@ function estimateTaskMonitorUsageCost(params: {
     (params.uncachedInputTokens * entry.inputUsdPerMillion) / 1_000_000 +
     (params.cachedInputTokens * entry.cachedInputUsdPerMillion) / 1_000_000 +
     (params.outputTokens * entry.outputUsdPerMillion) / 1_000_000;
-  return { model, totalUsd };
+  return { model, serviceTier, totalUsd };
+}
+
+function resolveTaskMonitorPricingServiceTier(params: {
+  fastMode?: boolean;
+  serviceTier?: string;
+}): "standard" | "priority" | undefined {
+  if (params.fastMode === true) {
+    return "priority";
+  }
+
+  const serviceTier = params.serviceTier?.trim().toLowerCase();
+  if (!serviceTier || serviceTier === "default" || serviceTier === "standard") {
+    return "standard";
+  }
+  if (serviceTier === "fast" || serviceTier === "priority") {
+    return "priority";
+  }
+  return undefined;
 }
 
 function formatTaskMonitorTokenCount(value: number): string {
@@ -1890,6 +1973,28 @@ function completedAtFromTerminalNotification(
   return normalizeNotificationTimestamp(
     readRecord(notification.params.turn)?.completedAt ??
       readRecord(notification.params.turn)?.completed_at,
+  );
+}
+
+function tokenUsageFromTerminalNotification(
+  notification: AppServerNotification,
+): unknown {
+  if (
+    notification.method !== "turn/completed" &&
+    notification.method !== "turn/failed" &&
+    notification.method !== "turn/cancelled"
+  ) {
+    return undefined;
+  }
+
+  const params = readRecord(notification.params);
+  const turn = readRecord(params?.turn);
+  return (
+    params?.tokenUsage ??
+    params?.token_usage ??
+    turn?.tokenUsage ??
+    turn?.token_usage ??
+    turn?.usage
   );
 }
 
@@ -6171,13 +6276,23 @@ export class DesktopBackendRegistry {
         this.reservedCodexStartThreadIds.delete(params.threadId);
       }
     }
+    const preferredServiceTier = resolveTaskMonitorPricingServiceTier({
+      fastMode: modelSettings.fastMode,
+      serviceTier: modelSettings.serviceTier,
+    });
     const reviewSubAgentRecord: ReviewSubAgentRecord = {
       backend: params.backend as Exclude<AppServerBackendKind, AcpBackendId>,
       createdAt: Date.now(),
       parentThreadId: result.threadId,
+      ...(modelSettings.fastMode !== undefined
+        ? { preferredFastMode: modelSettings.fastMode }
+        : {}),
       ...(modelSettings.model ? { preferredModel: modelSettings.model } : {}),
       ...(modelSettings.reasoningEffort
         ? { preferredReasoningEffort: modelSettings.reasoningEffort }
+        : {}),
+      ...(preferredServiceTier
+        ? { preferredServiceTier }
         : {}),
       reviewThreadId: result.reviewThreadId || result.threadId,
       task: reviewTaskLabel(params.target),
@@ -9626,8 +9741,12 @@ export class DesktopBackendRegistry {
       );
       const reviewRecord = this.activeReviewSubAgents.get(reviewKey);
       const completedReviewRecord = this.reviewSubAgentsByReviewTurn.get(reviewKey);
-      const usageSnapshot = buildTaskMonitorUsageSnapshot({
-        model: reviewRecord?.preferredModel ?? completedReviewRecord?.preferredModel,
+      const notificationParams = readRecord(notification.params);
+      const usageModel =
+        readStringLike(notificationParams, ["model"]) ?? undefined;
+      const usageSnapshot = buildReviewSubAgentUsageSnapshot({
+        model: usageModel,
+        record: reviewRecord ?? completedReviewRecord,
         tokenUsage: notification.params.tokenUsage,
       });
       if (!usageSnapshot) {
@@ -9647,7 +9766,8 @@ export class DesktopBackendRegistry {
         reviewThreadId:
           completedReviewRecord?.reviewThreadId ?? notification.params.threadId,
         turnId: notification.params.turnId,
-        usage: usageSnapshot,
+        tokenUsage: notification.params.tokenUsage,
+        usageModel,
       });
       if (reviewUsagePersisted) {
         return;
@@ -9683,7 +9803,8 @@ export class DesktopBackendRegistry {
     parentThreadId: string;
     reviewThreadId: string;
     turnId: string;
-    usage: ThreadSubAgentSummary["monitorUsage"];
+    tokenUsage: unknown;
+    usageModel?: string;
   }): Promise<boolean> {
     const overlay = await this.overlayStore.getThreadOverlayState({
       backend: params.backend,
@@ -9699,13 +9820,21 @@ export class DesktopBackendRegistry {
     if (!existing) {
       return false;
     }
+    const usage = buildReviewSubAgentUsageSnapshot({
+      existing,
+      model: params.usageModel,
+      tokenUsage: params.tokenUsage,
+    });
+    if (!usage) {
+      return false;
+    }
 
     await this.overlayStore.upsertThreadSubAgent({
       backend: params.backend,
       threadId: params.parentThreadId,
       subAgent: {
         ...existing,
-        monitorUsage: params.usage,
+        monitorUsage: usage,
         updatedAt: Date.now(),
       },
     });
@@ -9824,6 +9953,11 @@ export class DesktopBackendRegistry {
       status: patch.status ?? existing?.status ?? "running",
       createdAt: record.createdAt,
       updatedAt: patch.updatedAt ?? Date.now(),
+      ...(record.preferredFastMode !== undefined
+        ? { preferredFastMode: record.preferredFastMode }
+        : existing?.preferredFastMode !== undefined
+          ? { preferredFastMode: existing.preferredFastMode }
+          : {}),
       ...(record.preferredModel ?? existing?.preferredModel
         ? { preferredModel: record.preferredModel ?? existing?.preferredModel }
         : {}),
@@ -9831,6 +9965,12 @@ export class DesktopBackendRegistry {
         ? {
             preferredReasoningEffort:
               record.preferredReasoningEffort ?? existing?.preferredReasoningEffort,
+          }
+        : {}),
+      ...(record.preferredServiceTier ?? existing?.preferredServiceTier
+        ? {
+            preferredServiceTier:
+              record.preferredServiceTier ?? existing?.preferredServiceTier,
           }
         : {}),
       monitorThreadId: record.reviewThreadId,
@@ -9874,6 +10014,7 @@ export class DesktopBackendRegistry {
     completedAt?: number;
     method: AppServerNotification["method"];
     threadId: string;
+    tokenUsage?: unknown;
     turnId: string;
   }): Promise<void> {
     const activeReview = this.findActiveReviewSubAgentForTerminal(params);
@@ -9884,10 +10025,18 @@ export class DesktopBackendRegistry {
     this.activeReviewSubAgents.delete(activeReview.key);
     const { record } = activeReview;
     const completedAt = params.completedAt ?? Date.now();
+    const monitorUsage =
+      params.tokenUsage !== undefined
+        ? buildReviewSubAgentUsageSnapshot({
+            record,
+            tokenUsage: params.tokenUsage,
+          })
+        : undefined;
     if (params.method === "turn/completed") {
       await this.persistReviewSubAgent(record, {
         completedAt,
         lastMessage: "Review completed.",
+        ...(monitorUsage ? { monitorUsage } : {}),
         outcome: "success",
         status: "success",
         updatedAt: completedAt,
@@ -9899,6 +10048,7 @@ export class DesktopBackendRegistry {
       await this.persistReviewSubAgent(record, {
         completedAt,
         lastMessage: "Review cancelled.",
+        ...(monitorUsage ? { monitorUsage } : {}),
         outcome: "cancelled",
         status: "cancelled",
         updatedAt: completedAt,
@@ -9909,6 +10059,7 @@ export class DesktopBackendRegistry {
     await this.persistReviewSubAgent(record, {
       completedAt,
       lastMessage: "Review failed.",
+      ...(monitorUsage ? { monitorUsage } : {}),
       outcome: "failure",
       status: "failed",
       updatedAt: completedAt,
@@ -12717,6 +12868,7 @@ export class DesktopBackendRegistry {
           completedAt: completedAtFromTerminalNotification(event.notification),
           method: event.notification.method,
           threadId: notification.params.threadId,
+          tokenUsage: tokenUsageFromTerminalNotification(event.notification),
           turnId,
         });
       }

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -9739,14 +9739,20 @@ export class DesktopBackendRegistry {
         notification.params.threadId,
         notification.params.turnId,
       );
-      const reviewRecord = this.activeReviewSubAgents.get(reviewKey);
+      const activeReview = this.findActiveReviewSubAgentForTurn({
+        backend: event.backend,
+        threadId: notification.params.threadId,
+        turnId: notification.params.turnId,
+      });
+      const reviewRecord = activeReview?.record;
       const completedReviewRecord = this.reviewSubAgentsByReviewTurn.get(reviewKey);
+      const persistedRecord = reviewRecord ?? completedReviewRecord;
       const notificationParams = readRecord(notification.params);
       const usageModel =
         readStringLike(notificationParams, ["model"]) ?? undefined;
       const usageSnapshot = buildReviewSubAgentUsageSnapshot({
         model: usageModel,
-        record: reviewRecord ?? completedReviewRecord,
+        record: persistedRecord,
         tokenUsage: notification.params.tokenUsage,
       });
       if (!usageSnapshot) {
@@ -9765,7 +9771,7 @@ export class DesktopBackendRegistry {
           completedReviewRecord?.parentThreadId ?? notification.params.threadId,
         reviewThreadId:
           completedReviewRecord?.reviewThreadId ?? notification.params.threadId,
-        turnId: notification.params.turnId,
+        turnId: completedReviewRecord?.turnId ?? notification.params.turnId,
         tokenUsage: notification.params.tokenUsage,
         usageModel,
       });
@@ -10024,6 +10030,12 @@ export class DesktopBackendRegistry {
 
     this.activeReviewSubAgents.delete(activeReview.key);
     const { record } = activeReview;
+    if (params.turnId !== record.turnId) {
+      this.reviewSubAgentsByReviewTurn.set(
+        buildReviewSubAgentKey(record.backend, record.reviewThreadId, params.turnId),
+        record,
+      );
+    }
     const completedAt = params.completedAt ?? Date.now();
     const monitorUsage =
       params.tokenUsage !== undefined
@@ -10067,6 +10079,14 @@ export class DesktopBackendRegistry {
   }
 
   private findActiveReviewSubAgentForTerminal(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    turnId: string;
+  }): { key: string; record: ReviewSubAgentRecord } | undefined {
+    return this.findActiveReviewSubAgentForTurn(params);
+  }
+
+  private findActiveReviewSubAgentForTurn(params: {
     backend: AppServerBackendKind;
     threadId: string;
     turnId: string;

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -2738,6 +2738,17 @@ function summarizeTokenUsageActivity(
         status: "completed",
       },
     ],
+    tokenUsage: {
+      ...(tokens.cachedInputTokens !== undefined
+        ? { cachedInputTokens: tokens.cachedInputTokens }
+        : {}),
+      ...(tokens.inputTokens !== undefined ? { inputTokens: tokens.inputTokens } : {}),
+      ...(tokens.outputTokens !== undefined ? { outputTokens: tokens.outputTokens } : {}),
+      ...(tokens.reasoningOutputTokens !== undefined
+        ? { reasoningOutputTokens: tokens.reasoningOutputTokens }
+        : {}),
+      ...(tokens.totalTokens !== undefined ? { totalTokens: tokens.totalTokens } : {}),
+    },
     ...(turn ? { turn } : {}),
   };
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -299,7 +299,9 @@ describe("ThreadContextPanel", () => {
             monitorThreadId: "thread-1",
             monitorTurnId: "turn-review-1",
             monitorUsage: {
-              summary: "800 uncached in · 200 cached · 50 out",
+              model: "gpt-5.4-mini",
+              summary:
+                "800 uncached in · 200 cached · 50 out · <$0.001 list price",
               tokenUsage: {
                 inputTokens: 1000,
                 cachedInputTokens: 200,
@@ -307,14 +309,21 @@ describe("ThreadContextPanel", () => {
                 outputTokens: 50,
                 totalTokens: 1050,
               },
+              cost: {
+                model: "gpt-5.4-mini",
+                totalUsd: 0.00084,
+              },
             },
           },
         ],
       },
     });
 
+    expect(screen.getByText("gpt-5.4-mini")).toBeInTheDocument();
     expect(
-      screen.getByText("Review usage: 800 uncached in · 200 cached · 50 out"),
+      screen.getByText(
+        "Review usage: 800 uncached in · 200 cached · 50 out · <$0.001 list price",
+      ),
     ).toBeInTheDocument();
   });
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
@@ -27,6 +27,10 @@ export function SubAgentsPanel(props: SubAgentsPanelProps) {
         <ul className="context-list context-list--cards">
           {subAgents.map((subAgent) => {
             const tone = subAgentTone(subAgent.status);
+            const model =
+              subAgent.preferredModel ??
+              subAgent.monitorUsage?.model ??
+              subAgent.monitorUsage?.cost?.model;
             return (
               <li key={subAgent.monitorId} className="rail-card">
                 {/* Status on its own line so it never competes with the
@@ -39,8 +43,8 @@ export function SubAgentsPanel(props: SubAgentsPanelProps) {
                 <p className="rail-card__title" title={subAgent.task}>
                   {subAgent.task}
                 </p>
-                {subAgent.preferredModel ? (
-                  <p className="rail-card__model">{subAgent.preferredModel}</p>
+                {model ? (
+                  <p className="rail-card__model">{model}</p>
                 ) : null}
                 <p className="rail-card__times">
                   <span className="rail-card__time-label">Started</span>{" "}

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -140,6 +140,8 @@ export type ThreadSubAgentSummary = {
   updatedAt: number;
   preferredModel?: string;
   preferredReasoningEffort?: string;
+  preferredServiceTier?: string;
+  preferredFastMode?: boolean;
   monitorThreadId?: ThreadIdentifier;
   monitorTurnId?: ThreadIdentifier;
   lastMessage?: string;

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -379,6 +379,13 @@ export type AppServerThreadActivityEntry = {
   tone?: "warning";
   status?: AppServerThreadActivityStatus;
   details: AppServerThreadActivityDetail[];
+  tokenUsage?: {
+    cachedInputTokens?: number;
+    inputTokens?: number;
+    outputTokens?: number;
+    reasoningOutputTokens?: number;
+    totalTokens?: number;
+  };
   turn?: AppServerThreadTurnMetadata;
 };
 

--- a/packages/shared/src/contracts/task-monitor-tools.ts
+++ b/packages/shared/src/contracts/task-monitor-tools.ts
@@ -51,9 +51,12 @@ export type CompleteMonitoringToolArgs = {
 export type TaskMonitorUsageSnapshot = {
   cost?: {
     model: string;
+    serviceTier?: string;
     totalUsd: number;
   };
+  fastMode?: boolean;
   model?: string;
+  serviceTier?: string;
   summary: string;
   tokenUsage: {
     cachedInputTokens?: number;


### PR DESCRIPTION
## Summary

- Review sub-agent cards now carry the same model and usage metadata as regular monitor sub-agent cards when a review is started with resolved model settings.
- Review token usage now keeps that model context, including when usage arrives after the review already completed, so the card can show list-price cost instead of only raw token counts.
- The Sub-Agents card model row now falls back to usage/cost metadata, which helps older or late-patched review records display the best available model.

## Verification

- I verified the focused registry and renderer coverage with `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx`.
- I verified TypeScript with `pnpm typecheck`.
- I verified dependency boundaries with `pnpm lint:boundaries`.

## Notes

- No migration is required. Existing review records keep working, and cards can use model metadata from the usage snapshot when the preferred model is absent.

## Post-Deploy Monitoring & Validation

- Watch desktop main/renderer logs for `thread/subAgents/updated`, review completion, or Sub-Agents panel render errors.
- Healthy signal: a dogfood Codex review run appears in the Sub-Agents tab with the review model, start/end timestamps, and a `Review usage:` row that includes token and list-price information when pricing is known.
- Failure signal: review sub-agent cards still omit model/cost metadata while non-review monitor cards show it, or renderer errors appear when opening the Sub-Agents tab.
- Mitigation trigger: revert this PR if review sub-agent persistence or Sub-Agents panel rendering regresses during dogfood validation.
- Validation window and owner: next desktop dogfood review run after merge, owned by PwrDrvr.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5_Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
