### PR TITLE
feat(desktop): add PwrAgent agent management and handoff tools

### DIFF
--- a/apps/desktop/src/main/__tests__/automation-inspection-codex-tools.test.ts
+++ b/apps/desktop/src/main/__tests__/automation-inspection-codex-tools.test.ts
@@ -10,13 +10,13 @@ describe("automation inspection Codex dynamic tools", () => {
     expect(buildAutomationInspectionDynamicToolSpecs()).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          namespace: "pwragent_automations",
+          namespace: "pwragent",
           name: "list_automations",
           inputSchema: expect.objectContaining({ type: "object" }),
           deferLoading: false,
         }),
         expect.objectContaining({
-          namespace: "pwragent_automations",
+          namespace: "pwragent",
           name: "get_automation_run_artifact",
           inputSchema: expect.objectContaining({ type: "object" }),
           deferLoading: false,

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -114,6 +114,21 @@ function expectedDir(p: string): string {
   return path.resolve(p).replace(/\\/g, "/");
 }
 
+function createAgentOverlay(threadId = "agent-thread"): ThreadOverlayState {
+  return {
+    backend: "codex",
+    threadId,
+    executionMode: "default",
+    extraLinkedDirectories: [],
+    agent: {
+      name: "Parent Agent",
+      instructionLineCount: 0,
+      instructionsTooLong: false,
+      updatedAt: 1_000,
+    },
+  };
+}
+
 async function flushAsync(): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 0));
 }
@@ -1728,7 +1743,7 @@ describe("DesktopBackendRegistry", () => {
       grokClient: new MockBackendClient({
         initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
       }),
-      overlayStore: createOverlayStoreMock(),
+      overlayStore,
     });
 
     const response = await registry.listBackends({ includeUnavailable: true });
@@ -5247,7 +5262,7 @@ script = "echo setup"
     await registry.close();
   });
 
-  it("passes task monitor tools but not Agent tools when starting ordinary Codex threads", async () => {
+  it("advertises PwrAgent dynamic tools when starting ordinary Codex threads", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: {
         serverInfo: { name: "Codex App Server", version: "1.0.0" },
@@ -5268,12 +5283,37 @@ script = "echo setup"
     const dynamicTools = codexClient.lastStartThreadParams?.dynamicTools as
       | Array<{ namespace: string; name: string }>
       | undefined;
-    expect(dynamicTools).toEqual([
-      expect.objectContaining({
-        namespace: "pwragent",
-        name: "create_monitor_delegation",
-      }),
-    ]);
+    expect(dynamicTools).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          namespace: "pwragent",
+          name: "list_automations",
+        }),
+        expect.objectContaining({
+          namespace: "pwragent",
+          name: "manage_pwragent",
+        }),
+        expect.objectContaining({
+          namespace: "pwragent",
+          name: "search_threads",
+        }),
+        expect.objectContaining({
+          namespace: "pwragent",
+          name: "get_current_messaging_surface",
+        }),
+        expect.objectContaining({
+          namespace: "pwragent",
+          name: "handoff_task",
+        }),
+        expect.objectContaining({
+          namespace: "pwragent",
+          name: "create_monitor_delegation",
+        }),
+      ]),
+    );
+    expect(new Set(dynamicTools?.map((tool) => tool.namespace))).toEqual(
+      new Set(["pwragent"]),
+    );
 
     await registry.close();
   });
@@ -5378,7 +5418,7 @@ script = "echo setup"
     await registry.close();
   });
 
-  it("passes task monitor parent tools when continuing existing Codex threads", async () => {
+  it("advertises PwrAgent dynamic tools when continuing existing Codex threads", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: {
         serverInfo: { name: "Codex App Server", version: "1.0.0" },
@@ -5401,12 +5441,32 @@ script = "echo setup"
     });
 
     expect(codexClient.lastStartTurnParams?.dynamicTools).toEqual(
-      [
+      expect.arrayContaining([
+        expect.objectContaining({
+          namespace: "pwragent",
+          name: "list_automations",
+        }),
+        expect.objectContaining({
+          namespace: "pwragent",
+          name: "manage_pwragent",
+        }),
+        expect.objectContaining({
+          namespace: "pwragent",
+          name: "search_threads",
+        }),
+        expect.objectContaining({
+          namespace: "pwragent",
+          name: "get_current_messaging_surface",
+        }),
+        expect.objectContaining({
+          namespace: "pwragent",
+          name: "handoff_task",
+        }),
         expect.objectContaining({
           namespace: "pwragent",
           name: "create_monitor_delegation",
         }),
-      ],
+      ]),
     );
     expect(
       (codexClient.lastStartTurnParams?.dynamicTools as Array<{
@@ -7529,12 +7589,12 @@ script = "pnpm install"
       fastMode: undefined,
       approvalPolicy: "on-request",
       sandbox: "workspace-write",
-      dynamicTools: [
+      dynamicTools: expect.arrayContaining([
         expect.objectContaining({
           namespace: "pwragent",
           name: "create_monitor_delegation",
         }),
-      ],
+      ]),
     });
 
     await registry.close();
@@ -13179,7 +13239,11 @@ command = "pnpm dev"
       grokClient: new MockBackendClient({
         initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
       }),
-      overlayStore: createOverlayStoreMock(),
+      overlayStore: createOverlayStoreMock({
+        overlays: {
+          "codex:thread-1": createAgentOverlay("thread-1"),
+        },
+      }),
     });
     const events: AgentEvent[] = [];
     const unsubscribe = registry.onEvent((event) => {
@@ -13297,6 +13361,7 @@ command = "pnpm dev"
       }),
       overlayStore: createOverlayStoreMock({
         overlays: {
+          "codex:agent-thread": createAgentOverlay(),
           "codex:thread-1": {
             backend: "codex",
             threadId: "thread-1",
@@ -13418,7 +13483,11 @@ command = "pnpm dev"
       grokClient: new MockBackendClient({
         initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
       }),
-      overlayStore: createOverlayStoreMock(),
+      overlayStore: createOverlayStoreMock({
+        overlays: {
+          "codex:agent-thread": createAgentOverlay(),
+        },
+      }),
     });
     await registry.publishLocalEvent({
       backend: "codex",
@@ -13830,7 +13899,11 @@ command = "pnpm dev"
           },
         ],
       }),
-      overlayStore: createOverlayStoreMock(),
+      overlayStore: createOverlayStoreMock({
+        overlays: {
+          "codex:agent-thread": createAgentOverlay(),
+        },
+      }),
       threadSearchService: { search } as unknown as ThreadSearchService,
     });
     await registry.publishLocalEvent({
@@ -13966,7 +14039,11 @@ command = "pnpm dev"
       grokClient: new MockBackendClient({
         initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
       }),
-      overlayStore: createOverlayStoreMock(),
+      overlayStore: createOverlayStoreMock({
+        overlays: {
+          "codex:agent-thread": createAgentOverlay(),
+        },
+      }),
     });
     await registry.publishLocalEvent({
       backend: "codex",
@@ -14053,7 +14130,11 @@ command = "pnpm dev"
       grokClient: new MockBackendClient({
         initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
       }),
-      overlayStore: createOverlayStoreMock(),
+      overlayStore: createOverlayStoreMock({
+        overlays: {
+          "codex:agent-thread": createAgentOverlay(),
+        },
+      }),
     });
     await registry.publishLocalEvent({
       backend: "codex",
@@ -14147,7 +14228,11 @@ command = "pnpm dev"
           },
         ],
       }),
-      overlayStore: createOverlayStoreMock(),
+      overlayStore: createOverlayStoreMock({
+        overlays: {
+          "codex:agent-thread": createAgentOverlay(),
+        },
+      }),
     });
     await registry.publishLocalEvent({
       backend: "codex",
@@ -14212,6 +14297,7 @@ command = "pnpm dev"
     });
     const overlayStore = createOverlayStoreMock({
       overlays: {
+        "codex:agent-thread": createAgentOverlay(),
         "codex:target-thread": {
           backend: "codex",
           threadId: "target-thread",
@@ -14318,6 +14404,7 @@ command = "pnpm dev"
     });
     const overlayStore = createOverlayStoreMock({
       overlays: {
+        "codex:agent-thread": createAgentOverlay(),
         "codex:target-thread": {
           backend: "codex",
           threadId: "target-thread",
@@ -14405,6 +14492,7 @@ command = "pnpm dev"
     });
     const overlayStore = createOverlayStoreMock({
       overlays: {
+        "codex:agent-thread": createAgentOverlay(),
         "codex:target-thread": {
           backend: "codex",
           threadId: "target-thread",
@@ -14540,6 +14628,87 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("rejects Agent-only PwrAgent tools from active ordinary threads", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+    });
+    const appManagementHandler = vi.fn(async () => ({
+      ok: true as const,
+      data: {
+        action: "status" as const,
+        runtime: {
+          currentVersion: "1.2.3",
+          startedAt: 1_000,
+          startedAtIso: "1970-01-01T00:00:01.000Z",
+          startedAtLocal: "Jan 1, 1970, 12:00:01 AM",
+          now: 61_000,
+          nowIso: "1970-01-01T00:01:01.000Z",
+          nowLocal: "Jan 1, 1970, 12:01:01 AM",
+          uptimeMs: 60_000,
+          uptimeHuman: "1m 0s",
+        },
+        update: {
+          status: { status: "idle" as const },
+          updateAvailableToDownload: false,
+          updateDownloadedWillInstallOnRestart: false,
+        },
+        result: { status: "reported" as const },
+      },
+    }));
+    registry.setPwrAgentAppManagementHandler(appManagementHandler);
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "ordinary-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "ordinary-thread",
+        turnId: "turn-1",
+        callId: "call-1",
+        requestId: "call-1",
+        namespace: "pwragent",
+        tool: "manage_pwragent",
+        arguments: { action: "status" },
+      },
+    } as AppServerPendingRequestNotification);
+
+    expect(response).toEqual({
+      success: false,
+      contentItems: [
+        {
+          type: "inputText",
+          text: JSON.stringify(
+            {
+              code: "forbidden",
+              message: "App management tools are available only to Agent threads.",
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    });
+    expect(appManagementHandler).not.toHaveBeenCalled();
+
+    await registry.close();
+  });
+
   it("rejects thread handoff dynamic tool calls that do not match an active Agent turn", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start"] },
@@ -14623,7 +14792,11 @@ command = "pnpm dev"
       grokClient: new MockBackendClient({
         initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
       }),
-      overlayStore: createOverlayStoreMock(),
+      overlayStore: createOverlayStoreMock({
+        overlays: {
+          "codex:thread-1": createAgentOverlay("thread-1"),
+        },
+      }),
     });
     const events: AgentEvent[] = [];
     const unsubscribe = registry.onEvent((event) => {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -5299,11 +5299,19 @@ script = "echo setup"
         }),
         expect.objectContaining({
           namespace: "pwragent",
+          name: "read_thread",
+        }),
+        expect.objectContaining({
+          namespace: "pwragent",
           name: "get_current_messaging_surface",
         }),
         expect.objectContaining({
           namespace: "pwragent",
           name: "handoff_task",
+        }),
+        expect.objectContaining({
+          namespace: "pwragent",
+          name: "send_message_to_thread",
         }),
         expect.objectContaining({
           namespace: "pwragent",
@@ -5367,6 +5375,10 @@ script = "echo setup"
         }),
         expect.objectContaining({
           namespace: "pwragent",
+          name: "read_thread",
+        }),
+        expect.objectContaining({
+          namespace: "pwragent",
           name: "get_thread_status",
         }),
         expect.objectContaining({
@@ -5384,6 +5396,10 @@ script = "echo setup"
         expect.objectContaining({
           namespace: "pwragent",
           name: "handoff_task",
+        }),
+        expect.objectContaining({
+          namespace: "pwragent",
+          name: "send_message_to_thread",
         }),
       ]),
     );
@@ -5456,11 +5472,19 @@ script = "echo setup"
         }),
         expect.objectContaining({
           namespace: "pwragent",
+          name: "read_thread",
+        }),
+        expect.objectContaining({
+          namespace: "pwragent",
           name: "get_current_messaging_surface",
         }),
         expect.objectContaining({
           namespace: "pwragent",
           name: "handoff_task",
+        }),
+        expect.objectContaining({
+          namespace: "pwragent",
+          name: "send_message_to_thread",
         }),
         expect.objectContaining({
           namespace: "pwragent",
@@ -13814,6 +13838,149 @@ command = "pnpm dev"
     await rm(root, { recursive: true, force: true });
   });
 
+  it("sends a follow-up prompt to another thread from an active turn", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: null,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "parent-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "parent-thread",
+        turnId: "turn-1",
+        callId: "call-1",
+        requestId: "call-1",
+        namespace: "pwragent",
+        tool: "send_message_to_thread",
+        arguments: {
+          backend: "codex",
+          threadId: "target-thread",
+          prompt: "Please pick up the CI failure.",
+          model: "gpt-5.5",
+          reasoningEffort: "high",
+          serviceTier: "priority",
+          fastMode: true,
+          executionMode: "full-access",
+          approvalPolicy: "never",
+          sandbox: "danger-full-access",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    expect(response).toMatchObject({ success: true });
+    const payload = JSON.parse(
+      (response as { contentItems: Array<{ text: string }> }).contentItems[0]!.text,
+    );
+    expect(payload).toEqual({
+      backend: "codex",
+      threadId: "target-thread",
+      turnId: "turn-1",
+      promptPreview: "Please pick up the CI failure.",
+      settings: {
+        executionMode: "full-access",
+        model: "gpt-5.5",
+        reasoningEffort: "high",
+        serviceTier: "priority",
+        fastMode: true,
+        approvalPolicy: "never",
+        sandbox: "danger-full-access",
+      },
+    });
+    expect(codexClient.lastStartTurnParams).toMatchObject({
+      threadId: "target-thread",
+      input: [{ type: "text", text: "Please pick up the CI failure." }],
+      model: "gpt-5.5",
+      reasoningEffort: "high",
+      serviceTier: "priority",
+      fastMode: true,
+      approvalPolicy: "never",
+      sandbox: "danger-full-access",
+    });
+
+    await registry.close();
+  });
+
+  it("rejects sending a follow-up prompt to the invoking thread", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "parent-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "parent-thread",
+        turnId: "turn-1",
+        callId: "call-1",
+        requestId: "call-1",
+        namespace: "pwragent",
+        tool: "send_message_to_thread",
+        arguments: {
+          backend: "codex",
+          threadId: "parent-thread",
+          prompt: "Loop back into myself.",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    expect(response).toEqual({
+      success: false,
+      contentItems: [
+        {
+          type: "inputText",
+          text: JSON.stringify(
+            {
+              code: "forbidden",
+              message:
+                "send_message_to_thread targets another thread. Continue the current thread by replying normally.",
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    });
+    expect(codexClient.lastStartTurnParams).toBeUndefined();
+
+    await registry.close();
+  });
+
   it("routes thread inspection search through the thread search service when available", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/list"] },
@@ -14281,6 +14448,148 @@ command = "pnpm dev"
       codexClient.listThreadsCalls
         .map((call) => call.params?.archived)
     ).toEqual([false]);
+
+    await registry.close();
+  });
+
+  it("reads bounded transcript content from another thread", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/read"] },
+      replay: {
+        entries: [
+          {
+            type: "message",
+            id: "entry-user-1",
+            role: "user",
+            text: "Please inspect this thread.",
+            createdAt: 1000,
+          },
+          {
+            type: "activity",
+            id: "entry-command-1",
+            summary: "Ran command",
+            status: "completed",
+            details: [
+              {
+                id: "detail-1",
+                kind: "command",
+                label: "pnpm test",
+                status: "completed",
+                command: {
+                  displayCommand: "pnpm test",
+                  output: `${"line ".repeat(1000)}done`,
+                  exitCode: 0,
+                },
+              },
+            ],
+          },
+        ],
+        messages: [
+          {
+            id: "message-user-1",
+            role: "user",
+            text: "Please inspect this thread.",
+            createdAt: 1000,
+          },
+        ],
+        lastUserMessage: "Please inspect this thread.",
+        pagination: {
+          supportsPagination: true,
+          hasPreviousPage: true,
+          previousCursor: "cursor-1",
+        },
+        threadStatus: "idle",
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "agent-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "agent-thread",
+        turnId: "turn-1",
+        callId: "call-1",
+        requestId: "call-1",
+        namespace: "pwragent",
+        tool: "read_thread",
+        arguments: {
+          backend: "codex",
+          threadId: "target-thread",
+          limit: 5,
+          maxCharsPerEntry: 200,
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    expect(response).toMatchObject({ success: true });
+    const payload = JSON.parse(
+      (response as { contentItems: Array<{ text: string }> }).contentItems[0]!.text,
+    );
+    expect(payload).toMatchObject({
+      read: {
+        backend: "codex",
+        threadId: "target-thread",
+        limit: 5,
+        maxCharsPerEntry: 200,
+        status: "idle",
+        pagination: {
+          supportsPagination: true,
+          hasPreviousPage: true,
+          previousCursor: "cursor-1",
+        },
+        entries: [
+          {
+            type: "message",
+            id: "entry-user-1",
+            role: "user",
+            text: "Please inspect this thread.",
+          },
+          {
+            type: "activity",
+            id: "entry-command-1",
+            details: [
+              {
+                kind: "command",
+                command: {
+                  displayCommand: "pnpm test",
+                  output: expect.stringContaining("..."),
+                },
+                truncated: true,
+              },
+            ],
+          },
+        ],
+        messages: [
+          {
+            id: "message-user-1",
+            role: "user",
+            text: "Please inspect this thread.",
+          },
+        ],
+      },
+    });
+    expect(codexClient.lastReadThreadParams).toEqual({
+      threadId: "target-thread",
+      includeTurns: true,
+      limit: 5,
+    });
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -5251,7 +5251,7 @@ script = "echo setup"
       | undefined;
     expect(dynamicTools).toEqual([
       expect.objectContaining({
-        namespace: "pwragent_task_monitors",
+        namespace: "pwragent",
         name: "create_monitor_delegation",
       }),
     ]);
@@ -5287,39 +5287,39 @@ script = "echo setup"
     expect(codexClient.lastStartThreadParams?.dynamicTools).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          namespace: "pwragent_automations",
+          namespace: "pwragent",
           name: "list_automations",
         }),
         expect.objectContaining({
-          namespace: "pwragent_automations",
+          namespace: "pwragent",
           name: "get_automation_run_artifact",
         }),
         expect.objectContaining({
-          namespace: "pwragent_task_monitors",
+          namespace: "pwragent",
           name: "create_monitor_delegation",
         }),
         expect.objectContaining({
-          namespace: "pwragent_app",
+          namespace: "pwragent",
           name: "manage_pwragent",
         }),
         expect.objectContaining({
-          namespace: "pwragent_threads",
+          namespace: "pwragent",
           name: "search_threads",
         }),
         expect.objectContaining({
-          namespace: "pwragent_threads",
+          namespace: "pwragent",
           name: "get_thread_status",
         }),
         expect.objectContaining({
-          namespace: "pwragent_threads",
+          namespace: "pwragent",
           name: "mutate_thread",
         }),
         expect.objectContaining({
-          namespace: "pwragent_messaging",
+          namespace: "pwragent",
           name: "get_current_messaging_surface",
         }),
         expect.objectContaining({
-          namespace: "pwragent_messaging",
+          namespace: "pwragent",
           name: "attach_thread_here",
         }),
       ]),
@@ -5331,20 +5331,14 @@ script = "echo setup"
         }>).map((tool) => tool.namespace),
       ),
     ).toEqual(
-      new Set([
-        "pwragent_automations",
-        "pwragent_app",
-        "pwragent_threads",
-        "pwragent_messaging",
-        "pwragent_task_monitors",
-      ]),
+      new Set(["pwragent"]),
     );
     expect(
       (codexClient.lastStartThreadParams?.dynamicTools as Array<{
         namespace: string;
         name: string;
       }> | undefined)
-        ?.filter((tool) => tool.namespace === "pwragent_task_monitors")
+        ?.filter((tool) => tool.name === "create_monitor_delegation")
         .map((tool) => tool.name),
     ).toEqual(["create_monitor_delegation"]);
     await expect(
@@ -5386,7 +5380,7 @@ script = "echo setup"
     expect(codexClient.lastStartTurnParams?.dynamicTools).toEqual(
       [
         expect.objectContaining({
-          namespace: "pwragent_task_monitors",
+          namespace: "pwragent",
           name: "create_monitor_delegation",
         }),
       ],
@@ -5396,7 +5390,7 @@ script = "echo setup"
         namespace: string;
         name: string;
       }> | undefined)
-        ?.filter((tool) => tool.namespace === "pwragent_task_monitors")
+        ?.filter((tool) => tool.name === "create_monitor_delegation")
         .map((tool) => tool.name),
     ).toEqual(["create_monitor_delegation"]);
 
@@ -5444,23 +5438,23 @@ script = "echo setup"
     expect(codexClient.lastStartTurnParams?.dynamicTools).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          namespace: "pwragent_automations",
+          namespace: "pwragent",
           name: "list_automations",
         }),
         expect.objectContaining({
-          namespace: "pwragent_threads",
+          namespace: "pwragent",
           name: "search_threads",
         }),
         expect.objectContaining({
-          namespace: "pwragent_app",
+          namespace: "pwragent",
           name: "manage_pwragent",
         }),
         expect.objectContaining({
-          namespace: "pwragent_messaging",
+          namespace: "pwragent",
           name: "attach_thread_here",
         }),
         expect.objectContaining({
-          namespace: "pwragent_task_monitors",
+          namespace: "pwragent",
           name: "create_monitor_delegation",
         }),
       ]),
@@ -7374,23 +7368,23 @@ script = "pnpm install"
     expect(codexClient.lastStartThreadParams?.dynamicTools).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          namespace: "pwragent_automations",
+          namespace: "pwragent",
           name: "list_automations",
         }),
         expect.objectContaining({
-          namespace: "pwragent_threads",
+          namespace: "pwragent",
           name: "search_threads",
         }),
         expect.objectContaining({
-          namespace: "pwragent_app",
+          namespace: "pwragent",
           name: "manage_pwragent",
         }),
         expect.objectContaining({
-          namespace: "pwragent_messaging",
+          namespace: "pwragent",
           name: "get_current_messaging_surface",
         }),
         expect.objectContaining({
-          namespace: "pwragent_messaging",
+          namespace: "pwragent",
           name: "attach_thread_here",
         }),
       ]),
@@ -7506,7 +7500,7 @@ script = "pnpm install"
       sandbox: "workspace-write",
       dynamicTools: [
         expect.objectContaining({
-          namespace: "pwragent_task_monitors",
+          namespace: "pwragent",
           name: "create_monitor_delegation",
         }),
       ],
@@ -13414,7 +13408,7 @@ command = "pnpm dev"
         turnId: "turn-1",
         callId: "call-1",
         requestId: "call-1",
-        namespace: "pwragent_app",
+        namespace: "pwragent",
         tool: "manage_pwragent",
         arguments: {
           action: "status",
@@ -15171,7 +15165,7 @@ command = "pnpm dev"
       codexClient.startTurnCalls[1]?.input[0]?.type === "text"
         ? codexClient.startTurnCalls[1].input[0].text
         : "",
-    ).toContain("pwragent_task_monitors.complete_monitoring");
+    ).toContain("pwragent.complete_monitoring");
     expect(
       codexClient.startTurnCalls[1]?.input[0]?.type === "text"
         ? codexClient.startTurnCalls[1].input[0].text
@@ -15375,7 +15369,7 @@ command = "pnpm dev"
       codexClient.startTurnCalls[1]?.input[0]?.type === "text"
         ? codexClient.startTurnCalls[1].input[0].text
         : "",
-    ).toContain("pwragent_task_monitors.complete_monitoring");
+    ).toContain("pwragent.complete_monitoring");
 
     await checkStaleTaskMonitors(Date.now() + 180_000);
 

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -13310,7 +13310,7 @@ command = "pnpm dev"
     await registry.close();
   });
 
