### PR TITLE
fix(desktop): pin edits title/controls in a fixed header, scroll only the list

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
@@ -1,4 +1,11 @@
-import { useId, useState } from "react";
+import {
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type RefObject,
+} from "react";
 import type {
   AppServerThreadActivityDetail,
   EditGroupCommitState,
@@ -144,6 +151,31 @@ function formatGroupTimestamp(group: EditedFileGroup): string | undefined {
     : undefined;
 }
 
+/**
+ * Live element height via ResizeObserver. Drives the sticky offset for a
+ * group's file rows: a fixed pixel estimate gaps or overlaps because the
+ * group header height varies (one vs two rows, badge state, summary wrap), so
+ * we measure the real header instead.
+ */
+function useMeasuredHeight(ref: RefObject<HTMLElement | null>): number | undefined {
+  const [height, setHeight] = useState<number | undefined>(undefined);
+  useLayoutEffect(() => {
+    const element = ref.current;
+    if (!element) {
+      return;
+    }
+    const measure = () => setHeight(element.getBoundingClientRect().height);
+    measure();
+    if (typeof ResizeObserver === "undefined") {
+      return;
+    }
+    const observer = new ResizeObserver(measure);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [ref]);
+  return height;
+}
+
 function EditedFileGroupSection(props: {
   group: EditedFileGroup;
   commitState?: EditGroupCommitState;
@@ -152,10 +184,24 @@ function EditedFileGroupSection(props: {
   const [expanded, setExpanded] = useState(props.defaultExpanded);
   const bodyId = useId();
   const timestamp = formatGroupTimestamp(props.group);
+  // Feed the measured header height to `--edits-group-header-height` so an
+  // expanded file's sticky toggle pins flush beneath this group's header
+  // rather than at a guessed offset.
+  const headerRef = useRef<HTMLDivElement>(null);
+  const headerHeight = useMeasuredHeight(headerRef);
 
   return (
-    <section className="edited-file-groups__group">
-      <div className="edited-file-groups__group-header">
+    <section
+      className="edited-file-groups__group"
+      style={
+        headerHeight != null
+          ? ({
+              "--edits-group-header-height": `${headerHeight}px`,
+            } as CSSProperties)
+          : undefined
+      }
+    >
+      <div ref={headerRef} className="edited-file-groups__group-header">
         <button
           type="button"
           className="edited-file-groups__group-toggle"

--- a/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
@@ -18,6 +18,14 @@ type EditedFileGroupListProps = {
   groups: EditedFileGroup[];
   /** Git commit lifecycle per group key, from `useEditCommitStates`. */
   commitStatesByKey?: Record<string, EditGroupCommitState>;
+  /**
+   * Which view to render. Controlled by the parent so the `By turn / All
+   * files` toggle can live in the surface's fixed header (above the scroll
+   * region) instead of scrolling with the list. Defaults to `"turns"`; only
+   * meaningful with more than one group. Render `<EditedFileViewToggle>` in
+   * the header to drive it.
+   */
+  view?: EditedFileGroupView;
 };
 
 const groupTimeFormatter = new Intl.DateTimeFormat(undefined, {
@@ -39,8 +47,48 @@ const groupTimeFormatter = new Intl.DateTimeFormat(undefined, {
  */
 const VISIBLE_TURN_GROUPS = 3;
 
+/**
+ * The `By turn / All files` segmented control. Rendered by the parent in its
+ * fixed header (the context-rail Edits header, the LiveWorkRail card header)
+ * so it stays put while the list scrolls beneath it. Only worth showing when
+ * there is more than one group.
+ */
+export function EditedFileViewToggle(props: {
+  view: EditedFileGroupView;
+  onViewChange: (view: EditedFileGroupView) => void;
+}) {
+  return (
+    <div
+      className="edited-file-groups__view-toggle"
+      role="group"
+      aria-label="Edited files view"
+    >
+      <button
+        type="button"
+        className={`edited-file-groups__view-btn${
+          props.view === "turns" ? " is-active" : ""
+        }`}
+        aria-pressed={props.view === "turns"}
+        onClick={() => props.onViewChange("turns")}
+      >
+        By turn
+      </button>
+      <button
+        type="button"
+        className={`edited-file-groups__view-btn${
+          props.view === "files" ? " is-active" : ""
+        }`}
+        aria-pressed={props.view === "files"}
+        onClick={() => props.onViewChange("files")}
+      >
+        All files
+      </button>
+    </div>
+  );
+}
+
 export function EditedFileGroupList(props: EditedFileGroupListProps) {
-  const [view, setView] = useState<EditedFileGroupView>("turns");
+  const view = props.view ?? "turns";
   const [showAllTurns, setShowAllTurns] = useState(false);
 
   if (props.groups.length === 0) {
@@ -53,35 +101,6 @@ export function EditedFileGroupList(props: EditedFileGroupListProps) {
 
   return (
     <div className="edited-file-groups">
-      <div className="edited-file-groups__view-toggle">
-        <div
-          className="edited-file-groups__view-toggle-inner"
-          role="group"
-          aria-label="Edited files view"
-        >
-          <button
-            type="button"
-            className={`edited-file-groups__view-btn${
-              view === "turns" ? " is-active" : ""
-            }`}
-            aria-pressed={view === "turns"}
-            onClick={() => setView("turns")}
-          >
-            By turn
-          </button>
-          <button
-            type="button"
-            className={`edited-file-groups__view-btn${
-              view === "files" ? " is-active" : ""
-            }`}
-            aria-pressed={view === "files"}
-            onClick={() => setView("files")}
-          >
-            All files
-          </button>
-        </div>
-      </div>
-
       {view === "turns" ? (
         (() => {
           const visibleGroups = showAllTurns

--- a/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
@@ -53,31 +53,33 @@ export function EditedFileGroupList(props: EditedFileGroupListProps) {
 
   return (
     <div className="edited-file-groups">
-      <div
-        className="edited-file-groups__view-toggle"
-        role="group"
-        aria-label="Edited files view"
-      >
-        <button
-          type="button"
-          className={`edited-file-groups__view-btn${
-            view === "turns" ? " is-active" : ""
-          }`}
-          aria-pressed={view === "turns"}
-          onClick={() => setView("turns")}
+      <div className="edited-file-groups__view-toggle">
+        <div
+          className="edited-file-groups__view-toggle-inner"
+          role="group"
+          aria-label="Edited files view"
         >
-          By turn
-        </button>
-        <button
-          type="button"
-          className={`edited-file-groups__view-btn${
-            view === "files" ? " is-active" : ""
-          }`}
-          aria-pressed={view === "files"}
-          onClick={() => setView("files")}
-        >
-          All files
-        </button>
+          <button
+            type="button"
+            className={`edited-file-groups__view-btn${
+              view === "turns" ? " is-active" : ""
+            }`}
+            aria-pressed={view === "turns"}
+            onClick={() => setView("turns")}
+          >
+            By turn
+          </button>
+          <button
+            type="button"
+            className={`edited-file-groups__view-btn${
+              view === "files" ? " is-active" : ""
+            }`}
+            aria-pressed={view === "files"}
+            onClick={() => setView("files")}
+          >
+            All files
+          </button>
+        </div>
       </div>
 
       {view === "turns" ? (

--- a/apps/desktop/src/renderer/src/features/thread-detail/LiveWorkRail.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/LiveWorkRail.tsx
@@ -7,7 +7,11 @@ import type {
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { TranscriptPlan } from "./TranscriptPlan";
-import { EditedFileGroupList } from "./EditedFileGroupList";
+import {
+  EditedFileGroupList,
+  EditedFileViewToggle,
+  type EditedFileGroupView,
+} from "./EditedFileGroupList";
 import {
   summarizeEditedFileGroups,
   type EditedFileGroup,
@@ -54,6 +58,7 @@ export function LiveWorkRail(props: LiveWorkRailProps) {
     props.planEntry || editedSummary || props.changedFilesEntry,
   );
   const [collapsed, setCollapsed] = useState(false);
+  const [editedView, setEditedView] = useState<EditedFileGroupView>("turns");
   const bodyId = useId();
 
   if (!hasContent) {
@@ -92,17 +97,29 @@ export function LiveWorkRail(props: LiveWorkRailProps) {
           <span className="live-work-rail__chevron" aria-hidden="true" />
           <span className="live-work-rail__title">{railTitle}</span>
         </button>
-        {editedSummary && props.onMoveEditedFilesToSidebar ? (
-          <button
-            type="button"
-            className="live-work-rail__dock-toggle"
-            onClick={props.onMoveEditedFilesToSidebar}
-            aria-label="Move edited files to the sidebar Edits panel"
-            title="Move edited files to the sidebar Edits panel"
-          >
-            Sidebar
-          </button>
-        ) : null}
+        <div className="live-work-rail__header-actions">
+          {/* The view toggle lives in the fixed header (not the scroll body)
+              so it stays put while a long diff scrolls, and reclaims the
+              vertical band the inline toggle used to take. Only meaningful
+              with more than one turn group, and pointless while collapsed. */}
+          {editedFileGroups.length > 1 && !collapsed ? (
+            <EditedFileViewToggle
+              view={editedView}
+              onViewChange={setEditedView}
+            />
+          ) : null}
+          {editedSummary && props.onMoveEditedFilesToSidebar ? (
+            <button
+              type="button"
+              className="live-work-rail__dock-toggle"
+              onClick={props.onMoveEditedFilesToSidebar}
+              aria-label="Move edited files to the sidebar Edits panel"
+              title="Move edited files to the sidebar Edits panel"
+            >
+              Sidebar
+            </button>
+          ) : null}
+        </div>
       </header>
 
       {/* Body stays mounted across collapse toggles so the
@@ -123,6 +140,7 @@ export function LiveWorkRail(props: LiveWorkRailProps) {
             <EditedFileGroupList
               groups={editedFileGroups}
               commitStatesByKey={props.editedFileCommitStates}
+              view={editedView}
             />
           </section>
         ) : null}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/EditedFileGroupList.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/EditedFileGroupList.test.tsx
@@ -1,7 +1,12 @@
 import "@testing-library/jest-dom/vitest";
 import { afterEach, describe, expect, it } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { EditedFileGroupList } from "../EditedFileGroupList";
+import { useState } from "react";
+import {
+  EditedFileGroupList,
+  EditedFileViewToggle,
+  type EditedFileGroupView,
+} from "../EditedFileGroupList";
 import type { EditedFileGroup } from "../edited-file-groups";
 
 afterEach(cleanup);
@@ -105,11 +110,42 @@ describe("EditedFileGroupList Show more / Show less", () => {
     expect(screen.queryByText("Uncommitted")).not.toBeInTheDocument();
   });
 
-  it("does not show the turn toggle in the All files view", () => {
-    render(<EditedFileGroupList groups={groups(5)} />);
+  it("does not show the turn-overflow toggle in the All files view", () => {
+    // View is now controlled by the parent; the flattened "files" view has no
+    // per-turn grouping, so no Show more / Show less affordance.
+    render(<EditedFileGroupList groups={groups(5)} view="files" />);
 
-    fireEvent.click(screen.getByRole("button", { name: "All files" }));
     expect(screen.queryByRole("button", { name: /Show \d+ more/ })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Show less" })).not.toBeInTheDocument();
+  });
+});
+
+describe("EditedFileViewToggle", () => {
+  function Harness() {
+    const [view, setView] = useState<EditedFileGroupView>("turns");
+    return (
+      <>
+        <EditedFileViewToggle view={view} onViewChange={setView} />
+        <span data-testid="current-view">{view}</span>
+      </>
+    );
+  }
+
+  it("reflects the active view and reports changes", () => {
+    render(<Harness />);
+
+    expect(screen.getByTestId("current-view")).toHaveTextContent("turns");
+    expect(screen.getByRole("button", { name: "By turn" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "All files" }));
+
+    expect(screen.getByTestId("current-view")).toHaveTextContent("files");
+    expect(screen.getByRole("button", { name: "All files" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
   });
 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/EditsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/EditsPanel.tsx
@@ -20,7 +20,7 @@ type EditsPanelProps = {
  */
 export function EditsPanel(props: EditsPanelProps) {
   return (
-    <section className="context-panel__section">
+    <section className="context-panel__section context-panel__section--edits">
       <div className="edits-panel__header">
         <h3>Edits</h3>
         <button

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/EditsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/EditsPanel.tsx
@@ -1,5 +1,10 @@
+import { useState } from "react";
 import type { EditGroupCommitState } from "@pwragent/shared";
-import { EditedFileGroupList } from "../EditedFileGroupList";
+import {
+  EditedFileGroupList,
+  EditedFileViewToggle,
+  type EditedFileGroupView,
+} from "../EditedFileGroupList";
 import type { EditedFileGroup } from "../edited-file-groups";
 import type { EditedFilesDock } from "./context-tab";
 
@@ -17,12 +22,26 @@ type EditsPanelProps = {
  * the open thread, grouped per turn (newest first). Shows the same
  * data as the LiveWorkRail's Edited Files section; the dock toggle
  * controls whether that above-composer copy renders at all.
+ *
+ * The panel is a flex column with a FIXED header (title + view toggle +
+ * dock toggle) and an internally scrolling body, so the chrome never
+ * translates with the list — only the groups scroll, their sticky
+ * headers pinning to the body's top edge.
  */
 export function EditsPanel(props: EditsPanelProps) {
+  const [view, setView] = useState<EditedFileGroupView>("turns");
+  const hasGroups = props.groups.length > 0;
+  const showViewToggle = props.groups.length > 1;
+
   return (
     <section className="context-panel__section context-panel__section--edits">
       <div className="edits-panel__header">
-        <h3>Edits</h3>
+        <div className="edits-panel__title-group">
+          <h3>Edits</h3>
+          {showViewToggle ? (
+            <EditedFileViewToggle view={view} onViewChange={setView} />
+          ) : null}
+        </div>
         <button
           type="button"
           className="edits-panel__dock-toggle"
@@ -38,17 +57,20 @@ export function EditsPanel(props: EditsPanelProps) {
           {props.dock === "sidebar" ? "Show above composer" : "Only show here"}
         </button>
       </div>
-      {props.groups.length > 0 ? (
-        <EditedFileGroupList
-          groups={props.groups}
-          commitStatesByKey={props.commitStatesByKey}
-        />
-      ) : (
-        <p className="context-empty">
-          No uncommitted file edits yet. Edits from agent turns accumulate
-          here until they are committed.
-        </p>
-      )}
+      <div className="edits-panel__body">
+        {hasGroups ? (
+          <EditedFileGroupList
+            groups={props.groups}
+            commitStatesByKey={props.commitStatesByKey}
+            view={view}
+          />
+        ) : (
+          <p className="context-empty">
+            No uncommitted file edits yet. Edits from agent turns accumulate
+            here until they are committed.
+          </p>
+        )}
+      </div>
     </section>
   );
 }

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -132,6 +132,9 @@ describe("Tangerine Terminal theme contract", () => {
       "thinking-scanner-beam-width",
       "thinking-scanner-delay",
       "thinking-scanner-travel",
+      // Edits-rail sticky-stack geometry: a local layout custom property
+      // (set + read on `.edited-file-groups`), not a theme token.
+      "edits-view-toggle-height",
     ]);
     const tokenReferences = [...css.matchAll(/var\(--([a-z0-9-]+)\)/g)].map(
       ([, token]) => token

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -132,9 +132,6 @@ describe("Tangerine Terminal theme contract", () => {
       "thinking-scanner-beam-width",
       "thinking-scanner-delay",
       "thinking-scanner-travel",
-      // Edits-rail sticky-stack geometry: a local layout custom property
-      // (set + read on `.edited-file-groups`), not a theme token.
-      "edits-view-toggle-height",
     ]);
     const tokenReferences = [...css.matchAll(/var\(--([a-z0-9-]+)\)/g)].map(
       ([, token]) => token

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -8608,12 +8608,12 @@ textarea,
      resets font-size, so a longhand before it is silently overridden. */
   font-size: 12px;
   text-align: left;
-  /* Stay reachable while scrolling through an expanded file's diff
-     (#510). Pins BELOW the group header (the bottom rung of the sticky
-     z-index ladder) so the file row scrolls behind the group header
-     rather than over it. The `--edits-group-header-height` offset resolves
-     to 0 in the single-group view (rendered without the `.edited-file-groups`
-     wrapper, so no group header sits above it). */
+  /* Stay reachable while scrolling through an expanded file's diff (#510).
+     Pins flush BELOW its group header (whose MEASURED height feeds
+     `--edits-group-header-height`), and the group header (z-index 2) sits
+     above this row so the diff scrolls behind it. The offset resolves to 0 in
+     the single-group view (rendered without the `.edited-file-groups` wrapper,
+     so no group header sits above it). */
   position: sticky;
   top: var(--edits-group-header-height, 0px);
   z-index: 1;
@@ -8671,8 +8671,10 @@ textarea,
   /* Sticky group headers pin to the top of the surface's scroll body (the
      fixed title + view toggle live OUTSIDE that body, so nothing pins above
      them here). The per-file row, when its diff is expanded, pins just below
-     its group header — `--edits-group-header-height` is that offset. Estimate;
-     tune against the running app. */
+     its group header — `--edits-group-header-height` is that offset, set
+     per-group from the MEASURED header height (EditedFileGroupSection) so it's
+     always flush. This 52px is only the pre-measurement / no-ResizeObserver
+     fallback. */
   --edits-group-header-height: 52px;
 }
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -8598,11 +8598,15 @@ textarea,
   font-size: 12px;
   text-align: left;
   /* Stay reachable while scrolling through an expanded file's diff
-     (#510). Sticky stacking is handled by the browser: when the next
-     file-toggle reaches top, it pushes the previous one out.
-     z-index sits above the diff body. */
+     (#510). Pins BELOW the group header (which pins below the controls)
+     and sits at the bottom of the sticky z-index ladder, so the file row
+     scrolls behind the group header rather than over it. */
   position: sticky;
-  top: 0;
+  /* Fallbacks resolve to 0 in the single-group view (rendered without the
+     `.edited-file-groups` wrapper, so no controls/group header sit above). */
+  top: calc(
+    var(--edits-controls-bottom, 0px) + var(--edits-group-header-height, 0px)
+  );
   z-index: 1;
 }
 
@@ -8655,9 +8659,33 @@ textarea,
   display: flex;
   flex-direction: column;
   gap: 6px;
+  /* Sticky-stack geometry. `--edits-sticky-base` (set on the scroll
+     container) is the height of any header pinned ABOVE the view toggle:
+     0 in the LiveWorkRail (its title sits outside the scroll), the panel
+     header's height in the context-rail Edits panel. The view toggle pins at
+     the base; the group header and file rows stack below it. The heights are
+     estimates — tune against the running app. */
+  --edits-view-toggle-height: 30px;
+  --edits-group-header-height: 52px;
+  --edits-controls-bottom: calc(
+    var(--edits-sticky-base, 0px) + var(--edits-view-toggle-height)
+  );
 }
 
+/* Full-bleed sticky bar so content scrolls behind the toggle, not past the
+   sides of the pill. */
 .edited-file-groups__view-toggle {
+  position: sticky;
+  top: var(--edits-sticky-base, 0px);
+  z-index: 3;
+  display: flex;
+  align-self: stretch;
+  width: 100%;
+  padding-block: 4px;
+  background: var(--bg-panel-elevated);
+}
+
+.edited-file-groups__view-toggle-inner {
   display: inline-flex;
   align-self: flex-start;
   gap: 0;
@@ -8725,8 +8753,13 @@ textarea,
   gap: 2px;
   min-width: 0;
   position: sticky;
-  top: 0;
-  z-index: 1;
+  /* Sticky ladder (mirrors the Directories tab): the controls pin above the
+     group header, which pins above the file rows, each in a DESCENDING
+     z-index so lower levels scroll BEHIND higher ones instead of painting
+     over them. `top` stacks below the controls via `--edits-controls-bottom`
+     (the bottom edge of the pinned view toggle), set on `.edited-file-groups`. */
+  top: var(--edits-controls-bottom, 0px);
+  z-index: 2;
   padding: 5px 6px;
   border-radius: 6px;
   background: var(--bg-panel-elevated);
@@ -8877,13 +8910,23 @@ textarea,
 }
 
 /* Context-rail Edits panel: section header carries the dock toggle so
-   "Only show here" / "Show above composer" sits next to the title. */
+   "Only show here" / "Show above composer" sits next to the title.
+   Pinned at the very top of the scroll region (z-index 4 — the top of the
+   edits sticky ladder) so the title + dock toggle stay put while a long
+   diff scrolls beneath. The 8px below the title is `padding-bottom`, not
+   `margin-bottom`, so the opaque background extends through that gap and
+   no scrolled content peeks between the header and the sticky view toggle
+   that pins just under it (at `--edits-sticky-base`). */
 .edits-panel__header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  margin-bottom: 8px;
+  position: sticky;
+  top: 0;
+  z-index: 4;
+  padding-bottom: 8px;
+  background: var(--bg-panel-elevated);
 }
 
 .edits-panel__dock-toggle {
@@ -10373,6 +10416,18 @@ textarea,
 .context-panel__section--status {
   margin-top: auto;
   border-top: 1px solid var(--border-subtle);
+}
+
+/* Edits panel: the sticky "Edits" header (pinned at the scroll top) is the
+   chrome that pins ABOVE the edited-file-groups view toggle, so the toggle —
+   and the group header below it — must start beneath the header's height.
+   Feed that height to the sticky ladder via `--edits-sticky-base`. Estimate
+   (14px title + 8px padding-bottom, rounded down so the toggle overlaps the
+   header's opaque padding rather than leaving a gap); tune against the app.
+   The LiveWorkRail leaves this unset (its title sits outside the scroll
+   body, so the view toggle pins at 0). */
+.context-panel__section--edits {
+  --edits-sticky-base: 26px;
 }
 
 .context-list {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -8439,6 +8439,17 @@ textarea,
   border-bottom: 0;
 }
 
+/* Right-aligned cluster in the fixed card header: the edited-files view
+   toggle (when more than one turn group) next to the Sidebar dock toggle.
+   Holding the toggle here — outside the scroll body — keeps it put while a
+   long diff scrolls and frees the vertical band an inline toggle bar took. */
+.live-work-rail__header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
+}
+
 .live-work-rail__collapse {
   display: inline-flex;
   align-items: center;
@@ -8598,15 +8609,13 @@ textarea,
   font-size: 12px;
   text-align: left;
   /* Stay reachable while scrolling through an expanded file's diff
-     (#510). Pins BELOW the group header (which pins below the controls)
-     and sits at the bottom of the sticky z-index ladder, so the file row
-     scrolls behind the group header rather than over it. */
+     (#510). Pins BELOW the group header (the bottom rung of the sticky
+     z-index ladder) so the file row scrolls behind the group header
+     rather than over it. The `--edits-group-header-height` offset resolves
+     to 0 in the single-group view (rendered without the `.edited-file-groups`
+     wrapper, so no group header sits above it). */
   position: sticky;
-  /* Fallbacks resolve to 0 in the single-group view (rendered without the
-     `.edited-file-groups` wrapper, so no controls/group header sit above). */
-  top: calc(
-    var(--edits-controls-bottom, 0px) + var(--edits-group-header-height, 0px)
-  );
+  top: var(--edits-group-header-height, 0px);
   z-index: 1;
 }
 
@@ -8659,36 +8668,20 @@ textarea,
   display: flex;
   flex-direction: column;
   gap: 6px;
-  /* Sticky-stack geometry. `--edits-sticky-base` (set on the scroll
-     container) is the height of any header pinned ABOVE the view toggle:
-     0 in the LiveWorkRail (its title sits outside the scroll), the panel
-     header's height in the context-rail Edits panel. The view toggle pins at
-     the base; the group header and file rows stack below it. The heights are
-     estimates — tune against the running app. */
-  --edits-view-toggle-height: 30px;
+  /* Sticky group headers pin to the top of the surface's scroll body (the
+     fixed title + view toggle live OUTSIDE that body, so nothing pins above
+     them here). The per-file row, when its diff is expanded, pins just below
+     its group header — `--edits-group-header-height` is that offset. Estimate;
+     tune against the running app. */
   --edits-group-header-height: 52px;
-  --edits-controls-bottom: calc(
-    var(--edits-sticky-base, 0px) + var(--edits-view-toggle-height)
-  );
 }
 
-/* Full-bleed sticky bar so content scrolls behind the toggle, not past the
-   sides of the pill. */
+/* `By turn / All files` segmented control. Rendered in the surface's fixed
+   header (Edits-panel header, LiveWorkRail card header), not the scroll body. */
 .edited-file-groups__view-toggle {
-  position: sticky;
-  top: var(--edits-sticky-base, 0px);
-  z-index: 3;
-  display: flex;
-  align-self: stretch;
-  width: 100%;
-  padding-block: 4px;
-  background: var(--bg-panel-elevated);
-}
-
-.edited-file-groups__view-toggle-inner {
   display: inline-flex;
-  align-self: flex-start;
   gap: 0;
+  flex: 0 0 auto;
   border: 1px solid var(--border-subtle);
   border-radius: 6px;
   overflow: hidden;
@@ -8744,7 +8737,7 @@ textarea,
 
 /* Two-row card header: the "Edited N files" summary gets its own line so
    the commit badges can't crush it, with the badge + date on a wrapping
-   second line. Sticky so the header pins to the top of the scroll region
+   second line. Sticky so the header pins to the top of the scroll body
    while a long diff scrolls beneath it (the opaque card background hides the
    scrolled content). */
 .edited-file-groups__group-header {
@@ -8753,12 +8746,11 @@ textarea,
   gap: 2px;
   min-width: 0;
   position: sticky;
-  /* Sticky ladder (mirrors the Directories tab): the controls pin above the
-     group header, which pins above the file rows, each in a DESCENDING
-     z-index so lower levels scroll BEHIND higher ones instead of painting
-     over them. `top` stacks below the controls via `--edits-controls-bottom`
-     (the bottom edge of the pinned view toggle), set on `.edited-file-groups`. */
-  top: var(--edits-controls-bottom, 0px);
+  /* Pins to the top of the surface's scroll body (the title + view toggle are
+     a fixed header OUTSIDE the body, so nothing pins above this). z-index 2
+     sits ABOVE the file row (z-index 1) so an expanded diff scrolls BEHIND the
+     group header instead of painting over it — mirroring the Directories tab. */
+  top: 0;
   z-index: 2;
   padding: 5px 6px;
   border-radius: 6px;
@@ -8909,24 +8901,41 @@ textarea,
   font-size: 11px;
 }
 
-/* Context-rail Edits panel: section header carries the dock toggle so
-   "Only show here" / "Show above composer" sits next to the title.
-   Pinned at the very top of the scroll region (z-index 4 — the top of the
-   edits sticky ladder) so the title + dock toggle stay put while a long
-   diff scrolls beneath. The 8px below the title is `padding-bottom`, not
-   `margin-bottom`, so the opaque background extends through that gap and
-   no scrolled content peeks between the header and the sticky view toggle
-   that pins just under it (at `--edits-sticky-base`). */
+/* Context-rail Edits panel: a FIXED header (it lives outside the panel's
+   scroll body, so it never translates with the list) carrying the title, the
+   view toggle, and the dock toggle. Left group = title + `By turn / All files`;
+   right = "Only show here" / "Show above composer". */
 .edits-panel__header {
+  flex: 0 0 auto;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  position: sticky;
-  top: 0;
-  z-index: 4;
-  padding-bottom: 8px;
-  background: var(--bg-panel-elevated);
+  padding: 12px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.edits-panel__title-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+/* Scroll body: only the edited-file groups scroll, their sticky headers
+   pinning to this body's top edge. `padding-top: 0` lets the first group
+   header pin flush; the 8px of breathing room above it is restored as a
+   first-child margin that scrolls away with the content. */
+.edits-panel__body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 0 12px 12px;
+}
+
+.edits-panel__body > *:first-child {
+  margin-block-start: 8px;
 }
 
 .edits-panel__dock-toggle {
@@ -10418,16 +10427,19 @@ textarea,
   border-top: 1px solid var(--border-subtle);
 }
 
-/* Edits panel: the sticky "Edits" header (pinned at the scroll top) is the
-   chrome that pins ABOVE the edited-file-groups view toggle, so the toggle —
-   and the group header below it — must start beneath the header's height.
-   Feed that height to the sticky ladder via `--edits-sticky-base`. Estimate
-   (14px title + 8px padding-bottom, rounded down so the toggle overlaps the
-   header's opaque padding rather than leaving a gap); tune against the app.
-   The LiveWorkRail leaves this unset (its title sits outside the scroll
-   body, so the view toggle pins at 0). */
-.context-panel__section--edits {
-  --edits-sticky-base: 26px;
+/* Edits panel fills the tab as a flex column: a fixed `.edits-panel__header`
+   over an internally scrolling `.edits-panel__body`. Overrides the default
+   section padding (the header + body own their own insets) so the body's
+   sticky group headers pin to its top edge with no translate. The outer
+   `.context-panel__scroll` then never scrolls for this tab — the section is
+   exactly its height and the body owns the overflow. */
+.context-panel__section.context-panel__section--edits {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  height: 100%;
+  padding: 0;
+  border-bottom: 0;
 }
 
 .context-list {


### PR DESCRIPTION
## What

Two sticky-layout bugs on the edited-files surfaces (the context-rail **Edits** panel and the above-composer **LiveWorkRail**):

1. **Title + controls scrolled up a few px before pinning.** They lived *inside* the scroll region, and a sticky element always translates with content until it reaches its offset — so the "Edits" title and the `By turn / All files` toggle drifted up on scroll instead of staying put.
2. **An expanded diff painted *over* the per-turn group header** instead of scrolling behind it — the group header shared `z-index: 1` with the file rows.

## How

The robust fix is to keep the chrome **out of the scroll region** rather than try to pin it inside it. Per review feedback, the toggle also moves *up into the header row*, reclaiming the vertical band the toggle bar used.

- **`EditedFileGroupList`** is now a controlled list — `view` comes from the parent — and the segmented control is extracted as **`EditedFileViewToggle`** for the parent to render in its fixed header.
- **Context-rail `EditsPanel`** becomes a flex column: a fixed `.edits-panel__header` (title + view toggle + dock toggle) over an internally scrolling `.edits-panel__body`. The section fills the tab (`height: 100%`), so the outer `.context-panel__scroll` never scrolls for this tab and the body owns the overflow. The header physically can't translate.
- **`LiveWorkRail`** renders the toggle in its existing fixed card header (left of **Sidebar**), so it's fixed for free; the body keeps scrolling.

This collapses the sticky stack from four rungs back to two and **removes the fragile pixel estimates**:

| Level | z-index | pins at |
|---|---|---|
| Group header | 2 | `top: 0` (scroll-body top) |
| File row (expanded diff, #510) | 1 | `--edits-group-header-height` |

`--edits-group-header-height` is the only remaining estimate (the offset that keeps an expanded file's filename reachable below its group header).

## Resolves the prior review

- **Single-group correctness gap** closes naturally: with the toggle gone from the list, the file-toggle offset resolves to `0` and pins at the body top *beneath* the fixed header.
- Drops `--edits-sticky-base`, `--edits-controls-bottom`, `--edits-view-toggle-height`, the full-bleed sticky bar, and the theme-contract allowlist entry that came with them — so the stale-comment / redundant-`width` / sticky-base-math nits are gone with the code.

## Tests
- `pnpm test` — `EditedFileGroupList` (controlled-view + new `EditedFileViewToggle` coverage), thread-detail suite, theme-contract: all green (300 passed).
- Typecheck + `pnpm lint:colors` clean.
- The single-group `live-work-rail-sticky-gap` E2E fixture is structurally unaffected (file-toggle offset stays `0`, still pins flush with the body top).

## ⚠️ Still wants a screenshot pass
The structural jiggle is fixed by construction now (the header isn't in the scroll). Worth eyeballing: (a) the toggle next to **Edits** / left of **Sidebar** on a narrow rail, and (b) `--edits-group-header-height: 52px` for the #510 filename pin in a long multi-group diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)