### PR TITLE
feat(approvals): surface backend approval choices

### DIFF
--- a/apps/desktop/e2e/approval-pending.spec.ts
+++ b/apps/desktop/e2e/approval-pending.spec.ts
@@ -55,7 +55,7 @@ async function openApprovalPendingReplay() {
     app.window.getByText("Waiting for approval before this turn can continue.")
   ).toBeVisible();
   await expect(
-    app.window.getByRole("button", { name: "Approve" })
+    app.window.getByRole("button", { name: "Approve Once" })
   ).toBeVisible();
 
   return app;
@@ -79,7 +79,7 @@ test("shows pending approval UI without duplicating the turn elsewhere", async (
       app.window.getByText("Waiting for approval before this turn can continue.")
     ).toBeVisible();
     await expect(
-      app.window.getByRole("button", { name: "Approve" })
+      app.window.getByRole("button", { name: "Approve Once" })
     ).toBeVisible();
   } finally {
     await app.close();
@@ -90,7 +90,7 @@ test("dismisses the pending approval UI after approval", async () => {
   const app = await openApprovalPendingReplay();
 
   try {
-    await app.window.getByRole("button", { name: "Approve" }).click();
+    await app.window.getByRole("button", { name: "Approve Once" }).click();
 
     await expect(
       app.window.getByRole("group", { name: "Pending approval" })

--- a/apps/desktop/src/main/__tests__/messaging-approval-renderer.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-approval-renderer.test.ts
@@ -164,7 +164,7 @@ describe("buildApprovalIntent", () => {
       expect.objectContaining({
         id: "approval:accept_with_execpolicy_amendment:1",
         decision: "accept_with_execpolicy_amendment",
-        label: "Approve Prefix: pnpm test",
+        label: "Always Allow Prefix: pnpm test",
         response: { decision: structuredDecision },
       }),
       expect.objectContaining({

--- a/apps/desktop/src/main/__tests__/messaging-approval-renderer.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-approval-renderer.test.ts
@@ -101,13 +101,39 @@ describe("buildApprovalIntent", () => {
         label: "Approve Once",
         decision: "accept",
         fallbackText: "1",
+        response: { decision: "accept" },
       }),
       expect.objectContaining({
         label: "Cancel",
         decision: "cancel",
         fallbackText: "2",
+        response: { decision: "cancel" },
       }),
     ]);
+  });
+
+  it("advertises only replies backed by rendered command approval actions", () => {
+    const intent = buildApprovalIntent({
+      id: "approval-fallback",
+      createdAt: 1000,
+      request: {
+        method: "item/commandExecution/requestApproval",
+        params: {
+          threadId: "thread-1",
+          requestId: "request-fallback",
+          prompt: "Run tests?",
+        },
+      },
+    });
+
+    expect(intent.decisions).toEqual([
+      expect.objectContaining({ decision: "accept" }),
+      expect.objectContaining({ decision: "accept_for_session" }),
+      expect.objectContaining({ decision: "decline" }),
+      expect.objectContaining({ decision: "cancel" }),
+    ]);
+    expect(intent.body).toContain('"yes for this session"');
+    expect(intent.body).toContain('"no"');
   });
 
   it("renders structured backend decisions as generic approval actions", () => {
@@ -136,6 +162,7 @@ describe("buildApprovalIntent", () => {
         label: "Approve Once",
       }),
       expect.objectContaining({
+        id: "approval:accept_with_execpolicy_amendment:1",
         decision: "accept_with_execpolicy_amendment",
         label: "Approve Prefix: pnpm test",
         response: { decision: structuredDecision },

--- a/apps/desktop/src/main/__tests__/messaging-approval-renderer.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-approval-renderer.test.ts
@@ -14,6 +14,7 @@ describe("buildApprovalIntent", () => {
           requestId: "request-1",
           prompt: "Run the focused tests?",
           command: "/bin/zsh -lc 'pnpm test -- messaging-controller'",
+          availableDecisions: ["accept", "acceptForSession", "cancel"],
         },
       },
     });
@@ -29,6 +30,7 @@ describe("buildApprovalIntent", () => {
         expect.objectContaining({
           decision: "accept_for_session",
           fallbackText: "2",
+          response: { decision: "acceptForSession" },
         }),
       ]),
     });
@@ -104,6 +106,42 @@ describe("buildApprovalIntent", () => {
         label: "Cancel",
         decision: "cancel",
         fallbackText: "2",
+      }),
+    ]);
+  });
+
+  it("renders structured backend decisions as generic approval actions", () => {
+    const structuredDecision = {
+      acceptWithExecpolicyAmendment: {
+        execpolicy_amendment: ["pnpm", "test"],
+      },
+    };
+    const intent = buildApprovalIntent({
+      id: "approval-prefix",
+      createdAt: 1000,
+      request: {
+        method: "item/commandExecution/requestApproval",
+        params: {
+          threadId: "thread-1",
+          requestId: "request-prefix",
+          prompt: "Run tests?",
+          availableDecisions: ["accept", structuredDecision, "cancel"],
+        },
+      },
+    });
+
+    expect(intent.decisions).toEqual([
+      expect.objectContaining({
+        decision: "accept",
+        label: "Approve Once",
+      }),
+      expect.objectContaining({
+        decision: "accept_with_execpolicy_amendment",
+        label: "Approve Prefix: pnpm test",
+        response: { decision: structuredDecision },
+      }),
+      expect.objectContaining({
+        decision: "cancel",
       }),
     ]);
   });

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -9777,6 +9777,78 @@ describe("MessagingController", () => {
     });
   });
 
