### PR TITLE
feat(desktop): edits panel in context rail, commit-aware accumulation, dirty/unpushed thread chips

### DIFF
--- a/apps/desktop/e2e/edited-changes-order.spec.ts
+++ b/apps/desktop/e2e/edited-changes-order.spec.ts
@@ -26,9 +26,14 @@ test("expanded edited changes stay in transcript order", async () => {
       })
     ).toBeVisible();
 
-    const activityToggle = app.window.getByRole("button", { name: /Edited 1 file/i });
+    // Scope to the transcript region: the accumulated edited files also
+    // render in the LiveWorkRail above the composer (rehydrated from the
+    // replay), so a page-wide "Edited 1 file" / file-row locator resolves
+    // to two elements and trips Playwright strict mode.
+    const transcript = app.window.getByRole("region", { name: "Transcript" });
+    const activityToggle = transcript.getByRole("button", { name: /Edited 1 file/i });
     await activityToggle.click();
-    await app.window.getByRole("button", { name: /Update TranscriptList.tsx/i }).click();
+    await transcript.getByRole("button", { name: /Update TranscriptList.tsx/i }).click();
     await expect(app.window.getByText("const b = 2;")).toBeVisible();
     await expect(app.window.getByText("const c = 3;")).toBeVisible();
     await expect(app.window.getByText("2 unmodified lines skipped")).toHaveCount(0);

--- a/apps/desktop/e2e/focused-diff-zoom.spec.ts
+++ b/apps/desktop/e2e/focused-diff-zoom.spec.ts
@@ -23,9 +23,12 @@ test("eligible diffs fall back to deterministic zoomed-out context", async () =>
       })
     ).toBeVisible();
 
-    const activityToggle = app.window.getByRole("button", { name: /Edited 1 file/i });
+    // Scope to the transcript region — the rehydrated LiveWorkRail also
+    // lists the edited file, so page-wide locators hit strict mode.
+    const transcript = app.window.getByRole("region", { name: "Transcript" });
+    const activityToggle = transcript.getByRole("button", { name: /Edited 1 file/i });
     await activityToggle.click();
-    await app.window.getByRole("button", { name: /Update example.ts/i }).click();
+    await transcript.getByRole("button", { name: /Update example.ts/i }).click();
 
     await expect(app.window.getByText("7 lines skipped")).toBeVisible();
     await expect(app.window.getByRole("button", { name: "Zoom in" })).toBeVisible();
@@ -64,8 +67,10 @@ test("focused diff overrides can hide low-signal hunks end-to-end", async () => 
       })
     ).toBeVisible();
 
-    await app.window.getByRole("button", { name: /Edited 1 file/i }).click();
-    await app.window.getByRole("button", { name: /Update example.ts/i }).click();
+    // Same transcript scoping as above — the rail duplicates these names.
+    const transcript = app.window.getByRole("region", { name: "Transcript" });
+    await transcript.getByRole("button", { name: /Edited 1 file/i }).click();
+    await transcript.getByRole("button", { name: /Update example.ts/i }).click();
 
     await expect(app.window.getByText("1 hunk hidden, 6 lines skipped")).toBeVisible();
     await expect(app.window.getByText("// refreshed comment")).toHaveCount(0);

