### PR TITLE
fix(desktop): preserve rich lists pasted into blockquotes

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -382,26 +382,59 @@ function parseHtmlInlineContent(
 }
 
 function parseHtmlListItemContent(listItem: HTMLElement): JSONContent[] {
-  const blockChildren = Array.from(listItem.children).filter((child) => {
-    const tagName = child.tagName.toLowerCase();
-    return tagName !== "ul" && tagName !== "ol";
-  });
-  const inlineNodes =
-    blockChildren.length > 0
-      ? blockChildren.flatMap((child) => parseHtmlInlineContent(child))
-      : Array.from(listItem.childNodes).flatMap((child) =>
-          child instanceof HTMLElement &&
-          ["ul", "ol"].includes(child.tagName.toLowerCase())
-            ? []
-            : parseHtmlInlineContent(child),
-        );
+  const inlineNodes = Array.from(listItem.childNodes).flatMap((child) =>
+    child instanceof HTMLElement && isHtmlListElement(child)
+      ? []
+      : parseHtmlInlineContent(child),
+  );
+
+  const nestedLists = Array.from(listItem.children)
+    .filter((child): child is HTMLElement => child instanceof HTMLElement)
+    .filter(isHtmlListElement)
+    .map(parseHtmlListElement)
+    .filter((child): child is JSONContent => child !== undefined);
 
   return [
     {
       type: "paragraph",
       content: inlineNodes.length > 0 ? inlineNodes : undefined,
     },
+    ...nestedLists,
   ];
+}
+
+function isHtmlListElement(element: HTMLElement): boolean {
+  const tagName = element.tagName.toLowerCase();
+  return tagName === "ul" || tagName === "ol";
+}
+
+function parseHtmlListElement(listElement: HTMLElement): JSONContent | undefined {
+  const tagName = listElement.tagName.toLowerCase();
+  const items = Array.from(listElement.children)
+    .filter((item): item is HTMLElement => item instanceof HTMLElement)
+    .filter((item) => item.tagName.toLowerCase() === "li")
+    .map((item) => ({
+      type: "listItem",
+      content: parseHtmlListItemContent(item),
+    }));
+
+  if (items.length === 0) {
+    return undefined;
+  }
+
+  if (tagName === "ol") {
+    const start = Number.parseInt(listElement.getAttribute("start") ?? "1", 10);
+    return {
+      type: "orderedList",
+      attrs: { start: Number.isFinite(start) ? start : 1 },
+      content: items,
+    };
+  }
+
+  return {
+    type: "bulletList",
+    content: items,
+  };
 }
 
 function parseClipboardHtmlStructuredContent(
@@ -413,42 +446,11 @@ function parseClipboardHtmlStructuredContent(
   }
 
   const doc = new DOMParser().parseFromString(html, "text/html");
-  const listElements = Array.from(doc.body.querySelectorAll("ul, ol"))
+  return Array.from(doc.body.querySelectorAll("ul, ol"))
     .filter((child): child is HTMLElement => child instanceof HTMLElement)
-    .filter((child) => !child.parentElement?.closest("li"));
-
-  return listElements.flatMap((child) => {
-    const tagName = child.tagName.toLowerCase();
-    const items = Array.from(child.children)
-      .filter((item): item is HTMLElement => item instanceof HTMLElement)
-      .filter((item) => item.tagName.toLowerCase() === "li")
-      .map((item) => ({
-        type: "listItem",
-        content: parseHtmlListItemContent(item),
-      }));
-
-    if (items.length === 0) {
-      return [];
-    }
-
-    if (tagName === "ol") {
-      const start = Number.parseInt(child.getAttribute("start") ?? "1", 10);
-      return [
-        {
-          type: "orderedList",
-          attrs: { start: Number.isFinite(start) ? start : 1 },
-          content: items,
-        },
-      ];
-    }
-
-    return [
-      {
-        type: "bulletList",
-        content: items,
-      },
-    ];
-  });
+    .filter((child) => !child.parentElement?.closest("li"))
+    .map(parseHtmlListElement)
+    .filter((child): child is JSONContent => child !== undefined);
 }
 
 function buildTiptapContent(

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -332,6 +332,125 @@ function buildMarkdownListItem(text: string): JSONContent {
   };
 }
 
