### PR TITLE
fix(desktop): reuse navigation thread lists for branch drift

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -5502,6 +5502,44 @@ script = "echo setup"
     await registry.close();
   });
 
+  it("reuses navigation Codex thread lists for branch drift in the refresh window", async () => {
+    const codexClient = new MockBackendClient({
+      threads: [
+        {
+          id: "thread-codex",
+          title: "Codex thread",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({}),
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await registry.listThreads({
+      backend: "codex",
+      callerReason: "navigation-snapshot",
+    });
+    await registry.listThreads({
+      backend: "codex",
+      callerReason: "branch-drift",
+    });
+
+    expect(codexClient.listThreadsCallCount).toBe(1);
+    expect(codexClient.lastListThreadsParams).toMatchObject({
+      enrichDirectories: false,
+    });
+    expect(codexClient.lastListThreadsDiagnostics).toMatchObject({
+      callerReason: "navigation-snapshot",
+    });
+
+    await registry.close();
+  });
+
   it("keeps cheap navigation lists separate from directory-enriched thread lists", async () => {
     const codexClient = new MockBackendClient({
       threads: [

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -3795,13 +3795,10 @@ export class DesktopBackendRegistry {
         params.enrichDirectories ?? shouldEnrichThreadDirectories(params.callerReason),
     };
     const cacheKey = this.buildThreadListCacheKey(normalizedParams);
-    const cached = this.threadListCache.get(cacheKey);
     const now = Date.now();
-    if (cached?.threads && (cached.expiresAt ?? 0) > now) {
-      return cached.threads;
-    }
-    if (cached?.promise) {
-      return await cached.promise;
+    const cached = this.findReusableThreadListCache(normalizedParams, cacheKey, now);
+    if (cached) {
+      return await cached;
     }
 
     const promise = this.readThreadList(normalizedParams)
@@ -8873,6 +8870,52 @@ export class DesktopBackendRegistry {
         params.backend === "grok" ? undefined : params.enrichDirectories === true,
       filter: params.filter?.trim() ?? "",
     });
+  }
+
+  private findReusableThreadListCache(
+    params: {
+      archived?: boolean;
+      backend?: AppServerBackendKind;
+      callerReason?: ThreadListCallerReason;
+      enrichDirectories?: boolean;
+      filter?: string;
+    },
+    cacheKey: string,
+    now: number,
+  ): Promise<AppServerThreadSummary[]> | AppServerThreadSummary[] | undefined {
+    const exact = this.readFreshThreadListCache(cacheKey, now);
+    if (exact) {
+      return exact;
+    }
+
+    if (
+      params.backend !== "codex" ||
+      params.archived === true ||
+      params.enrichDirectories !== false ||
+      shouldBackfillCodexDirectoryRelationships(params.callerReason)
+    ) {
+      return undefined;
+    }
+
+    const backfillCapableKey = this.buildThreadListCacheKey({
+      ...params,
+      callerReason: "navigation-snapshot",
+    });
+    if (backfillCapableKey === cacheKey) {
+      return undefined;
+    }
+    return this.readFreshThreadListCache(backfillCapableKey, now);
+  }
+
+  private readFreshThreadListCache(
+    cacheKey: string,
+    now: number,
+  ): Promise<AppServerThreadSummary[]> | AppServerThreadSummary[] | undefined {
+    const cached = this.threadListCache.get(cacheKey);
+    if (cached?.threads && (cached.expiresAt ?? 0) > now) {
+      return cached.threads;
+    }
+    return cached?.promise;
   }
 
   private invalidateThreadListCache(backend?: AppServerBackendKind): void {


### PR DESCRIPTION
## Summary

- Branch-drift checks now reuse a fresh Codex navigation thread list instead of immediately repaginating `thread/list` after navigation has already fetched the same active threads.
- The reuse is one-way: cheap branch-drift lookups can consume a backfill-capable navigation cache entry, but they still cannot satisfy a later navigation caller that needs directory-relationship backfill.
- Added a registry regression test so Codex matches the existing Grok coalescing behavior for navigation followed by branch drift.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts -- --runInBand`

## Notes

- This targets the scary burst of `callerReason=navigation-snapshot` followed by `callerReason=branch-drift` `thread/list` traffic. The remaining 2-10 ms bursts inside one caller are expected Codex pagination, not a wake loop.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
