### PR TITLE
fix(desktop): profile and unblock startup

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry-replay-isolation.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry-replay-isolation.test.ts
@@ -11,15 +11,26 @@ const constructorState = vi.hoisted(() => ({
   codexCount: 0,
   codexArgs: [] as Array<string[] | undefined>,
   codexEnvs: [] as Array<NodeJS.ProcessEnv | undefined>,
+  codexResolveArgs: [] as Array<
+    ((env: NodeJS.ProcessEnv) => Promise<string[]> | string[]) | undefined
+  >,
+  codexResolveEnvs: [] as Array<(() => Promise<NodeJS.ProcessEnv>) | undefined>,
   grokCount: 0,
 }));
 
 vi.mock("../codex-app-server/client", () => ({
   CodexAppServerClient: class {
-    constructor(options?: { args?: string[]; env?: NodeJS.ProcessEnv }) {
+    constructor(options?: {
+      args?: string[];
+      env?: NodeJS.ProcessEnv;
+      resolveArgs?: (env: NodeJS.ProcessEnv) => Promise<string[]> | string[];
+      resolveEnv?: () => Promise<NodeJS.ProcessEnv>;
+    }) {
       constructorState.codexCount += 1;
       constructorState.codexArgs.push(options?.args);
       constructorState.codexEnvs.push(options?.env);
+      constructorState.codexResolveArgs.push(options?.resolveArgs);
+      constructorState.codexResolveEnvs.push(options?.resolveEnv);
     }
 
     async close(): Promise<void> {
@@ -79,6 +90,7 @@ vi.mock("../settings/desktop-settings-singleton", () => ({
   getDesktopSettingsService: () => ({
     resolveCodexCommandPreference: () => undefined,
     resolveCodexSpawnEnv: () => settingsState.codexEnv,
+    resolveCodexSpawnEnvAsync: async () => settingsState.codexEnv ?? process.env,
     resolveWorktreeStorage: () => "in-repo",
   }),
 }));
@@ -181,6 +193,8 @@ beforeEach(() => {
   constructorState.codexCount = 0;
   constructorState.codexArgs = [];
   constructorState.codexEnvs = [];
+  constructorState.codexResolveArgs = [];
+  constructorState.codexResolveEnvs = [];
   constructorState.grokCount = 0;
   settingsState.codexEnv = undefined;
 });
@@ -279,14 +293,15 @@ describe("DesktopBackendRegistry replay isolation", () => {
     });
 
     expect(constructorState.codexCount).toBe(1);
-    expect(constructorState.codexArgs).toEqual([
-      [
-        "-c",
-        'approval_policy="on-request"',
-        "-c",
-        'sandbox_mode="workspace-write"',
-      ],
+    const resolveArgs = constructorState.codexResolveArgs[0];
+    expect(resolveArgs).toBeTypeOf("function");
+    await expect(Promise.resolve(resolveArgs?.({}))).resolves.toEqual([
+      "-c",
+      'approval_policy="on-request"',
+      "-c",
+      'sandbox_mode="workspace-write"',
     ]);
+    expect(constructorState.codexArgs).toEqual([undefined]);
 
     await registry.close();
   });
@@ -303,6 +318,9 @@ describe("DesktopBackendRegistry replay isolation", () => {
 
     expect(constructorState.codexCount).toBe(1);
     expect(constructorState.codexEnvs[0]?.CODEX_HOME).toBe(codexHome);
+    await expect(constructorState.codexResolveEnvs[0]?.()).resolves.toMatchObject({
+      CODEX_HOME: codexHome,
+    });
 
     await registry.close();
   });
@@ -316,7 +334,9 @@ describe("DesktopBackendRegistry replay isolation", () => {
       overlayStore: createOverlayStoreMock(),
     });
 
-    expect(constructorState.codexArgs[0]).toContain(
+    const resolvedEnv = await constructorState.codexResolveEnvs[0]?.();
+    const resolvedArgs = await constructorState.codexResolveArgs[0]?.(resolvedEnv ?? {});
+    expect(resolvedArgs).toContain(
       'shell_environment_policy.set.PATH="/opt/homebrew/bin:/usr/bin:/bin"',
     );
 

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -99,10 +99,12 @@ class MockTransport implements JsonRpcTransport {
     | undefined = undefined;
 
   readonly sentMessages: string[] = [];
+  readonly options?: unknown;
   private messageHandler: (message: string) => void = () => undefined;
   private closeHandler: (error?: Error) => void = () => undefined;
 
-  constructor() {
+  constructor(options?: unknown) {
+    this.options = options;
     MockTransport.instances.push(this);
   }
 
@@ -929,8 +931,8 @@ class MockTransport implements JsonRpcTransport {
 
 vi.mock("../codex-app-server/stdio-transport", () => {
   class MockStdioJsonRpcTransport extends MockTransport {
-    constructor() {
-      super();
+    constructor(options?: unknown) {
+      super(options);
     }
   }
 
@@ -1016,6 +1018,44 @@ describe("CodexAppServerClient", () => {
     MockTransport.threadListResultBySearchTerm.clear();
     MockTransport.turnInterruptResponseMode = "success";
     MockTransport.threadResumeError = undefined;
+  });
+
+  it("passes hydrated env into dynamic launch args", async () => {
+    const resolveEnv = vi.fn(async () => ({
+      PATH: "/opt/homebrew/bin:/usr/local/bin:/usr/bin",
+    }));
+    const resolveArgs = vi.fn((env: NodeJS.ProcessEnv) => [
+      "-c",
+      `shell_environment_policy.set.PATH=${JSON.stringify(env.PATH)}`,
+    ]);
+
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    new CodexAppServerClient({
+      args: [
+        "-c",
+        'shell_environment_policy.set.PATH="/usr/bin"',
+      ],
+      resolveArgs,
+      resolveEnv,
+    });
+
+    const transport = MockTransport.instances.at(-1);
+    const options = transport?.options as
+      | {
+          resolveArgs?: (env: NodeJS.ProcessEnv) => Promise<string[]> | string[];
+          resolveEnv?: () => Promise<NodeJS.ProcessEnv>;
+        }
+      | undefined;
+    const hydratedEnv = await options?.resolveEnv?.();
+    const args = await options?.resolveArgs?.(hydratedEnv ?? {});
+
+    expect(resolveEnv).toHaveBeenCalledTimes(1);
+    expect(resolveArgs).toHaveBeenCalledWith({
+      PATH: "/opt/homebrew/bin:/usr/local/bin:/usr/bin",
+    });
+    expect(args).toContain(
+      'shell_environment_policy.set.PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin"',
+    );
   });
 
   it("initializes once and normalizes thread/list results", async () => {

--- a/apps/desktop/src/main/__tests__/startup-cpu-profile-session.test.ts
+++ b/apps/desktop/src/main/__tests__/startup-cpu-profile-session.test.ts
@@ -62,6 +62,12 @@ describe("startup CPU profiling session", () => {
     expect(result.session.rendererProfilePath).toBe(
       path.join(expectedDirectory, "renderer.cpuprofile"),
     );
+    expect(result.session.mainHeapSnapshotPath).toBe(
+      path.join(expectedDirectory, "main.heapsnapshot"),
+    );
+    expect(result.session.rendererHeapSnapshotPath).toBe(
+      path.join(expectedDirectory, "renderer.heapsnapshot"),
+    );
     expect(result.session.analysisPath).toBe(path.join(expectedDirectory, "analysis.json"));
     expect(result.session.summaryPath).toBe(path.join(expectedDirectory, "summary.md"));
 
@@ -87,10 +93,15 @@ describe("startup CPU profiling session", () => {
         summaryFilename: "summary.md",
         generatedAt: null,
       },
+      heapSnapshots: {
+        enabled: false,
+        files: [],
+      },
       config: {
         postLoadDurationMs: 5000,
         hardTimeoutMs: 15000,
         quitOnComplete: false,
+        captureHeapSnapshots: false,
       },
       versions: {
         appVersion: "0.1.0",
@@ -141,6 +152,7 @@ describe("startup CPU profiling session", () => {
     });
 
     await result.session.markProfileCaptured("main", "2026-04-19T13:30:09.000Z");
+    await result.session.registerHeapSnapshot("main.heapsnapshot");
     await result.session.markAnalysisGenerated("2026-04-19T13:30:10.000Z");
     await result.session.complete({
       completedAt: "2026-04-19T13:30:11.000Z",
@@ -191,6 +203,9 @@ describe("startup CPU profiling session", () => {
         summaryFilename: "summary.md",
         generatedAt: "2026-04-19T13:30:10.000Z",
       },
+      heapSnapshots: {
+        files: ["main.heapsnapshot"],
+      },
     });
   });
 
@@ -219,6 +234,7 @@ describe("startup CPU profiling session", () => {
         PWRAGENT_STARTUP_CPU_PROFILE_POST_LOAD_MS: "8000",
         PWRAGENT_STARTUP_CPU_PROFILE_HARD_TIMEOUT_MS: "25000",
         PWRAGENT_STARTUP_CPU_PROFILE_QUIT_ON_COMPLETE: "1",
+        PWRAGENT_STARTUP_PROFILE_HEAP_SNAPSHOTS: "1",
       },
       repoRoot: workspace.path,
     });
@@ -228,6 +244,7 @@ describe("startup CPU profiling session", () => {
       postLoadDurationMs: 8000,
       hardTimeoutMs: 25000,
       quitOnComplete: true,
+      captureHeapSnapshots: true,
     });
   });
 

--- a/apps/desktop/src/main/__tests__/startup-cpu-profiler.test.ts
+++ b/apps/desktop/src/main/__tests__/startup-cpu-profiler.test.ts
@@ -19,6 +19,7 @@ function createEnabledConfig() {
     postLoadDurationMs: 5000,
     hardTimeoutMs: 15000,
     quitOnComplete: false,
+    captureHeapSnapshots: false,
   };
 }
 
@@ -31,11 +32,14 @@ function createSession(): StartupCpuProfileSession {
     eventsPath: "/repo/.local/startup-cpu-2026-04-19-0930-abc123/events.ndjson",
     mainProfilePath: "/repo/.local/startup-cpu-2026-04-19-0930-abc123/main.cpuprofile",
     rendererProfilePath: "/repo/.local/startup-cpu-2026-04-19-0930-abc123/renderer.cpuprofile",
+    mainHeapSnapshotPath: "/repo/.local/startup-cpu-2026-04-19-0930-abc123/main.heapsnapshot",
+    rendererHeapSnapshotPath: "/repo/.local/startup-cpu-2026-04-19-0930-abc123/renderer.heapsnapshot",
     analysisPath: "/repo/.local/startup-cpu-2026-04-19-0930-abc123/analysis.json",
     summaryPath: "/repo/.local/startup-cpu-2026-04-19-0930-abc123/summary.md",
     appendEvent: vi.fn(async () => undefined),
     markProfileCaptured: vi.fn(async () => undefined),
     markAnalysisGenerated: vi.fn(async () => undefined),
+    registerHeapSnapshot: vi.fn(async () => undefined),
     complete: vi.fn(async () => undefined),
   };
 }
@@ -57,6 +61,7 @@ function createWindowTarget() {
           handlers.push(handler);
           webContentsHandlers.set(event, handlers);
         }),
+        takeHeapSnapshot: vi.fn(async () => undefined),
       },
     },
     emitWindow(event: string, ...args: unknown[]) {
@@ -144,9 +149,10 @@ describe("StartupCpuProfiler", () => {
       source: "main",
       capturedAt: "2026-04-19T13:30:00.000Z",
       type: "controller-started",
-      detail: {
+      detail: expect.objectContaining({
+        elapsedMs: expect.any(Number),
         sessionDirectory: session.directoryPath,
-      },
+      }),
     });
     expect(session.appendEvent).toHaveBeenCalledWith({
       source: "main",
@@ -157,6 +163,47 @@ describe("StartupCpuProfiler", () => {
         status: "completed",
       },
     });
+  });
+
+  it("captures startup heap snapshots when enabled", async () => {
+    const session = createSession();
+    const { window, emitWebContents } = createWindowTarget();
+    const writeMainHeapSnapshot = vi.fn(() => session.mainHeapSnapshotPath);
+
+    const { StartupCpuProfiler } = await import("../diagnostics/startup-cpu-profiler");
+    const profiler = new StartupCpuProfiler({
+      config: {
+        ...createEnabledConfig(),
+        captureHeapSnapshots: true,
+      },
+      now: () => new Date("2026-04-19T13:30:00.000Z"),
+      createSession: vi.fn(async () => ({
+        ok: true as const,
+        session,
+      })),
+      createMainProfiler: vi.fn(() => ({
+        start: vi.fn(async () => true),
+        stop: vi.fn(async () => true),
+      })),
+      createRendererProfiler: vi.fn(() => ({
+        start: vi.fn(async () => true),
+        stop: vi.fn(async () => true),
+      })),
+      analyzeSession: vi.fn(async () => ({ ok: true })),
+      writeMainHeapSnapshot,
+    });
+
+    await profiler.start();
+    profiler.attachWindow(window as never);
+    emitWebContents("did-finish-load");
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(writeMainHeapSnapshot).toHaveBeenCalledWith(session.mainHeapSnapshotPath);
+    expect(window.webContents.takeHeapSnapshot).toHaveBeenCalledWith(
+      session.rendererHeapSnapshotPath,
+    );
+    expect(session.registerHeapSnapshot).toHaveBeenCalledWith("main.heapsnapshot");
+    expect(session.registerHeapSnapshot).toHaveBeenCalledWith("renderer.heapsnapshot");
   });
 
   it("quits the app after capture when requested by profiling config", async () => {

--- a/apps/desktop/src/main/app-menu-bridge.ts
+++ b/apps/desktop/src/main/app-menu-bridge.ts
@@ -18,6 +18,7 @@ import {
   APP_MENU_POPUP_CHANNEL,
 } from "../shared/ipc";
 import type { AppMenuTopLevel } from "../shared/app-menu";
+import { timeStartupProfileOperation } from "./diagnostics/startup-profile-events";
 
 /**
  * Top-level entries of the current application menu, for the renderer's custom
@@ -52,7 +53,12 @@ export function wireAppMenuBridge(): void {
   if (wired) return;
   wired = true;
 
-  ipcMain.handle(APP_MENU_MODEL_CHANNEL, () => appMenuTopLevel());
+  ipcMain.handle(APP_MENU_MODEL_CHANNEL, async () =>
+    await timeStartupProfileOperation({
+      type: "ipc-main:getAppMenuModel",
+      operation: async () => appMenuTopLevel(),
+    }),
+  );
 
   ipcMain.on(APP_MENU_POPUP_CHANNEL, (event, payload: unknown) => {
     if (payload === null || typeof payload !== "object") return;

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -3211,10 +3211,13 @@ export class DesktopBackendRegistry {
       options?.codexClient ??
       replayClients?.codexClient ??
       new CodexAppServerClient({
-        args: buildCodexClientArgs(codexEnv),
+        args: settingsService ? undefined : buildCodexClientArgs(codexEnv),
         command: codexCommand,
         connectionObserver: codexObserver,
         env: codexEnv,
+        resolveArgs: settingsService
+          ? async (env) => buildCodexClientArgs(env)
+          : undefined,
         resolveEnv: settingsService
           ? async () => await settingsService.resolveCodexSpawnEnvAsync()
           : undefined,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -3215,6 +3215,9 @@ export class DesktopBackendRegistry {
         command: codexCommand,
         connectionObserver: codexObserver,
         env: codexEnv,
+        resolveEnv: settingsService
+          ? async () => await settingsService.resolveCodexSpawnEnvAsync()
+          : undefined,
         clientVersion,
         // Fire the gate at the client level too, not just the
         // listThreads layer. Without this, `describeCodexBackend`

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -106,6 +106,7 @@ type CodexClientOptions = {
   command?: string;
   args?: string[];
   env?: NodeJS.ProcessEnv;
+  resolveArgs?: (env: NodeJS.ProcessEnv) => Promise<string[]> | string[];
   resolveEnv?: () => Promise<NodeJS.ProcessEnv>;
   directoryResolver?: (
     projectKey?: string
@@ -4965,6 +4966,7 @@ export class CodexAppServerClient {
         command: options.command?.trim() || "codex",
         args: options.args ?? [],
         env: options.env,
+        resolveArgs: options.resolveArgs,
         resolveEnv: options.resolveEnv,
       }),
       options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -106,6 +106,7 @@ type CodexClientOptions = {
   command?: string;
   args?: string[];
   env?: NodeJS.ProcessEnv;
+  resolveEnv?: () => Promise<NodeJS.ProcessEnv>;
   directoryResolver?: (
     projectKey?: string
   ) => Promise<LinkedDirectorySummary[]>;
@@ -4963,7 +4964,8 @@ export class CodexAppServerClient {
       new StdioJsonRpcTransport({
         command: options.command?.trim() || "codex",
         args: options.args ?? [],
-        env: options.env
+        env: options.env,
+        resolveEnv: options.resolveEnv,
       }),
       options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
       options.connectionObserver,

--- a/apps/desktop/src/main/codex-app-server/stdio-transport.ts
+++ b/apps/desktop/src/main/codex-app-server/stdio-transport.ts
@@ -25,6 +25,7 @@ export type StdioJsonRpcTransportOptions = {
   command: string;
   args?: string[];
   env?: NodeJS.ProcessEnv;
+  resolveArgs?: (env: NodeJS.ProcessEnv) => Promise<string[]> | string[];
   resolveEnv?: () => Promise<NodeJS.ProcessEnv>;
 };
 
@@ -53,6 +54,9 @@ export class StdioJsonRpcTransport implements JsonRpcTransport {
     const env = this.options.resolveEnv
       ? await this.options.resolveEnv()
       : this.options.env ?? process.env;
+    const args = this.options.resolveArgs
+      ? await this.options.resolveArgs(env)
+      : this.options.args ?? [];
     const command = await resolveCodexCommand({
       command: this.options.command,
       env,
@@ -63,7 +67,7 @@ export class StdioJsonRpcTransport implements JsonRpcTransport {
       version: command.version ?? null,
     });
 
-    const child = spawn(command.command, ["app-server", ...(this.options.args ?? [])], {
+    const child = spawn(command.command, ["app-server", ...args], {
       stdio: ["pipe", "pipe", "pipe"],
       env,
     });

--- a/apps/desktop/src/main/codex-app-server/stdio-transport.ts
+++ b/apps/desktop/src/main/codex-app-server/stdio-transport.ts
@@ -25,6 +25,7 @@ export type StdioJsonRpcTransportOptions = {
   command: string;
   args?: string[];
   env?: NodeJS.ProcessEnv;
+  resolveEnv?: () => Promise<NodeJS.ProcessEnv>;
 };
 
 export { compareCodexCliVersions };
@@ -49,7 +50,9 @@ export class StdioJsonRpcTransport implements JsonRpcTransport {
       return;
     }
 
-    const env = this.options.env ?? process.env;
+    const env = this.options.resolveEnv
+      ? await this.options.resolveEnv()
+      : this.options.env ?? process.env;
     const command = await resolveCodexCommand({
       command: this.options.command,
       env,

--- a/apps/desktop/src/main/diagnostics/startup-cpu-analysis.ts
+++ b/apps/desktop/src/main/diagnostics/startup-cpu-analysis.ts
@@ -45,6 +45,13 @@ export type StartupCpuProcessAnalysis = {
   topSourcesByTotal: RankedSource[];
 };
 
+export type StartupProfileTimelineEvent = {
+  elapsedMs?: number;
+  source: "main" | "renderer";
+  type: string;
+  detail?: Record<string, unknown>;
+};
+
 export type StartupCpuSessionAnalysis = {
   generatedAt: string;
   sessionDirectoryName: string;
@@ -52,6 +59,7 @@ export type StartupCpuSessionAnalysis = {
   analysisPath: string;
   summaryPath: string;
   results: StartupCpuProcessAnalysis[];
+  timeline: StartupProfileTimelineEvent[];
 };
 
 export function analyzeCpuProfile(params: {
@@ -163,6 +171,7 @@ function normalizeLocationNumber(value: number | undefined): number | undefined 
 export function renderStartupCpuAnalysisSummary(params: {
   sessionDirectoryName: string;
   results: StartupCpuProcessAnalysis[];
+  timeline?: StartupProfileTimelineEvent[];
 }): string {
   const lines = [
     "# Startup CPU Analysis",
@@ -170,6 +179,25 @@ export function renderStartupCpuAnalysisSummary(params: {
     `Session: \`${params.sessionDirectoryName}\``,
     "",
   ];
+
+  if (params.timeline?.length) {
+    lines.push("## Startup Timeline");
+    lines.push("");
+    for (const event of params.timeline.slice(0, 80)) {
+      const elapsed =
+        event.elapsedMs === undefined
+          ? "unknown"
+          : `${event.elapsedMs.toFixed(1)} ms`;
+      const detail = formatTimelineDetail(event.detail);
+      lines.push(
+        `- ${elapsed} [${event.source}] \`${event.type}\`${detail ? ` — ${detail}` : ""}`,
+      );
+    }
+    if (params.timeline.length > 80) {
+      lines.push(`- … ${params.timeline.length - 80} more events in analysis.json`);
+    }
+    lines.push("");
+  }
 
   for (const result of params.results) {
     lines.push(`## ${formatProcessHeading(result.process)}`);
@@ -209,6 +237,9 @@ export async function analyzeStartupCpuProfileSession(options: {
 }): Promise<StartupCpuSessionAnalysis> {
   const desktopRoot = path.join(options.repoRoot, "apps/desktop");
   const results: StartupCpuProcessAnalysis[] = [];
+  const timeline = await readStartupProfileTimeline(
+    path.join(options.sessionDirectoryPath, "events.ndjson"),
+  );
 
   const mainProfile = await readOptionalCpuProfile(
     path.join(options.sessionDirectoryPath, "main.cpuprofile"),
@@ -249,6 +280,7 @@ export async function analyzeStartupCpuProfileSession(options: {
     analysisPath: options.analysisPath,
     summaryPath: options.summaryPath,
     results,
+    timeline,
   };
 
   await fs.writeFile(options.analysisPath, `${JSON.stringify(analysis, null, 2)}\n`, "utf8");
@@ -257,11 +289,95 @@ export async function analyzeStartupCpuProfileSession(options: {
     renderStartupCpuAnalysisSummary({
       sessionDirectoryName: analysis.sessionDirectoryName,
       results: analysis.results,
+      timeline: analysis.timeline,
     }),
     "utf8",
   );
 
   return analysis;
+}
+
+function formatTimelineDetail(detail: Record<string, unknown> | undefined): string {
+  if (!detail) {
+    return "";
+  }
+
+  const entries = Object.entries(detail).filter(([key]) => key !== "elapsedMs");
+  if (entries.length === 0) {
+    return "";
+  }
+
+  return entries
+    .slice(0, 6)
+    .map(([key, value]) => `${key}=${formatTimelineValue(value)}`)
+    .join(", ");
+}
+
+function formatTimelineValue(value: unknown): string {
+  if (typeof value === "string") {
+    return JSON.stringify(value.length > 80 ? `${value.slice(0, 77)}...` : value);
+  }
+  if (typeof value === "number" || typeof value === "boolean" || value === null) {
+    return String(value);
+  }
+  if (value === undefined) {
+    return "undefined";
+  }
+
+  return JSON.stringify(value);
+}
+
+async function readStartupProfileTimeline(
+  filePath: string,
+): Promise<StartupProfileTimelineEvent[]> {
+  let content: string;
+  try {
+    content = await fs.readFile(filePath, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+
+  return content
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as {
+      detail?: Record<string, unknown>;
+      source?: unknown;
+      type?: unknown;
+    })
+    .filter(
+      (event): event is {
+        detail?: Record<string, unknown>;
+        source: "main" | "renderer";
+        type: string;
+      } =>
+        (event.source === "main" || event.source === "renderer") &&
+        typeof event.type === "string",
+    )
+    .map((event) => ({
+      source: event.source,
+      type: event.type,
+      ...(event.detail ? { detail: event.detail } : {}),
+      ...(typeof event.detail?.elapsedMs === "number"
+        ? { elapsedMs: event.detail.elapsedMs }
+        : {}),
+    }))
+    .sort((left, right) => {
+      if (left.elapsedMs === undefined && right.elapsedMs === undefined) {
+        return 0;
+      }
+      if (left.elapsedMs === undefined) {
+        return 1;
+      }
+      if (right.elapsedMs === undefined) {
+        return -1;
+      }
+      return left.elapsedMs - right.elapsedMs;
+    });
 }
 
 function formatProcessHeading(process: CpuProfileProcess): string {

--- a/apps/desktop/src/main/diagnostics/startup-cpu-profile-config.ts
+++ b/apps/desktop/src/main/diagnostics/startup-cpu-profile-config.ts
@@ -12,6 +12,7 @@ export type StartupCpuProfileConfig =
       postLoadDurationMs: number;
       hardTimeoutMs: number;
       quitOnComplete: boolean;
+      captureHeapSnapshots: boolean;
     };
 
 function isEnabled(value: string | undefined): boolean {
@@ -40,7 +41,10 @@ export function resolveStartupCpuProfileConfig(options?: {
   repoRoot?: string;
 }): StartupCpuProfileConfig {
   const env = options?.env ?? process.env;
-  if (!isEnabled(env.PWRAGENT_STARTUP_CPU_PROFILING)) {
+  if (
+    !isEnabled(env.PWRAGENT_STARTUP_PROFILE) &&
+    !isEnabled(env.PWRAGENT_STARTUP_CPU_PROFILING)
+  ) {
     return { enabled: false };
   }
 
@@ -51,7 +55,11 @@ export function resolveStartupCpuProfileConfig(options?: {
   return {
     enabled: true,
     repoRoot,
-    outputRoot: path.join(repoRoot, ".local"),
+    outputRoot: path.resolve(
+      env.PWRAGENT_STARTUP_PROFILE_DIR
+      ?? env.PWRAGENT_STARTUP_CPU_PROFILE_DIR
+      ?? path.join(repoRoot, ".local"),
+    ),
     postLoadDurationMs: parsePositiveInteger(
       env.PWRAGENT_STARTUP_CPU_PROFILE_POST_LOAD_MS,
       DEFAULT_POST_LOAD_DURATION_MS,
@@ -61,5 +69,6 @@ export function resolveStartupCpuProfileConfig(options?: {
       DEFAULT_HARD_TIMEOUT_MS,
     ),
     quitOnComplete: isEnabled(env.PWRAGENT_STARTUP_CPU_PROFILE_QUIT_ON_COMPLETE),
+    captureHeapSnapshots: isEnabled(env.PWRAGENT_STARTUP_PROFILE_HEAP_SNAPSHOTS),
   };
 }

--- a/apps/desktop/src/main/diagnostics/startup-cpu-profile-session.ts
+++ b/apps/desktop/src/main/diagnostics/startup-cpu-profile-session.ts
@@ -35,13 +35,18 @@ type StartupCpuProfileManifest = {
   analysis: {
     jsonFilename: string;
     summaryFilename: string;
-    generatedAt: string | null;
-  };
-  config: {
-    postLoadDurationMs: number;
-    hardTimeoutMs: number;
-    quitOnComplete: boolean;
-  };
+      generatedAt: string | null;
+    };
+    heapSnapshots: {
+      enabled: boolean;
+      files: string[];
+    };
+    config: {
+      postLoadDurationMs: number;
+      hardTimeoutMs: number;
+      quitOnComplete: boolean;
+      captureHeapSnapshots: boolean;
+    };
   versions: StartupCpuProfileVersions;
 };
 
@@ -53,6 +58,8 @@ export type StartupCpuProfileSession = {
   eventsPath: string;
   mainProfilePath: string;
   rendererProfilePath: string;
+  mainHeapSnapshotPath: string;
+  rendererHeapSnapshotPath: string;
   analysisPath: string;
   summaryPath: string;
   appendEvent: (event: StartupCpuProfileSessionEvent) => Promise<void>;
@@ -61,6 +68,7 @@ export type StartupCpuProfileSession = {
     capturedAt: string,
   ) => Promise<void>;
   markAnalysisGenerated: (generatedAt: string) => Promise<void>;
+  registerHeapSnapshot: (filename: string) => Promise<void>;
   complete: (params: {
     status: "completed" | "partial" | "failed";
     completedAt: string;
@@ -109,6 +117,8 @@ export async function createStartupCpuProfileSession(options: {
   const eventsPath = path.join(directoryPath, "events.ndjson");
   const mainProfilePath = path.join(directoryPath, "main.cpuprofile");
   const rendererProfilePath = path.join(directoryPath, "renderer.cpuprofile");
+  const mainHeapSnapshotPath = path.join(directoryPath, "main.heapsnapshot");
+  const rendererHeapSnapshotPath = path.join(directoryPath, "renderer.heapsnapshot");
   const analysisPath = path.join(directoryPath, "analysis.json");
   const summaryPath = path.join(directoryPath, "summary.md");
 
@@ -132,10 +142,15 @@ export async function createStartupCpuProfileSession(options: {
       summaryFilename: path.basename(summaryPath),
       generatedAt: null,
     },
+    heapSnapshots: {
+      enabled: options.config.captureHeapSnapshots,
+      files: [],
+    },
     config: {
       postLoadDurationMs: options.config.postLoadDurationMs,
       hardTimeoutMs: options.config.hardTimeoutMs,
       quitOnComplete: options.config.quitOnComplete,
+      captureHeapSnapshots: options.config.captureHeapSnapshots,
     },
     versions: options.versions,
   };
@@ -176,6 +191,8 @@ export async function createStartupCpuProfileSession(options: {
       eventsPath,
       mainProfilePath,
       rendererProfilePath,
+      mainHeapSnapshotPath,
+      rendererHeapSnapshotPath,
       analysisPath,
       summaryPath,
       appendEvent: async (event) => {
@@ -193,6 +210,13 @@ export async function createStartupCpuProfileSession(options: {
       markAnalysisGenerated: async (generatedAt) => {
         await updateManifest((current) => {
           current.analysis.generatedAt = generatedAt;
+        });
+      },
+      registerHeapSnapshot: async (filename) => {
+        await updateManifest((current) => {
+          if (!current.heapSnapshots.files.includes(filename)) {
+            current.heapSnapshots.files.push(filename);
+          }
         });
       },
       complete: async ({ status, completedAt: completedAtValue }) => {

--- a/apps/desktop/src/main/diagnostics/startup-cpu-profiler.ts
+++ b/apps/desktop/src/main/diagnostics/startup-cpu-profiler.ts
@@ -1,5 +1,6 @@
 import { app, type BrowserWindow } from "electron";
 import path from "node:path";
+import { writeHeapSnapshot } from "node:v8";
 import { getMainLogger } from "../log";
 import { analyzeStartupCpuProfileSession } from "./startup-cpu-analysis";
 import {
@@ -17,6 +18,11 @@ import {
   resolveStartupCpuProfileConfig,
   type StartupCpuProfileConfig,
 } from "./startup-cpu-profile-config";
+import {
+  flushStartupProfileEvents,
+  installStartupProfileEventRecorder,
+  recordStartupProfileEvent,
+} from "./startup-profile-events";
 
 type Logger = Pick<Console, "info" | "warn" | "error">;
 
@@ -31,6 +37,10 @@ type RendererProfiler = {
 };
 
 type WindowTarget = Pick<BrowserWindow, "on" | "webContents">;
+type StartupHeapSnapshotTarget = {
+  isDestroyed?: () => boolean;
+  takeHeapSnapshot?: (filePath: string) => Promise<void>;
+};
 
 type EnabledStartupCpuProfileConfig = Extract<StartupCpuProfileConfig, { enabled: true }>;
 
@@ -80,6 +90,7 @@ export class StartupCpuProfiler {
   private readonly createMainProfiler: CreateMainProfiler;
   private readonly createRendererProfiler: CreateRendererProfiler;
   private readonly analyzeSession: AnalyzeStartupCpuProfileSession;
+  private readonly writeMainHeapSnapshot: (filePath: string) => string;
 
   private session?: StartupCpuProfileSession;
   private mainProfiler?: MainProfiler;
@@ -87,6 +98,8 @@ export class StartupCpuProfiler {
   private attachedWindow = false;
   private postLoadStopTimer?: ReturnType<typeof setTimeout>;
   private hardTimeoutTimer?: ReturnType<typeof setTimeout>;
+  private disposeEventRecorder?: () => void;
+  private rendererHeapSnapshotTarget?: StartupHeapSnapshotTarget;
   private stopped = false;
 
   constructor(options?: {
@@ -97,6 +110,7 @@ export class StartupCpuProfiler {
     createMainProfiler?: CreateMainProfiler;
     createRendererProfiler?: CreateRendererProfiler;
     analyzeSession?: AnalyzeStartupCpuProfileSession;
+    writeMainHeapSnapshot?: (filePath: string) => string;
   }) {
     this.config =
       options?.config
@@ -122,6 +136,7 @@ export class StartupCpuProfiler {
     this.analyzeSession =
       options?.analyzeSession
       ?? analyzeStartupCpuProfileSession;
+    this.writeMainHeapSnapshot = options?.writeMainHeapSnapshot ?? writeHeapSnapshot;
   }
 
   async start(): Promise<void> {
@@ -147,10 +162,12 @@ export class StartupCpuProfiler {
     }
 
     this.session = created.session;
+    this.disposeEventRecorder = installStartupProfileEventRecorder({
+      session: created.session,
+      now: this.now,
+    });
     this.mainProfiler = this.createMainProfiler(created.session);
-    await created.session.appendEvent({
-      source: "main",
-      capturedAt: this.now().toISOString(),
+    recordStartupProfileEvent({
       type: "controller-started",
       detail: {
         sessionDirectory: created.session.directoryPath,
@@ -173,10 +190,17 @@ export class StartupCpuProfiler {
     }
 
     this.attachedWindow = true;
+    this.rendererHeapSnapshotTarget = window.webContents as StartupHeapSnapshotTarget;
+    recordStartupProfileEvent({
+      type: "window-attached",
+    });
     this.rendererProfiler = this.createRendererProfiler(this.session, window.webContents);
     void this.rendererProfiler.start();
 
     window.webContents.on("did-finish-load", () => {
+      recordStartupProfileEvent({
+        type: "window-did-finish-load",
+      });
       if (this.stopped) {
         return;
       }
@@ -195,14 +219,23 @@ export class StartupCpuProfiler {
     });
 
     window.webContents.on("did-fail-load", () => {
+      recordStartupProfileEvent({
+        type: "window-did-fail-load",
+      });
       void this.stop("did-fail-load");
     });
 
     window.webContents.on("render-process-gone", () => {
+      recordStartupProfileEvent({
+        type: "window-render-process-gone",
+      });
       void this.stop("render-process-gone");
     });
 
     window.on("closed", () => {
+      recordStartupProfileEvent({
+        type: "window-closed",
+      });
       void this.stop("window-closed");
     });
   }
@@ -229,6 +262,8 @@ export class StartupCpuProfiler {
       : mainCaptured || rendererCaptured
         ? "partial"
         : "failed";
+    await this.captureHeapSnapshots();
+    await flushStartupProfileEvents();
 
     try {
       if (mainCaptured || rendererCaptured) {
@@ -265,6 +300,8 @@ export class StartupCpuProfiler {
         status,
       },
     });
+    this.disposeEventRecorder?.();
+    this.disposeEventRecorder = undefined;
 
     if (this.config.quitOnComplete) {
       app.quit();
@@ -285,6 +322,108 @@ export class StartupCpuProfiler {
     if (this.hardTimeoutTimer) {
       clearTimeout(this.hardTimeoutTimer);
       this.hardTimeoutTimer = undefined;
+    }
+  }
+
+  private async captureHeapSnapshots(): Promise<void> {
+    if (!this.config.enabled || !this.config.captureHeapSnapshots || !this.session) {
+      return;
+    }
+
+    const results = await Promise.allSettled([
+      this.captureMainHeapSnapshot(),
+      this.captureRendererHeapSnapshot(),
+    ]);
+
+    for (const result of results) {
+      if (result.status === "rejected") {
+        this.logger.error("startup heap snapshot failed", result.reason);
+      }
+    }
+  }
+
+  private async captureMainHeapSnapshot(): Promise<void> {
+    if (!this.session) {
+      return;
+    }
+
+    const filename = path.basename(this.session.mainHeapSnapshotPath);
+    try {
+      recordStartupProfileEvent({
+        type: "heap-snapshot:start",
+        detail: {
+          filename,
+          process: "main",
+        },
+      });
+      this.writeMainHeapSnapshot(this.session.mainHeapSnapshotPath);
+      await this.session.registerHeapSnapshot(filename);
+      recordStartupProfileEvent({
+        type: "heap-snapshot:end",
+        detail: {
+          filename,
+          ok: true,
+          process: "main",
+        },
+      });
+    } catch (error) {
+      recordStartupProfileEvent({
+        type: "heap-snapshot:end",
+        detail: {
+          error: serializeError(error),
+          filename,
+          ok: false,
+          process: "main",
+        },
+      });
+      throw error;
+    }
+  }
+
+  private async captureRendererHeapSnapshot(): Promise<void> {
+    if (!this.session || !this.rendererHeapSnapshotTarget?.takeHeapSnapshot) {
+      return;
+    }
+
+    if (this.rendererHeapSnapshotTarget.isDestroyed?.()) {
+      return;
+    }
+
+    const filename = path.basename(this.session.rendererHeapSnapshotPath);
+    try {
+      recordStartupProfileEvent({
+        source: "renderer",
+        type: "heap-snapshot:start",
+        detail: {
+          filename,
+          process: "renderer",
+        },
+      });
+      await this.rendererHeapSnapshotTarget.takeHeapSnapshot(
+        this.session.rendererHeapSnapshotPath,
+      );
+      await this.session.registerHeapSnapshot(filename);
+      recordStartupProfileEvent({
+        source: "renderer",
+        type: "heap-snapshot:end",
+        detail: {
+          filename,
+          ok: true,
+          process: "renderer",
+        },
+      });
+    } catch (error) {
+      recordStartupProfileEvent({
+        source: "renderer",
+        type: "heap-snapshot:end",
+        detail: {
+          error: serializeError(error),
+          filename,
+          ok: false,
+          process: "renderer",
+        },
+      });
+      throw error;
     }
   }
 }

--- a/apps/desktop/src/main/diagnostics/startup-profile-events.ts
+++ b/apps/desktop/src/main/diagnostics/startup-profile-events.ts
@@ -1,0 +1,139 @@
+import { performance } from "node:perf_hooks";
+import type {
+  StartupCpuProfileSession,
+  StartupCpuProfileSessionEvent,
+} from "./startup-cpu-profile-session";
+
+export type StartupProfileEventSource = StartupCpuProfileSessionEvent["source"];
+
+type StartupProfileEventRecorder = {
+  dispose: () => void;
+  flush: () => Promise<void>;
+  record: (
+    source: StartupProfileEventSource,
+    type: string,
+    detail?: Record<string, unknown>,
+  ) => void;
+};
+
+let activeRecorder: StartupProfileEventRecorder | undefined;
+
+function serializeError(error: unknown): Record<string, unknown> {
+  if (error instanceof Error) {
+    return {
+      message: error.message,
+      name: error.name,
+    };
+  }
+
+  return {
+    message: String(error),
+  };
+}
+
+export function installStartupProfileEventRecorder(options: {
+  now?: () => Date;
+  session: StartupCpuProfileSession;
+  startTimeMs?: number;
+}): () => void {
+  const now = options.now ?? (() => new Date());
+  const startTimeMs = options.startTimeMs ?? performance.now();
+  let appendQueue = Promise.resolve();
+  let disposed = false;
+
+  const recorder: StartupProfileEventRecorder = {
+    dispose: () => {
+      disposed = true;
+      if (activeRecorder === recorder) {
+        activeRecorder = undefined;
+      }
+    },
+    flush: async () => {
+      await appendQueue;
+    },
+    record: (source, type, detail) => {
+      if (disposed) {
+        return;
+      }
+
+      const elapsedMs = Math.max(0, performance.now() - startTimeMs);
+      appendQueue = appendQueue.then(
+        () =>
+          options.session.appendEvent({
+            source,
+            capturedAt: now().toISOString(),
+            type,
+            detail: {
+              elapsedMs: Number(elapsedMs.toFixed(3)),
+              ...(detail ?? {}),
+            },
+          }),
+        () =>
+          options.session.appendEvent({
+            source,
+            capturedAt: now().toISOString(),
+            type,
+            detail: {
+              elapsedMs: Number(elapsedMs.toFixed(3)),
+              ...(detail ?? {}),
+            },
+          }),
+      );
+      void appendQueue;
+    },
+  };
+  activeRecorder = recorder;
+
+  return () => {
+    recorder.dispose();
+  };
+}
+
+export function isStartupProfileRecordingActive(): boolean {
+  return activeRecorder !== undefined;
+}
+
+export async function flushStartupProfileEvents(): Promise<void> {
+  await activeRecorder?.flush();
+}
+
+export function recordStartupProfileEvent(params: {
+  detail?: Record<string, unknown>;
+  source?: StartupProfileEventSource;
+  type: string;
+}): void {
+  activeRecorder?.record(params.source ?? "main", params.type, params.detail);
+}
+
+export async function timeStartupProfileOperation<T>(params: {
+  detail?: Record<string, unknown>;
+  operation: () => Promise<T>;
+  source?: StartupProfileEventSource;
+  type: string;
+}): Promise<T> {
+  if (!activeRecorder) {
+    return await params.operation();
+  }
+
+  const source = params.source ?? "main";
+  const startedAt = performance.now();
+  activeRecorder.record(source, `${params.type}:start`, params.detail);
+
+  try {
+    const result = await params.operation();
+    activeRecorder.record(source, `${params.type}:end`, {
+      ...(params.detail ?? {}),
+      durationMs: Number((performance.now() - startedAt).toFixed(3)),
+      ok: true,
+    });
+    return result;
+  } catch (error) {
+    activeRecorder.record(source, `${params.type}:end`, {
+      ...(params.detail ?? {}),
+      durationMs: Number((performance.now() - startedAt).toFixed(3)),
+      error: serializeError(error),
+      ok: false,
+    });
+    throw error;
+  }
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -77,6 +77,7 @@ import {
   resolveMainLogProfileName,
 } from "./log";
 import { StartupCpuProfiler } from "./diagnostics/startup-cpu-profiler";
+import { recordStartupProfileEvent } from "./diagnostics/startup-profile-events";
 import {
   disposeDesktopMessagingRuntime,
   getDesktopMessagingRuntime,
@@ -178,6 +179,9 @@ function logBootDecision(decision: ProfileBootDecision): void {
 function prewarmInitialThreadList(): void {
   if (getDesktopSettingsService().isCodexBootstrapDeferred()) {
     mainLog.info("startup thread list prewarm deferred until onboarding completes");
+    recordStartupProfileEvent({
+      type: "startup-thread-list-prewarm:deferred",
+    });
     return;
   }
   const startedAt = Date.now();
@@ -186,6 +190,13 @@ function prewarmInitialThreadList(): void {
       callerReason: "startup-prewarm",
     })
     .then((threads) => {
+      recordStartupProfileEvent({
+        type: "startup-thread-list-prewarm:completed",
+        detail: {
+          count: threads.length,
+          durationMs: Date.now() - startedAt,
+        },
+      });
       if (!isDevelopment) {
         return;
       }
@@ -195,6 +206,13 @@ function prewarmInitialThreadList(): void {
       });
     })
     .catch((error) => {
+      recordStartupProfileEvent({
+        type: "startup-thread-list-prewarm:failed",
+        detail: {
+          durationMs: Date.now() - startedAt,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      });
       if (!isDevelopment) {
         return;
       }
@@ -514,6 +532,7 @@ export function bootstrapApp(): void {
     const startupCpuProfiler = new StartupCpuProfiler();
     startupCpuProfilerForNewWindows = startupCpuProfiler;
     await startupCpuProfiler.start();
+    recordStartupProfileEvent({ type: "app-when-ready" });
     installDevelopmentDockIcon();
     // Boot decision — resolves which profile (if any) this Electron
     // instance should open into. When the decision is `open` we run
@@ -555,6 +574,12 @@ export function bootstrapApp(): void {
     if (bootMode === "active-profile") {
       cleanupBootstrapProfile();
     }
+    recordStartupProfileEvent({
+      type: "boot-mode-resolved",
+      detail: {
+        bootMode,
+      },
+    });
     initializeAppState(bootMode);
     // Skip the focus-request watcher in bootstrap mode. The watcher
     // mkdirs `<root>/profiles/<active>/state/focus-requests/` to
@@ -661,12 +686,16 @@ export function bootstrapApp(): void {
     // current snapshot. When messaging is disabled the runtime singleton
     // still exists (default config); status returns []  / never emits.
     registerMessagingStatusIpcHandlers();
+    recordStartupProfileEvent({ type: "main-window-create:start" });
     quitAppOnMainWindowClose(
       createMainWindow({
         startupCpuProfiler,
       }),
     );
+    recordStartupProfileEvent({ type: "main-window-create:end" });
+    recordStartupProfileEvent({ type: "startup-thread-list-prewarm:start" });
     prewarmInitialThreadList();
+    recordStartupProfileEvent({ type: "startup-thread-list-prewarm:scheduled" });
 
     // Wire up auto-update *after* the window is created so a slow update
     // check does not delay first paint. Skips automatically in dev.

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -48,6 +48,7 @@ import {
   type UpdateThreadExpectedBranchResponse,
 } from "@pwragent/shared";
 import { getDesktopBackendRegistry } from "../app-server/backend-registry";
+import { timeStartupProfileOperation } from "../diagnostics/startup-profile-events";
 import {
   AGENT_CANCEL_THREAD_EXECUTION_MODE_QUEUE_CHANNEL,
   AGENT_EVENT_CHANNEL,
@@ -283,7 +284,13 @@ export function registerAgentIpcHandlers(): void {
       _event,
       request?: ListBackendsRequest
     ): Promise<ListBackendsResponse> => {
-      return await registry.listBackends(request);
+      return await timeStartupProfileOperation({
+        type: "ipc-main:listBackends",
+        detail: {
+          hasRequest: request !== undefined,
+        },
+        operation: async () => await registry.listBackends(request),
+      });
     },
   );
 

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -158,6 +158,7 @@ import { ThreadMigrationService } from "../app-server/thread-migration-service";
 import { ProviderTranscriptThreadSearchAdapter } from "../thread-search/thread-search-provider-adapters";
 import { ThreadSearchService } from "../thread-search/thread-search-service";
 import { ThreadSearchStore } from "../thread-search/thread-search-store";
+import { timeStartupProfileOperation } from "../diagnostics/startup-profile-events";
 
 const isDevelopment = process.env.NODE_ENV !== "production";
 const THREAD_PR_REFRESH_MIN_INTERVAL_MS = 60_000;
@@ -2662,7 +2663,14 @@ export function registerAppServerIpcHandlers(): void {
       _event,
       request?: AppServerListThreadsRequest
     ): Promise<AppServerListThreadsResponse> => {
-      return await appServerService.listThreads(request);
+      return await timeStartupProfileOperation({
+        type: "ipc-main:listThreads",
+        detail: {
+          archived: Boolean(request?.archived),
+          backend: request?.backend ?? null,
+        },
+        operation: async () => await appServerService.listThreads(request),
+      });
     }
   );
   ipcMain.removeHandler(THREAD_SEARCH_CHANNEL);
@@ -2682,7 +2690,14 @@ export function registerAppServerIpcHandlers(): void {
       _event,
       request: AppServerReadThreadRequest
     ): Promise<AppServerReadThreadResponse> => {
-      return await appServerService.readThread(request);
+      return await timeStartupProfileOperation({
+        type: "ipc-main:readThread",
+        detail: {
+          backend: request.backend,
+          threadId: request.threadId,
+        },
+        operation: async () => await appServerService.readThread(request),
+      });
     }
   );
   ipcMain.removeHandler(APP_SERVER_PERSIST_THREAD_USAGE_ACTIVITY_CHANNEL);
@@ -2809,7 +2824,13 @@ export function registerAppServerIpcHandlers(): void {
       _event,
       request?: GetNavigationSnapshotRequest,
     ): Promise<NavigationSnapshot> => {
-      return await appServerService.getNavigationSnapshot(request);
+      return await timeStartupProfileOperation({
+        type: "ipc-main:getNavigationSnapshot",
+        detail: {
+          forceRefresh: Boolean(request?.forceRefresh),
+        },
+        operation: async () => await appServerService.getNavigationSnapshot(request),
+      });
     },
   );
   ipcMain.removeHandler(NAVIGATION_SET_BROWSE_MODE_CHANNEL);
@@ -2929,7 +2950,17 @@ export function registerAppServerIpcHandlers(): void {
       _event,
       request: RefreshThreadPullRequestsRequest,
     ): Promise<RefreshThreadPullRequestsResponse> => {
-      return await appServerService.refreshThreadPullRequests(request);
+      return await timeStartupProfileOperation({
+        type: "ipc-main:refreshThreadPullRequests",
+        detail: {
+          backend: request.backend ?? null,
+          directoryPathCount: request.directoryPaths.length,
+          threadId: request.threadId,
+          trigger: request.trigger ?? null,
+        },
+        operation: async () =>
+          await appServerService.refreshThreadPullRequests(request),
+      });
     },
   );
   ipcMain.removeHandler(NAVIGATION_REFRESH_DIRECTORY_GIT_STATUSES_CHANNEL);
@@ -2939,7 +2970,15 @@ export function registerAppServerIpcHandlers(): void {
       _event,
       request: RefreshDirectoryGitStatusesRequest,
     ): Promise<RefreshDirectoryGitStatusesResponse> => {
-      return await appServerService.refreshDirectoryGitStatusesForKeys(request);
+      return await timeStartupProfileOperation({
+        type: "ipc-main:refreshDirectoryGitStatuses",
+        detail: {
+          force: Boolean(request.force),
+          keyCount: request.directoryKeys.length,
+        },
+        operation: async () =>
+          await appServerService.refreshDirectoryGitStatusesForKeys(request),
+      });
     },
   );
   ipcMain.removeHandler(NAVIGATION_RESOLVE_EDIT_COMMIT_STATES_CHANNEL);
@@ -2956,7 +2995,10 @@ export function registerAppServerIpcHandlers(): void {
   ipcMain.handle(
     NAVIGATION_GET_GH_STATUS_CHANNEL,
     async (_event, request: GetGhStatusRequest | undefined): Promise<GhStatus> => {
-      return await appServerService.getGhStatus(request ?? {});
+      return await timeStartupProfileOperation({
+        type: "ipc-main:getGhStatus",
+        operation: async () => await appServerService.getGhStatus(request ?? {}),
+      });
     },
   );
   ipcMain.removeHandler(NAVIGATION_ENSURE_DIRECTORY_LAUNCHPAD_CHANNEL);

--- a/apps/desktop/src/main/ipc/boot-info.ts
+++ b/apps/desktop/src/main/ipc/boot-info.ts
@@ -10,6 +10,7 @@ import {
   APP_WAIT_FOR_PROFILE_ALIVE_CHANNEL,
 } from "../../shared/ipc";
 import { getMainLogger } from "../log";
+import { timeStartupProfileOperation } from "../diagnostics/startup-profile-events";
 import {
   assertUnreachableProfileBootDecision,
   findLiveProfileRuntimeMarkers,
@@ -93,7 +94,11 @@ export function registerBootInfoIpcHandlers(options?: {
   ipcMain.removeHandler(APP_GET_BOOT_INFO_CHANNEL);
   ipcMain.handle(
     APP_GET_BOOT_INFO_CHANNEL,
-    async (): Promise<DesktopBootInfo> => buildBootInfo(),
+    async (): Promise<DesktopBootInfo> =>
+      await timeStartupProfileOperation({
+        type: "ipc-main:getBootInfo",
+        operation: async () => buildBootInfo(),
+      }),
   );
 
   // `quitApp` fires from the wizard's bootstrap-confirm "Quit

--- a/apps/desktop/src/main/ipc/messaging-status.ts
+++ b/apps/desktop/src/main/ipc/messaging-status.ts
@@ -27,6 +27,7 @@ import { loadDesktopMessagingConfigFromSettings } from "../messaging/messaging-c
 import { getDesktopMessagingActivityLog } from "../messaging/desktop-messaging-activity-log";
 import { getDesktopMessagingPairingStore } from "../messaging/desktop-messaging-pairing-store";
 import { getMainLogger } from "../log";
+import { timeStartupProfileOperation } from "../diagnostics/startup-profile-events";
 import { showMessagingActivityWindow } from "../messaging-activity-window";
 import { getDesktopSettingsService } from "../settings/desktop-settings-singleton";
 import { resolveRuntimeMessagingOverride } from "../runtime-flags";
@@ -310,7 +311,10 @@ export function registerMessagingStatusIpcHandlers(): void {
   ipcMain.handle(
     MESSAGING_GET_PLATFORM_STATUSES_CHANNEL,
     async (): Promise<MessagingPlatformStatus[]> => {
-      return runtime.getPlatformStatuses();
+      return await timeStartupProfileOperation({
+        type: "ipc-main:getMessagingPlatformStatuses",
+        operation: async () => runtime.getPlatformStatuses(),
+      });
     },
   );
 

--- a/apps/desktop/src/main/ipc/preload-log.ts
+++ b/apps/desktop/src/main/ipc/preload-log.ts
@@ -1,6 +1,13 @@
 import { ipcMain } from "electron";
-import { PRELOAD_LOG_CHANNEL } from "../../shared/ipc";
+import {
+  PRELOAD_LOG_CHANNEL,
+  STARTUP_PROFILE_EVENT_CHANNEL,
+} from "../../shared/ipc";
 import { getMainLogger } from "../log";
+import {
+  recordStartupProfileEvent,
+  type StartupProfileEventSource,
+} from "../diagnostics/startup-profile-events";
 
 type PreloadLogLevel = "error" | "info" | "warn";
 
@@ -10,10 +17,17 @@ type PreloadLogRequest = {
   message?: string;
 };
 
+type StartupProfileRendererEventRequest = {
+  detail?: Record<string, unknown>;
+  source?: StartupProfileEventSource;
+  type?: string;
+};
+
 const preloadLog = getMainLogger("pwragent:preload");
 
 export function registerPreloadLogIpcHandlers(): void {
   ipcMain.removeAllListeners(PRELOAD_LOG_CHANNEL);
+  ipcMain.removeAllListeners(STARTUP_PROFILE_EVENT_CHANNEL);
   ipcMain.on(
     PRELOAD_LOG_CHANNEL,
     (_event, request: PreloadLogRequest): void => {
@@ -29,8 +43,24 @@ export function registerPreloadLogIpcHandlers(): void {
       preloadLog[level](message, details);
     },
   );
+  ipcMain.on(
+    STARTUP_PROFILE_EVENT_CHANNEL,
+    (_event, request: StartupProfileRendererEventRequest): void => {
+      const type = request.type?.trim();
+      if (!type) {
+        return;
+      }
+
+      recordStartupProfileEvent({
+        source: request.source ?? "renderer",
+        type,
+        detail: request.detail,
+      });
+    },
+  );
 }
 
 export function disposePreloadLogIpcHandlers(): void {
   ipcMain.removeAllListeners(PRELOAD_LOG_CHANNEL);
+  ipcMain.removeAllListeners(STARTUP_PROFILE_EVENT_CHANNEL);
 }

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -77,6 +77,7 @@ import {
   resolveDefaultCodexHome,
 } from "@pwrdrvr/codex-discovery";
 import { getMainLogger } from "../log";
+import { timeStartupProfileOperation } from "../diagnostics/startup-profile-events";
 import { BUILT_IN_ACP_STRATEGIES, type AcpAgentStrategy } from "@pwrdrvr/agent-acp";
 import { AcpAgentStore } from "../acp/acp-agent-store";
 import { isBannedAcpRegistryId } from "../acp/acp-agent-allowlist";
@@ -872,11 +873,15 @@ export function registerSettingsIpcHandlers(
     async (
       _event,
       _request?: ReadDesktopSettingsRequest,
-    ): Promise<ReadDesktopSettingsResponse> => ({
-      snapshot: applyRuntimeMessagingSnapshot(
-        await getService(service).readSettings(),
-      ),
-    }),
+    ): Promise<ReadDesktopSettingsResponse> =>
+      await timeStartupProfileOperation({
+        type: "ipc-main:readSettings",
+        operation: async () => ({
+          snapshot: applyRuntimeMessagingSnapshot(
+            await getService(service).readSettings(),
+          ),
+        }),
+      }),
   );
 
   ipcMain.removeHandler(SETTINGS_WRITE_CONFIG_CHANNEL);

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -22,6 +22,7 @@ import type {
   DesktopWorktreeStorageLocation,
   MessagingToolUpdateMode,
 } from "@pwragent/shared";
+import { execFile } from "node:child_process";
 import {
   DESKTOP_APPEARANCE_DENSITY_DEFAULT,
   DESKTOP_APPEARANCE_THEME_DEFAULT,
@@ -137,6 +138,11 @@ import { getMainLogger } from "../log";
 // (passed below) where the in-tree copy hardcoded `getMainLogger`.
 import { mergeLoginShellEnvIntoEnv } from "@pwrdrvr/agent-transport";
 
+const LOGIN_SHELL_ENV_MARKER_START = "__PWRAGENT_LOGIN_SHELL_ENV_START__";
+const LOGIN_SHELL_ENV_MARKER_END = "__PWRAGENT_LOGIN_SHELL_ENV_END__";
+const LOGIN_SHELL_ENV_TIMEOUT_MS = 2_500;
+const LOGIN_SHELL_ENV_MAX_BUFFER = 1024 * 1024;
+
 // Codex home/profile paths come back from `@pwrdrvr/codex-discovery` via
 // `path.join`/`path.resolve`, which emit backslashes on Windows
 // (`C:\Users\…\.codex\profiles\work`). These strings are surfaced as
@@ -236,6 +242,88 @@ function clampInteger(value: number, maxValue: number): number {
   return Math.min(Math.max(value, 0), maxValue);
 }
 
+function defaultLoginShellCandidates(env: NodeJS.ProcessEnv): string[] {
+  return [
+    env.SHELL?.trim(),
+    "/bin/zsh",
+    "/bin/bash",
+    "/bin/sh",
+  ].filter((shell): shell is string => Boolean(shell));
+}
+
+function extractMarkedEnv(output: string): NodeJS.ProcessEnv | undefined {
+  const lines = output.split(/\r?\n/);
+  const startIndex = lines.indexOf(LOGIN_SHELL_ENV_MARKER_START);
+  const endIndex = lines.indexOf(LOGIN_SHELL_ENV_MARKER_END);
+  if (startIndex === -1 || endIndex === -1 || endIndex <= startIndex) {
+    return undefined;
+  }
+
+  const shellEnv: NodeJS.ProcessEnv = {};
+  for (const line of lines.slice(startIndex + 1, endIndex)) {
+    const equalsIndex = line.indexOf("=");
+    if (equalsIndex <= 0) {
+      continue;
+    }
+    shellEnv[line.slice(0, equalsIndex)] = line.slice(equalsIndex + 1);
+  }
+  return shellEnv;
+}
+
+async function resolveInteractiveLoginShellEnvAsync(
+  env: NodeJS.ProcessEnv,
+): Promise<NodeJS.ProcessEnv | undefined> {
+  if (process.platform === "win32") {
+    return undefined;
+  }
+
+  const command = [
+    `command printf '${LOGIN_SHELL_ENV_MARKER_START}\\n'`,
+    "command env",
+    `command printf '${LOGIN_SHELL_ENV_MARKER_END}\\n'`,
+  ].join("; ");
+  const failures: Array<{ error: string; shell: string }> = [];
+
+  for (const shell of defaultLoginShellCandidates(env)) {
+    try {
+      const output = await new Promise<string>((resolve, reject) => {
+        execFile(
+          shell,
+          ["-ilc", command],
+          {
+            encoding: "utf8",
+            env,
+            maxBuffer: LOGIN_SHELL_ENV_MAX_BUFFER,
+            timeout: LOGIN_SHELL_ENV_TIMEOUT_MS,
+          },
+          (error, stdout) => {
+            if (error) {
+              reject(error);
+              return;
+            }
+            resolve(stdout);
+          },
+        );
+      });
+      const shellEnv = extractMarkedEnv(output);
+      if (shellEnv) {
+        return shellEnv;
+      }
+      failures.push({ shell, error: "missing env markers" });
+    } catch (error) {
+      failures.push({
+        shell,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  getMainLogger("pwragent:shell-environment").warn("login-shell-env-failed", {
+    failures,
+  });
+  return undefined;
+}
+
 export class DesktopSettingsService {
   private readonly env: NodeJS.ProcessEnv;
   private readonly argv: readonly string[];
@@ -263,6 +351,8 @@ export class DesktopSettingsService {
     key: string;
     promise: ReturnType<typeof discoverGhCommands>;
   };
+  private codexSpawnEnv?: NodeJS.ProcessEnv;
+  private codexSpawnEnvHydrationPromise?: Promise<NodeJS.ProcessEnv>;
 
   constructor(private readonly options: DesktopSettingsServiceOptions) {
     this.env = options.env ?? process.env;
@@ -1112,15 +1202,70 @@ export class DesktopSettingsService {
   }
 
   resolveCodexSpawnEnv(): NodeJS.ProcessEnv {
-    const spawnEnv = mergeLoginShellEnvIntoEnv(this.env, {
-      resolveShellEnv: this.options.resolveCodexShellEnv,
-      // Preserve the in-tree copy's diagnostic logging (the kit defaults to
-      // no-op when no logger is injected).
-      logger: getMainLogger("pwragent:shell-environment"),
-    });
-    if (!this.startupCodexHome) return spawnEnv;
+    if (this.options.resolveCodexShellEnv) {
+      return this.withStartupCodexHome(
+        mergeLoginShellEnvIntoEnv(this.env, {
+          resolveShellEnv: this.options.resolveCodexShellEnv,
+          // Preserve the in-tree copy's diagnostic logging (the kit defaults to
+          // no-op when no logger is injected).
+          logger: getMainLogger("pwragent:shell-environment"),
+        }),
+      );
+    }
+
+    const targetEnv = this.ensureBaseCodexSpawnEnv();
+    void this.resolveCodexSpawnEnvAsync();
+    return targetEnv;
+  }
+
+  async resolveCodexSpawnEnvAsync(): Promise<NodeJS.ProcessEnv> {
+    if (this.options.resolveCodexShellEnv) {
+      return this.resolveCodexSpawnEnv();
+    }
+
+    if (this.codexSpawnEnvHydrationPromise) {
+      return await this.codexSpawnEnvHydrationPromise;
+    }
+
+    const targetEnv = this.ensureBaseCodexSpawnEnv();
+    this.codexSpawnEnvHydrationPromise = resolveInteractiveLoginShellEnvAsync(this.env)
+      .then((shellEnv) => {
+        const logger = getMainLogger("pwragent:shell-environment");
+        if (!shellEnv || Object.keys(shellEnv).length === 0) {
+          logger.warn("login-shell-env-merge-empty", {
+            parentPathLength: this.env.PATH?.length ?? 0,
+            parentShell: this.env.SHELL,
+            shellCandidates: defaultLoginShellCandidates(this.env),
+          });
+          return targetEnv;
+        }
+
+        logger.info("login-shell-env-merged", {
+          keys: Object.keys(shellEnv).length,
+          parentPathLength: this.env.PATH?.length ?? 0,
+          hydratedPathLength: shellEnv.PATH?.length ?? 0,
+          hadNvmDir: Boolean(shellEnv.NVM_DIR),
+          hadHomebrewPrefix: Boolean(shellEnv.HOMEBREW_PREFIX),
+        });
+        Object.assign(targetEnv, shellEnv);
+        if (this.startupCodexHome) {
+          targetEnv.CODEX_HOME = this.startupCodexHome;
+        }
+        return targetEnv;
+      });
+
+    return await this.codexSpawnEnvHydrationPromise;
+  }
+
+  private ensureBaseCodexSpawnEnv(): NodeJS.ProcessEnv {
+    this.codexSpawnEnv ??= this.withStartupCodexHome({ ...this.env });
+    return this.codexSpawnEnv;
+  }
+
+  private withStartupCodexHome(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+    if (!this.startupCodexHome) return env;
     return {
-      ...spawnEnv,
+      ...env,
       CODEX_HOME: this.startupCodexHome,
     };
   }

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -16,6 +16,7 @@ import { MainProcessHeapMonitor } from "./diagnostics/main-process-heap-monitor"
 import { RendererHeapMonitor } from "./diagnostics/renderer-heap-monitor";
 import { RendererHotCpuProfiler } from "./diagnostics/renderer-hot-cpu-profiler";
 import { getMainLogger } from "./log";
+import { recordStartupProfileEvent } from "./diagnostics/startup-profile-events";
 import { resolveActiveProfilePath } from "./profile";
 import { getDesktopSettingsService } from "./settings/desktop-settings-singleton";
 import { attachWindowFocusSync } from "./window-focus-sync";
@@ -390,13 +391,21 @@ export function createMainWindow(options?: {
     if (isDevelopment) {
       mainLog.info("showing window", { reason });
     }
+    recordStartupProfileEvent({
+      type: "window-show",
+      detail: {
+        reason,
+      },
+    });
     window.show();
   };
   window.once("ready-to-show", () => {
+    recordStartupProfileEvent({ type: "window-ready-to-show" });
     showWindow("ready-to-show");
   });
   if (!isMac) {
     window.webContents.once("did-finish-load", () => {
+      recordStartupProfileEvent({ type: "window-did-finish-load-fallback-arm" });
       setTimeout(() => showWindow("fallback"), 500);
     });
   }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -320,6 +320,7 @@ import {
   NAVIGATION_UPDATE_DIRECTORY_LAUNCHPAD_CHANNEL,
   ONBOARDING_COMPLETE_CODEX_BOOTSTRAP_CHANNEL,
   PRELOAD_LOG_CHANNEL,
+  STARTUP_PROFILE_EVENT_CHANNEL,
   PROFILES_CREATE_CHANNEL,
   APP_GET_BOOT_INFO_CHANNEL,
   APP_QUIT_CHANNEL,
@@ -388,10 +389,77 @@ function recordPreloadLog(
   });
 }
 
+function isEnvEnabled(value: string | undefined): boolean {
+  return ["1", "true", "yes", "on"].includes(value?.trim().toLowerCase() ?? "");
+}
+
+const startupProfileEnabled =
+  isEnvEnabled(process.env.PWRAGENT_STARTUP_PROFILE) ||
+  isEnvEnabled(process.env.PWRAGENT_STARTUP_CPU_PROFILING);
+const preloadStartedAt = performance.now();
+
+function recordStartupProfileRendererEvent(
+  type: string,
+  detail?: Record<string, unknown>,
+): void {
+  if (!startupProfileEnabled) {
+    return;
+  }
+
+  ipcRenderer.send(STARTUP_PROFILE_EVENT_CHANNEL, {
+    source: "renderer",
+    type,
+    detail: {
+      preloadElapsedMs: Number((performance.now() - preloadStartedAt).toFixed(3)),
+      ...(detail ?? {}),
+    },
+  });
+}
+
+async function invokeWithStartupProfileTiming<T>(
+  label: string,
+  channel: string,
+  ...args: unknown[]
+): Promise<T> {
+  if (!startupProfileEnabled) {
+    return await ipcRenderer.invoke(channel, ...args);
+  }
+
+  const startedAt = performance.now();
+  recordStartupProfileRendererEvent("ipc-renderer:start", {
+    channel,
+    label,
+  });
+
+  try {
+    const result = await ipcRenderer.invoke(channel, ...args);
+    recordStartupProfileRendererEvent("ipc-renderer:end", {
+      channel,
+      durationMs: Number((performance.now() - startedAt).toFixed(3)),
+      label,
+      ok: true,
+    });
+    return result as T;
+  } catch (error) {
+    recordStartupProfileRendererEvent("ipc-renderer:end", {
+      channel,
+      durationMs: Number((performance.now() - startedAt).toFixed(3)),
+      error: error instanceof Error ? error.message : String(error),
+      label,
+      ok: false,
+    });
+    throw error;
+  }
+}
+
 recordPreloadLog("info", "start", {
   contextIsolated: process.contextIsolated,
   platform: process.platform,
   electron: process.versions.electron
+});
+recordStartupProfileRendererEvent("preload-start", {
+  contextIsolated: process.contextIsolated,
+  platform: process.platform,
 });
 
 const isDevelopment = process.env.NODE_ENV !== "production";
@@ -535,7 +603,10 @@ const desktopApi = Object.freeze({
   ): Promise<WriteDesktopSecretsToProfileResponse> =>
     await ipcRenderer.invoke(PROFILES_WRITE_SECRETS_CHANNEL, request),
   getBootInfo: async (): Promise<DesktopBootInfo> =>
-    await ipcRenderer.invoke(APP_GET_BOOT_INFO_CHANNEL),
+    await invokeWithStartupProfileTiming(
+      "getBootInfo",
+      APP_GET_BOOT_INFO_CHANNEL,
+    ),
   quitApp: async (): Promise<void> => await ipcRenderer.invoke(APP_QUIT_CHANNEL),
   waitForProfileAlive: async (
     request: WaitForDesktopProfileAliveRequest,
@@ -550,7 +621,11 @@ const desktopApi = Object.freeze({
   listThreads: async (
     request?: AppServerListThreadsRequest
   ): Promise<AppServerListThreadsResponse> =>
-    await ipcRenderer.invoke(APP_SERVER_LIST_THREADS_CHANNEL, request),
+    await invokeWithStartupProfileTiming(
+      "listThreads",
+      APP_SERVER_LIST_THREADS_CHANNEL,
+      request,
+    ),
   searchThreads: async (
     request?: ThreadSearchRequest,
   ): Promise<ThreadSearchResponse> =>
@@ -562,7 +637,11 @@ const desktopApi = Object.freeze({
   listBackends: async (
     request?: ListBackendsRequest
   ): Promise<ListBackendsResponse> =>
-    await ipcRenderer.invoke(BACKEND_LIST_CHANNEL, request),
+    await invokeWithStartupProfileTiming(
+      "listBackends",
+      BACKEND_LIST_CHANNEL,
+      request,
+    ),
   listAcpAgents: async (
     request?: ListAcpAgentSettingsRequest,
   ): Promise<ListAcpAgentSettingsResponse> =>
@@ -570,7 +649,11 @@ const desktopApi = Object.freeze({
   readSettings: async (
     request?: ReadDesktopSettingsRequest,
   ): Promise<ReadDesktopSettingsResponse> =>
-    await ipcRenderer.invoke(SETTINGS_READ_CHANNEL, request),
+    await invokeWithStartupProfileTiming(
+      "readSettings",
+      SETTINGS_READ_CHANNEL,
+      request,
+    ),
   writeSettingsConfig: async (
     request: WriteDesktopSettingsConfigRequest,
   ): Promise<DesktopSettingsWriteResponse> =>
@@ -636,7 +719,11 @@ const desktopApi = Object.freeze({
   readThread: async (
     request: AppServerReadThreadRequest
   ): Promise<AppServerReadThreadResponse> =>
-    await ipcRenderer.invoke(APP_SERVER_READ_THREAD_CHANNEL, request),
+    await invokeWithStartupProfileTiming(
+      "readThread",
+      APP_SERVER_READ_THREAD_CHANNEL,
+      request,
+    ),
   persistThreadUsageActivity: async (
     request: PersistThreadUsageActivityRequest,
   ): Promise<PersistThreadUsageActivityResponse> =>
@@ -786,7 +873,11 @@ const desktopApi = Object.freeze({
   getNavigationSnapshot: async (
     request?: GetNavigationSnapshotRequest,
   ): Promise<NavigationSnapshot> =>
-    await ipcRenderer.invoke(NAVIGATION_SNAPSHOT_CHANNEL, request),
+    await invokeWithStartupProfileTiming(
+      "getNavigationSnapshot",
+      NAVIGATION_SNAPSHOT_CHANNEL,
+      request,
+    ),
   setNavigationBrowseMode: async (
     request: SetNavigationBrowseModeRequest,
   ): Promise<SetNavigationBrowseModeResponse> =>
@@ -837,11 +928,16 @@ const desktopApi = Object.freeze({
   refreshThreadPullRequests: async (
     request: RefreshThreadPullRequestsRequest,
   ): Promise<RefreshThreadPullRequestsResponse> =>
-    await ipcRenderer.invoke(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL, request),
+    await invokeWithStartupProfileTiming(
+      "refreshThreadPullRequests",
+      NAVIGATION_REFRESH_THREAD_PRS_CHANNEL,
+      request,
+    ),
   refreshDirectoryGitStatuses: async (
     request: RefreshDirectoryGitStatusesRequest,
   ): Promise<RefreshDirectoryGitStatusesResponse> =>
-    await ipcRenderer.invoke(
+    await invokeWithStartupProfileTiming(
+      "refreshDirectoryGitStatuses",
       NAVIGATION_REFRESH_DIRECTORY_GIT_STATUSES_CHANNEL,
       request,
     ),
@@ -853,7 +949,11 @@ const desktopApi = Object.freeze({
       request,
     ),
   getGhStatus: async (request?: GetGhStatusRequest): Promise<GhStatus> =>
-    await ipcRenderer.invoke(NAVIGATION_GET_GH_STATUS_CHANNEL, request),
+    await invokeWithStartupProfileTiming(
+      "getGhStatus",
+      NAVIGATION_GET_GH_STATUS_CHANNEL,
+      request,
+    ),
   ensureDirectoryLaunchpad: async (
     request: EnsureDirectoryLaunchpadRequest,
   ): Promise<EnsureDirectoryLaunchpadResponse> =>
@@ -909,6 +1009,12 @@ const desktopApi = Object.freeze({
     request: RendererDiagnosticLogRequest,
   ): Promise<void> => {
     recordPreloadLog(request.level, request.message, request.details);
+  },
+  recordStartupProfileEvent: (
+    type: string,
+    detail?: Record<string, unknown>,
+  ): void => {
+    recordStartupProfileRendererEvent(type, detail);
   },
   onWindowFocus: (callback: () => void): (() => void) => {
     const listener = () => callback();
@@ -1010,7 +1116,10 @@ const desktopApi = Object.freeze({
     };
   },
   getMessagingPlatformStatuses: async (): Promise<MessagingPlatformStatus[]> =>
-    await ipcRenderer.invoke(MESSAGING_GET_PLATFORM_STATUSES_CHANNEL),
+    await invokeWithStartupProfileTiming(
+      "getMessagingPlatformStatuses",
+      MESSAGING_GET_PLATFORM_STATUSES_CHANNEL,
+    ),
   setMessagingEnabled: async (
     request: SetMessagingEnabledRequest,
   ): Promise<SetMessagingEnabledResponse> =>
@@ -1088,7 +1197,10 @@ const desktopApi = Object.freeze({
   // reads the top-level model once on mount and pops the live native submenu on
   // click / Alt-mnemonic. No-op surface on macOS/Linux (the bar isn't mounted).
   getAppMenuModel: async (): Promise<AppMenuTopLevel[]> =>
-    await ipcRenderer.invoke(APP_MENU_MODEL_CHANNEL),
+    await invokeWithStartupProfileTiming(
+      "getAppMenuModel",
+      APP_MENU_MODEL_CHANNEL,
+    ),
   popupAppMenu: (request: AppMenuPopupRequest): void => {
     ipcRenderer.send(APP_MENU_POPUP_CHANNEL, request);
   },

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -553,7 +553,12 @@ function DesktopAppShell(props: {
     };
   }, [desktopApi]);
   useEffect(() => {
-    if (threadViewReady || mainView !== "thread" || navigation.loading) {
+    if (
+      threadViewReady ||
+      mainView !== "thread" ||
+      navigation.loading ||
+      !navigation.loaded
+    ) {
       return;
     }
 
@@ -576,23 +581,34 @@ function DesktopAppShell(props: {
         window.clearTimeout(timeoutId);
       }
     };
-  }, [mainView, navigation.loading, threadViewReady]);
+  }, [
+    mainView,
+    navigation.loaded,
+    navigation.loading,
+    threadViewReady,
+  ]);
   useEffect(() => {
     if (!threadViewReady || ThreadViewComponent) {
       return;
     }
 
     let cancelled = false;
+    desktopApi?.recordStartupProfileEvent?.("thread-view-import:start");
     void import("./features/thread-detail/ThreadView").then((module) => {
+      desktopApi?.recordStartupProfileEvent?.("thread-view-import:end");
       if (!cancelled) {
         setThreadViewComponent(() => module.ThreadView);
       }
+    }).catch((error) => {
+      desktopApi?.recordStartupProfileEvent?.("thread-view-import:error", {
+        error: error instanceof Error ? error.message : String(error),
+      });
     });
 
     return () => {
       cancelled = true;
     };
-  }, [ThreadViewComponent, threadViewReady]);
+  }, [ThreadViewComponent, desktopApi, threadViewReady]);
   useEffect(() => {
     // Subscribe to the PwrAgent → Settings… menu push. The Settings
     // overlay is in-renderer (not a separate BrowserWindow), so the

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -577,6 +577,10 @@ export type DesktopApi = {
     request: ImageUploadNormalizationLogRequest
   ) => Promise<void>;
   logRendererDiagnostic?: (request: RendererDiagnosticLogRequest) => Promise<void>;
+  recordStartupProfileEvent?: (
+    type: string,
+    detail?: Record<string, unknown>,
+  ) => void;
   reportRendererError?: (report: RendererErrorReport) => Promise<void>;
   onAgentEvent?: (callback: (event: AgentEvent) => void) => () => void;
   /**

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -1886,6 +1886,7 @@ export function useThreadNavigation(
   worktreeArchiveError?: string;
   renameThreadError?: string;
   loading: boolean;
+  loaded: boolean;
   refreshing: boolean;
   refresh: () => Promise<void>;
   materializeDirectoryLaunchpad: (
@@ -2165,9 +2166,20 @@ export function useThreadNavigation(
       }));
 
       try {
+        desktopApi.recordStartupProfileEvent?.("navigation-refresh:start", {
+          forceRefresh: Boolean(options?.forceRefresh),
+          hasCurrentResponse: Boolean(stateRef.current.response),
+          preferredSelectionKey: preferredSelectionKey ?? null,
+        });
         const snapshot = options?.forceRefresh
           ? await desktopApi.getNavigationSnapshot({ forceRefresh: true })
           : await desktopApi.getNavigationSnapshot();
+        desktopApi.recordStartupProfileEvent?.("navigation-refresh:snapshot", {
+          directoryCount: snapshot.directories.length,
+          forceRefresh: Boolean(options?.forceRefresh),
+          threadCount: snapshot.threads.length,
+          unchanged: Boolean(snapshot.unchanged),
+        });
         const response = removeThreadKeysFromSnapshot(
           snapshot,
           suppressedArchivedThreadKeysRef.current
@@ -2232,6 +2244,9 @@ export function useThreadNavigation(
           );
         });
       } catch (error) {
+        desktopApi.recordStartupProfileEvent?.("navigation-refresh:error", {
+          error: error instanceof Error ? error.message : String(error),
+        });
         setState((current) => ({
           loading: false,
           refreshing: false,
@@ -4886,6 +4901,7 @@ export function useThreadNavigation(
     worktreeArchiveError,
     renameThreadError,
     loading: state.loading,
+    loaded: Boolean(state.response),
     refreshing: state.refreshing,
     refresh: refreshNavigation,
     materializeDirectoryLaunchpad,

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -2925,10 +2925,19 @@ export function useThreadSessionState(params: {
       }));
 
       try {
+        desktopApi?.recordStartupProfileEvent?.("thread-hydration:start", {
+          backend: targetThread.source,
+          threadId: targetThread.id,
+        });
         const response = normalizeResponseImageBoundaryText(await readThread({
           backend: targetThread.source,
           threadId: targetThread.id,
         }));
+        desktopApi?.recordStartupProfileEvent?.("thread-hydration:response", {
+          backend: targetThread.source,
+          entryCount: response.replay.entries.length,
+          threadId: targetThread.id,
+        });
 
         if (requestVersionsRef.current[targetThreadKey] !== requestVersion) {
           return;
@@ -3006,6 +3015,11 @@ export function useThreadSessionState(params: {
           };
         });
       } catch (error) {
+        desktopApi?.recordStartupProfileEvent?.("thread-hydration:error", {
+          backend: targetThread.source,
+          error: error instanceof Error ? error.message : String(error),
+          threadId: targetThread.id,
+        });
         if (requestVersionsRef.current[targetThreadKey] !== requestVersion) {
           return;
         }
@@ -3019,7 +3033,12 @@ export function useThreadSessionState(params: {
         }));
       }
     },
-    [desktopApi?.readThread, logStaleThinkingState, updateSession]
+    [
+      desktopApi?.readThread,
+      desktopApi?.recordStartupProfileEvent,
+      logStaleThinkingState,
+      updateSession,
+    ]
   );
 
   useEffect(() => {

--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -41,9 +41,16 @@ const desktopApi = (
         callback: (isFullScreen: boolean) => void,
       ) => () => void;
       platform?: string;
+      recordStartupProfileEvent?: (
+        type: string,
+        detail?: Record<string, unknown>,
+      ) => void;
     };
   }
 ).pwragent;
+desktopApi?.recordStartupProfileEvent?.("renderer-main-module-start", {
+  hash: window.location.hash,
+});
 if (desktopApi?.platform) {
   document.documentElement.dataset.platform = desktopApi.platform;
 }
@@ -151,6 +158,7 @@ function chooseRoot(): ReactElement {
   return routes.find((route) => route.match(hash))?.render() ?? <App />;
 }
 
+desktopApi?.recordStartupProfileEvent?.("react-render:start");
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <RendererErrorBoundary>
@@ -158,3 +166,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
     </RendererErrorBoundary>
   </React.StrictMode>,
 );
+desktopApi?.recordStartupProfileEvent?.("react-render:scheduled");
+requestAnimationFrame(() => {
+  desktopApi?.recordStartupProfileEvent?.("renderer-first-animation-frame");
+});

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -205,6 +205,7 @@ export const IMAGE_UPLOAD_FALLBACK_CHANNEL = "image-upload:fallback";
 export const IMAGE_UPLOAD_NORMALIZATION_LOG_CHANNEL =
   "image-upload:normalization-log";
 export const PRELOAD_LOG_CHANNEL = "preload:log";
+export const STARTUP_PROFILE_EVENT_CHANNEL = "startup-profile:event";
 export const WINDOW_FOCUS_SYNC_CHANNEL = "window:focus-sync";
 /**
  * Main → renderer push: fired on `enter-full-screen` / `leave-full-screen`


### PR DESCRIPTION
## Summary

Desktop startup now has a profiling harness that can explain the blank `Loading...` gap with main/renderer CPU profiles, a cross-process startup timeline, IPC timings, and optional heap snapshots. The live Codex login-shell environment hydration no longer blocks window creation, and the thread-detail bundle waits until the initial navigation snapshot has loaded before importing the markdown-heavy transcript view.

## Measurements

Captured with `PWRAGENT_STARTUP_PROFILE=1 PWRAGENT_STARTUP_CPU_PROFILE_QUIT_ON_COMPLETE=1 pnpm dev:no-messaging` on the same machine/profile.

| Marker | Before | After |
|---|---:|---:|
| `main-window-create:start` | ~969 ms | ~68 ms |
| `window-show` | ~1722 ms | ~698 ms |
| initial navigation snapshot received | ~4013 ms | ~1459 ms |
| selected thread hydrated | ~4100 ms | ~1574 ms |

The remaining long pole is renderer CPU during `ThreadView` import: `react-markdown.js` still accounts for about 2.2s self time in the final profile, with `thread-view-import` running from ~1529 ms to ~4019 ms. This PR makes that cost visible and keeps it from delaying the first navigation snapshot/read.

## Notes

- `PWRAGENT_STARTUP_PROFILE=1` enables startup capture.
- `PWRAGENT_STARTUP_PROFILE_DIR=/path` overrides the output directory.
- `PWRAGENT_STARTUP_PROFILE_HEAP_SNAPSHOTS=1` additionally captures main and renderer heap snapshots.
- Existing `PWRAGENT_STARTUP_CPU_PROFILING` env names still work.

## Test Plan

- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm test apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx apps/desktop/src/main/__tests__/desktop-settings-service.test.ts apps/desktop/src/main/__tests__/codex-client.test.ts apps/desktop/src/main/__tests__/stdio-transport.test.ts apps/desktop/src/main/__tests__/startup-cpu-profile-session.test.ts apps/desktop/src/main/__tests__/startup-cpu-profiler.test.ts apps/desktop/src/main/__tests__/startup-cpu-analysis.test.ts`
- Manual startup profile run with `pnpm dev:no-messaging`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
