### PR TITLE
feat(desktop): surface native Codex subagents

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -11845,6 +11845,7 @@ command = "pnpm dev"
       initializeResult: { methods: ["turn/start"] },
     });
     const overlayStore = createOverlayStoreMock();
+    const upsertThreadSubAgent = vi.spyOn(overlayStore, "upsertThreadSubAgent");
     const registry = new DesktopBackendRegistry({
       codexClient,
       grokClient: new MockBackendClient({
@@ -11891,6 +11892,7 @@ command = "pnpm dev"
       lastMessage: "Inspecting the diff.",
     });
     expect(overlay?.subAgents?.[0]?.task).toEqual(expect.stringContaining("correctness"));
+    expect(upsertThreadSubAgent).toHaveBeenCalledTimes(1);
 
     await codexClient.emit({
       method: "thread/tokenUsage/updated",
@@ -11923,6 +11925,7 @@ command = "pnpm dev"
         uncachedInputTokens: 900,
       },
     });
+    expect(upsertThreadSubAgent).toHaveBeenCalledTimes(2);
 
     await registry.close();
   });
@@ -12030,6 +12033,7 @@ command = "pnpm dev"
     expect(afterCloseOverlay?.subAgents?.[0]).toMatchObject({
       outcome: "success",
       status: "success",
+      lastMessage: "Review completed with no findings.",
     });
 
     await registry.close();

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -11870,6 +11870,7 @@ command = "pnpm dev"
       overlayStore,
     });
     const nativeThreadId = "019ebb70-2c58-7143-850e-0a699607c755";
+    const upsertThreadUsageLine = vi.spyOn(overlayStore, "upsertThreadUsageLine");
 
     await codexClient.emit({
       method: "item/completed",
@@ -11962,6 +11963,15 @@ command = "pnpm dev"
     const pricing = await overlayStore.readThreadPricing({
       backend: "codex",
       threadId: "thread-parent",
+    });
+    expect(upsertThreadUsageLine).toHaveBeenCalledTimes(1);
+    expect(upsertThreadUsageLine).toHaveBeenCalledWith({
+      line: expect.objectContaining({
+        source: "monitor",
+        sourceItemId: `codex-native:${nativeThreadId}`,
+        parentThreadId: "thread-parent",
+        threadId: nativeThreadId,
+      }),
     });
     expect(pricing.lines).toHaveLength(1);
     expect(pricing.lines[0]).toMatchObject({

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -11930,6 +11930,8 @@ command = "pnpm dev"
       method: "thread/tokenUsage/updated",
       params: {
         threadId: nativeThreadId,
+        turnId: "turn-native-1",
+        model: "gpt-5.4-mini",
         tokenUsage: {
           total: {
             inputTokens: 1_000,
@@ -11957,6 +11959,22 @@ command = "pnpm dev"
         uncachedInputTokens: 900,
       },
     });
+    const pricing = await overlayStore.readThreadPricing({
+      backend: "codex",
+      threadId: "thread-parent",
+    });
+    expect(pricing.lines).toHaveLength(1);
+    expect(pricing.lines[0]).toMatchObject({
+      model: "gpt-5.4-mini",
+      parentThreadId: "thread-parent",
+      priceStatus: "priced",
+      scope: "monitor",
+      source: "monitor",
+      sourceItemId: `codex-native:${nativeThreadId}`,
+      threadId: nativeThreadId,
+      turnId: "turn-native-1",
+    });
+    expect(pricing.lines[0]?.totalCostMicros).toBeGreaterThan(0);
     expect(upsertThreadSubAgent).toHaveBeenCalledTimes(2);
 
     await registry.close();

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -11916,6 +11916,7 @@ command = "pnpm dev"
     expect(overlay?.subAgents?.[0]).toMatchObject({
       monitorId: `codex-native:${nativeThreadId}`,
       monitorThreadId: nativeThreadId,
+      monitorTurnId: "turn-1",
       agentName: "Poincare",
       preferredModel: "gpt-5.4-mini",
       preferredReasoningEffort: "medium",
@@ -11957,6 +11958,83 @@ command = "pnpm dev"
       },
     });
     expect(upsertThreadSubAgent).toHaveBeenCalledTimes(2);
+
+    await registry.close();
+  });
+
+  it("fills Codex native sub-agent names from parent assistant output", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+    });
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+    const nativeThreadId = "019ebb70-2c58-7143-850e-0a699607c755";
+
+    await codexClient.emit({
+      method: "item/completed",
+      params: {
+        threadId: "thread-parent",
+        turnId: "turn-1",
+        item: {
+          id: "collab-spawn-1",
+          type: "collabAgentToolCall",
+          tool: "spawnAgent",
+          status: "completed",
+          receiverThreadIds: [nativeThreadId],
+          prompt: "Check the status of PR #783.",
+          model: "gpt-5.4-mini",
+          reasoningEffort: "low",
+          agentsStates: {
+            [nativeThreadId]: {
+              status: "running",
+            },
+          },
+        },
+      },
+    } as AppServerNotification);
+    let overlay = await overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-parent",
+    });
+    expect(overlay?.subAgents?.[0]).toMatchObject({
+      monitorTurnId: "turn-1",
+    });
+    expect(overlay?.subAgents?.[0]?.agentName).toBeUndefined();
+
+    await codexClient.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-parent",
+        turnId: "turn-1",
+        turn: {
+          id: "turn-1",
+          status: "completed",
+          output: [
+            {
+              type: "text",
+              text: "Spawned sub-agent Huygens for PR #783 using `gpt-5.4-mini` with low reasoning. I did not wait.",
+            },
+          ],
+        },
+      },
+    } as AppServerNotification);
+
+    overlay = await overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-parent",
+    });
+    expect(overlay?.subAgents?.[0]).toMatchObject({
+      agentName: "Huygens",
+      monitorTurnId: "turn-1",
+      preferredModel: "gpt-5.4-mini",
+      preferredReasoningEffort: "low",
+    });
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -11866,6 +11866,20 @@ command = "pnpm dev"
           tool: "spawnAgent",
           status: "completed",
           receiverThreadIds: [nativeThreadId],
+          receiverThreads: [
+            {
+              threadId: nativeThreadId,
+              thread: {
+                source: {
+                  subAgent: {
+                    thread_spawn: {
+                      agent_nickname: "Poincare",
+                    },
+                  },
+                },
+              },
+            },
+          ],
           prompt: "You are the correctness reviewer. Inspect the diff.",
           model: "gpt-5.4-mini",
           reasoningEffort: "medium",
