### PR TITLE
fix(ci): avoid pnpm action setup on Windows

### DIFF
--- a/.github/actions/configure-windows-nodejs/action.yml
+++ b/.github/actions/configure-windows-nodejs/action.yml
@@ -1,0 +1,39 @@
+name: Configure Windows Node.js
+description: Set up Node.js, activate the repo-pinned pnpm via Corepack, and restore the pnpm store cache.
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version-file: .nvmrc
+
+    - name: Activate pnpm
+      id: pnpm
+      shell: pwsh
+      run: |
+        $packageManager = (Get-Content package.json | ConvertFrom-Json).packageManager
+        if (-not $packageManager.StartsWith("pnpm@")) {
+          throw "Expected packageManager to pin pnpm, got '$packageManager'"
+        }
+
+        corepack enable pnpm
+        corepack prepare $packageManager --activate
+        pnpm --version
+        "cache-key-segment=$($packageManager.Replace('@', '-'))" >> $env:GITHUB_OUTPUT
+
+    - name: Resolve pnpm store path
+      id: pnpm-store
+      shell: pwsh
+      run: |
+        $storePath = pnpm store path --silent
+        "path=$storePath" >> $env:GITHUB_OUTPUT
+
+    - name: Restore pnpm store
+      uses: actions/cache@v5
+      with:
+        path: ${{ steps.pnpm-store.outputs.path }}
+        key: pnpm-store-${{ runner.os }}-${{ runner.arch }}-${{ steps.pnpm.outputs.cache-key-segment }}-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: |
+          pnpm-store-${{ runner.os }}-${{ runner.arch }}-${{ steps.pnpm.outputs.cache-key-segment }}-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,20 +135,11 @@ jobs:
         uses: actions/checkout@v6
         timeout-minutes: 10
 
-      # The Linux configure-nodejs / install-ripgrep composite actions are
-      # POSIX-only, so set up Node + pnpm + ripgrep directly here. Git-for-Windows
-      # (bundling bash.exe, used by the agent's shell tools) is preinstalled on
-      # windows-latest runners.
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-        timeout-minutes: 5
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
+      # pwrdrvr/configure-nodejs is POSIX-only, so use a Windows-specific
+      # setup action that activates the repo-pinned pnpm through Corepack.
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/configure-windows-nodejs
         timeout-minutes: 10
-        with:
-          node-version-file: .nvmrc
-          cache: pnpm
 
       - name: Install dependencies
         timeout-minutes: 15
@@ -183,16 +174,9 @@ jobs:
         uses: actions/checkout@v6
         timeout-minutes: 10
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-        timeout-minutes: 5
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/configure-windows-nodejs
         timeout-minutes: 10
-        with:
-          node-version-file: .nvmrc
-          cache: pnpm
 
       - name: Install dependencies
         timeout-minutes: 15

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,17 +221,10 @@ jobs:
           ref: ${{ github.event.inputs.tag || github.ref }}
           persist-credentials: false
 
-      # pwrdrvr/configure-nodejs is POSIX-only, so set up Node + pnpm directly.
-      # Git-for-Windows (bash.exe, used by the agent's shell tools) is
-      # preinstalled on windows-latest runners.
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: .nvmrc
-          cache: pnpm
+      # pwrdrvr/configure-nodejs is POSIX-only, so use a Windows-specific
+      # setup action that activates the repo-pinned pnpm through Corepack.
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/configure-windows-nodejs
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
Windows CI no longer pays the `pnpm/action-setup` self-installer cost before dependency installation. The Windows build/test and installer jobs now activate the repo-pinned pnpm version through Corepack, then restore a pnpm-store cache keyed by OS, architecture, pnpm version, and the lockfile.

This keeps `pnpm install --frozen-lockfile` on the same pinned package manager while removing the setup path that spent 69 seconds in the observed run before the actual install started.

## Validation
- Parsed `.github/workflows/ci.yml`, `.github/workflows/release.yml`, and `.github/actions/configure-windows-nodejs/action.yml` with Ruby YAML.
- Ran `git diff --check` on the changed workflow/action files.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