--- a/apps/desktop/src/main/__tests__/desktop-config-ui.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-config-ui.test.ts
@@ -6,12 +6,12 @@ import {
 import { applyTomlEdits, parseTomlTables } from "../settings/toml-editor";
 
 // Regression: the `[ui]` window-layout section (sidebar hidden, context-rail
-// pinned, active tab) must survive the read path. `pruneEmptyConfig`
-// reconstructs the config section-by-section, so a newly added section that
-// it doesn't copy is silently dropped — which made persisted layout prefs
-// never restore on relaunch.
+// pinned, active tab, edited-files dock) must survive the read path.
+// `pruneEmptyConfig` reconstructs the config section-by-section, so a newly
+// added section that it doesn't copy is silently dropped — which made
+// persisted layout prefs never restore on relaunch.
 describe("desktop config [ui] section", () => {
-  it("reads [ui] booleans + string into config.ui", () => {
+  it("reads [ui] booleans + strings into config.ui", () => {
     const src = [
       "[general.appearance]",
       'theme = "light"',
@@ -20,6 +20,7 @@ describe("desktop config [ui] section", () => {
       "context_rail_pinned = true",
       "sidebar_hidden = true",
       'active_context_tab = "providers"',
+      'edited_files_dock = "sidebar"',
       "",
     ].join("\n");
 
@@ -29,6 +30,7 @@ describe("desktop config [ui] section", () => {
       contextRailPinned: true,
       sidebarHidden: true,
       activeContextTab: "providers",
+      editedFilesDock: "sidebar",
     });
   });
 
@@ -43,6 +45,7 @@ describe("desktop config [ui] section", () => {
         sidebarHidden: true,
         contextRailPinned: true,
         activeContextTab: "providers",
+        editedFilesDock: "sidebar",
       },
     });
     const written = applyTomlEdits("", edits);
@@ -52,25 +55,34 @@ describe("desktop config [ui] section", () => {
       sidebarHidden: true,
       contextRailPinned: true,
       activeContextTab: "providers",
+      editedFilesDock: "sidebar",
     });
   });
 
-  it("deletes default-valued [ui] keys on write (off/info are absent on disk)", () => {
+  it("deletes default-valued [ui] keys on write (off/info/above are absent on disk)", () => {
     const existing = [
       "[ui]",
       "sidebar_hidden = true",
       "context_rail_pinned = true",
       'active_context_tab = "providers"',
+      'edited_files_dock = "sidebar"',
       "",
     ].join("\n");
     const edits = desktopSettingsPatchToEdits(
-      { ui: { sidebarHidden: false, contextRailPinned: false, activeContextTab: "info" } },
+      {
+        ui: {
+          sidebarHidden: false,
+          contextRailPinned: false,
+          activeContextTab: "info",
+          editedFilesDock: "above",
+        },
+      },
       parseTomlTables(existing, "test.toml"),
     );
     const written = applyTomlEdits(existing, edits);
     const config = parseDesktopSettingsToml(written, "test.toml");
 
-    // All three reverted to defaults → the section carries no values.
+    // All four reverted to defaults → the section carries no values.
     expect(config.ui).toBeUndefined();
   });
 });

--- a/apps/desktop/src/main/__tests__/thread-directory-enricher.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-directory-enricher.test.ts
@@ -44,7 +44,7 @@ describe("createThreadDirectoryEnricher", () => {
           });
           return;
         }
-        if (args.includes("--porcelain")) {
+        if (args.includes("worktree")) {
           callback(null, {
             stdout: [
               "worktree /Users/huntharo/pwrdrvr/PwrAgent",
@@ -59,6 +59,29 @@ describe("createThreadDirectoryEnricher", () => {
             stdout: "feature-one\n",
             stderr: "",
           });
+          return;
+        }
+        // Git working-state probes (all run with --no-optional-locks).
+        if (args.includes("--numstat")) {
+          callback(null, {
+            stdout: "3\t1\tapps/desktop/src/file.ts\n-\t-\tassets/logo.png\n",
+            stderr: "",
+          });
+          return;
+        }
+        if (args.includes("status")) {
+          callback(null, {
+            stdout: " M apps/desktop/src/file.ts\n?? scratch/new-file.txt\n",
+            stderr: "",
+          });
+          return;
+        }
+        if (args.includes("rev-list")) {
+          callback(null, { stdout: "2\n", stderr: "" });
+          return;
+        }
+        if (args[args.length - 1] === "remote") {
+          callback(null, { stdout: "origin\n", stderr: "" });
           return;
         }
 
@@ -97,11 +120,22 @@ describe("createThreadDirectoryEnricher", () => {
         },
       ],
       observedGitBranch: "feature-one",
+      gitWorkingState: {
+        // Binary numstat lines ("-\t-") count as a dirty file with no
+        // line totals.
+        dirtyFiles: 2,
+        dirtyAdditions: 3,
+        dirtyDeletions: 1,
+        untrackedFiles: 1,
+        unpushedCommits: 2,
+      },
     });
     expect(second).toEqual(first);
     expect(accessMock).toHaveBeenCalledTimes(3);
     expect(readFileMock).toHaveBeenCalledTimes(1);
-    expect(execFileMock).toHaveBeenCalledTimes(3);
+    // 3 directory-resolution calls + 4 working-state probes (numstat,
+    // status, remote, rev-list). The cached second lookup adds none.
+    expect(execFileMock).toHaveBeenCalledTimes(7);
   });
 
   it("recovers the home repo from a worktree .git file when git worktree list fails", async () => {

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -5446,6 +5446,9 @@ export class CodexAppServerClient {
             gitBranch: thread.gitBranch,
             linkedDirectories: enrichment.linkedDirectories,
             observedGitBranch: enrichment.observedGitBranch,
+            ...(enrichment.gitWorkingState
+              ? { gitWorkingState: enrichment.gitWorkingState }
+              : {}),
             source: "codex" as const,
           },
         };

--- a/apps/desktop/src/main/codex-app-server/thread-directory-enricher.ts
+++ b/apps/desktop/src/main/codex-app-server/thread-directory-enricher.ts
@@ -2,7 +2,10 @@ import { execFile as execFileCallback } from "node:child_process";
 import { access, readFile } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
-import type { LinkedDirectorySummary } from "@pwragent/shared";
+import type {
+  LinkedDirectorySummary,
+  ThreadGitWorkingState,
+} from "@pwragent/shared";
 import { isToolManagedWorktreePath } from "@pwragent/shared";
 import { getMainLogger } from "../log";
 
@@ -22,6 +25,7 @@ function toDirectoryId(value: string): string {
 export type ThreadDirectoryEnrichment = {
   linkedDirectories: LinkedDirectorySummary[];
   observedGitBranch?: string;
+  gitWorkingState?: ThreadGitWorkingState;
 };
 
 type CachedEnrichment = {
@@ -45,6 +49,87 @@ async function runGit(projectKey: string, args: string[]): Promise<string> {
     env: process.env,
   });
   return result.stdout.trim();
+}
+
+// `--no-optional-locks` keeps these background probes from taking the
+// index lock out from under an agent running its own git commands in
+// the same worktree.
+async function runGitNoLocks(projectKey: string, args: string[]): Promise<string> {
+  const result = await execFile(
+    "git",
+    ["--no-optional-locks", "-C", projectKey, ...args],
+    { env: process.env },
+  );
+  return result.stdout.trim();
+}
+
+function parseNumstat(output: string): {
+  files: number;
+  additions: number;
+  deletions: number;
+} {
+  let files = 0;
+  let additions = 0;
+  let deletions = 0;
+  for (const line of output.split("\n")) {
+    const match = line.match(/^(\d+|-)\t(\d+|-)\t/);
+    if (!match) {
+      continue;
+    }
+    files += 1;
+    if (match[1] !== "-") {
+      additions += Number(match[1]);
+    }
+    if (match[2] !== "-") {
+      deletions += Number(match[2]);
+    }
+  }
+  return { files, additions, deletions };
+}
+
+async function readGitWorkingState(
+  currentPath: string,
+): Promise<ThreadGitWorkingState | undefined> {
+  const [numstatOutput, statusOutput, remotesOutput] = await Promise.all([
+    // Staged + unstaged line counts vs HEAD. Fails on an unborn HEAD
+    // (fresh repo with no commits) — treated as "no tracked changes".
+    runGitNoLocks(currentPath, ["diff", "--numstat", "HEAD"]).catch(
+      () => undefined,
+    ),
+    runGitNoLocks(currentPath, ["status", "--porcelain"]).catch(() => undefined),
+    runGitNoLocks(currentPath, ["remote"]).catch(() => undefined),
+  ]);
+  if (numstatOutput === undefined && statusOutput === undefined) {
+    return undefined;
+  }
+
+  const numstat = parseNumstat(numstatOutput ?? "");
+  const untrackedFiles = (statusOutput ?? "")
+    .split("\n")
+    .filter((line) => line.startsWith("??")).length;
+
+  // "Unpushed" means reachable from HEAD but on no remote ref. With no
+  // remotes configured, every commit would count — meaningless for a
+  // local-only repo, so report 0 instead.
+  let unpushedCommits = 0;
+  if (remotesOutput?.trim()) {
+    const count = await runGitNoLocks(currentPath, [
+      "rev-list",
+      "--count",
+      "HEAD",
+      "--not",
+      "--remotes",
+    ]).catch(() => undefined);
+    unpushedCommits = count !== undefined ? Number(count) || 0 : 0;
+  }
+
+  return {
+    dirtyFiles: numstat.files,
+    dirtyAdditions: numstat.additions,
+    dirtyDeletions: numstat.deletions,
+    untrackedFiles,
+    unpushedCommits,
+  };
 }
 
 async function pathExists(targetPath: string): Promise<boolean> {
@@ -206,12 +291,14 @@ async function loadThreadDirectoryEnrichment(
   }
 
   try {
-    const [repoRoot, worktreeList, observedGitBranch, gitMetadata] = await Promise.all([
-      runGit(currentPath, ["rev-parse", "--show-toplevel"]),
-      runGit(currentPath, ["worktree", "list", "--porcelain"]),
-      runGit(currentPath, ["rev-parse", "--abbrev-ref", "HEAD"]).catch(() => undefined),
-      readGitMetadataEvidence(currentPath),
-    ]);
+    const [repoRoot, worktreeList, observedGitBranch, gitMetadata, gitWorkingState] =
+      await Promise.all([
+        runGit(currentPath, ["rev-parse", "--show-toplevel"]),
+        runGit(currentPath, ["worktree", "list", "--porcelain"]),
+        runGit(currentPath, ["rev-parse", "--abbrev-ref", "HEAD"]).catch(() => undefined),
+        readGitMetadataEvidence(currentPath),
+        readGitWorkingState(currentPath).catch(() => undefined),
+      ]);
     const worktreePaths = parseGitWorktrees(worktreeList);
     const primaryPath = path.resolve(worktreePaths[0] || repoRoot);
     const currentWorktreePath =
@@ -249,6 +336,7 @@ async function loadThreadDirectoryEnrichment(
         },
       ],
       observedGitBranch: observedGitBranch?.trim() || undefined,
+      ...(gitWorkingState ? { gitWorkingState } : {}),
     };
   } catch (error) {
     const gitMetadataFallback = await buildLinkedDirectoryFromGitMetadata(currentPath);

--- a/apps/desktop/src/main/grok-app-server/client.ts
+++ b/apps/desktop/src/main/grok-app-server/client.ts
@@ -911,6 +911,9 @@ export class GrokAppServerClient {
           ...(enrichment.observedGitBranch
             ? { observedGitBranch: enrichment.observedGitBranch }
             : {}),
+          ...(enrichment.gitWorkingState
+            ? { gitWorkingState: enrichment.gitWorkingState }
+            : {}),
           source: "grok" as const,
         };
       })

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -110,6 +110,7 @@ export type DesktopSettingsConfig = {
     sidebarHidden?: boolean;
     contextRailPinned?: boolean;
     activeContextTab?: string;
+    editedFilesDock?: string;
   };
   messaging?: {
     enabled?: boolean;
@@ -756,6 +757,13 @@ export function desktopSettingsPatchToEdits(
       set(["ui", "active_context_tab"], patch.ui.activeContextTab);
     }
   }
+  if (patch.ui?.editedFilesDock !== undefined) {
+    if (patch.ui.editedFilesDock === "above") {
+      edits.push({ op: "delete", path: ["ui", "edited_files_dock"] });
+    } else {
+      set(["ui", "edited_files_dock"], patch.ui.editedFilesDock);
+    }
+  }
 
   if (patch.messaging?.inputDebounceMs !== undefined) {
     set(["messaging", "input_debounce_ms"], patch.messaging.inputDebounceMs);
@@ -1197,6 +1205,7 @@ function normalizeDesktopConfig(
       sidebarHidden: readBoolean(ui?.sidebar_hidden),
       contextRailPinned: readBoolean(ui?.context_rail_pinned),
       activeContextTab: readString(ui?.active_context_tab),
+      editedFilesDock: readString(ui?.edited_files_dock),
     },
     messaging: {
       enabled: readBoolean(messaging?.enabled),

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -496,6 +496,10 @@ export class DesktopSettingsService {
           value: config.ui?.activeContextTab ?? "info",
           source: config.ui?.activeContextTab === undefined ? "default" : "config",
         },
+        editedFilesDock: {
+          value: config.ui?.editedFilesDock ?? "above",
+          source: config.ui?.editedFilesDock === undefined ? "default" : "config",
+        },
       },
       messaging: {
         enabled: this.resolveConfigBoolean(config.messaging?.enabled, true),

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -30,8 +30,11 @@ import {
 import type { ThreadViewProps } from "./features/thread-detail/ThreadView";
 import {
   DEFAULT_CONTEXT_TAB,
+  DEFAULT_EDITED_FILES_DOCK,
   isContextTabId,
+  isEditedFilesDock,
   type ContextTabId,
+  type EditedFilesDock,
 } from "./features/thread-detail/context-panels/context-tab";
 import { ThreadPlaceholderHeader } from "./features/thread-detail/ThreadPlaceholderHeader";
 import { useComposerDraftStore } from "./features/composer/useComposerDraftStore";
@@ -171,6 +174,9 @@ function DesktopAppShell(props: {
   const [contextRailPinned, setContextRailPinned] = useState(false);
   const [activeContextTab, setActiveContextTab] =
     useState<ContextTabId>(DEFAULT_CONTEXT_TAB);
+  const [editedFilesDock, setEditedFilesDock] = useState<EditedFilesDock>(
+    DEFAULT_EDITED_FILES_DOCK,
+  );
   const [mainView, setMainView] = useState<
     "thread" | "settings" | "automations" | "search"
   >("thread");
@@ -286,6 +292,13 @@ function DesktopAppShell(props: {
     },
     [writeConfig],
   );
+  const setEditedFilesDockPersisted = useCallback(
+    (dock: EditedFilesDock) => {
+      setEditedFilesDock(dock);
+      void writeConfig({ ui: { editedFilesDock: dock } });
+    },
+    [writeConfig],
+  );
 
   // Adopt the persisted layout prefs once the settings snapshot arrives.
   // Guarded so later snapshot refreshes never clobber an in-session toggle.
@@ -300,6 +313,10 @@ function DesktopAppShell(props: {
     setContextRailPinned(uiPrefs.contextRailPinned.value);
     if (isContextTabId(uiPrefs.activeContextTab.value)) {
       setActiveContextTab(uiPrefs.activeContextTab.value);
+    }
+    const editedFilesDockPref = uiPrefs.editedFilesDock?.value;
+    if (isEditedFilesDock(editedFilesDockPref)) {
+      setEditedFilesDock(editedFilesDockPref);
     }
   }, [uiPrefs]);
 
@@ -647,6 +664,8 @@ function DesktopAppShell(props: {
     onContextRailPinnedChange: setContextRailPinnedPersisted,
     activeContextTab,
     onActiveContextTabChange: setActiveContextTabPersisted,
+    editedFilesDock,
+    onEditedFilesDockChange: setEditedFilesDockPersisted,
     sidebarHidden,
     onToggleSidebar: () => setSidebarHiddenPersisted(!sidebarHidden),
     mastheadActions,

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -458,6 +458,7 @@ describe("App", () => {
         sidebarHidden: { value: false, source: "default" },
         contextRailPinned: { value: false, source: "default" },
         activeContextTab: { value: "info", source: "default" },
+        editedFilesDock: { value: "above", source: "default" },
       },
       messaging: {
         enabled: { value: true, source: "default" },

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
@@ -25,8 +25,37 @@ export function ThreadMetaChips({
   // tooltip (not a native `title`) so it escapes the sidebar's clipped
   // scroll region, matching the copyable branch/path chips.
   const pinTooltip = useViewportTooltip({ className: "viewport-tooltip" });
+  const gitStateTooltip = useViewportTooltip({ className: "viewport-tooltip" });
   const branchDrifted = isBranchDrifted(thread.gitBranch, thread.observedGitBranch);
   const branchChip = thread.gitBranch ?? thread.observedGitBranch;
+  const gitWorking = thread.gitWorkingState;
+  const hasTrackedDirt = Boolean(
+    gitWorking &&
+      (gitWorking.dirtyFiles > 0 ||
+        gitWorking.dirtyAdditions > 0 ||
+        gitWorking.dirtyDeletions > 0),
+  );
+  const hasUntracked = Boolean(gitWorking && gitWorking.untrackedFiles > 0);
+  const dirtyTooltip = gitWorking
+    ? [
+        hasTrackedDirt
+          ? `Uncommitted changes: ${gitWorking.dirtyFiles} file${
+              gitWorking.dirtyFiles === 1 ? "" : "s"
+            }, +${gitWorking.dirtyAdditions.toLocaleString()}, -${gitWorking.dirtyDeletions.toLocaleString()}`
+          : undefined,
+        hasUntracked
+          ? `${gitWorking.untrackedFiles} untracked file${
+              gitWorking.untrackedFiles === 1 ? "" : "s"
+            }`
+          : undefined,
+      ]
+        .filter(Boolean)
+        .join("\n")
+    : "";
+  const unpushedCount = gitWorking?.unpushedCommits ?? 0;
+  const unpushedTooltip = `${unpushedCount} commit${
+    unpushedCount === 1 ? "" : "s"
+  } not pushed to a remote`;
   const linkedDirectoryChips = includeLinkedDirectories
     ? thread.linkedDirectories.length > 0
       ? linkedDirectoryMode === "kind"
@@ -152,6 +181,48 @@ export function ThreadMetaChips({
           now {thread.observedGitBranch}
         </CopyableThreadChip>
       ) : null}
+
+      {hasTrackedDirt || hasUntracked ? (
+        <span
+          aria-label={dirtyTooltip.replace(/\n/g, "; ")}
+          role="img"
+          className="thread-row__chip thread-row__chip--dirty thread-row__chip--mono"
+          onMouseEnter={(event) =>
+            gitStateTooltip.show(event.currentTarget, dirtyTooltip)
+          }
+          onMouseLeave={gitStateTooltip.hide}
+        >
+          {hasTrackedDirt ? (
+            <>
+              <span className="thread-row__chip-stat thread-row__chip-stat--added">
+                +{gitWorking!.dirtyAdditions.toLocaleString()}
+              </span>
+              <span className="thread-row__chip-stat thread-row__chip-stat--removed">
+                -{gitWorking!.dirtyDeletions.toLocaleString()}
+              </span>
+            </>
+          ) : (
+            <span className="thread-row__chip-stat">
+              {gitWorking!.untrackedFiles} new
+            </span>
+          )}
+        </span>
+      ) : null}
+
+      {unpushedCount > 0 ? (
+        <span
+          aria-label={unpushedTooltip}
+          role="img"
+          className="thread-row__chip thread-row__chip--unpushed thread-row__chip--mono"
+          onMouseEnter={(event) =>
+            gitStateTooltip.show(event.currentTarget, unpushedTooltip)
+          }
+          onMouseLeave={gitStateTooltip.hide}
+        >
+          ↑{unpushedCount.toLocaleString()}
+        </span>
+      ) : null}
+      {gitStateTooltip.tooltipNode}
     </>
   );
 }

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
@@ -435,4 +435,74 @@ describe("ThreadRow chip flow", () => {
     );
     expect(screen.getByRole("tooltip")).not.toHaveTextContent("status unknown");
   });
+
+  it("renders dirty-tree line counts and unpushed-commit chips from gitWorkingState", () => {
+    const { container } = renderRow({
+      thread: {
+        ...baseThread,
+        gitWorkingState: {
+          dirtyFiles: 2,
+          dirtyAdditions: 112,
+          dirtyDeletions: 3,
+          untrackedFiles: 1,
+          unpushedCommits: 4,
+        },
+      },
+    });
+
+    const dirtyChip = container.querySelector(".thread-row__chip--dirty");
+    expect(dirtyChip).not.toBeNull();
+    expect(dirtyChip).toHaveTextContent("+112");
+    expect(dirtyChip).toHaveTextContent("-3");
+    expect(dirtyChip).toHaveAttribute(
+      "aria-label",
+      "Uncommitted changes: 2 files, +112, -3; 1 untracked file",
+    );
+
+    const unpushedChip = container.querySelector(".thread-row__chip--unpushed");
+    expect(unpushedChip).not.toBeNull();
+    expect(unpushedChip).toHaveTextContent("↑4");
+    expect(unpushedChip).toHaveAttribute(
+      "aria-label",
+      "4 commits not pushed to a remote",
+    );
+  });
+
+  it("renders an untracked-only dirty chip without +/- stats", () => {
+    const { container } = renderRow({
+      thread: {
+        ...baseThread,
+        gitWorkingState: {
+          dirtyFiles: 0,
+          dirtyAdditions: 0,
+          dirtyDeletions: 0,
+          untrackedFiles: 3,
+          unpushedCommits: 0,
+        },
+      },
+    });
+
+    const dirtyChip = container.querySelector(".thread-row__chip--dirty");
+    expect(dirtyChip).toHaveTextContent("3 new");
+    expect(container.querySelector(".thread-row__chip-stat--added")).toBeNull();
+    expect(container.querySelector(".thread-row__chip--unpushed")).toBeNull();
+  });
+
+  it("renders no git working-state chips when the tree is clean and pushed", () => {
+    const { container } = renderRow({
+      thread: {
+        ...baseThread,
+        gitWorkingState: {
+          dirtyFiles: 0,
+          dirtyAdditions: 0,
+          dirtyDeletions: 0,
+          untrackedFiles: 0,
+          unpushedCommits: 0,
+        },
+      },
+    });
+
+    expect(container.querySelector(".thread-row__chip--dirty")).toBeNull();
+    expect(container.querySelector(".thread-row__chip--unpushed")).toBeNull();
+  });
 });

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -140,6 +140,7 @@ function createSnapshot(
       sidebarHidden: { value: false, source: "default" },
       contextRailPinned: { value: false, source: "default" },
       activeContextTab: { value: "info", source: "default" },
+      editedFilesDock: { value: "above", source: "default" },
     },
     messaging: {
       enabled: { value: true, source: "default" },

--- a/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
@@ -1,0 +1,181 @@
+import { useId, useState } from "react";
+import type { AppServerThreadActivityDetail } from "@pwragent/shared";
+import { TranscriptDiff } from "./TranscriptDiff";
+import {
+  flattenEditedFileGroups,
+  type EditedFileGroup,
+} from "./edited-file-groups";
+
+export type EditedFileGroupView = "turns" | "files";
+
+type EditedFileGroupListProps = {
+  /** Newest-first, from `collectEditedFileGroups`. */
+  groups: EditedFileGroup[];
+};
+
+const groupTimeFormatter = new Intl.DateTimeFormat(undefined, {
+  month: "short",
+  day: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+});
+
+/**
+ * Accumulated edited files, shared between the LiveWorkRail (above the
+ * composer) and the context-rail Edits panel. With multiple turn
+ * groups the user can flip between per-turn rounds and the flattened
+ * per-file view; a single group renders as a plain file list.
+ */
+export function EditedFileGroupList(props: EditedFileGroupListProps) {
+  const [view, setView] = useState<EditedFileGroupView>("turns");
+
+  if (props.groups.length === 0) {
+    return null;
+  }
+
+  if (props.groups.length === 1) {
+    return <EditedFileList details={props.groups[0].details} />;
+  }
+
+  return (
+    <div className="edited-file-groups">
+      <div
+        className="edited-file-groups__view-toggle"
+        role="group"
+        aria-label="Edited files view"
+      >
+        <button
+          type="button"
+          className={`edited-file-groups__view-btn${
+            view === "turns" ? " is-active" : ""
+          }`}
+          aria-pressed={view === "turns"}
+          onClick={() => setView("turns")}
+        >
+          By turn
+        </button>
+        <button
+          type="button"
+          className={`edited-file-groups__view-btn${
+            view === "files" ? " is-active" : ""
+          }`}
+          aria-pressed={view === "files"}
+          onClick={() => setView("files")}
+        >
+          All files
+        </button>
+      </div>
+
+      {view === "turns" ? (
+        props.groups.map((group, index) => (
+          <EditedFileGroupSection
+            key={group.key}
+            group={group}
+            defaultExpanded={index === 0}
+          />
+        ))
+      ) : (
+        <EditedFileList details={flattenEditedFileGroups(props.groups)} />
+      )}
+    </div>
+  );
+}
+
+function formatGroupTimestamp(group: EditedFileGroup): string | undefined {
+  const timestamp = group.turn?.completedAt ?? group.turn?.startedAt;
+  return typeof timestamp === "number"
+    ? groupTimeFormatter.format(timestamp)
+    : undefined;
+}
+
+function EditedFileGroupSection(props: {
+  group: EditedFileGroup;
+  defaultExpanded: boolean;
+}) {
+  const [expanded, setExpanded] = useState(props.defaultExpanded);
+  const bodyId = useId();
+  const timestamp = formatGroupTimestamp(props.group);
+
+  return (
+    <section className="edited-file-groups__group">
+      <button
+        type="button"
+        className="edited-file-groups__group-toggle"
+        aria-controls={bodyId}
+        aria-expanded={expanded}
+        onClick={() => setExpanded((current) => !current)}
+      >
+        <span className="live-work-rail__chevron" aria-hidden="true" />
+        <span className="edited-file-groups__group-summary">
+          {props.group.live ? "This turn · " : ""}
+          {props.group.summary}
+        </span>
+        {props.group.committed ? (
+          <span className="edited-file-groups__group-tag">Committed</span>
+        ) : null}
+        {timestamp ? (
+          <span className="edited-file-groups__group-time">{timestamp}</span>
+        ) : null}
+      </button>
+      <div id={bodyId} hidden={!expanded}>
+        {expanded ? <EditedFileList details={props.group.details} /> : null}
+      </div>
+    </section>
+  );
+}
+
+export function EditedFileList(props: {
+  details: AppServerThreadActivityDetail[];
+}) {
+  return (
+    <ul className="live-work-rail__file-list">
+      {props.details.map((detail) => (
+        <li key={detail.id} className="live-work-rail__file-row">
+          <EditedFileRow detail={detail} />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export function EditedFileRow(props: {
+  detail: AppServerThreadActivityDetail;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const diffId = useId();
+  const additions = props.detail.fileDiff?.additions ?? 0;
+  const removals = props.detail.fileDiff?.removals ?? 0;
+
+  return (
+    <>
+      <button
+        type="button"
+        className="live-work-rail__file-toggle"
+        aria-controls={diffId}
+        aria-expanded={expanded}
+        onClick={() => setExpanded((current) => !current)}
+      >
+        <span className="live-work-rail__chevron" aria-hidden="true" />
+        <span className="live-work-rail__file-path" title={props.detail.path}>
+          {props.detail.label}
+        </span>
+        <span className="live-work-rail__file-stats" aria-label="File diff summary">
+          <span className="live-work-rail__file-stat live-work-rail__file-stat--removed">
+            -{removals.toLocaleString()}
+          </span>
+          <span className="live-work-rail__file-stat live-work-rail__file-stat--added">
+            +{additions.toLocaleString()}
+          </span>
+        </span>
+      </button>
+      {/* Diff container stays in the DOM (with `hidden`) so the
+          row's `aria-controls={diffId}` always resolves. The
+          potentially-heavy TranscriptDiff itself is still
+          conditionally mounted to keep the render cost in line
+          with what the user actually opens. */}
+      <div id={diffId} className="live-work-rail__file-diff" hidden={!expanded}>
+        {expanded ? <TranscriptDiff detail={props.detail} compact /> : null}
+      </div>
+    </>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
@@ -107,9 +107,13 @@ function EditedFileGroupSection(props: {
       >
         <span className="live-work-rail__chevron" aria-hidden="true" />
         <span className="edited-file-groups__group-summary">
-          {props.group.live ? "This turn · " : ""}
           {props.group.summary}
         </span>
+        {props.group.live ? (
+          <span className="edited-file-groups__group-tag edited-file-groups__group-tag--live">
+            This turn
+          </span>
+        ) : null}
         {props.group.committed ? (
           <span className="edited-file-groups__group-tag">Committed</span>
         ) : null}

--- a/apps/desktop/src/renderer/src/features/thread-detail/LiveWorkRail.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/LiveWorkRail.tsx
@@ -1,15 +1,16 @@
 import { useId, useState } from "react";
 import type {
-  AppServerThreadActivityDetail,
   AppServerThreadActivityEntry,
   AppServerThreadPlanEntry,
   DesktopApplicationsSnapshot,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
-import { TranscriptDiff } from "./TranscriptDiff";
 import { TranscriptPlan } from "./TranscriptPlan";
-
-export type LiveWorkRailDock = "above" | "sidebar";
+import { EditedFileGroupList } from "./EditedFileGroupList";
+import {
+  summarizeEditedFileGroups,
+  type EditedFileGroup,
+} from "./edited-file-groups";
 
 export type LiveWorkRailProps = {
   applications?: DesktopApplicationsSnapshot;
@@ -20,12 +21,13 @@ export type LiveWorkRailProps = {
    */
   changedFilesEntry?: AppServerThreadActivityEntry;
   desktopApi?: DesktopApi;
-  dock: LiveWorkRailDock;
   /**
-   * Cumulative turn diff from `turn/diff/updated`. Renders in the
-   * Edited Files section with per-file inline diff expansion.
+   * Accumulated edited-file groups (newest first) from
+   * `collectEditedFileGroups`: the live turn's cumulative diff plus
+   * every prior uncommitted turn's edits. Omitted entirely when the
+   * user docks edited files to the context-rail Edits panel.
    */
-  editedFilesEntry?: AppServerThreadActivityEntry;
+  editedFileGroups?: EditedFileGroup[];
   /**
    * `true` when the rail is showing snapshots from a completed turn
    * (pinned until the next turn starts). `false` while the live turn
@@ -33,23 +35,20 @@ export type LiveWorkRailProps = {
    */
   pinned: boolean;
   planEntry?: AppServerThreadPlanEntry;
-  onDockChange: (dock: LiveWorkRailDock) => void;
+  /**
+   * Moves the edited-files list into the context-rail Edits panel
+   * (and stops rendering it here). Present only while edited files
+   * are docked above the composer.
+   */
+  onMoveEditedFilesToSidebar?: () => void;
 };
 
 export function LiveWorkRail(props: LiveWorkRailProps) {
-  // Treat an editedFilesEntry as absent if none of its details carry a
-  // fileDiff — otherwise the rail title would claim "Edited N files,
-  // +A, -R" while the body had nothing to render below it (the gap
-  // would land on the user as "rail says something happened but the
-  // list is empty"). Same logic applied uniformly to title + body.
-  const editedFilesEntry =
-    props.editedFilesEntry &&
-    props.editedFilesEntry.details.some((detail) => detail.fileDiff)
-      ? props.editedFilesEntry
-      : undefined;
+  const editedFileGroups = props.editedFileGroups ?? [];
+  const editedSummary = summarizeEditedFileGroups(editedFileGroups);
 
   const hasContent = Boolean(
-    props.planEntry || editedFilesEntry || props.changedFilesEntry,
+    props.planEntry || editedSummary || props.changedFilesEntry,
   );
   const [collapsed, setCollapsed] = useState(false);
   const bodyId = useId();
@@ -66,18 +65,14 @@ export function LiveWorkRail(props: LiveWorkRailProps) {
   // inside the section.
   const sectionLabels: string[] = [];
   if (props.planEntry) sectionLabels.push("Plan");
-  if (editedFilesEntry) sectionLabels.push(editedFilesEntry.summary);
+  if (editedSummary) sectionLabels.push(editedSummary);
   if (props.changedFilesEntry) sectionLabels.push(props.changedFilesEntry.summary);
   const railTitle = sectionLabels.join(" · ");
   const railAriaLabel = props.pinned ? `${railTitle} (last turn)` : railTitle;
 
-  const dockToggleLabel =
-    props.dock === "above" ? "Dock to sidebar" : "Dock above composer";
-  const nextDock: LiveWorkRailDock = props.dock === "above" ? "sidebar" : "above";
-
   return (
     <aside
-      className={`live-work-rail live-work-rail--dock-${props.dock}${
+      className={`live-work-rail${
         props.pinned ? " live-work-rail--pinned" : ""
       }${collapsed ? " live-work-rail--collapsed" : ""}`}
       role="complementary"
@@ -94,15 +89,17 @@ export function LiveWorkRail(props: LiveWorkRailProps) {
           <span className="live-work-rail__chevron" aria-hidden="true" />
           <span className="live-work-rail__title">{railTitle}</span>
         </button>
-        <button
-          type="button"
-          className="live-work-rail__dock-toggle"
-          onClick={() => props.onDockChange(nextDock)}
-          aria-label={dockToggleLabel}
-          title={dockToggleLabel}
-        >
-          {props.dock === "above" ? "Sidebar" : "Above"}
-        </button>
+        {editedSummary && props.onMoveEditedFilesToSidebar ? (
+          <button
+            type="button"
+            className="live-work-rail__dock-toggle"
+            onClick={props.onMoveEditedFilesToSidebar}
+            aria-label="Move edited files to the sidebar Edits panel"
+            title="Move edited files to the sidebar Edits panel"
+          >
+            Sidebar
+          </button>
+        ) : null}
       </header>
 
       {/* Body stays mounted across collapse toggles so the
@@ -118,8 +115,10 @@ export function LiveWorkRail(props: LiveWorkRailProps) {
           />
         ) : null}
 
-        {editedFilesEntry ? (
-          <EditedFilesSection entry={editedFilesEntry} />
+        {editedSummary ? (
+          <section className="live-work-rail__section live-work-rail__section--edited">
+            <EditedFileGroupList groups={editedFileGroups} />
+          </section>
         ) : null}
 
         {props.changedFilesEntry ? (
@@ -127,75 +126,6 @@ export function LiveWorkRail(props: LiveWorkRailProps) {
         ) : null}
       </div>
     </aside>
-  );
-}
-
-function EditedFilesSection(props: {
-  entry: AppServerThreadActivityEntry;
-}) {
-  const filesWithDiffs = props.entry.details.filter(
-    (detail) => detail.fileDiff,
-  );
-  if (filesWithDiffs.length === 0) {
-    return null;
-  }
-
-  // The cumulative summary (e.g. "Edited 2 files, +5, -2") lives in
-  // the rail-level title now (#510). No `aria-label` on the inner
-  // section — adding one would duplicate the rail-level landmark
-  // text in screen-reader landmark navigation.
-  return (
-    <section className="live-work-rail__section live-work-rail__section--edited">
-      <ul className="live-work-rail__file-list">
-        {filesWithDiffs.map((detail) => (
-          <li key={detail.id} className="live-work-rail__file-row">
-            <EditedFileRow detail={detail} />
-          </li>
-        ))}
-      </ul>
-    </section>
-  );
-}
-
-function EditedFileRow(props: {
-  detail: AppServerThreadActivityDetail;
-}) {
-  const [expanded, setExpanded] = useState(false);
-  const diffId = useId();
-  const additions = props.detail.fileDiff?.additions ?? 0;
-  const removals = props.detail.fileDiff?.removals ?? 0;
-
-  return (
-    <>
-      <button
-        type="button"
-        className="live-work-rail__file-toggle"
-        aria-controls={diffId}
-        aria-expanded={expanded}
-        onClick={() => setExpanded((current) => !current)}
-      >
-        <span className="live-work-rail__chevron" aria-hidden="true" />
-        <span className="live-work-rail__file-path" title={props.detail.path}>
-          {props.detail.label}
-        </span>
-        <span className="live-work-rail__file-stats" aria-label="File diff summary">
-          <span className="live-work-rail__file-stat live-work-rail__file-stat--removed">
-            -{removals.toLocaleString()}
-          </span>
-          <span className="live-work-rail__file-stat live-work-rail__file-stat--added">
-            +{additions.toLocaleString()}
-          </span>
-        </span>
-      </button>
-      {/* Diff container stays in the DOM (with `hidden`) so the
-          row's `aria-controls={diffId}` always resolves. The
-          potentially-heavy TranscriptDiff itself is still
-          conditionally mounted to keep the render cost in line
-          with what the user actually opens. */}
-      <div id={diffId} className="live-work-rail__file-diff" hidden={!expanded}>
-        {expanded ? <TranscriptDiff detail={props.detail} compact /> : null}
-      </div>
-    </>
   );
 }
 
@@ -221,4 +151,3 @@ function ChangedFilesSection(props: {
     </section>
   );
 }
-

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -15,6 +15,7 @@ import type { BackendSummary, NavigationThreadSummary } from "@pwragent/shared";
 import type { WindowPointerSnapshot } from "../../../../shared/window-pointer";
 import {
   AutomationsIcon,
+  EditsIcon,
   InfoIcon,
   ProjectsIcon,
   PullRequestIcon,
@@ -29,8 +30,13 @@ import { ProviderStatusPanel } from "./context-panels/ProviderStatusPanel";
 import { SubAgentsPanel } from "./context-panels/SubAgentsPanel";
 import { PullRequestsPanel } from "./context-panels/PullRequestsPanel";
 import { LinkedProjectsPanel } from "./context-panels/LinkedProjectsPanel";
+import { EditsPanel } from "./context-panels/EditsPanel";
 import { buildRailTooltipText } from "./context-panels/context-rail-shared";
-import type { ContextTabId } from "./context-panels/context-tab";
+import type {
+  ContextTabId,
+  EditedFilesDock,
+} from "./context-panels/context-tab";
+import type { EditedFileGroup } from "./edited-file-groups";
 
 const HOVER_RAIL_POINTER_POLL_MS = 500;
 const HOVER_RAIL_OFF_TARGET_CLOSE_MS = 1_200;
@@ -46,6 +52,7 @@ type ContextTab = {
 
 const CONTEXT_TABS: ContextTab[] = [
   { id: "info", label: "Thread info", Icon: InfoIcon },
+  { id: "edits", label: "Edits", Icon: EditsIcon },
   { id: "subagents", label: "Sub-agents", Icon: SubAgentsIcon },
   { id: "automations", label: "Automations", Icon: AutomationsIcon },
   { id: "prs", label: "Pull requests", Icon: PullRequestIcon },
@@ -83,6 +90,10 @@ type ThreadContextPanelProps = {
   ) => Promise<void>;
   activeTab: ContextTabId;
   onActiveTabChange: (tab: ContextTabId) => void;
+  /** Accumulated edited-file groups for the Edits tab (newest first). */
+  editedFileGroups?: EditedFileGroup[];
+  editedFilesDock?: EditedFilesDock;
+  onEditedFilesDockChange?: (dock: EditedFilesDock) => void;
 };
 
 export function ThreadContextPanel(props: ThreadContextPanelProps) {
@@ -576,6 +587,14 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
             onRestoreWorktree={props.onRestoreWorktree}
             showTooltip={showRailTooltip}
             hideTooltip={hideRailTooltip}
+          />
+        );
+      case "edits":
+        return (
+          <EditsPanel
+            groups={props.editedFileGroups ?? []}
+            dock={props.editedFilesDock ?? "above"}
+            onDockChange={props.onEditedFilesDockChange ?? (() => {})}
           />
         );
       case "subagents":

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -42,6 +42,8 @@ const HOVER_RAIL_POINTER_POLL_MS = 500;
 const HOVER_RAIL_OFF_TARGET_CLOSE_MS = 1_200;
 const HOVER_RAIL_REVEAL_DELAY_MS = 350;
 
+const noop = (): void => {};
+
 type ContextTab = {
   id: ContextTabId;
   label: string;
@@ -594,7 +596,7 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
           <EditsPanel
             groups={props.editedFileGroups ?? []}
             dock={props.editedFilesDock ?? "above"}
-            onDockChange={props.onEditedFilesDockChange ?? (() => {})}
+            onDockChange={props.onEditedFilesDockChange ?? noop}
           />
         );
       case "subagents":

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -53,15 +53,18 @@ import { MessagingStatusBar } from "../messaging-status/MessagingStatusBar";
 import { ThreadContextPanel } from "./ThreadContextPanel";
 import {
   DEFAULT_CONTEXT_TAB,
+  DEFAULT_EDITED_FILES_DOCK,
   type ContextTabId,
+  type EditedFilesDock,
 } from "./context-panels/context-tab";
+import { collectEditedFileGroups } from "./edited-file-groups";
 import type { HistoryNavControls } from "../chrome/HistoryNavButtons";
 import type { MastheadActionsProps } from "../chrome/MastheadActions";
 import { ThreadHeader } from "./ThreadHeader";
 import { ThreadPlaceholderHeader } from "./ThreadPlaceholderHeader";
 import { TranscriptImageLightbox } from "./TranscriptImageLightbox";
 import { TranscriptList } from "./TranscriptList";
-import { LiveWorkRail, type LiveWorkRailDock } from "./LiveWorkRail";
+import { LiveWorkRail } from "./LiveWorkRail";
 import {
   buildQuestionnaireResponse,
   type PendingQuestionnaireState,
@@ -885,6 +888,14 @@ export type ThreadViewProps = {
   onContextRailPinnedChange?: (pinned: boolean) => void;
   activeContextTab?: ContextTabId;
   onActiveContextTabChange?: (tab: ContextTabId) => void;
+  /**
+   * Where the accumulated edited-files list renders: above the
+   * composer (default) or only in the context-rail Edits panel. A
+   * window preference like the context-rail tab — owned and persisted
+   * by App.
+   */
+  editedFilesDock?: EditedFilesDock;
+  onEditedFilesDockChange?: (dock: EditedFilesDock) => void;
   sidebarHidden?: boolean;
   onToggleSidebar?: () => void;
   /**
@@ -996,18 +1007,17 @@ export function ThreadView(props: ThreadViewProps) {
     useState<AppServerThreadActivityEntry>();
   const [pendingPlanEntry, setPendingPlanEntry] =
     useState<AppServerThreadPlanEntry>();
-  // Snapshots of the two rail-owned live entries at turn/completed
-  // time. The LiveWorkRail uses these to keep showing what the last
-  // turn produced even after the live state has cleared, until the
-  // next turn starts. `pendingProtocolActivityEntry` (MCP status /
+  // Snapshot of the rail-owned live plan entry at turn/completed time.
+  // The LiveWorkRail uses it to keep showing the last turn's plan even
+  // after the live state has cleared, until the next turn starts.
+  // Edited files no longer need a snapshot — turn/completed defers the
+  // cumulative diff entry into the transcript, where
+  // `collectEditedFileGroups` accumulates it (and survives reloads via
+  // the persisted replay). `pendingProtocolActivityEntry` (MCP status /
   // warnings) is not snapshotted because it doesn't belong in the
   // rail; the dupe-fix that clears it on turn/completed still applies.
-  const [lastCompletedActivityEntry, setLastCompletedActivityEntry] =
-    useState<AppServerThreadActivityEntry>();
   const [lastCompletedPlanEntry, setLastCompletedPlanEntry] =
     useState<AppServerThreadPlanEntry>();
-  const [liveWorkRailDock, setLiveWorkRailDock] =
-    useState<LiveWorkRailDock>("above");
   // Refs mirror the pending state so the turn/completed handler can read
   // the latest values to snapshot, then clear via setState without
   // racing or queuing extra micro-renders.
@@ -1043,9 +1053,11 @@ export function ThreadView(props: ThreadViewProps) {
   // user controls it explicitly).
   const contextRailPinned = props.contextRailPinned ?? false;
   const activeContextTab = props.activeContextTab ?? DEFAULT_CONTEXT_TAB;
+  const editedFilesDock = props.editedFilesDock ?? DEFAULT_EDITED_FILES_DOCK;
   const sidebarHidden = props.sidebarHidden ?? false;
   const onContextRailPinnedChange = props.onContextRailPinnedChange ?? noop;
   const onActiveContextTabChange = props.onActiveContextTabChange ?? noop;
+  const onEditedFilesDockChange = props.onEditedFilesDockChange ?? noop;
   const onToggleSidebar = props.onToggleSidebar ?? noop;
 
   useEffect(() => {
@@ -1053,7 +1065,6 @@ export function ThreadView(props: ThreadViewProps) {
     setPendingProtocolActivityEntry(undefined);
     setPendingUsageActivityEntry(undefined);
     setPendingPlanEntry(undefined);
-    setLastCompletedActivityEntry(undefined);
     setLastCompletedPlanEntry(undefined);
     setPendingRequestBusy(false);
     setPendingRequestError(undefined);
@@ -1092,7 +1103,6 @@ export function ThreadView(props: ThreadViewProps) {
     const previous = lastSeenActiveTurnIdRef.current;
     lastSeenActiveTurnIdRef.current = props.activeTurnId;
     if (props.activeTurnId && props.activeTurnId !== previous) {
-      setLastCompletedActivityEntry(undefined);
       setLastCompletedPlanEntry(undefined);
     }
   }, [props.activeTurnId]);
@@ -1505,6 +1515,35 @@ export function ThreadView(props: ThreadViewProps) {
       ? pendingActivityEntry
       : undefined;
 
+  // Accumulated edited files: persisted replay entries + deferred live
+  // entries grouped per turn, cleared past a committed turn once the
+  // next turn starts. Rehydrates on thread load because the replay
+  // already carries per-file diffs and command exit codes.
+  const editedFileGroups = useMemo(
+    () =>
+      collectEditedFileGroups({
+        entries: props.transcriptEntries,
+        activeTurnId: props.activeTurnId,
+        livePendingEntry: pendingRailActivityEntry,
+      }),
+    [props.transcriptEntries, props.activeTurnId, pendingRailActivityEntry],
+  );
+
+  const moveEditedFilesToSidebar = useCallback(() => {
+    onEditedFilesDockChange("sidebar");
+    onActiveContextTabChange("edits");
+    // Reveal the destination: an unpinned rail would leave the moved
+    // list invisible, which reads as "my edits vanished".
+    if (!contextRailPinned) {
+      onContextRailPinnedChange(true);
+    }
+  }, [
+    contextRailPinned,
+    onActiveContextTabChange,
+    onContextRailPinnedChange,
+    onEditedFilesDockChange,
+  ]);
+
   useEffect(() => {
     if (!pendingActivityEntry) {
       return;
@@ -1628,7 +1667,6 @@ export function ThreadView(props: ThreadViewProps) {
           const completedActivity = completeEntryTurn(pendingActivityEntryRef.current);
           if (completedActivity) {
             deferLiveTranscriptEntry(completedActivity);
-            setLastCompletedActivityEntry(completedActivity);
           }
           setPendingActivityEntry(undefined);
 
@@ -2309,24 +2347,23 @@ export function ThreadView(props: ThreadViewProps) {
             ) : null}
           </section>
 
-          {liveWorkRailDock === "above" ? (
-            <LiveWorkRail
-              applications={props.applications}
-              changedFilesEntry={liveWorkRailChangedFilesEntry}
-              desktopApi={props.desktopApi}
-              dock="above"
-              editedFilesEntry={
-                pendingRailActivityEntry ??
-                (props.activeTurnId ? undefined : lastCompletedActivityEntry)
-              }
-              pinned={!props.activeTurnId}
-              planEntry={
-                pendingPlanEntry ??
-                (props.activeTurnId ? undefined : lastCompletedPlanEntry)
-              }
-              onDockChange={setLiveWorkRailDock}
-            />
-          ) : null}
+          <LiveWorkRail
+            applications={props.applications}
+            changedFilesEntry={liveWorkRailChangedFilesEntry}
+            desktopApi={props.desktopApi}
+            editedFileGroups={
+              editedFilesDock === "above" ? editedFileGroups : undefined
+            }
+            pinned={!props.activeTurnId}
+            planEntry={
+              pendingPlanEntry ??
+              (props.activeTurnId ? undefined : lastCompletedPlanEntry)
+            }
+            onMoveEditedFilesToSidebar={
+              editedFilesDock === "above" ? moveEditedFilesToSidebar : undefined
+            }
+          />
+
 
           <Composer
             activeTurnId={props.activeTurnId}
@@ -2383,30 +2420,14 @@ export function ThreadView(props: ThreadViewProps) {
           />
         </div>
 
-        {liveWorkRailDock === "sidebar" ? (
-          <LiveWorkRail
-            applications={props.applications}
-            changedFilesEntry={liveWorkRailChangedFilesEntry}
-            desktopApi={props.desktopApi}
-            dock="sidebar"
-            editedFilesEntry={
-              pendingRailActivityEntry ??
-              (props.activeTurnId ? undefined : lastCompletedActivityEntry)
-            }
-            pinned={!props.activeTurnId}
-            planEntry={
-              pendingPlanEntry ??
-              (props.activeTurnId ? undefined : lastCompletedPlanEntry)
-            }
-            onDockChange={setLiveWorkRailDock}
-          />
-        ) : null}
-
         <ThreadContextPanel
           activeTab={activeContextTab}
           backendError={props.backendError}
           backends={props.backends}
           desktopApi={props.desktopApi}
+          editedFileGroups={editedFileGroups}
+          editedFilesDock={editedFilesDock}
+          onEditedFilesDockChange={onEditedFilesDockChange}
           onActiveTabChange={onActiveContextTabChange}
           onRefreshNavigation={props.onRefreshNavigation}
           onResizingChange={setContextRailResizing}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1627,6 +1627,17 @@ export function ThreadView(props: ThreadViewProps) {
         event.notification.method === "turn/failed" ||
         event.notification.method === "turn/cancelled"
       ) {
+        // A failed/cancelled turn still made real file edits before it
+        // stopped (turn/diff/updated only carries actual changes). Defer
+        // the pending diff entry into the transcript — same path as
+        // turn/completed — so the accumulated Edited Files groups retain
+        // that turn's work instead of dropping it until a replay refresh
+        // happens to re-fetch it. Protocol/usage entries are status/cost,
+        // not edits, so they're still cleared.
+        const interruptedActivity = pendingActivityEntryRef.current;
+        if (interruptedActivity && activityHasFileDiff(interruptedActivity)) {
+          deferLiveTranscriptEntry(interruptedActivity);
+        }
         setPendingActivityEntry(undefined);
         setPendingProtocolActivityEntry(undefined);
         setPendingUsageActivityEntry(undefined);

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/LiveWorkRail.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/LiveWorkRail.test.tsx
@@ -6,6 +6,7 @@ import type {
 } from "@pwragent/shared";
 import { describe, expect, it, vi } from "vitest";
 import { LiveWorkRail } from "../LiveWorkRail";
+import { collectEditedFileGroups } from "../edited-file-groups";
 
 function buildEditedFilesEntry(): AppServerThreadActivityEntry {
   return {
@@ -43,6 +44,12 @@ function buildEditedFilesEntry(): AppServerThreadActivityEntry {
   };
 }
 
+function buildEditedFileGroups() {
+  return collectEditedFileGroups({
+    entries: [buildEditedFilesEntry()],
+  });
+}
+
 function buildChangedFilesEntry(): AppServerThreadActivityEntry {
   return {
     type: "activity",
@@ -76,53 +83,44 @@ function buildPlanEntry(): AppServerThreadPlanEntry {
 
 describe("LiveWorkRail", () => {
   it("renders nothing when there's no live or pinned content", () => {
-    const { container } = render(
-      <LiveWorkRail dock="above" pinned={false} onDockChange={() => undefined} />,
-    );
+    const { container } = render(<LiveWorkRail pinned={false} />);
     expect(container).toBeEmptyDOMElement();
   });
 
-  it("treats an editedFilesEntry as absent when none of its details carry a fileDiff", () => {
+  it("renders nothing when an entry's details carry no fileDiff (accumulator filters it)", () => {
     // Defensive: a malformed entry with summary "Edited 1 file" but
     // empty/non-diff details would otherwise produce a rail title
     // claiming work-was-done while the body had nothing to render
-    // below it. The rail title and the section body share the same
-    // gating so they can't disagree (#510 follow-up).
-    const editedFilesEntryWithoutDiffs: AppServerThreadActivityEntry = {
-      type: "activity",
-      id: "live-diff-empty",
-      summary: "Edited 1 file",
-      createdAt: 1_000,
-      details: [
+    // below it. The gating lives in collectEditedFileGroups so the
+    // rail title and body can't disagree (#510 follow-up).
+    const groups = collectEditedFileGroups({
+      entries: [
         {
-          id: "detail-non-diff",
-          kind: "write",
-          label: "Update mystery.ts",
-          path: "/repo/mystery.ts",
+          type: "activity",
+          id: "live-diff-empty",
+          summary: "Edited 1 file",
+          createdAt: 1_000,
+          details: [
+            {
+              id: "detail-non-diff",
+              kind: "write",
+              label: "Update mystery.ts",
+              path: "/repo/mystery.ts",
+            },
+          ],
         },
       ],
-    };
+    });
+    expect(groups).toHaveLength(0);
     const { container } = render(
-      <LiveWorkRail
-        dock="above"
-        pinned={false}
-        editedFilesEntry={editedFilesEntryWithoutDiffs}
-        onDockChange={() => undefined}
-      />,
+      <LiveWorkRail pinned={false} editedFileGroups={groups} />,
     );
-    // No content → rail returns null entirely (just like the "no
-    // entries" empty-state case).
     expect(container).toBeEmptyDOMElement();
   });
 
   it("uses the section summary as the rail title when not pinned", () => {
     render(
-      <LiveWorkRail
-        dock="above"
-        pinned={false}
-        editedFilesEntry={buildEditedFilesEntry()}
-        onDockChange={() => undefined}
-      />,
+      <LiveWorkRail pinned={false} editedFileGroups={buildEditedFileGroups()} />,
     );
     expect(
       screen.getByRole("complementary", { name: "Edited 2 files, +5, -2" }),
@@ -134,12 +132,7 @@ describe("LiveWorkRail", () => {
 
   it("suffixes the aria label with (last turn) when pinned but keeps the same summary text in the visible title", () => {
     render(
-      <LiveWorkRail
-        dock="above"
-        pinned={true}
-        editedFilesEntry={buildEditedFilesEntry()}
-        onDockChange={() => undefined}
-      />,
+      <LiveWorkRail pinned={true} editedFileGroups={buildEditedFileGroups()} />,
     );
     expect(
       screen.getByRole("complementary", {
@@ -151,12 +144,10 @@ describe("LiveWorkRail", () => {
   it("joins multiple section summaries in the rail title with a midline dot", () => {
     render(
       <LiveWorkRail
-        dock="above"
         pinned={false}
         planEntry={buildPlanEntry()}
-        editedFilesEntry={buildEditedFilesEntry()}
+        editedFileGroups={buildEditedFileGroups()}
         changedFilesEntry={buildChangedFilesEntry()}
-        onDockChange={() => undefined}
       />,
     );
     expect(
@@ -168,12 +159,7 @@ describe("LiveWorkRail", () => {
 
   it("expands a file's diff in place when its row is clicked", () => {
     render(
-      <LiveWorkRail
-        dock="above"
-        pinned={false}
-        editedFilesEntry={buildEditedFilesEntry()}
-        onDockChange={() => undefined}
-      />,
+      <LiveWorkRail pinned={false} editedFileGroups={buildEditedFileGroups()} />,
     );
     // Section heading is gone — the rail title carries the summary
     // (see "uses the section summary as the rail title" above).
@@ -192,12 +178,7 @@ describe("LiveWorkRail", () => {
 
   it("renders the Changed Files section as a static list (no diff expand, no section heading)", () => {
     render(
-      <LiveWorkRail
-        dock="above"
-        pinned={false}
-        changedFilesEntry={buildChangedFilesEntry()}
-        onDockChange={() => undefined}
-      />,
+      <LiveWorkRail pinned={false} changedFilesEntry={buildChangedFilesEntry()} />,
     );
     // Section heading was redundant with the rail title, dropped.
     expect(
@@ -216,25 +197,13 @@ describe("LiveWorkRail", () => {
   });
 
   it("renders the plan section by delegating to TranscriptPlan", () => {
-    render(
-      <LiveWorkRail
-        dock="above"
-        pinned={false}
-        planEntry={buildPlanEntry()}
-        onDockChange={() => undefined}
-      />,
-    );
+    render(<LiveWorkRail pinned={false} planEntry={buildPlanEntry()} />);
     expect(screen.getByText("1 out of 3 tasks completed")).toBeInTheDocument();
   });
 
   it("toggles the whole rail collapsed and expanded from the title button", () => {
     render(
-      <LiveWorkRail
-        dock="above"
-        pinned={false}
-        editedFilesEntry={buildEditedFilesEntry()}
-        onDockChange={() => undefined}
-      />,
+      <LiveWorkRail pinned={false} editedFileGroups={buildEditedFileGroups()} />,
     );
     const collapseButton = screen.getByRole("button", {
       name: /Edited 2 files, \+5, -2/,
@@ -262,43 +231,41 @@ describe("LiveWorkRail", () => {
     ).toBeVisible();
   });
 
-  it("flips the dock via the dock-toggle button", () => {
-    const onDockChange = vi.fn();
+  it("moves edited files to the sidebar Edits panel via the header button", () => {
+    const onMove = vi.fn();
     render(
       <LiveWorkRail
-        dock="above"
         pinned={false}
-        editedFilesEntry={buildEditedFilesEntry()}
-        onDockChange={onDockChange}
+        editedFileGroups={buildEditedFileGroups()}
+        onMoveEditedFilesToSidebar={onMove}
       />,
     );
-    fireEvent.click(screen.getByRole("button", { name: "Dock to sidebar" }));
-    expect(onDockChange).toHaveBeenCalledWith("sidebar");
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Move edited files to the sidebar Edits panel",
+      }),
+    );
+    expect(onMove).toHaveBeenCalledTimes(1);
   });
 
-  it("offers the reverse dock label when already in sidebar mode", () => {
-    const onDockChange = vi.fn();
+  it("hides the sidebar button when no move handler is provided (edits docked to sidebar)", () => {
     render(
-      <LiveWorkRail
-        dock="sidebar"
-        pinned={false}
-        editedFilesEntry={buildEditedFilesEntry()}
-        onDockChange={onDockChange}
-      />,
+      <LiveWorkRail pinned={false} changedFilesEntry={buildChangedFilesEntry()} />,
     );
-    fireEvent.click(screen.getByRole("button", { name: "Dock above composer" }));
-    expect(onDockChange).toHaveBeenCalledWith("above");
+    expect(
+      screen.queryByRole("button", {
+        name: "Move edited files to the sidebar Edits panel",
+      }),
+    ).not.toBeInTheDocument();
   });
 
   it("renders all three sections together with the joined rail title and per-section bodies", () => {
     render(
       <LiveWorkRail
-        dock="above"
         pinned={false}
         planEntry={buildPlanEntry()}
-        editedFilesEntry={buildEditedFilesEntry()}
+        editedFileGroups={buildEditedFileGroups()}
         changedFilesEntry={buildChangedFilesEntry()}
-        onDockChange={() => undefined}
       />,
     );
     expect(

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -13,6 +13,7 @@ import type { ComponentProps } from "react";
 import type { BackendSummary, NavigationThreadSummary } from "@pwragent/shared";
 import { ThreadContextPanel } from "../ThreadContextPanel";
 import type { ContextTabId } from "../context-panels/context-tab";
+import { collectEditedFileGroups } from "../edited-file-groups";
 
 const HOVER_RAIL_REVEAL_DELAY_MS = 350;
 
@@ -101,7 +102,15 @@ const baseBackend: BackendSummary = {
 type PanelOverrides = Partial<
   Pick<
     ComponentProps<typeof ThreadContextPanel>,
-    "activeTab" | "backends" | "desktopApi" | "pinned" | "thread" | "onRefreshNavigation"
+    | "activeTab"
+    | "backends"
+    | "desktopApi"
+    | "pinned"
+    | "thread"
+    | "onRefreshNavigation"
+    | "editedFileGroups"
+    | "editedFilesDock"
+    | "onEditedFilesDockChange"
   >
 >;
 
@@ -322,14 +331,14 @@ describe("ThreadContextPanel", () => {
     renderPanel({ pinned: true });
 
     const info = screen.getByRole("tab", { name: "Thread info" });
-    const subAgents = screen.getByRole("tab", { name: "Sub-agents" });
+    const edits = screen.getByRole("tab", { name: "Edits" });
     info.focus();
     expect(document.activeElement).toBe(info);
 
     fireEvent.keyDown(info, { key: "ArrowDown" });
-    expect(document.activeElement).toBe(subAgents);
+    expect(document.activeElement).toBe(edits);
 
-    fireEvent.keyDown(subAgents, { key: "ArrowUp" });
+    fireEvent.keyDown(edits, { key: "ArrowUp" });
     expect(document.activeElement).toBe(info);
 
     fireEvent.keyDown(info, { key: "End" });
@@ -608,5 +617,58 @@ describe("ThreadContextPanel", () => {
 
     expect(screen.getByText(/Spark 5h limit: 98% left/)).toBeInTheDocument();
     expect(screen.getByText(/Spark Weekly limit: 100% left/)).toBeInTheDocument();
+  });
+
+  it("renders the Edits tab empty state when no edits accumulated", () => {
+    renderPanel({ activeTab: "edits", pinned: true });
+
+    expect(
+      screen.getByText(/No uncommitted file edits yet/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders accumulated edit groups on the Edits tab and toggles the dock", () => {
+    const groups = collectEditedFileGroups({
+      entries: [
+        {
+          type: "activity",
+          id: "live-diff-turn-1",
+          summary: "Edited 1 file, +2, -0",
+          details: [
+            {
+              id: "detail-1",
+              kind: "write",
+              label: "Update a.ts",
+              path: "/repo/src/a.ts",
+              fileDiff: {
+                kind: "update",
+                additions: 2,
+                removals: 0,
+                diff: "--- a/src/a.ts\n+++ b/src/a.ts\n@@ -1,0 +1,2 @@\n+x\n+y\n",
+              },
+            },
+          ],
+          turn: { id: "turn-1" },
+        },
+      ],
+    });
+    const onEditedFilesDockChange = vi.fn();
+    renderPanel({
+      activeTab: "edits",
+      pinned: true,
+      editedFileGroups: groups,
+      editedFilesDock: "sidebar",
+      onEditedFilesDockChange,
+    });
+
+    expect(screen.getByRole("heading", { level: 3, name: "Edits" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Update a\.ts/ }),
+    ).toBeInTheDocument();
+
+    // Docked to the sidebar → the toggle offers to restore the
+    // above-composer copy.
+    fireEvent.click(screen.getByRole("button", { name: "Show above composer" }));
+    expect(onEditedFilesDockChange).toHaveBeenCalledWith("above");
   });
 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/edited-file-groups.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/edited-file-groups.test.ts
@@ -1,0 +1,356 @@
+import { describe, expect, it } from "vitest";
+import type {
+  AppServerThreadActivityDetail,
+  AppServerThreadActivityEntry,
+  AppServerThreadEntry,
+} from "@pwragent/shared";
+import {
+  collectEditedFileGroups,
+  commandLooksLikeGitCommit,
+  flattenEditedFileGroups,
+  summarizeEditedFileGroups,
+} from "../edited-file-groups";
+
+let detailCounter = 0;
+
+function fileDiffDetail(params: {
+  path: string;
+  additions?: number;
+  removals?: number;
+  kind?: "add" | "delete" | "update";
+}): AppServerThreadActivityDetail {
+  detailCounter += 1;
+  const kind = params.kind ?? "update";
+  return {
+    id: `detail-${detailCounter}`,
+    kind: "write",
+    label: `${kind[0].toUpperCase()}${kind.slice(1)} ${params.path.split("/").pop()}`,
+    path: params.path,
+    fileDiff: {
+      kind,
+      diff: `diff for ${params.path} (#${detailCounter})`,
+      additions: params.additions ?? 1,
+      removals: params.removals ?? 0,
+    },
+  };
+}
+
+function activityEntry(params: {
+  id: string;
+  turnId?: string;
+  details: AppServerThreadActivityDetail[];
+}): AppServerThreadActivityEntry {
+  return {
+    type: "activity",
+    id: params.id,
+    summary: "activity",
+    details: params.details,
+    ...(params.turnId ? { turn: { id: params.turnId } } : {}),
+  };
+}
+
+function commitDetail(params?: {
+  command?: string;
+  exitCode?: number;
+  status?: "completed" | "failed";
+}): AppServerThreadActivityDetail {
+  detailCounter += 1;
+  return {
+    id: `commit-${detailCounter}`,
+    kind: "command",
+    label: "git commit",
+    status: params?.status ?? "completed",
+    command: {
+      displayCommand: params?.command ?? 'git commit -m "checkpoint"',
+      ...(params?.exitCode !== undefined ? { exitCode: params.exitCode } : {}),
+    },
+  };
+}
+
+function messageEntry(turnId: string): AppServerThreadEntry {
+  return {
+    type: "message",
+    id: `message-${turnId}`,
+    role: "assistant",
+    text: "done",
+    turn: { id: turnId },
+  };
+}
+
+describe("commandLooksLikeGitCommit", () => {
+  it.each([
+    ['git commit -m "fix"', true],
+    ["git add -A && git commit -m fix", true],
+    ["git -C /repo commit --amend", true],
+    ["git -c user.name=x commit", true],
+    ["git log --oneline", false],
+    ["echo commit", false],
+    ["git status", false],
+    ["pnpm test && git push", false],
+  ])("%s → %s", (command, expected) => {
+    expect(commandLooksLikeGitCommit(command)).toBe(expected);
+  });
+});
+
+describe("collectEditedFileGroups", () => {
+  it("groups edits per turn, newest first, merging repeat edits to the same file", () => {
+    const groups = collectEditedFileGroups({
+      entries: [
+        activityEntry({
+          id: "a1",
+          turnId: "turn-1",
+          details: [
+            fileDiffDetail({ path: "src/a.ts", additions: 2 }),
+            fileDiffDetail({ path: "src/a.ts", additions: 3, removals: 1 }),
+          ],
+        }),
+        activityEntry({
+          id: "a2",
+          turnId: "turn-2",
+          details: [fileDiffDetail({ path: "src/b.ts", additions: 5 })],
+        }),
+      ],
+    });
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0].key).toBe("turn-2");
+    expect(groups[1].key).toBe("turn-1");
+    // turn-1's two edits to src/a.ts merged into one row with summed counts.
+    expect(groups[1].details).toHaveLength(1);
+    expect(groups[1].details[0].fileDiff?.additions).toBe(5);
+    expect(groups[1].details[0].fileDiff?.removals).toBe(1);
+    expect(groups[1].summary).toBe("Edited 1 file, +5, -1");
+  });
+
+  it("prefers a turn's live cumulative diff entry over its per-edit entries", () => {
+    const groups = collectEditedFileGroups({
+      entries: [
+        activityEntry({
+          id: "item-1",
+          turnId: "turn-1",
+          details: [fileDiffDetail({ path: "src/a.ts", additions: 100 })],
+        }),
+        activityEntry({
+          id: "live-diff-turn-1",
+          turnId: "turn-1",
+          details: [fileDiffDetail({ path: "src/a.ts", additions: 4 })],
+        }),
+      ],
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].additions).toBe(4);
+  });
+
+  it("clears groups up to and including a committed turn once a later turn exists", () => {
+    const groups = collectEditedFileGroups({
+      entries: [
+        activityEntry({
+          id: "a1",
+          turnId: "turn-1",
+          details: [fileDiffDetail({ path: "src/a.ts" })],
+        }),
+        activityEntry({
+          id: "a2",
+          turnId: "turn-2",
+          details: [fileDiffDetail({ path: "src/b.ts" }), commitDetail()],
+        }),
+        activityEntry({
+          id: "a3",
+          turnId: "turn-3",
+          details: [fileDiffDetail({ path: "src/c.ts" })],
+        }),
+      ],
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].key).toBe("turn-3");
+  });
+
+  it("keeps committed groups visible while the commit turn is still the last turn", () => {
+    const groups = collectEditedFileGroups({
+      entries: [
+        activityEntry({
+          id: "a1",
+          turnId: "turn-1",
+          details: [fileDiffDetail({ path: "src/a.ts" })],
+        }),
+        activityEntry({
+          id: "a2",
+          turnId: "turn-2",
+          details: [fileDiffDetail({ path: "src/b.ts" }), commitDetail()],
+        }),
+      ],
+    });
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0].key).toBe("turn-2");
+    expect(groups[0].committed).toBe(true);
+    expect(groups[1].key).toBe("turn-1");
+  });
+
+  it("treats a message-only later turn as 'next turn started' for clearing", () => {
+    const groups = collectEditedFileGroups({
+      entries: [
+        activityEntry({
+          id: "a1",
+          turnId: "turn-1",
+          details: [fileDiffDetail({ path: "src/a.ts" }), commitDetail()],
+        }),
+        messageEntry("turn-2"),
+      ],
+    });
+
+    expect(groups).toHaveLength(0);
+  });
+
+  it("treats an active turn id as 'next turn started' for clearing", () => {
+    const entries = [
+      activityEntry({
+        id: "a1",
+        turnId: "turn-1",
+        details: [fileDiffDetail({ path: "src/a.ts" }), commitDetail()],
+      }),
+    ];
+
+    expect(collectEditedFileGroups({ entries })).toHaveLength(1);
+    expect(
+      collectEditedFileGroups({ entries, activeTurnId: "turn-2" }),
+    ).toHaveLength(0);
+    // The commit turn itself being active must NOT clear its own group.
+    expect(
+      collectEditedFileGroups({ entries, activeTurnId: "turn-1" }),
+    ).toHaveLength(1);
+  });
+
+  it("does not clear on a failed git commit", () => {
+    const groups = collectEditedFileGroups({
+      entries: [
+        activityEntry({
+          id: "a1",
+          turnId: "turn-1",
+          details: [
+            fileDiffDetail({ path: "src/a.ts" }),
+            commitDetail({ exitCode: 1, status: "failed" }),
+          ],
+        }),
+        activityEntry({
+          id: "a2",
+          turnId: "turn-2",
+          details: [fileDiffDetail({ path: "src/b.ts" })],
+        }),
+      ],
+    });
+
+    expect(groups).toHaveLength(2);
+  });
+
+  it("renders the live pending cumulative diff as the newest group", () => {
+    const groups = collectEditedFileGroups({
+      entries: [
+        activityEntry({
+          id: "a1",
+          turnId: "turn-1",
+          details: [fileDiffDetail({ path: "src/a.ts" })],
+        }),
+      ],
+      activeTurnId: "turn-2",
+      livePendingEntry: activityEntry({
+        id: "live-diff-turn-2",
+        turnId: "turn-2",
+        details: [fileDiffDetail({ path: "src/b.ts", additions: 7 })],
+      }),
+    });
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0].key).toBe("turn-2");
+    expect(groups[0].live).toBe(true);
+    expect(groups[0].additions).toBe(7);
+    expect(groups[1].live).toBe(false);
+  });
+
+  it("ignores activity entries whose details carry no fileDiff", () => {
+    const groups = collectEditedFileGroups({
+      entries: [
+        activityEntry({
+          id: "a1",
+          turnId: "turn-1",
+          details: [
+            {
+              id: "plain",
+              kind: "write",
+              label: "Update x.ts",
+              path: "src/x.ts",
+            },
+          ],
+        }),
+      ],
+    });
+    expect(groups).toHaveLength(0);
+  });
+});
+
+describe("flattenEditedFileGroups", () => {
+  it("merges the same file across turns with summed counts and stacked diffs", () => {
+    const groups = collectEditedFileGroups({
+      entries: [
+        activityEntry({
+          id: "a1",
+          turnId: "turn-1",
+          details: [fileDiffDetail({ path: "src/a.ts", additions: 2, removals: 1 })],
+        }),
+        activityEntry({
+          id: "a2",
+          turnId: "turn-2",
+          details: [
+            fileDiffDetail({ path: "src/a.ts", additions: 3 }),
+            fileDiffDetail({ path: "src/b.ts", additions: 4 }),
+          ],
+        }),
+      ],
+    });
+
+    const flattened = flattenEditedFileGroups(groups);
+    expect(flattened).toHaveLength(2);
+    const fileA = flattened.find((detail) => detail.path === "src/a.ts");
+    expect(fileA?.fileDiff?.additions).toBe(5);
+    expect(fileA?.fileDiff?.removals).toBe(1);
+    // Oldest diff first in the stacked text.
+    expect(fileA?.fileDiff?.diff.indexOf("(#")).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe("summarizeEditedFileGroups", () => {
+  it("returns undefined with no groups and appends the turn count with several", () => {
+    expect(summarizeEditedFileGroups([])).toBeUndefined();
+
+    const groups = collectEditedFileGroups({
+      entries: [
+        activityEntry({
+          id: "a1",
+          turnId: "turn-1",
+          details: [fileDiffDetail({ path: "src/a.ts", additions: 2, removals: 1 })],
+        }),
+        activityEntry({
+          id: "a2",
+          turnId: "turn-2",
+          details: [fileDiffDetail({ path: "src/b.ts", additions: 4 })],
+        }),
+      ],
+    });
+    expect(summarizeEditedFileGroups(groups)).toBe(
+      "Edited 2 files, +6, -1 · 2 turns",
+    );
+
+    const single = collectEditedFileGroups({
+      entries: [
+        activityEntry({
+          id: "a1",
+          turnId: "turn-1",
+          details: [fileDiffDetail({ path: "src/a.ts", additions: 2, removals: 1 })],
+        }),
+      ],
+    });
+    expect(summarizeEditedFileGroups(single)).toBe("Edited 1 file, +2, -1");
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -2150,7 +2150,14 @@ describe("ThreadView", () => {
       />
     );
 
-    expect(screen.getAllByRole("button", { name: /Edited 1 file/i })).toHaveLength(1);
+    // Replay caught up: the pending live entry clears (no dupe), but the
+    // rail keeps rendering the persisted entry's edits — accumulated
+    // edited files rehydrate from the replay instead of vanishing. Two
+    // matches: the transcript work-group row and the rail title button.
+    expect(screen.getAllByRole("button", { name: /Edited 1 file/i })).toHaveLength(2);
+    expect(
+      screen.getByRole("complementary", { name: /Edited 1 file, \+1, -2/ }),
+    ).toBeInTheDocument();
   });
 
   it("renders Codex warning notifications inline", async () => {
@@ -4068,7 +4075,7 @@ describe("ThreadView", () => {
     }
   });
 
-  it("clears the pinned rail when a new turn starts (issue #495)", async () => {
+  it("keeps the prior turn's uncommitted edits in the rail when a new turn starts", async () => {
     let agentEventHandler:
       | ((event: { backend: "codex"; notification: AppServerNotification }) => void)
       | undefined;
@@ -4176,12 +4183,16 @@ describe("ThreadView", () => {
       fireEvent.click(screen.getByRole("button", { name: "Start turn 2" }));
     });
 
-    // Snapshot cleared. The rail's Edited Files section (which carried
-    // turn 1's summary in the title) is gone until turn 2 produces its
-    // own diff. Other sections may still render with their own
-    // content, but no "Edited 1 file" text should be on screen.
+    // Turn 1's edits were not committed, so they stay in the rail when
+    // turn 2 starts — edits accumulate across turns until a successful
+    // `git commit` lands (the turn AFTER the commit clears them; see
+    // edited-file-groups.test.ts for the commit-boundary cases). The
+    // "(last turn)" pinned suffix drops because a turn is active again.
     expect(
-      screen.queryByRole("complementary", { name: /Edited 1 file/ }),
+      screen.getByRole("complementary", { name: /Edited 1 file/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("complementary", { name: /\(last turn\)/i }),
     ).not.toBeInTheDocument();
   });
 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -4195,4 +4195,97 @@ describe("ThreadView", () => {
       screen.queryByRole("complementary", { name: /\(last turn\)/i }),
     ).not.toBeInTheDocument();
   });
+
+  it("retains a failed turn's edits in the rail instead of dropping them", async () => {
+    let agentEventHandler:
+      | ((event: { backend: "codex"; notification: AppServerNotification }) => void)
+      | undefined;
+    const liveDiff = [
+      "diff --git a/src/example.ts b/src/example.ts",
+      "--- a/src/example.ts",
+      "+++ b/src/example.ts",
+      "@@ -1,1 +1,2 @@",
+      " existing line",
+      "+added before the failure",
+    ].join("\n");
+
+    function Harness() {
+      const [entries, setEntries] = useState<any[]>([]);
+      return (
+        <ThreadView
+          activeTurnId="turn-1"
+          activeTurnStartedAt={1_000}
+          addOptimisticUserMessage={(_text) => "optimistic-1"}
+          backends={[]}
+          composerDisabled={false}
+          desktopApi={{
+            onAgentEvent: (callback) => {
+              agentEventHandler = callback as typeof agentEventHandler;
+              return () => undefined;
+            },
+          }}
+          loading={false}
+          loadingMore={false}
+          messageCount={entries.length}
+          selectedThread={{
+            id: "thread-fail",
+            title: "Failure lifecycle",
+            titleSource: "explicit",
+            source: "codex",
+            updatedAt: Date.now(),
+            linkedDirectories: [],
+            inbox: { inInbox: false },
+          }}
+          skills={[]}
+          transcriptEntries={entries}
+          clearPendingRequest={() => undefined}
+          onLiveTranscriptEntry={(entry) => {
+            setEntries((current) => [...current, entry]);
+          }}
+          onLoadOlder={async () => undefined}
+          removeOptimisticMessage={(_id) => undefined}
+        />
+      );
+    }
+
+    render(<Harness />);
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/diff/updated",
+          params: { threadId: "thread-fail", turnId: "turn-1", diff: liveDiff },
+        },
+      });
+    });
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/failed",
+          params: {
+            threadId: "thread-fail",
+            turnId: "turn-1",
+            turn: {
+              id: "turn-1",
+              status: "failed",
+              error: { message: "boom" },
+            },
+          },
+        },
+      });
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // The failed turn made a real edit before stopping; it is deferred
+    // into the transcript so the accumulated Edited Files groups keep it
+    // rather than dropping it until a replay refresh re-fetches it.
+    expect(
+      screen.getByRole("complementary", { name: /Edited 1 file/ }),
+    ).toBeInTheDocument();
+  });
 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/EditsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/EditsPanel.tsx
@@ -1,0 +1,48 @@
+import { EditedFileGroupList } from "../EditedFileGroupList";
+import type { EditedFileGroup } from "../edited-file-groups";
+import type { EditedFilesDock } from "./context-tab";
+
+type EditsPanelProps = {
+  /** Newest-first accumulated edited-file groups for the open thread. */
+  groups: EditedFileGroup[];
+  dock: EditedFilesDock;
+  onDockChange: (dock: EditedFilesDock) => void;
+};
+
+/**
+ * Context-rail Edits tab: the accumulated uncommitted file edits for
+ * the open thread, grouped per turn (newest first). Shows the same
+ * data as the LiveWorkRail's Edited Files section; the dock toggle
+ * controls whether that above-composer copy renders at all.
+ */
+export function EditsPanel(props: EditsPanelProps) {
+  return (
+    <section className="context-panel__section">
+      <div className="edits-panel__header">
+        <h3>Edits</h3>
+        <button
+          type="button"
+          className="edits-panel__dock-toggle"
+          onClick={() =>
+            props.onDockChange(props.dock === "sidebar" ? "above" : "sidebar")
+          }
+          title={
+            props.dock === "sidebar"
+              ? "Also show edited files above the composer"
+              : "Only show edited files in this panel"
+          }
+        >
+          {props.dock === "sidebar" ? "Show above composer" : "Only show here"}
+        </button>
+      </div>
+      {props.groups.length > 0 ? (
+        <EditedFileGroupList groups={props.groups} />
+      ) : (
+        <p className="context-empty">
+          No uncommitted file edits yet. Edits from agent turns accumulate
+          here until they are committed.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/context-tab.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/context-tab.ts
@@ -5,6 +5,7 @@
  */
 export type ContextTabId =
   | "info"
+  | "edits"
   | "subagents"
   | "automations"
   | "prs"
@@ -13,6 +14,7 @@ export type ContextTabId =
 
 export const CONTEXT_TAB_IDS: ContextTabId[] = [
   "info",
+  "edits",
   "subagents",
   "automations",
   "prs",
@@ -27,4 +29,18 @@ export function isContextTabId(value: unknown): value is ContextTabId {
     typeof value === "string" &&
     (CONTEXT_TAB_IDS as string[]).includes(value)
   );
+}
+
+/**
+ * Where the accumulated edited-files list renders: above the composer
+ * (default LiveWorkRail placement) or only in the context-rail Edits
+ * panel. Persisted to `config.toml` `[ui] edited_files_dock`; lives
+ * here for the same dependency-light reason as `ContextTabId`.
+ */
+export type EditedFilesDock = "above" | "sidebar";
+
+export const DEFAULT_EDITED_FILES_DOCK: EditedFilesDock = "above";
+
+export function isEditedFilesDock(value: unknown): value is EditedFilesDock {
+  return value === "above" || value === "sidebar";
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/edited-file-groups.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/edited-file-groups.ts
@@ -298,11 +298,22 @@ export function summarizeEditedFileGroups(
   if (groups.length === 0) {
     return undefined;
   }
-  const flattened = flattenEditedFileGroups(groups);
-  const additions = groups.reduce((total, group) => total + group.additions, 0);
-  const removals = groups.reduce((total, group) => total + group.removals, 0);
+  // Count unique files via a key Set rather than `flattenEditedFileGroups`
+  // — the title only needs the file count + totals, and flattening would
+  // concatenate every group's diff text on each render (this runs in the
+  // LiveWorkRail body on every turn/diff/updated delta).
+  const fileKeys = new Set<string>();
+  let additions = 0;
+  let removals = 0;
+  for (const group of groups) {
+    additions += group.additions;
+    removals += group.removals;
+    for (const detail of group.details) {
+      fileKeys.add(detail.path ?? detail.id);
+    }
+  }
   const summary = formatChangedFileSummary({
-    count: flattened.length,
+    count: fileKeys.size,
     prefix: "Edited",
     additions,
     removals,

--- a/apps/desktop/src/renderer/src/features/thread-detail/edited-file-groups.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/edited-file-groups.ts
@@ -1,0 +1,311 @@
+import type {
+  AppServerThreadActivityDetail,
+  AppServerThreadActivityEntry,
+  AppServerThreadEntry,
+  AppServerThreadTurnMetadata,
+} from "@pwragent/shared";
+import { formatChangedFileSummary } from "./live-transcript-activity";
+
+/**
+ * One accumulated set of file edits, normally a single turn's worth.
+ * Groups build up across turns until a successful `git commit` lands;
+ * the committed groups stay visible until the NEXT turn starts, then
+ * drop (see `collectEditedFileGroups`).
+ */
+export type EditedFileGroup = {
+  /** Stable render key: the turn id, or a synthetic per-entry key. */
+  key: string;
+  turn?: AppServerThreadTurnMetadata;
+  /** Per-file details; every detail carries a `fileDiff`. */
+  details: AppServerThreadActivityDetail[];
+  /** "Edited N files, +A, -R" for this group. */
+  summary: string;
+  additions: number;
+  removals: number;
+  /** True when this group's turn also ran a successful `git commit`. */
+  committed: boolean;
+  /** True when this group is the in-flight turn's live cumulative diff. */
+  live: boolean;
+};
+
+/**
+ * Matches a `git … commit …` invocation at the start of a command or
+ * after a shell connector. Only option-shaped tokens may sit between
+ * `git` and `commit` (`-C <path>`, `-c key=val`, `--git-dir=…`) so
+ * commands that merely mention "commit" later don't false-positive.
+ */
+const GIT_COMMIT_COMMAND = /(?:^|[;&|]\s*)git\s+(?:-{1,2}[\w-]+(?:[= ]\S+)?\s+)*commit\b/;
+
+export function commandLooksLikeGitCommit(command: string): boolean {
+  return GIT_COMMIT_COMMAND.test(command);
+}
+
+function isSuccessfulGitCommitDetail(detail: AppServerThreadActivityDetail): boolean {
+  if (detail.kind !== "command" || !detail.command) {
+    return false;
+  }
+  const command = detail.command.displayCommand || detail.command.rawCommand;
+  if (!command || !commandLooksLikeGitCommit(command)) {
+    return false;
+  }
+  if (typeof detail.command.exitCode === "number") {
+    return detail.command.exitCode === 0;
+  }
+  return detail.status === "completed";
+}
+
+/**
+ * Live cumulative turn diffs (from `turn/diff/updated`) are built with
+ * this id prefix — see `buildPendingDiffEntry` in ThreadView. When a
+ * turn has one, it is authoritative for that turn (it already folds
+ * repeat edits of the same file together), so per-item file-change
+ * entries from the same turn are ignored to avoid double counting.
+ */
+const LIVE_CUMULATIVE_DIFF_ID_PREFIX = "live-diff-";
+
+type TurnBucket = {
+  key: string;
+  orderIndex: number;
+  turn?: AppServerThreadTurnMetadata;
+  detailsByKey: Map<string, AppServerThreadActivityDetail>;
+  cumulative?: AppServerThreadActivityEntry;
+  committed: boolean;
+  live: boolean;
+};
+
+function mergeFileDiffDetail(
+  existing: AppServerThreadActivityDetail | undefined,
+  detail: AppServerThreadActivityDetail,
+): AppServerThreadActivityDetail {
+  if (!existing?.fileDiff || !detail.fileDiff) {
+    return detail;
+  }
+
+  // A file added then updated within the window is still net-new; a
+  // delete wins outright (the stacked diff preserves the history).
+  const kind =
+    detail.fileDiff.kind === "delete"
+      ? "delete"
+      : existing.fileDiff.kind === "add"
+        ? "add"
+        : detail.fileDiff.kind;
+
+  return {
+    ...existing,
+    status: detail.status ?? existing.status,
+    label: kind === existing.fileDiff.kind ? existing.label : detail.label,
+    fileDiff: {
+      kind,
+      diff: `${existing.fileDiff.diff}\n${detail.fileDiff.diff}`,
+      additions: existing.fileDiff.additions + detail.fileDiff.additions,
+      removals: existing.fileDiff.removals + detail.fileDiff.removals,
+      ...(detail.fileDiff.omittedReason
+        ? { omittedReason: detail.fileDiff.omittedReason }
+        : {}),
+    },
+  };
+}
+
+/**
+ * Walk transcript entries (persisted replay + deferred live entries, in
+ * order) and build the accumulated edited-file groups:
+ *
+ * - Edits group per turn; turns accumulate while nothing is committed.
+ * - A successful `git commit` in turn C clears everything up to and
+ *   including C — but only once a LATER turn exists (committed work
+ *   stays on screen until the next turn starts).
+ * - `livePendingEntry` (the in-flight turn's cumulative diff) renders
+ *   as the newest group while a turn is streaming.
+ *
+ * Returns groups newest-first.
+ */
+export function collectEditedFileGroups(params: {
+  entries: readonly AppServerThreadEntry[];
+  activeTurnId?: string;
+  livePendingEntry?: AppServerThreadActivityEntry;
+}): EditedFileGroup[] {
+  const turnOrder: string[] = [];
+  const orderIndexByKey = new Map<string, number>();
+  const buckets = new Map<string, TurnBucket>();
+
+  const ensureTurnIndex = (key: string): number => {
+    let index = orderIndexByKey.get(key);
+    if (index === undefined) {
+      index = turnOrder.length;
+      turnOrder.push(key);
+      orderIndexByKey.set(key, index);
+    }
+    return index;
+  };
+
+  const ensureBucket = (
+    key: string,
+    turn: AppServerThreadTurnMetadata | undefined,
+  ): TurnBucket => {
+    const orderIndex = ensureTurnIndex(key);
+    let bucket = buckets.get(key);
+    if (!bucket) {
+      bucket = {
+        key,
+        orderIndex,
+        turn,
+        detailsByKey: new Map(),
+        committed: false,
+        live: false,
+      };
+      buckets.set(key, bucket);
+    } else if (!bucket.turn && turn) {
+      bucket.turn = turn;
+    }
+    return bucket;
+  };
+
+  for (const entry of params.entries) {
+    const turnKey = entry.turn?.id;
+    if (entry.type !== "activity") {
+      // Non-activity entries still advance the turn order — a turn
+      // that only produced messages still counts as "the next turn
+      // started" for the committed-group clearing rule.
+      if (turnKey) {
+        ensureTurnIndex(turnKey);
+      }
+      continue;
+    }
+
+    const hasFileDiff = entry.details.some((detail) => detail.fileDiff);
+    const hasCommit = entry.details.some(isSuccessfulGitCommitDetail);
+    if (!hasFileDiff && !hasCommit) {
+      if (turnKey) {
+        ensureTurnIndex(turnKey);
+      }
+      continue;
+    }
+
+    const key = turnKey ?? `entry:${entry.id}`;
+    const bucket = ensureBucket(key, entry.turn);
+    if (hasCommit) {
+      bucket.committed = true;
+    }
+    if (!hasFileDiff) {
+      continue;
+    }
+
+    if (entry.id.startsWith(LIVE_CUMULATIVE_DIFF_ID_PREFIX)) {
+      bucket.cumulative = entry;
+      continue;
+    }
+
+    for (const detail of entry.details) {
+      if (!detail.fileDiff) {
+        continue;
+      }
+      const detailKey = detail.path ?? detail.id;
+      bucket.detailsByKey.set(
+        detailKey,
+        mergeFileDiffDetail(bucket.detailsByKey.get(detailKey), detail),
+      );
+    }
+  }
+
+  if (params.livePendingEntry) {
+    const key =
+      params.livePendingEntry.turn?.id ?? params.activeTurnId ?? "live-turn";
+    const bucket = ensureBucket(key, params.livePendingEntry.turn);
+    bucket.cumulative = params.livePendingEntry;
+    bucket.live = true;
+  } else if (params.activeTurnId) {
+    // An active turn with no edits yet still counts as "started" so
+    // committed groups from prior turns clear immediately.
+    ensureTurnIndex(params.activeTurnId);
+  }
+
+  const lastTurnIndex = turnOrder.length - 1;
+  let clearThroughIndex = -1;
+  for (const bucket of buckets.values()) {
+    if (bucket.committed && bucket.orderIndex < lastTurnIndex) {
+      clearThroughIndex = Math.max(clearThroughIndex, bucket.orderIndex);
+    }
+  }
+
+  const groups: EditedFileGroup[] = [];
+  for (const bucket of [...buckets.values()].sort(
+    (left, right) => left.orderIndex - right.orderIndex,
+  )) {
+    if (bucket.orderIndex <= clearThroughIndex) {
+      continue;
+    }
+
+    const details = bucket.cumulative
+      ? bucket.cumulative.details.filter((detail) => detail.fileDiff)
+      : [...bucket.detailsByKey.values()];
+    if (details.length === 0) {
+      continue;
+    }
+
+    const additions = details.reduce(
+      (total, detail) => total + (detail.fileDiff?.additions ?? 0),
+      0,
+    );
+    const removals = details.reduce(
+      (total, detail) => total + (detail.fileDiff?.removals ?? 0),
+      0,
+    );
+    groups.push({
+      key: bucket.key,
+      turn: bucket.turn,
+      details,
+      summary: formatChangedFileSummary({
+        count: details.length,
+        prefix: "Edited",
+        additions,
+        removals,
+      }),
+      additions,
+      removals,
+      committed: bucket.committed,
+      live: bucket.live,
+    });
+  }
+
+  return groups.reverse();
+}
+
+/**
+ * Merge groups into a single per-file list ("current state" view).
+ * Groups are newest-first; merging walks oldest→newest so stacked
+ * diffs read chronologically. Returns files in first-edit order.
+ */
+export function flattenEditedFileGroups(
+  groups: readonly EditedFileGroup[],
+): AppServerThreadActivityDetail[] {
+  const detailsByKey = new Map<string, AppServerThreadActivityDetail>();
+  for (const group of [...groups].reverse()) {
+    for (const detail of group.details) {
+      const detailKey = detail.path ?? detail.id;
+      detailsByKey.set(
+        detailKey,
+        mergeFileDiffDetail(detailsByKey.get(detailKey), detail),
+      );
+    }
+  }
+  return [...detailsByKey.values()];
+}
+
+/** Combined rail-title summary across all groups. */
+export function summarizeEditedFileGroups(
+  groups: readonly EditedFileGroup[],
+): string | undefined {
+  if (groups.length === 0) {
+    return undefined;
+  }
+  const flattened = flattenEditedFileGroups(groups);
+  const additions = groups.reduce((total, group) => total + group.additions, 0);
+  const removals = groups.reduce((total, group) => total + group.removals, 0);
+  const summary = formatChangedFileSummary({
+    count: flattened.length,
+    prefix: "Edited",
+    additions,
+    removals,
+  });
+  return groups.length > 1 ? `${summary} · ${groups.length} turns` : summary;
+}

--- a/apps/desktop/src/renderer/src/icons/EditsIcon.tsx
+++ b/apps/desktop/src/renderer/src/icons/EditsIcon.tsx
@@ -1,0 +1,14 @@
+import { resolveIconSvgProps, type IconProps } from "./icon-types";
+
+/** Edited-files glyph: a document with +/- change marks. */
+export function EditsIcon(props: IconProps) {
+  return (
+    <svg {...resolveIconSvgProps(props)}>
+      <path d="M14 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8z" />
+      <path d="M14 3v5h5" />
+      <path d="M9.5 12.5h3" />
+      <path d="M11 11v3" />
+      <path d="M9.5 17h3" />
+    </svg>
+  );
+}

--- a/apps/desktop/src/renderer/src/icons/index.ts
+++ b/apps/desktop/src/renderer/src/icons/index.ts
@@ -6,6 +6,7 @@ export { CloseIcon } from "./CloseIcon";
 export { CopyIcon } from "./CopyIcon";
 export { DiscordIcon } from "./DiscordIcon";
 export { EditorIcon } from "./EditorIcon";
+export { EditsIcon } from "./EditsIcon";
 export { FeishuIcon } from "./FeishuIcon";
 export { FileCodeIcon } from "./FileCodeIcon";
 export { FolderIcon } from "./FolderIcon";

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -350,13 +350,15 @@ describe("Tangerine Terminal theme contract", () => {
     );
   });
 
-  it("keeps the above-docked live work rail inset to match the chat column", () => {
+  it("keeps the live work rail inset to match the chat column", () => {
     // The bar carries 16px side margins, so its width must leave room for
     // them (`100% - 32px`). A bare `100%` plus the margins overflows once the
     // chat column is narrower than --chat-column-max (sidebar + context rail
     // both open), ramming the bar flush against both edges while the
-    // composer/transcript stay inset.
-    const rule = extractRuleBody(css, ".live-work-rail--dock-above");
+    // composer/transcript stay inset. (The old in-transcript "sidebar" dock
+    // is gone — edited files dock to the context-rail Edits panel — so the
+    // inset contract now lives on the base .live-work-rail rule.)
+    const rule = extractRuleBody(css, ".live-work-rail");
     expect(rule).toContain("width: min(100% - 32px, var(--chat-column-max));");
     expect(rule).toContain("margin: 0 16px 8px;");
   });

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -8508,6 +8508,12 @@ textarea,
   text-transform: uppercase;
 }
 
+.edited-file-groups__group-tag--live {
+  border-color: var(--accent-border);
+  background: var(--accent-soft);
+  color: var(--accent-bright);
+}
+
 .edited-file-groups__group-time {
   flex: 0 0 auto;
   color: var(--text-muted);

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3372,6 +3372,26 @@ textarea,
   color: var(--text-secondary);
 }
 
+/* Local git working-state markers: uncommitted line counts (dirty tree)
+   and commits that exist on no remote. Quiet elevated-panel pills — the
+   colored +/- stats carry the signal, the chip chrome stays neutral. */
+.thread-row__chip--dirty,
+.thread-row__chip--unpushed {
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-panel-elevated);
+  color: var(--text-secondary);
+  gap: 4px;
+  font-variant-numeric: tabular-nums;
+}
+
+.thread-row__chip-stat--added {
+  color: var(--success-text);
+}
+
+.thread-row__chip-stat--removed {
+  color: var(--danger-text);
+}
+
 .thread-row__chip--mono,
 .context-grid__mono {
   font-family: "IBM Plex Mono", "JetBrains Mono", "SF Mono", ui-monospace, monospace;
@@ -8160,10 +8180,11 @@ textarea,
   color: inherit;
 }
 
-/* LiveWorkRail (issue #495) — sticky cumulative view of the active or
-   most-recently-completed turn's edited files + plan. Two dock modes:
-   "above" flows in the primary column between the transcript and the
-   composer; "sidebar" mounts as a third column at the layout level. */
+/* LiveWorkRail (issue #495) — sticky cumulative view of the active
+   turn's edited files + plan, flowing in the primary column between
+   the transcript and the composer. The old in-transcript "sidebar"
+   dock is gone: edited files dock to the context-rail Edits panel
+   instead (`ui.edited_files_dock`). */
 .live-work-rail {
   display: flex;
   flex-direction: column;
@@ -8173,9 +8194,6 @@ textarea,
   background: var(--bg-panel-elevated);
   color: var(--text-primary);
   font-size: 13px;
-}
-
-.live-work-rail--dock-above {
   /* Cap at the same width as the composer + transcript reading
      column (--chat-column-max) so the rail lines up visually with
      the composer's input. Issue #495 follow-up.
@@ -8192,14 +8210,6 @@ textarea,
      internally so a 50-file refactor doesn't push the composer off
      screen. */
   max-height: min(38vh, 360px);
-}
-
-.live-work-rail--dock-sidebar {
-  width: 320px;
-  flex: 0 0 320px;
-  margin: 12px 12px 12px 0;
-  border-radius: 8px;
-  max-height: none;
 }
 
 .live-work-rail--pinned {
@@ -8414,6 +8424,120 @@ textarea,
 
 .live-work-rail__file-diff {
   padding: 6px 6px 10px 18px;
+}
+
+/* Accumulated edited-file groups — one collapsible section per turn,
+   newest first, shared between the LiveWorkRail and the context-rail
+   Edits panel. File rows reuse the live-work-rail row primitives. */
+.edited-file-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.edited-file-groups__view-toggle {
+  display: inline-flex;
+  align-self: flex-start;
+  gap: 0;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.edited-file-groups__view-btn {
+  padding: 2px 8px;
+  border: 0;
+  background: var(--bg-input);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 11px;
+  letter-spacing: 0.02em;
+}
+
+.edited-file-groups__view-btn.is-active {
+  background: var(--bg-row-active);
+  color: var(--text-primary);
+}
+
+.edited-file-groups__group {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.edited-file-groups__group-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  padding: 4px 6px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  text-align: left;
+}
+
+.edited-file-groups__group-toggle:hover {
+  background: var(--bg-panel-hover);
+  color: var(--text-primary);
+}
+
+.edited-file-groups__group-summary {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+  flex: 1 1 auto;
+  font-weight: 600;
+}
+
+.edited-file-groups__group-tag {
+  flex: 0 0 auto;
+  padding: 0 6px;
+  border: 1px solid var(--success-border);
+  border-radius: 999px;
+  background: var(--success-soft);
+  color: var(--success-text);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.edited-file-groups__group-time {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+/* Context-rail Edits panel: section header carries the dock toggle so
+   "Only show here" / "Show above composer" sits next to the title. */
+.edits-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.edits-panel__dock-toggle {
+  flex: 0 0 auto;
+  padding: 2px 8px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 4px;
+  background: var(--bg-input);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 11px;
+}
+
+.edits-panel__dock-toggle:hover {
+  border-color: var(--accent-border);
+  color: var(--text-primary);
 }
 
 .transcript-activity {

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -98,6 +98,7 @@ describe("desktop settings contracts", () => {
         sidebarHidden: { value: false, source: "default" },
         contextRailPinned: { value: false, source: "default" },
         activeContextTab: { value: "info", source: "default" },
+        editedFilesDock: { value: "above", source: "default" },
       },
       messaging: {
         enabled: {

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -245,6 +245,26 @@ export type AppServerAcpSessionRuntimeState = {
   updatedAt?: number;
 };
 
+/**
+ * Snapshot of local git working-tree state for a thread's working
+ * directory: uncommitted change totals plus commits that exist on no
+ * remote ref. Computed by the thread directory enricher alongside
+ * `observedGitBranch`; absent when the directory is not a git checkout
+ * or the probe failed.
+ */
+export type ThreadGitWorkingState = {
+  /** Files with staged or unstaged modifications vs HEAD. */
+  dirtyFiles: number;
+  /** Added lines across staged + unstaged changes vs HEAD. */
+  dirtyAdditions: number;
+  /** Removed lines across staged + unstaged changes vs HEAD. */
+  dirtyDeletions: number;
+  /** Untracked files. */
+  untrackedFiles: number;
+  /** Local commits not present on any remote ref (0 when no remotes). */
+  unpushedCommits: number;
+};
+
 export type AppServerThreadSummary = {
   id: ThreadIdentifier;
   title: string;
@@ -258,6 +278,7 @@ export type AppServerThreadSummary = {
   gitBranch?: string;
   gitOriginUrl?: string;
   observedGitBranch?: string;
+  gitWorkingState?: ThreadGitWorkingState;
   source: AppServerBackendKind;
   executionMode?: ThreadExecutionMode;
   model?: string;

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -475,11 +475,15 @@ export type DesktopSettingsSnapshot = {
    * open, and which context-rail tab was last active. `activeContextTab`
    * is a plain string here; the renderer validates it against its known
    * tab ids and falls back to the default when unrecognized.
+   * `editedFilesDock` follows the same plain-string + renderer-validated
+   * pattern: "above" (default, edited files render above the composer)
+   * or "sidebar" (edited files only show in the context-rail Edits tab).
    */
   ui: {
     sidebarHidden: DesktopSettingsValue<boolean>;
     contextRailPinned: DesktopSettingsValue<boolean>;
     activeContextTab: DesktopSettingsValue<string>;
+    editedFilesDock: DesktopSettingsValue<string>;
   };
   messaging: {
     enabled: DesktopSettingsValue<boolean>;
@@ -677,6 +681,7 @@ export type DesktopSettingsConfigPatch = {
     sidebarHidden?: boolean;
     contextRailPinned?: boolean;
     activeContextTab?: string;
+    editedFilesDock?: string;
   };
   messaging?: {
     enabled?: boolean;


### PR DESCRIPTION
## Summary

- **Edits tab in the right context rail, replacing the in-transcript dock.** The LiveWorkRail's old "sidebar" dock carved a second 320px sidebar out of the transcript area. The rail's header button is now "Sidebar" (Move edited files to the sidebar Edits panel): it moves the list into a new context-rail **Edits** tab, activates the tab, and pins the rail so the move is visible. The panel offers the reverse ("Show above composer"), and the preference persists in `config.toml` as `[ui] edited_files_dock` (deleted on default, like `active_context_tab`). The Edits tab always renders the accumulated list; the dock pref only controls the above-composer copy.
- **Edited files accumulate per turn up to a commit, and rehydrate on thread load.** New pure accumulator (`edited-file-groups.ts`) walks transcript/replay entries and groups file diffs per turn. A successful `git commit` (matched from persisted command details — `git … commit` invocation with exit code 0, so `git log`-style mentions don't false-positive) keeps its groups visible **until the next turn starts**, then clears everything up to and including the commit turn; uncommitted turns A+B+C all stay listed. Because the replay already carries per-file diffs and command exit codes, the popup now rehydrates after a restart instead of coming back empty. Groups render newest-first with timestamps and a "Committed" tag, plus a **By turn / All files** toggle (flat view merges same-file edits with summed counts and stacked diffs). A turn's live cumulative diff is authoritative for that turn, so live + replay entries can't double-count.
- **Dirty-tree and unpushed-commit chips on thread rows.** The thread directory enricher additionally probes local git working state: `diff --numstat HEAD` (uncommitted +/- line counts), `status --porcelain` (untracked count), and `rev-list --count HEAD --not --remotes` (commits on no remote — covers new worktree branches with no upstream; reports 0 when the repo has no remotes). Probes run with `--no-optional-locks` so they never contend for the index lock with an agent's own git commands, and ride the existing 5s enrichment cache. Thread rows and headers render `+112 −3` (or `N new` for untracked-only) and `↑4` chips with tooltips; both can show at once. Data flows through the existing navigation snapshot — no new IPC.

## Verification

- `pnpm lint` (SQL, codex-storage, colors, licenses, full typecheck, dependency boundaries) passes.
- Full workspace unit suite: 3720 tests pass, including new suites for the accumulator (commit-boundary cases, live-diff dedupe, flatten/merge, failed-commit no-clear), the chips, the Edits panel, the `[ui]` config round-trip, and the enricher git probes.
- Targeted Playwright e2e in real Electron (live-work-rail collapse/expand/title + plan rendering): 7 passed.

## Notes

- **Intentional behavior change:** the rail no longer blanks when a new turn starts — prior uncommitted turns stay listed beneath the live turn's group. Two ThreadView tests asserting the old clear-on-new-turn behavior were reworked to assert accumulation; the theme-contract test pinning the rail's chat-column inset moved from `.live-work-rail--dock-above` to the base class in the same commit (the dock modifier classes are gone).
- In the rounds view the newest group expands by default and older groups start collapsed — easy to flip if the other default reads better.
- `gitWorkingState` is recomputed per navigation snapshot (5s TTL per directory), so chips track reality within a refresh cycle rather than live-watching the filesystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)