### PR TITLE
feat(desktop): close the search screen on Escape

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1060,6 +1060,16 @@ function DesktopAppShell(props: {
               history={historyNav}
               state={threadSearchState}
               threads={navigation.threads}
+              onClose={() => {
+                // Esc pops the search screen off the history stack (same as the
+                // title-bar Back button); if there's nowhere to go back to,
+                // just leave the search view.
+                if (history.canGoBack) {
+                  history.goBack();
+                } else {
+                  setMainView("thread");
+                }
+              }}
               onOpenResult={async (result) => {
                 // Deep-link to the match: open the thread with the find bar
                 // seeded with the search query so it highlights + scrolls the

--- a/apps/desktop/src/renderer/src/features/thread-search/ThreadSearchPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-search/ThreadSearchPanel.tsx
@@ -53,6 +53,12 @@ type ThreadSearchPanelProps = {
   }) => Promise<void> | void;
   onOpenMessagingActivity?: (platform?: MessagingChannelKind) => void;
   /**
+   * Close the search screen (Escape). App routes this to history back so it
+   * pops the search entry off the stack and returns to wherever you came from,
+   * matching the title-bar Back button. Fires even with a typed query.
+   */
+  onClose?: () => void;
+  /**
    * Window panel toggles + relocated masthead, threaded straight through to
    * the shared {@link ThreadPlaceholderHeader} so search wears the same title
    * bar as the thread view — the MSG status, the sidebar toggle, and the
@@ -257,7 +263,24 @@ export function ThreadSearchPanel(props: ThreadSearchPanelProps) {
   const resultCount = response?.results.length ?? 0;
 
   return (
-    <section className="thread-view thread-search" aria-label="Thread search">
+    <section
+      className="thread-view thread-search"
+      aria-label="Thread search"
+      // Escape closes the search screen from anywhere inside it (the input is
+      // autofocused, so this catches the common "⌘⇧F then Esc" path, and still
+      // fires after typing). Scoped to the panel rather than a window listener
+      // so it won't also dismiss an overlay (e.g. the sidebar quick-search).
+      onKeyDown={(event) => {
+        if (
+          event.key === "Escape" &&
+          !event.defaultPrevented &&
+          props.onClose
+        ) {
+          event.preventDefault();
+          props.onClose();
+        }
+      }}
+    >
       <ThreadPlaceholderHeader
         desktopApi={props.desktopApi}
         title="Search"

--- a/apps/desktop/src/renderer/src/features/thread-search/__tests__/ThreadSearchPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-search/__tests__/ThreadSearchPanel.test.tsx
@@ -61,6 +61,17 @@ describe("ThreadSearchPanel", () => {
       });
     });
   });
+
+  it("closes on Escape, including after typing a query", () => {
+    const onClose = vi.fn();
+    render(<ThreadSearchPanel onOpenResult={vi.fn()} onClose={onClose} />);
+
+    const input = screen.getByLabelText("Search threads");
+    fireEvent.change(input, { target: { value: "still typing" } });
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("basename", () => {


### PR DESCRIPTION
## Summary

Feedback: pressing **Escape** on the global search screen (⌘⇧F) did nothing — it didn't close the screen or go back. Now Escape closes the search screen and goes **back one entry in the navigation stack**, matching the title-bar Back button.

- Works from anywhere inside the search screen (the search input is autofocused, so the common "⌘⇧F then Esc" path is covered).
- Works **even after typing a query** — a single Escape always closes; there's intentionally no "clear the field first" step (per the reported expectation).

## How it works

- **`ThreadSearchPanel`** gains an `onClose?` prop and an `onKeyDown` on its root `<section>`. Escape calls `onClose`. It's **panel-scoped** (not a window listener) so it can't also dismiss an unrelated overlay like the sidebar quick-search popup, and it's guarded by `!event.defaultPrevented` so a nested handler (e.g. a header popover) can claim Escape first.
- **`App`** routes `onClose` to `history.goBack()` when there's somewhere to go back to, otherwise falls back to `setMainView("thread")` so the screen always closes.

Using history-back (rather than the ⌘⇧F toggle) means it pops the search entry off the stack and returns you to where you came from, instead of pushing a duplicate forward entry.

## Verification

- `pnpm --filter @pwragent/desktop typecheck` ✅, `pnpm lint:boundaries` ✅.
- `ThreadSearchPanel` tests (10/10) ✅ — added a case asserting Escape calls `onClose` even with a typed query.

## Notes

- The `goBack` half mirrors the existing title-bar Back button, so it wasn't separately driven in a live build; the unit test covers the Esc→close wiring.
- No change to ⌘⇧F itself (still toggles search), to the in-thread ⌘F find bar, or to the sidebar quick-search popup.
