### PR TITLE
feat(messaging): support Codex skill questionnaires

### DIFF
--- a/apps/desktop/e2e/request-user-input.spec.ts
+++ b/apps/desktop/e2e/request-user-input.spec.ts
@@ -50,10 +50,17 @@ test("answers request_user_input questionnaires with back and next navigation", 
     const pendingInput = app.window.getByRole("group", { name: "Pending input" });
 
     await pendingInput.getByRole("button", { name: /Large refactor/ }).click();
-    await pendingInput.getByRole("button", { name: "Next" }).click();
     await expect(pendingInput.getByText("Question 2 of 2")).toBeVisible();
 
     await pendingInput.getByRole("button", { name: /Unit only/ }).click();
+    await expect(pendingInput.getByRole("heading", { name: "Review answers" })).toBeVisible();
+
+    await pendingInput.getByRole("button", { name: "Back" }).click();
+    await expect(pendingInput.getByText("Question 2 of 2")).toBeVisible();
+    await expect(
+      pendingInput.getByRole("button", { name: /Unit only/ })
+    ).toHaveAttribute("aria-pressed", "true");
+
     await pendingInput.getByRole("button", { name: "Back" }).click();
     await expect(pendingInput.getByText("Question 1 of 2")).toBeVisible();
     await expect(
@@ -61,6 +68,7 @@ test("answers request_user_input questionnaires with back and next navigation", 
     ).toHaveAttribute("aria-pressed", "true");
 
     await pendingInput.getByRole("button", { name: "Next" }).click();
+    await pendingInput.getByRole("button", { name: "Review" }).click();
     await pendingInput.getByRole("button", { name: "Submit" }).click();
 
     await expect(app.window.getByRole("group", { name: "Pending input" })).toHaveCount(0);

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -769,6 +769,7 @@ class MockBackendClient {
     reasoningEffort?: string;
     fastMode?: boolean;
     codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
+    defaultModeRequestUserInput?: boolean;
   };
   lastForkThreadParams?: {
     threadId: string;
@@ -794,6 +795,7 @@ class MockBackendClient {
     reasoningEffort?: string;
     fastMode?: boolean;
     codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
+    defaultModeRequestUserInput?: boolean;
     dynamicTools?: unknown;
   };
   interruptTurnCallCount = 0;
@@ -1061,6 +1063,7 @@ class MockBackendClient {
     reasoningEffort?: string;
     fastMode?: boolean;
     codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
+    defaultModeRequestUserInput?: boolean;
   }): Promise<{ threadId: string }> {
     this.lastStartThreadParams = params;
     return this.options.startThreadResult ?? { threadId: "thread-1" };
@@ -1095,6 +1098,7 @@ class MockBackendClient {
     reasoningEffort?: string;
     fastMode?: boolean;
     codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
+    defaultModeRequestUserInput?: boolean;
     dynamicTools?: unknown;
   }): Promise<{ threadId: string; turnId: string }> {
     this.startTurnCallCount += 1;
@@ -1487,6 +1491,37 @@ function createKimiAcpRegistry(options?: {
 }
 
 describe("DesktopBackendRegistry", () => {
+  it("passes the Codex default-mode question toggle to new and resumed threads", async () => {
+    const codexClient = new MockBackendClient({ threads: [] });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({ threads: [] }),
+      overlayStore: createOverlayStoreMock(),
+      resolveCodexDefaultModeRequestUserInput: () => true,
+    });
+
+    try {
+      await registry.startThread({
+        backend: "codex",
+        cwd: process.cwd(),
+      });
+      expect(codexClient.lastStartThreadParams?.defaultModeRequestUserInput).toBe(
+        true,
+      );
+
+      await registry.startTurn({
+        backend: "codex",
+        threadId: "thread-1",
+        input: [{ type: "text", text: "continue" }],
+      });
+      expect(codexClient.lastStartTurnParams?.defaultModeRequestUserInput).toBe(
+        true,
+      );
+    } finally {
+      await registry.close();
+    }
+  });
+
   it("returns ACP provider commands from session metadata", async () => {
     const session: AcpSessionMetadata = {
       backendId: "acp:kimi",

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -5198,6 +5198,35 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("enables default-mode request_user_input in Codex thread/start config", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    await client.startThread({
+      cwd: "/Users/huntharo/pwrdrvr/PwrAgent",
+      defaultModeRequestUserInput: true,
+    });
+
+    const transport = MockTransport.instances.at(-1);
+    expect(transport).toBeDefined();
+    const startPayload = transport!.sentMessages
+      .map((message) => JSON.parse(message) as { method?: string; params?: unknown })
+      .find((payload) => payload.method === "thread/start");
+
+    expect(startPayload?.params).toMatchObject({
+      cwd: "/Users/huntharo/pwrdrvr/PwrAgent",
+      config: {
+        "features.default_mode_request_user_input": true,
+      },
+    });
+
+    await client.close();
+  });
+
   it("starts the first turn on a newly created thread without a resume preflight", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
     MockTransport.turnStartResult = {
@@ -6070,6 +6099,40 @@ describe("CodexAppServerClient", () => {
         },
       ],
     });
+
+    await client.close();
+  });
+
+  it("enables default-mode request_user_input in Codex thread/resume config", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    await client.startTurn({
+      threadId: "thread-2",
+      input: [{ type: "text", text: "Reply to the existing thread" }],
+      defaultModeRequestUserInput: true,
+    });
+
+    const transport = MockTransport.instances.at(-1);
+    expect(transport).toBeDefined();
+    const resumePayload = transport!.sentMessages
+      .map((message) => JSON.parse(message) as { method?: string; params?: unknown })
+      .find((payload) => payload.method === "thread/resume");
+    const turnPayload = transport!.sentMessages
+      .map((message) => JSON.parse(message) as { method?: string; params?: unknown })
+      .find((payload) => payload.method === "turn/start");
+
+    expect(resumePayload?.params).toMatchObject({
+      threadId: "thread-2",
+      config: {
+        "features.default_mode_request_user_input": true,
+      },
+    });
+    expect(turnPayload?.params).not.toHaveProperty("config");
 
     await client.close();
   });

--- a/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
@@ -124,6 +124,22 @@ describe("desktopSettingsPatchToEdits — experimental", () => {
       },
     ]);
   });
+
+  it("writes the Codex default-mode request_user_input flag", () => {
+    const edits = desktopSettingsPatchToEdits({
+      experimental: {
+        codexDefaultModeRequestUserInput: true,
+      },
+    });
+
+    expect(edits).toEqual([
+      {
+        op: "set",
+        path: ["experimental", "codex_default_mode_request_user_input"],
+        value: true,
+      },
+    ]);
+  });
 });
 
 describe("desktopSettingsPatchToEdits — image uploads", () => {

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -1648,6 +1648,39 @@ describe("DesktopSettingsService", () => {
     );
   });
 
+  it("defaults Codex default-mode request_user_input to false and persists it", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    const service = new DesktopSettingsService({
+      configPath,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    const initial = await service.readSettings();
+    expect(initial.experimental.codexDefaultModeRequestUserInput).toEqual({
+      value: false,
+      source: "default",
+    });
+    expect(service.resolveCodexDefaultModeRequestUserInput()).toBe(false);
+
+    await service.writeConfigPatch({
+      experimental: {
+        codexDefaultModeRequestUserInput: true,
+      },
+    });
+
+    const updated = await service.readSettings();
+    expect(updated.experimental.codexDefaultModeRequestUserInput).toEqual({
+      value: true,
+      source: "config",
+    });
+    expect(service.resolveCodexDefaultModeRequestUserInput()).toBe(true);
+    expect(fs.readFileSync(configPath, "utf8")).toContain(
+      "codex_default_mode_request_user_input = true",
+    );
+  });
+
   it("preserves unknown sections written by other builds when saving a patch", async () => {
     const root = createTempRoot();
     const configPath = path.join(root, "config.toml");

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -9608,6 +9608,133 @@ describe("MessagingController", () => {
     });
   });
 
+  it("records questionnaire answers, navigates review, and submits through messaging", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+    await harness.controller.handleBackendPendingRequest("codex", {
+      method: "item/tool/requestUserInput",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        requestId: "request-questions",
+        questions: [
+          {
+            id: "breakfast",
+            header: "Breakfast",
+            question: "What's for breakfast?",
+            isOther: true,
+            isSecret: false,
+            options: [
+              {
+                label: "Pancakes (Recommended)",
+                description: "A funny baseline.",
+              },
+            ],
+          },
+          {
+            id: "tone",
+            header: "Tone",
+            question: "How silly should it be?",
+            isOther: false,
+            isSecret: false,
+            options: [
+              {
+                label: "Dry",
+                description: "Small smile.",
+              },
+              {
+                label: "Extremely silly",
+                description: "Maximum breakfast chaos.",
+              },
+            ],
+          },
+        ],
+      },
+    } satisfies AppServerPendingRequestNotification);
+
+    expect(harness.delivered.at(-3)).toMatchObject({
+      kind: "questionnaire",
+      phase: "answering",
+      currentIndex: 0,
+    });
+    harness.delivered.length = 0;
+
+    await harness.controller.handleInboundEvent(
+      buildTextEvent("A tiny waffle with a serious hat."),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "questionnaire",
+      phase: "answering",
+      currentIndex: 1,
+      answers: [
+        {
+          kind: "custom",
+          value: "A tiny waffle with a serious hat.",
+        },
+        null,
+      ],
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "tone:option:1" }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "questionnaire",
+      phase: "review",
+      answers: [
+        {
+          kind: "custom",
+          value: "A tiny waffle with a serious hat.",
+        },
+        {
+          kind: "option",
+          optionId: "tone:option:1",
+          value: "Dry",
+        },
+      ],
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "questionnaire:back" }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "questionnaire",
+      phase: "answering",
+      currentIndex: 1,
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "tone:option:2" }),
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "questionnaire:submit" }),
+    );
+
+    expect(harness.submitServerRequest).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      turnId: "turn-1",
+      requestId: "request-questions",
+      response: {
+        answers: {
+          breakfast: {
+            answers: ["A tiny waffle with a serious hat."],
+          },
+          tone: {
+            answers: ["Extremely silly"],
+          },
+        },
+      },
+    });
+    expect(harness.delivered.at(-2)).toMatchObject({
+      kind: "questionnaire",
+      phase: "submitted",
+    });
+  });
+
   it("does not resurrect waiting when a delayed approval arrives after the backend is idle", async () => {
     const harness = await createHarness();
     harness.startTurn

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -9707,8 +9707,13 @@ describe("MessagingController", () => {
     });
 
     await harness.controller.handleInboundEvent(
-      buildCallbackEvent({ actionId: "tone:option:2" }),
+      buildCallbackEvent({ actionId: "questionnaire:next" }),
     );
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "questionnaire",
+      phase: "review",
+    });
+
     await harness.controller.handleInboundEvent(
       buildCallbackEvent({ actionId: "questionnaire:submit" }),
     );