+  it("submits fallback command approvals for session from advertised text replies", async () => {
+    const harness = await createHarness();
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "bind:codex:thread-1",
+        value: {
+          backend: "codex",
+          threadId: "thread-1",
+        },
+      }),
+    );
+    await harness.controller.handleBackendPendingRequest("codex", {
+      method: "item/commandExecution/requestApproval",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        requestId: "approval-fallback",
+        prompt: "Run tests?",
+        command: "pnpm test",
+      },
+    });
+
+    await harness.controller.handleInboundEvent(buildTextEvent("yes for this session"));
+
+    expect(harness.submitServerRequest).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      turnId: "turn-1",
+      requestId: "approval-fallback",
+      response: {
+        decision: "accept_for_session",
+      },
+    });
+  });
+
+  it("submits normalized decisions for legacy display-string options", async () => {
+    const harness = await createHarness();
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "bind:codex:thread-1",
+        value: {
+          backend: "codex",
+          threadId: "thread-1",
+        },
+      }),
+    );
+    await harness.controller.handleBackendPendingRequest("codex", {
+      method: "turn/requestApproval",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        requestId: "approval-options",
+        prompt: "Run tests?",
+        options: ["Approve Once", "Cancel"],
+      },
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "approval:accept" }),
+    );
+
+    expect(harness.submitServerRequest).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      turnId: "turn-1",
+      requestId: "approval-options",
+      response: {
+        decision: "accept",
+      },
+    });
+  });
+
   it("resumes typing after submitting an approval response for the waiting turn", async () => {
     const harness = await createHarness();
     await bindThread(harness);
@@ -9932,7 +10004,7 @@ describe("MessagingController", () => {
     });
 
     await harness.controller.handleInboundEvent(
-      buildCallbackEvent({ actionId: "approval:accept_with_execpolicy_amendment" }),
+      buildCallbackEvent({ actionId: "approval:accept_with_execpolicy_amendment:1" }),
     );
 
     expect(harness.submitServerRequest).toHaveBeenCalledWith({
@@ -9942,6 +10014,54 @@ describe("MessagingController", () => {
       requestId: "approval-prefix",
       response: {
         decision: structuredDecision,
+      },
+    });
+  });
+
+  it("submits the selected structured approval amendment when ids would otherwise collide", async () => {
+    const harness = await createHarness();
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "bind:codex:thread-1",
+        value: {
+          backend: "codex",
+          threadId: "thread-1",
+        },
+      }),
+    );
+    const firstDecision = {
+      acceptWithExecpolicyAmendment: {
+        execpolicy_amendment: ["pnpm", "test"],
+      },
+    };
+    const secondDecision = {
+      acceptWithExecpolicyAmendment: {
+        execpolicy_amendment: ["pnpm", "lint"],
+      },
+    };
+    await harness.controller.handleBackendPendingRequest("codex", {
+      method: "item/commandExecution/requestApproval",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        requestId: "approval-prefix",
+        prompt: "Run tests?",
+        command: "pnpm test",
+        availableDecisions: [firstDecision, secondDecision, "cancel"],
+      },
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "approval:accept_with_execpolicy_amendment:1" }),
+    );
+
+    expect(harness.submitServerRequest).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      turnId: "turn-1",
+      requestId: "approval-prefix",
+      response: {
+        decision: secondDecision,
       },
     });
   });

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -9746,6 +9746,7 @@ describe("MessagingController", () => {
         requestId: "approval-1",
         prompt: "Run tests?",
         command: "/bin/zsh -lc 'pnpm test -- messaging-controller'",
+        availableDecisions: ["accept", "acceptForSession", "cancel"],
       },
     });
 
