### PR TITLE
fix(desktop): truncate lens-switch labels, swap "Directories"→"Dirs" when narrow

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -868,7 +868,23 @@ export function Sidebar(props: SidebarProps) {
               type="button"
               onClick={() => props.onBrowseModeChange(mode)}
             >
-              {browseModeLabels[mode]}
+              {mode === "directories" ? (
+                // Two labels, one shown at a time by the .lens-switch
+                // container query: the full word while the column is wide
+                // enough, "Dirs" once it narrows. The hidden span drops out
+                // of the accessible name (display:none), so the visible text
+                // is always the tab's name.
+                <>
+                  <span className="lens-switch__label lens-switch__label--full">
+                    {browseModeLabels[mode]}
+                  </span>
+                  <span className="lens-switch__label lens-switch__label--abbrev">
+                    Dirs
+                  </span>
+                </>
+              ) : (
+                <span className="lens-switch__label">{browseModeLabels[mode]}</span>
+              )}
             </button>
           ))}
         </div>

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -220,15 +220,18 @@ describe("Sidebar", () => {
     const lensTabs = within(
       screen.getByRole("tablist", { name: "Thread lenses" })
     ).getAllByRole("tab");
-    expect(lensTabs.map((tab) => tab.textContent)).toEqual([
-      "Updated",
-      "Created",
-      "Directories",
-    ]);
-    expect(screen.getByRole("tab", { name: "Directories" })).toHaveAttribute(
-      "aria-selected",
-      "true"
-    );
+    // The Directories tab carries a responsive short form ("Dirs") alongside
+    // the full word; which one shows is decided purely in CSS by a container
+    // query, so the tab's raw textContent holds both spans. Assert the full
+    // label (the visible text in a real browser at normal widths).
+    expect(
+      lensTabs.map(
+        (tab) =>
+          tab.querySelector(".lens-switch__label--full")?.textContent ??
+          tab.textContent
+      )
+    ).toEqual(["Updated", "Created", "Directories"]);
+    expect(lensTabs[2]).toHaveAttribute("aria-selected", "true");
     expect(screen.getAllByText("PwrAgent").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Cross-project cleanup").length).toBeGreaterThan(0);
     expect(screen.getAllByText("OpenAI").length).toBeGreaterThan(0);

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2412,6 +2412,11 @@ textarea,
   border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: var(--bg-panel);
+  /* Width-query container so the longest label ("Directories") can swap to
+     a short form once the (resizable) sidebar narrows past the point where it
+     would otherwise spill past the segmented control. The width is extrinsic
+     (`width: 100%`), so inline-size containment is safe here. */
+  container-type: inline-size;
 }
 
 .lens-switch__button,
@@ -2426,13 +2431,48 @@ textarea,
 }
 
 .lens-switch__button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   min-width: 0;
   height: 32px;
   padding: 0 6px;
+  /* Clip rather than let a too-long label bleed past the segmented control's
+     rounded box. The inner label handles the ellipsis; this is the wall. */
+  overflow: hidden;
   background: transparent;
   color: var(--text-secondary);
   transition: none;
   white-space: nowrap;
+}
+
+/* Label inside each lens button. Truncates with an ellipsis when a column is
+   too narrow to show the full word — the universal fallback for "Updated" /
+   "Created" / "Directories" alike. min-width:0 lets the flex child shrink
+   below its content width so text-overflow can engage. */
+.lens-switch__label {
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+/* "Directories" is the only label long enough to routinely clip, so it gets a
+   readable short form ("Dirs") instead of a mid-word ellipsis. The abbreviated
+   span is hidden until the container query below decides the column is too
+   tight for the full word. */
+.lens-switch__label--abbrev {
+  display: none;
+}
+
+@container (max-width: 300px) {
+  .lens-switch__label--full {
+    display: none;
+  }
+
+  .lens-switch__label--abbrev {
+    display: inline;
+  }
 }
 
 .lens-switch__button.is-active {


### PR DESCRIPTION
## Summary

- The thread lens switch (`Updated` / `Created` / `Directories`) let a long label spill past the segmented control's rounded box once the resizable sidebar (280–560px) was narrowed.
- Each button now clips (`overflow: hidden`) and its label truncates with `text-overflow: ellipsis`, so text can never escape the box.
- A container query keyed to the lens-switch's own width swaps the full `Directories` label for `Dirs` *just before* it would start clipping — a clean short form instead of a mid-word ellipsis. With `box-sizing: border-box` the query measures the content box, so the swap fires at sidebar ≤ ~340px; the full word clips below ~328px, so "Dirs" always wins first.
- The `Directories` tab renders both a full and a `Dirs` span, toggled purely in CSS. Exactly one is visible in a real browser, so the accessible name always equals the visible text — no `aria-label`, no WCAG 2.5.3 label-in-name mismatch.

Pure CSS can't "swap text only when it overflows" (that needs JS measurement); the container query is the CSS-native equivalent, with the ellipsis as the universal backstop for all three labels (e.g. `Updated`/`Created` only at the 280px floor).

Files:
- `app.css` — `container-type: inline-size` on `.lens-switch`; flex-center + `overflow: hidden` buttons; new `.lens-switch__label` ellipsis; `@container (max-width: 300px)` swap.
- `Sidebar.tsx` — labels wrapped in `.lens-switch__label`; Directories tab gets the dual full/`Dirs` spans.
- `sidebar.test.tsx` — the one assertion that read raw `textContent` now reads the full-label span (jsdom applies no CSS, so both spans are present).

## Verification

- `pnpm --filter @pwragent/desktop typecheck` — clean.
- `pnpm test … sidebar.test.tsx theme-contract.test.tsx` — 111 passed.
- Rendered the exact final CSS across the full 280–560px resize range in Chromium to confirm the swap point and that no label escapes the box.

## Notes

- Existing E2E `getByRole("tab", { name: "directories" })` specs run at the 408px default width, where `Directories` is shown (accessible name `Directories`) — unaffected.
- No new imports, so dependency boundaries are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)