@@ -9724,7 +9729,7 @@ describe("MessagingController", () => {
             answers: ["A tiny waffle with a serious hat."],
           },
           tone: {
-            answers: ["Extremely silly"],
+            answers: ["Dry"],
           },
         },
       },

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -9740,6 +9740,58 @@ describe("MessagingController", () => {
     });
   });
 
+  it("normalizes legacy persisted questionnaire intents when answering", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+    const binding = await harness.store.findActiveBindingForChannel(
+      buildTextEvent("").channel,
+    );
+    expect(binding).toBeDefined();
+    await harness.store.upsertPendingIntent({
+      id: "legacy-questionnaire",
+      bindingId: binding!.id,
+      channel: binding!.channel,
+      intent: {
+        id: "legacy-questionnaire",
+        kind: "questionnaire",
+        createdAt: 1000,
+        currentIndex: 0,
+        requestContext: {
+          backend: "codex",
+          method: "item/tool/requestUserInput",
+          requestId: "request-legacy",
+          threadId: "thread-1",
+          turnId: "turn-1",
+        },
+        questions: [
+          {
+            id: "q1",
+            question: "Legacy freeform?",
+            allowFreeform: true,
+            options: [],
+          },
+        ],
+      } as unknown as MessagingSurfaceIntent,
+      allowedActorIds: ["user-1"],
+      createdAt: 1000,
+      expiresAt: 2000,
+    });
+    harness.delivered.length = 0;
+
+    await harness.controller.handleInboundEvent(buildTextEvent("Recovered answer."));
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "questionnaire",
+      phase: "review",
+      answers: [
+        {
+          kind: "custom",
+          value: "Recovered answer.",
+        },
+      ],
+    });
+  });
+
   it("does not resurrect waiting when a delayed approval arrives after the backend is idle", async () => {
     const harness = await createHarness();
     harness.startTurn

--- a/apps/desktop/src/main/__tests__/messaging-interaction-mapper.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-interaction-mapper.test.ts
@@ -123,6 +123,35 @@ describe("DeterministicInteractionMapper", () => {
     });
   });
 
