### PR TITLE
fix(desktop): lazy fetch live diff text

### DIFF
--- a/apps/desktop/src/main/__tests__/agent-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-ipc.test.ts
@@ -349,4 +349,56 @@ describe("agent ipc", () => {
 
     disposeAgentIpcHandlers();
   });
+
+  it("attaches pre-shaped live diff activity before broadcasting to renderer subscribers", async () => {
+    const {
+      registerAgentIpcHandlers,
+      disposeAgentIpcHandlers,
+    } = await import("../ipc/agent-ipc");
+    const { AGENT_EVENT_CHANNEL } = await import("../../shared/ipc");
+    const diff = [
+      "diff --git a/src/example.ts b/src/example.ts",
+      "--- a/src/example.ts",
+      "+++ b/src/example.ts",
+      "@@ -1,1 +1,2 @@",
+      " existing",
+      "+added",
+    ].join("\n");
+
+    registerAgentIpcHandlers();
+
+    await registryListener?.({
+      backend: "codex",
+      notification: {
+        method: "turn/diff/updated",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          diff,
+        },
+      },
+    } as AgentEvent);
+
+    expect(send).toHaveBeenCalledWith(
+      AGENT_EVENT_CHANNEL,
+      expect.objectContaining({
+        rendererActivityEntry: expect.objectContaining({
+          id: "live-diff-turn-1",
+          summary: "Edited 1 file, +1, -0",
+          details: [
+            expect.objectContaining({
+              label: "Update example.ts",
+              path: "src/example.ts",
+              fileDiff: expect.objectContaining({
+                additions: 1,
+                removals: 0,
+              }),
+            }),
+          ],
+        }),
+      }),
+    );
+
+    disposeAgentIpcHandlers();
+  });
 });

