### PR TITLE
fix(desktop): render sub-thread parents flush, not indented like children

### DIFF
--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2602,8 +2602,16 @@ textarea,
   padding-left: 12px;
 }
 
-.thread-row-shell.has-subthreads .thread-row {
-  padding-left: 30px;
+/* A parent card (has sub-threads) stays flush with its sibling rows —
+   only the TITLE LINE is inset to clear the disclosure chevron
+   (`.thread-row__subthread-toggle`, which sits at the title-line start).
+   The card edge, chips, and everything below align with non-parent rows,
+   so the card reads as a tree parent rather than an indented child; the
+   children below it carry the only real indent (`--nested` + the
+   subthread-list connector). Previously the whole card was padded 30px,
+   which made parents look nested. */
+.thread-row-shell.has-subthreads .thread-row__heading {
+  padding-left: 20px;
 }
 
 .thread-row__subthread-toggle {


### PR DESCRIPTION
## Summary

A thread card that has sub-threads was padded `padding-left: 30px` across the **whole card** to make room for the disclosure chevron in its left gutter. That shifted the title *and* the chip row right, so a parent thread read like an indented child rather than a tree parent (and the selection accent bar clustered against the chevron).

This insets **only the title line** instead: `.thread-row-shell.has-subthreads .thread-row__heading` gets `padding-left: 20px`, so the chevron + unread cookie + title clear the toggle while the **card edge and chip row stay flush with non-parent sibling rows**. The card now reads as a parent; the sub-threads below it carry the only real indent (the `--nested` padding + the subthread-list connector line). The chevron stays at the title-line start, and the accent bar already runs below it (from the merged #785 fix), so there's no orange-line cluster.

One rule changed (`-2/+10` in `app.css`); no React/behavior changes — the chevron still toggles and children still indent.

## Verification

- `pnpm lint:colors` passes (CSS-only; no new color literals — just a `padding-left`).
- No unit test asserts the old `has-subthreads` padding, so nothing to update; the full CI gate runs on this PR.
- Behavior is unchanged: the disclosure toggle, child indentation, and selection treatment all still work.
- This is a **layout** change — best confirmed live in the Directories lens with a parent that has children (a flush parent with the chevron at the title-line start and indented children below).

## Notes

- Builds on the already-merged "accent bar starts below the chevron" fix, so the selection bar runs down the left edge below the title without crowding the chevron.
- **Compact density caveat:** the chevron is pinned at `top: 13px` while a compact row is shorter — that's pre-existing, not introduced here. If it reads off in compact once you look, I can align it in this same branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
