### PR TITLE
fix(desktop): hide untracked directories from edits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 .pnpm-store/
 .local/
+.tmp/
 .DS_Store
 coverage/
 dist/

--- a/apps/desktop/src/main/__tests__/git-working-state-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-working-state-service.test.ts
@@ -1,6 +1,6 @@
 import os from "node:os";
 import path from "node:path";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { describe, expect, it, vi } from "vitest";
 import {
   GitWorkingStateService,
@@ -207,6 +207,9 @@ describe("GitWorkingStateService", () => {
       if (args.includes("--numstat")) {
         return "2\t1\tdocs/PwrAgnt v2.html\n4\t0\tsrc/other-b.ts\n";
       }
+      if (args.includes("ls-files")) {
+        return "scratch/new.txt\0";
+      }
       return undefined;
     });
     const service = new GitWorkingStateService({ runGit });
@@ -241,6 +244,154 @@ describe("GitWorkingStateService", () => {
       truncated: true,
       maxFiles: 2,
     });
+  });
+
+  it("expands collapsed untracked directories without an unbounded status scan", async () => {
+    const worktreePath = "/repo/wt";
+    const { runGit, calls } = fakeGit((args) => {
+      if (args.includes("status")) {
+        return "?? .tmp/\0";
+      }
+      if (args.includes("ls-files")) {
+        return ".tmp/monitors/run/stdout.log\0.tmp/monitors/run/stderr.log\0";
+      }
+      if (args.includes("--numstat")) return "";
+      return undefined;
+    });
+    const service = new GitWorkingStateService({ runGit });
+
+    const response = await service.listOtherChanges(worktreePath);
+
+    expect(
+      calls.some(
+        (call) =>
+          call.args.includes("status") &&
+          call.args.includes("--untracked-files=normal"),
+      ),
+    ).toBe(true);
+    expect(calls.some((call) => call.args.includes("ls-files"))).toBe(true);
+    expect(response.changes).toEqual([
+      {
+        path: normalizeTestPath(`${worktreePath}/.tmp/monitors/run/stdout.log`),
+        repoPath: ".tmp/monitors/run/stdout.log",
+        status: "untracked",
+        staged: false,
+        unstaged: true,
+      },
+      {
+        path: normalizeTestPath(`${worktreePath}/.tmp/monitors/run/stderr.log`),
+        repoPath: ".tmp/monitors/run/stderr.log",
+        status: "untracked",
+        staged: false,
+        unstaged: true,
+      },
+    ]);
+  });
+
+  it("caps expansion of large untracked directory trees", async () => {
+    const worktreePath = "/repo/wt";
+    const { runGit } = fakeGit((args) => {
+      if (args.includes("status")) return "?? node_modules/\0";
+      if (args.includes("ls-files")) {
+        return [
+          "node_modules/a.js",
+          "node_modules/b.js",
+          "node_modules/c.js",
+          "node_modules/d.js",
+        ].join("\0");
+      }
+      if (args.includes("--numstat")) return "";
+      return undefined;
+    });
+    const service = new GitWorkingStateService({ runGit });
+
+    const response = await service.listOtherChanges(worktreePath, { maxFiles: 2 });
+
+    expect(response.changes).toEqual([
+      {
+        path: normalizeTestPath(`${worktreePath}/node_modules/a.js`),
+        repoPath: "node_modules/a.js",
+        status: "untracked",
+        staged: false,
+        unstaged: true,
+      },
+      {
+        path: normalizeTestPath(`${worktreePath}/node_modules/b.js`),
+        repoPath: "node_modules/b.js",
+        status: "untracked",
+        staged: false,
+        unstaged: true,
+      },
+    ]);
+    expect(response.totalChanges).toBe(3);
+    expect(response.truncated).toBe(true);
+  });
+
+  it("does not let excluded files consume the untracked directory expansion cap", async () => {
+    const worktreePath = "/repo/wt";
+    const { runGit } = fakeGit((args) => {
+      if (args.includes("status")) return "?? scratch/\0";
+      if (args.includes("ls-files")) {
+        return [
+          "scratch/turn-a.txt",
+          "scratch/turn-b.txt",
+          "scratch/other.txt",
+        ].join("\0");
+      }
+      if (args.includes("--numstat")) return "";
+      return undefined;
+    });
+    const service = new GitWorkingStateService({ runGit });
+
+    const response = await service.listOtherChanges(worktreePath, {
+      excludePaths: [
+        `${worktreePath}/scratch/turn-a.txt`,
+        `${worktreePath}/scratch/turn-b.txt`,
+      ],
+      maxFiles: 1,
+    });
+
+    expect(response.changes).toEqual([
+      {
+        path: normalizeTestPath(`${worktreePath}/scratch/other.txt`),
+        repoPath: "scratch/other.txt",
+        status: "untracked",
+        staged: false,
+        unstaged: true,
+      },
+    ]);
+    expect(response.totalChanges).toBe(1);
+    expect(response.truncated).toBe(false);
+  });
+
+  it("caps displayed changes from any single top-level directory", async () => {
+    const worktreePath = "/repo/wt";
+    const { runGit } = fakeGit((args) => {
+      if (args.includes("status")) return "?? node_modules/\0?? src/readme.md\0";
+      if (args.includes("ls-files")) {
+        return Array.from(
+          { length: 25 },
+          (_, index) => `node_modules/pkg-${index}.js`,
+        ).join("\0");
+      }
+      if (args.includes("--numstat")) return "";
+      return undefined;
+    });
+    const service = new GitWorkingStateService({ runGit });
+
+    const response = await service.listOtherChanges(worktreePath);
+
+    expect(
+      response.changes.filter((change) =>
+        change.repoPath.startsWith("node_modules/"),
+      ),
+    ).toHaveLength(20);
+    expect(response.changes.at(-1)).toMatchObject({
+      repoPath: "src/readme.md",
+      status: "untracked",
+    });
+    expect(response.totalChanges).toBe(22);
+    expect(response.truncated).toBe(true);
   });
 
   it("recovers unstaged status records after git stdout trimming", async () => {
@@ -354,6 +505,25 @@ describe("GitWorkingStateService", () => {
       });
       expect(response.detail?.fileDiff?.diff).toContain("+++ b/note.txt");
       expect(response.detail?.fileDiff?.diff).toContain("+hello");
+    } finally {
+      await rm(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("does not build an edited-file detail for an untracked directory", async () => {
+    const tmpRoot = await mkdtemp(makeTempPrefix());
+    const dirPath = path.join(tmpRoot, ".tmp");
+    await mkdir(dirPath);
+    const { runGit } = fakeGit((args) => {
+      if (args.includes("status")) return "?? .tmp/";
+      return undefined;
+    });
+    const service = new GitWorkingStateService({ runGit });
+
+    try {
+      const response = await service.getOtherChangeDiff(tmpRoot, dirPath);
+
+      expect(response.detail).toBeUndefined();
     } finally {
       await rm(tmpRoot, { recursive: true, force: true });
     }

--- a/apps/desktop/src/main/app-server/git-working-state-service.ts
+++ b/apps/desktop/src/main/app-server/git-working-state-service.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { spawn } from "node:child_process";
 import { readFile, stat } from "node:fs/promises";
 import { IterableMapper } from "@shutterstock/p-map-iterable";
 import type {
@@ -9,7 +10,7 @@ import type {
   WorktreeOtherChangeEntry,
   WorktreeOtherChangeStatus,
 } from "@pwragent/shared";
-import { runGitCommand } from "./git-executable";
+import { resolveGitExecutable, runGitCommand } from "./git-executable";
 
 function normalizeAbsolutePath(value: string): string {
   return path.resolve(value).replace(/\\/g, "/");
@@ -19,14 +20,18 @@ function normalizeAbsolutePath(value: string): string {
 const EDIT_COMMIT_RESOLVE_CONCURRENCY = 4;
 const DEFAULT_OTHER_CHANGES_MAX_FILES = 50;
 const HARD_OTHER_CHANGES_MAX_FILES = 100;
+const OTHER_CHANGES_MAX_FILES_PER_TOP_LEVEL = 20;
 const DEFAULT_OTHER_CHANGE_DIFF_MAX_BYTES = 200_000;
 const HARD_OTHER_CHANGE_DIFF_MAX_BYTES = 500_000;
+const UNTRACKED_DIRECTORY_EXPANSION_MAX_BYTES = 128_000;
+const UNTRACKED_DIRECTORY_EXPANSION_TIMEOUT_MS = 1_500;
 
 type GitCommandRunner = (
   cwd: string,
   args: string[],
   env?: NodeJS.ProcessEnv,
 ) => Promise<string>;
+type UntrackedPathFilter = (repoPath: string) => boolean;
 
 type AcceptedPushedCommitOptions = {
   acceptedPushedCommitShas?: string[];
@@ -192,6 +197,49 @@ function parseStatusPorcelain(
   return entries;
 }
 
+function isCollapsedUntrackedDirectoryEntry(
+  entry: WorktreeOtherChangeEntry,
+): boolean {
+  return entry.status === "untracked" && entry.repoPath.endsWith("/");
+}
+
+function topLevelChangeBucket(repoPath: string): string {
+  const normalized = normalizeGitRelativePath(repoPath).replace(/\/+$/, "");
+  return normalized.split("/").filter(Boolean)[0] ?? normalized;
+}
+
+function makeUntrackedEntry(
+  cwd: string,
+  repoPath: string,
+): WorktreeOtherChangeEntry | undefined {
+  const normalizedRepoPath = normalizeGitRelativePath(repoPath);
+  if (!normalizedRepoPath || normalizedRepoPath.endsWith("/")) {
+    return undefined;
+  }
+  return {
+    path: normalizeAbsolutePath(path.resolve(cwd, normalizedRepoPath)),
+    repoPath: normalizedRepoPath,
+    status: "untracked",
+    staged: false,
+    unstaged: true,
+  };
+}
+
+function parseLimitedNulRecords(
+  output: string,
+  limit: number,
+  includeRepoPath: UntrackedPathFilter = () => true,
+): { records: string[]; truncated: boolean } {
+  const records = output
+    .split("\0")
+    .map(normalizeGitRelativePath)
+    .filter((record) => record && includeRepoPath(record));
+  return {
+    records: records.slice(0, limit),
+    truncated: records.length > limit,
+  };
+}
+
 function parseNumstatByPath(
   output: string,
 ): Map<string, { additions?: number; removals?: number; binary?: boolean }> {
@@ -288,6 +336,150 @@ async function enrichUntrackedChangeStats(
     // Summary stats are best-effort; expansion can still report a precise
     // omitted/unavailable reason for the single requested file.
   }
+}
+
+async function listUntrackedDirectoryFilesWithRunner(
+  cwd: string,
+  repoPath: string,
+  limit: number,
+  includeRepoPath: UntrackedPathFilter,
+  runGit: GitCommandRunner,
+  gitEnv?: NodeJS.ProcessEnv,
+): Promise<{ repoPaths: string[]; truncated: boolean }> {
+  const output = await runGit(
+    cwd,
+    [
+      "--no-optional-locks",
+      "ls-files",
+      "--others",
+      "--exclude-standard",
+      "-z",
+      "--",
+      repoPath,
+    ],
+    gitEnv,
+  ).catch(() => "");
+  const parsed = parseLimitedNulRecords(output, limit, includeRepoPath);
+  return {
+    repoPaths: parsed.records,
+    truncated: parsed.truncated,
+  };
+}
+
+async function listUntrackedDirectoryFilesLimited(
+  cwd: string,
+  repoPath: string,
+  limit: number,
+  includeRepoPath: UntrackedPathFilter,
+  gitEnv?: NodeJS.ProcessEnv,
+): Promise<{ repoPaths: string[]; truncated: boolean }> {
+  if (limit <= 0) {
+    return { repoPaths: [], truncated: true };
+  }
+
+  const git = await resolveGitExecutable(gitEnv ?? process.env);
+  return await new Promise((resolve) => {
+    const repoPaths: string[] = [];
+    let pending = "";
+    let bytesRead = 0;
+    let truncated = false;
+    let settled = false;
+
+    const child = spawn(
+      git,
+      [
+        "-C",
+        cwd,
+        "--no-optional-locks",
+        "ls-files",
+        "--others",
+        "--exclude-standard",
+        "-z",
+        "--",
+        repoPath,
+      ],
+      { env: gitEnv ?? process.env },
+    );
+
+    const finish = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      resolve({ repoPaths: repoPaths.slice(0, limit), truncated });
+    };
+
+    const stop = () => {
+      truncated = true;
+      child.kill();
+    };
+
+    const timeout = setTimeout(stop, UNTRACKED_DIRECTORY_EXPANSION_TIMEOUT_MS);
+
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      if (settled || truncated) {
+        return;
+      }
+      bytesRead += Buffer.byteLength(chunk);
+      pending += chunk;
+
+      let separatorIndex = pending.indexOf("\0");
+      while (separatorIndex >= 0) {
+        const record = pending.slice(0, separatorIndex);
+        pending = pending.slice(separatorIndex + 1);
+        const normalized = normalizeGitRelativePath(record);
+        if (normalized && includeRepoPath(normalized)) {
+          repoPaths.push(normalized);
+          if (repoPaths.length > limit) {
+            stop();
+            return;
+          }
+        }
+        separatorIndex = pending.indexOf("\0");
+      }
+
+      if (bytesRead > UNTRACKED_DIRECTORY_EXPANSION_MAX_BYTES) {
+        stop();
+      }
+    });
+    child.once("error", finish);
+    child.once("close", finish);
+  });
+}
+
+async function expandUntrackedDirectoryEntry(
+  cwd: string,
+  entry: WorktreeOtherChangeEntry,
+  limit: number,
+  includeRepoPath: UntrackedPathFilter,
+  runGit: GitCommandRunner,
+  gitEnv?: NodeJS.ProcessEnv,
+): Promise<{ changes: WorktreeOtherChangeEntry[]; truncated: boolean }> {
+  const listing =
+    runGit === defaultRunGit
+      ? await listUntrackedDirectoryFilesLimited(
+          cwd,
+          entry.repoPath,
+          limit,
+          includeRepoPath,
+          gitEnv,
+        )
+      : await listUntrackedDirectoryFilesWithRunner(
+          cwd,
+          entry.repoPath,
+          limit,
+          includeRepoPath,
+          runGit,
+          gitEnv,
+        );
+  return {
+    changes: listing.repoPaths
+      .map((repoPath) => makeUntrackedEntry(cwd, repoPath))
+      .filter((change): change is WorktreeOtherChangeEntry => Boolean(change)),
+    truncated: listing.truncated,
+  };
 }
 
 async function summarizeUntrackedChanges(
@@ -561,8 +753,8 @@ export class GitWorkingStateService {
   /**
    * List worktree changes that are not already represented by turn-level
    * edited-file groups. This is intentionally summary-only: file count is
-   * capped, untracked directories stay collapsed by git's default status mode,
-   * and no patch text is generated here.
+   * capped overall and per top-level directory, collapsed untracked directories
+   * are expanded only up to those caps, and no patch text is generated here.
    */
   async listOtherChanges(
     worktreePath: string,
@@ -600,10 +792,80 @@ export class GitWorkingStateService {
         .filter(Boolean)
         .map(normalizeAbsolutePath),
     );
-    const allChanges = parseStatusPorcelain(output, cwd).filter(
-      (entry) => !excluded.has(normalizeAbsolutePath(entry.path)),
-    );
+    const includeRepoPath = (repoPath: string): boolean =>
+      !excluded.has(normalizeAbsolutePath(path.resolve(cwd, repoPath)));
+    const allChanges: WorktreeOtherChangeEntry[] = [];
+    const changesByTopLevel = new Map<string, number>();
+    let stoppedBeforeEnd = false;
+    let expansionTruncated = false;
+    let topLevelTruncated = false;
+    const addChange = (
+      entry: WorktreeOtherChangeEntry,
+    ): "added" | "total-capped" | "top-level-capped" => {
+      if (allChanges.length >= maxFiles + 1) {
+        return "total-capped";
+      }
+      const bucket = topLevelChangeBucket(entry.repoPath);
+      const bucketCount = changesByTopLevel.get(bucket) ?? 0;
+      if (bucketCount >= OTHER_CHANGES_MAX_FILES_PER_TOP_LEVEL) {
+        return "top-level-capped";
+      }
+      changesByTopLevel.set(bucket, bucketCount + 1);
+      allChanges.push(entry);
+      return "added";
+    };
+    const parsedChanges = parseStatusPorcelain(output, cwd);
+    for (const entry of parsedChanges) {
+      if (excluded.has(normalizeAbsolutePath(entry.path))) {
+        continue;
+      }
+      if (!isCollapsedUntrackedDirectoryEntry(entry)) {
+        const result = addChange(entry);
+        if (result === "top-level-capped") {
+          topLevelTruncated = true;
+        }
+      } else {
+        const bucket = topLevelChangeBucket(entry.repoPath);
+        const remainingForTopLevel =
+          OTHER_CHANGES_MAX_FILES_PER_TOP_LEVEL -
+          (changesByTopLevel.get(bucket) ?? 0);
+        if (remainingForTopLevel <= 0) {
+          topLevelTruncated = true;
+          continue;
+        }
+        const remaining = Math.min(
+          maxFiles + 1 - allChanges.length,
+          remainingForTopLevel + 1,
+        );
+        const expanded = await expandUntrackedDirectoryEntry(
+          cwd,
+          entry,
+          remaining,
+          includeRepoPath,
+          this.runGit,
+          this.gitEnv,
+        );
+        expansionTruncated ||= expanded.truncated;
+        for (const expandedEntry of expanded.changes) {
+          const result = addChange(expandedEntry);
+          if (result === "top-level-capped") {
+            topLevelTruncated = true;
+          }
+          if (result !== "added") {
+            break;
+          }
+        }
+      }
+      if (allChanges.length > maxFiles) {
+        stoppedBeforeEnd = true;
+        break;
+      }
+    }
     const visible = allChanges.slice(0, maxFiles);
+    const totalChanges =
+      (expansionTruncated || topLevelTruncated) && allChanges.length <= maxFiles
+        ? allChanges.length + 1
+        : allChanges.length;
 
     const trackedPaths = visible
       .filter((entry) => entry.status !== "untracked")
@@ -639,8 +901,12 @@ export class GitWorkingStateService {
 
     return {
       changes: visible,
-      totalChanges: allChanges.length,
-      truncated: allChanges.length > visible.length,
+      totalChanges,
+      truncated:
+        expansionTruncated ||
+        topLevelTruncated ||
+        stoppedBeforeEnd ||
+        allChanges.length > visible.length,
       maxFiles,
     };
   }
@@ -685,7 +951,7 @@ export class GitWorkingStateService {
       try {
         const fileStat = await stat(absolutePath);
         if (!fileStat.isFile()) {
-          omittedReason = "Diff omitted for untracked directory.";
+          return {};
         } else if (fileStat.size > maxBytes) {
           omittedReason = `Diff omitted for large untracked file (${fileStat.size.toLocaleString()} bytes).`;
         } else {


### PR DESCRIPTION
## Summary

The Edits panel no longer shows a collapsed untracked directory such as `.tmp/` as an edited file. Before this fix, Git's default untracked status mode could report a whole directory, which PwrAgent rendered as a file-like "Other" change with no useful diff.

The working-state service still keeps the broad Git status scan in collapsed-directory mode for safety, then expands collapsed untracked directories only far enough to fill the UI caps. The list is bounded overall, bounded to 20 displayed files per top-level directory, and the directory expansion subprocess is also bounded by output bytes and a short timeout.

Repo-local `.tmp/` output is ignored so generated monitor logs do not pollute the edited-files list.

## Test Plan

- `pnpm test apps/desktop/src/main/__tests__/git-working-state-service.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
