### PR TITLE
fix(messaging): submit final questionnaire answers directly

### DIFF
--- a/apps/desktop/e2e/request-user-input.spec.ts
+++ b/apps/desktop/e2e/request-user-input.spec.ts
@@ -51,15 +51,7 @@ test("answers request_user_input questionnaires with back and next navigation", 
 
     await pendingInput.getByRole("button", { name: /Large refactor/ }).click();
     await expect(pendingInput.getByText("Question 2 of 2")).toBeVisible();
-
-    await pendingInput.getByRole("button", { name: /Unit only/ }).click();
-    await expect(pendingInput.getByRole("heading", { name: "Review answers" })).toBeVisible();
-
-    await pendingInput.getByRole("button", { name: "Back" }).click();
-    await expect(pendingInput.getByText("Question 2 of 2")).toBeVisible();
-    await expect(
-      pendingInput.getByRole("button", { name: /Unit only/ })
-    ).toHaveAttribute("aria-pressed", "true");
+    await expect(pendingInput.getByRole("button", { name: "Submit" })).toBeDisabled();
 
     await pendingInput.getByRole("button", { name: "Back" }).click();
     await expect(pendingInput.getByText("Question 1 of 2")).toBeVisible();
@@ -68,8 +60,7 @@ test("answers request_user_input questionnaires with back and next navigation", 
     ).toHaveAttribute("aria-pressed", "true");
 
     await pendingInput.getByRole("button", { name: "Next" }).click();
-    await pendingInput.getByRole("button", { name: "Review" }).click();
-    await pendingInput.getByRole("button", { name: "Submit" }).click();
+    await pendingInput.getByRole("button", { name: /Unit only/ }).click();
 
     await expect(app.window.getByRole("group", { name: "Pending input" })).toHaveCount(0);
     await expect(app.window.getByRole("status")).toContainText("Thinking");

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -9925,7 +9925,7 @@ describe("MessagingController", () => {
     });
   });
 