@@ -9762,7 +9763,7 @@ describe("MessagingController", () => {
       turnId: "turn-1",
       requestId: "approval-1",
       response: {
-        decision: "accept_for_session",
+        decision: "acceptForSession",
       },
     });
     expect(
@@ -9898,6 +9899,49 @@ describe("MessagingController", () => {
       },
       targetSurface: {
         id: `surface:${approvalIntent?.id}`,
+      },
+    });
+  });
+
+  it("submits structured approval decisions from messaging callbacks", async () => {
+    const harness = await createHarness();
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "bind:codex:thread-1",
+        value: {
+          backend: "codex",
+          threadId: "thread-1",
+        },
+      }),
+    );
+    const structuredDecision = {
+      acceptWithExecpolicyAmendment: {
+        execpolicy_amendment: ["pnpm", "test"],
+      },
+    };
+    await harness.controller.handleBackendPendingRequest("codex", {
+      method: "item/commandExecution/requestApproval",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        requestId: "approval-prefix",
+        prompt: "Run tests?",
+        command: "pnpm test",
+        availableDecisions: ["accept", structuredDecision, "cancel"],
+      },
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "approval:accept_with_execpolicy_amendment" }),
+    );
+
+    expect(harness.submitServerRequest).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      turnId: "turn-1",
+      requestId: "approval-prefix",
+      response: {
+        decision: structuredDecision,
       },
     });
   });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1251,6 +1251,8 @@ function pendingRequestDecisionFromMessagingApproval(
   switch (decision) {
     case "accept":
     case "accept_for_session":
+    case "accept_with_execpolicy_amendment":
+    case "apply_network_policy_amendment":
       return "approve";
     case "decline":
       return "decline";

--- a/apps/desktop/src/main/messaging/core/deterministic-interaction-mapper.ts
+++ b/apps/desktop/src/main/messaging/core/deterministic-interaction-mapper.ts
@@ -159,6 +159,16 @@ function matchApprovalSynonym(
   ) {
     return intent.decisions.find((action) => action.decision === "accept_for_session");
   }
+  if (
+    normalized === "approve and remember" ||
+    normalized === "remember" ||
+    normalized === "approve prefix" ||
+    normalized === "allow prefix"
+  ) {
+    return intent.decisions.find(
+      (action) => action.decision === "accept_with_execpolicy_amendment",
+    );
+  }
   if (YES_SYNONYMS.has(normalized)) {
     return intent.decisions.find((action) => action.decision === "accept");
   }

--- a/apps/desktop/src/main/messaging/core/messaging-approval-renderer.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-approval-renderer.ts
@@ -25,6 +25,7 @@ export function buildApprovalIntent(params: {
     buildDecisions(params.request),
     params.capabilityProfile,
   );
+  const replyInstruction = approvalReplyInstruction(decisions);
 
   return {
     id: params.id,
@@ -37,11 +38,11 @@ export function buildApprovalIntent(params: {
         ? ["Command:", "```shell", stripDisplayShellWrapper(command), "```"].join("\n")
         : undefined,
       fileContext ? ["Context:", fileContext].join("\n") : undefined,
-      "Reply with \"1\", \"2\", \"yes\", \"yes for this session\", \"no\", or use a button.",
+      replyInstruction.body,
     ]
       .filter((part): part is string => Boolean(part))
       .join("\n\n"),
-    fallbackText: "Reply yes, yes for this session, no, cancel, or a choice number.",
+    fallbackText: replyInstruction.fallbackText,
     decisions,
   };
 }
@@ -73,6 +74,53 @@ function messagingDecisionFromPendingAction(
   action: PendingRequestAction,
 ): MessagingApprovalDecision {
   return action.decision;
+}
+
+function approvalReplyInstruction(
+  decisions: MessagingApprovalIntent["decisions"],
+): { body: string; fallbackText: string } {
+  const examples = new Set<string>();
+  for (const decision of decisions) {
+    if (decision.fallbackText) {
+      examples.add(decision.fallbackText);
+    }
+  }
+  if (decisions.some((decision) => decision.decision === "accept")) {
+    examples.add("yes");
+  }
+  if (decisions.some((decision) => decision.decision === "accept_for_session")) {
+    examples.add("yes for this session");
+  }
+  if (
+    decisions.some(
+      (decision) => decision.decision === "accept_with_execpolicy_amendment",
+    )
+  ) {
+    examples.add("approve and remember");
+  }
+  if (decisions.some((decision) => decision.decision === "decline")) {
+    examples.add("no");
+  }
+  if (decisions.some((decision) => decision.decision === "cancel")) {
+    examples.add("cancel");
+  }
+
+  if (!examples.size) {
+    return {
+      body: "Use a supported provider action to respond.",
+      fallbackText: "Use a supported provider action to respond.",
+    };
+  }
+
+  const quotedExamples = Array.from(examples, (example) => `"${example}"`);
+  const list =
+    quotedExamples.length === 1
+      ? quotedExamples[0]!
+      : `${quotedExamples.slice(0, -1).join(", ")}, or ${quotedExamples.at(-1)}`;
+  return {
+    body: `Reply with ${list}, or use a button.`,
+    fallbackText: `Reply with ${Array.from(examples).join(", ")}, or use a button.`,
+  };
 }
 
 function extractCommand(

--- a/apps/desktop/src/main/messaging/core/messaging-approval-renderer.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-approval-renderer.ts
@@ -1,5 +1,7 @@
-import type {
-  AppServerPendingRequestNotification,
+import {
+  buildPendingRequestActions,
+  type AppServerPendingRequestNotification,
+  type PendingRequestAction,
 } from "@pwragent/shared";
 import type {
   MessagingApprovalDecision,
@@ -20,7 +22,7 @@ export function buildApprovalIntent(params: {
   const command = extractCommand(params.request.params);
   const fileContext = extractFileContext(params.request.params);
   const decisions = applyActionCapabilityLimits(
-    buildDecisions(params.request.params.options),
+    buildDecisions(params.request),
     params.capabilityProfile,
   );
 
@@ -31,7 +33,9 @@ export function buildApprovalIntent(params: {
     title: titleForRequest(params.request),
     body: [
       prompt,
-      command ? ["Command:", "```shell", stripDisplayShellWrapper(command), "```"].join("\n") : undefined,
+      command
+        ? ["Command:", "```shell", stripDisplayShellWrapper(command), "```"].join("\n")
+        : undefined,
       fileContext ? ["Context:", fileContext].join("\n") : undefined,
       "Reply with \"1\", \"2\", \"yes\", \"yes for this session\", \"no\", or use a button.",
     ]
@@ -53,80 +57,27 @@ function titleForRequest(request: AppServerPendingRequestNotification): string {
 }
 
 function buildDecisions(
-  options: string[] | undefined,
+  request: AppServerPendingRequestNotification,
 ): MessagingApprovalIntent["decisions"] {
-  const provided = options
-    ?.map((option, index) => decisionFromOption(option, index))
-    .filter((decision): decision is MessagingApprovalIntent["decisions"][number] =>
-      Boolean(decision),
-    );
-  if (provided && provided.length > 0) {
-    return provided;
-  }
-
-  return [
-    {
-      id: "approval:accept",
-      label: "Approve Once",
-      decision: "accept",
-      style: "primary",
-      fallbackText: "1",
-    },
-    {
-      id: "approval:accept_for_session",
-      label: "Approve for Session",
-      decision: "accept_for_session",
-      style: "secondary",
-      fallbackText: "2",
-    },
-    {
-      id: "approval:decline",
-      label: "Decline",
-      decision: "decline",
-      style: "danger",
-      fallbackText: "3",
-    },
-    {
-      id: "approval:cancel",
-      label: "Cancel",
-      decision: "cancel",
-      style: "secondary",
-      fallbackText: "4",
-    },
-  ];
+  return buildPendingRequestActions(request).map((action) => ({
+    id: action.id,
+    label: action.label,
+    decision: messagingDecisionFromPendingAction(action),
+    style: action.style,
+    fallbackText: action.fallbackText,
+    response: action.response,
+  }));
 }
 
-function decisionFromOption(
-  option: string,
-  index: number,
-): MessagingApprovalIntent["decisions"][number] | undefined {
-  const normalized = option.toLowerCase();
-  const decision: MessagingApprovalDecision | undefined = normalized.includes("session")
-    ? "accept_for_session"
-    : normalized.includes("decline") || normalized.includes("deny") || normalized === "no"
-      ? "decline"
-      : normalized.includes("cancel")
-        ? "cancel"
-        : normalized.includes("approve") ||
-            normalized.includes("allow") ||
-            normalized.includes("accept") ||
-            normalized === "yes"
-          ? "accept"
-          : undefined;
-  if (!decision) {
-    return undefined;
-  }
-
-  return {
-    id: `approval:${decision}`,
-    label: option,
-    decision,
-    style: decision === "accept" ? "primary" : decision === "decline" ? "danger" : "secondary",
-    fallbackText: String(index + 1),
-  };
+function messagingDecisionFromPendingAction(
+  action: PendingRequestAction,
+): MessagingApprovalDecision {
+  return action.decision;
 }
 
-function extractCommand(params: AppServerPendingRequestNotification["params"]): string | undefined {
+function extractCommand(
+  params: AppServerPendingRequestNotification["params"],
+): string | undefined {
   const promptCommand =
     commandFromApprovalText(stringField(params.prompt)) ??
     commandFromApprovalText(stringField(params.reason));

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -2269,8 +2269,9 @@ export class MessagingController {
     actionId: string,
   ): Promise<MessagingApprovalDecision | undefined> {
     const requestContext = intent.requestContext;
-    const decision = intent.decisions.find((action) => action.id === actionId)?.decision;
-    if (!requestContext || !decision || !this.options.backend.submitServerRequest) {
+    const action = intent.decisions.find((candidate) => candidate.id === actionId);
+    const decision = action?.decision;
+    if (!requestContext || !action || !this.options.backend.submitServerRequest) {
       return decision;
     }
 
@@ -2279,9 +2280,7 @@ export class MessagingController {
       threadId: requestContext.threadId,
       turnId: requestContext.turnId,
       requestId: requestContext.requestId,
-      response: {
-        decision,
-      },
+      response: action.response ?? { decision },
     });
     return decision;
   }
@@ -12624,6 +12623,10 @@ function approvalResponseLabel(
       return "Approved";
     case "accept_for_session":
       return "Approved for Session";
+    case "accept_with_execpolicy_amendment":
+      return "Approved and Remembered";
+    case "apply_network_policy_amendment":
+      return "Network Rule Applied";
     case "decline":
       return "Declined";
     case "cancel":

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -31,6 +31,7 @@ import type {
   NavigationDirectorySummary,
   NavigationLaunchpadDraft,
   NavigationThreadSummary,
+  PendingRequestAction,
   ThreadExecutionMode,
 } from "@pwragent/shared";
 import {
@@ -1977,9 +1978,7 @@ export function ThreadView(props: ThreadViewProps) {
     selectedThread,
   ]);
 
-  async function respondToPendingRequest(
-    decision: "approve" | "decline" | "cancel"
-  ): Promise<void> {
+  async function respondToPendingRequest(action: PendingRequestAction): Promise<void> {
     if (!props.desktopApi?.submitServerRequest || !selectedThread || !props.pendingRequest) {
       setPendingRequestError("Desktop bridge is missing submitServerRequest().");
       return;
@@ -1997,11 +1996,18 @@ export function ThreadView(props: ThreadViewProps) {
             ? props.pendingRequest.params.turnId
             : undefined,
         requestId: props.pendingRequest.params.requestId,
-        response: buildPendingRequestResponse(props.pendingRequest, decision),
+        response: buildPendingRequestResponse(props.pendingRequest, action),
       });
       props.clearPendingRequest(
         props.pendingRequest.params.requestId,
-        decision === "approve" ? "Thinking" : undefined
+        (
+          action.decision === "accept" ||
+          action.decision === "accept_for_session" ||
+          action.decision === "accept_with_execpolicy_amendment" ||
+          action.decision === "apply_network_policy_amendment"
+        )
+          ? "Thinking"
+          : undefined,
       );
     } catch (error) {
       setPendingRequestError(error instanceof Error ? error.message : String(error));

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -17,10 +17,12 @@ import type {
   AppServerThreadReplayPagination,
   AutomationTimelineCard,
   DesktopApplicationsSnapshot,
+  PendingRequestAction,
   ThreadMessagingBindingTransition,
   ThreadPermissionTransition,
   ThreadTurnFailure,
 } from "@pwragent/shared";
+import { buildPendingRequestActions } from "@pwragent/shared";
 import { injectAutomationCards } from "./automation-card-entries";
 import { injectMessagingBindingTransitions } from "./messaging-binding-transition-entries";
 import { injectPermissionTransitions } from "./permission-transition-entries";
@@ -82,7 +84,7 @@ type TranscriptListProps = {
   skills?: AppServerSkillSummary[];
   onOpenImage?: (image: AppServerThreadImagePart) => void;
   onViewportChange?: (viewport?: TranscriptViewport) => void;
-  onRespondToPendingRequest?: (decision: "approve" | "decline" | "cancel") => Promise<void>;
+  onRespondToPendingRequest?: (action: PendingRequestAction) => Promise<void>;
   onPendingMcpInteractionChange?: (state: PendingMcpInteractionState) => void;
   onSubmitPendingMcpInteraction?: (
     state: PendingMcpInteractionState,
@@ -375,6 +377,11 @@ export function TranscriptList(props: TranscriptListProps) {
       props.pendingUserInput ||
       props.pendingStatusText ||
       props.runningTurnUsageText
+  );
+  const pendingRequestActions = useMemo(
+    () =>
+      props.pendingRequest ? buildPendingRequestActions(props.pendingRequest) : [],
+    [props.pendingRequest],
   );
   const automationThreadTarget = useMemo(
     () => parseThreadIdentity(props.threadId),
@@ -999,36 +1006,23 @@ export function TranscriptList(props: TranscriptListProps) {
                 text={pendingRequestPrompt(props.pendingRequest)}
               />
               <div className="transcript-request__actions">
-                <button
-                  className="button button--primary"
-                  disabled={props.pendingRequestBusy}
-                  type="button"
-                  onClick={() => {
-                    void props.onRespondToPendingRequest?.("approve");
-                  }}
-                >
-                  Approve
-                </button>
-                <button
-                  className="button button--ghost"
-                  disabled={props.pendingRequestBusy}
-                  type="button"
-                  onClick={() => {
-                    void props.onRespondToPendingRequest?.("decline");
-                  }}
-                >
-                  Decline
-                </button>
-                <button
-                  className="button button--ghost"
-                  disabled={props.pendingRequestBusy}
-                  type="button"
-                  onClick={() => {
-                    void props.onRespondToPendingRequest?.("cancel");
-                  }}
-                >
-                  Cancel turn
-                </button>
+                {pendingRequestActions.map((action) => (
+                  <button
+                    className={
+                      action.style === "primary"
+                        ? "button button--primary"
+                        : "button button--ghost"
+                    }
+                    disabled={props.pendingRequestBusy}
+                    key={action.id}
+                    type="button"
+                    onClick={() => {
+                      void props.onRespondToPendingRequest?.(action);
+                    }}
+                  >
+                    {action.label}
+                  </button>
+                ))}
               </div>
             </div>
           ) : null}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -2436,7 +2436,7 @@ describe("ThreadView", () => {
 
     expect(screen.getByRole("group", { name: "Pending approval" })).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Approve" }));
+    fireEvent.click(screen.getByRole("button", { name: "Approve Once" }));
 
     await waitFor(() => {
       expect(submitServerRequest).toHaveBeenCalledWith({

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9645,6 +9645,12 @@ textarea,
 .transcript-questionnaire__actions,
 .transcript-mcp__actions {
   justify-content: flex-start;
+  flex-wrap: wrap;
+}
+
+.transcript-request__actions .button {
+  max-width: 100%;
+  white-space: normal;
 }
 
 .transcript-questionnaire__prompt,

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -646,6 +646,8 @@ export type MessagingQuestionnaireQuestion = {
 export type MessagingApprovalDecision =
   | "accept"
   | "accept_for_session"
+  | "accept_with_execpolicy_amendment"
+  | "apply_network_policy_amendment"
   | "decline"
   | "cancel";
 
@@ -772,7 +774,12 @@ export type MessagingApprovalIntent = MessagingBaseSurfaceIntent & {
   kind: "approval";
   title: string;
   body: string;
-  decisions: Array<MessagingSurfaceAction & { decision: MessagingApprovalDecision }>;
+  decisions: Array<
+    MessagingSurfaceAction & {
+      decision: MessagingApprovalDecision;
+      response?: { decision: unknown };
+    }
+  >;
 };
 
 export type MessagingConfirmationIntent = MessagingBaseSurfaceIntent & {

--- a/packages/shared/src/__tests__/pending-request-response.test.ts
+++ b/packages/shared/src/__tests__/pending-request-response.test.ts
@@ -143,7 +143,7 @@ describe("buildPendingRequestResponse", () => {
       }),
       expect.objectContaining({
         decision: "accept_with_execpolicy_amendment",
-        label: "Approve Prefix: pnpm test",
+        label: "Always Allow Prefix: pnpm test",
         response: { decision: structuredDecision },
       }),
       expect.objectContaining({

--- a/packages/shared/src/__tests__/pending-request-response.test.ts
+++ b/packages/shared/src/__tests__/pending-request-response.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { AppServerPendingRequestNotification } from "../contracts/normalized-app-server";
-import { buildPendingRequestResponse } from "../pending-request-response";
+import {
+  buildPendingRequestActions,
+  buildPendingRequestResponse,
+} from "../pending-request-response";
 
 function createRequest(
   overrides: Partial<AppServerPendingRequestNotification> = {},
@@ -65,5 +68,79 @@ describe("buildPendingRequestResponse", () => {
     expect(buildPendingRequestResponse(request, "approve")).toEqual({
       decision: "allow",
     });
+  });
+
+  it("exposes structured execpolicy amendment decisions", () => {
+    const structuredDecision = {
+      acceptWithExecpolicyAmendment: {
+        execpolicy_amendment: ["pnpm", "test"],
+      },
+    };
+    const request = createRequest({
+      params: {
+        threadId: "thread-1",
+        requestId: "request-1",
+        availableDecisions: ["accept", structuredDecision, "cancel"],
+      },
+    });
+
+    const actions = buildPendingRequestActions(request);
+
+    expect(actions).toEqual([
+      expect.objectContaining({
+        decision: "accept",
+        label: "Approve Once",
+      }),
+      expect.objectContaining({
+        decision: "accept_with_execpolicy_amendment",
+        label: "Approve Prefix: pnpm test",
+        response: { decision: structuredDecision },
+      }),
+      expect.objectContaining({
+        decision: "cancel",
+      }),
+    ]);
+    expect(buildPendingRequestResponse(request, actions[1]!)).toEqual({
+      decision: structuredDecision,
+    });
+  });
+
+  it("labels network policy amendment decisions", () => {
+    const allowHost = {
+      applyNetworkPolicyAmendment: {
+        network_policy_amendment: {
+          host: "api.example.com",
+          action: "allow",
+        },
+      },
+    };
+    const denyHost = {
+      applyNetworkPolicyAmendment: {
+        network_policy_amendment: {
+          host: "api.example.com",
+          action: "deny",
+        },
+      },
+    };
+    const request = createRequest({
+      params: {
+        threadId: "thread-1",
+        requestId: "request-1",
+        availableDecisions: [allowHost, denyHost],
+      },
+    });
+
+    expect(buildPendingRequestActions(request)).toEqual([
+      expect.objectContaining({
+        decision: "apply_network_policy_amendment",
+        label: "Allow api.example.com",
+        style: "primary",
+      }),
+      expect.objectContaining({
+        decision: "apply_network_policy_amendment",
+        label: "Block api.example.com",
+        style: "danger",
+      }),
+    ]);
   });
 });

--- a/packages/shared/src/__tests__/pending-request-response.test.ts
+++ b/packages/shared/src/__tests__/pending-request-response.test.ts
@@ -56,6 +56,56 @@ describe("buildPendingRequestResponse", () => {
     });
   });
 
+  it("keeps legacy option labels while submitting normalized decisions", () => {
+    const request = createRequest({
+      method: "turn/requestApproval",
+      params: {
+        threadId: "thread-1",
+        requestId: "request-1",
+        options: ["Approve Once", "Cancel"],
+      },
+    });
+
+    const actions = buildPendingRequestActions(request);
+
+    expect(actions).toEqual([
+      expect.objectContaining({
+        label: "Approve Once",
+        response: { decision: "accept" },
+      }),
+      expect.objectContaining({
+        label: "Cancel",
+        response: { decision: "cancel" },
+      }),
+    ]);
+    expect(buildPendingRequestResponse(request, actions[0]!)).toEqual({
+      decision: "accept",
+    });
+  });
+
+  it("includes the advertised command approval replies in fallback actions", () => {
+    const request = createRequest();
+
+    expect(buildPendingRequestActions(request)).toEqual([
+      expect.objectContaining({
+        decision: "accept",
+        fallbackText: "1",
+      }),
+      expect.objectContaining({
+        decision: "accept_for_session",
+        fallbackText: "2",
+      }),
+      expect.objectContaining({
+        decision: "decline",
+        fallbackText: "3",
+      }),
+      expect.objectContaining({
+        decision: "cancel",
+        fallbackText: "4",
+      }),
+    ]);
+  });
+
   it("reads structured decision descriptors", () => {
     const request = createRequest({
       params: {
@@ -102,6 +152,52 @@ describe("buildPendingRequestResponse", () => {
     ]);
     expect(buildPendingRequestResponse(request, actions[1]!)).toEqual({
       decision: structuredDecision,
+    });
+  });
+
+  it("assigns unique ids to structured amendment decisions", () => {
+    const firstPrefix = {
+      acceptWithExecpolicyAmendment: {
+        execpolicy_amendment: ["pnpm", "test"],
+      },
+    };
+    const secondPrefix = {
+      acceptWithExecpolicyAmendment: {
+        execpolicy_amendment: ["pnpm", "lint"],
+      },
+    };
+    const firstHost = {
+      applyNetworkPolicyAmendment: {
+        network_policy_amendment: {
+          host: "api.example.com",
+          action: "allow",
+        },
+      },
+    };
+    const secondHost = {
+      applyNetworkPolicyAmendment: {
+        network_policy_amendment: {
+          host: "cdn.example.com",
+          action: "allow",
+        },
+      },
+    };
+    const request = createRequest({
+      params: {
+        threadId: "thread-1",
+        requestId: "request-1",
+        availableDecisions: [firstPrefix, secondPrefix, firstHost, secondHost],
+      },
+    });
+
+    const actions = buildPendingRequestActions(request);
+
+    expect(new Set(actions.map((action) => action.id)).size).toBe(actions.length);
+    expect(buildPendingRequestResponse(request, actions[1]!)).toEqual({
+      decision: secondPrefix,
+    });
+    expect(buildPendingRequestResponse(request, actions[3]!)).toEqual({
+      decision: secondHost,
     });
   });
 

--- a/packages/shared/src/pending-request-response.ts
+++ b/packages/shared/src/pending-request-response.ts
@@ -118,7 +118,7 @@ function actionFromEntry(
     return actionFromDecisionString(
       request,
       entry,
-      entry,
+      preserveStringLabel ? legacyOptionResponseDecision(entry) : entry,
       index,
       preserveStringLabel ? entry : undefined,
     );
@@ -136,7 +136,7 @@ function actionFromEntry(
     return buildAction({
       decision: "accept_with_execpolicy_amendment",
       fallbackText: String(index + 1),
-      id: "approval:accept_with_execpolicy_amendment",
+      id: `approval:accept_with_execpolicy_amendment:${index}`,
       label: label ?? execpolicyLabel(execpolicyPayload),
       responseDecision: entry,
       style: "primary",
@@ -155,7 +155,7 @@ function actionFromEntry(
     return buildAction({
       decision: "apply_network_policy_amendment",
       fallbackText: String(index + 1),
-      id: `approval:apply_network_policy_amendment:${action ?? index}`,
+      id: `approval:apply_network_policy_amendment:${action ?? "rule"}:${index}`,
       label: label ?? networkPolicyLabel(networkPayload),
       responseDecision: entry,
       style: action?.toLowerCase() === "deny" ? "danger" : "primary",
@@ -208,8 +208,24 @@ function defaultPendingRequestActions(
         style: "primary",
       }),
       buildAction({
-        decision: "cancel",
+        decision: "accept_for_session",
         fallbackText: "2",
+        id: "approval:accept_for_session",
+        label: "Approve for Session",
+        responseDecision: "accept_for_session",
+        style: "secondary",
+      }),
+      buildAction({
+        decision: "decline",
+        fallbackText: "3",
+        id: "approval:decline",
+        label: "Decline",
+        responseDecision: "decline",
+        style: "danger",
+      }),
+      buildAction({
+        decision: "cancel",
+        fallbackText: "4",
         id: "approval:cancel",
         label: "Cancel Turn",
         responseDecision: "cancel",
@@ -340,6 +356,10 @@ function normalizeDecision(
     return "cancel";
   }
   return undefined;
+}
+
+function legacyOptionResponseDecision(rawDecision: string): string {
+  return normalizeDecision(rawDecision) ?? rawDecision;
 }
 
 function defaultLabel(

--- a/packages/shared/src/pending-request-response.ts
+++ b/packages/shared/src/pending-request-response.ts
@@ -405,7 +405,7 @@ function execpolicyLabel(payload: object): string {
     ? prefix.filter((part): part is string => typeof part === "string")
     : undefined;
   const rendered = command?.join(" ").trim();
-  return rendered ? `Approve Prefix: ${rendered}` : "Approve Command Prefix";
+  return rendered ? `Always Allow Prefix: ${rendered}` : "Always Allow Command Prefix";
 }
 
 function networkPolicyLabel(payload: object): string {

--- a/packages/shared/src/pending-request-response.ts
+++ b/packages/shared/src/pending-request-response.ts
@@ -1,14 +1,35 @@
 import type { AppServerPendingRequestNotification } from "./contracts/normalized-app-server";
 
 export type PendingRequestDecision = "approve" | "decline" | "cancel";
+export type PendingRequestActionDecision =
+  | "accept"
+  | "accept_for_session"
+  | "accept_with_execpolicy_amendment"
+  | "apply_network_policy_amendment"
+  | "decline"
+  | "cancel";
+export type PendingRequestActionStyle = "primary" | "secondary" | "danger";
+
+export type PendingRequestAction = {
+  id: string;
+  label: string;
+  decision: PendingRequestActionDecision;
+  style: PendingRequestActionStyle;
+  fallbackText: string;
+  response: { decision: unknown };
+};
 
 export function buildPendingRequestResponse(
   request: AppServerPendingRequestNotification,
-  decision: PendingRequestDecision,
-): { decision: string } {
-  const availableDecision = selectAvailableDecision(request.params, decision);
-  if (availableDecision) {
-    return { decision: availableDecision };
+  decision: PendingRequestDecision | PendingRequestAction,
+): { decision: unknown } {
+  if (typeof decision !== "string") {
+    return decision.response;
+  }
+
+  const availableAction = selectAvailableAction(request, decision);
+  if (availableAction) {
+    return availableAction.response;
   }
 
   if (request.method.includes("commandExecution/requestApproval")) {
@@ -36,49 +57,360 @@ export function buildPendingRequestResponse(
   return { decision };
 }
 
-function selectAvailableDecision(
-  params: AppServerPendingRequestNotification["params"],
-  decision: PendingRequestDecision,
-): string | undefined {
-  const rawDecisions =
-    readDecisionStrings(params.availableDecisions) ?? readDecisionStrings(params.decisions);
-  if (!rawDecisions?.length) {
-    return undefined;
+export function buildPendingRequestActions(
+  request: AppServerPendingRequestNotification,
+): PendingRequestAction[] {
+  const availableDecisions =
+    readDecisionEntries(request.params.availableDecisions) ??
+    readDecisionEntries(request.params.decisions);
+  const optionDecisions = availableDecisions
+    ? undefined
+    : readDecisionEntries(request.params.options);
+  const rawDecisions = availableDecisions ?? optionDecisions;
+  const preserveStringLabels = Boolean(optionDecisions);
+  const provided = rawDecisions
+    ?.map((entry, index) =>
+      actionFromEntry(request, entry, index, preserveStringLabels),
+    )
+    .filter((entry): entry is PendingRequestAction => Boolean(entry));
+  if (provided?.length) {
+    return provided;
   }
 
-  const acceptedAliases =
-    decision === "approve"
-      ? ["accept", "approve", "allow"]
-      : decision === "decline"
-        ? ["decline", "deny", "reject"]
-        : ["cancel", "abort", "stop"];
-
-  return rawDecisions.find((value) =>
-    acceptedAliases.some((alias) => value.toLowerCase().includes(alias)),
-  );
+  return defaultPendingRequestActions(request);
 }
 
-function readDecisionStrings(value: unknown): string[] | undefined {
+function selectAvailableAction(
+  request: AppServerPendingRequestNotification,
+  decision: PendingRequestDecision,
+): PendingRequestAction | undefined {
+  const actions = buildPendingRequestActions(request);
+  if (decision === "approve") {
+    return (
+      actions.find((action) => action.decision === "accept") ??
+      actions.find(
+        (action) =>
+          (action.decision === "accept_for_session" ||
+            action.decision === "accept_with_execpolicy_amendment" ||
+            action.decision === "apply_network_policy_amendment") &&
+          action.style !== "danger",
+      )
+    );
+  }
+  const acceptedKind = decision === "decline" ? "decline" : "cancel";
+  return actions.find((action) => action.decision === acceptedKind);
+}
+
+function readDecisionEntries(value: unknown): unknown[] | undefined {
   if (!Array.isArray(value)) {
     return undefined;
   }
+  return value;
+}
 
-  return value
-    .map((entry) => {
-      if (typeof entry === "string") {
-        return entry.trim();
-      }
-      if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
-        return undefined;
-      }
-      const record = entry as Record<string, unknown>;
-      for (const key of ["decision", "value", "name", "id"]) {
-        const raw = record[key];
-        if (typeof raw === "string" && raw.trim()) {
-          return raw.trim();
-        }
-      }
-      return undefined;
-    })
-    .filter((entry): entry is string => Boolean(entry));
+function actionFromEntry(
+  request: AppServerPendingRequestNotification,
+  entry: unknown,
+  index: number,
+  preserveStringLabel: boolean,
+): PendingRequestAction | undefined {
+  if (typeof entry === "string") {
+    return actionFromDecisionString(
+      request,
+      entry,
+      entry,
+      index,
+      preserveStringLabel ? entry : undefined,
+    );
+  }
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    return undefined;
+  }
+  const record = entry as Record<string, unknown>;
+  const label = readString(record.label) ?? readString(record.title);
+
+  const execpolicyPayload =
+    record.acceptWithExecpolicyAmendment ??
+    record.accept_with_execpolicy_amendment;
+  if (execpolicyPayload && typeof execpolicyPayload === "object") {
+    return buildAction({
+      decision: "accept_with_execpolicy_amendment",
+      fallbackText: String(index + 1),
+      id: "approval:accept_with_execpolicy_amendment",
+      label: label ?? execpolicyLabel(execpolicyPayload),
+      responseDecision: entry,
+      style: "primary",
+    });
+  }
+
+  const networkPayload =
+    record.applyNetworkPolicyAmendment ?? record.apply_network_policy_amendment;
+  if (networkPayload && typeof networkPayload === "object") {
+    const network = networkPayload as Record<string, unknown>;
+    const amendment = network.network_policy_amendment;
+    const action =
+      amendment && typeof amendment === "object"
+        ? readString((amendment as Record<string, unknown>).action)
+        : undefined;
+    return buildAction({
+      decision: "apply_network_policy_amendment",
+      fallbackText: String(index + 1),
+      id: `approval:apply_network_policy_amendment:${action ?? index}`,
+      label: label ?? networkPolicyLabel(networkPayload),
+      responseDecision: entry,
+      style: action?.toLowerCase() === "deny" ? "danger" : "primary",
+    });
+  }
+
+  for (const key of ["decision", "value", "name", "id"]) {
+    const raw = readString(record[key]);
+    if (raw) {
+      return actionFromDecisionString(request, raw, raw, index, label);
+    }
+  }
+
+  return undefined;
+}
+
+function actionFromDecisionString(
+  request: AppServerPendingRequestNotification,
+  rawDecision: string,
+  responseDecision: unknown,
+  index: number,
+  label?: string,
+): PendingRequestAction | undefined {
+  const normalized = normalizeDecision(rawDecision);
+  if (!normalized) {
+    return undefined;
+  }
+
+  return buildAction({
+    decision: normalized,
+    fallbackText: String(index + 1),
+    id: `approval:${normalized}`,
+    label: label ?? defaultLabel(request, normalized),
+    responseDecision,
+    style: defaultStyle(normalized),
+  });
+}
+
+function defaultPendingRequestActions(
+  request: AppServerPendingRequestNotification,
+): PendingRequestAction[] {
+  if (request.method.includes("commandExecution/requestApproval")) {
+    return [
+      buildAction({
+        decision: "accept",
+        fallbackText: "1",
+        id: "approval:accept",
+        label: "Approve Once",
+        responseDecision: "accept",
+        style: "primary",
+      }),
+      buildAction({
+        decision: "cancel",
+        fallbackText: "2",
+        id: "approval:cancel",
+        label: "Cancel Turn",
+        responseDecision: "cancel",
+        style: "secondary",
+      }),
+    ];
+  }
+
+  if (request.method.includes("fileChange/requestApproval")) {
+    return [
+      buildAction({
+        decision: "accept",
+        fallbackText: "1",
+        id: "approval:accept",
+        label: "Approve Once",
+        responseDecision: "accept",
+        style: "primary",
+      }),
+      buildAction({
+        decision: "decline",
+        fallbackText: "2",
+        id: "approval:decline",
+        label: "Decline",
+        responseDecision: "decline",
+        style: "danger",
+      }),
+      buildAction({
+        decision: "cancel",
+        fallbackText: "3",
+        id: "approval:cancel",
+        label: "Cancel Turn",
+        responseDecision: "cancel",
+        style: "secondary",
+      }),
+    ];
+  }
+
+  return [
+    buildAction({
+      decision: "accept",
+      fallbackText: "1",
+      id: "approval:accept",
+      label: "Approve Once",
+      responseDecision: "approve",
+      style: "primary",
+    }),
+    buildAction({
+      decision: "decline",
+      fallbackText: "2",
+      id: "approval:decline",
+      label: "Decline",
+      responseDecision: "decline",
+      style: "danger",
+    }),
+    buildAction({
+      decision: "cancel",
+      fallbackText: "3",
+      id: "approval:cancel",
+      label: "Cancel Turn",
+      responseDecision: "cancel",
+      style: "secondary",
+    }),
+  ];
+}
+
+function buildAction(params: {
+  decision: PendingRequestActionDecision;
+  fallbackText: string;
+  id: string;
+  label: string;
+  responseDecision: unknown;
+  style: PendingRequestActionStyle;
+}): PendingRequestAction {
+  return {
+    id: params.id,
+    label: params.label,
+    decision: params.decision,
+    style: params.style,
+    fallbackText: params.fallbackText,
+    response: { decision: params.responseDecision },
+  };
+}
+
+function normalizeDecision(
+  value: string,
+): PendingRequestActionDecision | undefined {
+  const normalized = value.trim().toLowerCase().replace(/[-_\s]/g, "");
+  if (
+    ["acceptforsession", "approveforsession", "allowforsession"].includes(
+      normalized,
+    )
+  ) {
+    return "accept_for_session";
+  }
+  if (
+    [
+      "acceptwithexecpolicyamendment",
+      "approvewithexecpolicyamendment",
+      "acceptwithcommandprefix",
+    ].includes(normalized)
+  ) {
+    return "accept_with_execpolicy_amendment";
+  }
+  if (
+    ["applynetworkpolicyamendment", "networkpolicyamendment"].includes(
+      normalized,
+    )
+  ) {
+    return "apply_network_policy_amendment";
+  }
+  if (
+    [
+      "accept",
+      "acceptonce",
+      "approve",
+      "approveonce",
+      "allow",
+      "allowonce",
+      "yes",
+    ].includes(normalized)
+  ) {
+    return "accept";
+  }
+  if (["decline", "deny", "reject", "no"].includes(normalized)) {
+    return "decline";
+  }
+  if (["cancel", "abort", "stop"].includes(normalized)) {
+    return "cancel";
+  }
+  return undefined;
+}
+
+function defaultLabel(
+  request: AppServerPendingRequestNotification,
+  decision: PendingRequestActionDecision,
+): string {
+  switch (decision) {
+    case "accept":
+      return "Approve Once";
+    case "accept_for_session":
+      return hasNetworkApprovalContext(request)
+        ? "Allow for Conversation"
+        : "Approve for Session";
+    case "accept_with_execpolicy_amendment":
+      return "Approve Command Prefix";
+    case "apply_network_policy_amendment":
+      return "Apply Network Rule";
+    case "decline":
+      return "Decline";
+    case "cancel":
+      return "Cancel Turn";
+  }
+}
+
+function defaultStyle(decision: PendingRequestActionDecision): PendingRequestActionStyle {
+  switch (decision) {
+    case "accept":
+    case "accept_with_execpolicy_amendment":
+    case "apply_network_policy_amendment":
+      return "primary";
+    case "decline":
+      return "danger";
+    case "accept_for_session":
+    case "cancel":
+      return "secondary";
+  }
+}
+
+function execpolicyLabel(payload: object): string {
+  const record = payload as Record<string, unknown>;
+  const prefix = record.execpolicy_amendment ?? record.proposed_execpolicy_amendment;
+  const command = Array.isArray(prefix)
+    ? prefix.filter((part): part is string => typeof part === "string")
+    : undefined;
+  const rendered = command?.join(" ").trim();
+  return rendered ? `Approve Prefix: ${rendered}` : "Approve Command Prefix";
+}
+
+function networkPolicyLabel(payload: object): string {
+  const amendment = (payload as Record<string, unknown>).network_policy_amendment;
+  const record =
+    amendment && typeof amendment === "object"
+      ? (amendment as Record<string, unknown>)
+      : undefined;
+  const action = readString(record?.action)?.toLowerCase();
+  const host = readString(record?.host);
+  if (action === "deny") {
+    return host ? `Block ${host}` : "Block Host";
+  }
+  return host ? `Allow ${host}` : "Allow Host";
+}
+
+function hasNetworkApprovalContext(
+  request: AppServerPendingRequestNotification,
+): boolean {
+  return Boolean(
+    request.params.network_approval_context ??
+      request.params.networkApprovalContext,
+  );
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }


### PR DESCRIPTION
## Summary

- I surfaced backend-provided approval decisions in the desktop pending approval UI instead of hard-coding approve/decline buttons.
- I added a shared approval decision parser that preserves structured backend responses for session, exec-policy, and network-policy approval actions.
- I exposed the available decisions through the generic messaging approval intent so messaging providers can present the same action set and submit the exact callback payload.

## Verification

- I ran `pnpm test packages/shared/src/__tests__/pending-request-response.test.ts apps/desktop/src/main/__tests__/messaging-approval-renderer.test.ts apps/desktop/src/main/__tests__/messaging-controller.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx`.
- I ran `pnpm --filter @pwragent/desktop typecheck`.
- I ran `pnpm typecheck`.
- I ran `git diff --check`.

## Notes

- `pnpm exec prettier --check ...` could not run because `prettier` is not installed in this checkout.
