### PR TITLE
feat(desktop): jump search results to the matched message

### DIFF
--- a/apps/desktop/src/main/__tests__/thread-search-provider-adapters.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-search-provider-adapters.test.ts
@@ -22,6 +22,36 @@ describe("ProviderTranscriptThreadSearchAdapter", () => {
     });
   });
 
+  it("captures the matched message's turn id for deep-linking", async () => {
+    const adapter = new ProviderTranscriptThreadSearchAdapter(async () => {
+      const response = readThreadResponse(
+        "We discussed branch drift screenshots in this thread.",
+      );
+      // Plain messages carry no turn; the matching entry does, and the adapter
+      // recovers it so the desktop can scroll to the turn's `data-turn-id`.
+      response.replay.entries = [
+        {
+          type: "message",
+          id: "message-1",
+          role: "user",
+          text: "We discussed branch drift screenshots in this thread.",
+          turn: { id: "turn-7" },
+        },
+      ];
+      return response;
+    });
+
+    const response = await adapter.searchContent({
+      candidates: [candidate("thread-1")],
+      limit: 5,
+      query: "branch drift",
+    });
+
+    expect(response.results[0]?.snippets).toEqual([
+      expect.objectContaining({ scope: "provider_content", turnId: "turn-7" }),
+    ]);
+  });
+
   it("reports provider read failures as unavailable scopes", async () => {
     const adapter = new ProviderTranscriptThreadSearchAdapter(async () => {
       throw new Error("provider offline");

--- a/apps/desktop/src/main/thread-search/thread-search-provider-adapters.ts
+++ b/apps/desktop/src/main/thread-search/thread-search-provider-adapters.ts
@@ -69,6 +69,7 @@ export class ProviderTranscriptThreadSearchAdapter {
               field: snippet.field,
               text: snippet.text,
               truncated: snippet.truncated,
+              ...(snippet.turnId ? { turnId: snippet.turnId } : {}),
             },
           ],
         });
@@ -92,12 +93,15 @@ export class ProviderTranscriptThreadSearchAdapter {
 function findTranscriptSnippet(
   response: AppServerReadThreadResponse,
   terms: string[],
-): { field: string; text: string; truncated?: boolean } | undefined {
+): { field: string; text: string; truncated?: boolean; turnId?: string } | undefined {
   for (const message of response.replay.messages) {
     const text = message.text.trim();
     if (text && textMatchesTerms(text, terms)) {
       return {
         field: `message:${message.role}`,
+        // Plain messages carry no turn; recover it from the matching entry so
+        // the desktop can deep-link the result to the turn's `data-turn-id`.
+        turnId: turnIdForMessage(response, message.id),
         ...buildSnippet(text, terms[0] ?? ""),
       };
     }
@@ -120,12 +124,25 @@ function findTranscriptSnippet(
       if (textMatchesTerms(text, terms)) {
         return {
           field: "activity",
+          turnId: entry.turn?.id,
           ...buildSnippet(text, terms[0] ?? ""),
         };
       }
     }
   }
 
+  return undefined;
+}
+
+function turnIdForMessage(
+  response: AppServerReadThreadResponse,
+  messageId: string,
+): string | undefined {
+  for (const entry of response.replay.entries) {
+    if (entry.type === "message" && entry.id === messageId) {
+      return entry.turn?.id;
+    }
+  }
   return undefined;
 }
 

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -183,9 +183,14 @@ function DesktopAppShell(props: {
   const [mainView, setMainView] = useState<
     "thread" | "settings" | "automations" | "search"
   >("thread");
-  // In-thread find bar (⌘F) visibility, owned here so the find chord and the
-  // bar's own Escape share one source of truth.
-  const [threadFindOpen, setThreadFindOpen] = useState(false);
+  // In-thread find bar (⌘F). `manualFindOpen` is the ⌘F toggle; `findRequest`
+  // is a deep-link from a search result (seeded query + its target thread).
+  // The bar is open when either applies (see `threadFindOpen` below).
+  const [manualFindOpen, setManualFindOpen] = useState(false);
+  const [findRequest, setFindRequest] = useState<{
+    query: string;
+    threadKey: string;
+  }>();
   // Thread-list quick-jump popup (⌘F while the sidebar is focused).
   const [sidebarSearchOpen, setSidebarSearchOpen] = useState(false);
   // Initial section for SettingsScreen — non-undefined when navigation
@@ -502,15 +507,29 @@ function DesktopAppShell(props: {
         return;
       }
       if (mainView === "thread") {
-        setThreadFindOpen(true);
+        setManualFindOpen(true);
       }
     },
   });
-  // The in-thread find bar is per-thread chrome: drop it when the operator
-  // leaves the thread view or switches to a different thread.
+  // Manual find is per-thread chrome: drop it when the operator leaves the
+  // thread view or switches threads. The deep-link find (findRequest) closes
+  // on its own — it's keyed to its target thread (see `threadFindOpen`).
   useEffect(() => {
-    setThreadFindOpen(false);
-  }, [mainView, navigation.selectedThreadKey]);
+    if (mainView !== "thread") {
+      setManualFindOpen(false);
+      setFindRequest(undefined);
+    }
+  }, [mainView]);
+  useEffect(() => {
+    setManualFindOpen(false);
+  }, [navigation.selectedThreadKey]);
+  // Find bar is open for a manual ⌘F, or for a search deep-link while its
+  // target thread is the one on screen.
+  const deepLinkFindActive =
+    findRequest !== undefined &&
+    findRequest.threadKey === navigation.selectedThreadKey;
+  const threadFindOpen = manualFindOpen || deepLinkFindActive;
+  const threadFindInitialQuery = deepLinkFindActive ? findRequest.query : undefined;
   const historyNav: HistoryNavControls = useMemo(
     () => ({
       canGoBack: history.canGoBack,
@@ -793,7 +812,15 @@ function DesktopAppShell(props: {
     mastheadActions,
     historyNav,
     findOpen: threadFindOpen,
-    onFindOpenChange: setThreadFindOpen,
+    findInitialQuery: threadFindInitialQuery,
+    onFindOpenChange: (open: boolean) => {
+      // The bar only ever calls this to close itself (Escape / ✕). Clear both
+      // the manual toggle and any deep-link request so it stays closed.
+      if (!open) {
+        setManualFindOpen(false);
+        setFindRequest(undefined);
+      }
+    },
     onHandoffThreadWorkspace: navigation.selectedThread
       ? async (request) =>
           await navigation.handoffThreadWorkspace(
@@ -999,6 +1026,22 @@ function DesktopAppShell(props: {
               state={threadSearchState}
               threads={navigation.threads}
               onOpenResult={async (result) => {
+                // Deep-link to the match: open the thread with the find bar
+                // seeded with the search query so it highlights + scrolls the
+                // matched message into view (auto-loading older history if the
+                // match lives further up than the first page).
+                const seed = threadSearchState.query.trim();
+                setFindRequest(
+                  seed
+                    ? {
+                        query: seed,
+                        threadKey: buildThreadIdentityKey(
+                          result.backend,
+                          result.threadId,
+                        ),
+                      }
+                    : undefined,
+                );
                 setMainView("thread");
                 await navigation.showThread(result);
               }}

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -190,6 +190,7 @@ function DesktopAppShell(props: {
   const [findRequest, setFindRequest] = useState<{
     query: string;
     threadKey: string;
+    turnId?: string;
   }>();
   // Thread-list quick-jump popup (⌘F while the sidebar is focused).
   const [sidebarSearchOpen, setSidebarSearchOpen] = useState(false);
@@ -520,9 +521,23 @@ function DesktopAppShell(props: {
       setFindRequest(undefined);
     }
   }, [mainView]);
+  // Manual find doesn't follow a thread switch. A deep-link find DOES follow to
+  // its target thread — but once the operator navigates away from that target,
+  // clear the request so returning to the thread later doesn't silently
+  // re-open find with the stale query.
+  const deepLinkLandedRef = useRef(false);
   useEffect(() => {
     setManualFindOpen(false);
-  }, [navigation.selectedThreadKey]);
+    if (!findRequest) {
+      deepLinkLandedRef.current = false;
+      return;
+    }
+    if (navigation.selectedThreadKey === findRequest.threadKey) {
+      deepLinkLandedRef.current = true;
+    } else if (deepLinkLandedRef.current) {
+      setFindRequest(undefined);
+    }
+  }, [navigation.selectedThreadKey, findRequest]);
   // Find bar is open for a manual ⌘F, or for a search deep-link while its
   // target thread is the one on screen.
   const deepLinkFindActive =
@@ -530,6 +545,7 @@ function DesktopAppShell(props: {
     findRequest.threadKey === navigation.selectedThreadKey;
   const threadFindOpen = manualFindOpen || deepLinkFindActive;
   const threadFindInitialQuery = deepLinkFindActive ? findRequest.query : undefined;
+  const threadFindTurnId = deepLinkFindActive ? findRequest.turnId : undefined;
   const historyNav: HistoryNavControls = useMemo(
     () => ({
       canGoBack: history.canGoBack,
@@ -813,6 +829,7 @@ function DesktopAppShell(props: {
     historyNav,
     findOpen: threadFindOpen,
     findInitialQuery: threadFindInitialQuery,
+    findTurnId: threadFindTurnId,
     onFindOpenChange: (open: boolean) => {
       // The bar only ever calls this to close itself (Escape / ✕). Clear both
       // the manual toggle and any deep-link request so it stays closed.
@@ -1039,6 +1056,7 @@ function DesktopAppShell(props: {
                           result.backend,
                           result.threadId,
                         ),
+                        turnId: result.turnId,
                       }
                     : undefined,
                 );

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadFindBar.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadFindBar.tsx
@@ -12,6 +12,12 @@ import { CloseIcon, SearchIcon } from "../../icons";
 const HIGHLIGHT_ALL = "thread-find";
 const HIGHLIGHT_ACTIVE = "thread-find-active";
 
+// Safety cap on the deep-link auto-load loop. `hasMoreHistory` normally stops
+// it once the thread is fully loaded; this guards the pathological case where
+// the matched text never renders in the DOM (e.g. markdown reflowed it across
+// nodes) so we don't keep paging a giant thread forever.
+const MAX_AUTO_LOADS = 60;
+
 type ThreadFindBarProps = {
   /** The element whose text content is searched (the transcript). */
   containerRef: RefObject<HTMLElement | null>;
@@ -20,6 +26,17 @@ type ThreadFindBarProps = {
    * highlights track live transcript content.
    */
   refreshKey?: unknown;
+  /**
+   * When opened from a search result, pre-fill the input with this query and
+   * auto-load older history until it's found (deep-link to the match).
+   */
+  initialQuery?: string;
+  /** Whether older transcript pages remain (drives the deep-link auto-load). */
+  hasMoreHistory?: boolean;
+  /** Whether an older-page load is in flight. */
+  loadingMore?: boolean;
+  /** Load one older transcript page. */
+  onLoadOlder?: () => Promise<void> | void;
   onClose: () => void;
 };
 
@@ -87,12 +104,29 @@ export function ThreadFindBar(props: ThreadFindBarProps): ReactElement {
   const [matches, setMatches] = useState<Range[]>([]);
   const [activeIndex, setActiveIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
+  // The search-seeded query we're auto-loading toward (deep-link), plus how
+  // many older pages we've requested for it and whether we've landed on it.
+  const seededRef = useRef<string | undefined>(undefined);
+  const autoLoadsRef = useRef(0);
+  const landedSeedRef = useRef<string | undefined>(undefined);
 
   // Focus + select on mount and whenever the bar is (re)opened.
   useEffect(() => {
     inputRef.current?.focus();
     inputRef.current?.select();
   }, []);
+
+  // Adopt a search-seeded query (deep-link from a search result) once per
+  // distinct seed, re-arming the auto-load budget.
+  useEffect(() => {
+    const seed = props.initialQuery?.trim();
+    if (seed && seed !== seededRef.current) {
+      seededRef.current = seed;
+      autoLoadsRef.current = 0;
+      landedSeedRef.current = undefined;
+      setQuery(seed);
+    }
+  }, [props.initialQuery]);
 
   // Recompute matches when the query or the underlying transcript changes.
   useEffect(() => {
@@ -128,6 +162,65 @@ export function ThreadFindBar(props: ThreadFindBarProps): ReactElement {
   // Drop highlights when the bar unmounts (closed).
   useEffect(() => clearHighlights, []);
 
+  // Deep-link: while showing the seeded query with no match yet, page in older
+  // history until it appears (or we run out / hit the cap). Each load grows the
+  // transcript, bumping refreshKey, which re-collects matches and re-runs this.
+  const autoLoadActive =
+    seededRef.current !== undefined &&
+    query === seededRef.current &&
+    query !== "";
+  useEffect(() => {
+    if (
+      !autoLoadActive ||
+      matches.length > 0 ||
+      props.loadingMore ||
+      !props.hasMoreHistory ||
+      autoLoadsRef.current >= MAX_AUTO_LOADS
+    ) {
+      return;
+    }
+    autoLoadsRef.current += 1;
+    void props.onLoadOlder?.();
+    // props intentionally excluded from deps: the effect re-runs as the
+    // transcript/pagination state changes, and reads the latest callbacks.
+  }, [autoLoadActive, matches.length, props.loadingMore, props.hasMoreHistory]);
+
+  // Once the seeded deep-link match is found AND older-page loading has
+  // settled, scroll it into view — once per seed, and re-asserted past the
+  // transcript's own post-load scroll restoration (which otherwise snaps the
+  // view back to the bottom). The generic scroll effect above handles manual
+  // ⌘F + match cycling; this one owns the deep-link landing.
+  useEffect(() => {
+    const seed = seededRef.current;
+    if (
+      !seed ||
+      query !== seed ||
+      matches.length === 0 ||
+      props.loadingMore ||
+      landedSeedRef.current === seed
+    ) {
+      return;
+    }
+    landedSeedRef.current = seed;
+    const active = matches[activeIndex];
+    const anchor =
+      active?.startContainer instanceof Element
+        ? active.startContainer
+        : active?.startContainer.parentElement;
+    if (!anchor) {
+      return;
+    }
+    requestAnimationFrame(() =>
+      requestAnimationFrame(() =>
+        anchor.scrollIntoView({ block: "center", behavior: "smooth" }),
+      ),
+    );
+    window.setTimeout(
+      () => anchor.scrollIntoView({ block: "center", behavior: "auto" }),
+      300,
+    );
+  }, [matches, activeIndex, props.loadingMore, query]);
+
   const step = useCallback(
     (delta: number) => {
       setActiveIndex((current) => {
@@ -153,7 +246,16 @@ export function ThreadFindBar(props: ThreadFindBarProps): ReactElement {
   };
 
   const count = matches.length;
-  const status = query === "" ? "" : count > 0 ? `${activeIndex + 1} of ${count}` : "No matches";
+  const searchingOlder =
+    autoLoadActive && count === 0 && (props.loadingMore || props.hasMoreHistory);
+  const status =
+    query === ""
+      ? ""
+      : count > 0
+        ? `${activeIndex + 1} of ${count}`
+        : searchingOlder
+          ? "Searching older messages…"
+          : "No matches";
 
   return (
     <div className="thread-find" role="search" aria-label="Find in thread">

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadFindBar.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadFindBar.tsx
@@ -18,6 +18,10 @@ const HIGHLIGHT_ACTIVE = "thread-find-active";
 // nodes) so we don't keep paging a giant thread forever.
 const MAX_AUTO_LOADS = 60;
 
+// How many animation frames (~2.5s at 60fps) the deep-link landing keeps the
+// match pinned to center while a heavy thread finishes reflowing after load.
+const HOLD_CENTERED_FRAMES = 150;
+
 type ThreadFindBarProps = {
   /** The element whose text content is searched (the transcript). */
   containerRef: RefObject<HTMLElement | null>;
@@ -31,6 +35,13 @@ type ThreadFindBarProps = {
    * auto-load older history until it's found (deep-link to the match).
    */
   initialQuery?: string;
+  /**
+   * Turn id of the matched message, when the search result carried one. The
+   * authoritative deep-link target: auto-load until this turn's `data-turn-id`
+   * anchor renders, then scroll to it (the text highlight is a bonus that can
+   * miss if markdown reflowed the snippet across nodes).
+   */
+  turnId?: string;
   /** Whether older transcript pages remain (drives the deep-link auto-load). */
   hasMoreHistory?: boolean;
   /** Whether an older-page load is in flight. */
@@ -102,6 +113,11 @@ function collectMatchRanges(container: HTMLElement, query: string): Range[] {
 export function ThreadFindBar(props: ThreadFindBarProps): ReactElement {
   const [query, setQuery] = useState("");
   const [matches, setMatches] = useState<Range[]>([]);
+  // Whether the deep-link target is on screen yet: the matched turn's
+  // `data-turn-id` anchor has rendered, or a text match was found. Drives the
+  // auto-load loop and the landing scroll so a turn that reflowed its snippet
+  // text still stops paging and scrolls into view.
+  const [targetFound, setTargetFound] = useState(false);
   const [activeIndex, setActiveIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
   // The search-seeded query we're auto-loading toward (deep-link), plus how
@@ -133,12 +149,18 @@ export function ThreadFindBar(props: ThreadFindBarProps): ReactElement {
     const container = props.containerRef.current;
     if (!container || !highlightsSupported()) {
       setMatches([]);
+      setTargetFound(false);
       return;
     }
     const ranges = collectMatchRanges(container, query);
     setMatches(ranges);
     setActiveIndex((current) => (current < ranges.length ? current : 0));
-  }, [query, props.refreshKey, props.containerRef]);
+    const anchorPresent = props.turnId
+      ? container.querySelector(`[data-turn-id="${CSS.escape(props.turnId)}"]`) !==
+        null
+      : false;
+    setTargetFound(anchorPresent || ranges.length > 0);
+  }, [query, props.refreshKey, props.containerRef, props.turnId]);
 
   // Paint the highlights and scroll the active match into view.
   useEffect(() => {
@@ -172,7 +194,7 @@ export function ThreadFindBar(props: ThreadFindBarProps): ReactElement {
   useEffect(() => {
     if (
       !autoLoadActive ||
-      matches.length > 0 ||
+      targetFound ||
       props.loadingMore ||
       !props.hasMoreHistory ||
       autoLoadsRef.current >= MAX_AUTO_LOADS
@@ -183,43 +205,97 @@ export function ThreadFindBar(props: ThreadFindBarProps): ReactElement {
     void props.onLoadOlder?.();
     // props intentionally excluded from deps: the effect re-runs as the
     // transcript/pagination state changes, and reads the latest callbacks.
-  }, [autoLoadActive, matches.length, props.loadingMore, props.hasMoreHistory]);
+  }, [autoLoadActive, targetFound, props.loadingMore, props.hasMoreHistory]);
 
   // Once the seeded deep-link match is found AND older-page loading has
-  // settled, scroll it into view — once per seed, and re-asserted past the
+  // settled, scroll it into view — once per seed, and held centered past the
   // transcript's own post-load scroll restoration (which otherwise snaps the
-  // view back to the bottom). The generic scroll effect above handles manual
-  // ⌘F + match cycling; this one owns the deep-link landing.
+  // view back). The generic scroll effect above handles manual ⌘F + match
+  // cycling; this one owns the deep-link landing.
   useEffect(() => {
     const seed = seededRef.current;
     if (
       !seed ||
       query !== seed ||
-      matches.length === 0 ||
+      !targetFound ||
       props.loadingMore ||
       landedSeedRef.current === seed
     ) {
       return;
     }
-    landedSeedRef.current = seed;
-    const active = matches[activeIndex];
-    const anchor =
-      active?.startContainer instanceof Element
-        ? active.startContainer
-        : active?.startContainer.parentElement;
-    if (!anchor) {
+    const container = props.containerRef.current;
+    // Resolve the scroll target LIVE on every frame, not once. Two reasons:
+    // (1) the matched text often renders a frame or two after its turn anchor,
+    // so a target captured at landing can miss it; (2) the message re-renders
+    // as the heavy thread reflows, detaching any captured node. A turn spans
+    // several transcript items sharing one `data-turn-id` (user prompt +
+    // assistant reply + activities), so we can't just take the first — we scope
+    // the text search to each item and pick the one actually containing the
+    // match (the assistant reply), falling back to the captured text range.
+    const turnId = props.turnId;
+    const fallbackAnchor = ((): Element | null => {
+      const active = matches[activeIndex];
+      if (active?.startContainer instanceof Element) {
+        return active.startContainer;
+      }
+      return active?.startContainer.parentElement ?? null;
+    })();
+    const resolveTarget = (): Element | null => {
+      if (turnId && container) {
+        const items = container.querySelectorAll(
+          `[data-turn-id="${CSS.escape(turnId)}"]`,
+        );
+        for (const item of items) {
+          const ranges = collectMatchRanges(item as HTMLElement, seed);
+          const node = ranges[0]?.startContainer;
+          if (node) {
+            return node instanceof Element ? node : node.parentElement;
+          }
+        }
+        // No text hit in the turn yet (still rendering, or the snippet isn't
+        // plain text e.g. a PR-number deep-link): aim at the last item of the
+        // turn — the assistant reply — rather than the user prompt up top.
+        const last = items[items.length - 1];
+        return last?.querySelector("*") ?? last ?? fallbackAnchor;
+      }
+      return fallbackAnchor;
+    };
+    if (!resolveTarget()) {
       return;
     }
-    requestAnimationFrame(() =>
-      requestAnimationFrame(() =>
-        anchor.scrollIntoView({ block: "center", behavior: "smooth" }),
-      ),
-    );
-    window.setTimeout(
-      () => anchor.scrollIntoView({ block: "center", behavior: "auto" }),
-      300,
-    );
-  }, [matches, activeIndex, props.loadingMore, query]);
+    landedSeedRef.current = seed;
+    // Hold the match centered across the whole settling window. A heavily
+    // paginated thread keeps reflowing in bursts for a couple seconds after the
+    // match renders — older pages just prepended, collapsed turn groups and
+    // lazily loaded edit rows resize, and the transcript's own scroll
+    // restoration tugs back — so a one-shot scroll lands then drifts off as
+    // later content prepends above. Re-center every frame for the window
+    // instead; once content truly stops moving, re-centering an already-
+    // centered anchor is a no-op. Bail the instant the operator scrolls — a
+    // deep-link landing shouldn't fight someone who's taken over.
+    const deadline = HOLD_CENTERED_FRAMES;
+    let frame = 0;
+    let rafId = 0;
+    let takenOver = false;
+    const onUserScroll = (): void => {
+      takenOver = true;
+    };
+    const stop = (): void => {
+      cancelAnimationFrame(rafId);
+      container?.removeEventListener("wheel", onUserScroll);
+    };
+    container?.addEventListener("wheel", onUserScroll, { passive: true });
+    const tick = (): void => {
+      if (takenOver || frame >= deadline) {
+        stop();
+        return;
+      }
+      resolveTarget()?.scrollIntoView({ block: "center", behavior: "auto" });
+      frame += 1;
+      rafId = requestAnimationFrame(tick);
+    };
+    rafId = requestAnimationFrame(tick);
+  }, [matches, activeIndex, props.loadingMore, query, targetFound, props.turnId, props.containerRef]);
 
   const step = useCallback(
     (delta: number) => {
@@ -247,7 +323,7 @@ export function ThreadFindBar(props: ThreadFindBarProps): ReactElement {
 
   const count = matches.length;
   const searchingOlder =
-    autoLoadActive && count === 0 && (props.loadingMore || props.hasMoreHistory);
+    autoLoadActive && !targetFound && (props.loadingMore || props.hasMoreHistory);
   const status =
     query === ""
       ? ""

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadFindBar.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadFindBar.tsx
@@ -224,14 +224,14 @@ export function ThreadFindBar(props: ThreadFindBarProps): ReactElement {
       return;
     }
     const container = props.containerRef.current;
-    // Resolve the scroll target LIVE on every frame, not once. Two reasons:
-    // (1) the matched text often renders a frame or two after its turn anchor,
-    // so a target captured at landing can miss it; (2) the message re-renders
-    // as the heavy thread reflows, detaching any captured node. A turn spans
-    // several transcript items sharing one `data-turn-id` (user prompt +
-    // assistant reply + activities), so we can't just take the first — we scope
-    // the text search to each item and pick the one actually containing the
-    // match (the assistant reply), falling back to the captured text range.
+    // Resolve the scroll target, caching the confirmed text match so we don't
+    // re-walk the turn every frame. A turn spans several transcript items
+    // sharing one `data-turn-id` (user prompt + assistant reply + activities),
+    // so we can't take the first — we scope the text search to each item and
+    // pick the one actually containing the match (the assistant reply). The
+    // matched text usually renders a frame or two after the turn anchor, so we
+    // keep re-resolving until it appears; once found we reuse it while it stays
+    // connected, re-resolving only if a re-render detaches the node.
     const turnId = props.turnId;
     const fallbackAnchor = ((): Element | null => {
       const active = matches[activeIndex];
@@ -240,25 +240,37 @@ export function ThreadFindBar(props: ThreadFindBarProps): ReactElement {
       }
       return active?.startContainer.parentElement ?? null;
     })();
+    let cached: Element | null = null;
+    let cachedIsMatch = false;
     const resolveTarget = (): Element | null => {
+      if (cached && cachedIsMatch && cached.isConnected) {
+        return cached;
+      }
       if (turnId && container) {
         const items = container.querySelectorAll(
           `[data-turn-id="${CSS.escape(turnId)}"]`,
         );
         for (const item of items) {
-          const ranges = collectMatchRanges(item as HTMLElement, seed);
-          const node = ranges[0]?.startContainer;
+          const node = collectMatchRanges(item as HTMLElement, seed)[0]
+            ?.startContainer;
           if (node) {
-            return node instanceof Element ? node : node.parentElement;
+            cached = node instanceof Element ? node : node.parentElement;
+            cachedIsMatch = true;
+            return cached;
           }
         }
         // No text hit in the turn yet (still rendering, or the snippet isn't
-        // plain text e.g. a PR-number deep-link): aim at the last item of the
-        // turn — the assistant reply — rather than the user prompt up top.
+        // plain text e.g. a PR-number deep-link): aim at the last item — the
+        // assistant reply — not the user prompt up top. Not cached as a match,
+        // so later frames keep looking for the real hit.
         const last = items[items.length - 1];
-        return last?.querySelector("*") ?? last ?? fallbackAnchor;
+        cached = last?.querySelector("*") ?? last ?? fallbackAnchor;
+        cachedIsMatch = false;
+        return cached;
       }
-      return fallbackAnchor;
+      cached = fallbackAnchor;
+      cachedIsMatch = false;
+      return cached;
     };
     if (!resolveTarget()) {
       return;
@@ -295,7 +307,14 @@ export function ThreadFindBar(props: ThreadFindBarProps): ReactElement {
       rafId = requestAnimationFrame(tick);
     };
     rafId = requestAnimationFrame(tick);
-  }, [matches, activeIndex, props.loadingMore, query, targetFound, props.turnId, props.containerRef]);
+    // Tear down on unmount (bar closed) so the loop can't keep scrolling the
+    // transcript or leak its wheel listener past close. `matches`/`activeIndex`
+    // are intentionally excluded from deps: they change as the thread settles,
+    // and re-running mid-hold would tear the loop down early (the landedSeedRef
+    // guard already blocks a second landing). `fallbackAnchor` reads them once,
+    // at landing — when the match is freshest.
+    return stop;
+  }, [props.loadingMore, query, targetFound, props.turnId, props.containerRef]);
 
   const step = useCallback(
     (delta: number) => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -916,6 +916,8 @@ export type ThreadViewProps = {
   onFindOpenChange?: (open: boolean) => void;
   /** Seed query for the find bar when deep-linking from a search result. */
   findInitialQuery?: string;
+  /** Turn id to load+scroll to when deep-linking a search match. */
+  findTurnId?: string;
   onLoadOlder: () => Promise<void>;
   onArchiveThread?: (thread: NavigationThreadSummary) => Promise<void>;
   onRefreshNavigation?: () => Promise<void>;
@@ -2425,6 +2427,7 @@ export function ThreadView(props: ThreadViewProps) {
               containerRef={transcriptPanelRef}
               refreshKey={`${selectedThread!.source}:${selectedThread!.id}:${props.transcriptEntries.length}`}
               initialQuery={props.findInitialQuery}
+              turnId={props.findTurnId}
               hasMoreHistory={Boolean(
                 props.transcriptPagination?.supportsPagination &&
                   props.transcriptPagination.hasPreviousPage,

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -914,6 +914,8 @@ export type ThreadViewProps = {
   /** In-thread find bar (⌘F): open state + close callback, owned by App. */
   findOpen?: boolean;
   onFindOpenChange?: (open: boolean) => void;
+  /** Seed query for the find bar when deep-linking from a search result. */
+  findInitialQuery?: string;
   onLoadOlder: () => Promise<void>;
   onArchiveThread?: (thread: NavigationThreadSummary) => Promise<void>;
   onRefreshNavigation?: () => Promise<void>;
@@ -2422,6 +2424,13 @@ export function ThreadView(props: ThreadViewProps) {
             <ThreadFindBar
               containerRef={transcriptPanelRef}
               refreshKey={`${selectedThread!.source}:${selectedThread!.id}:${props.transcriptEntries.length}`}
+              initialQuery={props.findInitialQuery}
+              hasMoreHistory={Boolean(
+                props.transcriptPagination?.supportsPagination &&
+                  props.transcriptPagination.hasPreviousPage,
+              )}
+              loadingMore={props.loadingMore}
+              onLoadOlder={props.onLoadOlder}
               onClose={() => props.onFindOpenChange?.(false)}
             />
           ) : null}

--- a/apps/desktop/src/renderer/src/features/thread-search/ThreadSearchPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-search/ThreadSearchPanel.tsx
@@ -48,6 +48,8 @@ type ThreadSearchPanelProps = {
   onOpenResult: (result: {
     backend: AppServerBackendKind;
     threadId: string;
+    /** Turn of the matched message, for deep-linking to it in the thread. */
+    turnId?: string;
   }) => Promise<void> | void;
   onOpenMessagingActivity?: (platform?: MessagingChannelKind) => void;
   /**
@@ -330,6 +332,7 @@ export function ThreadSearchPanel(props: ThreadSearchPanelProps) {
                       void props.onOpenResult({
                         backend: result.backend,
                         threadId: result.threadId,
+                        turnId: result.snippets.find((s) => s.turnId)?.turnId,
                       });
                     }}
                   />

--- a/packages/shared/src/contracts/thread-search.ts
+++ b/packages/shared/src/contracts/thread-search.ts
@@ -101,6 +101,12 @@ export type ThreadSearchSnippet = {
   field?: string;
   text: string;
   truncated?: boolean;
+  /**
+   * Turn id of the matched message/entry, when known. Lets the desktop
+   * deep-link a search result to the matched turn — load older history until
+   * its `data-turn-id` anchor renders, then scroll to it.
+   */
+  turnId?: string;
 };
 
 export type ThreadSearchUnavailableScope = {


### PR DESCRIPTION
## Summary

Clicking a thread-search result opened the thread but left you at the bottom — the matched message wasn't scrolled into view. Now opening a result **deep-links to the matched turn**, reusing the in-thread find bar so you also get the highlight, the "N of M" count, and next/prev cycling.

## How it works

- **Backend** (`thread-search-provider-adapters.ts`) stamps the matched message/activity's `turnId` onto the snippet (new `ThreadSearchSnippet.turnId` in the shared contract). Plain messages carry no turn, so it's recovered from the matching replay entry.
- **Renderer** threads `turnId` through the result click → `App.findRequest` → `ThreadView.findTurnId` → `ThreadFindBar`. Find-open is **derived** — `manualFindOpen` (⌘F) OR a deep-link while its target thread is on screen — which keeps the existing "close find on thread change" effect from slamming the bar shut during the search→thread navigation. `findRequest` is cleared once you leave the deep-linked thread so revisiting it later doesn't re-open find with a stale query.
- **ThreadFindBar** seeds the query and, since the match usually lives above the first loaded page, **auto-loads older history** until the matched turn's `data-turn-id` anchor (or the text itself) renders — bounded by `hasMoreHistory` and a safety cap. Status shows "Searching older messages…" while it pages.
- **Landing.** It then scrolls the match into view and **holds it centered** for a short window. A Codex turn tags several transcript items with one shared `data-turn-id` (user prompt + assistant reply + activities), so the target is resolved by scoping the text search to each item and picking the one that actually contains the match (not the prompt up top). The target is re-resolved live (and the confirmed hit cached) because the matched text renders a frame after its anchor and re-renders can detach a captured node. Re-centering every frame for ~2.5s defeats the transcript's own post-load scroll-restoration (the original "1 of 1 but stuck at the bottom" bug); it bails the instant you scroll, and tears down on close.

Manual ⌘F (find within the loaded view) is unchanged.

## Verification

- `pnpm --filter @pwragent/desktop typecheck` ✅, `pnpm lint:boundaries` ✅, adapter + thread-view + search-panel tests ✅.
- Drove a headed build with the exact reported case: searched a phrase buried deep in a long thread (`So we eliminated the repeated 90-second churn.`), clicked the result — the thread opened, ~15 archived pages paged in automatically, and the view landed **centered on the highlighted match** (find bar "1 of 1"). Renderer-console tracing confirmed the turn-id resolution and the centered hold.

## Notes

- For a match deep in a very long thread, the deep-link pages in older history to reach it (bounded by a 60-page safety cap). That's inherent to scrolling to an arbitrary message in a paginated transcript.
- A snippet whose text is split across markdown elements won't be found by the in-DOM text search; the `turnId` anchor still lets it stop paging and land on the turn (the text highlight is the part that can miss). Plain-prose matches (the common case) land reliably and highlighted.
- New adapter test covers `turnId` capture. No renderer test for the landing — it's scroll/pagination/rAF integration (CSS Highlight API + DOM layout + paging) that jsdom can't exercise; verified live instead.
