### PR TITLE
fix(desktop): refresh retained PR chips by URL

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -289,7 +289,8 @@ const getAuthStatus = vi.fn(async () => ({
   hasRepoScope: true,
 }));
 const fetchPullRequestByUrl = vi.fn(
-  async (): Promise<PrSummary | undefined> => undefined,
+  async (_request: { cwd: string; url: string }): Promise<PrSummary | undefined> =>
+    undefined,
 );
 const detectPullRequestsForThread = vi.fn(async (): Promise<PrSummary[]> => []);
 
@@ -1394,6 +1395,143 @@ describe("app server ipc", () => {
         prs: fetchedPrs,
       }),
     );
+  });
+
+  it("refreshes retained PRs from all subscribers on a coalesced lookup", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_REFRESH_THREAD_PRS_CHANNEL } = await import("../../shared/ipc");
+    const baseRequest = {
+      backend: "codex",
+      branch: "codex/reused-branch",
+      directoryPaths: ["/repo"],
+    } satisfies Omit<RefreshThreadPullRequestsRequest, "threadId">;
+    const firstRequest = {
+      ...baseRequest,
+      threadId: "thread-1",
+    } satisfies RefreshThreadPullRequestsRequest;
+    const secondRequest = {
+      ...baseRequest,
+      threadId: "thread-2",
+    } satisfies RefreshThreadPullRequestsRequest;
+    const firstRequestKey = buildThreadPrRequestKey({
+      backend: "codex",
+      threadId: firstRequest.threadId,
+      branch: baseRequest.branch,
+      directoryPaths: baseRequest.directoryPaths,
+    });
+    const secondRequestKey = buildThreadPrRequestKey({
+      backend: "codex",
+      threadId: secondRequest.threadId,
+      branch: baseRequest.branch,
+      directoryPaths: baseRequest.directoryPaths,
+    });
+    const firstStalePr = githubPr({
+      number: 255,
+      org: "Giphy",
+      repo: "GifGrabber",
+      state: "passing",
+      url: "https://github.com/Giphy/GifGrabber/pull/255",
+    });
+    const secondStalePr = githubPr({
+      number: 256,
+      org: "Giphy",
+      repo: "GifGrabber",
+      state: "pending",
+      url: "https://github.com/Giphy/GifGrabber/pull/256",
+    });
+    const firstMergedPr = githubPr({
+      ...firstStalePr,
+      state: "passing",
+      lifecycleState: "merged",
+    });
+    const secondMergedPr = githubPr({
+      ...secondStalePr,
+      state: "passing",
+      lifecycleState: "merged",
+    });
+    getThreadOverlayState
+      .mockResolvedValueOnce({
+        backend: "codex",
+        threadId: firstRequest.threadId,
+        executionMode: "default",
+        extraLinkedDirectories: [],
+        prs: [firstStalePr],
+        prsFetchedAt: Date.now() - 120_000,
+        prsRefreshKey: firstRequestKey,
+      })
+      .mockResolvedValueOnce({
+        backend: "codex",
+        threadId: secondRequest.threadId,
+        executionMode: "default",
+        extraLinkedDirectories: [],
+        prs: [secondStalePr],
+        prsFetchedAt: Date.now() - 120_000,
+        prsRefreshKey: secondRequestKey,
+      });
+    let resolveFetch: ((prs: PrSummary[]) => void) | undefined;
+    detectPullRequestsForThread.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveFetch = resolve;
+      }),
+    );
+    fetchPullRequestByUrl.mockImplementation(async ({ url }: { url: string }) => {
+      if (url.endsWith("/255")) return firstMergedPr;
+      if (url.endsWith("/256")) return secondMergedPr;
+      return undefined;
+    });
+
+    registerAppServerIpcHandlers();
+
+    const handler = handlers.get(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL)!;
+    const first = handler({}, firstRequest);
+    const second = handler({}, secondRequest);
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      {
+        backend: "codex",
+        threadId: "thread-1",
+        provider: "github.com",
+        ghAvailable: true,
+        prs: [firstStalePr],
+      },
+      {
+        backend: "codex",
+        threadId: "thread-2",
+        provider: "github.com",
+        ghAvailable: true,
+        prs: [secondStalePr],
+      },
+    ]);
+    await vi.waitFor(() => {
+      expect(detectPullRequestsForThread).toHaveBeenCalledOnce();
+    });
+    resolveFetch?.([]);
+
+    await vi.waitFor(() => {
+      expect(fetchPullRequestByUrl).toHaveBeenCalledWith({
+        cwd: "/repo",
+        url: "https://github.com/Giphy/GifGrabber/pull/255",
+      });
+      expect(fetchPullRequestByUrl).toHaveBeenCalledWith({
+        cwd: "/repo",
+        url: "https://github.com/Giphy/GifGrabber/pull/256",
+      });
+    });
+    await vi.waitFor(() => {
+      expect(setThreadPullRequests).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        prs: [firstMergedPr],
+        fetchedAt: expect.any(Number),
+        refreshKey: firstRequestKey,
+      });
+      expect(setThreadPullRequests).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-2",
+        prs: [secondMergedPr],
+        fetchedAt: expect.any(Number),
+        refreshKey: secondRequestKey,
+      });
+    });
   });
 
   it("returns recent cached empty PR lookups without hitting GitHub", async () => {

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -288,6 +288,9 @@ const getAuthStatus = vi.fn(async () => ({
   scopes: ["repo"],
   hasRepoScope: true,
 }));
+const fetchPullRequestByUrl = vi.fn(
+  async (): Promise<PrSummary | undefined> => undefined,
+);
 const detectPullRequestsForThread = vi.fn(async (): Promise<PrSummary[]> => []);
 
 function githubPr(
@@ -419,6 +422,7 @@ vi.mock("../pr-status/github-pr-fetcher", () => ({
     return {
       isGhAvailable,
       getAuthStatus,
+      fetchPullRequestByUrl,
     };
   }),
 }));
@@ -470,6 +474,8 @@ describe("app server ipc", () => {
     isGhAvailable.mockClear();
     isGhAvailable.mockResolvedValue(true);
     getAuthStatus.mockClear();
+    fetchPullRequestByUrl.mockReset();
+    fetchPullRequestByUrl.mockResolvedValue(undefined);
     detectPullRequestsForThread.mockReset();
     detectPullRequestsForThread.mockResolvedValue([]);
   });
@@ -1720,6 +1726,116 @@ describe("app server ipc", () => {
         fetchedAt: expect.any(Number),
         refreshKey: requestKey,
       });
+    });
+  });
+
+  it("refreshes retained non-terminal PRs by URL when the current branch lookup is empty", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_REFRESH_THREAD_PRS_CHANNEL } = await import("../../shared/ipc");
+    const request = {
+      backend: "codex",
+      threadId: "thread-1",
+      branch: "codex/fix-reel-upload-button-swift",
+      directoryPaths: ["/repo"],
+    } satisfies RefreshThreadPullRequestsRequest;
+    const requestKey = buildThreadPrRequestKey({
+      backend: "codex",
+      threadId: "thread-1",
+      branch: "codex/fix-reel-upload-button-swift",
+      directoryPaths: ["/repo"],
+    });
+    const lookupKey = buildPrLookupKey({
+      branch: "codex/fix-reel-upload-button-swift",
+      directoryPaths: ["/repo"],
+    });
+    const stalePr = githubPr({
+      number: 255,
+      org: "Giphy",
+      repo: "GifGrabber",
+      title: "[codex] Fix upload button after reel switching",
+      state: "passing",
+      url: "https://github.com/Giphy/GifGrabber/pull/255",
+    });
+    const mergedPr = githubPr({
+      ...stalePr,
+      state: "passing",
+      lifecycleState: "merged",
+      reviewState: "ready_for_review",
+      mergeState: "unknown",
+    });
+    getThreadOverlayState.mockResolvedValueOnce({
+      backend: "codex",
+      threadId: "thread-1",
+      executionMode: "default",
+      extraLinkedDirectories: [],
+      prs: [stalePr],
+      prsFetchedAt: Date.now() - 120_000,
+      prsRefreshKey: requestKey,
+    });
+    detectPullRequestsForThread.mockResolvedValueOnce([]);
+    fetchPullRequestByUrl.mockResolvedValueOnce(mergedPr);
+
+    registerAppServerIpcHandlers();
+
+    const response = await handlers.get(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL)?.(
+      {},
+      request,
+    );
+
+    expect(response).toEqual({
+      backend: "codex",
+      threadId: "thread-1",
+      provider: "github.com",
+      ghAvailable: true,
+      prs: [stalePr],
+    });
+    await vi.waitFor(() => {
+      expect(detectPullRequestsForThread).toHaveBeenCalledWith({
+        fetcher: expect.any(Object),
+        branch: "codex/fix-reel-upload-button-swift",
+        directoryPaths: ["/repo"],
+      });
+    });
+    await vi.waitFor(() => {
+      expect(fetchPullRequestByUrl).toHaveBeenCalledWith({
+        cwd: "/repo",
+        url: "https://github.com/Giphy/GifGrabber/pull/255",
+      });
+    });
+    await vi.waitFor(() => {
+      expect(setThreadPullRequests).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        prs: [mergedPr],
+        fetchedAt: expect.any(Number),
+        refreshKey: requestKey,
+      });
+    });
+    expect(writePrStatusCacheEntries).toHaveBeenCalledWith([
+      {
+        provider: "github.com",
+        prKey: "github.com/giphy/gifgrabber#255",
+        fetchedAt: expect.any(Number),
+        pr: mergedPr,
+      },
+    ]);
+    expect(writePrLookupCacheEntry).toHaveBeenCalledWith({
+      lookupKey,
+      provider: "github.com",
+      branch: "codex/fix-reel-upload-button-swift",
+      directoryPaths: ["/repo"],
+      fetchedAt: expect.any(Number),
+      prs: [],
+    });
+    expect(publishLocalEvent).toHaveBeenCalledWith({
+      backend: "codex",
+      notification: {
+        method: "thread/pullRequests/updated",
+        params: {
+          threadId: "thread-1",
+          prs: [mergedPr],
+        },
+      },
     });
   });
 

