### PR TITLE
fix(desktop): gate lightweight navigation refresh

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -29,6 +29,10 @@ const listThreads = vi.fn(async (request?: {
   archived?: boolean;
   backend?: "codex" | "grok";
   filter?: string;
+  forceRefresh?: boolean;
+  limit?: number;
+  maxPages?: number;
+  skipArchivedMetadataRefresh?: boolean;
 }) =>
   request?.archived
     ? [
@@ -521,6 +525,10 @@ describe("app server ipc", () => {
       backend: undefined,
       callerReason: "navigation-snapshot",
       filter: undefined,
+      forceRefresh: undefined,
+      limit: undefined,
+      maxPages: undefined,
+      skipArchivedMetadataRefresh: false,
     });
     expect(reconcileNavigationSnapshot).toHaveBeenCalledWith({
       backend: "all",
@@ -562,6 +570,87 @@ describe("app server ipc", () => {
         executionMode: "default",
       },
     });
+  });
+
+  it("uses one active recent page for lightweight navigation refreshes", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+
+    registerAppServerIpcHandlers();
+
+    await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.(
+      {},
+      {
+        forceRefresh: true,
+        refreshMode: "active-recent",
+      } satisfies GetNavigationSnapshotRequest,
+    );
+
+    expect(listThreads).toHaveBeenCalledWith({
+      backend: undefined,
+      callerReason: "navigation-snapshot:active-recent",
+      filter: undefined,
+      forceRefresh: true,
+      limit: 50,
+      maxPages: 1,
+      skipArchivedMetadataRefresh: true,
+    });
+  });
+
+  it("merges lightweight navigation refreshes into the last full thread list", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+
+    const staleThread = {
+      id: "thread-stale",
+      title: "Stale thread",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      linkedDirectories: [],
+      updatedAt: 1_000,
+    };
+    const recentThread = {
+      id: "thread-recent",
+      title: "Recent thread",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      linkedDirectories: [],
+      updatedAt: 2_000,
+    };
+    const updatedRecentThread = {
+      ...recentThread,
+      title: "Updated recent thread",
+      updatedAt: 3_000,
+    };
+    listThreads
+      .mockResolvedValueOnce([recentThread, staleThread])
+      .mockResolvedValueOnce([updatedRecentThread]);
+
+    registerAppServerIpcHandlers();
+
+    await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.(
+      {},
+      {} satisfies GetNavigationSnapshotRequest,
+    );
+    await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.(
+      {},
+      {
+        forceRefresh: true,
+        refreshMode: "active-recent",
+      } satisfies GetNavigationSnapshotRequest,
+    );
+
+    expect(reconcileNavigationSnapshot).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        threads: [
+          expect.objectContaining({
+            id: "thread-recent",
+            title: "Updated recent thread",
+          }),
+          expect.objectContaining({ id: "thread-stale" }),
+        ],
+      }),
+    );
   });
 
   it("returns backend scope all when listing threads without a backend filter", async () => {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -983,6 +983,9 @@ class MockBackendClient {
     archived?: boolean;
     enrichDirectories?: boolean;
     filter?: string;
+    limit?: number;
+    maxPages?: number;
+    skipArchivedMetadataRefresh?: boolean;
   }, diagnostics?: { callerReason?: string; ownerId?: string }): Promise<AppServerThreadSummary[]> {
     this.listThreadsCallCount += 1;
     this.lastListThreadsDiagnostics = diagnostics;
@@ -5669,6 +5672,69 @@ script = "echo setup"
     ).resolves.toMatchObject([{ id: "thread-codex-new" }]);
 
     expect(codexClient.listThreadsCallCount).toBeGreaterThan(initialReadCount);
+
+    await registry.close();
+  });
+
+  it("does not run archive cleanup from partial active-recent Codex lists", async () => {
+    const codexClient = new MockBackendClient({
+      archivedThreads: [
+        {
+          id: "thread-codex",
+          title: "Archived Codex thread",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          archivedAt: 2_000,
+        },
+      ],
+      threads: [
+        {
+          id: "thread-codex",
+          title: "Codex thread",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({}),
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await registry.listThreads({
+      backend: "codex",
+      callerReason: "navigation-snapshot",
+    });
+    codexClient.setThreads([
+      {
+        id: "thread-codex-new",
+        title: "New Codex thread",
+        titleSource: "explicit",
+        source: "codex",
+        linkedDirectories: [],
+      },
+    ]);
+
+    await registry.listThreads({
+      backend: "codex",
+      callerReason: "navigation-snapshot:active-recent",
+      forceRefresh: true,
+      limit: 50,
+      maxPages: 1,
+      skipArchivedMetadataRefresh: true,
+    });
+    await Promise.resolve();
+
+    expect(codexClient.listThreadsCalls).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          params: expect.objectContaining({ archived: true }),
+        }),
+      ]),
+    );
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -5728,6 +5728,12 @@ script = "echo setup"
     });
     await Promise.resolve();
 
