### PR TITLE
fix(messaging): keep durable pending prompts alive

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -12135,6 +12135,90 @@ describe("MessagingController", () => {
     expect(harness.startTurn).not.toHaveBeenCalled();
   });
 
+  it("restores first-prompt capture after cancelling a Full Access new-thread warning", async () => {
+    let now = 1000;
+    const navigation = buildNavigationSnapshot();
+    navigation.launchpadDefaults = {
+      ...navigation.launchpadDefaults,
+      executionMode: "full-access",
+    };
+    const harness = await createHarness({
+      navigation,
+      now: () => now,
+      pendingIntentTtlMs: 60_000,
+      fullAccessControls: {
+        allowEscalation: true,
+        allowThreadResume: true,
+        warningPolicy: "always",
+        authorizedUsers: {
+          telegram: [{ id: "user-1", displayName: "" }],
+        },
+      },
+    });
+    await bindThread(harness);
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+    await harness.controller.handleInboundEvent(buildTextEvent("first prompt"));
+    const firstWarning = harness.delivered.at(-1);
+    expect(firstWarning).toMatchObject({
+      kind: "confirmation",
+      title: "Enable Full Access?",
+    });
+
+    now += 90_000;
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "full-access-risk:cancel",
+        value: findAction(firstWarning, "full-access-risk:cancel").value,
+      }),
+    );
+    harness.startTurn.mockClear();
+    harness.materializeDirectoryLaunchpad.mockClear();
+    harness.delivered.length = 0;
+
+    await harness.controller.handleInboundEvent(buildTextEvent("second prompt"));
+
+    const secondWarning = harness.delivered.at(-1);
+    expect(secondWarning).toMatchObject({
+      kind: "confirmation",
+      title: "Enable Full Access?",
+    });
+    expect(harness.startTurn).not.toHaveBeenCalled();
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "full-access-risk:accept",
+        value: findAction(secondWarning, "full-access-risk:accept").value,
+      }),
+    );
+
+    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: [
+          {
+            type: "text",
+            text: "second prompt",
+          },
+        ],
+        launchpad: expect.objectContaining({
+          executionMode: "full-access",
+        }),
+      }),
+      expectMaterializeOptions(),
+    );
+    expect(harness.startTurn).not.toHaveBeenCalled();
+  });
+
   it("delivers the normal start failure if approved Full Access prompt startup throws", async () => {
     const navigation = buildNavigationSnapshot();
     navigation.launchpadDefaults = {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -994,6 +994,53 @@ describe("MessagingController", () => {
     });
   });
 
+  it("keeps a pending new-thread first prompt usable after the picker TTL", async () => {
+    let now = 1000;
+    const harness = await createHarness({
+      now: () => now,
+      pendingIntentTtlMs: 60_000,
+    });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/resume --new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+
+    now += 2 * 24 * 60 * 60 * 1000;
+    await harness.controller.handleInboundEvent(buildTextEvent("Fix the delayed prompt bug"));
+
+    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: [
+          {
+            type: "text",
+            text: "Fix the delayed prompt bug",
+          },
+        ],
+        launchpad: expect.objectContaining({
+          backend: "codex",
+          directoryKey: "directory:pwragent",
+          directoryLabel: "PwrAgent",
+          directoryPath: "/repo/pwragent",
+        }),
+      }),
+      expectMaterializeOptions(),
+    );
+    expect(harness.delivered).not.toContainEqual(
+      expect.objectContaining({
+        kind: "confirmation",
+        title: expect.stringContaining("PwrAgent commands"),
+      }),
+    );
+  });
+
   it("updates the ready prompt into the first status card without exhausting the DM budget", async () => {
     let now = 0;
     const scope: MessagingDeliveryScope = {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -27,17 +27,18 @@ import type {
   UpdateDirectoryLaunchpadRequest,
 } from "@pwragent/shared";
 import { applyNavigationLaunchpadProviderSettingsPatch } from "@pwragent/shared";
-import type {
-  MessagingCapabilityProfile,
-  MessagingSurfaceAction,
-  MessagingChannelKind,
-  MessagingDeliveryScope,
-  MessagingDeliveryResult,
-  MessagingInboundCallbackEvent,
-  MessagingInboundEvent,
-  MessagingInboundTextEvent,
-  MessagingJsonValue,
-  MessagingSurfaceIntent,
+import {
+  MESSAGING_CALLBACK_HANDLE_TTL_MS,
+  type MessagingCapabilityProfile,
+  type MessagingSurfaceAction,
+  type MessagingChannelKind,
+  type MessagingDeliveryScope,
+  type MessagingDeliveryResult,
+  type MessagingInboundCallbackEvent,
+  type MessagingInboundEvent,
+  type MessagingInboundTextEvent,
+  type MessagingJsonValue,
+  type MessagingSurfaceIntent,
 } from "@pwragent/messaging-interface";
 import { PERMISSIVE_CAPABILITY_PROFILE } from "@pwragent/messaging-interface/testing";
 import {
@@ -9924,6 +9925,59 @@ describe("MessagingController", () => {
           id: "q1",
           allowFreeform: true,
         }),
+      ],
+    });
+  });
+
+  it("keeps Plan questionnaires active for the durable callback lifetime", async () => {
+    let now = 1000;
+    const harness = await createHarness({ now: () => now });
+    await bindThread(harness);
+
+    await harness.controller.handleBackendPendingRequest("codex", {
+      method: "item/tool/requestUserInput",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        requestId: "request-long-lived",
+        questions: [
+          {
+            id: "q1",
+            header: "Mode",
+            question: "How should I proceed?",
+            isOther: true,
+            isSecret: false,
+            options: [
+              {
+                label: "Implement (Recommended)",
+                description: "Start coding.",
+              },
+            ],
+          },
+        ],
+      },
+    } satisfies AppServerPendingRequestNotification);
+
+    const questionnaire = harness.delivered.find(
+      (intent) => intent.kind === "questionnaire",
+    );
+    expect(questionnaire).toBeDefined();
+    await expect(harness.store.getPendingIntent(questionnaire!.id, { now })).resolves
+      .toMatchObject({
+        expiresAt: now + MESSAGING_CALLBACK_HANDLE_TTL_MS,
+      });
+
+    now += 5 * 24 * 60 * 60 * 1000;
+    harness.delivered.length = 0;
+    await harness.controller.handleInboundEvent(buildTextEvent("Keep it pragmatic."));
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "questionnaire",
+      answers: [
+        {
+          kind: "custom",
+          value: "Keep it pragmatic.",
+        },
       ],
     });
   });

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -219,6 +219,7 @@ import {
   renderAutomationOutputForMessaging,
 } from "../../automations/automation-output-decision.js";
 const DEFAULT_PENDING_INTENT_TTL_MS = 15 * 60 * 1000;