@@ -11886,6 +11900,7 @@ command = "pnpm dev"
     expect(overlay?.subAgents?.[0]).toMatchObject({
       monitorId: `codex-native:${nativeThreadId}`,
       monitorThreadId: nativeThreadId,
+      agentName: "Poincare",
       preferredModel: "gpt-5.4-mini",
       preferredReasoningEffort: "medium",
       status: "running",
@@ -11955,6 +11970,20 @@ command = "pnpm dev"
           tool: "spawnAgent",
           status: "completed",
           receiverThreadIds: [nativeThreadId],
+          receiverThreads: [
+            {
+              threadId: nativeThreadId,
+              thread: {
+                source: {
+                  subAgent: {
+                    thread_spawn: {
+                      agent_nickname: "Poincare",
+                    },
+                  },
+                },
+              },
+            },
+          ],
           prompt: "You are the correctness reviewer. Inspect the diff.",
           model: "gpt-5.4-mini",
           agentsStates: {
@@ -12001,6 +12030,7 @@ command = "pnpm dev"
       monitorId: `codex-native:${nativeThreadId}`,
       createdAt,
       monitorThreadId: nativeThreadId,
+      agentName: "Poincare",
       outcome: "success",
       status: "success",
       lastMessage: "Review completed with no findings.",
@@ -12031,6 +12061,7 @@ command = "pnpm dev"
       threadId: "thread-parent",
     });
     expect(afterCloseOverlay?.subAgents?.[0]).toMatchObject({
+      agentName: "Poincare",
       outcome: "success",
       status: "success",
       lastMessage: "Review completed with no findings.",

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -12039,6 +12039,84 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("completes no-wait Codex native sub-agents from async transcript notifications", async () => {
+    vi.useFakeTimers();
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+    });
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+    const nativeThreadId = "019ed784-fd83-7c43-9c5a-cad810e5bee8";
+
+    try {
+      await codexClient.emit({
+        method: "item/completed",
+        params: {
+          threadId: "thread-parent",
+          turnId: "turn-1",
+          item: {
+            id: "collab-spawn-1",
+            type: "collabAgentToolCall",
+            tool: "spawnAgent",
+            status: "completed",
+            receiverThreadIds: [nativeThreadId],
+            prompt: "Check the status of PR #783.",
+            model: "gpt-5.4-mini",
+            agentsStates: {
+              [nativeThreadId]: {
+                status: "running",
+              },
+            },
+          },
+        },
+      } as AppServerNotification);
+
+      await codexClient.emit({
+        method: "item/completed",
+        params: {
+          threadId: "thread-parent",
+          turnId: "turn-1",
+          item: {
+            id: "subagent-notification-1",
+            type: "agentMessage",
+            text:
+              "<subagent_notification>\n" +
+              JSON.stringify({
+                agent_path: nativeThreadId,
+                status: {
+                  completed: "PR #783 checks are all green.",
+                },
+              }) +
+              "\n</subagent_notification>",
+          },
+        },
+      } as AppServerNotification);
+
+      const overlay = await overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-parent",
+      });
+      expect(overlay?.subAgents?.[0]).toMatchObject({
+        completedAt: expect.any(Number),
+        lastMessage: "PR #783 checks are all green.",
+        outcome: "success",
+        status: "success",
+      });
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(codexClient.readThreadCalls).toHaveLength(0);
+    } finally {
+      await registry.close();
+      vi.useRealTimers();
+    }
+  });
+
   it("updates Codex native sub-agent summaries from later wait calls", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start"] },

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -12052,6 +12052,35 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("ignores Codex terminal notifications without turn output when parsing native sub-agent text", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await expect(
+      codexClient.emit({
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "completed",
+          },
+        },
+      } as AppServerNotification),
+    ).resolves.toBeUndefined();
+
+    await registry.close();
+  });
+
   it("completes no-wait Codex native sub-agents from async transcript notifications", async () => {
     vi.useFakeTimers();
     const codexClient = new MockBackendClient({

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -795,8 +795,15 @@ class MockBackendClient {
   lastReadThreadParams?: {
     threadId: string;
     before?: string;
+    includeTurns?: boolean;
     limit?: number;
   };
+  readThreadCalls: Array<{
+    threadId: string;
+    before?: string;
+    includeTurns?: boolean;
+    limit?: number;
+  }> = [];
   injectedThreadItems: Array<{ threadId: string; items: unknown[] }> = [];
   lastStartThreadParams?: {
     cwd?: string;
@@ -937,6 +944,7 @@ class MockBackendClient {
       initializeError?: Error;
       threads?: AppServerThreadSummary[];
       replay?: AppServerThreadReplay;
+      readThreadReplays?: AppServerThreadReplay[];
       skills?: Array<{
         commands?: AppServerAvailableCommandSummary[];
         cwd?: string;
@@ -1078,9 +1086,17 @@ class MockBackendClient {
   async readThread(_params?: {
     threadId: string;
     before?: string;
+    includeTurns?: boolean;
     limit?: number;
   }): Promise<AppServerThreadReplay> {
     this.lastReadThreadParams = _params;
+    if (_params) {
+      this.readThreadCalls.push(_params);
+    }
+    const replay = this.options.readThreadReplays?.shift();
+    if (replay) {
+      return replay;
+    }
     return this.options.replay ?? {
       entries: [],
       messages: [],
@@ -12068,6 +12084,124 @@ command = "pnpm dev"
     });
 
     await registry.close();
+  });
+
+  it("reconciles no-wait Codex native sub-agents from child thread status", async () => {
+    vi.useFakeTimers();
+    const nativeThreadId = "019ebb70-2c58-7143-850e-0a699607c755";
+    const replay = (
+      threadStatus: AppServerThreadReplay["threadStatus"],
+      lastAssistantMessage?: string,
+    ): AppServerThreadReplay => ({
+      entries: [],
+      messages: lastAssistantMessage
+        ? [
+            {
+              id: "assistant-final",
+              role: "assistant",
+              text: lastAssistantMessage,
+            },
+          ]
+        : [],
+      ...(lastAssistantMessage ? { lastAssistantMessage } : {}),
+      pagination: {
+        supportsPagination: false,
+        hasPreviousPage: false,
+      },
+      ...(threadStatus ? { threadStatus } : {}),
+    });
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/read", "turn/start"] },
+      readThreadReplays: [
+        replay("active"),
+        replay("idle"),
+        replay("idle", "PR #783 checks are passing."),
+      ],
+    });
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+
+    try {
+      await codexClient.emit({
+        method: "item/completed",
+        params: {
+          threadId: "thread-parent",
+          turnId: "turn-1",
+          item: {
+            id: "collab-spawn-1",
+            type: "collabAgentToolCall",
+            tool: "spawnAgent",
+            status: "completed",
+            receiverThreadIds: [nativeThreadId],
+            prompt: "Check the status of PR #783.",
+            model: "gpt-5.4-mini",
+            agentsStates: {
+              [nativeThreadId]: {
+                status: "running",
+              },
+            },
+          },
+        },
+      } as AppServerNotification);
+
+      expect(codexClient.readThreadCalls).toHaveLength(0);
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(codexClient.readThreadCalls).toEqual([
+        {
+          threadId: nativeThreadId,
+          includeTurns: false,
+          limit: 0,
+        },
+      ]);
+
+      let overlay = await overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-parent",
+      });
+      expect(overlay?.subAgents?.[0]).toMatchObject({
+        status: "running",
+        lastMessage: "Spawned by Codex native spawnAgent.",
+      });
+
+      await vi.advanceTimersByTimeAsync(15_000);
+      expect(codexClient.readThreadCalls).toEqual([
+        {
+          threadId: nativeThreadId,
+          includeTurns: false,
+          limit: 0,
+        },
+        {
+          threadId: nativeThreadId,
+          includeTurns: false,
+          limit: 0,
+        },
+        {
+          threadId: nativeThreadId,
+          includeTurns: true,
+          limit: 12,
+        },
+      ]);
+
+      overlay = await overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-parent",
+      });
+      expect(overlay?.subAgents?.[0]).toMatchObject({
+        outcome: "success",
+        status: "success",
+        lastMessage: "PR #783 checks are passing.",
+        completedAt: expect.any(Number),
+      });
+    } finally {
+      await registry.close();
+      vi.useRealTimers();
+    }
   });
 
   it("interrupts Codex reviews with the backend active turn id", async () => {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -12008,19 +12008,14 @@ command = "pnpm dev"
     expect(overlay?.subAgents?.[0]?.agentName).toBeUndefined();
 
     await codexClient.emit({
-      method: "turn/completed",
+      method: "item/completed",
       params: {
         threadId: "thread-parent",
         turnId: "turn-1",
-        turn: {
-          id: "turn-1",
-          status: "completed",
-          output: [
-            {
-              type: "text",
-              text: "Spawned sub-agent Huygens for PR #783 using `gpt-5.4-mini` with low reasoning. I did not wait.",
-            },
-          ],
+        item: {
+          id: "assistant-message-1",
+          type: "agentMessage",
+          text: "Spawned sub-agent Huygens for PR #783 using `gpt-5.4-mini` with low reasoning. I did not wait.",
         },
       },
     } as AppServerNotification);

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -11840,6 +11840,201 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("persists Codex native spawnAgent calls as sub-agent summaries", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+    });
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+    const nativeThreadId = "019ebb70-2c58-7143-850e-0a699607c755";
+
+    await codexClient.emit({
+      method: "item/completed",
+      params: {
+        threadId: "thread-parent",
+        turnId: "turn-1",
+        item: {
+          id: "collab-spawn-1",
+          type: "collabAgentToolCall",
+          tool: "spawnAgent",
+          status: "completed",
+          receiverThreadIds: [nativeThreadId],
+          prompt: "You are the correctness reviewer. Inspect the diff.",
+          model: "gpt-5.4-mini",
+          reasoningEffort: "medium",
+          agentsStates: {
+            [nativeThreadId]: {
+              status: "running",
+              message: "Inspecting the diff.",
+            },
+          },
+        },
+      },
+    } as AppServerNotification);
+
+    const overlay = await overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-parent",
+    });
+    expect(overlay?.subAgents?.[0]).toMatchObject({
+      monitorId: `codex-native:${nativeThreadId}`,
+      monitorThreadId: nativeThreadId,
+      preferredModel: "gpt-5.4-mini",
+      preferredReasoningEffort: "medium",
+      status: "running",
+      lastMessage: "Inspecting the diff.",
+    });
+    expect(overlay?.subAgents?.[0]?.task).toEqual(expect.stringContaining("correctness"));
+
+    await codexClient.emit({
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: nativeThreadId,
+        tokenUsage: {
+          total: {
+            inputTokens: 1_000,
+            cachedInputTokens: 100,
+            outputTokens: 40,
+            reasoningOutputTokens: 10,
+          },
+        },
+      },
+    });
+    const usageOverlay = await overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-parent",
+    });
+    expect(usageOverlay?.subAgents?.[0]?.monitorUsage).toMatchObject({
+      summary: expect.stringContaining(
+        "900 uncached in · 100 cached · 40 out (10 reasoning)",
+      ),
+      tokenUsage: {
+        cachedInputTokens: 100,
+        inputTokens: 1_000,
+        outputTokens: 40,
+        reasoningOutputTokens: 10,
+        totalTokens: 1_050,
+        uncachedInputTokens: 900,
+      },
+    });
+
+    await registry.close();
+  });
+
+  it("updates Codex native sub-agent summaries from later wait calls", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+    });
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+    const nativeThreadId = "019ebb70-2c58-7143-850e-0a699607c755";
+
+    await codexClient.emit({
+      method: "item/completed",
+      params: {
+        threadId: "thread-parent",
+        turnId: "turn-1",
+        item: {
+          id: "collab-spawn-1",
+          type: "collabAgentToolCall",
+          tool: "spawnAgent",
+          status: "completed",
+          receiverThreadIds: [nativeThreadId],
+          prompt: "You are the correctness reviewer. Inspect the diff.",
+          model: "gpt-5.4-mini",
+          agentsStates: {
+            [nativeThreadId]: {
+              status: "running",
+            },
+          },
+        },
+      },
+    } as AppServerNotification);
+    const createdAt = (
+      await overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-parent",
+      })
+    )?.subAgents?.[0]?.createdAt;
+
+    await codexClient.emit({
+      method: "item/completed",
+      params: {
+        threadId: "thread-parent",
+        turnId: "turn-1",
+        item: {
+          id: "collab-wait-1",
+          type: "collabAgentToolCall",
+          tool: "wait",
+          status: "completed",
+          receiverThreadIds: [nativeThreadId],
+          agentsStates: {
+            [nativeThreadId]: {
+              status: "completed",
+              message: "Review completed with no findings.",
+            },
+          },
+        },
+      },
+    } as AppServerNotification);
+
+    const overlay = await overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-parent",
+    });
+    expect(overlay?.subAgents?.[0]).toMatchObject({
+      monitorId: `codex-native:${nativeThreadId}`,
+      createdAt,
+      monitorThreadId: nativeThreadId,
+      outcome: "success",
+      status: "success",
+      lastMessage: "Review completed with no findings.",
+    });
+    expect(overlay?.subAgents?.[0]?.completedAt).toEqual(expect.any(Number));
+
+    await codexClient.emit({
+      method: "item/completed",
+      params: {
+        threadId: "thread-parent",
+        turnId: "turn-1",
+        item: {
+          id: "collab-close-1",
+          type: "collabAgentToolCall",
+          tool: "closeAgent",
+          status: "completed",
+          receiverThreadIds: [nativeThreadId],
+          agentsStates: {
+            [nativeThreadId]: {
+              status: "shutdown",
+            },
+          },
+        },
+      },
+    } as AppServerNotification);
+    const afterCloseOverlay = await overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-parent",
+    });
+    expect(afterCloseOverlay?.subAgents?.[0]).toMatchObject({
+      outcome: "success",
+      status: "success",
+    });
+
+    await registry.close();
+  });
+
   it("interrupts Codex reviews with the backend active turn id", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/interrupt", "review/start"] },

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -413,6 +413,7 @@ type BackendClient = {
     threadId: string;
     includeTurns?: boolean;
     before?: string;
+    includeTurns?: boolean;
     limit?: number;
   }): Promise<AppServerReadThreadResponse["replay"]>;
   injectThreadItems?(params: { threadId: string; items: unknown[] }): Promise<void>;
@@ -1648,6 +1649,14 @@ type CodexNativeSubAgentCall = {
   tool: string;
 };
 