--- a/apps/desktop/src/main/__tests__/github-pr-fetcher.test.ts
+++ b/apps/desktop/src/main/__tests__/github-pr-fetcher.test.ts
@@ -423,6 +423,47 @@ describe("GithubPrFetcher", () => {
     });
   });
 
+  describe("fetchPullRequestByUrl", () => {
+    it("uses gh pr view for retained PR chips whose head branch is no longer current", async () => {
+      const { fetcher, exec } = buildFetcher({
+        stdout: JSON.stringify(rawMergedPr()),
+      });
+      const result = await fetcher.fetchPullRequestByUrl({
+        cwd: "/tmp/repo",
+        url: "https://github.com/pwrdrvr/PwrAgent/pull/178",
+      });
+      expect(result).toEqual({
+        provider: "github.com",
+        number: 178,
+        org: "pwrdrvr",
+        repo: "PwrAgent",
+        title: "Retain thread pull request history",
+        state: "passing",
+        checkState: "passing",
+        lifecycleState: "merged",
+        reviewState: "ready_for_review",
+        mergeState: "unknown",
+        url: "https://github.com/pwrdrvr/PwrAgent/pull/178",
+      });
+      expect(exec).toHaveBeenCalledWith("/tmp/repo", [
+        "pr",
+        "view",
+        "https://github.com/pwrdrvr/PwrAgent/pull/178",
+        "--json",
+        expect.any(String),
+      ]);
+    });
+
+    it("returns undefined on subprocess failure", async () => {
+      const { fetcher } = buildFetcher({ error: new Error("gh failed") });
+      const result = await fetcher.fetchPullRequestByUrl({
+        cwd: "/tmp/repo",
+        url: "https://github.com/pwrdrvr/PwrAgent/pull/178",
+      });
+      expect(result).toBeUndefined();
+    });
+  });
+
   describe("isGhAvailable / invalidateGhAvailable", () => {
     it("caches the probe and re-uses for repeated calls within the TTL", async () => {
       const { fetcher, probeGhAvailable } = buildFetcher();

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -411,6 +411,20 @@ function normalizePrSummary(pr: PrSummary): PrSummary {
   };
 }
 
+function dedupePrsByStatusKey(prs: PrSummary[]): PrSummary[] {
+  const seen = new Set<string>();
+  const out: PrSummary[] = [];
+  for (const pr of prs.map(normalizePrSummary)) {
+    const key = getPrStatusKey(pr);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    out.push(pr);
+  }
+  return out;
+}
+
 function normalizePrCheckState(
   state: string | undefined,
 ): NonNullable<PrSummary["checkState"]> {
@@ -1626,6 +1640,7 @@ class DesktopAppServerService {
     request: RefreshThreadPullRequestsRequest;
     lookupKey: string;
     lookupDirectoryPaths: string[];
+    previousPrs: PrSummary[];
   }): Promise<{ prs: PrSummary[]; fetchedAt: number }> {
     const prs = (await detectPullRequestsForThread({
       fetcher: this.getPrFetcher(),
@@ -1633,8 +1648,14 @@ class DesktopAppServerService {
       directoryPaths: params.request.directoryPaths,
     })).map(normalizePrSummary);
     const fetchedAt = Date.now();
-    this.rememberPrStatuses(prs, fetchedAt);
-    await this.writePrStatusesToCache(prs, fetchedAt);
+    const retainedPrs = await this.fetchRetainedNonTerminalPullRequests({
+      prs: params.previousPrs,
+      discoveredPrs: prs,
+      cwd: params.lookupDirectoryPaths[0] ?? params.request.directoryPaths[0],
+    });
+    const statusPrs = dedupePrsByStatusKey([...prs, ...retainedPrs]);
+    this.rememberPrStatuses(statusPrs, fetchedAt);
+    await this.writePrStatusesToCache(statusPrs, fetchedAt);
     this.rememberPrLookup({
       lookupKey: params.lookupKey,
       provider: normalizePullRequestProvider(params.request.provider),
@@ -1653,6 +1674,47 @@ class DesktopAppServerService {
     });
 
     return { prs, fetchedAt };
+  }
+
+  private async fetchRetainedNonTerminalPullRequests(params: {
+    prs: PrSummary[];
+    discoveredPrs: PrSummary[];
+    cwd?: string;
+  }): Promise<PrSummary[]> {
+    const cwd = params.cwd;
+    if (!cwd) {
+      return [];
+    }
+
+    const discoveredKeys = new Set(
+      params.discoveredPrs.map((pr) => getPrStatusKey(pr)),
+    );
+    const seenRetainedKeys = new Set<string>();
+    const retainedPrs = params.prs
+      .map(normalizePrSummary)
+      .filter((pr) => {
+        const key = getPrStatusKey(pr);
+        if (discoveredKeys.has(key)) return false;
+        if (seenRetainedKeys.has(key)) return false;
+        if (pr.lifecycleState === "merged" || pr.lifecycleState === "closed") {
+          return false;
+        }
+        seenRetainedKeys.add(key);
+        return true;
+      });
+
+    if (retainedPrs.length === 0) {
+      return [];
+    }
+
+    const fetcher = this.getPrFetcher();
+    const refreshed = await Promise.all(
+      retainedPrs.map((pr) =>
+        fetcher.fetchPullRequestByUrl({ cwd, url: pr.url }),
+      ),
+    );
+    return refreshed.filter((pr): pr is PrSummary => Boolean(pr))
+      .map(normalizePrSummary);
   }
 
   private startPullRequestLookupRefresh(params: {

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1649,7 +1649,10 @@ class DesktopAppServerService {
     })).map(normalizePrSummary);
     const fetchedAt = Date.now();
     const retainedPrs = await this.fetchRetainedNonTerminalPullRequests({
-      prs: params.previousPrs,
+      prs: this.getPullRequestLookupSubscriberPreviousPrs({
+        lookupKey: params.lookupKey,
+        fallbackPrs: params.previousPrs,
+      }),
       discoveredPrs: prs,
       cwd: params.lookupDirectoryPaths[0] ?? params.request.directoryPaths[0],
     });
@@ -1674,6 +1677,17 @@ class DesktopAppServerService {
     });
 
     return { prs, fetchedAt };
+  }
+
+  private getPullRequestLookupSubscriberPreviousPrs(params: {
+    lookupKey: string;
+    fallbackPrs: PrSummary[];
+  }): PrSummary[] {
+    const subscribers = this.prLookupSubscribers.get(params.lookupKey);
+    if (!subscribers?.size) {
+      return params.fallbackPrs;
+    }
+    return [...subscribers.values()].flatMap((subscriber) => subscriber.previousPrs);
   }
 
   private async fetchRetainedNonTerminalPullRequests(params: {

--- a/apps/desktop/src/main/pr-status/github-pr-fetcher.ts
+++ b/apps/desktop/src/main/pr-status/github-pr-fetcher.ts
@@ -266,6 +266,38 @@ export class GithubPrFetcher {
   }
 
   /**
+   * Fetch the latest state for a retained PR chip by URL. This covers thread
+   * history chips whose original head branch no longer matches the thread's
+   * current branch lookup.
+   */
+  async fetchPullRequestByUrl(params: {
+    cwd: string;
+    url: string;
+  }): Promise<PrSummary | undefined> {
+    if (!(await this.isGhAvailable())) {
+      return undefined;
+    }
+    try {
+      const { stdout } = await this.exec(params.cwd, [
+        "pr",
+        "view",
+        params.url,
+        "--json",
+        GH_FIELDS,
+      ]);
+      const payload = JSON.parse(stdout) as GhPrPayload;
+      return parseGhPrPayload(payload);
+    } catch (error) {
+      fetcherLog.warn("gh pr view failed", {
+        cwd: params.cwd,
+        url: params.url,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return undefined;
+    }
+  }
+
+  /**
    * Probe `gh auth status` and return parsed installed / logged-in /
    * scopes info for the Applications settings panel. Result is cached
    * for `authStatusCacheTtlMs` (default 5 min) so reopening the


### PR DESCRIPTION
## Summary
Retained PR chips now refresh even when the thread has moved to a different branch and the current `gh pr list --head` lookup returns nothing. This fixes stale open/passing chips for PRs that were merged after their original head branch stopped matching the thread branch.

The branch lookup cache stays branch-scoped: retained non-terminal PRs are refreshed separately with `gh pr view <url>`, then the existing PR status cache and `thread/pullRequests/updated` notification path publish the corrected state.

## Tests
- `pnpm test apps/desktop/src/main/__tests__/app-server-ipc.test.ts apps/desktop/src/main/__tests__/github-pr-fetcher.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