-  it("handles thread inspection dynamic tool calls from active Agent turns", async () => {
+  it("handles thread inspection dynamic tool calls from active turns", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/list"] },
       threads: [
@@ -13450,7 +13450,7 @@ command = "pnpm dev"
     await registry.close();
   });
 
-  it("handles app management dynamic tool calls from active Agent turns", async () => {
+  it("handles app management dynamic tool calls from active turns", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start"] },
     });
@@ -13534,7 +13534,7 @@ command = "pnpm dev"
     await registry.close();
   });
 
-  it("handles thread handoff dynamic tool calls from active Agent turns", async () => {
+  it("handles thread handoff dynamic tool calls from active Codex turns", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-handoff-"));
     try {
       await git(root, ["init", "-b", "main"]);
@@ -13558,8 +13558,8 @@ command = "pnpm dev"
       initializeResult: { methods: ["thread/start", "thread/list", "turn/start"] },
       threads: [
         {
-          id: "agent-thread",
-          title: "Parent Agent",
+          id: "ordinary-thread",
+          title: "Parent Thread",
           titleSource: "explicit",
           source: "codex",
           linkedDirectories: [
@@ -13576,9 +13576,9 @@ command = "pnpm dev"
     });
     const overlayStore = createOverlayStoreMock({
       overlays: {
-        "codex:agent-thread": {
+        "codex:ordinary-thread": {
           backend: "codex",
-          threadId: "agent-thread",
+          threadId: "ordinary-thread",
           executionMode: "full-access",
           model: "gpt-5.4",
           reasoningEffort: "high",
@@ -13592,12 +13592,6 @@ command = "pnpm dev"
               path: expectedDir(root),
             },
           ],
-          agent: {
-            name: "Parent Agent",
-            instructionLineCount: 0,
-            instructionsTooLong: false,
-            updatedAt: 1000,
-          },
         },
       },
     });
@@ -13642,7 +13636,7 @@ command = "pnpm dev"
               binding: {
                 id: "binding-parent",
                 backend: "codex",
-                threadId: "agent-thread",
+                threadId: "ordinary-thread",
                 targetKind: "agent_thread",
               },
               channel: "discord",
@@ -13669,7 +13663,7 @@ command = "pnpm dev"
       notification: {
         method: "turn/started",
         params: {
-          threadId: "agent-thread",
+          threadId: "ordinary-thread",
           turnId: "turn-1",
           turn: { id: "turn-1" },
         },
@@ -13679,7 +13673,7 @@ command = "pnpm dev"
     const response = await codexClient.emitRequest({
       method: "item/tool/call",
       params: {
-        threadId: "agent-thread",
+        threadId: "ordinary-thread",
         turnId: "turn-1",
         callId: "call-1",
         requestId: "call-1",
@@ -13746,7 +13740,7 @@ command = "pnpm dev"
         operation: "attach_thread_here",
         context: {
           backend: "codex",
-          threadId: "agent-thread",
+          threadId: "ordinary-thread",
           turnId: "turn-1",
         },
         args: {
@@ -13786,7 +13780,7 @@ command = "pnpm dev"
         ? codexClient.lastStartTurnParams.input[0].text
         : "";
     expect(prompt).toContain("Task:\nInvestigate issue XYZ and report back.");
-    expect(prompt).toContain("- Thread ID: agent-thread");
+    expect(prompt).toContain("- Thread ID: ordinary-thread");
     expect(prompt).toContain("- Turn ID: turn-1");
     expect(prompt).toContain(`- CWD: ${normalizedRoot}`);
     expect(prompt).toContain("Additional context from parent:");
@@ -13802,9 +13796,9 @@ command = "pnpm dev"
       },
       handoffOrigin: {
         sourceBackend: "codex",
-        sourceThreadId: "agent-thread",
+        sourceThreadId: "ordinary-thread",
         sourceTurnId: "turn-1",
-        sourceTitle: "Parent Agent",
+        sourceTitle: "Parent Thread",
         taskTitle: "Investigate issue XYZ",
         seedMode: "clean",
         groupingMode: "none",
@@ -14291,7 +14285,7 @@ command = "pnpm dev"
     await registry.close();
   });
 
-  it("mutates PwrAgent thread settings from active Agent turns", async () => {
+  it("mutates PwrAgent thread settings from active turns", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/list"] },
     });
@@ -14628,7 +14622,7 @@ command = "pnpm dev"
     await registry.close();
   });
 
-  it("rejects Agent-only PwrAgent tools from active ordinary threads", async () => {
+  it("handles PwrAgent app management tools from active ordinary threads", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start"] },
     });
@@ -14688,28 +14682,25 @@ command = "pnpm dev"
       },
     } as AppServerPendingRequestNotification);
 
-    expect(response).toEqual({
-      success: false,
+    expect(response).toMatchObject({
+      success: true,
       contentItems: [
         {
           type: "inputText",
-          text: JSON.stringify(
-            {
-              code: "forbidden",
-              message: "App management tools are available only to Agent threads.",
-            },
-            null,
-            2,
-          ),
+          text: expect.stringContaining('"currentVersion": "1.2.3"'),
         },
       ],
     });
-    expect(appManagementHandler).not.toHaveBeenCalled();
+    expect(appManagementHandler).toHaveBeenCalledWith({
+      operation: "manage_pwragent",
+      context: {},
+      args: { action: "status" },
+    });
 
     await registry.close();
   });
 
-  it("rejects thread handoff dynamic tool calls that do not match an active Agent turn", async () => {
+  it("rejects thread handoff dynamic tool calls that do not match an active turn", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start"] },
     });
@@ -14718,22 +14709,7 @@ command = "pnpm dev"
       grokClient: new MockBackendClient({
         initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
       }),
-      overlayStore: createOverlayStoreMock({
-        overlays: {
-          "codex:agent-thread": {
-            backend: "codex",
-            threadId: "agent-thread",
-            executionMode: "default",
-            extraLinkedDirectories: [],
-            agent: {
-              name: "Parent Agent",
-              instructionLineCount: 0,
-              instructionsTooLong: false,
-              updatedAt: 1000,
-            },
-          },
-        },
-      }),
+      overlayStore: createOverlayStoreMock(),
     });
     await registry.publishLocalEvent({
       backend: "codex",
@@ -14770,7 +14746,7 @@ command = "pnpm dev"
             {
               code: "forbidden",
               message:
-                "Thread handoff tool calls must originate from an active Agent turn on the same thread.",
+                "Thread handoff tool calls must originate from an active turn on the same thread.",
             },
             null,
             2,

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -5322,6 +5322,10 @@ script = "echo setup"
           namespace: "pwragent",
           name: "attach_thread_here",
         }),
+        expect.objectContaining({
+          namespace: "pwragent",
+          name: "handoff_task",
+        }),
       ]),
     );
     expect(
@@ -5452,6 +5456,10 @@ script = "echo setup"
         expect.objectContaining({
           namespace: "pwragent",
           name: "attach_thread_here",
+        }),
+        expect.objectContaining({
+          namespace: "pwragent",
+          name: "handoff_task",
         }),
         expect.objectContaining({
           namespace: "pwragent",
@@ -7386,6 +7394,10 @@ script = "pnpm install"
         expect.objectContaining({
           namespace: "pwragent",
           name: "attach_thread_here",
+        }),
+        expect.objectContaining({
+          namespace: "pwragent",
+          name: "handoff_task",
         }),
       ]),
     );

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -13690,7 +13690,7 @@ command = "pnpm dev"
       },
     ]);
     expect(codexClient.lastStartThreadParams).toMatchObject({
-      cwd: root,
+      cwd: normalizedRoot,
       model: "gpt-5.4",
       reasoningEffort: "high",
       serviceTier: "priority",
@@ -13704,7 +13704,7 @@ command = "pnpm dev"
     });
     expect(codexClient.lastStartTurnParams).toMatchObject({
       threadId: "thread-1",
-      cwd: root,
+      cwd: normalizedRoot,
       model: "gpt-5.4",
       reasoningEffort: "high",
       serviceTier: "priority",

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -13331,7 +13331,7 @@ command = "pnpm dev"
         turnId: "turn-1",
         callId: "call-1",
         requestId: "call-1",
-        namespace: "pwragent_threads",
+        namespace: "pwragent",
         tool: "search_threads",
         arguments: {
           agentOnly: true,
@@ -13852,7 +13852,7 @@ command = "pnpm dev"
         turnId: "turn-1",
         callId: "call-1",
         requestId: "call-1",
-        namespace: "pwragent_threads",
+        namespace: "pwragent",
         tool: "search_threads",
         arguments: {
           query: "branch drift",
@@ -13987,7 +13987,7 @@ command = "pnpm dev"
         turnId: "turn-1",
         callId: "call-1",
         requestId: "call-1",
-        namespace: "pwragent_threads",
+        namespace: "pwragent",
         tool: "search_threads",
         arguments: {},
       },
@@ -14074,7 +14074,7 @@ command = "pnpm dev"
         turnId: "turn-1",
         callId: "call-1",
         requestId: "call-1",
-        namespace: "pwragent_threads",
+        namespace: "pwragent",
         tool: "search_threads",
         arguments: {
           query: "telegram naming OR playwright e2e OR desktop failures",
@@ -14168,7 +14168,7 @@ command = "pnpm dev"
         turnId: "turn-1",
         callId: "call-1",
         requestId: "call-1",
-        namespace: "pwragent_threads",
+        namespace: "pwragent",
         tool: "get_thread_status",
         arguments: {
           backend: "codex",
@@ -14246,7 +14246,7 @@ command = "pnpm dev"
         turnId: "turn-1",
         callId: "call-1",
         requestId: "call-1",
-        namespace: "pwragent_threads",
+        namespace: "pwragent",
         tool: "mutate_thread",
         arguments: {
           backend: "codex",
@@ -14352,7 +14352,7 @@ command = "pnpm dev"
         turnId: "turn-1",
         callId: "call-1",
         requestId: "call-1",
-        namespace: "pwragent_threads",
+        namespace: "pwragent",
         tool: "mutate_thread",
         arguments: {
           backend: "codex",
@@ -14439,7 +14439,7 @@ command = "pnpm dev"
         turnId: "turn-1",
         callId: "call-1",
         requestId: "call-1",
-        namespace: "pwragent_threads",
+        namespace: "pwragent",
         tool: "mutate_thread",
         arguments: {
           backend: "codex",

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -13629,6 +13629,7 @@ command = "pnpm dev"
     const payload = JSON.parse(
       (response as { contentItems: Array<{ text: string }> }).contentItems[0]!.text,
     );
+    const normalizedRoot = expectedDir(root);
     expect(payload).toMatchObject({
       backend: "codex",
       threadId: "thread-1",
@@ -13648,7 +13649,7 @@ command = "pnpm dev"
       },
       workspace: {
         mode: "same",
-        cwd: root,
+        cwd: normalizedRoot,
         branch: "main",
         git: {
           kind: "git_local",
@@ -13718,7 +13719,7 @@ command = "pnpm dev"
     expect(prompt).toContain("Task:\nInvestigate issue XYZ and report back.");
     expect(prompt).toContain("- Thread ID: agent-thread");
     expect(prompt).toContain("- Turn ID: turn-1");
-    expect(prompt).toContain("- CWD: ");
+    expect(prompt).toContain(`- CWD: ${normalizedRoot}`);
     expect(prompt).toContain("Additional context from parent:");
     expect(prompt).toContain("Parent already checked the latest CI run.");
     await expect(
@@ -13740,7 +13741,7 @@ command = "pnpm dev"
         groupingMode: "none",
         workspace: {
           mode: "same",
-          cwd: root,
+          cwd: normalizedRoot,
           branch: "main",
         },
       },

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -5299,6 +5299,10 @@ script = "echo setup"
           name: "create_monitor_delegation",
         }),
         expect.objectContaining({
+          namespace: "pwragent_app",
+          name: "manage_pwragent",
+        }),
+        expect.objectContaining({
           namespace: "pwragent_threads",
           name: "search_threads",
         }),
@@ -5329,6 +5333,7 @@ script = "echo setup"
     ).toEqual(
       new Set([
         "pwragent_automations",
+        "pwragent_app",
         "pwragent_threads",
         "pwragent_messaging",
         "pwragent_task_monitors",
@@ -5445,6 +5450,10 @@ script = "echo setup"
         expect.objectContaining({
           namespace: "pwragent_threads",
           name: "search_threads",
+        }),
+        expect.objectContaining({
+          namespace: "pwragent_app",
+          name: "manage_pwragent",
         }),
         expect.objectContaining({
           namespace: "pwragent_messaging",
@@ -7371,6 +7380,10 @@ script = "pnpm install"
         expect.objectContaining({
           namespace: "pwragent_threads",
           name: "search_threads",
+        }),
+        expect.objectContaining({
+          namespace: "pwragent_app",
+          name: "manage_pwragent",
         }),
         expect.objectContaining({
           namespace: "pwragent_messaging",
@@ -13342,6 +13355,86 @@ command = "pnpm dev"
     });
     expect(codexClient.lastListThreadsDiagnostics).toMatchObject({
       callerReason: "agent-thread-inspection",
+    });
+
+    await registry.close();
+  });
+
+  it("handles app management dynamic tool calls from active Agent turns", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+    });
+    const appManagementHandler = vi.fn(async () => ({
+      ok: true as const,
+      data: {
+        action: "status" as const,
+        runtime: {
+          currentVersion: "1.2.3",
+          startedAt: 1_000,
+          startedAtIso: "1970-01-01T00:00:01.000Z",
+          startedAtLocal: "Jan 1, 1970, 12:00:01 AM",
+          now: 61_000,
+          nowIso: "1970-01-01T00:01:01.000Z",
+          nowLocal: "Jan 1, 1970, 12:01:01 AM",
+          uptimeMs: 60_000,
+          uptimeHuman: "1m 0s",
+        },
+        update: {
+          status: { status: "idle" as const },
+          updateAvailableToDownload: false,
+          updateDownloadedWillInstallOnRestart: false,
+        },
+        result: { status: "reported" as const },
+      },
+    }));
+    const registry = new DesktopBackendRegistry({
+      appManagementHandler,
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "agent-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "agent-thread",
+        turnId: "turn-1",
+        callId: "call-1",
+        requestId: "call-1",
+        namespace: "pwragent_app",
+        tool: "manage_pwragent",
+        arguments: {
+          action: "status",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    expect(response).toMatchObject({
+      success: true,
+      contentItems: [
+        {
+          type: "inputText",
+          text: expect.stringContaining('"currentVersion": "1.2.3"'),
+        },
+      ],
+    });
+    expect(appManagementHandler).toHaveBeenCalledWith({
+      operation: "manage_pwragent",
+      context: {},
+      args: { action: "status" },
     });
 
     await registry.close();

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -429,6 +429,25 @@ function createOverlayStoreMock(params?: {
       overlays.set(key, next);
       return next;
     },
+    setThreadHandoffOrigin: async (settings: {
+      backend: "codex" | "grok";
+      threadId: string;
+      handoffOrigin: ThreadOverlayState["handoffOrigin"] | null;
+    }) => {
+      const key = `${settings.backend}:${settings.threadId}`;
+      const current = overlays.get(key) ?? {
+        backend: settings.backend,
+        threadId: settings.threadId,
+        executionMode: "default" as const,
+        extraLinkedDirectories: [],
+      };
+      const next = {
+        ...current,
+        handoffOrigin: settings.handoffOrigin ?? undefined,
+      } as ThreadOverlayState;
+      overlays.set(key, next);
+      return next;
+    },
     setThreadCodexEnvironmentRuntime: async (settings: {
       backend: "codex" | "grok";
       threadId: string;

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -13465,6 +13465,291 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("handles thread handoff dynamic tool calls from active Agent turns", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-handoff-"));
+    try {
+      await git(root, ["init", "-b", "main"]);
+    } catch {
+      await git(root, ["init"]);
+      await git(root, ["checkout", "-b", "main"]);
+    }
+    await writeFile(path.join(root, "README.md"), "handoff\n", "utf8");
+    await git(root, ["add", "README.md"]);
+    await git(root, [
+      "-c",
+      "user.name=PwrAgent Tests",
+      "-c",
+      "user.email=tests@pwragent.local",
+      "commit",
+      "-m",
+      "initial",
+    ]);
+
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/start", "thread/list", "turn/start"] },
+      threads: [
+        {
+          id: "agent-thread",
+          title: "Parent Agent",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [
+            {
+              id: expectedDir(root),
+              kind: "local",
+              label: "handoff",
+              path: expectedDir(root),
+            },
+          ],
+          updatedAt: 1000,
+        },
+      ],
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:agent-thread": {
+          backend: "codex",
+          threadId: "agent-thread",
+          executionMode: "full-access",
+          model: "gpt-5.4",
+          reasoningEffort: "high",
+          serviceTier: "priority",
+          fastMode: true,
+          extraLinkedDirectories: [
+            {
+              id: expectedDir(root),
+              kind: "local",
+              label: "handoff",
+              path: expectedDir(root),
+            },
+          ],
+          agent: {
+            name: "Parent Agent",
+            instructionLineCount: 0,
+            instructionsTooLong: false,
+            updatedAt: 1000,
+          },
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+      threadTitleGenerationService: null,
+    });
+    const messagingRequests: unknown[] = [];
+    registry.setMessagingAgentToolService({
+      async handlePwrAgentMessagingRequest(request) {
+        messagingRequests.push(request);
+        return {
+          ok: true,
+          data: {
+            binding: {
+              id: "binding-child",
+              backend: "codex",
+              threadId: "thread-1",
+              targetKind: "agent_thread",
+              displayName: "Investigate issue XYZ",
+            },
+            channel: "discord",
+            conversation: {
+              id: "thread-123",
+              kind: "thread",
+              title: "Investigate issue XYZ",
+              parentId: "channel-1",
+              parentTitle: "ops",
+            },
+            createdConversation: {
+              id: "thread-123",
+              kind: "thread",
+              title: "Investigate issue XYZ",
+              parentId: "channel-1",
+              parentTitle: "ops",
+            },
+            location: {
+              binding: {
+                id: "binding-parent",
+                backend: "codex",
+                threadId: "agent-thread",
+                targetKind: "agent_thread",
+              },
+              channel: "discord",
+              conversation: {
+                id: "channel-1",
+                kind: "channel",
+                title: "ops",
+              },
+              managedConversation: {
+                canCreateChild: true,
+                operations: [],
+                outcome: "ok",
+                providerSupportsCreation: true,
+              },
+            },
+            outcome: "created_and_attached",
+            placement: "new_child",
+          },
+        };
+      },
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "agent-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "agent-thread",
+        turnId: "turn-1",
+        callId: "call-1",
+        requestId: "call-1",
+        namespace: "pwragent",
+        tool: "handoff_task",
+        arguments: {
+          task: "Investigate issue XYZ and report back.",
+          title: "Investigate issue XYZ",
+          context: "Parent already checked the latest CI run.",
+          messagingAttachment: "new_child",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    expect(response).toMatchObject({ success: true });
+    const payload = JSON.parse(
+      (response as { contentItems: Array<{ text: string }> }).contentItems[0]!.text,
+    );
+    expect(payload).toMatchObject({
+      backend: "codex",
+      threadId: "thread-1",
+      turnId: "turn-1",
+      title: "Investigate issue XYZ",
+      seedMode: "clean",
+      groupingMode: "none",
+      inheritedSettings: {
+        backend: "codex",
+        executionMode: "full-access",
+        model: "gpt-5.4",
+        reasoningEffort: "high",
+        serviceTier: "priority",
+        fastMode: true,
+        approvalPolicy: "never",
+        sandbox: "danger-full-access",
+      },
+      workspace: {
+        mode: "same",
+        cwd: root,
+        branch: "main",
+        git: {
+          kind: "git_local",
+          worktreeCreationAvailable: true,
+        },
+      },
+      messagingAttachment: {
+        requested: true,
+        outcome: "created_and_attached",
+        channel: "discord",
+        conversation: {
+          id: "thread-123",
+          kind: "thread",
+          title: "Investigate issue XYZ",
+        },
+        createdConversation: {
+          id: "thread-123",
+          kind: "thread",
+          title: "Investigate issue XYZ",
+        },
+      },
+    });
+    expect(messagingRequests).toEqual([
+      {
+        operation: "attach_thread_here",
+        context: {
+          backend: "codex",
+          threadId: "agent-thread",
+          turnId: "turn-1",
+        },
+        args: {
+          backend: "codex",
+          threadId: "thread-1",
+          placement: "new_child",
+          targetKind: "agent_thread",
+          title: "Investigate issue XYZ",
+        },
+      },
+    ]);
+    expect(codexClient.lastStartThreadParams).toMatchObject({
+      cwd: root,
+      model: "gpt-5.4",
+      reasoningEffort: "high",
+      serviceTier: "priority",
+      fastMode: true,
+      approvalPolicy: "never",
+      sandbox: "danger-full-access",
+    });
+    expect(codexClient.lastRenameThreadParams).toEqual({
+      threadId: "thread-1",
+      name: "Investigate issue XYZ",
+    });
+    expect(codexClient.lastStartTurnParams).toMatchObject({
+      threadId: "thread-1",
+      cwd: root,
+      model: "gpt-5.4",
+      reasoningEffort: "high",
+      serviceTier: "priority",
+      fastMode: true,
+      approvalPolicy: "never",
+      sandbox: "danger-full-access",
+    });
+    const prompt =
+      codexClient.lastStartTurnParams?.input[0]?.type === "text"
+        ? codexClient.lastStartTurnParams.input[0].text
+        : "";
+    expect(prompt).toContain("Task:\nInvestigate issue XYZ and report back.");
+    expect(prompt).toContain("- Thread ID: agent-thread");
+    expect(prompt).toContain("- Turn ID: turn-1");
+    expect(prompt).toContain("- CWD: ");
+    expect(prompt).toContain("Additional context from parent:");
+    expect(prompt).toContain("Parent already checked the latest CI run.");
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-1",
+      }),
+    ).resolves.toMatchObject({
+      agent: {
+        name: "Investigate issue XYZ",
+      },
+      handoffOrigin: {
+        sourceBackend: "codex",
+        sourceThreadId: "agent-thread",
+        sourceTurnId: "turn-1",
+        sourceTitle: "Parent Agent",
+        taskTitle: "Investigate issue XYZ",
+        seedMode: "clean",
+        groupingMode: "none",
+        workspace: {
+          mode: "same",
+          cwd: root,
+          branch: "main",
+        },
+      },
+    });
+
+    await registry.close();
+    await rm(root, { recursive: true, force: true });
+  });
+
   it("routes thread inspection search through the thread search service when available", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/list"] },
@@ -14250,6 +14535,80 @@ command = "pnpm dev"
       ],
     });
     expect(handler).not.toHaveBeenCalled();
+
+    await registry.close();
+  });
+
+  it("rejects thread handoff dynamic tool calls that do not match an active Agent turn", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock({
+        overlays: {
+          "codex:agent-thread": {
+            backend: "codex",
+            threadId: "agent-thread",
+            executionMode: "default",
+            extraLinkedDirectories: [],
+            agent: {
+              name: "Parent Agent",
+              instructionLineCount: 0,
+              instructionsTooLong: false,
+              updatedAt: 1000,
+            },
+          },
+        },
+      }),
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "other-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "agent-thread",
+        turnId: "turn-1",
+        callId: "call-1",
+        requestId: "call-1",
+        namespace: "pwragent",
+        tool: "handoff_task",
+        arguments: {
+          task: "Investigate issue XYZ.",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    expect(response).toEqual({
+      success: false,
+      contentItems: [
+        {
+          type: "inputText",
+          text: JSON.stringify(
+            {
+              code: "forbidden",
+              message:
+                "Thread handoff tool calls must originate from an active Agent turn on the same thread.",
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    });
+    expect(codexClient.lastStartThreadParams).toBeUndefined();
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -6345,7 +6345,7 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
-  it("passes dynamic tool specs when resuming an existing thread before a turn", async () => {
+  it("passes dynamic tool specs when resuming and starting a turn on an existing thread", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
 
     const client = new CodexAppServerClient({
@@ -6375,8 +6375,26 @@ describe("CodexAppServerClient", () => {
     const resumePayload = transport!.sentMessages
       .map((message) => JSON.parse(message) as { method?: string; params?: unknown })
       .find((payload) => payload.method === "thread/resume");
+    const turnStartPayload = transport!.sentMessages
+      .map((message) => JSON.parse(message) as { method?: string; params?: unknown })
+      .find((payload) => payload.method === "turn/start");
 
     expect(resumePayload?.params).toMatchObject({
+      threadId: "thread-2",
+      dynamicTools: [
+        {
+          namespace: "pwragent_task_monitors",
+          name: "create_monitor_delegation",
+          description: "Delegate monitoring work.",
+          inputSchema: {
+            type: "object",
+            additionalProperties: false,
+          },
+          deferLoading: false,
+        },
+      ],
+    });
+    expect(turnStartPayload?.params).toMatchObject({
       threadId: "thread-2",
       dynamicTools: [
         {

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -80,6 +80,7 @@ const getExistingRuntimeMessagingLeaseCoordinatorMock = vi.fn();
 const requestBindingRevokeAllForThreadMock = vi.fn();
 const setMessagingArchiveCleanerMock = vi.fn();
 const setMessagingAgentToolServiceMock = vi.fn();
+const setPwrAgentAppManagementHandlerMock = vi.fn();
 const listThreadsMock = vi.fn<(request?: unknown) => Promise<unknown[]>>();
 const disposeDesktopMessagingRuntimeMock = vi.fn();
 const registerMessagingStatusIpcHandlersMock = vi.fn();
@@ -348,6 +349,7 @@ vi.mock("../app-server/backend-registry", () => ({
   getDesktopBackendRegistry: vi.fn(() => ({
     listThreads: listThreadsMock,
     setMessagingAgentToolService: setMessagingAgentToolServiceMock,
+    setPwrAgentAppManagementHandler: setPwrAgentAppManagementHandlerMock,
     setMessagingArchiveCleaner: setMessagingArchiveCleanerMock,
   })),
 }));
@@ -484,6 +486,7 @@ describe("bootstrapApp", () => {
     requestBindingRevokeAllForThreadMock.mockReset();
     setMessagingArchiveCleanerMock.mockReset();
     setMessagingAgentToolServiceMock.mockReset();
+    setPwrAgentAppManagementHandlerMock.mockReset();
     listThreadsMock.mockReset();
     listThreadsMock.mockResolvedValue([]);
     disposeDesktopMessagingRuntimeMock.mockReset();

--- a/apps/desktop/src/main/__tests__/overlay-store-agent.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-agent.test.ts
@@ -1,7 +1,10 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { AGENT_PERSONA_INSTRUCTIONS_LINE_GUIDANCE } from "@pwragent/shared";
+import {
+  AGENT_PERSONA_INSTRUCTIONS_LINE_GUIDANCE,
+  type ThreadHandoffOrigin,
+} from "@pwragent/shared";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { SqliteOverlayStore } from "../state/overlay-store-sqlite";
 import { StateDb } from "../state/state-db";
@@ -107,5 +110,43 @@ describe("SqliteOverlayStore - thread Agent metadata", () => {
         },
       }),
     ).rejects.toThrow("Agent thread name is required.");
+  });
+
+  it("persists handoff origin metadata across sqlite handles", async () => {
+    const handoffOrigin: ThreadHandoffOrigin = {
+      sourceBackend: "codex",
+      sourceThreadId: "parent-thread",
+      sourceTurnId: "turn-1",
+      seedMode: "clean",
+      groupingMode: "none",
+      createdAt: 1_773_000_000_000,
+      workspace: {
+        mode: "same",
+        path: "/tmp/project",
+        git: {
+          kind: "repo",
+          rootPath: "/tmp/project",
+          branch: "main",
+          worktreeCreationAvailable: true,
+        },
+      },
+    };
+
+    await store.setThreadHandoffOrigin({
+      backend: "codex",
+      threadId: "child-thread",
+      handoffOrigin,
+    });
+    stateDb.close();
+
+    const reopenedDb = StateDb.open(path.join(tempDir, "state.db"));
+    const reopenedStore = new SqliteOverlayStore(reopenedDb);
+    await expect(
+      reopenedStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "child-thread",
+      }),
+    ).resolves.toMatchObject({ handoffOrigin });
+    reopenedDb.close();
   });
 });

--- a/apps/desktop/src/main/__tests__/overlay-store-agent.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-agent.test.ts
@@ -122,11 +122,9 @@ describe("SqliteOverlayStore - thread Agent metadata", () => {
       createdAt: 1_773_000_000_000,
       workspace: {
         mode: "same",
-        path: "/tmp/project",
+        cwd: "/tmp/project",
         git: {
-          kind: "repo",
-          rootPath: "/tmp/project",
-          branch: "main",
+          kind: "git_local",
           worktreeCreationAvailable: true,
         },
       },

--- a/apps/desktop/src/main/__tests__/pwragent-agent-tool-legacy-namespaces.test.ts
+++ b/apps/desktop/src/main/__tests__/pwragent-agent-tool-legacy-namespaces.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { handlePwrAgentMessagingDynamicToolCall } from "../agent-tools/pwragent-messaging-codex-tools";
+import { handlePwrAgentThreadDynamicToolCall } from "../agent-tools/pwragent-thread-codex-tools";
+
+describe("PwrAgent legacy agent tool namespaces", () => {
+  it("routes pwragent_threads calls through the unified thread handler", async () => {
+    const handler = vi.fn(async () => ({
+      ok: true as const,
+      data: {
+        threads: [],
+        totalCount: 0,
+        limit: 5,
+        truncated: false,
+      },
+    }));
+
+    await expect(
+      handlePwrAgentThreadDynamicToolCall({
+        backend: "codex",
+        handler,
+        call: {
+          threadId: "agent-thread",
+          turnId: "turn-1",
+          callId: "call-1",
+          namespace: "pwragent_threads",
+          tool: "search_threads",
+          arguments: { limit: 5 },
+        },
+      }),
+    ).resolves.toMatchObject({ success: true });
+    expect(handler).toHaveBeenCalledWith({
+      operation: "search_threads",
+      context: {
+        backend: "codex",
+        threadId: "agent-thread",
+      },
+      args: { limit: 5 },
+    });
+  });
+
+  it("routes pwragent_messaging calls through the unified messaging handler", async () => {
+    const handler = vi.fn(async () => ({
+      ok: true as const,
+      data: {
+        binding: {
+          id: "binding-1",
+          backend: "codex" as const,
+          threadId: "child-thread",
+          targetKind: "agent_thread" as const,
+        },
+        channel: "discord" as const,
+        conversation: {
+          id: "thread-1",
+          kind: "thread" as const,
+          title: "Child thread",
+        },
+        location: {
+          binding: {
+            id: "binding-parent",
+            backend: "codex" as const,
+            threadId: "agent-thread",
+            targetKind: "agent_thread" as const,
+          },
+          channel: "discord" as const,
+          conversation: {
+            id: "channel-1",
+            kind: "channel" as const,
+            title: "ops",
+          },
+          managedConversation: {
+            canCreateChild: true,
+            operations: [],
+            outcome: "ok" as const,
+            providerSupportsCreation: true,
+          },
+        },
+        outcome: "attached" as const,
+        placement: "current_conversation" as const,
+      },
+    }));
+
+    await expect(
+      handlePwrAgentMessagingDynamicToolCall({
+        backend: "codex",
+        handler,
+        call: {
+          threadId: "agent-thread",
+          turnId: "turn-1",
+          callId: "call-1",
+          namespace: "pwragent_messaging",
+          tool: "attach_thread_here",
+          arguments: {
+            backend: "codex",
+            threadId: "child-thread",
+            placement: "current_conversation",
+          },
+        },
+      }),
+    ).resolves.toMatchObject({ success: true });
+    expect(handler).toHaveBeenCalledWith({
+      operation: "attach_thread_here",
+      context: {
+        backend: "codex",
+        threadId: "agent-thread",
+        turnId: "turn-1",
+      },
+      args: {
+        backend: "codex",
+        threadId: "child-thread",
+        placement: "current_conversation",
+      },
+    });
+  });
+});

--- a/apps/desktop/src/main/__tests__/pwragent-app-agent-tools.test.ts
+++ b/apps/desktop/src/main/__tests__/pwragent-app-agent-tools.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { buildPwrAgentAppToolRouter } from "../agent-tools/pwragent-app-agent-tools";
+
+describe("PwrAgent app agent tools", () => {
+  it("projects manage_pwragent and dispatches normalized actions", async () => {
+    const handler = vi.fn(async () => ({
+      ok: true as const,
+      data: {
+        action: "status" as const,
+        runtime: {
+          currentVersion: "1.2.3",
+          startedAt: 1_000,
+          startedAtIso: "1970-01-01T00:00:01.000Z",
+          startedAtLocal: "Jan 1, 1970, 12:00:01 AM",
+          now: 61_000,
+          nowIso: "1970-01-01T00:01:01.000Z",
+          nowLocal: "Jan 1, 1970, 12:01:01 AM",
+          uptimeMs: 60_000,
+          uptimeHuman: "1m 0s",
+        },
+        update: {
+          status: { status: "idle" as const },
+          updateAvailableToDownload: false,
+          updateDownloadedWillInstallOnRestart: false,
+        },
+        result: { status: "reported" as const },
+      },
+    }));
+    const router = buildPwrAgentAppToolRouter(handler);
+
+    expect(router.buildDynamicToolSpecs()).toEqual([
+      expect.objectContaining({
+        namespace: "pwragent_app",
+        name: "manage_pwragent",
+      }),
+    ]);
+
+    await expect(
+      router.handleDynamicToolCall({
+        backend: "codex",
+        call: {
+          threadId: "agent-thread",
+          turnId: "turn-1",
+          callId: "call-1",
+          namespace: "pwragent_app",
+          tool: "manage_pwragent",
+          arguments: { action: "status" },
+        },
+      }),
+    ).resolves.toEqual({
+      success: true,
+      contentItems: [
+        {
+          type: "inputText",
+          text: expect.stringContaining('"currentVersion": "1.2.3"'),
+        },
+      ],
+    });
+    expect(handler).toHaveBeenCalledWith({
+      operation: "manage_pwragent",
+      context: {},
+      args: { action: "status" },
+    });
+  });
+
+  it("rejects unknown app management actions before dispatch", async () => {
+    const handler = vi.fn();
+    const router = buildPwrAgentAppToolRouter(handler);
+
+    await expect(
+      router.handleDynamicToolCall({
+        backend: "codex",
+        call: {
+          threadId: "agent-thread",
+          turnId: "turn-1",
+          callId: "call-1",
+          namespace: "pwragent_app",
+          tool: "manage_pwragent",
+          arguments: { action: "launch_missiles" },
+        },
+      }),
+    ).resolves.toMatchObject({ success: false });
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/__tests__/pwragent-app-agent-tools.test.ts
+++ b/apps/desktop/src/main/__tests__/pwragent-app-agent-tools.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { buildPwrAgentAppToolRouter } from "../agent-tools/pwragent-app-agent-tools";
+import { handlePwrAgentAppDynamicToolCall } from "../agent-tools/pwragent-app-codex-tools";
 
 describe("PwrAgent app agent tools", () => {
   it("projects manage_pwragent and dispatches normalized actions", async () => {
@@ -31,7 +32,7 @@ describe("PwrAgent app agent tools", () => {
 
     expect(router.buildDynamicToolSpecs()).toEqual([
       expect.objectContaining({
-        namespace: "pwragent_app",
+        namespace: "pwragent",
         name: "manage_pwragent",
       }),
     ]);
@@ -43,7 +44,7 @@ describe("PwrAgent app agent tools", () => {
           threadId: "agent-thread",
           turnId: "turn-1",
           callId: "call-1",
-          namespace: "pwragent_app",
+          namespace: "pwragent",
           tool: "manage_pwragent",
           arguments: { action: "status" },
         },
@@ -75,12 +76,58 @@ describe("PwrAgent app agent tools", () => {
           threadId: "agent-thread",
           turnId: "turn-1",
           callId: "call-1",
-          namespace: "pwragent_app",
+          namespace: "pwragent",
           tool: "manage_pwragent",
           arguments: { action: "launch_missiles" },
         },
       }),
     ).resolves.toMatchObject({ success: false });
     expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("accepts the legacy pwragent_app namespace as an invocation alias", async () => {
+    const handler = vi.fn(async () => ({
+      ok: true as const,
+      data: {
+        action: "stop" as const,
+        runtime: {
+          currentVersion: "1.2.3",
+          startedAt: 1_000,
+          startedAtIso: "1970-01-01T00:00:01.000Z",
+          startedAtLocal: "Jan 1, 1970, 12:00:01 AM",
+          now: 61_000,
+          nowIso: "1970-01-01T00:01:01.000Z",
+          nowLocal: "Jan 1, 1970, 12:01:01 AM",
+          uptimeMs: 60_000,
+          uptimeHuman: "1m 0s",
+        },
+        update: {
+          status: { status: "idle" as const },
+          updateAvailableToDownload: false,
+          updateDownloadedWillInstallOnRestart: false,
+        },
+        result: { status: "stop_accepted" as const },
+      },
+    }));
+
+    await expect(
+      handlePwrAgentAppDynamicToolCall({
+        backend: "codex",
+        handler,
+        call: {
+          threadId: "agent-thread",
+          turnId: "turn-1",
+          callId: "call-1",
+          namespace: "pwragent_app",
+          tool: "manage_pwragent",
+          arguments: { action: "stop" },
+        },
+      }),
+    ).resolves.toMatchObject({ success: true });
+    expect(handler).toHaveBeenCalledWith({
+      operation: "manage_pwragent",
+      context: {},
+      args: { action: "stop" },
+    });
   });
 });

--- a/apps/desktop/src/main/__tests__/pwragent-app-management-service.test.ts
+++ b/apps/desktop/src/main/__tests__/pwragent-app-management-service.test.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const appMock = {
+  getVersion: vi.fn(() => "1.2.3"),
+  quit: vi.fn(),
+  relaunch: vi.fn(),
+};
+const checkForAppUpdatesNowMock = vi.fn();
+const installDownloadedAppUpdateMock = vi.fn();
+const readAppUpdateStatusMock = vi.fn();
+const requestQuitMock = vi.fn();
+
+vi.mock("electron", () => ({
+  app: appMock,
+}));
+
+vi.mock("../auto-updater", () => ({
+  checkForAppUpdatesNow: checkForAppUpdatesNowMock,
+  installDownloadedAppUpdate: installDownloadedAppUpdateMock,
+  readAppUpdateStatus: readAppUpdateStatusMock,
+}));
+
+vi.mock("../quit-manager", () => ({
+  requestQuit: requestQuitMock,
+}));
+
+describe("PwrAgent app management service", () => {
+  beforeEach(() => {
+    appMock.getVersion.mockReturnValue("1.2.3");
+    appMock.quit.mockReset();
+    appMock.relaunch.mockReset();
+    checkForAppUpdatesNowMock.mockReset();
+    installDownloadedAppUpdateMock.mockReset();
+    readAppUpdateStatusMock.mockReset();
+    readAppUpdateStatusMock.mockReturnValue({ status: "idle" });
+    requestQuitMock.mockReset();
+  });
+
+  it("reports current version, local start time fields, and uptime", async () => {
+    const { createPwrAgentAppManagementHandler } = await import(
+      "../agent-tools/pwragent-app-management-service"
+    );
+    const handler = createPwrAgentAppManagementHandler({
+      now: () => 121_000,
+      startedAt: 1_000,
+      version: () => "9.9.9",
+    });
+
+    await expect(
+      handler({
+        operation: "manage_pwragent",
+        context: {},
+        args: { action: "status" },
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      data: {
+        action: "status",
+        runtime: {
+          currentVersion: "9.9.9",
+          startedAt: 1_000,
+          startedAtIso: "1970-01-01T00:00:01.000Z",
+          now: 121_000,
+          nowIso: "1970-01-01T00:02:01.000Z",
+          uptimeMs: 120_000,
+          uptimeHuman: "2m 0s",
+        },
+        update: {
+          status: { status: "idle" },
+          updateAvailableToDownload: false,
+          updateDownloadedWillInstallOnRestart: false,
+        },
+        result: { status: "reported" },
+      },
+    });
+  });
+
+  it("checks for upgrades and marks downloaded updates as restart-ready", async () => {
+    checkForAppUpdatesNowMock.mockResolvedValue({
+      status: "downloaded",
+      version: "1.2.4",
+    });
+    const { createPwrAgentAppManagementHandler } = await import(
+      "../agent-tools/pwragent-app-management-service"
+    );
+    const handler = createPwrAgentAppManagementHandler({
+      now: () => 2_000,
+      startedAt: 1_000,
+    });
+
+    const response = await handler({
+      operation: "manage_pwragent",
+      context: {},
+      args: { action: "upgrade_check" },
+    });
+
+    expect(checkForAppUpdatesNowMock).toHaveBeenCalledWith("manual");
+    expect(response).toMatchObject({
+      ok: true,
+      data: {
+        update: {
+          status: { status: "downloaded", version: "1.2.4" },
+          updateDownloadedWillInstallOnRestart: true,
+        },
+        result: {
+          status: "check_completed",
+          check: { status: "downloaded", version: "1.2.4" },
+        },
+      },
+    });
+  });
+
+  it("routes plain restarts through the injected restart confirmation", async () => {
+    readAppUpdateStatusMock.mockReturnValue({
+      status: "available",
+      version: "1.2.4",
+    });
+    const requestRestart = vi.fn(async (performRestart: () => void) => {
+      performRestart();
+      return true;
+    });
+    const { createPwrAgentAppManagementHandler } = await import(
+      "../agent-tools/pwragent-app-management-service"
+    );
+    const handler = createPwrAgentAppManagementHandler({
+      now: () => 2_000,
+      requestRestart,
+      startedAt: 1_000,
+    });
+
+    const response = await handler({
+      operation: "manage_pwragent",
+      context: {},
+      args: { action: "restart" },
+    });
+
+    expect(requestRestart).toHaveBeenCalledTimes(1);
+    expect(appMock.relaunch).toHaveBeenCalledTimes(1);
+    expect(appMock.quit).toHaveBeenCalledTimes(1);
+    expect(response).toMatchObject({
+      ok: true,
+      data: {
+        result: {
+          status: "restart_accepted",
+          installingDownloadedUpdate: false,
+        },
+        update: {
+          updateAvailableToDownload: true,
+          updateDownloadedWillInstallOnRestart: false,
+        },
+      },
+    });
+  });
+
+  it("uses update install when restarting with a downloaded update", async () => {
+    readAppUpdateStatusMock.mockReturnValue({
+      status: "downloaded",
+      version: "1.2.4",
+    });
+    installDownloadedAppUpdateMock.mockResolvedValue({ status: "restarting" });
+    const { createPwrAgentAppManagementHandler } = await import(
+      "../agent-tools/pwragent-app-management-service"
+    );
+    const handler = createPwrAgentAppManagementHandler({
+      now: () => 2_000,
+      startedAt: 1_000,
+    });
+
+    const response = await handler({
+      operation: "manage_pwragent",
+      context: {},
+      args: { action: "restart" },
+    });
+
+    expect(installDownloadedAppUpdateMock).toHaveBeenCalledTimes(1);
+    expect(response).toMatchObject({
+      ok: true,
+      data: {
+        result: {
+          status: "restart_accepted",
+          installingDownloadedUpdate: true,
+        },
+        update: {
+          updateDownloadedWillInstallOnRestart: true,
+        },
+      },
+    });
+  });
+});

--- a/apps/desktop/src/main/__tests__/pwragent-messaging-agent-tools.test.ts
+++ b/apps/desktop/src/main/__tests__/pwragent-messaging-agent-tools.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { buildPwrAgentMessagingToolRouter } from "../agent-tools/pwragent-messaging-agent-tools";
-import { isPwrAgentMessagingDynamicToolCall } from "../agent-tools/pwragent-messaging-codex-tools";
+import {
+  handlePwrAgentMessagingDynamicToolCall,
+  isPwrAgentMessagingDynamicToolCall,
+} from "../agent-tools/pwragent-messaging-codex-tools";
 
 describe("PwrAgent messaging agent tools", () => {
   it("does not advertise deprecated location tool but still recognizes legacy calls", async () => {
@@ -42,10 +45,43 @@ describe("PwrAgent messaging agent tools", () => {
         tool: "get_current_location",
       }),
     ).toBe(true);
+    expect(
+      isPwrAgentMessagingDynamicToolCall({
+        namespace: "pwragent",
+        tool: "get_current_location",
+      }),
+    ).toBe(true);
 
     await expect(
       router.handleDynamicToolCall({
         backend: "codex",
+        call: {
+          threadId: "agent-thread",
+          turnId: "turn-1",
+          callId: "call-1",
+          namespace: "pwragent",
+          tool: "get_current_location",
+          arguments: {},
+        },
+      }),
+    ).resolves.toMatchObject({
+      success: true,
+    });
+    expect(handler).toHaveBeenCalledWith({
+      operation: "get_current_location",
+      context: {
+        backend: "codex",
+        threadId: "agent-thread",
+        turnId: "turn-1",
+      },
+      args: {},
+    });
+
+    handler.mockClear();
+    await expect(
+      handlePwrAgentMessagingDynamicToolCall({
+        backend: "codex",
+        handler,
         call: {
           threadId: "agent-thread",
           turnId: "turn-1",

--- a/apps/desktop/src/main/__tests__/pwragent-thread-agent-tools.test.ts
+++ b/apps/desktop/src/main/__tests__/pwragent-thread-agent-tools.test.ts
@@ -25,7 +25,7 @@ describe("PwrAgent thread agent tools", () => {
         name: "get_thread_status",
       }),
       expect.objectContaining({
-        namespace: "pwragent_threads",
+        namespace: "pwragent",
         name: "mutate_thread",
       }),
     ]);

--- a/apps/desktop/src/main/__tests__/pwragent-thread-agent-tools.test.ts
+++ b/apps/desktop/src/main/__tests__/pwragent-thread-agent-tools.test.ts
@@ -15,20 +15,26 @@ describe("PwrAgent thread agent tools", () => {
     }));
     const router = buildPwrAgentThreadToolRouter(handler);
 
-    expect(router.buildDynamicToolSpecs()).toEqual([
-      expect.objectContaining({
-        namespace: "pwragent",
-        name: "search_threads",
-      }),
-      expect.objectContaining({
-        namespace: "pwragent",
-        name: "get_thread_status",
-      }),
-      expect.objectContaining({
-        namespace: "pwragent",
-        name: "mutate_thread",
-      }),
-    ]);
+    expect(router.buildDynamicToolSpecs()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          namespace: "pwragent",
+          name: "search_threads",
+        }),
+        expect.objectContaining({
+          namespace: "pwragent",
+          name: "read_thread",
+        }),
+        expect.objectContaining({
+          namespace: "pwragent",
+          name: "get_thread_status",
+        }),
+        expect.objectContaining({
+          namespace: "pwragent",
+          name: "mutate_thread",
+        }),
+      ]),
+    );
 
     await expect(
       router.handleDynamicToolCall({

--- a/apps/desktop/src/main/__tests__/pwragent-thread-agent-tools.test.ts
+++ b/apps/desktop/src/main/__tests__/pwragent-thread-agent-tools.test.ts
@@ -17,11 +17,11 @@ describe("PwrAgent thread agent tools", () => {
 
     expect(router.buildDynamicToolSpecs()).toEqual([
       expect.objectContaining({
-        namespace: "pwragent_threads",
+        namespace: "pwragent",
         name: "search_threads",
       }),
       expect.objectContaining({
-        namespace: "pwragent_threads",
+        namespace: "pwragent",
         name: "get_thread_status",
       }),
       expect.objectContaining({
@@ -37,7 +37,7 @@ describe("PwrAgent thread agent tools", () => {
           threadId: "agent-thread",
           turnId: "turn-1",
           callId: "call-1",
-          namespace: "pwragent_threads",
+          namespace: "pwragent",
           tool: "search_threads",
           arguments: {
             query: "PwrAgent",

--- a/apps/desktop/src/main/agent-tools/__tests__/pwragent-thread-orchestration-agent-tools.test.ts
+++ b/apps/desktop/src/main/agent-tools/__tests__/pwragent-thread-orchestration-agent-tools.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  buildPwrAgentThreadOrchestrationToolRouter,
+  PWRAGENT_THREAD_ORCHESTRATION_UNAVAILABLE_MESSAGE,
+} from "../pwragent-thread-orchestration-agent-tools";
+
+describe("pwragent thread orchestration agent tools", () => {
+  it("projects handoff_task under the unified pwragent namespace", () => {
+    const router = buildPwrAgentThreadOrchestrationToolRouter(undefined);
+
+    expect(router.buildDynamicToolSpecs()).toEqual([
+      expect.objectContaining({
+        namespace: "pwragent",
+        name: "handoff_task",
+        deferLoading: false,
+        inputSchema: expect.objectContaining({
+          required: ["task"],
+          properties: expect.objectContaining({
+            seedMode: expect.objectContaining({
+              enum: ["clean", "fork"],
+            }),
+            groupingMode: expect.objectContaining({
+              enum: ["none", "subthread"],
+            }),
+            workspaceMode: expect.objectContaining({
+              enum: ["same", "new_worktree", "none"],
+            }),
+          }),
+        }),
+      }),
+    ]);
+  });
+
+  it("returns unavailable when no handler is registered", async () => {
+    const router = buildPwrAgentThreadOrchestrationToolRouter(undefined);
+
+    await expect(
+      router.handleDynamicToolCall({
+        backend: "codex",
+        call: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          callId: "call-1",
+          namespace: "pwragent",
+          tool: "handoff_task",
+          arguments: { task: "Ship it" },
+        },
+      }),
+    ).resolves.toEqual({
+      success: false,
+      contentItems: [
+        {
+          type: "inputText",
+          text: JSON.stringify(
+            {
+              code: "internal_error",
+              message: PWRAGENT_THREAD_ORCHESTRATION_UNAVAILABLE_MESSAGE,
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    });
+  });
+
+  it("validates task before dispatch", async () => {
+    const handler = vi.fn();
+    const router = buildPwrAgentThreadOrchestrationToolRouter(handler);
+
+    await expect(
+      router.handleDynamicToolCall({
+        backend: "codex",
+        call: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          callId: "call-1",
+          namespace: "pwragent",
+          tool: "handoff_task",
+          arguments: { task: "  " },
+        },
+      }),
+    ).resolves.toMatchObject({ success: false });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("normalizes args and dispatches with caller context", async () => {
+    const handler = vi.fn(async () => ({
+      ok: true as const,
+      data: {
+        backend: "codex" as const,
+        threadId: "thread-child",
+        turnId: "turn-child",
+        seedMode: "fork" as const,
+        groupingMode: "subthread" as const,
+        inheritedSettings: { backend: "codex" as const },
+        origin: {
+          sourceBackend: "codex" as const,
+          sourceThreadId: "thread-1",
+          sourceTurnId: "turn-1",
+          seedMode: "fork" as const,
+          groupingMode: "subthread" as const,
+          createdAt: 1_773_000_000_000,
+          workspace: {
+            mode: "same" as const,
+            git: {
+              kind: "none" as const,
+              worktreeCreationAvailable: false as const,
+              unavailableReason: "No workspace.",
+            },
+          },
+        },
+        workspace: {
+          mode: "same" as const,
+          git: {
+            kind: "none" as const,
+            worktreeCreationAvailable: false as const,
+            unavailableReason: "No workspace.",
+          },
+        },
+        messagingAttachment: {
+          requested: false as const,
+          outcome: "not_requested" as const,
+        },
+      },
+    }));
+    const router = buildPwrAgentThreadOrchestrationToolRouter(handler);
+
+    await router.handleDynamicToolCall({
+      backend: "codex",
+      call: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-1",
+        namespace: "pwragent",
+        tool: "handoff_task",
+        arguments: {
+          task: "  Ship it  ",
+          seedMode: "fork",
+          groupingMode: "subthread",
+          workspaceMode: "same",
+          messagingAttachment: "auto",
+        },
+      },
+    });
+
+    expect(handler).toHaveBeenCalledWith({
+      operation: "handoff_task",
+      context: {
+        backend: "codex",
+        threadId: "thread-1",
+        turnId: "turn-1",
+      },
+      args: {
+        task: "Ship it",
+        seedMode: "fork",
+        groupingMode: "subthread",
+        workspaceMode: "same",
+        messagingAttachment: "auto",
+      },
+    });
+  });
+});

--- a/apps/desktop/src/main/agent-tools/__tests__/pwragent-thread-orchestration-agent-tools.test.ts
+++ b/apps/desktop/src/main/agent-tools/__tests__/pwragent-thread-orchestration-agent-tools.test.ts
@@ -29,6 +29,14 @@ describe("pwragent thread orchestration agent tools", () => {
           }),
         }),
       }),
+      expect.objectContaining({
+        namespace: "pwragent",
+        name: "send_message_to_thread",
+        deferLoading: false,
+        inputSchema: expect.objectContaining({
+          required: ["backend", "threadId", "prompt"],
+        }),
+      }),
     ]);
   });
 
@@ -79,6 +87,30 @@ describe("pwragent thread orchestration agent tools", () => {
           namespace: "pwragent",
           tool: "handoff_task",
           arguments: { task: "  " },
+        },
+      }),
+    ).resolves.toMatchObject({ success: false });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("validates send_message_to_thread before dispatch", async () => {
+    const handler = vi.fn();
+    const router = buildPwrAgentThreadOrchestrationToolRouter(handler);
+
+    await expect(
+      router.handleDynamicToolCall({
+        backend: "codex",
+        call: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          callId: "call-1",
+          namespace: "pwragent",
+          tool: "send_message_to_thread",
+          arguments: {
+            backend: "codex",
+            threadId: "target-thread",
+            prompt: "  ",
+          },
         },
       }),
     ).resolves.toMatchObject({ success: false });
@@ -158,6 +190,57 @@ describe("pwragent thread orchestration agent tools", () => {
         groupingMode: "subthread",
         workspaceMode: "same",
         messagingAttachment: "auto",
+      },
+    });
+  });
+
+  it("normalizes send_message_to_thread args and dispatches with caller context", async () => {
+    const handler = vi.fn(async () => ({
+      ok: true as const,
+      data: {
+        backend: "codex" as const,
+        threadId: "target-thread",
+        turnId: "target-turn",
+        promptPreview: "Check CI",
+        settings: {
+          model: "gpt-5.5",
+          fastMode: true,
+        },
+      },
+    }));
+    const router = buildPwrAgentThreadOrchestrationToolRouter(handler);
+
+    await router.handleDynamicToolCall({
+      backend: "codex",
+      call: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-1",
+        namespace: "pwragent",
+        tool: "send_message_to_thread",
+        arguments: {
+          backend: "codex",
+          threadId: " target-thread ",
+          prompt: " Check CI ",
+          model: " gpt-5.5 ",
+          fastMode: true,
+        },
+      },
+    });
+
+    expect(handler).toHaveBeenCalledWith({
+      operation: "send_message_to_thread",
+      context: {
+        backend: "codex",
+        threadId: "thread-1",
+        turnId: "turn-1",
+      },
+      args: {
+        backend: "codex",
+        threadId: "target-thread",
+        prompt: "Check CI",
+        model: "gpt-5.5",
+        fastMode: true,
       },
     });
   });

--- a/apps/desktop/src/main/agent-tools/agent-tool-catalog-registry.ts
+++ b/apps/desktop/src/main/agent-tools/agent-tool-catalog-registry.ts
@@ -21,6 +21,10 @@ import {
   buildPwrAgentMessagingToolRouter,
   type PwrAgentMessagingHandler,
 } from "./pwragent-messaging-agent-tools.js";
+import {
+  buildPwrAgentThreadOrchestrationToolRouter,
+  type PwrAgentThreadOrchestrationHandler,
+} from "./pwragent-thread-orchestration-agent-tools.js";
 
 export type ResolvedAgentToolCatalog = {
   id: AgentToolCatalogId;
@@ -34,6 +38,7 @@ export function resolveAgentToolCatalogs(params: {
   automationInspectionHandler?: AutomationInspectionHandler;
   messagingHandler?: PwrAgentMessagingHandler;
   threadInspectionHandler?: PwrAgentThreadInspectionHandler;
+  threadOrchestrationHandler?: PwrAgentThreadOrchestrationHandler;
 }): ResolvedAgentToolCatalog[] {
   if (!params.agent) {
     return [];
@@ -49,6 +54,11 @@ export function resolveAgentToolCatalogs(params: {
   const threadDynamicTools = threadRouter.buildDynamicToolSpecs();
   const messagingRouter = buildPwrAgentMessagingToolRouter(params.messagingHandler);
   const messagingDynamicTools = messagingRouter.buildDynamicToolSpecs();
+  const threadOrchestrationRouter = buildPwrAgentThreadOrchestrationToolRouter(
+    params.threadOrchestrationHandler,
+  );
+  const threadOrchestrationDynamicTools =
+    threadOrchestrationRouter.buildDynamicToolSpecs();
   return [
     {
       id: "automation_inspection",
@@ -107,6 +117,21 @@ export function resolveAgentToolCatalogs(params: {
           id: "messaging_context",
           namespace: PWRAGENT_TOOL_NAMESPACE,
           tools: messagingDynamicTools,
+        }),
+      },
+    },
+    {
+      id: "thread_orchestration",
+      dynamicTools: threadOrchestrationDynamicTools,
+      summary: {
+        id: "thread_orchestration",
+        namespace: PWRAGENT_TOOL_NAMESPACE,
+        enabled: true,
+        toolCount: threadOrchestrationDynamicTools.length,
+        fingerprint: buildCatalogFingerprint({
+          id: "thread_orchestration",
+          namespace: PWRAGENT_TOOL_NAMESPACE,
+          tools: threadOrchestrationDynamicTools,
         }),
       },
     },

--- a/apps/desktop/src/main/agent-tools/agent-tool-catalog-registry.ts
+++ b/apps/desktop/src/main/agent-tools/agent-tool-catalog-registry.ts
@@ -3,10 +3,7 @@ import type {
   AgentToolCatalogSummary,
   ThreadAgentMetadata,
 } from "@pwragent/shared";
-import { AUTOMATION_INSPECTION_TOOL_NAMESPACE } from "@pwragent/shared";
-import { PWRAGENT_APP_TOOL_NAMESPACE } from "@pwragent/shared";
-import { PWRAGENT_MESSAGING_TOOL_NAMESPACE } from "@pwragent/shared";
-import { PWRAGENT_THREAD_TOOL_NAMESPACE } from "@pwragent/shared";
+import { PWRAGENT_TOOL_NAMESPACE } from "@pwragent/shared";
 import type { DynamicToolSpec } from "@pwrdrvr/codex-app-server-protocol/v2";
 import {
   buildAutomationInspectionToolRouter,
@@ -58,12 +55,12 @@ export function resolveAgentToolCatalogs(params: {
       dynamicTools: automationDynamicTools,
       summary: {
         id: "automation_inspection",
-        namespace: AUTOMATION_INSPECTION_TOOL_NAMESPACE,
+        namespace: PWRAGENT_TOOL_NAMESPACE,
         enabled: true,
         toolCount: automationDynamicTools.length,
         fingerprint: buildCatalogFingerprint({
           id: "automation_inspection",
-          namespace: AUTOMATION_INSPECTION_TOOL_NAMESPACE,
+          namespace: PWRAGENT_TOOL_NAMESPACE,
           tools: automationDynamicTools,
         }),
       },
@@ -73,12 +70,12 @@ export function resolveAgentToolCatalogs(params: {
       dynamicTools: appDynamicTools,
       summary: {
         id: "app_management",
-        namespace: PWRAGENT_APP_TOOL_NAMESPACE,
+        namespace: PWRAGENT_TOOL_NAMESPACE,
         enabled: true,
         toolCount: appDynamicTools.length,
         fingerprint: buildCatalogFingerprint({
           id: "app_management",
-          namespace: PWRAGENT_APP_TOOL_NAMESPACE,
+          namespace: PWRAGENT_TOOL_NAMESPACE,
           tools: appDynamicTools,
         }),
       },
@@ -88,12 +85,12 @@ export function resolveAgentToolCatalogs(params: {
       dynamicTools: threadDynamicTools,
       summary: {
         id: "thread_inspection",
-        namespace: PWRAGENT_THREAD_TOOL_NAMESPACE,
+        namespace: PWRAGENT_TOOL_NAMESPACE,
         enabled: true,
         toolCount: threadDynamicTools.length,
         fingerprint: buildCatalogFingerprint({
           id: "thread_inspection",
-          namespace: PWRAGENT_THREAD_TOOL_NAMESPACE,
+          namespace: PWRAGENT_TOOL_NAMESPACE,
           tools: threadDynamicTools,
         }),
       },
@@ -103,12 +100,12 @@ export function resolveAgentToolCatalogs(params: {
       dynamicTools: messagingDynamicTools,
       summary: {
         id: "messaging_context",
-        namespace: PWRAGENT_MESSAGING_TOOL_NAMESPACE,
+        namespace: PWRAGENT_TOOL_NAMESPACE,
         enabled: true,
         toolCount: messagingDynamicTools.length,
         fingerprint: buildCatalogFingerprint({
           id: "messaging_context",
-          namespace: PWRAGENT_MESSAGING_TOOL_NAMESPACE,
+          namespace: PWRAGENT_TOOL_NAMESPACE,
           tools: messagingDynamicTools,
         }),
       },

--- a/apps/desktop/src/main/agent-tools/agent-tool-catalog-registry.ts
+++ b/apps/desktop/src/main/agent-tools/agent-tool-catalog-registry.ts
@@ -4,6 +4,7 @@ import type {
   ThreadAgentMetadata,
 } from "@pwragent/shared";
 import { AUTOMATION_INSPECTION_TOOL_NAMESPACE } from "@pwragent/shared";
+import { PWRAGENT_APP_TOOL_NAMESPACE } from "@pwragent/shared";
 import { PWRAGENT_MESSAGING_TOOL_NAMESPACE } from "@pwragent/shared";
 import { PWRAGENT_THREAD_TOOL_NAMESPACE } from "@pwragent/shared";
 import type { DynamicToolSpec } from "@pwrdrvr/codex-app-server-protocol/v2";
@@ -11,6 +12,10 @@ import {
   buildAutomationInspectionToolRouter,
   type AutomationInspectionHandler,
 } from "../automations/automation-inspection-agent-tools.js";
+import {
+  buildPwrAgentAppToolRouter,
+  type PwrAgentAppManagementHandler,
+} from "./pwragent-app-agent-tools.js";
 import {
   buildPwrAgentThreadToolRouter,
   type PwrAgentThreadInspectionHandler,
@@ -28,6 +33,7 @@ export type ResolvedAgentToolCatalog = {
 
 export function resolveAgentToolCatalogs(params: {
   agent?: ThreadAgentMetadata | { name: string; instructions?: string } | null;
+  appManagementHandler?: PwrAgentAppManagementHandler;
   automationInspectionHandler?: AutomationInspectionHandler;
   messagingHandler?: PwrAgentMessagingHandler;
   threadInspectionHandler?: PwrAgentThreadInspectionHandler;
@@ -40,6 +46,8 @@ export function resolveAgentToolCatalogs(params: {
     params.automationInspectionHandler,
   );
   const automationDynamicTools = automationRouter.buildDynamicToolSpecs();
+  const appRouter = buildPwrAgentAppToolRouter(params.appManagementHandler);
+  const appDynamicTools = appRouter.buildDynamicToolSpecs();
   const threadRouter = buildPwrAgentThreadToolRouter(params.threadInspectionHandler);
   const threadDynamicTools = threadRouter.buildDynamicToolSpecs();
   const messagingRouter = buildPwrAgentMessagingToolRouter(params.messagingHandler);
@@ -57,6 +65,21 @@ export function resolveAgentToolCatalogs(params: {
           id: "automation_inspection",
           namespace: AUTOMATION_INSPECTION_TOOL_NAMESPACE,
           tools: automationDynamicTools,
+        }),
+      },
+    },
+    {
+      id: "app_management",
+      dynamicTools: appDynamicTools,
+      summary: {
+        id: "app_management",
+        namespace: PWRAGENT_APP_TOOL_NAMESPACE,
+        enabled: true,
+        toolCount: appDynamicTools.length,
+        fingerprint: buildCatalogFingerprint({
+          id: "app_management",
+          namespace: PWRAGENT_APP_TOOL_NAMESPACE,
+          tools: appDynamicTools,
         }),
       },
     },

--- a/apps/desktop/src/main/agent-tools/agent-tool-catalog-registry.ts
+++ b/apps/desktop/src/main/agent-tools/agent-tool-catalog-registry.ts
@@ -1,7 +1,6 @@
 import type {
   AgentToolCatalogId,
   AgentToolCatalogSummary,
-  ThreadAgentMetadata,
 } from "@pwragent/shared";
 import { PWRAGENT_TOOL_NAMESPACE } from "@pwragent/shared";
 import type { DynamicToolSpec } from "@pwrdrvr/codex-app-server-protocol/v2";
@@ -33,17 +32,12 @@ export type ResolvedAgentToolCatalog = {
 };
 
 export function resolveAgentToolCatalogs(params: {
-  agent?: ThreadAgentMetadata | { name: string; instructions?: string } | null;
   appManagementHandler?: PwrAgentAppManagementHandler;
   automationInspectionHandler?: AutomationInspectionHandler;
   messagingHandler?: PwrAgentMessagingHandler;
   threadInspectionHandler?: PwrAgentThreadInspectionHandler;
   threadOrchestrationHandler?: PwrAgentThreadOrchestrationHandler;
 }): ResolvedAgentToolCatalog[] {
-  if (!params.agent) {
-    return [];
-  }
-
   const automationRouter = buildAutomationInspectionToolRouter(
     params.automationInspectionHandler,
   );

--- a/apps/desktop/src/main/agent-tools/pwragent-app-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-app-agent-tools.ts
@@ -7,7 +7,7 @@ import type {
 import {
   PWRAGENT_APP_MANAGEMENT_ACTIONS,
   PWRAGENT_APP_OPERATION_NAMES,
-  PWRAGENT_APP_TOOL_NAMESPACE,
+  PWRAGENT_TOOL_NAMESPACE,
 } from "@pwragent/shared";
 import type {
   AgentToolDefinition,
@@ -28,9 +28,11 @@ export type PwrAgentAppManagementHandler = (
 
 export function buildPwrAgentAppToolRouter(
   handler: PwrAgentAppManagementHandler | undefined,
-  options: { unsupportedMessage?: string } = {},
+  options: { namespace?: string; unsupportedMessage?: string } = {},
 ): AgentToolRouter {
-  return new AgentToolRouter(buildPwrAgentAppToolDefinitions(handler), {
+  return new AgentToolRouter(buildPwrAgentAppToolDefinitions(handler, {
+    namespace: options.namespace,
+  }), {
     unsupportedMessage:
       options.unsupportedMessage ?? "Unsupported PwrAgent app tool.",
   });
@@ -38,9 +40,10 @@ export function buildPwrAgentAppToolRouter(
 
 export function buildPwrAgentAppToolDefinitions(
   handler: PwrAgentAppManagementHandler | undefined,
+  options: { namespace?: string } = {},
 ): AgentToolDefinition<PwrAgentAppOperationName>[] {
   return PWRAGENT_APP_OPERATION_NAMES.map((operation) => ({
-    namespace: PWRAGENT_APP_TOOL_NAMESPACE,
+    namespace: options.namespace ?? PWRAGENT_TOOL_NAMESPACE,
     name: operation,
     description: descriptionForOperation(operation),
     inputSchema: inputSchemaForOperation(operation),

--- a/apps/desktop/src/main/agent-tools/pwragent-app-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-app-agent-tools.ts
@@ -1,0 +1,120 @@
+import type {
+  PwrAgentAppManagementAction,
+  PwrAgentAppOperationName,
+  PwrAgentAppRequest,
+  PwrAgentAppResponse,
+} from "@pwragent/shared";
+import {
+  PWRAGENT_APP_MANAGEMENT_ACTIONS,
+  PWRAGENT_APP_OPERATION_NAMES,
+  PWRAGENT_APP_TOOL_NAMESPACE,
+} from "@pwragent/shared";
+import type {
+  AgentToolDefinition,
+  AgentToolDispatchResult,
+} from "./agent-tool-definition.js";
+import {
+  agentToolFailure,
+  agentToolSuccess,
+} from "./agent-tool-definition.js";
+import { AgentToolRouter } from "./agent-tool-router.js";
+
+export const PWRAGENT_APP_MANAGEMENT_UNAVAILABLE_MESSAGE =
+  "PwrAgent app management tools are not available.";
+
+export type PwrAgentAppManagementHandler = (
+  request: PwrAgentAppRequest,
+) => PwrAgentAppResponse | Promise<PwrAgentAppResponse>;
+
+export function buildPwrAgentAppToolRouter(
+  handler: PwrAgentAppManagementHandler | undefined,
+  options: { unsupportedMessage?: string } = {},
+): AgentToolRouter {
+  return new AgentToolRouter(buildPwrAgentAppToolDefinitions(handler), {
+    unsupportedMessage:
+      options.unsupportedMessage ?? "Unsupported PwrAgent app tool.",
+  });
+}
+
+export function buildPwrAgentAppToolDefinitions(
+  handler: PwrAgentAppManagementHandler | undefined,
+): AgentToolDefinition<PwrAgentAppOperationName>[] {
+  return PWRAGENT_APP_OPERATION_NAMES.map((operation) => ({
+    namespace: PWRAGENT_APP_TOOL_NAMESPACE,
+    name: operation,
+    description: descriptionForOperation(operation),
+    inputSchema: inputSchemaForOperation(operation),
+    deferLoading: false,
+    dispatch: async (args): Promise<AgentToolDispatchResult> => {
+      if (!handler) {
+        return agentToolFailure({
+          code: "internal_error",
+          message: PWRAGENT_APP_MANAGEMENT_UNAVAILABLE_MESSAGE,
+        });
+      }
+      const action = normalizeAction(args.action);
+      if (!action) {
+        return agentToolFailure({
+          code: "invalid_arguments",
+          message:
+            "manage_pwragent requires action to be one of: status, upgrade_check, restart, stop.",
+        });
+      }
+      const response = await handler({
+        operation,
+        context: {},
+        args: { action },
+      } as PwrAgentAppRequest);
+      return appResponseToAgentToolResult(response);
+    },
+  }));
+}
+
+function descriptionForOperation(operation: PwrAgentAppOperationName): string {
+  switch (operation) {
+    case "manage_pwragent":
+      return "Read PwrAgent runtime/update status, check for upgrades, or request a PwrAgent restart/stop.";
+  }
+}
+
+function inputSchemaForOperation(
+  operation: PwrAgentAppOperationName,
+): Record<string, unknown> {
+  switch (operation) {
+    case "manage_pwragent":
+      return {
+        type: "object",
+        additionalProperties: false,
+        required: ["action"],
+        properties: {
+          action: {
+            type: "string",
+            enum: PWRAGENT_APP_MANAGEMENT_ACTIONS,
+            description:
+              "`status` reports version, start time, uptime, and update state. `upgrade_check` checks for an available or downloaded update. `restart` restarts PwrAgent and installs a downloaded update when one is ready. `stop` quits PwrAgent.",
+          },
+        },
+      };
+  }
+}
+
+function normalizeAction(value: unknown): PwrAgentAppManagementAction | undefined {
+  return typeof value === "string" &&
+    PWRAGENT_APP_MANAGEMENT_ACTIONS.includes(
+      value as PwrAgentAppManagementAction,
+    )
+    ? (value as PwrAgentAppManagementAction)
+    : undefined;
+}
+
+function appResponseToAgentToolResult(
+  response: PwrAgentAppResponse,
+): AgentToolDispatchResult {
+  if (response.ok) {
+    return agentToolSuccess(response.data);
+  }
+  return agentToolFailure({
+    code: response.error.code,
+    message: response.error.message,
+  });
+}

--- a/apps/desktop/src/main/agent-tools/pwragent-app-codex-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-app-codex-tools.ts
@@ -1,0 +1,61 @@
+import type {
+  AppServerBackendKind,
+  PwrAgentAppOperationName,
+} from "@pwragent/shared";
+import {
+  PWRAGENT_APP_OPERATION_NAMES,
+  PWRAGENT_APP_TOOL_NAMESPACE,
+} from "@pwragent/shared";
+import type {
+  DynamicToolCallParams,
+  DynamicToolCallResponse,
+} from "@pwrdrvr/codex-app-server-protocol/v2";
+import {
+  readAgentDynamicToolCall,
+  toDynamicToolResponse,
+} from "./agent-tool-router.js";
+import {
+  buildPwrAgentAppToolRouter,
+  type PwrAgentAppManagementHandler,
+} from "./pwragent-app-agent-tools.js";
+
+export function isPwrAgentAppDynamicToolCall(
+  call: Pick<DynamicToolCallParams, "namespace" | "tool">,
+): call is DynamicToolCallParams & {
+  namespace: typeof PWRAGENT_APP_TOOL_NAMESPACE;
+  tool: PwrAgentAppOperationName;
+} {
+  return (
+    call.namespace === PWRAGENT_APP_TOOL_NAMESPACE &&
+    PWRAGENT_APP_OPERATION_NAMES.includes(call.tool as PwrAgentAppOperationName)
+  );
+}
+
+export async function handlePwrAgentAppDynamicToolCall(params: {
+  backend: AppServerBackendKind;
+  call: DynamicToolCallParams;
+  handler: PwrAgentAppManagementHandler | undefined;
+}): Promise<DynamicToolCallResponse> {
+  return await buildPwrAgentAppToolRouter(params.handler).handleDynamicToolCall({
+    backend: params.backend,
+    call: params.call,
+  });
+}
+
+export function buildPwrAgentAppDynamicToolErrorResponse(params: {
+  code: "forbidden" | "internal_error" | "unsupported_operation";
+  message: string;
+}): DynamicToolCallResponse {
+  return toDynamicToolResponse({
+    ok: false,
+    code: params.code,
+    message: params.message,
+  });
+}
+
+export function readPwrAgentAppDynamicToolCall(request: {
+  method: string;
+  params: Record<string, unknown>;
+}): DynamicToolCallParams | undefined {
+  return readAgentDynamicToolCall(request);
+}

--- a/apps/desktop/src/main/agent-tools/pwragent-app-codex-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-app-codex-tools.ts
@@ -5,6 +5,7 @@ import type {
 import {
   PWRAGENT_APP_OPERATION_NAMES,
   PWRAGENT_APP_TOOL_NAMESPACE,
+  PWRAGENT_TOOL_NAMESPACE,
 } from "@pwragent/shared";
 import type {
   DynamicToolCallParams,
@@ -22,12 +23,15 @@ import {
 export function isPwrAgentAppDynamicToolCall(
   call: Pick<DynamicToolCallParams, "namespace" | "tool">,
 ): call is DynamicToolCallParams & {
-  namespace: typeof PWRAGENT_APP_TOOL_NAMESPACE;
+  namespace: typeof PWRAGENT_APP_TOOL_NAMESPACE | typeof PWRAGENT_TOOL_NAMESPACE;
   tool: PwrAgentAppOperationName;
 } {
   return (
-    call.namespace === PWRAGENT_APP_TOOL_NAMESPACE &&
-    PWRAGENT_APP_OPERATION_NAMES.includes(call.tool as PwrAgentAppOperationName)
+    call.namespace === PWRAGENT_APP_TOOL_NAMESPACE ||
+    (call.namespace === PWRAGENT_TOOL_NAMESPACE &&
+      PWRAGENT_APP_OPERATION_NAMES.includes(
+        call.tool as PwrAgentAppOperationName,
+      ))
   );
 }
 
@@ -36,9 +40,12 @@ export async function handlePwrAgentAppDynamicToolCall(params: {
   call: DynamicToolCallParams;
   handler: PwrAgentAppManagementHandler | undefined;
 }): Promise<DynamicToolCallResponse> {
+  const call = isPwrAgentAppDynamicToolCall(params.call)
+    ? { ...params.call, namespace: PWRAGENT_TOOL_NAMESPACE }
+    : params.call;
   return await buildPwrAgentAppToolRouter(params.handler).handleDynamicToolCall({
     backend: params.backend,
-    call: params.call,
+    call,
   });
 }
 

--- a/apps/desktop/src/main/agent-tools/pwragent-app-management-service.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-app-management-service.ts
@@ -1,0 +1,248 @@
+import { app } from "electron";
+import type {
+  PwrAgentAppManagementData,
+  PwrAgentAppRequest,
+  PwrAgentAppResponse,
+  PwrAgentUpdateToolStatus,
+} from "@pwragent/shared";
+import type {
+  AppUpdateCheckResult,
+  AppUpdateStatus,
+} from "../../shared/app-metadata";
+import {
+  checkForAppUpdatesNow,
+  installDownloadedAppUpdate,
+  readAppUpdateStatus,
+} from "../auto-updater";
+import { requestQuit } from "../quit-manager";
+
+export type PwrAgentAppManagementServiceOptions = {
+  now?: () => number;
+  requestRestart?: (performRestart: () => void) => Promise<boolean>;
+  requestStop?: (performStop: () => void) => Promise<boolean>;
+  startedAt: number;
+  version?: () => string;
+};
+
+const DEFER_QUIT_MS = 150;
+
+export function createPwrAgentAppManagementHandler(
+  options: PwrAgentAppManagementServiceOptions,
+) {
+  return async (request: PwrAgentAppRequest): Promise<PwrAgentAppResponse> => {
+    if (request.operation !== "manage_pwragent") {
+      return {
+        ok: false,
+        error: {
+          code: "unsupported_operation",
+          message: "Unsupported PwrAgent app management operation.",
+        },
+      };
+    }
+
+    const action = request.args.action;
+    try {
+      if (action === "upgrade_check") {
+        const check = await checkForAppUpdatesNow("manual");
+        return {
+          ok: true,
+          data: buildManagementData({
+            action,
+            check,
+            options,
+            result: { status: "check_completed", check: toToolUpdateStatus(check) },
+            updateStatus: toToolUpdateStatus(check),
+          }),
+        };
+      }
+
+      if (action === "restart") {
+        const status = readAppUpdateStatus();
+        if (status.status === "downloaded") {
+          const install = await installDownloadedAppUpdate({
+            requestQuit: async (performQuit) =>
+              await requestQuit({
+                performQuit: () => defer(performQuit),
+                source: "update-install",
+              }),
+          });
+          if (install.status === "error") {
+            return {
+              ok: true,
+              data: buildManagementData({
+                action,
+                options,
+                result: { status: "cancelled", message: install.message },
+                updateStatus: status,
+              }),
+            };
+          }
+          return {
+            ok: true,
+            data: buildManagementData({
+              action,
+              options,
+              result: {
+                status: "restart_accepted",
+                installingDownloadedUpdate: true,
+              },
+              updateStatus: status,
+            }),
+          };
+        }
+
+        const accepted = await (options.requestRestart ??
+          (async (performRestart) =>
+            await requestQuit({
+              performQuit: () => defer(performRestart),
+              source: "agent-tool",
+            })))(() => {
+          app.relaunch();
+          app.quit();
+        });
+        return {
+          ok: true,
+          data: buildManagementData({
+            action,
+            options,
+            result: accepted
+              ? {
+                  status: "restart_accepted",
+                  installingDownloadedUpdate: false,
+                }
+              : { status: "cancelled", message: "PwrAgent restart cancelled." },
+            updateStatus: status,
+          }),
+        };
+      }
+
+      if (action === "stop") {
+        const status = readAppUpdateStatus();
+        const accepted = await (options.requestStop ??
+          (async (performStop) =>
+            await requestQuit({
+              performQuit: () => defer(performStop),
+              source: "agent-tool",
+            })))(() => {
+          app.quit();
+        });
+        return {
+          ok: true,
+          data: buildManagementData({
+            action,
+            options,
+            result: accepted
+              ? { status: "stop_accepted" }
+              : { status: "cancelled", message: "PwrAgent stop cancelled." },
+            updateStatus: status,
+          }),
+        };
+      }
+
+      return {
+        ok: true,
+        data: buildManagementData({
+          action,
+          options,
+          result: { status: "reported" },
+          updateStatus: readAppUpdateStatus(),
+        }),
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        error: {
+          code: "internal_error",
+          message: error instanceof Error ? error.message : String(error),
+        },
+      };
+    }
+  };
+}
+
+function buildManagementData(params: {
+  action: PwrAgentAppManagementData["action"];
+  check?: AppUpdateCheckResult;
+  options: PwrAgentAppManagementServiceOptions;
+  result: PwrAgentAppManagementData["result"];
+  updateStatus: AppUpdateStatus | PwrAgentUpdateToolStatus;
+}): PwrAgentAppManagementData {
+  const status = toToolUpdateStatus(params.updateStatus);
+  return {
+    action: params.action,
+    runtime: buildRuntimeStatus(params.options),
+    update: {
+      status,
+      updateAvailableToDownload: status.status === "available",
+      updateDownloadedWillInstallOnRestart: status.status === "downloaded",
+    },
+    result: params.result,
+  };
+}
+
+function buildRuntimeStatus(
+  options: PwrAgentAppManagementServiceOptions,
+): PwrAgentAppManagementData["runtime"] {
+  const now = options.now?.() ?? Date.now();
+  const uptimeMs = Math.max(0, now - options.startedAt);
+  return {
+    currentVersion: options.version?.() ?? app.getVersion(),
+    startedAt: options.startedAt,
+    startedAtIso: new Date(options.startedAt).toISOString(),
+    startedAtLocal: formatLocalDateTime(options.startedAt),
+    now,
+    nowIso: new Date(now).toISOString(),
+    nowLocal: formatLocalDateTime(now),
+    uptimeMs,
+    uptimeHuman: formatDuration(uptimeMs),
+  };
+}
+
+function toToolUpdateStatus(
+  status: AppUpdateStatus | AppUpdateCheckResult | PwrAgentUpdateToolStatus,
+): PwrAgentUpdateToolStatus {
+  switch (status.status) {
+    case "idle":
+    case "checking":
+      return { status: status.status };
+    case "skipped":
+      return { status: "skipped", reason: status.reason };
+    case "no-update":
+    case "available":
+    case "downloaded":
+      return { status: status.status, version: status.version };
+    case "downloading":
+      return {
+        status: "downloading",
+        version: status.version,
+        ...(status.percent !== undefined ? { percent: status.percent } : {}),
+      };
+    case "error":
+      return { status: "error", message: status.message };
+  }
+}
+
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const days = Math.floor(totalSeconds / 86_400);
+  const hours = Math.floor((totalSeconds % 86_400) / 3_600);
+  const minutes = Math.floor((totalSeconds % 3_600) / 60);
+  const seconds = totalSeconds % 60;
+  const parts: string[] = [];
+  if (days) parts.push(`${days}d`);
+  if (hours || parts.length) parts.push(`${hours}h`);
+  if (minutes || parts.length) parts.push(`${minutes}m`);
+  parts.push(`${seconds}s`);
+  return parts.join(" ");
+}
+
+function formatLocalDateTime(timestamp: number): string {
+  return new Date(timestamp).toLocaleString(undefined, {
+    dateStyle: "medium",
+    timeStyle: "medium",
+  });
+}
+
+function defer(fn: () => void): void {
+  setTimeout(fn, DEFER_QUIT_MS).unref?.();
+}

--- a/apps/desktop/src/main/agent-tools/pwragent-messaging-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-messaging-agent-tools.ts
@@ -6,7 +6,7 @@ import type {
 import {
   PWRAGENT_MESSAGING_CALLABLE_OPERATION_NAMES,
   PWRAGENT_MESSAGING_OPERATION_NAMES,
-  PWRAGENT_MESSAGING_TOOL_NAMESPACE,
+  PWRAGENT_TOOL_NAMESPACE,
 } from "@pwragent/shared";
 import type {
   AgentToolDefinition,
@@ -27,9 +27,11 @@ export type PwrAgentMessagingHandler = (
 
 export function buildPwrAgentMessagingToolRouter(
   handler: PwrAgentMessagingHandler | undefined,
-  options: { unsupportedMessage?: string } = {},
+  options: { namespace?: string; unsupportedMessage?: string } = {},
 ): AgentToolRouter {
-  return new AgentToolRouter(buildPwrAgentMessagingToolDefinitions(handler), {
+  return new AgentToolRouter(buildPwrAgentMessagingToolDefinitions(handler, {
+    namespace: options.namespace,
+  }), {
     unsupportedMessage:
       options.unsupportedMessage ?? "Unsupported PwrAgent messaging tool.",
   });
@@ -37,9 +39,10 @@ export function buildPwrAgentMessagingToolRouter(
 
 export function buildPwrAgentMessagingToolDefinitions(
   handler: PwrAgentMessagingHandler | undefined,
+  options: { namespace?: string } = {},
 ): AgentToolDefinition<PwrAgentMessagingOperationName>[] {
   return PWRAGENT_MESSAGING_CALLABLE_OPERATION_NAMES.map((operation) => ({
-    namespace: PWRAGENT_MESSAGING_TOOL_NAMESPACE,
+    namespace: options.namespace ?? PWRAGENT_TOOL_NAMESPACE,
     name: operation,
     description: descriptionForOperation(operation),
     inputSchema: inputSchemaForOperation(operation),

--- a/apps/desktop/src/main/agent-tools/pwragent-messaging-codex-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-messaging-codex-tools.ts
@@ -5,6 +5,7 @@ import type {
 import {
   PWRAGENT_MESSAGING_CALLABLE_OPERATION_NAMES,
   PWRAGENT_MESSAGING_TOOL_NAMESPACE,
+  PWRAGENT_TOOL_NAMESPACE,
 } from "@pwragent/shared";
 import type {
   DynamicToolCallParams,
@@ -22,11 +23,14 @@ import {
 export function isPwrAgentMessagingDynamicToolCall(
   call: Pick<DynamicToolCallParams, "namespace" | "tool">,
 ): call is DynamicToolCallParams & {
-  namespace: typeof PWRAGENT_MESSAGING_TOOL_NAMESPACE;
+  namespace:
+    | typeof PWRAGENT_MESSAGING_TOOL_NAMESPACE
+    | typeof PWRAGENT_TOOL_NAMESPACE;
   tool: PwrAgentMessagingOperationName;
 } {
   return (
-    call.namespace === PWRAGENT_MESSAGING_TOOL_NAMESPACE &&
+    (call.namespace === PWRAGENT_MESSAGING_TOOL_NAMESPACE ||
+      call.namespace === PWRAGENT_TOOL_NAMESPACE) &&
     PWRAGENT_MESSAGING_CALLABLE_OPERATION_NAMES.includes(
       call.tool as PwrAgentMessagingOperationName,
     )
@@ -38,9 +42,12 @@ export async function handlePwrAgentMessagingDynamicToolCall(params: {
   call: DynamicToolCallParams;
   handler: PwrAgentMessagingHandler | undefined;
 }): Promise<DynamicToolCallResponse> {
+  const call = isPwrAgentMessagingDynamicToolCall(params.call)
+    ? { ...params.call, namespace: PWRAGENT_TOOL_NAMESPACE }
+    : params.call;
   return await buildPwrAgentMessagingToolRouter(params.handler).handleDynamicToolCall({
     backend: params.backend,
-    call: params.call,
+    call,
   });
 }
 

--- a/apps/desktop/src/main/agent-tools/pwragent-thread-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-thread-agent-tools.ts
@@ -5,7 +5,7 @@ import type {
 } from "@pwragent/shared";
 import {
   PWRAGENT_THREAD_INSPECTION_OPERATION_NAMES,
-  PWRAGENT_THREAD_TOOL_NAMESPACE,
+  PWRAGENT_TOOL_NAMESPACE,
 } from "@pwragent/shared";
 import type {
   AgentToolDefinition,
@@ -26,9 +26,11 @@ export type PwrAgentThreadInspectionHandler = (
 
 export function buildPwrAgentThreadToolRouter(
   handler: PwrAgentThreadInspectionHandler | undefined,
-  options: { unsupportedMessage?: string } = {},
+  options: { namespace?: string; unsupportedMessage?: string } = {},
 ): AgentToolRouter {
-  return new AgentToolRouter(buildPwrAgentThreadToolDefinitions(handler), {
+  return new AgentToolRouter(buildPwrAgentThreadToolDefinitions(handler, {
+    namespace: options.namespace,
+  }), {
     unsupportedMessage:
       options.unsupportedMessage ?? "Unsupported PwrAgent thread tool.",
   });
@@ -36,9 +38,10 @@ export function buildPwrAgentThreadToolRouter(
 
 export function buildPwrAgentThreadToolDefinitions(
   handler: PwrAgentThreadInspectionHandler | undefined,
+  options: { namespace?: string } = {},
 ): AgentToolDefinition<PwrAgentThreadInspectionOperationName>[] {
   return PWRAGENT_THREAD_INSPECTION_OPERATION_NAMES.map((operation) => ({
-    namespace: PWRAGENT_THREAD_TOOL_NAMESPACE,
+    namespace: options.namespace ?? PWRAGENT_TOOL_NAMESPACE,
     name: operation,
     description: descriptionForOperation(operation),
     inputSchema: inputSchemaForOperation(operation),

--- a/apps/desktop/src/main/agent-tools/pwragent-thread-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-thread-agent-tools.ts
@@ -72,6 +72,8 @@ function descriptionForOperation(
   switch (operation) {
     case "search_threads":
       return "Search known PwrAgent threads by title, summary, Agent metadata, backend, and linked directory. Omit query to inspect recent lightweight thread candidates before choosing a thread.";
+    case "read_thread":
+      return "Read a bounded page of another known PwrAgent thread's recent transcript and activity. Use search_threads first when the threadId is unknown.";
     case "get_thread_status":
       return "Read status and compact metadata for a known PwrAgent thread.";
     case "mutate_thread":
@@ -167,6 +169,52 @@ function inputSchemaForOperation(
             type: "string",
           },
           threadId: { type: "string" },
+        },
+      };
+    case "read_thread":
+      return {
+        type: "object",
+        additionalProperties: false,
+        required: ["backend", "threadId"],
+        properties: {
+          backend: {
+            type: "string",
+          },
+          threadId: { type: "string" },
+          before: {
+            type: "string",
+            description:
+              "Optional pagination cursor returned by a previous read_thread response.",
+          },
+          limit: {
+            type: "integer",
+            minimum: 1,
+            maximum: 20,
+            description:
+              "Maximum transcript entries to return. Defaults to 10.",
+          },
+          includeMessages: {
+            type: "boolean",
+            description:
+              "Whether to include normalized transcript messages. Defaults to true.",
+          },
+          includeEntries: {
+            type: "boolean",
+            description:
+              "Whether to include normalized timeline entries. Defaults to true.",
+          },
+          includeStatus: {
+            type: "boolean",
+            description:
+              "Whether to include current thread status when available. Defaults to true.",
+          },
+          maxCharsPerEntry: {
+            type: "integer",
+            minimum: 200,
+            maximum: 20000,
+            description:
+              "Maximum characters retained in each text-like transcript field. Defaults to 4000.",
+          },
         },
       };
     case "mutate_thread":

--- a/apps/desktop/src/main/agent-tools/pwragent-thread-codex-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-thread-codex-tools.ts
@@ -5,6 +5,7 @@ import type {
 import {
   PWRAGENT_THREAD_INSPECTION_OPERATION_NAMES,
   PWRAGENT_THREAD_TOOL_NAMESPACE,
+  PWRAGENT_TOOL_NAMESPACE,
 } from "@pwragent/shared";
 import type {
   DynamicToolCallParams,
@@ -22,14 +23,15 @@ import {
 export function isPwrAgentThreadDynamicToolCall(
   call: Pick<DynamicToolCallParams, "namespace" | "tool">,
 ): call is DynamicToolCallParams & {
-  namespace: typeof PWRAGENT_THREAD_TOOL_NAMESPACE;
+  namespace: typeof PWRAGENT_THREAD_TOOL_NAMESPACE | typeof PWRAGENT_TOOL_NAMESPACE;
   tool: PwrAgentThreadInspectionOperationName;
 } {
   return (
-    call.namespace === PWRAGENT_THREAD_TOOL_NAMESPACE &&
-    PWRAGENT_THREAD_INSPECTION_OPERATION_NAMES.includes(
-      call.tool as PwrAgentThreadInspectionOperationName,
-    )
+    call.namespace === PWRAGENT_THREAD_TOOL_NAMESPACE ||
+    (call.namespace === PWRAGENT_TOOL_NAMESPACE &&
+      PWRAGENT_THREAD_INSPECTION_OPERATION_NAMES.includes(
+        call.tool as PwrAgentThreadInspectionOperationName,
+      ))
   );
 }
 
@@ -38,9 +40,12 @@ export async function handlePwrAgentThreadDynamicToolCall(params: {
   call: DynamicToolCallParams;
   handler: PwrAgentThreadInspectionHandler | undefined;
 }): Promise<DynamicToolCallResponse> {
+  const call = isPwrAgentThreadDynamicToolCall(params.call)
+    ? { ...params.call, namespace: PWRAGENT_TOOL_NAMESPACE }
+    : params.call;
   return await buildPwrAgentThreadToolRouter(params.handler).handleDynamicToolCall({
     backend: params.backend,
-    call: params.call,
+    call,
   });
 }
 

--- a/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
@@ -1,0 +1,273 @@
+import type {
+  HandoffTaskGroupingMode,
+  HandoffTaskMessagingAttachmentMode,
+  HandoffTaskSeedMode,
+  HandoffTaskToolArgs,
+  HandoffTaskWorkspaceMode,
+  PwrAgentThreadOrchestrationOperationName,
+  PwrAgentThreadOrchestrationRequest,
+  PwrAgentThreadOrchestrationResponse,
+} from "@pwragent/shared";
+import {
+  HANDOFF_TASK_GROUPING_MODES,
+  HANDOFF_TASK_MESSAGING_ATTACHMENT_MODES,
+  HANDOFF_TASK_SEED_MODES,
+  HANDOFF_TASK_WORKSPACE_MODES,
+  PWRAGENT_THREAD_ORCHESTRATION_OPERATION_NAMES,
+  PWRAGENT_TOOL_NAMESPACE,
+} from "@pwragent/shared";
+import type {
+  AgentToolDefinition,
+  AgentToolDispatchResult,
+} from "./agent-tool-definition.js";
+import {
+  agentToolFailure,
+  agentToolSuccess,
+} from "./agent-tool-definition.js";
+import { AgentToolRouter } from "./agent-tool-router.js";
+
+export const PWRAGENT_THREAD_ORCHESTRATION_UNAVAILABLE_MESSAGE =
+  "PwrAgent thread handoff tools are not available.";
+
+export type PwrAgentThreadOrchestrationHandler = (
+  request: PwrAgentThreadOrchestrationRequest,
+) =>
+  | PwrAgentThreadOrchestrationResponse
+  | Promise<PwrAgentThreadOrchestrationResponse>;
+
+export function buildPwrAgentThreadOrchestrationToolRouter(
+  handler: PwrAgentThreadOrchestrationHandler | undefined,
+  options: { namespace?: string; unsupportedMessage?: string } = {},
+): AgentToolRouter {
+  return new AgentToolRouter(
+    buildPwrAgentThreadOrchestrationToolDefinitions(handler, {
+      namespace: options.namespace,
+    }),
+    {
+      unsupportedMessage:
+        options.unsupportedMessage ?? "Unsupported PwrAgent thread handoff tool.",
+    },
+  );
+}
+
+export function buildPwrAgentThreadOrchestrationToolDefinitions(
+  handler: PwrAgentThreadOrchestrationHandler | undefined,
+  options: { namespace?: string } = {},
+): AgentToolDefinition<PwrAgentThreadOrchestrationOperationName>[] {
+  return PWRAGENT_THREAD_ORCHESTRATION_OPERATION_NAMES.map((operation) => ({
+    namespace: options.namespace ?? PWRAGENT_TOOL_NAMESPACE,
+    name: operation,
+    description: descriptionForOperation(operation),
+    inputSchema: inputSchemaForOperation(operation),
+    deferLoading: false,
+    dispatch: async (args, context): Promise<AgentToolDispatchResult> => {
+      if (!handler) {
+        return agentToolFailure({
+          code: "internal_error",
+          message: PWRAGENT_THREAD_ORCHESTRATION_UNAVAILABLE_MESSAGE,
+        });
+      }
+      const normalizedArgs = normalizeHandoffTaskArgs(args);
+      if (!normalizedArgs) {
+        return agentToolFailure({
+          code: "invalid_arguments",
+          message: "handoff_task requires a non-empty task string.",
+        });
+      }
+      const response = await handler({
+        operation,
+        context: {
+          backend: context.backend,
+          threadId: context.threadId,
+          turnId: context.turnId,
+        },
+        args: normalizedArgs,
+      } as PwrAgentThreadOrchestrationRequest);
+      return threadOrchestrationResponseToAgentToolResult(response);
+    },
+  }));
+}
+
+function descriptionForOperation(
+  operation: PwrAgentThreadOrchestrationOperationName,
+): string {
+  switch (operation) {
+    case "handoff_task":
+      return "Create and start a new PwrAgent Agent thread for a delegated task. Use this when the user asks to hand off or delegate work to a new thread. Omitted settings inherit from the invoking Agent turn. Clean new-thread handoff is the default; use seedMode=fork only when the user asks to fork this thread, and groupingMode=subthread only when the user asks for a sub-thread.";
+  }
+}
+
+function inputSchemaForOperation(
+  operation: PwrAgentThreadOrchestrationOperationName,
+): Record<string, unknown> {
+  switch (operation) {
+    case "handoff_task":
+      return {
+        type: "object",
+        additionalProperties: false,
+        required: ["task"],
+        properties: {
+          task: {
+            type: "string",
+            description:
+              "The concrete task for the created thread to perform. Include the user's requested work, not the parent transcript.",
+          },
+          title: {
+            type: "string",
+            description:
+              "Optional short title for the created thread or handoff task.",
+          },
+          context: {
+            type: "string",
+            description:
+              "Optional bounded context the parent Agent wants to include in the created thread's first prompt.",
+          },
+          seedMode: {
+            type: "string",
+            enum: HANDOFF_TASK_SEED_MODES,
+            description:
+              "`clean` starts a fresh thread and is the default. `fork` copies the current thread transcript and should be used only when the user explicitly asks to fork this thread.",
+          },
+          groupingMode: {
+            type: "string",
+            enum: HANDOFF_TASK_GROUPING_MODES,
+            description:
+              "`none` leaves the created thread ungrouped and is the default. `subthread` groups it under the invoking thread only when the user asks for a sub-thread.",
+          },
+          workspaceMode: {
+            type: "string",
+            enum: HANDOFF_TASK_WORKSPACE_MODES,
+            description:
+              "`same` inherits the current workspace and is the default. `new_worktree` requests an isolated Git worktree. `none` allows a no-workspace thread.",
+          },
+          messagingAttachment: {
+            type: "string",
+            enum: HANDOFF_TASK_MESSAGING_ATTACHMENT_MODES,
+            description:
+              "Whether to attach the created thread to the current messaging location. Defaults to `auto` for messaging-originated turns and `none` otherwise.",
+          },
+          backend: { type: "string" },
+          model: { type: "string" },
+          reasoningEffort: { type: "string" },
+          serviceTier: { type: "string" },
+          fastMode: { type: "boolean" },
+          executionMode: { type: "string" },
+          approvalPolicy: { type: "string" },
+          sandbox: { type: "string" },
+          branchName: {
+            type: "string",
+            description:
+              "Optional branch name for an explicit new-worktree handoff.",
+          },
+        },
+      };
+  }
+}
+
+function normalizeHandoffTaskArgs(
+  args: Record<string, unknown>,
+): HandoffTaskToolArgs | undefined {
+  const task = readTrimmedString(args.task);
+  if (!task) {
+    return undefined;
+  }
+  return {
+    task,
+    ...(readTrimmedString(args.title)
+      ? { title: readTrimmedString(args.title) }
+      : {}),
+    ...(readTrimmedString(args.context)
+      ? { context: readTrimmedString(args.context) }
+      : {}),
+    ...(readChoice(args.seedMode, HANDOFF_TASK_SEED_MODES)
+      ? {
+          seedMode: readChoice(
+            args.seedMode,
+            HANDOFF_TASK_SEED_MODES,
+          ) as HandoffTaskSeedMode,
+        }
+      : {}),
+    ...(readChoice(args.groupingMode, HANDOFF_TASK_GROUPING_MODES)
+      ? {
+          groupingMode: readChoice(
+            args.groupingMode,
+            HANDOFF_TASK_GROUPING_MODES,
+          ) as HandoffTaskGroupingMode,
+        }
+      : {}),
+    ...(readChoice(args.workspaceMode, HANDOFF_TASK_WORKSPACE_MODES)
+      ? {
+          workspaceMode: readChoice(
+            args.workspaceMode,
+            HANDOFF_TASK_WORKSPACE_MODES,
+          ) as HandoffTaskWorkspaceMode,
+        }
+      : {}),
+    ...(readChoice(
+      args.messagingAttachment,
+      HANDOFF_TASK_MESSAGING_ATTACHMENT_MODES,
+    )
+      ? {
+          messagingAttachment: readChoice(
+            args.messagingAttachment,
+            HANDOFF_TASK_MESSAGING_ATTACHMENT_MODES,
+          ) as HandoffTaskMessagingAttachmentMode,
+        }
+      : {}),
+    ...(readTrimmedString(args.backend)
+      ? { backend: readTrimmedString(args.backend) as HandoffTaskToolArgs["backend"] }
+      : {}),
+    ...(readTrimmedString(args.model)
+      ? { model: readTrimmedString(args.model) }
+      : {}),
+    ...(readTrimmedString(args.reasoningEffort)
+      ? { reasoningEffort: readTrimmedString(args.reasoningEffort) }
+      : {}),
+    ...(readTrimmedString(args.serviceTier)
+      ? { serviceTier: readTrimmedString(args.serviceTier) }
+      : {}),
+    ...(typeof args.fastMode === "boolean" ? { fastMode: args.fastMode } : {}),
+    ...(readTrimmedString(args.executionMode)
+      ? {
+          executionMode: readTrimmedString(
+            args.executionMode,
+          ) as HandoffTaskToolArgs["executionMode"],
+        }
+      : {}),
+    ...(readTrimmedString(args.approvalPolicy)
+      ? { approvalPolicy: readTrimmedString(args.approvalPolicy) }
+      : {}),
+    ...(readTrimmedString(args.sandbox)
+      ? { sandbox: readTrimmedString(args.sandbox) }
+      : {}),
+    ...(readTrimmedString(args.branchName)
+      ? { branchName: readTrimmedString(args.branchName) }
+      : {}),
+  };
+}
+
+function readTrimmedString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function readChoice<TValue extends string>(
+  value: unknown,
+  choices: readonly TValue[],
+): TValue | undefined {
+  return typeof value === "string" && choices.includes(value as TValue)
+    ? (value as TValue)
+    : undefined;
+}
+
+function threadOrchestrationResponseToAgentToolResult(
+  response: PwrAgentThreadOrchestrationResponse,
+): AgentToolDispatchResult {
+  if (response.ok) {
+    return agentToolSuccess(response.data);
+  }
+  return agentToolFailure({
+    code: response.error.code,
+    message: response.error.message,
+    data: response.error.data,
+  });
+}

--- a/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
@@ -7,6 +7,7 @@ import type {
   PwrAgentThreadOrchestrationOperationName,
   PwrAgentThreadOrchestrationRequest,
   PwrAgentThreadOrchestrationResponse,
+  SendMessageToThreadToolArgs,
 } from "@pwragent/shared";
 import {
   HANDOFF_TASK_GROUPING_MODES,
@@ -67,11 +68,11 @@ export function buildPwrAgentThreadOrchestrationToolDefinitions(
           message: PWRAGENT_THREAD_ORCHESTRATION_UNAVAILABLE_MESSAGE,
         });
       }
-      const normalizedArgs = normalizeHandoffTaskArgs(args);
+      const normalizedArgs = normalizeArgsForOperation(operation, args);
       if (!normalizedArgs) {
         return agentToolFailure({
           code: "invalid_arguments",
-          message: "handoff_task requires a non-empty task string.",
+          message: invalidArgumentsMessageForOperation(operation),
         });
       }
       const response = await handler({
@@ -94,6 +95,8 @@ function descriptionForOperation(
   switch (operation) {
     case "handoff_task":
       return "Create and start a new PwrAgent Agent thread for a delegated task. Use this when the user asks to hand off or delegate work to a new thread. Omitted settings inherit from the invoking Agent turn. Clean new-thread handoff is the default; use seedMode=fork only when the user asks to fork this thread, and groupingMode=subthread only when the user asks for a sub-thread.";
+    case "send_message_to_thread":
+      return "Send a follow-up prompt to another existing PwrAgent thread. Use search_threads or read_thread first when the target threadId is unknown. Do not use this for the current thread; reply normally instead.";
   }
 }
 
@@ -161,6 +164,57 @@ function inputSchemaForOperation(
           },
         },
       };
+    case "send_message_to_thread":
+      return {
+        type: "object",
+        additionalProperties: false,
+        required: ["backend", "threadId", "prompt"],
+        properties: {
+          backend: {
+            type: "string",
+            description: "Backend that owns the target thread.",
+          },
+          threadId: {
+            type: "string",
+            description: "Existing target thread id that should receive the prompt.",
+          },
+          prompt: {
+            type: "string",
+            description:
+              "The follow-up message to send as a new turn in the target thread.",
+          },
+          model: { type: "string" },
+          reasoningEffort: { type: "string" },
+          serviceTier: { type: "string" },
+          fastMode: { type: "boolean" },
+          executionMode: { type: "string" },
+          approvalPolicy: { type: "string" },
+          sandbox: { type: "string" },
+        },
+      };
+  }
+}
+
+function normalizeArgsForOperation(
+  operation: PwrAgentThreadOrchestrationOperationName,
+  args: Record<string, unknown>,
+): HandoffTaskToolArgs | SendMessageToThreadToolArgs | undefined {
+  switch (operation) {
+    case "handoff_task":
+      return normalizeHandoffTaskArgs(args);
+    case "send_message_to_thread":
+      return normalizeSendMessageToThreadArgs(args);
+  }
+}
+
+function invalidArgumentsMessageForOperation(
+  operation: PwrAgentThreadOrchestrationOperationName,
+): string {
+  switch (operation) {
+    case "handoff_task":
+      return "handoff_task requires a non-empty task string.";
+    case "send_message_to_thread":
+      return "send_message_to_thread requires non-empty backend, threadId, and prompt strings.";
   }
 }
 
@@ -242,6 +296,45 @@ function normalizeHandoffTaskArgs(
       : {}),
     ...(readTrimmedString(args.branchName)
       ? { branchName: readTrimmedString(args.branchName) }
+      : {}),
+  };
+}
+
+function normalizeSendMessageToThreadArgs(
+  args: Record<string, unknown>,
+): SendMessageToThreadToolArgs | undefined {
+  const backend = readTrimmedString(args.backend);
+  const threadId = readTrimmedString(args.threadId);
+  const prompt = readTrimmedString(args.prompt);
+  if (!backend || !threadId || !prompt) {
+    return undefined;
+  }
+  return {
+    backend: backend as SendMessageToThreadToolArgs["backend"],
+    threadId,
+    prompt,
+    ...(readTrimmedString(args.model)
+      ? { model: readTrimmedString(args.model) }
+      : {}),
+    ...(readTrimmedString(args.reasoningEffort)
+      ? { reasoningEffort: readTrimmedString(args.reasoningEffort) }
+      : {}),
+    ...(readTrimmedString(args.serviceTier)
+      ? { serviceTier: readTrimmedString(args.serviceTier) }
+      : {}),
+    ...(typeof args.fastMode === "boolean" ? { fastMode: args.fastMode } : {}),
+    ...(readTrimmedString(args.executionMode)
+      ? {
+          executionMode: readTrimmedString(
+            args.executionMode,
+          ) as SendMessageToThreadToolArgs["executionMode"],
+        }
+      : {}),
+    ...(readTrimmedString(args.approvalPolicy)
+      ? { approvalPolicy: readTrimmedString(args.approvalPolicy) }
+      : {}),
+    ...(readTrimmedString(args.sandbox)
+      ? { sandbox: readTrimmedString(args.sandbox) }
       : {}),
   };
 }

--- a/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-codex-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-codex-tools.ts
@@ -1,0 +1,69 @@
+import type {
+  AppServerBackendKind,
+  PwrAgentThreadOrchestrationOperationName,
+} from "@pwragent/shared";
+import {
+  PWRAGENT_THREAD_ORCHESTRATION_OPERATION_NAMES,
+  PWRAGENT_TOOL_NAMESPACE,
+} from "@pwragent/shared";
+import type {
+  DynamicToolCallParams,
+  DynamicToolCallResponse,
+} from "@pwrdrvr/codex-app-server-protocol/v2";
+import {
+  readAgentDynamicToolCall,
+  toDynamicToolResponse,
+} from "./agent-tool-router.js";
+import {
+  buildPwrAgentThreadOrchestrationToolRouter,
+  type PwrAgentThreadOrchestrationHandler,
+} from "./pwragent-thread-orchestration-agent-tools.js";
+
+export function isPwrAgentThreadOrchestrationDynamicToolCall(
+  call: Pick<DynamicToolCallParams, "namespace" | "tool">,
+): call is DynamicToolCallParams & {
+  namespace: typeof PWRAGENT_TOOL_NAMESPACE;
+  tool: PwrAgentThreadOrchestrationOperationName;
+} {
+  return (
+    call.namespace === PWRAGENT_TOOL_NAMESPACE &&
+    PWRAGENT_THREAD_ORCHESTRATION_OPERATION_NAMES.includes(
+      call.tool as PwrAgentThreadOrchestrationOperationName,
+    )
+  );
+}
+
+export async function handlePwrAgentThreadOrchestrationDynamicToolCall(params: {
+  backend: AppServerBackendKind;
+  call: DynamicToolCallParams;
+  handler: PwrAgentThreadOrchestrationHandler | undefined;
+}): Promise<DynamicToolCallResponse> {
+  return await buildPwrAgentThreadOrchestrationToolRouter(
+    params.handler,
+  ).handleDynamicToolCall({
+    backend: params.backend,
+    call: params.call,
+  });
+}
+
+export function buildPwrAgentThreadOrchestrationDynamicToolErrorResponse(params: {
+  code:
+    | "forbidden"
+    | "internal_error"
+    | "unsupported_backend"
+    | "unsupported_operation";
+  message: string;
+}): DynamicToolCallResponse {
+  return toDynamicToolResponse({
+    ok: false,
+    code: params.code,
+    message: params.message,
+  });
+}
+
+export function readPwrAgentThreadOrchestrationDynamicToolCall(request: {
+  method: string;
+  params: Record<string, unknown>;
+}): DynamicToolCallParams | undefined {
+  return readAgentDynamicToolCall(request);
+}

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -14973,7 +14973,7 @@ export class DesktopBackendRegistry {
         });
         return toThreadInspectionSummaryFromSearchResult(
           result,
-          overlay?.agent,
+          overlay,
           messagingBindings,
         );
       }),
@@ -14993,7 +14993,7 @@ export class DesktopBackendRegistry {
           backend: thread.source,
           threadId: thread.id,
         });
-        return toThreadInspectionSummary(thread, overlay?.agent, messagingBindings);
+        return toThreadInspectionSummary(thread, overlay, messagingBindings);
       }),
     );
   }
@@ -15927,7 +15927,7 @@ function filterThreadInspectionSummaries(
 
 function toThreadInspectionSummary(
   thread: AppServerThreadSummary,
-  agent: ThreadAgentMetadata | undefined,
+  overlay: ThreadOverlayState | undefined,
   messagingBindings: MessagingThreadBindingSummary[] | undefined,
 ): ThreadInspectionSummary {
   return {
@@ -15939,7 +15939,8 @@ function toThreadInspectionSummary(
     createdAt: thread.createdAt,
     updatedAt: thread.updatedAt,
     archivedAt: thread.archivedAt,
-    agent,
+    agent: overlay?.agent,
+    handoffOrigin: overlay?.handoffOrigin,
     executionMode: thread.executionMode,
     model: thread.model,
     reasoningEffort: thread.reasoningEffort,
@@ -15952,7 +15953,7 @@ function toThreadInspectionSummary(
 
 function toThreadInspectionSummaryFromSearchResult(
   result: ThreadSearchResult,
-  agent: ThreadAgentMetadata | undefined,
+  overlay: ThreadOverlayState | undefined,
   messagingBindings: MessagingThreadBindingSummary[] | undefined,
 ): ThreadInspectionSummary {
   return {
@@ -15964,7 +15965,8 @@ function toThreadInspectionSummaryFromSearchResult(
     createdAt: result.createdAt,
     updatedAt: result.updatedAt,
     archivedAt: result.archivedAt,
-    agent,
+    agent: overlay?.agent,
+    handoffOrigin: overlay?.handoffOrigin,
     model: result.model,
     linkedDirectories: result.linkedDirectories,
     ...(messagingBindings?.length ? { messagingBindings } : {}),

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -13605,21 +13605,6 @@ export class DesktopBackendRegistry {
             "Automation inspection tool calls must originate from an active turn on the same thread.",
         });
       }
-      if (!(await this.isAgentThreadForDynamicToolCall(backend, dynamicToolCall))) {
-        backendRegistryLog.warn("rejecting automation inspection dynamic tool call from non-Agent thread", {
-          backend,
-          callId: dynamicToolCall.callId,
-          namespace: dynamicToolCall.namespace,
-          threadId: dynamicToolCall.threadId,
-          tool: dynamicToolCall.tool,
-          turnId: dynamicToolCall.turnId,
-        });
-        return buildAutomationInspectionDynamicToolErrorResponse({
-          code: "forbidden",
-          message:
-            "Automation inspection tools are available only to Agent threads.",
-        });
-      }
       backendRegistryLog.info("handling automation inspection dynamic tool call", {
         backend,
         callId: dynamicToolCall.callId,
@@ -13654,21 +13639,6 @@ export class DesktopBackendRegistry {
             "Thread inspection tool calls must originate from an active turn on the same thread.",
         });
       }
-      if (!(await this.isAgentThreadForDynamicToolCall(backend, threadToolCall))) {
-        backendRegistryLog.warn("rejecting thread inspection dynamic tool call from non-Agent thread", {
-          backend,
-          callId: threadToolCall.callId,
-          namespace: threadToolCall.namespace,
-          threadId: threadToolCall.threadId,
-          tool: threadToolCall.tool,
-          turnId: threadToolCall.turnId,
-        });
-        return buildPwrAgentThreadDynamicToolErrorResponse({
-          code: "forbidden",
-          message:
-            "Thread inspection tools are available only to Agent threads.",
-        });
-      }
       backendRegistryLog.info("handling thread inspection dynamic tool call", {
         backend,
         callId: threadToolCall.callId,
@@ -13700,21 +13670,7 @@ export class DesktopBackendRegistry {
         return buildPwrAgentAppDynamicToolErrorResponse({
           code: "forbidden",
           message:
-            "App management tool calls must originate from an active Agent turn on the same thread.",
-        });
-      }
-      if (!(await this.isAgentThreadForDynamicToolCall(backend, appToolCall))) {
-        backendRegistryLog.warn("rejecting app management dynamic tool call from non-Agent thread", {
-          backend,
-          callId: appToolCall.callId,
-          namespace: appToolCall.namespace,
-          threadId: appToolCall.threadId,
-          tool: appToolCall.tool,
-          turnId: appToolCall.turnId,
-        });
-        return buildPwrAgentAppDynamicToolErrorResponse({
-          code: "forbidden",
-          message: "App management tools are available only to Agent threads.",
+            "App management tool calls must originate from an active turn on the same thread.",
         });
       }
       backendRegistryLog.info("handling app management dynamic tool call", {
@@ -13753,26 +13709,7 @@ export class DesktopBackendRegistry {
         return buildPwrAgentThreadOrchestrationDynamicToolErrorResponse({
           code: "forbidden",
           message:
-            "Thread handoff tool calls must originate from an active Agent turn on the same thread.",
-        });
-      }
-      if (
-        !(await this.isAgentThreadForDynamicToolCall(
-          backend,
-          threadOrchestrationToolCall,
-        ))
-      ) {
-        backendRegistryLog.warn("rejecting thread orchestration dynamic tool call from non-Agent thread", {
-          backend,
-          callId: threadOrchestrationToolCall.callId,
-          namespace: threadOrchestrationToolCall.namespace,
-          threadId: threadOrchestrationToolCall.threadId,
-          tool: threadOrchestrationToolCall.tool,
-          turnId: threadOrchestrationToolCall.turnId,
-        });
-        return buildPwrAgentThreadOrchestrationDynamicToolErrorResponse({
-          code: "forbidden",
-          message: "Thread handoff tools are available only to Agent threads.",
+            "Thread handoff tool calls must originate from an active turn on the same thread.",
         });
       }
       backendRegistryLog.info("handling thread orchestration dynamic tool call", {
@@ -13810,21 +13747,7 @@ export class DesktopBackendRegistry {
         return buildPwrAgentMessagingDynamicToolErrorResponse({
           code: "forbidden",
           message:
-            "Messaging context tool calls must originate from an active turn on the same Agent thread.",
-        });
-      }
-      if (!(await this.isAgentThreadForDynamicToolCall(backend, messagingToolCall))) {
-        backendRegistryLog.warn("rejecting messaging context dynamic tool call from non-Agent thread", {
-          backend,
-          callId: messagingToolCall.callId,
-          namespace: messagingToolCall.namespace,
-          threadId: messagingToolCall.threadId,
-          tool: messagingToolCall.tool,
-          turnId: messagingToolCall.turnId,
-        });
-        return buildPwrAgentMessagingDynamicToolErrorResponse({
-          code: "forbidden",
-          message: "Messaging context tools are available only to Agent threads.",
+            "Messaging context tool calls must originate from an active turn on the same thread.",
         });
       }
       backendRegistryLog.info("handling messaging context dynamic tool call", {
@@ -13945,17 +13868,6 @@ export class DesktopBackendRegistry {
     return this.activeTurnKeys.has(buildActiveTurnKey(backend, call.threadId, turnId));
   }
 
-  private async isAgentThreadForDynamicToolCall(
-    backend: AppServerBackendKind,
-    call: { threadId: string },
-  ): Promise<boolean> {
-    const overlay = await this.overlayStore.getThreadOverlayState({
-      backend,
-      threadId: call.threadId,
-    });
-    return Boolean(overlay?.agent);
-  }
-
   private async handleThreadOrchestrationRequest(
     request: PwrAgentThreadOrchestrationRequest,
   ): Promise<PwrAgentThreadOrchestrationResponse> {
@@ -13983,13 +13895,13 @@ export class DesktopBackendRegistry {
     ) {
       return threadOrchestrationFailure(
         "forbidden",
-        "Thread handoff tools must be invoked from a live Agent turn.",
+        "Thread handoff tools must be invoked from a live turn.",
       );
     }
     if (sourceBackend !== "codex") {
       return threadOrchestrationFailure(
         "unsupported_backend",
-        "Thread handoff tools are currently available only from Codex Agent threads.",
+        "Thread handoff tools are currently available only from Codex threads.",
       );
     }
 
@@ -14001,16 +13913,16 @@ export class DesktopBackendRegistry {
       );
     }
 
-    const sourceOverlay = await this.overlayStore.getThreadOverlayState({
-      backend: sourceBackend,
-      threadId: sourceThreadId,
-    });
-    if (!sourceOverlay?.agent) {
-      return threadOrchestrationFailure(
-        "forbidden",
-        "Thread handoff tools are available only to Agent threads.",
-      );
-    }
+    const sourceOverlay =
+      (await this.overlayStore.getThreadOverlayState({
+        backend: sourceBackend,
+        threadId: sourceThreadId,
+      })) ??
+      ({
+        backend: sourceBackend,
+        threadId: sourceThreadId,
+        extraLinkedDirectories: [],
+      } satisfies ThreadOverlayState);
 
     const task = request.args.task.trim();
     if (!task) {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6831,7 +6831,6 @@ export class DesktopBackendRegistry {
       runtime: acpRuntimeWithModel,
     });
     const agentToolCatalogs = resolveAgentToolCatalogs({
-      agent: request.agent,
       appManagementHandler: this.appManagementHandler,
       automationInspectionHandler: this.automationInspectionHandler,
       messagingHandler: this.messagingHandler,
@@ -7409,7 +7408,6 @@ export class DesktopBackendRegistry {
               const effectiveMode = params.executionMode ?? mode;
               const modeSettings = EXECUTION_MODE_SUMMARIES[effectiveMode];
               const agentToolCatalogs = resolveAgentToolCatalogs({
-                agent: overlay?.agent,
                 appManagementHandler: this.appManagementHandler,
                 automationInspectionHandler: this.automationInspectionHandler,
                 messagingHandler: this.messagingHandler,
@@ -13607,6 +13605,21 @@ export class DesktopBackendRegistry {
             "Automation inspection tool calls must originate from an active turn on the same thread.",
         });
       }
+      if (!(await this.isAgentThreadForDynamicToolCall(backend, dynamicToolCall))) {
+        backendRegistryLog.warn("rejecting automation inspection dynamic tool call from non-Agent thread", {
+          backend,
+          callId: dynamicToolCall.callId,
+          namespace: dynamicToolCall.namespace,
+          threadId: dynamicToolCall.threadId,
+          tool: dynamicToolCall.tool,
+          turnId: dynamicToolCall.turnId,
+        });
+        return buildAutomationInspectionDynamicToolErrorResponse({
+          code: "forbidden",
+          message:
+            "Automation inspection tools are available only to Agent threads.",
+        });
+      }
       backendRegistryLog.info("handling automation inspection dynamic tool call", {
         backend,
         callId: dynamicToolCall.callId,
@@ -13641,6 +13654,21 @@ export class DesktopBackendRegistry {
             "Thread inspection tool calls must originate from an active turn on the same thread.",
         });
       }
+      if (!(await this.isAgentThreadForDynamicToolCall(backend, threadToolCall))) {
+        backendRegistryLog.warn("rejecting thread inspection dynamic tool call from non-Agent thread", {
+          backend,
+          callId: threadToolCall.callId,
+          namespace: threadToolCall.namespace,
+          threadId: threadToolCall.threadId,
+          tool: threadToolCall.tool,
+          turnId: threadToolCall.turnId,
+        });
+        return buildPwrAgentThreadDynamicToolErrorResponse({
+          code: "forbidden",
+          message:
+            "Thread inspection tools are available only to Agent threads.",
+        });
+      }
       backendRegistryLog.info("handling thread inspection dynamic tool call", {
         backend,
         callId: threadToolCall.callId,
@@ -13673,6 +13701,20 @@ export class DesktopBackendRegistry {
           code: "forbidden",
           message:
             "App management tool calls must originate from an active Agent turn on the same thread.",
+        });
+      }
+      if (!(await this.isAgentThreadForDynamicToolCall(backend, appToolCall))) {
+        backendRegistryLog.warn("rejecting app management dynamic tool call from non-Agent thread", {
+          backend,
+          callId: appToolCall.callId,
+          namespace: appToolCall.namespace,
+          threadId: appToolCall.threadId,
+          tool: appToolCall.tool,
+          turnId: appToolCall.turnId,
+        });
+        return buildPwrAgentAppDynamicToolErrorResponse({
+          code: "forbidden",
+          message: "App management tools are available only to Agent threads.",
         });
       }
       backendRegistryLog.info("handling app management dynamic tool call", {
@@ -13714,6 +13756,25 @@ export class DesktopBackendRegistry {
             "Thread handoff tool calls must originate from an active Agent turn on the same thread.",
         });
       }
+      if (
+        !(await this.isAgentThreadForDynamicToolCall(
+          backend,
+          threadOrchestrationToolCall,
+        ))
+      ) {
+        backendRegistryLog.warn("rejecting thread orchestration dynamic tool call from non-Agent thread", {
+          backend,
+          callId: threadOrchestrationToolCall.callId,
+          namespace: threadOrchestrationToolCall.namespace,
+          threadId: threadOrchestrationToolCall.threadId,
+          tool: threadOrchestrationToolCall.tool,
+          turnId: threadOrchestrationToolCall.turnId,
+        });
+        return buildPwrAgentThreadOrchestrationDynamicToolErrorResponse({
+          code: "forbidden",
+          message: "Thread handoff tools are available only to Agent threads.",
+        });
+      }
       backendRegistryLog.info("handling thread orchestration dynamic tool call", {
         backend,
         callId: threadOrchestrationToolCall.callId,
@@ -13750,6 +13811,20 @@ export class DesktopBackendRegistry {
           code: "forbidden",
           message:
             "Messaging context tool calls must originate from an active turn on the same Agent thread.",
+        });
+      }
+      if (!(await this.isAgentThreadForDynamicToolCall(backend, messagingToolCall))) {
+        backendRegistryLog.warn("rejecting messaging context dynamic tool call from non-Agent thread", {
+          backend,
+          callId: messagingToolCall.callId,
+          namespace: messagingToolCall.namespace,
+          threadId: messagingToolCall.threadId,
+          tool: messagingToolCall.tool,
+          turnId: messagingToolCall.turnId,
+        });
+        return buildPwrAgentMessagingDynamicToolErrorResponse({
+          code: "forbidden",
+          message: "Messaging context tools are available only to Agent threads.",
         });
       }
       backendRegistryLog.info("handling messaging context dynamic tool call", {
@@ -13868,6 +13943,17 @@ export class DesktopBackendRegistry {
     const turnId = call.turnId?.trim();
     if (!turnId) return false;
     return this.activeTurnKeys.has(buildActiveTurnKey(backend, call.threadId, turnId));
+  }
+
+  private async isAgentThreadForDynamicToolCall(
+    backend: AppServerBackendKind,
+    call: { threadId: string },
+  ): Promise<boolean> {
+    const overlay = await this.overlayStore.getThreadOverlayState({
+      backend,
+      threadId: call.threadId,
+    });
+    return Boolean(overlay?.agent);
   }
 
   private async handleThreadOrchestrationRequest(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -149,9 +149,6 @@ import {
   DEFAULT_THREAD_INSPECTION_RECENT_LIMIT,
   DEFAULT_THREAD_INSPECTION_SEARCH_LIMIT,
   MAX_THREAD_INSPECTION_SEARCH_LIMIT,
-  PWRAGENT_APP_TOOL_NAMESPACE,
-  PWRAGENT_MESSAGING_TOOL_NAMESPACE,
-  PWRAGENT_THREAD_TOOL_NAMESPACE,
   isThreadSearchContentMode,
   isThreadSearchSemanticMode,
   type PendingRequestDecision,
@@ -161,7 +158,6 @@ import {
   DEFAULT_TASK_MONITOR_POLL_INTERVAL_SECONDS,
   DEFAULT_TASK_MONITOR_REASONING_EFFORT,
   DEFAULT_TASK_MONITOR_STARTUP_TIMEOUT_SECONDS,
-  TASK_MONITOR_TOOL_NAMESPACE,
   type CompleteMonitoringToolArgs,
   type CreateMonitorDelegationToolArgs,
   type InjectMonitorProgressToolArgs,
@@ -198,6 +194,7 @@ import { GrokAppServerClient } from "../grok-app-server/client";
 import {
   buildAutomationInspectionDynamicToolErrorResponse,
   handleAutomationInspectionDynamicToolCall,
+  isAutomationInspectionDynamicToolCall,
   readAutomationInspectionDynamicToolCall,
   type AutomationInspectionHandler,
 } from "../automations/automation-inspection-codex-tools";
@@ -208,6 +205,7 @@ import {
   buildTaskMonitorDynamicToolSpecs,
   findUnsupportedCodexExecSessionReference,
   handleTaskMonitorDynamicToolCall,
+  isTaskMonitorDynamicToolCall,
   normalizeHeartbeatIntervalSeconds,
   normalizePollIntervalSeconds,
   normalizePreferredMonitorModel,
@@ -217,18 +215,21 @@ import {
 import {
   buildPwrAgentAppDynamicToolErrorResponse,
   handlePwrAgentAppDynamicToolCall,
+  isPwrAgentAppDynamicToolCall,
   readPwrAgentAppDynamicToolCall,
 } from "../agent-tools/pwragent-app-codex-tools";
 import type { PwrAgentAppManagementHandler } from "../agent-tools/pwragent-app-agent-tools";
 import {
   buildPwrAgentThreadDynamicToolErrorResponse,
   handlePwrAgentThreadDynamicToolCall,
+  isPwrAgentThreadDynamicToolCall,
   readPwrAgentThreadDynamicToolCall,
 } from "../agent-tools/pwragent-thread-codex-tools";
 import type { PwrAgentThreadInspectionHandler } from "../agent-tools/pwragent-thread-agent-tools";
 import {
   buildPwrAgentMessagingDynamicToolErrorResponse,
   handlePwrAgentMessagingDynamicToolCall,
+  isPwrAgentMessagingDynamicToolCall,
   readPwrAgentMessagingDynamicToolCall,
 } from "../agent-tools/pwragent-messaging-codex-tools";
 import type { PwrAgentMessagingHandler } from "../agent-tools/pwragent-messaging-agent-tools";
@@ -2251,13 +2252,13 @@ function buildTaskMonitorRecoveryPrompt(params: {
   return [
     "PwrAgent monitor recovery instruction:",
     "",
-    `The previous monitor turn ended with status \"${params.terminalStatus}\" before it called pwragent_task_monitors.complete_monitoring.`,
+    `The previous monitor turn ended with status \"${params.terminalStatus}\" before it called pwragent.complete_monitoring.`,
     "You must now report the final monitor result. Use only the monitor task context you already have.",
     "",
     `Monitor id: ${params.monitorId}`,
     `Task: ${params.task}`,
     "",
-    "Call pwragent_task_monitors.complete_monitoring exactly once.",
+    "Call pwragent.complete_monitoring exactly once.",
     "If you cannot determine a successful final outcome from the context you have, use outcome \"failure\" and explain that monitoring ended without a determinate result.",
     "Do not sleep, poll indefinitely, or do unrelated work in this recovery turn.",
   ].join("\n");
@@ -13474,7 +13475,10 @@ export class DesktopBackendRegistry {
       method: request.method,
       params: request.params,
     });
-    if (dynamicToolCall?.namespace === "pwragent_automations") {
+    if (
+      dynamicToolCall &&
+      isAutomationInspectionDynamicToolCall(dynamicToolCall)
+    ) {
       if (!this.isLiveDynamicToolCall(backend, dynamicToolCall)) {
         backendRegistryLog.warn("rejecting automation inspection dynamic tool call", {
           backend,
@@ -13508,7 +13512,7 @@ export class DesktopBackendRegistry {
       method: request.method,
       params: request.params,
     });
-    if (threadToolCall?.namespace === PWRAGENT_THREAD_TOOL_NAMESPACE) {
+    if (threadToolCall && isPwrAgentThreadDynamicToolCall(threadToolCall)) {
       if (!this.isLiveDynamicToolCall(backend, threadToolCall)) {
         backendRegistryLog.warn("rejecting thread inspection dynamic tool call", {
           backend,
@@ -13542,7 +13546,7 @@ export class DesktopBackendRegistry {
       method: request.method,
       params: request.params,
     });
-    if (appToolCall?.namespace === PWRAGENT_APP_TOOL_NAMESPACE) {
+    if (appToolCall && isPwrAgentAppDynamicToolCall(appToolCall)) {
       if (!this.isLiveDynamicToolCall(backend, appToolCall)) {
         backendRegistryLog.warn("rejecting app management dynamic tool call", {
           backend,
@@ -13577,7 +13581,10 @@ export class DesktopBackendRegistry {
       method: request.method,
       params: request.params,
     });
-    if (messagingToolCall?.namespace === PWRAGENT_MESSAGING_TOOL_NAMESPACE) {
+    if (
+      messagingToolCall &&
+      isPwrAgentMessagingDynamicToolCall(messagingToolCall)
+    ) {
       if (!this.isLiveDynamicToolCall(backend, messagingToolCall)) {
         backendRegistryLog.warn("rejecting messaging context dynamic tool call", {
           backend,
@@ -13612,7 +13619,7 @@ export class DesktopBackendRegistry {
       method: request.method,
       params: request.params,
     });
-    if (taskMonitorToolCall?.namespace === TASK_MONITOR_TOOL_NAMESPACE) {
+    if (taskMonitorToolCall && isTaskMonitorDynamicToolCall(taskMonitorToolCall)) {
       if (backend !== "codex") {
         return buildTaskMonitorDynamicToolErrorResponse({
           code: "forbidden",
@@ -14414,7 +14421,7 @@ export class DesktopBackendRegistry {
     await this.finishTaskMonitorDelegation({
       completionSource,
       details: [
-        "PwrAgent generated this fallback because the monitor subagent stopped without invoking pwragent_task_monitors.complete_monitoring.",
+        "PwrAgent generated this fallback because the monitor subagent stopped without invoking pwragent.complete_monitoring.",
         `Fallback reason: ${params.reason}.`,
         params.terminalStatus
           ? `Last monitor turn status: ${params.terminalStatus}.`

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -33,6 +33,7 @@ import {
   type AppServerReadThreadResponse,
   type AppServerThreadActivityEntry,
   type AppServerThreadEntry,
+  type AppServerThreadMessage,
   type AppServerThreadReplay,
   type AppServerThreadStatus,
   type AppServerThreadSummary,
@@ -112,8 +113,11 @@ import {
   type ThreadAgentMetadata,
   type MessagingThreadBindingSummary,
   type MutateThreadToolArgs,
+  type ReadThreadToolArgs,
   type PwrAgentThreadInspectionRequest,
   type PwrAgentThreadInspectionResponse,
+  type ThreadReadEntrySummary,
+  type ThreadReadMessageSummary,
   type ThreadMutationAppliedChange,
   type PwrAgentThreadOrchestrationErrorCode,
   type PwrAgentThreadOrchestrationRequest,
@@ -13871,13 +13875,108 @@ export class DesktopBackendRegistry {
   private async handleThreadOrchestrationRequest(
     request: PwrAgentThreadOrchestrationRequest,
   ): Promise<PwrAgentThreadOrchestrationResponse> {
-    if (request.operation !== "handoff_task") {
+    if (request.operation === "handoff_task") {
+      return await this.handoffTaskToThread(request);
+    }
+    if (request.operation === "send_message_to_thread") {
+      return await this.sendMessageToThread(request);
+    }
+    return threadOrchestrationFailure(
+      "unsupported_operation",
+      "Unsupported PwrAgent thread orchestration operation.",
+    );
+  }
+
+  private async sendMessageToThread(
+    request: PwrAgentThreadOrchestrationRequest<"send_message_to_thread">,
+  ): Promise<PwrAgentThreadOrchestrationResponse> {
+    const sourceTurnId = request.context.turnId?.trim();
+    if (
+      !sourceTurnId ||
+      !this.isLiveDynamicToolCall(request.context.backend, {
+        threadId: request.context.threadId,
+        turnId: sourceTurnId,
+      })
+    ) {
       return threadOrchestrationFailure(
-        "unsupported_operation",
-        "Unsupported PwrAgent thread orchestration operation.",
+        "forbidden",
+        "Thread orchestration tools must be invoked from a live turn.",
       );
     }
-    return await this.handoffTaskToThread(request);
+    const backend = request.args.backend;
+    if (!isAppServerBackendKind(backend)) {
+      return threadOrchestrationFailure(
+        "invalid_arguments",
+        "backend must be a known PwrAgent backend.",
+      );
+    }
+    const threadId = request.args.threadId.trim();
+    const prompt = request.args.prompt.trim();
+    if (!threadId || !prompt) {
+      return threadOrchestrationFailure(
+        "invalid_arguments",
+        "send_message_to_thread requires non-empty threadId and prompt strings.",
+      );
+    }
+    if (
+      backend === request.context.backend &&
+      threadId === request.context.threadId
+    ) {
+      return threadOrchestrationFailure(
+        "forbidden",
+        "send_message_to_thread targets another thread. Continue the current thread by replying normally.",
+      );
+    }
+
+    try {
+      const settings = {
+        ...(request.args.executionMode
+          ? { executionMode: request.args.executionMode }
+          : {}),
+        ...(request.args.model ? { model: request.args.model } : {}),
+        ...(request.args.reasoningEffort
+          ? { reasoningEffort: request.args.reasoningEffort }
+          : {}),
+        ...(request.args.serviceTier
+          ? { serviceTier: request.args.serviceTier }
+          : {}),
+        ...(Object.hasOwn(request.args, "fastMode")
+          ? { fastMode: request.args.fastMode }
+          : {}),
+        ...(request.args.approvalPolicy
+          ? { approvalPolicy: request.args.approvalPolicy }
+          : {}),
+        ...(request.args.sandbox ? { sandbox: request.args.sandbox } : {}),
+      };
+      const turn = await this.startTurn({
+        backend,
+        threadId,
+        input: [{ type: "text", text: prompt }],
+        executionMode: request.args.executionMode,
+        model: request.args.model,
+        reasoningEffort: request.args.reasoningEffort,
+        serviceTier: request.args.serviceTier,
+        fastMode: request.args.fastMode,
+        approvalPolicy: request.args.approvalPolicy,
+        sandbox: request.args.sandbox,
+      });
+      return {
+        ok: true,
+        data: {
+          backend,
+          threadId: turn.threadId,
+          turnId: turn.turnId,
+          promptPreview: truncateThreadInspectionText(prompt, 240),
+          settings,
+        },
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return threadOrchestrationFailure(
+        /not found/i.test(message) ? "not_found" : "turn_start_failed",
+        message,
+      );
+    }
   }
 
   private async handoffTaskToThread(
@@ -15398,6 +15497,10 @@ export class DesktopBackendRegistry {
       };
     }
 
+    if (request.operation === "read_thread") {
+      return await this.handleReadThreadInspectionRequest(request.args);
+    }
+
     if (request.operation === "mutate_thread") {
       return await this.handleMutateThreadInspectionRequest(request.args);
     }
@@ -15544,6 +15647,114 @@ export class DesktopBackendRegistry {
         },
       },
     };
+  }
+
+  private async handleReadThreadInspectionRequest(
+    args: ReadThreadToolArgs,
+  ): Promise<PwrAgentThreadInspectionResponse> {
+    if (!isAppServerBackendKind(args.backend)) {
+      return {
+        ok: false,
+        error: {
+          code: "invalid_arguments",
+          message: "backend must be a known PwrAgent backend.",
+        },
+      };
+    }
+    const threadId = args.threadId?.trim();
+    if (!threadId) {
+      return {
+        ok: false,
+        error: {
+          code: "invalid_arguments",
+          message: "threadId is required.",
+        },
+      };
+    }
+    const before = args.before?.trim();
+    const limit = clampInteger(
+      args.limit,
+      DEFAULT_THREAD_INSPECTION_READ_LIMIT,
+      MAX_THREAD_INSPECTION_READ_LIMIT,
+    );
+    const maxCharsPerEntry = clampInteger(
+      args.maxCharsPerEntry,
+      DEFAULT_THREAD_INSPECTION_READ_ENTRY_CHARS,
+      MAX_THREAD_INSPECTION_READ_ENTRY_CHARS,
+    );
+
+    try {
+      const response = await this.readThread({
+        backend: args.backend,
+        threadId,
+        includeTurns: true,
+        ...(before ? { before } : {}),
+        limit,
+      });
+      const replay = response.replay;
+      const status = response.threadStatus ?? replay.threadStatus;
+      return {
+        ok: true,
+        data: {
+          read: {
+            backend: args.backend,
+            threadId,
+            limit,
+            ...(before ? { before } : {}),
+            maxCharsPerEntry,
+            ...(args.includeEntries === false
+              ? {}
+              : {
+                  entries: replay.entries
+                    .slice(0, limit)
+                    .map((entry) =>
+                      toThreadReadEntrySummary(entry, maxCharsPerEntry),
+                    ),
+                }),
+            ...(args.includeMessages === false
+              ? {}
+              : {
+                  messages: replay.messages
+                    .slice(0, limit)
+                    .map((message) =>
+                      toThreadReadMessageSummary(message, maxCharsPerEntry),
+                    ),
+                }),
+            ...(replay.lastUserMessage
+              ? {
+                  lastUserMessage: truncateThreadInspectionText(
+                    replay.lastUserMessage,
+                    maxCharsPerEntry,
+                  ),
+                }
+              : {}),
+            ...(replay.lastAssistantMessage
+              ? {
+                  lastAssistantMessage: truncateThreadInspectionText(
+                    replay.lastAssistantMessage,
+                    maxCharsPerEntry,
+                  ),
+                }
+              : {}),
+            pagination: replay.pagination,
+            ...(args.includeStatus === false
+              ? {}
+              : status
+                ? { status }
+                : {}),
+          },
+        },
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        ok: false,
+        error: {
+          code: /not found/i.test(message) ? "not_found" : "internal_error",
+          message,
+        },
+      };
+    }
   }
 
   private getThreadInspectionSearchService(): ThreadSearchService | null {
@@ -16459,6 +16670,164 @@ function readThreadInspectionBackend(
     : undefined;
 }
 
+const DEFAULT_THREAD_INSPECTION_READ_LIMIT = 10;
+const MAX_THREAD_INSPECTION_READ_LIMIT = 20;
+const DEFAULT_THREAD_INSPECTION_READ_ENTRY_CHARS = 4_000;
+const MAX_THREAD_INSPECTION_READ_ENTRY_CHARS = 20_000;
+
+function toThreadReadMessageSummary(
+  message: AppServerThreadMessage,
+  maxCharsPerEntry: number,
+): ThreadReadMessageSummary {
+  const text = truncateThreadInspectionTextWithFlag(
+    message.text,
+    maxCharsPerEntry,
+  );
+  return {
+    id: message.id,
+    role: message.role,
+    ...(message.createdAt !== undefined ? { createdAt: message.createdAt } : {}),
+    text: text.value,
+    ...(text.truncated ? { truncated: true } : {}),
+  };
+}
+
+function toThreadReadEntrySummary(
+  entry: AppServerThreadEntry,
+  maxCharsPerEntry: number,
+): ThreadReadEntrySummary {
+  switch (entry.type) {
+    case "message": {
+      const text = truncateThreadInspectionTextWithFlag(
+        entry.text,
+        maxCharsPerEntry,
+      );
+      return {
+        type: "message",
+        id: entry.id,
+        role: entry.role,
+        text: text.value,
+        ...(entry.createdAt !== undefined ? { createdAt: entry.createdAt } : {}),
+        ...(entry.phase ? { phase: entry.phase } : {}),
+        ...(entry.turn ? { turn: entry.turn } : {}),
+        ...(text.truncated ? { truncated: true } : {}),
+      };
+    }
+    case "activity": {
+      const summary = truncateThreadInspectionTextWithFlag(
+        entry.summary,
+        maxCharsPerEntry,
+      );
+      const details = entry.details.slice(0, 10).map((detail) => {
+        const markdown = detail.markdown
+          ? truncateThreadInspectionTextWithFlag(detail.markdown, maxCharsPerEntry)
+          : undefined;
+        const output = detail.command?.output
+          ? truncateThreadInspectionTextWithFlag(
+              detail.command.output,
+              maxCharsPerEntry,
+            )
+          : undefined;
+        return {
+          id: detail.id,
+          kind: detail.kind,
+          label: truncateThreadInspectionText(detail.label, 320),
+          ...(markdown ? { markdown: markdown.value } : {}),
+          ...(detail.path ? { path: detail.path } : {}),
+          ...(detail.url ? { url: detail.url } : {}),
+          ...(detail.status ? { status: detail.status } : {}),
+          ...(detail.command
+            ? {
+                command: {
+                  displayCommand: detail.command.displayCommand,
+                  ...(detail.command.rawCommand
+                    ? { rawCommand: detail.command.rawCommand }
+                    : {}),
+                  ...(detail.command.cwd ? { cwd: detail.command.cwd } : {}),
+                  ...(output ? { output: output.value } : {}),
+                  ...(detail.command.exitCode !== undefined
+                    ? { exitCode: detail.command.exitCode }
+                    : {}),
+                  ...(detail.command.durationMs !== undefined
+                    ? { durationMs: detail.command.durationMs }
+                    : {}),
+                },
+              }
+            : {}),
+          ...(summary.truncated || markdown?.truncated || output?.truncated
+            ? { truncated: true }
+            : {}),
+        };
+      });
+      return {
+        type: "activity",
+        id: entry.id,
+        summary: summary.value,
+        ...(entry.createdAt !== undefined ? { createdAt: entry.createdAt } : {}),
+        ...(entry.status ? { status: entry.status } : {}),
+        ...(entry.turn ? { turn: entry.turn } : {}),
+        details,
+        ...(summary.truncated || entry.details.length > details.length
+          ? { truncated: true }
+          : {}),
+      };
+    }
+    case "plan": {
+      const explanation = entry.explanation
+        ? truncateThreadInspectionTextWithFlag(
+            entry.explanation,
+            maxCharsPerEntry,
+          )
+        : undefined;
+      const markdown = entry.markdown
+        ? truncateThreadInspectionTextWithFlag(entry.markdown, maxCharsPerEntry)
+        : undefined;
+      const steps = entry.steps.slice(0, 20).map((step) => ({
+        step: truncateThreadInspectionText(step.step, 500),
+        status: step.status,
+      }));
+      return {
+        type: "plan",
+        id: entry.id,
+        ...(entry.createdAt !== undefined ? { createdAt: entry.createdAt } : {}),
+        ...(explanation ? { explanation: explanation.value } : {}),
+        ...(markdown ? { markdown: markdown.value } : {}),
+        ...(entry.turn ? { turn: entry.turn } : {}),
+        steps,
+        ...(explanation?.truncated ||
+        markdown?.truncated ||
+        entry.steps.length > steps.length
+          ? { truncated: true }
+          : {}),
+      };
+    }
+    case "review": {
+      const review = truncateThreadInspectionTextWithFlag(
+        entry.review,
+        maxCharsPerEntry,
+      );
+      const displayText = entry.displayText
+        ? truncateThreadInspectionTextWithFlag(
+            entry.displayText,
+            maxCharsPerEntry,
+          )
+        : undefined;
+      return {
+        type: "review",
+        id: entry.id,
+        ...(entry.createdAt !== undefined ? { createdAt: entry.createdAt } : {}),
+        ...(entry.status ? { status: entry.status } : {}),
+        review: review.value,
+        ...(displayText ? { displayText: displayText.value } : {}),
+        ...(entry.turn ? { turn: entry.turn } : {}),
+        ...(review.truncated || displayText?.truncated
+          ? { truncated: true }
+          : {}),
+      };
+    }
+  }
+}
+
 function isThreadMutationExecutionMode(
   value: unknown,
 ): value is ThreadExecutionMode {
@@ -16792,11 +17161,21 @@ function buildThreadInspectionDateRange(params: {
 }
 
 function truncateThreadInspectionText(value: string, maxLength: number): string {
+  return truncateThreadInspectionTextWithFlag(value, maxLength).value;
+}
+
+function truncateThreadInspectionTextWithFlag(
+  value: string,
+  maxLength: number,
+): { value: string; truncated: boolean } {
   const normalized = value.replace(/\s+/g, " ").trim();
   if (normalized.length <= maxLength) {
-    return normalized;
+    return { value: normalized, truncated: false };
   }
-  return `${normalized.slice(0, Math.max(0, maxLength - 3)).trimEnd()}...`;
+  return {
+    value: `${normalized.slice(0, Math.max(0, maxLength - 3)).trimEnd()}...`,
+    truncated: true,
+  };
 }
 
 let registry: DesktopBackendRegistry | null = null;

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -115,6 +115,16 @@ import {
   type PwrAgentThreadInspectionRequest,
   type PwrAgentThreadInspectionResponse,
   type ThreadMutationAppliedChange,
+  type PwrAgentThreadOrchestrationErrorCode,
+  type PwrAgentThreadOrchestrationRequest,
+  type PwrAgentThreadOrchestrationResponse,
+  type HandoffTaskResult,
+  type HandoffTaskSeedMode,
+  type HandoffTaskGroupingMode,
+  type HandoffTaskWorkspaceMode,
+  type HandoffTaskInheritedSettings,
+  type HandoffTaskMessagingAttachment,
+  type ThreadHandoffOriginWorkspace,
   type ThreadInspectionSummary,
   type ThreadSearchFilters,
   type ThreadSearchResult,
@@ -233,6 +243,13 @@ import {
   readPwrAgentMessagingDynamicToolCall,
 } from "../agent-tools/pwragent-messaging-codex-tools";
 import type { PwrAgentMessagingHandler } from "../agent-tools/pwragent-messaging-agent-tools";
+import {
+  buildPwrAgentThreadOrchestrationDynamicToolErrorResponse,
+  handlePwrAgentThreadOrchestrationDynamicToolCall,
+  isPwrAgentThreadOrchestrationDynamicToolCall,
+  readPwrAgentThreadOrchestrationDynamicToolCall,
+} from "../agent-tools/pwragent-thread-orchestration-codex-tools";
+import type { PwrAgentThreadOrchestrationHandler } from "../agent-tools/pwragent-thread-orchestration-agent-tools";
 import type { MessagingAgentToolService } from "../messaging/messaging-agent-tool-service";
 import { resolveAutomationInspectionMcpCommand } from "../automations/automation-inspection-cli";
 import { resolveAgentToolCatalogs } from "../agent-tools/agent-tool-catalog-registry";
@@ -4076,6 +4093,98 @@ function pageNormalizedReplay(
   };
 }
 
+function threadOrchestrationFailure(
+  code: PwrAgentThreadOrchestrationErrorCode,
+  message: string,
+  data?: unknown,
+): PwrAgentThreadOrchestrationResponse {
+  return {
+    ok: false,
+    error: {
+      code,
+      message,
+      ...(data === undefined ? {} : { data }),
+    },
+  };
+}
+
+function buildHandoffTaskPrompt(params: {
+  task: string;
+  context?: string;
+  origin: {
+    sourceBackend: AppServerBackendKind;
+    sourceThreadId: string;
+    sourceTurnId?: string;
+    sourceTitle?: string;
+  };
+  inheritedSettings: HandoffTaskInheritedSettings;
+  workspace: ThreadHandoffOriginWorkspace;
+}): string {
+  const lines = [
+    "You are a PwrAgent handoff thread created by another Agent thread.",
+    "",
+    "Task:",
+    params.task,
+    "",
+    "Source thread:",
+    `- Backend: ${params.origin.sourceBackend}`,
+    `- Thread ID: ${params.origin.sourceThreadId}`,
+    ...(params.origin.sourceTurnId
+      ? [`- Turn ID: ${params.origin.sourceTurnId}`]
+      : []),
+    ...(params.origin.sourceTitle
+      ? [`- Title: ${params.origin.sourceTitle}`]
+      : []),
+    "",
+    "Inherited settings:",
+    `- Backend: ${params.inheritedSettings.backend}`,
+    ...(params.inheritedSettings.model
+      ? [`- Model: ${params.inheritedSettings.model}`]
+      : []),
+    ...(params.inheritedSettings.reasoningEffort
+      ? [`- Reasoning effort: ${params.inheritedSettings.reasoningEffort}`]
+      : []),
+    ...(params.inheritedSettings.serviceTier
+      ? [`- Service tier: ${params.inheritedSettings.serviceTier}`]
+      : []),
+    ...(params.inheritedSettings.fastMode !== undefined
+      ? [`- Fast mode: ${params.inheritedSettings.fastMode ? "on" : "off"}`]
+      : []),
+    ...(params.inheritedSettings.executionMode
+      ? [`- Permission mode: ${params.inheritedSettings.executionMode}`]
+      : []),
+    ...(params.inheritedSettings.approvalPolicy
+      ? [`- Approval policy: ${params.inheritedSettings.approvalPolicy}`]
+      : []),
+    ...(params.inheritedSettings.sandbox
+      ? [`- Sandbox: ${params.inheritedSettings.sandbox}`]
+      : []),
+    "",
+    "Workspace:",
+    `- Mode: ${params.workspace.mode}`,
+    ...(params.workspace.cwd ? [`- CWD: ${params.workspace.cwd}`] : []),
+    ...(params.workspace.linkedDirectory?.path
+      ? [`- Project path: ${params.workspace.linkedDirectory.path}`]
+      : []),
+    ...(params.workspace.linkedDirectory?.worktreePath
+      ? [`- Worktree path: ${params.workspace.linkedDirectory.worktreePath}`]
+      : []),
+    ...(params.workspace.branch ? [`- Branch: ${params.workspace.branch}`] : []),
+    `- Git: ${params.workspace.git.kind}`,
+    `- New worktree supported: ${
+      params.workspace.git.worktreeCreationAvailable ? "yes" : "no"
+    }`,
+    "",
+    "Parent context reference:",
+    "The thread that spawned this handoff is the source thread above. Use that reference if a future tool or UI surface can fetch more context from the parent.",
+  ];
+  const trimmedContext = params.context?.trim();
+  if (trimmedContext) {
+    lines.push("", "Additional context from parent:", trimmedContext);
+  }
+  return lines.join("\n");
+}
+
 export class DesktopBackendRegistry {
   private readonly codexClient: BackendClient;
   private readonly grokClient: BackendClient;
@@ -4191,6 +4300,8 @@ export class DesktopBackendRegistry {
     };
   private readonly threadInspectionHandler: PwrAgentThreadInspectionHandler =
     async (request) => await this.handleThreadInspectionRequest(request);
+  private readonly threadOrchestrationHandler: PwrAgentThreadOrchestrationHandler =
+    async (request) => await this.handleThreadOrchestrationRequest(request);
   private threadInspectionSearchService: ThreadSearchService | null | undefined;
   private readonly headlessAutomationTurns = new Map<
     string,
@@ -6725,6 +6836,7 @@ export class DesktopBackendRegistry {
       automationInspectionHandler: this.automationInspectionHandler,
       messagingHandler: this.messagingHandler,
       threadInspectionHandler: this.threadInspectionHandler,
+      threadOrchestrationHandler: this.threadOrchestrationHandler,
     });
     const resolvedDynamicTools =
       backend === "codex"
@@ -7302,6 +7414,7 @@ export class DesktopBackendRegistry {
                 automationInspectionHandler: this.automationInspectionHandler,
                 messagingHandler: this.messagingHandler,
                 threadInspectionHandler: this.threadInspectionHandler,
+                threadOrchestrationHandler: this.threadOrchestrationHandler,
               });
               const started = await client.startTurn({
                 threadId: params.threadId,
@@ -13577,6 +13690,45 @@ export class DesktopBackendRegistry {
       });
     }
 
+    const threadOrchestrationToolCall =
+      readPwrAgentThreadOrchestrationDynamicToolCall({
+        method: request.method,
+        params: request.params,
+      });
+    if (
+      threadOrchestrationToolCall &&
+      isPwrAgentThreadOrchestrationDynamicToolCall(threadOrchestrationToolCall)
+    ) {
+      if (!this.isLiveDynamicToolCall(backend, threadOrchestrationToolCall)) {
+        backendRegistryLog.warn("rejecting thread orchestration dynamic tool call", {
+          backend,
+          callId: threadOrchestrationToolCall.callId,
+          namespace: threadOrchestrationToolCall.namespace,
+          threadId: threadOrchestrationToolCall.threadId,
+          tool: threadOrchestrationToolCall.tool,
+          turnId: threadOrchestrationToolCall.turnId,
+        });
+        return buildPwrAgentThreadOrchestrationDynamicToolErrorResponse({
+          code: "forbidden",
+          message:
+            "Thread handoff tool calls must originate from an active Agent turn on the same thread.",
+        });
+      }
+      backendRegistryLog.info("handling thread orchestration dynamic tool call", {
+        backend,
+        callId: threadOrchestrationToolCall.callId,
+        namespace: threadOrchestrationToolCall.namespace,
+        threadId: threadOrchestrationToolCall.threadId,
+        tool: threadOrchestrationToolCall.tool,
+        turnId: threadOrchestrationToolCall.turnId,
+      });
+      return await handlePwrAgentThreadOrchestrationDynamicToolCall({
+        backend,
+        call: threadOrchestrationToolCall,
+        handler: this.threadOrchestrationHandler,
+      });
+    }
+
     const messagingToolCall = readPwrAgentMessagingDynamicToolCall({
       method: request.method,
       params: request.params,
@@ -13716,6 +13868,469 @@ export class DesktopBackendRegistry {
     const turnId = call.turnId?.trim();
     if (!turnId) return false;
     return this.activeTurnKeys.has(buildActiveTurnKey(backend, call.threadId, turnId));
+  }
+
+  private async handleThreadOrchestrationRequest(
+    request: PwrAgentThreadOrchestrationRequest,
+  ): Promise<PwrAgentThreadOrchestrationResponse> {
+    if (request.operation !== "handoff_task") {
+      return threadOrchestrationFailure(
+        "unsupported_operation",
+        "Unsupported PwrAgent thread orchestration operation.",
+      );
+    }
+    return await this.handoffTaskToThread(request);
+  }
+
+  private async handoffTaskToThread(
+    request: PwrAgentThreadOrchestrationRequest<"handoff_task">,
+  ): Promise<PwrAgentThreadOrchestrationResponse> {
+    const sourceBackend = request.context.backend;
+    const sourceThreadId = request.context.threadId;
+    const sourceTurnId = request.context.turnId?.trim();
+    if (
+      !sourceTurnId ||
+      !this.isLiveDynamicToolCall(sourceBackend, {
+        threadId: sourceThreadId,
+        turnId: sourceTurnId,
+      })
+    ) {
+      return threadOrchestrationFailure(
+        "forbidden",
+        "Thread handoff tools must be invoked from a live Agent turn.",
+      );
+    }
+    if (sourceBackend !== "codex") {
+      return threadOrchestrationFailure(
+        "unsupported_backend",
+        "Thread handoff tools are currently available only from Codex Agent threads.",
+      );
+    }
+
+    const backend = request.args.backend ?? sourceBackend;
+    if (backend !== "codex") {
+      return threadOrchestrationFailure(
+        "unsupported_backend",
+        "Thread handoff can currently create only Codex Agent threads.",
+      );
+    }
+
+    const sourceOverlay = await this.overlayStore.getThreadOverlayState({
+      backend: sourceBackend,
+      threadId: sourceThreadId,
+    });
+    if (!sourceOverlay?.agent) {
+      return threadOrchestrationFailure(
+        "forbidden",
+        "Thread handoff tools are available only to Agent threads.",
+      );
+    }
+
+    const task = request.args.task.trim();
+    if (!task) {
+      return threadOrchestrationFailure(
+        "invalid_arguments",
+        "handoff_task requires a non-empty task string.",
+      );
+    }
+
+    const seedMode: HandoffTaskSeedMode = request.args.seedMode ?? "clean";
+    const groupingMode: HandoffTaskGroupingMode =
+      request.args.groupingMode ?? "none";
+    const workspaceMode: HandoffTaskWorkspaceMode =
+      request.args.workspaceMode ?? "same";
+    const sourceThread = await this.findThreadForWorkspaceHandoff({
+      backend: sourceBackend,
+      callerReason: "agent-handoff",
+      threadId: sourceThreadId,
+    });
+    const sourceCwd = await this.resolveThreadEnvironmentCwd(
+      sourceBackend,
+      sourceThreadId,
+      sourceOverlay,
+    );
+    const sourceLinkedDirectory = this.resolveHandoffLinkedDirectory({
+      cwd: sourceCwd,
+      overlay: sourceOverlay,
+      thread: sourceThread,
+    });
+    const sourceWorkspace = await this.buildThreadHandoffWorkspaceSummary({
+      cwd: sourceCwd,
+      linkedDirectory: sourceLinkedDirectory,
+      mode: "same",
+    });
+
+    if (workspaceMode !== "none" && !sourceCwd?.trim()) {
+      return threadOrchestrationFailure(
+        "unsupported_workspace",
+        "The source thread has no current workspace. Ask for workspaceMode=none to create an unscoped handoff thread.",
+      );
+    }
+    if (
+      workspaceMode === "new_worktree" &&
+      !sourceWorkspace.git.worktreeCreationAvailable
+    ) {
+      return threadOrchestrationFailure(
+        "unsupported_workspace",
+        sourceWorkspace.git.unavailableReason ??
+          "The source workspace cannot create a new Git worktree.",
+        { workspace: sourceWorkspace },
+      );
+    }
+
+    const executionMode =
+      request.args.executionMode ??
+      this.activeCodexTurnModes.get(
+        buildActiveTurnModeKey(sourceThreadId, sourceTurnId),
+      ) ??
+      sourceOverlay.executionMode ??
+      (await this.resolveCodexThreadExecutionModeForActiveTurn(sourceThreadId));
+    const modeSettings = EXECUTION_MODE_SUMMARIES[executionMode];
+    const inheritedSettings: HandoffTaskInheritedSettings = {
+      backend,
+      executionMode,
+      model: request.args.model ?? sourceOverlay.model,
+      reasoningEffort:
+        request.args.reasoningEffort ?? sourceOverlay.reasoningEffort,
+      serviceTier: request.args.serviceTier ?? sourceOverlay.serviceTier,
+      fastMode: request.args.fastMode ?? sourceOverlay.fastMode,
+      approvalPolicy: request.args.approvalPolicy ?? modeSettings.approvalPolicy,
+      sandbox: request.args.sandbox ?? modeSettings.sandbox,
+      codexEnvironmentRuntime: sourceOverlay.codexEnvironmentRuntime,
+    };
+    const title =
+      request.args.title?.trim() ||
+      shortenDerivedThreadTitle(task) ||
+      "Delegated task";
+    const agent = {
+      name: title,
+      instructions:
+        "Work only on the delegated task from the parent PwrAgent thread. Keep progress and results in this thread.",
+    };
+    const cwdForChild = workspaceMode === "none" ? undefined : sourceCwd;
+
+    let threadId: string;
+    let createdLinkedDirectory: LinkedDirectorySummary | undefined;
+    let createdWorkspaceMode = workspaceMode;
+    try {
+      if (seedMode === "fork") {
+        const forked = await this.forkThread({
+          backend,
+          sourceThreadId,
+          ...(groupingMode === "subthread"
+            ? { parentThreadId: sourceThreadId }
+            : {}),
+          executionMode,
+          directoryLabel:
+            sourceLinkedDirectory?.label ||
+            (sourceCwd ? path.basename(sourceCwd) : undefined) ||
+            title,
+          directoryPath: cwdForChild,
+          workMode: workspaceMode === "new_worktree" ? "worktree" : "local",
+          branchName: request.args.branchName,
+          model: inheritedSettings.model,
+          reasoningEffort: inheritedSettings.reasoningEffort,
+          serviceTier: inheritedSettings.serviceTier,
+          fastMode: inheritedSettings.fastMode,
+          approvalPolicy: inheritedSettings.approvalPolicy,
+          sandbox: inheritedSettings.sandbox,
+        });
+        threadId = forked.threadId;
+        createdLinkedDirectory = forked.linkedDirectory;
+        createdWorkspaceMode =
+          forked.workMode === "worktree" ? "new_worktree" : workspaceMode;
+        await this.overlayStore.setThreadAgent({
+          backend,
+          threadId,
+          agent,
+        });
+      } else {
+        const started = await this.startThread({
+          backend,
+          executionMode,
+          cwd: cwdForChild,
+          workMode: workspaceMode === "new_worktree" ? "worktree" : "local",
+          branchName: request.args.branchName,
+          model: inheritedSettings.model,
+          reasoningEffort: inheritedSettings.reasoningEffort,
+          serviceTier: inheritedSettings.serviceTier,
+          fastMode: inheritedSettings.fastMode,
+          approvalPolicy: inheritedSettings.approvalPolicy,
+          sandbox: inheritedSettings.sandbox,
+          codexEnvironmentRuntime: inheritedSettings.codexEnvironmentRuntime,
+          agent,
+        });
+        threadId = started.threadId;
+        if (groupingMode === "subthread") {
+          await this.overlayStore.setThreadParent?.({
+            backend,
+            threadId,
+            parentThreadId: sourceThreadId,
+          });
+        }
+      }
+      await this.renameThread({ backend, threadId, name: title }).catch(
+        (error) => {
+          backendRegistryLog.warn("thread handoff rename failed", {
+            backend,
+            error: error instanceof Error ? error.message : String(error),
+            threadId,
+          });
+        },
+      );
+    } catch (error) {
+      return threadOrchestrationFailure(
+        workspaceMode === "new_worktree" ? "unsupported_workspace" : "internal_error",
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+
+    const pendingThread = this.pendingStartedThreads.get(`${backend}:${threadId}`);
+    const childCwd =
+      resolveThreadWorkspaceCwd(pendingThread) ||
+      createdLinkedDirectory?.worktreePath ||
+      createdLinkedDirectory?.path ||
+      cwdForChild;
+    const childLinkedDirectory =
+      createdLinkedDirectory ??
+      this.resolveHandoffLinkedDirectory({
+        cwd: childCwd,
+        overlay: await this.overlayStore.getThreadOverlayState({ backend, threadId }),
+        thread: pendingThread,
+      });
+    const workspace = await this.buildThreadHandoffWorkspaceSummary({
+      cwd: childCwd,
+      linkedDirectory: childLinkedDirectory,
+      mode: createdWorkspaceMode,
+    });
+    const createdAt = request.context.now ?? Date.now();
+    const origin = {
+      sourceBackend,
+      sourceThreadId,
+      sourceTurnId,
+      sourceTitle: sourceThread?.title,
+      taskTitle: title,
+      seedMode,
+      groupingMode,
+      createdAt,
+      workspace,
+    };
+    await this.overlayStore.setThreadHandoffOrigin({
+      backend,
+      threadId,
+      handoffOrigin: origin,
+    });
+    this.invalidateThreadListCache(backend);
+
+    const prompt = buildHandoffTaskPrompt({
+      task,
+      context: request.args.context,
+      origin,
+      inheritedSettings,
+      workspace,
+    });
+    let turnId: string | undefined;
+    let turnStartFailure: HandoffTaskResult["turnStartFailure"];
+    try {
+      const turn = await this.startTurn({
+        backend,
+        threadId,
+        input: [{ type: "text", text: prompt }],
+        executionMode,
+        model: inheritedSettings.model,
+        reasoningEffort: inheritedSettings.reasoningEffort,
+        serviceTier: inheritedSettings.serviceTier,
+        fastMode: inheritedSettings.fastMode,
+        approvalPolicy: inheritedSettings.approvalPolicy,
+        sandbox: inheritedSettings.sandbox,
+      });
+      turnId = turn.turnId;
+    } catch (error) {
+      turnStartFailure = {
+        phase: "turn",
+        message: error instanceof Error ? error.message : String(error),
+      };
+      backendRegistryLog.warn("thread handoff created thread but turn failed", {
+        backend,
+        error: turnStartFailure.message,
+        threadId,
+      });
+    }
+
+    const messagingAttachment = await this.attachHandoffThreadToMessaging({
+      mode: request.args.messagingAttachment,
+      sourceBackend,
+      sourceThreadId,
+      sourceTurnId,
+      backend,
+      threadId,
+      title,
+    });
+    return {
+      ok: true,
+      data: {
+        backend,
+        threadId,
+        turnId,
+        title,
+        seedMode,
+        groupingMode,
+        ...(groupingMode === "subthread"
+          ? { groupedUnderThreadId: sourceThreadId }
+          : {}),
+        inheritedSettings,
+        origin,
+        workspace,
+        messagingAttachment,
+        ...(turnStartFailure ? { turnStartFailure } : {}),
+      },
+    };
+  }
+
+  private async attachHandoffThreadToMessaging(params: {
+    mode?: "none" | "auto" | "current_conversation" | "new_child";
+    sourceBackend: AppServerBackendKind;
+    sourceThreadId: string;
+    sourceTurnId: string;
+    backend: AppServerBackendKind;
+    threadId: string;
+    title: string;
+  }): Promise<HandoffTaskMessagingAttachment> {
+    if (params.mode === "none") {
+      return { requested: false, outcome: "not_requested" };
+    }
+    const placement =
+      params.mode === "new_child"
+        ? "new_child"
+        : params.mode === "current_conversation"
+          ? "current_conversation"
+          : "auto";
+    const explicitRequest = params.mode !== undefined;
+    const response = await this.messagingHandler({
+      operation: "attach_thread_here",
+      context: {
+        backend: params.sourceBackend,
+        threadId: params.sourceThreadId,
+        turnId: params.sourceTurnId,
+      },
+      args: {
+        backend: params.backend,
+        threadId: params.threadId,
+        placement,
+        targetKind: "agent_thread",
+        title: params.title,
+      },
+    });
+    if (response.ok && "binding" in response.data) {
+      return {
+        requested: true,
+        outcome: response.data.outcome,
+        channel: response.data.channel,
+        conversation: {
+          id: response.data.conversation.id,
+          kind: response.data.conversation.kind,
+          title: response.data.conversation.title,
+        },
+        ...(response.data.createdConversation
+          ? {
+              createdConversation: {
+                id: response.data.createdConversation.id,
+                kind: response.data.createdConversation.kind,
+                title: response.data.createdConversation.title,
+              },
+            }
+          : {}),
+      };
+    }
+    if (!explicitRequest) {
+      return { requested: false, outcome: "not_requested" };
+    }
+    if (response.ok) {
+      return {
+        requested: true,
+        outcome: "failed",
+        reason: "Messaging location did not return an attachable binding.",
+      };
+    }
+    return {
+      requested: true,
+      outcome:
+        response.error.code === "not_found"
+          ? "not_available"
+          : response.error.code === "forbidden"
+            ? "forbidden"
+            : response.error.code === "unsupported_operation"
+              ? "unsupported"
+              : "failed",
+      reason: response.error.message,
+    };
+  }
+
+  private resolveHandoffLinkedDirectory(params: {
+    cwd?: string;
+    overlay?: ThreadOverlayState;
+    thread?: Pick<AppServerThreadSummary, "linkedDirectories">;
+  }): LinkedDirectorySummary | undefined {
+    const candidates = [
+      ...(params.overlay?.extraLinkedDirectories ?? []),
+      ...(params.thread?.linkedDirectories ?? []),
+    ];
+    const cwd = params.cwd?.trim();
+    return (
+      (cwd
+        ? candidates.find(
+            (directory) =>
+              directory.worktreePath === cwd || directory.path === cwd,
+          )
+        : undefined) ??
+      candidates.find((directory) => directory.kind === "worktree") ??
+      candidates.find((directory) => directory.kind === "local") ??
+      candidates[0]
+    );
+  }
+
+  private async buildThreadHandoffWorkspaceSummary(params: {
+    cwd?: string;
+    linkedDirectory?: LinkedDirectorySummary;
+    mode: HandoffTaskWorkspaceMode;
+  }): Promise<ThreadHandoffOriginWorkspace> {
+    const cwd = params.cwd?.trim();
+    if (!cwd) {
+      return {
+        mode: params.mode,
+        git: {
+          kind: "none",
+          worktreeCreationAvailable: false,
+          unavailableReason: "No workspace is associated with this thread.",
+        },
+      };
+    }
+    const branch = await readCurrentGitBranch(cwd).catch(() => undefined);
+    if (!branch) {
+      return {
+        mode: params.mode,
+        cwd,
+        linkedDirectory: params.linkedDirectory,
+        git: {
+          kind: "non_git",
+          worktreeCreationAvailable: false,
+          unavailableReason: "The workspace is not a Git repository.",
+        },
+      };
+    }
+    return {
+      mode: params.mode,
+      cwd,
+      branch,
+      linkedDirectory: params.linkedDirectory,
+      git: {
+        kind:
+          params.linkedDirectory?.kind === "worktree"
+            ? "git_worktree"
+            : "git_local",
+        worktreeCreationAvailable: true,
+      },
+    };
   }
 
   private async handleTaskMonitorRequest(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -149,6 +149,7 @@ import {
   DEFAULT_THREAD_INSPECTION_RECENT_LIMIT,
   DEFAULT_THREAD_INSPECTION_SEARCH_LIMIT,
   MAX_THREAD_INSPECTION_SEARCH_LIMIT,
+  PWRAGENT_APP_TOOL_NAMESPACE,
   PWRAGENT_MESSAGING_TOOL_NAMESPACE,
   PWRAGENT_THREAD_TOOL_NAMESPACE,
   isThreadSearchContentMode,
@@ -213,6 +214,12 @@ import {
   normalizePreferredMonitorReasoningEffort,
   readTaskMonitorDynamicToolCall,
 } from "./task-monitor-codex-tools";
+import {
+  buildPwrAgentAppDynamicToolErrorResponse,
+  handlePwrAgentAppDynamicToolCall,
+  readPwrAgentAppDynamicToolCall,
+} from "../agent-tools/pwragent-app-codex-tools";
+import type { PwrAgentAppManagementHandler } from "../agent-tools/pwragent-app-agent-tools";
 import {
   buildPwrAgentThreadDynamicToolErrorResponse,
   handlePwrAgentThreadDynamicToolCall,
@@ -4164,6 +4171,7 @@ export class DesktopBackendRegistry {
   private hasLoggedNotificationsEnabledError = false;
   private readonly threadTurnQueue: ThreadTurnQueue;
   private automationInspectionHandler?: AutomationInspectionHandler;
+  private appManagementHandler?: PwrAgentAppManagementHandler;
   private messagingAgentToolService?: MessagingAgentToolService;
   private readonly messagingHandler: PwrAgentMessagingHandler =
     async (request) => {
@@ -4280,6 +4288,7 @@ export class DesktopBackendRegistry {
     messagingStore?: MessagingArchiveCleanupStore | null;
     messagingArchiveCleaner?: MessagingArchiveCleaner | null;
     automationInspectionMcpCommand?: string;
+    appManagementHandler?: PwrAgentAppManagementHandler | null;
     createScratchProjectDirectory?: () => Promise<string>;
     codexEnvironmentCommandRunner?: CodexEnvironmentCommandRunner;
     codexEnvironmentHydrationStore?: CodexEnvironmentHydrationStoreLike;
@@ -4431,6 +4440,7 @@ export class DesktopBackendRegistry {
     });
     this.messagingStore = options?.messagingStore;
     this.messagingArchiveCleaner = options?.messagingArchiveCleaner;
+    this.appManagementHandler = options?.appManagementHandler ?? undefined;
     this.gitWorkspaceHandoffService =
       options?.gitWorkspaceHandoffService ??
       new GitWorkspaceHandoffService({
@@ -4659,6 +4669,12 @@ export class DesktopBackendRegistry {
     handler: AutomationInspectionHandler | null | undefined,
   ): void {
     this.automationInspectionHandler = handler ?? undefined;
+  }
+
+  setPwrAgentAppManagementHandler(
+    handler: PwrAgentAppManagementHandler | null | undefined,
+  ): void {
+    this.appManagementHandler = handler ?? undefined;
   }
 
   async publishLocalEvent(event: AgentEvent): Promise<void> {
@@ -6704,6 +6720,7 @@ export class DesktopBackendRegistry {
     });
     const agentToolCatalogs = resolveAgentToolCatalogs({
       agent: request.agent,
+      appManagementHandler: this.appManagementHandler,
       automationInspectionHandler: this.automationInspectionHandler,
       messagingHandler: this.messagingHandler,
       threadInspectionHandler: this.threadInspectionHandler,
@@ -7280,6 +7297,7 @@ export class DesktopBackendRegistry {
               const modeSettings = EXECUTION_MODE_SUMMARIES[effectiveMode];
               const agentToolCatalogs = resolveAgentToolCatalogs({
                 agent: overlay?.agent,
+                appManagementHandler: this.appManagementHandler,
                 automationInspectionHandler: this.automationInspectionHandler,
                 messagingHandler: this.messagingHandler,
                 threadInspectionHandler: this.threadInspectionHandler,
@@ -13520,6 +13538,41 @@ export class DesktopBackendRegistry {
         handler: this.threadInspectionHandler,
       });
     }
+    const appToolCall = readPwrAgentAppDynamicToolCall({
+      method: request.method,
+      params: request.params,
+    });
+    if (appToolCall?.namespace === PWRAGENT_APP_TOOL_NAMESPACE) {
+      if (!this.isLiveDynamicToolCall(backend, appToolCall)) {
+        backendRegistryLog.warn("rejecting app management dynamic tool call", {
+          backend,
+          callId: appToolCall.callId,
+          namespace: appToolCall.namespace,
+          threadId: appToolCall.threadId,
+          tool: appToolCall.tool,
+          turnId: appToolCall.turnId,
+        });
+        return buildPwrAgentAppDynamicToolErrorResponse({
+          code: "forbidden",
+          message:
+            "App management tool calls must originate from an active Agent turn on the same thread.",
+        });
+      }
+      backendRegistryLog.info("handling app management dynamic tool call", {
+        backend,
+        callId: appToolCall.callId,
+        namespace: appToolCall.namespace,
+        threadId: appToolCall.threadId,
+        tool: appToolCall.tool,
+        turnId: appToolCall.turnId,
+      });
+      return await handlePwrAgentAppDynamicToolCall({
+        backend,
+        call: appToolCall,
+        handler: this.appManagementHandler,
+      });
+    }
+
     const messagingToolCall = readPwrAgentMessagingDynamicToolCall({
       method: request.method,
       params: request.params,

--- a/apps/desktop/src/main/app-server/task-monitor-codex-tools.ts
+++ b/apps/desktop/src/main/app-server/task-monitor-codex-tools.ts
@@ -13,6 +13,7 @@ import {
   DEFAULT_TASK_MONITOR_POLL_INTERVAL_SECONDS,
   DEFAULT_TASK_MONITOR_REASONING_EFFORT,
   DEFAULT_TASK_MONITOR_STARTUP_TIMEOUT_SECONDS,
+  PWRAGENT_TOOL_NAMESPACE,
   TASK_MONITOR_TOOL_NAMESPACE,
   isTaskMonitorOperationName,
 } from "@pwragent/shared";
@@ -30,7 +31,7 @@ export function buildTaskMonitorDynamicToolSpecs(
   role: "parent" | "monitor" | "all" = "all",
 ): DynamicToolSpec[] {
   const createTool: DynamicToolSpec = {
-    namespace: TASK_MONITOR_TOOL_NAMESPACE,
+    namespace: PWRAGENT_TOOL_NAMESPACE,
     name: "create_monitor_delegation",
     description:
       "Create and start a lightweight PwrAgent-managed monitor thread for long-running asynchronous work or repeatable status checks. Use this instead of polling from the parent agent when the task may take more than one short status check, especially when you are about to sleep/wait/poll every few seconds for a command, job, service, or external operation to finish. If you have checked something for progress for about 30 seconds and the check is repeatable, hand it to this monitor with enough context to run that check for you. The task and monitorContext must include the exact monitoring procedure the parent was about to run itself: cwd or target location, command/status command or wait API, poll cadence, terminal success/failure conditions, and relevant log collection steps. Do not pass parent-local Codex/tool session ids such as exec_command/write_stdin session_id values; monitor threads cannot access those sessions, stdout/stderr streams, stdin, or exit status. For a local build/test/script, delegate before starting it and provide cwd plus the exact command so the monitor starts it and captures output itself. Prefer separate stdout/stderr capture files plus a combined output file when practical, and include those file paths in the final handoff. If the command is already running, provide durable process/log/status files that the monitor can read. Use pollIntervalSeconds as the combined poll and heartbeat cadence; default to 30 seconds unless the delegated procedure clearly needs a different cadence. PwrAgent starts the monitor with the returned preferred model/reasoning settings and the monitor callback tools attached; do not call generic spawnAgent for this flow.",
@@ -52,7 +53,7 @@ export function buildTaskMonitorDynamicToolSpecs(
   };
   const monitorTools: DynamicToolSpec[] = [
     {
-      namespace: TASK_MONITOR_TOOL_NAMESPACE,
+      namespace: PWRAGENT_TOOL_NAMESPACE,
       name: "inject_progress",
       description:
         "Inject a concise progress update from a monitor subagent into the parent PwrAgent thread without starting or waking a parent turn.",
@@ -72,7 +73,7 @@ export function buildTaskMonitorDynamicToolSpecs(
       deferLoading: false,
     },
     {
-      namespace: TASK_MONITOR_TOOL_NAMESPACE,
+      namespace: PWRAGENT_TOOL_NAMESPACE,
       name: "complete_monitoring",
       description:
         "Finish a monitor delegation, inject the final result, and by default trigger exactly one parent turn with the final context.",
@@ -135,12 +136,13 @@ export function readTaskMonitorDynamicToolCall(request: {
 export function isTaskMonitorDynamicToolCall(
   call: Pick<DynamicToolCallParams, "namespace" | "tool">,
 ): call is DynamicToolCallParams & {
-  namespace: typeof TASK_MONITOR_TOOL_NAMESPACE;
+  namespace: typeof PWRAGENT_TOOL_NAMESPACE | typeof TASK_MONITOR_TOOL_NAMESPACE;
   tool: TaskMonitorOperationName;
 } {
   return (
-    call.namespace === TASK_MONITOR_TOOL_NAMESPACE &&
-    isTaskMonitorOperationName(call.tool)
+    call.namespace === TASK_MONITOR_TOOL_NAMESPACE ||
+    (call.namespace === PWRAGENT_TOOL_NAMESPACE &&
+      isTaskMonitorOperationName(call.tool))
   );
 }
 
@@ -150,6 +152,12 @@ export async function handleTaskMonitorDynamicToolCall(params: {
   handler: TaskMonitorHandler;
 }): Promise<DynamicToolCallResponse> {
   if (!isTaskMonitorDynamicToolCall(params.call)) {
+    return buildTaskMonitorDynamicToolErrorResponse({
+      code: "unsupported_operation",
+      message: "Unsupported PwrAgent task monitor tool.",
+    });
+  }
+  if (!isTaskMonitorOperationName(params.call.tool)) {
     return buildTaskMonitorDynamicToolErrorResponse({
       code: "unsupported_operation",
       message: "Unsupported PwrAgent task monitor tool.",
@@ -245,13 +253,13 @@ export function buildMonitorDelegationPrompt(params: {
     "</delegated_monitoring_procedure>",
     "",
     "<progress_protocol>",
-    "- Immediately after startup, before the first external poll or sleep, call pwragent_task_monitors.inject_progress with monitorId, status \"running\", and a concise message such as \"Monitor started: checking task status.\"",
+    "- Immediately after startup, before the first external poll or sleep, call pwragent.inject_progress with monitorId, status \"running\", and a concise message such as \"Monitor started: checking task status.\"",
     `- After the startup injection, poll about every ${pollInterval} seconds while the task is incomplete.`,
     "- Every poll should produce one non-waking progress injection: report the externally visible state change, or if nothing changed and the task is still running, send a brief heartbeat such as \"Still running: waiting for the task to finish.\"",
     `- Do not send routine heartbeat updates more often than about every ${heartbeatInterval} seconds unless the external state changed.`,
     "- Progress injections are non-waking: they must not ask the parent agent to act.",
     "- Do not include the parent transcript or broad repository context in progress updates.",
-    "- When the task reaches success, failure, or cancellation, call pwragent_task_monitors.complete_monitoring exactly once.",
+    "- When the task reaches success, failure, or cancellation, call pwragent.complete_monitoring exactly once.",
     "- The completion call is the only handoff that should trigger the parent agent.",
     "</progress_protocol>",
     params.finalHandoffPrompt?.trim()

--- a/apps/desktop/src/main/auto-updater.ts
+++ b/apps/desktop/src/main/auto-updater.ts
@@ -61,6 +61,10 @@ function downloadedVersion(): string | undefined {
   return updateStatus.status === "downloaded" ? updateStatus.version : undefined;
 }
 
+export function readAppUpdateStatus(): AppUpdateStatus {
+  return updateStatus;
+}
+
 function currentUpdateChannel(): "latest" | "prerelease" {
   try {
     return getDesktopSettingsService().resolveUpdateChannel();
@@ -453,6 +457,41 @@ export function initAutoUpdater(): void {
   void checkForAppUpdatesNow("startup");
 }
 
+export async function installDownloadedAppUpdate(options?: {
+  requestQuit?: (performQuit: () => void) => Promise<boolean>;
+}): Promise<AppUpdateInstallResult> {
+  const version = downloadedVersion();
+  if (!version) {
+    return {
+      status: "error",
+      message: "No downloaded update is ready to install.",
+    };
+  }
+  try {
+    log.info("installing downloaded update", { version });
+    const performQuit = (): void => {
+      autoUpdater.quitAndInstall();
+    };
+    if (options?.requestQuit) {
+      const quitAccepted = await options.requestQuit(performQuit);
+      if (!quitAccepted) {
+        return {
+          status: "error",
+          message: "Update restart cancelled.",
+        };
+      }
+    } else {
+      performQuit();
+    }
+    return { status: "restarting" };
+  } catch (err) {
+    return {
+      status: "error",
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
 export function registerAppUpdateIpcHandlers(options?: {
   requestQuit?: (performQuit: () => void) => Promise<boolean>;
 }): void {
@@ -472,36 +511,7 @@ export function registerAppUpdateIpcHandlers(options?: {
   ipcMain.handle(
     APP_UPDATE_INSTALL_CHANNEL,
     async (): Promise<AppUpdateInstallResult> => {
-      const version = downloadedVersion();
-      if (!version) {
-        return {
-          status: "error",
-          message: "No downloaded update is ready to install.",
-        };
-      }
-      try {
-        log.info("installing downloaded update", { version });
-        const performQuit = (): void => {
-          autoUpdater.quitAndInstall();
-        };
-        if (options?.requestQuit) {
-          const quitAccepted = await options.requestQuit(performQuit);
-          if (!quitAccepted) {
-            return {
-              status: "error",
-              message: "Update restart cancelled.",
-            };
-          }
-        } else {
-          performQuit();
-        }
-        return { status: "restarting" };
-      } catch (err) {
-        return {
-          status: "error",
-          message: err instanceof Error ? err.message : String(err),
-        };
-      }
+      return await installDownloadedAppUpdate(options);
     },
   );
   ipcMain.handle(

--- a/apps/desktop/src/main/automations/automation-inspection-agent-tools.ts
+++ b/apps/desktop/src/main/automations/automation-inspection-agent-tools.ts
@@ -4,7 +4,7 @@ import type {
   AutomationInspectionRequest,
   AutomationInspectionResponse,
 } from "@pwragent/shared";
-import { AUTOMATION_INSPECTION_TOOL_NAMESPACE } from "@pwragent/shared";
+import { PWRAGENT_TOOL_NAMESPACE } from "@pwragent/shared";
 import type {
   AgentToolDefinition,
   AgentToolDispatchResult,
@@ -25,9 +25,11 @@ export type AutomationInspectionHandler = (
 
 export function buildAutomationInspectionToolRouter(
   handler: AutomationInspectionHandler | undefined,
-  options: { unsupportedMessage?: string } = {},
+  options: { namespace?: string; unsupportedMessage?: string } = {},
 ): AgentToolRouter {
-  return new AgentToolRouter(buildAutomationInspectionToolDefinitions(handler), {
+  return new AgentToolRouter(buildAutomationInspectionToolDefinitions(handler, {
+    namespace: options.namespace,
+  }), {
     unsupportedMessage:
       options.unsupportedMessage ?? "Unsupported PwrAgent automation tool.",
   });
@@ -35,9 +37,10 @@ export function buildAutomationInspectionToolRouter(
 
 export function buildAutomationInspectionToolDefinitions(
   handler: AutomationInspectionHandler | undefined,
+  options: { namespace?: string } = {},
 ): AgentToolDefinition<AutomationInspectionOperationName>[] {
   return buildAutomationInspectionToolCatalog().map((spec) => ({
-    namespace: AUTOMATION_INSPECTION_TOOL_NAMESPACE,
+    namespace: options.namespace ?? PWRAGENT_TOOL_NAMESPACE,
     name: spec.name,
     description: spec.description,
     inputSchema: spec.inputSchema,

--- a/apps/desktop/src/main/automations/automation-inspection-codex-tools.ts
+++ b/apps/desktop/src/main/automations/automation-inspection-codex-tools.ts
@@ -5,6 +5,7 @@ import type {
 import {
   AUTOMATION_INSPECTION_OPERATION_NAMES,
   AUTOMATION_INSPECTION_TOOL_NAMESPACE,
+  PWRAGENT_TOOL_NAMESPACE,
 } from "@pwragent/shared";
 import type {
   DynamicToolCallParams,
@@ -29,14 +30,17 @@ export function buildAutomationInspectionDynamicToolSpecs(): DynamicToolSpec[] {
 export function isAutomationInspectionDynamicToolCall(
   call: Pick<DynamicToolCallParams, "namespace" | "tool">,
 ): call is DynamicToolCallParams & {
-  namespace: typeof AUTOMATION_INSPECTION_TOOL_NAMESPACE;
+  namespace:
+    | typeof AUTOMATION_INSPECTION_TOOL_NAMESPACE
+    | typeof PWRAGENT_TOOL_NAMESPACE;
   tool: AutomationInspectionOperationName;
 } {
   return (
-    call.namespace === AUTOMATION_INSPECTION_TOOL_NAMESPACE &&
-    AUTOMATION_INSPECTION_OPERATION_NAMES.includes(
-      call.tool as AutomationInspectionOperationName,
-    )
+    call.namespace === AUTOMATION_INSPECTION_TOOL_NAMESPACE ||
+    (call.namespace === PWRAGENT_TOOL_NAMESPACE &&
+      AUTOMATION_INSPECTION_OPERATION_NAMES.includes(
+        call.tool as AutomationInspectionOperationName,
+      ))
   );
 }
 
@@ -45,9 +49,12 @@ export async function handleAutomationInspectionDynamicToolCall(params: {
   call: DynamicToolCallParams;
   handler: AutomationInspectionHandler | undefined;
 }): Promise<DynamicToolCallResponse> {
+  const call = isAutomationInspectionDynamicToolCall(params.call)
+    ? { ...params.call, namespace: PWRAGENT_TOOL_NAMESPACE }
+    : params.call;
   return await buildAutomationInspectionToolRouter(params.handler).handleDynamicToolCall({
     backend: params.backend,
-    call: params.call,
+    call,
   });
 }
 

--- a/apps/desktop/src/main/automations/automation-inspection-mcp.ts
+++ b/apps/desktop/src/main/automations/automation-inspection-mcp.ts
@@ -21,8 +21,9 @@ export type AutomationInspectionMcpTool = AgentMcpTool & {
 export type AutomationInspectionMcpCallResponse = AgentMcpToolCallResponse;
 
 export function buildAutomationInspectionMcpTools(): AutomationInspectionMcpTool[] {
-  return buildAutomationInspectionToolRouter(undefined).buildMcpTools() as
-    AutomationInspectionMcpTool[];
+  return buildAutomationInspectionToolRouter(undefined, {
+    namespace: AUTOMATION_INSPECTION_TOOL_NAMESPACE,
+  }).buildMcpTools() as AutomationInspectionMcpTool[];
 }
 
 export function isAutomationInspectionMcpToolName(
@@ -44,6 +45,7 @@ export async function handleAutomationInspectionMcpToolCall(params: {
   handler: AutomationInspectionHandler | undefined;
 }): Promise<AutomationInspectionMcpCallResponse> {
   return await buildAutomationInspectionToolRouter(params.handler, {
+    namespace: AUTOMATION_INSPECTION_TOOL_NAMESPACE,
     unsupportedMessage: `Unsupported ${AUTOMATION_INSPECTION_TOOL_NAMESPACE} tool.`,
   }).handleMcpToolCall({
     backend: params.backend,

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -185,6 +185,10 @@ type CodexThreadResumePayload = CodexThreadResumeParams & {
   dynamicTools?: CodexDynamicToolSpec[] | null;
 };
 
+type CodexTurnStartPayload = CodexTurnStartParams & {
+  dynamicTools?: CodexDynamicToolSpec[] | null;
+};
+
 type SkillCatalogEntry = {
   commands?: AppServerAvailableCommandSummary[];
   cwd?: string;
@@ -5026,8 +5030,9 @@ function buildTurnStartPayload(params: {
   collaborationMode?: AppServerCollaborationModeRequest;
   collaborationFallbackModel?: string;
   collaborationFallbackReasoningEffort?: string;
-}): CodexTurnStartParams {
-  const base: CodexTurnStartParams = {
+  dynamicTools?: CodexDynamicToolSpec[];
+}): CodexTurnStartPayload {
+  const base: CodexTurnStartPayload = {
     threadId: params.threadId,
     input: params.input.map(toCodexUserInput),
   };
@@ -5057,6 +5062,9 @@ function buildTurnStartPayload(params: {
   }
   if (params.outputSchema) {
     base.outputSchema = params.outputSchema;
+  }
+  if (params.dynamicTools?.length) {
+    base.dynamicTools = params.dynamicTools;
   }
 
   const collaborationOverrides = buildCollaborationModeOverrides({
@@ -6161,6 +6169,7 @@ export class CodexAppServerClient {
             "reasoningEffort",
             "reasoning_effort"
           ),
+          dynamicTools: params.dynamicTools,
         }),
       ],
       timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow, Menu, nativeImage, shell } from "electron";
 import { join } from "node:path";
 import { getDesktopBackendRegistry } from "./app-server/backend-registry";
+import { createPwrAgentAppManagementHandler } from "./agent-tools/pwragent-app-management-service";
 import { disposeAgentIpcHandlers, registerAgentIpcHandlers } from "./ipc/agent-ipc";
 import {
   disposeAppMetadataIpcHandlers,
@@ -138,6 +139,7 @@ const PWRAGENT_ISSUE_REPORTER_URL =
 const isMac = process.platform === "darwin";
 const isDevelopment = process.env.NODE_ENV !== "production";
 const mainLog = getMainLogger("pwragent:main");
+const mainProcessStartedAt = Date.now();
 let mainProcessResourcesDisposed = false;
 let quitInProgress = false;
 let profileFocusRequestWatcher: ProfileFocusRequestWatcher | null = null;
@@ -597,6 +599,12 @@ export function bootstrapApp(): void {
       installProfileFocusRequestWatcher();
     }
     installApplicationMenu();
+    getDesktopBackendRegistry().setPwrAgentAppManagementHandler(
+      createPwrAgentAppManagementHandler({
+        startedAt: mainProcessStartedAt,
+        version: () => app.getVersion(),
+      }),
+    );
     // Windows: serve the painted title-bar menu bar from the live application
     // menu (idempotent; the renderer mounts the bar only on win32).
     wireAppMenuBridge();

--- a/apps/desktop/src/main/quit-manager.ts
+++ b/apps/desktop/src/main/quit-manager.ts
@@ -12,6 +12,7 @@ export const QUIT_CONFIRMATION_COUNTDOWN_SECONDS = 10;
 export type QuitRequestSource =
   | "before-quit"
   | "ipc"
+  | "agent-tool"
   | "main-window-closed"
   | "menu"
   | "signal"

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -254,6 +254,7 @@ export class SqliteOverlayStore {
           retainedBranchDriftPairs: current?.retainedBranchDriftPairs,
           immutableUsageActivities: current?.immutableUsageActivities,
           subAgents: current?.subAgents,
+          handoffOrigin: current?.handoffOrigin,
           lastSeenAt: params.fetchedAt,
           lastSeenUpdatedAt: thread.updatedAt,
           extraLinkedDirectories: current?.extraLinkedDirectories ?? [],
@@ -905,6 +906,26 @@ export class SqliteOverlayStore {
     const nextState: ThreadOverlayState = {
       ...current,
       agent: params.agent ? normalizeThreadAgent(params.agent, params.now) : undefined,
+    };
+    this.putThread(threadKey, nextState);
+    return nextState;
+  }
+
+  async setThreadHandoffOrigin(params: {
+    backend: ThreadOverlayState["backend"];
+    threadId: string;
+    handoffOrigin: ThreadOverlayState["handoffOrigin"] | null;
+  }): Promise<ThreadOverlayState> {
+    const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+    const current = this.getThread(threadKey) ?? {
+      backend: params.backend,
+      threadId: params.threadId,
+      executionMode: "default" as const,
+      extraLinkedDirectories: [],
+    };
+    const nextState: ThreadOverlayState = {
+      ...current,
+      handoffOrigin: params.handoffOrigin ?? undefined,
     };
     this.putThread(threadKey, nextState);
     return nextState;
@@ -2466,6 +2487,7 @@ export type OverlayStoreLike = Pick<
   | "setThreadPin"
   | "setThreadParent"
   | "setThreadAgent"
+  | "setThreadHandoffOrigin"
   | "reorderThreadPins"
   | "updateSubthreadOrder"
   | "setSubthreadsCollapsed"

--- a/docs/plans/2026-06-18-001-feat-agent-task-handoff-tool-plan.md
+++ b/docs/plans/2026-06-18-001-feat-agent-task-handoff-tool-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Add agent task handoff dynamic tool"
 type: feat
-status: active
+status: completed
 date: 2026-06-18
 ---
 

--- a/docs/plans/2026-06-18-001-feat-agent-task-handoff-tool-plan.md
+++ b/docs/plans/2026-06-18-001-feat-agent-task-handoff-tool-plan.md
@@ -1,0 +1,536 @@
+---
+title: "feat: Add agent task handoff dynamic tool"
+type: feat
+status: active
+date: 2026-06-18
+---
+
+# feat: Add agent task handoff dynamic tool
+
+## Summary
+
+Add a first-class `pwragent` dynamic tool that lets an Agent hand a task to a newly created thread. The tool should inherit the invoking thread's provider, model, reasoning, fast mode, permission mode, Codex environment, and workspace by default, apply only explicit user overrides, start the new thread with a structured handoff prompt, and preserve a durable reference back to the spawning thread. Clean new-thread handoff is the default; transcript fork and sub-thread grouping are explicit modes.
+
+---
+
+## Problem Frame
+
+Today PwrAgent can start threads, fork Codex threads, materialize launchpads, attach messaging surfaces, and spawn lightweight monitor delegates. Those capabilities are not yet available as a deterministic "handoff this task to a new thread" Agent tool. Without that tool, an Agent has to rely on prompt convention, slash commands, or monitor-specific delegation, which cannot reliably inherit the current thread's runtime settings and workspace context.
+
+The requested behavior is explicitly thread-oriented: a user should be able to say "handoff task XYZ to a new thread" from desktop or messaging, and the current Agent should invoke a tool that creates and starts that new thread with the right project/worktree, execution settings, origin reference, and optional messaging attachment. If the user says "fork this thread" or "handoff to a sub-thread," those words select explicit modes rather than changing the default handoff behavior.
+
+---
+
+## Requirements
+
+- R1. Expose task handoff through the existing advertised `pwragent` dynamic-tool namespace, not a new public namespace or slash command.
+- R2. Keep existing deprecated namespace facades for old tool families working for existing threads; the new handoff tool should not require another compatibility namespace.
+- R3. Create a new independent thread by default, not a transcript fork.
+- R4. Inherit the invoking thread's backend/provider, execution mode, approval/sandbox policy, model, reasoning effort, service tier, fast mode, Codex environment runtime, ACP runtime, current workspace, linked directory, Git branch, and worktree context by default where the backend supports those fields.
+- R5. Apply only explicit user-requested overrides, and reject unsupported or ambiguous overrides with structured tool errors.
+- R6. Start the created thread immediately with a handoff prompt assembled from the Agent-supplied task plus PwrAgent-owned context metadata.
+- R7. Persist a source reference on the created thread so it can identify the spawning thread, spawning turn, source title, branch, workspace/worktree, and creation time without implying shared transcript access.
+- R8. Support optional sub-thread grouping through the existing parent/subthread UI relationship when the user explicitly asks for a sub-thread; leave grouping off by default.
+- R9. Return a bounded structured result containing the created thread id, backend, turn id or start failure, inherited settings summary, workspace summary, optional subthread grouping outcome, and any messaging attachment outcome.
+- R10. Enforce runtime access: the tool call must originate from a live Agent turn on the same thread, must be denied when the current context cannot support handoff, and must return clear reasons for messaging or user access denial.
+- R11. When invoked from a messaging-originated Agent turn, optionally attach the created thread to the current messaging location using the existing messaging context rules, falling back to an explicit "created but not attached" result when the provider or actor cannot do that.
+- R12. Preserve the current dynamic-tool compatibility and catalog model while reducing new branch-per-tool dispatch in `backend-registry.ts`.
+- R13. Cover contracts, router behavior, inheritance, thread creation, messaging attachment, runtime denial, and regression compatibility with focused tests.
+- R14. Report whether the current project is backed by Git, whether worktree creation is available, and which workspace mode was selected or rejected.
+- R15. Mark the created thread as an Agent thread by default, inheriting the parent Agent metadata and enabled tool catalogs unless explicit future policy says otherwise.
+- R16. Support an explicit fork seed mode that copies the current thread transcript when the user asks to fork, while preserving clean new-thread handoff as the default.
+
+---
+
+## Scope Boundaries
+
+- This plan creates a new Agent dynamic tool for task handoff; it does not add a user-facing slash command.
+- This plan creates a new independent thread and starts a first turn by default; it copies the parent transcript only when an explicit fork mode is requested.
+- This plan may create an isolated worktree when explicitly requested, but same-current-workspace inheritance is the default.
+- This plan does not replace `pwragent_task_monitors.create_monitor_delegation`; monitors remain the lightweight polling/status-check tool.
+- This plan does not implement full Bot/RBAC policy, cross-machine handoff, or reusable Agent templates.
+- This plan does not give created threads direct access to parent transcript storage or Codex-owned session files.
+
+### Deferred to Follow-Up Work
+
+- Rich cross-thread context retrieval where the created thread can request additional parent-thread context through an audited PwrAgent tool.
+- A general thread-control catalog with enqueue-message and approval-management tools beyond this handoff operation.
+- ACP MCP parity for every backend if current ACP tool registration cannot yet expose the new catalog with equivalent runtime context.
+- UI polish for showing handoff-origin metadata beyond optional subthread grouping and the tool result.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/shared/src/contracts/agent-tools.ts` defines the single advertised `pwragent` tool namespace and internal catalog ids.
+- `packages/shared/src/contracts/thread-tools.ts`, `app-tools.ts`, `messaging-tools.ts`, and `task-monitor-tools.ts` show the current operation-name, args, response, error-code, and deprecated-namespace compatibility shape.
+- `apps/desktop/src/main/agent-tools/agent-tool-definition.ts`, `agent-tool-router.ts`, and `agent-tool-catalog-registry.ts` define the catalog/router substrate used by current Agent dynamic tools.
+- `apps/desktop/src/main/agent-tools/pwragent-thread-agent-tools.ts`, `pwragent-app-agent-tools.ts`, and `pwragent-messaging-agent-tools.ts` show how catalog definitions project into Codex dynamic tool specs.
+- `apps/desktop/src/main/app-server/backend-registry.ts` owns `startThread`, `startTurn`, `forkThread`, `materializeDirectoryLaunchpad`, dynamic-tool dispatch, live-turn validation, model setting resolution, Codex environment runtime persistence, and parent-thread grouping.
+- `packages/shared/src/contracts/agent.ts` carries `StartThreadRequest`, `StartTurnRequest`, `ForkThreadRequest`, and `MaterializeDirectoryLaunchpadRequest` fields for inherited provider/runtime settings.
+- `packages/shared/src/contracts/navigation.ts` defines `ThreadOverlayState`, `NavigationThreadSummary`, `NavigationLaunchpadDraft`, `ThreadAgentMetadata`, and the explicit UI-only parent thread invariant.
+- `apps/desktop/src/main/state/overlay-store-sqlite.ts` persists thread overlay state, Agent metadata, model settings, Codex environment runtime, parent/subthread ordering, and linked-directory overlays.
+- `apps/desktop/src/main/messaging/desktop-backend-bridge.ts`, `messaging-controller.ts`, and `pwragent-messaging-agent-tools.ts` provide the existing messaging bridge and current-location/attach-thread dynamic tools.
+- `apps/desktop/src/main/__tests__/backend-registry.test.ts` already contains focused coverage for Agent dynamic tools, launchpad materialization, forking, parent grouping, runtime inheritance, and dynamic-tool denial.
+- `apps/desktop/src/main/agent-tools/__tests__/agent-tool-router.test.ts` and `packages/shared/src/contracts/__tests__/agent-tools.test.ts` are the closest contract/router test patterns.
+
+### Institutional Learnings
+
+- `docs/solutions/2026-05-07-codex-permission-mode-state-machine.md` warns against silent fallback across security-relevant permission boundaries. The handoff tool must inherit and log/return effective permission state deliberately instead of relying on upstream defaults.
+- `docs/plans/2026-06-07-001-feat-agent-thread-messaging-tools-plan.md` established the catalog-driven Agent tool direction and the single `pwragent` namespace.
+- `docs/plans/2026-05-22-001-feat-messaging-new-thread-backend-selection-plan.md` established that messaging-created threads should respect backend/model/reasoning/fast/permission choices before creation.
+- `docs/plans/2026-04-29-001-feat-thread-workspace-handoff-plan.md` established that workspace/worktree movement and metadata updates belong in desktop main, not renderer or messaging-specific branches.
+
+### External References
+
+- Not used. Existing repository contracts and prior PwrAgent plans provide the relevant patterns.
+
+---
+
+## Key Technical Decisions
+
+- Use one public namespace with internal catalog grouping: the new tool should be advertised as `pwragent.handoff_task`, with a new internal catalog id such as `thread_orchestration`. Catalog ids are enablement and diagnostics metadata, not user-facing namespaces.
+- Default to same-workspace new threads: "handoff task to a new thread" should preserve the current project/worktree unless the user explicitly asks for isolation, a new branch, or a new worktree.
+- Start a clean new thread rather than fork by default: Codex `thread/fork` copies source transcript semantics, so it should be used only when the user explicitly asks to fork the current thread.
+- Let the Agent provide task intent, and let PwrAgent provide the envelope: the dynamic tool args carry the Agent's task summary and optional context, while the handler injects source thread, runtime, workspace, and messaging metadata in a consistent wrapper.
+- Persist origin metadata separately from `parentThreadId`: origin metadata is always useful for handoff provenance, while `parentThreadId` is only set when the user requests sub-thread grouping.
+- Treat permission and environment inheritance as security-relevant: inherit from the current effective overlay/runtime state, derive approval/sandbox from execution mode where needed, and reject mismatched overrides instead of silently normalizing to a different mode.
+- Attach to messaging only through existing messaging policy: when requested, use the current messaging-location context and attach rules; if the actor/provider cannot attach, the thread creation can still succeed with a structured non-attachment reason.
+- Consolidate dynamic-tool dispatch while adding this tool: the implementation should move toward a single PwrAgent dynamic tool router path so `backend-registry.ts` does not grow another nearly identical catalog branch.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should this be a new public namespace? No. It belongs under the existing `pwragent` namespace; only internal catalog grouping should expand.
+- Should this be a slash command? No. Messaging should reach it through Agent dynamic tools.
+- Should the default be a new worktree? No. Inherit the current workspace/worktree by default; create a new worktree only when explicitly requested.
+- Should this use Codex fork by default? No. The handoff creates a clean thread and starts it with a prompt unless the user explicitly asks to fork.
+- Should parent grouping imply context sharing? No. Preserve the existing invariant and put required context in the prompt/origin metadata; only set sub-thread grouping when requested.
+
+### Deferred to Implementation
+
+- Exact tool argument names may adjust to match the surrounding contract naming style.
+- Exact handoff prompt wording should be finalized during implementation, but the envelope fields and invariant are plan-owned.
+- Whether ACP MCP can expose this tool in the same PR depends on the current ACP dynamic-tool/MCP registration path; unsupported runtimes should report an unavailable catalog reason rather than pretend parity.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+sequenceDiagram
+  participant User as User
+  participant Parent as Parent Agent turn
+  participant Router as PwrAgent tool router
+  participant Service as Handoff service
+  participant Registry as Backend registry
+  participant Store as Overlay and messaging stores
+  participant Child as Target thread
+
+  User->>Parent: handoff task XYZ to a new thread
+  Parent->>Router: pwragent.handoff_task(task, overrides)
+  Router->>Service: live caller context + validated args
+  Service->>Registry: read source overlay and workspace state
+  Service->>Registry: start or fork target thread with inherited settings
+  Service->>Store: persist handoff origin and optional grouping
+  Service->>Child: start first turn with structured handoff prompt
+  Service->>Store: optional messaging attach through existing policy
+  Service-->>Parent: created thread, turn, settings, workspace, attach result
+```
+
+### Inheritance Matrix
+
+| Source concept | Default behavior |
+|---|---|
+| Backend/provider | Use invoking thread backend when that backend can start a new thread. |
+| Model/reasoning/service tier/fast mode | Use overlay/current thread model settings and backend defaults resolution. |
+| Permission mode | Use current effective execution mode; approval/sandbox derive from the same mode unless explicitly overridden. |
+| Codex environment | Preserve selected environment/action runtime for same-workspace handoff; derive a child-safe runtime for new worktree handoff. |
+| Workspace/worktree | Use current resolved workspace and linked directory by default; create a new worktree only when requested. |
+| Messaging location | Attach only when requested/auto-enabled and existing messaging context authorizes it. |
+| Parent context | Persist source metadata and include a bounded prompt envelope; do not read parent transcript files except through explicit backend fork support. |
+
+---
+
+## Implementation Units
+
+```mermaid
+flowchart TB
+  U1["U1 Contracts"] --> U2["U2 Tool definitions"]
+  U1 --> U3["U3 Origin metadata"]
+  U2 --> U4["U4 Handoff service"]
+  U3 --> U4
+  U4 --> U5["U5 Dispatch integration"]
+  U4 --> U6["U6 Messaging attachment"]
+  U5 --> U7["U7 Tests"]
+  U6 --> U7
+  U7 --> U8["U8 Docs and guidance"]
+```
+
+### U1. Shared Handoff Contracts
+
+**Goal:** Define the tool operation, args, response, errors, catalog id, and origin metadata shape in shared contracts.
+
+**Requirements:** R1, R4, R5, R7, R9, R10, R12
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/shared/src/contracts/agent-tools.ts`
+- Create: `packages/shared/src/contracts/thread-orchestration-tools.ts`
+- Modify: `packages/shared/src/contracts/navigation.ts`
+- Modify: `packages/shared/src/index.ts`
+- Test: `packages/shared/src/contracts/__tests__/agent-tools.test.ts`
+- Test: `packages/shared/src/contracts/__tests__/thread-orchestration-tools.test.ts`
+
+**Approach:**
+- Add an internal catalog id for thread orchestration while keeping `PWRAGENT_TOOL_NAMESPACE` as the only advertised namespace.
+- Define `handoff_task` args around task text, optional title/context, seed mode, grouping mode, workspace mode, explicit provider/runtime overrides, and optional messaging attachment mode.
+- Define a bounded success payload with created thread identity, first-turn status, inherited settings, workspace/git details, origin metadata, optional grouping outcome, fork outcome, and attachment outcome.
+- Define structured error codes for invalid arguments, forbidden, not found, unsupported backend, unsupported workspace, ambiguous workspace, turn start failure, and internal errors.
+- Extend `ThreadOverlayState` with durable handoff-origin metadata that records source backend/thread/turn, source title when available, source workspace/worktree/branch, created time, and requested task title.
+
+**Patterns to follow:**
+- `packages/shared/src/contracts/agent-tools.ts`
+- `packages/shared/src/contracts/thread-tools.ts`
+- `packages/shared/src/contracts/messaging-tools.ts`
+- `packages/shared/src/contracts/navigation.ts`
+
+**Test scenarios:**
+- Happy path: catalog ids include thread orchestration and normalization preserves known ids while dropping unknown ids.
+- Happy path: handoff args/response types accept clean, fork, no-grouping, subthread-grouping, same-workspace, and new-worktree modes.
+- Edge case: unknown catalog ids remain ignored by normalization.
+- Error path: invalid operation names and invalid attachment modes are rejected by contract helpers where helpers exist.
+
+**Verification:** Shared contract tests prove the new catalog and operation are stable without changing the public namespace.
+
+### U2. Tool Definition and Router Projection
+
+**Goal:** Add the `pwragent.handoff_task` Agent tool definition and project it into dynamic-tool specs through the existing catalog system.
+
+**Requirements:** R1, R2, R5, R9, R10, R12
+
+**Dependencies:** U1
+
+**Files:**
+- Create: `apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts`
+- Create: `apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-codex-tools.ts`
+- Modify: `apps/desktop/src/main/agent-tools/agent-tool-catalog-registry.ts`
+- Modify: `apps/desktop/src/main/agent-tools/agent-tool-router.ts`
+- Test: `apps/desktop/src/main/agent-tools/__tests__/agent-tool-router.test.ts`
+- Test: `apps/desktop/src/main/__tests__/backend-registry.test.ts`
+
+**Approach:**
+- Define the tool once with namespace, name, description, JSON schema, and dispatch bridge.
+- Keep legacy facade logic only for existing old namespaces; because `handoff_task` is new, advertise it only under `pwragent`.
+- Include guidance in the tool description that it should be used when the user asks to hand off/delegate a task to a new thread, and that omitted settings inherit from the invoking thread.
+- Extend router support so catalog dispatch can normalize new and existing PwrAgent tool calls consistently.
+
+**Patterns to follow:**
+- `apps/desktop/src/main/agent-tools/pwragent-thread-agent-tools.ts`
+- `apps/desktop/src/main/agent-tools/pwragent-app-agent-tools.ts`
+- `apps/desktop/src/main/agent-tools/pwragent-messaging-agent-tools.ts`
+
+**Test scenarios:**
+- Happy path: Agent catalog resolution includes `handoff_task` for Agent threads under the `pwragent` namespace.
+- Happy path: dynamic tool spec exposes the expected name, description, schema, and no deprecated namespace.
+- Error path: unknown orchestration tool names return `unsupported_operation`.
+- Regression: existing deprecated namespaces for app/thread/messaging/automation tools still route as before.
+
+**Verification:** Dynamic tool specs show a single public namespace and include the new operation without breaking compatibility for existing tool families.
+
+### U3. Handoff Origin Persistence
+
+**Goal:** Persist and surface enough origin metadata for the created thread to know where it came from without treating the parent transcript as shared memory.
+
+**Requirements:** R7, R8, R9, R13
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `apps/desktop/src/main/state/overlay-store-sqlite.ts`
+- Modify: `apps/desktop/src/main/app-server/backend-registry.ts`
+- Modify: `packages/shared/src/contracts/thread-tools.ts`
+- Test: `apps/desktop/src/main/__tests__/overlay-store-agent.test.ts`
+- Test: `apps/desktop/src/main/__tests__/backend-registry.test.ts`
+- Test: `packages/shared/src/contracts/__tests__/thread-orchestration-tools.test.ts`
+
+**Approach:**
+- Add an overlay-store setter for handoff origin metadata or fold it into an existing thread-overlay update helper if that keeps the store API smaller.
+- Store origin metadata on the created thread after its thread id exists and before or alongside the first turn start.
+- Reuse `setThreadParent` only when the tool args request sub-thread grouping, while documenting and testing that this remains UI-only grouping.
+- Extend thread inspection/status summaries to include handoff origin where useful, keeping output bounded.
+
+**Patterns to follow:**
+- `apps/desktop/src/main/state/overlay-store-sqlite.ts` `setThreadParent`
+- `packages/shared/src/contracts/navigation.ts` `ThreadOverlayState`
+- `packages/shared/src/contracts/thread-tools.ts` status summaries
+
+**Test scenarios:**
+- Happy path: setting handoff origin persists across store reopen and does not overwrite Agent metadata, model settings, or parent grouping.
+- Happy path: requested sub-thread grouping is written through `setThreadParent` and parent `subthreadOrder` updates.
+- Happy path: default handoff stores origin metadata without setting `parentThreadId`.
+- Edge case: source title or branch can be absent without failing persistence.
+- Regression: parent grouping remains independent of origin metadata and can be cleared without deleting origin metadata unless explicitly requested.
+
+**Verification:** Overlay state can answer "who spawned this thread, from what workspace, and when" without reading provider-private transcript storage.
+
+### U4. Backend Handoff Service
+
+**Goal:** Implement the orchestration service that resolves source context, inherits settings, creates or forks the target thread, starts the first turn, and returns a structured result.
+
+**Requirements:** R3, R4, R5, R6, R7, R8, R9, R10, R13, R14, R15, R16
+
+**Dependencies:** U1, U3
+
+**Files:**
+- Create: `apps/desktop/src/main/app-server/agent-task-handoff-service.ts`
+- Modify: `apps/desktop/src/main/app-server/backend-registry.ts`
+- Test: `apps/desktop/src/main/__tests__/agent-task-handoff-service.test.ts`
+- Test: `apps/desktop/src/main/__tests__/backend-registry.test.ts`
+
+**Approach:**
+- Build a service owned by desktop main so it can coordinate backend clients, overlay state, Git workspace resolution, Codex environment runtime, and messaging policy without crossing dependency boundaries.
+- Resolve the invoking thread's overlay, current execution mode, model settings, active workspace, linked directory, Git branch, Agent metadata, and environment runtime from existing registry/store helpers.
+- Compute a workspace capability summary that distinguishes no workspace, non-Git workspace, Git local checkout, Git worktree, and worktree-creation availability; include that summary in success and denial responses.
+- Create the target with `startThread` for clean-thread semantics by default, passing inherited settings and workspace details.
+- When explicit fork seed mode is requested and the backend supports it, use `forkThread` to seed the target from the current transcript, then start the first handoff turn in the forked thread.
+- Reject fork seed mode with a structured unsupported-backend error for backends that cannot fork.
+- For same-workspace handoff, pass the current resolved cwd/linked directory and preserve Codex environment runtime with a current workspace cwd.
+- For explicit new-worktree handoff, reuse launchpad workspace preparation semantics and derive a child-safe Codex environment runtime rather than reusing stale cwd data.
+- Start the first turn with a structured prompt that includes the Agent-supplied task and PwrAgent-owned source metadata.
+- If thread creation or fork succeeds but first turn start fails, keep the created thread and return `turnStartFailure` with enough information for the parent Agent to report recovery options.
+
+**Execution note:** Implement characterization coverage around existing start-thread inheritance before adding the handoff service, because this unit depends on permission/runtime fields that have regressed historically.
+
+**Patterns to follow:**
+- `apps/desktop/src/main/app-server/backend-registry.ts` `startThread`
+- `apps/desktop/src/main/app-server/backend-registry.ts` `startTurn`
+- `apps/desktop/src/main/app-server/backend-registry.ts` `materializeDirectoryLaunchpad`
+- `apps/desktop/src/main/app-server/backend-registry.ts` `buildForkedCodexEnvironmentRuntime`
+
+**Test scenarios:**
+- Happy path: same-workspace Codex handoff starts a created thread with inherited execution mode, model, reasoning effort, service tier, fast mode, cwd, linked directory, Agent metadata, and Codex environment runtime.
+- Happy path: created thread is marked as an Agent thread and receives the same enabled PwrAgent tool catalogs as the parent by default.
+- Happy path: explicit fork seed mode calls the backend fork path, preserves inherited runtime settings, and then starts the handoff turn in the forked thread.
+- Happy path: explicit sub-thread grouping sets parent grouping, while default clean handoff does not.
+- Happy path: explicit new-worktree handoff prepares a worktree, records ownership, updates linked directory metadata, and starts the created thread on the requested branch.
+- Happy path: first prompt contains the task and bounded origin metadata but no parent transcript dump.
+- Edge case: parent thread has no resolvable workspace and the tool returns `unsupported_workspace` unless args explicitly allow a no-workspace created thread.
+- Edge case: parent workspace is not Git-backed, so same-workspace handoff can proceed but new-worktree handoff is denied with worktree capability details.
+- Edge case: queued permission mode on the parent does not silently become the child execution mode while the parent turn is still active.
+- Error path: unsupported backend, backend without create-thread capability, or backend without fork capability for requested fork mode returns a structured denial before mutation.
+- Error path: thread creation succeeds but turn start fails, returning created thread id plus turn failure without rolling back the created thread.
+
+**Verification:** A parent Agent can hand off a task and receive a created thread id plus turn state, with inherited runtime settings visible in overlays and backend start parameters.
+
+### U5. Runtime Access and Dispatch Integration
+
+**Goal:** Route `handoff_task` calls through runtime guards that are shared with the existing PwrAgent tools and avoid adding another bespoke branch in `backend-registry.ts`.
+
+**Requirements:** R1, R2, R10, R12, R13
+
+**Dependencies:** U2, U4
+
+**Files:**
+- Modify: `apps/desktop/src/main/app-server/backend-registry.ts`
+- Modify: `apps/desktop/src/main/agent-tools/agent-tool-catalog-registry.ts`
+- Modify: `apps/desktop/src/main/agent-tools/agent-tool-router.ts`
+- Test: `apps/desktop/src/main/__tests__/backend-registry.test.ts`
+- Test: `apps/desktop/src/main/agent-tools/__tests__/agent-tool-router.test.ts`
+
+**Approach:**
+- Introduce a unified PwrAgent dynamic-tool dispatch path that can identify any registered `pwragent` tool definition, apply the live-turn guard, normalize deprecated namespaces for existing families, and invoke the right handler.
+- Keep task monitor handling separate if needed because its namespace and monitor lifecycle are intentionally distinct.
+- Require an active turn id matching the calling backend/thread for handoff and return a forbidden tool response when the call is stale, out-of-thread, or missing turn context.
+- Include denial reason data for unsupported messaging contexts, unsupported backends, and unavailable handlers.
+
+**Patterns to follow:**
+- `apps/desktop/src/main/app-server/backend-registry.ts` `isLiveDynamicToolCall`
+- `apps/desktop/src/main/agent-tools/pwragent-thread-codex-tools.ts`
+- `apps/desktop/src/main/agent-tools/pwragent-app-codex-tools.ts`
+
+**Test scenarios:**
+- Happy path: active Agent turn can invoke `pwragent.handoff_task`.
+- Error path: call with missing turn id, stale turn id, wrong thread id, or wrong backend is denied before handler execution.
+- Error path: non-Agent thread does not receive the tool spec and direct invocation is denied or unsupported.
+- Regression: app, thread, messaging, and automation tools still dispatch successfully through their old compatibility paths.
+- Regression: task monitor tools retain their existing namespace and lifecycle behavior.
+
+**Verification:** Adding the new handoff tool reduces or at least does not increase catalog-specific dispatch branching in `backend-registry.ts`.
+
+### U6. Messaging-Origin Attachment
+
+**Goal:** Let messaging-originated Agent turns hand off a task to a new thread and make that created thread reachable from the current messaging location when policy and provider capabilities allow it.
+
+**Requirements:** R6, R9, R10, R11, R13
+
+**Dependencies:** U4, U5
+
+**Files:**
+- Modify: `apps/desktop/src/main/app-server/agent-task-handoff-service.ts`
+- Modify: `apps/desktop/src/main/agent-tools/pwragent-messaging-agent-tools.ts`
+- Modify: `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- Test: `apps/desktop/src/main/__tests__/agent-task-handoff-service.test.ts`
+- Test: `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+- Test: `apps/desktop/src/main/__tests__/backend-registry.test.ts`
+
+**Approach:**
+- Reuse the current messaging context lookup keyed by backend/thread/turn so the handoff service can tell whether the active turn came from messaging.
+- If attachment is `auto` or explicitly requested, route through the same attach-thread policy used by `attach_thread_here`, including actor authorization and provider managed-conversation capability checks.
+- When a provider can create a child conversation/topic, attach the created thread there; otherwise attach to the current conversation only when that matches the existing placement policy.
+- If attachment is denied or unsupported after thread creation, return a non-fatal attachment outcome explaining why.
+
+**Patterns to follow:**
+- `apps/desktop/src/main/agent-tools/pwragent-messaging-agent-tools.ts`
+- `packages/shared/src/contracts/messaging-tools.ts`
+- `apps/desktop/src/main/messaging/core/messaging-controller.ts` browse/binding policy
+
+**Test scenarios:**
+- Happy path: messaging-originated handoff with child-conversation support creates and attaches the created thread to the new provider conversation.
+- Happy path: messaging-originated handoff with current-conversation placement attaches the created thread to the current location when allowed.
+- Edge case: desktop-originated handoff with `auto` attachment skips messaging attachment and reports no messaging location.
+- Error path: unauthorized messaging actor or missing provider permission returns thread-created-but-not-attached with a clear reason.
+- Regression: existing `get_current_location` and `attach_thread_here` tools still work independently.
+
+**Verification:** A user invoking an Agent from messaging can ask for a handoff and get a created thread that is either reachable from messaging or reports exactly why it is not.
+
+### U7. End-to-End Behavioral Tests
+
+**Goal:** Lock the cross-layer behavior with tests that exercise the real registry/tool path rather than only unit-level helpers.
+
+**Requirements:** R1, R3, R4, R6, R7, R8, R9, R10, R11, R13, R14, R15, R16
+
+**Dependencies:** U1, U2, U3, U4, U5, U6
+
+**Files:**
+- Modify: `apps/desktop/src/main/__tests__/backend-registry.test.ts`
+- Create: `apps/desktop/src/main/__tests__/agent-task-handoff-service.test.ts`
+- Modify: `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+- Modify: `apps/desktop/src/main/agent-tools/__tests__/agent-tool-router.test.ts`
+- Modify: `packages/shared/src/contracts/__tests__/agent-tools.test.ts`
+- Modify: `packages/shared/src/contracts/__tests__/thread-orchestration-tools.test.ts`
+
+**Approach:**
+- Prefer focused main-process tests using existing mocks over broad Electron E2E unless implementation changes renderer-visible behavior.
+- Add at least one full dynamic-tool call test from active Agent turn through router/service/startThread/startTurn mocks.
+- Add failure tests for stale tool calls and unsupported workspace/backend cases.
+- Add regression assertions for inherited settings because permission/model/runtime fields are the feature's core correctness surface.
+
+**Test scenarios:**
+- Integration: active Agent dynamic tool call creates and starts a thread with inherited settings and origin metadata, without parent grouping by default.
+- Integration: explicit sub-thread handoff creates parent grouping.
+- Integration: explicit fork handoff copies transcript through the backend fork path and starts the handoff turn.
+- Integration: same request from messaging attaches the created thread when provider policy permits.
+- Integration: stale dynamic tool call returns forbidden and does not call thread creation.
+- Error path: first turn start failure returns created thread identity plus structured failure.
+- Regression: old deprecated namespaces for existing app/thread/messaging tools still invoke their facades.
+- Regression: no implementation reads Codex-owned session JSONL or sqlite storage to build the handoff prompt.
+
+**Verification:** The implementation can be reviewed through deterministic tests without requiring a live messaging provider or a live Codex child for every scenario.
+
+### U8. Guidance, Tool Copy, and Operational Notes
+
+**Goal:** Add concise guidance so Agents know when to use the new tool, and document the runtime denial model for future tool additions.
+
+**Requirements:** R1, R2, R5, R10, R11, R12
+
+**Dependencies:** U2, U5, U6
+
+**Files:**
+- Modify: `docs/messaging-architecture.md`
+- Modify: `docs/messaging-platform-integration.md`
+- Modify: `apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts`
+- Test: none
+
+**Approach:**
+- Document that "handoff task to a new thread" should use `pwragent.handoff_task` from an Agent turn rather than slash commands.
+- Document that all PwrAgent product tools use the `pwragent` namespace, while internal catalog ids control grouping/diagnostics.
+- Document that tool visibility does not imply availability in every runtime context; handlers must deny at runtime with structured reasons when called from stale turns, unsupported messaging locations, unsupported backends, or unauthorized actors.
+- Keep operator-facing docs compact; avoid exposing implementation catalog details beyond what helps troubleshoot unavailable tools.
+
+**Patterns to follow:**
+- `docs/messaging-architecture.md`
+- `docs/messaging-platform-integration.md`
+- Existing dynamic tool descriptions in `apps/desktop/src/main/agent-tools/`
+
+**Test scenarios:**
+- Test expectation: none -- this unit updates documentation and tool descriptions only.
+
+**Verification:** Docs and tool copy tell Agents and maintainers to use the single dynamic-tool surface and expect runtime denial when context does not authorize an operation.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** Agent turns, backend registry, dynamic-tool catalogs, overlay store, Git workspace resolution, Codex environment runtime, and messaging binding policy all participate in the handoff path.
+- **Error propagation:** Tool handler errors should return structured tool failures; thread-created/turn-failed and thread-created/not-attached are partial-success states, not generic internal errors.
+- **State lifecycle risks:** Thread creation or fork is not atomic with first turn start, optional grouping, or messaging attachment. The response must expose partial state so the parent Agent can recover or report accurately.
+- **API surface parity:** Codex dynamic tools are the primary target. ACP MCP exposure should be added only where the current runtime can carry equivalent caller context; otherwise the catalog should be unavailable with a reason.
+- **Integration coverage:** Unit tests alone will not prove inherited settings across registry boundaries; backend-registry tests must assert the actual parameters passed to thread start/turn start.
+- **Unchanged invariants:** Parent/subthread relationships remain UI grouping only; Codex private storage remains off-limits; task monitors remain a separate monitor-specific tool surface.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Permission mode inheritance silently drifts from the parent | Read from the current effective overlay/runtime state, derive approval/sandbox through existing execution-mode summaries, and test inherited start parameters. |
+| Thread is created or forked but first turn fails | Return a partial-success result with created thread id and turn failure details; do not hide the created thread. |
+| New tool adds another namespace or dispatch branch | Advertise only `pwragent.handoff_task` and consolidate dispatch through catalog/router helpers. |
+| Messaging attachment accidentally bypasses actor/provider policy | Reuse existing messaging context and attach-thread policy; report non-fatal attachment denial reasons. |
+| New worktree mode corrupts workspace expectations | Default to same workspace; require explicit worktree request; reuse existing launchpad/worktree preparation and ownership recording. |
+| Handoff prompt leaks too much parent context | Include bounded source metadata and Agent-provided summary only; never inspect Codex session files. |
+
+---
+
+## Alternative Approaches Considered
+
+- Use `pwragent_task_monitors.create_monitor_delegation`: Rejected because monitor delegates are optimized for lightweight asynchronous status checks, not full inherited thread creation with messaging attachment and workspace/runtime settings.
+- Use Codex `thread/fork` by default: Rejected because fork semantics copy transcript context. It remains available only as an explicit seed mode when the user asks to fork.
+- Add another public namespace such as `pwragent_threads`: Rejected because the product direction is a single `pwragent` surface with internal catalogs and deprecated facades only for existing threads.
+- Implement as a messaging slash command: Rejected because the user specifically wants messaging to use Agent dynamic tools rather than command parsing.
+
+---
+
+## Success Metrics
+
+- An Agent can invoke `pwragent.handoff_task` from an active turn and receive a created thread id plus first-turn state.
+- The created thread starts with the same effective provider/runtime/workspace settings unless the user explicitly requested supported overrides.
+- Messaging-originated handoffs either attach the created thread to the current messaging location or return a clear non-attachment reason.
+- Existing deprecated namespaces for old tool families continue to work for already-running threads.
+- No new code path reads Codex-owned session JSONL, rollout files, or sqlite storage.
+
+---
+
+## Documentation / Operational Notes
+
+- Update messaging docs to describe Agent dynamic-tool handoff as the route for "handoff task to a new thread."
+- Keep troubleshooting language centered on runtime availability: a tool can be registered but deny invocation because the turn is stale, the actor is not authorized, the backend cannot start a child, or the messaging provider cannot create/attach a child conversation.
+- Mention that handoff-created threads are independent Agent threads by default; sub-thread grouping is optional and does not grant context sharing.
+
+---
+
+## Sources & References
+
+- Related plan: `docs/plans/2026-06-07-001-feat-agent-thread-messaging-tools-plan.md`
+- Related plan: `docs/plans/2026-05-22-001-feat-messaging-new-thread-backend-selection-plan.md`
+- Related plan: `docs/plans/2026-04-29-001-feat-thread-workspace-handoff-plan.md`
+- Institutional learning: `docs/solutions/2026-05-07-codex-permission-mode-state-machine.md`
+- Related code: `packages/shared/src/contracts/agent-tools.ts`
+- Related code: `packages/shared/src/contracts/agent.ts`
+- Related code: `packages/shared/src/contracts/navigation.ts`
+- Related code: `packages/shared/src/contracts/thread-tools.ts`
+- Related code: `apps/desktop/src/main/agent-tools/agent-tool-router.ts`
+- Related code: `apps/desktop/src/main/agent-tools/agent-tool-catalog-registry.ts`
+- Related code: `apps/desktop/src/main/app-server/backend-registry.ts`
+- Related code: `apps/desktop/src/main/state/overlay-store-sqlite.ts`
+- Related code: `apps/desktop/src/main/messaging/core/messaging-controller.ts`

--- a/packages/shared/src/contracts/__tests__/agent-tools.test.ts
+++ b/packages/shared/src/contracts/__tests__/agent-tools.test.ts
@@ -18,11 +18,13 @@ describe("agent tool contracts", () => {
       "app_management",
       "thread_inspection",
       "messaging_context",
+      "thread_orchestration",
     ]);
     expect(isAgentToolCatalogId("automation_inspection")).toBe(true);
     expect(isAgentToolCatalogId("app_management")).toBe(true);
     expect(isAgentToolCatalogId("thread_inspection")).toBe(true);
     expect(isAgentToolCatalogId("messaging_context")).toBe(true);
+    expect(isAgentToolCatalogId("thread_orchestration")).toBe(true);
     expect(isAgentToolCatalogId("shell")).toBe(false);
   });
 
@@ -34,6 +36,7 @@ describe("agent tool contracts", () => {
         "app_management",
         "thread_inspection",
         "messaging_context",
+        "thread_orchestration",
         "unknown",
       ]),
     ).toEqual([
@@ -41,6 +44,7 @@ describe("agent tool contracts", () => {
       "app_management",
       "thread_inspection",
       "messaging_context",
+      "thread_orchestration",
     ]);
     expect(
       normalizeAgentToolCatalogIds(undefined, {

--- a/packages/shared/src/contracts/__tests__/agent-tools.test.ts
+++ b/packages/shared/src/contracts/__tests__/agent-tools.test.ts
@@ -2,11 +2,16 @@ import { describe, expect, it } from "vitest";
 
 import {
   AGENT_TOOL_CATALOG_IDS,
+  PWRAGENT_TOOL_NAMESPACE,
   isAgentToolCatalogId,
   normalizeAgentToolCatalogIds,
 } from "../agent-tools";
 
 describe("agent tool contracts", () => {
+  it("defines the unified PwrAgent dynamic tool namespace", () => {
+    expect(PWRAGENT_TOOL_NAMESPACE).toBe("pwragent");
+  });
+
   it("defines the v1 agent tool catalog ids", () => {
     expect(AGENT_TOOL_CATALOG_IDS).toEqual([
       "automation_inspection",

--- a/packages/shared/src/contracts/__tests__/agent-tools.test.ts
+++ b/packages/shared/src/contracts/__tests__/agent-tools.test.ts
@@ -10,10 +10,12 @@ describe("agent tool contracts", () => {
   it("defines the v1 agent tool catalog ids", () => {
     expect(AGENT_TOOL_CATALOG_IDS).toEqual([
       "automation_inspection",
+      "app_management",
       "thread_inspection",
       "messaging_context",
     ]);
     expect(isAgentToolCatalogId("automation_inspection")).toBe(true);
+    expect(isAgentToolCatalogId("app_management")).toBe(true);
     expect(isAgentToolCatalogId("thread_inspection")).toBe(true);
     expect(isAgentToolCatalogId("messaging_context")).toBe(true);
     expect(isAgentToolCatalogId("shell")).toBe(false);
@@ -24,12 +26,14 @@ describe("agent tool contracts", () => {
       normalizeAgentToolCatalogIds([
         "automation_inspection",
         "automation_inspection",
+        "app_management",
         "thread_inspection",
         "messaging_context",
         "unknown",
       ]),
     ).toEqual([
       "automation_inspection",
+      "app_management",
       "thread_inspection",
       "messaging_context",
     ]);

--- a/packages/shared/src/contracts/__tests__/thread-orchestration-tools.test.ts
+++ b/packages/shared/src/contracts/__tests__/thread-orchestration-tools.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PWRAGENT_THREAD_ORCHESTRATION_ERROR_CODES,
+  PWRAGENT_THREAD_ORCHESTRATION_OPERATION_NAMES,
+  type HandoffTaskResult,
+  type HandoffTaskToolArgs,
+  type ThreadHandoffOrigin,
+} from "../thread-orchestration-tools";
+
+describe("thread orchestration tool contracts", () => {
+  it("defines the handoff task operation", () => {
+    expect(PWRAGENT_THREAD_ORCHESTRATION_OPERATION_NAMES).toEqual([
+      "handoff_task",
+    ]);
+  });
+
+  it("defines structured handoff error codes", () => {
+    expect(PWRAGENT_THREAD_ORCHESTRATION_ERROR_CODES).toEqual([
+      "invalid_arguments",
+      "not_found",
+      "forbidden",
+      "unsupported_backend",
+      "unsupported_workspace",
+      "unsupported_operation",
+      "ambiguous_workspace",
+      "turn_start_failed",
+      "internal_error",
+    ]);
+  });
+
+  it("models clean, fork, grouping, workspace, and messaging modes", () => {
+    const args = {
+      task: "Implement the handoff service",
+      seedMode: "fork",
+      groupingMode: "subthread",
+      workspaceMode: "new_worktree",
+      messagingAttachment: "new_child",
+      fastMode: true,
+    } satisfies HandoffTaskToolArgs;
+
+    expect(args).toMatchObject({
+      seedMode: "fork",
+      groupingMode: "subthread",
+      workspaceMode: "new_worktree",
+      messagingAttachment: "new_child",
+    });
+  });
+
+  it("keeps handoff origin serializable and separate from parent grouping", () => {
+    const origin = {
+      sourceBackend: "codex",
+      sourceThreadId: "thread-parent",
+      sourceTurnId: "turn-1",
+      sourceTitle: "Parent",
+      taskTitle: "Handoff",
+      seedMode: "clean",
+      groupingMode: "none",
+      createdAt: 1_773_000_000_000,
+      workspace: {
+        mode: "same",
+        cwd: "/repo",
+        branch: "main",
+        git: {
+          kind: "git_local",
+          worktreeCreationAvailable: true,
+        },
+      },
+    } satisfies ThreadHandoffOrigin;
+
+    const result = {
+      backend: "codex",
+      threadId: "thread-child",
+      turnId: "turn-child",
+      seedMode: "clean",
+      groupingMode: "none",
+      inheritedSettings: {
+        backend: "codex",
+        executionMode: "default",
+        model: "gpt-5",
+        fastMode: false,
+      },
+      origin,
+      workspace: origin.workspace,
+      messagingAttachment: {
+        requested: false,
+        outcome: "not_requested",
+      },
+    } satisfies HandoffTaskResult;
+
+    expect(JSON.parse(JSON.stringify(result))).toEqual(result);
+    expect(result.groupedUnderThreadId).toBeUndefined();
+  });
+});

--- a/packages/shared/src/contracts/__tests__/thread-orchestration-tools.test.ts
+++ b/packages/shared/src/contracts/__tests__/thread-orchestration-tools.test.ts
@@ -68,7 +68,7 @@ describe("thread orchestration tool contracts", () => {
       },
     } satisfies ThreadHandoffOrigin;
 
-    const result = {
+    const result: HandoffTaskResult = {
       backend: "codex",
       threadId: "thread-child",
       turnId: "turn-child",
@@ -86,7 +86,7 @@ describe("thread orchestration tool contracts", () => {
         requested: false,
         outcome: "not_requested",
       },
-    } satisfies HandoffTaskResult;
+    };
 
     expect(JSON.parse(JSON.stringify(result))).toEqual(result);
     expect(result.groupedUnderThreadId).toBeUndefined();

--- a/packages/shared/src/contracts/__tests__/thread-orchestration-tools.test.ts
+++ b/packages/shared/src/contracts/__tests__/thread-orchestration-tools.test.ts
@@ -12,6 +12,7 @@ describe("thread orchestration tool contracts", () => {
   it("defines the handoff task operation", () => {
     expect(PWRAGENT_THREAD_ORCHESTRATION_OPERATION_NAMES).toEqual([
       "handoff_task",
+      "send_message_to_thread",
     ]);
   });
 

--- a/packages/shared/src/contracts/agent-tools.ts
+++ b/packages/shared/src/contracts/agent-tools.ts
@@ -1,5 +1,6 @@
 export const AGENT_TOOL_CATALOG_IDS = [
   "automation_inspection",
+  "app_management",
   "thread_inspection",
   "messaging_context",
 ] as const;

--- a/packages/shared/src/contracts/agent-tools.ts
+++ b/packages/shared/src/contracts/agent-tools.ts
@@ -1,3 +1,5 @@
+export const PWRAGENT_TOOL_NAMESPACE = "pwragent";
+
 export const AGENT_TOOL_CATALOG_IDS = [
   "automation_inspection",
   "app_management",

--- a/packages/shared/src/contracts/agent-tools.ts
+++ b/packages/shared/src/contracts/agent-tools.ts
@@ -5,6 +5,7 @@ export const AGENT_TOOL_CATALOG_IDS = [
   "app_management",
   "thread_inspection",
   "messaging_context",
+  "thread_orchestration",
 ] as const;
 
 export type AgentToolCatalogId = (typeof AGENT_TOOL_CATALOG_IDS)[number];

--- a/packages/shared/src/contracts/app-tools.ts
+++ b/packages/shared/src/contracts/app-tools.ts
@@ -1,3 +1,4 @@
+/** @deprecated Use PWRAGENT_TOOL_NAMESPACE for advertised dynamic tools. */
 export const PWRAGENT_APP_TOOL_NAMESPACE = "pwragent_app";
 
 export const PWRAGENT_APP_OPERATION_NAMES = ["manage_pwragent"] as const;

--- a/packages/shared/src/contracts/app-tools.ts
+++ b/packages/shared/src/contracts/app-tools.ts
@@ -1,0 +1,102 @@
+export const PWRAGENT_APP_TOOL_NAMESPACE = "pwragent_app";
+
+export const PWRAGENT_APP_OPERATION_NAMES = ["manage_pwragent"] as const;
+
+export type PwrAgentAppOperationName =
+  (typeof PWRAGENT_APP_OPERATION_NAMES)[number];
+
+export const PWRAGENT_APP_MANAGEMENT_ACTIONS = [
+  "status",
+  "upgrade_check",
+  "restart",
+  "stop",
+] as const;
+
+export type PwrAgentAppManagementAction =
+  (typeof PWRAGENT_APP_MANAGEMENT_ACTIONS)[number];
+
+export const PWRAGENT_APP_ERROR_CODES = [
+  "invalid_arguments",
+  "forbidden",
+  "unsupported_operation",
+  "internal_error",
+] as const;
+
+export type PwrAgentAppErrorCode = (typeof PWRAGENT_APP_ERROR_CODES)[number];
+
+export type PwrAgentAppManagementContext = {
+  now?: number;
+};
+
+export type ManagePwrAgentToolArgs = {
+  action: PwrAgentAppManagementAction;
+};
+
+export type PwrAgentAppToolArgsByOperation = {
+  manage_pwragent: ManagePwrAgentToolArgs;
+};
+
+export type PwrAgentAppToolArgs<
+  TOperation extends PwrAgentAppOperationName = PwrAgentAppOperationName,
+> = PwrAgentAppToolArgsByOperation[TOperation];
+
+export type PwrAgentUpdateToolStatus =
+  | { status: "idle" }
+  | { status: "skipped"; reason: string }
+  | { status: "checking" }
+  | { status: "no-update"; version: string }
+  | { status: "available"; version: string }
+  | { status: "downloading"; version: string; percent?: number }
+  | { status: "downloaded"; version: string }
+  | { status: "error"; message: string };
+
+export type PwrAgentAppRuntimeStatus = {
+  currentVersion: string;
+  startedAt: number;
+  startedAtIso: string;
+  startedAtLocal: string;
+  now: number;
+  nowIso: string;
+  nowLocal: string;
+  uptimeMs: number;
+  uptimeHuman: string;
+};
+
+export type PwrAgentAppManagementData = {
+  action: PwrAgentAppManagementAction;
+  runtime: PwrAgentAppRuntimeStatus;
+  update: {
+    status: PwrAgentUpdateToolStatus;
+    updateAvailableToDownload: boolean;
+    updateDownloadedWillInstallOnRestart: boolean;
+  };
+  result:
+    | { status: "reported" }
+    | { status: "check_completed"; check: PwrAgentUpdateToolStatus }
+    | { status: "restart_accepted"; installingDownloadedUpdate: boolean }
+    | { status: "stop_accepted" }
+    | { status: "cancelled"; message: string };
+};
+
+export type PwrAgentAppRequest<
+  TOperation extends PwrAgentAppOperationName = PwrAgentAppOperationName,
+> = {
+  [TOperationKey in TOperation]: {
+    operation: TOperationKey;
+    context: PwrAgentAppManagementContext;
+    args: PwrAgentAppToolArgs<TOperationKey>;
+  };
+}[TOperation];
+
+export type PwrAgentAppResponse =
+  | {
+      ok: true;
+      data: PwrAgentAppManagementData;
+    }
+  | {
+      ok: false;
+      error: {
+        code: PwrAgentAppErrorCode;
+        message: string;
+      };
+    };

--- a/packages/shared/src/contracts/automation-tools.ts
+++ b/packages/shared/src/contracts/automation-tools.ts
@@ -12,6 +12,7 @@ import type {
   AutomationTimelineCard,
 } from "./automations";
 
+/** @deprecated Use PWRAGENT_TOOL_NAMESPACE for advertised dynamic tools. */
 export const AUTOMATION_INSPECTION_TOOL_NAMESPACE = "pwragent_automations";
 
 export const AUTOMATION_INSPECTION_OPERATION_NAMES = [

--- a/packages/shared/src/contracts/messaging-tools.ts
+++ b/packages/shared/src/contracts/messaging-tools.ts
@@ -9,6 +9,7 @@ import type {
   MessagingConversationKind,
 } from "./messaging";
 
+/** @deprecated Use PWRAGENT_TOOL_NAMESPACE for advertised dynamic tools. */
 export const PWRAGENT_MESSAGING_TOOL_NAMESPACE = "pwragent_messaging";
 
 export const PWRAGENT_MESSAGING_OPERATION_NAMES = [

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -27,6 +27,7 @@ import type {
   TaskMonitorCompletionSource,
   TaskMonitorUsageSnapshot,
 } from "./task-monitor-tools";
+import type { ThreadHandoffOrigin } from "./thread-orchestration-tools";
 
 export type InboxReason = "new-thread" | "updated-since-seen";
 
@@ -130,6 +131,8 @@ export type NavigationThreadSummary = AppServerThreadSummary & {
    * survive app restart exactly as reported by the monitor lifecycle.
    */
   subAgents?: ThreadSubAgentSummary[];
+  /** Durable origin metadata for threads created by an Agent handoff tool. */
+  handoffOrigin?: ThreadHandoffOrigin;
 };
 
 export type ThreadSubAgentStatus =
@@ -1053,6 +1056,8 @@ export type ThreadOverlayState = {
   immutableUsageActivities?: AppServerThreadActivityEntry[];
   /** Durable delegated sub-agent/task-monitor summaries for this thread. */
   subAgents?: ThreadSubAgentSummary[];
+  /** Durable origin metadata for threads created by an Agent handoff tool. */
+  handoffOrigin?: ThreadHandoffOrigin;
   /**
    * Pending permission mode change waiting for the active turn to end.
    * Lives in registry memory only — the overlay store does NOT serialize

--- a/packages/shared/src/contracts/task-monitor-tools.ts
+++ b/packages/shared/src/contracts/task-monitor-tools.ts
@@ -1,5 +1,6 @@
 import type { AppServerBackendKind, ThreadIdentifier } from "./normalized-app-server";
 
+/** @deprecated Use PWRAGENT_TOOL_NAMESPACE for advertised dynamic tools. */
 export const TASK_MONITOR_TOOL_NAMESPACE = "pwragent_task_monitors";
 
 export const DEFAULT_TASK_MONITOR_MODEL = "gpt-5.4-mini";

--- a/packages/shared/src/contracts/thread-orchestration-tools.ts
+++ b/packages/shared/src/contracts/thread-orchestration-tools.ts
@@ -1,0 +1,189 @@
+import type {
+  AppServerBackendKind,
+  CodexThreadEnvironmentRuntime,
+  LinkedDirectorySummary,
+  ThreadExecutionMode,
+  ThreadIdentifier,
+} from "./normalized-app-server";
+import type { MessagingChannelKind, MessagingConversationKind } from "./messaging";
+
+export const PWRAGENT_THREAD_ORCHESTRATION_OPERATION_NAMES = [
+  "handoff_task",
+] as const;
+
+export type PwrAgentThreadOrchestrationOperationName =
+  (typeof PWRAGENT_THREAD_ORCHESTRATION_OPERATION_NAMES)[number];
+
+export const PWRAGENT_THREAD_ORCHESTRATION_ERROR_CODES = [
+  "invalid_arguments",
+  "not_found",
+  "forbidden",
+  "unsupported_backend",
+  "unsupported_workspace",
+  "unsupported_operation",
+  "ambiguous_workspace",
+  "turn_start_failed",
+  "internal_error",
+] as const;
+
+export type PwrAgentThreadOrchestrationErrorCode =
+  (typeof PWRAGENT_THREAD_ORCHESTRATION_ERROR_CODES)[number];
+
+export type PwrAgentThreadOrchestrationContext = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  turnId?: string;
+  now?: number;
+};
+
+export type HandoffTaskSeedMode = "clean" | "fork";
+
+export type HandoffTaskGroupingMode = "none" | "subthread";
+
+export type HandoffTaskWorkspaceMode = "same" | "new_worktree" | "none";
+
+export type HandoffTaskMessagingAttachmentMode =
+  | "none"
+  | "auto"
+  | "current_conversation"
+  | "new_child";
+
+export type HandoffTaskToolArgs = {
+  task: string;
+  title?: string;
+  context?: string;
+  seedMode?: HandoffTaskSeedMode;
+  groupingMode?: HandoffTaskGroupingMode;
+  workspaceMode?: HandoffTaskWorkspaceMode;
+  messagingAttachment?: HandoffTaskMessagingAttachmentMode;
+  backend?: AppServerBackendKind;
+  model?: string;
+  reasoningEffort?: string;
+  serviceTier?: string;
+  fastMode?: boolean;
+  executionMode?: ThreadExecutionMode;
+  approvalPolicy?: string;
+  sandbox?: string;
+  branchName?: string;
+};
+
+export type ThreadHandoffOriginWorkspace = {
+  mode: HandoffTaskWorkspaceMode;
+  cwd?: string;
+  branch?: string;
+  linkedDirectory?: LinkedDirectorySummary;
+  git:
+    | { kind: "none"; worktreeCreationAvailable: false; unavailableReason: string }
+    | {
+        kind: "non_git";
+        worktreeCreationAvailable: false;
+        unavailableReason: string;
+      }
+    | {
+        kind: "git_local" | "git_worktree";
+        worktreeCreationAvailable: boolean;
+        unavailableReason?: string;
+      };
+};
+
+export type ThreadHandoffOrigin = {
+  sourceBackend: AppServerBackendKind;
+  sourceThreadId: ThreadIdentifier;
+  sourceTurnId?: string;
+  sourceTitle?: string;
+  taskTitle?: string;
+  seedMode: HandoffTaskSeedMode;
+  groupingMode: HandoffTaskGroupingMode;
+  createdAt: number;
+  workspace: ThreadHandoffOriginWorkspace;
+};
+
+export type HandoffTaskInheritedSettings = {
+  backend: AppServerBackendKind;
+  executionMode?: ThreadExecutionMode;
+  model?: string;
+  reasoningEffort?: string;
+  serviceTier?: string;
+  fastMode?: boolean;
+  approvalPolicy?: string;
+  sandbox?: string;
+  codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
+};
+
+export type HandoffTaskMessagingAttachment =
+  | {
+      requested: false;
+      outcome: "not_requested";
+    }
+  | {
+      requested: true;
+      outcome: "attached" | "created_and_attached";
+      channel: MessagingChannelKind;
+      conversation: {
+        id: string;
+        kind: MessagingConversationKind;
+        title?: string;
+      };
+      createdConversation?: {
+        id: string;
+        kind: MessagingConversationKind;
+        title?: string;
+      };
+    }
+  | {
+      requested: true;
+      outcome: "not_available" | "forbidden" | "unsupported" | "failed";
+      reason: string;
+    };
+
+export type HandoffTaskResult = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  turnId?: string;
+  title?: string;
+  seedMode: HandoffTaskSeedMode;
+  groupingMode: HandoffTaskGroupingMode;
+  groupedUnderThreadId?: ThreadIdentifier;
+  inheritedSettings: HandoffTaskInheritedSettings;
+  origin: ThreadHandoffOrigin;
+  workspace: ThreadHandoffOriginWorkspace;
+  messagingAttachment: HandoffTaskMessagingAttachment;
+  turnStartFailure?: {
+    message: string;
+    phase: "turn";
+  };
+};
+
+export type PwrAgentThreadOrchestrationToolArgsByOperation = {
+  handoff_task: HandoffTaskToolArgs;
+};
+
+export type PwrAgentThreadOrchestrationToolArgs<
+  TOperation extends PwrAgentThreadOrchestrationOperationName =
+    PwrAgentThreadOrchestrationOperationName,
+> = PwrAgentThreadOrchestrationToolArgsByOperation[TOperation];
+
+export type PwrAgentThreadOrchestrationRequest<
+  TOperation extends PwrAgentThreadOrchestrationOperationName =
+    PwrAgentThreadOrchestrationOperationName,
+> = {
+  [TOperationKey in TOperation]: {
+    operation: TOperationKey;
+    context: PwrAgentThreadOrchestrationContext;
+    args: PwrAgentThreadOrchestrationToolArgs<TOperationKey>;
+  };
+}[TOperation];
+
+export type PwrAgentThreadOrchestrationResponse =
+  | {
+      ok: true;
+      data: HandoffTaskResult;
+    }
+  | {
+      ok: false;
+      error: {
+        code: PwrAgentThreadOrchestrationErrorCode;
+        message: string;
+        data?: unknown;
+      };
+    };

--- a/packages/shared/src/contracts/thread-orchestration-tools.ts
+++ b/packages/shared/src/contracts/thread-orchestration-tools.ts
@@ -37,16 +37,29 @@ export type PwrAgentThreadOrchestrationContext = {
 };
 
 export type HandoffTaskSeedMode = "clean" | "fork";
+export const HANDOFF_TASK_SEED_MODES = ["clean", "fork"] as const;
 
 export type HandoffTaskGroupingMode = "none" | "subthread";
+export const HANDOFF_TASK_GROUPING_MODES = ["none", "subthread"] as const;
 
 export type HandoffTaskWorkspaceMode = "same" | "new_worktree" | "none";
+export const HANDOFF_TASK_WORKSPACE_MODES = [
+  "same",
+  "new_worktree",
+  "none",
+] as const;
 
 export type HandoffTaskMessagingAttachmentMode =
   | "none"
   | "auto"
   | "current_conversation"
   | "new_child";
+export const HANDOFF_TASK_MESSAGING_ATTACHMENT_MODES = [
+  "none",
+  "auto",
+  "current_conversation",
+  "new_child",
+] as const;
 
 export type HandoffTaskToolArgs = {
   task: string;

--- a/packages/shared/src/contracts/thread-orchestration-tools.ts
+++ b/packages/shared/src/contracts/thread-orchestration-tools.ts
@@ -9,6 +9,7 @@ import type { MessagingChannelKind, MessagingConversationKind } from "./messagin
 
 export const PWRAGENT_THREAD_ORCHESTRATION_OPERATION_NAMES = [
   "handoff_task",
+  "send_message_to_thread",
 ] as const;
 
 export type PwrAgentThreadOrchestrationOperationName =
@@ -78,6 +79,19 @@ export type HandoffTaskToolArgs = {
   approvalPolicy?: string;
   sandbox?: string;
   branchName?: string;
+};
+
+export type SendMessageToThreadToolArgs = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  prompt: string;
+  model?: string;
+  reasoningEffort?: string;
+  serviceTier?: string;
+  fastMode?: boolean;
+  executionMode?: ThreadExecutionMode;
+  approvalPolicy?: string;
+  sandbox?: string;
 };
 
 export type ThreadHandoffOriginWorkspace = {
@@ -167,8 +181,25 @@ export type HandoffTaskResult = {
   };
 };
 
+export type SendMessageToThreadResult = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  turnId: string;
+  promptPreview: string;
+  settings: {
+    executionMode?: ThreadExecutionMode;
+    model?: string;
+    reasoningEffort?: string;
+    serviceTier?: string;
+    fastMode?: boolean;
+    approvalPolicy?: string;
+    sandbox?: string;
+  };
+};
+
 export type PwrAgentThreadOrchestrationToolArgsByOperation = {
   handoff_task: HandoffTaskToolArgs;
+  send_message_to_thread: SendMessageToThreadToolArgs;
 };
 
 export type PwrAgentThreadOrchestrationToolArgs<
@@ -190,7 +221,7 @@ export type PwrAgentThreadOrchestrationRequest<
 export type PwrAgentThreadOrchestrationResponse =
   | {
       ok: true;
-      data: HandoffTaskResult;
+      data: HandoffTaskResult | SendMessageToThreadResult;
     }
   | {
       ok: false;

--- a/packages/shared/src/contracts/thread-tools.ts
+++ b/packages/shared/src/contracts/thread-tools.ts
@@ -1,5 +1,9 @@
 import type {
   AppServerBackendKind,
+  AppServerThreadActivityStatus,
+  AppServerThreadMessage,
+  AppServerThreadReplayPagination,
+  AppServerThreadTurnMetadata,
   AppServerThreadStatus,
   ThreadExecutionMode,
   ThreadIdentifier,
@@ -25,6 +29,7 @@ export const PWRAGENT_THREAD_TOOL_NAMESPACE = "pwragent_threads";
 
 export const PWRAGENT_THREAD_INSPECTION_OPERATION_NAMES = [
   "search_threads",
+  "read_thread",
   "get_thread_status",
   "mutate_thread",
 ] as const;
@@ -71,6 +76,38 @@ export type SearchThreadsToolArgs = {
 export type GetThreadStatusToolArgs = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;
+};
+
+export type ReadThreadToolArgs = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  /**
+   * Provider pagination cursor returned by a previous read_thread response.
+   */
+  before?: string;
+  /**
+   * Maximum transcript entries to return. Implementations clamp this to a
+   * bounded product limit.
+   */
+  limit?: number;
+  /**
+   * Include normalized transcript messages in the response. Defaults to true.
+   */
+  includeMessages?: boolean;
+  /**
+   * Include normalized timeline entries in the response. Defaults to true.
+   */
+  includeEntries?: boolean;
+  /**
+   * Include current thread status when the backend can provide it.
+   * Defaults to true.
+   */
+  includeStatus?: boolean;
+  /**
+   * Maximum characters retained in each text-like transcript field.
+   * Implementations clamp this to a bounded product limit.
+   */
+  maxCharsPerEntry?: number;
 };
 
 export type MutateThreadToolArgs = {
@@ -144,8 +181,90 @@ export type ThreadStatusInspectionSummary = ThreadInspectionSummary & {
   queuedExecutionModeAt?: number;
 };
 
+export type ThreadReadMessageSummary = Pick<
+  AppServerThreadMessage,
+  "id" | "role" | "createdAt"
+> & {
+  text: string;
+  truncated?: boolean;
+};
+
+export type ThreadReadEntrySummary =
+  | {
+      type: "message";
+      id: string;
+      role: AppServerThreadMessage["role"];
+      text: string;
+      createdAt?: number;
+      phase?: "commentary" | "final";
+      turn?: AppServerThreadTurnMetadata;
+      truncated?: boolean;
+    }
+  | {
+      type: "activity";
+      id: string;
+      summary: string;
+      createdAt?: number;
+      status?: AppServerThreadActivityStatus;
+      turn?: AppServerThreadTurnMetadata;
+      details: Array<{
+        id: string;
+        kind: "read" | "write" | "command";
+        label: string;
+        markdown?: string;
+        path?: string;
+        url?: string;
+        status?: AppServerThreadActivityStatus;
+        command?: {
+          displayCommand: string;
+          rawCommand?: string;
+          cwd?: string;
+          output?: string;
+          exitCode?: number;
+          durationMs?: number;
+        };
+        truncated?: boolean;
+      }>;
+      truncated?: boolean;
+    }
+  | {
+      type: "plan";
+      id: string;
+      createdAt?: number;
+      explanation?: string;
+      markdown?: string;
+      turn?: AppServerThreadTurnMetadata;
+      steps: Array<{ step: string; status: string }>;
+      truncated?: boolean;
+    }
+  | {
+      type: "review";
+      id: string;
+      createdAt?: number;
+      status?: AppServerThreadActivityStatus;
+      review: string;
+      displayText?: string;
+      turn?: AppServerThreadTurnMetadata;
+      truncated?: boolean;
+    };
+
+export type ThreadReadResult = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  limit: number;
+  before?: string;
+  maxCharsPerEntry: number;
+  entries?: ThreadReadEntrySummary[];
+  messages?: ThreadReadMessageSummary[];
+  lastUserMessage?: string;
+  lastAssistantMessage?: string;
+  pagination: AppServerThreadReplayPagination;
+  status?: AppServerThreadStatus;
+};
+
 export type PwrAgentThreadInspectionToolArgsByOperation = {
   search_threads: SearchThreadsToolArgs;
+  read_thread: ReadThreadToolArgs;
   get_thread_status: GetThreadStatusToolArgs;
   mutate_thread: MutateThreadToolArgs;
 };
@@ -180,6 +299,9 @@ export type PwrAgentThreadInspectionResponse =
             unavailableScopes?: ThreadSearchUnavailableScope[];
             contentMode?: ThreadSearchContentMode;
             semanticMode?: ThreadSearchSemanticMode;
+          }
+        | {
+            read: ThreadReadResult;
           }
         | {
             thread: ThreadStatusInspectionSummary;

--- a/packages/shared/src/contracts/thread-tools.ts
+++ b/packages/shared/src/contracts/thread-tools.ts
@@ -9,6 +9,7 @@ import type {
   MessagingThreadBindingSummary,
   ThreadAgentMetadata,
 } from "./navigation";
+import type { ThreadHandoffOrigin } from "./thread-orchestration-tools";
 import type {
   ThreadSearchContentMode,
   ThreadSearchConfidenceBand,
@@ -123,6 +124,7 @@ export type ThreadInspectionSummary = {
   updatedAt?: number;
   archivedAt?: number;
   agent?: ThreadAgentMetadata;
+  handoffOrigin?: ThreadHandoffOrigin;
   executionMode?: ThreadExecutionMode;
   model?: string;
   reasoningEffort?: string;

--- a/packages/shared/src/contracts/thread-tools.ts
+++ b/packages/shared/src/contracts/thread-tools.ts
@@ -19,6 +19,7 @@ import type {
   ThreadSearchUnavailableScope,
 } from "./thread-search";
 
+/** @deprecated Use PWRAGENT_TOOL_NAMESPACE for advertised dynamic tools. */
 export const PWRAGENT_THREAD_TOOL_NAMESPACE = "pwragent_threads";
 
 export const PWRAGENT_THREAD_INSPECTION_OPERATION_NAMES = [

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -5,6 +5,7 @@ export * from "./codex-turn-error";
 export * from "./contracts/backend";
 export * from "./contracts/agent";
 export * from "./contracts/agent-tools";
+export * from "./contracts/app-tools";
 export * from "./contracts/automations";
 export * from "./contracts/automation-tools";
 export * from "./contracts/task-monitor-tools";

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -9,6 +9,7 @@ export * from "./contracts/app-tools";
 export * from "./contracts/automations";
 export * from "./contracts/automation-tools";
 export * from "./contracts/task-monitor-tools";
+export * from "./contracts/thread-orchestration-tools";
 export * from "./contracts/branch-drift";
 export * from "./contracts/composer-drafts";
 export * from "./contracts/diff-focus";

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -44,6 +44,7 @@ export default defineConfig({
           include: [
             "apps/desktop/scripts/**/*.test.mjs",
             "apps/desktop/src/main/__tests__/**/*.test.ts",
+            "apps/desktop/src/main/agent-tools/__tests__/**/*.test.ts",
             "apps/desktop/src/shared/__tests__/**/*.test.ts"
           ],
           // Inline @pwrdrvr/codex-discovery so vitest transforms it. Without


### PR DESCRIPTION
## Summary

- I added `pwragent.manage_pwragent` as the Agent dynamic tool for PwrAgent app management, with `status`, `upgrade_check`, `restart`, and `stop` actions.
- I added `pwragent.handoff_task` as the Agent dynamic tool for handing work to a newly created Agent thread.
- I made handoffs inherit the parent Agent thread's Codex workspace, model, reasoning, fast mode, permission mode, approval/sandbox policy, and Codex environment runtime unless the tool call explicitly overrides them.
- I persist handoff origin metadata on the created thread, start the child turn with a bounded handoff prompt, support explicit fork/subthread/new-worktree modes, and return Git/worktree capability details in the tool result.
- I wired optional messaging attachment through the existing messaging `attach_thread_here` policy so messaging-originated Agent turns can attach the created child thread without a slash command.
- I unified the advertised PwrAgent Agent dynamic-tool surface under the single `pwragent` namespace across app management, automations, thread inspection, messaging context, and task monitors.
- I kept the old namespaces (`pwragent_app`, `pwragent_automations`, `pwragent_threads`, `pwragent_messaging`, and `pwragent_task_monitors`) as deprecated invocation aliases so existing threads can still call them.
- I exposed updater status/install helpers so the app-management tool can report available/downloaded updates and install a downloaded update on restart.

## Verification

- I verified the focused app-management, updater, shared-contract, and backend-registry tests pass.
- I verified the focused handoff contracts, router projection, overlay persistence, runtime creation/denial, messaging attachment, and legacy namespace facade tests pass.
- I verified the full `backend-registry.test.ts` file passes.
- I verified the touched dynamic-tool suites pass without a test-name filter.
- I verified the desktop typecheck passes.
- I verified dependency boundaries pass.
- I verified the diff has no whitespace errors.

Commands run:

```bash
pnpm test packages/shared/src/contracts/__tests__/agent-tools.test.ts apps/desktop/src/main/__tests__/pwragent-app-agent-tools.test.ts apps/desktop/src/main/__tests__/pwragent-app-management-service.test.ts apps/desktop/src/main/__tests__/pwragent-thread-agent-tools.test.ts
pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts -t "Agent dynamic tools|app management dynamic tool"
pnpm test apps/desktop/src/main/__tests__/auto-updater.test.ts apps/desktop/src/main/__tests__/pwragent-app-agent-tools.test.ts apps/desktop/src/main/__tests__/pwragent-app-management-service.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts -t "auto updater|PwrAgent app|app management dynamic tool|Agent dynamic tools"
pnpm test apps/desktop/src/main/__tests__/pwragent-app-agent-tools.test.ts apps/desktop/src/main/__tests__/pwragent-thread-agent-tools.test.ts apps/desktop/src/main/__tests__/automation-inspection-codex-tools.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts
pnpm test packages/shared/src/contracts/__tests__/agent-tools.test.ts apps/desktop/src/main/__tests__/pwragent-app-agent-tools.test.ts apps/desktop/src/main/__tests__/pwragent-thread-agent-tools.test.ts apps/desktop/src/main/__tests__/automation-inspection-codex-tools.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts
pnpm test apps/desktop/src/main/__tests__/automation-inspection-mcp.test.ts packages/shared/src/contracts/__tests__/agent-tools.test.ts apps/desktop/src/main/__tests__/pwragent-app-agent-tools.test.ts apps/desktop/src/main/__tests__/pwragent-thread-agent-tools.test.ts apps/desktop/src/main/__tests__/automation-inspection-codex-tools.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts
pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts -t "thread handoff"
pnpm test packages/shared/src/contracts/__tests__/agent-tools.test.ts packages/shared/src/contracts/__tests__/thread-orchestration-tools.test.ts apps/desktop/src/main/agent-tools/__tests__/agent-tool-router.test.ts apps/desktop/src/main/agent-tools/__tests__/pwragent-thread-orchestration-agent-tools.test.ts apps/desktop/src/main/__tests__/pwragent-agent-tool-legacy-namespaces.test.ts apps/desktop/src/main/__tests__/pwragent-app-agent-tools.test.ts apps/desktop/src/main/__tests__/overlay-store-agent.test.ts
pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts
pnpm --filter @pwragent/desktop typecheck
pnpm lint:boundaries
git diff --check
```

## Post-Deploy Monitoring & Validation

- Log searches: `handling app management dynamic tool call`, `handling thread orchestration dynamic tool call`, `handling automation inspection dynamic tool call`, `handling thread inspection dynamic tool call`, `handling messaging context dynamic tool call`, `handling task monitor dynamic tool call`, `rejecting * dynamic tool call`, `Unsupported PwrAgent * tool`, and updater logs around `checkForUpdates` / downloaded update install.
- Healthy signals: new Agent Codex threads advertise only the `pwragent` namespace for PwrAgent tools; `handoff_task` creates a child Agent thread with inherited settings and persisted origin metadata; messaging handoffs attach or report a structured non-attachment reason; existing threads using legacy namespaces still receive structured responses; `manage_pwragent` status returns version/start time/uptime; upgrade checks report available/downloaded state; restart/stop requests complete with accepted responses.
- Failure signals: known tools returning `unsupported_operation`, pending `item/tool/call` requests timing out, dynamic-tool active-turn rejections for valid live turns, handoff children missing origin metadata or inherited workspace/settings, updater status stuck in `checking`/`downloading`, or restart requests not installing an already downloaded update.
- Validation window and owner: watch the first beta rollout for 24 hours after merge/release; owner is the PwrDrvr operator shipping the beta.
- Rollback/mitigation: disable or remove the advertised app-management catalog for Agent threads if management actions misbehave; retain legacy alias predicates so old threads remain compatible while rolling forward a fix.

## Notes

- Messaging-originated Agent threads use this through dynamic tools, not slash commands.
- `handoff_task` defaults to a clean child thread in the same workspace; fork, subthread grouping, and new-worktree creation are explicit tool modes.
- `status` includes the running app version, start date/time, current date/time, uptime in milliseconds, and a human-readable duration.
- `upgrade_check` reports whether an update is available to download or already downloaded and ready to install on restart.
- Code review: dedicated multi-agent review was skipped because the available subagent tool requires explicit user authorization for delegation; I did a manual contract review and fixed the deprecated-namespace unknown-tool compatibility edge.
