### PR TITLE
fix(desktop): extend thread list cache reuse

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -5540,6 +5540,63 @@ script = "echo setup"
     await registry.close();
   });
 
+  it("bypasses completed thread-list cache entries for forced navigation refreshes", async () => {
+    const codexClient = new MockBackendClient({
+      threads: [
+        {
+          id: "thread-codex",
+          title: "Codex thread",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({}),
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await expect(
+      registry.listThreads({
+        backend: "codex",
+        callerReason: "navigation-snapshot",
+      }),
+    ).resolves.toMatchObject([{ id: "thread-codex" }]);
+    const initialReadCount = codexClient.listThreadsCallCount;
+
+    codexClient.setThreads([
+      {
+        id: "thread-codex-new",
+        title: "New Codex thread",
+        titleSource: "explicit",
+        source: "codex",
+        linkedDirectories: [],
+      },
+    ]);
+
+    await expect(
+      registry.listThreads({
+        backend: "codex",
+        callerReason: "navigation-snapshot",
+      }),
+    ).resolves.toMatchObject([{ id: "thread-codex" }]);
+    expect(codexClient.listThreadsCallCount).toBe(initialReadCount);
+
+    await expect(
+      registry.listThreads({
+        backend: "codex",
+        callerReason: "navigation-snapshot",
+        forceRefresh: true,
+      }),
+    ).resolves.toMatchObject([{ id: "thread-codex-new" }]);
+
+    expect(codexClient.listThreadsCallCount).toBeGreaterThan(initialReadCount);
+
+    await registry.close();
+  });
+
   it("keeps cheap navigation lists separate from directory-enriched thread lists", async () => {
     const codexClient = new MockBackendClient({
       threads: [

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -3766,6 +3766,7 @@ export class DesktopBackendRegistry {
     callerReason?: ThreadListCallerReason;
     enrichDirectories?: boolean;
     filter?: string;
+    forceRefresh?: boolean;
   } = {}): Promise<AppServerThreadSummary[]> {
     // Hard gate: the bootstrap profile MUST NEVER serve thread data,
     // regardless of what the bootstrap config.toml's onboarding
@@ -3816,6 +3817,7 @@ export class DesktopBackendRegistry {
         enrichDirectories: normalizedParams.enrichDirectories,
         expiresInMs: cached.expiresInMs,
         filterPresent: Boolean(normalizedParams.filter?.trim()),
+        forceRefresh: normalizedParams.forceRefresh === true,
         pending: cached.pending,
         source: cached.source,
         threadCount: cached.threadCount,
@@ -3830,6 +3832,7 @@ export class DesktopBackendRegistry {
       callerReason: normalizedParams.callerReason ?? "thread-list",
       enrichDirectories: normalizedParams.enrichDirectories,
       filterPresent: Boolean(normalizedParams.filter?.trim()),
+      forceRefresh: normalizedParams.forceRefresh === true,
     });
     const promise = this.readThreadList(normalizedParams)
       .then((threads) => {
@@ -3845,6 +3848,7 @@ export class DesktopBackendRegistry {
           enrichDirectories: normalizedParams.enrichDirectories,
           expiresInMs: THREAD_LIST_REUSE_WINDOW_MS,
           filterPresent: Boolean(normalizedParams.filter?.trim()),
+          forceRefresh: normalizedParams.forceRefresh === true,
           threadCount: threads.length,
         });
         return threads;
@@ -3859,6 +3863,7 @@ export class DesktopBackendRegistry {
           enrichDirectories: normalizedParams.enrichDirectories,
           error: error instanceof Error ? error.message : String(error),
           filterPresent: Boolean(normalizedParams.filter?.trim()),
+          forceRefresh: normalizedParams.forceRefresh === true,
         });
         throw error;
       });
@@ -8903,6 +8908,7 @@ export class DesktopBackendRegistry {
     callerReason?: ThreadListCallerReason;
     enrichDirectories?: boolean;
     filter?: string;
+    forceRefresh?: boolean;
   }): string {
     const codexDirectoryBackfill =
       params.backend === "grok" ||
@@ -8928,10 +8934,15 @@ export class DesktopBackendRegistry {
       callerReason?: ThreadListCallerReason;
       enrichDirectories?: boolean;
       filter?: string;
+      forceRefresh?: boolean;
     },
     cacheKey: string,
     now: number,
   ): ThreadListCacheHit | undefined {
+    if (params.forceRefresh === true) {
+      return this.readPendingThreadListCache(cacheKey, "exact");
+    }
+
     const exact = this.readFreshThreadListCache(cacheKey, now, "exact");
     if (exact) {
       return exact;
@@ -8981,6 +8992,22 @@ export class DesktopBackendRegistry {
       };
     }
     return undefined;
+  }
+
+  private readPendingThreadListCache(
+    cacheKey: string,
+    source: ThreadListCacheHit["source"],
+  ): ThreadListCacheHit | undefined {
+    const cached = this.threadListCache.get(cacheKey);
+    if (!cached?.promise) {
+      return undefined;
+    }
+    return {
+      cacheKey,
+      pending: true,
+      source,
+      value: cached.promise,
+    };
   }
 
   private invalidateThreadListCache(backend?: AppServerBackendKind): void {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -284,9 +284,10 @@ type InitializeResult = {
 
 const isDevelopment = process.env.NODE_ENV !== "production";
 const REPLAY_THREAD_TITLE_ENV = "PWRAGENT_REPLAY_THREAD_TITLE";
-// Keep startup prewarm useful through renderer parse/effect scheduling. Thread
-// lifecycle notifications still invalidate this cache when the list changes.
-const THREAD_LIST_REUSE_WINDOW_MS = 5_000;
+// Keep expensive Codex thread-list walks reusable across focus/navigation bursts.
+// Thread lifecycle notifications still invalidate this cache when list metadata
+// changes, so this window can be much longer than initial renderer scheduling.
+const THREAD_LIST_REUSE_WINDOW_MS = 60_000;
 const ACTIVE_TURN_HANDOFF_ERROR =
   "Worktree/local migration is not available while a turn is in progress. Resubmit when the turn completes.";
 /**
@@ -9158,10 +9159,12 @@ export class DesktopBackendRegistry {
       method === "thread/parent/cleared" ||
       method === "thread/parent/set" ||
       method === "thread/started" ||
+      method === "thread/status/changed" ||
       method === "thread/subAgents/updated" ||
       method === "thread/subthreadOrder/updated" ||
       method === "thread/subthreadsCollapsed/updated" ||
       method === "thread/unarchived" ||
+      method === "turn/cancelled" ||
       method === "turn/completed" ||
       method === "turn/failed"
     );

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -2165,6 +2165,15 @@ type ThreadListCacheState = {
   threads?: AppServerThreadSummary[];
 };
 
+type ThreadListCacheHit = {
+  cacheKey: string;
+  expiresInMs?: number;
+  pending: boolean;
+  source: "exact" | "navigation-shared";
+  threadCount?: number;
+  value: Promise<AppServerThreadSummary[]> | AppServerThreadSummary[];
+};
+
 let threadListCacheSequence = 0;
 
 function shouldEnrichThreadDirectories(
@@ -3798,19 +3807,57 @@ export class DesktopBackendRegistry {
     const now = Date.now();
     const cached = this.findReusableThreadListCache(normalizedParams, cacheKey, now);
     if (cached) {
-      return await cached;
+      logDebug("threadListCache:hit", {
+        archived: normalizedParams.archived === true,
+        backend: normalizedParams.backend ?? "all",
+        callerReason: normalizedParams.callerReason ?? "thread-list",
+        enrichDirectories: normalizedParams.enrichDirectories,
+        expiresInMs: cached.expiresInMs,
+        filterPresent: Boolean(normalizedParams.filter?.trim()),
+        pending: cached.pending,
+        source: cached.source,
+        threadCount: cached.threadCount,
+      });
+      return await cached.value;
     }
 
+    const startedAt = Date.now();
+    logDebug("threadListCache:miss", {
+      archived: normalizedParams.archived === true,
+      backend: normalizedParams.backend ?? "all",
+      callerReason: normalizedParams.callerReason ?? "thread-list",
+      enrichDirectories: normalizedParams.enrichDirectories,
+      filterPresent: Boolean(normalizedParams.filter?.trim()),
+    });
     const promise = this.readThreadList(normalizedParams)
       .then((threads) => {
         this.threadListCache.set(cacheKey, {
           expiresAt: Date.now() + THREAD_LIST_REUSE_WINDOW_MS,
           threads,
         });
+        logDebug("threadListCache:store", {
+          archived: normalizedParams.archived === true,
+          backend: normalizedParams.backend ?? "all",
+          callerReason: normalizedParams.callerReason ?? "thread-list",
+          durationMs: Date.now() - startedAt,
+          enrichDirectories: normalizedParams.enrichDirectories,
+          expiresInMs: THREAD_LIST_REUSE_WINDOW_MS,
+          filterPresent: Boolean(normalizedParams.filter?.trim()),
+          threadCount: threads.length,
+        });
         return threads;
       })
       .catch((error) => {
         this.threadListCache.delete(cacheKey);
+        logDebug("threadListCache:error", {
+          archived: normalizedParams.archived === true,
+          backend: normalizedParams.backend ?? "all",
+          callerReason: normalizedParams.callerReason ?? "thread-list",
+          durationMs: Date.now() - startedAt,
+          enrichDirectories: normalizedParams.enrichDirectories,
+          error: error instanceof Error ? error.message : String(error),
+          filterPresent: Boolean(normalizedParams.filter?.trim()),
+        });
         throw error;
       });
     this.threadListCache.set(cacheKey, { promise });
@@ -8882,8 +8929,8 @@ export class DesktopBackendRegistry {
     },
     cacheKey: string,
     now: number,
-  ): Promise<AppServerThreadSummary[]> | AppServerThreadSummary[] | undefined {
-    const exact = this.readFreshThreadListCache(cacheKey, now);
+  ): ThreadListCacheHit | undefined {
+    const exact = this.readFreshThreadListCache(cacheKey, now, "exact");
     if (exact) {
       return exact;
     }
@@ -8904,18 +8951,34 @@ export class DesktopBackendRegistry {
     if (backfillCapableKey === cacheKey) {
       return undefined;
     }
-    return this.readFreshThreadListCache(backfillCapableKey, now);
+    return this.readFreshThreadListCache(backfillCapableKey, now, "navigation-shared");
   }
 
   private readFreshThreadListCache(
     cacheKey: string,
     now: number,
-  ): Promise<AppServerThreadSummary[]> | AppServerThreadSummary[] | undefined {
+    source: ThreadListCacheHit["source"],
+  ): ThreadListCacheHit | undefined {
     const cached = this.threadListCache.get(cacheKey);
     if (cached?.threads && (cached.expiresAt ?? 0) > now) {
-      return cached.threads;
+      return {
+        cacheKey,
+        expiresInMs: Math.max(0, (cached.expiresAt ?? 0) - now),
+        pending: false,
+        source,
+        threadCount: cached.threads.length,
+        value: cached.threads,
+      };
     }
-    return cached?.promise;
+    if (cached?.promise) {
+      return {
+        cacheKey,
+        pending: true,
+        source,
+        value: cached.promise,
+      };
+    }
+    return undefined;
   }
 
   private invalidateThreadListCache(backend?: AppServerBackendKind): void {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -286,8 +286,9 @@ const isDevelopment = process.env.NODE_ENV !== "production";
 const REPLAY_THREAD_TITLE_ENV = "PWRAGENT_REPLAY_THREAD_TITLE";
 // Keep expensive Codex thread-list walks reusable across focus/navigation bursts.
 // Thread lifecycle notifications still invalidate this cache when list metadata
-// changes, so this window can be much longer than initial renderer scheduling.
-const THREAD_LIST_REUSE_WINDOW_MS = 60_000;
+// changes, so this window can cover ordinary foreground idle time while
+// background polling catches external Codex changes on a slower cadence.
+const THREAD_LIST_REUSE_WINDOW_MS = 5 * 60_000;
 const ACTIVE_TURN_HANDOFF_ERROR =
   "Worktree/local migration is not available while a turn is in progress. Resubmit when the turn completes.";
 /**

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -263,6 +263,14 @@ const GENERATED_CODEX_SERVER_REQUEST_METHODS = new Set<CodexServerRequestMethod>
 ]);
 const codexClientLog = getMainLogger("pwragent:codex-client");
 
+function logCodexClientDebug(event: string, payload: Record<string, unknown>): void {
+  if (process.env.NODE_ENV === "production") {
+    return;
+  }
+
+  codexClientLog.info(event, payload);
+}
+
 function isApprovalLikeMethod(method: string): boolean {
   return method.endsWith("/requestApproval");
 }
@@ -4823,6 +4831,13 @@ async function requestThreadListPages(params: {
 }): Promise<RawCodexThreadSummary[]> {
   const pages: RawCodexThreadSummary[] = [];
   const seenCursors = new Set<string>();
+  const startedAt = Date.now();
+  let maxPageThreads = 0;
+  let maxPreviewBytes = 0;
+  let pageCount = 0;
+  let previewBytes = 0;
+  let rawThreadCount = 0;
+  let terminalReason: "no-next-cursor" | "repeated-cursor" | undefined;
   let cursor: string | undefined;
 
   do {
@@ -4835,9 +4850,24 @@ async function requestThreadListPages(params: {
     });
     const page = extractThreadListPage(result);
     pages.push(...page.threads);
+    pageCount += 1;
+    rawThreadCount += page.threads.length;
+    maxPageThreads = Math.max(maxPageThreads, page.threads.length);
+    for (const thread of page.threads) {
+      const threadPreviewBytes =
+        typeof thread.preview === "string" ? Buffer.byteLength(thread.preview) : 0;
+      previewBytes += threadPreviewBytes;
+      maxPreviewBytes = Math.max(maxPreviewBytes, threadPreviewBytes);
+    }
 
     const nextCursor = page.nextCursor?.trim();
-    if (!nextCursor || seenCursors.has(nextCursor)) {
+    if (!nextCursor) {
+      terminalReason = "no-next-cursor";
+      cursor = undefined;
+      break;
+    }
+    if (seenCursors.has(nextCursor)) {
+      terminalReason = "repeated-cursor";
       cursor = undefined;
       break;
     }
@@ -4846,7 +4876,23 @@ async function requestThreadListPages(params: {
     cursor = nextCursor;
   } while (cursor);
 
-  return mergeThreadSummaries(pages);
+  const mergedThreads = mergeThreadSummaries(pages);
+  logCodexClientDebug("threadListPages", {
+    archived: params.archived === true,
+    callerReason: params.diagnostics?.callerReason ?? "thread-list",
+    durationMs: Date.now() - startedAt,
+    filterPresent: Boolean(params.filter?.trim()),
+    maxPageThreads,
+    maxPreviewBytes,
+    mergedThreadCount: mergedThreads.length,
+    ownerId: params.diagnostics?.ownerId,
+    pageCount,
+    previewBytes,
+    rawThreadCount,
+    terminalReason,
+  });
+
+  return mergedThreads;
 }
 
 type HelperTurnResult =

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -1117,6 +1117,21 @@ function normalizeThreadSummary(value: string | undefined): string | undefined {
   return trimmed;
 }
 
+function measureThreadPreviewBytes(thread: RawCodexThreadSummary): number {
+  const record = asRecord(thread);
+  if (!record) {
+    return 0;
+  }
+  const preview = pickString(record, [
+    "preview",
+    "summary",
+    "snippet",
+    "firstUserMessage",
+    "first_user_message",
+  ]);
+  return preview ? Buffer.byteLength(preview) : 0;
+}
+
 function normalizeSessionOriginator(value: string | undefined): string | undefined {
   const normalized = value?.trim().toLowerCase();
   return normalized || undefined;
@@ -4854,8 +4869,7 @@ async function requestThreadListPages(params: {
     rawThreadCount += page.threads.length;
     maxPageThreads = Math.max(maxPageThreads, page.threads.length);
     for (const thread of page.threads) {
-      const threadPreviewBytes =
-        typeof thread.preview === "string" ? Buffer.byteLength(thread.preview) : 0;
+      const threadPreviewBytes = measureThreadPreviewBytes(thread);
       previewBytes += threadPreviewBytes;
       maxPreviewBytes = Math.max(maxPreviewBytes, threadPreviewBytes);
     }

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -357,6 +357,7 @@ function getNavigationSnapshotRequestKey(
   return JSON.stringify({
     backend: request.backend ?? "all",
     filter: request.filter ?? "",
+    forceRefresh: request.forceRefresh === true,
   });
 }
 
@@ -879,6 +880,7 @@ class DesktopAppServerService {
       backend: backend === "all" ? undefined : backend,
       callerReason: "navigation-snapshot",
       filter: request.filter,
+      forceRefresh: request.forceRefresh,
     });
     const messagingBindingsByThreadKey = await buildMessagingBindingsByThreadKey(threads);
     const automationsByThreadKey = buildAutomationSummariesByThreadKey();

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -61,6 +61,7 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
       backend: backend === "all" ? undefined : backend,
       callerReason: "messaging-navigation-snapshot",
       filter: request.filter,
+      forceRefresh: request.forceRefresh,
     });
     const messagingBindingsByThreadKey = await buildMessagingBindingsByThreadKey(threads);
     const queuedExecutionModesByThreadKey =

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -762,6 +762,69 @@ describe("useThreadNavigation", () => {
     });
   });
 
+  it("forces background navigation refreshes to bypass backend thread-list cache", async () => {
+    let intervalHandler: (() => void) | undefined;
+    const originalSetInterval = globalThis.setInterval;
+    vi.spyOn(globalThis, "setInterval").mockImplementation((handler, timeout, ...args) => {
+      if (timeout !== 5 * 60_000) {
+        return originalSetInterval(handler, timeout, ...args);
+      }
+      intervalHandler = typeof handler === "function" ? () => handler() : undefined;
+      return 1 as unknown as ReturnType<typeof setInterval>;
+    });
+
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: ["codex:thread-1"],
+      threads: [
+        {
+          id: "thread-1",
+          title: "First thread",
+          titleSource: "explicit" as const,
+          summary: "First thread summary",
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: {
+            inInbox: true,
+            reason: "new-thread" as const,
+          },
+          updatedAt: 1_000,
+        },
+      ],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+    };
+
+    const { result, unmount } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.id).toBe("thread-1");
+    });
+
+    expect(getNavigationSnapshot).toHaveBeenCalledTimes(1);
+    expect(getNavigationSnapshot.mock.calls[0]).toEqual([]);
+    expect(intervalHandler).toBeDefined();
+
+    act(() => {
+      intervalHandler?.();
+    });
+
+    await waitFor(() => {
+      expect(getNavigationSnapshot).toHaveBeenCalledTimes(2);
+      expect(getNavigationSnapshot).toHaveBeenLastCalledWith({ forceRefresh: true });
+    });
+
+    unmount();
+  });
+
   it("applies streamed directory git status updates without refreshing the snapshot", async () => {
     const listeners = new Set<(event: any) => void>();
     const getNavigationSnapshot = vi.fn(async () => ({

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -91,6 +91,10 @@ type NavigationState = {
   response?: NavigationSnapshot;
 };
 
+type NavigationRefreshOptions = {
+  forceRefresh?: boolean;
+};
+
 function buildLaunchpadSelectionKey(directoryKey: string): string {
   return `launchpad:${directoryKey}`;
 }
@@ -2069,6 +2073,7 @@ export function useThreadNavigation(
   const refreshInFlightRef = useRef(false);
   const queuedRefreshRef = useRef<
     | {
+        forceRefresh?: boolean;
         forcePreferredSelection?: boolean;
         preferredOptimisticThread?: NavigationThreadSummary;
         preferredSelectionKey?: string;
@@ -2129,7 +2134,8 @@ export function useThreadNavigation(
     async (
       preferredSelectionKey?: string,
       preferredOptimisticThread?: NavigationThreadSummary,
-      forcePreferredSelection = false
+      forcePreferredSelection = false,
+      options?: NavigationRefreshOptions
     ): Promise<void> => {
       if (!enabled) {
         setState({
@@ -2159,8 +2165,11 @@ export function useThreadNavigation(
       }));
 
       try {
+        const snapshot = options?.forceRefresh
+          ? await desktopApi.getNavigationSnapshot({ forceRefresh: true })
+          : await desktopApi.getNavigationSnapshot();
         const response = removeThreadKeysFromSnapshot(
-          await desktopApi.getNavigationSnapshot(),
+          snapshot,
           suppressedArchivedThreadKeysRef.current
         );
         const optimisticSelection = preferredOptimisticThread ?? optimisticThreadRef.current;
@@ -2238,9 +2247,11 @@ export function useThreadNavigation(
     async (
       preferredSelectionKey?: string,
       preferredOptimisticThread?: NavigationThreadSummary,
-      forcePreferredSelection = false
+      forcePreferredSelection = false,
+      options?: NavigationRefreshOptions
     ): Promise<void> => {
       const initialRequest = {
+        forceRefresh: options?.forceRefresh === true,
         forcePreferredSelection,
         preferredOptimisticThread,
         preferredSelectionKey,
@@ -2260,7 +2271,8 @@ export function useThreadNavigation(
           await performRefresh(
             nextRequest.preferredSelectionKey,
             nextRequest.preferredOptimisticThread,
-            nextRequest.forcePreferredSelection
+            nextRequest.forcePreferredSelection,
+            { forceRefresh: nextRequest.forceRefresh }
           );
           nextRequest = queuedRefreshRef.current;
         }
@@ -2278,9 +2290,12 @@ export function useThreadNavigation(
     (
       preferredSelectionKey?: string,
       preferredOptimisticThread?: NavigationThreadSummary,
-      forcePreferredSelection = false
+      forcePreferredSelection = false,
+      options?: NavigationRefreshOptions
     ): void => {
       queuedRefreshRef.current = {
+        forceRefresh:
+          options?.forceRefresh === true || queuedRefreshRef.current?.forceRefresh === true,
         forcePreferredSelection,
         preferredOptimisticThread,
         preferredSelectionKey,
@@ -2301,7 +2316,8 @@ export function useThreadNavigation(
         void refresh(
           nextRequest.preferredSelectionKey,
           nextRequest.preferredOptimisticThread,
-          nextRequest.forcePreferredSelection
+          nextRequest.forcePreferredSelection,
+          { forceRefresh: nextRequest.forceRefresh }
         );
       }, 0);
     },
@@ -2357,7 +2373,9 @@ export function useThreadNavigation(
     }
 
     const timer = setInterval(() => {
-      scheduleRefresh();
+      scheduleRefresh(undefined, undefined, false, {
+        forceRefresh: true,
+      });
     }, NAVIGATION_BACKGROUND_REFRESH_INTERVAL_MS);
 
     return () => {

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -53,7 +53,7 @@ export type ArchiveThreadOptions = {
 
 const ROOT_NEW_THREAD_WORKSPACE_LAUNCHPAD_KEY = "workspace:new-thread";
 const ROOT_NEW_THREAD_WORKSPACE_LABEL = "Workspaces";
-const NAVIGATION_BACKGROUND_REFRESH_INTERVAL_MS = 30_000;
+const NAVIGATION_BACKGROUND_REFRESH_INTERVAL_MS = 5 * 60_000;
 const DEFAULT_BROWSE_MODE: BrowseMode = "inbox";
 
 function normalizeBrowseMode(value: unknown): BrowseMode {

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -643,6 +643,7 @@ export type NavigationSnapshot = {
 export type GetNavigationSnapshotRequest = {
   backend?: AppServerBackendScope;
   filter?: string;
+  forceRefresh?: boolean;
 };
 
 export type SetNavigationBrowseModeRequest = {


### PR DESCRIPTION
## Summary

- I extended the desktop thread-list reuse window from 5 seconds to 5 minutes so focus/navigation bursts and ordinary foreground idle time do not immediately repaginate expensive Codex `thread/list` calls.
- I slowed renderer background navigation refresh from 30 seconds to 5 minutes after protocol capture showed the old cadence punched through the 60-second backend cache every ~90 seconds.
- I added development-only instrumentation for registry cache hits/misses/stores and Codex pagination summaries, including caller reason, page counts, thread counts, preview byte totals, timing, and cache source.
- I expanded cache invalidation to include `thread/status/changed` and `turn/cancelled`, keeping the longer reuse window tied to lifecycle updates.

## Verification

- I verified the focused Codex/thread-list tests pass: `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/main/__tests__/codex-client.test.ts -- --runInBand`
- I verified the backend-registry suite after the cache-policy change: `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts -- --runInBand`
- I verified the 5-minute cache/background-refresh tuning: `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx -- --runInBand`
- I verified desktop typecheck: `pnpm --filter @pwragent/desktop typecheck`
- I manually re-ran the protocol-capture workflow on the PR branch: startup was 1.7 MB, selecting one thread grew to 2.5 MB, waiting 2 minutes stayed at 2.5 MB, and waiting 6 minutes grew to 4.1 MB from one background navigation refresh.
- I ran `git diff --check`

## Notes

- This is the immediate mitigation for repeated full Codex thread-list walks. A protocol-level metadata-only/no-preview list call is still the cleaner long-term fix.
