### PR TITLE
fix(desktop): vertically center the sub-thread toggle on the title line

### DIFF
--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -347,6 +347,13 @@
   top: 3px;
 }
 
+/* Mirror the .thread-row__actions compact shift for the sub-thread toggle:
+   compact rows pad 6px (vs 8px), so the title line — and the toggle that
+   centers on it — moves up 2px (9px -> 7px). */
+:root[data-density="compact"] .thread-row__subthread-toggle {
+  top: 7px;
+}
+
 :root[data-density="compact"] .thread-row:not(:has(.thread-row__chip--reaction)):not(:has(.thread-row__chip--pin)) {
   gap: 0;
 }
@@ -2656,7 +2663,13 @@ textarea,
 
 .thread-row__subthread-toggle {
   position: absolute;
-  top: 13px;
+  /* Center the toggle on the title's FIRST line, not the row's geometric
+     center — same anchoring as .thread-row__actions, whose 26px button is
+     topped at 5px so its midpoint lands on the ~18px title-line midpoint
+     (8px row padding-top + ~9px into the 15px/1.25 line box). The toggle is
+     18px tall, so top = 18 - 9 = 9. Compact density shifts this up 2px (see
+     the density-compact block) to track its 6px top padding. */
+  top: 9px;
   left: 8px;
   z-index: 4;
   display: grid;
@@ -3118,14 +3131,14 @@ textarea,
 }
 
 /* A card with sub-threads carries the expand/collapse toggle in its left
-   gutter (`.thread-row__subthread-toggle`, top: 13px / 18px tall → bottom
-   at 31px, left: 8px). The selection accent bar (`::before`, top: 8px,
+   gutter (`.thread-row__subthread-toggle`, top: 9px / 18px tall → bottom
+   at 27px, left: 8px). The selection accent bar (`::before`, top: 8px,
    left: 5px) otherwise starts level with the toggle and the two cluster
-   against the card border. Drop the bar's start below the toggle so it
+   against the card border. Drop the bar's start just below the toggle so it
    still telegraphs selection down the card's left edge without running
    into the chevron. */
 .thread-row-shell.has-subthreads .thread-row.is-selected::before {
-  top: 34px;
+  top: 30px;
 }
 
 .thread-row__header {


### PR DESCRIPTION
## Problem

The parent-card disclosure triangle in the sidebar (`.thread-row__subthread-toggle`) sits **too low** — it doesn't line up with the title text, most visibly in the collapsed (right-pointing ▶) state.

It's absolutely positioned at `top: 13px`. With an 18px-tall box that puts its **center at 22px** from the row top — but the title's first-line midpoint is at **~18px** (`8px` row padding-top + ~9px into the 15px/1.25 line box). So the triangle rides ~4px low.

## Fix

Anchor it to the title line exactly the way `.thread-row__actions` (the overflow/reaction buttons) already does. That element is a 26px button at `top: 5px` → midpoint **18px**, which its own comment documents as "the title's line midpoint."

- `top: 13px → 9px` — an 18px box at `top: 9px` centers at **18px**, on the title line.
- **New** compact-density override `top: 7px`, mirroring `.thread-row__actions`' `5px → 3px` compact shift. Compact rows pad `6px` instead of `8px`, so the title line (and the toggle centered on it) moves up 2px. The toggle previously had no density override, so it was misaligned in compact too.
- The toggle now bottoms at `27px` (was `31px`), so the coupled selection accent-bar start (`.thread-row-shell.has-subthreads .thread-row.is-selected::before`) drops `34px → 30px` to keep its original ~3px clearance below the toggle. Comments updated to match.

CSS-only; both the expanded (▼) and collapsed (▶) states share the same box, so both re-center. The filled-triangle shape/rotation is unchanged.

## Verification

- `chevron-contract.test.ts` (the disclosure-language contract from #795) still passes 21/21 — this change touches only `top`, not the triangle's borders/rotation.
- No test asserts the toggle's position.

⚠️ Visual confirmation worth a glance — the derivation lands the center at the title-line midpoint by construction, but it's a pixel calibration. I can launch `pnpm dev` and screenshot a parent row (collapsed + expanded) if you want it on record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)