### PR TITLE
perf(desktop): reduce sidebar-resize CPU load

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -53,6 +53,7 @@ import { useThreadNavigation } from "./lib/useThreadNavigation";
 import { usePwrAgentProfiles } from "./lib/usePwrAgentProfiles";
 import { usePullRequestRefresh } from "./features/pr-status/usePullRequestRefresh";
 import { useThreadSessionState } from "./lib/useThreadSessionState";
+import { setSidebarResizing } from "./lib/sidebar-resize-signal";
 import { useThreadSkills } from "./lib/useThreadSkills";
 import { useQueuedTurnRelease } from "./lib/useQueuedTurnRelease";
 import { CodexConfigWarningBanner } from "./features/codex-config/CodexConfigWarningBanner";
@@ -164,6 +165,14 @@ function DesktopAppShell(props: {
   settings: DesktopSettingsState;
 }) {
   const [sidebarWidth, setSidebarWidth] = useState(408);
+  // Live mirror of `sidebarWidth`. A pointer drag updates this ref (and the
+  // DOM) on every move WITHOUT calling setState, so the `.app-shell` rerender
+  // (→ Sidebar → every un-virtualized ThreadRow) that used to fire on each
+  // pointermove is gone. The `.app-shell` CSS var is rendered from the ref so
+  // an incidental rerender mid-drag (e.g. an agent event) re-applies the live
+  // dragged width instead of snapping back to the stale committed state.
+  const sidebarWidthRef = useRef(sidebarWidth);
+  const appShellRef = useRef<HTMLDivElement>(null);
   // Hardcoded sidebar resize bounds — mirrored in resizeSidebar() below.
   // Exposed as constants so both the setter and the aria-valuemin/max
   // attributes on the resize handle stay in sync.
@@ -907,24 +916,65 @@ function DesktopAppShell(props: {
   const threadDetailPending =
     mainView === "thread" && (!ThreadViewComponent || selectedThreadPending);
 
+  const clampSidebarWidth = (nextWidth: number): number =>
+    Math.min(sidebarMaxWidth, Math.max(sidebarMinWidth, nextWidth));
+
+  // Keyboard / commit path: a discrete, low-frequency width change. Keep ref
+  // and state in lockstep so the rendered CSS var and `aria-valuenow` agree.
   const resizeSidebar = (nextWidth: number): void => {
-    setSidebarWidth(Math.min(sidebarMaxWidth, Math.max(sidebarMinWidth, nextWidth)));
+    const clamped = clampSidebarWidth(nextWidth);
+    sidebarWidthRef.current = clamped;
+    setSidebarWidth(clamped);
   };
 
   const startSidebarResize = (event: PointerEvent<HTMLElement>): void => {
     event.preventDefault();
     const startX = event.clientX;
-    const startWidth = sidebarWidth;
+    const startWidth = sidebarWidthRef.current;
+    let frame = 0;
 
+    const flush = (): void => {
+      frame = 0;
+      appShellRef.current?.style.setProperty(
+        "--sidebar-width",
+        `${sidebarWidthRef.current}px`,
+      );
+    };
     const move = (moveEvent: globalThis.PointerEvent): void => {
-      resizeSidebar(startWidth + moveEvent.clientX - startX);
+      // Update the live width synchronously so any incidental rerender reads
+      // the current value, but coalesce the actual DOM write to one per frame.
+      sidebarWidthRef.current = clampSidebarWidth(
+        startWidth + moveEvent.clientX - startX,
+      );
+      if (frame === 0) {
+        frame = window.requestAnimationFrame(flush);
+      }
     };
     const stop = (): void => {
       window.removeEventListener("pointermove", move);
       window.removeEventListener("pointerup", stop);
       window.removeEventListener("pointercancel", stop);
+      if (frame !== 0) {
+        window.cancelAnimationFrame(frame);
+        frame = 0;
+      }
+      // Make sure the DOM is at the final width before the transcript
+      // re-syncs (the last move's rAF flush may have been cancelled above).
+      flush();
+      // Commit the final width to React state exactly once so it survives
+      // future rerenders and drives `aria-valuenow` — a single reconcile in
+      // place of one per pointermove.
+      setSidebarWidth(sidebarWidthRef.current);
+      // Release the transcript's resize/scroll sync, which re-syncs once now
+      // that the pane has settled at its final width.
+      setSidebarResizing(false);
     };
 
+    // Pause the transcript's per-frame ResizeObserver/onScroll re-sync for the
+    // duration of the drag — the main pane reflows on every frame, and the
+    // un-virtualized transcript responding to each reflow is the dominant cost
+    // (see lib/sidebar-resize-signal.ts).
+    setSidebarResizing(true);
     window.addEventListener("pointermove", move);
     window.addEventListener("pointerup", stop);
     window.addEventListener("pointercancel", stop);
@@ -944,9 +994,10 @@ function DesktopAppShell(props: {
         actions={mastheadActions}
       />
       <div
+        ref={appShellRef}
         className="app-shell"
         data-sidebar-hidden={sidebarHidden ? "true" : undefined}
-        style={{ "--sidebar-width": `${sidebarWidth}px` } as CSSProperties}
+        style={{ "--sidebar-width": `${sidebarWidthRef.current}px` } as CSSProperties}
       >
         <Sidebar
           backends={backendSummaries.backends}
@@ -1035,7 +1086,7 @@ function DesktopAppShell(props: {
             await navigation.refresh?.();
           }}
           onResizeStart={startSidebarResize}
-          onResizeByKeyboard={(delta) => resizeSidebar(sidebarWidth + delta)}
+          onResizeByKeyboard={(delta) => resizeSidebar(sidebarWidthRef.current + delta)}
           sidebarWidth={sidebarWidth}
           sidebarMinWidth={sidebarMinWidth}
           sidebarMaxWidth={sidebarMaxWidth}

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -171,10 +171,14 @@ function DesktopAppShell(props: {
   // pointermove is gone. The `.app-shell` CSS var is rendered from the ref so
   // an incidental rerender mid-drag (e.g. an agent event) re-applies the live
   // dragged width instead of snapping back to the stale committed state.
+  //
+  // INVARIANT: the rendered width reads from this ref, so it must track state.
+  // Write the width through `commitSidebarWidth` (below); never call
+  // `setSidebarWidth` directly, or the rendered width diverges from state.
   const sidebarWidthRef = useRef(sidebarWidth);
   const appShellRef = useRef<HTMLDivElement>(null);
-  // Hardcoded sidebar resize bounds — mirrored in resizeSidebar() below.
-  // Exposed as constants so both the setter and the aria-valuemin/max
+  // Hardcoded sidebar resize bounds — mirrored in clampSidebarWidth() below.
+  // Exposed as constants so both the clamp and the aria-valuemin/max
   // attributes on the resize handle stay in sync.
   const sidebarMinWidth = 280;
   const sidebarMaxWidth = 560;
@@ -919,12 +923,18 @@ function DesktopAppShell(props: {
   const clampSidebarWidth = (nextWidth: number): number =>
     Math.min(sidebarMaxWidth, Math.max(sidebarMinWidth, nextWidth));
 
-  // Keyboard / commit path: a discrete, low-frequency width change. Keep ref
-  // and state in lockstep so the rendered CSS var and `aria-valuenow` agree.
+  // The single writer of the sidebar width: keeps `sidebarWidthRef` (which the
+  // rendered `--sidebar-width` reads from) and React state in lockstep. The
+  // per-frame drag path writes the ref + DOM directly for speed and calls this
+  // only once on pointerup; every other caller goes through here.
+  const commitSidebarWidth = (width: number): void => {
+    sidebarWidthRef.current = width;
+    setSidebarWidth(width);
+  };
+
+  // Keyboard / commit path: a discrete, low-frequency width change.
   const resizeSidebar = (nextWidth: number): void => {
-    const clamped = clampSidebarWidth(nextWidth);
-    sidebarWidthRef.current = clamped;
-    setSidebarWidth(clamped);
+    commitSidebarWidth(clampSidebarWidth(nextWidth));
   };
 
   const startSidebarResize = (event: PointerEvent<HTMLElement>): void => {
@@ -964,7 +974,7 @@ function DesktopAppShell(props: {
       // Commit the final width to React state exactly once so it survives
       // future rerenders and drives `aria-valuenow` — a single reconcile in
       // place of one per pointermove.
-      setSidebarWidth(sidebarWidthRef.current);
+      commitSidebarWidth(sidebarWidthRef.current);
       // Release the transcript's resize/scroll sync, which re-syncs once now
       // that the pane has settled at its final width.
       setSidebarResizing(false);

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -28,6 +28,10 @@ import { injectMessagingBindingTransitions } from "./messaging-binding-transitio
 import { injectPermissionTransitions } from "./permission-transition-entries";
 import { injectTurnFailures } from "./turn-failure-entries";
 import type { DesktopApi } from "../../lib/desktop-api";
+import {
+  isSidebarResizing,
+  subscribeSidebarResizing,
+} from "../../lib/sidebar-resize-signal";
 import { ThinkingScanner } from "./ThinkingScanner";
 import { PendingQuestionnaire } from "./PendingQuestionnaire";
 import { PendingMcpInteraction } from "./PendingMcpInteraction";
@@ -806,6 +810,13 @@ export function TranscriptList(props: TranscriptListProps) {
     }
 
     const observer = new ResizeObserver(() => {
+      // While the sidebar is being dragged the main pane reflows every frame.
+      // Reading/writing scroll geometry + re-rendering on each of those frames
+      // is a layout-thrash amplifier; skip it here and re-sync once when the
+      // drag ends (see the subscribeSidebarResizing effect below).
+      if (isSidebarResizing()) {
+        return;
+      }
       if (isGluedToBottomRef.current) {
         scrollToBottom();
       } else {
@@ -817,6 +828,22 @@ export function TranscriptList(props: TranscriptListProps) {
     return () => {
       observer.disconnect();
     };
+  }, [scrollToBottom, syncScrollState]);
+
+  // When a sidebar drag ends, the pane has settled at its final width but the
+  // ResizeObserver/onScroll handlers were paused throughout — re-sync the
+  // scroll state once so glue-to-bottom and the scroll-edge fades are correct.
+  useEffect(() => {
+    return subscribeSidebarResizing((active) => {
+      if (active) {
+        return;
+      }
+      if (isGluedToBottomRef.current) {
+        scrollToBottom();
+      } else {
+        syncScrollState({ preserveGlueOnResize: true });
+      }
+    });
   }, [scrollToBottom, syncScrollState]);
 
   if (props.loading && !hasTranscriptContent && !hasPendingContent) {
@@ -868,6 +895,12 @@ export function TranscriptList(props: TranscriptListProps) {
           }
         }}
         onScroll={() => {
+          // A sidebar drag can shift scrollTop via reflow/scroll-anchoring;
+          // those aren't real navigations, so skip the re-sync until the drag
+          // ends (the user can't scroll while holding the resize handle).
+          if (isSidebarResizing()) {
+            return;
+          }
           syncScrollState({ preserveGlueOnResize: true });
         }}
       >

--- a/apps/desktop/src/renderer/src/lib/__tests__/sidebar-resize-signal.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/sidebar-resize-signal.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  isSidebarResizing,
+  setSidebarResizing,
+  subscribeSidebarResizing,
+} from "../sidebar-resize-signal";
+
+// The signal is module-level singleton state; reset it after every test so the
+// cases can't bleed into one another.
+afterEach(() => {
+  setSidebarResizing(false);
+});
+
+describe("sidebar-resize-signal", () => {
+  it("starts inactive", () => {
+    expect(isSidebarResizing()).toBe(false);
+  });
+
+  it("reflects the active flag through isSidebarResizing()", () => {
+    setSidebarResizing(true);
+    expect(isSidebarResizing()).toBe(true);
+    setSidebarResizing(false);
+    expect(isSidebarResizing()).toBe(false);
+  });
+
+  it("notifies subscribers on each transition with the new value", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeSidebarResizing(listener);
+
+    setSidebarResizing(true);
+    setSidebarResizing(false);
+
+    expect(listener.mock.calls).toEqual([[true], [false]]);
+    unsubscribe();
+  });
+
+  it("does not notify when the value is unchanged", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeSidebarResizing(listener);
+
+    setSidebarResizing(true);
+    setSidebarResizing(true); // duplicate — must be a no-op
+    setSidebarResizing(false);
+    setSidebarResizing(false); // duplicate — must be a no-op
+
+    expect(listener.mock.calls).toEqual([[true], [false]]);
+    unsubscribe();
+  });
+
+  it("notifies every subscriber", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const unsubFirst = subscribeSidebarResizing(first);
+    const unsubSecond = subscribeSidebarResizing(second);
+
+    setSidebarResizing(true);
+
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(first).toHaveBeenCalledWith(true);
+    expect(second).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledWith(true);
+    unsubFirst();
+    unsubSecond();
+  });
+
+  it("stops notifying after unsubscribe", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeSidebarResizing(listener);
+
+    setSidebarResizing(true);
+    unsubscribe();
+    setSidebarResizing(false);
+
+    expect(listener.mock.calls).toEqual([[true]]);
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/sidebar-resize-signal.ts
+++ b/apps/desktop/src/renderer/src/lib/sidebar-resize-signal.ts
@@ -1,0 +1,40 @@
+// Renderer-local signal shared between the App sidebar-resize drag handler and
+// the transcript's scroll/resize sync. While the left sidebar is being actively
+// dragged, every pointer frame changes `--sidebar-width`, which resizes the main
+// pane and reflows the (un-virtualized) transcript. The transcript's
+// ResizeObserver/onScroll handlers normally respond by reading layout
+// (scrollHeight/clientHeight) and writing scrollTop + calling setState — a
+// read→write→read layout thrash plus a full re-render, once per frame.
+//
+// During an active drag we pause that re-sync (see TranscriptList) so the drag
+// pays only the unavoidable single reflow per frame, not the amplified thrash.
+// The transcript re-syncs once when the drag ends.
+//
+// Per-window by construction: each renderer window is its own module instance.
+
+type Listener = (active: boolean) => void;
+
+let active = false;
+const listeners = new Set<Listener>();
+
+export function isSidebarResizing(): boolean {
+  return active;
+}
+
+export function setSidebarResizing(next: boolean): void {
+  if (active === next) {
+    return;
+  }
+  active = next;
+  for (const listener of listeners) {
+    listener(active);
+  }
+}
+
+/** Subscribe to drag start/stop transitions. Returns an unsubscribe fn. */
+export function subscribeSidebarResizing(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}


### PR DESCRIPTION
## Summary

- Dragging the left sidebar resize handle pinned ~50–70% of a CPU core. A renderer CPU capture during a fast drag showed two per-frame costs, both now removed.
- **Eliminate per-frame React reconciliation.** `--sidebar-width` was React state on `.app-shell`, so every `pointermove` re-rendered App → Sidebar → every (un-virtualized) `ThreadRow`. The drag now writes `--sidebar-width` imperatively on the shell node, rAF-coalesced, and commits to React state once on `pointerup`. The inline style renders from a ref so an incidental rerender mid-drag re-applies the live width instead of snapping back to the stale committed value.
- **Stop the transcript reflow amplifier.** Each `--sidebar-width` change resizes the main pane and reflows the un-virtualized transcript; the transcript's `ResizeObserver`/`onScroll` then did a read→write→read layout thrash plus a full re-render every frame. A small renderer-local signal (`lib/sidebar-resize-signal.ts`) pauses that re-sync while the sidebar is actively dragged and re-syncs once when the drag ends (re-glues to bottom / fixes the scroll-edge fades).

## Verification

- `pnpm --filter @pwragent/desktop typecheck` — clean
- `pnpm test apps/desktop/src/renderer/src/features/navigation apps/desktop/src/renderer/src/features/thread-detail` — 385/385 pass
- `pnpm lint:boundaries` — no violations (new `sidebar-resize-signal.ts` is renderer-local, imports nothing)
- `pnpm lint:colors` — pass
- Manual: renderer CPU profile during a fast continuous drag, before → after this change:

  | Metric (active drag) | Before | After |
  |---|---|---|
  | Trigger sample | 93.0% | 52.4% |
  | Idle | 49.8% | 56.0% |
  | `jsxDEV` (React element creation) | 163 ms | 24.7 ms |
  | `TranscriptActivity` renders | 10.7 ms | 1.3 ms |

  It now takes sustained fast dragging to even cross 50% (was an instant pin).

## Notes

- The JS re-render storm is gone; the remaining cost is the inherent single per-frame reflow of the **un-virtualized** content (transcript + thread list). Driving that toward idle needs either freezing the transcript width during the drag (minor UX change — content reflows once on release) or virtualizing the transcript (larger, riskier — would be a separate PR).
- Deliberately did **not** use `content-visibility: auto` here: on `.thread-row-shell` its paint containment clips on-screen overlays (the inline chip menu and the drop-indicator bars), and on transcript items it's blocked by the `display: contents` item wrapper used for the `role="list"` a11y tree.
- Branch is based 5 commits behind `main`; no conflicts expected, but rebase before merge if desired.