### PR TITLE
fix(desktop): count merged PR commits as pushed

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -196,7 +196,12 @@ type WorkingStateEntry = {
   };
 };
 const readWorktreeWorkingStateEntries = vi.fn(
-  (worktreePaths: string[]): AsyncGenerator<WorkingStateEntry> =>
+  (
+    worktreePaths: string[],
+    _options?: {
+      acceptedPushedCommitShasByWorktreePath?: Record<string, string[] | undefined>;
+    },
+  ): AsyncGenerator<WorkingStateEntry> =>
     (async function* () {
       for (const worktreePath of worktreePaths) {
         yield { worktreePath } satisfies WorkingStateEntry;
@@ -2765,6 +2770,50 @@ describe("app server ipc", () => {
           gitWorkingState,
         }),
       },
+    });
+  });
+
+  it("passes merged PR commit SHAs into working-state probes", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+    const mergedPrSha = "a".repeat(40);
+
+    listThreads.mockResolvedValueOnce([
+      {
+        id: "thread-1",
+        title: "Thread one",
+        titleSource: "explicit",
+        source: "codex",
+        projectKey: "/repo/wt",
+        linkedDirectories: [],
+        updatedAt: 2000,
+        prs: [
+          githubPr({
+            number: 806,
+            org: "pwrdrvr",
+            repo: "PwrAgent",
+            title: "PR canonical info store",
+            state: "passing",
+            lifecycleState: "merged",
+            url: "https://github.com/pwrdrvr/PwrAgent/pull/806",
+            commitShas: [mergedPrSha],
+          }),
+        ],
+      },
+    ] as never);
+
+    registerAppServerIpcHandlers();
+    await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
+
+    await vi.waitFor(() => {
+      expect(readWorktreeWorkingStateEntries).toHaveBeenCalledWith(
+        ["/repo/wt"],
+        {
+          acceptedPushedCommitShasByWorktreePath: {
+            "/repo/wt": [mergedPrSha],
+          },
+        },
+      );
     });
   });
 

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -2863,6 +2863,128 @@ describe("app server ipc", () => {
     ]);
   });
 
+  it("refreshes a thread's working state after its expected branch changes", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+
+    listThreads.mockResolvedValueOnce([
+      {
+        id: "thread-1",
+        title: "Thread one",
+        titleSource: "explicit",
+        source: "codex",
+        projectKey: "/repo/wt",
+        linkedDirectories: [],
+        updatedAt: 2000,
+      },
+    ] as never);
+
+    registerAppServerIpcHandlers();
+    await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
+    await vi.waitFor(() => {
+      expect(writeThreadGitWorkingStateCacheEntry).toHaveBeenCalled();
+    });
+    const callsAfterSnapshot = readWorktreeWorkingStateEntries.mock.calls.length;
+
+    emitRegistryEvent({
+      backend: "codex",
+      notification: {
+        method: "thread/branch/updated",
+        params: {
+          threadId: "thread-1",
+          branch: "fix/new-branch",
+        },
+      },
+    });
+
+    expect(invalidateWorktreeWorkingState).toHaveBeenCalledWith("/repo/wt");
+    await vi.waitFor(() => {
+      expect(readWorktreeWorkingStateEntries.mock.calls.length).toBe(
+        callsAfterSnapshot + 1,
+      );
+    });
+    expect(readWorktreeWorkingStateEntries.mock.calls.at(-1)?.[0]).toEqual([
+      "/repo/wt",
+    ]);
+  });
+
+  it("refreshes pull requests for the rendered branch when a turn completes", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+    const discoveredPr = githubPr({
+      number: 813,
+      org: "pwrdrvr",
+      repo: "PwrAgent",
+      title: "Count merged PR commits as pushed",
+      state: "pending",
+      url: "https://github.com/pwrdrvr/PwrAgent/pull/813",
+    });
+
+    listThreads.mockResolvedValueOnce([
+      {
+        id: "thread-1",
+        title: "Thread one",
+        titleSource: "explicit",
+        source: "codex",
+        projectKey: "/repo/wt",
+        linkedDirectories: [
+          {
+            id: "directory:/repo/app",
+            label: "app",
+            path: "/repo/app",
+            kind: "worktree",
+            worktreePath: "/repo/wt",
+          },
+        ],
+        gitBranch: "fix/merged-pr-commits-pushed",
+        observedGitBranch: "fix/merged-pr-commits-pushed",
+        updatedAt: 2000,
+      },
+    ] as never);
+    detectPullRequestsForThread.mockResolvedValueOnce([discoveredPr]);
+
+    registerAppServerIpcHandlers();
+    await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
+    await vi.waitFor(() => {
+      expect(writeThreadGitWorkingStateCacheEntry).toHaveBeenCalled();
+    });
+    detectPullRequestsForThread.mockClear();
+
+    emitRegistryEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "t1",
+          turn: { id: "t1", status: "completed" },
+        },
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(detectPullRequestsForThread).toHaveBeenCalledWith({
+        fetcher: expect.any(Object),
+        branch: "fix/merged-pr-commits-pushed",
+        directoryPaths: ["/repo/wt"],
+      });
+    });
+    await vi.waitFor(() => {
+      expect(setThreadPullRequests).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        prs: [discoveredPr],
+        fetchedAt: expect.any(Number),
+        refreshKey: buildThreadPrRequestKey({
+          backend: "codex",
+          threadId: "thread-1",
+          branch: "fix/merged-pr-commits-pushed",
+          directoryPaths: ["/repo/wt"],
+        }),
+      });
+    });
+  });
+
   it("ignores a completed non-git command for working-state refresh", async () => {
     const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
     const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -2985,6 +2985,84 @@ describe("app server ipc", () => {
     });
   });
 
