### PR TITLE
fix(desktop): show all-files edit totals

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
@@ -165,6 +165,10 @@ export function EditedFileGroupList(props: EditedFileGroupListProps) {
     props.groups.length === 1 && props.showSingleGroupHeader;
   const effectiveView = preserveSingleGroupHeader ? "turns" : view;
   const [showAllTurns, setShowAllTurns] = useState(false);
+  const flattenedDetails = useMemo(
+    () => flattenEditedFileGroups(props.groups),
+    [props.groups],
+  );
 
   // Union of gitignored paths across every resolved group, so a row in any
   // view (grouped / flattened / single) can flag itself as ignored.
@@ -237,9 +241,43 @@ export function EditedFileGroupList(props: EditedFileGroupListProps) {
           );
         })()
       ) : (
-        <EditedFileList details={flattenEditedFileGroups(props.groups)} />
+        <EditedFileFlatSection details={flattenedDetails} />
       );
   }
+}
+
+function formatEditedFileCount(count: number): string {
+  return `Edited ${count.toLocaleString()} ${count === 1 ? "file" : "files"}`;
+}
+
+function EditedFileFlatSection(props: {
+  details: AppServerThreadActivityDetail[];
+}) {
+  const totals = props.details.reduce(
+    (sum, detail) => ({
+      additions: sum.additions + (detail.fileDiff?.additions ?? 0),
+      removals: sum.removals + (detail.fileDiff?.removals ?? 0),
+    }),
+    { additions: 0, removals: 0 },
+  );
+
+  return (
+    <>
+      <div className="edited-file-groups__group-header edited-file-groups__flat-header">
+        <div className="edited-file-groups__flat-summary">
+          <span className="edited-file-groups__group-summary">
+            {formatEditedFileCount(props.details.length)}
+          </span>
+        </div>
+        <DiffStat
+          additions={totals.additions}
+          removals={totals.removals}
+          className="diff-stat--chip"
+        />
+      </div>
+      <EditedFileList details={props.details} />
+    </>
+  );
 }
 
 function formatGroupTimestamp(group: EditedFileGroup): string | undefined {

--- a/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
@@ -165,10 +165,6 @@ export function EditedFileGroupList(props: EditedFileGroupListProps) {
     props.groups.length === 1 && props.showSingleGroupHeader;
   const effectiveView = preserveSingleGroupHeader ? "turns" : view;
   const [showAllTurns, setShowAllTurns] = useState(false);
-  const flattenedDetails = useMemo(
-    () => flattenEditedFileGroups(props.groups),
-    [props.groups],
-  );
 
   // Union of gitignored paths across every resolved group, so a row in any
   // view (grouped / flattened / single) can flag itself as ignored.
@@ -241,7 +237,7 @@ export function EditedFileGroupList(props: EditedFileGroupListProps) {
           );
         })()
       ) : (
-        <EditedFileFlatSection details={flattenedDetails} />
+        <EditedFileFlatSection groups={props.groups} />
       );
   }
 }
@@ -250,10 +246,12 @@ function formatEditedFileCount(count: number): string {
   return `Edited ${count.toLocaleString()} ${count === 1 ? "file" : "files"}`;
 }
 
-function EditedFileFlatSection(props: {
-  details: AppServerThreadActivityDetail[];
-}) {
-  const totals = props.details.reduce(
+function EditedFileFlatSection(props: { groups: EditedFileGroup[] }) {
+  const details = useMemo(
+    () => flattenEditedFileGroups(props.groups),
+    [props.groups],
+  );
+  const totals = details.reduce(
     (sum, detail) => ({
       additions: sum.additions + (detail.fileDiff?.additions ?? 0),
       removals: sum.removals + (detail.fileDiff?.removals ?? 0),
@@ -266,7 +264,7 @@ function EditedFileFlatSection(props: {
       <div className="edited-file-groups__group-header edited-file-groups__flat-header">
         <div className="edited-file-groups__flat-summary">
           <span className="edited-file-groups__group-summary">
-            {formatEditedFileCount(props.details.length)}
+            {formatEditedFileCount(details.length)}
           </span>
         </div>
         <DiffStat
@@ -275,7 +273,7 @@ function EditedFileFlatSection(props: {
           className="diff-stat--chip"
         />
       </div>
-      <EditedFileList details={props.details} />
+      <EditedFileList details={details} />
     </>
   );
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/EditedFileGroupList.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/EditedFileGroupList.test.tsx
@@ -66,6 +66,50 @@ describe("EditedFileGroupList Show more / Show less", () => {
     expect(screen.queryByRole("button", { name: /Show \d+ more/ })).not.toBeInTheDocument();
   });
 
+  it("shows aggregate added and removed totals above the All files list", () => {
+    const first = group(1);
+    const second = group(2);
+    const flatGroups: EditedFileGroup[] = [
+      {
+        ...second,
+        details: [
+          {
+            ...second.details[0],
+            fileDiff: {
+              kind: "update",
+              diff: "",
+              additions: 2,
+              removals: 1,
+            },
+          },
+        ],
+        additions: 2,
+        removals: 1,
+      },
+      {
+        ...first,
+        details: [
+          {
+            ...first.details[0],
+            fileDiff: {
+              kind: "update",
+              diff: "",
+              additions: 3,
+              removals: 3,
+            },
+          },
+        ],
+        additions: 3,
+        removals: 3,
+      },
+    ];
+
+    render(<EditedFileGroupList groups={flatGroups} view="files" />);
+
+    expect(screen.getByText("Edited 2 files")).toBeInTheDocument();
+    expect(screen.getByLabelText("+5 -4")).toBeInTheDocument();
+  });
+
   it("renders the git commit badge per group from the resolved states", () => {
     render(
       <EditedFileGroupList

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9074,6 +9074,15 @@ textarea,
   color: var(--text-primary);
 }
 
+.edited-file-groups__flat-summary {
+  grid-area: summary;
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
 /* Badge cell (commit lifecycle / "This turn"). In the sidebar's second row it
    sits under the summary text, so it's indented past the chevron + gap. */
 .edited-file-groups__group-badge {


### PR DESCRIPTION
## Summary
The Edits panel no longer drops the total added/removed line counts when switching from By turn to All files. The flattened view now keeps a compact aggregate header above the file list, so users can see the same high-level diff scale before drilling into individual files.

The total is computed from the flattened per-file details, which keeps the header aligned with the rows shown in All files even when a file was edited across multiple turns.

## Verification
- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/EditedFileGroupList.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm test apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/DiffStat.test.tsx`
- `pnpm lint:boundaries`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
