### PR TITLE
chore(desktop): quiet per-thread routing log during content search

### DIFF
--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -5205,12 +5205,18 @@ export class DesktopBackendRegistry {
 
     const replay =
       backend === "codex"
-        ? await this.withCodexThreadClient(request.threadId, async (client) =>
-            await client.readThread({
-              threadId: request.threadId,
-              before: request.before,
-              limit: request.limit,
-            }),
+        ? await this.withCodexThreadClient(
+            request.threadId,
+            async (client) =>
+              await client.readThread({
+                threadId: request.threadId,
+                before: request.before,
+                limit: request.limit,
+              }),
+            // Reads are execution-mode-agnostic; skip the routing diagnostic so
+            // content search (one readThread per thread) doesn't spew it.
+            undefined,
+            false,
           )
         : await this.grokClient.readThread({
             threadId: request.threadId,
@@ -10051,6 +10057,12 @@ export class DesktopBackendRegistry {
     threadId: string,
     operation: (client: BackendClient, mode: ThreadExecutionMode) => Promise<T>,
     requestedMode?: ThreadExecutionMode,
+    // Whether to emit the routing diagnostic. Reads (readThread) are
+    // execution-mode-agnostic and get called once per thread by content
+    // search, so they opt out — otherwise a single thread search spews one
+    // routing line per thread. Turn/execution paths keep it on (the #203
+    // security cross-check in messaging-controller relies on it).
+    logRouting = true,
   ): Promise<T> {
     // Single-client passthrough. The mode passed to the operation is no
     // longer a routing decision — it's documentation for callers that
@@ -10075,12 +10087,14 @@ export class DesktopBackendRegistry {
         source = "default-fallback";
       }
     }
-    backendRegistryLog.debug("codex thread client routing", {
-      threadId,
-      requestedMode,
-      resolvedMode: mode,
-      source,
-    });
+    if (logRouting) {
+      backendRegistryLog.debug("codex thread client routing", {
+        threadId,
+        requestedMode,
+        resolvedMode: mode,
+        source,
+      });
+    }
     return await operation(this.codexClient, mode);
   }
 


### PR DESCRIPTION
## Summary

A `Cmd+Shift+F` thread search runs with `contentMode: "available"`, which reads **every** thread's transcript via `readThread` to match message content. The per-thread `withCodexThreadClient` helper emitted a `codex thread client routing …` debug line for each read, so a single search produced ~one line per thread (50+ lines) — noisy when debug log collection is on.

Reads are execution-mode-agnostic (the resolved mode doesn't affect a read), so `readThread` now opts out of the routing diagnostic via a new `logRouting` flag on `withCodexThreadClient` (default `true`). **Turn/execution paths keep logging it** — the messaging-controller's #203 security cross-check (verifying a turn routed to the intended sandbox mode) relies on that line.

The companion `codexDirectorySourceReconcile:completed … callerReason=thread-search` summary line is unchanged (it fires at most once per search).

## Verification

- `pnpm --filter @pwragent/desktop typecheck` ✅. No tests reference the routing log.
- Headed dev build: a startup `readThread` (the same gated path the content search uses) now emits **zero** `codex thread client routing` lines — it logged one before. The search path reads threads via the identical helper, so the per-thread burst is gone.

## Notes

- Log-level only; no behavior change to routing or search results.
- Pre-existing on `main`; independent of the search-shortcuts work in #786 (a `Cmd+Shift+F` search just made the noise easy to notice).
- A separate, larger opportunity (not in this PR): a content-mode search re-reads every thread's transcript on each run — worth caching/scoping if it becomes a perf concern.