+type CodexNativeSubAgentReconciliation = {
+  attempts: number;
+  parentThreadId: string;
+  receiverThreadId: string;
+  startedAt: number;
+  timer?: NodeJS.Timeout;
+};
+
 const CODEX_NATIVE_SUBAGENT_TOOLS = new Set<CodexNativeSubAgentTool>([
   "spawnAgent",
   "sendInput",
@@ -1655,6 +1664,12 @@ const CODEX_NATIVE_SUBAGENT_TOOLS = new Set<CodexNativeSubAgentTool>([
   "wait",
   "closeAgent",
 ]);
+
+const CODEX_NATIVE_SUBAGENT_INITIAL_STATUS_DELAY_MS = 10_000;
+const CODEX_NATIVE_SUBAGENT_ACTIVITY_STATUS_DELAY_MS = 2_000;
+const CODEX_NATIVE_SUBAGENT_MAX_RECONCILE_ATTEMPTS = 30;
+const CODEX_NATIVE_SUBAGENT_MAX_RECONCILE_AGE_MS = 30 * 60 * 1000;
+const CODEX_NATIVE_SUBAGENT_FINAL_READ_LIMIT = 12;
 
 function isCodexNativeSubAgentTool(tool: string): tool is CodexNativeSubAgentTool {
   return CODEX_NATIVE_SUBAGENT_TOOLS.has(tool as CodexNativeSubAgentTool);
@@ -1942,6 +1957,16 @@ function codexNativeSubAgentOutcome(
 
 function codexNativeSubAgentIsTerminal(status: ThreadSubAgentSummary["status"]): boolean {
   return status === "success" || status === "failure" || status === "cancelled";
+}
+
+function codexNativeSubAgentNextReconciliationDelayMs(attempts: number): number {
+  if (attempts <= 1) {
+    return 15_000;
+  }
+  if (attempts <= 3) {
+    return 30_000;
+  }
+  return 60_000;
 }
 
 function codexNativeSubAgentTask(params: {
@@ -3918,6 +3943,10 @@ export class DesktopBackendRegistry {
     ReviewSubAgentRecord
   >();
   private readonly codexNativeSubAgentParents = new Map<string, string>();
+  private readonly codexNativeSubAgentReconciliations = new Map<
+    string,
+    CodexNativeSubAgentReconciliation
+  >();
   private readonly observedCodexSettingsByThread = new Map<string, ObservedCodexSettings>();
   private readonly reservedCodexStartThreadIds = new Set<string>();
   private readonly reservedAcpStartThreadKeys = new Set<string>();
@@ -9673,6 +9702,12 @@ export class DesktopBackendRegistry {
     if (this.taskMonitorWatchdogTimer) {
       clearInterval(this.taskMonitorWatchdogTimer);
     }
+    for (const reconciliation of this.codexNativeSubAgentReconciliations.values()) {
+      if (reconciliation.timer) {
+        clearTimeout(reconciliation.timer);
+      }
+    }
+    this.codexNativeSubAgentReconciliations.clear();
     for (const unsubscribe of this.unsubscribers.splice(0)) {
       unsubscribe();
     }
@@ -11365,6 +11400,13 @@ export class DesktopBackendRegistry {
         },
       },
     });
+    if (!codexNativeSubAgentIsTerminal(existing.status)) {
+      this.scheduleCodexNativeSubAgentReconciliation({
+        delayMs: CODEX_NATIVE_SUBAGENT_ACTIVITY_STATUS_DELAY_MS,
+        parentThreadId,
+        receiverThreadId: event.notification.params.threadId,
+      });
+    }
   }
 
   private async persistExistingReviewSubAgentUsage(params: {
@@ -11558,6 +11600,196 @@ export class DesktopBackendRegistry {
         },
       },
     });
+    if (codexNativeSubAgentIsTerminal(status)) {
+      this.clearCodexNativeSubAgentReconciliation(params.receiverThreadId);
+    } else {
+      this.scheduleCodexNativeSubAgentReconciliation({
+        delayMs: CODEX_NATIVE_SUBAGENT_INITIAL_STATUS_DELAY_MS,
+        parentThreadId: params.parentThreadId,
+        receiverThreadId: params.receiverThreadId,
+      });
+    }
+  }
+
+  private scheduleCodexNativeSubAgentReconciliation(params: {
+    delayMs: number;
+    parentThreadId: string;
+    receiverThreadId: string;
+  }): void {
+    const existing = this.codexNativeSubAgentReconciliations.get(
+      params.receiverThreadId,
+    );
+    if (existing?.timer) {
+      clearTimeout(existing.timer);
+    }
+    const reconciliation: CodexNativeSubAgentReconciliation = existing ?? {
+      attempts: 0,
+      parentThreadId: params.parentThreadId,
+      receiverThreadId: params.receiverThreadId,
+      startedAt: Date.now(),
+    };
+    reconciliation.parentThreadId = params.parentThreadId;
+    const timer = setTimeout(() => {
+      const scheduled = this.codexNativeSubAgentReconciliations.get(
+        params.receiverThreadId,
+      );
+      if (scheduled) {
+        scheduled.timer = undefined;
+      }
+      void this.reconcileCodexNativeSubAgent(params.receiverThreadId);
+    }, params.delayMs);
+    timer.unref?.();
+    reconciliation.timer = timer;
+    this.codexNativeSubAgentReconciliations.set(
+      params.receiverThreadId,
+      reconciliation,
+    );
+  }
+
+  private clearCodexNativeSubAgentReconciliation(receiverThreadId: string): void {
+    const reconciliation =
+      this.codexNativeSubAgentReconciliations.get(receiverThreadId);
+    if (reconciliation?.timer) {
+      clearTimeout(reconciliation.timer);
+    }
+    this.codexNativeSubAgentReconciliations.delete(receiverThreadId);
+  }
+
+  private async reconcileCodexNativeSubAgent(
+    receiverThreadId: string,
+  ): Promise<void> {
+    const reconciliation =
+      this.codexNativeSubAgentReconciliations.get(receiverThreadId);
+    if (!reconciliation) {
+      return;
+    }
+
+    const overlay = await this.overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: reconciliation.parentThreadId,
+    });
+    const monitorId = codexNativeSubAgentId(receiverThreadId);
+    const existing = overlay?.subAgents?.find(
+      (subAgent) => subAgent.monitorId === monitorId,
+    );
+    if (!existing || codexNativeSubAgentIsTerminal(existing.status)) {
+      this.clearCodexNativeSubAgentReconciliation(receiverThreadId);
+      return;
+    }
+
+    const now = Date.now();
+    if (
+      reconciliation.attempts >= CODEX_NATIVE_SUBAGENT_MAX_RECONCILE_ATTEMPTS ||
+      now - reconciliation.startedAt > CODEX_NATIVE_SUBAGENT_MAX_RECONCILE_AGE_MS
+    ) {
+      this.clearCodexNativeSubAgentReconciliation(receiverThreadId);
+      return;
+    }
+
+    try {
+      const probe = await this.withCodexThreadClient(
+        receiverThreadId,
+        async (client) =>
+          await client.readThread({
+            threadId: receiverThreadId,
+            includeTurns: false,
+            limit: 0,
+          }),
+        undefined,
+        false,
+      );
+      reconciliation.attempts += 1;
+      const status = probe.threadStatus;
+
+      if (status === "idle") {
+        const completed = await this.completeCodexNativeSubAgentFromThread({
+          existing,
+          parentThreadId: reconciliation.parentThreadId,
+          receiverThreadId,
+        });
+        if (completed) {
+          this.clearCodexNativeSubAgentReconciliation(receiverThreadId);
+          return;
+        }
+      }
+    } catch (error) {
+      backendRegistryLog.debug("codex native subagent reconciliation failed", {
+        error: error instanceof Error ? error.message : String(error),
+        parentThreadId: reconciliation.parentThreadId,
+        receiverThreadId,
+      });
+    }
+
+    const latest = this.codexNativeSubAgentReconciliations.get(receiverThreadId);
+    if (!latest) {
+      return;
+    }
+    this.scheduleCodexNativeSubAgentReconciliation({
+      delayMs: codexNativeSubAgentNextReconciliationDelayMs(latest.attempts),
+      parentThreadId: latest.parentThreadId,
+      receiverThreadId,
+    });
+  }
+
+  private async completeCodexNativeSubAgentFromThread(params: {
+    existing: ThreadSubAgentSummary;
+    parentThreadId: string;
+    receiverThreadId: string;
+  }): Promise<boolean> {
+    const replay = await this.withCodexThreadClient(
+      params.receiverThreadId,
+      async (client) =>
+        await client.readThread({
+          threadId: params.receiverThreadId,
+          includeTurns: true,
+          limit: CODEX_NATIVE_SUBAGENT_FINAL_READ_LIMIT,
+        }),
+      undefined,
+      false,
+    );
+    if (replay.threadStatus === "active") {
+      return false;
+    }
+
+    const overlay = await this.overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: params.parentThreadId,
+    });
+    const monitorId = codexNativeSubAgentId(params.receiverThreadId);
+    const existing =
+      overlay?.subAgents?.find((subAgent) => subAgent.monitorId === monitorId) ??
+      params.existing;
+    if (codexNativeSubAgentIsTerminal(existing.status)) {
+      return true;
+    }
+
+    const now = Date.now();
+    const lastMessage = replay.lastAssistantMessage
+      ? truncateSubAgentText(replay.lastAssistantMessage, 360)
+      : "Codex native sub-agent completed.";
+    await this.overlayStore.upsertThreadSubAgent({
+      backend: "codex",
+      threadId: params.parentThreadId,
+      subAgent: {
+        ...existing,
+        status: "success",
+        outcome: "success",
+        completedAt: existing.completedAt ?? now,
+        lastMessage,
+        updatedAt: now,
+      },
+    });
+    this.invalidateThreadListCache("codex");
+    await this.emit({
+      backend: "codex",
+      notification: {
+        method: "thread/subAgents/updated",
+        params: {
+          threadId: params.parentThreadId,
+        },
+      },
+    });
+    return true;
   }
 
   private async persistTaskMonitorSubAgent(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -11544,9 +11544,21 @@ export class DesktopBackendRegistry {
       return;
     }
     const notificationParams = readRecord(event.notification.params);
-    const notificationModel = readOptionalString(notificationParams, ["model"]);
+    const notificationModel = readTaskMonitorUsageModel({
+      notificationModel: event.notification.params.model,
+      tokenUsage: event.notification.params.tokenUsage,
+    });
+    const serviceTier = readTaskMonitorUsageServiceTier(
+      event.notification.params.tokenUsage,
+    );
+    const fastMode = readTaskMonitorUsageFastMode(
+      event.notification.params.tokenUsage,
+    );
+    const model = notificationModel ?? existing.preferredModel;
     const usageSnapshot = buildTaskMonitorUsageSnapshot({
-      model: notificationModel ?? existing.preferredModel,
+      fastMode,
+      model,
+      serviceTier,
       tokenUsage: event.notification.params.tokenUsage,
     });
     if (!usageSnapshot) {
@@ -11572,6 +11584,28 @@ export class DesktopBackendRegistry {
         },
       },
     });
