### PR TITLE
feat(desktop): fan out PR status updates by key

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -1987,6 +1987,81 @@ describe("app server ipc", () => {
     });
   });
 
+  it("does not publish PR update events when retained PR status is unchanged", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_REFRESH_THREAD_PRS_CHANNEL } = await import("../../shared/ipc");
+    const request = {
+      backend: "codex",
+      threadId: "thread-1",
+      branch: "codex/fix-reel-upload-button-swift",
+      directoryPaths: ["/repo"],
+    } satisfies RefreshThreadPullRequestsRequest;
+    const requestKey = buildThreadPrRequestKey({
+      backend: "codex",
+      threadId: "thread-1",
+      branch: "codex/fix-reel-upload-button-swift",
+      directoryPaths: ["/repo"],
+    });
+    const unchangedPr = githubPr({
+      number: 255,
+      org: "Giphy",
+      repo: "GifGrabber",
+      title: "[codex] Fix upload button after reel switching",
+      state: "passing",
+      url: "https://github.com/Giphy/GifGrabber/pull/255",
+    });
+    getThreadOverlayState.mockResolvedValueOnce({
+      backend: "codex",
+      threadId: "thread-1",
+      executionMode: "default",
+      extraLinkedDirectories: [],
+      prs: [unchangedPr],
+      prsFetchedAt: Date.now() - 120_000,
+      prsRefreshKey: requestKey,
+    });
+    detectPullRequestsForThread.mockResolvedValueOnce([]);
+    fetchPullRequestByUrl.mockResolvedValueOnce(unchangedPr);
+
+    registerAppServerIpcHandlers();
+
+    await handlers.get(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL)?.({}, request);
+
+    await vi.waitFor(() => {
+      expect(fetchPullRequestByUrl).toHaveBeenCalledWith({
+        cwd: "/repo",
+        url: "https://github.com/Giphy/GifGrabber/pull/255",
+      });
+    });
+    expect(writePrStatusCacheEntries).toHaveBeenCalledWith([
+      {
+        provider: "github.com",
+        prKey: "github.com/giphy/gifgrabber#255",
+        fetchedAt: expect.any(Number),
+        pr: unchangedPr,
+      },
+    ]);
+    expect(publishLocalEvent).not.toHaveBeenCalledWith({
+      backend: "codex",
+      notification: {
+        method: "pullRequest/status/updated",
+        params: {
+          prKey: "github.com/giphy/gifgrabber#255",
+          pr: unchangedPr,
+        },
+      },
+    });
+    expect(publishLocalEvent).not.toHaveBeenCalledWith({
+      backend: "codex",
+      notification: {
+        method: "thread/pullRequests/updated",
+        params: {
+          threadId: "thread-1",
+          prs: [unchangedPr],
+        },
+      },
+    });
+  });
+
   it("short-circuits PR refresh when all cached PRs are terminal for the same lookup", async () => {
     const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
     const { NAVIGATION_REFRESH_THREAD_PRS_CHANNEL } = await import("../../shared/ipc");

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -1957,6 +1957,16 @@ describe("app server ipc", () => {
         pr: mergedPr,
       },
     ]);
+    expect(publishLocalEvent).toHaveBeenCalledWith({
+      backend: "codex",
+      notification: {
+        method: "pullRequest/status/updated",
+        params: {
+          prKey: "github.com/giphy/gifgrabber#255",
+          pr: mergedPr,
+        },
+      },
+    });
     expect(writePrLookupCacheEntry).toHaveBeenCalledWith({
       lookupKey,
       provider: "github.com",

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -95,8 +95,9 @@ import {
   type UpdateSubthreadOrderResponse,
 } from "@pwragent/shared";
 import {
-  DEFAULT_PULL_REQUEST_PROVIDER,
+  buildPullRequestStatusKey,
   buildThreadIdentityKey,
+  normalizePullRequestProvider as normalizeSharedPullRequestProvider,
 } from "@pwragent/shared";
 import { registerDirectoryFromDisk } from "../app-server/directory-registration-service";
 import {
@@ -395,8 +396,7 @@ function getPullRequestLookupKey(
 }
 
 function normalizePullRequestProvider(provider: string | undefined): string {
-  return (provider ?? DEFAULT_PULL_REQUEST_PROVIDER).trim().toLowerCase()
-    || DEFAULT_PULL_REQUEST_PROVIDER;
+  return normalizeSharedPullRequestProvider(provider);
 }
 
 function normalizePrSummary(pr: PrSummary): PrSummary {
@@ -454,7 +454,7 @@ function legacyPrReviewState(state: string | undefined): PrSummary["reviewState"
 function getPrStatusKey(
   pr: Pick<PrSummary, "provider" | "org" | "repo" | "number">,
 ): string {
-  return `${normalizePullRequestProvider(pr.provider)}/${pr.org.toLowerCase()}/${pr.repo.toLowerCase()}#${pr.number}`;
+  return buildPullRequestStatusKey(pr);
 }
 
 function prSummariesEqual(left: PrSummary[], right: PrSummary[]): boolean {
@@ -1639,6 +1639,7 @@ class DesktopAppServerService {
   }
 
   private async fetchPullRequestLookup(params: {
+    backend: AppServerBackendKind;
     request: RefreshThreadPullRequestsRequest;
     lookupKey: string;
     lookupDirectoryPaths: string[];
@@ -1661,6 +1662,10 @@ class DesktopAppServerService {
     const statusPrs = dedupePrsByStatusKey([...prs, ...retainedPrs]);
     this.rememberPrStatuses(statusPrs, fetchedAt);
     await this.writePrStatusesToCache(statusPrs, fetchedAt);
+    await this.publishPullRequestStatusUpdates({
+      backend: params.backend,
+      prs: statusPrs,
+    });
     this.rememberPrLookup({
       lookupKey: params.lookupKey,
       provider: normalizePullRequestProvider(params.request.provider),
@@ -2074,6 +2079,26 @@ class DesktopAppServerService {
         },
       },
     });
+  }
+
+  private async publishPullRequestStatusUpdates(params: {
+    backend: AppServerBackendKind;
+    prs: PrSummary[];
+  }): Promise<void> {
+    await Promise.all(
+      params.prs.map(async (pr) => {
+        await getDesktopBackendRegistry().publishLocalEvent({
+          backend: params.backend,
+          notification: {
+            method: "pullRequest/status/updated",
+            params: {
+              prKey: getPrStatusKey(pr),
+              pr,
+            },
+          },
+        });
+      }),
+    );
   }
 
   async getGhStatus(request: GetGhStatusRequest): Promise<GhStatus> {

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1660,11 +1660,11 @@ class DesktopAppServerService {
       cwd: params.lookupDirectoryPaths[0] ?? params.request.directoryPaths[0],
     });
     const statusPrs = dedupePrsByStatusKey([...prs, ...retainedPrs]);
-    this.rememberPrStatuses(statusPrs, fetchedAt);
+    const changedStatusPrs = this.rememberPrStatuses(statusPrs, fetchedAt);
     await this.writePrStatusesToCache(statusPrs, fetchedAt);
     await this.publishPullRequestStatusUpdates({
       backend: params.backend,
-      prs: statusPrs,
+      prs: changedStatusPrs,
     });
     this.rememberPrLookup({
       lookupKey: params.lookupKey,
@@ -1926,12 +1926,16 @@ class DesktopAppServerService {
     return lookupKey;
   }
 
-  private rememberPrStatuses(prs: PrSummary[], fetchedAt: number): void {
+  private rememberPrStatuses(prs: PrSummary[], fetchedAt: number): PrSummary[] {
+    const changedPrs: PrSummary[] = [];
     for (const pr of prs.map(normalizePrSummary)) {
       const key = getPrStatusKey(pr);
       const current = this.prStatusRegistry.get(key);
       if (current && current.fetchedAt > fetchedAt) {
         continue;
+      }
+      if (!current || !prSummariesEqual([current.pr], [pr])) {
+        changedPrs.push(pr);
       }
       this.prStatusRegistry.set(key, {
         ...current,
@@ -1939,6 +1943,7 @@ class DesktopAppServerService {
         fetchedAt,
       });
     }
+    return changedPrs;
   }
 
   private rememberPrLookup(entry: {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -4819,6 +4819,13 @@ describe("useThreadNavigation", () => {
       expect(result.current.threads).toHaveLength(3);
     });
 
+    Object.defineProperty(unrelatedPr, "provider", {
+      configurable: true,
+      get: () => {
+        throw new Error("unrelated PR should not be scanned during status fanout");
+      },
+    });
+
     await act(async () => {
       for (const listener of listeners) {
         listener({
@@ -4839,8 +4846,8 @@ describe("useThreadNavigation", () => {
         .toEqual([updatedPr]);
       expect(result.current.threads.find((thread) => thread.id === "thread-2")?.prs)
         .toEqual([updatedPr]);
-      expect(result.current.threads.find((thread) => thread.id === "thread-3")?.prs)
-        .toEqual([unrelatedPr]);
+      expect(result.current.threads.find((thread) => thread.id === "thread-3")?.prs?.[0])
+        .toBe(unrelatedPr);
     });
     await waitFor(() => {
       expect(getNavigationSnapshot).toHaveBeenCalledTimes(2);

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -1,6 +1,9 @@
 import "@testing-library/jest-dom/vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { shortenDerivedThreadTitle } from "@pwragent/shared";
+import {
+  buildPullRequestStatusKey,
+  shortenDerivedThreadTitle,
+} from "@pwragent/shared";
 import type {
   NavigationLaunchpadDefaults,
   NavigationLaunchpadDraft,
@@ -4714,6 +4717,133 @@ describe("useThreadNavigation", () => {
 
     await waitFor(() => {
       expect(result.current.selectedThread?.prs).toEqual([updatedPr]);
+    });
+  });
+
+  it("fans out pull request status updates to every visible matching PR key", async () => {
+    const listeners = new Set<(event: any) => void>();
+    const initialPr: PrSummary = {
+      provider: "github.com",
+      number: 255,
+      org: "Giphy",
+      repo: "GifGrabber",
+      state: "passing",
+      checkState: "passing",
+      lifecycleState: "open",
+      reviewState: "draft",
+      mergeState: "mergeable",
+      url: "https://github.com/Giphy/GifGrabber/pull/255",
+    };
+    const updatedPr: PrSummary = {
+      ...initialPr,
+      lifecycleState: "merged",
+      reviewState: "ready_for_review",
+      mergeState: "unknown",
+    };
+    const unrelatedPr: PrSummary = {
+      ...initialPr,
+      number: 256,
+      url: "https://github.com/Giphy/GifGrabber/pull/256",
+    };
+    const getNavigationSnapshot = vi
+      .fn()
+      .mockResolvedValueOnce({
+        backend: "all" as const,
+        fetchedAt: Date.now(),
+        unchanged: false,
+        inboxThreadKeys: ["codex:thread-1", "grok:thread-2"],
+        threads: [
+          {
+            id: "thread-1",
+            title: "First thread",
+            titleSource: "explicit" as const,
+            source: "codex" as const,
+            linkedDirectories: [],
+            prs: [initialPr],
+            inbox: { inInbox: true, reason: "new-thread" as const },
+            updatedAt: 1_000,
+          },
+          {
+            id: "thread-2",
+            title: "Second thread",
+            titleSource: "explicit" as const,
+            source: "grok" as const,
+            linkedDirectories: [],
+            prs: [{ ...initialPr }],
+            inbox: { inInbox: true, reason: "new-thread" as const },
+            updatedAt: 2_000,
+          },
+          {
+            id: "thread-3",
+            title: "Unrelated thread",
+            titleSource: "explicit" as const,
+            source: "codex" as const,
+            linkedDirectories: [],
+            prs: [unrelatedPr],
+            inbox: { inInbox: true, reason: "new-thread" as const },
+            updatedAt: 3_000,
+          },
+        ],
+        directories: [],
+        launchpadDefaults: {
+          backend: "codex" as const,
+          executionMode: "default" as const,
+        },
+      })
+      .mockResolvedValue({
+        backend: "all" as const,
+        fetchedAt: Date.now(),
+        unchanged: true,
+        inboxThreadKeys: ["codex:thread-1", "grok:thread-2"],
+        threads: [],
+        directories: [],
+        launchpadDefaults: {
+          backend: "codex" as const,
+          executionMode: "default" as const,
+        },
+      });
+
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: (callback) => {
+        listeners.add(callback);
+        return () => {
+          listeners.delete(callback);
+        };
+      },
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.threads).toHaveLength(3);
+    });
+
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "pullRequest/status/updated",
+            params: {
+              prKey: buildPullRequestStatusKey(updatedPr),
+              pr: updatedPr,
+            },
+          },
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(result.current.threads.find((thread) => thread.id === "thread-1")?.prs)
+        .toEqual([updatedPr]);
+      expect(result.current.threads.find((thread) => thread.id === "thread-2")?.prs)
+        .toEqual([updatedPr]);
+      expect(result.current.threads.find((thread) => thread.id === "thread-3")?.prs)
+        .toEqual([unrelatedPr]);
+    });
+    await waitFor(() => {
+      expect(getNavigationSnapshot).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -23,6 +23,7 @@ import type {
 import {
   buildAppendPinRank,
   buildPinnedRanks,
+  buildPullRequestStatusKey,
   buildThreadIdentityKey,
   comparePinnedThreads,
   compareThreadsByCreatedAtDesc,
@@ -1260,6 +1261,51 @@ function applyThreadPullRequestsUpdate(
     : snapshot;
 }
 
+function applyPullRequestStatusUpdate(
+  snapshot: NavigationSnapshot | undefined,
+  params: { prKey: string; pr: PrSummary }
+): NavigationSnapshot | undefined {
+  if (!snapshot) {
+    return snapshot;
+  }
+
+  let changed = false;
+  const threads = snapshot.threads.map((thread) => {
+    if (!thread.prs?.length) {
+      return thread;
+    }
+
+    let threadChanged = false;
+    const prs = thread.prs.map((pr) => {
+      if (buildPullRequestStatusKey(pr) !== params.prKey) {
+        return pr;
+      }
+      if (prSummariesEqual([pr], [params.pr])) {
+        return pr;
+      }
+      threadChanged = true;
+      return params.pr;
+    });
+
+    if (!threadChanged) {
+      return thread;
+    }
+
+    changed = true;
+    return {
+      ...thread,
+      prs,
+    };
+  });
+
+  return changed
+    ? {
+        ...snapshot,
+        threads,
+      }
+    : snapshot;
+}
+
 function applyThreadModelSettingsUpdate(
   snapshot: NavigationSnapshot | undefined,
   params: {
@@ -2436,6 +2482,22 @@ export function useThreadNavigation(
             backend: event.backend,
             threadId,
             prs,
+          }),
+        }));
+        scheduleRefresh();
+        return;
+      }
+
+      if (method === "pullRequest/status/updated") {
+        const { prKey, pr } = event.notification.params as {
+          prKey: string;
+          pr: PrSummary;
+        };
+        setState((current) => ({
+          ...current,
+          response: applyPullRequestStatusUpdate(current.response, {
+            prKey,
+            pr,
           }),
         }));
         scheduleRefresh();

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -96,6 +96,16 @@ type NavigationRefreshOptions = {
   forceRefresh?: boolean;
 };
 
+type PrChipLocation = {
+  threadIndex: number;
+  prIndex: number;
+};
+
+type PrChipLocationIndex = {
+  snapshot: NavigationSnapshot;
+  byPrKey: Map<string, PrChipLocation[]>;
+};
+
 function buildLaunchpadSelectionKey(directoryKey: string): string {
   return `launchpad:${directoryKey}`;
 }
@@ -1263,47 +1273,84 @@ function applyThreadPullRequestsUpdate(
 
 function applyPullRequestStatusUpdate(
   snapshot: NavigationSnapshot | undefined,
-  params: { prKey: string; pr: PrSummary }
-): NavigationSnapshot | undefined {
+  params: { prKey: string; pr: PrSummary; index?: PrChipLocationIndex }
+): { snapshot: NavigationSnapshot | undefined; index: PrChipLocationIndex | undefined } {
   if (!snapshot) {
-    return snapshot;
+    return { snapshot, index: undefined };
   }
 
-  let changed = false;
-  const threads = snapshot.threads.map((thread) => {
-    if (!thread.prs?.length) {
-      return thread;
+  const index =
+    params.index?.snapshot === snapshot
+      ? params.index
+      : buildPrChipLocationIndex(snapshot);
+  const locations = index.byPrKey.get(params.prKey);
+  if (!locations?.length) {
+    return { snapshot, index };
+  }
+
+  let threads: NavigationSnapshot["threads"] | undefined;
+  const updatedThreadIndexes = new Set<number>();
+  for (const location of locations) {
+    const sourceThreads = threads ?? snapshot.threads;
+    const thread = sourceThreads[location.threadIndex];
+    const currentPr = thread?.prs?.[location.prIndex];
+    if (!thread || !currentPr) {
+      continue;
+    }
+    if (buildPullRequestStatusKey(currentPr) !== params.prKey) {
+      continue;
+    }
+    if (prSummariesEqual([currentPr], [params.pr])) {
+      continue;
     }
 
-    let threadChanged = false;
-    const prs = thread.prs.map((pr) => {
-      if (buildPullRequestStatusKey(pr) !== params.prKey) {
-        return pr;
-      }
-      if (prSummariesEqual([pr], [params.pr])) {
-        return pr;
-      }
-      threadChanged = true;
-      return params.pr;
+    if (!threads) {
+      threads = [...snapshot.threads];
+    }
+    if (!updatedThreadIndexes.has(location.threadIndex)) {
+      threads[location.threadIndex] = {
+        ...thread,
+        prs: [...(thread.prs ?? [])],
+      };
+      updatedThreadIndexes.add(location.threadIndex);
+    }
+    threads[location.threadIndex]!.prs![location.prIndex] = params.pr;
+  }
+
+  if (!threads) {
+    return { snapshot, index };
+  }
+
+  const nextSnapshot = {
+    ...snapshot,
+    threads,
+  };
+  return {
+    snapshot: nextSnapshot,
+    index: {
+      snapshot: nextSnapshot,
+      byPrKey: index.byPrKey,
+    },
+  };
+}
+
+function buildPrChipLocationIndex(
+  snapshot: NavigationSnapshot,
+): PrChipLocationIndex {
+  const byPrKey = new Map<string, PrChipLocation[]>();
+  snapshot.threads.forEach((thread, threadIndex) => {
+    thread.prs?.forEach((pr, prIndex) => {
+      const prKey = buildPullRequestStatusKey(pr);
+      const locations = byPrKey.get(prKey) ?? [];
+      locations.push({ threadIndex, prIndex });
+      byPrKey.set(prKey, locations);
     });
-
-    if (!threadChanged) {
-      return thread;
-    }
-
-    changed = true;
-    return {
-      ...thread,
-      prs,
-    };
   });
 
-  return changed
-    ? {
-        ...snapshot,
-        threads,
-      }
-    : snapshot;
+  return {
+    snapshot,
+    byPrKey,
+  };
 }
 
 function applyThreadModelSettingsUpdate(
@@ -2111,6 +2158,7 @@ export function useThreadNavigation(
     refreshing: false,
   });
   const [viewForeground, setViewForeground] = useState(isRendererViewForeground);
+  const prChipLocationIndexRef = useRef<PrChipLocationIndex | undefined>(undefined);
 
   const optimisticThreadRef = useRef<NavigationThreadSummary | undefined>(undefined);
   const retainedUnreadThreadRef = useRef<NavigationThreadSummary | undefined>(undefined);
@@ -2184,6 +2232,7 @@ export function useThreadNavigation(
       options?: NavigationRefreshOptions
     ): Promise<void> => {
       if (!enabled) {
+        prChipLocationIndexRef.current = undefined;
         setState({
           loading: false,
           refreshing: false,
@@ -2194,6 +2243,7 @@ export function useThreadNavigation(
       }
 
       if (!desktopApi?.getNavigationSnapshot) {
+        prChipLocationIndexRef.current = undefined;
         setState({
           loading: false,
           refreshing: false,
@@ -2233,11 +2283,13 @@ export function useThreadNavigation(
             };
           }
 
+          const nextResponse = reconcileNavigationSnapshot(current.response, response);
+          prChipLocationIndexRef.current = buildPrChipLocationIndex(nextResponse);
           return {
             loading: false,
             refreshing: false,
             error: undefined,
-            response: reconcileNavigationSnapshot(current.response, response),
+            response: nextResponse,
           };
         });
 
@@ -2401,6 +2453,7 @@ export function useThreadNavigation(
 
   useEffect(() => {
     if (!enabled) {
+      prChipLocationIndexRef.current = undefined;
       setState({
         loading: false,
         refreshing: false,
@@ -2476,14 +2529,23 @@ export function useThreadNavigation(
           threadId: string;
           prs: PrSummary[];
         };
-        setState((current) => ({
-          ...current,
-          response: applyThreadPullRequestsUpdate(current.response, {
+        setState((current) => {
+          const nextResponse = applyThreadPullRequestsUpdate(current.response, {
             backend: event.backend,
             threadId,
             prs,
-          }),
-        }));
+          });
+          prChipLocationIndexRef.current = nextResponse
+            ? buildPrChipLocationIndex(nextResponse)
+            : undefined;
+          if (nextResponse === current.response) {
+            return current;
+          }
+          return {
+            ...current,
+            response: nextResponse,
+          };
+        });
         scheduleRefresh();
         return;
       }
@@ -2493,13 +2555,21 @@ export function useThreadNavigation(
           prKey: string;
           pr: PrSummary;
         };
-        setState((current) => ({
-          ...current,
-          response: applyPullRequestStatusUpdate(current.response, {
+        setState((current) => {
+          const result = applyPullRequestStatusUpdate(current.response, {
             prKey,
             pr,
-          }),
-        }));
+            index: prChipLocationIndexRef.current,
+          });
+          prChipLocationIndexRef.current = result.index;
+          if (result.snapshot === current.response) {
+            return current;
+          }
+          return {
+            ...current,
+            response: result.snapshot,
+          };
+        });
         scheduleRefresh();
         return;
       }

--- a/packages/shared/src/contracts/__tests__/pull-request-status-key.test.ts
+++ b/packages/shared/src/contracts/__tests__/pull-request-status-key.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { buildPullRequestStatusKey } from "../navigation";
+
+describe("buildPullRequestStatusKey", () => {
+  it("normalizes provider, owner, and repo casing", () => {
+    expect(
+      buildPullRequestStatusKey({
+        provider: "GitHub.COM",
+        org: "Giphy",
+        repo: "GifGrabber",
+        number: 255,
+      }),
+    ).toBe("github.com/giphy/gifgrabber#255");
+  });
+
+  it("defaults blank providers to github.com", () => {
+    expect(
+      buildPullRequestStatusKey({
+        provider: "",
+        org: "pwrdrvr",
+        repo: "PwrAgent",
+        number: 797,
+      }),
+    ).toBe("github.com/pwrdrvr/pwragent#797");
+  });
+});

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -237,6 +237,19 @@ export type PrSummary = {
   url: string;
 };
 
+export function normalizePullRequestProvider(
+  provider: PullRequestProvider | undefined,
+): PullRequestProvider {
+  return (provider ?? DEFAULT_PULL_REQUEST_PROVIDER).trim().toLowerCase()
+    || DEFAULT_PULL_REQUEST_PROVIDER;
+}
+
+export function buildPullRequestStatusKey(
+  pr: Pick<PrSummary, "provider" | "org" | "repo" | "number">,
+): string {
+  return `${normalizePullRequestProvider(pr.provider)}/${pr.org.toLowerCase()}/${pr.repo.toLowerCase()}#${pr.number}`;
+}
+
 export type DirectorySummaryKind = "directory" | "workspace" | "unlinked";
 export type NavigationBrowseMode = "inbox" | "recents" | "directories";
 export type LaunchpadWorkMode = "local" | "worktree";

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -1195,6 +1195,13 @@ export type AppServerNotification =
         prs: PrSummary[];
       };
     }
+  | {
+      method: "pullRequest/status/updated";
+      params: {
+        prKey: string;
+        pr: PrSummary;
+      };
+    }
   /**
    * Directory pin lifecycle — mirror of `thread/pin/*` minus the
    * implicit per-backend dimension (directories are


### PR DESCRIPTION
## Summary
PR chips now update everywhere in the visible navigation snapshot when any refresh observes a newer state for the same canonical PR key. A merged PR no longer depends on each individual thread receiving its own thread-scoped PR update before every matching chip changes color/state.

The shared key is `provider/org/repo#number`, so main-process cache writes and renderer patching use the same identity. Thread-specific `thread/pullRequests/updated` events still persist each thread's retained PR list; the new `pullRequest/status/updated` event fans the canonical state out across every visible matching chip.

## Tests
- `pnpm test packages/shared/src/contracts/__tests__/pull-request-status-key.test.ts apps/desktop/src/main/__tests__/app-server-ipc.test.ts apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx apps/desktop/src/main/__tests__/github-pr-fetcher.test.ts`
- `pnpm typecheck`
- `pnpm lint:boundaries`

## Post-Deploy Monitoring & Validation
- Watch app logs for `background PR lookup refresh failed`, `gh pr view failed`, and `gh pr list (single-branch) failed` over the first 24 hours after release.
- Healthy signal: hovering or selecting any thread with a retained PR causes all visible chips for that PR number/repo to converge to the same lifecycle/check state after the refresh completes.
- Failure signal: one visible chip for a PR shows merged/closed while another visible chip for the same provider/org/repo/number remains open/passing after a manual refresh or hover.
- Rollback trigger: repeated renderer errors from `agent:event` handling or a spike in PR refresh failures tied to `pullRequest/status/updated` payloads.
- Owner/window: desktop owner validates during the next dogfood session against threads sharing the same PR key.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
