### PR TITLE
fix(agent-tools): expose messaging attachments in thread inspection

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1207,8 +1207,13 @@ function createMessagingArchiveCleanupStoreMock(options?: {
   bindings?: Array<{
     backend?: "codex" | "grok";
     channel?: "telegram" | "discord";
+    conversationKind?: MessagingBindingRecord["channel"]["conversation"]["kind"];
+    conversationTitle?: string;
     id: string;
+    parentTitle?: string;
+    targetKind?: MessagingBindingRecord["targetKind"];
     threadId: string;
+    updatedAt?: number;
   }>;
   pendingIntentIds?: string[];
 }) {
@@ -1224,14 +1229,16 @@ function createMessagingArchiveCleanupStoreMock(options?: {
         channel: {
           channel: binding.channel ?? "telegram",
           conversation: {
-            kind: "dm",
+            kind: binding.conversationKind ?? "dm",
             id: `${binding.id}:conversation`,
-            title: `${binding.id} conversation`,
+            title: binding.conversationTitle ?? `${binding.id} conversation`,
+            parentTitle: binding.parentTitle,
           },
         },
         authorizedActorIds: [`${binding.id}:actor`],
         createdAt: 1,
-        updatedAt: 1,
+        targetKind: binding.targetKind,
+        updatedAt: binding.updatedAt ?? 1,
       },
     ]),
   );
