### PR TITLE
fix(desktop): standardize expand/collapse chevrons to one disclosure language

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -849,6 +849,10 @@ export function DirectoriesList(props: DirectoriesListProps) {
             })()}
           >
             <span className="directory-row__summary-main">
+              <span
+                aria-hidden="true"
+                className={`directory-row__chevron${expanded ? " is-open" : ""}`}
+              />
               <span aria-hidden="true" className="directory-row__icon">
                 {directory.kind === "workspace" ? (
                   <WorkspaceIcon size={14} />
@@ -869,10 +873,6 @@ export function DirectoriesList(props: DirectoriesListProps) {
                   {directory.needsAttentionCount}
                 </span>
               ) : null}
-              <span
-                aria-hidden="true"
-                className={`directory-row__chevron${expanded ? " is-open" : ""}`}
-              />
             </span>
           </button>
 

--- a/apps/desktop/src/renderer/src/features/settings/SettingsLayout.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsLayout.tsx
@@ -395,6 +395,7 @@ export function SettingsSection(props: {
         onClick={handleHeaderClick}
         onKeyDown={handleHeaderKeyDown}
       >
+        <span className="settings-section__chevron" aria-hidden="true" />
         <div className="settings-section__header-main">
           {props.eyebrow ? <p className="eyebrow">{props.eyebrow}</p> : null}
           <h2 id={headingId}>{props.title}</h2>
@@ -404,7 +405,6 @@ export function SettingsSection(props: {
         </div>
         <span className="settings-section__header-actions">
           {props.chip ? <span className={chipClass}>{props.chip}</span> : null}
-          <span className="settings-section__chevron" aria-hidden="true" />
         </span>
       </div>
       <div

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-section-chevron.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-section-chevron.test.tsx
@@ -1,0 +1,34 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { SettingsSection } from "../SettingsLayout";
+
+afterEach(cleanup);
+
+describe("settings section disclosure chevron placement", () => {
+  it("renders the chevron as the first child of the header, before the title block", () => {
+    const { container } = render(
+      <SettingsSection title="Telegram">
+        <div>body</div>
+      </SettingsSection>
+    );
+
+    const header = container.querySelector(".settings-section__header-button");
+    expect(header).not.toBeNull();
+
+    const children = [...(header as HTMLElement).children];
+    expect(children[0]).toHaveClass("settings-section__chevron");
+    expect(children[1]).toHaveClass("settings-section__header-main");
+  });
+
+  it("no longer renders the chevron inside the right-side header actions", () => {
+    const { container } = render(
+      <SettingsSection title="Telegram">
+        <div>body</div>
+      </SettingsSection>
+    );
+
+    const actions = container.querySelector(".settings-section__header-actions");
+    expect(actions?.querySelector(".settings-section__chevron")).toBeNull();
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptActivity.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptActivity.tsx
@@ -42,8 +42,8 @@ export function TranscriptActivity(props: TranscriptActivityProps) {
                 setIsExpanded((current) => !current);
               }}
             >
-              <span className="transcript-activity__label">{props.entry.summary}</span>
               <span className="transcript-activity__chevron" aria-hidden="true" />
+              <span className="transcript-activity__label">{props.entry.summary}</span>
             </button>
             <span className="transcript-activity__header-actions">
               <TranscriptCopyButton

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptWorkPhaseGroup.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptWorkPhaseGroup.tsx
@@ -42,14 +42,12 @@ export const TranscriptWorkPhaseGroup = memo(function TranscriptWorkPhaseGroup(
           aria-expanded={props.expanded}
           onClick={props.onToggle}
         >
+          <span className="transcript-work-phase-group__chevron" aria-hidden="true" />
           <span>
             <TranscriptWorkPhaseGroupLabel
               activeStartedAt={props.activeStartedAt}
               label={props.label}
             />
-          </span>
-          <span className="transcript-work-phase-group__chevron" aria-hidden="true">
-            {props.expanded ? "^" : "v"}
           </span>
         </button>
       ) : (

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/chevron-placement.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/chevron-placement.test.tsx
@@ -1,0 +1,53 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AppServerThreadActivityEntry } from "@pwragent/shared";
+import { TranscriptActivity } from "../TranscriptActivity";
+import { TranscriptWorkPhaseGroup } from "../TranscriptWorkPhaseGroup";
+
+afterEach(cleanup);
+
+const activityEntry: AppServerThreadActivityEntry = {
+  type: "activity",
+  id: "activity-1",
+  summary: "Turn usage",
+  // A detail makes the entry collapsible, so the toggle + chevron render.
+  details: [{ id: "detail-1", kind: "read", label: "read a file" }],
+};
+
+describe("transcript disclosure chevron placement", () => {
+  it("renders the activity chevron before its label (left of the label)", () => {
+    const { container } = render(<TranscriptActivity entry={activityEntry} />);
+
+    const toggle = container.querySelector(".transcript-activity__toggle");
+    expect(toggle).not.toBeNull();
+
+    const children = [...(toggle as HTMLElement).children];
+    expect(children[0]).toHaveClass("transcript-activity__chevron");
+    expect(children[1]).toHaveClass("transcript-activity__label");
+  });
+
+  it("renders the previous-messages chevron as an empty element before the label", () => {
+    const { container } = render(
+      <TranscriptWorkPhaseGroup
+        collapsible
+        expanded={false}
+        label="3 previous messages"
+        entries={[]}
+        skills={[]}
+        onToggle={vi.fn()}
+      />
+    );
+
+    const toggle = container.querySelector(".transcript-work-phase-group__toggle");
+    expect(toggle).not.toBeNull();
+
+    const children = [...(toggle as HTMLElement).children];
+    // Chevron is the first child (left of the label).
+    expect(children[0]).toHaveClass("transcript-work-phase-group__chevron");
+    // Migrated off the literal "v"/"^" text glyph to a CSS border chevron,
+    // so the element carries no text of its own.
+    expect(children[0]?.textContent).toBe("");
+    expect((toggle as HTMLElement).textContent).toContain("3 previous messages");
+  });
+});

--- a/apps/desktop/src/renderer/src/styles/__tests__/chevron-contract.test.ts
+++ b/apps/desktop/src/renderer/src/styles/__tests__/chevron-contract.test.ts
@@ -1,0 +1,124 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Locks the shared disclosure-chevron language (PR #795). Every inline
+ * expand/collapse chevron must point RIGHT when collapsed (`rotate(-45deg)`)
+ * and rotate 90deg to point DOWN when expanded (`rotate(45deg)`). The
+ * direction lives entirely in CSS, so it can only be asserted here, not in
+ * a render test. The sidebar thread-tree triangle is a deliberate FILLED
+ * exception and is asserted separately.
+ */
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const css = readFileSync(path.resolve(testDir, "../app.css"), "utf8");
+
+/** Body of the first top-level CSS rule whose selector matches exactly. */
+function ruleBody(selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = css.match(
+    new RegExp(`(?:^|\\n)${escaped}\\s*\\{(?<body>[\\s\\S]*?)\\n\\}`)
+  );
+  if (!match?.groups?.body) {
+    throw new Error(`Expected app.css to define ${selector}`);
+  }
+  return match.groups.body;
+}
+
+// Each row names the selector that styles the COLLAPSED state and the one
+// that styles the EXPANDED state. (For most chevrons the base element rule
+// is the collapsed state; for the settings header the base is the expanded
+// state because the panel defaults to open — either way the contract is the
+// same: collapsed -> rotate(-45deg), expanded -> rotate(45deg).)
+const INLINE_CHEVRONS: Array<{ name: string; collapsed: string; expanded: string }> = [
+  {
+    name: "transcript activity entry",
+    collapsed: ".transcript-activity__chevron",
+    expanded: '.transcript-activity__toggle[aria-expanded="true"] .transcript-activity__chevron',
+  },
+  {
+    name: "transcript activity nested detail",
+    collapsed: ".transcript-activity__chevron",
+    expanded:
+      '.transcript-activity__detail-toggle[aria-expanded="true"] .transcript-activity__chevron',
+  },
+  {
+    name: "previous-messages work-phase group",
+    collapsed: ".transcript-work-phase-group__chevron",
+    expanded:
+      '.transcript-work-phase-group__toggle[aria-expanded="true"] .transcript-work-phase-group__chevron',
+  },
+  {
+    name: "sidebar directory header",
+    collapsed: ".directory-row__chevron",
+    expanded: ".directory-row__chevron.is-open",
+  },
+  {
+    name: "settings section header",
+    collapsed: ".settings-panel--is-collapsed .settings-section__chevron::before",
+    expanded: ".settings-section__chevron::before",
+  },
+  {
+    name: "edited-files group toggle",
+    collapsed: '.edited-file-groups__group-toggle[aria-expanded="false"] .live-work-rail__chevron',
+    expanded: '.edited-file-groups__group-toggle[aria-expanded="true"] .live-work-rail__chevron',
+  },
+  {
+    name: "live-work-rail file toggle",
+    collapsed: '.live-work-rail__file-toggle[aria-expanded="false"] .live-work-rail__chevron',
+    expanded: '.live-work-rail__file-toggle[aria-expanded="true"] .live-work-rail__chevron',
+  },
+];
+
+// The base element rule that paints each unfilled chevron's "V" shape.
+const UNFILLED_BASE_RULES = [
+  ".transcript-activity__chevron",
+  ".transcript-work-phase-group__chevron",
+  ".directory-row__chevron",
+  ".settings-section__chevron::before",
+  ".live-work-rail__chevron",
+];
+
+describe("chevron disclosure direction contract", () => {
+  it.each(INLINE_CHEVRONS)(
+    "$name points right when collapsed (rotate(-45deg))",
+    ({ collapsed }) => {
+      const body = ruleBody(collapsed);
+      expect(body).toContain("rotate(-45deg)");
+      // "rotate(-45deg)" never contains the substring "rotate(45deg)", so
+      // this guards against an expanded value leaking into a collapsed rule.
+      expect(body).not.toContain("rotate(45deg)");
+    }
+  );
+
+  it.each(INLINE_CHEVRONS)(
+    "$name points down when expanded (rotate(45deg))",
+    ({ expanded }) => {
+      const body = ruleBody(expanded);
+      expect(body).toContain("rotate(45deg)");
+      expect(body).not.toContain("rotate(-45deg)");
+    }
+  );
+
+  it.each(UNFILLED_BASE_RULES)("%s is an unfilled border chevron", (selector) => {
+    const body = ruleBody(selector);
+    expect(body).toContain("border-right");
+    expect(body).toContain("border-bottom");
+  });
+
+  it("never uses the old 180deg flip (rotate(225deg)) anywhere", () => {
+    // The pre-#795 transcript/directory chevrons flipped down->up via
+    // rotate(225deg). The unified language never does; guard against it
+    // creeping back in on any selector.
+    expect(css).not.toContain("rotate(225deg)");
+  });
+
+  it("keeps the sidebar thread-tree as a deliberate FILLED-triangle exception", () => {
+    // Intentionally NOT the unfilled -45/45 language: filled = navigation
+    // tree, unfilled = inline content disclosure. A solid triangle via
+    // border-left that swings 0 -> 90deg.
+    expect(ruleBody(".thread-row__subthread-toggle::before")).toContain("border-left");
+    expect(ruleBody(".thread-row__subthread-toggle.is-open::before")).toContain("rotate(90deg)");
+  });
+});

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3696,12 +3696,9 @@ textarea,
      padding drop, each directory header now reads ~22px taller
      than the comfortable touch target instead of 54px. */
   min-height: 32px;
-  /* Lateral inset: 4px on the left mirrors the gap from the
-     selected-row border to the folder icon; 10px on the right gives
-     the chevron the same visual breathing room from the
-     selected-row border on the opposite edge (chevron is a
-     rotated-square glyph so it visually crowds its bounding-box
-     right edge more than the folder icon crowds its left). */
+  /* Lateral inset: 4px on the left sits before the disclosure chevron
+     and folder icon; 10px on the right gives the meta block (attention
+     count pill) breathing room from the selected-row border. */
   padding: 4px 10px 4px 4px;
 }
 
@@ -3748,6 +3745,9 @@ textarea,
 }
 
 .directory-row__chevron {
+  /* Standard inline disclosure chevron (see .live-work-rail__chevron):
+     points right when collapsed, rotates 90deg to point down when
+     expanded. Sits at the left of the row, before the folder icon. */
   display: inline-flex;
   flex: 0 0 auto;
   width: 9px;
@@ -3756,11 +3756,11 @@ textarea,
   border-bottom: 1.75px solid var(--text-muted);
   opacity: 0.82;
   transition: transform 120ms ease;
-  transform: rotate(45deg) translateY(-1px);
+  transform: rotate(-45deg);
 }
 
 .directory-row__chevron.is-open {
-  transform: rotate(225deg) translateY(1px);
+  transform: rotate(45deg);
 }
 
 .directory-row__launchpad-button {
@@ -5294,17 +5294,20 @@ textarea,
 }
 
 .settings-section__chevron::before {
+  /* Standard inline disclosure chevron (see .live-work-rail__chevron):
+     down when expanded, right when collapsed. Now left of the section
+     title, so the right-placement translate nudges are dropped. */
   width: 7px;
   height: 7px;
   border-right: 1.5px solid currentColor;
   border-bottom: 1.5px solid currentColor;
   content: "";
-  transform: translateY(-1px) rotate(45deg);
+  transform: rotate(45deg);
   transition: transform 120ms ease;
 }
 
 .settings-panel--is-collapsed .settings-section__chevron::before {
-  transform: translateX(-2px) rotate(-45deg);
+  transform: rotate(-45deg);
 }
 
 .settings-section__header-button:hover .settings-section__chevron,
@@ -7972,7 +7975,22 @@ textarea,
 }
 
 .transcript-work-phase-group__chevron {
+  /* Standard inline disclosure chevron (see .live-work-rail__chevron): an
+     unfilled border "V", right when collapsed, down when expanded. Replaces
+     the old "v"/"^" text glyph so it matches every other disclosure. */
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 8px;
+  height: 8px;
+  border-right: 1.5px solid currentColor;
+  border-bottom: 1.5px solid currentColor;
   color: var(--text-muted);
+  transform: rotate(-45deg);
+  transition: transform 120ms ease;
+}
+
+.transcript-work-phase-group__toggle[aria-expanded="true"] .transcript-work-phase-group__chevron {
+  transform: rotate(45deg);
 }
 
 .transcript-work-phase-group__content {
@@ -8571,6 +8589,18 @@ textarea,
 
 .live-work-rail__file-toggle[aria-expanded="false"] .live-work-rail__chevron {
   transform: rotate(-45deg);
+}
+
+/* The committed "Edited files" group toggles reuse .live-work-rail__chevron
+   but sit on .edited-file-groups__group-toggle, so they need their own
+   rotation hooks — without these the chevron was stuck pointing down in
+   both states instead of animating right (collapsed) -> down (expanded). */
+.edited-file-groups__group-toggle[aria-expanded="false"] .live-work-rail__chevron {
+  transform: rotate(-45deg);
+}
+
+.edited-file-groups__group-toggle[aria-expanded="true"] .live-work-rail__chevron {
+  transform: rotate(45deg);
 }
 
 .live-work-rail__body {
@@ -9760,8 +9790,8 @@ textarea,
   min-width: 0;
   flex: 1 1 auto;
   align-items: center;
-  justify-content: space-between;
-  gap: 12px;
+  justify-content: flex-start;
+  gap: 8px;
   padding: 4px 12px;
   border: 0;
   border-radius: 4px;
@@ -9804,17 +9834,21 @@ textarea,
 }
 
 .transcript-activity__chevron {
+  /* Standard inline disclosure chevron (see .live-work-rail__chevron): an
+     unfilled border "V" that points right when collapsed and rotates 90deg
+     to point down when expanded. Rendered to the left of the label. */
+  display: inline-block;
+  flex: 0 0 auto;
   width: 8px;
   height: 8px;
-  margin-top: -2px;
   border-right: 1.5px solid var(--text-muted);
   border-bottom: 1.5px solid var(--text-muted);
-  transform: rotate(45deg);
+  transform: rotate(-45deg);
   transition: transform 120ms ease;
 }
 
 .transcript-activity__toggle[aria-expanded="true"] .transcript-activity__chevron {
-  transform: rotate(225deg);
+  transform: rotate(45deg);
 }
 
 .transcript-activity__details {
@@ -9863,7 +9897,7 @@ textarea,
 }
 
 .transcript-activity__detail-toggle[aria-expanded="true"] .transcript-activity__chevron {
-  transform: rotate(225deg);
+  transform: rotate(45deg);
 }
 
 .transcript-activity__detail-label {


### PR DESCRIPTION
## Problem

The app shipped **four different disclosure-chevron treatments**, which read inconsistently:

| Surface | Shape | Side | Closed → Open | Standard? |
|---|---|---|---|---|
| Sidebar thread tree (`.thread-row__subthread-toggle`) | Filled ▶ | Left | ▶ → ▼ (90°) | ✅ |
| Edited-files group (`.live-work-rail__chevron`) | Unfilled V | Left | (static ▼ — never rotated) | ⚠️ |
| Transcript activity (Turn Usage / Env setup) | Unfilled V | Right | ▼ → ▲ (180°) | ❌ |
| "N previous messages" | **Text glyph `v`/`^`** | Right | v → ^ | ❌ |
| Directory header | Unfilled V | Right | ▼ → ▲ (180°) | ❌ |
| Settings section headers | Unfilled V | Right | ▶ → ▼ (right-placed) | ❌ |

The transcript/header chevrons pointed **down when closed / up when open** (a 180° flip nobody uses), sat on the **right**, and one was a literal text glyph. The settings chevron pointed the right direction but sat far to the right of the title — you'd read "Telegram" and then have to look all the way across the row to find its expand state, and a right-placed ▶ points off the edge rather than toward the content it opens.

## Fix — one inline disclosure language

Unfilled border "V", **points right when collapsed → rotates 90° to point down when expanded**, placed **left of the label** (matching `.live-work-rail__chevron` and the filled sidebar tree triangle):

- **Transcript activity entries** — chevron moved left; 180° flip → 90° right→down; dropped the `translateY` hack.
- **"N previous messages"** — `v`/`^` text glyph replaced with the border-V chevron, moved left, right→down. *(Accessible name unchanged; chevron is `aria-hidden`.)*
- **Sidebar directory header** — chevron moved from far-right to the left of the row (before the folder icon, Finder-style); 180° flip → 90° right→down.
- **Settings section headers** — chevron moved from far-right to the left of the title; dropped the right-placement translate nudges. State is now readable next to the label, and ▶-collapsed points toward the title it expands.
- **Committed "Edited files" group toggle** — added the missing rotation hooks. It reused `.live-work-rail__chevron` but had no rotation selector for `.edited-file-groups__group-toggle`, so it was **stuck pointing down** in both states. Now animates right→down.

## Deliberately left as-is

- **Sidebar thread-tree triangle** stays a **filled** triangle — the conventional tree-node affordance, already right→down. Decision: *filled = navigation tree, unfilled = inline content disclosure.*
- **Composer project-picker caret** is a dropdown indicator, not an expander.

## Tests

- **`chevron-contract.test.ts`** — CSS text contract (direction lives in CSS, not the DOM): every inline chevron is `rotate(-45deg)` collapsed / `rotate(45deg)` expanded, the unfilled base rules carry `border-right` + `border-bottom`, the old `rotate(225deg)` 180° flip appears nowhere, and the filled thread-tree triangle stays a documented `rotate(90deg)` exception.
- **`chevron-placement.test.tsx`** — transcript activity + "previous messages" chevrons render to the left of their label; the previous-messages chevron is now an empty element (off the `v`/`^` glyph).
- **`settings-section-chevron.test.tsx`** — settings chevron is the header's first child, no longer in the right-side actions.
- All green; `pnpm --filter @pwragent/desktop typecheck` clean; existing `transcript-list.test.tsx` 60/60.

## Verification

- Rebased on current `main` (clean replay; only `app.css` overlapped upstream and in non-adjacent regions). Complementary to #799 (parent-card inset), which this does not touch.
- Settings left-placement **visually confirmed** (collapsed ▶ / expanded ▼ read cleanly). Directory-header left-placement still worth a glance.

## Follow-up

Three non-blocking polish items (shared-primitive consolidation, `display` value unification, hover-color consistency) tracked in #805.

🤖 Generated with [Claude Code](https://claude.com/claude-code)