### PR TITLE
feat(desktop): edited-file row polish — single-row transcript, status pill, ignored flags, path + open-in-editor

### DIFF
--- a/apps/desktop/src/main/__tests__/git-working-state-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-working-state-service.test.ts
@@ -189,6 +189,56 @@ describe("GitWorkingStateService.resolveEditCommitStates", () => {
     }
   });
 
+  it("flags gitignored paths and excludes them from the committed judgement", async () => {
+    const responder = (args: string[]): string | undefined => {
+      if (args.includes("diff") && args.includes("--name-only")) return "";
+      if (args.includes("ls-files")) return "";
+      if (args.includes("check-ignore")) {
+        // Report the relative inputs ending in PR.md as ignored.
+        const inputs = args.slice(args.indexOf("--") + 1);
+        return inputs.filter((value) => value.endsWith("PR.md")).join("\n");
+      }
+      if (args.includes("log")) {
+        const paths = args.slice(args.indexOf("--") + 1);
+        return paths.some((p) => p.endsWith("src/b.ts"))
+          ? `${"b".repeat(40)}\n`
+          : "";
+      }
+      if (args.includes("rev-list")) return ""; // pushed
+      return undefined;
+    };
+    const { runGit, calls } = fakeGit(responder);
+    const service = new GitWorkingStateService({ runGit });
+
+    const states = await service.resolveEditCommitStates("/repo/wt", [
+      // Mixed: a committed tracked file alongside a gitignored one. The group
+      // still reads committed/pushed from the tracked file, but the ignored
+      // file is surfaced separately rather than implied committed.
+      { key: "g-mixed", paths: ["/repo/wt/src/b.ts", "/repo/wt/PR.md"] },
+      // All-ignored: no tracked files ⇒ not committed, but flagged ignored.
+      { key: "g-ignored", paths: ["/repo/wt/PR.md"] },
+    ]);
+
+    expect(states["g-mixed"]).toEqual({
+      committed: true,
+      commitSha: "b".repeat(40),
+      shortSha: "bbbbbbb",
+      pushed: true,
+      ignoredPaths: ["/repo/wt/PR.md"],
+    });
+    expect(states["g-ignored"]).toEqual({
+      committed: false,
+      ignoredPaths: ["/repo/wt/PR.md"],
+    });
+    // The ignored set is resolved once over the union, lock-safe.
+    expect(
+      calls.filter((call) => call.args.includes("check-ignore")),
+    ).toHaveLength(1);
+    for (const call of calls) {
+      expect(call.args[0]).toBe("--no-optional-locks");
+    }
+  });
+
   it("runs the remote-reachability check once per unique commit", async () => {
     const { runGit, calls } = fakeGit(respondCommitStates);
     const service = new GitWorkingStateService({ runGit });

--- a/apps/desktop/src/main/app-server/git-working-state-service.ts
+++ b/apps/desktop/src/main/app-server/git-working-state-service.ts
@@ -256,6 +256,36 @@ export class GitWorkingStateService {
       }
     }
 
+    // Gitignored inputs, resolved in one `check-ignore` over the union of all
+    // group paths (relative to cwd, dropping any outside the worktree). These
+    // files can never be committed, so they're carried separately rather than
+    // letting their absence silently read as "committed". `check-ignore` exits
+    // non-zero when nothing matches — treated here as "none ignored".
+    const allInputPaths = [
+      ...new Set(
+        groups.flatMap((group) =>
+          group.paths.map((value) => value.trim()).filter(Boolean),
+        ),
+      ),
+    ];
+    const ignoredPaths = new Set<string>();
+    const relativeInputs = allInputPaths
+      .map((value) => path.relative(cwd, value))
+      .filter((relative) => relative && !relative.startsWith(".."));
+    if (relativeInputs.length > 0) {
+      const ignoredOutput = await noLocks([
+        "check-ignore",
+        "--",
+        ...relativeInputs,
+      ]).catch(() => "");
+      for (const line of ignoredOutput.split("\n")) {
+        const relative = line.trim();
+        if (relative) {
+          ignoredPaths.add(normalizeAbsolutePath(path.resolve(cwd, relative)));
+        }
+      }
+    }
+
     // Memoize the per-commit remote-reachability check by promise so concurrent
     // groups sharing a commit run `rev-list` once.
     const pushedBySha = new Map<string, Promise<boolean>>();
@@ -280,24 +310,41 @@ export class GitWorkingStateService {
       const paths = [
         ...new Set(group.paths.map((value) => value.trim()).filter(Boolean)),
       ];
-      if (paths.length === 0) {
-        return { key: group.key, state: { committed: false } };
+      // Ignored files are surfaced separately and excluded from the
+      // committed/pushed judgement — only the tracked files decide that.
+      const ignored = paths.filter((value) =>
+        ignoredPaths.has(normalizeAbsolutePath(value)),
+      );
+      const ignoredState: Pick<EditGroupCommitState, "ignoredPaths"> =
+        ignored.length > 0 ? { ignoredPaths: ignored } : {};
+      const trackedPaths = paths.filter(
+        (value) => !ignoredPaths.has(normalizeAbsolutePath(value)),
+      );
+
+      if (trackedPaths.length === 0) {
+        return { key: group.key, state: { committed: false, ...ignoredState } };
       }
-      if (paths.some((value) => dirtyPaths.has(normalizeAbsolutePath(value)))) {
-        return { key: group.key, state: { committed: false } };
+      if (
+        trackedPaths.some((value) =>
+          dirtyPaths.has(normalizeAbsolutePath(value)),
+        )
+      ) {
+        return { key: group.key, state: { committed: false, ...ignoredState } };
       }
 
       const sha = (
-        await noLocks(["log", "-1", "--format=%H", "--", ...paths]).catch(
-          () => "",
-        )
+        await noLocks([
+          "log",
+          "-1",
+          "--format=%H",
+          "--",
+          ...trackedPaths,
+        ]).catch(() => "")
       ).trim();
       // Not dirty AND no commit in history ⇒ the files left the working tree
-      // without a commit we can find: almost always `.gitignore`'d files the
-      // agent wrote (invisible to both `diff HEAD` and `ls-files --others
-      // --exclude-standard`). Don't claim "committed" without a SHA to back it.
+      // without a commit we can find. Don't claim "committed" without a SHA.
       if (!sha) {
-        return { key: group.key, state: { committed: false } };
+        return { key: group.key, state: { committed: false, ...ignoredState } };
       }
 
       return {
@@ -307,6 +354,7 @@ export class GitWorkingStateService {
           commitSha: sha,
           shortSha: sha.slice(0, 7),
           pushed: await resolvePushed(sha),
+          ...ignoredState,
         },
       };
     };

--- a/apps/desktop/src/main/ipc/applications.ts
+++ b/apps/desktop/src/main/ipc/applications.ts
@@ -1,10 +1,35 @@
-import { ipcMain } from "electron";
+import { access } from "node:fs/promises";
+import { ipcMain, shell } from "electron";
 import type {
   OpenDesktopApplicationRequest,
   OpenDesktopApplicationResponse,
+  OpenPathRequest,
+  OpenPathResponse,
 } from "@pwragent/shared";
-import { APPLICATION_OPEN_CHANNEL } from "../../shared/ipc";
+import { APPLICATION_OPEN_CHANNEL, PATH_OPEN_CHANNEL } from "../../shared/ipc";
 import { openDesktopApplication } from "../settings/application-discovery";
+
+/**
+ * Open a filesystem path with the OS default handler. The fallback the
+ * edited-file rows use when no editor application is configured/available, so
+ * "open file" still does something via the OS-registered program.
+ */
+async function openPathWithOsDefault(
+  request: OpenPathRequest,
+): Promise<OpenPathResponse> {
+  const target = request.path?.trim();
+  if (!target) {
+    return { opened: false, error: "No file path was provided." };
+  }
+  try {
+    await access(target);
+  } catch {
+    return { opened: false, error: `Path does not exist: ${target}` };
+  }
+  // `shell.openPath` resolves to "" on success or an error message on failure.
+  const error = await shell.openPath(target);
+  return error ? { opened: false, error } : { opened: true };
+}
 
 export function registerApplicationIpcHandlers(): void {
   ipcMain.removeHandler(APPLICATION_OPEN_CHANNEL);
@@ -15,8 +40,16 @@ export function registerApplicationIpcHandlers(): void {
       request: OpenDesktopApplicationRequest,
     ): Promise<OpenDesktopApplicationResponse> => openDesktopApplication(request),
   );
+
+  ipcMain.removeHandler(PATH_OPEN_CHANNEL);
+  ipcMain.handle(
+    PATH_OPEN_CHANNEL,
+    async (_event, request: OpenPathRequest): Promise<OpenPathResponse> =>
+      openPathWithOsDefault(request),
+  );
 }
 
 export function disposeApplicationIpcHandlers(): void {
   ipcMain.removeHandler(APPLICATION_OPEN_CHANNEL);
+  ipcMain.removeHandler(PATH_OPEN_CHANNEL);
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -167,6 +167,8 @@ import type {
   DesktopSettingsWriteResponse,
   OpenDesktopApplicationRequest,
   OpenDesktopApplicationResponse,
+  OpenPathRequest,
+  OpenPathResponse,
   OpenDesktopPwrAgentProfileRequest,
   OpenDesktopPwrAgentProfileResponse,
   ReadDesktopSettingsRequest,
@@ -272,6 +274,7 @@ import {
   APP_SERVER_RENAME_THREAD_CHANNEL,
   APP_SERVER_READ_THREAD_CHANNEL,
   APPLICATION_OPEN_CHANNEL,
+  PATH_OPEN_CHANNEL,
   BACKEND_LIST_CHANNEL,
   CODEX_ENVIRONMENT_SETUP_PROGRESS_CHANNEL,
   COMPOSER_DRAFT_CLEAR_CHANNEL,
@@ -633,6 +636,8 @@ const desktopApi = Object.freeze({
     request: OpenDesktopApplicationRequest,
   ): Promise<OpenDesktopApplicationResponse> =>
     await ipcRenderer.invoke(APPLICATION_OPEN_CHANNEL, request),
+  openPath: async (request: OpenPathRequest): Promise<OpenPathResponse> =>
+    await ipcRenderer.invoke(PATH_OPEN_CHANNEL, request),
   readThread: async (
     request: AppServerReadThreadRequest
   ): Promise<AppServerReadThreadResponse> =>

--- a/apps/desktop/src/renderer/src/features/thread-detail/EditGroupCommitBadge.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/EditGroupCommitBadge.tsx
@@ -3,10 +3,11 @@ import { copyText, formatCopyTooltip } from "../../lib/copy-text";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
 
 /**
- * Git lifecycle badge for an accumulated edited-file group: uncommitted
- * (the "unread"/active state) → committed, with a copyable short-SHA chip and
- * a pushed/local indicator. Renders nothing until the commit state resolves,
- * so a freshly committed group doesn't flash "uncommitted" first.
+ * Git lifecycle badge for an accumulated edited-file group, as a single status
+ * pill plus a copyable short-SHA chip: uncommitted (the "unread"/active state)
+ * → committed (local) → pushed. Pushed implies committed, so "Pushed" REPLACES
+ * "Committed" rather than stacking both. Renders nothing until the commit state
+ * resolves, so a freshly committed group doesn't flash "uncommitted" first.
  */
 export function EditGroupCommitBadge(props: { state?: EditGroupCommitState }) {
   const { state } = props;
@@ -22,21 +23,19 @@ export function EditGroupCommitBadge(props: { state?: EditGroupCommitState }) {
     );
   }
 
+  const pushed = state.pushed === true;
   return (
     <span className="edit-commit-badge edit-commit-badge--committed">
-      <span className="edit-commit-badge__label">Committed</span>
+      <span
+        className={`edit-commit-badge__status edit-commit-badge__status--${
+          pushed ? "pushed" : "committed"
+        }`}
+      >
+        {pushed ? "Pushed" : "Committed"}
+      </span>
       {state.commitSha && state.shortSha ? (
         <CommitShaChip sha={state.commitSha} shortSha={state.shortSha} />
       ) : null}
-      {state.pushed === undefined ? null : (
-        <span
-          className={`edit-commit-badge__push edit-commit-badge__push--${
-            state.pushed ? "pushed" : "local"
-          }`}
-        >
-          {state.pushed ? "Pushed" : "Local"}
-        </span>
-      )}
     </span>
   );
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/EditGroupCommitBadge.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/EditGroupCommitBadge.tsx
@@ -6,8 +6,10 @@ import { useViewportTooltip } from "../../lib/useViewportTooltip";
  * Git lifecycle badge for an accumulated edited-file group, as a single status
  * pill plus a copyable short-SHA chip: uncommitted (the "unread"/active state)
  * → committed (local) → pushed. Pushed implies committed, so "Pushed" REPLACES
- * "Committed" rather than stacking both. Renders nothing until the commit state
- * resolves, so a freshly committed group doesn't flash "uncommitted" first.
+ * "Committed" rather than stacking both. A trailing "N ignored" hint flags any
+ * gitignored files in the group (never part of a commit). Renders nothing until
+ * the commit state resolves, so a freshly committed group doesn't flash
+ * "uncommitted" first.
  */
 export function EditGroupCommitBadge(props: { state?: EditGroupCommitState }) {
   const { state } = props;
@@ -15,26 +17,31 @@ export function EditGroupCommitBadge(props: { state?: EditGroupCommitState }) {
     return null;
   }
 
-  if (!state.committed) {
-    return (
-      <span className="edit-commit-badge edit-commit-badge--uncommitted">
-        Uncommitted
-      </span>
-    );
-  }
+  const status: { variant: "uncommitted" | "committed" | "pushed"; label: string } =
+    !state.committed
+      ? { variant: "uncommitted", label: "Uncommitted" }
+      : state.pushed === true
+        ? { variant: "pushed", label: "Pushed" }
+        : { variant: "committed", label: "Committed" };
+  const ignoredCount = state.ignoredPaths?.length ?? 0;
 
-  const pushed = state.pushed === true;
   return (
-    <span className="edit-commit-badge edit-commit-badge--committed">
+    <span className="edit-commit-badge">
       <span
-        className={`edit-commit-badge__status edit-commit-badge__status--${
-          pushed ? "pushed" : "committed"
-        }`}
+        className={`edit-commit-badge__status edit-commit-badge__status--${status.variant}`}
       >
-        {pushed ? "Pushed" : "Committed"}
+        {status.label}
       </span>
-      {state.commitSha && state.shortSha ? (
+      {state.committed && state.commitSha && state.shortSha ? (
         <CommitShaChip sha={state.commitSha} shortSha={state.shortSha} />
+      ) : null}
+      {ignoredCount > 0 ? (
+        <span
+          className="edit-commit-badge__ignored"
+          title="Files in this group that git ignores — never part of a commit"
+        >
+          {ignoredCount} ignored
+        </span>
       ) : null}
     </span>
   );

--- a/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
@@ -79,7 +79,7 @@ type EditedFileGroupListProps = {
   /** Open an edited file (absolute path) in the editor / OS default. */
   onOpenFile?: (absolutePath: string) => void;
   /** Scroll the transcript to a group's turn (clickable timestamp). */
-  onScrollToTurn?: (turnId: string) => void;
+  onScrollToTurn?: (turnId: string, turnTimeMs?: number) => void;
 };
 
 const groupTimeFormatter = new Intl.DateTimeFormat(undefined, {
@@ -256,12 +256,14 @@ function EditedFileGroupSection(props: {
   group: EditedFileGroup;
   commitState?: EditGroupCommitState;
   defaultExpanded: boolean;
-  onScrollToTurn?: (turnId: string) => void;
+  onScrollToTurn?: (turnId: string, turnTimeMs?: number) => void;
 }) {
   const [expanded, setExpanded] = useState(props.defaultExpanded);
   const bodyId = useId();
   const timestamp = formatGroupTimestamp(props.group);
   const turnId = props.group.turn?.id;
+  const turnTimeMs =
+    props.group.turn?.completedAt ?? props.group.turn?.startedAt;
   const canScrollToTurn = Boolean(turnId && props.onScrollToTurn);
   // Feed the measured header height to `--edits-group-header-height` so an
   // expanded file's sticky toggle pins flush beneath this group's header
@@ -318,7 +320,9 @@ function EditedFileGroupSection(props: {
               className="edited-file-groups__group-time edited-file-groups__group-time--link"
               title="Scroll the transcript to this turn"
               aria-label={`Scroll the transcript to this turn (${timestamp})`}
-              onClick={() => turnId && props.onScrollToTurn?.(turnId)}
+              onClick={() =>
+                turnId && props.onScrollToTurn?.(turnId, turnTimeMs)
+              }
             >
               {timestamp}
             </button>

--- a/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
@@ -201,6 +201,10 @@ function EditedFileGroupSection(props: {
           : undefined
       }
     >
+      {/* Flat header: summary / badge / diff-stat / time are siblings so the
+          group header can reflow per surface via CSS grid areas — a two-row
+          stack in the width-constrained sidebar, a single row (summary + badge
+          … stat + time) in the width-rich transcript rail. */}
       <div ref={headerRef} className="edited-file-groups__group-header">
         <button
           type="button"
@@ -213,13 +217,8 @@ function EditedFileGroupSection(props: {
           <span className="edited-file-groups__group-summary">
             {props.group.summary}
           </span>
-          <DiffStat
-            additions={props.group.additions}
-            removals={props.group.removals}
-            className="diff-stat--chip"
-          />
         </button>
-        <div className="edited-file-groups__group-meta">
+        <div className="edited-file-groups__group-badge">
           {props.group.live ? (
             <span className="edited-file-groups__group-tag edited-file-groups__group-tag--live">
               This turn
@@ -227,10 +226,15 @@ function EditedFileGroupSection(props: {
           ) : (
             <EditGroupCommitBadge state={props.commitState} />
           )}
-          {timestamp ? (
-            <span className="edited-file-groups__group-time">{timestamp}</span>
-          ) : null}
         </div>
+        <DiffStat
+          additions={props.group.additions}
+          removals={props.group.removals}
+          className="diff-stat--chip"
+        />
+        {timestamp ? (
+          <span className="edited-file-groups__group-time">{timestamp}</span>
+        ) : null}
       </div>
       <div id={bodyId} hidden={!expanded}>
         {expanded ? <EditedFileList details={props.group.details} /> : null}

--- a/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
@@ -1,6 +1,9 @@
 import {
+  createContext,
+  useContext,
   useId,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
   type CSSProperties,
@@ -10,6 +13,7 @@ import type {
   AppServerThreadActivityDetail,
   EditGroupCommitState,
 } from "@pwragent/shared";
+import { EditorIcon } from "../../icons";
 import { TranscriptDiff } from "./TranscriptDiff";
 import { DiffStat } from "./DiffStat";
 import { EditGroupCommitBadge } from "./EditGroupCommitBadge";
@@ -19,6 +23,43 @@ import {
 } from "./edited-file-groups";
 
 export type EditedFileGroupView = "turns" | "files";
+
+/**
+ * Per-row config the surface supplies once (worktree root for repo-relative
+ * paths, the set of gitignored absolute paths, and an open-in-editor handler)
+ * and every `EditedFileRow` reads via context, so it doesn't have to be
+ * threaded through the grouped / flattened / single-group render paths.
+ */
+type EditedFileRowConfig = {
+  worktreeRoot?: string;
+  ignoredPaths: ReadonlySet<string>;
+  onOpenFile?: (absolutePath: string) => void;
+};
+
+const EditedFileRowContext = createContext<EditedFileRowConfig>({
+  ignoredPaths: new Set<string>(),
+});
+
+/** Forward-slash normalize so renderer paths match the main-process set. */
+function normalizePath(value: string): string {
+  return value.replace(/\\/g, "/");
+}
+
+/** Display the path relative to the worktree root, falling back to absolute. */
+function toRepoRelativePath(
+  absolutePath: string,
+  worktreeRoot?: string,
+): string {
+  if (!worktreeRoot) {
+    return absolutePath;
+  }
+  const root = normalizePath(worktreeRoot).replace(/\/+$/, "");
+  const full = normalizePath(absolutePath);
+  if (full === root) {
+    return absolutePath;
+  }
+  return full.startsWith(`${root}/`) ? full.slice(root.length + 1) : absolutePath;
+}
 
 type EditedFileGroupListProps = {
   /** Newest-first, from `collectEditedFileGroups`. */
@@ -33,6 +74,10 @@ type EditedFileGroupListProps = {
    * the header to drive it.
    */
   view?: EditedFileGroupView;
+  /** Absolute worktree root, for showing repo-relative paths on a file row. */
+  worktreeRoot?: string;
+  /** Open an edited file (absolute path) in the editor / OS default. */
+  onOpenFile?: (absolutePath: string) => void;
 };
 
 const groupTimeFormatter = new Intl.DateTimeFormat(undefined, {
@@ -98,17 +143,46 @@ export function EditedFileGroupList(props: EditedFileGroupListProps) {
   const view = props.view ?? "turns";
   const [showAllTurns, setShowAllTurns] = useState(false);
 
+  // Union of gitignored paths across every resolved group, so a row in any
+  // view (grouped / flattened / single) can flag itself as ignored.
+  const ignoredPaths = useMemo(() => {
+    const set = new Set<string>();
+    for (const state of Object.values(props.commitStatesByKey ?? {})) {
+      for (const ignored of state.ignoredPaths ?? []) {
+        set.add(normalizePath(ignored));
+      }
+    }
+    return set;
+  }, [props.commitStatesByKey]);
+
+  const rowConfig = useMemo<EditedFileRowConfig>(
+    () => ({
+      worktreeRoot: props.worktreeRoot,
+      ignoredPaths,
+      onOpenFile: props.onOpenFile,
+    }),
+    [props.worktreeRoot, ignoredPaths, props.onOpenFile],
+  );
+
   if (props.groups.length === 0) {
     return null;
   }
 
-  if (props.groups.length === 1) {
-    return <EditedFileList details={props.groups[0].details} />;
-  }
+  const content =
+    props.groups.length === 1 ? (
+      <EditedFileList details={props.groups[0].details} />
+    ) : (
+      <div className="edited-file-groups">{renderGroupedOrFlat()}</div>
+    );
 
   return (
-    <div className="edited-file-groups">
-      {view === "turns" ? (
+    <EditedFileRowContext.Provider value={rowConfig}>
+      {content}
+    </EditedFileRowContext.Provider>
+  );
+
+  function renderGroupedOrFlat() {
+    return view === "turns" ? (
         (() => {
           const visibleGroups = showAllTurns
             ? props.groups
@@ -139,9 +213,8 @@ export function EditedFileGroupList(props: EditedFileGroupListProps) {
         })()
       ) : (
         <EditedFileList details={flattenEditedFileGroups(props.groups)} />
-      )}
-    </div>
-  );
+      );
+  }
 }
 
 function formatGroupTimestamp(group: EditedFileGroup): string | undefined {
@@ -264,6 +337,17 @@ export function EditedFileRow(props: {
   const diffId = useId();
   const additions = props.detail.fileDiff?.additions ?? 0;
   const removals = props.detail.fileDiff?.removals ?? 0;
+  const { worktreeRoot, ignoredPaths, onOpenFile } = useContext(
+    EditedFileRowContext,
+  );
+  const absolutePath = props.detail.path;
+  const ignored = absolutePath
+    ? ignoredPaths.has(normalizePath(absolutePath))
+    : false;
+  const repoRelativePath = absolutePath
+    ? toRepoRelativePath(absolutePath, worktreeRoot)
+    : undefined;
+  const canOpen = Boolean(absolutePath && onOpenFile);
 
   return (
     <>
@@ -275,8 +359,18 @@ export function EditedFileRow(props: {
         onClick={() => setExpanded((current) => !current)}
       >
         <span className="live-work-rail__chevron" aria-hidden="true" />
-        <span className="live-work-rail__file-path" title={props.detail.path}>
-          {props.detail.label}
+        <span className="live-work-rail__file-label">
+          <span className="live-work-rail__file-path" title={props.detail.path}>
+            {props.detail.label}
+          </span>
+          {ignored ? (
+            <span
+              className="edited-file-row__ignored"
+              title="This file is gitignored — it isn't part of any commit"
+            >
+              Ignored
+            </span>
+          ) : null}
         </span>
         <DiffStat
           additions={additions}
@@ -290,7 +384,34 @@ export function EditedFileRow(props: {
           conditionally mounted to keep the render cost in line
           with what the user actually opens. */}
       <div id={diffId} className="live-work-rail__file-diff" hidden={!expanded}>
-        {expanded ? <TranscriptDiff detail={props.detail} compact /> : null}
+        {expanded ? (
+          <>
+            {repoRelativePath || canOpen ? (
+              <div className="edited-file-row__meta">
+                {repoRelativePath ? (
+                  <span
+                    className="edited-file-row__path"
+                    title={props.detail.path}
+                  >
+                    {repoRelativePath}
+                  </span>
+                ) : null}
+                {canOpen && absolutePath ? (
+                  <button
+                    type="button"
+                    className="edited-file-row__open"
+                    onClick={() => onOpenFile?.(absolutePath)}
+                    aria-label={`Open ${repoRelativePath ?? props.detail.label} in editor`}
+                    title="Open in editor"
+                  >
+                    <EditorIcon className="edited-file-row__open-icon" />
+                  </button>
+                ) : null}
+              </div>
+            ) : null}
+            <TranscriptDiff detail={props.detail} compact />
+          </>
+        ) : null}
       </div>
     </>
   );

--- a/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
@@ -78,6 +78,8 @@ type EditedFileGroupListProps = {
   worktreeRoot?: string;
   /** Open an edited file (absolute path) in the editor / OS default. */
   onOpenFile?: (absolutePath: string) => void;
+  /** Scroll the transcript to a group's turn (clickable timestamp). */
+  onScrollToTurn?: (turnId: string) => void;
 };
 
 const groupTimeFormatter = new Intl.DateTimeFormat(undefined, {
@@ -196,6 +198,7 @@ export function EditedFileGroupList(props: EditedFileGroupListProps) {
                   group={group}
                   commitState={props.commitStatesByKey?.[group.key]}
                   defaultExpanded={index === 0}
+                  onScrollToTurn={props.onScrollToTurn}
                 />
               ))}
               {props.groups.length > VISIBLE_TURN_GROUPS ? (
@@ -253,10 +256,13 @@ function EditedFileGroupSection(props: {
   group: EditedFileGroup;
   commitState?: EditGroupCommitState;
   defaultExpanded: boolean;
+  onScrollToTurn?: (turnId: string) => void;
 }) {
   const [expanded, setExpanded] = useState(props.defaultExpanded);
   const bodyId = useId();
   const timestamp = formatGroupTimestamp(props.group);
+  const turnId = props.group.turn?.id;
+  const canScrollToTurn = Boolean(turnId && props.onScrollToTurn);
   // Feed the measured header height to `--edits-group-header-height` so an
   // expanded file's sticky toggle pins flush beneath this group's header
   // rather than at a guessed offset.
@@ -306,7 +312,19 @@ function EditedFileGroupSection(props: {
           className="diff-stat--chip"
         />
         {timestamp ? (
-          <span className="edited-file-groups__group-time">{timestamp}</span>
+          canScrollToTurn ? (
+            <button
+              type="button"
+              className="edited-file-groups__group-time edited-file-groups__group-time--link"
+              title="Scroll the transcript to this turn"
+              aria-label={`Scroll the transcript to this turn (${timestamp})`}
+              onClick={() => turnId && props.onScrollToTurn?.(turnId)}
+            >
+              {timestamp}
+            </button>
+          ) : (
+            <span className="edited-file-groups__group-time">{timestamp}</span>
+          )
         ) : null}
       </div>
       <div id={bodyId} hidden={!expanded}>

--- a/apps/desktop/src/renderer/src/features/thread-detail/LiveWorkRail.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/LiveWorkRail.tsx
@@ -40,7 +40,7 @@ export type LiveWorkRailProps = {
   /** Open an edited file (absolute path) in the editor / OS default. */
   onOpenEditedFile?: (absolutePath: string) => void;
   /** Scroll the transcript to a group's turn position (timestamp click). */
-  onScrollToTurn?: (turnId: string) => void;
+  onScrollToTurn?: (turnId: string, turnTimeMs?: number) => void;
   /**
    * `true` when the rail is showing snapshots from a completed turn
    * (pinned until the next turn starts). `false` while the live turn

--- a/apps/desktop/src/renderer/src/features/thread-detail/LiveWorkRail.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/LiveWorkRail.tsx
@@ -35,6 +35,10 @@ export type LiveWorkRailProps = {
   editedFileGroups?: EditedFileGroup[];
   /** Git commit lifecycle per group key, from `useEditCommitStates`. */
   editedFileCommitStates?: Record<string, EditGroupCommitState>;
+  /** Absolute worktree root, for repo-relative paths on expanded file rows. */
+  editedFilesWorktreeRoot?: string;
+  /** Open an edited file (absolute path) in the editor / OS default. */
+  onOpenEditedFile?: (absolutePath: string) => void;
   /**
    * `true` when the rail is showing snapshots from a completed turn
    * (pinned until the next turn starts). `false` while the live turn
@@ -141,6 +145,8 @@ export function LiveWorkRail(props: LiveWorkRailProps) {
               groups={editedFileGroups}
               commitStatesByKey={props.editedFileCommitStates}
               view={editedView}
+              worktreeRoot={props.editedFilesWorktreeRoot}
+              onOpenFile={props.onOpenEditedFile}
             />
           </section>
         ) : null}

--- a/apps/desktop/src/renderer/src/features/thread-detail/LiveWorkRail.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/LiveWorkRail.tsx
@@ -39,6 +39,8 @@ export type LiveWorkRailProps = {
   editedFilesWorktreeRoot?: string;
   /** Open an edited file (absolute path) in the editor / OS default. */
   onOpenEditedFile?: (absolutePath: string) => void;
+  /** Scroll the transcript to a group's turn position (timestamp click). */
+  onScrollToTurn?: (turnId: string) => void;
   /**
    * `true` when the rail is showing snapshots from a completed turn
    * (pinned until the next turn starts). `false` while the live turn
@@ -147,6 +149,7 @@ export function LiveWorkRail(props: LiveWorkRailProps) {
               view={editedView}
               worktreeRoot={props.editedFilesWorktreeRoot}
               onOpenFile={props.onOpenEditedFile}
+              onScrollToTurn={props.onScrollToTurn}
             />
           </section>
         ) : null}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -101,6 +101,7 @@ type ThreadContextPanelProps = {
   editedFileCommitStates?: Record<string, EditGroupCommitState>;
   editedFilesWorktreeRoot?: string;
   onOpenEditedFile?: (absolutePath: string) => void;
+  onScrollToTurn?: (turnId: string) => void;
   editedFilesDock?: EditedFilesDock;
   onEditedFilesDockChange?: (dock: EditedFilesDock) => void;
 };
@@ -605,6 +606,7 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
             commitStatesByKey={props.editedFileCommitStates}
             worktreeRoot={props.editedFilesWorktreeRoot}
             onOpenFile={props.onOpenEditedFile}
+            onScrollToTurn={props.onScrollToTurn}
             dock={props.editedFilesDock ?? "above"}
             onDockChange={props.onEditedFilesDockChange ?? noop}
           />

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -99,6 +99,8 @@ type ThreadContextPanelProps = {
   /** Accumulated edited-file groups for the Edits tab (newest first). */
   editedFileGroups?: EditedFileGroup[];
   editedFileCommitStates?: Record<string, EditGroupCommitState>;
+  editedFilesWorktreeRoot?: string;
+  onOpenEditedFile?: (absolutePath: string) => void;
   editedFilesDock?: EditedFilesDock;
   onEditedFilesDockChange?: (dock: EditedFilesDock) => void;
 };
@@ -601,6 +603,8 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
           <EditsPanel
             groups={props.editedFileGroups ?? []}
             commitStatesByKey={props.editedFileCommitStates}
+            worktreeRoot={props.editedFilesWorktreeRoot}
+            onOpenFile={props.onOpenEditedFile}
             dock={props.editedFilesDock ?? "above"}
             onDockChange={props.onEditedFilesDockChange ?? noop}
           />

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -101,7 +101,7 @@ type ThreadContextPanelProps = {
   editedFileCommitStates?: Record<string, EditGroupCommitState>;
   editedFilesWorktreeRoot?: string;
   onOpenEditedFile?: (absolutePath: string) => void;
-  onScrollToTurn?: (turnId: string) => void;
+  onScrollToTurn?: (turnId: string, turnTimeMs?: number) => void;
   editedFilesDock?: EditedFilesDock;
   onEditedFilesDockChange?: (dock: EditedFilesDock) => void;
 };

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1593,18 +1593,38 @@ export function ThreadView(props: ThreadViewProps) {
   );
 
   // Scroll the transcript to a turn's position — backs the clickable
-  // edited-file group timestamps. The transcript items are anchored with
-  // `data-turn-id` (TranscriptList); a no-op if that turn isn't in the DOM.
-  const handleScrollToTurn = useCallback((turnId: string) => {
-    const container = transcriptPanelRef.current;
-    if (!container || !turnId) {
-      return;
-    }
-    const target = container.querySelector(
-      `[data-turn-id="${CSS.escape(turnId)}"]`,
-    );
-    target?.scrollIntoView({ block: "center", behavior: "smooth" });
-  }, []);
+  // edited-file group timestamps. Transcript items are anchored with
+  // `data-turn-id`; but a turn's id isn't always on a rendered item (work-phase
+  // grouping renders only the group's first entry, members are folded in), so
+  // fall back to the rendered turn whose time is closest to the group's
+  // timestamp. No-op if neither resolves.
+  const handleScrollToTurn = useCallback(
+    (turnId: string, turnTimeMs?: number) => {
+      const container = transcriptPanelRef.current;
+      if (!container) {
+        return;
+      }
+      let target: Element | null = turnId
+        ? container.querySelector(`[data-turn-id="${CSS.escape(turnId)}"]`)
+        : null;
+      if (!target && typeof turnTimeMs === "number") {
+        let bestDelta = Infinity;
+        for (const candidate of container.querySelectorAll("[data-turn-time]")) {
+          const time = Number((candidate as HTMLElement).dataset.turnTime);
+          if (!Number.isFinite(time)) {
+            continue;
+          }
+          const delta = Math.abs(time - turnTimeMs);
+          if (delta < bestDelta) {
+            bestDelta = delta;
+            target = candidate;
+          }
+        }
+      }
+      target?.scrollIntoView({ block: "center", behavior: "smooth" });
+    },
+    [],
+  );
 
   const moveEditedFilesToSidebar = useCallback(() => {
     onEditedFilesDockChange("sidebar");

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1551,6 +1551,47 @@ export function ThreadView(props: ThreadViewProps) {
     refreshKey: JSON.stringify(selectedThread?.gitWorkingState ?? null),
   });
 
+  // Open an edited file: the configured/first-available editor (same
+  // resolution as transcript file links), falling back to the OS default
+  // handler when no editor is available. Shared by both edited-file surfaces.
+  const editedFilesWorktreeRoot = selectedThread?.projectKey;
+  const applications = props.applications;
+  const desktopApi = props.desktopApi;
+  const handleOpenEditedFile = useCallback(
+    (absolutePath: string) => {
+      const editor =
+        applications?.editors.find(
+          (application) =>
+            application.canOpenWorkspace &&
+            application.id === applications?.preferredEditorId.value,
+        ) ??
+        applications?.editors.find((application) => application.canOpenWorkspace);
+      if (editor && desktopApi?.openApplication) {
+        void desktopApi
+          .openApplication({
+            applicationId: editor.id,
+            kind: "editor",
+            targetPath: absolutePath,
+          })
+          .catch((error: unknown) => {
+            console.error("Failed to open edited file in editor", error);
+          });
+        return;
+      }
+      void desktopApi
+        ?.openPath?.({ path: absolutePath })
+        .then((response) => {
+          if (response && !response.opened) {
+            console.error("Failed to open edited file", response.error);
+          }
+        })
+        .catch((error: unknown) => {
+          console.error("Failed to open edited file", error);
+        });
+    },
+    [applications, desktopApi],
+  );
+
   const moveEditedFilesToSidebar = useCallback(() => {
     onEditedFilesDockChange("sidebar");
     onActiveContextTabChange("edits");
@@ -2401,6 +2442,8 @@ export function ThreadView(props: ThreadViewProps) {
               editedFilesDock === "above" ? editedFileGroups : undefined
             }
             editedFileCommitStates={editedFileCommitStates}
+            editedFilesWorktreeRoot={editedFilesWorktreeRoot}
+            onOpenEditedFile={handleOpenEditedFile}
             pinned={!props.activeTurnId}
             planEntry={
               pendingPlanEntry ??
@@ -2474,6 +2517,8 @@ export function ThreadView(props: ThreadViewProps) {
           desktopApi={props.desktopApi}
           editedFileGroups={editedFileGroups}
           editedFileCommitStates={editedFileCommitStates}
+          editedFilesWorktreeRoot={editedFilesWorktreeRoot}
+          onOpenEditedFile={handleOpenEditedFile}
           editedFilesDock={editedFilesDock}
           onEditedFilesDockChange={onEditedFilesDockChange}
           onActiveTabChange={onActiveContextTabChange}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1592,6 +1592,20 @@ export function ThreadView(props: ThreadViewProps) {
     [applications, desktopApi],
   );
 
+  // Scroll the transcript to a turn's position — backs the clickable
+  // edited-file group timestamps. The transcript items are anchored with
+  // `data-turn-id` (TranscriptList); a no-op if that turn isn't in the DOM.
+  const handleScrollToTurn = useCallback((turnId: string) => {
+    const container = transcriptPanelRef.current;
+    if (!container || !turnId) {
+      return;
+    }
+    const target = container.querySelector(
+      `[data-turn-id="${CSS.escape(turnId)}"]`,
+    );
+    target?.scrollIntoView({ block: "center", behavior: "smooth" });
+  }, []);
+
   const moveEditedFilesToSidebar = useCallback(() => {
     onEditedFilesDockChange("sidebar");
     onActiveContextTabChange("edits");
@@ -2444,6 +2458,7 @@ export function ThreadView(props: ThreadViewProps) {
             editedFileCommitStates={editedFileCommitStates}
             editedFilesWorktreeRoot={editedFilesWorktreeRoot}
             onOpenEditedFile={handleOpenEditedFile}
+            onScrollToTurn={handleScrollToTurn}
             pinned={!props.activeTurnId}
             planEntry={
               pendingPlanEntry ??
@@ -2519,6 +2534,7 @@ export function ThreadView(props: ThreadViewProps) {
           editedFileCommitStates={editedFileCommitStates}
           editedFilesWorktreeRoot={editedFilesWorktreeRoot}
           onOpenEditedFile={handleOpenEditedFile}
+          onScrollToTurn={handleScrollToTurn}
           editedFilesDock={editedFilesDock}
           onEditedFilesDockChange={onEditedFilesDockChange}
           onActiveTabChange={onActiveContextTabChange}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -98,22 +98,6 @@ type LaunchpadEnvironmentSetupProgress = {
 
 const noop = (): void => {};
 
-/** Nearest ancestor that actually scrolls vertically (overflow + overflow). */
-function findScrollableAncestor(element: Element): HTMLElement | null {
-  let current = element.parentElement;
-  while (current) {
-    const style = window.getComputedStyle(current);
-    if (
-      current.scrollHeight > current.clientHeight &&
-      /(auto|scroll)/.test(style.overflowY)
-    ) {
-      return current;
-    }
-    current = current.parentElement;
-  }
-  return null;
-}
-
 function applyLaunchpadEnvironmentSetupProgress(
   current: LaunchpadEnvironmentSetupProgress | undefined,
   event: CodexEnvironmentSetupProgressEvent,
@@ -1640,27 +1624,11 @@ export function ThreadView(props: ThreadViewProps) {
       if (!target) {
         return;
       }
-      // Center the target by setting the scroll container's `scrollTop`
-      // directly. `scrollIntoView` was observed scrolling the wrong ancestor
-      // (the panel section / document) and leaving the transcript's own
-      // `.transcript-list__items` scroller untouched — this mirrors how
-      // `scrollToBottom` drives that scroller in TranscriptList.
-      const scroller = findScrollableAncestor(target);
-      if (!scroller) {
-        target.scrollIntoView({ block: "center", behavior: "smooth" });
-        return;
-      }
-      const targetRect = target.getBoundingClientRect();
-      const scrollerRect = scroller.getBoundingClientRect();
-      const delta =
-        targetRect.top -
-        scrollerRect.top -
-        scroller.clientHeight / 2 +
-        targetRect.height / 2;
-      scroller.scrollTo({
-        top: scroller.scrollTop + delta,
-        behavior: "smooth",
-      });
+      // The `.transcript-list__item` wrapper is `display: contents` (no box),
+      // so scrolling IT is a no-op and its rect is empty. Scroll a real child
+      // element into view instead — the same approach the find bar uses.
+      const anchor = target.querySelector("*") ?? target;
+      anchor.scrollIntoView({ block: "center", behavior: "smooth" });
     },
     [],
   );

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -98,6 +98,22 @@ type LaunchpadEnvironmentSetupProgress = {
 
 const noop = (): void => {};
 
+/** Nearest ancestor that actually scrolls vertically (overflow + overflow). */
+function findScrollableAncestor(element: Element): HTMLElement | null {
+  let current = element.parentElement;
+  while (current) {
+    const style = window.getComputedStyle(current);
+    if (
+      current.scrollHeight > current.clientHeight &&
+      /(auto|scroll)/.test(style.overflowY)
+    ) {
+      return current;
+    }
+    current = current.parentElement;
+  }
+  return null;
+}
+
 function applyLaunchpadEnvironmentSetupProgress(
   current: LaunchpadEnvironmentSetupProgress | undefined,
   event: CodexEnvironmentSetupProgressEvent,
@@ -1621,7 +1637,30 @@ export function ThreadView(props: ThreadViewProps) {
           }
         }
       }
-      target?.scrollIntoView({ block: "center", behavior: "smooth" });
+      if (!target) {
+        return;
+      }
+      // Center the target by setting the scroll container's `scrollTop`
+      // directly. `scrollIntoView` was observed scrolling the wrong ancestor
+      // (the panel section / document) and leaving the transcript's own
+      // `.transcript-list__items` scroller untouched — this mirrors how
+      // `scrollToBottom` drives that scroller in TranscriptList.
+      const scroller = findScrollableAncestor(target);
+      if (!scroller) {
+        target.scrollIntoView({ block: "center", behavior: "smooth" });
+        return;
+      }
+      const targetRect = target.getBoundingClientRect();
+      const scrollerRect = scroller.getBoundingClientRect();
+      const delta =
+        targetRect.top -
+        scrollerRect.top -
+        scroller.clientHeight / 2 +
+        targetRect.height / 2;
+      scroller.scrollTo({
+        top: scroller.scrollTop + delta,
+        behavior: "smooth",
+      });
     },
     [],
   );

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1604,9 +1604,17 @@ export function ThreadView(props: ThreadViewProps) {
       if (!container) {
         return;
       }
-      let target: Element | null = turnId
-        ? container.querySelector(`[data-turn-id="${CSS.escape(turnId)}"]`)
-        : null;
+      // Land on the turn's LAST anchored entry, not its first: the clicked
+      // timestamp is the turn-END time, and the edited-file activity sits near
+      // the turn's tail. Scrolling to the first entry drops the user at the
+      // turn's start (an earlier time than the label, which reads as wrong).
+      let target: Element | null = null;
+      if (turnId) {
+        const matches = container.querySelectorAll(
+          `[data-turn-id="${CSS.escape(turnId)}"]`,
+        );
+        target = matches.length > 0 ? matches[matches.length - 1] : null;
+      }
       if (!target && typeof turnTimeMs === "number") {
         let bestDelta = Infinity;
         for (const candidate of container.querySelectorAll("[data-turn-time]")) {
@@ -1615,7 +1623,9 @@ export function ThreadView(props: ThreadViewProps) {
             continue;
           }
           const delta = Math.abs(time - turnTimeMs);
-          if (delta < bestDelta) {
+          // `<=` so the LAST entry of the nearest turn wins (its tail), to
+          // match the turn-end semantics of the primary path.
+          if (delta <= bestDelta) {
             bestDelta = delta;
             target = candidate;
           }

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -878,11 +878,15 @@ export function TranscriptList(props: TranscriptListProps) {
             const entryKey =
               item.type === "workPhaseGroup" ? item.id : item.entry.id;
             // Anchor each item to its turn so external surfaces (the edited-file
-            // group timestamps) can scroll the transcript to a turn's position.
-            const turnId =
+            // group timestamps) can scroll the transcript to a turn's position —
+            // by turn id, with the turn's end/start time as a fallback for turns
+            // whose id isn't directly on a rendered item (work-phase grouping).
+            const itemTurn =
               item.type === "workPhaseGroup"
-                ? item.entries[0]?.turn?.id
-                : item.entry.turn?.id;
+                ? item.entries[0]?.turn
+                : item.entry.turn;
+            const turnId = itemTurn?.id;
+            const turnTime = itemTurn?.completedAt ?? itemTurn?.startedAt;
             const body =
               item.type === "workPhaseGroup" ? (
                 <TranscriptWorkPhaseGroup
@@ -935,6 +939,9 @@ export function TranscriptList(props: TranscriptListProps) {
                 className="transcript-list__item"
                 role="listitem"
                 data-turn-id={turnId || undefined}
+                data-turn-time={
+                  typeof turnTime === "number" ? turnTime : undefined
+                }
               >
                 {body}
               </div>

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -877,6 +877,12 @@ export function TranscriptList(props: TranscriptListProps) {
           {transcriptRenderItems.map((item) => {
             const entryKey =
               item.type === "workPhaseGroup" ? item.id : item.entry.id;
+            // Anchor each item to its turn so external surfaces (the edited-file
+            // group timestamps) can scroll the transcript to a turn's position.
+            const turnId =
+              item.type === "workPhaseGroup"
+                ? item.entries[0]?.turn?.id
+                : item.entry.turn?.id;
             const body =
               item.type === "workPhaseGroup" ? (
                 <TranscriptWorkPhaseGroup
@@ -924,7 +930,12 @@ export function TranscriptList(props: TranscriptListProps) {
                 />
               );
             return (
-              <div key={entryKey} className="transcript-list__item" role="listitem">
+              <div
+                key={entryKey}
+                className="transcript-list__item"
+                role="listitem"
+                data-turn-id={turnId || undefined}
+              >
                 {body}
               </div>
             );

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/EditedFileGroupList.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/EditedFileGroupList.test.tsx
@@ -85,12 +85,14 @@ describe("EditedFileGroupList Show more / Show less", () => {
     expect(screen.getByText("Uncommitted")).toBeInTheDocument();
     expect(screen.getByText("aaaaaaa")).toBeInTheDocument();
     expect(screen.getByText("Pushed")).toBeInTheDocument();
+    // Pushed implies committed, so "Pushed" replaces "Committed" — never both.
+    expect(screen.queryByText("Committed")).not.toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: `Copy commit ${"a".repeat(40)}` }),
     ).toBeInTheDocument();
   });
 
-  it("shows a local-only badge for an unpushed commit", () => {
+  it("shows a plain Committed badge for an unpushed commit", () => {
     render(
       <EditedFileGroupList
         groups={groups(2)}
@@ -105,7 +107,10 @@ describe("EditedFileGroupList Show more / Show less", () => {
       />,
     );
 
-    expect(screen.getByText("Local")).toBeInTheDocument();
+    expect(screen.getByText("Committed")).toBeInTheDocument();
+    // No "Pushed" for a local-only commit, and no separate "Local" pill.
+    expect(screen.queryByText("Pushed")).not.toBeInTheDocument();
+    expect(screen.queryByText("Local")).not.toBeInTheDocument();
     // turn-2 has no resolved state yet → no badge (avoids a wrong flash).
     expect(screen.queryByText("Uncommitted")).not.toBeInTheDocument();
   });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/EditedFileGroupList.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/EditedFileGroupList.test.tsx
@@ -147,6 +147,52 @@ describe("EditedFileGroupList Show more / Show less", () => {
     // Per-file chip on the ignored row.
     expect(screen.getByText("Ignored")).toBeInTheDocument();
   });
+
+  it("makes the group timestamp scroll the transcript to its turn", () => {
+    const onScrollToTurn = vi.fn();
+    const timed: EditedFileGroup = {
+      key: "turn-9",
+      turn: { id: "turn-9", completedAt: 1_718_000_000_000 },
+      details: group(9).details,
+      summary: "Edited 1 file",
+      additions: 1,
+      removals: 0,
+      live: false,
+    };
+    // group(8) carries no timestamp, so only the timed group renders a button.
+    render(
+      <EditedFileGroupList
+        groups={[timed, group(8)]}
+        onScrollToTurn={onScrollToTurn}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Scroll the transcript to this turn/,
+      }),
+    );
+    expect(onScrollToTurn).toHaveBeenCalledWith("turn-9");
+  });
+
+  it("renders the timestamp as plain text when scrolling isn't wired", () => {
+    const timed: EditedFileGroup = {
+      key: "turn-9",
+      turn: { id: "turn-9", completedAt: 1_718_000_000_000 },
+      details: group(9).details,
+      summary: "Edited 1 file",
+      additions: 1,
+      removals: 0,
+      live: false,
+    };
+    render(<EditedFileGroupList groups={[timed, group(8)]} />);
+
+    expect(
+      screen.queryByRole("button", {
+        name: /Scroll the transcript to this turn/,
+      }),
+    ).not.toBeInTheDocument();
+  });
 });
 
 describe("EditedFileRow path + open affordances", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/EditedFileGroupList.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/EditedFileGroupList.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { useState } from "react";
 import {
@@ -122,6 +122,88 @@ describe("EditedFileGroupList Show more / Show less", () => {
 
     expect(screen.queryByRole("button", { name: /Show \d+ more/ })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Show less" })).not.toBeInTheDocument();
+  });
+
+  it("flags gitignored files with a per-file chip and a group count", () => {
+    // turn-2 is the newest group (index 0), so it's expanded by default and
+    // its file row renders.
+    render(
+      <EditedFileGroupList
+        groups={groups(2)}
+        commitStatesByKey={{
+          "turn-2": {
+            committed: true,
+            commitSha: "a".repeat(40),
+            shortSha: "aaaaaaa",
+            pushed: true,
+            ignoredPaths: ["src/file-2.ts"],
+          },
+        }}
+      />,
+    );
+
+    // Group-level hint on the badge ("· 1 ignored" — the dot is CSS).
+    expect(screen.getByText("1 ignored")).toBeInTheDocument();
+    // Per-file chip on the ignored row.
+    expect(screen.getByText("Ignored")).toBeInTheDocument();
+  });
+});
+
+describe("EditedFileRow path + open affordances", () => {
+  const fileGroup: EditedFileGroup = {
+    key: "turn-x",
+    turn: { id: "turn-x" },
+    details: [
+      {
+        id: "detail-x",
+        kind: "write",
+        label: "Foo.ts",
+        path: "/repo/apps/desktop/Foo.ts",
+        fileDiff: {
+          kind: "update",
+          diff: "@@ -1 +1 @@\n+hello\n",
+          additions: 1,
+          removals: 0,
+        },
+      },
+    ],
+    summary: "Edited 1 file",
+    additions: 1,
+    removals: 0,
+    live: false,
+  };
+
+  it("shows the repo-relative path and opens the file from the expanded row", () => {
+    const onOpenFile = vi.fn();
+    render(
+      <EditedFileGroupList
+        groups={[fileGroup]}
+        worktreeRoot="/repo"
+        onOpenFile={onOpenFile}
+      />,
+    );
+
+    // The repo-relative path only appears once the row is expanded.
+    expect(screen.queryByText("apps/desktop/Foo.ts")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Foo\.ts/ }));
+
+    expect(screen.getByText("apps/desktop/Foo.ts")).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Open apps/desktop/Foo.ts in editor",
+      }),
+    );
+    expect(onOpenFile).toHaveBeenCalledWith("/repo/apps/desktop/Foo.ts");
+  });
+
+  it("omits the open affordance when no handler is provided", () => {
+    render(<EditedFileGroupList groups={[fileGroup]} worktreeRoot="/repo" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Foo\.ts/ }));
+    expect(screen.getByText("apps/desktop/Foo.ts")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Open .* in editor/ }),
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/EditedFileGroupList.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/EditedFileGroupList.test.tsx
@@ -172,7 +172,8 @@ describe("EditedFileGroupList Show more / Show less", () => {
         name: /Scroll the transcript to this turn/,
       }),
     );
-    expect(onScrollToTurn).toHaveBeenCalledWith("turn-9");
+    // Turn id for the precise match, plus the turn-end time for the fallback.
+    expect(onScrollToTurn).toHaveBeenCalledWith("turn-9", 1_718_000_000_000);
   });
 
   it("renders the timestamp as plain text when scrolling isn't wired", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/EditsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/EditsPanel.tsx
@@ -13,6 +13,10 @@ type EditsPanelProps = {
   groups: EditedFileGroup[];
   /** Git commit lifecycle per group key, from `useEditCommitStates`. */
   commitStatesByKey?: Record<string, EditGroupCommitState>;
+  /** Absolute worktree root, for repo-relative paths on expanded file rows. */
+  worktreeRoot?: string;
+  /** Open an edited file (absolute path) in the editor / OS default. */
+  onOpenFile?: (absolutePath: string) => void;
   dock: EditedFilesDock;
   onDockChange: (dock: EditedFilesDock) => void;
 };
@@ -63,6 +67,8 @@ export function EditsPanel(props: EditsPanelProps) {
             groups={props.groups}
             commitStatesByKey={props.commitStatesByKey}
             view={view}
+            worktreeRoot={props.worktreeRoot}
+            onOpenFile={props.onOpenFile}
           />
         ) : (
           <p className="context-empty">

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/EditsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/EditsPanel.tsx
@@ -17,6 +17,8 @@ type EditsPanelProps = {
   worktreeRoot?: string;
   /** Open an edited file (absolute path) in the editor / OS default. */
   onOpenFile?: (absolutePath: string) => void;
+  /** Scroll the transcript to a group's turn position (timestamp click). */
+  onScrollToTurn?: (turnId: string) => void;
   dock: EditedFilesDock;
   onDockChange: (dock: EditedFilesDock) => void;
 };
@@ -69,6 +71,7 @@ export function EditsPanel(props: EditsPanelProps) {
             view={view}
             worktreeRoot={props.worktreeRoot}
             onOpenFile={props.onOpenFile}
+            onScrollToTurn={props.onScrollToTurn}
           />
         ) : (
           <p className="context-empty">

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/EditsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/EditsPanel.tsx
@@ -18,7 +18,7 @@ type EditsPanelProps = {
   /** Open an edited file (absolute path) in the editor / OS default. */
   onOpenFile?: (absolutePath: string) => void;
   /** Scroll the transcript to a group's turn position (timestamp click). */
-  onScrollToTurn?: (turnId: string) => void;
+  onScrollToTurn?: (turnId: string, turnTimeMs?: number) => void;
   dock: EditedFilesDock;
   onDockChange: (dock: EditedFilesDock) => void;
 };

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -172,6 +172,8 @@ import type {
   DesktopSettingsWriteResponse,
   OpenDesktopApplicationRequest,
   OpenDesktopApplicationResponse,
+  OpenPathRequest,
+  OpenPathResponse,
   OpenDesktopPwrAgentProfileRequest,
   OpenDesktopPwrAgentProfileResponse,
   ReadDesktopSettingsRequest,
@@ -486,6 +488,7 @@ export type DesktopApi = {
   openApplication?: (
     request: OpenDesktopApplicationRequest
   ) => Promise<OpenDesktopApplicationResponse>;
+  openPath?: (request: OpenPathRequest) => Promise<OpenPathResponse>;
   listThreads?: (
     request?: AppServerListThreadsRequest
   ) => Promise<AppServerListThreadsResponse>;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -8785,15 +8785,22 @@ textarea,
   outline-offset: 1px;
 }
 
-/* Two-row card header: the "Edited N files" summary gets its own line so
-   the commit badges can't crush it, with the badge + date on a wrapping
-   second line. Sticky so the header pins to the top of the scroll body
-   while a long diff scrolls beneath it (the opaque card background hides the
-   scrolled content). */
+/* Group header is a grid of four cells — summary / badge / diff-stat / time —
+   so it can reflow per surface without changing the DOM. DEFAULT (the
+   width-constrained sidebar Edits panel) is a two-row stack: summary + stat on
+   top, badge + date beneath, so the commit badges never crush the summary. The
+   transcript rail overrides to a single row below. Sticky so the header pins to
+   the top of the scroll body while a long diff scrolls beneath it (the opaque
+   card background hides the scrolled content). */
 .edited-file-groups__group-header {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-areas:
+    "summary stat"
+    "badge   time";
+  align-items: center;
+  column-gap: 8px;
+  row-gap: 2px;
   min-width: 0;
   position: sticky;
   /* Pins to the top of the surface's scroll body (the title + view toggle are
@@ -8808,10 +8815,10 @@ textarea,
 }
 
 .edited-file-groups__group-toggle {
+  grid-area: summary;
   display: flex;
   align-items: center;
   gap: 6px;
-  width: 100%;
   min-width: 0;
   padding: 0;
   border: 0;
@@ -8827,14 +8834,19 @@ textarea,
   color: var(--text-primary);
 }
 
-/* Second row: badge (left) + date (right), aligned under the summary text
-   (past the chevron). Wraps rather than truncating on a narrow rail. */
-.edited-file-groups__group-meta {
-  display: flex;
+/* Badge cell (commit lifecycle / "This turn"). In the sidebar's second row it
+   sits under the summary text, so it's indented past the chevron + gap. */
+.edited-file-groups__group-badge {
+  grid-area: badge;
+  display: inline-flex;
   align-items: center;
-  flex-wrap: wrap;
-  gap: 4px 6px;
+  min-width: 0;
   padding-left: 22px;
+}
+
+.edited-file-groups__group-header > .diff-stat {
+  grid-area: stat;
+  justify-self: end;
 }
 
 .edited-file-groups__group-summary {
@@ -8844,6 +8856,19 @@ textarea,
   min-width: 0;
   flex: 1 1 auto;
   font-weight: 600;
+}
+
+/* Transcript rail (width-rich, height-constrained): collapse the header to a
+   single row — `summary  badge  ……  stat  time` — to reclaim vertical space.
+   The 1fr spacer column pushes the diff-stat + timestamp to the right edge. */
+.live-work-rail__section--edited .edited-file-groups__group-header {
+  grid-template-columns: auto auto minmax(8px, 1fr) auto auto;
+  grid-template-areas: "summary badge . stat time";
+  row-gap: 0;
+}
+
+.live-work-rail__section--edited .edited-file-groups__group-badge {
+  padding-left: 0;
 }
 
 .edited-file-groups__group-tag {
@@ -8945,8 +8970,8 @@ textarea,
 }
 
 .edited-file-groups__group-time {
-  flex: 0 0 auto;
-  margin-left: auto;
+  grid-area: time;
+  justify-self: end;
   color: var(--text-muted);
   font-size: 11px;
 }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9065,6 +9065,35 @@ textarea,
   font-size: 11px;
 }
 
+/* Clickable variant: scrolls the transcript to this group's turn. Reads as the
+   same muted timestamp until hovered/focused, then reveals a link affordance.
+   `font-size` must follow `font: inherit` — the shorthand resets it. */
+.edited-file-groups__group-time--link {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  font: inherit;
+  font-size: 11px;
+  color: var(--text-muted);
+  cursor: pointer;
+  text-decoration: underline dotted transparent;
+  text-underline-offset: 2px;
+  transition:
+    color 120ms ease,
+    text-decoration-color 120ms ease;
+}
+
+.edited-file-groups__group-time--link:hover {
+  color: var(--text-secondary);
+  text-decoration-color: currentColor;
+}
+
+.edited-file-groups__group-time--link:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 1px;
+  border-radius: 3px;
+}
+
 /* Context-rail Edits panel: a FIXED header (it lives outside the panel's
    scroll body, so it never translates with the list) carrying the title, the
    view toggle, and the dock toggle. Left group = title + `By turn / All files`;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -8911,10 +8911,26 @@ textarea,
   text-transform: uppercase;
 }
 
-.edit-commit-badge__label {
-  color: var(--text-muted);
+/* Single status pill: "Committed" (local) or "Pushed". Pushed implies
+   committed, so it replaces — never stacks with — the committed label. */
+.edit-commit-badge__status {
+  padding: 0 6px;
+  border: 1px solid transparent;
+  border-radius: 999px;
   letter-spacing: 0.04em;
   text-transform: uppercase;
+}
+
+.edit-commit-badge__status--committed {
+  border-color: var(--border-subtle);
+  background: var(--bg-panel-elevated);
+  color: var(--text-muted);
+}
+
+.edit-commit-badge__status--pushed {
+  border-color: var(--success-border);
+  background: var(--success-soft);
+  color: var(--success-text);
 }
 
 .edit-commit-badge__sha {
@@ -8947,26 +8963,6 @@ textarea,
 .edit-commit-badge__sha-value {
   font-family: var(--font-mono);
   letter-spacing: 0.02em;
-}
-
-.edit-commit-badge__push {
-  padding: 0 6px;
-  border: 1px solid transparent;
-  border-radius: 999px;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
-.edit-commit-badge__push--pushed {
-  border-color: var(--success-border);
-  background: var(--success-soft);
-  color: var(--success-text);
-}
-
-.edit-commit-badge__push--local {
-  border-color: var(--border-subtle);
-  background: var(--bg-panel-elevated);
-  color: var(--text-muted);
 }
 
 .edited-file-groups__group-time {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -8671,10 +8671,91 @@ textarea,
   background: var(--bg-panel-hover);
 }
 
+/* Middle grid cell of the file toggle: the filename (ellipsizing) with an
+   optional "Ignored" chip riding alongside it. */
+.live-work-rail__file-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
 .live-work-rail__file-path {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  min-width: 0;
+  flex: 0 1 auto;
+}
+
+/* Per-file flag: this file is gitignored, so it never enters a commit even
+   when its group reads "Committed". Warning-toned so it stands out from the
+   filename. */
+.edited-file-row__ignored {
+  flex: 0 0 auto;
+  padding: 0 5px;
+  border: 1px solid color-mix(in srgb, var(--status-warning) 38%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--status-warning) 12%, transparent);
+  color: var(--status-warning);
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+/* Expanded-file meta line above the diff: the repo-relative path (so the
+   reader knows WHERE the file lives, not just its basename) and an
+   open-in-editor affordance. */
+.edited-file-row__meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+  min-width: 0;
+}
+
+.edited-file-row__path {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+  flex: 0 1 auto;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.edited-file-row__open {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 4px;
+  background: var(--bg-input);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease,
+    border-color 120ms ease;
+}
+
+.edited-file-row__open:hover {
+  border-color: var(--accent-border);
+  color: var(--text-primary);
+}
+
+.edited-file-row__open:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 1px;
+}
+
+.edited-file-row__open-icon {
+  width: 14px;
+  height: 14px;
 }
 
 /* Shared +A/-R stat: + (green) then - (red), no comma — consistent with the
@@ -8891,7 +8972,8 @@ textarea,
 }
 
 /* Per-group git lifecycle: uncommitted → committed (with copyable SHA chip)
-   → pushed / local. Mirrors the group-tag pill scale. */
+   → pushed, plus a "N ignored" hint for gitignored files. Mirrors the
+   group-tag pill scale. */
 .edit-commit-badge {
   flex: 0 0 auto;
   display: inline-flex;
@@ -8901,24 +8983,21 @@ textarea,
   font-weight: 600;
 }
 
-.edit-commit-badge--uncommitted {
-  padding: 0 6px;
-  border: 1px solid color-mix(in srgb, var(--status-warning) 42%, transparent);
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--status-warning) 14%, transparent);
-  color: var(--status-warning);
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
-/* Single status pill: "Committed" (local) or "Pushed". Pushed implies
-   committed, so it replaces — never stacks with — the committed label. */
+/* Single status pill: one of "Uncommitted" / "Committed" (local) / "Pushed".
+   Pushed implies committed, so it replaces — never stacks with — the committed
+   label. */
 .edit-commit-badge__status {
   padding: 0 6px;
   border: 1px solid transparent;
   border-radius: 999px;
   letter-spacing: 0.04em;
   text-transform: uppercase;
+}
+
+.edit-commit-badge__status--uncommitted {
+  border-color: color-mix(in srgb, var(--status-warning) 42%, transparent);
+  background: color-mix(in srgb, var(--status-warning) 14%, transparent);
+  color: var(--status-warning);
 }
 
 .edit-commit-badge__status--committed {
@@ -8931,6 +9010,20 @@ textarea,
   border-color: var(--success-border);
   background: var(--success-soft);
   color: var(--success-text);
+}
+
+/* Gitignored-file hint, e.g. "· 1 ignored". Muted, not a pill — a quiet aside
+   to the committed/pushed status so a `.gitignore`'d file isn't read as part
+   of the commit. */
+.edit-commit-badge__ignored {
+  color: var(--text-muted);
+  font-weight: 500;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.edit-commit-badge__ignored::before {
+  content: "· ";
 }
 
 .edit-commit-badge__sha {

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -261,6 +261,7 @@ export const SETTINGS_PICK_GH_COMMAND_CHANNEL =
 export const ONBOARDING_COMPLETE_CODEX_BOOTSTRAP_CHANNEL =
   "onboarding:complete-codex-bootstrap";
 export const APPLICATION_OPEN_CHANNEL = "application:open";
+export const PATH_OPEN_CHANNEL = "path:open";
 export const APP_METADATA_READ_CHANNEL = "app:read-metadata";
 export const APP_LICENSE_DOCUMENT_READ_CHANNEL = "app:read-license-document";
 export const APP_CHANGELOG_DOCUMENT_READ_CHANNEL = "app:read-changelog-document";

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -552,6 +552,14 @@ export type EditGroupCommitState = {
   commitSha?: string;
   shortSha?: string;
   pushed?: boolean;
+  /**
+   * Absolute paths in this group that git ignores (matched by `.gitignore` /
+   * excludes). Such files never enter a commit, so the group can read
+   * `committed`/`pushed` from its tracked files while these are flagged
+   * separately — a per-file "ignored" chip plus a group-level count — so a
+   * `.gitignore`'d file isn't silently implied to be committed.
+   */
+  ignoredPaths?: string[];
 };
 
 export type ResolveEditCommitStatesRequest = {

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -1119,6 +1119,21 @@ export type OpenDesktopApplicationResponse = {
   opened: true;
 };
 
+/**
+ * Open a filesystem path with the OS default handler (`shell.openPath`). The
+ * fallback for "open this edited file" when no editor application is
+ * configured/available. `opened` is false with an `error` message when the OS
+ * could not open it.
+ */
+export type OpenPathRequest = {
+  path: string;
+};
+
+export type OpenPathResponse = {
+  opened: boolean;
+  error?: string;
+};
+
 export function isDesktopChatReplyComposer(
   value: string,
 ): value is DesktopChatReplyComposer {


### PR DESCRIPTION
A batch of edited-file UI refinements for both surfaces — the transcript **LiveWorkRail** and the context-rail **Edits** panel.

## 1. Single-row group header in the transcript
The group header used the same two-row stack on both surfaces — good for the narrow sidebar, wasteful in the wide/short transcript. The transcript now reflows to one row (`summary  badge  …  stat  time`) via CSS grid areas; the sidebar keeps its two-row stack. One flat DOM, two layouts.

## 2. `Pushed` replaces `Committed` (no redundant pair)
Pushed implies committed, so the badge is now a **single status pill**: `Uncommitted` → `Committed` (local) → `Pushed`. Dropped the standalone `Local` pill.

## 3. Gitignored files are flagged (not implied committed)
`resolveEditCommitStates` runs `git check-ignore` over the group paths and carries the matches (`EditGroupCommitState.ignoredPaths`). Ignored files are **excluded** from the committed/pushed judgement (they can never be committed) and surfaced two ways:
- a per-file **`Ignored`** chip on the row, and
- a **`· N ignored`** hint on the group badge.

So a `.gitignore`'d file like `PR-779.md` is no longer silently implied committed when its group reads `Committed`/`Pushed`.

## 4. Repo-relative path on expand
Expanding a file row shows its path relative to the thread's worktree root (e.g. `apps/desktop/Foo.ts`) above the diff — so it's clear *where* the file lives, not just its basename.

## 5. Open in editor
A button on the expanded row opens the file in the configured / first-available editor (same resolution as transcript file links), falling back to the **OS default** via a new `path:open` IPC (`shell.openPath`) when no editor is available.

### Plumbing
- `EditGroupCommitState` gains `ignoredPaths`; new `openPath` IPC + preload + `DesktopApi` method + `OpenPathRequest/Response` types.
- The surfaces pass a worktree root + open handler down; `EditedFileGroupList` provides them (plus the union ignored-path set) to every `EditedFileRow` via context, so grouped / flattened / single-group paths all get them without prop-drilling.

## Tests
- Resolver: `check-ignore` over mixed + all-ignored groups.
- Renderer: per-file ignored chip + group count; repo-relative path + open-button click; plus the existing badge/toggle/sticky suites.
- typecheck (shared + desktop), `lint:colors` / `boundaries` / `codex-storage` / `sql` all clean.

## ⚠️ Visual + behavior pass
- The `Ignored` chip (warning-toned) next to a filename; `· N ignored` on the badge.
- Repo-relative path + the editor button on an expanded row; clicking it opens your configured editor, or the OS default if none.
- Note: the open button currently lives in the **expanded** row area (the file-toggle is already a button, so nesting a second button in the row header is invalid HTML) — say the word if you'd rather it be always-visible and I'll restructure the row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)