@@ -5206,7 +5213,7 @@ script = "echo setup"
         }),
         expect.objectContaining({
           namespace: "pwragent_messaging",
-          name: "get_current_location",
+          name: "get_current_messaging_surface",
         }),
         expect.objectContaining({
           namespace: "pwragent_messaging",
@@ -7199,7 +7206,7 @@ script = "pnpm install"
         }),
         expect.objectContaining({
           namespace: "pwragent_messaging",
-          name: "get_current_location",
+          name: "get_current_messaging_surface",
         }),
         expect.objectContaining({
           namespace: "pwragent_messaging",
@@ -12244,6 +12251,21 @@ command = "pnpm dev"
       grokClient: new MockBackendClient({
         initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
       }),
+      messagingStore: createMessagingArchiveCleanupStoreMock({
+        bindings: [
+          {
+            id: "binding-telegram-jambalayah",
+            backend: "codex",
+            channel: "telegram",
+            conversationKind: "topic",
+            conversationTitle: "Jambalayah",
+            parentTitle: "PwrAgent Mini Dev Group",
+            targetKind: "agent_thread",
+            threadId: "thread-1",
+            updatedAt: 2_500,
+          },
+        ],
+      }),
       overlayStore: createOverlayStoreMock({
         overlays: {
           "codex:thread-1": {
@@ -12311,6 +12333,16 @@ command = "pnpm dev"
           agent: {
             name: "Inbox Agent",
           },
+          messagingBindings: [
+            {
+              bindingId: "binding-telegram-jambalayah",
+              platform: "telegram",
+              conversationKind: "topic",
+              conversationTitle: "Jambalayah",
+              parentTitle: "PwrAgent Mini Dev Group",
+              activeAt: 2_500,
+            },
+          ],
         },
       ],
       totalCount: 1,
@@ -12389,6 +12421,20 @@ command = "pnpm dev"
       grokClient: new MockBackendClient({
         initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
       }),
+      messagingStore: createMessagingArchiveCleanupStoreMock({
+        bindings: [
+          {
+            id: "binding-discord-branch-drift",
+            backend: "codex",
+            channel: "discord",
+            conversationKind: "thread",
+            conversationTitle: "branch drift screenshots",
+            parentTitle: "dev",
+            threadId: "thread-1",
+            updatedAt: 4_000,
+          },
+        ],
+      }),
       overlayStore: createOverlayStoreMock(),
       threadSearchService: { search } as unknown as ThreadSearchService,
     });
@@ -12462,6 +12508,16 @@ command = "pnpm dev"
           threadId: "thread-1",
           title: "Branch drift dialog screenshots",
           confidence: "medium",
+          messagingBindings: [
+            {
+              bindingId: "binding-discord-branch-drift",
+              platform: "discord",
+              conversationKind: "thread",
+              conversationTitle: "branch drift screenshots",
+              parentTitle: "dev",
+              activeAt: 4_000,
+            },
+          ],
           snippets: [
             {
               scope: "provider_content",
@@ -12681,6 +12737,21 @@ command = "pnpm dev"
       grokClient: new MockBackendClient({
         initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
       }),
+      messagingStore: createMessagingArchiveCleanupStoreMock({
+        bindings: [
+          {
+            id: "binding-telegram-active",
+            backend: "codex",
+            channel: "telegram",
+            conversationKind: "topic",
+            conversationTitle: "Jeeves",
+            parentTitle: "PwrAgent Mini Dev Group",
+            targetKind: "agent_thread",
+            threadId: "active-thread",
+            updatedAt: 3_000,
+          },
+        ],
+      }),
       overlayStore: createOverlayStoreMock(),
     });
     await registry.publishLocalEvent({
@@ -12720,6 +12791,16 @@ command = "pnpm dev"
         threadId: "active-thread",
         title: "Jeeves",
         status: "idle",
+        messagingBindings: [
+          {
+            bindingId: "binding-telegram-active",
+            platform: "telegram",
+            conversationKind: "topic",
+            conversationTitle: "Jeeves",
+            parentTitle: "PwrAgent Mini Dev Group",
+            activeAt: 3_000,
+          },
+        ],
       },
     });
     expect(

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -13008,6 +13008,88 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("rejects invalid thread mutations before applying earlier requested fields", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list"] },
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:target-thread": {
+          backend: "codex",
+          threadId: "target-thread",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "agent-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "agent-thread",
+        turnId: "turn-1",
+        callId: "call-1",
+        requestId: "call-1",
+        namespace: "pwragent_threads",
+        tool: "mutate_thread",
+        arguments: {
+          backend: "codex",
+          threadId: "target-thread",
+          title: "Pizza Agent",
+          model: "gpt-5.5",
+          executionMode: "yolo",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    expect(response).toEqual({
+      success: false,
+      contentItems: [
+        {
+          type: "inputText",
+          text: JSON.stringify(
+            {
+              code: "invalid_arguments",
+              message:
+                "executionMode must be default or full-access when provided.",
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    });
+    expect(codexClient.lastRenameThreadParams).toBeUndefined();
+    const overlay = await overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "target-thread",
+    });
+    expect(overlay).toMatchObject({
+      executionMode: "default",
+    });
+    expect(overlay?.model).toBeUndefined();
+
+    await registry.close();
+  });
+
   it("rejects automation inspection dynamic tool calls that do not match an active turn", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start"] },

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -5212,6 +5212,10 @@ script = "echo setup"
           name: "get_thread_status",
         }),
         expect.objectContaining({
+          namespace: "pwragent_threads",
+          name: "mutate_thread",
+        }),
+        expect.objectContaining({
           namespace: "pwragent_messaging",
           name: "get_current_messaging_surface",
         }),
@@ -12807,6 +12811,199 @@ command = "pnpm dev"
       codexClient.listThreadsCalls
         .map((call) => call.params?.archived)
     ).toEqual([false]);
+
+    await registry.close();
+  });
+
+  it("mutates PwrAgent thread settings from active Agent turns", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list"] },
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:target-thread": {
+          backend: "codex",
+          threadId: "target-thread",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "agent-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "agent-thread",
+        turnId: "turn-1",
+        callId: "call-1",
+        requestId: "call-1",
+        namespace: "pwragent_threads",
+        tool: "mutate_thread",
+        arguments: {
+          backend: "codex",
+          threadId: "target-thread",
+          title: "Pizza Agent",
+          model: "gpt-5.5",
+          reasoningEffort: "medium",
+          fastMode: true,
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    expect(response).toMatchObject({
+      success: true,
+      contentItems: [
+        {
+          type: "inputText",
+          text: expect.any(String),
+        },
+      ],
+    });
+    const payload = JSON.parse(
+      (response as { contentItems: Array<{ text: string }> }).contentItems[0]!.text,
+    );
+    expect(payload).toEqual({
+      mutation: {
+        backend: "codex",
+        threadId: "target-thread",
+        dryRun: false,
+        changes: [
+          {
+            field: "title",
+            status: "applied",
+            to: "Pizza Agent",
+          },
+          {
+            field: "model_settings",
+            status: "applied",
+            to: {
+              model: "gpt-5.5",
+              reasoningEffort: "medium",
+              fastMode: true,
+            },
+          },
+        ],
+      },
+    });
+    expect(codexClient.lastRenameThreadParams).toEqual({
+      threadId: "target-thread",
+      name: "Pizza Agent",
+    });
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "target-thread",
+      }),
+    ).resolves.toMatchObject({
+      model: "gpt-5.5",
+      reasoningEffort: "medium",
+      fastMode: true,
+    });
+
+    await registry.close();
+  });
+
+  it("dry-runs thread mutations without applying them", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list"] },
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:target-thread": {
+          backend: "codex",
+          threadId: "target-thread",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "agent-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "agent-thread",
+        turnId: "turn-1",
+        callId: "call-1",
+        requestId: "call-1",
+        namespace: "pwragent_threads",
+        tool: "mutate_thread",
+        arguments: {
+          backend: "codex",
+          threadId: "target-thread",
+          title: "Pizza Agent",
+          executionMode: "full-access",
+          dryRun: true,
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    const payload = JSON.parse(
+      (response as { contentItems: Array<{ text: string }> }).contentItems[0]!.text,
+    );
+    expect(payload).toEqual({
+      mutation: {
+        backend: "codex",
+        threadId: "target-thread",
+        dryRun: true,
+        changes: [
+          {
+            field: "title",
+            status: "would_apply",
+            to: "Pizza Agent",
+          },
+          {
+            field: "execution_mode",
+            status: "would_apply",
+            to: "full-access",
+          },
+        ],
+      },
+    });
+    expect(codexClient.lastRenameThreadParams).toBeUndefined();
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "target-thread",
+      }),
+    ).resolves.toMatchObject({
+      executionMode: "default",
+    });
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -274,6 +274,21 @@ describe("MessagingController", () => {
   });
 
   it("reports the current messaging surface for an active Agent-thread turn", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.threads[0] = {
+      ...navigation.threads[0]!,
+      agent: {
+        name: "Messaging Agent",
+        instructionLineCount: 1,
+        instructionsTooLong: false,
+        updatedAt: 1000,
+      },
+      executionMode: "default",
+      gitBranch: "main",
+      model: "gpt-5.5",
+      projectKey: "/repo/pwragent",
+      title: "node_modules, node version, pnpm build",
+    };
     const createManagedConversation = vi.fn(async () => ({
       channel: "telegram" as const,
       outcome: "unsupported" as const,
@@ -294,6 +309,7 @@ describe("MessagingController", () => {
     const harness = await createHarness({
       createManagedConversation,
       getManagedConversationRights,
+      navigation,
     });
     const channelEvent = buildTelegramChannelCommandEvent("/agent");
     const event = buildTextEvent("attach it here", {
@@ -335,6 +351,14 @@ describe("MessagingController", () => {
           binding: {
             backend: "codex",
             targetKind: "agent_thread",
+            thread: {
+              agentName: "Messaging Agent",
+              executionMode: "default",
+              gitBranch: "main",
+              model: "gpt-5.5",
+              projectKey: "/repo/pwragent",
+              title: "node_modules, node version, pnpm build",
+            },
             threadId: "thread-1",
           },
           channel: "telegram",
@@ -367,6 +391,9 @@ describe("MessagingController", () => {
           binding: {
             backend: "codex",
             targetKind: "agent_thread",
+            thread: {
+              title: "node_modules, node version, pnpm build",
+            },
             threadId: "thread-1",
           },
           channel: "telegram",

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -317,7 +317,7 @@ describe("MessagingController", () => {
 
     await expect(
       harness.controller.handlePwrAgentMessagingRequest({
-        operation: "get_current_location",
+        operation: "get_current_messaging_surface",
         context: {
           backend: "codex",
           threadId: "thread-1",
@@ -411,7 +411,7 @@ describe("MessagingController", () => {
     expect(harness.startTurn).toHaveBeenCalledTimes(2);
     await expect(
       harness.controller.handlePwrAgentMessagingRequest({
-        operation: "get_current_location",
+        operation: "get_current_messaging_surface",
         context: {
           backend: "codex",
           threadId: "thread-1",

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -350,6 +350,34 @@ describe("MessagingController", () => {
         },
       },
     });
+    await expect(
+      harness.controller.handlePwrAgentMessagingRequest({
+        operation: "get_current_location",
+        context: {
+          backend: "codex",
+          threadId: "thread-1",
+          turnId: "turn-1",
+        },
+        args: {},
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      data: {
+        location: {
+          binding: {
+            backend: "codex",
+            targetKind: "agent_thread",
+            threadId: "thread-1",
+          },
+          channel: "telegram",
+          conversation: {
+            id: "-1001",
+            kind: "channel",
+            title: "Ops",
+          },
+        },
+      },
+    });
     expect(getManagedConversationRights).toHaveBeenCalledWith(
       expect.objectContaining({
         actor: event.actor,

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -273,7 +273,7 @@ describe("MessagingController", () => {
     });
   });
 
-  it("reports the current messaging location for an active Agent-thread turn", async () => {
+  it("reports the current messaging surface for an active Agent-thread turn", async () => {
     const createManagedConversation = vi.fn(async () => ({
       channel: "telegram" as const,
       outcome: "unsupported" as const,

--- a/apps/desktop/src/main/__tests__/pwragent-messaging-agent-tools.test.ts
+++ b/apps/desktop/src/main/__tests__/pwragent-messaging-agent-tools.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { buildPwrAgentMessagingToolRouter } from "../agent-tools/pwragent-messaging-agent-tools";
+import { isPwrAgentMessagingDynamicToolCall } from "../agent-tools/pwragent-messaging-codex-tools";
+
+describe("PwrAgent messaging agent tools", () => {
+  it("does not advertise deprecated location tool but still recognizes legacy calls", async () => {
+    const handler = vi.fn(async () => ({
+      ok: true as const,
+      data: {
+        location: {
+          binding: {
+            id: "binding-1",
+            backend: "codex" as const,
+            threadId: "agent-thread",
+            targetKind: "agent_thread" as const,
+          },
+          channel: "telegram" as const,
+          conversation: {
+            id: "topic-1",
+            kind: "topic" as const,
+          },
+          managedConversation: {
+            canCreateChild: false,
+            operations: [],
+            outcome: "unsupported" as const,
+            providerSupportsCreation: false,
+          },
+        },
+      },
+    }));
+    const router = buildPwrAgentMessagingToolRouter(handler);
+
+    const specs = router.buildDynamicToolSpecs();
+    expect(specs.map((tool) => tool.name)).toEqual([
+      "get_current_messaging_surface",
+      "attach_thread_here",
+    ]);
+    expect(
+      isPwrAgentMessagingDynamicToolCall({
+        namespace: "pwragent_messaging",
+        tool: "get_current_location",
+      }),
+    ).toBe(true);
+
+    await expect(
+      router.handleDynamicToolCall({
+        backend: "codex",
+        call: {
+          threadId: "agent-thread",
+          turnId: "turn-1",
+          callId: "call-1",
+          namespace: "pwragent_messaging",
+          tool: "get_current_location",
+          arguments: {},
+        },
+      }),
+    ).resolves.toMatchObject({
+      success: true,
+    });
+    expect(handler).toHaveBeenCalledWith({
+      operation: "get_current_location",
+      context: {
+        backend: "codex",
+        threadId: "agent-thread",
+        turnId: "turn-1",
+      },
+      args: {},
+    });
+  });
+});

--- a/apps/desktop/src/main/__tests__/pwragent-thread-agent-tools.test.ts
+++ b/apps/desktop/src/main/__tests__/pwragent-thread-agent-tools.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { buildPwrAgentThreadToolRouter } from "../agent-tools/pwragent-thread-agent-tools";
 
 describe("PwrAgent thread agent tools", () => {
-  it("projects search/status tools and dispatches with Agent thread context", async () => {
+  it("projects thread tools and dispatches with Agent thread context", async () => {
     const handler = vi.fn(async () => ({
       ok: true as const,
       data: {
@@ -23,6 +23,10 @@ describe("PwrAgent thread agent tools", () => {
       expect.objectContaining({
         namespace: "pwragent_threads",
         name: "get_thread_status",
+      }),
+      expect.objectContaining({
+        namespace: "pwragent_threads",
+        name: "mutate_thread",
       }),
     ]);
 

--- a/apps/desktop/src/main/agent-tools/agent-tool-definition.ts
+++ b/apps/desktop/src/main/agent-tools/agent-tool-definition.ts
@@ -37,6 +37,11 @@ export type AgentToolDefinition<TName extends string = string> = {
   name: TName;
   description: string;
   inputSchema: Record<string, unknown>;
+  /**
+   * Hidden definitions are callable compatibility facades, but are not
+   * advertised to new Agent turns or MCP clients.
+   */
+  advertise?: boolean;
   deferLoading?: boolean;
   dispatch: (
     args: Record<string, unknown>,

--- a/apps/desktop/src/main/agent-tools/agent-tool-router.ts
+++ b/apps/desktop/src/main/agent-tools/agent-tool-router.ts
@@ -50,21 +50,25 @@ export class AgentToolRouter {
   }
 
   buildDynamicToolSpecs(): DynamicToolSpec[] {
-    return this.definitions.map((definition) => ({
-      namespace: definition.namespace,
-      name: definition.name,
-      description: definition.description,
-      inputSchema: definition.inputSchema as DynamicToolSpec["inputSchema"],
-      deferLoading: definition.deferLoading ?? false,
-    }));
+    return this.definitions
+      .filter((definition) => definition.advertise !== false)
+      .map((definition) => ({
+        namespace: definition.namespace,
+        name: definition.name,
+        description: definition.description,
+        inputSchema: definition.inputSchema as DynamicToolSpec["inputSchema"],
+        deferLoading: definition.deferLoading ?? false,
+      }));
   }
 
   buildMcpTools(): AgentMcpTool[] {
-    return this.definitions.map((definition) => ({
-      name: definition.name,
-      description: definition.description,
-      inputSchema: definition.inputSchema,
-    }));
+    return this.definitions
+      .filter((definition) => definition.advertise !== false)
+      .map((definition) => ({
+        name: definition.name,
+        description: definition.description,
+        inputSchema: definition.inputSchema,
+      }));
   }
 
   acceptsDynamicToolCall(

--- a/apps/desktop/src/main/agent-tools/pwragent-messaging-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-messaging-agent-tools.ts
@@ -71,9 +71,9 @@ export function buildPwrAgentMessagingToolDefinitions(
 function descriptionForOperation(operation: PwrAgentMessagingOperationName): string {
   switch (operation) {
     case "get_current_location":
-      return "Deprecated alias for get_current_messaging_surface. Inspect the messaging platform, actor, conversation, binding, and native thread/topic creation capability for the surface that started this Agent turn.";
+      return "Deprecated alias for get_current_messaging_surface. Inspect the messaging platform, actor, conversation, binding, compact bound-thread identity, and native thread/topic creation capability for the surface that started this Agent turn.";
     case "get_current_messaging_surface":
-      return "Inspect the messaging platform, actor, conversation, binding, and native thread/topic creation capability for the surface that started this Agent turn.";
+      return "Inspect the messaging platform, actor, conversation, binding, compact bound-thread identity, and native thread/topic creation capability for the surface that started this Agent turn.";
     case "attach_thread_here":
       return "Attach a known PwrAgent thread to the current messaging surface, creating a native child thread/topic when the provider supports it. This does not rename the PwrAgent thread.";
   }

--- a/apps/desktop/src/main/agent-tools/pwragent-messaging-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-messaging-agent-tools.ts
@@ -66,10 +66,10 @@ export function buildPwrAgentMessagingToolDefinitions(
 
 function descriptionForOperation(operation: PwrAgentMessagingOperationName): string {
   switch (operation) {
-    case "get_current_location":
+    case "get_current_messaging_surface":
       return "Inspect the messaging platform, actor, conversation, binding, and native thread/topic creation capability for the surface that started this Agent turn.";
     case "attach_thread_here":
-      return "Attach a known PwrAgent thread to the current messaging location, creating a native child thread/topic when the provider supports it.";
+      return "Attach a known PwrAgent thread to the current messaging surface, creating a native child thread/topic when the provider supports it.";
   }
 }
 
@@ -77,7 +77,7 @@ function inputSchemaForOperation(
   operation: PwrAgentMessagingOperationName,
 ): Record<string, unknown> {
   switch (operation) {
-    case "get_current_location":
+    case "get_current_messaging_surface":
       return {
         type: "object",
         additionalProperties: false,

--- a/apps/desktop/src/main/agent-tools/pwragent-messaging-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-messaging-agent-tools.ts
@@ -4,6 +4,7 @@ import type {
   PwrAgentMessagingResponse,
 } from "@pwragent/shared";
 import {
+  PWRAGENT_MESSAGING_CALLABLE_OPERATION_NAMES,
   PWRAGENT_MESSAGING_OPERATION_NAMES,
   PWRAGENT_MESSAGING_TOOL_NAMESPACE,
 } from "@pwragent/shared";
@@ -37,11 +38,14 @@ export function buildPwrAgentMessagingToolRouter(
 export function buildPwrAgentMessagingToolDefinitions(
   handler: PwrAgentMessagingHandler | undefined,
 ): AgentToolDefinition<PwrAgentMessagingOperationName>[] {
-  return PWRAGENT_MESSAGING_OPERATION_NAMES.map((operation) => ({
+  return PWRAGENT_MESSAGING_CALLABLE_OPERATION_NAMES.map((operation) => ({
     namespace: PWRAGENT_MESSAGING_TOOL_NAMESPACE,
     name: operation,
     description: descriptionForOperation(operation),
     inputSchema: inputSchemaForOperation(operation),
+    advertise: PWRAGENT_MESSAGING_OPERATION_NAMES.includes(
+      operation as (typeof PWRAGENT_MESSAGING_OPERATION_NAMES)[number],
+    ),
     deferLoading: false,
     dispatch: async (args, context): Promise<AgentToolDispatchResult> => {
       if (!handler) {
@@ -66,6 +70,8 @@ export function buildPwrAgentMessagingToolDefinitions(
 
 function descriptionForOperation(operation: PwrAgentMessagingOperationName): string {
   switch (operation) {
+    case "get_current_location":
+      return "Deprecated alias for get_current_messaging_surface. Inspect the messaging platform, actor, conversation, binding, and native thread/topic creation capability for the surface that started this Agent turn.";
     case "get_current_messaging_surface":
       return "Inspect the messaging platform, actor, conversation, binding, and native thread/topic creation capability for the surface that started this Agent turn.";
     case "attach_thread_here":
@@ -77,6 +83,7 @@ function inputSchemaForOperation(
   operation: PwrAgentMessagingOperationName,
 ): Record<string, unknown> {
   switch (operation) {
+    case "get_current_location":
     case "get_current_messaging_surface":
       return {
         type: "object",

--- a/apps/desktop/src/main/agent-tools/pwragent-messaging-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-messaging-agent-tools.ts
@@ -69,7 +69,7 @@ function descriptionForOperation(operation: PwrAgentMessagingOperationName): str
     case "get_current_messaging_surface":
       return "Inspect the messaging platform, actor, conversation, binding, and native thread/topic creation capability for the surface that started this Agent turn.";
     case "attach_thread_here":
-      return "Attach a known PwrAgent thread to the current messaging surface, creating a native child thread/topic when the provider supports it.";
+      return "Attach a known PwrAgent thread to the current messaging surface, creating a native child thread/topic when the provider supports it. This does not rename the PwrAgent thread.";
   }
 }
 
@@ -93,14 +93,22 @@ function inputSchemaForOperation(
             type: "string",
           },
           threadId: { type: "string" },
-          title: { type: "string" },
+          title: {
+            type: "string",
+            description:
+              "Optional title for a newly created native messaging child topic/thread. This is not a PwrAgent thread rename.",
+          },
           placement: {
             type: "string",
             enum: ["auto", "new_child", "current_conversation"],
+            description:
+              "Where to attach the target thread. Use new_child to create a native messaging child topic/thread when supported; use current_conversation only when replacing or reusing the current conversation binding is intended.",
           },
           targetKind: {
             type: "string",
             enum: ["thread", "agent_thread"],
+            description:
+              "How PwrAgent should classify the messaging binding. This does not change the target thread's Agent metadata or title.",
           },
         },
       };

--- a/apps/desktop/src/main/agent-tools/pwragent-messaging-codex-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-messaging-codex-tools.ts
@@ -3,7 +3,7 @@ import type {
   PwrAgentMessagingOperationName,
 } from "@pwragent/shared";
 import {
-  PWRAGENT_MESSAGING_OPERATION_NAMES,
+  PWRAGENT_MESSAGING_CALLABLE_OPERATION_NAMES,
   PWRAGENT_MESSAGING_TOOL_NAMESPACE,
 } from "@pwragent/shared";
 import type {
@@ -27,7 +27,7 @@ export function isPwrAgentMessagingDynamicToolCall(
 } {
   return (
     call.namespace === PWRAGENT_MESSAGING_TOOL_NAMESPACE &&
-    PWRAGENT_MESSAGING_OPERATION_NAMES.includes(
+    PWRAGENT_MESSAGING_CALLABLE_OPERATION_NAMES.includes(
       call.tool as PwrAgentMessagingOperationName,
     )
   );

--- a/apps/desktop/src/main/agent-tools/pwragent-thread-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-thread-agent-tools.ts
@@ -71,6 +71,8 @@ function descriptionForOperation(
       return "Search known PwrAgent threads by title, summary, Agent metadata, backend, and linked directory. Omit query to inspect recent lightweight thread candidates before choosing a thread.";
     case "get_thread_status":
       return "Read status and compact metadata for a known PwrAgent thread.";
+    case "mutate_thread":
+      return "Mutate guarded PwrAgent thread settings such as the PwrAgent thread title, model settings, or execution mode. This does not rename any attached Telegram topic, Discord thread, or other messaging surface.";
   }
 }
 
@@ -162,6 +164,54 @@ function inputSchemaForOperation(
             type: "string",
           },
           threadId: { type: "string" },
+        },
+      };
+    case "mutate_thread":
+      return {
+        type: "object",
+        additionalProperties: false,
+        required: ["backend", "threadId"],
+        properties: {
+          backend: {
+            type: "string",
+          },
+          threadId: { type: "string" },
+          title: {
+            type: "string",
+            description:
+              "New PwrAgent thread title. This does not rename attached messaging topics or threads.",
+          },
+          model: {
+            type: "string",
+            description:
+              "Provider model id to use for future turns, for example `gpt-5.5`.",
+          },
+          serviceTier: {
+            type: "string",
+            description:
+              "Provider service tier to use for future turns when supported.",
+          },
+          reasoningEffort: {
+            type: "string",
+            description:
+              "Provider reasoning effort to use for future turns when supported.",
+          },
+          fastMode: {
+            type: "boolean",
+            description:
+              "Whether to enable the thread's fast-mode setting when supported.",
+          },
+          executionMode: {
+            type: "string",
+            enum: ["default", "full-access"],
+            description:
+              "Thread execution/permission mode. Active turns may queue this until the next safe boundary.",
+          },
+          dryRun: {
+            type: "boolean",
+            description:
+              "When true, validate and report requested mutations without applying them.",
+          },
         },
       };
   }

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -105,8 +105,10 @@ import {
   type ThreadTurnFailure,
   type ThreadAgentMetadata,
   type MessagingThreadBindingSummary,
+  type MutateThreadToolArgs,
   type PwrAgentThreadInspectionRequest,
   type PwrAgentThreadInspectionResponse,
+  type ThreadMutationAppliedChange,
   type ThreadInspectionSummary,
   type ThreadSearchFilters,
   type ThreadSearchResult,
@@ -12511,11 +12513,139 @@ export class DesktopBackendRegistry {
       };
     }
 
+    if (request.operation === "mutate_thread") {
+      return await this.handleMutateThreadInspectionRequest(request.args);
+    }
+
     return {
       ok: false,
       error: {
         code: "unsupported_operation",
         message: "Unsupported PwrAgent thread inspection operation.",
+      },
+    };
+  }
+
+  private async handleMutateThreadInspectionRequest(
+    args: MutateThreadToolArgs,
+  ): Promise<PwrAgentThreadInspectionResponse> {
+    if (!isAppServerBackendKind(args.backend)) {
+      return {
+        ok: false,
+        error: {
+          code: "invalid_arguments",
+          message: "backend must be a known PwrAgent backend.",
+        },
+      };
+    }
+    const threadId = args.threadId?.trim();
+    if (!threadId) {
+      return {
+        ok: false,
+        error: {
+          code: "invalid_arguments",
+          message: "threadId is required.",
+        },
+      };
+    }
+
+    const dryRun = args.dryRun === true;
+    const changes: ThreadMutationAppliedChange[] = [];
+
+    if (Object.hasOwn(args, "title")) {
+      if (typeof args.title !== "string" || !args.title.trim()) {
+        return {
+          ok: false,
+          error: {
+            code: "invalid_arguments",
+            message: "title must be a non-empty string when provided.",
+          },
+        };
+      }
+      const title = args.title.trim();
+      if (!dryRun) {
+        await this.renameThread({
+          backend: args.backend,
+          threadId,
+          name: title,
+        });
+      }
+      changes.push({
+        field: "title",
+        status: dryRun ? "would_apply" : "applied",
+        to: title,
+      });
+    }
+
+    const modelSettings = readThreadMutationModelSettings(args);
+    if (modelSettings.error) {
+      return {
+        ok: false,
+        error: {
+          code: "invalid_arguments",
+          message: modelSettings.error,
+        },
+      };
+    }
+    if (modelSettings.value) {
+      if (!dryRun) {
+        await this.setThreadModelSettings({
+          backend: args.backend,
+          threadId,
+          ...modelSettings.value,
+        });
+      }
+      changes.push({
+        field: "model_settings",
+        status: dryRun ? "would_apply" : "applied",
+        to: modelSettings.value,
+      });
+    }
+
+    if (Object.hasOwn(args, "executionMode")) {
+      if (!isThreadMutationExecutionMode(args.executionMode)) {
+        return {
+          ok: false,
+          error: {
+            code: "invalid_arguments",
+            message: "executionMode must be default or full-access when provided.",
+          },
+        };
+      }
+      if (!dryRun) {
+        await this.setThreadExecutionMode({
+          backend: args.backend,
+          threadId,
+          executionMode: args.executionMode,
+        });
+      }
+      changes.push({
+        field: "execution_mode",
+        status: dryRun ? "would_apply" : "applied",
+        to: args.executionMode,
+      });
+    }
+
+    if (changes.length === 0) {
+      return {
+        ok: false,
+        error: {
+          code: "invalid_arguments",
+          message:
+            "At least one mutation field is required: title, model, serviceTier, reasoningEffort, fastMode, or executionMode.",
+        },
+      };
+    }
+
+    return {
+      ok: true,
+      data: {
+        mutation: {
+          backend: args.backend,
+          threadId,
+          dryRun,
+          changes,
+        },
       },
     };
   }
@@ -13295,6 +13425,53 @@ function readThreadInspectionBackend(
   return typeof value === "string" && isAppServerBackendKind(value)
     ? value
     : undefined;
+}
+
+function isThreadMutationExecutionMode(
+  value: unknown,
+): value is ThreadExecutionMode {
+  return value === "default" || value === "full-access";
+}
+
+function readThreadMutationModelSettings(
+  args: MutateThreadToolArgs,
+):
+  | {
+      value: Omit<SetThreadModelSettingsRequest, "backend" | "threadId">;
+      error?: never;
+    }
+  | { value?: never; error: string }
+  | { value?: undefined; error?: undefined } {
+  const settings: Omit<SetThreadModelSettingsRequest, "backend" | "threadId"> = {};
+  const stringFields = [
+    ["model", "model"],
+    ["serviceTier", "serviceTier"],
+    ["reasoningEffort", "reasoningEffort"],
+  ] as const;
+
+  for (const [inputField, outputField] of stringFields) {
+    if (!Object.hasOwn(args, inputField)) {
+      continue;
+    }
+    const value = args[inputField];
+    if (typeof value !== "string" || !value.trim()) {
+      return {
+        error: `${inputField} must be a non-empty string when provided.`,
+      };
+    }
+    settings[outputField] = value.trim();
+  }
+
+  if (Object.hasOwn(args, "fastMode")) {
+    if (typeof args.fastMode !== "boolean") {
+      return {
+        error: "fastMode must be a boolean when provided.",
+      };
+    }
+    settings.fastMode = args.fastMode;
+  }
+
+  return Object.keys(settings).length > 0 ? { value: settings } : {};
 }
 
 function clampInteger(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -5,7 +5,10 @@ import { stat } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 import type { DynamicToolSpec as CodexDynamicToolSpec } from "@pwrdrvr/codex-app-server-protocol/v2";
-import type { MessagingApprovalDecision } from "@pwragent/messaging-interface";
+import type {
+  MessagingApprovalDecision,
+  MessagingBindingRecord,
+} from "@pwragent/messaging-interface";
 import { getAppStateDb, getAppStateMode } from "../state/app-state";
 import type { OverlayStoreLike } from "../state/overlay-store-sqlite";
 import { requestShowThread } from "../window-show-thread";
@@ -101,6 +104,7 @@ import {
   type ThreadPermissionTransitionStatus,
   type ThreadTurnFailure,
   type ThreadAgentMetadata,
+  type MessagingThreadBindingSummary,
   type PwrAgentThreadInspectionRequest,
   type PwrAgentThreadInspectionResponse,
   type ThreadInspectionSummary,
@@ -12550,7 +12554,15 @@ export class DesktopBackendRegistry {
           backend: result.backend,
           threadId: result.threadId,
         });
-        return toThreadInspectionSummaryFromSearchResult(result, overlay?.agent);
+        const messagingBindings = await this.getThreadInspectionMessagingBindings({
+          backend: result.backend,
+          threadId: result.threadId,
+        });
+        return toThreadInspectionSummaryFromSearchResult(
+          result,
+          overlay?.agent,
+          messagingBindings,
+        );
       }),
     );
   }
@@ -12564,9 +12576,58 @@ export class DesktopBackendRegistry {
           backend: thread.source,
           threadId: thread.id,
         });
-        return toThreadInspectionSummary(thread, overlay?.agent);
+        const messagingBindings = await this.getThreadInspectionMessagingBindings({
+          backend: thread.source,
+          threadId: thread.id,
+        });
+        return toThreadInspectionSummary(thread, overlay?.agent, messagingBindings);
       }),
     );
+  }
+
+  private async getThreadInspectionMessagingBindings(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): Promise<MessagingThreadBindingSummary[] | undefined> {
+    const store = this.resolveMessagingInspectionStore();
+    if (!store) {
+      return undefined;
+    }
+    try {
+      const bindings = await store.findActiveBindingsForThread(params);
+      if (bindings.length === 0) {
+        return undefined;
+      }
+      return bindings.map(toMessagingThreadBindingSummary);
+    } catch (error) {
+      backendRegistryLog.warn("failed to resolve thread inspection messaging bindings", {
+        backend: params.backend,
+        error: error instanceof Error ? error.message : String(error),
+        threadId: params.threadId,
+      });
+      return undefined;
+    }
+  }
+
+  private resolveMessagingInspectionStore(): Pick<
+    MessagingStoreLike,
+    "findActiveBindingsForThread"
+  > | undefined {
+    if (this.messagingStore === null) {
+      return undefined;
+    }
+    if (this.messagingStore) {
+      return this.messagingStore;
+    }
+
+    try {
+      return getDesktopMessagingStore();
+    } catch (error) {
+      backendRegistryLog.debug("messaging store unavailable for thread inspection", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return undefined;
+    }
   }
 
   private notificationsEnabled(): boolean {
@@ -13271,6 +13332,7 @@ function filterThreadInspectionSummaries(
 function toThreadInspectionSummary(
   thread: AppServerThreadSummary,
   agent: ThreadAgentMetadata | undefined,
+  messagingBindings: MessagingThreadBindingSummary[] | undefined,
 ): ThreadInspectionSummary {
   return {
     backend: thread.source,
@@ -13287,6 +13349,7 @@ function toThreadInspectionSummary(
     reasoningEffort: thread.reasoningEffort,
     serviceTier: thread.serviceTier,
     fastMode: thread.fastMode,
+    ...(messagingBindings?.length ? { messagingBindings } : {}),
     linkedDirectories: thread.linkedDirectories,
   };
 }
@@ -13294,6 +13357,7 @@ function toThreadInspectionSummary(
 function toThreadInspectionSummaryFromSearchResult(
   result: ThreadSearchResult,
   agent: ThreadAgentMetadata | undefined,
+  messagingBindings: MessagingThreadBindingSummary[] | undefined,
 ): ThreadInspectionSummary {
   return {
     backend: result.backend,
@@ -13307,6 +13371,7 @@ function toThreadInspectionSummaryFromSearchResult(
     agent,
     model: result.model,
     linkedDirectories: result.linkedDirectories,
+    ...(messagingBindings?.length ? { messagingBindings } : {}),
     score: result.score,
     confidence: result.confidence,
     matchReasons: result.matchReasons,
@@ -13429,6 +13494,25 @@ function toThreadInspectionSearchSummary(
     ...(thread.matchReasons?.length
       ? { matchReasons: thread.matchReasons.slice(0, 6) }
       : {}),
+    ...(thread.messagingBindings?.length
+      ? {
+          messagingBindings: thread.messagingBindings.slice(0, 5).map((binding) => ({
+            bindingId: binding.bindingId,
+            platform: binding.platform,
+            ...(binding.conversationKind
+              ? { conversationKind: binding.conversationKind }
+              : {}),
+            ...(binding.conversationTitle
+              ? { conversationTitle: binding.conversationTitle }
+              : {}),
+            ...(binding.parentTitle ? { parentTitle: binding.parentTitle } : {}),
+            ...(binding.ancestorTitle
+              ? { ancestorTitle: binding.ancestorTitle }
+              : {}),
+            ...(binding.activeAt !== undefined ? { activeAt: binding.activeAt } : {}),
+          })),
+        }
+      : {}),
     ...(thread.snippets?.length
       ? {
           snippets: thread.snippets.slice(0, 3).map((snippet) => ({
@@ -13446,6 +13530,21 @@ function toThreadInspectionSearchSummary(
       path: directory.path,
       ...(directory.worktreePath ? { worktreePath: directory.worktreePath } : {}),
     })),
+  };
+}
+
+function toMessagingThreadBindingSummary(
+  binding: MessagingBindingRecord,
+): MessagingThreadBindingSummary {
+  const conversation = binding.channel.conversation;
+  return {
+    bindingId: binding.id,
+    platform: binding.channel.channel,
+    conversationKind: conversation.kind,
+    conversationTitle: conversation.title,
+    parentTitle: conversation.parentTitle,
+    ancestorTitle: conversation.ancestorTitle,
+    activeAt: binding.updatedAt,
   };
 }
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -12550,8 +12550,8 @@ export class DesktopBackendRegistry {
     }
 
     const dryRun = args.dryRun === true;
-    const changes: ThreadMutationAppliedChange[] = [];
 
+    let title: string | undefined;
     if (Object.hasOwn(args, "title")) {
       if (typeof args.title !== "string" || !args.title.trim()) {
         return {
@@ -12562,19 +12562,7 @@ export class DesktopBackendRegistry {
           },
         };
       }
-      const title = args.title.trim();
-      if (!dryRun) {
-        await this.renameThread({
-          backend: args.backend,
-          threadId,
-          name: title,
-        });
-      }
-      changes.push({
-        field: "title",
-        status: dryRun ? "would_apply" : "applied",
-        to: title,
-      });
+      title = args.title.trim();
     }
 
     const modelSettings = readThreadMutationModelSettings(args);
@@ -12587,21 +12575,8 @@ export class DesktopBackendRegistry {
         },
       };
     }
-    if (modelSettings.value) {
-      if (!dryRun) {
-        await this.setThreadModelSettings({
-          backend: args.backend,
-          threadId,
-          ...modelSettings.value,
-        });
-      }
-      changes.push({
-        field: "model_settings",
-        status: dryRun ? "would_apply" : "applied",
-        to: modelSettings.value,
-      });
-    }
 
+    let executionMode: ThreadExecutionMode | undefined;
     if (Object.hasOwn(args, "executionMode")) {
       if (!isThreadMutationExecutionMode(args.executionMode)) {
         return {
@@ -12612,17 +12587,29 @@ export class DesktopBackendRegistry {
           },
         };
       }
-      if (!dryRun) {
-        await this.setThreadExecutionMode({
-          backend: args.backend,
-          threadId,
-          executionMode: args.executionMode,
-        });
-      }
+      executionMode = args.executionMode;
+    }
+
+    const changes: ThreadMutationAppliedChange[] = [];
+    if (title !== undefined) {
+      changes.push({
+        field: "title",
+        status: dryRun ? "would_apply" : "applied",
+        to: title,
+      });
+    }
+    if (modelSettings.value) {
+      changes.push({
+        field: "model_settings",
+        status: dryRun ? "would_apply" : "applied",
+        to: modelSettings.value,
+      });
+    }
+    if (executionMode !== undefined) {
       changes.push({
         field: "execution_mode",
         status: dryRun ? "would_apply" : "applied",
-        to: args.executionMode,
+        to: executionMode,
       });
     }
 
@@ -12635,6 +12622,30 @@ export class DesktopBackendRegistry {
             "At least one mutation field is required: title, model, serviceTier, reasoningEffort, fastMode, or executionMode.",
         },
       };
+    }
+
+    if (title !== undefined && !dryRun) {
+      await this.renameThread({
+        backend: args.backend,
+        threadId,
+        name: title,
+      });
+    }
+
+    if (modelSettings.value && !dryRun) {
+      await this.setThreadModelSettings({
+        backend: args.backend,
+        threadId,
+        ...modelSettings.value,
+      });
+    }
+
+    if (executionMode !== undefined && !dryRun) {
+      await this.setThreadExecutionMode({
+        backend: args.backend,
+        threadId,
+        executionMode,
+      });
     }
 
     return {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -628,7 +628,7 @@ export class MessagingController {
     request: PwrAgentMessagingRequest,
   ): Promise<PwrAgentMessagingResponse> {
     switch (request.operation) {
-      case "get_current_location": {
+      case "get_current_messaging_surface": {
         const origin = await this.resolveAgentMessagingOrigin(request.context);
         if (!origin.ok) {
           return origin;

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -628,6 +628,7 @@ export class MessagingController {
     request: PwrAgentMessagingRequest,
   ): Promise<PwrAgentMessagingResponse> {
     switch (request.operation) {
+      case "get_current_location":
       case "get_current_messaging_surface": {
         const origin = await this.resolveAgentMessagingOrigin(request.context);
         if (!origin.ok) {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -29,6 +29,7 @@ import type {
   LaunchpadWorkMode,
   MaterializedDirectoryLaunchpadThread,
   MessagingToolUpdateMode,
+  PwrAgentMessagingBoundThreadSummary,
   PwrAgentMessagingLocationSummary,
   PwrAgentMessagingManagedConversationSummary,
   PwrAgentMessagingRequest,
@@ -270,6 +271,14 @@ type ActiveAgentMessagingOrigin = {
 
 type AgentMessagingOriginResolution =
   | { ok: true; origin: ActiveAgentMessagingOrigin }
+  | Extract<PwrAgentMessagingResponse, { ok: false }>;
+
+type AttachTargetResolution =
+  | {
+      ok: true;
+      navigation: NavigationSnapshot;
+      thread: NavigationThreadSummary;
+    }
   | Extract<PwrAgentMessagingResponse, { ok: false }>;
 
 type ExecutionModeResolution = {
@@ -10575,7 +10584,9 @@ export class MessagingController {
       return target;
     }
 
-    const location = await this.summarizeAgentMessagingLocation(origin.origin);
+    const location = await this.summarizeAgentMessagingLocation(origin.origin, {
+      navigation: target.navigation,
+    });
     const resolvedPlacement = this.resolveAttachPlacement({
       location,
       origin: origin.origin,
@@ -10644,7 +10655,10 @@ export class MessagingController {
     return {
       ok: true,
       data: {
-        binding: summarizeMessagingBinding(visibleBinding),
+        binding: summarizeMessagingBinding(
+          visibleBinding,
+          summarizeNavigationThreadForMessaging(target.thread),
+        ),
         channel: visibleBinding.channel.channel,
         conversation: summarizeMessagingConversation(visibleBinding.channel.conversation),
         createdConversation: createdConversation
@@ -10662,7 +10676,7 @@ export class MessagingController {
   private async resolveAttachTarget(
     backend: AppServerBackendKind,
     threadId: string,
-  ): Promise<{ ok: true } | Extract<PwrAgentMessagingResponse, { ok: false }>> {
+  ): Promise<AttachTargetResolution> {
     let navigation: NavigationSnapshot;
     try {
       navigation = await this.options.backend.getNavigationSnapshot({ backend });
@@ -10694,7 +10708,7 @@ export class MessagingController {
       };
     }
 
-    return { ok: true };
+    return { ok: true, navigation, thread: target };
   }
 
   private resolveAttachPlacement(params: {
@@ -10803,14 +10817,51 @@ export class MessagingController {
 
   private async summarizeAgentMessagingLocation(
     origin: ActiveAgentMessagingOrigin,
+    options: { navigation?: NavigationSnapshot } = {},
   ): Promise<PwrAgentMessagingLocationSummary> {
     return {
       actor: summarizeMessagingActor(origin.event.actor),
-      binding: summarizeMessagingBinding(origin.binding),
+      binding: summarizeMessagingBinding(
+        origin.binding,
+        await this.resolveBoundThreadSummary(
+          origin.binding,
+          options.navigation,
+        ),
+      ),
       channel: origin.event.channel.channel,
       conversation: summarizeMessagingConversation(origin.event.channel.conversation),
       managedConversation: await this.resolveManagedConversationSummary(origin),
     };
+  }
+
+  private async resolveBoundThreadSummary(
+    binding: MessagingBindingRecord,
+    navigation?: NavigationSnapshot,
+  ): Promise<PwrAgentMessagingBoundThreadSummary | undefined> {
+    const existingThread = navigation
+      ? findThreadForBinding(navigation, binding)
+      : undefined;
+    if (existingThread) {
+      return summarizeNavigationThreadForMessaging(existingThread);
+    }
+    try {
+      const refreshedNavigation = await this.options.backend.getNavigationSnapshot({
+        backend: binding.backend,
+      });
+      const thread = findThreadForBinding(refreshedNavigation, binding);
+      if (!thread) {
+        return undefined;
+      }
+      return summarizeNavigationThreadForMessaging(thread);
+    } catch (error) {
+      this.logger.warn?.("failed to resolve messaging surface bound thread summary", {
+        backend: binding.backend,
+        bindingId: binding.id,
+        error: error instanceof Error ? error.message : String(error),
+        threadId: binding.threadId,
+      });
+      return undefined;
+    }
   }
 
   private async resolveManagedConversationSummary(
@@ -12361,6 +12412,7 @@ function summarizeMessagingActor(
 
 function summarizeMessagingBinding(
   binding: MessagingBindingRecord,
+  thread?: PwrAgentMessagingBoundThreadSummary,
 ): PwrAgentMessagingLocationSummary["binding"] {
   return {
     id: binding.id,
@@ -12368,6 +12420,21 @@ function summarizeMessagingBinding(
     threadId: binding.threadId,
     targetKind: binding.targetKind ?? "thread",
     displayName: binding.displayName,
+    ...(thread ? { thread } : {}),
+  };
+}
+
+function summarizeNavigationThreadForMessaging(
+  thread: NavigationThreadSummary,
+): PwrAgentMessagingBoundThreadSummary {
+  const gitBranch = thread.gitBranch ?? thread.observedGitBranch;
+  return {
+    title: thread.title,
+    ...(thread.projectKey ? { projectKey: thread.projectKey } : {}),
+    ...(gitBranch ? { gitBranch } : {}),
+    ...(thread.model ? { model: thread.model } : {}),
+    ...(thread.executionMode ? { executionMode: thread.executionMode } : {}),
+    ...(thread.agent?.name ? { agentName: thread.agent.name } : {}),
   };
 }
 

--- a/packages/shared/src/contracts/messaging-tools.ts
+++ b/packages/shared/src/contracts/messaging-tools.ts
@@ -11,7 +11,7 @@ import type {
 export const PWRAGENT_MESSAGING_TOOL_NAMESPACE = "pwragent_messaging";
 
 export const PWRAGENT_MESSAGING_OPERATION_NAMES = [
-  "get_current_location",
+  "get_current_messaging_surface",
   "attach_thread_here",
 ] as const;
 
@@ -111,7 +111,7 @@ export type AttachThreadHereResult = {
 };
 
 export type PwrAgentMessagingToolArgsByOperation = {
-  get_current_location: GetCurrentMessagingLocationToolArgs;
+  get_current_messaging_surface: GetCurrentMessagingLocationToolArgs;
   attach_thread_here: AttachThreadHereToolArgs;
 };
 

--- a/packages/shared/src/contracts/messaging-tools.ts
+++ b/packages/shared/src/contracts/messaging-tools.ts
@@ -15,8 +15,23 @@ export const PWRAGENT_MESSAGING_OPERATION_NAMES = [
   "attach_thread_here",
 ] as const;
 
-export type PwrAgentMessagingOperationName =
+export const PWRAGENT_MESSAGING_LEGACY_OPERATION_NAMES = [
+  "get_current_location",
+] as const;
+
+export const PWRAGENT_MESSAGING_CALLABLE_OPERATION_NAMES = [
+  ...PWRAGENT_MESSAGING_OPERATION_NAMES,
+  ...PWRAGENT_MESSAGING_LEGACY_OPERATION_NAMES,
+] as const;
+
+export type PwrAgentMessagingAdvertisedOperationName =
   (typeof PWRAGENT_MESSAGING_OPERATION_NAMES)[number];
+
+export type PwrAgentMessagingLegacyOperationName =
+  (typeof PWRAGENT_MESSAGING_LEGACY_OPERATION_NAMES)[number];
+
+export type PwrAgentMessagingOperationName =
+  (typeof PWRAGENT_MESSAGING_CALLABLE_OPERATION_NAMES)[number];
 
 export const PWRAGENT_MESSAGING_ERROR_CODES = [
   "invalid_arguments",
@@ -112,6 +127,7 @@ export type AttachThreadHereResult = {
 
 export type PwrAgentMessagingToolArgsByOperation = {
   get_current_messaging_surface: GetCurrentMessagingSurfaceToolArgs;
+  get_current_location: GetCurrentMessagingSurfaceToolArgs;
   attach_thread_here: AttachThreadHereToolArgs;
 };
 

--- a/packages/shared/src/contracts/messaging-tools.ts
+++ b/packages/shared/src/contracts/messaging-tools.ts
@@ -85,7 +85,7 @@ export type PwrAgentMessagingLocationSummary = {
   managedConversation: PwrAgentMessagingManagedConversationSummary;
 };
 
-export type GetCurrentMessagingLocationToolArgs = Record<string, never>;
+export type GetCurrentMessagingSurfaceToolArgs = Record<string, never>;
 
 export type AttachThreadHerePlacement =
   | "auto"
@@ -111,7 +111,7 @@ export type AttachThreadHereResult = {
 };
 
 export type PwrAgentMessagingToolArgsByOperation = {
-  get_current_messaging_surface: GetCurrentMessagingLocationToolArgs;
+  get_current_messaging_surface: GetCurrentMessagingSurfaceToolArgs;
   attach_thread_here: AttachThreadHereToolArgs;
 };
 

--- a/packages/shared/src/contracts/messaging-tools.ts
+++ b/packages/shared/src/contracts/messaging-tools.ts
@@ -1,5 +1,6 @@
 import type {
   AppServerBackendKind,
+  ThreadExecutionMode,
   ThreadIdentifier,
 } from "./normalized-app-server";
 import type {
@@ -67,12 +68,22 @@ export type PwrAgentMessagingActorSummary = {
   isBot?: boolean;
 };
 
+export type PwrAgentMessagingBoundThreadSummary = {
+  title: string;
+  projectKey?: string;
+  gitBranch?: string;
+  model?: string;
+  executionMode?: ThreadExecutionMode;
+  agentName?: string;
+};
+
 export type PwrAgentMessagingBindingSummary = {
   id: string;
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;
   targetKind: MessagingBindingTargetKind;
   displayName?: string;
+  thread?: PwrAgentMessagingBoundThreadSummary;
 };
 
 export type PwrAgentMessagingManagedConversationOperationSummary = {

--- a/packages/shared/src/contracts/thread-tools.ts
+++ b/packages/shared/src/contracts/thread-tools.ts
@@ -5,7 +5,10 @@ import type {
   ThreadIdentifier,
 } from "./normalized-app-server";
 import type { LinkedDirectorySummary } from "./normalized-app-server";
-import type { ThreadAgentMetadata } from "./navigation";
+import type {
+  MessagingThreadBindingSummary,
+  ThreadAgentMetadata,
+} from "./navigation";
 import type {
   ThreadSearchContentMode,
   ThreadSearchConfidenceBand,
@@ -86,6 +89,7 @@ export type ThreadInspectionSummary = {
   score?: number;
   confidence?: ThreadSearchConfidenceBand;
   matchReasons?: ThreadSearchMatchReason[];
+  messagingBindings?: MessagingThreadBindingSummary[];
   snippets?: ThreadSearchSnippet[];
 };
 

--- a/packages/shared/src/contracts/thread-tools.ts
+++ b/packages/shared/src/contracts/thread-tools.ts
@@ -24,6 +24,7 @@ export const PWRAGENT_THREAD_TOOL_NAMESPACE = "pwragent_threads";
 export const PWRAGENT_THREAD_INSPECTION_OPERATION_NAMES = [
   "search_threads",
   "get_thread_status",
+  "mutate_thread",
 ] as const;
 
 export type PwrAgentThreadInspectionOperationName =
@@ -70,6 +71,47 @@ export type GetThreadStatusToolArgs = {
   threadId: ThreadIdentifier;
 };
 
+export type MutateThreadToolArgs = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  /**
+   * Renames the PwrAgent thread itself. This does not rename any attached
+   * Telegram topic, Discord thread, or other messaging surface.
+   */
+  title?: string;
+  model?: string;
+  serviceTier?: string;
+  reasoningEffort?: string;
+  fastMode?: boolean;
+  executionMode?: ThreadExecutionMode;
+  /**
+   * Validate and report the requested mutations without applying them.
+   */
+  dryRun?: boolean;
+};
+
+export type ThreadMutationField =
+  | "title"
+  | "model_settings"
+  | "execution_mode";
+
+export type ThreadMutationChangeStatus =
+  | "would_apply"
+  | "applied";
+
+export type ThreadMutationAppliedChange = {
+  field: ThreadMutationField;
+  status: ThreadMutationChangeStatus;
+  to?: unknown;
+};
+
+export type ThreadMutationResult = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  dryRun: boolean;
+  changes: ThreadMutationAppliedChange[];
+};
+
 export type ThreadInspectionSummary = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;
@@ -102,6 +144,7 @@ export type ThreadStatusInspectionSummary = ThreadInspectionSummary & {
 export type PwrAgentThreadInspectionToolArgsByOperation = {
   search_threads: SearchThreadsToolArgs;
   get_thread_status: GetThreadStatusToolArgs;
+  mutate_thread: MutateThreadToolArgs;
 };
 
 export type PwrAgentThreadInspectionToolArgs<
@@ -137,6 +180,9 @@ export type PwrAgentThreadInspectionResponse =
           }
         | {
             thread: ThreadStatusInspectionSummary;
+          }
+        | {
+            mutation: ThreadMutationResult;
           };
     }
   | {


### PR DESCRIPTION
## Summary

- Rename the advertised Agent messaging-origin tool from `get_current_location` to `get_current_messaging_surface`
- Keep `get_current_location` as a deprecated, non-advertised facade for existing Agent thread contexts
- Return compact bound-thread identity on `get_current_messaging_surface` so Agents can answer common "where am I?" questions without a second thread-status call
- Include active messaging binding summaries in `search_threads` and `get_thread_status` tool results
- Add a guarded `mutate_thread` Agent tool for PwrAgent thread title, model settings, fast mode, and execution mode changes
- Clarify that `attach_thread_here.title` names a native messaging topic/thread, not the PwrAgent thread

## Verification

- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts -t "Agent dynamic tools|thread inspection|mutates PwrAgent thread settings|dry-runs thread mutations"`
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts -t "mutates PwrAgent thread settings|dry-runs thread mutations|rejects invalid thread mutations"`
- `pnpm test apps/desktop/src/main/__tests__/pwragent-thread-agent-tools.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts -t "PwrAgent thread agent tools|mutates PwrAgent thread settings|dry-runs thread mutations"`
- `pnpm test apps/desktop/src/main/__tests__/pwragent-messaging-agent-tools.test.ts apps/desktop/src/main/__tests__/messaging-controller.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts -t "PwrAgent messaging agent tools|current messaging surface|Agent dynamic tools"`
- `pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts apps/desktop/src/main/__tests__/pwragent-messaging-agent-tools.test.ts`
- `pnpm --filter @pwragent/shared typecheck`
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `git diff --check`

## Notes

- This lets Agents answer whether a found PwrAgent thread is attached to any messaging surface without relying on the current turn's messaging origin.
- `mutate_thread` is intentionally explicit and scoped. For example, renaming a PwrAgent thread to `Pizza Agent` is a `title` mutation, while renaming a Telegram topic or Discord thread remains outside this tool.
