### PR TITLE
fix(desktop): dismiss viewport tooltips on window blur and scroll

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
@@ -403,6 +403,66 @@ describe("ThreadRow chip flow", () => {
     );
   });
 
+  it("dismisses the PR tooltip on window blur (cmd-tab away leaves no mouseleave)", () => {
+    renderRow({
+      thread: {
+        ...baseThread,
+        prs: [
+          {
+            provider: "github.com",
+            number: 123,
+            org: "pwrdrvr",
+            repo: "PwrAgent",
+            title: "Retain thread pull request history",
+            state: "passing",
+            url: "https://github.com/pwrdrvr/PwrAgent/pull/123",
+          },
+        ],
+      },
+    });
+
+    const prChip = screen.getByRole("button", {
+      name: /Open pwrdrvr\/PwrAgent#123/,
+    });
+    fireEvent.mouseEnter(prChip);
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+
+    // Switching apps never fires mouseleave on the chip, so the tooltip
+    // would otherwise linger. Window blur must tear it down.
+    fireEvent.blur(window);
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  it("dismisses the PR tooltip when the thread list scrolls", () => {
+    const { container } = renderRow({
+      thread: {
+        ...baseThread,
+        prs: [
+          {
+            provider: "github.com",
+            number: 123,
+            org: "pwrdrvr",
+            repo: "PwrAgent",
+            title: "Retain thread pull request history",
+            state: "passing",
+            url: "https://github.com/pwrdrvr/PwrAgent/pull/123",
+          },
+        ],
+      },
+    });
+
+    const prChip = screen.getByRole("button", {
+      name: /Open pwrdrvr\/PwrAgent#123/,
+    });
+    fireEvent.mouseEnter(prChip);
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+
+    // The portal is position:fixed, so it detaches from its target on scroll.
+    // A capture-phase scroll listener must dismiss it.
+    fireEvent.scroll(container);
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
   it("renders merged PRs as terminal purple chips without unknown check status", () => {
     renderRow({
       thread: {

--- a/apps/desktop/src/renderer/src/lib/useViewportTooltip.tsx
+++ b/apps/desktop/src/renderer/src/lib/useViewportTooltip.tsx
@@ -1,5 +1,6 @@
 import {
   useCallback,
+  useEffect,
   useLayoutEffect,
   useRef,
   useState,
@@ -95,6 +96,26 @@ export function useViewportTooltip(options: {
   const hide = useCallback((): void => {
     setState(undefined);
   }, []);
+
+  // A hover tooltip is shown on pointerenter/focus, but those handlers give
+  // us no dismissal signal when the window loses focus (cmd-tab away leaves
+  // the pointer "over" the chip, so no `mouseleave` fires) or when the list
+  // scrolls underneath the position:fixed portal (the tooltip detaches from
+  // its target and lingers). Tear it down on either, matching ReactionPicker's
+  // window-level teardown. Keyed on visibility so the measure pass doesn't
+  // resubscribe each render.
+  const visible = state !== undefined;
+  useEffect(() => {
+    if (!visible) {
+      return;
+    }
+    window.addEventListener("blur", hide);
+    window.addEventListener("scroll", hide, { capture: true });
+    return () => {
+      window.removeEventListener("blur", hide);
+      window.removeEventListener("scroll", hide, { capture: true });
+    };
+  }, [visible, hide]);
 
   const tooltipNode =
     state && typeof document !== "undefined"


### PR DESCRIPTION
## Summary

- PR-status chips (and every other `useViewportTooltip` consumer) showed their tooltip on `pointerenter`/`focus` and hid it on the matching leave/blur — but those handlers never fired in two cases, leaving a tooltip stranded mid-viewport:
  1. **cmd-tab away** — switching apps leaves the pointer "over" the chip, so no `mouseleave` ever fires.
  2. **scroll after returning** — the tooltip is a `position: fixed` portal (so it can escape the sidebar's `overflow` clipping), so when the list scrolls it detaches from its target and lingers.
- Fix lives in the shared [`useViewportTooltip`](apps/desktop/src/renderer/src/lib/useViewportTooltip.tsx) hook, so it cleans up the PR chip plus all ~6 other chip consumers (ThreadRow, ThreadMetaChips, Sidebar, EditGroupCommitBadge, NewThreadButton) at once. While a tooltip is visible it now tears down on window `blur` and on capture-phase `scroll`, mirroring `ReactionPicker`'s existing window-level teardown. Keyed on visibility so the two-pass measure render doesn't resubscribe each render.

## Verification

- Added two regression tests in [thread-row-chips.test.tsx](apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx): the PR tooltip dismisses on window blur, and on list scroll.
- `pnpm test apps/desktop/.../thread-row-chips.test.tsx` → **25/25 pass**.
- `pnpm --filter @pwragent/desktop typecheck` → clean.

## Notes

- Deliberate behavior choice: the tooltip **dismisses** on scroll rather than repositioning to follow its anchor (which is what `ReactionPicker` does for its anchored popover). For a hover tooltip, vanishing on scroll matches native tooltip behavior and is the "clean it up" outcome — the hover relationship is already broken once the content moves under it.