+const NEW_THREAD_PROMPT_CAPTURE_TTL_MS = MESSAGING_CALLBACK_HANDLE_TTL_MS;
 const TYPING_ACTIVITY_LEASE_MS = 15_000;
 const TYPING_ACTIVITY_REFRESH_MS = 10_000;
 // Discrete item lifecycle events are cheap provider lease renewals, not
@@ -4468,20 +4469,46 @@ export class MessagingController {
       directory,
     });
     await this.presentNewThreadPromptGate(
-      normalizeNewThreadSessionForBackend({
-        ...session,
-        backend: selectedBackend.kind,
-        mode: "new_thread_options",
-        pageIndex: 0,
-        workMode,
-        branchName: workMode === "worktree" ? session.branchName : undefined,
-        selectedProject: project,
-        updatedAt: this.now(),
-        expiresAt: this.now() + this.pendingIntentTtlMs,
-      }, selectedBackend, this.now()),
+      normalizeNewThreadSessionForBackend(
+        this.withNewThreadPromptCaptureExpiry({
+          ...session,
+          backend: selectedBackend.kind,
+          mode: "new_thread_options",
+          pageIndex: 0,
+          workMode,
+          branchName: workMode === "worktree" ? session.branchName : undefined,
+          selectedProject: project,
+          updatedAt: this.now(),
+          expiresAt: this.now() + this.pendingIntentTtlMs,
+        }),
+        selectedBackend,
+        this.now(),
+      ),
       event,
       navigation,
     );
+  }
+
+  private withNewThreadPromptCaptureExpiry(
+    session: MessagingBrowseSessionRecord,
+  ): MessagingBrowseSessionRecord {
+    if (
+      !isNewThreadLaunchAction(session.launchAction) ||
+      session.mode !== "new_thread_options" ||
+      !session.selectedProject
+    ) {
+      return session;
+    }
+
+    const expiresAt = this.now() + NEW_THREAD_PROMPT_CAPTURE_TTL_MS;
+    return {
+      ...session,
+      expiresAt: Math.max(session.expiresAt, expiresAt),
+      textInputExpiresAt: Math.max(
+        session.textInputExpiresAt ?? session.expiresAt,
+        expiresAt,
+      ),
+    };
   }
 
   private async presentNewThreadPromptGate(
@@ -8398,7 +8425,9 @@ export class MessagingController {
         ...context.session,
         expiresAt: Math.max(context.session.expiresAt, expiresAt),
         textInputExpiresAt:
-          context.session.textInputExpiresAt ?? context.session.expiresAt,
+          options.presentationMode === "message"
+            ? this.now()
+            : context.session.textInputExpiresAt ?? context.session.expiresAt,
         updatedAt: this.now(),
       });
     }

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -8472,7 +8472,11 @@ export class MessagingController {
           filter: session.query,
         });
         if (context.kind === "new-thread") {
-          await this.presentNewThreadPromptGate(session, event, navigation);
+          await this.presentNewThreadPromptGate(
+            this.withNewThreadPromptCaptureExpiry(session),
+            event,
+            navigation,
+          );
         } else {
           await this.renderResumeBrowser(session, navigation, event);
         }

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -218,7 +218,7 @@ import {
   renderAutomationDecisionForMessaging,
   renderAutomationOutputForMessaging,
 } from "../../automations/automation-output-decision.js";
-const DEFAULT_PENDING_INTENT_TTL_MS = 15 * 60 * 1000;
+const DEFAULT_PENDING_INTENT_TTL_MS = MESSAGING_CALLBACK_HANDLE_TTL_MS;
 const NEW_THREAD_PROMPT_CAPTURE_TTL_MS = MESSAGING_CALLBACK_HANDLE_TTL_MS;
 const TYPING_ACTIVITY_LEASE_MS = 15_000;
 const TYPING_ACTIVITY_REFRESH_MS = 10_000;


### PR DESCRIPTION
## Summary

Messaging pending workflow state now uses the same 30-day lifetime as provider callback handles. Durable DB-backed pending intents and browse sessions no longer disappear after 15 minutes, so Codex plan questionnaires, button-driven navigator flows, and new-thread first-prompt capture can survive phone-away / next-day use and still clean up through the normal expiry sweep.

Starting a new thread from messaging also preserves the "send your first instruction" state after project selection. If someone selects a project, puts their phone away, and sends the first prompt a day or two later, that message now starts the pending new thread instead of falling through to generic command help. Once a Full Access warning has already captured the first prompt, follow-up text is still treated normally rather than being appended to the warned prompt.

Pairing tokens remain short-lived because they are auth/linking credentials, not durable workflow state.

## Test Plan

- `pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