+    if (typeof this.overlayStore.upsertThreadUsageLine === "function") {
+      const line = buildTaskMonitorUsageLine({
+        backend: "codex",
+        fastMode,
+        model,
+        monitorId,
+        monitorThreadId: event.notification.params.threadId,
+        monitorTurnId:
+          readOptionalString(notificationParams, ["turnId", "turn_id"]) ??
+          existing.monitorTurnId,
+        parentThreadId,
+        serviceTier,
+        source: "monitor",
+        usage: usageSnapshot,
+      });
+      logUnpricedThreadUsageLine(line);
+      await this.overlayStore.upsertThreadUsageLine({ line });
+      await this.emitThreadPricingUpdated({
+        backend: "codex",
+        threadId: line.parentThreadId ?? line.threadId,
+      });
+    }
     if (!codexNativeSubAgentIsTerminal(existing.status)) {
       this.scheduleCodexNativeSubAgentReconciliation({
         delayMs: CODEX_NATIVE_SUBAGENT_ACTIVITY_STATUS_DELAY_MS,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1644,6 +1644,7 @@ type CodexNativeSubAgentTool =
 type CodexNativeSubAgentCall = {
   item: Record<string, unknown>;
   itemId?: string;
+  parentTurnId?: string;
   receiverThreadIds: string[];
   receiverThreadNames: Map<string, string>;
   tool: string;
@@ -1732,6 +1733,19 @@ function normalizeCodexNativeAgentName(value: unknown): string | undefined {
   }
   const normalized = value.replace(/\s+/g, " ").trim().replace(/^@+/, "");
   return normalized ? truncateSubAgentText(normalized, 80) : undefined;
+}
+
+function extractCodexNativeSpawnedAgentNames(text: string): string[] {
+  const names: string[] = [];
+  const pattern =
+    /Spawned\s+sub-agent\s+(?:`([^`]+)`|@?([A-Za-z][A-Za-z0-9_.-]{0,79}))/gi;
+  for (const match of text.matchAll(pattern)) {
+    const name = normalizeCodexNativeAgentName(match[1] ?? match[2]);
+    if (name) {
+      names.push(name);
+    }
+  }
+  return names;
 }
 
 function readCodexNativeAgentNameFromSource(
@@ -1837,6 +1851,9 @@ function readCodexNativeSubAgentCalls(
     candidates.push(item);
   }
   const turn = readRecord(params?.turn);
+  const notificationTurnId =
+    readOptionalString(params, ["turnId", "turn_id"]) ??
+    readOptionalString(turn, ["id", "turnId", "turn_id"]);
   const turnItems = Array.isArray(turn?.items) ? turn.items : [];
   for (const turnItem of turnItems) {
     const record = readRecord(turnItem);
@@ -1861,6 +1878,9 @@ function readCodexNativeSubAgentCalls(
       {
         item: candidate,
         itemId: readOptionalString(candidate, ["id", "itemId", "item_id"]),
+        parentTurnId:
+          readOptionalString(candidate, ["turnId", "turn_id"]) ??
+          notificationTurnId,
         receiverThreadIds: readStringArrayLike(candidate, [
           "receiverThreadIds",
           "receiver_thread_ids",
@@ -11497,6 +11517,67 @@ export class DesktopBackendRegistry {
     }
   }
 
+  private async recordCodexNativeSubAgentNamesFromTurn(event: AgentEvent): Promise<void> {
+    if (event.backend !== "codex" || event.notification.method !== "turn/completed") {
+      return;
+    }
+    const parentThreadId = event.notification.params.threadId;
+    const turnId = turnIdFromTerminalNotification(event.notification);
+    const text = finalTextFromTerminalNotification(event.notification);
+    if (!parentThreadId || !turnId || !text) {
+      return;
+    }
+    const names = extractCodexNativeSpawnedAgentNames(text);
+    if (names.length === 0) {
+      return;
+    }
+
+    const overlay = await this.overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: parentThreadId,
+    });
+    const candidates = (overlay?.subAgents ?? [])
+      .filter(
+        (subAgent) =>
+          subAgent.monitorId.startsWith("codex-native:") &&
+          subAgent.monitorTurnId === turnId &&
+          !subAgent.agentName,
+      )
+      .sort((left, right) => left.createdAt - right.createdAt);
+    if (candidates.length === 0) {
+      return;
+    }
+
+    const count = Math.min(candidates.length, names.length);
+    const now = Date.now();
+    for (let index = 0; index < count; index += 1) {
+      const candidate = candidates[index];
+      const agentName = names[index];
+      if (!candidate || !agentName) {
+        continue;
+      }
+      await this.overlayStore.upsertThreadSubAgent({
+        backend: "codex",
+        threadId: parentThreadId,
+        subAgent: {
+          ...candidate,
+          agentName,
+          updatedAt: now,
+        },
+      });
+    }
+    this.invalidateThreadListCache("codex");
+    await this.emit({
+      backend: "codex",
+      notification: {
+        method: "thread/subAgents/updated",
+        params: {
+          threadId: parentThreadId,
+        },
+      },
+    });
+  }
+
   private async persistCodexNativeSubAgent(params: {
     call: CodexNativeSubAgentCall;
     parentThreadId: string;
@@ -11564,6 +11645,11 @@ export class DesktopBackendRegistry {
       createdAt: existing?.createdAt ?? now,
       updatedAt: now,
       monitorThreadId: params.receiverThreadId,
+      ...(params.call.parentTurnId
+        ? { monitorTurnId: params.call.parentTurnId }
+        : existing?.monitorTurnId
+          ? { monitorTurnId: existing.monitorTurnId }
+          : {}),
       ...(agentName ? { agentName } : {}),
       ...(model
         ? { preferredModel: model }
@@ -15174,6 +15260,7 @@ export class DesktopBackendRegistry {
 
     await this.recordLiveThreadUsage(event);
     await this.recordCodexNativeSubAgentActivity(event);
+    await this.recordCodexNativeSubAgentNamesFromTurn(event);
     await this.recordTaskMonitorUsage(event);
 
     this.rememberThreadTitleFromEvent(event);

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -413,7 +413,6 @@ type BackendClient = {
     threadId: string;
     includeTurns?: boolean;
     before?: string;
-    includeTurns?: boolean;
     limit?: number;
   }): Promise<AppServerReadThreadResponse["replay"]>;
   injectThreadItems?(params: { threadId: string; items: unknown[] }): Promise<void>;
@@ -1257,7 +1256,25 @@ function readNonEmptyString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
-function readOptionalString(value: unknown): string | undefined {
+function readOptionalString(value: unknown): string | undefined;
+function readOptionalString(
+  record: Record<string, unknown> | undefined,
+  keys: string[],
+): string | undefined;
+function readOptionalString(
+  value: unknown,
+  keys?: string[],
+): string | undefined {
+  if (keys) {
+    return (
+      readStringLike(
+        value && typeof value === "object" && !Array.isArray(value)
+          ? (value as Record<string, unknown>)
+          : undefined,
+        keys,
+      ) ?? undefined
+    );
+  }
   return typeof value === "string" ? value : undefined;
 }
 
@@ -1702,13 +1719,6 @@ function normalizeCodexItemType(value: unknown): string | undefined {
   return typeof value === "string"
     ? value.replace(/[^a-z0-9]/gi, "").toLowerCase()
     : undefined;
-}
-
-function readOptionalString(
-  record: Record<string, unknown> | undefined,
-  keys: string[],
-): string | undefined {
-  return readStringLike(record, keys) ?? undefined;
 }
 
 function readStringArrayValue(value: unknown): string[] {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1644,6 +1644,7 @@ type CodexNativeSubAgentCall = {
   item: Record<string, unknown>;
   itemId?: string;
   receiverThreadIds: string[];
+  receiverThreadNames: Map<string, string>;
   tool: string;
 };
 
@@ -1710,6 +1711,107 @@ function readStringArrayLike(
   return [];
 }
 
+function normalizeCodexNativeAgentName(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = value.replace(/\s+/g, " ").trim().replace(/^@+/, "");
+  return normalized ? truncateSubAgentText(normalized, 80) : undefined;
+}
+
+function readCodexNativeAgentNameFromSource(
+  source: Record<string, unknown> | undefined,
+): string | undefined {
+  if (!source) {
+    return undefined;
+  }
+  const direct =
+    normalizeCodexNativeAgentName(source.agentNickname) ??
+    normalizeCodexNativeAgentName(source.agent_nickname) ??
+    normalizeCodexNativeAgentName(source.nickname) ??
+    normalizeCodexNativeAgentName(source.name);
+  if (direct) {
+    return direct;
+  }
+
+  const subAgent = readRecord(source.subAgent) ?? readRecord(source.sub_agent);
+  const spawn =
+    readRecord(subAgent?.thread_spawn) ??
+    readRecord(subAgent?.threadSpawn) ??
+    readRecord(source.thread_spawn) ??
+    readRecord(source.threadSpawn);
+  return (
+    normalizeCodexNativeAgentName(spawn?.agent_nickname) ??
+    normalizeCodexNativeAgentName(spawn?.agentNickname) ??
+    normalizeCodexNativeAgentName(subAgent?.agentNickname) ??
+    normalizeCodexNativeAgentName(subAgent?.agent_nickname)
+  );
+}
+
+function readCodexNativeAgentNameFromThread(
+  thread: Record<string, unknown> | undefined,
+): string | undefined {
+  if (!thread) {
+    return undefined;
+  }
+  return (
+    normalizeCodexNativeAgentName(thread.agentNickname) ??
+    normalizeCodexNativeAgentName(thread.agent_nickname) ??
+    normalizeCodexNativeAgentName(thread.nickname) ??
+    normalizeCodexNativeAgentName(thread.name) ??
+    readCodexNativeAgentNameFromSource(readRecord(thread.source)) ??
+    readCodexNativeAgentNameFromSource(readRecord(thread.thread_spawn)) ??
+    readCodexNativeAgentNameFromSource(readRecord(thread.threadSpawn))
+  );
+}
+
+function readCodexNativeReceiverThreadNames(
+  item: Record<string, unknown>,
+): Map<string, string> {
+  const names = new Map<string, string>();
+
+  const recordName = (threadId: string | undefined, name: string | undefined) => {
+    if (threadId && name) {
+      names.set(threadId, name);
+    }
+  };
+
+  const receiverThreads = Array.isArray(item.receiverThreads)
+    ? item.receiverThreads
+    : Array.isArray(item.receiver_threads)
+      ? item.receiver_threads
+      : [];
+  for (const receiverThread of receiverThreads) {
+    const receiver = readRecord(receiverThread);
+    if (!receiver) {
+      continue;
+    }
+    const threadId = readOptionalString(receiver, [
+      "threadId",
+      "thread_id",
+      "id",
+    ]);
+    const thread = readRecord(receiver.thread) ?? receiver;
+    recordName(
+      threadId,
+      readCodexNativeAgentNameFromThread(thread) ??
+        readCodexNativeAgentNameFromSource(readRecord(receiver.source)),
+    );
+  }
+
+  const states = readRecord(item.agentsStates) ?? readRecord(item.agents_states);
+  for (const [threadId, state] of Object.entries(states ?? {})) {
+    const stateRecord = readRecord(state);
+    recordName(
+      threadId,
+      readCodexNativeAgentNameFromThread(stateRecord) ??
+        readCodexNativeAgentNameFromSource(readRecord(stateRecord?.source)),
+    );
+  }
+
+  return names;
+}
+
 function readCodexNativeSubAgentCalls(
   notification: AppServerNotification,
 ): CodexNativeSubAgentCall[] {
@@ -1749,6 +1851,7 @@ function readCodexNativeSubAgentCalls(
           "receiver_thread_ids",
           "receivers",
         ]),
+        receiverThreadNames: readCodexNativeReceiverThreadNames(candidate),
         tool,
       },
     ];
@@ -11391,6 +11494,9 @@ export class DesktopBackendRegistry {
       "reasoningEffort",
       "reasoning_effort",
     ]);
+    const agentName =
+      params.call.receiverThreadNames.get(params.receiverThreadId) ??
+      existing?.agentName;
     const outcome = codexNativeSubAgentOutcome(status);
     const nextLastMessage = codexNativeSubAgentMessage({
       agentMessage: agentState.message,
@@ -11416,6 +11522,7 @@ export class DesktopBackendRegistry {
       createdAt: existing?.createdAt ?? now,
       updatedAt: now,
       monitorThreadId: params.receiverThreadId,
+      ...(agentName ? { agentName } : {}),
       ...(model
         ? { preferredModel: model }
         : existing?.preferredModel

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -11669,17 +11669,24 @@ export class DesktopBackendRegistry {
     }
   }
 
-  private async recordCodexNativeSubAgentNamesFromTurn(event: AgentEvent): Promise<void> {
-    if (event.backend !== "codex" || event.notification.method !== "turn/completed") {
+  private async recordCodexNativeSubAgentNames(event: AgentEvent): Promise<void> {
+    if (event.backend !== "codex") {
       return;
     }
-    const parentThreadId = event.notification.params.threadId;
-    const turnId = turnIdFromTerminalNotification(event.notification);
-    const text = finalTextFromTerminalNotification(event.notification);
-    if (!parentThreadId || !turnId || !text) {
+    const params = readRecord(event.notification.params);
+    if (!params) {
       return;
     }
-    const names = extractCodexNativeSpawnedAgentNames(text);
+    const parentThreadId = readOptionalString(params, ["threadId", "thread_id"]);
+    const turn = readRecord(params.turn);
+    const turnId =
+      readOptionalString(params, ["turnId", "turn_id"]) ?? readOptionalString(turn, ["id"]);
+    if (!parentThreadId || !turnId) {
+      return;
+    }
+    const names = textFragmentsFromCodexNotification(event.notification).flatMap(
+      (text) => extractCodexNativeSpawnedAgentNames(text),
+    );
     if (names.length === 0) {
       return;
     }
@@ -15483,7 +15490,7 @@ export class DesktopBackendRegistry {
     await this.recordLiveThreadUsage(event);
     await this.recordCodexNativeSubAgentActivity(event);
     await this.recordCodexNativeSubAgentNotifications(event);
-    await this.recordCodexNativeSubAgentNamesFromTurn(event);
+    await this.recordCodexNativeSubAgentNames(event);
     await this.recordTaskMonitorUsage(event);
 
     this.rememberThreadTitleFromEvent(event);

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -2916,7 +2916,10 @@ function finalTextFromTerminalNotification(
     AppServerNotification,
     { method: "turn/completed" }
   >;
-  const text = completed.params.turn.output
+  const output = Array.isArray(completed.params.turn.output)
+    ? completed.params.turn.output
+    : [];
+  const text = output
     .filter((item) => item.type === "text")
     .map((item) => item.text.trim())
     .filter(Boolean)

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -11454,6 +11454,9 @@ export class DesktopBackendRegistry {
     if (!threadId) {
       return;
     }
+    if (event.backend === "codex" && this.codexNativeSubAgentParents.has(threadId)) {
+      return;
+    }
     if (
       Array.from(this.taskMonitorDelegations.values()).some(
         (record) => record.monitorThreadId === threadId,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1658,6 +1658,12 @@ type CodexNativeSubAgentReconciliation = {
   timer?: NodeJS.Timeout;
 };
 
+type CodexNativeSubAgentNotification = {
+  lastMessage?: string;
+  receiverThreadId: string;
+  status: ThreadSubAgentSummary["status"];
+};
+
 const CODEX_NATIVE_SUBAGENT_TOOLS = new Set<CodexNativeSubAgentTool>([
   "spawnAgent",
   "sendInput",
@@ -1746,6 +1752,114 @@ function extractCodexNativeSpawnedAgentNames(text: string): string[] {
     }
   }
   return names;
+}
+
+function codexNativeNotificationMessage(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return truncateSubAgentText(value, 360);
+  }
+  const record = readRecord(value);
+  return record
+    ? truncateSubAgentText(
+        readOptionalString(record, ["message", "summary", "output", "text"]) ?? "",
+        360,
+      ) || undefined
+    : undefined;
+}
+
+function codexNativeNotificationStatus(
+  value: unknown,
+): { message?: string; status?: ThreadSubAgentSummary["status"] } {
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (["completed", "complete", "success", "succeeded"].includes(normalized)) {
+      return { status: "success" };
+    }
+    if (["failed", "failure", "errored", "error"].includes(normalized)) {
+      return { status: "failure" };
+    }
+    if (["cancelled", "canceled", "interrupted"].includes(normalized)) {
+      return { status: "cancelled" };
+    }
+    if (["running", "active", "in_progress", "inprogress"].includes(normalized)) {
+      return { status: "running" };
+    }
+    return {};
+  }
+
+  const record = readRecord(value);
+  if (!record) {
+    return {};
+  }
+  for (const [key, status] of [
+    ["completed", "success"],
+    ["complete", "success"],
+    ["success", "success"],
+    ["succeeded", "success"],
+    ["failed", "failure"],
+    ["failure", "failure"],
+    ["errored", "failure"],
+    ["error", "failure"],
+    ["cancelled", "cancelled"],
+    ["canceled", "cancelled"],
+    ["interrupted", "cancelled"],
+    ["running", "running"],
+    ["active", "running"],
+  ] as const) {
+    if (record[key] !== undefined) {
+      return {
+        message: codexNativeNotificationMessage(record[key]),
+        status,
+      };
+    }
+  }
+  return codexNativeNotificationStatus(
+    readOptionalString(record, ["status", "state"]) ?? undefined,
+  );
+}
+
+function extractCodexNativeSubAgentNotifications(
+  text: string,
+): CodexNativeSubAgentNotification[] {
+  const notifications: CodexNativeSubAgentNotification[] = [];
+  const pattern = /<subagent_notification>\s*([\s\S]*?)\s*<\/subagent_notification>/gi;
+  for (const match of text.matchAll(pattern)) {
+    const rawJson = match[1]?.trim();
+    if (!rawJson) {
+      continue;
+    }
+    let payload: unknown;
+    try {
+      payload = JSON.parse(rawJson);
+    } catch {
+      continue;
+    }
+    const record = readRecord(payload);
+    if (!record) {
+      continue;
+    }
+    const receiverThreadId = readOptionalString(record, [
+      "agent_path",
+      "agentPath",
+      "threadId",
+      "thread_id",
+      "receiverThreadId",
+      "receiver_thread_id",
+    ]);
+    if (!receiverThreadId) {
+      continue;
+    }
+    const parsedStatus = codexNativeNotificationStatus(record.status);
+    if (!parsedStatus.status) {
+      continue;
+    }
+    notifications.push({
+      receiverThreadId,
+      status: parsedStatus.status,
+      ...(parsedStatus.message ? { lastMessage: parsedStatus.message } : {}),
+    });
+  }
+  return notifications;
 }
 
 function readCodexNativeAgentNameFromSource(
@@ -2799,6 +2913,44 @@ function finalTextFromTerminalNotification(
     .join("\n\n")
     .trim();
   return text || undefined;
+}
+
+function textFragmentsFromCodexNotification(
+  notification: AppServerNotification,
+): string[] {
+  const fragments: string[] = [];
+  const terminalText = finalTextFromTerminalNotification(notification);
+  if (terminalText) {
+    fragments.push(terminalText);
+  }
+
+  if (notification.method === "item/agentMessage/delta") {
+    const delta = readOptionalString(readRecord(notification.params), ["delta"]);
+    if (delta) {
+      fragments.push(delta);
+    }
+  }
+
+  if (
+    notification.method === "item/started" ||
+    notification.method === "item/completed"
+  ) {
+    const params = readRecord(notification.params);
+    const item = readRecord(params?.item);
+    const itemText =
+      readOptionalString(item, ["text", "content", "message", "summary"]) ??
+      readOptionalString(readRecord(item?.data), [
+        "text",
+        "content",
+        "message",
+        "summary",
+      ]);
+    if (itemText) {
+      fragments.push(itemText);
+    }
+  }
+
+  return fragments;
 }
 
 function errorMessageFromTerminalNotification(
@@ -11578,6 +11730,76 @@ export class DesktopBackendRegistry {
     });
   }
 
+  private async recordCodexNativeSubAgentNotifications(
+    event: AgentEvent,
+  ): Promise<void> {
+    if (event.backend !== "codex") {
+      return;
+    }
+    const notifications = textFragmentsFromCodexNotification(event.notification).flatMap(
+      (text) => extractCodexNativeSubAgentNotifications(text),
+    );
+    if (notifications.length === 0) {
+      return;
+    }
+
+    const now = Date.now();
+    for (const notification of notifications) {
+      const parentThreadId =
+        this.codexNativeSubAgentParents.get(notification.receiverThreadId) ??
+        readOptionalString(readRecord(event.notification.params), [
+          "threadId",
+          "thread_id",
+        ]);
+      if (!parentThreadId) {
+        continue;
+      }
+      const overlay = await this.overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: parentThreadId,
+      });
+      const monitorId = codexNativeSubAgentId(notification.receiverThreadId);
+      const existing = overlay?.subAgents?.find(
+        (subAgent) => subAgent.monitorId === monitorId,
+      );
+      if (!existing) {
+        continue;
+      }
+
+      const outcome = codexNativeSubAgentOutcome(notification.status);
+      const terminal = codexNativeSubAgentIsTerminal(notification.status);
+      await this.overlayStore.upsertThreadSubAgent({
+        backend: "codex",
+        threadId: parentThreadId,
+        subAgent: {
+          ...existing,
+          status: codexNativeSubAgentIsTerminal(existing.status)
+            ? existing.status
+            : notification.status,
+          updatedAt: now,
+          ...(notification.lastMessage
+            ? { lastMessage: notification.lastMessage }
+            : {}),
+          ...(outcome && !existing.outcome ? { outcome } : {}),
+          ...(terminal ? { completedAt: existing.completedAt ?? now } : {}),
+        },
+      });
+      if (terminal) {
+        this.clearCodexNativeSubAgentReconciliation(notification.receiverThreadId);
+      }
+      this.invalidateThreadListCache("codex");
+      await this.emit({
+        backend: "codex",
+        notification: {
+          method: "thread/subAgents/updated",
+          params: {
+            threadId: parentThreadId,
+          },
+        },
+      });
+    }
+  }
+
   private async persistCodexNativeSubAgent(params: {
     call: CodexNativeSubAgentCall;
     parentThreadId: string;
@@ -15260,6 +15482,7 @@ export class DesktopBackendRegistry {
 
     await this.recordLiveThreadUsage(event);
     await this.recordCodexNativeSubAgentActivity(event);
+    await this.recordCodexNativeSubAgentNotifications(event);
     await this.recordCodexNativeSubAgentNamesFromTurn(event);
     await this.recordTaskMonitorUsage(event);
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -14642,19 +14642,22 @@ export class DesktopBackendRegistry {
       });
       if (event.backend === "codex") {
         // Turn-end is the resume boundary — flush any queued mode change
-        // now. Fire-and-forget; failures are logged + retried inside
+        // now. Fire-and-forget so terminal turn fan-out does not block on
+        // permission prompts; startTurn/startReview also await any in-flight
+        // flush before launching the next Codex request.
+        // Failures are logged + retried inside
         // flushQueuedExecutionModeIfPresent.
         void this.flushQueuedExecutionModeIfPresent(
           notification.params.threadId,
         );
       } else if (isAcpBackendId(event.backend)) {
         if (this.usesSlashControlledAcpExecutionModes(event.backend)) {
-          void this.flushQueuedExecutionModeIfPresent(
+          await this.flushQueuedExecutionModeIfPresent(
             notification.params.threadId,
             event.backend,
           );
         }
-        void this.flushQueuedAcpRuntimeOptionIfPresent(
+        await this.flushQueuedAcpRuntimeOptionIfPresent(
           event.backend,
           notification.params.threadId,
         );
@@ -14738,12 +14741,12 @@ export class DesktopBackendRegistry {
       if (event.backend !== "codex") {
         if (isAcpBackendId(event.backend)) {
           if (this.usesSlashControlledAcpExecutionModes(event.backend)) {
-            void this.flushQueuedExecutionModeIfPresent(
+            await this.flushQueuedExecutionModeIfPresent(
               event.notification.params.threadId,
               event.backend,
             );
           }
-          void this.flushQueuedAcpRuntimeOptionIfPresent(
+          await this.flushQueuedAcpRuntimeOptionIfPresent(
             event.backend,
             event.notification.params.threadId,
           );
@@ -14773,7 +14776,7 @@ export class DesktopBackendRegistry {
         // on the protocol shape; we cover both for resilience). Idempotent
         // when no queue is set.
         if (!hasActiveCodexReviewTurn) {
-          void this.flushQueuedExecutionModeIfPresent(
+          await this.flushQueuedExecutionModeIfPresent(
             event.notification.params.threadId,
           );
         }
@@ -14792,6 +14795,9 @@ export class DesktopBackendRegistry {
         status: readStatusType(event.notification.params.status),
       });
     }
+
+    await this.recordTaskMonitorUsage(event);
+    await this.recordCodexNativeSubAgentActivity(event);
 
     if (event.notification.method === "serverRequest/resolved") {
       const key = buildPendingRequestKey({

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1633,6 +1633,252 @@ type ReviewSubAgentRecord = {
   turnId: string;
 };
 
+type CodexNativeSubAgentTool =
+  | "spawnAgent"
+  | "sendInput"
+  | "resumeAgent"
+  | "wait"
+  | "closeAgent";
+
+type CodexNativeSubAgentCall = {
+  item: Record<string, unknown>;
+  itemId?: string;
+  receiverThreadIds: string[];
+  tool: string;
+};
+
+const CODEX_NATIVE_SUBAGENT_TOOLS = new Set<CodexNativeSubAgentTool>([
+  "spawnAgent",
+  "sendInput",
+  "resumeAgent",
+  "wait",
+  "closeAgent",
+]);
+
+function isCodexNativeSubAgentTool(tool: string): tool is CodexNativeSubAgentTool {
+  return CODEX_NATIVE_SUBAGENT_TOOLS.has(tool as CodexNativeSubAgentTool);
+}
+
+function codexNativeSubAgentId(threadId: string): string {
+  return `codex-native:${threadId}`;
+}
+
+function shortCodexNativeAgentId(threadId: string): string {
+  return threadId.length > 8 ? threadId.slice(0, 8) : threadId;
+}
+
+function truncateSubAgentText(value: string, maxLength: number): string {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+  return `${normalized.slice(0, Math.max(0, maxLength - 3)).trimEnd()}...`;
+}
+
+function normalizeCodexItemType(value: unknown): string | undefined {
+  return typeof value === "string"
+    ? value.replace(/[^a-z0-9]/gi, "").toLowerCase()
+    : undefined;
+}
+
+function readOptionalString(
+  record: Record<string, unknown> | undefined,
+  keys: string[],
+): string | undefined {
+  return readStringLike(record, keys) ?? undefined;
+}
+
+function readStringArrayValue(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string" && entry.trim() !== "")
+    : [];
+}
+
+function readStringArrayLike(
+  record: Record<string, unknown> | undefined,
+  keys: string[],
+): string[] {
+  if (!record) {
+    return [];
+  }
+  for (const key of keys) {
+    const values = readStringArrayValue(record[key]);
+    if (values.length > 0) {
+      return values;
+    }
+  }
+  return [];
+}
+
+function readCodexNativeSubAgentCalls(
+  notification: AppServerNotification,
+): CodexNativeSubAgentCall[] {
+  const params = readRecord(notification.params);
+  const candidates: Record<string, unknown>[] = [];
+  const item = readRecord(params?.item);
+  if (item) {
+    candidates.push(item);
+  }
+  const turn = readRecord(params?.turn);
+  const turnItems = Array.isArray(turn?.items) ? turn.items : [];
+  for (const turnItem of turnItems) {
+    const record = readRecord(turnItem);
+    if (record) {
+      candidates.push(record);
+    }
+  }
+  const paramItems = Array.isArray(params?.items) ? params.items : [];
+  for (const paramItem of paramItems) {
+    const record = readRecord(paramItem);
+    if (record) {
+      candidates.push(record);
+    }
+  }
+
+  return candidates.flatMap((candidate) => {
+    if (normalizeCodexItemType(candidate.type) !== "collabagenttoolcall") {
+      return [];
+    }
+    const tool = readOptionalString(candidate, ["tool"]) ?? "collabAgent";
+    return [
+      {
+        item: candidate,
+        itemId: readOptionalString(candidate, ["id", "itemId", "item_id"]),
+        receiverThreadIds: readStringArrayLike(candidate, [
+          "receiverThreadIds",
+          "receiver_thread_ids",
+          "receivers",
+        ]),
+        tool,
+      },
+    ];
+  });
+}
+
+function readCodexNativeAgentState(
+  item: Record<string, unknown>,
+  threadId: string,
+): { message?: string; status?: string } {
+  const states = readRecord(item.agentsStates) ?? readRecord(item.agents_states);
+  const state = states?.[threadId];
+  if (typeof state === "string") {
+    return { status: state };
+  }
+  const record = readRecord(state);
+  if (!record) {
+    return {};
+  }
+  return {
+    message: readOptionalString(record, ["message", "output", "summary"]),
+    status: readOptionalString(record, ["status", "state"]),
+  };
+}
+
+function mapCodexNativeSubAgentStatus(params: {
+  agentState?: string;
+  itemStatus?: string;
+  tool: string;
+}): ThreadSubAgentSummary["status"] {
+  const itemStatus = params.itemStatus?.toLowerCase();
+  const agentState = params.agentState?.toLowerCase();
+  if (itemStatus === "failed") {
+    return "failure";
+  }
+  if (agentState) {
+    if (["completed", "complete", "success", "succeeded"].includes(agentState)) {
+      return "success";
+    }
+    if (["failed", "failure", "errored", "error"].includes(agentState)) {
+      return "failure";
+    }
+    if (["cancelled", "canceled", "interrupted"].includes(agentState)) {
+      return "cancelled";
+    }
+    if (["blocked", "pendingapproval", "pendingapprovalrequest"].includes(agentState)) {
+      return "blocked";
+    }
+    if (["pendinginit", "pending", "running", "inprogress", "active"].includes(agentState)) {
+      return "running";
+    }
+    if (agentState === "shutdown") {
+      return params.tool === "closeAgent" ? "cancelled" : "success";
+    }
+    if (agentState === "notfound") {
+      return "failure";
+    }
+  }
+  if (itemStatus === "in_progress" || itemStatus === "running") {
+    return "running";
+  }
+  if (params.tool === "closeAgent" && itemStatus === "completed") {
+    return "cancelled";
+  }
+  if (params.tool === "spawnAgent" && itemStatus === "completed") {
+    return "running";
+  }
+  if (itemStatus === "completed" && params.tool === "wait") {
+    return "success";
+  }
+  return "running";
+}
+
+function codexNativeSubAgentOutcome(
+  status: ThreadSubAgentSummary["status"],
+): ThreadSubAgentSummary["outcome"] | undefined {
+  if (status === "success") {
+    return "success";
+  }
+  if (status === "failure") {
+    return "failure";
+  }
+  if (status === "cancelled") {
+    return "cancelled";
+  }
+  return undefined;
+}
+
+function codexNativeSubAgentIsTerminal(status: ThreadSubAgentSummary["status"]): boolean {
+  return status === "success" || status === "failure" || status === "cancelled";
+}
+
+function codexNativeSubAgentTask(params: {
+  prompt?: string;
+  threadId: string;
+}): string {
+  const promptTitle = params.prompt
+    ? shortenDerivedThreadTitle(params.prompt) ?? params.prompt
+    : undefined;
+  return promptTitle
+    ? truncateSubAgentText(promptTitle, 120)
+    : `Codex subagent ${shortCodexNativeAgentId(params.threadId)}`;
+}
+
+function codexNativeSubAgentMessage(params: {
+  agentMessage?: string;
+  agentState?: string;
+  tool: string;
+}): string {
+  if (params.agentMessage) {
+    return truncateSubAgentText(params.agentMessage, 360);
+  }
+  switch (params.tool) {
+    case "spawnAgent":
+      return "Spawned by Codex native spawnAgent.";
+    case "sendInput":
+      return "Sent input to Codex native subagent.";
+    case "resumeAgent":
+      return "Resumed Codex native subagent.";
+    case "wait":
+      return params.agentState
+        ? `Observed Codex native subagent state: ${params.agentState}.`
+        : "Waited on Codex native subagent.";
+    case "closeAgent":
+      return "Closed Codex native subagent.";
+    default:
+      return `Observed Codex native ${params.tool} call.`;
+  }
+}
+
 function taskMonitorFailure<TOperation extends TaskMonitorRequest["operation"]>(
   operation: TOperation,
   code: "forbidden" | "internal_error" | "invalid_arguments" | "not_found" | "unsupported_operation",
@@ -3568,6 +3814,7 @@ export class DesktopBackendRegistry {
     string,
     ReviewSubAgentRecord
   >();
+  private readonly codexNativeSubAgentParents = new Map<string, string>();
   private readonly observedCodexSettingsByThread = new Map<string, ObservedCodexSettings>();
   private readonly reservedCodexStartThreadIds = new Set<string>();
   private readonly reservedAcpStartThreadKeys = new Set<string>();
@@ -10788,6 +11035,7 @@ export class DesktopBackendRegistry {
       (record) => record.monitorThreadId === notification.params.threadId,
     );
     if (!monitorRecord) {
+      await this.recordCodexNativeSubAgentUsage(event);
       return;
     }
 
@@ -10956,6 +11204,66 @@ export class DesktopBackendRegistry {
     }
   }
 
+  private async recordCodexNativeSubAgentUsage(event: AgentEvent): Promise<void> {
+    if (
+      event.backend !== "codex" ||
+      event.notification.method !== "thread/tokenUsage/updated"
+    ) {
+      return;
+    }
+    const parentThreadId = this.codexNativeSubAgentParents.get(
+      event.notification.params.threadId,
+    );
+    if (!parentThreadId) {
+      return;
+    }
+    const overlay = await this.overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: parentThreadId,
+    });
+    const monitorId = codexNativeSubAgentId(event.notification.params.threadId);
+    const existing = overlay?.subAgents?.find(
+      (subAgent) => subAgent.monitorId === monitorId,
+    );
+    if (!existing) {
+      backendRegistryLog.warn("codex native subagent usage had no matching card", {
+        monitorId,
+        parentThreadId,
+        threadId: event.notification.params.threadId,
+      });
+      return;
+    }
+    const notificationParams = readRecord(event.notification.params);
+    const notificationModel = readOptionalString(notificationParams, ["model"]);
+    const usageSnapshot = buildTaskMonitorUsageSnapshot({
+      model: notificationModel ?? existing.preferredModel,
+      tokenUsage: event.notification.params.tokenUsage,
+    });
+    if (!usageSnapshot) {
+      return;
+    }
+
+    await this.overlayStore.upsertThreadSubAgent({
+      backend: "codex",
+      threadId: parentThreadId,
+      subAgent: {
+        ...existing,
+        monitorUsage: usageSnapshot,
+        updatedAt: Date.now(),
+      },
+    });
+    this.invalidateThreadListCache("codex");
+    await this.emit({
+      backend: "codex",
+      notification: {
+        method: "thread/subAgents/updated",
+        params: {
+          threadId: parentThreadId,
+        },
+      },
+    });
+  }
+
   private async persistExistingReviewSubAgentUsage(params: {
     backend: AppServerBackendKind;
     parentThreadId: string;
@@ -10998,6 +11306,143 @@ export class DesktopBackendRegistry {
       },
     });
     return true;
+  }
+
+  private async recordCodexNativeSubAgentActivity(event: AgentEvent): Promise<void> {
+    if (event.backend !== "codex") {
+      return;
+    }
+    const params = readRecord(event.notification.params);
+    const threadId = readOptionalString(params, ["threadId", "thread_id"]);
+    if (!threadId) {
+      return;
+    }
+    const calls = readCodexNativeSubAgentCalls(event.notification);
+    if (calls.length === 0) {
+      return;
+    }
+
+    for (const call of calls) {
+      if (!isCodexNativeSubAgentTool(call.tool)) {
+        backendRegistryLog.warn("unhandled codex native subagent tool", {
+          itemId: call.itemId,
+          method: event.notification.method,
+          threadId,
+          tool: call.tool,
+        });
+        continue;
+      }
+      if (call.receiverThreadIds.length === 0) {
+        backendRegistryLog.warn("codex native subagent call missing receiver thread ids", {
+          itemId: call.itemId,
+          method: event.notification.method,
+          threadId,
+          tool: call.tool,
+        });
+        continue;
+      }
+
+      for (const receiverThreadId of call.receiverThreadIds) {
+        await this.persistCodexNativeSubAgent({
+          call,
+          parentThreadId: threadId,
+          receiverThreadId,
+        });
+      }
+    }
+  }
+
+  private async persistCodexNativeSubAgent(params: {
+    call: CodexNativeSubAgentCall;
+    parentThreadId: string;
+    receiverThreadId: string;
+  }): Promise<void> {
+    const now = Date.now();
+    this.codexNativeSubAgentParents.set(params.receiverThreadId, params.parentThreadId);
+    const overlay = await this.overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: params.parentThreadId,
+    });
+    const monitorId = codexNativeSubAgentId(params.receiverThreadId);
+    const existing = overlay?.subAgents?.find(
+      (subAgent) => subAgent.monitorId === monitorId,
+    );
+    const prompt = readOptionalString(params.call.item, ["prompt"]);
+    const itemStatus = readOptionalString(params.call.item, ["status"]);
+    const agentState = readCodexNativeAgentState(
+      params.call.item,
+      params.receiverThreadId,
+    );
+    const mappedStatus = mapCodexNativeSubAgentStatus({
+      agentState: agentState.status,
+      itemStatus,
+      tool: params.call.tool,
+    });
+    const status =
+      existing && codexNativeSubAgentIsTerminal(existing.status)
+        ? existing.status
+        : mappedStatus;
+    const completedAt =
+      codexNativeSubAgentIsTerminal(status) && !existing?.completedAt
+        ? now
+        : existing?.completedAt;
+    const model = readOptionalString(params.call.item, ["model"]);
+    const reasoningEffort = readOptionalString(params.call.item, [
+      "reasoningEffort",
+      "reasoning_effort",
+    ]);
+    const outcome = codexNativeSubAgentOutcome(status);
+    const subAgent: ThreadSubAgentSummary = {
+      monitorId,
+      task:
+        existing?.task ??
+        codexNativeSubAgentTask({
+          prompt,
+          threadId: params.receiverThreadId,
+        }),
+      status,
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+      monitorThreadId: params.receiverThreadId,
+      ...(model
+        ? { preferredModel: model }
+        : existing?.preferredModel
+          ? { preferredModel: existing.preferredModel }
+          : {}),
+      ...(reasoningEffort
+        ? { preferredReasoningEffort: reasoningEffort }
+        : existing?.preferredReasoningEffort
+          ? { preferredReasoningEffort: existing.preferredReasoningEffort }
+          : {}),
+      lastMessage: codexNativeSubAgentMessage({
+        agentMessage: agentState.message,
+        agentState: agentState.status,
+        tool: params.call.tool,
+      }),
+      ...(outcome
+        ? { outcome }
+        : existing?.outcome
+          ? { outcome: existing.outcome }
+          : {}),
+      ...(completedAt ? { completedAt } : {}),
+      ...(existing?.monitorUsage ? { monitorUsage: existing.monitorUsage } : {}),
+    };
+
+    await this.overlayStore.upsertThreadSubAgent({
+      backend: "codex",
+      threadId: params.parentThreadId,
+      subAgent,
+    });
+    this.invalidateThreadListCache("codex");
+    await this.emit({
+      backend: "codex",
+      notification: {
+        method: "thread/subAgents/updated",
+        params: {
+          threadId: params.parentThreadId,
+        },
+      },
+    });
   }
 
   private async persistTaskMonitorSubAgent(
@@ -14378,6 +14823,7 @@ export class DesktopBackendRegistry {
     }
 
     await this.recordLiveThreadUsage(event);
+    await this.recordCodexNativeSubAgentActivity(event);
     await this.recordTaskMonitorUsage(event);
 
     this.rememberThreadTitleFromEvent(event);

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -11392,6 +11392,18 @@ export class DesktopBackendRegistry {
       "reasoning_effort",
     ]);
     const outcome = codexNativeSubAgentOutcome(status);
+    const nextLastMessage = codexNativeSubAgentMessage({
+      agentMessage: agentState.message,
+      agentState: agentState.status,
+      tool: params.call.tool,
+    });
+    const lastMessage =
+      existing &&
+      codexNativeSubAgentIsTerminal(existing.status) &&
+      !agentState.message &&
+      existing.lastMessage
+        ? existing.lastMessage
+        : nextLastMessage;
     const subAgent: ThreadSubAgentSummary = {
       monitorId,
       task:
@@ -11414,11 +11426,7 @@ export class DesktopBackendRegistry {
         : existing?.preferredReasoningEffort
           ? { preferredReasoningEffort: existing.preferredReasoningEffort }
           : {}),
-      lastMessage: codexNativeSubAgentMessage({
-        agentMessage: agentState.message,
-        agentState: agentState.status,
-        tool: params.call.tool,
-      }),
+      lastMessage,
       ...(outcome
         ? { outcome }
         : existing?.outcome
@@ -14795,9 +14803,6 @@ export class DesktopBackendRegistry {
         status: readStatusType(event.notification.params.status),
       });
     }
-
-    await this.recordTaskMonitorUsage(event);
-    await this.recordCodexNativeSubAgentActivity(event);
 
     if (event.notification.method === "serverRequest/resolved") {
       const key = buildPendingRequestKey({

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -5126,6 +5126,7 @@ function buildThreadReadPayload(params: {
   threadId: string;
   includeTurns?: boolean;
   before?: string;
+  includeTurns?: boolean;
   limit?: number;
 }): CodexThreadReadPayload {
   const payload: CodexThreadReadPayload = {
@@ -5967,6 +5968,7 @@ export class CodexAppServerClient {
     threadId: string;
     includeTurns?: boolean;
     before?: string;
+    includeTurns?: boolean;
     limit?: number;
   }): Promise<AppServerThreadReplay> {
     await this.ensureInitialized();

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -5126,7 +5126,6 @@ function buildThreadReadPayload(params: {
   threadId: string;
   includeTurns?: boolean;
   before?: string;
-  includeTurns?: boolean;
   limit?: number;
 }): CodexThreadReadPayload {
   const payload: CodexThreadReadPayload = {
@@ -5968,7 +5967,6 @@ export class CodexAppServerClient {
     threadId: string;
     includeTurns?: boolean;
     before?: string;
-    includeTurns?: boolean;
     limit?: number;
   }): Promise<AppServerThreadReplay> {
     await this.ensureInitialized();

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -2889,10 +2889,6 @@ export function Composer(props: ComposerProps) {
         event.notification.method === "thread/status/changed" &&
         statusRecord?.type === "idle"
       ) {
-        if (activeTurnIdRef.current) {
-          return;
-        }
-
         props.onPendingStatusChange?.(undefined);
         updateSending(false);
         setInterrupting(false);

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1503,6 +1503,7 @@ export function Composer(props: ComposerProps) {
   const inputWrapRef = useRef<HTMLDivElement>(null);
   const autocompleteListRef = useRef<HTMLDivElement>(null);
   const activeTurnIdRef = useRef<string | undefined>(props.activeTurnId);
+  const confirmedActiveTurnIdRef = useRef<string | undefined>(undefined);
   const activeReviewTurnIdRef = useRef<string | undefined>(undefined);
   const inFlightReviewSubmissionKeyRef = useRef<string | undefined>(undefined);
   const autocompleteOptionRefs = useRef<Array<HTMLButtonElement | null>>([]);
@@ -2346,6 +2347,9 @@ export function Composer(props: ComposerProps) {
     } else if (!nextTurnId || activeReviewTurnIdRef.current !== nextTurnId) {
       activeReviewTurnIdRef.current = undefined;
     }
+    if (!nextTurnId || confirmedActiveTurnIdRef.current !== nextTurnId) {
+      confirmedActiveTurnIdRef.current = undefined;
+    }
     activeTurnIdRef.current = nextTurnId;
     setActiveTurnId(nextTurnId);
   };
@@ -2829,6 +2833,7 @@ export function Composer(props: ComposerProps) {
           return;
         }
         updateActiveTurnId(startedTurnId);
+        confirmedActiveTurnIdRef.current = startedTurnId;
         props.onActiveTurnIdChange?.(startedTurnId);
       }
 
@@ -2892,6 +2897,12 @@ export function Composer(props: ComposerProps) {
         if (
           activeReviewTurnIdRef.current &&
           activeTurnIdRef.current === activeReviewTurnIdRef.current
+        ) {
+          return;
+        }
+        if (
+          activeTurnIdRef.current &&
+          activeTurnIdRef.current === confirmedActiveTurnIdRef.current
         ) {
           return;
         }

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -2889,6 +2889,12 @@ export function Composer(props: ComposerProps) {
         event.notification.method === "thread/status/changed" &&
         statusRecord?.type === "idle"
       ) {
+        if (
+          activeReviewTurnIdRef.current &&
+          activeTurnIdRef.current === activeReviewTurnIdRef.current
+        ) {
+          return;
+        }
         props.onPendingStatusChange?.(undefined);
         updateSending(false);
         setInterrupting(false);

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -9470,6 +9470,64 @@ describe("Composer", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("clears stale thinking when Codex reports the thread is idle", async () => {
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    const onActiveTurnIdChange = vi.fn();
+    const onPendingStatusChange = vi.fn();
+
+    render(
+      <Composer
+        activeTurnId="turn-stale"
+        desktopApi={{
+          onAgentEvent: (callback) => {
+            agentEventHandler = callback;
+            return () => undefined;
+          },
+          startTurn: async () => ({
+            backend: "codex",
+            threadId: "thread-1",
+            turnId: "turn-1",
+          }),
+        }}
+        disabled={false}
+        onActiveTurnIdChange={onActiveTurnIdChange}
+        onPendingStatusChange={onPendingStatusChange}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Build Codex client",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument();
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "thread/status/changed",
+          params: {
+            threadId: "thread-1",
+            status: { type: "idle" },
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "Stop" })).not.toBeInTheDocument();
+    });
+    expect(onActiveTurnIdChange).toHaveBeenCalledWith(undefined);
+    expect(onPendingStatusChange).toHaveBeenCalledWith(undefined);
+  });
+
   it("releases the queued-turn lock when Stop repairs stale active state", async () => {
     const draftStore = createComposerDraftStore();
     const scopeKey = "thread:codex:thread-stale-queue";
@@ -9547,7 +9605,7 @@ describe("Composer", () => {
     );
   });
 
-  it("keeps the stop button visible when idle status arrives before completion", async () => {
+  it("clears stale thinking when idle status arrives before completion", async () => {
     let agentEventHandler:
       | ((event: {
           backend: "codex";
@@ -9641,8 +9699,10 @@ describe("Composer", () => {
       });
     });
 
-    expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument();
-    expect(onPendingStatusChange).not.toHaveBeenCalledWith(undefined);
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "Stop" })).not.toBeInTheDocument();
+    });
+    expect(onPendingStatusChange).toHaveBeenCalledWith(undefined);
   });
 
   it("sends Codex turns with plan collaboration mode when plan mode is enabled", async () => {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -9609,7 +9609,7 @@ describe("Composer", () => {
     );
   });
 
-  it("clears stale thinking when idle status arrives before completion", async () => {
+  it("keeps confirmed thinking when idle status arrives before completion", async () => {
     let agentEventHandler:
       | ((event: {
           backend: "codex";
@@ -9703,10 +9703,8 @@ describe("Composer", () => {
       });
     });
 
-    await waitFor(() => {
-      expect(screen.queryByRole("button", { name: "Stop" })).not.toBeInTheDocument();
-    });
-    expect(onPendingStatusChange).toHaveBeenCalledWith(undefined);
+    expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument();
+    expect(onPendingStatusChange).not.toHaveBeenCalledWith(undefined);
   });
 
   it("sends Codex turns with plan collaboration mode when plan mode is enabled", async () => {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -4527,6 +4527,10 @@ describe("Composer", () => {
           },
         },
       });
+    });
+    expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument();
+
+    await act(async () => {
       agentEventHandler?.({
         backend: "codex",
         notification: {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -392,6 +392,31 @@ describe("ThreadContextPanel", () => {
     expect(modal.getByText("Codex native spawnAgent")).toBeInTheDocument();
   });
 
+  it("does not duplicate the Codex native source line while running", () => {
+    renderPanel({
+      activeTab: "subagents",
+      pinned: true,
+      thread: {
+        ...baseThread,
+        subAgents: [
+          {
+            monitorId: "codex-native:019ed7df-5876-7882-9b75-7fd647372da7",
+            task: "Check PR status",
+            status: "running",
+            createdAt: 2000,
+            updatedAt: 2500,
+            monitorThreadId: "019ed7df-5876-7882-9b75-7fd647372da7",
+            lastMessage: "Spawned by Codex native spawnAgent.",
+          },
+        ],
+      },
+    });
+
+    expect(screen.getAllByText("Spawned by Codex native spawnAgent.")).toHaveLength(
+      1,
+    );
+  });
+
   it("moves focus between tabs with Arrow keys (roving tablist)", () => {
     renderPanel({ pinned: true });
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -227,6 +227,7 @@ describe("ThreadContextPanel", () => {
             status: "running",
             createdAt: 2000,
             updatedAt: 2500,
+            agentName: "Poincare",
             preferredModel: "gpt-5.4-mini",
             monitorThreadId: "monitor-thread-2",
             lastMessage: "Lint is still running.",
@@ -261,6 +262,7 @@ describe("ThreadContextPanel", () => {
     });
 
     expect(screen.getByText("Watch CI until it completes.")).toBeInTheDocument();
+    expect(screen.getByText("Poincare")).toBeInTheDocument();
     expect(screen.getByText("Running")).toBeInTheDocument();
     expect(screen.getByText("Lint is still running.")).toBeInTheDocument();
     expect(
@@ -288,6 +290,8 @@ describe("ThreadContextPanel", () => {
       modal.getByRole("heading", { level: 2, name: "Watch CI until it completes." }),
     ).toBeInTheDocument();
     expect(modal.getByText("Latest message")).toBeInTheDocument();
+    expect(modal.getByText("Name")).toBeInTheDocument();
+    expect(modal.getByText("Poincare")).toBeInTheDocument();
     expect(modal.getByText("Lint is still running.")).toBeInTheDocument();
     expect(modal.getByText("Tokens & pricing")).toBeInTheDocument();
     expect(modal.getByText("gpt-5.4-mini")).toBeInTheDocument();

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -340,6 +340,43 @@ describe("ThreadContextPanel", () => {
     ).toBeInTheDocument();
   });
 
+  it("labels Codex native sub-agent usage separately from monitor usage", () => {
+    renderPanel({
+      activeTab: "subagents",
+      pinned: true,
+      thread: {
+        ...baseThread,
+        subAgents: [
+          {
+            monitorId: "codex-native:019ed7df-5876-7882-9b75-7fd647372da7",
+            task: "Check PR status",
+            status: "success",
+            createdAt: 2000,
+            updatedAt: 2500,
+            monitorThreadId: "019ed7df-5876-7882-9b75-7fd647372da7",
+            monitorUsage: {
+              summary: "800 uncached in · 200 cached · 50 out",
+              tokenUsage: {
+                inputTokens: 1000,
+                cachedInputTokens: 200,
+                uncachedInputTokens: 800,
+                outputTokens: 50,
+                totalTokens: 1050,
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(
+      screen.getByText("Codex usage: 800 uncached in · 200 cached · 50 out"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Monitor usage: 800 uncached in · 200 cached · 50 out"),
+    ).not.toBeInTheDocument();
+  });
+
   it("moves focus between tabs with Arrow keys (roving tablist)", () => {
     renderPanel({ pinned: true });
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -352,7 +352,10 @@ describe("ThreadContextPanel", () => {
             task: "Check PR status",
             status: "success",
             createdAt: 2000,
+            completedAt: 3000,
             updatedAt: 2500,
+            agentName: "Peirce",
+            lastMessage: "PR #783 is open and all required checks are passing.",
             monitorThreadId: "019ed7df-5876-7882-9b75-7fd647372da7",
             monitorUsage: {
               summary: "800 uncached in · 200 cached · 50 out",
@@ -372,9 +375,21 @@ describe("ThreadContextPanel", () => {
     expect(
       screen.getByText("Codex usage: 800 uncached in · 200 cached · 50 out"),
     ).toBeInTheDocument();
+    expect(screen.getByText("Peirce")).toBeInTheDocument();
+    expect(
+      screen.getByText("Spawned by Codex native spawnAgent."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("PR #783 is open and all required checks are passing."),
+    ).toBeInTheDocument();
     expect(
       screen.queryByText("Monitor usage: 800 uncached in · 200 cached · 50 out"),
     ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Details" }));
+    const modal = within(screen.getByRole("dialog"));
+    expect(modal.getByText("Source")).toBeInTheDocument();
+    expect(modal.getByText("Codex native spawnAgent")).toBeInTheDocument();
   });
 
   it("moves focus between tabs with Arrow keys (roving tablist)", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentDetailsModal.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentDetailsModal.tsx
@@ -9,6 +9,7 @@ import {
   subAgentTone,
 } from "./subagent-format";
 import { RailStatusChip } from "./RailStatusChip";
+import { subAgentOriginLabel } from "./subagent-kind";
 
 type SubAgentDetailsModalProps = {
   subAgent: ThreadSubAgentSummary;
@@ -78,6 +79,7 @@ export function SubAgentDetailsModal(props: SubAgentDetailsModalProps) {
   const tone = subAgentTone(subAgent.status);
   const usage = subAgent.monitorUsage;
   const model = subAgent.preferredModel ?? usage?.model ?? usage?.cost?.model;
+  const originLabel = subAgentOriginLabel(subAgent);
   const ariaLabel = subAgent.agentName
     ? `${subAgent.agentName}: ${subAgent.task}`
     : subAgent.task;
@@ -119,6 +121,12 @@ export function SubAgentDetailsModal(props: SubAgentDetailsModalProps) {
             <div>
               <dt>Name</dt>
               <dd>{subAgent.agentName}</dd>
+            </div>
+          ) : null}
+          {originLabel ? (
+            <div>
+              <dt>Source</dt>
+              <dd>{originLabel}</dd>
             </div>
           ) : null}
           {model ? (

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentDetailsModal.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentDetailsModal.tsx
@@ -78,6 +78,9 @@ export function SubAgentDetailsModal(props: SubAgentDetailsModalProps) {
   const tone = subAgentTone(subAgent.status);
   const usage = subAgent.monitorUsage;
   const model = subAgent.preferredModel ?? usage?.model ?? usage?.cost?.model;
+  const ariaLabel = subAgent.agentName
+    ? `${subAgent.agentName}: ${subAgent.task}`
+    : subAgent.task;
 
   if (typeof document === "undefined") {
     return null;
@@ -88,7 +91,7 @@ export function SubAgentDetailsModal(props: SubAgentDetailsModalProps) {
       className="subagent-modal"
       role="dialog"
       aria-modal="true"
-      aria-label={`Sub-agent details: ${subAgent.task}`}
+      aria-label={`Sub-agent details: ${ariaLabel}`}
       onClick={props.onClose}
     >
       <div
@@ -112,6 +115,12 @@ export function SubAgentDetailsModal(props: SubAgentDetailsModalProps) {
         <h2 className="subagent-modal__title">{subAgent.task}</h2>
 
         <dl className="subagent-modal__facts">
+          {subAgent.agentName ? (
+            <div>
+              <dt>Name</dt>
+              <dd>{subAgent.agentName}</dd>
+            </div>
+          ) : null}
           {model ? (
             <div>
               <dt>Model</dt>

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
@@ -8,20 +8,14 @@ import { formatTimestamp } from "./context-rail-shared";
 import { subAgentStatusLabel, subAgentTone } from "./subagent-format";
 import { RailStatusChip } from "./RailStatusChip";
 import { SubAgentDetailsModal } from "./SubAgentDetailsModal";
+import {
+  subAgentOriginSentence,
+  subAgentUsageLabel,
+} from "./subagent-kind";
 
 type SubAgentsPanelProps = {
   thread: NavigationThreadSummary;
 };
-
-function subAgentUsageLabel(subAgent: ThreadSubAgentSummary): string {
-  if (subAgent.monitorId.startsWith("codex-native:")) {
-    return "Codex";
-  }
-  if (subAgent.monitorId.startsWith("review:")) {
-    return "Review";
-  }
-  return "Monitor";
-}
 
 /** Sub-Agents tab: durable task-monitor cards spawned from this thread. */
 export function SubAgentsPanel(props: SubAgentsPanelProps) {
@@ -37,6 +31,7 @@ export function SubAgentsPanel(props: SubAgentsPanelProps) {
         <ul className="context-list context-list--cards">
           {subAgents.map((subAgent) => {
             const tone = subAgentTone(subAgent.status);
+            const originSentence = subAgentOriginSentence(subAgent);
             return (
               <li key={subAgent.monitorId} className="rail-card">
                 {/* Status on its own line so it never competes with the
@@ -68,6 +63,9 @@ export function SubAgentsPanel(props: SubAgentsPanelProps) {
                     </>
                   ) : null}
                 </p>
+                {originSentence ? (
+                  <p className="rail-card__message">{originSentence}</p>
+                ) : null}
                 {subAgent.lastMessage ? (
                   <p className="rail-card__message">{subAgent.lastMessage}</p>
                 ) : null}

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
@@ -32,6 +32,10 @@ export function SubAgentsPanel(props: SubAgentsPanelProps) {
           {subAgents.map((subAgent) => {
             const tone = subAgentTone(subAgent.status);
             const originSentence = subAgentOriginSentence(subAgent);
+            const latestMessage =
+              subAgent.lastMessage && subAgent.lastMessage !== originSentence
+                ? subAgent.lastMessage
+                : undefined;
             return (
               <li key={subAgent.monitorId} className="rail-card">
                 {/* Status on its own line so it never competes with the
@@ -66,8 +70,8 @@ export function SubAgentsPanel(props: SubAgentsPanelProps) {
                 {originSentence ? (
                   <p className="rail-card__message">{originSentence}</p>
                 ) : null}
-                {subAgent.lastMessage ? (
-                  <p className="rail-card__message">{subAgent.lastMessage}</p>
+                {latestMessage ? (
+                  <p className="rail-card__message">{latestMessage}</p>
                 ) : null}
                 {subAgent.monitorUsage?.summary ? (
                   <p className="rail-card__usage">

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
@@ -36,6 +36,11 @@ export function SubAgentsPanel(props: SubAgentsPanelProps) {
                     {subAgentStatusLabel(subAgent.status)}
                   </RailStatusChip>
                 </p>
+                {subAgent.agentName ? (
+                  <p className="rail-card__agent-name" title={subAgent.agentName}>
+                    {subAgent.agentName}
+                  </p>
+                ) : null}
                 <p className="rail-card__title" title={subAgent.task}>
                   {subAgent.task}
                 </p>

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
@@ -75,8 +75,8 @@ export function SubAgentsPanel(props: SubAgentsPanelProps) {
         </ul>
       ) : (
         <p className="context-empty">
-          No sub-agents yet. Delegated task monitors started from this thread
-          will appear here.
+          No sub-agents yet. Delegated monitors, reviews, and observed native
+          Codex sub-agents started from this thread will appear here.
         </p>
       )}
       {detailsFor ? (

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
@@ -13,6 +13,16 @@ type SubAgentsPanelProps = {
   thread: NavigationThreadSummary;
 };
 
+function subAgentUsageLabel(subAgent: ThreadSubAgentSummary): string {
+  if (subAgent.monitorId.startsWith("codex-native:")) {
+    return "Codex";
+  }
+  if (subAgent.monitorId.startsWith("review:")) {
+    return "Review";
+  }
+  return "Monitor";
+}
+
 /** Sub-Agents tab: durable task-monitor cards spawned from this thread. */
 export function SubAgentsPanel(props: SubAgentsPanelProps) {
   const { subAgents, loading } = useSubAgents(props.thread);
@@ -63,7 +73,7 @@ export function SubAgentsPanel(props: SubAgentsPanelProps) {
                 ) : null}
                 {subAgent.monitorUsage?.summary ? (
                   <p className="rail-card__usage">
-                    {subAgent.monitorId.startsWith("review:") ? "Review" : "Monitor"} usage:{" "}
+                    {subAgentUsageLabel(subAgent)} usage:{" "}
                     {subAgent.monitorUsage.summary}
                   </p>
                 ) : null}

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/subagent-kind.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/subagent-kind.ts
@@ -1,0 +1,31 @@
+import type { ThreadSubAgentSummary } from "@pwragent/shared";
+
+export function isCodexNativeSubAgent(subAgent: ThreadSubAgentSummary): boolean {
+  return subAgent.monitorId.startsWith("codex-native:");
+}
+
+export function subAgentOriginLabel(
+  subAgent: ThreadSubAgentSummary,
+): string | undefined {
+  if (isCodexNativeSubAgent(subAgent)) {
+    return "Codex native spawnAgent";
+  }
+  return undefined;
+}
+
+export function subAgentOriginSentence(
+  subAgent: ThreadSubAgentSummary,
+): string | undefined {
+  const label = subAgentOriginLabel(subAgent);
+  return label ? `Spawned by ${label}.` : undefined;
+}
+
+export function subAgentUsageLabel(subAgent: ThreadSubAgentSummary): string {
+  if (isCodexNativeSubAgent(subAgent)) {
+    return "Codex";
+  }
+  if (subAgent.monitorId.startsWith("review:")) {
+    return "Review";
+  }
+  return "Monitor";
+}

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -11915,6 +11915,17 @@ textarea,
   overflow: hidden;
 }
 
+.rail-card__agent-name {
+  margin: 0;
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 650;
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .rail-card__model {
   margin: 0;
   color: var(--text-secondary);

--- a/packages/agent-core/src/__tests__/navigation-state.test.ts
+++ b/packages/agent-core/src/__tests__/navigation-state.test.ts
@@ -245,3 +245,57 @@ describe("navigation Agent metadata", () => {
     );
   });
 });
+
+describe("navigation sub-agent metadata", () => {
+  it("includes sub-agent display names in the navigation snapshot hash", () => {
+    const baseSubAgent = {
+      monitorId: "codex-native:thread-agent",
+      task: "Check PR status",
+      status: "running" as const,
+      createdAt: 1_000,
+      updatedAt: 1_000,
+      monitorThreadId: "thread-agent",
+      monitorTurnId: "turn-1",
+    };
+    const [threadWithoutName] = materializeNavigationThreads({
+      firstSnapshot: false,
+      overlayByThreadKey: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          subAgents: [baseSubAgent],
+        },
+      },
+      previousKnownThreadKeys: ["codex:thread-1"],
+      threads: [buildThread()],
+    });
+    const [threadWithName] = materializeNavigationThreads({
+      firstSnapshot: false,
+      overlayByThreadKey: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          subAgents: [{ ...baseSubAgent, agentName: "Huygens" }],
+        },
+      },
+      previousKnownThreadKeys: ["codex:thread-1"],
+      threads: [buildThread()],
+    });
+
+    expect(
+      buildNavigationSnapshotHash({
+        backend: "codex",
+        threads: [threadWithoutName!],
+      }),
+    ).not.toBe(
+      buildNavigationSnapshotHash({
+        backend: "codex",
+        threads: [threadWithName!],
+      }),
+    );
+  });
+});

--- a/packages/agent-core/src/domain/navigation-state.ts
+++ b/packages/agent-core/src/domain/navigation-state.ts
@@ -284,6 +284,7 @@ export function buildNavigationSnapshotHash(params: {
         monitorId: subAgent.monitorId,
         task: subAgent.task,
         status: subAgent.status,
+        agentName: subAgent.agentName ?? null,
         createdAt: subAgent.createdAt,
         updatedAt: subAgent.updatedAt,
         preferredModel: subAgent.preferredModel ?? null,

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -147,6 +147,7 @@ export type ThreadSubAgentSummary = {
   status: ThreadSubAgentStatus;
   createdAt: number;
   updatedAt: number;
+  agentName?: string;
   preferredModel?: string;
   preferredReasoningEffort?: string;
   monitorThreadId?: ThreadIdentifier;


### PR DESCRIPTION
## Summary

- Persist observed Codex-native `spawnAgent` / collab-agent activity into the existing Sub-agents sidecar as best-effort cards
- Patch those cards from later `wait`, `sendInput`, `resumeAgent`, `closeAgent`, and live token-usage events when Codex reports enough metadata
- Log unhandled native collab-agent shapes so we can add support from real traces without owning Codex's subagent lifecycle

## Verification

- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts -t "persists Codex native spawnAgent calls as sub-agent summaries|updates Codex native sub-agent summaries"`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`

## Notes

- This is intentionally best-effort tracking for Codex-native subagents. PwrAgent-managed task monitors remain the primary owned lifecycle path.
