### PR TITLE
fix(tests): stabilize sqlite overlay store specs

### DIFF
--- a/apps/desktop/src/main/__tests__/overlay-store-directory-pins.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-directory-pins.test.ts
@@ -1,23 +1,22 @@
-import { mkdtempSync, rmSync } from "node:fs";
-import os from "node:os";
-import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { SqliteOverlayStore } from "../state/overlay-store-sqlite";
 import { StateDb } from "../state/state-db";
+import {
+  createTempStateDb,
+  openInMemoryStateDb,
+  removeTempStateDbDir,
+} from "./sqlite-test-utils";
 
 let stateDb: StateDb;
 let store: SqliteOverlayStore;
-let tempDir: string;
 
 beforeEach(() => {
-  tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-directory-pins-test-"));
-  stateDb = StateDb.open(path.join(tempDir, "state.db"));
+  stateDb = openInMemoryStateDb();
   store = new SqliteOverlayStore(stateDb);
 });
 
 afterEach(() => {
   stateDb.close();
-  rmSync(tempDir, { recursive: true, force: true });
 });
 
 /**
@@ -119,20 +118,37 @@ describe("SqliteOverlayStore — directory pins", () => {
   });
 
   it("persists pin state across sqlite handles", async () => {
-    await store.setDirectoryPin({
-      directoryKey: "directory:/Users/me/code/PwrAgent",
-      pinnedRank: "1024",
-    });
+    const { dbPath, tempDir } = createTempStateDb(
+      "pwragent-directory-pins-test-",
+    );
     stateDb.close();
+    stateDb = StateDb.open(dbPath);
+    store = new SqliteOverlayStore(stateDb);
 
-    const reopenedDb = StateDb.open(path.join(tempDir, "state.db"));
-    const reopenedStore = new SqliteOverlayStore(reopenedDb);
-    await expect(
-      reopenedStore.getDirectoryOverlayState({
+    try {
+      await store.setDirectoryPin({
         directoryKey: "directory:/Users/me/code/PwrAgent",
-      }),
-    ).resolves.toMatchObject({ pinnedRank: "1024" });
-    reopenedDb.close();
+        pinnedRank: "1024",
+      });
+      stateDb.close();
+
+      const reopenedDb = StateDb.open(dbPath);
+      const reopenedStore = new SqliteOverlayStore(reopenedDb);
+      try {
+        await expect(
+          reopenedStore.getDirectoryOverlayState({
+            directoryKey: "directory:/Users/me/code/PwrAgent",
+          }),
+        ).resolves.toMatchObject({ pinnedRank: "1024" });
+      } finally {
+        reopenedDb.close();
+      }
+    } finally {
+      stateDb.close();
+      removeTempStateDbDir(tempDir);
+      stateDb = openInMemoryStateDb();
+      store = new SqliteOverlayStore(stateDb);
+    }
   });
 
   it("readAllDirectoryOverlays returns every persisted row keyed by directoryKey", async () => {

--- a/apps/desktop/src/main/__tests__/overlay-store-launchpad-defaults.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-launchpad-defaults.test.ts
@@ -1,23 +1,22 @@
-import { mkdtempSync, rmSync } from "node:fs";
-import os from "node:os";
-import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { SqliteOverlayStore } from "../state/overlay-store-sqlite";
 import { StateDb } from "../state/state-db";
+import {
+  createTempStateDb,
+  openInMemoryStateDb,
+  removeTempStateDbDir,
+} from "./sqlite-test-utils";
 
 let stateDb: StateDb;
 let store: SqliteOverlayStore;
-let tempDir: string;
 
 beforeEach(() => {
-  tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-launchpad-defaults-test-"));
-  stateDb = StateDb.open(path.join(tempDir, "state.db"));
+  stateDb = openInMemoryStateDb();
   store = new SqliteOverlayStore(stateDb);
 });
 
 afterEach(() => {
   stateDb.close();
-  rmSync(tempDir, { recursive: true, force: true });
 });
 
 function listDefaultKeys(): string[] {
@@ -37,19 +36,34 @@ function readDefaultValue(key: string): unknown {
 
 describe("SqliteOverlayStore - launchpad defaults", () => {
   it("persists the selected navigation browse mode", async () => {
+    const { dbPath, tempDir } = createTempStateDb(
+      "pwragent-launchpad-defaults-test-",
+    );
+    stateDb.close();
+    stateDb = StateDb.open(dbPath);
+    store = new SqliteOverlayStore(stateDb);
+
     expect(store.getNavigationBrowseModeSync()).toBe("inbox");
 
-    await expect(store.setNavigationBrowseMode("directories")).resolves.toBe(
-      "directories",
-    );
-    await expect(store.getNavigationBrowseMode()).resolves.toBe("directories");
-
-    const reopenedDb = StateDb.open(path.join(tempDir, "state.db"));
-    const reopenedStore = new SqliteOverlayStore(reopenedDb);
     try {
-      expect(reopenedStore.getNavigationBrowseModeSync()).toBe("directories");
+      await expect(store.setNavigationBrowseMode("directories")).resolves.toBe(
+        "directories",
+      );
+      await expect(store.getNavigationBrowseMode()).resolves.toBe("directories");
+      stateDb.close();
+
+      const reopenedDb = StateDb.open(dbPath);
+      const reopenedStore = new SqliteOverlayStore(reopenedDb);
+      try {
+        expect(reopenedStore.getNavigationBrowseModeSync()).toBe("directories");
+      } finally {
+        reopenedDb.close();
+      }
     } finally {
-      reopenedDb.close();
+      stateDb.close();
+      removeTempStateDbDir(tempDir);
+      stateDb = openInMemoryStateDb();
+      store = new SqliteOverlayStore(stateDb);
     }
   });
 

--- a/apps/desktop/src/main/__tests__/overlay-store-permission-transitions.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-permission-transitions.test.ts
@@ -1,14 +1,15 @@
-import { mkdtempSync, rmSync } from "node:fs";
-import os from "node:os";
-import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { ThreadPermissionTransition } from "@pwragent/shared";
 import { SqliteOverlayStore } from "../state/overlay-store-sqlite";
 import { StateDb } from "../state/state-db";
+import {
+  createTempStateDb,
+  openInMemoryStateDb,
+  removeTempStateDbDir,
+} from "./sqlite-test-utils";
 
 let stateDb: StateDb;
 let store: SqliteOverlayStore;
-let tempDir: string;
 
 function buildTransition(
   overrides: Partial<ThreadPermissionTransition>,
@@ -25,16 +26,12 @@ function buildTransition(
 }
 
 beforeEach(() => {
-  tempDir = mkdtempSync(
-    path.join(os.tmpdir(), "pwragent-permission-transitions-test-"),
-  );
-  stateDb = StateDb.open(path.join(tempDir, "state.db"));
+  stateDb = openInMemoryStateDb();
   store = new SqliteOverlayStore(stateDb);
 });
 
 afterEach(() => {
   stateDb.close();
-  rmSync(tempDir, { recursive: true, force: true });
 });
 
 describe("SqliteOverlayStore — permission transition log", () => {
@@ -76,48 +73,59 @@ describe("SqliteOverlayStore — permission transition log", () => {
   });
 
   it("does NOT persist queued execution-mode fields across reopen", async () => {
-    // Seed an overlay with executionMode + a transition log entry, then
-    // simulate the registry-memory queue by writing the queue fields
-    // through setThreadExecutionMode + a side-channel manipulation that
-    // we'd never do in real code — except we DON'T have a public
-    // setter for queue fields, so the only way to verify persistence
-    // semantics is to confirm the ThreadOverlayState read does not
-    // resurrect queue fields after reopen, even when an
-    // appendPermissionTransition has happened in between.
-    await store.setThreadExecutionMode({
-      backend: "codex",
-      threadId: "thread-1",
-      executionMode: "default",
-    });
-    await store.appendPermissionTransition({
-      backend: "codex",
-      threadId: "thread-1",
-      transition: buildTransition({ id: "entry-1", status: "applied" }),
-    });
-
-    const dbPath = path.join(tempDir, "state.db");
+    const { dbPath, tempDir } = createTempStateDb(
+      "pwragent-permission-transitions-test-",
+    );
     stateDb.close();
-
-    const reopened = StateDb.open(dbPath);
-    const reopenedStore = new SqliteOverlayStore(reopened);
-    const overlay = await reopenedStore.getThreadOverlayState({
-      backend: "codex",
-      threadId: "thread-1",
-    });
-    // Transition log persists.
-    expect(overlay?.permissionTransitionLog).toEqual([
-      buildTransition({ id: "entry-1", status: "applied" }),
-    ]);
-    // Queue fields, even if they leaked into the in-memory state at
-    // some point, are never serialized — they reset to undefined on
-    // reopen.
-    expect(overlay?.queuedExecutionMode).toBeUndefined();
-    expect(overlay?.queuedExecutionModeAt).toBeUndefined();
-    reopened.close();
-
-    // Re-open the original handle so afterEach's close doesn't double-close.
     stateDb = StateDb.open(dbPath);
     store = new SqliteOverlayStore(stateDb);
+
+    try {
+      // Seed an overlay with executionMode + a transition log entry, then
+      // simulate the registry-memory queue by writing the queue fields
+      // through setThreadExecutionMode + a side-channel manipulation that
+      // we'd never do in real code — except we DON'T have a public
+      // setter for queue fields, so the only way to verify persistence
+      // semantics is to confirm the ThreadOverlayState read does not
+      // resurrect queue fields after reopen, even when an
+      // appendPermissionTransition has happened in between.
+      await store.setThreadExecutionMode({
+        backend: "codex",
+        threadId: "thread-1",
+        executionMode: "default",
+      });
+      await store.appendPermissionTransition({
+        backend: "codex",
+        threadId: "thread-1",
+        transition: buildTransition({ id: "entry-1", status: "applied" }),
+      });
+      stateDb.close();
+
+      const reopened = StateDb.open(dbPath);
+      const reopenedStore = new SqliteOverlayStore(reopened);
+      try {
+        const overlay = await reopenedStore.getThreadOverlayState({
+          backend: "codex",
+          threadId: "thread-1",
+        });
+        // Transition log persists.
+        expect(overlay?.permissionTransitionLog).toEqual([
+          buildTransition({ id: "entry-1", status: "applied" }),
+        ]);
+        // Queue fields, even if they leaked into the in-memory state at
+        // some point, are never serialized — they reset to undefined on
+        // reopen.
+        expect(overlay?.queuedExecutionMode).toBeUndefined();
+        expect(overlay?.queuedExecutionModeAt).toBeUndefined();
+      } finally {
+        reopened.close();
+      }
+    } finally {
+      stateDb.close();
+      removeTempStateDbDir(tempDir);
+      stateDb = openInMemoryStateDb();
+      store = new SqliteOverlayStore(stateDb);
+    }
   });
 
   it("scopes the log per (backend, threadId)", async () => {

--- a/apps/desktop/src/main/__tests__/overlay-store-pins.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-pins.test.ts
@@ -1,23 +1,22 @@
-import { mkdtempSync, rmSync } from "node:fs";
-import os from "node:os";
-import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { SqliteOverlayStore } from "../state/overlay-store-sqlite";
 import { StateDb } from "../state/state-db";
+import {
+  createTempStateDb,
+  openInMemoryStateDb,
+  removeTempStateDbDir,
+} from "./sqlite-test-utils";
 
 let stateDb: StateDb;
 let store: SqliteOverlayStore;
-let tempDir: string;
 
 beforeEach(() => {
-  tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-pins-test-"));
-  stateDb = StateDb.open(path.join(tempDir, "state.db"));
+  stateDb = openInMemoryStateDb();
   store = new SqliteOverlayStore(stateDb);
 });
 
 afterEach(() => {
   stateDb.close();
-  rmSync(tempDir, { recursive: true, force: true });
 });
 
 describe("SqliteOverlayStore — thread pins", () => {
@@ -95,19 +94,37 @@ describe("SqliteOverlayStore — thread pins", () => {
   });
 
   it("persists pin state across sqlite handles", async () => {
-    await store.setThreadPin({
-      backend: "codex",
-      threadId: "thread-1",
-      pinnedRank: "1024",
-    });
+    const { dbPath, tempDir } = createTempStateDb("pwragent-pins-test-");
     stateDb.close();
+    stateDb = StateDb.open(dbPath);
+    store = new SqliteOverlayStore(stateDb);
 
-    const reopenedDb = StateDb.open(path.join(tempDir, "state.db"));
-    const reopenedStore = new SqliteOverlayStore(reopenedDb);
-    await expect(
-      reopenedStore.getThreadOverlayState({ backend: "codex", threadId: "thread-1" }),
-    ).resolves.toMatchObject({ pinnedRank: "1024" });
-    reopenedDb.close();
+    try {
+      await store.setThreadPin({
+        backend: "codex",
+        threadId: "thread-1",
+        pinnedRank: "1024",
+      });
+      stateDb.close();
+
+      const reopenedDb = StateDb.open(dbPath);
+      const reopenedStore = new SqliteOverlayStore(reopenedDb);
+      try {
+        await expect(
+          reopenedStore.getThreadOverlayState({
+            backend: "codex",
+            threadId: "thread-1",
+          }),
+        ).resolves.toMatchObject({ pinnedRank: "1024" });
+      } finally {
+        reopenedDb.close();
+      }
+    } finally {
+      stateDb.close();
+      removeTempStateDbDir(tempDir);
+      stateDb = openInMemoryStateDb();
+      store = new SqliteOverlayStore(stateDb);
+    }
   });
 
   it("persists dynamic ACP backend pin state with an escaped thread key", async () => {
@@ -131,43 +148,57 @@ describe("SqliteOverlayStore — thread pins", () => {
   });
 
   it("persists sub-thread parent, order, and collapsed state", async () => {
-    await store.setThreadParent({
-      backend: "codex",
-      threadId: "review-thread",
-      parentThreadId: "parent-thread",
-    });
-    await store.updateSubthreadOrder({
-      backend: "codex",
-      parentThreadId: "parent-thread",
-      threadIds: ["review-thread", "scratch-thread"],
-    });
-    await store.setSubthreadsCollapsed({
-      backend: "codex",
-      parentThreadId: "parent-thread",
-      collapsed: true,
-    });
-
+    const { dbPath, tempDir } = createTempStateDb("pwragent-pins-test-");
     stateDb.close();
+    stateDb = StateDb.open(dbPath);
+    store = new SqliteOverlayStore(stateDb);
 
-    const reopenedDb = StateDb.open(path.join(tempDir, "state.db"));
-    const reopenedStore = new SqliteOverlayStore(reopenedDb);
-    await expect(
-      reopenedStore.getThreadOverlayState({
+    try {
+      await store.setThreadParent({
         backend: "codex",
         threadId: "review-thread",
-      }),
-    ).resolves.toMatchObject({
-      parentThreadId: "parent-thread",
-    });
-    await expect(
-      reopenedStore.getThreadOverlayState({
+        parentThreadId: "parent-thread",
+      });
+      await store.updateSubthreadOrder({
         backend: "codex",
-        threadId: "parent-thread",
-      }),
-    ).resolves.toMatchObject({
-      subthreadOrder: ["review-thread", "scratch-thread"],
-      subthreadsCollapsed: true,
-    });
-    reopenedDb.close();
+        parentThreadId: "parent-thread",
+        threadIds: ["review-thread", "scratch-thread"],
+      });
+      await store.setSubthreadsCollapsed({
+        backend: "codex",
+        parentThreadId: "parent-thread",
+        collapsed: true,
+      });
+      stateDb.close();
+
+      const reopenedDb = StateDb.open(dbPath);
+      const reopenedStore = new SqliteOverlayStore(reopenedDb);
+      try {
+        await expect(
+          reopenedStore.getThreadOverlayState({
+            backend: "codex",
+            threadId: "review-thread",
+          }),
+        ).resolves.toMatchObject({
+          parentThreadId: "parent-thread",
+        });
+        await expect(
+          reopenedStore.getThreadOverlayState({
+            backend: "codex",
+            threadId: "parent-thread",
+          }),
+        ).resolves.toMatchObject({
+          subthreadOrder: ["review-thread", "scratch-thread"],
+          subthreadsCollapsed: true,
+        });
+      } finally {
+        reopenedDb.close();
+      }
+    } finally {
+      stateDb.close();
+      removeTempStateDbDir(tempDir);
+      stateDb = openInMemoryStateDb();
+      store = new SqliteOverlayStore(stateDb);
+    }
   });
 });

--- a/apps/desktop/src/main/__tests__/overlay-store-turn-failures.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-turn-failures.test.ts
@@ -1,14 +1,15 @@
-import { mkdtempSync, rmSync } from "node:fs";
-import os from "node:os";
-import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { ThreadTurnFailure } from "@pwragent/shared";
 import { SqliteOverlayStore } from "../state/overlay-store-sqlite";
 import { StateDb } from "../state/state-db";
+import {
+  createTempStateDb,
+  openInMemoryStateDb,
+  removeTempStateDbDir,
+} from "./sqlite-test-utils";
 
 let stateDb: StateDb;
 let store: SqliteOverlayStore;
-let tempDir: string;
 
 function buildFailure(
   overrides: Partial<ThreadTurnFailure>,
@@ -23,14 +24,12 @@ function buildFailure(
 }
 
 beforeEach(() => {
-  tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-turn-failures-test-"));
-  stateDb = StateDb.open(path.join(tempDir, "state.db"));
+  stateDb = openInMemoryStateDb();
   store = new SqliteOverlayStore(stateDb);
 });
 
 afterEach(() => {
   stateDb.close();
-  rmSync(tempDir, { recursive: true, force: true });
 });
 
 describe("SqliteOverlayStore — turn failure log", () => {
@@ -96,29 +95,40 @@ describe("SqliteOverlayStore — turn failure log", () => {
   });
 
   it("persists the failure log across a reopen", async () => {
-    await store.appendTurnFailure({
-      backend: "codex",
-      threadId: "thread-1",
-      failure: buildFailure({ id: "entry-1", turnId: "turn-1" }),
-    });
-
-    const dbPath = path.join(tempDir, "state.db");
+    const { dbPath, tempDir } = createTempStateDb(
+      "pwragent-turn-failures-test-",
+    );
     stateDb.close();
-
-    const reopened = StateDb.open(dbPath);
-    const reopenedStore = new SqliteOverlayStore(reopened);
-    const overlay = await reopenedStore.getThreadOverlayState({
-      backend: "codex",
-      threadId: "thread-1",
-    });
-    expect(overlay?.turnFailureLog).toEqual([
-      buildFailure({ id: "entry-1", turnId: "turn-1" }),
-    ]);
-    reopened.close();
-
-    // Re-open the original handle so afterEach's close doesn't double-close.
     stateDb = StateDb.open(dbPath);
     store = new SqliteOverlayStore(stateDb);
+
+    try {
+      await store.appendTurnFailure({
+        backend: "codex",
+        threadId: "thread-1",
+        failure: buildFailure({ id: "entry-1", turnId: "turn-1" }),
+      });
+      stateDb.close();
+
+      const reopened = StateDb.open(dbPath);
+      const reopenedStore = new SqliteOverlayStore(reopened);
+      try {
+        const overlay = await reopenedStore.getThreadOverlayState({
+          backend: "codex",
+          threadId: "thread-1",
+        });
+        expect(overlay?.turnFailureLog).toEqual([
+          buildFailure({ id: "entry-1", turnId: "turn-1" }),
+        ]);
+      } finally {
+        reopened.close();
+      }
+    } finally {
+      stateDb.close();
+      removeTempStateDbDir(tempDir);
+      stateDb = openInMemoryStateDb();
+      store = new SqliteOverlayStore(stateDb);
+    }
   });
 
   it("scopes the log per (backend, threadId)", async () => {

--- a/apps/desktop/src/main/__tests__/sqlite-test-utils.ts
+++ b/apps/desktop/src/main/__tests__/sqlite-test-utils.ts
@@ -1,0 +1,28 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { StateDb } from "../state/state-db";
+
+export function openInMemoryStateDb(): StateDb {
+  return StateDb.open(":memory:");
+}
+
+export function createTempStateDb(prefix: string): {
+  dbPath: string;
+  tempDir: string;
+} {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), prefix));
+  return {
+    dbPath: path.join(tempDir, "state.db"),
+    tempDir,
+  };
+}
+
+export function removeTempStateDbDir(tempDir: string): void {
+  rmSync(tempDir, {
+    recursive: true,
+    force: true,
+    maxRetries: 5,
+    retryDelay: 100,
+  });
+}


### PR DESCRIPTION
## Summary
Windows overlay-store tests now avoid file-backed sqlite unless a test is explicitly verifying close/reopen persistence. The flaky suites still exercise real sqlite persistence paths where it matters, but ordinary store behavior runs against `:memory:` handles so Windows CI is no longer repeatedly creating, closing, and deleting WAL databases in hook setup/teardown.

This should make the prior failure mode more reliable because the expensive `%TEMP%` sqlite file lifecycle is removed from most cases, and the remaining temp DB cleanup is centralized with bounded retry handling for Windows file-handle release latency.

## Verification
- `pnpm test apps/desktop/src/main/__tests__/overlay-store-directory-pins.test.ts apps/desktop/src/main/__tests__/overlay-store-launchpad-defaults.test.ts apps/desktop/src/main/__tests__/overlay-store-permission-transitions.test.ts apps/desktop/src/main/__tests__/overlay-store-pins.test.ts apps/desktop/src/main/__tests__/overlay-store-turn-failures.test.ts`
- `pnpm exec vitest run --config vitest.workspace.ts --project desktop-main`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