+  it("refreshes post-turn pull requests for an adopted branch instead of stale snapshot context", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+    const discoveredPr = githubPr({
+      number: 814,
+      org: "pwrdrvr",
+      repo: "PwrAgent",
+      title: "Refresh adopted branch PRs",
+      state: "pending",
+      url: "https://github.com/pwrdrvr/PwrAgent/pull/814",
+    });
+
+    listThreads.mockResolvedValueOnce([
+      {
+        id: "thread-1",
+        title: "Thread one",
+        titleSource: "explicit",
+        source: "codex",
+        projectKey: "/repo/wt",
+        linkedDirectories: [
+          {
+            id: "directory:/repo/app",
+            label: "app",
+            path: "/repo/app",
+            kind: "worktree",
+            worktreePath: "/repo/wt",
+          },
+        ],
+        gitBranch: "fix/old-branch",
+        observedGitBranch: "fix/old-branch",
+        updatedAt: 2000,
+      },
+    ] as never);
+    detectPullRequestsForThread.mockResolvedValueOnce([discoveredPr]);
+
+    registerAppServerIpcHandlers();
+    await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
+    await vi.waitFor(() => {
+      expect(writeThreadGitWorkingStateCacheEntry).toHaveBeenCalled();
+    });
+    detectPullRequestsForThread.mockClear();
+
+    emitRegistryEvent({
+      backend: "codex",
+      notification: {
+        method: "thread/branch/updated",
+        params: {
+          threadId: "thread-1",
+          branch: "fix/adopted-branch",
+        },
+      },
+    });
+    emitRegistryEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "t1",
+          turn: { id: "t1", status: "completed" },
+        },
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(detectPullRequestsForThread).toHaveBeenCalledWith({
+        fetcher: expect.any(Object),
+        branch: "fix/adopted-branch",
+        directoryPaths: ["/repo/wt"],
+      });
+    });
+    expect(detectPullRequestsForThread).not.toHaveBeenCalledWith({
+      fetcher: expect.any(Object),
+      branch: "fix/old-branch",
+      directoryPaths: ["/repo/wt"],
+    });
+  });
+
   it("ignores a completed non-git command for working-state refresh", async () => {
     const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
     const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -16838,7 +16838,9 @@ command = "pnpm dev"
     });
 
     let overlayDuringTerminalEvent: ThreadOverlayState | undefined;
+    const eventMethods: string[] = [];
     registry.onEvent(async (event) => {
+      eventMethods.push(event.notification.method);
       if (event.notification.method !== "turn/completed") {
         return;
       }
@@ -16881,6 +16883,11 @@ command = "pnpm dev"
         gitBranch: "fix/queued-review-release",
         observedGitBranch: "fix/queued-review-release",
       });
+      expect(eventMethods).toEqual([
+        "turn/started",
+        "thread/branch/updated",
+        "turn/completed",
+      ]);
       expect(codexClient.lastUpdateThreadMetadataParams).toEqual({
         threadId: "thread-branch",
         gitInfo: {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -16893,6 +16893,45 @@ command = "pnpm dev"
     }
   });
 
