### PR TITLE
feat(desktop): annotate edited-file groups with git commit/push state

### DIFF
--- a/apps/desktop/src/main/__tests__/git-working-state-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-working-state-service.test.ts
@@ -133,3 +133,64 @@ describe("GitWorkingStateService", () => {
     expect(seen.get("/repo/one")).toMatchObject({ dirtyFiles: 2 });
   });
 });
+
+describe("GitWorkingStateService.resolveEditCommitStates", () => {
+  function respondCommitStates(args: string[]): string | undefined {
+    if (args.includes("diff") && args.includes("--name-only")) {
+      return "src/a.ts\n"; // a.ts still has uncommitted changes
+    }
+    if (args.includes("ls-files")) {
+      return ""; // nothing untracked
+    }
+    if (args.includes("log")) {
+      const paths = args.slice(args.indexOf("--") + 1);
+      if (paths.some((p) => p.endsWith("/src/b.ts"))) return `${"b".repeat(40)}\n`;
+      if (paths.some((p) => p.endsWith("/src/c.ts"))) return `${"c".repeat(40)}\n`;
+      return "";
+    }
+    if (args.includes("rev-list")) {
+      const sha = args[args.indexOf("rev-list") + 2];
+      // c-commit is local-only (rev-list returns it); b-commit is pushed (empty).
+      return sha?.startsWith("c") ? sha : "";
+    }
+    return undefined;
+  }
+
+  it("classifies groups as uncommitted vs committed with sha + push state", async () => {
+    const { runGit, calls } = fakeGit(respondCommitStates);
+    const service = new GitWorkingStateService({ runGit });
+
+    const states = await service.resolveEditCommitStates("/repo/wt", [
+      { key: "g-a", paths: ["/repo/wt/src/a.ts"] },
+      { key: "g-b", paths: ["/repo/wt/src/b.ts"] },
+      { key: "g-c", paths: ["/repo/wt/src/c.ts"] },
+    ]);
+
+    expect(states["g-a"]).toEqual({ committed: false });
+    expect(states["g-b"]).toEqual({
+      committed: true,
+      commitSha: "b".repeat(40),
+      shortSha: "bbbbbbb",
+      pushed: true,
+    });
+    expect(states["g-c"]).toEqual({
+      committed: true,
+      commitSha: "c".repeat(40),
+      shortSha: "ccccccc",
+      pushed: false,
+    });
+    // Every probe is lock-safe.
+    for (const call of calls) {
+      expect(call.args[0]).toBe("--no-optional-locks");
+    }
+  });
+
+  it("returns an empty map for no worktree or no groups", async () => {
+    const { runGit, calls } = fakeGit(respondCommitStates);
+    const service = new GitWorkingStateService({ runGit });
+
+    expect(await service.resolveEditCommitStates("", [{ key: "g", paths: ["/x"] }])).toEqual({});
+    expect(await service.resolveEditCommitStates("/repo/wt", [])).toEqual({});
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -57,6 +57,8 @@ import {
   type LatestCodexConfigWarningResponse,
   type ListBackendsRequest,
   type ListBackendsResponse,
+  type EditGroupCommitInput,
+  type EditGroupCommitState,
   type LinkedDirectorySummary,
   type MaterializeDirectoryLaunchpadRequest,
   type MaterializeDirectoryLaunchpadOptions,
@@ -5209,6 +5211,16 @@ export class DesktopBackendRegistry {
 
   invalidateWorktreeWorkingState(worktreePath?: string): void {
     this.gitWorkingStateService.invalidate(worktreePath);
+  }
+
+  async resolveEditCommitStates(
+    worktreePath: string,
+    groups: EditGroupCommitInput[],
+  ): Promise<Record<string, EditGroupCommitState>> {
+    return await this.gitWorkingStateService.resolveEditCommitStates(
+      worktreePath,
+      groups,
+    );
   }
 
   async readThread(

--- a/apps/desktop/src/main/app-server/git-working-state-service.ts
+++ b/apps/desktop/src/main/app-server/git-working-state-service.ts
@@ -1,6 +1,15 @@
+import path from "node:path";
 import { IterableMapper } from "@shutterstock/p-map-iterable";
-import type { ThreadGitWorkingState } from "@pwragent/shared";
+import type {
+  EditGroupCommitInput,
+  EditGroupCommitState,
+  ThreadGitWorkingState,
+} from "@pwragent/shared";
 import { runGitCommand } from "./git-executable";
+
+function normalizeAbsolutePath(value: string): string {
+  return path.resolve(value).replace(/\\/g, "/");
+}
 
 type GitCommandRunner = (
   cwd: string,
@@ -205,5 +214,95 @@ export class GitWorkingStateService {
       return;
     }
     this.cache.delete(key);
+  }
+
+  /**
+   * Resolve the git commit lifecycle of a thread's edited-file groups against
+   * the live worktree. For each group: it's `committed` when none of its files
+   * still differ from HEAD or sit untracked; if committed, `git log` gives the
+   * most recent commit touching those files, and a remote-reachability check
+   * marks it pushed vs local-only. Read-only and lock-safe. Git itself
+   * normalizes the (absolute) paths, so callers don't path-match.
+   */
+  async resolveEditCommitStates(
+    worktreePath: string,
+    groups: EditGroupCommitInput[],
+  ): Promise<Record<string, EditGroupCommitState>> {
+    const cwd = worktreePath?.trim();
+    const states: Record<string, EditGroupCommitState> = {};
+    if (!cwd || groups.length === 0) {
+      return states;
+    }
+
+    const gitEnv = this.gitEnv;
+    const noLocks = (args: string[]): Promise<string> =>
+      this.runGit(cwd, ["--no-optional-locks", ...args], gitEnv);
+
+    // The set of files that still have working-tree changes (tracked diffs vs
+    // HEAD + untracked). Clean newline-separated relative paths — easier to
+    // parse than `status --porcelain` status codes / rename arrows.
+    const [diffOutput, untrackedOutput] = await Promise.all([
+      noLocks(["diff", "--name-only", "HEAD"]).catch(() => ""),
+      noLocks(["ls-files", "--others", "--exclude-standard"]).catch(() => ""),
+    ]);
+    const dirtyPaths = new Set<string>();
+    for (const line of `${diffOutput}\n${untrackedOutput}`.split("\n")) {
+      const relative = line.trim();
+      if (relative) {
+        dirtyPaths.add(normalizeAbsolutePath(path.resolve(cwd, relative)));
+      }
+    }
+
+    const pushedBySha = new Map<string, boolean>();
+    for (const group of groups) {
+      const paths = [
+        ...new Set(group.paths.map((value) => value.trim()).filter(Boolean)),
+      ];
+      if (paths.length === 0) {
+        states[group.key] = { committed: false };
+        continue;
+      }
+
+      const committed = paths.every(
+        (value) => !dirtyPaths.has(normalizeAbsolutePath(value)),
+      );
+      if (!committed) {
+        states[group.key] = { committed: false };
+        continue;
+      }
+
+      const sha = (
+        await noLocks(["log", "-1", "--format=%H", "--", ...paths]).catch(
+          () => "",
+        )
+      ).trim();
+      if (!sha) {
+        states[group.key] = { committed: true };
+        continue;
+      }
+
+      let pushed = pushedBySha.get(sha);
+      if (pushed === undefined) {
+        // `rev-list -1 <sha> --not --remotes` lists sha only when it (or its
+        // tip) isn't reachable from any remote ref. Empty ⇒ pushed. With no
+        // remotes configured, nothing is excluded ⇒ non-empty ⇒ local-only.
+        const localOnly = (
+          await noLocks(["rev-list", "-1", sha, "--not", "--remotes"]).catch(
+            () => "",
+          )
+        ).trim();
+        pushed = localOnly === "";
+        pushedBySha.set(sha, pushed);
+      }
+
+      states[group.key] = {
+        committed: true,
+        commitSha: sha,
+        shortSha: sha.slice(0, 7),
+        pushed,
+      };
+    }
+
+    return states;
   }
 }

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -83,6 +83,8 @@ import {
   type RenameThreadResponse,
   type RestoreWorktreeRequest,
   type RestoreWorktreeResponse,
+  type ResolveEditCommitStatesRequest,
+  type ResolveEditCommitStatesResponse,
   type RestoreThreadRequest,
   type RestoreThreadResponse,
   type ThreadGitWorkingState,
@@ -124,6 +126,7 @@ import {
   FOCUSED_DIFF_ANALYZE_CHANNEL,
   NAVIGATION_GET_GH_STATUS_CHANNEL,
   NAVIGATION_REFRESH_DIRECTORY_GIT_STATUSES_CHANNEL,
+  NAVIGATION_RESOLVE_EDIT_COMMIT_STATES_CHANNEL,
   NAVIGATION_REFRESH_THREAD_PRS_CHANNEL,
   NAVIGATION_REORDER_DIRECTORY_PINS_CHANNEL,
   NAVIGATION_REORDER_THREAD_PINS_CHANNEL,
@@ -931,6 +934,16 @@ class DesktopAppServerService {
       unchanged:
         snapshot.unchanged && directoriesUnchanged && !canonicalSnapshot.changed,
     };
+  }
+
+  async resolveEditCommitStates(
+    request: ResolveEditCommitStatesRequest,
+  ): Promise<ResolveEditCommitStatesResponse> {
+    const states = await getDesktopBackendRegistry().resolveEditCommitStates(
+      request.worktreePath,
+      request.groups,
+    );
+    return { states };
   }
 
   private collectThreadWorktreePaths(
@@ -2830,6 +2843,16 @@ export function registerAppServerIpcHandlers(): void {
       return await appServerService.refreshDirectoryGitStatusesForKeys(request);
     },
   );
+  ipcMain.removeHandler(NAVIGATION_RESOLVE_EDIT_COMMIT_STATES_CHANNEL);
+  ipcMain.handle(
+    NAVIGATION_RESOLVE_EDIT_COMMIT_STATES_CHANNEL,
+    async (
+      _event,
+      request: ResolveEditCommitStatesRequest,
+    ): Promise<ResolveEditCommitStatesResponse> => {
+      return await appServerService.resolveEditCommitStates(request);
+    },
+  );
   ipcMain.removeHandler(NAVIGATION_GET_GH_STATUS_CHANNEL);
   ipcMain.handle(
     NAVIGATION_GET_GH_STATUS_CHANNEL,
@@ -2916,6 +2939,7 @@ export async function disposeAppServerIpcHandlers(): Promise<void> {
   ipcMain.removeHandler(NAVIGATION_SET_THREAD_AGENT_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_REFRESH_DIRECTORY_GIT_STATUSES_CHANNEL);
+  ipcMain.removeHandler(NAVIGATION_RESOLVE_EDIT_COMMIT_STATES_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_GET_GH_STATUS_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_ENSURE_DIRECTORY_LAUNCHPAD_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_UPDATE_DIRECTORY_LAUNCHPAD_CHANNEL);

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -115,6 +115,8 @@ import type {
   RefreshThreadPullRequestsResponse,
   RefreshDirectoryGitStatusesRequest,
   RefreshDirectoryGitStatusesResponse,
+  ResolveEditCommitStatesRequest,
+  ResolveEditCommitStatesResponse,
   NavigationSnapshot,
   ResetDirectoryLaunchpadRequest,
   ResetDirectoryLaunchpadResponse,
@@ -300,6 +302,7 @@ import {
   NAVIGATION_PICK_DIRECTORY_FROM_DISK_CHANNEL,
   NAVIGATION_REFRESH_THREAD_PRS_CHANNEL,
   NAVIGATION_REFRESH_DIRECTORY_GIT_STATUSES_CHANNEL,
+  NAVIGATION_RESOLVE_EDIT_COMMIT_STATES_CHANNEL,
   NAVIGATION_REORDER_DIRECTORY_PINS_CHANNEL,
   NAVIGATION_REORDER_THREAD_PINS_CHANNEL,
   NAVIGATION_REGISTER_DIRECTORY_FROM_DISK_CHANNEL,
@@ -840,6 +843,13 @@ const desktopApi = Object.freeze({
   ): Promise<RefreshDirectoryGitStatusesResponse> =>
     await ipcRenderer.invoke(
       NAVIGATION_REFRESH_DIRECTORY_GIT_STATUSES_CHANNEL,
+      request,
+    ),
+  resolveEditCommitStates: async (
+    request: ResolveEditCommitStatesRequest,
+  ): Promise<ResolveEditCommitStatesResponse> =>
+    await ipcRenderer.invoke(
+      NAVIGATION_RESOLVE_EDIT_COMMIT_STATES_CHANNEL,
       request,
     ),
   getGhStatus: async (request?: GetGhStatusRequest): Promise<GhStatus> =>

--- a/apps/desktop/src/renderer/src/features/thread-detail/DiffStat.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/DiffStat.tsx
@@ -1,0 +1,24 @@
+/**
+ * Added/removed line counts rendered consistently everywhere: `+A` (green)
+ * then `-R` (red), no comma, monospace — matching the thread-row dirty chip.
+ * Pass `className="diff-stat--chip"` for the pill treatment.
+ */
+export function DiffStat(props: {
+  additions: number;
+  removals: number;
+  className?: string;
+}) {
+  return (
+    <span
+      className={`diff-stat${props.className ? ` ${props.className}` : ""}`}
+      aria-label={`+${props.additions.toLocaleString()} -${props.removals.toLocaleString()}`}
+    >
+      <span className="diff-stat__added">
+        +{props.additions.toLocaleString()}
+      </span>
+      <span className="diff-stat__removed">
+        -{props.removals.toLocaleString()}
+      </span>
+    </span>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/EditGroupCommitBadge.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/EditGroupCommitBadge.tsx
@@ -1,0 +1,69 @@
+import { useState } from "react";
+import type { EditGroupCommitState } from "@pwragent/shared";
+import { copyText } from "../../lib/copy-text";
+
+/**
+ * Git lifecycle badge for an accumulated edited-file group: uncommitted
+ * (the "unread"/active state) → committed, with a copyable short-SHA chip and
+ * a pushed/local indicator. Renders nothing until the commit state resolves,
+ * so a freshly committed group doesn't flash "uncommitted" first.
+ */
+export function EditGroupCommitBadge(props: { state?: EditGroupCommitState }) {
+  const { state } = props;
+  if (!state) {
+    return null;
+  }
+
+  if (!state.committed) {
+    return (
+      <span className="edit-commit-badge edit-commit-badge--uncommitted">
+        Uncommitted
+      </span>
+    );
+  }
+
+  return (
+    <span className="edit-commit-badge edit-commit-badge--committed">
+      <span className="edit-commit-badge__label">Committed</span>
+      {state.commitSha && state.shortSha ? (
+        <CommitShaChip sha={state.commitSha} shortSha={state.shortSha} />
+      ) : null}
+      {state.pushed === undefined ? null : (
+        <span
+          className={`edit-commit-badge__push edit-commit-badge__push--${
+            state.pushed ? "pushed" : "local"
+          }`}
+        >
+          {state.pushed ? "Pushed" : "Local"}
+        </span>
+      )}
+    </span>
+  );
+}
+
+function CommitShaChip(props: { sha: string; shortSha: string }) {
+  const [copied, setCopied] = useState(false);
+
+  return (
+    <button
+      type="button"
+      className="edit-commit-badge__sha"
+      title={`Copy commit ${props.sha}`}
+      aria-label={`Copy commit ${props.sha}`}
+      onClick={(event) => {
+        // The badge sits beside (not inside) the group toggle, but stop
+        // propagation anyway so a future wrapping handler can't swallow it.
+        event.stopPropagation();
+        void copyText(props.sha).then(() => {
+          setCopied(true);
+          window.setTimeout(() => setCopied(false), 1200);
+        });
+      }}
+    >
+      <code className="edit-commit-badge__sha-value">{props.shortSha}</code>
+      <span className="edit-commit-badge__sha-action" aria-hidden="true">
+        {copied ? "Copied" : "Copy"}
+      </span>
+    </button>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
@@ -1,6 +1,10 @@
 import { useId, useState } from "react";
-import type { AppServerThreadActivityDetail } from "@pwragent/shared";
+import type {
+  AppServerThreadActivityDetail,
+  EditGroupCommitState,
+} from "@pwragent/shared";
 import { TranscriptDiff } from "./TranscriptDiff";
+import { EditGroupCommitBadge } from "./EditGroupCommitBadge";
 import {
   flattenEditedFileGroups,
   type EditedFileGroup,
@@ -11,6 +15,8 @@ export type EditedFileGroupView = "turns" | "files";
 type EditedFileGroupListProps = {
   /** Newest-first, from `collectEditedFileGroups`. */
   groups: EditedFileGroup[];
+  /** Git commit lifecycle per group key, from `useEditCommitStates`. */
+  commitStatesByKey?: Record<string, EditGroupCommitState>;
 };
 
 const groupTimeFormatter = new Intl.DateTimeFormat(undefined, {
@@ -85,6 +91,7 @@ export function EditedFileGroupList(props: EditedFileGroupListProps) {
                 <EditedFileGroupSection
                   key={group.key}
                   group={group}
+                  commitState={props.commitStatesByKey?.[group.key]}
                   defaultExpanded={index === 0}
                 />
               ))}
@@ -117,6 +124,7 @@ function formatGroupTimestamp(group: EditedFileGroup): string | undefined {
 
 function EditedFileGroupSection(props: {
   group: EditedFileGroup;
+  commitState?: EditGroupCommitState;
   defaultExpanded: boolean;
 }) {
   const [expanded, setExpanded] = useState(props.defaultExpanded);
@@ -125,29 +133,30 @@ function EditedFileGroupSection(props: {
 
   return (
     <section className="edited-file-groups__group">
-      <button
-        type="button"
-        className="edited-file-groups__group-toggle"
-        aria-controls={bodyId}
-        aria-expanded={expanded}
-        onClick={() => setExpanded((current) => !current)}
-      >
-        <span className="live-work-rail__chevron" aria-hidden="true" />
-        <span className="edited-file-groups__group-summary">
-          {props.group.summary}
-        </span>
+      <div className="edited-file-groups__group-header">
+        <button
+          type="button"
+          className="edited-file-groups__group-toggle"
+          aria-controls={bodyId}
+          aria-expanded={expanded}
+          onClick={() => setExpanded((current) => !current)}
+        >
+          <span className="live-work-rail__chevron" aria-hidden="true" />
+          <span className="edited-file-groups__group-summary">
+            {props.group.summary}
+          </span>
+        </button>
         {props.group.live ? (
           <span className="edited-file-groups__group-tag edited-file-groups__group-tag--live">
             This turn
           </span>
-        ) : null}
-        {props.group.committed ? (
-          <span className="edited-file-groups__group-tag">Committed</span>
-        ) : null}
+        ) : (
+          <EditGroupCommitBadge state={props.commitState} />
+        )}
         {timestamp ? (
           <span className="edited-file-groups__group-time">{timestamp}</span>
         ) : null}
-      </button>
+      </div>
       <div id={bodyId} hidden={!expanded}>
         {expanded ? <EditedFileList details={props.group.details} /> : null}
       </div>

--- a/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
@@ -146,16 +146,18 @@ function EditedFileGroupSection(props: {
             {props.group.summary}
           </span>
         </button>
-        {props.group.live ? (
-          <span className="edited-file-groups__group-tag edited-file-groups__group-tag--live">
-            This turn
-          </span>
-        ) : (
-          <EditGroupCommitBadge state={props.commitState} />
-        )}
-        {timestamp ? (
-          <span className="edited-file-groups__group-time">{timestamp}</span>
-        ) : null}
+        <div className="edited-file-groups__group-meta">
+          {props.group.live ? (
+            <span className="edited-file-groups__group-tag edited-file-groups__group-tag--live">
+              This turn
+            </span>
+          ) : (
+            <EditGroupCommitBadge state={props.commitState} />
+          )}
+          {timestamp ? (
+            <span className="edited-file-groups__group-time">{timestamp}</span>
+          ) : null}
+        </div>
       </div>
       <div id={bodyId} hidden={!expanded}>
         {expanded ? <EditedFileList details={props.group.details} /> : null}

--- a/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
@@ -4,6 +4,7 @@ import type {
   EditGroupCommitState,
 } from "@pwragent/shared";
 import { TranscriptDiff } from "./TranscriptDiff";
+import { DiffStat } from "./DiffStat";
 import { EditGroupCommitBadge } from "./EditGroupCommitBadge";
 import {
   flattenEditedFileGroups,
@@ -145,6 +146,11 @@ function EditedFileGroupSection(props: {
           <span className="edited-file-groups__group-summary">
             {props.group.summary}
           </span>
+          <DiffStat
+            additions={props.group.additions}
+            removals={props.group.removals}
+            className="diff-stat--chip"
+          />
         </button>
         <div className="edited-file-groups__group-meta">
           {props.group.live ? (
@@ -201,14 +207,7 @@ export function EditedFileRow(props: {
         <span className="live-work-rail__file-path" title={props.detail.path}>
           {props.detail.label}
         </span>
-        <span className="live-work-rail__file-stats" aria-label="File diff summary">
-          <span className="live-work-rail__file-stat live-work-rail__file-stat--removed">
-            -{removals.toLocaleString()}
-          </span>
-          <span className="live-work-rail__file-stat live-work-rail__file-stat--added">
-            +{additions.toLocaleString()}
-          </span>
-        </span>
+        <DiffStat additions={additions} removals={removals} />
       </button>
       {/* Diff container stays in the DOM (with `hidden`) so the
           row's `aria-controls={diffId}` always resolves. The

--- a/apps/desktop/src/renderer/src/features/thread-detail/LiveWorkRail.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/LiveWorkRail.tsx
@@ -3,6 +3,7 @@ import type {
   AppServerThreadActivityEntry,
   AppServerThreadPlanEntry,
   DesktopApplicationsSnapshot,
+  EditGroupCommitState,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { TranscriptPlan } from "./TranscriptPlan";
@@ -28,6 +29,8 @@ export type LiveWorkRailProps = {
    * user docks edited files to the context-rail Edits panel.
    */
   editedFileGroups?: EditedFileGroup[];
+  /** Git commit lifecycle per group key, from `useEditCommitStates`. */
+  editedFileCommitStates?: Record<string, EditGroupCommitState>;
   /**
    * `true` when the rail is showing snapshots from a completed turn
    * (pinned until the next turn starts). `false` while the live turn
@@ -117,7 +120,10 @@ export function LiveWorkRail(props: LiveWorkRailProps) {
 
         {editedSummary ? (
           <section className="live-work-rail__section live-work-rail__section--edited">
-            <EditedFileGroupList groups={editedFileGroups} />
+            <EditedFileGroupList
+              groups={editedFileGroups}
+              commitStatesByKey={props.editedFileCommitStates}
+            />
           </section>
         ) : null}
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -11,7 +11,11 @@ import {
   type PointerEvent,
 } from "react";
 import { createPortal } from "react-dom";
-import type { BackendSummary, NavigationThreadSummary } from "@pwragent/shared";
+import type {
+  BackendSummary,
+  EditGroupCommitState,
+  NavigationThreadSummary,
+} from "@pwragent/shared";
 import type { WindowPointerSnapshot } from "../../../../shared/window-pointer";
 import {
   AutomationsIcon,
@@ -94,6 +98,7 @@ type ThreadContextPanelProps = {
   onActiveTabChange: (tab: ContextTabId) => void;
   /** Accumulated edited-file groups for the Edits tab (newest first). */
   editedFileGroups?: EditedFileGroup[];
+  editedFileCommitStates?: Record<string, EditGroupCommitState>;
   editedFilesDock?: EditedFilesDock;
   onEditedFilesDockChange?: (dock: EditedFilesDock) => void;
 };
@@ -595,6 +600,7 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
         return (
           <EditsPanel
             groups={props.editedFileGroups ?? []}
+            commitStatesByKey={props.editedFileCommitStates}
             dock={props.editedFilesDock ?? "above"}
             onDockChange={props.onEditedFilesDockChange ?? noop}
           />

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -58,6 +58,7 @@ import {
   type EditedFilesDock,
 } from "./context-panels/context-tab";
 import { collectEditedFileGroups } from "./edited-file-groups";
+import { useEditCommitStates } from "./useEditCommitStates";
 import type { HistoryNavControls } from "../chrome/HistoryNavButtons";
 import type { MastheadActionsProps } from "../chrome/MastheadActions";
 import { ThreadFindBar } from "./ThreadFindBar";
@@ -1535,6 +1536,16 @@ export function ThreadView(props: ThreadViewProps) {
     [props.transcriptEntries, props.activeTurnId, pendingRailActivityEntry],
   );
 
+  // Git commit lifecycle per group, resolved against the live worktree.
+  // Re-resolves when the thread's working state shifts (a commit/push), so the
+  // per-group badges stay accurate without re-reading the transcript.
+  const editedFileCommitStates = useEditCommitStates({
+    desktopApi: props.desktopApi,
+    worktreePath: selectedThread?.projectKey,
+    groups: editedFileGroups,
+    refreshKey: JSON.stringify(selectedThread?.gitWorkingState ?? null),
+  });
+
   const moveEditedFilesToSidebar = useCallback(() => {
     onEditedFilesDockChange("sidebar");
     onActiveContextTabChange("edits");
@@ -2384,6 +2395,7 @@ export function ThreadView(props: ThreadViewProps) {
             editedFileGroups={
               editedFilesDock === "above" ? editedFileGroups : undefined
             }
+            editedFileCommitStates={editedFileCommitStates}
             pinned={!props.activeTurnId}
             planEntry={
               pendingPlanEntry ??
@@ -2456,6 +2468,7 @@ export function ThreadView(props: ThreadViewProps) {
           backends={props.backends}
           desktopApi={props.desktopApi}
           editedFileGroups={editedFileGroups}
+          editedFileCommitStates={editedFileCommitStates}
           editedFilesDock={editedFilesDock}
           onEditedFilesDockChange={onEditedFilesDockChange}
           onActiveTabChange={onActiveContextTabChange}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/DiffStat.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/DiffStat.test.tsx
@@ -1,0 +1,32 @@
+import "@testing-library/jest-dom/vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { DiffStat } from "../DiffStat";
+
+afterEach(cleanup);
+
+describe("DiffStat", () => {
+  it("renders +additions before -removals with no comma", () => {
+    const { container } = render(<DiffStat additions={244} removals={3} />);
+    const stat = container.querySelector(".diff-stat")!;
+
+    expect(stat.textContent).toBe("+244-3");
+    const children = [...stat.children];
+    expect(children[0]).toHaveClass("diff-stat__added");
+    expect(children[0]).toHaveTextContent("+244");
+    expect(children[1]).toHaveClass("diff-stat__removed");
+    expect(children[1]).toHaveTextContent("-3");
+  });
+
+  it("locale-formats large counts", () => {
+    const { container } = render(<DiffStat additions={1234} removals={0} />);
+    expect(container.querySelector(".diff-stat__added")).toHaveTextContent("+1,234");
+  });
+
+  it("applies the chip modifier when requested", () => {
+    const { container } = render(
+      <DiffStat additions={1} removals={0} className="diff-stat--chip" />,
+    );
+    expect(container.querySelector(".diff-stat")).toHaveClass("diff-stat--chip");
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/EditedFileGroupList.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/EditedFileGroupList.test.tsx
@@ -22,7 +22,6 @@ function group(n: number): EditedFileGroup {
     summary: `Edited turn ${n}`,
     additions: 1,
     removals: 0,
-    committed: false,
     live: false,
   };
 }
@@ -60,6 +59,50 @@ describe("EditedFileGroupList Show more / Show less", () => {
 
     expect(screen.getByText("Edited turn 1")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Show \d+ more/ })).not.toBeInTheDocument();
+  });
+
+  it("renders the git commit badge per group from the resolved states", () => {
+    render(
+      <EditedFileGroupList
+        groups={groups(2)}
+        commitStatesByKey={{
+          "turn-2": { committed: false },
+          "turn-1": {
+            committed: true,
+            commitSha: "a".repeat(40),
+            shortSha: "aaaaaaa",
+            pushed: true,
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Uncommitted")).toBeInTheDocument();
+    expect(screen.getByText("aaaaaaa")).toBeInTheDocument();
+    expect(screen.getByText("Pushed")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: `Copy commit ${"a".repeat(40)}` }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows a local-only badge for an unpushed commit", () => {
+    render(
+      <EditedFileGroupList
+        groups={groups(2)}
+        commitStatesByKey={{
+          "turn-1": {
+            committed: true,
+            commitSha: "f".repeat(40),
+            shortSha: "fffffff",
+            pushed: false,
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Local")).toBeInTheDocument();
+    // turn-2 has no resolved state yet → no badge (avoids a wrong flash).
+    expect(screen.queryByText("Uncommitted")).not.toBeInTheDocument();
   });
 
   it("does not show the turn toggle in the All files view", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/edited-file-groups.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/edited-file-groups.test.ts
@@ -7,7 +7,7 @@ import type {
 import {
   MAX_RETAINED_TURN_GROUPS,
   collectEditedFileGroups,
-  commandLooksLikeGitCommit,
+  editGroupPaths,
   flattenEditedFileGroups,
   summarizeEditedFileGroups,
 } from "../edited-file-groups";
@@ -50,46 +50,21 @@ function activityEntry(params: {
   };
 }
 
-function commitDetail(params?: {
-  command?: string;
-  exitCode?: number;
-  status?: "completed" | "failed";
-}): AppServerThreadActivityDetail {
-  detailCounter += 1;
-  return {
-    id: `commit-${detailCounter}`,
-    kind: "command",
-    label: "git commit",
-    status: params?.status ?? "completed",
-    command: {
-      displayCommand: params?.command ?? 'git commit -m "checkpoint"',
-      ...(params?.exitCode !== undefined ? { exitCode: params.exitCode } : {}),
-    },
-  };
-}
-
-function messageEntry(turnId: string): AppServerThreadEntry {
-  return {
-    type: "message",
-    id: `message-${turnId}`,
-    role: "assistant",
-    text: "done",
-    turn: { id: turnId },
-  };
-}
-
-describe("commandLooksLikeGitCommit", () => {
-  it.each([
-    ['git commit -m "fix"', true],
-    ["git add -A && git commit -m fix", true],
-    ["git -C /repo commit --amend", true],
-    ["git -c user.name=x commit", true],
-    ["git log --oneline", false],
-    ["echo commit", false],
-    ["git status", false],
-    ["pnpm test && git push", false],
-  ])("%s → %s", (command, expected) => {
-    expect(commandLooksLikeGitCommit(command)).toBe(expected);
+describe("editGroupPaths", () => {
+  it("collects the group's distinct edited file paths", () => {
+    const [group] = collectEditedFileGroups({
+      entries: [
+        activityEntry({
+          id: "a1",
+          turnId: "turn-1",
+          details: [
+            fileDiffDetail({ path: "src/a.ts" }),
+            fileDiffDetail({ path: "src/b.ts" }),
+          ],
+        }),
+      ],
+    });
+    expect(editGroupPaths(group).sort()).toEqual(["src/a.ts", "src/b.ts"]);
   });
 });
 
@@ -143,7 +118,10 @@ describe("collectEditedFileGroups", () => {
     expect(groups[0].additions).toBe(4);
   });
 
-  it("clears groups up to and including a committed turn once a later turn exists", () => {
+  it("accumulates every turn's edits and never clears them on its own", () => {
+    // Commit/push lifecycle is resolved against the live worktree
+    // (resolveEditCommitStates), not by clearing groups here — so all turns
+    // stay viewable regardless of any git commands in the transcript.
     const groups = collectEditedFileGroups({
       entries: [
         activityEntry({
@@ -154,7 +132,7 @@ describe("collectEditedFileGroups", () => {
         activityEntry({
           id: "a2",
           turnId: "turn-2",
-          details: [fileDiffDetail({ path: "src/b.ts" }), commitDetail()],
+          details: [fileDiffDetail({ path: "src/b.ts" })],
         }),
         activityEntry({
           id: "a3",
@@ -164,86 +142,11 @@ describe("collectEditedFileGroups", () => {
       ],
     });
 
-    expect(groups).toHaveLength(1);
-    expect(groups[0].key).toBe("turn-3");
-  });
-
-  it("keeps committed groups visible while the commit turn is still the last turn", () => {
-    const groups = collectEditedFileGroups({
-      entries: [
-        activityEntry({
-          id: "a1",
-          turnId: "turn-1",
-          details: [fileDiffDetail({ path: "src/a.ts" })],
-        }),
-        activityEntry({
-          id: "a2",
-          turnId: "turn-2",
-          details: [fileDiffDetail({ path: "src/b.ts" }), commitDetail()],
-        }),
-      ],
-    });
-
-    expect(groups).toHaveLength(2);
-    expect(groups[0].key).toBe("turn-2");
-    expect(groups[0].committed).toBe(true);
-    expect(groups[1].key).toBe("turn-1");
-  });
-
-  it("treats a message-only later turn as 'next turn started' for clearing", () => {
-    const groups = collectEditedFileGroups({
-      entries: [
-        activityEntry({
-          id: "a1",
-          turnId: "turn-1",
-          details: [fileDiffDetail({ path: "src/a.ts" }), commitDetail()],
-        }),
-        messageEntry("turn-2"),
-      ],
-    });
-
-    expect(groups).toHaveLength(0);
-  });
-
-  it("treats an active turn id as 'next turn started' for clearing", () => {
-    const entries = [
-      activityEntry({
-        id: "a1",
-        turnId: "turn-1",
-        details: [fileDiffDetail({ path: "src/a.ts" }), commitDetail()],
-      }),
-    ];
-
-    expect(collectEditedFileGroups({ entries })).toHaveLength(1);
-    expect(
-      collectEditedFileGroups({ entries, activeTurnId: "turn-2" }),
-    ).toHaveLength(0);
-    // The commit turn itself being active must NOT clear its own group.
-    expect(
-      collectEditedFileGroups({ entries, activeTurnId: "turn-1" }),
-    ).toHaveLength(1);
-  });
-
-  it("does not clear on a failed git commit", () => {
-    const groups = collectEditedFileGroups({
-      entries: [
-        activityEntry({
-          id: "a1",
-          turnId: "turn-1",
-          details: [
-            fileDiffDetail({ path: "src/a.ts" }),
-            commitDetail({ exitCode: 1, status: "failed" }),
-          ],
-        }),
-        activityEntry({
-          id: "a2",
-          turnId: "turn-2",
-          details: [fileDiffDetail({ path: "src/b.ts" })],
-        }),
-      ],
-    });
-
-    expect(groups).toHaveLength(2);
+    expect(groups.map((group) => group.key)).toEqual([
+      "turn-3",
+      "turn-2",
+      "turn-1",
+    ]);
   });
 
   it("renders the live pending cumulative diff as the newest group", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/edited-file-groups.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/edited-file-groups.test.ts
@@ -95,7 +95,11 @@ describe("collectEditedFileGroups", () => {
     expect(groups[1].details).toHaveLength(1);
     expect(groups[1].details[0].fileDiff?.additions).toBe(5);
     expect(groups[1].details[0].fileDiff?.removals).toBe(1);
-    expect(groups[1].summary).toBe("Edited 1 file, +5, -1");
+    // Summary is count-only; +/- live on the group's additions/removals
+    // (rendered via the shared DiffStat chip).
+    expect(groups[1].summary).toBe("Edited 1 file");
+    expect(groups[1].additions).toBe(5);
+    expect(groups[1].removals).toBe(1);
   });
 
   it("prefers a turn's live cumulative diff entry over its per-edit entries", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/EditsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/EditsPanel.tsx
@@ -1,3 +1,4 @@
+import type { EditGroupCommitState } from "@pwragent/shared";
 import { EditedFileGroupList } from "../EditedFileGroupList";
 import type { EditedFileGroup } from "../edited-file-groups";
 import type { EditedFilesDock } from "./context-tab";
@@ -5,6 +6,8 @@ import type { EditedFilesDock } from "./context-tab";
 type EditsPanelProps = {
   /** Newest-first accumulated edited-file groups for the open thread. */
   groups: EditedFileGroup[];
+  /** Git commit lifecycle per group key, from `useEditCommitStates`. */
+  commitStatesByKey?: Record<string, EditGroupCommitState>;
   dock: EditedFilesDock;
   onDockChange: (dock: EditedFilesDock) => void;
 };
@@ -36,7 +39,10 @@ export function EditsPanel(props: EditsPanelProps) {
         </button>
       </div>
       {props.groups.length > 0 ? (
-        <EditedFileGroupList groups={props.groups} />
+        <EditedFileGroupList
+          groups={props.groups}
+          commitStatesByKey={props.commitStatesByKey}
+        />
       ) : (
         <p className="context-empty">
           No uncommitted file edits yet. Edits from agent turns accumulate

--- a/apps/desktop/src/renderer/src/features/thread-detail/edited-file-groups.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/edited-file-groups.ts
@@ -18,9 +18,10 @@ export const MAX_RETAINED_TURN_GROUPS = 10;
 
 /**
  * One accumulated set of file edits, normally a single turn's worth.
- * Groups build up across turns until a successful `git commit` lands;
- * the committed groups stay visible until the NEXT turn starts, then
- * drop (see `collectEditedFileGroups`).
+ * Groups build up across turns and stay viewable; their git lifecycle
+ * (uncommitted → committed → pushed) is resolved separately against the
+ * live worktree (see `resolveEditCommitStates`) rather than guessed from
+ * the agent's command transcript.
  */
 export type EditedFileGroup = {
   /** Stable render key: the turn id, or a synthetic per-entry key. */
@@ -32,36 +33,23 @@ export type EditedFileGroup = {
   summary: string;
   additions: number;
   removals: number;
-  /** True when this group's turn also ran a successful `git commit`. */
-  committed: boolean;
   /** True when this group is the in-flight turn's live cumulative diff. */
   live: boolean;
 };
 
 /**
- * Matches a `git … commit …` invocation at the start of a command or
- * after a shell connector. Only option-shaped tokens may sit between
- * `git` and `commit` (`-C <path>`, `-c key=val`, `--git-dir=…`) so
- * commands that merely mention "commit" later don't false-positive.
+ * Collect the absolute file paths a group edited — the input to
+ * `resolveEditCommitStates`, which maps them to a commit + push state.
  */
-const GIT_COMMIT_COMMAND = /(?:^|[;&|]\s*)git\s+(?:-{1,2}[\w-]+(?:[= ]\S+)?\s+)*commit\b/;
-
-export function commandLooksLikeGitCommit(command: string): boolean {
-  return GIT_COMMIT_COMMAND.test(command);
-}
-
-function isSuccessfulGitCommitDetail(detail: AppServerThreadActivityDetail): boolean {
-  if (detail.kind !== "command" || !detail.command) {
-    return false;
+export function editGroupPaths(group: EditedFileGroup): string[] {
+  const paths = new Set<string>();
+  for (const detail of group.details) {
+    const candidate = detail.path?.trim();
+    if (candidate) {
+      paths.add(candidate);
+    }
   }
-  const command = detail.command.displayCommand || detail.command.rawCommand;
-  if (!command || !commandLooksLikeGitCommit(command)) {
-    return false;
-  }
-  if (typeof detail.command.exitCode === "number") {
-    return detail.command.exitCode === 0;
-  }
-  return detail.status === "completed";
+  return [...paths];
 }
 
 /**
@@ -79,7 +67,6 @@ type TurnBucket = {
   turn?: AppServerThreadTurnMetadata;
   detailsByKey: Map<string, AppServerThreadActivityDetail>;
   cumulative?: AppServerThreadActivityEntry;
-  committed: boolean;
   live: boolean;
 };
 
@@ -120,10 +107,9 @@ function mergeFileDiffDetail(
  * Walk transcript entries (persisted replay + deferred live entries, in
  * order) and build the accumulated edited-file groups:
  *
- * - Edits group per turn; turns accumulate while nothing is committed.
- * - A successful `git commit` in turn C clears everything up to and
- *   including C — but only once a LATER turn exists (committed work
- *   stays on screen until the next turn starts).
+ * - Edits group per turn; turns accumulate and stay viewable. Groups are
+ *   never cleared from the transcript — their committed/pushed lifecycle is
+ *   resolved against the live worktree (see `resolveEditCommitStates`).
  * - `livePendingEntry` (the in-flight turn's cumulative diff) renders
  *   as the newest group while a turn is streaming.
  *
@@ -160,7 +146,6 @@ export function collectEditedFileGroups(params: {
         orderIndex,
         turn,
         detailsByKey: new Map(),
-        committed: false,
         live: false,
       };
       buckets.set(key, bucket);
@@ -173,32 +158,16 @@ export function collectEditedFileGroups(params: {
   for (const entry of params.entries) {
     const turnKey = entry.turn?.id;
     if (entry.type !== "activity") {
-      // Non-activity entries still advance the turn order — a turn
-      // that only produced messages still counts as "the next turn
-      // started" for the committed-group clearing rule.
-      if (turnKey) {
-        ensureTurnIndex(turnKey);
-      }
       continue;
     }
 
     const hasFileDiff = entry.details.some((detail) => detail.fileDiff);
-    const hasCommit = entry.details.some(isSuccessfulGitCommitDetail);
-    if (!hasFileDiff && !hasCommit) {
-      if (turnKey) {
-        ensureTurnIndex(turnKey);
-      }
+    if (!hasFileDiff) {
       continue;
     }
 
     const key = turnKey ?? `entry:${entry.id}`;
     const bucket = ensureBucket(key, entry.turn);
-    if (hasCommit) {
-      bucket.committed = true;
-    }
-    if (!hasFileDiff) {
-      continue;
-    }
 
     if (entry.id.startsWith(LIVE_CUMULATIVE_DIFF_ID_PREFIX)) {
       bucket.cumulative = entry;
@@ -223,28 +192,12 @@ export function collectEditedFileGroups(params: {
     const bucket = ensureBucket(key, params.livePendingEntry.turn);
     bucket.cumulative = params.livePendingEntry;
     bucket.live = true;
-  } else if (params.activeTurnId) {
-    // An active turn with no edits yet still counts as "started" so
-    // committed groups from prior turns clear immediately.
-    ensureTurnIndex(params.activeTurnId);
-  }
-
-  const lastTurnIndex = turnOrder.length - 1;
-  let clearThroughIndex = -1;
-  for (const bucket of buckets.values()) {
-    if (bucket.committed && bucket.orderIndex < lastTurnIndex) {
-      clearThroughIndex = Math.max(clearThroughIndex, bucket.orderIndex);
-    }
   }
 
   const groups: EditedFileGroup[] = [];
   for (const bucket of [...buckets.values()].sort(
     (left, right) => left.orderIndex - right.orderIndex,
   )) {
-    if (bucket.orderIndex <= clearThroughIndex) {
-      continue;
-    }
-
     const details = bucket.cumulative
       ? bucket.cumulative.details.filter((detail) => detail.fileDiff)
       : [...bucket.detailsByKey.values()];
@@ -272,7 +225,6 @@ export function collectEditedFileGroups(params: {
       }),
       additions,
       removals,
-      committed: bucket.committed,
       live: bucket.live,
     });
   }

--- a/apps/desktop/src/renderer/src/features/thread-detail/edited-file-groups.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/edited-file-groups.ts
@@ -4,7 +4,10 @@ import type {
   AppServerThreadEntry,
   AppServerThreadTurnMetadata,
 } from "@pwragent/shared";
-import { formatChangedFileSummary } from "./live-transcript-activity";
+import {
+  formatChangedFileCount,
+  formatChangedFileSummary,
+} from "./live-transcript-activity";
 
 /**
  * Upper bound on accumulated turn-groups kept by `collectEditedFileGroups`.
@@ -29,7 +32,7 @@ export type EditedFileGroup = {
   turn?: AppServerThreadTurnMetadata;
   /** Per-file details; every detail carries a `fileDiff`. */
   details: AppServerThreadActivityDetail[];
-  /** "Edited N files, +A, -R" for this group. */
+  /** "Edited N files" — file count only; +/- render via `DiffStat`. */
   summary: string;
   additions: number;
   removals: number;
@@ -217,12 +220,10 @@ export function collectEditedFileGroups(params: {
       key: bucket.key,
       turn: bucket.turn,
       details,
-      summary: formatChangedFileSummary({
-        count: details.length,
-        prefix: "Edited",
-        additions,
-        removals,
-      }),
+      // Count only — the +/- stats render via the shared colored DiffStat
+      // chip in the header (consistent with the thread-row dirty chip),
+      // not as plain comma-separated text.
+      summary: formatChangedFileCount({ count: details.length, prefix: "Edited" }),
       additions,
       removals,
       live: bucket.live,

--- a/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
@@ -1286,15 +1286,20 @@ export function getBasename(path: string): string {
   return segments[segments.length - 1] || path;
 }
 
+export function formatChangedFileCount(params: {
+  count: number;
+  prefix: "Changed" | "Edited";
+}): string {
+  return `${params.prefix} ${params.count} file${params.count === 1 ? "" : "s"}`;
+}
+
 export function formatChangedFileSummary(params: {
   count: number;
   prefix: "Changed" | "Edited";
   additions: number;
   removals: number;
 }): string {
-  const parts = [
-    `${params.prefix} ${params.count} file${params.count === 1 ? "" : "s"}`,
-  ];
+  const parts = [formatChangedFileCount(params)];
   if (params.additions > 0 || params.removals > 0) {
     parts.push(
       `+${params.additions.toLocaleString()}, -${params.removals.toLocaleString()}`

--- a/apps/desktop/src/renderer/src/features/thread-detail/useEditCommitStates.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/useEditCommitStates.ts
@@ -1,0 +1,66 @@
+import { useEffect, useMemo, useState } from "react";
+import type { EditGroupCommitState } from "@pwragent/shared";
+import type { DesktopApi } from "../../lib/desktop-api";
+import { editGroupPaths, type EditedFileGroup } from "./edited-file-groups";
+
+/**
+ * Resolve the git commit lifecycle (uncommitted → committed → pushed/local)
+ * of a thread's edited-file groups against the live worktree, via the main
+ * process. Re-resolves when the group set changes or the worktree's working
+ * state shifts (`refreshKey` — pass a signature of the thread's
+ * `gitWorkingState` so a commit/push flips the badges). Returns an empty map
+ * until the first resolution lands; groups simply render unbadged until then.
+ */
+export function useEditCommitStates(params: {
+  desktopApi?: Pick<DesktopApi, "resolveEditCommitStates">;
+  worktreePath?: string;
+  groups: readonly EditedFileGroup[];
+  refreshKey?: string;
+}): Record<string, EditGroupCommitState> {
+  const { desktopApi, worktreePath, groups, refreshKey } = params;
+  const [states, setStates] = useState<Record<string, EditGroupCommitState>>(
+    {},
+  );
+
+  // A stable signature of the {key → paths} inputs so we only re-resolve when
+  // the actual groups/files change, not on every transcript re-render.
+  const groupsInput = useMemo(
+    () => groups.map((group) => ({ key: group.key, paths: editGroupPaths(group) })),
+    [groups],
+  );
+  const groupsSignature = useMemo(
+    () => JSON.stringify(groupsInput),
+    [groupsInput],
+  );
+
+  useEffect(() => {
+    const resolve = desktopApi?.resolveEditCommitStates;
+    const normalizedWorktree = worktreePath?.trim();
+    if (!resolve || !normalizedWorktree || groupsInput.length === 0) {
+      setStates({});
+      return;
+    }
+
+    let cancelled = false;
+    void resolve({ worktreePath: normalizedWorktree, groups: groupsInput })
+      .then((response) => {
+        if (!cancelled) {
+          setStates(response.states);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setStates({});
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+    // groupsSignature stands in for groupsInput (deep value), refreshKey for
+    // the worktree's working state.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [desktopApi?.resolveEditCommitStates, worktreePath, groupsSignature, refreshKey]);
+
+  return states;
+}

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -103,6 +103,8 @@ import type {
   RefreshThreadPullRequestsResponse,
   RefreshDirectoryGitStatusesRequest,
   RefreshDirectoryGitStatusesResponse,
+  ResolveEditCommitStatesRequest,
+  ResolveEditCommitStatesResponse,
   NavigationSnapshot,
   ResetDirectoryLaunchpadRequest,
   ResetDirectoryLaunchpadResponse,
@@ -530,6 +532,9 @@ export type DesktopApi = {
   refreshDirectoryGitStatuses?: (
     request: RefreshDirectoryGitStatusesRequest
   ) => Promise<RefreshDirectoryGitStatusesResponse>;
+  resolveEditCommitStates?: (
+    request: ResolveEditCommitStatesRequest
+  ) => Promise<ResolveEditCommitStatesResponse>;
   getGhStatus?: (request?: GetGhStatusRequest) => Promise<GhStatus>;
   ensureDirectoryLaunchpad?: (
     request: EnsureDirectoryLaunchpadRequest

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -8698,22 +8698,32 @@ textarea,
   outline-offset: 1px;
 }
 
+/* Two-row card header: the "Edited N files" summary gets its own line so
+   the commit badges can't crush it, with the badge + date on a wrapping
+   second line. Sticky so the header pins to the top of the scroll region
+   while a long diff scrolls beneath it (the opaque card background hides the
+   scrolled content). */
 .edited-file-groups__group-header {
   display: flex;
-  align-items: center;
-  gap: 6px;
+  flex-direction: column;
+  gap: 2px;
   min-width: 0;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  padding: 5px 6px;
+  border-radius: 6px;
+  background: var(--bg-panel-elevated);
 }
 
 .edited-file-groups__group-toggle {
   display: flex;
   align-items: center;
   gap: 6px;
-  flex: 1 1 auto;
+  width: 100%;
   min-width: 0;
-  padding: 4px 6px;
+  padding: 0;
   border: 0;
-  border-radius: 4px;
   background: transparent;
   color: var(--text-secondary);
   cursor: pointer;
@@ -8723,8 +8733,17 @@ textarea,
 }
 
 .edited-file-groups__group-toggle:hover {
-  background: var(--bg-panel-hover);
   color: var(--text-primary);
+}
+
+/* Second row: badge (left) + date (right), aligned under the summary text
+   (past the chevron). Wraps rather than truncating on a narrow rail. */
+.edited-file-groups__group-meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px 6px;
+  padding-left: 22px;
 }
 
 .edited-file-groups__group-summary {
@@ -8842,6 +8861,7 @@ textarea,
 
 .edited-file-groups__group-time {
   flex: 0 0 auto;
+  margin-left: auto;
   color: var(--text-muted);
   font-size: 11px;
 }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -8620,6 +8620,34 @@ textarea,
   font-weight: 600;
 }
 
+/* Shared +A/-R stat: + (green) then - (red), no comma — consistent with the
+   thread-row dirty chip. `--chip` adds the pill treatment for the group
+   header; bare it sits inline in the per-file rows. */
+.diff-stat {
+  display: inline-flex;
+  align-items: baseline;
+  flex: 0 0 auto;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.diff-stat__added {
+  color: var(--success-text);
+}
+
+.diff-stat__removed {
+  color: var(--danger-text);
+}
+
+.diff-stat--chip {
+  padding: 0 6px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  background: var(--bg-panel-elevated);
+}
+
 .live-work-rail__file-stat--added {
   color: var(--success-text);
 }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -8698,10 +8698,18 @@ textarea,
   outline-offset: 1px;
 }
 
+.edited-file-groups__group-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
 .edited-file-groups__group-toggle {
   display: flex;
   align-items: center;
   gap: 6px;
+  flex: 1 1 auto;
   min-width: 0;
   padding: 4px 6px;
   border: 0;
@@ -8745,6 +8753,91 @@ textarea,
   border-color: var(--accent-border);
   background: var(--accent-soft);
   color: var(--accent-bright);
+}
+
+/* Per-group git lifecycle: uncommitted → committed (with copyable SHA chip)
+   → pushed / local. Mirrors the group-tag pill scale. */
+.edit-commit-badge {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10px;
+  font-weight: 600;
+}
+
+.edit-commit-badge--uncommitted {
+  padding: 0 6px;
+  border: 1px solid color-mix(in srgb, var(--status-warning) 42%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--status-warning) 14%, transparent);
+  color: var(--status-warning);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.edit-commit-badge__label {
+  color: var(--text-muted);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.edit-commit-badge__sha {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 1px 6px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 4px;
+  background: var(--bg-panel-elevated);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font: inherit;
+  font-size: 10px;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease;
+}
+
+.edit-commit-badge__sha:hover {
+  background: var(--bg-panel-hover);
+  color: var(--text-primary);
+}
+
+.edit-commit-badge__sha:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 1px;
+}
+
+.edit-commit-badge__sha-value {
+  font-family: var(--font-mono);
+  letter-spacing: 0.02em;
+}
+
+.edit-commit-badge__sha-action {
+  color: var(--text-muted);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.edit-commit-badge__push {
+  padding: 0 6px;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.edit-commit-badge__push--pushed {
+  border-color: var(--success-border);
+  background: var(--success-soft);
+  color: var(--success-text);
+}
+
+.edit-commit-badge__push--local {
+  border-color: var(--border-subtle);
+  background: var(--bg-panel-elevated);
+  color: var(--text-muted);
 }
 
 .edited-file-groups__group-time {

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -89,6 +89,8 @@ export const NAVIGATION_GET_GH_STATUS_CHANNEL =
   "navigation:get-gh-status";
 export const NAVIGATION_REFRESH_DIRECTORY_GIT_STATUSES_CHANNEL =
   "navigation:refresh-directory-git-statuses";
+export const NAVIGATION_RESOLVE_EDIT_COMMIT_STATES_CHANNEL =
+  "navigation:resolve-edit-commit-states";
 export const MESSAGING_GET_PLATFORM_STATUSES_CHANNEL =
   "messaging:get-platform-statuses";
 export const MESSAGING_PLATFORM_STATUS_EVENT_CHANNEL =

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -530,6 +530,39 @@ export type RefreshDirectoryGitStatusesResponse = {
   scheduledCount: number;
 };
 
+/**
+ * One accumulated edited-file group to resolve git commit state for. `key`
+ * is the rail's stable group key; `paths` are the absolute file paths the
+ * group edited.
+ */
+export type EditGroupCommitInput = {
+  key: string;
+  paths: string[];
+};
+
+/**
+ * Git lifecycle of an edited-file group, resolved against the live worktree
+ * (not the agent's command transcript). A group is `committed` when none of
+ * its files still have uncommitted working-tree changes; `commitSha` is the
+ * most recent commit touching those files, and `pushed` reflects whether that
+ * commit is reachable from any remote ref (omitted when it can't be told).
+ */
+export type EditGroupCommitState = {
+  committed: boolean;
+  commitSha?: string;
+  shortSha?: string;
+  pushed?: boolean;
+};
+
+export type ResolveEditCommitStatesRequest = {
+  worktreePath: string;
+  groups: EditGroupCommitInput[];
+};
+
+export type ResolveEditCommitStatesResponse = {
+  states: Record<string, EditGroupCommitState>;
+};
+
 const ACP_BACKEND_ID_PREFIX = "acp:";
 const ACP_REGISTRY_ID_PATTERN = /^[A-Za-z0-9._-]+$/;
 


### PR DESCRIPTION
**Stacked on #788** (base = `feat/desktop-live-git-working-state-chips`). Retarget to `main` once #788 merges.

Replaces the "did a `git commit` run in the transcript?" regex (`commandLooksLikeGitCommit`) — which guessed from command text and *cleared* edited-file groups — with a worktree-truth model: groups stay viewable, and each turn-group is badged with its real git lifecycle: **uncommitted → committed → pushed / local**, with a copyable short-SHA chip.

### Why
The old model was unreliable (it can't see commits made in a terminal/IDE, and clearing the rail on a guessed commit hid work the user still wanted). #788 first tried clearing groups on a clean tree; that was reverted — the right model is to keep the edits and annotate them.

### How
Codex file-change `detail.path` is **absolute**, so resolution lives entirely in the **main process** — git normalizes the paths, so there's no fragile renderer path-matching and no per-thread payload. One lazy IPC resolves all of a thread's visible groups at once:
- `git diff --name-only HEAD` + `git ls-files --others --exclude-standard` → the dirty/untracked set. A group is **committed** when none of its files are in it.
- `git log -1 --format=%H -- <group paths>` → the most recent commit touching the group (the SHA chip).
- `git rev-list -1 <sha> --not --remotes` → empty ⇒ **pushed**, else **local-only**.

All read-only with `--no-optional-locks`. Resolved lazily for the open thread and re-resolved when #788's working-state push shifts the dirty/unpushed counts (i.e. a commit/push), so badges stay live without re-reading the transcript.

### Changes
- `GitWorkingStateService.resolveEditCommitStates` + backend-registry / IPC / preload / desktop-api wiring + `ResolveEditCommitStates*` + `EditGroupCommitState` contract.
- `collectEditedFileGroups` no longer detects commits or clears groups — removed `commandLooksLikeGitCommit`, `isSuccessfulGitCommitDetail`, the `committed` flag, and the `clearThroughIndex` logic. It just accumulates per turn (capped at 10) and stays viewable.
- `useEditCommitStates` hook resolves states for the open thread; `EditGroupCommitBadge` renders the badge (Uncommitted, or Committed + copyable `<sha7>` chip + Pushed/Local), threaded through `LiveWorkRail` and the context-rail `EditsPanel`.

### Reviewer notes
- Renderer still only imports `@pwragent/shared`; `lint:boundaries` clean.
- The SHA chip sits beside (not inside) the section toggle button to avoid nested-button HTML.
- "Committed" here means "no longer in the working tree" (committed *or* discarded) — the SHA confirms a commit when present. Renders no badge until resolution lands, so a committed group never flashes "uncommitted."

### Tests / verification
- Resolver classification (uncommitted / committed + sha + pushed/local), badge rendering (incl. local-only + copy button), and the new accumulate-don't-clear behavior in `collectEditedFileGroups`.
- Full touched-test batch (524) + `pnpm lint` (typecheck across all packages, sql, codex-storage, colors, boundaries) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)