### PR TITLE
fix(desktop): handle nested code fences consistently in composer paste

### DIFF
--- a/apps/desktop/e2e/composer-markdown-paste.spec.ts
+++ b/apps/desktop/e2e/composer-markdown-paste.spec.ts
@@ -534,3 +534,54 @@ test("a bullet list round-trips identically from text/plain and from list HTML",
   expect(plain).toBe(expected);
   expect(html).toBe(plain);
 });
+
+// --- Nested language fences: the composer must agree with the transcript ---
+//
+// An outer ``` block whose body is itself a ```lang block is "malformed"
+// markdown — CommonMark closes the outer block at the inner bare ```. The
+// transcript repairs this (repairNestedLanguageFences) and renders ONE block;
+// the composer used to parse it naively and split into two. Both surfaces now
+// share the repair, so a transcript message copied (raw text/plain) and pasted
+// back reconstructs identically. The value round-trips to itself: the serializer
+// re-emits the 3-backtick outer fence, which the parser repairs again.
+const NESTED_FENCE_MESSAGE = [
+  "Intro line.",
+  "",
+  "```",
+  "Some text.",
+  "",
+  "```ts",
+  "const value = 1;",
+  "```",
+  "```",
+  "",
+  "Outro line.",
+].join("\n");
+
+test("a pasted nested language fence stays one code block (matches the transcript)", async () => {
+  const fixture = await createPasteFixture();
+  const app = await launchElectronApp({ fixturePath: fixture.fixturePath });
+
+  try {
+    await openExistingThread(app);
+    const tiptapInput = app.window.getByTestId("composer-tiptap-input");
+    await app.window.getByRole("textbox", { name: "Reply" }).focus();
+
+    await pasteIntoReply(app.window, { text: NESTED_FENCE_MESSAGE });
+
+    const editor = tiptapInput.locator(".composer-tiptap-input__editor");
+    // The outer block stays ONE <pre>; the bug split it at the inner ``` close
+    // and opened a second, spurious block for the trailing text.
+    await expect(editor.locator("> pre")).toHaveCount(1);
+    // The inner ```ts fence survives as literal content of the outer block.
+    await expect(editor.locator("> pre")).toContainText("```ts");
+    await expect(editor.locator("> pre")).toContainText("const value = 1;");
+    // Text after the outer close stays outside the block, as a paragraph.
+    await expect(editor.locator("> p", { hasText: "Outro line." })).toHaveCount(1);
+    // Stable, lossless round-trip.
+    await expect(tiptapInput).toHaveAttribute("data-value", NESTED_FENCE_MESSAGE);
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});

--- a/apps/desktop/e2e/composer-markdown-paste.spec.ts
+++ b/apps/desktop/e2e/composer-markdown-paste.spec.ts
@@ -585,3 +585,68 @@ test("a pasted nested language fence stays one code block (matches the transcrip
     await fixture.cleanup();
   }
 });