+  it("notifies listeners when the renderer adopts a new expected branch", async () => {
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/metadata/update"] },
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+    const events: AgentEvent[] = [];
+    const unsubscribe = registry.onEvent((event) => {
+      events.push(event);
+    });
+
+    try {
+      await registry.updateThreadExpectedBranch({
+        backend: "codex",
+        threadId: "thread-branch",
+        branch: "fix/new-branch",
+      });
+
+      expect(events).toContainEqual({
+        backend: "codex",
+        notification: {
+          method: "thread/branch/updated",
+          params: {
+            threadId: "thread-branch",
+            branch: "fix/new-branch",
+          },
+        },
+      });
+    } finally {
+      unsubscribe();
+      await registry.close();
+    }
+  });
+
   it("does not persist a retained branch drift pair when expected branch is HEAD", async () => {
     const overlayStore = createOverlayStoreMock({
       overlays: {

--- a/apps/desktop/src/main/__tests__/git-working-state-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-working-state-service.test.ts
@@ -79,6 +79,26 @@ describe("probeWorktreeWorkingState", () => {
     expect(calls.some((call) => call.args.includes("rev-list"))).toBe(false);
   });
 
+  it("does not count commits attached to merged PRs as unpushed", async () => {
+    const mergedPrSha = "a".repeat(40);
+    const localOnlySha = "b".repeat(40);
+    const { runGit } = fakeGit((args) => {
+      if (args.includes("--numstat")) return "";
+      if (args.includes("status")) return "";
+      if (args[args.length - 1] === "remote") return "origin\n";
+      if (args.includes("rev-list") && args.includes("--count")) return "2\n";
+      if (args.includes("rev-list")) return `${mergedPrSha}\n${localOnlySha}\n`;
+      return undefined;
+    });
+
+    const state = await probeWorktreeWorkingState("/repo/wt", {
+      runGit,
+      acceptedPushedCommitShas: [mergedPrSha],
+    });
+
+    expect(state?.unpushedCommits).toBe(1);
+  });
+
   it("returns undefined when the directory is not a git checkout", async () => {
     const { runGit } = fakeGit(() => undefined);
     expect(await probeWorktreeWorkingState("/not/a/repo", { runGit })).toBeUndefined();
@@ -252,6 +272,32 @@ describe("GitWorkingStateService.resolveEditCommitStates", () => {
     expect(states["g-b"]).toMatchObject({ committed: true, pushed: true });
     expect(states["g-b2"]).toMatchObject({ committed: true, pushed: true });
     expect(calls.filter((call) => call.args.includes("rev-list"))).toHaveLength(1);
+  });
+
+  it("treats commits attached to merged PRs as pushed even when no remote ref contains them", async () => {
+    const mergedPrSha = "d".repeat(40);
+    const responder = (args: string[]): string | undefined => {
+      if (args.includes("diff") && args.includes("--name-only")) return "";
+      if (args.includes("ls-files")) return "";
+      if (args.includes("check-ignore")) return "";
+      if (args.includes("log")) return `${mergedPrSha}\n`;
+      if (args.includes("rev-list")) return `${mergedPrSha}\n`;
+      return undefined;
+    };
+    const { runGit } = fakeGit(responder);
+    const service = new GitWorkingStateService({ runGit });
+
+    const states = await service.resolveEditCommitStates(
+      "/repo/wt",
+      [{ key: "g-merged", paths: ["/repo/wt/src/merged.ts"] }],
+      { acceptedPushedCommitShas: [mergedPrSha] },
+    );
+
+    expect(states["g-merged"]).toMatchObject({
+      committed: true,
+      commitSha: mergedPrSha,
+      pushed: true,
+    });
   });
 
   it("returns an empty map for no worktree or no groups", async () => {

--- a/apps/desktop/src/main/__tests__/github-pr-fetcher.test.ts
+++ b/apps/desktop/src/main/__tests__/github-pr-fetcher.test.ts
@@ -22,6 +22,10 @@ function rawMergedPr() {
     mergeable: "MERGEABLE",
     mergeStateStatus: "CLEAN",
     mergedAt: "2026-05-05T00:06:31Z",
+    commits: [
+      { oid: "a".repeat(40) },
+      { oid: "b".repeat(40) },
+    ],
     headRefName: "feat/desktop-thread-reactions-and-pr-chips",
     headRepository: { name: "PwrAgent" },
     headRepositoryOwner: { login: "pwrdrvr" },
@@ -49,6 +53,7 @@ describe("parseGhPrPayload", () => {
       lifecycleState: "merged",
       reviewState: "ready_for_review",
       mergeState: "unknown",
+      commitShas: ["a".repeat(40), "b".repeat(40)],
       url: "https://github.com/pwrdrvr/PwrAgent/pull/178",
     });
   });
@@ -394,6 +399,7 @@ describe("GithubPrFetcher", () => {
           lifecycleState: "merged",
           reviewState: "ready_for_review",
           mergeState: "unknown",
+          commitShas: ["a".repeat(40), "b".repeat(40)],
           url: "https://github.com/pwrdrvr/PwrAgent/pull/178",
         },
       ]);
@@ -443,6 +449,7 @@ describe("GithubPrFetcher", () => {
         lifecycleState: "merged",
         reviewState: "ready_for_review",
         mergeState: "unknown",
+        commitShas: ["a".repeat(40), "b".repeat(40)],
         url: "https://github.com/pwrdrvr/PwrAgent/pull/178",
       });
       expect(exec).toHaveBeenCalledWith("/tmp/repo", [

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -7523,6 +7523,18 @@ export class DesktopBackendRegistry {
       threadId: params.threadId,
       branch: normalizedObservedBranch,
     });
+    if (previousExpectedBranch !== normalizedObservedBranch) {
+      await this.emit({
+        backend: params.backend,
+        notification: {
+          method: "thread/branch/updated",
+          params: {
+            threadId: params.threadId,
+            branch: normalizedObservedBranch,
+          },
+        },
+      } as unknown as AgentEvent);
+    }
 
     if (previousExpectedBranch !== normalizedObservedBranch) {
       backendRegistryLog.info("adopted active-turn branch change", {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -221,7 +221,11 @@ import { createReplayClientsFromEnv } from "../testing/replay-runtime";
 import { GitDirectoryService } from "./git-directory-service";
 import type { DirectoryGitStatusEntry } from "./git-directory-service";
 import { GitWorkingStateService } from "./git-working-state-service";
-import type { WorktreeWorkingStateEntry } from "./git-working-state-service";
+import type {
+  GitWorkingStateEntryOptions,
+  ResolveEditCommitStatesOptions,
+  WorktreeWorkingStateEntry,
+} from "./git-working-state-service";
 import { resolveWorktreeRepositoryDirectory } from "./thread-directory-enricher";
 import { GitWorkspaceHandoffService } from "./git-workspace-handoff-service";
 import { WorktreeArchiveService } from "./worktree-archive-service";
@@ -5262,8 +5266,9 @@ export class DesktopBackendRegistry {
 
   readWorktreeWorkingStateEntries(
     worktreePaths: string[],
+    options?: GitWorkingStateEntryOptions,
   ): AsyncIterable<WorktreeWorkingStateEntry> {
-    return this.gitWorkingStateService.readWorkingStateEntries(worktreePaths);
+    return this.gitWorkingStateService.readWorkingStateEntries(worktreePaths, options);
   }
 
   invalidateWorktreeWorkingState(worktreePath?: string): void {
@@ -5273,10 +5278,12 @@ export class DesktopBackendRegistry {
   async resolveEditCommitStates(
     worktreePath: string,
     groups: EditGroupCommitInput[],
+    options?: ResolveEditCommitStatesOptions,
   ): Promise<Record<string, EditGroupCommitState>> {
     return await this.gitWorkingStateService.resolveEditCommitStates(
       worktreePath,
       groups,
+      options,
     );
   }
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -7553,6 +7553,16 @@ export class DesktopBackendRegistry {
       threadId: params.threadId,
       branch,
     });
+    await this.emit({
+      backend: params.backend,
+      notification: {
+        method: "thread/branch/updated",
+        params: {
+          threadId: params.threadId,
+          branch,
+        },
+      },
+    } as unknown as AgentEvent);
 
     backendRegistryLog.info("updated thread expected branch", {
       backend: params.backend,

--- a/apps/desktop/src/main/app-server/git-working-state-service.ts
+++ b/apps/desktop/src/main/app-server/git-working-state-service.ts
@@ -20,6 +20,30 @@ type GitCommandRunner = (
   env?: NodeJS.ProcessEnv,
 ) => Promise<string>;
 
+type AcceptedPushedCommitOptions = {
+  acceptedPushedCommitShas?: string[];
+};
+
+function buildAcceptedPushedCommitSet(
+  commitShas: string[] | undefined,
+): Set<string> {
+  return new Set(
+    (commitShas ?? [])
+      .map((sha) => sha.trim().toLowerCase())
+      .filter((sha) => /^[0-9a-f]{40}$/.test(sha)),
+  );
+}
+
+function buildWorkingStateCacheKey(
+  worktreePath: string,
+  acceptedPushedCommitShas: string[] | undefined,
+): string {
+  const accepted = [...buildAcceptedPushedCommitSet(acceptedPushedCommitShas)]
+    .sort()
+    .join(",");
+  return accepted ? `${worktreePath}\0${accepted}` : worktreePath;
+}
+
 async function defaultRunGit(
   cwd: string,
   args: string[],
@@ -65,7 +89,10 @@ function parseNumstat(output: string): {
  */
 export async function probeWorktreeWorkingState(
   worktreePath: string,
-  options: { runGit?: GitCommandRunner; gitEnv?: NodeJS.ProcessEnv } = {},
+  options: {
+    runGit?: GitCommandRunner;
+    gitEnv?: NodeJS.ProcessEnv;
+  } & AcceptedPushedCommitOptions = {},
 ): Promise<ThreadGitWorkingState | undefined> {
   const runGit = options.runGit ?? defaultRunGit;
   const gitEnv = options.gitEnv;
@@ -93,14 +120,33 @@ export async function probeWorktreeWorkingState(
   // local-only repo, so report 0 instead.
   let unpushedCommits = 0;
   if (remotesOutput?.trim()) {
-    const count = await runGitNoLocks([
-      "rev-list",
-      "--count",
-      "HEAD",
-      "--not",
-      "--remotes",
-    ]).catch(() => undefined);
-    unpushedCommits = count !== undefined ? Number(count) || 0 : 0;
+    const acceptedPushedCommitShas = buildAcceptedPushedCommitSet(
+      options.acceptedPushedCommitShas,
+    );
+    if (acceptedPushedCommitShas.size > 0) {
+      const output = await runGitNoLocks([
+        "rev-list",
+        "HEAD",
+        "--not",
+        "--remotes",
+      ]).catch(() => undefined);
+      unpushedCommits = output === undefined
+        ? 0
+        : output
+          .split("\n")
+          .map((sha) => sha.trim().toLowerCase())
+          .filter((sha) => sha && !acceptedPushedCommitShas.has(sha))
+          .length;
+    } else {
+      const count = await runGitNoLocks([
+        "rev-list",
+        "--count",
+        "HEAD",
+        "--not",
+        "--remotes",
+      ]).catch(() => undefined);
+      unpushedCommits = count !== undefined ? Number(count) || 0 : 0;
+    }
   }
 
   return {
@@ -116,6 +162,12 @@ export type WorktreeWorkingStateEntry = {
   worktreePath: string;
   gitWorkingState?: ThreadGitWorkingState;
 };
+
+export type GitWorkingStateEntryOptions = {
+  acceptedPushedCommitShasByWorktreePath?: Record<string, string[] | undefined>;
+};
+
+export type ResolveEditCommitStatesOptions = AcceptedPushedCommitOptions;
 
 type CachedWorkingState = {
   expiresAt: number;
@@ -158,12 +210,16 @@ export class GitWorkingStateService {
 
   readWorkingStateEntries(
     worktreePaths: string[],
+    options: GitWorkingStateEntryOptions = {},
   ): AsyncIterable<WorktreeWorkingStateEntry> {
     return new IterableMapper(
       worktreePaths,
       async (worktreePath): Promise<WorktreeWorkingStateEntry> => ({
         worktreePath,
-        gitWorkingState: await this.readWorkingState(worktreePath),
+        gitWorkingState: await this.readWorkingState(worktreePath, {
+          acceptedPushedCommitShas:
+            options.acceptedPushedCommitShasByWorktreePath?.[worktreePath],
+        }),
       }),
       {
         concurrency: this.concurrency,
@@ -174,14 +230,16 @@ export class GitWorkingStateService {
 
   async readWorkingState(
     worktreePath: string,
+    options: AcceptedPushedCommitOptions = {},
   ): Promise<ThreadGitWorkingState | undefined> {
     const key = worktreePath?.trim();
     if (!key) {
       return undefined;
     }
+    const cacheKey = buildWorkingStateCacheKey(key, options.acceptedPushedCommitShas);
 
     const now = Date.now();
-    const cached = this.cache.get(key);
+    const cached = this.cache.get(cacheKey);
     if (cached?.inFlight) {
       return await cached.inFlight;
     }
@@ -192,17 +250,18 @@ export class GitWorkingStateService {
     const inFlight = probeWorktreeWorkingState(key, {
       runGit: this.runGit,
       gitEnv: this.gitEnv,
+      acceptedPushedCommitShas: options.acceptedPushedCommitShas,
     })
       .then((value) => {
-        this.cache.set(key, { expiresAt: Date.now() + this.cacheTtlMs, value });
+        this.cache.set(cacheKey, { expiresAt: Date.now() + this.cacheTtlMs, value });
         return value;
       })
       .catch((error) => {
-        this.cache.delete(key);
+        this.cache.delete(cacheKey);
         throw error;
       });
 
-    this.cache.set(key, {
+    this.cache.set(cacheKey, {
       expiresAt: cached?.expiresAt ?? 0,
       inFlight,
       value: cached?.value,
@@ -216,7 +275,11 @@ export class GitWorkingStateService {
     if (!key) {
       return;
     }
-    this.cache.delete(key);
+    for (const cacheKey of this.cache.keys()) {
+      if (cacheKey === key || cacheKey.startsWith(`${key}\0`)) {
+        this.cache.delete(cacheKey);
+      }
+    }
   }
 
   /**
@@ -230,6 +293,7 @@ export class GitWorkingStateService {
   async resolveEditCommitStates(
     worktreePath: string,
     groups: EditGroupCommitInput[],
+    options: ResolveEditCommitStatesOptions = {},
   ): Promise<Record<string, EditGroupCommitState>> {
     const cwd = worktreePath?.trim();
     const states: Record<string, EditGroupCommitState> = {};
@@ -240,6 +304,9 @@ export class GitWorkingStateService {
     const gitEnv = this.gitEnv;
     const noLocks = (args: string[]): Promise<string> =>
       this.runGit(cwd, ["--no-optional-locks", ...args], gitEnv);
+    const acceptedPushedCommitShas = buildAcceptedPushedCommitSet(
+      options.acceptedPushedCommitShas,
+    );
 
     // The set of files that still have working-tree changes (tracked diffs vs
     // HEAD + untracked). Clean newline-separated relative paths — easier to
@@ -293,6 +360,11 @@ export class GitWorkingStateService {
       const existing = pushedBySha.get(sha);
       if (existing) {
         return existing;
+      }
+      if (acceptedPushedCommitShas.has(sha.trim().toLowerCase())) {
+        const promise = Promise.resolve(true);
+        pushedBySha.set(sha, promise);
+        return promise;
       }
       // `rev-list -1 <sha> --not --remotes` lists sha only when it (or its
       // tip) isn't reachable from any remote ref. Empty ⇒ pushed. With no

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1565,6 +1565,7 @@ class DesktopAppServerService {
     }
 
     const params = event.notification.params as {
+      branch?: string;
       threadId?: string;
       item?: { command?: string };
     };
@@ -1583,6 +1584,17 @@ class DesktopAppServerService {
     }
 
     const threadKey = buildThreadIdentityKey(event.backend, threadId);
+    if (method === "thread/branch/updated") {
+      const branch = params.branch?.trim();
+      const existingContext = this.prRefreshContextByThreadKey.get(threadKey);
+      if (branch && existingContext) {
+        this.prRefreshContextByThreadKey.set(threadKey, {
+          ...existingContext,
+          branch,
+        });
+      }
+    }
+
     const worktreePath = this.worktreePathByThreadKey.get(threadKey);
     if (worktreePath) {
       getDesktopBackendRegistry().invalidateWorktreeWorkingState(worktreePath);

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -410,7 +410,19 @@ function normalizePrSummary(pr: PrSummary): PrSummary {
     lifecycleState: pr.lifecycleState ?? legacyPrLifecycleState(pr.state),
     reviewState: pr.reviewState ?? legacyPrReviewState(pr.state),
     mergeState: pr.mergeState ?? "unknown",
+    commitShas: normalizeCommitShas(pr.commitShas),
   };
+}
+
+function normalizeCommitShas(commitShas: string[] | undefined): string[] | undefined {
+  const normalized = [
+    ...new Set(
+      (commitShas ?? [])
+        .map((sha) => sha.trim().toLowerCase())
+        .filter((sha) => /^[0-9a-f]{40}$/.test(sha)),
+    ),
+  ].sort();
+  return normalized.length > 0 ? normalized : undefined;
 }
 
 function dedupePrsByStatusKey(prs: PrSummary[]): PrSummary[] {
@@ -477,6 +489,7 @@ function prSummariesEqual(left: PrSummary[], right: PrSummary[]): boolean {
       candidate.lifecycleState === pr.lifecycleState &&
       candidate.reviewState === pr.reviewState &&
       candidate.mergeState === pr.mergeState &&
+      JSON.stringify(candidate.commitShas ?? []) === JSON.stringify(pr.commitShas ?? []) &&
       candidate.url === pr.url
     );
   });
@@ -586,6 +599,12 @@ class DesktopAppServerService {
   // a turn/command-completion event can refresh the right worktree's chips
   // without re-reading the navigation snapshot. Populated on every snapshot.
   private readonly worktreePathByThreadKey = new Map<string, string>();
+  // Merged PR commits are accepted as "pushed" even when the PR head branch
+  // has been deleted and no remote ref still contains those SHAs locally.
+  private readonly mergedPrCommitShasByThread = new Map<
+    string,
+    { worktreePath: string; commitShas: Set<string> }
+  >();
   private threadSearchService: ThreadSearchService | null = null;
   private threadMigrationService: ThreadMigrationService | null = null;
   // Parent of the most recently picked directory, used as the "Add directory"
@@ -940,6 +959,7 @@ class DesktopAppServerService {
 
     await this.loadThreadGitWorkingStateCache();
     this.rememberThreadWorktreePaths(canonicalSnapshot.threads);
+    this.rememberMergedPrCommitShas(canonicalSnapshot.threads);
     const threadsWithWorkingState = canonicalSnapshot.threads.map((thread) =>
       this.applyCachedWorktreeWorkingState(thread),
     );
@@ -960,12 +980,16 @@ class DesktopAppServerService {
   async resolveEditCommitStates(
     request: ResolveEditCommitStatesRequest,
   ): Promise<ResolveEditCommitStatesResponse> {
+    const acceptedPushedCommitShas = this.getMergedPrCommitShasForWorktree(
+      request.worktreePath,
+    );
     // Coalesce identical in-flight requests (same worktree + groups) so an
     // overlapping renderer re-resolve doesn't spawn a second git burst — they
     // share one result.
     const requestKey = JSON.stringify({
       worktreePath: request.worktreePath,
       groups: request.groups,
+      acceptedPushedCommitShas,
     });
     const pending = this.pendingEditCommitResolves.get(requestKey);
     if (pending) {
@@ -973,7 +997,9 @@ class DesktopAppServerService {
     }
 
     const promise = getDesktopBackendRegistry()
-      .resolveEditCommitStates(request.worktreePath, request.groups)
+      .resolveEditCommitStates(request.worktreePath, request.groups, {
+        acceptedPushedCommitShas,
+      })
       .then((states) => ({ states }));
     this.pendingEditCommitResolves.set(requestKey, promise);
     try {
@@ -1008,6 +1034,66 @@ class DesktopAppServerService {
         this.worktreePathByThreadKey.delete(threadKey);
       }
     }
+  }
+
+  private rememberMergedPrCommitShas(
+    threads: NavigationSnapshot["threads"],
+  ): void {
+    for (const thread of threads) {
+      this.rememberMergedPrCommitShasForThread({
+        backend: thread.source,
+        threadId: thread.id,
+        worktreePath: thread.projectKey,
+        prs: thread.prs ?? [],
+      });
+    }
+  }
+
+  private rememberMergedPrCommitShasForThread(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    worktreePath?: string;
+    prs: PrSummary[];
+  }): string | undefined {
+    const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+    const worktreePath = params.worktreePath?.trim()
+      || this.worktreePathByThreadKey.get(threadKey);
+    if (!worktreePath) {
+      this.mergedPrCommitShasByThread.delete(threadKey);
+      return undefined;
+    }
+    const commitShas = this.extractMergedPrCommitShas(params.prs);
+    if (commitShas.length === 0) {
+      this.mergedPrCommitShasByThread.delete(threadKey);
+      return worktreePath;
+    }
+    this.mergedPrCommitShasByThread.set(threadKey, {
+      worktreePath,
+      commitShas: new Set(commitShas),
+    });
+    return worktreePath;
+  }
+
+  private extractMergedPrCommitShas(
+    prs: PrSummary[] | undefined,
+  ): string[] {
+    return (prs ?? [])
+      .filter((pr) => pr.lifecycleState === "merged" || pr.state === "merged")
+      .flatMap((pr) => normalizeCommitShas(pr.commitShas) ?? []);
+  }
+
+  private getMergedPrCommitShasForWorktree(worktreePath: string): string[] {
+    const accepted = new Set<string>();
+    const normalizedWorktreePath = worktreePath.trim();
+    for (const entry of this.mergedPrCommitShasByThread.values()) {
+      if (entry.worktreePath !== normalizedWorktreePath) {
+        continue;
+      }
+      for (const sha of entry.commitShas) {
+        accepted.add(sha);
+      }
+    }
+    return [...accepted];
   }
 
   private applyCachedWorktreeWorkingState(
@@ -1373,6 +1459,14 @@ class DesktopAppServerService {
 
     for await (const entry of getDesktopBackendRegistry().readWorktreeWorkingStateEntries(
       refreshable,
+      {
+        acceptedPushedCommitShasByWorktreePath: Object.fromEntries(
+          refreshable.map((worktreePath) => [
+            worktreePath,
+            this.getMergedPrCommitShasForWorktree(worktreePath),
+          ]),
+        ),
+      },
     )) {
       await this.writeWorktreeWorkingStateEntry({
         worktreePath: entry.worktreePath,
@@ -2075,6 +2169,17 @@ class DesktopAppServerService {
     threadId: string;
     prs: PrSummary[];
   }): Promise<void> {
+    const worktreePath = this.rememberMergedPrCommitShasForThread(params);
+    if (worktreePath) {
+      getDesktopBackendRegistry().invalidateWorktreeWorkingState(worktreePath);
+      void this.loadThreadGitWorkingStateCache().then(() => {
+        this.startWorktreeWorkingStateRefresh({
+          automatic: false,
+          worktreePaths: [worktreePath],
+          force: true,
+        });
+      });
+    }
     await getDesktopBackendRegistry().publishLocalEvent({
       backend: params.backend,
       notification: {

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -599,6 +599,15 @@ class DesktopAppServerService {
   // a turn/command-completion event can refresh the right worktree's chips
   // without re-reading the navigation snapshot. Populated on every snapshot.
   private readonly worktreePathByThreadKey = new Map<string, string>();
+  private readonly prRefreshContextByThreadKey = new Map<
+    string,
+    {
+      backend: AppServerBackendKind;
+      threadId: string;
+      branch: string;
+      directoryPaths: string[];
+    }
+  >();
   // Merged PR commits are accepted as "pushed" even when the PR head branch
   // has been deleted and no remote ref still contains those SHAs locally.
   private readonly mergedPrCommitShasByThread = new Map<
@@ -959,6 +968,7 @@ class DesktopAppServerService {
 
     await this.loadThreadGitWorkingStateCache();
     this.rememberThreadWorktreePaths(canonicalSnapshot.threads);
+    this.rememberThreadPrRefreshContexts(canonicalSnapshot.threads);
     this.rememberMergedPrCommitShas(canonicalSnapshot.threads);
     const threadsWithWorkingState = canonicalSnapshot.threads.map((thread) =>
       this.applyCachedWorktreeWorkingState(thread),
@@ -1033,6 +1043,27 @@ class DesktopAppServerService {
       } else {
         this.worktreePathByThreadKey.delete(threadKey);
       }
+    }
+  }
+
+  private rememberThreadPrRefreshContexts(
+    threads: NavigationSnapshot["threads"],
+  ): void {
+    for (const thread of threads) {
+      const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+      const branch =
+        thread.observedGitBranch?.trim() || thread.gitBranch?.trim() || "";
+      const directoryPaths = resolveThreadPullRequestDirectoryPaths(thread);
+      if (!branch || directoryPaths.length === 0) {
+        this.prRefreshContextByThreadKey.delete(threadKey);
+        continue;
+      }
+      this.prRefreshContextByThreadKey.set(threadKey, {
+        backend: thread.source,
+        threadId: thread.id,
+        branch,
+        directoryPaths,
+      });
     }
   }
 
@@ -1527,7 +1558,8 @@ class DesktopAppServerService {
       method !== "turn/completed" &&
       method !== "turn/failed" &&
       method !== "turn/cancelled" &&
-      method !== "item/completed"
+      method !== "item/completed" &&
+      method !== "thread/branch/updated"
     ) {
       return;
     }
@@ -1542,7 +1574,7 @@ class DesktopAppServerService {
     }
 
     // A command item only matters here when it mutated git state; a turn
-    // ending always warrants a re-probe (it may have committed/edited).
+    // ending or expected-branch adoption always warrants a re-probe.
     if (method === "item/completed") {
       const command = params.item?.command;
       if (!command || !commandLooksLikeGitMutation(command)) {
@@ -1552,18 +1584,32 @@ class DesktopAppServerService {
 
     const threadKey = buildThreadIdentityKey(event.backend, threadId);
     const worktreePath = this.worktreePathByThreadKey.get(threadKey);
-    if (!worktreePath) {
-      return;
+    if (worktreePath) {
+      getDesktopBackendRegistry().invalidateWorktreeWorkingState(worktreePath);
+      void this.loadThreadGitWorkingStateCache().then(() => {
+        this.startWorktreeWorkingStateRefresh({
+          automatic: false,
+          worktreePaths: [worktreePath],
+          force: true,
+        });
+      });
     }
 
-    getDesktopBackendRegistry().invalidateWorktreeWorkingState(worktreePath);
-    void this.loadThreadGitWorkingStateCache().then(() => {
-      this.startWorktreeWorkingStateRefresh({
-        automatic: false,
-        worktreePaths: [worktreePath],
-        force: true,
-      });
-    });
+    if (method === "turn/completed") {
+      const prContext = this.prRefreshContextByThreadKey.get(threadKey);
+      if (prContext) {
+        void this.refreshThreadPullRequests({
+          ...prContext,
+          provider: "github.com",
+          trigger: "post-turn",
+        }).catch((error) => {
+          appServerLog.warn("post-turn PR refresh failed", {
+            threadId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        });
+      }
+    }
   }
 
   async markThreadSeen(
@@ -1694,6 +1740,7 @@ class DesktopAppServerService {
       allExistingPrsTerminal
       && branch !== "HEAD"
       && request.trigger !== "user"
+      && request.trigger !== "post-turn"
     ) {
       return {
         backend,
@@ -1983,7 +2030,9 @@ class DesktopAppServerService {
   ): string | undefined {
     const now = Date.now();
     const minInterval =
-      trigger === "user"
+      trigger === "post-turn"
+        ? 0
+        : trigger === "user"
         ? terminalOnly
           ? TERMINAL_USER_THREAD_PR_REFRESH_MIN_INTERVAL_MS
           : USER_THREAD_PR_REFRESH_MIN_INTERVAL_MS
@@ -2706,6 +2755,7 @@ class DesktopAppServerService {
     this.workingStateCacheLoaded = false;
     this.automaticWorktreeWorkingStateRefreshesStarted = 0;
     this.worktreePathByThreadKey.clear();
+    this.prRefreshContextByThreadKey.clear();
     await this.threadMigrationService?.dispose();
     this.threadMigrationService = null;
     await disposeDesktopBackendRegistry();
@@ -2752,6 +2802,26 @@ function isFreshWorktreeWorkingStateCacheEntry(
   entry: WorktreeGitWorkingStateCacheEntry,
 ): boolean {
   return Date.now() - entry.fetchedAt < WORKTREE_WORKING_STATE_CACHE_MAX_AGE_MS;
+}
+
+function resolveThreadPullRequestDirectoryPaths(
+  thread: NavigationSnapshot["threads"][number],
+): string[] {
+  const seen = new Set<string>();
+  const paths: string[] = [];
+  for (const directory of thread.linkedDirectories ?? []) {
+    const candidate =
+      directory.kind === "worktree"
+        ? directory.worktreePath ?? directory.path
+        : directory.path;
+    const normalized = candidate?.trim();
+    if (!normalized || seen.has(normalized)) {
+      continue;
+    }
+    seen.add(normalized);
+    paths.push(normalized);
+  }
+  return paths;
 }
 
 /**

--- a/apps/desktop/src/main/pr-status/github-pr-fetcher.ts
+++ b/apps/desktop/src/main/pr-status/github-pr-fetcher.ts
@@ -28,6 +28,7 @@ const GH_FIELDS = [
   "mergeable",
   "mergeStateStatus",
   "mergedAt",
+  "commits",
   "headRefName",
   "headRepository",
   "headRepositoryOwner",
@@ -64,6 +65,7 @@ type GhPrPayload = {
   mergeable?: string | null;
   mergeStateStatus?: string | null;
   mergedAt: string | null;
+  commits?: { oid?: string | null }[] | null;
   headRefName: string;
   headRepository: { name?: string } | null;
   headRepositoryOwner: { login?: string } | null;
@@ -428,8 +430,22 @@ export function parseGhPrPayload(row: GhPrPayload): PrSummary {
     lifecycleState: deriveLifecycleState(row),
     reviewState: deriveReviewState(row),
     mergeState: deriveMergeState(row),
+    ...parseCommitShas(row),
     url: row.url,
   };
+}
+
+function parseCommitShas(
+  row: Pick<GhPrPayload, "commits">,
+): Pick<PrSummary, "commitShas"> {
+  const commitShas = [
+    ...new Set(
+      (row.commits ?? [])
+        .map((commit) => commit.oid?.trim().toLowerCase())
+        .filter((oid): oid is string => Boolean(oid && /^[0-9a-f]{40}$/.test(oid))),
+    ),
+  ].sort();
+  return commitShas.length > 0 ? { commitShas } : {};
 }
 
 function parsePullRequestProvider(url: string): string {

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -84,7 +84,19 @@ function normalizePrSummary(pr: PrSummary): PrSummary {
     lifecycleState: pr.lifecycleState ?? legacyPrLifecycleState(pr.state),
     reviewState: pr.reviewState ?? legacyPrReviewState(pr.state),
     mergeState: pr.mergeState ?? "unknown",
+    commitShas: normalizeCommitShas(pr.commitShas),
   };
+}
+
+function normalizeCommitShas(commitShas: string[] | undefined): string[] | undefined {
+  const normalized = [
+    ...new Set(
+      (commitShas ?? [])
+        .map((sha) => sha.trim().toLowerCase())
+        .filter((sha) => /^[0-9a-f]{40}$/.test(sha)),
+    ),
+  ].sort();
+  return normalized.length > 0 ? normalized : undefined;
 }
 
 function normalizePrCheckState(

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -465,6 +465,7 @@ function prSummariesEqual(
       candidate.lifecycleState === pr.lifecycleState &&
       candidate.reviewState === pr.reviewState &&
       candidate.mergeState === pr.mergeState &&
+      JSON.stringify(candidate.commitShas ?? []) === JSON.stringify(pr.commitShas ?? []) &&
       candidate.url === pr.url
     );
   });

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -829,8 +829,10 @@ export type RefreshThreadPullRequestsRequest = {
    * Refresh intent controls main-process coalescing. Scheduled polling is
    * rate-limited globally and per PR; direct user interaction gets a much
    * shorter per-PR cooldown and bypasses the global GitHub token bucket.
+   * Post-turn refreshes also bypass the scheduled bucket so a PR opened
+   * during a turn can appear as soon as the turn ends.
    */
-  trigger?: "scheduled" | "user";
+  trigger?: "scheduled" | "user" | "post-turn";
   /** Branch the renderer believes the thread is on. */
   branch: string;
   /**

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -234,6 +234,12 @@ export type PrSummary = {
   lifecycleState?: PrLifecycleState;
   reviewState?: PrReviewState;
   mergeState?: PrMergeState;
+  /**
+   * Commit OIDs attached to this PR when the provider returns them. Used to
+   * keep merged PR commits from reading as local-only after the remote head
+   * branch is deleted.
+   */
+  commitShas?: string[];
   url: string;
 };
 


### PR DESCRIPTION
## Summary

After a PR is merged and its head branch is deleted, thread rows no longer treat that PR's commits as local-only just because no remote branch still contains them. PR refreshes now persist the commit OIDs attached to each PR, and the working-state probes accept commits from merged PRs as pushed for both the sidebar unpushed count and edited-file commit badges.

The accepted commit set is derived in the app-server layer from merged PRs already attached to the thread, then passed into the generic git working-state service so the lower-level git probe does not need PR or overlay knowledge.

## Test Plan

- `pnpm test apps/desktop/src/main/__tests__/github-pr-fetcher.test.ts apps/desktop/src/main/__tests__/git-working-state-service.test.ts apps/desktop/src/main/__tests__/app-server-ipc.test.ts apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx packages/shared/src/contracts/__tests__/pull-request-status-key.test.ts`
- `pnpm typecheck`
- `pnpm lint:boundaries`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