-  it("records questionnaire answers, navigates review, and submits through messaging", async () => {
+  it("records questionnaire answers, navigates back and next, and submits through messaging", async () => {
     const harness = await createHarness();
     await bindThread(harness);
     await harness.controller.handleBackendPendingRequest("codex", {
@@ -9994,12 +9994,32 @@ describe("MessagingController", () => {
     });
 
     await harness.controller.handleInboundEvent(
-      buildCallbackEvent({ actionId: "tone:option:1" }),
+      buildCallbackEvent({ actionId: "questionnaire:back" }),
     );
 
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "questionnaire",
-      phase: "review",
+      phase: "answering",
+      currentIndex: 0,
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "questionnaire:next" }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "questionnaire",
+      phase: "answering",
+      currentIndex: 1,
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "tone:option:1" }),
+    );
+
+    expect(harness.delivered.at(-2)).toMatchObject({
+      kind: "questionnaire",
+      phase: "submitted",
       answers: [
         {
           kind: "custom",
@@ -10012,28 +10032,6 @@ describe("MessagingController", () => {
         },
       ],
     });
-
-    await harness.controller.handleInboundEvent(
-      buildCallbackEvent({ actionId: "questionnaire:back" }),
-    );
-
-    expect(harness.delivered.at(-1)).toMatchObject({
-      kind: "questionnaire",
-      phase: "answering",
-      currentIndex: 1,
-    });
-
-    await harness.controller.handleInboundEvent(
-      buildCallbackEvent({ actionId: "questionnaire:next" }),
-    );
-    expect(harness.delivered.at(-1)).toMatchObject({
-      kind: "questionnaire",
-      phase: "review",
-    });
-
-    await harness.controller.handleInboundEvent(
-      buildCallbackEvent({ actionId: "questionnaire:submit" }),
-    );
 
     expect(harness.submitServerRequest).toHaveBeenCalledWith({
       backend: "codex",
@@ -10099,7 +10097,7 @@ describe("MessagingController", () => {
 
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "questionnaire",
-      phase: "review",
+      phase: "submitted",
       answers: [
         {
           kind: "custom",

--- a/apps/desktop/src/main/__tests__/messaging-interaction-mapper.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-interaction-mapper.test.ts
@@ -123,7 +123,7 @@ describe("DeterministicInteractionMapper", () => {
     });
   });
 
-  it("matches review navigation on answered final questionnaire questions", () => {
+  it("matches submit navigation on answered final questionnaire questions", () => {
     const intent = {
       id: "intent-questionnaire-final",
       kind: "questionnaire",
@@ -146,9 +146,9 @@ describe("DeterministicInteractionMapper", () => {
       ],
     } satisfies MessagingQuestionnaireIntent;
 
-    expect(mapper.mapText({ intent, text: "review" })).toMatchObject({
+    expect(mapper.mapText({ intent, text: "submit" })).toMatchObject({
       kind: "matched",
-      action: { id: "questionnaire:next", label: "Review" },
+      action: { id: "questionnaire:submit", label: "Submit" },
     });
   });
 

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -2371,6 +2371,11 @@ export class MessagingController {
       kind: "custom",
       value,
     });
+    if (this.questionnaireReadyToSubmit(updated)) {
+      await this.submitAndRetireQuestionnaire(pendingIntent, updated, event);
+      return true;
+    }
+
     await this.updateQuestionnairePendingIntent(pendingIntent, updated, event);
     return true;
   }
@@ -2404,7 +2409,7 @@ export class MessagingController {
     }
 
     if (action.id === "questionnaire:submit") {
-      if (!intent.answers.every(messagingQuestionnaireAnswerComplete)) {
+      if (!this.questionnaireReadyToSubmit(intent)) {
         await this.deliver(
           buildConfirmationIntent({
             id: this.newIntentId("questionnaire-incomplete"),
@@ -2420,22 +2425,17 @@ export class MessagingController {
         return;
       }
 
-      const submittedIntent: MessagingQuestionnaireIntent = {
-        ...intent,
-        phase: "submitted",
-      };
-      await this.submitQuestionnaireIntent(submittedIntent);
-      await this.deliverQuestionnaireIntent(pendingIntent, submittedIntent, event);
-      await this.options.store.deletePendingIntent(pendingIntent.id);
-      await this.resumeBindingForPendingIntent(
-        pendingIntent,
-        "pending_request.submitted",
-      );
+      await this.submitAndRetireQuestionnaire(pendingIntent, intent, event);
       return;
     }
 
     const updated = this.questionnaireWithOptionAnswer(intent, action.id);
     if (updated !== intent) {
+      if (this.questionnaireReadyToSubmit(updated)) {
+        await this.submitAndRetireQuestionnaire(pendingIntent, updated, event);
+        return;
+      }
+
       await this.updateQuestionnairePendingIntent(pendingIntent, updated, event);
     }
   }
@@ -2481,7 +2481,7 @@ export class MessagingController {
     return {
       ...intent,
       answers,
-      phase: "review",
+      phase: "answering",
     };
   }
 
@@ -2495,15 +2495,37 @@ export class MessagingController {
       return intent;
     }
     if (intent.currentIndex >= intent.questions.length - 1) {
-      return {
-        ...intent,
-        phase: "review",
-      };
+      return intent;
     }
     return {
       ...intent,
       currentIndex: intent.currentIndex + 1,
     };
+  }
+
+  private questionnaireReadyToSubmit(intent: MessagingQuestionnaireIntent): boolean {
+    return (
+      intent.currentIndex >= intent.questions.length - 1 &&
+      intent.answers.every(messagingQuestionnaireAnswerComplete)
+    );
+  }
+
+  private async submitAndRetireQuestionnaire(
+    pendingIntent: MessagingPendingIntentRecord,
+    intent: MessagingQuestionnaireIntent,
+    event: MessagingInboundCallbackEvent | MessagingInboundTextEvent,
+  ): Promise<void> {
+    const submittedIntent: MessagingQuestionnaireIntent = {
+      ...intent,
+      phase: "submitted",
+    };
+    await this.submitQuestionnaireIntent(submittedIntent);
+    await this.deliverQuestionnaireIntent(pendingIntent, submittedIntent, event);
+    await this.options.store.deletePendingIntent(pendingIntent.id);
+    await this.resumeBindingForPendingIntent(
+      pendingIntent,
+      "pending_request.submitted",
+    );
   }
 
   private questionnaireWithPreviousQuestion(

--- a/apps/desktop/src/renderer/src/features/thread-detail/PendingQuestionnaire.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/PendingQuestionnaire.tsx
@@ -1,14 +1,12 @@
 import { useLayoutEffect, useRef } from "react";
 import {
+  answerQuestionnaireOption,
   answerQuestionnaireOptionAndAdvance,
   answerQuestionnaireText,
   canAdvanceQuestionnaire,
-  canReviewQuestionnaire,
   canSubmitQuestionnaire,
   goToNextQuestion,
   goToPreviousQuestion,
-  goToQuestionnaireReview,
-  questionnaireAnswerDisplay,
   type PendingQuestionnaireState,
 } from "./questionnaire";
 
@@ -65,72 +63,7 @@ export function PendingQuestionnaire(props: PendingQuestionnaireProps) {
 
   const isLastQuestion = props.state.currentIndex === props.state.questions.length - 1;
   const canMoveNext = canAdvanceQuestionnaire(props.state);
-  const canMoveToReview = canReviewQuestionnaire(props.state);
   const canSubmit = canSubmitQuestionnaire(props.state);
-
-  if (props.state.phase === "review" || props.state.phase === "submitted") {
-    const submitted = props.state.phase === "submitted";
-    return (
-      <div className="transcript-questionnaire" role="group" aria-label="Pending input">
-        <div className="transcript-questionnaire__header">
-          <span className="chip chip--mode">
-            {submitted ? "Input submitted" : "Review answers"}
-          </span>
-          <span className="transcript-message__time">
-            {props.state.questions.length} answer
-            {props.state.questions.length === 1 ? "" : "s"}
-          </span>
-        </div>
-
-        <div className="transcript-questionnaire__prompt">
-          <h3>{submitted ? "Submitted answers" : "Review answers"}</h3>
-        </div>
-
-        <div className="transcript-questionnaire__summary">
-          {props.state.questions.map((summaryQuestion, index) => {
-            const title = [summaryQuestion.header, summaryQuestion.question]
-              .filter(Boolean)
-              .join(summaryQuestion.header && summaryQuestion.question ? ": " : "");
-            return (
-              <div className="transcript-questionnaire__summary-item" key={summaryQuestion.id}>
-                <span className="transcript-questionnaire__summary-question">
-                  {index + 1}. {title}
-                </span>
-                <span className="transcript-questionnaire__summary-answer">
-                  {questionnaireAnswerDisplay(props.state.answers[index]) || "No answer"}
-                </span>
-              </div>
-            );
-          })}
-        </div>
-
-        {submitted ? null : (
-          <div className="transcript-questionnaire__actions">
-            <button
-              className="button button--ghost"
-              disabled={props.busy}
-              type="button"
-              onClick={() => {
-                props.onChange(goToPreviousQuestion(props.state));
-              }}
-            >
-              Back
-            </button>
-            <button
-              className="button button--primary"
-              disabled={props.busy || !canSubmit}
-              type="button"
-              onClick={() => {
-                void props.onSubmit(props.state);
-              }}
-            >
-              Submit
-            </button>
-          </div>
-        )}
-      </div>
-    );
-  }
 
   return (
     <div className="transcript-questionnaire" role="group" aria-label="Pending input">
@@ -163,9 +96,13 @@ export function PendingQuestionnaire(props: PendingQuestionnaireProps) {
                 aria-pressed={selected}
                 disabled={props.busy}
                 onClick={() => {
-                  props.onChange(
-                    answerQuestionnaireOptionAndAdvance(props.state, option.key),
-                  );
+                  if (isLastQuestion) {
+                    const answered = answerQuestionnaireOption(props.state, option.key);
+                    void props.onSubmit(answered);
+                    return;
+                  }
+
+                  props.onChange(answerQuestionnaireOptionAndAdvance(props.state, option.key));
                 }}
               >
                 <span className="transcript-questionnaire__option-label">
@@ -220,13 +157,13 @@ export function PendingQuestionnaire(props: PendingQuestionnaireProps) {
         {isLastQuestion ? (
           <button
             className="button button--primary"
-            disabled={props.busy || !canMoveToReview}
+            disabled={props.busy || !canSubmit}
             type="button"
             onClick={() => {
-              props.onChange(goToQuestionnaireReview(props.state));
+              void props.onSubmit(props.state);
             }}
           >
-            Review
+            Submit
           </button>
         ) : (
           <button

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/pending-questionnaire.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/pending-questionnaire.test.tsx
@@ -126,16 +126,7 @@ describe("PendingQuestionnaire", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /Large refactor/ }));
     expect(screen.getByText("Question 2 of 2")).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole("button", { name: /Unit only/ }));
-    expect(screen.getAllByText("Review answers").length).toBeGreaterThan(0);
-
-    fireEvent.click(screen.getByRole("button", { name: "Back" }));
-    expect(screen.getByText("Question 2 of 2")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Unit only/ })).toHaveAttribute(
-      "aria-pressed",
-      "true"
-    );
+    expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
 
     fireEvent.click(screen.getByRole("button", { name: "Back" }));
     expect(screen.getByText("Question 1 of 2")).toBeInTheDocument();
@@ -145,12 +136,17 @@ describe("PendingQuestionnaire", () => {
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Next" }));
-    fireEvent.click(screen.getByRole("button", { name: "Review" }));
-    expect(screen.getByText(/Scope: How much should change\?/)).toBeInTheDocument();
-    expect(screen.getByText(/Tests: Which test path\?/)).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Submit" }));
+    fireEvent.click(screen.getByRole("button", { name: /Unit only/ }));
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        answers: [
+          expect.objectContaining({ kind: "option", optionKey: "B" }),
+          expect.objectContaining({ kind: "option", optionKey: "A" }),
+        ],
+      })
+    );
   });
 
   it("keeps freeform answers compact and caps autosizing growth", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -2831,7 +2831,6 @@ describe("ThreadView", () => {
     expect(screen.queryByRole("button", { name: "Approve" })).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: /Small patch/ }));
-    fireEvent.click(screen.getByRole("button", { name: "Submit" }));
 
     await waitFor(() => {
       expect(submitServerRequest).toHaveBeenCalledWith({

--- a/apps/desktop/src/renderer/src/features/thread-detail/questionnaire.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/questionnaire.ts
@@ -187,51 +187,8 @@ export function canAdvanceQuestionnaire(state: PendingQuestionnaireState): boole
   );
 }
 
-export function canReviewQuestionnaire(state: PendingQuestionnaireState): boolean {
-  return (
-    state.phase === "answering" &&
-    state.currentIndex === state.questions.length - 1 &&
-    canSubmitQuestionnaire(state)
-  );
-}
-
 export function canSubmitQuestionnaire(state: PendingQuestionnaireState): boolean {
   return state.answers.every(isAnswerComplete);
-}
-
-export function goToQuestionnaireReview(
-  state: PendingQuestionnaireState
-): PendingQuestionnaireState {
-  if (!canSubmitQuestionnaire(state)) {
-    return state;
-  }
-
-  return {
-    ...state,
-    phase: "review",
-  };
-}
-
-export function markQuestionnaireSubmitted(
-  state: PendingQuestionnaireState
-): PendingQuestionnaireState {
-  return {
-    ...state,
-    phase: "submitted",
-  };
-}
-
-export function questionnaireAnswerDisplay(
-  answer: PendingQuestionnaireAnswer | null | undefined
-): string {
-  if (!answer) {
-    return "";
-  }
-  const value = answer.value.trim();
-  if (!value) {
-    return "";
-  }
-  return answer.kind === "text" ? `Custom: ${value}` : value;
 }
 
 export function buildQuestionnaireResponse(
@@ -260,7 +217,7 @@ function advanceAfterAnswer(
     };
   }
 
-  return goToQuestionnaireReview(state);
+  return state;
 }
 
 function answerCurrentQuestion(

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9993,36 +9993,6 @@ textarea,
   line-height: 1.4;
 }
 
-.transcript-questionnaire__summary {
-  display: grid;
-  gap: 8px;
-}
-
-.transcript-questionnaire__summary-item {
-  display: grid;
-  gap: 4px;
-  padding: 8px 0;
-  border-bottom: 1px solid var(--border-subtle);
-}
-
-.transcript-questionnaire__summary-item:last-child {
-  border-bottom: 0;
-}
-
-.transcript-questionnaire__summary-question {
-  color: var(--text-secondary);
-  font-size: 13px;
-  line-height: 1.35;
-}
-
-.transcript-questionnaire__summary-answer {
-  color: var(--text-primary);
-  font-size: 14px;
-  font-weight: 650;
-  line-height: 1.4;
-  overflow-wrap: anywhere;
-}
-
 .transcript-questionnaire__freeform {
   display: grid;
   gap: 6px;

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -856,10 +856,10 @@ export function messagingQuestionnaireActions(
   if (messagingQuestionnaireAnswerComplete(answer)) {
     const isFinalQuestion = normalized.currentIndex >= normalized.questions.length - 1;
     actions.push({
-      id: "questionnaire:next",
-      label: isFinalQuestion ? "Review" : "Next",
+      id: isFinalQuestion ? "questionnaire:submit" : "questionnaire:next",
+      label: isFinalQuestion ? "Submit" : "Next",
       style: isFinalQuestion ? "primary" : "navigation",
-      fallbackText: isFinalQuestion ? "review" : "next",
+      fallbackText: isFinalQuestion ? "submit" : "next",
     });
   }
 


### PR DESCRIPTION
## Summary

Questionnaires now finish when the user answers the final question instead of showing a separate review card. Single-question prompts submit from the selected option, final freeform prompts show `Submit`, and messaging providers expose `Submit` for answered final questions while still preserving back/next navigation before the final answer.

Legacy messaging intents already sitting in `review` remain submit-able/back-able so existing pending rows do not get stranded, but new questionnaire answers no longer create that review phase.

## Tests

- `pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts -t questionnaire`
- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/questionnaire.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/pending-questionnaire.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx apps/desktop/src/main/__tests__/messaging-interaction-mapper.test.ts packages/messaging/interface/src/__tests__/messaging-interface.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm -r --filter './packages/messaging/**' typecheck`
- `pnpm --filter @pwragent/desktop test:e2e -- e2e/request-user-input.spec.ts`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
