### PR TITLE
fix(desktop): show single edit group metadata in sidebar

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
@@ -80,6 +80,13 @@ type EditedFileGroupListProps = {
   onOpenFile?: (absolutePath: string) => void;
   /** Scroll the transcript to a group's turn (clickable timestamp). */
   onScrollToTurn?: (turnId: string, turnTimeMs?: number) => void;
+  /**
+   * Keep the per-turn group header when there is only one group. The
+   * above-composer rail already carries the single-group summary in its outer
+   * header, but the sidebar Edits panel needs the group header for timestamp
+   * and git lifecycle metadata.
+   */
+  showSingleGroupHeader?: boolean;
 };
 
 const groupTimeFormatter = new Intl.DateTimeFormat(undefined, {
@@ -93,7 +100,8 @@ const groupTimeFormatter = new Intl.DateTimeFormat(undefined, {
  * Accumulated edited files, shared between the LiveWorkRail (above the
  * composer) and the context-rail Edits panel. With multiple turn
  * groups the user can flip between per-turn rounds and the flattened
- * per-file view; a single group renders as a plain file list.
+ * per-file view. A single group defaults to a plain file list unless the
+ * surface needs the group header metadata.
  */
 /**
  * Turn-groups shown in the "By turn" view before the rest collapse behind a
@@ -171,7 +179,7 @@ export function EditedFileGroupList(props: EditedFileGroupListProps) {
   }
 
   const content =
-    props.groups.length === 1 ? (
+    props.groups.length === 1 && !props.showSingleGroupHeader ? (
       <EditedFileList details={props.groups[0].details} />
     ) : (
       <div className="edited-file-groups">{renderGroupedOrFlat()}</div>

--- a/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
@@ -151,6 +151,9 @@ export function EditedFileViewToggle(props: {
 
 export function EditedFileGroupList(props: EditedFileGroupListProps) {
   const view = props.view ?? "turns";
+  const preserveSingleGroupHeader =
+    props.groups.length === 1 && props.showSingleGroupHeader;
+  const effectiveView = preserveSingleGroupHeader ? "turns" : view;
   const [showAllTurns, setShowAllTurns] = useState(false);
 
   // Union of gitignored paths across every resolved group, so a row in any
@@ -179,7 +182,7 @@ export function EditedFileGroupList(props: EditedFileGroupListProps) {
   }
 
   const content =
-    props.groups.length === 1 && !props.showSingleGroupHeader ? (
+    props.groups.length === 1 && !preserveSingleGroupHeader ? (
       <EditedFileList details={props.groups[0].details} />
     ) : (
       <div className="edited-file-groups">{renderGroupedOrFlat()}</div>
@@ -192,7 +195,7 @@ export function EditedFileGroupList(props: EditedFileGroupListProps) {
   );
 
   function renderGroupedOrFlat() {
-    return view === "turns" ? (
+    return effectiveView === "turns" ? (
         (() => {
           const visibleGroups = showAllTurns
             ? props.groups

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/EditsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/EditsPanel.tsx
@@ -72,6 +72,7 @@ export function EditsPanel(props: EditsPanelProps) {
             worktreeRoot={props.worktreeRoot}
             onOpenFile={props.onOpenFile}
             onScrollToTurn={props.onScrollToTurn}
+            showSingleGroupHeader
           />
         ) : (
           <p className="context-empty">

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/EditsPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/EditsPanel.test.tsx
@@ -1,21 +1,21 @@
 import "@testing-library/jest-dom/vitest";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { EditsPanel } from "../EditsPanel";
 import type { EditedFileGroup } from "../../edited-file-groups";
 
 afterEach(cleanup);
 
-function editedGroup(): EditedFileGroup {
+function editedGroup(n = 1): EditedFileGroup {
   return {
-    key: "turn-1",
-    turn: { id: "turn-1", completedAt: 1_718_000_000_000 },
+    key: `turn-${n}`,
+    turn: { id: `turn-${n}`, completedAt: 1_718_000_000_000 + n },
     details: [
       {
-        id: "detail-1",
+        id: `detail-${n}`,
         kind: "write",
-        label: "ipc.ts",
-        path: "/repo/apps/desktop/src/main/ipc.ts",
+        label: `file-${n}.ts`,
+        path: `/repo/apps/desktop/src/main/file-${n}.ts`,
         fileDiff: {
           kind: "update",
           diff: "@@ -1 +1 @@\n+hello\n",
@@ -31,24 +31,46 @@ function editedGroup(): EditedFileGroup {
   };
 }
 
+function renderEditsPanel(groups: EditedFileGroup[]) {
+  return (
+    <EditsPanel
+      groups={groups}
+      commitStatesByKey={{
+        "turn-1": {
+          committed: true,
+          commitSha: "a".repeat(40),
+          shortSha: "aaaaaaa",
+          pushed: true,
+        },
+      }}
+      dock="sidebar"
+      onDockChange={vi.fn()}
+      onScrollToTurn={vi.fn()}
+    />
+  );
+}
+
 describe("EditsPanel", () => {
   it("keeps the group header for a single edit history in the sidebar", () => {
-    render(
-      <EditsPanel
-        groups={[editedGroup()]}
-        commitStatesByKey={{
-          "turn-1": {
-            committed: true,
-            commitSha: "a".repeat(40),
-            shortSha: "aaaaaaa",
-            pushed: true,
-          },
-        }}
-        dock="sidebar"
-        onDockChange={vi.fn()}
-        onScrollToTurn={vi.fn()}
-      />,
-    );
+    render(renderEditsPanel([editedGroup()]));
+
+    expect(
+      screen.getByRole("button", { name: /Edited 1 file/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: /Scroll the transcript to this turn/,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("aaaaaaa")).toBeInTheDocument();
+    expect(screen.getByText("Pushed")).toBeInTheDocument();
+  });
+
+  it("keeps the single group header after the hidden view toggle was left on All files", () => {
+    const { rerender } = render(renderEditsPanel([editedGroup(2), editedGroup(1)]));
+
+    fireEvent.click(screen.getByRole("button", { name: "All files" }));
+    rerender(renderEditsPanel([editedGroup(1)]));
 
     expect(
       screen.getByRole("button", { name: /Edited 1 file/i }),

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/EditsPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/EditsPanel.test.tsx
@@ -1,0 +1,64 @@
+import "@testing-library/jest-dom/vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { EditsPanel } from "../EditsPanel";
+import type { EditedFileGroup } from "../../edited-file-groups";
+
+afterEach(cleanup);
+
+function editedGroup(): EditedFileGroup {
+  return {
+    key: "turn-1",
+    turn: { id: "turn-1", completedAt: 1_718_000_000_000 },
+    details: [
+      {
+        id: "detail-1",
+        kind: "write",
+        label: "ipc.ts",
+        path: "/repo/apps/desktop/src/main/ipc.ts",
+        fileDiff: {
+          kind: "update",
+          diff: "@@ -1 +1 @@\n+hello\n",
+          additions: 1,
+          removals: 0,
+        },
+      },
+    ],
+    summary: "Edited 1 file",
+    additions: 1,
+    removals: 0,
+    live: false,
+  };
+}
+
+describe("EditsPanel", () => {
+  it("keeps the group header for a single edit history in the sidebar", () => {
+    render(
+      <EditsPanel
+        groups={[editedGroup()]}
+        commitStatesByKey={{
+          "turn-1": {
+            committed: true,
+            commitSha: "a".repeat(40),
+            shortSha: "aaaaaaa",
+            pushed: true,
+          },
+        }}
+        dock="sidebar"
+        onDockChange={vi.fn()}
+        onScrollToTurn={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /Edited 1 file/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: /Scroll the transcript to this turn/,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("aaaaaaa")).toBeInTheDocument();
+    expect(screen.getByText("Pushed")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

The sidebar Edits panel now keeps the per-turn edit header even when a thread has only one edit history, so users still see when the edits happened and whether the edits were committed or pushed. The above-composer rail keeps its compact single-group rendering because its outer rail header already carries the summary.

A regression test covers the one-group sidebar path with the timestamp target, short commit SHA, and pushed badge present.

## Test Plan

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/EditsPanel.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/EditedFileGroupList.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