--- a/apps/desktop/src/main/__tests__/agent-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-ipc.test.ts
@@ -390,6 +390,13 @@ describe("agent ipc", () => {
               label: "Update example.ts",
               path: "src/example.ts",
               fileDiff: expect.objectContaining({
+                diff: "",
+                diffRef: expect.objectContaining({
+                  source: "live",
+                  threadId: "thread-1",
+                  entryId: "live-diff-turn-1",
+                  detailId: "live-diff-turn-1-1",
+                }),
                 additions: 1,
                 removals: 0,
               }),

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -642,6 +642,85 @@ describe("app server ipc", () => {
     expect(output).not.toContain("x".repeat(60_000));
   });
 
+  it("strips readThread file diffs behind fetchable refs before crossing IPC", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const {
+      APP_SERVER_GET_THREAD_FILE_DIFF_CHANNEL,
+      APP_SERVER_READ_THREAD_CHANNEL,
+    } = await import("../../shared/ipc");
+    const diff = [
+      "@@ -1,2 +1,4 @@",
+      " existing",
+      "+added one",
+      "+added two",
+    ].join("\n");
+    const readThreadResponse: AppServerReadThreadResponse = {
+      backend: "codex",
+      fetchedAt: 1234,
+      threadId: "thread-diff-ref",
+      replay: {
+        entries: [
+          {
+            type: "activity",
+            id: "activity-1",
+            summary: "Edited 1 file",
+            details: [
+              {
+                id: "detail-1",
+                kind: "write",
+                label: "Update file.ts",
+                path: "/repo/file.ts",
+                fileDiff: {
+                  kind: "update",
+                  diff,
+                  additions: 2,
+                  removals: 0,
+                },
+              },
+            ],
+          },
+        ],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+      },
+      threadStatus: "idle",
+    };
+    readThread.mockResolvedValueOnce(readThreadResponse as never);
+
+    registerAppServerIpcHandlers();
+
+    const response = await handlers.get(APP_SERVER_READ_THREAD_CHANNEL)?.(
+      {},
+      { backend: "codex", threadId: "thread-diff-ref" },
+    ) as AppServerReadThreadResponse | undefined;
+    const entry = response?.replay.entries[0];
+    const detail = entry?.type === "activity" ? entry.details[0] : undefined;
+
+    expect(detail?.fileDiff).toMatchObject({
+      diff: "",
+      additions: 2,
+      removals: 0,
+      diffRef: {
+        source: "thread",
+        backend: "codex",
+        threadId: "thread-diff-ref",
+        entryId: "activity-1",
+        detailId: "detail-1",
+      },
+    });
+    expect(JSON.stringify(response)).not.toContain("+added one");
+
+    const fetched = await handlers.get(APP_SERVER_GET_THREAD_FILE_DIFF_CHANNEL)?.(
+      {},
+      { ref: detail!.fileDiff!.diffRef! },
+    );
+
+    expect(fetched).toEqual({ diff });
+  });
+
   it("hydrates retained worktree snapshots when listing archived threads", async () => {
     const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
     const { APP_SERVER_LIST_THREADS_CHANNEL } = await import("../../shared/ipc");

--- a/apps/desktop/src/main/__tests__/live-diff-activity.test.ts
+++ b/apps/desktop/src/main/__tests__/live-diff-activity.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import { RENDERER_PAYLOAD_STRING_LIMIT_CHARS } from "@pwragent/shared";
-import { buildLiveDiffActivityEntry } from "../app-server/live-diff-activity";
+import {
+  buildLiveDiffActivityEntry,
+  getLiveThreadFileDiff,
+} from "../app-server/live-diff-activity";
 
 describe("live diff activity normalization", () => {
   it("splits a live unified diff into pre-shaped per-file activity details", () => {
@@ -63,8 +65,14 @@ describe("live diff activity normalization", () => {
           },
         ],
       });
-      expect(entry?.details[0]?.fileDiff?.diff).toContain("diff --git a/src/one.ts");
-      expect(entry?.details[1]?.fileDiff?.diff).toContain("diff --git a/src/two.ts");
+      expect(entry?.details[0]?.fileDiff?.diff).toBe("");
+      expect(entry?.details[1]?.fileDiff?.diff).toBe("");
+      expect(
+        getLiveThreadFileDiff(entry!.details[0]!.fileDiff!.diffRef!),
+      ).toContain("diff --git a/src/one.ts");
+      expect(
+        getLiveThreadFileDiff(entry!.details[1]!.fileDiff!.diffRef!),
+      ).toContain("diff --git a/src/two.ts");
     } finally {
       vi.useRealTimers();
     }
@@ -104,7 +112,7 @@ describe("live diff activity normalization", () => {
     ]);
   });
 
-  it("caps aggregate inline diff text across many small file sections", () => {
+  it("keeps large live diff text behind refs instead of embedding it in events", () => {
     const sections = Array.from({ length: 80 }, (_, index) => {
       const fileName = `src/file-${index}.ts`;
       const addedLine = `+${"x".repeat(700)}`;
@@ -126,23 +134,22 @@ describe("live diff activity normalization", () => {
       },
     });
 
-    const totalInlineDiffChars =
-      entry?.details.reduce(
-        (total, detail) => total + (detail.fileDiff?.diff.length ?? 0),
-        0,
-      ) ?? 0;
-    const omittedDetails =
-      entry?.details.filter((detail) => detail.fileDiff?.omittedReason) ?? [];
-
     expect(entry?.details).toHaveLength(80);
     expect(entry?.summary).toBe("Edited 80 files, +80, -0");
-    expect(totalInlineDiffChars).toBeLessThanOrEqual(
-      RENDERER_PAYLOAD_STRING_LIMIT_CHARS,
-    );
-    expect(omittedDetails.length).toBeGreaterThan(0);
-    expect(omittedDetails[0]?.fileDiff).toMatchObject({
+    expect(
+      entry?.details.every((detail) => detail.fileDiff?.diff === ""),
+    ).toBe(true);
+    expect(entry?.details[0]?.fileDiff).toMatchObject({
       diff: "",
-      omittedReason: expect.stringContaining("cumulative diff exceeds"),
+      diffRef: expect.objectContaining({
+        source: "live",
+        threadId: "thread-large",
+        entryId: "live-diff-turn-large",
+        detailId: "live-diff-turn-large-1",
+      }),
     });
+    expect(
+      getLiveThreadFileDiff(entry!.details[0]!.fileDiff!.diffRef!),
+    ).toContain("diff --git a/src/file-0.ts");
   });
 });

--- a/apps/desktop/src/main/__tests__/live-diff-activity.test.ts
+++ b/apps/desktop/src/main/__tests__/live-diff-activity.test.ts
@@ -100,7 +100,7 @@ describe("live diff activity normalization", () => {
       },
     });
 
-    expect(entry?.id).toBe("live-diff-thread-1");
+    expect(entry?.id).toMatch(/^live-diff-thread-1-\d+$/);
     expect(entry?.summary).toBe("Edited 2 files, +1, -1");
     expect(entry?.details.map((detail) => detail.fileDiff?.kind)).toEqual([
       "add",
@@ -110,6 +110,51 @@ describe("live diff activity normalization", () => {
       "Add new.ts",
       "Delete old.ts",
     ]);
+  });
+
+  it("uses unique live diff refs when turn id is omitted", () => {
+    const firstDiff = [
+      "diff --git a/src/example.ts b/src/example.ts",
+      "--- a/src/example.ts",
+      "+++ b/src/example.ts",
+      "@@ -1,1 +1,1 @@",
+      "-first",
+      "+first updated",
+    ].join("\n");
+    const secondDiff = [
+      "diff --git a/src/example.ts b/src/example.ts",
+      "--- a/src/example.ts",
+      "+++ b/src/example.ts",
+      "@@ -1,1 +1,1 @@",
+      "-second",
+      "+second updated",
+    ].join("\n");
+
+    const first = buildLiveDiffActivityEntry({
+      method: "turn/diff/updated",
+      params: {
+        threadId: "thread-no-turn",
+        diff: firstDiff,
+      },
+    });
+    const second = buildLiveDiffActivityEntry({
+      method: "turn/diff/updated",
+      params: {
+        threadId: "thread-no-turn",
+        diff: secondDiff,
+      },
+    });
+
+    expect(first?.id).not.toBe(second?.id);
+    const firstRef = first?.details[0]?.fileDiff?.diffRef;
+    const secondRef = second?.details[0]?.fileDiff?.diffRef;
+    expect(firstRef?.key).not.toBe(secondRef?.key);
+    expect(firstRef ? getLiveThreadFileDiff(firstRef) : undefined).toContain(
+      "first updated",
+    );
+    expect(secondRef ? getLiveThreadFileDiff(secondRef) : undefined).toContain(
+      "second updated",
+    );
   });
 
   it("keeps large live diff text behind refs instead of embedding it in events", () => {

--- a/apps/desktop/src/main/__tests__/live-diff-activity.test.ts
+++ b/apps/desktop/src/main/__tests__/live-diff-activity.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { RENDERER_PAYLOAD_STRING_LIMIT_CHARS } from "@pwragent/shared";
 import { buildLiveDiffActivityEntry } from "../app-server/live-diff-activity";
 
 describe("live diff activity normalization", () => {
@@ -101,5 +102,47 @@ describe("live diff activity normalization", () => {
       "Add new.ts",
       "Delete old.ts",
     ]);
+  });
+
+  it("caps aggregate inline diff text across many small file sections", () => {
+    const sections = Array.from({ length: 80 }, (_, index) => {
+      const fileName = `src/file-${index}.ts`;
+      const addedLine = `+${"x".repeat(700)}`;
+      return [
+        `diff --git a/${fileName} b/${fileName}`,
+        `--- a/${fileName}`,
+        `+++ b/${fileName}`,
+        "@@ -1,1 +1,2 @@",
+        " existing",
+        addedLine,
+      ].join("\n");
+    });
+    const entry = buildLiveDiffActivityEntry({
+      method: "turn/diff/updated",
+      params: {
+        threadId: "thread-large",
+        turnId: "turn-large",
+        diff: sections.join("\n"),
+      },
+    });
+
+    const totalInlineDiffChars =
+      entry?.details.reduce(
+        (total, detail) => total + (detail.fileDiff?.diff.length ?? 0),
+        0,
+      ) ?? 0;
+    const omittedDetails =
+      entry?.details.filter((detail) => detail.fileDiff?.omittedReason) ?? [];
+
+    expect(entry?.details).toHaveLength(80);
+    expect(entry?.summary).toBe("Edited 80 files, +80, -0");
+    expect(totalInlineDiffChars).toBeLessThanOrEqual(
+      RENDERER_PAYLOAD_STRING_LIMIT_CHARS,
+    );
+    expect(omittedDetails.length).toBeGreaterThan(0);
+    expect(omittedDetails[0]?.fileDiff).toMatchObject({
+      diff: "",
+      omittedReason: expect.stringContaining("cumulative diff exceeds"),
+    });
   });
 });

--- a/apps/desktop/src/main/__tests__/live-diff-activity.test.ts
+++ b/apps/desktop/src/main/__tests__/live-diff-activity.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildLiveDiffActivityEntry } from "../app-server/live-diff-activity";
+
+describe("live diff activity normalization", () => {
+  it("splits a live unified diff into pre-shaped per-file activity details", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-17T12:00:00.000Z"));
+
+    const diff = [
+      "diff --git a/src/one.ts b/src/one.ts",
+      "--- a/src/one.ts",
+      "+++ b/src/one.ts",
+      "@@ -1,2 +1,2 @@",
+      "-old one",
+      "+new one",
+      " context",
+      "diff --git a/src/two.ts b/src/two.ts",
+      "--- a/src/two.ts",
+      "+++ b/src/two.ts",
+      "@@ -1,1 +1,2 @@",
+      " existing",
+      "+new two",
+    ].join("\n");
+
+    try {
+      const entry = buildLiveDiffActivityEntry({
+        method: "turn/diff/updated",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          diff,
+        },
+      });
+
+      expect(entry).toMatchObject({
+        type: "activity",
+        id: "live-diff-turn-1",
+        createdAt: Date.parse("2026-06-17T12:00:00.000Z"),
+        summary: "Edited 2 files, +2, -1",
+        details: [
+          {
+            id: "live-diff-turn-1-1",
+            kind: "write",
+            label: "Update one.ts",
+            path: "src/one.ts",
+            fileDiff: {
+              kind: "update",
+              additions: 1,
+              removals: 1,
+            },
+          },
+          {
+            id: "live-diff-turn-1-2",
+            kind: "write",
+            label: "Update two.ts",
+            path: "src/two.ts",
+            fileDiff: {
+              kind: "update",
+              additions: 1,
+              removals: 0,
+            },
+          },
+        ],
+      });
+      expect(entry?.details[0]?.fileDiff?.diff).toContain("diff --git a/src/one.ts");
+      expect(entry?.details[1]?.fileDiff?.diff).toContain("diff --git a/src/two.ts");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("classifies add and delete diffs from /dev/null headers", () => {
+    const diff = [
+      "diff --git a/new.ts b/new.ts",
+      "--- /dev/null",
+      "+++ b/new.ts",
+      "@@ -0,0 +1,1 @@",
+      "+created",
+      "diff --git a/old.ts b/old.ts",
+      "--- a/old.ts",
+      "+++ /dev/null",
+      "@@ -1,1 +0,0 @@",
+      "-removed",
+    ].join("\n");
+
+    const entry = buildLiveDiffActivityEntry({
+      method: "turn/diff/updated",
+      params: {
+        threadId: "thread-1",
+        diff,
+      },
+    });
+
+    expect(entry?.id).toBe("live-diff-thread-1");
+    expect(entry?.summary).toBe("Edited 2 files, +1, -1");
+    expect(entry?.details.map((detail) => detail.fileDiff?.kind)).toEqual([
+      "add",
+      "delete",
+    ]);
+    expect(entry?.details.map((detail) => detail.label)).toEqual([
+      "Add new.ts",
+      "Delete old.ts",
+    ]);
+  });
+});

--- a/apps/desktop/src/main/__tests__/thread-file-diff-cache.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-file-diff-cache.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import type { AppServerReadThreadResponse } from "@pwragent/shared";
+import {
+  getThreadReplayFileDiff,
+  shapeReadThreadFileDiffsForRenderer,
+} from "../app-server/thread-file-diff-cache";
+
+function buildReadThreadResponse(diff: string): AppServerReadThreadResponse {
+  return {
+    backend: "codex",
+    fetchedAt: 1,
+    threadId: "thread-lazy-replay",
+    replay: {
+      entries: [
+        {
+          type: "activity",
+          id: "activity-1",
+          createdAt: 1,
+          summary: "Edited 1 file",
+          details: [
+            {
+              id: "detail-1",
+              kind: "write",
+              label: "Update thread-view.test.tsx",
+              path: "/repo/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx",
+              fileDiff: {
+                kind: "update",
+                diff,
+                additions: 128,
+                removals: 0,
+              },
+            },
+          ],
+        },
+      ],
+      messages: [],
+      pagination: {
+        supportsPagination: false,
+        hasPreviousPage: false,
+      },
+    },
+  };
+}
+
+describe("thread file diff cache", () => {
+  it("strips replay diff text into a fetchable thread diff ref", () => {
+    const diff = [
+      "@@ -1,2 +1,4 @@",
+      " existing",
+      "+added one",
+      "+added two",
+    ].join("\n");
+
+    const shaped = shapeReadThreadFileDiffsForRenderer(
+      buildReadThreadResponse(diff),
+    );
+    const detail = shaped.replay.entries[0]?.type === "activity"
+      ? shaped.replay.entries[0].details[0]
+      : undefined;
+
+    expect(detail?.fileDiff).toMatchObject({
+      kind: "update",
+      diff: "",
+      additions: 128,
+      removals: 0,
+      diffRef: {
+        source: "thread",
+        backend: "codex",
+        threadId: "thread-lazy-replay",
+        entryId: "activity-1",
+        detailId: "detail-1",
+      },
+    });
+    expect(detail?.fileDiff?.diffRef?.key).toContain(
+      "thread:codex:thread-lazy-replay:activity-1:detail-1:",
+    );
+    expect(getThreadReplayFileDiff(detail!.fileDiff!.diffRef!)).toBe(diff);
+  });
+
+  it("does not attach a ref when a diff was already omitted", () => {
+    const response = buildReadThreadResponse("large omitted body");
+    const entry = response.replay.entries[0];
+    if (entry.type !== "activity") {
+      throw new Error("Expected activity entry");
+    }
+    entry.details[0]!.fileDiff!.omittedReason = "Large file diff omitted.";
+
+    const shaped = shapeReadThreadFileDiffsForRenderer(response);
+    const detail = shaped.replay.entries[0]?.type === "activity"
+      ? shaped.replay.entries[0].details[0]
+      : undefined;
+
+    expect(detail?.fileDiff).toMatchObject({
+      diff: "",
+      omittedReason: "Large file diff omitted.",
+    });
+    expect(detail?.fileDiff?.diffRef).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/main/app-server/live-diff-activity.ts
+++ b/apps/desktop/src/main/app-server/live-diff-activity.ts
@@ -4,6 +4,17 @@ import type {
   AppServerThreadActivityEntry,
   AppServerThreadFileChangeKind,
 } from "@pwragent/shared";
+import { RENDERER_PAYLOAD_STRING_LIMIT_CHARS } from "@pwragent/shared";
+
+const LIVE_DIFF_INLINE_BUDGET_CHARS = RENDERER_PAYLOAD_STRING_LIMIT_CHARS;
+
+function liveDiffOmittedReason(originalLength: number): string {
+  return [
+    "Live diff omitted from inline view because the cumulative diff exceeds",
+    `${LIVE_DIFF_INLINE_BUDGET_CHARS.toLocaleString()} characters.`,
+    `Original section length: ${originalLength.toLocaleString()} characters.`,
+  ].join(" ");
+}
 
 function summarizeDiff(diff: string): { additions: number; removals: number } {
   let additions = 0;
@@ -118,6 +129,7 @@ export function extractLiveDiffActivityDetails(params: {
 
   const normalizedSections = sections.length > 0 ? sections : [{ lines }];
   const details: AppServerThreadActivityDetail[] = [];
+  let remainingInlineDiffChars = LIVE_DIFF_INLINE_BUDGET_CHARS;
 
   for (const [index, section] of normalizedSections.entries()) {
     const rawBefore = section.lines.find((line) => line.startsWith("--- "))?.slice(4).trim();
@@ -131,6 +143,10 @@ export function extractLiveDiffActivityDetails(params: {
 
     const kind = inferDiffKind(section.lines);
     const diffSummary = summarizeDiff(diffText);
+    const includeInlineDiff = diffText.length <= remainingInlineDiffChars;
+    if (includeInlineDiff) {
+      remainingInlineDiffChars -= diffText.length;
+    }
 
     details.push({
       id: `${params.entryId}-${index + 1}`,
@@ -139,9 +155,15 @@ export function extractLiveDiffActivityDetails(params: {
       ...(path ? { path } : {}),
       fileDiff: {
         kind,
-        diff: diffText,
+        diff: includeInlineDiff ? diffText : "",
         additions: diffSummary.additions,
         removals: diffSummary.removals,
+        ...(includeInlineDiff
+          ? {}
+          : {
+              omittedReason: liveDiffOmittedReason(diffText.length),
+              originalLength: diffText.length,
+            }),
       },
     });
   }

--- a/apps/desktop/src/main/app-server/live-diff-activity.ts
+++ b/apps/desktop/src/main/app-server/live-diff-activity.ts
@@ -9,6 +9,7 @@ import type {
 const MAX_LIVE_DIFF_CACHE_ENTRIES = 2_000;
 
 const liveDiffCache = new Map<string, { diff: string; storedAt: number }>();
+let fallbackLiveDiffEntrySequence = 0;
 
 function buildLiveDiffRef(params: {
   threadId: string;
@@ -206,7 +207,9 @@ export function extractLiveDiffActivityDetails(params: {
 export function buildLiveDiffActivityEntry(
   notification: Extract<AppServerNotification, { method: "turn/diff/updated" }>,
 ): AppServerThreadActivityEntry | undefined {
-  const entryId = `live-diff-${notification.params.turnId ?? notification.params.threadId}`;
+  const entryId = notification.params.turnId
+    ? `live-diff-${notification.params.turnId}`
+    : `live-diff-${notification.params.threadId}-${fallbackLiveDiffEntrySequence += 1}`;
   const details = extractLiveDiffActivityDetails({
     diff: notification.params.diff,
     entryId,

--- a/apps/desktop/src/main/app-server/live-diff-activity.ts
+++ b/apps/desktop/src/main/app-server/live-diff-activity.ts
@@ -1,0 +1,184 @@
+import type {
+  AppServerNotification,
+  AppServerThreadActivityDetail,
+  AppServerThreadActivityEntry,
+  AppServerThreadFileChangeKind,
+} from "@pwragent/shared";
+
+function summarizeDiff(diff: string): { additions: number; removals: number } {
+  let additions = 0;
+  let removals = 0;
+
+  for (const line of diff.split("\n")) {
+    if (
+      !line ||
+      line.startsWith("+++") ||
+      line.startsWith("---") ||
+      line.startsWith("@@") ||
+      line.startsWith("\\")
+    ) {
+      continue;
+    }
+
+    if (line.startsWith("+")) {
+      additions += 1;
+      continue;
+    }
+
+    if (line.startsWith("-")) {
+      removals += 1;
+    }
+  }
+
+  return { additions, removals };
+}
+
+function normalizeDiffPath(path: string | undefined): string | undefined {
+  if (!path || path === "/dev/null") {
+    return undefined;
+  }
+
+  return path.replace(/^[ab]\//, "");
+}
+
+function inferDiffKind(lines: string[]): AppServerThreadFileChangeKind {
+  const beforeLine = lines.find((line) => line.startsWith("--- "));
+  const afterLine = lines.find((line) => line.startsWith("+++ "));
+
+  if (beforeLine?.slice(4).trim() === "/dev/null") {
+    return "add";
+  }
+
+  if (afterLine?.slice(4).trim() === "/dev/null") {
+    return "delete";
+  }
+
+  return "update";
+}
+
+function getBasename(path: string): string {
+  const segments = path.split(/[\\/]/);
+  return segments[segments.length - 1] || path;
+}
+
+function buildDiffLabel(kind: AppServerThreadFileChangeKind, path?: string): string {
+  const verb = kind[0]?.toUpperCase() + kind.slice(1);
+  return `${verb} ${path ? getBasename(path) : "file"}`;
+}
+
+function formatChangedFileCount(params: {
+  count: number;
+  prefix: "Changed" | "Edited";
+}): string {
+  return `${params.prefix} ${params.count} file${params.count === 1 ? "" : "s"}`;
+}
+
+function formatChangedFileSummary(params: {
+  count: number;
+  prefix: "Changed" | "Edited";
+  additions: number;
+  removals: number;
+}): string {
+  const parts = [formatChangedFileCount(params)];
+  if (params.additions > 0 || params.removals > 0) {
+    parts.push(
+      `+${params.additions.toLocaleString()}, -${params.removals.toLocaleString()}`,
+    );
+  }
+  return parts.join(", ");
+}
+
+export function extractLiveDiffActivityDetails(params: {
+  diff: string;
+  entryId: string;
+}): AppServerThreadActivityDetail[] {
+  const lines = params.diff.replace(/\r\n?/g, "\n").split("\n");
+  const sections: Array<{ lines: string[] }> = [];
+  let currentSection: { lines: string[] } | undefined;
+
+  for (const line of lines) {
+    if (line.startsWith("diff --git ")) {
+      if (currentSection?.lines.length) {
+        sections.push(currentSection);
+      }
+      currentSection = { lines: [line] };
+      continue;
+    }
+
+    if (!currentSection) {
+      currentSection = { lines: [] };
+    }
+
+    currentSection.lines.push(line);
+  }
+
+  if (currentSection?.lines.length) {
+    sections.push(currentSection);
+  }
+
+  const normalizedSections = sections.length > 0 ? sections : [{ lines }];
+  const details: AppServerThreadActivityDetail[] = [];
+
+  for (const [index, section] of normalizedSections.entries()) {
+    const rawBefore = section.lines.find((line) => line.startsWith("--- "))?.slice(4).trim();
+    const rawAfter = section.lines.find((line) => line.startsWith("+++ "))?.slice(4).trim();
+    const path = normalizeDiffPath(rawAfter) ?? normalizeDiffPath(rawBefore);
+    const diffText = section.lines.join("\n").trim();
+
+    if (!diffText) {
+      continue;
+    }
+
+    const kind = inferDiffKind(section.lines);
+    const diffSummary = summarizeDiff(diffText);
+
+    details.push({
+      id: `${params.entryId}-${index + 1}`,
+      kind: "write",
+      label: buildDiffLabel(kind, path),
+      ...(path ? { path } : {}),
+      fileDiff: {
+        kind,
+        diff: diffText,
+        additions: diffSummary.additions,
+        removals: diffSummary.removals,
+      },
+    });
+  }
+
+  return details;
+}
+
+export function buildLiveDiffActivityEntry(
+  notification: Extract<AppServerNotification, { method: "turn/diff/updated" }>,
+): AppServerThreadActivityEntry | undefined {
+  const entryId = `live-diff-${notification.params.turnId ?? notification.params.threadId}`;
+  const details = extractLiveDiffActivityDetails({
+    diff: notification.params.diff,
+    entryId,
+  });
+  if (details.length === 0) {
+    return undefined;
+  }
+  const additions = details.reduce(
+    (total, detail) => total + (detail.fileDiff?.additions ?? 0),
+    0,
+  );
+  const removals = details.reduce(
+    (total, detail) => total + (detail.fileDiff?.removals ?? 0),
+    0,
+  );
+
+  return {
+    type: "activity",
+    id: entryId,
+    createdAt: Date.now(),
+    summary: formatChangedFileSummary({
+      count: details.length,
+      prefix: "Edited",
+      additions,
+      removals,
+    }),
+    details,
+  };
+}

--- a/apps/desktop/src/main/app-server/live-diff-activity.ts
+++ b/apps/desktop/src/main/app-server/live-diff-activity.ts
@@ -3,17 +3,51 @@ import type {
   AppServerThreadActivityDetail,
   AppServerThreadActivityEntry,
   AppServerThreadFileChangeKind,
+  AppServerThreadFileDiffRef,
 } from "@pwragent/shared";
-import { RENDERER_PAYLOAD_STRING_LIMIT_CHARS } from "@pwragent/shared";
 
-const LIVE_DIFF_INLINE_BUDGET_CHARS = RENDERER_PAYLOAD_STRING_LIMIT_CHARS;
+const MAX_LIVE_DIFF_CACHE_ENTRIES = 2_000;
 
-function liveDiffOmittedReason(originalLength: number): string {
-  return [
-    "Live diff omitted from inline view because the cumulative diff exceeds",
-    `${LIVE_DIFF_INLINE_BUDGET_CHARS.toLocaleString()} characters.`,
-    `Original section length: ${originalLength.toLocaleString()} characters.`,
-  ].join(" ");
+const liveDiffCache = new Map<string, { diff: string; storedAt: number }>();
+
+function buildLiveDiffRef(params: {
+  threadId: string;
+  entryId: string;
+  detailId: string;
+}): AppServerThreadFileDiffRef {
+  return {
+    source: "live",
+    key: `live:${params.threadId}:${params.entryId}:${params.detailId}`,
+    threadId: params.threadId,
+    entryId: params.entryId,
+    detailId: params.detailId,
+  };
+}
+
+function rememberLiveDiff(ref: AppServerThreadFileDiffRef, diff: string): void {
+  liveDiffCache.set(ref.key, { diff, storedAt: Date.now() });
+  if (liveDiffCache.size <= MAX_LIVE_DIFF_CACHE_ENTRIES) {
+    return;
+  }
+
+  const entriesByAge = [...liveDiffCache.entries()].sort(
+    (left, right) => left[1].storedAt - right[1].storedAt,
+  );
+  for (const [key] of entriesByAge.slice(
+    0,
+    liveDiffCache.size - MAX_LIVE_DIFF_CACHE_ENTRIES,
+  )) {
+    liveDiffCache.delete(key);
+  }
+}
+
+export function getLiveThreadFileDiff(
+  ref: AppServerThreadFileDiffRef,
+): string | undefined {
+  if (ref.source !== "live") {
+    return undefined;
+  }
+  return liveDiffCache.get(ref.key)?.diff;
 }
 
 function summarizeDiff(diff: string): { additions: number; removals: number } {
@@ -102,6 +136,7 @@ function formatChangedFileSummary(params: {
 export function extractLiveDiffActivityDetails(params: {
   diff: string;
   entryId: string;
+  threadId: string;
 }): AppServerThreadActivityDetail[] {
   const lines = params.diff.replace(/\r\n?/g, "\n").split("\n");
   const sections: Array<{ lines: string[] }> = [];
@@ -129,7 +164,6 @@ export function extractLiveDiffActivityDetails(params: {
 
   const normalizedSections = sections.length > 0 ? sections : [{ lines }];
   const details: AppServerThreadActivityDetail[] = [];
-  let remainingInlineDiffChars = LIVE_DIFF_INLINE_BUDGET_CHARS;
 
   for (const [index, section] of normalizedSections.entries()) {
     const rawBefore = section.lines.find((line) => line.startsWith("--- "))?.slice(4).trim();
@@ -143,27 +177,25 @@ export function extractLiveDiffActivityDetails(params: {
 
     const kind = inferDiffKind(section.lines);
     const diffSummary = summarizeDiff(diffText);
-    const includeInlineDiff = diffText.length <= remainingInlineDiffChars;
-    if (includeInlineDiff) {
-      remainingInlineDiffChars -= diffText.length;
-    }
+    const detailId = `${params.entryId}-${index + 1}`;
+    const diffRef = buildLiveDiffRef({
+      threadId: params.threadId,
+      entryId: params.entryId,
+      detailId,
+    });
+    rememberLiveDiff(diffRef, diffText);
 
     details.push({
-      id: `${params.entryId}-${index + 1}`,
+      id: detailId,
       kind: "write",
       label: buildDiffLabel(kind, path),
       ...(path ? { path } : {}),
       fileDiff: {
         kind,
-        diff: includeInlineDiff ? diffText : "",
+        diff: "",
+        diffRef,
         additions: diffSummary.additions,
         removals: diffSummary.removals,
-        ...(includeInlineDiff
-          ? {}
-          : {
-              omittedReason: liveDiffOmittedReason(diffText.length),
-              originalLength: diffText.length,
-            }),
       },
     });
   }
@@ -178,6 +210,7 @@ export function buildLiveDiffActivityEntry(
   const details = extractLiveDiffActivityDetails({
     diff: notification.params.diff,
     entryId,
+    threadId: notification.params.threadId,
   });
   if (details.length === 0) {
     return undefined;

--- a/apps/desktop/src/main/app-server/thread-file-diff-cache.ts
+++ b/apps/desktop/src/main/app-server/thread-file-diff-cache.ts
@@ -1,0 +1,174 @@
+import { createHash } from "node:crypto";
+import type {
+  AppServerBackendKind,
+  AppServerReadThreadResponse,
+  AppServerThreadActivityDetail,
+  AppServerThreadActivityEntry,
+  AppServerThreadEntry,
+  AppServerThreadFileDiffRef,
+} from "@pwragent/shared";
+
+const MAX_THREAD_DIFF_CACHE_ENTRIES = 5_000;
+const MAX_THREAD_DIFF_CACHE_CHARS = 20_000_000;
+
+const threadDiffCache = new Map<string, { diff: string; storedAt: number }>();
+let threadDiffCacheChars = 0;
+
+function buildThreadDiffRef(params: {
+  backend: AppServerBackendKind;
+  threadId: string;
+  entryId: string;
+  detailId: string;
+  diff: string;
+}): AppServerThreadFileDiffRef {
+  const hash = createHash("sha256").update(params.diff).digest("hex").slice(0, 16);
+  return {
+    source: "thread",
+    key: `thread:${params.backend}:${params.threadId}:${params.entryId}:${params.detailId}:${hash}`,
+    backend: params.backend,
+    threadId: params.threadId,
+    entryId: params.entryId,
+    detailId: params.detailId,
+  };
+}
+
+function rememberThreadDiff(ref: AppServerThreadFileDiffRef, diff: string): void {
+  const existing = threadDiffCache.get(ref.key);
+  if (existing) {
+    threadDiffCacheChars -= existing.diff.length;
+  }
+  threadDiffCache.set(ref.key, { diff, storedAt: Date.now() });
+  threadDiffCacheChars += diff.length;
+
+  if (
+    threadDiffCache.size <= MAX_THREAD_DIFF_CACHE_ENTRIES &&
+    threadDiffCacheChars <= MAX_THREAD_DIFF_CACHE_CHARS
+  ) {
+    return;
+  }
+
+  const entriesByAge = [...threadDiffCache.entries()].sort(
+    (left, right) => left[1].storedAt - right[1].storedAt,
+  );
+  for (const [key, value] of entriesByAge) {
+    if (
+      threadDiffCache.size <= MAX_THREAD_DIFF_CACHE_ENTRIES &&
+      threadDiffCacheChars <= MAX_THREAD_DIFF_CACHE_CHARS
+    ) {
+      break;
+    }
+    threadDiffCache.delete(key);
+    threadDiffCacheChars -= value.diff.length;
+  }
+}
+
+export function getThreadReplayFileDiff(
+  ref: AppServerThreadFileDiffRef,
+): string | undefined {
+  if (ref.source !== "thread") {
+    return undefined;
+  }
+  return threadDiffCache.get(ref.key)?.diff;
+}
+
+function shapeActivityDetailDiff(params: {
+  backend: AppServerBackendKind;
+  threadId: string;
+  entryId: string;
+  detail: AppServerThreadActivityDetail;
+}): AppServerThreadActivityDetail {
+  const fileDiff = params.detail.fileDiff;
+  if (!fileDiff?.diff) {
+    return params.detail;
+  }
+
+  if (fileDiff.omittedReason) {
+    return {
+      ...params.detail,
+      fileDiff: {
+        ...fileDiff,
+        diff: "",
+      },
+    };
+  }
+
+  const diffRef = buildThreadDiffRef({
+    backend: params.backend,
+    threadId: params.threadId,
+    entryId: params.entryId,
+    detailId: params.detail.id,
+    diff: fileDiff.diff,
+  });
+  rememberThreadDiff(diffRef, fileDiff.diff);
+
+  return {
+    ...params.detail,
+    fileDiff: {
+      ...fileDiff,
+      diff: "",
+      diffRef,
+    },
+  };
+}
+
+function shapeActivityEntryDiffs(params: {
+  backend: AppServerBackendKind;
+  threadId: string;
+  entry: AppServerThreadActivityEntry;
+}): AppServerThreadActivityEntry {
+  let changed = false;
+  const details = params.entry.details.map((detail) => {
+    const shaped = shapeActivityDetailDiff({
+      backend: params.backend,
+      threadId: params.threadId,
+      entryId: params.entry.id,
+      detail,
+    });
+    changed = changed || shaped !== detail;
+    return shaped;
+  });
+
+  return changed ? { ...params.entry, details } : params.entry;
+}
+
+function shapeThreadEntryDiffs(params: {
+  backend: AppServerBackendKind;
+  threadId: string;
+  entry: AppServerThreadEntry;
+}): AppServerThreadEntry {
+  if (params.entry.type !== "activity") {
+    return params.entry;
+  }
+  return shapeActivityEntryDiffs({
+    backend: params.backend,
+    threadId: params.threadId,
+    entry: params.entry,
+  });
+}
+
+export function shapeReadThreadFileDiffsForRenderer(
+  response: AppServerReadThreadResponse,
+): AppServerReadThreadResponse {
+  let changed = false;
+  const entries = response.replay.entries.map((entry) => {
+    const shaped = shapeThreadEntryDiffs({
+      backend: response.backend,
+      threadId: response.threadId,
+      entry,
+    });
+    changed = changed || shaped !== entry;
+    return shaped;
+  });
+
+  if (!changed) {
+    return response;
+  }
+
+  return {
+    ...response,
+    replay: {
+      ...response.replay,
+      entries,
+    },
+  };
+}

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -48,6 +48,7 @@ import {
   type UpdateThreadExpectedBranchResponse,
 } from "@pwragent/shared";
 import { getDesktopBackendRegistry } from "../app-server/backend-registry";
+import { buildLiveDiffActivityEntry } from "../app-server/live-diff-activity";
 import { timeStartupProfileOperation } from "../diagnostics/startup-profile-events";
 import {
   AGENT_CANCEL_THREAD_EXECUTION_MODE_QUEUE_CHANNEL,
@@ -253,12 +254,23 @@ function coalescedAgentEventLogKey(
   });
 }
 
+function withRendererActivityEntry(event: AgentEvent): AgentEvent {
+  if (event.backend !== "codex" || event.notification.method !== "turn/diff/updated") {
+    return event;
+  }
+
+  const rendererActivityEntry = buildLiveDiffActivityEntry(
+    event.notification as Extract<AgentEvent["notification"], { method: "turn/diff/updated" }>,
+  );
+  return rendererActivityEntry ? { ...event, rendererActivityEntry } : event;
+}
+
 function broadcastAgentEvent(event: AgentEvent): void {
   const eventSummary = summarizeAgentEvent(event);
   if (eventSummary) {
     logAgentEventSummary(eventSummary);
   }
-  const rendererEvent = sanitizeRendererPayload(event);
+  const rendererEvent = sanitizeRendererPayload(withRendererActivityEntry(event));
 
   // Only deliver to windows that registered for this channel.
   // Secondary windows (e.g. the Messaging Activity window) opt out by

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -170,6 +170,10 @@ import { ThreadSearchService } from "../thread-search/thread-search-service";
 import { ThreadSearchStore } from "../thread-search/thread-search-store";
 import { timeStartupProfileOperation } from "../diagnostics/startup-profile-events";
 import { getLiveThreadFileDiff } from "../app-server/live-diff-activity";
+import {
+  getThreadReplayFileDiff,
+  shapeReadThreadFileDiffsForRenderer,
+} from "../app-server/thread-file-diff-cache";
 
 const isDevelopment = process.env.NODE_ENV !== "production";
 const THREAD_PR_REFRESH_MIN_INTERVAL_MS = 60_000;
@@ -753,8 +757,9 @@ class DesktopAppServerService {
       threadStatus: response.threadStatus ?? response.replay.threadStatus,
     });
 
+    const materialized = await materializeTranscriptImageUrlsForRenderer(response);
     return sanitizeRendererPayload(
-      await materializeTranscriptImageUrlsForRenderer(response),
+      shapeReadThreadFileDiffsForRenderer(materialized),
     );
   }
 
@@ -2956,9 +2961,11 @@ export function registerAppServerIpcHandlers(): void {
       _event,
       request: GetThreadFileDiffRequest,
     ): Promise<GetThreadFileDiffResponse> => {
-      const diff = getLiveThreadFileDiff(request.ref);
+      const diff =
+        getLiveThreadFileDiff(request.ref) ??
+        getThreadReplayFileDiff(request.ref);
       return diff === undefined
-        ? { omittedReason: "Diff is no longer available for this live update." }
+        ? { omittedReason: "Diff is no longer available for this thread entry." }
         : { diff };
     },
   );

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -29,6 +29,8 @@ import {
   type PersistThreadUsageActivityResponse,
   type AppServerReadThreadRequest,
   type AppServerReadThreadResponse,
+  type GetThreadFileDiffRequest,
+  type GetThreadFileDiffResponse,
   type EnsureDirectoryLaunchpadRequest,
   type EnsureDirectoryLaunchpadResponse,
   type FocusedDiffAnalysisRequest,
@@ -124,6 +126,7 @@ import {
   APP_SERVER_RESTORE_WORKTREE_CHANNEL,
   APP_SERVER_RENAME_THREAD_CHANNEL,
   APP_SERVER_READ_THREAD_CHANNEL,
+  APP_SERVER_GET_THREAD_FILE_DIFF_CHANNEL,
   THREAD_MIGRATION_LIST_SOURCES_CHANNEL,
   THREAD_MIGRATION_LIST_SOURCE_THREADS_CHANNEL,
   THREAD_MIGRATION_RETRY_CHANNEL,
@@ -166,6 +169,7 @@ import { ProviderTranscriptThreadSearchAdapter } from "../thread-search/thread-s
 import { ThreadSearchService } from "../thread-search/thread-search-service";
 import { ThreadSearchStore } from "../thread-search/thread-search-store";
 import { timeStartupProfileOperation } from "../diagnostics/startup-profile-events";
+import { getLiveThreadFileDiff } from "../app-server/live-diff-activity";
 
 const isDevelopment = process.env.NODE_ENV !== "production";
 const THREAD_PR_REFRESH_MIN_INTERVAL_MS = 60_000;
@@ -2945,6 +2949,19 @@ export function registerAppServerIpcHandlers(): void {
       });
     }
   );
+  ipcMain.removeHandler(APP_SERVER_GET_THREAD_FILE_DIFF_CHANNEL);
+  ipcMain.handle(
+    APP_SERVER_GET_THREAD_FILE_DIFF_CHANNEL,
+    async (
+      _event,
+      request: GetThreadFileDiffRequest,
+    ): Promise<GetThreadFileDiffResponse> => {
+      const diff = getLiveThreadFileDiff(request.ref);
+      return diff === undefined
+        ? { omittedReason: "Diff is no longer available for this live update." }
+        : { diff };
+    },
+  );
   ipcMain.removeHandler(APP_SERVER_PERSIST_THREAD_USAGE_ACTIVITY_CHANNEL);
   ipcMain.handle(
     APP_SERVER_PERSIST_THREAD_USAGE_ACTIVITY_CHANNEL,
@@ -3325,6 +3342,7 @@ export async function disposeAppServerIpcHandlers(): Promise<void> {
   ipcMain.removeHandler(APP_SERVER_LIST_SKILLS_CHANNEL);
   ipcMain.removeHandler(APP_SERVER_LIST_THREADS_CHANNEL);
   ipcMain.removeHandler(APP_SERVER_READ_THREAD_CHANNEL);
+  ipcMain.removeHandler(APP_SERVER_GET_THREAD_FILE_DIFF_CHANNEL);
   ipcMain.removeHandler(APP_SERVER_PERSIST_THREAD_USAGE_ACTIVITY_CHANNEL);
   ipcMain.removeHandler(APP_SERVER_ARCHIVE_THREAD_CHANNEL);
   ipcMain.removeHandler(APP_SERVER_RESTORE_THREAD_CHANNEL);

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -53,6 +53,8 @@ import type {
   ThreadSearchResponse,
   AppServerReadThreadRequest,
   AppServerReadThreadResponse,
+  GetThreadFileDiffRequest,
+  GetThreadFileDiffResponse,
   PersistThreadUsageActivityRequest,
   PersistThreadUsageActivityResponse,
   CheckThreadBranchDriftRequest,
@@ -287,6 +289,7 @@ import {
   APP_SERVER_RESTORE_WORKTREE_CHANNEL,
   APP_SERVER_RENAME_THREAD_CHANNEL,
   APP_SERVER_READ_THREAD_CHANNEL,
+  APP_SERVER_GET_THREAD_FILE_DIFF_CHANNEL,
   APPLICATION_OPEN_CHANNEL,
   INTEGRATED_TERMINAL_CLOSE_CHANNEL,
   INTEGRATED_TERMINAL_CREATE_CHANNEL,
@@ -807,6 +810,10 @@ const desktopApi = Object.freeze({
       APP_SERVER_READ_THREAD_CHANNEL,
       request,
     ),
+  getThreadFileDiff: async (
+    request: GetThreadFileDiffRequest,
+  ): Promise<GetThreadFileDiffResponse> =>
+    await ipcRenderer.invoke(APP_SERVER_GET_THREAD_FILE_DIFF_CHANNEL, request),
   persistThreadUsageActivity: async (
     request: PersistThreadUsageActivityRequest,
   ): Promise<PersistThreadUsageActivityResponse> =>

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -79,8 +79,6 @@ import {
   type PendingMcpInteractionState,
 } from "./mcp-elicitation";
 import {
-  formatChangedFileSummary,
-  getBasename,
   mergeActivityDetails,
   readRendererSequence,
   summarizeActivityStatus,
@@ -401,34 +399,6 @@ function arePlanEntriesEquivalent(
   });
 }
 
-function summarizeDiff(diff: string): { additions: number; removals: number } {
-  let additions = 0;
-  let removals = 0;
-
-  for (const line of diff.split("\n")) {
-    if (
-      !line ||
-      line.startsWith("+++") ||
-      line.startsWith("---") ||
-      line.startsWith("@@") ||
-      line.startsWith("\\")
-    ) {
-      continue;
-    }
-
-    if (line.startsWith("+")) {
-      additions += 1;
-      continue;
-    }
-
-    if (line.startsWith("-")) {
-      removals += 1;
-    }
-  }
-
-  return { additions, removals };
-}
-
 function getPlanNotificationItemId(params: Record<string, unknown>): string | undefined {
   if (typeof params.itemId === "string") {
     return params.itemId;
@@ -602,128 +572,6 @@ function normalizeLivePlanSteps(value: unknown): AppServerThreadPlanStep[] {
 
     return [{ step, status }];
   });
-}
-
-function normalizeDiffPath(path: string | undefined): string | undefined {
-  if (!path || path === "/dev/null") {
-    return undefined;
-  }
-
-  return path.replace(/^[ab]\//, "");
-}
-
-function inferDiffKind(lines: string[]): "add" | "delete" | "update" {
-  const beforeLine = lines.find((line) => line.startsWith("--- "));
-  const afterLine = lines.find((line) => line.startsWith("+++ "));
-
-  if (beforeLine?.slice(4).trim() === "/dev/null") {
-    return "add";
-  }
-
-  if (afterLine?.slice(4).trim() === "/dev/null") {
-    return "delete";
-  }
-
-  return "update";
-}
-
-function buildDiffLabel(kind: "add" | "delete" | "update", path?: string): string {
-  const verb = kind[0]?.toUpperCase() + kind.slice(1);
-  return `${verb} ${path ? getBasename(path) : "file"}`;
-}
-
-function extractDiffDetails(
-  diff: string,
-  entryId: string
-): AppServerThreadActivityDetail[] {
-  const lines = diff.replace(/\r\n?/g, "\n").split("\n");
-  const sections: Array<{ lines: string[] }> = [];
-  let currentSection: { lines: string[] } | undefined;
-
-  for (const line of lines) {
-    if (line.startsWith("diff --git ")) {
-      if (currentSection?.lines.length) {
-        sections.push(currentSection);
-      }
-      currentSection = { lines: [line] };
-      continue;
-    }
-
-    if (!currentSection) {
-      currentSection = { lines: [] };
-    }
-
-    currentSection.lines.push(line);
-  }
-
-  if (currentSection?.lines.length) {
-    sections.push(currentSection);
-  }
-
-  const normalizedSections = sections.length > 0 ? sections : [{ lines }];
-  const details: AppServerThreadActivityDetail[] = [];
-
-  for (const [index, section] of normalizedSections.entries()) {
-    const rawBefore = section.lines.find((line) => line.startsWith("--- "))?.slice(4).trim();
-    const rawAfter = section.lines.find((line) => line.startsWith("+++ "))?.slice(4).trim();
-    const path = normalizeDiffPath(rawAfter) ?? normalizeDiffPath(rawBefore);
-    const diffText = section.lines.join("\n").trim();
-
-    if (!diffText) {
-      continue;
-    }
-
-    const kind = inferDiffKind(section.lines);
-    const diffSummary = summarizeDiff(diffText);
-
-    details.push({
-      id: `${entryId}-${index + 1}`,
-      kind: "write",
-      label: buildDiffLabel(kind, path),
-      ...(path ? { path } : {}),
-      fileDiff: {
-        kind,
-        diff: diffText,
-        additions: diffSummary.additions,
-        removals: diffSummary.removals,
-      },
-    });
-  }
-
-  return details;
-}
-
-function buildPendingDiffEntry(params: {
-  diff: string;
-  id: string;
-  turn?: AppServerThreadTurnMetadata;
-}): AppServerThreadActivityEntry | undefined {
-  const details = extractDiffDetails(params.diff, params.id);
-  if (details.length === 0) {
-    return undefined;
-  }
-  const additions = details.reduce(
-    (total, detail) => total + (detail.fileDiff?.additions ?? 0),
-    0
-  );
-  const removals = details.reduce(
-    (total, detail) => total + (detail.fileDiff?.removals ?? 0),
-    0
-  );
-
-  return {
-    type: "activity",
-    id: params.id,
-    createdAt: Date.now(),
-    summary: formatChangedFileSummary({
-      count: details.length,
-      prefix: "Edited",
-      additions,
-      removals,
-    }),
-    details,
-    ...(params.turn ? { turn: params.turn } : {}),
-  };
 }
 
 function buildWarningActivityEntry(params: {
@@ -1907,31 +1755,23 @@ export function ThreadView(props: ThreadViewProps) {
       }
 
       if (event.notification.method === "turn/diff/updated") {
-        if (typeof event.notification.params.diff !== "string") {
+        if (!event.rendererActivityEntry) {
           return;
         }
 
-        setPendingActivityEntry(
-          buildPendingDiffEntry({
-            diff: event.notification.params.diff,
-            id: `live-diff-${
+        const turn = buildLiveTurnMetadata({
+          turnId:
+            liveNotificationTurnId(
               typeof event.notification.params.turnId === "string"
                 ? event.notification.params.turnId
-                : typeof event.notification.params.turnId === "string"
-                  ? event.notification.params.turnId
-                  : selectedThread.id
-            }`,
-            turn: buildLiveTurnMetadata({
-              turnId:
-                liveNotificationTurnId(
-                  typeof event.notification.params.turnId === "string"
-                    ? event.notification.params.turnId
-                    : undefined
-                ),
-              activeTurnStartedAt: props.activeTurnStartedAt,
-            }),
-          })
-        );
+                : undefined
+            ),
+          activeTurnStartedAt: props.activeTurnStartedAt,
+        });
+        setPendingActivityEntry({
+          ...event.rendererActivityEntry,
+          ...(turn ? { turn } : {}),
+        });
         return;
       }
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -655,12 +655,36 @@ function activityContainsDiff(
   pendingEntry: AppServerThreadActivityEntry
 ): boolean {
   return pendingEntry.details.every((pendingDetail) => {
-    const pendingDiff = pendingDetail.fileDiff?.diff;
-    if (!pendingDiff) {
+    const pendingFileDiff = pendingDetail.fileDiff;
+    if (!pendingFileDiff) {
       return false;
     }
 
-    return candidate.details.some((detail) => detail.fileDiff?.diff === pendingDiff);
+    return candidate.details.some((detail) => {
+      const candidateFileDiff = detail.fileDiff;
+      if (!candidateFileDiff) {
+        return false;
+      }
+
+      if (pendingFileDiff.diff) {
+        return candidateFileDiff.diff === pendingFileDiff.diff;
+      }
+
+      if (!pendingFileDiff.diffRef) {
+        return false;
+      }
+
+      const sameFile =
+        pendingDetail.path && detail.path
+          ? pendingDetail.path === detail.path
+          : pendingDetail.label === detail.label;
+      return (
+        sameFile &&
+        candidateFileDiff.kind === pendingFileDiff.kind &&
+        candidateFileDiff.additions === pendingFileDiff.additions &&
+        candidateFileDiff.removals === pendingFileDiff.removals
+      );
+    });
   });
 }
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptDiff.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptDiff.tsx
@@ -31,9 +31,15 @@ export function TranscriptDiff(props: TranscriptDiffProps) {
   }>({ loading: false });
   const diff = props.detail.fileDiff;
   const desktopApi = useDesktopApi();
-  const diffRef = diff?.diffRef;
+  const diffRefs = useMemo(
+    () => diff?.diffRefs ?? (diff?.diffRef ? [diff.diffRef] : []),
+    [diff?.diffRef, diff?.diffRefs],
+  );
+  const diffRefKey = diffRefs.map((ref) => ref.key).join("|");
   const inlineDiffText = diff?.omittedReason ? "" : diff?.diff ?? "";
-  const shouldFetchDiff = Boolean(diffRef && !diff?.diff && !diff?.omittedReason);
+  const shouldFetchDiff = Boolean(
+    diffRefs.length > 0 && !diff?.diff && !diff?.omittedReason,
+  );
   const diffText = shouldFetchDiff ? fetchedDiff.diff ?? "" : inlineDiffText;
   const omittedReason = diff?.omittedReason ?? fetchedDiff.omittedReason;
   const parsed = useMemo(() => parseUnifiedDiff(diffText), [diffText]);
@@ -44,10 +50,10 @@ export function TranscriptDiff(props: TranscriptDiffProps) {
   useEffect(() => {
     setIsZoomedIn(false);
     setFocusedView(null);
-  }, [diffText, diffRef?.key, props.detail.path]);
+  }, [diffText, diffRefKey, props.detail.path]);
 
   useEffect(() => {
-    if (!diffRef || !shouldFetchDiff) {
+    if (diffRefs.length === 0 || !shouldFetchDiff) {
       setFetchedDiff({ loading: false });
       return;
     }
@@ -55,7 +61,7 @@ export function TranscriptDiff(props: TranscriptDiffProps) {
     const getThreadFileDiff = desktopApi?.getThreadFileDiff;
     if (!getThreadFileDiff) {
       setFetchedDiff({
-        refKey: diffRef.key,
+        refKey: diffRefKey,
         loading: false,
         omittedReason: "Diff is unavailable in this renderer.",
       });
@@ -63,16 +69,22 @@ export function TranscriptDiff(props: TranscriptDiffProps) {
     }
 
     let active = true;
-    setFetchedDiff({ refKey: diffRef.key, loading: true });
-    void getThreadFileDiff({ ref: diffRef })
-      .then((response) => {
+    setFetchedDiff({ refKey: diffRefKey, loading: true });
+    void Promise.all(diffRefs.map((ref) => getThreadFileDiff({ ref })))
+      .then((responses) => {
         if (!active) {
           return;
         }
+        const omitted = responses.find((response) => response.omittedReason);
         setFetchedDiff({
-          refKey: diffRef.key,
-          diff: response.diff,
-          omittedReason: response.omittedReason,
+          refKey: diffRefKey,
+          diff: omitted
+            ? undefined
+            : responses
+                .map((response) => response.diff)
+                .filter((value): value is string => Boolean(value))
+                .join("\n"),
+          omittedReason: omitted?.omittedReason,
           loading: false,
         });
       })
@@ -81,16 +93,16 @@ export function TranscriptDiff(props: TranscriptDiffProps) {
           return;
         }
         setFetchedDiff({
-          refKey: diffRef.key,
+          refKey: diffRefKey,
           loading: false,
-          omittedReason: "Diff is unavailable for this live update.",
+          omittedReason: "Diff is unavailable for this thread entry.",
         });
       });
 
     return () => {
       active = false;
     };
-  }, [desktopApi, diffRef, shouldFetchDiff]);
+  }, [desktopApi, diffRefKey, diffRefs, shouldFetchDiff]);
 
   useEffect(() => {
     if (!diff || omittedReason || !diffText || !eligibility.eligible || !desktopApi?.analyzeFocusedDiff) {
@@ -155,7 +167,7 @@ export function TranscriptDiff(props: TranscriptDiffProps) {
     );
   }
 
-  if (fetchedDiff.loading && fetchedDiff.refKey === diffRef?.key) {
+  if (fetchedDiff.loading && fetchedDiff.refKey === diffRefKey) {
     return (
       <div className="transcript-diff transcript-diff--omitted">
         {props.detail.path && !props.compact ? (

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptDiff.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptDiff.tsx
@@ -23,9 +23,19 @@ type TranscriptDiffProps = {
 export function TranscriptDiff(props: TranscriptDiffProps) {
   const [isZoomedIn, setIsZoomedIn] = useState(false);
   const [focusedView, setFocusedView] = useState<DiffView | null>(null);
+  const [fetchedDiff, setFetchedDiff] = useState<{
+    refKey?: string;
+    diff?: string;
+    omittedReason?: string;
+    loading: boolean;
+  }>({ loading: false });
   const diff = props.detail.fileDiff;
-  const diffText = diff?.omittedReason ? "" : diff?.diff ?? "";
   const desktopApi = useDesktopApi();
+  const diffRef = diff?.diffRef;
+  const inlineDiffText = diff?.omittedReason ? "" : diff?.diff ?? "";
+  const shouldFetchDiff = Boolean(diffRef && !diff?.diff && !diff?.omittedReason);
+  const diffText = shouldFetchDiff ? fetchedDiff.diff ?? "" : inlineDiffText;
+  const omittedReason = diff?.omittedReason ?? fetchedDiff.omittedReason;
   const parsed = useMemo(() => parseUnifiedDiff(diffText), [diffText]);
   const eligibility = useMemo(() => getFocusedDiffEligibility(parsed), [parsed]);
   const hunkSummaries = useMemo(() => summarizeHunksForFocus(parsed), [parsed]);
@@ -34,10 +44,56 @@ export function TranscriptDiff(props: TranscriptDiffProps) {
   useEffect(() => {
     setIsZoomedIn(false);
     setFocusedView(null);
-  }, [diffText, props.detail.path]);
+  }, [diffText, diffRef?.key, props.detail.path]);
 
   useEffect(() => {
-    if (!diff || diff.omittedReason || !eligibility.eligible || !desktopApi?.analyzeFocusedDiff) {
+    if (!diffRef || !shouldFetchDiff) {
+      setFetchedDiff({ loading: false });
+      return;
+    }
+
+    const getThreadFileDiff = desktopApi?.getThreadFileDiff;
+    if (!getThreadFileDiff) {
+      setFetchedDiff({
+        refKey: diffRef.key,
+        loading: false,
+        omittedReason: "Diff is unavailable in this renderer.",
+      });
+      return;
+    }
+
+    let active = true;
+    setFetchedDiff({ refKey: diffRef.key, loading: true });
+    void getThreadFileDiff({ ref: diffRef })
+      .then((response) => {
+        if (!active) {
+          return;
+        }
+        setFetchedDiff({
+          refKey: diffRef.key,
+          diff: response.diff,
+          omittedReason: response.omittedReason,
+          loading: false,
+        });
+      })
+      .catch(() => {
+        if (!active) {
+          return;
+        }
+        setFetchedDiff({
+          refKey: diffRef.key,
+          loading: false,
+          omittedReason: "Diff is unavailable for this live update.",
+        });
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [desktopApi, diffRef, shouldFetchDiff]);
+
+  useEffect(() => {
+    if (!diff || omittedReason || !diffText || !eligibility.eligible || !desktopApi?.analyzeFocusedDiff) {
       return;
     }
 
@@ -71,7 +127,7 @@ export function TranscriptDiff(props: TranscriptDiffProps) {
     return () => {
       active = false;
     };
-  }, [desktopApi, diff, diffText, eligibility.eligible, hunkSummaries, parsed, props.detail.path]);
+  }, [desktopApi, diff, diffText, eligibility.eligible, hunkSummaries, omittedReason, parsed, props.detail.path]);
 
   const defaultView = useMemo(() => {
     if (!eligibility.eligible) {
@@ -86,7 +142,7 @@ export function TranscriptDiff(props: TranscriptDiffProps) {
     return null;
   }
 
-  if (diff.omittedReason) {
+  if (omittedReason) {
     return (
       <div className="transcript-diff transcript-diff--omitted">
         {props.detail.path && !props.compact ? (
@@ -94,7 +150,20 @@ export function TranscriptDiff(props: TranscriptDiffProps) {
             {props.detail.path}
           </p>
         ) : null}
-        <p className="transcript-diff__omitted">{diff.omittedReason}</p>
+        <p className="transcript-diff__omitted">{omittedReason}</p>
+      </div>
+    );
+  }
+
+  if (fetchedDiff.loading && fetchedDiff.refKey === diffRef?.key) {
+    return (
+      <div className="transcript-diff transcript-diff--omitted">
+        {props.detail.path && !props.compact ? (
+          <p className="transcript-diff__path" title={props.detail.path}>
+            {props.detail.path}
+          </p>
+        ) : null}
+        <p className="transcript-diff__omitted">Loading diff...</p>
       </div>
     );
   }

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/edited-file-groups.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/edited-file-groups.test.ts
@@ -19,6 +19,7 @@ function fileDiffDetail(params: {
   additions?: number;
   removals?: number;
   kind?: "add" | "delete" | "update";
+  diffRefKey?: string;
 }): AppServerThreadActivityDetail {
   detailCounter += 1;
   const kind = params.kind ?? "update";
@@ -29,7 +30,19 @@ function fileDiffDetail(params: {
     path: params.path,
     fileDiff: {
       kind,
-      diff: `diff for ${params.path} (#${detailCounter})`,
+      diff: params.diffRefKey ? "" : `diff for ${params.path} (#${detailCounter})`,
+      ...(params.diffRefKey
+        ? {
+            diffRef: {
+              source: "thread" as const,
+              key: params.diffRefKey,
+              backend: "codex" as const,
+              threadId: "thread-1",
+              entryId: "entry-1",
+              detailId: `detail-${detailCounter}`,
+            },
+          }
+        : {}),
       additions: params.additions ?? 1,
       removals: params.removals ?? 0,
     },
@@ -100,6 +113,43 @@ describe("collectEditedFileGroups", () => {
     expect(groups[1].summary).toBe("Edited 1 file");
     expect(groups[1].additions).toBe(5);
     expect(groups[1].removals).toBe(1);
+  });
+
+  it("keeps merged lazy diff refs fetchable instead of marking the row omitted", () => {
+    const groups = collectEditedFileGroups({
+      entries: [
+        activityEntry({
+          id: "a1",
+          turnId: "turn-1",
+          details: [
+            fileDiffDetail({
+              path: "src/a.ts",
+              additions: 2,
+              diffRefKey: "thread:one",
+            }),
+            fileDiffDetail({
+              path: "src/a.ts",
+              additions: 3,
+              removals: 1,
+              diffRefKey: "thread:two",
+            }),
+          ],
+        }),
+      ],
+    });
+
+    const fileDiff = groups[0]?.details[0]?.fileDiff;
+    expect(fileDiff).toMatchObject({
+      diff: "",
+      additions: 5,
+      removals: 1,
+      diffRef: expect.objectContaining({ key: "thread:two" }),
+      diffRefs: [
+        expect.objectContaining({ key: "thread:one" }),
+        expect.objectContaining({ key: "thread:two" }),
+      ],
+    });
+    expect(fileDiff?.omittedReason).toBeUndefined();
   });
 
   it("prefers a turn's live cumulative diff entry over its per-edit entries", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -44,6 +44,7 @@ import { ThreadView } from "../ThreadView";
 function buildRendererLiveDiffEvent(params: {
   additions: number;
   diff: string;
+  lazy?: boolean;
   path: string;
   removals: number;
   threadId: string;
@@ -64,7 +65,18 @@ function buildRendererLiveDiffEvent(params: {
         path: params.path,
         fileDiff: {
           kind: "update",
-          diff: params.diff,
+          diff: params.lazy ? "" : params.diff,
+          ...(params.lazy
+            ? {
+                diffRef: {
+                  source: "live" as const,
+                  key: `live:${params.threadId}:${entryId}:${entryId}-1`,
+                  threadId: params.threadId,
+                  entryId,
+                  detailId: `${entryId}-1`,
+                },
+              }
+            : {}),
           additions: params.additions,
           removals: params.removals,
         },
@@ -2344,6 +2356,121 @@ describe("ThreadView", () => {
     // edited files rehydrate from the replay instead of vanishing. Two
     // matches: the transcript work-group row and the rail title button.
     expect(screen.getAllByRole("button", { name: /Edited 1 file/i })).toHaveLength(2);
+    expect(
+      screen.getByRole("complementary", { name: /Edited 1 file, \+1, -2/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("clears lazy live diff activity once matching replay diff arrives", async () => {
+    const selectedThread = {
+      id: "thread-lazy",
+      title: "Fix lazy diff catch-up",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      updatedAt: Date.now(),
+      linkedDirectories: [],
+      inbox: {
+        inInbox: false,
+      },
+    };
+    const liveDiff = [
+      "diff --git a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts",
+      "--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts",
+      "+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts",
+      "@@ -113,2 +113,1 @@",
+      "-<<<<<<< HEAD",
+      "-function appendMessageEntries(",
+      "+function messageMatchesOptimisticEntry(",
+    ].join("\n");
+    let agentEventHandler: ((event: AgentEvent) => void) | undefined;
+    const getThreadFileDiff = vi.fn(async () => ({ diff: liveDiff }));
+
+    const renderThread = (transcriptEntries: any[]) => (
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[]}
+        composerDisabled={false}
+        desktopApi={{
+          getThreadFileDiff,
+          onAgentEvent: (callback) => {
+            agentEventHandler = callback as typeof agentEventHandler;
+            return () => undefined;
+          },
+        }}
+        loading={false}
+        loadingMore={false}
+        messageCount={transcriptEntries.length}
+        selectedThread={selectedThread}
+        skills={[]}
+        transcriptEntries={transcriptEntries}
+        clearPendingRequest={() => undefined}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+      />
+    );
+
+    const { rerender } = render(
+      renderThread([
+        {
+          type: "message",
+          id: "message-1",
+          role: "user",
+          text: "Fix the merge markers.",
+        },
+      ]),
+    );
+
+    await act(async () => {
+      agentEventHandler?.(
+        buildRendererLiveDiffEvent({
+          additions: 1,
+          diff: liveDiff,
+          lazy: true,
+          path: "apps/desktop/src/renderer/src/lib/useThreadSessionState.ts",
+          removals: 2,
+          threadId: "thread-lazy",
+          turnId: "turn-1",
+        }),
+      );
+    });
+
+    rerender(
+      renderThread([
+        {
+          type: "message",
+          id: "message-1",
+          role: "user",
+          text: "Fix the merge markers.",
+        },
+        {
+          type: "activity",
+          id: "activity-1",
+          summary: "Edited 1 file",
+          turn: { id: "turn-1", status: "in_progress" },
+          details: [
+            {
+              id: "detail-1",
+              kind: "write",
+              label: "Update useThreadSessionState.ts",
+              path: "apps/desktop/src/renderer/src/lib/useThreadSessionState.ts",
+              fileDiff: {
+                kind: "update",
+                additions: 1,
+                removals: 2,
+                diff: liveDiff,
+              },
+            },
+          ],
+        },
+      ]),
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Update useThreadSessionState.ts/i }),
+    );
+
+    expect(screen.getByText("function messageMatchesOptimisticEntry(")).toBeInTheDocument();
+    expect(getThreadFileDiff).not.toHaveBeenCalled();
     expect(
       screen.getByRole("complementary", { name: /Edited 1 file, \+1, -2/ }),
     ).toBeInTheDocument();

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -3,7 +3,9 @@ import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testi
 import { useState } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
+  AgentEvent,
   AppServerNotification,
+  AppServerThreadActivityEntry,
   AppServerPendingRequestNotification,
   MessagingPlatformStatus,
   NavigationDirectorySummary,
@@ -38,6 +40,50 @@ vi.mock("../IntegratedTerminal", () => ({
 }));
 
 import { ThreadView } from "../ThreadView";
+
+function buildRendererLiveDiffEvent(params: {
+  additions: number;
+  diff: string;
+  path: string;
+  removals: number;
+  threadId: string;
+  turnId: string;
+}): AgentEvent {
+  const entryId = `live-diff-${params.turnId}`;
+  const basename = params.path.split(/[\\/]/).at(-1) ?? params.path;
+  const rendererActivityEntry: AppServerThreadActivityEntry = {
+    type: "activity",
+    id: entryId,
+    createdAt: 1_000,
+    summary: `Edited 1 file, +${params.additions}, -${params.removals}`,
+    details: [
+      {
+        id: `${entryId}-1`,
+        kind: "write",
+        label: `Update ${basename}`,
+        path: params.path,
+        fileDiff: {
+          kind: "update",
+          diff: params.diff,
+          additions: params.additions,
+          removals: params.removals,
+        },
+      },
+    ],
+  };
+  return {
+    backend: "codex",
+    notification: {
+      method: "turn/diff/updated",
+      params: {
+        threadId: params.threadId,
+        turnId: params.turnId,
+        diff: params.diff,
+      },
+    },
+    rendererActivityEntry,
+  };
+}
 
 afterEach(() => {
   cleanup();
@@ -1474,12 +1520,7 @@ describe("ThreadView", () => {
         { step: "Verify the thread view", status: "pending" as const }
       ]
     };
-    let agentEventHandler:
-      | ((event: {
-          backend: "codex";
-          notification: AppServerNotification;
-        }) => void)
-      | undefined;
+    let agentEventHandler: ((event: AgentEvent) => void) | undefined;
 
     const { rerender } = render(
       <ThreadView
@@ -1662,12 +1703,7 @@ describe("ThreadView", () => {
         inInbox: false
       }
     };
-    let agentEventHandler:
-      | ((event: {
-          backend: "codex";
-          notification: AppServerNotification;
-        }) => void)
-      | undefined;
+    let agentEventHandler: ((event: AgentEvent) => void) | undefined;
 
     const { rerender } = render(
       <ThreadView
@@ -2007,12 +2043,7 @@ describe("ThreadView", () => {
         inInbox: false
       }
     };
-    let agentEventHandler:
-      | ((event: {
-          backend: "codex";
-          notification: AppServerNotification;
-        }) => void)
-      | undefined;
+    let agentEventHandler: ((event: AgentEvent) => void) | undefined;
 
     render(
       <ThreadView
@@ -2121,12 +2152,7 @@ describe("ThreadView", () => {
       "-function appendMessageEntries(",
       "+function messageMatchesOptimisticEntry("
     ].join("\n");
-    let agentEventHandler:
-      | ((event: {
-          backend: "codex";
-          notification: AppServerNotification;
-        }) => void)
-      | undefined;
+    let agentEventHandler: ((event: AgentEvent) => void) | undefined;
 
     const { rerender } = render(
       <ThreadView
@@ -2193,17 +2219,16 @@ describe("ThreadView", () => {
     );
 
     await act(async () => {
-      agentEventHandler?.({
-        backend: "codex",
-        notification: {
-          method: "turn/diff/updated",
-          params: {
-            threadId: "thread-2",
-            turnId: "turn-1",
-            diff: liveDiff
-          }
-        },
-      });
+      agentEventHandler?.(
+        buildRendererLiveDiffEvent({
+          additions: 1,
+          diff: liveDiff,
+          path: "apps/desktop/src/renderer/src/lib/useThreadSessionState.ts",
+          removals: 2,
+          threadId: "thread-2",
+          turnId: "turn-1",
+        }),
+      );
       agentEventHandler?.({
         backend: "codex",
         notification: {
@@ -4106,9 +4131,7 @@ describe("ThreadView", () => {
     const consoleErrorSpy = vi
       .spyOn(console, "error")
       .mockImplementation(() => undefined);
-    let agentEventHandler:
-      | ((event: { backend: "codex"; notification: AppServerNotification }) => void)
-      | undefined;
+    let agentEventHandler: ((event: AgentEvent) => void) | undefined;
     const liveDiff = [
       "diff --git a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts",
       "--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts",
@@ -4174,13 +4197,16 @@ describe("ThreadView", () => {
       // During the active turn, the rail (h3 heading) is the single
       // display surface for the cumulative diff.
       await act(async () => {
-        agentEventHandler?.({
-          backend: "codex",
-          notification: {
-            method: "turn/diff/updated",
-            params: { threadId: "thread-dupe", turnId: "turn-1", diff: liveDiff },
-          },
-        });
+        agentEventHandler?.(
+          buildRendererLiveDiffEvent({
+            additions: 1,
+            diff: liveDiff,
+            path: "apps/desktop/src/renderer/src/lib/useThreadSessionState.ts",
+            removals: 2,
+            threadId: "thread-dupe",
+            turnId: "turn-1",
+          }),
+        );
       });
       // Rail title carries the summary (the section h3 was merged into
       // the rail title in the #495 follow-up).
@@ -4240,9 +4266,7 @@ describe("ThreadView", () => {
   });
 
   it("keeps the prior turn's uncommitted edits in the rail when a new turn starts", async () => {
-    let agentEventHandler:
-      | ((event: { backend: "codex"; notification: AppServerNotification }) => void)
-      | undefined;
+    let agentEventHandler: ((event: AgentEvent) => void) | undefined;
     const liveDiff = [
       "diff --git a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts",
       "--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts",
@@ -4306,13 +4330,16 @@ describe("ThreadView", () => {
     render(<Harness />);
 
     await act(async () => {
-      agentEventHandler?.({
-        backend: "codex",
-        notification: {
-          method: "turn/diff/updated",
-          params: { threadId: "thread-pin", turnId: "turn-1", diff: liveDiff },
-        },
-      });
+      agentEventHandler?.(
+        buildRendererLiveDiffEvent({
+          additions: 1,
+          diff: liveDiff,
+          path: "apps/desktop/src/renderer/src/lib/useThreadSessionState.ts",
+          removals: 0,
+          threadId: "thread-pin",
+          turnId: "turn-1",
+        }),
+      );
     });
     await act(async () => {
       agentEventHandler?.({
@@ -4361,9 +4388,7 @@ describe("ThreadView", () => {
   });
 
   it("retains a failed turn's edits in the rail instead of dropping them", async () => {
-    let agentEventHandler:
-      | ((event: { backend: "codex"; notification: AppServerNotification }) => void)
-      | undefined;
+    let agentEventHandler: ((event: AgentEvent) => void) | undefined;
     const liveDiff = [
       "diff --git a/src/example.ts b/src/example.ts",
       "--- a/src/example.ts",
@@ -4415,13 +4440,16 @@ describe("ThreadView", () => {
     render(<Harness />);
 
     await act(async () => {
-      agentEventHandler?.({
-        backend: "codex",
-        notification: {
-          method: "turn/diff/updated",
-          params: { threadId: "thread-fail", turnId: "turn-1", diff: liveDiff },
-        },
-      });
+      agentEventHandler?.(
+        buildRendererLiveDiffEvent({
+          additions: 1,
+          diff: liveDiff,
+          path: "src/example.ts",
+          removals: 0,
+          threadId: "thread-fail",
+          turnId: "turn-1",
+        }),
+      );
     });
     await act(async () => {
       agentEventHandler?.({

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-diff.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-diff.test.tsx
@@ -1,5 +1,6 @@
 import "@testing-library/jest-dom/vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { AppServerThreadFileDiffRef } from "@pwragent/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { TranscriptDiff } from "../TranscriptDiff";
 
@@ -165,5 +166,65 @@ describe("TranscriptDiff", () => {
     expect(screen.getByText("Loading diff...")).toBeInTheDocument();
     await screen.findByText(/beta\/index/);
     expect(getThreadFileDiff).toHaveBeenCalledWith({ ref: diffRef });
+  });
+
+  it("fetches and stacks multiple referenced diff chunks for merged rows", async () => {
+    const firstDiff = [
+      "@@ -1,1 +1,2 @@",
+      " alpha",
+      "+beta",
+    ].join("\n");
+    const secondDiff = [
+      "@@ -4,1 +5,2 @@",
+      " gamma",
+      "+delta",
+    ].join("\n");
+    const refs: AppServerThreadFileDiffRef[] = [
+      {
+        source: "thread" as const,
+        key: "thread:thread-1:entry-1:detail-1",
+        backend: "codex" as const,
+        threadId: "thread-1",
+        entryId: "entry-1",
+        detailId: "detail-1",
+      },
+      {
+        source: "thread" as const,
+        key: "thread:thread-1:entry-2:detail-1",
+        backend: "codex" as const,
+        threadId: "thread-1",
+        entryId: "entry-2",
+        detailId: "detail-1",
+      },
+    ];
+    const getThreadFileDiff = vi.fn(
+      async ({ ref }: { ref: AppServerThreadFileDiffRef }) => ({
+      diff: ref.key.endsWith("entry-1:detail-1") ? firstDiff : secondDiff,
+    }));
+    (window as Window & { pwragent?: unknown }).pwragent = {
+      getThreadFileDiff,
+    };
+
+    render(
+      <TranscriptDiff
+        detail={{
+          ...DETAIL,
+          fileDiff: {
+            ...DETAIL.fileDiff,
+            diff: "",
+            diffRef: refs[1],
+            diffRefs: refs,
+            additions: 2,
+            removals: 0,
+          },
+        }}
+      />
+    );
+
+    await screen.findByText("beta");
+    expect(screen.getByText("delta")).toBeInTheDocument();
+    expect(getThreadFileDiff).toHaveBeenCalledTimes(2);
+    expect(getThreadFileDiff).toHaveBeenNthCalledWith(1, { ref: refs[0] });
+    expect(getThreadFileDiff).toHaveBeenNthCalledWith(2, { ref: refs[1] });
   });
 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-diff.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-diff.test.tsx
@@ -135,4 +135,35 @@ describe("TranscriptDiff", () => {
     expect(screen.queryByRole("button", { name: "Zoom in" })).not.toBeInTheDocument();
     expect(analyzeFocusedDiff).not.toHaveBeenCalled();
   });
+
+  it("fetches referenced live diff text only when the diff component renders", async () => {
+    const getThreadFileDiff = vi.fn(async () => ({ diff: ELIGIBLE_DIFF }));
+    (window as Window & { pwragent?: unknown }).pwragent = {
+      getThreadFileDiff
+    };
+    const diffRef = {
+      source: "live" as const,
+      key: "live:thread-1:entry-1:detail-1",
+      threadId: "thread-1",
+      entryId: "entry-1",
+      detailId: "detail-1"
+    };
+
+    render(
+      <TranscriptDiff
+        detail={{
+          ...DETAIL,
+          fileDiff: {
+            ...DETAIL.fileDiff,
+            diff: "",
+            diffRef
+          }
+        }}
+      />
+    );
+
+    expect(screen.getByText("Loading diff...")).toBeInTheDocument();
+    await screen.findByText(/beta\/index/);
+    expect(getThreadFileDiff).toHaveBeenCalledWith({ ref: diffRef });
+  });
 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/edited-file-groups.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/edited-file-groups.ts
@@ -89,6 +89,16 @@ function mergeFileDiffDetail(
       : existing.fileDiff.kind === "add"
         ? "add"
         : detail.fileDiff.kind;
+  const mergedDiffText =
+    existing.fileDiff.diff || detail.fileDiff.diff
+      ? `${existing.fileDiff.diff}\n${detail.fileDiff.diff}`
+      : "";
+  const omittedReason =
+    detail.fileDiff.omittedReason ??
+    existing.fileDiff.omittedReason ??
+    (existing.fileDiff.diffRef || detail.fileDiff.diffRef
+      ? "Combined live diff is available in the per-turn edit view."
+      : undefined);
 
   return {
     ...existing,
@@ -96,12 +106,13 @@ function mergeFileDiffDetail(
     label: kind === existing.fileDiff.kind ? existing.label : detail.label,
     fileDiff: {
       kind,
-      diff: `${existing.fileDiff.diff}\n${detail.fileDiff.diff}`,
+      diff: mergedDiffText,
       additions: existing.fileDiff.additions + detail.fileDiff.additions,
       removals: existing.fileDiff.removals + detail.fileDiff.removals,
-      ...(detail.fileDiff.omittedReason
-        ? { omittedReason: detail.fileDiff.omittedReason }
-        : {}),
+      ...(mergedDiffText || !detail.fileDiff.diffRef
+        ? {}
+        : { diffRef: detail.fileDiff.diffRef }),
+      ...(omittedReason ? { omittedReason } : {}),
     },
   };
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/edited-file-groups.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/edited-file-groups.ts
@@ -93,12 +93,16 @@ function mergeFileDiffDetail(
     existing.fileDiff.diff || detail.fileDiff.diff
       ? `${existing.fileDiff.diff}\n${detail.fileDiff.diff}`
       : "";
+  const fileDiffRefs = (
+    fileDiff: AppServerThreadActivityDetail["fileDiff"],
+  ) => fileDiff?.diffRefs ?? (fileDiff?.diffRef ? [fileDiff.diffRef] : []);
+  const diffRefs = [
+    ...fileDiffRefs(existing.fileDiff),
+    ...fileDiffRefs(detail.fileDiff),
+  ];
   const omittedReason =
     detail.fileDiff.omittedReason ??
-    existing.fileDiff.omittedReason ??
-    (existing.fileDiff.diffRef || detail.fileDiff.diffRef
-      ? "Combined live diff is available in the per-turn edit view."
-      : undefined);
+    existing.fileDiff.omittedReason;
 
   return {
     ...existing,
@@ -109,9 +113,12 @@ function mergeFileDiffDetail(
       diff: mergedDiffText,
       additions: existing.fileDiff.additions + detail.fileDiff.additions,
       removals: existing.fileDiff.removals + detail.fileDiff.removals,
-      ...(mergedDiffText || !detail.fileDiff.diffRef
+      ...(mergedDiffText || diffRefs.length === 0
         ? {}
-        : { diffRef: detail.fileDiff.diffRef }),
+        : {
+            diffRef: diffRefs[diffRefs.length - 1],
+            diffRefs,
+          }),
       ...(omittedReason ? { omittedReason } : {}),
     },
   };

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -42,6 +42,8 @@ import type {
   ForkThreadResponse,
   AppServerReadThreadRequest,
   AppServerReadThreadResponse,
+  GetThreadFileDiffRequest,
+  GetThreadFileDiffResponse,
   PersistThreadUsageActivityRequest,
   PersistThreadUsageActivityResponse,
   GetAutomationRunArtifactRequest,
@@ -356,6 +358,9 @@ export type DesktopApi = {
   readThread?: (
     request: AppServerReadThreadRequest
   ) => Promise<AppServerReadThreadResponse>;
+  getThreadFileDiff?: (
+    request: GetThreadFileDiffRequest,
+  ) => Promise<GetThreadFileDiffResponse>;
   persistThreadUsageActivity?: (
     request: PersistThreadUsageActivityRequest,
   ) => Promise<PersistThreadUsageActivityResponse>;

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -1,6 +1,8 @@
 export const APP_SERVER_LIST_THREADS_CHANNEL = "app-server:list-threads";
 export const THREAD_SEARCH_CHANNEL = "thread-search:search";
 export const APP_SERVER_READ_THREAD_CHANNEL = "app-server:read-thread";
+export const APP_SERVER_GET_THREAD_FILE_DIFF_CHANNEL =
+  "app-server:get-thread-file-diff";
 export const APP_SERVER_PERSIST_THREAD_USAGE_ACTIVITY_CHANNEL =
   "app-server:persist-thread-usage-activity";
 export const APP_SERVER_LIST_SKILLS_CHANNEL = "app-server:list-skills";

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -2,6 +2,7 @@ import type {
   AppServerBackendKind,
   AppServerMcpElicitationResponse,
   AppServerNotification,
+  AppServerThreadActivityEntry,
   LinkedDirectorySummary,
   ThreadExecutionMode,
   AppServerReviewDelivery,
@@ -619,6 +620,11 @@ export type RegisterDirectoryFromDiskResponse =
 export type AgentEvent = {
   backend: AppServerBackendKind;
   notification: AppServerNotification;
+  /**
+   * Optional main-process display model for live protocol notifications whose
+   * raw params are expensive for React to parse on every update.
+   */
+  rendererActivityEntry?: AppServerThreadActivityEntry;
 };
 
 export type LatestCodexConfigWarningResponse = {

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -363,9 +363,18 @@ export type AppServerSource = {
 
 export type AppServerThreadFileChangeKind = "add" | "delete" | "update";
 
+export type AppServerThreadFileDiffRef = {
+  source: "live";
+  key: string;
+  threadId: string;
+  entryId: string;
+  detailId: string;
+};
+
 export type AppServerThreadFileDiff = {
   kind: AppServerThreadFileChangeKind;
   diff: string;
+  diffRef?: AppServerThreadFileDiffRef;
   additions: number;
   removals: number;
   omittedReason?: string;
@@ -403,6 +412,15 @@ export type AppServerThreadActivityEntry = {
   details: AppServerThreadActivityDetail[];
   turn?: AppServerThreadTurnMetadata;
   usageLine?: ThreadUsageLineRecord;
+};
+
+export type GetThreadFileDiffRequest = {
+  ref: AppServerThreadFileDiffRef;
+};
+
+export type GetThreadFileDiffResponse = {
+  diff?: string;
+  omittedReason?: string;
 };
 
 export type AppServerThreadPlanStepStatus =

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -376,6 +376,7 @@ export type AppServerThreadFileDiff = {
   kind: AppServerThreadFileChangeKind;
   diff: string;
   diffRef?: AppServerThreadFileDiffRef;
+  diffRefs?: AppServerThreadFileDiffRef[];
   additions: number;
   removals: number;
   omittedReason?: string;

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -364,11 +364,12 @@ export type AppServerSource = {
 export type AppServerThreadFileChangeKind = "add" | "delete" | "update";
 
 export type AppServerThreadFileDiffRef = {
-  source: "live";
+  source: "live" | "thread";
   key: string;
   threadId: string;
   entryId: string;
   detailId: string;
+  backend?: AppServerBackendKind;
 };
 
 export type AppServerThreadFileDiff = {


### PR DESCRIPTION
## Summary

Live Codex diff updates now arrive at React as lightweight activity metadata plus per-file `diffRef` handles instead of raw unified diff text. The main process keeps the live diff text in an in-memory cache, and `TranscriptDiff` fetches a file's diff through IPC only when that diff component renders.

This keeps collapsed edit rows useful with path/stats/status data while avoiding pushing most live diff text into the renderer at all. Inline persisted diffs still render as before, no-`turnId` live diffs get unique refs, and replay catch-up can now clear lazy pending live diffs by matching file identity and stats instead of comparing inline diff text.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/live-diff-activity.test.ts apps/desktop/src/main/__tests__/agent-ipc.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-diff.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/edited-file-groups.test.ts -- --runInBand`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
