### PR TITLE
feat(desktop): search keyboard shortcuts, PR-number search, in-thread find

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -175,6 +175,9 @@ function DesktopAppShell(props: {
   const [mainView, setMainView] = useState<
     "thread" | "settings" | "automations" | "search"
   >("thread");
+  // In-thread find bar (⌘F) visibility, owned here so the find chord and the
+  // bar's own Escape share one source of truth.
+  const [threadFindOpen, setThreadFindOpen] = useState(false);
   // Initial section for SettingsScreen — non-undefined when navigation
   // came from a deep-link to a specific section. Resets when the user
   // switches mainView. The Messaging Activity surface is its own
@@ -377,7 +380,23 @@ function DesktopAppShell(props: {
   // thread-list quick search) is wired onto this same owner further below.
   useFindHotkeys({
     onOpenSearch: () => setMainView(mainView === "search" ? "thread" : "search"),
+    onFind: () => {
+      // The thread-list quick search (below) claims ⌘F while the sidebar is
+      // focused; anywhere else ⌘F finds within the open thread.
+      const active = document.activeElement as HTMLElement | null;
+      if (active?.closest(".sidebar")) {
+        return;
+      }
+      if (mainView === "thread") {
+        setThreadFindOpen(true);
+      }
+    },
   });
+  // The in-thread find bar is per-thread chrome: drop it when the operator
+  // leaves the thread view or switches to a different thread.
+  useEffect(() => {
+    setThreadFindOpen(false);
+  }, [mainView, navigation.selectedThreadKey]);
   const historyNav: HistoryNavControls = useMemo(
     () => ({
       canGoBack: history.canGoBack,
@@ -657,6 +676,8 @@ function DesktopAppShell(props: {
     onToggleSidebar: () => setSidebarHiddenPersisted(!sidebarHidden),
     mastheadActions,
     historyNav,
+    findOpen: threadFindOpen,
+    onFindOpenChange: setThreadFindOpen,
     onHandoffThreadWorkspace: navigation.selectedThread
       ? async (request) =>
           await navigation.handoffThreadWorkspace(

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -853,6 +853,7 @@ function DesktopAppShell(props: {
               masthead={mastheadActions}
               history={historyNav}
               state={threadSearchState}
+              threads={navigation.threads}
               onOpenResult={async (result) => {
                 setMainView("thread");
                 await navigation.showThread(result);

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -20,6 +20,7 @@ import {
 import { Sidebar } from "./features/navigation/Sidebar";
 import { AppTitleBar } from "./features/chrome/AppTitleBar";
 import type { HistoryNavControls } from "./features/chrome/HistoryNavButtons";
+import { useFindHotkeys } from "./features/chrome/useFindHotkeys";
 import { useHistoryNavHotkeys } from "./features/chrome/useHistoryNavHotkeys";
 import { useLayoutChordHotkeys } from "./features/chrome/useLayoutChordHotkeys";
 import type { SettingsSection } from "./features/settings/SettingsScreen";
@@ -372,6 +373,11 @@ function DesktopAppShell(props: {
     restore: restoreHistoryLocation,
   });
   useHistoryNavHotkeys({ onBack: history.goBack, onForward: history.goForward });
+  // ⌘⇧F / ⌃⇧F opens the global thread search screen. ⌘F (in-thread find /
+  // thread-list quick search) is wired onto this same owner further below.
+  useFindHotkeys({
+    onOpenSearch: () => setMainView(mainView === "search" ? "thread" : "search"),
+  });
   const historyNav: HistoryNavControls = useMemo(
     () => ({
       canGoBack: history.canGoBack,

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -178,6 +178,8 @@ function DesktopAppShell(props: {
   // In-thread find bar (⌘F) visibility, owned here so the find chord and the
   // bar's own Escape share one source of truth.
   const [threadFindOpen, setThreadFindOpen] = useState(false);
+  // Thread-list quick-jump popup (⌘F while the sidebar is focused).
+  const [sidebarSearchOpen, setSidebarSearchOpen] = useState(false);
   // Initial section for SettingsScreen — non-undefined when navigation
   // came from a deep-link to a specific section. Resets when the user
   // switches mainView. The Messaging Activity surface is its own
@@ -385,6 +387,7 @@ function DesktopAppShell(props: {
       // focused; anywhere else ⌘F finds within the open thread.
       const active = document.activeElement as HTMLElement | null;
       if (active?.closest(".sidebar")) {
+        setSidebarSearchOpen(true);
         return;
       }
       if (mainView === "thread") {
@@ -832,6 +835,13 @@ function DesktopAppShell(props: {
           onSelectThread={(thread) => {
             setMainView("thread");
             navigation.selectThread(thread);
+          }}
+          threadJumpOpen={sidebarSearchOpen}
+          onThreadJumpOpenChange={setSidebarSearchOpen}
+          onJumpToThread={(thread) => {
+            setMainView("thread");
+            navigation.selectThread(thread);
+            requestAnimationFrame(() => revealSelectedThreadInList());
           }}
           onArchiveThread={navigation.archiveThread}
           onRenameThread={navigation.renameThread}

--- a/apps/desktop/src/renderer/src/features/chrome/useFindHotkeys.ts
+++ b/apps/desktop/src/renderer/src/features/chrome/useFindHotkeys.ts
@@ -1,0 +1,49 @@
+import { useEffect, useRef } from "react";
+import { matchFindChord } from "../../lib/keyboard-accel";
+
+/**
+ * Single window-level owner for the find/search chords, mirroring
+ * {@link useLayoutChordHotkeys}:
+ *   ⌘F / ⌃F   → onFind        (context find; optional)
+ *   ⌘⇧F / ⌃⇧F → onOpenSearch  (open the global thread search screen)
+ *
+ * Call this exactly ONCE from the always-mounted shell owner. A ref keeps the
+ * handlers fresh so the listener binds once and never goes stale even though
+ * the callbacks close over fresh state each render.
+ *
+ * `onFind` is optional: when omitted, ⌘F is left untouched (no preventDefault)
+ * so the key isn't swallowed on surfaces that don't handle in-context find.
+ */
+export function useFindHotkeys(handlers: {
+  onOpenSearch: () => void;
+  onFind?: () => void;
+}): void {
+  const handlersRef = useRef(handlers);
+  useEffect(() => {
+    handlersRef.current = handlers;
+  });
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent): void => {
+      const chord = matchFindChord(event);
+      if (chord === null) {
+        return;
+      }
+      if (chord === "search") {
+        event.preventDefault();
+        handlersRef.current.onOpenSearch();
+        return;
+      }
+      const onFind = handlersRef.current.onFind;
+      if (!onFind) {
+        return;
+      }
+      event.preventDefault();
+      onFind();
+    };
+    window.addEventListener("keydown", handler);
+    return () => {
+      window.removeEventListener("keydown", handler);
+    };
+  }, []);
+}

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -39,6 +39,7 @@ import {
   runtimeGitRefCopyValue,
 } from "../../lib/runtime-identity";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
+import { formatPrimaryAccel } from "../../lib/keyboard-accel";
 import {
   formatRateLimitLine,
   selectVisibleRateLimits,
@@ -724,6 +725,7 @@ export function Sidebar(props: SidebarProps) {
         <div className="sidebar__masthead-actions">
           <MastheadActionButton
             ariaLabel="Search threads"
+            tooltipText={`Search threads  (${formatPrimaryAccel("F", { shift: true })})`}
             ariaPressed={props.threadSearchActive}
             className={`sidebar__icon-button${props.threadSearchActive ? " is-active" : ""}`}
             onClick={props.onOpenThreadSearch}
@@ -1478,9 +1480,12 @@ function MastheadActionButton(props: {
   children: ReactNode;
   className: string;
   disabled?: boolean;
+  /** Tooltip text; defaults to ariaLabel. Use to append a shortcut hint. */
+  tooltipText?: string;
   onClick?: () => void;
 }) {
   const tooltip = useViewportTooltip({ className: "viewport-tooltip" });
+  const tooltipLabel = props.tooltipText ?? props.ariaLabel;
 
   return (
     <>
@@ -1495,8 +1500,8 @@ function MastheadActionButton(props: {
           tooltip.hide();
           props.onClick?.();
         }}
-        onFocus={(event) => tooltip.show(event.currentTarget, props.ariaLabel)}
-        onMouseEnter={(event) => tooltip.show(event.currentTarget, props.ariaLabel)}
+        onFocus={(event) => tooltip.show(event.currentTarget, tooltipLabel)}
+        onMouseEnter={(event) => tooltip.show(event.currentTarget, tooltipLabel)}
         onMouseLeave={tooltip.hide}
       >
         {props.children}

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -40,6 +40,7 @@ import {
 } from "../../lib/runtime-identity";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import { formatPrimaryAccel } from "../../lib/keyboard-accel";
+import { SidebarSearchPopup } from "./SidebarSearchPopup";
 import {
   formatRateLimitLine,
   selectVisibleRateLimits,
@@ -96,6 +97,10 @@ type SidebarProps = {
   ) => Promise<void>;
   onOpenAutomations?: () => void;
   onOpenThreadSearch?: () => void;
+  /** Quick-jump popup (⌘F while the sidebar is focused), owned by App. */
+  threadJumpOpen?: boolean;
+  onThreadJumpOpenChange?: (open: boolean) => void;
+  onJumpToThread?: (thread: NavigationThreadSummary) => void;
   onOpenLaunchpad: (
     directory: NavigationDirectorySummary,
     preferredBackend?: AppServerBackendKind
@@ -699,6 +704,13 @@ export function Sidebar(props: SidebarProps) {
 
   return (
     <aside className="sidebar" aria-label="Threads">
+      {props.threadJumpOpen ? (
+        <SidebarSearchPopup
+          threads={props.threads}
+          onJumpToThread={props.onJumpToThread ?? props.onSelectThread}
+          onClose={() => props.onThreadJumpOpenChange?.(false)}
+        />
+      ) : null}
       <div
         aria-label="Resize thread sidebar"
         aria-orientation="vertical"

--- a/apps/desktop/src/renderer/src/features/navigation/SidebarSearchPopup.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/SidebarSearchPopup.tsx
@@ -1,0 +1,160 @@
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type ReactElement,
+} from "react";
+import {
+  buildThreadIdentityKey,
+  type NavigationThreadSummary,
+} from "@pwragent/shared";
+import { SearchIcon } from "../../icons";
+import { threadMatchesQuery } from "../thread-search/thread-match";
+
+const MAX_RESULTS = 8;
+
+type SidebarSearchPopupProps = {
+  threads: readonly NavigationThreadSummary[];
+  onJumpToThread: (thread: NavigationThreadSummary) => void;
+  onClose: () => void;
+};
+
+/**
+ * Quick-jump popup over the thread list (⌘F while the sidebar is focused).
+ * Filters the in-memory thread set by title, PR number, branch, and linked
+ * directory; ↑/↓ move the active row, Enter (or click) jumps, Escape closes.
+ */
+export function SidebarSearchPopup(props: SidebarSearchPopupProps): ReactElement {
+  const [query, setQuery] = useState("");
+  const [activeIndex, setActiveIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const results = useMemo(() => {
+    const trimmed = query.trim();
+    if (!trimmed) {
+      return [];
+    }
+    return props.threads
+      .filter((thread) => threadMatchesQuery(thread, trimmed))
+      .slice(0, MAX_RESULTS);
+  }, [query, props.threads]);
+
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [query]);
+
+  // Dismiss when focus or a click lands outside the popup.
+  useEffect(() => {
+    const onPointerDown = (event: PointerEvent): void => {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        props.onClose();
+      }
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    return () => document.removeEventListener("pointerdown", onPointerDown);
+  }, [props]);
+
+  const jump = (thread: NavigationThreadSummary): void => {
+    props.onJumpToThread(thread);
+    props.onClose();
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>): void => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      props.onClose();
+      return;
+    }
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setActiveIndex((index) => Math.min(index + 1, results.length - 1));
+      return;
+    }
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setActiveIndex((index) => Math.max(index - 1, 0));
+      return;
+    }
+    if (event.key === "Enter") {
+      event.preventDefault();
+      const thread = results[activeIndex];
+      if (thread) {
+        jump(thread);
+      }
+    }
+  };
+
+  const trimmed = query.trim();
+  return (
+    <div className="sidebar-search" ref={rootRef} role="dialog" aria-label="Jump to thread">
+      <div className="sidebar-search__field">
+        <span className="sidebar-search__icon" aria-hidden>
+          <SearchIcon size={14} />
+        </span>
+        <input
+          ref={inputRef}
+          className="sidebar-search__input"
+          aria-label="Jump to thread"
+          placeholder="Jump to thread, PR #, branch…"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          onKeyDown={handleKeyDown}
+        />
+      </div>
+      {trimmed ? (
+        results.length > 0 ? (
+          <ul className="sidebar-search__results" role="listbox">
+            {results.map((thread, index) => (
+              <li
+                key={buildThreadIdentityKey(thread.source, thread.id)}
+                role="option"
+                aria-selected={index === activeIndex}
+              >
+                <button
+                  type="button"
+                  className={`sidebar-search__result${
+                    index === activeIndex ? " is-active" : ""
+                  }`}
+                  onMouseEnter={() => setActiveIndex(index)}
+                  onClick={() => jump(thread)}
+                >
+                  <span className="sidebar-search__result-title">{thread.title}</span>
+                  {describeThread(thread) ? (
+                    <span className="sidebar-search__result-meta">
+                      {describeThread(thread)}
+                    </span>
+                  ) : null}
+                </button>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="sidebar-search__empty">No threads match</p>
+        )
+      ) : null}
+    </div>
+  );
+}
+
+function describeThread(thread: NavigationThreadSummary): string {
+  const parts: string[] = [];
+  const pr = (thread.prs ?? [])[0];
+  if (pr) {
+    parts.push(`#${pr.number}`);
+  }
+  if (thread.gitBranch) {
+    parts.push(thread.gitBranch);
+  }
+  const directory = (thread.linkedDirectories ?? [])[0];
+  if (directory?.label) {
+    parts.push(directory.label);
+  }
+  return parts.join(" · ");
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadFindBar.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadFindBar.tsx
@@ -1,0 +1,222 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type ReactElement,
+  type RefObject,
+} from "react";
+import { CloseIcon, SearchIcon } from "../../icons";
+
+const HIGHLIGHT_ALL = "thread-find";
+const HIGHLIGHT_ACTIVE = "thread-find-active";
+
+type ThreadFindBarProps = {
+  /** The element whose text content is searched (the transcript). */
+  containerRef: RefObject<HTMLElement | null>;
+  /**
+   * Re-run matching whenever this changes (thread switch, new messages), so
+   * highlights track live transcript content.
+   */
+  refreshKey?: unknown;
+  onClose: () => void;
+};
+
+/**
+ * Whether this renderer supports the CSS Custom Highlight API. We highlight
+ * matches with Ranges + `::highlight(...)` rather than mutating the
+ * React-rendered transcript DOM. Electron's Chromium supports it; the guard
+ * keeps the bar from throwing in any environment that doesn't.
+ */
+function highlightsSupported(): boolean {
+  return (
+    typeof CSS !== "undefined" &&
+    "highlights" in CSS &&
+    typeof Highlight !== "undefined"
+  );
+}
+
+function clearHighlights(): void {
+  if (!highlightsSupported()) {
+    return;
+  }
+  CSS.highlights.delete(HIGHLIGHT_ALL);
+  CSS.highlights.delete(HIGHLIGHT_ACTIVE);
+}
+
+function collectMatchRanges(container: HTMLElement, query: string): Range[] {
+  const needle = query.toLowerCase();
+  if (!needle) {
+    return [];
+  }
+  const ranges: Range[] = [];
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT, {
+    acceptNode(node) {
+      const value = node.nodeValue;
+      if (!value || !value.toLowerCase().includes(needle)) {
+        return NodeFilter.FILTER_REJECT;
+      }
+      const parent = node.parentElement;
+      if (parent && (parent.tagName === "SCRIPT" || parent.tagName === "STYLE")) {
+        return NodeFilter.FILTER_REJECT;
+      }
+      return NodeFilter.FILTER_ACCEPT;
+    },
+  });
+  let node = walker.nextNode();
+  while (node) {
+    const haystack = (node.nodeValue ?? "").toLowerCase();
+    let from = 0;
+    let index = haystack.indexOf(needle, from);
+    while (index !== -1) {
+      const range = document.createRange();
+      range.setStart(node, index);
+      range.setEnd(node, index + needle.length);
+      ranges.push(range);
+      from = index + needle.length;
+      index = haystack.indexOf(needle, from);
+    }
+    node = walker.nextNode();
+  }
+  return ranges;
+}
+
+export function ThreadFindBar(props: ThreadFindBarProps): ReactElement {
+  const [query, setQuery] = useState("");
+  const [matches, setMatches] = useState<Range[]>([]);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Focus + select on mount and whenever the bar is (re)opened.
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
+
+  // Recompute matches when the query or the underlying transcript changes.
+  useEffect(() => {
+    const container = props.containerRef.current;
+    if (!container || !highlightsSupported()) {
+      setMatches([]);
+      return;
+    }
+    const ranges = collectMatchRanges(container, query);
+    setMatches(ranges);
+    setActiveIndex((current) => (current < ranges.length ? current : 0));
+  }, [query, props.refreshKey, props.containerRef]);
+
+  // Paint the highlights and scroll the active match into view.
+  useEffect(() => {
+    if (!highlightsSupported()) {
+      return;
+    }
+    CSS.highlights.set(HIGHLIGHT_ALL, new Highlight(...matches));
+    const active = matches[activeIndex];
+    if (active) {
+      CSS.highlights.set(HIGHLIGHT_ACTIVE, new Highlight(active));
+      const anchor =
+        active.startContainer instanceof Element
+          ? active.startContainer
+          : active.startContainer.parentElement;
+      anchor?.scrollIntoView({ block: "center", behavior: "smooth" });
+    } else {
+      CSS.highlights.delete(HIGHLIGHT_ACTIVE);
+    }
+  }, [matches, activeIndex]);
+
+  // Drop highlights when the bar unmounts (closed).
+  useEffect(() => clearHighlights, []);
+
+  const step = useCallback(
+    (delta: number) => {
+      setActiveIndex((current) => {
+        if (matches.length === 0) {
+          return 0;
+        }
+        return (current + delta + matches.length) % matches.length;
+      });
+    },
+    [matches.length],
+  );
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>): void => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      props.onClose();
+      return;
+    }
+    if (event.key === "Enter") {
+      event.preventDefault();
+      step(event.shiftKey ? -1 : 1);
+    }
+  };
+
+  const count = matches.length;
+  const status = query === "" ? "" : count > 0 ? `${activeIndex + 1} of ${count}` : "No matches";
+
+  return (
+    <div className="thread-find" role="search" aria-label="Find in thread">
+      <span className="thread-find__icon" aria-hidden>
+        <SearchIcon size={14} />
+      </span>
+      <input
+        ref={inputRef}
+        className="thread-find__input"
+        aria-label="Find in thread"
+        placeholder="Find in thread"
+        value={query}
+        onChange={(event) => setQuery(event.target.value)}
+        onKeyDown={handleKeyDown}
+      />
+      <span className="thread-find__count" aria-live="polite">
+        {status}
+      </span>
+      <button
+        className="thread-find__nav"
+        type="button"
+        aria-label="Previous match"
+        disabled={count === 0}
+        onClick={() => step(-1)}
+      >
+        <ChevronGlyph direction="up" />
+      </button>
+      <button
+        className="thread-find__nav"
+        type="button"
+        aria-label="Next match"
+        disabled={count === 0}
+        onClick={() => step(1)}
+      >
+        <ChevronGlyph direction="down" />
+      </button>
+      <button
+        className="thread-find__close"
+        type="button"
+        aria-label="Close find"
+        onClick={props.onClose}
+      >
+        <CloseIcon size={14} aria-hidden />
+      </button>
+    </div>
+  );
+}
+
+function ChevronGlyph(props: { direction: "up" | "down" }): ReactElement {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      focusable="false"
+    >
+      {props.direction === "up" ? <path d="m6 14 6-6 6 6" /> : <path d="m6 10 6 6 6-6" />}
+    </svg>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -57,6 +57,7 @@ import {
 } from "./context-panels/context-tab";
 import type { HistoryNavControls } from "../chrome/HistoryNavButtons";
 import type { MastheadActionsProps } from "../chrome/MastheadActions";
+import { ThreadFindBar } from "./ThreadFindBar";
 import { ThreadHeader } from "./ThreadHeader";
 import { ThreadPlaceholderHeader } from "./ThreadPlaceholderHeader";
 import { TranscriptImageLightbox } from "./TranscriptImageLightbox";
@@ -898,6 +899,9 @@ export type ThreadViewProps = {
    * Owned by App's useNavigationHistory.
    */
   historyNav?: HistoryNavControls;
+  /** In-thread find bar (⌘F): open state + close callback, owned by App. */
+  findOpen?: boolean;
+  onFindOpenChange?: (open: boolean) => void;
   onLoadOlder: () => Promise<void>;
   onArchiveThread?: (thread: NavigationThreadSummary) => Promise<void>;
   onRefreshNavigation?: () => Promise<void>;
@@ -1047,6 +1051,8 @@ export function ThreadView(props: ThreadViewProps) {
   const onContextRailPinnedChange = props.onContextRailPinnedChange ?? noop;
   const onActiveContextTabChange = props.onActiveContextTabChange ?? noop;
   const onToggleSidebar = props.onToggleSidebar ?? noop;
+  // Transcript element the in-thread find bar (⌘F) searches + highlights.
+  const transcriptPanelRef = useRef<HTMLElement>(null);
 
   useEffect(() => {
     setPendingActivityEntry(undefined);
@@ -2255,7 +2261,19 @@ export function ThreadView(props: ThreadViewProps) {
             />
           ) : null}
 
-          <section className="transcript-panel" aria-label="Transcript">
+          {props.findOpen ? (
+            <ThreadFindBar
+              containerRef={transcriptPanelRef}
+              refreshKey={`${selectedThread!.source}:${selectedThread!.id}:${props.transcriptEntries.length}`}
+              onClose={() => props.onFindOpenChange?.(false)}
+            />
+          ) : null}
+
+          <section
+            className="transcript-panel"
+            aria-label="Transcript"
+            ref={transcriptPanelRef}
+          >
             <TranscriptList
               entries={props.transcriptEntries}
               permissionTransitions={selectedThread!.permissionTransitionLog}

--- a/apps/desktop/src/renderer/src/features/thread-search/ThreadSearchPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-search/ThreadSearchPanel.tsx
@@ -8,6 +8,7 @@ import {
 import type {
   AppServerBackendKind,
   MessagingChannelKind,
+  NavigationThreadSummary,
   ThreadSearchConfidenceBand,
   ThreadSearchMatchReasonKind,
   ThreadSearchResponse,
@@ -17,6 +18,7 @@ import type { DesktopApi } from "../../lib/desktop-api";
 import type { HistoryNavControls } from "../chrome/HistoryNavButtons";
 import type { MastheadActionsProps } from "../chrome/MastheadActions";
 import { ThreadPlaceholderHeader } from "../thread-detail/ThreadPlaceholderHeader";
+import { mergePrNumberMatches } from "./thread-match";
 import { BranchIcon, FolderIcon, SearchIcon, WorktreeIcon } from "../../icons";
 
 /**
@@ -65,6 +67,12 @@ type ThreadSearchPanelProps = {
   /** Back/Forward pair for the title bar, forwarded to the header. */
   history?: HistoryNavControls;
   /**
+   * The full navigation thread list, used to resolve bare PR-number queries
+   * ("#779" / "779") against persisted overlay PRs — those aren't in the FTS
+   * index, so the matches are merged in client-side.
+   */
+  threads?: readonly NavigationThreadSummary[];
+  /**
    * Lifted query/results state (see {@link useThreadSearchPanelState}).
    * Optional so the component still renders self-contained in unit tests;
    * App supplies it so results survive opening a result.
@@ -82,6 +90,7 @@ const MATCH_REASON_LABELS: Record<ThreadSearchMatchReasonKind, string> = {
   branch_match: "Branch match",
   backend_match: "Backend match",
   model_match: "Model match",
+  pr_number_match: "PR match",
   time_filter: "Recent",
   archive_filter: "Archived",
   provider_content_match: "Message content",
@@ -230,13 +239,12 @@ export function ThreadSearchPanel(props: ThreadSearchPanelProps) {
     setLoading(true);
     setError(undefined);
     try {
-      setResponse(
-        await props.desktopApi.searchThreads({
-          contentMode: "available",
-          limit: 25,
-          query: trimmed,
-        }),
-      );
+      const result = await props.desktopApi.searchThreads({
+        contentMode: "available",
+        limit: 25,
+        query: trimmed,
+      });
+      setResponse(mergePrNumberMatches(result, trimmed, props.threads));
     } catch (searchError) {
       setError(searchError instanceof Error ? searchError.message : String(searchError));
     } finally {

--- a/apps/desktop/src/renderer/src/features/thread-search/__tests__/thread-match.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-search/__tests__/thread-match.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import type {
+  NavigationThreadSummary,
+  PrSummary,
+  ThreadSearchResponse,
+  ThreadSearchResult,
+} from "@pwragent/shared";
+import {
+  mergePrNumberMatches,
+  parsePrNumberQuery,
+  threadMatchesQuery,
+  threadsByPrNumber,
+} from "../thread-match";
+
+function pr(number: number, title?: string): PrSummary {
+  return {
+    provider: "github.com",
+    number,
+    org: "pwrdrvr",
+    repo: "PwrAgent",
+    state: "pending",
+    url: `https://github.com/pwrdrvr/PwrAgent/pull/${number}`,
+    ...(title ? { title } : {}),
+  };
+}
+
+function thread(partial: Partial<NavigationThreadSummary>): NavigationThreadSummary {
+  return {
+    source: "codex",
+    id: "t1",
+    title: "Untitled",
+    linkedDirectories: [],
+    ...partial,
+  } as NavigationThreadSummary;
+}
+
+function response(results: ThreadSearchResult[] = []): ThreadSearchResponse {
+  return {
+    backend: "all",
+    fetchedAt: 0,
+    query: "",
+    filters: {},
+    contentMode: "available",
+    semanticMode: "disabled",
+    results,
+    searchedScopes: [],
+    unavailableScopes: [],
+  };
+}
+
+describe("parsePrNumberQuery", () => {
+  it("parses bare and #-prefixed numbers, trimming whitespace", () => {
+    expect(parsePrNumberQuery("779")).toBe(779);
+    expect(parsePrNumberQuery("#779")).toBe(779);
+    expect(parsePrNumberQuery("  #779  ")).toBe(779);
+  });
+
+  it("rejects anything that isn't a bare PR number", () => {
+    expect(parsePrNumberQuery("fix 779")).toBeNull();
+    expect(parsePrNumberQuery("messaging")).toBeNull();
+    expect(parsePrNumberQuery("#0")).toBeNull();
+    expect(parsePrNumberQuery("")).toBeNull();
+    expect(parsePrNumberQuery("12345678")).toBeNull();
+  });
+});
+
+describe("threadsByPrNumber", () => {
+  it("finds threads whose persisted PRs include the number", () => {
+    const a = thread({ id: "a", prs: [pr(779)] });
+    const b = thread({ id: "b", prs: [pr(12)] });
+    const c = thread({ id: "c" });
+    expect(threadsByPrNumber([a, b, c], 779)).toEqual([a]);
+  });
+});
+
+describe("mergePrNumberMatches", () => {
+  it("prepends a PR match for a bare PR-number query", () => {
+    const t = thread({ id: "a", prs: [pr(779, "Fix the thing")] });
+    const merged = mergePrNumberMatches(response(), "#779", [t]);
+    expect(merged.results).toHaveLength(1);
+    expect(merged.results[0].threadId).toBe("a");
+    expect(merged.results[0].matchReasons[0]?.kind).toBe("pr_number_match");
+    expect(merged.results[0].confidence).toBe("high");
+  });
+
+  it("returns the response untouched for non-PR queries", () => {
+    const t = thread({ id: "a", prs: [pr(779)] });
+    const base = response();
+    expect(mergePrNumberMatches(base, "hello", [t])).toBe(base);
+  });
+
+  it("does not duplicate a thread already present in the backend results", () => {
+    const t = thread({ id: "a", source: "codex", prs: [pr(779)] });
+    const existing: ThreadSearchResult = {
+      backend: "codex",
+      threadId: "a",
+      identityKey: "codex:a",
+      title: "Already here",
+      linkedDirectories: [],
+      source: "codex",
+      score: 0,
+      confidence: "medium",
+      matchReasons: [{ kind: "summary_match" }],
+      snippets: [],
+    };
+    const merged = mergePrNumberMatches(response([existing]), "779", [t]);
+    expect(merged.results).toHaveLength(1);
+    expect(merged.results[0]).toBe(existing);
+  });
+});
+
+describe("threadMatchesQuery", () => {
+  const t = thread({
+    title: "Messaging bug",
+    gitBranch: "fix/messaging",
+    prs: [pr(779)],
+    linkedDirectories: [{ id: "d", label: "PwrAgent", path: "/x", kind: "local" }],
+  });
+
+  it("matches title, branch, PR number (with or without #), and directory", () => {
+    expect(threadMatchesQuery(t, "messaging")).toBe(true);
+    expect(threadMatchesQuery(t, "fix/")).toBe(true);
+    expect(threadMatchesQuery(t, "779")).toBe(true);
+    expect(threadMatchesQuery(t, "#779")).toBe(true);
+    expect(threadMatchesQuery(t, "pwragent")).toBe(true);
+  });
+
+  it("returns false for non-matches and empty queries", () => {
+    expect(threadMatchesQuery(t, "zzz")).toBe(false);
+    expect(threadMatchesQuery(t, "   ")).toBe(false);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-search/thread-match.ts
+++ b/apps/desktop/src/renderer/src/features/thread-search/thread-match.ts
@@ -1,0 +1,118 @@
+import {
+  buildThreadIdentityKey,
+  type NavigationThreadSummary,
+  type ThreadSearchResponse,
+  type ThreadSearchResult,
+} from "@pwragent/shared";
+
+/**
+ * Parse a "bare PR number" query — "779" or "#779" — into its number, or
+ * `null` when the query is anything else. Bounded to 7 digits so a long digit
+ * run isn't mistaken for a PR.
+ */
+export function parsePrNumberQuery(query: string): number | null {
+  const match = query.trim().match(/^#?(\d{1,7})$/);
+  if (!match) {
+    return null;
+  }
+  const value = Number(match[1]);
+  return Number.isInteger(value) && value > 0 ? value : null;
+}
+
+function threadPrNumbers(thread: NavigationThreadSummary): number[] {
+  return (thread.prs ?? []).map((pr) => pr.number);
+}
+
+/** Threads linked to the given PR number (via persisted overlay PRs). */
+export function threadsByPrNumber(
+  threads: readonly NavigationThreadSummary[],
+  prNumber: number,
+): NavigationThreadSummary[] {
+  return threads.filter((thread) => threadPrNumbers(thread).includes(prNumber));
+}
+
+/** Synthesize a search result for a PR-number hit on a navigation thread. */
+export function prMatchToSearchResult(
+  thread: NavigationThreadSummary,
+  prNumber: number,
+): ThreadSearchResult {
+  const pr = (thread.prs ?? []).find((entry) => entry.number === prNumber);
+  return {
+    backend: thread.source,
+    threadId: thread.id,
+    identityKey: buildThreadIdentityKey(thread.source, thread.id),
+    title: thread.title,
+    ...(thread.projectKey ? { projectKey: thread.projectKey } : {}),
+    linkedDirectories: thread.linkedDirectories ?? [],
+    source: thread.source,
+    ...(thread.gitBranch ? { gitBranch: thread.gitBranch } : {}),
+    ...(thread.model ? { model: thread.model } : {}),
+    score: 1,
+    confidence: "high",
+    matchReasons: [{ kind: "pr_number_match", value: `#${prNumber}` }],
+    snippets: pr?.title
+      ? [
+          {
+            scope: "metadata",
+            field: "pr",
+            text: `${pr.org}/${pr.repo} #${pr.number} — ${pr.title}`,
+          },
+        ]
+      : [],
+  };
+}
+
+/**
+ * When `query` is a bare PR number, prepend its linked threads (deduped
+ * against the backend hits) to a search response — so "#779" / "779" finds
+ * the right thread even though PR numbers aren't in the FTS index.
+ */
+export function mergePrNumberMatches(
+  response: ThreadSearchResponse,
+  query: string,
+  threads: readonly NavigationThreadSummary[] | undefined,
+): ThreadSearchResponse {
+  const prNumber = parsePrNumberQuery(query);
+  if (prNumber === null || !threads) {
+    return response;
+  }
+  const seen = new Set(response.results.map((result) => result.identityKey));
+  const prResults = threadsByPrNumber(threads, prNumber)
+    .map((thread) => prMatchToSearchResult(thread, prNumber))
+    .filter((result) => !seen.has(result.identityKey));
+  if (prResults.length === 0) {
+    return response;
+  }
+  return { ...response, results: [...prResults, ...response.results] };
+}
+
+/**
+ * Client-side relevance test for the thread-list quick search: matches title,
+ * linked PR number, git branch, and linked-directory label. PR numbers match
+ * with or without the leading "#".
+ */
+export function threadMatchesQuery(
+  thread: NavigationThreadSummary,
+  query: string,
+): boolean {
+  const needle = query.trim().toLowerCase();
+  if (!needle) {
+    return false;
+  }
+  if (thread.title.toLowerCase().includes(needle)) {
+    return true;
+  }
+  if ((thread.gitBranch ?? "").toLowerCase().includes(needle)) {
+    return true;
+  }
+  const bareNeedle = needle.replace(/^#/, "");
+  if (
+    bareNeedle.length > 0 &&
+    threadPrNumbers(thread).some((number) => String(number).includes(bareNeedle))
+  ) {
+    return true;
+  }
+  return (thread.linkedDirectories ?? []).some((directory) =>
+    (directory.label ?? "").toLowerCase().includes(needle),
+  );
+}

--- a/apps/desktop/src/renderer/src/lib/keyboard-accel.ts
+++ b/apps/desktop/src/renderer/src/lib/keyboard-accel.ts
@@ -118,24 +118,52 @@ export function matchHistoryNavChord(
 }
 
 /**
+ * Classify a keydown as a find/search chord, or `null`:
+ *   ⌘F / ⌃F   → "find"   (context find — in-thread find when a thread is open,
+ *                          or the thread-list quick-search when the sidebar is
+ *                          focused; the caller resolves which from focus)
+ *   ⌘⇧F / ⌃⇧F → "search" (open the global thread search screen)
+ *
+ * Unlike {@link matchLayoutChord}, find stays live inside editable fields —
+ * ⌘F is a universal "find" gesture that should fire even while the caret is in
+ * the composer or another input. ⌥ is excluded so it never collides with an
+ * Option chord.
+ */
+export function matchFindChord(event: KeyboardEvent): "find" | "search" | null {
+  if (!isPrimaryAccel(event)) {
+    return null;
+  }
+  if (event.altKey) {
+    return null;
+  }
+  if (!isAccelLetter(event, "f")) {
+    return null;
+  }
+  return event.shiftKey ? "search" : "find";
+}
+
+/**
  * Render the display label for a primary-accelerator chord, adjusted for
- * the current platform: ⌘/⌥ glyphs on macOS, "Ctrl"/"Alt" words joined
- * with "+" on Windows/Linux. This is presentation only — {@link
+ * the current platform: ⌘/⌥/⇧ glyphs on macOS, "Ctrl"/"Alt"/"Shift" words
+ * joined with "+" on Windows/Linux. This is presentation only — {@link
  * isPrimaryAccel} accepts either Cmd or Ctrl at runtime, so the binding
  * works regardless of which label we show. Falls back to the Windows/Linux
  * form when the platform is unknown (the desktop bridge is unavailable).
  */
 export function formatPrimaryAccel(
   key: string,
-  options: { alt?: boolean } = {},
+  options: { alt?: boolean; shift?: boolean } = {},
 ): string {
   const isMac = getDesktopApi()?.platform === "darwin";
   if (isMac) {
-    return `⌘${options.alt ? "⌥" : ""}${key}`;
+    return `⌘${options.alt ? "⌥" : ""}${options.shift ? "⇧" : ""}${key}`;
   }
   const parts = ["Ctrl"];
   if (options.alt) {
     parts.push("Alt");
+  }
+  if (options.shift) {
+    parts.push("Shift");
   }
   parts.push(key);
   return parts.join("+");

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -7108,6 +7108,8 @@ textarea,
 }
 
 .thread-view__primary {
+  /* Positioning context for the absolutely-placed in-thread find bar (⌘F). */
+  position: relative;
   display: flex;
   flex: 1;
   flex-direction: column;
@@ -7119,6 +7121,91 @@ textarea,
   gap: 0;
   min-width: 0;
   min-height: 0;
+}
+
+/* In-thread find (⌘F). Matches are painted with the CSS Custom Highlight API
+   (Range-based) so the React-rendered transcript DOM is never mutated. */
+::highlight(thread-find) {
+  background-color: var(--accent-soft);
+  color: var(--accent-bright);
+}
+
+::highlight(thread-find-active) {
+  background-color: var(--accent);
+  color: var(--button-text);
+}
+
+.thread-find {
+  position: absolute;
+  z-index: 30;
+  top: 10px;
+  right: 18px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 6px 5px 10px;
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  background: var(--bg-panel-elevated);
+  box-shadow: var(--shadow-popover);
+}
+
+.thread-find__icon {
+  display: inline-flex;
+  color: var(--text-muted);
+}
+
+.thread-find__input {
+  width: 200px;
+  min-width: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  outline: none;
+}
+
+.thread-find__input::placeholder {
+  color: var(--text-muted);
+}
+
+.thread-find__count {
+  min-width: 62px;
+  color: var(--text-muted);
+  font-size: 12px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.thread-find__nav,
+.thread-find__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.thread-find__nav:hover:not(:disabled),
+.thread-find__close:hover {
+  background: var(--bg-panel-hover);
+  color: var(--text-primary);
+}
+
+.thread-find__nav:focus-visible,
+.thread-find__close:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 1px;
+}
+
+.thread-find__nav:disabled {
+  opacity: 0.4;
+  cursor: default;
 }
 
 /* The right-rail context panel still reads as a card. */

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -753,6 +753,105 @@ textarea,
   border-right: 1px solid var(--border-subtle);
 }
 
+/* Thread-list quick-jump popup (⌘F while the sidebar is focused). Floats below
+   the masthead, over the thread list. */
+.sidebar-search {
+  position: absolute;
+  z-index: 40;
+  top: 52px;
+  left: 10px;
+  right: 10px;
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100% - 64px);
+  overflow: hidden;
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  background: var(--bg-panel-elevated);
+  box-shadow: var(--shadow-popover);
+}
+
+.sidebar-search__field {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.sidebar-search__icon {
+  display: inline-flex;
+  color: var(--text-muted);
+}
+
+.sidebar-search__input {
+  flex: 1;
+  min-width: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  outline: none;
+}
+
+.sidebar-search__input::placeholder {
+  color: var(--text-muted);
+}
+
+.sidebar-search__results {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin: 0;
+  padding: 4px;
+  overflow-y: auto;
+  list-style: none;
+}
+
+.sidebar-search__result {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  width: 100%;
+  padding: 6px 8px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.sidebar-search__result.is-active {
+  background: var(--bg-row-active);
+}
+
+.sidebar-search__result-title {
+  overflow: hidden;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sidebar-search__result-meta {
+  overflow: hidden;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-muted);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sidebar-search__empty {
+  margin: 0;
+  padding: 12px;
+  color: var(--text-muted);
+  font-size: 12px;
+  text-align: center;
+}
+
 .sidebar__resize-handle,
 .context-rail__resize-handle {
   position: absolute;

--- a/packages/shared/src/contracts/thread-search.ts
+++ b/packages/shared/src/contracts/thread-search.ts
@@ -55,6 +55,7 @@ export const THREAD_SEARCH_MATCH_REASON_KINDS = [
   "branch_match",
   "backend_match",
   "model_match",
+  "pr_number_match",
   "time_filter",
   "archive_filter",
   "provider_content_match",


### PR DESCRIPTION
## Summary

Four search/keyboard improvements, built in focused commits:

- **`Cmd+Shift+F` opens the global thread search** (Ctrl+Shift+F elsewhere). New `matchFindChord` + a single-owner `useFindHotkeys` hook mirroring `useLayoutChordHotkeys`. The sidebar Search button's tooltip now shows the shortcut ("Search threads (⌘⇧F)").
- **PR-number search in the search screen.** Typing `779` or `#779` surfaces the thread linked to PR #779. PR numbers aren't in the FTS index, but the navigation snapshot already carries persisted overlay PRs on `thread.prs` (full parity with the backend), so a bare PR-number query is resolved client-side and prepended (deduped) to the backend results as a HIGH-confidence `pr_number_match`. No FTS schema change.
- **`Cmd+F` in-thread find bar.** A thread-scoped find bar over the transcript using the **CSS Custom Highlight API** (Range-based `::highlight(...)`, no DOM mutation). Shows "n of m", Enter / Shift+Enter (and ↑/↓) cycle matches and scroll the active one into view, Escape closes.
- **`Cmd+F` quick-jump popup when the sidebar is focused.** Filters the in-memory thread list by title / PR# / branch / directory (shared `threadMatchesQuery`); ↑/↓ + Enter jump to the thread and scroll its row into view.

`Cmd+F` is focus-routed in App: sidebar focused → quick-jump popup; otherwise → in-thread find. `Cmd+Shift+F` is always the global search.

## Verification

- `pnpm --filter @pwragent/desktop typecheck` ✅, `pnpm lint:boundaries` ✅, `pnpm lint:colors` ✅.
- New `thread-match` unit tests ✅ (8: `parsePrNumberQuery`, `threadsByPrNumber`, `mergePrNumberMatches` prepend/dedupe/passthrough, `threadMatchesQuery`).
- Drove a headed build and confirmed all four live: `Cmd+Shift+F` opens search + the shortcut tooltip; searching `235` returns the linked thread as a HIGH "PR match" above the FTS hits; `Cmd+F` in a thread highlighted matches ("1 of 46", tangerine matches + accent-filled active, Enter cycles); `Cmd+F` in the sidebar opened the popup, filtered by PR number, and ArrowDown+Enter jumped to the thread and revealed its row.

## Notes

- **Design choice:** PR-number search is resolved client-side rather than via an FTS schema migration — the renderer already has the same persisted PR data the backend overlay holds, so this is the right-sized, migration-free path. A `pr_number_match` reason kind was added to the shared contract (labelled "PR match").
- **In-thread find** searches the *loaded* transcript only (paged-out history isn't in the DOM, same as a browser find). Matches are painted via the CSS Custom Highlight API (supported in Electron's Chromium).
- Branched off `origin/main`; independent of the search-polish PR #762 (already merged into main).