### PR TITLE
feat(desktop): surface non-turn worktree edits

### DIFF
--- a/apps/desktop/src/main/__tests__/git-working-state-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-working-state-service.test.ts
@@ -1,3 +1,5 @@
+import os from "node:os";
+import path from "node:path";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -6,6 +8,14 @@ import {
 } from "../app-server/git-working-state-service";
 
 type GitCall = { cwd: string; args: string[] };
+
+function makeTempPrefix(): string {
+  return path.join(os.tmpdir(), "pwragent-git-working-state-");
+}
+
+function normalizeTestPath(value: string): string {
+  return path.resolve(value).replace(/\\/g, "/");
+}
 
 function fakeGit(
   responder: (args: string[]) => string | undefined,
@@ -106,10 +116,10 @@ describe("probeWorktreeWorkingState", () => {
   });
 
   it("includes cheap untracked text additions in the dirty working-state totals", async () => {
-    const tmpRoot = await mkdtemp("/tmp/pwragent-git-working-state-");
+    const tmpRoot = await mkdtemp(makeTempPrefix());
     try {
-      await writeFile(`${tmpRoot}/note.txt`, "alpha\nbeta\n", "utf8");
-      await writeFile(`${tmpRoot}/archive.zip`, Buffer.from([0, 1, 2, 3]));
+      await writeFile(path.join(tmpRoot, "note.txt"), "alpha\nbeta\n", "utf8");
+      await writeFile(path.join(tmpRoot, "archive.zip"), Buffer.from([0, 1, 2, 3]));
       const { runGit } = fakeGit((args) => {
         if (args.includes("--numstat")) return "3\t1\tsrc/a.ts\n";
         if (args.includes("status")) {
@@ -183,6 +193,7 @@ describe("GitWorkingStateService", () => {
   });
 
   it("lists other worktree changes with excluded turn paths filtered before the cap", async () => {
+    const worktreePath = "/repo/wt";
     const { runGit } = fakeGit((args) => {
       if (args.includes("status")) {
         return [
@@ -200,15 +211,15 @@ describe("GitWorkingStateService", () => {
     });
     const service = new GitWorkingStateService({ runGit });
 
-    const response = await service.listOtherChanges("/repo/wt", {
-      excludePaths: ["/repo/wt/src/turn.ts"],
+    const response = await service.listOtherChanges(worktreePath, {
+      excludePaths: [`${worktreePath}/src/turn.ts`],
       maxFiles: 2,
     });
 
     expect(response).toEqual({
       changes: [
         {
-          path: "/repo/wt/docs/PwrAgnt v2.html",
+          path: normalizeTestPath(`${worktreePath}/docs/PwrAgnt v2.html`),
           repoPath: "docs/PwrAgnt v2.html",
           status: "modified",
           staged: false,
@@ -217,7 +228,7 @@ describe("GitWorkingStateService", () => {
           removals: 1,
         },
         {
-          path: "/repo/wt/src/other-b.ts",
+          path: normalizeTestPath(`${worktreePath}/src/other-b.ts`),
           repoPath: "src/other-b.ts",
           status: "added",
           staged: true,
@@ -255,10 +266,10 @@ describe("GitWorkingStateService", () => {
   });
 
   it("reports added-line totals for small untracked text files and byte sizes for binary files", async () => {
-    const tmpRoot = await mkdtemp("/tmp/pwragent-git-working-state-");
+    const tmpRoot = await mkdtemp(makeTempPrefix());
     try {
-      await writeFile(`${tmpRoot}/note.txt`, "alpha\nbeta\n", "utf8");
-      await writeFile(`${tmpRoot}/archive.zip`, Buffer.from([0, 1, 2, 3]));
+      await writeFile(path.join(tmpRoot, "note.txt"), "alpha\nbeta\n", "utf8");
+      await writeFile(path.join(tmpRoot, "archive.zip"), Buffer.from([0, 1, 2, 3]));
       const { runGit } = fakeGit((args) => {
         if (args.includes("status")) return "?? note.txt\0?? archive.zip\0";
         if (args.includes("--numstat")) return "";
@@ -270,7 +281,7 @@ describe("GitWorkingStateService", () => {
 
       expect(response.changes).toEqual([
         {
-          path: `${tmpRoot}/note.txt`,
+          path: normalizeTestPath(path.join(tmpRoot, "note.txt")),
           repoPath: "note.txt",
           status: "untracked",
           staged: false,
@@ -280,7 +291,7 @@ describe("GitWorkingStateService", () => {
           removals: 0,
         },
         {
-          path: `${tmpRoot}/archive.zip`,
+          path: normalizeTestPath(path.join(tmpRoot, "archive.zip")),
           repoPath: "archive.zip",
           status: "untracked",
           staged: false,
@@ -295,9 +306,9 @@ describe("GitWorkingStateService", () => {
   });
 
   it("does not report line totals for tracked binary changes", async () => {
-    const tmpRoot = await mkdtemp("/tmp/pwragent-git-working-state-");
+    const tmpRoot = await mkdtemp(makeTempPrefix());
     try {
-      await writeFile(`${tmpRoot}/asset.png`, Buffer.from([0, 1, 2]));
+      await writeFile(path.join(tmpRoot, "asset.png"), Buffer.from([0, 1, 2]));
       const { runGit } = fakeGit((args) => {
         if (args.includes("status")) return " M asset.png\0";
         if (args.includes("--numstat")) return "-\t-\tasset.png\n";
@@ -309,7 +320,7 @@ describe("GitWorkingStateService", () => {
 
       expect(response.changes).toEqual([
         {
-          path: `${tmpRoot}/asset.png`,
+          path: normalizeTestPath(path.join(tmpRoot, "asset.png")),
           repoPath: "asset.png",
           status: "modified",
           staged: false,
@@ -324,8 +335,8 @@ describe("GitWorkingStateService", () => {
   });
 
   it("builds a single-file diff on demand for an untracked file", async () => {
-    const tmpRoot = await mkdtemp("/tmp/pwragent-git-working-state-");
-    const filePath = `${tmpRoot}/note.txt`;
+    const tmpRoot = await mkdtemp(makeTempPrefix());
+    const filePath = path.join(tmpRoot, "note.txt");
     await writeFile(filePath, "hello\nworld\n", "utf8");
     const { runGit } = fakeGit((args) => {
       if (args.includes("status")) return "?? note.txt";

--- a/apps/desktop/src/main/__tests__/git-working-state-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-working-state-service.test.ts
@@ -1,3 +1,4 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { describe, expect, it, vi } from "vitest";
 import {
   GitWorkingStateService,
@@ -45,7 +46,7 @@ describe("probeWorktreeWorkingState", () => {
     const state = await probeWorktreeWorkingState("/repo/wt", { runGit });
 
     expect(state).toEqual({
-      dirtyFiles: 2,
+      dirtyFiles: 4,
       dirtyAdditions: 3,
       dirtyDeletions: 1,
       untrackedFiles: 2,
@@ -103,6 +104,34 @@ describe("probeWorktreeWorkingState", () => {
     const { runGit } = fakeGit(() => undefined);
     expect(await probeWorktreeWorkingState("/not/a/repo", { runGit })).toBeUndefined();
   });
+
+  it("includes cheap untracked text additions in the dirty working-state totals", async () => {
+    const tmpRoot = await mkdtemp("/tmp/pwragent-git-working-state-");
+    try {
+      await writeFile(`${tmpRoot}/note.txt`, "alpha\nbeta\n", "utf8");
+      await writeFile(`${tmpRoot}/archive.zip`, Buffer.from([0, 1, 2, 3]));
+      const { runGit } = fakeGit((args) => {
+        if (args.includes("--numstat")) return "3\t1\tsrc/a.ts\n";
+        if (args.includes("status")) {
+          return " M src/a.ts\0?? note.txt\0?? archive.zip\0?? scratch/\0";
+        }
+        if (args[args.length - 1] === "remote") return "";
+        return undefined;
+      });
+
+      const state = await probeWorktreeWorkingState(tmpRoot, { runGit });
+
+      expect(state).toEqual({
+        dirtyFiles: 4,
+        dirtyAdditions: 5,
+        dirtyDeletions: 1,
+        untrackedFiles: 3,
+        unpushedCommits: 0,
+      });
+    } finally {
+      await rm(tmpRoot, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("GitWorkingStateService", () => {
@@ -150,7 +179,173 @@ describe("GitWorkingStateService", () => {
     }
 
     expect([...seen.keys()].sort()).toEqual(["/repo/one", "/repo/two"]);
-    expect(seen.get("/repo/one")).toMatchObject({ dirtyFiles: 2 });
+    expect(seen.get("/repo/one")).toMatchObject({ dirtyFiles: 4 });
+  });
+
+  it("lists other worktree changes with excluded turn paths filtered before the cap", async () => {
+    const { runGit } = fakeGit((args) => {
+      if (args.includes("status")) {
+        return [
+          " M src/turn.ts",
+          " M docs/PwrAgnt v2.html",
+          "A  src/other-b.ts",
+          "?? scratch/",
+          "",
+        ].join("\0");
+      }
+      if (args.includes("--numstat")) {
+        return "2\t1\tdocs/PwrAgnt v2.html\n4\t0\tsrc/other-b.ts\n";
+      }
+      return undefined;
+    });
+    const service = new GitWorkingStateService({ runGit });
+
+    const response = await service.listOtherChanges("/repo/wt", {
+      excludePaths: ["/repo/wt/src/turn.ts"],
+      maxFiles: 2,
+    });
+
+    expect(response).toEqual({
+      changes: [
+        {
+          path: "/repo/wt/docs/PwrAgnt v2.html",
+          repoPath: "docs/PwrAgnt v2.html",
+          status: "modified",
+          staged: false,
+          unstaged: true,
+          additions: 2,
+          removals: 1,
+        },
+        {
+          path: "/repo/wt/src/other-b.ts",
+          repoPath: "src/other-b.ts",
+          status: "added",
+          staged: true,
+          unstaged: false,
+          additions: 4,
+          removals: 0,
+        },
+      ],
+      totalChanges: 3,
+      truncated: true,
+      maxFiles: 2,
+    });
+  });
+
+  it("recovers unstaged status records after git stdout trimming", async () => {
+    const { runGit } = fakeGit((args) => {
+      if (args.includes("status")) {
+        return "M apps/desktop/src/main/__tests__/git-working-state-service.test.ts\0";
+      }
+      if (args.includes("--numstat")) {
+        return "";
+      }
+      return undefined;
+    });
+    const service = new GitWorkingStateService({ runGit });
+
+    const response = await service.listOtherChanges("/repo/wt", {
+      excludePaths: [
+        "/repo/wt/apps/desktop/src/main/__tests__/git-working-state-service.test.ts",
+      ],
+    });
+
+    expect(response.changes).toEqual([]);
+    expect(response.totalChanges).toBe(0);
+  });
+
+  it("reports added-line totals for small untracked text files and byte sizes for binary files", async () => {
+    const tmpRoot = await mkdtemp("/tmp/pwragent-git-working-state-");
+    try {
+      await writeFile(`${tmpRoot}/note.txt`, "alpha\nbeta\n", "utf8");
+      await writeFile(`${tmpRoot}/archive.zip`, Buffer.from([0, 1, 2, 3]));
+      const { runGit } = fakeGit((args) => {
+        if (args.includes("status")) return "?? note.txt\0?? archive.zip\0";
+        if (args.includes("--numstat")) return "";
+        return undefined;
+      });
+      const service = new GitWorkingStateService({ runGit });
+
+      const response = await service.listOtherChanges(tmpRoot);
+
+      expect(response.changes).toEqual([
+        {
+          path: `${tmpRoot}/note.txt`,
+          repoPath: "note.txt",
+          status: "untracked",
+          staged: false,
+          unstaged: true,
+          sizeBytes: 11,
+          additions: 2,
+          removals: 0,
+        },
+        {
+          path: `${tmpRoot}/archive.zip`,
+          repoPath: "archive.zip",
+          status: "untracked",
+          staged: false,
+          unstaged: true,
+          binary: true,
+          sizeBytes: 4,
+        },
+      ]);
+    } finally {
+      await rm(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("does not report line totals for tracked binary changes", async () => {
+    const tmpRoot = await mkdtemp("/tmp/pwragent-git-working-state-");
+    try {
+      await writeFile(`${tmpRoot}/asset.png`, Buffer.from([0, 1, 2]));
+      const { runGit } = fakeGit((args) => {
+        if (args.includes("status")) return " M asset.png\0";
+        if (args.includes("--numstat")) return "-\t-\tasset.png\n";
+        return undefined;
+      });
+      const service = new GitWorkingStateService({ runGit });
+
+      const response = await service.listOtherChanges(tmpRoot);
+
+      expect(response.changes).toEqual([
+        {
+          path: `${tmpRoot}/asset.png`,
+          repoPath: "asset.png",
+          status: "modified",
+          staged: false,
+          unstaged: true,
+          binary: true,
+          sizeBytes: 3,
+        },
+      ]);
+    } finally {
+      await rm(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("builds a single-file diff on demand for an untracked file", async () => {
+    const tmpRoot = await mkdtemp("/tmp/pwragent-git-working-state-");
+    const filePath = `${tmpRoot}/note.txt`;
+    await writeFile(filePath, "hello\nworld\n", "utf8");
+    const { runGit } = fakeGit((args) => {
+      if (args.includes("status")) return "?? note.txt";
+      return undefined;
+    });
+    const service = new GitWorkingStateService({ runGit });
+
+    try {
+      const response = await service.getOtherChangeDiff(tmpRoot, filePath);
+
+      expect(response.detail?.fileDiff).toMatchObject({
+        kind: "add",
+        additions: 2,
+        removals: 0,
+      });
+      expect(response.detail?.fileDiff?.diff).toContain("+++ b/note.txt");
+      expect(response.detail?.fileDiff?.diff).toContain("+hello");
+    } finally {
+      await rm(tmpRoot, { recursive: true, force: true });
+    }
   });
 });
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -5289,6 +5289,25 @@ export class DesktopBackendRegistry {
     );
   }
 
+  async listWorktreeOtherChanges(
+    worktreePath: string,
+    options?: { excludePaths?: string[]; maxFiles?: number },
+  ) {
+    return await this.gitWorkingStateService.listOtherChanges(worktreePath, options);
+  }
+
+  async getWorktreeOtherChangeDiff(
+    worktreePath: string,
+    filePath: string,
+    options?: { maxBytes?: number },
+  ) {
+    return await this.gitWorkingStateService.getOtherChangeDiff(
+      worktreePath,
+      filePath,
+      options,
+    );
+  }
+
   async readThread(
     request: AppServerReadThreadRequest
   ): Promise<AppServerReadThreadResponse> {

--- a/apps/desktop/src/main/app-server/git-working-state-service.ts
+++ b/apps/desktop/src/main/app-server/git-working-state-service.ts
@@ -1,9 +1,13 @@
 import path from "node:path";
+import { readFile, stat } from "node:fs/promises";
 import { IterableMapper } from "@shutterstock/p-map-iterable";
 import type {
+  AppServerThreadActivityDetail,
   EditGroupCommitInput,
   EditGroupCommitState,
   ThreadGitWorkingState,
+  WorktreeOtherChangeEntry,
+  WorktreeOtherChangeStatus,
 } from "@pwragent/shared";
 import { runGitCommand } from "./git-executable";
 
@@ -13,6 +17,10 @@ function normalizeAbsolutePath(value: string): string {
 
 /** Bounded concurrency for the per-group `git log`/`rev-list` commit probes. */
 const EDIT_COMMIT_RESOLVE_CONCURRENCY = 4;
+const DEFAULT_OTHER_CHANGES_MAX_FILES = 50;
+const HARD_OTHER_CHANGES_MAX_FILES = 100;
+const DEFAULT_OTHER_CHANGE_DIFF_MAX_BYTES = 200_000;
+const HARD_OTHER_CHANGE_DIFF_MAX_BYTES = 500_000;
 
 type GitCommandRunner = (
   cwd: string,
@@ -76,6 +84,271 @@ function parseNumstat(output: string): {
   return { files, additions, deletions };
 }
 
+function clampPositiveInteger(
+  value: number | undefined,
+  fallback: number,
+  max: number,
+): number {
+  if (!Number.isFinite(value) || value === undefined) {
+    return fallback;
+  }
+  return Math.max(1, Math.min(Math.floor(value), max));
+}
+
+function normalizeGitRelativePath(value: string): string {
+  return value.replace(/\\/g, "/").replace(/^\/+/, "");
+}
+
+function statusCodeToChangeStatus(
+  indexCode: string,
+  worktreeCode: string,
+): WorktreeOtherChangeStatus {
+  const code = indexCode !== " " && indexCode !== "?" ? indexCode : worktreeCode;
+  switch (code) {
+    case "A":
+      return "added";
+    case "C":
+      return "copied";
+    case "D":
+      return "deleted";
+    case "M":
+      return "modified";
+    case "R":
+      return "renamed";
+    case "T":
+      return "typechange";
+    case "?":
+      return "untracked";
+    default:
+      return "unknown";
+  }
+}
+
+function parseStatusPorcelainRecord(
+  record: string,
+  cwd: string,
+): WorktreeOtherChangeEntry | undefined {
+  if (record.length < 3) {
+    return undefined;
+  }
+  let indexCode = record[0] ?? " ";
+  let worktreeCode = record[1] ?? " ";
+  let pathStart = 3;
+  if (record[1] === " " && record[2] !== " ") {
+    // runGitCommand trims stdout; an unstaged-only status record starts with
+    // a leading space (` M path`), so after trim the first record can arrive
+    // as `M path`. Recover that shape instead of dropping the path's first
+    // character (`apps/...` -> `pps/...`).
+    indexCode = " ";
+    worktreeCode = record[0] ?? " ";
+    pathStart = 2;
+  }
+  let repoPath = record.slice(pathStart);
+  const renameSeparator = repoPath.indexOf(" -> ");
+  if (renameSeparator >= 0) {
+    repoPath = repoPath.slice(renameSeparator + " -> ".length);
+  }
+  repoPath = normalizeGitRelativePath(repoPath);
+  if (!repoPath) {
+    return undefined;
+  }
+  return {
+    path: normalizeAbsolutePath(path.resolve(cwd, repoPath)),
+    repoPath,
+    status: statusCodeToChangeStatus(indexCode, worktreeCode),
+    staged: indexCode !== " " && indexCode !== "?",
+    unstaged: worktreeCode !== " " || indexCode === "?",
+  };
+}
+
+function parseStatusPorcelain(
+  output: string,
+  cwd: string,
+): WorktreeOtherChangeEntry[] {
+  if (output.includes("\0")) {
+    const records = output.split("\0").filter(Boolean);
+    const entries: WorktreeOtherChangeEntry[] = [];
+    for (let index = 0; index < records.length; index += 1) {
+      const entry = parseStatusPorcelainRecord(records[index]!, cwd);
+      if (!entry) {
+        continue;
+      }
+      entries.push(entry);
+      if (entry.status === "renamed" || entry.status === "copied") {
+        index += 1;
+      }
+    }
+    return entries;
+  }
+
+  const entries: WorktreeOtherChangeEntry[] = [];
+  for (const rawLine of output.split("\n")) {
+    if (!rawLine) {
+      continue;
+    }
+    const entry = parseStatusPorcelainRecord(rawLine, cwd);
+    if (entry) entries.push(entry);
+  }
+  return entries;
+}
+
+function parseNumstatByPath(
+  output: string,
+): Map<string, { additions?: number; removals?: number; binary?: boolean }> {
+  const stats = new Map<
+    string,
+    { additions?: number; removals?: number; binary?: boolean }
+  >();
+  for (const line of output.split("\n")) {
+    const [rawAdditions, rawRemovals, ...pathParts] = line.split("\t");
+    const repoPath = normalizeGitRelativePath(pathParts.join("\t"));
+    if (!repoPath) {
+      continue;
+    }
+    if (rawAdditions === "-" || rawRemovals === "-") {
+      stats.set(repoPath, { binary: true });
+    } else {
+      stats.set(repoPath, {
+        additions: rawAdditions ? Number(rawAdditions) || 0 : 0,
+        removals: rawRemovals ? Number(rawRemovals) || 0 : 0,
+      });
+    }
+  }
+  return stats;
+}
+
+function isPathInsideWorktree(cwd: string, absolutePath: string): boolean {
+  const relative = path.relative(cwd, absolutePath);
+  return Boolean(relative) && !relative.startsWith("..") && !path.isAbsolute(relative);
+}
+
+function summarizeDiffText(diff: string): {
+  additions: number;
+  removals: number;
+} {
+  let additions = 0;
+  let removals = 0;
+  for (const line of diff.split("\n")) {
+    if (
+      line.startsWith("+++") ||
+      line.startsWith("---") ||
+      line.startsWith("@@") ||
+      line.startsWith("\\")
+    ) {
+      continue;
+    }
+    if (line.startsWith("+")) {
+      additions += 1;
+    } else if (line.startsWith("-")) {
+      removals += 1;
+    }
+  }
+  return { additions, removals };
+}
+
+function countTextLines(contents: string): number {
+  if (contents.length === 0) {
+    return 0;
+  }
+  const lines = contents.split("\n");
+  return lines.length > 0 && lines[lines.length - 1] === ""
+    ? lines.length - 1
+    : lines.length;
+}
+
+async function readFileSize(absolutePath: string): Promise<number | undefined> {
+  try {
+    const fileStat = await stat(absolutePath);
+    return fileStat.size;
+  } catch {
+    return undefined;
+  }
+}
+
+async function enrichUntrackedChangeStats(
+  entry: WorktreeOtherChangeEntry,
+): Promise<void> {
+  try {
+    const fileStat = await stat(entry.path);
+    if (!fileStat.isFile()) {
+      return;
+    }
+    entry.sizeBytes = fileStat.size;
+    if (fileStat.size > DEFAULT_OTHER_CHANGE_DIFF_MAX_BYTES) {
+      return;
+    }
+    const buffer = await readFile(entry.path);
+    if (buffer.includes(0)) {
+      entry.binary = true;
+      return;
+    }
+    entry.additions = countTextLines(buffer.toString("utf8"));
+    entry.removals = 0;
+  } catch {
+    // Summary stats are best-effort; expansion can still report a precise
+    // omitted/unavailable reason for the single requested file.
+  }
+}
+
+async function summarizeUntrackedChanges(
+  cwd: string,
+  statusOutput: string,
+): Promise<{ files: number; additions: number }> {
+  const untrackedEntries = parseStatusPorcelain(statusOutput, cwd).filter(
+    (entry) => entry.status === "untracked",
+  );
+  const visibleEntries = untrackedEntries.slice(0, DEFAULT_OTHER_CHANGES_MAX_FILES);
+  await Promise.all(visibleEntries.map((entry) => enrichUntrackedChangeStats(entry)));
+  return {
+    files: untrackedEntries.length,
+    additions: visibleEntries.reduce(
+      (sum, entry) => sum + (entry.additions ?? 0),
+      0,
+    ),
+  };
+}
+
+function buildUntrackedFileDiff(repoPath: string, contents: string): string {
+  const lines = contents.length > 0 ? contents.split("\n") : [];
+  const lineCount = countTextLines(contents);
+  const body = lines
+    .slice(0, lineCount)
+    .map((line) => `+${line}`)
+    .join("\n");
+  return [
+    `diff --git a/${repoPath} b/${repoPath}`,
+    "new file mode 100644",
+    "index 0000000..0000000",
+    "--- /dev/null",
+    `+++ b/${repoPath}`,
+    `@@ -0,0 +1,${lineCount} @@`,
+    body,
+  ]
+    .filter((line, index) => index < 6 || line.length > 0)
+    .join("\n");
+}
+
+function statusLabel(status: WorktreeOtherChangeStatus): string {
+  switch (status) {
+    case "added":
+      return "Added";
+    case "copied":
+      return "Copied";
+    case "deleted":
+      return "Deleted";
+    case "modified":
+      return "Modified";
+    case "renamed":
+      return "Renamed";
+    case "typechange":
+      return "Type changed";
+    case "untracked":
+      return "Untracked";
+    default:
+      return "Changed";
+  }
+}
+
 /**
  * Probe a thread's working directory for its local git working state:
  * uncommitted change totals (staged + unstaged vs HEAD), untracked file
@@ -103,7 +376,12 @@ export async function probeWorktreeWorkingState(
     // Staged + unstaged line counts vs HEAD. Fails on an unborn HEAD
     // (fresh repo with no commits) — treated as "no tracked changes".
     runGitNoLocks(["diff", "--numstat", "HEAD"]).catch(() => undefined),
-    runGitNoLocks(["status", "--porcelain"]).catch(() => undefined),
+    runGitNoLocks([
+      "status",
+      "--porcelain=v1",
+      "-z",
+      "--untracked-files=normal",
+    ]).catch(() => undefined),
     runGitNoLocks(["remote"]).catch(() => undefined),
   ]);
   if (numstatOutput === undefined && statusOutput === undefined) {
@@ -111,9 +389,7 @@ export async function probeWorktreeWorkingState(
   }
 
   const numstat = parseNumstat(numstatOutput ?? "");
-  const untrackedFiles = (statusOutput ?? "")
-    .split("\n")
-    .filter((line) => line.startsWith("??")).length;
+  const untracked = await summarizeUntrackedChanges(worktreePath, statusOutput ?? "");
 
   // "Unpushed" means reachable from HEAD but on no remote ref. With no
   // remotes configured, every commit would count — meaningless for a
@@ -150,10 +426,10 @@ export async function probeWorktreeWorkingState(
   }
 
   return {
-    dirtyFiles: numstat.files,
-    dirtyAdditions: numstat.additions,
+    dirtyFiles: numstat.files + untracked.files,
+    dirtyAdditions: numstat.additions + untracked.additions,
     dirtyDeletions: numstat.deletions,
-    untrackedFiles,
+    untrackedFiles: untracked.files,
     unpushedCommits,
   };
 }
@@ -280,6 +556,182 @@ export class GitWorkingStateService {
         this.cache.delete(cacheKey);
       }
     }
+  }
+
+  /**
+   * List worktree changes that are not already represented by turn-level
+   * edited-file groups. This is intentionally summary-only: file count is
+   * capped, untracked directories stay collapsed by git's default status mode,
+   * and no patch text is generated here.
+   */
+  async listOtherChanges(
+    worktreePath: string,
+    options: {
+      excludePaths?: string[];
+      maxFiles?: number;
+    } = {},
+  ): Promise<{
+    changes: WorktreeOtherChangeEntry[];
+    totalChanges: number;
+    truncated: boolean;
+    maxFiles: number;
+  }> {
+    const cwd = worktreePath?.trim();
+    const maxFiles = clampPositiveInteger(
+      options.maxFiles,
+      DEFAULT_OTHER_CHANGES_MAX_FILES,
+      HARD_OTHER_CHANGES_MAX_FILES,
+    );
+    if (!cwd) {
+      return { changes: [], totalChanges: 0, truncated: false, maxFiles };
+    }
+
+    const noLocks = (args: string[]): Promise<string> =>
+      this.runGit(cwd, ["--no-optional-locks", ...args], this.gitEnv);
+    const output = await noLocks([
+      "status",
+      "--porcelain=v1",
+      "-z",
+      "--untracked-files=normal",
+    ]).catch(() => "");
+    const excluded = new Set(
+      (options.excludePaths ?? [])
+        .map((value) => value.trim())
+        .filter(Boolean)
+        .map(normalizeAbsolutePath),
+    );
+    const allChanges = parseStatusPorcelain(output, cwd).filter(
+      (entry) => !excluded.has(normalizeAbsolutePath(entry.path)),
+    );
+    const visible = allChanges.slice(0, maxFiles);
+
+    const trackedPaths = visible
+      .filter((entry) => entry.status !== "untracked")
+      .map((entry) => entry.repoPath);
+    if (trackedPaths.length > 0) {
+      const numstatOutput = await noLocks([
+        "diff",
+        "--numstat",
+        "HEAD",
+        "--",
+        ...trackedPaths,
+      ]).catch(() => "");
+      const statsByPath = parseNumstatByPath(numstatOutput);
+      for (const entry of visible) {
+        const stats = statsByPath.get(entry.repoPath);
+        if (stats) {
+          if (stats.binary) {
+            entry.binary = true;
+            entry.sizeBytes = await readFileSize(entry.path);
+          } else {
+            entry.additions = stats.additions ?? 0;
+            entry.removals = stats.removals ?? 0;
+          }
+        }
+      }
+    }
+
+    await Promise.all(
+      visible
+        .filter((entry) => entry.status === "untracked")
+        .map((entry) => enrichUntrackedChangeStats(entry)),
+    );
+
+    return {
+      changes: visible,
+      totalChanges: allChanges.length,
+      truncated: allChanges.length > visible.length,
+      maxFiles,
+    };
+  }
+
+  async getOtherChangeDiff(
+    worktreePath: string,
+    filePath: string,
+    options: { maxBytes?: number } = {},
+  ): Promise<{ detail?: AppServerThreadActivityDetail }> {
+    const cwd = worktreePath?.trim();
+    const absolutePath = normalizeAbsolutePath(path.resolve(filePath));
+    const maxBytes = clampPositiveInteger(
+      options.maxBytes,
+      DEFAULT_OTHER_CHANGE_DIFF_MAX_BYTES,
+      HARD_OTHER_CHANGE_DIFF_MAX_BYTES,
+    );
+    if (!cwd || !isPathInsideWorktree(cwd, absolutePath)) {
+      return {};
+    }
+
+    const repoPath = normalizeGitRelativePath(path.relative(cwd, absolutePath));
+    const noLocks = (args: string[]): Promise<string> =>
+      this.runGit(cwd, ["--no-optional-locks", ...args], this.gitEnv);
+    const status = parseStatusPorcelain(
+      await noLocks([
+        "status",
+        "--porcelain=v1",
+        "-z",
+        "--untracked-files=normal",
+        "--",
+        repoPath,
+      ]).catch(() => ""),
+      cwd,
+    ).find((entry) => normalizeAbsolutePath(entry.path) === absolutePath);
+    if (!status) {
+      return {};
+    }
+
+    let diff = "";
+    let omittedReason: string | undefined;
+    if (status.status === "untracked") {
+      try {
+        const fileStat = await stat(absolutePath);
+        if (!fileStat.isFile()) {
+          omittedReason = "Diff omitted for untracked directory.";
+        } else if (fileStat.size > maxBytes) {
+          omittedReason = `Diff omitted for large untracked file (${fileStat.size.toLocaleString()} bytes).`;
+        } else {
+          const buffer = await readFile(absolutePath);
+          if (buffer.includes(0)) {
+            omittedReason = "Diff omitted for binary untracked file.";
+          } else {
+            diff = buildUntrackedFileDiff(repoPath, buffer.toString("utf8"));
+          }
+        }
+      } catch {
+        omittedReason = "Diff unavailable for this untracked file.";
+      }
+    } else {
+      diff = await noLocks(["diff", "--no-ext-diff", "HEAD", "--", repoPath]).catch(
+        () => "",
+      );
+      if (diff.length > maxBytes) {
+        omittedReason = `Diff omitted because it exceeds ${maxBytes.toLocaleString()} bytes.`;
+        diff = "";
+      }
+    }
+
+    const stats = summarizeDiffText(diff);
+    const fileDiffKind =
+      status.status === "deleted"
+        ? "delete"
+        : status.status === "untracked" || status.status === "added"
+          ? "add"
+          : "update";
+    return {
+      detail: {
+        id: `other-change:${absolutePath}`,
+        kind: "write",
+        label: path.basename(repoPath) || repoPath,
+        path: absolutePath,
+        fileDiff: {
+          kind: fileDiffKind,
+          diff,
+          additions: status.additions ?? stats.additions,
+          removals: status.removals ?? stats.removals,
+          ...(omittedReason ? { omittedReason } : {}),
+        },
+        markdown: statusLabel(status.status),
+      },
+    };
   }
 
   /**

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -85,6 +85,10 @@ import {
   type RestoreWorktreeResponse,
   type ResolveEditCommitStatesRequest,
   type ResolveEditCommitStatesResponse,
+  type ListWorktreeOtherChangesRequest,
+  type ListWorktreeOtherChangesResponse,
+  type GetWorktreeOtherChangeDiffRequest,
+  type GetWorktreeOtherChangeDiffResponse,
   type RestoreThreadRequest,
   type RestoreThreadResponse,
   type ThreadGitWorkingState,
@@ -128,6 +132,8 @@ import {
   NAVIGATION_GET_GH_STATUS_CHANNEL,
   NAVIGATION_REFRESH_DIRECTORY_GIT_STATUSES_CHANNEL,
   NAVIGATION_RESOLVE_EDIT_COMMIT_STATES_CHANNEL,
+  NAVIGATION_LIST_WORKTREE_OTHER_CHANGES_CHANNEL,
+  NAVIGATION_GET_WORKTREE_OTHER_CHANGE_DIFF_CHANNEL,
   NAVIGATION_REFRESH_THREAD_PRS_CHANNEL,
   NAVIGATION_REORDER_DIRECTORY_PINS_CHANNEL,
   NAVIGATION_REORDER_THREAD_PINS_CHANNEL,
@@ -1017,6 +1023,28 @@ class DesktopAppServerService {
     } finally {
       this.pendingEditCommitResolves.delete(requestKey);
     }
+  }
+
+  async listWorktreeOtherChanges(
+    request: ListWorktreeOtherChangesRequest,
+  ): Promise<ListWorktreeOtherChangesResponse> {
+    return await getDesktopBackendRegistry().listWorktreeOtherChanges(
+      request.worktreePath,
+      {
+        excludePaths: request.excludePaths,
+        maxFiles: request.maxFiles,
+      },
+    );
+  }
+
+  async getWorktreeOtherChangeDiff(
+    request: GetWorktreeOtherChangeDiffRequest,
+  ): Promise<GetWorktreeOtherChangeDiffResponse> {
+    return await getDesktopBackendRegistry().getWorktreeOtherChangeDiff(
+      request.worktreePath,
+      request.path,
+      { maxBytes: request.maxBytes },
+    );
   }
 
   private collectThreadWorktreePaths(
@@ -3208,6 +3236,26 @@ export function registerAppServerIpcHandlers(): void {
       return await appServerService.resolveEditCommitStates(request);
     },
   );
+  ipcMain.removeHandler(NAVIGATION_LIST_WORKTREE_OTHER_CHANGES_CHANNEL);
+  ipcMain.handle(
+    NAVIGATION_LIST_WORKTREE_OTHER_CHANGES_CHANNEL,
+    async (
+      _event,
+      request: ListWorktreeOtherChangesRequest,
+    ): Promise<ListWorktreeOtherChangesResponse> => {
+      return await appServerService.listWorktreeOtherChanges(request);
+    },
+  );
+  ipcMain.removeHandler(NAVIGATION_GET_WORKTREE_OTHER_CHANGE_DIFF_CHANNEL);
+  ipcMain.handle(
+    NAVIGATION_GET_WORKTREE_OTHER_CHANGE_DIFF_CHANNEL,
+    async (
+      _event,
+      request: GetWorktreeOtherChangeDiffRequest,
+    ): Promise<GetWorktreeOtherChangeDiffResponse> => {
+      return await appServerService.getWorktreeOtherChangeDiff(request);
+    },
+  );
   ipcMain.removeHandler(NAVIGATION_GET_GH_STATUS_CHANNEL);
   ipcMain.handle(
     NAVIGATION_GET_GH_STATUS_CHANNEL,
@@ -3298,6 +3346,8 @@ export async function disposeAppServerIpcHandlers(): Promise<void> {
   ipcMain.removeHandler(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_REFRESH_DIRECTORY_GIT_STATUSES_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_RESOLVE_EDIT_COMMIT_STATES_CHANNEL);
+  ipcMain.removeHandler(NAVIGATION_LIST_WORKTREE_OTHER_CHANGES_CHANNEL);
+  ipcMain.removeHandler(NAVIGATION_GET_WORKTREE_OTHER_CHANGE_DIFF_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_GET_GH_STATUS_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_ENSURE_DIRECTORY_LAUNCHPAD_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_UPDATE_DIRECTORY_LAUNCHPAD_CHANNEL);

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -117,6 +117,10 @@ import type {
   RefreshDirectoryGitStatusesResponse,
   ResolveEditCommitStatesRequest,
   ResolveEditCommitStatesResponse,
+  ListWorktreeOtherChangesRequest,
+  ListWorktreeOtherChangesResponse,
+  GetWorktreeOtherChangeDiffRequest,
+  GetWorktreeOtherChangeDiffResponse,
   NavigationSnapshot,
   ResetDirectoryLaunchpadRequest,
   ResetDirectoryLaunchpadResponse,
@@ -323,6 +327,8 @@ import {
   NAVIGATION_REFRESH_THREAD_PRS_CHANNEL,
   NAVIGATION_REFRESH_DIRECTORY_GIT_STATUSES_CHANNEL,
   NAVIGATION_RESOLVE_EDIT_COMMIT_STATES_CHANNEL,
+  NAVIGATION_LIST_WORKTREE_OTHER_CHANGES_CHANNEL,
+  NAVIGATION_GET_WORKTREE_OTHER_CHANGE_DIFF_CHANNEL,
   NAVIGATION_REORDER_DIRECTORY_PINS_CHANNEL,
   NAVIGATION_REORDER_THREAD_PINS_CHANNEL,
   NAVIGATION_REGISTER_DIRECTORY_FROM_DISK_CHANNEL,
@@ -1023,6 +1029,20 @@ const desktopApi = Object.freeze({
   ): Promise<ResolveEditCommitStatesResponse> =>
     await ipcRenderer.invoke(
       NAVIGATION_RESOLVE_EDIT_COMMIT_STATES_CHANNEL,
+      request,
+    ),
+  listWorktreeOtherChanges: async (
+    request: ListWorktreeOtherChangesRequest,
+  ): Promise<ListWorktreeOtherChangesResponse> =>
+    await ipcRenderer.invoke(
+      NAVIGATION_LIST_WORKTREE_OTHER_CHANGES_CHANNEL,
+      request,
+    ),
+  getWorktreeOtherChangeDiff: async (
+    request: GetWorktreeOtherChangeDiffRequest,
+  ): Promise<GetWorktreeOtherChangeDiffResponse> =>
+    await ipcRenderer.invoke(
+      NAVIGATION_GET_WORKTREE_OTHER_CHANGE_DIFF_CHANNEL,
       request,
     ),
   getGhStatus: async (request?: GetGhStatusRequest): Promise<GhStatus> =>

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
@@ -29,7 +29,7 @@ export function ThreadMetaChips({
   const branchDrifted = isBranchDrifted(thread.gitBranch, thread.observedGitBranch);
   const branchChip = thread.gitBranch ?? thread.observedGitBranch;
   const gitWorking = thread.gitWorkingState;
-  const hasTrackedDirt = Boolean(
+  const hasDirtySummary = Boolean(
     gitWorking &&
       (gitWorking.dirtyFiles > 0 ||
         gitWorking.dirtyAdditions > 0 ||
@@ -38,7 +38,7 @@ export function ThreadMetaChips({
   const hasUntracked = Boolean(gitWorking && gitWorking.untrackedFiles > 0);
   const dirtyTooltip = gitWorking
     ? [
-        hasTrackedDirt
+        hasDirtySummary
           ? `Uncommitted changes: ${gitWorking.dirtyFiles} file${
               gitWorking.dirtyFiles === 1 ? "" : "s"
             }, +${gitWorking.dirtyAdditions.toLocaleString()}, -${gitWorking.dirtyDeletions.toLocaleString()}`
@@ -182,7 +182,7 @@ export function ThreadMetaChips({
         </CopyableThreadChip>
       ) : null}
 
-      {hasTrackedDirt || hasUntracked ? (
+      {hasDirtySummary || hasUntracked ? (
         <span
           aria-label={dirtyTooltip.replace(/\n/g, "; ")}
           role="img"
@@ -192,7 +192,7 @@ export function ThreadMetaChips({
           }
           onMouseLeave={gitStateTooltip.hide}
         >
-          {hasTrackedDirt ? (
+          {hasDirtySummary ? (
             <>
               <span className="thread-row__chip-stat thread-row__chip-stat--added">
                 +{gitWorking!.dirtyAdditions.toLocaleString()}

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
@@ -441,7 +441,7 @@ describe("ThreadRow chip flow", () => {
       thread: {
         ...baseThread,
         gitWorkingState: {
-          dirtyFiles: 2,
+          dirtyFiles: 3,
           dirtyAdditions: 112,
           dirtyDeletions: 3,
           untrackedFiles: 1,
@@ -456,7 +456,7 @@ describe("ThreadRow chip flow", () => {
     expect(dirtyChip).toHaveTextContent("-3");
     expect(dirtyChip).toHaveAttribute(
       "aria-label",
-      "Uncommitted changes: 2 files, +112, -3; 1 untracked file",
+      "Uncommitted changes: 3 files, +112, -3; 1 untracked file",
     );
 
     const unpushedChip = container.querySelector(".thread-row__chip--unpushed");
@@ -468,7 +468,31 @@ describe("ThreadRow chip flow", () => {
     );
   });
 
-  it("renders an untracked-only dirty chip without +/- stats", () => {
+  it("renders an untracked-only dirty chip with +/- stats when available", () => {
+    const { container } = renderRow({
+      thread: {
+        ...baseThread,
+        gitWorkingState: {
+          dirtyFiles: 3,
+          dirtyAdditions: 17,
+          dirtyDeletions: 0,
+          untrackedFiles: 3,
+          unpushedCommits: 0,
+        },
+      },
+    });
+
+    const dirtyChip = container.querySelector(".thread-row__chip--dirty");
+    expect(dirtyChip).toHaveTextContent("+17");
+    expect(dirtyChip).toHaveTextContent("-0");
+    expect(dirtyChip).toHaveAttribute(
+      "aria-label",
+      "Uncommitted changes: 3 files, +17, -0; 3 untracked files",
+    );
+    expect(container.querySelector(".thread-row__chip--unpushed")).toBeNull();
+  });
+
+  it("renders a legacy untracked-only dirty chip without +/- stats", () => {
     const { container } = renderRow({
       thread: {
         ...baseThread,

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -617,6 +617,8 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
             groups={props.editedFileGroups ?? []}
             commitStatesByKey={props.editedFileCommitStates}
             worktreeRoot={props.editedFilesWorktreeRoot}
+            desktopApi={props.desktopApi}
+            workingStateRefreshKey={JSON.stringify(props.thread.gitWorkingState ?? null)}
             onOpenFile={props.onOpenEditedFile}
             preferredEditor={props.preferredEditor}
             onScrollToTurn={props.onScrollToTurn}

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/EditsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/EditsPanel.tsx
@@ -1,13 +1,20 @@
-import { useState } from "react";
+import { useEffect, useId, useMemo, useState } from "react";
 import type {
+  AppServerThreadActivityDetail,
   DesktopApplicationDiscoveryCandidate,
   EditGroupCommitState,
+  WorktreeOtherChangeEntry,
+  WorktreeOtherChangeStatus,
 } from "@pwragent/shared";
+import { EditorIcon } from "../../../icons";
+import type { DesktopApi } from "../../../lib/desktop-api";
+import { DiffStat } from "../DiffStat";
 import {
   EditedFileGroupList,
   EditedFileViewToggle,
   type EditedFileGroupView,
 } from "../EditedFileGroupList";
+import { TranscriptDiff } from "../TranscriptDiff";
 import type { EditedFileGroup } from "../edited-file-groups";
 import type { EditedFilesDock } from "./context-tab";
 
@@ -26,7 +33,157 @@ type EditsPanelProps = {
   onScrollToTurn?: (turnId: string, turnTimeMs?: number) => void;
   dock: EditedFilesDock;
   onDockChange: (dock: EditedFilesDock) => void;
+  desktopApi?: Pick<
+    DesktopApi,
+    "listWorktreeOtherChanges" | "getWorktreeOtherChangeDiff"
+  >;
+  workingStateRefreshKey?: string;
 };
+
+const OTHER_CHANGES_MAX_FILES = 50;
+const OTHER_CHANGE_DIFF_MAX_BYTES = 200_000;
+
+function collectEditedPaths(groups: readonly EditedFileGroup[]): string[] {
+  return [
+    ...new Set(
+      groups.flatMap((group) =>
+        group.details
+          .map((detail) => detail.path?.trim())
+          .filter((path): path is string => Boolean(path)),
+      ),
+    ),
+  ];
+}
+
+function useOtherWorktreeChanges(params: {
+  desktopApi?: Pick<DesktopApi, "listWorktreeOtherChanges">;
+  worktreeRoot?: string;
+  editedPaths: readonly string[];
+  refreshKey?: string;
+}) {
+  const [state, setState] = useState<{
+    changes: WorktreeOtherChangeEntry[];
+    totalChanges: number;
+    truncated: boolean;
+    loading: boolean;
+  }>({
+    changes: [],
+    totalChanges: 0,
+    truncated: false,
+    loading: false,
+  });
+  const sortedEditedPaths = useMemo(
+    () => [...params.editedPaths].sort(),
+    [params.editedPaths],
+  );
+  const editedPathSignature = useMemo(
+    () => JSON.stringify(sortedEditedPaths),
+    [sortedEditedPaths],
+  );
+
+  useEffect(() => {
+    const listChanges = params.desktopApi?.listWorktreeOtherChanges;
+    const worktreePath = params.worktreeRoot?.trim();
+    if (!listChanges || !worktreePath) {
+      setState({ changes: [], totalChanges: 0, truncated: false, loading: false });
+      return;
+    }
+
+    let cancelled = false;
+    setState((current) => ({ ...current, loading: true }));
+    void listChanges({
+      worktreePath,
+      excludePaths: sortedEditedPaths,
+      maxFiles: OTHER_CHANGES_MAX_FILES,
+    })
+      .then((response) => {
+        if (!cancelled) {
+          setState({
+            changes: response.changes,
+            totalChanges: response.totalChanges,
+            truncated: response.truncated,
+            loading: false,
+          });
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setState({ changes: [], totalChanges: 0, truncated: false, loading: false });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    params.desktopApi?.listWorktreeOtherChanges,
+    params.worktreeRoot,
+    editedPathSignature,
+    sortedEditedPaths,
+    params.refreshKey,
+  ]);
+
+  return state;
+}
+
+function statusAction(status: WorktreeOtherChangeStatus): string {
+  switch (status) {
+    case "added":
+    case "untracked":
+      return "Add";
+    case "copied":
+      return "Copy";
+    case "deleted":
+      return "Delete";
+    case "modified":
+    case "typechange":
+      return "Update";
+    case "renamed":
+      return "Rename";
+    default:
+      return "Update";
+  }
+}
+
+function basename(repoPath: string): string {
+  const normalized = repoPath.replace(/\\/g, "/").replace(/\/+$/, "");
+  return normalized.split("/").filter(Boolean).pop() ?? repoPath;
+}
+
+function otherChangeLabel(change: WorktreeOtherChangeEntry): string {
+  return `${statusAction(change.status)} ${basename(change.repoPath)}`;
+}
+
+function otherChangesSummary(totalChanges: number): string {
+  return `Other ${totalChanges.toLocaleString()} ${
+    totalChanges === 1 ? "file" : "files"
+  }`;
+}
+
+function formatByteSize(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) {
+    return "";
+  }
+  if (bytes >= 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
+  if (bytes >= 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+  return `${bytes.toLocaleString()} B`;
+}
+
+function FileSizeStat(props: { bytes: number }) {
+  const label = formatByteSize(props.bytes);
+  if (!label) {
+    return null;
+  }
+  return (
+    <span className="diff-stat diff-stat--chip file-size-stat" aria-label={label}>
+      {label}
+    </span>
+  );
+}
 
 /**
  * Context-rail Edits tab: the accumulated uncommitted file edits for
@@ -43,6 +200,17 @@ export function EditsPanel(props: EditsPanelProps) {
   const [view, setView] = useState<EditedFileGroupView>("turns");
   const hasGroups = props.groups.length > 0;
   const showViewToggle = props.groups.length > 1;
+  const editedPaths = useMemo(
+    () => collectEditedPaths(props.groups),
+    [props.groups],
+  );
+  const otherChanges = useOtherWorktreeChanges({
+    desktopApi: props.desktopApi,
+    worktreeRoot: props.worktreeRoot,
+    editedPaths,
+    refreshKey: props.workingStateRefreshKey,
+  });
+  const hasOtherChanges = otherChanges.changes.length > 0;
 
   return (
     <section className="context-panel__section context-panel__section--edits">
@@ -69,6 +237,16 @@ export function EditsPanel(props: EditsPanelProps) {
         </button>
       </div>
       <div className="edits-panel__body">
+        {hasOtherChanges ? (
+          <OtherChangesSection
+            changes={otherChanges.changes}
+            totalChanges={otherChanges.totalChanges}
+            truncated={otherChanges.truncated}
+            worktreeRoot={props.worktreeRoot}
+            desktopApi={props.desktopApi}
+            onOpenFile={props.onOpenFile}
+          />
+        ) : null}
         {hasGroups ? (
           <EditedFileGroupList
             groups={props.groups}
@@ -81,12 +259,203 @@ export function EditsPanel(props: EditsPanelProps) {
             showSingleGroupHeader
           />
         ) : (
-          <p className="context-empty">
-            No uncommitted file edits yet. Edits from agent turns accumulate
-            here until they are committed.
-          </p>
+          !hasOtherChanges && !otherChanges.loading ? (
+            <p className="context-empty">
+              No uncommitted file edits yet. Edits from agent turns accumulate
+              here until they are committed.
+            </p>
+          ) : null
         )}
       </div>
     </section>
+  );
+}
+
+function OtherChangesSection(props: {
+  changes: WorktreeOtherChangeEntry[];
+  totalChanges: number;
+  truncated: boolean;
+  worktreeRoot?: string;
+  desktopApi?: Pick<DesktopApi, "getWorktreeOtherChangeDiff">;
+  onOpenFile?: (absolutePath: string) => void;
+}) {
+  const [expanded, setExpanded] = useState(true);
+  const bodyId = useId();
+  const hiddenCount = Math.max(0, props.totalChanges - props.changes.length);
+  const totals = useMemo(
+    () =>
+      props.changes.reduce(
+        (sum, change) => ({
+          additions: sum.additions + (change.additions ?? 0),
+          removals: sum.removals + (change.removals ?? 0),
+        }),
+        { additions: 0, removals: 0 },
+      ),
+    [props.changes],
+  );
+
+  return (
+    <section className="edited-file-groups__group other-changes">
+      <div className="edited-file-groups__group-header other-changes__header">
+        <button
+          type="button"
+          className="edited-file-groups__group-toggle other-changes__toggle"
+          aria-expanded={expanded}
+          aria-controls={bodyId}
+          onClick={() => setExpanded((current) => !current)}
+        >
+          <span className="live-work-rail__chevron" aria-hidden="true" />
+          <span className="edited-file-groups__group-summary">
+            {otherChangesSummary(props.totalChanges)}
+          </span>
+        </button>
+        <DiffStat
+          additions={totals.additions}
+          removals={totals.removals}
+          className="diff-stat--chip"
+        />
+      </div>
+      <div id={bodyId} hidden={!expanded}>
+        {expanded ? (
+          <>
+            <ul className="live-work-rail__file-list">
+              {props.changes.map((change) => (
+                <li key={change.path} className="live-work-rail__file-row">
+                  <OtherChangeRow
+                    change={change}
+                    worktreeRoot={props.worktreeRoot}
+                    desktopApi={props.desktopApi}
+                    onOpenFile={props.onOpenFile}
+                  />
+                </li>
+              ))}
+            </ul>
+            {props.truncated ? (
+              <p className="other-changes__truncated">
+                {hiddenCount.toLocaleString()} more not shown.
+              </p>
+            ) : null}
+          </>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+function OtherChangeRow(props: {
+  change: WorktreeOtherChangeEntry;
+  worktreeRoot?: string;
+  desktopApi?: Pick<DesktopApi, "getWorktreeOtherChangeDiff">;
+  onOpenFile?: (absolutePath: string) => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const [detail, setDetail] = useState<
+    AppServerThreadActivityDetail | undefined
+  >();
+  const [loading, setLoading] = useState(false);
+  const diffId = useId();
+  const canOpen = Boolean(props.onOpenFile);
+  const hasStats =
+    props.change.additions !== undefined || props.change.removals !== undefined;
+  const showSize = !hasStats && props.change.sizeBytes !== undefined;
+  const label = otherChangeLabel(props.change);
+
+  useEffect(() => {
+    if (!expanded || detail) {
+      return;
+    }
+    const getDiff = props.desktopApi?.getWorktreeOtherChangeDiff;
+    const worktreePath = props.worktreeRoot?.trim();
+    if (!getDiff || !worktreePath) {
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    void getDiff({
+      worktreePath,
+      path: props.change.path,
+      maxBytes: OTHER_CHANGE_DIFF_MAX_BYTES,
+    })
+      .then((response) => {
+        if (!cancelled) {
+          setDetail(response.detail);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setDetail(undefined);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    detail,
+    expanded,
+    props.change.path,
+    props.desktopApi,
+    props.worktreeRoot,
+  ]);
+
+  return (
+    <>
+      <button
+        type="button"
+        className="live-work-rail__file-toggle"
+        aria-controls={diffId}
+        aria-expanded={expanded}
+        onClick={() => setExpanded((current) => !current)}
+      >
+        <span className="live-work-rail__chevron" aria-hidden="true" />
+        <span className="live-work-rail__file-label">
+          <span className="live-work-rail__file-path" title={props.change.path}>
+            {label}
+          </span>
+        </span>
+        {hasStats ? (
+          <DiffStat
+            additions={props.change.additions ?? 0}
+            removals={props.change.removals ?? 0}
+            className="diff-stat--chip"
+          />
+        ) : showSize ? (
+          <FileSizeStat bytes={props.change.sizeBytes ?? 0} />
+        ) : null}
+      </button>
+      <div id={diffId} className="live-work-rail__file-diff" hidden={!expanded}>
+        {expanded ? (
+          <>
+            <div className="edited-file-row__meta">
+              <span className="edited-file-row__path" title={props.change.path}>
+                {props.change.repoPath}
+              </span>
+              {canOpen ? (
+                <button
+                  type="button"
+                  className="edited-file-row__open"
+                  onClick={() => props.onOpenFile?.(props.change.path)}
+                  aria-label={`Open ${props.change.repoPath} in editor`}
+                  title="Open in editor"
+                >
+                  <EditorIcon className="edited-file-row__open-icon" />
+                </button>
+              ) : null}
+            </div>
+            {loading ? (
+              <p className="other-changes__loading">Loading diff...</p>
+            ) : detail ? (
+              <TranscriptDiff detail={detail} compact />
+            ) : (
+              <p className="other-changes__loading">Diff unavailable.</p>
+            )}
+          </>
+        ) : null}
+      </div>
+    </>
   );
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/EditsPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/EditsPanel.test.tsx
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom/vitest";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { EditsPanel } from "../EditsPanel";
 import type { EditedFileGroup } from "../../edited-file-groups";
 
@@ -82,5 +82,88 @@ describe("EditsPanel", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("aaaaaaa")).toBeInTheDocument();
     expect(screen.getByText("Pushed")).toBeInTheDocument();
+  });
+
+  it("shows non-turn worktree changes first and fetches their diff only when expanded", async () => {
+    const listWorktreeOtherChanges = vi.fn(async () => ({
+      changes: [
+        {
+          path: "/repo/docs/design.md",
+          repoPath: "docs/design.md",
+          status: "modified" as const,
+          staged: false,
+          unstaged: true,
+          additions: 3,
+          removals: 1,
+        },
+        {
+          path: "/repo/docs/PwrAgent.zip",
+          repoPath: "docs/PwrAgent.zip",
+          status: "untracked" as const,
+          staged: false,
+          unstaged: true,
+          binary: true,
+          sizeBytes: 15_846_287,
+        },
+      ],
+      totalChanges: 2,
+      truncated: false,
+      maxFiles: 50,
+    }));
+    const getWorktreeOtherChangeDiff = vi.fn(async () => ({
+      detail: {
+        id: "other-change:/repo/docs/design.md",
+        kind: "write" as const,
+        label: "design.md",
+        path: "/repo/docs/design.md",
+        fileDiff: {
+          kind: "update" as const,
+          diff: "--- a/docs/design.md\n+++ b/docs/design.md\n@@ -1 +1 @@\n-old\n+new\n",
+          additions: 1,
+          removals: 1,
+        },
+      },
+    }));
+
+    render(
+      <EditsPanel
+        groups={[editedGroup()]}
+        dock="sidebar"
+        onDockChange={vi.fn()}
+        worktreeRoot="/repo"
+        desktopApi={{ listWorktreeOtherChanges, getWorktreeOtherChangeDiff }}
+      />,
+    );
+
+    const otherToggle = await screen.findByRole("button", {
+      name: /Other 2 files/i,
+    });
+    expect(otherToggle).toBeInTheDocument();
+    expect(screen.getAllByLabelText("+3 -1")).toHaveLength(2);
+    expect(screen.getByText("Update design.md")).toBeInTheDocument();
+    expect(screen.getByText("Add PwrAgent.zip")).toBeInTheDocument();
+    expect(screen.getByLabelText("15.1 MB")).toBeInTheDocument();
+    expect(listWorktreeOtherChanges).toHaveBeenCalledWith({
+      worktreePath: "/repo",
+      excludePaths: ["/repo/apps/desktop/src/main/file-1.ts"],
+      maxFiles: 50,
+    });
+    expect(getWorktreeOtherChangeDiff).not.toHaveBeenCalled();
+
+    fireEvent.click(otherToggle);
+    expect(screen.queryByText("Update design.md")).not.toBeInTheDocument();
+
+    fireEvent.click(otherToggle);
+    fireEvent.click(screen.getByRole("button", { name: /Update design\.md/i }));
+
+    await waitFor(() => {
+      expect(getWorktreeOtherChangeDiff).toHaveBeenCalledWith({
+        worktreePath: "/repo",
+        path: "/repo/docs/design.md",
+        maxBytes: 200000,
+      });
+    });
+    expect(screen.getByText("docs/design.md")).toBeInTheDocument();
+    expect(await screen.findByText("new")).toBeInTheDocument();
   });
 });

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -115,6 +115,10 @@ import type {
   RefreshDirectoryGitStatusesResponse,
   ResolveEditCommitStatesRequest,
   ResolveEditCommitStatesResponse,
+  ListWorktreeOtherChangesRequest,
+  ListWorktreeOtherChangesResponse,
+  GetWorktreeOtherChangeDiffRequest,
+  GetWorktreeOtherChangeDiffResponse,
   NavigationSnapshot,
   ResetDirectoryLaunchpadRequest,
   ResetDirectoryLaunchpadResponse,
@@ -569,6 +573,12 @@ export type DesktopApi = {
   resolveEditCommitStates?: (
     request: ResolveEditCommitStatesRequest
   ) => Promise<ResolveEditCommitStatesResponse>;
+  listWorktreeOtherChanges?: (
+    request: ListWorktreeOtherChangesRequest
+  ) => Promise<ListWorktreeOtherChangesResponse>;
+  getWorktreeOtherChangeDiff?: (
+    request: GetWorktreeOtherChangeDiffRequest
+  ) => Promise<GetWorktreeOtherChangeDiffResponse>;
   getGhStatus?: (request?: GetGhStatusRequest) => Promise<GhStatus>;
   ensureDirectoryLaunchpad?: (
     request: EnsureDirectoryLaunchpadRequest

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -8873,6 +8873,10 @@ textarea,
   background: var(--bg-panel-elevated);
 }
 
+.file-size-stat {
+  color: var(--text-secondary);
+}
+
 .live-work-rail__file-diff {
   padding: 6px 6px 10px 18px;
 }
@@ -9179,6 +9183,22 @@ textarea,
   outline: 2px solid var(--focus-ring);
   outline-offset: 1px;
   border-radius: 3px;
+}
+
+.other-changes {
+  margin: 8px 0 10px;
+}
+
+.other-changes__truncated,
+.other-changes__loading {
+  margin: 6px 0 0;
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.other-changes .live-work-rail__file-list {
+  margin-top: 2px;
 }
 
 /* Context-rail Edits panel: a FIXED header (it lives outside the panel's

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -91,6 +91,10 @@ export const NAVIGATION_REFRESH_DIRECTORY_GIT_STATUSES_CHANNEL =
   "navigation:refresh-directory-git-statuses";
 export const NAVIGATION_RESOLVE_EDIT_COMMIT_STATES_CHANNEL =
   "navigation:resolve-edit-commit-states";
+export const NAVIGATION_LIST_WORKTREE_OTHER_CHANGES_CHANNEL =
+  "navigation:list-worktree-other-changes";
+export const NAVIGATION_GET_WORKTREE_OTHER_CHANGE_DIFF_CHANNEL =
+  "navigation:get-worktree-other-change-diff";
 export const MESSAGING_GET_PLATFORM_STATUSES_CHANNEL =
   "messaging:get-platform-statuses";
 export const MESSAGING_PLATFORM_STATUS_EVENT_CHANNEL =

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -3,6 +3,7 @@ import type {
   AppServerBackendScope,
   AppServerBuiltinBackendKind,
   AppServerBackendKind,
+  AppServerThreadActivityDetail,
   AppServerThreadActivityEntry,
   AppServerThreadImagePart,
   AppServerThreadSummary,
@@ -588,6 +589,54 @@ export type ResolveEditCommitStatesRequest = {
 
 export type ResolveEditCommitStatesResponse = {
   states: Record<string, EditGroupCommitState>;
+};
+
+export type WorktreeOtherChangeStatus =
+  | "added"
+  | "copied"
+  | "deleted"
+  | "modified"
+  | "renamed"
+  | "typechange"
+  | "untracked"
+  | "unknown";
+
+export type WorktreeOtherChangeEntry = {
+  path: string;
+  repoPath: string;
+  status: WorktreeOtherChangeStatus;
+  staged: boolean;
+  unstaged: boolean;
+  binary?: boolean;
+  sizeBytes?: number;
+  additions?: number;
+  removals?: number;
+};
+
+export type ListWorktreeOtherChangesRequest = {
+  worktreePath: string;
+  /** Absolute paths already represented by agent-turn edit groups. */
+  excludePaths?: string[];
+  /** Bounded by the main process; callers can request a smaller cap. */
+  maxFiles?: number;
+};
+
+export type ListWorktreeOtherChangesResponse = {
+  changes: WorktreeOtherChangeEntry[];
+  totalChanges: number;
+  truncated: boolean;
+  maxFiles: number;
+};
+
+export type GetWorktreeOtherChangeDiffRequest = {
+  worktreePath: string;
+  path: string;
+  /** Bounded by the main process; callers can request a smaller cap. */
+  maxBytes?: number;
+};
+
+export type GetWorktreeOtherChangeDiffResponse = {
+  detail?: AppServerThreadActivityDetail;
 };
 
 const ACP_BACKEND_ID_PREFIX = "acp:";


### PR DESCRIPTION
## Summary

The Edits panel now shows worktree changes that were not produced by agent turns, using the same collapsible file-group presentation as turn edits. This makes dirty work visible without generating every diff up front: the file list is capped, files already shown in turn edits are filtered out, and a single-file diff is fetched only when that row is expanded.

Dirty counts now tell the same story in the thread list and the Edits panel. Small untracked text files contribute added-line totals, untracked entries contribute to the file count, and binary or large files avoid fake line stats and surface byte-size metadata instead.

## Design Notes

- Untracked directories are counted as entries but are not recursively expanded, which protects repos that forgot to ignore large generated trees.
- Binary tracked and untracked files do not report `+0 -0`; they can show a size chip when the size is available.
- The Other changes section reuses the existing edited-file group chrome instead of introducing a separate bordered section style.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/git-working-state-service.test.ts apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/EditsPanel.test.tsx`
- `pnpm --filter @pwragent/desktop exec tsc --noEmit`
- `pnpm lint:colors`
- `pnpm lint:boundaries`
- `pnpm typecheck`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex GPT-5](https://img.shields.io/badge/Codex_GPT--5-000000)
