### PR TITLE
feat(desktop): browser-style back/forward across threads and search

### DIFF
--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -63,6 +63,19 @@ pnpm dev
 - For visual verification of UI changes, either command can show real threads in the sidebar and thread detail pane; prefer `dev:no-messaging` when the UI work does not need live messaging.
 - If the app starts but shows no threads, you are likely running from the wrong directory or with overridden env vars.
 
+## E2E Locator Hygiene Around Global Chrome
+
+The thread/search title bars always render the history Back/Forward
+buttons (accessible names `Back` and `Forward`), and they stay mounted
+behind overlays like the onboarding wizard. A page-wide
+`getByRole("button", { name: /Back/i })` will resolve to multiple
+elements and fail Playwright strict mode. When writing specs:
+
+- Scope to a container (`dialog.getByRole(...)`) or anchor the regex to
+  the full label (e.g. the wizard's `/^← Back/i`).
+- Target the history buttons themselves via their test ids:
+  `history-nav-back` / `history-nav-forward`.
+
 ## Inspecting Branch Drift Dialog E2E
 
 To open the replay-backed "Thread branch changed" dialog and keep Electron

--- a/apps/desktop/e2e/onboarding-wizard.spec.ts
+++ b/apps/desktop/e2e/onboarding-wizard.spec.ts
@@ -241,7 +241,9 @@ test.describe("Onboarding wizard", () => {
       await continueBtn.click({ force: true });
       await expect(flash).toHaveCount(1);
 
-      await app.window.getByRole("button", { name: /Back/i }).click();
+      // Anchored like the other call sites: the loose /Back/i also matches
+      // the title-bar history Back button in the shell behind the wizard.
+      await app.window.getByRole("button", { name: /^← Back/i }).click();
       // Back lands on the shared Codex login step (login already deferred,
       // so its Continue is live); Continue returns to messaging-safety.
       await app.window.getByRole("button", { name: /^Continue/i }).click();

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -3,19 +3,23 @@ import {
   lazy,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
   type ComponentType,
   type CSSProperties,
   type PointerEvent,
 } from "react";
-import type {
-  DesktopBootInfo,
-  DesktopCodexProfileModel,
-  DesktopPwrAgentProfileSummary,
+import {
+  parseThreadIdentityKey,
+  type DesktopBootInfo,
+  type DesktopCodexProfileModel,
+  type DesktopPwrAgentProfileSummary,
 } from "@pwragent/shared";
 import { Sidebar } from "./features/navigation/Sidebar";
 import { AppTitleBar } from "./features/chrome/AppTitleBar";
+import type { HistoryNavControls } from "./features/chrome/HistoryNavButtons";
+import { useHistoryNavHotkeys } from "./features/chrome/useHistoryNavHotkeys";
 import { useLayoutChordHotkeys } from "./features/chrome/useLayoutChordHotkeys";
 import type { SettingsSection } from "./features/settings/SettingsScreen";
 import {
@@ -35,6 +39,10 @@ import { useAppearance, type AppearanceController } from "./lib/useAppearance";
 import { useBackendSummaries } from "./lib/useBackendSummaries";
 import { useDesktopApi, type DesktopApi } from "./lib/desktop-api";
 import { useRuntimeIdentity } from "./lib/runtime-identity";
+import {
+  useNavigationHistory,
+  type NavigationHistoryLocation,
+} from "./lib/useNavigationHistory";
 import { useThreadNavigation } from "./lib/useThreadNavigation";
 import { usePwrAgentProfiles } from "./lib/usePwrAgentProfiles";
 import { usePullRequestRefresh } from "./features/pr-status/usePullRequestRefresh";
@@ -50,7 +58,10 @@ import {
 } from "../../shared/hot-cpu-profile";
 import { AppUpdateBanner } from "./features/update/AppUpdateBanner";
 import { AutomationsScreen } from "./features/automations/AutomationsScreen";
-import { ThreadSearchPanel } from "./features/thread-search/ThreadSearchPanel";
+import {
+  ThreadSearchPanel,
+  useThreadSearchPanelState,
+} from "./features/thread-search/ThreadSearchPanel";
 
 const SETTINGS_SECTIONS = new Set<SettingsSection>([
   "general",
@@ -309,6 +320,48 @@ function DesktopAppShell(props: {
     onRefreshNavigation: navigation.refresh,
     selectedThread: navigation.selectedThread,
   });
+  // Browser-style back/forward across threads and the search view. The
+  // tracked location is (mainView, selected thread); Settings, Automations,
+  // and launchpads stay untracked — they're modal-ish chrome, not places
+  // you navigate back to (see useNavigationHistory). Search query/results
+  // live up here so Back lands on a still-populated results list after
+  // opening a result unmounts the panel.
+  const threadSearchState = useThreadSearchPanelState();
+  const historyLocation = useMemo<NavigationHistoryLocation | undefined>(() => {
+    if (mainView === "search") {
+      return { view: "search" };
+    }
+    if (mainView === "thread" && navigation.selectedThreadKey) {
+      return { view: "thread", threadKey: navigation.selectedThreadKey };
+    }
+    return undefined;
+  }, [mainView, navigation.selectedThreadKey]);
+  const showThread = navigation.showThread;
+  const restoreHistoryLocation = useCallback(
+    (location: NavigationHistoryLocation): void => {
+      if (location.view === "search") {
+        setMainView("search");
+        return;
+      }
+      setMainView("thread");
+      const parts = parseThreadIdentityKey(location.threadKey);
+      if (parts) {
+        void showThread(parts);
+      }
+    },
+    [showThread],
+  );
+  const history = useNavigationHistory({
+    current: historyLocation,
+    restore: restoreHistoryLocation,
+  });
+  useHistoryNavHotkeys({ onBack: history.goBack, onForward: history.goForward });
+  const historyNav: HistoryNavControls = {
+    canGoBack: history.canGoBack,
+    canGoForward: history.canGoForward,
+    onBack: history.goBack,
+    onForward: history.goForward,
+  };
   const baseComposerDraftStore = useComposerDraftStore();
   const composerDraftStore = useDurableComposerDraftStore(
     baseComposerDraftStore,
@@ -578,6 +631,7 @@ function DesktopAppShell(props: {
     sidebarHidden,
     onToggleSidebar: () => setSidebarHiddenPersisted(!sidebarHidden),
     mastheadActions,
+    historyNav,
     onHandoffThreadWorkspace: navigation.selectedThread
       ? async (request) =>
           await navigation.handoffThreadWorkspace(
@@ -772,6 +826,8 @@ function DesktopAppShell(props: {
                 onToggleRail: () => setContextRailPinnedPersisted(!contextRailPinned),
               }}
               masthead={mastheadActions}
+              history={historyNav}
+              state={threadSearchState}
               onOpenResult={async (result) => {
                 setMainView("thread");
                 await navigation.showThread(result);
@@ -790,6 +846,7 @@ function DesktopAppShell(props: {
                   onToggleRail: () => setContextRailPinnedPersisted(!contextRailPinned),
                 }}
                 masthead={mastheadActions}
+                history={historyNav}
               />
             </section>
           ) : ThreadViewComponent ? (

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -11,6 +11,7 @@ import {
   type PointerEvent,
 } from "react";
 import {
+  buildThreadIdentityKey,
   parseThreadIdentityKey,
   type DesktopBootInfo,
   type DesktopCodexProfileModel,
@@ -351,17 +352,35 @@ function DesktopAppShell(props: {
     },
     [showThread],
   );
+  // Undefined while the snapshot is empty/loading so a transient blank
+  // thread list can't wipe the stacks; otherwise dead threads (archived,
+  // backend disconnected) are pruned from history.
+  const liveThreadKeys = useMemo<ReadonlySet<string> | undefined>(
+    () =>
+      navigation.threads.length > 0
+        ? new Set(
+            navigation.threads.map((thread) =>
+              buildThreadIdentityKey(thread.source, thread.id),
+            ),
+          )
+        : undefined,
+    [navigation.threads],
+  );
   const history = useNavigationHistory({
     current: historyLocation,
+    liveThreadKeys,
     restore: restoreHistoryLocation,
   });
   useHistoryNavHotkeys({ onBack: history.goBack, onForward: history.goForward });
-  const historyNav: HistoryNavControls = {
-    canGoBack: history.canGoBack,
-    canGoForward: history.canGoForward,
-    onBack: history.goBack,
-    onForward: history.goForward,
-  };
+  const historyNav: HistoryNavControls = useMemo(
+    () => ({
+      canGoBack: history.canGoBack,
+      canGoForward: history.canGoForward,
+      onBack: history.goBack,
+      onForward: history.goForward,
+    }),
+    [history],
+  );
   const baseComposerDraftStore = useComposerDraftStore();
   const composerDraftStore = useDurableComposerDraftStore(
     baseComposerDraftStore,

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -3029,6 +3029,236 @@ describe("App", () => {
     expect(readThread).toHaveBeenCalledTimes(2);
   });
 
+  it("walks back and forward across threads and search from the title bar", async () => {
+    const searchThreads = vi.fn(async () => ({
+      backend: "all" as const,
+      contentMode: "available" as const,
+      fetchedAt: Date.now(),
+      filters: { backend: "all" as const, includeArchived: false },
+      query: "history",
+      results: [
+        {
+          backend: "codex" as const,
+          confidence: "high" as const,
+          identityKey: "codex:thread-1",
+          linkedDirectories: [],
+          matchReasons: [{ kind: "exact_title" as const }],
+          score: 90,
+          snippets: [
+            {
+              scope: "provider_content" as const,
+              text: "Opened from search.",
+            },
+          ],
+          source: "codex" as const,
+          threadId: "thread-1",
+          title: "First cached thread",
+        },
+      ],
+      searchedScopes: ["metadata" as const],
+      semanticMode: "disabled" as const,
+      unavailableScopes: [],
+    }));
+
+    Object.defineProperty(window, "pwragent", {
+      configurable: true,
+      value: {
+        ping: () => "pong",
+        listSkills: async () => ({
+          backend: "codex" as const,
+          fetchedAt: Date.now(),
+          data: [],
+        }),
+        listBackends: async () => ({
+          fetchedAt: Date.now(),
+          backends: [
+            {
+              kind: "codex",
+              label: "Codex app server",
+              available: true,
+              methods: ["thread/list", "thread/read", "turn/start"],
+              capabilities: {
+                listThreads: true,
+                createThread: false,
+                resumeThread: true,
+                renameThread: false,
+                readThread: true,
+                startTurn: true,
+                interruptTurn: true,
+                steerTurn: false,
+                transcriptPagination: true,
+                toolUse: false,
+                approvalRequests: false,
+                multiDirectoryThreads: true,
+              },
+              executionModes: [
+                {
+                  mode: "default",
+                  label: "Default Access",
+                  available: true,
+                  isDefault: true,
+                },
+              ],
+            },
+          ],
+        }),
+        getNavigationSnapshot: async () => ({
+          backend: "all" as const,
+          fetchedAt: Date.now(),
+          unchanged: false,
+          inboxThreadKeys: ["codex:thread-1"],
+          threads: [
+            {
+              id: "thread-1",
+              title: "First cached thread",
+              titleSource: "explicit" as const,
+              summary: "Cached first thread",
+              source: "codex" as const,
+              linkedDirectories: [],
+              inbox: {
+                inInbox: true,
+                reason: "new-thread" as const,
+              },
+              updatedAt: 1_000,
+            },
+            {
+              id: "thread-2",
+              title: "Second cached thread",
+              titleSource: "explicit" as const,
+              summary: "Cached second thread",
+              source: "codex" as const,
+              linkedDirectories: [],
+              inbox: {
+                inInbox: false,
+              },
+              updatedAt: 2_000,
+            },
+          ],
+        }),
+        markThreadSeen: async ({
+          backend,
+          threadId,
+        }: {
+          backend: "codex" | "grok";
+          threadId: string;
+        }) => ({
+          backend,
+          threadId,
+          seenAt: Date.now(),
+        }),
+        onAgentEvent: () => () => undefined,
+        onWindowFocus: () => () => undefined,
+        platform: "darwin",
+        readThread: async ({
+          backend,
+          threadId,
+        }: {
+          backend: "codex" | "grok";
+          threadId: string;
+        }) => ({
+          backend,
+          fetchedAt: Date.now(),
+          threadId,
+          replay: {
+            entries: [],
+            messages: [],
+            pagination: {
+              supportsPagination: false,
+              hasPreviousPage: false,
+            },
+          },
+        }),
+        searchThreads,
+        versions: {
+          electron: "41.2.1",
+        },
+      },
+    });
+
+    render(<App />);
+
+    await screen.findByRole("heading", {
+      level: 2,
+      name: "First cached thread",
+    });
+
+    // Nowhere to go yet — the auto-selected first thread is the only entry.
+    expect(screen.getByRole("button", { name: "Back" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Forward" })).toBeDisabled();
+
+    await clickButton(/Second cached thread/i);
+    await screen.findByRole("heading", {
+      level: 2,
+      name: "Second cached thread",
+    });
+    expect(screen.getByRole("button", { name: "Back" })).toBeEnabled();
+
+    // Search, then open the result (thread 1).
+    await clickButton("Search threads");
+    fireEvent.change(screen.getByRole("textbox", { name: "Search threads" }), {
+      target: { value: "history" },
+    });
+    await clickButton("Search");
+    await screen.findByText("Opened from search.");
+    await clickButton(/Opened from search/);
+    await screen.findByRole("heading", {
+      level: 2,
+      name: "First cached thread",
+    });
+
+    // Back lands on search with the results still populated — no re-query.
+    await clickButton("Back");
+    await screen.findByRole("heading", { level: 2, name: "Search" });
+    expect(screen.getByText("Opened from search.")).toBeInTheDocument();
+    expect(searchThreads).toHaveBeenCalledTimes(1);
+
+    // Back again: the thread we were reading before opening search.
+    await clickButton("Back");
+    await screen.findByRole("heading", {
+      level: 2,
+      name: "Second cached thread",
+    });
+
+    // Back to the start, where the affordance bottoms out.
+    await clickButton("Back");
+    await screen.findByRole("heading", {
+      level: 2,
+      name: "First cached thread",
+    });
+    expect(screen.getByRole("button", { name: "Back" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Forward" })).toBeEnabled();
+
+    await clickButton("Forward");
+    await screen.findByRole("heading", {
+      level: 2,
+      name: "Second cached thread",
+    });
+
+    // The window-level chord (⌘[) and the mouse thumb buttons drive the
+    // same history.
+    await act(async () => {
+      fireEvent.keyDown(window, {
+        metaKey: true,
+        code: "BracketLeft",
+        key: "[",
+      });
+      await Promise.resolve();
+    });
+    await screen.findByRole("heading", {
+      level: 2,
+      name: "First cached thread",
+    });
+
+    await act(async () => {
+      fireEvent.mouseUp(window, { button: 4 });
+      await Promise.resolve();
+    });
+    await screen.findByRole("heading", {
+      level: 2,
+      name: "Second cached thread",
+    });
+  });
+
   it("renames the selected thread from the sidebar actions menu", async () => {
     let threadTitle = "Build Codex client";
     const renameThread = vi.fn(

--- a/apps/desktop/src/renderer/src/features/chrome/HistoryNavButtons.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/HistoryNavButtons.tsx
@@ -1,0 +1,44 @@
+import { ChevronLeftIcon, ChevronRightIcon } from "../../icons";
+import { formatPrimaryAccel } from "../../lib/keyboard-accel";
+
+export type HistoryNavControls = {
+  canGoBack: boolean;
+  canGoForward: boolean;
+  onBack: () => void;
+  onForward: () => void;
+};
+
+/**
+ * Browser-style Back/Forward pair for thread + search navigation. Lives at
+ * the leading edge of the thread/search title bars (ThreadHeader and
+ * ThreadPlaceholderHeader). The buttons only fire the callbacks — history
+ * state is owned by `useNavigationHistory` in the app shell, and the
+ * window-level shortcuts (⌘[/⌘], mouse back/forward buttons) are bound
+ * once there via `useHistoryNavHotkeys`.
+ */
+export function HistoryNavButtons(props: HistoryNavControls) {
+  return (
+    <div className="history-nav" role="group" aria-label="History navigation">
+      <button
+        type="button"
+        className="history-nav__chip"
+        aria-label="Back"
+        title={`Back  (${formatPrimaryAccel("[")})`}
+        disabled={!props.canGoBack}
+        onClick={props.onBack}
+      >
+        <ChevronLeftIcon size={15} aria-hidden />
+      </button>
+      <button
+        type="button"
+        className="history-nav__chip"
+        aria-label="Forward"
+        title={`Forward  (${formatPrimaryAccel("]")})`}
+        disabled={!props.canGoForward}
+        onClick={props.onForward}
+      >
+        <ChevronRightIcon size={15} aria-hidden />
+      </button>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/chrome/HistoryNavButtons.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/HistoryNavButtons.tsx
@@ -23,6 +23,7 @@ export function HistoryNavButtons(props: HistoryNavControls) {
         type="button"
         className="history-nav__chip"
         aria-label="Back"
+        data-testid="history-nav-back"
         title={`Back  (${formatPrimaryAccel("[")})`}
         disabled={!props.canGoBack}
         onClick={props.onBack}
@@ -33,6 +34,7 @@ export function HistoryNavButtons(props: HistoryNavControls) {
         type="button"
         className="history-nav__chip"
         aria-label="Forward"
+        data-testid="history-nav-forward"
         title={`Forward  (${formatPrimaryAccel("]")})`}
         disabled={!props.canGoForward}
         onClick={props.onForward}

--- a/apps/desktop/src/renderer/src/features/chrome/useHistoryNavHotkeys.ts
+++ b/apps/desktop/src/renderer/src/features/chrome/useHistoryNavHotkeys.ts
@@ -1,0 +1,58 @@
+import { useEffect, useRef } from "react";
+import { matchHistoryNavChord } from "../../lib/keyboard-accel";
+
+/**
+ * Binds the single window-level listener pair for history navigation:
+ * the keyboard chords (⌘[/⌘], Alt+←/→ — see `matchHistoryNavChord`) and
+ * the back/forward thumb buttons on a mouse (Chromium reports them as
+ * `button` 3 and 4). Call this exactly ONCE, from the always-mounted
+ * shell owner — never per HistoryNavButtons instance — mirroring
+ * `useLayoutChordHotkeys`, so the affordance works app-wide regardless
+ * of which header (thread, placeholder, search) is on screen.
+ *
+ * A ref holds the latest handlers so the listeners bind once and never
+ * go stale, even though the callbacks close over fresh state each render.
+ */
+export function useHistoryNavHotkeys(handlers: {
+  onBack: () => void;
+  onForward: () => void;
+}): void {
+  const handlersRef = useRef(handlers);
+  useEffect(() => {
+    handlersRef.current = handlers;
+  });
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent): void => {
+      const chord = matchHistoryNavChord(event);
+      if (chord === null) {
+        return;
+      }
+      event.preventDefault();
+      if (chord === "back") {
+        handlersRef.current.onBack();
+      } else {
+        handlersRef.current.onForward();
+      }
+    };
+    const onMouseUp = (event: MouseEvent): void => {
+      if (event.button !== 3 && event.button !== 4) {
+        return;
+      }
+      // The renderer has no webContents history, so without this the
+      // thumb buttons would be dead clicks; claim them for thread history.
+      event.preventDefault();
+      if (event.button === 3) {
+        handlersRef.current.onBack();
+      } else {
+        handlersRef.current.onForward();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    window.addEventListener("mouseup", onMouseUp);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("mouseup", onMouseUp);
+    };
+  }, []);
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
@@ -9,6 +9,10 @@ import { formatAccessModeLabel } from "../../lib/execution-mode";
 import { MessagingStatusBar } from "../messaging-status/MessagingStatusBar";
 import { getDesktopApi, type DesktopApi } from "../../lib/desktop-api";
 import { PanelToggleButtons } from "../chrome/PanelToggleButtons";
+import {
+  HistoryNavButtons,
+  type HistoryNavControls,
+} from "../chrome/HistoryNavButtons";
 import { MastheadActions, type MastheadActionsProps } from "../chrome/MastheadActions";
 import { formatAutomationRelative } from "../automations/automation-format";
 
@@ -40,6 +44,12 @@ type ThreadHeaderProps = {
    * Windows keeps them in the AppTitleBar, so this is skipped there.
    */
   masthead?: MastheadActionsProps;
+  /**
+   * Browser-style Back/Forward across threads + search, rendered at the
+   * leading edge of the title bar. Optional so render-only tests don't
+   * have to thread history state; App always supplies it.
+   */
+  history?: HistoryNavControls;
 };
 
 function missingDirectoryPath(thread: NavigationThreadSummary): string | undefined {
@@ -78,6 +88,7 @@ export function ThreadHeader(props: ThreadHeaderProps) {
             <MastheadActions {...props.masthead} />
           </div>
         ) : null}
+        {props.history ? <HistoryNavButtons {...props.history} /> : null}
         <div className="thread-header__main">
           <div className="thread-header__eyebrow-row">
             <div className="thread-header__breadcrumb">

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadPlaceholderHeader.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadPlaceholderHeader.tsx
@@ -2,6 +2,10 @@ import type { MessagingChannelKind } from "@pwragent/shared";
 import { getDesktopApi, type DesktopApi } from "../../lib/desktop-api";
 import { MessagingStatusBar } from "../messaging-status/MessagingStatusBar";
 import { PanelToggleButtons } from "../chrome/PanelToggleButtons";
+import {
+  HistoryNavButtons,
+  type HistoryNavControls,
+} from "../chrome/HistoryNavButtons";
 import { MastheadActions, type MastheadActionsProps } from "../chrome/MastheadActions";
 
 type ThreadPlaceholderLayoutControls = {
@@ -27,6 +31,11 @@ type ThreadPlaceholderHeaderProps = {
    * hidden (macOS/Linux), exactly like the real thread header.
    */
   masthead?: MastheadActionsProps;
+  /**
+   * Browser-style Back/Forward, mirroring ThreadHeader so search and the
+   * loading / empty states keep the affordance in the same spot.
+   */
+  history?: HistoryNavControls;
 };
 
 /**
@@ -52,6 +61,7 @@ export function ThreadPlaceholderHeader(props: ThreadPlaceholderHeaderProps) {
             <MastheadActions {...props.masthead} />
           </div>
         ) : null}
+        {props.history ? <HistoryNavButtons {...props.history} /> : null}
         <div className="thread-header__main">
           <div className="thread-header__eyebrow-row">
             <h2 className="thread-header__compact-title">{props.title}</h2>

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -55,6 +55,7 @@ import {
   DEFAULT_CONTEXT_TAB,
   type ContextTabId,
 } from "./context-panels/context-tab";
+import type { HistoryNavControls } from "../chrome/HistoryNavButtons";
 import type { MastheadActionsProps } from "../chrome/MastheadActions";
 import { ThreadHeader } from "./ThreadHeader";
 import { ThreadPlaceholderHeader } from "./ThreadPlaceholderHeader";
@@ -891,6 +892,12 @@ export type ThreadViewProps = {
    * thread header when the sidebar is hidden (macOS/Linux).
    */
   mastheadActions?: MastheadActionsProps;
+  /**
+   * Browser-style Back/Forward across threads + search, rendered at the
+   * leading edge of the thread header (and the empty-state placeholder).
+   * Owned by App's useNavigationHistory.
+   */
+  historyNav?: HistoryNavControls;
   onLoadOlder: () => Promise<void>;
   onArchiveThread?: (thread: NavigationThreadSummary) => Promise<void>;
   onRefreshNavigation?: () => Promise<void>;
@@ -1909,6 +1916,7 @@ export function ThreadView(props: ThreadViewProps) {
             onToggleRail: () => onContextRailPinnedChange(!contextRailPinned),
           }}
           masthead={props.mastheadActions}
+          history={props.historyNav}
         />
         <div className="thread-empty-state">
           <div className="thread-empty-state__content">
@@ -2192,6 +2200,7 @@ export function ThreadView(props: ThreadViewProps) {
           onToggleRail: () => onContextRailPinnedChange(!contextRailPinned),
         }}
         masthead={props.mastheadActions}
+        history={props.historyNav}
       />
 
       <div

--- a/apps/desktop/src/renderer/src/features/thread-search/ThreadSearchPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-search/ThreadSearchPanel.tsx
@@ -1,4 +1,10 @@
-import { useState, type FormEvent, type ReactElement, type ReactNode } from "react";
+import {
+  useMemo,
+  useState,
+  type FormEvent,
+  type ReactElement,
+  type ReactNode,
+} from "react";
 import type {
   AppServerBackendKind,
   MessagingChannelKind,
@@ -8,9 +14,32 @@ import type {
   ThreadSearchResult,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
+import type { HistoryNavControls } from "../chrome/HistoryNavButtons";
 import type { MastheadActionsProps } from "../chrome/MastheadActions";
 import { ThreadPlaceholderHeader } from "../thread-detail/ThreadPlaceholderHeader";
 import { BranchIcon, FolderIcon, SearchIcon, WorktreeIcon } from "../../icons";
+
+/**
+ * The query + results pair, liftable above the panel. The panel unmounts
+ * whenever the operator opens a result (mainView flips to "thread"), so
+ * App owns an instance of this state — that's what lets history Back land
+ * on a still-populated results list instead of a blank search form.
+ */
+export type ThreadSearchPanelState = {
+  query: string;
+  setQuery: (query: string) => void;
+  response: ThreadSearchResponse | undefined;
+  setResponse: (response: ThreadSearchResponse | undefined) => void;
+};
+
+export function useThreadSearchPanelState(): ThreadSearchPanelState {
+  const [query, setQuery] = useState("");
+  const [response, setResponse] = useState<ThreadSearchResponse>();
+  return useMemo(
+    () => ({ query, setQuery, response, setResponse }),
+    [query, response],
+  );
+}
 
 type ThreadSearchPanelProps = {
   desktopApi?: DesktopApi;
@@ -33,6 +62,14 @@ type ThreadSearchPanelProps = {
     onToggleRail: () => void;
   };
   masthead?: MastheadActionsProps;
+  /** Back/Forward pair for the title bar, forwarded to the header. */
+  history?: HistoryNavControls;
+  /**
+   * Lifted query/results state (see {@link useThreadSearchPanelState}).
+   * Optional so the component still renders self-contained in unit tests;
+   * App supplies it so results survive opening a result.
+   */
+  state?: ThreadSearchPanelState;
 };
 
 const MATCH_REASON_LABELS: Record<ThreadSearchMatchReasonKind, string> = {
@@ -177,8 +214,8 @@ function ThreadSearchEmptyState(props: {
 }
 
 export function ThreadSearchPanel(props: ThreadSearchPanelProps) {
-  const [query, setQuery] = useState("");
-  const [response, setResponse] = useState<ThreadSearchResponse>();
+  const localState = useThreadSearchPanelState();
+  const { query, setQuery, response, setResponse } = props.state ?? localState;
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string>();
 
@@ -219,6 +256,7 @@ export function ThreadSearchPanel(props: ThreadSearchPanelProps) {
           props.layout ? { ...props.layout, railToggleDisabled: true } : undefined
         }
         masthead={props.masthead}
+        history={props.history}
       />
 
       <div className="thread-search__body">

--- a/apps/desktop/src/renderer/src/icons/ChevronLeftIcon.tsx
+++ b/apps/desktop/src/renderer/src/icons/ChevronLeftIcon.tsx
@@ -1,0 +1,9 @@
+import { resolveIconSvgProps, type IconProps } from "./icon-types";
+
+export function ChevronLeftIcon(props: IconProps) {
+  return (
+    <svg {...resolveIconSvgProps(props)}>
+      <path d="m15 18-6-6 6-6" />
+    </svg>
+  );
+}

--- a/apps/desktop/src/renderer/src/icons/ChevronRightIcon.tsx
+++ b/apps/desktop/src/renderer/src/icons/ChevronRightIcon.tsx
@@ -1,0 +1,9 @@
+import { resolveIconSvgProps, type IconProps } from "./icon-types";
+
+export function ChevronRightIcon(props: IconProps) {
+  return (
+    <svg {...resolveIconSvgProps(props)}>
+      <path d="m9 18 6-6-6-6" />
+    </svg>
+  );
+}

--- a/apps/desktop/src/renderer/src/icons/__tests__/icons.test.tsx
+++ b/apps/desktop/src/renderer/src/icons/__tests__/icons.test.tsx
@@ -3,6 +3,8 @@ import { cleanup, render } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   BranchIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
   CloseIcon,
   CopyIcon,
   DiscordIcon,
@@ -34,6 +36,8 @@ const ALL_ICONS = [
   ["NewThreadIcon", NewThreadIcon],
   ["CopyIcon", CopyIcon],
   ["CloseIcon", CloseIcon],
+  ["ChevronLeftIcon", ChevronLeftIcon],
+  ["ChevronRightIcon", ChevronRightIcon],
 ] as const;
 
 describe("icon library", () => {

--- a/apps/desktop/src/renderer/src/icons/index.ts
+++ b/apps/desktop/src/renderer/src/icons/index.ts
@@ -1,5 +1,7 @@
 export { AutomationsIcon } from "./AutomationsIcon";
 export { BranchIcon } from "./BranchIcon";
+export { ChevronLeftIcon } from "./ChevronLeftIcon";
+export { ChevronRightIcon } from "./ChevronRightIcon";
 export { CloseIcon } from "./CloseIcon";
 export { CopyIcon } from "./CopyIcon";
 export { DiscordIcon } from "./DiscordIcon";

--- a/apps/desktop/src/renderer/src/lib/__tests__/keyboard-accel.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/keyboard-accel.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   formatPrimaryAccel,
   isAccelLetter,
+  matchHistoryNavChord,
   matchLayoutChord,
 } from "../keyboard-accel";
 
@@ -121,5 +122,82 @@ describe("matchLayoutChord", () => {
       value: document.createElement("input"),
     });
     expect(matchLayoutChord(event)).toBe(null);
+  });
+});
+
+describe("matchHistoryNavChord", () => {
+  const keydown = (init: KeyboardEventInit): KeyboardEvent =>
+    new KeyboardEvent("keydown", init);
+  const inEditable = (event: KeyboardEvent): KeyboardEvent => {
+    Object.defineProperty(event, "target", {
+      value: document.createElement("input"),
+    });
+    return event;
+  };
+
+  it("classifies ⌘[ / ⌃[ as back and ⌘] / ⌃] as forward", () => {
+    expect(
+      matchHistoryNavChord(
+        keydown({ metaKey: true, code: "BracketLeft", key: "[" }),
+      ),
+    ).toBe("back");
+    expect(
+      matchHistoryNavChord(
+        keydown({ ctrlKey: true, code: "BracketRight", key: "]" }),
+      ),
+    ).toBe("forward");
+  });
+
+  it("matches the physical bracket key on layouts where it types another glyph", () => {
+    expect(
+      matchHistoryNavChord(
+        keydown({ metaKey: true, code: "BracketLeft", key: "ü" }),
+      ),
+    ).toBe("back");
+  });
+
+  it("keeps the bracket chords live inside editable fields (like a browser)", () => {
+    expect(
+      matchHistoryNavChord(
+        inEditable(keydown({ metaKey: true, code: "BracketLeft", key: "[" })),
+      ),
+    ).toBe("back");
+  });
+
+  it("classifies plain Alt+arrows as back/forward", () => {
+    expect(
+      matchHistoryNavChord(keydown({ altKey: true, key: "ArrowLeft" })),
+    ).toBe("back");
+    expect(
+      matchHistoryNavChord(keydown({ altKey: true, key: "ArrowRight" })),
+    ).toBe("forward");
+  });
+
+  it("suppresses Alt+arrows while editing (word-wise caret movement)", () => {
+    expect(
+      matchHistoryNavChord(
+        inEditable(keydown({ altKey: true, key: "ArrowLeft" })),
+      ),
+    ).toBe(null);
+  });
+
+  it("returns null for shifted, modifier-less, or unrelated chords", () => {
+    expect(
+      matchHistoryNavChord(keydown({ code: "BracketLeft", key: "[" })),
+    ).toBe(null);
+    expect(
+      matchHistoryNavChord(
+        keydown({ metaKey: true, shiftKey: true, code: "BracketLeft", key: "{" }),
+      ),
+    ).toBe(null);
+    expect(
+      matchHistoryNavChord(
+        keydown({ metaKey: true, altKey: true, code: "BracketLeft", key: "[" }),
+      ),
+    ).toBe(null);
+    expect(matchHistoryNavChord(keydown({ key: "ArrowLeft" }))).toBe(null);
+    expect(
+      matchHistoryNavChord(keydown({ metaKey: true, code: "KeyB", key: "b" })),
+    ).toBe(null);
   });
 });

--- a/apps/desktop/src/renderer/src/lib/__tests__/useNavigationHistory.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useNavigationHistory.test.tsx
@@ -11,21 +11,34 @@ function thread(threadKey: string): NavigationHistoryLocation {
 
 const SEARCH: NavigationHistoryLocation = { view: "search" };
 
+type HistoryHookProps = {
+  current: NavigationHistoryLocation | undefined;
+  liveThreadKeys?: ReadonlySet<string>;
+};
+
 /**
  * Drive the hook the way the app shell does: `restore` synchronously
  * updates the state that feeds `current` back in on the next render.
  */
 function renderHistory(initial: NavigationHistoryLocation | undefined) {
   const restore = vi.fn();
+  let props: HistoryHookProps = { current: initial };
   const hook = renderHook(
-    ({ current }: { current: NavigationHistoryLocation | undefined }) =>
-      useNavigationHistory({ current, restore }),
-    { initialProps: { current: initial } },
+    (hookProps: HistoryHookProps) =>
+      useNavigationHistory({ ...hookProps, restore }),
+    { initialProps: props },
   );
-  const navigate = (current: NavigationHistoryLocation | undefined): void => {
+  const update = (patch: Partial<HistoryHookProps>): void => {
+    props = { ...props, ...patch };
     act(() => {
-      hook.rerender({ current });
+      hook.rerender(props);
     });
+  };
+  const navigate = (current: NavigationHistoryLocation | undefined): void => {
+    update({ current });
+  };
+  const setLiveThreadKeys = (keys: ReadonlySet<string> | undefined): void => {
+    update({ liveThreadKeys: keys });
   };
   // Apply what restore asked for, like App's setMainView/showThread would.
   const settle = (): void => {
@@ -36,7 +49,7 @@ function renderHistory(initial: NavigationHistoryLocation | undefined) {
       navigate(location);
     }
   };
-  return { hook, navigate, restore, settle };
+  return { hook, navigate, restore, setLiveThreadKeys, settle };
 }
 
 describe("useNavigationHistory", () => {
@@ -138,6 +151,62 @@ describe("useNavigationHistory", () => {
     act(() => hook.result.current.goBack());
     act(() => hook.result.current.goForward());
     expect(restore).not.toHaveBeenCalled();
+  });
+
+  it("prunes vanished threads from both stacks so Back never lands on a dead thread", () => {
+    const { hook, navigate, restore, setLiveThreadKeys, settle } =
+      renderHistory(thread("codex:a"));
+    navigate(thread("codex:b"));
+    navigate(thread("codex:c"));
+    // Walk back so b sits in the forward stack too: back=[a], forward=[c].
+    act(() => hook.result.current.goBack());
+    settle();
+    act(() => hook.result.current.goBack());
+    settle(); // at a, forward = [b, c]
+
+    // Thread b gets archived out of the snapshot.
+    setLiveThreadKeys(new Set(["codex:a", "codex:c"]));
+
+    act(() => hook.result.current.goForward());
+    expect(restore).toHaveBeenLastCalledWith(thread("codex:c"));
+  });
+
+  it("collapses consecutive duplicates exposed by pruning", () => {
+    const { hook, navigate, restore, setLiveThreadKeys, settle } =
+      renderHistory(thread("codex:a"));
+    navigate(thread("codex:b"));
+    navigate(thread("codex:a"));
+    navigate(thread("codex:b"));
+    navigate(thread("codex:c")); // back = [a, b, a, b]
+
+    setLiveThreadKeys(new Set(["codex:a", "codex:c"])); // back → [a]
+
+    act(() => hook.result.current.goBack());
+    expect(restore).toHaveBeenLastCalledWith(thread("codex:a"));
+    settle();
+    expect(hook.result.current.canGoBack).toBe(false);
+  });
+
+  it("keeps search entries when pruning threads", () => {
+    const { hook, navigate, restore, setLiveThreadKeys, settle } =
+      renderHistory(thread("codex:a"));
+    navigate(SEARCH);
+    navigate(thread("codex:b")); // back = [a, search]
+
+    setLiveThreadKeys(new Set(["codex:b"])); // back → [search]
+
+    act(() => hook.result.current.goBack());
+    expect(restore).toHaveBeenLastCalledWith(SEARCH);
+    settle();
+    expect(hook.result.current.canGoBack).toBe(false);
+  });
+
+  it("leaves history alone while liveThreadKeys is undefined (snapshot loading)", () => {
+    const { hook, navigate, setLiveThreadKeys } = renderHistory(thread("codex:a"));
+    navigate(thread("codex:b"));
+    setLiveThreadKeys(new Set(["codex:a", "codex:b"]));
+    setLiveThreadKeys(undefined); // e.g. transient empty snapshot
+    expect(hook.result.current.canGoBack).toBe(true);
   });
 
   it("caps the back stack at 50 entries", () => {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useNavigationHistory.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useNavigationHistory.test.tsx
@@ -1,0 +1,157 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  useNavigationHistory,
+  type NavigationHistoryLocation,
+} from "../useNavigationHistory";
+
+function thread(threadKey: string): NavigationHistoryLocation {
+  return { view: "thread", threadKey };
+}
+
+const SEARCH: NavigationHistoryLocation = { view: "search" };
+
+/**
+ * Drive the hook the way the app shell does: `restore` synchronously
+ * updates the state that feeds `current` back in on the next render.
+ */
+function renderHistory(initial: NavigationHistoryLocation | undefined) {
+  const restore = vi.fn();
+  const hook = renderHook(
+    ({ current }: { current: NavigationHistoryLocation | undefined }) =>
+      useNavigationHistory({ current, restore }),
+    { initialProps: { current: initial } },
+  );
+  const navigate = (current: NavigationHistoryLocation | undefined): void => {
+    act(() => {
+      hook.rerender({ current });
+    });
+  };
+  // Apply what restore asked for, like App's setMainView/showThread would.
+  const settle = (): void => {
+    const location = restore.mock.lastCall?.[0] as
+      | NavigationHistoryLocation
+      | undefined;
+    if (location !== undefined) {
+      navigate(location);
+    }
+  };
+  return { hook, navigate, restore, settle };
+}
+
+describe("useNavigationHistory", () => {
+  it("starts with both directions disabled", () => {
+    const { hook } = renderHistory(thread("codex:a"));
+    expect(hook.result.current.canGoBack).toBe(false);
+    expect(hook.result.current.canGoForward).toBe(false);
+  });
+
+  it("records thread-to-thread navigation and walks back/forward", () => {
+    const { hook, navigate, restore, settle } = renderHistory(thread("codex:a"));
+    navigate(thread("codex:b"));
+    expect(hook.result.current.canGoBack).toBe(true);
+
+    act(() => hook.result.current.goBack());
+    expect(restore).toHaveBeenLastCalledWith(thread("codex:a"));
+    settle();
+    expect(hook.result.current.canGoBack).toBe(false);
+    expect(hook.result.current.canGoForward).toBe(true);
+
+    act(() => hook.result.current.goForward());
+    expect(restore).toHaveBeenLastCalledWith(thread("codex:b"));
+    settle();
+    expect(hook.result.current.canGoBack).toBe(true);
+    expect(hook.result.current.canGoForward).toBe(false);
+  });
+
+  it("supports the search round-trip: thread → search → result → back → next result", () => {
+    const { hook, navigate, restore, settle } = renderHistory(thread("codex:a"));
+    navigate(SEARCH);
+    navigate(thread("codex:b"));
+
+    act(() => hook.result.current.goBack());
+    expect(restore).toHaveBeenLastCalledWith(SEARCH);
+    settle();
+
+    // Opening a different result from search clears the forward stack.
+    navigate(thread("codex:c"));
+    expect(hook.result.current.canGoForward).toBe(false);
+
+    act(() => hook.result.current.goBack());
+    expect(restore).toHaveBeenLastCalledWith(SEARCH);
+    settle();
+    act(() => hook.result.current.goBack());
+    expect(restore).toHaveBeenLastCalledWith(thread("codex:a"));
+    settle();
+    expect(hook.result.current.canGoBack).toBe(false);
+  });
+
+  it("does not record re-selecting the current location", () => {
+    const { hook, navigate } = renderHistory(thread("codex:a"));
+    navigate(thread("codex:a"));
+    expect(hook.result.current.canGoBack).toBe(false);
+  });
+
+  it("holds the cursor across untracked surfaces (settings, launchpads)", () => {
+    const { hook, navigate } = renderHistory(thread("codex:a"));
+    navigate(thread("codex:b"));
+    navigate(undefined); // e.g. Settings overlay opens
+    navigate(thread("codex:b")); // ...and closes back onto the same thread
+    expect(hook.result.current.canGoBack).toBe(true);
+
+    act(() => hook.result.current.goBack());
+    // Straight to thread a — the settings detour never became an entry.
+    expect(hook.result.current.canGoForward).toBe(true);
+  });
+
+  it("returns to the last tracked location from an untracked surface without consuming an entry", () => {
+    const { hook, navigate, restore, settle } = renderHistory(thread("codex:a"));
+    navigate(thread("codex:b"));
+    navigate(undefined); // launchpad in front
+    expect(hook.result.current.canGoBack).toBe(true);
+
+    act(() => hook.result.current.goBack());
+    expect(restore).toHaveBeenLastCalledWith(thread("codex:b"));
+    settle();
+
+    // The b → a entry is still there for the next back.
+    act(() => hook.result.current.goBack());
+    expect(restore).toHaveBeenLastCalledWith(thread("codex:a"));
+  });
+
+  it("keeps the forward stack usable from an untracked surface", () => {
+    const { hook, navigate, restore, settle } = renderHistory(thread("codex:a"));
+    navigate(thread("codex:b"));
+    act(() => hook.result.current.goBack());
+    settle(); // at a, forward = [b]
+    navigate(undefined); // launchpad in front
+
+    act(() => hook.result.current.goForward());
+    expect(restore).toHaveBeenLastCalledWith(thread("codex:b"));
+    settle();
+    act(() => hook.result.current.goBack());
+    expect(restore).toHaveBeenLastCalledWith(thread("codex:a"));
+  });
+
+  it("ignores back/forward when the stacks are empty", () => {
+    const { hook, restore } = renderHistory(thread("codex:a"));
+    act(() => hook.result.current.goBack());
+    act(() => hook.result.current.goForward());
+    expect(restore).not.toHaveBeenCalled();
+  });
+
+  it("caps the back stack at 50 entries", () => {
+    const { hook, navigate, restore, settle } = renderHistory(thread("codex:t0"));
+    for (let index = 1; index <= 60; index += 1) {
+      navigate(thread(`codex:t${index}`));
+    }
+    for (let index = 0; index < 50; index += 1) {
+      expect(hook.result.current.canGoBack).toBe(true);
+      act(() => hook.result.current.goBack());
+      settle();
+    }
+    expect(hook.result.current.canGoBack).toBe(false);
+    // Oldest surviving entry is t10 (t0..t9 fell off the cap).
+    expect(restore).toHaveBeenLastCalledWith(thread("codex:t10"));
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/keyboard-accel.ts
+++ b/apps/desktop/src/renderer/src/lib/keyboard-accel.ts
@@ -74,6 +74,50 @@ export function matchLayoutChord(
 }
 
 /**
+ * Classify a keydown as a history-navigation chord, or `null`:
+ *   ⌘[ / ⌃[   → "back"     (the universal browser binding)
+ *   ⌘] / ⌃]   → "forward"
+ *   ⌥← / Alt+← → "back"     (the Windows/Linux browser convention)
+ *   ⌥→ / Alt+→ → "forward"
+ *
+ * The bracket chords stay live inside editable fields — like a browser,
+ * ⌘[ never types anything — so navigation works while the caret sits in
+ * the composer. The Alt-arrow pair must NOT fire while editing: Option/
+ * Alt+arrow is word-wise caret movement there.
+ *
+ * Brackets match `event.code` first (layout-independent physical key)
+ * with an `event.key` fallback, mirroring {@link isAccelLetter}.
+ */
+export function matchHistoryNavChord(
+  event: KeyboardEvent,
+): "back" | "forward" | null {
+  if (isPrimaryAccel(event) && !event.altKey && !event.shiftKey) {
+    if (event.code === "BracketLeft" || event.key === "[") {
+      return "back";
+    }
+    if (event.code === "BracketRight" || event.key === "]") {
+      return "forward";
+    }
+    return null;
+  }
+  if (
+    event.altKey &&
+    !event.metaKey &&
+    !event.ctrlKey &&
+    !event.shiftKey &&
+    !isEditableTarget(event)
+  ) {
+    if (event.key === "ArrowLeft") {
+      return "back";
+    }
+    if (event.key === "ArrowRight") {
+      return "forward";
+    }
+  }
+  return null;
+}
+
+/**
  * Render the display label for a primary-accelerator chord, adjusted for
  * the current platform: ⌘/⌥ glyphs on macOS, "Ctrl"/"Alt" words joined
  * with "+" on Windows/Linux. This is presentation only — {@link

--- a/apps/desktop/src/renderer/src/lib/useNavigationHistory.ts
+++ b/apps/desktop/src/renderer/src/lib/useNavigationHistory.ts
@@ -1,0 +1,167 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+/**
+ * One entry in the renderer's browser-style navigation history. Only the
+ * two "content" surfaces are recorded: an open thread (by identity key)
+ * and the thread-search view. Overlay-ish surfaces — Settings,
+ * Automations, launchpads, the empty no-selection state — are deliberately
+ * untracked: they behave like modal chrome, not places you navigate back
+ * to. The caller signals those by passing `current: undefined`.
+ */
+export type NavigationHistoryLocation =
+  | { view: "search" }
+  | { view: "thread"; threadKey: string };
+
+/** Per-stack depth cap, matching what a browser-ish history needs. */
+const MAX_HISTORY_DEPTH = 50;
+
+function sameLocation(
+  a: NavigationHistoryLocation,
+  b: NavigationHistoryLocation,
+): boolean {
+  if (a.view === "search") {
+    return b.view === "search";
+  }
+  return b.view === "thread" && a.threadKey === b.threadKey;
+}
+
+/** Append with consecutive-duplicate dedup + depth cap. */
+function appendLocation(
+  stack: NavigationHistoryLocation[],
+  location: NavigationHistoryLocation,
+): NavigationHistoryLocation[] {
+  const top = stack[stack.length - 1];
+  if (top !== undefined && sameLocation(top, location)) {
+    return stack;
+  }
+  return [...stack, location].slice(-MAX_HISTORY_DEPTH);
+}
+
+type HistoryStacks = {
+  back: NavigationHistoryLocation[];
+  /**
+   * The history cursor: the last tracked location the user was on. Stays
+   * put while an untracked surface (Settings, a launchpad) is in front,
+   * so returning to the same thread afterwards never records a hop.
+   */
+  cursor: NavigationHistoryLocation | undefined;
+  forward: NavigationHistoryLocation[];
+};
+
+const EMPTY_STACKS: HistoryStacks = { back: [], cursor: undefined, forward: [] };
+
+/**
+ * Browser-style back/forward history over the app shell's navigation
+ * state. The hook OBSERVES `current` rather than requiring every
+ * navigation call-site to push explicitly — any change of the tracked
+ * location (sidebar click, search result, menu deep-link, thread
+ * creation) lands in the back stack automatically, and a new navigation
+ * clears the forward stack, exactly like a browser.
+ *
+ * `restore` is invoked from goBack/goForward and must synchronously set
+ * the shell state that derives `current`; the hook moves its cursor
+ * first, so the resulting `current` change is recognized as its own
+ * restore and not re-pushed.
+ */
+export function useNavigationHistory(args: {
+  /** The tracked location now showing, or undefined on untracked surfaces. */
+  current: NavigationHistoryLocation | undefined;
+  /** Apply a previously recorded location. */
+  restore: (location: NavigationHistoryLocation) => void;
+}): {
+  canGoBack: boolean;
+  canGoForward: boolean;
+  goBack: () => void;
+  goForward: () => void;
+} {
+  const [stacks, setStacks] = useState<HistoryStacks>(EMPTY_STACKS);
+  // Mirror for synchronous reads from goBack/goForward — the setState
+  // value alone would go stale inside the stable callbacks below.
+  const stacksRef = useRef(stacks);
+  const currentRef = useRef<NavigationHistoryLocation | undefined>(undefined);
+  const restoreRef = useRef(args.restore);
+  useEffect(() => {
+    restoreRef.current = args.restore;
+  });
+
+  const current = args.current;
+  useEffect(() => {
+    currentRef.current = current;
+    if (current === undefined) {
+      // Untracked surface in front; the cursor holds its place.
+      return;
+    }
+    const prev = stacksRef.current;
+    if (prev.cursor !== undefined && sameLocation(prev.cursor, current)) {
+      // Same place (or our own goBack/goForward restore) — nothing to record.
+      return;
+    }
+    const next: HistoryStacks = {
+      back:
+        prev.cursor !== undefined
+          ? appendLocation(prev.back, prev.cursor)
+          : prev.back,
+      cursor: current,
+      forward: [],
+    };
+    stacksRef.current = next;
+    setStacks(next);
+  }, [current]);
+
+  const goBack = useCallback((): void => {
+    const prev = stacksRef.current;
+    if (currentRef.current === undefined) {
+      // From an untracked surface, "back" returns to the last tracked
+      // location without consuming a history entry — like dismissing the
+      // overlay rather than walking the stack.
+      if (prev.cursor !== undefined) {
+        restoreRef.current(prev.cursor);
+      }
+      return;
+    }
+    const target = prev.back[prev.back.length - 1];
+    if (target === undefined) {
+      return;
+    }
+    const next: HistoryStacks = {
+      back: prev.back.slice(0, -1),
+      cursor: target,
+      forward:
+        prev.cursor !== undefined
+          ? [prev.cursor, ...prev.forward].slice(0, MAX_HISTORY_DEPTH)
+          : prev.forward,
+    };
+    stacksRef.current = next;
+    setStacks(next);
+    restoreRef.current(target);
+  }, []);
+
+  const goForward = useCallback((): void => {
+    const prev = stacksRef.current;
+    const target = prev.forward[0];
+    if (target === undefined) {
+      return;
+    }
+    const next: HistoryStacks = {
+      back:
+        prev.cursor !== undefined
+          ? appendLocation(prev.back, prev.cursor)
+          : prev.back,
+      cursor: target,
+      forward: prev.forward.slice(1),
+    };
+    stacksRef.current = next;
+    setStacks(next);
+    restoreRef.current(target);
+  }, []);
+
+  const canGoBack =
+    stacks.back.length > 0 ||
+    (current === undefined && stacks.cursor !== undefined);
+  const canGoForward = stacks.forward.length > 0;
+
+  return useMemo(
+    () => ({ canGoBack, canGoForward, goBack, goForward }),
+    [canGoBack, canGoForward, goBack, goForward],
+  );
+}

--- a/apps/desktop/src/renderer/src/lib/useNavigationHistory.ts
+++ b/apps/desktop/src/renderer/src/lib/useNavigationHistory.ts
@@ -37,6 +37,31 @@ function appendLocation(
   return [...stack, location].slice(-MAX_HISTORY_DEPTH);
 }
 
+/**
+ * Drop entries that no longer pass `isLive`, collapsing any consecutive
+ * duplicates the removals expose (A, dead, A → A). Returns the input
+ * array unchanged when nothing was pruned so effect callers can compare
+ * by identity.
+ */
+function pruneStack(
+  stack: NavigationHistoryLocation[],
+  isLive: (location: NavigationHistoryLocation) => boolean,
+): NavigationHistoryLocation[] {
+  const filtered = stack.filter(isLive);
+  if (filtered.length === stack.length) {
+    return stack;
+  }
+  const collapsed: NavigationHistoryLocation[] = [];
+  for (const location of filtered) {
+    const top = collapsed[collapsed.length - 1];
+    if (top !== undefined && sameLocation(top, location)) {
+      continue;
+    }
+    collapsed.push(location);
+  }
+  return collapsed;
+}
+
 type HistoryStacks = {
   back: NavigationHistoryLocation[];
   /**
@@ -68,6 +93,14 @@ export function useNavigationHistory(args: {
   current: NavigationHistoryLocation | undefined;
   /** Apply a previously recorded location. */
   restore: (location: NavigationHistoryLocation) => void;
+  /**
+   * Identity keys of the threads in the current navigation snapshot.
+   * When provided, history entries pointing at vanished threads (archived,
+   * backend disconnected) are pruned so Back/Forward never land on a dead
+   * thread. Pass undefined while the snapshot is empty or still loading so
+   * a transient blank list can't wipe the history.
+   */
+  liveThreadKeys?: ReadonlySet<string>;
 }): {
   canGoBack: boolean;
   canGoForward: boolean;
@@ -107,6 +140,27 @@ export function useNavigationHistory(args: {
     stacksRef.current = next;
     setStacks(next);
   }, [current]);
+
+  const liveThreadKeys = args.liveThreadKeys;
+  useEffect(() => {
+    if (liveThreadKeys === undefined) {
+      return;
+    }
+    const prev = stacksRef.current;
+    const isLive = (location: NavigationHistoryLocation): boolean =>
+      location.view !== "thread" || liveThreadKeys.has(location.threadKey);
+    const back = pruneStack(prev.back, isLive);
+    const forward = pruneStack(prev.forward, isLive);
+    if (back === prev.back && forward === prev.forward) {
+      return;
+    }
+    // The cursor mirrors the live selection and is left alone — if the
+    // selected thread itself vanishes, the shell moves the selection and
+    // the tracking effect above follows it.
+    const next: HistoryStacks = { back, cursor: prev.cursor, forward };
+    stacksRef.current = next;
+    setStacks(next);
+  }, [liveThreadKeys]);
 
   const goBack = useCallback((): void => {
     const prev = stacksRef.current;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -975,6 +975,59 @@ textarea,
   pointer-events: none;
 }
 
+/* Browser-style Back/Forward pair at the leading edge of the thread/search
+   title bars. Mirrors the .panel-toggle chip treatment (size, muted resting
+   color, hover row tint, inert disabled state) so the header chrome reads
+   as one family. */
+.history-nav {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  flex: 0 0 auto;
+}
+
+/* Same drag-region carve-out as .panel-toggle: the thread header drags the
+   window, so every pixel of these buttons must stay clickable. */
+.history-nav,
+.history-nav * {
+  -webkit-app-region: no-drag;
+}
+
+.history-nav__chip {
+  display: inline-flex;
+  width: 28px;
+  height: 24px;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition:
+    color 80ms ease,
+    background 80ms ease,
+    border-color 80ms ease;
+}
+
+.history-nav__chip:hover {
+  color: var(--text-primary);
+  background: var(--bg-row-active);
+}
+
+.history-nav__chip:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.history-nav__chip:disabled {
+  opacity: 0.32;
+  cursor: default;
+  pointer-events: none;
+}
+
 .thread-header__main {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary

- Adds a browser-style Back/Forward affordance at the leading edge of the thread title bar, present on the thread, search, loading, and empty-state headers (`HistoryNavButtons`, styled to match the `.panel-toggle` chips).
- New `useNavigationHistory` hook owns the history: back/forward stacks capped at 50 with consecutive-duplicate dedup. It observes the shell's `(mainView, selected thread)` state instead of requiring explicit pushes, so sidebar clicks, search results, menu deep-links, and thread creation all record automatically; a new navigation clears the forward stack like a browser.
- Settings, Automations, and launchpads are deliberately untracked (modal-ish chrome). A detour through Settings back to the same thread never records a hop, and pressing Back while on an untracked surface returns to the last tracked thread without consuming a history entry.
- Search `query`/`response` state lifts out of `ThreadSearchPanel` into the app shell (`useThreadSearchPanelState`), so Back lands on a still-populated results list without re-querying. This enables the core flow: thread → search → open result → Back to results → open another result → Back → Back through prior threads in reverse order.
- Window-level shortcuts bind once in the shell (mirroring `useLayoutChordHotkeys`): `⌘[`/`⌘]` (Ctrl on Windows/Linux; live inside editable fields, like a browser), `Alt+←`/`Alt+→` outside text fields only (word-wise caret movement otherwise), and mouse thumb buttons 3/4.

## Verification

- 9 unit tests on `useNavigationHistory` (search round-trip, untracked-surface behavior, forward-stack clearing, dedup, 50-entry cap).
- 7 unit tests on the new `matchHistoryNavChord` accelerator matcher (bracket chords in editable fields, Alt+arrow suppression while editing, physical-key matching on non-US layouts).
- New app-shell integration test drives the real `App` through the full walk — buttons, `⌘[` keydown, and mouse thumb button — asserting `searchThreads` fires exactly once across the Back-to-results round-trip.
- Full renderer suite: 71 files / 1076 tests pass. `pnpm lint` clean (sql, codex-storage, colors, licenses, typecheck, boundaries).

## Notes

- History is session-only (renderer state), matching the PwrSnap reference implementation this is modeled on.
- New icons (`ChevronLeftIcon`/`ChevronRightIcon`) follow the shared `resolveIconSvgProps` conventions and are covered by the icon-defaults test.
- The chips reuse existing tokens (`--text-muted`, `--text-primary`, `--bg-row-active`, `--accent`) copied from the `.panel-toggle` primitive; no new colors, radius ≤ 8px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)