### PR TITLE
fix(desktop): truncate overflowing sidebar chips with ellipsis

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
@@ -103,7 +103,7 @@ export function ThreadMetaChips({
                 <span aria-hidden="true" className="thread-row__chip-icon">
                   {directory.kind === "worktree" ? <WorktreeIcon size={12} /> : <FolderIcon size={12} />}
                 </span>
-                {directory.label}
+                <span className="thread-row__chip-label">{directory.label}</span>
               </CopyableThreadChip>
             );
           })
@@ -162,7 +162,7 @@ export function ThreadMetaChips({
           <span aria-hidden="true" className="thread-row__chip-icon">
             <BranchIcon size={12} />
           </span>
-          {branchChip}
+          <span className="thread-row__chip-label">{branchChip}</span>
         </CopyableThreadChip>
       ) : null}
 
@@ -178,7 +178,7 @@ export function ThreadMetaChips({
           <span aria-hidden="true" className="thread-row__chip-icon">
             !
           </span>
-          now {thread.observedGitBranch}
+          <span className="thread-row__chip-label">now {thread.observedGitBranch}</span>
         </CopyableThreadChip>
       ) : null}
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1371,6 +1371,12 @@ textarea,
 .thread-row__chip-wrap {
   position: relative;
   display: inline-flex;
+  /* Clamp + shrink like the chip it wraps. Without this the inline-flex
+     wrapper grows to the binding label's natural width, so the inner
+     chip's `max-width: 100%` resolves against an unconstrained parent and
+     never truncates — the label overflows the row instead of eliding. */
+  min-width: 0;
+  max-width: 100%;
 }
 
 .thread-row__chip-menu {
@@ -3430,6 +3436,19 @@ textarea,
   align-items: center;
   flex: 0 0 auto;
   line-height: 1;
+}
+
+/* Text content of a chip. The pill is an inline-flex container, so
+   `text-overflow: ellipsis` on the chip itself is inert — it only engages on
+   the text-bearing child. `min-width: 0` lets this label shrink below its
+   content size so a long branch name / breadcrumb truncates with a "…"
+   instead of ramming the final glyphs into the pill's padding. */
+.thread-row__chip-label {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* PR chips on thread rows. Color comes from the --status-* tokens


### PR DESCRIPTION
## Summary

- Long text in the left-sidebar chips (branch names, drift, linked directories, messaging breadcrumbs) hard-clipped into the pill padding or overflowed the row instead of truncating. The pill is an `inline-flex` container, so `text-overflow: ellipsis` on the chip itself is **inert** — it only engages on a text-bearing child.
- Wrap chip text in a `.thread-row__chip-label` span with `min-width: 0; overflow: hidden; text-overflow: ellipsis` so a long branch name / breadcrumb truncates with a native `…`.
- Clamp `.thread-row__chip-wrap` (`min-width: 0; max-width: 100%`) so the binding chip's relative wrapper (which anchors its unbind menu) no longer grows to the label's natural width — without it the inner chip's `max-width: 100%` resolved against an unconstrained parent and the label overflowed the row.
- Thread titles already truncated natively (they're not flex containers) and are **unchanged**.

This is pure CSS — no JS, no observers. An earlier draft of this PR faded the chip/title edge instead of clipping, but the fade can't self-gate in CSS, so it needed a per-element `ResizeObserver` to toggle the mask. With hundreds of un-virtualized sidebar rows that meant 1000+ observers firing every frame while dragging the sidebar — which pinned a CPU core. Native ellipsis is free, so we kept it.

> Note: the branch name still says `fade`; the final approach is ellipsis. Left the branch as-is to avoid disrupting the open PR.

## Verification

- `pnpm --filter @pwragent/desktop typecheck` — clean.
- `pnpm test apps/desktop/src/renderer/src/features/navigation` — 93 tests pass.
- `pnpm lint:colors` and `pnpm lint:boundaries` — pass.
- Visual: branch / linked-dir / drift / binding chips now show `…` instead of ramming text into the pill or overflowing the row; titles unchanged; no CPU spike when resizing the left bar.

## Notes

- Net change is 2 files (+22/−3): the chip-text wrappers in `ThreadMetaChips.tsx` and the `.thread-row__chip-label` + `.thread-row__chip-wrap` rules in `app.css`. `ThreadRow.tsx`/`DirectoriesList.tsx` have no net change — the binding chip already had its label span (it just lacked the CSS rule) and titles already truncated.
- The chip ellipsis is gated purely by CSS overflow, so it stays correct on sidebar resize with zero runtime cost.