### PR TITLE
fix(desktop): dedupe active turn edits from other changes

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/EditsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/EditsPanel.tsx
@@ -43,7 +43,32 @@ type EditsPanelProps = {
 const OTHER_CHANGES_MAX_FILES = 50;
 const OTHER_CHANGE_DIFF_MAX_BYTES = 200_000;
 
-function collectEditedPaths(groups: readonly EditedFileGroup[]): string[] {
+function isAbsolutePathLike(value: string): boolean {
+  return value.startsWith("/") || /^[A-Za-z]:[\\/]/.test(value);
+}
+
+function toWorktreeAbsolutePath(
+  path: string,
+  worktreeRoot?: string,
+): string | undefined {
+  const trimmed = path.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  if (isAbsolutePathLike(trimmed)) {
+    return trimmed;
+  }
+  const root = worktreeRoot?.trim().replace(/[\\/]+$/, "");
+  if (!root) {
+    return undefined;
+  }
+  return `${root}/${trimmed.replace(/^[\\/]+/, "")}`;
+}
+
+function collectEditedPaths(
+  groups: readonly EditedFileGroup[],
+  worktreeRoot?: string,
+): string[] {
   return [
     ...new Set(
       groups.flatMap((group) =>
@@ -52,7 +77,10 @@ function collectEditedPaths(groups: readonly EditedFileGroup[]): string[] {
           .filter((path): path is string => Boolean(path)),
       ),
     ),
-  ];
+  ].flatMap((path) => {
+    const absolutePath = toWorktreeAbsolutePath(path, worktreeRoot);
+    return absolutePath ? [absolutePath] : [path];
+  });
 }
 
 function useOtherWorktreeChanges(params: {
@@ -201,8 +229,8 @@ export function EditsPanel(props: EditsPanelProps) {
   const hasGroups = props.groups.length > 0;
   const showViewToggle = props.groups.length > 1;
   const editedPaths = useMemo(
-    () => collectEditedPaths(props.groups),
-    [props.groups],
+    () => collectEditedPaths(props.groups, props.worktreeRoot),
+    [props.groups, props.worktreeRoot],
   );
   const otherChanges = useOtherWorktreeChanges({
     desktopApi: props.desktopApi,

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/EditsPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/EditsPanel.test.tsx
@@ -84,6 +84,52 @@ describe("EditsPanel", () => {
     expect(screen.getByText("Pushed")).toBeInTheDocument();
   });
 
+  it("excludes live turn files with repo-relative paths from other changes", async () => {
+    const listWorktreeOtherChanges = vi.fn(async () => ({
+      changes: [],
+      totalChanges: 0,
+      truncated: false,
+      maxFiles: 50,
+    }));
+    const group: EditedFileGroup = {
+      ...editedGroup(),
+      key: "live-turn",
+      live: true,
+      details: [
+        {
+          id: "live-detail-1",
+          kind: "write",
+          label: "Update ipc.ts",
+          path: "apps/desktop/src/shared/ipc.ts",
+          fileDiff: {
+            kind: "update",
+            diff: "@@ -1 +1 @@\n+hello\n",
+            additions: 1,
+            removals: 0,
+          },
+        },
+      ],
+    };
+
+    render(
+      <EditsPanel
+        groups={[group]}
+        dock="sidebar"
+        onDockChange={vi.fn()}
+        worktreeRoot="/repo"
+        desktopApi={{ listWorktreeOtherChanges }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(listWorktreeOtherChanges).toHaveBeenCalledWith({
+        worktreePath: "/repo",
+        excludePaths: ["/repo/apps/desktop/src/shared/ipc.ts"],
+        maxFiles: 50,
+      });
+    });
+  });
+
   it("shows non-turn worktree changes first and fetches their diff only when expanded", async () => {
     const listWorktreeOtherChanges = vi.fn(async () => ({
       changes: [


### PR DESCRIPTION
## Summary

The Edits panel no longer reports files from the active turn in both `This turn` and `Other changes`.

Live turn diffs arrive with repo-relative paths, while the Other changes query filters against absolute worktree paths. This normalizes edited file paths against the worktree root before requesting non-turn changes, so active-turn files are excluded correctly.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/EditsPanel.test.tsx apps/desktop/src/main/__tests__/git-working-state-service.test.ts`
- `pnpm --filter @pwragent/desktop exec tsc --noEmit`