+function getHtmlInlineMark(tagName: string): { type: string } | undefined {
+  if (tagName === "strong" || tagName === "b") {
+    return { type: "bold" };
+  }
+  if (tagName === "em" || tagName === "i") {
+    return { type: "italic" };
+  }
+  if (tagName === "s" || tagName === "strike" || tagName === "del") {
+    return { type: "strike" };
+  }
+  if (tagName === "code") {
+    return { type: "code" };
+  }
+  return undefined;
+}
+
+function parseHtmlInlineContent(
+  node: Node,
+  inheritedMarks: { type: string }[] = [],
+): JSONContent[] {
+  if (node.nodeType === Node.TEXT_NODE) {
+    const text = node.textContent ?? "";
+    if (!text) {
+      return [];
+    }
+    return [
+      {
+        type: "text",
+        text,
+        ...(inheritedMarks.length > 0 ? { marks: inheritedMarks } : {}),
+      },
+    ];
+  }
+
+  if (!(node instanceof HTMLElement)) {
+    return [];
+  }
+
+  if (node.tagName.toLowerCase() === "br") {
+    return [{ type: "hardBreak" }];
+  }
+
+  const mark = getHtmlInlineMark(node.tagName.toLowerCase());
+  const nextMarks = mark ? [...inheritedMarks, mark] : inheritedMarks;
+  return Array.from(node.childNodes).flatMap((child) =>
+    parseHtmlInlineContent(child, nextMarks),
+  );
+}
+
+function parseHtmlListItemContent(listItem: HTMLElement): JSONContent[] {
+  const blockChildren = Array.from(listItem.children).filter((child) => {
+    const tagName = child.tagName.toLowerCase();
+    return tagName !== "ul" && tagName !== "ol";
+  });
+  const inlineNodes =
+    blockChildren.length > 0
+      ? blockChildren.flatMap((child) => parseHtmlInlineContent(child))
+      : Array.from(listItem.childNodes).flatMap((child) =>
+          child instanceof HTMLElement &&
+          ["ul", "ol"].includes(child.tagName.toLowerCase())
+            ? []
+            : parseHtmlInlineContent(child),
+        );
+
+  return [
+    {
+      type: "paragraph",
+      content: inlineNodes.length > 0 ? inlineNodes : undefined,
+    },
+  ];
+}
+
+function parseClipboardHtmlStructuredContent(
+  event: ClipboardEvent<HTMLDivElement>,
+): JSONContent[] {
+  const html = event.clipboardData?.getData("text/html") ?? "";
+  if (!html.trim()) {
+    return [];
+  }
+
+  const doc = new DOMParser().parseFromString(html, "text/html");
+  const listElements = Array.from(doc.body.querySelectorAll("ul, ol"))
+    .filter((child): child is HTMLElement => child instanceof HTMLElement)
+    .filter((child) => !child.parentElement?.closest("li"));
+
+  return listElements.flatMap((child) => {
+    const tagName = child.tagName.toLowerCase();
+    const items = Array.from(child.children)
+      .filter((item): item is HTMLElement => item instanceof HTMLElement)
+      .filter((item) => item.tagName.toLowerCase() === "li")
+      .map((item) => ({
+        type: "listItem",
+        content: parseHtmlListItemContent(item),
+      }));
+
+    if (items.length === 0) {
+      return [];
+    }
+
+    if (tagName === "ol") {
+      const start = Number.parseInt(child.getAttribute("start") ?? "1", 10);
+      return [
+        {
+          type: "orderedList",
+          attrs: { start: Number.isFinite(start) ? start : 1 },
+          content: items,
+        },
+      ];
+    }
+
+    return [
+      {
+        type: "bulletList",
+        content: items,
+      },
+    ];
+  });
+}
+
 function buildTiptapContent(
   value: string,
   skillTokens: ComposerSkillToken[],
@@ -831,6 +950,13 @@ function getPlainTextFromPaste(event: ClipboardEvent<HTMLDivElement>): string {
   return event.clipboardData?.getData("text/plain").replace(/\r\n?/g, "\n") ?? "";
 }
 
+function clipboardHtmlHasStructuredBlocks(
+  event: ClipboardEvent<HTMLDivElement>,
+): boolean {
+  const html = event.clipboardData?.getData("text/html") ?? "";
+  return /<(?:pre|ul|ol|blockquote|h[1-6])[\s>]/i.test(html);
+}
+
 function selectionIsInsideNode(editor: TiptapEditor, nodeTypeName: string): boolean {
   const { $from, $to } = editor.state.selection;
   const isInside = ($pos: typeof $from): boolean => {
@@ -865,6 +991,13 @@ function pastePlainTextIntoActiveBlock(
   }
 
   if (selectionIsInsideNode(editor, "blockquote")) {
+    const structuredHtmlContent = parseClipboardHtmlStructuredContent(event);
+    if (structuredHtmlContent.length > 0) {
+      event.preventDefault();
+      return editor.commands.insertContent(structuredHtmlContent, {
+        updateSelection: true,
+      });
+    }
     event.preventDefault();
     return editor.commands.insertContent(splitTextContent(text), {
       updateSelection: true,
@@ -906,8 +1039,7 @@ function pastePlainMarkdownText(
   // this targets — one rendered message copied with both flavors — and is not
   // meant to be a general markdown/HTML merge. Note <p> alone does NOT count:
   // bare paragraph HTML around a text/plain fence must still reach the parser.
-  const html = event.clipboardData?.getData("text/html") ?? "";
-  if (html.trim().length > 0 && /<(?:pre|ul|ol|blockquote|h[1-6])[\s>]/i.test(html)) {
+  if (clipboardHtmlHasStructuredBlocks(event)) {
     return false;
   }
 

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx
@@ -338,6 +338,143 @@ describe("ComposerTiptapInput", () => {
     expect(quoteListItems[1]).toHaveTextContent("Added Escape-key handling.");
   });
 
+  it("preserves text around inline marks in rich lists pasted inside a blockquote", async () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <ComposerTiptapInput
+        editorDocument={{
+          type: "doc",
+          content: [
+            {
+              type: "blockquote",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Checklist:" }],
+                },
+              ],
+            },
+          ],
+        }}
+        id="reply"
+        label="Reply"
+        markdownConversion
+        onChange={onChange}
+        placeholder="Ask anything"
+        skillTokens={[]}
+        value="> Checklist:"
+      />,
+    );
+    const textbox = await screen.findByRole("textbox", { name: "Reply" });
+    setComposerSelection(textbox, "Checklist:".length);
+
+    fireEvent.paste(textbox, {
+      clipboardData: {
+        files: [],
+        getData: (type: string) => {
+          if (type === "text/html") {
+            return "<ul><li>Use <strong>bold</strong> text</li></ul>";
+          }
+          if (type === "text/plain") {
+            return "Use bold text";
+          }
+          return "";
+        },
+        items: [],
+        types: ["text/html", "text/plain"],
+      },
+    });
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenLastCalledWith(
+        [
+          "> Checklist:",
+          "> ",
+          "> - Use **bold** text",
+        ].join("\n"),
+        [],
+        expect.any(Object),
+      );
+    });
+
+    const quoteListItem = container.querySelector("blockquote ul > li");
+    expect(quoteListItem).toHaveTextContent("Use bold text");
+    expect(quoteListItem?.querySelector("strong")).toHaveTextContent("bold");
+  });
+
+  it("preserves nested rich list items pasted inside a blockquote", async () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <ComposerTiptapInput
+        editorDocument={{
+          type: "doc",
+          content: [
+            {
+              type: "blockquote",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Tasks:" }],
+                },
+              ],
+            },
+          ],
+        }}
+        id="reply"
+        label="Reply"
+        markdownConversion
+        onChange={onChange}
+        placeholder="Ask anything"
+        skillTokens={[]}
+        value="> Tasks:"
+      />,
+    );
+    const textbox = await screen.findByRole("textbox", { name: "Reply" });
+    setComposerSelection(textbox, "Tasks:".length);
+
+    fireEvent.paste(textbox, {
+      clipboardData: {
+        files: [],
+        getData: (type: string) => {
+          if (type === "text/html") {
+            return [
+              "<ul>",
+              "<li>",
+              "Parent task",
+              "<ul><li>Nested task</li></ul>",
+              "</li>",
+              "</ul>",
+            ].join("");
+          }
+          if (type === "text/plain") {
+            return "Parent task\nNested task";
+          }
+          return "";
+        },
+        items: [],
+        types: ["text/html", "text/plain"],
+      },
+    });
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenLastCalledWith(
+        [
+          "> Tasks:",
+          "> ",
+          "> - Parent task",
+          ">   - Nested task",
+        ].join("\n"),
+        [],
+        expect.any(Object),
+      );
+    });
+
+    const parentItem = container.querySelector("blockquote > ul > li");
+    const nestedItem = container.querySelector("blockquote ul ul > li");
+    expect(parentItem).toHaveTextContent("Parent task");
+    expect(nestedItem).toHaveTextContent("Nested task");
+  });
+
   it("preserves paragraph separators when pasting a handoff prefix without a code block", async () => {
     const { onChange } = renderTiptapInput();
     const textbox = await screen.findByRole("textbox", { name: "Reply" });

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx
@@ -260,6 +260,84 @@ describe("ComposerTiptapInput", () => {
     ).toBe(false);
   });
 
+  it("preserves rich web-page lists when pasting inside a blockquote", async () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <ComposerTiptapInput
+        editorDocument={{
+          type: "doc",
+          content: [
+            {
+              type: "blockquote",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Release notes:" }],
+                },
+              ],
+            },
+          ],
+        }}
+        id="reply"
+        label="Reply"
+        markdownConversion
+        onChange={onChange}
+        placeholder="Ask anything"
+        skillTokens={[]}
+        value="> Release notes:"
+      />,
+    );
+    const textbox = await screen.findByRole("textbox", { name: "Reply" });
+    setComposerSelection(textbox, "Release notes:".length);
+
+    fireEvent.paste(textbox, {
+      clipboardData: {
+        files: [],
+        getData: (type: string) => {
+          if (type === "text/html") {
+            return [
+              "<ul>",
+              "<li>Improved composer paste handling.</li>",
+              "<li>Added Escape-key handling.</li>",
+              "</ul>",
+            ].join("");
+          }
+          if (type === "text/plain") {
+            return [
+              "Improved composer paste handling.",
+              "Added Escape-key handling.",
+            ].join("\n");
+          }
+          return "";
+        },
+        items: [],
+        types: ["text/html", "text/plain"],
+      },
+    });
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenLastCalledWith(
+        [
+          "> Release notes:",
+          "> ",
+          "> - Improved composer paste handling.",
+          "> - Added Escape-key handling.",
+        ].join("\n"),
+        [],
+        expect.any(Object),
+      );
+    });
+
+    const quoteListItems = [
+      ...container.querySelectorAll("blockquote ul > li"),
+    ];
+    expect(quoteListItems).toHaveLength(2);
+    expect(quoteListItems[0]).toHaveTextContent(
+      "Improved composer paste handling.",
+    );
+    expect(quoteListItems[1]).toHaveTextContent("Added Escape-key handling.");
+  });
+
   it("preserves paragraph separators when pasting a handoff prefix without a code block", async () => {
     const { onChange } = renderTiptapInput();
     const textbox = await screen.findByRole("textbox", { name: "Reply" });


### PR DESCRIPTION
## Summary
Pasting a rich list from GitHub release notes into an existing composer blockquote now keeps it as a real list instead of flattening the items into quoted plain text. The blockquote paste path now preserves structured HTML list content before falling back to plain-text insertion, while the existing code-block and plain quote paste behavior stays intact.

## Testing
- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx -- --runInBand`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
