### PR TITLE
fix(desktop): stop and dock dev action runs

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -8359,6 +8359,118 @@ command = '''node -e "require('node:fs').writeFileSync(process.argv[1], 'action-
     }
   });
 
+  it("restores an ambiguously failed detached action to running when output continues", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-thread-env-live-output-"));
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          codexEnvironmentRuntime: {
+            environmentId: "environment",
+            environmentName: "PwrAgnt",
+            executionTarget: "local",
+            cwd: root,
+            setupEnabled: false,
+            actions: [
+              {
+                id: "dev",
+                name: "Dev",
+                command: "pnpm dev",
+              },
+            ],
+          },
+        },
+      },
+    });
+    let commandParams: Parameters<CodexEnvironmentCommandRunner>[0] | undefined;
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/list"] },
+        threads: [],
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+      codexEnvironmentCommandRunner: vi.fn(async (params) => {
+        commandParams = params;
+        return { pid: 12345 };
+      }),
+    });
+
+    try {
+      const response = await registry.runCodexEnvironmentAction({
+        backend: "codex",
+        threadId: "thread-1",
+        actionId: "dev",
+      });
+      const runId = response.codexEnvironmentRuntime?.actionRuns?.[0]?.runId;
+      expect(runId).toBeTruthy();
+      expect(commandParams).toBeTruthy();
+
+      commandParams?.onDetachedOutput?.({ output: "booting" });
+      await expectEventually(
+        async () =>
+          (
+            await overlayStore.getThreadOverlayState({
+              backend: "codex",
+              threadId: "thread-1",
+            })
+          )?.codexEnvironmentRuntime?.actionRuns?.[0]?.output,
+        "booting",
+      );
+
+      commandParams?.onDetachedExit?.({
+        exitCode: null,
+        exitSignal: null,
+        durationMs: 7_000,
+        output: "booting",
+      });
+      await expectEventually(
+        async () =>
+          (
+            await overlayStore.getThreadOverlayState({
+              backend: "codex",
+              threadId: "thread-1",
+            })
+          )?.codexEnvironmentRuntime?.actionRuns?.[0]?.status,
+        "failed",
+      );
+
+      commandParams?.onDetachedOutput?.({ output: "booting\nready" });
+      await expectEventually(
+        async () =>
+          (
+            await overlayStore.getThreadOverlayState({
+              backend: "codex",
+              threadId: "thread-1",
+            })
+          )?.codexEnvironmentRuntime?.actionRuns?.[0]?.status,
+        "started",
+      );
+      const overlay = await overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-1",
+      });
+      const run = overlay?.codexEnvironmentRuntime?.actionRuns?.[0];
+      expect(run).toMatchObject({
+        runId,
+        status: "started",
+        output: "booting\nready",
+      });
+      expect(run?.durationMs).toBeUndefined();
+      expect(run?.exitedAt).toBeUndefined();
+      expect(run?.exitCode).toBeUndefined();
+      expect(run?.exitSignal).toBeUndefined();
+    } finally {
+      await registry.close();
+      await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    }
+  });
+
   it("attributes output to the right run when two env actions run concurrently on the same thread", async () => {
     // Multi-instance regression test: Start + Test (or E2E + Unit) workflows
     // require independent run tracking, otherwise a second concurrent run

--- a/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
@@ -7,6 +7,7 @@ import {
   buildExitErrorSuffix,
   CODEX_ENVIRONMENT_SETUP_TIMEOUT_MS_ENV,
   startLocalCodexEnvironmentAction,
+  stopCodexEnvironmentDetachedCommand,
 } from "../app-server/codex-environment-runtime";
 import { resolveWindowsBashShell } from "../windows-shell";
 
@@ -163,6 +164,53 @@ describe("codex environment runtime", () => {
           "stdout third",
           "stderr fourth",
         ].join("\n"),
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    }
+  }, 15_000);
+
+  it("stops a detached action process tree by run id", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-env-stop-"));
+    const runId = "test-run-stop";
+    try {
+      const detachedExit = new Promise<{ exitSignal: NodeJS.Signals | null }>(
+        (resolve, reject) => {
+          void startLocalCodexEnvironmentAction({
+            actionId: "start-dev",
+            runId,
+            env: {
+              ...process.env,
+              SHELL: spawnableShell("/bin/sh"),
+            },
+            onDetachedExit: resolve,
+            runtime: {
+              environmentId: "env",
+              environmentName: "Env",
+              executionTarget: "local",
+              cwd: root,
+              actions: [
+                {
+                  id: "start-dev",
+                  name: "Start dev",
+                  command: "while true; do sleep 1; done",
+                },
+              ],
+            },
+          }).catch(reject);
+        },
+      );
+
+      await expectEventually(async () => {
+        const result = stopCodexEnvironmentDetachedCommand(runId, "stop");
+        if (!result.found) {
+          throw new Error("Detached process is not registered yet");
+        }
+        return result;
+      });
+
+      await expect(detachedExit).resolves.toMatchObject({
+        exitSignal: expect.any(String),
       });
     } finally {
       await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });

--- a/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
@@ -209,9 +209,16 @@ describe("codex environment runtime", () => {
         return result;
       });
 
-      await expect(detachedExit).resolves.toMatchObject({
-        exitSignal: expect.any(String),
-      });
+      if (isWindows) {
+        await expect(detachedExit).resolves.toMatchObject({
+          exitCode: expect.any(Number),
+          exitSignal: null,
+        });
+      } else {
+        await expect(detachedExit).resolves.toMatchObject({
+          exitSignal: expect.any(String),
+        });
+      }
     } finally {
       await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     }

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -78,6 +78,8 @@ import {
   type RetainThreadBranchDriftResponse,
   type RunCodexEnvironmentActionRequest,
   type RunCodexEnvironmentActionResponse,
+  type StopCodexEnvironmentActionRequest,
+  type StopCodexEnvironmentActionResponse,
   type SetCodexThreadEnvironmentRequest,
   type SetCodexThreadEnvironmentResponse,
   type SetAcpSessionRuntimeOptionRequest,
@@ -264,6 +266,7 @@ import {
   applyLocalCodexEnvironmentSelection,
   CodexEnvironmentStartupError,
   startLocalCodexEnvironmentAction,
+  stopCodexEnvironmentDetachedCommand,
   type CodexEnvironmentCommandRunner,
   type CodexEnvironmentDetachedExit,
   type CodexEnvironmentDetachedOutput,
@@ -8459,6 +8462,82 @@ export class DesktopBackendRegistry {
           threadId: request.threadId,
           codexEnvironmentRuntime: nextRuntime,
         });
+
+        return {
+          backend: request.backend,
+          threadId: request.threadId,
+          codexEnvironmentRuntime: nextRuntime,
+        };
+      },
+    );
+  }
+
+  async stopCodexEnvironmentAction(
+    request: StopCodexEnvironmentActionRequest,
+  ): Promise<StopCodexEnvironmentActionResponse> {
+    return this.withCodexEnvironmentRuntimeLock(
+      request.backend,
+      request.threadId,
+      async () => {
+        const overlay = await this.overlayStore.getThreadOverlayState({
+          backend: request.backend,
+          threadId: request.threadId,
+        });
+        const runtime = overlay?.codexEnvironmentRuntime;
+        if (!runtime) {
+          throw new Error("This thread does not have a selected environment.");
+        }
+
+        const currentRuns = readCodexEnvironmentActionRuns(runtime);
+        const matchingRun = currentRuns.find((run) => run.runId === request.runId);
+        if (!matchingRun) {
+          throw new Error("This environment action run is no longer available.");
+        }
+        if (matchingRun.status !== "started") {
+          return {
+            backend: request.backend,
+            threadId: request.threadId,
+            codexEnvironmentRuntime: runtime,
+          };
+        }
+
+        const nextRuns = applyCodexEnvironmentActionRunUpdate(currentRuns, {
+          kind: "patch",
+          runId: request.runId,
+          patch: {
+            terminationMode: request.mode,
+            terminationRequestedAt:
+              matchingRun.terminationRequestedAt ?? Date.now(),
+          },
+        });
+        const nextRuntime: CodexThreadEnvironmentRuntime = {
+          ...runtime,
+          actionRuns: nextRuns,
+        };
+        await this.overlayStore.setThreadCodexEnvironmentRuntime?.({
+          backend: request.backend,
+          threadId: request.threadId,
+          codexEnvironmentRuntime: nextRuntime,
+        });
+        this.invalidateThreadListCache(request.backend);
+        await this.emitCodexEnvironmentRuntimeUpdated({
+          backend: request.backend,
+          threadId: request.threadId,
+          codexEnvironmentRuntime: nextRuntime,
+        });
+
+        const result = stopCodexEnvironmentDetachedCommand(
+          request.runId,
+          request.mode,
+        );
+        if (!result.found) {
+          backendRegistryLog.warn("codex-environment-action-stop-missing-process", {
+            backend: request.backend,
+            threadId: request.threadId,
+            runId: request.runId,
+            mode: request.mode,
+          });
+        }
 
         return {
           backend: request.backend,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -43,6 +43,7 @@ import {
   type BackendAcpRuntimeOptionSource,
   type BackendAcpSessionRuntimeState,
   type BackendCapabilities,
+  type CodexEnvironmentActionRun,
   type CodexEnvironmentOption,
   type CodexEnvironmentSetupProgressEvent,
   type CodexThreadEnvironmentRuntime,
@@ -8824,10 +8825,25 @@ export class DesktopBackendRegistry {
           if (matching.output === params.event.output) {
             return;
           }
+          // A null/null close can come from a wrapper path while the useful
+          // descendant is still producing output. Fresh output proves the run
+          // is not terminal, so keep the UI in a controllable running state.
+          const ambiguousTerminalFailure =
+            matching.status === "failed" &&
+            matching.exitCode === undefined &&
+            matching.exitSignal === undefined;
+          const patch: Partial<CodexEnvironmentActionRun> = {
+            output: params.event.output,
+          };
+          if (ambiguousTerminalFailure) {
+            patch.status = "started";
+            patch.durationMs = undefined;
+            patch.exitedAt = undefined;
+          }
           const nextRuns = applyCodexEnvironmentActionRunUpdate(currentRuns, {
             kind: "patch",
             runId: params.runId,
-            patch: { output: params.event.output },
+            patch,
           });
           const next: CodexThreadEnvironmentRuntime = {
             ...current,

--- a/apps/desktop/src/main/app-server/codex-environment-runtime.ts
+++ b/apps/desktop/src/main/app-server/codex-environment-runtime.ts
@@ -582,9 +582,13 @@ function runShellCommand(
           // (the actual command, e.g. `sleep`) linger, which keeps the `close`
           // event from firing (timeouts hang) and holds handles on the
           // workspace temp dir (EBUSY on cleanup). Kill the whole process tree.
-          spawnSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
-            stdio: "ignore",
-          });
+          // Match POSIX stop semantics: SIGTERM gets a non-forced taskkill,
+          // while SIGKILL is the immediate/fallback forced termination.
+          const taskkillArgs = ["/pid", String(child.pid), "/t"];
+          if (signal === "SIGKILL") {
+            taskkillArgs.push("/f");
+          }
+          spawnSync("taskkill", taskkillArgs, { stdio: "ignore" });
         }
       } catch (error) {
         environmentRuntimeLog.warn("codex-environment-command-kill-failed", {

--- a/apps/desktop/src/main/app-server/codex-environment-runtime.ts
+++ b/apps/desktop/src/main/app-server/codex-environment-runtime.ts
@@ -135,6 +135,11 @@ export type CodexEnvironmentCommandParams = {
    * `onDetachedExit.output`, so callers don't need to merge.
    */
   onDetachedOutput?: (event: CodexEnvironmentDetachedOutput) => void;
+  /**
+   * Stable key used by the UI/backend to stop a detached process tree.
+   * Intended to be the action runId.
+   */
+  detachedTerminationKey?: string;
 };
 
 export type CodexEnvironmentDetachedExit = {
@@ -150,6 +155,7 @@ export type CodexEnvironmentDetachedOutput = {
 };
 
 export const DETACHED_OUTPUT_SNAPSHOT_MS = 500;
+const DETACHED_STOP_SIGKILL_GRACE_MS = 2_000;
 
 export type CodexEnvironmentCommandResult = {
   durationMs?: number;
@@ -167,6 +173,53 @@ type ShellEnvironmentCaptureTarget = {
 export type CodexEnvironmentCommandRunner = (
   params: CodexEnvironmentCommandParams,
 ) => Promise<CodexEnvironmentCommandResult>;
+
+type DetachedCommandProcess = {
+  killTree: (signal: NodeJS.Signals) => void;
+  closed: () => boolean;
+  killHandle?: NodeJS.Timeout;
+};
+
+const detachedCommandProcesses = new Map<string, DetachedCommandProcess>();
+
+export type CodexEnvironmentDetachedCommandStopMode = "stop" | "terminate";
+
+export type CodexEnvironmentDetachedCommandStopResult = {
+  found: boolean;
+  alreadyClosed: boolean;
+};
+
+export function stopCodexEnvironmentDetachedCommand(
+  terminationKey: string,
+  mode: CodexEnvironmentDetachedCommandStopMode,
+): CodexEnvironmentDetachedCommandStopResult {
+  const processEntry = detachedCommandProcesses.get(terminationKey);
+  if (!processEntry) {
+    return { found: false, alreadyClosed: false };
+  }
+  if (processEntry.closed()) {
+    detachedCommandProcesses.delete(terminationKey);
+    return { found: true, alreadyClosed: true };
+  }
+
+  if (processEntry.killHandle) {
+    clearTimeout(processEntry.killHandle);
+    processEntry.killHandle = undefined;
+  }
+
+  if (mode === "terminate") {
+    processEntry.killTree("SIGKILL");
+    return { found: true, alreadyClosed: false };
+  }
+
+  processEntry.killTree("SIGTERM");
+  processEntry.killHandle = setTimeout(() => {
+    if (!processEntry.closed()) {
+      processEntry.killTree("SIGKILL");
+    }
+  }, DETACHED_STOP_SIGKILL_GRACE_MS);
+  return { found: true, alreadyClosed: false };
+}
 
 export async function applyLocalCodexEnvironmentSelection(params: {
   commandRunner?: CodexEnvironmentCommandRunner;
@@ -347,6 +400,7 @@ export async function applyLocalCodexEnvironmentSelection(params: {
         command: selection.action.command,
         env: actionEnv,
         mode: "detach",
+        detachedTerminationKey: runId,
         onDetachedExit: params.onActionDetachedExit,
         onDetachedOutput: params.onActionDetachedOutput,
       });
@@ -425,6 +479,7 @@ export async function startLocalCodexEnvironmentAction(params: {
       command: action.command,
       env: actionEnv,
       mode: "detach",
+      detachedTerminationKey: params.runId,
       onDetachedExit: params.onDetachedExit,
       onDetachedOutput: params.onDetachedOutput,
     });
@@ -538,6 +593,16 @@ function runShellCommand(
           message: error instanceof Error ? error.message : String(error),
         });
       }
+    };
+
+    const registerDetachedProcess = () => {
+      if (params.mode !== "detach" || !params.detachedTerminationKey) {
+        return;
+      }
+      detachedCommandProcesses.set(params.detachedTerminationKey, {
+        killTree: terminateChild,
+        closed: () => closed,
+      });
     };
 
     const settle = (callback: () => void) => {
@@ -673,6 +738,7 @@ function runShellCommand(
 
     if (params.mode === "detach") {
       child.once("spawn", () => {
+        registerDetachedProcess();
         // Let the parent exit independently of this child. child.unref()
         // alone doesn't suffice when stdio is "pipe": the libuv pipe
         // handles on child.stdout/stderr also keep the parent's event
@@ -707,6 +773,16 @@ function runShellCommand(
       // onDetachedExit so callers can persist the exit details to
       // overlay state for the anchored env-action output UI.
       child.once("close", (code, signal) => {
+        closed = true;
+        if (params.detachedTerminationKey) {
+          const processEntry = detachedCommandProcesses.get(
+            params.detachedTerminationKey,
+          );
+          if (processEntry?.killHandle) {
+            clearTimeout(processEntry.killHandle);
+          }
+          detachedCommandProcesses.delete(params.detachedTerminationKey);
+        }
         // Cancel any pending throttled snapshot so it doesn't race past
         // onDetachedExit's final-output write to the overlay.
         if (snapshotTimer) {

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -24,6 +24,8 @@ import {
   type RetainThreadBranchDriftResponse,
   type RunCodexEnvironmentActionRequest,
   type RunCodexEnvironmentActionResponse,
+  type StopCodexEnvironmentActionRequest,
+  type StopCodexEnvironmentActionResponse,
   type SetAcpSessionRuntimeOptionRequest,
   type SetAcpSessionRuntimeOptionResponse,
   type SetCodexThreadEnvironmentRequest,
@@ -61,6 +63,7 @@ import {
   AGENT_QUEUE_THREAD_EXECUTION_MODE_CHANNEL,
   AGENT_RETAIN_THREAD_BRANCH_DRIFT_CHANNEL,
   AGENT_RUN_CODEX_ENVIRONMENT_ACTION_CHANNEL,
+  AGENT_STOP_CODEX_ENVIRONMENT_ACTION_CHANNEL,
   AGENT_SET_CODEX_THREAD_ENVIRONMENT_CHANNEL,
   AGENT_SET_ACP_SESSION_RUNTIME_OPTION_CHANNEL,
   AGENT_SET_THREAD_EXECUTION_MODE_CHANNEL,
@@ -607,6 +610,17 @@ export function registerAgentIpcHandlers(): void {
     },
   );
 
+  ipcMain.removeHandler(AGENT_STOP_CODEX_ENVIRONMENT_ACTION_CHANNEL);
+  ipcMain.handle(
+    AGENT_STOP_CODEX_ENVIRONMENT_ACTION_CHANNEL,
+    async (
+      _event,
+      request: StopCodexEnvironmentActionRequest,
+    ): Promise<StopCodexEnvironmentActionResponse> => {
+      return await registry.stopCodexEnvironmentAction(request);
+    },
+  );
+
   ipcMain.removeHandler(AGENT_SET_CODEX_THREAD_ENVIRONMENT_CHANNEL);
   ipcMain.handle(
     AGENT_SET_CODEX_THREAD_ENVIRONMENT_CHANNEL,
@@ -670,6 +684,7 @@ export function disposeAgentIpcHandlers(): void {
   ipcMain.removeHandler(AGENT_RETAIN_THREAD_BRANCH_DRIFT_CHANNEL);
   ipcMain.removeHandler(AGENT_MATERIALIZE_DIRECTORY_LAUNCHPAD_CHANNEL);
   ipcMain.removeHandler(AGENT_RUN_CODEX_ENVIRONMENT_ACTION_CHANNEL);
+  ipcMain.removeHandler(AGENT_STOP_CODEX_ENVIRONMENT_ACTION_CHANNEL);
   ipcMain.removeHandler(AGENT_SET_CODEX_THREAD_ENVIRONMENT_CHANNEL);
   ipcMain.removeHandler(AGENT_SUBMIT_SERVER_REQUEST_CHANNEL);
   ipcMain.removeHandler(AGENT_TRUST_CODEX_PROJECT_CHANNEL);

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -121,6 +121,7 @@ export type DesktopSettingsConfig = {
     contextRailPinned?: boolean;
     activeContextTab?: string;
     editedFilesDock?: string;
+    actionRunsDock?: string;
   };
   messaging?: {
     enabled?: boolean;
@@ -818,6 +819,13 @@ export function desktopSettingsPatchToEdits(
       set(["ui", "edited_files_dock"], patch.ui.editedFilesDock);
     }
   }
+  if (patch.ui?.actionRunsDock !== undefined) {
+    if (patch.ui.actionRunsDock === "above") {
+      edits.push({ op: "delete", path: ["ui", "action_runs_dock"] });
+    } else {
+      set(["ui", "action_runs_dock"], patch.ui.actionRunsDock);
+    }
+  }
 
   if (patch.messaging?.inputDebounceMs !== undefined) {
     set(["messaging", "input_debounce_ms"], patch.messaging.inputDebounceMs);
@@ -1276,6 +1284,7 @@ function normalizeDesktopConfig(
       contextRailPinned: readBoolean(ui?.context_rail_pinned),
       activeContextTab: readString(ui?.active_context_tab),
       editedFilesDock: readString(ui?.edited_files_dock),
+      actionRunsDock: readString(ui?.action_runs_dock),
     },
     messaging: {
       enabled: readBoolean(messaging?.enabled),

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -618,6 +618,10 @@ export class DesktopSettingsService {
           value: config.ui?.editedFilesDock ?? "above",
           source: config.ui?.editedFilesDock === undefined ? "default" : "config",
         },
+        actionRunsDock: {
+          value: config.ui?.actionRunsDock ?? "above",
+          source: config.ui?.actionRunsDock === undefined ? "default" : "config",
+        },
       },
       messaging: {
         enabled: this.resolveConfigBoolean(config.messaging?.enabled, true),

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -130,6 +130,8 @@ import type {
   RenameThreadResponse,
   RunCodexEnvironmentActionRequest,
   RunCodexEnvironmentActionResponse,
+  StopCodexEnvironmentActionRequest,
+  StopCodexEnvironmentActionResponse,
   SetCodexThreadEnvironmentRequest,
   SetCodexThreadEnvironmentResponse,
   RestoreWorktreeRequest,
@@ -240,6 +242,7 @@ import {
   AGENT_QUEUE_THREAD_EXECUTION_MODE_CHANNEL,
   AGENT_RETAIN_THREAD_BRANCH_DRIFT_CHANNEL,
   AGENT_RUN_CODEX_ENVIRONMENT_ACTION_CHANNEL,
+  AGENT_STOP_CODEX_ENVIRONMENT_ACTION_CHANNEL,
   AGENT_SET_CODEX_THREAD_ENVIRONMENT_CHANNEL,
   AGENT_SET_ACP_SESSION_RUNTIME_OPTION_CHANNEL,
   AGENT_SET_THREAD_EXECUTION_MODE_CHANNEL,
@@ -934,6 +937,13 @@ const desktopApi = Object.freeze({
   ): Promise<RunCodexEnvironmentActionResponse> =>
     await ipcRenderer.invoke(
       AGENT_RUN_CODEX_ENVIRONMENT_ACTION_CHANNEL,
+      request,
+    ),
+  stopCodexEnvironmentAction: async (
+    request: StopCodexEnvironmentActionRequest,
+  ): Promise<StopCodexEnvironmentActionResponse> =>
+    await ipcRenderer.invoke(
+      AGENT_STOP_CODEX_ENVIRONMENT_ACTION_CHANNEL,
       request,
     ),
   setCodexThreadEnvironment: async (

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -32,9 +32,12 @@ import {
 import type { ThreadViewProps } from "./features/thread-detail/ThreadView";
 import {
   DEFAULT_CONTEXT_TAB,
+  DEFAULT_ACTION_RUNS_DOCK,
   DEFAULT_EDITED_FILES_DOCK,
+  isActionRunsDock,
   isContextTabId,
   isEditedFilesDock,
+  type ActionRunsDock,
   type ContextTabId,
   type EditedFilesDock,
 } from "./features/thread-detail/context-panels/context-tab";
@@ -194,6 +197,9 @@ function DesktopAppShell(props: {
     useState<ContextTabId>(DEFAULT_CONTEXT_TAB);
   const [editedFilesDock, setEditedFilesDock] = useState<EditedFilesDock>(
     DEFAULT_EDITED_FILES_DOCK,
+  );
+  const [actionRunsDock, setActionRunsDock] = useState<ActionRunsDock>(
+    DEFAULT_ACTION_RUNS_DOCK,
   );
   const [mainView, setMainView] = useState<
     "thread" | "settings" | "automations" | "search"
@@ -415,6 +421,13 @@ function DesktopAppShell(props: {
     },
     [writeConfig],
   );
+  const setActionRunsDockPersisted = useCallback(
+    (dock: ActionRunsDock) => {
+      setActionRunsDock(dock);
+      void writeConfig({ ui: { actionRunsDock: dock } });
+    },
+    [writeConfig],
+  );
 
   // Adopt the persisted layout prefs once the settings snapshot arrives.
   // Guarded so later snapshot refreshes never clobber an in-session toggle.
@@ -433,6 +446,10 @@ function DesktopAppShell(props: {
     const editedFilesDockPref = uiPrefs.editedFilesDock?.value;
     if (isEditedFilesDock(editedFilesDockPref)) {
       setEditedFilesDock(editedFilesDockPref);
+    }
+    const actionRunsDockPref = uiPrefs.actionRunsDock?.value;
+    if (isActionRunsDock(actionRunsDockPref)) {
+      setActionRunsDock(actionRunsDockPref);
     }
   }, [uiPrefs]);
 
@@ -863,6 +880,8 @@ function DesktopAppShell(props: {
     onActiveContextTabChange: setActiveContextTabPersisted,
     editedFilesDock,
     onEditedFilesDockChange: setEditedFilesDockPersisted,
+    actionRunsDock,
+    onActionRunsDockChange: setActionRunsDockPersisted,
     sidebarHidden,
     onToggleSidebar: () => setSidebarHiddenPersisted(!sidebarHidden),
     mastheadActions,

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -466,6 +466,7 @@ describe("App", () => {
         contextRailPinned: { value: false, source: "default" },
         activeContextTab: { value: "info", source: "default" },
         editedFilesDock: { value: "above", source: "default" },
+        actionRunsDock: { value: "above", source: "default" },
       },
       messaging: {
         enabled: { value: true, source: "default" },

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -75,6 +75,12 @@ import { ComposerTiptapInput } from "./ComposerTiptapInput";
 import { ProjectPicker } from "./ProjectPicker";
 import { TranscriptCopyButton } from "../thread-detail/TranscriptCopyButton";
 import {
+  EnvActionRunEntry,
+  EnvActionRunsView,
+  formatDurationMs,
+  formatRunningDurationMs,
+} from "../thread-detail/EnvActionRunsView";
+import {
   useComposerDraftStore,
   type ComposerDraftSnapshot,
   type ComposerDraftStore,
@@ -127,6 +133,14 @@ type ComposerProps = {
   ) => Promise<void>;
   /** Discard this launchpad draft (the "Cancel" button next to "Start thread"). */
   onCancelLaunchpad?: (directoryKey: string) => void;
+  onMoveEnvActionsToSidebar?: () => void;
+  onDismissEnvActionRun?: (run: CodexEnvironmentActionRun) => void;
+  onStopEnvActionRun?: (
+    run: CodexEnvironmentActionRun,
+    mode: "stop" | "terminate"
+  ) => void;
+  hiddenEnvActionRunIds?: ReadonlySet<string>;
+  showEnvActionAnchors?: boolean;
   onBeforeSendTurn?: () => void;
   onPendingStatusChange?: (status?: string) => void;
   onRefreshNavigation?: () => Promise<void>;
@@ -576,56 +590,13 @@ function QueuedImageAttachments(props: {
   );
 }
 
-const ENV_ACTION_OUTPUT_MAX_LINES = 500;
 const ENV_ACTION_RUN_CONFIRMATION_MS = 5_000;
-
-function tailLines(text: string, maxLines: number): string {
-  const lines = text.split("\n");
-  if (lines.length <= maxLines) return text;
-  const dropped = lines.length - maxLines;
-  return [
-    `[…${dropped} earlier lines truncated]`,
-    ...lines.slice(-maxLines),
-  ].join("\n");
-}
-
-type EnvActionOutputChunk = {
-  id: number;
-  text: string;
-};
-
-type EnvActionOutputState = {
-  rawOutput: string;
-  chunks: EnvActionOutputChunk[];
-  nextChunkId: number;
-};
 
 type ThreadEnvActionStartingKey = {
   actionId: string;
   backend: NavigationThreadSummary["source"];
   threadId: string;
 };
-
-function buildEnvActionOutputState(
-  output: string,
-  nextChunkId = 1,
-): EnvActionOutputState {
-  const text = tailLines(output, ENV_ACTION_OUTPUT_MAX_LINES);
-  return {
-    rawOutput: output,
-    chunks: text ? [{ id: nextChunkId - 1, text }] : [],
-    nextChunkId,
-  };
-}
-
-function trimEnvActionOutputChunks(
-  chunks: EnvActionOutputChunk[],
-): EnvActionOutputChunk[] {
-  const text = chunks.map((chunk) => chunk.text).join("");
-  const trimmed = tailLines(text, ENV_ACTION_OUTPUT_MAX_LINES);
-  if (trimmed === text) return chunks;
-  return [{ id: chunks.at(-1)?.id ?? 0, text: trimmed }];
-}
 
 function sameThreadEnvActionStartingKey(
   left: ThreadEnvActionStartingKey | undefined,
@@ -639,60 +610,7 @@ function sameThreadEnvActionStartingKey(
   );
 }
 
-function elementContainsSelection(element: HTMLElement | null): boolean {
-  if (!element) return false;
-  const selection = element.ownerDocument.getSelection();
-  if (!selection || selection.rangeCount === 0 || selection.isCollapsed) {
-    return false;
-  }
-  for (let index = 0; index < selection.rangeCount; index += 1) {
-    const range = selection.getRangeAt(index);
-    if (
-      element.contains(range.startContainer) ||
-      element.contains(range.endContainer)
-    ) {
-      return true;
-    }
-  }
-  return false;
-}
-
-// Exported for unit testing; the existing call sites import via the
-// in-file identifier.
-export function formatDurationMs(
-  ms?: number,
-  options?: { coarseAfterMinute?: boolean },
-): string {
-  if (!ms || !Number.isFinite(ms)) return "";
-  if (ms < 1_000) return `${Math.round(ms)}ms`;
-  // Always integer seconds — the previous `toFixed(1)` for elapsed < 10s
-  // produced "0.9s" / "1.9s" displays that kept changing the last digit
-  // every render even when the second hadn't actually advanced.
-  const totalSeconds = Math.round(ms / 1_000);
-  if (totalSeconds < 60) return `${totalSeconds}s`;
-  // Convert via totalSeconds rather than `Math.round(seconds % 60)`,
-  // which would have flipped `seconds=119.5` into `"1m 60s"` because of
-  // half-up rounding at the 60-second boundary.
-  const minutes = Math.floor(totalSeconds / 60);
-  // For live counters (e.g., the "running for Xm" anchor meta),
-  // coarseAfterMinute drops the seconds portion entirely past 1m so
-  // the display only changes on minute boundaries — otherwise the
-  // ticking "Xm Ys" with sub-minute updates was a distracting noise
-  // floor for long-running actions like `pnpm dev`. Static one-shot
-  // displays (e.g., "ran 2m 30s" on an already-exited run) leave the
-  // option off and keep full precision since the value never changes
-  // after first paint.
-  if (options?.coarseAfterMinute) return `${minutes}m`;
-  const remainder = totalSeconds % 60;
-  return remainder ? `${minutes}m ${remainder}s` : `${minutes}m`;
-}
-
-export function formatRunningDurationMs(ms?: number): string {
-  if (ms === undefined || !Number.isFinite(ms) || ms < 0) return "";
-  const totalSeconds = Math.floor(ms / 1_000);
-  if (totalSeconds < 1) return "0s";
-  return formatDurationMs(totalSeconds * 1_000);
-}
+export { formatDurationMs, formatRunningDurationMs };
 
 /**
  * Set of run identities the user has explicitly dismissed in this session.
@@ -717,9 +635,14 @@ const envActionAnchorSessionStartedAt = Date.now();
 // reach the anchor through the Composer.
 export function EnvActionAnchorList(props: {
   runtime?: Pick<CodexThreadEnvironmentRuntime, "actionRuns" | "environmentName"> | undefined;
+  hiddenRunIds?: ReadonlySet<string>;
+  onDismissRun?: (run: CodexEnvironmentActionRun) => void;
+  onMoveToSidebar?: () => void;
+  onStopRun?: (run: CodexEnvironmentActionRun, mode: "stop" | "terminate") => void;
 }): ReactNode {
   const runs = readCodexEnvironmentActionRuns(props.runtime);
   const visible = runs.filter((run) => {
+    if (props.hiddenRunIds?.has(run.runId)) return false;
     if (dismissedEnvActionAnchorKeys.has(run.runId)) return false;
     const latestActivityAt = Math.max(run.exitedAt ?? 0, run.startedAt ?? 0);
     // Anything not started during this renderer session is treated as
@@ -736,15 +659,6 @@ export function EnvActionAnchorList(props: {
     }
     return true;
   });
-  const hasVisibleStartedRun = visible.some((run) => run.status === "started");
-  const [, setElapsedTick] = useState(0);
-  useEffect(() => {
-    if (!hasVisibleStartedRun) return undefined;
-    const handle = setInterval(() => {
-      setElapsedTick((tick) => tick + 1);
-    }, 1_000);
-    return () => clearInterval(handle);
-  }, [hasVisibleStartedRun]);
   // Bumped after dismissal to force a re-render (the dismissed-set lives
   // outside React state).
   const [, setDismissTick] = useState(0);
@@ -752,19 +666,18 @@ export function EnvActionAnchorList(props: {
   if (visible.length === 0) return null;
 
   return (
-    <>
-      {visible.map((run) => (
-        <EnvActionAnchorEntry
-          key={run.runId}
-          run={run}
-          environmentName={props.runtime?.environmentName}
-          onDismiss={() => {
-            dismissedEnvActionAnchorKeys.add(run.runId);
-            setDismissTick((tick) => tick + 1);
-          }}
-        />
-      ))}
-    </>
+    <EnvActionRunsView
+      environmentName={props.runtime?.environmentName}
+      onDismiss={(run) => {
+        dismissedEnvActionAnchorKeys.add(run.runId);
+        props.onDismissRun?.(run);
+        setDismissTick((tick) => tick + 1);
+      }}
+      onMoveToSidebar={props.onMoveToSidebar}
+      onStop={props.onStopRun}
+      placement="composer"
+      runs={visible}
+    />
   );
 }
 
@@ -774,158 +687,16 @@ export function EnvActionAnchorEntry(props: {
   run: CodexEnvironmentActionRun;
   environmentName: string | undefined;
   onDismiss: () => void;
+  onStop?: (run: CodexEnvironmentActionRun, mode: "stop" | "terminate") => void;
 }): ReactNode {
-  const { run } = props;
-  const status = run.status;
-  const label =
-    status === "started"
-      ? "Env action running"
-      : status === "exited"
-        ? "Env action exited"
-        : "Env action failed";
-
-  const meta: string[] = [];
-  if (run.pid) meta.push(`pid ${run.pid}`);
-  if (status === "started" && typeof run.startedAt === "number") {
-    meta.push(
-      `running for ${formatRunningDurationMs(Date.now() - run.startedAt)}`,
-    );
-  }
-  if (status !== "started") {
-    if (typeof run.exitCode === "number") {
-      meta.push(`exit ${run.exitCode}`);
-    } else if (run.exitSignal) {
-      meta.push(`signal ${run.exitSignal}`);
-    }
-    if (run.durationMs) {
-      meta.push(`ran ${formatDurationMs(run.durationMs)}`);
-    }
-  }
-
-  const output = (run.output ?? "").trim();
-  const outputLineCount = output
-    ? tailLines(output, ENV_ACTION_OUTPUT_MAX_LINES).split("\n").length
-    : 0;
-  const modifier =
-    status === "failed"
-      ? "composer__queued--env-action-failed"
-      : status === "exited"
-        ? "composer__queued--env-action-exited"
-        : "composer__queued--env-action-running";
-
   return (
-    <details
-      className={`composer__queued composer__queued--env-action ${modifier}`}
-      aria-label={label}
-    >
-      <summary className="composer__queued-env-action-summary">
-        <span
-          className="composer__queued-env-action-chevron"
-          aria-hidden="true"
-        />
-        <span className="composer__queued-env-action-summary-text">
-          <span className="composer__queued-label">{label}</span>
-          <span className="composer__queued-text">
-            {run.actionName}
-            {props.environmentName ? ` · ${props.environmentName}` : ""}
-            {meta.length > 0 ? ` · ${meta.join(" · ")}` : ""}
-          </span>
-        </span>
-        <button
-          className="composer__secondary-action composer__queued-env-action-dismiss"
-          type="button"
-          onClick={(event) => {
-            // Prevent the click from toggling the surrounding <details>.
-            event.preventDefault();
-            event.stopPropagation();
-            props.onDismiss();
-          }}
-        >
-          Dismiss
-        </button>
-      </summary>
-      <div className="composer__queued-env-action-body">
-        {run.command ? (
-          <div className="composer__queued-env-action-section">
-            <div className="composer__queued-env-action-section-label">
-              Command
-            </div>
-            <pre className="composer__queued-env-action-command-block">
-              <code>$ {run.command}</code>
-            </pre>
-          </div>
-        ) : null}
-        <div className="composer__queued-env-action-section">
-          <div className="composer__queued-env-action-section-label">
-            Output
-            {outputLineCount
-              ? ` · ${outputLineCount} line${
-                  outputLineCount === 1 ? "" : "s"
-                }`
-              : ""}
-          </div>
-          <EnvActionOutputBlock output={output} status={status} />
-        </div>
-      </div>
-    </details>
-  );
-}
-
-function EnvActionOutputBlock(props: {
-  output: string;
-  status: CodexEnvironmentActionRun["status"];
-}): ReactNode {
-  const outputRef = useRef<HTMLPreElement | null>(null);
-  const [state, setState] = useState<EnvActionOutputState>(() =>
-    buildEnvActionOutputState(props.output),
-  );
-
-  useLayoutEffect(() => {
-    setState((current) => {
-      if (current.rawOutput === props.output) {
-        return current;
-      }
-
-      if (
-        current.rawOutput &&
-        props.output.startsWith(current.rawOutput)
-      ) {
-        const appended = props.output.slice(current.rawOutput.length);
-        if (!appended) {
-          return { ...current, rawOutput: props.output };
-        }
-        const nextChunks = [
-          ...current.chunks,
-          { id: current.nextChunkId, text: appended },
-        ];
-        return {
-          rawOutput: props.output,
-          chunks: elementContainsSelection(outputRef.current)
-            ? nextChunks
-            : trimEnvActionOutputChunks(nextChunks),
-          nextChunkId: current.nextChunkId + 1,
-        };
-      }
-
-      return buildEnvActionOutputState(props.output, current.nextChunkId + 1);
-    });
-  }, [props.output]);
-
-  const placeholder =
-    props.status === "started"
-      ? "(no output yet — waiting for the command to print something)"
-      : "(no output captured)";
-
-  return (
-    <pre className="composer__queued-env-action-output" ref={outputRef}>
-      <code>
-        {state.chunks.length > 0
-          ? state.chunks.map((chunk) => (
-              <span key={chunk.id}>{chunk.text}</span>
-            ))
-          : placeholder}
-      </code>
-    </pre>
+    <EnvActionRunEntry
+      environmentName={props.environmentName}
+      onDismiss={() => props.onDismiss()}
+      onStop={props.onStop}
+      placement="composer"
+      run={props.run}
+    />
   );
 }
 
@@ -5369,7 +5140,15 @@ export function Composer(props: ComposerProps) {
           above an input that already names itself was redundant
           chrome. */}
 
-      <EnvActionAnchorList runtime={props.thread?.codexEnvironmentRuntime} />
+      {props.showEnvActionAnchors === false ? null : (
+        <EnvActionAnchorList
+          runtime={props.thread?.codexEnvironmentRuntime}
+          hiddenRunIds={props.hiddenEnvActionRunIds}
+          onDismissRun={props.onDismissEnvActionRun}
+          onMoveToSidebar={props.onMoveEnvActionsToSidebar}
+          onStopRun={props.onStopEnvActionRun}
+        />
+      )}
 
       {pendingSteer ? (
         <div

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/EnvActionAnchorEntry.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/EnvActionAnchorEntry.test.tsx
@@ -35,7 +35,7 @@ function buildRun(
 
 describe("EnvActionAnchorEntry", () => {
   describe("status branches", () => {
-    it("renders the running label with always-visible Dismiss while started", () => {
+    it("renders the running label with Stop and Terminate while started", () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date(1_700_000_000_750));
       render(
@@ -48,11 +48,12 @@ describe("EnvActionAnchorEntry", () => {
       expect(
         screen.getByLabelText("Env action running"),
       ).toBeInTheDocument();
-      // Dismiss is always available now, regardless of status — a
-      // long-running action that the user no longer cares about
-      // should be clearable without having to wait for it to exit.
+      expect(screen.queryByRole("button", { name: "Dismiss" })).toBeNull();
       expect(
-        screen.getByRole("button", { name: "Dismiss" }),
+        screen.getByRole("button", { name: "Stop" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Terminate" }),
       ).toBeInTheDocument();
       // The pid meta and the command echo land in the same anchor.
       expect(screen.getByText(/pid 12345/)).toBeInTheDocument();
@@ -213,6 +214,38 @@ describe("EnvActionAnchorEntry", () => {
     });
   });
 
+  describe("stop interaction", () => {
+    it("invokes onStop with graceful stop when the user clicks Stop", () => {
+      const onStop = vi.fn();
+      const run = buildRun({ status: "started" });
+      render(
+        <EnvActionAnchorEntry
+          run={run}
+          environmentName={undefined}
+          onDismiss={() => {}}
+          onStop={onStop}
+        />,
+      );
+      fireEvent.click(screen.getByRole("button", { name: "Stop" }));
+      expect(onStop).toHaveBeenCalledWith(run, "stop");
+    });
+
+    it("invokes onStop with terminate when the user clicks Terminate", () => {
+      const onStop = vi.fn();
+      const run = buildRun({ status: "started" });
+      render(
+        <EnvActionAnchorEntry
+          run={run}
+          environmentName={undefined}
+          onDismiss={() => {}}
+          onStop={onStop}
+        />,
+      );
+      fireEvent.click(screen.getByRole("button", { name: "Terminate" }));
+      expect(onStop).toHaveBeenCalledWith(run, "terminate");
+    });
+  });
+
   describe("environment-name decoration", () => {
     it("appends environmentName when provided", () => {
       render(
@@ -321,26 +354,42 @@ describe("EnvActionAnchorList", () => {
     }
   });
 
-  it("stops ticking after the only running anchor is dismissed", async () => {
+  it("stops ticking after the only running anchor exits and is dismissed", async () => {
     const setIntervalSpy = vi.spyOn(window, "setInterval");
     const clearIntervalSpy = vi.spyOn(window, "clearInterval");
     try {
-      render(
+      const runtime = {
+        environmentName: "PwrAgnt",
+        actionRuns: [
+          buildRun({
+            runId: "dismissed-running-run",
+            startedAt: Date.now(),
+            status: "started",
+          }),
+        ],
+      };
+      const { rerender } = render(
         <EnvActionAnchorList
-          runtime={{
-            environmentName: "PwrAgnt",
-            actionRuns: [
-              buildRun({
-                runId: "dismissed-running-run",
-                startedAt: Date.now(),
-                status: "started",
-              }),
-            ],
-          }}
+          runtime={runtime}
         />,
       );
 
       expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 1_000);
+      rerender(
+        <EnvActionAnchorList
+          runtime={{
+            ...runtime,
+            actionRuns: [
+              {
+                ...runtime.actionRuns[0],
+                status: "failed",
+                exitSignal: "SIGTERM",
+                exitedAt: Date.now(),
+              },
+            ],
+          }}
+        />,
+      );
       fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
 
       await waitFor(() => {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/EnvActionAnchorEntry.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/EnvActionAnchorEntry.test.tsx
@@ -8,6 +8,7 @@ import {
   formatDurationMs,
   formatRunningDurationMs,
 } from "../Composer";
+import { EnvActionRunsView } from "../../thread-detail/EnvActionRunsView";
 
 afterEach(() => {
   vi.useRealTimers();
@@ -215,6 +216,50 @@ describe("EnvActionAnchorEntry", () => {
   });
 
   describe("stop interaction", () => {
+    it("uses the shared styled tooltip for icon action controls", async () => {
+      render(
+        <EnvActionRunsView
+          runs={[buildRun({ status: "started" })]}
+          placement="composer"
+          onMoveToSidebar={() => {}}
+          onStop={() => {}}
+        />,
+      );
+
+      const stopButton = screen.getByRole("button", { name: "Stop" });
+      expect(stopButton).not.toHaveAttribute("title");
+      fireEvent.mouseEnter(stopButton);
+      expect(await screen.findByRole("tooltip")).toHaveClass("viewport-tooltip");
+      expect(screen.getByRole("tooltip")).toHaveTextContent("Stop gracefully");
+      expect(screen.getByRole("tooltip")).toHaveTextContent("Sends SIGTERM first");
+
+      fireEvent.mouseLeave(stopButton);
+      await waitFor(() => {
+        expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+      });
+
+      const terminateButton = screen.getByRole("button", { name: "Terminate" });
+      expect(terminateButton).not.toHaveAttribute("title");
+      fireEvent.mouseEnter(terminateButton);
+      expect(await screen.findByRole("tooltip")).toHaveClass("viewport-tooltip");
+      expect(screen.getByRole("tooltip")).toHaveTextContent("Terminate now");
+      expect(screen.getByRole("tooltip")).toHaveTextContent("Force-kills");
+
+      fireEvent.mouseLeave(terminateButton);
+      await waitFor(() => {
+        expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+      });
+
+      const sidebarButton = screen.getByRole("button", {
+        name: "Move action to the sidebar Actions panel",
+      });
+      expect(sidebarButton).not.toHaveAttribute("title");
+      fireEvent.mouseEnter(sidebarButton);
+      expect(await screen.findByRole("tooltip")).toHaveClass("viewport-tooltip");
+      expect(screen.getByRole("tooltip")).toHaveTextContent("Show in sidebar");
+      expect(screen.getByRole("tooltip")).toHaveTextContent("Actions panel");
+    });
+
     it("invokes onStop with graceful stop when the user clicks Stop", () => {
       const onStop = vi.fn();
       const run = buildRun({ status: "started" });

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -160,6 +160,7 @@ function createSnapshot(
       contextRailPinned: { value: false, source: "default" },
       activeContextTab: { value: "info", source: "default" },
       editedFilesDock: { value: "above", source: "default" },
+      actionRunsDock: { value: "above", source: "default" },
     },
     messaging: {
       enabled: { value: true, source: "default" },

--- a/apps/desktop/src/renderer/src/features/thread-detail/EnvActionRunsView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/EnvActionRunsView.tsx
@@ -229,28 +229,32 @@ export function EnvActionRunEntry(props: {
           {status === "started" ? (
             <>
               <button
-                className="composer__secondary-action composer__queued-env-action-stop"
+                className="composer__secondary-action composer__queued-env-action-control composer__queued-env-action-stop"
                 type="button"
                 disabled={stopping}
+                aria-label="Stop"
+                title="Stop gracefully"
                 onClick={(event) => {
                   event.preventDefault();
                   event.stopPropagation();
                   props.onStop?.(run, "stop");
                 }}
               >
-                Stop
+                <EnvActionStopIcon />
               </button>
               <button
-                className="composer__secondary-action composer__queued-env-action-terminate"
+                className="composer__secondary-action composer__queued-env-action-control composer__queued-env-action-terminate"
                 type="button"
                 disabled={stopping && terminationMode === "terminate"}
+                aria-label="Terminate"
+                title="Terminate process tree now"
                 onClick={(event) => {
                   event.preventDefault();
                   event.stopPropagation();
                   props.onStop?.(run, "terminate");
                 }}
               >
-                Terminate
+                <EnvActionTerminateIcon />
               </button>
             </>
           ) : (
@@ -268,7 +272,7 @@ export function EnvActionRunEntry(props: {
           )}
           {props.placement === "composer" && props.onMoveToSidebar ? (
             <button
-              className="composer__secondary-action composer__queued-env-action-sidebar"
+              className="composer__secondary-action composer__queued-env-action-control composer__queued-env-action-sidebar"
               type="button"
               aria-label="Move action to the sidebar Actions panel"
               title="Move action to the sidebar Actions panel"
@@ -278,7 +282,7 @@ export function EnvActionRunEntry(props: {
                 props.onMoveToSidebar?.();
               }}
             >
-              Sidebar
+              <EnvActionSidebarIcon />
             </button>
           ) : null}
         </span>
@@ -307,6 +311,67 @@ export function EnvActionRunEntry(props: {
         </div>
       </div>
     </details>
+  );
+}
+
+function EnvActionStopIcon(): ReactNode {
+  return (
+    <svg
+      className="composer__queued-env-action-icon"
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.9"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="7" y="7" width="10" height="10" rx="1.5" />
+    </svg>
+  );
+}
+
+function EnvActionTerminateIcon(): ReactNode {
+  return (
+    <svg
+      className="composer__queued-env-action-icon"
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.9"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M8.5 3.5h7l5 5v7l-5 5h-7l-5-5v-7z" />
+      <path d="m9 9 6 6" />
+      <path d="m15 9-6 6" />
+    </svg>
+  );
+}
+
+function EnvActionSidebarIcon(): ReactNode {
+  return (
+    <svg
+      className="composer__queued-env-action-icon"
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.9"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="4" y="5" width="16" height="14" rx="2" />
+      <path d="M10 5v14" />
+      <path d="m15 10 3 2-3 2" />
+    </svg>
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/EnvActionRunsView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/EnvActionRunsView.tsx
@@ -3,9 +3,11 @@ import {
   useLayoutEffect,
   useRef,
   useState,
+  type MouseEvent as ReactMouseEvent,
   type ReactNode,
 } from "react";
 import type { CodexEnvironmentActionRun } from "@pwragent/shared";
+import { useViewportTooltip } from "../../lib/useViewportTooltip";
 
 const ENV_ACTION_OUTPUT_MAX_LINES = 500;
 
@@ -228,12 +230,14 @@ export function EnvActionRunEntry(props: {
         <span className="composer__queued-env-action-actions">
           {status === "started" ? (
             <>
-              <button
-                className="composer__secondary-action composer__queued-env-action-control composer__queued-env-action-stop"
-                type="button"
+              <EnvActionControlButton
+                ariaLabel="Stop"
+                className="composer__queued-env-action-stop"
                 disabled={stopping}
-                aria-label="Stop"
-                title="Stop gracefully"
+                tooltip={[
+                  "Stop gracefully",
+                  "Sends SIGTERM first, then force terminates if the process tree does not exit.",
+                ].join("\n")}
                 onClick={(event) => {
                   event.preventDefault();
                   event.stopPropagation();
@@ -241,13 +245,15 @@ export function EnvActionRunEntry(props: {
                 }}
               >
                 <EnvActionStopIcon />
-              </button>
-              <button
-                className="composer__secondary-action composer__queued-env-action-control composer__queued-env-action-terminate"
-                type="button"
+              </EnvActionControlButton>
+              <EnvActionControlButton
+                ariaLabel="Terminate"
+                className="composer__queued-env-action-terminate"
                 disabled={stopping && terminationMode === "terminate"}
-                aria-label="Terminate"
-                title="Terminate process tree now"
+                tooltip={[
+                  "Terminate now",
+                  "Force-kills the process tree immediately.",
+                ].join("\n")}
                 onClick={(event) => {
                   event.preventDefault();
                   event.stopPropagation();
@@ -255,7 +261,7 @@ export function EnvActionRunEntry(props: {
                 }}
               >
                 <EnvActionTerminateIcon />
-              </button>
+              </EnvActionControlButton>
             </>
           ) : (
             <button
@@ -271,11 +277,13 @@ export function EnvActionRunEntry(props: {
             </button>
           )}
           {props.placement === "composer" && props.onMoveToSidebar ? (
-            <button
-              className="composer__secondary-action composer__queued-env-action-control composer__queued-env-action-sidebar"
-              type="button"
-              aria-label="Move action to the sidebar Actions panel"
-              title="Move action to the sidebar Actions panel"
+            <EnvActionControlButton
+              ariaLabel="Move action to the sidebar Actions panel"
+              className="composer__queued-env-action-sidebar"
+              tooltip={[
+                "Show in sidebar",
+                "Opens the Actions panel and hides this row above the composer.",
+              ].join("\n")}
               onClick={(event) => {
                 event.preventDefault();
                 event.stopPropagation();
@@ -283,7 +291,7 @@ export function EnvActionRunEntry(props: {
               }}
             >
               <EnvActionSidebarIcon />
-            </button>
+            </EnvActionControlButton>
           ) : null}
         </span>
       </summary>
@@ -311,6 +319,50 @@ export function EnvActionRunEntry(props: {
         </div>
       </div>
     </details>
+  );
+}
+
+function EnvActionControlButton(props: {
+  ariaLabel: string;
+  children: ReactNode;
+  className: string;
+  disabled?: boolean;
+  onClick: (event: ReactMouseEvent<HTMLButtonElement>) => void;
+  tooltip: string;
+}): ReactNode {
+  const tooltip = useViewportTooltip({ className: "viewport-tooltip" });
+  const className = [
+    "composer__secondary-action",
+    "composer__queued-env-action-control",
+    props.className,
+  ].join(" ");
+
+  const showTooltip = (target: HTMLButtonElement): void => {
+    if (!props.disabled) {
+      tooltip.show(target, props.tooltip);
+    }
+  };
+
+  return (
+    <>
+      <button
+        aria-label={props.ariaLabel}
+        className={className}
+        disabled={props.disabled}
+        type="button"
+        onBlur={tooltip.hide}
+        onClick={(event) => {
+          tooltip.hide();
+          props.onClick(event);
+        }}
+        onFocus={(event) => showTooltip(event.currentTarget)}
+        onMouseEnter={(event) => showTooltip(event.currentTarget)}
+        onMouseLeave={tooltip.hide}
+      >
+        {props.children}
+      </button>
+      {tooltip.tooltipNode}
+    </>
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/EnvActionRunsView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/EnvActionRunsView.tsx
@@ -1,0 +1,369 @@
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import type { CodexEnvironmentActionRun } from "@pwragent/shared";
+
+const ENV_ACTION_OUTPUT_MAX_LINES = 500;
+
+function tailLines(text: string, maxLines: number): string {
+  const lines = text.split("\n");
+  if (lines.length <= maxLines) return text;
+  const dropped = lines.length - maxLines;
+  return [
+    `[…${dropped} earlier lines truncated]`,
+    ...lines.slice(-maxLines),
+  ].join("\n");
+}
+
+type EnvActionOutputChunk = {
+  id: number;
+  text: string;
+};
+
+type EnvActionOutputState = {
+  rawOutput: string;
+  chunks: EnvActionOutputChunk[];
+  nextChunkId: number;
+};
+
+function buildEnvActionOutputState(
+  output: string,
+  nextChunkId = 1,
+): EnvActionOutputState {
+  const text = tailLines(output, ENV_ACTION_OUTPUT_MAX_LINES);
+  return {
+    rawOutput: output,
+    chunks: text ? [{ id: nextChunkId - 1, text }] : [],
+    nextChunkId,
+  };
+}
+
+function trimEnvActionOutputChunks(
+  chunks: EnvActionOutputChunk[],
+): EnvActionOutputChunk[] {
+  const text = chunks.map((chunk) => chunk.text).join("");
+  const trimmed = tailLines(text, ENV_ACTION_OUTPUT_MAX_LINES);
+  if (trimmed === text) return chunks;
+  return [{ id: chunks.at(-1)?.id ?? 0, text: trimmed }];
+}
+
+function elementContainsSelection(element: HTMLElement | null): boolean {
+  if (!element) return false;
+  const selection = element.ownerDocument.getSelection();
+  if (!selection || selection.rangeCount === 0 || selection.isCollapsed) {
+    return false;
+  }
+  for (let index = 0; index < selection.rangeCount; index += 1) {
+    const range = selection.getRangeAt(index);
+    if (
+      element.contains(range.startContainer) ||
+      element.contains(range.endContainer)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function formatDurationMs(
+  ms?: number,
+  options?: { coarseAfterMinute?: boolean },
+): string {
+  if (!ms || !Number.isFinite(ms)) return "";
+  if (ms < 1_000) return `${Math.round(ms)}ms`;
+  const totalSeconds = Math.round(ms / 1_000);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const minutes = Math.floor(totalSeconds / 60);
+  if (options?.coarseAfterMinute) return `${minutes}m`;
+  const remainder = totalSeconds % 60;
+  return remainder ? `${minutes}m ${remainder}s` : `${minutes}m`;
+}
+
+export function formatRunningDurationMs(ms?: number): string {
+  if (ms === undefined || !Number.isFinite(ms) || ms < 0) return "";
+  const totalSeconds = Math.floor(ms / 1_000);
+  if (totalSeconds < 1) return "0s";
+  return formatDurationMs(totalSeconds * 1_000);
+}
+
+export function EnvActionRunsView(props: {
+  environmentName?: string;
+  runs: CodexEnvironmentActionRun[];
+  onDismiss?: (run: CodexEnvironmentActionRun) => void;
+  onMoveToSidebar?: () => void;
+  onShowAboveComposer?: () => void;
+  onStop?: (run: CodexEnvironmentActionRun, mode: "stop" | "terminate") => void;
+  placement: "composer" | "sidebar";
+}): ReactNode {
+  const hasStartedRun = props.runs.some((run) => run.status === "started");
+  const [, setElapsedTick] = useState(0);
+  useEffect(() => {
+    if (!hasStartedRun) return undefined;
+    const handle = setInterval(() => {
+      setElapsedTick((tick) => tick + 1);
+    }, 1_000);
+    return () => clearInterval(handle);
+  }, [hasStartedRun]);
+
+  if (props.runs.length === 0) return null;
+
+  return (
+    <>
+      {props.placement === "sidebar" ? (
+        <header className="env-actions-panel__header">
+          <div className="env-actions-panel__title-group">
+            <h3>Actions</h3>
+            <span className="env-actions-panel__count">
+              {props.runs.length}
+            </span>
+          </div>
+          {props.onShowAboveComposer ? (
+            <button
+              type="button"
+              className="env-actions-panel__dock-toggle"
+              onClick={props.onShowAboveComposer}
+              title="Also show action runs above the composer"
+            >
+              Show above composer
+            </button>
+          ) : null}
+        </header>
+      ) : null}
+      <div
+        className={`env-action-runs env-action-runs--${props.placement}`}
+      >
+        {props.runs.map((run) => (
+          <EnvActionRunEntry
+            key={run.runId}
+            environmentName={props.environmentName}
+            onDismiss={props.onDismiss}
+            onMoveToSidebar={props.onMoveToSidebar}
+            onStop={props.onStop}
+            placement={props.placement}
+            run={run}
+          />
+        ))}
+      </div>
+    </>
+  );
+}
+
+export function EnvActionRunEntry(props: {
+  environmentName?: string;
+  onDismiss?: (run: CodexEnvironmentActionRun) => void;
+  onMoveToSidebar?: () => void;
+  onStop?: (run: CodexEnvironmentActionRun, mode: "stop" | "terminate") => void;
+  placement: "composer" | "sidebar";
+  run: CodexEnvironmentActionRun;
+}): ReactNode {
+  const { run } = props;
+  const status = run.status;
+  const terminationMode = run.terminationMode;
+  const label =
+    status === "started"
+      ? terminationMode
+        ? "Env action stopping"
+        : "Env action running"
+      : terminationMode
+        ? "Env action stopped"
+        : status === "exited"
+          ? "Env action exited"
+          : "Env action failed";
+
+  const meta: string[] = [];
+  if (run.pid) meta.push(`pid ${run.pid}`);
+  if (status === "started" && typeof run.startedAt === "number") {
+    meta.push(
+      `running for ${formatRunningDurationMs(Date.now() - run.startedAt)}`,
+    );
+  }
+  if (terminationMode && status === "started") {
+    meta.push(terminationMode === "terminate" ? "terminating" : "stopping");
+  }
+  if (status !== "started") {
+    if (typeof run.exitCode === "number") {
+      meta.push(`exit ${run.exitCode}`);
+    } else if (run.exitSignal) {
+      meta.push(`signal ${run.exitSignal}`);
+    }
+    if (run.durationMs) {
+      meta.push(`ran ${formatDurationMs(run.durationMs)}`);
+    }
+  }
+
+  const output = (run.output ?? "").trim();
+  const outputLineCount = output
+    ? tailLines(output, ENV_ACTION_OUTPUT_MAX_LINES).split("\n").length
+    : 0;
+  const modifier =
+    status === "failed"
+      ? "composer__queued--env-action-failed"
+      : status === "exited"
+        ? "composer__queued--env-action-exited"
+        : "composer__queued--env-action-running";
+  const stopping = status === "started" && Boolean(terminationMode);
+
+  return (
+    <details
+      className={`composer__queued composer__queued--env-action ${modifier} env-action-run env-action-run--${props.placement}`}
+      aria-label={label}
+    >
+      <summary className="composer__queued-env-action-summary">
+        <span
+          className="composer__queued-env-action-chevron"
+          aria-hidden="true"
+        />
+        <span className="composer__queued-env-action-summary-text">
+          <span className="composer__queued-label">{label}</span>
+          <span className="composer__queued-text">
+            {run.actionName}
+            {props.environmentName ? ` · ${props.environmentName}` : ""}
+            {meta.length > 0 ? ` · ${meta.join(" · ")}` : ""}
+          </span>
+        </span>
+        <span className="composer__queued-env-action-actions">
+          {status === "started" ? (
+            <>
+              <button
+                className="composer__secondary-action composer__queued-env-action-stop"
+                type="button"
+                disabled={stopping}
+                onClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  props.onStop?.(run, "stop");
+                }}
+              >
+                Stop
+              </button>
+              <button
+                className="composer__secondary-action composer__queued-env-action-terminate"
+                type="button"
+                disabled={stopping && terminationMode === "terminate"}
+                onClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  props.onStop?.(run, "terminate");
+                }}
+              >
+                Terminate
+              </button>
+            </>
+          ) : (
+            <button
+              className="composer__secondary-action composer__queued-env-action-dismiss"
+              type="button"
+              onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                props.onDismiss?.(run);
+              }}
+            >
+              Dismiss
+            </button>
+          )}
+          {props.placement === "composer" && props.onMoveToSidebar ? (
+            <button
+              className="composer__secondary-action composer__queued-env-action-sidebar"
+              type="button"
+              aria-label="Move action run to the sidebar Actions panel"
+              title="Move action run to the sidebar Actions panel"
+              onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                props.onMoveToSidebar?.();
+              }}
+            >
+              Sidebar
+            </button>
+          ) : null}
+        </span>
+      </summary>
+      <div className="composer__queued-env-action-body">
+        {run.command ? (
+          <div className="composer__queued-env-action-section">
+            <div className="composer__queued-env-action-section-label">
+              Command
+            </div>
+            <pre className="composer__queued-env-action-command-block">
+              <code>$ {run.command}</code>
+            </pre>
+          </div>
+        ) : null}
+        <div className="composer__queued-env-action-section">
+          <div className="composer__queued-env-action-section-label">
+            Output
+            {outputLineCount
+              ? ` · ${outputLineCount} line${
+                  outputLineCount === 1 ? "" : "s"
+                }`
+              : ""}
+          </div>
+          <EnvActionOutputBlock output={output} status={status} />
+        </div>
+      </div>
+    </details>
+  );
+}
+
+function EnvActionOutputBlock(props: {
+  output: string;
+  status: CodexEnvironmentActionRun["status"];
+}): ReactNode {
+  const outputRef = useRef<HTMLPreElement | null>(null);
+  const [state, setState] = useState<EnvActionOutputState>(() =>
+    buildEnvActionOutputState(props.output),
+  );
+
+  useLayoutEffect(() => {
+    setState((current) => {
+      if (current.rawOutput === props.output) {
+        return current;
+      }
+
+      if (
+        current.rawOutput &&
+        props.output.startsWith(current.rawOutput)
+      ) {
+        const appended = props.output.slice(current.rawOutput.length);
+        if (!appended) {
+          return { ...current, rawOutput: props.output };
+        }
+        const nextChunks = [
+          ...current.chunks,
+          { id: current.nextChunkId, text: appended },
+        ];
+        return {
+          rawOutput: props.output,
+          chunks: elementContainsSelection(outputRef.current)
+            ? nextChunks
+            : trimEnvActionOutputChunks(nextChunks),
+          nextChunkId: current.nextChunkId + 1,
+        };
+      }
+
+      return buildEnvActionOutputState(props.output, current.nextChunkId + 1);
+    });
+  }, [props.output]);
+
+  const placeholder =
+    props.status === "started"
+      ? "(no output yet — waiting for the command to print something)"
+      : "(no output captured)";
+
+  return (
+    <pre className="composer__queued-env-action-output" ref={outputRef}>
+      <code>
+        {state.chunks.length > 0
+          ? state.chunks.map((chunk) => (
+              <span key={chunk.id}>{chunk.text}</span>
+            ))
+          : placeholder}
+      </code>
+    </pre>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/EnvActionRunsView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/EnvActionRunsView.tsx
@@ -270,8 +270,8 @@ export function EnvActionRunEntry(props: {
             <button
               className="composer__secondary-action composer__queued-env-action-sidebar"
               type="button"
-              aria-label="Move action run to the sidebar Actions panel"
-              title="Move action run to the sidebar Actions panel"
+              aria-label="Move action to the sidebar Actions panel"
+              title="Move action to the sidebar Actions panel"
               onClick={(event) => {
                 event.preventDefault();
                 event.stopPropagation();

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -16,6 +16,7 @@ import type {
   DesktopApplicationDiscoveryCandidate,
   EditGroupCommitState,
   NavigationThreadSummary,
+  CodexEnvironmentActionRun,
   ThreadPricingSummary,
   ThreadUsageLineRecord,
 } from "@pwragent/shared";
@@ -29,6 +30,7 @@ import {
   PullRequestIcon,
   ServerIcon,
   SubAgentsIcon,
+  TerminalIcon,
   type IconProps,
 } from "../../icons";
 import type { DesktopApi } from "../../lib/desktop-api";
@@ -40,9 +42,11 @@ import { PullRequestsPanel } from "./context-panels/PullRequestsPanel";
 import { LinkedProjectsPanel } from "./context-panels/LinkedProjectsPanel";
 import { EditsPanel } from "./context-panels/EditsPanel";
 import { PricingPanel } from "./context-panels/PricingPanel";
+import { ActionRunsPanel } from "./context-panels/ActionRunsPanel";
 import { buildRailTooltipText } from "./context-panels/context-rail-shared";
 import type {
   ContextTabId,
+  ActionRunsDock,
   EditedFilesDock,
 } from "./context-panels/context-tab";
 import type { EditedFileGroup } from "./edited-file-groups";
@@ -65,6 +69,7 @@ const CONTEXT_TABS: ContextTab[] = [
   { id: "info", label: "Thread info", Icon: InfoIcon },
   { id: "edits", label: "Edits", Icon: EditsIcon },
   { id: "pricing", label: "Pricing", Icon: PricingIcon },
+  { id: "actions", label: "Actions", Icon: TerminalIcon },
   { id: "subagents", label: "Sub-agents", Icon: SubAgentsIcon },
   { id: "automations", label: "Automations", Icon: AutomationsIcon },
   { id: "prs", label: "Pull requests", Icon: PullRequestIcon },
@@ -121,6 +126,16 @@ type ThreadContextPanelProps = {
   onScrollToTurn?: (turnId: string, turnTimeMs?: number) => void;
   editedFilesDock?: EditedFilesDock;
   onEditedFilesDockChange?: (dock: EditedFilesDock) => void;
+  actionRuns?: CodexEnvironmentActionRun[];
+  actionRunsDock?: ActionRunsDock;
+  actionRunsEnvironmentName?: string;
+  onActionRunsDockChange?: (dock: ActionRunsDock) => void;
+  onShowActionRunsAboveComposer?: () => void;
+  onDismissEnvActionRun?: (run: CodexEnvironmentActionRun) => void;
+  onStopEnvActionRun?: (
+    run: CodexEnvironmentActionRun,
+    mode: "stop" | "terminate"
+  ) => void;
 };
 
 // Clamp bounds for the context-rail width. Shared by the resize math and the
@@ -652,6 +667,22 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
             pricing={props.pricing}
             displayOptions={props.pricingDisplayOptions}
             onScrollToTurn={props.onScrollToTurn}
+          />
+        );
+      case "actions":
+        return (
+          <ActionRunsPanel
+            dock={props.actionRunsDock ?? "above"}
+            environmentName={props.actionRunsEnvironmentName}
+            onDockChange={(dock) => {
+              props.onActionRunsDockChange?.(dock);
+              if (dock === "above") {
+                props.onShowActionRunsAboveComposer?.();
+              }
+            }}
+            onDismissRun={props.onDismissEnvActionRun}
+            onStopRun={props.onStopEnvActionRun}
+            runs={props.actionRuns ?? []}
           />
         );
       case "subagents":

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -26,6 +26,7 @@ import type {
   AppServerSkillSummary,
   BackendSummary,
   CodexEnvironmentSetupProgressEvent,
+  CodexEnvironmentActionRun,
   DesktopApplicationsSnapshot,
   DesktopChatReplyComposer,
   HandoffThreadWorkspaceRequest,
@@ -56,7 +57,9 @@ import { MessagingStatusBar } from "../messaging-status/MessagingStatusBar";
 import { ThreadContextPanel } from "./ThreadContextPanel";
 import {
   DEFAULT_CONTEXT_TAB,
+  DEFAULT_ACTION_RUNS_DOCK,
   DEFAULT_EDITED_FILES_DOCK,
+  type ActionRunsDock,
   type ContextTabId,
   type EditedFilesDock,
 } from "./context-panels/context-tab";
@@ -915,6 +918,8 @@ export type ThreadViewProps = {
    */
   editedFilesDock?: EditedFilesDock;
   onEditedFilesDockChange?: (dock: EditedFilesDock) => void;
+  actionRunsDock?: ActionRunsDock;
+  onActionRunsDockChange?: (dock: ActionRunsDock) => void;
   sidebarHidden?: boolean;
   onToggleSidebar?: () => void;
   /**
@@ -1080,6 +1085,9 @@ export function ThreadView(props: ThreadViewProps) {
     useState<string>();
   const [launchpadSetupProgress, setLaunchpadSetupProgress] =
     useState<LaunchpadEnvironmentSetupProgress>();
+  const [dismissedEnvActionRunIds, setDismissedEnvActionRunIds] = useState<
+    Set<string>
+  >(() => new Set());
   // The context-rail pin is a window-level preference owned by App and
   // toggled from the header chips (no more wide-display force-pin — the
   // user controls it explicitly).
@@ -1092,10 +1100,12 @@ export function ThreadView(props: ThreadViewProps) {
       ? DEFAULT_CONTEXT_TAB
       : props.activeContextTab ?? DEFAULT_CONTEXT_TAB;
   const editedFilesDock = props.editedFilesDock ?? DEFAULT_EDITED_FILES_DOCK;
+  const actionRunsDock = props.actionRunsDock ?? DEFAULT_ACTION_RUNS_DOCK;
   const sidebarHidden = props.sidebarHidden ?? false;
   const onContextRailPinnedChange = props.onContextRailPinnedChange ?? noop;
   const onActiveContextTabChange = props.onActiveContextTabChange ?? noop;
   const onEditedFilesDockChange = props.onEditedFilesDockChange ?? noop;
+  const onActionRunsDockChange = props.onActionRunsDockChange ?? noop;
   const onToggleSidebar = props.onToggleSidebar ?? noop;
   // Transcript element the in-thread find bar (⌘F) searches + highlights.
   const transcriptPanelRef = useRef<HTMLElement>(null);
@@ -1148,6 +1158,12 @@ export function ThreadView(props: ThreadViewProps) {
   }, [props.activeTurnId]);
 
   const selectedThread = props.selectedThread;
+  const envActionRuns = readCodexEnvironmentActionRuns(
+    selectedThread?.codexEnvironmentRuntime,
+  );
+  const visibleEnvActionRuns = envActionRuns.filter(
+    (run) => !dismissedEnvActionRunIds.has(run.runId),
+  );
   const selectedThreadBackend = useMemo(
     () =>
       selectedThread
@@ -1728,6 +1744,53 @@ export function ThreadView(props: ThreadViewProps) {
     onContextRailPinnedChange,
     onEditedFilesDockChange,
   ]);
+
+  const moveActionRunsToSidebar = useCallback(() => {
+    onActionRunsDockChange("sidebar");
+    onActiveContextTabChange("actions");
+    if (!contextRailPinned) {
+      onContextRailPinnedChange(true);
+    }
+  }, [
+    contextRailPinned,
+    onActionRunsDockChange,
+    onActiveContextTabChange,
+    onContextRailPinnedChange,
+  ]);
+
+  const showActionRunsAboveComposer = useCallback(() => {
+    onActionRunsDockChange("above");
+  }, [onActionRunsDockChange]);
+
+  const stopEnvActionRun = useCallback(
+    (run: CodexEnvironmentActionRun, mode: "stop" | "terminate") => {
+      if (!selectedThread || !props.desktopApi?.stopCodexEnvironmentAction) {
+        return;
+      }
+      void props.desktopApi
+        .stopCodexEnvironmentAction({
+          backend: selectedThread.source,
+          threadId: selectedThread.id,
+          runId: run.runId,
+          mode,
+        })
+        .catch((error: unknown) => {
+          console.error("Failed to stop environment action run", error);
+        });
+    },
+    [props.desktopApi, selectedThread],
+  );
+
+  const dismissEnvActionRun = useCallback((run: CodexEnvironmentActionRun) => {
+    setDismissedEnvActionRunIds((current) => {
+      if (current.has(run.runId)) {
+        return current;
+      }
+      const next = new Set(current);
+      next.add(run.runId);
+      return next;
+    });
+  }, []);
 
   useEffect(() => {
     if (!pendingActivityEntry) {
@@ -2618,6 +2681,15 @@ export function ThreadView(props: ThreadViewProps) {
             onBeforeSendTurn={() => {
               setTranscriptReglueRequestKey((current) => current + 1);
             }}
+            onMoveEnvActionsToSidebar={
+              actionRunsDock === "above" && envActionRuns.length > 0
+                ? moveActionRunsToSidebar
+                : undefined
+            }
+            onDismissEnvActionRun={dismissEnvActionRun}
+            onStopEnvActionRun={stopEnvActionRun}
+            hiddenEnvActionRunIds={dismissedEnvActionRunIds}
+            showEnvActionAnchors={actionRunsDock === "above"}
             onSetExecutionMode={props.onSetExecutionMode}
             onSetAcpRuntimeOption={props.onSetAcpRuntimeOption}
             onCancelExecutionModeQueue={props.onCancelExecutionModeQueue}
@@ -2667,6 +2739,15 @@ export function ThreadView(props: ThreadViewProps) {
           onScrollToTurn={handleScrollToTurn}
           editedFilesDock={editedFilesDock}
           onEditedFilesDockChange={onEditedFilesDockChange}
+          actionRuns={visibleEnvActionRuns}
+          actionRunsDock={actionRunsDock}
+          actionRunsEnvironmentName={
+            selectedThread?.codexEnvironmentRuntime?.environmentName
+          }
+          onActionRunsDockChange={onActionRunsDockChange}
+          onShowActionRunsAboveComposer={showActionRunsAboveComposer}
+          onDismissEnvActionRun={dismissEnvActionRun}
+          onStopEnvActionRun={stopEnvActionRun}
           onActiveTabChange={onActiveContextTabChange}
           onRefreshNavigation={props.onRefreshNavigation}
           onResizingChange={setContextRailResizing}

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ActionRunsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ActionRunsPanel.tsx
@@ -1,0 +1,47 @@
+import type { CodexEnvironmentActionRun } from "@pwragent/shared";
+import { EnvActionRunsView } from "../EnvActionRunsView";
+import type { ActionRunsDock } from "./context-tab";
+
+type ActionRunsPanelProps = {
+  dock: ActionRunsDock;
+  environmentName?: string;
+  onDockChange: (dock: ActionRunsDock) => void;
+  onDismissRun?: (run: CodexEnvironmentActionRun) => void;
+  onStopRun?: (
+    run: CodexEnvironmentActionRun,
+    mode: "stop" | "terminate"
+  ) => void;
+  runs: CodexEnvironmentActionRun[];
+};
+
+export function ActionRunsPanel(props: ActionRunsPanelProps) {
+  return (
+    <section className="context-panel__section context-panel__section--env-actions">
+      {props.runs.length > 0 ? (
+        <EnvActionRunsView
+          environmentName={props.environmentName}
+          onShowAboveComposer={
+            props.dock === "sidebar" ? () => props.onDockChange("above") : undefined
+          }
+          onDismiss={props.onDismissRun}
+          onStop={props.onStopRun}
+          placement="sidebar"
+          runs={props.runs}
+        />
+      ) : (
+        <>
+          <header className="env-actions-panel__header">
+            <div className="env-actions-panel__title-group">
+              <h3>Actions</h3>
+            </div>
+          </header>
+          <div className="env-actions-panel__body">
+            <p className="context-empty">
+              No environment actions have run for this thread yet.
+            </p>
+          </div>
+        </>
+      )}
+    </section>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/context-tab.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/context-tab.ts
@@ -7,6 +7,7 @@ export type ContextTabId =
   | "info"
   | "edits"
   | "pricing"
+  | "actions"
   | "subagents"
   | "automations"
   | "prs"
@@ -17,6 +18,7 @@ export const CONTEXT_TAB_IDS: ContextTabId[] = [
   "info",
   "edits",
   "pricing",
+  "actions",
   "subagents",
   "automations",
   "prs",
@@ -44,5 +46,13 @@ export type EditedFilesDock = "above" | "sidebar";
 export const DEFAULT_EDITED_FILES_DOCK: EditedFilesDock = "above";
 
 export function isEditedFilesDock(value: unknown): value is EditedFilesDock {
+  return value === "above" || value === "sidebar";
+}
+
+export type ActionRunsDock = "above" | "sidebar";
+
+export const DEFAULT_ACTION_RUNS_DOCK: ActionRunsDock = "above";
+
+export function isActionRunsDock(value: unknown): value is ActionRunsDock {
   return value === "above" || value === "sidebar";
 }

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -128,6 +128,8 @@ import type {
   RenameThreadResponse,
   RunCodexEnvironmentActionRequest,
   RunCodexEnvironmentActionResponse,
+  StopCodexEnvironmentActionRequest,
+  StopCodexEnvironmentActionResponse,
   SetCodexThreadEnvironmentRequest,
   SetCodexThreadEnvironmentResponse,
   RestoreWorktreeRequest,
@@ -428,6 +430,9 @@ export type DesktopApi = {
   runCodexEnvironmentAction?: (
     request: RunCodexEnvironmentActionRequest,
   ) => Promise<RunCodexEnvironmentActionResponse>;
+  stopCodexEnvironmentAction?: (
+    request: StopCodexEnvironmentActionRequest,
+  ) => Promise<StopCodexEnvironmentActionResponse>;
   setCodexThreadEnvironment?: (
     request: SetCodexThreadEnvironmentRequest,
   ) => Promise<SetCodexThreadEnvironmentResponse>;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9404,6 +9404,74 @@ textarea,
   color: var(--accent-bright);
 }
 
+.context-panel__section.context-panel__section--env-actions {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+  padding: 0;
+}
+
+.env-actions-panel__header {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 12px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.env-actions-panel__title-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.env-actions-panel__count {
+  min-width: 20px;
+  height: 20px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1;
+}
+
+.env-actions-panel__dock-toggle {
+  flex: 0 0 auto;
+  padding: 2px 8px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 4px;
+  background: var(--bg-input);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 11px;
+}
+
+.env-actions-panel__dock-toggle:hover {
+  border-color: var(--accent-border);
+  color: var(--text-primary);
+}
+
+.env-actions-panel__body,
+.env-action-runs--sidebar {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 12px;
+}
+
+.env-action-runs--sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
 .transcript-activity {
   width: min(100%, 760px);
   padding: 12px 0 0;
@@ -12315,6 +12383,39 @@ textarea,
 
 .composer__queued-env-action-dismiss {
   flex: 0 0 auto;
+}
+
+.composer__queued-env-action-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex: 0 0 auto;
+}
+
+.composer__queued-env-action-actions .composer__secondary-action:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+
+.env-action-run--sidebar {
+  width: 100%;
+}
+
+.env-action-run--sidebar .composer__queued-env-action-summary {
+  align-items: flex-start;
+}
+
+.env-action-run--sidebar .composer__queued-env-action-summary-text {
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.env-action-run--sidebar .composer__queued-env-action-summary-text .composer__queued-text {
+  white-space: normal;
+}
+
+.env-action-run--sidebar .composer__queued-env-action-output {
+  max-height: 260px;
 }
 
 .composer__queued-env-action-body {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -12388,7 +12388,55 @@ textarea,
 .composer__queued-env-action-actions {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: 4px;
+  flex: 0 0 auto;
+}
+
+.composer__queued-env-action-control {
+  width: 30px;
+  min-width: 30px;
+  min-height: 30px;
+  height: 30px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--bg-input) 78%, transparent);
+  color: var(--text-muted);
+}
+
+.composer__queued-env-action-control:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--accent-border) 72%, var(--border-subtle));
+  background: var(--bg-panel-hover);
+  color: var(--text-primary);
+}
+
+.composer__queued-env-action-control:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.composer__queued-env-action-stop:hover:not(:disabled) {
+  color: var(--text-primary);
+}
+
+.composer__queued-env-action-terminate {
+  color: color-mix(in srgb, var(--danger-text) 74%, var(--text-muted));
+}
+
+.composer__queued-env-action-terminate:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--danger-border) 70%, var(--border-subtle));
+  background: color-mix(in srgb, var(--danger-soft) 34%, var(--bg-panel-hover));
+  color: var(--danger-text);
+}
+
+.composer__queued-env-action-sidebar:hover:not(:disabled) {
+  color: var(--accent-bright);
+}
+
+.composer__queued-env-action-icon {
+  display: block;
   flex: 0 0 auto;
 }
 

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -46,6 +46,8 @@ export const CODEX_ENVIRONMENT_SETUP_PROGRESS_CHANNEL =
   "codex-environment:setup-progress";
 export const AGENT_RUN_CODEX_ENVIRONMENT_ACTION_CHANNEL =
   "agent:run-codex-environment-action";
+export const AGENT_STOP_CODEX_ENVIRONMENT_ACTION_CHANNEL =
+  "agent:stop-codex-environment-action";
 export const AGENT_SET_CODEX_THREAD_ENVIRONMENT_CHANNEL =
   "agent:set-codex-thread-environment";
 export const AGENT_SUBMIT_SERVER_REQUEST_CHANNEL = "agent:submit-server-request";

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -118,6 +118,7 @@ describe("desktop settings contracts", () => {
         contextRailPinned: { value: false, source: "default" },
         activeContextTab: { value: "info", source: "default" },
         editedFilesDock: { value: "above", source: "default" },
+        actionRunsDock: { value: "above", source: "default" },
       },
       messaging: {
         enabled: {

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -552,6 +552,19 @@ export type RunCodexEnvironmentActionResponse = {
   codexEnvironmentRuntime: CodexThreadEnvironmentRuntime;
 };
 
+export type StopCodexEnvironmentActionRequest = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  runId: string;
+  mode: "stop" | "terminate";
+};
+
+export type StopCodexEnvironmentActionResponse = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  codexEnvironmentRuntime: CodexThreadEnvironmentRuntime;
+};
+
 export type SetCodexThreadEnvironmentRequest = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -165,6 +165,13 @@ export type CodexEnvironmentActionRun = {
   exitSignal?: string;
   durationMs?: number;
   output?: string;
+  /**
+   * User-requested process-tree shutdown. While status remains "started",
+   * this means PwrAgent has already sent a signal and is waiting for the
+   * process close callback to report the final exit details.
+   */
+  terminationRequestedAt?: number;
+  terminationMode?: "stop" | "terminate";
 };
 
 export type CodexThreadEnvironmentRuntime = {

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -514,15 +514,17 @@ export type DesktopSettingsSnapshot = {
    * open, and which context-rail tab was last active. `activeContextTab`
    * is a plain string here; the renderer validates it against its known
    * tab ids and falls back to the default when unrecognized.
-   * `editedFilesDock` follows the same plain-string + renderer-validated
+   * `editedFilesDock` and `actionRunsDock` follow the same plain-string +
+   * renderer-validated
    * pattern: "above" (default, edited files render above the composer)
-   * or "sidebar" (edited files only show in the context-rail Edits tab).
+   * or "sidebar" (the content only shows in its context-rail tab).
    */
   ui: {
     sidebarHidden: DesktopSettingsValue<boolean>;
     contextRailPinned: DesktopSettingsValue<boolean>;
     activeContextTab: DesktopSettingsValue<string>;
     editedFilesDock: DesktopSettingsValue<string>;
+    actionRunsDock: DesktopSettingsValue<string>;
   };
   messaging: {
     enabled: DesktopSettingsValue<boolean>;
@@ -728,6 +730,7 @@ export type DesktopSettingsConfigPatch = {
     contextRailPinned?: boolean;
     activeContextTab?: string;
     editedFilesDock?: string;
+    actionRunsDock?: string;
   };
   messaging?: {
     enabled?: boolean;


### PR DESCRIPTION
## Summary

Dev Action rows now behave like live process controls instead of dismissible notifications. While an action is running, users can request a graceful Stop or immediate Terminate; Dismiss only appears after the process has exited so long-running compilers and dev servers cannot be forgotten while still alive.

Action runs also have a durable home in the thread context rail. The composer anchor can move the run to the new Actions tab, the dock preference persists across launches, and stopped runs can be dismissed from either surface.

## Details

- Tracks detached environment action processes by run id so Stop sends SIGTERM to the process tree and escalates to SIGKILL, while Terminate sends SIGKILL immediately.
- Adds IPC/preload/shared contracts for stopping action runs and annotates runs while termination is pending.
- Reuses one shared action-run renderer for the composer anchor and the sidebar Actions panel so output, command text, Stop/Terminate, and Dismiss stay consistent.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts apps/desktop/src/renderer/src/features/composer/__tests__/EnvActionAnchorEntry.test.tsx apps/desktop/src/renderer/src/features/composer/__tests__/EnvActionAnchorList.test.tsx apps/desktop/src/main/__tests__/desktop-config-ui.test.ts packages/shared/src/contracts/__tests__/settings.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