+
+// --- Backfill: paste-fidelity gaps surfaced in #809 review ---
+//
+// Two paths the #809 tests didn't exercise directly:
+//  (1) inline code in a PLAIN paragraph — the original report's shape, which
+//      rides ProseMirror's paste rules rather than buildMarkdownTiptapContent,
+//      so the pill CSS must apply to a <code> the parser never produced; and
+//  (2) a list pasted into a NON-empty composer — the realistic "typed an intro,
+//      then pasted a list" flow, where the block must append rather than land
+//      as literal "- " text.
+
+test("pasted inline code in a plain paragraph (paste-rule path) renders as a styled pill", async () => {
+  const fixture = await createPasteFixture();
+  const app = await launchElectronApp({ fixturePath: fixture.fixturePath });
+
+  try {
+    await openExistingThread(app);
+    const tiptapInput = app.window.getByTestId("composer-tiptap-input");
+    await app.window.getByRole("textbox", { name: "Reply" }).focus();
+
+    // No block markdown: this does NOT route through the markdown parser; the
+    // code mark comes from ProseMirror's inline paste rules. The pill must still
+    // land (the original complaint was inline code in prose looking like bare text).
+    await pasteIntoReply(app.window, { text: "Run `pnpm install` then build." });
+
+    const code = tiptapInput.locator(".composer-tiptap-input__editor :not(pre) > code").first();
+    await expect(code).toHaveText("pnpm install");
+    const pill = await code.evaluate((element) => {
+      const style = getComputedStyle(element);
+      return { background: style.backgroundColor, borderWidth: style.borderTopWidth };
+    });
+    expect(pill.borderWidth).toBe("1px");
+    expect(pill.background).not.toBe("rgba(0, 0, 0, 0)");
+    expect(pill.background).not.toBe("transparent");
+
+    await expect(tiptapInput).toHaveAttribute("data-value", "Run `pnpm install` then build.");
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
+test("a list pasted after existing composer text appends as a real list", async () => {
+  const fixture = await createPasteFixture();
+  const app = await launchElectronApp({ fixturePath: fixture.fixturePath });
+
+  try {
+    await openExistingThread(app);
+    const tiptapInput = app.window.getByTestId("composer-tiptap-input");
+    await app.window.getByRole("textbox", { name: "Reply" }).focus();
+
+    // Existing content first, cursor left at the end — a paste into a NON-empty
+    // composer, unlike the other tests which paste into an empty one.
+    await app.window.keyboard.type("My intro");
+    await pasteIntoReply(app.window, { text: ["- First", "- Second"].join("\n") });
+
+    await expect(
+      tiptapInput.locator(".composer-tiptap-input__editor > ul > li"),
+    ).toHaveCount(2);
+    await expect(tiptapInput).toHaveAttribute("data-value", "My intro\n\n- First\n- Second");
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -16,6 +16,10 @@ import StarterKit from "@tiptap/starter-kit";
 import { closeHistory } from "prosemirror-history";
 import { EditorContent, useEditor, type JSONContent } from "@tiptap/react";
 import type { AppServerSkillSummary } from "@pwragent/shared";
+import {
+  parseBacktickFenceLine,
+  repairNestedLanguageFences,
+} from "../../lib/markdown-fences";
 import { buildSkillTooltip, findSkillTrigger } from "../../lib/skill-mentions";
 import type {
   ComposerInputChangeMetadata,
@@ -279,10 +283,6 @@ function parseInlineMarkdownWithMarks(
   return nodes;
 }
 
-function matchMarkdownCodeFence(line: string): RegExpMatchArray | null {
-  return line.match(/^```([A-Za-z0-9_-]*)\s*$/);
-}
-
 function matchMarkdownOrderedListItem(line: string): RegExpMatchArray | null {
   return line.match(/^\s{0,3}(\d+)\.\s+(.+)$/);
 }
@@ -293,7 +293,7 @@ function matchMarkdownBulletListItem(line: string): RegExpMatchArray | null {
 
 function isMarkdownBlockStart(line: string): boolean {
   return (
-    matchMarkdownCodeFence(line) !== null ||
+    parseBacktickFenceLine(line) !== undefined ||
     matchMarkdownOrderedListItem(line) !== null ||
     matchMarkdownBulletListItem(line) !== null
   );
@@ -379,17 +379,32 @@ function buildTiptapContent(
 }
 
 function buildMarkdownTiptapContent(value: string): JSONContent {
-  const lines = value.replace(/\r\n/g, "\n").split("\n");
+  // Repair malformed nested language fences the same way the transcript renderer
+  // does, so a pasted code block that contains an inner ```lang fence parses
+  // into ONE code block on both surfaces instead of splitting at the inner close.
+  const lines = repairNestedLanguageFences(value.replace(/\r\n/g, "\n")).split("\n");
   const content: JSONContent[] = [];
   let index = 0;
 
   while (index < lines.length) {
     const line = lines[index] ?? "";
-    const codeFence = matchMarkdownCodeFence(line);
-    if (codeFence) {
+    const openFence = parseBacktickFenceLine(line);
+    if (openFence) {
       index += 1;
       const codeLines: string[] = [];
-      while (index < lines.length && !/^```\s*$/.test(lines[index] ?? "")) {
+      while (index < lines.length) {
+        const closeFence = parseBacktickFenceLine(lines[index] ?? "");
+        // A closing fence has at least as many backticks as the opener and no
+        // info string. A shorter fence, or one carrying a language, is body
+        // content — this is what keeps an inner ```ts inside a repaired outer
+        // ```` block rather than ending the block early.
+        if (
+          closeFence &&
+          closeFence.length >= openFence.length &&
+          closeFence.info === ""
+        ) {
+          break;
+        }
         codeLines.push(lines[index] ?? "");
         index += 1;
       }
@@ -398,7 +413,7 @@ function buildMarkdownTiptapContent(value: string): JSONContent {
       }
       content.push({
         type: "codeBlock",
-        attrs: { language: codeFence[1] || null },
+        attrs: { language: openFence.info.split(/\s+/)[0] || null },
         content: codeLines.length > 0
           ? [{ type: "text", text: codeLines.join("\n") }]
           : undefined,

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
@@ -7,6 +7,7 @@ import ReactMarkdown, { type Components, type UrlTransform } from "react-markdow
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 import type { DesktopApi } from "../../lib/desktop-api";
+import { repairNestedLanguageFences } from "../../lib/markdown-fences";
 import { SkillChip } from "../composer/SkillChip";
 import { remarkTableProfile } from "./remark-table-profile";
 import { TranscriptCopyButton } from "./TranscriptCopyButton";
@@ -395,98 +396,6 @@ function denormalizeMarkdownUrl(url: string): string {
   }
 
   return url;
-}
-
-type BacktickFenceLine = {
-  carriageReturn: string;
-  indent: string;
-  info: string;
-  length: number;
-};
-
-function parseBacktickFenceLine(line: string): BacktickFenceLine | undefined {
-  const match = /^( {0,3})(`{3,})([^`\r\n]*?)[ \t]*(\r?)$/.exec(line);
-  if (!match) {
-    return undefined;
-  }
-
-  return {
-    carriageReturn: match[4] ?? "",
-    indent: match[1] ?? "",
-    info: (match[3] ?? "").trim(),
-    length: match[2]?.length ?? 0,
-  };
-}
-
-function replaceBacktickFenceLine(line: string, length: number): string {
-  const parsed = parseBacktickFenceLine(line);
-  if (!parsed) {
-    return line;
-  }
-
-  const info = parsed.info ? parsed.info : "";
-  return `${parsed.indent}${"`".repeat(length)}${info}${parsed.carriageReturn}`;
-}
-
-function repairNestedLanguageFences(markdown: string): string {
-  if (!markdown.includes("```")) {
-    return markdown;
-  }
-
-  const lines = markdown.split("\n");
-  let changed = false;
-
-  for (let index = 0; index < lines.length; index += 1) {
-    const opening = parseBacktickFenceLine(lines[index] ?? "");
-    if (!opening) {
-      continue;
-    }
-
-    let closeIndex = -1;
-    let depth = 1;
-    let maxFenceLength = opening.length;
-    let sawNestedLanguageFence = false;
-
-    for (let scanIndex = index + 1; scanIndex < lines.length; scanIndex += 1) {
-      const fence = parseBacktickFenceLine(lines[scanIndex] ?? "");
-      if (!fence) {
-        continue;
-      }
-
-      maxFenceLength = Math.max(maxFenceLength, fence.length);
-
-      if (fence.info) {
-        sawNestedLanguageFence = true;
-        depth += 1;
-        continue;
-      }
-
-      if (depth > 1) {
-        depth -= 1;
-        continue;
-      }
-
-      if (sawNestedLanguageFence) {
-        closeIndex = scanIndex;
-      }
-      break;
-    }
-
-    if (closeIndex === -1) {
-      continue;
-    }
-
-    const repairedFenceLength = maxFenceLength + 1;
-    lines[index] = replaceBacktickFenceLine(lines[index] ?? "", repairedFenceLength);
-    lines[closeIndex] = replaceBacktickFenceLine(
-      lines[closeIndex] ?? "",
-      repairedFenceLength
-    );
-    changed = true;
-    index = closeIndex;
-  }
-
-  return changed ? lines.join("\n") : markdown;
 }
 
 function stripFileLineSuffix(filePath: string): string {

--- a/apps/desktop/src/renderer/src/lib/__tests__/markdown-fences.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/markdown-fences.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseBacktickFenceLine,
+  repairNestedLanguageFences,
+} from "../markdown-fences";
+
+describe("parseBacktickFenceLine", () => {
+  it("parses an opening fence with a language", () => {
+    expect(parseBacktickFenceLine("```ts")).toMatchObject({ length: 3, info: "ts" });
+  });
+
+  it("parses a longer bare fence", () => {
+    expect(parseBacktickFenceLine("````")).toMatchObject({ length: 4, info: "" });
+  });
+
+  it("rejects non-fence lines and short runs", () => {
+    expect(parseBacktickFenceLine("not a fence")).toBeUndefined();
+    expect(parseBacktickFenceLine("`` two")).toBeUndefined();
+  });
+});
+
+describe("repairNestedLanguageFences", () => {
+  it("lengthens the outer fence around a nested language fence", () => {
+    const input = ["```", "```ts", "const value = 1;", "```", "```"].join("\n");
+    const expected = ["````", "```ts", "const value = 1;", "```", "````"].join("\n");
+    expect(repairNestedLanguageFences(input)).toBe(expected);
+  });
+
+  it("leaves a well-formed single code block untouched", () => {
+    const input = ["```ts", "const value = 1;", "```"].join("\n");
+    expect(repairNestedLanguageFences(input)).toBe(input);
+  });
+
+  it("leaves nested BARE fences untouched (only a nested language fence triggers a repair)", () => {
+    const input = ["```", "```", "```"].join("\n");
+    expect(repairNestedLanguageFences(input)).toBe(input);
+  });
+
+  it("returns text with no fences unchanged", () => {
+    const input = "Just prose.\n\nMore prose.";
+    expect(repairNestedLanguageFences(input)).toBe(input);
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/markdown-fences.ts
+++ b/apps/desktop/src/renderer/src/lib/markdown-fences.ts
@@ -1,0 +1,107 @@
+// Shared fenced-code-block helpers. Both the transcript renderer
+// (`ThreadMarkdown`) and the composer's markdown parser
+// (`ComposerTiptapInput`) use these so a nested code fence is interpreted the
+// SAME way on display and on paste — otherwise the two surfaces disagree about
+// where an outer block ends (see the "nested code block rendering" bug).
+
+export type BacktickFenceLine = {
+  carriageReturn: string;
+  indent: string;
+  info: string;
+  length: number;
+};
+
+// Parse a line as an opening/closing backtick fence (3+ backticks, up to 3
+// spaces of indent, an optional info string). Returns undefined for non-fence
+// lines. Variable length matters: a closing fence must be at least as long as
+// its opener, which is what lets a 3-backtick fence live inside a 4-backtick one.
+export function parseBacktickFenceLine(line: string): BacktickFenceLine | undefined {
+  const match = /^( {0,3})(`{3,})([^`\r\n]*?)[ \t]*(\r?)$/.exec(line);
+  if (!match) {
+    return undefined;
+  }
+
+  return {
+    carriageReturn: match[4] ?? "",
+    indent: match[1] ?? "",
+    info: (match[3] ?? "").trim(),
+    length: match[2]?.length ?? 0,
+  };
+}
+
+export function replaceBacktickFenceLine(line: string, length: number): string {
+  const parsed = parseBacktickFenceLine(line);
+  if (!parsed) {
+    return line;
+  }
+
+  const info = parsed.info ? parsed.info : "";
+  return `${parsed.indent}${"`".repeat(length)}${info}${parsed.carriageReturn}`;
+}
+
+// Repair the "malformed nested code fence" pattern: an outer fence with no info
+// string that contains an inner fence WITH a language (e.g. a ``` block whose
+// body is itself a ```ts block). Markdown would close the outer block at the
+// inner fence's bare close; we instead lengthen the outer open + its real close
+// so the inner fence is preserved as content. Only fires when a nested
+// language fence was actually seen, so well-formed blocks pass through untouched.
+export function repairNestedLanguageFences(markdown: string): string {
+  if (!markdown.includes("```")) {
+    return markdown;
+  }
+
+  const lines = markdown.split("\n");
+  let changed = false;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const opening = parseBacktickFenceLine(lines[index] ?? "");
+    if (!opening) {
+      continue;
+    }
+
+    let closeIndex = -1;
+    let depth = 1;
+    let maxFenceLength = opening.length;
+    let sawNestedLanguageFence = false;
+
+    for (let scanIndex = index + 1; scanIndex < lines.length; scanIndex += 1) {
+      const fence = parseBacktickFenceLine(lines[scanIndex] ?? "");
+      if (!fence) {
+        continue;
+      }
+
+      maxFenceLength = Math.max(maxFenceLength, fence.length);
+
+      if (fence.info) {
+        sawNestedLanguageFence = true;
+        depth += 1;
+        continue;
+      }
+
+      if (depth > 1) {
+        depth -= 1;
+        continue;
+      }
+
+      if (sawNestedLanguageFence) {
+        closeIndex = scanIndex;
+      }
+      break;
+    }
+
+    if (closeIndex === -1) {
+      continue;
+    }
+
+    const repairedFenceLength = maxFenceLength + 1;
+    lines[index] = replaceBacktickFenceLine(lines[index] ?? "", repairedFenceLength);
+    lines[closeIndex] = replaceBacktickFenceLine(
+      lines[closeIndex] ?? "",
+      repairedFenceLength,
+    );
+    changed = true;
+    index = closeIndex;
+  }
+
+  return changed ? lines.join("\n") : markdown;
+}


### PR DESCRIPTION
## Summary

Composer paste-fidelity fix (follow-up to #803/#809, both merged). Rebased onto `main` — base is now `main`, diff is just this change.

Copying a transcript message that wraps an inner ```` ```lang ```` block inside an outer ```` ``` ```` block, then pasting it back into the composer, **split the outer block at the inner bare ``` close** — two blocks, mangled trailing text. The transcript renders it as **one** block because it runs `repairNestedLanguageFences` (#772); the composer's parser didn't — so the surfaces disagreed.

Two divergences had to be closed:
1. The composer never applied the nested-fence repair.
2. Even with the repair, it lengthens the outer fence to 4 backticks — which the composer's *exactly-3-backtick* matcher wouldn't recognize.

Fix — make both surfaces share one implementation:
- Extracted `repairNestedLanguageFences` + `parseBacktickFenceLine` into `src/renderer/src/lib/markdown-fences.ts` (verbatim from `ThreadMarkdown`, which now imports it — **transcript behavior unchanged**).
- Apply the repair in the composer's `buildMarkdownTiptapContent`.
- Upgrade fence matching to **variable length**: opener 3+ backticks; closer ≥ opener length with no info string. `isMarkdownBlockStart` uses the same parser so paragraph collection and the paste trigger agree.

The value round-trips to itself: the serializer re-emits the 3-backtick outer fence, which the parser repairs again next parse.

> **Behavior note:** swapping the exactly-3-backtick matcher for `parseBacktickFenceLine` makes composer fence detection more CommonMark-aligned — indented fences (0–3 spaces), multi-word info strings, and 4+ backtick fences now register. More correct; low regression risk (full suite green). Multi-word info is reduced to its first token for the `language` attr.

## Verification

- `lib/__tests__/markdown-fences.ts` unit test (7 cases) locks the shared contract.
- `composer-markdown-paste.spec.ts` → **12 E2E tests** (real Electron), all green:
  - the nested-fence case (one `<pre>`, inner ```` ```ts ```` preserved as content, trailing text outside, stable round-trip);
  - **2 backfill tests from the #809 review** (commit 2): inline code in a *plain paragraph* (paste-rule path, not the parser) renders the pill; a list pasted into a *non-empty* composer appends as a real list;
  - plus the 9 inherited list / inline-code / paragraph-break / convergence tests.
- Transcript `thread-markdown` tests (24) and the 157 composer unit tests — unchanged, green.
- `typecheck` clean; `lint:boundaries` clean (915 modules).

## Commits

1. `fix(desktop): handle nested code fences consistently in composer paste`
2. `test(desktop): backfill composer paste-fidelity coverage from #809 review` — test-only

## Notes

- The shared module imports nothing internal; both consumers reach it via a renderer-relative path → no dependency-boundary impact.
- Out of scope (unchanged on both surfaces): the composer still doesn't build heading/blockquote nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)