### PR TITLE
docs(design): refresh PwrAgent v2 prototype

### DIFF
--- a/docs/design/pwragent-v2/project/PwrAgnt v3.html
+++ b/docs/design/pwragent-v2/project/PwrAgnt v3.html
@@ -6,6 +6,7 @@
 <link rel="stylesheet" href="lib/colors_and_type.css">
 <link rel="stylesheet" href="styles.css">
 <link rel="stylesheet" href="newthread.css">
+<link rel="stylesheet" href="rbac.css">
 <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
 <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
 <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
@@ -19,6 +20,7 @@
 <script type="text/babel" src="threadview.jsx"></script>
 <script type="text/babel" src="rightrail.jsx"></script>
 <script type="text/babel" src="newthread.jsx"></script>
+<script type="text/babel" src="rbac.jsx"></script>
 <script type="text/babel" src="settings.jsx"></script>
 <script type="text/babel" src="activity.jsx"></script>
 <script type="text/babel" src="tweaks-panel.jsx"></script>
@@ -128,12 +130,13 @@ const PLATFORMS = [
 
 /* -------- defaults / tweaks -------- */
 const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
-  "lens": "Directories",
+  "lens": "Recents",
   "messagingOn": true,
   "blinkTelegram": false,
-  "showRail": false,
+  "showRail": true,
   "denseRows": false,
-  "showDevContext": false
+  "showDevContext": true,
+  "plainThreads": false
 }/*EDITMODE-END*/;
 
 function App() {
@@ -283,6 +286,7 @@ function App() {
         <div className={`pa-window ${showRail && screen === "main" ? "" : "no-rail"}`}>
           <window.PA.Sidebar
             showDevContext={tweaks.showDevContext}
+            plainThreads={tweaks.plainThreads}
             data={data}
             selectedId={screen === "newthread" ? null : selectedId}
             onSelect={(id) => { setSelectedId(id); setScreen("main"); }}
@@ -371,6 +375,7 @@ function App() {
           options={["Inbox", "Recents", "Directories"]}
         />
         <window.TweakToggle label="Show context rail" value={tweaks.showRail} onChange={(v) => setTweak("showRail", v)} />
+        <window.TweakToggle label="Plain threads (no chat/PRs)" value={tweaks.plainThreads} onChange={(v) => setTweak("plainThreads", v)} />
         <window.TweakToggle label="Show dev folder/branch (debug)" value={tweaks.showDevContext} onChange={(v) => setTweak("showDevContext", v)} />
         <window.TweakSection label="Messaging" />
         <window.TweakToggle label="Messaging on" value={tweaks.messagingOn} onChange={(v) => setTweak("messagingOn", v)} />
@@ -382,6 +387,7 @@ function App() {
         <window.TweakButton label="Settings · Experimental" onClick={() => { setScreen("settings"); setSettingsSection("experimental"); }} />
         <window.TweakButton label="Settings · Worktrees" onClick={() => { setScreen("settings"); setSettingsSection("worktrees"); }} />
         <window.TweakButton label="Settings · Applications" onClick={() => { setScreen("settings"); setSettingsSection("applications"); }} />
+        <window.TweakButton label="Settings · Access Control" onClick={() => { setScreen("settings"); setSettingsSection("access"); }} />
         <window.TweakButton label="Messaging Activity" onClick={() => setScreen("activity")} />
       </window.TweaksPanel>
     </div>

--- a/docs/design/pwragent-v2/project/PwrAgnt v4.html
+++ b/docs/design/pwragent-v2/project/PwrAgnt v4.html
@@ -6,6 +6,7 @@
 <link rel="stylesheet" href="lib/colors_and_type.css">
 <link rel="stylesheet" href="styles.css">
 <link rel="stylesheet" href="newthread.css">
+<link rel="stylesheet" href="rbac.css">
 <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
 <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
 <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
@@ -19,6 +20,7 @@
 <script type="text/babel" src="threadview.jsx"></script>
 <script type="text/babel" src="rightrail.jsx"></script>
 <script type="text/babel" src="newthread.jsx"></script>
+<script type="text/babel" src="rbac.jsx"></script>
 <script type="text/babel" src="settings.jsx"></script>
 <script type="text/babel" src="activity.jsx"></script>
 <script type="text/babel" src="tweaks-panel.jsx"></script>
@@ -128,12 +130,14 @@ const PLATFORMS = [
 
 /* -------- defaults / tweaks -------- */
 const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
-  "lens": "Directories",
+  "lens": "Recents",
   "messagingOn": true,
   "blinkTelegram": false,
-  "showRail": false,
+  "showRail": true,
   "denseRows": false,
-  "showDevContext": false
+  "showDevContext": true,
+  "plainThreads": true,
+  "contextPercent": 57
 }/*EDITMODE-END*/;
 
 function App() {
@@ -283,6 +287,7 @@ function App() {
         <div className={`pa-window ${showRail && screen === "main" ? "" : "no-rail"}`}>
           <window.PA.Sidebar
             showDevContext={tweaks.showDevContext}
+            plainThreads={tweaks.plainThreads}
             data={data}
             selectedId={screen === "newthread" ? null : selectedId}
             onSelect={(id) => { setSelectedId(id); setScreen("main"); }}
@@ -300,7 +305,7 @@ function App() {
               setScreen("newthread");
             }}
           />
-          {screen === "main" && threadForView && <window.PA.ThreadView thread={threadForView} onSend={sendMessage} />}
+          {screen === "main" && threadForView && <window.PA.ThreadView thread={threadForView} onSend={sendMessage} contextPercent={tweaks.contextPercent ?? 57} />}
           {screen === "newthread" && (
             <window.PA.NewThread
               recents={recents}
@@ -371,7 +376,15 @@ function App() {
           options={["Inbox", "Recents", "Directories"]}
         />
         <window.TweakToggle label="Show context rail" value={tweaks.showRail} onChange={(v) => setTweak("showRail", v)} />
+        <window.TweakToggle label="Plain threads (no chat/PRs)" value={tweaks.plainThreads} onChange={(v) => setTweak("plainThreads", v)} />
         <window.TweakToggle label="Show dev folder/branch (debug)" value={tweaks.showDevContext} onChange={(v) => setTweak("showDevContext", v)} />
+        <window.TweakSlider
+          label="Context window used"
+          min={0} max={100} step={1}
+          value={tweaks.contextPercent ?? 57}
+          onChange={(v) => setTweak("contextPercent", v)}
+          unit="%"
+        />
         <window.TweakSection label="Messaging" />
         <window.TweakToggle label="Messaging on" value={tweaks.messagingOn} onChange={(v) => setTweak("messagingOn", v)} />
         <window.TweakToggle label="Blink Telegram" value={tweaks.blinkTelegram} onChange={(v) => setTweak("blinkTelegram", v)} />
@@ -382,6 +395,7 @@ function App() {
         <window.TweakButton label="Settings · Experimental" onClick={() => { setScreen("settings"); setSettingsSection("experimental"); }} />
         <window.TweakButton label="Settings · Worktrees" onClick={() => { setScreen("settings"); setSettingsSection("worktrees"); }} />
         <window.TweakButton label="Settings · Applications" onClick={() => { setScreen("settings"); setSettingsSection("applications"); }} />
+        <window.TweakButton label="Settings · Access Control" onClick={() => { setScreen("settings"); setSettingsSection("access"); }} />
         <window.TweakButton label="Messaging Activity" onClick={() => setScreen("activity")} />
       </window.TweaksPanel>
     </div>

--- a/docs/design/pwragent-v2/project/lib/colors_and_type.css
+++ b/docs/design/pwragent-v2/project/lib/colors_and_type.css
@@ -14,35 +14,35 @@
   --font-display: "Geist", "SF Pro Display", system-ui, sans-serif;
 
   /* ---------- COLOR — surfaces (warm off-black system) ---------- */
-  --bg-app:            #0a0908;   /* root, slightly warm */
-  --bg-sidebar:        #0e0d0b;   /* nav rail */
-  --bg-panel:          #13110e;   /* primary cards/content panels */
-  --bg-panel-elevated: #1a1714;   /* nested cards, popovers */
-  --bg-panel-hover:    #1f1a15;   /* hover on panels */
-  --bg-row-active:     #2a1810;   /* deep copper-tinted, selected items */
-  --bg-input:          #0d0c0a;   /* input fields */
-  --bg-overlay:        rgba(10, 9, 8, 0.78);  /* modal scrim */
+  --bg-app:            #000000;   /* root, true black */
+  --bg-sidebar:        #050505;   /* nav rail */
+  --bg-panel:          #0a0a0a;   /* primary cards/content panels */
+  --bg-panel-elevated: #101010;   /* nested cards, popovers */
+  --bg-panel-hover:    #14110d;   /* hover on panels */
+  --bg-row-active:     #120800;   /* deep copper-black, selected items */
+  --bg-input:          #080808;   /* input fields */
+  --bg-overlay:        rgba(0, 0, 0, 0.78);  /* modal scrim */
 
   /* ---------- COLOR — borders ---------- */
-  --border-subtle: rgba(247, 243, 235, 0.08);
-  --border-default: rgba(247, 243, 235, 0.12);
-  --border-strong: rgba(247, 243, 235, 0.18);
+  --border-subtle: rgba(247, 243, 235, 0.10);
+  --border-default: rgba(247, 243, 235, 0.14);
+  --border-strong: rgba(247, 243, 235, 0.20);
 
   /* ---------- COLOR — text ---------- */
-  --text-primary:   #f5efe3;   /* warm bone — never pure white */
-  --text-secondary: #b8b0a4;
-  --text-muted:     #8a8275;
-  --text-subtle:    #5a544b;
+  --text-primary:   #f7f3eb;   /* warm bone — never pure white */
+  --text-secondary: #b8b0a5;
+  --text-muted:     #8c857a;
+  --text-subtle:    rgba(247, 243, 235, 0.42);
 
-  /* ---------- COLOR — accent (burnt copper) ---------- */
-  --accent:        #e8743a;
-  --accent-strong: #f48a55;
-  --accent-bright: #fda984;
-  --accent-deep:   #9c4d20;
-  --accent-soft:   rgba(232, 116, 58, 0.14);
-  --accent-tint:   rgba(232, 116, 58, 0.06);
-  --accent-border: rgba(232, 116, 58, 0.38);
-  --accent-shadow: rgba(232, 116, 58, 0.30);
+  /* ---------- COLOR — accent (tangerine) ---------- */
+  --accent:        #ff8a1f;
+  --accent-strong: #ffa33d;
+  --accent-bright: #ffb35c;
+  --accent-deep:   #b3590f;
+  --accent-soft:   rgba(255, 138, 31, 0.12);
+  --accent-tint:   rgba(255, 138, 31, 0.06);
+  --accent-border: rgba(255, 138, 31, 0.42);
+  --accent-shadow: rgba(255, 138, 31, 0.34);
 
   /* ---------- COLOR — brand blue (logo / parent stamp ONLY) ---------- */
   /* Reserved for the PwrDrvr brand mark on its navy plate. Do NOT use
@@ -52,28 +52,28 @@
   --brand-blue-deep:  #0e1a2b;
 
   /* ---------- COLOR — semantic ---------- */
-  --danger:        #e85a3a;
-  --danger-soft:   rgba(232, 90, 58, 0.16);
-  --danger-border: rgba(232, 90, 58, 0.36);
+  --danger:        #c45a3a;
+  --danger-soft:   rgba(185, 66, 50, 0.24);
+  --danger-border: rgba(255, 176, 161, 0.32);
   --danger-text:   #ffb0a1;
 
-  --success:       #6dba7e;
-  --success-soft:  rgba(109, 186, 126, 0.14);
-  --success-border:rgba(109, 186, 126, 0.32);
+  --success:       #5fa969;
+  --success-soft:  rgba(74, 148, 92, 0.18);
+  --success-border:rgba(74, 148, 92, 0.32);
   --success-text:  #9ce5b3;
 
-  --info:          #6b9ad8;
-  --info-soft:     rgba(107, 154, 216, 0.14);
-  --info-border:   rgba(107, 154, 216, 0.32);
-  --info-text:     #a8c5ee;
+  --info:          #5689c4;
+  --info-soft:     rgba(86, 137, 196, 0.16);
+  --info-border:   rgba(86, 137, 196, 0.28);
+  --info-text:     #9fc8ff;
 
-  --warn:          #d8a85a;
-  --warn-soft:     rgba(216, 168, 90, 0.14);
-  --warn-border:   rgba(216, 168, 90, 0.32);
+  --warn:          #d99a3d;
+  --warn-soft:     rgba(217, 154, 61, 0.16);
+  --warn-border:   rgba(217, 154, 61, 0.32);
   --warn-text:     #e8c890;
 
   /* ---------- BUTTON ---------- */
-  --button-text-on-accent: #1a0d05;   /* dark warm-black, used on bright copper fills */
+  --button-text-on-accent: #120800;   /* deep copper-black, used on bright tangerine fills */
 
   /* ---------- SHADOWS ---------- */
   --shadow-xs:     0 1px 2px rgba(0, 0, 0, 0.32);

--- a/docs/design/pwragent-v2/project/newthread.css
+++ b/docs/design/pwragent-v2/project/newthread.css
@@ -8,38 +8,46 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  background: var(--bg-thread, var(--bg-panel));
-}
-.pa-newthread__inner {
-  flex: 1;
-  min-height: 0;
-  display: flex;
-  flex-direction: column;
-  padding: 28px 32px 18px;
-  max-width: 1280px;
-  width: 100%;
-  margin: 0 auto;
+  background: var(--bg-app);
 }
 
-/* ---- Header ---- */
-.pa-newthread__header {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  margin-bottom: 18px;
+/* Top bar — same shape & rhythm as .pa-thread__header in threadview */
+.pa-newthread__topbar {
+  display: flex; align-items: center; gap: 12px;
+  padding: 14px 22px;
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-app);
 }
-.pa-newthread__eyebrow-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-.pa-newthread__eyebrow {
+.pa-newthread__topbar-eyebrow {
   font: 700 10px/1 var(--font-sans);
   color: var(--accent);
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  margin-right: 2px;
 }
+.pa-newthread__topbar-title {
+  margin: 0;
+  font: 700 16px/1.2 var(--font-sans);
+  color: var(--text-primary);
+  letter-spacing: -0.01em;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  max-width: 40%;
+}
+.pa-newthread__meta {
+  display: flex;
+  gap: 28px;
+}
+.pa-newthread__meta-col { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.pa-newthread__meta-label {
+  font: 500 9px/1 var(--font-sans);
+  color: var(--text-muted);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.pa-newthread__meta-value {
+  font: 600 12px/1.2 var(--font-sans);
+  color: var(--text-primary);
+}
+
 .pa-pill2 {
   display: inline-flex; align-items: center;
   height: 22px; padding: 0 8px;
@@ -48,27 +56,64 @@
   color: var(--text-secondary);
   font: 500 11px/1 var(--font-sans);
 }
-.pa-newthread__spacer { flex: 1; }
-.pa-newthread__meta {
-  display: flex;
-  gap: 36px;
+
+/* Inner content reuses .pa-transcript__inner — only deltas live here */
+.pa-newthread__transcript-inner > * + * { border-top: 0 !important; }
+.pa-newthread__transcript-inner { gap: 14px; padding-top: 22px; }
+
+/* ---- Branch picker (pa-projpop variant) ---- */
+.pa-pick--branch { max-width: 260px; }
+.pa-pick--branch .pa-pick__txt { max-width: 180px; }
+.pa-bpop { min-width: 360px; max-width: 460px; }
+.pa-bpop__scope {
+  margin-left: 8px;
+  font: 500 10px/1 var(--font-mono);
+  color: var(--text-secondary);
+  letter-spacing: 0;
+  text-transform: none;
 }
-.pa-newthread__meta-col { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
-.pa-newthread__meta-label {
-  font: 500 10px/1 var(--font-sans);
-  color: var(--text-muted);
-  letter-spacing: 0.04em;
+.pa-bpop__row { gap: 8px; }
+.pa-bpop__name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  font: 500 12px/1 var(--font-mono);
+  color: var(--text-primary);
+}
+.pa-bpop__tag {
+  display: inline-flex; align-items: center;
+  height: 16px; padding: 0 6px;
+  border-radius: 8px;
+  font: 600 9px/1 var(--font-sans);
   text-transform: uppercase;
+  letter-spacing: 0.05em;
+  flex: 0 0 auto;
 }
-.pa-newthread__meta-value {
-  font: 600 13px/1.2 var(--font-sans);
-  color: var(--text-primary);
+.pa-bpop__tag--current {
+  background: color-mix(in oklab, var(--accent) 18%, transparent);
+  color: var(--accent-bright);
 }
-.pa-newthread__title {
-  font: 700 30px/1.05 var(--font-sans);
-  color: var(--text-primary);
-  margin: 4px 0 0;
-  letter-spacing: -0.01em;
+.pa-bpop__tag--busy {
+  background: color-mix(in oklab, var(--text-muted) 22%, transparent);
+  color: var(--text-secondary);
+}
+.pa-bpop__counts {
+  display: inline-flex; align-items: center; gap: 4px;
+  font: 500 10px/1 var(--font-mono);
+  flex: 0 0 auto;
+}
+.pa-bpop__ahead { color: oklch(72% 0.12 145); }
+.pa-bpop__behind { color: oklch(72% 0.13 35); }
+.pa-bpop__when {
+  font: 400 10px/1 var(--font-mono);
+  color: var(--text-muted);
+  flex: 0 0 auto;
+  min-width: 56px;
+  text-align: right;
+}
+.pa-bpop__newname {
+  font-family: var(--font-mono);
+  color: var(--accent-bright);
 }
 
 /* ---- Project info card ---- */

--- a/docs/design/pwragent-v2/project/newthread.jsx
+++ b/docs/design/pwragent-v2/project/newthread.jsx
@@ -101,6 +101,123 @@ function ProjectPicker({ value, recents, onChange, onPickFromDisk }) {
 }
 
 /* ----------------------------------------------------------------
+   Branch picker — sits next to the Worktree picker. Mirrors the
+   ProjectPicker pattern: popover, search, recents, action row.
+   Scoped to the currently-selected project's branch list.
+---------------------------------------------------------------- */
+function BranchPicker({ project, value, worktreeMode, onChange, onCreate }) {
+  const I = window.PA.Icon;
+  const [open, setOpen] = useStateNT(false);
+  const [query, setQuery] = useStateNT("");
+  const ref = useRefNT(null);
+
+  useEffectNT(() => {
+    if (!open) return;
+    const onDoc = (e) => { if (ref.current && !ref.current.contains(e.target)) setOpen(false); };
+    document.addEventListener("mousedown", onDoc);
+    return () => document.removeEventListener("mousedown", onDoc);
+  }, [open]);
+
+  const branches = (project && project.branches) || [];
+  const filtered = useMemoNT(() => {
+    if (!query.trim()) return branches;
+    const q = query.trim().toLowerCase();
+    return branches.filter((b) => b.name.toLowerCase().includes(q));
+  }, [branches, query]);
+
+  const disabled = !project || !project.isRepo;
+  const label = value || project?.branch || "main";
+  const isWorktreeBase = worktreeMode === "worktree";
+
+  return (
+    <span ref={ref} style={{ position: "relative", display: "inline-flex" }}>
+      <button
+        className={`pa-pick pa-pick--branch ${disabled ? "" : "is-active"}`}
+        onClick={(e) => { if (disabled) return; e.stopPropagation(); setOpen(!open); }}
+        disabled={disabled}
+        type="button"
+        title={disabled ? "Pick a git project first" : (isWorktreeBase ? `Worktree base: ${label}` : `Branch: ${label}`)}
+      >
+        <I.Branch size={11} />
+        <span className="pa-pick__txt">{label}</span>
+        <span className="pa-pick__chev">▾</span>
+      </button>
+
+      {open && !disabled && (
+        <div className="pa-pop pa-projpop pa-bpop" style={{ bottom: "calc(100% + 6px)", right: 0 }}>
+          <div className="pa-projpop__head">
+            <I.Search size={12} />
+            <input
+              className="pa-projpop__search"
+              placeholder="Find or create branch"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              autoFocus
+            />
+          </div>
+
+          <div className="pa-projpop__section">
+            {isWorktreeBase ? "Branch off from" : "Switch branch"}
+            <span className="pa-bpop__scope">{project.dir}</span>
+          </div>
+
+          {filtered.length === 0 && !query.trim() && (
+            <div className="pa-projpop__empty">No branches yet.</div>
+          )}
+
+          {filtered.map((b) => {
+            const active = b.name === label;
+            return (
+              <button
+                key={b.name}
+                className={`pa-projpop__row pa-bpop__row ${active ? "is-active" : ""}`}
+                onClick={() => { onChange(b.name); setOpen(false); }}
+                type="button"
+              >
+                <I.Branch size={12} />
+                <span className="pa-bpop__name" title={b.name}>{b.name}</span>
+                {b.current && <span className="pa-bpop__tag pa-bpop__tag--current">current</span>}
+                {b.busy && <span className="pa-bpop__tag pa-bpop__tag--busy">in&nbsp;use</span>}
+                <span className="pa-bpop__counts">
+                  {b.ahead > 0 && <span className="pa-bpop__ahead">↑{b.ahead}</span>}
+                  {b.behind > 0 && <span className="pa-bpop__behind">↓{b.behind}</span>}
+                </span>
+                <span className="pa-bpop__when">{b.lastCommit}</span>
+                {active && <I.Check size={12} />}
+              </button>
+            );
+          })}
+
+          {query.trim() && !filtered.some((b) => b.name === query.trim()) && (
+            <button
+              className="pa-projpop__row pa-projpop__row--action"
+              onClick={() => { onCreate?.(query.trim()); setOpen(false); setQuery(""); }}
+              type="button"
+            >
+              <I.Plus size={13} />
+              <span className="pa-projpop__name">Create&nbsp;<span className="pa-bpop__newname">{query.trim()}</span></span>
+              <span className="pa-projpop__hint">⏎</span>
+            </button>
+          )}
+
+          <div className="pa-projpop__sep" />
+
+          <button
+            className="pa-projpop__row pa-projpop__row--action"
+            onClick={() => { onCreate?.(); setOpen(false); }}
+            type="button"
+          >
+            <I.Plus size={13} />
+            <span className="pa-projpop__name">New branch from {label}…</span>
+            <span className="pa-projpop__hint">⌘B</span>
+          </button>
+        </div>
+      )}
+    </span>
+  );
+}
+
+/* ----------------------------------------------------------------
    File-browser modal — stand-in for the native Open dialog.
    Lets the user "navigate" a fake filesystem and pick a folder.
 ---------------------------------------------------------------- */
@@ -231,6 +348,7 @@ function FileBrowser({ initialPath, onCancel, onPick }) {
 function NewThread({ recents, initialProject, onCancel, onStart }) {
   const I = window.PA.Icon;
   const [project, setProject] = useStateNT(initialProject || null);
+  const [branch, setBranch] = useStateNT(initialProject?.branch || "main");
   const [text, setText] = useStateNT("");
   const [fast, setFast] = useStateNT(false);
   const [plan, setPlan] = useStateNT(false);
@@ -242,7 +360,7 @@ function NewThread({ recents, initialProject, onCancel, onStart }) {
   const start = () => {
     if (!canStart) return;
     onStart({
-      project,
+      project: { ...project, branch },
       text,
       worktreeMode,
       fast,
@@ -254,15 +372,19 @@ function NewThread({ recents, initialProject, onCancel, onStart }) {
   const onChosenFromDisk = (target) => {
     setBrowser(false);
     // Synthesize a directory entry; mark it as "new" so it gets added on start.
-    setProject({
+    const newProj = {
       dir: target.name,
       path: target.fullPath,
       branch: target.branch,
       isRepo: target.repo,
       isNew: true,
       lastUsed: Date.now(),
-    });
-    // If it's not a repo, default to local rather than worktree.
+      branches: target.repo ? [
+        { name: target.branch || "main", lastCommit: "just now", ahead: 0, behind: 0, current: true },
+      ] : [],
+    };
+    setProject(newProj);
+    setBranch(target.branch || "main");
     if (!target.repo) setWorktreeMode("local");
   };
 
@@ -276,174 +398,178 @@ function NewThread({ recents, initialProject, onCancel, onStart }) {
         />
       )}
 
-      <div className="pa-newthread__inner">
-        <header className="pa-newthread__header">
-          <div className="pa-newthread__eyebrow-row">
-            <span className="pa-newthread__eyebrow">NEW THREAD</span>
-            <span className="pa-pill2">OpenAI</span>
-            <span className="pa-pill2">Full Access</span>
-            <span className="pa-newthread__spacer" />
-            <div className="pa-newthread__meta">
-              <div className="pa-newthread__meta-col">
-                <div className="pa-newthread__meta-label">Workspace</div>
-                <div className="pa-newthread__meta-value">
-                  {project
-                    ? (worktreeMode === "worktree" && project.isRepo ? "New worktree" : "Local")
-                    : "—"}
-                </div>
-              </div>
-              <div className="pa-newthread__meta-col">
-                <div className="pa-newthread__meta-label">Branch</div>
-                <div className="pa-newthread__meta-value">{project?.branch || "—"}</div>
-              </div>
+      <div className="pa-newthread__topbar">
+        <div className="pa-newthread__topbar-eyebrow">NEW THREAD</div>
+        <h1 className="pa-newthread__topbar-title">
+          {project ? project.dir : "Untitled"}
+        </h1>
+        <span className="pa-pill2">OpenAI</span>
+        <span className="pa-pill2">Full Access</span>
+        <span style={{ flex: 1 }} />
+        <div className="pa-newthread__meta">
+          <div className="pa-newthread__meta-col">
+            <div className="pa-newthread__meta-label">Workspace</div>
+            <div className="pa-newthread__meta-value">
+              {project
+                ? (worktreeMode === "worktree" && project.isRepo ? "New worktree" : "Local")
+                : "—"}
             </div>
           </div>
-          <h1 className="pa-newthread__title">
-            {project ? project.dir : "Untitled"}
-          </h1>
-        </header>
-
-        {project ? (
-          <section className="pa-newthread__card">
-            <div className="pa-newthread__card-col">
-              <div className="pa-newthread__card-row">
-                <div className="pa-newthread__field-label">Project</div>
-                <div className="pa-newthread__field-value">{project.dir}</div>
-              </div>
-              <div className="pa-newthread__card-row">
-                <div className="pa-newthread__field-label">Threads</div>
-                <div className="pa-newthread__field-value pa-newthread__field-value--strong">
-                  {project.isNew ? "0 threads (new)" : `${project.threadCount ?? 0} threads`}
-                </div>
-              </div>
-              <div className="pa-newthread__card-row">
-                <div className="pa-newthread__field-label">Status</div>
-                <div className="pa-newthread__field-value">
-                  {project.isNew ? "Not yet tracked" : "Up to date"}
-                </div>
-              </div>
-            </div>
-            <div className="pa-newthread__card-col">
-              <div className="pa-newthread__card-row">
-                <div className="pa-newthread__field-label">Path</div>
-                <div className="pa-newthread__field-value pa-newthread__field-value--mono">
-                  {project.path || "—"}
-                </div>
-              </div>
-              <div className="pa-newthread__card-row">
-                <div className="pa-newthread__field-label">Upstream</div>
-                <div className="pa-newthread__field-value pa-newthread__field-value--mono">
-                  {project.isRepo ? `origin/${project.branch || "main"}` : "—"}
-                </div>
-              </div>
-              <div className="pa-newthread__card-row">
-                <div className="pa-newthread__field-label">Current branch</div>
-                <div className="pa-newthread__field-value pa-newthread__field-value--mono">
-                  {project.branch || "—"}
-                </div>
-              </div>
-            </div>
-          </section>
-        ) : (
-          <section className="pa-newthread__card pa-newthread__card--empty">
-            <div className="pa-newthread__empty">
-              <I.Folder size={22} />
-              <div className="pa-newthread__empty-title">No project selected</div>
-              <div className="pa-newthread__empty-sub">
-                Pick a directory below to start the thread in. We'll add it to your Directories list.
-              </div>
-            </div>
-          </section>
-        )}
-
-        <div className="pa-newthread__filler" />
-
-        {/* ---- Composer ---- */}
-        <div className="pa-composer">
-          <div className="pa-composer__eyebrow">New thread</div>
-          <div className="pa-newthread__compose-input">
-            <span className="pa-slash">$ce:plan</span>
-            <textarea
-              className="pa-composer__textarea pa-newthread__textarea"
-              placeholder="Describe what you want to do…"
-              value={text}
-              onChange={(e) => setText(e.target.value)}
-              onKeyDown={(e) => { if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) start(); }}
-              autoFocus
-            />
+          <div className="pa-newthread__meta-col">
+            <div className="pa-newthread__meta-label">Branch</div>
+            <div className="pa-newthread__meta-value">{branch || "—"}</div>
           </div>
+        </div>
+      </div>
 
-          <div className="pa-composer__row">
-            <button className="pa-pick">OpenAI<span className="pa-pick__chev">▾</span></button>
-            <button className="pa-pick"><span>Full Access</span><span className="pa-pick__chev">▾</span></button>
-
-            {/* NEW: Project picker, sits before Worktree */}
-            <ProjectPicker
-              value={project}
-              recents={recents}
-              onChange={(d) => {
-                setProject({ ...d, isNew: false, lastUsed: Date.now() });
-                if (!d.isRepo) setWorktreeMode("local");
-                else setWorktreeMode("worktree");
-              }}
-              onPickFromDisk={onPickFromDisk}
-            />
-
-            <button
-              className={`pa-pick ${project && project.isRepo ? "is-active" : ""}`}
-              onClick={() => {
-                if (!project) return;
-                setWorktreeMode((m) => m === "worktree" ? "local" : (project.isRepo ? "worktree" : "local"));
-              }}
-              disabled={!project}
-              title={project?.isRepo ? "Toggle worktree / local" : "Local only — not a git repo"}
-            >
-              <I.Worktree size={11} />
-              <span>{worktreeMode === "worktree" && project?.isRepo ? "New worktree" : "Local"}</span>
-              <span className="pa-pick__chev">▾</span>
-            </button>
-
-            <button className="pa-pick" disabled={!project}>
-              <I.Branch size={11} />
-              <span>{project?.branch || "main"}</span>
-              <span className="pa-pick__chev">▾</span>
-            </button>
-
-            <button className="pa-pick"><span>GPT-5.5</span><span className="pa-pick__chev">▾</span></button>
-            <button className="pa-pick"><span>high</span><span className="pa-pick__chev">▾</span></button>
-
-            <span className="pa-composer__spacer" />
-
-            <button className={`pa-toggle2 ${fast ? "is-on" : ""}`} onClick={() => setFast(!fast)}>
-              <span className="pa-toggle__box">{fast && <I.Check size={9} />}</span>
-              Fast mode
-            </button>
-            <button className={`pa-toggle2 ${plan ? "is-on" : ""}`} onClick={() => setPlan(!plan)}>
-              <span className="pa-toggle__box">{plan && <I.Check size={9} />}</span>
-              Plan mode
-            </button>
-          </div>
-
-          <div className="pa-composer__row">
-            <button className="pa-applaunch" disabled={!project}>
-              <I.VSCodeGlyph size={16} />VS Code
-            </button>
-            <button className="pa-applaunch" disabled={!project}>
-              <I.GhosttyGlyph size={16} />Ghostty
-            </button>
-            <span className="pa-composer__spacer" />
-            {project?.isNew && (
-              <span className="pa-newthread__addnote">
-                <I.Plus size={11} />
-                Adds <strong>{project.dir}</strong> to Directories
-              </span>
+      <div className="pa-transcript">
+        <div className="pa-transcript__fade pa-transcript__fade--top" />
+        <div className="pa-transcript__scroll">
+          <div className="pa-transcript__inner pa-newthread__transcript-inner">
+            {project ? (
+              <section className="pa-newthread__card">
+                <div className="pa-newthread__card-col">
+                  <div className="pa-newthread__card-row">
+                    <div className="pa-newthread__field-label">Project</div>
+                    <div className="pa-newthread__field-value">{project.dir}</div>
+                  </div>
+                  <div className="pa-newthread__card-row">
+                    <div className="pa-newthread__field-label">Threads</div>
+                    <div className="pa-newthread__field-value pa-newthread__field-value--strong">
+                      {project.isNew ? "0 threads (new)" : `${project.threadCount ?? 0} threads`}
+                    </div>
+                  </div>
+                  <div className="pa-newthread__card-row">
+                    <div className="pa-newthread__field-label">Status</div>
+                    <div className="pa-newthread__field-value">
+                      {project.isNew ? "Not yet tracked" : "Up to date"}
+                    </div>
+                  </div>
+                </div>
+                <div className="pa-newthread__card-col">
+                  <div className="pa-newthread__card-row">
+                    <div className="pa-newthread__field-label">Path</div>
+                    <div className="pa-newthread__field-value pa-newthread__field-value--mono">
+                      {project.path || "—"}
+                    </div>
+                  </div>
+                  <div className="pa-newthread__card-row">
+                    <div className="pa-newthread__field-label">Upstream</div>
+                    <div className="pa-newthread__field-value pa-newthread__field-value--mono">
+                      {project.isRepo ? `origin/${branch || "main"}` : "—"}
+                    </div>
+                  </div>
+                  <div className="pa-newthread__card-row">
+                    <div className="pa-newthread__field-label">Selected branch</div>
+                    <div className="pa-newthread__field-value pa-newthread__field-value--mono">
+                      {branch || "—"}
+                    </div>
+                  </div>
+                </div>
+              </section>
+            ) : (
+              <section className="pa-newthread__card pa-newthread__card--empty">
+                <div className="pa-newthread__empty">
+                  <I.Folder size={22} />
+                  <div className="pa-newthread__empty-title">No project selected</div>
+                  <div className="pa-newthread__empty-sub">
+                    Pick a directory below to start the thread in. We'll add it to your Directories list.
+                  </div>
+                </div>
+              </section>
             )}
-            <button className="pa-newthread__cancel" onClick={onCancel}>Cancel</button>
-            <button className="pa-send" onClick={start} disabled={!canStart} title={!project ? "Pick a project first" : !text.trim() ? "Type a prompt" : "Start thread"}>
-              <I.Send size={12} />
-              Start thread
-            </button>
           </div>
+        </div>
+        <div className="pa-transcript__fade pa-transcript__fade--bottom" />
+      </div>
+
+      {/* ---- Composer (shares styles with thread reply) ---- */}
+      <div className="pa-composer">
+        <div className="pa-composer__eyebrow">New thread</div>
+        <div className="pa-newthread__compose-input">
+          <span className="pa-slash">$ce:plan</span>
+          <textarea
+            className="pa-composer__textarea pa-newthread__textarea"
+            placeholder="Describe what you want to do…"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            onKeyDown={(e) => { if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) start(); }}
+            autoFocus
+          />
+        </div>
+
+        <div className="pa-composer__row">
+          <button className="pa-pick">OpenAI<span className="pa-pick__chev">▾</span></button>
+          <button className="pa-pick"><span>Full Access</span><span className="pa-pick__chev">▾</span></button>
+
+          <ProjectPicker
+            value={project}
+            recents={recents}
+            onChange={(d) => {
+              setProject({ ...d, isNew: false, lastUsed: Date.now() });
+              setBranch(d.branch || "main");
+              if (!d.isRepo) setWorktreeMode("local");
+              else setWorktreeMode("worktree");
+            }}
+            onPickFromDisk={onPickFromDisk}
+          />
+
+          <button
+            className={`pa-pick ${project && project.isRepo ? "is-active" : ""}`}
+            onClick={() => {
+              if (!project) return;
+              setWorktreeMode((m) => m === "worktree" ? "local" : (project.isRepo ? "worktree" : "local"));
+            }}
+            disabled={!project}
+            title={project?.isRepo ? "Toggle worktree / local" : "Local only — not a git repo"}
+          >
+            <I.Worktree size={11} />
+            <span>{worktreeMode === "worktree" && project?.isRepo ? "New worktree" : "Local"}</span>
+            <span className="pa-pick__chev">▾</span>
+          </button>
+
+          <BranchPicker
+            project={project}
+            value={branch}
+            worktreeMode={worktreeMode}
+            onChange={(b) => setBranch(b)}
+            onCreate={(name) => { if (name) setBranch(name); }}
+          />
+
+          <button className="pa-pick"><span>GPT-5.5</span><span className="pa-pick__chev">▾</span></button>
+          <button className="pa-pick"><span>high</span><span className="pa-pick__chev">▾</span></button>
+
+          <span className="pa-composer__spacer" />
+
+          <button className={`pa-toggle2 ${fast ? "is-on" : ""}`} onClick={() => setFast(!fast)}>
+            <span className="pa-toggle__box">{fast && <I.Check size={9} />}</span>
+            Fast mode
+          </button>
+          <button className={`pa-toggle2 ${plan ? "is-on" : ""}`} onClick={() => setPlan(!plan)}>
+            <span className="pa-toggle__box">{plan && <I.Check size={9} />}</span>
+            Plan mode
+          </button>
+        </div>
+
+        <div className="pa-composer__row">
+          <button className="pa-applaunch" disabled={!project}>
+            <I.VSCodeGlyph size={16} />VS Code
+          </button>
+          <button className="pa-applaunch" disabled={!project}>
+            <I.GhosttyGlyph size={16} />Ghostty
+          </button>
+          <span className="pa-composer__spacer" />
+          {project?.isNew && (
+            <span className="pa-newthread__addnote">
+              <I.Plus size={11} />
+              Adds <strong>{project.dir}</strong> to Directories
+            </span>
+          )}
+          <button className="pa-newthread__cancel" onClick={onCancel}>Cancel</button>
+          <button className="pa-send" onClick={start} disabled={!canStart} title={!project ? "Pick a project first" : !text.trim() ? "Type a prompt" : "Start thread"}>
+            <I.Send size={12} />
+            Start thread
+          </button>
         </div>
       </div>
     </main>

--- a/docs/design/pwragent-v2/project/rbac.css
+++ b/docs/design/pwragent-v2/project/rbac.css
@@ -1,0 +1,445 @@
+/* ============================================================
+   RBAC — Access Control panel
+   Three-column authorization graph with SVG connectors.
+   ============================================================ */
+
+.rbac-callout {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 14px;
+  border: 1px solid var(--accent-border);
+  background: var(--accent-soft);
+  border-radius: 10px;
+  margin-bottom: 16px;
+}
+.rbac-callout__icon {
+  width: 28px; height: 28px;
+  flex: 0 0 auto;
+  border-radius: 6px;
+  background: var(--bg-panel-elevated);
+  border: 1px solid var(--accent-border);
+  color: var(--accent-bright);
+  display: inline-flex; align-items: center; justify-content: center;
+}
+.rbac-callout__title {
+  font: 700 13px/1.2 var(--font-sans);
+  color: var(--text-primary);
+  margin-bottom: 4px;
+}
+.rbac-callout__body {
+  font: 400 12.5px/1.5 var(--font-sans);
+  color: var(--text-secondary);
+  text-wrap: pretty;
+}
+.rbac-callout__body code {
+  font: 500 11.5px/1 var(--font-mono);
+  color: var(--accent-bright);
+  background: rgba(247,243,235,0.04);
+  padding: 1px 5px;
+  border-radius: 4px;
+}
+
+.rbac-tabs {
+  display: inline-flex;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-panel);
+  border-radius: 8px;
+  padding: 3px;
+  gap: 2px;
+  margin-bottom: 14px;
+}
+.rbac-tabs__btn {
+  padding: 7px 12px;
+  border: 1px solid transparent;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--text-secondary);
+  font: 600 12px/1 var(--font-sans);
+  cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+}
+.rbac-tabs__btn.is-active {
+  background: var(--bg-row-active);
+  border-color: var(--accent-border);
+  color: var(--accent-bright);
+}
+.rbac-tabs__count {
+  font: 600 10px/1 var(--font-mono);
+  padding: 2px 5px;
+  border-radius: 4px;
+  background: var(--bg-panel-elevated);
+  color: var(--text-muted);
+}
+.rbac-tabs__btn.is-active .rbac-tabs__count {
+  color: var(--accent-bright);
+  background: var(--bg-app);
+}
+
+/* Toolbar above the graph */
+.rbac-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+}
+.rbac-toolbar__sp { flex: 1; }
+.rbac-legend {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  font: 500 11px/1 var(--font-sans);
+  color: var(--text-muted);
+}
+.rbac-legend__sw {
+  display: inline-flex; align-items: center; gap: 5px;
+}
+.rbac-legend__line {
+  display: inline-block;
+  width: 22px; height: 2px;
+  border-radius: 2px;
+}
+.rbac-legend__line.is-allow { background: var(--accent); }
+.rbac-legend__line.is-danger { background: #e84a5f; }
+.rbac-legend__line.is-reject {
+  background: transparent;
+  border-top: 2px dashed var(--danger);
+  height: 0;
+  border-radius: 0;
+}
+
+/* Graph container */
+.rbac-graph {
+  position: relative;
+  border: 1px solid var(--border-subtle);
+  border-radius: 12px;
+  background: linear-gradient(180deg, var(--bg-panel) 0%, var(--bg-app) 100%);
+  padding: 18px 18px 22px;
+  overflow: hidden;
+}
+.rbac-graph__cols {
+  position: relative;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 130px; /* room for connectors */
+  z-index: 2;
+}
+.rbac-graph__svg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 1;
+}
+.rbac-graph__svg path {
+  fill: none;
+  stroke-width: 1.5;
+  transition: stroke 140ms ease, opacity 140ms ease, stroke-width 140ms ease;
+}
+.rbac-graph__svg path.is-allow { stroke: rgba(232, 116, 58, 0.35); }
+.rbac-graph__svg path.is-danger { stroke: rgba(232, 74, 95, 0.7); stroke-width: 2; }
+.rbac-graph__svg path.is-reject {
+  stroke: rgba(232, 90, 58, 0.75);
+  stroke-dasharray: 4 5;
+  stroke-width: 1.75;
+}
+.rbac-graph__svg path.is-dim { opacity: 0.12; }
+.rbac-graph__svg path.is-active {
+  stroke: var(--accent-bright);
+  stroke-width: 2.5;
+  opacity: 1;
+  filter: drop-shadow(0 0 4px var(--accent-shadow));
+}
+.rbac-graph__svg path.is-active.is-danger {
+  stroke: #ff5e75;
+  filter: drop-shadow(0 0 4px rgba(232, 74, 95, 0.65));
+}
+
+/* Column headers */
+.rbac-col__head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 4px 10px;
+  margin-bottom: 8px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.rbac-col__eyebrow {
+  font: 600 10px/1 var(--font-sans);
+  color: var(--accent);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  flex: 1;
+}
+.rbac-col__count {
+  font: 500 10px/1 var(--font-mono);
+  color: var(--text-muted);
+  padding: 3px 7px;
+  border-radius: 999px;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-panel-elevated);
+}
+.rbac-col__list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+/* Group header inside actors col */
+.rbac-actor-group {
+  font: 600 10px/1 var(--font-sans);
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 8px 4px 4px;
+  display: flex; align-items: center; gap: 6px;
+}
+.rbac-actor-group .pa-ico { color: var(--accent); }
+
+/* Generic node card */
+.rbac-node {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 9px;
+  background: var(--bg-panel);
+  cursor: pointer;
+  transition: border-color 140ms ease, background 140ms ease, transform 140ms ease;
+}
+.rbac-node:hover {
+  border-color: var(--accent-border);
+  background: var(--bg-panel-hover);
+}
+.rbac-node.is-active {
+  border-color: var(--accent);
+  background: var(--bg-row-active);
+  box-shadow: 0 0 0 1px var(--accent-border), 0 8px 24px var(--accent-shadow);
+}
+.rbac-node.is-dim { opacity: 0.35; }
+.rbac-node.is-danger {
+  border-color: rgba(255, 138, 106, 0.4);
+  background: linear-gradient(180deg, rgba(255,138,106,0.07), transparent);
+}
+.rbac-node.is-danger.is-active {
+  border-color: #ff8a6a;
+  box-shadow: 0 0 0 1px rgba(255,138,106,0.5), 0 8px 28px rgba(255,138,106,0.25);
+}
+
+.rbac-avatar {
+  width: 28px; height: 28px;
+  border-radius: 7px;
+  background: var(--bg-panel-elevated);
+  border: 1px solid var(--border-subtle);
+  display: inline-flex; align-items: center; justify-content: center;
+  font: 700 11px/1 var(--font-mono);
+  color: var(--accent-bright);
+  flex: 0 0 auto;
+  position: relative;
+}
+.rbac-avatar.is-bucket {
+  background: rgba(232, 90, 58, 0.08);
+  border-color: var(--danger-border);
+  color: var(--danger-text);
+}
+.rbac-avatar__src {
+  position: absolute;
+  bottom: -3px; right: -3px;
+  width: 12px; height: 12px;
+  border-radius: 4px;
+  background: var(--bg-app);
+  display: inline-flex; align-items: center; justify-content: center;
+  border: 1px solid var(--border-subtle);
+}
+
+.rbac-node__main {
+  flex: 1; min-width: 0;
+}
+.rbac-node__name {
+  font: 600 12.5px/1.2 var(--font-sans);
+  color: var(--text-primary);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  display: flex; align-items: center; gap: 6px;
+}
+.rbac-node__sub {
+  font: 500 11px/1.3 var(--font-mono);
+  color: var(--text-muted);
+  margin-top: 2px;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.rbac-node__badge {
+  font: 600 9px/1 var(--font-sans);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 3px 6px;
+  border-radius: 4px;
+  background: var(--bg-panel-elevated);
+  color: var(--text-muted);
+  border: 1px solid var(--border-subtle);
+  flex: 0 0 auto;
+}
+.rbac-node__badge.is-builtin {
+  color: var(--accent-bright);
+  border-color: var(--accent-border);
+  background: var(--accent-soft);
+}
+.rbac-node__badge.is-danger {
+  color: #ffb09a;
+  border-color: rgba(255,138,106,0.45);
+  background: rgba(255,138,106,0.12);
+}
+.rbac-node__badge.is-reject {
+  color: var(--danger-text);
+  border-color: var(--danger-border);
+  background: var(--danger-soft);
+}
+
+/* Permission count chip on the right side of permission cards */
+.rbac-revcount {
+  display: inline-flex; align-items: center; gap: 4px;
+  height: 20px; padding: 0 7px;
+  border-radius: 999px;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-panel-elevated);
+  color: var(--text-secondary);
+  font: 600 10px/1 var(--font-mono);
+  flex: 0 0 auto;
+}
+.rbac-revcount.is-wide {
+  color: var(--danger-text);
+  border-color: var(--danger-border);
+  background: var(--danger-soft);
+}
+.rbac-revcount.is-zero {
+  color: var(--text-subtle);
+}
+
+/* Reject sink card */
+.rbac-reject {
+  margin-top: 14px;
+  padding: 12px 14px;
+  border: 1px dashed var(--danger-border);
+  background: rgba(232,90,58,0.06);
+  border-radius: 10px;
+  display: flex; align-items: center; gap: 10px;
+}
+.rbac-reject__icon {
+  width: 28px; height: 28px;
+  border-radius: 7px;
+  background: var(--danger-soft);
+  border: 1px solid var(--danger-border);
+  color: var(--danger-text);
+  display: inline-flex; align-items: center; justify-content: center;
+  flex: 0 0 auto;
+}
+.rbac-reject__title {
+  font: 700 12px/1.2 var(--font-sans);
+  color: var(--danger-text);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.rbac-reject__sub {
+  font: 500 11px/1.4 var(--font-sans);
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+.rbac-reject__count {
+  font: 700 18px/1 var(--font-mono);
+  color: var(--danger-text);
+}
+
+/* Tooltip for permission reverse-map hover */
+.rbac-tip {
+  position: absolute;
+  z-index: 30;
+  width: 280px;
+  background: var(--bg-panel-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: 10px;
+  box-shadow: var(--shadow-lg);
+  padding: 10px 12px;
+  pointer-events: none;
+}
+.rbac-tip__title {
+  font: 700 12px/1.2 var(--font-sans);
+  color: var(--text-primary);
+  margin-bottom: 6px;
+}
+.rbac-tip__lede {
+  font: 500 11px/1.4 var(--font-sans);
+  color: var(--text-muted);
+  margin-bottom: 8px;
+}
+.rbac-tip__list {
+  display: flex; flex-direction: column; gap: 4px;
+  max-height: 220px; overflow: hidden;
+}
+.rbac-tip__row {
+  display: flex; align-items: center; gap: 8px;
+  font: 500 11.5px/1.2 var(--font-mono);
+  color: var(--text-secondary);
+}
+.rbac-tip__row .rbac-tip__via {
+  margin-left: auto;
+  font: 500 10px/1 var(--font-sans);
+  color: var(--text-muted);
+}
+.rbac-tip__more {
+  margin-top: 6px;
+  font: 600 10px/1 var(--font-sans);
+  color: var(--accent-bright);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+/* Roles & Profiles tab cards */
+.rbac-roles-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+.rbac-role-card {
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-panel);
+  border-radius: 10px;
+  padding: 14px 16px;
+  display: flex; flex-direction: column; gap: 8px;
+}
+.rbac-role-card.is-danger {
+  border-color: rgba(255,138,106,0.4);
+  background: linear-gradient(180deg, rgba(255,138,106,0.06), transparent 60%);
+}
+.rbac-role-card__head {
+  display: flex; align-items: center; gap: 8px;
+}
+.rbac-role-card__name {
+  flex: 1;
+  font: 700 13px/1.2 var(--font-sans);
+  color: var(--text-primary);
+}
+.rbac-role-card__sub {
+  font: 400 12px/1.45 var(--font-sans);
+  color: var(--text-muted);
+}
+.rbac-role-card__perms {
+  display: flex; flex-wrap: wrap; gap: 4px;
+  padding-top: 6px;
+  border-top: 1px dashed var(--border-subtle);
+}
+.rbac-role-card__perm {
+  font: 500 10.5px/1 var(--font-mono);
+  padding: 4px 7px;
+  border-radius: 4px;
+  background: var(--bg-panel-elevated);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-subtle);
+}
+.rbac-role-card__perm.is-danger {
+  color: #ffb09a;
+  border-color: rgba(255,138,106,0.4);
+  background: rgba(255,138,106,0.08);
+}

--- a/docs/design/pwragent-v2/project/rbac.jsx
+++ b/docs/design/pwragent-v2/project/rbac.jsx
@@ -1,0 +1,598 @@
+/* eslint-disable */
+/* RBAC — Access Control panel
+   Three-column authorization graph: Actors → Roles → Permissions.
+   Strictly additive policy semantics (union of all bound roles).
+*/
+const { useState: useRBACState, useMemo: useRBACMemo, useRef: useRBACRef, useLayoutEffect, useEffect: useRBACEffect } = React;
+
+/* ---------- Data ---------- */
+const RBAC_ACTORS = [
+  // Telegram named
+  { id: "a1", name: "@huntharo",      kind: "user", source: "Telegram", note: "id 8460800771 · admin", roles: ["r1","r2","r3","r4"] },
+  { id: "a2", name: "@thomas_m",      kind: "user", source: "Telegram", note: "id 4477120091",          roles: ["r1","r2","r3"] },
+  { id: "a3", name: "@jamie_d",       kind: "user", source: "Telegram", note: "id 9912884001",          roles: ["r1","r2"] },
+  // Discord named
+  { id: "a4", name: "hunt.dev",       kind: "user", source: "Discord",  note: "guild #pwragent-internal", roles: ["r2","r5"] },
+  { id: "a5", name: "ops-bot",        kind: "user", source: "Discord",  note: "guild #pwragent-internal · webhook", roles: ["r1"] },
+  // Buckets
+  { id: "b1", name: "Unspecified senders",
+    kind: "bucket", source: "Discord",
+    note: "guild #pwragent-staging · 47 members",
+    bucketCount: 47, roles: [] },
+  { id: "b2", name: "Unspecified senders",
+    kind: "bucket", source: "Telegram",
+    note: "DMs from non-allowlisted IDs · 12 today",
+    bucketCount: 12, roles: [] },
+];
+
+const RBAC_ROLES = [
+  { id: "r1", name: "Read-Only Observer",     builtin: true, sub: "Watch threads, no actions.",                   perms: ["p2"] },
+  { id: "r2", name: "Thread Starter",         builtin: true, sub: "Start threads + read-only sandbox runs.",      perms: ["p1","p2","p5"] },
+  { id: "r3", name: "Codex Default Operator", builtin: true, sub: "Sandboxed Codex with default access mode.",    perms: ["p1","p2","p3","p4","p5"] },
+  { id: "r4", name: "Codex Full Operator",    builtin: true, danger: true,
+    sub: "Unrestricted host shell. Can grant itself new permissions.",
+    perms: ["p1","p2","p3","p4","p5","p6","p7","p8"] },
+  { id: "r5", name: "drvr-billing Steward",   builtin: false, sub: "Custom — scoped to drvr-billing repo only.", perms: ["p1","p2","p4","p6"] },
+];
+
+const RBAC_PERMS = [
+  { id: "p1", name: "Start agent thread",          sub: "Open a new thread, any model." },
+  { id: "p2", name: "View thread activity",        sub: "Read transcripts and tool calls." },
+  { id: "p3", name: "Start Codex dev thread",      sub: "Codex with editor + worktree." },
+  { id: "p4", name: "Codex Default Access",        sub: "Sandboxed file ops, prompted writes." },
+  { id: "p5", name: "Codex Read-Only Sandbox",     sub: "No writes, no shell side-effects." },
+  { id: "p6", name: "Add directories to Codex",    sub: "Grow the trust root.", danger: "med" },
+  { id: "p7", name: "Codex Full Access",           sub: "Unrestricted host shell.", danger: "high" },
+  { id: "p8", name: "Modify configs · grant roles", sub: "Self-elevation surface.", danger: "high" },
+];
+
+/* Reverse map: each permission → list of {actor, viaRole} */
+function rbacBuildReverse() {
+  const map = {};
+  RBAC_PERMS.forEach(p => map[p.id] = []);
+  RBAC_ACTORS.forEach(a => {
+    const seen = new Set();
+    (a.roles || []).forEach(rid => {
+      const role = RBAC_ROLES.find(r => r.id === rid);
+      if (!role) return;
+      role.perms.forEach(pid => {
+        // Track first role granting this permission to keep tooltip clean.
+        const key = `${a.id}|${pid}`;
+        if (seen.has(key)) return;
+        seen.add(key);
+        map[pid].push({ actor: a, role });
+      });
+    });
+  });
+  return map;
+}
+
+/* ---------- Components ---------- */
+
+function Avatar({ actor }) {
+  const I = window.PA.Icon;
+  const letter = actor.kind === "bucket"
+    ? "?"
+    : actor.name.replace(/^@/, "")[0].toUpperCase();
+  const SrcGlyph = actor.source === "Telegram" ? I.Telegram : actor.source === "Discord" ? I.Discord : I.Slack;
+  return (
+    <span className={`rbac-avatar ${actor.kind === "bucket" ? "is-bucket" : ""}`}>
+      {letter}
+      <span className="rbac-avatar__src" title={actor.source}>
+        <SrcGlyph size={9} brand />
+      </span>
+    </span>
+  );
+}
+
+function PermDangerGlyph({ danger }) {
+  const I = window.PA.Icon;
+  if (danger === "high") return <I.AlertTriangle size={13} />;
+  if (danger === "med")  return <I.Eye size={13} />;
+  return null;
+}
+
+function RBACGraph() {
+  const I = window.PA.Icon;
+  const containerRef = useRBACRef(null);
+  const colsRef = useRBACRef(null);
+  const actorRefs = useRBACRef({});
+  const roleRefs = useRBACRef({});
+  const permRefs = useRBACRef({});
+  const rejectRef = useRBACRef(null);
+  const [size, setSize] = useRBACState({ w: 0, h: 0 });
+  const [hover, setHover] = useRBACState(null); // {kind, id}
+  const [tipPos, setTipPos] = useRBACState(null);
+
+  const reverse = useRBACMemo(rbacBuildReverse, []);
+
+  // Recompute sizes on layout
+  useLayoutEffect(() => {
+    if (!containerRef.current) return;
+    const update = () => {
+      const r = containerRef.current.getBoundingClientRect();
+      setSize({ w: r.width, h: r.height });
+    };
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(containerRef.current);
+    return () => ro.disconnect();
+  }, []);
+
+  /* compute path between two element rects (right edge -> left edge) */
+  const compute = () => {
+    if (!containerRef.current) return { actorRole: [], rolePerm: [], reject: [] };
+    const cb = containerRef.current.getBoundingClientRect();
+    const right = (el) => {
+      if (!el) return null;
+      const r = el.getBoundingClientRect();
+      return { x: r.right - cb.left, y: r.top + r.height / 2 - cb.top };
+    };
+    const left = (el) => {
+      if (!el) return null;
+      const r = el.getBoundingClientRect();
+      return { x: r.left - cb.left, y: r.top + r.height / 2 - cb.top };
+    };
+    const path = (a, b) => {
+      if (!a || !b) return "";
+      const dx = Math.max(40, (b.x - a.x) * 0.5);
+      return `M ${a.x} ${a.y} C ${a.x + dx} ${a.y}, ${b.x - dx} ${b.y}, ${b.x} ${b.y}`;
+    };
+
+    const actorRole = [];
+    const rolePerm = [];
+    const reject = [];
+
+    RBAC_ACTORS.forEach((a) => {
+      const aEl = actorRefs.current[a.id];
+      if (a.roles.length === 0) {
+        // wires to reject sink (which is rendered to the right of perms)
+        const rj = rejectRef.current;
+        if (aEl && rj) {
+          const aR = right(aEl);
+          const rL = left(rj);
+          // arc up & out then down to the reject sink
+          const dx = (rL.x - aR.x);
+          const d = `M ${aR.x} ${aR.y} C ${aR.x + dx * 0.55} ${aR.y}, ${rL.x - dx * 0.45} ${rL.y}, ${rL.x} ${rL.y}`;
+          reject.push({ id: `rj-${a.id}`, d, actorId: a.id });
+        }
+        return;
+      }
+      a.roles.forEach((rid) => {
+        const rEl = roleRefs.current[rid];
+        if (!aEl || !rEl) return;
+        actorRole.push({
+          id: `${a.id}-${rid}`,
+          d: path(right(aEl), left(rEl)),
+          actorId: a.id, roleId: rid,
+          danger: rid === "r4",
+        });
+      });
+    });
+
+    RBAC_ROLES.forEach((r) => {
+      const rEl = roleRefs.current[r.id];
+      r.perms.forEach((pid) => {
+        const pEl = permRefs.current[pid];
+        if (!rEl || !pEl) return;
+        const perm = RBAC_PERMS.find((x) => x.id === pid);
+        rolePerm.push({
+          id: `${r.id}-${pid}`,
+          d: path(right(rEl), left(pEl)),
+          roleId: r.id, permId: pid,
+          danger: r.danger || perm?.danger === "high",
+        });
+      });
+    });
+
+    return { actorRole, rolePerm, reject };
+  };
+
+  const wires = useRBACMemo(compute, [size.w, size.h]);
+
+  /* Active path resolution from hover */
+  const isActive = (which, info) => {
+    if (!hover) return false;
+    if (hover.kind === "actor") {
+      if (which === "ar") return info.actorId === hover.id;
+      if (which === "rp") {
+        const a = RBAC_ACTORS.find(x => x.id === hover.id);
+        return a && a.roles.includes(info.roleId);
+      }
+      if (which === "rj") return info.actorId === hover.id;
+    }
+    if (hover.kind === "role") {
+      if (which === "ar") return info.roleId === hover.id;
+      if (which === "rp") return info.roleId === hover.id;
+      return false;
+    }
+    if (hover.kind === "perm") {
+      if (which === "rp") return info.permId === hover.id;
+      if (which === "ar") {
+        const role = RBAC_ROLES.find(r => r.id === info.roleId);
+        return role && role.perms.includes(hover.id);
+      }
+      return false;
+    }
+    return false;
+  };
+
+  const isDimWire = (which, info) => {
+    if (!hover) return false;
+    return !isActive(which, info);
+  };
+
+  const nodeActive = (kind, id) => {
+    if (!hover) return false;
+    if (hover.kind === kind && hover.id === id) return true;
+    if (hover.kind === "actor" && kind === "role") {
+      const a = RBAC_ACTORS.find(x => x.id === hover.id);
+      return a && a.roles.includes(id);
+    }
+    if (hover.kind === "actor" && kind === "perm") {
+      const a = RBAC_ACTORS.find(x => x.id === hover.id);
+      if (!a) return false;
+      const allPerms = new Set();
+      a.roles.forEach(rid => {
+        const r = RBAC_ROLES.find(x => x.id === rid);
+        if (r) r.perms.forEach(p => allPerms.add(p));
+      });
+      return allPerms.has(id);
+    }
+    if (hover.kind === "role" && kind === "actor") {
+      const a = RBAC_ACTORS.find(x => x.id === id);
+      return a && a.roles.includes(hover.id);
+    }
+    if (hover.kind === "role" && kind === "perm") {
+      const r = RBAC_ROLES.find(x => x.id === hover.id);
+      return r && r.perms.includes(id);
+    }
+    if (hover.kind === "perm" && kind === "role") {
+      const r = RBAC_ROLES.find(x => x.id === id);
+      return r && r.perms.includes(hover.id);
+    }
+    if (hover.kind === "perm" && kind === "actor") {
+      const a = RBAC_ACTORS.find(x => x.id === id);
+      if (!a) return false;
+      return a.roles.some(rid => {
+        const r = RBAC_ROLES.find(x => x.id === rid);
+        return r && r.perms.includes(hover.id);
+      });
+    }
+    return false;
+  };
+
+  const nodeDim = (kind, id) => hover && !nodeActive(kind, id);
+
+  const handlePermEnter = (perm, e) => {
+    setHover({ kind: "perm", id: perm.id });
+    const cb = containerRef.current.getBoundingClientRect();
+    const r = e.currentTarget.getBoundingClientRect();
+    setTipPos({
+      // place tooltip just above the perm card, aligned to its left edge
+      x: Math.min(cb.width - 290, r.left - cb.left),
+      y: r.top - cb.top - 8,
+      perm,
+    });
+  };
+  const handlePermLeave = () => { setHover(null); setTipPos(null); };
+
+  // Group actors by source for the left column
+  const actorsBySource = useRBACMemo(() => {
+    const groups = { Telegram: [], Discord: [] };
+    RBAC_ACTORS.forEach(a => { (groups[a.source] ||= []).push(a); });
+    return groups;
+  }, []);
+
+  const rejectedCount = useRBACMemo(
+    () => RBAC_ACTORS.filter(a => a.roles.length === 0)
+      .reduce((acc, a) => acc + (a.bucketCount || 1), 0),
+    []
+  );
+
+  return (
+    <div className="rbac-graph" ref={containerRef}>
+      <svg className="rbac-graph__svg" width={size.w} height={size.h}>
+        {wires.reject.map(w => (
+          <path
+            key={w.id} d={w.d}
+            className={`is-reject ${isActive("rj", w) ? "is-active" : ""} ${isDimWire("rj", w) ? "is-dim" : ""}`}
+          />
+        ))}
+        {wires.actorRole.map(w => (
+          <path
+            key={w.id} d={w.d}
+            className={`is-allow ${w.danger ? "is-danger" : ""} ${isActive("ar", w) ? "is-active" : ""} ${isDimWire("ar", w) ? "is-dim" : ""}`}
+          />
+        ))}
+        {wires.rolePerm.map(w => (
+          <path
+            key={w.id} d={w.d}
+            className={`is-allow ${w.danger ? "is-danger" : ""} ${isActive("rp", w) ? "is-active" : ""} ${isDimWire("rp", w) ? "is-dim" : ""}`}
+          />
+        ))}
+      </svg>
+
+      <div className="rbac-graph__cols" ref={colsRef}>
+        {/* ACTORS */}
+        <div className="rbac-col">
+          <div className="rbac-col__head">
+            <span className="rbac-col__eyebrow">Actors</span>
+            <span className="rbac-col__count">{RBAC_ACTORS.length}</span>
+          </div>
+          <div className="rbac-col__list">
+            {["Telegram", "Discord"].map((src) => (
+              <React.Fragment key={src}>
+                <div className="rbac-actor-group">
+                  {src === "Telegram" ? <I.Telegram size={11} brand /> : <I.Discord size={11} brand />}
+                  <span>{src}</span>
+                </div>
+                {actorsBySource[src].map((a) => {
+                  const isReject = a.roles.length === 0;
+                  return (
+                    <div
+                      key={a.id}
+                      ref={el => actorRefs.current[a.id] = el}
+                      className={`rbac-node ${nodeActive("actor", a.id) ? "is-active" : ""} ${nodeDim("actor", a.id) ? "is-dim" : ""}`}
+                      onMouseEnter={() => setHover({ kind: "actor", id: a.id })}
+                      onMouseLeave={() => setHover(null)}
+                    >
+                      <Avatar actor={a} />
+                      <div className="rbac-node__main">
+                        <div className="rbac-node__name">
+                          {a.kind === "bucket" ? a.name : a.name}
+                          {a.kind === "bucket" && (
+                            <span className="rbac-node__badge">{a.bucketCount}</span>
+                          )}
+                        </div>
+                        <div className="rbac-node__sub">{a.note}</div>
+                      </div>
+                      {isReject && <span className="rbac-node__badge is-reject">No role</span>}
+                    </div>
+                  );
+                })}
+              </React.Fragment>
+            ))}
+          </div>
+        </div>
+
+        {/* ROLES */}
+        <div className="rbac-col">
+          <div className="rbac-col__head">
+            <span className="rbac-col__eyebrow">PwrAgent · Roles (additive)</span>
+            <span className="rbac-col__count">{RBAC_ROLES.length}</span>
+          </div>
+          <div className="rbac-col__list">
+            {RBAC_ROLES.map((r) => (
+              <div
+                key={r.id}
+                ref={el => roleRefs.current[r.id] = el}
+                className={`rbac-node ${r.danger ? "is-danger" : ""} ${nodeActive("role", r.id) ? "is-active" : ""} ${nodeDim("role", r.id) ? "is-dim" : ""}`}
+                onMouseEnter={() => setHover({ kind: "role", id: r.id })}
+                onMouseLeave={() => setHover(null)}
+              >
+                <span className={`rbac-avatar ${r.danger ? "is-bucket" : ""}`} style={r.danger ? {} : { color: "var(--accent-bright)" }}>
+                  {r.danger ? <I.AlertTriangle size={14} /> : <I.Lock size={14} />}
+                </span>
+                <div className="rbac-node__main">
+                  <div className="rbac-node__name">{r.name}</div>
+                  <div className="rbac-node__sub">{r.sub}</div>
+                </div>
+                <span className={`rbac-node__badge ${r.builtin ? "is-builtin" : ""} ${r.danger ? "is-danger" : ""}`}>
+                  {r.danger ? "Danger" : r.builtin ? "Built-in" : "Custom"}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* PERMISSIONS */}
+        <div className="rbac-col">
+          <div className="rbac-col__head">
+            <span className="rbac-col__eyebrow">Permissions</span>
+            <span className="rbac-col__count">{RBAC_PERMS.length}</span>
+          </div>
+          <div className="rbac-col__list">
+            {RBAC_PERMS.map((p) => {
+              const reach = reverse[p.id].length;
+              const wide = p.danger === "high" && reach > 1;
+              return (
+                <div
+                  key={p.id}
+                  ref={el => permRefs.current[p.id] = el}
+                  className={`rbac-node ${p.danger === "high" ? "is-danger" : ""} ${nodeActive("perm", p.id) ? "is-active" : ""} ${nodeDim("perm", p.id) ? "is-dim" : ""}`}
+                  onMouseEnter={(e) => handlePermEnter(p, e)}
+                  onMouseLeave={handlePermLeave}
+                >
+                  <span className={`rbac-avatar ${p.danger === "high" ? "is-bucket" : ""}`} style={p.danger ? {} : { color: "var(--accent-bright)" }}>
+                    {p.danger === "high" ? <I.AlertTriangle size={14} /> : p.danger === "med" ? <I.Eye size={14} /> : <I.Check size={13} />}
+                  </span>
+                  <div className="rbac-node__main">
+                    <div className="rbac-node__name">{p.name}</div>
+                    <div className="rbac-node__sub">{p.sub}</div>
+                  </div>
+                  <span className={`rbac-revcount ${wide ? "is-wide" : ""} ${reach === 0 ? "is-zero" : ""}`} title={`${reach} actor(s) currently reach this`}>
+                    ↩ {reach}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+
+          <div
+            ref={rejectRef}
+            className="rbac-reject"
+            onMouseEnter={() => setHover({ kind: "perm", id: "_reject" })}
+            onMouseLeave={() => setHover(null)}
+          >
+            <span className="rbac-reject__icon"><I.X size={14} /></span>
+            <div style={{ flex: 1 }}>
+              <div className="rbac-reject__title">End state · Rejected</div>
+              <div className="rbac-reject__sub">
+                Actors with zero matching roles fall through to a hard reject.
+                Messages are dropped, never queued.
+              </div>
+            </div>
+            <span className="rbac-reject__count">{rejectedCount}</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Hover tooltip for permissions */}
+      {tipPos && hover?.kind === "perm" && tipPos.perm && (
+        <div className="rbac-tip" style={{ left: tipPos.x, top: Math.max(8, tipPos.y - 180) }}>
+          <div className="rbac-tip__title">{tipPos.perm.name}</div>
+          <div className="rbac-tip__lede">
+            Reachable by <b style={{ color: "var(--text-primary)" }}>{reverse[tipPos.perm.id].length}</b> actor{reverse[tipPos.perm.id].length === 1 ? "" : "s"} via{" "}
+            <b style={{ color: "var(--text-primary)" }}>
+              {new Set(reverse[tipPos.perm.id].map(r => r.role.id)).size}
+            </b>{" "}
+            role{new Set(reverse[tipPos.perm.id].map(r => r.role.id)).size === 1 ? "" : "s"}.
+          </div>
+          <div className="rbac-tip__list">
+            {reverse[tipPos.perm.id].slice(0, 6).map((row, i) => (
+              <div key={i} className="rbac-tip__row">
+                <Avatar actor={row.actor} />
+                <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                  {row.actor.name}{row.actor.kind === "bucket" ? ` (${row.actor.bucketCount})` : ""}
+                </span>
+                <span className="rbac-tip__via">via {row.role.name}</span>
+              </div>
+            ))}
+            {reverse[tipPos.perm.id].length > 6 && (
+              <div className="rbac-tip__more">+ {reverse[tipPos.perm.id].length - 6} more — click to inspect</div>
+            )}
+            {reverse[tipPos.perm.id].length === 0 && (
+              <div className="rbac-tip__row" style={{ color: "var(--text-subtle)" }}>No actor currently reaches this.</div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function RBACRoles() {
+  const I = window.PA.Icon;
+  return (
+    <div className="rbac-roles-grid">
+      {RBAC_ROLES.map((r) => (
+        <div key={r.id} className={`rbac-role-card ${r.danger ? "is-danger" : ""}`}>
+          <div className="rbac-role-card__head">
+            <span className={`rbac-avatar ${r.danger ? "is-bucket" : ""}`} style={r.danger ? {} : { color: "var(--accent-bright)" }}>
+              {r.danger ? <I.AlertTriangle size={14} /> : <I.Lock size={14} />}
+            </span>
+            <div className="rbac-role-card__name">{r.name}</div>
+            <span className={`rbac-node__badge ${r.builtin ? "is-builtin" : ""} ${r.danger ? "is-danger" : ""}`}>
+              {r.danger ? "Danger" : r.builtin ? "Built-in" : "Custom"}
+            </span>
+          </div>
+          <div className="rbac-role-card__sub">{r.sub}</div>
+          <div className="rbac-role-card__perms">
+            {r.perms.map((pid) => {
+              const p = RBAC_PERMS.find(x => x.id === pid);
+              return (
+                <span key={pid} className={`rbac-role-card__perm ${p?.danger === "high" ? "is-danger" : ""}`}>
+                  {p?.name}
+                </span>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+      <div className="rbac-role-card" style={{ alignItems: "center", justifyContent: "center", borderStyle: "dashed", color: "var(--text-muted)", textAlign: "center" }}>
+        <I.Plus size={18} />
+        <div style={{ font: "600 12px/1.3 var(--font-sans)", color: "var(--text-secondary)" }}>New custom role</div>
+        <div style={{ font: "400 11.5px/1.4 var(--font-sans)", color: "var(--text-muted)" }}>
+          Compose a profile from individual permissions. Roles are additive — bind multiple to one actor.
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function RBACPanel() {
+  const I = window.PA.Icon;
+  const [tab, setTab] = useRBACState("graph");
+
+  return (
+    <>
+      <div className="pa-settings__head">
+        <div className="pa-settings__head-text">
+          <div className="pa-settings__head-eyebrow">Access Control</div>
+          <h1 className="pa-settings__head-title">Authorization graph</h1>
+          <p className="pa-settings__head-help">
+            Bind messaging-platform actors (Telegram &amp; Discord users, guild buckets, anything else PwrAgent
+            sees) to one or more role profiles. Permissions are <b>strictly additive</b> — if any bound role
+            grants a capability, the actor has it. Hover any node to trace the path; hover a permission on the
+            right to see every actor that currently reaches it.
+          </p>
+        </div>
+        <button className="pa-btn-strong"><I.Plus size={13} /> New custom role</button>
+      </div>
+
+      <div className="rbac-callout">
+        <span className="rbac-callout__icon"><I.AlertTriangle size={14} /></span>
+        <div>
+          <div className="rbac-callout__title">Codex Full Access is escalation-equivalent</div>
+          <div className="rbac-callout__body">
+            Granting <code>p7 · Codex Full Access</code> gives the actor near-complete control of the host
+            machine — arbitrary shell, config writes, and the ability to grant themselves any role on the
+            graph below. Treat it like <code>sudo</code>. Audit-log entries for this permission are mandatory
+            and cannot be disabled.
+          </div>
+        </div>
+      </div>
+
+      <div className="rbac-tabs">
+        <button className={`rbac-tabs__btn ${tab === "graph" ? "is-active" : ""}`} onClick={() => setTab("graph")}>
+          <I.Activity size={12} /> Graph
+          <span className="rbac-tabs__count">{RBAC_ACTORS.length}/{RBAC_ROLES.length}/{RBAC_PERMS.length}</span>
+        </button>
+        <button className={`rbac-tabs__btn ${tab === "roles" ? "is-active" : ""}`} onClick={() => setTab("roles")}>
+          <I.Lock size={12} /> Roles &amp; profiles
+          <span className="rbac-tabs__count">{RBAC_ROLES.length}</span>
+        </button>
+        <button className={`rbac-tabs__btn ${tab === "audit" ? "is-active" : ""}`} onClick={() => setTab("audit")}>
+          <I.Clock size={12} /> Audit
+        </button>
+      </div>
+
+      {tab === "graph" && (
+        <>
+          <div className="rbac-toolbar">
+            <div className="rbac-legend">
+              <span className="rbac-legend__sw"><span className="rbac-legend__line is-allow" /> Allow</span>
+              <span className="rbac-legend__sw"><span className="rbac-legend__line is-danger" /> Dangerous path</span>
+              <span className="rbac-legend__sw"><span className="rbac-legend__line is-reject" /> Reject (no role)</span>
+            </div>
+            <span className="rbac-toolbar__sp" />
+            <button className="pa-btn-sec"><I.Download size={12} /> Export policy</button>
+            <button className="pa-btn-sec"><I.Refresh size={12} /> Re-evaluate</button>
+          </div>
+          <RBACGraph />
+        </>
+      )}
+
+      {tab === "roles" && <RBACRoles />}
+
+      {tab === "audit" && (
+        <div className="pa-card">
+          <div className="pa-card__head">
+            <span className="pa-card__eyebrow">Audit</span>
+            <h2 className="pa-card__title">Permission decisions</h2>
+            <span className="pa-card__chip">last 24h</span>
+          </div>
+          <div className="pa-card__body" style={{ color: "var(--text-muted)", font: "400 12.5px/1.5 var(--font-sans)" }}>
+            Stub — wire up to <code className="pa-md__inline">~/.pwragent/audit.jsonl</code>. Show
+            ALLOW / DENY decisions with actor, role(s) consulted, permission, and source line so we can
+            answer "why was this allowed?" after the fact.
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+window.PA = window.PA || {};
+window.PA.RBACPanel = RBACPanel;

--- a/docs/design/pwragent-v2/project/settings.jsx
+++ b/docs/design/pwragent-v2/project/settings.jsx
@@ -558,6 +558,7 @@ const SECTIONS = [
   { id: "applications", label: "Applications", icon: "VSCodeGlyph" },
   { id: "worktrees", label: "Worktrees", icon: "Worktree" },
   { id: "messaging", label: "Messaging", icon: "Activity", badge: true },
+  { id: "access", label: "Access Control", icon: "Lock" },
   { id: "models", label: "Models", icon: "Zap" },
   { id: "experimental", label: "Experimental", icon: "Loader" },
   { id: "about", label: "About", icon: "Info" },
@@ -592,6 +593,7 @@ function Settings({ section, setSection, onExit, platforms }) {
         {section === "applications" && <ApplicationsPanel />}
         {section === "worktrees" && <WorktreesPanel />}
         {section === "messaging" && <MessagingPanel platforms={platforms} />}
+        {section === "access" && <window.PA.RBACPanel />}
         {section === "models" && <ModelsPanel />}
         {section === "experimental" && <ExperimentalPanel />}
         {section === "about" && <AboutPanel />}

--- a/docs/design/pwragent-v2/project/sidebar.jsx
+++ b/docs/design/pwragent-v2/project/sidebar.jsx
@@ -70,15 +70,22 @@ function ThreadPlatformChip({ platform, status, blink, onUnbind }) {
   );
 }
 
-function ThreadRow({ thread, selected, onClick, onAddReaction, onUnbindPlatform }) {
+function ThreadRow({ thread, selected, onClick, onAddReaction, onUnbindPlatform, plain }) {
   const I = window.PA.Icon;
   const [picker, setPicker] = useStateSB(false);
-  const cls = ["pa-tr", selected ? "is-selected" : "", (thread.reactions||[]).length ? "has-reactions" : ""].filter(Boolean).join(" ");
+  const cls = ["pa-tr", selected ? "is-selected" : "", (thread.reactions||[]).length && !plain ? "has-reactions" : "", plain ? "is-plain" : ""].filter(Boolean).join(" ");
+  const showPlatforms = !plain && (thread.platforms || []).length > 0;
+  const prs = plain ? [] : (thread.prs || []);
+  const reactions = plain ? [] : (thread.reactions || []);
   return (
     <button className={cls} onClick={onClick} style={{ position: "relative" }}>
       <div className="pa-tr__head">
-        {thread.working && <span className="pa-tr__working-dot" title="Working…" />}
-        {(thread.platforms || []).length > 0 && (
+        <span className="pa-tr__lead">
+          {thread.working
+            ? <span className="pa-tr__working-dot" title="Working…" />
+            : <span className="pa-tr__idle-dot" aria-hidden="true" />}
+        </span>
+        {showPlatforms && (
           <span className="pa-tr__platforms">
             {thread.platforms.map((p) => (
               <ThreadPlatformChip
@@ -108,10 +115,10 @@ function ThreadRow({ thread, selected, onClick, onAddReaction, onUnbindPlatform 
           </span>
         )}
       </div>
-      {((thread.prs && thread.prs.length) || (thread.reactions && thread.reactions.length) || true) && (
+      {((prs.length) || (reactions.length) || true) && (
         <div className="pa-tr__row-end">
-          {(thread.prs || []).map((pr, i) => <PRChip key={i} pr={pr} />)}
-          {(thread.reactions || []).map((r, i) => (
+          {prs.map((pr, i) => <PRChip key={i} pr={pr} />)}
+          {reactions.map((r, i) => (
             <span key={i} className={`pa-react ${r.mine ? "is-mine" : ""}`} onClick={(e) => e.stopPropagation()}>
               <span className="pa-react__emoji">{r.emoji}</span>
               {r.count > 1 && r.count}
@@ -149,7 +156,7 @@ function LensSwitch({ value, onChange }) {
   );
 }
 
-function DirectoryGroup({ group, selectedId, onSelect, onAddReaction, onUnbindPlatform, onNewThreadInDir }) {
+function DirectoryGroup({ group, selectedId, onSelect, onAddReaction, onUnbindPlatform, onNewThreadInDir, plain }) {
   const I = window.PA.Icon;
   return (
     <div className="pa-dir-section">
@@ -174,13 +181,14 @@ function DirectoryGroup({ group, selectedId, onSelect, onAddReaction, onUnbindPl
           onClick={() => onSelect(t.id)}
           onAddReaction={onAddReaction}
           onUnbindPlatform={onUnbindPlatform}
+          plain={plain}
         />
       ))}
     </div>
   );
 }
 
-function Sidebar({ data, selectedId, onSelect, lens, setLens, contextDir, contextBranch, showDevContext, newThreadActive, onAddReaction, onUnbindPlatform, onNewThread, onNewThreadInDir }) {
+function Sidebar({ data, selectedId, onSelect, lens, setLens, contextDir, contextBranch, showDevContext, newThreadActive, onAddReaction, onUnbindPlatform, onNewThread, onNewThreadInDir, plainThreads }) {
   const I = window.PA.Icon;
   const flat = data.flatMap((g) => g.threads);
   return (
@@ -222,6 +230,7 @@ function Sidebar({ data, selectedId, onSelect, lens, setLens, contextDir, contex
             onClick={() => onSelect(t.id)}
             onAddReaction={onAddReaction}
             onUnbindPlatform={onUnbindPlatform}
+            plain={plainThreads}
           />
         ))}
         {lens === "Directories" && data.map((g) => (
@@ -233,6 +242,7 @@ function Sidebar({ data, selectedId, onSelect, lens, setLens, contextDir, contex
             onAddReaction={onAddReaction}
             onUnbindPlatform={onUnbindPlatform}
             onNewThreadInDir={onNewThreadInDir}
+            plain={plainThreads}
           />
         ))}
       </div>

--- a/docs/design/pwragent-v2/project/styles.css
+++ b/docs/design/pwragent-v2/project/styles.css
@@ -27,8 +27,7 @@ body {
   flex: 0 0 auto;
   display: flex;
   align-items: stretch;
-  background: #050403;
-  border-bottom: 1px solid var(--border-subtle);
+  background: transparent;
   -webkit-app-region: drag;
   position: relative;
   z-index: 30;
@@ -40,10 +39,12 @@ body {
   align-items: center;
   gap: 14px;
   padding: 0 14px 0 12px;
+  background: var(--bg-sidebar);
+  border-right: 1px solid var(--border-subtle);
 }
 .pa-tb__divider {
-  width: 1px;
-  background: var(--border-subtle);
+  width: 0;
+  background: transparent;
   align-self: stretch;
 }
 .pa-tb__main-zone {
@@ -53,6 +54,7 @@ body {
   align-items: center;
   gap: 10px;
   padding: 0 14px;
+  background: var(--bg-app);
 }
 .pa-tb__lights { display: flex; gap: 8px; padding-right: 4px; -webkit-app-region: no-drag;}
 .pa-tb__light { width: 12px; height: 12px; border-radius: 999px; }
@@ -488,7 +490,20 @@ body {
   font-family: var(--font-sans);
   transition: background 140ms ease, border-color 140ms ease;
 }
-.pa-tr:hover { background: var(--bg-panel-hover); }
+.pa-tr:hover {
+  background: var(--bg-panel-hover);
+  border-color: rgba(232, 116, 58, 0.18);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+}
+.pa-tr:hover .pa-tr__title { color: #fff; }
+.pa-tr:hover::after {
+  content: "";
+  position: absolute;
+  top: 14px; bottom: 14px; left: 5px;
+  width: 2px; border-radius: 999px;
+  background: rgba(232, 116, 58, 0.45);
+}
+.pa-tr.is-selected:hover::after { display: none; }
 .pa-tr.is-selected {
   border-color: var(--accent-border);
   background: var(--bg-row-active);
@@ -666,6 +681,7 @@ body {
 .pa-thread__header {
   display: flex; align-items: center; gap: 12px;
   padding: 14px 22px;
+  background: transparent;
   border-bottom: 1px solid var(--border-subtle);
 }
 .pa-thread__title {
@@ -1062,13 +1078,16 @@ body {
 .pa-composer {
   flex: 0 0 auto;
   border: 0;
-  border-top: 1px solid var(--border-subtle);
   border-radius: 0;
-  background: var(--bg-panel);
-  padding: 12px 22px 14px;
+  background: transparent;
+  padding: 12px 28px 22px;
   display: flex;
   flex-direction: column;
   gap: 10px;
+  width: 100%;
+  max-width: 940px;
+  margin: 0 auto;
+  box-sizing: border-box;
 }
 .pa-composer__eyebrow {
   font: 600 10px/1 var(--font-sans);
@@ -1078,20 +1097,27 @@ body {
 }
 .pa-composer__textarea {
   width: 100%;
-  min-height: 56px;
+  min-height: 54px;
   resize: none;
-  border: none;
-  background: transparent;
+  border: 1px solid var(--border-subtle);
+  border-radius: 10px;
+  background: var(--bg-panel);
   color: var(--text-primary);
   font: 400 13px/1.5 var(--font-sans);
   outline: none;
+  padding: 12px 14px;
+  box-sizing: border-box;
+  transition: border-color 140ms ease, box-shadow 140ms ease;
+}
+.pa-composer__textarea:focus {
+  border-color: var(--accent-border);
+  box-shadow: 0 0 0 1px var(--accent-border);
 }
 .pa-composer__textarea::placeholder { color: var(--text-muted); }
 
 .pa-composer__row {
   display: flex; gap: 6px; align-items: center; flex-wrap: wrap;
-  padding-top: 8px;
-  border-top: 1px solid var(--border-subtle);
+  padding-top: 4px;
 }
 .pa-composer__spacer { flex: 1; }
 
@@ -1179,6 +1205,206 @@ body {
 }
 .pa-send:hover { background: var(--accent-strong); }
 .pa-send:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* ============================================================
+   CONTEXT-WINDOW MOON — ported from desktop renderer
+   (waxing/waning sprite tracks how full the model context is)
+   ============================================================ */
+.context-window-moon {
+  display: inline-flex;
+  min-height: 28px;
+  min-width: 0;
+  align-items: center;
+  gap: 6px;
+  padding: 0 4px 0 2px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 28px;
+  letter-spacing: 0.02em;
+  cursor: default;
+  user-select: none;
+  position: relative;
+}
+.context-window-moon:focus-visible {
+  outline: 1px solid var(--accent-border);
+  outline-offset: 2px;
+  border-radius: 6px;
+}
+
+.context-window-moon__sprite {
+  display: inline-flex;
+  width: 22px;
+  height: 22px;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+}
+
+.context-window-moon__disc {
+  position: relative;
+  display: block;
+  width: 20px;
+  height: 20px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 179, 92, 0.44);
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 34% 28%, rgba(255, 241, 203, 0.72) 0 8%, transparent 17%),
+    radial-gradient(circle at 68% 62%, rgba(132, 58, 13, 0.28) 0 7%, transparent 13%),
+    radial-gradient(circle at 48% 76%, rgba(94, 42, 13, 0.20) 0 5%, transparent 11%),
+    radial-gradient(circle at 72% 30%, rgba(255, 205, 128, 0.36) 0 6%, transparent 14%),
+    radial-gradient(circle at 38% 34%, var(--accent-bright) 0%, var(--accent-strong) 42%, var(--accent) 100%);
+  box-shadow:
+    0 0 10px rgba(255, 138, 31, 0.30),
+    inset 0 0 4px rgba(255, 243, 220, 0.26);
+}
+.context-window-moon__disc::before {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background:
+    radial-gradient(circle at 63% 34%, rgba(71, 28, 7, 0.36) 0 1px, rgba(255, 207, 139, 0.18) 1px 2px, transparent 3px),
+    radial-gradient(circle at 42% 58%, rgba(77, 33, 10, 0.30) 0 1px, rgba(255, 218, 153, 0.14) 1px 2px, transparent 3px),
+    radial-gradient(circle at 78% 78%, rgba(80, 34,  9, 0.28) 0 1px, transparent 3px),
+    radial-gradient(circle at 50% 22%, rgba(255, 229, 171, 0.22) 0 1px, transparent 3px);
+  content: "";
+  mix-blend-mode: multiply;
+  opacity: 0.72;
+}
+.context-window-moon__disc::after {
+  position: absolute;
+  inset: -1px auto -1px var(--context-window-moon-shadow-left, -1px);
+  width: var(--context-window-moon-shadow-width, 100%);
+  border-radius: var(--context-window-moon-shadow-radius, 50%);
+  background: var(--bg-input);
+  box-shadow:
+    var(--context-window-moon-terminator-glow, 1px 0 3px rgba(255, 169, 79, 0.18)),
+    inset var(--context-window-moon-shadow-inset, -1px 0 2px) rgba(255, 138, 31, 0.16);
+  content: "";
+}
+
+/* phase-0 — empty (new moon) */
+.context-window-moon__sprite--phase-0 .context-window-moon__disc {
+  background:
+    radial-gradient(circle at 60% 36%, rgba(255, 138, 31, 0.08) 0 2px, transparent 3px),
+    rgba(255, 138, 31, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(255, 138, 31, 0.14);
+}
+.context-window-moon__sprite--phase-0 .context-window-moon__disc::after {
+  --context-window-moon-shadow-width: 100%;
+}
+
+/* phases 1..3 — waxing (shadow on the left, shrinking) */
+.context-window-moon__sprite--phase-1 { --context-window-moon-shadow-width: 76%; }
+.context-window-moon__sprite--phase-2 {
+  --context-window-moon-shadow-radius: 0;
+  --context-window-moon-shadow-width: 50%;
+}
+.context-window-moon__sprite--phase-3 { --context-window-moon-shadow-width: 24%; }
+
+/* phase 4 — full */
+.context-window-moon__sprite--phase-4 { --context-window-moon-shadow-width: 0%; }
+
+/* phases 5..7 — waning (shadow flipped to the right, growing) */
+.context-window-moon__sprite--phase-5 {
+  --context-window-moon-shadow-left: auto;
+  --context-window-moon-shadow-inset: 1px 0 2px;
+  --context-window-moon-shadow-width: 24%;
+  --context-window-moon-terminator-glow: -1px 0 3px rgba(255, 169, 79, 0.18);
+}
+.context-window-moon__sprite--phase-5 .context-window-moon__disc::after,
+.context-window-moon__sprite--phase-6 .context-window-moon__disc::after,
+.context-window-moon__sprite--phase-7 .context-window-moon__disc::after {
+  right: -1px;
+}
+.context-window-moon__sprite--phase-6 {
+  --context-window-moon-shadow-left: auto;
+  --context-window-moon-shadow-inset: 1px 0 2px;
+  --context-window-moon-shadow-radius: 0;
+  --context-window-moon-shadow-width: 50%;
+  --context-window-moon-terminator-glow: -1px 0 3px rgba(255, 169, 79, 0.18);
+}
+.context-window-moon__sprite--phase-7 {
+  --context-window-moon-shadow-left: auto;
+  --context-window-moon-shadow-inset: 1px 0 2px;
+  --context-window-moon-shadow-width: 76%;
+  --context-window-moon-terminator-glow: -1px 0 3px rgba(255, 169, 79, 0.18);
+}
+
+/* phase 4 + 8 — accent ring */
+.context-window-moon__sprite--phase-4 .context-window-moon__disc,
+.context-window-moon__sprite--phase-8 .context-window-moon__disc {
+  border-color: var(--accent-strong);
+}
+
+/* phase 8 — danger (over-budget glow) */
+.context-window-moon__sprite--phase-8 { --context-window-moon-shadow-width: 0%; }
+.context-window-moon__sprite--phase-8 .context-window-moon__disc {
+  box-shadow:
+    0 0 12px rgba(255, 138, 31, 0.48),
+    inset 0 0 4px rgba(255, 243, 220, 0.34);
+}
+
+.context-window-moon__label {
+  max-width: 4ch;
+  overflow: hidden;
+  white-space: nowrap;
+  color: var(--text-secondary);
+  font-feature-settings: "tnum";
+}
+.context-window-moon[data-phase="4"] .context-window-moon__label,
+.context-window-moon[data-phase="8"] .context-window-moon__label {
+  color: var(--accent-bright);
+}
+
+/* tooltip — bubble above the moon on hover/focus */
+.context-window-moon__tooltip {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  right: 0;
+  z-index: 30;
+  display: none;
+  min-width: 220px;
+  padding: 8px 10px;
+  border: 1px solid var(--accent-border);
+  border-radius: 8px;
+  background: var(--bg-row-active);
+  box-shadow: var(--shadow-md);
+  color: var(--text-secondary);
+  font-family: var(--font-sans);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.4;
+  white-space: normal;
+  pointer-events: none;
+}
+.context-window-moon__tooltip strong {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--accent-bright);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.context-window-moon__tooltip-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  color: var(--text-muted);
+}
+.context-window-moon__tooltip-row b {
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-weight: 500;
+}
+.context-window-moon:hover .context-window-moon__tooltip,
+.context-window-moon:focus-visible .context-window-moon__tooltip {
+  display: block;
+}
 
 /* ============================================================
    RIGHT RAIL — context panel
@@ -1898,6 +2124,19 @@ body {
 @keyframes pa-sweep { 0% { transform: translateX(-100%); } 100% { transform: translateX(100%); } }
 
 /* Working dot — left-of-title pulsing indicator */
+.pa-tr__lead {
+  width: 10px; height: 10px;
+  flex: 0 0 auto;
+  display: inline-flex; align-items: center; justify-content: center;
+}
+.pa-tr__idle-dot {
+  width: 6px; height: 6px;
+  border-radius: 999px;
+  background: rgba(140, 133, 122, 0.32);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+.pa-tr.is-selected .pa-tr__idle-dot,
+.pa-tr:hover .pa-tr__idle-dot { background: rgba(232, 116, 58, 0.55); }
 .pa-tr__working-dot {
   width: 8px; height: 8px;
   border-radius: 999px;

--- a/docs/design/pwragent-v2/project/threadview.jsx
+++ b/docs/design/pwragent-v2/project/threadview.jsx
@@ -187,9 +187,83 @@ function MessageBlock({ msg }) {
 }
 
 /* ----------------------------------------------------------------
+   Context-window moon — ported from the desktop renderer.
+   A waxing/waning sprite that visualizes how full the model's
+   context window is. Phase 0 = empty (new moon),
+   phase 4 = full (~100%), phase 8 = over budget (danger glow).
+---------------------------------------------------------------- */
+const CONTEXT_MOON_PHASES = [
+  "new moon",        // 0  · empty
+  "waxing crescent", // 1
+  "first quarter",   // 2
+  "waxing gibbous",  // 3
+  "full moon",       // 4  · at capacity
+  "waning gibbous",  // 5
+  "last quarter",    // 6
+  "waning crescent", // 7
+  "blood moon",      // 8  · over budget
+];
+function moonPhaseForPercent(p) {
+  if (p <= 0) return 0;
+  if (p < 18) return 1;
+  if (p < 38) return 2;
+  if (p < 58) return 3;
+  if (p < 78) return 4;
+  if (p < 88) return 5;
+  if (p < 95) return 6;
+  if (p < 100) return 7;
+  return 8;
+}
+function compactNum(n) {
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(n >= 10_000_000 ? 0 : 1).replace(/\.0$/, "") + "M";
+  if (n >= 1_000) return (n / 1_000).toFixed(n >= 10_000 ? 0 : 1).replace(/\.0$/, "") + "k";
+  return String(n);
+}
+function ContextWindowMoon({ usedPercent = 0, totalTokens, modelContextWindow, model = "GPT-5.5" }) {
+  const phase = moonPhaseForPercent(usedPercent);
+  const phaseLabel = CONTEXT_MOON_PHASES[phase];
+  const pct = Math.round(usedPercent);
+  const percentLabel = `${pct}%`;
+  const tokens = totalTokens ?? Math.round((usedPercent / 100) * (modelContextWindow ?? 200_000));
+  const max = modelContextWindow ?? 200_000;
+  const label = `Context window ${percentLabel} full, ${compactNum(tokens)}/${compactNum(max)} tokens, ${phaseLabel}`;
+  return (
+    <div
+      aria-label={label}
+      className="context-window-moon"
+      data-phase={phase}
+      role="img"
+      tabIndex={0}
+    >
+      <span
+        aria-hidden="true"
+        className={`context-window-moon__sprite context-window-moon__sprite--phase-${phase}`}
+      >
+        <span className="context-window-moon__disc" />
+      </span>
+      <span className="context-window-moon__label">{percentLabel}</span>
+      <span className="context-window-moon__tooltip" role="tooltip">
+        <strong>Context · {phaseLabel}</strong>
+        <span className="context-window-moon__tooltip-row">
+          <span>Used</span><b>{pct}%</b>
+        </span>
+        <span className="context-window-moon__tooltip-row">
+          <span>Snapshot</span><b>{compactNum(tokens)} / {compactNum(max)}</b>
+        </span>
+        <span className="context-window-moon__tooltip-row">
+          <span>Model</span><b>{model}</b>
+        </span>
+      </span>
+    </div>
+  );
+}
+window.PA = window.PA || {};
+window.PA.ContextWindowMoon = ContextWindowMoon;
+
+/* ----------------------------------------------------------------
    Composer (now sits flush against bottom of app)
 ---------------------------------------------------------------- */
-function Composer({ onSend }) {
+function Composer({ onSend, contextPercent = 57 }) {
   const I = window.PA.Icon;
   const [text, setText] = useStateTV("");
   const [fast, setFast] = useStateTV(false);
@@ -197,7 +271,6 @@ function Composer({ onSend }) {
   const send = () => { if (!text.trim()) return; onSend?.(text); setText(""); };
   return (
     <div className="pa-composer">
-      <div className="pa-composer__eyebrow">Reply</div>
       <textarea
         className="pa-composer__textarea"
         placeholder="Reply to this thread"
@@ -225,9 +298,11 @@ function Composer({ onSend }) {
         <button className="pa-applaunch"><I.VSCodeGlyph size={16} />VS Code</button>
         <button className="pa-applaunch"><I.GhosttyGlyph size={16} />Ghostty</button>
         <span className="pa-composer__spacer" />
-        <button className="pa-pick" disabled style={{opacity:.6}}>
-          <I.Activity size={11} /><span>57%</span>
-        </button>
+        <window.PA.ContextWindowMoon
+          usedPercent={contextPercent}
+          modelContextWindow={200000}
+          model="GPT-5.5"
+        />
         <button className="pa-send" onClick={send} disabled={!text.trim()}>
           <I.Send size={12} />Send
         </button>
@@ -367,7 +442,7 @@ Test Files  1 passed (1)
 /* ----------------------------------------------------------------
    Thread view — full-bleed transcript, composer flush at bottom
 ---------------------------------------------------------------- */
-function ThreadView({ thread, onSend }) {
+function ThreadView({ thread, onSend, contextPercent }) {
   const turns = (thread.turns && thread.turns.length > 4) ? thread.turns : buildSampleTurns();
   const scrollRef = useRefTV(null);
 
@@ -395,7 +470,7 @@ function ThreadView({ thread, onSend }) {
         <div className="pa-transcript__fade pa-transcript__fade--top" />
         <div className="pa-transcript__fade pa-transcript__fade--bottom" />
       </section>
-      <Composer onSend={onSend} />
+      <Composer onSend={onSend} contextPercent={contextPercent} />
     </main>
   );
 }


### PR DESCRIPTION
## Summary

The PwrAgent v2 reference prototype now carries the newer desktop design surfaces: branch-aware thread starts, a context-window moon in the composer, and an Access Control settings panel for reviewing actors, roles, permissions, and rejected senders.

## What changed

- Adds the Access Control/RBAC settings concept with a three-column authorization graph and rejected-sender handling.
- Updates the new-thread prototype around project branch selection, worktree context, and a transcript-style layout that matches the thread view.
- Refreshes the thread composer and sidebar treatment with the context-window moon, quieter composer chrome, stronger hover states, and the true-black/tangerine theme pass.
- Adds v3 and v4 HTML snapshots so the design bundle keeps the newer prototype entry points alongside v2.

## Validation

- `git diff --cached --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
