### PR TITLE
fix(desktop): allow prefixing initial composer code blocks

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -827,6 +827,33 @@ function insertPlainSpaceAtTextblockEnd(editor: TiptapEditor): boolean {
   return true;
 }
 
+function insertParagraphBeforeInitialCodeBlock(editor: TiptapEditor): boolean {
+  const { selection, schema } = editor.state;
+  if (!selection.empty) {
+    return false;
+  }
+
+  const currentPos = selection.$from;
+  if (
+    currentPos.depth !== 1 ||
+    currentPos.parent.type.name !== "codeBlock" ||
+    currentPos.parentOffset !== 0 ||
+    currentPos.before(currentPos.depth) !== 0
+  ) {
+    return false;
+  }
+
+  const paragraph = schema.nodes.paragraph?.createAndFill();
+  if (!paragraph) {
+    return false;
+  }
+
+  const transaction = editor.state.tr.insert(0, paragraph);
+  editor.view.dispatch(transaction);
+  editor.commands.setTextSelection(1);
+  return true;
+}
+
 function getPlainTextFromPaste(event: ClipboardEvent<HTMLDivElement>): string {
   return event.clipboardData?.getData("text/plain").replace(/\r\n?/g, "\n") ?? "";
 }
@@ -1569,6 +1596,21 @@ export const ComposerTiptapInput = forwardRef<
 
           if (
             propsRef.current.markdownConversion &&
+            (event.key === "ArrowLeft" || event.key === "ArrowUp") &&
+            !event.metaKey &&
+            !event.ctrlKey &&
+            !event.altKey &&
+            !event.shiftKey
+          ) {
+            const currentEditor = editorRef.current;
+            if (currentEditor && insertParagraphBeforeInitialCodeBlock(currentEditor)) {
+              event.preventDefault();
+              return true;
+            }
+          }
+
+          if (
+            propsRef.current.markdownConversion &&
             event.key === "ArrowRight" &&
             !event.metaKey &&
             !event.ctrlKey &&
@@ -1941,6 +1983,19 @@ export const ComposerTiptapInput = forwardRef<
           return;
         }
         if (event.key === "ArrowUp" || event.key === "ArrowDown") {
+          if (
+            props.markdownConversion &&
+            event.key === "ArrowUp" &&
+            !event.metaKey &&
+            !event.ctrlKey &&
+            !event.altKey &&
+            !event.shiftKey &&
+            insertParagraphBeforeInitialCodeBlock(editor)
+          ) {
+            event.preventDefault();
+            event.stopPropagation();
+            return;
+          }
           propsRef.current.onKeyDown?.(event as unknown as KeyboardEvent<HTMLDivElement>);
           if (event.defaultPrevented) {
             event.stopPropagation();

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx
@@ -385,6 +385,42 @@ describe("ComposerTiptapInput", () => {
     );
   });
 
+  it("pressing ArrowUp at the start of an initial code block creates a paragraph above it", async () => {
+    const value = "```ts\nconst answer = 42;\n```";
+    const { container, onChange } = renderTiptapInput({ value });
+    const textbox = await screen.findByRole("textbox", { name: "Reply" });
+
+    setComposerSelection(textbox, 0);
+    fireEvent.keyDown(textbox, { key: "ArrowUp" });
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenLastCalledWith(`\n\n${value}`, []);
+    });
+    const editorChildren = [
+      ...(container.querySelector(".composer-tiptap-input__editor")?.children ?? []),
+    ];
+    expect(editorChildren[0]?.tagName).toBe("P");
+    expect(editorChildren[1]?.tagName).toBe("PRE");
+  });
+
+  it("pressing ArrowLeft at the start of an initial code block creates a paragraph above it", async () => {
+    const value = "```ts\nconst answer = 42;\n```";
+    const { container, onChange } = renderTiptapInput({ value });
+    const textbox = await screen.findByRole("textbox", { name: "Reply" });
+
+    setComposerSelection(textbox, 0);
+    fireEvent.keyDown(textbox, { key: "ArrowLeft" });
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenLastCalledWith(`\n\n${value}`, []);
+    });
+    const editorChildren = [
+      ...(container.querySelector(".composer-tiptap-input__editor")?.children ?? []),
+    ];
+    expect(editorChildren[0]?.tagName).toBe("P");
+    expect(editorChildren[1]?.tagName).toBe("PRE");
+  });
+
   // The `is-empty` class on `.composer-tiptap-input` is the contract
   // hook for empty-state styling — currently used for the placeholder
   // appearance, but reserved for any future CSS that distinguishes


### PR DESCRIPTION
## Summary

Starting a composer reply with a fenced code block no longer traps the cursor at the top of the block. Pressing ArrowUp or ArrowLeft at the first position now creates a normal paragraph above the initial code block, so users can add introductory text without rebuilding the draft.

The fix is scoped to the first top-level code block and leaves normal arrow navigation unchanged elsewhere.

## Tests

- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx`
- `pnpm --filter @pwragent/desktop exec tsc --noEmit --pretty false --project tsconfig.json`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)