+    expect(codexClient.lastListThreadsParams).toMatchObject({
+      enrichDirectories: false,
+      limit: 50,
+      maxPages: 1,
+      skipArchivedMetadataRefresh: true,
+    });
     expect(codexClient.listThreadsCalls).not.toEqual(
       expect.arrayContaining([
         expect.objectContaining({

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -3017,6 +3017,34 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("forwards metadata-only thread/read requests to Codex", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => []
+    });
+
+    await client.readThread({
+      threadId: "thread-2",
+      includeTurns: false
+    });
+
+    const transport = MockTransport.instances.at(-1);
+    expect(transport).toBeDefined();
+
+    const readRequest = transport!.sentMessages
+      .map((message) => JSON.parse(message) as { method?: string; params?: unknown })
+      .find((message) => message.method === "thread/read");
+
+    expect(readRequest?.params).toMatchObject({
+      threadId: "thread-2",
+      includeTurns: false
+    });
+
+    await client.close();
+  });
+
   it("preserves image parts from Codex thread/read messages", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
 

--- a/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
@@ -125,6 +125,22 @@ describe("desktopSettingsPatchToEdits — experimental", () => {
     ]);
   });
 
+  it("writes the lightweight navigation refresh flag", () => {
+    const edits = desktopSettingsPatchToEdits({
+      experimental: {
+        lightweightNavigationRefresh: true,
+      },
+    });
+
+    expect(edits).toEqual([
+      {
+        op: "set",
+        path: ["experimental", "lightweight_navigation_refresh"],
+        value: true,
+      },
+    ]);
+  });
+
   it("writes the thread pricing summary flag", () => {
     const edits = desktopSettingsPatchToEdits({
       experimental: {

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -1648,6 +1648,37 @@ describe("DesktopSettingsService", () => {
     );
   });
 
+  it("defaults lightweight navigation refresh to false and persists it", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    const service = new DesktopSettingsService({
+      configPath,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    const initial = await service.readSettings();
+    expect(initial.experimental.lightweightNavigationRefresh).toEqual({
+      value: false,
+      source: "default",
+    });
+
+    await service.writeConfigPatch({
+      experimental: {
+        lightweightNavigationRefresh: true,
+      },
+    });
+
+    const updated = await service.readSettings();
+    expect(updated.experimental.lightweightNavigationRefresh).toEqual({
+      value: true,
+      source: "config",
+    });
+    expect(fs.readFileSync(configPath, "utf8")).toContain(
+      "lightweight_navigation_refresh = true",
+    );
+  });
+
   it("defaults thread pricing summary to false and persists it", async () => {
     const root = createTempRoot();
     const configPath = path.join(root, "config.toml");

--- a/apps/desktop/src/main/__tests__/grok-app-server-client.test.ts
+++ b/apps/desktop/src/main/__tests__/grok-app-server-client.test.ts
@@ -149,6 +149,60 @@ describe("GrokAppServerClient", () => {
     await client.close();
   });
 
+  it("forwards metadata-only and bounded read options to the Grok app server", async () => {
+    const readParams: Record<string, unknown>[] = [];
+    const server = {
+      request: async (method: string, params: Record<string, unknown>): Promise<unknown> => {
+        if (method === "initialize") {
+          return {
+            serverInfo: { name: "@pwragent/grok-app-server", version: "1.0.0" },
+            methods: ["thread/read"],
+          };
+        }
+        if (method === "thread/read") {
+          readParams.push(params);
+          return {
+            threadId: "thread-1",
+            thread: { threadId: "thread-1" },
+            messages: [],
+            items: [],
+          };
+        }
+        throw new Error(`Unexpected request ${method}`);
+      },
+      notify: async () => undefined,
+      onNotification: () => () => undefined,
+    };
+    const client = new GrokAppServerClient({ server });
+
+    await client.readThread({
+      threadId: "thread-1",
+      includeTurns: false,
+      limit: 0,
+    });
+    await client.readThread({
+      threadId: "thread-1",
+      before: "cursor-before-1",
+      limit: 5,
+    });
+
+    expect(readParams).toEqual([
+      {
+        threadId: "thread-1",
+        includeTurns: false,
+        limit: 0,
+      },
+      {
+        threadId: "thread-1",
+        includeTurns: true,
+        before: "cursor-before-1",
+        limit: 5,
+      },
+    ]);
+
+    await client.close();
+  });
+
   it("retries initialization when the initialized notification fails", async () => {
     let initializeRequestCount = 0;
     let initializedNotificationCount = 0;

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -2558,6 +2558,7 @@ type ThreadListCallerReason =
   | "ipc-list-threads"
   | "messaging-navigation-snapshot"
   | "navigation-snapshot"
+  | "navigation-snapshot:active-recent"
   | "startup-prewarm"
   | "title-generation"
   | "workspace-handoff"
@@ -2588,6 +2589,7 @@ function shouldEnrichThreadDirectories(
     case "branch-drift":
     case "messaging-navigation-snapshot":
     case "navigation-snapshot":
+    case "navigation-snapshot:active-recent":
     case "startup-prewarm":
     case "title-generation":
     case "turn-cwd":
@@ -2604,6 +2606,7 @@ function shouldBackfillCodexDirectoryRelationships(
     case "directory-relationship-reconcile":
     case "messaging-navigation-snapshot":
     case "navigation-snapshot":
+    case "navigation-snapshot:active-recent":
     case "startup-prewarm":
       return true;
     default:

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -371,7 +371,14 @@ type BackendClient = {
   close(): Promise<void>;
   getInitializeResult(): Promise<InitializeResult>;
   listThreads(
-    params?: { archived?: boolean; enrichDirectories?: boolean; filter?: string },
+    params?: {
+      archived?: boolean;
+      enrichDirectories?: boolean;
+      filter?: string;
+      limit?: number;
+      maxPages?: number;
+      skipArchivedMetadataRefresh?: boolean;
+    },
     diagnostics?: { callerReason?: string; ownerId?: string },
   ): Promise<AppServerThreadSummary[]>;
   enrichThreadDirectories?(
@@ -4191,6 +4198,9 @@ export class DesktopBackendRegistry {
     enrichDirectories?: boolean;
     filter?: string;
     forceRefresh?: boolean;
+    limit?: number;
+    maxPages?: number;
+    skipArchivedMetadataRefresh?: boolean;
   } = {}): Promise<AppServerThreadSummary[]> {
     // Hard gate: the bootstrap profile MUST NEVER serve thread data,
     // regardless of what the bootstrap config.toml's onboarding
@@ -4242,6 +4252,10 @@ export class DesktopBackendRegistry {
         expiresInMs: cached.expiresInMs,
         filterPresent: Boolean(normalizedParams.filter?.trim()),
         forceRefresh: normalizedParams.forceRefresh === true,
+        limit: normalizedParams.limit,
+        maxPages: normalizedParams.maxPages,
+        skipArchivedMetadataRefresh:
+          normalizedParams.skipArchivedMetadataRefresh === true,
         pending: cached.pending,
         source: cached.source,
         threadCount: cached.threadCount,
@@ -4257,6 +4271,10 @@ export class DesktopBackendRegistry {
       enrichDirectories: normalizedParams.enrichDirectories,
       filterPresent: Boolean(normalizedParams.filter?.trim()),
       forceRefresh: normalizedParams.forceRefresh === true,
+      limit: normalizedParams.limit,
+      maxPages: normalizedParams.maxPages,
+      skipArchivedMetadataRefresh:
+        normalizedParams.skipArchivedMetadataRefresh === true,
     });
     const promise = this.readThreadList(normalizedParams)
       .then((threads) => {
@@ -4273,6 +4291,10 @@ export class DesktopBackendRegistry {
           expiresInMs: THREAD_LIST_REUSE_WINDOW_MS,
           filterPresent: Boolean(normalizedParams.filter?.trim()),
           forceRefresh: normalizedParams.forceRefresh === true,
+          limit: normalizedParams.limit,
+          maxPages: normalizedParams.maxPages,
+          skipArchivedMetadataRefresh:
+            normalizedParams.skipArchivedMetadataRefresh === true,
           threadCount: threads.length,
         });
         return threads;
@@ -4288,6 +4310,10 @@ export class DesktopBackendRegistry {
           error: error instanceof Error ? error.message : String(error),
           filterPresent: Boolean(normalizedParams.filter?.trim()),
           forceRefresh: normalizedParams.forceRefresh === true,
+          limit: normalizedParams.limit,
+          maxPages: normalizedParams.maxPages,
+          skipArchivedMetadataRefresh:
+            normalizedParams.skipArchivedMetadataRefresh === true,
         });
         throw error;
       });
@@ -4309,6 +4335,9 @@ export class DesktopBackendRegistry {
     callerReason?: ThreadListCallerReason;
     enrichDirectories: boolean;
     filter?: string;
+    limit?: number;
+    maxPages?: number;
+    skipArchivedMetadataRefresh?: boolean;
   }): Promise<AppServerThreadSummary[]> {
     const diagnostics = {
       callerReason: params.callerReason ?? "thread-list",
@@ -4324,14 +4353,19 @@ export class DesktopBackendRegistry {
           archived: params.archived,
           enrichDirectories: params.enrichDirectories,
           filter: params.filter,
+          limit: params.limit,
+          maxPages: params.maxPages,
+          skipArchivedMetadataRefresh: params.skipArchivedMetadataRefresh,
         }, diagnostics),
       });
-      this.scheduleThreadListArchiveStateCleanup({
-        backend: "codex",
-        filter: params.filter,
-        archived: params.archived,
-        threads,
-      });
+      if (!params.skipArchivedMetadataRefresh) {
+        this.scheduleThreadListArchiveStateCleanup({
+          backend: "codex",
+          filter: params.filter,
+          archived: params.archived,
+          threads,
+        });
+      }
       return threads;
     }
 
@@ -4374,6 +4408,9 @@ export class DesktopBackendRegistry {
         callerReason: params.callerReason,
         enrichDirectories: params.enrichDirectories,
         filter: params.filter,
+        limit: params.limit,
+        maxPages: params.maxPages,
+        skipArchivedMetadataRefresh: params.skipArchivedMetadataRefresh,
       }),
       this.listThreads({
         backend: "grok",
@@ -9526,6 +9563,9 @@ export class DesktopBackendRegistry {
     enrichDirectories?: boolean;
     filter?: string;
     forceRefresh?: boolean;
+    limit?: number;
+    maxPages?: number;
+    skipArchivedMetadataRefresh?: boolean;
   }): string {
     const codexDirectoryBackfill =
       params.backend === "grok" ||
@@ -9541,6 +9581,9 @@ export class DesktopBackendRegistry {
       enrichDirectories:
         params.backend === "grok" ? undefined : params.enrichDirectories === true,
       filter: params.filter?.trim() ?? "",
+      limit: params.limit,
+      maxPages: params.maxPages,
+      skipArchivedMetadataRefresh: params.skipArchivedMetadataRefresh === true,
     });
   }
 
@@ -9552,6 +9595,9 @@ export class DesktopBackendRegistry {
       enrichDirectories?: boolean;
       filter?: string;
       forceRefresh?: boolean;
+      limit?: number;
+      maxPages?: number;
+      skipArchivedMetadataRefresh?: boolean;
     },
     cacheKey: string,
     now: number,
@@ -10143,6 +10189,9 @@ export class DesktopBackendRegistry {
     archived?: boolean;
     enrichDirectories?: boolean;
     filter?: string;
+    limit?: number;
+    maxPages?: number;
+    skipArchivedMetadataRefresh?: boolean;
   } = {}, diagnostics?: {
     callerReason?: string;
     ownerId?: string;

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -410,6 +410,7 @@ type BackendClient = {
   ): () => void;
   readThread(params: {
     threadId: string;
+    includeTurns?: boolean;
     before?: string;
     limit?: number;
   }): Promise<AppServerReadThreadResponse["replay"]>;
@@ -3347,6 +3348,68 @@ function buildCodexParentDynamicToolSpecs(
   ];
 }
 
+function pageNormalizedReplay(
+  replay: AppServerThreadReplay,
+  options: {
+    before?: string;
+    includeTurns?: boolean;
+    limit?: number;
+  },
+): AppServerThreadReplay {
+  if (options.includeTurns === false) {
+    return {
+      ...replay,
+      entries: [],
+      messages: [],
+      lastUserMessage: undefined,
+      lastAssistantMessage: undefined,
+      pagination: {
+        supportsPagination: false,
+        hasPreviousPage: false,
+      },
+    };
+  }
+
+  if (options.limit === undefined && !options.before) {
+    return replay;
+  }
+
+  const endIndex = options.before
+    ? replay.entries.findIndex((entry) => entry.id === options.before)
+    : replay.entries.length;
+  const boundedEndIndex = endIndex >= 0 ? endIndex : replay.entries.length;
+  const limit =
+    options.limit === undefined ? undefined : Math.max(0, Math.floor(options.limit));
+  const startIndex = limit === undefined ? 0 : Math.max(0, boundedEndIndex - limit);
+  const entries = replay.entries.slice(startIndex, boundedEndIndex);
+  const messages = entries.flatMap((entry) =>
+    entry.type === "message"
+      ? [
+          {
+            id: entry.id,
+            role: entry.role,
+            text: entry.text,
+            ...(entry.parts ? { parts: entry.parts } : {}),
+            ...(entry.createdAt ? { createdAt: entry.createdAt } : {}),
+          },
+        ]
+      : [],
+  );
+  const firstEntry = entries[0];
+  const hasPreviousPage = startIndex > 0;
+
+  return {
+    ...replay,
+    entries,
+    messages,
+    pagination: {
+      supportsPagination: true,
+      hasPreviousPage,
+      ...(hasPreviousPage && firstEntry ? { previousCursor: firstEntry.id } : {}),
+    },
+  };
+}
+
 export class DesktopBackendRegistry {
   private readonly codexClient: BackendClient;
   private readonly grokClient: BackendClient;
@@ -4682,7 +4745,10 @@ export class DesktopBackendRegistry {
       throw new Error(`ACP session not found: ${request.threadId}`);
     }
 
-    const replay = await this.acpBackend.readReplay(backend, request.threadId);
+    const replay = pageNormalizedReplay(
+      await this.acpBackend.readReplay(backend, request.threadId),
+      request,
+    );
     return {
       backend,
       fetchedAt: Date.now(),
@@ -5776,6 +5842,7 @@ export class DesktopBackendRegistry {
             async (client) =>
               await client.readThread({
                 threadId: request.threadId,
+                includeTurns: request.includeTurns,
                 before: request.before,
                 limit: request.limit,
               }),
@@ -5786,11 +5853,12 @@ export class DesktopBackendRegistry {
           )
         : await this.grokClient.readThread({
             threadId: request.threadId,
+            includeTurns: request.includeTurns,
             before: request.before,
             limit: request.limit,
           });
 
-    if (backend === "codex" && !request.before) {
+    if (backend === "codex" && !request.before && request.includeTurns !== false) {
       await this.repairCodexThreadDirectoryRelationship({
         reason: "selected-thread",
         threadId: request.threadId,
@@ -5801,17 +5869,21 @@ export class DesktopBackendRegistry {
       backend,
       threadId: request.threadId,
     });
-    const replayWithEnvironment = appendCodexEnvironmentSetupActivity({
-      replay,
-      runtime: overlay?.codexEnvironmentRuntime,
-    });
-    const replayWithImmutableUsage = request.before
-      ? replayWithEnvironment
-      : mergeImmutableUsageActivities({
-          replay: replayWithEnvironment,
-          activities: overlay?.immutableUsageActivities,
-        });
-    if (!request.before) {
+    const shouldAppendTranscriptOverlays = request.includeTurns !== false;
+    const replayWithEnvironment = shouldAppendTranscriptOverlays
+      ? appendCodexEnvironmentSetupActivity({
+          replay,
+          runtime: overlay?.codexEnvironmentRuntime,
+        })
+      : replay;
+    const replayWithImmutableUsage =
+      request.before || !shouldAppendTranscriptOverlays
+        ? replayWithEnvironment
+        : mergeImmutableUsageActivities({
+            replay: replayWithEnvironment,
+            activities: overlay?.immutableUsageActivities,
+          });
+    if (!request.before && shouldAppendTranscriptOverlays) {
       await this.persistReplayUsageLines(replayWithEnvironment);
     }
     const pricing =
@@ -13368,6 +13440,7 @@ export class DesktopBackendRegistry {
       }
       const status = await this.readThread({
         backend: request.args.backend,
+        includeTurns: false,
         limit: 0,
         threadId,
       })

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -5124,12 +5124,13 @@ type CodexThreadReadPayload = CodexThreadReadParams & {
 
 function buildThreadReadPayload(params: {
   threadId: string;
+  includeTurns?: boolean;
   before?: string;
   limit?: number;
 }): CodexThreadReadPayload {
   const payload: CodexThreadReadPayload = {
     threadId: params.threadId,
-    includeTurns: true,
+    includeTurns: params.includeTurns ?? true,
   };
 
   if (params.before) {
@@ -5964,6 +5965,7 @@ export class CodexAppServerClient {
 
   async readThread(params: {
     threadId: string;
+    includeTurns?: boolean;
     before?: string;
     limit?: number;
   }): Promise<AppServerThreadReplay> {

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -4422,13 +4422,14 @@ function extractThreadListPage(value: unknown): RawCodexThreadListPage {
 function buildThreadDiscoveryPayloads(
   filter?: string,
   archived?: boolean,
-  cursor?: string
+  cursor?: string,
+  limit = 50
 ): CodexThreadListParams[] {
   const searchTerm = filter?.trim() || undefined;
   const baseParams: CodexThreadListParams = {
     archived,
     cursor,
-    limit: 50,
+    limit,
     sortKey: "updated_at",
     sourceKinds: ["cli", "vscode"],
     useStateDbOnly: true,
@@ -5177,6 +5178,8 @@ async function requestThreadListPages(params: {
   client: JsonRpcConnection;
   diagnostics?: JsonRpcObserverDiagnostics;
   filter?: string;
+  limit?: number;
+  maxPages?: number;
   requestTimeoutMs: number;
 }): Promise<RawCodexThreadSummary[]> {
   const pages: RawCodexThreadSummary[] = [];
@@ -5187,15 +5190,25 @@ async function requestThreadListPages(params: {
   let pageCount = 0;
   let previewBytes = 0;
   let rawThreadCount = 0;
-  let terminalReason: "no-next-cursor" | "repeated-cursor" | undefined;
+  let terminalReason: "max-pages" | "no-next-cursor" | "repeated-cursor" | undefined;
   let cursor: string | undefined;
+  const requestedLimit = params.limit ?? 50;
+  const maxPagesLimit =
+    params.maxPages !== undefined && Number.isFinite(params.maxPages)
+      ? Math.max(1, Math.floor(params.maxPages))
+      : undefined;
 
   do {
     const result = await requestWithFallbacks({
       client: params.client,
       diagnostics: params.diagnostics,
       methods: ["thread/list"] as CodexClientRequestMethod[],
-      payloads: buildThreadDiscoveryPayloads(params.filter, params.archived, cursor),
+      payloads: buildThreadDiscoveryPayloads(
+        params.filter,
+        params.archived,
+        cursor,
+        requestedLimit,
+      ),
       timeoutMs: params.requestTimeoutMs,
     });
     const page = extractThreadListPage(result);
@@ -5207,6 +5220,12 @@ async function requestThreadListPages(params: {
       const threadPreviewBytes = measureThreadPreviewBytes(thread);
       previewBytes += threadPreviewBytes;
       maxPreviewBytes = Math.max(maxPreviewBytes, threadPreviewBytes);
+    }
+
+    if (maxPagesLimit !== undefined && pageCount >= maxPagesLimit) {
+      terminalReason = "max-pages";
+      cursor = undefined;
+      break;
     }
 
     const nextCursor = page.nextCursor?.trim();
@@ -5645,6 +5664,9 @@ export class CodexAppServerClient {
     archived?: boolean;
     enrichDirectories?: boolean;
     filter?: string;
+    limit?: number;
+    maxPages?: number;
+    skipArchivedMetadataRefresh?: boolean;
   }, diagnostics?: JsonRpcObserverDiagnostics): Promise<AppServerThreadSummary[]> {
     await this.ensureInitialized();
 
@@ -5660,6 +5682,8 @@ export class CodexAppServerClient {
         client: this.connection,
         diagnostics,
         filter: params?.filter,
+        limit: params?.limit,
+        maxPages: params?.maxPages,
         requestTimeoutMs: requestParams.timeoutMs,
       });
       return await this.enrichThreads(filterVisibleCodexThreads(archivedThreads), {
@@ -5673,14 +5697,20 @@ export class CodexAppServerClient {
         client: this.connection,
         diagnostics,
         filter: params?.filter,
+        limit: params?.limit,
+        maxPages: params?.maxPages,
         requestTimeoutMs: requestParams.timeoutMs,
       }),
     );
-    const threads = mergeArchivedThreadMetadata({
-      activeThreads,
-      archivedThreads: this.getCachedArchivedThreadMetadata(params?.filter),
-    });
-    this.scheduleArchivedThreadMetadataRefresh(params?.filter, diagnostics);
+    const threads = params?.skipArchivedMetadataRefresh
+      ? activeThreads
+      : mergeArchivedThreadMetadata({
+          activeThreads,
+          archivedThreads: this.getCachedArchivedThreadMetadata(params?.filter),
+        });
+    if (!params?.skipArchivedMetadataRefresh) {
+      this.scheduleArchivedThreadMetadataRefresh(params?.filter, diagnostics);
+    }
 
     return await this.enrichThreads(threads, {
       enrichDirectories: params?.enrichDirectories ?? true,

--- a/apps/desktop/src/main/grok-app-server/client.ts
+++ b/apps/desktop/src/main/grok-app-server/client.ts
@@ -154,6 +154,14 @@ function readString(
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
+function readBoolean(
+  record: Record<string, unknown> | undefined,
+  key: string
+): boolean | undefined {
+  const value = record?.[key];
+  return typeof value === "boolean" ? value : undefined;
+}
+
 function readTimestamp(
   record: Record<string, unknown>,
   ...keys: string[]
@@ -286,10 +294,7 @@ function extractThreadSummaryList(value: unknown): RawThreadSummary[] {
 }
 
 function extractThreadReplay(value: unknown): AppServerThreadReplay {
-  const pagination = {
-    supportsPagination: false,
-    hasPreviousPage: false,
-  } as const;
+  const pagination = extractReplayPagination(value);
 
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return {
@@ -336,6 +341,17 @@ function extractThreadReplay(value: unknown): AppServerThreadReplay {
   }
 
   return withThreadStatus(buildReplayFromMessages([], pagination), value);
+}
+
+function extractReplayPagination(value: unknown): AppServerThreadReplay["pagination"] {
+  const record = asRecord(value);
+  const pagination = asRecord(record?.pagination);
+  const previousCursor = readString(pagination, "previousCursor");
+  return {
+    supportsPagination: readBoolean(pagination, "supportsPagination") ?? Boolean(previousCursor),
+    hasPreviousPage: readBoolean(pagination, "hasPreviousPage") ?? Boolean(previousCursor),
+    ...(previousCursor ? { previousCursor } : {}),
+  };
 }
 
 function fallbackLastMessages(record: {
@@ -939,17 +955,24 @@ export class GrokAppServerClient {
 
   async readThread(params: {
     threadId: string;
+    includeTurns?: boolean;
     before?: string;
     limit?: number;
   }): Promise<AppServerThreadReplay> {
     await this.ensureInitialized();
 
-    const result = await this.request("thread/read", {
+    const request: Record<string, unknown> = {
       threadId: params.threadId,
-      includeTurns: true,
-      before: params.before,
-      limit: params.limit,
-    });
+      includeTurns: params.includeTurns ?? true,
+    };
+    if (params.before) {
+      request.before = params.before;
+    }
+    if (params.limit !== undefined) {
+      request.limit = params.limit;
+    }
+
+    const result = await this.request("thread/read", request);
 
     return extractThreadReplay(result);
   }

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -374,7 +374,47 @@ function getNavigationSnapshotRequestKey(
     backend: request.backend ?? "all",
     filter: request.filter ?? "",
     forceRefresh: request.forceRefresh === true,
+    refreshMode: request.refreshMode ?? "full",
   });
+}
+
+function buildThreadSnapshotCacheKey(
+  backend: AppServerBackendScope,
+  filter?: string,
+): string {
+  return JSON.stringify({
+    backend,
+    filter: filter?.trim() ?? "",
+  });
+}
+
+function mergeRecentThreadsIntoCachedSnapshot(
+  cachedThreads: AppServerThreadSummary[] | undefined,
+  recentThreads: AppServerThreadSummary[],
+): AppServerThreadSummary[] {
+  if (!cachedThreads || cachedThreads.length === 0) {
+    return recentThreads;
+  }
+  const recentByKey = new Map(
+    recentThreads.map((thread) => [
+      buildThreadIdentityKey(thread.source, thread.id),
+      thread,
+    ]),
+  );
+  const merged = cachedThreads.map((thread) => {
+    const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+    return recentByKey.get(threadKey) ?? thread;
+  });
+  const cachedKeys = new Set(
+    cachedThreads.map((thread) => buildThreadIdentityKey(thread.source, thread.id)),
+  );
+  for (const thread of recentThreads) {
+    const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+    if (!cachedKeys.has(threadKey)) {
+      merged.push(thread);
+    }
+  }
+  return merged.sort((left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0));
 }
 
 function getThreadPullRequestsRequestKey(
@@ -634,6 +674,10 @@ class DesktopAppServerService {
   private readonly previousDirectoriesByBackend = new Map<
     AppServerBackendScope,
     NavigationSnapshot["directories"]
+  >();
+  private readonly lastFullNavigationThreadsByKey = new Map<
+    string,
+    AppServerThreadSummary[]
   >();
   private readonly directoryGitStatusByKey = new Map<
     string,
@@ -983,12 +1027,29 @@ class DesktopAppServerService {
     request: GetNavigationSnapshotRequest,
   ): Promise<NavigationSnapshot> {
     const backend: AppServerBackendScope = request.backend ?? "all";
-    const threads = await getDesktopBackendRegistry().listThreads({
+    const refreshMode = request.refreshMode ?? "full";
+    const activeRecentRefresh = refreshMode === "active-recent";
+    const cacheKey = buildThreadSnapshotCacheKey(backend, request.filter);
+    const fetchedThreads = await getDesktopBackendRegistry().listThreads({
       backend: backend === "all" ? undefined : backend,
-      callerReason: "navigation-snapshot",
+      callerReason: activeRecentRefresh
+        ? "navigation-snapshot:active-recent"
+        : "navigation-snapshot",
       filter: request.filter,
       forceRefresh: request.forceRefresh,
+      limit: activeRecentRefresh ? 50 : undefined,
+      maxPages: activeRecentRefresh ? 1 : undefined,
+      skipArchivedMetadataRefresh: activeRecentRefresh,
     });
+    const threads = activeRecentRefresh
+      ? mergeRecentThreadsIntoCachedSnapshot(
+          this.lastFullNavigationThreadsByKey.get(cacheKey),
+          fetchedThreads,
+        )
+      : fetchedThreads;
+    if (!activeRecentRefresh) {
+      this.lastFullNavigationThreadsByKey.set(cacheKey, threads);
+    }
     const messagingBindingsByThreadKey = await buildMessagingBindingsByThreadKey(threads);
     const automationsByThreadKey = buildAutomationSummariesByThreadKey();
     const queuedExecutionModesByThreadKey = getDesktopBackendRegistry()
@@ -2978,6 +3039,7 @@ class DesktopAppServerService {
     this.pendingDirectoryGitStatusRefreshes.clear();
     this.pendingDirectoryGitStatusKeys.clear();
     this.previousDirectoriesByBackend.clear();
+    this.lastFullNavigationThreadsByKey.clear();
     this.directoryGitStatusByKey.clear();
     this.directoryGitStatusCacheLoaded = false;
     this.automaticDirectoryGitStatusRefreshesStarted = 0;

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -836,6 +836,7 @@ class DesktopAppServerService {
     const response = await getDesktopBackendRegistry().readThread({
       backend,
       threadId: request.threadId,
+      includeTurns: request.includeTurns,
       before: request.before,
       limit: request.limit,
     });

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -64,6 +64,9 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
       callerReason: "messaging-navigation-snapshot",
       filter: request.filter,
       forceRefresh: request.forceRefresh,
+      limit: request.refreshMode === "active-recent" ? 50 : undefined,
+      maxPages: request.refreshMode === "active-recent" ? 1 : undefined,
+      skipArchivedMetadataRefresh: request.refreshMode === "active-recent",
     });
     const messagingBindingsByThreadKey = await buildMessagingBindingsByThreadKey(threads);
     const queuedExecutionModesByThreadKey =

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -98,6 +98,7 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
   }): Promise<AppServerThreadStatus | undefined> {
     const response = await this.registry.readThread({
       backend: request.backend,
+      includeTurns: false,
       limit: 0,
       threadId: request.threadId,
     });

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -97,6 +97,7 @@ export type DesktopSettingsConfig = {
     chatReplyComposer?: StoredChatReplyComposer;
     fullAccessRiskWarningDismissed?: boolean;
     liveTranscriptEventFiltering?: boolean;
+    lightweightNavigationRefresh?: boolean;
     threadPricingSummary?: boolean;
     threadPricingDisplayUsd?: boolean;
     threadPricingDisplayCodexCredits?: boolean;
@@ -631,6 +632,12 @@ export function desktopSettingsPatchToEdits(
     set(
       ["experimental", "live_transcript_event_filtering"],
       patch.experimental.liveTranscriptEventFiltering,
+    );
+  }
+  if (patch.experimental?.lightweightNavigationRefresh !== undefined) {
+    set(
+      ["experimental", "lightweight_navigation_refresh"],
+      patch.experimental.lightweightNavigationRefresh,
     );
   }
   if (patch.experimental?.threadPricingSummary !== undefined) {
@@ -1249,6 +1256,9 @@ function normalizeDesktopConfig(
       ),
       liveTranscriptEventFiltering: readBoolean(
         experimental?.live_transcript_event_filtering,
+      ),
+      lightweightNavigationRefresh: readBoolean(
+        experimental?.lightweight_navigation_refresh,
       ),
       threadPricingSummary: readBoolean(experimental?.thread_pricing_summary),
       threadPricingDisplayUsd: readBoolean(

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -555,6 +555,10 @@ export class DesktopSettingsService {
           config.experimental?.liveTranscriptEventFiltering,
           false,
         ),
+        lightweightNavigationRefresh: this.resolveConfigBoolean(
+          config.experimental?.lightweightNavigationRefresh,
+          false,
+        ),
         threadPricingSummary: this.resolveConfigBoolean(
           config.experimental?.threadPricingSummary,
           false,

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -55,7 +55,10 @@ import {
 import { useThreadNavigation } from "./lib/useThreadNavigation";
 import { usePwrAgentProfiles } from "./lib/usePwrAgentProfiles";
 import { usePullRequestRefresh } from "./features/pr-status/usePullRequestRefresh";
-import { useThreadSessionState } from "./lib/useThreadSessionState";
+import {
+  LIGHTWEIGHT_INITIAL_THREAD_HISTORY_LIMIT,
+  useThreadSessionState,
+} from "./lib/useThreadSessionState";
 import { setSidebarResizing } from "./lib/sidebar-resize-signal";
 import { useThreadSkills } from "./lib/useThreadSkills";
 import { useQueuedTurnRelease } from "./lib/useQueuedTurnRelease";
@@ -746,8 +749,13 @@ function DesktopAppShell(props: {
     settings.snapshot?.onboarding?.completed.value,
   ]);
   const loadThreadDetail = threadViewReady && mainView === "thread";
+  const lightweightNavigationRefresh =
+    settings.snapshot?.experimental.lightweightNavigationRefresh?.value ?? false;
   const session = useThreadSessionState({
     desktopApi,
+    initialHistoryLimit: lightweightNavigationRefresh
+      ? LIGHTWEIGHT_INITIAL_THREAD_HISTORY_LIMIT
+      : undefined,
     liveTranscriptEventFiltering:
       settings.snapshot?.experimental.liveTranscriptEventFiltering?.value ?? false,
     thread: loadThreadDetail ? navigation.selectedThread : undefined,

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -461,6 +461,8 @@ function DesktopAppShell(props: {
   const runtimeIdentity = useRuntimeIdentity(desktopApi);
   const navigation = useThreadNavigation(desktopApi, {
     enabled: normalAppEnabled,
+    lightweightNavigationRefresh:
+      settings.snapshot?.experimental.lightweightNavigationRefresh?.value ?? false,
     threadViewVisible: mainView === "thread",
   });
   // Keep the backend-error toast's thread lookup fresh without making the

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -442,6 +442,10 @@ describe("App", () => {
           value: false,
           source: "default",
         },
+        lightweightNavigationRefresh: {
+          value: false,
+          source: "default",
+        },
         codexDefaultModeRequestUserInput: {
           value: false,
           source: "default",

--- a/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
@@ -32,6 +32,11 @@ const DEFAULT_LIVE_TRANSCRIPT_EVENT_FILTERING = {
   source: "default" as const,
 };
 
+const DEFAULT_LIGHTWEIGHT_NAVIGATION_REFRESH = {
+  value: false,
+  source: "default" as const,
+};
+
 const DEFAULT_CODEX_DEFAULT_MODE_REQUEST_USER_INPUT = {
   value: false,
   source: "default" as const,
@@ -63,6 +68,7 @@ export function ExperimentalSettings(props: {
   onDiffCondensationEnabledChange: (enabled: boolean) => Promise<void>;
   onDiffCondensationModelChange: (model: string) => Promise<void>;
   onLiveTranscriptEventFilteringChange: (enabled: boolean) => Promise<void>;
+  onLightweightNavigationRefreshChange: (enabled: boolean) => Promise<void>;
   onThreadPricingSummaryChange: (enabled: boolean) => Promise<void>;
   onThreadPricingDisplayUsdChange: (enabled: boolean) => Promise<void>;
   onThreadPricingDisplayCodexCreditsChange: (enabled: boolean) => Promise<void>;
@@ -75,6 +81,9 @@ export function ExperimentalSettings(props: {
   const liveTranscriptEventFiltering =
     props.snapshot.experimental.liveTranscriptEventFiltering ??
     DEFAULT_LIVE_TRANSCRIPT_EVENT_FILTERING;
+  const lightweightNavigationRefresh =
+    props.snapshot.experimental.lightweightNavigationRefresh ??
+    DEFAULT_LIGHTWEIGHT_NAVIGATION_REFRESH;
   const threadPricingSummary =
     props.snapshot.experimental.threadPricingSummary ??
     DEFAULT_THREAD_PRICING_SUMMARY;
@@ -154,6 +163,32 @@ export function ExperimentalSettings(props: {
                 label="Display Codex Credits"
                 onChange={(enabled) => {
                   void props.onThreadPricingDisplayCodexCreditsChange(enabled);
+                }}
+              />
+            }
+          />
+        </div>
+      </SettingsSection>
+
+      <SettingsSection
+        eyebrow="Experimental"
+        title="Lightweight Navigation Refresh"
+        description="Use a one-page active thread-list poll while focused and coalesce full refreshes after focus events. Disabled by default while this behavior is validated against external Codex changes."
+        chip={lightweightNavigationRefresh.value ? "On" : "Off"}
+        chipKind={lightweightNavigationRefresh.value ? "ok" : "default"}
+      >
+        <div className="settings-fields">
+          <SettingsField
+            label="Enable lightweight navigation refresh"
+            sub="When on, foreground background polling reads only the most recently active page and focus refreshes are throttled."
+            source={sourceBadge(lightweightNavigationRefresh)}
+            control={
+              <SettingsSwitch
+                checked={lightweightNavigationRefresh.value}
+                disabled={props.saving}
+                label="Enable lightweight navigation refresh"
+                onChange={(enabled) => {
+                  void props.onLightweightNavigationRefreshChange(enabled);
                 }}
               />
             }

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -409,6 +409,11 @@ function SettingsSectionBody(props: {
             experimental: { liveTranscriptEventFiltering: enabled },
           });
         }}
+        onLightweightNavigationRefreshChange={async (enabled: boolean) => {
+          await props.settings.writeConfig({
+            experimental: { lightweightNavigationRefresh: enabled },
+          });
+        }}
         onThreadPricingSummaryChange={async (enabled: boolean) => {
           await props.settings.writeConfig({
             experimental: { threadPricingSummary: enabled },

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -141,6 +141,10 @@ function createSnapshot(
         value: false,
         source: "default",
       },
+      lightweightNavigationRefresh: {
+        value: false,
+        source: "default",
+      },
       threadPricingSummary: {
         value: false,
         source: "default",
@@ -658,6 +662,17 @@ describe("SettingsScreen", () => {
 
     fireEvent.click(
       screen.getByRole("switch", {
+        name: "Enable lightweight navigation refresh",
+      }),
+    );
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        experimental: { lightweightNavigationRefresh: true },
+      });
+    });
+
+    fireEvent.click(
+      screen.getByRole("switch", {
         name: "Enable Codex skill questions",
       }),
     );
@@ -954,6 +969,31 @@ describe("SettingsScreen", () => {
     await waitFor(() => {
       expect(settings.writeConfig).toHaveBeenCalledWith({
         experimental: { codexDefaultModeRequestUserInput: true },
+      });
+    });
+  });
+
+  it("defaults lightweight navigation refresh off for stale snapshots", async () => {
+    const snapshot = createSnapshot() as any;
+    delete snapshot.experimental.lightweightNavigationRefresh;
+    const settings = createSettingsState(snapshot);
+
+    render(
+      <SettingsScreen
+        initialSection="experimental"
+        settings={settings}
+      />,
+    );
+
+    const refreshSwitch = screen.getByRole("switch", {
+      name: "Enable lightweight navigation refresh",
+    });
+    expect(refreshSwitch).toHaveAttribute("aria-checked", "false");
+
+    fireEvent.click(refreshSwitch);
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        experimental: { lightweightNavigationRefresh: true },
       });
     });
   });

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -765,7 +765,7 @@ describe("useThreadNavigation", () => {
     });
   });
 
-  it("forces background navigation refreshes to bypass backend thread-list cache", async () => {
+  it("uses a cheap active-recent refresh for foreground background polling", async () => {
     let intervalHandler: (() => void) | undefined;
     const originalSetInterval = globalThis.setInterval;
     vi.spyOn(globalThis, "setInterval").mockImplementation((handler, timeout, ...args) => {
@@ -822,7 +822,107 @@ describe("useThreadNavigation", () => {
 
     await waitFor(() => {
       expect(getNavigationSnapshot).toHaveBeenCalledTimes(2);
-      expect(getNavigationSnapshot).toHaveBeenLastCalledWith({ forceRefresh: true });
+      expect(getNavigationSnapshot).toHaveBeenLastCalledWith({
+        forceRefresh: true,
+        refreshMode: "active-recent",
+      });
+    });
+
+    unmount();
+  });
+
+  it("throttles full focus refreshes to one per minute after completion", async () => {
+    let focusListener: (() => void) | undefined;
+    let delayedFocusHandler: (() => void) | undefined;
+    const originalSetTimeout = globalThis.setTimeout;
+    const setTimeoutSpy = vi
+      .spyOn(globalThis, "setTimeout")
+      .mockImplementation((handler, timeout, ...args) => {
+        if (typeof timeout === "number" && timeout > 10_000) {
+          delayedFocusHandler =
+            typeof handler === "function" ? () => handler(...args) : undefined;
+          return 42 as unknown as ReturnType<typeof setTimeout>;
+        }
+        return originalSetTimeout(handler, timeout, ...args);
+      });
+    vi.spyOn(globalThis, "clearTimeout").mockImplementation(() => undefined);
+    const dateNowSpy = vi.spyOn(Date, "now");
+    dateNowSpy.mockReturnValue(1_000_000);
+
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: ["codex:thread-1"],
+      threads: [
+        {
+          id: "thread-1",
+          title: "First thread",
+          titleSource: "explicit" as const,
+          summary: "First thread summary",
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: {
+            inInbox: true,
+            reason: "new-thread" as const,
+          },
+          updatedAt: 1_000,
+        },
+      ],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      onWindowFocus: (callback) => {
+        focusListener = callback;
+        return () => {
+          focusListener = undefined;
+        };
+      },
+    };
+
+    const { result, unmount } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.id).toBe("thread-1");
+    });
+
+    act(() => {
+      focusListener?.();
+    });
+
+    await waitFor(() => {
+      expect(getNavigationSnapshot).toHaveBeenCalledTimes(2);
+      expect(getNavigationSnapshot).toHaveBeenLastCalledWith({
+        forceRefresh: true,
+        refreshMode: "full",
+      });
+    });
+
+    dateNowSpy.mockReturnValue(1_030_000);
+    act(() => {
+      focusListener?.();
+      focusListener?.();
+    });
+
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 30_000);
+    expect(getNavigationSnapshot).toHaveBeenCalledTimes(2);
+
+    dateNowSpy.mockReturnValue(1_060_000);
+    act(() => {
+      delayedFocusHandler?.();
+    });
+
+    await waitFor(() => {
+      expect(getNavigationSnapshot).toHaveBeenCalledTimes(3);
+      expect(getNavigationSnapshot).toHaveBeenLastCalledWith({
+        forceRefresh: true,
+        refreshMode: "full",
+      });
     });
 
     unmount();

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -765,7 +765,7 @@ describe("useThreadNavigation", () => {
     });
   });
 
-  it("uses a cheap active-recent refresh for foreground background polling", async () => {
+  it("uses broad forced background polling by default", async () => {
     let intervalHandler: (() => void) | undefined;
     const originalSetInterval = globalThis.setInterval;
     vi.spyOn(globalThis, "setInterval").mockImplementation((handler, timeout, ...args) => {
@@ -824,8 +824,131 @@ describe("useThreadNavigation", () => {
       expect(getNavigationSnapshot).toHaveBeenCalledTimes(2);
       expect(getNavigationSnapshot).toHaveBeenLastCalledWith({
         forceRefresh: true,
+      });
+    });
+
+    unmount();
+  });
+
+  it("uses a cheap active-recent refresh for opt-in foreground background polling", async () => {
+    let intervalHandler: (() => void) | undefined;
+    const originalSetInterval = globalThis.setInterval;
+    vi.spyOn(globalThis, "setInterval").mockImplementation((handler, timeout, ...args) => {
+      if (timeout !== 5 * 60_000) {
+        return originalSetInterval(handler, timeout, ...args);
+      }
+      intervalHandler = typeof handler === "function" ? () => handler() : undefined;
+      return 1 as unknown as ReturnType<typeof setInterval>;
+    });
+
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: ["codex:thread-1"],
+      threads: [
+        {
+          id: "thread-1",
+          title: "First thread",
+          titleSource: "explicit" as const,
+          summary: "First thread summary",
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: {
+            inInbox: true,
+            reason: "new-thread" as const,
+          },
+          updatedAt: 1_000,
+        },
+      ],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+    };
+
+    const { result, unmount } = renderHook(() =>
+      useThreadNavigation(desktopApi, { lightweightNavigationRefresh: true }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.id).toBe("thread-1");
+    });
+
+    expect(getNavigationSnapshot).toHaveBeenCalledTimes(1);
+    expect(getNavigationSnapshot.mock.calls[0]).toEqual([]);
+    expect(intervalHandler).toBeDefined();
+
+    act(() => {
+      intervalHandler?.();
+    });
+
+    await waitFor(() => {
+      expect(getNavigationSnapshot).toHaveBeenCalledTimes(2);
+      expect(getNavigationSnapshot).toHaveBeenLastCalledWith({
+        forceRefresh: true,
         refreshMode: "active-recent",
       });
+    });
+
+    unmount();
+  });
+
+  it("uses the ordinary scheduled refresh on focus by default", async () => {
+    let focusListener: (() => void) | undefined;
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: ["codex:thread-1"],
+      threads: [
+        {
+          id: "thread-1",
+          title: "First thread",
+          titleSource: "explicit" as const,
+          summary: "First thread summary",
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: {
+            inInbox: true,
+            reason: "new-thread" as const,
+          },
+          updatedAt: 1_000,
+        },
+      ],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      onWindowFocus: (callback) => {
+        focusListener = callback;
+        return () => {
+          focusListener = undefined;
+        };
+      },
+    };
+
+    const { result, unmount } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.id).toBe("thread-1");
+    });
+
+    act(() => {
+      focusListener?.();
+    });
+
+    await waitFor(() => {
+      expect(getNavigationSnapshot).toHaveBeenCalledTimes(2);
+      expect(getNavigationSnapshot.mock.calls.at(-1)).toEqual([]);
     });
 
     unmount();
@@ -885,7 +1008,9 @@ describe("useThreadNavigation", () => {
       },
     };
 
-    const { result, unmount } = renderHook(() => useThreadNavigation(desktopApi));
+    const { result, unmount } = renderHook(() =>
+      useThreadNavigation(desktopApi, { lightweightNavigationRefresh: true }),
+    );
 
     await waitFor(() => {
       expect(result.current.selectedThread?.id).toBe("thread-1");

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -325,13 +325,15 @@ describe("useThreadSessionState", () => {
       limit: LIGHTWEIGHT_INITIAL_THREAD_HISTORY_LIMIT,
       threadId: "thread-1",
     });
-    expect(transcriptLabels(result.current.entries)).toEqual([
-      "message:Older 1",
-      "message:Older 2",
-      "message:Recent 1",
-      "message:Recent 2",
-      "message:Recent 3",
-    ]);
+    await waitFor(() => {
+      expect(transcriptLabels(result.current.entries)).toEqual([
+        "message:Older 1",
+        "message:Older 2",
+        "message:Recent 1",
+        "message:Recent 2",
+        "message:Recent 3",
+      ]);
+    });
     expect(result.current.response?.replay.pagination.previousCursor).toBe(
       "oldest-page"
     );

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -9,6 +9,7 @@ import type {
 import type { DesktopApi } from "../desktop-api";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  LIGHTWEIGHT_INITIAL_THREAD_HISTORY_LIMIT,
   getContextWindowMoonPhase,
   useThreadSessionState,
 } from "../useThreadSessionState";
@@ -156,6 +157,96 @@ describe("useThreadSessionState", () => {
 
     expect(result.current.threadBusy).toBe(false);
     expect(result.current.thinkingThreadKeys["codex:thread-1"]).toBeUndefined();
+  });
+
+  it("uses a bounded initial thread history limit when configured", async () => {
+    const readThread = vi.fn(async ({ backend, threadId }) => ({
+      backend: backend ?? "codex",
+      fetchedAt: Date.now(),
+      threadId,
+      threadStatus: "idle" as const,
+      replay: {
+        entries: [],
+        messages: [],
+        pagination: {
+          supportsPagination: true,
+          hasPreviousPage: true,
+          previousCursor: "entry-1",
+        },
+      },
+    }));
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread,
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        initialHistoryLimit: LIGHTWEIGHT_INITIAL_THREAD_HISTORY_LIMIT,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitForThreadHydration(result);
+    expect(readThread).toHaveBeenCalledWith({
+      backend: "codex",
+      limit: LIGHTWEIGHT_INITIAL_THREAD_HISTORY_LIMIT,
+      threadId: "thread-1",
+    });
+  });
+
+  it("rehydrates the selected thread when the initial history limit changes", async () => {
+    const readThread = vi.fn(async ({ backend, threadId }) => ({
+      backend: backend ?? "codex",
+      fetchedAt: Date.now(),
+      threadId,
+      threadStatus: "idle" as const,
+      replay: {
+        entries: [],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+      },
+    }));
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread,
+    };
+    const thread = buildThread({ id: "thread-1", updatedAt: 1_000 });
+    const { result, rerender } = renderHook(
+      ({ initialHistoryLimit }: { initialHistoryLimit?: number }) =>
+        useThreadSessionState({
+          desktopApi,
+          initialHistoryLimit,
+          thread,
+        }),
+      {
+        initialProps: {
+          initialHistoryLimit: undefined as number | undefined,
+        },
+      }
+    );
+
+    await waitForThreadHydration(result);
+    expect(readThread).toHaveBeenCalledTimes(1);
+    expect(readThread).toHaveBeenLastCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    rerender({ initialHistoryLimit: LIGHTWEIGHT_INITIAL_THREAD_HISTORY_LIMIT });
+
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(2);
+    });
+    expect(readThread).toHaveBeenLastCalledWith({
+      backend: "codex",
+      limit: LIGHTWEIGHT_INITIAL_THREAD_HISTORY_LIMIT,
+      threadId: "thread-1",
+    });
   });
 
   it("keeps a newer active turn busy when an older turn completion arrives", async () => {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -5,6 +5,8 @@ import type {
   AppServerReadThreadResponse,
   AppServerThreadActivityEntry,
   AppServerThreadEntry,
+  AppServerThreadMessage,
+  AppServerThreadMessageEntry,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../desktop-api";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -41,6 +43,53 @@ function transcriptLabels(entries: AppServerThreadEntry[]): string[] {
         ? `activity:${entry.summary}`
         : entry.type
   );
+}
+
+function messageEntry(params: {
+  createdAt: number;
+  id: string;
+  role?: AppServerThreadMessage["role"];
+  text: string;
+}): AppServerThreadMessageEntry {
+  return {
+    type: "message",
+    id: params.id,
+    role: params.role ?? "assistant",
+    text: params.text,
+    createdAt: params.createdAt,
+  };
+}
+
+function readThreadResponse(params: {
+  entries: AppServerThreadEntry[];
+  fetchedAt?: number;
+  hasPreviousPage: boolean;
+  previousCursor?: string;
+  supportsPagination?: boolean;
+  threadId?: string;
+}): AppServerReadThreadResponse {
+  return {
+    backend: "codex",
+    fetchedAt: params.fetchedAt ?? Date.now(),
+    threadId: params.threadId ?? "thread-1",
+    threadStatus: "idle",
+    replay: {
+      entries: params.entries,
+      messages: params.entries
+        .filter(
+          (entry): entry is AppServerThreadMessageEntry =>
+            entry.type === "message"
+        )
+        .map(({ type: _type, ...message }) => message),
+      pagination: {
+        supportsPagination: params.supportsPagination ?? true,
+        hasPreviousPage: params.hasPreviousPage,
+        ...(params.previousCursor
+          ? { previousCursor: params.previousCursor }
+          : {}),
+      },
+    },
+  };
 }
 
 function diffActivity(params: {
@@ -194,6 +243,98 @@ describe("useThreadSessionState", () => {
       limit: LIGHTWEIGHT_INITIAL_THREAD_HISTORY_LIMIT,
       threadId: "thread-1",
     });
+  });
+
+  it("preserves loaded older transcript pages across limited refreshes", async () => {
+    const initialTail = readThreadResponse({
+      entries: [
+        messageEntry({ id: "recent-1", text: "Recent 1", createdAt: 300 }),
+        messageEntry({ id: "recent-2", text: "Recent 2", createdAt: 400 }),
+      ],
+      hasPreviousPage: true,
+      previousCursor: "older-page",
+    });
+    const olderPage = readThreadResponse({
+      entries: [
+        messageEntry({ id: "older-1", text: "Older 1", createdAt: 100 }),
+        messageEntry({ id: "older-2", text: "Older 2", createdAt: 200 }),
+      ],
+      hasPreviousPage: true,
+      previousCursor: "oldest-page",
+    });
+    const refreshedTail = readThreadResponse({
+      entries: [
+        messageEntry({ id: "recent-1", text: "Recent 1", createdAt: 300 }),
+        messageEntry({ id: "recent-2", text: "Recent 2", createdAt: 400 }),
+        messageEntry({ id: "recent-3", text: "Recent 3", createdAt: 500 }),
+      ],
+      hasPreviousPage: true,
+      previousCursor: "older-page-again",
+    });
+    const readThread = vi
+      .fn()
+      .mockResolvedValueOnce(initialTail)
+      .mockResolvedValueOnce(olderPage)
+      .mockResolvedValueOnce(refreshedTail);
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread,
+    };
+    const { result, rerender } = renderHook(
+      ({ updatedAt }: { updatedAt: number }) =>
+        useThreadSessionState({
+          desktopApi,
+          initialHistoryLimit: LIGHTWEIGHT_INITIAL_THREAD_HISTORY_LIMIT,
+          thread: buildThread({ id: "thread-1", updatedAt }),
+        }),
+      {
+        initialProps: { updatedAt: 1_000 },
+      }
+    );
+
+    await waitForThreadHydration(result);
+    expect(transcriptLabels(result.current.entries)).toEqual([
+      "message:Recent 1",
+      "message:Recent 2",
+    ]);
+
+    await act(async () => {
+      await result.current.loadOlder();
+    });
+
+    await waitFor(() => {
+      expect(transcriptLabels(result.current.entries)).toEqual([
+        "message:Older 1",
+        "message:Older 2",
+        "message:Recent 1",
+        "message:Recent 2",
+      ]);
+    });
+    expect(result.current.response?.replay.pagination.previousCursor).toBe(
+      "oldest-page"
+    );
+
+    rerender({ updatedAt: 2_000 });
+
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(3);
+    });
+
+    expect(readThread).toHaveBeenLastCalledWith({
+      backend: "codex",
+      limit: LIGHTWEIGHT_INITIAL_THREAD_HISTORY_LIMIT,
+      threadId: "thread-1",
+    });
+    expect(transcriptLabels(result.current.entries)).toEqual([
+      "message:Older 1",
+      "message:Older 2",
+      "message:Recent 1",
+      "message:Recent 2",
+      "message:Recent 3",
+    ]);
+    expect(result.current.response?.replay.pagination.previousCursor).toBe(
+      "oldest-page"
+    );
   });
 
   it("rehydrates the selected thread when the initial history limit changes", async () => {

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -1942,6 +1942,7 @@ function reviewDisplayTextFromTarget(
 
 type UseThreadNavigationOptions = {
   enabled?: boolean;
+  lightweightNavigationRefresh?: boolean;
   threadViewVisible?: boolean;
 };
 
@@ -2124,6 +2125,7 @@ export function useThreadNavigation(
   const setThreadModelSettings = desktopApi?.setThreadModelSettings;
   const setNavigationBrowseModeRequest = desktopApi?.setNavigationBrowseMode;
   const enabled = options.enabled ?? true;
+  const lightweightNavigationRefresh = options.lightweightNavigationRefresh ?? false;
   const threadViewVisible = options.threadViewVisible ?? true;
   const [browseMode, setBrowseMode] = useState<BrowseMode>(readBridgedBrowseMode);
   const [selectedItemKey, setSelectedItemKey] = useState<string>();
@@ -2557,21 +2559,31 @@ export function useThreadNavigation(
   }, [enabled, refresh]);
 
   useEffect(() => {
-    if (!enabled || !desktopApi?.getNavigationSnapshot || !viewForeground) {
+    if (
+      !enabled ||
+      !desktopApi?.getNavigationSnapshot ||
+      (lightweightNavigationRefresh && !viewForeground)
+    ) {
       return;
     }
 
     const timer = setInterval(() => {
       scheduleRefresh(undefined, undefined, false, {
         forceRefresh: true,
-        refreshMode: "active-recent",
+        refreshMode: lightweightNavigationRefresh ? "active-recent" : undefined,
       });
     }, NAVIGATION_BACKGROUND_REFRESH_INTERVAL_MS);
 
     return () => {
       clearInterval(timer);
     };
-  }, [desktopApi?.getNavigationSnapshot, enabled, scheduleRefresh, viewForeground]);
+  }, [
+    desktopApi?.getNavigationSnapshot,
+    enabled,
+    lightweightNavigationRefresh,
+    scheduleRefresh,
+    viewForeground,
+  ]);
 
   useEffect(() => {
     if (!enabled || !desktopApi?.onWindowFocus) {
@@ -2579,9 +2591,19 @@ export function useThreadNavigation(
     }
 
     return desktopApi.onWindowFocus(() => {
-      scheduleFocusRefresh();
+      if (lightweightNavigationRefresh) {
+        scheduleFocusRefresh();
+        return;
+      }
+      scheduleRefresh();
     });
-  }, [desktopApi, enabled, scheduleFocusRefresh]);
+  }, [
+    desktopApi,
+    enabled,
+    lightweightNavigationRefresh,
+    scheduleFocusRefresh,
+    scheduleRefresh,
+  ]);
 
   useEffect(() => {
     if (!enabled || !desktopApi?.onAgentEvent) {

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -55,6 +55,7 @@ export type ArchiveThreadOptions = {
 const ROOT_NEW_THREAD_WORKSPACE_LAUNCHPAD_KEY = "workspace:new-thread";
 const ROOT_NEW_THREAD_WORKSPACE_LABEL = "Workspaces";
 const NAVIGATION_BACKGROUND_REFRESH_INTERVAL_MS = 5 * 60_000;
+const NAVIGATION_FOCUS_REFRESH_MIN_INTERVAL_MS = 60_000;
 const DEFAULT_BROWSE_MODE: BrowseMode = "inbox";
 
 function normalizeBrowseMode(value: unknown): BrowseMode {
@@ -94,6 +95,7 @@ type NavigationState = {
 
 type NavigationRefreshOptions = {
   forceRefresh?: boolean;
+  refreshMode?: "active-recent" | "full";
 };
 
 type PrChipLocation = {
@@ -2173,6 +2175,7 @@ export function useThreadNavigation(
         forcePreferredSelection?: boolean;
         preferredOptimisticThread?: NavigationThreadSummary;
         preferredSelectionKey?: string;
+        refreshMode?: "active-recent" | "full";
       }
     | undefined
   >(undefined);
@@ -2180,6 +2183,12 @@ export function useThreadNavigation(
   const scheduledRefreshTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined
   );
+  const scheduledFocusRefreshTimerRef = useRef<
+    ReturnType<typeof setTimeout> | undefined
+  >(undefined);
+  const focusRefreshInFlightRef = useRef(false);
+  const focusRefreshQueuedRef = useRef(false);
+  const lastFocusRefreshCompletedAtRef = useRef(0);
   const launchpadUpdateRevisionRef = useRef(new Map<string, number>());
   const pendingPickedLaunchpadRef = useRef(new Map<string, NavigationLaunchpadDraft>());
   const setNavigationBrowseModeRequestRef = useRef(setNavigationBrowseModeRequest);
@@ -2268,8 +2277,15 @@ export function useThreadNavigation(
           hasCurrentResponse: Boolean(stateRef.current.response),
           preferredSelectionKey: preferredSelectionKey ?? null,
         });
-        const snapshot = options?.forceRefresh
-          ? await desktopApi.getNavigationSnapshot({ forceRefresh: true })
+        const snapshotRequest =
+          options?.forceRefresh || options?.refreshMode
+            ? {
+                ...(options?.forceRefresh ? { forceRefresh: true } : {}),
+                ...(options?.refreshMode ? { refreshMode: options.refreshMode } : {}),
+              }
+            : undefined;
+        const snapshot = snapshotRequest
+          ? await desktopApi.getNavigationSnapshot(snapshotRequest)
           : await desktopApi.getNavigationSnapshot();
         desktopApi.recordStartupProfileEvent?.("navigation-refresh:snapshot", {
           directoryCount: snapshot.directories.length,
@@ -2369,6 +2385,7 @@ export function useThreadNavigation(
         forcePreferredSelection,
         preferredOptimisticThread,
         preferredSelectionKey,
+        refreshMode: options?.refreshMode,
       };
 
       if (refreshInFlightRef.current) {
@@ -2386,7 +2403,10 @@ export function useThreadNavigation(
             nextRequest.preferredSelectionKey,
             nextRequest.preferredOptimisticThread,
             nextRequest.forcePreferredSelection,
-            { forceRefresh: nextRequest.forceRefresh }
+            {
+              forceRefresh: nextRequest.forceRefresh,
+              refreshMode: nextRequest.refreshMode,
+            }
           );
           nextRequest = queuedRefreshRef.current;
         }
@@ -2413,6 +2433,11 @@ export function useThreadNavigation(
         forcePreferredSelection,
         preferredOptimisticThread,
         preferredSelectionKey,
+        refreshMode:
+          options?.refreshMode === "full" ||
+          queuedRefreshRef.current?.refreshMode === "full"
+            ? "full"
+            : options?.refreshMode ?? queuedRefreshRef.current?.refreshMode,
       };
 
       if (scheduledRefreshTimerRef.current !== undefined) {
@@ -2431,17 +2456,66 @@ export function useThreadNavigation(
           nextRequest.preferredSelectionKey,
           nextRequest.preferredOptimisticThread,
           nextRequest.forcePreferredSelection,
-          { forceRefresh: nextRequest.forceRefresh }
+          {
+            forceRefresh: nextRequest.forceRefresh,
+            refreshMode: nextRequest.refreshMode,
+          }
         );
       }, 0);
     },
     [refresh]
   );
 
+  const scheduleFocusRefresh = useCallback((): void => {
+    if (focusRefreshInFlightRef.current) {
+      focusRefreshQueuedRef.current = true;
+      return;
+    }
+
+    if (scheduledFocusRefreshTimerRef.current !== undefined) {
+      focusRefreshQueuedRef.current = true;
+      return;
+    }
+
+    const elapsedSinceLastCompletion =
+      Date.now() - lastFocusRefreshCompletedAtRef.current;
+    const delayMs = Math.max(
+      0,
+      NAVIGATION_FOCUS_REFRESH_MIN_INTERVAL_MS - elapsedSinceLastCompletion,
+    );
+
+    const runRefresh = () => {
+      scheduledFocusRefreshTimerRef.current = undefined;
+      focusRefreshQueuedRef.current = false;
+      focusRefreshInFlightRef.current = true;
+      void refresh(undefined, undefined, false, {
+        forceRefresh: true,
+        refreshMode: "full",
+      }).finally(() => {
+        focusRefreshInFlightRef.current = false;
+        lastFocusRefreshCompletedAtRef.current = Date.now();
+        if (focusRefreshQueuedRef.current) {
+          scheduleFocusRefresh();
+        }
+      });
+    };
+
+    if (delayMs === 0) {
+      runRefresh();
+      return;
+    }
+
+    focusRefreshQueuedRef.current = true;
+    scheduledFocusRefreshTimerRef.current = setTimeout(runRefresh, delayMs);
+  }, [refresh]);
+
   useEffect(() => {
     return () => {
       if (scheduledRefreshTimerRef.current !== undefined) {
         clearTimeout(scheduledRefreshTimerRef.current);
+      }
+      if (scheduledFocusRefreshTimerRef.current !== undefined) {
+        clearTimeout(scheduledFocusRefreshTimerRef.current);
       }
     };
   }, []);
@@ -2483,20 +2557,21 @@ export function useThreadNavigation(
   }, [enabled, refresh]);
 
   useEffect(() => {
-    if (!enabled || !desktopApi?.getNavigationSnapshot) {
+    if (!enabled || !desktopApi?.getNavigationSnapshot || !viewForeground) {
       return;
     }
 
     const timer = setInterval(() => {
       scheduleRefresh(undefined, undefined, false, {
         forceRefresh: true,
+        refreshMode: "active-recent",
       });
     }, NAVIGATION_BACKGROUND_REFRESH_INTERVAL_MS);
 
     return () => {
       clearInterval(timer);
     };
-  }, [desktopApi?.getNavigationSnapshot, enabled, scheduleRefresh]);
+  }, [desktopApi?.getNavigationSnapshot, enabled, scheduleRefresh, viewForeground]);
 
   useEffect(() => {
     if (!enabled || !desktopApi?.onWindowFocus) {
@@ -2504,9 +2579,9 @@ export function useThreadNavigation(
     }
 
     return desktopApi.onWindowFocus(() => {
-      scheduleRefresh();
+      scheduleFocusRefresh();
     });
-  }, [desktopApi, enabled, scheduleRefresh]);
+  }, [desktopApi, enabled, scheduleFocusRefresh]);
 
   useEffect(() => {
     if (!enabled || !desktopApi?.onAgentEvent) {

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -134,6 +134,7 @@ type ThreadSessionEntry = {
   hydratedUpdatedAt?: number;
   interacted: boolean;
   lastTouchedAt: number;
+  loadedOlderHistory: boolean;
   loading: boolean;
   loadingMore: boolean;
   needsHydrationAfterCompletion: boolean;
@@ -175,6 +176,7 @@ function createEmptyThreadSessionEntry(): ThreadSessionEntry {
     expectOwnUpdate: false,
     interacted: false,
     lastTouchedAt: Date.now(),
+    loadedOlderHistory: false,
     loading: false,
     loadingMore: false,
     needsHydrationAfterCompletion: false,
@@ -538,6 +540,36 @@ function mergeTranscriptMessages(
   }
 
   return merged;
+}
+
+function preserveLoadedTranscriptHistory(
+  response: AppServerReadThreadResponse,
+  retainedResponse: AppServerReadThreadResponse | undefined,
+  shouldPreserve: boolean
+): AppServerReadThreadResponse {
+  if (
+    !shouldPreserve ||
+    !retainedResponse ||
+    !response.replay.pagination.supportsPagination
+  ) {
+    return response;
+  }
+
+  return {
+    ...response,
+    replay: {
+      ...response.replay,
+      entries: mergeItems(
+        retainedResponse.replay.entries,
+        response.replay.entries
+      ),
+      messages: mergeItems(
+        retainedResponse.replay.messages,
+        response.replay.messages
+      ),
+      pagination: retainedResponse.replay.pagination,
+    },
+  };
 }
 
 function isCodexImageBoundaryText(value: string): boolean {
@@ -3043,9 +3075,14 @@ export function useThreadSessionState(params: {
             [...(current.response?.replay.entries ?? []), ...liveTranscriptSources],
             liveTranscriptSources
           );
+          const responseWithLoadedHistory = preserveLoadedTranscriptHistory(
+            orderedResponse,
+            current.response,
+            current.loadedOlderHistory
+          );
           const hydratedCompletedTurn = didHydrateCompletedTurn(
             current.response,
-            orderedResponse
+            responseWithLoadedHistory
           );
           const needsHydrationAfterCompletion =
             current.needsHydrationAfterCompletion && !hydratedCompletedTurn;
@@ -3067,7 +3104,7 @@ export function useThreadSessionState(params: {
             logStaleThinkingState({
               current,
               reasons: thinkingReasons,
-              response: orderedResponse,
+              response: responseWithLoadedHistory,
               targetThreadKey,
             });
           }
@@ -3094,7 +3131,7 @@ export function useThreadSessionState(params: {
             needsHydrationAfterCompletion,
             optimisticEntries: pruneOptimisticEntries(
               current.optimisticEntries,
-              orderedResponse
+              responseWithLoadedHistory
             ),
             pendingAssistantMessage: shouldClearStaleThinking
               ? undefined
@@ -3102,7 +3139,7 @@ export function useThreadSessionState(params: {
             pendingStatusText: shouldClearStaleThinking
               ? undefined
               : current.pendingStatusText,
-            response: orderedResponse,
+            response: responseWithLoadedHistory,
           };
         });
       } catch (error) {
@@ -4434,6 +4471,7 @@ export function useThreadSessionState(params: {
               },
             }
           : olderResponse,
+        loadedOlderHistory: Boolean(current.response),
       }));
     } catch (error) {
       if ((requestVersionsRef.current[threadKey] ?? 0) !== requestVersion) {

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -49,6 +49,7 @@ import {
 } from "../features/thread-detail/live-transcript-activity";
 
 const MAX_VIEW_ONLY_THREADS = 10;
+export const LIGHTWEIGHT_INITIAL_THREAD_HISTORY_LIMIT = 5;
 const SUPPORTED_APPROVAL_REQUEST_METHODS = new Set([
   "turn/requestApproval",
   "review/requestApproval",
@@ -129,6 +130,7 @@ type ThreadSessionEntry = {
   error?: string;
   expectOwnUpdate: boolean;
   failedHydrationVersion?: number | "unknown";
+  hydratedInitialHistoryLimit?: number;
   hydratedUpdatedAt?: number;
   interacted: boolean;
   lastTouchedAt: number;
@@ -2830,6 +2832,7 @@ function didHydrateCompletedTurn(
 
 export function useThreadSessionState(params: {
   desktopApi?: DesktopApi;
+  initialHistoryLimit?: number;
   liveTranscriptEventFiltering?: boolean;
   thread?: NavigationThreadSummary;
 }): {
@@ -2977,6 +2980,8 @@ export function useThreadSessionState(params: {
     [desktopApi?.logRendererDiagnostic]
   );
 
+  const initialHistoryLimit = params.initialHistoryLimit;
+
   const loadLatest = useCallback(
     async (targetThread: NavigationThreadSummary): Promise<void> => {
       const readThread = desktopApi?.readThread;
@@ -3013,6 +3018,9 @@ export function useThreadSessionState(params: {
         });
         const response = normalizeResponseImageBoundaryText(await readThread({
           backend: targetThread.source,
+          ...(initialHistoryLimit !== undefined
+            ? { limit: initialHistoryLimit }
+            : {}),
           threadId: targetThread.id,
         }));
         desktopApi?.recordStartupProfileEvent?.("thread-hydration:response", {
@@ -3075,6 +3083,7 @@ export function useThreadSessionState(params: {
             error: undefined,
             expectOwnUpdate: false,
             failedHydrationVersion: undefined,
+            hydratedInitialHistoryLimit: initialHistoryLimit,
             hydratedUpdatedAt:
               needsHydrationAfterCompletion && completionHydrationRetries < 2
                 ? undefined
@@ -3118,6 +3127,7 @@ export function useThreadSessionState(params: {
     [
       desktopApi?.readThread,
       desktopApi?.recordStartupProfileEvent,
+      initialHistoryLimit,
       logStaleThinkingState,
       updateSession,
     ]
@@ -3299,6 +3309,9 @@ export function useThreadSessionState(params: {
     }
 
     if (thread.updatedAt == null || session.hydratedUpdatedAt === thread.updatedAt) {
+      if (session.hydratedInitialHistoryLimit !== initialHistoryLimit) {
+        void loadLatest(thread);
+      }
       return;
     }
 
@@ -3333,7 +3346,7 @@ export function useThreadSessionState(params: {
     }
 
     void loadLatest(thread);
-  }, [loadLatest, sessions, thread, threadKey, updateSession]);
+  }, [initialHistoryLimit, loadLatest, sessions, thread, threadKey, updateSession]);
 
   useEffect(() => {
     if (!desktopApi?.onAgentEvent) {

--- a/apps/desktop/src/renderer/src/lib/useThreadTranscript.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadTranscript.ts
@@ -44,6 +44,7 @@ function messageMatchesOptimisticEntry(
 
 export function useThreadTranscript(params: {
   desktopApi?: DesktopApi;
+  initialHistoryLimit?: number;
   thread?: NavigationThreadSummary;
 }): {
   addOptimisticUserMessage: (
@@ -60,7 +61,7 @@ export function useThreadTranscript(params: {
   refresh: () => Promise<void>;
   response?: AppServerReadThreadResponse;
 } {
-  const { desktopApi, thread } = params;
+  const { desktopApi, initialHistoryLimit, thread } = params;
   const [response, setResponse] = useState<AppServerReadThreadResponse>();
   const [optimisticEntries, setOptimisticEntries] = useState<AppServerThreadMessageEntry[]>([]);
   const [loading, setLoading] = useState(false);
@@ -101,6 +102,9 @@ export function useThreadTranscript(params: {
     try {
       const nextResponse = await desktopApi.readThread({
         backend: thread.source,
+        ...(initialHistoryLimit !== undefined
+          ? { limit: initialHistoryLimit }
+          : {}),
         threadId: thread.id
       });
       if (requestVersionRef.current !== requestVersion) {
@@ -118,7 +122,7 @@ export function useThreadTranscript(params: {
         setLoading(false);
       }
     }
-  }, [desktopApi, thread]);
+  }, [desktopApi, initialHistoryLimit, thread]);
 
   useEffect(() => {
     void loadLatest();

--- a/packages/agent-core/src/__tests__/codex-app-server-contract.test.ts
+++ b/packages/agent-core/src/__tests__/codex-app-server-contract.test.ts
@@ -226,7 +226,7 @@ describe("Codex app-server contract", () => {
     });
 
     expect(turn).toEqual({ threadId: "thread-1", turnId: "turn-1" });
-    expect(replay).toEqual({
+    expect(replay).toMatchObject({
       threadId: "thread-1",
       thread: {
         threadId: "thread-1",
@@ -264,6 +264,95 @@ describe("Codex app-server contract", () => {
       ],
       lastUserMessage: "Ship it",
       lastAssistantMessage: "Done.",
+      pagination: {
+        supportsPagination: false,
+        hasPreviousPage: false,
+      },
     });
+  });
+
+  it("honors metadata-only and bounded thread/read requests", async () => {
+    const provider = new FakeProvider();
+    const { server } = createTestHarness({ provider });
+    await server.request("thread/start", { cwd: "/repo/workspace" });
+
+    const firstTurn = await server.request("turn/start", {
+      threadId: "thread-1",
+      input: [{ type: "text", text: "First ask" }],
+      collaborationMode: { mode: "default" },
+    });
+    provider.runs[0]?.deferred.resolve({
+      assistantText: "First answer.",
+      providerResponseId: "resp_1",
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    await server.request("turn/start", {
+      threadId: "thread-1",
+      input: [{ type: "text", text: "Second ask" }],
+      collaborationMode: { mode: "default" },
+    });
+    provider.runs[1]?.deferred.resolve({
+      assistantText: "Second answer.",
+      providerResponseId: "resp_2",
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    await expect(
+      server.request("thread/read", {
+        threadId: "thread-1",
+        includeTurns: false,
+      })
+    ).resolves.toMatchObject({
+      threadId: "thread-1",
+      thread: {
+        threadId: "thread-1",
+        cwd: "/repo/workspace",
+      },
+      messages: [],
+      items: [],
+    });
+
+    const latestPage = (await server.request("thread/read", {
+      threadId: "thread-1",
+      includeTurns: true,
+      limit: 2,
+    })) as { pagination: { previousCursor?: string } };
+
+    expect(latestPage).toMatchObject({
+      messages: [
+        { role: "user", text: "Second ask" },
+        { role: "assistant", text: "Second answer." },
+      ],
+      items: [
+        { type: "userMessage", text: "Second ask" },
+        { type: "agentMessage", text: "Second answer." },
+      ],
+      pagination: {
+        supportsPagination: true,
+        hasPreviousPage: true,
+      },
+    });
+
+    await expect(
+      server.request("thread/read", {
+        threadId: "thread-1",
+        includeTurns: true,
+        before: latestPage.pagination.previousCursor,
+        limit: 2,
+      })
+    ).resolves.toMatchObject({
+      messages: [
+        { role: "user", text: "First ask" },
+        { role: "assistant", text: "First answer." },
+      ],
+      pagination: {
+        supportsPagination: true,
+        hasPreviousPage: false,
+      },
+    });
+    expect(firstTurn).toEqual({ threadId: "thread-1", turnId: "turn-1" });
   });
 });

--- a/packages/agent-core/src/__tests__/codex-app-server-contract.test.ts
+++ b/packages/agent-core/src/__tests__/codex-app-server-contract.test.ts
@@ -264,10 +264,6 @@ describe("Codex app-server contract", () => {
       ],
       lastUserMessage: "Ship it",
       lastAssistantMessage: "Done.",
-      pagination: {
-        supportsPagination: false,
-        hasPreviousPage: false,
-      },
     });
   });
 

--- a/packages/agent-core/src/app-server/codex-app-server.ts
+++ b/packages/agent-core/src/app-server/codex-app-server.ts
@@ -290,7 +290,11 @@ export class CodexAppServer {
     if (!thread) {
       throw new AppServerProtocolError(`Unknown thread: ${threadId}`);
     }
-    return this.state.readThread(threadId);
+    return this.state.readThread(threadId, {
+      before: asOptionalString(params.before),
+      includeTurns: asOptionalBoolean(params.includeTurns),
+      limit: asOptionalNonNegativeInteger(params.limit),
+    });
   }
 
   private async startCompaction(
@@ -478,6 +482,12 @@ function asOptionalString(value: unknown): string | undefined {
 
 function asOptionalBoolean(value: unknown): boolean | undefined {
   return typeof value === "boolean" ? value : undefined;
+}
+
+function asOptionalNonNegativeInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? Math.max(0, Math.floor(value))
+    : undefined;
 }
 
 function asOptionalStringArray(value: unknown): string[] | undefined {

--- a/packages/agent-core/src/app-server/internal-contract.ts
+++ b/packages/agent-core/src/app-server/internal-contract.ts
@@ -73,6 +73,11 @@ export type ThreadReplay = {
   items: ThreadReplayItem[];
   lastUserMessage?: string;
   lastAssistantMessage?: string;
+  pagination?: {
+    supportsPagination: boolean;
+    hasPreviousPage: boolean;
+    previousCursor?: string;
+  };
 };
 
 export type AppServerItemStatus =

--- a/packages/agent-core/src/app-server/session-state.ts
+++ b/packages/agent-core/src/app-server/session-state.ts
@@ -89,6 +89,12 @@ function buildReplayPagination(
   };
 }
 
+function stripUndefinedRecord<T extends Record<string, unknown>>(value: T): T {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entryValue]) => entryValue !== undefined),
+  ) as T;
+}
+
 export class AppServerSessionState {
   private readonly store?: AppServerSessionStore;
   private readonly threads = new Map<string, ThreadState>();
@@ -363,17 +369,14 @@ export class AppServerSessionState {
         thread,
         messages: [],
         items: [],
-        pagination: {
-          supportsPagination: false,
-          hasPreviousPage: false,
-        },
       };
     }
 
     const limitedItems = pageReplayItems(items, options);
+    const isPagedRead = limitedItems !== items;
     const replayMessages =
-      limitedItems === items
-        ? messages
+      !isPagedRead
+        ? messages.map((message) => stripUndefinedRecord(message))
         : limitedItems.flatMap((item) =>
             item.role && item.text
               ? [
@@ -403,10 +406,12 @@ export class AppServerSessionState {
       threadId,
       thread,
       messages: replayMessages,
-      items: limitedItems,
+      items: limitedItems.map((item) => normalizeReplayItem(item)),
       lastUserMessage,
       lastAssistantMessage,
-      pagination: buildReplayPagination(items, limitedItems),
+      ...(isPagedRead
+        ? { pagination: buildReplayPagination(items, limitedItems) }
+        : {}),
     };
   }
 

--- a/packages/agent-core/src/app-server/session-state.ts
+++ b/packages/agent-core/src/app-server/session-state.ts
@@ -36,6 +36,59 @@ type CreateThreadParams = {
 
 type ThreadMutation = Partial<Omit<ThreadState, "threadId" | "createdAt">>;
 
+function normalizeReadLimit(limit: number | undefined): number | undefined {
+  if (limit === undefined || !Number.isFinite(limit)) {
+    return undefined;
+  }
+  return Math.max(0, Math.floor(limit));
+}
+
+function pageReplayItems(
+  items: ThreadReplayItem[],
+  options: {
+    before?: string;
+    limit?: number;
+  },
+): ThreadReplayItem[] {
+  const limit = normalizeReadLimit(options.limit);
+  if (limit === undefined && !options.before) {
+    return items;
+  }
+
+  const endIndex = options.before
+    ? items.findIndex((item) => item.id === options.before)
+    : items.length;
+  const boundedEndIndex = endIndex >= 0 ? endIndex : items.length;
+  const startIndex =
+    limit === undefined ? 0 : Math.max(0, boundedEndIndex - limit);
+  return items.slice(startIndex, boundedEndIndex);
+}
+
+function buildReplayPagination(
+  allItems: ThreadReplayItem[],
+  pageItems: ThreadReplayItem[],
+): ThreadReplay["pagination"] {
+  if (pageItems === allItems) {
+    return {
+      supportsPagination: false,
+      hasPreviousPage: false,
+    };
+  }
+
+  const firstPageItem = pageItems[0];
+  const firstPageIndex = firstPageItem
+    ? allItems.findIndex((item) => item.id === firstPageItem.id)
+    : allItems.length;
+  const hasPreviousPage = firstPageIndex > 0;
+  return {
+    supportsPagination: true,
+    hasPreviousPage,
+    ...(hasPreviousPage && firstPageItem
+      ? { previousCursor: firstPageItem.id }
+      : {}),
+  };
+}
+
 export class AppServerSessionState {
   private readonly store?: AppServerSessionStore;
   private readonly threads = new Map<string, ThreadState>();
@@ -292,7 +345,11 @@ export class AppServerSessionState {
     });
   }
 
-  readThread(threadId: string): ThreadReplay {
+  readThread(threadId: string, options: {
+    before?: string;
+    includeTurns?: boolean;
+    limit?: number;
+  } = {}): ThreadReplay {
     this.refreshFromStore();
     const thread = this.threads.get(threadId);
     if (!thread) {
@@ -300,6 +357,34 @@ export class AppServerSessionState {
     }
     const messages = [...(this.messages.get(threadId) ?? [])];
     const items = [...(this.items.get(threadId) ?? [])];
+    if (options.includeTurns === false) {
+      return {
+        threadId,
+        thread,
+        messages: [],
+        items: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+      };
+    }
+
+    const limitedItems = pageReplayItems(items, options);
+    const replayMessages =
+      limitedItems === items
+        ? messages
+        : limitedItems.flatMap((item) =>
+            item.role && item.text
+              ? [
+                  {
+                    role: item.role,
+                    text: item.text,
+                    ...(item.parts ? { parts: item.parts } : {}),
+                  },
+                ]
+              : []
+          );
     let lastUserMessage: string | undefined;
     let lastAssistantMessage: string | undefined;
     for (let index = messages.length - 1; index >= 0; index -= 1) {
@@ -317,10 +402,11 @@ export class AppServerSessionState {
     return {
       threadId,
       thread,
-      messages,
-      items,
+      messages: replayMessages,
+      items: limitedItems,
       lastUserMessage,
       lastAssistantMessage,
+      pagination: buildReplayPagination(items, limitedItems),
     };
   }
 

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -79,6 +79,10 @@ describe("desktop settings contracts", () => {
           value: false,
           source: "default",
         },
+        lightweightNavigationRefresh: {
+          value: false,
+          source: "default",
+        },
         threadPricingSummary: {
           value: false,
           source: "default",

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -739,6 +739,7 @@ export type GetNavigationSnapshotRequest = {
   backend?: AppServerBackendScope;
   filter?: string;
   forceRefresh?: boolean;
+  refreshMode?: "active-recent" | "full";
 };
 
 export type SetNavigationBrowseModeRequest = {

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -636,6 +636,7 @@ export type RenameThreadResponse = {
 export type AppServerReadThreadRequest = {
   backend?: AppServerBackendKind;
   threadId: ThreadIdentifier;
+  includeTurns?: boolean;
   before?: string;
   limit?: number;
 };

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -460,6 +460,13 @@ export type DesktopSettingsSnapshot = {
      */
     liveTranscriptEventFiltering: DesktopSettingsValue<boolean>;
     /**
+     * Gates the lightweight navigation refresh experiment. When disabled,
+     * background navigation refreshes keep using broad forced snapshots.
+     * When enabled, foreground polling uses the one-page active-recent
+     * snapshot and focus refreshes are coalesced.
+     */
+    lightweightNavigationRefresh: DesktopSettingsValue<boolean>;
+    /**
      * Gates the thread context-rail Pricing tab. The pricing ledger may still
      * collect data for validation, but the user-visible summary stays hidden
      * while this experimental setting is disabled.
@@ -705,6 +712,7 @@ export type DesktopSettingsConfigPatch = {
   experimental?: {
     fullAccessRiskWarningDismissed?: boolean;
     liveTranscriptEventFiltering?: boolean;
+    lightweightNavigationRefresh?: boolean;
     threadPricingSummary?: boolean;
     threadPricingDisplayUsd?: boolean;
     threadPricingDisplayCodexCredits?: boolean;


### PR DESCRIPTION
## Summary

- I rebased this branch onto current `origin/main` and kept `lightweight_navigation_refresh` as an active Experimental setting, defaulted off.
- With the setting off, background navigation polling keeps the broad forced snapshot behavior and focus events use the existing scheduled refresh path.
- With the setting on, focused background polling uses one active-recent Codex `thread/list` page and focus catch-up refreshes are coalesced to at most once per minute after completion.
- I transplanted the thread-history loading split from `origin/handoff/thread-history-load-split`: `thread/read` can now honor `includeTurns`, `limit`, and `before`; status/background reads can omit turns; replay pagination metadata is preserved.
- Selected-thread initial hydration uses a small recent tail only when `lightweight_navigation_refresh` is enabled. Changing the setting while a thread is open rehydrates that thread with the new mode, so a restart is not required.

## Verification

- I ran `pnpm test packages/agent-core/src/__tests__/codex-app-server-contract.test.ts apps/desktop/src/main/__tests__/codex-client.test.ts apps/desktop/src/main/__tests__/grok-app-server-client.test.ts apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx apps/desktop/src/main/__tests__/desktop-settings-service.test.ts apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts packages/shared/src/contracts/__tests__/settings.test.ts -- --runInBand`; 10 files passed, 432 tests passed.
- I ran `pnpm --filter @pwragent/desktop typecheck`; it passed after syncing node_modules with `pnpm install`.
- I ran `pnpm typecheck`; it passed.
- I ran `pnpm lint:boundaries`; it passed.
- I ran `git diff --check`; it passed.