+  it("matches review navigation on answered final questionnaire questions", () => {
+    const intent = {
+      id: "intent-questionnaire-final",
+      kind: "questionnaire",
+      createdAt: 1000,
+      answers: [
+        {
+          kind: "custom",
+          value: "Ship the compact version.",
+        },
+      ],
+      currentIndex: 0,
+      phase: "answering",
+      questions: [
+        {
+          id: "q1",
+          question: "Final answer?",
+          options: [],
+          allowFreeform: true,
+        },
+      ],
+    } satisfies MessagingQuestionnaireIntent;
+
+    expect(mapper.mapText({ intent, text: "review" })).toMatchObject({
+      kind: "matched",
+      action: { id: "questionnaire:next", label: "Review" },
+    });
+  });
+
   it("passes unrelated instructions through instead of forcing a choice", () => {
     const intent = {
       id: "intent-select",

--- a/apps/desktop/src/main/__tests__/messaging-interaction-mapper.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-interaction-mapper.test.ts
@@ -97,7 +97,9 @@ describe("DeterministicInteractionMapper", () => {
       id: "intent-questionnaire",
       kind: "questionnaire",
       createdAt: 1000,
+      answers: [{ kind: "custom", value: "Ready." }, null],
       currentIndex: 0,
+      phase: "answering",
       questions: [
         {
           id: "q1",

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -408,6 +408,7 @@ type BackendClient = {
     reasoningEffort?: string;
     fastMode?: boolean;
     codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
+    defaultModeRequestUserInput?: boolean;
     dynamicTools?: CodexDynamicToolSpec[];
   }): Promise<{ threadId: string }>;
   forkThread?(params: {
@@ -433,6 +434,7 @@ type BackendClient = {
     reasoningEffort?: string;
     fastMode?: boolean;
     codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
+    defaultModeRequestUserInput?: boolean;
     dynamicTools?: CodexDynamicToolSpec[];
   }): Promise<{
     threadId: string;
@@ -3119,6 +3121,7 @@ export class DesktopBackendRegistry {
    * `ONBOARDING_CODEX_GATE_ENABLED`.
    */
   private readonly isCodexBootstrapDeferredFn: () => boolean;
+  private readonly resolveCodexDefaultModeRequestUserInputFn: () => boolean;
   /**
    * Reports whether the registry is running inside the throwaway
    * bootstrap profile (`.bootstrap/`). When `true`, `listThreads`
@@ -3153,6 +3156,7 @@ export class DesktopBackendRegistry {
     threadSearchService?: ThreadSearchService | null;
     isCodexBootstrapDeferred?: () => boolean;
     isBootstrapMode?: () => boolean;
+    resolveCodexDefaultModeRequestUserInput?: () => boolean;
     acpWorktreeRepositoryResolver?: (
       cwd: string,
     ) => Promise<LinkedDirectorySummary | undefined>;
@@ -3195,6 +3199,23 @@ export class DesktopBackendRegistry {
     const settingsService = createsLiveCodexClient
       ? getDesktopSettingsService()
       : undefined;
+    this.resolveCodexDefaultModeRequestUserInputFn =
+      options?.resolveCodexDefaultModeRequestUserInput ??
+      (() => {
+        try {
+          return (
+            settingsService?.resolveCodexDefaultModeRequestUserInput() ?? false
+          );
+        } catch (error) {
+          backendRegistryLog.warn(
+            "failed to resolve Codex default-mode request_user_input setting",
+            {
+              error: error instanceof Error ? error.message : String(error),
+            },
+          );
+          return false;
+        }
+      });
     const codexCommand = settingsService?.resolveCodexCommandPreference();
     const codexEnv =
       typeof settingsService?.resolveCodexSpawnEnv === "function"
@@ -5513,6 +5534,12 @@ export class DesktopBackendRegistry {
           approvalPolicy: request.approvalPolicy ?? modeSettings.approvalPolicy,
           sandbox: request.sandbox ?? modeSettings.sandbox,
           codexEnvironmentRuntime: request.codexEnvironmentRuntime,
+          ...(backend === "codex"
+            ? {
+                defaultModeRequestUserInput:
+                  this.resolveCodexDefaultModeRequestUserInputFn(),
+              }
+            : {}),
           dynamicTools,
         });
     const startedAt = Date.now();
@@ -6049,6 +6076,8 @@ export class DesktopBackendRegistry {
                 ...(overlay?.codexEnvironmentRuntime
                   ? { codexEnvironmentRuntime: overlay.codexEnvironmentRuntime }
                   : {}),
+                defaultModeRequestUserInput:
+                  this.resolveCodexDefaultModeRequestUserInputFn(),
                 dynamicTools: buildCodexParentDynamicToolSpecs(agentToolCatalogs),
               });
               activeTurnMode = effectiveMode;

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -92,6 +92,8 @@ const DEFAULT_CODEX_THREAD_TITLE_TIMEOUT_MS = 20_000;
 const CODEX_THREAD_TITLE_CONFIG: NonNullable<CodexThreadStartParams["config"]> = {
   web_search: "disabled",
 };
+const CODEX_DEFAULT_MODE_REQUEST_USER_INPUT_CONFIG_KEY =
+  "features.default_mode_request_user_input";
 const SUPPORTED_CODEX_MODEL_ORDER = [
   "gpt-5.5",
   "gpt-5.4",
@@ -4397,6 +4399,7 @@ function buildThreadStartPayload(params: {
   ephemeral?: boolean;
   codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
   config?: CodexThreadStartParams["config"];
+  defaultModeRequestUserInput?: boolean;
   dynamicTools?: CodexDynamicToolSpec[];
 }): CodexThreadStartParams {
   const base: CodexThreadStartParams = {
@@ -4429,7 +4432,10 @@ function buildThreadStartPayload(params: {
     base.ephemeral = params.ephemeral;
   }
   const config = mergeCodexShellEnvironmentPolicyConfig(
-    params.config,
+    mergeCodexDefaultModeRequestUserInputConfig(
+      params.config,
+      params.defaultModeRequestUserInput,
+    ),
     params.codexEnvironmentRuntime,
   );
   if (config) {
@@ -4482,6 +4488,20 @@ function mergeCodexShellEnvironmentPolicyConfig(
     },
     { ...baseConfig },
   ) as CodexThreadStartParams["config"];
+}
+
+function mergeCodexDefaultModeRequestUserInputConfig(
+  config: CodexThreadStartParams["config"] | undefined,
+  enabled: boolean | undefined,
+): CodexThreadStartParams["config"] | undefined {
+  if (!enabled) {
+    return config;
+  }
+  const baseConfig = isPlainRecord(config) ? config : {};
+  return {
+    ...baseConfig,
+    [CODEX_DEFAULT_MODE_REQUEST_USER_INPUT_CONFIG_KEY]: true,
+  } as CodexThreadStartParams["config"];
 }
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
@@ -4561,6 +4581,7 @@ function buildThreadResumePayloads(params: {
   reasoningEffort?: string;
   fastMode?: boolean;
   codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
+  defaultModeRequestUserInput?: boolean;
   dynamicTools?: CodexDynamicToolSpec[];
 }): CodexThreadResumePayload[] {
   const base: CodexThreadResumePayload = {
@@ -4596,7 +4617,10 @@ function buildThreadResumePayloads(params: {
     };
   }
   const config = mergeCodexShellEnvironmentPolicyConfig(
-    base.config,
+    mergeCodexDefaultModeRequestUserInputConfig(
+      base.config,
+      params.defaultModeRequestUserInput,
+    ),
     params.codexEnvironmentRuntime,
   );
   if (config) {
@@ -5662,6 +5686,7 @@ export class CodexAppServerClient {
     reasoningEffort?: string;
     fastMode?: boolean;
     codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
+    defaultModeRequestUserInput?: boolean;
     dynamicTools?: CodexDynamicToolSpec[];
   }): Promise<{ threadId: string }> {
     await this.ensureInitialized();
@@ -5731,6 +5756,7 @@ export class CodexAppServerClient {
     reasoningEffort?: string;
     fastMode?: boolean;
     codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
+    defaultModeRequestUserInput?: boolean;
     dynamicTools?: CodexDynamicToolSpec[];
   }): Promise<{
     threadId: string;
@@ -5758,6 +5784,7 @@ export class CodexAppServerClient {
           reasoningEffort: params.reasoningEffort,
           fastMode: params.fastMode,
           codexEnvironmentRuntime: params.codexEnvironmentRuntime,
+          defaultModeRequestUserInput: params.defaultModeRequestUserInput,
           dynamicTools: params.dynamicTools,
         }),
         timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS

--- a/apps/desktop/src/main/messaging/core/deterministic-interaction-mapper.ts
+++ b/apps/desktop/src/main/messaging/core/deterministic-interaction-mapper.ts
@@ -4,6 +4,7 @@ import type {
   MessagingSurfaceAction,
   MessagingSurfaceIntent,
 } from "@pwragent/messaging-interface";
+import { messagingQuestionnaireActions } from "@pwragent/messaging-interface";
 import type {
   MessagingInteractionMapper,
   MessagingInteractionMapperResult,
@@ -94,32 +95,7 @@ export function actionsForIntent(intent: MessagingSurfaceIntent): MessagingSurfa
 }
 
 function questionnaireActions(intent: MessagingQuestionnaireIntent): MessagingSurfaceAction[] {
-  const question = intent.questions[intent.currentIndex];
-  const actions: MessagingSurfaceAction[] = question?.options ?? [];
-  if (intent.currentIndex > 0) {
-    actions.push({
-      id: "questionnaire:back",
-      label: "Back",
-      style: "navigation",
-      fallbackText: "back",
-    });
-  }
-  if (intent.currentIndex < intent.questions.length - 1) {
-    actions.push({
-      id: "questionnaire:next",
-      label: "Next",
-      style: "navigation",
-      fallbackText: "next",
-    });
-  } else {
-    actions.push({
-      id: "questionnaire:submit",
-      label: "Submit",
-      style: "primary",
-      fallbackText: "submit",
-    });
-  }
-  return actions;
+  return messagingQuestionnaireActions(intent);
 }
 
 function matchSynonym(
@@ -188,7 +164,12 @@ function actionTokens(action: MessagingSurfaceAction): string[] {
     .flatMap((value) => {
       const normalized = normalizeText(value);
       const labelNumber = /^(\d+)\s/.exec(normalized)?.[1];
-      return labelNumber ? [normalized, labelNumber] : [normalized];
+      const unmarked = normalized.replace(/^selected:\s+/, "");
+      const tokens = new Set([normalized, unmarked]);
+      if (labelNumber) {
+        tokens.add(labelNumber);
+      }
+      return [...tokens];
     });
 }
 

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -66,14 +66,20 @@ import type {
   MessagingMonitorState,
   MessagingMonitorSubscriptionRecord,
   MessagingPendingIntentRecord,
+  MessagingQuestionnaireAnswer,
+  MessagingQuestionnaireIntent,
   MessagingStreamUpdateIntent,
+  MessagingSurfaceAction,
   MessagingSurfaceRef,
   MessagingSurfaceIntent,
   MessagingThreadTopicLinkRecord,
   MessagingTopicCleanupProposalItem,
   MessagingTopicCleanupProposalRecord,
 } from "@pwragent/messaging-interface";
-import { MESSAGING_CALLBACK_HANDLE_TTL_MS } from "@pwragent/messaging-interface";
+import {
+  MESSAGING_CALLBACK_HANDLE_TTL_MS,
+  messagingQuestionnaireAnswerComplete,
+} from "@pwragent/messaging-interface";
 import {
   buildHelpActions,
   formatMessagingCommandHelpBody,
@@ -1337,6 +1343,12 @@ export class MessagingController {
           });
           return;
         }
+        if (
+          pendingIntent.intent.kind === "questionnaire" &&
+          await this.handleQuestionnaireTextAnswer(pendingIntent, event)
+        ) {
+          return;
+        }
         if (pendingNewThread) {
           await this.appendPendingNewThreadPrompt(pendingNewThread, event);
           return;
@@ -2234,6 +2246,10 @@ export class MessagingController {
         );
         return;
       }
+      if (action && pendingIntent.intent.kind === "questionnaire") {
+        await this.handleQuestionnaireAction(pendingIntent, event, action);
+        return;
+      }
     }
 
     if ((event.actionId ?? event.interaction.id).startsWith("approval:")) {
@@ -2243,6 +2259,21 @@ export class MessagingController {
           createdAt: this.now(),
           title: "Approval expired",
           body: "That approval request is no longer available. Retry the command or request that needed approval.",
+          recoverable: true,
+        }),
+        undefined,
+        event,
+      );
+      return;
+    }
+
+    if ((event.actionId ?? event.interaction.id).startsWith("questionnaire:")) {
+      await this.deliver(
+        buildErrorIntent({
+          id: this.newIntentId("expired-questionnaire"),
+          createdAt: this.now(),
+          title: "Input request expired",
+          body: "That input request is no longer available. Retry the command or request that needed input.",
           recoverable: true,
         }),
         undefined,
@@ -2262,6 +2293,243 @@ export class MessagingController {
       undefined,
       event,
     );
+  }
+
+  private async handleQuestionnaireTextAnswer(
+    pendingIntent: MessagingPendingIntentRecord,
+    event: MessagingInboundTextEvent,
+  ): Promise<boolean> {
+    if (pendingIntent.intent.kind !== "questionnaire") {
+      return false;
+    }
+
+    const intent = pendingIntent.intent;
+    const question = intent.questions[intent.currentIndex];
+    const value = event.text.trim();
+    if (intent.phase !== "answering" || !question?.allowFreeform || !value) {
+      return false;
+    }
+
+    const updated = this.questionnaireWithRecordedAnswer(intent, {
+      kind: "custom",
+      value,
+    });
+    await this.updateQuestionnairePendingIntent(pendingIntent, updated, event);
+    return true;
+  }
+
+  private async handleQuestionnaireAction(
+    pendingIntent: MessagingPendingIntentRecord,
+    event: MessagingInboundCallbackEvent,
+    action: MessagingSurfaceAction,
+  ): Promise<void> {
+    if (pendingIntent.intent.kind !== "questionnaire") {
+      return;
+    }
+
+    const intent = pendingIntent.intent;
+    if (action.id === "questionnaire:back") {
+      await this.updateQuestionnairePendingIntent(
+        pendingIntent,
+        this.questionnaireWithPreviousQuestion(intent),
+        event,
+      );
+      return;
+    }
+
+    if (action.id === "questionnaire:next") {
+      await this.updateQuestionnairePendingIntent(
+        pendingIntent,
+        this.questionnaireWithNextQuestion(intent),
+        event,
+      );
+      return;
+    }
+
+    if (action.id === "questionnaire:submit") {
+      if (!intent.answers.every(messagingQuestionnaireAnswerComplete)) {
+        await this.deliver(
+          buildConfirmationIntent({
+            id: this.newIntentId("questionnaire-incomplete"),
+            capabilityProfile: this.capabilityProfile,
+            createdAt: this.now(),
+            title: "Answer each question",
+            body: "Review the input request and answer every question before submitting.",
+            fallbackText: "Answer each question before submitting.",
+          }),
+          undefined,
+          event,
+        );
+        return;
+      }
+
+      const submittedIntent: MessagingQuestionnaireIntent = {
+        ...intent,
+        phase: "submitted",
+      };
+      await this.submitQuestionnaireIntent(submittedIntent);
+      await this.deliverQuestionnaireIntent(pendingIntent, submittedIntent, event);
+      await this.options.store.deletePendingIntent(pendingIntent.id);
+      await this.resumeBindingForPendingIntent(
+        pendingIntent,
+        "pending_request.submitted",
+      );
+      return;
+    }
+
+    const updated = this.questionnaireWithOptionAnswer(intent, action.id);
+    if (updated !== intent) {
+      await this.updateQuestionnairePendingIntent(pendingIntent, updated, event);
+    }
+  }
+
+  private questionnaireWithOptionAnswer(
+    intent: MessagingQuestionnaireIntent,
+    optionId: string,
+  ): MessagingQuestionnaireIntent {
+    if (intent.phase !== "answering") {
+      return intent;
+    }
+
+    const question = intent.questions[intent.currentIndex];
+    const option = question?.options.find((candidate) => candidate.id === optionId);
+    if (!option) {
+      return intent;
+    }
+
+    return this.questionnaireWithRecordedAnswer(intent, {
+      kind: "option",
+      optionId: option.id,
+      value: typeof option.value === "string" ? option.value : option.label,
+    });
+  }
+
+  private questionnaireWithRecordedAnswer(
+    intent: MessagingQuestionnaireIntent,
+    answer: MessagingQuestionnaireAnswer,
+  ): MessagingQuestionnaireIntent {
+    const answers = [...intent.answers];
+    answers[intent.currentIndex] = answer;
+
+    const nextIndex = intent.currentIndex + 1;
+    if (nextIndex < intent.questions.length) {
+      return {
+        ...intent,
+        answers,
+        currentIndex: nextIndex,
+        phase: "answering",
+      };
+    }
+
+    return {
+      ...intent,
+      answers,
+      phase: "review",
+    };
+  }
+
+  private questionnaireWithNextQuestion(
+    intent: MessagingQuestionnaireIntent,
+  ): MessagingQuestionnaireIntent {
+    if (intent.phase !== "answering") {
+      return intent;
+    }
+    if (!messagingQuestionnaireAnswerComplete(intent.answers[intent.currentIndex])) {
+      return intent;
+    }
+    if (intent.currentIndex >= intent.questions.length - 1) {
+      return {
+        ...intent,
+        phase: "review",
+      };
+    }
+    return {
+      ...intent,
+      currentIndex: intent.currentIndex + 1,
+    };
+  }
+
+  private questionnaireWithPreviousQuestion(
+    intent: MessagingQuestionnaireIntent,
+  ): MessagingQuestionnaireIntent {
+    if (intent.phase === "review") {
+      return {
+        ...intent,
+        currentIndex: Math.max(0, intent.questions.length - 1),
+        phase: "answering",
+      };
+    }
+    if (intent.phase !== "answering" || intent.currentIndex <= 0) {
+      return intent;
+    }
+    return {
+      ...intent,
+      currentIndex: intent.currentIndex - 1,
+    };
+  }
+
+  private async updateQuestionnairePendingIntent(
+    pendingIntent: MessagingPendingIntentRecord,
+    intent: MessagingQuestionnaireIntent,
+    event: MessagingInboundCallbackEvent | MessagingInboundTextEvent,
+  ): Promise<void> {
+    const result = await this.deliverQuestionnaireIntent(pendingIntent, intent, event);
+    await this.options.store.upsertPendingIntent({
+      ...pendingIntent,
+      intent,
+      surface: result.surface ?? pendingIntent.surface,
+    });
+  }
+
+  private async deliverQuestionnaireIntent(
+    pendingIntent: MessagingPendingIntentRecord,
+    intent: MessagingQuestionnaireIntent,
+    event: MessagingInboundCallbackEvent | MessagingInboundTextEvent,
+  ): Promise<MessagingDeliveryResult> {
+    const binding = pendingIntent.bindingId
+      ? await this.options.store.getBinding(pendingIntent.bindingId)
+      : undefined;
+    const targetSurface = pendingIntent.surface ?? (
+      event.kind === "callback" ? event.interaction : undefined
+    );
+    const deliveryIntent: MessagingQuestionnaireIntent = targetSurface
+      ? {
+          ...intent,
+          delivery: {
+            mode: "update",
+            replaceMarkup: true,
+            fallback: "present_new",
+          },
+          targetSurface,
+        }
+      : intent;
+    return await this.deliver(deliveryIntent, binding, event);
+  }
+
+  private async submitQuestionnaireIntent(
+    intent: MessagingQuestionnaireIntent,
+  ): Promise<void> {
+    const requestContext = intent.requestContext;
+    if (!requestContext || !this.options.backend.submitServerRequest) {
+      return;
+    }
+
+    await this.options.backend.submitServerRequest({
+      backend: requestContext.backend,
+      threadId: requestContext.threadId,
+      turnId: requestContext.turnId,
+      requestId: requestContext.requestId,
+      response: {
+        answers: Object.fromEntries(
+          intent.questions.map((question, index) => [
+            question.id,
+            {
+              answers: questionnaireAnswerValue(intent.answers[index]),
+            },
+          ]),
+        ),
+      },
+    });
   }
 
   private async submitApprovalAction(
@@ -13385,6 +13653,13 @@ function readStringValue(
 
   const result = value[key];
   return typeof result === "string" ? result : undefined;
+}
+
+function questionnaireAnswerValue(
+  answer: MessagingQuestionnaireAnswer | null | undefined,
+): string[] {
+  const value = answer?.value.trim();
+  return value ? [value] : [];
 }
 
 function readNullableStringValue(

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -79,6 +79,7 @@ import type {
 import {
   MESSAGING_CALLBACK_HANDLE_TTL_MS,
   messagingQuestionnaireAnswerComplete,
+  normalizeMessagingQuestionnaireIntent,
 } from "@pwragent/messaging-interface";
 import {
   buildHelpActions,
@@ -2303,7 +2304,7 @@ export class MessagingController {
       return false;
     }
 
-    const intent = pendingIntent.intent;
+    const intent = normalizeMessagingQuestionnaireIntent(pendingIntent.intent);
     const question = intent.questions[intent.currentIndex];
     const value = event.text.trim();
     if (intent.phase !== "answering" || !question?.allowFreeform || !value) {
@@ -2327,7 +2328,7 @@ export class MessagingController {
       return;
     }
 
-    const intent = pendingIntent.intent;
+    const intent = normalizeMessagingQuestionnaireIntent(pendingIntent.intent);
     if (action.id === "questionnaire:back") {
       await this.updateQuestionnairePendingIntent(
         pendingIntent,

--- a/apps/desktop/src/main/messaging/core/messaging-renderer.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-renderer.ts
@@ -189,7 +189,9 @@ export function buildQuestionnaireIntent(params: {
     id: params.id,
     kind: "questionnaire",
     createdAt: params.createdAt,
+    answers: params.request.params.questions.map(() => null),
     currentIndex: 0,
+    phase: "answering",
     fallbackText: "Reply with an option, Back, Next, Submit, or a free-form answer.",
     questions: params.request.params.questions.map((question) => ({
       id: question.id,
@@ -203,6 +205,7 @@ export function buildQuestionnaireIntent(params: {
         description: option.description || undefined,
         fallbackText: String(index + 1),
         recommended: /\(recommended\)/i.test(option.label),
+        value: option.label,
       })),
     })),
   };

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -97,6 +97,7 @@ export type DesktopSettingsConfig = {
     chatReplyComposer?: StoredChatReplyComposer;
     fullAccessRiskWarningDismissed?: boolean;
     liveTranscriptEventFiltering?: boolean;
+    codexDefaultModeRequestUserInput?: boolean;
     diffCondensation?: {
       enabled?: boolean;
       model?: string;
@@ -626,6 +627,12 @@ export function desktopSettingsPatchToEdits(
     set(
       ["experimental", "live_transcript_event_filtering"],
       patch.experimental.liveTranscriptEventFiltering,
+    );
+  }
+  if (patch.experimental?.codexDefaultModeRequestUserInput !== undefined) {
+    set(
+      ["experimental", "codex_default_mode_request_user_input"],
+      patch.experimental.codexDefaultModeRequestUserInput,
     );
   }
   if (patch.experimental?.diffCondensation?.model !== undefined) {
@@ -1213,6 +1220,9 @@ function normalizeDesktopConfig(
       ),
       liveTranscriptEventFiltering: readBoolean(
         experimental?.live_transcript_event_filtering,
+      ),
+      codexDefaultModeRequestUserInput: readBoolean(
+        experimental?.codex_default_mode_request_user_input,
       ),
       diffCondensation: {
         enabled: readBoolean(diffCondensation?.enabled),

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -555,6 +555,10 @@ export class DesktopSettingsService {
           config.experimental?.liveTranscriptEventFiltering,
           false,
         ),
+        codexDefaultModeRequestUserInput: this.resolveConfigBoolean(
+          config.experimental?.codexDefaultModeRequestUserInput,
+          false,
+        ),
         diffCondensation: {
           enabled: this.resolveDiffCondensationEnabled(
             config.experimental?.diffCondensation?.enabled,
@@ -1033,6 +1037,13 @@ export class DesktopSettingsService {
   resolveNotificationsEnabled(): boolean {
     return this.resolveConfigBoolean(
       this.readConfig().config.general?.notificationsEnabled,
+      false,
+    ).value;
+  }
+
+  resolveCodexDefaultModeRequestUserInput(): boolean {
+    return this.resolveConfigBoolean(
+      this.readConfig().config.experimental?.codexDefaultModeRequestUserInput,
       false,
     ).value;
   }

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -442,6 +442,10 @@ describe("App", () => {
           value: false,
           source: "default",
         },
+        codexDefaultModeRequestUserInput: {
+          value: false,
+          source: "default",
+        },
         diffCondensation: {
           enabled: { value: false, source: "default" },
           model: { value: "auto", source: "default" },

--- a/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
@@ -31,6 +31,11 @@ const DEFAULT_LIVE_TRANSCRIPT_EVENT_FILTERING = {
   source: "default" as const,
 };
 
+const DEFAULT_CODEX_DEFAULT_MODE_REQUEST_USER_INPUT = {
+  value: false,
+  source: "default" as const,
+};
+
 const DEFAULT_AGENT_CORE_GROK = {
   value: false,
   source: "default" as const,
@@ -42,12 +47,18 @@ export function ExperimentalSettings(props: {
   onDiffCondensationEnabledChange: (enabled: boolean) => Promise<void>;
   onDiffCondensationModelChange: (model: string) => Promise<void>;
   onLiveTranscriptEventFilteringChange: (enabled: boolean) => Promise<void>;
+  onCodexDefaultModeRequestUserInputChange: (
+    enabled: boolean,
+  ) => Promise<void>;
   onAgentCoreGrokChange: (enabled: boolean) => Promise<void>;
 }) {
   const condensation = props.snapshot.experimental.diffCondensation;
   const liveTranscriptEventFiltering =
     props.snapshot.experimental.liveTranscriptEventFiltering ??
     DEFAULT_LIVE_TRANSCRIPT_EVENT_FILTERING;
+  const codexDefaultModeRequestUserInput =
+    props.snapshot.experimental.codexDefaultModeRequestUserInput ??
+    DEFAULT_CODEX_DEFAULT_MODE_REQUEST_USER_INPUT;
   const agentCoreGrok =
     props.snapshot.experimental.agentCoreGrok ?? DEFAULT_AGENT_CORE_GROK;
   const knownCondensationModel = DIFF_CONDENSATION_MODEL_OPTIONS.some(
@@ -126,6 +137,32 @@ export function ExperimentalSettings(props: {
                   </button>
                 ) : null}
               </div>
+            }
+          />
+        </div>
+      </SettingsSection>
+
+      <SettingsSection
+        eyebrow="Experimental"
+        title="Codex Skill Questions"
+        description="Allow Codex skills to pause ordinary turns for structured questions when the installed Codex build supports default-mode request_user_input."
+        chip={codexDefaultModeRequestUserInput.value ? "On" : "Off"}
+        chipKind={codexDefaultModeRequestUserInput.value ? "ok" : "default"}
+      >
+        <div className="settings-fields">
+          <SettingsField
+            label="Enable Codex skill questions"
+            sub="When on, PwrAgent enables Codex's default-mode request_user_input feature for Codex threads."
+            source={sourceBadge(codexDefaultModeRequestUserInput)}
+            control={
+              <SettingsSwitch
+                checked={codexDefaultModeRequestUserInput.value}
+                disabled={props.saving}
+                label="Enable Codex skill questions"
+                onChange={(enabled) => {
+                  void props.onCodexDefaultModeRequestUserInputChange(enabled);
+                }}
+              />
             }
           />
         </div>

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -409,6 +409,11 @@ function SettingsSectionBody(props: {
             experimental: { liveTranscriptEventFiltering: enabled },
           });
         }}
+        onCodexDefaultModeRequestUserInputChange={async (enabled: boolean) => {
+          await props.settings.writeConfig({
+            experimental: { codexDefaultModeRequestUserInput: enabled },
+          });
+        }}
         onAgentCoreGrokChange={async (enabled: boolean) => {
           await props.settings.writeConfig({
             experimental: { agentCoreGrok: enabled },

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -124,6 +124,10 @@ function createSnapshot(
         value: false,
         source: "default",
       },
+      codexDefaultModeRequestUserInput: {
+        value: false,
+        source: "default",
+      },
       diffCondensation: {
         enabled: { value: false, source: "default" },
         model: { value: "auto", source: "default" },
@@ -604,6 +608,17 @@ describe("SettingsScreen", () => {
       });
     });
 
+    fireEvent.click(
+      screen.getByRole("switch", {
+        name: "Enable Codex skill questions",
+      }),
+    );
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        experimental: { codexDefaultModeRequestUserInput: true },
+      });
+    });
+
     fireEvent.click(within(sections).getByRole("button", { name: "Messaging" }));
     expect(screen.getByRole("heading", { name: "General" })).toBeInTheDocument();
     expect(screen.getByRole("radio", { name: "Medium" })).toHaveAttribute(
@@ -826,6 +841,31 @@ describe("SettingsScreen", () => {
     await waitFor(() => {
       expect(settings.writeConfig).toHaveBeenCalledWith({
         experimental: { liveTranscriptEventFiltering: true },
+      });
+    });
+  });
+
+  it("defaults Codex skill questions off for stale snapshots", async () => {
+    const snapshot = createSnapshot() as any;
+    delete snapshot.experimental.codexDefaultModeRequestUserInput;
+    const settings = createSettingsState(snapshot);
+
+    render(
+      <SettingsScreen
+        initialSection="experimental"
+        settings={settings}
+      />,
+    );
+
+    const questionsSwitch = screen.getByRole("switch", {
+      name: "Enable Codex skill questions",
+    });
+    expect(questionsSwitch).toHaveAttribute("aria-checked", "false");
+
+    fireEvent.click(questionsSwitch);
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        experimental: { codexDefaultModeRequestUserInput: true },
       });
     });
   });

--- a/apps/desktop/src/renderer/src/features/thread-detail/PendingQuestionnaire.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/PendingQuestionnaire.tsx
@@ -1,10 +1,14 @@
+import { useLayoutEffect, useRef } from "react";
 import {
-  answerQuestionnaireOption,
+  answerQuestionnaireOptionAndAdvance,
   answerQuestionnaireText,
   canAdvanceQuestionnaire,
+  canReviewQuestionnaire,
   canSubmitQuestionnaire,
   goToNextQuestion,
   goToPreviousQuestion,
+  goToQuestionnaireReview,
+  questionnaireAnswerDisplay,
   type PendingQuestionnaireState,
 } from "./questionnaire";
 
@@ -15,17 +19,118 @@ type PendingQuestionnaireProps = {
   onSubmit: (state: PendingQuestionnaireState) => Promise<void> | void;
 };
 
+const FREEFORM_MAX_ROWS = 4;
+const FREEFORM_FALLBACK_LINE_HEIGHT = 19;
+
+function resizeFreeformTextarea(element: HTMLTextAreaElement | null): void {
+  if (!element) {
+    return;
+  }
+  element.style.height = "auto";
+
+  const computed = window.getComputedStyle(element);
+  const rawLineHeight = Number.parseFloat(computed.lineHeight);
+  const fontSize = Number.parseFloat(computed.fontSize) || 13;
+  const lineHeight =
+    Number.isFinite(rawLineHeight) && rawLineHeight > 0
+      ? computed.lineHeight.endsWith("px")
+        ? rawLineHeight
+        : rawLineHeight * fontSize
+      : FREEFORM_FALLBACK_LINE_HEIGHT;
+  const paddingTop = Number.parseFloat(computed.paddingTop) || 0;
+  const paddingBottom = Number.parseFloat(computed.paddingBottom) || 0;
+  const borderTop = Number.parseFloat(computed.borderTopWidth) || 0;
+  const borderBottom = Number.parseFloat(computed.borderBottomWidth) || 0;
+  const maxHeight =
+    lineHeight * FREEFORM_MAX_ROWS + paddingTop + paddingBottom + borderTop + borderBottom;
+  const nextHeight = Math.min(element.scrollHeight, maxHeight);
+
+  element.style.height = `${nextHeight}px`;
+  element.style.overflowY = element.scrollHeight > maxHeight ? "auto" : "hidden";
+}
+
 export function PendingQuestionnaire(props: PendingQuestionnaireProps) {
   const question = props.state.questions[props.state.currentIndex];
   const answer = props.state.answers[props.state.currentIndex];
+  const freeformRef = useRef<HTMLTextAreaElement | null>(null);
+  const textAnswer = answer?.kind === "text" ? answer.value : "";
+
+  useLayoutEffect(() => {
+    resizeFreeformTextarea(freeformRef.current);
+  }, [textAnswer, props.state.currentIndex, question?.allowFreeform]);
+
   if (!question) {
     return null;
   }
 
   const isLastQuestion = props.state.currentIndex === props.state.questions.length - 1;
   const canMoveNext = canAdvanceQuestionnaire(props.state);
+  const canMoveToReview = canReviewQuestionnaire(props.state);
   const canSubmit = canSubmitQuestionnaire(props.state);
-  const textAnswer = answer?.kind === "text" ? answer.value : "";
+
+  if (props.state.phase === "review" || props.state.phase === "submitted") {
+    const submitted = props.state.phase === "submitted";
+    return (
+      <div className="transcript-questionnaire" role="group" aria-label="Pending input">
+        <div className="transcript-questionnaire__header">
+          <span className="chip chip--mode">
+            {submitted ? "Input submitted" : "Review answers"}
+          </span>
+          <span className="transcript-message__time">
+            {props.state.questions.length} answer
+            {props.state.questions.length === 1 ? "" : "s"}
+          </span>
+        </div>
+
+        <div className="transcript-questionnaire__prompt">
+          <h3>{submitted ? "Submitted answers" : "Review answers"}</h3>
+        </div>
+
+        <div className="transcript-questionnaire__summary">
+          {props.state.questions.map((summaryQuestion, index) => {
+            const title = [summaryQuestion.header, summaryQuestion.question]
+              .filter(Boolean)
+              .join(summaryQuestion.header && summaryQuestion.question ? ": " : "");
+            return (
+              <div className="transcript-questionnaire__summary-item" key={summaryQuestion.id}>
+                <span className="transcript-questionnaire__summary-question">
+                  {index + 1}. {title}
+                </span>
+                <span className="transcript-questionnaire__summary-answer">
+                  {questionnaireAnswerDisplay(props.state.answers[index]) || "No answer"}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+
+        {submitted ? null : (
+          <div className="transcript-questionnaire__actions">
+            <button
+              className="button button--ghost"
+              disabled={props.busy}
+              type="button"
+              onClick={() => {
+                props.onChange(goToPreviousQuestion(props.state));
+              }}
+            >
+              Back
+            </button>
+            <button
+              className="button button--primary"
+              disabled={props.busy || !canSubmit}
+              type="button"
+              onClick={() => {
+                void props.onSubmit(props.state);
+              }}
+            >
+              Submit
+            </button>
+          </div>
+        )}
+      </div>
+    );
+  }
 
   return (
     <div className="transcript-questionnaire" role="group" aria-label="Pending input">
@@ -58,7 +163,9 @@ export function PendingQuestionnaire(props: PendingQuestionnaireProps) {
                 aria-pressed={selected}
                 disabled={props.busy}
                 onClick={() => {
-                  props.onChange(answerQuestionnaireOption(props.state, option.key));
+                  props.onChange(
+                    answerQuestionnaireOptionAndAdvance(props.state, option.key),
+                  );
                 }}
               >
                 <span className="transcript-questionnaire__option-label">
@@ -87,10 +194,12 @@ export function PendingQuestionnaire(props: PendingQuestionnaireProps) {
         <label className="transcript-questionnaire__freeform">
           <span>Other answer</span>
           <textarea
+            ref={freeformRef}
             value={textAnswer}
             disabled={props.busy}
-            rows={3}
+            rows={1}
             onChange={(event) => {
+              resizeFreeformTextarea(event.currentTarget);
               props.onChange(answerQuestionnaireText(props.state, event.target.value));
             }}
           />
@@ -111,13 +220,13 @@ export function PendingQuestionnaire(props: PendingQuestionnaireProps) {
         {isLastQuestion ? (
           <button
             className="button button--primary"
-            disabled={props.busy || !canSubmit}
+            disabled={props.busy || !canMoveToReview}
             type="button"
             onClick={() => {
-              void props.onSubmit(props.state);
+              props.onChange(goToQuestionnaireReview(props.state));
             }}
           >
-            Submit
+            Review
           </button>
         ) : (
           <button

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/pending-questionnaire.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/pending-questionnaire.test.tsx
@@ -16,6 +16,7 @@ function buildState(): PendingQuestionnaireState {
     itemId: "input-1",
     requestId: "input-request-1",
     currentIndex: 0,
+    phase: "answering",
     answers: [null, null],
     questions: [
       {
@@ -64,6 +65,29 @@ function buildState(): PendingQuestionnaireState {
   };
 }
 
+function buildFreeformState(): PendingQuestionnaireState {
+  return {
+    method: "item/tool/requestUserInput",
+    threadId: "thread-1",
+    turnId: "turn-1",
+    itemId: "input-1",
+    requestId: "input-request-1",
+    currentIndex: 0,
+    phase: "answering",
+    answers: [null],
+    questions: [
+      {
+        id: "breakfast",
+        header: "Breakfast",
+        question: "What's for breakfast?",
+        options: [],
+        allowFreeform: true,
+        secret: false,
+      },
+    ],
+  };
+}
+
 describe("PendingQuestionnaire", () => {
   it("renders plan questions without approval controls", () => {
     render(
@@ -101,10 +125,19 @@ describe("PendingQuestionnaire", () => {
     expect(screen.getByRole("button", { name: "Next" })).toBeDisabled();
 
     fireEvent.click(screen.getByRole("button", { name: /Large refactor/ }));
-    fireEvent.click(screen.getByRole("button", { name: "Next" }));
-    fireEvent.click(screen.getByRole("button", { name: /Unit only/ }));
-    fireEvent.click(screen.getByRole("button", { name: "Back" }));
+    expect(screen.getByText("Question 2 of 2")).toBeInTheDocument();
 
+    fireEvent.click(screen.getByRole("button", { name: /Unit only/ }));
+    expect(screen.getAllByText("Review answers").length).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
+    expect(screen.getByText("Question 2 of 2")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Unit only/ })).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
     expect(screen.getByText("Question 1 of 2")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Large refactor/ })).toHaveAttribute(
       "aria-pressed",
@@ -112,8 +145,39 @@ describe("PendingQuestionnaire", () => {
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    fireEvent.click(screen.getByRole("button", { name: "Review" }));
+    expect(screen.getByText(/Scope: How much should change\?/)).toBeInTheDocument();
+    expect(screen.getByText(/Tests: Which test path\?/)).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Submit" }));
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps freeform answers compact and caps autosizing growth", () => {
+    const onChange = vi.fn();
+    render(
+      <PendingQuestionnaire
+        state={buildFreeformState()}
+        onChange={onChange}
+        onSubmit={async () => undefined}
+      />,
+    );
+
+    const textarea = screen.getByLabelText("Other answer") as HTMLTextAreaElement;
+    expect(textarea).toHaveAttribute("rows", "1");
+
+    Object.defineProperty(textarea, "scrollHeight", {
+      configurable: true,
+      value: 400,
+    });
+    fireEvent.change(textarea, {
+      target: {
+        value: "Line one\nLine two\nLine three\nLine four\nLine five",
+      },
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(textarea.style.overflowY).toBe("auto");
+    expect(Number.parseFloat(textarea.style.height)).toBeLessThan(120);
   });
 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -2633,6 +2633,7 @@ describe("ThreadView", () => {
       itemId: "input-1",
       requestId: "input-request-1",
       currentIndex: 0,
+      phase: "answering",
       answers: [null],
       questions: [
         {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -3113,6 +3113,7 @@ describe("TranscriptList", () => {
           threadId: "thread-1",
           requestId: "input-request-1",
           currentIndex: 0,
+          phase: "answering",
           answers: [null],
           questions: [
             {

--- a/apps/desktop/src/renderer/src/features/thread-detail/questionnaire.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/questionnaire.ts
@@ -30,6 +30,8 @@ export type PendingQuestionnaireAnswer =
       value: string;
     };
 
+export type PendingQuestionnairePhase = "answering" | "review" | "submitted";
+
 export type PendingQuestionnaireState = {
   method: "item/tool/requestUserInput";
   requestId: string;
@@ -38,6 +40,7 @@ export type PendingQuestionnaireState = {
   itemId?: string;
   questions: PendingQuestionnaireQuestion[];
   currentIndex: number;
+  phase: PendingQuestionnairePhase;
   answers: Array<PendingQuestionnaireAnswer | null>;
 };
 
@@ -97,8 +100,16 @@ export function createQuestionnaireState(
     ...(request.params.itemId ? { itemId: request.params.itemId } : {}),
     questions,
     currentIndex: 0,
+    phase: "answering",
     answers: questions.map(() => null),
   };
+}
+
+export function answerQuestionnaireOptionAndAdvance(
+  state: PendingQuestionnaireState,
+  optionKey: string
+): PendingQuestionnaireState {
+  return advanceAfterAnswer(answerQuestionnaireOption(state, optionKey));
 }
 
 export function answerQuestionnaireOption(
@@ -149,6 +160,14 @@ export function goToNextQuestion(
 export function goToPreviousQuestion(
   state: PendingQuestionnaireState
 ): PendingQuestionnaireState {
+  if (state.phase === "review" || state.phase === "submitted") {
+    return {
+      ...state,
+      currentIndex: Math.max(0, state.questions.length - 1),
+      phase: "answering",
+    };
+  }
+
   if (state.currentIndex <= 0) {
     return state;
   }
@@ -156,18 +175,63 @@ export function goToPreviousQuestion(
   return {
     ...state,
     currentIndex: state.currentIndex - 1,
+    phase: "answering",
   };
 }
 
 export function canAdvanceQuestionnaire(state: PendingQuestionnaireState): boolean {
   return (
+    state.phase === "answering" &&
     state.currentIndex < state.questions.length - 1 &&
     isAnswerComplete(state.answers[state.currentIndex])
   );
 }
 
+export function canReviewQuestionnaire(state: PendingQuestionnaireState): boolean {
+  return (
+    state.phase === "answering" &&
+    state.currentIndex === state.questions.length - 1 &&
+    canSubmitQuestionnaire(state)
+  );
+}
+
 export function canSubmitQuestionnaire(state: PendingQuestionnaireState): boolean {
   return state.answers.every(isAnswerComplete);
+}
+
+export function goToQuestionnaireReview(
+  state: PendingQuestionnaireState
+): PendingQuestionnaireState {
+  if (!canSubmitQuestionnaire(state)) {
+    return state;
+  }
+
+  return {
+    ...state,
+    phase: "review",
+  };
+}
+
+export function markQuestionnaireSubmitted(
+  state: PendingQuestionnaireState
+): PendingQuestionnaireState {
+  return {
+    ...state,
+    phase: "submitted",
+  };
+}
+
+export function questionnaireAnswerDisplay(
+  answer: PendingQuestionnaireAnswer | null | undefined
+): string {
+  if (!answer) {
+    return "";
+  }
+  const value = answer.value.trim();
+  if (!value) {
+    return "";
+  }
+  return answer.kind === "text" ? `Custom: ${value}` : value;
 }
 
 export function buildQuestionnaireResponse(
@@ -183,6 +247,20 @@ export function buildQuestionnaireResponse(
       ])
     ),
   };
+}
+
+function advanceAfterAnswer(
+  state: PendingQuestionnaireState
+): PendingQuestionnaireState {
+  if (state.currentIndex < state.questions.length - 1) {
+    return {
+      ...state,
+      currentIndex: state.currentIndex + 1,
+      phase: "answering",
+    };
+  }
+
+  return goToQuestionnaireReview(state);
 }
 
 function answerCurrentQuestion(

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9916,6 +9916,36 @@ textarea,
   line-height: 1.4;
 }
 
+.transcript-questionnaire__summary {
+  display: grid;
+  gap: 8px;
+}
+
+.transcript-questionnaire__summary-item {
+  display: grid;
+  gap: 4px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.transcript-questionnaire__summary-item:last-child {
+  border-bottom: 0;
+}
+
+.transcript-questionnaire__summary-question {
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.35;
+}
+
+.transcript-questionnaire__summary-answer {
+  color: var(--text-primary);
+  font-size: 14px;
+  font-weight: 650;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
 .transcript-questionnaire__freeform {
   display: grid;
   gap: 6px;
@@ -9925,15 +9955,17 @@ textarea,
 }
 
 .transcript-questionnaire__freeform textarea {
-  min-height: 84px;
-  resize: vertical;
+  min-height: 37px;
+  max-height: calc((13px * 1.45 * 4) + 20px);
+  resize: none;
+  overflow-y: hidden;
   border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: var(--surface-overlay-soft);
   color: var(--text-primary);
   font: inherit;
   line-height: 1.45;
-  padding: 10px 12px;
+  padding: 8px 10px;
 }
 
 .transcript-questionnaire__freeform textarea:focus {

--- a/packages/messaging/interface/src/__tests__/messaging-interface.test.ts
+++ b/packages/messaging/interface/src/__tests__/messaging-interface.test.ts
@@ -1,12 +1,16 @@
 import type {
   MessagingDeliveryResult,
   MessagingInboundEvent,
+  MessagingQuestionnaireIntent,
   MessagingSurfaceIntent,
 } from "../index";
 import {
   MESSAGING_SURFACE_INTENT_KINDS,
   extractMessagingPairingToken,
+  formatMessagingQuestionnaireText,
   looksLikePairingAttempt,
+  messagingQuestionnaireActions,
+  normalizeMessagingQuestionnaireIntent,
 } from "../index";
 
 type FakeProvider = {
@@ -133,6 +137,87 @@ describe("messaging interface package", () => {
     expect(extractMessagingPairingToken(`pair ${token} ${largePayload}`)).toBe(token);
     expect(extractMessagingPairingToken(`${largePayload} pair ${token}`)).toBeUndefined();
     expect(extractMessagingPairingToken(`pair ${largePayload}`)).toBeUndefined();
+  });
+
+  it("normalizes legacy questionnaire intents before deriving actions", () => {
+    const legacyIntent = {
+      id: "intent-questionnaire-legacy",
+      kind: "questionnaire",
+      createdAt: 1000,
+      currentIndex: 0,
+      questions: [
+        {
+          id: "q1",
+          question: "First?",
+          options: [
+            {
+              id: "q1:option:1",
+              label: "First option",
+            },
+          ],
+        },
+      ],
+    } as unknown as MessagingQuestionnaireIntent;
+
+    expect(normalizeMessagingQuestionnaireIntent(legacyIntent)).toMatchObject({
+      answers: [null],
+      currentIndex: 0,
+      phase: "answering",
+    });
+    expect(messagingQuestionnaireActions(legacyIntent)).toEqual([
+      expect.objectContaining({
+        id: "q1:option:1",
+        label: "First option",
+      }),
+    ]);
+  });
+
+  it("masks secret questionnaire answers in provider-visible text", () => {
+    const intent = {
+      id: "intent-questionnaire-secret",
+      kind: "questionnaire",
+      createdAt: 1000,
+      currentIndex: 0,
+      phase: "review",
+      answers: [
+        {
+          kind: "custom",
+          value: "sk-live-secret",
+        },
+        {
+          kind: "custom",
+          value: "normal answer",
+        },
+      ],
+      questions: [
+        {
+          id: "token",
+          question: "Token?",
+          options: [],
+          allowFreeform: true,
+          secret: true,
+        },
+        {
+          id: "note",
+          question: "Note?",
+          options: [],
+          allowFreeform: true,
+        },
+      ],
+    } satisfies MessagingQuestionnaireIntent;
+
+    const reviewText = formatMessagingQuestionnaireText(intent);
+    expect(reviewText).toContain("Secret answer provided");
+    expect(reviewText).toContain("Custom: normal answer");
+    expect(reviewText).not.toContain("sk-live-secret");
+
+    const answeringText = formatMessagingQuestionnaireText({
+      ...intent,
+      currentIndex: 0,
+      phase: "answering",
+    });
+    expect(answeringText).toContain("Current answer: Secret answer provided");
+    expect(answeringText).not.toContain("sk-live-secret");
   });
 
   it("does not throw on fuzzed pairing-like payloads", () => {

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -643,6 +643,19 @@ export type MessagingQuestionnaireQuestion = {
   secret?: boolean;
 };
 
+export type MessagingQuestionnaireAnswer =
+  | {
+      kind: "option";
+      optionId: string;
+      value: string;
+    }
+  | {
+      kind: "custom";
+      value: string;
+    };
+
+export type MessagingQuestionnairePhase = "answering" | "review" | "submitted";
+
 export type MessagingApprovalDecision =
   | "accept"
   | "accept_for_session"
@@ -766,9 +779,152 @@ export type MessagingMultiSelectIntent = MessagingBaseSurfaceIntent & {
 
 export type MessagingQuestionnaireIntent = MessagingBaseSurfaceIntent & {
   kind: "questionnaire";
+  answers: Array<MessagingQuestionnaireAnswer | null>;
   currentIndex: number;
+  phase: MessagingQuestionnairePhase;
   questions: MessagingQuestionnaireQuestion[];
 };
+
+export function messagingQuestionnaireActions(
+  intent: MessagingQuestionnaireIntent,
+): MessagingSurfaceAction[] {
+  if (intent.phase === "submitted") {
+    return [];
+  }
+
+  if (intent.phase === "review") {
+    return [
+      {
+        id: "questionnaire:back",
+        label: "Back",
+        style: "navigation",
+        fallbackText: "back",
+      },
+      {
+        id: "questionnaire:submit",
+        label: "Submit",
+        style: "primary",
+        fallbackText: "submit",
+      },
+    ];
+  }
+
+  const question = intent.questions[intent.currentIndex];
+  const answer = intent.answers[intent.currentIndex];
+  const actions: MessagingSurfaceAction[] = (question?.options ?? []).map(
+    (option) => ({
+      ...option,
+      label:
+        answer?.kind === "option" && answer.optionId === option.id
+          ? `Selected: ${option.label}`
+          : option.label,
+    }),
+  );
+
+  if (intent.currentIndex > 0) {
+    actions.push({
+      id: "questionnaire:back",
+      label: "Back",
+      style: "navigation",
+      fallbackText: "back",
+    });
+  }
+  if (
+    intent.currentIndex < intent.questions.length - 1 &&
+    messagingQuestionnaireAnswerComplete(answer)
+  ) {
+    actions.push({
+      id: "questionnaire:next",
+      label: "Next",
+      style: "navigation",
+      fallbackText: "next",
+    });
+  }
+
+  return actions;
+}
+
+export function messagingQuestionnaireAnswerComplete(
+  answer: MessagingQuestionnaireAnswer | null | undefined,
+): boolean {
+  return Boolean(answer?.value.trim());
+}
+
+export function messagingQuestionnaireAnswerDisplay(
+  answer: MessagingQuestionnaireAnswer | null | undefined,
+): string {
+  if (!answer) {
+    return "";
+  }
+  const value = answer.value.trim();
+  if (!value) {
+    return "";
+  }
+  return answer.kind === "custom" ? `Custom: ${value}` : value;
+}
+
+export function formatMessagingQuestionnaireText(
+  intent: MessagingQuestionnaireIntent,
+): string {
+  if (intent.phase === "review" || intent.phase === "submitted") {
+    const lines = [
+      intent.phase === "submitted" ? "Submitted answers" : "Review answers",
+      "",
+    ];
+    intent.questions.forEach((question, index) => {
+      const title = [question.header, question.question]
+        .filter(Boolean)
+        .join(question.header && question.question ? ": " : "");
+      lines.push(`${index + 1}. ${title}`);
+      lines.push(
+        `Answer: ${
+          messagingQuestionnaireAnswerDisplay(intent.answers[index]) || "No answer"
+        }`,
+      );
+      if (index < intent.questions.length - 1) {
+        lines.push("");
+      }
+    });
+    return lines.join("\n");
+  }
+
+  const question = intent.questions[intent.currentIndex] ?? intent.questions[0];
+  if (!question) {
+    return "Input needed.";
+  }
+
+  const lines = [
+    `Question ${intent.currentIndex + 1} of ${intent.questions.length}`,
+    "",
+  ];
+  if (question.header) {
+    lines.push(question.header);
+  }
+  lines.push(question.question);
+
+  const answer = intent.answers[intent.currentIndex];
+  question.options.forEach((option, index) => {
+    const selected = answer?.kind === "option" && answer.optionId === option.id;
+    lines.push("");
+    lines.push(`${selected ? "[selected] " : ""}${index + 1}. ${option.label}`);
+    if (option.description) {
+      lines.push(`   ${option.description}`);
+    }
+  });
+
+  if (question.allowFreeform) {
+    lines.push("", "Other: reply with a free-form answer.");
+  }
+
+  const currentAnswer = messagingQuestionnaireAnswerDisplay(
+    intent.answers[intent.currentIndex],
+  );
+  if (currentAnswer) {
+    lines.push("", `Current answer: ${currentAnswer}`);
+  }
+
+  return lines.join("\n");
+}
 
 export type MessagingApprovalIntent = MessagingBaseSurfaceIntent & {
   kind: "approval";

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -785,14 +785,38 @@ export type MessagingQuestionnaireIntent = MessagingBaseSurfaceIntent & {
   questions: MessagingQuestionnaireQuestion[];
 };
 
+export function normalizeMessagingQuestionnaireIntent(
+  intent: MessagingQuestionnaireIntent,
+): MessagingQuestionnaireIntent {
+  const questions = Array.isArray(intent.questions) ? intent.questions : [];
+  const rawAnswers = Array.isArray(intent.answers) ? intent.answers : [];
+  const answers = questions.map((_, index) => rawAnswers[index] ?? null);
+  const currentIndex =
+    Number.isInteger(intent.currentIndex) && intent.currentIndex >= 0
+      ? Math.min(intent.currentIndex, Math.max(0, questions.length - 1))
+      : 0;
+  const phase = isMessagingQuestionnairePhase(intent.phase)
+    ? intent.phase
+    : "answering";
+
+  return {
+    ...intent,
+    answers,
+    currentIndex,
+    phase,
+    questions,
+  };
+}
+
 export function messagingQuestionnaireActions(
   intent: MessagingQuestionnaireIntent,
 ): MessagingSurfaceAction[] {
-  if (intent.phase === "submitted") {
+  const normalized = normalizeMessagingQuestionnaireIntent(intent);
+  if (normalized.phase === "submitted") {
     return [];
   }
 
-  if (intent.phase === "review") {
+  if (normalized.phase === "review") {
     return [
       {
         id: "questionnaire:back",
@@ -809,8 +833,8 @@ export function messagingQuestionnaireActions(
     ];
   }
 
-  const question = intent.questions[intent.currentIndex];
-  const answer = intent.answers[intent.currentIndex];
+  const question = normalized.questions[normalized.currentIndex];
+  const answer = normalized.answers[normalized.currentIndex];
   const actions: MessagingSurfaceAction[] = (question?.options ?? []).map(
     (option) => ({
       ...option,
@@ -821,7 +845,7 @@ export function messagingQuestionnaireActions(
     }),
   );
 
-  if (intent.currentIndex > 0) {
+  if (normalized.currentIndex > 0) {
     actions.push({
       id: "questionnaire:back",
       label: "Back",
@@ -830,7 +854,7 @@ export function messagingQuestionnaireActions(
     });
   }
   if (messagingQuestionnaireAnswerComplete(answer)) {
-    const isFinalQuestion = intent.currentIndex >= intent.questions.length - 1;
+    const isFinalQuestion = normalized.currentIndex >= normalized.questions.length - 1;
     actions.push({
       id: "questionnaire:next",
       label: isFinalQuestion ? "Review" : "Next",
@@ -850,6 +874,7 @@ export function messagingQuestionnaireAnswerComplete(
 
 export function messagingQuestionnaireAnswerDisplay(
   answer: MessagingQuestionnaireAnswer | null | undefined,
+  options: { secret?: boolean } = {},
 ): string {
   if (!answer) {
     return "";
@@ -858,41 +883,48 @@ export function messagingQuestionnaireAnswerDisplay(
   if (!value) {
     return "";
   }
+  if (options.secret) {
+    return "Secret answer provided";
+  }
   return answer.kind === "custom" ? `Custom: ${value}` : value;
 }
 
 export function formatMessagingQuestionnaireText(
   intent: MessagingQuestionnaireIntent,
 ): string {
-  if (intent.phase === "review" || intent.phase === "submitted") {
+  const normalized = normalizeMessagingQuestionnaireIntent(intent);
+  if (normalized.phase === "review" || normalized.phase === "submitted") {
     const lines = [
-      intent.phase === "submitted" ? "Submitted answers" : "Review answers",
+      normalized.phase === "submitted" ? "Submitted answers" : "Review answers",
       "",
     ];
-    intent.questions.forEach((question, index) => {
+    normalized.questions.forEach((question, index) => {
       const title = [question.header, question.question]
         .filter(Boolean)
         .join(question.header && question.question ? ": " : "");
       lines.push(`${index + 1}. ${title}`);
       lines.push(
         `Answer: ${
-          messagingQuestionnaireAnswerDisplay(intent.answers[index]) || "No answer"
+          messagingQuestionnaireAnswerDisplay(normalized.answers[index], {
+            secret: question.secret,
+          }) || "No answer"
         }`,
       );
-      if (index < intent.questions.length - 1) {
+      if (index < normalized.questions.length - 1) {
         lines.push("");
       }
     });
     return lines.join("\n");
   }
 
-  const question = intent.questions[intent.currentIndex] ?? intent.questions[0];
+  const question =
+    normalized.questions[normalized.currentIndex] ?? normalized.questions[0];
   if (!question) {
     return "Input needed.";
   }
 
   const lines = [
-    `Question ${intent.currentIndex + 1} of ${intent.questions.length}`,
+    `Question ${normalized.currentIndex + 1} of ${normalized.questions.length}`,
     "",
   ];
   if (question.header) {
@@ -900,7 +932,7 @@ export function formatMessagingQuestionnaireText(
   }
   lines.push(question.question);
 
-  const answer = intent.answers[intent.currentIndex];
+  const answer = normalized.answers[normalized.currentIndex];
   question.options.forEach((option, index) => {
     const selected = answer?.kind === "option" && answer.optionId === option.id;
     lines.push("");
@@ -915,13 +947,20 @@ export function formatMessagingQuestionnaireText(
   }
 
   const currentAnswer = messagingQuestionnaireAnswerDisplay(
-    intent.answers[intent.currentIndex],
+    normalized.answers[normalized.currentIndex],
+    { secret: question.secret },
   );
   if (currentAnswer) {
     lines.push("", `Current answer: ${currentAnswer}`);
   }
 
   return lines.join("\n");
+}
+
+function isMessagingQuestionnairePhase(
+  value: unknown,
+): value is MessagingQuestionnairePhase {
+  return value === "answering" || value === "review" || value === "submitted";
 }
 
 export type MessagingApprovalIntent = MessagingBaseSurfaceIntent & {

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -829,15 +829,13 @@ export function messagingQuestionnaireActions(
       fallbackText: "back",
     });
   }
-  if (
-    intent.currentIndex < intent.questions.length - 1 &&
-    messagingQuestionnaireAnswerComplete(answer)
-  ) {
+  if (messagingQuestionnaireAnswerComplete(answer)) {
+    const isFinalQuestion = intent.currentIndex >= intent.questions.length - 1;
     actions.push({
       id: "questionnaire:next",
-      label: "Next",
-      style: "navigation",
-      fallbackText: "next",
+      label: isFinalQuestion ? "Review" : "Next",
+      style: isFinalQuestion ? "primary" : "navigation",
+      fallbackText: isFinalQuestion ? "review" : "next",
     });
   }
 

--- a/packages/messaging/providers/discord/src/discord-formatting.ts
+++ b/packages/messaging/providers/discord/src/discord-formatting.ts
@@ -5,7 +5,11 @@ import type {
   MessagingSurfaceAction,
   MessagingSurfaceIntent,
 } from "@pwragent/messaging-interface";
-import { layoutMessagingActionRows } from "@pwragent/messaging-interface";
+import {
+  formatMessagingQuestionnaireText,
+  layoutMessagingActionRows,
+  messagingQuestionnaireActions,
+} from "@pwragent/messaging-interface";
 
 export const DISCORD_COMPONENT_CUSTOM_ID_LIMIT_BYTES = 100;
 export const DISCORD_MESSAGE_CONTENT_LIMIT = 2000;
@@ -87,10 +91,8 @@ export function textForDiscordIntent(intent: MessagingSurfaceIntent): string {
       return intent.prompt;
     case "multi_select":
       return intent.prompt;
-    case "questionnaire": {
-      const question = intent.questions[intent.currentIndex] ?? intent.questions[0];
-      return [question?.header, question?.question].filter(Boolean).join("\n");
-    }
+    case "questionnaire":
+      return formatMessagingQuestionnaireText(intent);
     case "approval":
       return [intent.title, intent.body].join("\n\n");
     case "confirmation":
@@ -113,10 +115,8 @@ export function actionsForDiscordIntent(
       return intent.choices;
     case "multi_select":
       return intent.choices;
-    case "questionnaire": {
-      const question = intent.questions[intent.currentIndex] ?? intent.questions[0];
-      return question?.options ?? [];
-    }
+    case "questionnaire":
+      return messagingQuestionnaireActions(intent);
     case "approval":
       return intent.decisions;
     case "confirmation":

--- a/packages/messaging/providers/feishu/src/feishu-formatting.ts
+++ b/packages/messaging/providers/feishu/src/feishu-formatting.ts
@@ -1,5 +1,7 @@
 import {
+  formatMessagingQuestionnaireText,
   layoutMessagingActionRows,
+  messagingQuestionnaireActions,
   type MessagingActionLayoutPolicy,
   type MessagingCapabilityProfile,
   type MessagingContentPart,
@@ -59,10 +61,8 @@ export function actionsForFeishuIntent(
     case "single_select":
     case "multi_select":
       return intent.choices;
-    case "questionnaire": {
-      const question = intent.questions[intent.currentIndex] ?? intent.questions[0];
-      return question?.options ?? [];
-    }
+    case "questionnaire":
+      return messagingQuestionnaireActions(intent);
     case "approval":
       return intent.decisions;
     case "confirmation":
@@ -177,12 +177,8 @@ export function textForFeishuIntent(intent: MessagingSurfaceIntent): string {
       return [intent.prompt, intent.fallbackText]
         .filter((value): value is string => Boolean(value))
         .join("\n\n");
-    case "questionnaire": {
-      const question = intent.questions[intent.currentIndex] ?? intent.questions[0];
-      return [question?.header, question?.question]
-        .filter((value): value is string => Boolean(value))
-        .join("\n\n");
-    }
+    case "questionnaire":
+      return formatMessagingQuestionnaireText(intent);
     case "approval":
       return [intent.title, intent.body].filter(Boolean).join("\n\n");
     case "confirmation":

--- a/packages/messaging/providers/line/src/line-formatting.ts
+++ b/packages/messaging/providers/line/src/line-formatting.ts
@@ -1,5 +1,7 @@
 import {
+  formatMessagingQuestionnaireText,
   layoutMessagingActionRows,
+  messagingQuestionnaireActions,
   type MessagingActionLayoutPolicy,
   type MessagingCapabilityProfile,
   type MessagingContentPart,
@@ -77,10 +79,8 @@ export function actionsForLineIntent(
     case "single_select":
     case "multi_select":
       return intent.choices;
-    case "questionnaire": {
-      const question = intent.questions[intent.currentIndex] ?? intent.questions[0];
-      return question?.options ?? [];
-    }
+    case "questionnaire":
+      return messagingQuestionnaireActions(intent);
     case "approval":
       return intent.decisions;
     case "confirmation":
@@ -195,12 +195,8 @@ export function textForLineIntent(intent: MessagingSurfaceIntent): string {
       return [intent.prompt, intent.fallbackText]
         .filter((value): value is string => Boolean(value))
         .join("\n\n");
-    case "questionnaire": {
-      const question = intent.questions[intent.currentIndex] ?? intent.questions[0];
-      return [question?.header, question?.question]
-        .filter((value): value is string => Boolean(value))
-        .join("\n\n");
-    }
+    case "questionnaire":
+      return formatMessagingQuestionnaireText(intent);
     case "approval":
     case "confirmation":
       return [intent.title, intent.body].filter(Boolean).join("\n\n");

--- a/packages/messaging/providers/mattermost/src/mattermost-formatting.ts
+++ b/packages/messaging/providers/mattermost/src/mattermost-formatting.ts
@@ -1,5 +1,7 @@
 import {
+  formatMessagingQuestionnaireText,
   layoutMessagingActionRows,
+  messagingQuestionnaireActions,
   type MessagingActionLayoutPolicy,
   type MessagingCapabilityProfile,
   type MessagingContentPart,
@@ -130,10 +132,8 @@ export function actionsForMattermostIntent(
       return intent.choices;
     case "multi_select":
       return intent.choices;
-    case "questionnaire": {
-      const question = intent.questions[intent.currentIndex] ?? intent.questions[0];
-      return question?.options ?? [];
-    }
+    case "questionnaire":
+      return messagingQuestionnaireActions(intent);
     case "approval":
       return intent.decisions;
     case "confirmation":
@@ -254,13 +254,8 @@ export function textForMattermostIntent(intent: MessagingSurfaceIntent): string 
       return [intent.prompt, intent.fallbackText]
         .filter((value): value is string => Boolean(value))
         .join("\n\n");
-    case "questionnaire": {
-      const question =
-        intent.questions[intent.currentIndex] ?? intent.questions[0];
-      return [question?.header, question?.question]
-        .filter((value): value is string => Boolean(value))
-        .join("\n");
-    }
+    case "questionnaire":
+      return formatMessagingQuestionnaireText(intent);
     case "approval":
       return [intent.title, intent.body].join("\n\n");
     case "confirmation":

--- a/packages/messaging/providers/slack/src/slack-formatting.ts
+++ b/packages/messaging/providers/slack/src/slack-formatting.ts
@@ -1,5 +1,7 @@
 import {
+  formatMessagingQuestionnaireText,
   layoutMessagingActionRows,
+  messagingQuestionnaireActions,
   type MessagingActionLayoutPolicy,
   type MessagingCapabilityProfile,
   type MessagingContentPart,
@@ -81,10 +83,8 @@ export function actionsForSlackIntent(
     case "single_select":
     case "multi_select":
       return intent.choices;
-    case "questionnaire": {
-      const question = intent.questions[intent.currentIndex] ?? intent.questions[0];
-      return question?.options ?? [];
-    }
+    case "questionnaire":
+      return messagingQuestionnaireActions(intent);
     case "approval":
       return intent.decisions;
     case "confirmation":
@@ -203,12 +203,8 @@ export function textForSlackIntent(intent: MessagingSurfaceIntent): string {
       return [intent.prompt, intent.fallbackText]
         .filter((value): value is string => Boolean(value))
         .join("\n\n");
-    case "questionnaire": {
-      const question = intent.questions[intent.currentIndex] ?? intent.questions[0];
-      return [question?.header, question?.question]
-        .filter((value): value is string => Boolean(value))
-        .join("\n\n");
-    }
+    case "questionnaire":
+      return formatMessagingQuestionnaireText(intent);
     case "approval":
       return [intent.title, intent.body].filter(Boolean).join("\n\n");
     case "confirmation":

--- a/packages/messaging/providers/telegram/src/telegram-formatting.ts
+++ b/packages/messaging/providers/telegram/src/telegram-formatting.ts
@@ -6,7 +6,11 @@ import type {
   MessagingSurfaceAction,
   MessagingSurfaceIntent,
 } from "@pwragent/messaging-interface";
-import { layoutMessagingActionRows } from "@pwragent/messaging-interface";
+import {
+  formatMessagingQuestionnaireText,
+  layoutMessagingActionRows,
+  messagingQuestionnaireActions,
+} from "@pwragent/messaging-interface";
 
 export const TELEGRAM_CALLBACK_DATA_LIMIT_BYTES = 64;
 export const TELEGRAM_MESSAGE_TEXT_LIMIT = 4096;
@@ -96,13 +100,8 @@ export function textForTelegramIntent(intent: MessagingSurfaceIntent): string {
       return renderTelegramHtml(intent.prompt, "plain");
     case "multi_select":
       return renderTelegramHtml(intent.prompt, "plain");
-    case "questionnaire": {
-      const question = intent.questions[intent.currentIndex] ?? intent.questions[0];
-      return renderTelegramHtml(
-        [question?.header, question?.question].filter(Boolean).join("\n"),
-        "plain",
-      );
-    }
+    case "questionnaire":
+      return renderTelegramHtml(formatMessagingQuestionnaireText(intent), "plain");
     case "approval":
       return renderTelegramHtml([intent.title, intent.body].join("\n\n"), "markdown");
     case "confirmation":
@@ -125,10 +124,8 @@ export function actionsForTelegramIntent(
       return intent.choices;
     case "multi_select":
       return intent.choices;
-    case "questionnaire": {
-      const question = intent.questions[intent.currentIndex] ?? intent.questions[0];
-      return question?.options ?? [];
-    }
+    case "questionnaire":
+      return messagingQuestionnaireActions(intent);
     case "approval":
       return intent.decisions;
     case "confirmation":

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -79,6 +79,10 @@ describe("desktop settings contracts", () => {
           value: false,
           source: "default",
         },
+        codexDefaultModeRequestUserInput: {
+          value: false,
+          source: "default",
+        },
         diffCondensation: {
           enabled: { value: false, source: "default" },
           model: { value: "auto", source: "default" },

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -460,6 +460,12 @@ export type DesktopSettingsSnapshot = {
      */
     liveTranscriptEventFiltering: DesktopSettingsValue<boolean>;
     /**
+     * Enables Codex's upstream default-mode request_user_input feature for
+     * ordinary turns, allowing skills to pause and ask structured questions
+     * outside Plan mode when the installed Codex build supports it.
+     */
+    codexDefaultModeRequestUserInput: DesktopSettingsValue<boolean>;
+    /**
      * Diff condensation (a.k.a. "diff eliding") gates whether we send
      * focused-diff requests to xAI. When enabled, less-relevant diff
      * hunks are hidden via an xAI judgment call. When disabled, every
@@ -680,6 +686,7 @@ export type DesktopSettingsConfigPatch = {
   experimental?: {
     fullAccessRiskWarningDismissed?: boolean;
     liveTranscriptEventFiltering?: boolean;
+    codexDefaultModeRequestUserInput?: boolean;
     diffCondensation?: {
       enabled?: boolean;
       /** "auto" or a specific model id. Empty string is coerced to "auto". */


### PR DESCRIPTION
## Summary

Codex skill questions are now answerable in PwrAgent instead of getting stuck behind an app-server request the UI could not present. Operators can opt into the experimental Codex request-user-input support, answer a skill's question set in the desktop app, and use the same questionnaire flow from messaging providers.

## What Changed

- Added the experimental setting and app-server launch wiring for Codex default-mode skill questions.
- Normalized `item/tool/requestUserInput` into a questionnaire surface with explicit answers and phases.
- Gave messaging questionnaires a real state machine: option selection, freeform replies, Back, Next, review, Submit, and submitted summaries.
- Moved Telegram, Discord, Slack, LINE, Mattermost, and Feishu onto the shared questionnaire text/action model so provider navigation stays consistent.
- Tightened the desktop pending-input card with a composer-like freeform field and a final answers review card before submission.
- Hardened messaging questionnaire display against old pending-intent rows and masked secret answers in provider-visible summaries.

## Tests

- `pnpm test apps/desktop/src/main/__tests__/codex-client.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/main/__tests__/desktop-settings-service.test.ts apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx packages/shared/src/contracts/__tests__/settings.test.ts -t "skill|elicit|requestUserInput|experimental"`
- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/questionnaire.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/pending-questionnaire.test.tsx`
- `pnpm test packages/messaging/interface/src/__tests__/messaging-interface.test.ts apps/desktop/src/main/__tests__/messaging-interaction-mapper.test.ts apps/desktop/src/main/__tests__/messaging-controller.test.ts -t "questionnaire|pairing"`
- `pnpm test apps/desktop/src/main/__tests__/messaging-interaction-mapper.test.ts apps/desktop/src/main/__tests__/messaging-controller.test.ts -t "questionnaire|Plan questionnaires|typing while presenting"`
- `pnpm --filter @pwragent/desktop test:e2e -- e2e/request-user-input.spec.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm --filter @pwragent/messaging-interface typecheck`
- `pnpm -r --filter './packages/messaging/**' typecheck`
- `pnpm lint:boundaries`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/Codex-GPT--5-000000)
