### PR TITLE
perf(desktop): bound, dedupe, debounce + scope the edit-commit-state resolver

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -204,6 +204,17 @@ const readWorktreeWorkingStateEntries = vi.fn(
     })(),
 );
 const invalidateWorktreeWorkingState = vi.fn((_worktreePath?: string) => undefined);
+// Hold the result until the test releases it, so two concurrent IPC requests
+// overlap and exercise the in-flight dedup.
+let releaseEditCommitResolve: (() => void) | undefined;
+const resolveEditCommitStates = vi.fn(
+  async (): Promise<Record<string, unknown>> => {
+    await new Promise<void>((resolve) => {
+      releaseEditCommitResolve = resolve;
+    });
+    return { "g-1": { committed: false } };
+  },
+);
 const registryEventListeners: Array<(event: unknown) => void> = [];
 const onEvent = vi.fn((listener: (event: unknown) => void) => {
   registryEventListeners.push(listener);
@@ -395,6 +406,7 @@ vi.mock("../app-server/backend-registry", () => ({
     readDirectoryStatusEntries,
     readWorktreeWorkingStateEntries,
     invalidateWorktreeWorkingState,
+    resolveEditCommitStates,
     onEvent,
     publishLocalEvent,
     ensureDirectoryLaunchpad,
@@ -436,6 +448,8 @@ describe("app server ipc", () => {
     readThreadGitWorkingStateCache.mockResolvedValue({});
     writeThreadGitWorkingStateCacheEntry.mockClear();
     readWorktreeWorkingStateEntries.mockClear();
+    resolveEditCommitStates.mockClear();
+    releaseEditCommitResolve = undefined;
     invalidateWorktreeWorkingState.mockClear();
     onEvent.mockClear();
     registryEventListeners.length = 0;
@@ -2500,6 +2514,34 @@ describe("app server ipc", () => {
     expect(readWorktreeWorkingStateEntries.mock.calls.length).toBe(
       callsAfterSnapshot,
     );
+  });
+
+  it("coalesces concurrent identical resolveEditCommitStates requests", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_RESOLVE_EDIT_COMMIT_STATES_CHANNEL } = await import(
+      "../../shared/ipc"
+    );
+
+    registerAppServerIpcHandlers();
+
+    const request = {
+      worktreePath: "/repo/wt",
+      groups: [{ key: "g-1", paths: ["/repo/wt/a.ts"] }],
+    };
+    const handler = handlers.get(NAVIGATION_RESOLVE_EDIT_COMMIT_STATES_CHANNEL);
+    const first = handler?.({}, request);
+    const second = handler?.({}, request);
+
+    // Both requests are in flight; release the single shared registry call.
+    await vi.waitFor(() => {
+      expect(releaseEditCommitResolve).toBeDefined();
+    });
+    releaseEditCommitResolve?.();
+
+    const [a, b] = await Promise.all([first, second]);
+    expect(a).toEqual({ states: { "g-1": { committed: false } } });
+    expect(b).toEqual({ states: { "g-1": { committed: false } } });
+    expect(resolveEditCommitStates).toHaveBeenCalledTimes(1);
   });
 
   it("caps automatic startup directory git status refreshes", async () => {

--- a/apps/desktop/src/main/__tests__/git-working-state-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-working-state-service.test.ts
@@ -189,6 +189,21 @@ describe("GitWorkingStateService.resolveEditCommitStates", () => {
     }
   });
 
+  it("runs the remote-reachability check once per unique commit", async () => {
+    const { runGit, calls } = fakeGit(respondCommitStates);
+    const service = new GitWorkingStateService({ runGit });
+
+    // Two groups resolving to the same commit must share one `rev-list`.
+    const states = await service.resolveEditCommitStates("/repo/wt", [
+      { key: "g-b", paths: ["/repo/wt/src/b.ts"] },
+      { key: "g-b2", paths: ["/repo/wt/src/b.ts"] },
+    ]);
+
+    expect(states["g-b"]).toMatchObject({ committed: true, pushed: true });
+    expect(states["g-b2"]).toMatchObject({ committed: true, pushed: true });
+    expect(calls.filter((call) => call.args.includes("rev-list"))).toHaveLength(1);
+  });
+
   it("returns an empty map for no worktree or no groups", async () => {
     const { runGit, calls } = fakeGit(respondCommitStates);
     const service = new GitWorkingStateService({ runGit });

--- a/apps/desktop/src/main/app-server/git-working-state-service.ts
+++ b/apps/desktop/src/main/app-server/git-working-state-service.ts
@@ -11,6 +11,9 @@ function normalizeAbsolutePath(value: string): string {
   return path.resolve(value).replace(/\\/g, "/");
 }
 
+/** Bounded concurrency for the per-group `git log`/`rev-list` commit probes. */
+const EDIT_COMMIT_RESOLVE_CONCURRENCY = 4;
+
 type GitCommandRunner = (
   cwd: string,
   args: string[],
@@ -253,22 +256,35 @@ export class GitWorkingStateService {
       }
     }
 
-    const pushedBySha = new Map<string, boolean>();
-    for (const group of groups) {
+    // Memoize the per-commit remote-reachability check by promise so concurrent
+    // groups sharing a commit run `rev-list` once.
+    const pushedBySha = new Map<string, Promise<boolean>>();
+    const resolvePushed = (sha: string): Promise<boolean> => {
+      const existing = pushedBySha.get(sha);
+      if (existing) {
+        return existing;
+      }
+      // `rev-list -1 <sha> --not --remotes` lists sha only when it (or its
+      // tip) isn't reachable from any remote ref. Empty ⇒ pushed. With no
+      // remotes configured, nothing is excluded ⇒ non-empty ⇒ local-only.
+      const promise = noLocks(["rev-list", "-1", sha, "--not", "--remotes"])
+        .then((output) => output.trim() === "")
+        .catch(() => true);
+      pushedBySha.set(sha, promise);
+      return promise;
+    };
+
+    const resolveGroupState = async (
+      group: EditGroupCommitInput,
+    ): Promise<{ key: string; state: EditGroupCommitState }> => {
       const paths = [
         ...new Set(group.paths.map((value) => value.trim()).filter(Boolean)),
       ];
       if (paths.length === 0) {
-        states[group.key] = { committed: false };
-        continue;
+        return { key: group.key, state: { committed: false } };
       }
-
-      const hasUncommittedChange = paths.some((value) =>
-        dirtyPaths.has(normalizeAbsolutePath(value)),
-      );
-      if (hasUncommittedChange) {
-        states[group.key] = { committed: false };
-        continue;
+      if (paths.some((value) => dirtyPaths.has(normalizeAbsolutePath(value)))) {
+        return { key: group.key, state: { committed: false } };
       }
 
       const sha = (
@@ -281,30 +297,26 @@ export class GitWorkingStateService {
       // agent wrote (invisible to both `diff HEAD` and `ls-files --others
       // --exclude-standard`). Don't claim "committed" without a SHA to back it.
       if (!sha) {
-        states[group.key] = { committed: false };
-        continue;
+        return { key: group.key, state: { committed: false } };
       }
 
-      let pushed = pushedBySha.get(sha);
-      if (pushed === undefined) {
-        // `rev-list -1 <sha> --not --remotes` lists sha only when it (or its
-        // tip) isn't reachable from any remote ref. Empty ⇒ pushed. With no
-        // remotes configured, nothing is excluded ⇒ non-empty ⇒ local-only.
-        const localOnly = (
-          await noLocks(["rev-list", "-1", sha, "--not", "--remotes"]).catch(
-            () => "",
-          )
-        ).trim();
-        pushed = localOnly === "";
-        pushedBySha.set(sha, pushed);
-      }
-
-      states[group.key] = {
-        committed: true,
-        commitSha: sha,
-        shortSha: sha.slice(0, 7),
-        pushed,
+      return {
+        key: group.key,
+        state: {
+          committed: true,
+          commitSha: sha,
+          shortSha: sha.slice(0, 7),
+          pushed: await resolvePushed(sha),
+        },
       };
+    };
+
+    // Bounded concurrency rather than one git subprocess at a time.
+    for await (const entry of new IterableMapper(groups, resolveGroupState, {
+      concurrency: EDIT_COMMIT_RESOLVE_CONCURRENCY,
+      maxUnread: EDIT_COMMIT_RESOLVE_CONCURRENCY * 2,
+    })) {
+      states[entry.key] = entry.state;
     }
 
     return states;

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -525,6 +525,10 @@ class DesktopAppServerService {
     string,
     Promise<RefreshThreadPullRequestsResponse>
   >();
+  private readonly pendingEditCommitResolves = new Map<
+    string,
+    Promise<ResolveEditCommitStatesResponse>
+  >();
   private readonly prStatusRegistry = new Map<string, PrStatusRegistryEntry>();
   private readonly prLookupRegistry = new Map<string, PrLookupRegistryEntry>();
   private readonly pendingPrLookupRefreshes = new Map<string, Promise<void>>();
@@ -939,11 +943,27 @@ class DesktopAppServerService {
   async resolveEditCommitStates(
     request: ResolveEditCommitStatesRequest,
   ): Promise<ResolveEditCommitStatesResponse> {
-    const states = await getDesktopBackendRegistry().resolveEditCommitStates(
-      request.worktreePath,
-      request.groups,
-    );
-    return { states };
+    // Coalesce identical in-flight requests (same worktree + groups) so an
+    // overlapping renderer re-resolve doesn't spawn a second git burst — they
+    // share one result.
+    const requestKey = JSON.stringify({
+      worktreePath: request.worktreePath,
+      groups: request.groups,
+    });
+    const pending = this.pendingEditCommitResolves.get(requestKey);
+    if (pending) {
+      return await pending;
+    }
+
+    const promise = getDesktopBackendRegistry()
+      .resolveEditCommitStates(request.worktreePath, request.groups)
+      .then((states) => ({ states }));
+    this.pendingEditCommitResolves.set(requestKey, promise);
+    try {
+      return await promise;
+    } finally {
+      this.pendingEditCommitResolves.delete(requestKey);
+    }
   }
 
   private collectThreadWorktreePaths(
@@ -2452,6 +2472,7 @@ class DesktopAppServerService {
     this.prFetcher = undefined;
     this.pendingNavigationSnapshots.clear();
     this.pendingThreadPullRequestRefreshes.clear();
+    this.pendingEditCommitResolves.clear();
     this.prStatusRegistry.clear();
     this.prLookupRegistry.clear();
     this.pendingPrLookupRefreshes.clear();

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1539,10 +1539,15 @@ export function ThreadView(props: ThreadViewProps) {
   // Git commit lifecycle per group, resolved against the live worktree.
   // Re-resolves when the thread's working state shifts (a commit/push), so the
   // per-group badges stay accurate without re-reading the transcript.
+  // Only resolve commit state when an edits surface is actually on screen —
+  // the above-composer rail (dock "above") or the context-rail Edits tab.
+  // Otherwise the badges aren't rendered and the git probes are pure waste.
+  const editsSurfaceVisible =
+    editedFilesDock === "above" || activeContextTab === "edits";
   const editedFileCommitStates = useEditCommitStates({
     desktopApi: props.desktopApi,
     worktreePath: selectedThread?.projectKey,
-    groups: editedFileGroups,
+    groups: editsSurfaceVisible ? editedFileGroups : [],
     refreshKey: JSON.stringify(selectedThread?.gitWorkingState ?? null),
   });
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/useEditCommitStates.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/useEditCommitStates.ts
@@ -4,12 +4,20 @@ import type { DesktopApi } from "../../lib/desktop-api";
 import { editGroupPaths, type EditedFileGroup } from "./edited-file-groups";
 
 /**
+ * Debounce window before resolving. A git-heavy turn pushes a fresh working
+ * state after every commit; without this each push would spawn its own burst
+ * of `git` probes in the main process. Coalesce a flurry into one resolve.
+ */
+const RESOLVE_DEBOUNCE_MS = 300;
+
+/**
  * Resolve the git commit lifecycle (uncommitted → committed → pushed/local)
  * of a thread's edited-file groups against the live worktree, via the main
- * process. Re-resolves when the group set changes or the worktree's working
- * state shifts (`refreshKey` — pass a signature of the thread's
- * `gitWorkingState` so a commit/push flips the badges). Returns an empty map
- * until the first resolution lands; groups simply render unbadged until then.
+ * process. Re-resolves (debounced) when the group set changes or the
+ * worktree's working state shifts (`refreshKey` — pass a signature of the
+ * thread's `gitWorkingState` so a commit/push flips the badges). Pass an empty
+ * `groups` array when the edits surface isn't shown to skip resolution
+ * entirely. Returns an empty map until the first resolution lands.
  */
 export function useEditCommitStates(params: {
   desktopApi?: Pick<DesktopApi, "resolveEditCommitStates">;
@@ -42,20 +50,23 @@ export function useEditCommitStates(params: {
     }
 
     let cancelled = false;
-    void resolve({ worktreePath: normalizedWorktree, groups: groupsInput })
-      .then((response) => {
-        if (!cancelled) {
-          setStates(response.states);
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setStates({});
-        }
-      });
+    const timer = window.setTimeout(() => {
+      void resolve({ worktreePath: normalizedWorktree, groups: groupsInput })
+        .then((response) => {
+          if (!cancelled) {
+            setStates(response.states);
+          }
+        })
+        .catch(() => {
+          if (!cancelled) {
+            setStates({});
+          }
+        });
+    }, RESOLVE_DEBOUNCE_MS);
 
     return () => {
       cancelled = true;
+      window.clearTimeout(timer);
     };
     // groupsSignature stands in for groupsInput (deep value), refreshKey for
     // the worktree's working state.


### PR DESCRIPTION
**Stacked on #791.** Performance follow-up to the edited-files commit-annotation feature (#789). The resolver was correct but could spawn a burst of sequential `git` subprocesses on every working-state change, with no debounce or dedup — worst on git-heavy turns. Four fixes, in the order we discussed:

1. **Bounded concurrency** — the per-group `git log`/`rev-list` probes run 4-wide via `IterableMapper` instead of one-at-a-time. Plus the per-commit pushed/local check is memoized **by promise**, so groups sharing a commit run `rev-list` once (even under concurrency).
2. **In-flight dedup (IPC)** — concurrent identical requests (same worktree + groups) share a single resolve, mirroring `pendingDirectoryGitStatusKeys`.
3. **Debounce (renderer hook, 300ms)** — a flurry of post-commit working-state pushes collapses into one resolve.
4. **Resolve only what's shown** — the hook now gets groups only when an edits surface is on screen (the above-composer rail *or* the context-rail Edits tab); otherwise it skips the git probes entirely.

### Notes
- All read-only with `--no-optional-locks` (unchanged); these run in the main process, so this is about reducing subprocess churn, not UI jank.
- One refinement intentionally **not** done: resolving only the *visible* (non-`Show more`) groups. That needs the show-more state and would mean moving the hook into `EditedFileGroupList` (+ test churn); pre-resolving the ≤10 retained groups keeps "Show more" instant and is bounded. Easy follow-up if it matters.

### Tests
- Resolver: `rev-list` runs once across two groups sharing a commit.
- IPC: two concurrent identical requests → one registry call, both get the result.
- typecheck + boundaries + the touched suite (156) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)