### PR TITLE
fix(desktop): reconstruct lists and style inline code on composer paste

### DIFF
--- a/apps/desktop/e2e/composer-markdown-paste.spec.ts
+++ b/apps/desktop/e2e/composer-markdown-paste.spec.ts
@@ -386,3 +386,151 @@ test("plain-text and text/html copies of one source paste to identical markdown"
   expect(html.value).toBe(plain.value);
   expect(plain.value).toBe(SOURCE_EXPECTED);
 });
+
+// --- Block reconstruction: lists and inline-code styling on paste ---
+//
+// A fence-less markdown paste (e.g. the "copy" button on a rendered transcript
+// message, which yields text/plain markdown only) used to bypass the markdown
+// parser entirely: bold/inline-code came back via paste rules, but `- item`
+// stayed literal text because ProseMirror's default paste has no block rules.
+// pastePlainMarkdownText now reroutes any paste carrying block markdown (a fence
+// OR a list) through buildMarkdownTiptapContent, so lists reconstruct too. The
+// HTML-authoritative guard still defers to the default paste when the clipboard
+// HTML already encodes the structure (a <pre>/<ul>/<ol>/<blockquote>/<hN>).
+
+async function pasteListAndReadValue(flavor: {
+  html?: string;
+  text: string;
+}): Promise<string | null> {
+  const fixture = await createPasteFixture();
+  const app = await launchElectronApp({ fixturePath: fixture.fixturePath });
+  try {
+    await openExistingThread(app);
+    const tiptapInput = app.window.getByTestId("composer-tiptap-input");
+    await app.window.getByRole("textbox", { name: "Reply" }).focus();
+    await pasteIntoReply(app.window, flavor);
+    // Wait for the list to render before snapshotting the serialized value.
+    await expect(
+      tiptapInput.locator(".composer-tiptap-input__editor > ul > li"),
+    ).toHaveCount(2);
+    return await tiptapInput.getAttribute("data-value");
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+}
+
+test("a pasted bullet list is reconstructed as a list (text/plain only)", async () => {
+  const fixture = await createPasteFixture();
+  const app = await launchElectronApp({ fixturePath: fixture.fixturePath });
+
+  try {
+    await openExistingThread(app);
+    const tiptapInput = app.window.getByTestId("composer-tiptap-input");
+    await app.window.getByRole("textbox", { name: "Reply" }).focus();
+
+    await pasteIntoReply(app.window, {
+      text: ["Here are the steps:", "", "- First item", "- Second item", "- Third item"].join("\n"),
+    });
+
+    await expect(
+      tiptapInput.locator(".composer-tiptap-input__editor > ul > li"),
+    ).toHaveCount(3);
+    await expect(tiptapInput).toHaveAttribute(
+      "data-value",
+      "Here are the steps:\n\n- First item\n- Second item\n- Third item",
+    );
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
+test("a pasted ordered list is reconstructed as a list (text/plain only)", async () => {
+  const fixture = await createPasteFixture();
+  const app = await launchElectronApp({ fixturePath: fixture.fixturePath });
+
+  try {
+    await openExistingThread(app);
+    const tiptapInput = app.window.getByTestId("composer-tiptap-input");
+    await app.window.getByRole("textbox", { name: "Reply" }).focus();
+
+    await pasteIntoReply(app.window, {
+      text: ["Order matters:", "", "1. Alpha", "2. Beta", "3. Gamma"].join("\n"),
+    });
+
+    await expect(
+      tiptapInput.locator(".composer-tiptap-input__editor > ol > li"),
+    ).toHaveCount(3);
+    await expect(tiptapInput).toHaveAttribute(
+      "data-value",
+      "Order matters:\n\n1. Alpha\n2. Beta\n3. Gamma",
+    );
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
+test("pasted inline code renders as a styled pill, not bare text", async () => {
+  const fixture = await createPasteFixture();
+  const app = await launchElectronApp({ fixturePath: fixture.fixturePath });
+
+  try {
+    await openExistingThread(app);
+    const tiptapInput = app.window.getByTestId("composer-tiptap-input");
+    await app.window.getByRole("textbox", { name: "Reply" }).focus();
+
+    // Bullet items that are entirely inline code (the shape of the real handoff
+    // messages). The list routes through the parser, which applies code marks.
+    await pasteIntoReply(app.window, {
+      text: [
+        "The cache hit log:",
+        "",
+        "- `Cache hit for: node-cache`",
+        "- `Cache restored successfully`",
+      ].join("\n"),
+    });
+
+    const editor = tiptapInput.locator(".composer-tiptap-input__editor");
+    await expect(editor.locator("> ul > li")).toHaveCount(2);
+
+    const code = editor.locator(":not(pre) > code").first();
+    await expect(code).toHaveText("Cache hit for: node-cache");
+    // The inline-code pill landed (border + non-transparent fill), unlike a bare
+    // browser <code> which has neither.
+    const pill = await code.evaluate((element) => {
+      const style = getComputedStyle(element);
+      return { background: style.backgroundColor, borderWidth: style.borderTopWidth };
+    });
+    expect(pill.borderWidth).toBe("1px");
+    expect(pill.background).not.toBe("rgba(0, 0, 0, 0)");
+    expect(pill.background).not.toBe("transparent");
+
+    // The marks round-trip back to backticks, and the list is preserved.
+    await expect(tiptapInput).toHaveAttribute(
+      "data-value",
+      "The cache hit log:\n\n- `Cache hit for: node-cache`\n- `Cache restored successfully`",
+    );
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
+test("a bullet list round-trips identically from text/plain and from list HTML", async () => {
+  const text = ["Steps:", "", "- First", "- Second"].join("\n");
+  const expected = "Steps:\n\n- First\n- Second";
+
+  // text/plain only → parser reconstructs the list.
+  const plain = await pasteListAndReadValue({ text });
+  // Rich HTML with a <ul> → the guard defers to the default paste, which
+  // reconstructs from the HTML. Either flavor must serialize to the same markdown.
+  const html = await pasteListAndReadValue({
+    html: "<p>Steps:</p><ul><li>First</li><li>Second</li></ul>",
+    text,
+  });
+
+  expect(plain).toBe(expected);
+  expect(html).toBe(plain);
+});

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -299,6 +299,15 @@ function isMarkdownBlockStart(line: string): boolean {
   );
 }
 
+// Does the text contain block-level markdown that `buildMarkdownTiptapContent`
+// reconstructs but ProseMirror's default paste does not? Inline marks
+// (bold/italic/code) are handled by paste rules, so a pure-prose paste does NOT
+// match here — only a fenced code block or a list does. This is the gate for
+// rerouting a paste through the markdown parser instead of the default path.
+function containsBlockMarkdown(text: string): boolean {
+  return text.split("\n").some((line) => isMarkdownBlockStart(line));
+}
+
 function isMarkdownSectionLabelLine(line: string): boolean {
   return /^[^\s].*:\s*$/.test(line);
 }
@@ -850,34 +859,40 @@ function pastePlainTextIntoActiveBlock(
   return false;
 }
 
-function pastePlainMarkdownWithFences(
+function pastePlainMarkdownText(
   editor: TiptapEditor,
   event: ClipboardEvent<HTMLDivElement>,
 ): boolean {
   const text = getPlainTextFromPaste(event);
-  if (!/^```[A-Za-z0-9_-]*\s*$/m.test(text)) {
+  // Only reroute through the markdown parser when the text carries block
+  // structure the default paste won't rebuild (fences, bullet/ordered lists).
+  // Pure prose — and inline-only markdown like **bold** / `code`, which paste
+  // rules already handle — stays on the default path so we don't disturb
+  // mid-sentence pastes.
+  if (!containsBlockMarkdown(text)) {
     return false;
   }
 
-  // HTML-authoritative paste: when the clipboard carries rich HTML that
-  // already represents a code block (a <pre>), defer to ProseMirror's default
-  // paste. It derives paragraph structure from the HTML — which disambiguates
-  // a single "\n" (soft break, same paragraph) from a real paragraph break —
-  // whereas rebuilding from text/plain alone would collapse paragraphs whenever
-  // the plain flavor flattens breaks to single newlines. A code fence must NOT
-  // change how prose paragraphs are parsed; it should only ensure a code block
-  // is formed, and the HTML already does that here.
+  // HTML-authoritative paste: when the clipboard carries rich HTML that already
+  // encodes this block structure (a <pre>, <ul>/<ol>, <blockquote>, or heading),
+  // defer to ProseMirror's default paste. It derives structure — and paragraph
+  // breaks — from the HTML, which disambiguates a single "\n" (soft break, same
+  // paragraph) from a real paragraph break, whereas rebuilding from text/plain
+  // alone would collapse paragraphs whenever the plain flavor flattens breaks to
+  // single newlines. The presence of block markdown must NOT change how prose is
+  // parsed; it should only ensure the block is formed, which the HTML does here.
   //
-  // We keep the custom fence parse (do NOT defer) only when text/plain is the
+  // We keep the custom parse (do NOT defer) only when text/plain is the
   // authoritative markdown source: either there is no usable HTML, or the HTML
-  // carries no <pre> at all (so the default paste would render the fence as
-  // literal prose). The <pre> test is a deliberately coarse presence heuristic,
-  // not a per-fence reconciliation: a multi-fence paste whose HTML happens to
-  // carry only some of those code blocks still defers wholesale. That is fine
-  // for the case this targets — one rendered message copied with both flavors —
-  // and is not meant to be a general fence/HTML merge.
+  // carries none of those block tags (so the default paste would flatten the
+  // list/fence to literal prose). The tag test is a deliberately coarse presence
+  // heuristic, not a per-block reconciliation; a mixed paste whose HTML encodes
+  // only some of the blocks still defers wholesale. That is fine for the case
+  // this targets — one rendered message copied with both flavors — and is not
+  // meant to be a general markdown/HTML merge. Note <p> alone does NOT count:
+  // bare paragraph HTML around a text/plain fence must still reach the parser.
   const html = event.clipboardData?.getData("text/html") ?? "";
-  if (html.trim().length > 0 && /<pre[\s>]/i.test(html)) {
+  if (html.trim().length > 0 && /<(?:pre|ul|ol|blockquote|h[1-6])[\s>]/i.test(html)) {
     return false;
   }
 
@@ -1581,7 +1596,7 @@ export const ComposerTiptapInput = forwardRef<
           return pastePlainTextIntoActiveBlock(
             currentEditor,
             event as unknown as ClipboardEvent<HTMLDivElement>,
-          ) || pastePlainMarkdownWithFences(
+          ) || pastePlainMarkdownText(
             currentEditor,
             event as unknown as ClipboardEvent<HTMLDivElement>,
           );

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -11759,6 +11759,20 @@ textarea,
   font: inherit;
 }
 
+/* Inline code pill — matches the transcript's `.transcript-message__code` so a
+ * pasted/typed `inline` span reads identically in the composer and the rendered
+ * message. Scoped to `:not(pre) > code` so it never restyles code blocks (whose
+ * <code> lives under <pre> and keeps `font: inherit` above). */
+.composer-tiptap-input__editor :not(pre) > code {
+  padding: 1px 6px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-panel-elevated);
+  font-family: var(--font-mono);
+  font-size: 0.92em;
+  overflow-wrap: anywhere;
+}
+
 .composer-tiptap-input__editor blockquote {
   margin: 0;
   padding-left: 10px;


### PR DESCRIPTION
## Summary

Follow-up to #803 (now merged). Completes the composer paste-fidelity round-trip: pasting a rendered transcript message (or its markdown) should look nearly identical in the composer.

- **Lists now reconstruct.** A fence-less markdown paste (e.g. a message copied as `text/plain` markdown) previously bypassed the markdown parser — `**bold**` / `` `code` `` came back via paste rules, but `- item` / `1. item` stayed literal text because ProseMirror's default paste has no block-level rules. Generalized `pastePlainMarkdownWithFences` → **`pastePlainMarkdownText`**: it reroutes any paste carrying block markdown (a fence **or** a list) through the existing `buildMarkdownTiptapContent`, which already builds bullet/ordered lists.
- **HTML-authoritative guard broadened in step.** It now defers to the default paste when the clipboard HTML already encodes the structure as `<pre>`/`<ul>`/`<ol>`/`<blockquote>`/`<hN>`. Bare `<p>` still does **not** count, so a `text/plain` fence wrapped in paragraph HTML still reaches the parser (preserves the merged #803 behavior — its 5 tests are unchanged and still green).
- **Inline code is now styled.** The composer had no inline-`code` rule — only `pre code` for code blocks — so an inline span rendered as bare monospace. Added a `:not(pre) > code` pill matching the transcript's `.transcript-message__code`, scoped so it never touches code blocks.
- **URLs intentionally stay plain text.** The composer disables links by design (locked by existing tests); URL text round-trips and linkifies in the transcript on send.

## Verification

- `composer-markdown-paste.spec.ts` → **9 tests, all passing** in real Electron:
  - the 5 paragraph-break tests from #803 — **unchanged, still green** (no regression from the broadened guard);
  - bullet-list reconstruction (text/plain only);
  - ordered-list reconstruction (text/plain only);
  - inline-code pill styling (asserts a `code` element with a 1px border and non-transparent fill);
  - a bullet list round-trips identically from text/plain **and** from list HTML (validates the broadened guard's deferral path).
- `pnpm --filter @pwragent/desktop typecheck` — clean.
- Rebuilt and re-ran on the current `main` base after rebasing off the merged #803.

## Notes

- Behavioral consequence worth a glance: a paste whose `text/plain` has a line starting with `- ` / `N. ` now becomes a list (previously literal text). This matches what the composer already does for **typed** and **value-set** content — the paste path was the lone inconsistency — so it's a consistency fix, not new ambiguity.
- Headings (`#`) and blockquotes (`>`) are **out of scope**: `buildMarkdownTiptapContent` doesn't build those nodes yet, so they'd render as literal text in the composer regardless of paste path. Left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)