### PR TITLE
fix(desktop): wrap unbroken plain-text runs in transcript messages

### DIFF
--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -760,6 +760,30 @@ describe("Tangerine Terminal theme contract", () => {
     expect(preCodeRule).not.toContain("white-space: pre;");
   });
 
+  it("wraps unbroken plain-text runs in transcript paragraphs and lists instead of overflowing the chat column", () => {
+    // A monitor-subagent report pasted a pnpm progress separator — an
+    // 80-char unbroken `++++…` run — into a user message. The run lands
+    // as plain text in `<p class="transcript-message__paragraph">`
+    // (remark-breaks keeps the surrounding log lines in one paragraph),
+    // and an unbroken run has no soft break opportunities. Unlike the
+    // inline-code chip and fenced-pre paths locked above, the paragraph
+    // and list rules declare no overflow-wrap, so the run renders at its
+    // intrinsic width, escapes the .transcript-message card edge, and
+    // forces a horizontal scrollbar on the entire transcript.
+    //
+    // Lock `overflow-wrap: anywhere;` on both plain-text containers
+    // (the property inherits, so `<li>` children of __list pick it up).
+    // It is deliberately NOT placed on a shared ancestor like
+    // .transcript-message__text: inherited overflow-wrap reaches table
+    // cells too, where `anywhere` changes min-content sizing and would
+    // defeat the wide-table horizontal scroll affordance.
+    const paragraphRule = extractRuleBody(css, ".transcript-message__paragraph");
+    expect(paragraphRule).toContain("overflow-wrap: anywhere;");
+
+    const listRule = extractRuleBody(css, ".transcript-message__list");
+    expect(listRule).toContain("overflow-wrap: anywhere;");
+  });
+
   it("bounds long transcript code and quote blocks with their own vertical scroll", () => {
     const preRule = extractRuleBody(css, ".transcript-message__pre");
     expect(preRule).toContain("max-height:");

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -7703,6 +7703,7 @@ textarea,
 
 .transcript-message__paragraph {
   white-space: normal;
+  overflow-wrap: anywhere;
 }
 
 .transcript-message__heading {
@@ -7746,6 +7747,7 @@ textarea,
 .transcript-message__list {
   margin: 0;
   padding-left: 20px;
+  overflow-wrap: anywhere;
 }
 
 .transcript-message__list li + li {


### PR DESCRIPTION
## Summary

- An unbroken run with no spaces (e.g. a pasted pnpm progress separator of 80 `+` characters) rendered at intrinsic width inside a user-message paragraph, escaped the `.transcript-message` card edge, and forced a horizontal scrollbar on the entire chat transcript.
- Root cause: the plain-text path (`.transcript-message__paragraph`, `.transcript-message__list`) declared no `overflow-wrap`, unlike inline code chips, fenced `<pre>` blocks, and links, which all already have wrap rules locked by contract tests.
- Fix: add `overflow-wrap: anywhere;` to both plain-text containers so unbroken runs break inside the card. The property is set element-level on purpose — inherited from a shared ancestor like `.transcript-message__text` it would reach table cells, where `anywhere` changes min-content sizing and defeats the wide-table horizontal-scroll affordance (`.thread-markdown__table-scroll`).
- Adds a wrap-contract test in `theme-contract.test.tsx` beside the three existing sibling wrap tests (inline code / fenced pre / pre code), committed first as a failing test, turned green by the CSS commit.

## Verification

- `pnpm test apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx` — 40/40 pass (the new test failed before the CSS change with `expected '\n  white-space: normal;' to contain 'overflow-wrap: anywhere;'`).

## Notes

- Two-line CSS change + one contract test; no component or markup changes. `remark-breaks` keeps pasted log lines in a single paragraph, which is why the `+++…` run lands on this path.
- If a different handling is ever preferred (e.g. per-message clipping), the contract test is the only place encoding the wrap choice — change its assertions and comment in the same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)